### PR TITLE
Add RECOVERY_OWNERSHIP registry for session recovery coverage

### DIFF
--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -1263,7 +1263,11 @@ def _get_agent_session_timeout(session) -> int:
 
 
 async def _agent_session_health_check() -> None:
-    """Unified health check for all sessions — the single recovery mechanism.
+    """Health check for worker-managed sessions (running and pending).
+
+    Other non-terminal statuses (active, dormant, paused, paused_circuit) are
+    monitored by the bridge-hosted watchdog in monitoring/session_watchdog.py.
+    See RECOVERY_OWNERSHIP in models/session_lifecycle.py for the full coverage map.
 
     Scans both 'running' and 'pending' sessions:
 

--- a/docs/features/session-recovery-mechanisms.md
+++ b/docs/features/session-recovery-mechanisms.md
@@ -93,6 +93,27 @@ The session system has 8 mechanisms that can revive, recover, or re-enqueue sess
 | Terminal safety | **Safe by design** -- has no `AgentSession` imports, operates at process level only |
 | Guard | N/A (no session awareness) |
 
+## Recovery Ownership
+
+Session recovery is split between two processes: the **worker** and the **bridge-hosted watchdog**. Each non-terminal status has exactly one owner responsible for detecting stuck sessions and recovering them.
+
+The authoritative registry is `RECOVERY_OWNERSHIP` in `models/session_lifecycle.py`. A unit test (`tests/unit/test_recovery_ownership.py`) asserts that every non-terminal status has a registered owner, so adding a new status without declaring ownership breaks CI.
+
+| Status | Owner | Recovery Mechanism |
+|--------|-------|--------------------|
+| `pending` | worker | `_agent_session_health_check` starts a worker for stalled pending sessions |
+| `running` | worker | `_agent_session_health_check` + `_recover_interrupted_agent_sessions_startup` reset to pending |
+| `waiting_for_children` | worker | `_agent_session_hierarchy_health_check` finalizes stuck parents |
+| `active` | bridge-watchdog | `monitoring/session_watchdog.py` `check_all_sessions` + `check_stalled_sessions` |
+| `dormant` | bridge-watchdog | `monitoring/session_watchdog.py` via `check_stalled_sessions` activity check |
+| `paused` | bridge-watchdog | `agent/hibernation.py` session-resume-drip |
+| `paused_circuit` | bridge-watchdog | `agent/sustainability.py` circuit breaker drip |
+| `superseded` | none | Transitional status; superseded sessions are finalized immediately |
+
+**Why the split exists:** The worker process owns execution lifecycle (pending, running, hierarchy). The bridge-hosted watchdog owns monitoring of sessions that are paused or waiting outside the execution loop (active, dormant, paused variants). This split emerged naturally from the bridge/worker separation (PR #826) and is now formally documented here.
+
+**Adding a new non-terminal status:** Add it to `NON_TERMINAL_STATUSES` in `models/session_lifecycle.py`, then add a corresponding entry to `RECOVERY_OWNERSHIP` with the process that will monitor it. The CI test enforces this.
+
 ## Guard Implementation: `transition_status()` `reject_from_terminal`
 
 The `transition_status()` function in `models/session_lifecycle.py` now has a `reject_from_terminal` parameter (default `True`):

--- a/models/session_lifecycle.py
+++ b/models/session_lifecycle.py
@@ -36,6 +36,21 @@ NON_TERMINAL_STATUSES = frozenset(
     }
 )
 
+# Recovery ownership — maps every non-terminal status to the process responsible
+# for detecting stuck sessions in that state and recovering them.
+# This is an informational constant; it is not used for runtime routing.
+# See docs/features/session-recovery-mechanisms.md for the full rationale.
+RECOVERY_OWNERSHIP: dict[str, str] = {
+    "pending": "worker",  # _agent_session_health_check
+    "running": "worker",  # _agent_session_health_check + startup recovery
+    "active": "bridge-watchdog",  # session_watchdog check_all/stalled
+    "dormant": "bridge-watchdog",  # session_watchdog activity check
+    "waiting_for_children": "worker",  # _agent_session_hierarchy_health_check
+    "superseded": "none",  # transitional; finalized immediately
+    "paused_circuit": "bridge-watchdog",  # sustainability.py circuit drip
+    "paused": "bridge-watchdog",  # hibernation.py session-resume-drip
+}
+
 # All known statuses
 ALL_STATUSES = TERMINAL_STATUSES | NON_TERMINAL_STATUSES
 

--- a/tests/unit/test_recovery_ownership.py
+++ b/tests/unit/test_recovery_ownership.py
@@ -1,0 +1,32 @@
+"""Tests for RECOVERY_OWNERSHIP coverage completeness.
+
+Adding a new non-terminal status without registering its recovery owner
+must break this test, forcing the developer to declare which process
+is responsible for recovering sessions in that state.
+"""
+
+from models.session_lifecycle import NON_TERMINAL_STATUSES, RECOVERY_OWNERSHIP
+
+
+class TestRecoveryOwnershipCoverage:
+    """Assert RECOVERY_OWNERSHIP covers every non-terminal status."""
+
+    def test_keys_match_non_terminal_statuses(self):
+        """RECOVERY_OWNERSHIP must have exactly the same keys as NON_TERMINAL_STATUSES."""
+        assert set(RECOVERY_OWNERSHIP.keys()) == NON_TERMINAL_STATUSES
+
+    def test_no_empty_owners(self):
+        """Every entry must have a non-empty owner string."""
+        for status, owner in RECOVERY_OWNERSHIP.items():
+            assert isinstance(owner, str) and len(owner) > 0, (
+                f"RECOVERY_OWNERSHIP[{status!r}] has empty or non-string owner: {owner!r}"
+            )
+
+    def test_owners_are_known_values(self):
+        """Owner values must be one of the recognized process names."""
+        known_owners = {"worker", "bridge-watchdog", "none"}
+        for status, owner in RECOVERY_OWNERSHIP.items():
+            assert owner in known_owners, (
+                f"RECOVERY_OWNERSHIP[{status!r}] = {owner!r} is not a known owner. "
+                f"Known: {known_owners}"
+            )


### PR DESCRIPTION
## Summary
- Adds `RECOVERY_OWNERSHIP` dict to `models/session_lifecycle.py` mapping every non-terminal status to its recovery owner process (worker, bridge-watchdog, or none)
- Creates `tests/unit/test_recovery_ownership.py` with coverage completeness test so adding a new status without registering ownership breaks CI
- Fixes misleading `_agent_session_health_check` docstring that claimed to be "the single recovery mechanism" when it only covers running and pending
- Adds Recovery Ownership section to `docs/features/session-recovery-mechanisms.md` documenting the worker-vs-bridge split

## Test plan
- [x] `pytest tests/unit/test_recovery_ownership.py -v` passes (3 tests)
- [x] `grep -c "single recovery mechanism" agent/agent_session_queue.py` returns 0
- [x] `ruff check` passes on all changed files
- [ ] Review that ownership mapping matches actual recovery mechanisms

Closes #871