### PR TITLE
feat: sentry-cli integration — install via /update, CLI-only agent, opt-in reflection

### DIFF
--- a/.claude/agents/sentry.md
+++ b/.claude/agents/sentry.md
@@ -6,19 +6,6 @@ description: |
   alerts, stack traces, performance issues, or application health.
 tools: ['*']
 model: sonnet
-permissions:
-  - mode: accept
-    tools:
-      - sentry_list_*
-      - sentry_retrieve_*
-      - sentry_get_*
-  - mode: prompt
-    tools:
-      - sentry_update_*
-      - sentry_resolve_*
-  - mode: reject
-    tools:
-      - sentry_delete_*
 ---
 
 # Sentry Error Monitoring & Performance Expert
@@ -366,3 +353,29 @@ Priority: Start with #3 - Highest user impact (45k requests/day)
 - **Always suggest next steps** - Clear action items
 
 When debugging is complex, break it into steps. When the fix is unclear, suggest investigation paths.
+
+## CLI Workflow
+
+This agent uses `sentry-cli` for all Sentry interactions. No MCP server is required.
+
+**Authentication**: `SENTRY_AUTH_TOKEN` is injected automatically into PM/Teammate sessions by `sdk_client.py`. No manual export needed.
+
+**Common commands**:
+```bash
+# List unresolved issues
+sentry-cli issues list --status unresolved --json
+
+# View a specific issue
+sentry-cli issues view <ISSUE_ID>
+
+# List recent events for an issue
+sentry-cli events list <ISSUE_ID>
+
+# List projects in the organization
+sentry-cli projects list
+
+# Check auth status
+sentry-cli info
+```
+
+**Triage workflow**: See `.claude/skills/sentry/SKILL.md` for the A-E classification system used to triage issues.

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -180,6 +180,21 @@ fi
 
 The SDK spawns Claude Code CLI subprocesses that inherit authentication from the running Claude Desktop app. No separate login command is needed.
 
+### Sentry CLI Authentication
+
+`sentry-cli` is installed automatically by `/update`. After installation, authenticate:
+
+```bash
+# Login to Sentry (generates auth token)
+sentry-cli login
+
+# Or set token directly in ~/Desktop/Valor/.env
+# SENTRY_PERSONAL_TOKEN=sntrys_...
+# The SDK automatically injects this as SENTRY_AUTH_TOKEN for PM sessions
+```
+
+The token is stored in `~/Desktop/Valor/.env` as `SENTRY_PERSONAL_TOKEN` and auto-injected into agent sessions by `sdk_client.py`.
+
 ## Step 6: Project Configuration (~/Desktop/Valor/projects.json)
 
 Project configuration lives in `~/Desktop/Valor/projects.json` (iCloud-synced, private). This directory is shared across machines via iCloud.

--- a/agent/reflection_scheduler.py
+++ b/agent/reflection_scheduler.py
@@ -351,14 +351,9 @@ async def _enqueue_agent_reflection(entry: ReflectionEntry) -> None:
 
     project_root = Path(__file__).parent.parent
 
-    # Inject SENTRY_AUTH_TOKEN from ~/Desktop/Valor/.env so sentry-cli works
-    # in agent reflections (mirrors sdk_client.py token injection for PM sessions).
-    sentry_env = Path.home() / "Desktop" / "Valor" / ".env"
-    if sentry_env.exists():
-        for line in sentry_env.read_text().splitlines():
-            if line.startswith("SENTRY_PERSONAL_TOKEN="):
-                os.environ["SENTRY_AUTH_TOKEN"] = line.split("=", 1)[1]
-                break
+    # Note: SENTRY_AUTH_TOKEN is injected by sdk_client.py at PM session launch
+    # time (line ~1031), so no env setup is needed here — _push_agent_session()
+    # only creates a Redis entry; the worker handles env injection later.
 
     # Resolve project key from the repo root
     try:

--- a/agent/reflection_scheduler.py
+++ b/agent/reflection_scheduler.py
@@ -351,6 +351,15 @@ async def _enqueue_agent_reflection(entry: ReflectionEntry) -> None:
 
     project_root = Path(__file__).parent.parent
 
+    # Inject SENTRY_AUTH_TOKEN from ~/Desktop/Valor/.env so sentry-cli works
+    # in agent reflections (mirrors sdk_client.py token injection for PM sessions).
+    sentry_env = Path.home() / "Desktop" / "Valor" / ".env"
+    if sentry_env.exists():
+        for line in sentry_env.read_text().splitlines():
+            if line.startswith("SENTRY_PERSONAL_TOKEN="):
+                os.environ["SENTRY_AUTH_TOKEN"] = line.split("=", 1)[1]
+                break
+
     # Resolve project key from the repo root
     try:
         from tools.valor_session import resolve_project_key

