### PR TITLE
chore: consolidate secrets to ~/Desktop/Valor/.env as single source of truth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # Valor AI System Configuration
-# Copy this file to .env and fill in your actual values
+# Documents the contents of ~/Desktop/Valor/.env (the iCloud-synced secrets vault).
+# Do NOT copy this file to .env — the repo .env is a symlink to the vault.
+# To add a new secret: add it to ~/Desktop/Valor/.env, then document it here.
 
 # =============================================================================
 # SERVICE LABEL PREFIX (launchd)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,9 +360,17 @@ The bridge includes automatic crash recovery (see `docs/features/bridge-self-hea
 
 ### Configuration Files
 
-- `.env` - Environment variables and API keys
+- `.env` - Symlink → `~/Desktop/Valor/.env` (do not write secrets here directly)
 - `~/Desktop/Valor/projects.json` - Multi-project configuration (iCloud-synced, private)
 - `.claude/settings.local.json` - Claude Code settings
+
+## Secrets
+
+All secrets go in **`~/Desktop/Valor/.env`**. Never write secrets to `repo/.env`.
+
+The repo `.env` is a symlink — writing to it writes to the vault, but the canonical workflow is to edit `~/Desktop/Valor/.env` directly. The symlink is created automatically by `scripts/remote-update.sh` and `scripts/update/env_sync.py` on each machine after iCloud syncs.
+
+**Adding a new secret:** add it to `~/Desktop/Valor/.env`, add a placeholder to `.env.example`, add a field to `config/settings.py`. That's it — no sync step needed.
 
 ## Plan Requirements (This Repo Only)
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ A PM session steers the pipeline and delegates coding work to a Dev session. See
 # 1. Install dependencies
 pip install -e .
 
-# 2. Configure environment
-cp .env.example .env
-# Edit .env with your API keys and comms credentials
+# 2. Configure environment (symlink to vault)
+ln -sf ~/Desktop/Valor/.env ~/src/ai/.env
+# All secrets live in ~/Desktop/Valor/.env (iCloud-synced vault)
 
 # 3. Start the bridge and worker
 ./scripts/start_bridge.sh

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -42,7 +42,7 @@ from dotenv import load_dotenv  # noqa: E402
 # Load environment variables FIRST before any env checks
 env_path = Path(__file__).parent.parent / ".env"
 load_dotenv(env_path)
-load_dotenv(Path.home() / "Desktop" / "Valor" / ".env")
+load_dotenv(Path.home() / "Desktop" / "Valor" / ".env")  # symlink target — no-op
 
 # Initialize Sentry error tracking (skip gracefully if DSN not configured)
 from bridge.hibernation import is_hibernating  # noqa: E402

--- a/docs/features/config-architecture.md
+++ b/docs/features/config-architecture.md
@@ -52,16 +52,39 @@ from config.paths import PROJECT_ROOT, DATA_DIR, CONFIG_DIR, VALOR_DIR, LOGS_DIR
 
 | File | Purpose | Source-Controlled |
 |------|---------|-------------------|
-| `.env` | Secrets and environment overrides | No (gitignored) |
-| `.env.example` | Template documenting all env vars | Yes |
-| `config/settings.py` | Pydantic Settings model (single source of truth) | Yes |
+| `.env` | Symlink → `~/Desktop/Valor/.env` (secrets) | No (gitignored) |
+| `~/Desktop/Valor/.env` | **Secrets source of truth** (iCloud-synced, machine-private) | No (external vault) |
+| `.env.example` | Documents the contents of `~/Desktop/Valor/.env` | Yes |
+| `config/settings.py` | Pydantic Settings model (single source of truth for config schema) | Yes |
 | `config/paths.py` | Path constants derived from `__file__` | Yes |
 | `~/Desktop/Valor/projects.json` | Per-project config (working dirs, GitHub orgs, Telegram groups) | No (external, iCloud-synced) |
 | `config/projects.example.json` | Template for projects.json | Yes |
 | `config/models.py` | Model name constants | Yes |
 | `config/personas/_base.md` | Shared persona base (identity, values, tools, philosophy) | Yes |
 | `config/personas/{persona}.md` | Per-persona overlays (developer, project-manager, teammate) | Yes |
