### PR TITLE
feat(sdlc): per-stage docs/sdlc/ repo addenda with reflection agent

### DIFF
--- a/.claude/commands/do-merge.md
+++ b/.claude/commands/do-merge.md
@@ -1,5 +1,9 @@
 # Merge Gate
 
+## Repo Addendum
+
+Before starting, check if `docs/sdlc/do-merge.md` exists in the current repo. If it does, read it and incorporate its guidance as repo-specific addenda to these instructions.
+
 You are the merge gate for the SDLC pipeline. Your job is to programmatically verify all prerequisites are met, then execute the merge.
 
 ## Pre-Merge Pipeline Check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ valor-telegram send --chat "Tom" --file ./screenshot.png "Caption"
 | `python scripts/reflections.py --ignore "pattern"` | Silence a bug pattern for 14 days |
 | `./scripts/install_reflections.sh` | Install reflections launchd schedule |
 | `tail -f logs/reflections.log` | Stream reflections logs |
+| `tail -f logs/sdlc_reflection.log` | Stream SDLC reflection logs |
 | `python scripts/autoexperiment.py --target observer --iterations 50` | Run autoexperiment on observer prompt |
 | `python scripts/autoexperiment.py --target summarizer --dry-run` | Dry-run autoexperiment on summarizer |
 | `python scripts/autoexperiment.py --list-targets` | List autoexperiment targets |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,10 @@ valor-telegram send --chat "Tom" --file ./screenshot.png "Caption"
 | `python scripts/reflections.py --ignore "pattern"` | Silence a bug pattern for 14 days |
 | `./scripts/install_reflections.sh` | Install reflections launchd schedule |
 | `tail -f logs/reflections.log` | Stream reflections logs |
+| `python scripts/sdlc_reflection.py` | Run SDLC reflection manually |
+| `python scripts/sdlc_reflection.py --dry-run` | Preview SDLC reflection without writing |
+| `python scripts/sdlc_reflection.py --days 14` | Run with larger lookback window |
+| `./scripts/install_sdlc_reflection.sh` | Install SDLC reflection launchd schedule |
 | `tail -f logs/sdlc_reflection.log` | Stream SDLC reflection logs |
 | `python scripts/autoexperiment.py --target observer --iterations 50` | Run autoexperiment on observer prompt |
 | `python scripts/autoexperiment.py --target summarizer --dry-run` | Dry-run autoexperiment on summarizer |

--- a/com.valor.sdlc-reflection.plist
+++ b/com.valor.sdlc-reflection.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>__SERVICE_LABEL__</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>set -a; source __PROJECT_DIR__/.env; set +a; exec __PROJECT_DIR__/.venv/bin/python __PROJECT_DIR__/scripts/sdlc_reflection.py</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>__PROJECT_DIR__</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/usr/sbin:/bin</string>
+        <key>HOME</key>
+        <string>__HOME_DIR__</string>
+    </dict>
+    <key>StartInterval</key>
+    <integer>259200</integer>
+    <key>StandardOutPath</key>
+    <string>__PROJECT_DIR__/logs/reflections.log</string>
+    <key>StandardErrorPath</key>
+    <string>__PROJECT_DIR__/logs/reflections_error.log</string>
+</dict>
+</plist>

--- a/docs/features/sdlc-repo-addenda.md
+++ b/docs/features/sdlc-repo-addenda.md
@@ -93,6 +93,10 @@ State is stored in `data/sdlc_reflection_last_run.json`.
 | `scripts/update/migrations.py` | Added `create_sdlc_stubs` migration |
 | `tests/unit/test_sdlc_stubs.py` | Unit tests for migration and stubs |
 
+## Adding a New SDLC Stage
+
+Adding a 9th (or later) SDLC stage requires a new named migration entry in `scripts/update/migrations.py`. The `create_sdlc_stubs` migration is recorded once in `data/migrations_completed.json` — a new stage stub will NOT be auto-created unless a new migration is registered and run.
+
 ## See Also
 
 - `docs/features/README.md` — Feature index

--- a/docs/sdlc/do-build.md
+++ b/docs/sdlc/do-build.md
@@ -1,0 +1,26 @@
+# do-build addendum — this repo only
+<!-- Do not duplicate content from the global skill (~/.claude/skills/do-build/SKILL.md). Only include what is unique to this repo. Max 300 lines. -->
+
+## Lint and Format
+
+This repo uses `ruff` for both formatting and linting. The pre-commit hook auto-fixes all fixable issues via `ruff format` + `ruff check --fix`. Do not run manual lint checks during build — the hook handles it on final commits.
+
+Use `--no-verify` on intermediate WIP commits only. Final commits must go through the hook.
+
+## Test Isolation
+
+Unit tests in `tests/unit/` must never touch production Redis. Use `REDIS_TEST_DB` or a separate prefix. Bulk Redis operations must always be project-scoped. See `tests/README.md` for test markers.
+
+## Worktree Pattern
+
+- Builder agents work in `.worktrees/{slug}/`, not main checkout
+- Never `git checkout session/{slug}` — the worktree IS the checkout
+- Commits happen at logical checkpoints throughout Implement, not batched at end
+
+## Definition of Done (this repo)
+
+In addition to global DoD, this repo requires:
+- `python -m ruff check .` passes (exit 0)
+- `python -m ruff format --check .` passes (exit 0)
+- `pytest tests/unit/ -x -q` passes
+- New `docs/features/` doc created if plan has one in the ## Documentation section

