### PR TITLE
fix: prevent duplicate session execution after health-check recovery

### DIFF
--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -1408,6 +1408,32 @@ async def _agent_session_health_check() -> None:
                     reason = f"exceeded timeout ({int(running_seconds)}s > {timeout}s)"
 
             if should_recover:
+                # Guard: if response was already delivered, finalize instead
+                # of recovering to pending (prevents duplicate delivery, #918)
+                if getattr(entry, "response_delivered_at", None) is not None:
+                    try:
+                        from models.session_lifecycle import finalize_session
+
+                        logger.info(
+                            "[session-health] Session %s already delivered response at %s, "
+                            "finalizing instead of recovering",
+                            entry.agent_session_id,
+                            entry.response_delivered_at,
+                        )
+                        finalize_session(
+                            entry,
+                            "completed",
+                            reason="health check: already delivered",
+                        )
+                        recovered += 1
+                    except Exception as e:
+                        logger.error(
+                            "[session-health] Failed to finalize already-delivered session %s: %s",
+                            entry.agent_session_id,
+                            e,
+                        )
+                    continue
+
                 is_local = worker_key.startswith("local")
                 logger.warning(
                     "[session-health] Recovering stuck session %s "
@@ -3141,6 +3167,16 @@ async def _execute_agent_session(session: AgentSession) -> None:
                 f"[{session.project_key}] Output delivered "
                 f"(stop_reason={stop_reason}, {len(msg)} chars)"
             )
