### PR TITLE
Add context fidelity modes for sub-agent steering

### DIFF
--- a/agent/context_modes.py
+++ b/agent/context_modes.py
@@ -1,0 +1,201 @@
+"""Context fidelity modes for sub-agent steering.
+
+Defines four context compression modes (full, compact, minimal, steering)
+and builder functions that produce right-sized context strings for each
+SDLC sub-skill. Skills declare their fidelity requirement via the
+SKILL_FIDELITY registry; the dispatcher calls get_context_for_skill()
+to build the appropriate context before invoking a sub-agent.
+
+See: https://github.com/tomcounsell/ai/issues/329
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+class ContextFidelity(enum.Enum):
+    """Context compression level for sub-agent dispatch.
+
+    Each mode controls how much prior session state is forwarded
+    to a sub-agent when the SDLC dispatcher invokes a skill.
+    """
+
+    FULL = "full"
+    COMPACT = "compact"
+    MINIMAL = "minimal"
+    STEERING = "steering"
+
+
+@dataclass
+class ContextRequest:
+    """Input data for context builders.
+
+    All fields are optional — builders gracefully degrade when fields
+    are absent, producing shorter (or empty) output.
+
+    Attributes:
+        plan_path: Path to the plan document (relative to repo root).
+        task_description: Specific task text for minimal mode.
+        current_stage: Current SDLC stage name (e.g. "BUILD").
+        completed_stages: List of previously completed stage names.
+        artifacts: Key outputs from prior stages (branch, PR URL, etc.).
+        recent_messages: Last N human messages for steering context.
+        session_transcript: Full session transcript for full mode.
+    """
+
+    plan_path: str | None = None
+    task_description: str | None = None
+    current_stage: str | None = None
+    completed_stages: list[str] | None = None
+    artifacts: dict[str, str] | None = None
+    recent_messages: list[str] | None = None
+    session_transcript: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Builder functions
+# ---------------------------------------------------------------------------
+
+
+def build_full_context(request: ContextRequest) -> str:
+    """Build full context — complete session transcript.
+
+    Use case: resuming within the same skill after interruption.
+    Returns the full transcript with a header, or empty string if
+    no transcript is available.
+    """
+    if not request.session_transcript:
+        return ""
+
+    return f"## Full Session Context\n\n{request.session_transcript}"
+
+
+def build_compact_context(request: ContextRequest) -> str:
+    """Build compact context — structured summary for stage handoffs.
+
+    Use case: passing context between SDLC stages (e.g. BUILD -> TEST).
+    Includes plan reference, completed stages, artifacts, and current stage.
+    Approximate target: ~800 tokens.
+    """
+    parts: list[str] = ["## Pipeline Context"]
+
+    if request.current_stage:
+        parts.append(f"\nCurrent stage: {request.current_stage}")
+
+    if request.completed_stages:
+        stages_str = ", ".join(request.completed_stages)
+        parts.append(f"Completed stages: {stages_str}")
+
+    if request.plan_path:
+        parts.append(f"Plan: {request.plan_path}")
+
+    if request.artifacts:
+        parts.append("\nArtifacts:")
+        for key, value in request.artifacts.items():
+            parts.append(f"  - {key}: {value}")
+
+    return "\n".join(parts)
+
+
+def build_minimal_context(request: ContextRequest) -> str:
+    """Build minimal context — just the task and essential references.
+
+    Use case: individual builder sub-agents that only need their
+    specific task description. Returns empty string if no task is provided.
+    Approximate target: ~200 tokens.
+    """
+    if not request.task_description:
+        return ""
+
+    parts: list[str] = [f"## Task\n\n{request.task_description}"]
+
+    if request.artifacts:
+        parts.append("\nReferences:")
+        for key, value in request.artifacts.items():
+            parts.append(f"  - {key}: {value}")
+
+    return "\n".join(parts)
+
+
+def build_steering_context(request: ContextRequest) -> str:
+    """Build steering context — minimal state for observer coaching.
+
+    Use case: observer/coaching messages that need to know what stage
+    the pipeline is in, what is done, and any recent human messages.
+    Approximate target: ~300 tokens.
+    """
+    parts: list[str] = ["## Steering Context"]
+
+    if request.current_stage:
+        parts.append(f"\nActive stage: {request.current_stage}")
+
+    if request.completed_stages:
+        parts.append(f"Done: {', '.join(request.completed_stages)}")
+
+    if request.recent_messages:
+        parts.append("\nRecent human messages:")
+        for msg in request.recent_messages:
+            parts.append(f"  > {msg}")
+
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Skill fidelity registry
+# ---------------------------------------------------------------------------
+
+SKILL_FIDELITY: dict[str, ContextFidelity] = {
+    "do-plan": ContextFidelity.COMPACT,
+    "do-build": ContextFidelity.COMPACT,
+    "do-test": ContextFidelity.COMPACT,
+    "do-patch": ContextFidelity.COMPACT,
+    "do-pr-review": ContextFidelity.COMPACT,
+    "do-docs": ContextFidelity.COMPACT,
+    "builder": ContextFidelity.MINIMAL,
+}
+
+# Maps fidelity enum values to their builder functions.
+_FIDELITY_BUILDERS = {
+    ContextFidelity.FULL: build_full_context,
+    ContextFidelity.COMPACT: build_compact_context,
+    ContextFidelity.MINIMAL: build_minimal_context,
+    ContextFidelity.STEERING: build_steering_context,
+}
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+def get_context_for_skill(
+    skill_name: str,
+    request: ContextRequest,
+) -> str:
+    """Build context string for a skill based on its declared fidelity.
+
+    Looks up the skill's fidelity requirement in SKILL_FIDELITY (defaults
+    to COMPACT for unknown skills) and calls the corresponding builder.
+
+    Args:
+        skill_name: Name of the skill (e.g. "do-build", "builder").
+        request: ContextRequest populated with available session state.
+
+    Returns:
+        Formatted context string sized to the skill's fidelity level.
+    """
+    fidelity = SKILL_FIDELITY.get(skill_name, ContextFidelity.COMPACT)
+    builder = _FIDELITY_BUILDERS[fidelity]
+    result = builder(request)
+    logger.debug(
+        "Built %s context for skill %r: %d chars",
+        fidelity.value,
+        skill_name,
+        len(result),
+    )
+    return result

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -18,6 +18,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [Coaching Loop](coaching-loop.md) | Merged classifier-coach with LLM-generated coaching, tiered fallback, error crash guard, open question gate, and stage-aware auto-continue for SDLC jobs | Shipped |
 | [Code Impact Finder](code-impact-finder.md) | Semantic search for blast radius analysis during /do-plan | Shipped |
 | [Completion Tracking](completion-tracking.md) | Branch-based work tracking and completion token system | Archived |
+| [Context Fidelity Modes](context-fidelity-modes.md) | Right-sized context compression (full/compact/minimal/steering) for sub-agent dispatch | Shipped |
 | [Correlation IDs](correlation-ids.md) | End-to-end request tracing with shared correlation_id from Telegram receipt to response delivery | Shipped |
 | [Deep Plan Analysis](deep-plan-analysis.md) | Prior Art, Data Flow, Failure Analysis, and Architectural Impact investigation sections in /do-plan | Shipped |
 | [Design Review](do-design-review.md) | Review web UI against 10 premium design criteria with severity ratings | Shipped |

--- a/docs/features/context-fidelity-modes.md
+++ b/docs/features/context-fidelity-modes.md
@@ -1,0 +1,61 @@
+# Context Fidelity Modes
+
+**Module:** `agent/context_modes.py`
+**Issue:** [#329](https://github.com/tomcounsell/ai/issues/329)
+
+## Overview
+
+Context fidelity modes control how much session state is forwarded to sub-agents when the SDLC dispatcher invokes a skill. Instead of passing the full conversation transcript (wasteful) or a one-line summary (lossy), each skill declares the compression level it needs.
+
+## Modes
+
+| Mode | Enum Value | Use Case | Content |
+|------|-----------|----------|---------|
+| **Full** | `ContextFidelity.FULL` | Resume within same skill | Complete session transcript |
+| **Compact** | `ContextFidelity.COMPACT` | Stage handoffs (BUILD -> TEST) | Plan path, completed stages, artifacts |
+| **Minimal** | `ContextFidelity.MINIMAL` | Individual builder sub-agents | Task description + essential refs |
+| **Steering** | `ContextFidelity.STEERING` | Observer coaching messages | Current stage, done stages, recent human messages |
+
+## Skill Registry
+
+Each skill declares its fidelity via `SKILL_FIDELITY` in `agent/context_modes.py`:
+
+```python
+from agent.context_modes import SKILL_FIDELITY, ContextFidelity
+
+SKILL_FIDELITY = {
+    "do-plan": ContextFidelity.COMPACT,
+    "do-build": ContextFidelity.COMPACT,
+    "do-test": ContextFidelity.COMPACT,
+    "do-patch": ContextFidelity.COMPACT,
+    "do-pr-review": ContextFidelity.COMPACT,
+    "do-docs": ContextFidelity.COMPACT,
+    "builder": ContextFidelity.MINIMAL,
+}
+```
+
+Unknown skills default to `COMPACT`.
+
+## Usage
+
+```python
+from agent.context_modes import ContextRequest, get_context_for_skill
+
+# Build a context request from available session state
+request = ContextRequest(
+    plan_path="docs/plans/my-feature.md",
+    current_stage="TEST",
+    completed_stages=["ISSUE", "PLAN", "BUILD"],
+    artifacts={"branch": "session/my-feature", "pr_url": "https://..."},
+)
+
+# Dispatch builds context sized to the skill's declared fidelity
+context = get_context_for_skill("do-test", request)
+```
+
+## Design Decisions
+
+- **No token budget enforcement** -- approximate sizes are guidelines, not hard limits. The model handles truncation naturally.
+- **No graph DSL** -- we use a linear pipeline, not a graph. The registry is a simple dict.
+- **Plain dicts for artifacts** -- when SkillOutcome (#328) ships, artifacts can be replaced with typed objects.
+- **Default to compact** -- safe middle ground for any skill not explicitly registered.

--- a/docs/plans/context_fidelity_modes.md
+++ b/docs/plans/context_fidelity_modes.md
@@ -1,0 +1,119 @@
+---
+status: In Progress
+type: enhancement
+appetite: Medium
+owner: Valor
+created: 2026-03-10
+tracking: https://github.com/tomcounsell/ai/issues/329
+---
+
+# Context Fidelity Modes for Sub-Agent Steering
+
+## Problem
+
+When `/do-build` spawns builder sub-agents or `/sdlc` dispatches to sub-skills, context is passed as raw text — either the full conversation (wasteful, 50k+ tokens) or a brief summary (lossy). There is no principled middle ground. This causes:
+
+1. **Context bloat** — builders receive entire conversation history when they only need the plan + task
+2. **Lost context** — session resumes have no structured summary of prior work
+3. **Wasted tokens** — sub-agents inherit irrelevant prior conversation
+
+## Appetite
+
+**Size:** Medium — 4 context builder functions, skill annotations, wiring into dispatch
+
+**Team:** Solo dev
+
+**Interactions:**
+- Review rounds: 1
+
+## Prerequisites
+
+None — builds on existing `bridge/context.py` and `agent/sdk_client.py`. Does NOT depend on #328 (SkillOutcome) — uses plain dicts for artifacts until that ships.
+
+## Solution
+
+### Phase 1: Define Context Modes and Builders
+
+Create `agent/context_modes.py` with an enum and four builder functions:
+
+| Mode | Function | Use Case | Approximate Size |
+|------|----------|----------|-----------------|
+| `full` | `build_full_context()` | Resume within same skill | Full session transcript |
+| `compact` | `build_compact_context()` | Stage handoffs (BUILD->TEST) | ~800 tokens |
+| `minimal` | `build_minimal_context()` | Individual builder tasks | ~200 tokens |
+| `steering` | `build_steering_context()` | Observer coaching | ~300 tokens |
+
+Each function takes a `ContextRequest` dataclass containing:
+- `plan_path` (optional str) — path to plan document
+- `task_description` (optional str) — specific task for minimal mode
+- `current_stage` (optional str) — SDLC stage name
+- `completed_stages` (optional list[str]) — previously completed stages
+- `artifacts` (optional dict) — key outputs from prior stages (branch name, PR URL, etc.)
+- `recent_messages` (optional list[str]) — last N human messages for steering
+- `session_transcript` (optional str) — full transcript for full mode
+
+### Phase 2: Annotate Skills with Fidelity Requirements
+
+Add a `context_fidelity` field to a skill metadata registry in `agent/context_modes.py`:
+
+```python
+SKILL_FIDELITY: dict[str, ContextFidelity] = {
+    "do-plan": ContextFidelity.COMPACT,
+    "do-build": ContextFidelity.COMPACT,
+    "do-test": ContextFidelity.COMPACT,
+    "do-patch": ContextFidelity.COMPACT,
+    "do-pr-review": ContextFidelity.COMPACT,
+    "do-docs": ContextFidelity.COMPACT,
+    "builder": ContextFidelity.MINIMAL,
+}
+```
+
+### Phase 3: Wire into `get_context_for_skill()`
+
+Create a top-level dispatch function:
+
+```python
+def get_context_for_skill(
+    skill_name: str,
+    request: ContextRequest,
+) -> str:
+    """Build context string for a skill based on its declared fidelity."""
+```
+
+This reads the fidelity from `SKILL_FIDELITY` (defaulting to `compact`) and calls the appropriate builder.
+
+### Rabbit Holes
+
+- **Token counting** — do NOT enforce token budgets. Let the model handle truncation. The approximate sizes are guidelines, not hard limits.
+- **Thread reuse** — we already have session IDs; no changes to session management.
+- **SkillOutcome integration** — use plain dicts for artifacts. When #328 ships, replace dict with SkillOutcome.
+- **Automatic compression** — do NOT auto-compress during live sessions. These modes are for dispatch-time context building only.
+
+## No-Gos
+
+- No token budget enforcement (let the model handle truncation naturally)
+- No changes to session management or session IDs
+- No graph DSL or DOT syntax
+- No summary:low/medium/high granularity (overkill for linear pipeline)
+- No automatic mid-session context compression
+
+## Update System
+
+No update system changes required — this feature is purely internal to the agent module and does not affect deployment, dependencies, or the update script.
+
+## Agent Integration
+
+No agent integration required — context modes are consumed internally by the SDLC dispatcher and sub-agent spawning code. No new MCP servers or tool changes needed.
+
+## Documentation
+
+- [ ] Create `docs/features/context-fidelity-modes.md` describing the modes and how skills declare fidelity
+- [ ] Add entry to `docs/features/README.md` index table
+
+## Tasks
+
+- [ ] Create `agent/context_modes.py` with `ContextFidelity` enum, `ContextRequest` dataclass, and four builder functions
+- [ ] Create `tests/test_context_modes.py` with unit tests for each builder
+- [ ] Add `get_context_for_skill()` dispatch function
+- [ ] Add `SKILL_FIDELITY` registry mapping skill names to modes
+- [ ] Verify all tests pass, linting clean

--- a/tests/test_context_modes.py
+++ b/tests/test_context_modes.py
@@ -1,0 +1,246 @@
+"""Tests for agent/context_modes.py — context fidelity modes for sub-agent steering."""
+
+import pytest
+
+from agent.context_modes import (
+    SKILL_FIDELITY,
+    ContextFidelity,
+    ContextRequest,
+    build_compact_context,
+    build_full_context,
+    build_minimal_context,
+    build_steering_context,
+    get_context_for_skill,
+)
+
+# ---------------------------------------------------------------------------
+# ContextFidelity enum
+# ---------------------------------------------------------------------------
+
+
+class TestContextFidelity:
+    def test_has_four_modes(self):
+        assert len(ContextFidelity) == 4
+
+    @pytest.mark.parametrize(
+        "mode",
+        ["full", "compact", "minimal", "steering"],
+    )
+    def test_mode_exists(self, mode: str):
+        assert hasattr(ContextFidelity, mode.upper())
+
+    def test_enum_values_are_strings(self):
+        for member in ContextFidelity:
+            assert isinstance(member.value, str)
+
+
+# ---------------------------------------------------------------------------
+# ContextRequest dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestContextRequest:
+    def test_defaults_to_none(self):
+        req = ContextRequest()
+        assert req.plan_path is None
+        assert req.task_description is None
+        assert req.current_stage is None
+        assert req.completed_stages is None
+        assert req.artifacts is None
+        assert req.recent_messages is None
+        assert req.session_transcript is None
+
+    def test_all_fields_settable(self):
+        req = ContextRequest(
+            plan_path="docs/plans/my-feature.md",
+            task_description="Implement the widget",
+            current_stage="BUILD",
+            completed_stages=["PLAN"],
+            artifacts={"branch": "session/my-feature", "pr_url": "https://..."},
+            recent_messages=["do the thing"],
+            session_transcript="full transcript here",
+        )
+        assert req.plan_path == "docs/plans/my-feature.md"
+        assert req.task_description == "Implement the widget"
+        assert req.current_stage == "BUILD"
+        assert req.completed_stages == ["PLAN"]
+        assert req.artifacts["branch"] == "session/my-feature"
+        assert req.recent_messages == ["do the thing"]
+        assert req.session_transcript == "full transcript here"
+
+
+# ---------------------------------------------------------------------------
+# build_full_context
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFullContext:
+    def test_returns_transcript_when_provided(self):
+        req = ContextRequest(session_transcript="Hello world transcript")
+        result = build_full_context(req)
+        assert "Hello world transcript" in result
+
+    def test_returns_empty_string_when_no_transcript(self):
+        req = ContextRequest()
+        result = build_full_context(req)
+        assert result == ""
+
+    def test_includes_header(self):
+        req = ContextRequest(session_transcript="some content")
+        result = build_full_context(req)
+        # Should have some structure, not just raw transcript
+        assert len(result) > len("some content")
+
+
+# ---------------------------------------------------------------------------
+# build_compact_context
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCompactContext:
+    def test_includes_current_stage(self):
+        req = ContextRequest(current_stage="TEST")
+        result = build_compact_context(req)
+        assert "TEST" in result
+
+    def test_includes_completed_stages(self):
+        req = ContextRequest(
+            current_stage="BUILD",
+            completed_stages=["ISSUE", "PLAN"],
+        )
+        result = build_compact_context(req)
+        assert "ISSUE" in result
+        assert "PLAN" in result
+
+    def test_includes_artifacts(self):
+        req = ContextRequest(
+            current_stage="TEST",
+            artifacts={"branch": "session/my-feature", "pr_url": "https://github.com/pr/1"},
+        )
+        result = build_compact_context(req)
+        assert "session/my-feature" in result
+        assert "https://github.com/pr/1" in result
+
+    def test_includes_plan_path(self):
+        req = ContextRequest(
+            current_stage="BUILD",
+            plan_path="docs/plans/my-feature.md",
+        )
+        result = build_compact_context(req)
+        assert "docs/plans/my-feature.md" in result
+
+    def test_empty_request_returns_nonempty(self):
+        """Even with no data, compact mode should produce some structure."""
+        req = ContextRequest()
+        result = build_compact_context(req)
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# build_minimal_context
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMinimalContext:
+    def test_includes_task_description(self):
+        req = ContextRequest(task_description="Fix the login bug in auth.py")
+        result = build_minimal_context(req)
+        assert "Fix the login bug in auth.py" in result
+
+    def test_empty_task_returns_empty(self):
+        req = ContextRequest()
+        result = build_minimal_context(req)
+        assert result == ""
+
+    def test_includes_artifacts_if_provided(self):
+        req = ContextRequest(
+            task_description="Build widget",
+            artifacts={"branch": "session/widget"},
+        )
+        result = build_minimal_context(req)
+        assert "session/widget" in result
+
+
+# ---------------------------------------------------------------------------
+# build_steering_context
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSteeringContext:
+    def test_includes_current_stage(self):
+        req = ContextRequest(current_stage="REVIEW")
+        result = build_steering_context(req)
+        assert "REVIEW" in result
+
+    def test_includes_completed_stages(self):
+        req = ContextRequest(
+            current_stage="TEST",
+            completed_stages=["ISSUE", "PLAN", "BUILD"],
+        )
+        result = build_steering_context(req)
+        assert "BUILD" in result
+
+    def test_includes_recent_messages(self):
+        req = ContextRequest(
+            current_stage="BUILD",
+            recent_messages=["please add error handling", "also fix the typo"],
+        )
+        result = build_steering_context(req)
+        assert "please add error handling" in result
+        assert "also fix the typo" in result
+
+    def test_empty_request_returns_nonempty(self):
+        req = ContextRequest()
+        result = build_steering_context(req)
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# SKILL_FIDELITY registry
+# ---------------------------------------------------------------------------
+
+
+class TestSkillFidelity:
+    def test_known_skills_have_entries(self):
+        expected_skills = ["do-plan", "do-build", "do-test", "do-patch", "do-pr-review", "do-docs"]
+        for skill in expected_skills:
+            assert skill in SKILL_FIDELITY, f"{skill} missing from SKILL_FIDELITY"
+
+    def test_builder_is_minimal(self):
+        assert SKILL_FIDELITY["builder"] == ContextFidelity.MINIMAL
+
+    def test_all_values_are_fidelity_enum(self):
+        for skill, fidelity in SKILL_FIDELITY.items():
+            assert isinstance(fidelity, ContextFidelity), f"{skill} has non-enum value"
+
+
+# ---------------------------------------------------------------------------
+# get_context_for_skill (dispatch)
+# ---------------------------------------------------------------------------
+
+
+class TestGetContextForSkill:
+    def test_builder_gets_minimal(self):
+        req = ContextRequest(task_description="Build the widget")
+        result = get_context_for_skill("builder", req)
+        # Minimal mode includes task description
+        assert "Build the widget" in result
+
+    def test_do_build_gets_compact(self):
+        req = ContextRequest(current_stage="BUILD", completed_stages=["PLAN"])
+        result = get_context_for_skill("do-build", req)
+        assert "BUILD" in result
+
+    def test_unknown_skill_defaults_to_compact(self):
+        req = ContextRequest(current_stage="TEST")
+        result = get_context_for_skill("unknown-skill", req)
+        # Should use compact (default), which includes stage
+        assert "TEST" in result
+
+    def test_full_mode_via_explicit_request(self):
+        """Full context is available when a skill is mapped to it."""
+        # Currently no default skills use full, but the mechanism should work
+        req = ContextRequest(session_transcript="full transcript")
+        result = get_context_for_skill("do-build", req)
+        # do-build is compact, so transcript should NOT appear
+        assert "full transcript" not in result


### PR DESCRIPTION
## Summary

Closes #329

- Introduces four context compression modes (full, compact, minimal, steering) in `agent/context_modes.py` that right-size the context passed to SDLC sub-agents
- Each mode has a dedicated builder function producing appropriately-sized context strings
- Skills declare their fidelity requirement via the `SKILL_FIDELITY` registry; unknown skills default to `compact`
- `get_context_for_skill()` dispatches to the correct builder based on skill name

## What changed

| File | Change |
|------|--------|
| `agent/context_modes.py` | New module: `ContextFidelity` enum, `ContextRequest` dataclass, 4 builder functions, `SKILL_FIDELITY` registry, dispatch function |
| `tests/test_context_modes.py` | 30 unit tests covering all modes, registry, and dispatch |
| `docs/plans/context_fidelity_modes.md` | Plan document |
| `docs/features/context-fidelity-modes.md` | Feature documentation |
| `docs/features/README.md` | Added index entry |

## Context modes

| Mode | Use Case | Content |
|------|----------|---------|
| `full` | Resume within same skill | Complete session transcript |
| `compact` | Stage handoffs (BUILD->TEST) | Plan path, completed stages, artifacts |
| `minimal` | Individual builder sub-agents | Task description + essential refs |
| `steering` | Observer coaching messages | Current stage, done stages, recent human messages |

## Test plan

- [x] 30 unit tests covering all builders, enum, dataclass, registry, and dispatch
- [x] Ruff lint clean
- [x] Black format clean
- [x] All tests pass: `pytest tests/test_context_modes.py` -> 30 passed

Generated with [Claude Code](https://claude.com/claude-code)