### PR TITLE
test(#936): add email bridge operational layer test coverage

### DIFF
--- a/docs/features/email-bridge.md
+++ b/docs/features/email-bridge.md
@@ -75,6 +75,7 @@ IMAP_HOST=imap.gmail.com
 IMAP_PORT=993
 IMAP_USER=valor@yuda.me
 IMAP_PASSWORD=<gmail-app-password>
+IMAP_MAX_BATCH=20        # max unseen messages fetched per poll cycle (default: 20)
 
 # SMTP (outbound)
 SMTP_HOST=smtp.gmail.com
@@ -144,6 +145,8 @@ Or via the service script:
 **`telegram_message_id=0` sentinel.** The session queue requires a message ID for deduplication. Email sessions use `0` as a sentinel value since they have no Telegram message ID. This avoids a nullable field or a parallel code path in the queue.
 
 **Transport stored in `extra_context`.** `extra_context["transport"] = "email"` is the discriminator the worker uses to select `EmailOutputHandler` over `TelegramRelayOutputHandler`. The same mechanism supports future transports (e.g. Slack) without changes to the core queue.
+
+**Per-poll batch cap (`IMAP_MAX_BATCH`).** Each poll cycle fetches at most `IMAP_MAX_BATCH` unseen messages (default 20, configurable via env var). On inboxes with thousands of unread messages, this prevents the poller from hanging indefinitely on a single cycle. The most recent messages are fetched first.
 
 **30-second poll interval.** A balance between responsiveness and IMAP connection overhead. Gmail supports IMAP IDLE for push delivery, but polling is simpler and sufficient for the current load.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -320,3 +320,6 @@ Source modules with no test coverage. Priority targets for new tests.
 | High | `agent/completion.py` | 316 | Auto-continue |
 | High | `tools/job_scheduler.py` | 705 | Async work execution |
 | Medium | Hook validators (29 files) | ~1,500 | Config enforcement |
+
+**Partially covered** (operational layer added in #936):
+- `bridge/email_bridge.py` — parsing, SMTP output, routing, and thread continuation have full coverage. Operational layer (`main()`, `_poll_imap()` batch cap, `_email_inbox_loop()` health timestamp) now covered via unit and integration tests.

--- a/tests/README.md
+++ b/tests/README.md
@@ -80,6 +80,13 @@ tests/
 | integration | `test_unthreaded_routing.py` | 7 | Unthreaded message routing |
 | e2e | `test_message_pipeline.py` | 37 | Full routing → context → response flow |
 
+### `messaging` — Email bridge
+
+| Level | File | Tests | Description |
+|-------|------|------:|-------------|
+| unit | `test_email_bridge.py` | 31 | Parsing, SMTP output, batch cap, env loading |
+| integration | `test_email_bridge.py` | 5 | Inbound routing, thread continuation, health timestamp |
+
 ### `sdlc` — Pipeline stages and observer
 
 | Level | File | Tests | Description |

--- a/tests/integration/test_email_bridge.py
+++ b/tests/integration/test_email_bridge.py
@@ -253,7 +253,7 @@ class TestProcessInboundEmail:
 # ---------------------------------------------------------------------------
 
 
-class _BreakLoop(Exception):
+class _BreakLoopError(Exception):
     """Sentinel exception to break out of the infinite polling loop after one iteration."""
 
 
@@ -283,7 +283,7 @@ class TestHealthTimestamp:
             nonlocal call_count
             call_count += 1
             if call_count >= 1:
-                raise _BreakLoop("break after first iteration")
+                raise _BreakLoopError("break after first iteration")
 
         try:
             with patch(
@@ -297,7 +297,7 @@ class TestHealthTimestamp:
                         side_effect=_break_after_first,
                     ):
                         await _email_inbox_loop(imap_config, config={})
-        except _BreakLoop:
+        except _BreakLoopError:
             pass
 
         # Verify health timestamp was written

--- a/tests/integration/test_email_bridge.py
+++ b/tests/integration/test_email_bridge.py
@@ -246,3 +246,70 @@ class TestProcessInboundEmail:
             f"Expected session_id={original_session_id!r} from thread continuation, "
             f"got {called_session_id!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Tests: health timestamp in _email_inbox_loop
+# ---------------------------------------------------------------------------
+
+
+class _BreakLoop(Exception):
+    """Sentinel exception to break out of the infinite polling loop after one iteration."""
+
+
+class TestHealthTimestamp:
+    """_email_inbox_loop() writes email:last_poll_ts to Redis on each poll."""
+
+    @pytest.mark.asyncio
+    async def test_health_timestamp_written_after_poll(self):
+        """After one successful poll iteration, email:last_poll_ts is set in Redis."""
+        from bridge.email_bridge import REDIS_LAST_POLL_KEY, _email_inbox_loop
+
+        test_r = _test_redis()
+        # Ensure the key does not exist before the test
+        test_r.delete(REDIS_LAST_POLL_KEY)
+
+        imap_config = {
+            "host": "imap.example.com",
+            "port": 993,
+            "user": "test@example.com",
+            "password": "secret",
+            "ssl": True,
+        }
+
+        call_count = 0
+
+        async def _break_after_first(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 1:
+                raise _BreakLoop("break after first iteration")
+
+        try:
+            with patch(
+                "bridge.email_bridge._poll_imap",
+                new_callable=AsyncMock,
+                return_value=[],
+            ):
+                with patch("bridge.email_bridge._get_redis", return_value=test_r):
+                    with patch(
+                        "bridge.email_bridge.asyncio.sleep",
+                        side_effect=_break_after_first,
+                    ):
+                        await _email_inbox_loop(imap_config, config={})
+        except _BreakLoop:
+            pass
+
+        # Verify health timestamp was written
+        ts_value = test_r.get(REDIS_LAST_POLL_KEY)
+        assert ts_value is not None, (
+            f"Expected {REDIS_LAST_POLL_KEY} to be set in Redis after one poll"
+        )
+        # Verify it's a valid float timestamp
+        ts_float = float(ts_value)
+        assert ts_float > 0
+        assert ts_float <= time.time() + 1  # not in the future
+
+        # Cleanup
+        test_r.delete(REDIS_LAST_POLL_KEY)
+        test_r.close()

--- a/tests/unit/test_email_bridge.py
+++ b/tests/unit/test_email_bridge.py
@@ -5,16 +5,20 @@ the standard library. SMTP is mocked via unittest.mock.patch to avoid network
 calls.
 """
 
+import asyncio
 import email.mime.multipart
 import email.mime.text
-from unittest.mock import AsyncMock, MagicMock, patch
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
 from bridge.email_bridge import (
+    IMAP_MAX_BATCH,
     EmailOutputHandler,
     _decode_header_value,
     _extract_address,
+    _poll_imap,
     parse_email_message,
 )
 
@@ -393,3 +397,111 @@ class TestEmailOutputHandlerSend:
         call_kwargs = mock_dl.call_args.kwargs
         assert call_kwargs["session_id"] == "test-session-dl"
         assert call_kwargs["recipient"] == "recipient@example.com"
+
+
+# ---------------------------------------------------------------------------
+# _poll_imap() batch cap
+# ---------------------------------------------------------------------------
+
+
+class TestPollImapBatchCap:
+    """_poll_imap() caps fetches to IMAP_MAX_BATCH per poll cycle."""
+
+    @pytest.mark.asyncio
+    async def test_batch_cap_limits_fetched_messages(self):
+        """When IMAP returns more than IMAP_MAX_BATCH unseen messages, only
+        IMAP_MAX_BATCH are fetched (store + fetch) and returned."""
+        total_unseen = IMAP_MAX_BATCH + 10
+        # Build fake message IDs as bytes (IMAP returns space-separated byte IDs)
+        fake_msg_ids = b" ".join(str(i).encode() for i in range(1, total_unseen + 1))
+
+        mock_conn = MagicMock()
+        mock_conn.login.return_value = ("OK", [])
+        mock_conn.select.return_value = ("OK", [])
+        mock_conn.search.return_value = ("OK", [fake_msg_ids])
+        mock_conn.store.return_value = ("OK", [])
+        # conn.fetch returns a tuple with raw bytes for each message
+        mock_conn.fetch.return_value = ("OK", [(b"1", b"raw email bytes")])
+
+        imap_config = {
+            "host": "imap.example.com",
+            "port": 993,
+            "user": "test@example.com",
+            "password": "secret",
+            "ssl": True,
+        }
+
+        with patch("bridge.email_bridge.imaplib.IMAP4_SSL", return_value=mock_conn):
+            # Patch asyncio.to_thread to call the sync function directly
+            with patch(
+                "bridge.email_bridge.asyncio.to_thread",
+                side_effect=lambda fn: fn(),
+            ):
+                result = await _poll_imap(imap_config)
+
+        assert mock_conn.store.call_count == IMAP_MAX_BATCH
+        assert mock_conn.fetch.call_count == IMAP_MAX_BATCH
+        assert len(result) == IMAP_MAX_BATCH
+
+    @pytest.mark.asyncio
+    async def test_batch_cap_exact_boundary(self):
+        """When IMAP returns exactly IMAP_MAX_BATCH messages, all are fetched
+        (no truncation)."""
+        fake_msg_ids = b" ".join(
+            str(i).encode() for i in range(1, IMAP_MAX_BATCH + 1)
+        )
+
+        mock_conn = MagicMock()
+        mock_conn.login.return_value = ("OK", [])
+        mock_conn.select.return_value = ("OK", [])
+        mock_conn.search.return_value = ("OK", [fake_msg_ids])
+        mock_conn.store.return_value = ("OK", [])
+        mock_conn.fetch.return_value = ("OK", [(b"1", b"raw email bytes")])
+
+        imap_config = {
+            "host": "imap.example.com",
+            "port": 993,
+            "user": "test@example.com",
+            "password": "secret",
+            "ssl": True,
+        }
+
+        with patch("bridge.email_bridge.imaplib.IMAP4_SSL", return_value=mock_conn):
+            with patch(
+                "bridge.email_bridge.asyncio.to_thread",
+                side_effect=lambda fn: fn(),
+            ):
+                result = await _poll_imap(imap_config)
+
+        assert mock_conn.store.call_count == IMAP_MAX_BATCH
+        assert mock_conn.fetch.call_count == IMAP_MAX_BATCH
+        assert len(result) == IMAP_MAX_BATCH
+
+
+# ---------------------------------------------------------------------------
+# main() env loading
+# ---------------------------------------------------------------------------
+
+
+class TestMainEnvLoading:
+    """main() loads .env files via load_dotenv before starting the async loop."""
+
+    def test_main_calls_load_dotenv_with_correct_paths(self):
+        """main() calls load_dotenv twice: repo .env and vault .env."""
+        with patch("dotenv.load_dotenv") as mock_load:
+            with patch("bridge.email_bridge.asyncio.run"):
+                from bridge.email_bridge import main
+
+                main()
+
+        assert mock_load.call_count == 2
+
+        # First call: repo .env (relative to email_bridge.py's parent.parent)
+        first_path = mock_load.call_args_list[0][0][0]
+        assert str(first_path).endswith(".env")
+        assert "Desktop" not in str(first_path)
+
+        # Second call: vault .env
+        second_path = mock_load.call_args_list[1][0][0]
+        assert "Desktop" in str(second_path) and "Valor" in str(second_path)
+        assert str(second_path).endswith(".env")

--- a/tests/unit/test_email_bridge.py
+++ b/tests/unit/test_email_bridge.py
@@ -5,11 +5,9 @@ the standard library. SMTP is mocked via unittest.mock.patch to avoid network
 calls.
 """
 
-import asyncio
 import email.mime.multipart
 import email.mime.text
-from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -447,9 +445,7 @@ class TestPollImapBatchCap:
     async def test_batch_cap_exact_boundary(self):
         """When IMAP returns exactly IMAP_MAX_BATCH messages, all are fetched
         (no truncation)."""
-        fake_msg_ids = b" ".join(
-            str(i).encode() for i in range(1, IMAP_MAX_BATCH + 1)
-        )
+        fake_msg_ids = b" ".join(str(i).encode() for i in range(1, IMAP_MAX_BATCH + 1))
 
         mock_conn = MagicMock()
         mock_conn.login.return_value = ("OK", [])


### PR DESCRIPTION
## Summary
- Add regression tests for three bugs hotfixed in commit `53ea6401` that had zero test coverage
- Batch cap test: verifies `_poll_imap()` caps fetches to `IMAP_MAX_BATCH` when IMAP returns more unseen messages
- Env loading test: verifies `main()` calls `load_dotenv()` with both repo and vault `.env` paths
- Health timestamp test: verifies `_email_inbox_loop()` writes `email:last_poll_ts` to Redis after each poll

## Changes
- `tests/unit/test_email_bridge.py`: Added `TestPollImapBatchCap` (2 tests) and `TestMainEnvLoading` (1 test)
- `tests/integration/test_email_bridge.py`: Added `TestHealthTimestamp` (1 test)
- `tests/README.md`: Added email bridge section to test index

## Testing
- [x] All 36 email bridge tests passing (31 unit + 5 integration)
- [x] Ruff lint clean
- [x] Ruff format clean

## Documentation
- [x] tests/README.md updated with email bridge test entries

## Definition of Done
- [x] Built: Test code implemented and working
- [x] Tested: All tests passing
- [x] Documented: README updated
- [x] Quality: Lint and format checks pass

Closes #936