-| `~/Desktop/Valor/` | Google OAuth tokens, DM whitelist, calendar config | No (machine-local) |
+| `~/Desktop/Valor/` | Google OAuth tokens, DM whitelist, calendar config, `.env` vault | No (machine-local) |
+
+### Secrets
+
+All secrets live in **`~/Desktop/Valor/.env`** — the iCloud-synced vault. The repository `.env` is a symlink to this file:
+
+```
+~/src/ai/.env → ~/Desktop/Valor/.env
+```
+
+**Why this design:**
+- `~/Desktop/Valor/` is iCloud-synced: secrets are available on every machine after sign-in, without any manual copy step
+- The symlink means all existing `load_dotenv` and pydantic-settings `env_file=".env"` calls work unchanged — they resolve through the symlink transparently
+- `.gitignore` covers `.env` by name, so the symlink entry is never committed regardless of what it points to
+
+**Adding a new secret:**
+1. Add the key/value to `~/Desktop/Valor/.env`
+2. Add a documented placeholder to `.env.example`
+3. Add the corresponding field to `config/settings.py`
+
+Never write secrets directly to `repo/.env`. Writing to the symlink writes to the vault, but adding secrets to `~/Desktop/Valor/.env` directly is the canonical workflow and avoids confusion.
+
+**On a fresh machine:** `scripts/remote-update.sh` and `scripts/update/env_sync.py` create the symlink automatically once iCloud has synced the vault file. Until then, a clear warning is logged.
 
 ### Credentials Location
 

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -28,9 +28,9 @@ cd ~/src/ai
 # 2. Install dependencies
 pip install -e .
 
-# 3. Configure environment
-cp .env.example .env
-# Edit .env with your credentials
+# 3. Configure environment (symlink to vault)
+ln -sf ~/Desktop/Valor/.env ~/src/ai/.env
+# All secrets live in ~/Desktop/Valor/.env (iCloud-synced vault)
 
 # 4. Start the bridge
 ./scripts/start_bridge.sh
@@ -53,11 +53,13 @@ This installs:
 
 ### 2. Configure Environment
 
-Copy the example and edit:
+The repo `.env` is a symlink to `~/Desktop/Valor/.env` — the iCloud-synced secrets vault. Create the symlink:
 
 ```bash
-cp .env.example .env
+ln -sf ~/Desktop/Valor/.env ~/src/ai/.env
 ```
+
+All secrets go in `~/Desktop/Valor/.env`. See `.env.example` for the full list of required variables.
 
 Required variables:
 

--- a/docs/plans/consolidate-secrets-env.md
+++ b/docs/plans/consolidate-secrets-env.md
@@ -1,5 +1,5 @@
 ---
-status: Building
+status: docs_complete
 type: chore
 appetite: Small
 owner: Valor Engels

--- a/scripts/remote-update.sh
+++ b/scripts/remote-update.sh
@@ -11,6 +11,20 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 LOCK_DIR="$PROJECT_DIR/data/update.lock"
 
+# ── Ensure .env → ~/Desktop/Valor/.env symlink ──────────────────────
+# The vault file is the single source of truth for secrets. On a fresh machine
+# or after accidental deletion, create the symlink before sourcing .env so the
+# rest of this script always reads from the vault.
+VAULT_ENV="$HOME/Desktop/Valor/.env"
+REPO_ENV="$PROJECT_DIR/.env"
+if [ -n "$VAULT_ENV" ] && [ -f "$VAULT_ENV" ] && [ ! -L "$REPO_ENV" ]; then
+    echo "[update] Creating .env symlink → $VAULT_ENV"
+    [ -f "$REPO_ENV" ] && rm -f "$REPO_ENV"
+    ln -sf "$VAULT_ENV" "$REPO_ENV"
+elif [ ! -f "$VAULT_ENV" ] && [ ! -L "$REPO_ENV" ]; then
+    echo "[update] WARN: Vault .env not found at $VAULT_ENV — iCloud may not have synced yet"
+fi
+
 set -a
 # shellcheck disable=SC1091
 [ -f "$PROJECT_DIR/.env" ] && source "$PROJECT_DIR/.env"

