### PR TITLE
Add 8 Dennett thinking skills from Intuition Pumps

### DIFF
--- a/.claude/skills/dennett-agency/SKILL.md
+++ b/.claude/skills/dennett-agency/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: dennett-agency
+description: Practical free will — distinguish sphexish routine from genuine choice, recognize levels of autonomy, and frame accountability around capability. From Dennett's "Intuition Pumps."
+---
+
+# Dennett Agency — Autonomy, Routine, and Accountability
+
+Tools for thinking about team autonomy, delegation, and when behavior is genuine choice versus mindless routine. Frame responsibility around capability, not metaphysics.
+
+## When to Use
+
+- Team development and delegation decisions
+- Performance conversations and coaching
+- Process automation assessments (what should be automated vs. needs judgment?)
+- Evaluating whether a workflow is genuinely adaptive or just sphexish
+- Organizational design and role definition
+
+## Core Tools
+
+### Sphexishness (#57)
+
+The Sphex wasp performs an elaborate nest-preparation ritual. If you move the prey while she's inspecting the nest, she re-does the entire routine from scratch. She has no ability to adapt — it's pure mechanical execution.
+
+**The question:** Are humans (or teams, or processes) ever sphexish? Yes. And it's worth noticing.
+
+**Signs of sphexishness:**
+- Repeating the same process even when circumstances have changed
+- Following a checklist without checking whether each item still applies
+- "We've always done it this way"
+- Restarting a procedure from scratch when a small disruption occurs
+- Inability to skip steps that are obviously unnecessary in context
+
+**In practice:** When reviewing a process or behavior, ask: "If the context changed, would this adapt? Or would it mechanically repeat?" Sphexish processes need either automation (if the routine is correct) or redesign (if it needs judgment).
+
+### Avoiders, Evaders, and Options (#59)
+
+Three levels of behavioral sophistication:
+
+**Avoiders** — Simple, mechanical responses. Thermostat turns off the heat. No learning, no adaptation.
+
+**Evaders** — Can learn from experience and adjust behavior. A mouse learns to avoid a trap location.
+
+**Option-generators** — Can consider hypothetical futures and choose between them. Humans planning a route.
+
+**In practice:** When assessing a team member, process, or system:
+- Is it an avoider? (Follows rules, reacts to triggers, no adaptation)
+- Is it an evader? (Learns from experience, adjusts behavior)
+- Does it generate options? (Considers alternatives, makes genuine choices)
+
+The appropriate level of autonomy matches the capability level. Don't give option-generator responsibilities to an avoider-level process.
+
+### Luther's "Here I Stand" (#55)
+
+"I can do no other" — being compelled by your values is the highest form of agency, not a constraint. When someone acts from deep conviction, that's more free than someone acting on a whim.
+
+**In practice:** When a team member says "I can't do it that way — it violates [principle]," that's not resistance to be overcome. That's agency. Distinguish principled stands from mere stubbornness by checking: is the objection grounded in a coherent value system?
+
+### The Determined Deliberator (#54)
+
+Even if deliberation is causally determined, it's still deliberation and it still matters. The fact that a decision has causes doesn't make it less of a decision.
+
+**In practice:** Don't dismiss someone's reasoning just because you can see the causes ("you only think that because of your background"). The reasoning still stands or falls on its own merits.
+
+### The Abilities of Players (#60)
+
+What matters for responsibility is having the right abilities, not some metaphysical freedom. Can they perceive the relevant information? Can they reason about it? Can they act on their reasoning?
+
+**In practice:** Frame accountability around capability:
+- Did they have access to the information they needed?
+- Did they have the skills to interpret it correctly?
+- Did they have the authority to act?
+- Were there blockers they couldn't control?
+
+If yes to all four and they still failed, that's a performance issue. If no to any, that's a systems issue.
+
+## Application Protocol
+
+### For Evaluating Processes
+
+1. **Sphexishness test**: Would this process adapt if the context changed?
+2. **Level assessment**: Is this an avoider, evader, or option-generator process?
+3. **Match check**: Does the autonomy level match the capability level?
+4. **Automation candidate**: Should this be automated (if sphexish) or empowered (if it needs judgment)?
+
+### For Coaching Conversations
+
+1. **Identify the behavior level**: Is the person avoiding, evading, or generating options?
+2. **Check for sphexishness**: Are they repeating a routine that no longer fits?
+3. **Diagnose the gap**: Is this a capability issue (they can't) or an agency issue (they won't)?
+4. **Frame accountability**: Did they have information, skill, authority, and freedom from blockers?
+5. **Develop toward options**: Help them move from rule-following to genuine judgment
+
+### For Delegation Decisions
+
+| Task Requires | Delegate To | Autonomy Level |
+|---|---|---|
+| Mechanical execution | Automation or avoider-level process | Low — follow the script |
+| Adaptive response | Evader-level (learns from feedback) | Medium — handle variations |
+| Novel judgment | Option-generator (considers alternatives) | High — own the outcome |
+
+## Anti-Patterns
+
+- **Treating option-generators like avoiders**: Micromanaging people who are capable of judgment
+- **Giving avoider-level processes option-generator responsibilities**: "The script will handle it" for situations requiring judgment
+- **Confusing sphexishness with discipline**: Discipline adapts to context; sphexishness doesn't
+- **Punishing capability gaps as agency failures**: "You should have known" when they literally couldn't have
+- **Confusing principled stands with stubbornness**: Luther's "Here I stand" is agency, not defiance