+            # Stamp response_delivered_at so health check won't re-queue (#918)
+            try:
+                if agent_session is not None:
+                    agent_session.response_delivered_at = datetime.now(UTC)
+                    agent_session.save()
+                    logger.info(f"Stamped response_delivered_at for session {session.session_id}")
+            except Exception as e:
+                logger.warning(
+                    f"Failed to stamp response_delivered_at for {session.session_id}: {e}"
+                )
 
     messenger = BossMessenger(
         _send_callback=send_to_chat,

--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -1356,6 +1356,13 @@ async def _agent_session_health_check() -> None:
     4. If no live worker for session.chat_id AND pending > AGENT_SESSION_HEALTH_MIN_RUNNING:
        start a worker. This replaces the old _recover_stalled_pending mechanism.
 
+    **Delivery guard (#918):** Before recovering a running session to pending,
+    the health check inspects ``response_delivered_at``. If the field is set,
+    the session already delivered its final response to Telegram — re-queuing
+    would cause a duplicate reply. Instead, the session is finalized as
+    ``completed`` via ``finalize_session()``. This prevents the crash-recover
+    loop that previously produced 6+ duplicate messages per session.
+
     Recovery resets status to 'pending' via direct mutation and save.
     Status is an IndexedField, so no delete-and-recreate is needed.
     Only sessions whose worker is confirmed dead are touched.

--- a/docs/features/bridge-self-healing.md
+++ b/docs/features/bridge-self-healing.md
@@ -128,13 +128,25 @@ Log rotation uses a dual-mechanism approach: Python-managed rotation for applica
 
 **Solution**: `cleanup_corrupted_agent_sessions()` runs at worker startup (before recovery), during `/update` (before stale cleanup), and hourly as the `agent-session-cleanup` reflection. It detects unsaveable sessions, deletes them (with fallback to direct Redis key deletion), and rebuilds indexes to clear orphaned `$IndexF`/`$KeyF`/`$SortF` entries. See also [Popoto Index Hygiene](popoto-index-hygiene.md) for the daily automated index rebuild that supplements this.
 
-### 8. Perplexity Provider Error Handling (`tools/web/providers/perplexity.py`)
+### 8. Health-Check Delivery Guard (`agent/agent_session_queue.py`)
+
+**Problem**: When a worker crashes or is cancelled mid-execution, the session stays in `running` state for startup recovery. After `AGENT_SESSION_HEALTH_MIN_RUNNING` (300s), the health check resets it to `pending` and the worker re-runs the session from scratch — including delivering a duplicate response. If each re-run also fails to complete cleanly, this repeats indefinitely, producing 6+ duplicate Telegram messages per session (#918).
+
+**Solution**: `send_to_chat` now stamps `response_delivered_at` (a `DatetimeField` on `AgentSession`) when a response is successfully delivered to Telegram. The `_agent_session_health_check` inspects this field before recovering a session: if `response_delivered_at` is set, the session already delivered its final response and re-queuing would cause a duplicate. Instead, it calls `finalize_session(entry, "completed")` to mark it done.
+
+Both the delivery stamp and the health-check guard are wrapped in `try/except` so that failures are logged but never crash the worker or health-check loop.
+
+**Key fields**:
+- `AgentSession.response_delivered_at` — nullable `DatetimeField`, set once on successful delivery
+- Health-check path: `_agent_session_health_check()` → `should_recover` → delivery guard → `finalize_session()`
+
+### 9. Perplexity Provider Error Handling (`tools/web/providers/perplexity.py`)
 
 **Problem**: The Perplexity search provider had a bare `except Exception` that silently swallowed all errors, including 401 Unauthorized responses from expired API keys.
 
 **Solution**: Added explicit `httpx.HTTPStatusError` handling before the generic catch. 401 errors now log a clear warning message directing the operator to refresh credentials in `.env`. Other HTTP errors are also logged with their status code.
 
-### 9. Service Installation
+### 10. Service Installation
 
 The watchdog is installed alongside the bridge:
 ```bash
@@ -148,7 +160,7 @@ The watchdog is installed alongside the bridge:
 
 The worker can also be installed separately via `./scripts/install_worker.sh`. See [Worker Service](worker-service.md) for details.
 
-### 10. Flood-Backoff Persistence (`bridge/telegram_bridge.py`)
+### 11. Flood-Backoff Persistence (`bridge/telegram_bridge.py`)
 
 **Problem**: When the bridge hits a Telegram `FloodWaitError` with a long duration, launchd restarts compound the problem. Each restart triggers a new connection attempt, which increments Telegram's flood counter, escalating the wait from seconds to hours.
 
@@ -166,7 +178,7 @@ The worker can also be installed separately via `./scripts/install_worker.sh`. S
 - The file is deleted on successful connect
 - All writes use atomic temp-file + `os.replace` to prevent corruption
 
-### 11. Dynamic Catchup Lookback (`bridge/catchup.py`)
+### 12. Dynamic Catchup Lookback (`bridge/catchup.py`)
 
 **Problem**: The fixed 60-minute `CATCHUP_LOOKBACK_MINUTES` means that after a multi-hour outage, messages older than 60 minutes are silently missed forever.
 
@@ -183,7 +195,7 @@ The worker can also be installed separately via `./scripts/install_worker.sh`. S
 
 **Logger handler guard**: `telegram_bridge.py` may execute its module-level setup twice in some launch configurations (once as `__main__`, once as `bridge.telegram_bridge`). This would add a second `RotatingFileHandler` to the root logger, doubling every log line. A guard checks for an existing handler with the same log file path before adding a new one.
 
-### 12. Update Polling (`com.valor.update`)
+### 13. Update Polling (`com.valor.update`)
 
 **Problem**: Code pushes to main could take up to 12 hours to propagate to all machines, since the update plist only ran at 6 AM and 6 PM.
 
@@ -205,7 +217,7 @@ tail -f logs/update.log
 
 **Manual override**: The Telegram `/update` command continues to work for immediate updates.
 
-### 13. Bridge Hibernation (`bridge/hibernation.py`)
+### 14. Bridge Hibernation (`bridge/hibernation.py`)
 
 **Problem**: The bridge has no distinction between two fundamentally different failure modes:
 1. **Auth expiry** — Telegram session token expired or revoked; requires human intervention (`python scripts/telegram_login.py`). The bridge cannot self-recover.

--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -139,6 +139,7 @@ class AgentSession(Model):
     started_at = DatetimeField(null=True)  # Cannot be SortedField because it starts as None
     updated_at = DatetimeField(auto_now=True, null=True)  # Renamed from last_activity
     completed_at = DatetimeField(null=True)
+    response_delivered_at = DatetimeField(null=True)
     working_dir = Field()
 
     # === Telegram origin (consolidated) ===
@@ -249,7 +250,13 @@ class AgentSession(Model):
     # === Backward-compatible field name mapping ===
 
     # DatetimeField names that should auto-convert float timestamps
-    _DATETIME_FIELDS = {"scheduled_at", "started_at", "updated_at", "completed_at"}
+    _DATETIME_FIELDS = {
+        "scheduled_at",
+        "started_at",
+        "updated_at",
+        "completed_at",
+        "response_delivered_at",
+    }
 
     # Known roles for validation
     _KNOWN_ROLES = {"pm", "dev"}
@@ -416,6 +423,12 @@ class AgentSession(Model):
             kwargs["completed_at"] = datetime.fromtimestamp(kwargs["completed_at"], tz=UTC)
         if "updated_at" in kwargs and isinstance(kwargs["updated_at"], int | float):
             kwargs["updated_at"] = datetime.fromtimestamp(kwargs["updated_at"], tz=UTC)
+        if "response_delivered_at" in kwargs and isinstance(
+            kwargs["response_delivered_at"], int | float
+        ):
+            kwargs["response_delivered_at"] = datetime.fromtimestamp(
+                kwargs["response_delivered_at"], tz=UTC
+            )
 
         return kwargs
 

--- a/tests/unit/test_agent_session_queue.py
+++ b/tests/unit/test_agent_session_queue.py
@@ -373,3 +373,105 @@ class TestPopAgentSessionThrottleGuard:
             "_pop_agent_session must return None when throttle='moderate' "
             "and only low-priority sessions are available"
         )
+
+
+class TestHealthCheckDeliveryGuard:
+    """Tests for the response_delivered_at guard in _agent_session_health_check.
+
+    When a session has response_delivered_at set, the health check should
+    finalize it as completed instead of resetting it to pending (which would
+    cause duplicate message delivery -- issue #918).
+    """
+
+    @pytest.mark.asyncio
+    async def test_delivered_session_finalized_not_requeued(self):
+        """Session WITH response_delivered_at should be marked completed,
+        not reset to pending."""
+        # Use session_type="teammate" + chat_id so worker_key = chat_id
+        delivered_session = _make_session(
+            status="running",
+            started_at=datetime(2020, 1, 1, tzinfo=UTC),
+            session_type="teammate",
+            chat_id="chat-123",
+        )
+        delivered_session.agent_session_id = "delivered-test-1"
+        delivered_session.response_delivered_at = datetime(2020, 1, 1, 0, 30, tzinfo=UTC)
+
+        mock_finalize = MagicMock()
+
+        with (
+            patch("agent.agent_session_queue.AgentSession") as mock_cls,
+            patch(
+                "agent.agent_session_queue._active_workers",
+                {"chat-123": MagicMock(done=MagicMock(return_value=True))},
+            ),
+        ):
+            mock_cls.query.filter.return_value = [delivered_session]
+            # The health check does a local import of finalize_session
+            with patch("agent.agent_session_queue.finalize_session", mock_finalize, create=True):
+                # Patch at the import target inside the function
+                import models.session_lifecycle as lifecycle_mod
+
+                original_finalize = lifecycle_mod.finalize_session
+                original_transition = lifecycle_mod.transition_status
+                lifecycle_mod.finalize_session = mock_finalize
+                mock_transition = MagicMock()
+                lifecycle_mod.transition_status = mock_transition
+                try:
+                    from agent.agent_session_queue import _agent_session_health_check
+
+                    await _agent_session_health_check()
+                finally:
+                    lifecycle_mod.finalize_session = original_finalize
+                    lifecycle_mod.transition_status = original_transition
+
+            # Should finalize as completed, NOT transition to pending
+            mock_finalize.assert_called_once()
+            call_args = mock_finalize.call_args
+            assert call_args[0][1] == "completed"
+            mock_transition.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_undelivered_session_recovered_to_pending(self):
+        """Session WITHOUT response_delivered_at should be recovered to
+        pending as before (existing behavior preserved)."""
+        # Use session_type="teammate" + chat_id so worker_key = chat_id
+        undelivered_session = _make_session(
+            status="running",
+            started_at=datetime(2020, 1, 1, tzinfo=UTC),
+            session_type="teammate",
+            chat_id="chat-456",
+        )
+        undelivered_session.agent_session_id = "undelivered-test-1"
+        # Ensure response_delivered_at is None (not set)
+
+        mock_transition = MagicMock()
+        mock_finalize = MagicMock()
+
+        with (
+            patch("agent.agent_session_queue.AgentSession") as mock_cls,
+            patch(
+                "agent.agent_session_queue._active_workers",
+                {"chat-456": MagicMock(done=MagicMock(return_value=True))},
+            ),
+            patch("agent.agent_session_queue._ensure_worker"),
+        ):
+            mock_cls.query.filter.return_value = [undelivered_session]
+            import models.session_lifecycle as lifecycle_mod
+
+            original_finalize = lifecycle_mod.finalize_session
+            original_transition = lifecycle_mod.transition_status
+            lifecycle_mod.finalize_session = mock_finalize
+            lifecycle_mod.transition_status = mock_transition
+            try:
+                from agent.agent_session_queue import _agent_session_health_check
+
+                await _agent_session_health_check()
+            finally:
+                lifecycle_mod.finalize_session = original_finalize
+                lifecycle_mod.transition_status = original_transition
+
+            # Should transition to pending, NOT finalize
+            mock_transition.assert_called_once()
+            assert mock_transition.call_args[0][1] == "pending"
+            mock_finalize.assert_not_called()


### PR DESCRIPTION
## Summary
- Adds `response_delivered_at` field to `AgentSession` model — stamped when `send_to_chat` delivers the final response
- Health check now finalizes already-delivered sessions as `completed` instead of resetting to `pending` for re-execution
- Prevents the duplicate message delivery loop observed in issue #918

Closes #918

## Test plan
- [x] Unit tests for health check delivery guard (session with/without `response_delivered_at`)
- [ ] Verify `pytest tests/unit/test_agent_session_queue.py -x -q` passes (17 tests)
- [ ] Verify no existing tests broken