--- a/scripts/start_bridge.sh
+++ b/scripts/start_bridge.sh
@@ -58,8 +58,8 @@ fi
 # Check for required config files
 if [ ! -f ".env" ]; then
     echo "ERROR: .env file not found."
-    echo "  cp .env.example .env"
-    echo "  # Then edit .env with your credentials"
+    echo "  ln -sf ~/Desktop/Valor/.env ~/src/ai/.env"
+    echo "  # .env must be a symlink to the vault at ~/Desktop/Valor/.env"
     exit 1
 fi
 

--- a/scripts/update/env_sync.py
+++ b/scripts/update/env_sync.py
@@ -1,110 +1,66 @@
-"""Sync specific env vars from the Valor vault to the project .env.
+"""Verify that the project .env is a symlink pointing to the Valor vault.
 
-The vault at ~/Desktop/Valor/.env (iCloud-synced) is the source of truth
-for API keys shared across machines. This module copies specific keys
-into the project's .env if they are missing or outdated.
+The vault at ~/Desktop/Valor/.env (iCloud-synced) is the single source of truth
+for all secrets. The project .env must be a symlink to it — never a regular file.
+
+On a fresh machine or after accidental deletion, this module creates the symlink
+automatically so the update process is self-healing.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+import logging
+from dataclasses import dataclass
 from pathlib import Path
 
-# Keys to sync from vault to project .env.
-# Add new keys here as services are added.
-SYNC_KEYS: list[str] = [
-    "VOYAGE_API_KEY",
-]
-
 VAULT_ENV_PATH = Path.home() / "Desktop" / "Valor" / ".env"
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
 class EnvSyncResult:
-    """Result of env sync operation."""
+    """Result of .env symlink verification."""
 
-    success: bool = True
-    added: list[str] = field(default_factory=list)
-    updated: list[str] = field(default_factory=list)
-    skipped: list[str] = field(default_factory=list)
+    symlink_ok: bool = False
+    created: bool = False
     error: str | None = None
 
 
-def _parse_env_file(path: Path) -> dict[str, str]:
-    """Parse a .env file into key-value pairs. Ignores comments and blank lines."""
-    result: dict[str, str] = {}
-    if not path.is_file():
-        return result
-    for line in path.read_text().splitlines():
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
-        if "=" not in line:
-            continue
-        key, _, value = line.partition("=")
-        result[key.strip()] = value.strip()
-    return result
-
-
 def sync_env_from_vault(project_dir: Path) -> EnvSyncResult:
-    """Copy SYNC_KEYS from vault .env to project .env if missing or changed."""
+    """Verify project .env is a symlink to the vault. Create it if missing.
+
+    Returns EnvSyncResult with:
+      - symlink_ok=True  if the symlink exists and points to the vault
+      - created=True     if the symlink was just created (was missing)
+      - error            set if the vault is absent or symlink could not be created
+    """
     result = EnvSyncResult()
     project_env = project_dir / ".env"
 
-    if not VAULT_ENV_PATH.is_file():
-        result.error = f"Vault .env not found at {VAULT_ENV_PATH}"
+    if not VAULT_ENV_PATH.exists():
+        result.error = (
+            f"Vault .env not found at {VAULT_ENV_PATH} — "
+            "iCloud may not have synced yet. Secrets unavailable until sync completes."
+        )
+        logger.warning(result.error)
         return result
 
