### PR TITLE
Implement plans #45, #51, #47, #52

### DIFF
--- a/.claude/agents/documentarian.md
+++ b/.claude/agents/documentarian.md
@@ -35,6 +35,7 @@ You are a Documentarian for the AI system. Your role is to maintain comprehensiv
    - Create helpful indexes
    - Add meaningful links between docs
    - Ensure searchability
+   - When creating feature documentation, always add an entry to `docs/features/README.md`. The index is a markdown table with columns: Feature (link), Description (one line), Status.
 
 ## Documentation Map
 

--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -54,13 +54,14 @@ Before executing, resolve the plan path:
 
 1. **Resolve the plan path** using the Plan Resolution logic above
 2. **Read the plan** at `PLAN_PATH`
-3. **Create a feature branch** - `git checkout -b build/{slug}` (derive slug from the plan filename)
-4. **Parse the Team Members** and Step by Step Tasks sections
-5. **Create all tasks** using `TaskCreate` before starting execution
-6. **Deploy agents** in order, respecting dependencies and parallel flags
-7. **Monitor progress** and handle any issues
-8. **Push and open a PR** - `git push -u origin build/{slug}` then `gh pr create`
-9. **Report completion** with PR URL when all tasks are done
+3. **Run prerequisite validation** - `python scripts/check_prerequisites.py {PLAN_PATH}`. If any check fails, report the failures and stop. Do not proceed to task execution. If no Prerequisites section exists, this passes automatically.
+4. **Create a feature branch** - `git checkout -b build/{slug}` (derive slug from the plan filename)
+5. **Parse the Team Members** and Step by Step Tasks sections
+6. **Create all tasks** using `TaskCreate` before starting execution
+7. **Deploy agents** in order, respecting dependencies and parallel flags
+8. **Monitor progress** and handle any issues
+9. **Push and open a PR** - `git push -u origin build/{slug}` then `gh pr create`
+10. **Report completion** with PR URL when all tasks are done
 
 ## Critical Rules
 

--- a/.claude/skills/make-plan/SKILL.md
+++ b/.claude/skills/make-plan/SKILL.md
@@ -25,6 +25,7 @@ hooks:
             --contains '## Team Orchestration'
             --contains '## Step by Step Tasks'
             --contains '## Success Criteria'
+            --contains '## Prerequisites'
             --contains '## Update System'
             --contains '## Agent Integration'
         - type: command
@@ -119,6 +120,16 @@ tracking: [GitHub Issue URL or Notion page URL - added automatically]
 
 **Team size:** [Solo | Pair | Small team]
 
+## Prerequisites
+
+[Environment requirements that must be satisfied before building. Each requirement has a programmatic check command. If no prerequisites are needed, write "No prerequisites — this work has no external dependencies."]
+
+| Requirement | Check Command | Purpose |
+|-------------|---------------|---------|
+| Example: `EXAMPLE_API_KEY` | `python -c "from dotenv import dotenv_values; assert dotenv_values('.env').get('EXAMPLE_API_KEY')"` | Example service access |
+
+Run all checks: `python scripts/check_prerequisites.py docs/plans/{slug}.md`
+
 ## Solution
 
 ### Key Elements
@@ -195,7 +206,7 @@ Settings page → Click "Enable 2FA" → Setup screen → Enter code → Confirm
 
 ### Feature Documentation
 - [ ] Create/update `docs/features/[feature-name].md` describing the feature
-- [ ] Add entry to documentation index
+- [ ] Add entry to `docs/features/README.md` index table
 
 ### External Documentation Site
 [If the repo uses Sphinx, Read the Docs, MkDocs, or similar:]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,3 +162,4 @@ This ensures new capabilities are wired into the system the user actually intera
 | `docs/deployment.md` | Multi-instance deployment |
 | `docs/tools-reference.md` | Complete tool documentation |
 | `config/SOUL.md` | Valor persona and philosophy |
+| `docs/features/README.md` | Feature index — look up how things work |

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,12 @@ Documentation for the Valor AI System - a unified conversational development env
 | [Monitoring](operations/monitoring.md) | System monitoring and health checks |
 | [Daydream System](operations/daydream-system.md) | Autonomous maintenance process |
 
