### PR TITLE
Force AgentSession into SDLC mode at classification time

### DIFF
--- a/agent/job_queue.py
+++ b/agent/job_queue.py
@@ -1102,6 +1102,15 @@ async def _execute_job(job: Job) -> None:
             agent_session.task_list_id = task_list_id
             agent_session.save()
             agent_session.append_history("user", (job.message_text or "")[:200])
+            # Force SDLC mode when classification says so (issue #246).
+            # This guarantees is_sdlc_job() returns True from the start,
+            # even if sub-skills fail to call session_progress.
+            if agent_session.classification_type == "sdlc":
+                agent_session.append_history("stage", "SDLC_MODE activated")
+                logger.info(
+                    f"[{job.project_key}] Forced SDLC mode for session "
+                    f"{job.session_id} (classification=sdlc)"
+                )
     except Exception as e:
         logger.debug(f"AgentSession update failed (non-fatal): {e}")
 

--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -223,14 +223,23 @@ class AgentSession(Model):
     def is_sdlc_job(self) -> bool:
         """Check if this session is an SDLC pipeline job.
 
-        Returns True if the session's history contains at least one
-        [stage] entry, indicating it was created by an SDLC skill
-        invocation (e.g., /sdlc, /do-build, /do-test).
+        Returns True if:
+        1. The session was classified as "sdlc" at input routing time, OR
+        2. The session's history contains at least one [stage] entry
+
+        The classification_type check (added for issue #246) is the primary
+        signal — it's set at classification time and cannot be lost. The
+        history check is the legacy fallback for sessions that have stage
+        entries from session_progress calls.
 
         Used by the auto-continue logic to choose between stage-aware
         routing (for SDLC jobs) and classifier-based routing (for
         casual/ad-hoc jobs).
         """
+        # Primary: classification_type set at input routing time
+        if self.classification_type == "sdlc":
+            return True
+        # Fallback: check for [stage] entries in history
         for entry in self._get_history_list():
             if isinstance(entry, str) and "[stage]" in entry.lower():
                 return True

--- a/tests/test_sdlc_mode.py
+++ b/tests/test_sdlc_mode.py
@@ -1,0 +1,72 @@
+"""Tests for SDLC mode activation (issue #246).
+
+Verifies that sessions classified as 'sdlc' are always detected as SDLC jobs,
+regardless of whether sub-skills call session_progress.
+
+Run with: pytest tests/test_sdlc_mode.py -v -p no:postgresql
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from models.agent_session import AgentSession
+
+
+class TestIsSdlcJobClassificationType:
+    """is_sdlc_job() should return True when classification_type is 'sdlc'."""
+
+    def test_classification_type_sdlc_returns_true(self):
+        """Sessions classified as 'sdlc' should be detected as SDLC jobs."""
+        session = AgentSession(
+            session_id="test_sdlc_246",
+            project_key="test",
+            classification_type="sdlc",
+        )
+        assert session.is_sdlc_job() is True
+
+    def test_classification_type_none_with_no_history_returns_false(self):
+        """Sessions with no classification and no history are not SDLC."""
+        session = AgentSession(
+            session_id="test_chat_246",
+            project_key="test",
+        )
+        assert session.is_sdlc_job() is False
+
+    def test_classification_type_chat_returns_false(self):
+        """Non-SDLC classifications should not be SDLC jobs."""
+        session = AgentSession(
+            session_id="test_chat_246",
+            project_key="test",
+            classification_type="chat",
+        )
+        assert session.is_sdlc_job() is False
+
+    def test_stage_history_still_works(self):
+        """Legacy path: [stage] entries in history should still trigger SDLC."""
+        session = AgentSession(
+            session_id="test_legacy_246",
+            project_key="test",
+            history=["[stage] PLAN in_progress"],
+        )
+        assert session.is_sdlc_job() is True
+
+    def test_classification_takes_priority_over_empty_history(self):
+        """classification_type=sdlc should work even with empty history."""
+        session = AgentSession(
+            session_id="test_priority_246",
+            project_key="test",
+            classification_type="sdlc",
+            history=[],
+        )
+        assert session.is_sdlc_job() is True
+
+    def test_sdlc_mode_activated_entry(self):
+        """The SDLC_MODE activated entry should make is_sdlc_job return True."""
+        session = AgentSession(
+            session_id="test_activated_246",
+            project_key="test",
+            history=["[user] SDLC issue 246", "[stage] SDLC_MODE activated"],
+        )
+        assert session.is_sdlc_job() is True


### PR DESCRIPTION
## Summary
- `is_sdlc_job()` now checks `classification_type == "sdlc"` as primary signal, falling back to `[stage]` history entries
- `_execute_job()` writes `[stage] SDLC_MODE activated` to history when classification is sdlc
- 6 tests passing, lint clean

Fixes #246

## Test plan
- [x] classification_type=sdlc → is_sdlc_job() returns True
- [x] No classification + no history → returns False
- [x] Legacy [stage] history path still works
- [x] SDLC_MODE activated entry detected
- [x] Lint passes