### PR TITLE
Fix three chained bugs in SDLC merge bookkeeping

### DIFF
--- a/.claude/commands/do-merge.md
+++ b/.claude/commands/do-merge.md
@@ -17,7 +17,7 @@ from bridge.pipeline_graph import DISPLAY_STAGES
 try:
     from bridge.pipeline_state import PipelineStateMachine
     from models.agent_session import AgentSession
-    session = AgentSession.get_by_slug('$SLUG')
+    session = next((s for s in AgentSession.query.all() if s.slug == '$SLUG'), None)
     if session:
         sm = PipelineStateMachine(session)
         states = sm.get_display_progress()
@@ -81,7 +81,14 @@ python -c "
 from bridge.pipeline_state import PipelineStateMachine
 from models.agent_session import AgentSession
 
-session = AgentSession.get_by_slug('$SLUG')
+try:
+    session = next((s for s in AgentSession.query.all() if s.slug == '$SLUG'), None)
+except Exception as e:
+    print(f'ERROR: Failed to query sessions: {e}')
+    print('Fall back to manual checks if needed.')
+    print('GATES_FAILED')
+    exit()
+
 if not session:
     print('ERROR: No session found for slug $SLUG')
     print('GATES_FAILED')
@@ -138,16 +145,16 @@ Before merging, scan the plan document for unchecked items that indicate unfinis
 SLUG=$(echo "$BRANCH" | sed 's|^session/||')
 PLAN_PATH="docs/plans/${SLUG}.md"
 
+# Read plan from origin/main (authoritative copy), not from cwd (which may be a stale worktree)
+PLAN_TEXT=$(git show origin/main:${PLAN_PATH} 2>/dev/null) || { echo "WARN: No plan found at origin/main:${PLAN_PATH} -- skipping completion gate"; exit 0; }
+
 python3 -c "
 import re, sys, yaml
-from pathlib import Path
 
-plan_path = Path('$PLAN_PATH')
-if not plan_path.exists():
-    print('WARN: No plan found at $PLAN_PATH -- skipping completion gate')
+plan_text = '''$PLAN_TEXT'''
+if not plan_text.strip():
+    print('WARN: Empty plan at origin/main:$PLAN_PATH -- skipping completion gate')
     sys.exit(0)
-
-plan_text = plan_path.read_text()
 
 # Parse frontmatter for allow_unchecked override
 frontmatter_match = re.match(r'^---\n(.*?)\n---', plan_text, re.DOTALL)
