### PR TITLE
fix(#987): resolve SDLC pipeline continuation race in _handle_dev_session_completion

### DIFF
--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -3095,29 +3095,46 @@ async def _handle_dev_session_completion(
 ) -> None:
     """Handle SDLC post-completion for dev role sessions run via CLI harness.
 
-    Called after _get_response_via_harness() returns. Classifies the outcome,
-    updates PipelineStateMachine, posts a stage comment to the tracking issue,
-    and steers the parent PM session with the completion status.
+    Called after complete_transcript() (which calls _finalize_parent_sync()) has
+    already run. This ordering invariant is critical: by the time this function
+    executes, _finalize_parent_sync has already transitioned the PM parent to its
+    terminal status. The re-check guard below will therefore correctly detect a
+    terminal PM and create a continuation PM rather than treating the orphaned
+    steering message as successful delivery.
 
-    If steering fails (parent already terminal), creates a continuation PM
-    session to carry the pipeline forward. This is the guaranteed fallback
-    that ensures pipeline progression regardless of PM lifecycle.
+    Must be called after complete_transcript() — NOT before. Calling before
+    complete_transcript() causes the race described in issue #987: steer is
+    accepted, then _finalize_parent_sync runs and orphans the steering message.
+
+    Classifies the outcome, updates PipelineStateMachine, posts a stage comment
+    to the tracking issue, and steers the parent PM session with the completion
+    status. If steering fails (parent already terminal), creates a continuation
+    PM session to carry the pipeline forward.
 
     All operations are wrapped in try/except -- failures never crash the worker.
 
     Args:
         session: The lightweight session record (from _send_callbacks key).
-        agent_session: The AgentSession popoto model instance (may be None).
+            Always populated from the queue entry — reliable even when
+            agent_session is None.
+        agent_session: The AgentSession popoto model instance (may be None
+            if the status="running" filter raced with a status transition).
         result: Final result text from the harness.
     """
     try:
-        # Get parent PM session
-        parent_id = (
-            getattr(agent_session, "parent_agent_session_id", None) if agent_session else None
+        # Get parent PM session.
+        # Path B fallback: when agent_session is None (status="running" filter
+        # returned nothing due to a race with health-check recovery or fast
+        # finalization), fall back to session.parent_agent_session_id. The outer
+        # `session` param is populated from the queue entry at enqueue time and
+        # is reliable regardless of the agent_session lookup result.
+        parent_id = getattr(agent_session, "parent_agent_session_id", None) or getattr(
+            session, "parent_agent_session_id", None
         )
         if not parent_id:
             logger.debug(
-                "[harness] No parent_agent_session_id on dev session, skipping PM steering"
+                "[harness] No parent_agent_session_id on dev session or session object, "
+                "skipping PM steering"
             )
             return
 
@@ -3916,13 +3933,6 @@ async def _execute_agent_session(session: AgentSession) -> None:
     if _harness_requeued:
         return
 
-    if _session_type == "dev" and not task.error:
-        await _handle_dev_session_completion(
-            session=session,
-            agent_session=agent_session,
-            result=task._result or "",
-        )
-
     # Update session status in Redis via AgentSession
     # When auto-continue deferred, session is still active (not completed)
     if agent_session:
@@ -3980,6 +3990,35 @@ async def _execute_agent_session(session: AgentSession) -> None:
                     session.agent_session_id,
                     e,
                 )
+
+    # Post-completion SDLC handling for dev sessions (Phase 3)
+    # IMPORTANT ORDERING INVARIANT: This call is placed AFTER the entire
+    # `if agent_session / else` block above. That block calls complete_transcript(),
+    # which calls finalize_session() → _finalize_parent_sync() synchronously
+    # (bridge/session_transcript.py:252, line 292). By the time
+    # _handle_dev_session_completion runs here, _finalize_parent_sync has already
+    # completed on BOTH the `if agent_session:` and `else:` paths. The re-check
+    # guard inside _handle_dev_session_completion will therefore correctly observe
+    # the PM's post-finalization (terminal) status and create a continuation PM.
+    # Moving this call earlier (before complete_transcript) causes the race
+    # described in issue #987: steer is accepted, then _finalize_parent_sync runs
+    # and the PM goes terminal, orphaning the steering message.
+    #
+    # Nudge path note: on the nudge path (defer_reaction=True), complete_transcript
+    # is skipped above, but _finalize_parent_sync still runs via the nudge path's
+    # own finalize_session call. This call is guarded by `_session_type == "dev"`,
+    # not by `defer_reaction`, so it executes on both the nudge and non-nudge paths.
+    #
+    # Skip if the session was silently re-queued for harness retry — the re-queued
+    # session hasn't run yet, so calling _handle_dev_session_completion with an empty
+    # result would emit a spurious "fail" outcome to the PM pipeline before the retry
+    # has a chance to succeed. (The _harness_requeued early-return above handles this.)
+    if _session_type == "dev" and not task.error:
+        await _handle_dev_session_completion(
+            session=session,
+            agent_session=agent_session,
+            result=task._result or "",
+        )
 
     # Save session snapshot for error cases
     if task.error:

--- a/docs/features/bridge-worker-architecture.md
+++ b/docs/features/bridge-worker-architecture.md
@@ -107,7 +107,7 @@ The worker's startup sequence is deterministic:
 
 ### Execution Harness Routing
 
-All session types (dev, pm, teammate) execute via the CLI harness (`claude -p`). There is no SDK execution branch — the `DEV_SESSION_HARNESS` feature flag was removed in issue #912.
+All session types (dev, pm, teammate) execute via the CLI harness (`claude -p`). There is no SDK execution branch — the `DEV_SESSION_HARNESS` feature flag was eliminated in issue #912.
 
 ```
 _execute_agent_session(session)

--- a/docs/features/bridge-worker-architecture.md
+++ b/docs/features/bridge-worker-architecture.md
@@ -130,12 +130,24 @@ get_response_via_harness(prior_uuid=..., session_id=..., full_context_message=..
     |   -- after success: persists captured session_id to AgentSession.claude_session_uuid
     |
     v
-_handle_dev_session_completion()  [dev sessions only]
+complete_transcript(session_id, status=final_status)
+    |   -- synchronous call: calls finalize_session() → _finalize_parent_sync() inline
+    |   -- transitions PM parent: running → waiting_for_children → completed
+    |   -- ORDERING INVARIANT: must complete before _handle_dev_session_completion runs
+    |
+    v
+_handle_dev_session_completion()  [dev sessions only, called AFTER complete_transcript]
     |-- PipelineStateMachine.classify_outcome()
     |-- complete_stage() or fail_stage()
     |-- post_stage_comment() -> GitHub issue
     |-- steer_session(parent_pm_session)
+    |-- re-check: if PM terminal at re-check → _create_continuation_pm()
+    |   (steer was accepted but PM finalized before it could process the message)
+    |-- Path B fallback: if agent_session=None, uses session.parent_agent_session_id
+    |   to look up parent and create continuation PM (no silent skip)
 ```
+
+**Dev session completion ordering** (fix for issue #987): `complete_transcript()` is called first (synchronously invoking `_finalize_parent_sync()` to transition the PM parent to its terminal status), then `_handle_dev_session_completion()` runs. This ordering ensures the re-check guard inside `_handle_dev_session_completion` reads the PM's post-finalization status correctly. If the PM is already terminal at re-check time, a continuation PM is created immediately. Calling `_handle_dev_session_completion` before `complete_transcript()` causes a race: the steer is accepted, then `_finalize_parent_sync` runs and orphans the steering message (the PM is terminal and will never consume it).
 
 PM and teammate sessions skip the post-completion SDLC handler. See [Harness Abstraction](harness-abstraction.md) for stream-json parsing, chunk suppression, health checks, and configuration, and [Harness Session Continuity](harness-session-continuity.md) for the `--resume` UUID persistence mechanism.
 

--- a/tests/unit/test_continuation_pm.py
+++ b/tests/unit/test_continuation_pm.py
@@ -270,13 +270,87 @@ class TestHandleCompletionContinuationFallback:
         assert "CONTINUATION" in cont.message_text
 
     @pytest.mark.asyncio
-    async def test_steer_success_no_continuation(self, redis_test_db):
-        """When steer_session succeeds and parent is still active, no continuation PM."""
+    async def test_steer_accepted_pm_terminal_creates_continuation(self, redis_test_db):
+        """When steer is accepted but PM is terminal at re-check, a continuation PM is created.
+
+        Under the new ordering (issue #987 fix), _handle_dev_session_completion is called
+        after complete_transcript() which has already run _finalize_parent_sync(). So when
+        the steer is accepted but the PM is in a terminal status at re-check time, a
+        continuation PM must be created — the steer message is orphaned and the PM will
+        never consume it.
+        """
         from agent.agent_session_queue import _handle_dev_session_completion
 
-        # Create an active parent
+        # Create a PM that is in terminal (completed) status — simulates the state
+        # after _finalize_parent_sync has already run.
+        terminal_pm_for_steer = AgentSession.create(
+            session_id="pm-terminal-steer-001",
+            session_type="pm",
+            project_key="test",
+            status="completed",
+            chat_id="999",
+            message_text="Run SDLC on issue #934 (issues/934)",
+            created_at=datetime.now(tz=UTC),
+            started_at=datetime.now(tz=UTC),
+            turn_count=0,
+            tool_call_count=0,
+        )
+        dev = AgentSession.create(
+            session_id="dev-terminal-steer-001",
+            session_type="dev",
+            project_key="test",
+            status="completed",
+            chat_id="999",
+            message_text="Stage: BUILD",
+            parent_agent_session_id=terminal_pm_for_steer.agent_session_id,
+            created_at=datetime.now(tz=UTC),
+            turn_count=0,
+            tool_call_count=0,
+        )
+
+        with (
+            patch(
+                "agent.agent_session_queue.steer_session",
+                return_value={
+                    "success": True,
+                    "session_id": terminal_pm_for_steer.session_id,
+                    "error": None,
+                },
+            ),
+            patch("agent.agent_session_queue._extract_issue_number", return_value=934),
+        ):
+            await _handle_dev_session_completion(
+                session=terminal_pm_for_steer,
+                agent_session=dev,
+                result="BUILD complete.",
+            )
+
+        # A continuation PM must be created — the steer was accepted but the PM
+        # is terminal and will never consume the message.
+        pm_children = [
+            c
+            for c in AgentSession.query.filter(
+                parent_agent_session_id=terminal_pm_for_steer.agent_session_id
+            )
+            if c.session_type == "pm"
+        ]
+        assert len(pm_children) >= 1
+        cont = pm_children[0]
+        assert cont.status == "pending"
+        assert "CONTINUATION" in cont.message_text
+
+    @pytest.mark.asyncio
+    async def test_steer_accepted_pm_non_terminal_no_continuation(self, redis_test_db):
+        """When steer is accepted and PM is still active at re-check, no continuation PM.
+
+        This is the happy path: the steer message was accepted and the PM is still
+        alive to process it. No continuation PM is needed.
+        """
+        from agent.agent_session_queue import _handle_dev_session_completion
+
+        # Create an active parent — still alive, will process the steering message
         active_pm = AgentSession.create(
-            session_id="pm-active-steer-001",
+            session_id="pm-active-steer-002",
             session_type="pm",
             project_key="test",
             status="active",
@@ -288,7 +362,7 @@ class TestHandleCompletionContinuationFallback:
             tool_call_count=0,
         )
         dev = AgentSession.create(
-            session_id="dev-active-steer-001",
+            session_id="dev-active-steer-002",
             session_type="dev",
             project_key="test",
             status="active",
@@ -313,7 +387,7 @@ class TestHandleCompletionContinuationFallback:
                 result="BUILD complete.",
             )
 
-        # No continuation PM should exist
+        # No continuation PM — the active PM will consume the steering message
         pm_children = [
             c
             for c in AgentSession.query.filter(parent_agent_session_id=active_pm.agent_session_id)
@@ -386,3 +460,165 @@ class TestContinuationDedup:
         ]
         # Only one continuation should exist despite two calls
         assert len(pm_children) == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Ordering race — PM terminal at re-check creates continuation PM
+# ---------------------------------------------------------------------------
+
+
+class TestHandleCompletionOrderingRace:
+    """Tests for the issue #987 ordering race fix.
+
+    After fix 1, _handle_dev_session_completion is called AFTER complete_transcript()
+    (which runs _finalize_parent_sync() inline). These tests verify that when the PM
+    is already terminal at the time of the re-check guard, a continuation PM is
+    unconditionally created regardless of whether the steer was accepted or rejected.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pm_terminal_at_recheck_creates_continuation(self, redis_test_db):
+        """Steer accepted + PM terminal at re-check → continuation PM created.
+
+        This directly simulates the post-fix scenario: _handle_dev_session_completion
+        is called after _finalize_parent_sync has already run, so the PM is already
+        in a terminal state. The re-check guard must detect this and create a
+        continuation PM.
+        """
+        from agent.agent_session_queue import _handle_dev_session_completion
+
+        # Parent is already terminal — simulates state after _finalize_parent_sync ran
+        completed_pm = AgentSession.create(
+            session_id="pm-ordering-race-001",
+            session_type="pm",
+            project_key="test",
+            status="completed",
+            chat_id="999",
+            message_text="Run SDLC on issue #987 (issues/987)",
+            created_at=datetime.now(tz=UTC),
+            started_at=datetime.now(tz=UTC),
+            turn_count=0,
+            tool_call_count=0,
+        )
+        dev = AgentSession.create(
+            session_id="dev-ordering-race-001",
+            session_type="dev",
+            project_key="test",
+            status="completed",
+            chat_id="999",
+            message_text="Stage: PLAN",
+            parent_agent_session_id=completed_pm.agent_session_id,
+            created_at=datetime.now(tz=UTC),
+            turn_count=0,
+            tool_call_count=0,
+        )
+
+        with (
+            patch(
+                "agent.agent_session_queue.steer_session",
+                return_value={
+                    "success": True,
+                    "session_id": completed_pm.session_id,
+                    "error": None,
+                },
+            ),
+            patch("agent.agent_session_queue._extract_issue_number", return_value=987),
+        ):
+            await _handle_dev_session_completion(
+                session=completed_pm,
+                agent_session=dev,
+                result="PLAN complete. Critique stage next.",
+            )
+
+        # Continuation PM must be created — steer was accepted but PM is terminal
+        pm_children = [
+            c
+            for c in AgentSession.query.filter(
+                parent_agent_session_id=completed_pm.agent_session_id
+            )
+            if c.session_type == "pm"
+        ]
+        assert len(pm_children) >= 1
+        cont = pm_children[0]
+        assert cont.status == "pending"
+        assert "CONTINUATION" in cont.message_text
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Path B — agent_session is None, uses session.parent_agent_session_id
+# ---------------------------------------------------------------------------
+
+
+class TestHandleCompletionPathBFallback:
+    """Tests for the Path B fix (issue #987 Fix 2).
+
+    When agent_session is None (status='running' filter returned nothing due to a
+    race with health-check recovery or fast finalization), _handle_dev_session_completion
+    must fall back to session.parent_agent_session_id rather than returning silently.
+    """
+
+    @pytest.mark.asyncio
+    async def test_agent_session_none_uses_session_parent_id(self, redis_test_db):
+        """When agent_session=None, session.parent_agent_session_id is used to create continuation PM.
+
+        Before fix 2, agent_session=None caused an early return with no continuation PM.
+        After fix 2, the outer session object's parent_agent_session_id is used as fallback.
+        """
+        from agent.agent_session_queue import _handle_dev_session_completion
+
+        # Parent is in terminal status
+        terminal_pm_path_b = AgentSession.create(
+            session_id="pm-path-b-001",
+            session_type="pm",
+            project_key="test",
+            status="completed",
+            chat_id="999",
+            message_text="Run SDLC on issue #987 (issues/987)",
+            created_at=datetime.now(tz=UTC),
+            started_at=datetime.now(tz=UTC),
+            turn_count=0,
+            tool_call_count=0,
+        )
+        # The outer session object (populated from queue entry) has parent_agent_session_id set
+        outer_session = AgentSession.create(
+            session_id="dev-path-b-001",
+            session_type="dev",
+            project_key="test",
+            status="completed",
+            chat_id="999",
+            message_text="Stage: PLAN",
+            parent_agent_session_id=terminal_pm_path_b.agent_session_id,
+            created_at=datetime.now(tz=UTC),
+            turn_count=0,
+            tool_call_count=0,
+        )
+
+        with (
+            patch(
+                "agent.agent_session_queue.steer_session",
+                return_value={
+                    "success": False,
+                    "error": "Session is in terminal status 'completed' — steering rejected",
+                },
+            ),
+            patch("agent.agent_session_queue._extract_issue_number", return_value=987),
+        ):
+            # agent_session=None simulates the status="running" filter returning nothing
+            await _handle_dev_session_completion(
+                session=outer_session,
+                agent_session=None,
+                result="PLAN complete.",
+            )
+
+        # Continuation PM must be created via session.parent_agent_session_id fallback
+        pm_children = [
+            c
+            for c in AgentSession.query.filter(
+                parent_agent_session_id=terminal_pm_path_b.agent_session_id
+            )
+            if c.session_type == "pm"
+        ]
+        assert len(pm_children) >= 1
+        cont = pm_children[0]
+        assert cont.status == "pending"
+        assert "CONTINUATION" in cont.message_text

--- a/tests/unit/test_continuation_pm.py
+++ b/tests/unit/test_continuation_pm.py
@@ -559,7 +559,7 @@ class TestHandleCompletionPathBFallback:
 
     @pytest.mark.asyncio
     async def test_agent_session_none_uses_session_parent_id(self, redis_test_db):
-        """When agent_session=None, session.parent_agent_session_id is used to create continuation PM.
+        """When agent_session is None, session.parent_agent_session_id creates continuation PM.
 
         Before fix 2, agent_session=None caused an early return with no continuation PM.
         After fix 2, the outer session object's parent_agent_session_id is used as fallback.


### PR DESCRIPTION
## Summary

- Fix the ordering race (issue #987) where `_handle_dev_session_completion` was called before `complete_transcript()`, causing steering messages to be orphaned when `_finalize_parent_sync` ran immediately after
- Fix Path B silent failure where `agent_session=None` caused an early return with no continuation PM instead of falling back to `session.parent_agent_session_id`

## Changes

- **`agent/agent_session_queue.py`**: Move `_handle_dev_session_completion` call to after the entire `if agent_session / else` block (both `complete_transcript()` paths). Add detailed ordering invariant comment. Update `parent_id` extraction to use `session.parent_agent_session_id` as fallback when `agent_session is None`. Update docstring to document the ordering contract.
- **`tests/unit/test_continuation_pm.py`**: Rename `test_steer_success_no_continuation` → `test_steer_accepted_pm_terminal_creates_continuation` (inverted assertion). Add `test_steer_accepted_pm_non_terminal_no_continuation` (happy path). Add `TestHandleCompletionOrderingRace::test_pm_terminal_at_recheck_creates_continuation`. Add `TestHandleCompletionPathBFallback::test_agent_session_none_uses_session_parent_id`.
- **`docs/features/bridge-worker-architecture.md`**: Document the correct completion ordering: `complete_transcript → _finalize_parent_sync → _handle_dev_session_completion`.

## Testing

- [x] `pytest tests/unit/test_continuation_pm.py` — 12/12 tests passing (includes 4 new/updated tests)
- [x] Unit tests: 4043 pass, 40 pre-existing failures on main (no new failures introduced)
- [x] Linting (ruff check + ruff format --check) — clean

## Documentation

- [x] `docs/features/bridge-worker-architecture.md` updated with completion ordering invariant
- [x] `_handle_dev_session_completion` docstring updated with ordering contract

## Definition of Done

- [x] Built: Both fixes implemented in `agent_session_queue.py`
- [x] Tested: All new tests pass, no regressions
- [x] Documented: Architecture doc and inline docstring updated
- [x] Quality: Lint and format checks pass

Closes #987