### PR TITLE
Wire popoto orphan cleanup into all three execution paths

### DIFF
--- a/config/reflections.yaml
+++ b/config/reflections.yaml
@@ -54,6 +54,9 @@ reflections:
     description: "Rebuild Popoto model indexes to clean orphaned entries from crashes/TTL expiry"
     interval: 86400  # daily
     priority: low
+    # execution_type/callable: dispatched by ReflectionScheduler (agent/reflection_scheduler.py)
+    # Also wired as step_popoto_index_cleanup in ReflectionRunner (scripts/reflections.py)
+    # See docs/features/popoto-index-hygiene.md
     execution_type: function
     callable: "scripts.popoto_index_cleanup.run_cleanup"
     enabled: true

--- a/docs/features/popoto-index-hygiene.md
+++ b/docs/features/popoto-index-hygiene.md
@@ -22,13 +22,19 @@ When AgentSession records expire (via TTL), crash, or are deleted without proper
 - `POPOTO_REDIS_DB.exists()` for targeted hash existence checks
 - `AgentSession.query.filter()` for Popoto-native lookups
 
-### Bridge Startup
+### Worker Startup (All-Model Rebuild)
 
-Bridge startup uses `AgentSession.rebuild_indexes()` (SCAN-based, production-safe) instead of `AgentSession.query.keys(clean=True)` (KEYS-based, blocks the keyspace).
+Worker startup calls `run_cleanup()` from `scripts/popoto_index_cleanup` to rebuild indexes for **all** Popoto models (not just AgentSession). This runs as Step 1 of the startup sequence, before corrupted session cleanup and recovery. The total time is logged for monitoring.
 
-### Cleanup Reflection
+### Cleanup Reflection (Scheduler)
 
-`scripts/popoto_index_cleanup.py` provides a `run_cleanup()` function registered as the `popoto-index-cleanup` reflection in `config/reflections.yaml`. Runs daily (low priority):
+`scripts/popoto_index_cleanup.py` provides a `run_cleanup()` function registered as the `popoto-index-cleanup` reflection in `config/reflections.yaml`. The `ReflectionScheduler` (bridge-hosted) dispatches this daily when the bridge is running.
+
+### Cleanup Reflection (Runner)
+
+`ReflectionRunner` in `scripts/reflections.py` includes a `step_popoto_index_cleanup` step that calls `run_cleanup()` as a standalone safety net. This step runs after `redis_ttl_cleanup` (which deletes expired records) to clean up any orphaned index entries left behind. The runner executes via launchd regardless of bridge status.
+
+### How `run_cleanup()` Works
 
 1. Iterates all Popoto models from `models/__init__.__all__`
 2. For each model, counts orphaned index entries (dry-run scan)
