### PR TITLE
fix(#1018): eliminate silent drop in CLI-harness steering

### DIFF
--- a/agent/health_check.py
+++ b/agent/health_check.py
@@ -411,6 +411,15 @@ async def _handle_steering(session_id: str) -> dict[str, Any] | None:
 
     Returns a hook result dict if steering action was taken, None otherwise.
     This runs on EVERY tool call (lightweight Redis LPOP).
+
+    Delivery paths:
+    - SDK-harness sessions: messages are injected mid-turn via client.interrupt()+query().
+    - CLI-harness sessions (no active SDK client): non-abort messages are written to
+      AgentSession.queued_steering_messages (turn-boundary inbox). The worker delivers
+      them at the next turn boundary. If the session cannot be found in the model,
+      falls back to re-pushing to the Redis list with a WARNING log.
+    - Abort signals: always delivered via hookSpecificOutput additionalContext regardless
+      of harness type.
     """
     from agent.steering import pop_all_steering_messages
 
@@ -462,11 +471,42 @@ async def _handle_steering(session_id: str) -> dict[str, Any] | None:
             )
             logger.info(f"[steering] Successfully injected into session {session_id}")
         else:
-            logger.warning(
-                f"[steering] No active client for session {session_id}, "
-                f"re-pushing messages for next session"
-            )
-            _repush_messages(session_id, messages)
+            # No active SDK client (CLI-harness session or SDK client not yet registered).
+            # For non-abort messages, write to the turn-boundary inbox instead of
+            # re-pushing to the Redis list (which would never be consumed).
+            non_abort = [m for m in messages if not m.get("is_abort")]
+            abort_msgs = [m for m in messages if m.get("is_abort")]
+
+            if non_abort:
+                try:
+                    from models.agent_session import AgentSession
+
+                    sessions = list(AgentSession.query.filter(session_id=session_id))
+                    if sessions:
+                        agent_session = sessions[0]
+                        logger.warning(
+                            f"[steering] No active client for {session_id} (CLI harness?); "
+                            f"writing to turn-boundary inbox instead"
+                        )
+                        for msg in non_abort:
+                            agent_session.push_steering_message(msg.get("text", ""))
+                    else:
+                        logger.warning(
+                            f"[steering] No active client and session {session_id} not found in "
+                            f"model — re-pushing {len(non_abort)} message(s) to Redis list"
+                        )
+                        _repush_messages(session_id, non_abort)
+                except Exception as e:
+                    logger.warning(
+                        f"[steering] No active client for {session_id}; model write failed "
+                        f"({e}) — re-pushing messages to Redis list"
+                    )
+                    _repush_messages(session_id, non_abort)
+
+            if abort_msgs:
+                # Abort messages stay in the Redis list — they are re-pushed so the
+                # watchdog can deliver them via additionalContext on the next tool call.
+                _repush_messages(session_id, abort_msgs)
     except Exception as e:
         logger.error(f"[steering] Failed to inject message: {e} — re-pushing to preserve")
         # Re-push so messages aren't lost on injection failure

--- a/docs/features/mid-session-steering.md
+++ b/docs/features/mid-session-steering.md
@@ -1,5 +1,7 @@
 # Mid-Session Steering: Real-Time Course Correction for Running Agents
 
+**Scope:** Telegram bridge reply-thread steering via Redis list (`steering:{session_id}`). For PM→child steering, see `session-steering.md`.
+
 ## Overview
 
 Mid-session steering allows a user to send a reply-to message in Telegram that gets injected into a currently running agent session, enabling real-time course correction without waiting for the agent to finish. This is distinct from creating a new session or resuming a completed session.

--- a/docs/features/pm-dev-session-architecture.md
+++ b/docs/features/pm-dev-session-architecture.md
@@ -383,7 +383,12 @@ The PM session can push steering messages to its running child Dev sessions, ena
 
 ### Mechanism
 
-The PM invokes `scripts/steer_child.py` via bash with the child's session ID and a steering message. The script validates the parent-child relationship (via `parent_session_id`) and pushes to the child's Redis steering queue. The child's watchdog hook picks up the message on the next tool call.
+The PM invokes `scripts/steer_child.py` via bash with the child's session ID and a steering message. The script validates the parent-child relationship (via `parent_session_id`) and writes to the child's turn-boundary inbox (`AgentSession.queued_steering_messages`). The worker delivers the message at the next turn boundary.
+
+**Delivery paths by harness type:**
+- **CLI-harness sessions** (default): `steer_child.py` calls `steer_session()` which writes to `queued_steering_messages`. The worker injects the message as user input at the next turn boundary. There is no mid-turn injection — the Dev session sees the message at most one turn late.
+- **Abort signals** (`--abort`): always use the Redis list (`steering:{session_id}`) regardless of harness type. The watchdog hook delivers these immediately via `additionalContext` injection.
+- **SDK-harness sessions** (legacy): both the turn-boundary inbox and the watchdog hook's mid-turn injection path are available, but all Dev sessions now default to CLI harness.
 
 ```bash
 # Steer a running child
@@ -396,7 +401,7 @@ python scripts/steer_child.py --session-id <child_id> --message "stop" --parent-
 python scripts/steer_child.py --list --parent-id <parent_id>
 ```
 
-This reuses the same steering infrastructure (Redis queue, watchdog consumption) as Telegram reply-thread steering. See [Steering Queue](steering-queue.md) for the full steering architecture.
+See [Session Steering](session-steering.md) for the turn-boundary inbox architecture and [Steering Queue](steering-queue.md) for the Redis list / mid-turn injection path.
 
 ## Q&A Formatting (Prose vs Structured)
 

--- a/docs/features/session-steering.md
+++ b/docs/features/session-steering.md
@@ -1,5 +1,7 @@
 # Session Steering
 
+**Scope:** Turn-boundary inbox (`AgentSession.queued_steering_messages`) consumed by the worker executor. Used by `valor-session steer` and `scripts/steer_child.py`.
+
 External steering for `AgentSession` via `queued_steering_messages`. Any process — the PM, a CLI user, another agent — can write messages to a running session's inbox. The worker injects them at the next turn boundary.
 
 ## Problem

--- a/docs/features/steering-queue.md
+++ b/docs/features/steering-queue.md
@@ -8,6 +8,8 @@ tracking: https://github.com/tomcounsell/ai/issues/23
 
 # Steering Queue: Mid-Execution Course Correction via Reply Threads
 
+**Scope:** Redis list steering queue design and bridge coalescing. SDK-harness mid-turn injection (legacy/secondary path). For PM→child steering, see `session-steering.md`.
+
 ## Problem
 
 When Valor is executing a long task (10-30+ minutes), the supervisor cannot course-correct mid-execution. Messages sent during a running session either:

--- a/scripts/steer_child.py
+++ b/scripts/steer_child.py
@@ -111,17 +111,35 @@ def _steer_child(session_id: str, message: str, parent_id: str, abort: bool) -> 
         )
         return 1
 
-    # Push the steering message
-    push_steering_message(
-        session_id=session_id,
-        text=message,
-        sender="pm",
-        is_abort=abort,
-    )
-
     preview = message[:60] + "..." if len(message) > 60 else message
-    action = "Aborted" if abort else "Steered"
-    print(f"{action} {session_id}: {preview}")
+
+    if abort:
+        # Abort signals use the Redis list path — the watchdog hook delivers these
+        # immediately (even for CLI-harness) via additionalContext injection.
+        push_steering_message(
+            session_id=session_id,
+            text=message,
+            sender="pm",
+            is_abort=True,
+        )
+        print(f"Aborted {session_id} (via Redis abort queue): {preview}")
+    else:
+        # Non-abort messages use the turn-boundary inbox (queued_steering_messages).
+        # This works for both SDK-harness and CLI-harness Dev sessions.
+        # steer_session() looks up by session_id (the Popoto field), not agent_session_id.
+        from agent.agent_session_queue import steer_session
+
+        target_session_id = child.session_id or session_id
+        result = steer_session(session_id=target_session_id, message=message)
+        if not result.get("success"):
+            error = result.get("error", "unknown error")
+            print(
+                f"Error: failed to steer session '{session_id}': {error}",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"Steered {session_id} (via turn-boundary inbox): {preview}")
+
     return 0
 
 

--- a/tests/integration/test_steering.py
+++ b/tests/integration/test_steering.py
@@ -596,11 +596,26 @@ class TestWatchdogSteering:
         assert "STEERING MESSAGE" in query_arg
 
     @pytest.mark.asyncio
-    async def test_watchdog_handles_missing_client(self):
-        """If no active client, messages should be re-pushed."""
-        from agent.health_check import _handle_steering
+    async def test_watchdog_handles_missing_client_session_found(self):
+        """If no active client but session exists in DB, message lands in queued_steering_messages.
 
-        session_id = "test_watchdog_noclient"
+        Turn-boundary inbox (not Redis re-push) when the model lookup succeeds.
+        """
+        from datetime import UTC, datetime
+
+        from agent.health_check import _handle_steering
+        from models.agent_session import AgentSession
+
+        session_id = "test_watchdog_noclient_found"
+        session = AgentSession(
+            session_id=session_id,
+            project_key="test-steer",
+            status="running",
+            message_text="test task",
+            created_at=datetime.now(tz=UTC),
+        )
+        session.save()
+
         push_steering_message(session_id, "focus on OAuth", "Tom")
 
         with patch("agent.sdk_client.get_active_client", return_value=None):
@@ -609,10 +624,79 @@ class TestWatchdogSteering:
         assert result is not None
         assert result["continue_"] is True
 
-        # Message should have been re-pushed
+        # Message should land in queued_steering_messages, NOT re-pushed to Redis list
+        msg = pop_steering_message(session_id)
+        assert msg is None, "Message should NOT have been re-pushed to Redis list"
+
+        # Verify it landed in the model's turn-boundary inbox
+        refreshed = list(AgentSession.query.filter(session_id=session_id))[0]
+        assert len(refreshed.queued_steering_messages) >= 1
+        assert "focus on OAuth" in refreshed.queued_steering_messages[0]
+
+    @pytest.mark.asyncio
+    async def test_watchdog_handles_missing_client_session_not_found(self):
+        """If no active client and session not in DB, message is re-pushed to Redis list."""
+        from agent.health_check import _handle_steering
+
+        session_id = "test_watchdog_noclient_notfound"
+        push_steering_message(session_id, "fallback message", "Tom")
+
+        with patch("agent.sdk_client.get_active_client", return_value=None):
+            result = await _handle_steering(session_id)
+
+        assert result is not None
+        assert result["continue_"] is True
+
+        # Session not in DB: message should be re-pushed to Redis list (existing fallback)
         msg = pop_steering_message(session_id)
         assert msg is not None
-        assert msg["text"] == "focus on OAuth"
+        assert msg["text"] == "fallback message"
+
+    @pytest.mark.asyncio
+    async def test_watchdog_fallback_to_repush_when_model_write_fails(self):
+        """If no active client and model write raises, messages are re-pushed to Redis list."""
+        from datetime import UTC, datetime
+
+        from agent.health_check import _handle_steering
+        from models.agent_session import AgentSession
+
+        session_id = "test_watchdog_model_write_fail"
+        session = AgentSession(
+            session_id=session_id,
+            project_key="test-steer",
+            status="running",
+            message_text="test task",
+            created_at=datetime.now(tz=UTC),
+        )
+        session.save()
+
+        push_steering_message(session_id, "update the tests", "Tom")
+
+        mock_session = session
+        original_push = mock_session.push_steering_message
+
+        def raise_on_push(msg):
+            raise RuntimeError("Redis write failed")
+
+        mock_session.push_steering_message = raise_on_push
+
+        with patch("agent.sdk_client.get_active_client", return_value=None):
+            with patch(
+                "models.agent_session.AgentSession.query",
+            ) as mock_query:
+                mock_query.filter.return_value = [mock_session]
+                result = await _handle_steering(session_id)
+
+        assert result is not None
+        assert result["continue_"] is True
+
+        # After model write failure, message should be re-pushed to Redis list
+        msg = pop_steering_message(session_id)
+        assert msg is not None
+        assert msg["text"] == "update the tests"
+
+        # Restore original method
+        mock_session.push_steering_message = original_push
 
     @pytest.mark.asyncio
     async def test_watchdog_repushes_on_injection_failure(self):
@@ -1122,3 +1206,153 @@ class TestResolveRootSessionId:
         assert "RESUME_REPLY_CHAIN_FAIL" in content, (
             "RESUME_REPLY_CHAIN_FAIL log tag missing — failure path invisible in logs"
         )
+
+
+class TestSteerChildDelivery:
+    """Integration tests for steer_child.py → CLI-harness delivery path.
+
+    These tests use real AgentSession objects (no mock of get_active_client or
+    push_steering_message) to verify the end-to-end steering delivery path.
+    """
+
+    def _create_dev_session(self, parent_agent_id: str, session_id: str, status: str = "running"):
+        """Create a Dev AgentSession with a parent-child relationship.
+
+        session_id: the Popoto session_id field (used by steer_session() for lookup).
+        Returns the saved session — use session.agent_session_id as the ID for _steer_child().
+        """
+        from datetime import UTC, datetime
+
+        from models.agent_session import AgentSession
+
+        session = AgentSession(
+            session_id=session_id,
+            project_key="test-steer-child",
+            status=status,
+            session_type="dev",
+            parent_agent_session_id=parent_agent_id,
+            message_text="dev task",
+            created_at=datetime.now(tz=UTC),
+        )
+        session.save()
+        return session
+
+    def _create_pm_session(self, session_id: str):
+        """Create a PM AgentSession. Returns the saved session."""
+        from datetime import UTC, datetime
+
+        from models.agent_session import AgentSession
+
+        session = AgentSession(
+            session_id=session_id,
+            project_key="test-steer-child",
+            status="running",
+            session_type="pm",
+            message_text="pm task",
+            created_at=datetime.now(tz=UTC),
+        )
+        session.save()
+        return session
+
+    def test_steer_child_cli_harness_delivery(self):
+        """_steer_child() writes message to turn-boundary inbox (queued_steering_messages)."""
+        from models.agent_session import AgentSession
+        from scripts.steer_child import _steer_child
+
+        parent = self._create_pm_session("tg_test_parent_p001")
+        child = self._create_dev_session(parent.agent_session_id, "tg_test_child_c001")
+
+        exit_code = _steer_child(
+            session_id=child.agent_session_id,
+            message="focus on error handling",
+            parent_id=parent.agent_session_id,
+            abort=False,
+        )
+
+        assert exit_code == 0
+
+        # Verify the message landed in queued_steering_messages
+        sessions = list(AgentSession.query.filter(id=child.agent_session_id))
+        assert sessions, "Child session not found after steering"
+        refreshed = sessions[0]
+        assert len(refreshed.queued_steering_messages) >= 1
+        assert "focus on error handling" in refreshed.queued_steering_messages[0]
+
+        # Verify the Redis list was NOT used (turn-boundary path only)
+        msg = pop_steering_message(child.session_id)
+        assert msg is None, "Message should NOT have gone to Redis steering list"
+
+    def test_steer_child_abort_uses_redis_list(self):
+        """_steer_child() with abort=True writes to Redis list, not turn-boundary inbox."""
+        from models.agent_session import AgentSession
+        from scripts.steer_child import _steer_child
+
+        parent = self._create_pm_session("tg_test_parent_p002")
+        child = self._create_dev_session(parent.agent_session_id, "tg_test_child_c002")
+
+        exit_code = _steer_child(
+            session_id=child.agent_session_id,
+            message="stop",
+            parent_id=parent.agent_session_id,
+            abort=True,
+        )
+
+        assert exit_code == 0
+
+        # Abort message should be on the Redis list with is_abort=True
+        # Abort path uses session_id (Redis key) from push_steering_message
+        msg = pop_steering_message(child.agent_session_id)
+        assert msg is not None, "Abort message should be in Redis steering list"
+        assert msg["is_abort"] is True
+        assert "stop" in msg["text"]
+
+        # queued_steering_messages should be empty (abort does NOT use turn-boundary inbox)
+        sessions = list(AgentSession.query.filter(id=child.agent_session_id))
+        refreshed = sessions[0]
+        inbox = refreshed.queued_steering_messages or []
+        assert len(inbox) == 0, "Abort messages must NOT appear in queued_steering_messages"
+
+    def test_steer_child_terminal_session_exits_nonzero(self):
+        """_steer_child() exits non-zero when session is in a terminal status."""
+        from scripts.steer_child import _steer_child
+
+        parent = self._create_pm_session("tg_test_parent_p003")
+        child = self._create_dev_session(
+            parent.agent_session_id, "tg_test_child_c003", status="completed"
+        )
+
+        exit_code = _steer_child(
+            session_id=child.agent_session_id,
+            message="too late",
+            parent_id=parent.agent_session_id,
+            abort=False,
+        )
+
+        assert exit_code == 1
+
+    def test_steer_child_steer_session_failure_exits_nonzero(self, capsys):
+        """_steer_child() exits non-zero and prints error when steer_session fails."""
+        from scripts.steer_child import _steer_child
+
+        parent = self._create_pm_session("tg_test_parent_p004")
+        child = self._create_dev_session(parent.agent_session_id, "tg_test_child_c004")
+
+        # Patch at the source module — _steer_child imports steer_session lazily
+        with patch(
+            "agent.agent_session_queue.steer_session",
+            return_value={
+                "success": False,
+                "session_id": child.session_id,
+                "error": "mock failure",
+            },
+        ):
+            exit_code = _steer_child(
+                session_id=child.agent_session_id,
+                message="will fail",
+                parent_id=parent.agent_session_id,
+                abort=False,
+            )
+
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        assert "mock failure" in captured.err


### PR DESCRIPTION
## Summary
- `scripts/steer_child.py`: non-abort messages now call `steer_session()` (writes to `AgentSession.queued_steering_messages` turn-boundary inbox) instead of `push_steering_message()` — abort messages continue using the Redis list path
- `agent/health_check.py` `_handle_steering()`: no-active-client branch now writes to `AgentSession.queued_steering_messages` when session is found, falls back to re-push on failure
- 4 new integration tests in `tests/integration/test_steering.py`; 2 existing tests updated
- Doc scope headers added to `mid-session-steering.md`, `session-steering.md`, `steering-queue.md`; `pm-dev-session-architecture.md` updated to accurately describe CLI-harness vs SDK-harness delivery paths

Closes #1018

## Test plan
- [ ] `pytest tests/integration/test_steering.py -x -q` — 59 passed
- [ ] `python -m ruff check .` — clean
- [ ] `grep -n "steer_session" scripts/steer_child.py` — shows import and call
- [ ] `grep -n "queued_steering_messages" agent/health_check.py` — shows fallback write