### PR TITLE
Summarizer fallback: agent self-summary via session steering

### DIFF
--- a/agent/steering.py
+++ b/agent/steering.py
@@ -142,3 +142,21 @@ def has_steering_messages(session_id: str) -> bool:
     r = _get_redis()
     key = _queue_key(session_id)
     return r.llen(key) > 0
+
+
+def peek_steering_sender(session_id: str) -> str | None:
+    """Peek at the sender of the most recent steering message without consuming it.
+
+    Uses LINDEX -1 to read the tail (most recently pushed) message.
+    Returns the sender string, or None if the queue is empty or unreadable.
+    """
+    r = _get_redis()
+    key = _queue_key(session_id)
+    raw = r.lindex(key, -1)
+    if raw is None:
+        return None
+    try:
+        msg = json.loads(raw)
+        return msg.get("sender")
+    except (json.JSONDecodeError, AttributeError):
+        return None

--- a/bridge/response.py
+++ b/bridge/response.py
@@ -544,6 +544,90 @@ async def send_response_with_files(
             if summarized.was_summarized:
                 logger.info(f"Summarized response: {len(response)} -> {len(text)} chars")
 
+            # ── Self-summary fallback via session steering ──
+            # When all summarizer backends fail, inject a steering message
+            # asking the agent to self-summarize. Send any files immediately
+            # (they would be lost if deferred), then return the STEERING_DEFERRED
+            # sentinel so the bridge callback knows this is intentional.
+            if summarized.needs_self_summary:
+                _session_id = getattr(session, "session_id", None) if session else None
+                _should_steer = bool(_session_id)
+
+                # Loop prevention: check if a self-summary steering message was
+                # already pushed for this session (avoids infinite loops if the
+                # agent's self-summary also fails summarization).
+                if _should_steer:
+                    try:
+                        from agent.steering import peek_steering_sender
+
+                        if peek_steering_sender(_session_id) == "summarizer-fallback":
+                            logger.warning(
+                                "Self-summary steering already pending, "
+                                "falling through to narration gate"
+                            )
+                            _should_steer = False
+                    except Exception:
+                        pass  # peek failed, proceed with steering attempt
+
+                if _should_steer:
+                    # Send files before returning (critique: don't lose full_output_file)
+                    for f in files:
+                        try:
+                            await client.send_file(_chat_id, f, reply_to=_reply_to)
+                        except Exception as fe:
+                            logger.error(f"Failed to send file during steering deferral: {fe}")
+
+                    # Push the self-summary instruction to the session steering queue
+                    try:
+                        from agent.steering import push_steering_message
+                        from bridge.summarizer import SELF_SUMMARY_INSTRUCTION
+
+                        push_steering_message(
+                            _session_id,
+                            SELF_SUMMARY_INSTRUCTION,
+                            sender="summarizer-fallback",
+                        )
+                        logger.info(
+                            f"Injected self-summary steering for session {_session_id}"
+                        )
+                        from bridge.summarizer import STEERING_DEFERRED
+
+                        return STEERING_DEFERRED  # type: ignore[return-value]
+                    except Exception as steer_err:
+                        logger.warning(
+                            f"Steering push failed (non-fatal), falling through: {steer_err}"
+                        )
+                        # Fall through to narration gate below
+
+                # No session available or steering failed — apply narration gate
+                # on the original (pre-summarization) text as last resort
+                try:
+                    from bridge.message_quality import (
+                        NARRATION_FALLBACK_MESSAGE,
+                        is_narration_only,
+                    )
+
+                    _fallback_text = response  # original filtered text
+                    if is_narration_only(_fallback_text[:500]):
+                        text = NARRATION_FALLBACK_MESSAGE
+                        logger.info("Narration gate triggered on fallback path")
+                    else:
+                        # Not narration — truncate as last resort
+                        from bridge.summarizer import SAFETY_TRUNCATE
+
+                        if len(_fallback_text) > SAFETY_TRUNCATE:
+                            text = _fallback_text[: SAFETY_TRUNCATE - 3] + "..."
+                        else:
+                            text = _fallback_text
+                except Exception:
+                    # is_narration_only raised — deliver as-is (non-fatal)
+                    from bridge.summarizer import SAFETY_TRUNCATE
+
+                    if len(response) > SAFETY_TRUNCATE:
+                        text = response[: SAFETY_TRUNCATE - 3] + "..."
+                    else:
+                        text = response
+
             # Persist semantic routing fields to session for future routing
             if session and summarized.was_summarized:
                 try:

--- a/bridge/response.py
+++ b/bridge/response.py
@@ -587,9 +587,7 @@ async def send_response_with_files(
                             SELF_SUMMARY_INSTRUCTION,
                             sender="summarizer-fallback",
                         )
-                        logger.info(
-                            f"Injected self-summary steering for session {_session_id}"
-                        )
+                        logger.info(f"Injected self-summary steering for session {_session_id}")
                         from bridge.summarizer import STEERING_DEFERRED
 
                         return STEERING_DEFERRED  # type: ignore[return-value]

--- a/bridge/summarizer.py
+++ b/bridge/summarizer.py
@@ -244,6 +244,7 @@ class SummarizedResponse:
     text: str
     full_output_file: Path | None = None
     was_summarized: bool = False
+    needs_self_summary: bool = False
     artifacts: dict[str, list[str]] = field(default_factory=dict)
     context_summary: str | None = None
     expectations: str | None = None
@@ -1134,6 +1135,24 @@ stakeholder-friendly language describing the feature or behavior affected."""
 # NOT blockers: code bugs (agent can fix), test failures (agent can debug), implementation
 # decisions (agent should decide), finding the right approach (agent's job).
 
+# Compact self-summary instruction injected via session steering when all summarizer
+# backends fail. Derived from SUMMARIZER_SYSTEM_PROMPT quality rules but kept short
+# to avoid polluting the agent's context window.
+SELF_SUMMARY_INSTRUCTION = (
+    "Your previous output could not be summarized by the automated summarizer. "
+    "Please re-state your output as a concise update for the project manager. "
+    "Rules: lead with outcomes, not process. Use 2-4 bullet points starting with "
+    '"\\u2022 ". Omit internal code details, line counts, and plans for next steps. '
+    "Preserve any commit hashes, PR/issue numbers, and explicit questions. "
+    "Do NOT include narration like 'Let me investigate' or 'I will check'. "
+    "If your work produced no substantive results, say so plainly."
+)
+
+# Sentinel returned by send_response_with_files when self-summary steering was
+# injected. Distinguishes "message deferred to agent self-summary" from "send
+# failed" so the bridge callback does not log a spurious error.
+STEERING_DEFERRED = "STEERING_DEFERRED"
+
 
 async def _summarize_with_haiku(prompt: str) -> StructuredSummary | None:
     """Try structured summarization via Anthropic Haiku API using tool_use.
@@ -1492,15 +1511,15 @@ async def summarize_response(
             expectations=expectations,
         )
 
-    # All backends failed — truncate as last resort
-    logger.error("All summarization backends failed, truncating")
-    truncated = raw_response
-    if len(truncated) > SAFETY_TRUNCATE:
-        truncated = truncated[: SAFETY_TRUNCATE - 3] + "..."
-
+    # All backends failed — signal self-summary via session steering instead
+    # of delivering raw truncated text. The caller (send_response_with_files)
+    # will push a steering message and the agent will self-summarize on its
+    # next turn. Files and artifacts are preserved for immediate delivery.
+    logger.error("All summarization backends failed, requesting self-summary via steering")
     return SummarizedResponse(
-        text=truncated,
+        text="",
         full_output_file=full_output_file,
         was_summarized=False,
+        needs_self_summary=True,
         artifacts=artifacts,
     )

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -1794,23 +1794,33 @@ async def main():
                             session=session,
                         )
                         if sent:
