### PR TITLE
Fix stale summarizer claims in pipeline docs and comments

### DIFF
--- a/bridge/pipeline_graph.py
+++ b/bridge/pipeline_graph.py
@@ -73,7 +73,7 @@ STAGE_TO_SKILL: dict[str, str] = {
 
 # Display-only linear stage list for progress templates and PM-facing messages.
 # PATCH is intentionally excluded -- it's a routing concept, not a display stage.
-# Used by PipelineStateMachine.get_display_progress() and summarizer rendering.
+# Used by PipelineStateMachine.get_display_progress() and bridge/coach.py.
 DISPLAY_STAGES: list[str] = [
     "ISSUE",
     "PLAN",

--- a/docs/features/pipeline-state-machine.md
+++ b/docs/features/pipeline-state-machine.md
@@ -121,7 +121,9 @@ Falls back to `"ambiguous"` for the Observer LLM to handle.
 - **SubagentStop hook** (`agent/hooks/subagent_stop.py`): Calls `complete_stage()` when the dev-session returns, marking the stage as `completed`
 - **ChatSession**: Uses state machine for stage queries and outcome classification
 - **Job Queue** (`agent/agent_session_queue.py`): Creates state machine in `send_to_chat()`, applies transitions from Observer decisions
-- **Summarizer** (`bridge/summarizer.py`): Reads `get_display_progress()` for Telegram stage rendering
+- **AgentSession** (`models/agent_session.py`): `get_stage_progress()` convenience wrapper around `get_display_progress()`
+- **Merge Gate** (`.claude/commands/do-merge.md`): Reads `get_display_progress()` for pre-merge pipeline validation
+- **Coach** (`bridge/coach.py`): Imports `DISPLAY_STAGES` for stage coaching logic
 
 ## What Was Deleted
 


### PR DESCRIPTION
## Summary
- Replace incorrect summarizer reference in `docs/features/pipeline-state-machine.md` Integration Points with actual callers (AgentSession, Merge Gate, Coach)
- Fix stale comment in `bridge/pipeline_graph.py` line 76 to reference `bridge/coach.py` instead of "summarizer rendering"

## Changes
- `docs/features/pipeline-state-machine.md`: Removed false claim that summarizer reads `get_display_progress()`. Added three verified integration points: AgentSession wrapper, Merge Gate, and Coach
- `bridge/pipeline_graph.py`: Updated comment on `DISPLAY_STAGES` to reference `bridge/coach.py` instead of "summarizer rendering"

## Testing
- [x] Grep confirms zero "summarizer" references in pipeline_graph.py
- [x] Grep confirms zero "Summarizer.*get_display_progress" in pipeline-state-machine.md
- [x] All listed integration points verified by grep against codebase
- [x] Lint clean (ruff check)

## Documentation
- [x] `docs/features/pipeline-state-machine.md` updated (this IS the deliverable)

## Definition of Done
- [x] Built: Documentation and comment corrected
- [x] Tested: Verification checks pass
- [x] Documented: Doc is the deliverable
- [x] Quality: Lint passes

Closes #653