--- a/docs/sdlc/do-docs.md
+++ b/docs/sdlc/do-docs.md
@@ -1,0 +1,26 @@
+# do-docs addendum — this repo only
+<!-- Do not duplicate content from the global skill (~/.claude/skills/do-docs/SKILL.md). Only include what is unique to this repo. Max 300 lines. -->
+
+## docs/features/ is the Primary Index
+
+All feature documentation lives in `docs/features/`. When creating a new feature doc, also add an entry to `docs/features/README.md` index table. The index is the canonical list of features; missing entries cause discoverability gaps.
+
+## CLAUDE.md Quick Reference
+
+If the feature adds a new CLI command, script, or tool, add it to the appropriate table in `CLAUDE.md`. The quick reference table is the first place devs look — keep it current.
+
+## docs/plans/ Commit-on-Main
+
+Plan files in `docs/plans/` must always stay on `main`. Never include plan file changes in a feature branch PR. If a docs update requires plan changes, make them directly on `main` in a separate commit.
+
+## docs/sdlc/ Addenda
+
+If the feature changes how an SDLC stage works for this repo, update the relevant `docs/sdlc/do-X.md` addendum. These files inform future SDLC skill runs. Keep them under 300 lines and never duplicate content from the global skill.
+
+## No Stale References
+
+Before finalizing docs, verify all file paths, command examples, and feature names still exist. Stale references (pointing to renamed files, removed commands) are worse than no docs — remove or update them.
+
+## Commit Docs on Feature Branch
+
+All `docs/features/` content is committed on the feature branch (`session/{slug}`), not on `main`. The merge brings docs in with the code.

--- a/docs/sdlc/do-merge.md
+++ b/docs/sdlc/do-merge.md
@@ -1,0 +1,39 @@
+# do-merge addendum — this repo only
+<!-- Do not duplicate content from the global merge command (.claude/commands/do-merge.md). Only include what is unique to this repo. Max 300 lines. -->
+
+## Documentation Gate
+
+Before merging, verify `docs/features/{slug}.md` exists if the plan specified one. This is a hard gate — missing feature docs block the merge.
+
+## Ruff Gates
+
+The merge gate must confirm:
+- `python -m ruff check .` exits 0
+- `python -m ruff format --check .` exits 0
+
+These run in the worktree, not main.
+
+## Plan Migration
+
+After merge, move the plan from `docs/plans/{slug}.md` to `docs/plans/completed/{slug}.md` on `main`. The plan stays on `main` (not the branch) throughout the lifecycle — migrate it on `main` post-merge.
+
+## Post-Merge Memory Extraction
+
+After merge, the pipeline runs post-merge learning extraction. This distills PR takeaways into memories (importance=7.0). No manual action needed — the worker handles it automatically via `_handle_merge_completion()`.
+
+## Worktree Cleanup
+
+After a successful merge, remove the worktree:
+```bash
+git worktree remove .worktrees/{slug}
+```
+
+The branch `session/{slug}` is deleted automatically by GitHub on merge if "delete branch on merge" is enabled.
+
+## Bridge/Worker Restart After Merge
+
+If the merged PR touched `bridge/`, `agent/`, or `worker/`, run:
+```bash
+./scripts/valor-service.sh restart
+```
+Confirm with `tail -5 logs/bridge.log` showing "Connected to Telegram".

--- a/docs/sdlc/do-patch.md
+++ b/docs/sdlc/do-patch.md
@@ -1,0 +1,26 @@
+# do-patch addendum — this repo only
+<!-- Do not duplicate content from the global skill (~/.claude/skills/do-patch/SKILL.md). Only include what is unique to this repo. Max 300 lines. -->
+
+## Worktree Context
+
+Patches apply inside the worktree at `.worktrees/{slug}/`, not the main checkout. The branch is `session/{slug}`. Never run `git checkout session/{slug}` from main — the worktree IS the checkout.
+
+## Ruff Auto-Fix
+
+This repo's pre-commit hook runs `ruff format` + `ruff check --fix` automatically. Do not manually fix whitespace or import order — commit and let the hook clean up. If the hook fails on a non-fixable lint error, fix that specific error and re-commit.
+
+## Test Isolation Regression
+
+After patching, re-run only the affected unit tests first (`pytest tests/unit/test_*.py -x -q`), then run the full unit suite. Do not skip the isolated run — it surfaces scope issues before the full suite.
+
+## Redis Safety
+
+If the patch touches any Redis operation, double-check it is project-scoped. Raw `r.delete`, `r.srem`, `r.sadd` calls on unscoped keys will corrupt production data. Use `instance.delete()` or `Model.rebuild_indexes()` instead.
+
+## Bridge/Worker Restart
+
+If the patch touches `bridge/`, `agent/`, or `worker/`, restart the bridge after committing:
+```bash
+./scripts/valor-service.sh restart
+```
+Verify with `tail -5 logs/bridge.log` — must show "Connected to Telegram".

--- a/docs/sdlc/do-plan-critique.md
+++ b/docs/sdlc/do-plan-critique.md
@@ -1,0 +1,27 @@
+# do-plan-critique addendum — this repo only
+<!-- Do not duplicate content from the global skill (~/.claude/skills/do-plan-critique/SKILL.md). Only include what is unique to this repo. Max 300 lines. -->
+
+## Required Section Enforcement
+
+The critique must verify all four required plan sections are present and substantive:
+
+- **## Documentation** — must include a checkbox task with a `docs/features/` path
+- **## Update System** — must address `scripts/update/migrations.py` for any Popoto model changes
+- **## Agent Integration** — must address MCP server exposure for new Python tools
+- **## Test Impact** — must list affected tests with UPDATE/DELETE/REPLACE dispositions
+
+If any section is missing or contains only a placeholder, raise it as a HIGH-severity blocker.
+
+## Popoto Migration Check
+
+If the plan touches any Popoto model, the critique must verify:
+- A migration function is planned in `scripts/update/migrations.py`
+- The migration is registered in `MIGRATIONS`
+- The plan avoids raw Redis operations
+
+## Multi-Machine Deployment
+
+This repo runs on multiple machines (see `docs/deployment.md`). The Archaeologist critic should check:
+- Does the plan require a new env var? It must be added to `.env.example` and `config/settings.py`
+- Does the plan introduce new dependencies? They must be propagated via the update system
+- Are there race conditions between machines running `/update` simultaneously?

