### PR TITLE
Unified analytics system for metrics collection and dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,9 @@ valor-telegram send --chat "Tom" --file ./screenshot.png "Caption"
 | `python scripts/autoexperiment.py --target summarizer --dry-run` | Dry-run autoexperiment on summarizer |
 | `python scripts/autoexperiment.py --list-targets` | List autoexperiment targets |
 | `./scripts/install_autoexperiment.sh` | Install autoexperiment nightly schedule |
+| `python -m tools.analytics export --days 30` | Export analytics metrics as JSON |
+| `python -m tools.analytics summary` | Print human-readable analytics summary |
+| `python -m tools.analytics rollup` | Run analytics daily rollup manually |
 | `python -m tools.agent_session_scheduler status` | Show queue status (pending, running, killed counts) |
 | `python -m tools.agent_session_scheduler list --status killed,abandoned` | List sessions filtered by status |
 | `python -m tools.agent_session_scheduler kill --agent-session-id <ID>` | Kill a running or pending session by ID |

--- a/agent/memory_extraction.py
+++ b/agent/memory_extraction.py
@@ -154,6 +154,19 @@ async def extract_observations_async(
         logger.info(
             f"[memory_extraction] Extracted {len(saved)} observations from session {session_id}"
         )
+
+        # Analytics: record extraction count
+        try:
+            from analytics.collector import record_metric
+
+            record_metric(
+                "memory.extraction",
+                float(len(saved)),
+                {"session_id": session_id, "project_key": project_key},
+            )
+        except Exception:
+            pass
+
         return saved
 
     except Exception as e:

--- a/agent/memory_retrieval.py
+++ b/agent/memory_retrieval.py
@@ -217,6 +217,13 @@ def retrieve_memories(
         )
 
         if not fused:
+            # Analytics: record recall attempt with zero hits
+            try:
+                from analytics.collector import record_metric
+
+                record_metric("memory.recall_attempt", 1, {"hits": 0, "project_key": project_key})
+            except Exception:
+                pass
             return []
 
         # Hydrate Memory instances from fused keys
@@ -230,6 +237,15 @@ def retrieve_memories(
                     records.append(record)
             except Exception:
                 continue
+
+        # Analytics: record recall attempt with hit count
+        try:
+            from analytics.collector import record_metric
+
+            dims = {"hits": len(records), "project_key": project_key}
+            record_metric("memory.recall_attempt", 1, dims)
+        except Exception:
+            pass
 
         return records
 

--- a/agent/sdk_client.py
+++ b/agent/sdk_client.py
@@ -1101,6 +1101,16 @@ class ValorAgent:
                                         f"{duration}ms"
                                     )
                                     logger.info(summary)
+                                    # Analytics: record token cost and turn count
+                                    try:
+                                        from analytics.collector import record_metric
+
+                                        dims = {"session_id": session_id} if session_id else {}
+                                        record_metric("session.cost_usd", cost, dims)
+                                        if turns is not None:
+                                            record_metric("session.turns", float(turns), dims)
+                                    except Exception:
+                                        pass
                                 if msg.is_error and retries < max_retries:
                                     retries += 1
                                     error_text = msg.result or "(empty)"

--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -1,0 +1,14 @@
+"""Unified analytics system for metrics collection and querying.
+
+Collects metrics from all subsystems (SDK client, session lifecycle,
+SDLC pipeline, memory operations, crash tracker, health checks) and
+stores them in SQLite (historical) and Redis (live counters).
+
+Usage:
+    from analytics.collector import record_metric
+    record_metric("session.cost_usd", 0.05, {"session_id": "abc123"})
+"""
+
+from analytics.collector import record_metric
+
+__all__ = ["record_metric"]

--- a/analytics/collector.py
+++ b/analytics/collector.py
@@ -27,6 +27,10 @@ _SQLITE_TIMEOUT = 5
 # TTL for daily Redis keys (30 days in seconds)
 _DAILY_TTL = 30 * 86400
 
+# Module-level SQLite connection (reused across writes)
+_sqlite_conn: sqlite3.Connection | None = None
+_db_initialized: bool = False
+
 
 def _get_db_path() -> Path:
     """Return the SQLite database path, creating the directory if needed."""
@@ -35,7 +39,10 @@ def _get_db_path() -> Path:
 
 
 def _init_db(conn: sqlite3.Connection) -> None:
-    """Initialize the database schema if it does not exist."""
+    """Initialize the database schema (runs once per process)."""
+    global _db_initialized
+    if _db_initialized:
+        return
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS metrics (
@@ -55,24 +62,34 @@ def _init_db(conn: sqlite3.Connection) -> None:
     )
     conn.execute("PRAGMA journal_mode=WAL")
     conn.commit()
+    _db_initialized = True
+
+
+def _get_connection() -> sqlite3.Connection:
+    """Return the module-level SQLite connection, creating it if needed."""
+    global _sqlite_conn
+    if _sqlite_conn is None:
+        db_path = _get_db_path()
+        _sqlite_conn = sqlite3.connect(str(db_path), timeout=_SQLITE_TIMEOUT)
+        _init_db(_sqlite_conn)
+    return _sqlite_conn
 
 
 def _write_sqlite(name: str, value: float, dimensions: dict[str, Any] | None, ts: float) -> None:
     """Write a metric event to SQLite. Best-effort."""
     try:
-        db_path = _get_db_path()
-        conn = sqlite3.connect(str(db_path), timeout=_SQLITE_TIMEOUT)
-        try:
-            _init_db(conn)
-            dims_json = json.dumps(dimensions) if dimensions else None
-            conn.execute(
-                "INSERT INTO metrics (timestamp, name, value, dimensions) VALUES (?, ?, ?, ?)",
-                (ts, name, value, dims_json),
-            )
-            conn.commit()
-        finally:
-            conn.close()
+        conn = _get_connection()
+        dims_json = json.dumps(dimensions) if dimensions else None
+        conn.execute(
+            "INSERT INTO metrics (timestamp, name, value, dimensions) VALUES (?, ?, ?, ?)",
+            (ts, name, value, dims_json),
+        )
+        conn.commit()
     except Exception as e:
+        # Connection may be stale/corrupt -- reset so next call retries
+        global _sqlite_conn, _db_initialized
+        _sqlite_conn = None
+        _db_initialized = False
         logger.warning("[analytics] SQLite write failed for %s: %s", name, e)
 
 

--- a/analytics/collector.py
+++ b/analytics/collector.py
@@ -1,0 +1,140 @@
+"""Metrics collector -- dual-write to SQLite (historical) and Redis (live).
+
+All public functions are best-effort: failures are logged and never propagated.
+This module is a pure sink with no reverse dependencies.
+"""
+
+import json
+import logging
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# SQLite database path
+_DB_DIR = Path(__file__).parent.parent / "data"
+_DB_PATH = _DB_DIR / "analytics.db"
+
+# Redis key prefixes
+_REDIS_LIVE_PREFIX = "analytics:live:"
+_REDIS_DAILY_PREFIX = "analytics:daily:"
+
+# Connection timeout for SQLite (seconds)
+_SQLITE_TIMEOUT = 5
+
+# TTL for daily Redis keys (30 days in seconds)
+_DAILY_TTL = 30 * 86400
+
+
+def _get_db_path() -> Path:
+    """Return the SQLite database path, creating the directory if needed."""
+    _DB_DIR.mkdir(parents=True, exist_ok=True)
+    return _DB_PATH
+
+
+def _init_db(conn: sqlite3.Connection) -> None:
+    """Initialize the database schema if it does not exist."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS metrics (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp REAL NOT NULL,
+            name TEXT NOT NULL,
+            value REAL NOT NULL,
+            dimensions TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_metrics_name_ts
+        ON metrics (name, timestamp)
+        """
+    )
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.commit()
+
+
+def _write_sqlite(name: str, value: float, dimensions: dict[str, Any] | None, ts: float) -> None:
+    """Write a metric event to SQLite. Best-effort."""
+    try:
+        db_path = _get_db_path()
+        conn = sqlite3.connect(str(db_path), timeout=_SQLITE_TIMEOUT)
+        try:
+            _init_db(conn)
+            dims_json = json.dumps(dimensions) if dimensions else None
+            conn.execute(
+                "INSERT INTO metrics (timestamp, name, value, dimensions) VALUES (?, ?, ?, ?)",
+                (ts, name, value, dims_json),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.warning("[analytics] SQLite write failed for %s: %s", name, e)
+
+
+def _write_redis(name: str, value: float, dimensions: dict[str, Any] | None, ts: float) -> None:
+    """Increment Redis live counter and daily rollup. Best-effort."""
+    try:
+        from popoto.redis_db import POPOTO_REDIS_DB
+
+        # Live counter: HINCRBYFLOAT on analytics:live:{name}
+        live_key = f"{_REDIS_LIVE_PREFIX}{name}"
+        dim_key = json.dumps(dimensions, sort_keys=True) if dimensions else "_total"
+        POPOTO_REDIS_DB.hincrbyfloat(live_key, dim_key, value)
+
+        # Daily rollup: HINCRBYFLOAT on analytics:daily:{date}
+        date_str = time.strftime("%Y-%m-%d", time.gmtime(ts))
+        daily_key = f"{_REDIS_DAILY_PREFIX}{date_str}"
+        POPOTO_REDIS_DB.hincrbyfloat(daily_key, name, value)
+        POPOTO_REDIS_DB.expire(daily_key, _DAILY_TTL)
+    except Exception as e:
+        logger.warning("[analytics] Redis write failed for %s: %s", name, e)
+
+
+def record_metric(
+    name: str,
+    value: float,
+    dimensions: dict[str, Any] | None = None,
+) -> None:
+    """Record a metric event to both SQLite and Redis.
+
+    Best-effort: all writes are wrapped in try/except. A failure in
+    one storage backend does not affect the other.
+
+    Args:
+        name: Dotted metric name (e.g., "session.cost_usd").
+        value: Numeric metric value.
+        dimensions: Optional dict of dimension key-value pairs.
+    """
+    # Validate inputs
+    if not name or not isinstance(name, str):
+        logger.warning("[analytics] record_metric called with invalid name: %r", name)
+        return
+
+    if value is None:
+        logger.warning("[analytics] record_metric called with None value for %s", name)
+        return
+
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        logger.warning("[analytics] record_metric: non-numeric value %r for %s", value, name)
+        return
+
+    ts = time.time()
+
+    # Write to both backends independently -- each wrapped so one failure
+    # does not prevent the other from succeeding
+    try:
+        _write_sqlite(name, value, dimensions, ts)
+    except Exception as e:
+        logger.warning("[analytics] SQLite write raised unexpectedly for %s: %s", name, e)
+
+    try:
+        _write_redis(name, value, dimensions, ts)
+    except Exception as e:
+        logger.warning("[analytics] Redis write raised unexpectedly for %s: %s", name, e)

--- a/analytics/query.py
+++ b/analytics/query.py
@@ -1,0 +1,221 @@
+"""Query API for analytics data.
+
+Provides functions to query historical metrics from SQLite and live
+counters from Redis. All functions return sensible defaults (empty
+lists, zero counts) when the database is empty or missing.
+"""
+
+import json
+import logging
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_DB_PATH = Path(__file__).parent.parent / "data" / "analytics.db"
+_SQLITE_TIMEOUT = 5
+
+
+def _get_connection() -> sqlite3.Connection | None:
+    """Get a SQLite connection, or None if the database does not exist."""
+    if not _DB_PATH.exists():
+        return None
+    try:
+        conn = sqlite3.connect(str(_DB_PATH), timeout=_SQLITE_TIMEOUT)
+        conn.row_factory = sqlite3.Row
+        return conn
+    except Exception as e:
+        logger.warning("[analytics-query] Failed to connect to SQLite: %s", e)
+        return None
+
+
+def query_metrics(
+    name: str,
+    start_time: float | None = None,
+    end_time: float | None = None,
+    dimensions_filter: dict[str, Any] | None = None,
+    limit: int = 1000,
+) -> list[dict]:
+    """Query raw metric events from SQLite.
+
+    Args:
+        name: Metric name to query.
+        start_time: Unix timestamp for range start (inclusive).
+        end_time: Unix timestamp for range end (inclusive).
+        dimensions_filter: Optional dict to filter by dimension values.
+        limit: Maximum rows to return.
+
+    Returns:
+        List of dicts with keys: timestamp, name, value, dimensions.
+    """
+    try:
+        conn = _get_connection()
+        if conn is None:
+            return []
+
+        try:
+            query = "SELECT timestamp, name, value, dimensions FROM metrics WHERE name = ?"
+            params: list[Any] = [name]
+
+            if start_time is not None:
+                query += " AND timestamp >= ?"
+                params.append(start_time)
+            if end_time is not None:
+                query += " AND timestamp <= ?"
+                params.append(end_time)
+
+            query += " ORDER BY timestamp DESC LIMIT ?"
+            params.append(limit)
+
+            rows = conn.execute(query, params).fetchall()
+            results = []
+            for row in rows:
+                dims = json.loads(row["dimensions"]) if row["dimensions"] else None
+                # Apply dimensions filter if specified
+                if dimensions_filter and dims:
+                    if not all(dims.get(k) == v for k, v in dimensions_filter.items()):
+                        continue
+                elif dimensions_filter and not dims:
+                    continue
+
+                results.append(
+                    {
+                        "timestamp": row["timestamp"],
+                        "name": row["name"],
+                        "value": row["value"],
+                        "dimensions": dims,
+                    }
+                )
+            return results
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.warning("[analytics-query] query_metrics failed: %s", e)
+        return []
+
+
+def query_daily_summary(name: str, days: int = 30) -> list[dict]:
+    """Query daily aggregated summaries for a metric.
+
+    Args:
+        name: Metric name to aggregate.
+        days: Number of days to look back.
+
+    Returns:
+        List of dicts with keys: date, count, total, avg.
+    """
+    try:
+        conn = _get_connection()
+        if conn is None:
+            return []
+
+        try:
+            cutoff = time.time() - (days * 86400)
+            query = """
+                SELECT
+                    date(timestamp, 'unixepoch') as date,
+                    COUNT(*) as count,
+                    SUM(value) as total,
+                    AVG(value) as avg
+                FROM metrics
+                WHERE name = ? AND timestamp >= ?
+                GROUP BY date(timestamp, 'unixepoch')
+                ORDER BY date DESC
+            """
+            rows = conn.execute(query, (name, cutoff)).fetchall()
+            return [
+                {
+                    "date": row["date"],
+                    "count": row["count"],
+                    "total": round(row["total"], 4),
+                    "avg": round(row["avg"], 4),
+                }
+                for row in rows
+            ]
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.warning("[analytics-query] query_daily_summary failed: %s", e)
+        return []
+
+
+def query_metric_total(name: str, days: int = 1) -> float:
+    """Get the total value of a metric over the last N days.
+
+    Args:
+        name: Metric name.
+        days: Number of days to look back.
+
+    Returns:
+        Sum of values, or 0.0 if no data.
+    """
+    try:
+        conn = _get_connection()
+        if conn is None:
+            return 0.0
+
+        try:
+            cutoff = time.time() - (days * 86400)
+            row = conn.execute(
+                "SELECT COALESCE(SUM(value), 0) as total "
+                "FROM metrics WHERE name = ? AND timestamp >= ?",
+                (name, cutoff),
+            ).fetchone()
+            return round(float(row["total"]), 4)
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.warning("[analytics-query] query_metric_total failed: %s", e)
+        return 0.0
+
+
+def query_metric_count(name: str, days: int = 1) -> int:
+    """Get the count of metric events over the last N days.
+
+    Args:
+        name: Metric name.
+        days: Number of days to look back.
+
+    Returns:
+        Count of events, or 0 if no data.
+    """
+    try:
+        conn = _get_connection()
+        if conn is None:
+            return 0
+
+        try:
+            cutoff = time.time() - (days * 86400)
+            row = conn.execute(
+                "SELECT COUNT(*) as cnt FROM metrics WHERE name = ? AND timestamp >= ?",
+                (name, cutoff),
+            ).fetchone()
+            return int(row["cnt"])
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.warning("[analytics-query] query_metric_count failed: %s", e)
+        return 0
+
+
+def list_metric_names() -> list[str]:
+    """List all distinct metric names in the database.
+
+    Returns:
+        Sorted list of metric names.
+    """
+    try:
+        conn = _get_connection()
+        if conn is None:
+            return []
+
+        try:
+            rows = conn.execute("SELECT DISTINCT name FROM metrics ORDER BY name").fetchall()
+            return [row["name"] for row in rows]
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.warning("[analytics-query] list_metric_names failed: %s", e)
+        return []

--- a/analytics/rollup.py
+++ b/analytics/rollup.py
@@ -1,0 +1,102 @@
+"""Daily rollup -- aggregate raw metrics and purge old events.
+
+Designed to run as reflections unit 18. Aggregates raw metric events
+into daily summaries in Redis and purges raw SQLite events older than
+30 days.
+"""
+
+import logging
+import sqlite3
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_DB_PATH = Path(__file__).parent.parent / "data" / "analytics.db"
+_SQLITE_TIMEOUT = 5
+_RETENTION_DAYS = 30
+_DAILY_TTL = 30 * 86400
+
+
+def rollup_daily() -> dict:
+    """Aggregate raw events into Redis daily summaries and purge old data.
+
+    Returns:
+        Dict with keys: aggregated_days, purged_rows, errors.
+    """
+    result = {"aggregated_days": 0, "purged_rows": 0, "errors": []}
+
+    if not _DB_PATH.exists():
+        logger.info("[analytics-rollup] No analytics database found, nothing to roll up")
+        return result
+
+    # Step 1: Aggregate into Redis daily keys
+    try:
+        conn = sqlite3.connect(str(_DB_PATH), timeout=_SQLITE_TIMEOUT)
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                """
+                SELECT
+                    date(timestamp, 'unixepoch') as date,
+                    name,
+                    COUNT(*) as count,
+                    SUM(value) as total
+                FROM metrics
+                WHERE timestamp >= ?
+                GROUP BY date(timestamp, 'unixepoch'), name
+                """,
+                (time.time() - (_RETENTION_DAYS * 86400),),
+            ).fetchall()
+
+            if rows:
+                try:
+                    from popoto.redis_db import POPOTO_REDIS_DB
+
+                    dates_seen = set()
+                    for row in rows:
+                        date_str = row["date"]
+                        dates_seen.add(date_str)
+                        daily_key = f"analytics:daily:{date_str}"
+                        # Set the aggregated total
+                        POPOTO_REDIS_DB.hset(daily_key, row["name"], str(round(row["total"], 4)))
+                        POPOTO_REDIS_DB.hset(daily_key, f"{row['name']}:count", str(row["count"]))
+                        POPOTO_REDIS_DB.expire(daily_key, _DAILY_TTL)
+
+                    result["aggregated_days"] = len(dates_seen)
+                    logger.info(
+                        "[analytics-rollup] Aggregated %d metrics across %d days",
+                        len(rows),
+                        len(dates_seen),
+                    )
+                except Exception as e:
+                    result["errors"].append(f"Redis aggregation failed: {e}")
+                    logger.warning("[analytics-rollup] Redis aggregation failed: %s", e)
+        finally:
+            conn.close()
+    except Exception as e:
+        result["errors"].append(f"SQLite read failed: {e}")
+        logger.warning("[analytics-rollup] SQLite read failed: %s", e)
+
+    # Step 2: Purge raw events older than retention period
+    try:
+        conn = sqlite3.connect(str(_DB_PATH), timeout=_SQLITE_TIMEOUT)
+        try:
+            cutoff = time.time() - (_RETENTION_DAYS * 86400)
+            cursor = conn.execute("DELETE FROM metrics WHERE timestamp < ?", (cutoff,))
+            purged = cursor.rowcount
+            conn.commit()
+            result["purged_rows"] = purged
+            if purged > 0:
+                logger.info(
+                    "[analytics-rollup] Purged %d raw events older than %d days",
+                    purged,
+                    _RETENTION_DAYS,
+                )
+        finally:
+            conn.close()
+    except Exception as e:
+        result["errors"].append(f"Purge failed: {e}")
+        logger.warning("[analytics-rollup] Purge failed: %s", e)
+
+    return result

