### PR TITLE
feat: stage-aware auto-continue for SDLC jobs (#178)

### DIFF
--- a/agent/job_queue.py
+++ b/agent/job_queue.py
@@ -35,16 +35,13 @@ RedisJob = AgentSession
 
 MSG_MAX_CHARS = 20_000  # ~5k tokens — reasonable context limit for agent input
 MAX_AUTO_CONTINUES = 3  # Max status updates to auto-continue before sending to chat
+MAX_AUTO_CONTINUES_SDLC = 10  # Higher cap for SDLC jobs (stage progress is real signal)
 
 # Job health check constants
 JOB_HEALTH_CHECK_INTERVAL = 300  # 5 minutes
 JOB_TIMEOUT_DEFAULT = 2700  # 45 minutes for standard jobs
-JOB_TIMEOUT_BUILD = (
-    9000  # 2.5 hours for build jobs (detected by /do-build in message_text)
-)
-JOB_HEALTH_MIN_RUNNING = (
-    300  # Don't recover jobs running less than 5 min (race condition guard)
-)
+JOB_TIMEOUT_BUILD = 9000  # 2.5 hours for build jobs (detected by /do-build in message_text)
+JOB_HEALTH_MIN_RUNNING = 300  # Don't recover jobs running less than 5 min (race condition guard)
 
 
 class Job:
@@ -273,9 +270,7 @@ async def _pop_job(project_key: str) -> Job | None:
     status index set but never REMOVEs from the old one, so mutating
     status and calling save() leaves a stale entry in the pending index.
     """
-    pending = await AgentSession.query.async_filter(
-        project_key=project_key, status="pending"
-    )
+    pending = await AgentSession.query.async_filter(project_key=project_key, status="pending")
     if not pending:
         return None
 
@@ -330,9 +325,7 @@ def _recover_interrupted_jobs(project_key: str) -> int:
     Uses delete-and-recreate to avoid KeyField index corruption.
     Returns the number of recovered jobs.
     """
-    running_jobs = list(
-        AgentSession.query.filter(project_key=project_key, status="running")
-    )
+    running_jobs = list(AgentSession.query.filter(project_key=project_key, status="running"))
     if not running_jobs:
         return 0
 
@@ -360,17 +353,13 @@ async def _reset_running_jobs(project_key: str) -> int:
     Uses delete-and-recreate to avoid KeyField index corruption.
     Returns the number of reset jobs.
     """
-    running_jobs = await AgentSession.query.async_filter(
-        project_key=project_key, status="running"
-    )
+    running_jobs = await AgentSession.query.async_filter(project_key=project_key, status="running")
     if not running_jobs:
         return 0
 
     for job in running_jobs:
         old_id = job.job_id
-        logger.info(
-            f"[{project_key}] Resetting in-flight job {old_id} to pending for next startup"
-        )
+        logger.info(f"[{project_key}] Resetting in-flight job {old_id} to pending for next startup")
         fields = _extract_job_fields(job)
         await job.async_delete()
         fields["status"] = "pending"
@@ -447,9 +436,7 @@ def _recover_orphaned_jobs(project_key: str) -> int:
                 fields = _extract_job_fields(orphan_job)
             except Exception:
                 # If decoding fails, skip this orphan
-                logger.warning(
-                    f"[{project_key}] Could not decode orphan {key_str}, skipping"
-                )
+                logger.warning(f"[{project_key}] Could not decode orphan {key_str}, skipping")
                 continue
 
             # Delete the orphan hash and class set entry
@@ -462,8 +449,7 @@ def _recover_orphaned_jobs(project_key: str) -> int:
             new_job = AgentSession.create(**fields)
             recovered += 1
             logger.warning(
-                f"[{project_key}] Recovered orphaned job from key {key_str} "
-                f"-> {new_job.job_id}"
+                f"[{project_key}] Recovered orphaned job from key {key_str} -> {new_job.job_id}"
             )
         except Exception as e:
             logger.error(f"[{project_key}] Failed to recover orphan {key}: {e}")
@@ -533,9 +519,7 @@ async def _job_health_check() -> None:
                 # Legacy job without started_at and no worker -- recover
                 should_recover = True
                 reason = "worker dead/missing, no started_at (legacy job)"
-            elif (
-                running_seconds is not None and running_seconds > JOB_HEALTH_MIN_RUNNING
-            ):
+            elif running_seconds is not None and running_seconds > JOB_HEALTH_MIN_RUNNING:
                 should_recover = True
                 reason = (
                     f"worker dead/missing, running for "
@@ -671,8 +655,7 @@ def _truncate_to_limit(text: str, label: str) -> str:
     original_len = len(text)
     text = "...[truncated]\n" + text[-(MSG_MAX_CHARS - 15) :]
     logger.warning(
-        f"Truncated {label}: {original_len} -> {len(text)} chars "
-        f"(kept last {MSG_MAX_CHARS} chars)"
+        f"Truncated {label}: {original_len} -> {len(text)} chars (kept last {MSG_MAX_CHARS} chars)"
     )
     return text
 
@@ -697,9 +680,7 @@ def _check_restart_flag() -> bool:
             return False
 
     flag_content = _RESTART_FLAG.read_text().strip()
-    logger.info(
-        f"Restart flag found ({flag_content}), no running jobs — restarting bridge"
-    )
+    logger.info(f"Restart flag found ({flag_content}), no running jobs — restarting bridge")
     return True
 
 
@@ -780,9 +761,7 @@ async def enqueue_job(
         auto_continue_count=auto_continue_count,
     )
     _ensure_worker(project_key)
-    logger.info(
-        f"[{project_key}] Enqueued job " f"(priority={priority}, depth={depth})"
-    )
+    logger.info(f"[{project_key}] Enqueued job (priority={priority}, depth={depth})")
     return depth
 
 
@@ -818,9 +797,7 @@ async def _worker_loop(project_key: str) -> None:
                     if _check_restart_flag():
                         _trigger_restart()
                     break
-                logger.info(
-                    f"[{project_key}] Drain guard caught job that would have been lost"
-                )
+                logger.info(f"[{project_key}] Drain guard caught job that would have been lost")
 
             try:
                 await _execute_job(job)
@@ -885,6 +862,77 @@ async def _calendar_heartbeat(slug: str, project: str | None = None) -> None:
 CALENDAR_HEARTBEAT_INTERVAL = 25 * 60  # 25 minutes (fits within 30-min segments)
 
 
+async def _enqueue_continuation(
+    job: "Job",
+    branch_name: str,
+    task_list_id: str,
+    auto_continue_count: int,
+    output_msg: str,
+    coaching_source: str = "stage_aware",
+) -> None:
+    """Enqueue a continuation job for stage-aware auto-continue.
+
+    Builds a coaching message and re-enqueues the job with the same
+    session_id so the SDK resumes the conversation. Used by both the
+    stage-aware path and the classifier path.
+
+    Args:
+        job: The current Job being executed.
+        branch_name: Git branch name for the session.
+        task_list_id: Task list ID for sub-agent isolation.
+        auto_continue_count: Current auto-continue count (already incremented).
+        output_msg: The agent output that triggered auto-continue.
+        coaching_source: Label for logging ("stage_aware" or "classifier").
+    """
+    from bridge.coach import build_coaching_message
+    from bridge.summarizer import ClassificationResult, OutputType
+
+    # For stage-aware continuations, build a minimal classification
+    # so the coach can still provide skill-aware coaching
+    classification = ClassificationResult(
+        output_type=OutputType.STATUS_UPDATE,
+        confidence=1.0,
+        reason=f"Stage-aware auto-continue ({coaching_source})",
+    )
+
+    # Resolve plan_file from WorkflowState if available
+    _plan_file = None
+    if job.workflow_id:
+        try:
+            from agent.workflow_state import WorkflowState
+
+            ws = WorkflowState.load(job.workflow_id)
+            if ws.data and ws.data.plan_file:
+                _plan_file = ws.data.plan_file
+        except Exception:
+            pass  # Degrade gracefully
+
+    coaching_message = build_coaching_message(
+        classification=classification,
+        plan_file=_plan_file,
+        job_message_text=job.message_text,
+    )
+
+    logger.info(
+        f"[{job.project_key}] Coaching message ({coaching_source}) "
+        f"({len(coaching_message)} chars): {coaching_message[:120]!r}"
+    )
+
+    await enqueue_job(
+        project_key=job.project_key,
+        session_id=job.session_id,
+        working_dir=job.working_dir,
+        message_text=coaching_message,
+        sender_name="System (auto-continue)",
+        chat_id=job.chat_id,
+        message_id=job.message_id,
+        priority="high",
+        work_item_slug=job.work_item_slug,
+        task_list_id=task_list_id,
+        auto_continue_count=auto_continue_count,
+    )
+
+
 async def _execute_job(job: Job) -> None:
     """
     Execute a single job:
@@ -934,9 +982,7 @@ async def _execute_job(job: Job) -> None:
     # Update the AgentSession (already created at enqueue time) with session-phase fields
     agent_session = None
     try:
-        sessions = list(
-            AgentSession.query.filter(project_key=job.project_key, status="running")
-        )
+        sessions = list(AgentSession.query.filter(project_key=job.project_key, status="running"))
         for s in sessions:
             if s.session_id == job.session_id:
                 agent_session = s
@@ -980,7 +1026,83 @@ async def _execute_job(job: Job) -> None:
             )
             return
 
