### PR TITLE
Add LLM-judged outcome detection and outcome history (#613)

### DIFF
--- a/agent/memory_extraction.py
+++ b/agent/memory_extraction.py
@@ -4,7 +4,8 @@ Extracts novel observations from agent response text via Haiku,
 saves them as Memory records with category-based importance levels.
 
 Detects outcomes by comparing injected thoughts against response
-content using bigram overlap, feeds results into ObservationProtocol.
+content using LLM judgment (with bigram fallback), feeds results
+into ObservationProtocol.
 
 All operations are async, wrapped in try/except — failures must never
 crash the agent or block session completion.
@@ -16,6 +17,7 @@ import json
 import logging
 import os
 import re
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -330,6 +332,114 @@ async def extract_post_merge_learning(
         return None
 
 
+# Outcome judgment prompt for Haiku — classifies influence of injected thoughts
+# Uses double-braces {{}} to escape literal braces from str.format()
+OUTCOME_JUDGMENT_PROMPT = (
+    "You are evaluating whether injected memory thoughts influenced an agent's response.\n"
+    "For each thought below, classify its relationship to the response as:\n"
+    '  "acted" — the response was meaningfully influenced by this memory\n'
+    '  "echoed" — keywords overlap but no causal link (coincidental)\n'
+    '  "dismissed" — no relationship between memory and response\n'
+    "\n"
+    "Return a JSON array with one object per thought, each with:\n"
+    '  "index": the 0-based index of the thought\n'
+    '  "outcome": "acted", "echoed", or "dismissed"\n'
+    '  "reasoning": one sentence explaining your judgment\n'
+    "\n"
+    "Example:\n"
+    '[{{"index": 0, "outcome": "acted",'
+    ' "reasoning": "Response adopted the deployment strategy."}}]\n'
+    "\n"
+    "Thoughts:\n{thoughts}\n\n"
+    "---\n\n"
+    "Agent response:\n{response}"
+)
+
+# Truncation bounds for outcome judgment
+_OUTCOME_RESPONSE_MAX_CHARS = 4000
+_OUTCOME_THOUGHT_MAX_CHARS = 500
+_OUTCOME_MAX_THOUGHTS = 5
+
+
+def _judge_outcomes_llm(
+    injected_thoughts: list[tuple[str, str]],
+    response_text: str,
+) -> dict[str, dict] | None:
+    """Use Haiku to judge whether injected thoughts influenced the response.
+
+    Returns dict of {memory_key: {"outcome": str, "reasoning": str}} or None
+    on failure. Callers should fall back to bigram overlap when this returns None.
+
+    Maps "echoed" to "dismissed" for ObservationProtocol compatibility --
+    echoed keywords without causal influence are noise, not signal.
+    """
+    try:
+        import anthropic
+
+        from config.models import MODEL_FAST
+        from utils.api_keys import get_anthropic_api_key
+
+        api_key = get_anthropic_api_key()
+        if not api_key:
+            return None
+
+        # Apply truncation bounds
+        capped_thoughts = injected_thoughts[:_OUTCOME_MAX_THOUGHTS]
+        thoughts_text = "\n".join(
+            f"[{i}] {content[:_OUTCOME_THOUGHT_MAX_CHARS]}"
+            for i, (_key, content) in enumerate(capped_thoughts)
+        )
+        truncated_response = response_text[:_OUTCOME_RESPONSE_MAX_CHARS]
+
+        prompt = OUTCOME_JUDGMENT_PROMPT.format(
+            thoughts=thoughts_text,
+            response=truncated_response,
+        )
+
+        client = anthropic.Anthropic(api_key=api_key)
+        message = client.messages.create(
+            model=MODEL_FAST,
+            max_tokens=300,
+            messages=[{"role": "user", "content": prompt}],
+        )
+
+        raw_text = message.content[0].text.strip()
+        judgments = json.loads(raw_text)
+
+        if not isinstance(judgments, list):
+            return None
+
+        result: dict[str, dict] = {}
+        for item in judgments:
+            if not isinstance(item, dict):
+                continue
+            idx = item.get("index")
+            if not isinstance(idx, int) or idx < 0 or idx >= len(capped_thoughts):
+                continue
+            outcome = item.get("outcome", "dismissed")
+            reasoning = item.get("reasoning", "")
+
+            # Map "echoed" to "dismissed" for ObservationProtocol compatibility
+            if outcome == "echoed":
+                outcome = "dismissed"
+            elif outcome not in ("acted", "dismissed"):
+                outcome = "dismissed"
+
+            memory_key = capped_thoughts[idx][0]
+            result[memory_key] = {"outcome": outcome, "reasoning": str(reasoning)[:200]}
+
+        # Fill in any thoughts that weren't covered by the LLM response
+        for i, (key, _content) in enumerate(capped_thoughts):
+            if key not in result:
+                result[key] = {"outcome": "dismissed", "reasoning": "not classified by judge"}
+
+        return result
+
+    except Exception as e:
+        logger.debug(f"[memory_extraction] LLM outcome judgment failed, will use fallback: {e}")
+        return None
+
+
 def _extract_bigrams(text: str) -> set[tuple[str, ...]]:
     """Extract unigrams and bigrams from text for overlap detection.
 
@@ -344,12 +454,19 @@ def _extract_bigrams(text: str) -> set[tuple[str, ...]]:
 def _persist_outcome_metadata(
     memories: list,
     outcome_map: dict[str, str],
+    reasoning_map: dict[str, str] | None = None,
 ) -> None:
     """Persist dismissal/acted outcome data in Memory metadata.
 
-    Updates dismissal_count and last_outcome in each memory's metadata dict.
-    When dismissal_count reaches the threshold, decays importance.
-    Resets dismissal_count on "acted" outcomes.
+    Updates dismissal_count, last_outcome, and outcome_history in each
+    memory's metadata dict. When dismissal_count reaches the threshold,
+    decays importance. Resets dismissal_count on "acted" outcomes.
+
+    Args:
+        memories: List of Memory instances to update.
+        outcome_map: Dict of {memory_id: "acted"|"dismissed"}.
+        reasoning_map: Optional dict of {memory_id: reasoning_string}
+            from LLM judge. If absent, reasoning defaults to empty string.
 
     Runs after ObservationProtocol to avoid conflicting saves.
     All exceptions are caught per-record -- one failure does not block others.
@@ -357,8 +474,12 @@ def _persist_outcome_metadata(
     from config.memory_defaults import (
         DISMISSAL_DECAY_THRESHOLD,
         DISMISSAL_IMPORTANCE_DECAY,
+        MAX_OUTCOME_HISTORY,
         MIN_IMPORTANCE_FLOOR,
     )
+
+    if reasoning_map is None:
+        reasoning_map = {}
 
     for m in memories:
         mid = getattr(m, "memory_id", "")
@@ -369,6 +490,22 @@ def _persist_outcome_metadata(
             meta = getattr(m, "metadata", None) or {}
             if not isinstance(meta, dict):
                 meta = {}
+
+            # Append to outcome_history (capped at MAX_OUTCOME_HISTORY)
+            history = meta.get("outcome_history", [])
+            if not isinstance(history, list):
+                history = []
+            history.append(
+                {
+                    "outcome": outcome,
+                    "reasoning": reasoning_map.get(mid, ""),
+                    "ts": int(time.time()),
+                }
+            )
+            # Keep only the most recent entries
+            if len(history) > MAX_OUTCOME_HISTORY:
+                history = history[-MAX_OUTCOME_HISTORY:]
+            meta["outcome_history"] = history
 
             if outcome == "dismissed":
                 meta["dismissal_count"] = meta.get("dismissal_count", 0) + 1
@@ -396,14 +533,26 @@ def _persist_outcome_metadata(
             continue  # fail-silent per record
 
 
+def compute_act_rate(outcome_history: list[dict]) -> float | None:
+    """Compute the act rate from an outcome history list.
+
+    Returns the ratio of "acted" outcomes to total outcomes, or None if
+    the history is empty.
+    """
+    if not outcome_history:
+        return None
+    acted = sum(1 for entry in outcome_history if entry.get("outcome") == "acted")
+    return acted / len(outcome_history)
+
+
 async def detect_outcomes_async(
     injected_thoughts: list[tuple[str, str]],
     response_text: str,
 ) -> dict[str, str]:
     """Compare injected thoughts against response content.
 
-    Uses bigram (1-2 word phrase) overlap for v1.
-    Non-empty overlap -> "acted", empty -> "dismissed".
+    Uses LLM judgment (Haiku) as the primary signal. Falls back to bigram
+    (1-2 word phrase) overlap when the LLM call fails or is unavailable.
 
     Feeds results into ObservationProtocol.on_context_used().
 
@@ -413,20 +562,35 @@ async def detect_outcomes_async(
         return {}
 
     try:
-        response_bigrams = _extract_bigrams(response_text)
         outcome_map: dict[str, str] = {}
+        reasoning_map: dict[str, str] = {}
         memory_keys: list[str] = []
 
-        for memory_key, thought_content in injected_thoughts:
-            thought_bigrams = _extract_bigrams(thought_content)
-            overlap = thought_bigrams & response_bigrams
+        # Try LLM judgment first
+        llm_result = _judge_outcomes_llm(injected_thoughts, response_text)
 
-            if overlap:
-                outcome_map[memory_key] = "acted"
-            else:
-                outcome_map[memory_key] = "dismissed"
+        if llm_result is not None:
+            # LLM judgment succeeded -- use it
+            for memory_key, thought_content in injected_thoughts:
+                judgment = llm_result.get(memory_key, {})
+                outcome_map[memory_key] = judgment.get("outcome", "dismissed")
+                reasoning_map[memory_key] = judgment.get("reasoning", "")
+                memory_keys.append(memory_key)
+            logger.debug("[memory_extraction] Used LLM judgment for outcome detection")
+        else:
+            # Fallback to bigram overlap
+            response_bigrams = _extract_bigrams(response_text)
+            for memory_key, thought_content in injected_thoughts:
+                thought_bigrams = _extract_bigrams(thought_content)
+                overlap = thought_bigrams & response_bigrams
 
-            memory_keys.append(memory_key)
+                if overlap:
+                    outcome_map[memory_key] = "acted"
+                else:
+                    outcome_map[memory_key] = "dismissed"
+
+                memory_keys.append(memory_key)
+            logger.debug("[memory_extraction] Used bigram fallback for outcome detection")
 
         # Feed into ObservationProtocol
         try:
@@ -463,9 +627,9 @@ async def detect_outcomes_async(
                         f"{acted} acted, {dismissed} dismissed"
                     )
 
-                # Persist dismissal/acted data in metadata
+                # Persist dismissal/acted data in metadata (with reasoning)
                 # Done after ObservationProtocol to avoid conflicting saves
-                _persist_outcome_metadata(memories, outcome_map)
+                _persist_outcome_metadata(memories, outcome_map, reasoning_map)
 
         except Exception as e:
             logger.warning(f"[memory_extraction] ObservationProtocol failed (non-fatal): {e}")

--- a/config/memory_defaults.py
+++ b/config/memory_defaults.py
@@ -66,6 +66,9 @@ DISMISSAL_DECAY_THRESHOLD = 3  # consecutive dismissals before importance decays
 DISMISSAL_IMPORTANCE_DECAY = 0.7  # multiply importance by this on threshold breach
 MIN_IMPORTANCE_FLOOR = 0.2  # never decay below this
 
+# Outcome history -- how many outcome entries to keep per memory
+MAX_OUTCOME_HISTORY = 10
+
 # Category recall weights -- post-fusion re-ranking multipliers for memory recall.
 # After RRF fusion returns scored results, each result's effective score is
 # multiplied by the weight for its category before re-sorting. Higher weight = more

--- a/models/memory.py
+++ b/models/memory.py
@@ -18,8 +18,6 @@ from config.memory_defaults import apply_defaults
 # Apply tuned defaults before model definition
 apply_defaults()
 
-from popoto.fields.existence_filter import ExistenceFilter  # noqa: E402
-
 from popoto import (  # noqa: E402
     AccessTrackerMixin,
     AutoKeyField,
@@ -33,6 +31,7 @@ from popoto import (  # noqa: E402
     StringField,
     WriteFilterMixin,
 )
+from popoto.fields.existence_filter import ExistenceFilter  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +66,10 @@ class Memory(WriteFilterMixin, AccessTrackerMixin, Model):
             tool_names (list[str]): Tool names from the session context
             dismissal_count (int): Consecutive dismissals before reset
             last_outcome (str): "acted" or "dismissed"
+            outcome_history (list[dict]): Last N outcome entries, each with:
+                outcome (str): "acted" or "dismissed"
+                reasoning (str): One-sentence LLM explanation
+                ts (int): Unix timestamp of the outcome
         relevance: Decay-sorted index, partitioned by project_key.
         confidence: Bayesian confidence, updated by ObservationProtocol.
         bm25: BM25 keyword search index on content for ranked retrieval.

--- a/tests/unit/test_memory_extraction.py
+++ b/tests/unit/test_memory_extraction.py
@@ -533,6 +533,330 @@ class TestPersistOutcomeMetadata:
         assert m.metadata["dismissal_count"] == 1
 
 
+class TestJudgeOutcomesLlm:
+    """Test agent/memory_extraction.py _judge_outcomes_llm()."""
+
+    def test_parses_valid_llm_response(self):
+        import json
+        from unittest.mock import MagicMock, patch
+
+        from agent.memory_extraction import _judge_outcomes_llm
+
+        llm_response = json.dumps(
+            [
+                {
+                    "index": 0,
+                    "outcome": "acted",
+                    "reasoning": "Response used the deployment strategy.",
+                },
+                {"index": 1, "outcome": "dismissed", "reasoning": "No relationship found."},
+            ]
+        )
+
+        mock_message = MagicMock()
+        mock_message.content = [MagicMock(text=llm_response)]
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = mock_message
+
+        with (
+            patch("anthropic.Anthropic", return_value=mock_client),
+            patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
+        ):
+            result = _judge_outcomes_llm(
+                [("key1", "use blue-green deployment"), ("key2", "kubernetes config")],
+                "We deployed using blue-green strategy.",
+            )
+
+        assert result is not None
+        assert result["key1"]["outcome"] == "acted"
+        assert result["key2"]["outcome"] == "dismissed"
+        assert "deployment" in result["key1"]["reasoning"]
+
+    def test_echoed_maps_to_dismissed(self):
+        import json
+        from unittest.mock import MagicMock, patch
+
+        from agent.memory_extraction import _judge_outcomes_llm
+
+        llm_response = json.dumps(
+            [
+                {
+                    "index": 0,
+                    "outcome": "echoed",
+                    "reasoning": "Keywords overlap but no causal link.",
+                },
+            ]
+        )
+
+        mock_message = MagicMock()
+        mock_message.content = [MagicMock(text=llm_response)]
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = mock_message
+
+        with (
+            patch("anthropic.Anthropic", return_value=mock_client),
+            patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
+        ):
+            result = _judge_outcomes_llm(
+                [("key1", "redis connection pooling")],
+                "Redis connections are managed via pooling.",
+            )
+
+        assert result is not None
+        assert result["key1"]["outcome"] == "dismissed"
+
+    def test_returns_none_on_api_failure(self):
+        from unittest.mock import patch
+
+        from agent.memory_extraction import _judge_outcomes_llm
+
+        with patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"):
+            with patch("anthropic.Anthropic", side_effect=Exception("API down")):
+                result = _judge_outcomes_llm(
+                    [("key1", "some thought")],
+                    "some response",
+                )
+
+        assert result is None
+
+    def test_returns_none_when_no_api_key(self):
+        from unittest.mock import patch
+
+        from agent.memory_extraction import _judge_outcomes_llm
+
+        with patch("utils.api_keys.get_anthropic_api_key", return_value=None):
+            result = _judge_outcomes_llm(
+                [("key1", "some thought")],
+                "some response",
+            )
+
+        assert result is None
+
+    def test_fills_missing_thoughts(self):
+        """Thoughts not covered by LLM response get dismissed by default."""
+        import json
+        from unittest.mock import MagicMock, patch
+
+        from agent.memory_extraction import _judge_outcomes_llm
+
+        # LLM only returns judgment for index 0, not index 1
+        llm_response = json.dumps(
+            [
+                {"index": 0, "outcome": "acted", "reasoning": "Influenced the response."},
+            ]
+        )
+
+        mock_message = MagicMock()
+        mock_message.content = [MagicMock(text=llm_response)]
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = mock_message
+
+        with (
+            patch("anthropic.Anthropic", return_value=mock_client),
+            patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
+        ):
+            result = _judge_outcomes_llm(
+                [("key1", "thought one"), ("key2", "thought two")],
+                "response text",
+            )
+
+        assert result is not None
+        assert result["key1"]["outcome"] == "acted"
+        assert result["key2"]["outcome"] == "dismissed"
+
+    def test_caps_at_max_thoughts(self):
+        """Only first 5 thoughts are sent to the LLM."""
+        import json
+        from unittest.mock import MagicMock, patch
+
+        from agent.memory_extraction import _OUTCOME_MAX_THOUGHTS, _judge_outcomes_llm
+
+        # Create 7 thoughts
+        thoughts = [(f"key{i}", f"thought number {i} with enough text") for i in range(7)]
+
+        llm_response = json.dumps(
+            [
+                {"index": i, "outcome": "acted", "reasoning": "yes"}
+                for i in range(_OUTCOME_MAX_THOUGHTS)
+            ]
+        )
+
+        mock_message = MagicMock()
+        mock_message.content = [MagicMock(text=llm_response)]
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = mock_message
+
+        with (
+            patch("anthropic.Anthropic", return_value=mock_client),
+            patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
+        ):
+            result = _judge_outcomes_llm(thoughts, "response text")
+
+        assert result is not None
+        # Only the first 5 should be in the result
+        assert len(result) == _OUTCOME_MAX_THOUGHTS
+        assert "key5" not in result
+        assert "key6" not in result
+
+    def test_invalid_json_returns_none(self):
+        from unittest.mock import MagicMock, patch
+
+        from agent.memory_extraction import _judge_outcomes_llm
+
+        mock_message = MagicMock()
+        mock_message.content = [MagicMock(text="not valid json at all")]
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = mock_message
+
+        with (
+            patch("anthropic.Anthropic", return_value=mock_client),
+            patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
+        ):
+            result = _judge_outcomes_llm(
+                [("key1", "thought")],
+                "response",
+            )
+
+        assert result is None
+
+
+class TestComputeActRate:
+    """Test agent/memory_extraction.py compute_act_rate()."""
+
+    def test_empty_history(self):
+        from agent.memory_extraction import compute_act_rate
+
+        assert compute_act_rate([]) is None
+
+    def test_all_acted(self):
+        from agent.memory_extraction import compute_act_rate
+
+        history = [{"outcome": "acted"}, {"outcome": "acted"}]
+        assert compute_act_rate(history) == 1.0
+
+    def test_all_dismissed(self):
+        from agent.memory_extraction import compute_act_rate
+
+        history = [{"outcome": "dismissed"}, {"outcome": "dismissed"}]
+        assert compute_act_rate(history) == 0.0
+
+    def test_mixed(self):
+        from agent.memory_extraction import compute_act_rate
+
+        history = [
+            {"outcome": "acted"},
+            {"outcome": "dismissed"},
+            {"outcome": "acted"},
+            {"outcome": "dismissed"},
+        ]
+        assert compute_act_rate(history) == 0.5
+
+    def test_single_entry(self):
+        from agent.memory_extraction import compute_act_rate
+
+        assert compute_act_rate([{"outcome": "acted"}]) == 1.0
+        assert compute_act_rate([{"outcome": "dismissed"}]) == 0.0
+
+
+class TestOutcomeHistory:
+    """Test outcome_history persistence in _persist_outcome_metadata()."""
+
+    def test_appends_to_outcome_history(self):
+        from unittest.mock import MagicMock
+
+        from agent.memory_extraction import _persist_outcome_metadata
+
+        m = MagicMock()
+        m.memory_id = "mem1"
+        m.metadata = {}
+        m.importance = 2.0
+
+        _persist_outcome_metadata([m], {"mem1": "acted"}, {"mem1": "Response used the strategy"})
+
+        history = m.metadata["outcome_history"]
+        assert len(history) == 1
+        assert history[0]["outcome"] == "acted"
+        assert history[0]["reasoning"] == "Response used the strategy"
+        assert "ts" in history[0]
+
+    def test_caps_at_max_history(self):
+        from unittest.mock import MagicMock
+
+        from agent.memory_extraction import _persist_outcome_metadata
+        from config.memory_defaults import MAX_OUTCOME_HISTORY
+
+        m = MagicMock()
+        m.memory_id = "mem1"
+        # Pre-fill with MAX entries
+        m.metadata = {
+            "outcome_history": [
+                {"outcome": "dismissed", "reasoning": "", "ts": i}
+                for i in range(MAX_OUTCOME_HISTORY)
+            ]
+        }
+        m.importance = 2.0
+
+        _persist_outcome_metadata([m], {"mem1": "acted"}, {"mem1": "new entry"})
+
+        history = m.metadata["outcome_history"]
+        assert len(history) == MAX_OUTCOME_HISTORY
+        # The newest entry should be last
+        assert history[-1]["outcome"] == "acted"
+        assert history[-1]["reasoning"] == "new entry"
+        # The oldest entry (ts=0) should have been dropped
+        assert history[0]["ts"] == 1
+
+    def test_backward_compatible_no_history(self):
+        """Old memories without outcome_history get it initialized."""
+        from unittest.mock import MagicMock
+
+        from agent.memory_extraction import _persist_outcome_metadata
+
+        m = MagicMock()
+        m.memory_id = "mem1"
+        m.metadata = {"dismissal_count": 1, "last_outcome": "dismissed"}
+        m.importance = 2.0
+
+        _persist_outcome_metadata([m], {"mem1": "dismissed"})
+
+        assert "outcome_history" in m.metadata
+        assert len(m.metadata["outcome_history"]) == 1
+        assert m.metadata["outcome_history"][0]["outcome"] == "dismissed"
+
+    def test_reasoning_defaults_to_empty_string(self):
+        """When no reasoning_map provided, reasoning is empty string."""
+        from unittest.mock import MagicMock
+
+        from agent.memory_extraction import _persist_outcome_metadata
+
+        m = MagicMock()
+        m.memory_id = "mem1"
+        m.metadata = {}
+        m.importance = 2.0
+
+        _persist_outcome_metadata([m], {"mem1": "acted"})
+
+        history = m.metadata["outcome_history"]
+        assert history[0]["reasoning"] == ""
+
+    def test_corrupted_history_gets_reset(self):
+        """Non-list outcome_history is replaced with fresh list."""
+        from unittest.mock import MagicMock
+
+        from agent.memory_extraction import _persist_outcome_metadata
+
+        m = MagicMock()
+        m.memory_id = "mem1"
+        m.metadata = {"outcome_history": "corrupted"}
+        m.importance = 2.0
+
+        _persist_outcome_metadata([m], {"mem1": "acted"})
+
+        history = m.metadata["outcome_history"]
+        assert isinstance(history, list)
+        assert len(history) == 1
+
+
 class TestPersonaPromptContainsIntentionalMemory:
     """Verify the base persona prompt includes intentional memory instructions."""
 

--- a/tools/memory_search/__init__.py
+++ b/tools/memory_search/__init__.py
@@ -33,6 +33,7 @@ def search(
     limit: int = 10,
     category: str | None = None,
     tag: str | None = None,
+    min_act_rate: float | None = None,
 ) -> dict[str, Any]:
     """Search memories by query string using BM25 + RRF fusion.
 
@@ -42,6 +43,7 @@ def search(
         limit: Maximum number of results to return.
         category: Filter by metadata category (correction, decision, pattern, surprise).
         tag: Filter by metadata tag.
+        min_act_rate: Filter to memories with act_rate >= this threshold (0.0-1.0).
 
     Returns:
         Dict with "results" list and "error" key (None if no error).
@@ -103,6 +105,16 @@ def search(
                 for r in filtered_records
                 if tag in (getattr(r, "metadata", None) or {}).get("tags", [])
             ]
+        if min_act_rate is not None:
+            from agent.memory_extraction import compute_act_rate
+
+            def _passes_act_rate(r: object) -> bool:
+                meta = getattr(r, "metadata", None) or {}
+                history = meta.get("outcome_history", [])
+                rate = compute_act_rate(history)
+                return rate is not None and rate >= min_act_rate
+
+            filtered_records = [r for r in filtered_records if _passes_act_rate(r)]
 
         results = []
         for record in filtered_records[:limit]:
@@ -250,6 +262,66 @@ def inspect(
 
     except Exception as e:
         logger.warning(f"[memory_search] inspect failed (non-fatal): {e}")
+        return {"error": str(e)}
+
+
+def outcome_stats(
+    project_key: str | None = None,
+) -> dict[str, Any]:
+    """Get aggregate outcome statistics for memories with outcome history.
+
+    Args:
+        project_key: Project partition key. Resolved from env if not provided.
+
+    Returns:
+        Dict with total_with_history, avg_act_rate, and top_acted list.
+    """
+    try:
+        from agent.memory_extraction import compute_act_rate
+        from models.memory import Memory
+
+        project_key = _resolve_project_key(project_key)
+
+        try:
+            all_records = list(Memory.query.filter(project_key=project_key))
+        except Exception:
+            all_records = []
+
+        memories_with_history = []
+        for record in all_records:
+            meta = getattr(record, "metadata", None) or {}
+            history = meta.get("outcome_history", [])
+            if history:
+                rate = compute_act_rate(history)
+                memories_with_history.append(
+                    {
+                        "memory_id": getattr(record, "memory_id", ""),
+                        "content": getattr(record, "content", "")[:100],
+                        "act_rate": rate if rate is not None else 0.0,
+                        "total_outcomes": len(history),
+                    }
+                )
+
+        if not memories_with_history:
+            return {
+                "project_key": project_key,
+                "total_with_history": 0,
+                "avg_act_rate": 0.0,
+                "top_acted": [],
+            }
+
+        avg_rate = sum(m["act_rate"] for m in memories_with_history) / len(memories_with_history)
+        top_acted = sorted(memories_with_history, key=lambda m: m["act_rate"], reverse=True)[:5]
+
+        return {
+            "project_key": project_key,
+            "total_with_history": len(memories_with_history),
+            "avg_act_rate": round(avg_rate, 3),
+            "top_acted": top_acted,
+        }
+
+    except Exception as e:
+        logger.warning(f"[memory_search] outcome_stats failed (non-fatal): {e}")
         return {"error": str(e)}
 
 

--- a/tools/memory_search/cli.py
+++ b/tools/memory_search/cli.py
@@ -18,8 +18,9 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from datetime import UTC
 
-from tools.memory_search import forget, inspect, save, search
+from tools.memory_search import forget, inspect, outcome_stats, save, search
 
 
 def cmd_search(args: argparse.Namespace) -> int:
@@ -30,6 +31,7 @@ def cmd_search(args: argparse.Namespace) -> int:
         limit=args.limit,
         category=getattr(args, "category", None),
         tag=getattr(args, "tag", None),
+        min_act_rate=getattr(args, "act_rate", None),
     )
 
     if result.get("error"):
@@ -129,6 +131,28 @@ def cmd_inspect(args: argparse.Namespace) -> int:
             print(f"  Dismissal count: {meta['dismissal_count']}")
         if meta.get("last_outcome"):
             print(f"  Last outcome: {meta['last_outcome']}")
+        outcome_history = meta.get("outcome_history", [])
+        if outcome_history:
+            from datetime import datetime
+
+            from agent.memory_extraction import compute_act_rate
+
+            act_rate = compute_act_rate(outcome_history)
+            rate_str = f"{act_rate:.0%}" if act_rate is not None else "N/A"
+            print(f"  Act rate: {rate_str} ({len(outcome_history)} outcomes)")
+            print("  Outcome history:")
+            print(f"    {'Date':<20} {'Outcome':<12} {'Reasoning'}")
+            print(f"    {'-' * 20} {'-' * 12} {'-' * 40}")
+            for entry in outcome_history:
+                ts = entry.get("ts", 0)
+                dt_str = (
+                    datetime.fromtimestamp(ts, tz=UTC).strftime("%Y-%m-%d %H:%M")
+                    if ts
+                    else "unknown"
+                )
+                outcome_val = entry.get("outcome", "?")
+                reasoning_val = entry.get("reasoning", "")[:60]
+                print(f"    {dt_str:<20} {outcome_val:<12} {reasoning_val}")
     elif args.stats:
         # Aggregate stats
         print(f"Memory stats for project '{result.get('project_key', '')}':")
@@ -140,6 +164,41 @@ def cmd_inspect(args: argparse.Namespace) -> int:
                 print(f"    {src}: {count}")
         avg_conf = result.get("avg_confidence", 0.0)
         print(f"  Avg confidence: {avg_conf:.2f}")
+
+    return 0
+
+
+def cmd_stats(args: argparse.Namespace) -> int:
+    """Show outcome statistics."""
+    result = outcome_stats(project_key=args.project)
+
+    if args.json:
+        print(json.dumps(result, indent=2, default=str))
+        return 0
+
+    if "error" in result:
+        print(f"Error: {result['error']}", file=sys.stderr)
+        return 1
+
+    project = result.get("project_key", "")
+    total = result.get("total_with_history", 0)
+    avg_rate = result.get("avg_act_rate", 0.0)
+
+    print(f"Outcome statistics for project '{project}':")
+    print(f"  Memories with outcome history: {total}")
+    print(f"  Average act rate: {avg_rate:.1%}")
+
+    top_acted = result.get("top_acted", [])
+    if top_acted:
+        print()
+        print("  Top acted-on memories:")
+        for mem in top_acted:
+            content = mem.get("content", "")
+            rate = mem.get("act_rate", 0.0)
+            total_outcomes = mem.get("total_outcomes", 0)
+            mid = mem.get("memory_id", "")
+            print(f"    [{rate:.0%} over {total_outcomes}] {content}")
+            print(f"      id={mid}")
 
     return 0
 
@@ -195,6 +254,12 @@ def main() -> int:
         help="Filter by metadata category",
     )
     search_parser.add_argument("--tag", "-t", help="Filter by metadata tag")
+    search_parser.add_argument(
+        "--act-rate",
+        type=float,
+        default=None,
+        help="Filter to memories with act_rate >= threshold (0.0-1.0)",
+    )
 
     # save command
     save_parser = subparsers.add_parser("save", help="Save a new memory")
@@ -223,6 +288,11 @@ def main() -> int:
     inspect_parser.add_argument("--project", "-p", help="Project key (default: from env)")
     inspect_parser.add_argument("--json", action="store_true", help="Output as JSON")
 
+    # stats command
+    stats_parser = subparsers.add_parser("stats", help="Show outcome statistics")
+    stats_parser.add_argument("--project", "-p", help="Project key (default: from env)")
+    stats_parser.add_argument("--json", action="store_true", help="Output as JSON")
+
     # forget command
     forget_parser = subparsers.add_parser("forget", help="Delete a memory")
     forget_parser.add_argument("--id", required=True, help="Memory ID to delete")
@@ -243,6 +313,7 @@ def main() -> int:
         "search": cmd_search,
         "save": cmd_save,
         "inspect": cmd_inspect,
+        "stats": cmd_stats,
         "forget": cmd_forget,
     }
 


### PR DESCRIPTION
## Summary
- Replace bigram overlap with Haiku LLM judgment as primary outcome detection signal in `detect_outcomes_async()`, classifying each injected thought as acted/echoed/dismissed with reasoning. Bigram overlap retained as zero-cost fallback when the API call fails.
- Add `outcome_history` list to Memory metadata (capped at 10 entries), each with outcome, reasoning, and unix timestamp. Add `compute_act_rate()` helper for derived act rate.
- Surface outcome data in `memory_search` CLI: `inspect` shows formatted outcome history table, `search` accepts `--act-rate` filter, new `stats` subcommand shows aggregate outcome statistics.

## Test plan
- [x] All 62 unit tests pass in `tests/unit/test_memory_extraction.py`
- [ ] Verify LLM judge parsing with mocked Anthropic client (7 new tests)
- [ ] Verify fallback to bigram on API failure
- [ ] Verify outcome_history persistence: append, cap at 10, backward compat
- [ ] Verify "echoed" maps to "dismissed" for ObservationProtocol
- [ ] Verify `memory_search inspect` displays outcome history
- [ ] Verify `memory_search stats` shows aggregate data
- [ ] Verify `memory_search search --act-rate 0.5` filters correctly

Closes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)