### PR TITLE
Add PR review audit reflection step (step 20)

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -71,7 +71,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [Race Condition Analysis](race-condition-analysis.md) | Structured concurrency analysis section in plan template with soft validator for async code | Shipped |
 | [Reaction Semantics](reaction-semantics.md) | Emoji reaction protocol for message delivery feedback and silent loss prevention | Shipped |
 | [Redis Model Relationships](redis-models.md) | Cross-references between Popoto models, project_key on all models, enrichment metadata ownership on TelegramMessage | Shipped |
-| [Reflections](reflections.md) | Unified reflection scheduler with declarative YAML registry, Redis state tracking, skip-if-running guard; subsumes health check, orphan recovery, branch cleanup, and 14-unit daily maintenance pipeline | Shipped |
+| [Reflections](reflections.md) | Unified reflection scheduler with declarative YAML registry, Redis state tracking, skip-if-running guard; subsumes health check, orphan recovery, branch cleanup, and 15-unit daily maintenance pipeline (including PR review audit) | Shipped |
 | [Reflections Dashboard](reflections-dashboard.md) | Web dashboard for monitoring reflection scheduler execution, run history, and ignore patterns at `/reflections/` | Shipped |
 | [Remote Update](remote-update.md) | Telegram command and cron for remote system updates across machines | Shipped |
 | [Review Workflow Screenshots](review-workflow-screenshots.md) | Screenshot capture during review for visual validation | Shipped |

--- a/docs/features/reflections.md
+++ b/docs/features/reflections.md
@@ -106,13 +106,13 @@ The bridge watchdog (`com.valor.bridge-watchdog`) is intentionally NOT in the re
 
 When the watchdog detects that the bridge process is not running (via `pgrep`), it calls `crash_tracker.log_crash("bridge_dead_on_watchdog_check")` to record the event. This captures SIGKILL and OOM kills that leave no traceback. The crash tracker's pattern detection requires 3+ crashes in 30 minutes before triggering escalation, so a single false positive from a startup race is harmless.
 
-## Daily Maintenance Pipeline (14 Units)
+## Daily Maintenance Pipeline (15 Units)
 
 The `daily-maintenance` reflection runs the full pipeline from `scripts/reflections.py`. The runner loads state from Redis, executes each unit in order, and checkpoints after every unit. If interrupted, the next run resumes from where it left off. Each unit is independently failable — a crash in one unit does not block the rest.
 
-The pipeline has 14 units: 11 independent items and 3 merged pipelines. Completed units are tracked by string key (e.g. `"legacy_code_scan"`), not by integer position. This means units can be reordered or renamed without data migrations — any unknown key in `completed_steps` is simply skipped.
+The pipeline has 15 units: 12 independent items and 3 merged pipelines. Completed units are tracked by string key (e.g. `"legacy_code_scan"`), not by integer position. This means units can be reordered or renamed without data migrations — any unknown key in `completed_steps` is simply skipped.
 
-### 14-Unit Pipeline
+### 15-Unit Pipeline
 
 **Independent units** (each checkpointed individually):
 
@@ -129,20 +129,21 @@ The pipeline has 14 units: 11 independent items and 3 merged pipelines. Complete
 | 9 | `feature_docs_audit` | Feature Docs Audit | Checks for stale references, README accuracy, plan-masquerading-as-feature, stub docs | AI repo only | Non-blocking |
 | 10 | `principal_staleness` | Principal Context Staleness | Checks age of PRINCIPAL.md and flags if stale | AI repo only | Non-blocking |
 | 11 | `disk_space_check` | Disk Space Check | Checks free disk space on project volume; finding if below 10 GB (see [Adding Reflection Tasks](adding-reflection-tasks.md)) | AI repo only | Non-blocking |
+| 12 | `pr_review_audit` | PR Review Audit | Scans merged PRs for unaddressed review findings from do-pr-review, files GitHub issues with severity labels | Per-project | Non-blocking, requires `gh` auth |
 
 **Merged pipelines** (sub-steps run internally, one checkpoint for the whole group):
 
 | # | Key | Name | Sub-steps | Description |
 |---|-----|------|-----------|-------------|
-| 12 | `session_intelligence` | Session Intelligence | session_analysis → llm_reflection → auto_fix_bugs | Analyzes sessions, reflects via Haiku, files high-confidence bug issues |
-| 13 | `behavioral_learning` | Behavioral Learning | episode_cycle_close → pattern_crystallization | Closes completed SDLC episodes and crystallizes recurring patterns |
-| 14 | `daily_report_and_notify` | Daily Report & Notify | produce_report → create_github_issue | Writes report, posts GitHub issues, sends Telegram summary (must be last) |
+| 13 | `session_intelligence` | Session Intelligence | session_analysis → llm_reflection → auto_fix_bugs | Analyzes sessions, reflects via Haiku, files high-confidence bug issues |
+| 14 | `behavioral_learning` | Behavioral Learning | episode_cycle_close → pattern_crystallization | Closes completed SDLC episodes and crystallizes recurring patterns |
+| 15 | `daily_report_and_notify` | Daily Report & Notify | produce_report → create_github_issue | Writes report, posts GitHub issues, sends Telegram summary (must be last) |
 
 **Removed:** `step_check_sentry` — was a permanent no-op (Sentry MCP never available in standalone mode). Deleted entirely.
 
 ## State & Persistence
 
-All reflections state lives in Redis via two Popoto models defined in `models/reflections.py`.
+All reflections state lives in Redis via three Popoto models defined in `models/reflections.py`.
 
 ### ReflectionRun
 
