### PR TITLE
Fix stop hook false positive after PR squash merge

### DIFF
--- a/.claude/hooks/post_tool_use.py
+++ b/.claude/hooks/post_tool_use.py
@@ -3,6 +3,7 @@
 
 import json
 import re
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -88,11 +89,30 @@ def save_sdlc_state(session_id: str, state: dict) -> None:
         raise
 
 
+def _get_current_branch() -> str | None:
+    """Return the current git branch name, or None if git fails."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        branch = result.stdout.strip()
+        return branch if branch else None
+    except Exception:
+        return None
+
+
 def update_sdlc_state_for_file_write(hook_input: dict) -> None:
     """Update SDLC state when a Write or Edit tool use touches a code file.
 
     Fast path: if the tool is not Write/Edit, or the file is not a code file,
     return immediately without any I/O.
+
+    On the first code modification, records the current git branch as
+    ``modified_on_branch`` so the stop hook can distinguish code that arrived
+    on main via a PR merge from code written directly on main.
     """
     tool_name = hook_input.get("tool_name", "")
     if tool_name not in ("Write", "Edit"):
@@ -106,6 +126,14 @@ def update_sdlc_state_for_file_write(hook_input: dict) -> None:
 
     session_id = hook_input.get("session_id", "unknown")
     state = load_sdlc_state(session_id)
+
+    # Record the branch on the *first* code modification only.
+    # Subsequent writes do not overwrite — the first branch wins.
+    if not state.get("code_modified") and "modified_on_branch" not in state:
+        branch = _get_current_branch()
+        if branch:
+            state["modified_on_branch"] = branch
+
     state["code_modified"] = True
     if file_path not in state["files"]:
         state["files"].append(file_path)
@@ -113,11 +141,19 @@ def update_sdlc_state_for_file_write(hook_input: dict) -> None:
 
 
 def update_sdlc_state_for_bash(hook_input: dict) -> None:
-    """Update quality_commands when a Bash tool runs pytest, ruff, or black.
+    """Update state when a Bash tool runs quality commands or merges a PR.
+
+    Tracks two categories of bash commands:
+
+    1. **Quality commands** (pytest, ruff, black): marks them as run in the
+       session's quality_commands dict.
+    2. **PR merge** (``gh pr merge``): resets ``code_modified`` to False,
+       since the code has been properly merged via a PR and is no longer
+       "pending" on the session.
 
     Key principle: if no sdlc_state.json exists (non-code session), do nothing.
-    We only track quality commands when the session is already classified as a
-    code session (i.e., the state file was created by a prior code file write).
+    We only track these when the session is already classified as a code session
+    (i.e., the state file was created by a prior code file write).
     """
     tool_name = hook_input.get("tool_name", "")
     if tool_name != "Bash":
@@ -125,6 +161,9 @@ def update_sdlc_state_for_bash(hook_input: dict) -> None:
 
     tool_input = hook_input.get("tool_input", {})
     command = tool_input.get("command", "")
+
+    # Detect gh pr merge commands (belt-and-suspenders cleanup after merge)
+    is_merge = bool(re.search(r"\bgh\s+pr\s+merge\b", command))
 
     # Check if this command runs any quality tool.
     # Use regex word boundary to avoid false positives like `echo "pytest"` or
@@ -135,7 +174,7 @@ def update_sdlc_state_for_bash(hook_input: dict) -> None:
             matched_command = cmd
             break
 
-    if matched_command is None:
+    if matched_command is None and not is_merge:
         return
 
     session_id = hook_input.get("session_id", "unknown")
@@ -146,7 +185,13 @@ def update_sdlc_state_for_bash(hook_input: dict) -> None:
         return
 
     state = load_sdlc_state(session_id)
-    state["quality_commands"][matched_command] = True
+
+    if matched_command is not None:
+        state["quality_commands"][matched_command] = True
+
+    if is_merge:
+        state["code_modified"] = False
+
     save_sdlc_state(session_id, state)
 
 