-        # Classify the output to decide routing
+        # === Stage-aware auto-continue for SDLC jobs ===
+        # Decision matrix (see docs/plans/stage_aware_auto_continue.md):
+        #
+        # | Pipeline state      | Output classification | Action            |
+        # |---------------------|-----------------------|-------------------|
+        # | Stages remaining    | (skipped)             | Auto-continue     |
+        # | All stages done     | Completion            | Deliver to user   |
+        # | All stages done     | Status (no evidence)  | Coach + continue  |
+        # | Any stage failed    | Error/blocker         | Deliver to user   |
+        # | No stages (non-SDLC)| Question              | Deliver to user   |
+        # | No stages (non-SDLC)| Status                | Auto-continue     |
+        #
+        # For SDLC jobs, stage progress is the primary termination signal.
+        # The classifier is only consulted when all stages are done or for
+        # non-SDLC jobs.
+
+        _is_sdlc = False
+        _sdlc_has_remaining = False
+        _sdlc_has_failed = False
+        if agent_session:
+            _is_sdlc = agent_session.is_sdlc_job()
+            if _is_sdlc:
+                _sdlc_has_remaining = agent_session.has_remaining_stages()
+                _sdlc_has_failed = agent_session.has_failed_stage()
+
+        # Determine the effective auto-continue cap for this job
+        effective_max = MAX_AUTO_CONTINUES_SDLC if _is_sdlc else MAX_AUTO_CONTINUES
+
+        if _is_sdlc and _sdlc_has_failed:
+            # SDLC job with a failed stage — deliver to user immediately.
+            # Don't auto-continue; the failure needs human attention.
+            logger.info(f"[{job.project_key}] SDLC stage failed — delivering to user")
+            await send_cb(job.chat_id, msg, job.message_id)
+            _completion_sent = True
+            return
+
+        if _is_sdlc and _sdlc_has_remaining and auto_continue_count < effective_max:
+            # SDLC job with stages remaining — auto-continue without classifier.
+            # Stage progress is a stronger signal than prose classification.
+            auto_continue_count += 1
+            progress = agent_session.get_stage_progress()
+            logger.info(
+                f"[{job.project_key}] Stage-aware auto-continue "
+                f"({auto_continue_count}/{effective_max}), "
+                f"progress: {progress}"
+            )
+
+            save_session_snapshot(
+                session_id=job.session_id,
+                event="auto_continue",
+                project_key=job.project_key,
+                branch_name=branch_name,
+                task_summary=f"Stage-aware auto-continue ({auto_continue_count}/{effective_max})",
+                extra_context={
+                    "routing": "stage_aware",
+                    "stage_progress": str(progress),
+                    "message_preview": msg[:200],
+                },
+                working_dir=str(working_dir),
+            )
+
+            await _enqueue_continuation(
+                job,
+                branch_name,
+                task_list_id,
+                auto_continue_count,
+                msg,
+                coaching_source="stage_aware",
+            )
+
+            _completion_sent = True
+            _defer_reaction = True
+            return
+
+        # === Classifier-based routing ===
+        # Used for: non-SDLC jobs, SDLC jobs with all stages done,
+        # and SDLC jobs that hit the safety cap.
         from bridge.summarizer import OutputType, classify_output
 
         classification = await classify_output(msg)
