### PR TITLE
Add PM session resume hydration context (#874)

### DIFF
--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -540,6 +540,71 @@ def _release_pop_lock(worker_key: str) -> None:
         logger.warning(f"[worker:{worker_key}] Pop lock release failed (non-fatal): {e}")
 
 
+async def _maybe_inject_resume_hydration(chosen, worker_key: str) -> None:
+    """Prepend resume context to a PM session's message_text if this is a resume.
+
+    Detects resume by checking for 2+ *_resume.json files in the session's log
+    directory (1 file = first start only). If resume detected and the session is
+    a PM session with a valid working_dir, prepends a <resumed-session-context>
+    block containing recent branch commits so the agent can skip completed work.
+
+    Silent on any failure -- session start must never crash due to hydration.
+    """
+    try:
+        # Gate: only PM sessions benefit from resume hydration
+        if getattr(chosen, "session_type", None) != "pm":
+            return
+
+        # Gate: working_dir must be set to avoid wrong-directory git summary
+        if not getattr(chosen, "working_dir", None):
+            logger.debug(
+                f"[worker:{worker_key}] Skipping resume hydration for session "
+                f"{chosen.id}: no working_dir set"
+            )
+            return
+
+        # Check for prior resume snapshots
+        from agent.session_logs import (
+            SESSION_LOGS_DIR,  # noqa: N811
+            _get_git_summary,
+        )
+
+        session_log_dir = SESSION_LOGS_DIR / chosen.session_id
+        if not session_log_dir.exists():
+            return
+
+        resume_files = list(session_log_dir.glob("*_resume.json"))
+        if len(resume_files) < 2:
+            return
+
+        # This is a genuine resume -- inject context
+        git_summary = _get_git_summary(working_dir=chosen.working_dir, log_depth=10)
+
+        hydration_block = (
+            "<resumed-session-context>\n"
+            "This session is resuming. The following commits already exist on the branch:\n"
+            f"{git_summary}\n"
+            "If any of these commits satisfy a stage in your current plan, skip that stage\n"
+            "and proceed to the next uncompleted stage. Do not re-dispatch work that is\n"
+            "already committed.\n"
+            "</resumed-session-context>"
+        )
+
+        original = chosen.message_text or ""
+        chosen.message_text = f"{hydration_block}\n\n{original}" if original else hydration_block
+        await chosen.async_save()
+        logger.info(
+            f"[worker:{worker_key}] Injected resume hydration into session {chosen.id} "
+            f"({len(resume_files)} prior resume files found)"
+        )
+
+    except Exception as e:
+        logger.warning(
+            f"[worker:{worker_key}] Failed to inject resume hydration for session "
+            f"{chosen.id} (non-fatal): {e}"
+        )
+
+
 async def _pop_agent_session(
     worker_key: str, is_project_keyed: bool = False
 ) -> AgentSession | None:
@@ -694,6 +759,10 @@ async def _pop_agent_session(
     finally:
         _release_pop_lock(worker_key)
 
+    # Inject resume hydration context BEFORE steering messages so the agent
+    # orients itself on prior work before processing new instructions (#874).
+    await _maybe_inject_resume_hydration(chosen, worker_key)
+
     # Drain any steering messages queued during the pending window (#619).
     # Follow-up messages arriving while the session was pending get pushed to
     # the steering queue by the bridge. We drain them here and prepend to
@@ -824,6 +893,9 @@ async def _pop_agent_session_with_fallback(
 
         chosen.started_at = datetime.now(tz=UTC)
         transition_status(chosen, "running", reason="worker picked up session (sync fallback)")
+
+        # Inject resume hydration context BEFORE steering messages (#874)
+        await _maybe_inject_resume_hydration(chosen, worker_key)
 
         # Drain steering messages (same logic as _pop_agent_session) (#619)
         try:

--- a/agent/session_logs.py
+++ b/agent/session_logs.py
@@ -22,11 +22,16 @@ SESSION_LOGS_DIR = Path(__file__).parent.parent / "logs" / "sessions"
 SESSION_LOGS_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def _get_git_summary(working_dir: str | None = None) -> str:
+def _get_git_summary(working_dir: str | None = None, log_depth: int = 3) -> str:
     """Get brief git status for snapshot context.
 
-    Runs `git status --short` and `git log --oneline -3` to capture
+    Runs `git status --short` and `git log --oneline -N` to capture
     the current working tree state and recent commit history.
+
+    Args:
+        working_dir: Directory to run git commands in. Falls back to repo root.
+        log_depth: Number of recent commits to include (default 3).
+
     Returns a combined string, or an error message on failure.
     """
     parts = []
@@ -50,7 +55,7 @@ def _get_git_summary(working_dir: str | None = None) -> str:
 
     try:
         log_result = subprocess.run(
-            ["git", "log", "--oneline", "-3"],
+            ["git", "log", "--oneline", f"-{log_depth}"],
             cwd=cwd,
             capture_output=True,
             text=True,

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -87,6 +87,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [Reflections](reflections.md) | Unified reflection scheduler with declarative YAML registry, Redis state tracking, skip-if-running guard; subsumes health check, agent-session-cleanup, branch cleanup, and 16-unit daily maintenance pipeline (including hooks audit and PR review audit) | Shipped |
 | [Reflections Dashboard](reflections-dashboard.md) | Web dashboard for monitoring reflection scheduler execution, run history, and ignore patterns at `/reflections/` | Shipped |
 | [Remote Update](remote-update.md) | Telegram command and cron for remote system updates across machines | Shipped |
+| [Resume Hydration Context](resume-hydration-context.md) | Injects recent branch commits into resumed PM sessions so the agent skips already-completed SDLC stages | Shipped |
 | [Review Workflow Screenshots](review-workflow-screenshots.md) | Screenshot capture during review for visual validation | Shipped |
 | [Scale Agent Session Queue (Popoto + Worktrees)](scale-agent-session-queue-with-popoto-and-worktrees.md) | Redis persistence and git worktrees for parallel build execution | Shipped |
 | [SDK Modernization](sdk-modernization.md) | Upgrade to SDK v0.1.35 with programmatic agents and expanded hooks | Shipped |

--- a/docs/features/resume-hydration-context.md
+++ b/docs/features/resume-hydration-context.md
@@ -1,0 +1,72 @@
+# Resume Hydration Context
+
+When a PM session resumes mid-SDLC-pipeline, the worker injects a `<resumed-session-context>` block into the first turn containing recent branch commits. This lets the agent correlate commit headlines against plan stages and skip already-completed work instead of wasting tool calls on rediscovery.
+
+## Problem
+
+Without resume hydration, a resumed PM session starts cold with no memory of prior stages. The agent re-reads files, re-runs tests, and re-dispatches stages whose commits are already in `git log`. In observed sessions, roughly 30-40% of tool calls were wasted on rediscovery after each resume.
+
+## How It Works
+
+### Resume Detection
+
+Resume is detected by checking the session's log directory (`logs/sessions/{session_id}/`) for `*_resume.json` files. Since `save_session_snapshot(event="resume")` runs on every session start, the first start always produces exactly 1 file. Two or more files means the session has been started at least twice -- a genuine resume.
+
+### Hydration Flow
+
+1. Worker pops a session via `_pop_agent_session()` or `_pop_agent_session_with_fallback()`
+2. Before steering messages are drained, `_maybe_inject_resume_hydration(chosen, worker_key)` runs
+3. If the session is a PM session, has a valid `working_dir`, and has 2+ resume files:
+   - Calls `_get_git_summary(working_dir=chosen.working_dir, log_depth=10)` for recent branch commits
+   - Prepends a `<resumed-session-context>` block to `chosen.message_text`
+   - Saves the updated session to Redis
+4. Steering messages are drained and appended after the hydration block
+5. The agent sees the context on its first turn and skips completed stages
+
+### Context Block Format
+
+```xml
+<resumed-session-context>
+This session is resuming. The following commits already exist on the branch:
+{git log --oneline -10 output}
+{git status --short output}
+If any of these commits satisfy a stage in your current plan, skip that stage
+and proceed to the next uncompleted stage. Do not re-dispatch work that is
+already committed.
+</resumed-session-context>
+```
+
+## Scoping Rules
+
+| Session Type | Receives Hydration |
+|--------------|-------------------|
+| PM           | Yes (if resumed with valid working_dir) |
+| Dev          | No -- one-shot stage executors, do not resume mid-pipeline |
+| Teammate     | No -- conversational sessions, no SDLC pipeline |
+
+## Guards
+
+- **Session type**: Only PM sessions receive hydration
+- **Working directory**: If `chosen.working_dir` is falsy, hydration is skipped with a debug log to avoid producing git state from the wrong directory
+- **Resume count**: Fewer than 2 `*_resume.json` files means first start only -- no hydration
+- **Silent failure**: The entire block is wrapped in try/except with a warning log. Session start never crashes due to hydration
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `agent/agent_session_queue.py` | `_maybe_inject_resume_hydration()` shared async helper, called from both pop paths |
+| `agent/session_logs.py` | `_get_git_summary(log_depth=10)` provides the git context with configurable depth |
+| `tests/unit/test_resume_hydration.py` | Unit tests covering all guard conditions and the happy path |
+
+## Design Decisions
+
+- **Filesystem-based resume detection** over Redis flags: no new model fields or keys needed; the resume.json files already exist as a side effect of `save_session_snapshot()`
+- **Advisory hint** over structured stage-commit mapping: the `<resumed-session-context>` block is plain text for the LLM to interpret. No fragile parsing of commit messages against stage names.
+- **`log_depth=10`** for hydration vs the default `log_depth=3` for snapshots: deeper history improves stage correlation without affecting the snapshot writer
+- **Prepend before steering** so the agent orients itself on prior work before processing new instructions
+
+## Tracking
+
+- GitHub Issue: [#874](https://github.com/tomcounsell/ai/issues/874)
+- Pull Request: [#878](https://github.com/tomcounsell/ai/pull/878)

--- a/docs/plans/resume-hydration-context.md
+++ b/docs/plans/resume-hydration-context.md
@@ -1,5 +1,5 @@
 ---
-status: Critiqued
+status: docs_complete
 type: feature
 appetite: Small
 owner: Valor

--- a/tests/unit/test_resume_hydration.py
+++ b/tests/unit/test_resume_hydration.py
@@ -1,0 +1,263 @@
+"""Tests for PM session resume hydration (#874).
+
+Validates that resumed PM sessions get a <resumed-session-context> block
+prepended to message_text, and that non-PM sessions, first starts, and
+sessions with falsy working_dir are correctly skipped.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_session(
+    session_id="test-session-123",
+    session_type="pm",
+    working_dir="/tmp/fake-worktree",
+    message_text="original message",
+):
+    """Create a minimal mock AgentSession for hydration tests."""
+    session = MagicMock()
+    session.id = "abc123"
+    session.session_id = session_id
+    session.session_type = session_type
+    session.working_dir = working_dir
+    session.message_text = message_text
+    session.async_save = AsyncMock()
+    return session
+
+
+# ---------------------------------------------------------------------------
+# _get_git_summary log_depth tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetGitSummaryLogDepth:
+    """Verify that log_depth controls the git log --oneline -N argument."""
+
+    @patch("subprocess.run")
+    def test_default_depth_is_3(self, mock_run):
+        """Default log_depth=3 produces git log --oneline -3."""
+        from agent.session_logs import _get_git_summary
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="clean", stderr="")
+        _get_git_summary(working_dir="/tmp/test")
+
+        # Find the git log call
+        log_calls = [c for c in mock_run.call_args_list if "log" in str(c)]
+        assert len(log_calls) == 1
+        assert "-3" in log_calls[0].args[0]
+
+    @patch("subprocess.run")
+    def test_custom_depth_10(self, mock_run):
+        """log_depth=10 produces git log --oneline -10."""
+        from agent.session_logs import _get_git_summary
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="clean", stderr="")
+        _get_git_summary(working_dir="/tmp/test", log_depth=10)
+
+        log_calls = [c for c in mock_run.call_args_list if "log" in str(c)]
+        assert len(log_calls) == 1
+        assert "-10" in log_calls[0].args[0]
+
+    @patch("subprocess.run")
+    def test_depth_appears_in_output(self, mock_run):
+        """Output includes commit lines from the git log call."""
+        from agent.session_logs import _get_git_summary
+
+        def side_effect(cmd, **kwargs):
+            if "status" in cmd:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            if "log" in cmd:
+                commits = "\n".join(f"abc{i} commit {i}" for i in range(5))
+                return MagicMock(returncode=0, stdout=commits, stderr="")
+            return MagicMock(returncode=1, stdout="", stderr="")
+
+        mock_run.side_effect = side_effect
+        result = _get_git_summary(working_dir="/tmp/test", log_depth=5)
+        assert "abc0 commit 0" in result
+        assert "abc4 commit 4" in result
+
+
+# ---------------------------------------------------------------------------
+# _maybe_inject_resume_hydration tests
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeInjectResumeHydration:
+    """Test the resume hydration helper."""
+
+    def _run(self, session, worker_key="test-worker"):
+        """Run the async helper synchronously."""
+        from agent.agent_session_queue import _maybe_inject_resume_hydration
+
+        asyncio.run(_maybe_inject_resume_hydration(session, worker_key))
+
+    # -- Session type gating --
+
+    def test_dev_session_skipped(self, tmp_path):
+        """Dev sessions never receive hydration regardless of resume state."""
+        session = _make_session(session_type="dev")
+        self._run(session)
+        # message_text unchanged
+        assert session.message_text == "original message"
+        session.async_save.assert_not_called()
+
+    def test_teammate_session_skipped(self, tmp_path):
+        """Teammate sessions never receive hydration."""
+        session = _make_session(session_type="teammate")
+        self._run(session)
+        assert session.message_text == "original message"
+        session.async_save.assert_not_called()
+
+    # -- Working dir guard --
+
+    def test_falsy_working_dir_none(self):
+        """PM session with working_dir=None is skipped."""
+        session = _make_session(working_dir=None)
+        self._run(session)
+        assert session.message_text == "original message"
+        session.async_save.assert_not_called()
+
+    def test_falsy_working_dir_empty_string(self):
+        """PM session with working_dir='' is skipped."""
+        session = _make_session(working_dir="")
+        self._run(session)
+        assert session.message_text == "original message"
+        session.async_save.assert_not_called()
+
+    # -- Resume detection threshold --
+
+    def test_no_resume_files_skipped(self, tmp_path):
+        """Session with 0 resume files (no log dir) is skipped."""
+        # session_id dir does not exist under tmp_path
+        with patch("agent.session_logs.SESSION_LOGS_DIR", tmp_path):
+            session = _make_session()
+            self._run(session)
+        assert session.message_text == "original message"
+        session.async_save.assert_not_called()
+
+    def test_one_resume_file_skipped(self, tmp_path):
+        """Session with exactly 1 resume file (first start only) is skipped."""
+        session_dir = tmp_path / "test-session-123"
+        session_dir.mkdir()
+        (session_dir / "1234567890_resume.json").write_text("{}")
+
+        with patch("agent.session_logs.SESSION_LOGS_DIR", tmp_path):
+            session = _make_session()
+            self._run(session)
+
+        assert session.message_text == "original message"
+        session.async_save.assert_not_called()
+
+    def test_two_resume_files_triggers_hydration(self, tmp_path):
+        """Session with 2+ resume files gets hydration prepended."""
+        session_dir = tmp_path / "test-session-123"
+        session_dir.mkdir()
+        (session_dir / "1234567890_resume.json").write_text("{}")
+        (session_dir / "1234567891_resume.json").write_text("{}")
+
+        git_summary = "Recent commits:\nabc123 Fix bug\ndef456 Add feature"
+
+        with (
+            patch("agent.session_logs.SESSION_LOGS_DIR", tmp_path),
+            patch(
+                "agent.session_logs._get_git_summary",
+                return_value=git_summary,
+            ) as mock_git,
+        ):
+            session = _make_session()
+            self._run(session)
+
+        # Hydration was injected
+        assert "<resumed-session-context>" in session.message_text
+        assert "abc123 Fix bug" in session.message_text
+        assert "original message" in session.message_text
+        session.async_save.assert_called_once()
+
+        # log_depth=10 was passed
+        mock_git.assert_called_once_with(working_dir="/tmp/fake-worktree", log_depth=10)
+
+    def test_hydration_prepends_before_original(self, tmp_path):
+        """Hydration block appears BEFORE the original message."""
+        session_dir = tmp_path / "test-session-123"
+        session_dir.mkdir()
+        (session_dir / "1234567890_resume.json").write_text("{}")
+        (session_dir / "1234567891_resume.json").write_text("{}")
+
+        with (
+            patch("agent.session_logs.SESSION_LOGS_DIR", tmp_path),
+            patch(
+                "agent.session_logs._get_git_summary",
+                return_value="commits here",
+            ),
+        ):
+            session = _make_session(message_text="do the next stage")
+            self._run(session)
+
+        # Hydration comes first
+        hydration_pos = session.message_text.index("<resumed-session-context>")
+        original_pos = session.message_text.index("do the next stage")
+        assert hydration_pos < original_pos
+
+    # -- Silent failure --
+
+    def test_git_summary_exception_does_not_crash(self, tmp_path):
+        """If _get_git_summary raises, helper returns without crashing."""
+        session_dir = tmp_path / "test-session-123"
+        session_dir.mkdir()
+        (session_dir / "1234567890_resume.json").write_text("{}")
+        (session_dir / "1234567891_resume.json").write_text("{}")
+
+        with (
+            patch("agent.session_logs.SESSION_LOGS_DIR", tmp_path),
+            patch(
+                "agent.session_logs._get_git_summary",
+                side_effect=RuntimeError("git broke"),
+            ),
+        ):
+            session = _make_session()
+            # Should not raise
+            self._run(session)
+
+        # message_text unchanged on failure
+        assert session.message_text == "original message"
+
+    # -- Glob pattern match --
+
+    def test_glob_matches_actual_filename_format(self, tmp_path):
+        """The *_resume.json glob matches the format save_session_snapshot uses."""
+        session_dir = tmp_path / "test-session-123"
+        session_dir.mkdir()
+        # Actual format: {int_timestamp}_{event}.json
+        (session_dir / "1712745600_resume.json").write_text("{}")
+        (session_dir / "1712745700_resume.json").write_text("{}")
+        # Non-resume files should NOT match
+        (session_dir / "1712745800_complete.json").write_text("{}")
+        (session_dir / "1712745900_error.json").write_text("{}")
+
+        matches = list(session_dir.glob("*_resume.json"))
+        assert len(matches) == 2
+        assert all("resume" in m.name for m in matches)
+
+    def test_three_resume_files_triggers_hydration(self, tmp_path):
+        """Session with 3 resume files (multiple resumes) also gets hydration."""
+        session_dir = tmp_path / "test-session-123"
+        session_dir.mkdir()
+        for i in range(3):
+            (session_dir / f"123456789{i}_resume.json").write_text("{}")
+
+        with (
+            patch("agent.session_logs.SESSION_LOGS_DIR", tmp_path),
+            patch(
+                "agent.session_logs._get_git_summary",
+                return_value="commits",
+            ),
+        ):
+            session = _make_session()
+            self._run(session)
+
+        assert "<resumed-session-context>" in session.message_text


### PR DESCRIPTION
## Summary
- When a PM session resumes (2+ prior `resume.json` files), prepend a `<resumed-session-context>` block with the last 10 branch commits to `message_text`, letting the agent skip already-committed SDLC stages instead of wasting tool calls on rediscovery
- Add `log_depth` parameter to `_get_git_summary()` (default 3 preserves existing behavior)
- Extract shared `_maybe_inject_resume_hydration()` helper called from both `_pop_agent_session()` and `_pop_agent_session_with_fallback()` pop paths
- Gated on PM sessions only, truthy `working_dir`, and 2+ resume files; silent failure on any exception

## Test plan
- [x] 14 unit tests in `tests/unit/test_resume_hydration.py` covering all gates and edge cases
- [x] Full unit suite passes (3572 passed)
- [x] Lint and format clean

Closes #874