--- a/docs/sdlc/do-plan.md
+++ b/docs/sdlc/do-plan.md
@@ -1,0 +1,37 @@
+# do-plan addendum — this repo only
+<!-- Do not duplicate content from the global skill (~/.claude/skills/do-plan/SKILL.md). Only include what is unique to this repo. Max 300 lines. -->
+
+## Popoto Schema Migration Requirement
+
+When a plan involves changes to any Popoto model (models in `agent/`, `bridge/`, `tools/`, or anywhere using `popoto`):
+
+- Add a migration function to `scripts/update/migrations.py`
+- Register it in the `MIGRATIONS` dict (required — `run_pending_migrations()` iterates `MIGRATIONS`)
+- Migration must be idempotent; it is recorded once in `data/migrations_completed.json`
+- Use subprocess to call a separate migration script if the logic is non-trivial
+- Never write raw Redis ops (`r.delete`, `r.srem`, `r.sadd`, `r.zrem`) — use `instance.delete()`, `Model.rebuild_indexes()`, or `transition_status()`
+
+## Required Plan Sections
+
+Every plan in this repo must include all four of these sections (validated by `.claude/hooks/validators/`):
+
+1. **## Documentation** — at least one checkbox task specifying a `docs/features/` path; or explicit "No documentation changes needed" with justification
+2. **## Update System** — describe whether `scripts/update/run.py` or `migrations.py` needs changes; new deps to propagate; explicit "No update system changes required" if none
+3. **## Agent Integration** — describe MCP server changes, `.mcp.json` changes, or explicit "No agent integration required"
+4. **## Test Impact** — checklist of existing test files that will break (UPDATE/DELETE/REPLACE), or explicit "No existing tests affected" with 50+ char justification
+
+Missing any of these sections will fail the pre-commit hook and block plan creation.
+
+## docs/plans/ Commit-on-Main Rule
+
+Plan documents must always be committed directly on `main`, never on feature branches. This is enforced by memory and convention. Use `git checkout main` before creating or updating plan files.
+
+## Transport-Keyed Callback Convention
+
+When adding output callbacks to the bridge, key them by transport type (e.g., `"telegram"`, `"local"`) not by session ID. See `bridge/telegram_bridge.py` and `agent/output_handler.py` for the pattern.
+
+## Slug Conventions
+
+- Slugs are kebab-case, derived from the plan filename (without `.md`)
+- Slugs tie together: plan doc, GitHub issue, worktree at `.worktrees/{slug}/`, branch `session/{slug}`, task list
+- Create the slug from the GitHub issue title, not from a description of the work

--- a/docs/sdlc/do-pr-review.md
+++ b/docs/sdlc/do-pr-review.md
@@ -1,0 +1,37 @@
+# do-pr-review addendum — this repo only
+<!-- Do not duplicate content from the global skill (~/.claude/skills/do-pr-review/SKILL.md). Only include what is unique to this repo. Max 300 lines. -->
+
+## Documentation Gate
+
+Every PR must have a corresponding `docs/features/{slug}.md` if the plan's `## Documentation` section specified one. Verify this file exists before approving. Missing docs are a blocker.
+
+## Plan Section Compliance
+
+Verify the plan included all four required sections (validated by hooks):
+- `## Documentation` — has checkbox tasks with `docs/features/` paths
+- `## Update System` — addresses `migrations.py` for Popoto changes
+- `## Agent Integration` — addresses MCP exposure for new Python tools
+- `## Test Impact` — lists affected tests with UPDATE/DELETE/REPLACE
+
+If the PR was built from a plan missing any section, flag it as a blocker.
+
+## Ruff and Test Gates
+
+A PR must not merge with:
+- `ruff check .` failures (exit non-zero)
+- `ruff format --check .` failures
+- Failing unit tests
+
+These are hard gates. No exceptions.
+
+## Multi-Machine Compatibility
+
+If the PR adds new environment variables, verify they are in `.env.example` and `config/settings.py`. If the PR adds new migrations, verify they are registered in `MIGRATIONS` in `scripts/update/migrations.py`.
+
+## Bridge/Worker Changes
+
+If the PR modifies `bridge/`, `agent/`, or `worker/`, flag for restart-after-deploy. The reviewer should note whether the change requires a service restart on all machines.
+
+## UI Screenshots
+
+For any PR that touches `ui/`, include before/after screenshots taken via `agent-browser` or `bowser`. Screenshots must show the actual running app at `localhost:8500`, not mockups.

