### PR TITLE
Fix TeammateMetrics SortedField type mismatch (#890)

### DIFF
--- a/agent/teammate_metrics.py
+++ b/agent/teammate_metrics.py
@@ -5,7 +5,8 @@ times. All operations are fire-and-forget -- metrics failures must never
 affect message processing.
 
 Uses the TeammateMetrics Popoto model (single-instance pattern) instead of
-raw Redis commands for proper ORM lifecycle and index management.
+raw Redis commands for proper ORM lifecycle and index management. Response
+times are stored via ListField.push() which performs atomic LPUSH+LTRIM.
 """
 
 from __future__ import annotations
@@ -16,9 +17,6 @@ import time
 from agent.intent_classifier import TEAMMATE_CONFIDENCE_THRESHOLD
 
 logger = logging.getLogger(__name__)
-
-# Max response time entries to keep per mode
-_MAX_RESPONSE_TIMES = 1000
 
 
 def _get_metrics():
@@ -59,6 +57,9 @@ def record_classification(intent: str, confidence: float) -> None:
 def record_response_time(mode: str, elapsed_seconds: float) -> None:
     """Record response time for a teammate or work session.
 
+    Stores an "elapsed:timestamp" entry via ListField.push(), which
+    performs an atomic LPUSH+LTRIM capped at max_length (1000).
+
     Args:
         mode: "teammate" or "work"
         elapsed_seconds: Time from message receipt to response delivery.
@@ -68,27 +69,13 @@ def record_response_time(mode: str, elapsed_seconds: float) -> None:
         if not metrics:
             return
 
-        # Store as member:score in the sorted field (score=timestamp for time-windowed analysis)
-        member = f"{elapsed_seconds:.2f}:{time.time():.0f}"
-        timestamp = time.time()
+        entry = f"{elapsed_seconds:.2f}:{time.time():.0f}"
 
         if mode == "teammate":
-            times = dict(metrics.teammate_response_times or {})
-            times[member] = timestamp
-            # Keep only last N entries by removing oldest
-            if len(times) > _MAX_RESPONSE_TIMES:
-                sorted_entries = sorted(times.items(), key=lambda x: x[1])
-                times = dict(sorted_entries[-_MAX_RESPONSE_TIMES:])
-            metrics.teammate_response_times = times
+            metrics.teammate_response_times.push(entry)
         else:
-            times = dict(metrics.work_response_times or {})
-            times[member] = timestamp
-            if len(times) > _MAX_RESPONSE_TIMES:
-                sorted_entries = sorted(times.items(), key=lambda x: x[1])
-                times = dict(sorted_entries[-_MAX_RESPONSE_TIMES:])
-            metrics.work_response_times = times
+            metrics.work_response_times.push(entry)
 
-        metrics.save()
         logger.debug(f"[teammate_metrics] Recorded {mode} response time: {elapsed_seconds:.2f}s")
     except Exception as e:
         logger.debug(f"[teammate_metrics] Failed to record response time: {e}")

--- a/docs/features/popoto-index-hygiene.md
+++ b/docs/features/popoto-index-hygiene.md
@@ -10,7 +10,7 @@ When AgentSession records expire (via TTL), crash, or are deleted without proper
 
 ### TeammateMetrics Popoto Model
 
-`models/teammate_metrics.py` replaces raw Redis counters in `agent/teammate_metrics.py`. Uses a single-instance pattern: one record keyed by `"global"` stores all classification counters (IntField) and response time sorted sets (SortedField). The public API (`record_classification`, `record_response_time`, `get_stats`) is preserved unchanged.
+`models/teammate_metrics.py` replaces raw Redis counters in `agent/teammate_metrics.py`. Uses a single-instance pattern: one record keyed by `"global"` stores all classification counters (IntField) and response time lists (ListField, capped at 1000 entries). The public API (`record_classification`, `record_response_time`, `get_stats`) is preserved unchanged.
 
 ### AgentSession Meta.ttl
 

--- a/docs/features/redis-models.md
+++ b/docs/features/redis-models.md
@@ -46,8 +46,8 @@ TeammateMetrics (singleton, key="global")
   teammate_classified_count (IntField)
   teammate_low_confidence_count (IntField)
   work_classified_count (IntField)
-  teammate_response_times (SortedField)
-  work_response_times (SortedField)
+  teammate_response_times (ListField, max_length=1000)
+  work_response_times (ListField, max_length=1000)
 ```
 
 ## Cross-References

--- a/models/teammate_metrics.py
+++ b/models/teammate_metrics.py
@@ -9,11 +9,11 @@ Fields:
     teammate_classified_count: Number of teammate classifications above threshold
     teammate_low_confidence_count: Number of teammate classifications below threshold
     work_classified_count: Number of work classifications
-    teammate_response_times: Sorted set of response times (score=timestamp)
-    work_response_times: Sorted set of response times (score=timestamp)
+    teammate_response_times: List of "elapsed:timestamp" strings (capped at 1000)
+    work_response_times: List of "elapsed:timestamp" strings (capped at 1000)
 """
 
-from popoto import IntField, KeyField, Model, SortedField
+from popoto import IntField, KeyField, ListField, Model
 
 
 class TeammateMetrics(Model):
@@ -28,11 +28,8 @@ class TeammateMetrics(Model):
     teammate_classified_count = IntField(default=0)
     teammate_low_confidence_count = IntField(default=0)
     work_classified_count = IntField(default=0)
-    teammate_response_times = SortedField(default=dict)
-    work_response_times = SortedField(default=dict)
-
-    # Max response time entries to keep per mode
-    _MAX_RESPONSE_TIMES = 1000
+    teammate_response_times = ListField(max_length=1000)
+    work_response_times = ListField(max_length=1000)
 
     @classmethod
     def get_or_create(cls) -> "TeammateMetrics":

--- a/tests/unit/test_qa_metrics.py
+++ b/tests/unit/test_qa_metrics.py
@@ -60,19 +60,21 @@ class TestRecordClassification:
 class TestRecordResponseTime:
     def test_records_teammate_time(self):
         mock_metrics = MagicMock()
-        mock_metrics.teammate_response_times = {}
-        mock_metrics.work_response_times = {}
+        mock_metrics.teammate_response_times = MagicMock()
+        mock_metrics.work_response_times = MagicMock()
         with patch("agent.teammate_metrics._get_metrics", return_value=mock_metrics):
             record_response_time("teammate", 1.5)
-            mock_metrics.save.assert_called_once()
+            mock_metrics.teammate_response_times.push.assert_called_once()
+            mock_metrics.work_response_times.push.assert_not_called()
 
     def test_records_work_time(self):
         mock_metrics = MagicMock()
-        mock_metrics.teammate_response_times = {}
-        mock_metrics.work_response_times = {}
+        mock_metrics.teammate_response_times = MagicMock()
+        mock_metrics.work_response_times = MagicMock()
         with patch("agent.teammate_metrics._get_metrics", return_value=mock_metrics):
             record_response_time("work", 2.3)
-            mock_metrics.save.assert_called_once()
+            mock_metrics.work_response_times.push.assert_called_once()
+            mock_metrics.teammate_response_times.push.assert_not_called()
 
     def test_no_metrics_does_not_crash(self):
         with patch("agent.teammate_metrics._get_metrics", return_value=None):


### PR DESCRIPTION
## Summary
- Replace `SortedField(default=dict)` with `ListField(max_length=1000)` for response time fields in `TeammateMetrics` model
- Rewrite `record_response_time()` to use `push()` (atomic LPUSH+LTRIM) instead of read-modify-write dict pattern that caused `float()` conversion errors
- Update test fixtures and assertions to match new ListField-based storage

## Test plan
- [x] All 12 unit tests in `tests/unit/test_qa_metrics.py` pass
- [x] `ruff check` and `ruff format --check` clean on all changed files
- [x] No references to `SortedField` remain in changed files

Fixes #890