### PR TITLE
Remove phantom references to non-existent bridge/coach.py

### DIFF
--- a/bridge/pipeline_graph.py
+++ b/bridge/pipeline_graph.py
@@ -73,7 +73,7 @@ STAGE_TO_SKILL: dict[str, str] = {
 
 # Display-only linear stage list for progress templates and PM-facing messages.
 # PATCH is intentionally excluded -- it's a routing concept, not a display stage.
-# Used by PipelineStateMachine.get_display_progress() and bridge/coach.py.
+# Used by PipelineStateMachine.get_display_progress().
 DISPLAY_STAGES: list[str] = [
     "ISSUE",
     "PLAN",

--- a/docs/features/pipeline-state-machine.md
+++ b/docs/features/pipeline-state-machine.md
@@ -149,7 +149,6 @@ Falls back to `"ambiguous"` when no pattern matches, for the Observer LLM to han
 - **Job Queue** (`agent/agent_session_queue.py`): Creates state machine in `send_to_chat()`, applies transitions from Observer decisions
 - **AgentSession** (`models/agent_session.py`): `get_stage_progress()` convenience wrapper around `get_display_progress()`
 - **Merge Gate** (`.claude/commands/do-merge.md`): Reads `get_display_progress()` for pre-merge pipeline validation
-- **Coach** (`bridge/coach.py`): Imports `DISPLAY_STAGES` for stage coaching logic
 
 ## What Was Deleted
 


### PR DESCRIPTION
## Summary
- Remove stale inline comment in `bridge/pipeline_graph.py` referencing `bridge/coach.py`
- Remove stale consumer bullet in `docs/features/pipeline-state-machine.md` for Coach (`bridge/coach.py`)

The file `bridge/coach.py` does not exist. These references were left behind from a previous cleanup.

Fixes #668

## Test plan
- [ ] Verify no remaining references to `bridge/coach.py` in the codebase
- [ ] Confirm `bridge/pipeline_graph.py` comment is still accurate