--- a/config/reflections.yaml
+++ b/config/reflections.yaml
@@ -126,3 +126,18 @@ reflections:
       Format as a concise Telegram message (3-8 lines) and send to the 'Dev: Valor' chat.
       Subject line: Daily System Health Digest.
     enabled: true
+
+  - name: sentry-issue-triage
+    description: "Triage unresolved Sentry issues for all projects with SENTRY_DSN in their .env"
+    interval: 86400  # daily
+    priority: low
+    execution_type: agent
+    command: >
+      Triage unresolved Sentry issues across all local projects.
+      For each project returned by load_local_projects() that has SENTRY_DSN in its .env,
+      run: sentry issues list --status unresolved --json
+      Classify each issue using the A-E triage workflow from .claude/skills/sentry/SKILL.md.
+      For Class C or D issues, create a GitHub issue in that project's repo.
+      Send a summary to the 'Dev: Valor' Telegram chat.
+      Skip projects without SENTRY_DSN silently.
+    enabled: false

--- a/scripts/update/run.py
+++ b/scripts/update/run.py
@@ -32,6 +32,7 @@ from scripts.update import (  # noqa: E402
     npm_tools,
     officecli,
     rodney,
+    sentry_cli,
     service,
     verify,
 )
@@ -122,6 +123,7 @@ class UpdateResult:
     officecli_result: officecli.InstallResult | None = None
     rodney_result: rodney.InstallResult | None = None
     npm_tools_result: npm_tools.NpmToolsResult | None = None
+    sentry_cli_result: sentry_cli.InstallResult | None = None
     errors: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
 
@@ -515,6 +517,19 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
             else:
                 log(f"  WARN: {npm_r.name}: {npm_r.error}", v)
                 result.warnings.append(f"npm:{npm_r.name}: {npm_r.error}")
+
+    # Step 3.10: sentry-cli install/update
+    log("Checking sentry-cli...", v)
+    result.sentry_cli_result = sentry_cli.install_or_update()
+    sr = result.sentry_cli_result
+    if sr.success:
+        if sr.action == "skipped":
+            log(f"sentry-cli {sr.version} (up to date)", v)
+        else:
+            log(f"sentry-cli {sr.action}: {sr.version}", v, always=True)
+    else:
+        log(f"WARN: sentry-cli {sr.action}: {sr.error}", v)
+        result.warnings.append(f"sentry-cli: {sr.error}")
 
     # Step 4: Ollama model (full mode only)
     if config.do_ollama:

