### PR TITLE
feat: email bridge — IMAP/SMTP secondary transport (issue #847)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -164,6 +164,30 @@ OLLAMA_URL=http://localhost:11434
 OLLAMA_VISION_MODEL=llama3.2-vision:11b
 
 # =============================================================================
+# Email Bridge (IMAP/SMTP)
+# =============================================================================
+
+# Gmail App Password setup: Google Account → Security → 2-Step Verification → App Passwords
+# Create an App Password for "Mail" and use it here (not your regular password).
+# Gmail IMAP: imap.gmail.com:993 (SSL), Gmail SMTP: smtp.gmail.com:587 (STARTTLS)
+
+IMAP_HOST=imap.gmail.com
+IMAP_PORT=993
+IMAP_USER=valor@yuda.me
+IMAP_PASSWORD=your-gmail-app-password-here
+# Set to "false" to disable SSL (not recommended)
+IMAP_SSL=true
+# Seconds between IMAP polls (default: 30)
+IMAP_POLL_INTERVAL=30
+
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=valor@yuda.me
+SMTP_PASSWORD=your-gmail-app-password-here
+# Set to "false" to disable STARTTLS (not recommended)
+SMTP_USE_TLS=true
+
+# =============================================================================
 # Feature Flags
 # =============================================================================
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,12 @@ valor-telegram send --chat "Tom" --file ./screenshot.png "Caption"
 | `./scripts/valor-service.sh worker-start` | Start standalone worker service |
 | `./scripts/valor-service.sh worker-restart` | Restart standalone worker |
 | `./scripts/valor-service.sh worker-status` | Check worker service status |
+| `./scripts/valor-service.sh email-start` | Start the email bridge (IMAP polling) |
+| `./scripts/valor-service.sh email-stop` | Stop the email bridge |
+| `./scripts/valor-service.sh email-restart` | Restart the email bridge |
+| `./scripts/valor-service.sh email-status` | Check email bridge status and last poll age |
+| `./scripts/valor-service.sh email-dead-letter list` | List failed SMTP sends in dead-letter queue |
+| `./scripts/valor-service.sh email-dead-letter replay --all` | Replay all dead-lettered emails |
 | `tail -f logs/bridge.log` | Stream bridge logs |
 | `pytest tests/` | Run all tests |
 | `pytest tests/unit/` | Run unit tests only (fast, ~60s) |

--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -176,6 +176,7 @@ async def _push_agent_session(
     scheduling_depth: int = 0,  # ignored, now derived
     depends_on: list[str] | None = None,  # ignored, removed
     project_config: dict | None = None,
+    extra_context_overrides: dict | None = None,
     **_kwargs,
 ) -> int:
     """Create an agent session in Redis and return the pending queue depth for this chat.
@@ -186,6 +187,11 @@ async def _push_agent_session(
     Bug 3 fix (issue #374): When creating a new record for a continuation
     (reply-to-resume), mark old completed records with the same session_id
     as 'superseded' to prevent ambiguity in later record selection.
+
+    Args:
+        extra_context_overrides: Additional key/value pairs merged into extra_context
+            before saving. Use for transport-specific metadata (e.g., transport="email",
+            email_message_id=...). Keys in overrides take precedence over derived values.
     """
     # Convert float timestamps to datetime (backward compat)
     if isinstance(scheduled_at, int | float):
@@ -207,6 +213,8 @@ async def _push_agent_session(
         extra_context["revival_context"] = revival_context
     if classification_type:
         extra_context["classification_type"] = classification_type
+    if extra_context_overrides:
+        extra_context.update(extra_context_overrides)
 
     # Mark old completed records as superseded to prevent duplicate-record ambiguity
     try:
@@ -1806,9 +1814,9 @@ SendCallback = Callable[[str, str, int, Any], Awaitable[None]]  # (chat_id, text
 ReactionCallback = Callable[[str, int, str | None], Awaitable[None]]
 ResponseCallback = Callable[[object, str, str, int], Awaitable[None]]
 
-_send_callbacks: dict[str, SendCallback] = {}
-_reaction_callbacks: dict[str, ReactionCallback] = {}
-_response_callbacks: dict[str, ResponseCallback] = {}
+_send_callbacks: dict[str | tuple[str, str], SendCallback] = {}
+_reaction_callbacks: dict[str | tuple[str, str], ReactionCallback] = {}
+_response_callbacks: dict[str | tuple[str, str], ResponseCallback] = {}
 
 
 def register_callbacks(
@@ -1817,6 +1825,7 @@ def register_callbacks(
     reaction_callback: ReactionCallback | None = None,
     response_callback: ResponseCallback | None = None,
     *,
+    transport: str | None = None,
     handler: OutputHandler | None = None,
 ) -> None:
     """
@@ -1831,30 +1840,38 @@ def register_callbacks(
         reaction_callback: Callable (chat_id, msg_id, emoji) -> sets a reaction.
         response_callback: Callable (event, text, chat_id, msg_id) ->
             sends response with file handling.
+        transport: Optional transport name (e.g. "email", "telegram"). When provided,
+                   callbacks are stored under a (project_key, transport) composite key,
+                   allowing multiple transports to coexist for the same project.
+                   When None (default), callbacks are stored under the plain project_key
+                   string key for backward compatibility.
         handler: An OutputHandler instance. If provided, its send() and react()
                  methods are wrapped as send_callback and reaction_callback.
     """
+    # Use composite key when transport is specified, else plain project_key
+    key: str | tuple[str, str] = (project_key, transport) if transport else project_key
+
     if handler is not None:
         # Wrap OutputHandler methods as raw callbacks for internal use
         if send_callback is None:
-            _send_callbacks[project_key] = handler.send
+            _send_callbacks[key] = handler.send
         else:
-            _send_callbacks[project_key] = send_callback
+            _send_callbacks[key] = send_callback
 
         if reaction_callback is None:
-            _reaction_callbacks[project_key] = handler.react
+            _reaction_callbacks[key] = handler.react
         else:
-            _reaction_callbacks[project_key] = reaction_callback
+            _reaction_callbacks[key] = reaction_callback
     else:
         if send_callback is None:
             raise ValueError("Either send_callback or handler must be provided")
         if reaction_callback is None:
             raise ValueError("Either reaction_callback or handler must be provided")
-        _send_callbacks[project_key] = send_callback
-        _reaction_callbacks[project_key] = reaction_callback
+        _send_callbacks[key] = send_callback
+        _reaction_callbacks[key] = reaction_callback
 
     if response_callback:
-        _response_callbacks[project_key] = response_callback
+        _response_callbacks[key] = response_callback
 
 
 # === Restart Flag (written by remote-update.sh) ===
@@ -1898,6 +1915,27 @@ def clear_restart_flag() -> bool:
     return False
 
 
+def _resolve_callbacks(
+    project_key: str,
+    transport: str | None,
+) -> tuple[SendCallback | None, ReactionCallback | None]:
+    """Resolve send and reaction callbacks for a project+transport combination.
+
+    Lookup order:
+    1. (project_key, transport) composite key — transport-specific handler
+    2. project_key string key — transport-agnostic handler (backward compat)
+    3. None — falls through to FileOutputHandler in caller
+    """
+    if transport:
+        composite_key = (project_key, transport)
+        send_cb = _send_callbacks.get(composite_key) or _send_callbacks.get(project_key)
+        react_cb = _reaction_callbacks.get(composite_key) or _reaction_callbacks.get(project_key)
+    else:
+        send_cb = _send_callbacks.get(project_key)
+        react_cb = _reaction_callbacks.get(project_key)
+    return send_cb, react_cb
+
+
 async def enqueue_agent_session(
     project_key: str,
     session_id: str,
@@ -1921,6 +1959,7 @@ async def enqueue_agent_session(
     session_type: str = SessionType.PM,
     scheduling_depth: int = 0,  # ignored, now derived
     project_config: dict | None = None,
+    extra_context_overrides: dict | None = None,
 ) -> int:
     """
     Add a session to Redis and ensure worker is running.
@@ -1930,6 +1969,8 @@ async def enqueue_agent_session(
             AgentSession so downstream code can read project properties without
             re-deriving from a parallel registry. Pass None for backward compat
             (legacy callers); the worker will fall back to loading from projects.json.
+        extra_context_overrides: Additional key/value pairs merged into extra_context.
+            Use for transport-specific metadata, e.g. transport="email".
 
     Returns queue depth after push.
     """
@@ -1961,6 +2002,7 @@ async def enqueue_agent_session(
         telegram_message_key=telegram_message_key,
         session_type=session_type,
         project_config=project_config,
+        extra_context_overrides=extra_context_overrides,
     )
     # Compute worker_key from the same inputs the property uses, without re-querying Redis
     if session_type == SessionType.TEAMMATE:
@@ -2953,8 +2995,13 @@ async def _execute_agent_session(session: AgentSession) -> None:
     asyncio.create_task(_calendar_heartbeat(session.project_key, project=session.project_key))
 
     # Create messenger with bridge callbacks, falling back to file output
-    send_cb = _send_callbacks.get(session.project_key)
-    react_cb = _reaction_callbacks.get(session.project_key)
+    # Find the transport from extra_context to support multiple transports per project
+    _transport = None
+    if agent_session:
+        _extra = getattr(agent_session, "extra_context", None) or {}
+        _transport = _extra.get("transport")
+
+    send_cb, react_cb = _resolve_callbacks(session.project_key, _transport)
 
     if not send_cb:
         from agent.output_handler import FileOutputHandler

--- a/bridge/email_bridge.py
+++ b/bridge/email_bridge.py
@@ -1,0 +1,619 @@
+"""Email bridge: IMAP inbox polling and SMTP output handler.
+
+Implements the secondary transport for inbound/outbound email alongside the
+Telegram bridge. Architecture mirrors bridge/telegram_bridge.py + telegram_relay.py:
+
+    IMAP poll loop → _process_inbound_email() → enqueue_agent_session()
+    EmailOutputHandler.send() → SMTP reply with In-Reply-To header
+
+Session IDs use the ``email_`` prefix to distinguish them from Telegram sessions.
+Transport is stored in AgentSession.extra_context["transport"] = "email".
+The sentinel ``telegram_message_id=0`` is used for all email sessions (email has
+no Telegram message ID).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import email as email_lib
+import email.header
+import email.mime.text
+import email.utils
+import imaplib
+import logging
+import os
+import smtplib
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# =============================================================================
+# Config helpers
+# =============================================================================
+
+# Timeout between IMAP polls (seconds)
+IMAP_POLL_INTERVAL = int(os.environ.get("IMAP_POLL_INTERVAL", "30"))
+
+# Max retries for SMTP sends before dead-lettering
+SMTP_MAX_RETRIES = 3
+
+# Redis key for health monitoring
+REDIS_LAST_POLL_KEY = "email:last_poll_ts"
+
+# TTL for email:msgid reverse-mapping keys (48 hours)
+EMAIL_MSGID_TTL = 48 * 3600
+
+
+def _get_imap_config() -> dict | None:
+    """Return IMAP connection config from environment, or None if not configured."""
+    host = os.environ.get("IMAP_HOST")
+    user = os.environ.get("IMAP_USER")
+    password = os.environ.get("IMAP_PASSWORD")
+    if not (host and user and password):
+        return None
+    return {
+        "host": host,
+        "user": user,
+        "password": password,
+        "port": int(os.environ.get("IMAP_PORT", "993")),
+        "ssl": os.environ.get("IMAP_SSL", "true").lower() != "false",
+    }
+
+
+def _get_smtp_config() -> dict | None:
+    """Return SMTP connection config from environment, or None if not configured."""
+    host = os.environ.get("SMTP_HOST")
+    user = os.environ.get("SMTP_USER")
+    password = os.environ.get("SMTP_PASSWORD")
+    if not (host and user and password):
+        return None
+    return {
+        "host": host,
+        "user": user,
+        "password": password,
+        "port": int(os.environ.get("SMTP_PORT", "587")),
+        "use_tls": os.environ.get("SMTP_USE_TLS", "true").lower() != "false",
+    }
+
+
+def _get_redis():
+    """Return a Redis connection (lazy, cached module-level)."""
+    import redis
+
+    redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+    return redis.Redis.from_url(redis_url, decode_responses=True)
+
+
+# =============================================================================
+# Email parsing helpers
+# =============================================================================
+
+
+def _decode_header_value(value: str | None) -> str:
+    """Decode an RFC-2047 encoded email header value to plain text."""
+    if not value:
+        return ""
+    parts = email.header.decode_header(value)
+    decoded_parts = []
+    for part, charset in parts:
+        if isinstance(part, bytes):
+            try:
+                decoded_parts.append(part.decode(charset or "utf-8", errors="replace"))
+            except Exception:
+                decoded_parts.append(part.decode("utf-8", errors="replace"))
+        else:
+            decoded_parts.append(part)
+    return "".join(decoded_parts).strip()
+
+
+def _extract_address(raw: str | None) -> str:
+    """Extract the plain email address from a From/Reply-To header value."""
+    if not raw:
+        return ""
+    _, addr = email.utils.parseaddr(raw)
+    return addr.lower().strip()
+
+
+def _extract_body(msg: email_lib.message.Message) -> str:
+    """Extract plain text body from an email message.
+
+    Prefers text/plain parts. Falls back to stripping HTML if no plain text.
+    Returns empty string if no usable body is found.
+    """
+    if msg.is_multipart():
+        for part in msg.walk():
+            ctype = part.get_content_type()
+            disposition = str(part.get("Content-Disposition", ""))
+            if ctype == "text/plain" and "attachment" not in disposition:
+                payload = part.get_payload(decode=True)
+                if payload:
+                    charset = part.get_content_charset() or "utf-8"
+                    return payload.decode(charset, errors="replace").strip()
+        # No plain text — try HTML fallback (strip tags)
+        for part in msg.walk():
+            if part.get_content_type() == "text/html":
+                payload = part.get_payload(decode=True)
+                if payload:
+                    charset = part.get_content_charset() or "utf-8"
+                    html = payload.decode(charset, errors="replace")
+                    import re
+
+                    text = re.sub(r"<[^>]+>", " ", html)
+                    text = re.sub(r"\s+", " ", text).strip()
+                    return text
+        return ""
+    else:
+        payload = msg.get_payload(decode=True)
+        if payload:
+            charset = msg.get_content_charset() or "utf-8"
+            return payload.decode(charset, errors="replace").strip()
+        return ""
+
+
+def parse_email_message(raw_bytes: bytes) -> dict | None:
+    """Parse raw email bytes into a structured dict.
+
+    Returns a dict with keys: from_addr, subject, body, message_id, in_reply_to.
+    Returns None if the email cannot be parsed or has no usable body.
+    """
+    try:
+        msg = email_lib.message_from_bytes(raw_bytes)
+    except Exception as e:
+        logger.warning(f"Failed to parse email bytes: {e}")
+        return None
+
+    from_raw = msg.get("From", "")
+    from_addr = _extract_address(from_raw)
+    if not from_addr:
+        logger.warning("Email has no From address, skipping")
+        return None
+
+    subject = _decode_header_value(msg.get("Subject", ""))
+    body = _extract_body(msg)
+
+    if not body or not body.strip():
+        logger.debug(f"Email from {from_addr} has empty body, skipping")
+        return None
+
+    message_id = msg.get("Message-ID", "").strip()
+    in_reply_to = msg.get("In-Reply-To", "").strip()
+
+    return {
+        "from_addr": from_addr,
+        "from_raw": from_raw,
+        "subject": subject,
+        "body": body.strip(),
+        "message_id": message_id,
+        "in_reply_to": in_reply_to,
+    }
+
+
+# =============================================================================
+# EmailOutputHandler
+# =============================================================================
+
+
+class EmailOutputHandler:
+    """Route agent session output to the email sender via SMTP.
+
+    Implements the OutputHandler protocol. The send() method composes an SMTP
+    reply with In-Reply-To and References headers so the reply threads correctly
+    in the recipient's email client.
+
+    react() is a no-op — email has no concept of emoji reactions.
+
+    Failed sends are retried up to SMTP_MAX_RETRIES times with exponential backoff.
+    Persistent failures are written to the dead letter queue in Redis under
+    email:dead_letter:{session_id}.
+    """
+
+    def __init__(
+        self,
+        smtp_config: dict | None = None,
+        redis_url: str | None = None,
+    ):
+        self._smtp_config = smtp_config or _get_smtp_config()
+        self._redis_url = redis_url or os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+        self._redis = None
+
+    def _get_redis(self):
+        if self._redis is None:
+            import redis
+
+            self._redis = redis.Redis.from_url(self._redis_url, decode_responses=True)
+        return self._redis
+
+    def _build_reply(
+        self,
+        to_addr: str,
+        subject: str,
+        body: str,
+        in_reply_to: str | None,
+        references: str | None,
+        from_addr: str,
+    ) -> email.mime.text.MIMEText:
+        """Compose an SMTP reply message."""
+        msg = email.mime.text.MIMEText(body, "plain", "utf-8")
+        msg["From"] = from_addr
+        msg["To"] = to_addr
+        if subject and not subject.lower().startswith("re:"):
+            msg["Subject"] = f"Re: {subject}"
+        else:
+            msg["Subject"] = subject or "Re: (no subject)"
+        if in_reply_to:
+            msg["In-Reply-To"] = in_reply_to
+        if references:
+            msg["References"] = references
+        msg["Date"] = email.utils.formatdate(localtime=True)
+        return msg
+
+    def _send_smtp(self, to_addr: str, mime_msg: email.mime.text.MIMEText) -> None:
+        """Send via SMTP (synchronous, run in thread executor)."""
+        cfg = self._smtp_config
+        if not cfg:
+            raise RuntimeError("SMTP not configured (missing SMTP_HOST/USER/PASSWORD)")
+
+        with smtplib.SMTP(cfg["host"], cfg["port"], timeout=30) as smtp:
+            if cfg.get("use_tls", True):
+                smtp.starttls()
+            smtp.login(cfg["user"], cfg["password"])
+            smtp.sendmail(cfg["user"], [to_addr], mime_msg.as_string())
+
+    async def send(
+        self,
+        chat_id: str,
+        text: str,
+        reply_to_msg_id: int,
+        session: Any = None,
+    ) -> None:
+        """Send agent output as an SMTP reply to the originating email.
+
+        Args:
+            chat_id: The sender's email address (used as the reply-to address).
+            text: Agent output text to send.
+            reply_to_msg_id: Ignored for email sessions (sentinel value 0).
+                             Threading is handled via In-Reply-To header from extra_context.
+            session: AgentSession providing extra_context with email_message_id and subject.
+        """
+        if not text:
+            return
+
+        extra = {}
+        session_id = None
+        if session is not None:
+            extra = getattr(session, "extra_context", None) or {}
+            session_id = getattr(session, "session_id", None)
+
+        original_message_id = extra.get("email_message_id", "")
+        original_subject = extra.get("email_subject", "")
+        from_addr = (
+            self._smtp_config["user"] if self._smtp_config else os.environ.get("SMTP_USER", "")
+        )
+
+        mime_msg = self._build_reply(
+            to_addr=chat_id,
+            subject=original_subject,
+            body=text,
+            in_reply_to=original_message_id or None,
+            references=original_message_id or None,
+            from_addr=from_addr,
+        )
+
+        # Retry with exponential backoff
+        last_error = None
+        for attempt in range(SMTP_MAX_RETRIES):
+            try:
+                await asyncio.to_thread(self._send_smtp, chat_id, mime_msg)
+                logger.info(
+                    f"[email] Sent reply to {chat_id} (session={session_id}, {len(text)} chars)"
+                )
+
+                # Store outbound Message-ID for future thread continuation
+                outbound_msg_id = mime_msg.get("Message-ID", "")
+                if outbound_msg_id and session_id:
+                    try:
+                        r = self._get_redis()
+                        key = f"email:msgid:{outbound_msg_id}"
+                        r.set(key, session_id, ex=EMAIL_MSGID_TTL)
+                    except Exception as redis_err:
+                        logger.warning(f"Failed to store outbound msgid mapping: {redis_err}")
+
+                return
+            except Exception as e:
+                last_error = e
+                backoff = 2**attempt
+                logger.warning(
+                    f"[email] SMTP send attempt {attempt + 1}/{SMTP_MAX_RETRIES} "
+                    f"failed for {chat_id}: {e}. Retrying in {backoff}s..."
+                )
+                await asyncio.sleep(backoff)
+
+        # All retries exhausted — write to dead letter queue
+        logger.error(
+            f"[email] SMTP send failed after {SMTP_MAX_RETRIES} attempts for {chat_id}: "
+            f"{last_error}. Writing to dead letter queue."
+        )
+        if session_id:
+            try:
+                from bridge.email_dead_letter import write_dead_letter
+
+                write_dead_letter(
+                    session_id=session_id,
+                    recipient=chat_id,
+                    subject=str(mime_msg.get("Subject", "")),
+                    body=text,
+                    headers={
+                        "In-Reply-To": str(mime_msg.get("In-Reply-To", "")),
+                        "References": str(mime_msg.get("References", "")),
+                    },
+                    error=str(last_error),
+                )
+            except Exception as dl_err:
+                logger.error(f"[email] Dead letter write also failed: {dl_err}")
+
+    async def react(
+        self,
+        chat_id: str,
+        msg_id: int,
+        emoji: str | None = None,
+    ) -> None:
+        """No-op — email has no emoji reaction concept."""
+        pass
+
+
+# =============================================================================
+# IMAP polling loop
+# =============================================================================
+
+
+async def _process_inbound_email(parsed: dict, config: dict) -> None:
+    """Process a single parsed inbound email.
+
+    Resolves the sender to a project, checks for thread continuation via
+    In-Reply-To header, and enqueues an AgentSession.
+
+    Args:
+        parsed: Dict from parse_email_message() with keys:
+                from_addr, subject, body, message_id, in_reply_to
+        config: The loaded projects.json config dict.
+    """
+    from agent.agent_session_queue import enqueue_agent_session
+    from bridge.routing import ACTIVE_PROJECTS, find_project_for_email
+
+    from_addr = parsed["from_addr"]
+    body = parsed["body"]
+    message_id = parsed["message_id"]
+    in_reply_to = parsed["in_reply_to"]
+    subject = parsed["subject"]
+
+    # Resolve sender to project
+    project = find_project_for_email(from_addr)
+    if project is None:
+        logger.info(f"[email] No project found for sender {from_addr}, discarding")
+        return
+
+    project_key = project.get("_key") or project.get("name", "unknown")
+    if project_key not in ACTIVE_PROJECTS:
+        logger.info(f"[email] Project '{project_key}' not in ACTIVE_PROJECTS, discarding")
+        return
+
+    working_dir = project.get("working_directory") or config.get("defaults", {}).get(
+        "working_directory", "~/src"
+    )
+
+    # Check for thread continuation via In-Reply-To
+    existing_session_id = None
+    if in_reply_to:
+        try:
+            r = _get_redis()
+            existing_session_id = r.get(f"email:msgid:{in_reply_to}")
+        except Exception as e:
+            logger.warning(f"[email] Redis lookup for In-Reply-To failed: {e}")
+
+    # Construct session_id
+    timestamp = int(time.time())
+    if existing_session_id:
+        session_id = existing_session_id
+        logger.info(
+            f"[email] Continuing session {session_id} "
+            f"from {from_addr} via In-Reply-To={in_reply_to}"
+        )
+    else:
+        safe_addr = from_addr.replace("@", "_at_").replace(".", "_")
+        session_id = f"email_{project_key}_{safe_addr}_{timestamp}"
+        logger.info(f"[email] New session {session_id} from {from_addr}")
+
+    # Store inbound Message-ID → session_id for future thread continuation
+    if message_id and session_id:
+        try:
+            r = _get_redis()
+            r.set(f"email:msgid:{message_id}", session_id, ex=EMAIL_MSGID_TTL)
+        except Exception as e:
+            logger.warning(f"[email] Failed to store inbound msgid mapping: {e}")
+
+    # Enqueue the session with email transport metadata
+    try:
+        await enqueue_agent_session(
+            project_key=project_key,
+            session_id=session_id,
+            working_dir=working_dir,
+            message_text=body,
+            sender_name=from_addr,
+            chat_id=from_addr,  # email address as chat_id
+            telegram_message_id=0,  # sentinel for email sessions
+            chat_title=subject or f"Email from {from_addr}",
+            project_config=project,
+            extra_context_overrides={
+                "transport": "email",
+                "email_message_id": message_id,
+                "email_from": from_addr,
+                "email_subject": subject,
+            },
+        )
+        logger.info(f"[email] Enqueued session {session_id} for {from_addr}")
+    except Exception as e:
+        logger.error(f"[email] Failed to enqueue session for {from_addr}: {e}")
+
+
+async def _poll_imap(imap_config: dict) -> list[bytes]:
+    """Connect to IMAP and fetch all unseen message bodies.
+
+    Marks fetched messages as SEEN atomically to prevent duplicate processing.
+    Returns a list of raw message bytes.
+    """
+    host = imap_config["host"]
+    port = imap_config["port"]
+    user = imap_config["user"]
+    password = imap_config["password"]
+    use_ssl = imap_config.get("ssl", True)
+
+    def _fetch_unseen() -> list[bytes]:
+        if use_ssl:
+            conn = imaplib.IMAP4_SSL(host, port)
+        else:
+            conn = imaplib.IMAP4(host, port)
+        try:
+            conn.login(user, password)
+            conn.select("INBOX")
+
+            # Search for unseen messages
+            status, data = conn.search(None, "UNSEEN")
+            if status != "OK" or not data or not data[0]:
+                return []
+
+            msg_ids = data[0].split()
+            if not msg_ids:
+                return []
+
+            messages = []
+            for msg_id in msg_ids:
+                # Mark as SEEN before fetching to prevent re-processing on concurrent polls
+                conn.store(msg_id, "+FLAGS", "\\Seen")
+                status, msg_data = conn.fetch(msg_id, "(RFC822)")
+                if status == "OK" and msg_data:
+                    for response_part in msg_data:
+                        if isinstance(response_part, tuple):
+                            messages.append(response_part[1])
+            return messages
+        finally:
+            try:
+                conn.logout()
+            except Exception:
+                pass
+
+    return await asyncio.to_thread(_fetch_unseen)
+
+
+async def _email_inbox_loop(imap_config: dict, config: dict) -> None:
+    """Main IMAP polling loop.
+
+    Polls the IMAP inbox every IMAP_POLL_INTERVAL seconds. On each successful
+    poll, updates email:last_poll_ts in Redis for health monitoring.
+
+    Implements exponential backoff on connection failures (up to 5 minutes max).
+    """
+    backoff = IMAP_POLL_INTERVAL
+    max_backoff = 300  # 5 minutes
+
+    while True:
+        try:
+            messages = await _poll_imap(imap_config)
+
+            # Update health timestamp
+            try:
+                r = _get_redis()
+                r.set(REDIS_LAST_POLL_KEY, str(time.time()))
+            except Exception as e:
+                logger.warning(f"[email] Failed to update health timestamp: {e}")
+
+            if messages:
+                logger.info(f"[email] Fetched {len(messages)} unseen message(s)")
+                for raw_bytes in messages:
+                    parsed = parse_email_message(raw_bytes)
+                    if parsed is None:
+                        continue
+                    try:
+                        await _process_inbound_email(parsed, config)
+                    except Exception as e:
+                        logger.error(
+                            f"[email] Error processing email from "
+                            f"{parsed.get('from_addr', 'unknown')}: {e}"
+                        )
+
+            # Reset backoff on success
+            backoff = IMAP_POLL_INTERVAL
+
+        except imaplib.IMAP4.error as e:
+            logger.error(f"[email] IMAP error: {e}. Retrying in {backoff}s...")
+            backoff = min(backoff * 2, max_backoff)
+
+        except OSError as e:
+            logger.error(f"[email] Network error during IMAP poll: {e}. Retrying in {backoff}s...")
+            backoff = min(backoff * 2, max_backoff)
+
+        except Exception as e:
+            logger.error(
+                f"[email] Unexpected error in IMAP poll loop: {e}. Retrying in {backoff}s..."
+            )
+            backoff = min(backoff * 2, max_backoff)
+
+        await asyncio.sleep(backoff)
+
+
+async def run_email_bridge() -> None:
+    """Start the email bridge IMAP polling loop.
+
+    Loads IMAP/SMTP config from environment. Exits with error if IMAP config
+    is not available. Safe to call even if email config is absent — returns
+    immediately with a warning in that case.
+    """
+    from bridge.routing import build_email_to_project_map, load_config
+
+    imap_config = _get_imap_config()
+    if not imap_config:
+        logger.warning(
+            "[email] IMAP not configured (missing IMAP_HOST/IMAP_USER/IMAP_PASSWORD). "
+            "Email bridge will not start."
+        )
+        return
+
+    smtp_config = _get_smtp_config()
+    if not smtp_config:
+        logger.warning(
+            "[email] SMTP not configured (missing SMTP_HOST/SMTP_USER/SMTP_PASSWORD). "
+            "Email bridge will start but cannot send replies."
+        )
+
+    # Load projects config and build email contact map
+    config = load_config()
+
+    # Initialize EMAIL_TO_PROJECT global (mirrors how telegram_bridge initializes GROUP_TO_PROJECT)
+    import bridge.routing as _routing_module
+
+    _routing_module.EMAIL_TO_PROJECT.update(build_email_to_project_map(config))
+
+    logger.info(
+        f"[email] Email bridge starting. "
+        f"IMAP host={imap_config['host']}, poll interval={IMAP_POLL_INTERVAL}s, "
+        f"contacts={len(_routing_module.EMAIL_TO_PROJECT)}"
+    )
+
+    await _email_inbox_loop(imap_config, config)
+
+
+def main() -> None:
+    """Entry point for ``python -m bridge.email_bridge``."""
+    import sys
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        stream=sys.stdout,
+    )
+
+    asyncio.run(run_email_bridge())
+
+
+if __name__ == "__main__":
+    main()

--- a/bridge/email_bridge.py
+++ b/bridge/email_bridge.py
@@ -241,6 +241,7 @@ class EmailOutputHandler:
             msg["Subject"] = f"Re: {subject}"
         else:
             msg["Subject"] = subject or "Re: (no subject)"
+        msg["Message-ID"] = email.utils.make_msgid(domain=from_addr.split("@")[-1])
         if in_reply_to:
             msg["In-Reply-To"] = in_reply_to
         if references:

--- a/bridge/email_dead_letter.py
+++ b/bridge/email_dead_letter.py
@@ -1,0 +1,267 @@
+"""Email dead letter queue management.
+
+Failed SMTP sends (after SMTP_MAX_RETRIES attempts) are persisted here as JSON
+blobs in Redis. Each entry is keyed by session_id.
+
+Redis key pattern: email:dead_letter:{session_id}
+
+Usage:
+    from bridge.email_dead_letter import list_dead_letters, replay_dead_letter
+
+Or via CLI:
+    python -m bridge.email_dead_letter list
+    python -m bridge.email_dead_letter replay --session-id <id>
+    python -m bridge.email_dead_letter replay --all
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+
+logger = logging.getLogger(__name__)
+
+DEAD_LETTER_KEY_PREFIX = "email:dead_letter:"
+
+
+def _get_redis():
+    """Return a Redis connection."""
+    import redis
+
+    redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+    return redis.Redis.from_url(redis_url, decode_responses=True)
+
+
+def write_dead_letter(
+    session_id: str,
+    recipient: str,
+    subject: str,
+    body: str,
+    headers: dict[str, str],
+    error: str,
+) -> None:
+    """Persist a failed SMTP send to the dead letter queue.
+
+    Args:
+        session_id: The AgentSession ID that generated the output.
+        recipient: Target email address.
+        subject: Email subject.
+        body: Email body text.
+        headers: SMTP headers dict (In-Reply-To, References, etc.).
+        error: Last error message from SMTP send attempt.
+    """
+    payload = {
+        "session_id": session_id,
+        "recipient": recipient,
+        "subject": subject,
+        "body": body,
+        "headers": headers,
+        "error": error,
+        "failed_at": time.time(),
+        "retry_count": 0,
+    }
+    key = f"{DEAD_LETTER_KEY_PREFIX}{session_id}"
+    try:
+        r = _get_redis()
+        r.set(key, json.dumps(payload))
+        logger.info(f"[email] Dead letter written: {key}")
+    except Exception as e:
+        logger.error(f"[email] Failed to write dead letter for {session_id}: {e}")
+
+
+def list_dead_letters() -> list[dict]:
+    """Return all dead letter entries as a list of dicts.
+
+    Returns:
+        List of dead letter payload dicts, sorted by failed_at (oldest first).
+    """
+    try:
+        r = _get_redis()
+        keys = list(r.scan_iter(f"{DEAD_LETTER_KEY_PREFIX}*"))
+        entries = []
+        for key in keys:
+            raw = r.get(key)
+            if raw:
+                try:
+                    entries.append(json.loads(raw))
+                except json.JSONDecodeError:
+                    logger.warning(f"[email] Corrupt dead letter entry at {key}, skipping")
+        entries.sort(key=lambda e: e.get("failed_at", 0))
+        return entries
+    except Exception as e:
+        logger.error(f"[email] Failed to list dead letters: {e}")
+        return []
+
+
+def replay_dead_letter(session_id: str) -> bool:
+    """Replay a single dead letter entry by sending via SMTP.
+
+    Removes the dead letter entry on success.
+
+    Args:
+        session_id: The session_id of the dead letter to replay.
+
+    Returns:
+        True if replay succeeded, False otherwise.
+    """
+    key = f"{DEAD_LETTER_KEY_PREFIX}{session_id}"
+    try:
+        r = _get_redis()
+        raw = r.get(key)
+        if not raw:
+            logger.warning(f"[email] No dead letter found for session_id={session_id}")
+            return False
+
+        payload = json.loads(raw)
+    except Exception as e:
+        logger.error(f"[email] Failed to read dead letter {session_id}: {e}")
+        return False
+
+    # Attempt SMTP send
+    try:
+        import email.mime.text
+        import email.utils
+        import smtplib
+
+        from bridge.email_bridge import _get_smtp_config
+
+        smtp_config = _get_smtp_config()
+        if not smtp_config:
+            logger.error("[email] SMTP not configured, cannot replay dead letter")
+            return False
+
+        from_addr = smtp_config["user"]
+        recipient = payload["recipient"]
+        subject = payload["subject"]
+        body = payload["body"]
+        headers = payload.get("headers", {})
+
+        msg = email.mime.text.MIMEText(body, "plain", "utf-8")
+        msg["From"] = from_addr
+        msg["To"] = recipient
+        msg["Subject"] = subject
+        msg["Date"] = email.utils.formatdate(localtime=True)
+        for header_name, header_value in headers.items():
+            if header_value:
+                msg[header_name] = header_value
+
+        with smtplib.SMTP(smtp_config["host"], smtp_config["port"], timeout=30) as smtp:
+            if smtp_config.get("use_tls", True):
+                smtp.starttls()
+            smtp.login(smtp_config["user"], smtp_config["password"])
+            smtp.sendmail(from_addr, [recipient], msg.as_string())
+
+        # Success — remove from dead letter queue
+        r.delete(key)
+        logger.info(f"[email] Replayed dead letter for session_id={session_id}")
+        return True
+
+    except Exception as e:
+        # Update retry count
+        try:
+            payload["retry_count"] = payload.get("retry_count", 0) + 1
+            payload["last_retry_error"] = str(e)
+            r.set(key, json.dumps(payload))
+        except Exception:
+            pass
+        logger.error(f"[email] Dead letter replay failed for {session_id}: {e}")
+        return False
+
+
+def replay_all_dead_letters() -> tuple[int, int]:
+    """Replay all dead letter entries.
+
+    Returns:
+        Tuple of (succeeded, failed) counts.
+    """
+    entries = list_dead_letters()
+    succeeded = 0
+    failed = 0
+    for entry in entries:
+        session_id = entry.get("session_id", "")
+        if replay_dead_letter(session_id):
+            succeeded += 1
+        else:
+            failed += 1
+    logger.info(f"[email] Dead letter replay complete: {succeeded} succeeded, {failed} failed")
+    return succeeded, failed
+
+
+# =============================================================================
+# CLI entry point
+# =============================================================================
+
+
+def _cli_list() -> None:
+    """Print all dead letter entries."""
+    entries = list_dead_letters()
+    if not entries:
+        print("No dead letter entries.")
+        return
+
+    print(f"Dead letter queue: {len(entries)} entry(ies)\n")
+    for entry in entries:
+        failed_at = entry.get("failed_at", 0)
+        failed_str = time.strftime("%Y-%m-%d %H:%M:%S UTC", time.gmtime(failed_at))
+        print(f"  session_id: {entry.get('session_id', 'unknown')}")
+        print(f"  recipient:  {entry.get('recipient', 'unknown')}")
+        print(f"  subject:    {entry.get('subject', '')}")
+        print(f"  failed_at:  {failed_str}")
+        print(f"  error:      {entry.get('error', 'unknown')}")
+        print(f"  retries:    {entry.get('retry_count', 0)}")
+        print()
+
+
+def _cli_replay(session_id: str | None, replay_all: bool) -> None:
+    """Replay dead letter(s)."""
+    if replay_all:
+        succeeded, failed = replay_all_dead_letters()
+        print(f"Replayed: {succeeded} succeeded, {failed} failed")
+    elif session_id:
+        ok = replay_dead_letter(session_id)
+        if ok:
+            print(f"Replayed dead letter for session_id={session_id}")
+        else:
+            print(f"Failed to replay dead letter for session_id={session_id}")
+    else:
+        print("Error: provide --session-id or --all")
+        raise SystemExit(1)
+
+
+def main() -> None:
+    """CLI entry point for dead letter management.
+
+    Usage:
+        python -m bridge.email_dead_letter list
+        python -m bridge.email_dead_letter replay --session-id <id>
+        python -m bridge.email_dead_letter replay --all
+    """
+    import argparse
+    import sys
+
+    logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
+
+    parser = argparse.ArgumentParser(
+        description="Email dead letter queue management",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("list", help="List all dead letter entries")
+
+    replay_parser = subparsers.add_parser("replay", help="Replay dead letter(s)")
+    replay_parser.add_argument("--session-id", help="Session ID to replay")
+    replay_parser.add_argument("--all", action="store_true", help="Replay all entries")
+
+    args = parser.parse_args()
+
+    if args.command == "list":
+        _cli_list()
+    elif args.command == "replay":
+        _cli_replay(args.session_id, args.all)
+
+
+if __name__ == "__main__":
+    main()

--- a/bridge/routing.py
+++ b/bridge/routing.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 CONFIG = {}
 DEFAULTS = {}
 GROUP_TO_PROJECT = {}
+EMAIL_TO_PROJECT: dict[str, dict] = {}
 ALL_MONITORED_GROUPS = []
 ACTIVE_PROJECTS = []
 RESPOND_TO_DMS = True
@@ -151,6 +152,42 @@ def build_group_to_project_map(config: dict) -> dict:
     return group_map
 
 
+def build_email_to_project_map(config: dict) -> dict:
+    """Build a mapping from email addresses (lowercase) to project configs.
+
+    Reads the 'email.contacts' section from each project in projects.json.
+    Keys are exact-match email addresses (lowercased). Values are the project
+    config dict (same as GROUP_TO_PROJECT values).
+
+    Returns:
+        dict mapping lowercase email address -> project config dict
+    """
+    email_map: dict[str, dict] = {}
+    projects = config.get("projects", {})
+
+    for project_key in ACTIVE_PROJECTS:
+        if project_key not in projects:
+            continue
+
+        project = projects[project_key]
+        project["_key"] = project_key  # Ensure key is set (mirrors group map behavior)
+
+        email_config = project.get("email", {})
+        contacts = email_config.get("contacts", {})
+
+        for email_addr, contact_info in contacts.items():
+            email_lower = email_addr.lower()
+            if email_lower in email_map:
+                logger.warning(f"Email '{email_addr}' is mapped to multiple projects, using first")
+                continue
+            email_map[email_lower] = project
+            logger.info(
+                f"Mapping email '{email_addr}' -> project '{project.get('name', project_key)}'"
+            )
+
+    return email_map
+
+
 # =============================================================================
 # Project and Chat Mapping
 # =============================================================================
@@ -167,6 +204,24 @@ def find_project_for_chat(chat_title: str | None) -> dict | None:
             return project
 
     return None
+
+
+def find_project_for_email(sender_email: str | None) -> dict | None:
+    """Find which project an email sender belongs to.
+
+    Exact-match lookup on the sender's email address in EMAIL_TO_PROJECT.
+    The map is built from projects.json 'email.contacts' sections.
+
+    Args:
+        sender_email: The sender's email address (case-insensitive).
+
+    Returns:
+        Project config dict with '_key' set, or None if no match.
+    """
+    if not sender_email:
+        return None
+
+    return EMAIL_TO_PROJECT.get(sender_email.lower())
 
 
 def is_team_chat(chat_title: str | None) -> bool:

--- a/config/projects.example.json
+++ b/config/projects.example.json
@@ -56,6 +56,13 @@
       "context": {
         "tech_stack": ["Python", "Framework"],
         "description": "Focus areas for this project"
+      },
+      "email": {
+        "_doc": "Optional. Maps sender email addresses to contacts for this project. Email bridge will route inbound emails from these addresses to this project. Remove this section if email is not needed.",
+        "contacts": {
+          "alice@example.com": {"name": "Alice", "persona": "teammate"},
+          "bob@example.com": {"name": "Bob"}
+        }
       }
     }
   },

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -43,6 +43,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [do-patch Skill](do-patch-skill.md) | Targeted fix skill for test failures and review blockers; called automatically by do-build | Shipped |
 | [Documentation Audit](documentation-audit.md) | Weekly LLM-powered audit of docs/ accuracy against codebase; KEEP / UPDATE / DELETE verdicts, directory and filename enforcement | Shipped |
 | [Documentation Lifecycle](documentation-lifecycle.md) | Automated validation and migration system for plan documentation tasks | Shipped |
+| [Email Bridge](email-bridge.md) | IMAP/SMTP transport alongside Telegram: sender-based project routing, thread continuation via In-Reply-To, transport-keyed output handlers, and dead letter queue for failed sends | Shipped |
 | [Emoji Embedding Reactions](emoji-embedding-reactions.md) | Embedding-based emoji reaction selection with standard and Premium custom emoji support, EmojiResult type, send_telegram --react and --emoji flags, and graceful degradation | Shipped |
 | [Enforce REVIEW/DOCS Stages](enforce-review-docs-stages.md) | Hard delivery gates in Observer preventing SDLC pipeline from skipping REVIEW and DOCS stages | Shipped |
 | [Enhanced Planning](enhanced-planning.md) | Spike Resolution (Phase 1.5), RFC Review (Phase 2.8), Infrastructure Documentation, and task validation fields for /do-plan | Shipped |

--- a/docs/features/deployment.md
+++ b/docs/features/deployment.md
@@ -159,6 +159,39 @@ All plist labels below use the `${SERVICE_LABEL_PREFIX}` configured in `.env`
 
 Both Bridge and Worker must run on bridge machines. The bridge is I/O only and does not process sessions on its own.
 
+### Email Bridge
+
+The email bridge runs as an optional service on bridge machines. It polls IMAP every 30 seconds and routes inbound emails to agent sessions via sender-based project matching.
+
+**Prerequisites:** Add `email.contacts` to `projects.json` and set IMAP/SMTP credentials in `.env`:
+
+```bash
+IMAP_HOST=imap.gmail.com
+IMAP_PORT=993
+IMAP_USER=valor@yuda.me
+IMAP_PASSWORD=<gmail-app-password>
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=valor@yuda.me
+SMTP_PASSWORD=<gmail-app-password>
+```
+
+```bash
+# Lifecycle
+./scripts/valor-service.sh email-start
+./scripts/valor-service.sh email-stop
+./scripts/valor-service.sh email-restart
+
+# Status (warns if last poll is > 5 minutes ago)
+./scripts/valor-service.sh email-status
+
+# Dead letter queue (failed SMTP sends)
+./scripts/valor-service.sh email-dead-letter list
+./scripts/valor-service.sh email-dead-letter replay --all
+```
+
+See [Email Bridge](email-bridge.md) for full architecture and configuration details.
+
 ### Worker Installation
 
 ```bash

--- a/docs/features/email-bridge.md
+++ b/docs/features/email-bridge.md
@@ -1,0 +1,154 @@
+# Email Bridge
+
+Email as a second transport alongside Telegram. Inbound emails are routed to agent sessions; outbound replies are delivered via SMTP with proper threading.
+
+## Architecture
+
+```
+IMAP inbox (valor@yuda.me)
+  → bridge/email_bridge.py (polls every 30s)
+    → find_project_for_email()   # bridge/routing.py
+    → enqueue_agent_session()    # transport="email"
+      → Worker resolves EmailOutputHandler via (project_key, "email") callback
+        → EmailOutputHandler.send()  # bridge/email_bridge.py
+          → SMTP reply with In-Reply-To header
+```
+
+### Key Modules
+
+| File | Role |
+|------|------|
+| `bridge/email_bridge.py` | IMAP polling loop, email parsing, `EmailOutputHandler` |
+| `bridge/email_dead_letter.py` | Dead letter queue for failed SMTP sends |
+| `bridge/routing.py` | `find_project_for_email()`, `build_email_to_project_map()` |
+| `agent/agent_session_queue.py` | Transport-keyed callbacks via `register_callbacks(transport=...)` and `_resolve_callbacks()`; `extra_context_overrides` parameter |
+
+### Session Identity
+
+Email sessions use an `email_` prefix for their session IDs:
+
+```
+email_{project_key}_{normalized_sender}_{unix_timestamp}
+# e.g. email_myproject_alice_at_example_com_1744000000
+```
+
+`telegram_message_id=0` is used as a sentinel (email sessions have no Telegram message ID).
+
+### Thread Continuation
+
+When an inbound email carries an `In-Reply-To` header, the bridge looks up `email:msgid:{message_id}` in Redis to find the existing `session_id`. Replies resume the original session rather than starting a new one.
+
+Each outbound SMTP send records the sent `Message-ID` in Redis so future replies can be correlated.
+
+### Transport-Keyed Callbacks
+
+`AgentSession` callbacks are keyed by `(project_key, transport)`. The worker resolves the correct `OutputHandler` by looking up `(project_key, "email")` instead of the Telegram default. This keeps email and Telegram sessions fully isolated with no cross-contamination of delivery channels.
+
+## Configuration
+
+### projects.json
+
+Add an `email.contacts` block to any project entry:
+
+```json
+{
+  "projects": {
+    "my-project": {
+      "email": {
+        "contacts": {
+          "alice@example.com": {"name": "Alice", "persona": "teammate"},
+          "bob@example.com":   {"name": "Bob",   "persona": "teammate"}
+        }
+      }
+    }
+  }
+}
+```
+
+Only senders listed in `contacts` are routed to sessions. Unrecognized senders are ignored.
+
+### Environment Variables
+
+```bash
+# IMAP (inbound)
+IMAP_HOST=imap.gmail.com
+IMAP_PORT=993
+IMAP_USER=valor@yuda.me
+IMAP_PASSWORD=<gmail-app-password>
+
+# SMTP (outbound)
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=valor@yuda.me
+SMTP_PASSWORD=<gmail-app-password>
+```
+
+See `.env.example` for the full list with comments.
+
+For Gmail, generate an App Password at <https://myaccount.google.com/apppasswords> (requires 2FA enabled).
+
+## Operations
+
+```bash
+# Lifecycle
+./scripts/valor-service.sh email-start
+./scripts/valor-service.sh email-stop
+./scripts/valor-service.sh email-restart
+
+# Status (shows last poll age and warns if > 5 minutes stale)
+./scripts/valor-service.sh email-status
+
+# Dead letter queue
+./scripts/valor-service.sh email-dead-letter list
+./scripts/valor-service.sh email-dead-letter replay --all
+```
+
+## Health Monitoring
+
+After each successful IMAP poll, the bridge writes the current timestamp to:
+
+```
+Redis key: email:last_poll_ts
+```
+
+`email-status` reads this key and warns if the last poll is older than 5 minutes, indicating the IMAP poller has stalled or crashed.
+
+## Dead Letter Queue
+
+When an SMTP send fails, the message is written to a dead letter entry in Redis:
+
+```
+Redis key: email:dead_letter:{session_id}
+```
+
+Inspect and replay via CLI:
+
+```bash
+python -m bridge.email_dead_letter list          # view all dead-lettered messages
+python -m bridge.email_dead_letter replay --all  # retry all failed sends
+```
+
+Or via the service script:
+
+```bash
+./scripts/valor-service.sh email-dead-letter list
+./scripts/valor-service.sh email-dead-letter replay --all
+```
+
+## Design Decisions
+
+**stdlib only.** `imaplib`, `smtplib`, and `email` from the Python standard library — no third-party dependencies. This keeps the email bridge installable anywhere Python runs.
+
+**Single inbox, sender-based routing.** All projects share one inbox (`valor@yuda.me`). The sender address determines which project the message is routed to. This avoids per-project mailboxes while keeping routing deterministic.
+
+**`telegram_message_id=0` sentinel.** The session queue requires a message ID for deduplication. Email sessions use `0` as a sentinel value since they have no Telegram message ID. This avoids a nullable field or a parallel code path in the queue.
+
+**Transport stored in `extra_context`.** `extra_context["transport"] = "email"` is the discriminator the worker uses to select `EmailOutputHandler` over `TelegramRelayOutputHandler`. The same mechanism supports future transports (e.g. Slack) without changes to the core queue.
+
+**30-second poll interval.** A balance between responsiveness and IMAP connection overhead. Gmail supports IMAP IDLE for push delivery, but polling is simpler and sufficient for the current load.
+
+## See Also
+
+- [Bridge/Worker Architecture](bridge-worker-architecture.md) — how the worker resolves output handlers
+- [Worker Service](worker-service.md) — standalone worker details
+- [Deployment](deployment.md) — email bridge setup in the service topology

--- a/scripts/valor-service.sh
+++ b/scripts/valor-service.sh
@@ -72,6 +72,15 @@ usage() {
     echo "  worker-status   Check worker status"
     echo "  worker-logs     Tail the worker logs"
     echo ""
+    echo "Email bridge commands:"
+    echo "  email-start     Start the email bridge (IMAP polling)"
+    echo "  email-stop      Stop the email bridge"
+    echo "  email-restart   Restart the email bridge"
+    echo "  email-status    Check email bridge status and last poll age"
+    echo "  email-dead-letter list    List failed SMTP sends"
+    echo "  email-dead-letter replay --all    Replay all dead-lettered emails"
+    echo "  email-dead-letter replay --session-id <id>    Replay one email"
+    echo ""
 }
 
 get_pid() {
@@ -654,6 +663,110 @@ tail_worker_logs() {
     tail -f "$LOG_DIR/worker.log" "$LOG_DIR/worker_error.log" 2>/dev/null
 }
 
+# =============================================================================
+# Email bridge functions
+# =============================================================================
+
+get_email_pid() {
+    pgrep -f "bridge.email_bridge" 2>/dev/null || true
+}
+
+is_email_running() {
+    local pid=$(get_email_pid)
+    [ -n "$pid" ]
+}
+
+start_email() {
+    echo "Starting email bridge..."
+
+    if is_email_running; then
+        local pid=$(get_email_pid)
+        echo "Email bridge is already running (PID: $pid)"
+        return 0
+    fi
+
+    ensure_setup
+    cd "$PROJECT_DIR"
+    nohup "$VENV/bin/python" -m bridge.email_bridge \
+        >> "$LOG_DIR/email_bridge.log" \
+        2>> "$LOG_DIR/email_bridge.error.log" &
+
+    sleep 2
+    if is_email_running; then
+        local pid=$(get_email_pid)
+        echo "Email bridge started (PID: $pid)"
+    else
+        echo "Failed to start email bridge. Check logs: $LOG_DIR/email_bridge.error.log"
+        return 1
+    fi
+}
+
+stop_email() {
+    local pid=$(get_email_pid)
+
+    if [ -z "$pid" ]; then
+        echo "Email bridge is not running"
+        return 0
+    fi
+
+    echo "Stopping email bridge (PID: $pid)..."
+    kill "$pid" 2>/dev/null || true
+
+    for i in {1..10}; do
+        if ! is_email_running; then
+            echo "Email bridge stopped"
+            return 0
+        fi
+        sleep 1
+    done
+
+    echo "Force killing email bridge..."
+    kill -9 "$pid" 2>/dev/null || true
+    echo "Email bridge stopped (forced)"
+}
+
+restart_email() {
+    echo "Restarting email bridge..."
+    stop_email
+    sleep 1
+    start_email
+}
+
+status_email() {
+    local pid=$(get_email_pid)
+
+    if [ -n "$pid" ]; then
+        echo "Email Bridge Status: RUNNING"
+        echo "PID: $pid"
+        echo "Uptime: $(ps -o etime= -p $pid 2>/dev/null | xargs)"
+        echo "Memory: $(ps -o rss= -p $pid 2>/dev/null | awk '{printf "%.1f MB", $1/1024}')"
+    else
+        echo "Email Bridge Status: STOPPED"
+    fi
+
+    # Check last poll timestamp from Redis
+    local last_poll
+    last_poll=$(cd "$PROJECT_DIR" && "$VENV/bin/python" -c "
+import os, redis, time
+r = redis.Redis.from_url(os.environ.get('REDIS_URL', 'redis://localhost:6379/0'), decode_responses=True)
+ts = r.get('email:last_poll_ts')
+if ts:
+    age = time.time() - float(ts)
+    print(f'Last poll: {age:.0f}s ago')
+    if age > 300:
+        print('WARNING: Last poll was more than 5 minutes ago — bridge may be stuck')
+else:
+    print('Last poll: never (bridge not started or no polls completed)')
+" 2>/dev/null || echo "Last poll: unknown (Redis unavailable)")
+    echo "$last_poll"
+}
+
+email_dead_letter() {
+    cd "$PROJECT_DIR"
+    "$VENV/bin/python" -m bridge.email_dead_letter "$@"
+}
+
+# =============================================================================
 # Main
 case "${1:-}" in
     start)
@@ -695,6 +808,22 @@ case "${1:-}" in
         ;;
     worker-logs)
         tail_worker_logs
+        ;;
+    email-start)
+        start_email
+        ;;
+    email-stop)
+        stop_email
+        ;;
+    email-restart)
+        restart_email
+        ;;
+    email-status)
+        status_email
+        ;;
+    email-dead-letter)
+        shift
+        email_dead_letter "$@"
         ;;
     *)
         usage

--- a/tests/integration/test_email_bridge.py
+++ b/tests/integration/test_email_bridge.py
@@ -1,0 +1,248 @@
+"""
+Integration tests for the email bridge inbound path.
+
+Tests _process_inbound_email() with a real enqueue_agent_session() call
+against the test Redis instance (provided by the autouse redis_test_db
+fixture in tests/conftest.py).
+
+Design:
+- enqueue_agent_session() is mocked to avoid Popoto persistence complexity
+  in tests — the unit under test is the routing/dispatch logic in
+  _process_inbound_email(), not Popoto internals.
+- Thread-continuation Redis lookups are exercised against the real test Redis
+  db (via a patched _get_redis() that points at db=1).
+- Unknown sender, active-project guard, and extra_context propagation are
+  all verified by inspecting mock call args.
+"""
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import redis
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parsed_email(
+    from_addr: str = "alice@example.com",
+    subject: str = "Help with my account",
+    body: str = "Hello, I need some assistance.",
+    message_id: str = "<msg-001@example.com>",
+    in_reply_to: str | None = None,
+) -> dict:
+    """Return a minimal parsed email dict matching parse_email_message() output."""
+    return {
+        "from_addr": from_addr,
+        "subject": subject,
+        "body": body,
+        "message_id": message_id,
+        "in_reply_to": in_reply_to,
+    }
+
+
+def _project_config(key: str = "test-project") -> dict:
+    """Return a minimal project config dict with email.contacts section."""
+    return {
+        "_key": key,
+        "name": key,
+        "working_directory": "/tmp/test-project",
+        "email": {
+            "contacts": {
+                "alice@example.com": {"name": "Alice"},
+            }
+        },
+    }
+
+
+def _projects_json(project_key: str = "test-project") -> dict:
+    """Return a minimal projects.json config dict."""
+    return {
+        "projects": {
+            project_key: _project_config(project_key),
+        }
+    }
+
+
+def _test_redis() -> redis.Redis:
+    """Return a Redis connection to the test db (db=1, matching conftest fixture)."""
+    return redis.Redis(db=1, decode_responses=True)
+
+
+# ---------------------------------------------------------------------------
+# Tests: inbound email → session enqueued
+# ---------------------------------------------------------------------------
+
+
+class TestProcessInboundEmail:
+    """Integration tests for _process_inbound_email() → enqueue_agent_session()."""
+
+    @pytest.mark.asyncio
+    async def test_new_inbound_email_enqueues_session(self):
+        """A new inbound email calls enqueue_agent_session with correct args."""
+        import bridge.routing as routing
+        from bridge.email_bridge import _process_inbound_email
+
+        project_key = "test-project"
+        project = _project_config(project_key)
+        config = _projects_json(project_key)
+
+        original_email_map = routing.EMAIL_TO_PROJECT.copy()
+        original_active = routing.ACTIVE_PROJECTS[:]
+        try:
+            routing.EMAIL_TO_PROJECT["alice@example.com"] = project
+            if project_key not in routing.ACTIVE_PROJECTS:
+                routing.ACTIVE_PROJECTS.append(project_key)
+
+            mock_enqueue = AsyncMock()
+            with patch("agent.agent_session_queue.enqueue_agent_session", mock_enqueue):
+                # Patch _get_redis so it uses the test db (not db=0)
+                test_r = _test_redis()
+                with patch("bridge.email_bridge._get_redis", return_value=test_r):
+                    await _process_inbound_email(_parsed_email(), config)
+                test_r.close()
+
+        finally:
+            routing.EMAIL_TO_PROJECT.clear()
+            routing.EMAIL_TO_PROJECT.update(original_email_map)
+            routing.ACTIVE_PROJECTS[:] = original_active
+
+        mock_enqueue.assert_called_once()
+        kwargs = mock_enqueue.call_args.kwargs
+
+        assert kwargs["project_key"] == project_key
+        assert kwargs["message_text"] == "Hello, I need some assistance."
+        assert kwargs["sender_name"] == "alice@example.com"
+        assert kwargs["chat_id"] == "alice@example.com"
+        assert kwargs["telegram_message_id"] == 0  # sentinel for email sessions
+        assert kwargs["working_dir"] == "/tmp/test-project"
+
+    @pytest.mark.asyncio
+    async def test_inbound_email_sets_email_extra_context(self):
+        """Extra context passed to enqueue_agent_session contains transport and email metadata."""
+        import bridge.routing as routing
+        from bridge.email_bridge import _process_inbound_email
+
+        project_key = "test-project"
+        project = _project_config(project_key)
+        config = _projects_json(project_key)
+
+        original_email_map = routing.EMAIL_TO_PROJECT.copy()
+        original_active = routing.ACTIVE_PROJECTS[:]
+        try:
+            routing.EMAIL_TO_PROJECT["alice@example.com"] = project
+            if project_key not in routing.ACTIVE_PROJECTS:
+                routing.ACTIVE_PROJECTS.append(project_key)
+
+            mock_enqueue = AsyncMock()
+            with patch("agent.agent_session_queue.enqueue_agent_session", mock_enqueue):
+                test_r = _test_redis()
+                with patch("bridge.email_bridge._get_redis", return_value=test_r):
+                    await _process_inbound_email(
+                        _parsed_email(
+                            message_id="<msg-42@example.com>",
+                            subject="Billing question",
+                        ),
+                        config,
+                    )
+                test_r.close()
+
+        finally:
+            routing.EMAIL_TO_PROJECT.clear()
+            routing.EMAIL_TO_PROJECT.update(original_email_map)
+            routing.ACTIVE_PROJECTS[:] = original_active
+
+        mock_enqueue.assert_called_once()
+        extra = mock_enqueue.call_args.kwargs.get("extra_context_overrides", {})
+
+        assert extra.get("transport") == "email"
+        assert extra.get("email_message_id") == "<msg-42@example.com>"
+        assert extra.get("email_from") == "alice@example.com"
+        assert extra.get("email_subject") == "Billing question"
+
+    @pytest.mark.asyncio
+    async def test_unknown_sender_discards_email(self):
+        """Email from an unknown sender is discarded — enqueue_agent_session not called."""
+        import bridge.routing as routing
+        from bridge.email_bridge import _process_inbound_email
+
+        project_key = "test-project"
+        config = _projects_json(project_key)
+
+        # Do NOT add unknown@stranger.com to EMAIL_TO_PROJECT
+        original_email_map = routing.EMAIL_TO_PROJECT.copy()
+        original_active = routing.ACTIVE_PROJECTS[:]
+        try:
+            if project_key not in routing.ACTIVE_PROJECTS:
+                routing.ACTIVE_PROJECTS.append(project_key)
+
+            mock_enqueue = AsyncMock()
+            with patch("agent.agent_session_queue.enqueue_agent_session", mock_enqueue):
+                test_r = _test_redis()
+                with patch("bridge.email_bridge._get_redis", return_value=test_r):
+                    await _process_inbound_email(
+                        _parsed_email(from_addr="unknown@stranger.com"),
+                        config,
+                    )
+                test_r.close()
+
+        finally:
+            routing.EMAIL_TO_PROJECT.clear()
+            routing.EMAIL_TO_PROJECT.update(original_email_map)
+            routing.ACTIVE_PROJECTS[:] = original_active
+
+        mock_enqueue.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_thread_continuation_reuses_session_id(self):
+        """When In-Reply-To matches a stored Message-ID, the original session_id is reused."""
+        import bridge.routing as routing
+        from bridge.email_bridge import _process_inbound_email
+
+        project_key = "test-project"
+        project = _project_config(project_key)
+        config = _projects_json(project_key)
+
+        # Pre-seed the thread-continuation mapping in test Redis (db=1)
+        original_session_id = f"email_{project_key}_alice_at_example_com_{int(time.time()) - 100}"
+        test_r = _test_redis()
+        test_r.set(
+            "email:msgid:<outbound-msg-001@example.com>",
+            original_session_id,
+            ex=172800,
+        )
+
+        original_email_map = routing.EMAIL_TO_PROJECT.copy()
+        original_active = routing.ACTIVE_PROJECTS[:]
+        try:
+            routing.EMAIL_TO_PROJECT["alice@example.com"] = project
+            if project_key not in routing.ACTIVE_PROJECTS:
+                routing.ACTIVE_PROJECTS.append(project_key)
+
+            mock_enqueue = AsyncMock()
+            with patch("agent.agent_session_queue.enqueue_agent_session", mock_enqueue):
+                # Patch _get_redis to return our pre-seeded test db connection
+                with patch("bridge.email_bridge._get_redis", return_value=test_r):
+                    await _process_inbound_email(
+                        _parsed_email(
+                            message_id="<reply-001@example.com>",
+                            in_reply_to="<outbound-msg-001@example.com>",
+                            body="Thanks for your help!",
+                        ),
+                        config,
+                    )
+
+        finally:
+            test_r.close()
+            routing.EMAIL_TO_PROJECT.clear()
+            routing.EMAIL_TO_PROJECT.update(original_email_map)
+            routing.ACTIVE_PROJECTS[:] = original_active
+
+        mock_enqueue.assert_called_once()
+        called_session_id = mock_enqueue.call_args.kwargs.get("session_id")
+        assert called_session_id == original_session_id, (
+            f"Expected session_id={original_session_id!r} from thread continuation, "
+            f"got {called_session_id!r}"
+        )

--- a/tests/unit/test_email_bridge.py
+++ b/tests/unit/test_email_bridge.py
@@ -358,7 +358,8 @@ class TestEmailOutputHandlerSend:
     @pytest.mark.asyncio
     async def test_send_no_smtp_config_raises_in_send_smtp(self):
         """_send_smtp raises RuntimeError when no SMTP config present."""
-        handler = EmailOutputHandler(smtp_config=None)
+        with patch("bridge.email_bridge._get_smtp_config", return_value=None):
+            handler = EmailOutputHandler(smtp_config=None)
         with pytest.raises(RuntimeError, match="SMTP not configured"):
             handler._send_smtp("recipient@example.com", MagicMock())
 

--- a/tests/unit/test_email_bridge.py
+++ b/tests/unit/test_email_bridge.py
@@ -1,0 +1,394 @@
+"""Unit tests for bridge.email_bridge parsing helpers and EmailOutputHandler.
+
+Uses real Python email library constructs to build test data — no mocks of
+the standard library. SMTP is mocked via unittest.mock.patch to avoid network
+calls.
+"""
+
+import email.mime.multipart
+import email.mime.text
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bridge.email_bridge import (
+    EmailOutputHandler,
+    _decode_header_value,
+    _extract_address,
+    parse_email_message,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_plain_email(
+    from_addr: str = "Alice <alice@example.com>",
+    subject: str = "Hello",
+    body: str = "This is the body.",
+    message_id: str = "<msg-001@example.com>",
+    in_reply_to: str = "",
+) -> bytes:
+    """Build a raw plain-text email as bytes."""
+    msg = email.mime.text.MIMEText(body, "plain", "utf-8")
+    msg["From"] = from_addr
+    msg["To"] = "valor@example.com"
+    msg["Subject"] = subject
+    if message_id:
+        msg["Message-ID"] = message_id
+    if in_reply_to:
+        msg["In-Reply-To"] = in_reply_to
+    return msg.as_bytes()
+
+
+def _make_multipart_email(
+    from_addr: str = "bob@example.com",
+    subject: str = "Multipart",
+    plain_body: str = "Plain text part.",
+    html_body: str = "<html><body><p>HTML part.</p></body></html>",
+) -> bytes:
+    """Build a raw multipart/alternative email with both plain and HTML parts."""
+    msg = email.mime.multipart.MIMEMultipart("alternative")
+    msg["From"] = from_addr
+    msg["To"] = "valor@example.com"
+    msg["Subject"] = subject
+    msg["Message-ID"] = "<multipart-001@example.com>"
+
+    part_plain = email.mime.text.MIMEText(plain_body, "plain", "utf-8")
+    part_html = email.mime.text.MIMEText(html_body, "html", "utf-8")
+    msg.attach(part_plain)
+    msg.attach(part_html)
+    return msg.as_bytes()
+
+
+# ---------------------------------------------------------------------------
+# parse_email_message()
+# ---------------------------------------------------------------------------
+
+
+class TestParseEmailMessage:
+    """parse_email_message() parses raw bytes into a structured dict."""
+
+    def test_valid_plain_text_email_returns_dict(self):
+        """Full plain text email parses to dict with all expected fields."""
+        raw = _make_plain_email(
+            from_addr="Alice <alice@example.com>",
+            subject="Hello there",
+            body="Hello, this is the email body.",
+            message_id="<msg-001@example.com>",
+            in_reply_to="<prev-msg@example.com>",
+        )
+        result = parse_email_message(raw)
+
+        assert result is not None
+        assert result["from_addr"] == "alice@example.com"
+        assert result["subject"] == "Hello there"
+        assert result["body"] == "Hello, this is the email body."
+        assert result["message_id"] == "<msg-001@example.com>"
+        assert result["in_reply_to"] == "<prev-msg@example.com>"
+
+    def test_multipart_email_returns_plain_text_body(self):
+        """Multipart email: plain text part is returned, not HTML."""
+        raw = _make_multipart_email(
+            plain_body="This is plain text.",
+            html_body="<html><body><b>Bold HTML</b></body></html>",
+        )
+        result = parse_email_message(raw)
+
+        assert result is not None
+        assert "plain text" in result["body"]
+        assert "<html>" not in result["body"]
+        assert "<b>" not in result["body"]
+
+    def test_email_with_empty_body_returns_none(self):
+        """Email with empty body (empty string) returns None."""
+        raw = _make_plain_email(body="")
+        result = parse_email_message(raw)
+        assert result is None
+
+    def test_email_with_whitespace_only_body_returns_none(self):
+        """Email with whitespace-only body returns None."""
+        raw = _make_plain_email(body="   \n\t  \n  ")
+        result = parse_email_message(raw)
+        assert result is None
+
+    def test_email_with_no_from_returns_none(self):
+        """Email missing a From address returns None."""
+        # Build a minimal email without From header
+        msg = email.mime.text.MIMEText("Some body content.", "plain", "utf-8")
+        msg["To"] = "valor@example.com"
+        msg["Subject"] = "No sender"
+        raw = msg.as_bytes()
+
+        result = parse_email_message(raw)
+        assert result is None
+
+    def test_from_raw_preserved_in_result(self):
+        """from_raw field preserves the original From header value."""
+        raw = _make_plain_email(from_addr="Alice Smith <alice@example.com>")
+        result = parse_email_message(raw)
+
+        assert result is not None
+        assert "Alice Smith" in result["from_raw"]
+
+    def test_missing_message_id_gives_empty_string(self):
+        """Email without Message-ID has empty string in result."""
+        raw = _make_plain_email(message_id="")
+        result = parse_email_message(raw)
+
+        assert result is not None
+        assert result["message_id"] == ""
+
+    def test_missing_in_reply_to_gives_empty_string(self):
+        """Email without In-Reply-To has empty string in result."""
+        raw = _make_plain_email(in_reply_to="")
+        result = parse_email_message(raw)
+
+        assert result is not None
+        assert result["in_reply_to"] == ""
+
+    def test_address_is_lowercased(self):
+        """Parsed from_addr is always lowercase."""
+        raw = _make_plain_email(from_addr="UPPER@EXAMPLE.COM")
+        result = parse_email_message(raw)
+
+        assert result is not None
+        assert result["from_addr"] == "upper@example.com"
+
+
+# ---------------------------------------------------------------------------
+# _extract_address()
+# ---------------------------------------------------------------------------
+
+
+class TestExtractAddress:
+    """_extract_address() parses email addresses from header values."""
+
+    def test_name_and_addr_format(self):
+        """'Alice <alice@example.com>' → 'alice@example.com'."""
+        assert _extract_address("Alice <alice@example.com>") == "alice@example.com"
+
+    def test_bare_address(self):
+        """'alice@example.com' → 'alice@example.com'."""
+        assert _extract_address("alice@example.com") == "alice@example.com"
+
+    def test_address_is_lowercased(self):
+        """Output is always lowercase."""
+        assert _extract_address("ALICE@EXAMPLE.COM") == "alice@example.com"
+
+    def test_none_returns_empty_string(self):
+        """None input returns empty string."""
+        assert _extract_address(None) == ""
+
+    def test_empty_string_returns_empty_string(self):
+        """Empty string returns empty string."""
+        assert _extract_address("") == ""
+
+    def test_name_with_spaces(self):
+        """'First Last <user@domain.com>' → 'user@domain.com'."""
+        assert _extract_address("First Last <user@domain.com>") == "user@domain.com"
+
+
+# ---------------------------------------------------------------------------
+# _decode_header_value()
+# ---------------------------------------------------------------------------
+
+
+class TestDecodeHeaderValue:
+    """_decode_header_value() decodes RFC-2047 encoded header strings."""
+
+    def test_plain_ascii_passthrough(self):
+        """Plain ASCII value is returned unchanged."""
+        assert _decode_header_value("Hello World") == "Hello World"
+
+    def test_none_returns_empty_string(self):
+        """None input returns empty string."""
+        assert _decode_header_value(None) == ""
+
+    def test_empty_string_returns_empty_string(self):
+        """Empty string returns empty string."""
+        assert _decode_header_value("") == ""
+
+    def test_rfc2047_encoded_utf8_decoded(self):
+        """RFC-2047 encoded header is decoded to plain text."""
+        # Build an encoded header via the standard library
+        import email.header
+
+        encoded = email.header.make_header([(b"Caf\xc3\xa9", "utf-8")]).__str__()
+        # After encode/decode round-trip
+        result = _decode_header_value(encoded)
+        assert "Caf" in result  # At minimum the ASCII prefix is present
+
+    def test_strips_surrounding_whitespace(self):
+        """Result is stripped of leading/trailing whitespace."""
+        result = _decode_header_value("  trimmed  ")
+        assert result == "trimmed"
+
+
+# ---------------------------------------------------------------------------
+# EmailOutputHandler.react()
+# ---------------------------------------------------------------------------
+
+
+class TestEmailOutputHandlerReact:
+    """react() is a documented no-op — email has no emoji reactions."""
+
+    @pytest.mark.asyncio
+    async def test_react_is_noop_no_exception(self):
+        """react() completes without raising any exception."""
+        handler = EmailOutputHandler(smtp_config=None)
+        # Should not raise
+        await handler.react(chat_id="someone@example.com", msg_id=0, emoji="👍")
+
+    @pytest.mark.asyncio
+    async def test_react_with_none_emoji_is_noop(self):
+        """react() with None emoji also completes silently."""
+        handler = EmailOutputHandler(smtp_config=None)
+        await handler.react(chat_id="someone@example.com", msg_id=0, emoji=None)
+
+
+# ---------------------------------------------------------------------------
+# EmailOutputHandler.send()
+# ---------------------------------------------------------------------------
+
+
+class TestEmailOutputHandlerSend:
+    """send() composes and dispatches SMTP replies."""
+
+    def _make_smtp_config(self) -> dict:
+        return {
+            "host": "smtp.example.com",
+            "user": "valor@example.com",
+            "password": "secret",
+            "port": 587,
+            "use_tls": False,
+        }
+
+    @pytest.mark.asyncio
+    async def test_send_empty_text_does_nothing(self):
+        """send() with empty text returns immediately without calling _send_smtp."""
+        handler = EmailOutputHandler(smtp_config=self._make_smtp_config())
+
+        with patch.object(handler, "_send_smtp") as mock_smtp:
+            await handler.send(
+                chat_id="recipient@example.com",
+                text="",
+                reply_to_msg_id=0,
+                session=None,
+            )
+            mock_smtp.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_calls_send_smtp_with_nonempty_text(self):
+        """send() with non-empty text invokes _send_smtp via asyncio.to_thread."""
+        handler = EmailOutputHandler(smtp_config=self._make_smtp_config())
+
+        with patch("bridge.email_bridge.asyncio.to_thread", new_callable=AsyncMock) as mock_thread:
+            mock_thread.return_value = None
+            await handler.send(
+                chat_id="recipient@example.com",
+                text="Hello from agent!",
+                reply_to_msg_id=0,
+                session=None,
+            )
+            mock_thread.assert_called_once()
+            # First arg to asyncio.to_thread should be handler._send_smtp
+            # Use __func__ comparison because bound method objects are re-created each access
+            first_arg = mock_thread.call_args[0][0]
+            assert first_arg.__func__ is EmailOutputHandler._send_smtp
+
+    @pytest.mark.asyncio
+    async def test_send_uses_email_message_id_from_session_context(self):
+        """In-Reply-To header is set from session.extra_context['email_message_id']."""
+        handler = EmailOutputHandler(smtp_config=self._make_smtp_config())
+
+        session = MagicMock()
+        session.extra_context = {
+            "email_message_id": "<original-msg@example.com>",
+            "email_subject": "Test Subject",
+        }
+        session.session_id = "email_proj_user_12345"
+
+        captured_mime = {}
+
+        async def fake_to_thread(fn, recipient, mime_msg):
+            captured_mime["msg"] = mime_msg
+
+        with patch("bridge.email_bridge.asyncio.to_thread", side_effect=fake_to_thread):
+            await handler.send(
+                chat_id="recipient@example.com",
+                text="Reply text",
+                reply_to_msg_id=0,
+                session=session,
+            )
+
+        assert "msg" in captured_mime
+        assert captured_mime["msg"]["In-Reply-To"] == "<original-msg@example.com>"
+
+    @pytest.mark.asyncio
+    async def test_send_builds_re_subject(self):
+        """Subject is prefixed with 'Re: ' when not already prefixed."""
+        handler = EmailOutputHandler(smtp_config=self._make_smtp_config())
+
+        session = MagicMock()
+        session.extra_context = {
+            "email_message_id": "",
+            "email_subject": "Original Subject",
+        }
+        session.session_id = "test-session"
+
+        captured_mime = {}
+
+        async def fake_to_thread(fn, recipient, mime_msg):
+            captured_mime["msg"] = mime_msg
+
+        with patch("bridge.email_bridge.asyncio.to_thread", side_effect=fake_to_thread):
+            await handler.send(
+                chat_id="recipient@example.com",
+                text="Agent reply",
+                reply_to_msg_id=0,
+                session=session,
+            )
+
+        assert "msg" in captured_mime
+        subject = captured_mime["msg"]["Subject"]
+        assert subject.startswith("Re:")
+
+    @pytest.mark.asyncio
+    async def test_send_no_smtp_config_raises_in_send_smtp(self):
+        """_send_smtp raises RuntimeError when no SMTP config present."""
+        handler = EmailOutputHandler(smtp_config=None)
+        with pytest.raises(RuntimeError, match="SMTP not configured"):
+            handler._send_smtp("recipient@example.com", MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_send_writes_dead_letter_after_all_retries_fail(self):
+        """After SMTP_MAX_RETRIES failures, dead letter queue is written."""
+        handler = EmailOutputHandler(smtp_config=self._make_smtp_config())
+
+        session = MagicMock()
+        session.extra_context = {"email_message_id": "", "email_subject": ""}
+        session.session_id = "test-session-dl"
+
+        # Make all SMTP attempts fail
+        with patch(
+            "bridge.email_bridge.asyncio.to_thread",
+            new_callable=AsyncMock,
+            side_effect=ConnectionRefusedError("SMTP refused"),
+        ):
+            with patch("bridge.email_bridge.asyncio.sleep", new_callable=AsyncMock):
+                with patch(
+                    "bridge.email_dead_letter.write_dead_letter", new_callable=MagicMock
+                ) as mock_dl:
+                    await handler.send(
+                        chat_id="recipient@example.com",
+                        text="Will fail",
+                        reply_to_msg_id=0,
+                        session=session,
+                    )
+
+        mock_dl.assert_called_once()
+        call_kwargs = mock_dl.call_args.kwargs
+        assert call_kwargs["session_id"] == "test-session-dl"
+        assert call_kwargs["recipient"] == "recipient@example.com"

--- a/tests/unit/test_email_routing.py
+++ b/tests/unit/test_email_routing.py
@@ -1,0 +1,236 @@
+"""Unit tests for email routing helpers in bridge.routing.
+
+Tests build_email_to_project_map() and find_project_for_email() using
+monkeypatching to control module-level globals (ACTIVE_PROJECTS, EMAIL_TO_PROJECT).
+"""
+
+import logging
+
+import pytest
+
+import bridge.routing as routing_module
+from bridge.routing import build_email_to_project_map, find_project_for_email
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(*projects: dict) -> dict:
+    """Build a minimal config dict with the given project entries."""
+    projects_dict = {}
+    for proj in projects:
+        key = proj["_key"]
+        entry = {k: v for k, v in proj.items() if k != "_key"}
+        projects_dict[key] = entry
+    return {"projects": projects_dict, "defaults": {}}
+
+
+# ---------------------------------------------------------------------------
+# Tests for find_project_for_email()
+# ---------------------------------------------------------------------------
+
+
+class TestFindProjectForEmail:
+    """find_project_for_email() does exact-match lookup in EMAIL_TO_PROJECT."""
+
+    @pytest.fixture(autouse=True)
+    def seed_email_map(self, monkeypatch):
+        """Populate EMAIL_TO_PROJECT with a known contact before each test."""
+        project = {
+            "_key": "acme",
+            "name": "ACME Corp",
+            "email": {
+                "contacts": {
+                    "alice@example.com": {"name": "Alice"},
+                }
+            },
+        }
+        monkeypatch.setattr(
+            routing_module,
+            "EMAIL_TO_PROJECT",
+            {"alice@example.com": project},
+        )
+
+    def test_known_address_returns_project(self):
+        """Exact-match address returns the mapped project dict."""
+        result = find_project_for_email("alice@example.com")
+        assert result is not None
+        assert result["name"] == "ACME Corp"
+
+    def test_case_insensitive_lookup(self):
+        """Lookup is case-insensitive — uppercase returns same project."""
+        result = find_project_for_email("ALICE@EXAMPLE.COM")
+        assert result is not None
+        assert result["name"] == "ACME Corp"
+
+    def test_mixed_case_lookup(self):
+        """Mixed-case address also resolves correctly."""
+        result = find_project_for_email("Alice@Example.Com")
+        assert result is not None
+
+    def test_unknown_address_returns_none(self):
+        """Address not in map returns None."""
+        result = find_project_for_email("unknown@example.com")
+        assert result is None
+
+    def test_none_sender_returns_none(self):
+        """None input returns None without error."""
+        result = find_project_for_email(None)
+        assert result is None
+
+    def test_empty_string_returns_none(self):
+        """Empty string returns None."""
+        result = find_project_for_email("")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Tests for build_email_to_project_map()
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEmailToProjectMap:
+    """build_email_to_project_map() reads email.contacts from active projects."""
+
+    @pytest.fixture(autouse=True)
+    def set_active_projects(self, monkeypatch):
+        """Set ACTIVE_PROJECTS to control which projects are processed."""
+        monkeypatch.setattr(routing_module, "ACTIVE_PROJECTS", ["acme", "beta"])
+
+    def test_builds_map_for_active_projects(self):
+        """Known contacts for active projects are mapped."""
+        config = _make_config(
+            {
+                "_key": "acme",
+                "name": "ACME Corp",
+                "email": {
+                    "contacts": {
+                        "alice@example.com": {"name": "Alice"},
+                        "bob@example.com": {"name": "Bob"},
+                    }
+                },
+            },
+        )
+        result = build_email_to_project_map(config)
+        assert "alice@example.com" in result
+        assert "bob@example.com" in result
+        assert result["alice@example.com"]["name"] == "ACME Corp"
+
+    def test_addresses_lowercased_in_map(self):
+        """Map keys are always lowercase regardless of config casing."""
+        config = _make_config(
+            {
+                "_key": "acme",
+                "name": "ACME Corp",
+                "email": {
+                    "contacts": {
+                        "Alice@EXAMPLE.COM": {"name": "Alice"},
+                    }
+                },
+            },
+        )
+        result = build_email_to_project_map(config)
+        assert "alice@example.com" in result
+        assert "Alice@EXAMPLE.COM" not in result
+
+    def test_inactive_projects_excluded(self, monkeypatch):
+        """Projects not in ACTIVE_PROJECTS are skipped."""
+        monkeypatch.setattr(routing_module, "ACTIVE_PROJECTS", ["acme"])
+        config = _make_config(
+            {
+                "_key": "acme",
+                "name": "ACME Corp",
+                "email": {"contacts": {"alice@example.com": {}}},
+            },
+            {
+                "_key": "beta",
+                "name": "Beta Project",
+                "email": {"contacts": {"charlie@example.com": {}}},
+            },
+        )
+        result = build_email_to_project_map(config)
+        assert "alice@example.com" in result
+        assert "charlie@example.com" not in result
+
+    def test_project_key_set_on_result_project(self):
+        """build_email_to_project_map() sets '_key' on each project dict."""
+        config = _make_config(
+            {
+                "_key": "acme",
+                "name": "ACME Corp",
+                "email": {"contacts": {"alice@example.com": {}}},
+            },
+        )
+        result = build_email_to_project_map(config)
+        assert result["alice@example.com"]["_key"] == "acme"
+
+    def test_project_with_no_email_config_produces_no_entries(self):
+        """Project without email.contacts produces no map entries."""
+        config = _make_config(
+            {
+                "_key": "acme",
+                "name": "ACME Corp",
+                # No 'email' key
+            },
+        )
+        result = build_email_to_project_map(config)
+        assert len(result) == 0
+
+    def test_project_with_empty_contacts_produces_no_entries(self):
+        """Project with contacts={} produces no map entries."""
+        config = _make_config(
+            {
+                "_key": "acme",
+                "name": "ACME Corp",
+                "email": {"contacts": {}},
+            },
+        )
+        result = build_email_to_project_map(config)
+        assert len(result) == 0
+
+    def test_duplicate_email_address_warns_and_uses_first(self, caplog):
+        """Duplicate address across two active projects: first wins, warning logged."""
+        config = _make_config(
+            {
+                "_key": "acme",
+                "name": "ACME Corp",
+                "email": {"contacts": {"shared@example.com": {}}},
+            },
+            {
+                "_key": "beta",
+                "name": "Beta Project",
+                "email": {"contacts": {"shared@example.com": {}}},
+            },
+        )
+        with caplog.at_level(logging.WARNING, logger="bridge.routing"):
+            result = build_email_to_project_map(config)
+
+        # First project wins
+        assert result["shared@example.com"]["name"] in ("ACME Corp", "Beta Project")
+        # A warning must have been emitted
+        assert any("multiple projects" in msg.lower() for msg in caplog.messages)
+
+    def test_multiple_projects_multiple_contacts(self):
+        """Multiple active projects each contribute their own contacts."""
+        config = _make_config(
+            {
+                "_key": "acme",
+                "name": "ACME Corp",
+                "email": {"contacts": {"alice@example.com": {}}},
+            },
+            {
+                "_key": "beta",
+                "name": "Beta Project",
+                "email": {"contacts": {"charlie@example.com": {}}},
+            },
+        )
+        result = build_email_to_project_map(config)
+        assert len(result) == 2
+        assert result["alice@example.com"]["_key"] == "acme"
+        assert result["charlie@example.com"]["_key"] == "beta"
+
+    def test_returns_empty_dict_for_empty_config(self):
+        """Empty config produces empty map without errors."""
+        result = build_email_to_project_map({"projects": {}, "defaults": {}})
+        assert result == {}

--- a/tests/unit/test_transport_keyed_callbacks.py
+++ b/tests/unit/test_transport_keyed_callbacks.py
@@ -1,0 +1,210 @@
+"""Unit tests for transport-keyed callback registration and resolution.
+
+Tests the multi-transport callback system in agent.agent_session_queue where
+callbacks can be stored under plain project_key strings (backward compat) or
+under (project_key, transport) composite keys for per-transport routing.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+import agent.agent_session_queue as queue_module
+from agent.agent_session_queue import _resolve_callbacks, register_callbacks
+
+
+def _make_handler():
+    """Create a minimal OutputHandler-like mock with async send and react."""
+    handler = AsyncMock()
+    handler.send = AsyncMock()
+    handler.react = AsyncMock()
+    return handler
+
+
+@pytest.fixture(autouse=True)
+def clear_callback_dicts():
+    """Reset the module-level callback dicts before each test."""
+    queue_module._send_callbacks.clear()
+    queue_module._reaction_callbacks.clear()
+    queue_module._response_callbacks.clear()
+    yield
+    queue_module._send_callbacks.clear()
+    queue_module._reaction_callbacks.clear()
+    queue_module._response_callbacks.clear()
+
+
+class TestPlainKeyRegistration:
+    """register_callbacks with no transport stores under plain string key."""
+
+    def test_plain_key_stored_and_resolved_without_transport(self):
+        """Plain key handler is resolved when no transport is given."""
+        handler = _make_handler()
+        register_callbacks("myproject", handler=handler)
+
+        send_cb, react_cb = _resolve_callbacks("myproject", None)
+        assert send_cb is handler.send
+        assert react_cb is handler.react
+
+    def test_plain_key_resolved_when_transport_given_but_no_composite_key(self):
+        """Plain key falls back when transport is given but no composite key exists."""
+        handler = _make_handler()
+        register_callbacks("myproject", handler=handler)
+
+        # Transport "telegram" requested but only plain key registered — should fall back
+        send_cb, react_cb = _resolve_callbacks("myproject", "telegram")
+        assert send_cb is handler.send
+        assert react_cb is handler.react
+
+    def test_plain_key_stored_under_string_not_tuple(self):
+        """Verify the internal dict key is a plain string, not a tuple."""
+        handler = _make_handler()
+        register_callbacks("myproject", handler=handler)
+
+        assert "myproject" in queue_module._send_callbacks
+        assert ("myproject", None) not in queue_module._send_callbacks
+
+
+class TestCompositeKeyRegistration:
+    """register_callbacks with transport stores under (project_key, transport) key."""
+
+    def test_email_transport_stored_under_composite_key(self):
+        """Email handler stored under ('project', 'email') composite key."""
+        handler = _make_handler()
+        register_callbacks("myproject", transport="email", handler=handler)
+
+        assert ("myproject", "email") in queue_module._send_callbacks
+        assert "myproject" not in queue_module._send_callbacks
+
+    def test_email_transport_resolved_correctly(self):
+        """Email-keyed handler is returned when email transport is requested."""
+        handler = _make_handler()
+        register_callbacks("myproject", transport="email", handler=handler)
+
+        send_cb, react_cb = _resolve_callbacks("myproject", "email")
+        assert send_cb is handler.send
+        assert react_cb is handler.react
+
+
+class TestDualTransportResolution:
+    """Both Telegram and email handlers registered for same project."""
+
+    def test_telegram_transport_gets_telegram_handler(self):
+        """_resolve_callbacks returns Telegram handler when transport='telegram'."""
+        tg_handler = _make_handler()
+        email_handler = _make_handler()
+
+        register_callbacks("proj", transport="telegram", handler=tg_handler)
+        register_callbacks("proj", transport="email", handler=email_handler)
+
+        send_cb, react_cb = _resolve_callbacks("proj", "telegram")
+        assert send_cb is tg_handler.send
+        assert react_cb is tg_handler.react
+
+    def test_email_transport_gets_email_handler(self):
+        """_resolve_callbacks returns email handler when transport='email'."""
+        tg_handler = _make_handler()
+        email_handler = _make_handler()
+
+        register_callbacks("proj", transport="telegram", handler=tg_handler)
+        register_callbacks("proj", transport="email", handler=email_handler)
+
+        send_cb, react_cb = _resolve_callbacks("proj", "email")
+        assert send_cb is email_handler.send
+        assert react_cb is email_handler.react
+
+    def test_both_keys_stored_independently(self):
+        """Registering two transports creates two independent dict entries."""
+        tg_handler = _make_handler()
+        email_handler = _make_handler()
+
+        register_callbacks("proj", transport="telegram", handler=tg_handler)
+        register_callbacks("proj", transport="email", handler=email_handler)
+
+        assert ("proj", "telegram") in queue_module._send_callbacks
+        assert ("proj", "email") in queue_module._send_callbacks
+        assert "proj" not in queue_module._send_callbacks
+
+
+class TestUnknownProjectFallback:
+    """Unregistered projects return (None, None) from _resolve_callbacks."""
+
+    def test_unknown_project_no_transport_returns_none(self):
+        """Completely unknown project returns (None, None)."""
+        send_cb, react_cb = _resolve_callbacks("nonexistent", None)
+        assert send_cb is None
+        assert react_cb is None
+
+    def test_unknown_project_with_transport_returns_none(self):
+        """Unknown project with transport also returns (None, None)."""
+        send_cb, react_cb = _resolve_callbacks("nonexistent", "email")
+        assert send_cb is None
+        assert react_cb is None
+
+
+class TestCompositeKeyFallbackToPlain:
+    """Composite key missing → falls back to plain key handler."""
+
+    def test_plain_key_fallback_when_composite_key_not_registered(self):
+        """Project has plain key only; requesting 'email' transport falls back to plain."""
+        handler = _make_handler()
+        register_callbacks("proj", handler=handler)
+
+        # No email composite key — should fall back to plain "proj" handler
+        send_cb, react_cb = _resolve_callbacks("proj", "email")
+        assert send_cb is handler.send
+        assert react_cb is handler.react
+
+    def test_plain_key_fallback_does_not_affect_registered_composite_keys(self):
+        """Email composite key overrides plain when both registered."""
+        plain_handler = _make_handler()
+        email_handler = _make_handler()
+
+        register_callbacks("proj", handler=plain_handler)
+        register_callbacks("proj", transport="email", handler=email_handler)
+
+        # email transport → composite key wins
+        send_cb, react_cb = _resolve_callbacks("proj", "email")
+        assert send_cb is email_handler.send
+
+        # no transport → plain key
+        send_cb_plain, react_cb_plain = _resolve_callbacks("proj", None)
+        assert send_cb_plain is plain_handler.send
+
+
+class TestRawCallbackRegistration:
+    """register_callbacks also accepts raw callables without a handler."""
+
+    def test_raw_send_and_react_callbacks_stored(self):
+        """Passing send_callback and reaction_callback directly works."""
+        send_fn = AsyncMock()
+        react_fn = AsyncMock()
+
+        register_callbacks("proj", send_callback=send_fn, reaction_callback=react_fn)
+
+        send_cb, react_cb = _resolve_callbacks("proj", None)
+        assert send_cb is send_fn
+        assert react_cb is react_fn
+
+    def test_raw_callbacks_with_transport(self):
+        """Raw callbacks with transport stored under composite key."""
+        send_fn = AsyncMock()
+        react_fn = AsyncMock()
+
+        register_callbacks(
+            "proj",
+            send_callback=send_fn,
+            reaction_callback=react_fn,
+            transport="telegram",
+        )
+
+        send_cb, react_cb = _resolve_callbacks("proj", "telegram")
+        assert send_cb is send_fn
+        assert react_cb is react_fn
+
+    def test_missing_send_callback_without_handler_raises(self):
+        """register_callbacks without handler and without send_callback raises ValueError."""
+        with pytest.raises(ValueError, match="send_callback"):
+            register_callbacks(
+                "proj",
+                reaction_callback=AsyncMock(),
+            )

--- a/worker/__main__.py
+++ b/worker/__main__.py
@@ -150,6 +150,9 @@ async def _run_worker(projects: dict, dry_run: bool = False) -> None:
     logger.info(f"Global session semaphore initialized: MAX_CONCURRENT_SESSIONS={_max_sessions}")
 
     handler = TelegramRelayOutputHandler(file_handler=FileOutputHandler())
+    from bridge.email_bridge import EmailOutputHandler as _EmailOutputHandler
+
+    email_handler = _EmailOutputHandler()
 
     # Verify Redis is reachable by attempting to list sessions
     try:
@@ -194,6 +197,13 @@ async def _run_worker(projects: dict, dry_run: bool = False) -> None:
     for project_key in projects:
         register_callbacks(project_key, handler=handler)
         logger.info(f"[{project_key}] Registered TelegramRelayOutputHandler")
+
+    # Register EmailOutputHandler for projects with email contacts config
+    for project_key, project_cfg in projects.items():
+        email_contacts = project_cfg.get("email", {}).get("contacts", {})
+        if email_contacts:
+            register_callbacks(project_key, transport="email", handler=email_handler)
+            logger.info(f"[{project_key}] Registered EmailOutputHandler (transport=email)")
 
     # Step 1: Rebuild indexes for ALL Popoto models (SCAN-based, production-safe)
     # Cleans up stale/orphaned index entries across all models, not just AgentSession


### PR DESCRIPTION
## Summary

- Adds `bridge/email_bridge.py` — IMAP polling loop, email parsing, `EmailOutputHandler` implementing the `OutputHandler` protocol. SMTP replies use `In-Reply-To` threading. Health monitoring via `email:last_poll_ts` Redis key.
- Adds `bridge/email_dead_letter.py` — dead letter queue for failed SMTP sends (`email:dead_letter:{session_id}`), with list/replay CLI.
- Extends `bridge/routing.py` with `find_project_for_email()`, `build_email_to_project_map()`, and `EMAIL_TO_PROJECT` global.
- Extends `agent/agent_session_queue.py` with transport-keyed callbacks (`register_callbacks(transport=...)`, `_resolve_callbacks()`), and `extra_context_overrides` on `enqueue_agent_session()`.
- Updates `worker/__main__.py` to register `EmailOutputHandler` for projects with email contacts.
- Adds `email-start/stop/restart/status/dead-letter` commands to `scripts/valor-service.sh`.
- Updates `.env.example` with IMAP/SMTP credential docs (Gmail App Password setup).
- Updates `config/projects.example.json` with `email.contacts` section schema.
- Creates `docs/features/email-bridge.md` and updates `README.md` + `deployment.md`.
- 58 unit tests across 3 new test files (all passing).

Closes #847.

## Test plan

- [ ] `pytest tests/unit/test_email_bridge.py tests/unit/test_email_routing.py tests/unit/test_transport_keyed_callbacks.py` — 58 tests, all green
- [ ] `ruff check` and `ruff format --check` — clean
- [ ] Import smoke: `python -c "from bridge.email_bridge import EmailOutputHandler; from bridge.routing import find_project_for_email"`
- [ ] Backward compat: existing Telegram unit tests pass unchanged (transport-keyed callback fallback preserves behavior)
- [ ] Manual: `./scripts/valor-service.sh email-status` reflects Redis poll timestamp
- [ ] Manual: `./scripts/valor-service.sh email-dead-letter list` lists empty queue

## Design decisions

- **stdlib only** — `imaplib`, `smtplib`, `email` — no new dependencies
- **`telegram_message_id=0` sentinel** — email sessions pass `0` as required `int`; `EmailOutputHandler.send()` ignores it and uses `In-Reply-To` from `extra_context`
- **Transport stored in `extra_context["transport"]`** — allows existing serialization paths to carry transport metadata without schema changes
- **Backward-compatible callbacks** — `_resolve_callbacks()` tries `(project_key, transport)` composite key first, falls back to plain `project_key` string key