### PR TITLE
Preserve calendar config entries during /update (minimal)

### DIFF
--- a/scripts/update/cal_integration.py
+++ b/scripts/update/cal_integration.py
@@ -205,7 +205,20 @@ def generate_calendar_config(project_dir: Path) -> CalendarConfigResult:
         gcal_by_name[cal["summary"]] = cal["id"]
 
     mappings: list[CalendarMapping] = []
-    calendars: dict[str, str] = {}
+
+    # Load existing config to preserve entries from other machines.
+    # This file is shared via iCloud across multiple machines — each
+    # machine should only add its own mappings, never remove others.
+    existing_calendars: dict[str, str] = {}
+    if config_path.exists():
+        try:
+            existing_calendars = json.loads(config_path.read_text()).get(
+                "calendars", {}
+            )
+        except (json.JSONDecodeError, KeyError):
+            pass
+
+    calendars: dict[str, str] = dict(existing_calendars)
 
     # Map 'dm' to primary
     calendars["dm"] = "primary"


### PR DESCRIPTION
## Summary
- Minimal fix for `generate_calendar_config()` overwriting the shared `calendar_config.json`
- The config file is synced via iCloud across 4 machines — one machine's `/update` was wiping project entries added by others
- Loads existing config first, merges new entries on top, never removes existing mappings
- Single-file change, no unrelated modifications (see #49 for the broader branch)

## Test plan
- [ ] Run `/update`, verify pre-existing calendar entries are preserved
- [ ] Confirm new project mappings still get added correctly
- [ ] Second machine's entries survive after first machine runs `/update`