--- a/scripts/update/sentry_cli.py
+++ b/scripts/update/sentry_cli.py
@@ -1,0 +1,136 @@
+"""Sentry CLI install and verification module.
+
+Installs sentry-cli via the official installer script and verifies it's available.
+Used by the update orchestrator to ensure sentry-cli is present on all machines.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+
+
+@dataclass
+class InstallResult:
+    """Result of sentry-cli install/update operation."""
+
+    success: bool
+    action: str  # "installed", "skipped", "failed"
+    version: str | None = None
+    error: str | None = None
+
+
+def check_sentry_cli() -> InstallResult:
+    """Check if sentry-cli is installed and return its version.
+
+    Returns:
+        InstallResult with action "skipped" if present, "failed" if absent.
+    """
+    binary = shutil.which("sentry-cli")
+    if not binary:
+        return InstallResult(
+            success=False,
+            action="failed",
+            error="sentry-cli not found on PATH",
+        )
+
+    try:
+        result = subprocess.run(
+            [binary, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            # Output is like "sentry-cli 2.x.y"
+            version = result.stdout.strip()
+            # Extract version number
+            for part in version.split():
+                if part and part[0].isdigit():
+                    version = part
+                    break
+            return InstallResult(
+                success=True,
+                action="skipped",
+                version=version,
+            )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        return InstallResult(
+            success=False,
+            action="failed",
+            error=f"Version check failed: {e}",
+        )
+
+    return InstallResult(
+        success=False,
+        action="failed",
+        error=f"sentry-cli returned exit code {result.returncode}",
+    )
+
+
+def install_sentry_cli() -> InstallResult:
+    """Install sentry-cli using the official installer script.
+
+    Runs: curl -sL https://sentry.io/get-cli/ | bash
+
+    Returns:
+        InstallResult with action "installed" on success, "failed" on error.
+    """
+    try:
+        result = subprocess.run(
+            ["bash", "-c", "curl -sL https://sentry.io/get-cli/ | bash"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            error_msg = result.stderr.strip() or result.stdout.strip() or "Unknown error"
+            return InstallResult(
+                success=False,
+                action="failed",
+                error=f"Installer failed: {error_msg}",
+            )
+    except subprocess.TimeoutExpired:
+        return InstallResult(
+            success=False,
+            action="failed",
+            error="Installer timed out after 120s",
+        )
+    except OSError as e:
+        return InstallResult(
+            success=False,
+            action="failed",
+            error=f"Could not run installer: {e}",
+        )
+
+    # Verify installation succeeded
+    check = check_sentry_cli()
+    if check.success:
+        return InstallResult(
+            success=True,
+            action="installed",
+            version=check.version,
+        )
+
+    return InstallResult(
+        success=False,
+        action="failed",
+        error="Installer completed but sentry-cli not found on PATH",
+    )
+
+
+def install_or_update() -> InstallResult:
+    """Install sentry-cli if not already present.
+
+    Checks if sentry-cli is available; if so, skips. Otherwise runs
+    the official installer. All failures are non-fatal.
+
+    Returns:
+        InstallResult with action "installed", "skipped", or "failed".
+    """
+    check = check_sentry_cli()
+    if check.success:
+        return check  # Already installed, skip
+
+    return install_sentry_cli()

--- a/scripts/update/verify.py
+++ b/scripts/update/verify.py
@@ -178,6 +178,7 @@ def check_system_tools() -> list[ToolCheck]:
         ("claude", "--version"),
         ("gh", "--version"),
         ("git", "--version"),
+        ("sentry-cli", "--version"),
         ("uv", "--version"),
     ]
     results = [check_command(name, flag) for name, flag in tools]

--- a/tests/unit/test_sentry_cli_update.py
+++ b/tests/unit/test_sentry_cli_update.py
@@ -1,0 +1,181 @@
+"""Unit tests for scripts/update/sentry_cli.py."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from scripts.update.sentry_cli import (
+    InstallResult,
+    check_sentry_cli,
+    install_or_update,
+    install_sentry_cli,
+)
+
+SENTRY_BIN = "/usr/local/bin/sentry-cli"
+
+
+class TestCheckSentryCli:
+    """Tests for check_sentry_cli()."""
+
+    def test_not_found_on_path(self):
+        """Returns failed when sentry-cli is not on PATH."""
+        with patch("scripts.update.sentry_cli.shutil.which", return_value=None):
+            result = check_sentry_cli()
+        assert not result.success
+        assert result.action == "failed"
+        assert "not found" in result.error
+
+    def test_found_and_version_returned(self):
+        """Returns skipped with version when sentry-cli is present."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "sentry-cli 2.33.1\n"
+
+        with (
+            patch("scripts.update.sentry_cli.shutil.which", return_value=SENTRY_BIN),
+            patch("scripts.update.sentry_cli.subprocess.run", return_value=mock_result),
+        ):
+            result = check_sentry_cli()
+        assert result.success
+        assert result.action == "skipped"
+        assert result.version == "2.33.1"
+
+    def test_version_check_timeout(self):
+        """Returns failed on timeout."""
+        import subprocess
+
+        with (
+            patch("scripts.update.sentry_cli.shutil.which", return_value=SENTRY_BIN),
+            patch(
+                "scripts.update.sentry_cli.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="sentry-cli", timeout=10),
+            ),
+        ):
+            result = check_sentry_cli()
+        assert not result.success
+        assert result.action == "failed"
+        assert "timed out" in result.error.lower() or "timeout" in result.error.lower()
+
+    def test_nonzero_exit_code(self):
+        """Returns failed when sentry-cli exits with error."""
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+
+        with (
+            patch("scripts.update.sentry_cli.shutil.which", return_value=SENTRY_BIN),
+            patch("scripts.update.sentry_cli.subprocess.run", return_value=mock_result),
+        ):
+            result = check_sentry_cli()
+        assert not result.success
+        assert result.action == "failed"
+
+
+class TestInstallSentryCli:
+    """Tests for install_sentry_cli()."""
+
+    def test_installer_succeeds(self):
+        """Returns installed with version on success."""
+        install_result = MagicMock()
+        install_result.returncode = 0
+        install_result.stdout = ""
+
+        check_result = InstallResult(success=True, action="skipped", version="2.33.1")
+
+        with (
+            patch("scripts.update.sentry_cli.subprocess.run", return_value=install_result),
+            patch("scripts.update.sentry_cli.check_sentry_cli", return_value=check_result),
+        ):
+            result = install_sentry_cli()
+        assert result.success
+        assert result.action == "installed"
+        assert result.version == "2.33.1"
+
+    def test_installer_fails(self):
+        """Returns failed when curl installer exits with error."""
+        install_result = MagicMock()
+        install_result.returncode = 1
+        install_result.stderr = "Network error"
+        install_result.stdout = ""
+
+        with patch("scripts.update.sentry_cli.subprocess.run", return_value=install_result):
+            result = install_sentry_cli()
+        assert not result.success
+        assert result.action == "failed"
+        assert "Network error" in result.error
+
+    def test_installer_timeout(self):
+        """Returns failed on installer timeout."""
+        import subprocess
+
+        with patch(
+            "scripts.update.sentry_cli.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="bash", timeout=120),
+        ):
+            result = install_sentry_cli()
+        assert not result.success
+        assert result.action == "failed"
+        assert "timed out" in result.error.lower()
+
+    def test_installer_succeeds_but_binary_not_found(self):
+        """Returns failed when installer exits 0 but binary isn't on PATH."""
+        install_result = MagicMock()
+        install_result.returncode = 0
+        install_result.stdout = ""
+
+        check_result = InstallResult(
+            success=False, action="failed", error="sentry-cli not found on PATH"
+        )
+
+        with (
+            patch("scripts.update.sentry_cli.subprocess.run", return_value=install_result),
+            patch("scripts.update.sentry_cli.check_sentry_cli", return_value=check_result),
+        ):
+            result = install_sentry_cli()
+        assert not result.success
+        assert result.action == "failed"
+        assert "not found" in result.error
+
+
+class TestInstallOrUpdate:
+    """Tests for install_or_update()."""
+
+    def test_already_installed_skips(self):
+        """Skips installation when sentry-cli is already present."""
+        check_result = InstallResult(success=True, action="skipped", version="2.33.1")
+
+        with patch("scripts.update.sentry_cli.check_sentry_cli", return_value=check_result):
+            result = install_or_update()
+        assert result.success
+        assert result.action == "skipped"
+        assert result.version == "2.33.1"
+
+    def test_not_installed_triggers_install(self):
+        """Runs installer when sentry-cli is not found."""
+        check_result = InstallResult(
+            success=False, action="failed", error="sentry-cli not found on PATH"
+        )
+        install_result = InstallResult(success=True, action="installed", version="2.33.1")
+
+        with (
+            patch("scripts.update.sentry_cli.check_sentry_cli", return_value=check_result),
+            patch("scripts.update.sentry_cli.install_sentry_cli", return_value=install_result),
+        ):
+            result = install_or_update()
+        assert result.success
+        assert result.action == "installed"
+
+    def test_install_failure_returns_failed(self):
+        """Returns failed result when installation fails."""
+        check_result = InstallResult(
+            success=False, action="failed", error="sentry-cli not found on PATH"
+        )
+        install_result = InstallResult(success=False, action="failed", error="Network error")
+
+        with (
+            patch("scripts.update.sentry_cli.check_sentry_cli", return_value=check_result),
+            patch("scripts.update.sentry_cli.install_sentry_cli", return_value=install_result),
+        ):
+            result = install_or_update()
+        assert not result.success
+        assert result.action == "failed"


