### PR TITLE
Docs audit: fix 10 documentation issues

### DIFF
--- a/docs/features/tools-reference.md
+++ b/docs/features/tools-reference.md
@@ -1,0 +1,423 @@
+# Tools Reference
+
+Complete documentation of all tools available in the Valor system.
+
+## MCP Server Tools
+
+Individual operations that can be composed into larger workflows:
+
+| Tool | Purpose | Configuration |
+|------|---------|---------------|
+| **Sentry** | Error monitoring, performance analysis | `.mcp.json` |
+| **GitHub** | Repository operations, PRs, issues | `gh` CLI (pre-authenticated) |
+
+## Local Python Tools
+
+Located in `tools/` directory, use via Python imports.
+
+### SMS Reader (`tools.sms_reader`)
+
+Read macOS Messages app, extract 2FA codes.
+
+```bash
+# Get recent 2FA codes
+python -c "from tools.sms_reader import get_2fa; print(get_2fa(minutes=5))"
+
+# CLI interface
+python -m tools.sms_reader.cli recent --limit 5
+```
+
+### Telegram History (`tools.telegram_history`)
+
+Search stored message history from Telegram conversations.
+
+```python
+from tools.telegram_history import search_history
+
+results = search_history(query="deployment", limit=10)
+```
+
+### Memory Search (`tools.memory_search`)
+
+Search, save, inspect, and forget memories from the Memory model.
+
+```python
+from tools.memory_search import search, save, inspect, forget
+
+results = search("deploy patterns", project_key="dm", limit=5)
+saved = save("API X requires auth header Y", importance=6.0)
+details = inspect(memory_id="abc123")
+deleted = forget("abc123")
+```
+
+```bash
+# CLI
+python -m tools.memory_search search "deploy patterns"
+python -m tools.memory_search save "important note" --importance 6.0
+python -m tools.memory_search inspect --stats --project dm
+python -m tools.memory_search forget --id abc123 --confirm
+```
+
+### Code Impact Finder (`tools.code_impact_finder`)
+
+Semantic search for code, configs, and docs coupled to a proposed change. Two-stage pipeline: embedding recall + Claude Haiku reranking. Used during `/do-plan` Phase 1 for blast radius analysis.
+
+```bash
+# CLI: find code affected by a change
+.venv/bin/python -m tools.code_impact_finder "change session ID derivation"
+
+# CLI: check index status
+.venv/bin/python -m tools.code_impact_finder --status
+```
+
+```python
+from tools.code_impact_finder import find_affected_code, index_code
+
+index_code()  # Build/refresh the embedding index
+results = find_affected_code("change session ID derivation")
+for r in results:
+    print(f"{r.relevance:.2f} | {r.path} | {r.section} | {r.impact_type}")
+```
+
+### Emoji Embedding (`tools.emoji_embedding`)
+
+Embedding-based emoji selection for Telegram reactions. Maps feeling words to the nearest emoji via cosine similarity, searching both the 73 standard Telegram reaction emojis and any available Premium custom emoji packs.
+
+```python
+from tools.emoji_embedding import find_best_emoji, find_best_emoji_for_message, EmojiResult
+
+result = find_best_emoji("excited")        # -> EmojiResult
+str(result)                                 # -> "🔥" (backward compatible)
+result.is_custom                            # -> True if custom emoji matched
+result.document_id                          # -> Telegram document_id for custom emoji
+
+result = find_best_emoji_for_message(text)  # -> EmojiResult for message context
+```
+
+Returns an `EmojiResult` dataclass carrying both standard emoji and optional custom emoji data. `str(result)` preserves backward compatibility. Custom emoji wins only when its score exceeds the standard match by a 0.05 delta.
+
+Used by the bridge for automatic reaction selection and by `send_telegram --react` / `--emoji` for agent-initiated reactions and messages. See `docs/features/emoji-embedding-reactions.md` for full documentation.
+
+### Send Telegram Reactions (`tools.send_telegram --react`)
+
+Set an emoji reaction on a Telegram message by describing a feeling word. The feeling is resolved to the nearest emoji (standard or custom) via the embedding index.
+
+```bash
+python tools/send_telegram.py --react "excited"
+python tools/send_telegram.py --react "great work"
+python tools/send_telegram.py --react "thinking"
+```
+
+Requires `TELEGRAM_REPLY_TO` to be set (identifies the message to react to). The reaction payload is queued to the Redis outbox and delivered by `bridge/telegram_relay.py`. When a custom emoji is matched, the payload includes `custom_emoji_document_id` for the relay to dispatch via `ReactionCustomEmoji`.
+
+### Send Telegram Custom Emoji (`tools.send_telegram --emoji`)
+
+Send a standalone custom emoji message by describing a feeling word. The feeling is resolved to the best emoji via the embedding index, preferring custom emoji when available.
+
+```bash
+python tools/send_telegram.py --emoji "celebration"
+python tools/send_telegram.py --emoji "excited"
+python tools/send_telegram.py --emoji "sad"
+```
+
+Requires `TELEGRAM_CHAT_ID` and `VALOR_SESSION_ID`. Queues a `custom_emoji_message` payload to the Redis outbox. The relay renders it using `MessageEntityCustomEmoji` for Premium custom emoji, falling back to plain text if the send fails.
+
+### Link Analysis (`tools.link_analysis`)
+
+URL extraction and metadata analysis.
+
+```python
+from tools.link_analysis import analyze_url
+
+metadata = analyze_url("https://example.com")
+```
+
+### Session Tags (`tools.session_tags`)
+
+CRUD and auto-tagging for session categorization.
+
+```python
+from tools.session_tags import add_tags, get_tags, sessions_by_tag, auto_tag_session
+
+add_tags("session-123", ["hotfix", "urgent"])
+tags = get_tags("session-123")
+bug_sessions = sessions_by_tag("bug")
+auto_tag_session("session-123")  # called automatically at session completion
+```
+
+### Agent Session Scheduler (`tools.agent_session_scheduler`)
+
+Agent-initiated queue operations. Schedule SDLC sessions, push arbitrary messages,
+and manage queue state mid-conversation.
+
+```bash
+# Schedule SDLC work for a GitHub issue
+python -m tools.agent_session_scheduler schedule --issue 113
+python -m tools.agent_session_scheduler schedule --issue 113 --after "2026-03-12T02:00:00Z"
+
+# Push arbitrary session
+python -m tools.agent_session_scheduler push --message "What is the architecture?"
+
+# Queue status
+python -m tools.agent_session_scheduler status
+
+# Queue manipulation
+python -m tools.agent_session_scheduler bump --agent-session-id <ID>
+python -m tools.agent_session_scheduler pop --project valor
+python -m tools.agent_session_scheduler cancel --agent-session-id <ID>
+
+# Kill a running or pending session (terminates subprocess, sets status="killed")
+python -m tools.agent_session_scheduler kill --agent-session-id <ID>
+python -m tools.agent_session_scheduler kill --session-id <SESSION_ID>
+python -m tools.agent_session_scheduler kill --all
+
+# List sessions by status
+python -m tools.agent_session_scheduler list --status killed,abandoned
+python -m tools.agent_session_scheduler list --status completed --limit 5
+
+# Clean up stale sessions (deletes killed/abandoned/failed older than N minutes)
+python -m tools.agent_session_scheduler cleanup --age 30 --dry-run   # Preview
+python -m tools.agent_session_scheduler cleanup --age 30              # Delete
+```
+
+See `docs/features/agent-session-scheduling.md` for full documentation.
+
+### Session Steering CLI (`tools.valor_session`)
+
+Create, steer, monitor, and kill `AgentSession` records. The primary external interface for session steering — any process can write messages to a running session's inbox.
+
+```bash
+# List all sessions
+python -m tools.valor_session list
+python -m tools.valor_session list --status running
+python -m tools.valor_session list --role pm
+
+# Inspect a session
+python -m tools.valor_session status --id <SESSION_ID>
+
+# Inject a steering message into a running session
+python -m tools.valor_session steer --id <SESSION_ID> --message "Stop after critique"
+
+# Create a new session
+python -m tools.valor_session create --role pm --message "Plan issue #735"
+python -m tools.valor_session create --role dev --message "Fix the bug" --parent <PARENT_ID>
+
+# Kill sessions
+python -m tools.valor_session kill --id <SESSION_ID>
+python -m tools.valor_session kill --all
+
+# JSON output for scripting
+python -m tools.valor_session status --id <SESSION_ID> --json
+```
+
+See `docs/features/session-steering.md` for full documentation.
+
+### SDLC Stage Query (`tools.sdlc_stage_query`)
+
+Query SDLC pipeline `stage_states` from a PM session. Used by the SDLC router skill as the primary signal for routing decisions (which sub-skill to dispatch next). Returns JSON mapping stage names to statuses.
+
+```bash
+# Query by session ID
+python -m tools.sdlc_stage_query --session-id tg_project_123_456
+
+# Query by GitHub issue number (finds the PM session tracking that issue)
+python -m tools.sdlc_stage_query --issue-number 704
+
+# No args — falls back to VALOR_SESSION_ID / AGENT_SESSION_ID env vars
+python -m tools.sdlc_stage_query
+```
+
+```python
+from tools.sdlc_stage_query import query_stage_states
+
+states = query_stage_states(session_id="tg_project_123_456")
+# {"ISSUE": "completed", "PLAN": "completed", "BUILD": "in_progress", ...}
+
+states = query_stage_states(issue_number=704)
+```
+
+Always exits 0 and returns `{}` on any error (missing session, Redis down, malformed data). See `docs/features/pipeline-state-machine.md` for how the router uses this tool.
+
+## OfficeCLI
+
+Standalone binary at `~/.local/bin/officecli` for creating, reading, and editing Office documents (.docx, .xlsx, .pptx). No dependencies, no Office installation needed. Installed and updated automatically by the update system (`scripts/update/officecli.py`).
+
+```bash
+# Create files
+officecli create report.docx
+officecli create data.xlsx
+officecli create slides.pptx
+
+# Read and inspect
+officecli view report.docx outline       # Document structure
+officecli view report.docx stats         # Page/word/shape counts
+officecli get report.docx '/body/p[1]' --json
+
+# Edit
+officecli set data.xlsx /Sheet1/A1 --prop value="Name" --prop bold=true
+officecli add slides.pptx /slide[1] --type shape --prop text="Revenue grew 25%"
+```
+
+Strategy: L1 (read) then L2 (DOM edit) then L3 (raw XML). Use `--json` for structured output. Run `officecli <format> set` for help on available properties.
+
+See `.claude/skills/officecli/SKILL.md` for the full agent reference.
+
+## Image Tools
+
+Installed CLI commands via `pip install -e .`
+
+### Image Generation (`valor-image-gen`)
+
+Generate images from text prompts using AI.
+
+```bash
+valor-image-gen "a cat wearing a space helmet"           # Square 1:1
+valor-image-gen "sunset over mountains" 16:9             # Landscape
+valor-image-gen "mobile app mockup" 9:16                 # Portrait/stories
+valor-image-gen --help                                   # Show all ratios
+```
+
+**Supported aspect ratios:**
+- `1:1` - Square (default)
+- `16:9` - Landscape/widescreen
+- `9:16` - Portrait/stories
+- `4:3` - Standard
+- `3:4` - Portrait standard
+
+Images saved to `generated_images/` and automatically sent via Telegram bridge.
+
+### Image Analysis (`valor-image-analyze`)
+
+Analyze images with AI vision capabilities.
+
+```bash
+valor-image-analyze photo.jpg                            # General analysis
+valor-image-analyze screenshot.png text                  # OCR/text extraction
+valor-image-analyze diagram.png description objects      # Multiple analyses
+valor-image-analyze --help                               # Show options
+```
+
+**Analysis types:**
+- `description` - General description of image contents
+- `objects` - Object detection and identification
+- `text` - OCR/text extraction
+- `tags` - Keywords and categories
+- `safety` - Content safety analysis
+
+## Browser Automation
+
+`agent-browser` - Installed globally via npm.
+
+Headless browser automation for web testing, form filling, screenshots, and data extraction.
+
+### Core Workflow
+
+```bash
+# 1. Navigate to page
+agent-browser open https://example.com
+
+# 2. Get interactive snapshot with element refs (@e1, @e2, etc.)
+agent-browser snapshot -i
+
+# 3. Interact using refs
+agent-browser click @e1
+agent-browser fill @e2 "search text"
+
+# 4. Re-snapshot after page changes
+agent-browser snapshot -i
+```
+
+### Common Commands
+
+| Command | Description |
+|---------|-------------|
+| `agent-browser open <url>` | Navigate to URL |
+| `agent-browser snapshot -i` | Interactive snapshot with element refs |
+| `agent-browser click @e1` | Click element by reference |
+| `agent-browser fill @e2 "text"` | Fill input field |
+| `agent-browser screenshot output.png` | Take screenshot |
+| `agent-browser extract` | Extract page content |
+| `agent-browser --help` | Full command list |
+
+### Screenshot Naming Convention
+
+For `/do-pr-review` workflow, screenshots follow this pattern:
+
+```
+generated_images/{workflow_id}/{nn}_{descriptive_name}.png
+
+Examples:
+generated_images/review-auth/01_main_dashboard.png
+generated_images/review-auth/02_user_profile.png
+generated_images/review-auth/03_error_state.png
+```
+
+## Workflows
+
+Multi-step processes that combine tools for common tasks.
+
+### PR Review Workflow (`/do-pr-review`)
+
+Validate implementation against spec with screenshots.
+
+```
+/do-pr-review [workflow_id] [spec_file]
+```
+
+Steps:
+1. Detect branch and workflow ID
+2. Find matching spec in `specs/*.md`
+3. Start app with `/prepare_app`
+4. Capture screenshots via `agent-browser`
+5. Compare implementation vs spec
+6. Classify issues (blocker/tech_debt/skippable)
+7. Generate report at `agents/{workflow_id}/review/report.json`
+
+### Code Review Workflow
+
+```
+fetch PR -> analyze changes -> check tests -> post review
+```
+
+### Incident Response
+
+```
+check Sentry -> identify cause -> create fix -> deploy
+```
+
+### Research Workflow
+
+```
+search web -> summarize -> store in memory
+```
+
+## Google Workspace Tools
+
+Located in `tools/google_workspace/`.
+
+### Calendar (`valor-calendar`)
+
+Google Calendar integration for work time tracking.
+
+```bash
+valor-calendar test                    # Test OAuth connection
+valor-calendar list                    # List upcoming events
+valor-calendar create "Meeting" start end  # Create event
+```
+
+## Tool Development
+
+See `/add-feature` skill for how to create new tools.
+
+### Permission Model
+
+| Pattern | Behavior | Use For |
+|---------|----------|---------|
+| `accept` | Auto-approve | Read operations (list, get, search) |
+| `prompt` | Ask user | Write operations (create, update) |
+| `reject` | Block | Dangerous operations (delete, destroy) |
+
+## See Also
+
+- Run `/add-feature` for creating new tools
+- Check `.claude/skills/` for skill implementations

