### PR TITLE
fix: PM orchestration audit hotfixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,11 @@ USE_API_BILLING=false
 # Minimum value is 1 (enforced by the worker). Default: 3
 # MAX_CONCURRENT_SESSIONS=3
 
+# Maximum number of slugged dev sessions that can execute simultaneously.
+# Must be <= MAX_CONCURRENT_SESSIONS. Default 1 preserves sequential behavior.
+# Minimum value is 1 (enforced by the worker). Default: 1
+# MAX_CONCURRENT_DEV_SESSIONS=1
+
 # Dev session execution harness.
 # =============================================================================
 # API Keys

--- a/.env.example
+++ b/.env.example
@@ -51,7 +51,6 @@ USE_API_BILLING=false
 # Minimum value is 1 (enforced by the worker). Default: 1
 # MAX_CONCURRENT_DEV_SESSIONS=1
 
-# Dev session execution harness.
 # =============================================================================
 # API Keys
 # =============================================================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,9 +290,7 @@ Standalone Worker (python -m worker) → Sole session execution engine
               (worker/__main__.py)         → Startup: index rebuild → recovery → orphan cleanup
                                            → Executes PM session (AgentSession role=pm, read-only)
                                                → PM creates Dev session via valor_session CLI
-                                                   → Worker routes Dev session by DEV_SESSION_HARNESS:
-                                                       sdk (default): Claude Agent SDK → Claude API
-                                                       claude-cli: claude -p subprocess → Claude API
+                                                   → Worker executes Dev session via CLI harness (claude -p → Claude API)
                                                    → _handle_dev_session_completion() → steers PM
                                            → Uses OutputHandler protocol (agent/output_handler.py)
                                            → TelegramRelayOutputHandler writes to Redis outbox

--- a/docs/features/pm-dev-session-architecture.md
+++ b/docs/features/pm-dev-session-architecture.md
@@ -385,6 +385,8 @@ The PM session can push steering messages to its running child Dev sessions, ena
 
 The PM invokes `scripts/steer_child.py` via bash with the child's session ID and a steering message. The script validates the parent-child relationship (via `parent_session_id`) and pushes to the child's Redis steering queue. The child's watchdog hook picks up the message on the next tool call.
 
+> **Status (2026-04-17):** The mid-execution hook consumer is not yet implemented. Messages written via `steer_child.py` are only consumed at session pickup and completion — they are silently dropped if the child session is already running. See issue TBD for consolidation plans.
+
 ```bash
 # Steer a running child
 python scripts/steer_child.py --session-id <child_id> --message "focus on tests" --parent-id <parent_id>

--- a/tests/unit/test_pm_persona_guards.py
+++ b/tests/unit/test_pm_persona_guards.py
@@ -1,4 +1,6 @@
-"""Tests for PM persona hardening — completion guards, child session timeout, pipeline stage assertion.
+"""Tests for PM persona hardening.
+
+Covers completion guards, child session timeout, and pipeline stage assertion.
 
 Verifies that the PM persona file (config/personas/project-manager.md) contains the
 three self-monitoring guard sections required by issue #1007:

--- a/tests/unit/test_recovery_respawn_safety.py
+++ b/tests/unit/test_recovery_respawn_safety.py
@@ -329,7 +329,7 @@ class TestStartupRecoverySkipsTerminal:
         with (
             patch("agent.agent_session_queue.AgentSession") as mock_as,
             patch("agent.agent_session_queue.time") as mock_time,
-            patch("models.session_lifecycle.finalize_session") as mock_finalize,
+            patch("models.session_lifecycle.finalize_session"),
             patch("models.session_lifecycle.update_session") as mock_update,
         ):
             mock_time.time.return_value = time.time()


### PR DESCRIPTION
## Summary

Three independent doc/config fixes from PM orchestration integration audit:

- **Hotfix 1**: Add `MAX_CONCURRENT_DEV_SESSIONS` to `.env.example` — env var was read in `worker/__main__.py:187` but absent from the config template, hiding it from fresh deploys
- **Hotfix 2**: Remove stale `DEV_SESSION_HARNESS` routing description from `CLAUDE.md` — eliminated in #912; all dev sessions now unconditionally use the CLI harness (`claude -p`)
- **Hotfix 3**: Add inline status note to `docs/features/pm-dev-session-architecture.md` flagging that the "watchdog hook picks up mid-execution steering" claim is not yet implemented — messages via `steer_child.py` are silently dropped during a running child session

## Test plan

- [ ] No new tests required — doc/config changes only
- [ ] Verify `.env.example` now lists `MAX_CONCURRENT_DEV_SESSIONS` adjacent to `MAX_CONCURRENT_SESSIONS`
- [ ] Verify `CLAUDE.md` system architecture diagram no longer references `DEV_SESSION_HARNESS`
- [ ] Verify `pm-dev-session-architecture.md` steering section has the status admonition