### PR TITLE
fix(tests): update stale format_duration assertions (#799)

### DIFF
--- a/tests/unit/test_ui_app.py
+++ b/tests/unit/test_ui_app.py
@@ -56,8 +56,8 @@ class TestJinja2Filters:
     def test_format_duration_seconds(self):
         from ui.app import _filter_format_duration
 
-        assert _filter_format_duration(5.2) == "<1m"
-        assert _filter_format_duration(59.9) == "<1m"
+        assert _filter_format_duration(5.2) == "5s"
+        assert _filter_format_duration(59.9) == "60s"
 
     def test_format_duration_minutes(self):
         from ui.app import _filter_format_duration

--- a/tests/unit/test_ui_reflections_data.py
+++ b/tests/unit/test_ui_reflections_data.py
@@ -62,7 +62,7 @@ class TestReflectionFormatters:
         from ui.app import _filter_format_duration
 
         assert _filter_format_duration(None) == "-"
-        assert _filter_format_duration(5.0) == "<1m"
+        assert _filter_format_duration(5.0) == "5s"
         assert _filter_format_duration(120.0) == "2m"
         assert _filter_format_duration(7200.0) == "2h"
 


### PR DESCRIPTION
## Summary

- Updates stale `<1m` assertions in two unit test files to match the compact seconds format (`5s`, `60s`) now produced by `format_duration`
- Affects `tests/unit/test_ui_app.py` (lines 59-60) and `tests/unit/test_ui_reflections_data.py` (line 65)
- Fixes issue #799

## What changed

| File | Old assertion | New assertion |
|------|--------------|---------------|
| `tests/unit/test_ui_app.py` | `"<1m"` | `"5s"` |
| `tests/unit/test_ui_app.py` | `"<1m"` | `"60s"` |
| `tests/unit/test_ui_reflections_data.py` | `"<1m"` | `"5s"` |

## Test plan

- [x] `pytest tests/unit/test_ui_app.py::TestJinja2Filters::test_format_duration_seconds` — passes
- [x] `pytest tests/unit/test_ui_reflections_data.py::TestReflectionFormatters::test_format_duration` — passes