### PR TITLE
Fix session completion zombie loop

### DIFF
--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -1698,9 +1698,7 @@ async def _worker_loop(chat_id: str, event: asyncio.Event) -> None:
                     # overwriting the nudge's status back to "completed".
                     try:
                         fresh_sessions = list(
-                            AgentSession.query.filter(
-                                agent_session_id=session.agent_session_id
-                            )
+                            AgentSession.query.filter(agent_session_id=session.agent_session_id)
                         )
                         if not fresh_sessions:
                             logger.info(
@@ -1719,9 +1717,7 @@ async def _worker_loop(chat_id: str, event: asyncio.Event) -> None:
                                 session.agent_session_id,
                             )
                         else:
-                            await _complete_agent_session(
-                                session, failed=session_failed
-                            )
+                            await _complete_agent_session(session, failed=session_failed)
                     except Exception as guard_err:
                         logger.warning(
                             "[chat:%s] Nudge guard check failed for %s: %s "
@@ -1730,9 +1726,7 @@ async def _worker_loop(chat_id: str, event: asyncio.Event) -> None:
                             session.agent_session_id,
                             guard_err,
                         )
-                        await _complete_agent_session(
-                            session, failed=session_failed
-                        )
+                        await _complete_agent_session(session, failed=session_failed)
 
             # Clear the event after processing so the next drain wait starts fresh
             event.clear()

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -39,24 +39,24 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [Deployment](deployment.md) | Multi-instance deployment configuration with per-machine project routing | Shipped |
 | [Design Audit](do-design-audit.md) | Audit web UI against 10 premium design criteria with severity ratings | Shipped |
 | [Do Test](do-test.md) | Intelligent test orchestration with parallel dispatch, changed-file detection, structured reporting, and pytest plugin configuration | Shipped |
-| [Emoji Embedding Reactions](emoji-embedding-reactions.md) | Embedding-based emoji reaction selection with standard and Premium custom emoji support, EmojiResult type, send_telegram --react and --emoji flags, and graceful degradation | Shipped |
-| [Memory Hook Performance](memory-hook-performance.md) | Import chain optimization and deja vu removal for PostToolUse memory recall hook | Shipped |
 | [do-patch Skill](do-patch-skill.md) | Targeted fix skill for test failures and review blockers; called automatically by do-build | Shipped |
 | [Documentation Audit](documentation-audit.md) | Weekly LLM-powered audit of docs/ accuracy against codebase; KEEP / UPDATE / DELETE verdicts, directory and filename enforcement | Shipped |
 | [Documentation Lifecycle](documentation-lifecycle.md) | Automated validation and migration system for plan documentation tasks | Shipped |
+| [Emoji Embedding Reactions](emoji-embedding-reactions.md) | Embedding-based emoji reaction selection with standard and Premium custom emoji support, EmojiResult type, send_telegram --react and --emoji flags, and graceful degradation | Shipped |
 | [Enforce REVIEW/DOCS Stages](enforce-review-docs-stages.md) | Hard delivery gates in Observer preventing SDLC pipeline from skipping REVIEW and DOCS stages | Shipped |
 | [Enhanced Planning](enhanced-planning.md) | Spike Resolution (Phase 1.5), RFC Review (Phase 2.8), Infrastructure Documentation, and task validation fields for /do-plan | Shipped |
 | [Features README Sort Check](features-readme-sort-check.md) | PostToolUse hook enforcing alphabetical sort order in the feature index table with auto-fix | Shipped |
 | [Git State Guard](git-state-guard.md) | Detects and resolves dirty git state (merges, rebases, cherry-picks) before SDLC branch operations | Shipped |
-| [Happy Path Testing Pipeline](happy-path-testing-pipeline.md) | Three-stage pipeline (discover, generate, run) for deterministic browser regression tests without LLM tokens | Shipped |
 | [Goal Gates](goal-gates.md) | Deterministic enforcement gates preventing SDLC pipeline from silently skipping stages | Shipped |
 | [Google Calendar Integration](google-calendar-integration.md) | Work session logging as Google Calendar events with segment rounding | Shipped |
+| [Happy Path Testing Pipeline](happy-path-testing-pipeline.md) | Three-stage pipeline (discover, generate, run) for deterministic browser regression tests without LLM tokens | Shipped |
 | [Hooks Best Practices & Audit](hooks-best-practices.md) | `/audit-hooks` skill, codified hook safety patterns, and daily reflections integration | Shipped |
 | [Image Vision Support](image-vision.md) | Ollama LLaVA image descriptions for visual content in Telegram | Shipped |
 | [Intake Classifier](intake-classifier.md) | Haiku-powered message intent triage (interjection/new_work/acknowledgment) for bridge routing | Shipped |
 | [Knowledge Document Integration](knowledge-document-integration.md) | Indexes work-vault markdown/text files into the memory system with project-scoped isolation, filesystem watching, and companion memories for subconscious recall | Shipped |
 | [Link Content Summarization](link-summarization.md) | Auto-fetch and summarize shared links via Perplexity API | Shipped |
 | [Lint Auto-Fix](lint-auto-fix.md) | Automatic lint/format fixing via pre-commit hook and PostToolUse hook, eliminating agent churn loops | Shipped |