--- a/agent/sdk_client.py
+++ b/agent/sdk_client.py
@@ -219,8 +219,12 @@ def _check_no_direct_main_push(
     """Check whether a session pushed code directly to main.
 
     Reads the session's sdlc_state.json. If code was modified and the current
-    git branch is 'main', returns a hard-block error message. Otherwise returns
-    None (session may complete).
+    git branch is 'main', checks ``modified_on_branch`` to distinguish:
+
+    - Code written on a ``session/*`` branch and now on main via PR merge
+      → **allowed** (no violation).
+    - Code written directly on main (or legacy state without the field)
+      → **hard-block** violation.
 
     This is a hard-block — there is no escape hatch at the SDK layer.
     Telegram is free text; there is no mechanism for a user to signal an
@@ -284,7 +288,20 @@ def _check_no_direct_main_push(
         # On a feature branch (inside /do-build worktree) — all good
         return None
 
-    # Code modified + on main = SDLC violation
+    # Code modified + on main: check where the code was *originally* written.
+    # If it was written on a session/* branch, it arrived here via PR merge —
+    # not a direct push. Only block if modified_on_branch is "main" or absent
+    # (legacy state without the field → preserve backward-compat behavior).
+    modified_on_branch = state.get("modified_on_branch", "")
+    if modified_on_branch.startswith("session/"):
+        logger.info(
+            f"[sdlc-main-check] Code for {session_id} was modified on "
+            f"'{modified_on_branch}' and is now on main — arrived via merge, "
+            "no violation."
+        )
+        return None
+
+    # Code modified on main (or legacy state) = SDLC violation
     modified_files = state.get("files", [])
     files_list = (
         "\n".join(f"  - {f}" for f in modified_files)

--- a/tests/unit/test_post_tool_use_sdlc.py
+++ b/tests/unit/test_post_tool_use_sdlc.py
@@ -319,3 +319,132 @@ class TestUpdateSdlcStateForBash:
         update_sdlc_state_for_bash(hook_input)
         state_path = sessions_dir / session_id / "sdlc_state.json"
         assert not state_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Merge detection: gh pr merge resets code_modified
+# ---------------------------------------------------------------------------
+
+
+class TestMergeDetection:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh pr merge --squash --delete-branch",
+            "gh pr merge 42 --squash",
+            "gh pr merge",
+            "gh pr merge --merge",
+            "gh pr merge --rebase",
+        ],
+    )
+    def test_gh_pr_merge_resets_code_modified(
+        self, patch_project_dir, tmp_session, command
+    ):
+        """gh pr merge commands should reset code_modified to false."""
+        session_id, _ = tmp_session
+        save_sdlc_state(session_id, _make_quality_state())
+        hook_input = {
+            "session_id": session_id,
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+        }
+        update_sdlc_state_for_bash(hook_input)
+        state = load_sdlc_state(session_id)
+        assert state["code_modified"] is False
+
+    def test_non_merge_command_preserves_code_modified(
+        self, patch_project_dir, tmp_session
+    ):
+        """Non-merge bash commands should not reset code_modified."""
+        session_id, _ = tmp_session
+        save_sdlc_state(session_id, _make_quality_state())
+        hook_input = {
+            "session_id": session_id,
+            "tool_name": "Bash",
+            "tool_input": {"command": "gh pr view 42"},
+        }
+        update_sdlc_state_for_bash(hook_input)
+        state = load_sdlc_state(session_id)
+        assert state["code_modified"] is True
+
+    def test_merge_without_existing_state_is_noop(self, patch_project_dir, tmp_session):
+        """gh pr merge without pre-existing state file does nothing."""
+        sessions_dir = patch_project_dir
+        session_id, _ = tmp_session
+        hook_input = {
+            "session_id": session_id,
+            "tool_name": "Bash",
+            "tool_input": {"command": "gh pr merge --squash"},
+        }
+        update_sdlc_state_for_bash(hook_input)
+        state_path = sessions_dir / session_id / "sdlc_state.json"
+        assert not state_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Branch recording: modified_on_branch set on first code write
+# ---------------------------------------------------------------------------
+
+
+class TestBranchRecording:
+    def test_branch_recorded_on_first_code_write(self, patch_project_dir, tmp_session):
+        """When code is first modified, modified_on_branch should be recorded."""
+        session_id, _ = tmp_session
+        hook_input = {
+            "session_id": session_id,
+            "tool_name": "Write",
+            "tool_input": {"file_path": "agent/foo.py"},
+        }
+        with patch("subprocess.run") as mock_run:
+            mock_result = type("Result", (), {"stdout": "session/my-feature\n"})()
+            mock_run.return_value = mock_result
+            update_sdlc_state_for_file_write(hook_input)
+        state = load_sdlc_state(session_id)
+        assert state["modified_on_branch"] == "session/my-feature"
+
+    def test_branch_not_overwritten_on_subsequent_writes(
+        self, patch_project_dir, tmp_session
+    ):
+        """modified_on_branch should only be set once (first write wins)."""
+        session_id, _ = tmp_session
+        # First write on session/first-branch
+        hook_input = {
+            "session_id": session_id,
+            "tool_name": "Write",
+            "tool_input": {"file_path": "agent/foo.py"},
+        }
+        with patch("subprocess.run") as mock_run:
+            mock_result = type("Result", (), {"stdout": "session/first-branch\n"})()
+            mock_run.return_value = mock_result
+            update_sdlc_state_for_file_write(hook_input)
+
+        # Second write (branch changed to main, but should not overwrite)
+        hook_input2 = {
+            "session_id": session_id,
+            "tool_name": "Write",
+            "tool_input": {"file_path": "agent/bar.py"},
+        }
+        with patch("subprocess.run") as mock_run:
+            mock_result = type("Result", (), {"stdout": "main\n"})()
+            mock_run.return_value = mock_result
+            update_sdlc_state_for_file_write(hook_input2)
+
+        state = load_sdlc_state(session_id)
+        assert state["modified_on_branch"] == "session/first-branch"
+
+    def test_branch_recording_failure_does_not_block_state_save(
+        self, patch_project_dir, tmp_session
+    ):
+        """If git rev-parse fails, state should still be saved with code_modified=True."""
+        session_id, _ = tmp_session
+        hook_input = {
+            "session_id": session_id,
+            "tool_name": "Write",
+            "tool_input": {"file_path": "agent/foo.py"},
+        }
+        with patch("subprocess.run", side_effect=Exception("git not found")):
+            update_sdlc_state_for_file_write(hook_input)
+        state = load_sdlc_state(session_id)
+        assert state["code_modified"] is True
+        # modified_on_branch should not be present since git failed
+        assert "modified_on_branch" not in state

--- a/tests/unit/test_sdk_client_sdlc.py
+++ b/tests/unit/test_sdk_client_sdlc.py
@@ -7,16 +7,33 @@ Covers:
 - _check_no_direct_main_push(): docs-only on main → allowed
 - _check_no_direct_main_push(): code on feature branch → allowed
 - _check_no_direct_main_push(): no state file → allowed
+- _check_no_direct_main_push(): modified_on_branch=session/* + main → no violation (merge)
+- _check_no_direct_main_push(): modified_on_branch=main + main → violation (direct push)
+- _check_no_direct_main_push(): no modified_on_branch + main → violation (backward compat)
 """
 
 from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
+from types import ModuleType
 from unittest.mock import MagicMock, patch
 
-from agent.sdk_client import (
+# Mock claude_agent_sdk before importing agent.sdk_client to avoid
+# dependency issues (mcp.types.ToolAnnotations import error).
+if "claude_agent_sdk" not in sys.modules:
+
+    class _MockSDK(ModuleType):
+        """Auto-mock module: returns a MagicMock for any attribute access."""
+
+        def __getattr__(self, name):
+            return MagicMock()
+
+    sys.modules["claude_agent_sdk"] = _MockSDK("claude_agent_sdk")
+
+from agent.sdk_client import (  # noqa: E402
     SDLC_WORKFLOW,
     _check_no_direct_main_push,
     load_system_prompt,
@@ -233,3 +250,51 @@ class TestCheckNoDirectMainPush:
         with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("git", 5)):
             result = _check_no_direct_main_push("git-fail-session", repo_root=tmp_path)
         assert result is None
+
+    # -----------------------------------------------------------------------
+    # modified_on_branch: merge scenario vs. direct push
+    # -----------------------------------------------------------------------
+
+    def test_modified_on_session_branch_now_on_main_returns_none(self, tmp_path):
+        """Code modified on session/foo, now on main → arrived via merge, no violation."""
+        result = self._run_check(
+            tmp_path,
+            "merged-session",
+            state={
+                "code_modified": True,
+                "modified_on_branch": "session/stop-hook-fix",
+                "files": ["agent/sdk_client.py"],
+            },
+            branch="main",
+        )
+        assert result is None
+
+    def test_modified_on_main_now_on_main_returns_violation(self, tmp_path):
+        """Code modified on main, still on main → direct push, violation."""
+        result = self._run_check(
+            tmp_path,
+            "direct-push-session",
+            state={
+                "code_modified": True,
+                "modified_on_branch": "main",
+                "files": ["agent/sdk_client.py"],
+            },
+            branch="main",
+        )
+        assert result is not None
+        assert "SDLC VIOLATION" in result
+
+    def test_no_modified_on_branch_legacy_returns_violation(self, tmp_path):
+        """Legacy state without modified_on_branch, on main → violation (backward compat)."""
+        result = self._run_check(
+            tmp_path,
+            "legacy-session",
+            state={
+                "code_modified": True,
+                "files": ["bridge/telegram_bridge.py"],
+                # No modified_on_branch — legacy state
+            },
+            branch="main",
+        )
+        assert result is not None
+        assert "SDLC VIOLATION" in result


### PR DESCRIPTION
## Summary
- Records `modified_on_branch` in `sdlc_state.json` when code is first written, so the stop hook knows code was written on `session/*` not `main`
- Detects `gh pr merge` in bash commands and resets `code_modified` to false
- `_check_no_direct_main_push()` now allows through code that was written on a `session/*` branch (arrived via merge)

Fixes #168

**Plan:** https://github.com/tomcounsell/ai/blob/main/docs/plans/stop-hook-false-positive-168.md

## Test plan
- [x] 10 new unit tests covering merge scenario, direct push, legacy state, branch recording, merge detection
- [x] All 63 tests pass
- [x] ruff + black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)