--- a/docs/sdlc/do-test.md
+++ b/docs/sdlc/do-test.md
@@ -1,0 +1,33 @@
+# do-test addendum — this repo only
+<!-- Do not duplicate content from the global skill (~/.claude/skills/do-test/SKILL.md). Only include what is unique to this repo. Max 300 lines. -->
+
+## Test Tiers and Markers
+
+Tests are organized by tier with pytest markers. See `tests/README.md` for the full index.
+
+- `tests/unit/` — No external connections; must be fast (~60s). Run with `-n auto` for parallel execution.
+- `tests/integration/` — Requires live APIs and services. Do not mock.
+- `pytest -m sdlc` — Run SDLC-related tests as a feature slice.
+
+## Redis Isolation
+
+Unit tests must never touch production Redis. Use `REDIS_TEST_DB` or a test-specific key prefix. Bulk Redis operations (`kill --all`, mass deletes) must always be project-scoped using the `PROJECT_NAME` prefix from `config/settings.py`.
+
+Violating this rule corrupts production session data.
+
+## AI Judge Pattern
+
+Integration tests that validate LLM outputs must use an AI judge (Haiku/Sonnet), not keyword matching. See `tests/integration/` for examples. Never assert on exact LLM response content.
+
+## Test Database State
+
+Before running integration tests, verify the bridge and worker are not running tests against the same Redis instance. Use `REDIS_TEST_DB=1` or a separate test-mode `.env`.
+
+## Quality Gates
+
+Tests must pass at these thresholds before a PR can merge:
+- Unit: 100% pass
+- Integration: 95% pass
+- E2E: 90% pass
+
+A failing unit test is a blocker; do not open a PR with failing unit tests.

--- a/scripts/install_sdlc_reflection.sh
+++ b/scripts/install_sdlc_reflection.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Install the SDLC reflection launchd service (runs every 3 days).
+# Usage: ./scripts/install_sdlc_reflection.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+set -a
+# shellcheck disable=SC1091
+[ -f "$PROJECT_DIR/.env" ] && source "$PROJECT_DIR/.env"
+set +a
+: "${SERVICE_LABEL_PREFIX:=com.valor}"
+
+PLIST_SRC="$PROJECT_DIR/com.valor.sdlc-reflection.plist"
+LABEL="${SERVICE_LABEL_PREFIX}.sdlc-reflection"
+PLIST_DST="$HOME/Library/LaunchAgents/${LABEL}.plist"
+
+# Ensure logs directory exists
+mkdir -p "$PROJECT_DIR/logs"
+
+# Check source plist exists
+if [ ! -f "$PLIST_SRC" ]; then
+    echo "ERROR: Plist not found at $PLIST_SRC"
+    exit 1
+fi
+
+# Unload existing version if present
+if launchctl list | grep -q "$LABEL"; then
+    echo "Unloading existing $LABEL..."
+    launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+fi
+
+# Copy plist to LaunchAgents with path substitution
+echo "Installing plist to $PLIST_DST..."
+sed "s|__PROJECT_DIR__|$PROJECT_DIR|g; s|__HOME_DIR__|$HOME|g; s|__SERVICE_LABEL__|$LABEL|g" "$PLIST_SRC" > "$PLIST_DST"
+
+# Load new version
+echo "Loading $LABEL..."
+launchctl bootstrap "gui/$(id -u)" "$PLIST_DST"
+
+echo ""
+echo "SDLC reflection service installed successfully."
+echo "Label:    $LABEL"
+echo "Schedule: every 3 days (259200s interval)"
+echo "Log:      $PROJECT_DIR/logs/reflections.log"
+echo ""
+echo "To run manually: python scripts/sdlc_reflection.py --dry-run"
+echo "To uninstall:    launchctl bootout gui/$(id -u)/$LABEL && rm $PLIST_DST"