@@ -994,20 +1116,18 @@ async def _execute_job(job: Job) -> None:
             # Without this, SDK crashes would be misclassified as status updates
             # and re-enqueued indefinitely, creating an infinite crash loop.
             # See docs/features/coaching-loop.md "Error-Classified Output Bypass".
-            logger.info(
-                f"[{job.project_key}] Error classified — skipping auto-continue"
-            )
+            logger.info(f"[{job.project_key}] Error classified — skipping auto-continue")
             # Fall through to send error to chat
 
         elif (
             classification.output_type == OutputType.STATUS_UPDATE
-            and auto_continue_count < MAX_AUTO_CONTINUES
+            and auto_continue_count < effective_max
         ):
             # Status update -- don't send to chat, re-enqueue job to continue session
             auto_continue_count += 1
             logger.info(
                 f"[{job.project_key}] Auto-continuing via job re-enqueue "
-                f"({auto_continue_count}/{MAX_AUTO_CONTINUES})"
+                f"({auto_continue_count}/{effective_max})"
             )
 
             # Log a session snapshot for audit trail
@@ -1016,8 +1136,9 @@ async def _execute_job(job: Job) -> None:
                 event="auto_continue",
                 project_key=job.project_key,
                 branch_name=branch_name,
-                task_summary=f"Auto-continued ({auto_continue_count}/{MAX_AUTO_CONTINUES})",
+                task_summary=f"Auto-continued ({auto_continue_count}/{effective_max})",
                 extra_context={
+                    "routing": "classifier",
                     "classification": classification.output_type.value,
                     "confidence": classification.confidence,
                     "reason": classification.reason,
@@ -1125,9 +1246,7 @@ async def _execute_job(job: Job) -> None:
                 _defer_reaction = True
 
             _completion_sent = True
-            logger.info(
-                f"[{job.project_key}] Completion sent — suppressing further outputs"
-            )
+            logger.info(f"[{job.project_key}] Completion sent — suppressing further outputs")
 
     messenger = BossMessenger(
         _send_callback=send_to_chat,
@@ -1156,9 +1275,7 @@ async def _execute_job(job: Job) -> None:
                 message_id=job.message_id,
             )
         except Exception as e:
-            logger.warning(
-                f"[{job.project_key}] Enrichment failed, using raw text: {e}"
-            )
+            logger.warning(f"[{job.project_key}] Enrichment failed, using raw text: {e}")
 
     # Run agent work directly in the project working directory
     project_config = {
@@ -1188,9 +1305,7 @@ async def _execute_job(job: Job) -> None:
     while task.is_running:
         await asyncio.sleep(2)
         if time.time() - last_heartbeat >= CALENDAR_HEARTBEAT_INTERVAL:
-            asyncio.create_task(
-                _calendar_heartbeat(job.project_key, project=job.project_key)
-            )
+            asyncio.create_task(_calendar_heartbeat(job.project_key, project=job.project_key))
             last_heartbeat = time.time()
 
     # Update session status in Redis via AgentSession
@@ -1200,9 +1315,7 @@ async def _execute_job(job: Job) -> None:
             from bridge.session_transcript import complete_transcript
 
             final_status = (
-                "active"
-                if _defer_reaction
-                else ("completed" if not task.error else "failed")
+                "active" if _defer_reaction else ("completed" if not task.error else "failed")
             )
             if not _defer_reaction:
                 complete_transcript(job.session_id, status=final_status)
@@ -1234,10 +1347,7 @@ async def _execute_job(job: Job) -> None:
 
         leftover = pop_all_steering_messages(job.session_id)
         if leftover:
-            texts = [
-                f"  [{m.get('sender', '?')}]: {m.get('text', '')[:120]}"
-                for m in leftover
-            ]
+            texts = [f"  [{m.get('sender', '?')}]: {m.get('text', '')[:120]}" for m in leftover]
             logger.warning(
                 f"[{job.project_key}] {len(leftover)} unconsumed steering "
                 f"message(s) dropped for session {job.session_id}:\n" + "\n".join(texts)
@@ -1420,8 +1530,7 @@ async def queue_revival_job(
     revival_text = f"Continue the unfinished work on branch `{revival_info['branch']}`."
     if additional_context:
         revival_text += (
-            "\n\nAsked user whether to resume and user "
-            f"responded with: {additional_context}"
+            f"\n\nAsked user whether to resume and user responded with: {additional_context}"
         )
 
     return await enqueue_job(
@@ -1437,9 +1546,7 @@ async def queue_revival_job(
     )
 
 
-async def cleanup_stale_branches(
-    working_dir: str, max_age_hours: float = 72
-) -> list[str]:
+async def cleanup_stale_branches(working_dir: str, max_age_hours: float = 72) -> list[str]:
     """
     Clean up session branches older than max_age_hours.
     Returns list of cleaned branch names.
@@ -1458,11 +1565,7 @@ async def cleanup_stale_branches(
             text=True,
             timeout=10,
         )
-        branches = [
-            b.strip().lstrip("* ")
-            for b in result.stdout.strip().split("\n")
-            if b.strip()
-        ]
+        branches = [b.strip().lstrip("* ") for b in result.stdout.strip().split("\n") if b.strip()]
 
         for branch in branches:
             age_result = subprocess.run(
@@ -1614,12 +1717,8 @@ def _cli_main() -> None:
     parser = argparse.ArgumentParser(description="Job queue management CLI")
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--status", action="store_true", help="Show current queue state")
-    group.add_argument(
-        "--flush-stuck", action="store_true", help="Recover all stuck running jobs"
-    )
-    group.add_argument(
-        "--flush-job", metavar="JOB_ID", help="Recover a specific job by ID"
-    )
+    group.add_argument("--flush-stuck", action="store_true", help="Recover all stuck running jobs")
+    group.add_argument("--flush-job", metavar="JOB_ID", help="Recover a specific job by ID")
 
     args = parser.parse_args()
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -15,7 +15,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [Build Session Reliability](build-session-reliability.md) | Logging propagation, commit-on-exit, worktree isolation, health monitoring | Shipped |
 | [Classification](classification.md) | Auto-classification of messages as bug/feature/chore with immutability and reclassify skill | Shipped |
 | [Completion Tracking](completion-tracking.md) | Branch-based work tracking and completion token system | Archived |
-| [Coaching Loop](coaching-loop.md) | Merged classifier-coach with LLM-generated coaching, tiered fallback, and error crash guard | Shipped |
+| [Coaching Loop](coaching-loop.md) | Merged classifier-coach with LLM-generated coaching, tiered fallback, error crash guard, and stage-aware auto-continue for SDLC jobs | Shipped |
 | [Code Impact Finder](code-impact-finder.md) | Semantic search for blast radius analysis during /do-plan | Shipped |
 | [Daydream](daydream.md) | Autonomous 14-step daily maintenance: cleanup, log analysis, session quality, LLM reflection, auto-fix PRs, multi-repo support, institutional memory, Telegram notifications | Shipped |
 | [Documentation Audit](documentation-audit.md) | Weekly LLM-powered audit of docs/ accuracy against codebase; KEEP / UPDATE / DELETE verdicts, directory and filename enforcement | Shipped |

--- a/docs/features/coaching-loop.md
+++ b/docs/features/coaching-loop.md
@@ -59,22 +59,53 @@ To add a future skill, add an entry to `SKILL_DETECTORS` — the coach picks it 
 
 ## Flow
 
+The auto-continue system uses a two-path routing strategy. SDLC jobs (those with `[stage]` entries in `AgentSession.history`) use pipeline stage progress as the primary signal. Non-SDLC jobs (casual chat, Q&A) use the LLM classifier.
+
 ```
 Agent Output
     |
     v
-Classifier (LLM) --- produces {type, confidence, reason, coaching_message}
+Is SDLC job? (check AgentSession.history for [stage] entries)
     |
-    v
-build_coaching_message()
-    |-- Tier 1:  coaching_message from classifier (if present)
-    |-- Tier 1b: heuristic rejection templates (if was_rejected but no LLM coaching)
-    |-- Tier 2:  skill-aware coaching (plan criteria or skill evidence hints)
-    +-- Tier 3:  plain "continue"
+    +-- YES: Stage-Aware Path
+    |     |
+    |     +-- Has failed stage? --> Deliver to user immediately
+    |     +-- Stages remaining? --> Auto-continue (skip classifier)
+    |     +-- All stages done?  --> Fall through to Classifier Path
     |
-    v
-[System Coach] message sent to agent
+    +-- NO: Classifier Path
+          |
+          v
+    Classifier (LLM) --- produces {type, confidence, reason, coaching_message}
+          |
+          v
+    build_coaching_message()
+          |-- Tier 1:  coaching_message from classifier (if present)
+          |-- Tier 1b: heuristic rejection templates (if was_rejected but no LLM coaching)
+          |-- Tier 2:  skill-aware coaching (plan criteria or skill evidence hints)
+          +-- Tier 3:  plain "continue"
+          |
+          v
+    [System Coach] message sent to agent
 ```
+
+### Stage-Aware Auto-Continue Decision Matrix
+
+| Pipeline state | Output classification | Action |
+|---|---|---|
+| Stages remaining | (skipped) | Auto-continue |
+| All stages done | Completion | Deliver to user |
+| All stages done | Status (no evidence) | Coach + continue |
+| Any stage failed | Error/blocker | Deliver to user |
+| No stages (non-SDLC) | Question | Deliver to user |
+| No stages (non-SDLC) | Status | Auto-continue (existing behavior) |
+
+### Auto-Continue Caps
+
+- **Non-SDLC jobs**: `MAX_AUTO_CONTINUES = 3` (classifier is the primary signal; counter prevents runaway loops)
+- **SDLC jobs**: `MAX_AUTO_CONTINUES_SDLC = 10` (stage progress is the real termination signal; counter is a safety net)
+
+Both caps are defined in `agent/job_queue.py`. The effective cap is selected based on `AgentSession.is_sdlc_job()`.
 
 ## Error-Classified Output Bypass (Crash Guard)
 
@@ -105,12 +136,14 @@ Without this guard, an SDK crash would produce output classified as a status upd
 |------|---------|
 | `bridge/summarizer.py` | LLM classifier that produces `ClassificationResult` with optional `coaching_message` |
 | `bridge/coach.py` | Tiered coaching resolution via `build_coaching_message()` |
-| `agent/job_queue.py` | Auto-continue wiring, WorkflowState resolution, duplicate suppression |
+| `agent/job_queue.py` | Auto-continue wiring, stage-aware routing, WorkflowState resolution, duplicate suppression |
+| `models/agent_session.py` | `AgentSession` with `is_sdlc_job()`, `has_remaining_stages()`, `has_failed_stage()` helpers |
 | `agent/sdk_client.py` | Session cleanup on SDK errors (marks sessions as `failed`) |
 | `monitoring/session_watchdog.py` | Stale session detection with unique constraint handling |
 | `tests/test_coach.py` | Coach module tests (skill detection, criteria extraction, coaching tiers) |
 | `tests/test_summarizer.py` | Classifier tests including coaching_message extraction |
 | `tests/test_auto_continue.py` | Auto-continue duplicate suppression tests |
+| `tests/test_stage_aware_auto_continue.py` | Stage-aware decision matrix tests (32 tests) |
 
 ## Tuning Guide
 

--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -161,7 +161,7 @@ class AgentSession(Model):
         """Parse history entries to determine SDLC stage completion status.
 
         Returns:
-            Dict mapping stage name to status: 'completed', 'in_progress', or 'pending'
+            Dict mapping stage name to status: 'completed', 'in_progress', 'failed', or 'pending'
         """
         progress = {stage: "pending" for stage in SDLC_STAGES}
         for entry in self._get_history_list():
@@ -170,11 +170,55 @@ class AgentSession(Model):
             entry_upper = entry.upper()
             for stage in SDLC_STAGES:
                 if stage in entry_upper:
-                    if "COMPLETED" in entry_upper or "☑" in entry:
+                    if "FAILED" in entry_upper or "ERROR" in entry_upper:
+                        progress[stage] = "failed"
+                    elif "COMPLETED" in entry_upper or "☑" in entry:
                         progress[stage] = "completed"
                     elif "IN_PROGRESS" in entry_upper or "▶" in entry:
                         progress[stage] = "in_progress"
         return progress
+
+    # === Stage-aware auto-continue helpers ===
+
+    def is_sdlc_job(self) -> bool:
+        """Check if this session is an SDLC pipeline job.
+
+        Returns True if the session's history contains at least one
+        [stage] entry, indicating it was created by an SDLC skill
+        invocation (e.g., /sdlc, /do-build, /do-test).
+
+        Used by the auto-continue logic to choose between stage-aware
+        routing (for SDLC jobs) and classifier-based routing (for
+        casual/ad-hoc jobs).
+        """
+        for entry in self._get_history_list():
+            if isinstance(entry, str) and "[stage]" in entry.lower():
+                return True
+        return False
+
+    def has_remaining_stages(self) -> bool:
+        """Check if any SDLC stages are not yet completed.
+
+        Returns True if at least one stage in the pipeline is still
+        'pending' or 'in_progress'. Returns False when all stages
+        are 'completed' (or 'failed').
+
+        Used by stage-aware auto-continue to decide whether to keep
+        going (stages remain) or consult the classifier (all done).
+        """
+        progress = self.get_stage_progress()
+        return any(status in ("pending", "in_progress") for status in progress.values())
+
+    def has_failed_stage(self) -> bool:
+        """Check if any SDLC stage has failed.
+
+        Returns True if a [stage] history entry contains FAILED or
+        ERROR for any stage. Failed stages are a hard stop signal --
+        the output should be delivered to the user immediately rather
+        than auto-continued.
+        """
+        progress = self.get_stage_progress()
+        return any(status == "failed" for status in progress.values())
 
     # === Cleanup ===
 

--- a/tests/test_stage_aware_auto_continue.py
+++ b/tests/test_stage_aware_auto_continue.py
@@ -1,0 +1,406 @@
+"""Tests for stage-aware auto-continue logic.
+
+Verifies that SDLC jobs use pipeline stage progress from AgentSession.history
+as the primary auto-continue signal, falling back to the classifier for
+non-SDLC jobs.
+
+Decision matrix:
+  | Pipeline state       | Output classification | Action            |
+  |----------------------|-----------------------|-------------------|
+  | Stages remaining     | (skipped)             | Auto-continue     |
+  | All stages done      | Completion            | Deliver to user   |
+  | All stages done      | Status (no evidence)  | Coach + continue  |
+  | Any stage failed     | Error/blocker         | Deliver to user   |
+  | No stages (non-SDLC) | Question              | Deliver to user   |
+  | No stages (non-SDLC) | Status                | Auto-continue     |
+
+Tests use Redis db=1 via the autouse redis_test_db fixture in conftest.py.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+# Mock the claude_agent_sdk before agent package tries to import it
+if "claude_agent_sdk" not in sys.modules:
+    _mock_sdk = MagicMock()
+    sys.modules["claude_agent_sdk"] = _mock_sdk
+
+from agent.job_queue import MAX_AUTO_CONTINUES, MAX_AUTO_CONTINUES_SDLC
+from models.agent_session import AgentSession
+
+# === AgentSession helper method tests ===
+
+
+class TestIsSDLCJob:
+    """Tests for AgentSession.is_sdlc_job()."""
+
+    def test_no_history_returns_false(self):
+        """Session with no history is not an SDLC job."""
+        session = AgentSession()
+        session.history = None
+        assert session.is_sdlc_job() is False
+
+    def test_empty_history_returns_false(self):
+        """Session with empty history is not an SDLC job."""
+        session = AgentSession()
+        session.history = []
+        assert session.is_sdlc_job() is False
+
+    def test_non_stage_history_returns_false(self):
+        """Session with only non-stage history entries is not SDLC."""
+        session = AgentSession()
+        session.history = [
+            "[user] Hello world",
+            "[system] Processing request",
+        ]
+        assert session.is_sdlc_job() is False
+
+    def test_stage_entry_returns_true(self):
+        """Session with a [stage] entry is an SDLC job."""
+        session = AgentSession()
+        session.history = [
+            "[user] /sdlc 178",
+            "[stage] ISSUE COMPLETED",
+        ]
+        assert session.is_sdlc_job() is True
+
+    def test_case_insensitive_stage_detection(self):
+        """Stage detection is case-insensitive."""
+        session = AgentSession()
+        session.history = ["[Stage] BUILD IN_PROGRESS"]
+        assert session.is_sdlc_job() is True
+
+    def test_mixed_history_with_stage_returns_true(self):
+        """Session with mixed entries including a stage is SDLC."""
+        session = AgentSession()
+        session.history = [
+            "[user] Start the build",
+            "[system] Running tests",
+            "[stage] PLAN COMPLETED",
+            "[summary] Plan phase done",
+        ]
+        assert session.is_sdlc_job() is True
+
+
+class TestHasRemainingStages:
+    """Tests for AgentSession.has_remaining_stages()."""
+
+    def test_no_history_returns_true(self):
+        """With no history, all stages are pending (remaining)."""
+        session = AgentSession()
+        session.history = None
+        assert session.has_remaining_stages() is True
+
+    def test_all_stages_completed(self):
+        """When all stages are completed, no remaining stages."""
+        session = AgentSession()
+        session.history = [
+            "[stage] ISSUE COMPLETED",
+            "[stage] PLAN COMPLETED",
+            "[stage] BUILD COMPLETED",
+            "[stage] TEST COMPLETED",
+            "[stage] REVIEW COMPLETED",
+            "[stage] DOCS COMPLETED",
+        ]
+        assert session.has_remaining_stages() is False
+
+    def test_some_stages_remaining(self):
+        """When some stages are completed, others remain."""
+        session = AgentSession()
+        session.history = [
+            "[stage] ISSUE COMPLETED",
+            "[stage] PLAN COMPLETED",
+            "[stage] BUILD IN_PROGRESS",
+        ]
+        assert session.has_remaining_stages() is True
+
+    def test_in_progress_counts_as_remaining(self):
+        """In-progress stages count as remaining."""
+        session = AgentSession()
+        session.history = [
+            "[stage] ISSUE COMPLETED",
+            "[stage] PLAN COMPLETED",
+            "[stage] BUILD COMPLETED",
+            "[stage] TEST COMPLETED",
+            "[stage] REVIEW COMPLETED",
+            "[stage] DOCS IN_PROGRESS",
+        ]
+        assert session.has_remaining_stages() is True
+
+    def test_failed_stage_not_remaining(self):
+        """Failed stages are NOT remaining (they're terminal)."""
+        session = AgentSession()
+        session.history = [
+            "[stage] ISSUE COMPLETED",
+            "[stage] PLAN COMPLETED",
+            "[stage] BUILD COMPLETED",
+            "[stage] TEST FAILED",
+            "[stage] REVIEW COMPLETED",
+            "[stage] DOCS COMPLETED",
+        ]
+        # TEST is failed, all others completed — no remaining (pending/in_progress)
+        assert session.has_remaining_stages() is False
+
+
+class TestHasFailedStage:
+    """Tests for AgentSession.has_failed_stage()."""
+
+    def test_no_history_returns_false(self):
+        """No history means no failed stages."""
+        session = AgentSession()
+        session.history = None
+        assert session.has_failed_stage() is False
+
+    def test_no_failures_returns_false(self):
+        """Completed stages only — no failures."""
+        session = AgentSession()
+        session.history = [
+            "[stage] ISSUE COMPLETED",
+            "[stage] PLAN COMPLETED",
+        ]
+        assert session.has_failed_stage() is False
+
+    def test_failed_stage_detected(self):
+        """FAILED keyword in stage entry is detected."""
+        session = AgentSession()
+        session.history = [
+            "[stage] ISSUE COMPLETED",
+            "[stage] BUILD FAILED",
+        ]
+        assert session.has_failed_stage() is True
+
+    def test_error_stage_detected(self):
+        """ERROR keyword in stage entry is detected."""
+        session = AgentSession()
+        session.history = [
+            "[stage] TEST ERROR: ModuleNotFoundError",
+        ]
+        assert session.has_failed_stage() is True
+
+    def test_non_stage_error_not_detected(self):
+        """Errors in non-stage entries don't count."""
+        session = AgentSession()
+        session.history = [
+            "[system] Error: something went wrong",
+            "[stage] BUILD COMPLETED",
+        ]
+        assert session.has_failed_stage() is False
+
+
+# === Stage-aware routing decision tests ===
+
+
+class TestStageAwareDecisionMatrix:
+    """Tests verifying the stage-aware auto-continue decision matrix.
+
+    These tests exercise the routing logic by simulating the conditions
+    that send_to_chat checks, verifying the correct action is taken.
+    """
+
+    def test_sdlc_stages_remaining_auto_continues(self):
+        """SDLC job with remaining stages should auto-continue without classifier."""
+        session = AgentSession()
+        session.history = [
+            "[stage] ISSUE COMPLETED",
+            "[stage] PLAN COMPLETED",
+            "[stage] BUILD IN_PROGRESS",
+        ]
+
+        assert session.is_sdlc_job() is True
+        assert session.has_remaining_stages() is True
+        assert session.has_failed_stage() is False
+
+        # Decision: auto-continue (stages remaining, no classifier needed)
+        auto_continue_count = 0
+        effective_max = MAX_AUTO_CONTINUES_SDLC
+
+        should_auto_continue = (
+            session.is_sdlc_job()
+            and session.has_remaining_stages()
+            and not session.has_failed_stage()
+            and auto_continue_count < effective_max
+        )
+        assert should_auto_continue is True
+
+    def test_sdlc_all_stages_done_falls_to_classifier(self):
+        """SDLC job with all stages done should use the classifier."""
+        session = AgentSession()
+        session.history = [
+            "[stage] ISSUE COMPLETED",
+            "[stage] PLAN COMPLETED",
+            "[stage] BUILD COMPLETED",
+            "[stage] TEST COMPLETED",
+            "[stage] REVIEW COMPLETED",
+            "[stage] DOCS COMPLETED",
+        ]
+
+        assert session.is_sdlc_job() is True
+        assert session.has_remaining_stages() is False
+        assert session.has_failed_stage() is False
+
+        # Decision: fall through to classifier (all stages done)
+        should_use_stage_routing = (
+            session.is_sdlc_job()
+            and session.has_remaining_stages()
+            and not session.has_failed_stage()
+        )
+        assert should_use_stage_routing is False
+
+    def test_sdlc_failed_stage_delivers_to_user(self):
+        """SDLC job with a failed stage should deliver immediately."""
+        session = AgentSession()
+        session.history = [
+            "[stage] ISSUE COMPLETED",
+            "[stage] PLAN COMPLETED",
+            "[stage] BUILD FAILED",
+        ]
+
+        assert session.is_sdlc_job() is True
+        assert session.has_failed_stage() is True
+
+        # Decision: deliver to user (failed stage)
+        should_deliver = session.is_sdlc_job() and session.has_failed_stage()
+        assert should_deliver is True
+
+    def test_non_sdlc_uses_classifier(self):
+        """Non-SDLC job should use the classifier-based routing."""
+        session = AgentSession()
+        session.history = [
+            "[user] Tell me about Python",
+            "[system] Processing casual question",
+        ]
+
+        assert session.is_sdlc_job() is False
+
+        # Decision: use classifier (not an SDLC job)
+        effective_max = MAX_AUTO_CONTINUES  # Non-SDLC gets lower cap
+        assert effective_max == 3
+
+    def test_sdlc_safety_cap_prevents_infinite_loop(self):
+        """SDLC auto-continue respects the safety cap even with stages remaining."""
+        session = AgentSession()
+        session.history = [
+            "[stage] ISSUE COMPLETED",
+            "[stage] PLAN IN_PROGRESS",
+        ]
+
+        assert session.is_sdlc_job() is True
+        assert session.has_remaining_stages() is True
+
+        # Simulate having hit the SDLC safety cap
+        auto_continue_count = MAX_AUTO_CONTINUES_SDLC
+        effective_max = MAX_AUTO_CONTINUES_SDLC
+
+        should_auto_continue = (
+            session.is_sdlc_job()
+            and session.has_remaining_stages()
+            and not session.has_failed_stage()
+            and auto_continue_count < effective_max
+        )
+        # Safety cap reached — falls through to classifier
+        assert should_auto_continue is False
+
+
+class TestMaxAutoContiuesConstants:
+    """Tests for the auto-continue constants."""
+
+    def test_max_auto_continues_value(self):
+        """Non-SDLC cap is 3."""
+        assert MAX_AUTO_CONTINUES == 3
+
+    def test_max_auto_continues_sdlc_value(self):
+        """SDLC cap is 10."""
+        assert MAX_AUTO_CONTINUES_SDLC == 10
+
+    def test_sdlc_cap_higher_than_standard(self):
+        """SDLC cap must be higher than the standard cap."""
+        assert MAX_AUTO_CONTINUES_SDLC > MAX_AUTO_CONTINUES
+
+    def test_both_caps_positive(self):
+        """Both caps must be positive integers."""
+        assert isinstance(MAX_AUTO_CONTINUES, int)
+        assert isinstance(MAX_AUTO_CONTINUES_SDLC, int)
+        assert MAX_AUTO_CONTINUES > 0
+        assert MAX_AUTO_CONTINUES_SDLC > 0
+
+
+class TestGetStageProgressWithFailures:
+    """Tests for get_stage_progress() including failure detection."""
+
+    def test_failed_stage_status(self):
+        """Failed stages show as 'failed' in progress dict."""
+        session = AgentSession()
+        session.history = [
+            "[stage] ISSUE COMPLETED",
+            "[stage] BUILD FAILED",
+        ]
+        progress = session.get_stage_progress()
+        assert progress["ISSUE"] == "completed"
+        assert progress["BUILD"] == "failed"
+        assert progress["PLAN"] == "pending"
+
+    def test_error_stage_status(self):
+        """Error stages show as 'failed' in progress dict."""
+        session = AgentSession()
+        session.history = [
+            "[stage] TEST ERROR: test suite crashed",
+        ]
+        progress = session.get_stage_progress()
+        assert progress["TEST"] == "failed"
+
+    def test_mixed_progress(self):
+        """Mix of completed, in_progress, pending, and failed stages."""
+        session = AgentSession()
+        session.history = [
+            "[stage] ISSUE COMPLETED",
+            "[stage] PLAN COMPLETED",
+            "[stage] BUILD COMPLETED",
+            "[stage] TEST FAILED",
+        ]
+        progress = session.get_stage_progress()
+        assert progress["ISSUE"] == "completed"
+        assert progress["PLAN"] == "completed"
+        assert progress["BUILD"] == "completed"
+        assert progress["TEST"] == "failed"
+        assert progress["REVIEW"] == "pending"
+        assert progress["DOCS"] == "pending"
+
+
+class TestStageAwareWithEmoji:
+    """Tests for stage detection using emoji markers (☑ and ▶)."""
+
+    def test_checkmark_emoji_completed(self):
+        """☑ emoji marks stage as completed."""
+        session = AgentSession()
+        session.history = ["[stage] ☑ ISSUE"]
+        assert session.is_sdlc_job() is True
+        progress = session.get_stage_progress()
+        assert progress["ISSUE"] == "completed"
+
+    def test_play_emoji_in_progress(self):
+        """▶ emoji marks stage as in_progress."""
+        session = AgentSession()
+        session.history = ["[stage] ▶ BUILD"]
+        progress = session.get_stage_progress()
+        assert progress["BUILD"] == "in_progress"
+        assert session.has_remaining_stages() is True
+
+
+class TestEffectiveMaxSelection:
+    """Tests verifying the correct max is chosen based on job type."""
+
+    def test_sdlc_job_gets_higher_cap(self):
+        """SDLC jobs should use MAX_AUTO_CONTINUES_SDLC."""
+        session = AgentSession()
+        session.history = ["[stage] ISSUE COMPLETED"]
+        is_sdlc = session.is_sdlc_job()
+        effective_max = MAX_AUTO_CONTINUES_SDLC if is_sdlc else MAX_AUTO_CONTINUES
+        assert effective_max == MAX_AUTO_CONTINUES_SDLC
+
+    def test_non_sdlc_job_gets_standard_cap(self):
+        """Non-SDLC jobs should use MAX_AUTO_CONTINUES."""
+        session = AgentSession()
+        session.history = ["[user] Hello"]
+        is_sdlc = session.is_sdlc_job()
+        effective_max = MAX_AUTO_CONTINUES_SDLC if is_sdlc else MAX_AUTO_CONTINUES
+        assert effective_max == MAX_AUTO_CONTINUES


### PR DESCRIPTION
## Summary

Closes #178

SDLC jobs now use pipeline stage progress from `AgentSession.history` as the primary auto-continue signal instead of relying solely on the LLM output classifier. The classifier is still consulted as a final gate when all stages are complete, and non-SDLC jobs are completely unchanged.

- **Stage-aware routing**: Before calling `classify_output()`, checks if the current job is an SDLC pipeline job with remaining stages. If so, auto-continues without the classifier.
- **Failed stage detection**: If any stage has FAILED/ERROR in history, delivers output to user immediately instead of auto-continuing.
- **Higher safety cap for SDLC jobs**: `MAX_AUTO_CONTINUES_SDLC = 10` (vs standard `MAX_AUTO_CONTINUES = 3`). Stage progress is the natural termination condition; the counter is a safety net.
- **New AgentSession helpers**: `is_sdlc_job()`, `has_remaining_stages()`, `has_failed_stage()`
- **`_enqueue_continuation()` helper**: Extracted shared logic for re-enqueuing continuation jobs with coaching messages.

### Decision Matrix

| Pipeline state | Output classification | Action |
|---|---|---|
| Stages remaining | (skipped) | Auto-continue |
| All stages done | Completion | Deliver to user |
| All stages done | Status (no evidence) | Coach + continue |
| Any stage failed | Error/blocker | Deliver to user |
| No stages (non-SDLC) | Question | Deliver to user |
| No stages (non-SDLC) | Status | Auto-continue (existing behavior) |

## Test plan

- [x] 32 new tests in `test_stage_aware_auto_continue.py` covering all decision matrix paths
- [x] 16 existing `test_auto_continue.py` tests pass without modification
- [x] Ruff lint passes
- [x] Documentation updated (`docs/features/coaching-loop.md`, `docs/features/README.md`)

Generated with [Claude Code](https://claude.com/claude-code)