--- a/bridge/pipeline_state.py
+++ b/bridge/pipeline_state.py
@@ -267,6 +267,12 @@ class PipelineStateMachine:
         if stage == "ISSUE":
             self.states[stage] = "in_progress"
             self._save()
+            try:
+                from analytics.collector import record_metric
+
+                record_metric("sdlc.stage_started", 1, {"stage": stage})
+            except Exception:
+                pass
             return
 
         # PATCH is startable if TEST or REVIEW is failed/completed
@@ -276,6 +282,12 @@ class PipelineStateMachine:
             if test_status in ("failed", "completed") or review_status in ("failed", "completed"):
                 self.states[stage] = "in_progress"
                 self._save()
+                try:
+                    from analytics.collector import record_metric
+
+                    record_metric("sdlc.stage_started", 1, {"stage": stage})
+                except Exception:
+                    pass
                 return
             raise ValueError(
                 f"Cannot start PATCH: neither TEST ({test_status}) "
@@ -286,12 +298,24 @@ class PipelineStateMachine:
         if stage == "PLAN" and self.states.get("CRITIQUE") in ("failed",):
             self.states[stage] = "in_progress"
             self._save()
+            try:
+                from analytics.collector import record_metric
+
+                record_metric("sdlc.stage_started", 1, {"stage": stage})
+            except Exception:
+                pass
             return
 
         # For cycle re-entry: TEST can restart after PATCH completes
         if stage == "TEST" and self.states.get("PATCH") in ("completed", "in_progress"):
             self.states[stage] = "in_progress"
             self._save()
+            try:
+                from analytics.collector import record_metric
+
+                record_metric("sdlc.stage_started", 1, {"stage": stage})
+            except Exception:
+                pass
             return
 
         # Check predecessors
@@ -300,12 +324,25 @@ class PipelineStateMachine:
             # No known predecessors — allow start
             self.states[stage] = "in_progress"
             self._save()
+            try:
+                from analytics.collector import record_metric
+
+                record_metric("sdlc.stage_started", 1, {"stage": stage})
+            except Exception:
+                pass
             return
 
         for pred in predecessors:
             if self.states.get(pred) == "completed":
                 self.states[stage] = "in_progress"
                 self._save()
+                # Analytics: record stage start
+                try:
+                    from analytics.collector import record_metric
+
+                    record_metric("sdlc.stage_started", 1, {"stage": stage})
+                except Exception:
+                    pass
                 return
 
         pred_statuses = {p: self.states.get(p, "pending") for p in predecessors}
@@ -355,6 +392,13 @@ class PipelineStateMachine:
                 self.states[next_stage] = "ready"
 
         self._save()
+        # Analytics: record stage completion
+        try:
+            from analytics.collector import record_metric
+
+            record_metric("sdlc.stage_completed", 1, {"stage": stage})
+        except Exception:
+            pass
         logger.info(
             f"Stage {stage} completed. "
             f"Patch cycles: {self.patch_cycle_count}. "

--- a/bridge/pipeline_state.py
+++ b/bridge/pipeline_state.py
@@ -137,6 +137,16 @@ def _parse_outcome_contract(output_tail: str) -> dict | None:
     return parsed
 
 
+def _record_stage_metric(metric_name: str, stage: str) -> None:
+    """Record an analytics metric for a stage transition. Best-effort."""
+    try:
+        from analytics.collector import record_metric
+
+        record_metric(metric_name, 1, {"stage": stage})
+    except Exception:
+        pass
+
+
 class PipelineStateMachine:
     """Manages SDLC pipeline stage transitions with ordering enforcement.
 
@@ -239,6 +249,12 @@ class PipelineStateMachine:
                 predecessors.append(src)
         return predecessors
 
+    def _activate_stage(self, stage: str) -> None:
+        """Set stage to in_progress, save, and record analytics."""
+        self.states[stage] = "in_progress"
+        self._save()
+        _record_stage_metric("sdlc.stage_started", stage)
+
     def start_stage(self, stage: str) -> None:
         """Mark a stage as in_progress.
 
@@ -265,14 +281,7 @@ class PipelineStateMachine:
 
         # ISSUE is always startable (it's the first stage)
         if stage == "ISSUE":
-            self.states[stage] = "in_progress"
-            self._save()
-            try:
-                from analytics.collector import record_metric
-
-                record_metric("sdlc.stage_started", 1, {"stage": stage})
-            except Exception:
-                pass
+            self._activate_stage(stage)
             return
 
         # PATCH is startable if TEST or REVIEW is failed/completed
@@ -280,14 +289,7 @@ class PipelineStateMachine:
             test_status = self.states.get("TEST", "pending")
             review_status = self.states.get("REVIEW", "pending")
             if test_status in ("failed", "completed") or review_status in ("failed", "completed"):
-                self.states[stage] = "in_progress"
-                self._save()
-                try:
-                    from analytics.collector import record_metric
-
-                    record_metric("sdlc.stage_started", 1, {"stage": stage})
-                except Exception:
-                    pass
+                self._activate_stage(stage)
                 return
             raise ValueError(
                 f"Cannot start PATCH: neither TEST ({test_status}) "
@@ -296,53 +298,24 @@ class PipelineStateMachine:
 
         # For cycle re-entry: PLAN can restart after CRITIQUE fails
         if stage == "PLAN" and self.states.get("CRITIQUE") in ("failed",):
-            self.states[stage] = "in_progress"
-            self._save()
-            try:
-                from analytics.collector import record_metric
-
-                record_metric("sdlc.stage_started", 1, {"stage": stage})
-            except Exception:
-                pass
+            self._activate_stage(stage)
             return
 
         # For cycle re-entry: TEST can restart after PATCH completes
         if stage == "TEST" and self.states.get("PATCH") in ("completed", "in_progress"):
-            self.states[stage] = "in_progress"
-            self._save()
-            try:
-                from analytics.collector import record_metric
-
-                record_metric("sdlc.stage_started", 1, {"stage": stage})
-            except Exception:
-                pass
+            self._activate_stage(stage)
             return
 
         # Check predecessors
         predecessors = self._get_predecessors(stage)
         if not predecessors:
             # No known predecessors — allow start
-            self.states[stage] = "in_progress"
-            self._save()
-            try:
-                from analytics.collector import record_metric
-
-                record_metric("sdlc.stage_started", 1, {"stage": stage})
-            except Exception:
-                pass
+            self._activate_stage(stage)
             return
 
         for pred in predecessors:
             if self.states.get(pred) == "completed":
-                self.states[stage] = "in_progress"
-                self._save()
-                # Analytics: record stage start
-                try:
-                    from analytics.collector import record_metric
-
-                    record_metric("sdlc.stage_started", 1, {"stage": stage})
-                except Exception:
-                    pass
+                self._activate_stage(stage)
                 return
 
         pred_statuses = {p: self.states.get(p, "pending") for p in predecessors}
@@ -392,13 +365,7 @@ class PipelineStateMachine:
                 self.states[next_stage] = "ready"
 
         self._save()
-        # Analytics: record stage completion
-        try:
-            from analytics.collector import record_metric
-
-            record_metric("sdlc.stage_completed", 1, {"stage": stage})
-        except Exception:
-            pass
+        _record_stage_metric("sdlc.stage_completed", stage)
         logger.info(
             f"Stage {stage} completed. "
             f"Patch cycles: {self.patch_cycle_count}. "

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -136,6 +136,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [Test Reliability: Flaky Filter](test-reliability-flaky-filter.md) | Branch-side retry for flaky tests, deterministic junitxml baseline parsing, and completeness validation for test classification | Shipped |
 | [Tools Standard](tools-standard.md) | Tool compliance standard, audit checks, and remediation results for the tools/ directory | Shipped |
 | [Trace & Verify Protocol](trace-and-verify.md) | Data-driven root cause analysis replacing narrative-only 5 Whys with forward verification | Shipped |
+| [Unified Analytics](unified-analytics.md) | Dual-write metrics collection (SQLite + Redis) with instrumentation across all subsystems, historical query API, CLI export, dashboard trend view, and reflections rollup | Shipped |
 | [UTC Timestamps](utc-timestamps.md) | All timestamps normalized to tz-aware UTC; CLI/log surfaces show explicit UTC labels, conversational surfaces convert to local time | Shipped |
 | [Web Dashboard](web-dashboard.md) | Session table with SDLC stage pills, project metadata popovers, history-based stage inference, and configurable retention via DASHBOARD_RETENTION_HOURS | Shipped |
 | [Web UI](web-ui.md) | Localhost FastAPI web application at port 8500 serving observability dashboards with HTMX interactivity and dark theme | Shipped |

--- a/docs/features/structured-logging-telemetry.md
+++ b/docs/features/structured-logging-telemetry.md
@@ -105,8 +105,20 @@ redis-cli HGETALL telemetry:daily:2026-03-10
 | `models/agent_session.py` | Structured LINK logging in set_link() |
 | `monitoring/health.py` | Health checks (observer telemetry check removed) |
 
+## Successor: Unified Analytics
+
+The telemetry implementation described above was deleted in #753 as dead code. It has been replaced by the [Unified Analytics](unified-analytics.md) system (#854), which provides:
+
+- SQLite-backed historical time-series (replacing the never-used Redis counters)
+- Instrumentation at all event points (SDK client, session lifecycle, pipeline state, memory ops, crash tracker, health checks)
+- Query API, CLI export, and dashboard integration
+- Daily rollup via the reflections scheduler
+
+The structured log formats documented above remain valid and unchanged.
+
 ## Related
 
 - Issue: [#319](https://github.com/tomcounsell/ai/issues/319)
 - Plan: `docs/plans/structured_logging_telemetry.md`
 - [Correlation IDs](correlation-ids.md) -- the tracing layer that telemetry builds on
+- [Unified Analytics](unified-analytics.md) -- the successor implementation (#854)

--- a/docs/features/unified-analytics.md
+++ b/docs/features/unified-analytics.md
@@ -1,0 +1,213 @@
+# Unified Analytics
+
+## Overview
+
+The unified analytics system collects metrics from all subsystems and stores them for historical querying. It replaces the deleted telemetry module (#753) with a dual-write architecture: SQLite for historical time-series and Redis for live counters. All metric recording is best-effort -- failures are caught and logged, never propagated to callers.
+
+## Architecture
+
+```
+Instrumentation points          Storage                    Output
+---------------------          -------                    ------
+
+sdk_client.py           --->   SQLite (data/analytics.db) ---> CLI export (JSON)
+session_lifecycle.py    --->     WAL mode, indexed         ---> Query API (Python)
+pipeline_state.py       --->                               ---> Dashboard (HTMX)
+memory_retrieval.py     --->   Redis (analytics:* keys)    ---> dashboard.json
+memory_extraction.py    --->     Live counters              ---> Reflections rollup
+crash_tracker.py        --->     Daily rollups (30d TTL)
+health.py               --->
+```
+
+Each instrumentation point calls `record_metric(name, value, dimensions)` which writes to both backends independently. A failure in one backend does not affect the other.
+
+## Metric Catalog
+
+All metric names use dotted notation.
+
+| Metric | Source | Description |
+|--------|--------|-------------|
+| `session.cost_usd` | `agent/sdk_client.py` | Token cost per session from `msg.total_cost_usd` |
+| `session.turns` | `agent/sdk_client.py` | Number of turns in a session |
+| `session.started` | `models/session_lifecycle.py` | Session start event (dimensions: session_type, project_key) |
+| `session.completed` | `models/session_lifecycle.py` | Session completion event (dimensions: session_type, status) |
+| `sdlc.stage_started` | `bridge/pipeline_state.py` | SDLC stage start (dimensions: stage) |
+| `sdlc.stage_completed` | `bridge/pipeline_state.py` | SDLC stage completion (dimensions: stage) |
+| `memory.recall_attempt` | `agent/memory_retrieval.py` | Memory recall attempt (dimensions: hits, project_key) |
+| `memory.extraction` | `agent/memory_extraction.py` | Post-session memory extraction (dimensions: count, project_key) |
+| `crash.recorded` | `monitoring/crash_tracker.py` | Crash event recorded (dimensions: service, exit_code) |
+| `health.check` | `monitoring/health.py` | Health check result (dimensions: component, status) |
+
+## Storage
+
+### SQLite (`data/analytics.db`)
+
+Single append-only table for historical time-series data:
+
+```sql
+CREATE TABLE metrics (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp REAL NOT NULL,
+    name TEXT NOT NULL,
+    value REAL NOT NULL,
+    dimensions TEXT  -- JSON string or NULL
+);
+
+CREATE INDEX idx_metrics_name_ts ON metrics (name, timestamp);
+```
+
+WAL mode is enabled for concurrent read/write support. Each write uses a 5-second timeout. The database auto-creates on first write -- no migration step needed.
+
+### Redis
+
+Two key patterns under the `analytics:` prefix:
+
+| Key Pattern | Type | TTL | Purpose |
+|-------------|------|-----|---------|
+| `analytics:live:{metric_name}` | Hash | None | Live counters keyed by dimensions JSON |
+| `analytics:daily:{YYYY-MM-DD}` | Hash | 30 days | Daily rollup totals per metric |
+
+Live counters use `HINCRBYFLOAT` for atomic increments. Daily keys store both totals and counts (`{metric}` and `{metric}:count` hash fields).
+
+## API Reference
+
+### Collector (`analytics/collector.py`)
+
+```python
+from analytics.collector import record_metric
+
+# Record a metric with dimensions
+record_metric("session.cost_usd", 0.05, {"session_id": "abc123"})
+
+# Record a simple counter
+record_metric("session.started", 1)
+```
+
+The function validates inputs (non-empty name, numeric value) and silently skips invalid calls with a warning log.
+
+### Query (`analytics/query.py`)
+
+```python
+from analytics.query import (
+    query_metrics,
+    query_daily_summary,
+    query_metric_total,
+    query_metric_count,
+    list_metric_names,
+)
+
+# Raw events for a metric in a time range
+events = query_metrics("session.cost_usd", start_time=t0, end_time=t1)
+
+# Daily aggregates (count, total, avg per day)
+daily = query_daily_summary("session.started", days=30)
+
+# Scalar aggregates
+total_cost = query_metric_total("session.cost_usd", days=7)
+session_count = query_metric_count("session.started", days=1)
+
+# List all known metrics
+names = list_metric_names()
+```
+
+All query functions return sensible defaults (empty lists, zero) when the database is missing or empty.
+
+### Rollup (`analytics/rollup.py`)
+
+```python
+from analytics.rollup import rollup_daily
+
+result = rollup_daily()
+# {"aggregated_days": 5, "purged_rows": 142, "errors": []}
+```
+
+Aggregates raw events into Redis daily summary keys and purges SQLite events older than 30 days. Runs automatically as reflections unit 15 (`analytics_rollup`).
+
+## CLI Usage
+
+```bash
+# Export all metrics as JSON (last 30 days by default)
+python -m tools.analytics export --days 30
+
+# Print human-readable summary
+python -m tools.analytics summary
+
+# Run daily rollup manually
+python -m tools.analytics rollup
+```
+
+The `export` command produces JSON with the structure:
+
+```json
+{
+  "exported_at": "2026-04-11T12:00:00Z",
+  "days": 30,
+  "metrics": {
+    "session.cost_usd": {
+      "total": 12.5,
+      "count": 250,
+      "daily": [
+        {"date": "2026-04-11", "count": 8, "total": 0.42, "avg": 0.0525}
+      ]
+    }
+  }
+}
+```
+
+## Dashboard Integration
+
+The `dashboard.json` endpoint includes an additive `analytics` key:
+
+```json
+{
+  "analytics": {
+    "sessions_today": 5,
+    "sessions_7d": 32,
+    "cost_today_usd": 0.25,
+    "cost_7d_usd": 1.80,
+    "daily_sessions": [
+      {"date": "2026-04-11", "count": 5, "total": 5.0, "avg": 1.0}
+    ]
+  }
+}
+```
+
+An HTMX partial (`ui/templates/_partials/analytics_trend.html`) renders a CSS-only sessions-per-day bar chart on the main dashboard page with 30-second polling refresh. When no data is available, it displays "No analytics data yet" gracefully.
+
+## Reflections Integration
+
+The daily rollup runs as reflections step 15 (`analytics_rollup`) in `scripts/reflections.py`. It:
+
+1. Reads raw events from SQLite within the retention window
+2. Aggregates totals and counts per day per metric into Redis daily keys
+3. Purges raw SQLite events older than 30 days to bound database growth
+
+No separate launchd job is needed -- the existing reflections schedule handles it.
+
+## Design Decisions
+
+- **SQLite over Redis for history**: Redis is ephemeral; SQLite provides durable, queryable time-series without external dependencies (stdlib only).
+- **Dual-write over single store**: Redis provides instant live counters for the dashboard; SQLite provides historical queries for export and trends.
+- **Best-effort everywhere**: Every `record_metric()` call is independently try/excepted at both the call site and within the collector. A Redis outage does not prevent SQLite writes and vice versa.
+- **Module-level connection reuse**: The SQLite connection is reused across writes within a process to minimize connection overhead. If a write fails, the connection is reset so the next call retries.
+- **No external dependencies**: Uses only Python stdlib `sqlite3` and existing Redis (via Popoto). No new pip packages.
+- **Lazy imports at call sites**: Instrumentation points use `from analytics.collector import record_metric` inside try/except blocks to avoid import-time failures.
+
+## Files
+
+| File | Role |
+|------|------|
+| `analytics/__init__.py` | Package init, re-exports `record_metric` |
+| `analytics/collector.py` | Dual-write collector (SQLite + Redis) |
+| `analytics/query.py` | Query API for historical and aggregate data |
+| `analytics/rollup.py` | Daily aggregation and purge job |
+| `tools/analytics.py` | CLI entry point (`python -m tools.analytics`) |
+| `ui/data/analytics.py` | Dashboard data provider |
+| `ui/templates/_partials/analytics_trend.html` | HTMX sessions-per-day bar chart |
+| `data/analytics.db` | SQLite database (auto-created, gitignored) |
+
+## Related
+
+- Issue: [#854](https://github.com/tomcounsell/ai/issues/854)
+- Plan: `docs/plans/unified-analytics.md`
+- Predecessor: [Structured Logging & Telemetry](structured-logging-telemetry.md) (design doc; implementation was deleted in #753)

--- a/docs/plans/unified-analytics.md
+++ b/docs/plans/unified-analytics.md
@@ -1,6 +1,6 @@
 ---
 slug: unified-analytics
-status: Ready
+status: Building
 type: feature
 appetite: Large
 tracking: https://github.com/tomcounsell/ai/issues/854

--- a/models/session_lifecycle.py
+++ b/models/session_lifecycle.py
@@ -360,6 +360,21 @@ def finalize_session(
     session.completed_at = time.time()
     session.save()
 
+    # Analytics: record session completion
+    try:
+        from analytics.collector import record_metric
+
+        record_metric(
+            "session.completed",
+            1,
+            {
+                "session_type": getattr(session, "session_type", None),
+                "status": status,
+            },
+        )
+    except Exception:
+        pass
+
 
 def transition_status(
     session,
@@ -482,6 +497,22 @@ def transition_status(
         session._saved_field_values["status"] = current_status
     session.status = new_status
     session.save()
+
+    # Analytics: record session start when transitioning to running
+    if new_status == "running" and current_status != "running":
+        try:
+            from analytics.collector import record_metric
+
+            record_metric(
+                "session.started",
+                1,
+                {
+                    "session_type": getattr(session, "session_type", None),
+                    "project_key": getattr(session, "project_key", None),
+                },
+            )
+        except Exception:
+            pass
 
 
 def _finalize_parent_sync(

--- a/monitoring/crash_tracker.py
+++ b/monitoring/crash_tracker.py
@@ -108,6 +108,18 @@ def log_event(event_type: str, reason: str | None = None) -> CrashEvent:
     except Exception as e:
         logger.error(f"Failed to log crash event: {e}")
 
+    # Analytics: record crash/start event
+    try:
+        from analytics.collector import record_metric
+
+        record_metric(
+            f"crash.{event_type}",
+            1,
+            {"commit_sha": sha, "reason": reason},
+        )
+    except Exception:
+        pass
+
     return event
 
 

--- a/monitoring/health.py
+++ b/monitoring/health.py
@@ -253,6 +253,19 @@ class HealthChecker:
         else:
             status = HealthStatus.HEALTHY
 
+        # Analytics: record health check results
+        try:
+            from analytics.collector import record_metric
+
+            for check in checks:
+                record_metric(
+                    "health.check",
+                    1,
+                    {"component": check.component, "status": check.status.value},
+                )
+        except Exception:
+            pass
+
         return OverallHealth(
             status=status,
             score=score,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,4 +107,5 @@ markers = [
     "impact: Code and documentation impact analysis",
     "models: Redis/Popoto model relationships and persistence",
     "webui: Web UI dashboards, routes, templates",
+    "analytics: Unified analytics collection, query, and dashboard",
 ]

--- a/scripts/reflections.py
+++ b/scripts/reflections.py
@@ -3,7 +3,7 @@
 Reflections - Autonomous Daily Maintenance System
 
 A long-running process that performs daily self-directed maintenance tasks.
-17 units: 14 independent items + 3 merged pipelines.
+18 units: 15 independent items + 3 merged pipelines.
 
 Independent units:
 1. legacy_code_scan — Clean Up Stale Code
@@ -20,11 +20,12 @@ Independent units:
 12. disk_space_check    — Disk Space Check
 13. pr_review_audit     — PR Review Audit
 14. linkedin_messages   — Check & Reply to LinkedIn Messages
+15. analytics_rollup    — Analytics Daily Rollup
 
 Merged pipelines (sub-steps run internally, one checkpoint per pipeline):
-15. session_intelligence    — Session Analysis + LLM Reflection + Bug Filing
-16. behavioral_learning     — Episode Cycle-Close + Pattern Crystallization
-17. daily_report_and_notify — Daily Report + GitHub Issues + Telegram (must be last)
+16. session_intelligence    — Session Analysis + LLM Reflection + Bug Filing
+17. behavioral_learning     — Episode Cycle-Close + Pattern Crystallization
+18. daily_report_and_notify — Daily Report + GitHub Issues + Telegram (must be last)
 
 All persistence is Redis-backed via Popoto models (see models/ directory).
 State: ReflectionRun | Ignore patterns: ReflectionIgnore
@@ -691,6 +692,7 @@ class ReflectionRunner:
             ("disk_space_check", "Disk Space Check", self.step_disk_space_check),
             ("pr_review_audit", "PR Review Audit", self.step_pr_review_audit),
             ("linkedin_messages", "LinkedIn Messages", self.step_linkedin_messages),
+            ("analytics_rollup", "Analytics Rollup", self.step_analytics_rollup),
             ("session_intelligence", "Session Intelligence", self.step_session_intelligence),
             ("behavioral_learning", "Behavioral Learning", self.step_behavioral_learning),
             ("daily_report_and_notify", "Daily Report & Notify", self.step_daily_report_and_notify),
@@ -2865,6 +2867,22 @@ class ReflectionRunner:
         self.state.step_progress["linkedin_messages"] = {
             "findings": len(findings),
         }
+
+    async def step_analytics_rollup(self) -> None:
+        """Run analytics daily rollup: aggregate metrics and purge old data."""
+        try:
+            from analytics.rollup import rollup_daily
+
+            result = rollup_daily()
+            self.state.add_finding(
+                "analytics_rollup",
+                f"Aggregated {result['aggregated_days']} days, purged {result['purged_rows']} rows",
+            )
+            self.state.step_progress["analytics_rollup"] = result
+        except Exception as e:
+            logger.warning(f"[reflections] Analytics rollup failed: {e}")
+            self.state.add_finding("analytics_rollup", f"Failed: {e}")
+            self.state.step_progress["analytics_rollup"] = {"error": str(e)}
 
     async def step_session_intelligence(self) -> None:
         """Pipeline: Session Analysis → LLM Reflection → Bug Filing.

--- a/tests/integration/test_analytics_dashboard.py
+++ b/tests/integration/test_analytics_dashboard.py
@@ -1,0 +1,36 @@
+"""Integration tests for analytics dashboard endpoints.
+
+Tests that dashboard.json includes the analytics key and that existing
+keys remain backward-compatible.
+"""
+
+import pytest
+
+
+@pytest.mark.analytics
+class TestDashboardAnalytics:
+    """Test analytics integration in dashboard endpoints."""
+
+    def test_analytics_summary_returns_valid_structure(self):
+        """get_analytics_summary should return a well-formed dict."""
+        from ui.data.analytics import get_analytics_summary
+
+        summary = get_analytics_summary()
+        assert isinstance(summary, dict)
+        assert "sessions_today" in summary
+        assert "sessions_7d" in summary
+        assert "cost_today_usd" in summary
+        assert "cost_7d_usd" in summary
+        assert "daily_sessions" in summary
+        assert isinstance(summary["daily_sessions"], list)
+
+    def test_analytics_summary_graceful_without_db(self, tmp_path, monkeypatch):
+        """Analytics summary should return zeros when no database exists."""
+        monkeypatch.setattr("analytics.query._DB_PATH", tmp_path / "nonexistent.db")
+
+        from ui.data.analytics import get_analytics_summary
+
+        summary = get_analytics_summary()
+        assert summary["sessions_today"] == 0
+        assert summary["sessions_7d"] == 0
+        assert summary["cost_today_usd"] == 0.0

--- a/tests/unit/test_analytics_cli.py
+++ b/tests/unit/test_analytics_cli.py
@@ -1,0 +1,110 @@
+"""Tests for tools.analytics CLI -- export, summary, rollup commands."""
+
+import json
+import sqlite3
+import time
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def populated_db(tmp_path, monkeypatch):
+    """Create a temp analytics database with test data."""
+    db_path = tmp_path / "analytics.db"
+    monkeypatch.setattr("analytics.query._DB_PATH", db_path)
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        CREATE TABLE metrics (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp REAL NOT NULL,
+            name TEXT NOT NULL,
+            value REAL NOT NULL,
+            dimensions TEXT
+        )
+        """
+    )
+    conn.execute("CREATE INDEX idx_metrics_name_ts ON metrics (name, timestamp)")
+
+    now = time.time()
+    test_data = [
+        (now - 3600, "session.started", 1.0, None),
+        (now - 7200, "session.cost_usd", 0.05, None),
+    ]
+    conn.executemany(
+        "INSERT INTO metrics (timestamp, name, value, dimensions) VALUES (?, ?, ?, ?)",
+        test_data,
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+@pytest.fixture
+def empty_db(tmp_path, monkeypatch):
+    """Point at a non-existent database."""
+    db_path = tmp_path / "nonexistent.db"
+    monkeypatch.setattr("analytics.query._DB_PATH", db_path)
+    return db_path
+
+
+class TestExportCommand:
+    def test_export_produces_valid_json(self, populated_db):
+        import argparse
+
+        from tools.analytics import cmd_export
+
+        args = argparse.Namespace(days=30)
+        output = StringIO()
+        with patch("sys.stdout", output):
+            cmd_export(args)
+
+        result = json.loads(output.getvalue())
+        assert "exported_at" in result
+        assert "metrics" in result
+        assert "session.started" in result["metrics"]
+
+    def test_export_empty_db_produces_valid_json(self, empty_db):
+        import argparse
+
+        from tools.analytics import cmd_export
+
+        args = argparse.Namespace(days=30)
+        output = StringIO()
+        with patch("sys.stdout", output):
+            cmd_export(args)
+
+        result = json.loads(output.getvalue())
+        assert result["metrics"] == {}
+
+
+class TestSummaryCommand:
+    def test_summary_with_data(self, populated_db):
+        import argparse
+
+        from tools.analytics import cmd_summary
+
+        args = argparse.Namespace()
+        output = StringIO()
+        with patch("sys.stdout", output):
+            cmd_summary(args)
+
+        text = output.getvalue()
+        assert "Analytics Summary" in text
+        assert "session.started" in text
+
+    def test_summary_no_data(self, empty_db):
+        import argparse
+
+        from tools.analytics import cmd_summary
+
+        args = argparse.Namespace()
+        output = StringIO()
+        with patch("sys.stdout", output):
+            cmd_summary(args)
+
+        text = output.getvalue()
+        assert "No analytics data" in text

--- a/tests/unit/test_analytics_collector.py
+++ b/tests/unit/test_analytics_collector.py
@@ -10,10 +10,13 @@ import pytest
 
 @pytest.fixture
 def temp_db(tmp_path, monkeypatch):
-    """Redirect analytics to a temp directory."""
+    """Redirect analytics to a temp directory and reset cached connection."""
     db_path = tmp_path / "analytics.db"
     monkeypatch.setattr("analytics.collector._DB_DIR", tmp_path)
     monkeypatch.setattr("analytics.collector._DB_PATH", db_path)
+    # Reset module-level cached connection so it picks up the new path
+    monkeypatch.setattr("analytics.collector._sqlite_conn", None)
+    monkeypatch.setattr("analytics.collector._db_initialized", False)
     return db_path
 
 

--- a/tests/unit/test_analytics_collector.py
+++ b/tests/unit/test_analytics_collector.py
@@ -1,0 +1,150 @@
+"""Tests for analytics.collector -- record_metric and best-effort pattern."""
+
+import json
+import sqlite3
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def temp_db(tmp_path, monkeypatch):
+    """Redirect analytics to a temp directory."""
+    db_path = tmp_path / "analytics.db"
+    monkeypatch.setattr("analytics.collector._DB_DIR", tmp_path)
+    monkeypatch.setattr("analytics.collector._DB_PATH", db_path)
+    return db_path
+
+
+class TestRecordMetric:
+    """Test record_metric writes to SQLite."""
+
+    def test_basic_write(self, temp_db):
+        """record_metric should write a row to SQLite."""
+        from analytics.collector import record_metric
+
+        # Mock Redis to avoid requiring a live connection
+        with patch("analytics.collector._write_redis"):
+            record_metric("test.metric", 42.0, {"key": "value"})
+
+        # Verify SQLite write
+        conn = sqlite3.connect(str(temp_db))
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute("SELECT * FROM metrics").fetchall()
+        conn.close()
+
+        assert len(rows) == 1
+        assert rows[0]["name"] == "test.metric"
+        assert rows[0]["value"] == 42.0
+        dims = json.loads(rows[0]["dimensions"])
+        assert dims["key"] == "value"
+
+    def test_write_without_dimensions(self, temp_db):
+        """record_metric should work without dimensions."""
+        from analytics.collector import record_metric
+
+        with patch("analytics.collector._write_redis"):
+            record_metric("test.simple", 1.0)
+
+        conn = sqlite3.connect(str(temp_db))
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute("SELECT * FROM metrics").fetchall()
+        conn.close()
+
+        assert len(rows) == 1
+        assert rows[0]["dimensions"] is None
+
+    def test_multiple_writes(self, temp_db):
+        """Multiple record_metric calls should create multiple rows."""
+        from analytics.collector import record_metric
+
+        with patch("analytics.collector._write_redis"):
+            record_metric("test.a", 1.0)
+            record_metric("test.b", 2.0)
+            record_metric("test.a", 3.0)
+
+        conn = sqlite3.connect(str(temp_db))
+        count = conn.execute("SELECT COUNT(*) FROM metrics").fetchone()[0]
+        conn.close()
+
+        assert count == 3
+
+    def test_wal_mode_enabled(self, temp_db):
+        """SQLite should use WAL journal mode."""
+        from analytics.collector import record_metric
+
+        with patch("analytics.collector._write_redis"):
+            record_metric("test.wal", 1.0)
+
+        conn = sqlite3.connect(str(temp_db))
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        conn.close()
+
+        assert mode == "wal"
+
+
+class TestBestEffortPattern:
+    """Test that failures are swallowed, never propagated."""
+
+    def test_invalid_name_does_not_raise(self, temp_db):
+        """Empty name should log and return, not raise."""
+        from analytics.collector import record_metric
+
+        record_metric("", 1.0)  # Should not raise
+        record_metric(None, 1.0)  # Should not raise
+
+    def test_none_value_does_not_raise(self, temp_db):
+        """None value should log and return, not raise."""
+        from analytics.collector import record_metric
+
+        record_metric("test.none", None)  # Should not raise
+
+    def test_non_numeric_value_does_not_raise(self, temp_db):
+        """Non-numeric value should log and return, not raise."""
+        from analytics.collector import record_metric
+
+        record_metric("test.bad", "not_a_number")  # Should not raise
+
+    def test_sqlite_failure_does_not_propagate(self, temp_db):
+        """A SQLite failure should not raise to the caller."""
+        from analytics.collector import record_metric
+
+        with patch("analytics.collector._write_sqlite", side_effect=Exception("DB gone")):
+            with patch("analytics.collector._write_redis"):
+                record_metric("test.broken", 1.0)  # Should not raise
+
+    def test_redis_failure_does_not_propagate(self, temp_db):
+        """A Redis failure should not prevent SQLite write or raise."""
+        from analytics.collector import record_metric
+
+        with patch("analytics.collector._write_redis", side_effect=Exception("Redis gone")):
+            record_metric("test.redis_fail", 1.0)  # Should not raise
+
+        # SQLite write should have succeeded
+        conn = sqlite3.connect(str(temp_db))
+        count = conn.execute(
+            "SELECT COUNT(*) FROM metrics WHERE name='test.redis_fail'"
+        ).fetchone()[0]
+        conn.close()
+        assert count == 1
+
+
+class TestRedisWrite:
+    """Test Redis write behavior."""
+
+    def test_redis_hincrbyfloat_called(self, temp_db):
+        """_write_redis should call HINCRBYFLOAT on live and daily keys."""
+        from analytics.collector import _write_redis
+
+        mock_redis = MagicMock()
+        with patch.dict(
+            "sys.modules",
+            {"popoto": MagicMock(), "popoto.redis_db": MagicMock(POPOTO_REDIS_DB=mock_redis)},
+        ):
+            _write_redis("test.metric", 1.0, {"k": "v"}, time.time())
+
+        # Should have called hincrbyfloat twice (live + daily)
+        assert mock_redis.hincrbyfloat.call_count == 2
+        # Should have called expire once (for daily key)
+        assert mock_redis.expire.call_count == 1

--- a/tests/unit/test_analytics_query.py
+++ b/tests/unit/test_analytics_query.py
@@ -1,0 +1,149 @@
+"""Tests for analytics.query -- query functions and empty database handling."""
+
+import json
+import sqlite3
+import time
+
+import pytest
+
+
+@pytest.fixture
+def populated_db(tmp_path, monkeypatch):
+    """Create a temp analytics database with test data."""
+    db_path = tmp_path / "analytics.db"
+    monkeypatch.setattr("analytics.query._DB_PATH", db_path)
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        CREATE TABLE metrics (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp REAL NOT NULL,
+            name TEXT NOT NULL,
+            value REAL NOT NULL,
+            dimensions TEXT
+        )
+        """
+    )
+    conn.execute("CREATE INDEX idx_metrics_name_ts ON metrics (name, timestamp)")
+
+    now = time.time()
+    # Insert test data across several days
+    test_data = [
+        (now - 3600, "session.started", 1.0, json.dumps({"session_type": "pm"})),
+        (now - 7200, "session.started", 1.0, json.dumps({"session_type": "dev"})),
+        (now - 86400, "session.started", 1.0, None),  # yesterday
+        (now - 86400 * 3, "session.started", 1.0, None),  # 3 days ago
+        (now - 3600, "session.cost_usd", 0.05, json.dumps({"session_id": "s1"})),
+        (now - 7200, "session.cost_usd", 0.10, json.dumps({"session_id": "s2"})),
+    ]
+    conn.executemany(
+        "INSERT INTO metrics (timestamp, name, value, dimensions) VALUES (?, ?, ?, ?)",
+        test_data,
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+@pytest.fixture
+def empty_db(tmp_path, monkeypatch):
+    """Point analytics query at a non-existent database."""
+    db_path = tmp_path / "nonexistent.db"
+    monkeypatch.setattr("analytics.query._DB_PATH", db_path)
+    return db_path
+
+
+class TestQueryMetrics:
+    def test_query_by_name(self, populated_db):
+        from analytics.query import query_metrics
+
+        results = query_metrics("session.started")
+        assert len(results) == 4
+        assert all(r["name"] == "session.started" for r in results)
+
+    def test_query_with_time_range(self, populated_db):
+        from analytics.query import query_metrics
+
+        now = time.time()
+        results = query_metrics("session.started", start_time=now - 86400)
+        # Should only get today's events (2), not yesterday or 3 days ago
+        assert len(results) == 2
+
+    def test_query_with_dimensions_filter(self, populated_db):
+        from analytics.query import query_metrics
+
+        results = query_metrics(
+            "session.started",
+            dimensions_filter={"session_type": "pm"},
+        )
+        assert len(results) == 1
+
+    def test_query_empty_database(self, empty_db):
+        from analytics.query import query_metrics
+
+        results = query_metrics("session.started")
+        assert results == []
+
+
+class TestQueryDailySummary:
+    def test_daily_summary(self, populated_db):
+        from analytics.query import query_daily_summary
+
+        results = query_daily_summary("session.started", days=7)
+        assert len(results) >= 1
+        # Each result should have date, count, total, avg
+        for r in results:
+            assert "date" in r
+            assert "count" in r
+            assert "total" in r
+            assert "avg" in r
+
+    def test_daily_summary_empty(self, empty_db):
+        from analytics.query import query_daily_summary
+
+        results = query_daily_summary("session.started", days=7)
+        assert results == []
+
+
+class TestQueryMetricTotal:
+    def test_total(self, populated_db):
+        from analytics.query import query_metric_total
+
+        total = query_metric_total("session.cost_usd", days=1)
+        assert total == 0.15  # 0.05 + 0.10
+
+    def test_total_empty(self, empty_db):
+        from analytics.query import query_metric_total
+
+        total = query_metric_total("session.cost_usd", days=1)
+        assert total == 0.0
+
+
+class TestQueryMetricCount:
+    def test_count(self, populated_db):
+        from analytics.query import query_metric_count
+
+        count = query_metric_count("session.started", days=1)
+        assert count == 2  # 2 events today
+
+    def test_count_empty(self, empty_db):
+        from analytics.query import query_metric_count
+
+        count = query_metric_count("session.started", days=1)
+        assert count == 0
+
+
+class TestListMetricNames:
+    def test_list_names(self, populated_db):
+        from analytics.query import list_metric_names
+
+        names = list_metric_names()
+        assert "session.started" in names
+        assert "session.cost_usd" in names
+
+    def test_list_names_empty(self, empty_db):
+        from analytics.query import list_metric_names
+
+        names = list_metric_names()
+        assert names == []

--- a/tools/analytics.py
+++ b/tools/analytics.py
@@ -1,0 +1,120 @@
+"""CLI tool for analytics export and management.
+
+Usage:
+    python -m tools.analytics export --days 30
+    python -m tools.analytics summary
+    python -m tools.analytics rollup
+"""
+
+import argparse
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+
+# Ensure project root on sys.path
+_project_root = str(Path(__file__).parent.parent)
+if _project_root not in sys.path:
+    sys.path.insert(0, _project_root)
+
+logger = logging.getLogger(__name__)
+
+
+def cmd_export(args: argparse.Namespace) -> None:
+    """Export analytics data as JSON."""
+    from analytics.query import (
+        list_metric_names,
+        query_daily_summary,
+        query_metric_count,
+        query_metric_total,
+    )
+
+    days = args.days
+    metrics = list_metric_names()
+
+    export_data = {
+        "exported_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "days": days,
+        "metrics": {},
+    }
+
+    for name in metrics:
+        total = query_metric_total(name, days=days)
+        count = query_metric_count(name, days=days)
+        daily = query_daily_summary(name, days=days)
+        export_data["metrics"][name] = {
+            "total": total,
+            "count": count,
+            "daily": daily,
+        }
+
+    json.dump(export_data, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+def cmd_summary(args: argparse.Namespace) -> None:
+    """Print a human-readable summary of analytics data."""
+    from analytics.query import list_metric_names, query_metric_count, query_metric_total
+
+    metrics = list_metric_names()
+    if not metrics:
+        print("No analytics data recorded yet.")
+        return
+
+    print(f"Analytics Summary ({len(metrics)} metrics)")
+    print("=" * 50)
+
+    for name in metrics:
+        count_1d = query_metric_count(name, days=1)
+        count_7d = query_metric_count(name, days=7)
+        total_1d = query_metric_total(name, days=1)
+        total_7d = query_metric_total(name, days=7)
+        print(f"\n  {name}:")
+        print(f"    Today:  {count_1d} events, total={total_1d}")
+        print(f"    7-day:  {count_7d} events, total={total_7d}")
+
+
+def cmd_rollup(args: argparse.Namespace) -> None:
+    """Run the daily rollup manually."""
+    from analytics.rollup import rollup_daily
+
+    result = rollup_daily()
+    agg = result["aggregated_days"]
+    purged = result["purged_rows"]
+    print(f"Rollup complete: {agg} days aggregated, {purged} rows purged")
+    if result["errors"]:
+        for err in result["errors"]:
+            print(f"  Error: {err}")
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        prog="analytics",
+        description="Unified analytics CLI",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # export
+    export_parser = subparsers.add_parser("export", help="Export analytics as JSON")
+    export_parser.add_argument("--days", type=int, default=30, help="Days to export (default: 30)")
+
+    # summary
+    subparsers.add_parser("summary", help="Print human-readable summary")
+
+    # rollup
+    subparsers.add_parser("rollup", help="Run daily rollup")
+
+    args = parser.parse_args()
+
+    if args.command == "export":
+        cmd_export(args)
+    elif args.command == "summary":
+        cmd_summary(args)
+    elif args.command == "rollup":
+        cmd_rollup(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/ui/app.py
+++ b/ui/app.py
@@ -121,6 +121,7 @@ def create_app() -> FastAPI:
     @app.get("/", response_class=HTMLResponse)
     def index(request: Request):
         """Root route: single-page dashboard with all system state."""
+        from ui.data.analytics import get_analytics_summary
         from ui.data.machine import get_machine_name, get_machine_projects
         from ui.data.reflections import get_all_reflections
         from ui.data.sdlc import get_all_sessions
@@ -128,6 +129,7 @@ def create_app() -> FastAPI:
         sessions = get_all_sessions()
         reflections = get_all_reflections()
         machine_projects = get_machine_projects()
+        analytics = get_analytics_summary()
         return templates.TemplateResponse(
             request,
             "index.html",
@@ -136,7 +138,20 @@ def create_app() -> FastAPI:
                 "reflections": reflections,
                 "machine_name": get_machine_name(),
                 "machine_projects": machine_projects,
+                "analytics": analytics,
             },
+        )
+
+    @app.get("/_partials/analytics/", response_class=HTMLResponse)
+    def partial_analytics_trend(request: Request):
+        """HTMX partial: analytics trend chart."""
+        from ui.data.analytics import get_analytics_summary
+
+        analytics = get_analytics_summary()
+        return templates.TemplateResponse(
+            request,
+            "_partials/analytics_trend.html",
+            {"analytics": analytics},
         )
 
     @app.get("/_partials/sessions/", response_class=HTMLResponse)
@@ -250,6 +265,7 @@ def create_app() -> FastAPI:
         """Full dashboard state as JSON for programmatic consumption."""
         from fastapi.responses import JSONResponse
 
+        from ui.data.analytics import get_analytics_summary
         from ui.data.machine import get_machine_name, get_machine_projects
         from ui.data.reflections import get_all_reflections
         from ui.data.sdlc import get_all_sessions
@@ -258,6 +274,7 @@ def create_app() -> FastAPI:
         worker = _get_worker_health()
         sessions = get_all_sessions()
         reflections = get_all_reflections()
+        analytics = get_analytics_summary()
 
         return JSONResponse(
             {
@@ -274,6 +291,7 @@ def create_app() -> FastAPI:
                     "name": get_machine_name(),
                     "projects": get_machine_projects(),
                 },
+                "analytics": analytics,
             }
         )
 

--- a/ui/data/analytics.py
+++ b/ui/data/analytics.py
@@ -1,0 +1,45 @@
+"""Dashboard data provider for analytics.
+
+Queries the analytics store and returns data structured for the
+dashboard.json endpoint and HTMX partials.
+"""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def get_analytics_summary() -> dict[str, Any]:
+    """Get analytics summary for dashboard.json.
+
+    Returns:
+        Dict with keys: sessions_today, sessions_7d, cost_today_usd,
+        cost_7d_usd, daily_sessions. Returns empty/zero values if
+        analytics database is missing or empty.
+    """
+    try:
+        from analytics.query import query_daily_summary, query_metric_count, query_metric_total
+
+        sessions_today = query_metric_count("session.started", days=1)
+        sessions_7d = query_metric_count("session.started", days=7)
+        cost_today = query_metric_total("session.cost_usd", days=1)
+        cost_7d = query_metric_total("session.cost_usd", days=7)
+        daily_sessions = query_daily_summary("session.started", days=30)
+
+        return {
+            "sessions_today": sessions_today,
+            "sessions_7d": sessions_7d,
+            "cost_today_usd": cost_today,
+            "cost_7d_usd": cost_7d,
+            "daily_sessions": daily_sessions,
+        }
+    except Exception as e:
+        logger.warning("[analytics-dashboard] Failed to get analytics summary: %s", e)
+        return {
+            "sessions_today": 0,
+            "sessions_7d": 0,
+            "cost_today_usd": 0.0,
+            "cost_7d_usd": 0.0,
+            "daily_sessions": [],
+        }

--- a/ui/static/style.css
+++ b/ui/static/style.css
@@ -984,3 +984,68 @@ a:hover {
     color: var(--text-primary);
     background: var(--bg-hover);
 }
+
+/* ── Analytics Trend Chart ── */
+.analytics-trend {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 1rem;
+    margin-bottom: 1rem;
+}
+
+.trend-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 0.75rem;
+}
+
+.trend-title {
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: var(--text-primary);
+}
+
+.trend-summary {
+    font-size: 0.75rem;
+}
+
+.trend-chart {
+    display: flex;
+    align-items: flex-end;
+    gap: 2px;
+    height: 80px;
+    padding-bottom: 1.2rem;
+    position: relative;
+}
+
+.trend-bar-wrapper {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    height: 100%;
+    justify-content: flex-end;
+    position: relative;
+}
+
+.trend-bar {
+    width: 100%;
+    min-height: 2px;
+    background: var(--accent);
+    border-radius: 2px 2px 0 0;
+    transition: height 0.3s ease;
+}
+
+.trend-bar-wrapper:hover .trend-bar {
+    background: var(--accent-hover);
+}
+
+.trend-label {
+    position: absolute;
+    bottom: -1.2rem;
+    font-size: 0.6rem;
+    color: var(--text-muted);
+    white-space: nowrap;
+}

--- a/ui/templates/_partials/analytics_trend.html
+++ b/ui/templates/_partials/analytics_trend.html
@@ -1,0 +1,33 @@
+{# Analytics trend: sessions-per-day bar chart (CSS-only, no JS charting lib) #}
+{% if analytics and analytics.daily_sessions %}
+<div class="analytics-trend">
+    <div class="trend-header">
+        <span class="trend-title">Sessions / Day (30d)</span>
+        <span class="trend-summary text-muted">
+            Today: {{ analytics.sessions_today }} &middot;
+            7d: {{ analytics.sessions_7d }} &middot;
+            Cost 7d: ${{ "%.2f"|format(analytics.cost_7d_usd) }}
+        </span>
+    </div>
+    <div class="trend-chart">
+        {% set max_count = analytics.daily_sessions | map(attribute='count') | max %}
+        {% for day in analytics.daily_sessions | reverse %}
+        <div class="trend-bar-wrapper" title="{{ day.date }}: {{ day.count }} sessions">
+            <div class="trend-bar"
+                 style="height: {{ (day.count / max_count * 100) if max_count > 0 else 0 }}%">
+            </div>
+            {% if loop.index % 7 == 1 or loop.last %}
+            <span class="trend-label">{{ day.date[-5:] }}</span>
+            {% endif %}
+        </div>
+        {% endfor %}
+    </div>
+</div>
+{% else %}
+<div class="analytics-trend">
+    <div class="trend-header">
+        <span class="trend-title">Analytics</span>
+    </div>
+    <p class="text-muted" style="padding: 0.5rem 0;">No analytics data yet. Metrics are collected automatically during system operation.</p>
+</div>
+{% endif %}

--- a/ui/templates/index.html
+++ b/ui/templates/index.html
@@ -14,6 +14,13 @@
     </div>
 </div>
 
+{# ── Analytics ── #}
+<section id="analytics" class="mt-8">
+    <div id="analytics-trend" hx-get="/_partials/analytics/" hx-trigger="load, every 30s" hx-swap="innerHTML">
+        {% include "_partials/analytics_trend.html" %}
+    </div>
+</section>
+
 {# ── Agent Sessions ── #}
 <section id="sessions">
     <h2>Agent Sessions</h2>


### PR DESCRIPTION
## Summary
- Add `analytics/` module with SQLite + Redis dual-write collector (`record_metric(name, value, dimensions)`), query API, and daily rollup
- Instrument 6 existing code paths: token cost (sdk_client), session lifecycle, SDLC stage transitions, memory recall/extraction, crash tracker, health checks
- Extend dashboard with `analytics` key in `dashboard.json` and HTMX sessions-per-day trend partial
- Add CLI tool (`python -m tools.analytics export/summary/rollup`) and reflections unit 18 for daily rollup
- All metric recording is best-effort -- failures are caught and logged, never crash the caller

Closes #854

## Test plan
- [x] 28 new tests pass (collector, query, CLI, dashboard integration)
- [x] Ruff lint and format clean
- [x] CLI export produces valid JSON with empty database
- [x] `record_metric()` works standalone without raising
- [x] dashboard.json backward-compatible (existing keys unchanged, new `analytics` key additive)
- [ ] Verify dashboard trend chart renders on localhost:8500 with live data
- [ ] Run full test suite to confirm no regressions