### PR TITLE
Fix broken tests and stale docs from unreviewed PRs #660-664

### DIFF
--- a/docs/features/reflections.md
+++ b/docs/features/reflections.md
@@ -51,7 +51,6 @@ reflections:
 | `orphan-recovery` | 30 min | normal | function | Recover stranded AgentSession objects |
 | `stale-branch-cleanup` | daily | low | function | Clean up session branches older than 72 hours |
 | `popoto-index-cleanup` | daily | low | function | Rebuild Popoto model indexes to remove orphaned entries (see [Popoto Index Hygiene](popoto-index-hygiene.md)) |
-| `daily-maintenance` | daily | low | function | Full 16-unit maintenance pipeline |
 
 ### State Model (`models/reflection.py`)
 
@@ -109,7 +108,7 @@ When the watchdog detects that the bridge process is not running (via `pgrep`), 
 
 ## Daily Maintenance Pipeline (16 Units)
 
-The `daily-maintenance` reflection runs the full pipeline from `scripts/reflections.py`. The runner loads state from Redis, executes each unit in order, and checkpoints after every unit. If interrupted, the next run resumes from where it left off. Each unit is independently failable — a crash in one unit does not block the rest.
+The daily maintenance pipeline runs from `scripts/reflections.py`. It is invoked manually or via launchd (not via the reflection scheduler -- the `daily-maintenance` registry entry was removed in PR #664). The runner loads state from Redis, executes each unit in order, and checkpoints after every unit. If interrupted, the next run resumes from where it left off. Each unit is independently failable -- a crash in one unit does not block the rest.
 
 The pipeline has 16 units: 13 independent items and 3 merged pipelines. Completed units are tracked by string key (e.g. `"legacy_code_scan"`), not by integer position. This means units can be reordered or renamed without data migrations — any unknown key in `completed_steps` is simply skipped.
 

--- a/docs/plans/unify-persona-vocabulary.md
+++ b/docs/plans/unify-persona-vocabulary.md
@@ -531,7 +531,7 @@ No agent integration required. No MCP server changes, no `.mcp.json` modificatio
 - **Severity**: CONCERN
 - **Critics**: Skeptic, Operator
 - **Location**: Scope table, Task 12 (validate-all)
-- **Finding**: Two Python files contain "Q&A" string references not listed in the plan's scope: `tools/job_scheduler.py` (line 4, docstring) and `bridge/coach.py` (line 356, comment). The Success Criteria require `grep -r "Q&A" --include="*.py"` to return zero results, so these must be updated or the grep will fail validation.
+- **Finding**: Two Python files contain "Q&A" string references not listed in the plan's scope: `tools/job_scheduler.py` (line 4, docstring) and `bridge/coach.py` [NOTE: `bridge/coach.py` was deleted by PR #661; this critique finding is now stale] (line 356, comment). The Success Criteria require `grep -r "Q&A" --include="*.py"` to return zero results, so these must be updated or the grep will fail validation.
 - **Suggestion**: Add both files to Task 7 or Task 8 scope. The fixes are trivial (docstring/comment text changes) but must be tracked to satisfy the zero-match grep criterion.
 
 #### 2. Summarizer dual-check pattern will break if qa_mode property is deleted

--- a/docs/plans/wire-pipeline-graph-563.md
+++ b/docs/plans/wire-pipeline-graph-563.md
@@ -15,7 +15,7 @@ last_comment_id:
 The SDLC pipeline has a graph-based routing system (`PIPELINE_EDGES` in `bridge/pipeline_graph.py`) that is well-designed, well-tested, and completely disconnected from the runtime execution path. Three separate routing implementations exist, only two are used at runtime, and neither uses the graph.
 
 **Current behavior:**
-- `_build_sdlc_stage_coaching()` in `bridge/coach.py` does a linear scan of `DISPLAY_STAGES` to find the first "pending" stage, ignoring the graph and its failure/cycle edges entirely
+- `_build_sdlc_stage_coaching()` in `bridge/coach.py` [NOTE: `bridge/coach.py` was deleted by PR #661; coaching logic moved to `bridge/session_coaching.py`] does a linear scan of `DISPLAY_STAGES` to find the first "pending" stage, ignoring the graph and its failure/cycle edges entirely
 - `_record_stage_on_parent()` in `agent/hooks/subagent_stop.py` always calls `complete_stage()`, never `fail_stage()` -- failed dev-sessions (test failures, review rejections) are recorded as successes
 - `classify_outcome()` in `bridge/pipeline_state.py` exists but is never called in production -- outcome detection from stop_reason and output patterns is dead code
 - `fail_stage()` exists but is never called in production -- the PATCH cycle path is dead code
@@ -44,7 +44,7 @@ The current (broken) flow when a dev-session completes:
 1. **Entry point**: DevSession finishes execution, SDK fires `subagent_stop` hook
 2. **`subagent_stop_hook()`** (`agent/hooks/subagent_stop.py`): Calls `_register_dev_session_completion()` which calls `_record_stage_on_parent()`
 3. **`_record_stage_on_parent()`**: Loads parent ChatSession, creates `PipelineStateMachine`, finds `current_stage()`, **always calls `complete_stage()`** regardless of actual outcome
-4. **Coach** (`bridge/coach.py`): On next auto-continue, `_build_sdlc_stage_coaching()` scans `DISPLAY_STAGES` linearly for the first "pending" stage, ignoring graph edges
+4. **Coach** (`bridge/coach.py` [deleted by PR #661; now `bridge/session_coaching.py`]): On next auto-continue, `_build_sdlc_stage_coaching()` scans `DISPLAY_STAGES` linearly for the first "pending" stage, ignoring graph edges
 5. **Dashboard** (`ui/data/sdlc.py`): If `stage_states` is empty, falls back to `_infer_stages_from_history()` heuristic
 
 The correct flow after this fix:
@@ -174,7 +174,7 @@ No update system changes required -- this feature is purely internal bridge/hook
 
 ## Agent Integration
 
-No agent integration required -- this is a bridge-internal change. The modifications are in hooks (`subagent_stop.py`, `pre_tool_use.py`), the coach (`bridge/coach.py`), and the pipeline state machine (`bridge/pipeline_state.py`). No MCP server changes, no `.mcp.json` changes, no new tools exposed to the agent.
+No agent integration required -- this is a bridge-internal change. The modifications are in hooks (`subagent_stop.py`, `pre_tool_use.py`), the coach (`bridge/session_coaching.py`, formerly `bridge/coach.py` which was deleted by PR #661), and the pipeline state machine (`bridge/pipeline_state.py`). No MCP server changes, no `.mcp.json` changes, no new tools exposed to the agent.
 
 ## Documentation
 

--- a/tests/unit/test_reflection_scheduler.py
+++ b/tests/unit/test_reflection_scheduler.py
@@ -47,7 +47,6 @@ class TestRegistryLoading:
             data = yaml.safe_load(f)
         all_names = [r["name"] for r in data["reflections"]]
         assert "health-check" in all_names
-        assert "daily-maintenance" in all_names
 
     def test_load_registry_returns_only_enabled(self):
         """load_registry() filters out disabled entries."""
@@ -490,15 +489,6 @@ class TestRegistryIntegrity:
         health_entries = [e for e in data["reflections"] if e["name"] == "health-check"]
         assert health_entries[0]["interval"] == 300
 
-    def test_daily_maintenance_interval_daily(self):
-        """Daily maintenance should run once per day (86400 seconds)."""
-        registry_path = Path(__file__).parent.parent.parent / "config" / "reflections.yaml"
-        with open(registry_path) as f:
-            data = yaml.safe_load(f)
-        daily_entries = [e for e in data["reflections"] if e["name"] == "daily-maintenance"]
-        assert len(daily_entries) == 1
-        assert daily_entries[0]["interval"] == 86400
-
     def test_no_duplicate_names(self):
         """All reflection names should be unique."""
         registry_path = Path(__file__).parent.parent.parent / "config" / "reflections.yaml"
@@ -513,7 +503,7 @@ class TestRegistryIntegrity:
         with open(registry_path) as f:
             data = yaml.safe_load(f)
         names = {e["name"] for e in data["reflections"]}
-        expected = {"health-check", "orphan-recovery", "stale-branch-cleanup", "daily-maintenance"}
+        expected = {"health-check", "orphan-recovery", "stale-branch-cleanup"}
         assert expected.issubset(names), f"Missing reflections: {expected - names}"
 
 


### PR DESCRIPTION
## Summary
- Fixed 3 broken unit tests in `test_reflection_scheduler.py` that expected `daily-maintenance` in `config/reflections.yaml` (removed by PR #664)
- Updated `docs/features/reflections.md` to remove `daily-maintenance` from registry table and clarify the pipeline invocation method
- Annotated stale `bridge/coach.py` references in `docs/plans/wire-pipeline-graph-563.md` and `docs/plans/unify-persona-vocabulary.md` (deleted by PR #661)

## Test plan
- [x] `pytest tests/unit/test_reflection_scheduler.py -x -q` -- all 47 tests pass
- [x] `pytest tests/unit/ -x -q` -- 2450 passed (1 pre-existing failure in `test_ui_app.py`, unrelated)
- [x] `ruff check` and `ruff format --check` clean on changed files
- [x] No `daily-maintenance` references remain in reflections.md registry table
- [x] All `bridge/coach.py` references in plan docs annotated with deletion note

Closes #668