--- a/.claude/skills/dennett-clarity/SKILL.md
+++ b/.claude/skills/dennett-clarity/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: dennett-clarity
+description: Use lay audiences as decoys to expose confusion, detect deepities, and translate between folk and technical language. A writing and editing skill from Dennett's "Intuition Pumps."
+---
+
+# Dennett Clarity — Writing and Thinking Clearly
+
+Use simplification as a diagnostic tool. When you can't explain something simply, you don't understand it well enough. Detect pseudo-profundity, bridge between audiences, and expose hidden confusion.
+
+## When to Use
+
+- Writing documentation or explanations
+- Preparing presentations for mixed audiences
+- Reviewing docs for clarity and accuracy
+- Onboarding materials
+- Translating between technical and business language
+- Any time you suspect jargon is hiding confusion
+
+## Core Tools
+
+### Using Lay Audiences as Decoys (#7)
+
+Explain your idea to a non-expert. The effort to simplify reveals your own confusions.
+
+**The method:** Before finalizing any explanation, restate it as if explaining to someone smart but unfamiliar with the domain. Points where you struggle to simplify are points where your own understanding is weak.
+
+**In practice:** This is "rubber ducking" elevated to a principle. The simplification isn't for the lay audience — it's for you. Every stumble reveals a gap in your model.
+
+### Deepity Detection (#12)
+
+A deepity has two readings: one trivially true, one profoundly false. It feels deep because your mind oscillates between them.
+
+**Examples in tech:**
+- "Data is the new oil" — trivially true (data is valuable), profoundly misleading (data doesn't deplete, isn't fungible, doesn't need refining the same way)
+- "Move fast and break things" — trivially true (speed matters), profoundly false (breaking production is not a strategy)
+- "The code should be self-documenting" — trivially true (clear code is good), profoundly false (architecture decisions need explanation beyond what any code reveals)
+
+**Detection:** When a statement feels profound, ask: "What's the trivial reading? What's the ambitious reading? Is the ambitious reading actually true?"
+
+### Manifest Image vs. Scientific Image (#16)
+
+Two valid descriptions of the same reality:
+- **Manifest**: How users/non-experts experience it ("the app is slow")
+- **Scientific**: The precise technical description ("P95 latency is 800ms due to N+1 queries")
+
+Good writing moves between these fluently. Start with the manifest image to orient, then introduce the scientific image to explain.
+
+### The Sorta Operator (#21)
+
+Approximation is not failure. Things can "sorta" have properties, and that's fine at the right level of description.
+
+**In practice:** Don't demand perfect precision in every explanation. "The cache sorta knows what you'll need next" is a valid explanation at the right level. Resist the urge to immediately correct it to "the cache uses an LRU eviction policy with probabilistic prefetching."
+
+### "Daddy Is a Doctor" (#15)
+
+Children's understanding of concepts is partial but functional. "Sorta" understanding can still be useful.
+
+**In practice:** When writing for non-experts, embrace partial understanding as a valid goal. The reader doesn't need the complete model — they need enough to act correctly.
+
+## Application Protocol
+
+### For Writing Documentation
+
+1. **Start with the manifest image** — What does this do from the user's perspective?
+2. **Simplify to expose gaps** — Explain it to an imaginary non-expert. Where do you struggle?
+3. **Fill the gaps** — Research or think through the parts you couldn't simplify
+4. **Layer in technical detail** — Add the scientific image for readers who need it
+5. **Scan for deepities** — Reread for statements that sound profound but say nothing
+6. **Check the sorta level** — Is each explanation at the right level of precision for its audience?
+
+### For Reviewing Documents
+
+1. **Deepity scan** — Flag profound-sounding but vacuous statements
+2. **Jargon audit** — For each technical term, ask: "Could this be said more simply without losing meaning?"
+3. **Audience check** — Is the level of explanation appropriate for the intended reader?
+4. **Gap detection** — Try to simplify each claim. Where simplification fails, the author may not understand it either
+5. **Manifest/scientific balance** — Is there enough folk-level framing for orientation?
+
+## Anti-Patterns
+
+- **Jargon as authority**: Using technical terms to sound expert rather than to communicate
+- **Precision fetishism**: Demanding technical accuracy in contexts where approximate understanding is the goal
+- **Deepity acceptance**: Nodding along with profound-sounding statements without checking if they're actually meaningful
+- **Curse of knowledge**: Forgetting what it's like not to know, and writing at a level that only experts can follow
+- **False simplification**: Oversimplifying to the point of being wrong (the sorta operator has limits)

--- a/.claude/skills/dennett-creativity/SKILL.md
+++ b/.claude/skills/dennett-creativity/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: dennett-creativity
+description: Jootsing (jumping out of the system) and structured perspective-switching for creative problem-solving. First map the constraints, then find the escape hatch. From Dennett's "Intuition Pumps."
+---
+
+# Dennett Creativity — Jootsing and Knob-Turning
+
+Creative problem-solving through systematic constraint mapping and deliberate rule-breaking. You have to know the rules deeply before you can creatively break them.
+
+## When to Use
+
+- Brainstorming and product ideation
+- Finding novel solutions to constrained problems
+- Breaking out of local optima in design
+- Exploring alternative approaches when stuck
+- Any time the obvious solutions feel inadequate
+
+## Core Tools
+
+### Jootsing (#8) — Jumping Out Of The System
+
+You must know the rules deeply before you can creatively break them. Jootsing is not random rule-breaking — it's informed, deliberate escape from a system you fully understand.
+
+**The method:**
+1. **Map the system**: What are the rules, conventions, constraints, and assumptions?
+2. **Understand why each exists**: Which rules are load-bearing? Which are conventions? Which are accidents?
+3. **Find the escape hatch**: Which rule, if broken, would unlock a fundamentally different solution?
+4. **Break it deliberately**: Not randomly, not all at once — break the specific constraint that's creating the limitation
+
+**Example:** "We need a faster build pipeline."
+- Map the rules: sequential stages, full test suite, Docker builds, deployment approval
+- Why each exists: stages catch errors early; full tests prevent regressions; Docker ensures consistency; approval prevents disasters
+- Escape hatch: what if tests ran in parallel, not sequentially? What if we tested only changed modules?
+- Result: break the "sequential full test" rule → incremental parallel testing → 10x speedup
+
+### Turning the Knobs (#56)
+
+Systematically vary the parameters of a problem to see which features actually do the work.
+
+**The method:**
+1. Identify the key variables in the problem
+2. Change one variable at a time to its extreme
+3. Observe what breaks and what still works
+4. The variables that cause the most change when turned are the ones that matter most
+
+**Example:** "Our onboarding takes too long."
+- Turn "number of steps" from 8 to 1 → What's the absolute minimum?
+- Turn "user technical level" from expert to novice → Which steps are genuinely needed?
+- Turn "time constraint" from days to 5 minutes → What would a speed-run look like?
+- Turn "automation" from manual to fully automated → What can be eliminated entirely?
+
+### The Hat as Thinking Tool (#65)
+
+Wear different "hats" (perspectives) to unlock different insights. Each hat sees a different problem.
+
+**Hats to try:**
+- **Naive user**: "I've never seen this before. What confuses me?"
+- **Adversary**: "How would I break this? Where are the failure modes?"
+- **Historian**: "How did we get here? What decisions led to this constraint?"
+- **Competitor**: "How would [X] solve this? What would they do differently?"
+- **Future self**: "In two years, what will I wish we'd done?"
+- **Minimalist**: "What's the simplest thing that could possibly work?"
+
+## Application Protocol
+
+### For Constrained Problems
+
+1. **Map all constraints** — list every rule, convention, requirement, and assumption
+2. **Classify constraints** — which are fundamental? which are conventional? which are accidental?
+3. **Turn knobs** — vary each constraint to its extreme. Which ones, when broken, unlock new solution spaces?
+4. **Jootse** — deliberately break the most productive constraint
+5. **Design within the new space** — now solve the problem with the old constraint removed
+
+### For Brainstorming
+
+1. **Put on different hats** — work through at least 3 perspectives
+2. **Turn knobs on the problem statement** — what if the problem were 10x bigger? 10x smaller? Reversed?
+3. **Identify the implicit rules** — what "obvious" constraints are you assuming?
+4. **Jootse once** — break exactly one assumption and explore what happens
+5. **Evaluate** — does the creative solution actually serve the goal, or is it just novel?
+
+## Guardrails
+
+Creativity without discipline is just chaos. Jootsing works because:
+- You understand the rules before breaking them
+- You break one rule at a time
+- You have a reason for the specific rule you're breaking
+- You check that the result actually improves things
+
+**Bad jootsing:** "Let's skip tests!" (breaking a rule you don't understand)
+**Good jootsing:** "Tests take 20 minutes because they're sequential. What if we ran them in dependency-isolated parallel groups?" (understanding the rule deeply enough to break it productively)
+
+## Anti-Patterns
+
+- **Random rule-breaking**: Breaking conventions without understanding them
+- **Premature creativity**: Looking for novel solutions when straightforward ones exist
+- **Knob-turning without purpose**: Varying parameters randomly instead of systematically
+- **Hat-wearing as theater**: Going through perspectives mechanically without genuinely adopting them
+- **Jootsing for its own sake**: Breaking rules to be clever rather than to solve a problem

--- a/.claude/skills/dennett-decomposition/SKILL.md
+++ b/.claude/skills/dennett-decomposition/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: dennett-decomposition
+description: Break complex systems into cascading layers of simpler, stupider parts. No homunculi, no wonder tissue, no central controller. Based on Daniel Dennett's "Intuition Pumps."
+---
+
+# Dennett Decomposition — Homuncular Decomposition
+
+Break any complex capability into successively simpler parts until no intelligence remains at any single point. This is how you go from "it's magic" to "it's engineering."
+
+## When to Use
+
+- Architecture reviews and system design
+- Breaking down monoliths or complex features
+- Organizational design and role decomposition
+- Debugging complex emergent behavior
+- Sprint planning for large features
+- Any time someone says "it just works" and you need to know how
+
+## Core Tools
+
+### A Cascade of Homunculi (#20)
+
+Decompose an intelligent-seeming whole into simpler and stupider parts until no "magic" remains.
+
+**The method:**
+1. Start with the complex capability: "The system understands user intent"
+2. Break it into sub-capabilities: "It parses input → classifies intent → retrieves context → generates response"
+3. Break each sub-capability into even simpler parts: "Classifies intent" becomes "tokenizes → embeds → compares to known patterns → selects highest match"
+4. Keep going until each piece is so simple it obviously works
+
+**The test:** At the bottom layer, can each piece be explained without invoking intelligence? If yes, you're done. If any piece still seems "smart," decompose it further.
+
+### Wonder Tissue Detection (#22)
+
+When a decomposition stops at a layer that's still mysterious, someone has inserted "wonder tissue" — a label that explains nothing.
+
+**Red flags:**
+- "The AI handles that part"
+- "The algorithm figures it out"
+- "Machine learning takes care of it"
+- "It uses deep learning"
+- "The system is intelligent enough to..."
+
+Each of these is a placeholder, not an explanation. Demand the next layer of decomposition.
+
+### Trapped in the Robot Control Room (#23)
+
+You can't run a complex system by micromanaging every detail from a central control point. The central controller becomes a bottleneck, and you've just moved the complexity instead of reducing it.
+
+**In practice:**
+- If your architecture has a "god object" or "master controller," you haven't decomposed — you've relocated
+- If one team/person must approve everything, the organization hasn't really distributed work
+- If one service must be consulted for every decision, you have a single point of failure disguised as architecture
+
+### The Cartesian Theater (#50)
+
+The mistaken idea that there's a single place where "it all comes together" for a central viewer. In the brain, there is no theater. In systems, there shouldn't be one either.
+
+**In practice:** Reject single-point-of-control designs. Decisions should emerge from distributed processes, not funnel through a central bottleneck.
+
+## Decomposition Protocol
+
+### Step 1: Name the Capability
+
+State what the system does at the highest level.
+- "The recommendation engine suggests relevant products"
+- "The hiring process selects good candidates"
+- "The build system ships tested code"
+
+### Step 2: First Decomposition
+
+Break the capability into 3-7 sub-capabilities. Each should be noticeably simpler than the whole.
+
+### Step 3: Check for Homunculi
+
+For each sub-capability, ask: "Does this require intelligence to work?" If yes, it's a homunculus — a little person inside the machine doing the hard work. Decompose it further.
+
+### Step 4: Check for Central Controllers
+
+Is there one piece that coordinates everything? If so, you've created a Cartesian Theater. Distribute the coordination.
+
+### Step 5: Check for Wonder Tissue
+
+Are there any pieces described with vague "smart" language? Replace wonder tissue with mechanism.
+
+### Step 6: Bottom Out
+
+Keep decomposing until every piece is "stupid" — simple enough that its operation is obvious. The test: could you explain each piece to someone who doesn't know the domain?
+
+## Example: Decomposing "The System Understands User Requests"
+
+**Level 0 (Wonder Tissue):** "The AI understands what users want"
+
+**Level 1:** Input parsing → Intent classification → Context retrieval → Response generation
+
+**Level 2 (Intent Classification):**
+- Tokenize input into words
+- Embed tokens into vector space (lookup table)
+- Compare vector to known intent clusters (nearest neighbor)
+- Return intent label with confidence score
+
+**Level 3 (Compare to known clusters):**
+- Compute cosine similarity between input vector and each cluster centroid
+- Sort by similarity score
+- Return top match if score > threshold, else "unknown"
+
+**Bottom:** Every piece is arithmetic (dot products, sorting, thresholds). No intelligence required at any single point. The "understanding" is an emergent property of the cascade.
+
+## Anti-Patterns
+
+- **Premature abstraction**: Stopping decomposition because "that's handled by [library/service]" — you need to understand what it does, not just that it exists
+- **Central controller**: Moving complexity to a master orchestrator instead of distributing it
+- **Wonder tissue**: Labeling a component "smart" and moving on
+- **Homunculus smuggling**: A sub-component that's just as complex as the whole
+- **Level-skipping**: Going from "the system works" to implementation details without the intermediate decomposition layers

--- a/.claude/skills/dennett-meta/SKILL.md
+++ b/.claude/skills/dennett-meta/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: dennett-meta
+description: Meta-philosophical tools — check that the problem matters, prioritize ruthlessly, and remember to actually use the tools. From Dennett's "Intuition Pumps."
+---
+
+# Dennett Meta — Is This Problem Worth Solving?
+
+Before diving into a problem, check whether it matters. Prioritize ruthlessly. And actively apply the other thinking tools rather than passively knowing about them.
+
+## When to Use
+
+- Project selection and roadmap prioritization
+- "Should we even be working on this?" conversations
+- Evaluating proposals, features, or research directions
+- Any time you're about to invest significant effort
+- When someone presents a technically impressive but possibly pointless initiative
+
+## Core Tools
+
+### Higher-Order Truths of Chmess (#62)
+
+Chmess is chess with one rule changed. You can prove theorems about Chmess with perfect rigor. But nobody cares, because the game doesn't matter.
+
+**The principle:** Technical validity is not the same as importance. You can be rigorously correct about a question nobody needs answered.
+
+**In practice:** Before investing in a problem, ask:
+- "Who will care about the answer?"
+- "What decision will this change?"
+- "If we solve this perfectly, does anything improve?"
+
+If the answer is "nobody / nothing / no" — it's Chmess. Move on.
+
+**Examples in tech:**
+- Optimizing a query that runs once a month and takes 2 seconds
+- Writing extensive type definitions for code that's being deprecated next sprint
+- Debating architectural patterns for a prototype that may not ship
+- Benchmarking micro-optimizations that are invisible at the user level
+
+### Sturgeon's Law — The 10% That's Good (#4, #63)
+
+90% of everything is crud. This isn't cynicism — it's a prioritization tool. Don't waste energy on the bottom 90%. Find the 10% that's good and invest there.
+
+**In practice:**
+- When evaluating a list of potential projects: most of them don't matter. Find the ones that do.
+- When reviewing proposals: most won't survive contact with reality. Identify the few that will.
+- When reading documentation: most of it is filler. Find the sections that carry actual information.
+- When debugging: most hypotheses are wrong. Prioritize by likelihood and impact.
+
+### Use the Tools. Try Harder. (#67)
+
+Dennett's rallying cry: these tools only work if you actually deploy them. Thinking well takes effort. Knowing about good thinking tools but not using them is the most common failure mode.
+
+**In practice:** This is a meta-instruction. When facing a hard problem:
+1. Pause before diving in
+2. Ask: "Which thinking tool applies here?"
+3. Actually use it — don't just nod at it
+4. The effort of applying the tool is the point
+
+**The checklist:**
+- Am I checking for smuggled assumptions? (dennett-reasoning)
+- Am I steelmanning before critiquing? (dennett-steelman)
+- Am I at the right level of explanation? (dennett-stances)
+- Am I decomposing or hand-waving? (dennett-decomposition)
+- Am I being clear or hiding behind jargon? (dennett-clarity)
+- Am I stuck in the system or looking for escape hatches? (dennett-creativity)
+- Am I dealing with genuine agency or sphexish routine? (dennett-agency)
+- Does this problem even matter? (dennett-meta — this skill)
+
+## Application Protocol
+
+### The Pre-Investment Check
+
+Before committing significant time to any problem:
+
+1. **Chmess check**: Is this a real problem or Chmess? Who cares about the answer?
+2. **Sturgeon filter**: Is this in the top 10% of things we could work on?
+3. **Impact check**: If we solve this, what concretely changes?
+4. **Opportunity cost**: What are we NOT doing while we work on this?
+
+If the problem passes all four checks, proceed. If not, explicitly state why and redirect.
+
+### The Prioritization Lens
+
+When presented with multiple options:
+
+| Filter | Question | Kill if... |
+|---|---|---|
+| Chmess | Does anyone care? | No real stakeholder or user |
+| Sturgeon | Is this in the top 10%? | There are clearly higher-impact alternatives |
+| Impact | What changes if we succeed? | Nothing measurable |
+| Reversibility | Can we undo it? | Yes, so don't over-invest in the decision |
+| Cost | What's the opportunity cost? | The forgone alternative is obviously better |
+
+### The Active Application Reminder
+
+At the start of any significant analytical or creative task, explicitly choose which Dennett tools to apply. Don't rely on them "naturally" arising — they won't. Select and deploy them deliberately.
+
+## Anti-Patterns
+
+- **Chmess investment**: Spending significant effort on technically valid but practically irrelevant work
+- **Bottom-90% engagement**: Treating all options as equally worthy of analysis
+- **Tool-knowing without tool-using**: Understanding the thinking tools but never deploying them
+- **False urgency**: Treating everything as critical, which is the same as treating nothing as critical
+- **Analysis paralysis**: Using meta-tools as an excuse to never start (know when to stop filtering and start building)

--- a/.claude/skills/dennett-reasoning/SKILL.md
+++ b/.claude/skills/dennett-reasoning/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: dennett-reasoning
+description: General reasoning hygiene — detect fallacies, flag assumption-smuggling, stress-test arguments, and demand mechanistic explanations. Based on Daniel Dennett's "Intuition Pumps and Other Tools for Thinking."
+---
+
+# Dennett Reasoning — Thinking Tools for Rigorous Analysis
+
+General-purpose reasoning hygiene drawn from Daniel Dennett's toolkit. Apply these tools to any analytical task: decision memos, proposal reviews, postmortems, architecture decisions, debugging sessions.
+
+## When to Use
+
+Activate when performing any analytical or evaluative task:
+- Reviewing proposals, designs, or arguments
+- Making decisions with trade-offs
+- Debugging complex problems
+- Conducting postmortems
+- Evaluating competing approaches
+
+## Core Tools
+
+### 1. Making Mistakes Well (#1)
+
+Errors are essential data. When you make a wrong turn, don't hide it — name the error, extract the lesson, and use it diagnostically.
+
+**In practice:** When you discover you were wrong about something mid-task, explicitly state what you believed, what was actually true, and what the gap reveals about your reasoning process.
+
+### 2. Reductio ad Absurdum (#2)
+
+Take a claim to its logical extreme. If the extreme is absurd, the original claim has a flaw.
+
+**In practice:** Before accepting a conclusion, ask: "If I push this logic to its extreme, where does it lead?" If the endpoint is absurd, the premise needs re-examination.
+
+### 3. Occam's Razor (#5)
+
+Don't multiply entities beyond necessity. Prefer the simpler explanation that covers the facts.
+
+**In practice:** When comparing competing explanations or solutions, explicitly invoke this: "Which explanation requires fewer assumptions?"
+
+### 4. Occam's Broom (#6)
+
+The trick of sweeping inconvenient facts under the rug. Recognize when someone (or you) is ignoring evidence that doesn't fit.
+
+**In practice:** After forming an explanation, actively ask: "What evidence am I ignoring? What inconvenient facts don't fit this story?" This is the antidote to confirmation bias.
+
+### 5. The "Surely" Operator (#10)
+
+When someone writes "surely X is true," they're papering over a gap in the argument. It's a red flag word.
+
+**In practice:** Flag hedging language that smuggles in undefended assumptions. Watch for: "surely," "obviously," "clearly," "of course," "it goes without saying," "everyone knows." Each of these signals an undefended claim.
+
+### 6. Rhetorical Questions (#11)
+
+Questions used to smuggle in an answer without actually defending it. The questioner avoids the burden of proof.
+
+**In practice:** When you encounter a rhetorical question in an argument or proposal, convert it to a declarative statement and ask: "Is this actually defended?"
+
+### 7. Deepity Detection (#12)
+
+A deepity is a statement with two readings: one trivially true, one profound but false. It seems deep because you oscillate between them.
+
+**Example:** "Love is just a word." Trivially true (it's a four-letter word). Profoundly false (love is obviously more than a word). The statement feels deep because your mind switches between readings.
+
+**In practice:** When evaluating mission statements, pitches, thought leadership, or "profound" claims, check: Does this have a trivial reading and a profound reading? Is the profound reading actually true?
+
+### 8. Wonder Tissue (#22)
+
+Labeling something as "special" or "mysterious" explains nothing. It's a placeholder, not an answer.
+
+**In practice:** When someone explains a capability by invoking magic words — "AI magic," "it just works," "the algorithm handles it," "deep learning figures it out" — demand the mechanism. What specifically happens? Wonder tissue is a label masquerading as an explanation.
+
+### 9. Cranes vs. Skyhooks (#38)
+
+Real explanations build up from simpler things (cranes). Fake explanations invoke miracles (skyhooks).
+
+**In practice:** When evaluating an explanation, ask: "Does this build up from known mechanisms (crane), or does it invoke something unexplained to do the heavy lifting (skyhook)?" Demand cranes. Reject skyhooks.
+
+### 10. Turning the Knobs (#56)
+
+Vary the parameters of a thought experiment to see which features actually do the work.
+
+**In practice:** When testing an argument or design decision, systematically change one variable at a time. "What if the input were 10x larger? What if the user were non-technical? What if we removed this constraint?" This isolates which factors actually matter.
+
+### 11. Cui Bono? (#71)
+
+Always ask: who benefits? In evolution, the gene. In organizations, follow the incentives.
+
+**In practice:** When confused about why something exists or persists, ask: "Who or what does this serve?" Follow the incentives. The answer often reveals the real explanation.
+
+### 12. Goulding Detection (#9)
+
+Three rhetorical tricks to watch for:
+- **Rathering**: False dichotomy — "rather than X, we should Y" (when both could be true)
+- **Piling On**: Stacking many weak arguments to create the illusion of a strong one
+- **Gould Two-Step**: Bait-and-switch on definitions mid-argument
+
+**In practice:** When reading persuasive writing or proposals, actively scan for these three patterns. They're extremely common in tech decision documents.
+
+## Application Protocol
+
+When performing analytical work, run through this checklist:
+
+1. **Flag smuggled assumptions** — Scan for "surely," "obviously," "clearly," and rhetorical questions
+2. **Check for Occam's Broom** — What inconvenient facts are being swept aside?
+3. **Demand cranes, not skyhooks** — Does the explanation build from known mechanisms?
+4. **Detect wonder tissue** — Are there fancy labels with no mechanism behind them?
+5. **Ask cui bono** — Who benefits from this being true?
+6. **Turn the knobs** — Vary key parameters to test which factors matter
+7. **Try reductio** — Push the logic to its extreme; does it hold?
+8. **Prefer simplicity** — Does a simpler explanation cover the same facts?
+
+## Mistakes are Opportunities (#66)
+
+Revisiting tool #1 at a higher level: the best discoveries come from well-handled errors. When you catch yourself making one of these reasoning mistakes, that's the most valuable moment — it reveals a pattern worth encoding.

--- a/.claude/skills/dennett-stances/SKILL.md
+++ b/.claude/skills/dennett-stances/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: dennett-stances
+description: Navigate levels of explanation — intentional, design, and physical stances. Pick the right abstraction level for the audience and problem. Based on Daniel Dennett's "Intuition Pumps."
+---
+
+# Dennett Stances — Levels of Explanation
+
+Navigate between different levels of explanation for any system. The right level depends on the question and the audience, not on what's "really" going on.
+
+## When to Use
+
+- System design and architecture discussions
+- Stakeholder communication across technical levels
+- Debugging (is this a logic bug, a design flaw, or a hardware issue?)
+- Explaining AI systems to non-engineers
+- Choosing the right abstraction level for documentation
+
+## Core Tools
+
+### The Three Stances (#18)
+
+Every system can be explained at three levels. Choose deliberately.
+
+**Intentional Stance** — Treat the system as a rational agent with beliefs and goals.
+- "The load balancer *wants* to distribute traffic evenly."
+- "The cache *expects* frequently accessed data."
+- Best for: High-level architecture, user-facing explanations, predicting behavior.
+
+**Design Stance** — Explain how the system is built to achieve its purpose.
+- "The load balancer uses round-robin with health checks."
+- "The cache uses LRU eviction with a 5-minute TTL."
+- Best for: Engineering discussions, debugging design flaws, code reviews.
+
+**Physical Stance** — Explain the actual mechanism, down to the implementation.
+- "The load balancer iterates through a server list array, incrementing an index."
+- "The cache stores entries in a hash map with a doubly-linked list for eviction ordering."
+- Best for: Debugging specific bugs, performance optimization, low-level troubleshooting.
+
+### Manifest Image vs. Scientific Image (#16)
+
+Two ways of seeing the same thing:
+- **Manifest image**: The everyday, folk-level understanding ("the app is slow")
+- **Scientific image**: The precise, technical understanding ("P95 latency is 800ms due to N+1 queries on the user endpoint")
+
+Both are valid. The manifest image is how users experience the system. The scientific image is how engineers fix it. Translation between them is a core skill.
+
+### Folk Psychology (#17)
+
+Our everyday framework for predicting behavior: beliefs, desires, intentions. It's a useful fiction — powerful for prediction, but don't confuse the map for the territory.
+
+**In practice:** When explaining system behavior, folk-psychological language ("the service wants," "the queue believes") is a powerful shortcut. Use it deliberately, but know when to drop down to mechanism.
+
+### Competence Without Comprehension (#30, #68)
+
+Systems can be competent — even brilliant — without understanding what they're doing. This is not a bug; it's a fundamental feature of complex systems.
+
+**In practice:** Don't anthropomorphize competence as understanding. An LLM that gives correct answers doesn't "understand" the way a human does. A well-tuned algorithm that outperforms experts doesn't "know" the domain. Recognizing this prevents both over-trust and under-use.
+
+### The Personal/Sub-personal Distinction (#19)
+
+Distinguish between person-level explanations ("she decided to refactor") and mechanism-level ones ("the diff shows 47 files changed with a new abstraction layer"). Know which level is appropriate.
+
+### Greedy Reductionism (#41)
+
+Reducing everything to the lowest level ("it's all just bits") misses real patterns at higher levels. The right level of abstraction depends on the question.
+
+**In practice:** Don't skip levels. If someone asks why the deploy failed, "cosmic rays flipped a bit" is technically possible but useless. Match the explanation to the question.
+
+## Application Protocol
+
+### Choosing a Stance
+
+| Question Type | Best Stance | Example |
+|---|---|---|
+| "What does this system do?" | Intentional | "It routes requests to the healthiest server" |
+| "How does it work?" | Design | "Round-robin with weighted health scores" |
+| "Why is it broken?" | Physical (usually) | "The health check goroutine is deadlocked on line 142" |
+| "Should we build it?" | Intentional | "We need something that knows when servers are overwhelmed" |
+
+### Shifting Between Stances
+
+When an explanation at one level isn't working, shift:
+- **Up** (physical → design → intentional): When drowning in detail, zoom out
+- **Down** (intentional → design → physical): When the abstraction hides the problem, zoom in
+
+### Audience Matching
+
+| Audience | Default Stance | When to Shift |
+|---|---|---|
+| End users | Intentional + manifest image | Never go below design |
+| Product managers | Intentional + design | Physical only for "why is this hard?" |
+| Engineers | Design + physical | Intentional for "why are we doing this?" |
+| Executives | Intentional + manifest | Design for "what's the approach?" |
+
+## Anti-Patterns
+
+- **Stance confusion**: Debugging at the intentional level ("the service doesn't want to respond") when you need the physical level
+- **Greedy reduction**: Explaining everything at the lowest level when a higher abstraction would be clearer
+- **Anthropomorphism-as-explanation**: Saying a system "wants" something and treating that as a complete explanation
+- **Level-skipping**: Jumping from "it's broken" to "rewrite it" without passing through design-level diagnosis

--- a/.claude/skills/dennett-steelman/SKILL.md
+++ b/.claude/skills/dennett-steelman/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: dennett-steelman
+description: Rapoport's Rules for charitable disagreement — restate the opposing view so well they thank you, find agreements, note what you learned, then critique. Based on Daniel Dennett's "Intuition Pumps."
+---
+
+# Dennett Steelman — Charitable Critique via Rapoport's Rules
+
+Transform how you handle disagreement, feedback, and evaluation. Before criticizing anything, steelman it first. This produces sharper critiques, builds trust, and prevents straw-manning.
+
+## When to Use
+
+- Code reviews and design critiques
+- Evaluating competing proposals or approaches
+- Providing feedback on plans, documents, or ideas
+- Conflict resolution between competing requirements
+- Any situation where you're about to say "this is wrong"
+
+## Core Tools
+
+### Rapoport's Rules (#3)
+
+Before criticizing any position, complete these four steps in order:
+
+**Step 1: Restate** — Express the other position so clearly and fairly that the person would say "Thanks, I wish I'd thought of putting it that way."
+
+**Step 2: List agreements** — Note every point of agreement, especially any that aren't widely shared.
+
+**Step 3: Note what you learned** — Mention anything you learned from the position you're about to critique.
+
+**Step 4: Then — and only then — critique** — Now state your disagreement. It will be sharper, fairer, and harder to dismiss.
+
+### Sturgeon's Law (#4)
+
+90% of everything is crud. Don't waste time attacking the worst examples — engage with the best.
+
+**In practice:** When evaluating an approach, technology, or proposal, seek out the strongest version. Don't critique a straw man. Ask: "What's the best possible version of this idea? Am I engaging with the strongest argument, or the weakest?"
+
+### Holding Your Fire (#64)
+
+Resist the urge to immediately object. Sit with an idea long enough to see if it grows on you.
+
+**In practice:** When your first instinct is "that's wrong," pause. Give the idea 30 seconds of genuine consideration. Ask: "What would have to be true for this to work?" Often, the best insights come from ideas that initially seem wrong.
+
+## Application Protocol
+
+### For Code Reviews
+
+1. **Read the entire change** before forming opinions
+2. **Restate the intent**: "This change aims to [X] by [approach]. The key design decision is [Y]."
+3. **List what works**: "The error handling pattern here is solid. The test coverage is thorough."
+4. **Note what you learned**: "I hadn't considered using [pattern] for this — that's clever."
+5. **Then critique**: "Given the intent, I think [specific issue] could cause [specific problem] because [reason]."
+
+### For Proposal/Design Evaluation
+
+1. **Steelman first**: Present the proposal's strongest case, better than its author did
+2. **Find the 10%**: If 90% is crud (Sturgeon's Law), what's the valuable 10%? Start there.
+3. **Hold your fire**: If something seems obviously wrong, that's exactly when to pause
+4. **Critique constructively**: Your critique is now informed by genuine understanding
+
+### For Disagreements
+
+1. **Restate their position** until they agree you've captured it
+2. **Acknowledge shared ground** — this changes the dynamic from adversarial to collaborative
+3. **Identify your actual disagreement** — often smaller than it first appeared
+4. **Propose a way forward** that preserves what's good about both positions
+
+## Anti-Patterns
+
+- **Straw-manning**: Critiquing a weak version of the argument instead of the real one
+- **Cherry-picking**: Finding the worst example and treating it as representative
+- **Dismissing without engaging**: "That won't work" without explaining why or considering the strongest version
+- **Immediate objection**: Responding to the first thing that seems wrong without understanding the whole
+
+## The Steelman Produces Sharper Critiques
+
+This isn't about being nice. It's about being right. When you steelman first:
+- You catch real problems instead of phantom ones
+- Your critiques are harder to dismiss
+- You sometimes discover the idea is better than you thought
+- The other person actually listens to your feedback


### PR DESCRIPTION
## Summary
8 Claude skills based on Daniel Dennett's 77 thinking tools from "Intuition Pumps and Other Tools for Thinking," organized into a 4-phase build plan.

## Skills Created

**Phase 1 — Always-on reasoning:**
- `dennett-reasoning` — 12 tools: reductio, Occam's Broom, "surely" operator, deepity detection, cranes vs skyhooks, cui bono, Goulding detection, wonder tissue, knob-turning
- `dennett-steelman` — Rapoport's Rules (restate, agree, learn, then critique) + Sturgeon's Law + holding fire

**Phase 2 — On-demand analysis:**
- `dennett-stances` — Intentional/design/physical stance selection, manifest vs scientific image, competence without comprehension
- `dennett-decomposition` — Homuncular decomposition (cascade of stupider parts), wonder tissue detection, anti-Cartesian Theater

**Phase 3 — Writing and creativity:**
- `dennett-clarity` — Lay audience as decoy, deepity detection, sorta operator, manifest/scientific image bridging
- `dennett-creativity` — Jootsing (jumping out of the system), knob-turning, hat-switching perspectives

**Phase 4 — Coaching and meta:**
- `dennett-agency` — Sphexishness, avoiders/evaders/options, Luther's agency, capability-based accountability
- `dennett-meta` — Chmess detection (is this problem worth solving?), Sturgeon prioritization, active tool deployment

## Source
Cataloged from Tom's spreadsheet mapping all 77 Dennett tools to skill groupings with priority ratings and build phases.

## Changes
- 8 new files in `.claude/skills/dennett-*/SKILL.md`
- 804 lines of skill definitions

## Testing
Each skill was written to match the spreadsheet's proposed description, key tools, and use cases. Skills are pure markdown — no code to test.