### PR TITLE
Fix web UI 500 from corrupt session data

### DIFF
--- a/tests/unit/test_ui_sdlc_data.py
+++ b/tests/unit/test_ui_sdlc_data.py
@@ -190,6 +190,93 @@ class TestHistoryParsing:
         assert events[0].timestamp == 123.0
 
 
+class TestSafeStr:
+    """Tests for _safe_str helper that sanitizes Popoto field values."""
+
+    def test_normal_string(self):
+        from ui.data.sdlc import _safe_str
+
+        assert _safe_str("hello") == "hello"
+
+    def test_none_returns_default(self):
+        from ui.data.sdlc import _safe_str
+
+        assert _safe_str(None) is None
+        assert _safe_str(None, "fallback") == "fallback"
+
+    def test_int_converted(self):
+        from ui.data.sdlc import _safe_str
+
+        assert _safe_str(42) == "42"
+
+    def test_float_converted(self):
+        from ui.data.sdlc import _safe_str
+
+        assert _safe_str(3.14) == "3.14"
+
+    def test_bool_converted(self):
+        from ui.data.sdlc import _safe_str
+
+        assert _safe_str(True) == "True"
+
+    def test_popoto_object_returns_default(self):
+        """Popoto DB_key or Field objects should be rejected, not str()-ed."""
+        from ui.data.sdlc import _safe_str
+
+        class FakeField:
+            pass
+
+        assert _safe_str(FakeField()) is None
+        assert _safe_str(FakeField(), "default") == "default"
+
+    def test_empty_string_preserved(self):
+        from ui.data.sdlc import _safe_str
+
+        assert _safe_str("") == ""
+
+
+class TestSafeFloat:
+    """Tests for _safe_float helper that sanitizes Popoto numeric fields."""
+
+    def test_int(self):
+        from ui.data.sdlc import _safe_float
+
+        assert _safe_float(42) == 42.0
+
+    def test_float(self):
+        from ui.data.sdlc import _safe_float
+
+        assert _safe_float(3.14) == 3.14
+
+    def test_numeric_string(self):
+        from ui.data.sdlc import _safe_float
+
+        assert _safe_float("1711234567.89") == 1711234567.89
+
+    def test_none(self):
+        from ui.data.sdlc import _safe_float
+
+        assert _safe_float(None) is None
+
+    def test_non_numeric_string(self):
+        from ui.data.sdlc import _safe_float
+
+        assert _safe_float("not a number") is None
+
+    def test_popoto_object(self):
+        from ui.data.sdlc import _safe_float
+
+        class FakeField:
+            pass
+
+        assert _safe_float(FakeField()) is None
+
+    def test_empty_string(self):
+        from ui.data.sdlc import _safe_float
+
+        assert _safe_float("") is None
+
+
 class TestSdlcQueryFunctions:
     """Tests for SDLC query functions against Redis."""
 

--- a/ui/data/sdlc.py
+++ b/ui/data/sdlc.py
@@ -329,6 +329,7 @@ def get_recent_completions(limit: int = 25, page: int = 1) -> list[PipelineProgr
         try:
             pipeline = _session_to_pipeline(session)
         except Exception:
+            logger.debug(f"Skipping corrupt session: {getattr(session, 'job_id', '?')}")
             continue
         completed.append(pipeline)
 


### PR DESCRIPTION
## Summary
- Sessions with missing/null fields caused popoto to return field descriptor objects instead of actual values, crashing the web UI with Pydantic validation errors
- Added `_safe_str` and `_safe_float` sanitization helpers to filter out popoto field descriptors
- Added try/except guards around `_session_to_pipeline` calls to skip corrupt records gracefully

## Test plan
- [x] Verified web UI returns 200 after fix (was returning 500)
- [x] Confirmed page renders HTML correctly
- [ ] Check web UI loads session list with mixed valid/corrupt data

🤖 Generated with [Claude Code](https://claude.com/claude-code)