### PR TITLE
refactor(#1026): collapse session_mode into session_type, remove role field

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,7 +288,7 @@ Telegram → Python Bridge (Telethon) → Enqueues AgentSession to Redis (I/O on
 
 Standalone Worker (python -m worker) → Sole session execution engine
               (worker/__main__.py)         → Startup: index rebuild → recovery → orphan cleanup
-                                           → Executes PM session (AgentSession role=pm, read-only)
+                                           → Executes PM session (AgentSession session_type=pm, read-only)
                                                → PM creates Dev session via valor_session CLI
                                                    → Worker executes Dev session via CLI harness (claude -p → Claude API)
                                                    → _handle_dev_session_completion() → steers PM

--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -176,7 +176,6 @@ _AGENT_SESSION_FIELDS = [
     "claude_session_uuid",
     "parent_agent_session_id",
     "session_type",
-    "role",
     "slug",
     "pm_sent_message_ids",
     "last_heartbeat_at",

--- a/agent/sdk_client.py
+++ b/agent/sdk_client.py
@@ -2195,14 +2195,14 @@ async def get_agent_response_sdk(
                 )
             except Exception:
                 pass  # Best-effort metrics
-            # Update session mode flag (skip PM sessions — they must stay PM)
+            # Update session type to Teammate (skip PM sessions — they must stay PM)
             if session_id and _session_type != SessionType.PM:
                 try:
                     from models.agent_session import AgentSession as _TMSession
 
                     for _s in _TMSession.query.filter(session_id=session_id):
                         if _s.status in ("running", "active", "pending"):
-                            _s.session_mode = PersonaType.TEAMMATE
+                            _s.session_type = SessionType.TEAMMATE
                             _s.save()
                             break
                 except Exception:
@@ -2252,7 +2252,7 @@ async def get_agent_response_sdk(
                         f"[{request_id}] Routing to collaboration mode "
                         f"(direct action, intent={_intent_result.intent})"
                     )
-                    # Update session mode so nudge loop uses reduced cap
+                    # Update session type to Teammate so nudge loop uses reduced cap
                     # (skip PM sessions — they must stay PM)
                     if session_id and _session_type != SessionType.PM:
                         try:
@@ -2260,7 +2260,7 @@ async def get_agent_response_sdk(
 
                             for _s in _TMSession.query.filter(session_id=session_id):
                                 if _s.status in ("running", "active", "pending"):
-                                    _s.session_mode = PersonaType.TEAMMATE
+                                    _s.session_type = SessionType.TEAMMATE
                                     _s.save()
                                     break
                         except Exception:

--- a/agent/sdk_client.py
+++ b/agent/sdk_client.py
@@ -2018,7 +2018,7 @@ async def get_agent_response_sdk(
     bridge.routing) to determine session behavior for PM sessions:
 
     - Teammate persona: bypasses the Haiku intent classifier, sets
-      session_mode=PersonaType.TEAMMATE directly on the session, reducing
+      session_type=SessionType.TEAMMATE directly on the session, reducing
       latency and API cost for DMs and groups with "teammate" persona.
     - Project Manager/Developer persona: bypasses the classifier, uses
       the config-determined persona without reclassification.

--- a/agent/session_executor.py
+++ b/agent/session_executor.py
@@ -758,9 +758,7 @@ async def _execute_agent_session(session: AgentSession) -> None:
                 )
 
             # Resolve session type and classification for PM auto-continue
-            _session_type = (
-                getattr(agent_session, "session_type", None) if agent_session else None
-            )
+            _session_type = getattr(agent_session, "session_type", None) if agent_session else None
             _classification = getattr(session, "classification_type", None)
             _is_teammate = (
                 agent_session is not None

--- a/agent/session_executor.py
+++ b/agent/session_executor.py
@@ -23,7 +23,7 @@ from agent.session_state import (
     _active_sessions,
 )
 from agent.worktree_manager import WORKTREES_DIR, validate_workspace
-from config.enums import PersonaType, SessionType  # noqa: F401
+from config.enums import SessionType
 from models.agent_session import AgentSession
 from models.session_lifecycle import TERMINAL_STATUSES as _TERMINAL_STATUSES
 
@@ -759,15 +759,12 @@ async def _execute_agent_session(session: AgentSession) -> None:
 
             # Resolve session type and classification for PM auto-continue
             _session_type = (
-                getattr(agent_session, "session_mode", None)
-                or getattr(agent_session, "session_type", None)
-                if agent_session
-                else None
+                getattr(agent_session, "session_type", None) if agent_session else None
             )
             _classification = getattr(session, "classification_type", None)
             _is_teammate = (
                 agent_session is not None
-                and getattr(agent_session, "session_mode", None) == PersonaType.TEAMMATE
+                and getattr(agent_session, "session_type", None) == SessionType.TEAMMATE
             )
 
             # Delegate routing decision to output_router (call site preserved here)
@@ -1481,7 +1478,7 @@ async def _execute_agent_session(session: AgentSession) -> None:
             # Teammate sessions: clear the processing reaction instead of setting completion emoji
             if (
                 agent_session
-                and getattr(agent_session, "session_mode", None) == PersonaType.TEAMMATE
+                and getattr(agent_session, "session_type", None) == SessionType.TEAMMATE
                 and not task.error
             ):
                 emoji = None  # Clear reaction

--- a/agent/sustainability.py
+++ b/agent/sustainability.py
@@ -244,7 +244,6 @@ def send_hibernation_notification(event: str, project_key: str | None = None) ->
             return
 
         notification_session = AgentSession(
-            role="teammate",
             session_type="teammate",
             project_key=pk,
             command=command,

--- a/bridge/message_drafter.py
+++ b/bridge/message_drafter.py
@@ -31,7 +31,7 @@ import anthropic
 import httpx
 
 from bridge.message_quality import PROCESS_NARRATION_PATTERNS as _PROCESS_NARRATION_PATTERNS
-from config.enums import PersonaType
+from config.enums import PersonaType, SessionType
 from config.models import MODEL_FAST, OPENROUTER_HAIKU, OPENROUTER_URL
 from utils.api_keys import get_anthropic_api_key
 
@@ -1140,7 +1140,7 @@ def _build_draft_prompt(
                 recent = history[-5:]  # Last 5 entries
                 context_parts.append("Recent history: " + " | ".join(str(e) for e in recent))
         # Signal Teammate mode so the LLM uses prose format
-        if getattr(session, "session_mode", None) == PersonaType.TEAMMATE:
+        if getattr(session, "session_type", None) == SessionType.TEAMMATE:
             context_parts.append("persona=teammate (use conversational prose, no bullets or emoji)")
         if context_parts:
             context_section = "\n\nSession context:\n" + "\n".join(context_parts) + "\n"
@@ -1548,7 +1548,7 @@ def _compose_structured_draft(summary_text: str, session=None, is_completion: bo
 
     # Teammate bypass: return prose directly without emoji prefix, bullet parsing,
     # or structured template. The LLM draft is already in conversational form.
-    if session and (getattr(session, "session_mode", None) == PersonaType.TEAMMATE):
+    if session and (getattr(session, "session_type", None) == SessionType.TEAMMATE):
         return summary_text.strip()
 
     # Parse questions from LLM output

--- a/docs/features/pm-dev-session-architecture.md
+++ b/docs/features/pm-dev-session-architecture.md
@@ -26,7 +26,7 @@ Session type derivation from resolved persona:
 - **Teammate persona** -> `session_type="teammate"` (Teammate session, conversational). Handles informational queries directly.
 - **PM, or unconfigured** -> `session_type="pm"` (PM session, PM persona). This includes SDLC work. The PM session decides whether to spawn a Dev session.
 
-There are exactly three session types: `pm`, `teammate`, and `dev`. The previous `chat` session type has been renamed to `pm` and `teammate` has been promoted from a secondary `session_mode` flag to a first-class session type. `session_type` is the **sole discriminator** for routing, permission injection, summarizer formatting, and nudge cap selection — the legacy `session_mode` field on `AgentSession` is deprecated (kept as a no-op `Field(null=True)` for 30-day Redis TTL safety) and has zero readers/writers in application code. See [Config-Driven Chat Mode](config-driven-chat-mode.md) for the config schema and resolution order.
+There are exactly three session types: `pm`, `teammate`, and `dev`. `session_type` is the **sole discriminator** for routing, permission injection, summarizer formatting, and nudge cap selection. The `session_mode` field on `AgentSession` remains as a no-op `Field(null=True)` purely to keep Redis deserialization safe for in-flight records during the 30-day TTL window; it has zero readers and zero writers in application code. See [Config-Driven Chat Mode](config-driven-chat-mode.md) for the config schema and resolution order.
 
 ## Enforcement — PM Session Tool Restrictions
 

--- a/docs/features/pm-dev-session-architecture.md
+++ b/docs/features/pm-dev-session-architecture.md
@@ -26,7 +26,7 @@ Session type derivation from resolved persona:
 - **Teammate persona** -> `session_type="teammate"` (Teammate session, conversational). Handles informational queries directly.
 - **PM, or unconfigured** -> `session_type="pm"` (PM session, PM persona). This includes SDLC work. The PM session decides whether to spawn a Dev session.
 
-There are exactly three session types: `pm`, `teammate`, and `dev`. The previous `chat` session type has been renamed to `pm` and `teammate` has been promoted from a secondary `session_mode` flag to a first-class session type. See [Config-Driven Chat Mode](config-driven-chat-mode.md) for the config schema and resolution order.
+There are exactly three session types: `pm`, `teammate`, and `dev`. The previous `chat` session type has been renamed to `pm` and `teammate` has been promoted from a secondary `session_mode` flag to a first-class session type. `session_type` is the **sole discriminator** for routing, permission injection, summarizer formatting, and nudge cap selection — the legacy `session_mode` field on `AgentSession` is deprecated (kept as a no-op `Field(null=True)` for 30-day Redis TTL safety) and has zero readers/writers in application code. See [Config-Driven Chat Mode](config-driven-chat-mode.md) for the config schema and resolution order.
 
 ## Enforcement — PM Session Tool Restrictions
 

--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -1,7 +1,6 @@
 """AgentSession model - unified lifecycle tracking for agent work.
 
-Single Popoto model with session_type discriminator ("pm", "teammate", or "dev")
-and an optional role field for flexible specialization within each session type.
+Single Popoto model with session_type discriminator ("pm", "teammate", or "dev").
 
 Popoto does not support model inheritance, so PM and Dev sessions are
 distinguished by the session_type field with factory methods and derived
@@ -15,14 +14,11 @@ Session types (permission model):
   Dev session (session_type="dev"): Full-permission Agent SDK session, Dev persona.
     Does the actual coding work, runs SDLC pipeline stages.
 
-Roles (specialization within a session type):
-  "pm"  - Project manager role (default for PM sessions)
-  "dev" - Developer role (default for dev sessions)
-  None  - Unspecialized (legacy or generic sessions)
-
 Parent-child relationship:
-  parent_agent_session_id is the canonical parent link (role-neutral).
-  Use create_child(role=...) to spawn child sessions.
+  parent_agent_session_id is the canonical parent link.
+  parent_session_id and parent_chat_session_id are deprecated aliases that
+  delegate to parent_agent_session_id via property.
+  Use create_child() to spawn child sessions.
 
 Status lifecycle (see models/session_lifecycle.py for canonical mutation functions):
   Non-terminal: pending -> running -> active -> dormant | waiting_for_children | superseded
@@ -79,7 +75,7 @@ class AgentSession(Model):
     """Unified model for all Agent SDK sessions, discriminated by session_type.
 
     Single Popoto model with a session_type discriminator ("pm", "teammate",
-    or "dev") and an optional role field for flexible specialization.
+    or "dev").
 
     Session types (permission model):
         PM session (session_type="pm"):
@@ -92,20 +88,15 @@ class AgentSession(Model):
             Full-permission Agent SDK session, Dev persona. Does the actual
             coding work, runs SDLC pipeline stages.
 
-    Roles (specialization):
-        "pm"  - Project manager (default for PM sessions)
-        "dev" - Developer (default for dev sessions)
-        None  - Unspecialized (legacy or generic sessions)
-
     Parent-child hierarchy:
-        parent_agent_session_id: Canonical parent link (role-neutral). Set
+        parent_agent_session_id: Canonical parent link. Set
             by all session creators (create_child, create_dev, enqueue_session).
 
     Factory methods:
         create_pm(): Create a PM session (PM persona, read-only).
         create_teammate(): Create a Teammate session (read-only).
-        create_child(role=...): Create a child session with the given role.
-        create_dev(): Backward-compat wrapper for create_child(role="dev").
+        create_child(): Create a child Dev session.
+        create_dev(): Backward-compat wrapper for create_child().
         create_local(): Create a local CLI session.
 
     Status values (13 total):
@@ -193,7 +184,7 @@ class AgentSession(Model):
     # === Watchdog fields ===
     watchdog_unhealthy = Field(null=True)  # Reason string when flagged unhealthy, None when healthy
 
-    # === Session mode ===
+    # === Session mode (deprecated — use session_type. Kept as no-op for 30-day Redis TTL safety.) ===
     session_mode = Field(null=True)
 
     # === Semantic routing fields ===
@@ -222,9 +213,6 @@ class AgentSession(Model):
 
     # === Dev session fields (null when session_type="pm" or "teammate") ===
     slug = Field(null=True)  # Derives branch, plan path, worktree
-
-    # === Role field (flexible specialization beyond session_type) ===
-    role = Field(null=True)  # "pm", "dev", or None for unspecialized sessions
 
     # === Session hierarchy fields ===
     parent_agent_session_id = KeyField(null=True)
@@ -312,22 +300,10 @@ class AgentSession(Model):
         "last_stdout_at",
     }
 
-    # Known roles for validation
-    _KNOWN_ROLES = {"pm", "dev"}
-
     def __init__(self, **kwargs):
         """Initialize AgentSession with backward-compatible field name support."""
         kwargs = self.__class__._normalize_kwargs(kwargs)
         super().__init__(**kwargs)
-
-    def save(self, *args, **kwargs):
-        """Save with soft validation: warn if role is None."""
-        if getattr(self, "role", None) is None and getattr(self, "session_type", None):
-            logger.debug(
-                f"AgentSession {getattr(self, 'session_id', '?')} saved with role=None "
-                f"(session_type={self.session_type})"
-            )
-        return super().save(*args, **kwargs)
 
     def __setattr__(self, name, value):
         """Auto-convert timestamps to datetime for DatetimeField fields.
@@ -1071,7 +1047,6 @@ class AgentSession(Model):
     def create_child(
         cls,
         *,
-        role: str | None = None,
         session_id: str,
         project_key: str,
         working_dir: str,
@@ -1081,10 +1056,9 @@ class AgentSession(Model):
         stage_states: dict | None = None,
         **kwargs,
     ) -> "AgentSession":
-        """Create a child AgentSession with the given role.
+        """Create a child Dev AgentSession.
 
         Args:
-            role: Session role (e.g., "dev", "pm"). Defaults to None.
             session_id: Unique session identifier.
             project_key: Project this session belongs to.
             working_dir: Working directory for the session.
@@ -1110,7 +1084,6 @@ class AgentSession(Model):
             parent_agent_session_id=parent_agent_session_id,
             initial_telegram_message=itm,
             slug=slug,
-            role=role,
             session_events=initial_events,
             created_at=datetime.now(tz=UTC),
             **kwargs,
@@ -1131,12 +1104,11 @@ class AgentSession(Model):
         stage_states: dict | None = None,
         **kwargs,
     ) -> "AgentSession":
-        """Create a Dev session (backward-compat wrapper for create_child(role='dev')).
+        """Create a Dev session (backward-compat wrapper for create_child()).
 
-        Deprecated: Use create_child(role="dev", ...) instead.
+        Deprecated: Use create_child(...) instead.
         """
         return cls.create_child(
-            role="dev",
             session_id=session_id,
             project_key=project_key,
             working_dir=working_dir,

--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -184,7 +184,8 @@ class AgentSession(Model):
     # === Watchdog fields ===
     watchdog_unhealthy = Field(null=True)  # Reason string when flagged unhealthy, None when healthy
 
-    # === Session mode (deprecated — use session_type. Kept as no-op for 30-day Redis TTL safety.) ===
+    # === Session mode (deprecated — use session_type) ===
+    # Kept as no-op Field(null=True) for 30-day Redis TTL safety on old records.
     session_mode = Field(null=True)
 
     # === Semantic routing fields ===

--- a/tests/unit/test_message_drafter.py
+++ b/tests/unit/test_message_drafter.py
@@ -20,6 +20,7 @@ from bridge.message_drafter import (
     draft_message,
     extract_artifacts,
 )
+from config.enums import SessionType
 from models.agent_session import SDLC_STAGES
 
 
@@ -36,7 +37,6 @@ def _mock_session_with_stages(stage_dict, links=None):
     session.issue_url = (links or {}).get("issue")
     session.plan_url = (links or {}).get("plan")
     session.pr_url = (links or {}).get("pr")
-    session.session_mode = None  # Default: not a Teammate session
     return session
 
 
@@ -1110,7 +1110,7 @@ class TestComposeStructuredDraft:
         from unittest.mock import MagicMock
 
         session = MagicMock()
-        session.session_mode = "teammate"
+        session.session_type = SessionType.TEAMMATE
         session.session_id = None  # Skip Redis refresh
 
         result = _compose_structured_draft(
@@ -1125,11 +1125,11 @@ class TestComposeStructuredDraft:
         assert "bridge uses Telethon" in result
 
     def test_non_teammate_mode_still_gets_structured(self):
-        """Non-Teammate sessions with session_mode=None still get structured formatting."""
+        """Non-Teammate sessions (session_type != TEAMMATE) still get structured formatting."""
         from unittest.mock import MagicMock
 
         session = MagicMock()
-        session.session_mode = None
+        session.session_type = SessionType.PM
         session.session_id = None
         session.status = "completed"
 
@@ -1158,7 +1158,7 @@ class TestNoMessageEcho:
         session.message_text = "continue"
         session.status = "running"
         session.is_sdlc = True
-        session.session_mode = None
+        session.session_type = SessionType.PM
 
         result = _compose_structured_draft(
             "• Built the bypass\n• Tests passing", session=session, is_completion=True
@@ -1176,7 +1176,7 @@ class TestNoMessageEcho:
         session._get_history_list.return_value = ["[user] What time is it?"]
         session.message_text = "What time is it?"
         session.status = "completed"
-        session.session_mode = None
+        session.session_type = SessionType.PM
         session.get_links.return_value = {}
 
         result = _compose_structured_draft("It's 3pm UTC+7", session=session, is_completion=True)
@@ -1300,7 +1300,7 @@ class TestComposeStructuredDraftWithSession:
     def test_teammate_mode_session_returns_prose(self):
         """Teammate session bypasses all structured formatting."""
         session = _mock_session_with_stages({})
-        session.session_mode = "teammate"
+        session.session_type = SessionType.TEAMMATE
         session.session_id = None  # Skip Redis refresh
         session.message_text = "How does the bridge work?"
         session.status = "completed"

--- a/tests/unit/test_qa_nudge_cap.py
+++ b/tests/unit/test_qa_nudge_cap.py
@@ -46,13 +46,19 @@ class TestTeammateReactionClearing:
         """Teammate sessions should clear the processing reaction (None) on success."""
         from unittest.mock import MagicMock
 
-        session = MagicMock()
-        session.session_mode = "teammate"
+        from config.enums import SessionType
 
-        # The reaction logic in agent_session_queue.py checks session_mode and returns None
+        agent_session = MagicMock()
+        agent_session.session_type = SessionType.TEAMMATE
+
+        # The reaction logic in agent/session_executor.py checks session_type and returns None
         # for successful Teammate sessions. We test the conditional directly.
         task_error = False
-        if session and getattr(session, "session_mode", None) == "teammate" and not task_error:
+        if (
+            agent_session
+            and getattr(agent_session, "session_type", None) == SessionType.TEAMMATE
+            and not task_error
+        ):
             emoji = None
         else:
             emoji = "completion"
@@ -62,11 +68,17 @@ class TestTeammateReactionClearing:
         """Non-Teammate sessions should still get a completion emoji."""
         from unittest.mock import MagicMock
 
-        session = MagicMock()
-        session.session_mode = None
+        from config.enums import SessionType
+
+        agent_session = MagicMock()
+        agent_session.session_type = SessionType.PM
 
         task_error = False
-        if session and getattr(session, "session_mode", None) == "teammate" and not task_error:
+        if (
+            agent_session
+            and getattr(agent_session, "session_type", None) == SessionType.TEAMMATE
+            and not task_error
+        ):
             emoji = None
         else:
             emoji = "completion"
@@ -76,11 +88,17 @@ class TestTeammateReactionClearing:
         """Teammate sessions with errors should still get error reaction."""
         from unittest.mock import MagicMock
 
-        session = MagicMock()
-        session.session_mode = "teammate"
+        from config.enums import SessionType
+
+        agent_session = MagicMock()
+        agent_session.session_type = SessionType.TEAMMATE
 
         task_error = True
-        if session and getattr(session, "session_mode", None) == "teammate" and not task_error:
+        if (
+            agent_session
+            and getattr(agent_session, "session_type", None) == SessionType.TEAMMATE
+            and not task_error
+        ):
             emoji = None
         else:
             emoji = "error"

--- a/tests/unit/test_ui_sdlc_data.py
+++ b/tests/unit/test_ui_sdlc_data.py
@@ -20,7 +20,6 @@ def _make_mock_session(**overrides):
         "agent_session_id": "mock-session-1",
         "session_id": "sess-1",
         "session_type": "dev",
-        "session_mode": None,
         "status": "running",
         "slug": None,
         "message_text": "test message",
@@ -542,7 +541,6 @@ class TestSessionToPipeline:
         mock_session.agent_session_id = "old-session"
         mock_session.session_id = "sess-1"
         mock_session.session_type = "dev"
-        mock_session.session_mode = None
         mock_session.status = "completed"
         mock_session.slug = None
         mock_session.message_text = "old message"

--- a/tools/valor_session.py
+++ b/tools/valor_session.py
@@ -169,14 +169,19 @@ def cmd_create(args: argparse.Namespace) -> int:
 
         from agent.agent_session_queue import _push_agent_session
         from bridge.utc import utc_now
+        from config.enums import SessionType
 
-        _ROLE_TO_SESSION_TYPE = {"pm": "pm", "dev": "dev", "teammate": "teammate"}
+        _role_to_session_type = {
+            "pm": SessionType.PM,
+            "dev": SessionType.DEV,
+            "teammate": SessionType.TEAMMATE,
+        }
         role = args.role or "pm"
-        if role not in _ROLE_TO_SESSION_TYPE:
+        if role not in _role_to_session_type:
             raise ValueError(
-                f"Unknown --role value: {role!r}. Allowed values: {sorted(_ROLE_TO_SESSION_TYPE)}"
+                f"Unknown --role value: {role!r}. Allowed values: {sorted(_role_to_session_type)}"
             )
-        session_type = _ROLE_TO_SESSION_TYPE[role]
+        session_type = _role_to_session_type[role]
         message = args.message
         chat_id = args.chat_id or "0"
         parent_id = getattr(args, "parent", None)
@@ -611,9 +616,7 @@ def cmd_list(args: argparse.Namespace) -> int:
         # Client-side role filter — matches on session_type only
         if role_filter:
             all_sessions = [
-                s
-                for s in all_sessions
-                if getattr(s, "session_type", None) == role_filter
+                s for s in all_sessions if getattr(s, "session_type", None) == role_filter
             ]
 
         # Sort by created_at descending

--- a/tools/valor_session.py
+++ b/tools/valor_session.py
@@ -170,7 +170,13 @@ def cmd_create(args: argparse.Namespace) -> int:
         from agent.agent_session_queue import _push_agent_session
         from bridge.utc import utc_now
 
+        _ROLE_TO_SESSION_TYPE = {"pm": "pm", "dev": "dev", "teammate": "teammate"}
         role = args.role or "pm"
+        if role not in _ROLE_TO_SESSION_TYPE:
+            raise ValueError(
+                f"Unknown --role value: {role!r}. Allowed values: {sorted(_ROLE_TO_SESSION_TYPE)}"
+            )
+        session_type = _ROLE_TO_SESSION_TYPE[role]
         message = args.message
         chat_id = args.chat_id or "0"
         parent_id = getattr(args, "parent", None)
@@ -191,8 +197,6 @@ def cmd_create(args: argparse.Namespace) -> int:
             wt_path = get_or_create_worktree(Path(working_dir), slug)
             working_dir = str(wt_path)
             print(f"  Worktree:    {working_dir}", file=sys.stderr)
-
-        session_type = role  # pm, dev, teammate
 
         # Resolve project_key: explicit flag takes priority, else derive from cwd
         explicit_key = getattr(args, "project_key", None)
@@ -402,7 +406,6 @@ def cmd_status(args: argparse.Namespace) -> int:
                 "session_id": session.session_id,
                 "status": session.status,
                 "session_type": getattr(session, "session_type", None),
-                "role": getattr(session, "role", None),
                 "auto_continue_count": session.auto_continue_count,
                 "created_at": str(session.created_at) if session.created_at else None,
                 "started_at": str(session.started_at) if session.started_at else None,
@@ -428,8 +431,7 @@ def cmd_status(args: argparse.Namespace) -> int:
         if worker_healthy is False:
             print("  WARNING: No active worker — session may wait indefinitely.", file=sys.stderr)
         stype = getattr(session, "session_type", "—")
-        srole = getattr(session, "role", "—")
-        print(f"  Type/Role:     {stype} / {srole}")
+        print(f"  Type:          {stype}")
         print(f"  Auto-continue: {session.auto_continue_count}")
         print(f"  Created:       {_format_ts(session.created_at)}")
         print(f"  Started:       {_format_ts(session.started_at)}")
@@ -548,7 +550,6 @@ def cmd_children(args: argparse.Namespace) -> int:
                     "agent_session_id": s.agent_session_id,
                     "status": s.status,
                     "session_type": getattr(s, "session_type", None),
-                    "role": getattr(s, "role", None),
                     "created_at": str(s.created_at) if s.created_at else None,
                     "message_preview": (s.message_text or "")[:120],
                 }
@@ -566,7 +567,7 @@ def cmd_children(args: argparse.Namespace) -> int:
         for s in all_children:
             sid = s.session_id or "—"
             status = s.status or "—"
-            stype = getattr(s, "session_type", None) or getattr(s, "role", None) or "—"
+            stype = getattr(s, "session_type", None) or "—"
             created = _format_ts(s.created_at)
             msg = (s.message_text or "")[:60]
             print(f"  {sid:<38} {status:<12} {stype:<8} {created:<22} {msg}")
@@ -607,13 +608,12 @@ def cmd_list(args: argparse.Namespace) -> int:
                 except Exception:
                     pass
 
-        # Client-side role filter
+        # Client-side role filter — matches on session_type only
         if role_filter:
             all_sessions = [
                 s
                 for s in all_sessions
-                if getattr(s, "role", None) == role_filter
-                or getattr(s, "session_type", None) == role_filter
+                if getattr(s, "session_type", None) == role_filter
             ]
 
         # Sort by created_at descending
@@ -638,7 +638,6 @@ def cmd_list(args: argparse.Namespace) -> int:
                     "status": s.status,
                     "priority": getattr(s, "priority", None) or "normal",
                     "session_type": getattr(s, "session_type", None),
-                    "role": getattr(s, "role", None),
                     "auto_continue_count": s.auto_continue_count,
                     "created_at": str(s.created_at) if s.created_at else None,
                     "message_preview": (s.message_text or "")[:60],
@@ -665,7 +664,7 @@ def cmd_list(args: argparse.Namespace) -> int:
                 sid = sid[:31] + "..."
             status = s.status or "—"
             priority = getattr(s, "priority", None) or "normal"
-            stype = getattr(s, "session_type", None) or getattr(s, "role", None) or "—"
+            stype = getattr(s, "session_type", None) or "—"
             nudges = s.auto_continue_count or 0
             created = _format_ts(s.created_at)
             msg = (s.message_text or "")[:38]

--- a/ui/data/sdlc.py
+++ b/ui/data/sdlc.py
@@ -18,7 +18,7 @@ import time
 from pydantic import BaseModel
 
 from agent.pipeline_graph import DISPLAY_STAGES
-from config.enums import PersonaType
+from config.enums import PersonaType, SessionType
 
 logger = logging.getLogger(__name__)
 
@@ -464,34 +464,22 @@ def _parse_history(history_list: list | None) -> list[PipelineEvent]:
 
 
 def _resolve_persona_display(session) -> str | None:
-    """Map session_mode and session_type into a dashboard display persona.
+    """Map session_type into a dashboard display persona.
 
-    session_mode takes priority when set:
-      session_mode="teammate"         → "Teammate"
-      session_mode="project-manager"  → "Project Manager"
-      session_mode="developer"        → "Developer"
-
-    Fallback from session_type:
-      session_type="dev"              → "Developer"
-      session_type="chat"             → "Project Manager"
+    session_type is the sole discriminator:
+      session_type="teammate"  → "Teammate"
+      session_type="pm"        → "Project Manager"
+      session_type="dev"       → "Developer"
     """
-    mode = getattr(session, "session_mode", None)
-    if mode == PersonaType.TEAMMATE:
-        return "Teammate"
-    if mode == PersonaType.PROJECT_MANAGER:
-        return "Project Manager"
-    if mode == PersonaType.DEVELOPER:
-        return "Developer"
-
     raw = getattr(session, "session_type", None)
     if raw is None:
         return None
-    if raw == "dev":
-        return "Developer"
-    if raw == "pm":
-        return "Project Manager"
-    if raw == "teammate":
+    if raw == SessionType.TEAMMATE:
         return "Teammate"
+    if raw == SessionType.PM:
+        return "Project Manager"
+    if raw == SessionType.DEV:
+        return "Developer"
     if raw == "chat":
         return "Project Manager"  # Legacy fallback for pre-migration sessions
     return _safe_str(raw)


### PR DESCRIPTION
## Summary
- Collapses `session_mode` field into `session_type`, eliminating the overlapping `role` field
- Updates all consumers to use `session_type` as the canonical field
- Updates tests and documentation to reflect the new field naming

## Related Issue
Closes #1026

## Test plan
- [ ] `pytest tests/unit/` passes
- [ ] `pytest tests/integration/` passes
- [ ] No references to deprecated `session_mode` or `role` remain in active code