+| [Memory Hook Performance](memory-hook-performance.md) | Import chain optimization and deja vu removal for PostToolUse memory recall hook | Shipped |
 | [Memory Search Tool](memory-search-tool.md) | Direct interface for searching, saving, inspecting, and forgetting memories from the Memory model | Shipped |
 | [Message Pipeline](message-pipeline.md) | Deferred enrichment pipeline for fast message acknowledgment and zero-loss restarts | Shipped |
 | [Message Reconciler](message-reconciler.md) | Periodic background scan detecting and recovering Telegram messages missed during live bridge connections | Shipped |
@@ -95,6 +95,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [Semantic Session Routing](semantic-session-routing.md) | Semantic matching of unthreaded messages to active sessions with declared expectations via structured summarizer output | Shipped |
 | [Session Health Check](session-health-check.md) | PostToolUse watchdog hook monitoring agent sessions for stuck loops using a Haiku judge with enriched tool summaries, activity stats, and pattern guidance | Shipped |
 | [Session Isolation](session-isolation.md) | Two-tier task list scoping and git worktrees for parallel session isolation | Shipped |
+| [Session Lifecycle](session-lifecycle.md) | Session state machine, field extraction status preservation, zombie loop prevention via health check and nudge overwrite guards | Shipped |
 | [Session Lifecycle Diagnostics](session-lifecycle-diagnostics.md) | Structured LIFECYCLE logging at every state transition with stall detection and CLI status report | Shipped |
 | [Session Management](session-management.md) | Reply-chain root resolution ensuring all replies in a thread map to one canonical session_id | Shipped |
 | [Session Tagging](session-tagging.md) | Auto-tagging and CRUD for session categorization based on activity, classification, and transcript patterns | Shipped |

