### PR TITLE
Add bounded retry guard to Telegram relay

### DIFF
--- a/bridge/telegram_relay.py
+++ b/bridge/telegram_relay.py
@@ -12,6 +12,14 @@ Redis queue contract:
     Backward compatibility: legacy payloads with ``file_path`` (string) are
     normalized to ``file_paths`` (list) at relay time during rolling deployments.
 
+Retry and dead-letter behavior:
+    Failed messages are re-queued with a ``_relay_attempts`` counter embedded in
+    the JSON payload. After ``MAX_RELAY_RETRIES`` (default 3) failed attempts,
+    text messages are routed to the dead letter queue via ``bridge/dead_letters.py``
+    for later replay. Reactions and custom emoji messages are ephemeral and are
+    discarded after exhausting retries. Unknown message types are rejected
+    immediately without entering the retry loop.
+
 After successful send, records the Telegram message ID on the AgentSession's
 pm_sent_message_ids field. This list is checked by the summarizer bypass
 in bridge/response.py.
@@ -33,6 +41,12 @@ RELAY_BATCH_SIZE = 10
 
 # Redis key pattern for scanning outbox queues
 OUTBOX_KEY_PATTERN = "telegram:outbox:*"
+
+# Maximum relay attempts before routing to dead letter
+MAX_RELAY_RETRIES = 3
+
+# Known message types accepted by the relay dispatcher
+KNOWN_MESSAGE_TYPES = {None, "reaction", "custom_emoji_message"}
 
 
 def _get_redis_connection() -> redis.Redis:
@@ -304,6 +318,49 @@ def _record_sent_message(session_id: str, msg_id: int) -> None:
         logger.warning(f"Relay: failed to record msg_id on session {session_id}: {e}")
 
 