--- a/scripts/sdlc_reflection.py
+++ b/scripts/sdlc_reflection.py
@@ -217,9 +217,48 @@ def propose_edits(
     return modified
 
 
+def _check_existing_reflection_pr() -> bool:
+    """Check if an open reflection PR already exists (title-prefix search).
+
+    Returns True if a matching open PR is found, False otherwise.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--state",
+                "open",
+                "--search",
+                "docs(sdlc): reflection update",
+                "--json",
+                "number,title",
+                "--limit",
+                "5",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=PROJECT_DIR,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            log(f"gh pr list (duplicate check) failed: {result.stderr[:300]}")
+            return False
+        prs = json.loads(result.stdout)
+        return len(prs) > 0
+    except Exception as e:
+        log(f"_check_existing_reflection_pr error: {e}")
+        return False
+
+
 def open_pr_with_changes(modified_stages: list[str]) -> bool:
     """Commit changes to a branch and open a PR for human review."""
     if not modified_stages:
+        return False
+
+    if _check_existing_reflection_pr():
+        log("Reflection PR already exists; skipping PR creation")
         return False
 
     branch = f"session/sdlc-reflection-{datetime.now(UTC).strftime('%Y%m%d')}"

--- a/scripts/sdlc_reflection.py
+++ b/scripts/sdlc_reflection.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""SDLC reflection agent.
+
+Fetches recently merged PRs, extracts per-stage learnings, and proposes
+targeted edits to docs/sdlc/do-X.md files. Runs every 3 days via launchd.
+
+Usage:
+    python scripts/sdlc_reflection.py             # Run and open a PR with proposed changes
+    python scripts/sdlc_reflection.py --dry-run   # Print proposed changes without writing
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+PROJECT_DIR = Path(__file__).parent.parent
+DATA_DIR = PROJECT_DIR / "data"
+LAST_RUN_FILE = DATA_DIR / "sdlc_reflection_last_run.json"
+SDLC_DIR = PROJECT_DIR / "docs" / "sdlc"
+LOG_FILE = PROJECT_DIR / "logs" / "reflections.log"
+
+STAGE_KEYWORDS: dict[str, list[str]] = {
+    "do-plan": ["plan", "planning", "do-plan", "shape up", "appetite", "slug"],
+    "do-plan-critique": ["critique", "war room", "critic", "skeptic", "do-plan-critique"],
+    "do-build": ["build", "implement", "worktree", "do-build", "builder"],
+    "do-test": ["test", "pytest", "do-test", "unit test", "integration test"],
+    "do-patch": ["patch", "fix", "do-patch", "failing test", "lint error"],
+    "do-pr-review": ["review", "pr review", "do-pr-review", "pull request review"],
+    "do-docs": ["docs", "documentation", "do-docs", "readme", "feature doc"],
+    "do-merge": ["merge", "do-merge", "merge gate", "squash"],
+}
+
+MAX_LINES_PER_FILE = 300
+DEFAULT_LOOKBACK_DAYS = 7
+
+
+def log(msg: str) -> None:
+    """Write to stdout and log file."""
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+    line = f"[sdlc-reflection] {timestamp} {msg}"
+    print(line)
+    try:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with open(LOG_FILE, "a") as f:
+            f.write(line + "\n")
+    except Exception:
+        pass  # Never crash on logging failure
+
+
+def load_last_run() -> dict:
+    """Load last-run metadata from data/sdlc_reflection_last_run.json."""
+    if LAST_RUN_FILE.exists():
+        try:
+            return json.loads(LAST_RUN_FILE.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+    return {"last_run_at": None, "last_pr_number": 0}
+
+
+def save_last_run(state: dict) -> None:
+    """Persist last-run metadata."""
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    LAST_RUN_FILE.write_text(json.dumps(state, indent=2) + "\n")
+
+
+def fetch_merged_prs(since_days: int = DEFAULT_LOOKBACK_DAYS) -> list[dict]:
+    """Fetch recently merged PRs using the gh CLI."""
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--state",
+                "merged",
+                "--limit",
+                "30",
+                "--json",
+                "number,title,body,mergedAt,headRefName",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=PROJECT_DIR,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            log(f"gh pr list failed: {result.stderr[:300]}")
+            return []
+        prs = json.loads(result.stdout)
+        # Filter to PRs merged within the lookback window
+        cutoff = datetime.now(UTC).timestamp() - (since_days * 86400)
+        recent = []
+        for pr in prs:
+            merged_at = pr.get("mergedAt", "")
+            if not merged_at:
+                continue
+            try:
+                ts = datetime.fromisoformat(merged_at.replace("Z", "+00:00")).timestamp()
+                if ts >= cutoff:
+                    recent.append(pr)
+            except (ValueError, AttributeError):
+                continue
+        return recent
+    except subprocess.TimeoutExpired:
+        log("gh pr list timed out")
+        return []
+    except Exception as e:
+        log(f"fetch_merged_prs error: {e}")
+        return []
+
+
+def classify_pr_by_stage(pr: dict) -> list[str]:
+    """Return list of SDLC stage names most relevant to this PR."""
+    text = (
+        (pr.get("title") or "") + " " + (pr.get("body") or "") + " " + (pr.get("headRefName") or "")
+    ).lower()
+
+    matches = []
+    for stage, keywords in STAGE_KEYWORDS.items():
+        if any(kw in text for kw in keywords):
+            matches.append(stage)
+    return matches
+
+
+def extract_learnings_from_prs(prs: list[dict]) -> dict[str, list[str]]:
+    """Extract per-stage learnings from PR titles and bodies.
+
+    Returns dict mapping stage name -> list of learning strings.
+    This is a lightweight heuristic extraction. The reflection agent
+    intentionally stays simple to avoid noise.
+    """
+    learnings: dict[str, list[str]] = {stage: [] for stage in STAGE_KEYWORDS}
+
+    for pr in prs:
+        stages = classify_pr_by_stage(pr)
+        if not stages:
+            continue
+
+        title = pr.get("title", "").strip()
+        body = (pr.get("body") or "").strip()
+
+        # Extract any lines starting with conventions we care about
+        for line in body.splitlines():
+            line = line.strip()
+            # Look for explicitly flagged learnings in PR body
+            if any(
+                line.lower().startswith(prefix)
+                for prefix in [
+                    "- lesson:",
+                    "- pattern:",
+                    "- note:",
+                    "- convention:",
+                    "- learning:",
+                    "- reminder:",
+                    "- caveat:",
+                ]
+            ):
+                for stage in stages:
+                    learnings[stage].append(f"<!-- PR #{pr['number']}: {title} -->\n{line}")
+
+    return learnings
+
+
+def propose_edits(
+    learnings: dict[str, list[str]],
+    dry_run: bool = False,
+) -> dict[str, bool]:
+    """Write proposed learnings to docs/sdlc/ stub files.
+
+    Returns dict mapping stage -> True if file was modified.
+    """
+    modified: dict[str, bool] = {}
+
+    for stage, items in learnings.items():
+        if not items:
+            continue
+
+        stub_path = SDLC_DIR / f"{stage}.md"
+        if not stub_path.exists():
+            log(f"Skipping {stage}: {stub_path} does not exist")
+            continue
+
+        current = stub_path.read_text()
+
+        # Build proposed additions
+        new_section = "\n## Reflection Notes (auto-generated)\n\n"
+        for item in items:
+            new_section += f"{item}\n\n"
+
+        proposed = current.rstrip() + "\n" + new_section
+
+        # Enforce 300-line limit — truncate oldest reflection notes if needed
+        proposed_lines = proposed.splitlines()
+        if len(proposed_lines) > MAX_LINES_PER_FILE:
+            overage = len(proposed_lines) - MAX_LINES_PER_FILE
+            log(
+                f"WARNING: {stage}.md would exceed {MAX_LINES_PER_FILE} lines "
+                f"(+{overage}); skipping to avoid limit violation"
+            )
+            continue
+
+        if dry_run:
+            log(f"[DRY RUN] Would add {len(items)} learning(s) to {stage}.md")
+            for item in items:
+                log(f"  - {item[:80]}")
+            modified[stage] = True
+        else:
+            stub_path.write_text(proposed)
+            log(f"Updated {stage}.md with {len(items)} learning(s)")
+            modified[stage] = True
+
+    return modified
+
+
+def open_pr_with_changes(modified_stages: list[str]) -> bool:
+    """Commit changes to a branch and open a PR for human review."""
+    if not modified_stages:
+        return False
+
+    branch = f"session/sdlc-reflection-{datetime.now(UTC).strftime('%Y%m%d')}"
+
+    try:
+        # Check if we're on main
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=PROJECT_DIR,
+        )
+        current_branch = result.stdout.strip()
+
+        if current_branch != "main":
+            log(f"Not on main (on {current_branch}); skipping PR creation")
+            return False
+
+        # Create branch
+        subprocess.run(
+            ["git", "checkout", "-b", branch], check=True, capture_output=True, cwd=PROJECT_DIR
+        )
+
+        # Stage modified files
+        for stage in modified_stages:
+            stub_path = SDLC_DIR / f"{stage}.md"
+            subprocess.run(
+                ["git", "add", str(stub_path)], check=True, capture_output=True, cwd=PROJECT_DIR
+            )
+
+        # Commit
+        commit_msg = (
+            f"docs(sdlc): reflection update for {', '.join(modified_stages)}\n\n"
+            f"Auto-generated by scripts/sdlc_reflection.py.\n"
+            f"Review before merging — do not merge without human approval.\n"
+            f"Stages updated: {', '.join(modified_stages)}"
+        )
+        subprocess.run(
+            ["git", "commit", "-m", commit_msg], check=True, capture_output=True, cwd=PROJECT_DIR
+        )
+
+        # Push
+        subprocess.run(
+            ["git", "push", "-u", "origin", branch],
+            check=True,
+            capture_output=True,
+            cwd=PROJECT_DIR,
+        )
+
+        # Open PR
+        pr_body = (
+            "## Summary\n\n"
+            "Auto-generated SDLC addendum updates from reflection agent.\n\n"
+            "**Stages updated:**\n"
+            + "\n".join(f"- `docs/sdlc/{s}.md`" for s in modified_stages)
+            + "\n\n**Review carefully** — only merge if changes are accurate and non-duplicative "
+            "of the global skill content.\n\n"
+            "Generated by `scripts/sdlc_reflection.py` (3-day cadence)."
+        )
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--title",
+                f"docs(sdlc): reflection update ({datetime.now(UTC).strftime('%Y-%m-%d')})",
+                "--body",
+                pr_body,
+                "--base",
+                "main",
+                "--head",
+                branch,
+            ],
+            capture_output=True,
+            text=True,
+            cwd=PROJECT_DIR,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            pr_url = result.stdout.strip()
+            log(f"PR opened: {pr_url}")
+            return True
+        else:
+            log(f"gh pr create failed: {result.stderr[:300]}")
+            return False
+
+    except subprocess.CalledProcessError as e:
+        log(f"git/gh error: {e}")
+        return False
+    finally:
+        # Return to main
+        subprocess.run(["git", "checkout", "main"], capture_output=True, cwd=PROJECT_DIR)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="SDLC reflection agent")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print proposed changes without writing files or opening a PR",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=DEFAULT_LOOKBACK_DAYS,
+        help=f"Lookback window in days (default: {DEFAULT_LOOKBACK_DAYS})",
+    )
+    args = parser.parse_args()
+
+    log(f"Starting SDLC reflection (dry_run={args.dry_run}, days={args.days})")
+
+    # Ensure docs/sdlc/ exists
+    if not SDLC_DIR.exists():
+        log("docs/sdlc/ does not exist; nothing to update")
+        return 0
+
+    # Fetch merged PRs
+    prs = fetch_merged_prs(since_days=args.days)
+    log(f"Found {len(prs)} merged PRs in last {args.days} days")
+
+    if not prs:
+        log("No merged PRs — nothing to learn from. Exiting.")
+        save_last_run(
+            {
+                "last_run_at": datetime.now(UTC).isoformat(),
+                "last_pr_number": 0,
+                "prs_found": 0,
+            }
+        )
+        return 0
+
+    # Extract learnings
+    learnings = extract_learnings_from_prs(prs)
+    total_learnings = sum(len(v) for v in learnings.values())
+    log(f"Extracted {total_learnings} learning(s) across stages")
+
+    if total_learnings == 0:
+        log("No actionable learnings found. Exiting.")
+        save_last_run(
+            {
+                "last_run_at": datetime.now(UTC).isoformat(),
+                "prs_found": len(prs),
+                "learnings_extracted": 0,
+            }
+        )
+        return 0
+
+    # Propose edits
+    modified = propose_edits(learnings, dry_run=args.dry_run)
+    modified_stages = [s for s, changed in modified.items() if changed]
+
+    if modified_stages and not args.dry_run:
+        success = open_pr_with_changes(modified_stages)
+        log(f"PR creation: {'success' if success else 'failed'}")
+
+    # Save state
+    save_last_run(
+        {
+            "last_run_at": datetime.now(UTC).isoformat(),
+            "prs_found": len(prs),
+            "learnings_extracted": total_learnings,
+            "stages_modified": modified_stages,
+        }
+    )
+
+    log("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/update/migrations.py
+++ b/scripts/update/migrations.py
@@ -110,6 +110,7 @@ def _migrate_create_sdlc_stubs(project_dir: Path) -> str | None:
                 path.write_text(_SDLC_STUB_TEMPLATE.format(name=name))
         return None
     except Exception as e:
+        print(f"[migration] create_sdlc_stubs failed: {e}")
         return str(e)
 
 

--- a/scripts/update/migrations.py
+++ b/scripts/update/migrations.py
@@ -77,11 +77,51 @@ def _migrate_agent_session_keyfield_rename(project_dir: Path) -> str | None:
         return str(e)
 
 
+_SDLC_STUB_TEMPLATE = """\
+# {name} addendum — this repo only
+<!-- Do not duplicate content from the global skill.
+     Only include what is unique to this repo. Max 300 lines. -->
+"""
+
+_SDLC_STUBS = [
+    "do-plan",
+    "do-plan-critique",
+    "do-build",
+    "do-test",
+    "do-patch",
+    "do-pr-review",
+    "do-docs",
+    "do-merge",
+]
+
+
+def _migrate_create_sdlc_stubs(project_dir: Path) -> str | None:
+    """Create docs/sdlc/ stub files if missing.
+
+    Idempotent — only creates files that do not yet exist.
+    Returns None on success, error string on failure.
+    """
+    try:
+        sdlc_dir = project_dir / "docs" / "sdlc"
+        sdlc_dir.mkdir(parents=True, exist_ok=True)
+        for name in _SDLC_STUBS:
+            path = sdlc_dir / f"{name}.md"
+            if not path.exists():
+                path.write_text(_SDLC_STUB_TEMPLATE.format(name=name))
+        return None
+    except Exception as e:
+        return str(e)
+
+
 # Migration name -> (function, description)
 MIGRATIONS: dict[str, tuple[callable, str]] = {
     "agent_session_keyfield_rename": (
         _migrate_agent_session_keyfield_rename,
         "Rename AgentSession job_id/parent_job_id KeyFields in Redis",
+    ),
+    "create_sdlc_stubs": (
+        _migrate_create_sdlc_stubs,
+        "Create docs/sdlc/ per-stage addendum stub files",
     ),
 }
 

--- a/tests/unit/test_sdlc_stubs.py
+++ b/tests/unit/test_sdlc_stubs.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -146,3 +148,48 @@ class TestGracefulDegradation:
 
         for stub in EXPECTED_STUBS:
             assert (sdlc_dir / stub).exists(), f"Missing in real repo: {stub}"
+
+
+class TestCheckExistingReflectionPr:
+    """Tests for _check_existing_reflection_pr duplicate-PR guard."""
+
+    def test_returns_true_when_existing_pr_found(self) -> None:
+        """Returns True when gh finds an open reflection PR."""
+        from scripts.sdlc_reflection import _check_existing_reflection_pr
+
+        mock_result = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=json.dumps(
+                [{"number": 100, "title": "docs(sdlc): reflection update (2026-04-10)"}]
+            ),
+            stderr="",
+        )
+        with patch("scripts.sdlc_reflection.subprocess.run", return_value=mock_result):
+            assert _check_existing_reflection_pr() is True
+
+    def test_returns_false_when_no_existing_pr(self) -> None:
+        """Returns False when gh finds no open reflection PRs."""
+        from scripts.sdlc_reflection import _check_existing_reflection_pr
+
+        mock_result = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=json.dumps([]),
+            stderr="",
+        )
+        with patch("scripts.sdlc_reflection.subprocess.run", return_value=mock_result):
+            assert _check_existing_reflection_pr() is False
+
+    def test_returns_false_on_gh_failure(self) -> None:
+        """Returns False (safe default) when gh command fails."""
+        from scripts.sdlc_reflection import _check_existing_reflection_pr
+
+        mock_result = subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout="",
+            stderr="gh: not logged in",
+        )
+        with patch("scripts.sdlc_reflection.subprocess.run", return_value=mock_result):
+            assert _check_existing_reflection_pr() is False

--- a/tests/unit/test_sdlc_stubs.py
+++ b/tests/unit/test_sdlc_stubs.py
@@ -1,0 +1,148 @@
+"""Tests for SDLC stub file creation via the migration system."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.update.migrations import (
+    _SDLC_STUBS,
+    MIGRATIONS,
+    _migrate_create_sdlc_stubs,
+    run_pending_migrations,
+)
+
+EXPECTED_STUBS = [
+    "do-plan.md",
+    "do-plan-critique.md",
+    "do-build.md",
+    "do-test.md",
+    "do-patch.md",
+    "do-pr-review.md",
+    "do-docs.md",
+    "do-merge.md",
+]
+
+
+class TestMigrateCreateSdlcStubs:
+    """Tests for _migrate_create_sdlc_stubs migration function."""
+
+    def test_creates_all_eight_stubs(self, tmp_path: Path) -> None:
+        """Migration creates all 8 docs/sdlc/ stub files."""
+        error = _migrate_create_sdlc_stubs(tmp_path)
+
+        assert error is None
+        sdlc_dir = tmp_path / "docs" / "sdlc"
+        assert sdlc_dir.is_dir()
+        for stub in EXPECTED_STUBS:
+            assert (sdlc_dir / stub).exists(), f"Missing stub: {stub}"
+
+    def test_stubs_have_comment_header(self, tmp_path: Path) -> None:
+        """Each created stub contains the required comment header."""
+        _migrate_create_sdlc_stubs(tmp_path)
+
+        sdlc_dir = tmp_path / "docs" / "sdlc"
+        for stub in EXPECTED_STUBS:
+            content = (sdlc_dir / stub).read_text()
+            assert "Do not duplicate content from the global skill" in content, (
+                f"{stub} missing comment header"
+            )
+
+    def test_idempotent_does_not_overwrite_existing(self, tmp_path: Path) -> None:
+        """Re-running migration does not overwrite files that already have content."""
+        # First run
+        _migrate_create_sdlc_stubs(tmp_path)
+
+        # Modify one file
+        do_plan = tmp_path / "docs" / "sdlc" / "do-plan.md"
+        original_content = do_plan.read_text()
+        custom_content = original_content + "\n## Custom Note\nThis was hand-authored.\n"
+        do_plan.write_text(custom_content)
+
+        # Second run should not overwrite
+        error = _migrate_create_sdlc_stubs(tmp_path)
+        assert error is None
+        assert do_plan.read_text() == custom_content, "Migration overwrote existing file"
+
+    def test_creates_docs_sdlc_directory(self, tmp_path: Path) -> None:
+        """Migration creates docs/sdlc/ directory if it does not exist."""
+        assert not (tmp_path / "docs" / "sdlc").exists()
+        _migrate_create_sdlc_stubs(tmp_path)
+        assert (tmp_path / "docs" / "sdlc").is_dir()
+
+    def test_stub_list_matches_expected(self) -> None:
+        """_SDLC_STUBS constant matches the expected 8 stage names."""
+        expected_names = {s.removesuffix(".md") for s in EXPECTED_STUBS}
+        assert set(_SDLC_STUBS) == expected_names
+
+    def test_returns_none_on_success(self, tmp_path: Path) -> None:
+        """Migration function returns None (no error) on success."""
+        result = _migrate_create_sdlc_stubs(tmp_path)
+        assert result is None
+
+
+class TestMigrationRegistry:
+    """Tests for create_sdlc_stubs in the MIGRATIONS registry."""
+
+    def test_create_sdlc_stubs_registered(self) -> None:
+        """create_sdlc_stubs is in the MIGRATIONS dict."""
+        assert "create_sdlc_stubs" in MIGRATIONS
+
+    def test_create_sdlc_stubs_has_description(self) -> None:
+        """create_sdlc_stubs entry has a non-empty description."""
+        _, description = MIGRATIONS["create_sdlc_stubs"]
+        assert description and len(description) > 10
+
+    def test_run_pending_migrations_creates_stubs(self, tmp_path: Path) -> None:
+        """run_pending_migrations() runs the create_sdlc_stubs migration."""
+        # Seed data dir so other migrations (e.g. keyfield_rename) are skipped
+        completed_path = tmp_path / "data" / "migrations_completed.json"
+        completed_path.parent.mkdir(parents=True)
+        completed_path.write_text(json.dumps(["agent_session_keyfield_rename"]) + "\n")
+
+        result = run_pending_migrations(tmp_path)
+
+        assert "create_sdlc_stubs" in result.ran
+        assert (tmp_path / "docs" / "sdlc" / "do-plan.md").exists()
+
+    def test_run_pending_migrations_idempotent(self, tmp_path: Path) -> None:
+        """Running migrations twice skips create_sdlc_stubs the second time."""
+        completed_path = tmp_path / "data" / "migrations_completed.json"
+        completed_path.parent.mkdir(parents=True)
+        completed_path.write_text(json.dumps(["agent_session_keyfield_rename"]) + "\n")
+
+        run_pending_migrations(tmp_path)
+        result2 = run_pending_migrations(tmp_path)
+
+        assert "create_sdlc_stubs" in result2.skipped
+        assert "create_sdlc_stubs" not in result2.ran
+
+
+class TestGracefulDegradation:
+    """Tests that missing addendum files do not raise errors."""
+
+    def test_missing_addendum_file_is_safe(self, tmp_path: Path) -> None:
+        """Checking for a missing addendum file (e.g., in skill logic) does not raise."""
+        addendum_path = tmp_path / "docs" / "sdlc" / "do-plan.md"
+
+        # Simulate what a skill would do: check for existence before reading
+        if addendum_path.exists():
+            content = addendum_path.read_text()
+        else:
+            content = ""
+
+        # Should reach here without exception
+        assert content == ""
+
+    def test_stub_files_in_real_repo(self) -> None:
+        """All 8 stub files exist in the actual docs/sdlc/ directory."""
+        repo_root = Path(__file__).parent.parent.parent
+        sdlc_dir = repo_root / "docs" / "sdlc"
+
+        if not sdlc_dir.exists():
+            pytest.skip("docs/sdlc/ not yet created — run /update first")
+
+        for stub in EXPECTED_STUBS:
+            assert (sdlc_dir / stub).exists(), f"Missing in real repo: {stub}"


