### PR TITLE
Fix ruff not in PATH inside git worktrees

### DIFF
--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -7,7 +7,7 @@ hooks:
     - matcher: "Write|Edit"
       hooks:
         - type: command
-          command: "ruff check --fix $CLAUDE_PROJECT_DIR || true"
+          command: "python -m ruff check --fix $CLAUDE_PROJECT_DIR || true"
         - type: command
           command: "black $CLAUDE_PROJECT_DIR || true"
 ---
@@ -93,7 +93,7 @@ Write the smallest amount of code that makes the failing test pass. Nothing more
 ```bash
 # Run again to confirm the test passes
 pytest tests/ -v -x                 # Should see GREEN (pass)
-ruff check .                        # Linting
+python -m ruff check .              # Linting
 black --check .                     # Formatting
 ```
 
@@ -108,7 +108,7 @@ With all tests green, improve the design of both implementation and tests.
 ```bash
 # Confirm everything still passes after refactoring
 pytest tests/ -v                    # All tests still GREEN
-ruff check .                        # Linting
+python -m ruff check .              # Linting
 black --check .                     # Formatting
 mypy . --ignore-missing-imports     # Type checking (if applicable)
 ```

--- a/.claude/agents/validator.md
+++ b/.claude/agents/validator.md
@@ -27,7 +27,7 @@ You are a read-only validation agent responsible for verifying that ONE task was
 For code changes:
 - [ ] Code compiles/runs without errors
 - [ ] Tests pass (if applicable)
-- [ ] Linting passes (`ruff check`)
+- [ ] Linting passes (`python -m ruff check`)
 - [ ] Formatting is correct (`black --check`)
 - [ ] Type hints present where appropriate
 
@@ -51,7 +51,7 @@ Do NOT trust the builder's self-reported output. You MUST verify independently:
 | Builder Claim | Your Verification |
 |---|---|
 | "Tests pass" | Run `pytest tests/ -v` — confirm 0 failures |
-| "Linting clean" | Run `ruff check .` — confirm 0 errors |
+| "Linting clean" | Run `python -m ruff check .` — confirm 0 errors |
 | "Formatting clean" | Run `black --check .` — confirm no reformats needed |
 | "File created at X" | Use Read tool on path X — confirm file exists and has expected content |
 | "Committed abc1234" | Run `git log --oneline -1` — confirm commit hash matches |

--- a/.claude/hooks/post_tool_use.py
+++ b/.claude/hooks/post_tool_use.py
@@ -212,9 +212,9 @@ def update_sdlc_state_for_bash(hook_input: dict) -> None:
     # Map regex patterns to quality command keys (order matters: check
     # "ruff format" before bare "ruff" to avoid premature match).
     quality_patterns = [
-        (r"(?:^|&&|\|\||;|\s)ruff\s+format\b", "ruff-format"),
+        (r"(?:^|&&|\|\||;|\s)(?:python\s+-m\s+)?ruff\s+format\b", "ruff-format"),
         (r"(?:^|&&|\|\||;|\s)pytest\b", "pytest"),
-        (r"(?:^|&&|\|\||;|\s)ruff\b", "ruff"),
+        (r"(?:^|&&|\|\||;|\s)(?:python\s+-m\s+)?ruff\b", "ruff"),
     ]
     matched_command = None
     for pattern, key in quality_patterns:

--- a/.claude/hooks/sdlc/sdlc_reminder.py
+++ b/.claude/hooks/sdlc/sdlc_reminder.py
@@ -34,7 +34,7 @@ CODE_EXTENSIONS = {".py", ".js", ".ts"}
 # The advisory message emitted once per session
 SDLC_REMINDER_MESSAGE = (
     "SDLC: Remember to run tests and linting before completing this task "
-    "(pytest tests/ && ruff check . && ruff format --check .)"
+    "(pytest tests/ && python -m ruff check . && python -m ruff format --check .)"
 )
 
 

--- a/.claude/hooks/sdlc/validate_sdlc_on_stop.py
+++ b/.claude/hooks/sdlc/validate_sdlc_on_stop.py
@@ -75,8 +75,8 @@ def has_code_changes() -> bool:
 # Quality gate detection
 QUALITY_RUN_HINTS = {
     "pytest": "pytest tests/",
-    "ruff": "ruff check .",
-    "ruff-format": "ruff format --check .",
+    "ruff": "python -m ruff check .",
+    "ruff-format": "python -m ruff format --check .",
 }
 
 ERROR_TEMPLATE = """\

--- a/.claude/hooks/sdlc_reminder.py
+++ b/.claude/hooks/sdlc_reminder.py
@@ -23,7 +23,7 @@ CODE_EXTENSIONS = {".py", ".js", ".ts"}
 # The advisory message emitted once per session
 SDLC_REMINDER_MESSAGE = (
     "SDLC: Remember to run tests and linting before completing this task "
-    "(pytest tests/ && ruff check . && ruff format --check .)"
+    "(pytest tests/ && python -m ruff check . && python -m ruff format --check .)"
 )
 
 

--- a/.claude/hooks/validators/validate_sdlc_on_stop.py
+++ b/.claude/hooks/validators/validate_sdlc_on_stop.py
@@ -39,8 +39,8 @@ def get_sdlc_state_path(session_id: str) -> Path:
 
 _QUALITY_RUN_HINTS = {
     "pytest": "pytest tests/",
-    "ruff": "ruff check .",
-    "ruff-format": "ruff format --check .",
+    "ruff": "python -m ruff check .",
+    "ruff-format": "python -m ruff format --check .",
 }
 
 _ERROR_TEMPLATE = """\

