### PR TITLE
refactor(bridge): centralize dedup recording in dispatch wrapper

### DIFF
--- a/bridge/dedup.py
+++ b/bridge/dedup.py
@@ -26,9 +26,21 @@ async def is_duplicate_message(chat_id, message_id: int) -> bool:
 
 
 async def record_message_processed(chat_id, message_id: int) -> None:
-    """Record that we processed this message."""
+    """Record that we processed this message.
+
+    Failures are logged at WARNING (not debug): a silent dedup outage causes
+    the reconciler to re-dispatch every message for the duration of the
+    failure, which is exactly the class of bug this function exists to
+    prevent. Exceptions are NOT re-raised -- dedup recording must never
+    break the caller's control flow.
+    """
     try:
         record = DedupRecord.get_or_create(str(chat_id))
         record.add_message(message_id)
     except Exception as e:
-        logger.debug(f"Dedup record failed (non-fatal): {e}")
+        logger.warning(
+            "dedup record failed for chat=%s msg=%s: %s",
+            chat_id,
+            message_id,
+            e,
+        )

--- a/bridge/dispatch.py
+++ b/bridge/dispatch.py
@@ -1,0 +1,126 @@
+"""Centralized dispatch wrapper for Telegram-originating session enqueues.
+
+Every Telegram-originating session enqueue in the live handler goes through
+``dispatch_telegram_session``, which enqueues and then records dedup atomically
+from the caller's perspective. This removes the distributed per-call-site
+contract that previously required every early-return branch in
+``bridge/telegram_bridge.py::handler`` to remember a manual
+``record_message_processed`` call.
+
+Non-enqueue branches (steering an existing session, finalizing a dormant
+session) call :func:`record_telegram_message_handled` to record dedup without
+enqueuing -- the reconciler treats the message as handled and skips it on its
+next 3-minute scan.
+
+Recovery paths (``bridge/catchup.py``, ``bridge/reconciler.py``) intentionally
+do NOT use this wrapper. They know they are writing to dedup and keep their
+explicit two-step pairing so future maintainers can see that these paths are
+different from the live handler's dispatch.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from agent.agent_session_queue import enqueue_agent_session
+from bridge.dedup import record_message_processed
+from config.enums import SessionType
+
+logger = logging.getLogger(__name__)
+
+
+async def dispatch_telegram_session(
+    *,
+    project_key: str,
+    session_id: str,
+    working_dir: str,
+    message_text: str,
+    sender_name: str,
+    chat_id: str,
+    telegram_message_id: int,
+    chat_title: str | None = None,
+    priority: str = "normal",
+    revival_context: str | None = None,
+    sender_id: int | None = None,
+    slug: str | None = None,
+    task_list_id: str | None = None,
+    classification_type: str | None = None,
+    auto_continue_count: int = 0,
+    correlation_id: str | None = None,
+    scheduled_at: float | None = None,
+    parent_agent_session_id: str | None = None,
+    telegram_message_key: str | None = None,
+    session_type: str = SessionType.PM,
+    scheduling_depth: int = 0,
+    project_config: dict | None = None,
+    extra_context_overrides: dict | None = None,
+) -> int:
+    """Enqueue a Telegram-originating session and record dedup.
+
+    Signature mirrors :func:`agent.agent_session_queue.enqueue_agent_session`
+    exactly so the live handler can pass through its existing kwargs.
+
+    Ordering matters: ``enqueue_agent_session`` must complete successfully
+    before ``record_message_processed`` runs. If the enqueue raises, we do
+    NOT record dedup -- the reconciler will pick the message up on its next
+    scan, which is the correct recovery behavior.
+
+    This wrapper does NOT catch exceptions from ``enqueue_agent_session``.
+    A failed enqueue propagates so the caller can log/handle, and leaves
+    dedup unrecorded so the reconciler can retry.
+
+    Returns:
+        The queue depth returned by ``enqueue_agent_session``.
+    """
+    depth = await enqueue_agent_session(
+        project_key=project_key,
+        session_id=session_id,
+        working_dir=working_dir,
+        message_text=message_text,
+        sender_name=sender_name,
+        chat_id=chat_id,
+        telegram_message_id=telegram_message_id,
+        chat_title=chat_title,
+        priority=priority,
+        revival_context=revival_context,
+        sender_id=sender_id,
+        slug=slug,
+        task_list_id=task_list_id,
+        classification_type=classification_type,
+        auto_continue_count=auto_continue_count,
+        correlation_id=correlation_id,
+        scheduled_at=scheduled_at,
+        parent_agent_session_id=parent_agent_session_id,
+        telegram_message_key=telegram_message_key,
+        session_type=session_type,
+        scheduling_depth=scheduling_depth,
+        project_config=project_config,
+        extra_context_overrides=extra_context_overrides,
+    )
+    await record_message_processed(chat_id, telegram_message_id)
+    return depth
+
+
+async def record_telegram_message_handled(chat_id, telegram_message_id: int) -> None:
+    """Record dedup for a message handled WITHOUT enqueuing a new session.
+
+    Use this for the non-enqueue branches of the live handler: intake
+    interjection (steer existing session), intake acknowledgment (finalize
+    dormant session), and the in-memory coalescing guard (merge into a
+    pending session). These branches "handled" the message -- the reconciler
+    must skip it on its next scan -- but they did not produce a new
+    ``AgentSession``.
+
+    This is a semantic sibling of :func:`dispatch_telegram_session`. Keeping
+    it as a distinct function earns its weight by emitting a ``logger.debug``
+    line with a grep-able signature that distinguishes steered/finalized
+    outcomes from the enqueue path. The underlying
+    :func:`bridge.dedup.record_message_processed` already swallows exceptions
+    and logs at warning level, so this function never raises either.
+    """
+    logger.debug(
+        "telegram message handled without enqueue: chat=%s msg=%s",
+        chat_id,
+        telegram_message_id,
+    )
+    await record_message_processed(chat_id, telegram_message_id)

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -98,6 +98,10 @@ from bridge.context import (  # noqa: E402
     references_prior_context,
     resolve_root_session_id,
 )
+from bridge.dispatch import (  # noqa: E402
+    dispatch_telegram_session,
+    record_telegram_message_handled,
+)
 from bridge.media import (  # noqa: E402
     MEDIA_DIR,  # noqa: F401
     VISION_EXTENSIONS,  # noqa: F401
@@ -1166,7 +1170,6 @@ async def main():
         import re as _re
 
         from agent.agent_session_queue import (
-            enqueue_agent_session,
             maybe_send_revival_prompt,
             queue_revival_agent_session,
         )
@@ -1336,10 +1339,7 @@ async def main():
                         # tightens the window for Race 2 (concurrent rapid-fire
                         # replies resolving to the same completed session).
                         # Plan IN-4.
-                        from bridge.dedup import (
-                            is_duplicate_message,
-                            record_message_processed,
-                        )
+                        from bridge.dedup import is_duplicate_message
 
                         if await is_duplicate_message(event.chat_id, message.id):
                             logger.debug(
@@ -1422,7 +1422,7 @@ async def main():
                         _completed_extra_overrides: dict | None = None
                         if reply_chain_context:
                             _completed_extra_overrides = {"reply_chain_hydrated": True}
-                        await enqueue_agent_session(
+                        await dispatch_telegram_session(
                             project_key=project_key,
                             session_id=session_id,
                             working_dir=_completed_working_dir,
@@ -1442,8 +1442,6 @@ async def main():
                             f"{session_id} with prior context "
                             f"(reply_chain={'yes' if reply_chain_context else 'no'})"
                         )
-
-                        await record_message_processed(event.chat_id, message.id)
                         return
             except (ConnectionError, OSError) as e:
                 # Redis/DB connection errors -- log at ERROR with traceback
@@ -1524,9 +1522,7 @@ async def main():
                             )
                             # Record as processed so bridge restart
                             # catch-up doesn't reprocess this message
-                            from bridge.dedup import record_message_processed
-
-                            await record_message_processed(event.chat_id, message.id)
+                            await record_telegram_message_handled(event.chat_id, message.id)
                             return
                         else:
                             # AgentSession still not in Redis after retry — fall through
@@ -1634,9 +1630,7 @@ async def main():
                                 sender_name,
                             )
                             # Record as processed and return
-                            from bridge.dedup import record_message_processed
-
-                            await record_message_processed(event.chat_id, message.id)
+                            await record_telegram_message_handled(event.chat_id, message.id)
                             return
                         else:
                             logger.info(
@@ -1666,9 +1660,7 @@ async def main():
                                 f"acknowledged session "
                                 f"{target_session.session_id} as complete"
                             )
-                            from bridge.dedup import record_message_processed
-
-                            await record_message_processed(event.chat_id, message.id)
+                            await record_telegram_message_handled(event.chat_id, message.id)
                             return
                         else:
                             logger.info(
@@ -1845,7 +1837,9 @@ async def main():
 
         # Enqueue: session_type drives PM vs Dev session creation.
         # Pass full project config so the session carries it through the pipeline.
-        depth = await enqueue_agent_session(
+        # dispatch_telegram_session wraps enqueue_agent_session + dedup record so
+        # every live-handler enqueue site has dedup recorded atomically.
+        depth = await dispatch_telegram_session(
             project_key=project_key,
             session_id=session_id,
             working_dir=working_dir_str,
@@ -1865,11 +1859,6 @@ async def main():
         logger.info(
             f"[{project_name}] Queued session for {sender_name} (msg {message_id}, depth={depth})"
         )
-
-        # Record message as processed (dedup for catch_up replays)
-        from bridge.dedup import record_message_processed
-
-        await record_message_processed(event.chat_id, message.id)
 
     # Mutable ref for knowledge watcher (populated later, read by shutdown handler)
     _knowledge_watcher_ref: list = [None]

--- a/docs/features/bridge-module-architecture.md
+++ b/docs/features/bridge-module-architecture.md
@@ -10,6 +10,8 @@ The Telegram bridge (`bridge/telegram_bridge.py`) is organized into focused sub-
 | `bridge/response.py` | Message formatting, reactions (re-exports from `agent/constants.py`), file extraction, sending |
 | `bridge/catchup.py` | Abandoned session revival and re-enqueueing |
 | `bridge/reconciler.py` | Periodic scan for messages missed during live connection |
+| `bridge/dedup.py` | Per-chat message dedup storage (`DedupRecord`), `is_duplicate_message`, `record_message_processed` |
+| `bridge/dispatch.py` | Centralized dispatch wrapper: every live-handler ingestion site enqueues and records dedup through `dispatch_telegram_session` / `record_telegram_message_handled` |
 
 ## telegram_bridge.py
 
@@ -40,3 +42,32 @@ from bridge.telegram_bridge import get_media_type
 ## Configuration Propagation
 
 Sub-modules that depend on runtime configuration (loaded from `~/Desktop/Valor/projects.json` and `.env`) receive it via module-level attribute assignment in `telegram_bridge.py` at startup. This avoids circular imports while ensuring sub-module functions have access to config, project mappings, and active project lists.
+
+## Message Ingestion Flow
+
+The `handler()` callback in `telegram_bridge.py` has five routes that can end in a dedup record. All five route through `bridge/dispatch.py` rather than calling `enqueue_agent_session` / `record_message_processed` directly. This centralization is enforced by an AST contract test (`tests/unit/test_bridge_dispatch_contract.py`) that fails the build if any `handler` branch bypasses the wrapper.
+
+```mermaid
+flowchart TD
+    U[Telegram Update] --> H[bridge/telegram_bridge.py::handler]
+
+    H -->|reply-to-valor: session already completed| B1[resume-completed branch]
+    H -->|rapid-fire follow-up within merge window| B2[in-memory coalescing guard]
+    H -->|classifier: interjection| B3[steer active session]
+    H -->|classifier: acknowledgment of dormant session| B4[finalize session]
+    H -->|new_work / classifier fallthrough| B5[canonical enqueue]
+
+    B1 --> DISP[bridge/dispatch.py::dispatch_telegram_session]
+    B5 --> DISP
+    B2 --> REC[bridge/dispatch.py::record_telegram_message_handled]
+    B3 --> REC
+    B4 --> REC
+
+    DISP --> Q[agent/agent_session_queue.py::enqueue_agent_session]
+    DISP --> DEDUP[bridge/dedup.py::record_message_processed]
+    REC --> DEDUP
+```
+
+The wrapper records dedup only after `enqueue_agent_session` returns successfully, so a failed enqueue leaves dedup unrecorded and the reconciler can retry the message on its next scan.
+
+Recovery paths (`bridge/catchup.py`, `bridge/reconciler.py`) are intentionally NOT routed through `bridge/dispatch.py` -- they keep their explicit `enqueue_agent_session` + `record_message_processed` pairing so future maintainers can see that these paths are different from the live handler's dispatch.

--- a/docs/features/message-reconciler.md
+++ b/docs/features/message-reconciler.md
@@ -82,7 +82,45 @@ grep reconciler logs/bridge.log
 
 ## Race Conditions
 
-A message could arrive at the event handler and the reconciler simultaneously before either records it in dedup. The session queue handles duplicate session IDs gracefully (second enqueue is a no-op), so this is a benign race with no user-visible effect.
+The live handler and the reconciler can both observe the same incoming message briefly, but the window is narrow and the outcomes are bounded.
+
+**Canonical path (queue coalesces).** The live handler's main enqueue path derives `session_id = tg_{project}_{chat_id}_{message_id}` -- identical to the `session_id` the reconciler would derive for the same message. If both fire before dedup is recorded, the second `enqueue_agent_session` is a no-op because the queue coalesces duplicate `session_id`s. No duplicate dispatch.
+
+**Resume-completed and other early-return branches (formerly unsafe, now mitigated).** The handler has several early-return branches that do NOT derive a fresh `session_id` from the incoming message -- they reuse an existing session id (resume-completed branch), steer an in-memory coalesced session, or finalize a dormant session. Their `session_id` differs from the reconciler's `tg_{project}_{chat_id}_{message_id}`, so the queue's coalescing guard does not fire. Historically each branch had to remember to call `record_message_processed` manually; a missed call produced a duplicate dispatch ~3 minutes later when the reconciler's next scan ran.
+
+`bridge/dispatch.py` closes this gap by providing `dispatch_telegram_session` (wraps enqueue + dedup record) and `record_telegram_message_handled` (dedup record only, for steer/finalize branches). Every live-handler branch now routes through one of these two helpers, so the reconciler's next `is_duplicate_message` check always returns True for a message the live handler has already handled. An AST contract test (`tests/unit/test_bridge_dispatch_contract.py`) fails the build if any new handler branch reintroduces a direct `enqueue_agent_session` or `record_message_processed` call.
+
+**Residual crash window.** If the bridge crashes between `enqueue_agent_session` returning and `record_message_processed` being written, the enqueued session survives in Redis but dedup is not recorded. The worker's recovery path will still pick up the enqueued session; the reconciler's next scan may also enqueue a second session under a different `session_id`. Orders of magnitude less likely than the class of bug the wrapper removes; accepted as residual risk.
+
+## Ingestion Paths
+
+```mermaid
+flowchart TD
+    TG[Telegram Update] --> H{handler}
+    H -->|reply to completed session| R1[resume-completed branch]
+    H -->|rapid-fire follow-up| R2[in-memory coalescing guard]
+    H -->|classifier: interjection| R3[steer active session]
+    H -->|classifier: acknowledgment| R4[finalize dormant session]
+    H -->|new_work| R5[canonical enqueue]
+
+    R1 --> D1[dispatch_telegram_session]
+    R5 --> D1
+    R2 --> D2[record_telegram_message_handled]
+    R3 --> D2
+    R4 --> D2
+
+    D1 --> E[enqueue_agent_session]
+    E --> DR[DedupRecord 2h TTL]
+    D1 --> DR
+    D2 --> DR
+
+    REC[reconciler_loop every 3m] -->|for each recent msg| CHK{is_duplicate_message}
+    CHK -->|yes| SKIP[skip]
+    CHK -->|no| RE[enqueue_agent_session +<br/>record_message_processed]
+    DR --> CHK
+```
+
+Every ingestion path writes to the same `DedupRecord` gate, so the reconciler's next scan short-circuits on anything the live handler already handled.
 
 ## API Cost
 
@@ -94,7 +132,10 @@ One `get_messages(limit=20)` call per monitored group per interval. With 5 group
 |------|---------|
 | `bridge/reconciler.py` | Reconciliation loop and single-scan function |
 | `bridge/telegram_bridge.py` | Registers reconciler as background task |
+| `bridge/dispatch.py` | Centralized dispatch wrapper; every live-handler ingestion site records dedup here |
+| `bridge/dedup.py` | `DedupRecord` storage, `is_duplicate_message`, `record_message_processed` |
 | `tests/unit/test_reconciler.py` | Unit tests for gap detection logic |
+| `tests/unit/test_bridge_dispatch_contract.py` | AST contract test: handler must not bypass `bridge/dispatch.py` |
 | `tests/integration/test_reconciler.py` | Integration test for end-to-end recovery |
 
 ## Related

--- a/tests/unit/test_bridge_dispatch_contract.py
+++ b/tests/unit/test_bridge_dispatch_contract.py
@@ -1,0 +1,266 @@
+"""Contract test: live handler must dispatch dedup through bridge/dispatch.py.
+
+The Telegram live handler (``bridge/telegram_bridge.py::handler``) has several
+early-return branches that must each record dedup so the reconciler's next
+3-minute scan skips the message. Historically this was a distributed
+per-call-site rule: every new branch had to remember to call
+``record_message_processed``. A missed call produced a duplicate agent
+session (see issue #948).
+
+This test enforces the contract at the AST level:
+
+1. The top-level ``handler`` function (decorated with ``@client.on(...)``)
+   contains zero direct calls to ``enqueue_agent_session`` or
+   ``record_message_processed``.
+2. ``bridge/dispatch.py::dispatch_telegram_session`` calls
+   ``enqueue_agent_session`` BEFORE ``record_message_processed`` so a
+   failed enqueue never poisons the dedup record.
+3. The AST walker itself detects a violation when given a synthetic
+   source containing a bare ``enqueue_agent_session`` call inside a
+   ``@client.on``-decorated handler (no manual inject/revert dance).
+
+Scope notes:
+- The walker enters the ``handler`` body but does NOT descend into nested
+  functions, lambdas, or comprehensions (C1). Non-handler code in
+  ``telegram_bridge.py`` (catchup/reconcile wrappers, etc.) is not
+  constrained.
+- ``handler`` is resolved deterministically by walking the module body and
+  matching the ``AsyncFunctionDef`` whose name is ``handler`` AND whose
+  decorator list contains a ``<x>.on(...)`` call (Telethon event
+  registration) (C2). A rename will fail loudly.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BRIDGE_SRC = REPO_ROOT / "bridge" / "telegram_bridge.py"
+DISPATCH_SRC = REPO_ROOT / "bridge" / "dispatch.py"
+
+BANNED_IN_HANDLER = frozenset({"enqueue_agent_session", "record_message_processed"})
+
+
+def _find_telethon_handler(tree: ast.Module) -> ast.AsyncFunctionDef | None:
+    """Find the Telethon ``handler`` async function deterministically.
+
+    Walks the full tree (handler is defined inside ``run_bridge``, not at
+    module top level), but pins to ``AsyncFunctionDef`` whose name is
+    ``handler`` AND whose decorator list contains a ``<name>.on(...)``
+    call. Returns None if not found.
+    """
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef):
+            continue
+        if node.name != "handler":
+            continue
+        for dec in node.decorator_list:
+            # Match @<name>.on(...) or @<name>.<attr>.on(...)
+            if isinstance(dec, ast.Call) and isinstance(dec.func, ast.Attribute):
+                if dec.func.attr == "on":
+                    return node
+    return None
+
+
+def _direct_calls(fn: ast.AsyncFunctionDef | ast.FunctionDef):
+    """Yield every ``ast.Call`` node in ``fn``'s body WITHOUT descending into
+    nested ``FunctionDef``/``AsyncFunctionDef``/``Lambda`` nodes.
+
+    This is the scope-aware walker required by C1 in the plan. Without
+    it, a nested helper's ``enqueue_agent_session`` call would be
+    attributed to ``handler`` itself, producing a false positive that
+    incentivizes contributors to work around the rule.
+    """
+
+    def _walk(node):
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+                continue
+            if isinstance(child, ast.Call):
+                yield child
+            yield from _walk(child)
+
+    yield from _walk(fn)
+
+
+def _banned_calls_in(fn: ast.AsyncFunctionDef | ast.FunctionDef) -> list[tuple[int, str]]:
+    """Return [(lineno, name), ...] for banned direct calls in ``fn``."""
+    hits: list[tuple[int, str]] = []
+    for call in _direct_calls(fn):
+        func = call.func
+        name: str | None = None
+        if isinstance(func, ast.Name):
+            name = func.id
+        elif isinstance(func, ast.Attribute):
+            name = func.attr
+        if name and name in BANNED_IN_HANDLER:
+            hits.append((call.lineno, name))
+    return hits
+
+
+class TestBridgeDispatchContract:
+    def test_handler_contains_no_direct_banned_calls(self):
+        """The live handler must route dedup through bridge/dispatch.py."""
+        tree = ast.parse(BRIDGE_SRC.read_text())
+        handler = _find_telethon_handler(tree)
+        assert handler is not None, (
+            "Could not find a Telethon handler in bridge/telegram_bridge.py "
+            "(AsyncFunctionDef named 'handler' with @<client>.on(...) decorator). "
+            "If the handler was renamed, update this contract test."
+        )
+        hits = _banned_calls_in(handler)
+        assert not hits, (
+            f"handler contains direct calls to "
+            f"{sorted(BANNED_IN_HANDLER)} — these MUST go through "
+            f"bridge.dispatch.dispatch_telegram_session or "
+            f"bridge.dispatch.record_telegram_message_handled. Offending "
+            f"call sites (lineno, name): {hits}"
+        )
+
+    def test_dispatch_calls_enqueue_before_record(self):
+        """dispatch_telegram_session must enqueue THEN record dedup.
+
+        Reversing the order would let a failed enqueue leave a dedup
+        record behind, causing the reconciler to skip a message that was
+        never enqueued (Risk 3 from the plan).
+        """
+        tree = ast.parse(DISPATCH_SRC.read_text())
+        fn = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == "dispatch_telegram_session":
+                fn = node
+                break
+        assert fn is not None, "dispatch_telegram_session not found in bridge/dispatch.py"
+
+        enqueue_line: int | None = None
+        record_line: int | None = None
+        for call in _direct_calls(fn):
+            f = call.func
+            name = f.id if isinstance(f, ast.Name) else (f.attr if isinstance(f, ast.Attribute) else None)
+            if name == "enqueue_agent_session" and enqueue_line is None:
+                enqueue_line = call.lineno
+            elif name == "record_message_processed" and record_line is None:
+                record_line = call.lineno
+        assert enqueue_line is not None, "dispatch_telegram_session must call enqueue_agent_session"
+        assert record_line is not None, "dispatch_telegram_session must call record_message_processed"
+        assert enqueue_line < record_line, (
+            f"dispatch_telegram_session must call enqueue_agent_session "
+            f"BEFORE record_message_processed (got enqueue at line "
+            f"{enqueue_line}, record at line {record_line})"
+        )
+
+    def test_contract_detects_violation_in_synthetic_source(self):
+        """The AST walker must flag a bare enqueue in a synthetic handler.
+
+        This replaces the fragile manual "inject a bare call, confirm, revert"
+        step from Task 4. If the walker regressed and stopped detecting
+        violations, this test would pass trivially — which is why we also
+        assert a NO-violation baseline on a clean synthetic source.
+        """
+        violating_source = """
+from agent.agent_session_queue import enqueue_agent_session
+
+class client:
+    @staticmethod
+    def on(_):
+        def deco(fn):
+            return fn
+        return deco
+
+@client.on(None)
+async def handler(event):
+    await enqueue_agent_session(project_key='x', session_id='y')
+"""
+        tree = ast.parse(violating_source)
+        handler = _find_telethon_handler(tree)
+        assert handler is not None, "synthetic handler not located by walker"
+        hits = _banned_calls_in(handler)
+        assert hits, "walker failed to flag bare enqueue_agent_session in synthetic handler"
+        assert any(name == "enqueue_agent_session" for _, name in hits)
+
+        clean_source = """
+class client:
+    @staticmethod
+    def on(_):
+        def deco(fn):
+            return fn
+        return deco
+
+@client.on(None)
+async def handler(event):
+    # routes through the wrapper; no banned direct call
+    from bridge.dispatch import dispatch_telegram_session
+    await dispatch_telegram_session(project_key='x', session_id='y', telegram_message_id=1, chat_id='c', working_dir='', message_text='', sender_name='')
+"""
+        tree = ast.parse(clean_source)
+        handler = _find_telethon_handler(tree)
+        assert handler is not None
+        assert _banned_calls_in(handler) == []
+
+    def test_walker_does_not_descend_into_nested_functions(self):
+        """C1: a banned call inside a nested helper must NOT trip the contract.
+
+        This prevents the walker from forcing contributors to avoid
+        legitimate nested helpers just to satisfy the contract.
+        """
+        source = """
+class client:
+    @staticmethod
+    def on(_):
+        def deco(fn):
+            return fn
+        return deco
+
+@client.on(None)
+async def handler(event):
+    def nested_helper():
+        # This banned call is in a nested function; the contract MUST NOT
+        # flag it because nested functions have their own scope.
+        enqueue_agent_session()
+    pass
+"""
+        tree = ast.parse(source)
+        handler = _find_telethon_handler(tree)
+        assert handler is not None
+        hits = _banned_calls_in(handler)
+        assert hits == [], (
+            f"walker must not descend into nested FunctionDef; "
+            f"spurious hits: {hits}"
+        )
+
+
+class TestDedupWarningLogging:
+    """C4: dedup failures must log at WARNING level (not debug)."""
+
+    def test_record_logs_warning_on_redis_failure(self, caplog):
+        import logging
+
+        import pytest
+        from unittest.mock import patch
+
+        from bridge.dedup import record_message_processed
+
+        async def _run():
+            with patch(
+                "models.dedup.DedupRecord.get_or_create",
+                side_effect=RuntimeError("redis down"),
+            ):
+                with caplog.at_level(logging.WARNING, logger="bridge.dedup"):
+                    await record_message_processed("chat_err", 42)
+
+        import asyncio
+
+        asyncio.run(_run())
+
+        warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "dedup record failed" in r.getMessage()
+        ]
+        assert warnings, (
+            "record_message_processed must log at WARNING (not debug) when "
+            "the underlying save raises. Got records: "
+            f"{[(r.levelname, r.getMessage()) for r in caplog.records]}"
+        )
+        msg = warnings[0].getMessage()
+        assert "chat_err" in msg and "42" in msg and "redis down" in msg

