### PR TITLE
Fix do-build skill argument parsing (#263)

### DIFF
--- a/.claude/skills/do-build/SKILL.md
+++ b/.claude/skills/do-build/SKILL.md
@@ -31,9 +31,9 @@ You are the **team lead** executing a plan document. You orchestrate work using 
 
 ## Variables
 
-PLAN_ARG: $1
+PLAN_ARG: $ARGUMENTS
 
-**If PLAN_ARG is empty or literally `$1`**: The skill argument substitution did not run. Look at the user's original message in the conversation — they invoked this as `/do-build <argument>`. Extract whatever follows `/do-build` as the value of PLAN_ARG. Do NOT stop or report an error; just use the argument from the message.
+**If PLAN_ARG is empty or literally `$ARGUMENTS`**: The skill argument substitution did not run. Look at the user's original message in the conversation — they invoked this as `/do-build <argument>`. Extract whatever follows `/do-build` as the value of PLAN_ARG. Do NOT stop or report an error; just use the argument from the message.
 
 ## Plan Resolution
 


### PR DESCRIPTION
## Summary
- Changed `PLAN_ARG: $1` to `PLAN_ARG: $ARGUMENTS` in do-build SKILL.md
- The Claude Code skill system uses `$ARGUMENTS` for argument substitution, not `$1`
- This caused do-build to always report "No PLAN_ARG was provided" regardless of what argument was passed
- Other skills (do-test, do-patch) already use `$ARGUMENTS` correctly

## Test plan
- [x] Verified `$ARGUMENTS` is used consistently (grep confirms no remaining `$1` references)
- [x] Confirmed do-test and do-patch use `$ARGUMENTS` as the pattern
- [ ] Manual test: invoke `/do-build docs/plans/some-plan.md` and verify it loads the plan

Closes #263