### PR TITLE
Replace residual magic strings with enum constants (PR #594 follow-up)

### DIFF
--- a/agent/job_queue.py
+++ b/agent/job_queue.py
@@ -22,7 +22,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from config.enums import SessionType
 from agent.branch_manager import (
     get_branch_state,
     get_plan_context,
@@ -31,6 +30,7 @@ from agent.branch_manager import (
 from agent.worktree_manager import WORKTREES_DIR, validate_workspace
 from bridge.response import REACTION_COMPLETE, REACTION_ERROR, REACTION_SUCCESS
 from bridge.session_logs import save_session_snapshot
+from config.enums import ChatMode, SessionType
 from models.agent_session import AgentSession
 
 logger = logging.getLogger(__name__)
@@ -2111,7 +2111,9 @@ async def _execute_job(job: Job) -> None:
         # Use reduced nudge cap for Q&A sessions
         _effective_nudge_cap = MAX_NUDGE_COUNT
         if agent_session:
-            if getattr(agent_session, "session_mode", None) == "qa" or getattr(agent_session, "qa_mode", False):
+            if getattr(agent_session, "session_mode", None) == ChatMode.QA or getattr(
+                agent_session, "qa_mode", False
+            ):
                 from agent.qa_handler import QA_MAX_NUDGE_COUNT
 
                 _effective_nudge_cap = QA_MAX_NUDGE_COUNT
@@ -2388,7 +2390,14 @@ async def _execute_job(job: Job) -> None:
     # Skip if a continuation job was enqueued (defer reaction to that job)
     if react_cb and not chat_state.defer_reaction:
         # Q&A sessions: clear the processing reaction instead of setting completion emoji
-        if agent_session and (getattr(agent_session, "session_mode", None) == "qa" or getattr(agent_session, "qa_mode", False)) and not task.error:
+        if (
+            agent_session
+            and (
+                getattr(agent_session, "session_mode", None) == ChatMode.QA
+                or getattr(agent_session, "qa_mode", False)
+            )
+            and not task.error
+        ):
             emoji = None  # Clear reaction
         elif task.error:
             emoji = REACTION_ERROR

--- a/bridge/summarizer.py
+++ b/bridge/summarizer.py
@@ -31,6 +31,7 @@ import anthropic
 import httpx
 
 from bridge.message_quality import PROCESS_NARRATION_PATTERNS as _PROCESS_NARRATION_PATTERNS
+from config.enums import ChatMode
 from config.models import MODEL_FAST, OPENROUTER_HAIKU
 from utils.api_keys import get_anthropic_api_key
 
@@ -958,7 +959,9 @@ def _build_summary_prompt(
                 recent = history[-5:]  # Last 5 entries
                 context_parts.append("Recent history: " + " | ".join(str(e) for e in recent))
         # Signal Q&A mode so the LLM uses prose format
-        if getattr(session, "session_mode", None) == "qa" or getattr(session, "qa_mode", False):
+        if getattr(session, "session_mode", None) == ChatMode.QA or getattr(
+            session, "qa_mode", False
+        ):
             context_parts.append("qa_mode=True (use conversational prose, no bullets or emoji)")
         if context_parts:
             context_section = "\n\nSession context:\n" + "\n".join(context_parts) + "\n"
@@ -1348,7 +1351,9 @@ def _compose_structured_summary(summary_text: str, session=None, is_completion: 
 
     # Q&A bypass: return prose directly without emoji prefix, bullet parsing,
     # or structured template. The LLM summary is already in conversational form.
-    if session and (getattr(session, "session_mode", None) == "qa" or getattr(session, "qa_mode", False)):
+    if session and (
+        getattr(session, "session_mode", None) == ChatMode.QA or getattr(session, "qa_mode", False)
+    ):
         return summary_text.strip()
 
     # Parse questions from LLM output

--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -217,11 +217,15 @@ class AgentSession(Model):
     def qa_mode(self) -> bool:
         """Backward-compatible property: True when session is in Q&A mode.
 
-        Reads session_mode first, falls back to the legacy ``qa_mode`` Redis
-        hash field for pre-migration sessions.  The legacy Popoto field was
-        renamed to ``_qa_mode_legacy`` to avoid colliding with this property,
-        but old sessions still store the value under the original ``qa_mode``
-        key.  We read both to cover all cases.
+        Reads session_mode first, falls back to the legacy ``_qa_mode_legacy``
+        Popoto field and a direct Redis hget for the original ``qa_mode`` key.
+
+        Note: The Popoto field ``_qa_mode_legacy`` stores under Redis key
+        ``_qa_mode_legacy``, NOT ``qa_mode``.  This means it does NOT read
+        data written by pre-rename sessions (which stored under ``qa_mode``).
+        The direct hget fallback on line ~236 covers that case.  The
+        ``_qa_mode_legacy`` check is defense-in-depth for any sessions that
+        may have written to the renamed field directly.
         """
         if self.session_mode == ChatMode.QA:
             return True

--- a/ui/data/sdlc.py
+++ b/ui/data/sdlc.py
@@ -15,6 +15,8 @@ import time
 
 from pydantic import BaseModel
 
+from config.enums import ChatMode
+
 logger = logging.getLogger(__name__)
 
 # SDLC stages in pipeline order (matches models/agent_session.py)
@@ -316,24 +318,26 @@ def _resolve_persona_display(session) -> str | None:
     if raw is None:
         return None
     if raw == "chat":
-        if getattr(session, "session_mode", None) == "qa" or getattr(session, "qa_mode", False):
+        if getattr(session, "session_mode", None) == ChatMode.QA or getattr(
+            session, "qa_mode", False
+        ):
             return "Q&A"
         return "PM"
-    if raw == "dev":
+    if raw == ChatMode.DEV:
         return "Dev"
     return _safe_str(raw)
 
 
 def _safe_str(val, default: str | None = None) -> str | None:
     """Return val as a string if it's a real value, else default."""
-    if val is None or not isinstance(val, (str, int, float, bool)):
+    if val is None or not isinstance(val, str | int | float | bool):
         return default
     return str(val)
 
 
 def _safe_float(val) -> float | None:
     """Return val as a float if it's a real number, else None."""
-    if isinstance(val, (int, float)):
+    if isinstance(val, int | float):
         return float(val)
     if isinstance(val, str):
         try:


### PR DESCRIPTION
## Summary
- Replace raw `== "qa"` and `== "dev"` string comparisons with `ChatMode.QA` and `ChatMode.DEV` enum constants in production code (`agent/job_queue.py`, `bridge/summarizer.py`, `ui/data/sdlc.py`)
- Correct the `qa_mode` property docstring in `models/agent_session.py` to accurately document that `_qa_mode_legacy` does NOT read pre-rename Redis data (the direct `hget` fallback covers that case)
- Left `agent/qa_metrics.py` and `agent/intent_classifier.py` unchanged -- those compare against LLM-returned intent strings, not internal routing enums

Addresses review findings from PR #594.

## Test plan
- [x] `pytest tests/unit/test_enums.py tests/unit/test_qa_nudge_cap.py tests/unit/test_routing_mode.py` -- 46/46 passed
- [x] Ruff lint and format pass