--- a/tests/unit/test_bridge_dispatch_contract.py
+++ b/tests/unit/test_bridge_dispatch_contract.py
@@ -137,13 +137,20 @@ class TestBridgeDispatchContract:
         record_line: int | None = None
         for call in _direct_calls(fn):
             f = call.func
-            name = f.id if isinstance(f, ast.Name) else (f.attr if isinstance(f, ast.Attribute) else None)
+            if isinstance(f, ast.Name):
+                name = f.id
+            elif isinstance(f, ast.Attribute):
+                name = f.attr
+            else:
+                name = None
             if name == "enqueue_agent_session" and enqueue_line is None:
                 enqueue_line = call.lineno
             elif name == "record_message_processed" and record_line is None:
                 record_line = call.lineno
         assert enqueue_line is not None, "dispatch_telegram_session must call enqueue_agent_session"
-        assert record_line is not None, "dispatch_telegram_session must call record_message_processed"
+        assert record_line is not None, (
+            "dispatch_telegram_session must call record_message_processed"
+        )
         assert enqueue_line < record_line, (
             f"dispatch_telegram_session must call enqueue_agent_session "
             f"BEFORE record_message_processed (got enqueue at line "
@@ -191,7 +198,15 @@ class client:
 async def handler(event):
     # routes through the wrapper; no banned direct call
     from bridge.dispatch import dispatch_telegram_session
-    await dispatch_telegram_session(project_key='x', session_id='y', telegram_message_id=1, chat_id='c', working_dir='', message_text='', sender_name='')
+    await dispatch_telegram_session(
+        project_key='x',
+        session_id='y',
+        telegram_message_id=1,
+        chat_id='c',
+        working_dir='',
+        message_text='',
+        sender_name='',
+    )
 """
         tree = ast.parse(clean_source)
         handler = _find_telethon_handler(tree)
@@ -224,10 +239,7 @@ async def handler(event):
         handler = _find_telethon_handler(tree)
         assert handler is not None
         hits = _banned_calls_in(handler)
-        assert hits == [], (
-            f"walker must not descend into nested FunctionDef; "
-            f"spurious hits: {hits}"
-        )
+        assert hits == [], f"walker must not descend into nested FunctionDef; spurious hits: {hits}"
 
 
 class TestDedupWarningLogging:
@@ -235,8 +247,6 @@ class TestDedupWarningLogging:
 
     def test_record_logs_warning_on_redis_failure(self, caplog):
         import logging
-
-        import pytest
         from unittest.mock import patch
 
         from bridge.dedup import record_message_processed
@@ -254,7 +264,8 @@ class TestDedupWarningLogging:
         asyncio.run(_run())
 
         warnings = [
-            r for r in caplog.records
+            r
+            for r in caplog.records
             if r.levelno == logging.WARNING and "dedup record failed" in r.getMessage()
         ]
         assert warnings, (


### PR DESCRIPTION
## Summary

Eliminates the distributed per-call-site dedup contract in `bridge/telegram_bridge.py::handler`. Every Telegram-originating session enqueue (and every handler early-return that "handled" a message without enqueueing) now routes through `bridge/dispatch.py`, which records dedup atomically from the caller's perspective. An AST-based regression test fails the build if any handler branch reintroduces a direct `enqueue_agent_session` or `record_message_processed` call.

Closes #948.

## Changes

- **`bridge/dispatch.py` (new)**: `dispatch_telegram_session` (enqueue + dedup record) and `record_telegram_message_handled` (dedup record only, for steer/finalize branches).
- **`bridge/telegram_bridge.py::handler`**: 5 call sites migrated. 5 inline `from bridge.dedup import record_message_processed` imports removed. Module-level import added for the new helpers.
- **`bridge/dedup.py::record_message_processed`**: log level raised from `debug` to `warning` so a Redis dedup outage is visible (plan concern C4).
- **`tests/unit/test_bridge_dispatch_contract.py` (new)**: 5 test cases -- AST contract on the handler, enqueue-before-record ordering in the wrapper (Risk 3), synthetic-source violation detection (replaces manual inject/revert, concern C5), scope-aware nested-function exemption (C1), and the new warning-level log assertion (C4). Handler lookup is pinned to the `@<client>.on(...)`-decorated `AsyncFunctionDef` (C2).
- **`docs/features/message-reconciler.md`**: "benign race" paragraph replaced with a precise live-vs-reconciler analysis; Ingestion Paths Mermaid diagram added; `bridge/dispatch.py` added to Files table.
- **`docs/features/bridge-module-architecture.md`**: Message Ingestion Flow section with Mermaid diagram added; `bridge/dispatch.py` and `bridge/dedup.py` added to the responsibility table.

## Reasoning walkthrough against the 2026-04-14 11:54 incident

Incident: a PM: PsyOPTIMAL message was processed by the handler's resume-completed-session branch which enqueued the session but did not record dedup. 2m 33s later the reconciler scanned, saw the message absent from dedup, re-classified it as missed, and enqueued a second session under a different `session_id` (the resume-completed branch reuses the existing session id; the reconciler always keys by `tg_{project}_{chat_id}_{message_id}`). The user received two replies.

Traced through the refactored code path: the resume-completed branch now calls `dispatch_telegram_session` (lines ~1323 in `bridge/telegram_bridge.py`). That helper calls `enqueue_agent_session` first; on successful return it calls `record_message_processed(chat_id, message.id)`. When the reconciler's 3-minute scan fires next, `is_duplicate_message(chat_id, message.id)` returns True and the message is skipped. The duplicate dispatch is structurally impossible via this path. The AST contract test guarantees no future branch can bypass the wrapper without the build failing.

## Testing

- [x] New contract test: `pytest tests/unit/test_bridge_dispatch_contract.py -v` -> 5 passed
- [x] Existing related tests: `pytest tests/unit/test_dedup.py tests/unit/test_duplicate_delivery.py tests/unit/test_reconciler.py` -> 32 passed
- [x] All bridge-area tests: 159 passed in 0.85s
- [x] Lint: `python -m ruff check bridge/ tests/unit/test_bridge_dispatch_contract.py` -> All checks passed
- [x] Format: `python -m ruff format --check` -> clean

## Documentation

- [x] `docs/features/message-reconciler.md` updated (race analysis, Mermaid, Files table)
- [x] `docs/features/bridge-module-architecture.md` updated (ingestion flow, responsibility table)
- [x] Plan success criteria all checked

## Definition of Done

- [x] Built: wrapper + 5 call-site migrations + regression test
- [x] Tested: 159 bridge-area tests passing; new contract test passing
- [x] Reviewed: self-review against plan + incident walkthrough above
- [x] Documented: both feature docs updated with corrected analysis and Mermaid diagrams
- [x] Quality: ruff check + format clean

Closes #948