### PR TITLE
Update pipeline docs: add Critique stage, clarify patch gate

### DIFF
--- a/.claude/skills/sdlc/SKILL.md
+++ b/.claude/skills/sdlc/SKILL.md
@@ -72,8 +72,8 @@ Based on the assessment, invoke exactly ONE sub-skill and return.
 | Branch exists, no PR | `/do-build` with plan path | Build must create the PR — resume build |
 | Tests failing | `/do-patch` then `/do-test` | Fix what is broken |
 | PR exists, no review | `/do-pr-review {pr_number}` | Code is ready for review |
-| PR review has blockers or nits | `/do-patch` | Address review feedback |
-| Review clean, docs not updated | `/do-docs` | Last step before merge |
+| PR review has blockers or nits | `/do-patch` | Address review feedback (must pass before DOCS) |
+| Review clean, docs not updated | `/do-docs` | Last step before merge (only after clean review) |
 | All stages complete | Report done | PM delivers to human |
 
 **CRITICAL**: Before dispatching `/do-pr-review`, verify a PR actually exists by checking the output of `gh pr list`. If no PR exists for this branch, dispatch `/do-build` instead — it handles PR creation. Never send `/do-pr-review` without a real PR number.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ The standard flow from conversation to shipped feature:
 ### Phase 2: SDLC (triggered by work request)
 - ChatSession steers the pipeline, invoking `/sdlc` skills as needed
 - `/sdlc` assesses current state, invokes ONE sub-skill, and returns
-- Stages: Plan -> Build -> Test -> Patch -> Review -> Patch -> Docs -> Merge
+- Stages: Plan -> Critique -> Build -> Test -> Patch -> Review -> Patch -> Docs -> Merge
 - See `.claude/skills/sdlc/SKILL.md` for the ground truth on stage definitions
 
 ### Phase 3: Review & Merge


### PR DESCRIPTION
## Summary
- Update CLAUDE.md pipeline description to include Critique stage (`Plan -> Critique -> Build -> ...`), matching the canonical graph in `bridge/pipeline_graph.py`
- Add clarifying notes to SDLC SKILL.md dispatch table making explicit that review findings must route through PATCH before advancing to DOCS

Closes #534

## Test plan
- [ ] Verify `grep 'Critique' CLAUDE.md` finds the updated pipeline description
- [ ] Verify SDLC SKILL.md dispatch table notes clarify post-review patch requirement
- [ ] Confirm pipeline description matches canonical graph in `bridge/pipeline_graph.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)