### PR TITLE
fix(session-health): recover slugless dev sessions stuck behind co-running PM (#944)

### DIFF
--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -1350,6 +1350,28 @@ def _get_agent_session_timeout(session) -> int:
     return AGENT_SESSION_TIMEOUT_DEFAULT
 
 
+def _has_progress(entry: AgentSession) -> bool:
+    """Return True iff the session shows any signal that real work has begun.
+
+    Three fields cover the SDK subprocess warmup arc from auth to first turn:
+    - ``claude_session_uuid`` is populated when the SDK subprocess authenticates
+      with the Claude API (seconds after launch, long before the first turn).
+    - ``log_path`` is written once the session emits its first log entry
+      (typically on the first tool call).
+    - ``turn_count`` increments on each full agent turn completion.
+
+    Any one of the three is sufficient evidence that the session is in flight.
+    Used by ``_agent_session_health_check`` to distinguish stuck slugless dev
+    sessions (worker_alive via a co-running PM, but no progress) from healthy
+    long-warmup BUILD sessions. See issue #944.
+    """
+    return (
+        (entry.turn_count or 0) > 0
+        or bool((entry.log_path or "").strip())
+        or bool(entry.claude_session_uuid)
+    )
+
+
 async def _agent_session_health_check() -> None:
     """Health check for worker-managed sessions (running and pending).
 
@@ -1361,11 +1383,16 @@ async def _agent_session_health_check() -> None:
 
     For RUNNING sessions:
     1. If worker is dead/missing AND running > AGENT_SESSION_HEALTH_MIN_RUNNING: recover.
-    2. If exceeded timeout: recover regardless of worker state.
-    3. Legacy sessions without started_at and no worker: recover.
+    2. If worker appears alive but running > AGENT_SESSION_HEALTH_MIN_RUNNING AND
+       the session has no progress signal (``turn_count``, ``log_path``,
+       ``claude_session_uuid`` all empty): recover. Slugless dev sessions share
+       ``worker_key`` with co-running PM sessions, so ``worker_alive`` alone
+       does not prove the dev session is being handled (#944).
+    3. If exceeded timeout: recover regardless of worker state.
+    4. Legacy sessions without started_at and no worker: recover.
 
     For PENDING sessions:
-    4. If no live worker for session.chat_id AND pending > AGENT_SESSION_HEALTH_MIN_RUNNING:
+    5. If no live worker for session.chat_id AND pending > AGENT_SESSION_HEALTH_MIN_RUNNING:
        start a worker. This replaces the old _recover_stalled_pending mechanism.
 
     **Delivery guard (#918):** Before recovering a running session to pending,
@@ -1420,6 +1447,21 @@ async def _agent_session_health_check() -> None:
                         int(running_seconds) if running_seconds else "?",
                         AGENT_SESSION_HEALTH_MIN_RUNNING,
                     )
+            # Project-keyed dev sessions share worker_key with PM; without a
+            # progress signal, worker_alive alone doesn't prove the dev session
+            # is being handled (#944).
+            elif (
+                running_seconds is not None
+                and running_seconds > AGENT_SESSION_HEALTH_MIN_RUNNING
+                and not _has_progress(entry)
+            ):
+                should_recover = True
+                reason = (
+                    f"worker alive but no progress signal, running for "
+                    f"{int(running_seconds)}s (>{AGENT_SESSION_HEALTH_MIN_RUNNING}s guard, "
+                    f"turn_count={entry.turn_count}, log_path={entry.log_path!r}, "
+                    f"claude_session_uuid={entry.claude_session_uuid!r})"
+                )
             elif started_ts is not None:
                 timeout = _get_agent_session_timeout(entry)
                 if running_seconds is not None and running_seconds > timeout:
@@ -1427,6 +1469,25 @@ async def _agent_session_health_check() -> None:
                     reason = f"exceeded timeout ({int(running_seconds)}s > {timeout}s)"
 
             if should_recover:
+                # O1: observability counter — classify the recovery reason and
+                # increment a project-scoped Redis counter for dashboards.
+                # Failure to write the counter must never block recovery.
+                try:
+                    if "no progress signal" in reason:
+                        _reason_kind = "no_progress"
+                    elif "exceeded timeout" in reason:
+                        _reason_kind = "timeout"
+                    else:
+                        _reason_kind = "worker_dead"
+                    from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+                    _R.incr(f"{entry.project_key}:session-health:recoveries:{_reason_kind}")
+                except Exception as _counter_err:
+                    logger.debug(
+                        "[session-health] recovery counter increment failed (non-fatal): %s",
+                        _counter_err,
+                    )
+
                 # Guard: if response was already delivered, finalize instead
                 # of recovering to pending (prevents duplicate delivery, #918)
                 if getattr(entry, "response_delivered_at", None) is not None:

--- a/docs/features/agent-session-health-monitor.md
+++ b/docs/features/agent-session-health-monitor.md
@@ -18,7 +18,8 @@ When a stuck running session is detected, it is automatically recovered by delet
 
 ### Detection
 
-- **Dead worker detection**: Checks `_active_workers[chat_id]` asyncio Task liveness via `.done()`. If the task has finished (crashed, cancelled, or completed), the session is considered orphaned.
+- **Dead worker detection**: Checks `_active_workers[worker_key]` asyncio Task liveness via `.done()`. If the task has finished (crashed, cancelled, or completed), the session is considered orphaned.
+- **No-progress detection (issue #944)**: Even when the worker is alive, a running session past the 300s startup guard is recovered if it shows no progress signal. `_has_progress(entry)` returns True iff ANY of `turn_count > 0`, non-empty `log_path`, or non-empty `claude_session_uuid` is set — together these cover the SDK subprocess warmup arc from auth to first turn. This catches slugless dev sessions stuck behind a co-running PM session (both share `worker_key == project_key`).
 - **Timeout detection**: Compares `started_at` timestamp against the configured max duration for the session type.
 - **Race condition guard**: Jobs must be running for at least 5 minutes (`AGENT_SESSION_HEALTH_MIN_RUNNING`) before they become eligible for recovery. This prevents false positives on jobs that just started processing.
 
@@ -35,10 +36,11 @@ Timeouts are measured from `started_at` (when the session begins processing), no
 
 When a stuck session is found:
 
-1. Log a warning with the session ID, project key, and reason (dead worker or timeout)
-2. Delete the orphaned AgentSession from Redis
-3. Re-create it as `pending` with all original data preserved
-4. Call `_ensure_worker()` to restart the processing loop for that project
+1. Log a warning with the session ID, project key, and reason (dead worker, no progress signal, or timeout)
+2. Increment the project-scoped Redis counter `{project_key}:session-health:recoveries:{worker_dead|no_progress|timeout}` for observability (non-fatal on failure)
+3. Delete the orphaned AgentSession from Redis
+4. Re-create it as `pending` with all original data preserved (local sessions finalize as `abandoned` instead)
+5. Call `_ensure_worker()` to restart the processing loop for that project
 
 ### Startup Integration
 
@@ -108,3 +110,4 @@ Constants in `agent/agent_session_queue.py`:
 - [agent-session-model.md](agent-session-model.md) -- AgentSession model fields and lifecycle
 - `agent/agent_session_queue.py` -- Implementation source
 - Issue #127 -- Original tracking issue
+- Issue #944 -- No-progress recovery for sessions stuck behind a shared-worker-key PM

--- a/docs/features/bridge-resilience.md
+++ b/docs/features/bridge-resilience.md
@@ -42,8 +42,9 @@ The six competing recovery mechanisms from the old system were replaced with one
 **`_agent_session_health_check()`** in `agent/agent_session_queue.py` scans both `running` and `pending` sessions:
 
 - **Running sessions**: If the worker for `session.worker_key` is dead/missing and the session has been running longer than the minimum threshold, recover it (reset to pending)
+- **Running sessions with no progress (#944)**: If the worker appears alive but the session has been running past `AGENT_SESSION_HEALTH_MIN_RUNNING` with no progress signal (`turn_count`, `log_path`, and `claude_session_uuid` all empty), recover it. Slugless dev sessions share `worker_key` with co-running PM sessions under the same project, so `worker_alive=True` alone does not prove the dev session is being handled. See [bridge-self-healing.md §8a](bridge-self-healing.md#8a-no-progress-recovery-for-shared-worker-key-sessions-944).
 - **Pending sessions**: If no live worker exists for `session.worker_key` and the session has been pending longer than the minimum threshold, start a worker
-- **Key invariant**: Sessions with a live worker on the same `worker_key` are never touched
+- **Key invariant**: Sessions with a live worker AND at least one progress signal are never touched
 
 ### Startup Recovery
 

--- a/docs/features/bridge-self-healing.md
+++ b/docs/features/bridge-self-healing.md
@@ -140,6 +140,28 @@ Both the delivery stamp and the health-check guard are wrapped in `try/except` s
 - `AgentSession.response_delivered_at` — nullable `DatetimeField`, set once on successful delivery
 - Health-check path: `_agent_session_health_check()` → `should_recover` → delivery guard → `finalize_session()`
 
+#### 8a. No-Progress Recovery for Shared-Worker-Key Sessions (#944)
+
+**Problem**: A slugless dev session shares `worker_key` with any co-running PM session under the same project (both resolve to `project_key` via `AgentSession.worker_key`). `_agent_session_health_check` determined liveness via `worker_alive = _active_workers.get(worker_key) is not None and not worker.done()`. When a PM was alive under the same project, `worker_alive = True` even though the stuck dev session was not actually being handled — so the `not worker_alive` branch was skipped, and the dev session was only recovered after the 45-minute timeout (`AGENT_SESSION_TIMEOUT_DEFAULT` / `AGENT_SESSION_TIMEOUT_BUILD`) — 9x the intended 5-minute cadence.
+
+**Solution**: A new `elif` branch in `_agent_session_health_check` recovers sessions that are `worker_alive=True`, past the `AGENT_SESSION_HEALTH_MIN_RUNNING` (300s) startup guard, AND have no progress signal. Progress is evaluated by `_has_progress(entry)` which returns True if ANY of three fields is set: `turn_count > 0`, a non-empty `log_path`, or a non-empty `claude_session_uuid`. Together these cover the full SDK subprocess warmup arc:
+
+- `claude_session_uuid` — set when the SDK subprocess authenticates with the Claude API (seconds after launch)
+- `log_path` — set once the session writes its first log entry (first tool call)
+- `turn_count` — incremented on each full agent turn completion
+
+A legitimately slow-starting BUILD session that takes 600s before its first turn will still have `claude_session_uuid` populated within seconds of auth, so the no-progress branch does not fire. The recovered session routes through the existing delivery guard, then the `is_local` split: local sessions become `abandoned`, project-keyed sessions become `pending` (re-queued with `priority=high` and a fresh `_ensure_worker` call). The PM-associated project-keyed worker will pop and execute the re-queued dev session because `_pop_agent_session` filters only by `project_key`/`status`, not by `session_type`.
+
+**Observability**: Each recovery increments a project-scoped Redis counter keyed `{project_key}:session-health:recoveries:{reason_kind}` where `reason_kind` is one of `worker_dead`, `no_progress`, or `timeout`. The counter write is wrapped in `try/except` — failure cannot block recovery.
+
+**Diagnosing no-progress recoveries**:
+
+- Log grep: `grep "worker alive but no progress signal" logs/worker.log` — each hit is one no-progress recovery and includes `turn_count`, `log_path`, and `claude_session_uuid` for the affected session.
+- Expected rate ceiling: ≤ 1 no-progress recovery per project per hour under normal operation. Bursts of no-progress recoveries for sessions that should be healthy indicate the `AGENT_SESSION_HEALTH_MIN_RUNNING` guard is too short or the progress signal is too narrow.
+- Redis counter: `redis-cli GET {project_key}:session-health:recoveries:no_progress` (note: reading via `redis-cli` is observability-only; never mutate Popoto-managed keys directly).
+
+**Accepted race**: The recovery path does NOT protect progress fields under CAS — only `status`. In the tight window between reading `entry` and calling `transition_status("pending")`, a worker writing progress can have its in-flight work re-queued. This is rare and benign: the worker pops the re-queued session and runs from scratch. See the `test_progress_written_between_check_and_transition_is_lost_but_session_retries` unit test for the locked-in behavior.
+
 ### 9. Perplexity Provider Error Handling (`tools/web/providers/perplexity.py`)
 
 **Problem**: The Perplexity search provider had a bare `except Exception` that silently swallowed all errors, including 401 Unauthorized responses from expired API keys.

--- a/docs/features/session-recovery-mechanisms.md
+++ b/docs/features/session-recovery-mechanisms.md
@@ -26,10 +26,12 @@ The session system has 8 mechanisms that can revive, recover, or re-enqueue sess
 | Property | Value |
 |----------|-------|
 | Location | `agent/agent_session_queue.py` |
-| Trigger | Periodic timer (every 60s) |
-| What it does | Recovers stuck `running` sessions (dead worker, timeout) back to `pending`; starts workers for stalled `pending` sessions |
+| Trigger | Periodic timer (every 5 min, `AGENT_SESSION_HEALTH_CHECK_INTERVAL`) |
+| What it does | Recovers stuck `running` sessions back to `pending` on three signals: (1) dead/missing worker, (2) worker alive but no progress after the 300s startup guard (issue #944), (3) exceeded session timeout. Starts workers for stalled `pending` sessions. |
+| Progress signal | `_has_progress(entry)` returns True iff ANY of `turn_count > 0`, non-empty `log_path`, or non-empty `claude_session_uuid`. Covers the full SDK subprocess warmup arc so long-warmup BUILD sessions are not misclassified. |
 | Terminal safety | **Safe by query scope** -- only queries `status="running"` and `status="pending"` |
 | Guard | Query filter (only non-terminal statuses) + `transition_status()` with default `reject_from_terminal=True` |
+| Observability | Each recovery increments `{project_key}:session-health:recoveries:{worker_dead\|no_progress\|timeout}` in Redis (counter write is non-fatal) |
 
 #### Finalization gap on re-execution (issue #917)
 

--- a/docs/plans/health-check-no-progress-recovery.md
+++ b/docs/plans/health-check-no-progress-recovery.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: docs_complete
 type: bug
 appetite: Small
 owner: Valor Engels
@@ -175,10 +175,10 @@ The touched block already has a surrounding `try/except` at `agent/agent_session
 
 ## Test Impact
 
-- [x] `tests/unit/test_agent_session_queue.py::TestHealthCheckDeliveryGuard` — UPDATE: add a new test class `TestHealthCheckNoProgressRecovery` alongside it with the 7 cases listed in Task 1 (including the AD2 regression `test_recovered_dev_session_popped_by_shared_pm_worker` and the AD1 race-acceptance `test_progress_written_between_check_and_transition_is_lost_but_session_retries`). The existing delivery-guard tests should remain green (they use sessions with `worker_alive=False`; the new branch only fires when `worker_alive=True`).
-- [x] `tests/unit/test_health_check_recovery_finalization.py` — VERIFY: this file covers `running → abandoned/completed` transitions. Confirm the existing tests still pass after the fix; no changes needed unless a test happens to exercise a session with `worker_alive=True`, past the guard, and no progress — in which case the outcome changes (which is the intent).
-- [x] `tests/integration/test_agent_session_health_monitor.py` — VERIFY: integration test; confirm the assertions still hold and add one new assertion that a `turn_count=0`/empty-`log_path` running session with a live project-keyed worker is recovered after the guard window.
-- [x] `tests/unit/test_recovery_respawn_safety.py`, `tests/unit/test_stall_detection.py`, `tests/integration/test_agent_session_queue_race.py` — VERIFY: these also exercise the health-check code path. Run them after the fix and confirm no regressions.
+- [ ] `tests/unit/test_agent_session_queue.py::TestHealthCheckDeliveryGuard` — UPDATE: add a new test class `TestHealthCheckNoProgressRecovery` alongside it with the 7 cases listed in Task 1 (including the AD2 regression `test_recovered_dev_session_popped_by_shared_pm_worker` and the AD1 race-acceptance `test_progress_written_between_check_and_transition_is_lost_but_session_retries`). The existing delivery-guard tests should remain green (they use sessions with `worker_alive=False`; the new branch only fires when `worker_alive=True`).
+- [ ] `tests/unit/test_health_check_recovery_finalization.py` — VERIFY: this file covers `running → abandoned/completed` transitions. Confirm the existing tests still pass after the fix; no changes needed unless a test happens to exercise a session with `worker_alive=True`, past the guard, and no progress — in which case the outcome changes (which is the intent).
+- [ ] `tests/integration/test_agent_session_health_monitor.py` — VERIFY: integration test; confirm the assertions still hold and add one new assertion that a `turn_count=0`/empty-`log_path` running session with a live project-keyed worker is recovered after the guard window.
+- [ ] `tests/unit/test_recovery_respawn_safety.py`, `tests/unit/test_stall_detection.py`, `tests/integration/test_agent_session_queue_race.py` — VERIFY: these also exercise the health-check code path. Run them after the fix and confirm no regressions.
 
 No tests are deleted. No existing assertions are inverted. The fix is additive in its recovery surface — it widens the set of sessions recovered by adding a new qualifying condition, without changing outcomes for any session that was already being handled.
 
@@ -234,12 +234,12 @@ No agent integration required. This is a worker-internal change. The health chec
 ## Documentation
 
 ### Feature Documentation
-- [x] Update `docs/features/bridge-self-healing.md` (or the closest doc on the health-check system) with one paragraph describing the no-progress recovery path. If no existing doc describes `_agent_session_health_check` in detail, add a short section to `docs/features/bridge-worker-architecture.md` under the worker's responsibilities.
-- [x] Grep `docs/` for references to `AGENT_SESSION_HEALTH_MIN_RUNNING` and `_agent_session_health_check` and update any that describe the recovery decision tree.
+- [x] Update `docs/features/bridge-self-healing.md` with subsection 8a describing the no-progress recovery path (landed in PR #947).
+- [x] Cascade updates to `docs/features/bridge-resilience.md`, `docs/features/session-recovery-mechanisms.md`, and `docs/features/agent-session-health-monitor.md` — all decision-tree descriptions now include the no-progress branch.
 
 ### Inline Documentation
-- [x] Update the docstring of `_agent_session_health_check` at `agent/agent_session_queue.py:1353-1381` to list the new no-progress branch as item 2 (renumber existing items).
-- [x] Add a one-line comment above the new branch explaining the rationale: "Project-keyed dev sessions share worker_key with PM; without a progress signal, worker_alive alone doesn't prove the dev session is being handled."
+- [x] Updated the docstring of `_agent_session_health_check` to list the new no-progress branch as item 2 (renumbered existing items).
+- [x] Added a one-line comment above the new branch explaining the shared-worker-key rationale.
 
 ### External Documentation Site
 
@@ -247,17 +247,17 @@ Not applicable — this repo has no Sphinx/MkDocs site.
 
 ## Success Criteria
 
-- [x] **User-framed outcome:** Time-to-recovery for a stuck slugless Dev session drops from ~45 min to ≤5 min when a PM co-runs on the same project key. Verified by reproducing the 2026-04-14 scenario (two local `"test"` dev sessions stuck with `turn_count=0`/empty `log_path` while a `"valor"` PM is active) in a test fixture or staging run.
-- [x] A slugless dev session stuck in `running` with `turn_count=0`, empty `log_path`, and empty `claude_session_uuid` is recovered (→ `abandoned` for local sessions, → `pending` for project-keyed sessions) within one health-check cycle after the startup guard expires, even when a PM session is actively running under the same `worker_key`.
-- [x] A legitimately active dev session (ANY of `turn_count > 0`, non-empty `log_path`, or non-empty `claude_session_uuid`) is NOT incorrectly recovered while its worker is alive.
-- [x] New unit test: mock `_active_workers` with a live project-keyed task, create a session with all three progress fields empty, advance time past the guard, assert the health check recovers it via the expected path (local → abandoned, project-keyed → pending).
-- [x] New unit test: parametrized over the progress-field truth table, assert non-recovery whenever ANY of `turn_count`, `log_path`, or `claude_session_uuid` is set.
-- [x] New unit test `test_recovered_dev_session_popped_by_shared_pm_worker`: asserts `_pop_agent_session(worker_key, is_project_keyed=True)` returns the recovered Dev session even when a PM owns the worker task (AD2 regression lock-in).
-- [x] New unit test `test_progress_written_between_check_and_transition_is_lost_but_session_retries`: asserts the AD1 race behavior — a session that writes progress AFTER `entry` is loaded but BEFORE `transition_status` runs is re-queued (documented acceptable false-positive).
-- [x] All existing tests in `tests/unit/test_agent_session_queue.py`, `tests/unit/test_health_check_recovery_finalization.py`, `tests/unit/test_recovery_respawn_safety.py`, `tests/unit/test_stall_detection.py`, `tests/integration/test_agent_session_health_monitor.py`, and `tests/integration/test_agent_session_queue_race.py` still pass.
-- [x] No regression to the 45-minute timeout path — sessions with progress still hit that fallback when their worker appears alive for longer than the timeout.
-- [x] Tests pass (`/do-test`).
-- [x] Documentation updated (`/do-docs`).
+- [ ] **User-framed outcome:** Time-to-recovery for a stuck slugless Dev session drops from ~45 min to ≤5 min when a PM co-runs on the same project key. Verified by reproducing the 2026-04-14 scenario (two local `"test"` dev sessions stuck with `turn_count=0`/empty `log_path` while a `"valor"` PM is active) in a test fixture or staging run.
+- [ ] A slugless dev session stuck in `running` with `turn_count=0`, empty `log_path`, and empty `claude_session_uuid` is recovered (→ `abandoned` for local sessions, → `pending` for project-keyed sessions) within one health-check cycle after the startup guard expires, even when a PM session is actively running under the same `worker_key`.
+- [ ] A legitimately active dev session (ANY of `turn_count > 0`, non-empty `log_path`, or non-empty `claude_session_uuid`) is NOT incorrectly recovered while its worker is alive.
+- [ ] New unit test: mock `_active_workers` with a live project-keyed task, create a session with all three progress fields empty, advance time past the guard, assert the health check recovers it via the expected path (local → abandoned, project-keyed → pending).
+- [ ] New unit test: parametrized over the progress-field truth table, assert non-recovery whenever ANY of `turn_count`, `log_path`, or `claude_session_uuid` is set.
+- [ ] New unit test `test_recovered_dev_session_popped_by_shared_pm_worker`: asserts `_pop_agent_session(worker_key, is_project_keyed=True)` returns the recovered Dev session even when a PM owns the worker task (AD2 regression lock-in).
+- [ ] New unit test `test_progress_written_between_check_and_transition_is_lost_but_session_retries`: asserts the AD1 race behavior — a session that writes progress AFTER `entry` is loaded but BEFORE `transition_status` runs is re-queued (documented acceptable false-positive).
+- [ ] All existing tests in `tests/unit/test_agent_session_queue.py`, `tests/unit/test_health_check_recovery_finalization.py`, `tests/unit/test_recovery_respawn_safety.py`, `tests/unit/test_stall_detection.py`, `tests/integration/test_agent_session_health_monitor.py`, and `tests/integration/test_agent_session_queue_race.py` still pass.
+- [ ] No regression to the 45-minute timeout path — sessions with progress still hit that fallback when their worker appears alive for longer than the timeout.
+- [ ] Tests pass (`/do-test`).
+- [ ] Documentation updated (`/do-docs`).
 
 ## Team Orchestration
 

--- a/tests/unit/test_agent_session_queue.py
+++ b/tests/unit/test_agent_session_queue.py
@@ -849,7 +849,9 @@ class TestHealthCheckNoProgressRecovery:
 
             result = await _pop_agent_session("valor", is_project_keyed=True)
 
-        assert result is not None, "PM-associated project-keyed worker must pop the recovered dev session"
+        assert result is not None, (
+            "PM-associated project-keyed worker must pop the recovered dev session"
+        )
         assert result.agent_session_id == "ad2-regression-1"
         assert result.session_type == "dev"
 

--- a/tests/unit/test_agent_session_queue.py
+++ b/tests/unit/test_agent_session_queue.py
@@ -589,3 +589,319 @@ def test_append_event_succeeds_with_bad_response_delivered_at():
     bad_val = session.response_delivered_at
     session.response_delivered_at = bad_val
     assert session.response_delivered_at is None
+
+
+class TestHealthCheckNoProgressRecovery:
+    """Tests for the no-progress recovery branch in _agent_session_health_check (#944).
+
+    When a slugless dev session shares ``worker_key`` with a co-running PM session,
+    ``worker_alive=True`` alone is insufficient to prove the dev session is being
+    handled. The health check must inspect ``turn_count``, ``log_path``, and
+    ``claude_session_uuid`` — if none is set and the 300s startup guard has
+    elapsed, the session is orphaned and must be recovered.
+    """
+
+    def _make_stuck_dev_session(
+        self,
+        *,
+        project_key: str = "test",
+        agent_session_id: str = "stuck-dev-1",
+        turn_count: int = 0,
+        log_path=None,
+        claude_session_uuid=None,
+        started_seconds_ago: int = 600,
+        response_delivered_at=None,
+    ) -> AgentSession:
+        """Build an unsaved slugless dev session stuck in ``running``."""
+        import time as _time
+
+        started_at = datetime.fromtimestamp(_time.time() - started_seconds_ago, tz=UTC)
+        session = _make_session(
+            project_key=project_key,
+            status="running",
+            session_type="dev",
+            chat_id="some-chat-id",
+            started_at=started_at,
+        )
+        # Slugless dev → worker_key == project_key
+        session.slug = None
+        session.agent_session_id = agent_session_id
+        session.turn_count = turn_count
+        session.log_path = log_path
+        session.claude_session_uuid = claude_session_uuid
+        if response_delivered_at is not None:
+            session.response_delivered_at = response_delivered_at
+        return session
+
+    def _patch_lifecycle(self):
+        """Return (mock_finalize, mock_transition, context_manager).
+
+        The context manager patches both finalize_session and transition_status
+        in models.session_lifecycle and restores them on exit.
+        """
+        import contextlib
+
+        mock_finalize = MagicMock()
+        mock_transition = MagicMock()
+
+        @contextlib.contextmanager
+        def _ctx():
+            import models.session_lifecycle as lifecycle_mod
+
+            original_finalize = lifecycle_mod.finalize_session
+            original_transition = lifecycle_mod.transition_status
+            lifecycle_mod.finalize_session = mock_finalize
+            lifecycle_mod.transition_status = mock_transition
+            try:
+                yield
+            finally:
+                lifecycle_mod.finalize_session = original_finalize
+                lifecycle_mod.transition_status = original_transition
+
+        return mock_finalize, mock_transition, _ctx()
+
+    @pytest.mark.asyncio
+    async def test_no_progress_project_keyed_recovered_to_pending(self):
+        """Slugless dev session with no progress and a live project-keyed worker
+        must be recovered to ``pending`` after the 300s guard."""
+        session = self._make_stuck_dev_session(
+            project_key="valor",
+            agent_session_id="no-prog-proj-1",
+        )
+        # worker_key for a slugless dev session == project_key
+        assert session.worker_key == "valor"
+
+        mock_finalize, mock_transition, lifecycle_ctx = self._patch_lifecycle()
+        live_worker = MagicMock(done=MagicMock(return_value=False))
+
+        with (
+            patch("agent.agent_session_queue.AgentSession") as mock_cls,
+            patch("agent.agent_session_queue._active_workers", {"valor": live_worker}),
+            patch("agent.agent_session_queue._ensure_worker"),
+            lifecycle_ctx,
+        ):
+            mock_cls.query.filter.return_value = [session]
+            from agent.agent_session_queue import _agent_session_health_check
+
+            await _agent_session_health_check()
+
+        mock_transition.assert_called_once()
+        assert mock_transition.call_args[0][1] == "pending"
+        mock_finalize.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_progress_local_session_abandoned(self):
+        """Local dev session (worker_key starts with ``local``) with no progress
+        and a live worker must be finalized as ``abandoned``."""
+        session = self._make_stuck_dev_session(
+            project_key="local-valor",
+            agent_session_id="no-prog-local-1",
+        )
+        assert session.worker_key == "local-valor"
+
+        mock_finalize, mock_transition, lifecycle_ctx = self._patch_lifecycle()
+        live_worker = MagicMock(done=MagicMock(return_value=False))
+
+        with (
+            patch("agent.agent_session_queue.AgentSession") as mock_cls,
+            patch("agent.agent_session_queue._active_workers", {"local-valor": live_worker}),
+            lifecycle_ctx,
+        ):
+            mock_cls.query.filter.return_value = [session]
+            from agent.agent_session_queue import _agent_session_health_check
+
+            await _agent_session_health_check()
+
+        mock_finalize.assert_called_once()
+        assert mock_finalize.call_args[0][1] == "abandoned"
+        mock_transition.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "turn_count,log_path,claude_session_uuid",
+        [
+            (2, None, None),
+            (2, "/tmp/x.jsonl", None),
+            (0, "/tmp/x.jsonl", None),
+            (0, None, "uuid-abc-123"),
+            (0, "", "uuid-abc-123"),
+        ],
+    )
+    async def test_with_progress_not_recovered_parametrized(
+        self, turn_count, log_path, claude_session_uuid
+    ):
+        """Any single progress signal (turn_count / log_path / claude_session_uuid)
+        is sufficient to keep a session from being recovered by the no-progress branch."""
+        session = self._make_stuck_dev_session(
+            project_key="valor",
+            agent_session_id=f"progress-{turn_count}-{bool(log_path)}-{bool(claude_session_uuid)}",
+            turn_count=turn_count,
+            log_path=log_path,
+            claude_session_uuid=claude_session_uuid,
+            started_seconds_ago=600,  # past the 300s guard but under the 45m timeout
+        )
+
+        mock_finalize, mock_transition, lifecycle_ctx = self._patch_lifecycle()
+        live_worker = MagicMock(done=MagicMock(return_value=False))
+
+        with (
+            patch("agent.agent_session_queue.AgentSession") as mock_cls,
+            patch("agent.agent_session_queue._active_workers", {"valor": live_worker}),
+            patch("agent.agent_session_queue._ensure_worker"),
+            lifecycle_ctx,
+        ):
+            mock_cls.query.filter.return_value = [session]
+            from agent.agent_session_queue import _agent_session_health_check
+
+            await _agent_session_health_check()
+
+        mock_finalize.assert_not_called()
+        mock_transition.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_progress_under_guard_not_recovered(self):
+        """No-progress session that has only been running 60s is under the
+        300s startup guard and must NOT be recovered."""
+        session = self._make_stuck_dev_session(
+            project_key="valor",
+            agent_session_id="under-guard-1",
+            started_seconds_ago=60,
+        )
+
+        mock_finalize, mock_transition, lifecycle_ctx = self._patch_lifecycle()
+        live_worker = MagicMock(done=MagicMock(return_value=False))
+
+        with (
+            patch("agent.agent_session_queue.AgentSession") as mock_cls,
+            patch("agent.agent_session_queue._active_workers", {"valor": live_worker}),
+            patch("agent.agent_session_queue._ensure_worker"),
+            lifecycle_ctx,
+        ):
+            mock_cls.query.filter.return_value = [session]
+            from agent.agent_session_queue import _agent_session_health_check
+
+            await _agent_session_health_check()
+
+        mock_finalize.assert_not_called()
+        mock_transition.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_progress_with_delivered_response_finalized_completed(self):
+        """Defensive: a no-progress session with response_delivered_at set must
+        still hit the delivery guard first and finalize as ``completed``."""
+        session = self._make_stuck_dev_session(
+            project_key="valor",
+            agent_session_id="no-prog-delivered-1",
+            response_delivered_at=datetime(2024, 1, 1, tzinfo=UTC),
+        )
+
+        mock_finalize, mock_transition, lifecycle_ctx = self._patch_lifecycle()
+        live_worker = MagicMock(done=MagicMock(return_value=False))
+
+        with (
+            patch("agent.agent_session_queue.AgentSession") as mock_cls,
+            patch("agent.agent_session_queue._active_workers", {"valor": live_worker}),
+            patch("agent.agent_session_queue._ensure_worker"),
+            lifecycle_ctx,
+        ):
+            mock_cls.query.filter.return_value = [session]
+            from agent.agent_session_queue import _agent_session_health_check
+
+            await _agent_session_health_check()
+
+        mock_finalize.assert_called_once()
+        assert mock_finalize.call_args[0][1] == "completed"
+        mock_transition.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_recovered_dev_session_popped_by_shared_pm_worker(self):
+        """AD2 regression: _pop_agent_session must not filter by session_type.
+
+        After a no-progress recovery transitions a slugless dev session to
+        ``pending``, the PM-associated project-keyed worker loop must be able
+        to pop and execute it. This locks in the assumption that
+        ``_pop_agent_session(worker_key, is_project_keyed=True)`` selects by
+        project_key/status only — no session_type filter.
+        """
+        session = self._make_stuck_dev_session(
+            project_key="valor",
+            agent_session_id="ad2-regression-1",
+        )
+        session.status = "pending"
+        session.priority = "high"
+
+        async def _mock_async_filter(**kwargs):
+            if kwargs.get("status") == "pending" and kwargs.get("project_key") == "valor":
+                return [session]
+            return []
+
+        with (
+            patch("agent.agent_session_queue.AgentSession") as mock_cls,
+            patch("agent.agent_session_queue._acquire_pop_lock", return_value=True),
+            patch("agent.agent_session_queue._release_pop_lock"),
+            patch("popoto.redis_db.POPOTO_REDIS_DB") as mock_redis,
+        ):
+            # Redis sustainability guards return falsy → proceed normally.
+            mock_redis.get.return_value = None
+            mock_cls.query.async_filter = AsyncMock(side_effect=_mock_async_filter)
+            # transition_status is called via save() internally; mock save to no-op.
+            session.save = MagicMock()
+
+            result = await _pop_agent_session("valor", is_project_keyed=True)
+
+        assert result is not None, "PM-associated project-keyed worker must pop the recovered dev session"
+        assert result.agent_session_id == "ad2-regression-1"
+        assert result.session_type == "dev"
+
+    @pytest.mark.asyncio
+    async def test_progress_written_between_check_and_transition_is_lost_but_session_retries(self):
+        """AD1 race acceptance: a worker writing progress AFTER ``entry`` is
+        loaded but BEFORE ``transition_status`` runs is NOT protected by the
+        status CAS. The session is re-queued regardless — accepted behavior.
+        """
+        session = self._make_stuck_dev_session(
+            project_key="valor",
+            agent_session_id="race-1",
+        )
+
+        def _set_progress_then_record(entry, new_status, **_):
+            # Simulate a concurrent progress write landing on the in-memory
+            # entry mid-recovery. The status CAS does not inspect progress
+            # fields, so the transition still proceeds.
+            entry.turn_count = 1
+
+        mock_finalize = MagicMock()
+        mock_transition = MagicMock(side_effect=_set_progress_then_record)
+
+        import contextlib
+
+        @contextlib.contextmanager
+        def _ctx():
+            import models.session_lifecycle as lifecycle_mod
+
+            orig_f = lifecycle_mod.finalize_session
+            orig_t = lifecycle_mod.transition_status
+            lifecycle_mod.finalize_session = mock_finalize
+            lifecycle_mod.transition_status = mock_transition
+            try:
+                yield
+            finally:
+                lifecycle_mod.finalize_session = orig_f
+                lifecycle_mod.transition_status = orig_t
+
+        live_worker = MagicMock(done=MagicMock(return_value=False))
+
+        with (
+            patch("agent.agent_session_queue.AgentSession") as mock_cls,
+            patch("agent.agent_session_queue._active_workers", {"valor": live_worker}),
+            patch("agent.agent_session_queue._ensure_worker"),
+            _ctx(),
+        ):
+            mock_cls.query.filter.return_value = [session]
+            from agent.agent_session_queue import _agent_session_health_check
+
+            await _agent_session_health_check()
+
+        mock_transition.assert_called_once()
+        assert mock_transition.call_args[0][1] == "pending"
+        mock_finalize.assert_not_called()


### PR DESCRIPTION
## Summary
- Adds a no-progress recovery branch to `_agent_session_health_check` so slugless dev sessions stuck in `running` (with `turn_count=0`, empty `log_path`, empty `claude_session_uuid`) are recovered within one 5-minute health-check cycle after the 300s startup guard — even when a PM session co-runs under the same `worker_key`.
- Introduces a `_has_progress(entry)` helper over three fields (`turn_count`, `log_path`, `claude_session_uuid`) that together cover the full SDK subprocess warmup arc, so long-warmup BUILD sessions are never misclassified.
- Adds project-scoped Redis recovery counters at `{project_key}:session-health:recoveries:{worker_dead|no_progress|timeout}` for operator observability (writes wrapped in try/except).

## Changes
- `agent/agent_session_queue.py`: new `_has_progress` helper, new `elif` branch in the decision tree between `not worker_alive` and the timeout fallback, updated docstring, O1 Redis counter hook.
- `tests/unit/test_agent_session_queue.py`: new `TestHealthCheckNoProgressRecovery` class with 11 cases covering project-keyed/local split, parametrized progress truth table, under-guard no-op, delivery-guard intersection, the AD2 regression lock-in (`test_recovered_dev_session_popped_by_shared_pm_worker`), and the AD1 race acceptance (`test_progress_written_between_check_and_transition_is_lost_but_session_retries`).
- `docs/features/bridge-self-healing.md`: new subsection 8a documenting the no-progress recovery path, the three-field progress signal, observability counter, log grep pattern, and the accepted race behavior.

## Testing
- [x] New test class: 11/11 passing (`pytest tests/unit/test_agent_session_queue.py::TestHealthCheckNoProgressRecovery`)
- [x] Full `tests/unit/test_agent_session_queue.py`: 37/37 passing
- [x] Unit batch per plan (`test_agent_session_queue` + `test_health_check_recovery_finalization` + `test_recovery_respawn_safety` + `test_stall_detection`): 111/111 passing
- [x] Integration (`test_agent_session_health_monitor` + `test_agent_session_queue_race`): 43/43 passing
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean

The pre-existing `-n auto` failures in `test_chunking.py`, `test_knowledge_indexer.py`, `test_intake_classifier.py`, `test_media_handling.py`, `test_summarizer.py`, `test_work_request_classifier.py` reproduce on `main` (verified by fresh clone) and are unrelated parallel-worker test isolation issues.

## Documentation
- [x] `docs/features/bridge-self-healing.md` updated with subsection 8a describing the new branch.
- [x] Inline docstring on `_agent_session_health_check` renumbered to list the no-progress branch as item 2.
- [x] `docs/features/bridge-worker-architecture.md` left unchanged — it does not describe the `_agent_session_health_check` decision tree; the feature doc is the right home for this.

## Definition of Done
- [x] Built: `_has_progress` helper + new elif branch + Redis counter wired up.
- [x] Tested: unit and integration suites green for affected modules.
- [x] Documented: feature doc updated, docstring updated, plan verification table runs.
- [x] Quality: lint and format clean.

Closes #944