### PR TITLE
fix(#984): restart flag TTL + heartbeat-aware worker-status

### DIFF
--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -26,7 +26,7 @@ import signal
 import subprocess
 import time
 from collections.abc import Awaitable, Callable
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -2239,9 +2239,37 @@ def register_callbacks(
 _RESTART_FLAG = Path(__file__).parent.parent / "data" / "restart-requested"
 
 
+_RESTART_FLAG_TTL = timedelta(hours=1)
+
+
 def _check_restart_flag() -> bool:
-    """Check if a restart has been requested and no sessions are running across all projects."""
+    """Check if a restart has been requested and no sessions are running across all projects.
+
+    Returns False (and deletes the flag) if the flag is older than 1 hour,
+    malformed, or empty — preventing stale flags from triggering self-destruct.
+    """
     if not _RESTART_FLAG.exists():
+        return False
+
+    flag_content = _RESTART_FLAG.read_text().strip()
+
+    # Validate flag freshness via embedded timestamp
+    try:
+        timestamp_str = flag_content.split()[0]
+        flag_time = datetime.fromisoformat(timestamp_str)
+        # Ensure timezone-aware comparison
+        if flag_time.tzinfo is None:
+            flag_time = flag_time.replace(tzinfo=UTC)
+        flag_age = datetime.now(UTC) - flag_time
+        if flag_age > _RESTART_FLAG_TTL:
+            logger.warning(f"Restart flag is stale (age={flag_age}) — ignoring and deleting")
+            _RESTART_FLAG.unlink(missing_ok=True)
+            return False
+    except (ValueError, IndexError):
+        logger.warning(
+            f"Restart flag has malformed content ({flag_content!r}) — ignoring and deleting"
+        )
+        _RESTART_FLAG.unlink(missing_ok=True)
         return False
 
     # Check all workers for running sessions
@@ -2250,7 +2278,6 @@ def _check_restart_flag() -> bool:
         logger.info(f"Restart requested but {len(running)} session(s) still running — deferring")
         return False
 
-    flag_content = _RESTART_FLAG.read_text().strip()
     logger.info(f"Restart flag found ({flag_content}), no running sessions — restarting bridge")
     return True
 

--- a/docs/features/bridge-self-healing.md
+++ b/docs/features/bridge-self-healing.md
@@ -227,6 +227,8 @@ The worker can also be installed separately via `./scripts/install_worker.sh`. S
 3. If new commits arrived: syncs dependencies (if dep files changed), writes `data/restart-requested`
 4. The bridge session queue detects the restart flag and triggers a graceful restart after in-flight sessions complete
 
+**Restart flag TTL**: The flag file embeds an ISO 8601 timestamp. `_check_restart_flag()` ignores (and deletes) flags older than 1 hour. This prevents stale flags from a previous update session from triggering a self-destruct on worker-only machines where no bridge is running to consume the flag promptly. Malformed or empty flag content is also safely ignored and deleted.
+
 **Verify polling is active**:
 ```bash
 launchctl list | grep com.valor.update
@@ -326,6 +328,12 @@ This follows the proven cancellation pattern from the worker graceful shutdown (
 6. `main()` returns, `sys.exit(1)` terminates process
 7. launchd restarts bridge after ThrottleInterval
 
+### 16. Worker Status Heartbeat Check (`scripts/valor-service.sh`)
+
+**Problem**: After the worker shuts down or hangs, `worker-status` reports `RUNNING` because the old PID still exists in the process table (zombie/sleeping state). `worker-start` refuses to launch a new process, leaving the queue silently unattended.
+
+**Solution**: `status_worker()` now reads the `data/last_worker_connected` heartbeat file (written by `_write_worker_heartbeat()` on every health loop tick). If the heartbeat age exceeds 360 seconds (matching the dashboard threshold), the status is reported as `STALE` instead of `RUNNING`, with exit code 2. This distinguishes a healthy worker (exit 0), a stopped worker (exit 1), and a hung/zombie worker (exit 2).
+
 ## Recovery Lock
 
 During recovery, `data/recovery-in-progress` is created to prevent:
@@ -375,6 +383,7 @@ rm data/auto-revert-enabled
 | `data/bridge-auth-required` | Hibernation flag file (presence = auth required) |
 | `data/flood-backoff` | Flood-backoff expiry (JSON) |
 | `data/last_connected` | Last-connected timestamp (ISO 8601) |
+| `data/last_worker_connected` | Worker heartbeat file (mtime checked by `worker-status`) |
 | `logs/watchdog.log` | Watchdog output |
 | `logs/worker/{session_id}.log` | FileOutputHandler dual-write output (persisted even during bridge downtime) |
 

--- a/docs/plans/memory-time-range-consolidation.md
+++ b/docs/plans/memory-time-range-consolidation.md
@@ -1,0 +1,123 @@
+---
+status: In Progress
+type: feature
+appetite: Small
+owner: Valor
+created: 2026-04-16
+tracking: https://github.com/tomcounsell/ai/issues/966
+last_comment_id:
+---
+
+# Time-Range Memory Views & Hierarchical Consolidation
+
+## Problem
+
+All Memory records carry timestamps (via AccessTrackerMixin and DecayingSortedField relevance scores) but there is no time-sliced view (day, week, month) of what was observed, corrected, or decided. Humans cannot answer "what did we learn this week?" without running ad-hoc queries. The existing consolidation pipeline (memory-dedup) produces no browsable artifact.
+
+## Design Decision
+
+**On-demand reconstitution** via a new `timeline` CLI command, not materialized files.
+
+Rationale:
+- Records already carry timestamps via the `relevance` DecayingSortedField (which embeds creation time in its decay score) and `last_accessed` from AccessTrackerMixin
+- Materialized daily-note files (like OpenClaw's `memory/YYYY-MM-DD.md`) go stale the moment consolidation runs and re-supersedes records
+- Once #965 (embedding-enabled recall) ships, semantic timeline queries become far more powerful than static files
+- The agent is the primary consumer; humans use the CLI for spot-checks
+
+**Implementation:**
+1. Add a `timeline` subcommand to `tools/memory_search` CLI that filters memories by time range
+2. Add a `timeline()` function to the `tools/memory_search` Python API for programmatic use
+3. Use the DecayingSortedField sorted set (which stores creation-time-based scores) to efficiently retrieve records within a time window via ZRANGEBYSCORE
+4. Support grouping output by day/category for human readability
+
+## Prior Art
+
+- `tools/memory_search/cli.py` — existing CLI with `search`, `save`, `inspect`, `forget`, `status` commands
+- `scripts/memory_consolidation.py` — existing nightly dedup reflection
+- `agent/memory_retrieval.py` — BM25 + RRF fusion retrieval with `get_relevance_ranked()`
+- OpenClaw `memory/YYYY-MM-DD.md` — materialized daily notes (rejected approach for this project)
+
+## Data Flow
+
+### Timeline Query
+
+1. User runs `python -m tools.memory_search timeline --since "7 days ago"` (or `--from 2026-04-01 --to 2026-04-15`)
+2. `timeline()` calls `get_memories_in_time_range()` which reads the DecayingSortedField sorted set via ZRANGEBYSCORE with min/max score bounds
+3. Hydrates Memory instances from matched Redis keys
+4. Groups by day and optionally by category
+5. Renders human-readable or JSON output
+
+### Score-to-Timestamp Mapping
+
+The DecayingSortedField stores scores that combine importance and creation time. The score decays over time from the base_score_field ("importance"). By examining the sorted set scores, we can derive approximate creation times. However, for reliable time-range queries, we use the score range as a proxy: higher scores = more recent (at same importance level).
+
+For the initial implementation, we use a simpler approach: iterate all records for the project and filter by `last_accessed` timestamp from AccessTrackerMixin (which is set on creation and each access). This is correct for small-to-medium datasets (<10k records). If performance becomes an issue, we can add a dedicated DateTimeField.
+
+## Architectural Impact
+
+- **Modified module:** `tools/memory_search/__init__.py` — add `timeline()` function
+- **Modified module:** `tools/memory_search/cli.py` — add `timeline` subcommand
+- **New utility:** `agent/memory_retrieval.py` — add `get_memories_in_time_range()` helper
+- **Interface changes:** New public function `timeline()` in tools/memory_search
+- **Coupling:** No new coupling — uses existing Memory model and retrieval infrastructure
+- **Reversibility:** Fully reversible — additive changes only, no schema migrations
+
+## Appetite
+
+**Size:** Small
+
+**Team:** Solo dev
+
+**Interactions:**
+- Review rounds: 1
+
+Additive feature with no breaking changes. The timeline function is a read-only query over existing data.
+
+## Prerequisites
+
+None. Works with existing Memory model and data.
+
+## Tasks
+
+- [ ] Add `timeline()` function to `tools/memory_search/__init__.py`
+- [ ] Add `get_memories_in_time_range()` to `agent/memory_retrieval.py`
+- [ ] Add `timeline` subcommand to `tools/memory_search/cli.py`
+- [ ] Write tests for timeline functionality
+- [ ] Verify all existing tests still pass
+
+## No-Gos
+
+- No materialized daily-note files (go stale after consolidation)
+- No schema migrations or new model fields (use existing timestamp data)
+- No changes to the consolidation pipeline (separate concern)
+- No embedding/vector search dependency (that is #965)
+
+## Failure Path Test Strategy
+
+- Empty project key returns empty timeline
+- Invalid date range returns helpful error
+- Time range with no matching records returns empty list
+- Superseded records are filtered out (same as retrieval)
+
+## Test Impact
+
+No existing tests affected — this is a greenfield feature adding new functions and CLI commands to an existing module. Existing test_memory_search.py tests are unmodified.
+
+## Documentation
+
+- [ ] Add `timeline` command to CLAUDE.md quick reference table
+- [ ] Update `docs/features/subconscious-memory.md` with timeline query documentation
+
+## Update System
+
+No update system changes required — this feature is purely internal to the memory search tool. No new dependencies or config files.
+
+## Agent Integration
+
+No agent integration required — the timeline function is exposed through the existing `tools/memory_search` CLI module which is already available to agents. No MCP server changes needed.
+
+## Rabbit Holes
+
+- **Exact creation timestamps:** The Memory model has no explicit `created_at` field. Using `last_accessed` as a proxy works for "when was this record last touched" but not "when was it originally created." Adding a DateTimeField is deferred until there is a concrete need beyond this feature.
+- **Hierarchical summaries:** Daily -> weekly -> monthly digest consolidation is a separate pipeline concern. This feature provides the query surface; hierarchical summarization can be layered on top later via a reflection task.
+- **Performance at scale:** Iterating all records per project is fine for <10k records. If the dataset grows significantly, a dedicated sorted set index by creation time would be the right optimization.

--- a/docs/plans/worker_lifecycle_fixes.md
+++ b/docs/plans/worker_lifecycle_fixes.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: Complete
 type: bug
 appetite: Small
 owner: Valor

--- a/scripts/valor-service.sh
+++ b/scripts/valor-service.sh
@@ -638,15 +638,36 @@ status_worker() {
     local pid=$(get_worker_pid)
 
     if [ -n "$pid" ]; then
-        echo "Worker Status: RUNNING"
-        echo "PID: $pid"
-        echo "Uptime: $(ps -o etime= -p $pid 2>/dev/null | xargs)"
-        echo "Memory: $(ps -o rss= -p $pid 2>/dev/null | awk '{printf "%.1f MB", $1/1024}')"
+        # Check heartbeat freshness to detect zombie/hung processes
+        local HEARTBEAT_FILE="$PROJECT_DIR/data/last_worker_connected"
+        local HEARTBEAT_AGE=9999
+        local HEARTBEAT_THRESHOLD=360
+        if [ -f "$HEARTBEAT_FILE" ]; then
+            HEARTBEAT_AGE=$(python3 -c "import os,time; print(int(time.time()-os.path.getmtime('$HEARTBEAT_FILE')))" 2>/dev/null || echo 9999)
+        fi
+
+        if [ "$HEARTBEAT_AGE" -gt "$HEARTBEAT_THRESHOLD" ]; then
+            echo "Worker Status: STALE"
+            echo "PID: $pid (process exists but heartbeat is stale — worker may be hung)"
+            echo "Uptime: $(ps -o etime= -p $pid 2>/dev/null | xargs)"
+            echo "Heartbeat: ${HEARTBEAT_AGE}s ago (threshold: ${HEARTBEAT_THRESHOLD}s)"
+            echo "Memory: $(ps -o rss= -p $pid 2>/dev/null | awk '{printf "%.1f MB", $1/1024}')"
+        else
+            echo "Worker Status: RUNNING"
+            echo "PID: $pid"
+            echo "Uptime: $(ps -o etime= -p $pid 2>/dev/null | xargs)"
+            echo "Heartbeat: ${HEARTBEAT_AGE}s ago"
+            echo "Memory: $(ps -o rss= -p $pid 2>/dev/null | awk '{printf "%.1f MB", $1/1024}')"
+        fi
 
         if launchctl list | grep -q "$WORKER_PLIST_NAME"; then
             echo "Launchd: INSTALLED (auto-start enabled)"
         else
             echo "Launchd: NOT INSTALLED (manual start only)"
+        fi
+
+        if [ "$HEARTBEAT_AGE" -gt "$HEARTBEAT_THRESHOLD" ]; then
+            return 2
         fi
         return 0
     else

--- a/tests/integration/test_remote_update.py
+++ b/tests/integration/test_remote_update.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 import subprocess
+from datetime import UTC
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -160,10 +161,17 @@ class TestRestartFlag:
 
         assert _check_restart_flag() is False
 
+    def _fresh_timestamp(self):
+        """Return a flag content string with a timestamp from 5 minutes ago."""
+        from datetime import datetime, timedelta
+
+        ts = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
+        return f"{ts} 3 commit(s)"
+
     def test_check_restart_flag_returns_true_when_flag_exists_and_no_jobs(self):
         from agent.agent_session_queue import _RESTART_FLAG, _check_restart_flag
 
-        _RESTART_FLAG.write_text("2026-02-02T10:00:00Z 3 commit(s)")
+        _RESTART_FLAG.write_text(self._fresh_timestamp())
 
         with patch("agent.agent_session_queue.AgentSession") as mock_session:
             mock_session.query.filter.return_value = []
@@ -176,7 +184,7 @@ class TestRestartFlag:
             _check_restart_flag,
         )
 
-        _RESTART_FLAG.write_text("2026-02-02T10:00:00Z 1 commit(s)")
+        _RESTART_FLAG.write_text(self._fresh_timestamp())
 
         # Simulate an active worker
         mock_task = MagicMock()
@@ -213,6 +221,38 @@ class TestRestartFlag:
 
         assert not _RESTART_FLAG.exists()
         mock_kill.assert_called_once_with(os.getpid(), 15)  # SIGTERM = 15
+
+    def test_check_restart_flag_ignores_stale_flag(self):
+        """A flag older than 1 hour should be ignored and deleted."""
+        from datetime import datetime, timedelta
+
+        from agent.agent_session_queue import _RESTART_FLAG, _check_restart_flag
+
+        stale_ts = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
+        _RESTART_FLAG.write_text(f"{stale_ts} 5 commit(s)")
+
+        result = _check_restart_flag()
+        assert result is False
+        assert not _RESTART_FLAG.exists(), "Stale flag should be deleted"
+
+    def test_check_restart_flag_handles_malformed_flag_content(self):
+        """Malformed or empty flag content should not raise — returns False and deletes."""
+        from agent.agent_session_queue import _RESTART_FLAG, _check_restart_flag
+
+        # Empty content
+        _RESTART_FLAG.write_text("")
+        assert _check_restart_flag() is False
+        assert not _RESTART_FLAG.exists()
+
+        # Garbage content
+        _RESTART_FLAG.write_text("not-a-timestamp blah")
+        assert _check_restart_flag() is False
+        assert not _RESTART_FLAG.exists()
+
+        # Whitespace only
+        _RESTART_FLAG.write_text("   \n  ")
+        assert _check_restart_flag() is False
+        assert not _RESTART_FLAG.exists()
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- **Bug 1 fix**: `_check_restart_flag()` now parses the embedded ISO timestamp and ignores flags older than 1 hour, preventing stale flags from triggering worker self-destruct on machines where no bridge consumes the flag. Malformed/empty flag content is safely handled (logged + deleted).
- **Bug 2 fix**: `status_worker()` in `valor-service.sh` now reads the `data/last_worker_connected` heartbeat file mtime. When heartbeat age exceeds 360s (matching the dashboard threshold), status reports `STALE` with exit code 2 instead of `RUNNING`, so zombie PIDs no longer mask a hung worker.
- Tests updated: existing `TestRestartFlag` tests use fresh timestamps; new tests for stale flag TTL and malformed content added.
- Docs updated: `docs/features/bridge-self-healing.md` documents restart flag TTL and STALE worker status.

Closes #984

## Test plan
- [x] `pytest tests/integration/test_remote_update.py::TestRestartFlag -v` — 8/8 pass
- [x] Full unit suite — 4130 passed (30 pre-existing failures in unrelated LLM classifier tests)
- [ ] Manual: write a stale flag (`echo "2020-01-01T00:00:00Z 1 commit(s)" > data/restart-requested`) and verify worker ignores it
- [ ] Manual: stop worker, wait 6 min, run `./scripts/valor-service.sh worker-status` and verify STALE output