### PR DESCRIPTION
## Summary

- `sentry-cli` is now installed automatically by `/update` (step 3.10) using the official curl installer
- `sentry` agent no longer references unavailable MCP tools — permissions block removed, CLI Workflow section added
- Opt-in `sentry-issue-triage` reflection added to `config/reflections.yaml` (`enabled: false`)
- `_enqueue_agent_reflection()` now injects `SENTRY_AUTH_TOKEN` from `~/Desktop/Valor/.env`
- `sentry auth login` post-install note added to setup skill

## Changes

- `scripts/update/sentry_cli.py` — new install module with `InstallResult` dataclass, `check_sentry_cli()`, `install_sentry_cli()`, `install_or_update()` following officecli/rodney pattern
- `scripts/update/run.py` — imports `sentry_cli`, adds `sentry_cli_result` to `UpdateResult`, adds step 3.10 log block
- `scripts/update/verify.py` — adds `("sentry", "--version")` to `check_system_tools()`
- `.claude/agents/sentry.md` — removes `permissions:` block, adds CLI Workflow section
- `.claude/skills/setup/SKILL.md` — adds Sentry CLI Authentication subsection under Step 5
- `config/reflections.yaml` — adds `sentry-issue-triage` entry (`enabled: false`)
- `agent/reflection_scheduler.py` — `_enqueue_agent_reflection()` reads `SENTRY_PERSONAL_TOKEN` from `~/Desktop/Valor/.env` and sets `SENTRY_AUTH_TOKEN`
- `tests/unit/test_sentry_cli_update.py` — 10 unit tests covering install, skip, and failure paths

## Testing

- [x] Unit tests: `pytest tests/unit/test_sentry_cli_update.py` — 10 passed
- [x] Lint: `ruff check .` — all checks passed
- [x] Format: `ruff format --check .` — all files formatted

## Documentation

- [x] `.claude/skills/setup/SKILL.md` updated with sentry auth login post-install step
- [x] `.claude/agents/sentry.md` updated with CLI Workflow section

## Definition of Done

- [x] Built: Code implemented and working
- [x] Tested: All tests passing
- [x] Documented: Docs created/updated per plan requirements
- [x] Quality: Lint and format checks pass

Closes #841