-                            try:
-                                # Capture the Telegram message_id from the returned Message
-                                # object so outbound TelegramMessage records have message_id
-                                # populated. This enables reverse lookup via
-                                # TelegramMessage.query.filter(chat_id=X, message_id=Y).
-                                sent_msg_id = getattr(sent, "id", None)
-                                store_message(
-                                    chat_id=chat_id,
-                                    content=filtered,  # full content, no truncation
-                                    sender="Valor",
-                                    timestamp=utc_now(),
-                                    message_type="response",
-                                    message_id=sent_msg_id,
-                                    reply_to_msg_id=reply_to_msg_id,
+                            # Check for steering deferral sentinel — message was
+                            # intentionally held back for agent self-summary, not a
+                            # send failure. Don't store or log an error.
+                            from bridge.summarizer import STEERING_DEFERRED
+
+                            if sent == STEERING_DEFERRED:
+                                logger.info(
+                                    f"Session queue delivery deferred to self-summary "
+                                    f"steering for chat {chat_id}"
                                 )
-                            except Exception:
-                                pass
+                            else:
+                                try:
+                                    # Capture the Telegram message_id from the returned
+                                    # Message object so outbound TelegramMessage records
+                                    # have message_id populated.
+                                    sent_msg_id = getattr(sent, "id", None)
+                                    store_message(
+                                        chat_id=chat_id,
+                                        content=filtered,
+                                        sender="Valor",
+                                        timestamp=utc_now(),
+                                        message_type="response",
+                                        message_id=sent_msg_id,
+                                        reply_to_msg_id=reply_to_msg_id,
+                                    )
+                                except Exception:
+                                    pass
                         elif filtered:
                             logger.error(
                                 f"Session queue send returned False for chat {chat_id} "

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -122,7 +122,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [Steering Queue](steering-queue.md) | Mid-execution course correction via Telegram reply threads and parent-child PM session-to-Dev session steering | Shipped |
 | [Structured Logging & Telemetry](structured-logging-telemetry.md) | Redis-backed telemetry counters, structured log lines, and health check integration for Observer Agent observability | Shipped |
 | [Subconscious Memory](subconscious-memory.md) | Automatic and intentional memory with structured metadata (category, file paths, tags), dismissal tracking with importance decay, multi-query decomposition for broader retrieval, and category-weighted recall re-ranking | Shipped |
-| [Summarizer Format](summarizer-format.md) | Structured bullet-point output with SDLC stage progress and markdown links for Telegram delivery | Shipped |
+| [Summarizer Format](summarizer-format.md) | Structured bullet-point output with SDLC stage progress, markdown links, and self-summary fallback via session steering for Telegram delivery | Shipped |
 | [SuperWhisper Transcription](superwhisper-transcription.md) | Dual-backend audio transcription with local SuperWhisper primary and OpenAI Whisper API fallback | Shipped |
 | [sustainable-self-healing.md](sustainable-self-healing.md) | Queue governance: circuit-based pause, drip resume, throttle, failure dedup, daily digest | Shipped |
 | [System Overview](system-overview.md) | High-level architecture and design principles | Archived |

--- a/docs/features/session-steering.md
+++ b/docs/features/session-steering.md
@@ -105,6 +105,18 @@ All symbols that previously lived only in `agent/agent_session_queue.py` are re-
 
 Existing callers (tests, integrations) that import from `agent.agent_session_queue` continue to work unchanged. The canonical location is now `agent.output_router`.
 
+## Summarizer Fallback Steering
+
+When both summarizer backends (Haiku and OpenRouter) fail, `send_response_with_files()` uses the steering infrastructure to request agent self-summary rather than delivering raw truncated text to Telegram.
+
+**Mechanism:** `push_steering_message(session_id, SELF_SUMMARY_INSTRUCTION, sender="summarizer-fallback")` injects a compact self-summary instruction. The agent produces a clean summary on its next turn.
+
+**Loop prevention:** `peek_steering_sender(session_id)` checks if a `"summarizer-fallback"` message is already queued before pushing another. This prevents infinite steering loops if the self-summary output also fails summarization.
+
+**Fallback chain:** If steering cannot be used (no session, Redis down, loop prevention), the system falls through to `is_narration_only()` as a last-resort gate before delivering text.
+
+See [Summarizer Format: Self-Summary Fallback](summarizer-format.md#self-summary-fallback-via-session-steering) for the full data flow.
+
 ## No-Gos
 
 - `bridge/summarizer.py` `nudge_feedback` is untouched — separate concept

--- a/docs/features/summarizer-format.md
+++ b/docs/features/summarizer-format.md
@@ -173,9 +173,35 @@ The `expectations` field description explicitly states it should only be set whe
 
 Basic `md` parse mode (not MarkdownV2). Supports bold, inline code, and `[text](url)` links. Falls back to plain text on parse errors.
 
+## Self-Summary Fallback via Session Steering
+
+When both summarizer backends (Haiku and OpenRouter) fail, the system avoids delivering raw truncated text to Telegram. Instead, it uses session steering to ask the agent to self-summarize.
+
+**Flow:**
+
+1. `summarize_response()` returns `SummarizedResponse(needs_self_summary=True, text="")` instead of truncating
+2. `send_response_with_files()` detects `needs_self_summary=True`
+3. If a session is available: pushes `SELF_SUMMARY_INSTRUCTION` to the session's steering queue via `push_steering_message(sender="summarizer-fallback")`
+4. Files (including `full_output_file`) are sent immediately -- only text delivery is deferred
+5. Returns `STEERING_DEFERRED` sentinel so the bridge callback knows this is intentional (not a send failure)
+6. The agent self-summarizes on its next turn, and the output flows through the normal delivery path
+
+**Loop prevention:** Before pushing a steering message, `peek_steering_sender()` checks if a `"summarizer-fallback"` message is already pending. If so, it skips steering and falls through to the narration gate.
+
+**Last-resort narration gate:** When no session is available, or steering fails, or loop prevention triggers:
+- `is_narration_only()` from `bridge/message_quality.py` checks the first 500 chars of the original text
+- If True: delivers `NARRATION_FALLBACK_MESSAGE` instead of raw narration
+- If False: delivers truncated text (existing behavior)
+
+**Key constants:**
+- `SELF_SUMMARY_INSTRUCTION` in `bridge/summarizer.py` -- compact prompt derived from `SUMMARIZER_SYSTEM_PROMPT` quality rules
+- `STEERING_DEFERRED` in `bridge/summarizer.py` -- sentinel return value for deferred delivery
+- `NARRATION_FALLBACK_MESSAGE` in `bridge/message_quality.py` -- user-friendly fallback text
+
 ## Related
 
 - [AgentSession Model](agent-session-model.md) - Unified lifecycle model with stage progress helpers
 - [Bridge Response Improvements](bridge-response-improvements.md) - Response pipeline
 - [Bridge Workflow Gaps](bridge-workflow-gaps.md) - Output classification and auto-continue
 - [PM Voice Refinement](pm-voice-refinement.md) - Naturalized SDLC language, crash pool, sentence truncation, milestone-selective emoji
+- [Session Steering](session-steering.md) - Steering infrastructure used by the self-summary fallback

--- a/docs/features/summarizer-format.md
+++ b/docs/features/summarizer-format.md
@@ -6,7 +6,7 @@ Structured output format for Telegram delivery of agent work summaries. Every re
 
 1. **SDLC: always summarize (even empty responses). Non-SDLC: summarize if >= 200 chars.** SDLC sessions always go through Haiku (stage lines + link footers needed). Even empty SDK responses render SDLC stage progress if session data is available. Non-SDLC short responses (< 200 chars) pass through raw -- this preserves programmatic skill output like `/update` that's already formatted.
 2. **SDLC template rendering**: Stage progress lines and link footers are rendered in Python code, not by the LLM. The LLM only generates bullet summaries and questions.
-3. **Question extraction (anti-fabrication)**: The LLM can surface questions using a `---` separator and `>> ` prefix, but ONLY questions that are **verbatim present** in the raw agent output. Declarative statements and plans must never be reframed as questions. The `expectations` field is set only when explicit questions exist. Legacy `? ` prefix is accepted and normalized to `>> ` by `_normalize_question_prefix()`.
+3. **Question extraction (anti-fabrication)**: The LLM can surface questions using a `---` separator and `>> ` prefix, but ONLY questions that are **verbatim present** in the raw agent output. Declarative statements and plans must never be reframed as questions. The `expectations` field is set only when explicit questions exist. The `? ` prefix from older formats is accepted and normalized to `>> ` by `_normalize_question_prefix()`.
 
 ## Output Format
 
@@ -92,7 +92,7 @@ No checkbox icons are used. The ISSUE stage label includes the issue number when
 
 ## Implementation
 
-- `bridge/summarizer.py`: `summarize_response()` (always-summarize entry point), `_strip_process_narration()` (pre-summarization cleanup), `_compose_structured_summary()` (template renderer with inline stage progress and link footer rendering), `_parse_summary_and_questions()` (question extractor), `_normalize_question_prefix()` (legacy `?` to `>>` conversion), `_linkify_references()` (auto-link PR/Issue refs)
+- `bridge/summarizer.py`: `summarize_response()` (always-summarize entry point), `_strip_process_narration()` (pre-summarization cleanup), `_compose_structured_summary()` (template renderer with inline stage progress and link footer rendering), `_parse_summary_and_questions()` (question extractor), `_normalize_question_prefix()` (`?` to `>>` prefix conversion), `_linkify_references()` (auto-link PR/Issue refs), `SELF_SUMMARY_INSTRUCTION` (steering prompt for fallback self-summary), `STEERING_DEFERRED` (sentinel for deferred delivery)
 - `bridge/response.py`: Always calls summarizer for non-empty text, passes `AgentSession` via `session=` kwarg. `_truncate_at_sentence_boundary()` ensures clean truncation at Telegram's 4096-char limit.
 - `bridge/telegram_bridge.py`: `_send` callback accepts and forwards `session` parameter
 - `agent/agent_session_queue.py`: `SendCallback` type includes session parameter, `send_to_chat()` uses `determine_delivery_action()` for routing decisions and passes `agent_session`

--- a/docs/plans/summarizer-fallback-steering.md
+++ b/docs/plans/summarizer-fallback-steering.md
@@ -1,6 +1,6 @@
 ---
 slug: summarizer-fallback-steering
-status: Planning
+status: Shipped
 type: bug
 appetite: Small
 tracking: https://github.com/tomcounsell/ai/issues/891

--- a/tests/unit/test_delivery_execution.py
+++ b/tests/unit/test_delivery_execution.py
@@ -209,6 +209,8 @@ class TestSelfSummaryFallback:
         mock_client = AsyncMock()
 
         summarized = _make_summarized_response(needs_self_summary=True)
+        # Must be >= 200 chars to trigger summarizer path
+        long_narration = "Let me investigate the configuration. " * 10
 
         with (
             patch(
@@ -221,17 +223,16 @@ class TestSelfSummaryFallback:
             await send_response_with_files(
                 mock_client,
                 None,
-                "Let me check. Let me investigate.",  # narration-only, short
+                long_narration,
                 chat_id=123,
                 reply_to=456,
                 session=session,
             )
 
-        # Should have sent something (either narration fallback or truncated)
-        if mock_send.called:
-            sent_text = mock_send.call_args[0][2]  # positional: client, chat_id, text
-            # Either the narration fallback message or the original text
-            assert len(sent_text) > 0
+        # Should have sent something (either narration fallback or truncated original)
+        assert mock_send.called, "send_markdown should have been called"
+        sent_text = mock_send.call_args[0][2]
+        assert len(sent_text) > 0
 
     async def test_narration_gate_replaces_narration_text(self):
         """is_narration_only gate replaces narration with NARRATION_FALLBACK_MESSAGE."""
@@ -242,7 +243,8 @@ class TestSelfSummaryFallback:
         mock_client = AsyncMock()
 
         summarized = _make_summarized_response(needs_self_summary=True)
-        narration_text = "Let me check. Let me investigate."
+        # Must be >= 200 chars to trigger summarizer path
+        narration_text = "Let me check the configuration. " * 10
 
         with (
             patch(
@@ -262,9 +264,9 @@ class TestSelfSummaryFallback:
                 session=session,
             )
 
-        if mock_send.called:
-            sent_text = mock_send.call_args[0][2]
-            assert sent_text == NARRATION_FALLBACK_MESSAGE
+        assert mock_send.called, "send_markdown should have been called"
+        sent_text = mock_send.call_args[0][2]
+        assert sent_text == NARRATION_FALLBACK_MESSAGE
 
     async def test_loop_prevention_skips_steering_when_already_pending(self):
         """If summarizer-fallback steering already pending, skip and fall through."""

--- a/tests/unit/test_delivery_execution.py
+++ b/tests/unit/test_delivery_execution.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -147,8 +146,6 @@ class TestDeliveryExecution:
 
 def _make_summarized_response(**kwargs):
     """Create a SummarizedResponse-like object."""
-    from pathlib import Path
-
     defaults = {
         "text": "",
         "full_output_file": None,

--- a/tests/unit/test_delivery_execution.py
+++ b/tests/unit/test_delivery_execution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -142,3 +143,163 @@ class TestDeliveryExecution:
 
         # Summarizer should have been called (no delivery instruction to bypass it)
         mock_sum.assert_called_once()
+
+
+def _make_summarized_response(**kwargs):
+    """Create a SummarizedResponse-like object."""
+    from pathlib import Path
+
+    defaults = {
+        "text": "",
+        "full_output_file": None,
+        "was_summarized": False,
+        "needs_self_summary": False,
+        "artifacts": {},
+        "context_summary": None,
+        "expectations": None,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.mark.asyncio
+class TestSelfSummaryFallback:
+    async def test_steering_injected_when_session_available(self):
+        """When needs_self_summary=True and session available, push steering and return sentinel."""
+        from bridge.response import send_response_with_files
+        from bridge.summarizer import STEERING_DEFERRED
+
+        session = _make_session(session_id="test-123")
+        mock_client = AsyncMock()
+
+        summarized = _make_summarized_response(needs_self_summary=True)
+        mock_push = MagicMock()
+        mock_peek = MagicMock(return_value=None)  # No prior steering message
+
+        with (
+            patch(
+                "bridge.summarizer.summarize_response",
+                new_callable=AsyncMock,
+                return_value=summarized,
+            ),
+            patch("agent.steering.push_steering_message", mock_push),
+            patch("agent.steering.peek_steering_sender", mock_peek),
+        ):
+            result = await send_response_with_files(
+                mock_client,
+                None,
+                "Let me investigate the issue. " * 20,  # long enough to trigger summarizer
+                chat_id=123,
+                reply_to=456,
+                session=session,
+            )
+
+        assert result == STEERING_DEFERRED
+        mock_push.assert_called_once()
+        call_args = mock_push.call_args
+        assert call_args[0][0] == "test-123"  # session_id
+        assert call_args[1]["sender"] == "summarizer-fallback"
+
+    async def test_no_session_falls_through_to_narration_gate(self):
+        """When needs_self_summary=True but no session, apply narration gate."""
+        from bridge.response import send_response_with_files
+
+        # No session_id on the session
+        session = _make_session(session_id=None)
+        mock_client = AsyncMock()
+
+        summarized = _make_summarized_response(needs_self_summary=True)
+
+        with (
+            patch(
+                "bridge.summarizer.summarize_response",
+                new_callable=AsyncMock,
+                return_value=summarized,
+            ),
+            patch("bridge.markdown.send_markdown", new_callable=AsyncMock) as mock_send,
+        ):
+            await send_response_with_files(
+                mock_client,
+                None,
+                "Let me check. Let me investigate.",  # narration-only, short
+                chat_id=123,
+                reply_to=456,
+                session=session,
+            )
+
+        # Should have sent something (either narration fallback or truncated)
+        if mock_send.called:
+            sent_text = mock_send.call_args[0][2]  # positional: client, chat_id, text
+            # Either the narration fallback message or the original text
+            assert len(sent_text) > 0
+
+    async def test_narration_gate_replaces_narration_text(self):
+        """is_narration_only gate replaces narration with NARRATION_FALLBACK_MESSAGE."""
+        from bridge.message_quality import NARRATION_FALLBACK_MESSAGE
+        from bridge.response import send_response_with_files
+
+        session = _make_session(session_id=None)
+        mock_client = AsyncMock()
+
+        summarized = _make_summarized_response(needs_self_summary=True)
+        narration_text = "Let me check. Let me investigate."
+
+        with (
+            patch(
+                "bridge.summarizer.summarize_response",
+                new_callable=AsyncMock,
+                return_value=summarized,
+            ),
+            patch("bridge.markdown.send_markdown", new_callable=AsyncMock) as mock_send,
+            patch("bridge.message_quality.is_narration_only", return_value=True),
+        ):
+            await send_response_with_files(
+                mock_client,
+                None,
+                narration_text,
+                chat_id=123,
+                reply_to=456,
+                session=session,
+            )
+
+        if mock_send.called:
+            sent_text = mock_send.call_args[0][2]
+            assert sent_text == NARRATION_FALLBACK_MESSAGE
+
+    async def test_loop_prevention_skips_steering_when_already_pending(self):
+        """If summarizer-fallback steering already pending, skip and fall through."""
+        from bridge.response import send_response_with_files
+
+        session = _make_session(session_id="test-loop")
+        mock_client = AsyncMock()
+
+        summarized = _make_summarized_response(needs_self_summary=True)
+        # peek_steering_sender returns "summarizer-fallback" indicating already pending
+        mock_peek = MagicMock(return_value="summarizer-fallback")
+        mock_push = MagicMock()
+
+        with (
+            patch(
+                "bridge.summarizer.summarize_response",
+                new_callable=AsyncMock,
+                return_value=summarized,
+            ),
+            patch("agent.steering.push_steering_message", mock_push),
+            patch("agent.steering.peek_steering_sender", mock_peek),
+            patch("bridge.markdown.send_markdown", new_callable=AsyncMock),
+        ):
+            result = await send_response_with_files(
+                mock_client,
+                None,
+                "x" * 300,
+                chat_id=123,
+                reply_to=456,
+                session=session,
+            )
+
+        # Should NOT have pushed another steering message
+        mock_push.assert_not_called()
+        # Should NOT have returned STEERING_DEFERRED
+        from bridge.summarizer import STEERING_DEFERRED
+
+        assert result != STEERING_DEFERRED

--- a/tests/unit/test_summarizer.py
+++ b/tests/unit/test_summarizer.py
@@ -170,8 +170,8 @@ class TestSummarizeResponse:
         mock_openrouter.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_all_backends_fail_truncates(self):
-        """If all summarization backends fail, truncate."""
+    async def test_all_backends_fail_requests_self_summary(self):
+        """If all summarization backends fail, signal self-summary via steering."""
         long_text = "x" * 5000
 
         mock_haiku = AsyncMock(return_value=None)
@@ -183,8 +183,18 @@ class TestSummarizeResponse:
             result = await summarize_response(long_text)
 
         assert result.was_summarized is False
-        assert len(result.text) <= 4096
-        assert result.text.endswith("...")
+        assert result.needs_self_summary is True
+        assert result.text == ""
+
+    @pytest.mark.asyncio
+    async def test_self_summary_instruction_quality(self):
+        """SELF_SUMMARY_INSTRUCTION contains key quality markers."""
+        from bridge.summarizer import SELF_SUMMARY_INSTRUCTION
+
+        assert "outcome" in SELF_SUMMARY_INSTRUCTION.lower()
+        assert "narration" in SELF_SUMMARY_INSTRUCTION.lower()
+        assert "bullet" in SELF_SUMMARY_INSTRUCTION.lower()
+        assert len(SELF_SUMMARY_INSTRUCTION) < 1000  # compact, not the full system prompt
 
     @pytest.mark.asyncio
     async def test_very_long_response_creates_file(self):


### PR DESCRIPTION
## Summary

When both summarizer backends (Haiku and OpenRouter) fail, the system now injects a steering message asking the agent to self-summarize instead of delivering raw truncated text to Telegram. This eliminates narrated train-of-thought text reaching users.

## Changes

- Added `needs_self_summary` field to `SummarizedResponse` dataclass and `SELF_SUMMARY_INSTRUCTION` constant
- Wired steering injection in `send_response_with_files()` with loop prevention via `peek_steering_sender()`
- Added `STEERING_DEFERRED` sentinel to avoid spurious error logs in bridge callback
- Wired `is_narration_only()` as last-resort gate when steering is unavailable (eliminates dead code)
- Added `peek_steering_sender()` to `agent/steering.py` for non-destructive queue inspection

## Testing

- [x] Unit tests passing (208 passed, 4 skipped)
- [x] New tests: self-summary trigger, steering injection, loop prevention, narration gate
- [x] Existing tests updated for new behavior
- [x] Linting (ruff check + format) passing

## Documentation

- [x] Updated `docs/features/summarizer-format.md` with self-summary fallback section
- [x] Updated `docs/features/session-steering.md` with summarizer fallback use case

## Definition of Done

- [x] Built: Code implemented and working
- [x] Tested: All tests passing
- [x] Documented: Docs created/updated
- [x] Quality: Lint and format checks pass

Closes #891