### PR TITLE
docs(#1027): consolidate three overlapping steering docs

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -130,7 +130,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [Skills Reorganization](skills-reorganization.md) | Canonical SKILL.md template, progressive disclosure, command consolidation, hardlink scoping | Shipped |
 | [Stall Retry](stall-retry.md) | Automatic retry of stalled agent sessions with exponential backoff, process cleanup, and Telegram notification on final failure | Shipped |
 | [Standardized Enums](standardized-enums.md) | StrEnum definitions for session types, personas, classifications, and chat modes replacing magic strings | Shipped |
-| [Steering Queue](steering-queue.md) | Mid-execution course correction via Telegram reply threads and parent-child PM session-to-Dev session steering | Shipped |
+| [Steering Queue: Historical Spec](steering-implementation-spec.md) | Original Redis list design, watchdog hook, and SDK client registry for mid-execution course correction (historical design spec) | Shipped |
 | [Structured Logging & Telemetry](structured-logging-telemetry.md) | Redis-backed telemetry counters, structured log lines, and health check integration for Observer Agent observability | Shipped |
 | [Subconscious Memory](subconscious-memory.md) | Automatic and intentional memory with structured metadata (category, file paths, tags), dismissal tracking with importance decay, multi-query decomposition for broader retrieval, category-weighted recall re-ranking, and nightly LLM-based semantic consolidation (`memory-dedup` reflection) with `superseded_by` tracking and recall filter | Shipped |
 | [Summarizer Format](summarizer-format.md) | Structured bullet-point output with SDLC stage progress, markdown links, and self-summary fallback via session steering for Telegram delivery | Shipped |

--- a/docs/features/bridge-workflow-gaps.md
+++ b/docs/features/bridge-workflow-gaps.md
@@ -102,4 +102,4 @@ The thumbs-up emoji reaction (👍) in Telegram serves as a **human-to-human** c
 
 - [Session Isolation](session-isolation.md) -- Task list and worktree isolation per session
 - [Bridge Self-Healing](bridge-self-healing.md) -- Crash recovery and watchdog system
-- [Steering Queue](steering-queue.md) -- Mid-execution course correction mechanism
+- [Steering Queue: Historical Spec](steering-implementation-spec.md) -- Mid-execution course correction mechanism

--- a/docs/features/mid-session-steering.md
+++ b/docs/features/mid-session-steering.md
@@ -2,6 +2,8 @@
 
 **Scope:** Telegram bridge reply-thread steering via Redis list (`steering:{session_id}`). For PM→child steering, see `session-steering.md`.
 
+**See also:** [Session Steering](session-steering.md) — canonical reference for the turn-boundary inbox model and parent-child steering
+
 ## Overview
 
 Mid-session steering allows a user to send a reply-to message in Telegram that gets injected into a currently running agent session, enabling real-time course correction without waiting for the agent to finish. This is distinct from creating a new session or resuming a completed session.
@@ -95,6 +97,6 @@ If a steering message arrives just as the agent finishes, `pop_all_steering_mess
 
 ## Related Documentation
 
-- [Steering Queue](steering-queue.md) -- Original implementation plan and design decisions
+- [Steering Queue: Historical Spec](steering-implementation-spec.md) -- Original implementation plan and design decisions
 - [Bridge Workflow Gaps](bridge-workflow-gaps.md) -- Auto-continue and output classification that interacts with session status
 - [Agent Session Model](agent-session-model.md) -- Session lifecycle and status transitions

--- a/docs/features/pm-dev-session-architecture.md
+++ b/docs/features/pm-dev-session-architecture.md
@@ -402,7 +402,7 @@ python scripts/steer_child.py --session-id <child_id> --message "stop" --parent-
 python scripts/steer_child.py --list --parent-id <parent_id>
 ```
 
-See [Session Steering](session-steering.md) for the turn-boundary inbox architecture and [Steering Queue](steering-queue.md) for the Redis list / mid-turn injection path.
+See [Session Steering](session-steering.md) for the turn-boundary inbox architecture and [Steering Queue: Historical Spec](steering-implementation-spec.md) for the Redis list / mid-turn injection path.
 
 ## Q&A Formatting (Prose vs Structured)
 

--- a/docs/features/reaction-semantics.md
+++ b/docs/features/reaction-semantics.md
@@ -102,5 +102,5 @@ Three paths to silent text loss have been identified and guarded:
 ## See Also
 
 - [Bridge Workflow Gaps](bridge-workflow-gaps.md) -- Output classification and auto-continue behavior
-- [Steering Queue](steering-queue.md) -- The steering mechanism (now only used for live human corrections, not auto-continue)
+- [Steering Queue: Historical Spec](steering-implementation-spec.md) -- The steering mechanism (now only used for live human corrections, not auto-continue)
 - [Session Isolation](session-isolation.md) -- How session context is preserved across re-enqueued jobs

--- a/docs/features/session-steering.md
+++ b/docs/features/session-steering.md
@@ -2,6 +2,10 @@
 
 **Scope:** Turn-boundary inbox (`AgentSession.queued_steering_messages`) consumed by the worker executor. Used by `valor-session steer` and `scripts/steer_child.py`.
 
+**See also:**
+- [Mid-Session Steering](mid-session-steering.md) — Telegram reply-thread flow (user-facing)
+- [Steering Queue: Historical Spec](steering-implementation-spec.md) — Original Redis list design and bridge coalescing
+
 External steering for `AgentSession` via `queued_steering_messages`. Any process — the PM, a CLI user, another agent — can write messages to a running session's inbox. The worker injects them at the next turn boundary.
 
 ## Problem
@@ -118,6 +122,72 @@ When both summarizer backends (Haiku and OpenRouter) fail, `send_response_with_f
 **Fallback chain:** If steering cannot be used (no session, Redis down, loop prevention), the system falls through to `is_narration_only()` as a last-resort gate before delivering text.
 
 See [Summarizer Format: Self-Summary Fallback](summarizer-format.md#self-summary-fallback-via-session-steering) for the full data flow.
+
+## Parent-Child Steering (PM session to Dev session)
+
+In addition to Telegram reply-thread steering (user to agent), the steering queue supports **parent-child steering** where a PM session (PM persona) pushes steering messages to its spawned Dev sessions.
+
+### How It Works
+
+The PM session invokes `scripts/steer_child.py` via bash to push steering messages to a running child Dev session. The script validates the parent-child relationship before pushing to the same Redis steering queue used by bridge steering.
+
+```
+PM session decides to steer
+    |
+    v
+python scripts/steer_child.py --session-id <child_id> --message "focus on tests" --parent-id <parent_id>
+    |
+    v
+Script validates: child exists, is a Dev session, parent_chat_session_id matches, status is "running"
+    |
+    v
+push_steering_message(child_session_id, text, sender="PM session")
+    |
+    v
+Child's watchdog picks up on next tool call (existing _handle_steering in health_check.py)
+    |
+    v
+Dev session adjusts behavior
+```
+
+### CLI Usage
+
+```bash
+# Steer a child Dev session
+python scripts/steer_child.py --session-id <child_id> --message "skip docs, focus on tests" --parent-id <parent_id>
+
+# Send abort signal to a child
+python scripts/steer_child.py --session-id <child_id> --message "stop" --parent-id <parent_id> --abort
+
+# List active child Dev sessions
+python scripts/steer_child.py --list --parent-id <parent_id>
+```
+
+The `--parent-id` can also be read from the `VALOR_SESSION_ID` environment variable, which is set by `sdk_client.py` for running sessions.
+
+### Validation
+
+The script enforces strict parent-child relationship validation:
+
+- Target must be an existing AgentSession
+- Target must be a Dev session (`is_dev` check)
+- Target's `parent_chat_session_id` must match the caller's ID
+- Target must be in `running` status
+
+All validation failures exit with non-zero code and print an error to stderr.
+
+### Relationship to Bridge Steering
+
+| Aspect | Bridge Steering | Parent-Child Steering |
+|--------|----------------|----------------------|
+| Caller | Telegram user (via reply thread) | PM session (via bash script) |
+| Entry point | `bridge/telegram_bridge.py` | `scripts/steer_child.py` |
+| Validation | Session ID match + running status | Parent-child relationship + running status |
+| Redis queue | Same (`steering:{session_id}`) | Same (`steering:{session_id}`) |
+| Consumption | Same (watchdog `_handle_steering`) | Same (watchdog `_handle_steering`) |
+| Sender field | User's name | "PM session" |
+
+Both paths converge on the same `push_steering_message()` function in `agent/steering.py` and the same consumption path in the watchdog hook.
 
 ## No-Gos
 

--- a/docs/features/steering-implementation-spec.md
+++ b/docs/features/steering-implementation-spec.md
@@ -6,7 +6,9 @@ created: 2026-02-02
 tracking: https://github.com/tomcounsell/ai/issues/23
 ---
 
-# Steering Queue: Mid-Execution Course Correction via Reply Threads
+# Steering Queue: Historical Design Specification
+
+> **Historical Design Specification** — This document records the original design decisions, Redis key structure, watchdog hook design, and SDK client registry rationale from the initial implementation of session steering. For the current operational reference, see [Session Steering](session-steering.md). For the end-to-end Telegram reply-thread flow, see [Mid-Session Steering](mid-session-steering.md).
 
 **Scope:** Redis list steering queue design and bridge coalescing. SDK-harness mid-turn injection (legacy/secondary path). For PM→child steering, see `session-steering.md`.
 
@@ -214,90 +216,6 @@ def clear_steering_queue(session_id: str) -> int:
 
 All use `POPOTO_REDIS_DB` directly with `RPUSH`, `LPOP`, and `DEL` on key `steering:{session_id}`. No TTL — messages persist until consumed or explicitly cleared by session completion.
 
-## Rabbit Holes & Risks
-
-### Risk 1: SDK interrupt + re-query behavior
-**Impact:** `client.interrupt()` sends an `SDKControlInterruptRequest` to the CLI subprocess. If the agent is mid-tool-execution (e.g., halfway through a git push), the interrupt could leave the working directory in a dirty state. Additionally, calling `client.query(steering_text)` after interrupt needs the CLI to be in a state where it accepts new user input — if the interrupt didn't fully cancel the pending tool, the query might fail or be ignored.
-**Mitigation:** Test this flow in isolation first with a simple long-running task. If interrupt + query doesn't work cleanly, fall back to injecting the steering text as a **tool result** via the hook return value (the hook already returns a dict to the SDK). Worst case: fall back to Option C (file-based signaling). The agent already reads files.
-
-### Risk 2: Race condition between watchdog and agent response
-**Impact:** The watchdog fires after a tool call. If the agent finishes between the steering push and the next tool call, the steering message is never consumed.
-**Mitigation:** When a session completes, check its steering queue. If messages remain, either auto-queue them as a new follow-up session or log them. Add `clear_steering_queue(session_id)` to `_execute_agent_session` completion path.
-
-### Risk 3: Watchdog hook doesn't have async access to Redis
-**Impact:** The hook is async but runs in the SDK's event loop. Redis calls via popoto are synchronous.
-**Mitigation:** Use `POPOTO_REDIS_DB.lpop()` directly — it's a sync Redis call but completes in <1ms (local Redis). Wrapping in `asyncio.to_thread()` is an option if needed but likely unnecessary for a single LPOP.
-
-### Risk 4: Multiple steering messages accumulate
-**Impact:** If the user sends several corrections in quick succession, they all queue up. The agent processes them one at a time (one per tool call), which could be confusing.
-**Mitigation:** Pop ALL messages from the queue in one check and concatenate them into a single injection. Use `LPOP` in a loop until empty, then combine.
-
-## Parent-Child Steering (PM session to Dev session)
-
-In addition to Telegram reply-thread steering (user to agent), the steering queue supports **parent-child steering** where a PM session (PM persona) pushes steering messages to its spawned Dev sessions.
-
-### How It Works
-
-The PM session invokes `scripts/steer_child.py` via bash to push steering messages to a running child Dev session. The script validates the parent-child relationship before pushing to the same Redis steering queue used by bridge steering.
-
-```
-PM session decides to steer
-    |
-    v
-python scripts/steer_child.py --session-id <child_id> --message "focus on tests" --parent-id <parent_id>
-    |
-    v
-Script validates: child exists, is a Dev session, parent_chat_session_id matches, status is "running"
-    |
-    v
-push_steering_message(child_session_id, text, sender="PM session")
-    |
-    v
-Child's watchdog picks up on next tool call (existing _handle_steering in health_check.py)
-    |
-    v
-Dev session adjusts behavior
-```
-
-### CLI Usage
-
-```bash
-# Steer a child Dev session
-python scripts/steer_child.py --session-id <child_id> --message "skip docs, focus on tests" --parent-id <parent_id>
-
-# Send abort signal to a child
-python scripts/steer_child.py --session-id <child_id> --message "stop" --parent-id <parent_id> --abort
-
-# List active child Dev sessions
-python scripts/steer_child.py --list --parent-id <parent_id>
-```
-
-The `--parent-id` can also be read from the `VALOR_SESSION_ID` environment variable, which is set by `sdk_client.py` for running sessions.
-
-### Validation
-
-The script enforces strict parent-child relationship validation:
-
-- Target must be an existing AgentSession
-- Target must be a Dev session (`is_dev` check)
-- Target's `parent_chat_session_id` must match the caller's ID
-- Target must be in `running` status
-
-All validation failures exit with non-zero code and print an error to stderr.
-
-### Relationship to Bridge Steering
-
-| Aspect | Bridge Steering | Parent-Child Steering |
-|--------|----------------|----------------------|
-| Caller | Telegram user (via reply thread) | PM session (via bash script) |
-| Entry point | `bridge/telegram_bridge.py` | `scripts/steer_child.py` |
-| Validation | Session ID match + running status | Parent-child relationship + running status |
-| Redis queue | Same (`steering:{session_id}`) | Same (`steering:{session_id}`) |
-| Consumption | Same (watchdog `_handle_steering`) | Same (watchdog `_handle_steering`) |
-| Sender field | User's name | "PM session" |
-
-Both paths converge on the same `push_steering_message()` function in `agent/steering.py` and the same consumption path in the watchdog hook.
-
 ## No-Gos (Out of Scope)
 
 - **Message classification AI** — Existing reply-to handling is sufficient for routing. No LLM-based classification of "steering vs new task" needed.
@@ -305,25 +223,3 @@ Both paths converge on the same `push_steering_message()` function in `agent/ste
 - **Multi-session steering** — Only one session runs per project at a time (enforced by session queue). No need to handle concurrent session steering.
 - **Non-reply steering** — Only reply-thread messages count as steering. A new mention always creates a new session.
 - **Automatic fan-out** — Parent-child steering is always explicit, per-child. No broadcasting to all children.
-
-## Success Criteria
-
-- [ ] Reply to a running session's message injects the reply into the active agent session
-- [ ] Agent acknowledges and acts on the steering message within its current execution
-- [ ] "stop" / "cancel" reply aborts the running session within one tool call
-- [ ] Non-reply messages during a running session queue normally with a position ack
-- [ ] Reply to a completed session resumes it (existing behavior preserved)
-- [ ] Steering queue cleans up after session completes (no orphaned Redis keys)
-- [ ] No production Redis pollution (steering keys cleaned up on session completion)
-- [ ] Tests cover: push/pop, abort signal, bridge routing, watchdog injection, cleanup
-
-## Files to Modify
-
-| File | Change |
-|------|--------|
-| `agent/steering.py` | **NEW** — Steering queue functions (push, pop, clear) |
-| `agent/health_check.py` | Add steering queue check to `watchdog_hook` |
-| `agent/sdk_client.py` | Store active client reference for interrupt access |
-| `bridge/telegram_bridge.py` | Route reply-to-active-session to steering queue |
-| `agent/agent_session_queue.py` | Clear steering queue on session completion; handle leftover messages |
-| `tests/test_steering.py` | **NEW** — Tests for steering queue, routing, and cleanup |

--- a/docs/features/steering-implementation-spec.md
+++ b/docs/features/steering-implementation-spec.md
@@ -10,7 +10,7 @@ tracking: https://github.com/tomcounsell/ai/issues/23
 
 > **Historical Design Specification** — This document records the original design decisions, Redis key structure, watchdog hook design, and SDK client registry rationale from the initial implementation of session steering. For the current operational reference, see [Session Steering](session-steering.md). For the end-to-end Telegram reply-thread flow, see [Mid-Session Steering](mid-session-steering.md).
 
-**Scope:** Redis list steering queue design and bridge coalescing. SDK-harness mid-turn injection (legacy/secondary path). For PM→child steering, see `session-steering.md`.
+**Scope:** Redis list steering queue design and bridge coalescing. SDK-harness mid-turn injection (secondary path; the current canonical path is the turn-boundary inbox in `session-steering.md`). For PM→child steering, see `session-steering.md`.
 
 ## Problem
 

--- a/docs/features/telegram-message-edit-handling.md
+++ b/docs/features/telegram-message-edit-handling.md
@@ -50,4 +50,4 @@ bridge/telegram_bridge.py (edit_handler)
 
 - [Mid-Session Steering](mid-session-steering.md) — Steering queue mechanics used by the running-session branch
 - [Bridge Workflow Gaps](bridge-workflow-gaps.md) — Session routing and output classification context
-- [Steering Queue](steering-queue.md) — Redis list push/pop implementation
+- [Steering Queue: Historical Spec](steering-implementation-spec.md) — Redis list push/pop implementation

--- a/docs/plans/completed/agent-session-field-cleanup.md
+++ b/docs/plans/completed/agent-session-field-cleanup.md
@@ -167,7 +167,7 @@ No agent integration required — AgentSession is not exposed through any MCP se
 
 - [ ] Update `docs/features/redis-models.md` — field name references throughout
 - [ ] Update `docs/features/session-isolation.md` — references `trigger_message_id`
-- [ ] Update `docs/features/steering-queue.md` — references `reply_to_msg_id`
+- [ ] Update `docs/features/steering-implementation-spec.md` — references `reply_to_msg_id`
 - [ ] Update inline comments on `models/agent_session.py` — field grouping comments
 
 ## Success Criteria
@@ -296,7 +296,7 @@ No agent integration required — AgentSession is not exposed through any MCP se
 - **Parallel**: false
 - Update `docs/features/redis-models.md` with new field names
 - Update `docs/features/session-isolation.md`
-- Update `docs/features/steering-queue.md`
+- Update `docs/features/steering-implementation-spec.md`
 - Update field comments in `models/agent_session.py`
 
 ### 7. Final Validation

--- a/docs/plans/parent-child-steering.md
+++ b/docs/plans/parent-child-steering.md
@@ -22,7 +22,7 @@ PM session can push steering messages to any active child Dev session at any tim
 
 ## Prior Art
 
-- **Issue #292 / PR #308**: Fixed reply-to steering reaching running agents. Established the bridge-to-steering-queue routing pattern. Directly relevant -- this work extends the same push mechanism to a new caller (PM session instead of bridge).
+- **Issue #292 / PR #308**: Fixed reply-to steering reaching running agents. Established the bridge-to-steering-queue routing pattern. Directly relevant -- this work extends the same push mechanism to a new caller (PM session instead of bridge). See [Steering Queue: Historical Spec](../features/steering-implementation-spec.md).
 - **Issue #329 / PR #349**: Context fidelity modes for sub-agent steering. Added fidelity levels to steering payloads. Relevant -- the new tool should respect existing fidelity conventions.
 - **Issue #318 / PR #366**: Route unthreaded messages into active sessions via expectations + queued_steering_messages. Extended steering routing beyond reply-to threads.
 - **Issue #459 / PR #464**: SDLC Redesign introducing PM/Dev session split. Created the parent-child relationship (`parent_chat_session_id`) that this feature relies on.
@@ -151,7 +151,7 @@ No MCP server integration required. The steering tool is a bash-callable script 
 
 ## Documentation
 
-- [ ] Update `docs/features/steering-queue.md` to document parent-child steering as a new steering path alongside bridge steering
+- [x] Update `docs/features/steering-implementation-spec.md` to document parent-child steering as a new steering path alongside bridge steering (consolidated into `session-steering.md` via #1027)
 - [ ] Update `docs/features/pm-dev-session-architecture.md` to document the steering capability in the PM/Dev session relationship section
 - [ ] Add entry to `docs/features/README.md` index table if not already covered
 
@@ -226,7 +226,7 @@ Using core tier only: builder, validator, documentarian.
 - **Assigned To**: steering-documentarian
 - **Agent Type**: documentarian
 - **Parallel**: false
-- Update `docs/features/steering-queue.md` with parent-child steering section
+- Update `docs/features/steering-implementation-spec.md` with parent-child steering section (consolidated into `session-steering.md` via #1027)
 - Update `docs/features/pm-dev-session-architecture.md` with steering capability
 - Update `docs/features/README.md` index if needed
 

--- a/docs/plans/redis-popoto-migration.md
+++ b/docs/plans/redis-popoto-migration.md
@@ -113,7 +113,7 @@ No existing tests affected for `bridge/dedup.py` -- it currently has zero test c
 ## Rabbit Holes
 
 - **Migrating the distributed lock to Popoto**: Popoto's `save()` cannot do atomic `SET NX EX`. The lock must stay as raw Redis. Do not attempt to wrap it in a model.
-- **Migrating `agent/steering.py`**: This is an intentional transient FIFO queue design (documented in `docs/features/steering-queue.md`). Explicitly out of scope.
+- **Migrating `agent/steering.py`**: This is an intentional transient FIFO queue design (documented in `docs/features/steering-implementation-spec.md`). Explicitly out of scope.
 - **Migrating `agent/job_queue.py`**: Contains ORM-repair code that intentionally uses raw Redis. Out of scope.
 - **Key migration/data continuity**: Do not build migration scripts for existing Redis keys. The data is ephemeral (TTLs of hours to days) and will naturally rotate.
 


### PR DESCRIPTION
## Summary

- `session-steering.md` absorbs the parent-child steering section from `steering-queue.md` and gains "See also" links at the top — it is now the single canonical reference for how steering works
- `mid-session-steering.md` gains a "See also: session-steering.md" link to close the asymmetric reference gap
- `steering-queue.md` is renamed to `steering-implementation-spec.md` and marked as a historical design spec with a prominent banner; the parent-child section is removed (moved to primary doc); No-Gos/Success Criteria plan artifacts are stripped; Redis key design, watchdog hook design, and SDK client registry rationale are preserved

## Changes

- `docs/features/session-steering.md` — parent-child section absorbed, "See also" block added
- `docs/features/mid-session-steering.md` — "See also" link added at top
- `docs/features/steering-queue.md` → renamed to `docs/features/steering-implementation-spec.md` with historical spec banner
- `docs/features/README.md` — index row updated for renamed file
- Cross-references updated in: `telegram-message-edit-handling.md`, `bridge-workflow-gaps.md`, `pm-dev-session-architecture.md`, `reaction-semantics.md`, `parent-child-steering.md`, `redis-popoto-migration.md`, `completed/agent-session-field-cleanup.md`

## Testing

- [x] No markdown links to `steering-queue.md` remain (all are prose mentions of the concept)
- [x] `steering-implementation-spec.md` exists with historical header
- [x] `steering-queue.md` is gone (renamed via git mv)
- [x] README index updated with new file name
- [x] Parent-child section present in `session-steering.md`
- [x] "See also" blocks present in both `session-steering.md` and `mid-session-steering.md`
- [x] Docs gate validation passed

## Documentation

- [x] `docs/features/session-steering.md` — parent-child section absorbed, cross-links added
- [x] `docs/features/mid-session-steering.md` — cross-link added
- [x] `docs/features/steering-implementation-spec.md` — historical spec with clean structure
- [x] `docs/features/README.md` — index updated

## Definition of Done

- [x] Built: All documentation restructured as planned
- [x] Tested: All verification checks pass
- [x] Documented: Docs are the deliverable
- [x] Quality: Docs gate validation passed, no broken links

Closes #1027