### PR TITLE
Fix dropped $ARGUMENTS across all skills

### DIFF
--- a/.claude/skills/add-feature/SKILL.md
+++ b/.claude/skills/add-feature/SKILL.md
@@ -40,6 +40,11 @@ Description of what this skill does.
 
 SOME_VAR: $1  # First argument passed to skill
 
+**If SOME_VAR is empty or literally `$1`**: The skill argument substitution
+did not run. Look at the user's original message — they invoked this as
+`/skill-name <argument>`. Extract the argument from there. Do NOT stop or
+report an error.
+
 ## Instructions
 
 [Step-by-step instructions for Claude Code to follow]

--- a/.claude/skills/do-patch/SKILL.md
+++ b/.claude/skills/do-patch/SKILL.md
@@ -25,6 +25,8 @@ Users may also invoke directly:
 PATCH_ARG: $ARGUMENTS
 ITERATION_CAP: 3  (default; caller may override by appending e.g. `--max-iterations 5`)
 
+**If PATCH_ARG is empty or literally `$ARGUMENTS`**: The skill argument substitution did not run. Look at the user's original message in the conversation — they invoked this as `/do-patch <argument>`. Extract whatever follows `/do-patch` as the value of PATCH_ARG. Do NOT stop or report an error; just use the argument from the message.
+
 ## Instructions
 
 ### Step 1: Identify What Is Broken

--- a/.claude/skills/do-skills-audit/SKILL.md
+++ b/.claude/skills/do-skills-audit/SKILL.md
@@ -23,6 +23,8 @@ Validates all `.claude/skills/*/SKILL.md` files against canonical template stand
 python .claude/skills/do-skills-audit/scripts/audit_skills.py $ARGUMENTS
 ```
 
+**If `$ARGUMENTS` was not substituted** (the command shows a literal `$ARGUMENTS`): Look at the user's original message — they invoked this as `/do-skills-audit <flags>`. Extract whatever follows `/do-skills-audit` and pass it to the script. If no flags were provided, run the script with no arguments (default behavior).
+
 ## Arguments
 
 | Flag | Description |

--- a/.claude/skills/do-test/SKILL.md
+++ b/.claude/skills/do-test/SKILL.md
@@ -12,6 +12,8 @@ You are the **test orchestrator**. You parse arguments, dispatch test runners (p
 
 TEST_ARGS: $ARGUMENTS
 
+**If TEST_ARGS is empty or literally `$ARGUMENTS`**: The skill argument substitution did not run. Look at the user's original message in the conversation — they invoked this as `/do-test <argument>`. Extract whatever follows `/do-test` as the value of TEST_ARGS. Do NOT stop or report an error; just use the argument from the message.
+
 ## Argument Parsing
 
 Parse `TEST_ARGS` to determine what to run:


### PR DESCRIPTION
## Summary
- Adds `$ARGUMENTS` fallback pattern to `do-test`, `do-patch`, and `do-skills-audit` skills
- When invoked via the Skill tool (programmatic), `$ARGUMENTS` substitution sometimes fails — the variable stays literal or becomes empty
- The fix instructs the agent to extract arguments from the user's original message when substitution fails
- Also removes stale `model-invocable` field from `do-patch` and updates the `add-feature` template to teach this pattern

## Changes
- `.claude/skills/do-test/SKILL.md` — added TEST_ARGS fallback instruction
- `.claude/skills/do-patch/SKILL.md` — added PATCH_ARG fallback + removed `model-invocable: true` (field no longer exists)
- `.claude/skills/do-skills-audit/SKILL.md` — added `$ARGUMENTS` fallback for bash command
- `.claude/skills/add-feature/SKILL.md` — updated skill template with fallback pattern as best practice

## Context
The `do-build` skill already had this fix (issue #169). This PR applies the same pattern to every other skill that uses `$ARGUMENTS` or `$1`.

Closes #169