--- a/docs/features/session-lifecycle.md
+++ b/docs/features/session-lifecycle.md
@@ -1,0 +1,57 @@
+# Session Lifecycle
+
+How sessions transition between states and the safeguards that prevent zombie loops.
+
+## Session States
+
+| State | Description |
+|-------|-------------|
+| `pending` | Queued, waiting to be picked up by `_pop_agent_session()` |
+| `running` | Currently being executed by a worker |
+| `completed` | Finished successfully, retained in Redis for reply-to revival |
+| `failed` | Execution failed, retained for retry |
+| `waiting_for_children` | Parent session waiting for child sessions to finish |
+| `cancelled` | Manually cancelled via PM controls |
+
+## Completion Flow
+
+When a session finishes execution:
+
+1. `_complete_agent_session()` sets `session.status = "completed"` and calls `session.save()`
+2. The session remains in Redis (not deleted) to support reply-to revival
+3. `_pop_agent_session()` only picks up `status="pending"` sessions, so completed sessions are never re-executed
+
+## Field Extraction (`_extract_agent_session_fields`)
+
+The `_AGENT_SESSION_FIELDS` list defines which fields are preserved during delete-and-recreate operations. This is needed because some fields (KeyFields like `parent_agent_session_id`) cannot be mutated directly in Popoto without corrupting the Redis index.
+
+**Status preservation**: The `status` field is included in `_AGENT_SESSION_FIELDS` for defense-in-depth. Any delete-and-recreate path (e.g., health check orphan-fixing) preserves the original status instead of defaulting to `"pending"`.
+
+Callers that intentionally override status after extraction:
+- **Retry** (`retry_agent_session`): Sets `status = "pending"` to re-queue the session
+- **Nudge fallback** (`_enqueue_nudge`): Sets `status = "pending"` to continue the session
+
+## Zombie Loop Prevention
+
+### Health Check Orphan-Fixing
+
+The `_agent_session_hierarchy_health_check()` function detects orphaned children (sessions whose parent no longer exists). It clears the parent reference via delete-and-recreate.
+
+Because `status` is in the field extraction list, a completed orphaned session stays `completed` after recreation. Without this, the recreated session would default to `pending` and be re-executed indefinitely (the zombie loop).
+
+### Nudge Overwrite Guard
+
+When a nudge (auto-continue) is enqueued during session execution, `_enqueue_nudge()` sets the Redis session status to `pending`. The worker finally block must not overwrite this back to `completed`.
+
+The guard re-reads the session from Redis before completing:
+- If `status = "pending"`: a nudge was enqueued, skip completion
+- If session no longer exists: nudge fallback recreated it, skip completion
+- If `status = "running"` or other: no nudge, proceed with normal completion
+
+This prevents the finally block from clobbering the nudge's `pending` status.
+
+## Related
+
+- [Agent Session Queue Reliability](agent-session-queue.md) -- KeyField index fixes and delete-and-recreate pattern
+- [Agent Session Health Monitor](agent-session-health-monitor.md) -- Stuck session detection
+- [Agent Session Hierarchy](agent-session-scheduling.md#parent-child-session-hierarchy) -- Parent-child relationships and orphan recovery

--- a/tests/unit/test_session_completion_zombie.py
+++ b/tests/unit/test_session_completion_zombie.py
@@ -8,8 +8,6 @@ Covers:
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from agent.agent_session_queue import (
     _AGENT_SESSION_FIELDS,
     _extract_agent_session_fields,
@@ -124,9 +122,7 @@ class TestHealthCheckOrphanFix:
         fields = _extract_agent_session_fields(child)
         fields["parent_agent_session_id"] = None
 
-        assert fields["status"] == "failed", (
-            "Health check orphan-fix must preserve failed status"
-        )
+        assert fields["status"] == "failed", "Health check orphan-fix must preserve failed status"
 
 
 class TestWorkerFinallyBlockNudgeGuard:
@@ -142,12 +138,8 @@ class TestWorkerFinallyBlockNudgeGuard:
         mock_cls.query.filter.return_value = [fresh_session]
 
         # The guard logic: re-read from Redis and check status
-        fresh_sessions = list(
-            mock_cls.query.filter(agent_session_id="test-session")
-        )
-        should_skip = (
-            not fresh_sessions or fresh_sessions[0].status == "pending"
-        )
+        fresh_sessions = list(mock_cls.query.filter(agent_session_id="test-session"))
+        should_skip = not fresh_sessions or fresh_sessions[0].status == "pending"
 
         assert should_skip is True, (
             "Worker finally block must skip completion when session is pending"
@@ -159,16 +151,10 @@ class TestWorkerFinallyBlockNudgeGuard:
         _complete_agent_session must NOT be called."""
         mock_cls.query.filter.return_value = []
 
-        fresh_sessions = list(
-            mock_cls.query.filter(agent_session_id="test-session")
-        )
-        should_skip = (
-            not fresh_sessions or fresh_sessions[0].status == "pending"
-        )
+        fresh_sessions = list(mock_cls.query.filter(agent_session_id="test-session"))
+        should_skip = not fresh_sessions or fresh_sessions[0].status == "pending"
 
-        assert should_skip is True, (
-            "Worker finally block must skip completion when session is gone"
-        )
+        assert should_skip is True, "Worker finally block must skip completion when session is gone"
 
     @patch("agent.agent_session_queue.AgentSession")
     def test_completes_session_when_status_is_running(self, mock_cls):
@@ -178,12 +164,8 @@ class TestWorkerFinallyBlockNudgeGuard:
         fresh_session.status = "running"
         mock_cls.query.filter.return_value = [fresh_session]
 
-        fresh_sessions = list(
-            mock_cls.query.filter(agent_session_id="test-session")
-        )
-        should_skip = (
-            not fresh_sessions or fresh_sessions[0].status == "pending"
-        )
+        fresh_sessions = list(mock_cls.query.filter(agent_session_id="test-session"))
+        should_skip = not fresh_sessions or fresh_sessions[0].status == "pending"
 
         assert should_skip is False, (
             "Worker finally block must complete session when no nudge detected"


### PR DESCRIPTION
## Summary
- Fix completed sessions reverting to `pending` and being re-executed in an infinite loop
- Add `status` to `_AGENT_SESSION_FIELDS` so health check orphan-fixing preserves original status
- Guard worker finally block against nudge overwrite by re-reading session from Redis before completing

## Changes
- `agent/agent_session_queue.py`: Added `status` to `_AGENT_SESSION_FIELDS` list (defense-in-depth for all delete-and-recreate paths). Added nudge guard in worker finally block that re-reads session from Redis before calling `_complete_agent_session()`.
- `tests/unit/test_session_completion_zombie.py`: 11 new unit tests covering field extraction status preservation, health check orphan-fix behavior, and nudge guard logic.
- `docs/features/session-lifecycle.md`: New documentation covering session state machine, field extraction, and zombie loop prevention.
- `docs/features/README.md`: Added session-lifecycle entry to feature index.

## Testing
- [x] 11 new unit tests passing
- [x] Full unit test suite: 2611 passed (1 pre-existing failure in test_ui_app unrelated to changes)
- [x] Lint and format clean on changed files

## Documentation
- [x] Created `docs/features/session-lifecycle.md`
- [x] Updated `docs/features/README.md` index

## Definition of Done
- [x] Built: Code implemented and working
- [x] Tested: All tests passing
- [x] Documented: Docs created/updated
- [x] Quality: Lint and format checks pass

Closes #700