@@ -247,10 +254,18 @@ BRANCH=$(gh pr view $ARGUMENTS --json headRefName -q .headRefName 2>/dev/null ||
 SLUG=$(echo "$BRANCH" | sed 's|^session/||')
 PLAN_PATH="docs/plans/${SLUG}.md"
 
-if [ -f "$PLAN_PATH" ]; then
-  python scripts/migrate_completed_plan.py "$PLAN_PATH" && echo "Plan deleted: $PLAN_PATH" || echo "WARN: Plan migration failed for $PLAN_PATH — delete manually if needed"
+# Read the authoritative plan from origin/main (plans are always committed on main, not session branches)
+if git show origin/main:${PLAN_PATH} > /tmp/plan_${SLUG}.md 2>/dev/null; then
+  python scripts/migrate_completed_plan.py "/tmp/plan_${SLUG}.md" && echo "Plan migrated: $PLAN_PATH" || echo "WARN: Plan migration failed for $PLAN_PATH — delete manually if needed"
+  # Delete the plan from the working tree if it exists
+  if [ -f "$PLAN_PATH" ]; then
+    rm -f "$PLAN_PATH"
+    git add "$PLAN_PATH" 2>/dev/null || true
+    echo "Plan file removed: $PLAN_PATH"
+  fi
+  rm -f "/tmp/plan_${SLUG}.md"
 else
-  echo "No plan at $PLAN_PATH — skipping cleanup"
+  echo "No plan at origin/main:$PLAN_PATH — skipping cleanup"
 fi
 ```
 

--- a/.claude/commands/do-merge.md
+++ b/.claude/commands/do-merge.md
@@ -148,10 +148,10 @@ PLAN_PATH="docs/plans/${SLUG}.md"
 # Read plan from origin/main (authoritative copy), not from cwd (which may be a stale worktree)
 PLAN_TEXT=$(git show origin/main:${PLAN_PATH} 2>/dev/null) || { echo "WARN: No plan found at origin/main:${PLAN_PATH} -- skipping completion gate"; exit 0; }
 
-python3 -c "
+echo "$PLAN_TEXT" | python3 -c "
 import re, sys, yaml
 
-plan_text = '''$PLAN_TEXT'''
+plan_text = sys.stdin.read()
 if not plan_text.strip():
     print('WARN: Empty plan at origin/main:$PLAN_PATH -- skipping completion gate')
     sys.exit(0)

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -25,7 +25,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [Bridge/Worker Architecture](bridge-worker-architecture.md) | Bridge/worker process separation: bridge as pure I/O adapter, worker as sole session executor, Redis contract, operator CLI. Includes `worker_key` routing (project-keyed vs chat-keyed serialization), global `MAX_CONCURRENT_SESSIONS` semaphore, Redis pop lock (TOCTOU prevention), and CLI session UUID isolation. | Shipped |
 | [Build Output Verification](build-output-verification.md) | Three-layer verification gates preventing /do-build from silently completing with no code changes | Shipped |
 | [Build Session Reliability](build-session-reliability.md) | Logging propagation, commit-on-exit, worktree isolation, health monitoring | Shipped |
-| [Chat Dev Session Architecture](pm-dev-session-architecture.md) | PM/Dev session split — session type discriminator splitting orchestration from execution | Shipped |
+| [PM/Dev Session Architecture](pm-dev-session-architecture.md) | PM/Dev session split — session type discriminator splitting orchestration from execution | Shipped |
 | [Classification](classification.md) | Auto-classification of messages as bug/feature/chore with immutability and reclassify skill | Shipped |
 | [Claude Code Memory](claude-code-memory.md) | Hook-based memory integration for Claude Code CLI sessions: prompt ingestion, tool-call recall with sliding window, deja vu signals, post-session extraction, AgentSession lifecycle tracking, and post-merge learning | Shipped |
 | [Code Impact Finder](code-impact-finder.md) | Semantic search for blast radius analysis during /do-plan | Shipped |

--- a/scripts/migrate_completed_plan.py
+++ b/scripts/migrate_completed_plan.py
@@ -83,6 +83,31 @@ def validate_feature_doc(doc_path: Path) -> tuple[bool, str]:
     return True, ""
 
 
+def extract_feature_name_from_index(feature_doc_filename: str) -> str | None:
+    """Extract the display name for a feature doc from the README index table.
+
+    Searches docs/features/README.md for a table row whose link target matches
+    the given filename (e.g., 'pm-dev-session-architecture.md') and returns the
+    bracketed display text (e.g., 'PM/Dev Session Architecture').
+
+    Returns None if no matching row is found.
+    """
+    index_path = Path("docs/features/README.md")
+    if not index_path.exists():
+        return None
+
+    content = index_path.read_text()
+
+    # Match table rows: | [Display Name](filename.md) | ... |
+    # The filename in the link target must match exactly
+    pattern = rf"\|\s*\[([^\]]+)\]\({re.escape(feature_doc_filename)}\)"
+    match = re.search(pattern, content)
+    if match:
+        return match.group(1)
+
+    return None
+
+
 def validate_feature_index(feature_name: str) -> tuple[bool, str]:
     """Validate feature is indexed in docs/features/README.md.
 
@@ -221,14 +246,22 @@ def main() -> int:
         return 1
     print("  PASS: Feature doc exists and has content")
 
-    # Extract feature name from doc path
-    feature_name = feature_doc_path.stem.replace("-", " ").title()
-    print(f"Feature name: {feature_name}")
-
-    # Validate feature index
-    valid, error = validate_feature_index(feature_name)
-    if not valid:
-        print(f"Error: {error}")
+    # Extract feature name from README index (avoids .title() mangling acronyms)
+    feature_doc_filename = feature_doc_path.name
+    feature_name = extract_feature_name_from_index(feature_doc_filename)
+    if feature_name:
+        print(f"Feature name (from index): {feature_name}")
+        # Validate using the extracted name
+        valid, error = validate_feature_index(feature_name)
+        if not valid:
+            print(f"Error: {error}")
+            return 1
+    else:
+        # Fallback: check if the filename appears as a link target in the index
+        print(
+            f"Warning: No README entry found linking to {feature_doc_filename}. "
+            f"Add entry to docs/features/README.md"
+        )
         return 1
     print("  PASS: Feature indexed in docs/features/README.md")
 

--- a/tests/unit/test_migrate_completed_plan.py
+++ b/tests/unit/test_migrate_completed_plan.py
@@ -1,0 +1,268 @@
+"""Tests for scripts/migrate_completed_plan.py.
+
+Covers Bug 1 fix: README-based display name extraction replacing .title() mangling.
+"""
+
+import re
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Import the functions under test directly
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from scripts.migrate_completed_plan import (
+    extract_feature_name_from_index,
+    validate_feature_index,
+    validate_feature_doc,
+    extract_feature_doc_path,
+)
+
+
+# --- Fixtures ---
+
+SAMPLE_README = textwrap.dedent("""\
+    # Feature Documentation Index
+
+    | Feature | Description | Status |
+    |---------|-------------|--------|
+    | [PM/Dev Session Architecture](pm-dev-session-architecture.md) | PM/Dev session split | Shipped |
+    | [SDLC Critique Stage](sdlc-critique-stage.md) | Automated plan validation | Shipped |
+    | [AI Evaluator](ai-evaluator.md) | Semantic build evaluation | Shipped |
+    | [Bridge Self-Healing](bridge-self-healing.md) | Crash recovery | Shipped |
+    | [Do-Build AI Evaluator](do-build-ai-evaluator.md) | AI evaluator step | Shipped |
+""")
+
+
+@pytest.fixture
+def mock_readme(tmp_path):
+    """Create a mock docs/features/README.md."""
+    readme_path = tmp_path / "docs" / "features" / "README.md"
+    readme_path.parent.mkdir(parents=True, exist_ok=True)
+    readme_path.write_text(SAMPLE_README)
+    return readme_path
+
+
+# --- Tests for extract_feature_name_from_index ---
+
+
+class TestExtractFeatureNameFromIndex:
+    """Test README-based display name extraction."""
+
+    def test_acronym_heavy_filename_pm(self, mock_readme):
+        """PM in filename should resolve to PM/Dev Session Architecture, not Pm/Dev..."""
+        with patch(
+            "scripts.migrate_completed_plan.Path",
+            side_effect=lambda p: mock_readme if p == "docs/features/README.md" else Path(p),
+        ):
+            # Direct test: parse the README content
+            result = _extract_from_content(SAMPLE_README, "pm-dev-session-architecture.md")
+            assert result == "PM/Dev Session Architecture"
+
+    def test_acronym_heavy_filename_sdlc(self):
+        """SDLC in filename should resolve correctly."""
+        result = _extract_from_content(SAMPLE_README, "sdlc-critique-stage.md")
+        assert result == "SDLC Critique Stage"
+
+    def test_acronym_heavy_filename_ai(self):
+        """AI in filename should resolve correctly."""
+        result = _extract_from_content(SAMPLE_README, "ai-evaluator.md")
+        assert result == "AI Evaluator"
+
+    def test_display_text_differs_from_filename(self):
+        """Display text can contain characters not in filename (e.g., slashes)."""
+        result = _extract_from_content(SAMPLE_README, "pm-dev-session-architecture.md")
+        assert result == "PM/Dev Session Architecture"
+        # Verify .title() would have mangled this
+        mangled = "pm-dev-session-architecture".replace("-", " ").title()
+        assert mangled == "Pm Dev Session Architecture"  # Wrong!
+        assert result != mangled
+
+    def test_hyphenated_compound_name(self):
+        """Compound names with hyphens (do-build) should resolve correctly."""
+        result = _extract_from_content(SAMPLE_README, "do-build-ai-evaluator.md")
+        assert result == "Do-Build AI Evaluator"
+
+    def test_missing_readme_entry(self):
+        """Filename with no matching README row returns None."""
+        result = _extract_from_content(SAMPLE_README, "nonexistent-feature.md")
+        assert result is None
+
+    def test_simple_filename(self):
+        """Simple filename without acronyms works fine."""
+        result = _extract_from_content(SAMPLE_README, "bridge-self-healing.md")
+        assert result == "Bridge Self-Healing"
+
+
+class TestValidateFeatureIndex:
+    """Test feature index validation."""
+
+    def test_feature_found_case_insensitive(self, tmp_path):
+        """validate_feature_index finds features case-insensitively."""
+        readme = tmp_path / "docs" / "features" / "README.md"
+        readme.parent.mkdir(parents=True, exist_ok=True)
+        readme.write_text(SAMPLE_README)
+
+        with _chdir(tmp_path):
+            valid, error = validate_feature_index("PM/Dev Session Architecture")
+            assert valid is True
+            assert error == ""
+
+    def test_feature_not_found(self, tmp_path):
+        """validate_feature_index returns error for missing feature."""
+        readme = tmp_path / "docs" / "features" / "README.md"
+        readme.parent.mkdir(parents=True, exist_ok=True)
+        readme.write_text(SAMPLE_README)
+
+        with _chdir(tmp_path):
+            valid, error = validate_feature_index("Nonexistent Feature XYZ")
+            assert valid is False
+            assert "Nonexistent Feature XYZ" in error
+
+    def test_no_readme_file(self, tmp_path):
+        """validate_feature_index handles missing README gracefully."""
+        with _chdir(tmp_path):
+            valid, error = validate_feature_index("Any Feature")
+            assert valid is False
+            assert "not found" in error
+
+
+class TestValidateFeatureDoc:
+    """Test feature doc validation."""
+
+    def test_valid_doc(self, tmp_path):
+        """Valid doc with title and content passes."""
+        doc = tmp_path / "feature.md"
+        doc.write_text("# My Feature\n\nThis is a substantial description of the feature.")
+        valid, error = validate_feature_doc(doc)
+        assert valid is True
+
+    def test_missing_doc(self, tmp_path):
+        """Missing doc fails gracefully."""
+        doc = tmp_path / "nonexistent.md"
+        valid, error = validate_feature_doc(doc)
+        assert valid is False
+        assert "not found" in error
+
+    def test_doc_without_title(self, tmp_path):
+        """Doc without title heading fails."""
+        doc = tmp_path / "feature.md"
+        doc.write_text("Just some text without a heading.")
+        valid, error = validate_feature_doc(doc)
+        assert valid is False
+        assert "missing title" in error
+
+    def test_doc_too_short(self, tmp_path):
+        """Doc with only title and no content fails."""
+        doc = tmp_path / "feature.md"
+        doc.write_text("# Title\n\nShort")
+        valid, error = validate_feature_doc(doc)
+        assert valid is False
+        assert "too short" in error
+
+
+class TestExtractFeatureDocPath:
+    """Test feature doc path extraction from plan text."""
+
+    def test_extracts_create_path(self):
+        plan = textwrap.dedent("""\
+            ## Documentation
+            - [ ] Create `docs/features/my-feature.md` describing the feature
+            - [ ] Update README index
+        """)
+        result = extract_feature_doc_path(plan)
+        assert result == "docs/features/my-feature.md"
+
+    def test_extracts_update_path(self):
+        plan = textwrap.dedent("""\
+            ## Documentation
+            - [ ] Update `docs/features/existing.md` with new section
+        """)
+        result = extract_feature_doc_path(plan)
+        assert result == "docs/features/existing.md"
+
+    def test_no_documentation_section(self):
+        plan = "## Other Section\nSome content"
+        result = extract_feature_doc_path(plan)
+        assert result is None
+
+
+class TestEndToEndMigrationChain:
+    """Integration test: full migration validation chain.
+
+    Exercises the specific scenario that triggered the original bug:
+    a feature named pm-dev-session-architecture with a README entry that
+    says PM/Dev Session Architecture (not Pm Dev Session Architecture).
+    """
+
+    def test_full_chain_with_acronym_feature(self, tmp_path):
+        """The migration chain works end-to-end with acronym-heavy filenames."""
+        # Set up docs/features/ directory
+        features_dir = tmp_path / "docs" / "features"
+        features_dir.mkdir(parents=True)
+
+        # Create the README index
+        readme = features_dir / "README.md"
+        readme.write_text(SAMPLE_README)
+
+        # Create the feature doc
+        feature_doc = features_dir / "pm-dev-session-architecture.md"
+        feature_doc.write_text(
+            "# PM/Teammate/Dev Session Architecture\n\n"
+            "Session type discriminator splitting orchestration from execution.\n\n"
+            "## Overview\nDetailed description of the architecture."
+        )
+
+        with _chdir(tmp_path):
+            # Step 1: validate feature doc exists
+            valid, error = validate_feature_doc(feature_doc)
+            assert valid is True, f"Feature doc validation failed: {error}"
+
+            # Step 2: extract name from index (the new way - Bug 1 fix)
+            feature_name = extract_feature_name_from_index("pm-dev-session-architecture.md")
+            assert feature_name is not None, "Failed to extract feature name from README"
+            assert feature_name == "PM/Dev Session Architecture"
+
+            # Step 3: validate the extracted name is in the index
+            valid, error = validate_feature_index(feature_name)
+            assert valid is True, f"Feature index validation failed: {error}"
+
+            # Step 4: verify the OLD way (.title()) would have failed
+            mangled_name = "pm-dev-session-architecture".replace("-", " ").title()
+            assert mangled_name == "Pm Dev Session Architecture"
+            # This would have failed because "Pm" != "PM"
+            valid_old, _ = validate_feature_index(mangled_name)
+            # The old approach fails because validate_feature_index uses re.IGNORECASE
+            # but the escaped "Pm Dev Session Architecture" won't match "PM/Dev Session Architecture"
+            # because of the "/" character difference
+            assert valid_old is False, "Old .title() approach should fail due to missing /"
+
+
+# --- Helpers ---
+
+
+def _extract_from_content(readme_content: str, filename: str) -> str | None:
+    """Extract feature name directly from README content (bypasses filesystem)."""
+    pattern = rf"\|\s*\[([^\]]+)\]\({re.escape(filename)}\)"
+    match = re.search(pattern, readme_content)
+    if match:
+        return match.group(1)
+    return None
+
+
+import contextlib
+import os
+
+
+@contextlib.contextmanager
+def _chdir(path):
+    """Context manager to temporarily change directory."""
+    old = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(old)

--- a/tests/unit/test_migrate_completed_plan.py
+++ b/tests/unit/test_migrate_completed_plan.py
@@ -5,11 +5,9 @@ Covers Bug 1 fix: README-based display name extraction replacing .title() mangli
 
 import contextlib
 import os
-import re
 import sys
 import textwrap
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -37,44 +35,42 @@ SAMPLE_README = textwrap.dedent("""\
 """)
 
 
-@pytest.fixture
-def mock_readme(tmp_path):
-    """Create a mock docs/features/README.md."""
-    readme_path = tmp_path / "docs" / "features" / "README.md"
-    readme_path.parent.mkdir(parents=True, exist_ok=True)
-    readme_path.write_text(SAMPLE_README)
-    return readme_path
-
-
 # --- Tests for extract_feature_name_from_index ---
 
 
 class TestExtractFeatureNameFromIndex:
-    """Test README-based display name extraction."""
+    """Test README-based display name extraction using the real function."""
 
-    def test_acronym_heavy_filename_pm(self, mock_readme):
+    @pytest.fixture(autouse=True)
+    def _setup_readme(self, tmp_path):
+        """Create a docs/features/README.md and chdir so the real function finds it."""
+        readme_path = tmp_path / "docs" / "features" / "README.md"
+        readme_path.parent.mkdir(parents=True, exist_ok=True)
+        readme_path.write_text(SAMPLE_README)
+        self._tmp = tmp_path
+
+    def _extract(self, filename: str) -> str | None:
+        with _chdir(self._tmp):
+            return extract_feature_name_from_index(filename)
+
+    def test_acronym_heavy_filename_pm(self):
         """PM in filename should resolve to PM/Dev Session Architecture, not Pm/Dev..."""
-        with patch(
-            "scripts.migrate_completed_plan.Path",
-            side_effect=lambda p: mock_readme if p == "docs/features/README.md" else Path(p),
-        ):
-            # Direct test: parse the README content
-            result = _extract_from_content(SAMPLE_README, "pm-dev-session-architecture.md")
-            assert result == "PM/Dev Session Architecture"
+        result = self._extract("pm-dev-session-architecture.md")
+        assert result == "PM/Dev Session Architecture"
 
     def test_acronym_heavy_filename_sdlc(self):
         """SDLC in filename should resolve correctly."""
-        result = _extract_from_content(SAMPLE_README, "sdlc-critique-stage.md")
+        result = self._extract("sdlc-critique-stage.md")
         assert result == "SDLC Critique Stage"
 
     def test_acronym_heavy_filename_ai(self):
         """AI in filename should resolve correctly."""
-        result = _extract_from_content(SAMPLE_README, "ai-evaluator.md")
+        result = self._extract("ai-evaluator.md")
         assert result == "AI Evaluator"
 
     def test_display_text_differs_from_filename(self):
         """Display text can contain characters not in filename (e.g., slashes)."""
-        result = _extract_from_content(SAMPLE_README, "pm-dev-session-architecture.md")
+        result = self._extract("pm-dev-session-architecture.md")
         assert result == "PM/Dev Session Architecture"
         # Verify .title() would have mangled this
         mangled = "pm-dev-session-architecture".replace("-", " ").title()
@@ -83,17 +79,17 @@ class TestExtractFeatureNameFromIndex:
 
     def test_hyphenated_compound_name(self):
         """Compound names with hyphens (do-build) should resolve correctly."""
-        result = _extract_from_content(SAMPLE_README, "do-build-ai-evaluator.md")
+        result = self._extract("do-build-ai-evaluator.md")
         assert result == "Do-Build AI Evaluator"
 
     def test_missing_readme_entry(self):
         """Filename with no matching README row returns None."""
-        result = _extract_from_content(SAMPLE_README, "nonexistent-feature.md")
+        result = self._extract("nonexistent-feature.md")
         assert result is None
 
     def test_simple_filename(self):
         """Simple filename without acronyms works fine."""
-        result = _extract_from_content(SAMPLE_README, "bridge-self-healing.md")
+        result = self._extract("bridge-self-healing.md")
         assert result == "Bridge Self-Healing"
 
 
@@ -241,15 +237,6 @@ class TestEndToEndMigrationChain:
 
 
 # --- Helpers ---
-
-
-def _extract_from_content(readme_content: str, filename: str) -> str | None:
-    """Extract feature name directly from README content (bypasses filesystem)."""
-    pattern = rf"\|\s*\[([^\]]+)\]\({re.escape(filename)}\)"
-    match = re.search(pattern, readme_content)
-    if match:
-        return match.group(1)
-    return None
 
 
 @contextlib.contextmanager

--- a/tests/unit/test_migrate_completed_plan.py
+++ b/tests/unit/test_migrate_completed_plan.py
@@ -3,7 +3,10 @@
 Covers Bug 1 fix: README-based display name extraction replacing .title() mangling.
 """
 
+import contextlib
+import os
 import re
+import sys
 import textwrap
 from pathlib import Path
 from unittest.mock import patch
@@ -11,16 +14,13 @@ from unittest.mock import patch
 import pytest
 
 # Import the functions under test directly
-import sys
-
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-from scripts.migrate_completed_plan import (
-    extract_feature_name_from_index,
-    validate_feature_index,
-    validate_feature_doc,
+from scripts.migrate_completed_plan import (  # noqa: E402
     extract_feature_doc_path,
+    extract_feature_name_from_index,
+    validate_feature_doc,
+    validate_feature_index,
 )
-
 
 # --- Fixtures ---
 
@@ -29,7 +29,7 @@ SAMPLE_README = textwrap.dedent("""\
 
     | Feature | Description | Status |
     |---------|-------------|--------|
-    | [PM/Dev Session Architecture](pm-dev-session-architecture.md) | PM/Dev session split | Shipped |
+    | [PM/Dev Session Architecture](pm-dev-session-architecture.md) | PM/Dev split | Shipped |
     | [SDLC Critique Stage](sdlc-critique-stage.md) | Automated plan validation | Shipped |
     | [AI Evaluator](ai-evaluator.md) | Semantic build evaluation | Shipped |
     | [Bridge Self-Healing](bridge-self-healing.md) | Crash recovery | Shipped |
@@ -223,7 +223,7 @@ class TestEndToEndMigrationChain:
 
             # Step 2: extract name from index (the new way - Bug 1 fix)
             feature_name = extract_feature_name_from_index("pm-dev-session-architecture.md")
-            assert feature_name is not None, "Failed to extract feature name from README"
+            assert feature_name is not None, "Failed to extract feature name"
             assert feature_name == "PM/Dev Session Architecture"
 
             # Step 3: validate the extracted name is in the index
@@ -235,9 +235,8 @@ class TestEndToEndMigrationChain:
             assert mangled_name == "Pm Dev Session Architecture"
             # This would have failed because "Pm" != "PM"
             valid_old, _ = validate_feature_index(mangled_name)
-            # The old approach fails because validate_feature_index uses re.IGNORECASE
-            # but the escaped "Pm Dev Session Architecture" won't match "PM/Dev Session Architecture"
-            # because of the "/" character difference
+            # The old approach fails: "Pm Dev Session Architecture"
+            # won't match "PM/Dev Session Architecture" (missing "/")
             assert valid_old is False, "Old .title() approach should fail due to missing /"
 
 
@@ -251,10 +250,6 @@ def _extract_from_content(readme_content: str, filename: str) -> str | None:
     if match:
         return match.group(1)
     return None
-
-
-import contextlib
-import os
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
## Summary
- **Bug 1**: Replace `.title()` in `migrate_completed_plan.py` with README-based display name extraction to prevent acronym mangling (PM->Pm, SDLC->Sdlc)
- **Bug 2**: Both plan-reading sites in `/do-merge` now use `git show origin/main:` instead of filesystem reads from cwd (stale worktree)
- **Bug 3**: Replace nonexistent `AgentSession.get_by_slug()` with working inline Popoto query at both call sites, add try/except to unprotected site
- Fix README drift: `Chat Dev Session Architecture` -> `PM/Dev Session Architecture`

## Changes
- `scripts/migrate_completed_plan.py`: New `extract_feature_name_from_index()` function; `main()` uses it instead of `.title()`
- `.claude/commands/do-merge.md`: Plan completion gate and post-merge migration read from `origin/main`; `get_by_slug` replaced with `query.all()` filter; try/except added to prerequisites check
- `docs/features/README.md`: Line 28 display text corrected
- `tests/unit/test_migrate_completed_plan.py`: 18 new tests (unit + integration)

## Testing
- [x] 18 unit tests passing (acronyms, edge cases, end-to-end chain)
- [x] Lint clean (ruff check + format)
- [x] Verification: zero `get_by_slug` in do-merge.md, zero `.title()` calls in migration script

## Definition of Done
- [x] Built: All three bugs fixed
- [x] Tested: 18 tests passing
- [x] Documented: README drift fixed, docs verified
- [x] Quality: Lint and format checks pass

Closes #884