### PR TITLE
feat(memory): add status subcommand to memory_search CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,9 @@ valor-telegram send --chat "Tom" --file ./screenshot.png "Caption"
 | `python -m tools.memory_search inspect --id <ID>` | Inspect a specific memory |
 | `python -m tools.memory_search inspect --stats` | Show memory statistics |
 | `python -m tools.memory_search forget --id <ID> --confirm` | Delete a memory |
+| `python -m tools.memory_search status` | Check memory system health (Redis, counts, superseded ratio) |
+| `python -m tools.memory_search status --json` | Memory health as machine-readable JSON |
+| `python -m tools.memory_search status --deep` | Memory health with orphan index count and per-category confidence |
 | `python -m tools.doctor` | Run all environment and health checks |
 | `python -m tools.doctor --quick` | Skip slow checks (Telegram session, model verification) |
 | `python -m tools.doctor --quality` | Include code quality checks (ruff, pytest) |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -63,7 +63,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [Lint Auto-Fix](lint-auto-fix.md) | Automatic lint/format fixing via pre-commit hook and PostToolUse hook, eliminating agent churn loops | Shipped |
 | [Local Doctor](local-doctor.md) | Unified health check CLI consolidating environment, service, auth, and resource checks into `python -m tools.doctor` | Shipped |
 | [Memory Hook Performance](memory-hook-performance.md) | Import chain optimization and deja vu removal for PostToolUse memory recall hook | Shipped |
-| [Memory Search Tool](memory-search-tool.md) | Direct interface for searching, saving, inspecting, and forgetting memories from the Memory model | Shipped |
+| [Memory Search Tool](memory-search-tool.md) | Direct interface for searching, saving, inspecting, forgetting, and health-checking memories from the Memory model (`status` subcommand: Redis ping, counts, superseded ratio, category breakdown) | Shipped |
 | [Message Pipeline](message-pipeline.md) | Deferred enrichment pipeline for fast message acknowledgment and zero-loss restarts | Shipped |
 | [Message Reconciler](message-reconciler.md) | Periodic background scan detecting and recovering Telegram messages missed during live bridge connections | Shipped |
 | [Mid-Session Steering](mid-session-steering.md) | End-to-end steering flow for injecting reply-to messages into running agent sessions | Shipped |

--- a/docs/features/memory-search-tool.md
+++ b/docs/features/memory-search-tool.md
@@ -4,9 +4,27 @@ Direct interface for searching, saving, inspecting, and forgetting memories from
 
 ## Overview
 
-The memory system previously had no direct interface -- memories accumulated silently and surfaced automatically via `<thought>` injection in the PostToolUse hook. This tool provides intentional access to the Memory model through four operations: search, save, inspect, and forget.
+The memory system previously had no direct interface -- memories accumulated silently and surfaced automatically via `<thought>` injection in the PostToolUse hook. This tool provides intentional access to the Memory model through five operations: search, save, inspect, forget, and status.
 
 ## API
+
+### `status(project_key=None, deep=False)`
+
+Return a health summary of the memory system. Fast path (<1s): Redis ping, total count, category breakdown, superseded count, avg confidence, last-write timestamp, EmbeddingField detection. Deep path (behind `deep=True`): orphan index count and per-category confidence averages.
+
+```python
+from tools.memory_search import status
+
+result = status(project_key="default")
+# {"healthy": True, "redis": {"ok": True}, "total": 80, "by_category": {...},
+#  "superseded": 3, "avg_confidence": 0.71, "last_write": "2026-04-15T02:37:04",
+#  "embedding_field": "not_configured"}
+
+result = status(deep=True)
+# adds: "orphan_index_count": 0, "by_category_confidence": {"correction": {"count": 5, "avg_confidence": 0.80}}
+```
+
+Returns `{"healthy": False, "error": "Redis unreachable: ..."}` when Redis is down.
 
 ### `search(query, project_key=None, limit=10)`
 
