### PR TITLE
feat(health-check): promote last_stdout_at to Tier-1 kill signal (#1046)

### DIFF
--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -141,8 +141,17 @@ HEARTBEAT_WRITE_INTERVAL = 60
 # age is strictly less than this window is considered fresh. 90s provides a
 # 30s grace margin over the 60s write cadence.
 HEARTBEAT_FRESHNESS_WINDOW = 90
-# Freshness window for the Tier 2 recent-stdout reprieve gate.
-STDOUT_FRESHNESS_WINDOW = 90
+# Freshness window (seconds) for the stdout-stale Tier 1 kill signal (#1046)
+# and the Tier 2 recent-stdout reprieve gate. A session whose last_stdout_at
+# age exceeds this window is flagged by Tier 1 even when both heartbeats are
+# fresh. 600s (10 min) accommodates long tool calls while bounding the
+# alive-but-silent failure mode. Env-tunable via STDOUT_FRESHNESS_WINDOW_SECS.
+STDOUT_FRESHNESS_WINDOW = int(os.environ.get("STDOUT_FRESHNESS_WINDOW_SECS", 600))
+# Deadline (seconds) after started_at before a session that has NEVER produced
+# stdout is also flagged by Tier 1. Preserves warmup tolerance (#1036) while
+# bounding the "silent from the start" case. Env-tunable via
+# FIRST_STDOUT_DEADLINE_SECS.
+FIRST_STDOUT_DEADLINE = int(os.environ.get("FIRST_STDOUT_DEADLINE_SECS", 300))
 # Max health-check kills before a session is finalized as `failed` instead
 # of being re-queued to `pending`. Ensures sessions always reach a terminal
 # status within ~10 minutes of going non-progressing, avoiding the
@@ -153,6 +162,13 @@ MAX_RECOVERY_ATTEMPTS = 2
 # health-check tick budget tight while still giving the cancellation a
 # moment to complete.
 TASK_CANCEL_TIMEOUT = 0.25
+
+# Module-level variable set by _has_progress() before returning False to
+# attribute the reason for flagging without changing the return type (#1046).
+# The health-check loop reads this immediately after _has_progress() returns
+# False to emit the tier1_flagged_stdout_stale counter. Reset to "" at the
+# top of _has_progress() on every call to avoid stale attribution.
+_last_progress_reason: str = ""
 
 
 # Fields to extract from AgentSession for delete-and-recreate pattern.
@@ -1576,6 +1592,30 @@ def _has_progress(entry: AgentSession) -> bool:
     (killing a working session). The kill trigger in the health check
     requires BOTH heartbeats to be stale before even evaluating Tier 2.
 
+    Tier 1 extension — stdout-stale kill signal (#1046):
+    Even when both heartbeats are fresh, a session whose ``last_stdout_at``
+    is stale beyond ``STDOUT_FRESHNESS_WINDOW`` (600s) is flagged by Tier 1.
+    This catches the alive-but-silent failure mode where a ``claude -p``
+    subprocess keeps emitting heartbeats but produces no stdout for 10+ min.
+
+    For sessions that have never produced stdout (``last_stdout_at is None``),
+    ``FIRST_STDOUT_DEADLINE`` (300s) applies: if ``started_at`` is older than
+    the deadline, Tier 1 flags the session. This preserves warmup tolerance
+    (#1036) while bounding the "silent from the start" case.
+
+    When a live-but-silent subprocess is flagged by Tier 1, Tier 2 gate (c)
+    "alive" will reprieve it — the subprocess is still running. The session
+    remains monitored and is only killed once the subprocess eventually goes
+    non-alive or the absolute timeout fires. This is intentional: an alive
+    subprocess should not be killed prematurely; the reprieve loop bounds kill
+    latency to ``STDOUT_FRESHNESS_WINDOW + one health-check tick`` after the
+    process goes non-alive.
+
+    The reason for the Tier 1 flag is stored in the module-level
+    ``_last_progress_reason`` variable (set before returning False) so the
+    health-check loop can emit a distinct counter without changing the return
+    type. The variable is reset to "" at the top of every call.
+
     Own-progress signals (original behavior, preserved):
     - ``claude_session_uuid`` — populated on SDK authentication.
     - ``log_path`` — written on the first log entry.
@@ -1592,17 +1632,42 @@ def _has_progress(entry: AgentSession) -> bool:
 
     Used by ``_agent_session_health_check`` to distinguish stuck slugless dev
     sessions (worker_alive via a co-running PM, but no progress) from healthy
-    long-warmup BUILD sessions. See issues #944, #963, and #1036.
+    long-warmup BUILD sessions. See issues #944, #963, #1036, and #1046.
     """
+    global _last_progress_reason
+    _last_progress_reason = ""
+
     # Tier 1: dual-heartbeat OR check (#1036). Fresh on either signal → progress.
     now_utc = datetime.now(tz=UTC)
+    any_heartbeat_fresh = False
     for hb_attr in ("last_heartbeat_at", "last_sdk_heartbeat_at"):
         hb = getattr(entry, hb_attr, None)
         if isinstance(hb, datetime):
             hb_aware = hb if hb.tzinfo else hb.replace(tzinfo=UTC)
             age_s = (now_utc - hb_aware).total_seconds()
             if age_s < HEARTBEAT_FRESHNESS_WINDOW:
-                return True
+                any_heartbeat_fresh = True
+                break
+
+    if any_heartbeat_fresh:
+        # Tier 1 extension: stdout-stale kill signal (#1046).
+        # Even with fresh heartbeats, flag if stdout is stale or overdue.
+        lso = getattr(entry, "last_stdout_at", None)
+        if isinstance(lso, datetime):
+            lso_aware = lso if lso.tzinfo else lso.replace(tzinfo=UTC)
+            if (now_utc - lso_aware).total_seconds() >= STDOUT_FRESHNESS_WINDOW:
+                _last_progress_reason = "stdout_stale"
+                return False  # stdout stale; Tier 1 flags despite fresh heartbeats
+        elif lso is None:
+            # No stdout yet — apply FIRST_STDOUT_DEADLINE relative to started_at.
+            started = getattr(entry, "started_at", None)
+            if started is not None:
+                started_aware = started if started.tzinfo else started.replace(tzinfo=UTC)
+                if (now_utc - started_aware).total_seconds() >= FIRST_STDOUT_DEADLINE:
+                    _last_progress_reason = "first_stdout_deadline"
+                    return False  # never produced stdout within deadline; flag
+        return True
+
     # Own-progress fields (original behavior, preserves #944 / #963 invariants).
     if (entry.turn_count or 0) > 0:
         return True
@@ -1871,6 +1936,22 @@ async def _agent_session_health_check() -> None:
                     except Exception as _m_err:
                         logger.debug("[session-health] tier1_flagged counter failed: %s", _m_err)
 
+                    # Emit stdout-stale counter when the flag came from stdout,
+                    # not from heartbeat staleness (#1046). _last_progress_reason
+                    # is set by _has_progress() before returning False.
+                    if _last_progress_reason in ("stdout_stale", "first_stdout_deadline"):
+                        try:
+                            from popoto.redis_db import POPOTO_REDIS_DB as _MR
+
+                            _MR.incr(
+                                f"{entry.project_key}:session-health:tier1_flagged_stdout_stale"
+                            )
+                        except Exception as _m_err:
+                            logger.debug(
+                                "[session-health] tier1_flagged_stdout_stale counter failed: %s",
+                                _m_err,
+                            )
+
                     reprieve = _tier2_reprieve_signal(handle, entry)
                     if reprieve is not None:
                         # Activity-positive: do NOT kill, do NOT increment recovery_attempts.
@@ -1889,7 +1970,10 @@ async def _agent_session_health_check() -> None:
                             entry.save(update_fields=["reprieve_count"])
                         except Exception as _rc_err:
                             logger.debug("[session-health] reprieve_count save failed: %s", _rc_err)
-                        logger.info(
+                        # Escalate log level after 3 reprieves to alert operators
+                        # that a session may be alive-but-silent indefinitely (#1046 C2).
+                        log_fn = logger.warning if (entry.reprieve_count or 0) >= 3 else logger.info
+                        log_fn(
                             "[session-health] Tier 2 reprieve (%s) for session %s — "
                             "skipping kill (reprieve_count=%s)",
                             reprieve,

--- a/docs/features/bridge-self-healing.md
+++ b/docs/features/bridge-self-healing.md
@@ -377,9 +377,9 @@ tail -f logs/worker_watchdog.log
 The periodic `_agent_session_health_check` (every 5 minutes) decides whether a
 long-running session is making progress. To minimize **false-negatives**
 (killing a working session) while still reaping genuinely wedged sessions, the
-detector uses two independent tiers. (Issue #1036.)
+detector uses two independent tiers. (Issues #1036 and #1046.)
 
-### Tier 1 — dual heartbeat
+### Tier 1 — dual heartbeat + stdout-stale kill signal
 
 Two independent 60-second writers update separate AgentSession fields:
 
@@ -389,10 +389,45 @@ Two independent 60-second writers update separate AgentSession fields:
 | `last_sdk_heartbeat_at` | Messenger-layer `BackgroundTask._watchdog` via `on_heartbeat_tick` callback | Every 60s while SDK subprocess runs |
 
 `_has_progress()` returns `True` if **either** heartbeat is within
-`HEARTBEAT_FRESHNESS_WINDOW` (90s). Tier 1 flags a session as potentially stuck
-only when **both** heartbeats are stale — this tolerates single-writer failures
-(e.g. event loop starved such that the queue heartbeat loop skips a beat, while
-the messenger watchdog keeps ticking, or vice versa).
+`HEARTBEAT_FRESHNESS_WINDOW` (90s) **and** stdout is fresh. Tier 1 flags a
+session as potentially stuck when **both** heartbeats are stale, OR when both
+heartbeats are fresh but stdout has been absent for too long (see below).
+
+**Stdout-stale kill signal (#1046):** The `_has_progress()` function includes a
+Tier 1 extension to catch the **alive-but-silent failure mode**: a `claude -p`
+subprocess can emit heartbeats every 60s (appearing healthy) yet produce zero
+stdout for hours — e.g. when the Claude API hangs or an MCP tool blocks. Even
+with both heartbeats fresh, `_has_progress()` returns `False` when:
+
+1. **`last_stdout_at` is set and stale** — `(now - last_stdout_at) >=
+   STDOUT_FRESHNESS_WINDOW` (600s = 10 min). The session is flagged even with
+   fresh heartbeats; Tier 2 gate (c) "alive" will typically reprieve it while
+   the subprocess is still running. Once the process goes non-alive, all Tier 2
+   gates fail and the kill path executes.
+
+2. **`last_stdout_at` is None** (session never produced stdout) **and `started_at`
+   is older than `FIRST_STDOUT_DEADLINE`** (300s = 5 min) — the session has not
+   emitted any stdout for 5+ minutes of runtime. This preserves warmup tolerance
+   from #1036 (young sessions with no stdout are fine) while bounding the
+   "silent from the start" failure case.
+
+**Constants** (both env-tunable):
+
+| Constant | Default | Env var | Purpose |
+|----------|---------|---------|---------|
+| `STDOUT_FRESHNESS_WINDOW` | 600s | `STDOUT_FRESHNESS_WINDOW_SECS` | Tier 1 stdout-stale threshold; also Tier 2 gate (e) reprieve window |
+| `FIRST_STDOUT_DEADLINE` | 300s | `FIRST_STDOUT_DEADLINE_SECS` | Tier 1 deadline for sessions that have never produced stdout |
+
+**Reprieve behavior for alive-but-silent sessions:** When Tier 1 stdout-stale
+fires, `_tier2_reprieve_signal()` is called. Gate (c) "alive" will reprieve the
+session as long as the subprocess is running — this is intentional; a running
+process should not be killed prematurely. The actual kill latency for a hung-
+but-alive process is bounded to `STDOUT_FRESHNESS_WINDOW + one health-check tick`
+after the process eventually goes non-alive or the absolute session timeout fires.
+
+**Operator alert:** After 3 Tier 2 reprieves, the reprieve log message is
+escalated from `INFO` to `WARNING`, signaling that the session may be in an
+indefinite alive-but-silent reprieve loop.
 
 ### Tier 2 — activity-positive reprieve gates
 
@@ -403,7 +438,7 @@ which evaluates three OS-level liveness checks via `psutil`:
 |------|-------|--------|
 | (c) alive    | `psutil.Process(pid).status()` not in `{zombie, dead, stopped}` | `"alive"` |
 | (d) children | `psutil.Process(pid).children()` non-empty (tool execution active) | `"children"` (preferred) |
-| (e) stdout   | `last_stdout_at` within `STDOUT_FRESHNESS_WINDOW` (90s) | `"stdout"` |
+| (e) stdout   | `last_stdout_at` within `STDOUT_FRESHNESS_WINDOW` (600s) | `"stdout"` |
 
 Any **one** passing gate reprieves the kill. The reprieve signal is logged and
 `reprieve_count` on the AgentSession is incremented for post-hoc analysis.
@@ -451,9 +486,15 @@ behavior before enabling kills during rollout.
 
 Redis counters keyed by `<project_key>:session-health:`:
 
-* `tier1_flagged_total` — every time both heartbeats were stale.
+* `tier1_flagged_total` — every time both heartbeats were stale (heartbeat-stale path).
+* `tier1_flagged_stdout_stale` — every time Tier 1 fired due to stale stdout or missed `FIRST_STDOUT_DEADLINE` (stdout-stale path, #1046). Use this counter to distinguish the alive-but-silent failure mode from dead-heartbeat kills in dashboards.
 * `tier2_reprieve_total:{alive|children|stdout}` — reprieve by signal.
 * `kill_total` — actual kills (after Tier 2 failed and kill-switch off).
+
+**Distinguishing kill causes in dashboards:**
+- `tier1_flagged_total` high, `tier1_flagged_stdout_stale` low → heartbeat writers are dying (clock/event-loop issue)
+- `tier1_flagged_stdout_stale` high → sessions hang silently (API/MCP tool issue)
+- `tier2_reprieve_total:alive` high → processes alive but silent; monitor `reprieve_count` for operator warnings
 
 ### Per-session fields
 
@@ -461,11 +502,12 @@ Redis counters keyed by `<project_key>:session-health:`:
 |-------|------|---------|
 | `last_heartbeat_at` | DatetimeField | Queue-layer heartbeat |
 | `last_sdk_heartbeat_at` | DatetimeField | Messenger watchdog heartbeat |
-| `last_stdout_at` | DatetimeField | Last SDK stdout event |
+| `last_stdout_at` | DatetimeField | Last SDK stdout event; Tier 1 stdout-stale input (#1046) |
+| `started_at` | DatetimeField | Session start time; `FIRST_STDOUT_DEADLINE` anchor (#1046) |
 | `recovery_attempts` | IntField | Kills only; finalizes at `MAX_RECOVERY_ATTEMPTS` |
-| `reprieve_count` | IntField | Tier 2 saves — diagnostic only |
+| `reprieve_count` | IntField | Tier 2 saves — diagnostic only; triggers WARNING log after 3 |
 
-All five fields are included in `_AGENT_SESSION_FIELDS` so they round-trip
+All fields are included in `_AGENT_SESSION_FIELDS` so they round-trip
 through delete-and-recreate paths (retry, orphan-fix, continuation fallback).
 
 ### Messenger callbacks (ORM-free)

--- a/docs/plans/promote-last-stdout-at-kill-signal.md
+++ b/docs/plans/promote-last-stdout-at-kill-signal.md
@@ -173,9 +173,9 @@ This is an internal health-check change with no user-visible output. The Redis c
 
 ## Test Impact
 
-- [ ] `tests/unit/test_health_check_recovery_finalization.py::TestDualHeartbeatOrSemantics` — UPDATE: add test cases for `last_stdout_at` stale with fresh heartbeats (tier-1 should flag), and `last_stdout_at is None` with old `started_at` (FIRST_STDOUT_DEADLINE case)
-- [ ] `tests/unit/test_health_check_recovery_finalization.py::TestTier2ReprieveGates::test_no_reprieve_on_stale_stdout` — UPDATE: the assertion `_tier2_reprieve_signal(handle, entry)` where `last_stdout_at=_ago(200)` returns `None` is based on `STDOUT_FRESHNESS_WINDOW=90`. After raising to 600, `_ago(200)` returns `"stdout"` (fresh within 600s). Update test to use `_ago(700)` for stale case.
-- [ ] `tests/unit/test_health_check_recovery_finalization.py::TestTier2ReprieveGates::test_reprieve_on_recent_stdout` — UPDATE: still valid after constant change (`_ago(30)` remains fresh), but verify.
+- [x] `tests/unit/test_health_check_recovery_finalization.py::TestDualHeartbeatOrSemantics` — UPDATE: add test cases for `last_stdout_at` stale with fresh heartbeats (tier-1 should flag), and `last_stdout_at is None` with old `started_at` (FIRST_STDOUT_DEADLINE case)
+- [x] `tests/unit/test_health_check_recovery_finalization.py::TestTier2ReprieveGates::test_no_reprieve_on_stale_stdout` — UPDATE: the assertion `_tier2_reprieve_signal(handle, entry)` where `last_stdout_at=_ago(200)` returns `None` is based on `STDOUT_FRESHNESS_WINDOW=90`. After raising to 600, `_ago(200)` returns `"stdout"` (fresh within 600s). Update test to use `_ago(700)` for stale case.
+- [x] `tests/unit/test_health_check_recovery_finalization.py::TestTier2ReprieveGates::test_reprieve_on_recent_stdout` — UPDATE: still valid after constant change (`_ago(30)` remains fresh), but verify.
 
 ## Rabbit Holes
 
@@ -226,24 +226,24 @@ No agent integration required — this is an internal worker health-check change
 
 ## Documentation
 
-- [ ] Update `docs/features/bridge-self-healing.md` — "Two-tier no-progress detector" section: add description of the stdout-stale tier-1 signal, document `STDOUT_FRESHNESS_WINDOW` change from 90s → 600s, document `FIRST_STDOUT_DEADLINE` constant (default 300s, env-tunable via `FIRST_STDOUT_DEADLINE_SECS`), and explain the alive-but-silent failure mode this addresses.
-- [ ] Update `docs/features/bridge-self-healing.md` — add `session-health:tier1_flagged_stdout_stale:{project_key}` to the Redis counter reference table so operators know how to distinguish heartbeat-stale vs. stdout-stale kills in dashboards.
-- [ ] Update inline docstring for `_has_progress()` in `agent/agent_session_queue.py` to document the new tier-1 stdout-stale branch and `FIRST_STDOUT_DEADLINE` fallback behavior.
+- [x] Update `docs/features/bridge-self-healing.md` — "Two-tier no-progress detector" section: add description of the stdout-stale tier-1 signal, document `STDOUT_FRESHNESS_WINDOW` change from 90s → 600s, document `FIRST_STDOUT_DEADLINE` constant (default 300s, env-tunable via `FIRST_STDOUT_DEADLINE_SECS`), and explain the alive-but-silent failure mode this addresses.
+- [x] Update `docs/features/bridge-self-healing.md` — add `session-health:tier1_flagged_stdout_stale:{project_key}` to the Redis counter reference table so operators know how to distinguish heartbeat-stale vs. stdout-stale kills in dashboards.
+- [x] Update inline docstring for `_has_progress()` in `agent/agent_session_queue.py` to document the new tier-1 stdout-stale branch and `FIRST_STDOUT_DEADLINE` fallback behavior.
 
 ## Success Criteria
 
-- [ ] A session whose `last_stdout_at` is stale for `STDOUT_FRESHNESS_WINDOW` (600s) is flagged by tier-1 even when both heartbeats are fresh.
-- [ ] A session with `last_stdout_at is None` and young `started_at` (< `FIRST_STDOUT_DEADLINE`) is NOT flagged — heartbeat-only semantics preserved (warmup tolerance, #1036 case).
-- [ ] A session with `last_stdout_at is None` and old `started_at` (> `FIRST_STDOUT_DEADLINE`) IS flagged by tier-1.
-- [ ] `session-health:tier1_flagged_stdout_stale:{project_key}` Redis counter increments on stdout-triggered tier-1 flags.
-- [ ] `DISABLE_PROGRESS_KILL=1` continues to suppress kills while emitting the new metric.
-- [ ] After two silent-hang recoveries, session transitions to terminal `failed` (existing PR #1039 path, no code change needed).
-- [ ] Unit test: fresh heartbeats + stale `last_stdout_at` (> 600s) → `_has_progress()` returns `False`.
-- [ ] Unit test: fresh heartbeats + fresh `last_stdout_at` (< 600s) → `_has_progress()` returns `True`.
-- [ ] Unit test: fresh heartbeats + `last_stdout_at is None` + young `started_at` → `_has_progress()` returns `True`.
-- [ ] Unit test: fresh heartbeats + `last_stdout_at is None` + old `started_at` → `_has_progress()` returns `False`.
-- [ ] Existing tier-2 test `test_no_reprieve_on_stale_stdout` updated for new 600s threshold — passes.
-- [ ] Tests pass (`pytest tests/unit/test_health_check_recovery_finalization.py -v`)
+- [x] A session whose `last_stdout_at` is stale for `STDOUT_FRESHNESS_WINDOW` (600s) is flagged by tier-1 even when both heartbeats are fresh.
+- [x] A session with `last_stdout_at is None` and young `started_at` (< `FIRST_STDOUT_DEADLINE`) is NOT flagged — heartbeat-only semantics preserved (warmup tolerance, #1036 case).
+- [x] A session with `last_stdout_at is None` and old `started_at` (> `FIRST_STDOUT_DEADLINE`) IS flagged by tier-1.
+- [x] `session-health:tier1_flagged_stdout_stale:{project_key}` Redis counter increments on stdout-triggered tier-1 flags.
+- [x] `DISABLE_PROGRESS_KILL=1` continues to suppress kills while emitting the new metric.
+- [x] After two silent-hang recoveries, session transitions to terminal `failed` (existing PR #1039 path, no code change needed).
+- [x] Unit test: fresh heartbeats + stale `last_stdout_at` (> 600s) → `_has_progress()` returns `False`.
+- [x] Unit test: fresh heartbeats + fresh `last_stdout_at` (< 600s) → `_has_progress()` returns `True`.
+- [x] Unit test: fresh heartbeats + `last_stdout_at is None` + young `started_at` → `_has_progress()` returns `True`.
+- [x] Unit test: fresh heartbeats + `last_stdout_at is None` + old `started_at` → `_has_progress()` returns `False`.
+- [x] Existing tier-2 test `test_no_reprieve_on_stale_stdout` updated for new 600s threshold — passes.
+- [x] Tests pass (`pytest tests/unit/test_health_check_recovery_finalization.py -v`)
 
 ## Team Orchestration
 

--- a/tests/unit/test_health_check_recovery_finalization.py
+++ b/tests/unit/test_health_check_recovery_finalization.py
@@ -337,6 +337,87 @@ class TestHasProgressDualHeartbeat:
         assert _has_progress(entry) is True
 
 
+class TestStdoutStaleTier1:
+    """Tests for the stdout-stale Tier 1 kill signal (#1046).
+
+    Even with fresh heartbeats, _has_progress() returns False when:
+    - last_stdout_at is stale beyond STDOUT_FRESHNESS_WINDOW (600s), or
+    - last_stdout_at is None and started_at is older than FIRST_STDOUT_DEADLINE (300s).
+
+    Sessions with fresh stdout or young started_at are NOT flagged.
+    """
+
+    @staticmethod
+    def _make_entry(**overrides):
+        defaults = {
+            "turn_count": 0,
+            "log_path": "",
+            "claude_session_uuid": None,
+            "last_heartbeat_at": _ago(30),  # fresh heartbeat — Tier 1 would normally pass
+            "last_sdk_heartbeat_at": None,
+            "last_stdout_at": None,
+            "started_at": None,
+        }
+        defaults.update(overrides)
+        entry = SimpleNamespace(**defaults)
+        entry.get_children = lambda: []
+        return entry
+
+    def test_fresh_heartbeats_stale_stdout_returns_false(self):
+        """Fresh heartbeats + stale stdout (> 600s) → Tier 1 flags → False."""
+        from agent.agent_session_queue import _has_progress
+
+        entry = self._make_entry(last_stdout_at=_ago(700))
+        assert _has_progress(entry) is False
+
+    def test_fresh_heartbeats_fresh_stdout_returns_true(self):
+        """Fresh heartbeats + fresh stdout (< 600s) → no flag → True."""
+        from agent.agent_session_queue import _has_progress
+
+        entry = self._make_entry(last_stdout_at=_ago(60))
+        assert _has_progress(entry) is True
+
+    def test_fresh_heartbeats_no_stdout_young_started_at_returns_true(self):
+        """Fresh heartbeats + no stdout + young started_at (< 300s) → warmup tolerance → True."""
+        from agent.agent_session_queue import _has_progress
+
+        entry = self._make_entry(last_stdout_at=None, started_at=_ago(120))
+        assert _has_progress(entry) is True
+
+    def test_fresh_heartbeats_no_stdout_old_started_at_returns_false(self):
+        """Fresh heartbeats + no stdout + old started_at (> 300s) → FIRST_STDOUT_DEADLINE → False."""
+        from agent.agent_session_queue import _has_progress
+
+        entry = self._make_entry(last_stdout_at=None, started_at=_ago(400))
+        assert _has_progress(entry) is False
+
+    def test_last_progress_reason_set_on_stdout_stale(self):
+        """_last_progress_reason is 'stdout_stale' when stdout-stale flag fires."""
+        import agent.agent_session_queue as q
+
+        entry = self._make_entry(last_stdout_at=_ago(700))
+        q._has_progress(entry)
+        assert q._last_progress_reason == "stdout_stale"
+
+    def test_last_progress_reason_set_on_first_stdout_deadline(self):
+        """_last_progress_reason is 'first_stdout_deadline' when deadline flag fires."""
+        import agent.agent_session_queue as q
+
+        entry = self._make_entry(last_stdout_at=None, started_at=_ago(400))
+        q._has_progress(entry)
+        assert q._last_progress_reason == "first_stdout_deadline"
+
+    def test_last_progress_reason_reset_on_true_return(self):
+        """_last_progress_reason is reset to '' when _has_progress() returns True."""
+        import agent.agent_session_queue as q
+
+        q._last_progress_reason = "leftover"
+        entry = self._make_entry(last_stdout_at=_ago(60))
+        result = q._has_progress(entry)
+        assert result is True
+        assert q._last_progress_reason == ""
+
+
 class TestTier2ReprieveGates:
     """Tests for _tier2_reprieve_signal (#1036).
 
@@ -430,11 +511,11 @@ class TestTier2ReprieveGates:
         assert _tier2_reprieve_signal(handle, entry) == "stdout"
 
     def test_no_reprieve_on_stale_stdout(self):
-        """No pid, stale stdout (>90s) → None."""
+        """No pid, stale stdout (>600s) → None (STDOUT_FRESHNESS_WINDOW raised to 600s, #1046)."""
         from agent.agent_session_queue import _tier2_reprieve_signal
 
         handle = self._make_handle(pid=None)
-        entry = self._make_entry(last_stdout_at=_ago(200))
+        entry = self._make_entry(last_stdout_at=_ago(700))
         assert _tier2_reprieve_signal(handle, entry) is None
 
     def test_no_reprieve_on_handle_none(self):


### PR DESCRIPTION
## Summary

- Extends `_has_progress()` with a stdout-stale Tier 1 kill signal that catches the alive-but-silent failure mode: sessions whose `last_stdout_at` is stale beyond `STDOUT_FRESHNESS_WINDOW` (600s) are flagged by Tier 1 even when both heartbeats are fresh
- Adds `FIRST_STDOUT_DEADLINE` (300s) to flag sessions that have never produced any stdout after a configurable warmup grace period
- Raises `STDOUT_FRESHNESS_WINDOW` from 90s to 600s (also relaxes Tier 2 gate (e) reprieve window, which is intentional)
- Adds `tier1_flagged_stdout_stale` Redis counter to distinguish alive-but-silent kills from heartbeat-stale kills in dashboards
- Escalates Tier 2 reprieve log to WARNING after 3 reprieves as an operator signal

## Changes

- `agent/agent_session_queue.py`: raise `STDOUT_FRESHNESS_WINDOW` 90→600, add `FIRST_STDOUT_DEADLINE=300`, add `_last_progress_reason` module-level variable, extend `_has_progress()` with stdout-stale branch, emit `tier1_flagged_stdout_stale` counter, escalate reprieve log after 3 reprieves
- `tests/unit/test_health_check_recovery_finalization.py`: add 7 new tests in `TestStdoutStaleTier1`, update `test_no_reprieve_on_stale_stdout` threshold from `_ago(200)` to `_ago(700)` for new 600s window
- `docs/features/bridge-self-healing.md`: document the stdout-stale Tier 1 signal, new constants, alive-but-silent failure mode, updated metrics table, and dashboard guidance

## Testing

- [x] All 49 unit tests in `test_health_check_recovery_finalization.py` passing
- [x] 7 new tests cover all stdout-stale code paths
- [x] Lint (ruff check) passing
- [x] Format (ruff format) passing

## Documentation

- [x] `docs/features/bridge-self-healing.md` updated with new Tier 1 stdout-stale signal, constants, and metrics

## Definition of Done

- [x] Built: stdout-stale Tier 1 branch implemented and working
- [x] Tested: All 49 unit tests passing including 7 new tests
- [x] Documented: bridge-self-healing.md updated
- [x] Quality: Lint and format checks pass

Closes #1046