--- a/.claude/skills/do-patch/SKILL.md
+++ b/.claude/skills/do-patch/SKILL.md
@@ -123,7 +123,7 @@ After the builder agent reports completion, run tests and lint directly — do N
 pytest tests/ -v --tb=short
 
 # Run lint checks
-ruff check .
+python -m ruff check .
 black --check .
 ```
 

--- a/.claude/skills/do-test/PYTHON.md
+++ b/.claude/skills/do-test/PYTHON.md
@@ -19,7 +19,7 @@ Loaded when the project uses Python (pytest, pyproject.toml, setup.py, etc.).
 ### Lint Tools
 
 ```bash
-ruff check .
+python -m ruff check .
 black --check .
 ```
 

--- a/.claude/skills/do-test/SKILL.md
+++ b/.claude/skills/do-test/SKILL.md
@@ -133,7 +133,7 @@ pytest tests/unit/test_foo.py tests/tools/test_bar.py -v --tb=short
 
 If lint is enabled, run lint sequentially after tests:
 ```bash
-ruff check .
+python -m ruff check .
 black --check .
 ```
 
@@ -207,7 +207,7 @@ Task({
   prompt: "Run lint checks in [CWD]:
 
     cd [CWD]
-    ruff check .
+    python -m ruff check .
     black --check .
 
     Report: pass/fail for each tool, and any issues found.",
@@ -231,7 +231,7 @@ Monitor all background tasks. Set a **2-minute timeout** from dispatch.
 4. Use the direct execution output for Result Aggregation
 5. Run lint directly too if lint agents also timed out:
    ```bash
-   ruff check .
+   python -m ruff check .
    black --check .
    ```
 

--- a/.claude/skills/new-valor-skill/SKILL.md
+++ b/.claude/skills/new-valor-skill/SKILL.md
@@ -140,7 +140,7 @@ Add to the appropriate tools section:
 ```bash
 pytest tools/<tool_name>/tests/ -v
 black tools/<tool_name>/
-ruff check tools/<tool_name>/
+python -m ruff check tools/<tool_name>/
 git add tools/<tool_name>/ pyproject.toml CLAUDE.md
 git commit -m "Add valor-<name> tool for <purpose>"
 git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Guidance for Claude Code when working with this repository.
 | `./scripts/valor-service.sh restart` | Restart after code changes |
 | `tail -f logs/bridge.log` | Stream bridge logs |
 | `pytest tests/` | Run all tests |
-| `ruff format . && ruff check .` | Format and lint |
+| `python -m ruff format . && python -m ruff check .` | Format and lint |
 | `python scripts/reflections.py` | Run reflections maintenance manually |
 | `python scripts/reflections.py --dry-run` | Test reflections without side effects |
 | `python scripts/reflections.py --ignore "pattern"` | Silence a bug pattern for 14 days |
@@ -128,7 +128,7 @@ Telegram → Python Bridge (Telethon) → Claude Agent SDK → Claude API
 
 Work is DONE when:
 1. ✅ Deliverable exists and works
-2. ✅ Code quality standards met (`ruff check`, `ruff format`)
+2. ✅ Code quality standards met (`python -m ruff check`, `python -m ruff format`)
 3. ✅ Changes committed and pushed to git
 4. ✅ Original request fulfilled
 

--- a/tests/unit/test_post_tool_use_sdlc.py
+++ b/tests/unit/test_post_tool_use_sdlc.py
@@ -262,6 +262,9 @@ class TestUpdateSdlcStateForBash:
             ("ruff check .", "ruff"),
             ("ruff format --check .", "ruff-format"),
             ("ruff format .", "ruff-format"),
+            ("python -m ruff check .", "ruff"),
+            ("python -m ruff format --check .", "ruff-format"),
+            ("python -m ruff format .", "ruff-format"),
         ],
     )
     def test_quality_command_updates_state(

--- a/tests/unit/test_validate_sdlc_on_stop.py
+++ b/tests/unit/test_validate_sdlc_on_stop.py
@@ -161,7 +161,7 @@ class TestCheckSdlcQualityGate:
         result = mod.check_sdlc_quality_gate("session-hints")
         assert result is not None
         assert "pytest tests/" in result
-        assert "ruff check ." in result
+        assert "python -m ruff check ." in result
 
     def test_error_message_mentions_skip_sdlc(self, patch_sessions_dir):
         """Error message should mention SKIP_SDLC escape hatch."""


### PR DESCRIPTION
## Summary
- Replace all bare `ruff` invocations with `python -m ruff` across hooks, skills, agents, and tests
- Update detection regex in `post_tool_use.py` to match both `ruff` and `python -m ruff` patterns (backward compatible)
- Update quality gate hints, SDLC reminder messages, and agent hook commands

## Changes
- **Hooks**: `post_tool_use.py` detection patterns, `sdlc_reminder.py` (both project and user-level), `validate_sdlc_on_stop.py` (both project and user-level)
- **Agents**: `builder.md` PostToolUse hook command and inline examples, `validator.md` instructions
- **Skills**: `do-test`, `do-patch`, `new-valor-skill` skill instructions
- **Config**: `CLAUDE.md` quick commands table
- **Tests**: Added `python -m ruff` pattern test cases, updated hint message assertions

## Testing
- [x] 92 unit tests passing (test_post_tool_use_sdlc, test_validate_sdlc_on_stop, test_sdlc_reminder)
- [x] New test cases verify `python -m ruff check .`, `python -m ruff format --check .`, `python -m ruff format .` are detected
- [x] Backward compatible: bare `ruff` patterns still detected
- [x] `python -m ruff format --check .` passes

## Definition of Done
- [x] Built: All invocations updated
- [x] Tested: All 92 tests passing
- [x] Quality: Lint and format checks pass (pre-existing lint issue in test_reflections.py unrelated)

Closes #266