### PR TITLE
Fix AgentSession.get_stage_progress() TypeError from removed slug kwarg

### DIFF
--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -1169,18 +1169,12 @@ class AgentSession(Model):
             links["pr"] = self.pr_url
         return links
 
-    def get_stage_progress(self, slug: str | None = None) -> dict[str, str]:
-        """Return SDLC stage completion status via PipelineStateMachine.
-
-        Args:
-            slug: Optional work item slug for artifact-based inference.
-                  When provided, fills in pending/ready gaps by checking
-                  observable artifacts (plan file, PR, review status).
-        """
+    def get_stage_progress(self) -> dict[str, str]:
+        """Return SDLC stage completion status via PipelineStateMachine."""
         from bridge.pipeline_state import PipelineStateMachine
 
         sm = PipelineStateMachine(self)
-        return sm.get_display_progress(slug=slug)
+        return sm.get_display_progress()
 
     # === Stage-aware auto-continue helpers ===
 


### PR DESCRIPTION
## Summary
PR #733 removed the `slug` parameter from `PipelineStateMachine.get_display_progress()` but missed updating `AgentSession.get_stage_progress()`, which still passed `slug=slug`. Any call raised `TypeError`, breaking lifecycle tests and silently degrading the dashboard and summarizer emoji paths.

## Changes
- `models/agent_session.py`: drop vestigial `slug` parameter from `get_stage_progress()` and call `sm.get_display_progress()` with no kwargs
- Remove stale docstring `Args` block referencing `slug`

## Testing
Before this fix: 10 failures in `tests/integration/test_agent_session_lifecycle.py`.
After this fix: 4 failures (all 6 `TestStageProgress` + `TestSDLCLifecycle` tests now pass).

The remaining 4 failures (`TestGetStatusEmoji::test_active_session_completion`, `TestComposeStructuredSummary::test_qa_session_no_stages`, `TestQALifecycle::test_qa_flow`, `TestChitChatLifecycle::test_chat_flow`) are pre-existing and unrelated to the TypeError: they expect `_get_status_emoji()` to return the checkmark for non-milestone completions, but the current milestone-selective logic in `bridge/summarizer.py` returns `""` for those. The plan explicitly placed fixing `_get_status_emoji()` in Rabbit Holes / No-Gos.

## Verification
- `grep -rn "get_stage_progress(slug" --include="*.py"` -> no callers pass `slug=`
- `python -m ruff format --check models/agent_session.py` -> clean
- 6 of 9 originally listed failing tests now pass

Closes #759