### PR TITLE
feat(do-plan): add WebSearch research phase (Phase 0.7)

### DIFF
--- a/.claude/skills/do-plan/PLAN_TEMPLATE.md
+++ b/.claude/skills/do-plan/PLAN_TEMPLATE.md
@@ -55,6 +55,24 @@ If nothing found, state "No prior issues found related to this work."]
 - **[Issue/PR #N]**: [Title] -- [What it did, outcome, relevance to current work]
 - **[Issue/PR #N]**: [Title] -- [What it did, outcome, relevance to current work]
 
+## Research
+
+<!-- Phase 0.7 of /do-plan uses WebSearch to gather external context before planning.
+     Skip if the work is purely internal (no external libraries, APIs, or ecosystem patterns involved).
+     Findings are saved as memories for future plan reuse. -->
+
+[External research findings from WebSearch that inform the technical approach.]
+
+**Queries used:**
+- [Search query 1]
+- [Search query 2]
+
+**Key findings:**
+- [Finding 1 — source URL, how it informs the plan]
+- [Finding 2 — source URL, how it informs the plan]
+
+[If no useful results: "No relevant external findings — proceeding with codebase context and training data."]
+
 ## Spike Results
 
 <!-- CONDITIONAL: Only include if Phase 1.5 ran spike tasks to validate assumptions.

--- a/.claude/skills/do-plan/SKILL.md
+++ b/.claude/skills/do-plan/SKILL.md
@@ -142,7 +142,6 @@ Gather relevant external context before planning. This surfaces current document
 
 7. **Proceed to Phase 1** with the research context available.
 
-
 ### Phase 1: Flesh Out at High Level
 
 1. **Understand the request** - What's being asked?

--- a/.claude/skills/do-plan/SKILL.md
+++ b/.claude/skills/do-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: do-plan
 description: "Use when creating or updating a feature plan document. Triggered by 'make a plan', 'plan this', 'flesh out the idea', or any request to scope and plan work before implementation."
-allowed-tools: Read, Write, Edit, Glob, Bash, AskUserQuestion
+allowed-tools: Read, Write, Edit, Glob, Bash, AskUserQuestion, ToolSearch, WebSearch
 ---
 
 # Make a Plan (Shape Up Methodology)
@@ -106,6 +106,42 @@ git log --oneline --since="$ISSUE_CREATED" -- <file1> <file2> ...
 | **Overlap** | An active plan in `docs/plans/` is already addressing the same area. | Surface the overlap. Ask whether to merge into the existing plan or coordinate. |
 
 This section stays in the plan document as durable evidence of when and how the freshness check was performed — reviewers during critique and build can tell at a glance whether the plan's premises were verified at plan time.
+
+### Phase 0.7: External Research (WebSearch)
+
+Gather relevant external context before planning. This surfaces current documentation, ecosystem patterns, and known pitfalls that training data may not cover.
+
+**Skip if:** The work is purely internal (no external libraries, APIs, or ecosystem patterns involved) — e.g., refactoring internal code, fixing a typo, or reorganizing files.
+
+1. **Load the WebSearch tool** — WebSearch is a deferred tool; its schema must be loaded before use:
+   ```
+   ToolSearch("select:WebSearch")
+   ```
+
+2. **Generate 1-3 search queries** from the issue context. Extract key technical terms from the issue title, problem statement, and desired outcome. Target:
+   - (a) Library or API documentation relevant to the approach
+   - (b) Ecosystem best practices or recommended patterns
+   - (c) Known pitfalls, breaking changes, or migration guides
+
+3. **Execute each query** using the WebSearch tool. Review the results for relevance.
+
+4. **Filter results** — Only retain findings that are directly relevant to the technical approach. Discard generic results, marketing content, or tangentially related material.
+
+5. **Save valuable findings as memories** for future plan reuse:
+   ```bash
+   python -m tools.memory_search save "Finding: [concise description with source URL]" --importance 5.0 --source agent
+   ```
+   Memory saves are fire-and-forget — if they fail, continue without error.
+
+6. **Write the `## Research` section** in the plan document with the findings. Include:
+   - The search queries used
+   - Key findings with source URLs
+   - How each finding informs the plan's technical approach
+
+   If no useful results were found, write: "No relevant external findings — proceeding with codebase context and training data."
+
+7. **Proceed to Phase 1** with the research context available.
+
 
 ### Phase 1: Flesh Out at High Level
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -148,6 +148,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [UTC Timestamps](utc-timestamps.md) | All timestamps normalized to tz-aware UTC; CLI/log surfaces show explicit UTC labels, conversational surfaces convert to local time | Shipped |
 | [Web Dashboard](web-dashboard.md) | Session table with SDLC stage pills, project metadata popovers, history-based stage inference, and configurable retention via DASHBOARD_RETENTION_HOURS | Shipped |
 | [Web UI](web-ui.md) | Localhost FastAPI web application at port 8500 serving observability dashboards with HTMX interactivity and dark theme | Shipped |
+| [WebSearch Research in Planning](websearch-do-plan.md) | Phase 0.7 in /do-plan: WebSearch-powered external research step that gathers library docs, ecosystem patterns, and known pitfalls before planning | Shipped |
 | [Worker Hibernation](worker-hibernation.md) | Mid-execution session pause and drip resume on Anthropic API failures: `paused` status, `worker:hibernating` Redis flag, `worker-health-gate` and `session-resume-drip` reflections | Shipped |
 | [Worker Service](worker-service.md) | Standalone worker process for AgentSession processing, OutputHandler protocol, TelegramRelayOutputHandler (Redis outbox), FileOutputHandler fallback, launchd service | Shipped |
 | [Workspace Safety Invariants](workspace-safety-invariants.md) | Pre-launch validation of agent working directories with CWD existence, path containment, and slug sanitization | Shipped |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -148,7 +148,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [UTC Timestamps](utc-timestamps.md) | All timestamps normalized to tz-aware UTC; CLI/log surfaces show explicit UTC labels, conversational surfaces convert to local time | Shipped |
 | [Web Dashboard](web-dashboard.md) | Session table with SDLC stage pills, project metadata popovers, history-based stage inference, and configurable retention via DASHBOARD_RETENTION_HOURS | Shipped |
 | [Web UI](web-ui.md) | Localhost FastAPI web application at port 8500 serving observability dashboards with HTMX interactivity and dark theme | Shipped |
-| WebSearch Research in Planning | Phase 0.7 in /do-plan: WebSearch-powered external research step that gathers library docs, ecosystem patterns, and known pitfalls before planning | Shipped |
+| [WebSearch Research in Planning](websearch-do-plan.md) | Phase 0.7 in /do-plan: WebSearch-powered external research step that gathers library docs, ecosystem patterns, and known pitfalls before planning | Shipped |
 | [Worker Hibernation](worker-hibernation.md) | Mid-execution session pause and drip resume on Anthropic API failures: `paused` status, `worker:hibernating` Redis flag, `worker-health-gate` and `session-resume-drip` reflections | Shipped |
 | [Worker Service](worker-service.md) | Standalone worker process for AgentSession processing, OutputHandler protocol, TelegramRelayOutputHandler (Redis outbox), FileOutputHandler fallback, launchd service | Shipped |
 | [Workspace Safety Invariants](workspace-safety-invariants.md) | Pre-launch validation of agent working directories with CWD existence, path containment, and slug sanitization | Shipped |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -148,7 +148,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [UTC Timestamps](utc-timestamps.md) | All timestamps normalized to tz-aware UTC; CLI/log surfaces show explicit UTC labels, conversational surfaces convert to local time | Shipped |
 | [Web Dashboard](web-dashboard.md) | Session table with SDLC stage pills, project metadata popovers, history-based stage inference, and configurable retention via DASHBOARD_RETENTION_HOURS | Shipped |
 | [Web UI](web-ui.md) | Localhost FastAPI web application at port 8500 serving observability dashboards with HTMX interactivity and dark theme | Shipped |
-| [WebSearch Research in Planning](websearch-do-plan.md) | Phase 0.7 in /do-plan: WebSearch-powered external research step that gathers library docs, ecosystem patterns, and known pitfalls before planning | Shipped |
+| WebSearch Research in Planning | Phase 0.7 in /do-plan: WebSearch-powered external research step that gathers library docs, ecosystem patterns, and known pitfalls before planning | Shipped |
 | [Worker Hibernation](worker-hibernation.md) | Mid-execution session pause and drip resume on Anthropic API failures: `paused` status, `worker:hibernating` Redis flag, `worker-health-gate` and `session-resume-drip` reflections | Shipped |
 | [Worker Service](worker-service.md) | Standalone worker process for AgentSession processing, OutputHandler protocol, TelegramRelayOutputHandler (Redis outbox), FileOutputHandler fallback, launchd service | Shipped |
 | [Workspace Safety Invariants](workspace-safety-invariants.md) | Pre-launch validation of agent working directories with CWD existence, path containment, and slug sanitization | Shipped |

--- a/docs/features/websearch-do-plan.md
+++ b/docs/features/websearch-do-plan.md
@@ -1,0 +1,33 @@
+# WebSearch Research in Planning
+
+Phase 0.7 in the `/do-plan` skill adds a WebSearch-powered external research step that gathers library documentation, ecosystem patterns, and known pitfalls before writing a plan.
+
+## How It Works
+
+1. **Query Generation**: The planner extracts key technical terms from the issue title, problem statement, and desired outcome to generate 1-3 targeted search queries
+2. **WebSearch Execution**: Each query is run via the built-in Claude Code `WebSearch` tool (loaded via `ToolSearch` since it is a deferred tool)
+3. **Filtering**: Results are evaluated for relevance to the planned work -- only directly applicable findings are retained
+4. **Memory Persistence**: Valuable findings are saved as memories (`importance ~5.0, source=agent`) for future plan reuse
+5. **Plan Integration**: Findings populate the `## Research` section in the plan document
+
+## Skip Conditions
+
+The research phase is skipped when:
+- The work is purely internal (no external libraries, APIs, or ecosystem patterns)
+- Small appetite with no external dependencies
+- WebSearch returns no useful results (the section notes "No relevant external findings")
+
+## Files Modified
+
+- `.claude/skills/do-plan/SKILL.md` -- Phase 0.7 instructions between Freshness Check (0.5) and Phase 1
+- `.claude/skills/do-plan/PLAN_TEMPLATE.md` -- `## Research` section after Prior Art, before Spike Results
+
+## Configuration
+
+The skill's `allowed-tools` frontmatter includes `ToolSearch, WebSearch` to enable the deferred tool pattern. No additional API keys are needed beyond what the Claude Code environment provides.
+
+## Related
+
+- [Enhanced Planning](enhanced-planning.md) -- Spike Resolution, RFC Review, and Infrastructure Documentation phases
+- [Deep Plan Analysis](deep-plan-analysis.md) -- Prior Art, Data Flow, and Failure Analysis sections
+- [Code Impact Finder](code-impact-finder.md) -- Semantic blast radius analysis during planning

--- a/docs/plans/websearch_do_plan.md
+++ b/docs/plans/websearch_do_plan.md
@@ -160,8 +160,8 @@ No agent integration required — this modifies the `/do-plan` skill's instructi
 - [x] Research phase instructions include memory save commands (`python -m tools.memory_search save ... --source agent`)
 - [x] Research phase includes graceful skip when results are empty or irrelevant
 - [x] Existing plan structure and required sections are preserved
-- [ ] Tests pass (`/do-test`)
-- [ ] Documentation updated (`/do-docs`)
+- [x] Tests pass (`/do-test`)
+- [x] Documentation updated (`/do-docs`)
 
 ## Team Orchestration
 

--- a/docs/plans/websearch_do_plan.md
+++ b/docs/plans/websearch_do_plan.md
@@ -100,8 +100,8 @@ No prerequisites — `tools/web/` requires `PERPLEXITY_API_KEY` or `TAVILY_API_K
 - No exception handlers in scope — WebSearch failures are handled by the "skip gracefully" instruction in the skill text.
 
 ### Empty/Invalid Input Handling
-- [ ] If WebSearch returns no results or empty content, the plan proceeds with "No relevant external findings" in the Research section
-- [ ] If memory save fails (Redis down, bad input), it fails silently — memory saves are never blocking
+- [x] If WebSearch returns no results or empty content, the plan proceeds with "No relevant external findings" in the Research section
+- [x] If memory save fails (Redis down, bad input), it fails silently — memory saves are never blocking
 
 ### Error State Rendering
 - Not applicable — no user-visible UI; the plan document is the output.
@@ -149,17 +149,17 @@ No agent integration required — this modifies the `/do-plan` skill's instructi
 
 ## Documentation
 
-- [ ] Update `docs/features/README.md` index table with a note about WebSearch in /do-plan
-- [ ] Add inline documentation in SKILL.md describing the research phase behavior and skip conditions
+- [x] Update `docs/features/README.md` index table with a note about WebSearch in /do-plan
+- [x] Add inline documentation in SKILL.md describing the research phase behavior and skip conditions
 
 ## Success Criteria
 
-- [ ] `/do-plan` SKILL.md contains a Phase 0.7 research step with WebSearch instructions (including ToolSearch load step)
-- [ ] `allowed-tools` in SKILL.md frontmatter includes `ToolSearch, WebSearch`
-- [ ] PLAN_TEMPLATE.md contains a `## Research` section with skip-if guidance
-- [ ] Research phase instructions include memory save commands (`python -m tools.memory_search save ... --source agent`)
-- [ ] Research phase includes graceful skip when results are empty or irrelevant
-- [ ] Existing plan structure and required sections are preserved
+- [x] `/do-plan` SKILL.md contains a Phase 0.7 research step with WebSearch instructions (including ToolSearch load step)
+- [x] `allowed-tools` in SKILL.md frontmatter includes `ToolSearch, WebSearch`
+- [x] PLAN_TEMPLATE.md contains a `## Research` section with skip-if guidance
+- [x] Research phase instructions include memory save commands (`python -m tools.memory_search save ... --source agent`)
+- [x] Research phase includes graceful skip when results are empty or irrelevant
+- [x] Existing plan structure and required sections are preserved
 - [ ] Tests pass (`/do-test`)
 - [ ] Documentation updated (`/do-docs`)
 


### PR DESCRIPTION
## Summary
- Add Phase 0.7 (External Research) to `/do-plan` between Freshness Check and Phase 1
- Add `ToolSearch, WebSearch` to the skill's `allowed-tools` frontmatter
- Add `## Research` section to PLAN_TEMPLATE.md between Prior Art and Spike Results

## Changes
- `.claude/skills/do-plan/SKILL.md`: New Phase 0.7 instructions covering ToolSearch loading, query generation, WebSearch execution, result filtering, memory persistence, and graceful skip
- `.claude/skills/do-plan/PLAN_TEMPLATE.md`: New `## Research` section with skip-if annotation and placeholder structure
- `docs/features/README.md`: Index entry for the new feature

## Testing
- [x] All existing required plan sections preserved
- [x] Phase 0.7 positioned correctly (after 0.5, before 1)
- [x] Research section positioned correctly (after Prior Art, before Spike Results)
- [x] Unit tests passing (1 pre-existing failure unrelated to this change)
- [x] Lint and format clean

## Documentation
- [x] Feature index updated in docs/features/README.md
- [x] Inline docs in SKILL.md describe skip conditions and usage

## Definition of Done
- [x] Built: Skill and template files updated
- [x] Tested: Verification checks passing
- [x] Documented: README index updated
- [x] Quality: Ruff format and lint clean

Closes #971