### PR TITLE
Fix worktree resume on interrupted sessions

### DIFF
--- a/.claude/skills/do-build/SKILL.md
+++ b/.claude/skills/do-build/SKILL.md
@@ -124,11 +124,11 @@ Where `$PR_URL` is the full GitHub PR URL returned by `gh pr create`.
    ```bash
    TARGET_REPO=$(git -C "$(dirname "$PLAN_PATH")" rev-parse --show-toplevel)
    ```
-6. **Create an isolated worktree** - Create `.worktrees/{slug}/` with branch `session/{slug}` in the **target repo** using the worktree manager (handles stale worktrees automatically):
+6. **Get or create an isolated worktree** - Get the existing worktree or create `.worktrees/{slug}/` with branch `session/{slug}` in the **target repo** using the worktree manager (handles stale worktrees and session resumption automatically):
    ```bash
-   python -c "from agent.worktree_manager import create_worktree; from pathlib import Path; create_worktree(Path('$TARGET_REPO'), '{slug}')"
+   python -c "from agent.worktree_manager import get_or_create_worktree; from pathlib import Path; print(get_or_create_worktree(Path('$TARGET_REPO'), '{slug}'))"
    ```
-   This handles all edge cases: stale worktrees from crashed sessions, missing directories with lingering git references, and branch-already-in-use errors. Settings files are copied automatically.
+   This is idempotent: if the worktree already exists (e.g., from an interrupted session), it returns the existing path. If not, it creates a fresh one. It also handles stale worktrees from crashed sessions, missing directories with lingering git references, and branch-already-in-use errors. Settings files are copied automatically.
    All subsequent agent work happens inside `$TARGET_REPO/.worktrees/{slug}/`, NOT the orchestrator repo directory.
 7. **Initialize pipeline state** - For fresh builds (no prior state), initialize now:
    ```bash
@@ -223,6 +223,8 @@ Task({
 IMPORTANT: You MUST work in the worktree directory: {absolute_path_to}/.worktrees/{slug}/
 Run \`cd {absolute_path_to}/.worktrees/{slug}/\` before doing any work.
 All file reads, writes, and commands should use this worktree path, not the main repo.
+
+NEVER use \`git checkout\` or \`git checkout -b\` on session/ branches. The worktree IS the checkout — just \`cd\` into it. Running \`git checkout session/{slug}\` will fail with a fatal error because the branch is locked by the worktree.
 
 Plan context: [relevant plan sections]
 

--- a/.claude/skills/do-build/WORKFLOW.md
+++ b/.claude/skills/do-build/WORKFLOW.md
@@ -41,6 +41,8 @@ Run \`cd {TARGET_REPO}/.worktrees/{slug}/\` before doing any work.
 All file reads, writes, and commands should use this worktree path, not the main repo.
 Note: {TARGET_REPO} is the target repository root (which may differ from the orchestrator repo for cross-repo builds).
 
+NEVER use \`git checkout\` or \`git checkout -b\` on session/ branches. The worktree IS the checkout — just \`cd\` into it. Running \`git checkout session/{slug}\` will fail with a fatal error because the branch is locked by the worktree.
+
 Plan context: [relevant plan sections]
 
 Your assignment:

--- a/agent/worktree_manager.py
+++ b/agent/worktree_manager.py
@@ -267,6 +267,39 @@ def create_worktree(repo_root: Path, slug: str, base_branch: str = "main") -> Pa
     return worktree_dir
 
 
+def get_or_create_worktree(repo_root: Path, slug: str, base_branch: str = "main") -> Path:
+    """Return an existing worktree path or create a new one.
+
+    This is the preferred entry point for the ``/do-build`` skill and any
+    code that needs a worktree for a given slug.  It is intentionally
+    idempotent: calling it when a worktree already exists is a no-op that
+    returns the existing path, and calling it when no worktree exists
+    creates one from scratch.
+
+    This function exists to make the "give me a worktree, I don't care if
+    it already exists" pattern explicit and self-documenting.  Under the
+    hood it delegates entirely to :func:`create_worktree`, which already
+    handles the resume-existing case (returns early when the directory is
+    present) as well as stale-worktree cleanup.
+
+    Args:
+        repo_root: Path to the main repository.
+        slug: Work item slug (used for directory name and branch).
+        base_branch: Branch to base a *new* worktree on (ignored when
+            the worktree already exists).
+
+    Returns:
+        Absolute path to the worktree directory
+        (``repo_root / .worktrees / slug``).
+
+    Raises:
+        ValueError: If the slug is invalid.
+        subprocess.CalledProcessError: If worktree creation fails after
+            recovery attempts.
+    """
+    return create_worktree(repo_root, slug, base_branch)
+
+
 def remove_worktree(repo_root: Path, slug: str, delete_branch: bool = True) -> bool:
     """Remove a git worktree and optionally its branch.
 

--- a/docs/features/session-isolation.md
+++ b/docs/features/session-isolation.md
@@ -46,8 +46,9 @@ Each tier 2 work item gets its own git worktree for filesystem isolation:
 - `settings.local.json` is copied into the worktree's `.claude/` directory (since it's not tracked by git)
 - On completion: changes are merged back, worktree is removed
 - Stale worktree references are automatically detected and cleaned up by `create_worktree()`
+- `get_or_create_worktree()` is the preferred idempotent entry point: it returns an existing worktree path or creates a new one, making session resumption seamless
 
-The worktree manager provides five operations: `create_worktree()`, `remove_worktree()`, `list_worktrees()`, `prune_worktrees()`, and `cleanup_after_merge()`.
+The worktree manager provides six operations: `get_or_create_worktree()`, `create_worktree()`, `remove_worktree()`, `list_worktrees()`, `prune_worktrees()`, and `cleanup_after_merge()`.
 
 ### Stale Worktree Recovery
 

--- a/tests/unit/test_worktree_manager.py
+++ b/tests/unit/test_worktree_manager.py
@@ -11,6 +11,7 @@ from agent.worktree_manager import (
     _validate_slug,
     cleanup_after_merge,
     create_worktree,
+    get_or_create_worktree,
 )
 
 
@@ -387,3 +388,76 @@ class TestCreateWorktreeStaleRecovery:
         # Should NOT have called find or run -- early return
         mock_find_wt.assert_not_called()
         mock_run.assert_not_called()
+
+
+class TestGetOrCreateWorktree:
+    """Tests for get_or_create_worktree — idempotent worktree access."""
+
+    @patch("agent.worktree_manager.subprocess.run")
+    @patch("agent.worktree_manager._find_worktree_for_branch")
+    @patch("agent.worktree_manager._branch_exists")
+    def test_creates_new_worktree_when_none_exists(
+        self, mock_branch_exists, mock_find_wt, mock_run
+    ):
+        """Creates a fresh worktree when no existing one is found."""
+        repo = Path("/fake/repo")
+        slug = "new-feature"
+        mock_find_wt.return_value = None
+        mock_branch_exists.return_value = False
+        mock_run.return_value = MagicMock(returncode=0)
+
+        with (
+            patch.object(Path, "exists", return_value=False),
+            patch.object(Path, "mkdir"),
+        ):
+            result = get_or_create_worktree(repo, slug)
+
+        assert result == repo / ".worktrees" / slug
+        assert mock_run.called
+
+    @patch("agent.worktree_manager.shutil.copy2")
+    @patch("agent.worktree_manager.subprocess.run")
+    @patch("agent.worktree_manager._find_worktree_for_branch")
+    @patch("agent.worktree_manager._branch_exists")
+    def test_returns_existing_worktree_without_error(
+        self, mock_branch_exists, mock_find_wt, mock_run, mock_copy
+    ):
+        """Returns existing worktree path when directory already exists (no-op)."""
+        repo = Path("/fake/repo")
+        slug = "existing-feature"
+
+        with patch.object(Path, "exists", return_value=True):
+            result = get_or_create_worktree(repo, slug)
+
+        assert result == repo / ".worktrees" / slug
+        # Should NOT have tried to create anything -- early return in create_worktree
+        mock_find_wt.assert_not_called()
+        mock_run.assert_not_called()
+
+    def test_invalid_slug_raises(self):
+        """Invalid slugs are rejected."""
+        repo = Path("/fake/repo")
+        with pytest.raises(ValueError, match="Invalid slug"):
+            get_or_create_worktree(repo, "../bad")
+
+    @patch("agent.worktree_manager.subprocess.run")
+    @patch("agent.worktree_manager._find_worktree_for_branch")
+    @patch("agent.worktree_manager._branch_exists")
+    def test_passes_base_branch_to_create(self, mock_branch_exists, mock_find_wt, mock_run):
+        """Custom base_branch is forwarded to create_worktree."""
+        repo = Path("/fake/repo")
+        slug = "custom-base"
+        mock_find_wt.return_value = None
+        mock_branch_exists.return_value = False
+        mock_run.return_value = MagicMock(returncode=0)
+
+        with (
+            patch.object(Path, "exists", return_value=False),
+            patch.object(Path, "mkdir"),
+        ):
+            result = get_or_create_worktree(repo, slug, base_branch="develop")
+
+        assert result == repo / ".worktrees" / slug
+        # Verify the git command used "develop" as base branch
+        cmd = mock_run.call_args[0][0]
+        assert "develop" in cmd


### PR DESCRIPTION
## Summary
- Add `get_or_create_worktree()` as the idempotent entry point for worktree access, making session resumption explicit and self-documenting
- Harden `/do-build` agent deployment prompts with explicit warnings against using `git checkout` on session branches
- Update session-isolation docs to document the new function

## Changes
- `agent/worktree_manager.py`: Add `get_or_create_worktree()` function (thin wrapper around `create_worktree()`)
- `.claude/skills/do-build/SKILL.md`: Use `get_or_create_worktree` in step 6, add checkout warning to agent prompt
- `.claude/skills/do-build/WORKFLOW.md`: Add checkout warning to agent prompt template
- `docs/features/session-isolation.md`: Document `get_or_create_worktree()` in worktree operations list
- `tests/unit/test_worktree_manager.py`: Add 4 unit tests for create-new, resume-existing, invalid slug, and custom base branch

## Testing
- [x] All 28 unit tests passing (including 4 new ones)
- [x] Ruff format and lint passing
- [x] Import verification passing

## Definition of Done
- [x] Built: Code implemented and working
- [x] Tested: All tests passing
- [x] Documented: session-isolation.md updated
- [x] Quality: Lint and format checks pass

Closes #267