+async def _dead_letter_message(message: dict, reason: str) -> None:
+    """Route a failed message to the dead letter queue or discard it.
+
+    Text messages are persisted via bridge/dead_letters.py for later replay.
+    Reactions and custom emoji messages are ephemeral and not worth replaying,
+    so they are logged at WARNING level and discarded.
+
+    Args:
+        message: The message payload that exhausted retries.
+        reason: Human-readable reason for dead-lettering.
+    """
+    msg_type = message.get("type")
+    chat_id = message.get("chat_id")
+
+    if msg_type in ("reaction", "custom_emoji_message"):
+        logger.warning(
+            f"Relay: discarding {msg_type} after {reason} (chat_id={chat_id}): {message}"
+        )
+        return
+
+    # Text/file messages -- persist to dead letter queue
+    text = message.get("text", "")
+    reply_to = message.get("reply_to")
+    if chat_id and text:
+        try:
+            from bridge.dead_letters import persist_failed_delivery
+
+            await persist_failed_delivery(
+                chat_id=int(chat_id),
+                reply_to=int(reply_to) if reply_to else None,
+                text=text,
+            )
+            logger.warning(
+                f"Relay: dead-lettered message for chat {chat_id} ({reason}, {len(text)} chars)"
+            )
+        except Exception as e:
+            logger.error(f"Relay: failed to persist dead letter for chat {chat_id}: {e}")
+    else:
+        logger.warning(
+            f"Relay: discarding non-text message after {reason} (chat_id={chat_id}): {message}"
+        )
+
+
 async def process_outbox(telegram_client) -> int:
     """Process all pending outbox queues, sending messages via Telethon.
 
@@ -338,53 +395,75 @@ async def process_outbox(telegram_client) -> int:
                     logger.warning(f"Relay: skipping malformed queue entry in {key}: {e}")
                     continue
 
-                # Handle reaction payloads separately
-                if message.get("type") == "reaction":
-                    reaction_ok = await _send_queued_reaction(telegram_client, message)
-                    if reaction_ok:
-                        sent_count += 1
+                # Validate message type before dispatch
+                msg_type = message.get("type")
+                if msg_type not in KNOWN_MESSAGE_TYPES:
+                    logger.warning(
+                        f"Relay: unknown message type '{msg_type}', discarding: {message}"
+                    )
                     continue
 
-                # Handle custom emoji message payloads
-                if message.get("type") == "custom_emoji_message":
-                    msg_id = await _send_custom_emoji_message(telegram_client, message)
+                # Dispatch to handler with unified error handling
+                success = False
+                msg_id = None
+                try:
+                    if msg_type == "reaction":
+                        success = await _send_queued_reaction(telegram_client, message)
+                    elif msg_type == "custom_emoji_message":
+                        msg_id = await _send_custom_emoji_message(telegram_client, message)
+                        success = msg_id is not None
+                    else:
+                        msg_id = await _send_queued_message(telegram_client, message)
+                        success = msg_id is not None
+                except Exception as handler_err:
+                    logger.warning(
+                        f"Relay: handler exception for {msg_type or 'default'} "
+                        f"in {key}: {handler_err}"
+                    )
+                    success = False
+
+                if success:
+                    sent_count += 1
+                    # Record sent message ID on AgentSession
                     if msg_id is not None:
-                        sent_count += 1
                         session_id = message.get("session_id")
                         if session_id:
                             await asyncio.to_thread(_record_sent_message, session_id, msg_id)
-                    continue
 
-                msg_id = await _send_queued_message(telegram_client, message)
+                    # Store sent message for Redis history (text messages only)
+                    if msg_type is None and msg_id is not None:
+                        try:
+                            from bridge.telegram_bridge import store_message
+                            from bridge.utc import utc_now
 
-                if msg_id is not None:
-                    sent_count += 1
-                    session_id = message.get("session_id")
-                    if session_id:
-                        await asyncio.to_thread(_record_sent_message, session_id, msg_id)
-
-                    # Store sent message for Redis history
-                    try:
-                        from bridge.telegram_bridge import store_message
-                        from bridge.utc import utc_now
-
-                        await asyncio.to_thread(
-                            store_message,
-                            chat_id=message.get("chat_id"),
-                            content=message.get("text", ""),
-                            sender="system",
-                            timestamp=utc_now(),
-                            message_type="pm_direct",
-                        )
-                    except Exception:
-                        pass  # Non-fatal: history storage is best-effort
+                            await asyncio.to_thread(
+                                store_message,
+                                chat_id=message.get("chat_id"),
+                                content=message.get("text", ""),
+                                sender="system",
+                                timestamp=utc_now(),
+                                message_type="pm_direct",
+                            )
+                        except Exception:
+                            pass  # Non-fatal: history storage is best-effort
                 else:
-                    # Send failed -- re-push to queue tail for retry
-                    try:
-                        await asyncio.to_thread(r.rpush, key, raw)
-                        logger.info(f"Relay: re-queued failed message in {key} for retry")
-                    except Exception as re_err:
-                        logger.error(f"Relay: failed to re-queue message: {re_err}")
+                    # Bounded retry: increment attempt counter, dead-letter if exhausted
+                    attempts = message.get("_relay_attempts", 0) + 1
+                    message["_relay_attempts"] = attempts
+                    if attempts >= MAX_RELAY_RETRIES:
+                        await _dead_letter_message(
+                            message, reason=f"max retries ({MAX_RELAY_RETRIES}) exceeded"
+                        )
+                    else:
+                        try:
+                            requeue_raw = json.dumps(message)
+                            await asyncio.to_thread(r.rpush, key, requeue_raw)
+                            logger.info(
+                                f"Relay: re-queued failed message in {key} "
+                                f"(attempt {attempts}/{MAX_RELAY_RETRIES})"
+                            )
+                        except Exception as re_err:
+                            logger.error(f"Relay: failed to re-queue message: {re_err}")
 
     except Exception as e:
         logger.error(f"Relay: outbox processing error: {e}", exc_info=True)

--- a/docs/features/relay-retry-guard.md
+++ b/docs/features/relay-retry-guard.md
@@ -1,0 +1,41 @@
+# Relay Retry Guard
+
+Bounded retry and dead-letter routing for the Telegram relay's outbox message processing.
+
+## Problem
+
+The relay in `bridge/telegram_relay.py` previously re-queued failed messages to the queue tail unconditionally. Messages that were structurally undeliverable (wrong type, missing fields, unrecognized format) would never succeed, creating an infinite retry loop that blocked session outbox queues and stalled agent sessions.
+
+## How It Works
+
+### Bounded Retries
+
+Each message gets a `_relay_attempts` counter embedded in the JSON payload. On failure, the counter increments and the message is re-queued. After `MAX_RELAY_RETRIES` (default 3) failed attempts, the message is routed to the dead letter queue instead of re-queuing.
+
+### Type Validation
+
+Before dispatch, each message's `type` field is checked against `KNOWN_MESSAGE_TYPES` (`None`, `"reaction"`, `"custom_emoji_message"`). Unknown types are logged and discarded immediately without entering the retry loop.
+
+### Dead Letter Routing
+
+The `_dead_letter_message()` helper routes exhausted messages based on type:
+
+- **Text messages** (type=None): persisted to `bridge/dead_letters.py` via `persist_failed_delivery()` for later replay
+- **Reactions and custom emoji messages**: logged at WARNING level and discarded (ephemeral, not worth replaying)
+
+### Unified Failure Handling
+
+All three message type paths (reaction, custom_emoji_message, default text) use the same bounded-retry logic. Handler dispatch is wrapped in try/except so unexpected exceptions feed into the retry path rather than crashing or falling through.
+
+## Configuration
+
+| Constant | Default | Description |
+|----------|---------|-------------|
+| `MAX_RELAY_RETRIES` | 3 | Maximum delivery attempts before dead-lettering |
+| `KNOWN_MESSAGE_TYPES` | `{None, "reaction", "custom_emoji_message"}` | Accepted message types |
+
+## Files
+
+- `bridge/telegram_relay.py` -- all implementation changes
+- `bridge/dead_letters.py` -- called by dead-letter routing (no changes)
+- `tests/unit/test_bridge_relay.py` -- unit tests covering all retry/dead-letter paths

--- a/tests/unit/test_bridge_relay.py
+++ b/tests/unit/test_bridge_relay.py
@@ -12,9 +12,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from bridge.telegram_relay import (
+    KNOWN_MESSAGE_TYPES,
+    MAX_RELAY_RETRIES,
     OUTBOX_KEY_PATTERN,
     RELAY_BATCH_SIZE,
     RELAY_POLL_INTERVAL,
+    _dead_letter_message,
     _record_sent_message,
     _send_queued_message,
     get_outbox_length,
@@ -33,6 +36,12 @@ class TestRelayConstants:
 
     def test_outbox_key_pattern(self):
         assert OUTBOX_KEY_PATTERN == "telegram:outbox:*"
+
+    def test_max_relay_retries(self):
+        assert MAX_RELAY_RETRIES == 3
+
+    def test_known_message_types(self):
+        assert KNOWN_MESSAGE_TYPES == {None, "reaction", "custom_emoji_message"}
 
 
 class TestSendQueuedMessage:
@@ -337,6 +346,92 @@ class TestGetOutboxLength:
         assert length == 0
 
 
+class TestDeadLetterMessage:
+    """Test the dead letter routing helper."""
+
+    @pytest.mark.asyncio
+    async def test_persists_text_message_to_dead_letter(self):
+        """Should call persist_failed_delivery for text messages."""
+        message = {
+            "chat_id": "12345",
+            "reply_to": 67890,
+            "text": "Failed message",
+            "session_id": "test-session",
+        }
+
+        with patch(
+            "bridge.dead_letters.persist_failed_delivery", new_callable=AsyncMock
+        ) as mock_persist:
+            await _dead_letter_message(message, reason="max retries exceeded")
+
+        mock_persist.assert_called_once_with(
+            chat_id=12345,
+            reply_to=67890,
+            text="Failed message",
+        )
+
+    @pytest.mark.asyncio
+    async def test_discards_reaction_without_persisting(self):
+        """Should log and discard reactions without calling persist_failed_delivery."""
+        message = {
+            "type": "reaction",
+            "chat_id": "12345",
+            "reply_to": 67890,
+            "emoji": "thumbsup",
+        }
+
+        with patch(
+            "bridge.dead_letters.persist_failed_delivery", new_callable=AsyncMock
+        ) as mock_persist:
+            await _dead_letter_message(message, reason="max retries exceeded")
+
+        mock_persist.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_discards_custom_emoji_without_persisting(self):
+        """Should log and discard custom emoji messages without persisting."""
+        message = {
+            "type": "custom_emoji_message",
+            "chat_id": "12345",
+            "emoji": "star",
+        }
+
+        with patch(
+            "bridge.dead_letters.persist_failed_delivery", new_callable=AsyncMock
+        ) as mock_persist:
+            await _dead_letter_message(message, reason="max retries exceeded")
+
+        mock_persist.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handles_persist_failure_gracefully(self):
+        """Should not raise when persist_failed_delivery fails."""
+        message = {
+            "chat_id": "12345",
+            "text": "Failed message",
+        }
+
+        with patch(
+            "bridge.dead_letters.persist_failed_delivery",
+            new_callable=AsyncMock,
+            side_effect=Exception("Redis down"),
+        ):
+            # Should not raise
+            await _dead_letter_message(message, reason="test")
+
+    @pytest.mark.asyncio
+    async def test_discards_message_without_text_or_chat_id(self):
+        """Should discard messages that have no text or chat_id."""
+        message = {"chat_id": "12345"}  # No text
+
+        with patch(
+            "bridge.dead_letters.persist_failed_delivery", new_callable=AsyncMock
+        ) as mock_persist:
+            await _dead_letter_message(message, reason="test")
+
+        mock_persist.assert_not_called()
+
+
 class TestProcessOutbox:
     """Test the outbox processing cycle."""
 
@@ -374,7 +469,7 @@ class TestProcessOutbox:
 
     @pytest.mark.asyncio
     async def test_requeues_on_send_failure(self):
-        """Should re-push message to queue tail on send failure."""
+        """Should re-push message with _relay_attempts to queue tail on send failure."""
         mock_redis = MagicMock()
         message = json.dumps(
             {
@@ -396,8 +491,190 @@ class TestProcessOutbox:
             sent = await process_outbox(MagicMock())
 
         assert sent == 0
-        # Verify re-push
+        # Verify re-push with _relay_attempts
         mock_redis.rpush.assert_called_once()
+        requeued_payload = json.loads(mock_redis.rpush.call_args[0][1])
+        assert requeued_payload["_relay_attempts"] == 1
+
+    @pytest.mark.asyncio
+    async def test_dead_letters_after_max_retries(self):
+        """Should route to dead letter after MAX_RELAY_RETRIES attempts."""
+        mock_redis = MagicMock()
+        # Message already at MAX_RELAY_RETRIES - 1 attempts
+        message = json.dumps(
+            {
+                "chat_id": "12345",
+                "text": "persistent failure",
+                "session_id": "test-session",
+                "_relay_attempts": MAX_RELAY_RETRIES - 1,
+            }
+        )
+        mock_redis.keys.return_value = ["telegram:outbox:test-session"]
+        mock_redis.lpop.side_effect = [message, None]
+
+        with (
+            patch("bridge.telegram_relay._get_redis_connection", return_value=mock_redis),
+            patch(
+                "bridge.telegram_relay._send_queued_message", new_callable=AsyncMock
+            ) as mock_send,
+            patch(
+                "bridge.telegram_relay._dead_letter_message", new_callable=AsyncMock
+            ) as mock_dead_letter,
+        ):
+            mock_send.return_value = None  # Send failed
+            sent = await process_outbox(MagicMock())
+
+        assert sent == 0
+        # Should NOT re-queue
+        mock_redis.rpush.assert_not_called()
+        # Should dead-letter
+        mock_dead_letter.assert_called_once()
+        dead_msg = mock_dead_letter.call_args[0][0]
+        assert dead_msg["_relay_attempts"] == MAX_RELAY_RETRIES
+
+    @pytest.mark.asyncio
+    async def test_unknown_message_type_discarded(self):
+        """Should discard messages with unknown type without re-queue."""
+        mock_redis = MagicMock()
+        message = json.dumps(
+            {
+                "type": "bogus_type",
+                "chat_id": "12345",
+                "text": "unknown",
+            }
+        )
+        mock_redis.keys.return_value = ["telegram:outbox:test-session"]
+        mock_redis.lpop.side_effect = [message, None]
+
+        with (
+            patch("bridge.telegram_relay._get_redis_connection", return_value=mock_redis),
+            patch(
+                "bridge.telegram_relay._send_queued_message", new_callable=AsyncMock
+            ) as mock_send,
+        ):
+            sent = await process_outbox(MagicMock())
+
+        assert sent == 0
+        # Should NOT call any handler
+        mock_send.assert_not_called()
+        # Should NOT re-queue
+        mock_redis.rpush.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handler_exception_feeds_retry_path(self):
+        """Should catch handler exceptions and feed into bounded retry."""
+        mock_redis = MagicMock()
+        message = json.dumps(
+            {
+                "chat_id": "12345",
+                "text": "crash message",
+                "session_id": "test-session",
+            }
+        )
+        mock_redis.keys.return_value = ["telegram:outbox:test-session"]
+        mock_redis.lpop.side_effect = [message, None]
+
+        with (
+            patch("bridge.telegram_relay._get_redis_connection", return_value=mock_redis),
+            patch(
+                "bridge.telegram_relay._send_queued_message",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("Unexpected crash"),
+            ),
+        ):
+            sent = await process_outbox(MagicMock())
+
+        assert sent == 0
+        # Should re-queue with _relay_attempts
+        mock_redis.rpush.assert_called_once()
+        requeued_payload = json.loads(mock_redis.rpush.call_args[0][1])
+        assert requeued_payload["_relay_attempts"] == 1
+
+    @pytest.mark.asyncio
+    async def test_reaction_failure_uses_bounded_retry(self):
+        """Should use bounded retry for reaction failures instead of silent discard."""
+        mock_redis = MagicMock()
+        message = json.dumps(
+            {
+                "type": "reaction",
+                "chat_id": "12345",
+                "reply_to": 67890,
+                "emoji": "thumbsup",
+            }
+        )
+        mock_redis.keys.return_value = ["telegram:outbox:test-session"]
+        mock_redis.lpop.side_effect = [message, None]
+
+        with (
+            patch("bridge.telegram_relay._get_redis_connection", return_value=mock_redis),
+            patch(
+                "bridge.telegram_relay._send_queued_reaction", new_callable=AsyncMock
+            ) as mock_reaction,
+        ):
+            mock_reaction.return_value = False  # Reaction failed
+            sent = await process_outbox(MagicMock())
+
+        assert sent == 0
+        # Should re-queue with retry counter
+        mock_redis.rpush.assert_called_once()
+        requeued_payload = json.loads(mock_redis.rpush.call_args[0][1])
+        assert requeued_payload["_relay_attempts"] == 1
+
+    @pytest.mark.asyncio
+    async def test_custom_emoji_failure_uses_bounded_retry(self):
+        """Should use bounded retry for custom emoji failures."""
+        mock_redis = MagicMock()
+        message = json.dumps(
+            {
+                "type": "custom_emoji_message",
+                "chat_id": "12345",
+                "emoji": "star",
+            }
+        )
+        mock_redis.keys.return_value = ["telegram:outbox:test-session"]
+        mock_redis.lpop.side_effect = [message, None]
+
+        with (
+            patch("bridge.telegram_relay._get_redis_connection", return_value=mock_redis),
+            patch(
+                "bridge.telegram_relay._send_custom_emoji_message", new_callable=AsyncMock
+            ) as mock_emoji,
+        ):
+            mock_emoji.return_value = None  # Send failed
+            sent = await process_outbox(MagicMock())
+
+        assert sent == 0
+        mock_redis.rpush.assert_called_once()
+        requeued_payload = json.loads(mock_redis.rpush.call_args[0][1])
+        assert requeued_payload["_relay_attempts"] == 1
+
+    @pytest.mark.asyncio
+    async def test_successful_messages_unaffected(self):
+        """Should not add _relay_attempts or change behavior for successful sends."""
+        mock_redis = MagicMock()
+        message = json.dumps(
+            {
+                "chat_id": "12345",
+                "text": "success message",
+                "session_id": "test-session",
+            }
+        )
+        mock_redis.keys.return_value = ["telegram:outbox:test-session"]
+        mock_redis.lpop.side_effect = [message, None]
+
+        with (
+            patch("bridge.telegram_relay._get_redis_connection", return_value=mock_redis),
+            patch(
+                "bridge.telegram_relay._send_queued_message", new_callable=AsyncMock
+            ) as mock_send,
+            patch("bridge.telegram_relay._record_sent_message"),
+        ):
+            mock_send.return_value = 42
+            sent = await process_outbox(MagicMock())
+
+        assert sent == 1
+        # Should NOT re-queue
+        mock_redis.rpush.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_skips_malformed_json(self):
@@ -421,3 +698,58 @@ class TestProcessOutbox:
             sent = await process_outbox(MagicMock())
 
         assert sent == 0
+
+    @pytest.mark.asyncio
+    async def test_retry_counter_increments_across_cycles(self):
+        """Should increment _relay_attempts correctly when message already has attempts."""
+        mock_redis = MagicMock()
+        # Message with 1 prior attempt
+        message = json.dumps(
+            {
+                "chat_id": "12345",
+                "text": "retrying",
+                "session_id": "test-session",
+                "_relay_attempts": 1,
+            }
+        )
+        mock_redis.keys.return_value = ["telegram:outbox:test-session"]
+        mock_redis.lpop.side_effect = [message, None]
+
+        with (
+            patch("bridge.telegram_relay._get_redis_connection", return_value=mock_redis),
+            patch(
+                "bridge.telegram_relay._send_queued_message", new_callable=AsyncMock
+            ) as mock_send,
+        ):
+            mock_send.return_value = None
+            await process_outbox(MagicMock())
+
+        # Should re-queue with attempts=2
+        mock_redis.rpush.assert_called_once()
+        requeued_payload = json.loads(mock_redis.rpush.call_args[0][1])
+        assert requeued_payload["_relay_attempts"] == 2
+
+    @pytest.mark.asyncio
+    async def test_mixed_success_and_failure_batch(self):
+        """Should handle a batch with both successful and failed messages correctly."""
+        mock_redis = MagicMock()
+        success_msg = json.dumps({"chat_id": "12345", "text": "good", "session_id": "s1"})
+        fail_msg = json.dumps({"chat_id": "12345", "text": "bad", "session_id": "s2"})
+        success_msg2 = json.dumps({"chat_id": "12345", "text": "also good", "session_id": "s3"})
+        mock_redis.keys.return_value = ["telegram:outbox:test-session"]
+        mock_redis.lpop.side_effect = [success_msg, fail_msg, success_msg2, None]
+
+        with (
+            patch("bridge.telegram_relay._get_redis_connection", return_value=mock_redis),
+            patch(
+                "bridge.telegram_relay._send_queued_message", new_callable=AsyncMock
+            ) as mock_send,
+            patch("bridge.telegram_relay._record_sent_message"),
+        ):
+            # First succeeds, second fails, third succeeds
+            mock_send.side_effect = [42, None, 43]
+            sent = await process_outbox(MagicMock())
+
+        assert sent == 2
+        # Only the failed message should be re-queued
+        assert mock_redis.rpush.call_count == 1


### PR DESCRIPTION
## Summary
- Adds bounded retries (max 3) to the Telegram relay's outbox message processing, preventing infinite retry loops from poisoned messages
- Unknown message types are validated and discarded immediately; all handler paths (reaction, custom_emoji, text) use unified bounded-retry logic
- Exhausted text messages route to dead letter queue via `bridge/dead_letters.py`; ephemeral reactions/emoji are discarded with WARNING log

## Test plan
- [x] 38 unit tests pass covering: retry exhaustion, unknown type discard, handler exception recovery, unified failure path for all message types, counter increment across cycles, mixed success/failure batches
- [x] Ruff format and lint pass
- [ ] Manual verification: deploy and confirm relay processes messages normally (success path unchanged)

Fixes #698