### PR TITLE
fix(#999): worker restart kickstart fallback + resume hydration field name

### DIFF
--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -852,7 +852,7 @@ async def _pop_agent_session(
                 prepend = "\n\n".join(extra_texts)
                 original = chosen.message_text or ""
                 chosen.message_text = f"{original}\n\n{prepend}" if original else prepend
-                await chosen.async_save(update_fields=["message_text", "updated_at"])
+                await chosen.async_save(update_fields=["initial_telegram_message", "updated_at"])
                 logger.info(
                     f"[worker:{worker_key}] Drained {len(extra_texts)} steering message(s) "
                     f"into session {chosen.id} message_text"
@@ -983,7 +983,9 @@ async def _pop_agent_session_with_fallback(
                     prepend = "\n\n".join(extra_texts)
                     original = chosen.message_text or ""
                     chosen.message_text = f"{original}\n\n{prepend}" if original else prepend
-                    await chosen.async_save(update_fields=["message_text", "updated_at"])
+                    await chosen.async_save(
+                        update_fields=["initial_telegram_message", "updated_at"]
+                    )
                     logger.info(
                         f"[worker:{worker_key}] Sync fallback: drained {len(extra_texts)} "
                         f"steering message(s) into session {chosen.id} message_text"

--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -667,7 +667,7 @@ async def _maybe_inject_resume_hydration(chosen, worker_key: str) -> None:
 
         original = chosen.message_text or ""
         chosen.message_text = f"{hydration_block}\n\n{original}" if original else hydration_block
-        await chosen.async_save(update_fields=["message_text", "updated_at"])
+        await chosen.async_save(update_fields=["initial_telegram_message", "updated_at"])
         logger.info(
             f"[worker:{worker_key}] Injected resume hydration into session {chosen.id} "
             f"({len(resume_files)} prior resume files found)"

--- a/docs/features/bridge-worker-architecture.md
+++ b/docs/features/bridge-worker-architecture.md
@@ -407,6 +407,15 @@ python -m tools.valor_session kill --id <ID>                # Kill a session
 ./scripts/valor-service.sh worker-status   # Worker-specific status
 ```
 
+## Update Orchestrator: Worker Start Verification
+
+After installing the worker service during `/update`, the update orchestrator (`scripts/update/run.py`) verifies the worker actually starts:
+
+1. **30-second heartbeat poll**: Checks `is_worker_running()` and heartbeat file mtime every 2 seconds (15 iterations).
+2. **Kickstart fallback**: If no worker process is detected after 30 seconds, the orchestrator runs `launchctl kickstart -k gui/{uid}/com.valor.worker` to force-start the service. This bypasses launchd's `ThrottleInterval` and handles cases where `bootout`+`bootstrap` registered the service but didn't start it.
+3. **15-second re-poll**: After kickstart, polls for another 15 seconds (8 iterations) using the same heartbeat check.
+4. **Error exit on persistent failure**: If the worker is still not running after the full 45-second window (30s initial + 15s post-kickstart), the update exits with `result.success = False` and logs `ERROR: Worker not running after kickstart retry -- system degraded`. This ensures operators are alerted to degraded state rather than silently continuing with a dead worker.
+
 ## Worker Exit Code and launchd Restart Behavior
 
 The worker exits with **code 1** when shut down via SIGTERM (e.g., by `./scripts/valor-service.sh worker-restart`). This is intentional.

--- a/docs/features/session-lifecycle.md
+++ b/docs/features/session-lifecycle.md
@@ -174,13 +174,13 @@ Any `AgentSession` method that saves companion fields (non-status fields) **must
 | `push_steering_message()` | `["queued_steering_messages", "updated_at"]` | `models/agent_session.py` |
 | `pop_steering_messages()` | `["queued_steering_messages", "updated_at"]` | `models/agent_session.py` |
 | Heartbeat in `_heartbeat_loop` | `["updated_at"]` | `agent/agent_session_queue.py` |
-| Steering drain (async) | `["message_text", "updated_at"]` | `agent/agent_session_queue.py` |
-| Steering drain (sync fallback) | `["message_text", "updated_at"]` | `agent/agent_session_queue.py` |
+| Steering drain (async) | `["initial_telegram_message", "updated_at"]` | `agent/agent_session_queue.py` |
+| Steering drain (sync fallback) | `["initial_telegram_message", "updated_at"]` | `agent/agent_session_queue.py` |
 | `retain_for_resume` save | `["retain_for_resume", "updated_at"]` | `agent/agent_session_queue.py` |
 | Session metadata save | `["updated_at", "branch_name", "task_list_id"]` | `agent/agent_session_queue.py` |
 | `response_delivered_at` save | `["response_delivered_at", "updated_at"]` | `agent/agent_session_queue.py` |
 | Branch/commit checkpoint | `["branch_name", "session_events", "updated_at"]` | `agent/agent_session_queue.py` |
-| Resume hydration | `["message_text", "updated_at"]` | `agent/agent_session_queue.py` |
+| Resume hydration | `["initial_telegram_message", "updated_at"]` | `agent/agent_session_queue.py` |
 | Priority reorder | `["priority", "updated_at"]` | `agent/agent_session_queue.py` |
 | Continuation project_config | `["project_config", "updated_at"]` | `agent/agent_session_queue.py` |
 | Tool call tracking | `["updated_at", "tool_call_count"]` | `.claude/hooks/post_tool_use.py` |

--- a/docs/features/worker-service.md
+++ b/docs/features/worker-service.md
@@ -124,7 +124,7 @@ This installs `com.valor.worker` as a launchd service that auto-starts on boot.
 
 The `/update` command (`scripts/update/run.py`) automatically manages the worker service alongside the bridge:
 
-- **Full update** (`--full`): Installs worker plist, verifies worker starts (polls up to 10s)
+- **Full update** (`--full`): Installs worker plist, verifies worker starts (30s heartbeat poll + kickstart fallback with 15s re-poll; exits with error if worker still not running after 45s total)
 - **Cron update** (`scripts/remote-update.sh`): Bootout old worker, substitute paths, bootstrap new
 - **Python API**: `scripts/update/service.py` exposes `install_worker()`, `restart_worker()`, `get_worker_status()`, `is_worker_running()`
 

--- a/docs/plans/worker-restart-verification.md
+++ b/docs/plans/worker-restart-verification.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: docs_complete
 type: bug
 appetite: Small
 owner: Valor
@@ -229,8 +229,8 @@ No agent integration required — both changes are in the update orchestrator an
 
 ## Documentation
 
-- [ ] Update `docs/features/bridge-worker-architecture.md` to note that `/update` now retries worker start via `launchctl kickstart` if the 30-second heartbeat window expires.
-- [ ] No new feature doc needed — this is a bug fix to existing infrastructure.
+- [x] Update `docs/features/bridge-worker-architecture.md` to note that `/update` now retries worker start via `launchctl kickstart` if the 30-second heartbeat window expires.
+- [x] No new feature doc needed — this is a bug fix to existing infrastructure.
 
 ## Success Criteria
 

--- a/scripts/update/run.py
+++ b/scripts/update/run.py
@@ -808,8 +808,47 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
                             "dashboard may show stale status briefly"
                         )
                     else:
-                        log("WARN: Worker not running after install", v, always=True)
-                        result.warnings.append("Worker not running after install")
+                        # Kickstart fallback: force-start the service if launchd
+                        # didn't auto-start after bootout+bootstrap.
+                        import subprocess
+
+                        uid = os.getuid()
+                        try:
+                            subprocess.run(
+                                ["launchctl", "kickstart", "-k", f"gui/{uid}/com.valor.worker"],
+                                capture_output=True,
+                            )
+                        except Exception as e:
+                            log(f"launchctl kickstart failed: {e}", v, always=True)
+                        # Re-poll for 15 more seconds
+                        for _ in range(8):
+                            _time.sleep(2)
+                            if service.is_worker_running():
+                                worker_pid = service.get_worker_pid()
+                                try:
+                                    if (
+                                        heartbeat_file.exists()
+                                        and heartbeat_file.stat().st_mtime > install_ts
+                                    ):
+                                        log(
+                                            f"Worker running after kickstart (PID: {worker_pid})",
+                                            v,
+                                            always=True,
+                                        )
+                                        worker_healthy = True
+                                        break
+                                except OSError:
+                                    pass
+                        if not worker_healthy:
+                            log(
+                                "ERROR: Worker not running after kickstart retry — system degraded",
+                                v,
+                                always=True,
+                            )
+                            result.warnings.append(
+                                "Worker not running after install and kickstart retry"
+                            )
+                            result.success = False
             else:
                 result.warnings.append("Worker plist install failed")
 

--- a/tests/unit/test_resume_hydration.py
+++ b/tests/unit/test_resume_hydration.py
@@ -176,7 +176,9 @@ class TestMaybeInjectResumeHydration:
         assert "<resumed-session-context>" in session.message_text
         assert "abc123 Fix bug" in session.message_text
         assert "original message" in session.message_text
-        session.async_save.assert_called_once()
+        session.async_save.assert_called_once_with(
+            update_fields=["initial_telegram_message", "updated_at"]
+        )
 
         # log_depth=10 was passed
         mock_git.assert_called_once_with(working_dir="/tmp/fake-worktree", log_depth=10)
@@ -202,6 +204,9 @@ class TestMaybeInjectResumeHydration:
         hydration_pos = session.message_text.index("<resumed-session-context>")
         original_pos = session.message_text.index("do the next stage")
         assert hydration_pos < original_pos
+        session.async_save.assert_called_once_with(
+            update_fields=["initial_telegram_message", "updated_at"]
+        )
 
     # -- Silent failure --
 
@@ -261,3 +266,6 @@ class TestMaybeInjectResumeHydration:
             self._run(session)
 
         assert "<resumed-session-context>" in session.message_text
+        session.async_save.assert_called_once_with(
+            update_fields=["initial_telegram_message", "updated_at"]
+        )


### PR DESCRIPTION
## Summary
- Add `launchctl kickstart -k` fallback in update orchestrator when worker fails to start within 30s; re-polls 15s after kickstart; exits with error if still dead
- Fix `async_save` field name in `_maybe_inject_resume_hydration`: use `initial_telegram_message` (real Popoto DictField) instead of `message_text` (property, silently skipped)
- Update test assertions to verify correct field name in `async_save` calls

## Changes
- `scripts/update/run.py`: Added kickstart fallback block after 30s heartbeat timeout
- `agent/agent_session_queue.py`: Fixed `update_fields` from `["message_text", ...]` to `["initial_telegram_message", ...]`
- `tests/unit/test_resume_hydration.py`: Added `assert_called_once_with(update_fields=["initial_telegram_message", "updated_at"])` to 3 tests
- `docs/features/bridge-worker-architecture.md`: Documented worker start verification flow

## Testing
- [x] `pytest tests/unit/test_resume_hydration.py -v` -- all 14 tests pass
- [x] `python -m ruff check` -- clean
- [x] `python -m ruff format --check` -- clean
- [x] Pre-existing failures confirmed on main (unrelated: missing API keys, event loop issue)

## Documentation
- [x] Updated bridge-worker-architecture.md with kickstart fallback section

## Definition of Done
- [x] Built: Code implemented and working
- [x] Tested: All related tests passing
- [x] Documented: Docs updated
- [x] Quality: Lint and format checks pass

Closes #999