### PR TITLE
fix(#1001): gate AgentSession creation to worker-spawned sessions only

### DIFF
--- a/.claude/hooks/user_prompt_submit.py
+++ b/.claude/hooks/user_prompt_submit.py
@@ -83,6 +83,14 @@ def main():
                 except Exception:
                     pass  # Non-fatal
             else:
+                # Only create AgentSession for worker-spawned sessions.
+                # Direct CLI invocations (no parent worker, no session type) produce no record —
+                # they add noise to the queue without providing value (issue #1001).
+                if not os.environ.get("VALOR_PARENT_SESSION_ID") and not os.environ.get(
+                    "SESSION_TYPE"
+                ):
+                    return
+
                 # First prompt in this session -- create AgentSession
                 from models.agent_session import AgentSession
 

--- a/docs/features/claude-code-memory.md
+++ b/docs/features/claude-code-memory.md
@@ -96,9 +96,11 @@ The Stop hook has a 10-second timeout. Haiku extraction typically completes in 2
 
 ## AgentSession Lifecycle Tracking
 
-Local Claude Code sessions create AgentSession records in Redis, providing dashboard observability on par with Telegram-originated sessions. The lifecycle is managed across three hooks using a sidecar file to share the AgentSession `agent_session_id`:
+Worker-spawned Claude Code sessions create AgentSession records in Redis, providing dashboard observability on par with Telegram-originated sessions. The lifecycle is managed across three hooks using a sidecar file to share the AgentSession `agent_session_id`:
 
-1. **UserPromptSubmit hook**: On the first prompt of a session, creates an AgentSession via `AgentSession.create_local(session_type=..., ...)` with `status="running"` and `session_id=f"local-{claude_session_id}"`. The hook reads the `SESSION_TYPE` environment variable injected by `sdk_client.py` when spawning subprocesses, so the record stores the actual persona (`teammate`, `pm`, or `dev`); if `SESSION_TYPE` is absent (standalone CLI use), it defaults to `dev`. The `agent_session_id` is persisted to `data/sessions/{session_id}/agent_session.json`.
+> **Note:** Direct CLI sessions (developer running `claude` at the terminal) do **not** create AgentSession records. The UserPromptSubmit hook gates creation on the presence of `SESSION_TYPE` or `VALOR_PARENT_SESSION_ID` environment variables, which are only set by `sdk_client.py` for worker-spawned sessions (issue [#1001](https://github.com/tomcounsell/ai/issues/1001)). Memory extraction, transcript backup, and all other hook functionality continue to work normally for direct CLI sessions — they simply have no AgentSession record.
+
+1. **UserPromptSubmit hook**: On the first prompt of a worker-spawned session, creates an AgentSession via `AgentSession.create_local(session_type=..., ...)` with `status="running"` and `session_id=f"local-{claude_session_id}"`. The hook reads the `SESSION_TYPE` environment variable injected by `sdk_client.py` when spawning subprocesses, so the record stores the actual persona (`teammate`, `pm`, or `dev`). The `agent_session_id` is persisted to `data/sessions/{session_id}/agent_session.json`.
 2. **PostToolUse hook**: On every tool call, reads `agent_session_id` from the sidecar and updates `updated_at` timestamp and increments `tool_call_count` on the AgentSession record.
 3. **Stop hook**: Reads `agent_session_id` from the sidecar, sets `completed_at`, and marks status as `completed` (or `failed` if `stop_reason` is "error" or "crash").
 
@@ -227,7 +229,7 @@ This is a parallel path to the Telegram agent memory system, not a replacement:
 | Ingestion | `Memory.safe_save()` in bridge | `ingest()` called from UserPromptSubmit hook |
 | Deja vu signals | `check_and_inject()` emits vague recognition and novel territory thoughts | `recall()` emits identical signals |
 | Post-merge learning | `extract_post_merge_learning()` in merge stage | `post_merge_extract()` triggered from Stop hook on `gh pr merge` detection |
-| Session tracking | AgentSession created by bridge handler (`AgentSession.create(session_type=...)`) | AgentSession created by UserPromptSubmit hook (`AgentSession.create_local(session_type=SESSION_TYPE env var or "dev", ...)`) |
+| Session tracking | AgentSession created by bridge handler (`AgentSession.create(session_type=...)`) | AgentSession created by UserPromptSubmit hook only for worker-spawned sessions (`AgentSession.create_local(session_type=SESSION_TYPE env var, ...)`); direct CLI sessions create no AgentSession (gated by `SESSION_TYPE`/`VALOR_PARENT_SESSION_ID` env vars) |
 | Category re-ranking | `_apply_category_weights()` in `check_and_inject()` | `_apply_category_weights()` imported from `agent.memory_hook` in `recall()` |
 | Shared code | `extract_topic_keywords()`, `_apply_category_weights()`, `extract_observations_async()`, `detect_outcomes_async()` | Same functions imported from `agent/` |
 

--- a/docs/plans/completed/direct-cli-session-no-agent-session.md
+++ b/docs/plans/completed/direct-cli-session-no-agent-session.md
@@ -1,5 +1,5 @@
 ---
-status: Building
+status: Complete
 type: bug
 appetite: Small
 owner: Valor Engels

--- a/docs/plans/direct-cli-session-no-agent-session.md
+++ b/docs/plans/direct-cli-session-no-agent-session.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: Building
 type: bug
 appetite: Small
 owner: Valor Engels

--- a/tests/unit/test_hook_user_prompt_submit.py
+++ b/tests/unit/test_hook_user_prompt_submit.py
@@ -176,8 +176,8 @@ class TestMainCallChain:
             f"but got kwargs: {call_kwargs}"
         )
 
-    def test_main_omits_session_type_when_env_var_unset(self, monkeypatch):
-        """When SESSION_TYPE is not set, main() calls create_local without session_type kwarg."""
+    def test_main_skips_create_local_when_no_env_vars(self, monkeypatch):
+        """No env vars set -> skip create_local entirely (issue #1001)."""
         hook = _load_hook_module()
 
         fake_hook_input = {
@@ -190,6 +190,67 @@ class TestMainCallChain:
         fake_agent_session.agent_session_id = "mock-agent-id-456"
 
         monkeypatch.delenv("SESSION_TYPE", raising=False)
+        monkeypatch.delenv("VALOR_PARENT_SESSION_ID", raising=False)
+
+        with (
+            patch.object(hook, "read_hook_input", return_value=fake_hook_input),
+            patch("hook_utils.memory_bridge.ingest"),
+            patch("hook_utils.memory_bridge.load_agent_session_sidecar", return_value=fake_sidecar),
+            patch("hook_utils.memory_bridge.save_agent_session_sidecar"),
+            patch("hook_utils.memory_bridge._get_project_key", return_value="ai"),
+            patch(
+                "models.agent_session.AgentSession.create_local", return_value=fake_agent_session
+            ) as mock_create,
+        ):
+            hook.main()
+
+        mock_create.assert_not_called()
+
+    def test_main_creates_session_when_session_type_set(self, monkeypatch):
+        """When SESSION_TYPE is set (worker-spawned), main() creates AgentSession."""
+        hook = _load_hook_module()
+
+        fake_hook_input = {
+            "prompt": "Worker session",
+            "session_id": "test-session-st",
+            "cwd": "/tmp",
+        }
+        fake_sidecar = {}
+        fake_agent_session = MagicMock()
+        fake_agent_session.agent_session_id = "mock-agent-id-st"
+
+        monkeypatch.setenv("SESSION_TYPE", "dev")
+        monkeypatch.delenv("VALOR_PARENT_SESSION_ID", raising=False)
+
+        with (
+            patch.object(hook, "read_hook_input", return_value=fake_hook_input),
+            patch("hook_utils.memory_bridge.ingest"),
+            patch("hook_utils.memory_bridge.load_agent_session_sidecar", return_value=fake_sidecar),
+            patch("hook_utils.memory_bridge.save_agent_session_sidecar"),
+            patch("hook_utils.memory_bridge._get_project_key", return_value="ai"),
+            patch(
+                "models.agent_session.AgentSession.create_local", return_value=fake_agent_session
+            ) as mock_create,
+        ):
+            hook.main()
+
+        mock_create.assert_called_once()
+
+    def test_main_creates_session_when_parent_session_id_set(self, monkeypatch):
+        """VALOR_PARENT_SESSION_ID set -> create AgentSession."""
+        hook = _load_hook_module()
+
+        fake_hook_input = {
+            "prompt": "Child session",
+            "session_id": "test-session-ps",
+            "cwd": "/tmp",
+        }
+        fake_sidecar = {}
+        fake_agent_session = MagicMock()
+        fake_agent_session.agent_session_id = "mock-agent-id-ps"
+
+        monkeypatch.delenv("SESSION_TYPE", raising=False)
+        monkeypatch.setenv("VALOR_PARENT_SESSION_ID", "agt_parent123")
 
         with (
             patch.object(hook, "read_hook_input", return_value=fake_hook_input),
@@ -205,7 +266,37 @@ class TestMainCallChain:
 
         mock_create.assert_called_once()
         call_kwargs = mock_create.call_args.kwargs
-        assert "session_type" not in call_kwargs, (
-            f"Expected create_local to be called WITHOUT session_type kwarg, "
-            f"but got kwargs: {call_kwargs}"
-        )
+        assert call_kwargs.get("parent_agent_session_id") == "agt_parent123"
+
+    def test_main_creates_session_when_both_env_vars_set(self, monkeypatch):
+        """Both env vars set -> create AgentSession."""
+        hook = _load_hook_module()
+
+        fake_hook_input = {
+            "prompt": "Both env vars",
+            "session_id": "test-session-both",
+            "cwd": "/tmp",
+        }
+        fake_sidecar = {}
+        fake_agent_session = MagicMock()
+        fake_agent_session.agent_session_id = "mock-agent-id-both"
+
+        monkeypatch.setenv("SESSION_TYPE", "teammate")
+        monkeypatch.setenv("VALOR_PARENT_SESSION_ID", "agt_parent456")
+
+        with (
+            patch.object(hook, "read_hook_input", return_value=fake_hook_input),
+            patch("hook_utils.memory_bridge.ingest"),
+            patch("hook_utils.memory_bridge.load_agent_session_sidecar", return_value=fake_sidecar),
+            patch("hook_utils.memory_bridge.save_agent_session_sidecar"),
+            patch("hook_utils.memory_bridge._get_project_key", return_value="ai"),
+            patch(
+                "models.agent_session.AgentSession.create_local", return_value=fake_agent_session
+            ) as mock_create,
+        ):
+            hook.main()
+
+        mock_create.assert_called_once()
+        call_kwargs = mock_create.call_args.kwargs
+        assert call_kwargs.get("session_type") == "teammate"
+        assert call_kwargs.get("parent_agent_session_id") == "agt_parent456"


### PR DESCRIPTION
## Summary
- Gate `AgentSession.create_local()` in `user_prompt_submit.py` behind `SESSION_TYPE` or `VALOR_PARENT_SESSION_ID` env vars — both set exclusively by `sdk_client.py` for worker-spawned sessions
- Direct CLI sessions (developer running `claude` at terminal) no longer create orphan `local-*` AgentSession records in Redis
- Memory extraction, transcript backup, and all hook functionality continue working normally for direct CLI sessions

Closes #1001

## Changes
- `.claude/hooks/user_prompt_submit.py`: Added 5-line gate before `create_local()` call
- `tests/unit/test_hook_user_prompt_submit.py`: Replaced 1 test, added 4 new gate tests (14 total, all pass)
- `docs/features/claude-code-memory.md`: Updated AgentSession tracking docs to reflect the gate
- `docs/plans/direct-cli-session-no-agent-session.md`: Status → Building

## Test plan
- [x] `pytest tests/unit/test_hook_user_prompt_submit.py -v` — 14/14 pass
- [x] `pytest tests/unit/test_stop_hook.py -v` — 17/17 pass (no regressions)
- [x] `ruff check` + `ruff format --check` — clean
- [ ] Verify: run `claude` directly, confirm no `local-*` AgentSession in Redis
- [ ] Verify: worker-spawned session still creates AgentSession as before