### PR TITLE
fix(harness): session continuity via --resume with unconditional context budget (#976)

### DIFF
--- a/agent/sdk_client.py
+++ b/agent/sdk_client.py
@@ -1562,12 +1562,19 @@ async def get_response_via_harness(
     chunks are accumulated internally and never delivered mid-session.
 
     When ``prior_uuid`` is provided and valid, injects ``--resume <uuid>`` into
-    the subprocess argv and skips ``_apply_context_budget()`` (the message is
-    already minimal). If the resumed session fails with a stale UUID error,
-    retries once using ``full_context_message`` without ``--resume``.
+    the subprocess argv. ``_apply_context_budget()`` is applied **unconditionally**
+    to the final argv message, regardless of ``--resume`` state. On the typical
+    resume path the message is small and the function is a no-op; on first turns
+    and pathological large single messages it bounds the argv to prevent the
+    binary's "Separator is found" overflow crash.
+
+    If the resumed subprocess exits with **any** non-zero return code, retries
+    once using ``full_context_message`` without ``--resume`` (no stderr substring
+    gate — substring matching is brittle across CLI versions and locales).
 
     When ``session_id`` is provided, stores the captured Claude Code UUID on
     the AgentSession record after a successful turn (Popoto/Redis side effect).
+    Tests that pass ``session_id`` must mock ``_store_claude_session_uuid``.
 
     Args:
         message: The prompt to send to the CLI.
@@ -1595,24 +1602,37 @@ async def get_response_via_harness(
         proc_env.update(env)
         proc_env.pop("ANTHROPIC_API_KEY", None)
 
+    # Apply context budget unconditionally. On resumed turns with a typical
+    # small message this is a no-op (one length comparison). On first turns
+    # and on pathological large single messages (pasted transcripts, forwarded
+    # logs) it bounds the argv to prevent the binary's chunk-limit crash.
+    original_len = len(message)
+    message = _apply_context_budget(message)
+    if len(message) < original_len:
+        logger.info(
+            f"[harness] Context budget applied: trimmed {original_len} → {len(message)} chars"
+        )
+
     if prior_uuid:
+        logger.info(f"[harness] Resuming Claude session {prior_uuid} for session_id={session_id}")
         cmd = harness_cmd + ["--resume", prior_uuid, message]
     else:
-        original_len = len(message)
-        message = _apply_context_budget(message)
-        if len(message) < original_len:
-            logger.info(
-                f"[harness] Context budget applied: trimmed {original_len} → {len(message)} chars"
-            )
         cmd = harness_cmd + [message]
 
-    result_text, session_id_from_harness = await _run_harness_subprocess(cmd, working_dir, proc_env)
+    result_text, session_id_from_harness, returncode = await _run_harness_subprocess(
+        cmd, working_dir, proc_env
+    )
 
-    # Stale-UUID fallback: if --resume failed with stale UUID error, retry without it
-    if result_text == _STALE_UUID_SENTINEL and prior_uuid:
+    # Mandatory stale-UUID fallback: when prior_uuid was set and the subprocess
+    # exits with ANY non-zero return code, retry once without --resume using the
+    # full-context message. The fallback does NOT inspect stderr — substring
+    # matching is brittle across CLI versions and locales, and an unnecessary
+    # retry on a non-stale-UUID error costs only one extra subprocess spawn.
+    if prior_uuid and returncode is not None and returncode != 0:
         if full_context_message is not None:
             logger.warning(
-                "[harness] --resume failed, retrying without --resume (stale UUID fallback)"
+                f"[harness] Stale UUID {prior_uuid} for session_id={session_id}, "
+                "falling back to first-turn path"
             )
             original_len = len(full_context_message)
             fallback_msg = _apply_context_budget(full_context_message)
@@ -1621,34 +1641,36 @@ async def get_response_via_harness(
                     f"[harness] Fallback budget: {original_len} → {len(fallback_msg)} chars"
                 )
             fallback_cmd = harness_cmd + [fallback_msg]
-            result_text, session_id_from_harness = await _run_harness_subprocess(
+            result_text, session_id_from_harness, _ = await _run_harness_subprocess(
                 fallback_cmd, working_dir, proc_env
             )
         else:
-            logger.error("[harness] --resume failed and no full_context_message for fallback")
+            logger.error(
+                f"[harness] Stale UUID {prior_uuid} for session_id={session_id}, "
+                "falling back to first-turn path — no full_context_message available"
+            )
+            result_text = None
 
     # Store the Claude Code UUID for next-turn --resume (#976)
     if session_id and session_id_from_harness:
         _store_claude_session_uuid(session_id, session_id_from_harness)
 
-    if result_text is not None and result_text != _STALE_UUID_SENTINEL:
+    if result_text is not None:
         return result_text
     return ""
-
-
-_STALE_UUID_SENTINEL = "__stale_uuid__"
 
 
 async def _run_harness_subprocess(
     cmd: list[str],
     working_dir: str,
     proc_env: dict[str, str],
-) -> tuple[str | None, str | None]:
+) -> tuple[str | None, str | None, int | None]:
     """Execute a harness subprocess and parse stream-json output.
 
-    Returns (result_text, session_id_from_harness). result_text is
-    ``_STALE_UUID_SENTINEL`` when the process fails with a stale-UUID error,
-    ``None`` for other failures without a result event.
+    Returns (result_text, session_id_from_harness, returncode). On binary-not-found,
+    returncode is None and result_text carries the error message. On stream-parse
+    success, result_text is the parsed result and returncode is the process exit
+    code (0 on success, non-zero on failure).
     """
     try:
         proc = await asyncio.create_subprocess_exec(
@@ -1660,7 +1682,7 @@ async def _run_harness_subprocess(
         )
     except FileNotFoundError as e:
         logger.error(f"Harness binary not found: {e}")
-        return (f"Error: CLI harness not found — {e}", None)
+        return (f"Error: CLI harness not found — {e}", None, None)
 
     full_text = ""
     result_text = None
@@ -1699,22 +1721,21 @@ async def _run_harness_subprocess(
                     full_text += chunk
 
     _, stderr_data = await proc.communicate()
-    if proc.returncode and proc.returncode != 0:
+    returncode = proc.returncode if proc.returncode is not None else 0
+    if returncode != 0:
         stderr_text = stderr_data.decode("utf-8", errors="replace") if stderr_data else ""
-        logger.warning(f"Harness exited with code {proc.returncode}: {stderr_text[:500]}")
-        if "requires a valid session" in stderr_text:
-            return (_STALE_UUID_SENTINEL, None)
+        logger.warning(f"Harness exited with code {returncode}: {stderr_text[:500]}")
 
     if result_text is not None:
-        return (result_text, session_id_from_harness)
+        return (result_text, session_id_from_harness, returncode)
     if full_text:
         logger.warning(
             "Harness exited without result event, returning %d chars of accumulated text",
             len(full_text),
         )
-        return (full_text, session_id_from_harness)
+        return (full_text, session_id_from_harness, returncode)
     logger.error("Harness exited without a result event and no accumulated text")
-    return (None, session_id_from_harness)
+    return (None, session_id_from_harness, returncode)
 
 
 async def verify_harness_health(harness_name: str) -> bool:

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -54,6 +54,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [Google Workspace Auth](google-workspace-auth.md) | Error-resilient OAuth with verify_token(), --reauth/--check CLI flags, and actionable error messages | Shipped |
 | [Happy Path Testing Pipeline](happy-path-testing-pipeline.md) | Three-stage pipeline (discover, generate, run) for deterministic browser regression tests without LLM tokens | Shipped |
 | [Harness Abstraction](harness-abstraction.md) | CLI harness execution for dev sessions via `claude -p` with env-var routing (`DEV_SESSION_HARNESS`), stream-json parsing, and startup health checks (Phases 1-2 of #780) | Shipped |
+| [Harness Session Continuity](harness-session-continuity.md) | Native `claude -p --resume <uuid>` continuity — persists the CLI session UUID on `AgentSession` after each turn, reuses it on next turn, falls back to full-context on any non-zero exit (#976) | Shipped |
 | [Hooks Best Practices & Audit](hooks-best-practices.md) | `/audit-hooks` skill, codified hook safety patterns, and daily reflections integration | Shipped |
 | [Image Vision Support](image-vision.md) | Ollama LLaVA image descriptions for visual content in Telegram | Shipped |
 | [Intake Classifier](intake-classifier.md) | Haiku-powered message intent triage (interjection/new_work/acknowledgment) for bridge routing | Shipped |

--- a/docs/features/bridge-worker-architecture.md
+++ b/docs/features/bridge-worker-architecture.md
@@ -112,14 +112,22 @@ All session types (dev, pm, teammate) execute via the CLI harness (`claude -p`).
 ```
 _execute_agent_session(session)
     |
-    v
-build_harness_turn_input()  -- enriches message with context headers
+    |-- _get_prior_session_uuid(session_id)  -- Popoto lookup of claude_session_uuid (#976)
     |
     v
-_apply_context_budget()     -- trims oldest context if input exceeds HARNESS_MAX_INPUT_CHARS (100K)
+build_harness_turn_input(skip_prefix=bool(prior_uuid))
+    |   -- first turn: full PROJECT/FROM/SCOPE/MESSAGE headers
+    |   -- resumed turn: raw new message only (binary has context from its session file)
     |
     v
-get_response_via_harness()  -- spawns claude -p subprocess
+_apply_context_budget()     -- trims if input exceeds HARNESS_MAX_INPUT_CHARS (100K); runs on every call
+    |
+    v
+get_response_via_harness(prior_uuid=..., session_id=..., full_context_message=...)
+    |   -- resumed turn: spawns `claude -p --resume <uuid> [raw_message]`
+    |   -- first turn:   spawns `claude -p [full_context_message]`
+    |   -- stale UUID:   on any non-zero exit with prior_uuid set, retries once without --resume
+    |   -- after success: persists captured session_id to AgentSession.claude_session_uuid
     |
     v
 _handle_dev_session_completion()  [dev sessions only]
@@ -129,7 +137,7 @@ _handle_dev_session_completion()  [dev sessions only]
     |-- steer_session(parent_pm_session)
 ```
 
-PM and teammate sessions skip the post-completion SDLC handler. See [Harness Abstraction](harness-abstraction.md) for full details on stream-json parsing, chunk suppression, health checks, and configuration.
+PM and teammate sessions skip the post-completion SDLC handler. See [Harness Abstraction](harness-abstraction.md) for stream-json parsing, chunk suppression, health checks, and configuration, and [Harness Session Continuity](harness-session-continuity.md) for the `--resume` UUID persistence mechanism.
 
 At runtime, the worker processes sessions via `_worker_loop(worker_key)` until the queue is empty, then waits for new enqueue events.
 

--- a/docs/features/harness-abstraction.md
+++ b/docs/features/harness-abstraction.md
@@ -44,17 +44,20 @@ Final result string returned
 
 - **`content_block_start` events**: Resets the internal text buffer — only the current block is retained, never a concatenation across blocks or turns
 - **`content_block_delta` events**: Text chunks accumulate into the current block buffer
-- **`result` event**: Contains the final response text and a `session_id` for potential future resume support
+- **`result` event**: Contains the final response text and a `session_id`. The session_id is persisted on the `AgentSession.claude_session_uuid` field and reused on the next turn via `--resume` (see [Harness Session Continuity](harness-session-continuity.md))
 - **Interruption (no `result` event)**: If the subprocess is killed before emitting `result` (e.g. crash or SIGTERM), the function returns `""` and logs at `ERROR` level. `BackgroundTask` skips the send on empty string — nothing reaches Telegram
 - **Error handling**: Malformed JSON lines are skipped; non-zero exit codes are logged with stderr
 
 The function returns the final result text only — it has no streaming callback parameter.
 
-### Context Budget Cap (issue #958)
+### Session Continuity and Context Budget (issues #958, #976)
 
-Before launching the subprocess, `get_response_via_harness()` calls `_apply_context_budget(message)`. If the assembled input exceeds `HARNESS_MAX_INPUT_CHARS` (100,000 characters), the oldest context is trimmed from the start of the string. The `MESSAGE:` boundary is preserved unconditionally — the steering message is never truncated. A `[CONTEXT TRIMMED]` marker is prepended so the agent is aware context was omitted.
+`get_response_via_harness()` uses two complementary mechanisms to keep the subprocess argv bounded:
 
-This prevents `Separator is not found, and chunk exceed the limit` crashes in the `claude` binary that occur when PM sessions accumulate large resume-hydration + reply-chain contexts across multiple Telegram turns. The cap is a module-level constant in `agent/sdk_client.py` and can be raised by editing it without other code changes.
+1. **Native `--resume` continuity (#976)** — On the first turn the captured `session_id` is persisted to `AgentSession.claude_session_uuid`. On subsequent turns the harness looks up the prior UUID and spawns `claude -p --resume <uuid> ... [raw_new_message]`; the binary loads prior context from its on-disk session file and the positional argv is just the new user message. Context overflow becomes structurally impossible for resumed turns. See [Harness Session Continuity](harness-session-continuity.md) for the two argv shapes, the stale-UUID fallback, and observability log lines.
+2. **Context budget cap (#958)** — `_apply_context_budget(message)` runs unconditionally before every spawn (first and resumed turns alike). If the assembled input exceeds `HARNESS_MAX_INPUT_CHARS` (100,000 characters), the oldest context is trimmed from the start of the string. The `MESSAGE:` boundary is preserved unconditionally — the steering message is never truncated. A `[CONTEXT TRIMMED]` marker is prepended so the agent is aware context was omitted.
+
+The budget remains in place even on resumed turns because a single new user message can still carry a forwarded transcript or pasted log that alone exceeds the chunk limit. Together the two mechanisms eliminated the `Separator is found, but chunk is longer than limit` crashes that previously affected long Telegram threads. The cap is a module-level constant in `agent/sdk_client.py` and can be raised by editing it without other code changes.
 
 ### Streaming Chunk Suppression
 
@@ -105,8 +108,8 @@ No changes to the `AgentSession` model are needed. Harness selection is purely a
 
 | File | What changed |
 |------|-------------|
-| `agent/sdk_client.py` | Added `get_response_via_harness()`, `verify_harness_health()`, `_HARNESS_COMMANDS` registry, `_apply_context_budget()`, `HARNESS_MAX_INPUT_CHARS` |
-| `agent/agent_session_queue.py` | Routing logic in `_execute_agent_session()`: checks `DEV_SESSION_HARNESS` env var for dev sessions |
+| `agent/sdk_client.py` | `get_response_via_harness()`, `verify_harness_health()`, `_HARNESS_COMMANDS` registry, `_apply_context_budget()`, `HARNESS_MAX_INPUT_CHARS`; `_get_prior_session_uuid()` / `_store_claude_session_uuid()` / `_UUID_PATTERN` for `--resume` continuity (#976); `build_harness_turn_input(skip_prefix=...)` for the two argv shapes |
+| `agent/agent_session_queue.py` | Routing logic in `_execute_agent_session()`: all session types go through the CLI harness; looks up prior UUID via `_get_prior_session_uuid()` and passes both full-context and minimal message forms to `get_response_via_harness()` so the stale-UUID fallback can retry without `--resume` |
 | `worker/__main__.py` | Startup health check when harness is non-`sdk` |
 | `agent/__init__.py` | Exports `get_response_via_harness` and `verify_harness_health` |
 | `tests/unit/test_harness_streaming.py` | Unit tests covering NDJSON parsing, text accumulation, error paths, health checks (isolation scope only — no send_cb) |

--- a/docs/features/harness-session-continuity.md
+++ b/docs/features/harness-session-continuity.md
@@ -1,0 +1,152 @@
+# Harness Session Continuity
+
+**Status:** Shipped (issue #976)
+**Owner:** agent/sdk_client.py, agent/agent_session_queue.py
+**Related:** [harness-abstraction.md](harness-abstraction.md), [pm-dev-session-architecture.md](pm-dev-session-architecture.md), PR #909
+
+## Problem
+
+Dev sessions executed via the CLI harness (`claude -p` subprocess) used to rebuild
+the entire reply chain, project header, scope text, and steering message into a
+single positional `argv` on every turn. On long Telegram threads that argv
+crossed the binary's internal chunk limit (~200KB), and the subprocess crashed
+with `Separator is found, but chunk is longer than limit`. The prior band-aid
+(`_apply_context_budget()`, #958) trimmed the argv string to ≤100KB but could
+not stop the binary from overflowing on intra-turn tool output.
+
+## Solution
+
+The harness now uses the Claude CLI's native `--resume` continuity:
+
+1. **First turn**: build the full-context message (`PROJECT` / `FROM` /
+   `SESSION_ID` / `TASK_SCOPE` / `SCOPE` / `MESSAGE`), spawn
+   `claude -p ... [full_context]`, capture the `session_id` from the stream-json
+   `result` event, and persist it on the `AgentSession` record's
+   `claude_session_uuid` field via `_store_claude_session_uuid()`.
+2. **Subsequent turns**: look up the prior UUID via
+   `_get_prior_session_uuid(session_id)`. When found and UUID-valid, spawn
+   `claude -p --resume <uuid> ... [raw_new_message]`. The binary loads prior
+   context from its on-disk session file; the positional argv stays bounded by
+   the size of the new user message alone.
+
+Context overflow becomes structurally impossible for resumed turns. On first
+turns and on pathological single mega-messages (pasted transcripts, forwarded
+logs), `_apply_context_budget()` still bounds the argv.
+
+## Two Harness Turn Shapes
+
+### Shape A — First turn (no prior UUID)
+
+```
+claude -p --verbose --output-format stream-json [full_context_message]
+```
+
+`full_context_message` is built by `build_harness_turn_input(skip_prefix=False)`
+and carries the `PROJECT` / `FROM` / `SESSION_ID` / `TASK_SCOPE` / `SCOPE` /
+`MESSAGE:` headers. `_apply_context_budget()` is applied before spawn.
+
+### Shape B — Resumed turn (prior UUID present and valid)
+
+```
+claude -p --verbose --output-format stream-json --resume <uuid> [new_user_message]
+```
+
+`new_user_message` is built by `build_harness_turn_input(skip_prefix=True)` and
+contains only the raw user message body — no context headers. The binary
+already has that context from its session file. `_apply_context_budget()` is
+still applied unconditionally to bound pathological single messages.
+
+## Role of `claude_session_uuid` on `AgentSession`
+
+The same Popoto field that the SDK path uses (PR #909) now serves the harness
+path too. Every successful `get_response_via_harness()` call that receives a
+`session_id` argument writes the captured UUID to the matching
+`AgentSession.claude_session_uuid`. The next turn's
+`_get_prior_session_uuid()` reads it and passes it into the harness.
+
+Serialization is handled by the worker's per-session queue: two turns for the
+same `session_id` are never in flight simultaneously, so the write-before-next-read
+invariant holds without additional locking.
+
+## Stale-UUID Fallback
+
+A prior UUID can become stale if the on-disk session file is deleted, the binary
+is upgraded to an incompatible format, or the file is never created (e.g.
+first-turn binary crash before flush). When `prior_uuid` was set and the
+subprocess exits with **any** non-zero return code, the harness retries once
+without `--resume`, using the `full_context_message` that the dispatcher passed
+as a fallback argument.
+
+The fallback is unconditional on exit code — it does **not** inspect stderr.
+Substring matching (e.g. `"requires a valid session"`) against the CLI's error
+text was rejected because:
+
+- CLI version drift changes the error phrasing.
+- Non-English locales emit localized errors.
+- An unnecessary retry on a real (non-stale-UUID) error costs only one extra
+  subprocess spawn — strictly cheaper than a silent stuck-empty turn.
+
+## Why `_apply_context_budget()` Is Retained
+
+Even on resumed turns, the single new user message is the positional argv. A
+Telegram message can carry a forwarded transcript or a pasted log that alone
+exceeds the chunk limit. `_apply_context_budget()` runs unconditionally:
+
+- On first turns: bounds the reconstructed full-context message.
+- On resumed turns with typical small messages: a no-op (one length comparison).
+- On resumed turns with pathological mega-messages: trims to the safe ceiling,
+  preserving the fix against the original "Separator is found" crash.
+
+The optimization "skip the budget when resuming" is explicitly rejected — it
+saves nothing on small messages and reintroduces the original crash on large
+ones.
+
+## Observability
+
+Two log lines enable grep-based tracking of harness continuity in production:
+
+- **INFO** `[harness] Resuming Claude session <uuid> for session_id=<sid>` —
+  emitted on every `--resume` injection.
+- **WARNING** `[harness] Stale UUID <uuid> for session_id=<sid>, falling back
+  to first-turn path` — emitted on every fallback trigger.
+
+Resume hit-rate: `grep -c 'Resuming Claude session' logs/worker.log`.
+Fallback incidence: `grep -c 'Stale UUID' logs/worker.log`.
+
+## File:line Index
+
+- `agent/sdk_client.py`
+  - `_get_prior_session_uuid()` — Popoto lookup of prior UUID by `session_id`.
+  - `_store_claude_session_uuid()` — Popoto write of UUID after each turn.
+  - `_apply_context_budget()` — argv size ceiling (retained safety net).
+  - `_UUID_PATTERN` — UUID v4 regex for input validation before `--resume`.
+  - `get_response_via_harness()` — harness subprocess entry point with
+    `prior_uuid`, `session_id`, and `full_context_message` keyword args.
+  - `_run_harness_subprocess()` — the actual `asyncio.create_subprocess_exec`
+    call, returns `(result, session_id, returncode)`.
+  - `build_harness_turn_input()` — context-prefix builder with
+    `skip_prefix` keyword arg.
+- `agent/agent_session_queue.py`
+  - `_execute_agent_session()` — call site; looks up prior UUID, builds both
+    full and minimal message forms, passes both to `get_response_via_harness`.
+
+## Tests
+
+- `tests/unit/test_harness_streaming.py::TestHarnessResume` — argv shape,
+  UUID storage, empty/invalid UUID handling, stale-UUID fallback on any
+  non-zero exit, observability log assertions.
+- `tests/unit/test_cross_repo_gh_resolution.py` — `skip_prefix=True` behavior
+  in `build_harness_turn_input()`.
+- `tests/integration/test_harness_resume.py` — two-turn cycle against the real
+  `claude` binary; gated on `shutil.which("claude")`.
+
+## Out of Scope / No-Go
+
+- BaseHarness abstraction (#780) — downstream consumer.
+- Pi harness adoption (#838) — separate work item.
+- Structured metrics/dashboards for resume hit-rate — grep-based observability
+  is sufficient for now.
+- Refactoring `build_harness_turn_input()` beyond the additive `skip_prefix`
+  flag.
+- Cross-process UUID race coordination — Popoto serialization via the worker
+  queue is sufficient.

--- a/docs/features/pm-dev-session-architecture.md
+++ b/docs/features/pm-dev-session-architecture.md
@@ -309,7 +309,10 @@ Worker picks up Dev session from Redis queue
     |
     v
 _execute_agent_session() routes all session types to CLI harness
-    |-- get_response_via_harness()  <- claude -p subprocess
+    |-- _get_prior_session_uuid(session_id)  <- Popoto lookup (#976)
+    |-- build_harness_turn_input(..., skip_prefix=<bool>)  <- two shapes
+    |-- get_response_via_harness()  <- claude -p [--resume <uuid>] subprocess
+    |       (see docs/features/harness-session-continuity.md)
     |
     v
 Dev session executes assigned work

--- a/docs/guides/claude-cli-reference.md
+++ b/docs/guides/claude-cli-reference.md
@@ -1,0 +1,179 @@
+# Claude CLI Reference
+
+> Source: https://code.claude.com/docs/en/cli-reference  
+> Retrieved: 2026-04-15
+
+## Overview
+
+Claude Code starts an interactive session by default. Use `-p`/`--print` for non-interactive output.
+
+```
+claude [options] [command] [prompt]
+```
+
+## CLI Commands
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `claude` | Start interactive session | `claude` |
+| `claude "query"` | Start interactive session with initial prompt | `claude "explain this project"` |
+| `claude -p "query"` | Query via SDK, then exit | `claude -p "explain this function"` |
+| `cat file \| claude -p "query"` | Process piped content | `cat logs.txt \| claude -p "explain"` |
+| `claude -c` | Continue most recent conversation in current directory | `claude -c` |
+| `claude -c -p "query"` | Continue via SDK (non-interactive) | `claude -c -p "Check for type errors"` |
+| `claude -r "<session>" "query"` | Resume session by ID or name | `claude -r "auth-refactor" "Finish this PR"` |
+| `claude update` | Update to latest version | `claude update` |
+| `claude auth login` | Sign in to Anthropic account | `claude auth login --console` |
+| `claude auth logout` | Log out | `claude auth logout` |
+| `claude auth status` | Show auth status as JSON | `claude auth status` |
+| `claude agents` | List configured subagents | `claude agents` |
+| `claude auto-mode defaults` | Print built-in auto mode classifier rules as JSON | `claude auto-mode defaults > rules.json` |
+| `claude mcp` | Configure MCP servers | — |
+| `claude plugin` | Manage plugins (alias: `claude plugins`) | — |
+| `claude remote-control` | Start a Remote Control server | `claude remote-control --name "My Project"` |
+| `claude setup-token` | Generate a long-lived OAuth token for CI/scripts | `claude setup-token` |
+
+## CLI Flags
+
+### Session Continuity
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `--continue`, `-c` | Load the most recent conversation in the current directory | `claude --continue` |
+| `--resume`, `-r` | Resume a specific session by ID or name, or show interactive picker | `claude --resume auth-refactor` |
+| `--session-id <uuid>` | Use a specific session ID (must be a valid UUID) | `claude --session-id "550e8400-..."` |
+| `--fork-session` | When resuming, create a new session ID instead of reusing the original | `claude --resume abc123 --fork-session` |
+| `--from-pr` | Resume sessions linked to a specific GitHub PR | `claude --from-pr 123` |
+| `--name`, `-n` | Set a display name for the session | `claude -n "my-feature-work"` |
+| `--no-session-persistence` | Disable session persistence (print mode only) | `claude -p --no-session-persistence "query"` |
+| `--teleport` | Resume a web session in your local terminal | `claude --teleport` |
+
+### Output & Format
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `--print`, `-p` | Print response without interactive mode | `claude -p "query"` |
+| `--output-format <format>` | Output format: `text`, `json`, `stream-json` (print mode only) | `claude -p "query" --output-format json` |
+| `--input-format <format>` | Input format: `text`, `stream-json` (print mode only) | `claude -p --input-format stream-json` |
+| `--include-partial-messages` | Include partial streaming events (requires `--print` and `stream-json`) | — |
+| `--include-hook-events` | Include hook lifecycle events in output stream (requires `stream-json`) | — |
+| `--replay-user-messages` | Re-emit user messages from stdin back on stdout | — |
+| `--json-schema <schema>` | Get validated JSON output matching a schema (print mode only) | — |
+| `--verbose` | Enable verbose logging, shows full turn-by-turn output | `claude --verbose` |
+
+### Model & Effort
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `--model <model>` | Set model: alias (`sonnet`, `opus`) or full name | `claude --model claude-sonnet-4-6` |
+| `--effort <level>` | Effort level: `low`, `medium`, `high`, `max` (Opus 4.6 only) | `claude --effort high` |
+| `--fallback-model <model>` | Fallback model when default is overloaded (print mode only) | `claude -p --fallback-model sonnet "query"` |
+| `--betas <betas...>` | Beta headers to include in API requests (API key users only) | `claude --betas interleaved-thinking` |
+
+### System Prompt
+
+| Flag | Behavior | Example |
+|------|----------|---------|
+| `--system-prompt <prompt>` | Replace entire default system prompt | `claude --system-prompt "You are a Python expert"` |
+| `--system-prompt-file <path>` | Replace with file contents | `claude --system-prompt-file ./prompts/review.txt` |
+| `--append-system-prompt <prompt>` | Append to the default system prompt | `claude --append-system-prompt "Always use TypeScript"` |
+| `--append-system-prompt-file <path>` | Append file contents to the default prompt | `claude --append-system-prompt-file ./style-rules.txt` |
+
+`--system-prompt` and `--system-prompt-file` are mutually exclusive. Append flags can combine with either replacement flag.
+
+### Permissions & Tools
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `--permission-mode <mode>` | Permission mode: `default`, `acceptEdits`, `plan`, `auto`, `dontAsk`, `bypassPermissions` | `claude --permission-mode plan` |
+| `--dangerously-skip-permissions` | Skip all permission prompts (equivalent to `bypassPermissions`) | — |
+| `--allow-dangerously-skip-permissions` | Add `bypassPermissions` to Shift+Tab cycle without starting in it | — |
+| `--tools <tools...>` | Restrict built-in tools (`""` disables all, `"default"` enables all) | `claude --tools "Bash,Edit,Read"` |
+| `--allowedTools <tools...>` | Tools that execute without prompting | `"Bash(git log *)" "Read"` |
+| `--disallowedTools <tools...>` | Tools removed from model context entirely | `"Bash(git log *)" "Edit"` |
+| `--permission-prompt-tool` | MCP tool to handle permission prompts in non-interactive mode | — |
+| `--enable-auto-mode` | Unlock auto mode in Shift+Tab cycle (Team/Enterprise/API plans only) | — |
+
+### Agents & Extensions
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `--agent <agent>` | Specify agent for current session (overrides `agent` setting) | `claude --agent my-custom-agent` |
+| `--agents <json>` | Define custom subagents dynamically via JSON | `claude --agents '{"reviewer":{"description":"...","prompt":"..."}}'` |
+| `--plugin-dir <path>` | Load plugins from directory (repeatable) | `claude --plugin-dir ./my-plugins` |
+| `--disable-slash-commands` | Disable all skills and commands | — |
+
+### MCP & Settings
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `--mcp-config <configs...>` | Load MCP servers from JSON files or strings | `claude --mcp-config ./mcp.json` |
+| `--strict-mcp-config` | Only use MCP servers from `--mcp-config` | — |
+| `--settings <file-or-json>` | Load additional settings from file or JSON string | `claude --settings ./settings.json` |
+| `--setting-sources <sources>` | Comma-separated setting sources to load: `user`, `project`, `local` | `claude --setting-sources user,project` |
+
+### Worktrees & IDE
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `--worktree`, `-w` | Start in isolated git worktree at `<repo>/.claude/worktrees/<name>` | `claude -w feature-auth` |
+| `--tmux` | Create a tmux session for the worktree (requires `--worktree`) | `claude -w feature-auth --tmux` |
+| `--ide` | Automatically connect to IDE on startup | `claude --ide` |
+| `--chrome` / `--no-chrome` | Enable/disable Chrome browser integration | `claude --chrome` |
+| `--teammate-mode` | Agent team display: `auto`, `in-process`, `tmux` | `claude --teammate-mode in-process` |
+
+### Performance & Caching
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `--bare` | Minimal mode: skip hooks, LSP, plugins, CLAUDE.md discovery, MCP. Sets `CLAUDE_CODE_SIMPLE=1` | `claude --bare -p "query"` |
+| `--exclude-dynamic-system-prompt-sections` | Move per-machine sections to first user message (improves cache reuse) | `claude -p --exclude-dynamic-system-prompt-sections "query"` |
+| `--max-budget-usd <amount>` | Maximum spend on API calls (print mode only) | `claude -p --max-budget-usd 5.00 "query"` |
+| `--max-turns <n>` | Limit agentic turns (print mode only, no limit by default) | `claude -p --max-turns 3 "query"` |
+| `--add-dir <directories...>` | Add directories for tool access (grants file access, not config discovery) | `claude --add-dir ../apps ../lib` |
+
+### Other
+
+| Flag | Description |
+|------|-------------|
+| `--debug [filter]` | Enable debug mode with optional category filtering (e.g., `"api,hooks"`) |
+| `--debug-file <path>` | Write debug logs to a file (implicitly enables debug mode) |
+| `--remote` | Create a new web session on claude.ai |
+| `--remote-control`, `--rc` | Start interactive session with Remote Control enabled |
+| `--remote-control-session-name-prefix` | Prefix for auto-generated Remote Control session names |
+| `--init` | Run initialization hooks and start interactive mode |
+| `--init-only` | Run initialization hooks and exit |
+| `--maintenance` | Run maintenance hooks and start interactive mode |
+| `--version`, `-v` | Output the version number |
+| `--help`, `-h` | Display help |
+
+## Key Patterns for Programmatic Use
+
+```bash
+# Non-interactive, stream JSON output
+claude -p --output-format stream-json --include-partial-messages "query"
+
+# Resume a specific session non-interactively
+claude -p -r <session-uuid> "next message"
+
+# Continue most recent session non-interactively
+claude -p -c "next message"
+
+# Resume + stream JSON (harness pattern)
+claude -p --resume <uuid> --output-format stream-json --include-partial-messages --permission-mode bypassPermissions "query"
+
+# Bare mode for fast scripted calls (no hooks, MCP, CLAUDE.md)
+claude --bare -p "query"
+
+# Improve prompt cache reuse across machines
+claude -p --exclude-dynamic-system-prompt-sections "query"
+```
+
+## Session Files
+
+Sessions are stored as JSONL files at:
+```
+~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl
+```
+
+The `--resume <uuid>` flag loads a specific session file. Both interactive and `-p` modes write to the same format, so sessions are interchangeable between modes.

--- a/docs/guides/pi-cli-reference.md
+++ b/docs/guides/pi-cli-reference.md
@@ -1,0 +1,253 @@
+# Pi CLI Reference
+
+> Source: `pi --help`, https://pi.dev/docs, https://github.com/badlogic/pi-mono  
+> Retrieved: 2026-04-15  
+> Version: v0.66.1 (installed at `/usr/local/bin/pi` or via npm)
+
+## Overview
+
+Pi is a minimal terminal coding harness designed for developers. It integrates with multiple LLM providers and is extensible via TypeScript plugins.
+
+```
+pi [options] [@files...] [messages...]
+```
+
+## Operational Modes
+
+| Mode | Flag | Purpose |
+|------|------|---------|
+| Interactive | (default) | Real-time terminal interface with editor |
+| Print | `-p`, `--print` | Execute prompt and exit |
+| JSON | `--mode json` | Emit all events as JSONL |
+| RPC | `--mode rpc` | Process integration via stdin/stdout (for non-Node integrations) |
+
+## Session Management
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `--continue`, `-c` | Resume most recent session | `pi -c "What did we discuss?"` |
+| `--resume`, `-r` | Browse and select from past sessions interactively | `pi -r` |
+| `--session <path>` | Load specific session file or partial UUID | `pi --session ~/.pi/agent/sessions/.../session.jsonl` |
+| `--fork <path>` | Fork specific session file into a new session | `pi --fork <path>` |
+| `--session-dir <dir>` | Custom session storage directory | `pi --session-dir ./sessions` |
+| `--no-session` | Ephemeral mode, no persistence | `pi --no-session -p "quick query"` |
+
+Sessions are stored as JSONL at `~/.pi/agent/sessions/<encoded-path>/`. Pi supports branching history — `/fork` and `--fork` create new sessions from existing ones.
+
+## Model & Provider
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `--provider <name>` | LLM provider (default: `google`) | `--provider anthropic` |
+| `--model <pattern>` | Model ID or pattern. Supports `provider/id` and `:thinking` suffix | `--model sonnet:high` |
+| `--api-key <key>` | Override environment API key | — |
+| `--thinking <level>` | Thinking level: `off`, `minimal`, `low`, `medium`, `high`, `xhigh` | `--thinking high` |
+| `--models <patterns>` | Comma-separated model patterns for Ctrl+P cycling | `--models "claude-*,gpt-4o"` |
+| `--list-models [search]` | List available models with optional fuzzy search | `pi --list-models sonnet` |
+
+**Model shorthand**: `pi --model openai/gpt-4o` (no `--provider` needed)  
+**Thinking shorthand**: `pi --model sonnet:high`
+
+## Tools
+
+| Flag | Description |
+|------|-------------|
+| `--tools <list>` | Comma-separated tools: `read,bash,edit,write,grep,find,ls` |
+| `--no-tools` | Disable all built-in tools |
+
+Default: `read,bash,edit,write`. `grep`, `find`, `ls` are off by default (read-only, explicit opt-in).
+
+## System Prompt
+
+| Flag | Description |
+|------|-------------|
+| `--system-prompt <text>` | Replace default system prompt |
+| `--append-system-prompt <text>` | Append to existing prompt |
+
+Context files (`AGENTS.md`, `CLAUDE.md`) are always concatenated regardless of replacement.
+
+## File Input
+
+Files prefixed with `@` are included in messages:
+
+```bash
+pi @prompt.md "Answer this"
+pi -p @screenshot.png "What's in this image?"
+pi @code.ts @test.ts "Review these files"
+```
+
+## Extensions & Skills
+
+| Flag | Description |
+|------|-------------|
+| `-e`, `--extension <path>` | Load extension file (repeatable; accepts path, npm, or git source) |
+| `--no-extensions`, `-ne` | Disable extension discovery (explicit `-e` paths still work) |
+| `--skill <path>` | Load skill file or directory (repeatable) |
+| `--no-skills`, `-ns` | Disable skill discovery |
+| `--prompt-template <path>` | Load prompt template (repeatable) |
+| `--no-prompt-templates`, `-np` | Disable prompt template discovery |
+| `--theme <path>` | Load theme (repeatable) |
+| `--no-themes` | Disable theme discovery |
+
+## Export & Utility
+
+| Flag | Description |
+|------|-------------|
+| `--export <file>` | Export session to HTML and exit |
+| `--offline` | Disable startup network operations (same as `PI_OFFLINE=1`) |
+| `--verbose` | Force verbose startup |
+| `--version`, `-v` | Show version number |
+| `--help`, `-h` | Show help |
+
+## Extension CLI Flags (from installed packages)
+
+| Flag | Description |
+|------|-------------|
+| `--lens-verbose` | Enable verbose pi-lens logging |
+| `--no-biome` | Disable Biome linting/formatting |
+| `--no-oxlint` | Disable Oxlint fast JS/TS linter |
+| `--no-ast-grep` | Disable ast-grep structural analysis |
+| `--no-ruff` | Disable Ruff Python linting |
+| `--no-shellcheck` | Disable shellcheck for shell scripts |
+| `--no-lsp` | Disable unified LSP diagnostics |
+| `--no-madge` | Disable circular dependency checking |
+| `--no-autoformat` | Disable automatic formatting on file write |
+| `--no-autofix` | Disable auto-fixing of lint issues |
+| `--no-tests` | Disable test runner on write |
+| `--error-debt` | Track test failures and block if tests start failing |
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `ANTHROPIC_API_KEY` | Anthropic Claude API key |
+| `ANTHROPIC_OAUTH_TOKEN` | Anthropic OAuth token (alternative to API key) |
+| `OPENAI_API_KEY` | OpenAI API key |
+| `AZURE_OPENAI_API_KEY` | Azure OpenAI API key |
+| `AZURE_OPENAI_BASE_URL` | Azure OpenAI base URL |
+| `GEMINI_API_KEY` | Google Gemini API key |
+| `GROQ_API_KEY` | Groq API key |
+| `CEREBRAS_API_KEY` | Cerebras API key |
+| `XAI_API_KEY` | xAI Grok API key |
+| `OPENROUTER_API_KEY` | OpenRouter API key |
+| `MISTRAL_API_KEY` | Mistral API key |
+| `AWS_PROFILE` / `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | AWS Bedrock credentials |
+| `AWS_REGION` | AWS region for Bedrock |
+| `PI_CODING_AGENT_DIR` | Session storage directory (default: `~/.pi/agent`) |
+| `PI_PACKAGE_DIR` | Override package directory (for Nix/Guix) |
+| `PI_OFFLINE` | Disable startup network operations when `1`/`true`/`yes` |
+| `PI_SHARE_VIEWER_URL` | Base URL for `/share` command |
+| `PI_CACHE_RETENTION` | Set to `long` for extended prompt caching |
+
+## Package Management
+
+```bash
+pi install <source> [-l]     # Install extension (project-local with -l)
+pi remove <source> [-l]      # Uninstall
+pi update [source]           # Update packages (skips pinned versions)
+pi list                      # List installed packages
+pi config                    # Toggle package resources (TUI)
+```
+
+Sources: `npm:@foo/pi-tools`, `git:github.com/user/repo`, HTTPS URLs.
+
+## Interactive Mode Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| Ctrl+C | Clear editor / Quit (twice) |
+| Escape | Cancel/abort |
+| Escape (twice) | Open session tree navigation |
+| Ctrl+L | Open model selector |
+| Ctrl+P / Shift+Ctrl+P | Cycle models forward/backward |
+| Shift+Tab | Adjust thinking level |
+| Ctrl+O | Toggle tool output visibility |
+| Ctrl+T | Collapse/expand reasoning blocks |
+| Shift+Enter | Multi-line input |
+| Ctrl+V | Paste images |
+| Alt+Enter | Queue follow-up message |
+| Enter | Send steering message (interrupts remaining tools) |
+
+## Interactive Commands (Slash)
+
+| Command | Function |
+|---------|----------|
+| `/model` | Switch models mid-session |
+| `/scoped-models` | Configure Ctrl+P cycling |
+| `/settings` | Adjust thinking, theme, delivery options |
+| `/resume` | Select from previous sessions |
+| `/new` | Start fresh session |
+| `/name <name>` | Rename current session |
+| `/session` | Display session metadata |
+| `/tree` | Navigate branching history |
+| `/fork` | Branch current session |
+| `/compact [prompt]` | Manual context compaction |
+| `/copy` | Clipboard export of last response |
+| `/export [file]` | HTML session export |
+| `/share` | Upload to GitHub gist |
+| `/reload` | Refresh extensions and resources |
+| `/hotkeys` | Display complete keybinding list |
+| `/quit` | Exit |
+
+## Configuration Files
+
+| Path | Purpose |
+|------|---------|
+| `~/.pi/agent/settings.json` | Global settings |
+| `.pi/settings.json` | Project settings (overrides global) |
+| `AGENTS.md` or `CLAUDE.md` | Context files (project and parent dirs) |
+| `.pi/SYSTEM.md` | Project system prompt override |
+| `~/.pi/agent/SYSTEM.md` | Global system prompt override |
+| `~/.pi/agent/keybindings.json` | Custom keybindings |
+| `~/.pi/agent/models.json` | Custom model definitions |
+
+## JSONL Event Types (JSON/RPC mode)
+
+Pi's `--mode json` emits newline-delimited JSON objects linked by `parentId`:
+
+| Event type | Description |
+|------------|-------------|
+| `session` | Session start/metadata |
+| `model_change` | Model switched mid-session |
+| `thinking_level_change` | Thinking level changed |
+| `message` | Content block (text, tool calls, tool results) |
+
+RPC mode uses LF-delimited JSONL. Split records on `\n` only — not Unicode line boundaries.
+
+## Key Patterns for Programmatic Use
+
+```bash
+# Non-interactive JSON output
+pi -p --mode json "query"
+
+# Resume specific session non-interactively
+pi -p --session ~/.pi/agent/sessions/.../session.jsonl "next message"
+
+# Continue most recent session non-interactively
+pi -p --continue "next message"
+
+# Multi-provider routing
+pi -p --provider openrouter --model anthropic/claude-opus-4-6 "query"
+
+# Groq for fast inference
+pi -p --provider groq --model llama-3.3-70b-versatile "query"
+
+# Read-only audit
+pi --tools read,grep,find,ls -p "Review the code in src/"
+
+# Ephemeral (no session saved)
+pi --no-session -p "quick one-off query"
+```
+
+## Compared to Claude CLI
+
+| Feature | Claude CLI | Pi CLI |
+|---------|-----------|--------|
+| Session continuity | `--resume <uuid>` or `--continue` | `--session <path>` or `--continue` |
+| Session storage | `~/.claude/projects/<cwd>/<uuid>.jsonl` | `~/.pi/agent/sessions/<cwd>/` |
+| Multi-provider | No (Anthropic only) | Yes (OpenAI, Groq, Gemini, Bedrock, etc.) |
+| Programmatic output | `--output-format stream-json` | `--mode json` |
+| Context compaction | `/compact` (interactive) | `/compact [prompt]` (interactive) |
+| Thinking levels | Via model config | `--thinking off/minimal/low/medium/high/xhigh` |
+| Bare/minimal mode | `--bare` | `--no-extensions --no-skills --no-tools` |
+| Hook system | Claude Code hooks (`.claude/hooks/`) | Extension API (`pi.on("tool_call", ...)`) |

--- a/docs/plans/harness-session-continuity.md
+++ b/docs/plans/harness-session-continuity.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: docs_complete
 type: bug
 appetite: Small
 owner: Valor Engels

--- a/tests/unit/test_harness_streaming.py
+++ b/tests/unit/test_harness_streaming.py
@@ -419,14 +419,20 @@ class TestHarnessResume:
         assert "--resume" not in call_args
 
     @pytest.mark.asyncio
-    async def test_skips_context_budget_on_resume(self):
-        """_apply_context_budget is not invoked when prior_uuid is set."""
+    async def test_applies_context_budget_unconditionally(self):
+        """_apply_context_budget is invoked on every call, including resumed turns.
+
+        Replaces the prior skips_context_budget_on_resume test. The plan mandates
+        unconditional budget application: on resumed turns with small messages it is
+        a no-op (one length comparison); on pathological mega-messages it bounds argv.
+        """
         from agent.sdk_client import get_response_via_harness
 
         uuid = "483d0525-8d68-474e-9f1e-89cadd91e263"
         with patch("asyncio.create_subprocess_exec") as mock_exec:
             mock_exec.return_value = self._mock_proc(self._make_result_stdout())
-            with patch("agent.sdk_client._apply_context_budget") as mock_budget:
+            budget_patch = "agent.sdk_client._apply_context_budget"
+            with patch(budget_patch, side_effect=lambda m, **kw: m) as mock_budget:
                 with patch("agent.sdk_client._store_claude_session_uuid"):
                     await get_response_via_harness(
                         message="short msg",
@@ -434,7 +440,7 @@ class TestHarnessResume:
                         prior_uuid=uuid,
                         session_id="test-session",
                     )
-            mock_budget.assert_not_called()
+            mock_budget.assert_called()
 
     @pytest.mark.asyncio
     async def test_applies_context_budget_on_first_turn(self):
@@ -517,8 +523,12 @@ class TestHarnessResume:
         assert "--resume" not in call_args
 
     @pytest.mark.asyncio
-    async def test_stale_uuid_fallback(self):
-        """When --resume fails with stale UUID error, retries without --resume."""
+    async def test_stale_uuid_fallback_on_any_nonzero_exit(self):
+        """Any non-zero exit on a resumed turn triggers the fallback (no stderr substring gate).
+
+        The fallback is mandatory and unconditional on exit code — stderr text is
+        irrelevant. Replaces the prior substring-gated test.
+        """
         from agent.sdk_client import get_response_via_harness
 
         uuid = "483d0525-8d68-474e-9f1e-89cadd91e263"
@@ -528,10 +538,12 @@ class TestHarnessResume:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
+                # Stderr is intentionally NOT the stale-UUID phrase — fallback must
+                # still fire because returncode is non-zero.
                 return self._mock_proc(
                     "",
                     returncode=1,
-                    stderr=b"Error: --resume requires a valid session ID or session title",
+                    stderr=b"Error: something else went wrong entirely",
                 )
             else:
                 return self._mock_proc(self._make_result_stdout(result="fallback result"))
@@ -550,33 +562,99 @@ class TestHarnessResume:
         assert call_count == 2
 
     @pytest.mark.asyncio
-    async def test_no_retry_on_other_errors(self):
-        """Non-stale-UUID errors do not trigger a retry."""
-        from agent.sdk_client import get_response_via_harness
+    async def test_no_retry_on_first_turn_failure(self):
+        """First-turn failures (prior_uuid=None) do NOT trigger a retry.
 
-        uuid = "483d0525-8d68-474e-9f1e-89cadd91e263"
+        Preserves the existing first-turn error path semantics.
+        """
+        from agent.sdk_client import get_response_via_harness
 
         with patch("asyncio.create_subprocess_exec") as mock_exec:
             mock_exec.return_value = self._mock_proc(
                 "",
                 returncode=1,
-                stderr=b"Error: something else went wrong",
+                stderr=b"Error: something went wrong",
             )
-            with patch("agent.sdk_client._store_claude_session_uuid"):
-                result = await get_response_via_harness(
-                    message="test",
-                    working_dir="/tmp",
-                    prior_uuid=uuid,
-                    session_id="test-session",
-                    full_context_message="FULL CONTEXT",
-                )
+            result = await get_response_via_harness(
+                message="test",
+                working_dir="/tmp",
+                prior_uuid=None,
+            )
 
-        assert result == ""
+        # No retry — only one subprocess call
         mock_exec.assert_called_once()
+        # Result is empty since there was no accumulated text and no result event
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_logs_resume_at_info(self):
+        """INFO log 'Resuming Claude session ...' is emitted when --resume is injected.
+
+        Observability guard — production grep against logs/worker.log relies on this.
+        """
+        from agent.sdk_client import get_response_via_harness
+
+        uuid = "483d0525-8d68-474e-9f1e-89cadd91e263"
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            mock_exec.return_value = self._mock_proc(self._make_result_stdout())
+            with patch("agent.sdk_client._store_claude_session_uuid"):
+                with patch("agent.sdk_client.logger") as mock_logger:
+                    await get_response_via_harness(
+                        message="test",
+                        working_dir="/tmp",
+                        prior_uuid=uuid,
+                        session_id="test-session",
+                    )
+
+        # Assert an INFO call was made containing "Resuming Claude session"
+        info_calls = [
+            call for call in mock_logger.info.call_args_list
+            if "Resuming Claude session" in str(call)
+        ]
+        assert info_calls, "Expected logger.info with 'Resuming Claude session' to be called"
+
+    @pytest.mark.asyncio
+    async def test_stale_uuid_fallback_logs_warning(self):
+        """WARNING log 'Stale UUID ...' is emitted when fallback fires.
+
+        Observability guard — production grep against logs/worker.log relies on this.
+        """
+        from agent.sdk_client import get_response_via_harness
+
+        uuid = "483d0525-8d68-474e-9f1e-89cadd91e263"
+        call_count = 0
+
+        async def mock_exec(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return self._mock_proc("", returncode=1, stderr=b"error")
+            return self._mock_proc(self._make_result_stdout(result="ok"))
+
+        with patch("asyncio.create_subprocess_exec", side_effect=mock_exec):
+            with patch("agent.sdk_client._store_claude_session_uuid"):
+                with patch("agent.sdk_client.logger") as mock_logger:
+                    await get_response_via_harness(
+                        message="test",
+                        working_dir="/tmp",
+                        prior_uuid=uuid,
+                        session_id="test-session",
+                        full_context_message="FULL CONTEXT",
+                    )
+
+        warning_calls = [
+            call for call in mock_logger.warning.call_args_list
+            if "Stale UUID" in str(call) and "falling back to first-turn path" in str(call)
+        ]
+        assert warning_calls, "Expected logger.warning with 'Stale UUID ... falling back to first-turn path'"
 
     @pytest.mark.asyncio
     async def test_fallback_without_full_context(self):
-        """When full_context_message is None and stale-UUID fallback triggers, returns empty."""
+        """When full_context_message is None and stale-UUID fallback triggers, returns empty.
+
+        The fallback cannot fire without the full-context message; log an error and
+        return "". Defensive guard.
+        """
         from agent.sdk_client import get_response_via_harness
 
         uuid = "483d0525-8d68-474e-9f1e-89cadd91e263"
@@ -585,7 +663,7 @@ class TestHarnessResume:
             mock_exec.return_value = self._mock_proc(
                 "",
                 returncode=1,
-                stderr=b"Error: --resume requires a valid session ID or session title",
+                stderr=b"Error: any non-zero exit",
             )
             with patch("agent.sdk_client._store_claude_session_uuid"):
                 result = await get_response_via_harness(

--- a/tests/unit/test_harness_streaming.py
+++ b/tests/unit/test_harness_streaming.py
@@ -608,7 +608,8 @@ class TestHarnessResume:
 
         # Assert an INFO call was made containing "Resuming Claude session"
         info_calls = [
-            call for call in mock_logger.info.call_args_list
+            call
+            for call in mock_logger.info.call_args_list
             if "Resuming Claude session" in str(call)
         ]
         assert info_calls, "Expected logger.info with 'Resuming Claude session' to be called"
@@ -643,10 +644,13 @@ class TestHarnessResume:
                     )
 
         warning_calls = [
-            call for call in mock_logger.warning.call_args_list
+            call
+            for call in mock_logger.warning.call_args_list
             if "Stale UUID" in str(call) and "falling back to first-turn path" in str(call)
         ]
-        assert warning_calls, "Expected logger.warning with 'Stale UUID ... falling back to first-turn path'"
+        assert warning_calls, (
+            "Expected logger.warning with 'Stale UUID ... falling back to first-turn path'"
+        )
 
     @pytest.mark.asyncio
     async def test_fallback_without_full_context(self):


### PR DESCRIPTION
## Summary

Fixes the `Separator is found, but chunk is longer than limit` crash on long
Telegram threads by using the Claude CLI's native `--resume` session continuity.
Extends the SDK-path UUID-storage pattern from PR #909 to the harness path.

**Closes #976**

## Changes

- **`get_response_via_harness()`** (`agent/sdk_client.py`) gains three keyword-only
  params: `prior_uuid`, `session_id`, `full_context_message`.
  - Validates `prior_uuid` against a UUID v4 regex before injection.
  - Injects `--resume <uuid>` into the subprocess argv when valid.
  - Emits INFO log `[harness] Resuming Claude session <uuid> for session_id=<sid>`
    on every `--resume` invocation (grep-able observability).
  - Applies `_apply_context_budget()` **unconditionally** — guards against
    pathological single mega-messages even on resumed turns.
  - On ANY non-zero exit when `prior_uuid` was set, retries once without
    `--resume` using `full_context_message` (no stderr substring gate —
    substring matching is brittle across CLI versions and locales).
  - Emits WARNING log `[harness] Stale UUID <uuid> for session_id=<sid>,
    falling back to first-turn path` when fallback fires.
  - Stores the captured Claude Code UUID on the `AgentSession` record via
    `_store_claude_session_uuid()` after every successful turn.

- **`build_harness_turn_input()`** (`agent/sdk_client.py`) gains a keyword-only
  `skip_prefix: bool = False` param. When True, returns the raw message
  unchanged (no context headers) — used on resumed turns where the binary
  already has context from its session file.

- **`_execute_agent_session()`** (`agent/agent_session_queue.py`) looks up
  `_prior_uuid = _get_prior_session_uuid(session.session_id)` before building
  the turn input, builds both full-context and minimal message forms, and
  passes both to `get_response_via_harness()` so the fallback has what it needs.

## Testing

- [x] 29 unit tests in `tests/unit/test_harness_streaming.py` pass
- [x] 14 unit tests in `tests/unit/test_cross_repo_gh_resolution.py` pass
  (includes new `skip_prefix` cases)
- [x] Integration test `tests/integration/test_harness_resume.py` created
  (gated on `shutil.which('claude')`, mark `@pytest.mark.integration`)
- [x] Observability log assertions (`test_logs_resume_at_info`,
  `test_stale_uuid_fallback_logs_warning`)
- [x] Lint (`ruff check`) and format (`ruff format`) pass on changed files

## Documentation

- [x] New feature doc: `docs/features/harness-session-continuity.md`
- [x] Entry added to `docs/features/README.md`
- [x] Cross-reference added in `docs/features/pm-dev-session-architecture.md`
- [x] Docstrings updated on `get_response_via_harness()` and
  `build_harness_turn_input()`
- [x] Inline comment at `_execute_agent_session` call site references #976
  and PR #909

## Definition of Done

- [x] Built: Code implemented and working
- [x] Tested: All targeted tests passing
- [x] Documented: Feature doc + README + inline docstrings
- [x] Quality: Lint and format checks pass

Closes #976