+### Features
+
+| Document | Description |
+|----------|-------------|
+| [Feature Index](features/README.md) | All implemented features with documentation |
+
 ### Quality & Testing
 
 | Document | Description |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,0 +1,32 @@
+# Feature Documentation Index
+
+Completed feature documentation for the Valor AI system. Each document describes an implemented feature, its design decisions, and how it works.
+
+## Features
+
+| Feature | Description | Status |
+|---------|-------------|--------|
+| [Bridge Response Improvements](bridge-response-improvements.md) | Enhancements to how the Telegram bridge formats and delivers responses | Shipped |
+| [Google Calendar Integration](google-calendar-integration.md) | Work session logging as Google Calendar events with segment rounding | Shipped |
+| [Hooks & Session Logging](hooks-session-logging.md) | Claude Code hooks for session event capture and structured logging | Shipped |
+| [Image Vision Support](image-vision.md) | Ollama LLaVA image descriptions for visual content in Telegram | Shipped |
+| [Link Content Summarization](link-summarization.md) | Auto-fetch and summarize shared links via Perplexity API | Shipped |
+| [Plan Prerequisites Validation](plan-prerequisites.md) | Declare and validate environment requirements before plan execution | Shipped |
+| [Popoto Redis Expansion](popoto-redis-expansion.md) | Migration from JSONL/JSON file state to Redis for atomicity and queries | Shipped |
+| [Remote Update](remote-update.md) | Telegram command and cron for remote system updates across machines | Shipped |
+| [Review Workflow Screenshots](review-workflow-screenshots.md) | Screenshot capture during review for visual validation | Shipped |
+| [Scale Job Queue (Popoto + Worktrees)](scale-job-queue-with-popoto-and-worktrees.md) | Redis persistence and git worktrees for parallel build execution | Shipped |
+| [Session Watchdog](session-watchdog.md) | Active session monitoring with proper cleanup and state management | Shipped |
+| [Steering Queue](steering-queue.md) | Mid-execution course correction via Telegram reply threads | Shipped |
+| [Telegram History & Links](telegram-history.md) | Searchable message history and link compilation from Telegram | Shipped |
+| [YouTube Transcription](youtube-transcription.md) | Auto-transcribe YouTube videos shared in messages for Claude context | Shipped |
+
+## Adding New Entries
+
+When shipping a new feature, add a row to the table above. Format:
+
+```markdown
+| [Feature Name](filename.md) | One-line description | Shipped |
+```
+
+Keep entries sorted alphabetically by feature name.

--- a/docs/features/plan-prerequisites.md
+++ b/docs/features/plan-prerequisites.md
@@ -1,0 +1,40 @@
+# Plan Prerequisites Validation
+
+## Overview
+
+Plans can declare environment prerequisites in a `## Prerequisites` markdown table. Before `/build` executes any tasks, it runs `scripts/check_prerequisites.py` to verify all requirements are met.
+
+## How It Works
+
+1. Plan author adds a `## Prerequisites` section with a markdown table listing requirements, check commands, and purposes
+2. When `/build` is invoked, step 0 runs `python scripts/check_prerequisites.py <plan-path>`
+3. The script parses the table, runs each check command, and reports pass/fail
+4. If any check fails, the build stops with a clear report of what's missing
+5. Plans without a Prerequisites section pass automatically (backward compatible)
+
+## Prerequisites Table Format
+
+```markdown
+## Prerequisites
+
+| Requirement | Check Command | Purpose |
+|-------------|---------------|---------|
+| `STRIPE_API_KEY` | `python -c "from dotenv import dotenv_values; assert dotenv_values('.env').get('STRIPE_API_KEY')"` | Stripe payments |
+| `redis-server` | `which redis-server` | Queue backend |
+```
+
+## Check Command Guidelines
+
+- Commands should be **read-only assertions** that test for presence, not modify state
+- Use `python -c "assert ..."` for environment variable checks
+- Use `which <tool>` for CLI tool availability
+- Use `python -c "import <module>"` for Python package checks
+- Each command runs with a 30-second timeout
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `scripts/check_prerequisites.py` | Prerequisite checker script |
+| `.claude/skills/make-plan/SKILL.md` | Plan template with Prerequisites section |
+| `.claude/commands/build.md` | Build skill with step 0 check |