--- a/docs/guides/agent-sdk-replacement-requirements.md
+++ b/docs/guides/agent-sdk-replacement-requirements.md
@@ -1,0 +1,227 @@
+# Agent SDK Replacement: Requirements & Considerations
+
+> **Purpose:** Requirements gathering for evaluating drop-in replacements for the Claude Agent SDK (`claude-agent-sdk`).
+> **Date:** 2026-04-04
+> **Current SDK:** `claude-agent-sdk==0.1.56` + `anthropic==0.89.0` + `mcp>=1.8.0`
+
+---
+
+## 1. Core Runtime Requirements
+
+### 1.1 Async Python Client
+- Must be fully async (`await client.query()`, `async for msg in client.receive_response()`)
+- Must support concurrent sessions (multiple agents running simultaneously)
+- Must be importable as a Python library, not just a CLI wrapper
+
+### 1.2 Streaming Response Protocol
+- Must stream intermediate `AssistantMessage` objects (text blocks) as they arrive
+- Must emit a final `ResultMessage` with stop_reason, session_id, cost metadata
+- Must distinguish between partial output and final completion
+- Must support detecting rate limiting vs normal end-of-turn vs error states
+
+### 1.3 Conversation Continuation
+- Must support resuming a prior conversation by session/transcript UUID
+- Must maintain full conversation history across resume boundaries
+- Must prevent cross-session contamination (session A's history leaking into session B)
+
+### 1.4 Error Recovery
+- Must allow feeding error messages back into the agent loop for retry
+- Must expose error classification (auth error, rate limit, timeout, API failure)
+- Must support max-retry configuration with graceful degradation
+
+---
+
+## 2. Tool & MCP Integration
+
+### 2.1 MCP Server Support
+- Must support registering external MCP servers (Notion, Sentry, GitHub, Linear, Stripe, etc.)
+- Must support MCP protocol >= 1.8.0
+- Must allow dynamic tool registration (not just static config)
+
+### 2.2 Built-in Tool Surface
+- Must provide or allow registration of core tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch
+- Must support Agent tool (spawning sub-agents from within an agent)
+- Must support NotebookEdit or equivalent for Jupyter workflows
+- Must support TodoWrite or equivalent for task list management
+
+### 2.3 Tool Filtering & Restriction
+- Must support per-session tool filtering (e.g., read-only agents get only Read/Glob/Grep)
+- Must support per-agent tool definitions (agent definitions with restricted tool lists)
+- Must allow blocking specific tools or file paths dynamically via hooks
+
+---
+
+## 3. Hook System (Critical)
+
+### 3.1 Required Hook Types
+| Hook | Purpose | Our Usage |
+|------|---------|-----------|
+| **PreToolUse** | Intercept before any tool executes | Block sensitive file writes, enforce PM read-only, register DevSessions |
+| **PostToolUse** | Execute after any tool completes | Watchdog health checks, stall detection, memory injection |
+| **Stop** | Execute when agent signals completion | SDLC branch enforcement, delivery review gate, session logging |
+| **SubagentStop** | Execute when a spawned sub-agent completes | DevSession registration, pipeline stage progression, GitHub issue comments |
+| **PreCompact** | Execute before context window compaction | Logging, context preservation |
+
+### 3.2 Hook Capabilities
+- Hooks must receive tool name, arguments, and session context
+- Hooks must be able to **block** tool execution (return deny/error)
+- Hooks must be able to **inject context** back into the conversation (additionalContext)
+- Hooks must support **matcher patterns** (match specific tools or all tools)
+- Hooks must be async Python callables (not shell scripts)
+- SubagentStop must provide the sub-agent's output and identity
+
+---
+
+## 4. Agent Orchestration
+
+### 4.1 Sub-Agent Spawning
+- Must support spawning child agents from within a parent agent (Agent tool)
+- Child agents must support independent tool sets, models, and system prompts
+- Must support 30+ agent definitions with distinct personas and capabilities
+- Must support `isolation: "worktree"` or equivalent for filesystem isolation
+
+### 4.2 Agent Definitions
+- Must support defining agents with: name, description, system prompt, tool list, model override
+- Must support loading agent definitions from markdown files (frontmatter + body)
+- Must support runtime agent registration (not just static config)
+
+### 4.3 Model Selection
+- Must support specifying different models per agent (e.g., Haiku for lightweight tasks, Opus for complex)
+- Must support model override at invocation time
+
+---
+
+## 5. Authentication & Billing
+
+### 5.1 Authentication Methods
+- Must support API key authentication (`ANTHROPIC_API_KEY`)
+- **Strongly preferred:** Support subscription/OAuth authentication (Claude Max plan — zero per-token cost)
+- Must support stripping API key to force subscription fallback
+
+### 5.2 Cost Tracking
+- Must expose token usage / cost metadata on ResultMessage
+- Must support billing attribution per session
+
+---
+
+## 6. System Prompt & Context Engineering
+
+### 6.1 System Prompt Injection
+- Must support multi-part system prompts (persona base + overlay + rules + project context)
+- Must support dynamic system prompt construction at session creation time
+- Must support CLAUDE.md-style project instructions (auto-loaded from working directory)
+
+### 6.2 Environment Variable Injection
+- Must support injecting env vars into the agent's execution environment
+- Critical vars: SDLC context, GitHub repo, session type, task list ID, chat IDs
+
+### 6.3 Permission Modes
+- Must support a "bypass permissions" / YOLO mode (no confirmation prompts)
+- Must support restricting write permissions per session type
+
+---
+
+## 7. Session Management
+
+### 7.1 Session Lifecycle
+- Must expose session UUID for tracking and continuation
+- Must support activity timestamps (last tool call, last output) for stall detection
+- Must support external kill/cancel of running sessions
+- Must support timeout configuration (both inactivity and hard wall-clock)
+
+### 7.2 Concurrency
+- Must support multiple concurrent agent sessions on one machine
+- Must handle rate limiting gracefully (backoff, not crash)
+- Circuit breaker pattern support (fail fast after N failures in window)
+
+---
+
+## 8. Working Directory & Filesystem
+
+### 8.1 Project Scoping
+- Must support setting a working directory per agent session
+- Must support git operations within that directory
+- Must support worktree isolation (separate git worktrees per work item)
+
+### 8.2 File Access
+- Must have unrestricted filesystem access (read/write anywhere, not sandboxed)
+- Must support reading images, PDFs, notebooks (multimodal)
+
+---
+
+## 9. Integration Surface
+
+### 9.1 Bridge Compatibility
+- Must work as a library called from async Python (Telethon event loop)
+- Must not require a separate daemon or server process
+- Must support callback-based output delivery (not just return value)
+
+### 9.2 CLI Compatibility
+- Should support CLI invocation for local development (equivalent to `claude` CLI)
+- Should support `.claude/` directory conventions (settings, hooks, commands, agents)
+
+---
+
+## 10. Non-Functional Requirements
+
+### 10.1 Performance
+- Session startup latency: < 5 seconds
+- Must not leak memory across long-running sessions (1+ hour sessions are normal)
+- Must handle 50+ nudge cycles without degradation
+
+### 10.2 Reliability
+- Must recover from transient API failures without losing conversation state
+- Must support graceful shutdown (no orphaned processes)
+- Must work with launchd service management (auto-restart on crash)
+
+### 10.3 Observability
+- Must expose enough metadata for external health monitoring
+- Must support logging integration points (session start, tool calls, completion)
+
+---
+
+## 11. Current Coupling Points (Migration Risk)
+
+These are the specific SDK interfaces our code depends on. A replacement must either match these or we must adapt.
+
+| Interface | Location | Risk |
+|-----------|----------|------|
+| `ClaudeSDKClient` class | `agent/sdk_client.py` | High — central integration point |
+| `ClaudeAgentOptions` dataclass | `agent/sdk_client.py` | High — session configuration |
+| `AssistantMessage` / `TextBlock` | `agent/sdk_client.py` | Medium — response parsing |
+| `ResultMessage` (stop_reason, session_id, is_error) | `agent/sdk_client.py` | High — routing decisions depend on these |
+| `HookMatcher` / hook registration | `agent/hooks/__init__.py` | High — 5 hook types, complex logic |
+| `AgentDefinition` model | `agent/agent_definitions.py` | Medium — 30+ definitions |
+| `continue_conversation` / `resume` params | `agent/sdk_client.py` | High — session continuity |
+| `bypassPermissions` mode | `agent/sdk_client.py` | Medium — but critical for autonomy |
+| `.claude/` directory conventions | Various | Low — can be adapted |
+
+---
+
+## 12. Evaluation Criteria (Weighted)
+
+| Criterion | Weight | Notes |
+|-----------|--------|-------|
+| Hook system parity | **Critical** | Without hooks, we lose SDLC enforcement, security, and orchestration |
+| Sub-agent spawning | **Critical** | PM→DevSession architecture depends on this |
+| Conversation continuation | **Critical** | Session continuity across nudge loops |
+| Streaming responses | **Critical** | Real-time activity detection and stall monitoring |
+| MCP server support | **High** | 6+ MCP integrations currently active |
+| Subscription auth (Max plan) | **High** | Cost difference is significant at our volume |
+| Async Python library | **High** | Bridge is async; sync would require major refactor |
+| Tool filtering per agent | **Medium** | Nice for security but could be enforced in hooks |
+| Agent definitions from files | **Medium** | Could be adapted |
+| CLI parity | **Low** | Local dev convenience, not production-critical |
+
+---
+
+## 13. Open Questions for Research Phase
+
+1. **Which frameworks support Claude models?** (vs being OpenAI-only or model-agnostic)
+2. **Do any support the Claude subscription/Max plan billing?** (or only API key)
+3. **Hook system equivalents?** Most frameworks have middleware/callbacks — how rich are they?
+4. **Sub-agent patterns?** Native support vs DIY orchestration?
+5. **MCP protocol support?** First-class or via adapter?
+6. **Migration effort?** Wrapper/adapter layer vs full rewrite of `sdk_client.py`?
+7. **Vendor lock-in?** Model-agnostic frameworks could enable multi-model strategies
+8. **Community & maintenance?** SDK maturity, release cadence, breaking changes history

--- a/docs/guides/claude-code-feature-swot.md
+++ b/docs/guides/claude-code-feature-swot.md
@@ -1,0 +1,653 @@
+# Claude Code Feature SWOT Analysis
+
+> Reference document analyzing Claude Code CLI features and their integration with the Valor orchestration system.
+> Created 2026-03-31.
+
+## System Baseline
+
+**Claude Code CLI:** v2.1.87 (bundled with Agent SDK)
+**Agent SDK:** v0.1.52 (pinned 0.1.53)
+**Auth:** Subscription/OAuth (Max plan) — no API credit consumption
+**Spawn:** SDK wraps CLI as subprocess via `agent/sdk_client.py`
+
+---
+
+## Feature Inventory
+
+### 1. Hook Lifecycle System
+
+**What it is:** Event-driven hooks that fire at specific points in the Claude Code execution lifecycle.
+
+**Our implementation:** 8 hook types, 15+ validators in `.claude/hooks/`
+
+| Hook Event | Fires When | Our Usage |
+|------------|-----------|-----------|
+| `UserPromptSubmit` | Every prompt | Calendar context injection, memory ingestion |
+| `PreToolUse` | Before any tool | Permission validation, merge guards |
+| `PostToolUse` | After any tool | Memory recall, SDLC reminders, file validators |
+| `Stop` | Session ends | SDLC validation, memory extraction, calendar sync |
+| `SubagentStop` | Subagent completes | Subagent output processing |
+
+**Code example — memory injection via PostToolUse:**
+```python
+# .claude/hooks/post_tool_use.py (simplified)
+def handle_post_tool_use(event: dict) -> dict:
+    """Inject subconscious memory as <thought> blocks."""
+    tool_name = event.get("tool_name", "")
+    tool_input = event.get("tool_input", {})
+    
+    # Build search query from tool context
+    query = extract_search_context(tool_name, tool_input)
+    
+    # Search memory with bloom filter pre-check
+    memories = memory_search(query, limit=3)
+    
+    if memories:
+        thoughts = format_as_thought_blocks(memories)
+        return {"additionalContext": thoughts}
+    return {}
+```
+
+**Code example — commit message validation:**
+```python
+# .claude/hooks/validators/validate_commit_message.py (simplified)
+def validate(event: dict) -> dict:
+    """Block commits with co-author lines or empty messages."""
+    command = event.get("tool_input", {}).get("command", "")
+    
+    if "git commit" in command:
+        if "Co-Authored-By" in command:
+            return {
+                "decision": "block",
+                "reason": "Co-author lines not allowed per project policy"
+            }
+    return {"decision": "allow"}
+```
+
+#### SWOT
+
+| | Analysis |
+|---|---------|
+| **Strengths** | Deep integration with memory pipeline. Validators enforce quality gates automatically. Self-correcting loops (block → fix → retry). |
+| **Weaknesses** | Hook execution is synchronous — adds latency to every tool call. No hook priority/ordering system. Each hook is a separate Python process spawn. |
+| **Opportunities** | **Conditional hook loading** — only load validators relevant to current work phase. **Hook performance metrics** — track which hooks add most latency. **Async hook batching** — run independent PostToolUse hooks concurrently. |
+| **Threats** | Hook proliferation degrades performance. A buggy validator can block all work. Process spawn overhead compounds with session length. |
+
+---
+
+### 2. Specialized Agent Definitions
+
+**What it is:** 31 Markdown-defined agent personas with scoped tool access and behavioral instructions.
+
+**Our implementation:** `.claude/agents/` with builder, validator, reviewer, and domain specialist archetypes.
+
+**Architecture:**
+```
+Agent Types (by capability)
+├── Builders (full write access)
+│   ├── builder.md — General implementation
+│   ├── designer.md — UI/UX
+│   ├── data-architect.md — Schema/migration
+│   ├── agent-architect.md — Agent design
+│   └── dev-session.md — Full SDLC stage execution
+├── Validators (read-only)
+│   ├── validator.md — Acceptance verification
+│   ├── code-reviewer.md — Code quality
+│   └── baseline-verifier.md — Regression classification
+├── Domain Specialists (scoped tools)
+│   ├── stripe.md — stripe_* tools only
+│   ├── sentry.md — sentry_* tools only
+│   ├── notion.md — notion_* tools only
+│   └── linear.md — linear_* tools only
+└── Quality Experts (read + analysis)
+    ├── security-reviewer.md
+    ├── test-engineer.md
+    ├── performance-optimizer.md
+    └── debugging-specialist.md
+```
+
+**Code example — agent definition structure:**
+```markdown
+<!-- .claude/agents/validator.md -->
+---
+name: validator
+description: Read-only validation agent
+tools:
+  - Read
+  - Glob
+  - Grep
+  - WebFetch
+# Explicitly NO Write, Edit, NotebookEdit
+---
+
+You are a validation agent. Your job is to verify work meets
+acceptance criteria WITHOUT modifying any files.
+
+## Verification Checklist
+1. All plan requirements addressed
+2. Tests pass
+3. No regressions introduced
+4. Code quality standards met
+```
+
+**Code example — spawning agents from skills:**
+```python
+# Conceptual pattern used by /do-build, /do-test, etc.
+# Builder agent gets full permissions
+agent_result = spawn_agent(
+    type="builder",
+    prompt=f"""Execute task: {task_description}
+    
+    Plan: {plan_content}
+    Branch: session/{slug}
+    Worktree: .worktrees/{slug}/
+    
+    Definition of done:
+    - Tests pass
+    - Ruff clean
+    - Changes committed""",
+    isolation="worktree"
+)
+
+# Validator agent verifies (read-only)
+validation = spawn_agent(
+    type="validator", 
+    prompt=f"Verify the builder's work against: {acceptance_criteria}"
+)
+```
+
+#### SWOT
+
+| | Analysis |
+|---|---------|
+| **Strengths** | Tool scoping reduces context pollution. Domain agents (Stripe, Sentry) can't accidentally touch code. Builder/validator separation enforces review discipline. |
+| **Weaknesses** | 31 agents = significant maintenance surface. Agent definitions are static Markdown — no dynamic capability adjustment. No agent performance tracking. |
+| **Opportunities** | **Agent composition** — chain agents (builder → validator → reviewer) as reusable pipelines. **Dynamic tool scoping** — adjust available tools based on task context. **Agent metrics** — track success rates, time-to-complete per agent type. |
+| **Threats** | Agent proliferation without pruning. Context window consumed by agent system prompts. Unclear which agent to use for edge cases. |
+
+---
+
+### 3. SDLC Pipeline Orchestration
+
+**What it is:** Automated software development lifecycle with stage-based routing.
+
+**Our implementation:** `Plan → Critique → Build → Test → Patch → Review → Patch → Docs → Merge`
+
+**Architecture:**
+```
+Telegram Message
+    → ChatSession (PM persona, read-only)
+        → /sdlc (single-stage router)
+            → Assesses current state
+            → Invokes ONE sub-skill:
+                /do-plan    → Creates plan doc on main
+                /do-build   → Executes plan in worktree
+                /do-test    → Runs test suite
+                /do-patch   → Fixes failures
+                /do-pr-review → Code review
+                /do-docs    → Documentation sync
+                /do-merge   → Merge gate
+            → Returns to ChatSession
+        → ChatSession decides next stage
+```
+
+**Code example — SDLC state assessment:**
+```python
+# Conceptual /sdlc routing logic
+def assess_and_route(context: dict) -> str:
+    """Determine which SDLC stage to invoke next."""
+    has_plan = check_plan_exists(context["slug"])
+    has_branch = check_branch_exists(f"session/{context['slug']}")
+    has_pr = check_pr_exists(context["slug"])
+    tests_pass = check_test_status(context["slug"])
+    
+    if not has_plan:
+        return "/do-plan"
+    if not has_branch:
+        return "/do-build"
+    if not tests_pass:
+        return "/do-patch"
+    if not has_pr:
+        return "/do-pr-review"  # Creates PR
+    if pr_has_blockers(context["slug"]):
+        return "/do-patch"
+    return "/do-merge"
+```
+
+**Code example — job queue for sequential SDLC:**
+```python
+# tools/job_scheduler.py — playlist mode
+python -m tools.job_scheduler playlist --issues 440 445 397
+
+# Each issue processed sequentially:
+# 1. Issue 440: plan → build → test → patch → review → docs → merge
+# 2. Issue 445: (starts after 440 completes)
+# 3. Issue 397: (starts after 445 completes)
+```
+
+#### SWOT
+
+| | Analysis |
+|---|---------|
+| **Strengths** | Full lifecycle automation. ChatSession/DevSession separation prevents scope creep. Job queue enables batch processing. Auto-continue keeps work flowing. |
+| **Weaknesses** | Sequential execution only — one issue at a time. Pipeline is rigid (can't skip stages easily). Patch loops can stall on flaky tests. |
+| **Opportunities** | **Parallel SDLC** — multiple issues in separate worktrees simultaneously. **Stage skipping** — allow fast-tracking for trivial changes. **Pipeline analytics** — track bottleneck stages, average time per stage. |
+| **Threats** | Worktree parallel execution risks shared resource conflicts (Redis, ports). Long pipelines consume significant compute. Failed merges can block the queue. |
+
+---
+
+### 4. Subconscious Memory Pipeline
+
+**What it is:** Persistent memory system that learns from interactions and injects relevant context.
+
+**Our implementation:** Redis-backed with Popoto ORM, BM25+RRF search, Bloom filter, decay scoring.
+
+**Architecture:**
+```
+Memory Lifecycle
+├── Ingestion
+│   ├── Human messages saved on receipt (importance=6.0)
+│   ├── Post-session Haiku extraction (corrections=4.0, patterns=1.0)
+│   ├── Intentional saves via CLI (importance=7.0-8.0)
+│   └── Post-merge learning extraction (importance=7.0)
+├── Retrieval
+│   ├── Bloom filter pre-check (fast rejection)
+│   ├── BM25 + RRF fusion search
+│   ├── Multi-query decomposition for broad coverage
+│   └── Injected as <thought> blocks via PostToolUse hook
+├── Reinforcement
+│   ├── Outcome detection (bigram overlap)
+│   ├── ObservationProtocol strengthen/weaken
+│   └── Dismissal tracking with importance decay
+└── Maintenance
+    ├── Reflections script (scheduled via launchd)
+    └── Memory consolidation (planned)
+```
+
+**Code example — memory search with metadata:**
+```bash
+# Search with category filter
+python -m tools.memory_search search "redis connection" --category correction
+
+# Save architectural decision
+python -m tools.memory_search save \
+  "Chose ContextAssembler over raw Redis queries — provides decay-aware scoring" \
+  --importance 7.0 --source agent
+
+# Inspect memory statistics
+python -m tools.memory_search inspect --stats
+```
+
+**Code example — thought injection pattern:**
+```python
+# How memories surface in agent context (hook_utils/memory_bridge.py)
+def inject_memories(query: str, file_context: str) -> str:
+    """Search memories and format as thought blocks."""
+    memories = search(query, limit=3, category=None)
+    
+    if not memories:
+        return ""
+    
+    thoughts = []
+    for mem in memories:
+        thoughts.append(
+            f"<thought>I recall: {mem['content']}</thought>"
+        )
+    return "\n".join(thoughts)
+```
+
+#### SWOT
+
+| | Analysis |
+|---|---------|
+| **Strengths** | Passive extraction means no explicit user action needed. Bloom filter makes retrieval fast. Category/tag system enables targeted recall. Decay prevents stale memories from dominating. |
+| **Weaknesses** | Passive extraction is low-signal (importance 1.0-4.0). No memory consolidation (similar memories accumulate). Bloom filter false positives waste search cycles. No memory expiry/TTL. |
+| **Opportunities** | **Scheduled consolidation** — merge similar memories nightly via cron. **Memory TTL** — use Popoto's undocumented TTL feature for auto-expiry. **Cross-project memory** — share learnings between projects. **Importance recalibration** — periodic review of memory importance scores. |
+| **Threats** | Memory volume grows unbounded without consolidation. High-importance noise drowns signal. Redis memory pressure under heavy extraction. |
+
+---
+
+### 5. Worktree Isolation
+
+**What it is:** Git worktrees provide filesystem-isolated copies of the repo for concurrent work.
+
+**Our implementation:** `agent/worktree_manager.py` — creates `.worktrees/{slug}/` per session.
+
+**Code example — worktree lifecycle:**
+```python
+# agent/worktree_manager.py (simplified)
+WORKTREES_DIR = ".worktrees"
+
+def create_worktree(slug: str, base_branch: str = "main") -> Path:
+    """Create isolated worktree for a work item."""
+    worktree_path = Path(WORKTREES_DIR) / slug
+    branch_name = f"session/{slug}"
+    
+    # Create worktree with new branch
+    subprocess.run([
+        "git", "worktree", "add",
+        str(worktree_path),
+        "-b", branch_name,
+        base_branch
+    ])
+    
+    return worktree_path
+
+def validate_workspace(path: Path, allowed_root: Path) -> bool:
+    """Safety checks: existence, containment, slug format."""
+    if not path.exists():
+        return False
+    if not str(path.resolve()).startswith(str(allowed_root.resolve())):
+        return False  # Path escape attempt
+    return True
+```
+
+#### SWOT
+
+| | Analysis |
+|---|---------|
+| **Strengths** | True filesystem isolation — no branch switching conflicts. Each work item gets own directory. Safety validation prevents path escape. |
+| **Weaknesses** | Currently sequential — worktrees exist but only one SDLC pipeline runs at a time. Disk space grows with active worktrees. Shared resources (Redis, ports) not isolated. |
+| **Opportunities** | **Parallel SDLC execution** — the infrastructure exists, just needs orchestration. **Worktree pooling** — pre-create worktrees for faster startup. **Resource namespacing** — Redis key prefixes per worktree. |
+| **Threats** | Race conditions on shared state (git index, Redis keys). Stale worktrees consuming disk. Merge conflicts when parallel branches touch same files. |
+
+---
+
+### 6. MCP Server Ecosystem
+
+**What it is:** Model Context Protocol servers that expose external service APIs as agent tools.
+
+**Our implementation:** 12+ servers in `config/mcp_library.json`
+
+**Operational servers:**
+```
+Operational (ready)          Configured (needs_setup)
+├── GitHub (gh CLI)          ├── Linear
+├── Sentry                   ├── Stripe  
+├── Filesystem               ├── Render
+├── Gmail (OAuth)            ├── Slack
+├── Calendar (OAuth)         ├── Jira
+├── Web Search               └── Notion
+└── Notion (via Claude AI)
+```
+
+**Code example — MCP server configuration:**
+```json
+// config/mcp_library.json (simplified)
+{
+  "sentry": {
+    "category": "development",
+    "description": "Error monitoring and performance analysis",
+    "auth": {"type": "token", "env_var": "SENTRY_API_KEY"},
+    "status": "ready",
+    "tools": [
+      {"name": "search_issues", "description": "Search Sentry issues"},
+      {"name": "get_issue", "description": "Get issue details"},
+      {"name": "update_issue", "description": "Update issue status"}
+    ]
+  }
+}
+```
+
+#### SWOT
+
+| | Analysis |
+|---|---------|
+| **Strengths** | Clean abstraction — agents call tools without knowing implementation. Auth management centralized. Library pattern enables easy addition of new servers. |
+| **Weaknesses** | Static configuration — all servers loaded regardless of task. Several servers in `needs_setup` state. No dynamic server discovery. Tool count inflates context window. |
+| **Opportunities** | **Dynamic MCP loading** — only load servers relevant to current task. **MCP health monitoring** — detect and report failing servers. **Custom MCP servers** — wrap internal tools as MCP for agent access. |
+| **Threats** | Every loaded MCP server consumes context tokens. Broken servers fail silently. Auth token expiry can block entire workflows. |
+
+---
+
+### 7. Scheduled Automation (Cron/Launchd)
+
+**What it is:** Periodic tasks running via macOS launchd.
+
+**Current schedules:**
+
+| Service | Plist | Script | Frequency |
+|---------|-------|--------|-----------|
+| Bridge | `com.valor.bridge` | `scripts/start_bridge.sh` | Always on |
+| Watchdog | `com.valor.bridge-watchdog` | `monitoring/bridge_watchdog.py` | Every 60s |
+| Issue Poller | `com.valor.issue-poller` | Issue polling script | Every 5min |
+| Reflections | `com.valor.reflections` | `scripts/reflections.py` | Scheduled |
+| AutoExperiment | `com.valor.autoexperiment` | `scripts/autoexperiment.py` | Nightly |
+
+**Code example — reflections maintenance:**
+```bash
+# Run reflections with dry-run
+python scripts/reflections.py --dry-run
+
+# Tasks performed:
+# 1. Legacy code cleanup scan
+# 2. Log review and error pattern detection  
+# 3. Sentry error monitoring
+# 4. Task management cleanup
+# 5. Documentation staleness check
+# 6. Daily report generation
+```
+
+**Remote triggers (via /schedule skill):**
+```bash
+# Claude Code remote trigger concept
+# Schedule a recurring agent task
+/schedule create --name "nightly-health" \
+  --cron "0 2 * * *" \
+  --prompt "Run health checks on all services, report anomalies"
+```
+
+#### SWOT
+
+| | Analysis |
+|---|---------|
+| **Strengths** | Watchdog ensures bridge resilience. Reflections automate maintenance. AutoExperiment enables self-improvement. Issue poller catches new work automatically. |
+| **Weaknesses** | No scheduled memory consolidation. No scheduled test suite runs. No scheduled dependency updates. Remote triggers underutilized. |
+| **Opportunities** | **Cron memory consolidation** — nightly dedup and merge similar memories. **Scheduled regression testing** — run full test suite nightly. **Dependency audit schedule** — weekly check for outdated packages. **Health check dashboards** — aggregate scheduled check results. |
+| **Threats** | Overlapping schedules consuming resources. Scheduled tasks failing silently. Launchd complexity for cross-machine deployment. |
+
+---
+
+### 8. Web Search & Fetch
+
+**What it is:** Built-in tools for web research and content retrieval.
+
+**Available tools:**
+- **WebSearch** — Full web search with domain filtering, returns markdown results
+- **WebFetch** — URL content retrieval with HTML→markdown conversion, 15-min cache
+
+**Code example — research pattern:**
+```python
+# Agent can use WebSearch for real-time information
+# Example: researching a library before integration
+web_result = WebSearch(
+    query="pydantic-ai agent framework best practices 2026",
+    allowed_domains=["docs.pydantic.dev", "github.com"]
+)
+
+# Fetch specific documentation
+doc_content = WebFetch(
+    url="https://docs.pydantic.dev/latest/agents/",
+    prompt="Extract the key patterns for agent tool definition"
+)
+```
+
+#### SWOT
+
+| | Analysis |
+|---|---------|
+| **Strengths** | Real-time information access. Domain filtering prevents noise. Caching reduces redundant fetches. |
+| **Weaknesses** | Not currently used in any automated pipeline. US-only limitation. No integration with memory system (fetched knowledge isn't persisted). |
+| **Opportunities** | **Research-to-memory pipeline** — auto-save valuable web findings as memories. **Dependency documentation fetching** — auto-fetch docs for new libraries. **Competitive analysis** — scheduled web research on relevant tools/frameworks. |
+| **Threats** | Web content quality varies. Rate limiting on frequent searches. Stale cache serving outdated info. |
+
+---
+
+## Consolidated SWOT Matrix
+
+### Strengths (Leverage These)
+
+1. **Mature hook pipeline** — 15+ validators, memory injection, quality gates
+2. **31 specialized agents** — right tool for every job, scoped permissions
+3. **Full SDLC automation** — plan through merge with auto-continue
+4. **Subconscious memory** — passive learning, contextual recall, decay scoring
+5. **Worktree infrastructure** — isolation exists, ready for parallel use
+6. **Self-healing bridge** — watchdog, crash recovery, escalation levels
+7. **Subscription auth** — no API credit consumption for Claude Code sessions
+
+### Weaknesses (Address These)
+
+1. **Sequential SDLC execution** — one issue at a time despite worktree support
+2. **No memory consolidation** — unbounded growth of low-signal memories
+3. **Static MCP loading** — all servers loaded, context window waste
+4. **No scheduled validation** — tests only run during SDLC pipeline
+5. **Hook performance** — synchronous execution, process spawn per hook
+6. **Agent sprawl** — 31 agents with no usage metrics or pruning strategy
+7. **Remote triggers underutilized** — scheduling capability exists but unused
+
+### Opportunities (Pursue These)
+
+1. **Worktree-parallel SDLC** — direct throughput multiplier, infrastructure ready
+2. **Cron memory consolidation** — nightly dedup, TTL expiry, importance recalibration
+3. **Dynamic MCP loading** — task-aware server activation, context savings
+4. **Scheduled regression testing** — nightly full suite, trend detection
+5. **Pipeline analytics** — track stage durations, bottlenecks, success rates
+6. **WebSearch integration** — research-to-memory pipeline for persistent knowledge
+7. **Agent metrics** — success rates per agent type, inform pruning decisions
+
+### Threats (Mitigate These)
+
+1. **Context window bloat** — expanding tooling competes for limited context space
+2. **Worktree race conditions** — shared resources (Redis, ports, git) under parallel load
+3. **Memory system overload** — higher session volume increases extraction/retrieval pressure
+4. **Hook latency accumulation** — more hooks = slower tool execution
+5. **Stale worktrees** — disk consumption from abandoned work items
+6. **Auth token expiry** — MCP servers and OAuth tokens failing mid-session
+
+---
+
+## Recommended Roadmap (Priority Order)
+
+### Phase 1: Low-Effort, High-Impact (1-2 weeks)
+
+**1.1 Cron Memory Consolidation**
+- Schedule nightly job to deduplicate similar memories (cosine similarity > 0.85)
+- Apply TTL to low-importance memories (Popoto's `Meta.ttl`)
+- Recalibrate importance scores based on access patterns
+- *Impact: Reduces memory noise, improves retrieval quality*
+
+**1.2 WebSearch Integration in Research Phases**
+- Add WebSearch to `/do-plan` for library/API research during planning
+- Save valuable findings as memories (importance=5.0, category="research")
+- *Impact: Better-informed plans, persistent knowledge base*
+
+**1.3 Scheduled Regression Testing**
+- Launchd job running `pytest tests/unit/ -n auto` nightly
+- Results posted to Telegram with pass/fail delta from previous run
+- *Impact: Catch regressions before they compound*
+
+### Phase 2: Medium-Effort, High-Impact (2-4 weeks)
+
+**2.1 Worktree-Parallel SDLC**
+- Enable concurrent SDLC pipelines in separate worktrees
+- Resource namespacing: Redis key prefixes per worktree slug
+- Port allocation: dynamic port assignment for test servers
+- Concurrency limit: max 3 parallel pipelines (resource safety)
+- *Impact: 2-3x throughput on independent issues*
+
+**2.2 Dynamic MCP Server Loading**
+- Analyze task context to determine required MCP servers
+- Load only relevant servers per session (e.g., Sentry only for bug fixes)
+- Lazy-load pattern: start with core servers, add on demand
+- *Impact: Significant context window savings*
+
+**2.3 Pipeline Analytics**
+- Track per-stage duration, patch loop counts, success/failure rates
+- Store in Redis with daily aggregation
+- Surface via web dashboard (`ui/`)
+- *Impact: Data-driven pipeline optimization*
+
+### Phase 3: High-Effort, Transformative (4-8 weeks)
+
+**3.1 Agent Performance Tracking**
+- Log agent invocations with outcome (success/failure/timeout)
+- Track cost per agent type (tokens consumed)
+- Identify underused agents for pruning
+- *Impact: Lean agent roster, cost optimization*
+
+**3.2 Hook Performance Optimization**
+- Batch independent hooks for concurrent execution
+- Conditional hook loading based on SDLC stage
+- Hook latency metrics and slow-hook alerting
+- *Impact: Faster tool execution, reduced session overhead*
+
+**3.3 Cross-Project Memory Sharing**
+- Memory partitioning with controlled cross-project queries
+- Shared "organizational knowledge" partition
+- Privacy controls for project-specific memories
+- *Impact: Learnings from one project benefit all projects*
+
+---
+
+## Architecture Diagrams
+
+### Current State
+```
+                    ┌─────────────────────────────┐
+                    │        Telegram Bridge       │
+                    │   (bridge/telegram_bridge)   │
+                    └──────────┬──────────────────┘
+                               │
+                    ┌──────────▼──────────────────┐
+                    │      ChatSession (PM)        │
+                    │   read-only orchestrator     │
+                    │   nudge loop for routing     │
+                    └──────────┬──────────────────┘
+                               │
+                    ┌──────────▼──────────────────┐
+                    │     DevSession (Dev)         │
+                    │   full-permission executor   │
+                    └──────────┬──────────────────┘
+                               │
+              ┌────────────────┼────────────────┐
+              │                │                │
+     ┌────────▼───────┐ ┌─────▼──────┐ ┌───────▼──────┐
+     │  Claude Code   │ │   Hooks    │ │  MCP Servers │
+     │  CLI (v2.1.87) │ │  (15+ val) │ │  (12+ svrs)  │
+     └────────┬───────┘ └─────┬──────┘ └───────┬──────┘
+              │               │                │
+     ┌────────▼───────────────▼────────────────▼──────┐
+     │              Redis (Popoto ORM)                │
+     │   Sessions │ Memory │ Jobs │ Messages │ State  │
+     └────────────────────────────────────────────────┘
+```
+
+### Target State (Post-Roadmap)
+```
+                    ┌─────────────────────────────┐
+                    │        Telegram Bridge       │
+                    └──────────┬──────────────────┘
+                               │
+                    ┌──────────▼──────────────────┐
+                    │      ChatSession (PM)        │
+                    │  + pipeline analytics        │
+                    └──────────┬──────────────────┘
+                               │
+              ┌────────────────┼────────────────┐
+              │                │                │
+     ┌────────▼───────┐ ┌─────▼──────┐ ┌───────▼──────┐
+     │  DevSession 1  │ │ DevSession 2│ │ DevSession 3 │
+     │  worktree/a    │ │ worktree/b  │ │ worktree/c   │
+     └────────┬───────┘ └─────┬──────┘ └───────┬──────┘
+              │               │                │
+     ┌────────▼───────────────▼────────────────▼──────┐
+     │         Dynamic MCP + Scoped Redis             │
+     │   Namespaced keys │ Lazy-loaded servers        │
+     └────────────────────────────────────────────────┘
+              │
+     ┌────────▼───────────────────────────────────────┐
+     │              Scheduled Jobs (launchd)           │
+     │  Memory consolidation │ Regression tests │      │
+     │  Health checks │ Agent metrics collection       │
+     └────────────────────────────────────────────────┘
+```

--- a/docs/guides/ruflo-deep-dive.md
+++ b/docs/guides/ruflo-deep-dive.md
@@ -1,0 +1,157 @@
+# Ruflo Deep Dive: Transferable Patterns for Our Orchestration
+
+> Research completed 2026-03-24 for [#493](https://github.com/tomcounsell/ai/issues/493)
+
+## Executive Summary
+
+[ruflo](https://github.com/ruvnet/ruflo) is a multi-agent orchestration framework built on Claude Code with 5,875 commits and 24k stars. An investigation into its actual implementation revealed significant gaps between marketing claims and reality. However, the broader landscape research surfaced genuinely useful patterns from other frameworks (Citadel, Mem0, RouteLLM, ComposioHQ) that informed three new issues and enriched five existing ones.
+
+**Bottom line:** ruflo's core value is a well-structured metadata/state layer for multi-agent coordination via MCP. The concepts worth adopting come from the broader ecosystem, not from ruflo specifically.
+
+---
+
+## Ruflo: Claims vs. Reality
+
+| Claim | Reality | Verdict |
+|-------|---------|---------|
+| 60+ specialized agent types | 89 `SKILL.md` prompt templates; `agent spawn` supports 15 types with hardcoded defaults | Marketing overstatement |
+| Self-learning neural architecture (SONA) | Trajectory storage + keyword routing + RL weight adjustment. Real TypeScript (835 lines), but tunes heuristics, not trains models | Genuine but modest |
+| WASM-based classification | `@ruvector/rvagent-wasm` published 6 days before review (v0.1.0, 620KB). Handles trivial AST transforms. Model router uses keyword matching | Nascent/aspirational |
+| 75% cost savings from tiered routing | Keyword matching: "architect"→opus, "typo"→haiku. No benchmarks provided | Unverified |
+| Enterprise orchestration engine | MCP tool wrapper for Claude Code. Agents are JSON records in `store.json`. Actual execution is Claude Code's Task tool | Accurate but misleading framing |
+
+### What's Genuinely Good
+
+- **Task orchestrator** (`v3/@claude-flow/swarm/src/coordination/task-orchestrator.ts`): Well-structured dependency graph resolution, priority queues, status tracking
+- **RL algorithms** (9 files): Legitimate Q-Learning, SARSA, A2C, PPO, DQN implementations with proper data structures
+- **Domain-driven design**: TypeScript codebase is well-organized with clear separation of concerns
+- **Graceful degradation**: All advanced features (`@ruvector/*`) are `optionalDependencies` — system works without them
+
+### Architecture
+
+ruflo is an MCP server providing tools to Claude Code. It manages state and metadata (what agents exist, what tasks are assigned, their status), but actual "agent execution" is Claude Code calling these MCP tools and using its own Task tool to spawn sub-agents. ruflo is essentially a state-tracking and routing layer wrapping Claude Code's native capabilities.
+
+---
+
+## Landscape: What Other Frameworks Do Better
+
+### Frameworks Surveyed
+
+| Framework | Stars | Key Innovation |
+|-----------|-------|----------------|
+| [Citadel](https://github.com/SethGammon/Citadel) | 236 | 4-tier routing by orchestration overhead; circuit breaker (3 failures → force approach change); wave-based discovery relay |
+| [Genie](https://github.com/automagik-dev/genie) | 261 | 10-Critic Council for pre-implementation review; severity gates block shipping |
+| [Superset](https://github.com/superset-sh/superset) | 7.8k | Provider-agnostic orchestration; 10+ parallel agents with automatic worktree isolation |
+| [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) | 11k | Teams-first orchestration; "deep interview" Socratic requirements clarification |
+| [ComposioHQ](https://github.com/ComposioHQ/agent-orchestrator) | — | CI failures + review comments auto-routed to agents; 8 swappable plugin slots |
+| [Claude Code Agent Teams](https://code.claude.com/docs/en/agent-teams) | Built-in | File-lock task claiming; mailbox messaging; no session resumption (limitation) |
+| [Claude Code Swarm](https://github.com/rekpero/claude-code-swarm) | — | 24/7 daemon watches GitHub issues; CI review loop |
+
+### Key Research: Memory Systems
+
+[Mem0](https://mem0.ai/) ([paper](https://arxiv.org/abs/2504.19413)) provides the most rigorous benchmarks for agent memory:
+- 26% accuracy improvement over naive approaches
+- 91% lower p95 latency
+- 90% token savings
+- Graph-based memory variant captures relational structures (+2% over base)
+- Hierarchical: short-term episodic buffers → medium-term stores → long-term semantic knowledge
+- Importance scoring + dynamic forgetting to manage storage costs
+
+**Relevance:** Validates our Popoto Agent Memory approach (#394). Mem0's architecture maps directly to Popoto primitives (DecayingSortedField, WriteFilter, CoOccurrenceField, CompositeScoreQuery).
+
+### Key Research: Model Routing
+
+[RouteLLM](https://github.com/lm-sys/RouteLLM) (UC Berkeley/Anyscale) provides benchmarked cost reduction:
+- 85% cost reduction on MT Bench, 45% on MMLU, 35% on GSM8K vs. GPT-4-only
+- Four trained routers: similarity-weighted ranking, matrix factorization, BERT classifier, causal LLM
+- Generalizes to new model pairs without retraining
+- 3.66x cost savings at CPT 50%, 2.49x at CPT 80%
+
+**Relevance:** At our current scale (~50-100 sessions/day), the infrastructure cost of trained routers likely exceeds savings. Worth revisiting at 500+ sessions/day. See [#502](#model-routing-future).
+
+### Key Research: Self-Improving Prompts
+
+[DSPy](https://dspy.ai/) (Stanford) has concrete benchmarks:
+- ReAct scores: 24% → 51% on gpt-4o-mini
+- Classification accuracy: 46.2% → 64.0%
+- F1 scores doubled with few lines of code
+
+OpenAI's [GEPA](https://developers.openai.com/cookbook/examples/partners/self_evolving_agents/autonomous_agent_retraining) (Genetic-Pareto) implements evolutionary prompt optimization with `VersionedPrompt` tracking for rollback safety.
+
+**Relevance:** Future direction for our `PolicyCache` primitive (#394). Once behavioral episode memory (#393) captures success patterns, DSPy-style optimization could tune crystallized patterns automatically.
+
+---
+
+## Transferable Patterns: What We Adopted
+
+### Pattern 1: Q&A Mode (from Citadel's tiered routing)
+
+**Issue:** [#499 — ChatSession Q&A mode](https://github.com/tomcounsell/ai/issues/499)
+
+Citadel routes by orchestration overhead, not model tier. We adapted this narrowly: ChatSession answers informational queries directly without spawning DevSession. All real work still goes through full SDLC — no shortcuts.
+
+**What we took:** The concept that not every message needs the same orchestration weight.
+**What we rejected:** Tiers 2-4 (simple fixes, parallel fleet). Risk of bypassing SDLC quality gates too high.
+
+### Pattern 2: Cross-Agent Knowledge Relay (from Mem0 + Citadel's discovery relay)
+
+**Issue:** [#500 — Cross-agent knowledge relay](https://github.com/tomcounsell/ai/issues/500)
+
+Sub-agent findings currently evaporate after each block of work. Mem0's consolidation pattern (episodic → semantic with importance scoring) combined with Citadel's brief compression concept informed a memory-based approach: persist findings in Popoto, make them searchable by future sub-agents.
+
+**What we took:** Persistent, searchable findings with natural decay.
+**What we rejected:** Wave orchestration mechanics, new `/pthread` parameters. Builds on memory system (#394) instead.
+
+### Pattern 3: Async Job Queue with Dependencies (from ComposioHQ + landscape)
+
+**Issue:** [#501 — Async job queue with branch-session mapping](https://github.com/tomcounsell/ai/issues/501)
+
+Multiple frameworks solve parallel execution via worktree isolation. We adapted this as a sequential queue with dependency tracking and automatic branch-session mapping — more valuable for our workflow than true parallelism.
+
+**What we took:** Job dependency graph (`depends_on`), deterministic branch resolution per slug+stage, session pause/resume with branch state.
+**What we rejected:** Parallel DevSessions on same machine. One at a time is fine; PM reorders the queue.
+
+---
+
+## Enriched Existing Issues
+
+| Issue | What Was Added |
+|-------|---------------|
+| [#394](https://github.com/tomcounsell/ai/issues/394) (Popoto Agent Memory) | Mem0 benchmarks validating approach; DSPy/GEPA as future PolicyCache directions; ruflo SONA reality check |
+| [#393](https://github.com/tomcounsell/ai/issues/393) (Behavioral Episode Memory) | Success pattern signals to mine; Mem0's episodic→semantic consolidation pattern |
+| [#189](https://github.com/tomcounsell/ai/issues/189) (More Souls) | Reframe from browsing to structured multi-persona compositions (Genie's 10-Critic Council) |
+| [#26](https://github.com/tomcounsell/ai/issues/26) (Multi-agent group conversation) | Claude Code Agent Teams, Citadel discovery relay, wave-based as dominant coordination pattern |
+| [#104](https://github.com/tomcounsell/ai/issues/104) (Iterative review loops) | ComposioHQ CI feedback routing; Citadel circuit breaker (3 failures → force approach change) |
+
+---
+
+## Future Considerations
+
+### Model-Tier Routing {#model-routing-future}
+
+RouteLLM proves 35-85% cost reduction with trained routers. At our current scale (~50-100 sessions/day), the infrastructure overhead likely exceeds savings. Revisit when:
+- Session volume exceeds 500/day
+- API costs become a significant line item
+- Simple heuristic routing (stage-based model selection) has been tried and found insufficient
+
+### Self-Improving Prompts
+
+DSPy and GEPA provide concrete frameworks for automated prompt optimization. Prerequisites:
+- Behavioral Episode Memory (#393) shipping — need success/failure data
+- PolicyCache primitive (#394) — need storage for optimized prompts
+- Evaluation datasets — need measurable quality criteria per task type
+
+### Claude Code Agent Teams
+
+Anthropic's built-in multi-agent feature is experimental but worth monitoring. Current limitations (no session resumption, no nested teams) make it less robust than our session management. As it matures, we may want to adopt its file-lock task claiming and mailbox messaging patterns.
+
+---
+
+## Methodology
+
+Three parallel research agents investigated:
+1. **Ruflo repo deep dive** — Fetched actual source files, traced claim→implementation for each feature
+2. **Landscape scan** — Surveyed 8+ frameworks, Mem0, RouteLLM, DSPy, OpenAI cookbooks
+3. **Our gap analysis** — Read job_queue.py, sdk_client.py, session_router.py, reflections.py, worktree_manager.py, pipeline_state.py, steer_child.py
+
+All findings cross-referenced against our codebase before issuing recommendations.


### PR DESCRIPTION
## Documentation Audit Report

**Scanned**: 139 files
**Updated**: 5 | **Deleted**: 1 | **Relocated**: 4 | **Kept**: 129

### Files Changed

- **UPDATE** `docs/features/reflections.md`: YAML example showed `_job_health_check` but actual callable is `_agent_session_health_check`
- **UPDATE** `docs/features/tools-reference.md`: Stale import `search_messages` corrected to `search_history`; Notion workflow reference updated
- **UPDATE** `docs/guides/agent-session-migration-audit.md`: References to `agent/job_queue.py` corrected to `agent/agent_session_queue.py`
- **UPDATE** `docs/features/enhanced-planning.md`: Fixed `docs/plans/shipped/` to `docs/plans/completed/`; removed dead link to `docs/guides/infra-docs.md`
- **UPDATE** `docs/README.md`: Removed stale Notion reference from architecture diagram
- **UPDATE** `CLAUDE.md`: Fixed stale paths `docs/deployment.md` and `docs/tools-reference.md` to `docs/features/` prefix
- **UPDATE** `docs/guides/valor-name-references.md`: Fixed stale paths to deployment.md and tools-reference.md
- **DELETE** `docs/guides/infra-docs.md`: Described `docs/infra/` directory structure that was never created
- **RELOCATED** `docs/tools-reference.md` → `docs/features/tools-reference.md`
- **RELOCATED** `docs/research/agent-sdk-replacement-requirements.md` → `docs/guides/agent-sdk-replacement-requirements.md`
- **RELOCATED** `docs/research/claude-code-feature-swot.md` → `docs/guides/claude-code-feature-swot.md`
- **RELOCATED** `docs/research/ruflo-deep-dive.md` → `docs/guides/ruflo-deep-dive.md`

### Files Kept (no changes needed)

<details>
<summary>129 files unchanged</summary>

All feature docs in `docs/features/`, remaining guides in `docs/guides/`, and `docs/README.md` had accurate references verified against the codebase.

</details>

### Notes

- Two references in `.claude/skills/add-feature/SKILL.md` and `.claude/skills/do-docs/SKILL.md` still point to `docs/tools-reference.md` -- these skill files are permission-restricted and need manual update
- The `docs/research/` non-canonical subdirectory has been eliminated; all three files relocated to `docs/guides/`