### PR TITLE
fix(#1004): prevent PM session deadlock when child dev can't get worker slot

### DIFF
--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -770,9 +770,33 @@ async def _pop_agent_session(
                 return dt.replace(tzinfo=UTC)
             return dt
 
+        # Build a lookup of parent statuses for child-priority boost (issue #1004).
+        # Sessions whose parent is in waiting_for_children sort before peers at
+        # the same priority tier, breaking the deadlock where the parent holds a
+        # slot while the child can never start.
+        _parent_ids = {
+            getattr(j, "parent_agent_session_id", None)
+            for j in eligible
+            if getattr(j, "parent_agent_session_id", None)
+        }
+        _parent_waiting: set[str] = set()
+        if _parent_ids:
+            try:
+                from models.agent_session import AgentSession as _ParentAS
+
+                for pid in _parent_ids:
+                    _matches = list(_ParentAS.query.filter(id=pid))
+                    if _matches and getattr(_matches[0], "status", None) == "waiting_for_children":
+                        _parent_waiting.add(pid)
+            except Exception:
+                pass  # If lookup fails, no boost — safe fallback
+
         def sort_key(j):
             prio = PRIORITY_RANK.get(j.priority, 2)  # default to normal
-            return (prio, _ensure_tz(j.created_at))
+            # Boost children of waiting parents: 0 sorts before 1
+            _pid = getattr(j, "parent_agent_session_id", None)
+            child_boost = 0 if _pid and _pid in _parent_waiting else 1
+            return (prio, child_boost, _ensure_tz(j.created_at))
 
         eligible.sort(key=sort_key)
 
@@ -3345,6 +3369,28 @@ async def _handle_dev_session_completion(
                         )
                     else:
                         logger.info(f"[harness] Steered parent PM session {parent.session_id}")
+                        # Immediately re-enqueue parent so it picks up the
+                        # steering message without waiting for the periodic
+                        # hierarchy health check.  Issue #1004.
+                        if refreshed_status == "waiting_for_children":
+                            try:
+                                from models.session_lifecycle import (
+                                    transition_status as _ts,
+                                )
+
+                                _ts(
+                                    refreshed_parent,
+                                    "pending",
+                                    reason="child completed, steering injected",
+                                )
+                                logger.info(
+                                    f"[harness] Re-enqueued parent {parent.session_id} "
+                                    f"from waiting_for_children to pending"
+                                )
+                            except Exception as re_enqueue_err:
+                                logger.warning(
+                                    f"[harness] Failed to re-enqueue parent: {re_enqueue_err}"
+                                )
                 except Exception:
                     # If refresh fails, assume steer worked
                     logger.info(f"[harness] Steered parent PM session {parent.session_id}")
@@ -3583,6 +3629,26 @@ async def _execute_agent_session(session: AgentSession) -> None:
         from agent.sdk_client import get_stop_reason
 
         stop_reason = get_stop_reason(session.session_id) if session.session_id else None
+
+        # Re-read agent_session from Redis for fresh status.  The in-memory
+        # copy was loaded with status="running" at session start and is stale
+        # when the PM calls wait-for-children (which updates Redis directly).
+        # Without this re-read the waiting_for_children guard in output_router
+        # never fires.  Issue #1004.
+        if agent_session is not None:
+            try:
+                from models.agent_session import AgentSession as _FreshAS
+
+                _fresh = list(_FreshAS.query.filter(session_id=session.session_id))
+                if _fresh:
+                    agent_session = sorted(
+                        _fresh,
+                        key=lambda s: s.created_at or 0,
+                        reverse=True,
+                    )[0]
+            except Exception:
+                pass  # Fall back to stale in-memory copy
+
         session_status = agent_session.status if agent_session else None
         unhealthy_reason = is_session_unhealthy(session.session_id) if session.session_id else None
 

--- a/agent/output_router.py
+++ b/agent/output_router.py
@@ -103,6 +103,11 @@ def determine_delivery_action(
         return "deliver_fallback"
     if auto_continue_count >= max_nudge_count:
         return "deliver"
+    # PM in waiting_for_children must deliver (not nudge) so the session exits
+    # cleanly and releases its global semaphore slot.  The child dev session
+    # can then acquire the slot.  Issue #1004.
+    if session_status == "waiting_for_children":
+        return "deliver"
     # PM sessions running SDLC work should continue through pipeline stages
     # rather than delivering after the first skill completes.
     # The PM decides when to stop; the bridge just keeps it working.

--- a/docs/features/pm-dev-session-architecture.md
+++ b/docs/features/pm-dev-session-architecture.md
@@ -159,6 +159,18 @@ Or directly via `AgentSession.create(session_type="pm", ...)`.
 - `summary`, `result_text`, `stage_states`, `last_commit_sha` -- derived from `session_events`
 - `scheduling_depth` -- derived from parent chain walk (max depth 5)
 
+## Deadlock Prevention
+
+When a PM session dispatches a child dev session and enters `waiting_for_children` status, three mechanisms prevent the PM from starving the child of worker slots (issue #1004):
+
+1. **Output router guard**: `determine_delivery_action()` in `agent/output_router.py` checks `session_status == "waiting_for_children"` *before* the PM+SDLC nudge check. When the guard fires, the PM's output is delivered (not nudged), allowing the session to exit cleanly and release its global semaphore slot. Without this guard, the nudge loop would re-enqueue the PM as `pending`, consuming a slot on every cycle while the child sits in the queue.
+
+2. **Child priority boost**: `_pop_agent_session()` in `agent/agent_session_queue.py` boosts child sessions whose parent is in `waiting_for_children` status. Within the same priority tier, these children sort before parentless sessions (FIFO is preserved among equals). This ensures the child gets the next available slot rather than competing with unrelated sessions.
+
+3. **Immediate PM re-enqueue**: `_handle_dev_session_completion()` transitions the parent PM from `waiting_for_children` to `pending` immediately after steering succeeds, rather than waiting for the periodic hierarchy health check. The health check remains as a safety-net fallback.
+
+4. **Session status re-read**: `send_to_chat()` re-reads the agent session from Redis before the routing decision. The in-memory copy is loaded with `status="running"` at session start and becomes stale when the PM calls `wait-for-children` (which updates Redis directly). Without this re-read, the output router guard would never fire.
+
 ## Nudge Loop (Bridge Output Routing)
 
 The bridge uses a single nudge model for all output routing. No Observer, no SDLC stage awareness, no PipelineStateMachine in the bridge layer.

--- a/tests/unit/test_child_priority_boost.py
+++ b/tests/unit/test_child_priority_boost.py
@@ -1,0 +1,119 @@
+"""Tests for child priority boost in _pop_agent_session sort key (issue #1004).
+
+Verifies that sessions whose parent is in waiting_for_children status sort
+before parentless sessions at the same priority tier, ensuring the child dev
+session gets a worker slot instead of being starved by the PM's nudge cycle.
+"""
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+
+def _make_session(
+    priority="normal",
+    parent_agent_session_id=None,
+    created_at=None,
+):
+    """Create a mock session object for sort key testing."""
+    return SimpleNamespace(
+        priority=priority,
+        parent_agent_session_id=parent_agent_session_id,
+        created_at=created_at or datetime.now(UTC),
+    )
+
+
+class TestChildPriorityBoostSortKey:
+    """Test the sort key logic that boosts children of waiting parents."""
+
+    def _sort_key(self, j, parent_waiting_set):
+        """Replicate the sort_key function from _pop_agent_session."""
+        from agent.agent_session_queue import PRIORITY_RANK
+
+        prio = PRIORITY_RANK.get(j.priority, 2)
+        _pid = getattr(j, "parent_agent_session_id", None)
+        child_boost = 0 if _pid and _pid in parent_waiting_set else 1
+        dt = j.created_at
+        if dt is None:
+            dt = datetime.min.replace(tzinfo=UTC)
+        if isinstance(dt, datetime) and dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return (prio, child_boost, dt)
+
+    def test_child_of_waiting_parent_sorts_before_parentless(self):
+        """Child of waiting_for_children parent sorts before parentless at same priority."""
+        t = datetime(2026, 1, 1, tzinfo=UTC)
+        child = _make_session(priority="normal", parent_agent_session_id="pm-1", created_at=t)
+        orphan = _make_session(priority="normal", parent_agent_session_id=None, created_at=t)
+
+        parent_waiting = {"pm-1"}
+        assert self._sort_key(child, parent_waiting) < self._sort_key(orphan, parent_waiting)
+
+    def test_child_of_running_parent_no_boost(self):
+        """Child of a running (not waiting) parent gets no boost."""
+        t = datetime(2026, 1, 1, tzinfo=UTC)
+        child = _make_session(priority="normal", parent_agent_session_id="pm-2", created_at=t)
+        orphan = _make_session(priority="normal", parent_agent_session_id=None, created_at=t)
+
+        parent_waiting = set()  # pm-2 is NOT waiting
+        assert self._sort_key(child, parent_waiting) == self._sort_key(orphan, parent_waiting)
+
+    def test_priority_still_dominates_over_boost(self):
+        """Higher priority session beats a boosted child at lower priority."""
+        t = datetime(2026, 1, 1, tzinfo=UTC)
+        high_prio = _make_session(priority="high", parent_agent_session_id=None, created_at=t)
+        boosted_child = _make_session(
+            priority="normal", parent_agent_session_id="pm-1", created_at=t
+        )
+
+        parent_waiting = {"pm-1"}
+        assert self._sort_key(high_prio, parent_waiting) < self._sort_key(
+            boosted_child, parent_waiting
+        )
+
+    def test_fifo_preserved_within_boosted_tier(self):
+        """Among boosted children at same priority, older session comes first."""
+        t1 = datetime(2026, 1, 1, tzinfo=UTC)
+        t2 = datetime(2026, 1, 2, tzinfo=UTC)
+        older = _make_session(priority="normal", parent_agent_session_id="pm-1", created_at=t1)
+        newer = _make_session(priority="normal", parent_agent_session_id="pm-1", created_at=t2)
+
+        parent_waiting = {"pm-1"}
+        assert self._sort_key(older, parent_waiting) < self._sort_key(newer, parent_waiting)
+
+    def test_fifo_preserved_within_non_boosted_tier(self):
+        """Among non-boosted sessions at same priority, older comes first."""
+        t1 = datetime(2026, 1, 1, tzinfo=UTC)
+        t2 = datetime(2026, 1, 2, tzinfo=UTC)
+        older = _make_session(priority="normal", created_at=t1)
+        newer = _make_session(priority="normal", created_at=t2)
+
+        parent_waiting = set()
+        assert self._sort_key(older, parent_waiting) < self._sort_key(newer, parent_waiting)
+
+    @pytest.mark.parametrize("priority", ["critical", "high", "normal", "low"])
+    def test_boost_works_at_all_priority_tiers(self, priority):
+        """Boost applies within each priority tier, not just normal."""
+        t = datetime(2026, 1, 1, tzinfo=UTC)
+        child = _make_session(priority=priority, parent_agent_session_id="pm-1", created_at=t)
+        orphan = _make_session(priority=priority, parent_agent_session_id=None, created_at=t)
+
+        parent_waiting = {"pm-1"}
+        assert self._sort_key(child, parent_waiting) < self._sort_key(orphan, parent_waiting)
+
+    def test_full_sort_order_example(self):
+        """Full sort of mixed sessions produces expected order."""
+        t = datetime(2026, 1, 1, tzinfo=UTC)
+        sessions = [
+            _make_session(priority="normal", parent_agent_session_id=None, created_at=t),
+            _make_session(priority="normal", parent_agent_session_id="pm-1", created_at=t),
+            _make_session(priority="high", parent_agent_session_id=None, created_at=t),
+        ]
+        parent_waiting = {"pm-1"}
+
+        sorted_sessions = sorted(sessions, key=lambda j: self._sort_key(j, parent_waiting))
+        # high-prio first, then boosted child, then normal orphan
+        assert sorted_sessions[0].priority == "high"
+        assert sorted_sessions[1].parent_agent_session_id == "pm-1"
+        assert sorted_sessions[2].parent_agent_session_id is None

--- a/tests/unit/test_output_router.py
+++ b/tests/unit/test_output_router.py
@@ -1,0 +1,196 @@
+"""Tests for agent/output_router.py — delivery action routing logic.
+
+Covers the waiting_for_children guard (issue #1004) and general routing.
+"""
+
+import pytest
+
+from agent.output_router import (
+    MAX_NUDGE_COUNT,
+    PIPELINE_COMPLETE_MARKER,
+    determine_delivery_action,
+)
+
+
+class TestWaitingForChildrenGuard:
+    """Issue #1004: PM in waiting_for_children must deliver, not nudge."""
+
+    def test_pm_sdlc_waiting_for_children_delivers(self):
+        """PM+SDLC session in waiting_for_children returns deliver, not nudge_continue."""
+        action = determine_delivery_action(
+            msg="Dispatched BUILD. Waiting for completion.",
+            stop_reason="end_turn",
+            auto_continue_count=0,
+            max_nudge_count=MAX_NUDGE_COUNT,
+            session_status="waiting_for_children",
+            session_type="pm",
+            classification_type="sdlc",
+        )
+        assert action == "deliver"
+
+    def test_pm_sdlc_running_still_nudges(self):
+        """PM+SDLC session in running status still returns nudge_continue."""
+        action = determine_delivery_action(
+            msg="Working on the pipeline...",
+            stop_reason="end_turn",
+            auto_continue_count=0,
+            max_nudge_count=MAX_NUDGE_COUNT,
+            session_status="running",
+            session_type="pm",
+            classification_type="sdlc",
+        )
+        assert action == "nudge_continue"
+
+    def test_pm_sdlc_active_still_nudges(self):
+        """PM+SDLC session in active status still returns nudge_continue."""
+        action = determine_delivery_action(
+            msg="Assessing pipeline state...",
+            stop_reason="end_turn",
+            auto_continue_count=0,
+            max_nudge_count=MAX_NUDGE_COUNT,
+            session_status="active",
+            session_type="pm",
+            classification_type="sdlc",
+        )
+        assert action == "nudge_continue"
+
+    def test_teammate_waiting_for_children_unaffected(self):
+        """Teammate session in waiting_for_children delivers normally (not PM path)."""
+        action = determine_delivery_action(
+            msg="Some output from teammate.",
+            stop_reason="end_turn",
+            auto_continue_count=0,
+            max_nudge_count=MAX_NUDGE_COUNT,
+            session_status="waiting_for_children",
+            session_type="teammate",
+            classification_type=None,
+        )
+        # Teammate sessions don't hit the PM+SDLC path, so they deliver normally
+        assert action == "deliver"
+
+    def test_waiting_for_children_with_none_session_type(self):
+        """waiting_for_children guard should not trigger without session_type=pm."""
+        action = determine_delivery_action(
+            msg="Some output.",
+            stop_reason="end_turn",
+            auto_continue_count=0,
+            max_nudge_count=MAX_NUDGE_COUNT,
+            session_status="waiting_for_children",
+            session_type=None,
+            classification_type=None,
+        )
+        assert action == "deliver"
+
+    def test_pm_sdlc_waiting_for_children_with_pipeline_complete_marker(self):
+        """Even with PIPELINE_COMPLETE_MARKER, waiting_for_children guard takes precedence."""
+        action = determine_delivery_action(
+            msg=f"Done. {PIPELINE_COMPLETE_MARKER}",
+            stop_reason="end_turn",
+            auto_continue_count=0,
+            max_nudge_count=MAX_NUDGE_COUNT,
+            session_status="waiting_for_children",
+            session_type="pm",
+            classification_type="sdlc",
+        )
+        # waiting_for_children guard fires before the PM+SDLC check
+        assert action == "deliver"
+
+    def test_pm_non_sdlc_waiting_for_children_delivers(self):
+        """PM non-SDLC session in waiting_for_children still delivers."""
+        action = determine_delivery_action(
+            msg="Waiting for child.",
+            stop_reason="end_turn",
+            auto_continue_count=0,
+            max_nudge_count=MAX_NUDGE_COUNT,
+            session_status="waiting_for_children",
+            session_type="pm",
+            classification_type="collaboration",
+        )
+        assert action == "deliver"
+
+    @pytest.mark.parametrize("session_status", [None, "running", "active", "pending"])
+    def test_non_waiting_statuses_do_not_trigger_guard(self, session_status):
+        """Only waiting_for_children triggers the early deliver guard."""
+        action = determine_delivery_action(
+            msg="Pipeline work in progress.",
+            stop_reason="end_turn",
+            auto_continue_count=0,
+            max_nudge_count=MAX_NUDGE_COUNT,
+            session_status=session_status,
+            session_type="pm",
+            classification_type="sdlc",
+        )
+        assert action == "nudge_continue"
+
+
+class TestExistingRouting:
+    """Ensure existing routing behavior is preserved."""
+
+    def test_terminal_status_delivers_already_completed(self):
+        action = determine_delivery_action(
+            msg="final output",
+            stop_reason="end_turn",
+            auto_continue_count=0,
+            max_nudge_count=MAX_NUDGE_COUNT,
+            session_status="completed",
+        )
+        assert action == "deliver_already_completed"
+
+    def test_completion_sent_drops(self):
+        action = determine_delivery_action(
+            msg="more output",
+            stop_reason="end_turn",
+            auto_continue_count=0,
+            max_nudge_count=MAX_NUDGE_COUNT,
+            completion_sent=True,
+        )
+        assert action == "drop"
+
+    def test_pm_sdlc_pipeline_complete_marker(self):
+        action = determine_delivery_action(
+            msg=f"All done! {PIPELINE_COMPLETE_MARKER}",
+            stop_reason="end_turn",
+            auto_continue_count=0,
+            max_nudge_count=MAX_NUDGE_COUNT,
+            session_type="pm",
+            classification_type="sdlc",
+        )
+        assert action == "deliver_pipeline_complete"
+
+    def test_pm_sdlc_normal_nudges(self):
+        action = determine_delivery_action(
+            msg="Working on BUILD stage...",
+            stop_reason="end_turn",
+            auto_continue_count=0,
+            max_nudge_count=MAX_NUDGE_COUNT,
+            session_type="pm",
+            classification_type="sdlc",
+        )
+        assert action == "nudge_continue"
+
+    def test_rate_limited_nudges(self):
+        action = determine_delivery_action(
+            msg="partial",
+            stop_reason="rate_limited",
+            auto_continue_count=0,
+            max_nudge_count=MAX_NUDGE_COUNT,
+        )
+        assert action == "nudge_rate_limited"
+
+    def test_empty_output_nudges(self):
+        action = determine_delivery_action(
+            msg="",
+            stop_reason="end_turn",
+            auto_continue_count=0,
+            max_nudge_count=MAX_NUDGE_COUNT,
+        )
+        assert action == "nudge_empty"
+
+    def test_normal_end_turn_delivers(self):
+        action = determine_delivery_action(
+            msg="Here is the answer.",
+            stop_reason="end_turn",
+            auto_continue_count=0,
+            max_nudge_count=MAX_NUDGE_COUNT,
+        )
+        assert action == "deliver"

--- a/tests/unit/test_recovery_respawn_safety.py
+++ b/tests/unit/test_recovery_respawn_safety.py
@@ -329,9 +329,7 @@ class TestStartupRecoverySkipsTerminal:
         with (
             patch("agent.agent_session_queue.AgentSession") as mock_as,
             patch("agent.agent_session_queue.time") as mock_time,
-            patch(
-                "models.session_lifecycle.finalize_session"
-            ) as mock_finalize,
+            patch("models.session_lifecycle.finalize_session") as mock_finalize,
             patch("models.session_lifecycle.update_session") as mock_update,
         ):
             mock_time.time.return_value = time.time()
@@ -390,8 +388,10 @@ class TestStartupRecoveryLocalSessionGuard:
         # finalize_session must have been called with "abandoned"
         mock_finalize.assert_called_once()
         call_args = mock_finalize.call_args
-        assert call_args[0][1] == "abandoned" or call_args[1].get("status") == "abandoned" or (
-            len(call_args[0]) >= 2 and call_args[0][1] == "abandoned"
+        assert (
+            call_args[0][1] == "abandoned"
+            or call_args[1].get("status") == "abandoned"
+            or (len(call_args[0]) >= 2 and call_args[0][1] == "abandoned")
         )
 
     def test_startup_recovery_recovers_bridge_sessions(self):


### PR DESCRIPTION
## Summary
- Add `waiting_for_children` guard in output router so PM delivers instead of nudging, releasing its semaphore slot for the child dev session
- Re-read agent session status from Redis in `send_to_chat()` before routing (fixes stale in-memory status)
- Add child priority boost in `_pop_agent_session` sort key so children of waiting parents get slots first
- Add immediate PM re-enqueue in `_handle_dev_session_completion` after successful steer
- Document deadlock prevention mechanisms in `docs/features/pm-dev-session-architecture.md`

Closes #1004

## Test plan
- [x] 18 unit tests for output router (`test_output_router.py`) covering waiting_for_children guard and existing routing
- [x] 10 unit tests for child priority boost sort key (`test_child_priority_boost.py`)
- [x] All 56 related tests pass (output_router + nudge_loop + duplicate_delivery + child_priority_boost)
- [x] Pre-existing test failures on main confirmed unrelated (test_continuation_pm, test_cross_wire_fixes, test_custom_emoji_index)