-    vault_vars = _parse_env_file(VAULT_ENV_PATH)
-    project_vars = _parse_env_file(project_env)
-
-    changes: list[str] = []
-    for key in SYNC_KEYS:
-        vault_value = vault_vars.get(key)
-        if vault_value is None:
-            result.skipped.append(key)
-            continue
-
-        project_value = project_vars.get(key)
-        if project_value == vault_value:
-            result.skipped.append(key)
-            continue
-
-        if project_value is None:
-            result.added.append(key)
-        else:
-            result.updated.append(key)
-
-        project_vars[key] = vault_value
-        changes.append(key)
-
-    if not changes:
+    # Already a correct symlink — nothing to do.
+    if project_env.is_symlink() and project_env.resolve() == VAULT_ENV_PATH.resolve():
+        result.symlink_ok = True
         return result
 
-    # Rewrite project .env preserving existing content, updating changed keys
+    # Regular file (old behaviour) or broken/wrong symlink — replace with symlink.
     try:
-        lines: list[str] = []
-        written_keys: set[str] = set()
-
-        if project_env.is_file():
-            for line in project_env.read_text().splitlines():
-                stripped = line.strip()
-                if stripped and not stripped.startswith("#") and "=" in stripped:
-                    key = stripped.partition("=")[0].strip()
-                    if key in changes:
-                        lines.append(f"{key}={project_vars[key]}")
-                        written_keys.add(key)
-                        continue
-                lines.append(line)
-
-        # Append any new keys not already in the file
-        for key in changes:
-            if key not in written_keys:
-                lines.append(f"{key}={project_vars[key]}")
-
-        project_env.write_text("\n".join(lines) + "\n")
-    except OSError as e:
-        result.success = False
-        result.error = str(e)
+        if project_env.exists() or project_env.is_symlink():
+            project_env.unlink()
+        project_env.symlink_to(VAULT_ENV_PATH)
+        result.symlink_ok = True
+        result.created = True
+        logger.info("Created .env symlink → %s", VAULT_ENV_PATH)
+    except OSError as exc:
+        result.error = str(exc)
+        logger.warning("Failed to create .env symlink: %s", exc)
 
     return result

--- a/scripts/update/run.py
+++ b/scripts/update/run.py
@@ -323,17 +323,15 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
                 log(f"WARN: Failed to link {action.dst}: {action.error}", v)
                 result.warnings.append(f"Hardlink failed: {action.dst}")
 
-    # Step 1.6: Sync env vars from vault
-    log("Syncing env vars from vault...", v)
+    # Step 1.6: Verify .env symlink
+    log("Verifying .env symlink...", v)
     result.env_sync_result = env_sync.sync_env_from_vault(project_dir)
     env_r = result.env_sync_result
-    if env_r.added:
-        log(f"Added env vars: {', '.join(env_r.added)}", v, always=True)
-    if env_r.updated:
-        log(f"Updated env vars: {', '.join(env_r.updated)}", v, always=True)
+    if env_r.created:
+        log(".env symlink created → ~/Desktop/Valor/.env", v, always=True)
     if env_r.error:
-        log(f"WARN: Env sync: {env_r.error}", v)
-        result.warnings.append(f"Env sync: {env_r.error}")
+        log(f"WARN: Env symlink: {env_r.error}", v)
+        result.warnings.append(f"Env symlink: {env_r.error}")
 
     # Step 1.7: Audit skill hooks for dangerous patterns
     log("Auditing skill hooks...", v)

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -6,10 +6,10 @@ from pathlib import Path
 import pytest
 from dotenv import load_dotenv
 
-# Load shared API keys from parent env file
+# Load shared API keys from vault (repo .env is a symlink to vault)
 load_dotenv(Path.home() / "src" / ".env")
 load_dotenv()
-load_dotenv(Path.home() / "Desktop" / "Valor" / ".env")
+load_dotenv(Path.home() / "Desktop" / "Valor" / ".env")  # symlink target — no-op
 
 
 @pytest.fixture