### PR DESCRIPTION
## Summary

- Creates `docs/sdlc/` with 8 hand-authored per-stage addendum files (do-plan through do-merge)
- Adds `## Repo Addendum` check to all 7 global SDLC skills and `do-merge` command
- Adds `create_sdlc_stubs` migration to `scripts/update/migrations.py` (idempotent, 3-day cron)
- Creates `scripts/sdlc_reflection.py`: fetches merged PRs, extracts learnings, opens PR every 3 days
- 12 unit tests, all passing; ruff clean

## What it does

Global SDLC skills now check for `docs/sdlc/do-X.md` at startup and incorporate repo-specific guidance. Missing files are a graceful no-op. On a clean machine, `/update` runs the `create_sdlc_stubs` migration which creates stub files. The reflection agent runs every 3 days, extracts explicitly flagged learnings from merged PR bodies (lines starting with `- lesson:`, `- pattern:`, etc.), and opens a PR for human review.

## Test plan

- [x] `pytest tests/unit/test_sdlc_stubs.py -v` — 12/12 pass
- [x] `python scripts/sdlc_reflection.py --dry-run` — exits cleanly
- [x] `python -m ruff check .` — clean
- [x] `python -m ruff format --check .` — clean
- [x] All 8 stub files exist in `docs/sdlc/` with comment headers
- [x] `scripts/update/migrations.py` has `create_sdlc_stubs` registered in `MIGRATIONS`
- [x] All 7 global SDLC skills + `do-merge` have `## Repo Addendum` section

Closes #927