### PR TITLE
docs: CONTRIBUTING.md, CHANGELOG.md, and README value-prop (#849)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,138 @@
+# Changelog
+
+All notable changes to Valor are documented here.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) v1.1.0. Versioning uses date-based milestones (the project has no formal semver releases yet). Entries are maintained manually — PRs for notable features should include a new entry under `[Unreleased]`.
+
+---
+
+## [Unreleased]
+
+---
+
+## [0.11.0] - 2026-04-15
+
+### Added
+- **Terminal emoji upgrade:** semantic `find_best_emoji` lookup for terminal reactions, replacing hardcoded emoji sets with LLM-judged `EmojiResult` with lazy cache (#992)
+- **YouTube search tool:** `valor-youtube-search` CLI via yt-dlp for video lookup from any agent or skill (#988)
+- **WebSearch in /do-plan:** automated web research phase (Phase 0.7) fetches current best-practice context before plan drafting (#982)
+- **Worker health check at enqueue:** `valor-session create` and `valor-session status` warn when no worker is consuming the queue (#983)
+- **Memory status subcommand:** `python -m tools.memory_search status` reports Redis health, record counts, and superseded ratio (#970)
+- **Memory consolidation reflection:** nightly LLM-based semantic dedup merges near-duplicate memory records via Haiku; original records preserved with `superseded_by` links (#959)
+- **Reflections package extraction:** replaced 3086-line monolith with 18-unit `reflections/` package; each unit independently testable and schedulable (#967)
+
+### Fixed
+- Startup recovery no longer hijacks local CLI sessions — discriminates by `session_id` instead of blind `session[0]` (#989)
+- SDLC pipeline continuation race in `_handle_dev_session_completion` — ordering invariant enforced (#990)
+- Harness session continuity via `--resume` to prevent context overflow (#981)
+
+---
+
+## [0.10.0] - 2026-04-13
+
+### Added
+- **Email bridge:** IMAP/SMTP secondary transport receives and sends email as a first-class channel alongside Telegram (#908)
+- **Email personas:** domain wildcard routing and customer-service persona for email sessions
+- **Sentry integration:** `sentry-cli` installed via `/update`, opt-in reflection, and release tracking wired to PRs (#916)
+- **SDLC stage model selection:** Opus for Plan/Critique/Review, Sonnet for Build/Test/Patch; hard-PATCH builder session resume via `--resume` flag (#909)
+- **CLI harness unification:** all session types (PM, Dev, Teammate) migrated to the `claude -p` CLI harness; SDK execution path removed (#912)
+- **Session inspect/children/--full-message:** `valor-session inspect`, `children`, and `--full-message` subcommands for deep session debugging (#930)
+- **Per-stage SDLC addenda:** `docs/sdlc/` repo-specific addenda read by SDLC skills at runtime; reflection agent updates them post-merge (#932)
+- **PM child fan-out:** PM sessions can spawn multiple Dev sessions for multi-issue SDLC prompts (#903)
+- **Chunked document retrieval:** fine-grained semantic search over documents split into overlapping chunks (#864)
+
+### Changed
+- All session types unified under CLI harness — SDK session execution removed
+
+### Fixed
+- Session isolation bypass: dev sessions now always get worktree isolation regardless of PM creation path (#888)
+- PM session read-only Bash allowlist enforced to prevent silent mutations (#883)
+
+---
+
+## [0.9.0] - 2026-04-09
+
+### Added
+- **Sustainable self-healing:** circuit-gated queue governance with flood backoff and dynamic catchup (#842)
+- **Project-keyed worker serialization:** worker processes one session per project at a time, preventing cross-project interference (#832)
+- **Analytics system:** unified metrics collection with daily rollup and dashboard integration (#895)
+- **Worker hibernation:** sessions pause mid-execution on API failures and drip-resume on recovery (#844)
+- **PM session read-only Bash allowlist:** restricts PM sessions to safe shell operations only (#883)
+- **AI semantic evaluator in /do-build:** acceptance criteria evaluated by LLM after deterministic checks pass (#807)
+
+### Fixed
+- Summarizer fallback: agent self-summary via session steering when summarizer is unavailable (#892)
+- Deterministic reply-to root cache and completed session resume (#922)
+
+---
+
+## [0.8.0] - 2026-03-25
+
+### Added
+- **Subconscious memory:** persistent long-term memory with bloom-filter recall, post-session extraction, and `<thought>` injection via Claude Code hooks (#515)
+- **Claude Code memory hooks:** UserPromptSubmit ingest, PostToolUse recall with file-based sliding window, Stop extracts observations (#525)
+- **Autoexperiment:** nightly autonomous prompt optimization framework for observer/summarizer targets via LLM self-evaluation (#411)
+
+### Changed
+- Memory recall uses multi-query decomposition to split large keyword sets into retrieval clusters for broader coverage
+
+---
+
+## [0.7.0] - 2026-03-17
+
+### Added
+- **Test suite organization:** feature markers, e2e test layer, and `tests/README.md` index with coverage map (#431)
+- **Pipeline graph:** directed cyclic graph for SDLC stage transitions with first-class failure cycles (#314)
+
+---
+
+## [0.6.0] - 2026-02-26
+
+### Added
+- **Unified AgentSession model:** single Popoto-backed model for all session types (PM, Dev, Teammate) with bullet-point summarizer (#180)
+- **Stage-aware auto-continue:** SDLC sessions auto-continue until the stage is complete or blocked on a genuine open question (#185)
+- **Session steering:** externalize guidance injection via `queued_steering_messages`; any process can steer a running session (#749)
+- **Daydream v2:** autonomous bug-fixing via plan-build-PR cycles with multi-repo support (#148)
+
+---
+
+## [0.5.0] - 2026-02-13
+
+### Added
+- **SDK modernization:** migrated core agent execution to Claude Agent SDK with tool-use and multi-turn support
+- **Telegram messaging:** full send/receive pipeline with session context surviving across conversations
+- **Link summarization:** URL content fetch and LLM summarization with Redis caching
+
+---
+
+## [0.4.0] - 2026-01-31
+
+### Added
+- **SDLC pipeline:** Plan → Critique → Build → Test → Review → Docs → Merge skill chain with failure cycles
+- **`/do-plan` skill:** Shape Up-style feature planning with structured frontmatter, team orchestration, and critique rounds
+- **`/do-build` skill:** worktree-isolated plan execution with builder/validator agent teams
+- **Worktree isolation:** per-feature git worktrees for parallel work without collisions
+- **Session management:** `valor-session` CLI for creating, listing, inspecting, steering, and killing sessions
+
+---
+
+## [0.3.0] - 2026-01-20
+
+### Added
+- **YouTube video transcription:** `yt-dlp` + Whisper pipeline for extracting transcripts from YouTube URLs
+- **Google Workspace integration:** Gmail, Calendar, Docs, Sheets via `gws` CLI and MCP servers
+
+---
+
+## [0.2.0] - 2025-11-28
+
+### Added
+- **Dashboard:** web UI on `localhost:8500` showing live sessions, system health, reflections, and machine state
+- **Self-healing:** watchdog service with crash tracking, 5-level escalation, and automatic recovery
+
+---
+
+## [0.1.0] - 2024-08-13
+
+### Added
+- Initial project bootstrap: Telegram bridge, standalone worker, Redis-backed session queue (Popoto ORM), and agent harness scaffolding

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,171 @@
+# Contributing to Valor
+
+Welcome. Valor is an autonomous AI coworker that owns its own machine and does real work. Contributions that extend its capabilities, fix bugs, or improve reliability are appreciated.
+
+This guide covers everything you need to open your first PR in under 30 minutes.
+
+## Table of Contents
+
+1. [Prerequisites and Setup](#prerequisites-and-setup)
+2. [Branch and PR Process](#branch-and-pr-process)
+3. [Code Style](#code-style)
+4. [Type Checking](#type-checking)
+5. [Tests](#tests)
+6. [Commit Conventions](#commit-conventions)
+7. [Extending the System](#extending-the-system)
+8. [Getting Help](#getting-help)
+
+---
+
+## Prerequisites and Setup
+
+Follow the Quick Start in [README.md](README.md) to get a working local environment. You will need Python 3.11+, `uv`, and a `.env` file with secrets.
+
+```bash
+pip install -e .
+```
+
+All dev dependencies (ruff, mypy, pytest) are included.
+
+---
+
+## Branch and PR Process
+
+1. **Create a branch** from `main` using the `session/{slug}` naming convention:
+   ```bash
+   git checkout -b session/my-feature
+   ```
+2. **Open an issue first** for non-trivial work. The issue is the source of truth for scope.
+3. **Open a PR** against `main`. Use the PR body to summarize changes, link the issue (`Closes #N`), and list what was tested.
+4. **All checks must pass** before merge: ruff, mypy (if applicable), and pytest.
+5. **One reviewer** is sufficient for most PRs.
+
+PR body format:
+```
+## Summary
+Brief description of what changed and why.
+
+## Changes
+- bullet points
+
+## Testing
+- [ ] Unit tests passing
+- [ ] Integration tests passing
+
+Closes #N
+```
+
+---
+
+## Code Style
+
+Valor uses [Ruff](https://docs.astral.sh/ruff/) for formatting and linting. All configuration lives in [`pyproject.toml`](pyproject.toml) under `[tool.ruff]` and `[tool.ruff.lint]`.
+
+```bash
+python -m ruff format .        # Format all files
+python -m ruff check .         # Lint all files
+python -m ruff check --fix .   # Auto-fix fixable issues
+```
+
+A pre-commit hook runs ruff automatically on final commits — it auto-fixes what it can and blocks on genuine errors. Use `--no-verify` during WIP commits only.
+
+---
+
+## Type Checking
+
+Valor uses [mypy](https://mypy.readthedocs.io/) for static type checking on core modules. Configuration lives in [`pyproject.toml`](pyproject.toml) under `[tool.mypy]`.
+
+```bash
+python -m mypy agent/ tools/ bridge/
+```
+
+New code in `agent/`, `tools/`, and `bridge/` should be fully typed.
+
+---
+
+## Tests
+
+Test infrastructure is documented in [`tests/README.md`](tests/README.md), including the full marker table and feature coverage map.
+
+**Running tests:**
+```bash
+pytest tests/unit/ -n auto     # Unit tests in parallel (~60s)
+pytest tests/integration/      # Integration tests (requires live APIs)
+pytest tests/                  # Full suite
+pytest -m sdlc                 # Tests for a specific feature marker
+```
+
+**Quality gates:**
+- Unit: 100% pass rate required
+- Integration: 95% pass rate required
+- E2E: 90% pass rate required
+
+**Testing philosophy:** No mocks for external services — use real APIs. Use AI judges for intelligence validation, not keyword matching.
+
+**New tests** should use existing feature markers (see `tests/README.md`) and live under the appropriate subdirectory (`unit/`, `integration/`, `e2e/`).
+
+**CHANGELOG:** PRs introducing notable features should include a new entry in [`CHANGELOG.md`](CHANGELOG.md) under `[Unreleased]`.
+
+---
+
+## Commit Conventions
+
+Commits should be detailed and focused. Follow this format:
+
+```
+type(scope): short description (#issue-number)
+
+Optional longer body explaining why the change was made.
+```
+
+**Types:** `feat`, `fix`, `chore`, `docs`, `test`, `refactor`
+
+**Examples:**
+```
+feat(memory): add status subcommand to memory_search CLI (#970)
+fix(bridge): conversation terminus detection to break bot reply loops (#969)
+chore: remove completed plan after PR merge
+```
+
+**Rules:**
+- Use imperative mood in the subject line ("add", not "added")
+- Keep the subject line under 72 characters
+- Reference the issue number when applicable
+- Do not include co-author trailers
+
+---
+
+## Extending the System
+
+### Adding a Skill
+
+Skills live in [`.claude/skills/`](.claude/skills/). Each skill is a directory with a `SKILL.md` entry point.
+
+1. Create `.claude/skills/my-skill/SKILL.md`
+2. Register it in [`.claude/settings.local.json`](.claude/settings.local.json) if it needs special permissions
+3. Document it in [`docs/features/`](docs/features/)
+
+### Adding a Tool
+
+Python tools live in [`tools/`](tools/). Tools callable by the agent must also be wired into an MCP server.
+
+1. Add your tool logic in `tools/my_tool.py`
+2. Expose it via an MCP server in `mcp_servers/` and register in [`.mcp.json`](.mcp.json)
+3. Add integration tests in `tests/integration/`
+
+### Adding a Bridge
+
+Comms bridges live in [`bridge/`](bridge/). Each bridge connects an external channel (Telegram, Email, etc.) to the session queue.
+
+1. Implement the bridge following the pattern in `bridge/telegram_bridge.py`
+2. Register output handlers using the `OutputHandler` protocol in `agent/output_handler.py`
+3. Add configuration to `config/settings.py`
+
+---
+
+## Getting Help
+
+- **Architecture and working guide:** [CLAUDE.md](CLAUDE.md)
+- **Feature documentation:** [docs/features/README.md](docs/features/README.md)
+- **Test suite index:** [tests/README.md](tests/README.md)
+- **Open an issue:** [GitHub Issues](https://github.com/tomcounsell/ai/issues)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ Skills live in [`.claude/skills/`](.claude/skills/). Each skill is a directory w
 Python tools live in [`tools/`](tools/). Tools callable by the agent must also be wired into an MCP server.
 
 1. Add your tool logic in `tools/my_tool.py`
-2. Expose it via an MCP server in `mcp_servers/` and register in [`.claude/settings.json`](.claude/settings.json)
+2. Register it as an MCP server in [`.claude/settings.json`](.claude/settings.json)
 3. Add integration tests in `tests/integration/`
 
 ### Adding a Bridge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ Skills live in [`.claude/skills/`](.claude/skills/). Each skill is a directory w
 Python tools live in [`tools/`](tools/). Tools callable by the agent must also be wired into an MCP server.
 
 1. Add your tool logic in `tools/my_tool.py`
-2. Expose it via an MCP server in `mcp_servers/` and register in [`.mcp.json`](.mcp.json)
+2. Expose it via an MCP server in `mcp_servers/` and register in [`.claude/settings.json`](.claude/settings.json)
 3. Add integration tests in `tests/integration/`
 
 ### Adding a Bridge

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 An autonomous AI coworker. Not an assistant, not a chatbot — a colleague that owns its own machine and does real work.
 
+## Why Valor?
+
+- **Works where you work.** Receives tasks via Telegram or Email and replies in the same thread — no context switching, no dashboards to check.
+- **Ships code end-to-end.** Plans a feature, critiques the plan, writes the code, runs tests, opens a PR, and merges it — without being babysat through each step.
+- **Remembers across sessions.** A subconscious memory system injects relevant past decisions and corrections as `<thought>` blocks at exactly the right moment.
+- **Fixes itself.** A watchdog + self-healing pipeline restarts on crashes, hibernates on API failures, and escalates to you only when automation can't recover.
+- **Extensible by design.** Add a new skill in `.claude/skills/`, wire a tool in `tools/` + MCP, or connect a new comms channel in `bridge/` — the architecture absorbs extensions without surgery.
+
 ## What Is This?
 
 Valor wraps agent harnesses (like Claude Code) and bridges them to the comms channels humans actually use (Telegram, Email, LinkedIn, and more). The supervisor assigns work and provides direction. Valor executes autonomously on its own Mac, reaching out when necessary.
@@ -21,6 +29,8 @@ Three layers:
 </p>
 
 See [`docs/features/bridge-worker-architecture.md`](docs/features/bridge-worker-architecture.md) for the full design.
+
+> **📸 TODO**: Add demo GIF or screenshot here — see [docs/assets/](docs/assets/) for placement instructions.
 
 ## The SDLC Pipeline
 

--- a/docs/plans/open-source-readiness.md
+++ b/docs/plans/open-source-readiness.md
@@ -200,19 +200,19 @@ No agent integration required — this is a documentation-only change. No new to
 
 This work IS the documentation. No additional feature docs needed.
 
-- [ ] `CONTRIBUTING.md` created at repo root
-- [ ] `CHANGELOG.md` created at repo root
-- [ ] `README.md` updated with value-prop section and demo placeholder
+- [x] `CONTRIBUTING.md` created at repo root
+- [x] `CHANGELOG.md` created at repo root
+- [x] `README.md` updated with value-prop section and demo placeholder
 
 ## Success Criteria
 
-- [ ] `CONTRIBUTING.md` exists at repo root and covers: PR process, code style (referencing ruff/mypy configs), test requirements (referencing pytest markers), commit conventions, and how to add skills/tools/agents
-- [ ] README contains a "Why Valor?" value-proposition section visible in the first scroll
-- [ ] README contains a clearly marked placeholder for demo media with instructions for how to produce it
-- [ ] `CHANGELOG.md` exists with at least 6 versioned entries covering major feature milestones, following Keep a Changelog v1.1.0 format
-- [ ] All new markdown files contain no broken links to nonexistent repo paths
-- [ ] No new ruff failures introduced by this PR — verify by diffing `python -m ruff check .` output against baseline commit `71e2f70e` (a pre-existing `F841` in `test_recovery_respawn_safety.py` is excluded from this gate)
-- [ ] No existing test files are broken
+- [x] `CONTRIBUTING.md` exists at repo root and covers: PR process, code style (referencing ruff/mypy configs), test requirements (referencing pytest markers), commit conventions, and how to add skills/tools/agents
+- [x] README contains a "Why Valor?" value-proposition section visible in the first scroll
+- [x] README contains a clearly marked placeholder for demo media with instructions for how to produce it
+- [x] `CHANGELOG.md` exists with at least 6 versioned entries covering major feature milestones, following Keep a Changelog v1.1.0 format
+- [x] All new markdown files contain no broken links to nonexistent repo paths
+- [x] No new ruff failures introduced by this PR — verify by diffing `python -m ruff check .` output against baseline commit `71e2f70e` (a pre-existing `F841` in `test_recovery_respawn_safety.py` is excluded from this gate)
+- [x] No existing test files are broken
 
 ## Team Orchestration
 


### PR DESCRIPTION
## Summary
- Adds `CONTRIBUTING.md` at repo root covering PR process, code style (ruff/mypy with pyproject.toml pointers), test requirements (pointer to tests/README.md + quality gates), commit conventions, and how to add skills/tools/agents
- Adds `CHANGELOG.md` following Keep a Changelog v1.1.0 with 11 versioned date-based milestones from project history
- Inserts "Why Valor?" value-proposition section into README (visible in first scroll) and a demo media placeholder blockquote after the architecture diagram

## Changes
- `CONTRIBUTING.md` — new file, ~1,200 words; references existing docs rather than duplicating
- `CHANGELOG.md` — new file; 11 versioned entries covering Email Bridge, SDLC Pipeline, Subconscious Memory, Session Management, Sentry, YouTube/Search, Dashboard, Autoexperiment, and more
- `README.md` — additive only; "Why Valor?" section + visible `> 📸 TODO` blockquote placeholder

## Testing
- [x] All internal links in CONTRIBUTING.md verified against repo paths
- [x] CHANGELOG has 11 versioned entries (>= 6 required)
- [x] README "Why Valor?" section present (`grep -q "Why Valor" README.md` passes)
- [x] No new ruff failures (pre-existing F841 in test_recovery_respawn_safety.py is excluded per plan)
- [x] No existing test files modified

## Documentation
- [x] This PR IS the documentation deliverable
- [x] Related docs scanned — no HIGH/MED-HIGH confidence matches needing updates

## Definition of Done
- [x] Built: All three files created/updated
- [x] Tested: All success criteria verified
- [x] Documented: Docs gate passed (3 doc changes validated)
- [x] Quality: No new lint errors introduced

Closes #849