### PR TITLE
Patch tech debt: hardcoded paths and deprecated APIs

### DIFF
--- a/agent/completion.py
+++ b/agent/completion.py
@@ -175,12 +175,29 @@ def check_code_quality(working_dir: Path) -> CompletionCheck:
                 name="Code Quality", passed=True, details="No Python files to check"
             )
 
-        # TODO: Actually run ruff/black and check results
-        # For now, assume quality is good if we got this far
+        # Run ruff check for linting
+        result = subprocess.run(
+            ["python", "-m", "ruff", "check", "--quiet", "."],
+            cwd=working_dir,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        if result.returncode != 0:
+            # Count issues from output lines
+            issues = [line for line in result.stdout.strip().splitlines() if line.strip()]
+            first = issues[0] if issues else result.stderr[:100]
+            return CompletionCheck(
+                name="Code Quality",
+                passed=False,
+                details=f"Ruff found {len(issues)} issue(s): {first}",
+            )
+
         return CompletionCheck(
             name="Code Quality",
             passed=True,
-            details=f"Python files present ({len(python_files)} files)",
+            details=f"Ruff check passed ({len(python_files)} files)",
         )
 
     except Exception as e:

--- a/agent/workflow_state.py
+++ b/agent/workflow_state.py
@@ -60,7 +60,7 @@ class WorkflowState:
             workflow_id: Unique 8-character workflow identifier
         """
         self.workflow_id = workflow_id
-        self.state_dir = Path(f"/Users/valorengels/src/ai/agents/{workflow_id}")
+        self.state_dir = Path(__file__).parent.parent / "agents" / workflow_id
         self.state_file = self.state_dir / "state.json"
         self._data: WorkflowStateData | None = None
 
@@ -94,7 +94,7 @@ class WorkflowState:
             # Update existing state
             update_dict = self._data.model_dump()
             update_dict.update(kwargs)
-            update_dict["updated_at"] = datetime.utcnow()
+            update_dict["updated_at"] = datetime.now(tz=None)
             self._data = WorkflowStateData(**update_dict)
 
     def save(self, phase: str | None = None) -> None:

--- a/agent/workflow_types.py
+++ b/agent/workflow_types.py
@@ -7,7 +7,7 @@ including plan → build → test → review workflows with unique workflow IDs.
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 # Workflow phases
 WorkflowPhase = Literal["plan", "build", "test", "review", "document"]
@@ -45,14 +45,8 @@ class WorkflowStateData(BaseModel):
     status: WorkflowStatus | None = Field(None, description="Current workflow status")
     telegram_chat_id: int | None = Field(None, description="Telegram chat ID for notifications")
     created_at: datetime = Field(
-        default_factory=datetime.utcnow, description="Workflow creation timestamp"
+        default_factory=datetime.now, description="Workflow creation timestamp"
     )
-    updated_at: datetime = Field(
-        default_factory=datetime.utcnow, description="Last update timestamp"
-    )
+    updated_at: datetime = Field(default_factory=datetime.now, description="Last update timestamp")
 
-    class Config:
-        """Pydantic model configuration."""
-
-        json_encoders = {datetime: lambda v: v.isoformat()}
-        populate_by_name = True
+    model_config = ConfigDict(populate_by_name=True)

--- a/tools/job_scheduler.py
+++ b/tools/job_scheduler.py
@@ -24,6 +24,7 @@ import sys
 import time
 import uuid
 from datetime import UTC, datetime
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +35,7 @@ MAX_SCHEDULING_DEPTH = 3
 # Default DM chat_id for headless jobs (Tom's DM)
 DEFAULT_DM_CHAT_ID = "179144806"
 DEFAULT_PROJECT_KEY = "valor"
-DEFAULT_WORKING_DIR = "/Users/valorengels/src/ai"
+DEFAULT_WORKING_DIR = str(Path(__file__).parent.parent)
 
 
 def _get_env_context() -> dict:

--- a/tools/telegram_history/cli.py
+++ b/tools/telegram_history/cli.py
@@ -12,9 +12,9 @@ Usage:
     valor-history stats [--group "Dev: Valor"]
 
 Install:
-    pip install -e /Users/valorengels/src/ai
+    pip install -e .  # from repo root
     # or add to PATH:
-    ln -s /Users/valorengels/src/ai/tools/telegram_history/cli.py ~/.local/bin/valor-history
+    ln -s $(pwd)/tools/telegram_history/cli.py ~/.local/bin/valor-history
 """
 
 import argparse


### PR DESCRIPTION
## Summary
- Replace hardcoded `/Users/valorengels/src/ai` paths with `Path(__file__)` resolution in `workflow_state.py`, `job_scheduler.py`, `telegram_history/cli.py`
- Implement actual `ruff check` in `completion.py` code quality gate (was a TODO stub)
- Migrate deprecated `datetime.utcnow()` → `datetime.now()`
- Migrate deprecated Pydantic v1 `class Config` → `model_config = ConfigDict(...)` in `workflow_types.py`

## Test plan
- [x] `pytest tests/test_workflow_sdk_integration.py` — 6/6 passing
- [x] `pytest tests/test_job_scheduler.py -k "not CLI"` — all passing (CLI failures pre-existing: `python` vs `python3`)
- [x] `ruff check` clean on all changed files
- [x] Path resolution verified: both resolve to correct `/Users/valorengels/src/ai`