--- a/docs/plans/bridge-keepalive-fix.md
+++ b/docs/plans/bridge-keepalive-fix.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: In Progress
 type: bug
 appetite: Small: 1-2 days
 owner: Valor

--- a/docs/plans/feature-docs-index.md
+++ b/docs/plans/feature-docs-index.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: In Progress
 type: chore
 appetite: Small: 1-2 days
 owner: Valor

--- a/docs/plans/plan-prerequisites.md
+++ b/docs/plans/plan-prerequisites.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: In Progress
 type: feature
 appetite: Small: 1-2 days
 owner: Valor

--- a/docs/plans/update-health-check-retry.md
+++ b/docs/plans/update-health-check-retry.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: In Progress
 type: bug
 appetite: Small: 1-2 days
 owner: Valor

--- a/scripts/check_prerequisites.py
+++ b/scripts/check_prerequisites.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Validate plan prerequisites before build execution.
+
+Reads a plan markdown file, parses the ## Prerequisites section for a
+markdown table, extracts check commands, and runs each one. Reports
+pass/fail for each requirement.
+
+Usage:
+    python scripts/check_prerequisites.py docs/plans/my-feature.md
+
+Exit codes:
+    0 - All checks passed (or no Prerequisites section found)
+    1 - One or more checks failed
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def extract_prerequisites(plan_text: str) -> list[dict[str, str]]:
+    """Extract prerequisite rows from the ## Prerequisites markdown table.
+
+    Returns a list of dicts with keys: requirement, check_command, purpose.
+    Returns empty list if no Prerequisites section or table found.
+    """
+    # Find the ## Prerequisites section
+    section_match = re.search(
+        r"^## Prerequisites\s*\n(.*?)(?=^## |\Z)",
+        plan_text,
+        re.MULTILINE | re.DOTALL,
+    )
+    if not section_match:
+        return []
+
+    section = section_match.group(1)
+
+    # Parse markdown table rows (skip header and separator)
+    rows = []
+    in_table = False
+    for line in section.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            if in_table:
+                break  # End of table
+            continue
+
+        # Skip separator row (e.g., |---|---|---|)
+        if re.match(r"^\|[\s\-:]+\|", stripped):
+            in_table = True
+            continue
+
+        # Skip header row (first row before separator)
+        if not in_table:
+            continue
+
+        # Parse table cells
+        cells = [c.strip() for c in stripped.strip("|").split("|")]
+        if len(cells) >= 2:
+            # Extract command from backticks if present
+            cmd_cell = cells[1]
+            cmd_match = re.search(r"`(.+?)`", cmd_cell)
+            command = cmd_match.group(1) if cmd_match else cmd_cell
+
+            rows.append(
+                {
+                    "requirement": cells[0].strip("`").strip(),
+                    "check_command": command,
+                    "purpose": cells[2].strip() if len(cells) >= 3 else "",
+                }
+            )
+
+    return rows
+
+
+def run_checks(prerequisites: list[dict[str, str]]) -> tuple[bool, list[str]]:
+    """Run each prerequisite check command.
+
+    Returns (all_passed, report_lines).
+    """
+    all_passed = True
+    report = []
+
+    for prereq in prerequisites:
+        req = prereq["requirement"]
+        cmd = prereq["check_command"]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if result.returncode == 0:
+                report.append(f"  PASS: {req}")
+            else:
+                all_passed = False
+                error = (
+                    result.stderr.strip() or result.stdout.strip() or "non-zero exit"
+                )
+                report.append(f"  FAIL: {req} -- {error}")
+        except subprocess.TimeoutExpired:
+            all_passed = False
+            report.append(f"  FAIL: {req} -- timed out after 30s")
+        except Exception as e:
+            all_passed = False
+            report.append(f"  FAIL: {req} -- {e}")
+
+    return all_passed, report
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: python scripts/check_prerequisites.py <plan-path>")
+        print("Validates prerequisites defined in a plan's ## Prerequisites table.")
+        return 1
+
+    plan_path = Path(sys.argv[1])
+    if not plan_path.exists():
+        print(f"Error: Plan file not found: {plan_path}")
+        return 1
+
+    plan_text = plan_path.read_text()
+    prerequisites = extract_prerequisites(plan_text)
+
+    if not prerequisites:
+        print(f"No Prerequisites section found in {plan_path}. Skipping checks.")
+        return 0
+
+    print(f"Checking {len(prerequisites)} prerequisite(s) from {plan_path}:")
+    all_passed, report = run_checks(prerequisites)
+
+    for line in report:
+        print(line)
+
+    if all_passed:
+        print(f"\nAll {len(prerequisites)} prerequisite(s) passed.")
+        return 0
+    else:
+        print("\nSome prerequisites failed. Fix issues before building.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/update/run.py
+++ b/scripts/update/run.py
@@ -244,11 +244,12 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
         else:
             result.warnings.append("Service install may have failed")
 
-        # Wait for bridge to start. launchd ThrottleInterval is 10s,
-        # so after a stop+load cycle it may take up to 12s to respawn.
+        # Wait for bridge to start after launchctl unload+load cycle.
+        # Polling window: 10 x 2s = 20s covers ThrottleInterval (10s)
+        # + bridge startup (~5s) + safety margin (~5s).
         import time
 
-        for _ in range(6):
+        for _ in range(10):
             time.sleep(2)
             result.service_status = service.get_service_status(project_dir)
             if result.service_status.running:

--- a/scripts/valor-service.sh
+++ b/scripts/valor-service.sh
@@ -241,11 +241,10 @@ install_service() {
     </dict>
     <key>RunAtLoad</key>
     <true/>
+    <!-- KeepAlive unconditional: restart on ANY exit (SIGTERM, crash, etc).
+         ThrottleInterval below prevents rapid restart loops. -->
     <key>KeepAlive</key>
-    <dict>
-        <key>SuccessfulExit</key>
-        <false/>
-    </dict>
+    <true/>
     <key>StandardOutPath</key>
     <string>${LOG_DIR}/bridge.log</string>
     <key>StandardErrorPath</key>


### PR DESCRIPTION
## Summary

- **#45 Bridge KeepAlive fix**: Change launchd plist from conditional `SuccessfulExit: false` to unconditional `KeepAlive: true` so bridge restarts after any exit (SIGTERM, crash, etc). Fixes silent outages after self-triggered restarts.
- **#51 Update health check retry**: Extend bridge status polling from 12s (6x2s) to 20s (10x2s) to cover launchd ThrottleInterval (10s) + startup time (~5s) + margin. Fixes false "Bridge not running" warnings.
- **#47 Feature docs index**: Create `docs/features/README.md` indexing all 13 existing feature docs. Add discovery links in CLAUDE.md, docs/README.md, make-plan template, and documentarian agent.
- **#52 Plan prerequisites**: Add `scripts/check_prerequisites.py` for validating plan prerequisites before build. Update make-plan template with `## Prerequisites` section, `/build` skill with step 0 validation, and validator hooks.

## Test plan

- [ ] Verify `grep -A1 'KeepAlive' scripts/valor-service.sh` shows `<true/>`
- [ ] Verify `grep 'range(10)' scripts/update/run.py` finds the extended polling loop
- [ ] Verify `docs/features/README.md` has 14 entries (13 existing + plan-prerequisites)
- [ ] Verify `python scripts/check_prerequisites.py docs/plans/bridge-keepalive-fix.md` exits 0 (no prereqs)
- [ ] Verify `grep '## Prerequisites' .claude/skills/make-plan/SKILL.md` finds the template section
- [ ] Verify `grep -i prerequisit .claude/commands/build.md` finds step 0

Closes #45, closes #51, closes #47, closes #52