### PR TITLE
Remove dead SDLC stage-tracking code from hook files

### DIFF
--- a/.claude/hooks/post_tool_use.py
+++ b/.claude/hooks/post_tool_use.py
@@ -34,18 +34,6 @@ CODE_EXTENSIONS = {".py", ".js", ".ts"}
 # Quality commands to track in the SDLC state
 QUALITY_COMMANDS = ("pytest", "ruff", "ruff-format")
 
-# Map SDLC skill names to their pipeline stage
-SKILL_TO_STAGE = {
-    "sdlc": "ISSUE",
-    "do-plan": "PLAN",
-    "do-build": "BUILD",
-    "do-test": "TEST",
-    "do-pr-review": "REVIEW",
-    "do-patch": None,  # Patch doesn't have its own stage
-    "do-docs": "DOCS",
-    "do-docs-audit": None,
-}
-
 
 def is_code_file(file_path: str) -> bool:
     """Return True if the file path has a code extension (.py, .js, .ts)."""
@@ -251,17 +239,6 @@ def update_sdlc_state_for_bash(hook_input: dict) -> None:
         )
 
 
-def update_stage_progress_for_skill(hook_input: dict) -> None:
-    """No-op: stage progress is now handled by the Observer Agent's stage detector.
-
-    The deterministic stage detector in bridge/stage_detector.py parses
-    worker transcripts for /do-* skill invocations and updates AgentSession
-    stages directly. This hook previously called tools/session_progress.py
-    which was deleted as part of the Observer Agent work (issue #309).
-    """
-    pass
-
-
 def check_file_reminders(hook_input: dict) -> None:
     """Print reminders when specific files are modified."""
     tool_name = hook_input.get("tool_name", "")
@@ -287,7 +264,6 @@ def main():
     # Update SDLC session state based on tool type
     update_sdlc_state_for_file_write(hook_input)
     update_sdlc_state_for_bash(hook_input)
-    update_stage_progress_for_skill(hook_input)
 
     session_id = get_session_id(hook_input)
     session_dir = ensure_session_log_dir(session_id)

--- a/.claude/hooks/pre_tool_use.py
+++ b/.claude/hooks/pre_tool_use.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Hook: PreToolUse - Log before tool execution and mark SDLC stages in_progress."""
+"""Hook: PreToolUse - Log before tool execution."""
 
 import subprocess
 import sys
@@ -16,29 +16,6 @@ from utils.constants import (
     get_session_id,
     read_hook_input,
 )
-
-# Map SDLC skill names to their pipeline stage
-SKILL_TO_STAGE = {
-    "sdlc": "ISSUE",
-    "do-plan": "PLAN",
-    "do-build": "BUILD",
-    "do-test": "TEST",
-    "do-pr-review": "REVIEW",
-    "do-patch": None,
-    "do-docs": "DOCS",
-    "do-docs-audit": None,
-}
-
-
-def mark_stage_in_progress(hook_input: dict) -> None:
-    """No-op: stage progress is now handled by the Observer Agent's stage detector.
-
-    The deterministic stage detector in bridge/stage_detector.py parses
-    worker transcripts for /do-* skill invocations and updates AgentSession
-    stages directly. This hook previously called tools/session_progress.py
-    which was deleted as part of the Observer Agent work (issue #309).
-    """
-    pass
 
 
 def capture_git_baseline_once(hook_input: dict) -> None:
@@ -85,9 +62,6 @@ def main():
 
     # Capture git baseline on first tool call (for stop hook comparison)
     capture_git_baseline_once(hook_input)
-
-    # Mark SDLC stages in_progress when skills start
-    mark_stage_in_progress(hook_input)
 
     session_id = get_session_id(hook_input)
     session_dir = ensure_session_log_dir(session_id)


### PR DESCRIPTION
## Summary

Removes dead code left behind after the Observer Agent migration (PR #321). The `SKILL_TO_STAGE` dicts, `mark_stage_in_progress()`, and `update_stage_progress_for_skill()` were converted to no-ops during the migration but their shells, call sites, and constants were left in place to reduce diff churn.

**Closes #325**

### Changes
- **`.claude/hooks/pre_tool_use.py`**: Removed `SKILL_TO_STAGE` dict, `mark_stage_in_progress()` no-op, and its call from `main()`. Updated module docstring.
- **`.claude/hooks/post_tool_use.py`**: Removed `SKILL_TO_STAGE` dict, `update_stage_progress_for_skill()` no-op, and its call from `main()`. Updated module docstring.

### Verification
- `grep -r "SKILL_TO_STAGE\|mark_stage_in_progress\|update_stage_progress_for_skill" .claude/hooks/` returns nothing
- `ruff check` and `ruff format` clean
- 277 tests pass (1 skip due to pre-existing test isolation issue #322)

## Test plan
- [x] No references to removed symbols remain in hooks
- [x] Ruff lint and format clean
- [x] All non-E2E tests pass in isolation
- [x] No functional behavior changes (removed code was already no-ops)