@@ -182,6 +183,26 @@ Suppresses auto-fix for specific patterns. Each entry has a TTL (default 14 days
 **Matching**: Case-insensitive substring match — if either the ignore pattern or the reflection pattern is a substring of the other, it's a match.
 
 **Cleanup**: Expired entries are pruned at the start of each auto-fix run (inside `session_intelligence`) and during Redis TTL cleanup (`redis_ttl_cleanup`).
+
+### PRReviewAudit
+
+Deduplication tracker for PR review audit findings. Prevents re-filing GitHub issues for already-audited review comments.
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `audit_id` | AutoKeyField | UUID |
+| `repo` | KeyField | GitHub repo slug (e.g. "tomcounsell/ai") |
+| `pr_number` | IntField | Pull request number |
+| `comment_id` | UniqueKeyField | Composite dedup key: `{repo}:{pr_number}:{comment_id}:{finding_index}` |
+| `severity` | Field | Classified severity (critical, standard, trivial) |
+| `filed_issue_url` | Field(null) | URL of the filed GitHub issue, if any |
+| `audited_at` | SortedField(float) | Timestamp when audited (for TTL cleanup and time window lookback) |
+
+**Dedup key format**: `{repo}:{pr_number}:{comment_id}:{finding_index}`. A single review comment may contain multiple structured findings; the finding_index ensures each is tracked independently.
+
+**Time window lookback**: `PRReviewAudit.last_successful_run()` returns the most recent `audited_at` timestamp, used by the PR review audit step to determine which PRs to scan. Falls back to yesterday if no prior audits exist. This closes multi-day gaps when reflections is down.
+
+**Cleanup**: Records older than 90 days are pruned via `cleanup_expired()` during Redis TTL cleanup (`redis_ttl_cleanup`).
 
 
 ## Session Analysis (part of `session_intelligence` pipeline)
@@ -270,7 +291,7 @@ python scripts/reflections.py --ignore "pattern text here" --reason "Intentional
 
 Reflections reads `~/Desktop/Valor/projects.json`, filters to repos present on the current machine via `load_local_projects()`, and runs per-project analysis. A machine with only `ai` checked out analyzes only `ai`; a machine with four repos analyzes all four.
 
-**Per-project steps**: 2 (Log Review), 4 (Task Cleanup), 11 (GitHub Issues + Telegram)
+**Per-project steps**: 2 (Log Review), 4 (Task Cleanup), 11 (GitHub Issues + Telegram), 12 (PR Review Audit)
 **AI-only steps**: Everything else runs once from the AI repo root
 
 ### Configuration
@@ -339,6 +360,39 @@ Prunes expired records to keep Redis lean:
 | BridgeEvent | 7 days | `cleanup_old()` |
 | ReflectionRun | 30 days | `cleanup_expired()` |
 | ReflectionIgnore | Per-entry TTL | `cleanup_expired()` |
+| PRReviewAudit | 90 days | `cleanup_expired()` |
+
+## PR Review Audit (`pr_review_audit`)
+
+Scans merged PRs for unaddressed review findings and files GitHub issues. This is the safety net for when the PM merges a PR with tech debt, test gaps, or nits left behind -- items that would otherwise silently disappear.
+
+### How It Works
+
+1. **PR discovery**: For each project with a `github` config, fetches merged PRs since the last successful audit via `gh pr list --state merged --search "merged:>={date}"`
+2. **Review parsing**: Fetches review comments and parses the structured do-pr-review format (`**Severity:**`, `**File:**`, `**Code:**`, `**Issue:**`, `**Fix:**`)
+3. **Address check**: For each finding, checks if the referenced file was modified in commits after the review comment timestamp (file-level heuristic)
+4. **Deduplication**: Checks Redis `PRReviewAudit` model to skip already-audited findings
+5. **Issue filing**: Files one GitHub issue per PR with unaddressed findings, grouped by severity, with labels `pr-review-audit` plus severity-specific labels (`critical`, `tech-debt`, `nit`)
+
+### Severity Classification
+
+| Review Format | Classification | GitHub Label |
+|--------------|----------------|--------------|
+| `blocker` | critical | `critical` |
+| `tech_debt` | standard | `tech-debt` |
+| `nit` | trivial | `nit` |
+
+### Safety Properties
+
+- **Per-project isolation** -- A failure on one project does not block others
+- **Rate limited** -- Processes at most 20 merged PRs per project per run
+- **Dedup** -- Redis-backed `PRReviewAudit` model prevents re-filing for audited comments
+- **Dry-run safe** -- When `--dry-run` is set, logs findings but skips issue creation and Redis writes
+- **Structured format only** -- Only parses well-formed do-pr-review findings; ignores free-text comments
+
+### Findings Namespacing
+
+Findings are added to `state.findings` with key `{slug}:pr_review_audit`. Step progress is recorded in `state.step_progress["pr_review_audit"]` with metrics: `prs_scanned`, `findings_total`, `findings_unaddressed`, `issues_filed`.
 
 ## Branch and Plan Cleanup (`branch_plan_cleanup`)
 
@@ -412,8 +466,8 @@ The scheduler picks it up on the next tick. No code changes or service restarts 
 | `agent/reflection_scheduler.py` | Unified scheduler: registry loader, schedule evaluator, executor |
 | `config/reflections.yaml` | Declarative registry of all reflections |
 | `models/reflection.py` | Reflection state model (per-reflection Redis tracking) |
-| `models/reflections.py` | Core models (ReflectionRun for daily pipeline, ReflectionIgnore) |
-| `scripts/reflections.py` | Daily maintenance 14-unit runner |
+| `models/reflections.py` | Core models: ReflectionRun (daily pipeline state), ReflectionIgnore (auto-fix suppression), PRReviewAudit (PR review dedup) |
+| `scripts/reflections.py` | Daily maintenance 15-unit runner |
 | `scripts/reflections_report.py` | GitHub issue creation module |
 | `scripts/install_reflections.sh` | launchd installation script (kept for manual invocation) |
 | `com.valor.reflections.plist` | launchd schedule definition (kept for manual invocation) |
@@ -429,7 +483,7 @@ The scheduler picks it up on the next tick. No code changes or service restarts 
 | PyYAML | Registry loader | Yes — reads `config/reflections.yaml` |
 | psutil | Memory instrumentation | Optional — memory snapshots degrade gracefully if missing |
 | `ANTHROPIC_API_KEY` | `documentation_audit`, `session_intelligence` | Conditional — LLM reflection and docs audit |
-| `gh` CLI (authenticated) | `task_management`, `session_intelligence`, `daily_report_and_notify`, `branch_plan_cleanup` | Conditional — task cleanup, bug issues |
+| `gh` CLI (authenticated) | `task_management`, `session_intelligence`, `daily_report_and_notify`, `branch_plan_cleanup`, `pr_review_audit` | Conditional — task cleanup, bug issues, PR review audit |
 | `telethon` | `daily_report_and_notify` | Conditional — Telegram notifications |
 | `~/Desktop/Valor/projects.json` | Multi-repo reflections | Optional — defaults to AI repo only |
 

--- a/models/reflections.py
+++ b/models/reflections.py
@@ -1,8 +1,9 @@
 """Reflections Popoto models - Redis-backed state for the reflections maintenance system.
 
-Two models:
+Three models:
 - ReflectionRun: per-run state with resumability (one per day)
 - ReflectionIgnore: auto-fix suppression with TTL-based auto-expiry
+- PRReviewAudit: deduplication tracker for PR review audit findings
 
 See docs/features/reflections.md for full documentation.
 """
@@ -13,6 +14,7 @@ from popoto import (
     AutoKeyField,
     DictField,
     Field,
+    IntField,
     KeyField,
     ListField,
     Model,
@@ -143,3 +145,97 @@ class ReflectionIgnore(Model):
             if entry_pattern and (entry_pattern in pattern_lower or pattern_lower in entry_pattern):
                 return True
         return False
+
+
+class PRReviewAudit(Model):
+    """Deduplication tracker for PR review audit findings.
+
+    Keyed by a composite of repo:pr_number:comment_id:finding_index to prevent
+    re-filing GitHub issues for already-audited review findings. Each record
+    stores the severity classification and the URL of the filed issue (if any).
+
+    A single review comment may contain multiple structured findings. The
+    finding_index ensures each finding is tracked independently, preventing
+    the case where auditing one finding silently marks others as audited.
+
+    Fields:
+        audit_id: Auto-generated unique key
+        repo: GitHub repo slug (e.g. "tomcounsell/ai")
+        pr_number: Pull request number
+        comment_id: Composite dedup key "{repo}:{pr_number}:{comment_id}:{finding_index}"
+        severity: Classified severity (critical, standard, trivial)
+        filed_issue_url: URL of the filed GitHub issue, if any
+        audited_at: Timestamp when this comment was audited (for TTL cleanup)
+    """
+
+    audit_id = AutoKeyField()
+    repo = KeyField()
+    pr_number = IntField()
+    comment_id = UniqueKeyField()  # Dedup key: "{repo}:{pr_number}:{comment_id}:{finding_index}"
+    severity = Field(null=True)
+    filed_issue_url = Field(null=True)
+    audited_at = SortedField(type=float)
+
+    @classmethod
+    def is_audited(cls, comment_key: str) -> bool:
+        """Check if a review finding has already been audited.
+
+        Args:
+            comment_key: Composite key in format "{repo}:{pr_number}:{comment_id}:{finding_index}"
+        """
+        existing = cls.query.filter(comment_id=comment_key)
+        return bool(existing)
+
+    @classmethod
+    def mark_audited(
+        cls,
+        comment_key: str,
+        repo: str,
+        pr_number: int,
+        severity: str,
+        issue_url: str | None = None,
+    ) -> "PRReviewAudit":
+        """Record a review finding as audited.
+
+        Args:
+            comment_key: Composite key in format "{repo}:{pr_number}:{comment_id}:{finding_index}"
+            repo: GitHub repo slug
+            pr_number: Pull request number
+            severity: Classified severity (critical, standard, trivial)
+            issue_url: URL of the filed GitHub issue, if any
+        """
+        return cls.create(
+            repo=repo,
+            pr_number=pr_number,
+            comment_id=comment_key,
+            severity=severity,
+            filed_issue_url=issue_url,
+            audited_at=time.time(),
+        )
+
+    @classmethod
+    def last_successful_run(cls) -> float | None:
+        """Return the most recent audited_at timestamp, or None if no audits exist.
+
+        Used to determine the PR time window for the next audit run.
+        """
+        all_audits = cls.query.all()
+        if not all_audits:
+            return None
+        latest = max(
+            (a.audited_at for a in all_audits if a.audited_at),
+            default=None,
+        )
+        return latest
+
+    @classmethod
+    def cleanup_expired(cls, max_age_days: int = 90) -> int:
+        """Delete audit records older than max_age_days."""
+        cutoff = time.time() - (max_age_days * 86400)
+        all_audits = cls.query.all()
+        deleted = 0
+        for audit in all_audits:
+            if audit.audited_at and audit.audited_at < cutoff:
+                audit.delete()
+                deleted += 1
+        return deleted

--- a/scripts/reflections.py
+++ b/scripts/reflections.py
@@ -3,7 +3,7 @@
 Reflections - Autonomous Daily Maintenance System
 
 A long-running process that performs daily self-directed maintenance tasks.
-14 units: 11 independent items + 3 merged pipelines.
+15 units: 12 independent items + 3 merged pipelines.
 
 Independent units:
 1. legacy_code_scan — Clean Up Stale Code
@@ -17,11 +17,12 @@ Independent units:
 9. feature_docs_audit   — Feature Docs Audit
 10. principal_staleness — Principal Context Staleness
 11. disk_space_check    — Disk Space Check
+12. pr_review_audit     — PR Review Audit
 
 Merged pipelines (sub-steps run internally, one checkpoint per pipeline):
-12. session_intelligence    — Session Analysis + LLM Reflection + Bug Filing
-13. behavioral_learning     — Episode Cycle-Close + Pattern Crystallization
-14. daily_report_and_notify — Daily Report + GitHub Issues + Telegram (must be last)
+13. session_intelligence    — Session Analysis + LLM Reflection + Bug Filing
+14. behavioral_learning     — Episode Cycle-Close + Pattern Crystallization
+15. daily_report_and_notify — Daily Report + GitHub Issues + Telegram (must be last)
 
 All persistence is Redis-backed via Popoto models (see models/ directory).
 State: ReflectionRun | Ignore patterns: ReflectionIgnore
@@ -472,6 +473,179 @@ def extract_errors_from_redis(target_date: str) -> list[dict[str, str]]:
     return errors
 
 
+# --- PR Review Audit helpers ---
+
+# Regex patterns for structured review findings from do-pr-review SKILL.md.
+# Expected format in review comments:
+#   **Severity:** blocker | tech_debt | nit
+#   **File:** path/to/file.py
+#   **Code:** `some_code()`
+#   **Issue:** Description of the problem
+#   **Fix:** Suggested fix
+_FINDING_SEVERITY_RE = re.compile(r"\*\*Severity:\*\*\s*(blocker|tech_debt|nit)", re.IGNORECASE)
+_FINDING_FILE_RE = re.compile(r"\*\*File:\*\*\s*`?([^\n`]+)`?")
+_FINDING_CODE_RE = re.compile(r"\*\*Code:\*\*\s*`?([^\n`]+)`?")
+_FINDING_ISSUE_RE = re.compile(r"\*\*Issue:\*\*\s*(.+?)(?=\n\*\*|\Z)", re.DOTALL)
+_FINDING_FIX_RE = re.compile(r"\*\*Fix:\*\*\s*(.+?)(?=\n\*\*|\Z)", re.DOTALL)
+
+# Severity classification mapping
+SEVERITY_MAP = {
+    "blocker": "critical",
+    "tech_debt": "standard",
+    "nit": "trivial",
+}
+
+# GitHub label mapping
+SEVERITY_LABELS = {
+    "critical": "critical",
+    "standard": "tech-debt",
+    "trivial": "nit",
+}
+
+
+def parse_review_findings(body: str) -> list[dict[str, str]]:
+    """Extract structured findings from a PR review comment body.
+
+    Parses the do-pr-review structured format with **Severity:**, **File:**,
+    **Code:**, **Issue:**, and **Fix:** fields. Only comments containing at
+    minimum a Severity and Issue field are considered valid findings.
+
+    Args:
+        body: The review comment body text.
+
+    Returns:
+        List of finding dicts with keys: severity, file_path, code,
+        issue_description, suggested_fix. The severity is already mapped
+        to the classified value (critical/standard/trivial).
+    """
+    if not body:
+        return []
+
+    findings = []
+
+    # Split on severity markers to handle multiple findings in one comment
+    # Find all severity matches and their positions
+    severity_matches = list(_FINDING_SEVERITY_RE.finditer(body))
+    if not severity_matches:
+        return []
+
+    for i, sev_match in enumerate(severity_matches):
+        # Extract the section for this finding (from this severity to the next, or end)
+        start = sev_match.start()
+        end = severity_matches[i + 1].start() if i + 1 < len(severity_matches) else len(body)
+        section = body[start:end]
+
+        raw_severity = sev_match.group(1).lower()
+        severity = SEVERITY_MAP.get(raw_severity, "standard")
+
+        # Issue is required (minimum: Severity + Issue)
+        issue_match = _FINDING_ISSUE_RE.search(section)
+        if not issue_match:
+            continue
+
+        file_match = _FINDING_FILE_RE.search(section)
+        code_match = _FINDING_CODE_RE.search(section)
+        fix_match = _FINDING_FIX_RE.search(section)
+
+        findings.append(
+            {
+                "severity": severity,
+                "raw_severity": raw_severity,
+                "file_path": file_match.group(1).strip() if file_match else "",
+                "code": code_match.group(1).strip() if code_match else "",
+                "issue_description": issue_match.group(1).strip(),
+                "suggested_fix": fix_match.group(1).strip() if fix_match else "",
+            }
+        )
+
+    return findings
+
+
+def check_finding_addressed(pr_commits: list[dict], review_timestamp: str, file_path: str) -> bool:
+    """Check if a finding was addressed by a commit after the review.
+
+    Uses file-level heuristic: if the file was modified in any commit after
+    the review comment timestamp, consider the finding addressed.
+
+    Args:
+        pr_commits: List of commit dicts from gh api (with 'commit.committer.date'
+            and 'files' keys).
+        review_timestamp: ISO 8601 timestamp of the review comment.
+        file_path: Path of the file referenced in the finding.
+
+    Returns:
+        True if the file was modified after the review, False otherwise.
+    """
+    if not file_path or not pr_commits:
+        return False
+
+    for commit in pr_commits:
+        commit_date = commit.get("commit", {}).get("committer", {}).get("date", "")
+        if not commit_date:
+            continue
+        # Compare timestamps lexicographically (ISO 8601 sorts correctly)
+        if commit_date > review_timestamp:
+            files = commit.get("files", [])
+            for f in files:
+                if f.get("filename", "") == file_path:
+                    return True
+    return False
+
+
+def format_audit_issue_body(
+    pr_number: int,
+    pr_title: str,
+    pr_url: str,
+    unaddressed: list[dict],
+) -> str:
+    """Format the GitHub issue body for unaddressed PR review findings.
+
+    Groups findings by severity and includes original review links.
+
+    Args:
+        pr_number: The PR number.
+        pr_title: The PR title.
+        pr_url: URL to the PR.
+        unaddressed: List of unaddressed finding dicts (with review_url added).
+
+    Returns:
+        Markdown-formatted issue body.
+    """
+    lines = [
+        "## Unaddressed PR Review Findings",
+        "",
+        f"**Source PR:** [{pr_title}]({pr_url}) (#{pr_number})",
+        "",
+    ]
+
+    # Group by severity
+    by_severity: dict[str, list[dict]] = {}
+    for finding in unaddressed:
+        sev = finding.get("severity", "standard")
+        by_severity.setdefault(sev, []).append(finding)
+
+    for severity in ["critical", "standard", "trivial"]:
+        group = by_severity.get(severity, [])
+        if not group:
+            continue
+        lines.append(f"### {severity.title()} ({len(group)})")
+        lines.append("")
+        for finding in group:
+            lines.append(f"- **File:** `{finding.get('file_path', 'N/A')}`")
+            if finding.get("code"):
+                lines.append(f"  **Code:** `{finding['code']}`")
+            lines.append(f"  **Issue:** {finding.get('issue_description', 'N/A')}")
+            if finding.get("suggested_fix"):
+                lines.append(f"  **Fix:** {finding['suggested_fix']}")
+            if finding.get("review_url"):
+                lines.append(f"  [Review comment]({finding['review_url']})")
+            lines.append("")
+
+    lines.append("---")
+    lines.append("*Filed automatically by the reflections PR review audit (step 20).*")
+    return "\n".join(lines)
+
+
 class ReflectionRunner:
     """Runs the reflections maintenance process.
 
@@ -494,6 +668,7 @@ class ReflectionRunner:
             ("feature_docs_audit", "Feature Docs Audit", self.step_feature_docs_audit),
             ("principal_staleness", "Principal Context Staleness", self.step_principal_staleness),
             ("disk_space_check", "Disk Space Check", self.step_disk_space_check),
+            ("pr_review_audit", "PR Review Audit", self.step_pr_review_audit),
             ("session_intelligence", "Session Intelligence", self.step_session_intelligence),
             ("behavioral_learning", "Behavioral Learning", self.step_behavioral_learning),
             ("daily_report_and_notify", "Daily Report & Notify", self.step_daily_report_and_notify),
@@ -597,6 +772,7 @@ class ReflectionRunner:
             "daily_report_and_notify",
             "task_management",
             "branch_plan_cleanup",
+            "pr_review_audit",
         }
         if step_key in gh_steps:
             try:
@@ -1028,7 +1204,7 @@ class ReflectionRunner:
             }
             return
 
-        dry_run = getattr(self.state, "_dry_run", False)
+        dry_run = self.state.dry_run
 
         prune_ignore_log()
         ignore_entries = load_ignore_log()
@@ -1782,9 +1958,8 @@ class ReflectionRunner:
         """
         import time as _time
 
-        from models.cyclic_episode import CyclicEpisode
-
         from models.agent_session import AgentSession
+        from models.cyclic_episode import CyclicEpisode
         from scripts.fingerprint_classifier import classify_session
 
         cutoff = _time.time() - 86400  # past 24 hours
@@ -2121,6 +2296,347 @@ class ReflectionRunner:
             "findings": len(findings),
         }
 
+    async def step_pr_review_audit(self) -> None:
+        """Step 20: Audit merged PRs for unaddressed review findings.
+
+        Scans recently merged PRs across all configured projects, extracts
+        structured review findings (using the do-pr-review format), checks
+        whether each finding was addressed by subsequent commits, and files
+        GitHub issues for unaddressed findings grouped by PR.
+
+        Data flow:
+        1. For each project with github config, fetch merged PRs since last audit
+        2. For each PR, fetch review comments and parse structured findings
+        3. Check if findings were addressed via commit history (file-level)
+        4. Deduplicate against Redis PRReviewAudit model
+        5. File one GitHub issue per PR with unaddressed findings
+        6. Record audited comments in Redis for dedup
+
+        Respects dry_run: when True, logs findings but skips issue creation
+        and Redis writes. Skips entirely if Redis is unavailable (caught by
+        preflight). Each project is processed independently with error isolation.
+        """
+        from models.reflections import PRReviewAudit
+
+        dry_run = self.state.dry_run
+        prs_scanned = 0
+        findings_total = 0
+        findings_unaddressed = 0
+        issues_filed = 0
+
+        # Determine time window: last successful audit or yesterday
+        last_run = PRReviewAudit.last_successful_run()
+        if last_run:
+            last_audit_date = datetime.fromtimestamp(last_run, tz=UTC).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
+        else:
+            last_audit_date = (utc_now() - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        # Convert to date-only for gh search query
+        search_date = last_audit_date[:10]
+
+        for project in self.projects:
+            slug = project["slug"]
+            github_config = project.get("github")
+            if not github_config:
+                continue
+
+            repo = github_config.get("repo", "")
+            if not repo:
+                continue
+
+            project_wd = project["working_directory"]
+
+            try:
+                # Fetch merged PRs since last audit (cap at 20)
+                pr_result = subprocess.run(
+                    [
+                        "gh",
+                        "pr",
+                        "list",
+                        "--repo",
+                        repo,
+                        "--state",
+                        "merged",
+                        "--limit",
+                        "20",
+                        "--search",
+                        f"merged:>={search_date}",
+                        "--json",
+                        "number,title,url,mergedAt",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                    cwd=project_wd,
+                )
+
+                if pr_result.returncode != 0:
+                    logger.warning(
+                        "PR review audit: gh pr list failed for %s: %s",
+                        slug,
+                        pr_result.stderr[:200],
+                    )
+                    continue
+
+                prs = json.loads(pr_result.stdout) if pr_result.stdout.strip() else []
+                if not prs:
+                    logger.info(f"PR review audit: no merged PRs for {slug} since {search_date}")
+                    continue
+
+                if len(prs) >= 20:
+                    logger.warning(
+                        "PR review audit: hit 20-PR cap for %s, some PRs may be skipped", slug
+                    )
+
+                for pr in prs:
+                    pr_number = pr.get("number")
+                    pr_title = pr.get("title", "")
+                    pr_url = pr.get("url", "")
+                    prs_scanned += 1
+
+                    try:
+                        # Fetch review comments (both review-level and inline)
+                        comments_result = subprocess.run(
+                            [
+                                "gh",
+                                "api",
+                                f"repos/{repo}/pulls/{pr_number}/comments",
+                                "--paginate",
+                            ],
+                            capture_output=True,
+                            text=True,
+                            timeout=30,
+                            cwd=project_wd,
+                        )
+
+                        reviews_result = subprocess.run(
+                            [
+                                "gh",
+                                "api",
+                                f"repos/{repo}/pulls/{pr_number}/reviews",
+                                "--paginate",
+                            ],
+                            capture_output=True,
+                            text=True,
+                            timeout=30,
+                            cwd=project_wd,
+                        )
+
+                        # Collect all comment bodies with metadata
+                        all_comments: list[dict] = []
+
+                        if comments_result.returncode == 0 and comments_result.stdout.strip():
+                            for comment in json.loads(comments_result.stdout):
+                                all_comments.append(
+                                    {
+                                        "id": comment.get("id", 0),
+                                        "body": comment.get("body", ""),
+                                        "created_at": comment.get("created_at", ""),
+                                        "html_url": comment.get("html_url", ""),
+                                    }
+                                )
+
+                        if reviews_result.returncode == 0 and reviews_result.stdout.strip():
+                            for review in json.loads(reviews_result.stdout):
+                                body = review.get("body", "")
+                                if body and body.strip():
+                                    all_comments.append(
+                                        {
+                                            "id": review.get("id", 0),
+                                            "body": body,
+                                            "created_at": review.get("submitted_at", ""),
+                                            "html_url": review.get("html_url", ""),
+                                        }
+                                    )
+
+                        if not all_comments:
+                            continue
+
+                        # Fetch PR commits for address detection
+                        commits_result = subprocess.run(
+                            [
+                                "gh",
+                                "api",
+                                f"repos/{repo}/pulls/{pr_number}/commits",
+                                "--paginate",
+                            ],
+                            capture_output=True,
+                            text=True,
+                            timeout=30,
+                            cwd=project_wd,
+                        )
+
+                        pr_commits: list[dict] = []
+                        if commits_result.returncode == 0 and commits_result.stdout.strip():
+                            pr_commits = json.loads(commits_result.stdout)
+
+                        # Parse findings from each comment
+                        unaddressed_for_pr: list[dict] = []
+
+                        for comment in all_comments:
+                            comment_findings = parse_review_findings(comment["body"])
+                            if not comment_findings:
+                                continue
+
+                            for finding_idx, finding in enumerate(comment_findings):
+                                findings_total += 1
+                                comment_key = f"{repo}:{pr_number}:{comment['id']}:{finding_idx}"
+
+                                # Dedup check
+                                if PRReviewAudit.is_audited(comment_key):
+                                    continue
+
+                                # Address check
+                                if check_finding_addressed(
+                                    pr_commits,
+                                    comment["created_at"],
+                                    finding["file_path"],
+                                ):
+                                    # Mark as audited even if addressed
+                                    if not dry_run:
+                                        PRReviewAudit.mark_audited(
+                                            comment_key=comment_key,
+                                            repo=repo,
+                                            pr_number=pr_number,
+                                            severity=finding["severity"],
+                                            issue_url=None,
+                                        )
+                                    continue
+
+                                findings_unaddressed += 1
+                                finding["review_url"] = comment["html_url"]
+                                finding["comment_key"] = comment_key
+                                unaddressed_for_pr.append(finding)
+
+                        if not unaddressed_for_pr:
+                            continue
+
+                        # File one GitHub issue per PR with all unaddressed findings
+                        severity_labels = set()
+                        for f in unaddressed_for_pr:
+                            label = SEVERITY_LABELS.get(f["severity"], "tech-debt")
+                            severity_labels.add(label)
+
+                        labels = ["pr-review-audit"] + sorted(severity_labels)
+                        issue_title = f"PR #{pr_number}: unaddressed review findings"
+                        issue_body = format_audit_issue_body(
+                            pr_number, pr_title, pr_url, unaddressed_for_pr
+                        )
+
+                        if dry_run:
+                            logger.info(
+                                "PR review audit: [DRY RUN] would file issue for PR #%d "
+                                "(%d unaddressed findings) in %s",
+                                pr_number,
+                                len(unaddressed_for_pr),
+                                slug,
+                            )
+                            self.state.add_finding(
+                                f"{slug}:pr_review_audit",
+                                f"[DRY RUN] Would file issue for PR #{pr_number}: "
+                                f"{len(unaddressed_for_pr)} unaddressed findings",
+                            )
+                            continue
+
+                        try:
+                            issue_result = subprocess.run(
+                                [
+                                    "gh",
+                                    "issue",
+                                    "create",
+                                    "--repo",
+                                    repo,
+                                    "--title",
+                                    issue_title,
+                                    "--body",
+                                    issue_body,
+                                ]
+                                + [arg for label in labels for arg in ("--label", label)],
+                                capture_output=True,
+                                text=True,
+                                timeout=30,
+                                cwd=project_wd,
+                            )
+
+                            issue_url = ""
+                            if issue_result.returncode == 0:
+                                issue_url = issue_result.stdout.strip()
+                                issues_filed += 1
+                                logger.info(
+                                    "PR review audit: filed issue %s for PR #%d in %s",
+                                    issue_url,
+                                    pr_number,
+                                    slug,
+                                )
+                            else:
+                                logger.warning(
+                                    "PR review audit: gh issue create failed for PR #%d in %s: %s",
+                                    pr_number,
+                                    slug,
+                                    issue_result.stderr[:200],
+                                )
+
+                            # Mark all findings as audited in Redis
+                            for f in unaddressed_for_pr:
+                                PRReviewAudit.mark_audited(
+                                    comment_key=f["comment_key"],
+                                    repo=repo,
+                                    pr_number=pr_number,
+                                    severity=f["severity"],
+                                    issue_url=issue_url,
+                                )
+
+                            self.state.add_finding(
+                                f"{slug}:pr_review_audit",
+                                f"Filed issue for PR #{pr_number}: "
+                                f"{len(unaddressed_for_pr)} unaddressed findings -> {issue_url}",
+                            )
+
+                        except Exception as e:
+                            logger.warning(
+                                "PR review audit: issue creation failed for PR #%d in %s: %s",
+                                pr_number,
+                                slug,
+                                str(e)[:200],
+                            )
+
+                    except Exception as e:
+                        logger.warning(
+                            "PR review audit: failed processing PR #%d in %s: %s",
+                            pr_number,
+                            slug,
+                            str(e)[:200],
+                        )
+                        continue
+
+            except Exception as e:
+                logger.warning(
+                    "PR review audit: failed for project %s: %s",
+                    slug,
+                    str(e)[:200],
+                )
+                continue
+
+        self.state.step_progress["pr_review_audit"] = {
+            "prs_scanned": prs_scanned,
+            "findings_total": findings_total,
+            "findings_unaddressed": findings_unaddressed,
+            "issues_filed": issues_filed,
+            "dry_run": dry_run,
+        }
+
+        if findings_unaddressed > 0:
+            logger.info(
+                "PR review audit: %d unaddressed findings across %d PRs, %d issues filed",
+                findings_unaddressed,
+                prs_scanned,
+                issues_filed,
+            )
+        else:
+            logger.info("PR review audit: scanned %d PRs, no unaddressed findings", prs_scanned)
+
     async def step_session_intelligence(self) -> None:
         """Pipeline: Session Analysis → LLM Reflection → Bug Filing.
 
@@ -2226,6 +2742,7 @@ class ReflectionsState:
     session_analysis: dict[str, Any] = field(default_factory=dict)
     reflections: list[dict[str, str]] = field(default_factory=list)
     auto_fix_attempts: list[dict] = field(default_factory=list)
+    dry_run: bool = False
 
     def save(self) -> None:
         """Save state to Redis ReflectionRun model."""
@@ -2249,7 +2766,7 @@ class ReflectionsState:
             auto_fix_attempts=self.auto_fix_attempts,
             step_progress=self.step_progress,
             started_at=started_at,
-            dry_run=getattr(self, "_dry_run", False),
+            dry_run=self.dry_run,
         )
 
     def add_finding(self, category: str, finding: str) -> None:
@@ -2298,7 +2815,7 @@ async def main() -> None:
 
     runner = ReflectionRunner()
     if args.dry_run:
-        runner.state._dry_run = True
+        runner.state.dry_run = True
         logger.info("DRY RUN mode — no side effects will be triggered")
     await runner.run()
 

--- a/tests/unit/test_pr_review_audit.py
+++ b/tests/unit/test_pr_review_audit.py
@@ -1,0 +1,345 @@
+"""Tests for PR review audit reflection step (step 20).
+
+Tests the finding parser, severity classification, address detection,
+issue body formatting, and step registration.
+"""
+
+from __future__ import annotations
+
+from scripts.reflections import (
+    SEVERITY_LABELS,
+    SEVERITY_MAP,
+    ReflectionRunner,
+    check_finding_addressed,
+    format_audit_issue_body,
+    parse_review_findings,
+)
+
+# --- parse_review_findings tests ---
+
+
+class TestParseReviewFindings:
+    """Tests for the structured finding parser."""
+
+    def test_well_formed_finding(self):
+        """Parse a complete, well-formed review finding."""
+        body = (
+            "**Severity:** blocker\n"
+            "**File:** `src/main.py`\n"
+            "**Code:** `do_thing()`\n"
+            "**Issue:** This function has no error handling\n"
+            "**Fix:** Wrap in try/except with proper logging\n"
+        )
+        findings = parse_review_findings(body)
+        assert len(findings) == 1
+        f = findings[0]
+        assert f["severity"] == "critical"
+        assert f["raw_severity"] == "blocker"
+        assert f["file_path"] == "src/main.py"
+        assert f["code"] == "do_thing()"
+        assert "no error handling" in f["issue_description"]
+        assert "try/except" in f["suggested_fix"]
+
+    def test_tech_debt_severity(self):
+        body = "**Severity:** tech_debt\n**Issue:** Should refactor this module\n"
+        findings = parse_review_findings(body)
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "standard"
+        assert findings[0]["raw_severity"] == "tech_debt"
+
+    def test_nit_severity(self):
+        body = "**Severity:** nit\n**Issue:** Typo in variable name\n"
+        findings = parse_review_findings(body)
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "trivial"
+
+    def test_partial_finding_no_file(self):
+        """Finding with only Severity and Issue (minimum required fields)."""
+        body = "**Severity:** blocker\n**Issue:** Critical logic error in auth flow\n"
+        findings = parse_review_findings(body)
+        assert len(findings) == 1
+        assert findings[0]["file_path"] == ""
+        assert findings[0]["code"] == ""
+        assert findings[0]["suggested_fix"] == ""
+
+    def test_missing_issue_field_skipped(self):
+        """Finding without Issue field is skipped (minimum not met)."""
+        body = "**Severity:** blocker\n**File:** `src/main.py`\n"
+        findings = parse_review_findings(body)
+        assert len(findings) == 0
+
+    def test_no_structured_format(self):
+        """Free-text comment without structured markers returns empty."""
+        body = "This looks good! Nice work on the refactoring."
+        findings = parse_review_findings(body)
+        assert len(findings) == 0
+
+    def test_empty_body(self):
+        findings = parse_review_findings("")
+        assert len(findings) == 0
+
+    def test_none_body(self):
+        findings = parse_review_findings(None)
+        assert len(findings) == 0
+
+    def test_multiple_findings_in_one_comment(self):
+        """Multiple structured findings in a single comment body."""
+        body = (
+            "**Severity:** blocker\n"
+            "**File:** `auth.py`\n"
+            "**Issue:** SQL injection vulnerability\n"
+            "**Fix:** Use parameterized queries\n"
+            "\n"
+            "**Severity:** nit\n"
+            "**File:** `utils.py`\n"
+            "**Issue:** Unused import\n"
+        )
+        findings = parse_review_findings(body)
+        assert len(findings) == 2
+        assert findings[0]["severity"] == "critical"
+        assert findings[0]["file_path"] == "auth.py"
+        assert findings[1]["severity"] == "trivial"
+        assert findings[1]["file_path"] == "utils.py"
+
+    def test_multiple_findings_get_unique_dedup_keys(self):
+        """Each finding in a multi-finding comment must get a distinct dedup key.
+
+        Regression test: previously all findings from one comment shared a
+        comment-level key, so auditing one finding silently skipped the rest.
+        """
+        body = (
+            "**Severity:** blocker\n"
+            "**File:** `auth.py`\n"
+            "**Issue:** SQL injection vulnerability\n"
+            "\n"
+            "**Severity:** nit\n"
+            "**File:** `utils.py`\n"
+            "**Issue:** Unused import\n"
+        )
+        findings = parse_review_findings(body)
+        assert len(findings) == 2
+
+        # Simulate key generation as done in step_20_pr_review_audit
+        repo = "owner/repo"
+        pr_number = 42
+        comment_id = 999
+        keys = []
+        for finding_idx, _finding in enumerate(findings):
+            keys.append(f"{repo}:{pr_number}:{comment_id}:{finding_idx}")
+
+        # Keys must be unique per finding
+        assert len(set(keys)) == len(keys)
+        assert keys[0] != keys[1]
+        assert keys[0].endswith(":0")
+        assert keys[1].endswith(":1")
+
+    def test_case_insensitive_severity(self):
+        body = "**Severity:** BLOCKER\n**Issue:** Something critical\n"
+        findings = parse_review_findings(body)
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "critical"
+
+    def test_file_path_without_backticks(self):
+        body = (
+            "**Severity:** tech_debt\n**File:** src/models/user.py\n**Issue:** Missing docstring\n"
+        )
+        findings = parse_review_findings(body)
+        assert len(findings) == 1
+        assert findings[0]["file_path"] == "src/models/user.py"
+
+
+# --- Severity mapping tests ---
+
+
+class TestSeverityMapping:
+    def test_all_severities_mapped(self):
+        assert SEVERITY_MAP["blocker"] == "critical"
+        assert SEVERITY_MAP["tech_debt"] == "standard"
+        assert SEVERITY_MAP["nit"] == "trivial"
+
+    def test_all_labels_mapped(self):
+        assert SEVERITY_LABELS["critical"] == "critical"
+        assert SEVERITY_LABELS["standard"] == "tech-debt"
+        assert SEVERITY_LABELS["trivial"] == "nit"
+
+
+# --- check_finding_addressed tests ---
+
+
+class TestCheckFindingAddressed:
+    def test_file_modified_after_review(self):
+        commits = [
+            {
+                "commit": {"committer": {"date": "2026-03-25T12:00:00Z"}},
+                "files": [{"filename": "src/main.py"}],
+            }
+        ]
+        assert check_finding_addressed(commits, "2026-03-25T10:00:00Z", "src/main.py") is True
+
+    def test_file_modified_before_review(self):
+        commits = [
+            {
+                "commit": {"committer": {"date": "2026-03-25T08:00:00Z"}},
+                "files": [{"filename": "src/main.py"}],
+            }
+        ]
+        assert check_finding_addressed(commits, "2026-03-25T10:00:00Z", "src/main.py") is False
+
+    def test_different_file_modified(self):
+        commits = [
+            {
+                "commit": {"committer": {"date": "2026-03-25T12:00:00Z"}},
+                "files": [{"filename": "src/other.py"}],
+            }
+        ]
+        assert check_finding_addressed(commits, "2026-03-25T10:00:00Z", "src/main.py") is False
+
+    def test_empty_commits(self):
+        assert check_finding_addressed([], "2026-03-25T10:00:00Z", "src/main.py") is False
+
+    def test_empty_file_path(self):
+        commits = [
+            {
+                "commit": {"committer": {"date": "2026-03-25T12:00:00Z"}},
+                "files": [{"filename": "src/main.py"}],
+            }
+        ]
+        assert check_finding_addressed(commits, "2026-03-25T10:00:00Z", "") is False
+
+    def test_multiple_commits_one_addresses(self):
+        commits = [
+            {
+                "commit": {"committer": {"date": "2026-03-25T08:00:00Z"}},
+                "files": [{"filename": "src/other.py"}],
+            },
+            {
+                "commit": {"committer": {"date": "2026-03-25T14:00:00Z"}},
+                "files": [{"filename": "src/main.py"}],
+            },
+        ]
+        assert check_finding_addressed(commits, "2026-03-25T10:00:00Z", "src/main.py") is True
+
+
+# --- format_audit_issue_body tests ---
+
+
+class TestFormatAuditIssueBody:
+    def test_basic_formatting(self):
+        findings = [
+            {
+                "severity": "critical",
+                "file_path": "auth.py",
+                "code": "login()",
+                "issue_description": "No rate limiting",
+                "suggested_fix": "Add rate limiter",
+                "review_url": "https://github.com/repo/pull/1#comment-123",
+            }
+        ]
+        body = format_audit_issue_body(1, "Fix auth", "https://github.com/repo/pull/1", findings)
+        assert "PR #1" in body or "#1" in body
+        assert "Fix auth" in body
+        assert "auth.py" in body
+        assert "No rate limiting" in body
+        assert "Add rate limiter" in body
+        assert "Critical" in body
+        assert "step 20" in body
+
+    def test_multiple_severities_grouped(self):
+        findings = [
+            {
+                "severity": "critical",
+                "file_path": "a.py",
+                "issue_description": "Critical bug",
+                "review_url": "",
+            },
+            {
+                "severity": "trivial",
+                "file_path": "b.py",
+                "issue_description": "Typo",
+                "review_url": "",
+            },
+        ]
+        body = format_audit_issue_body(2, "Some PR", "https://url", findings)
+        assert "Critical" in body
+        assert "Trivial" in body
+        # Critical should come before Trivial
+        assert body.index("Critical") < body.index("Trivial")
+
+    def test_empty_optional_fields(self):
+        findings = [
+            {
+                "severity": "standard",
+                "file_path": "",
+                "code": "",
+                "issue_description": "Some issue",
+                "suggested_fix": "",
+                "review_url": "",
+            }
+        ]
+        body = format_audit_issue_body(3, "PR title", "https://url", findings)
+        assert "Some issue" in body
+        assert "Standard" in body
+
+
+# --- ReflectionRunner registration tests ---
+
+
+class TestReflectionsStateDryRun:
+    """Verify dry_run is a proper public field on ReflectionsState."""
+
+    def test_dry_run_default_false(self):
+        from scripts.reflections import ReflectionsState
+
+        state = ReflectionsState()
+        assert state.dry_run is False
+
+    def test_dry_run_settable(self):
+        from scripts.reflections import ReflectionsState
+
+        state = ReflectionsState()
+        state.dry_run = True
+        assert state.dry_run is True
+
+
+class TestStepRegistration:
+    def test_pr_review_audit_registered(self):
+        """PR Review Audit step must be in the steps list."""
+        runner = ReflectionRunner()
+        step_keys = [s[0] for s in runner.steps]
+        assert "pr_review_audit" in step_keys
+
+    def test_pr_review_audit_name(self):
+        runner = ReflectionRunner()
+        step = [s for s in runner.steps if s[0] == "pr_review_audit"][0]
+        assert step[1] == "PR Review Audit"
+
+    def test_pr_review_audit_callable(self):
+        runner = ReflectionRunner()
+        step = [s for s in runner.steps if s[0] == "pr_review_audit"][0]
+        import asyncio
+
+        assert asyncio.iscoroutinefunction(step[2])
+
+
+# --- PRReviewAudit model tests ---
+
+
+class TestPRReviewAuditModel:
+    """Test that the model is importable and has expected interface."""
+
+    def test_importable(self):
+        from models.reflections import PRReviewAudit
+
+        assert PRReviewAudit is not None
+
+    def test_has_expected_classmethods(self):
+        from models.reflections import PRReviewAudit
+
+        assert hasattr(PRReviewAudit, "is_audited")
+        assert hasattr(PRReviewAudit, "mark_audited")
+        assert hasattr(PRReviewAudit, "last_successful_run")
+        assert hasattr(PRReviewAudit, "cleanup_expired")
+        assert callable(PRReviewAudit.is_audited)
+        assert callable(PRReviewAudit.mark_audited)
+        assert callable(PRReviewAudit.last_successful_run)
+        assert callable(PRReviewAudit.cleanup_expired)

--- a/tests/unit/test_reflections.py
+++ b/tests/unit/test_reflections.py
@@ -415,7 +415,7 @@ class TestAutoFixStep:
         from scripts.reflections import ReflectionRunner
 
         runner = ReflectionRunner()
-        runner.state._dry_run = True
+        runner.state.dry_run = True
         runner.state.reflections = [
             {
                 "category": "code_bug",
@@ -448,7 +448,7 @@ class TestAutoFixStep:
         from scripts.reflections import ReflectionRunner
 
         runner = ReflectionRunner()
-        runner.state._dry_run = False
+        runner.state.dry_run = False
         runner.state.reflections = [
             {
                 "category": "code_bug",
@@ -482,7 +482,7 @@ class TestAutoFixStep:
         from scripts.reflections import ReflectionRunner
 
         runner = ReflectionRunner()
-        runner.state._dry_run = True
+        runner.state.dry_run = True
         runner.state.reflections = [
             {
                 "category": "misunderstanding",  # not code_bug
@@ -535,7 +535,7 @@ class TestAutoFixStep:
         from scripts.reflections import ReflectionRunner
 
         runner = ReflectionRunner()
-        runner.state._dry_run = False
+        runner.state.dry_run = False
         runner.state.reflections = [
             {
                 "category": "code_bug",
@@ -622,7 +622,7 @@ class TestCLIFlags:
         assert entries[0].reason == "known issue"
 
     def test_dry_run_flag_sets_state(self, tmp_path, monkeypatch):
-        """--dry-run sets runner.state._dry_run = True."""
+        """--dry-run sets runner.state.dry_run = True."""
         import asyncio
         import sys
         from unittest.mock import patch
@@ -639,7 +639,7 @@ class TestCLIFlags:
         with patch.object(reflections_mod.ReflectionRunner, "run", fake_run):
             asyncio.run(reflections_mod.main())
 
-        assert captured_runner["instance"].state._dry_run is True
+        assert captured_runner["instance"].state.dry_run is True
 
 
 # --- Step 14 Branch and Plan Cleanup ---


### PR DESCRIPTION
## Summary
- Adds step 20 (PR Review Audit) to the reflections maintenance system that scans merged PRs for unaddressed review findings and files GitHub issues
- New `PRReviewAudit` Popoto model for Redis-backed deduplication keyed by `{repo}:{pr_number}:{comment_id}`
- Regex parser extracts structured findings from do-pr-review format (`**Severity:**`, `**File:**`, `**Code:**`, `**Issue:**`, `**Fix:**`)
- Address detection via file-level commit history heuristic (if file modified after review, finding considered addressed)
- One GitHub issue per PR with unaddressed findings, grouped by severity, with labels `pr-review-audit` + severity labels
- 20 PR cap per project per run, per-project error isolation, dry-run support, Redis-down skip via preflight

## Test plan
- [x] 27 unit tests covering parser (well-formed, partial, malformed, empty, multiple findings, case-insensitive), severity mapping, address detection, issue body formatting, step registration, and model interface
- [x] All tests pass (`pytest tests/unit/test_pr_review_audit.py`)
- [x] Lint clean (`ruff check`)
- [x] Verification commands from plan all pass (step registered, model importable)
- [ ] Integration validation with real merged PRs (next stage)

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)