### PR TITLE
Add path-containment guard to _cleanup_stale_worktree (#880)

### DIFF
--- a/agent/worktree_manager.py
+++ b/agent/worktree_manager.py
@@ -205,12 +205,46 @@ def _cleanup_stale_worktree(repo_root: Path, branch_name: str, worktree_path: st
     2. Worktree directory exists but is stale (leftover from a crashed session)
        -- ``git worktree remove --force`` removes it.
 
+    Path-containment invariant: this helper refuses to operate on any path
+    that is not strictly under ``repo_root / WORKTREES_DIR``. The precondition
+    follows the same shape as :func:`validate_workspace` (compute → check →
+    log-and-raise). The 2026-04-10 incident (issue #880) showed that trusting
+    the caller's path and falling back to a silent recursive delete can
+    recursively destroy the main repository when a session branch gets
+    checked out in the main working tree. The guard is the primary defense;
+    the fail-loud fallback is the secondary defense.
+
     Args:
         repo_root: Path to the main repository.
         branch_name: The branch name locked by the stale worktree.
         worktree_path: Path string from ``git worktree list``.
+
+    Raises:
+        RuntimeError: If ``worktree_path`` resolves to ``repo_root`` itself
+            or any path outside ``repo_root / WORKTREES_DIR``. This is a
+            loud failure by design -- see issue #880 for the incident that
+            motivated the guard.
     """
-    wt = Path(worktree_path)
+    wt = Path(worktree_path).resolve()
+    worktrees_root = (repo_root / WORKTREES_DIR).resolve()
+
+    # Path-containment guard. The ``wt == repo_root.resolve()`` clause is
+    # kept explicit for grep discoverability of the 2026-04-10 incident
+    # case (the bug was exactly ``wt == repo_root``); logically the
+    # ``is_relative_to(worktrees_root)`` clause alone would reject it.
+    # The ``logger.critical`` call MUST fire BEFORE the ``raise`` so
+    # crash-tracker correlation and log audits see the event even if a
+    # caller catches ``RuntimeError`` upstream.
+    if wt == repo_root.resolve() or not wt.is_relative_to(worktrees_root):
+        logger.critical(
+            f"Refusing to clean up worktree at {wt}: path is not under "
+            f"{worktrees_root}. branch={branch_name} repo_root={repo_root}. "
+            f"See issue #880 for the incident that motivated this guard."
+        )
+        raise RuntimeError(
+            f"Refusing to clean up worktree at {wt}: path is not under "
+            f"{worktrees_root}. Branch={branch_name}, repo_root={repo_root}."
+        )
 
     if not wt.exists():
         # Directory is gone but git still references it -- prune fixes this.
@@ -238,10 +272,23 @@ def _cleanup_stale_worktree(repo_root: Path, branch_name: str, worktree_path: st
         logger.info(f"Removed stale worktree: {worktree_path}")
     except subprocess.CalledProcessError as e:
         logger.error(f"Failed to remove stale worktree {worktree_path}: {e.stderr}")
+        # Fire logger.critical BEFORE prune_worktrees so a prune exception
+        # cannot swallow the critical log (C4). Order MUST be:
+        # logger.error -> logger.critical -> prune_worktrees -> rmtree.
+        logger.critical(
+            f"Fallback rmtree for stale worktree {wt} after git worktree "
+            f"remove failed. branch={branch_name} repo_root={repo_root}. "
+            f"See issue #880."
+        )
         # As a last resort, prune and manually remove the directory.
         prune_worktrees(repo_root)
         if wt.exists():
-            shutil.rmtree(wt, ignore_errors=True)
+            # Error suppression is intentionally absent here (see #880):
+            # silent partial destruction was the primary bug class. If this
+            # rmtree fails, we want the exception to propagate so the
+            # failure is surfaced, logged, and crash-tracked instead of
+            # leaving the repository in a half-destroyed state.
+            shutil.rmtree(wt)
             logger.info(f"Manually removed stale worktree directory: {worktree_path}")
             # Prune again to clean up the now-missing reference.
             prune_worktrees(repo_root)

--- a/docs/features/session-isolation.md
+++ b/docs/features/session-isolation.md
@@ -66,6 +66,12 @@ This makes the SDLC pipeline resilient to stale worktree state -- no manual `git
 
 See GitHub issue [#237](https://github.com/tomcounsell/ai/issues/237) for the original bug report.
 
+### Path-Containment Invariant
+
+`_cleanup_stale_worktree()` enforces a strict path-containment invariant: it will only operate on paths strictly under `repo_root / .worktrees/`. Any other input -- including `repo_root` itself -- raises `RuntimeError` before any filesystem operation runs. The `shutil.rmtree` fallback does not pass `ignore_errors=True`, so partial-destruction failures surface as real exceptions instead of being silently swallowed. Both the guard and the fallback fire `logger.critical` before acting, giving the crash tracker and log audits a correlation point.
+
+This guard was added in response to the 2026-04-10 incident (issue [#880](https://github.com/tomcounsell/ai/issues/880)), where a session branch got checked out in the main working tree and the cleanup helper was handed the main repo path; the `shutil.rmtree(..., ignore_errors=True)` fallback then recursively deleted the main repository. The guard now refuses bogus paths loudly and the fallback no longer hides errors.
+
 ### Post-Merge Worktree Cleanup
 
 When a PR is merged via `gh pr merge --squash --delete-branch`, the remote branch is deleted but local branch deletion fails if a git worktree still references it. The `cleanup_after_merge()` function handles this:

--- a/docs/features/workspace-safety-invariants.md
+++ b/docs/features/workspace-safety-invariants.md
@@ -64,10 +64,14 @@ There is an inherent time-of-check-to-time-of-use gap: the directory could be re
 - The validation here is proactive/preventive, not a sole line of defense
 - The race window is milliseconds in practice
 
+## Sibling Guard: Worktree Cleanup Path-Containment
+
+`validate_workspace()` is the **launch-time** containment guard. A sibling **delete-time** guard lives in `_cleanup_stale_worktree()` in the same module. After the 2026-04-10 incident ([#880](https://github.com/tomcounsell/ai/issues/880)), `_cleanup_stale_worktree()` refuses to operate on any path outside `repo_root / .worktrees/` (including `repo_root` itself) and its `shutil.rmtree` fallback no longer passes `ignore_errors=True`. Together these two guards establish a general invariant: *destructive filesystem operations must validate their target path.* See the [Path-Containment Invariant](session-isolation.md#path-containment-invariant) section of session-isolation.md for details.
+
 ## Implementation
 
 - **Source**: `validate_workspace()` in `agent/worktree_manager.py`
 - **Tests**: `tests/unit/test_workspace_safety.py` (23 tests across 4 test classes)
 - **Plan**: `docs/plans/workspace-safety-invariants.md`
 - **Issue**: [#306](https://github.com/tomcounsell/ai/issues/306)
-- **Prior art**: PR #304 (reactive CWD death guard)
+- **Prior art**: PR #304 (reactive CWD death guard), PR #882 / issue #880 (delete-time path guard)

--- a/tests/unit/test_worktree_manager.py
+++ b/tests/unit/test_worktree_manager.py
@@ -292,6 +292,110 @@ class TestCleanupStaleWorktree:
         # prune called twice (fallback path)
         assert mock_prune.call_count == 2
         mock_rmtree.assert_called_once()
+        # Tightened assertion for #880: ignore_errors must NOT be True.
+        # Silent partial destruction was the primary bug class; fail loud.
+        assert mock_rmtree.call_args.kwargs.get("ignore_errors") is not True
+
+    def test_guard_rejects_repo_root_path(self):
+        """Guard raises RuntimeError when worktree_path resolves to repo_root itself.
+
+        This is the exact path from the 2026-04-10 incident (issue #880):
+        a session branch got checked out in the main working tree, and the
+        helper was called with ``worktree_path == repo_root``. The guard
+        must refuse and raise loudly.
+
+        Uses ``match=r"not under"`` instead of a literal path substring
+        because ``.resolve()`` may follow platform symlinks (C3).
+        """
+        with pytest.raises(RuntimeError, match=r"not under"):
+            _cleanup_stale_worktree(Path("/repo"), "session/feat", "/repo")
+
+    def test_guard_rejects_path_outside_worktrees(self):
+        """Guard raises RuntimeError when worktree_path is outside the repo.
+
+        C3: MUST use ``match=r"not under"`` -- on macOS ``/tmp`` is a
+        symlink to ``/private/tmp``, so ``Path("/tmp/foo").resolve()``
+        returns ``/private/tmp/foo``. Any test asserting a literal
+        ``"/tmp/foo"`` substring fails on macOS but passes on Linux.
+        The ``"not under"`` phrase is platform-stable.
+        """
+        with pytest.raises(RuntimeError, match=r"not under"):
+            _cleanup_stale_worktree(Path("/repo"), "session/feat", "/tmp/foo")
+
+    def test_guard_rejects_sibling_dir_under_repo(self):
+        """Guard rejects paths inside repo_root but outside ``.worktrees/``.
+
+        A path that is under the repo but not under ``.worktrees/`` is
+        just as dangerous as a path outside the repo entirely -- the
+        helper should never recurse into arbitrary repo subdirs.
+        """
+        with pytest.raises(RuntimeError, match=r"not under"):
+            _cleanup_stale_worktree(Path("/repo"), "session/feat", "/repo/some-other-dir")
+
+    @patch("agent.worktree_manager.shutil.rmtree")
+    @patch("agent.worktree_manager.prune_worktrees")
+    @patch("agent.worktree_manager.subprocess.run")
+    @patch("agent.worktree_manager.logger")
+    def test_fallback_does_not_pass_ignore_errors(
+        self, mock_logger, mock_run, mock_prune, mock_rmtree
+    ):
+        """Fallback branch fires logger.critical before rmtree and does not
+        swallow errors via ``ignore_errors=True``.
+
+        Asserts C4 ordering: ``logger.error`` -> ``logger.critical`` ->
+        ``prune_worktrees`` -> ``rmtree``. The critical log MUST precede
+        ``prune_worktrees`` so a prune exception cannot swallow the
+        crash-tracker signal.
+        """
+        from subprocess import CalledProcessError
+
+        mock_run.side_effect = CalledProcessError(1, "git", stderr="lock error")
+        with patch.object(Path, "exists", return_value=True):
+            _cleanup_stale_worktree(Path("/repo"), "session/feat", "/repo/.worktrees/stuck")
+
+        # ignore_errors must NOT be passed as True (C1 / #880).
+        assert mock_rmtree.call_args.kwargs.get("ignore_errors") is not True
+
+        # logger.critical must have been called in the fallback branch.
+        assert mock_logger.critical.called, (
+            "logger.critical must fire in fallback branch for crash-tracker "
+            "correlation (see issue #880)"
+        )
+
+        # C4: call order must be logger.error -> logger.critical ->
+        # prune_worktrees -> rmtree. We verify this by inspecting
+        # mock_logger.mock_calls and the relative call ordering of the
+        # separately-patched mocks.
+        method_names = [
+            call[0] for call in mock_logger.mock_calls if call[0] in ("error", "critical")
+        ]
+        assert method_names[:2] == ["error", "critical"], (
+            f"Expected logger.error then logger.critical, got {method_names}"
+        )
+
+        # logger.critical must fire BEFORE prune_worktrees (C4). Compare
+        # mock_calls list positions using an ordering-sensitive Mock parent.
+        parent = MagicMock()
+        parent.attach_mock(mock_logger.critical, "critical")
+        parent.attach_mock(mock_prune, "prune")
+        parent.attach_mock(mock_rmtree, "rmtree")
+        # Re-run under the ordering mock to validate sequencing.
+        mock_run.side_effect = CalledProcessError(1, "git", stderr="lock error")
+        parent.reset_mock()
+        mock_logger.reset_mock()
+        mock_prune.reset_mock()
+        mock_rmtree.reset_mock()
+        with patch.object(Path, "exists", return_value=True):
+            _cleanup_stale_worktree(Path("/repo"), "session/feat", "/repo/.worktrees/stuck")
+        ordered = [c[0] for c in parent.mock_calls]
+        # critical must appear before prune; prune must appear before rmtree.
+        assert "critical" in ordered and "prune" in ordered and "rmtree" in ordered
+        assert ordered.index("critical") < ordered.index("prune"), (
+            f"logger.critical must precede prune_worktrees (C4). Order: {ordered}"
+        )
+        assert ordered.index("prune") < ordered.index("rmtree"), (
+            f"prune_worktrees must precede rmtree fallback. Order: {ordered}"
+        )
 
 
 class TestCreateWorktreeStaleRecovery:


### PR DESCRIPTION
## Summary

Hotfix for the 2026-04-10 incident where `_cleanup_stale_worktree` was handed the main repo path and its `shutil.rmtree(..., ignore_errors=True)` fallback recursively deleted the main working copy at `/Users/valorengels/src/ai`. Adds two layers of defense inside the helper itself:

1. **Path-containment guard** — resolves `worktree_path` and `repo_root/.worktrees`, then refuses any input that equals `repo_root` or is not relative to the worktrees root. `logger.critical` fires **before** `raise RuntimeError` so crash-tracker correlation works even if a caller catches the exception upstream (C1).
2. **Fail-loud fallback** — removed `ignore_errors=True` from the `shutil.rmtree` fallback. Reordered the `except subprocess.CalledProcessError` branch so `logger.error` → `logger.critical` → `prune_worktrees` → `rmtree`, ensuring a prune exception cannot swallow the critical log (C4).

## Changes

- `agent/worktree_manager.py::_cleanup_stale_worktree` — guard + reordered fallback + docstring update with `Raises:` section
- `tests/unit/test_worktree_manager.py::TestCleanupStaleWorktree` — four new test methods plus tightened existing fallback assertion
- `docs/features/session-isolation.md` — new "Path-Containment Invariant" subsection cross-referencing #880

## Testing

- [x] `pytest tests/unit/test_worktree_manager.py -x -q` — 32 passed
- [x] `python -m ruff check agent/worktree_manager.py tests/unit/test_worktree_manager.py` — clean
- [x] `python -m ruff format --check agent/worktree_manager.py tests/unit/test_worktree_manager.py` — clean

## Documentation

- [x] `docs/features/session-isolation.md` updated with Path-Containment Invariant section
- [x] Inline docstring + comment on `_cleanup_stale_worktree` explaining the guard and fail-loud fallback

## C2 Caller Audit (read-only)

Verified that `RuntimeError` escaping `_cleanup_stale_worktree` is handled cleanly by every transitive caller:

- `create_worktree` (`agent/worktree_manager.py:293-298`) — bare call, no `try/except`. `RuntimeError` propagates as designed.
- `get_or_create_worktree` (`agent/worktree_manager.py:372`) — delegates entirely to `create_worktree`. No additional exception handling.
- `agent/agent_session_queue.py:2700-2714` — only `worker/`-tree caller of `get_or_create_worktree`. Wrapped in `except Exception as e` with a warning log and fallback to the original `working_dir`. A guard trip is handled cleanly, not a worker crash.
- `agent/sdk_client.py` — only uses `validate_workspace`, not `get_or_create_worktree`. Not affected.

**Conclusion:** No worker-crash risk from the new `RuntimeError`. The guard can ship.

## Definition of Done

- [x] Built: Guard + fallback + tests + docs
- [x] Tested: 32/32 worktree tests pass
- [x] Documented: session-isolation.md updated
- [x] Quality: Ruff clean on touched files

Closes #880