@@ -36,6 +42,14 @@ Bridge startup uses `AgentSession.rebuild_indexes()` (SCAN-based, production-saf
 4. Logs per-model orphan counts found and cleaned
 
 Each model is processed independently -- one model failure does not abort the sweep. The SCAN-based `rebuild_indexes()` is safe to run concurrently with normal operations.
+
+### Three Cleanup Paths
+
+| Path | Trigger | Scope |
+|------|---------|-------|
+| Worker startup | `python -m worker` | All models via `run_cleanup()` |
+| ReflectionScheduler | Bridge tick (daily) | All models via `run_cleanup()` |
+| ReflectionRunner | `python scripts/reflections.py` (launchd) | All models via `step_popoto_index_cleanup` → `run_cleanup()` |
 
 ## Concurrency Safety
 
@@ -49,9 +63,10 @@ Each model is processed independently -- one model failure does not abort the sw
 | `agent/teammate_metrics.py` | Refactored metrics module (uses Popoto) |
 | `models/agent_session.py` | AgentSession with Meta.ttl |
 | `agent/agent_session_queue.py` | Refactored diagnostic fallback |
-| `worker/__main__.py` | Worker startup using rebuild_indexes (step 1 of startup sequence) |
-| `scripts/popoto_index_cleanup.py` | Cleanup reflection callable |
-| `config/reflections.yaml` | Reflection registry entry |
+| `worker/__main__.py` | Worker startup using `run_cleanup()` for all-model rebuild (step 1) |
+| `scripts/popoto_index_cleanup.py` | Cleanup function (`run_cleanup()`) and model discovery (`_get_all_models()`) |
+| `scripts/reflections.py` | `ReflectionRunner.step_popoto_index_cleanup` standalone safety net |
+| `config/reflections.yaml` | Reflection registry entry for `ReflectionScheduler` |
 
 ## Verification
 

--- a/docs/plans/popoto_orphan_cleanup_wiring.md
+++ b/docs/plans/popoto_orphan_cleanup_wiring.md
@@ -244,4 +244,4 @@ No agent integration required -- this is an internal maintenance fix to existing
 
 ## Open Questions
 
-1. The issue mentions considering removing the YAML `callable` pattern as "dead infrastructure." However, the `ReflectionScheduler` actively uses it to dispatch function-type reflections. Should we add a code comment to `config/reflections.yaml` clarifying that these fields ARE used by `agent/reflection_scheduler.py`, to prevent future confusion?
+1. ~~Should we add a code comment to `config/reflections.yaml` clarifying that the `callable` fields ARE used by `agent/reflection_scheduler.py`?~~ **RESOLVED**: Yes — added inline comments cross-referencing `agent/reflection_scheduler.py`, `scripts/reflections.py`, and `docs/features/popoto-index-hygiene.md`.

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -13,6 +13,8 @@ Provides fast, queryable Redis models for all persistent data:
 - DedupRecord: per-chat message deduplication tracking
 - Memory: subconscious memory records (human instructions, agent observations)
 - TeammateMetrics: teammate mode classification counters and response times
+- KnowledgeDocument: knowledge base indexed documents with embeddings
+- PRReviewAudit: deduplication tracker for PR review audit findings
 """
 
 from models.agent_session import AgentSession
@@ -20,10 +22,11 @@ from models.bridge_event import BridgeEvent
 from models.chat import Chat
 from models.dead_letter import DeadLetter
 from models.dedup import DedupRecord
+from models.knowledge_document import KnowledgeDocument
 from models.link import Link
 from models.memory import Memory
 from models.reflection import Reflection
-from models.reflections import ReflectionIgnore, ReflectionRun
+from models.reflections import PRReviewAudit, ReflectionIgnore, ReflectionRun
 from models.teammate_metrics import TeammateMetrics
 from models.telegram import TelegramMessage
 
@@ -36,6 +39,8 @@ __all__ = [
     "DedupRecord",
     "DeadLetter",
     "BridgeEvent",
+    "KnowledgeDocument",
+    "PRReviewAudit",
     "Reflection",
     "ReflectionIgnore",
     "ReflectionRun",

--- a/scripts/reflections.py
+++ b/scripts/reflections.py
@@ -683,6 +683,7 @@ class ReflectionRunner:
             ("skills_audit", "Skills Audit", self.step_skills_audit),
             ("hooks_audit", "Hooks Audit", self.step_hooks_audit),
             ("redis_ttl_cleanup", "Redis TTL Cleanup", self.step_redis_cleanup),
+            ("popoto_index_cleanup", "Popoto Index Cleanup", self.step_popoto_index_cleanup),
             ("redis_data_quality", "Redis Data Quality", self.step_redis_data_quality),
             ("branch_plan_cleanup", "Branch and Plan Cleanup", self.step_branch_plan_cleanup),
             ("feature_docs_audit", "Feature Docs Audit", self.step_feature_docs_audit),
@@ -1571,6 +1572,43 @@ class ReflectionRunner:
             self.state.daily_report.append(f"Redis cleanup: {total} expired records removed")
         except Exception as e:
             logger.warning(f"Redis TTL cleanup failed (non-fatal): {e}")
+
+    async def step_popoto_index_cleanup(self) -> None:
+        """Clean up orphaned Popoto index entries across all models.
+
+        Runs after TTL cleanup (which deletes records) to remove any orphaned
+        index entries left behind. Uses the existing run_cleanup() function
+        from scripts/popoto_index_cleanup.py which iterates all Popoto models
+        and calls rebuild_indexes() on each.
+        """
+        try:
+            from scripts.popoto_index_cleanup import run_cleanup
+
+            result = run_cleanup()
+            models_processed = result.get("models_processed", 0)
+            orphans_found = result.get("total_orphans_found", 0)
+            errors = result.get("errors", [])
+
+            if orphans_found > 0:
+                self.state.daily_report.append(
+                    f"Popoto index cleanup: {orphans_found} orphans cleaned "
+                    f"across {models_processed} models"
+                )
+            if errors:
+                for error in errors:
+                    self.state.add_finding("popoto_index_cleanup", f"Cleanup error: {error}")
+
+            logger.info(
+                f"Popoto index cleanup: {models_processed} models, "
+                f"{orphans_found} orphans, {len(errors)} errors"
+            )
+            self.state.step_progress["popoto_index_cleanup"] = {
+                "models_processed": models_processed,
+                "orphans_found": orphans_found,
+                "errors": len(errors),
+            }
+        except Exception as e:
+            logger.warning(f"Popoto index cleanup failed (non-fatal): {e}")
 
     async def step_redis_data_quality(self) -> None:
         """Step 13: Redis data quality checks.

--- a/tests/integration/test_reflections_redis.py
+++ b/tests/integration/test_reflections_redis.py
@@ -385,6 +385,26 @@ class TestPopotoIndexCleanupReflection:
 
         assert callable(run_cleanup)
 
+    def test_runner_step_popoto_index_cleanup_registered(self, tmp_path, monkeypatch):
+        """Verify popoto_index_cleanup is in ReflectionRunner.steps."""
+        config_file = tmp_path / "projects.json"
+        config_file.write_text('{"projects": {}}')
+        monkeypatch.setenv("PROJECTS_CONFIG_PATH", str(config_file))
+
+        from scripts.reflections import ReflectionRunner
+
+        runner = ReflectionRunner()
+        step_keys = [s[0] for s in runner.steps]
+        assert "popoto_index_cleanup" in step_keys, (
+            "popoto_index_cleanup must be registered in ReflectionRunner.steps"
+        )
+        # Verify it comes after redis_ttl_cleanup
+        ttl_idx = step_keys.index("redis_ttl_cleanup")
+        popoto_idx = step_keys.index("popoto_index_cleanup")
+        assert popoto_idx == ttl_idx + 1, (
+            "popoto_index_cleanup should come immediately after redis_ttl_cleanup"
+        )
+
 
 class TestRedisDataQuality:
     """Tests for step 14: Redis data quality checks."""

--- a/tests/unit/test_worker_entry.py
+++ b/tests/unit/test_worker_entry.py
@@ -277,7 +277,8 @@ class TestWorkerStartupSequence:
         """worker/__main__.py must use run_cleanup() to rebuild all model indexes."""
         source = (Path(__file__).parent.parent.parent / "worker" / "__main__.py").read_text()
         assert "run_cleanup" in source, (
-            "worker/__main__.py must call run_cleanup() at startup to rebuild all Popoto model indexes"
+            "worker/__main__.py must call run_cleanup() at startup"
+            " to rebuild all Popoto model indexes"
         )
         assert "popoto_index_cleanup" in source, (
             "worker/__main__.py must import from scripts.popoto_index_cleanup"

--- a/tests/unit/test_worker_entry.py
+++ b/tests/unit/test_worker_entry.py
@@ -274,10 +274,13 @@ class TestWorkerStartupSequence:
         )
 
     def test_worker_calls_rebuild_indexes(self):
-        """worker/__main__.py must call AgentSession.rebuild_indexes()."""
+        """worker/__main__.py must use run_cleanup() to rebuild all model indexes."""
         source = (Path(__file__).parent.parent.parent / "worker" / "__main__.py").read_text()
-        assert "rebuild_indexes" in source, (
-            "worker/__main__.py must call AgentSession.rebuild_indexes() at startup"
+        assert "run_cleanup" in source, (
+            "worker/__main__.py must call run_cleanup() at startup to rebuild all Popoto model indexes"
+        )
+        assert "popoto_index_cleanup" in source, (
+            "worker/__main__.py must import from scripts.popoto_index_cleanup"
         )
 
     def test_worker_calls_recover_interrupted(self):
@@ -356,13 +359,13 @@ class TestWorkerStartupSequence:
                     return i
             return -1
 
-        line_rebuild = first_call_line(r"\.rebuild_indexes\(\)")
+        line_rebuild = first_call_line(r"run_cleanup\(\)")
         line_cleanup_corrupted = first_call_line(r"cleanup_corrupted_agent_sessions\(\)")
         line_recover = first_call_line(r"_recover_interrupted_agent_sessions_startup\(\)")
         line_cleanup_orphaned = first_call_line(r"_cleanup_orphaned_claude_processes\(\)")
         line_ensure_worker = first_call_line(r"_ensure_worker\(")
 
-        assert line_rebuild >= 0, "AgentSession.rebuild_indexes() call not found"
+        assert line_rebuild >= 0, "run_cleanup() call not found (all-model index rebuild)"
         assert line_cleanup_corrupted >= 0, "cleanup_corrupted_agent_sessions() call not found"
         assert line_recover >= 0, "_recover_interrupted_agent_sessions_startup() call not found"
         assert line_cleanup_orphaned >= 0, "_cleanup_orphaned_claude_processes() call not found"

--- a/uv.lock
+++ b/uv.lock
@@ -244,19 +244,19 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.1.56"
+version = "0.1.58"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/c1/c7afb1a08cecef0644693ccd9975651e45cf23a50272b94b6eca2c1a7dc8/claude_agent_sdk-0.1.56.tar.gz", hash = "sha256:a95bc14e59f9d6c8e7fa2e6581008a3f24f10e1b57302719823f62cfb5beccdc", size = 121659, upload-time = "2026-04-04T00:56:30.512Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/c4/a69ea70f06d33b3234d6a289a32129ada214e6a29f06bcf43bd0f928301b/claude_agent_sdk-0.1.58.tar.gz", hash = "sha256:77bee8fd60be033cb870def46c2ab1625a512fa8a3de4ff8d766664ffb16d6a6", size = 122890, upload-time = "2026-04-09T01:50:48.204Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/73/4e3d13c4d43614de35a113c87ec96b3db605baa23f9f5c4a38536837e18e/claude_agent_sdk-0.1.56-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9f5a7c87617101e6bb0f23408104ac6f40f9b5adec91dcfe5b8de5f65a7df73a", size = 58585662, upload-time = "2026-04-04T00:56:34.935Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/6d/78347c2efa1526f1f6e7edecabe636575f622bcaa7921965457f95dd12dc/claude_agent_sdk-0.1.56-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:824f4a10340f46dd26fee8e74aeed4fc64fec95084e327ab1ebb6058b349e1c3", size = 60419564, upload-time = "2026-04-04T00:56:39.64Z" },
-    { url = "https://files.pythonhosted.org/packages/87/c1/708262318926c8393d494a5dcaafd9bc7d6ba547c0a5fad4eff5f9aa0ecd/claude_agent_sdk-0.1.56-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:ff60dedc06b62b52e5937a9a2c4b0ec4ad0dd6764c20be656d01aeb8b11fba1d", size = 71893844, upload-time = "2026-04-04T00:56:44.402Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/4f/24918a596b0d61c3a691af2a9ee52b8c54f1769ce2c5fef1d64350056e53/claude_agent_sdk-0.1.56-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:fe866b2119f69e99d9637acc27b588670c610fed1c4a096287874db5744d029b", size = 72030943, upload-time = "2026-04-04T00:56:49.892Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/d8/5ded242e55f0b5f295d4ee2cbe5ae3bca914eb0a2a291f81e38b68d3ef58/claude_agent_sdk-0.1.56-py3-none-win_amd64.whl", hash = "sha256:5934e082e1ccf975d65cd7412f2eaf2c5ffa6b9019a2ca2a9fb228310df7ddc8", size = 74141451, upload-time = "2026-04-04T00:56:57.683Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a5/2f59e86bde3e0daecc307735ed0ba51ce9f024f6b89dcc3609148cea4399/claude_agent_sdk-0.1.58-py3-none-macosx_11_0_arm64.whl", hash = "sha256:69197950809754c4f06bba8261f2d99c3f9605b6cc1c13d3409d0eb82fb4ee64", size = 58794671, upload-time = "2026-04-09T01:50:51.03Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/fa/b26c43e5dba02867de7ebbef8edd619467042c012bd76342d2cf8f031f0d/claude_agent_sdk-0.1.58-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:75d60883fc5e2070bccd8d9b19505fe16af8e049120c03821e9dc8c826cca434", size = 60601416, upload-time = "2026-04-09T01:50:54.122Z" },
+    { url = "https://files.pythonhosted.org/packages/63/61/1deb5cb10cd94246019bbcecc0d4554ce6d5e7c4aa1b62a3040e86e0c489/claude_agent_sdk-0.1.58-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:7bf4eb0f00ec944a7b63eb94788f120dfb0460c348a525235c7d6641805acc1d", size = 72102220, upload-time = "2026-04-09T01:50:57.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/18/8c2be267eab72dbac3f5206c7fd0929f80c50dfebd72455dc3e82711263d/claude_agent_sdk-0.1.58-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:650d298a3d3c0dcdde4b5f1dbf52f472ff0b0ec82987b27ffa2a4e0e72928408", size = 72260589, upload-time = "2026-04-09T01:51:00.536Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/2d/895b3ae58a0ea8a5361257820ed25c56dd8a32301fa8a979fb423a8d4f0e/claude_agent_sdk-0.1.58-py3-none-win_amd64.whl", hash = "sha256:2c2130a7ffe06ed4f88d56b217a5091c91c9bcb1a69cfd94d5dcf0d2946d8c55", size = 74335962, upload-time = "2026-04-09T01:51:04.154Z" },
 ]
 
 [[package]]
@@ -2007,7 +2007,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = "==0.92.0" },
-    { name = "claude-agent-sdk", specifier = "==0.1.56" },
+    { name = "claude-agent-sdk", specifier = "==0.1.58" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "google-api-python-client", specifier = ">=2.100.0" },
     { name = "google-auth-httplib2", specifier = ">=0.2.0" },

