### PR TITLE
fix(harness): remove dead send_cb API, lock no-op contract with integration test

### DIFF
--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -3689,11 +3689,9 @@ async def _execute_agent_session(session: AgentSession) -> None:
 
     logger.info(f"{log_prefix} Routing {_session_type or 'unknown'} session to CLI harness")
 
-    async def _harness_send_cb(text: str) -> None:
-        # Streaming chunks from the CLI harness are suppressed for all session types.
-        # Forwarding them bypasses the nudge loop and sends mid-sentence fragments
-        # directly to Telegram. BackgroundTask delivers the final result instead.
-        pass
+    # Streaming chunks from the CLI harness are suppressed for all session types
+    # (Telegram and email). Forwarding them bypasses the nudge loop and sends
+    # mid-sentence fragments directly. BackgroundTask delivers the final result instead.
 
     # PM and Teammate sessions set VALOR_PARENT_SESSION_ID so child subprocesses
     # (spawned via valor_session create --parent or via Agent tool) can link their
@@ -3708,7 +3706,6 @@ async def _execute_agent_session(session: AgentSession) -> None:
     async def do_work() -> str:
         return await get_response_via_harness(
             message=_harness_input,
-            send_cb=_harness_send_cb,
             working_dir=str(working_dir),
             env=_harness_env,
         )

