### PR TITLE
feat: PM session child fan-out for multi-issue SDLC prompts

### DIFF
--- a/agent/sdk_client.py
+++ b/agent/sdk_client.py
@@ -1961,7 +1961,8 @@ async def get_agent_response_sdk(
                 '    --parent "$AGENT_SESSION_ID" \\\\\n'
                 '    --message "Run SDLC on issue N"\n'
                 "After spawning ALL children, run:\n"
-                '  python -m tools.valor_session wait-for-children --session-id "$AGENT_SESSION_ID"\n'
+                "  python -m tools.valor_session wait-for-children"
+                ' --session-id "$AGENT_SESSION_ID"\n'
                 "to pause this session. Do NOT process multiple issues in a single session. "
                 "Spawn child sessions sequentially (one create call at a time) then call "
                 "wait-for-children once. Send a Telegram update before pausing so Valor "

--- a/agent/sdk_client.py
+++ b/agent/sdk_client.py
@@ -1953,7 +1953,20 @@ async def get_agent_response_sdk(
         else:
             # PM dispatch: orchestrate SDLC work stage-by-stage
             enriched_message += (
-                "\n\nYou are the PM. Orchestrate SDLC work stage-by-stage:\n"
+                "\n\nMULTI-ISSUE FAN-OUT: If the message contains more than one GitHub "
+                "issue number (e.g., 'Run SDLC on issues 777, 775, 776'), you MUST fan out. "
+                "For each issue number N, run:\n"
+                "  python -m tools.valor_session create \\\\\n"
+                "    --role pm \\\\\n"
+                '    --parent "$AGENT_SESSION_ID" \\\\\n'
+                '    --message "Run SDLC on issue N"\n'
+                "After spawning ALL children, run:\n"
+                '  python -m tools.valor_session wait-for-children --session-id "$AGENT_SESSION_ID"\n'
+                "to pause this session. Do NOT process multiple issues in a single session. "
+                "Spawn child sessions sequentially (one create call at a time) then call "
+                "wait-for-children once. Send a Telegram update before pausing so Valor "
+                "knows fan-out happened.\n\n"
+                "You are the PM. Orchestrate SDLC work stage-by-stage:\n"
                 "1. **Assess the current stage** — use read-only Bash commands "
                 "(gh issue view, gh pr view, gh pr list, grep) to determine "
                 "where work stands. You can run Bash for reads freely.\n"

--- a/config/personas/project-manager.md
+++ b/config/personas/project-manager.md
@@ -116,6 +116,32 @@ human and agent work. The 2026-04-10 incident proved this causes data loss.
 
 ---
 
+## Multi-Issue Fan-out
+
+When a message contains more than one GitHub issue number (e.g., "Run SDLC on issues 777, 775, 776"), you MUST fan out instead of handling all issues in a single session.
+
+**Steps:**
+
+1. For each issue number N, create a child PM session:
+   ```bash
+   python -m tools.valor_session create \
+     --role pm \
+     --parent "$AGENT_SESSION_ID" \
+     --message "Run SDLC on issue N"
+   ```
+2. Create child sessions sequentially — one `create` call at a time.
+3. After spawning ALL children, transition this session to `waiting_for_children`:
+   ```bash
+   python -m tools.valor_session wait-for-children --session-id "$AGENT_SESSION_ID"
+   ```
+4. Send a Telegram update before pausing (e.g., "Spawning 3 child sessions for issues 777, 775, 776 — I'll pause until all complete.").
+
+**Why:** Each child runs its own isolated SDLC pipeline. When all children reach a terminal state, `_finalize_parent_sync()` auto-transitions this session to `completed`. Do NOT handle multiple issues serially in a single session — context grows unboundedly and failures pollute each other.
+
+**Scope:** This applies only when multiple issues need active SDLC work. A message like "what's the status of issues 777 and 775?" does not trigger fan-out — answer directly.
+
+---
+
 ## Anomaly Response — Hibernate, Do Not Self-Heal
 
 When a child agent reports that the working tree is broken, `.git` is missing/corrupted,

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -78,6 +78,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [PM Channels](pm-channels.md) | Project manager mode routing Telegram groups to work-vault folders with SDLC bypass | Shipped |
 | [PM Routing: Collaboration](pm-routing-collaboration.md) | Four-way classification at bridge and intent levels (sdlc/collaboration/other/question) enabling PM to handle direct tasks without SDLC dev-session | Shipped |
 | [PM SDLC Decision Rules](pm-sdlc-decision-rules.md) | PM outcome parsing (success/partial/fail), auto-merge on clean gates, annotate-rather-than-skip for review findings | Shipped |
+| [PM Session Child Fan-out](pm-session-child-fanout.md) | Parent PM session detects multi-issue SDLC requests, spawns one child PM session per issue, pauses itself via `wait-for-children` subcommand, and auto-completes when all children finish | Shipped |
 | [PM session Teammate Mode](pm-teammate-mode.md) | Haiku-based intent classifier routing informational queries to direct PM session response without Dev session spawn | Shipped |
 | [PM Telegram Tool](pm-telegram-tool.md) | PM session composes and sends its own Telegram messages (text, file attachments, and multi-file albums) via Redis IPC, with summarizer as fallback | Shipped |
 | [PM Voice Refinement](pm-voice-refinement.md) | Naturalized SDLC language, crash message pool, sentence-aware truncation, milestone-selective emoji for PM output | Shipped |

--- a/docs/features/pm-dev-session-architecture.md
+++ b/docs/features/pm-dev-session-architecture.md
@@ -4,7 +4,7 @@
 
 The AgentSession model uses a **session_type discriminator** (`SessionType` enum from `config/enums.py`) to distinguish between three session roles:
 
-- **PM Session** (`session_type=SessionType.PM`): Read-only Agent SDK session with PM persona. Owns the Telegram conversation, orchestrates work, and spawns Dev sessions.
+- **PM Session** (`session_type=SessionType.PM`): Read-only Agent SDK session with PM persona. Owns the Telegram conversation, orchestrates work, and spawns Dev sessions. For multi-issue requests, a parent PM session can also spawn child PM sessions (see [PM Session Child Fan-out](pm-session-child-fanout.md)).
 - **Teammate Session** (`session_type=SessionType.TEAMMATE`): Conversational Agent SDK session with Teammate persona. Handles informational queries directly without spawning Dev sessions.
 - **Dev session** (`session_type=SessionType.DEV`): Full-permission Agent SDK session with Dev persona. Executes a single assigned SDLC stage and reports the result back to the PM.
 

--- a/docs/features/pm-session-child-fanout.md
+++ b/docs/features/pm-session-child-fanout.md
@@ -1,0 +1,102 @@
+# PM Session Child Fan-out
+
+## Overview
+
+When a PM session receives a message containing multiple GitHub issue numbers (e.g., "Run SDLC on issues 777, 775, 776"), it fans out: instead of handling all issues in a single session with growing context, it spawns one child PM session per issue and pauses itself until all children complete.
+
+## Trigger Conditions
+
+Fan-out activates when:
+- The PM session's message text contains **more than one GitHub issue number** requiring SDLC work.
+- Examples: "Run SDLC on issues 777, 775, 776", "Process #777 and #775", "777, 775, 776".
+
+Fan-out does **not** activate for status queries (e.g., "what's the status of 777 and 775?") — the PM answers those directly.
+
+## Data Flow
+
+1. **Parent PM session** receives the multi-issue message.
+2. **Fan-out**: PM runs one `valor_session create --role pm` call per issue:
+   ```bash
+   python -m tools.valor_session create \
+     --role pm \
+     --parent "$AGENT_SESSION_ID" \
+     --message "Run SDLC on issue 777"
+   ```
+3. **Pause**: After spawning all children, PM calls:
+   ```bash
+   python -m tools.valor_session wait-for-children --session-id "$AGENT_SESSION_ID"
+   ```
+   This transitions the parent to `waiting_for_children`.
+4. **Telegram update**: PM sends a visibility message before pausing (e.g., "Spawning 3 child sessions for issues 777, 775, 776 — I'll pause until all complete.").
+5. **Child execution**: The worker picks up each child PM session via project-keyed serialization (one at a time). Each child runs its own isolated SDLC pipeline.
+6. **Auto-completion**: When each child reaches a terminal state, `_finalize_parent_sync()` in `models/session_lifecycle.py` fires. When all children are terminal, the parent auto-transitions to `completed`.
+
+## Key Components
+
+### `tools/valor_session.py` — `wait-for-children` Subcommand
+
+New subcommand added to the `valor-session` CLI:
+
+```
+python -m tools.valor_session wait-for-children [--session-id SESSION_ID]
+```
+
+- `--session-id`: The AgentSession model ID to transition. Defaults to `$AGENT_SESSION_ID` env var.
+- Exits 0 on success; exits 1 if session not found, session ID not provided, or session is already in a terminal status.
+- Calls `transition_status(session, "waiting_for_children")` from `models.session_lifecycle`.
+
+### `agent/sdk_client.py` — PM Dispatch Fan-out Block
+
+The PM dispatch enrichment block in `load_pm_system_prompt()` prepends a `MULTI-ISSUE FAN-OUT` paragraph:
+
+> "If the message contains more than one GitHub issue number, you MUST fan out. For each issue number N, create a child PM session... After spawning ALL children, call wait-for-children..."
+
+### `config/personas/project-manager.md` — Multi-Issue Fan-out Section
+
+The in-repo PM persona overlay includes a `## Multi-Issue Fan-out` section with the same instructions, serving as the authoritative template and documentation for operators.
+
+### `models/session_lifecycle.py` — `_finalize_parent_sync()`
+
+Unchanged by this feature. When each child session reaches a terminal state, `_finalize_parent_sync()` at line 518 checks whether all children are terminal and transitions the parent accordingly. The parent's `waiting_for_children` status is the signal that finalization should propagate.
+
+## Sequential Execution
+
+Children run one at a time via existing project-keyed serialization (introduced in PR #831). No additional scheduling logic is needed — the queue naturally serializes children with the same `project_key` as the parent.
+
+## Race Condition Safety
+
+If a child completes before the parent finishes calling `wait-for-children`, `_finalize_parent_sync()` at lines 571-573 handles this: if the parent isn't in `waiting_for_children` yet when a child finalizes, it sets the parent to `waiting_for_children` itself, then checks all children's statuses. No race here because `enqueue_agent_session()` is synchronous — all children are registered in Redis before `wait-for-children` is called.
+
+## Error Handling
+
+- If `valor_session create` fails mid-fan-out, the parent is not yet in `waiting_for_children`. The worker's existing health-check loop handles the stuck-active parent session.
+- If the parent is already in a terminal status when `wait-for-children` is called, the subcommand exits 1 without attempting a transition.
+- `_finalize_parent_sync()` has try/except logging at lines 540-548; no new exception paths are introduced.
+
+## Session Management
+
+```bash
+# Check the parent and its children
+python -m tools.valor_session list --status waiting_for_children
+python -m tools.valor_session status --id <parent-id>
+
+# Manually transition a PM session to waiting_for_children
+python -m tools.valor_session wait-for-children --session-id <id>
+
+# Kill all children (they're just PM sessions)
+python -m tools.valor_session kill --all
+```
+
+## Testing
+
+Unit tests in:
+- `tests/unit/test_agent_session_hierarchy.py` — `TestCmdWaitForChildren`: transitions status, missing session, no session ID, reads env var, terminal status guard.
+- `tests/unit/test_pm_session_factory.py` — `TestPMPersonaFanoutInstruction`: fan-out text present in `sdk_client.py`, `project-manager.md` has the section, references `wait-for-children` and `--role pm`.
+
+## Related Features
+
+- [Session Lifecycle](session-lifecycle.md) — `transition_status()`, `_finalize_parent_sync()`, `waiting_for_children` status
+- [PM/Dev Session Architecture](pm-dev-session-architecture.md) — PM session spawning pattern
+- [Session Isolation](session-isolation.md) — Project-keyed serialization (sequential child execution)
+- [Session Steering](session-steering.md) — `valor-session` CLI, steering inbox
+- [Bridge/Worker Architecture](bridge-worker-architecture.md) — Worker picks up child sessions from queue

--- a/tests/unit/test_agent_session_hierarchy.py
+++ b/tests/unit/test_agent_session_hierarchy.py
@@ -437,3 +437,150 @@ class TestValorAgentSessionIdInjection:
         agent = ValorAgent(working_dir="/tmp/test")
         options = agent._create_options(session_id="test-session")
         assert "AGENT_SESSION_ID" not in options.env
+
+
+# ===================================================================
+# cmd_wait_for_children tests (tools/valor_session.py)
+# ===================================================================
+
+
+import argparse
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+_repo_root = Path(__file__).parent.parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from tools.valor_session import cmd_wait_for_children  # noqa: E402
+
+TERMINAL_STATUSES = frozenset({"completed", "failed", "killed", "abandoned", "cancelled"})
+
+
+def _wfc_args(session_id=None):
+    return argparse.Namespace(session_id=session_id)
+
+
+def _make_mock_session(session_id="sess-1", status="running"):
+    s = MagicMock()
+    s.session_id = session_id
+    s.status = status
+    return s
+
+
+class TestCmdWaitForChildren:
+    """Tests for cmd_wait_for_children in tools/valor_session.py."""
+
+    def test_transitions_status_to_waiting_for_children(self, capsys):
+        """wait-for-children calls transition_status with 'waiting_for_children'."""
+        session = _make_mock_session("sess-pm", "running")
+        mock_cls = MagicMock()
+        mock_cls.query.filter.return_value = [session]
+        mock_transition = MagicMock()
+
+        with (
+            patch("tools.valor_session._load_env"),
+            patch.dict(
+                "sys.modules",
+                {
+                    "models.agent_session": MagicMock(AgentSession=mock_cls),
+                    "models.session_lifecycle": MagicMock(
+                        TERMINAL_STATUSES=TERMINAL_STATUSES,
+                        transition_status=mock_transition,
+                    ),
+                },
+            ),
+        ):
+            result = cmd_wait_for_children(_wfc_args(session_id="sess-pm"))
+
+        assert result == 0
+        mock_transition.assert_called_once_with(session, "waiting_for_children")
+
+    def test_missing_session_exits_1(self, capsys):
+        """wait-for-children with unknown session ID returns 1."""
+        mock_cls = MagicMock()
+        mock_cls.query.filter.return_value = []
+
+        with (
+            patch("tools.valor_session._load_env"),
+            patch.dict(
+                "sys.modules",
+                {
+                    "models.agent_session": MagicMock(AgentSession=mock_cls),
+                    "models.session_lifecycle": MagicMock(
+                        TERMINAL_STATUSES=TERMINAL_STATUSES,
+                        transition_status=MagicMock(),
+                    ),
+                },
+            ),
+        ):
+            result = cmd_wait_for_children(_wfc_args(session_id="nonexistent"))
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "not found" in captured.err.lower() or "error" in captured.err.lower()
+
+    def test_no_session_id_no_env_exits_1(self, capsys, monkeypatch):
+        """wait-for-children with no --session-id and no AGENT_SESSION_ID env var exits 1."""
+        monkeypatch.delenv("AGENT_SESSION_ID", raising=False)
+
+        with patch("tools.valor_session._load_env"):
+            result = cmd_wait_for_children(_wfc_args(session_id=None))
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "no session id" in captured.err.lower() or "error" in captured.err.lower()
+
+    def test_uses_env_var_when_no_session_id_arg(self, capsys, monkeypatch):
+        """wait-for-children reads AGENT_SESSION_ID env var when --session-id is omitted."""
+        monkeypatch.setenv("AGENT_SESSION_ID", "env-sess-123")
+        session = _make_mock_session("env-sess-123", "running")
+        mock_cls = MagicMock()
+        mock_cls.query.filter.return_value = [session]
+        mock_transition = MagicMock()
+
+        with (
+            patch("tools.valor_session._load_env"),
+            patch.dict(
+                "sys.modules",
+                {
+                    "models.agent_session": MagicMock(AgentSession=mock_cls),
+                    "models.session_lifecycle": MagicMock(
+                        TERMINAL_STATUSES=TERMINAL_STATUSES,
+                        transition_status=mock_transition,
+                    ),
+                },
+            ),
+        ):
+            result = cmd_wait_for_children(_wfc_args(session_id=None))
+
+        assert result == 0
+        mock_transition.assert_called_once_with(session, "waiting_for_children")
+
+    def test_already_terminal_exits_1(self, capsys):
+        """wait-for-children on a terminal session returns 1 without calling transition_status."""
+        session = _make_mock_session("sess-done", "completed")
+        mock_cls = MagicMock()
+        mock_cls.query.filter.return_value = [session]
+        mock_transition = MagicMock()
+
+        with (
+            patch("tools.valor_session._load_env"),
+            patch.dict(
+                "sys.modules",
+                {
+                    "models.agent_session": MagicMock(AgentSession=mock_cls),
+                    "models.session_lifecycle": MagicMock(
+                        TERMINAL_STATUSES=TERMINAL_STATUSES,
+                        transition_status=mock_transition,
+                    ),
+                },
+            ),
+        ):
+            result = cmd_wait_for_children(_wfc_args(session_id="sess-done"))
+
+        assert result == 1
+        mock_transition.assert_not_called()
+        captured = capsys.readouterr()
+        assert "terminal" in captured.err.lower() or "error" in captured.err.lower()

--- a/tests/unit/test_agent_session_hierarchy.py
+++ b/tests/unit/test_agent_session_hierarchy.py
@@ -9,10 +9,21 @@ Tests cover:
 - agent_session_scheduler --parent-session flag and children subcommand
 """
 
+import argparse
+import sys
 import time
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+_repo_root = Path(__file__).parent.parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from tools.valor_session import cmd_wait_for_children  # noqa: E402
+
+TERMINAL_STATUSES = frozenset({"completed", "failed", "killed", "abandoned", "cancelled"})
 
 # ===================================================================
 # AgentSession hierarchy helpers (unit, no Redis)
@@ -442,20 +453,6 @@ class TestValorAgentSessionIdInjection:
 # ===================================================================
 # cmd_wait_for_children tests (tools/valor_session.py)
 # ===================================================================
-
-
-import argparse
-import sys
-from pathlib import Path
-from unittest.mock import MagicMock, call, patch
-
-_repo_root = Path(__file__).parent.parent.parent
-if str(_repo_root) not in sys.path:
-    sys.path.insert(0, str(_repo_root))
-
-from tools.valor_session import cmd_wait_for_children  # noqa: E402
-
-TERMINAL_STATUSES = frozenset({"completed", "failed", "killed", "abandoned", "cancelled"})
 
 
 def _wfc_args(session_id=None):

--- a/tests/unit/test_pm_session_factory.py
+++ b/tests/unit/test_pm_session_factory.py
@@ -158,5 +158,6 @@ class TestPMPersonaFanoutInstruction:
         sdk_path = Path(__file__).parent.parent.parent / "agent" / "sdk_client.py"
         source = sdk_path.read_text()
         assert "--role pm" in source, (
-            "sdk_client.py fan-out instruction must include '--role pm' to create child PM sessions."
+            "sdk_client.py fan-out instruction must include '--role pm' "
+            "to create child PM sessions."
         )

--- a/tests/unit/test_pm_session_factory.py
+++ b/tests/unit/test_pm_session_factory.py
@@ -119,3 +119,44 @@ class TestBridgeNoClassifyWorkRequest:
             "Bridge handler should not reference simple session type. "
             "All messages route to PM, Teammate, or Dev sessions."
         )
+
+
+class TestPMPersonaFanoutInstruction:
+    """Verify fan-out instruction is present in PM persona enriched prompt."""
+
+    def test_pm_persona_sdk_client_contains_fanout_instruction(self):
+        """sdk_client.py PM dispatch block must contain MULTI-ISSUE FAN-OUT text."""
+        sdk_path = Path(__file__).parent.parent.parent / "agent" / "sdk_client.py"
+        source = sdk_path.read_text()
+        assert "MULTI-ISSUE FAN-OUT" in source, (
+            "sdk_client.py PM dispatch block must contain 'MULTI-ISSUE FAN-OUT' instruction. "
+            "This triggers child PM session spawning for multi-issue requests."
+        )
+
+    def test_pm_persona_overlay_contains_fanout_section(self):
+        """config/personas/project-manager.md must contain Multi-Issue Fan-out section."""
+        persona_path = (
+            Path(__file__).parent.parent.parent / "config" / "personas" / "project-manager.md"
+        )
+        source = persona_path.read_text()
+        assert "Multi-Issue Fan-out" in source, (
+            "config/personas/project-manager.md must include a 'Multi-Issue Fan-out' section "
+            "describing when and how to spawn child PM sessions."
+        )
+
+    def test_sdk_client_fanout_references_wait_for_children(self):
+        """sdk_client.py fan-out instruction must reference the wait-for-children subcommand."""
+        sdk_path = Path(__file__).parent.parent.parent / "agent" / "sdk_client.py"
+        source = sdk_path.read_text()
+        assert "wait-for-children" in source, (
+            "sdk_client.py fan-out instruction must reference "
+            "'wait-for-children' subcommand so the PM knows how to pause."
+        )
+
+    def test_sdk_client_fanout_references_child_pm_role(self):
+        """sdk_client.py fan-out instruction must reference --role pm for child sessions."""
+        sdk_path = Path(__file__).parent.parent.parent / "agent" / "sdk_client.py"
+        source = sdk_path.read_text()
+        assert "--role pm" in source, (
+            "sdk_client.py fan-out instruction must include '--role pm' to create child PM sessions."
+        )

--- a/tools/valor_session.py
+++ b/tools/valor_session.py
@@ -464,6 +464,51 @@ def cmd_kill(args: argparse.Namespace) -> int:
         return 1
 
 
+def cmd_wait_for_children(args: argparse.Namespace) -> int:
+    """Transition the calling session to waiting_for_children status.
+
+    Used by PM sessions after spawning child PM sessions via fan-out.
+    The parent session will auto-transition to completed when all children
+    finish via _finalize_parent_sync() in models.session_lifecycle.
+    """
+    _load_env()
+    try:
+        import os
+
+        from models.agent_session import AgentSession
+        from models.session_lifecycle import TERMINAL_STATUSES, transition_status
+
+        session_id = getattr(args, "session_id", None) or os.environ.get("AGENT_SESSION_ID")
+        if not session_id:
+            print(
+                "Error: No session ID provided. Use --session-id or set $AGENT_SESSION_ID.",
+                file=sys.stderr,
+            )
+            return 1
+
+        sessions = list(AgentSession.query.filter(session_id=session_id))
+        if not sessions:
+            print(f"Error: Session not found: {session_id}", file=sys.stderr)
+            return 1
+
+        session = sessions[0]
+        current_status = getattr(session, "status", None)
+        if current_status in TERMINAL_STATUSES:
+            print(
+                f"Error: Session {session_id} is already in terminal status {current_status!r}.",
+                file=sys.stderr,
+            )
+            return 1
+
+        transition_status(session, "waiting_for_children")
+        print(f"Session {session_id} transitioned to waiting_for_children.")
+        return 0
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+
 def main() -> int:
     """Main entry point."""
     parser = argparse.ArgumentParser(
@@ -531,6 +576,17 @@ def main() -> int:
     kill_parser.add_argument("--all", action="store_true", help="Kill all running sessions")
     kill_parser.add_argument("--json", action="store_true", help="Output JSON")
 
+    # wait-for-children subcommand
+    wfc_parser = subparsers.add_parser(
+        "wait-for-children",
+        help="Transition session to waiting_for_children (called by PM after fan-out)",
+    )
+    wfc_parser.add_argument(
+        "--session-id",
+        dest="session_id",
+        help="Session ID to transition (defaults to $AGENT_SESSION_ID env var)",
+    )
+
     args = parser.parse_args()
 
     if not args.command:
@@ -543,6 +599,7 @@ def main() -> int:
         "status": cmd_status,
         "list": cmd_list,
         "kill": cmd_kill,
+        "wait-for-children": cmd_wait_for_children,
     }
 
     return dispatch[args.command](args)


### PR DESCRIPTION
## Summary

- Adds `wait-for-children` subcommand to `tools/valor_session.py` — transitions a PM session to `waiting_for_children` status after spawning child PM sessions
- Adds `MULTI-ISSUE FAN-OUT` instruction block to the PM persona in `agent/sdk_client.py` and `config/personas/project-manager.md` — when the PM receives multiple issue numbers, it spawns one child PM session per issue then pauses itself
- Unit tests (9 new) covering `wait-for-children` edge cases and PM persona instruction presence
- Feature doc at `docs/features/pm-session-child-fanout.md`

## Changes

- `tools/valor_session.py` — `cmd_wait_for_children()` function + `wait-for-children` argparse subcommand
- `agent/sdk_client.py` — MULTI-ISSUE FAN-OUT block prepended to PM dispatch enrichment
- `config/personas/project-manager.md` — `## Multi-Issue Fan-out` section added
- `tests/unit/test_agent_session_hierarchy.py` — `TestCmdWaitForChildren` (5 tests)
- `tests/unit/test_pm_session_factory.py` — `TestPMPersonaFanoutInstruction` (4 tests)
- `docs/features/pm-session-child-fanout.md` — new feature doc
- `docs/features/README.md` — index entry
- `docs/features/pm-dev-session-architecture.md` — note that PM sessions can spawn child PM sessions

## Testing

- [x] Unit tests passing: 45 tests in test_agent_session_hierarchy.py + test_pm_session_factory.py
- [x] Ruff clean (all checks passed)
- [x] Format clean (535 files already formatted)
- [x] `python -m tools.valor_session wait-for-children --help` exits 0
- [x] `grep "MULTI-ISSUE FAN-OUT" agent/sdk_client.py` matches
- [x] `docs/features/pm-session-child-fanout.md` exists

## Documentation

- [x] `docs/features/pm-session-child-fanout.md` created
- [x] `docs/features/README.md` updated with index entry
- [x] `docs/features/pm-dev-session-architecture.md` updated to note PM→PM child spawning
- [x] Documentation validation gate passed (3 docs changed)

## Definition of Done

- [x] Built: Code implemented and working
- [x] Tested: All new tests passing, no regressions introduced
- [x] Documented: Feature doc and index updated
- [x] Quality: Ruff and format checks pass

Closes #786