### PR TITLE
feat: terminal reactions via find_best_emoji (EmojiResult, lazy cache)

### DIFF
--- a/agent/constants.py
+++ b/agent/constants.py
@@ -17,16 +17,12 @@ All fallback emojis are confirmed in VALIDATED_REACTIONS.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from tools.emoji_embedding import EmojiResult
 
 logger = logging.getLogger(__name__)
 
 # Cache for lazily-resolved terminal reaction EmojiResult objects.
 # Populated on first access; never retried after failure.
-_TERMINAL_EMOJI_CACHE: dict[str, "EmojiResult"] = {}
+_TERMINAL_EMOJI_CACHE: dict[str, object] = {}
 
 # Feeling strings and fallback emojis for each terminal reaction constant.
 _TERMINAL_EMOJI_CONFIG: dict[str, tuple[str, str]] = {
@@ -36,7 +32,7 @@ _TERMINAL_EMOJI_CONFIG: dict[str, tuple[str, str]] = {
 }
 
 
-def _resolve_terminal_emoji(name: str, feeling: str, fallback_emoji: str) -> "EmojiResult":
+def _resolve_terminal_emoji(name: str, feeling: str, fallback_emoji: str) -> object:
     """Resolve a terminal reaction emoji, caching the result.
 
     Calls find_best_emoji(feeling) and caches the EmojiResult in
@@ -74,7 +70,7 @@ def _resolve_terminal_emoji(name: str, feeling: str, fallback_emoji: str) -> "Em
         return fallback
 
 
-def __getattr__(name: str) -> "EmojiResult":
+def __getattr__(name: str) -> object:
     """Lazily resolve terminal reaction constants on first access.
 
     Handles REACTION_SUCCESS, REACTION_COMPLETE, and REACTION_ERROR.

--- a/agent/constants.py
+++ b/agent/constants.py
@@ -4,9 +4,91 @@ Shared constants for the agent session system.
 These constants were originally defined in bridge/response.py but are used by
 both the bridge and the standalone worker. Canonical definitions live here;
 bridge/response.py re-exports them for backward compatibility.
+
+Terminal reaction constants (REACTION_SUCCESS, REACTION_COMPLETE, REACTION_ERROR)
+are resolved lazily via module __getattr__ using find_best_emoji() on first access.
+Each constant is cached in _TERMINAL_EMOJI_CACHE after first resolution — no HTTP
+call is made at import time and no retry is performed on failure. If find_best_emoji()
+raises any exception (missing API key, no embeddings file, network error), a hardcoded
+fallback EmojiResult is returned and cached: 👌 (SUCCESS), 👏 (COMPLETE), 😢 (ERROR).
+All fallback emojis are confirmed in VALIDATED_REACTIONS.
 """
 
-# Reaction emoji constants used by the session execution engine
-REACTION_SUCCESS = "\U0001f44d"  # Simple ack, no text reply needed
-REACTION_COMPLETE = "\U0001f3c6"  # Work done, text reply attached
-REACTION_ERROR = "\U0001f631"  # Something went wrong
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tools.emoji_embedding import EmojiResult
+
+logger = logging.getLogger(__name__)
+
+# Cache for lazily-resolved terminal reaction EmojiResult objects.
+# Populated on first access; never retried after failure.
+_TERMINAL_EMOJI_CACHE: dict[str, "EmojiResult"] = {}
+
+# Feeling strings and fallback emojis for each terminal reaction constant.
+_TERMINAL_EMOJI_CONFIG: dict[str, tuple[str, str]] = {
+    "REACTION_SUCCESS": ("acknowledged received silently noted", "\U0001f44c"),  # 👌
+    "REACTION_COMPLETE": ("task completed successfully work done", "\U0001f44f"),  # 👏
+    "REACTION_ERROR": ("error occurred something went wrong", "\U0001f622"),  # 😢
+}
+
+
+def _resolve_terminal_emoji(name: str, feeling: str, fallback_emoji: str) -> "EmojiResult":
+    """Resolve a terminal reaction emoji, caching the result.
+
+    Calls find_best_emoji(feeling) and caches the EmojiResult in
+    _TERMINAL_EMOJI_CACHE. Falls back to a hardcoded fallback EmojiResult
+    when find_best_emoji() raises an exception or returns the DEFAULT_EMOJI
+    (which happens when OPENROUTER_API_KEY is absent or embeddings are
+    unavailable). This ensures all three terminal constants remain distinct
+    even in degraded environments.
+
+    Args:
+        name: Constant name (e.g. "REACTION_SUCCESS") — used as cache key.
+        feeling: Human-readable feeling phrase passed to find_best_emoji().
+        fallback_emoji: Unicode emoji to use when find_best_emoji() fails or
+            returns the default fallback emoji.
+
+    Returns:
+        EmojiResult instance (always valid, never raises).
+    """
+    from tools.emoji_embedding import DEFAULT_EMOJI, EmojiResult
+
+    try:
+        from tools.emoji_embedding import find_best_emoji
+
+        result = find_best_emoji(feeling)
+        # If find_best_emoji returned the DEFAULT_EMOJI, the API was unavailable.
+        # Use our own fallback so the three constants remain distinct.
+        if result.emoji == DEFAULT_EMOJI and not result.is_custom:
+            raise ValueError(f"find_best_emoji returned default emoji for {name!r}")
+        _TERMINAL_EMOJI_CACHE[name] = result
+        return result
+    except Exception as exc:
+        logger.debug("find_best_emoji failed for %s (%r): %s — using fallback", name, feeling, exc)
+        fallback = EmojiResult(emoji=fallback_emoji)
+        _TERMINAL_EMOJI_CACHE[name] = fallback
+        return fallback
+
+
+def __getattr__(name: str) -> "EmojiResult":
+    """Lazily resolve terminal reaction constants on first access.
+
+    Handles REACTION_SUCCESS, REACTION_COMPLETE, and REACTION_ERROR.
+    The resolved EmojiResult is cached in _TERMINAL_EMOJI_CACHE so
+    subsequent attribute accesses are a dict lookup with no HTTP calls.
+
+    Raises:
+        AttributeError: For any name not in _TERMINAL_EMOJI_CONFIG.
+    """
+    if name in _TERMINAL_EMOJI_CACHE:
+        return _TERMINAL_EMOJI_CACHE[name]
+
+    if name in _TERMINAL_EMOJI_CONFIG:
+        feeling, fallback = _TERMINAL_EMOJI_CONFIG[name]
+        return _resolve_terminal_emoji(name, feeling, fallback)
+
+    raise AttributeError(f"module 'agent.constants' has no attribute {name!r}")

--- a/bridge/response.py
+++ b/bridge/response.py
@@ -165,7 +165,8 @@ REACTION_PROCESSING = "🤔"  # Default thinking emoji
 
 # REACTION_COMPLETE, REACTION_ERROR, REACTION_SUCCESS are re-exported from
 # agent.constants (canonical location) — imported at top of file for
-# backward compatibility with existing imports.
+# backward compatibility with existing imports. These are EmojiResult objects,
+# resolved lazily via find_best_emoji() on first access with hardcoded fallbacks.
 
 
 def filter_tool_logs(response: str) -> str:

--- a/docs/features/emoji-embedding-reactions.md
+++ b/docs/features/emoji-embedding-reactions.md
@@ -129,13 +129,13 @@ Every custom emoji code path has automatic fallback:
 
 The caller never needs to handle standard vs custom emoji explicitly. The `EmojiResult` type and dispatch logic handle all branching internally.
 
-## What Was Removed
+## Migration from Ollama Intent Classification
 
-This feature removed the following legacy code:
+The embedding-based system replaced the Ollama-based intent classifier. The following code is no longer in the codebase:
 
-- **`intent/__init__.py`** -- the entire module was deleted. It contained Ollama-based intent classification with heuristic fallback, used solely by `get_processing_emoji` for reaction selection.
-- **`INTENT_REACTIONS` dict** from `bridge/response.py` -- hardcoded mapping of 10 intent strings to emojis
-- **`get_processing_emoji()` and `get_processing_emoji_async()`** from `bridge/response.py` -- Ollama classification wrappers
+- **`intent/__init__.py`** -- deleted module. Contained Ollama-based intent classification with heuristic fallback, used solely by `get_processing_emoji` for reaction selection.
+- **`INTENT_REACTIONS` dict** -- hardcoded mapping of 10 intent strings to emojis, previously in `bridge/response.py`
+- **`get_processing_emoji()` and `get_processing_emoji_async()`** -- Ollama classification wrappers, previously in `bridge/response.py`
 
 The work-type classifier (`tools/classifier.py` / `classify_request_async`) was preserved and now runs as its own independent async task.
 

--- a/docs/features/emoji-embedding-reactions.md
+++ b/docs/features/emoji-embedding-reactions.md
@@ -163,6 +163,22 @@ The work-type classifier (`tools/classifier.py` / `classify_request_async`) was 
 | `tests/unit/test_custom_emoji_index.py` | Custom emoji index building and cache tests |
 | `tests/unit/test_send_telegram.py` | Reaction and emoji flag tests |
 
+## Terminal Reactions
+
+Session lifecycle events are reported back to Telegram via three terminal reaction constants defined in `agent/constants.py`:
+
+| Constant | Semantic | Feeling String | Fallback Emoji |
+|----------|----------|----------------|----------------|
+| `REACTION_SUCCESS` | Silent ack — no text reply sent | `"acknowledged received silently noted"` | 👌 |
+| `REACTION_COMPLETE` | Work done — text reply attached | `"task completed successfully work done"` | 👏 |
+| `REACTION_ERROR` | Something went wrong | `"error occurred something went wrong"` | 😢 |
+
+These constants are `EmojiResult` objects, **not** plain strings. They are resolved lazily via `find_best_emoji()` using the feeling strings above on first access inside a live request handler. The resolved value is cached in a module-level dict (`_TERMINAL_EMOJI_CACHE`) — no HTTP call is made at import time and no retry occurs after the first resolution.
+
+When `find_best_emoji()` is unavailable (missing `OPENROUTER_API_KEY`, absent embeddings file, or the function returns the default thinking emoji), `_resolve_terminal_emoji()` substitutes the hardcoded fallback `EmojiResult` listed in the table above. All three fallback emojis are confirmed in `VALIDATED_REACTIONS` and are distinct from each other, ensuring correct behavior in degraded environments.
+
+`bridge/response.py` re-exports these constants for backward compatibility. The `set_reaction()` call site already accepts `EmojiResult` objects transparently via the existing standard/custom emoji dispatch logic.
+
 ## See Also
 
 - [Classification](classification.md) -- work-type classification (bug/feature/chore), which is separate from emoji reactions

--- a/docs/plans/terminal-emoji-upgrade.md
+++ b/docs/plans/terminal-emoji-upgrade.md
@@ -128,12 +128,12 @@ No prerequisites — all infrastructure (EmojiResult, set_reaction, find_best_em
 
 ## Test Impact
 
-- [ ] `tests/unit/test_worker_entry.py::test_reaction_constants_importable_from_agent` — UPDATE: assert constants are EmojiResult instances; assert `.emoji` attr is in VALIDATED_REACTIONS rather than hardcoded specific emoji values.
-- [ ] `tests/unit/test_worker_entry.py::test_reaction_re_exports_from_bridge` — UPDATE: same update — EmojiResult instances, not hardcoded strings.
-- [ ] `tests/integration/test_reply_delivery.py::test_reaction_complete_in_validated_list` — UPDATE: extract `.emoji` from EmojiResult before checking VALIDATED_REACTIONS membership.
-- [ ] `tests/integration/test_reply_delivery.py::test_reaction_error_in_validated_list` — UPDATE: same — extract `.emoji`.
-- [ ] `tests/integration/test_reply_delivery.py::test_reaction_success_in_validated_list` — UPDATE: same — extract `.emoji`.
-- [ ] `tests/integration/test_reply_delivery.py::test_reaction_constants_are_distinct` (B1 fix) — UPDATE: EmojiResult is unhashable (mutable dataclass, `__hash__ = None`), so `set(all_reactions)` raises `TypeError`. Replace with `set(str(r) for r in all_reactions)` or `set(r.emoji for r in all_reactions)` to compare by value.
+- [x] `tests/unit/test_worker_entry.py::test_reaction_constants_importable_from_agent` — UPDATE: assert constants are EmojiResult instances; assert `.emoji` attr is in VALIDATED_REACTIONS rather than hardcoded specific emoji values.
+- [x] `tests/unit/test_worker_entry.py::test_reaction_re_exports_from_bridge` — UPDATE: same update — EmojiResult instances, not hardcoded strings.
+- [x] `tests/integration/test_reply_delivery.py::test_reaction_complete_in_validated_list` — UPDATE: extract `.emoji` from EmojiResult before checking VALIDATED_REACTIONS membership.
+- [x] `tests/integration/test_reply_delivery.py::test_reaction_error_in_validated_list` — UPDATE: same — extract `.emoji`.
+- [x] `tests/integration/test_reply_delivery.py::test_reaction_success_in_validated_list` — UPDATE: same — extract `.emoji`.
+- [x] `tests/integration/test_reply_delivery.py::test_reaction_constants_are_distinct` (B1 fix) — UPDATE: EmojiResult is unhashable (mutable dataclass, `__hash__ = None`), so `set(all_reactions)` raises `TypeError`. Replace with `set(str(r) for r in all_reactions)` or `set(r.emoji for r in all_reactions)` to compare by value.
 
 ## Rabbit Holes
 
@@ -174,17 +174,17 @@ No agent integration required — terminal reactions are set by the session exec
 
 ## Documentation
 
-- [ ] Update `docs/features/emoji-embedding-reactions.md` — add a "Terminal Reactions" subsection explaining that `REACTION_SUCCESS`, `REACTION_COMPLETE`, and `REACTION_ERROR` are now `EmojiResult` objects resolved via `find_best_emoji()` at import time, with the feeling strings used (`"acknowledged received silently noted"`, `"task completed successfully work done"`, `"error occurred something went wrong"`) and the hardcoded fallback emojis (`👌`, `👏`, `😢`).
-- [ ] Add an entry to `docs/features/README.md` index table for the terminal reactions section if one does not already reference `emoji-embedding-reactions.md`.
+- [x] Update `docs/features/emoji-embedding-reactions.md` — add a "Terminal Reactions" subsection explaining that `REACTION_SUCCESS`, `REACTION_COMPLETE`, and `REACTION_ERROR` are now `EmojiResult` objects resolved via `find_best_emoji()` at import time, with the feeling strings used (`"acknowledged received silently noted"`, `"task completed successfully work done"`, `"error occurred something went wrong"`) and the hardcoded fallback emojis (`👌`, `👏`, `😢`).
+- [x] Add an entry to `docs/features/README.md` index table for the terminal reactions section if one does not already reference `emoji-embedding-reactions.md`.
 
 ## Success Criteria
 
-- [ ] `REACTION_SUCCESS`, `REACTION_COMPLETE`, `REACTION_ERROR` are `EmojiResult` instances, not plain strings.
-- [ ] Each constant's `.emoji` fallback is in `VALIDATED_REACTIONS`.
-- [ ] All three constants have distinct `.emoji` values.
-- [ ] `_resolve_terminal_emoji()` returns a valid fallback EmojiResult when `find_best_emoji()` raises any exception.
-- [ ] All updated unit and integration tests pass (`pytest tests/unit/test_worker_entry.py tests/integration/test_reply_delivery.py`).
-- [ ] Ruff lint and format pass.
+- [x] `REACTION_SUCCESS`, `REACTION_COMPLETE`, `REACTION_ERROR` are `EmojiResult` instances, not plain strings.
+- [x] Each constant's `.emoji` fallback is in `VALIDATED_REACTIONS`.
+- [x] All three constants have distinct `.emoji` values.
+- [x] `_resolve_terminal_emoji()` returns a valid fallback EmojiResult when `find_best_emoji()` raises any exception.
+- [x] All updated unit and integration tests pass (`pytest tests/unit/test_worker_entry.py tests/integration/test_reply_delivery.py`).
+- [x] Ruff lint and format pass.
 
 ## Team Orchestration
 

--- a/tests/integration/test_reply_delivery.py
+++ b/tests/integration/test_reply_delivery.py
@@ -127,19 +127,19 @@ class TestReactionEmojiSelection:
     """Test that the correct reaction emojis are in validated/invalid lists."""
 
     def test_reaction_complete_in_validated_list(self):
-        """REACTION_COMPLETE must be an EmojiResult whose .emoji is in the validated reactions list."""
+        """REACTION_COMPLETE must be an EmojiResult whose .emoji is in VALIDATED_REACTIONS."""
         from bridge.response import REACTION_COMPLETE, VALIDATED_REACTIONS
 
         assert REACTION_COMPLETE.emoji in VALIDATED_REACTIONS
 
     def test_reaction_error_in_validated_list(self):
-        """REACTION_ERROR must be an EmojiResult whose .emoji is in the validated reactions list."""
+        """REACTION_ERROR must be an EmojiResult whose .emoji is in VALIDATED_REACTIONS."""
         from bridge.response import REACTION_ERROR, VALIDATED_REACTIONS
 
         assert REACTION_ERROR.emoji in VALIDATED_REACTIONS
 
     def test_reaction_success_in_validated_list(self):
-        """REACTION_SUCCESS must be an EmojiResult whose .emoji is in the validated reactions list."""
+        """REACTION_SUCCESS must be an EmojiResult whose .emoji is in VALIDATED_REACTIONS."""
         from bridge.response import REACTION_SUCCESS, VALIDATED_REACTIONS
 
         assert REACTION_SUCCESS.emoji in VALIDATED_REACTIONS

--- a/tests/integration/test_reply_delivery.py
+++ b/tests/integration/test_reply_delivery.py
@@ -127,22 +127,22 @@ class TestReactionEmojiSelection:
     """Test that the correct reaction emojis are in validated/invalid lists."""
 
     def test_reaction_complete_in_validated_list(self):
-        """REACTION_COMPLETE (🏆) must be in the validated reactions list."""
+        """REACTION_COMPLETE must be an EmojiResult whose .emoji is in the validated reactions list."""
         from bridge.response import REACTION_COMPLETE, VALIDATED_REACTIONS
 
-        assert REACTION_COMPLETE in VALIDATED_REACTIONS
+        assert REACTION_COMPLETE.emoji in VALIDATED_REACTIONS
 
     def test_reaction_error_in_validated_list(self):
-        """REACTION_ERROR (😱) must be in the validated reactions list."""
+        """REACTION_ERROR must be an EmojiResult whose .emoji is in the validated reactions list."""
         from bridge.response import REACTION_ERROR, VALIDATED_REACTIONS
 
-        assert REACTION_ERROR in VALIDATED_REACTIONS
+        assert REACTION_ERROR.emoji in VALIDATED_REACTIONS
 
     def test_reaction_success_in_validated_list(self):
-        """REACTION_SUCCESS (👍) must be in the validated reactions list."""
+        """REACTION_SUCCESS must be an EmojiResult whose .emoji is in the validated reactions list."""
         from bridge.response import REACTION_SUCCESS, VALIDATED_REACTIONS
 
-        assert REACTION_SUCCESS in VALIDATED_REACTIONS
+        assert REACTION_SUCCESS.emoji in VALIDATED_REACTIONS
 
     def test_reaction_received_in_validated_list(self):
         """REACTION_RECEIVED (👀) must be in the validated reactions list."""
@@ -157,7 +157,11 @@ class TestReactionEmojiSelection:
         assert "❌" in INVALID_REACTIONS
 
     def test_reaction_constants_are_distinct(self):
-        """All reaction constants should be different emojis."""
+        """All reaction constants should be different emojis.
+
+        REACTION_SUCCESS/COMPLETE/ERROR are EmojiResult objects (unhashable),
+        so we compare by .emoji string value rather than using set() directly.
+        """
         from bridge.response import (
             REACTION_COMPLETE,
             REACTION_ERROR,
@@ -166,14 +170,15 @@ class TestReactionEmojiSelection:
             REACTION_SUCCESS,
         )
 
-        all_reactions = [
-            REACTION_RECEIVED,
-            REACTION_PROCESSING,
-            REACTION_SUCCESS,
-            REACTION_COMPLETE,
-            REACTION_ERROR,
+        # Extract string representations — EmojiResult objects are unhashable
+        all_reaction_strs = [
+            REACTION_RECEIVED,  # plain string
+            REACTION_PROCESSING,  # plain string
+            str(REACTION_SUCCESS),  # EmojiResult -> str via __str__
+            str(REACTION_COMPLETE),  # EmojiResult -> str via __str__
+            str(REACTION_ERROR),  # EmojiResult -> str via __str__
         ]
-        assert len(set(all_reactions)) == len(all_reactions)
+        assert len(set(all_reaction_strs)) == len(all_reaction_strs)
 
     def test_no_validated_reaction_in_invalid_list(self):
         """No emoji should be in both VALIDATED_REACTIONS and INVALID_REACTIONS."""

--- a/tests/unit/test_worker_entry.py
+++ b/tests/unit/test_worker_entry.py
@@ -244,8 +244,13 @@ class TestImportDecoupling:
         assert REACTION_ERROR.emoji in VALIDATED_REACTIONS
 
     def test_reaction_re_exports_from_bridge(self):
-        """REACTION_* should still be importable from bridge.response (backward compat) as EmojiResult."""
-        from bridge.response import REACTION_COMPLETE, REACTION_ERROR, REACTION_SUCCESS, VALIDATED_REACTIONS
+        """REACTION_* should be importable from bridge.response (backward compat) as EmojiResult."""
+        from bridge.response import (
+            REACTION_COMPLETE,
+            REACTION_ERROR,
+            REACTION_SUCCESS,
+            VALIDATED_REACTIONS,
+        )
         from tools.emoji_embedding import EmojiResult
 
         assert isinstance(REACTION_SUCCESS, EmojiResult)

--- a/tests/unit/test_worker_entry.py
+++ b/tests/unit/test_worker_entry.py
@@ -231,20 +231,29 @@ class TestImportDecoupling:
             )
 
     def test_reaction_constants_importable_from_agent(self):
-        """REACTION_* constants should be importable from agent.constants."""
+        """REACTION_* constants should be importable from agent.constants as EmojiResult objects."""
         from agent.constants import REACTION_COMPLETE, REACTION_ERROR, REACTION_SUCCESS
+        from bridge.response import VALIDATED_REACTIONS
+        from tools.emoji_embedding import EmojiResult
 
-        assert REACTION_SUCCESS == "\U0001f44d"
-        assert REACTION_COMPLETE == "\U0001f3c6"
-        assert REACTION_ERROR == "\U0001f631"
+        assert isinstance(REACTION_SUCCESS, EmojiResult)
+        assert isinstance(REACTION_COMPLETE, EmojiResult)
+        assert isinstance(REACTION_ERROR, EmojiResult)
+        assert REACTION_SUCCESS.emoji in VALIDATED_REACTIONS
+        assert REACTION_COMPLETE.emoji in VALIDATED_REACTIONS
+        assert REACTION_ERROR.emoji in VALIDATED_REACTIONS
 
     def test_reaction_re_exports_from_bridge(self):
-        """REACTION_* should still be importable from bridge.response (backward compat)."""
-        from bridge.response import REACTION_COMPLETE, REACTION_ERROR, REACTION_SUCCESS
+        """REACTION_* should still be importable from bridge.response (backward compat) as EmojiResult."""
+        from bridge.response import REACTION_COMPLETE, REACTION_ERROR, REACTION_SUCCESS, VALIDATED_REACTIONS
+        from tools.emoji_embedding import EmojiResult
 
-        assert REACTION_SUCCESS == "\U0001f44d"
-        assert REACTION_COMPLETE == "\U0001f3c6"
-        assert REACTION_ERROR == "\U0001f631"
+        assert isinstance(REACTION_SUCCESS, EmojiResult)
+        assert isinstance(REACTION_COMPLETE, EmojiResult)
+        assert isinstance(REACTION_ERROR, EmojiResult)
+        assert REACTION_SUCCESS.emoji in VALIDATED_REACTIONS
+        assert REACTION_COMPLETE.emoji in VALIDATED_REACTIONS
+        assert REACTION_ERROR.emoji in VALIDATED_REACTIONS
 
     def test_session_logs_importable_from_agent(self):
         """save_session_snapshot should be importable from agent.session_logs."""


### PR DESCRIPTION
## Summary
- Replace hardcoded `REACTION_SUCCESS`/`REACTION_COMPLETE`/`REACTION_ERROR` Unicode strings in `agent/constants.py` with lazily-resolved `EmojiResult` objects via `find_best_emoji()`
- Module `__getattr__` defers resolution to first access — zero HTTP calls at import time
- Hardcoded fallbacks (👌 SUCCESS, 👏 COMPLETE, 😢 ERROR) ensure all three constants remain distinct and in `VALIDATED_REACTIONS` even when the API is unavailable

## Changes
- `agent/constants.py` — Replace three hardcoded strings with `_TERMINAL_EMOJI_CACHE`, `_resolve_terminal_emoji()`, and `__getattr__` lazy init
- `bridge/response.py` — Update comment to note constants are now `EmojiResult` objects
- `tests/unit/test_worker_entry.py` — Assert `isinstance(REACTION_*, EmojiResult)` and `.emoji in VALIDATED_REACTIONS`
- `tests/integration/test_reply_delivery.py` — Use `.emoji` attr for VALIDATED_REACTIONS checks; fix `test_reaction_constants_are_distinct` to use `str(r)` instead of unhashable `EmojiResult` in set (B1 fix)
- `docs/features/emoji-embedding-reactions.md` — Add "Terminal Reactions" subsection documenting the feeling strings, fallbacks, and lazy caching pattern

## Testing
- [x] 52 unit + integration tests passing
- [x] Verification: constants are `EmojiResult` instances with distinct fallback emojis in `VALIDATED_REACTIONS`
- [x] Linting (ruff check) passing on all changed files

## Documentation
- [x] "Terminal Reactions" subsection added to `docs/features/emoji-embedding-reactions.md`

## Definition of Done
- [x] Built: Lazy EmojiResult constants implemented and working
- [x] Tested: All 52 tests passing
- [x] Documented: Docs updated
- [x] Quality: Ruff lint clean on all changed files

Closes #975