--- a/tools/selfie/__init__.py
+++ b/tools/selfie/__init__.py
@@ -15,7 +15,7 @@ from openai import OpenAI
 from bridge.utc import utc_now
 
 load_dotenv()
-load_dotenv(Path.home() / "Desktop" / "Valor" / ".env")
+load_dotenv(Path.home() / "Desktop" / "Valor" / ".env")  # symlink target — no-op
 
 # Canonical appearance description derived from Valor's profile photo
 VALOR_APPEARANCE = (

--- a/tools/valor_session.py
+++ b/tools/valor_session.py
@@ -47,7 +47,7 @@ def _load_env() -> None:
         from dotenv import load_dotenv
 
         load_dotenv(_repo_root / ".env")
-        load_dotenv(Path.home() / "Desktop" / "Valor" / ".env")
+        load_dotenv(Path.home() / "Desktop" / "Valor" / ".env")  # symlink target — no-op
     except Exception:
         pass
 

--- a/tools/valor_telegram.py
+++ b/tools/valor_telegram.py
@@ -92,7 +92,7 @@ def _telethon_client():
     from dotenv import load_dotenv
 
     load_dotenv()
-    load_dotenv(Path.home() / "Desktop" / "Valor" / ".env")
+    load_dotenv(Path.home() / "Desktop" / "Valor" / ".env")  # symlink target — no-op
 
     try:
         api_id = int(os.environ.get("TELEGRAM_API_ID", "0"))


### PR DESCRIPTION
## Summary

- Replaces `~/src/ai/.env` regular file with a symlink → `~/Desktop/Valor/.env` (iCloud-synced vault)
- Rewrites `scripts/update/env_sync.py`: drops the old `SYNC_KEYS` copy loop, verifies/creates the symlink instead
- Updates `scripts/update/run.py` Step 1.6 log message and `EnvSyncResult` field references to match new shape
- Adds idempotent symlink repair block to `scripts/remote-update.sh` (placed before `.env` source line per critique)
- Annotates all double `load_dotenv` call sites with `# symlink target — no-op` comments
- Updates `docs/features/config-architecture.md`: fixes Config Files table, adds Secrets subsection
- Updates `CLAUDE.md`: adds `## Secrets` section with canonical rule
- Updates `.env.example` header: documents vault contents, not a file to copy

## Changes

- `scripts/update/env_sync.py` — complete rewrite: symlink verification replaces key sync
- `scripts/update/run.py` — Step 1.6 logging block updated to `env_r.symlink_ok`/`env_r.created`/`env_r.error`
- `scripts/remote-update.sh` — symlink repair block added before `.env` source (ordering fix from critique)
- `bridge/telegram_bridge.py`, `tools/selfie/__init__.py`, `tools/valor_session.py`, `tools/valor_telegram.py`, `tests/tools/conftest.py` — one-line `# symlink target — no-op` comment at double load_dotenv sites
- `docs/features/config-architecture.md` — Config Files table updated; Secrets subsection added
- `CLAUDE.md` — `## Secrets` section added after Configuration Files
- `.env.example` — header rewritten to reference vault path

## Testing

- [x] All 6 plan verification checks pass (symlink exists, target correct, lint, format, CLAUDE.md rule, config-architecture updated)
- [x] 376+ unit tests passing; pre-existing flaky failures (test_knowledge_indexer, test_work_request_classifier under load) confirmed on main
- [x] Ruff lint and format clean on all modified Python files

## Documentation

- [x] `docs/features/config-architecture.md` updated with Secrets subsection
- [x] `CLAUDE.md` updated with canonical Secrets rule
- [x] `.env.example` header updated to reference vault path

## Definition of Done

- [x] Built: symlink created, env_sync.py rewritten, remote-update.sh updated
- [x] Tested: all verification checks pass, unit tests pass
- [x] Documented: docs created/updated per plan requirements
- [x] Quality: lint and format checks pass

Closes #920