@@ -64,6 +82,12 @@ result = forget("abc123")
 ## CLI Usage
 
 ```bash
+# Status (health check)
+python -m tools.memory_search status
+python -m tools.memory_search status --json
+python -m tools.memory_search status --deep
+python -m tools.memory_search status --project dm
+
 # Search
 python -m tools.memory_search search "deploy patterns"
 python -m tools.memory_search search "deploy patterns" --project dm --limit 5 --json

--- a/docs/features/subconscious-memory.md
+++ b/docs/features/subconscious-memory.md
@@ -411,6 +411,38 @@ The fix threads `cwd` from `hook_input["cwd"]` through all four functions. `DEFA
 
 See [Claude Code Memory — Project Key Resolution](claude-code-memory.md#project-key-resolution) for the cwd threading table and one-time migration instructions.
 
+## Health Checks
+
+The `status` subcommand provides a focused, fast health snapshot of the memory system without the overhead of `python -m tools.doctor`.
+
+```bash
+python -m tools.memory_search status           # Human-readable summary (<1s)
+python -m tools.memory_search status --json    # Machine-readable JSON
+python -m tools.memory_search status --deep    # Adds orphan index count + per-category confidence
+python -m tools.memory_search status --project dm  # Scope to a specific project key
+```
+
+**JSON output shape:**
+```json
+{
+  "healthy": true,
+  "redis": {"ok": true},
+  "project_key": "default",
+  "total": 80,
+  "by_category": {"correction": 5, "pattern": 12, "other": 63},
+  "superseded": 3,
+  "avg_confidence": 0.5,
+  "last_write": "2026-04-15T02:37:04",
+  "embedding_field": "not_configured"
+}
+```
+
+`--deep` adds `orphan_index_count` (via `_count_orphans()` from `scripts/popoto_index_cleanup.py`) and `by_category_confidence` (per-category average confidence).
+
+**Exit codes:** 0 = healthy, 1 = Redis unreachable. The `tools.doctor` integration is a future step (tracked by issue #964).
+
+**Note:** `last_write` reflects the most recent relevance-score update, not creation time. Decay or boost operations on old records can make them appear recent.
+
 ## Error Handling
 
 All memory operations are wrapped in try/except with logging. The memory system is designed to fail silently:
@@ -447,3 +479,4 @@ No schema migrations are involved. Redis keys can be flushed without side effect
 - Downstream: Issue #395 (multi-persona memory partitioning), Issue #393 (behavioral episode memory)
 - Project key isolation: [#811](https://github.com/tomcounsell/ai/issues/811) (PR [#820](https://github.com/tomcounsell/ai/pull/820)) -- DEFAULT_PROJECT_KEY changed from "dm" to "default", cwd threading, migration script
 - Memory consolidation: [#795](https://github.com/tomcounsell/ai/issues/795) -- `memory-dedup` reflection, `superseded_by` fields, recall filter, semantic dedup via Haiku
+- Memory status CLI: [#964](https://github.com/tomcounsell/ai/issues/964) -- `python -m tools.memory_search status` health subcommand

--- a/docs/plans/memory-status-cli.md
+++ b/docs/plans/memory-status-cli.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: docs_complete
 type: feature
 appetite: Small
 owner: Valor Engels
@@ -178,9 +178,11 @@ No changes to `bridge/telegram_bridge.py`. No new MCP server registration.
 
 ## Documentation
 
-- [ ] Update `CLAUDE.md` command table: add `python -m tools.memory_search status` row with description "Check memory system health (Redis, counts, superseded ratio)"
-- [ ] Update `docs/features/subconscious-memory.md`: add a "Health Checks" subsection that references the new `status` subcommand
-- [ ] Add entry to `docs/features/README.md` index table if memory-status is considered a discrete feature (or append to the existing subconscious-memory row)
+- [x] Update `CLAUDE.md` command table: add `python -m tools.memory_search status` row with description "Check memory system health (Redis, counts, superseded ratio)"
+- [x] Update `docs/features/subconscious-memory.md`: add a "Health Checks" subsection that references the new `status` subcommand
+- [x] Add entry to `docs/features/README.md` index table if memory-status is considered a discrete feature (or append to the existing subconscious-memory row)
+- [x] Update `docs/features/memory-search-tool.md`: add `status()` API and CLI usage
+- [x] Update `docs/tools-reference.md`: add `status` to Memory Search section
 
 ## Success Criteria
 

--- a/docs/plans/memory-status-cli.md
+++ b/docs/plans/memory-status-cli.md
@@ -120,17 +120,17 @@ python -m tools.memory_search status
 ## Failure Path Test Strategy
 
 ### Exception Handling Coverage
-- [ ] `status()` wraps all Redis/Popoto calls in try/except; on Redis-down, returns `{"error": "Redis unreachable: ...", "healthy": False}`.
-- [ ] `cmd_status()` checks the `error` key and prints a clear message to stderr before exiting 1.
-- [ ] Tests must assert: (a) exit code 1 when Redis mock raises `ConnectionError`, (b) error text visible on stderr.
+- [x] `status()` wraps all Redis/Popoto calls in try/except; on Redis-down, returns `{"error": "Redis unreachable: ...", "healthy": False}`.
+- [x] `cmd_status()` checks the `error` key and prints a clear message to stderr before exiting 1.
+- [x] Tests must assert: (a) exit code 1 when Redis mock raises `ConnectionError`, (b) error text visible on stderr.
 
 ### Empty/Invalid Input Handling
-- [ ] `status()` with no memories in Redis returns zero counts gracefully (not a crash or KeyError).
-- [ ] `--project` with an unknown project key returns zero counts (not an error).
+- [x] `status()` with no memories in Redis returns zero counts gracefully (not a crash or KeyError).
+- [x] `--project` with an unknown project key returns zero counts (not an error).
 
 ### Error State Rendering
-- [ ] Human-readable output renders correctly when Redis is down (shows error, not empty table).
-- [ ] `--json` output when Redis is down emits `{"healthy": false, "error": "..."}` — not a stack trace.
+- [x] Human-readable output renders correctly when Redis is down (shows error, not empty table).
+- [x] `--json` output when Redis is down emits `{"healthy": false, "error": "..."}` — not a stack trace.
 
 ## Test Impact
 
@@ -186,15 +186,15 @@ No changes to `bridge/telegram_bridge.py`. No new MCP server registration.
 
 ## Success Criteria
 
-- [ ] `python -m tools.memory_search status` prints a human-readable health summary in <1s for typical memory sizes
-- [ ] `--json` flag emits `{"healthy": true/false, "redis": {...}, "total": N, "by_category": {...}, "superseded": N, "avg_confidence": 0.NN, "last_write": "...", "embedding_field": "configured|not_configured"}` structure
-- [ ] `--deep` flag adds `orphan_index_count` to the output
-- [ ] `--project <name>` scopes all counts to the specified project
-- [ ] Redis-down exits with code 1 and prints a human-readable error to stderr
-- [ ] `CLAUDE.md` command table updated
-- [ ] `tests/unit/test_memory_search_cli.py` created with coverage for: happy path, Redis-down, empty project, `--json`, `--deep`
-- [ ] Tests pass (`pytest tests/unit/test_memory_search_cli.py -v`)
-- [ ] Lint and format clean (`python -m ruff check . && python -m ruff format --check .`)
+- [x] `python -m tools.memory_search status` prints a human-readable health summary in <1s for typical memory sizes
+- [x] `--json` flag emits `{"healthy": true/false, "redis": {...}, "total": N, "by_category": {...}, "superseded": N, "avg_confidence": 0.NN, "last_write": "...", "embedding_field": "configured|not_configured"}` structure
+- [x] `--deep` flag adds `orphan_index_count` to the output
+- [x] `--project <name>` scopes all counts to the specified project
+- [x] Redis-down exits with code 1 and prints a human-readable error to stderr
+- [x] `CLAUDE.md` command table updated
+- [x] `tests/unit/test_memory_search_cli.py` created with coverage for: happy path, Redis-down, empty project, `--json`, `--deep`
+- [x] Tests pass (`pytest tests/unit/test_memory_search_cli.py -v`)
+- [x] Lint and format clean (`python -m ruff check . && python -m ruff format --check .`)
 
 ## Team Orchestration
 

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -39,19 +39,23 @@ results = search_messages(query="deployment", limit=10)
 
 ### Memory Search (`tools.memory_search`)
 
-Search, save, inspect, and forget memories from the Memory model.
+Search, save, inspect, forget, and health-check memories from the Memory model.
 
 ```python
-from tools.memory_search import search, save, inspect, forget
+from tools.memory_search import search, save, inspect, forget, status
 
 results = search("deploy patterns", project_key="dm", limit=5)
 saved = save("API X requires auth header Y", importance=6.0)
 details = inspect(memory_id="abc123")
 deleted = forget("abc123")
+health = status()  # {"healthy": True, "total": 80, "superseded": 3, ...}
 ```
 
 ```bash
 # CLI
+python -m tools.memory_search status              # memory system health check
+python -m tools.memory_search status --json       # machine-readable JSON
+python -m tools.memory_search status --deep       # adds orphan count + per-category confidence
 python -m tools.memory_search search "deploy patterns"
 python -m tools.memory_search save "important note" --importance 6.0
 python -m tools.memory_search inspect --stats --project dm

--- a/tests/unit/test_memory_search_cli.py
+++ b/tests/unit/test_memory_search_cli.py
@@ -220,7 +220,7 @@ class TestCmdStatus:
 
         with (
             patch("tools.memory_search.cli.status", return_value=redis_down_result),
-            patch("sys.stderr", new_callable=StringIO) as mock_err,
+            patch("sys.stderr", new_callable=StringIO),
         ):
             code = cmd_status(self._make_args())
 

--- a/tests/unit/test_memory_search_cli.py
+++ b/tests/unit/test_memory_search_cli.py
@@ -1,0 +1,371 @@
+"""Unit tests for tools.memory_search status subcommand.
+
+Covers: happy path, Redis-down, empty project, --json, --deep, --project scoping.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+
+def _make_memory_record(
+    category: str | None = None,
+    superseded_by: str = "",
+    confidence: float = 0.5,
+    relevance: float = 1_000_000.0,
+    source: str = "human",
+) -> MagicMock:
+    """Build a mock Memory record with the given attributes."""
+    record = MagicMock()
+    record.confidence = confidence
+    record.relevance = relevance
+    record.superseded_by = superseded_by
+    record.source = source
+    record.metadata = {"category": category} if category else {}
+    return record
+
+
+class TestStatusFunction:
+    """Tests for tools.memory_search.status() directly."""
+
+    def test_happy_path_returns_healthy(self):
+        """status() returns healthy=True with correct aggregate fields."""
+        from tools.memory_search import status
+
+        records = [
+            _make_memory_record(category="correction", relevance=2_000_000.0),
+            _make_memory_record(category="pattern", relevance=1_500_000.0),
+            _make_memory_record(),  # uncategorized → other
+        ]
+
+        with (
+            patch("tools.memory_search._fetch_all_records", return_value=records),
+            patch("popoto.redis_db.POPOTO_REDIS_DB") as mock_redis,
+        ):
+            mock_redis.ping.return_value = True
+            result = status(project_key="test-project")
+
+        assert result["healthy"] is True
+        assert result["total"] == 3
+        assert result["superseded"] == 0
+        assert "correction" in result["by_category"]
+        assert "pattern" in result["by_category"]
+        assert "other" in result["by_category"]
+        assert result["embedding_field"] in ("configured", "not_configured")
+        assert "last_write" in result
+
+    def test_redis_down_returns_unhealthy(self):
+        """status() returns healthy=False with error key when Redis is unreachable."""
+        from tools.memory_search import status
+
+        with patch("popoto.redis_db.POPOTO_REDIS_DB") as mock_redis:
+            mock_redis.ping.side_effect = ConnectionError("Connection refused")
+            result = status(project_key="test-project")
+
+        assert result["healthy"] is False
+        assert "error" in result
+        assert "Redis unreachable" in result["error"]
+
+    def test_empty_project_returns_zero_counts(self):
+        """status() with no memories returns zero counts, not an error."""
+        from tools.memory_search import status
+
+        with (
+            patch("tools.memory_search._fetch_all_records", return_value=[]),
+            patch("popoto.redis_db.POPOTO_REDIS_DB") as mock_redis,
+        ):
+            mock_redis.ping.return_value = True
+            result = status(project_key="empty-project")
+
+        assert result["healthy"] is True
+        assert result["total"] == 0
+        assert result["superseded"] == 0
+        assert result["avg_confidence"] == 0.0
+        assert result["last_write"] is None
+        assert result["by_category"] == {}
+
+    def test_superseded_count(self):
+        """status() correctly counts records where superseded_by != ''."""
+        from tools.memory_search import status
+
+        records = [
+            _make_memory_record(superseded_by="some-other-id"),
+            _make_memory_record(superseded_by=""),
+            _make_memory_record(superseded_by="another-id"),
+        ]
+
+        with (
+            patch("tools.memory_search._fetch_all_records", return_value=records),
+            patch("popoto.redis_db.POPOTO_REDIS_DB") as mock_redis,
+        ):
+            mock_redis.ping.return_value = True
+            result = status(project_key="test-project")
+
+        assert result["superseded"] == 2
+
+    def test_deep_adds_orphan_count(self):
+        """status(deep=True) includes orphan_index_count in result."""
+        import sys
+        import types
+
+        from tools.memory_search import status
+
+        records = [_make_memory_record()]
+
+        # Inject a fake popoto_index_cleanup module into sys.modules so the
+        # real sys.path.insert + import inside status() finds it.
+        fake_cleanup = types.ModuleType("popoto_index_cleanup")
+        fake_cleanup._count_orphans = lambda model: 5
+
+        with (
+            patch("tools.memory_search._fetch_all_records", return_value=records),
+            patch("popoto.redis_db.POPOTO_REDIS_DB") as mock_redis,
+            patch.dict(sys.modules, {"popoto_index_cleanup": fake_cleanup}),
+        ):
+            mock_redis.ping.return_value = True
+            result = status(project_key="test-project", deep=True)
+
+        assert "orphan_index_count" in result
+        assert "by_category_confidence" in result
+
+    def test_deep_per_category_confidence(self):
+        """status(deep=True) includes per-category confidence breakdown."""
+        import sys
+        import types
+
+        from tools.memory_search import status
+
+        records = [
+            _make_memory_record(category="correction", confidence=0.8),
+            _make_memory_record(category="correction", confidence=0.6),
+            _make_memory_record(category="pattern", confidence=0.4),
+        ]
+
+        fake_cleanup = types.ModuleType("popoto_index_cleanup")
+        fake_cleanup._count_orphans = lambda model: 0
+
+        with (
+            patch("tools.memory_search._fetch_all_records", return_value=records),
+            patch("popoto.redis_db.POPOTO_REDIS_DB") as mock_redis,
+            patch.dict(sys.modules, {"popoto_index_cleanup": fake_cleanup}),
+        ):
+            mock_redis.ping.return_value = True
+            result = status(project_key="test-project", deep=True)
+
+        cat_conf = result.get("by_category_confidence", {})
+        assert "correction" in cat_conf
+        assert cat_conf["correction"]["count"] == 2
+        assert abs(cat_conf["correction"]["avg_confidence"] - 0.7) < 0.001
+
+    def test_project_key_scoping(self):
+        """status() calls _fetch_all_records with the resolved project key."""
+        from tools.memory_search import status
+
+        with (
+            patch("tools.memory_search._fetch_all_records", return_value=[]) as mock_fetch,
+            patch("tools.memory_search._resolve_project_key", return_value="my-project"),
+            patch("popoto.redis_db.POPOTO_REDIS_DB") as mock_redis,
+        ):
+            mock_redis.ping.return_value = True
+            result = status(project_key="my-project")
+
+        mock_fetch.assert_called_once_with("my-project")
+        assert result["project_key"] == "my-project"
+
+
+class TestCmdStatus:
+    """Tests for the cmd_status() CLI handler."""
+
+    def _make_args(
+        self,
+        project: str | None = None,
+        json_output: bool = False,
+        deep: bool = False,
+    ) -> argparse.Namespace:
+        return argparse.Namespace(project=project, json=json_output, deep=deep)
+
+    def test_exit_code_0_on_success(self):
+        """cmd_status() exits 0 when status() returns healthy=True."""
+        from tools.memory_search.cli import cmd_status
+
+        healthy_result = {
+            "healthy": True,
+            "redis": {"ok": True},
+            "project_key": "test",
+            "total": 5,
+            "by_category": {"other": 5},
+            "superseded": 0,
+            "avg_confidence": 0.5,
+            "last_write": "2026-01-01T00:00:00",
+            "embedding_field": "not_configured",
+        }
+
+        with patch("tools.memory_search.cli.status", return_value=healthy_result):
+            code = cmd_status(self._make_args())
+
+        assert code == 0
+
+    def test_exit_code_1_on_redis_down(self):
+        """cmd_status() exits 1 when Redis is unreachable."""
+        from tools.memory_search.cli import cmd_status
+
+        redis_down_result = {
+            "healthy": False,
+            "error": "Redis unreachable: Connection refused",
+        }
+
+        with (
+            patch("tools.memory_search.cli.status", return_value=redis_down_result),
+            patch("sys.stderr", new_callable=StringIO) as mock_err,
+        ):
+            code = cmd_status(self._make_args())
+
+        assert code == 1
+
+    def test_redis_down_error_on_stderr(self):
+        """cmd_status() prints error text to stderr on Redis failure."""
+        from tools.memory_search.cli import cmd_status
+
+        redis_down_result = {
+            "healthy": False,
+            "error": "Redis unreachable: Connection refused",
+        }
+
+        stderr_output = StringIO()
+        with (
+            patch("tools.memory_search.cli.status", return_value=redis_down_result),
+            patch("sys.stderr", stderr_output),
+        ):
+            cmd_status(self._make_args())
+
+        assert "Redis unreachable" in stderr_output.getvalue()
+
+    def test_json_flag_emits_valid_json(self):
+        """cmd_status --json emits parseable JSON containing 'healthy'."""
+        from tools.memory_search.cli import cmd_status
+
+        healthy_result = {
+            "healthy": True,
+            "redis": {"ok": True},
+            "project_key": "test",
+            "total": 3,
+            "by_category": {"other": 3},
+            "superseded": 0,
+            "avg_confidence": 0.5,
+            "last_write": None,
+            "embedding_field": "not_configured",
+        }
+
+        stdout_output = StringIO()
+        with (
+            patch("tools.memory_search.cli.status", return_value=healthy_result),
+            patch("sys.stdout", stdout_output),
+        ):
+            code = cmd_status(self._make_args(json_output=True))
+
+        assert code == 0
+        parsed = json.loads(stdout_output.getvalue())
+        assert "healthy" in parsed
+        assert parsed["healthy"] is True
+
+    def test_json_flag_on_redis_down_emits_json_not_traceback(self):
+        """cmd_status --json with Redis down emits JSON with error field, not a traceback."""
+        from tools.memory_search.cli import cmd_status
+
+        redis_down_result = {
+            "healthy": False,
+            "error": "Redis unreachable: Connection refused",
+        }
+
+        stdout_output = StringIO()
+        with (
+            patch("tools.memory_search.cli.status", return_value=redis_down_result),
+            patch("sys.stdout", stdout_output),
+        ):
+            code = cmd_status(self._make_args(json_output=True))
+
+        assert code == 1
+        parsed = json.loads(stdout_output.getvalue())
+        assert parsed["healthy"] is False
+        assert "error" in parsed
+
+    def test_deep_flag_passed_to_status(self):
+        """cmd_status --deep passes deep=True to status()."""
+        from tools.memory_search.cli import cmd_status
+
+        healthy_result = {
+            "healthy": True,
+            "redis": {"ok": True},
+            "project_key": "test",
+            "total": 0,
+            "by_category": {},
+            "superseded": 0,
+            "avg_confidence": 0.0,
+            "last_write": None,
+            "embedding_field": "not_configured",
+            "orphan_index_count": 0,
+            "by_category_confidence": {},
+        }
+
+        with patch("tools.memory_search.cli.status", return_value=healthy_result) as mock_status:
+            cmd_status(self._make_args(deep=True))
+
+        mock_status.assert_called_once_with(project_key=None, deep=True)
+
+    def test_project_flag_passed_to_status(self):
+        """cmd_status --project <name> passes project_key to status()."""
+        from tools.memory_search.cli import cmd_status
+
+        healthy_result = {
+            "healthy": True,
+            "redis": {"ok": True},
+            "project_key": "myproj",
+            "total": 0,
+            "by_category": {},
+            "superseded": 0,
+            "avg_confidence": 0.0,
+            "last_write": None,
+            "embedding_field": "not_configured",
+        }
+
+        with patch("tools.memory_search.cli.status", return_value=healthy_result) as mock_status:
+            cmd_status(self._make_args(project="myproj"))
+
+        mock_status.assert_called_once_with(project_key="myproj", deep=False)
+
+
+class TestStatusSubcommandE2E:
+    """End-to-end tests via argparse (simulates CLI invocation)."""
+
+    def test_status_help_exits_0(self):
+        """python -m tools.memory_search status --help exits 0."""
+        import subprocess
+
+        result = subprocess.run(
+            [sys.executable, "-m", "tools.memory_search", "status", "--help"],
+            capture_output=True,
+            text=True,
+            cwd="/Users/valorengels/src/ai/.worktrees/memory-status-cli",
+        )
+        assert result.returncode == 0
+        assert "status" in result.stdout
+
+    def test_status_json_contains_healthy_key(self):
+        """python -m tools.memory_search status --json returns JSON with 'healthy' key."""
+        import subprocess
+
+        result = subprocess.run(
+            [sys.executable, "-m", "tools.memory_search", "status", "--json"],
+            capture_output=True,
+            text=True,
+            cwd="/Users/valorengels/src/ai/.worktrees/memory-status-cli",
+        )
+        # Exit 0 when Redis is up; exit 1 when down — both are valid in this test environment
+        output = result.stdout.strip()
+        if output:
+            parsed = json.loads(output)
+            assert "healthy" in parsed

--- a/tests/unit/test_memory_search_cli.py
+++ b/tests/unit/test_memory_search_cli.py
@@ -9,7 +9,10 @@ import argparse
 import json
 import sys
 from io import StringIO
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+_REPO_ROOT = str(Path(__file__).parents[2])
 
 
 def _make_memory_record(
@@ -349,7 +352,7 @@ class TestStatusSubcommandE2E:
             [sys.executable, "-m", "tools.memory_search", "status", "--help"],
             capture_output=True,
             text=True,
-            cwd="/Users/valorengels/src/ai/.worktrees/memory-status-cli",
+            cwd=_REPO_ROOT,
         )
         assert result.returncode == 0
         assert "status" in result.stdout
@@ -362,7 +365,7 @@ class TestStatusSubcommandE2E:
             [sys.executable, "-m", "tools.memory_search", "status", "--json"],
             capture_output=True,
             text=True,
-            cwd="/Users/valorengels/src/ai/.worktrees/memory-status-cli",
+            cwd=_REPO_ROOT,
         )
         # Exit 0 when Redis is up; exit 1 when down — both are valid in this test environment
         output = result.stdout.strip()

--- a/tools/memory_search/__init__.py
+++ b/tools/memory_search/__init__.py
@@ -18,6 +18,26 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+def _fetch_all_records(project_key: str) -> list:
+    """Fetch all memory records for a project key.
+
+    Shared helper used by inspect(stats=True) and status() to avoid
+    duplicating the Memory.query.filter(...) call.
+
+    Args:
+        project_key: Project partition key.
+
+    Returns:
+        List of Memory records, or empty list on error.
+    """
+    from models.memory import Memory
+
+    try:
+        return list(Memory.query.filter(project_key=project_key))
+    except Exception:
+        return []
+
+
 def _resolve_project_key(project_key: str | None = None) -> str:
     """Resolve project_key from argument or environment."""
     if project_key:
@@ -231,10 +251,7 @@ def inspect(
         if stats:
             project_key = _resolve_project_key(project_key)
             # Aggregate stats across project
-            try:
-                all_records = list(Memory.query.filter(project_key=project_key))
-            except Exception:
-                all_records = []
+            all_records = _fetch_all_records(project_key)
 
             if not all_records:
                 return {
@@ -323,6 +340,136 @@ def outcome_stats(
     except Exception as e:
         logger.warning(f"[memory_search] outcome_stats failed (non-fatal): {e}")
         return {"error": str(e)}
+
+
+def status(
+    project_key: str | None = None,
+    deep: bool = False,
+) -> dict[str, Any]:
+    """Return a health summary of the memory system.
+
+    Fast path (<1s): Redis ping, total count, category breakdown, superseded
+    count, average confidence, last-write timestamp, EmbeddingField detection.
+
+    Deep path (behind deep=True): orphan index count using _count_orphans()
+    from scripts/popoto_index_cleanup, per-category confidence averages.
+
+    Args:
+        project_key: Project partition key. Resolved from env if not provided.
+        deep: If True, run slow checks (orphan scan, per-category confidence).
+
+    Returns:
+        Dict with keys: healthy, redis, total, by_category, superseded,
+        avg_confidence, last_write, embedding_field. On Redis failure:
+        {"healthy": False, "error": "Redis unreachable: ..."}.
+    """
+    try:
+        from models.memory import Memory
+
+        # Redis ping — fail-fast
+        try:
+            from popoto.redis_db import POPOTO_REDIS_DB
+
+            POPOTO_REDIS_DB.ping()
+            redis_ok = True
+        except Exception as e:
+            return {"healthy": False, "error": f"Redis unreachable: {e}"}
+
+        project_key = _resolve_project_key(project_key)
+        all_records = _fetch_all_records(project_key)
+
+        total = len(all_records)
+
+        # Category breakdown
+        known_categories = {"correction", "decision", "pattern", "surprise"}
+        by_category: dict[str, int] = {}
+        superseded_count = 0
+        total_confidence = 0.0
+        last_relevance = 0.0
+
+        for record in all_records:
+            meta = getattr(record, "metadata", None) or {}
+            cat = meta.get("category") or ""
+            key = cat if cat in known_categories else "other"
+            by_category[key] = by_category.get(key, 0) + 1
+
+            if getattr(record, "superseded_by", "") != "":
+                superseded_count += 1
+
+            total_confidence += getattr(record, "confidence", 0.0)
+
+            rel = getattr(record, "relevance", 0.0) or 0.0
+            if rel > last_relevance:
+                last_relevance = rel
+
+        avg_confidence = total_confidence / total if total > 0 else 0.0
+
+        # last_write: relevance stores Unix timestamp float (last relevance update)
+        # NOTE: this reflects last relevance update, not creation time — decay/boost
+        # operations on old records can make them appear recent here.
+        if last_relevance > 0:
+            from datetime import datetime
+
+            last_write = datetime.fromtimestamp(last_relevance).isoformat()
+        else:
+            last_write = None
+
+        # EmbeddingField detection
+        embedding_field = Memory._meta.fields.get("embedding")
+        embedding_status = "configured" if embedding_field is not None else "not_configured"
+
+        result: dict[str, Any] = {
+            "healthy": True,
+            "redis": {"ok": redis_ok},
+            "project_key": project_key,
+            "total": total,
+            "by_category": by_category,
+            "superseded": superseded_count,
+            "avg_confidence": round(avg_confidence, 4),
+            "last_write": last_write,
+            "embedding_field": embedding_status,
+        }
+
+        if deep:
+            # Orphan detection — import from scripts/
+            orphan_count: int | str = "unavailable"
+            try:
+                import sys
+                from pathlib import Path
+
+                scripts_dir = str(Path(__file__).parents[2] / "scripts")
+                if scripts_dir not in sys.path:
+                    sys.path.insert(0, scripts_dir)
+                from popoto_index_cleanup import _count_orphans
+
+                orphan_count = _count_orphans(Memory)
+            except Exception as e:
+                logger.warning(f"[memory_search] orphan count failed: {e}")
+                orphan_count = f"error: {e}"
+
+            # Per-category confidence averages
+            cat_confidence: dict[str, dict[str, Any]] = {}
+            cat_totals: dict[str, list[float]] = {}
+            for record in all_records:
+                meta = getattr(record, "metadata", None) or {}
+                cat = meta.get("category") or ""
+                key = cat if cat in known_categories else "other"
+                conf = getattr(record, "confidence", 0.0)
+                cat_totals.setdefault(key, []).append(conf)
+            for cat_key, confs in cat_totals.items():
+                cat_confidence[cat_key] = {
+                    "count": len(confs),
+                    "avg_confidence": round(sum(confs) / len(confs), 4) if confs else 0.0,
+                }
+
+            result["orphan_index_count"] = orphan_count
+            result["by_category_confidence"] = cat_confidence
+
+        return result
+
+    except Exception as e:
+        logger.warning(f"[memory_search] status failed (non-fatal): {e}")
+        return {"healthy": False, "error": str(e)}
 
 
 def forget(memory_id: str) -> dict[str, Any]:

--- a/tools/memory_search/cli.py
+++ b/tools/memory_search/cli.py
@@ -20,7 +20,7 @@ import json
 import sys
 from datetime import UTC
 
-from tools.memory_search import forget, inspect, outcome_stats, save, search
+from tools.memory_search import forget, inspect, outcome_stats, save, search, status
 
 
 def cmd_search(args: argparse.Namespace) -> int:
@@ -230,6 +230,58 @@ def cmd_forget(args: argparse.Namespace) -> int:
         return 1
 
 
+def cmd_status(args: argparse.Namespace) -> int:
+    """Show memory system health status."""
+    result = status(
+        project_key=args.project,
+        deep=getattr(args, "deep", False),
+    )
+
+    # Redis-down: always exit 1 with human-readable error on stderr
+    if not result.get("healthy", True) and "error" in result:
+        if args.json:
+            print(json.dumps(result, indent=2, default=str))
+        else:
+            print(f"Error: {result['error']}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(result, indent=2, default=str))
+        return 0
+
+    # Human-readable output
+    project = result.get("project_key", "")
+    total = result.get("total", 0)
+    superseded = result.get("superseded", 0)
+    avg_conf = result.get("avg_confidence", 0.0)
+    last_write = result.get("last_write") or "unknown"
+    embedding = result.get("embedding_field", "unknown")
+    by_category = result.get("by_category", {})
+
+    print(f"Memory System Status — project '{project}'")
+    print(f"  Redis:           ok")
+    print(f"  Total records:   {total}")
+    print(f"  Superseded:      {superseded}")
+    print(f"  Avg confidence:  {avg_conf:.4f}")
+    print(f"  Last write:      {last_write}")
+    print(f"  Embedding field: {embedding}")
+
+    if by_category:
+        print("  By category:")
+        for cat, count in sorted(by_category.items()):
+            print(f"    {cat}: {count}")
+
+    if "orphan_index_count" in result:
+        print(f"  Orphan index keys: {result['orphan_index_count']}")
+
+    if "by_category_confidence" in result:
+        print("  Per-category confidence:")
+        for cat, info in sorted(result["by_category_confidence"].items()):
+            print(f"    {cat}: avg={info['avg_confidence']:.4f} (n={info['count']})")
+
+    return 0
+
+
 def main() -> int:
     """Main entry point."""
     parser = argparse.ArgumentParser(
@@ -303,6 +355,16 @@ def main() -> int:
     )
     forget_parser.add_argument("--json", action="store_true", help="Output as JSON")
 
+    # status command
+    status_parser = subparsers.add_parser("status", help="Check memory system health")
+    status_parser.add_argument("--project", "-p", help="Project key (default: from env)")
+    status_parser.add_argument("--json", action="store_true", help="Output as JSON")
+    status_parser.add_argument(
+        "--deep",
+        action="store_true",
+        help="Run slow checks: orphan index count and per-category confidence",
+    )
+
     args = parser.parse_args()
 
     if not args.command:
@@ -315,6 +377,7 @@ def main() -> int:
         "inspect": cmd_inspect,
         "stats": cmd_stats,
         "forget": cmd_forget,
+        "status": cmd_status,
     }
 
     handler = handlers.get(args.command)

--- a/tools/memory_search/cli.py
+++ b/tools/memory_search/cli.py
@@ -259,7 +259,7 @@ def cmd_status(args: argparse.Namespace) -> int:
     by_category = result.get("by_category", {})
 
     print(f"Memory System Status — project '{project}'")
-    print(f"  Redis:           ok")
+    print("  Redis:           ok")
     print(f"  Total records:   {total}")
     print(f"  Superseded:      {superseded}")
     print(f"  Avg confidence:  {avg_conf:.4f}")


### PR DESCRIPTION
## Summary
- Adds `python -m tools.memory_search status` for a focused, fast memory system health check (<1s)
- `--json` emits machine-readable health dict; `--deep` adds orphan index count and per-category confidence averages
- Extracts `_fetch_all_records()` shared helper to avoid duplication between `inspect(stats=True)` and `status()`

## Changes
- `tools/memory_search/__init__.py`: new `_fetch_all_records()` helper, new `status()` function
- `tools/memory_search/cli.py`: new `cmd_status()` handler, `status` subcommand with `--json`, `--deep`, `--project`
- `tests/unit/test_memory_search_cli.py`: 16 new tests covering happy path, Redis-down, empty project, all flags
- `CLAUDE.md`: added 3 Quick Commands table rows for status variants
- `docs/features/subconscious-memory.md`: new Health Checks section with JSON shape, exit codes, caveats
- `docs/features/README.md`: updated memory-search-tool row

## Testing
- [x] `pytest tests/unit/test_memory_search_cli.py -v` — 16/16 pass
- [x] `python -m ruff check .` — clean
- [x] `python -m ruff format --check .` — clean
- [x] `python -m tools.memory_search status` — verified live output
- [x] `python -m tools.memory_search status --json` — contains `healthy` key
- [x] `python -m tools.memory_search status --deep --json` — adds `orphan_index_count`

## Documentation
- [x] CLAUDE.md command table updated
- [x] docs/features/subconscious-memory.md Health Checks section added
- [x] docs/features/README.md memory-search-tool row updated

## Definition of Done
- [x] Built: `status()`, `cmd_status()`, argparse subcommand all implemented
- [x] Tested: 16 unit tests passing, including Redis-down and all flag combinations
- [x] Documented: CLAUDE.md + subconscious-memory.md + README.md
- [x] Quality: ruff lint and format clean

Closes #964