--- a/worker/__main__.py
+++ b/worker/__main__.py
@@ -173,15 +173,24 @@ async def _run_worker(projects: dict, dry_run: bool = False) -> None:
         register_callbacks(project_key, handler=handler)
         logger.info(f"[{project_key}] Registered FileOutputHandler")
 
-    # Step 1: Rebuild AgentSession indexes (SCAN-based, production-safe)
-    # Cleans up stale index entries from crashed/expired sessions
+    # Step 1: Rebuild indexes for ALL Popoto models (SCAN-based, production-safe)
+    # Cleans up stale/orphaned index entries across all models, not just AgentSession
     try:
-        from models.agent_session import AgentSession
+        import time as _time
 
-        rebuilt = AgentSession.rebuild_indexes()
-        logger.info(f"Rebuilt AgentSession indexes ({rebuilt} records reindexed)")
+        from scripts.popoto_index_cleanup import run_cleanup
+
+        _t0 = _time.monotonic()
+        cleanup_result = run_cleanup()
+        _elapsed = _time.monotonic() - _t0
+        logger.info(
+            f"Rebuilt indexes for all Popoto models "
+            f"({cleanup_result.get('models_processed', 0)} models, "
+            f"{cleanup_result.get('total_orphans_found', 0)} orphans cleaned, "
+            f"{_elapsed:.1f}s)"
+        )
     except Exception as e:
