### PR TITLE
fix: add ground truth rules to prevent hallucinated PR review findings (#181)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -37,6 +37,21 @@ You are a Code Reviewer for the AI system. Your role is to ensure code quality, 
    - Ensure type hints present
    - Validate formatting
 
+## Ground Truth Rules
+
+These rules are mandatory. Violating them produces hallucinated findings that waste time and erode trust.
+
+1. **Never cite code you haven't read.** Every file path, function name, and line number in your review MUST come from a file you read with the Read tool during this session. If you can't find it, don't reference it.
+
+2. **Quote the actual code.** When flagging an issue, include the verbatim code snippet from the file. Do not paraphrase or reconstruct code from memory. Copy-paste the exact lines.
+
+3. **Verify before claiming.** Before writing a finding:
+   - Confirm the file exists (you read it)
+   - Confirm the function/class exists at the line you're citing
+   - Confirm the behavior you're describing matches what the code actually does
+
+4. **If you can't verify, don't include it.** Drop the finding entirely. A missing valid finding is far less harmful than a fabricated one.
+
 ## Review Process
 
 ### 1. Understand Context

--- a/.claude/skills/do-pr-review/SKILL.md
+++ b/.claude/skills/do-pr-review/SKILL.md
@@ -138,11 +138,31 @@ For each requirement/acceptance criterion in the plan:
   - Documentation wording
   - Future enhancements
 
-**For each issue found:**
-1. Reference the file and line number
-2. Write clear description of the problem
-3. Suggest a fix
-4. Classify severity
+**For each issue found, use this format:**
+
+```
+**File:** `path/to/file.py:42` (verified: read this file)
+**Code:** `the_actual_code_on_that_line()`
+**Issue:** [clear description of the problem]
+**Severity:** blocker | tech_debt | nit
+**Fix:** [suggested fix]
+```
+
+The `Code:` field MUST be a verbatim quote from the file, not paraphrased. The `File:` path MUST be a file you read with the Read tool during this review. If you cannot produce both of these, do not include the finding.
+
+### 5.5. Verify Findings (mandatory)
+
+Before posting, verify every blocker and tech_debt finding:
+
+1. **Confirm the file exists** — you must have read it with the Read tool during this review
+2. **Confirm the code exists** — the function, class, or pattern you're citing must appear in the file at or near the line you reference
+3. **Confirm the behavior** — re-read the relevant code to make sure your description of the problem is accurate
+
+**If a finding fails verification** (file doesn't exist, function not found, behavior described doesn't match actual code):
+- **Drop it entirely.** Do not include unverified findings in the review.
+- A false blocker is worse than a missed real issue — it wastes time and erodes trust.
+
+This step exists because of issue #181: a prior review hallucinated two "blocker" findings citing functions and files that did not exist.
 
 ### 6. Post Review
 
@@ -154,11 +174,11 @@ gh pr review {pr_number} --request-changes --body "$(cat <<'EOF'
 [summary of blockers]
 
 ### Blockers
-- [ ] [blocker 1 with file:line reference]
-- [ ] [blocker 2 with file:line reference]
+- [ ] **`file.py:42`** — `actual_code()` — [description of issue]
+- [ ] **`file.py:87`** — `actual_code()` — [description of issue]
 
 ### Tech Debt (non-blocking)
-- [tech debt items]
+- **`file.py:15`** — `code()` — [description]
 
 ### Screenshots
 [screenshot references if captured]
@@ -229,6 +249,7 @@ Save this URL as `{review_url}` for the output summary.
 
 1. **Always read the plan first**: The plan is the source of truth for what should have been built
 2. **Focus on correctness over style**: Don't nitpick formatting if the code works
-3. **Be specific in issue descriptions**: Include file paths and line numbers
-4. **Classify severity honestly**: Don't mark blockers as tech debt to speed up merge
-5. **Capture key UI paths**: 1-3 screenshots typical, focus on changed functionality
+3. **Quote actual code in every finding**: Include the verbatim code snippet, not a paraphrase — this makes hallucinated findings self-evident
+4. **Verify before posting**: Every blocker must cite a file you read and code you saw (Step 5.5)
+5. **Classify severity honestly**: Don't mark blockers as tech debt to speed up merge
+6. **Capture key UI paths**: 1-3 screenshots typical, focus on changed functionality


### PR DESCRIPTION
## Summary
- Added **Ground Truth Rules** section to `.claude/agents/code-reviewer.md` — 4 mandatory rules requiring verified file references and verbatim code quotes
- Added **Step 5.5: Verify Findings** to `.claude/skills/do-pr-review/SKILL.md` — mandatory verification pass before posting
- Updated issue reporting format to require `File:` (verified), `Code:` (verbatim), `Issue:`, `Severity:`, `Fix:`
- Updated best practices to emphasize verification

## Context
PR #180 review produced two fabricated "BLOCKER" findings citing functions and files that didn't exist. This change ensures every finding is grounded in code the reviewer actually read.

## Test plan
- [ ] Read the updated SKILL.md and verify Step 5.5 is between Step 5 and Step 6
- [ ] Read the updated code-reviewer.md and verify Ground Truth Rules section exists
- [ ] Confirm the blocker template requires verbatim code quotes
- [ ] Next PR review should produce only verified findings

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)