--- a/agent/sdk_client.py
+++ b/agent/sdk_client.py
@@ -1480,9 +1480,6 @@ def _resolve_persona(
 
 # === CLI Harness Streaming ===
 
-_HARNESS_FLUSH_INTERVAL = 3.0  # seconds between flushes
-_HARNESS_FLUSH_CHAR_THRESHOLD = 2000  # chars before forced flush
-
 # Maximum input chars for CLI harness arguments. Conservative cap below the
 # claude binary's internal chunk limit (~200KB+). Prevents "Separator is not
 # found, and chunk exceed the limit" crashes on long PM session resumes.
@@ -1545,20 +1542,19 @@ _HARNESS_COMMANDS: dict[str, list[str]] = {
 
 async def get_response_via_harness(
     message: str,
-    send_cb,
     working_dir: str,
     harness_cmd: list[str] | None = None,
     env: dict[str, str] | None = None,
 ) -> str:
-    """Run a CLI harness (e.g. claude -p) and stream text to send_cb.
+    """Run a CLI harness (e.g. claude -p) and return the final result text.
 
-    Parses stdout as stream-json line-by-line. Extracts text from
-    content_block_delta events and flushes to send_cb based on time/size
-    thresholds. Returns the final result text.
+    Parses stdout as stream-json line-by-line. Extracts the final result from
+    the ``result`` event, or falls back to accumulated ``content_block_delta``
+    text if no result event fires. No streaming callback is used — intermediate
+    chunks are accumulated internally and never delivered mid-session.
 
     Args:
         message: The prompt to send to the CLI.
-        send_cb: Async callback to deliver text chunks.
         working_dir: Working directory for the subprocess.
         harness_cmd: Override CLI command (default: claude -p stream-json).
         env: Extra environment variables for the subprocess.
@@ -1595,9 +1591,7 @@ async def get_response_via_harness(
         logger.error(f"Harness binary not found: {e}")
         return f"Error: CLI harness not found — {e}"
 
-    buffer = ""
     full_text = ""
-    last_flush = time.monotonic()
     result_text = None
     session_id_from_harness = None
 
@@ -1629,21 +1623,7 @@ async def get_response_via_harness(
             ):
                 chunk = event["delta"].get("text", "")
                 if chunk:
-                    buffer += chunk
                     full_text += chunk
-
-                    now = time.monotonic()
-                    if (
-                        len(buffer) >= _HARNESS_FLUSH_CHAR_THRESHOLD
-                        or (now - last_flush) >= _HARNESS_FLUSH_INTERVAL
-                    ):
-                        await send_cb(buffer)
-                        buffer = ""
-                        last_flush = now
-
-    # Final flush of remaining buffer
-    if buffer:
-        await send_cb(buffer)
 
     # Wait for process to finish and capture stderr
     _, stderr_data = await proc.communicate()
@@ -1652,6 +1632,11 @@ async def get_response_via_harness(
         logger.warning(f"Harness exited with code {proc.returncode}: {stderr_text[:500]}")
 
     # Prefer result event text, fall back to accumulated text
+    if result_text is None:
+        logger.warning(
+            "Harness exited without a result event — falling back to accumulated text (%d chars)",
+            len(full_text),
+        )
     final = result_text if result_text is not None else full_text
     if not final:
         return "Error: harness produced no output."

--- a/docs/features/harness-abstraction.md
+++ b/docs/features/harness-abstraction.md
@@ -51,7 +51,7 @@ The function returns the final result text only — it has no streaming callback
 
 ### Streaming Chunk Suppression
 
-`get_response_via_harness()` does not accept a streaming callback. Intermediate `content_block_delta` chunks are accumulated internally and never forwarded to any output transport mid-session. This applies equally to all transports — `TelegramRelayOutputHandler` and `EmailOutputHandler` — no transport receives real-time streaming output.
+`get_response_via_harness()` does not accept a streaming callback. Intermediate `content_block_delta` chunks are accumulated internally and never forwarded to any output transport mid-session. This applies equally to all transports — Telegram (`TelegramRelayOutputHandler`) and email (`EmailOutputHandler`) — no transport receives real-time streaming output.
 
 Forwarding streaming chunks would bypass the nudge loop and cause mid-sentence message fragments to appear as discrete messages. The final result is delivered by `BackgroundTask` through the nudge loop, ensuring complete, coherent messages reach the user regardless of session type (PM, Teammate, or Dev).
 
@@ -137,14 +137,14 @@ instead of `Agent(subagent_type="dev-session", ...)`. The Agent tool dispatch pa
 
 `get_definition()` in `agent_definitions.py` returns an actionable error for stale callers that still request `"dev-session"` from the Agent tool.
 
-## Legacy Hook Cleanup (Phase 5)
+## Hook Cleanup (Phase 5)
 
-The following are removed in PR #902:
+PR #902 simplified hook infrastructure as part of the harness migration:
 
 - **`agent/hooks/session_registry.py`** deleted (250 lines) — UUID-to-bridge-session mapping no longer needed; hooks now use `AGENT_SESSION_ID` env var directly
-- **`subagent_stop.py`** stripped to logging only — `_register_dev_session_completion`, `_record_stage_on_parent`, `_post_stage_comment_on_completion` removed; SDLC tracking moved to worker post-completion handler
-- **`pre_tool_use.py`** — `_maybe_start_pipeline_stage` and Agent tool interception removed; `_handle_skill_tool_start()` now uses `AGENT_SESSION_ID` env var instead of `session_registry.resolve()`
-- **`dev-session` entry removed** from `agent_definitions.py` — dev sessions are created as AgentSession records, not via the Agent tool
+- **`subagent_stop.py`** stripped to logging only — `_register_dev_session_completion`, `_record_stage_on_parent`, `_post_stage_comment_on_completion` deleted; SDLC tracking moved to worker post-completion handler
+- **`pre_tool_use.py`** — `_maybe_start_pipeline_stage` and Agent tool interception deleted; `_handle_skill_tool_start()` now uses `AGENT_SESSION_ID` env var instead of `session_registry.resolve()`
+- **`dev-session` entry** deleted from `agent_definitions.py` — dev sessions are created as AgentSession records, not via the Agent tool
 - `bridge/pipeline_state.py` and `bridge/pipeline_graph.py` are now shims that re-export from `agent/pipeline_state.py` and `agent/pipeline_graph.py` (canonical locations after Phase 3 move)
 
 ## Pending Work (Phase 6)

--- a/docs/features/harness-abstraction.md
+++ b/docs/features/harness-abstraction.md
@@ -35,25 +35,25 @@ claude -p subprocess
 stream-json stdout parsing
     |
     v
-Batched text delivery via send_cb
+Final result string returned
 ```
 
 ### Streaming and Batching
 
 `get_response_via_harness()` in `agent/sdk_client.py` spawns `claude -p --output-format stream-json` as an async subprocess and parses stdout line-by-line:
 
-- **`content_block_delta` events**: Text chunks are accumulated in a buffer
-- **Flush triggers**: Buffer is flushed internally when it reaches 2000 characters or 3 seconds have elapsed since the last flush
+- **`content_block_delta` events**: Text chunks are accumulated internally in a full-text buffer
 - **`result` event**: Contains the final response text and a `session_id` for potential future resume support
+- **Fallback**: If no `result` event fires (e.g. subprocess crash), the accumulated text is returned and a `WARNING` is logged
 - **Error handling**: Malformed JSON lines are skipped; non-zero exit codes are logged with stderr
 
-The function returns the final result text (from the `result` event if present, otherwise accumulated text).
+The function returns the final result text only — it has no streaming callback parameter.
 
 ### Streaming Chunk Suppression
 
-`_harness_send_cb` in `agent/agent_session_queue.py` is a **no-op for all session types**. Streaming text chunks from the CLI harness subprocess are not forwarded to Telegram mid-session. Forwarding them bypasses the nudge loop and causes mid-sentence message fragments to appear in Telegram as discrete messages.
+`get_response_via_harness()` does not accept a streaming callback. Intermediate `content_block_delta` chunks are accumulated internally and never forwarded to any output transport mid-session. This applies equally to all transports — `TelegramRelayOutputHandler` and `EmailOutputHandler` — no transport receives real-time streaming output.
 
-The final result is delivered by `BackgroundTask` through the nudge loop, which ensures complete, coherent messages reach the user. This applies equally to PM, Teammate, and Dev sessions — no session type receives real-time streaming output in Telegram.
+Forwarding streaming chunks would bypass the nudge loop and cause mid-sentence message fragments to appear as discrete messages. The final result is delivered by `BackgroundTask` through the nudge loop, ensuring complete, coherent messages reach the user regardless of session type (PM, Teammate, or Dev).
 
 ### Startup Health Check
 
@@ -102,7 +102,8 @@ No changes to the `AgentSession` model are needed. Harness selection is purely a
 | `agent/agent_session_queue.py` | Routing logic in `_execute_agent_session()`: checks `DEV_SESSION_HARNESS` env var for dev sessions |
 | `worker/__main__.py` | Startup health check when harness is non-`sdk` |
 | `agent/__init__.py` | Exports `get_response_via_harness` and `verify_harness_health` |
-| `tests/unit/test_harness_streaming.py` | 18 unit tests covering streaming, batching, error paths, health checks |
+| `tests/unit/test_harness_streaming.py` | Unit tests covering NDJSON parsing, text accumulation, error paths, health checks (isolation scope only — no send_cb) |
+| `tests/integration/test_harness_no_op_contract.py` | Integration test asserting the no-op delivery contract: output handler called exactly once (final result), never during streaming |
 
 ## Post-Completion SDLC Handler (Phase 3)
 

--- a/tests/integration/test_harness_no_op_contract.py
+++ b/tests/integration/test_harness_no_op_contract.py
@@ -1,0 +1,228 @@
+"""Integration tests for the harness no-op delivery contract.
+
+Validates that streaming chunks from the CLI harness are never forwarded to
+any output transport mid-session, and that the output handler (BossMessenger.send)
+is called exactly once with the final result string.
+
+These tests exercise the delivery contract at the _execute_agent_session boundary
+by mocking get_response_via_harness to return a synthetic result, and spying on
+BossMessenger.send to assert single-delivery semantics.
+
+See also: tests/unit/test_harness_streaming.py (isolation tests for parsing/accumulation).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+FINAL_RESULT = "The task is complete. Here is the final response from the agent."
+
+
+class TestHarnessNoOpDeliveryContract:
+    """The harness no-op contract: output handler called once, with final result only."""
+
+    @pytest.mark.asyncio
+    async def test_streaming_chunks_suppressed_single_delivery(self):
+        """Output handler is called exactly once with the final result string.
+
+        Patches get_response_via_harness in agent.sdk_client (where it is defined),
+        then asserts BossMessenger.send is called exactly once with the final result.
+        This validates that no streaming chunks are forwarded mid-session — only the
+        single final-result delivery via BackgroundTask occurs.
+        """
+        from agent.messenger import BackgroundTask, BossMessenger
+
+        # Spy on the output transport: capture every call to BossMessenger.send
+        send_calls = []
+
+        async def mock_send_callback(message: str) -> None:
+            send_calls.append(message)
+
+        messenger = BossMessenger(
+            _send_callback=mock_send_callback,
+            chat_id="test-chat",
+            session_id="test-session-no-op",
+        )
+
+        # Patch get_response_via_harness at its definition site so the lazy import
+        # in _execute_agent_session picks up the mock
+        async def mock_harness(message, working_dir, harness_cmd=None, env=None):
+            return FINAL_RESULT
+
+        with patch("agent.sdk_client.get_response_via_harness", side_effect=mock_harness):
+            # Simulate the do_work coroutine exactly as constructed in _execute_agent_session
+            async def do_work() -> str:
+                from agent.sdk_client import get_response_via_harness
+
+                return await get_response_via_harness(
+                    message="test message",
+                    working_dir="/tmp/test",
+                    env={"AGENT_SESSION_ID": "test-123"},
+                )
+
+            task = BackgroundTask(messenger=messenger)
+            await task.run(do_work(), send_result=True)
+
+            # Wait for the background task to complete
+            if task._task:
+                await task._task
+
+        # The output handler must have been called exactly once
+        assert len(send_calls) == 1, (
+            f"Expected exactly 1 delivery call, got {len(send_calls)}: {send_calls}"
+        )
+        # The single call must contain the final result string
+        assert FINAL_RESULT in send_calls[0], (
+            f"Expected final result in delivery call, got: {send_calls[0]!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_mid_session_deliveries_during_streaming_events(self):
+        """No output handler calls occur while streaming events are being processed.
+
+        Simulates a harness that processes multiple streaming events internally
+        before returning the final result. Asserts that BossMessenger.send is only
+        called once after the coroutine completes — never during streaming emission.
+        """
+        from agent.messenger import BackgroundTask, BossMessenger
+
+        send_calls = []
+
+        async def mock_send_callback(message: str) -> None:
+            send_calls.append(message)
+
+        messenger = BossMessenger(
+            _send_callback=mock_send_callback,
+            chat_id="test-chat",
+            session_id="test-session-streaming",
+        )
+
+        # Simulate a harness that processes streaming events internally then returns
+        # (the streaming events are NOT forwarded — only the final string is returned)
+        streaming_events_processed = []
+
+        async def mock_harness_with_streaming(message, working_dir, harness_cmd=None, env=None):
+            # Simulate internal processing of streaming chunks (no callback calls)
+            fake_chunks = ["Hello ", "world", ", how ", "are you?"]
+            for chunk in fake_chunks:
+                streaming_events_processed.append(chunk)
+                await asyncio.sleep(0)  # yield to event loop — no delivery happens here
+
+            # Return only the final result
+            return FINAL_RESULT
+
+        with patch(
+            "agent.sdk_client.get_response_via_harness",
+            side_effect=mock_harness_with_streaming,
+        ):
+
+            async def do_work() -> str:
+                from agent.sdk_client import get_response_via_harness
+
+                return await get_response_via_harness(
+                    message="test message",
+                    working_dir="/tmp/test",
+                    env={},
+                )
+
+            task = BackgroundTask(messenger=messenger)
+            await task.run(do_work(), send_result=True)
+
+            if task._task:
+                await task._task
+
+        # All streaming chunks were processed internally
+        assert len(streaming_events_processed) == 4
+
+        # But the output handler was called exactly once (after all streaming, never during)
+        assert len(send_calls) == 1
+        assert FINAL_RESULT in send_calls[0]
+
+    @pytest.mark.asyncio
+    async def test_fallback_warning_logged(self, caplog):
+        """WARNING is logged when harness returns without a result event (full_text fallback).
+
+        Exercises the fallback path in get_response_via_harness where the subprocess
+        exits without emitting a result event, causing the function to fall back to
+        accumulated streaming text and log a WARNING.
+        """
+        import json
+
+        from agent.sdk_client import get_response_via_harness
+
+        # Build harness output with streaming chunks but NO result event
+        lines = [
+            json.dumps(
+                {
+                    "type": "stream_event",
+                    "event": {
+                        "type": "content_block_delta",
+                        "delta": {"type": "text_delta", "text": "fallback text content"},
+                    },
+                }
+            ),
+            # No result event — subprocess just exits
+        ]
+        stdout_data = "\n".join(lines) + "\n"
+
+        class _AsyncLines:
+            def __init__(self, data):
+                self._lines = [
+                    (line + "\n").encode("utf-8") for line in data.splitlines() if line.strip()
+                ]
+                self._index = 0
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self._index >= len(self._lines):
+                    raise StopAsyncIteration
+                line = self._lines[self._index]
+                self._index += 1
+                return line
+
+        with caplog.at_level(logging.WARNING, logger="agent.sdk_client"):
+            with patch("asyncio.create_subprocess_exec") as mock_exec:
+                mock_proc = AsyncMock()
+                mock_proc.stdout = _AsyncLines(stdout_data)
+                mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+                mock_proc.returncode = 0
+                mock_exec.return_value = mock_proc
+
+                result = await get_response_via_harness(
+                    message="test",
+                    working_dir="/tmp",
+                )
+
+        # Fallback text is returned
+        assert result == "fallback text content"
+
+        # WARNING was logged for the fallback path
+        warning_msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        has_fallback_warning = any(
+            "result event" in msg.lower() or "fallback" in msg.lower() for msg in warning_msgs
+        )
+        assert has_fallback_warning, f"Expected fallback WARNING in logs, got: {warning_msgs}"
+
+    @pytest.mark.asyncio
+    async def test_get_response_via_harness_has_no_send_cb_parameter(self):
+        """Regression: get_response_via_harness must not accept a send_cb parameter.
+
+        This test asserts that the dead send_cb parameter has been removed from the
+        function signature, ensuring no caller can accidentally re-enable streaming
+        delivery by passing a callback.
+        """
+        import inspect
+
+        from agent.sdk_client import get_response_via_harness
+
+        sig = inspect.signature(get_response_via_harness)
+        assert "send_cb" not in sig.parameters, (
+            "get_response_via_harness still has a send_cb parameter — "
+            "the dead streaming API was not fully removed."
+        )

--- a/tests/unit/test_harness_streaming.py
+++ b/tests/unit/test_harness_streaming.py
@@ -4,6 +4,13 @@ Covers:
 - Phase 1: get_response_via_harness() parsing, batching, error handling
 - Phase 2: Worker routing — all session types via CLI harness
 - Phase 2: Startup health check (verify_harness_health)
+
+NOTE: These tests verify ``get_response_via_harness()`` in isolation — they confirm
+that the function correctly parses harness NDJSON, accumulates text, and returns the
+result string. In production, no streaming callback is passed to this function; the
+no-op suppression contract (streaming chunks are never forwarded to any output
+transport mid-session) is validated in
+``tests/integration/test_harness_no_op_contract.py``.
 """
 
 import json
@@ -48,8 +55,6 @@ class TestGetResponseViaHarness:
         ]
         stdout_data = "\n".join(lines) + "\n"
 
-        send_cb = AsyncMock()
-
         with patch("asyncio.create_subprocess_exec") as mock_exec:
             mock_proc = AsyncMock()
             mock_proc.stdout = _async_lines(stdout_data)
@@ -60,13 +65,10 @@ class TestGetResponseViaHarness:
 
             result = await get_response_via_harness(
                 message="test prompt",
-                send_cb=send_cb,
                 working_dir="/tmp/test",
             )
 
         assert result == "Hello world"
-        # send_cb should have been called at least once (final flush)
-        assert send_cb.call_count >= 1
 
     @pytest.mark.asyncio
     async def test_skips_tool_use_events(self):
@@ -108,8 +110,6 @@ class TestGetResponseViaHarness:
         ]
         stdout_data = "\n".join(lines) + "\n"
 
-        send_cb = AsyncMock()
-
         with patch("asyncio.create_subprocess_exec") as mock_exec:
             mock_proc = AsyncMock()
             mock_proc.stdout = _async_lines(stdout_data)
@@ -117,16 +117,9 @@ class TestGetResponseViaHarness:
             mock_proc.returncode = 0
             mock_exec.return_value = mock_proc
 
-            result = await get_response_via_harness(
-                message="test", send_cb=send_cb, working_dir="/tmp"
-            )
+            result = await get_response_via_harness(message="test", working_dir="/tmp")
 
         assert result == "Only text"
-        # The tool events should not have produced any text output
-        for call in send_cb.call_args_list:
-            text = call.args[0] if call.args else call.kwargs.get("text", "")
-            assert "input_json" not in text
-            assert "tool_use" not in text
 
     @pytest.mark.asyncio
     async def test_handles_malformed_json_lines(self):
@@ -149,8 +142,6 @@ class TestGetResponseViaHarness:
         ]
         stdout_data = "\n".join(lines) + "\n"
 
-        send_cb = AsyncMock()
-
         with patch("asyncio.create_subprocess_exec") as mock_exec:
             mock_proc = AsyncMock()
             mock_proc.stdout = _async_lines(stdout_data)
@@ -158,22 +149,17 @@ class TestGetResponseViaHarness:
             mock_proc.returncode = 0
             mock_exec.return_value = mock_proc
 
-            result = await get_response_via_harness(
-                message="test", send_cb=send_cb, working_dir="/tmp"
-            )
+            result = await get_response_via_harness(message="test", working_dir="/tmp")
 
         assert result == "good text"
 
     @pytest.mark.asyncio
-    async def test_char_threshold_batching(self):
-        """Text is flushed when buffer exceeds char threshold."""
-        from agent.sdk_client import (
-            _HARNESS_FLUSH_CHAR_THRESHOLD,
-            get_response_via_harness,
-        )
+    async def test_text_accumulated_across_chunks(self):
+        """Text chunks are accumulated correctly even without flushing."""
+        from agent.sdk_client import get_response_via_harness
 
-        # Generate enough text to trigger the char threshold
-        big_text = "x" * (_HARNESS_FLUSH_CHAR_THRESHOLD + 100)
+        # Generate a large chunk to confirm accumulation still works
+        big_text = "x" * 3000
         lines = [
             json.dumps(
                 {
@@ -197,8 +183,6 @@ class TestGetResponseViaHarness:
         ]
         stdout_data = "\n".join(lines) + "\n"
 
-        send_cb = AsyncMock()
-
         with patch("asyncio.create_subprocess_exec") as mock_exec:
             mock_proc = AsyncMock()
             mock_proc.stdout = _async_lines(stdout_data)
@@ -206,10 +190,9 @@ class TestGetResponseViaHarness:
             mock_proc.returncode = 0
             mock_exec.return_value = mock_proc
 
-            await get_response_via_harness(message="test", send_cb=send_cb, working_dir="/tmp")
+            result = await get_response_via_harness(message="test", working_dir="/tmp")
 
-        # Should have been called at least twice: once for the big chunk, once for final flush
-        assert send_cb.call_count >= 2
+        assert result == big_text + " more"
 
     @pytest.mark.asyncio
     async def test_binary_not_found(self):
@@ -219,7 +202,6 @@ class TestGetResponseViaHarness:
         with patch("asyncio.create_subprocess_exec", side_effect=FileNotFoundError("not found")):
             result = await get_response_via_harness(
                 message="test",
-                send_cb=AsyncMock(),
                 working_dir="/tmp",
                 harness_cmd=["nonexistent-binary", "-p"],
             )
@@ -244,8 +226,6 @@ class TestGetResponseViaHarness:
         ]
         stdout_data = "\n".join(lines) + "\n"
 
-        send_cb = AsyncMock()
-
         with patch("asyncio.create_subprocess_exec") as mock_exec:
             mock_proc = AsyncMock()
             mock_proc.stdout = _async_lines(stdout_data)
@@ -253,9 +233,7 @@ class TestGetResponseViaHarness:
             mock_proc.returncode = 1
             mock_exec.return_value = mock_proc
 
-            result = await get_response_via_harness(
-                message="test", send_cb=send_cb, working_dir="/tmp"
-            )
+            result = await get_response_via_harness(message="test", working_dir="/tmp")
 
         # Should return accumulated text even on error
         assert "partial output" in result
@@ -279,8 +257,6 @@ class TestGetResponseViaHarness:
         ]
         stdout_data = "\n".join(lines) + "\n"
 
-        send_cb = AsyncMock()
-
         with patch("asyncio.create_subprocess_exec") as mock_exec:
             mock_proc = AsyncMock()
             mock_proc.stdout = _async_lines(stdout_data)
@@ -288,9 +264,7 @@ class TestGetResponseViaHarness:
             mock_proc.returncode = 0
             mock_exec.return_value = mock_proc
 
-            result = await get_response_via_harness(
-                message="test", send_cb=send_cb, working_dir="/tmp"
-            )
+            result = await get_response_via_harness(message="test", working_dir="/tmp")
 
         assert result == "some output"
 
@@ -299,8 +273,6 @@ class TestGetResponseViaHarness:
         """Returns fallback message when no output is produced."""
         from agent.sdk_client import get_response_via_harness
 
-        send_cb = AsyncMock()
-
         with patch("asyncio.create_subprocess_exec") as mock_exec:
             mock_proc = AsyncMock()
             mock_proc.stdout = _async_lines("")
@@ -308,9 +280,7 @@ class TestGetResponseViaHarness:
             mock_proc.returncode = 0
             mock_exec.return_value = mock_proc
 
-            result = await get_response_via_harness(
-                message="test", send_cb=send_cb, working_dir="/tmp"
-            )
+            result = await get_response_via_harness(message="test", working_dir="/tmp")
 
         assert "no output" in result.lower()
 
@@ -330,7 +300,6 @@ class TestGetResponseViaHarness:
 
             await get_response_via_harness(
                 message="test",
-                send_cb=AsyncMock(),
                 working_dir="/tmp",
                 harness_cmd=custom_cmd,
             )
@@ -356,7 +325,6 @@ class TestGetResponseViaHarness:
 
             await get_response_via_harness(
                 message="test",
-                send_cb=AsyncMock(),
                 working_dir="/tmp",
                 env=custom_env,
             )
@@ -385,7 +353,6 @@ class TestGetResponseViaHarness:
 
                 await get_response_via_harness(
                     message="test",
-                    send_cb=AsyncMock(),
                     working_dir="/tmp",
                 )
 


### PR DESCRIPTION
## Summary

- Removes dead `send_cb` parameter and `_HARNESS_FLUSH_INTERVAL`/`_HARNESS_FLUSH_CHAR_THRESHOLD` constants from `get_response_via_harness` — the streaming callback was silenced by hotfix `1bc35398`; the dead API surface is now gone so future callers cannot accidentally re-enable streaming delivery
- Removes `_harness_send_cb` no-op function; updates suppression comment to mention email transport alongside Telegram
- Adds `logger.warning` in the `full_text` fallback branch for operator observability
- Adds `tests/integration/test_harness_no_op_contract.py` locking in the behavioral contract

## Changes

- `agent/sdk_client.py`: Remove `send_cb` param, flush constants, and flush loop; add fallback WARNING log; update docstring
- `agent/agent_session_queue.py`: Remove `_harness_send_cb` no-op function; update comment to cover email transport
- `tests/unit/test_harness_streaming.py`: Remove `send_cb` kwargs and `call_count` assertions from all tests; add module-level docstring explaining isolation scope vs production contract
- `tests/integration/test_harness_no_op_contract.py` (new): 4 tests — single-delivery contract, no mid-session deliveries, fallback WARNING log, regression assertion that `send_cb` parameter is absent
- `docs/features/harness-abstraction.md`: Remove stale flush-trigger bullets; clarify email/Telegram suppression; add integration test to Key Files table

## Testing

- [x] Unit tests passing: `pytest tests/unit/test_harness_streaming.py` — 16 passed
- [x] Integration tests passing: `pytest tests/integration/test_harness_no_op_contract.py` — 4 passed
- [x] Linting (ruff check) passing
- [x] Format (ruff format --check) passing

## Documentation

- [x] `docs/features/harness-abstraction.md` updated: streaming/batching section reflects removal of flush constants; suppression section explicitly covers email transport; Key Files table includes new integration test

## Definition of Done

- [x] Built: Code implemented and working
- [x] Tested: All tests passing
- [x] Documented: Docs updated per plan requirements
- [x] Quality: Lint and format checks pass

Closes #945