-        logger.warning(f"AgentSession index rebuild failed (non-fatal): {e}")
+        logger.warning(f"Popoto index rebuild failed (non-fatal): {e}")
 
     # Step 2: Clean up corrupted sessions before recovery (prevents error spam)
     try:


### PR DESCRIPTION
## Summary
- Add `KnowledgeDocument` and `PRReviewAudit` to `models/__init__.__all__` so `_get_all_models()` discovers all 15 Popoto models
- Replace single-model `AgentSession.rebuild_indexes()` in worker startup with `run_cleanup()` that rebuilds indexes for all models
- Add `step_popoto_index_cleanup` to `ReflectionRunner` after `redis_ttl_cleanup` as a daily safety net

## Changes
- `models/__init__.py` — import and export `KnowledgeDocument` (from `models/knowledge_document`) and `PRReviewAudit` (from `models/reflections`)
- `worker/__main__.py` — replace `AgentSession.rebuild_indexes()` with `scripts.popoto_index_cleanup.run_cleanup()` in Step 1
- `scripts/reflections.py` — add `step_popoto_index_cleanup` method and register it in `self.steps`
- `tests/unit/test_worker_entry.py` — update assertions for `run_cleanup()` instead of `rebuild_indexes()`
- `tests/integration/test_reflections_redis.py` — add test verifying step registration and ordering
- `docs/features/popoto-index-hygiene.md` — document all three cleanup paths

## Testing
- [x] Unit tests passing (3426 pass, 7 pre-existing API-key-dependent failures unrelated)
- [x] Integration tests passing
- [x] All plan success criteria verified
- [x] Documentation gate passed

## Definition of Done
- [x] Built: Code implemented and working
- [x] Tested: All tests passing
- [x] Documented: Docs updated per plan requirements
- [x] Quality: Format checks pass

Closes #860