### PR TITLE
Unblock worker event loop — memory extraction hotfix (Layers 1+2)

### DIFF
--- a/agent/memory_extraction.py
+++ b/agent/memory_extraction.py
@@ -9,10 +9,19 @@ into ObservationProtocol.
 
 All operations are async, wrapped in try/except — failures must never
 crash the agent or block session completion.
+
+Event-loop safety invariant (hotfix #1055):
+    Every Anthropic call in this module MUST use ``anthropic.AsyncAnthropic``
+    inside ``async with`` for deterministic httpx cleanup, wrapped in
+    ``asyncio.wait_for(..., timeout=_EXTRACTION_HARD_TIMEOUT)`` with an
+    SDK-level ``timeout=_EXTRACTION_SDK_TIMEOUT`` kwarg. Sync ``anthropic.Anthropic``
+    is forbidden here — it blocks the worker event loop for arbitrary durations
+    on half-open TCP sockets (empirically observed: 6-hour stall on #1055).
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -20,6 +29,47 @@ import re
 import time
 
 logger = logging.getLogger(__name__)
+
+# Timeout constants for Anthropic extraction calls (hotfix #1055).
+#
+# Double-timeout rationale:
+#   - _EXTRACTION_SDK_TIMEOUT: passed to messages.create(timeout=...) so the
+#     Anthropic SDK (httpx) raises APITimeoutError on idle/slow sockets.
+#   - _EXTRACTION_HARD_TIMEOUT: outer asyncio.wait_for; fires from a separate
+#     asyncio timer so it still fires even when the SDK timer does not (e.g.,
+#     half-open TCP sockets where no socket event ever arrives).
+#   - 5s buffer lets the SDK raise its own typed error first for cleaner logs.
+_EXTRACTION_SDK_TIMEOUT = 30.0
+_EXTRACTION_HARD_TIMEOUT = 35.0
+
+
+def _record_extraction_error(
+    error_class: str,
+    session_id: str,
+    project_key: str | None = None,
+) -> None:
+    """Emit ``memory.extraction.error`` analytics counter (hotfix #1055).
+
+    Non-fatal — silent if analytics unavailable. Skips ``CancelledError`` which
+    is expected on worker shutdown and carries no signal. Every ``except``
+    branch in this module's three async-Anthropic call sites must call this.
+    """
+    if error_class == "CancelledError":
+        return
+    try:
+        from analytics.collector import record_metric
+
+        record_metric(
+            "memory.extraction.error",
+            1.0,
+            {
+                "error_class": error_class.lower(),
+                "session_id": session_id,
+                "project_key": project_key or "",
+            },
+        )
+    except Exception:
+        pass
 
 # Extraction prompt for Haiku — structured JSON output
 EXTRACTION_PROMPT = (
@@ -97,21 +147,38 @@ async def extract_observations_async(
             logger.warning("[memory_extraction] No Anthropic API key, skipping extraction")
             return []
 
-        client = anthropic.Anthropic(api_key=api_key)
-
         # Truncate response to avoid token limits
         truncated = response_text[:8000]
 
-        message = client.messages.create(
-            model=MODEL_FAST,
-            max_tokens=500,
-            messages=[
-                {
-                    "role": "user",
-                    "content": f"{EXTRACTION_PROMPT}\n\n---\n\n{truncated}",
-                }
-            ],
-        )
+        # hotfix #1055: AsyncAnthropic + double-timeout + async with for httpx cleanup.
+        # Sync anthropic.Anthropic is forbidden here — it blocks the worker event loop.
+        try:
+            async with anthropic.AsyncAnthropic(
+                api_key=api_key, timeout=_EXTRACTION_SDK_TIMEOUT
+            ) as client:
+                message = await asyncio.wait_for(
+                    client.messages.create(
+                        model=MODEL_FAST,
+                        max_tokens=500,
+                        messages=[
+                            {
+                                "role": "user",
+                                "content": f"{EXTRACTION_PROMPT}\n\n---\n\n{truncated}",
+                            }
+                        ],
+                        timeout=_EXTRACTION_SDK_TIMEOUT,
+                    ),
+                    timeout=_EXTRACTION_HARD_TIMEOUT,
+                )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[memory_extraction] Anthropic call exceeded %.1fs hard timeout (non-fatal); "
+                "extraction skipped for session_id=%s",
+                _EXTRACTION_HARD_TIMEOUT,
+                session_id,
+            )
+            _record_extraction_error("TimeoutError", session_id, project_key)
+            return []
 
         raw_text = message.content[0].text.strip()
 
@@ -171,6 +238,7 @@ async def extract_observations_async(
 
     except Exception as e:
         logger.warning(f"[memory_extraction] Extraction failed (non-fatal): {e}")
+        _record_extraction_error(type(e).__name__, session_id, project_key)
         return []
 
 
@@ -274,19 +342,39 @@ async def extract_post_merge_learning(
             )
             return None
 
-        client = anthropic.Anthropic(api_key=api_key)
-
         prompt = POST_MERGE_EXTRACTION_PROMPT.format(
             title=pr_title,
             body=(pr_body or "")[:4000],
             diff_summary=(diff_summary or "")[:4000],
         )
 
-        message = client.messages.create(
-            model=MODEL_FAST,
-            max_tokens=200,
-            messages=[{"role": "user", "content": prompt}],
-        )
+        # hotfix #1055: AsyncAnthropic + double-timeout + async with.
+        # Called from .claude/hooks/hook_utils/memory_bridge.py::post_merge_extract()
+        # via asyncio.run(...). The async-with + asyncio.wait_for pattern is still
+        # safe under asyncio.run because both helpers are reentrant-free and
+        # produce no nested loops. Guarded by
+        # test_extract_post_merge_learning_runs_inside_asyncio_run.
+        try:
+            async with anthropic.AsyncAnthropic(
+                api_key=api_key, timeout=_EXTRACTION_SDK_TIMEOUT
+            ) as client:
+                message = await asyncio.wait_for(
+                    client.messages.create(
+                        model=MODEL_FAST,
+                        max_tokens=200,
+                        messages=[{"role": "user", "content": prompt}],
+                        timeout=_EXTRACTION_SDK_TIMEOUT,
+                    ),
+                    timeout=_EXTRACTION_HARD_TIMEOUT,
+                )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[memory_extraction] Post-merge Anthropic call exceeded %.1fs hard timeout "
+                "(non-fatal); post-merge learning skipped",
+                _EXTRACTION_HARD_TIMEOUT,
+            )
+            _record_extraction_error("TimeoutError", "post-merge", project_key)
+            return None
 
         raw_text = message.content[0].text.strip()
 
@@ -342,6 +430,7 @@ async def extract_post_merge_learning(
 
     except Exception as e:
         logger.warning(f"[memory_extraction] Post-merge extraction failed (non-fatal): {e}")
+        _record_extraction_error(type(e).__name__, "post-merge", project_key)
         return None
 
 
@@ -374,7 +463,7 @@ _OUTCOME_THOUGHT_MAX_CHARS = 500
 _OUTCOME_MAX_THOUGHTS = 5
 
 
-def _judge_outcomes_llm(
+async def _judge_outcomes_llm(
     injected_thoughts: list[tuple[str, str]],
     response_text: str,
 ) -> dict[str, dict] | None:
@@ -385,6 +474,9 @@ def _judge_outcomes_llm(
 
     Maps "echoed" to "dismissed" for ObservationProtocol compatibility --
     echoed keywords without causal influence are noise, not signal.
+
+    Event-loop safety (hotfix #1055): uses AsyncAnthropic with double-timeout
+    inside ``async with`` for deterministic httpx cleanup.
     """
     try:
         import anthropic
@@ -409,12 +501,28 @@ def _judge_outcomes_llm(
             response=truncated_response,
         )
 
-        client = anthropic.Anthropic(api_key=api_key)
-        message = client.messages.create(
-            model=MODEL_FAST,
-            max_tokens=300,
-            messages=[{"role": "user", "content": prompt}],
-        )
+        # hotfix #1055: AsyncAnthropic + double-timeout + async with.
+        try:
+            async with anthropic.AsyncAnthropic(
+                api_key=api_key, timeout=_EXTRACTION_SDK_TIMEOUT
+            ) as client:
+                message = await asyncio.wait_for(
+                    client.messages.create(
+                        model=MODEL_FAST,
+                        max_tokens=300,
+                        messages=[{"role": "user", "content": prompt}],
+                        timeout=_EXTRACTION_SDK_TIMEOUT,
+                    ),
+                    timeout=_EXTRACTION_HARD_TIMEOUT,
+                )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[memory_extraction] Outcome judgment Anthropic call exceeded %.1fs "
+                "hard timeout (non-fatal); falling back to bigram overlap",
+                _EXTRACTION_HARD_TIMEOUT,
+            )
+            _record_extraction_error("TimeoutError", "outcome-judgment", None)
+            return None
 
         raw_text = message.content[0].text.strip()
         judgments = json.loads(raw_text)
@@ -450,6 +558,7 @@ def _judge_outcomes_llm(
 
     except Exception as e:
         logger.debug(f"[memory_extraction] LLM outcome judgment failed, will use fallback: {e}")
+        _record_extraction_error(type(e).__name__, "outcome-judgment", None)
         return None
 
 
@@ -579,8 +688,8 @@ async def detect_outcomes_async(
         reasoning_map: dict[str, str] = {}
         memory_keys: list[str] = []
 
-        # Try LLM judgment first
-        llm_result = _judge_outcomes_llm(injected_thoughts, response_text)
+        # Try LLM judgment first (hotfix #1055: now async-native via AsyncAnthropic)
+        llm_result = await _judge_outcomes_llm(injected_thoughts, response_text)
 
         if llm_result is not None:
             # LLM judgment succeeded -- use it
@@ -652,6 +761,7 @@ async def detect_outcomes_async(
 
     except Exception as e:
         logger.warning(f"[memory_extraction] Outcome detection failed (non-fatal): {e}")
+        _record_extraction_error(type(e).__name__, "detect-outcomes", None)
         return {}
 
 

--- a/agent/memory_extraction.py
+++ b/agent/memory_extraction.py
@@ -71,6 +71,7 @@ def _record_extraction_error(
     except Exception:
         pass
 
+
 # Extraction prompt for Haiku — structured JSON output
 EXTRACTION_PROMPT = (
     "Extract novel observations from this agent session response.\n"

--- a/agent/memory_extraction.py
+++ b/agent/memory_extraction.py
@@ -171,7 +171,7 @@ async def extract_observations_async(
                     ),
                     timeout=_EXTRACTION_HARD_TIMEOUT,
                 )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             logger.warning(
                 "[memory_extraction] Anthropic call exceeded %.1fs hard timeout (non-fatal); "
                 "extraction skipped for session_id=%s",
@@ -368,7 +368,7 @@ async def extract_post_merge_learning(
                     ),
                     timeout=_EXTRACTION_HARD_TIMEOUT,
                 )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             logger.warning(
                 "[memory_extraction] Post-merge Anthropic call exceeded %.1fs hard timeout "
                 "(non-fatal); post-merge learning skipped",
@@ -516,7 +516,7 @@ async def _judge_outcomes_llm(
                     ),
                     timeout=_EXTRACTION_HARD_TIMEOUT,
                 )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             logger.warning(
                 "[memory_extraction] Outcome judgment Anthropic call exceeded %.1fs "
                 "hard timeout (non-fatal); falling back to bigram overlap",

--- a/agent/messenger.py
+++ b/agent/messenger.py
@@ -203,24 +203,23 @@ class BackgroundTask:
         logger.info(f"[{self.messenger.session_id}] Background task started")
 
     async def _run_work(self, coro: Awaitable[str], send_result: bool) -> None:
-        """Execute the work and handle completion."""
+        """Execute the work and handle completion.
+
+        Note (hotfix #1055): Post-session memory extraction is NO LONGER called
+        from here. It is scheduled by ``agent/session_executor.py::
+        _schedule_post_session_extraction`` AFTER ``complete_transcript(...)``
+        runs, as a fire-and-forget ``asyncio.create_task`` — so a hang in
+        extraction cannot block session finalization or the dev→PM nudge.
+        Do NOT re-introduce an ``await run_post_session_extraction(...)``
+        block here: it would couple extraction latency to ``_run_work`` and
+        regress the 6-hour stall observed in #1055.
+        """
         try:
             self._result = await coro
             self._completed_at = utc_now()
 
             if send_result and self._result:
                 await self.messenger.send(self._result, message_type="result")
-
-            # Post-session memory extraction (non-fatal, async)
-            try:
-                from agent.memory_extraction import run_post_session_extraction
-
-                await run_post_session_extraction(
-                    session_id=self.messenger.session_id,
-                    response_text=str(self._result or ""),
-                )
-            except Exception as mem_err:
-                logger.debug(f"[{self.messenger.session_id}] Memory extraction skipped: {mem_err}")
 
         except Exception as e:
             self._error = e

--- a/agent/session_executor.py
+++ b/agent/session_executor.py
@@ -122,7 +122,8 @@ async def drain_pending_extractions(timeout: float = 5.0) -> None:
         task.cancel()
     if still_pending:
         logger.warning(
-            "[memory_extraction] Cancelled %d extraction task(s) that did not complete within %.1fs",
+            "[memory_extraction] Cancelled %d extraction task(s) that did not complete "
+            "within %.1fs",
             len(still_pending),
             timeout,
         )

--- a/agent/session_executor.py
+++ b/agent/session_executor.py
@@ -29,6 +29,105 @@ from models.session_lifecycle import TERMINAL_STATUSES as _TERMINAL_STATUSES
 
 logger = logging.getLogger(__name__)
 
+# -----------------------------------------------------------------------------
+# Post-session memory extraction scheduling (hotfix #1055)
+# -----------------------------------------------------------------------------
+# Keyed by session_id to deduplicate when _execute_agent_session runs twice for
+# the same session (health-check revival, retry, manual resume). dict (not set)
+# is required so duplicate schedules can be detected and skipped BEFORE a second
+# create_task fires.
+_pending_extraction_tasks: dict[str, asyncio.Task] = {}
+
+
+def _schedule_post_session_extraction(session_id: str, response_text: str) -> None:
+    """Fire-and-forget post-session memory extraction (hotfix #1055).
+
+    Synchronous — creates and registers an ``asyncio.create_task``; does NOT
+    await it. Preserves the #987 ordering invariant:
+    ``_handle_dev_session_completion`` must run before this extraction task
+    completes, so the PM nudge fires promptly while extraction is still pending.
+
+    **CRITICAL**: this function is declared ``def`` (not ``async def``) and
+    returns ``None``. Any ``await`` or ``asyncio.gather(...)`` on its result
+    would re-couple extraction latency to the PM nudge and regress #987 /
+    #1055. A review-time invariant guards against this.
+
+    Deduplicates by ``session_id``: if a non-done task is already registered
+    for this session, logs at INFO and returns. Prevents duplicate observation
+    saves and a race on ``clear_session(session_id)`` when
+    ``_execute_agent_session`` runs twice for the same session (health-check
+    revival, retry, manual resume).
+
+    Extraction failures (including the hard timeout in
+    ``agent/memory_extraction.py``) are swallowed inside the task wrapper and
+    never propagate out of this scheduler. ``CancelledError`` is re-raised so
+    ``drain_pending_extractions`` can cooperate with worker shutdown.
+    """
+    existing = _pending_extraction_tasks.get(session_id)
+    if existing is not None and not existing.done():
+        logger.info(
+            "[memory_extraction] Extraction already in-flight for %s, skipping duplicate",
+            session_id,
+        )
+        return
+
+    async def _wrapper() -> None:
+        try:
+            from agent.memory_extraction import run_post_session_extraction
+
+            await run_post_session_extraction(session_id, response_text)
+        except asyncio.CancelledError:
+            raise  # preserve cancellation semantics for shutdown drain
+        except Exception as e:
+            logger.debug(
+                "[memory_extraction] Background extraction failed for %s (non-fatal): %s",
+                session_id,
+                e,
+            )
+
+    task = asyncio.create_task(_wrapper(), name=f"post_session_extraction:{session_id}")
+    _pending_extraction_tasks[session_id] = task
+    task.add_done_callback(lambda t: _pending_extraction_tasks.pop(session_id, None))
+
+
+async def drain_pending_extractions(timeout: float = 5.0) -> None:
+    """Drain in-flight post-session extraction tasks on worker shutdown (hotfix #1055).
+
+    No-op if ``_pending_extraction_tasks`` is empty (first-deploy case / worker
+    that never ran a session).
+
+    Wiring: called from ``worker/__main__.py`` shutdown sequence AFTER the
+    worker-task wait (line ~408, ``await asyncio.gather(*pending, ...)``)
+    and BEFORE the health/notify/reflection cancels. At that ordering:
+
+    - All worker loops have drained → every extraction that will be scheduled
+      has been scheduled.
+    - The event loop is still running → pending extractions can complete or be
+      cancelled cleanly.
+    - Health/notify/reflection tasks are still live → we are ordered before
+      their cancellation, avoiding a mid-cancel scheduling race.
+
+    Common case (extraction near-complete): the 5s window lets the typical
+    1-5s extraction finish. Stall case (extraction wedged past the 35s hard
+    timeout internally): we accept losing this on shutdown; the internal
+    hard-timeout already caps worst-case latency.
+    """
+    if not _pending_extraction_tasks:
+        return  # First-deploy case — nothing to drain
+
+    pending = list(_pending_extraction_tasks.values())
+    logger.info("[memory_extraction] Draining %d pending extraction task(s)", len(pending))
+    done, still_pending = await asyncio.wait(pending, timeout=timeout)
+    for task in still_pending:
+        task.cancel()
+    if still_pending:
+        logger.warning(
+            "[memory_extraction] Cancelled %d extraction task(s) that did not complete within %.1fs",
+            len(still_pending),
+            timeout,
+        )
+
+
 # Harness startup retry constants
 _HARNESS_NOT_FOUND_PREFIX = "Error: CLI harness not found"
 _HARNESS_NOT_FOUND_MAX_RETRIES = 3
@@ -1266,6 +1365,18 @@ async def _execute_agent_session(session: AgentSession) -> None:
                         session.agent_session_id,
                         e,
                     )
+
+        # Schedule post-session memory extraction (hotfix #1055) — fire-and-forget.
+        #
+        # CRITICAL: synchronous call (no await, no gather). Any awaiting here would
+        # re-couple extraction latency to the PM nudge below, regressing the 6-hour
+        # stall observed in #1055 and the #987 ordering invariant.
+        #
+        # Runs AFTER both complete_transcript paths above (happy path at ~L1320
+        # and the #917 fallback at ~L1346), and BEFORE _handle_dev_session_completion
+        # below. Extraction runs in the background; its completion or failure does
+        # not delay the PM nudge. See drain_pending_extractions() for shutdown wiring.
+        _schedule_post_session_extraction(session.session_id, task._result or "")
 
         # Post-completion SDLC handling for dev sessions (Phase 3)
         # IMPORTANT ORDERING INVARIANT: This call is placed AFTER the entire

--- a/docs/features/claude-code-memory.md
+++ b/docs/features/claude-code-memory.md
@@ -225,7 +225,7 @@ This is a parallel path to the Telegram agent memory system, not a replacement:
 | State management | In-memory dicts | JSON sidecar files |
 | Entry point | `agent/memory_hook.py` | `.claude/hooks/hook_utils/memory_bridge.py` |
 | Recall trigger | `check_and_inject()` in health check | `recall()` called from PostToolUse hook |
-| Extraction trigger | `run_post_session_extraction()` in messenger | `extract()` called from Stop hook |
+| Extraction trigger | `_schedule_post_session_extraction()` in session_executor (fire-and-forget after `complete_transcript`; hotfix #1055) | `extract()` called from Stop hook |
 | Ingestion | `Memory.safe_save()` in bridge | `ingest()` called from UserPromptSubmit hook |
 | Deja vu signals | `check_and_inject()` emits vague recognition and novel territory thoughts | `recall()` emits identical signals |
 | Post-merge learning | `extract_post_merge_learning()` in merge stage | `post_merge_extract()` triggered from Stop hook on `gh pr merge` detection |

--- a/docs/features/subconscious-memory.md
+++ b/docs/features/subconscious-memory.md
@@ -76,14 +76,28 @@ The PostToolUse hook in `agent/health_check.py` checks for relevant memories on 
 
 ### Flow 3: Post-Session Extraction
 
-After a session completes in `agent/messenger.py`:
+After a session completes, extraction is scheduled from `agent/session_executor.py` **after** `complete_transcript(...)` finalizes the session (hotfix #1055):
 
-1. `run_post_session_extraction()` is called after `BackgroundTask._result` is set
-2. Haiku extracts novel observations as structured JSON (category, observation text, file_paths, tags), with a line-based fallback parser for robustness
-3. Each observation is saved as Memory with categorized importance (corrections/decisions at 4.0, patterns/surprises at 1.0) and structured metadata attached via `DictField`
-4. Outcome detection uses LLM judgment (Haiku) to classify each injected thought as `"acted"` (response was influenced), `"echoed"` (keyword overlap but no causal link), or `"dismissed"` (no relationship). `"echoed"` maps to `"dismissed"` for scoring. Bigram overlap is retained as a zero-cost fallback when the Haiku call fails or is rate-limited.
-5. `ObservationProtocol.on_context_used()` strengthens acted-on memories and weakens dismissed ones
-6. `_persist_outcome_metadata()` runs after ObservationProtocol, updating `dismissal_count`, `last_outcome`, and `outcome_history` in each memory's metadata. Each history entry includes `outcome`, `reasoning` (one-sentence LLM explanation), and `ts` (unix timestamp), capped at 10 entries. When a memory reaches the dismissal threshold (3 consecutive dismissals), its importance is decayed by 0.7x (floor: 0.2). Acting on a memory resets the dismissal counter
+1. `_schedule_post_session_extraction(session_id, response_text)` registers a fire-and-forget `asyncio.create_task` in `_pending_extraction_tasks` (a `dict[str, asyncio.Task]` keyed by `session_id` for dedup). The scheduler is **synchronous** — it does not `await` — so the dev→PM nudge fires immediately, independent of extraction latency.
+2. Inside the task wrapper, `run_post_session_extraction()` runs extract_observations → detect_outcomes → cleanup in sequence.
+3. Haiku extracts novel observations as structured JSON (category, observation text, file_paths, tags), with a line-based fallback parser for robustness
+4. Each observation is saved as Memory with categorized importance (corrections/decisions at 4.0, patterns/surprises at 1.0) and structured metadata attached via `DictField`
+5. Outcome detection uses LLM judgment (Haiku) to classify each injected thought as `"acted"` (response was influenced), `"echoed"` (keyword overlap but no causal link), or `"dismissed"` (no relationship). `"echoed"` maps to `"dismissed"` for scoring. Bigram overlap is retained as a zero-cost fallback when the Haiku call fails or is rate-limited.
+6. `ObservationProtocol.on_context_used()` strengthens acted-on memories and weakens dismissed ones
+7. `_persist_outcome_metadata()` runs after ObservationProtocol, updating `dismissal_count`, `last_outcome`, and `outcome_history` in each memory's metadata. Each history entry includes `outcome`, `reasoning` (one-sentence LLM explanation), and `ts` (unix timestamp), capped at 10 entries. When a memory reaches the dismissal threshold (3 consecutive dismissals), its importance is decayed by 0.7x (floor: 0.2). Acting on a memory resets the dismissal counter
+
+#### Event-Loop Safety (hotfix #1055)
+
+Extraction is the only part of the memory system that runs on the worker event loop (the Telegram bridge and hook-subprocess paths are out-of-loop). Event-loop safety is enforced by four invariants:
+
+- **Async-native Anthropic client, never sync.** All three Anthropic call sites in `agent/memory_extraction.py` (`extract_observations_async`, `extract_post_merge_learning`, `_judge_outcomes_llm`) use `async with anthropic.AsyncAnthropic(...) as client:` + `await client.messages.create(...)`. The sync `anthropic.Anthropic(...)` client is forbidden in this module — it blocked the worker for six hours in a production incident on a half-open TCP socket. A unit test grep-canary (`test_no_sync_anthropic_client_grep_canary`) guards against regressions.
+- **Double-timeout** on every Anthropic call: an SDK-level `timeout=_EXTRACTION_SDK_TIMEOUT` (30s) passed to `messages.create(...)` AND an outer `asyncio.wait_for(..., timeout=_EXTRACTION_HARD_TIMEOUT)` (35s, 5s buffer). The inner SDK timeout raises `anthropic.APITimeoutError` cleanly under normal slow-path behavior; the outer `asyncio.wait_for` hard-stops when the SDK timer does not fire (e.g., half-open sockets where no socket event ever arrives). Both constants live at module scope in `agent/memory_extraction.py`.
+- **Fire-and-forget ordering.** `_schedule_post_session_extraction(...)` is declared `def` (not `async def`) and is called synchronously in `_execute_agent_session` AFTER `complete_transcript(...)` runs on both the happy path and the #917 fallback, and BEFORE `await _handle_dev_session_completion(...)`. Any `await` on the scheduler would regress #987 and #1055 — a review-time invariant.
+- **Graceful shutdown drain.** `drain_pending_extractions(timeout=5.0)` is called from `worker/__main__.py` in the shutdown sequence, after the worker-task drain and before the health/notify/reflection task cancels. Pending tasks exceeding 5s are cancelled. Abrupt shutdown (SIGKILL) loses in-flight extractions; the 35s internal hard-timeout caps worst-case latency so the loss is bounded.
+
+**Loss tolerance:** Memory extraction is best-effort. A lost extraction on worker restart or Anthropic outage never crashes the agent, blocks a session, or surfaces to the user. Failures emit a `memory.extraction.error` analytics counter (tagged with `error_class`, `session_id`, `project_key`) so silent failures are visible on `/dashboard.json`. `CancelledError` is not counted — it is expected during graceful shutdown and carries no signal.
+
+**Orphan safety:** If a session's Popoto record is deleted while its extraction task is still running, the task is safe: `clear_session(session_id)` in the `finally` block of `run_post_session_extraction` only touches an in-memory dict and is a no-op on missing keys. Saved Memory records persist independently, keyed by `project_key`, not `session_id`.
 
 ### Flow 4: System Prompt Priming
 
@@ -490,3 +504,4 @@ No schema migrations are involved. Redis keys can be flushed without side effect
 - Project key isolation: [#811](https://github.com/tomcounsell/ai/issues/811) (PR [#820](https://github.com/tomcounsell/ai/pull/820)) -- DEFAULT_PROJECT_KEY changed from "dm" to "default", cwd threading, migration script
 - Memory consolidation: [#795](https://github.com/tomcounsell/ai/issues/795) -- `memory-dedup` reflection, `superseded_by` fields, recall filter, semantic dedup via Haiku
 - Memory status CLI: [#964](https://github.com/tomcounsell/ai/issues/964) -- `python -m tools.memory_search status` health subcommand
+- Event-loop unblock (Layers 1+2): [#1055](https://github.com/tomcounsell/ai/issues/1055) -- `AsyncAnthropic` with double-timeout, fire-and-forget scheduler decoupled from finalization, shutdown drain, `memory.extraction.error` analytics counter

--- a/docs/features/subconscious-memory.md
+++ b/docs/features/subconscious-memory.md
@@ -347,7 +347,7 @@ Pruning of superseded records is delegated to the future `memory-decay-prune` re
 | `scripts/memory_consolidation.py` | Nightly `memory-dedup` reflection callable: `run_consolidation(project_key=None, dry_run=True, max_merges=10)`. Haiku-based semantic dedup with dry-run/apply modes, rate cap, importance exemption, and contradiction flagging. |
 | `agent/memory_extraction.py` | Post-session JSON extraction with line-based fallback, LLM-judged outcome detection (with bigram fallback), outcome history persistence, dismissal tracking via `_persist_outcome_metadata()`, post-merge learning extraction |
 | `agent/health_check.py` | Integration point: `watchdog_hook()` calls `check_and_inject()` |
-| `agent/messenger.py` | Integration point: `_run_work()` calls `run_post_session_extraction()` |
+| `agent/session_executor.py` | Integration point: `_schedule_post_session_extraction()` fires `run_post_session_extraction()` as a background task AFTER `complete_transcript()` (hotfix #1055); `drain_pending_extractions()` drains pending tasks on worker shutdown |
 | `bridge/telegram_bridge.py` | Integration point: `Memory.safe_save()` after `store_message()` |
 | `.claude/hooks/hook_utils/memory_bridge.py` | Claude Code hook memory bridge (recall, ingest, extract, agent session sidecar helpers, post-merge extract) |
 | `.claude/hooks/user_prompt_submit.py` | Claude Code prompt ingestion hook and AgentSession creation |
@@ -483,7 +483,7 @@ The memory system has high reversibility:
 
 1. Remove `Memory.safe_save()` call from `bridge/telegram_bridge.py`
 2. Remove memory hook integration from `agent/health_check.py`
-3. Remove extraction hook from `agent/messenger.py`
+3. Remove `_schedule_post_session_extraction()` and `drain_pending_extractions()` from `agent/session_executor.py` and their call sites in `_execute_agent_session` and `worker/__main__.py`
 4. Delete `models/memory.py`, `config/memory_defaults.py`, `agent/memory_hook.py`, `agent/memory_extraction.py`
 5. Remove Memory from `models/__init__.py`
 6. Flush Redis keys: `redis-cli KEYS "*Memory*" | xargs redis-cli DEL`

--- a/docs/features/unified-analytics.md
+++ b/docs/features/unified-analytics.md
@@ -35,6 +35,7 @@ All metric names use dotted notation.
 | `sdlc.stage_completed` | `bridge/pipeline_state.py` | SDLC stage completion (dimensions: stage) |
 | `memory.recall_attempt` | `agent/memory_retrieval.py` | Memory recall attempt (dimensions: hits, project_key) |
 | `memory.extraction` | `agent/memory_extraction.py` | Post-session memory extraction (dimensions: count, project_key) |
+| `memory.extraction.error` | `agent/memory_extraction.py` | Extraction failure counter (dimensions: error_class, session_id, project_key). Emitted on every `except` branch except `CancelledError`. Introduced by hotfix #1055 to surface silent async extraction failures. |
 | `crash.recorded` | `monitoring/crash_tracker.py` | Crash event recorded (dimensions: service, exit_code) |
 | `health.check` | `monitoring/health.py` | Health check result (dimensions: component, status) |
 

--- a/docs/plans/unblock-worker-event-loop-hotfix.md
+++ b/docs/plans/unblock-worker-event-loop-hotfix.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: docs_complete
 type: bug
 appetite: Small
 owner: Tom Counsell

--- a/tests/integration/test_session_finalization_decoupled.py
+++ b/tests/integration/test_session_finalization_decoupled.py
@@ -159,12 +159,8 @@ class TestSessionFinalizationDecoupled:
             await asyncio.wait_for(task, timeout=0.5)
         except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
             pass
-        assert task.done() or task.cancelled(), (
-            "drain must have cancelled the hung task"
-        )
-        warning_messages = [
-            r.message for r in caplog.records if r.levelname == "WARNING"
-        ]
+        assert task.done() or task.cancelled(), "drain must have cancelled the hung task"
+        warning_messages = [r.message for r in caplog.records if r.levelname == "WARNING"]
         assert any("did not complete" in msg for msg in warning_messages), (
             f"drain should log WARNING when cancelling hung tasks (got {warning_messages})"
         )

--- a/tests/integration/test_session_finalization_decoupled.py
+++ b/tests/integration/test_session_finalization_decoupled.py
@@ -4,6 +4,14 @@ Verifies that the hotfix decouples post-session memory extraction from
 session finalization — the session completes and the PM nudge fires promptly,
 while extraction is still pending, even if extraction would stall indefinitely.
 
+NOTE (PR #1056 review nit): the plan's Test Impact section called for a
+Popoto-backed assertion that the PM's ``queued_steering_messages`` grew by
+exactly 1 after extraction was deferred. This test instead uses a simpler
+``asyncio.Event`` to signal the PM nudge, because spinning up a real Popoto
++ pyrogram + harness-subprocess stack was judged too heavy for the scheduler-
+boundary contract being verified here. A follow-up issue (#1057) tracks
+adding the full Popoto-backed test that exercises the PM inbox end-to-end.
+
 The full ``_execute_agent_session`` flow requires substantial Redis/Popoto
 infrastructure (AgentSession creation, pyrogram bridge, harness subprocess,
 session lifecycle transitions). This test focuses on the narrower contract
@@ -72,6 +80,15 @@ class TestSessionFinalizationDecoupled:
 
         caplog.set_level(logging.INFO, logger="agent.session_executor")
 
+        # NOTE (PR #1056 review nit): plan called for time.sleep(40); we use
+        # asyncio.sleep(30) instead because production flows through
+        # AsyncAnthropic + httpx + asyncio.wait_for — all cancellable at await
+        # points. A sync time.sleep in the coroutine body is uncancellable
+        # until the next await, which does not reflect production. The
+        # unit-test sibling `test_real_asyncio_wait_for_fires_with_tightened_constants`
+        # exercises the real timeout path against a cooperative hang with the
+        # hard-timeout shortened via monkeypatch. The scheduler-level SLO this
+        # test asserts is identical whether the inner coroutine yields or not.
         async def _slow_extract(session_id, response_text, project_key=None):
             await asyncio.sleep(30)  # Long stall; scheduler must not await.
 
@@ -157,7 +174,7 @@ class TestSessionFinalizationDecoupled:
         # to finalize in "cancelled" state before we assert.
         try:
             await asyncio.wait_for(task, timeout=0.5)
-        except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
+        except (TimeoutError, asyncio.CancelledError, Exception):
             pass
         assert task.done() or task.cancelled(), "drain must have cancelled the hung task"
         warning_messages = [r.message for r in caplog.records if r.levelname == "WARNING"]

--- a/tests/integration/test_session_finalization_decoupled.py
+++ b/tests/integration/test_session_finalization_decoupled.py
@@ -1,0 +1,200 @@
+"""Integration test for extraction-finalization decoupling (hotfix #1055).
+
+Verifies that the hotfix decouples post-session memory extraction from
+session finalization — the session completes and the PM nudge fires promptly,
+while extraction is still pending, even if extraction would stall indefinitely.
+
+The full ``_execute_agent_session`` flow requires substantial Redis/Popoto
+infrastructure (AgentSession creation, pyrogram bridge, harness subprocess,
+session lifecycle transitions). This test focuses on the narrower contract
+that the hotfix establishes at the scheduler boundary:
+
+  1. The synchronous ``_schedule_post_session_extraction`` returns promptly
+     even when extraction would block for 30+ seconds.
+  2. The scheduled task is still pending (``.done() is False``) at the moment
+     the scheduler returns.
+  3. A simulated "PM nudge" call that runs after the scheduler returns completes
+     in the 5-second bounded window — not blocked by extraction latency.
+  4. ``drain_pending_extractions`` cancels cooperatively-suspended tasks
+     within its timeout budget.
+  5. Cancellation does not propagate past the fire-and-forget wrapper's
+     ``try/except`` structure (CancelledError is re-raised cleanly for drain).
+
+The 5-second budget is the user-visible SLO: a dev session producing a
+30-second stall in extraction must still finalize and nudge the PM within
+5 seconds — the core promise of this hotfix.
+
+Why cooperative ``asyncio.sleep`` rather than sync ``time.sleep(40)``?
+Real production flows AsyncAnthropic → httpx → asyncio.wait_for, all of
+which are cancellable at every await point. A sync ``time.sleep`` in the
+coroutine body is uncancellable until the next await — a pathology that
+does not reflect production behavior. The double-timeout in
+``memory_extraction.py`` (SDK timeout=30s + asyncio.wait_for=35s) hard-caps
+the production latency in all cases.
+"""
+
+import asyncio
+import logging
+import time
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_pending_tasks():
+    from agent import session_executor as se
+
+    se._pending_extraction_tasks.clear()
+    yield
+    for task in list(se._pending_extraction_tasks.values()):
+        if not task.done():
+            task.cancel()
+    se._pending_extraction_tasks.clear()
+
+
+class TestSessionFinalizationDecoupled:
+    """End-to-end behavioral test for the decoupling guarantee (hotfix #1055)."""
+
+    @pytest.mark.asyncio
+    async def test_scheduler_returns_within_5s_window_with_hung_anthropic(
+        self, caplog, monkeypatch
+    ):
+        """The 5-second user-visible SLO: scheduler returns promptly even with hung extraction.
+
+        This is the core hotfix #1055 guarantee — a 40-second stall in extraction
+        must NOT delay finalization and PM nudge beyond the 5-second SLO. We
+        stub run_post_session_extraction itself (the top-level async entry point)
+        to block on asyncio.sleep(30); in production the outer asyncio.wait_for
+        inside memory_extraction.py caps this at 35s anyway, but the point of
+        Layer 2 is that even an uncapped 30s stall cannot delay the PM nudge.
+        """
+        from agent import session_executor as se
+
+        caplog.set_level(logging.INFO, logger="agent.session_executor")
+
+        async def _slow_extract(session_id, response_text, project_key=None):
+            await asyncio.sleep(30)  # Long stall; scheduler must not await.
+
+        monkeypatch.setattr(
+            "agent.memory_extraction.run_post_session_extraction",
+            _slow_extract,
+        )
+
+        pm_nudge_called = asyncio.Event()
+
+        async def _fake_handle_dev_completion(*args, **kwargs):
+            # Simulates the PM nudge that must run AFTER the scheduler returns.
+            pm_nudge_called.set()
+
+        start = time.time()
+
+        # Exact call-shape _execute_agent_session uses post-fix:
+        # synchronous schedule (no await), then await the PM nudge.
+        se._schedule_post_session_extraction("sess-int-1", "A" * 200)
+        await _fake_handle_dev_completion()
+
+        elapsed = time.time() - start
+
+        # The entire post-finalization sequence must complete within the 5s SLO.
+        assert elapsed < 5.0, (
+            f"scheduler + PM-nudge path took {elapsed:.2f}s — violates the 5s SLO. "
+            "Extraction latency MUST NOT block session finalization (hotfix #1055)."
+        )
+        assert pm_nudge_called.is_set(), "PM nudge must fire"
+
+        # The extraction task should still be pending.
+        task = se._pending_extraction_tasks.get("sess-int-1")
+        assert task is not None, "extraction task must still be registered"
+        assert task.done() is False, (
+            "extraction task MUST still be pending at this point — "
+            "proves scheduler and nudge ran ahead of extraction completion"
+        )
+
+        # Cleanup: cancel the cooperatively-suspended task.
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    @pytest.mark.asyncio
+    async def test_drain_cancels_cooperative_extraction_on_shutdown(self, caplog, monkeypatch):
+        """drain_pending_extractions cancels cooperatively-suspended tasks within timeout.
+
+        Uses asyncio.sleep (not time.sleep) because real production extraction
+        goes through AsyncAnthropic + httpx + asyncio.wait_for — all cooperative
+        cancellation points. A sync time.sleep in the coroutine body is NOT
+        cancellable until the next await, so the production code path does
+        not suffer from that pathology.
+        """
+        from agent import session_executor as se
+
+        caplog.set_level(logging.WARNING, logger="agent.session_executor")
+
+        async def _slow_extract(session_id, response_text, project_key=None):
+            await asyncio.sleep(30)  # Cooperative; cancellable at await point.
+
+        monkeypatch.setattr(
+            "agent.memory_extraction.run_post_session_extraction",
+            _slow_extract,
+        )
+
+        se._schedule_post_session_extraction("sess-drain-1", "A" * 200)
+        task = se._pending_extraction_tasks.get("sess-drain-1")
+        assert task is not None
+
+        # Drain with a short timeout; the cooperative sleep will be cancelled
+        # promptly when drain calls task.cancel().
+        start = time.time()
+        await se.drain_pending_extractions(timeout=0.5)
+        elapsed = time.time() - start
+
+        # Drain budget: ~0.5s timeout + cancel overhead.
+        assert elapsed < 2.0, (
+            f"drain exceeded its 0.5s timeout by too much (took {elapsed:.2f}s total)"
+        )
+        # Drain called task.cancel(); give one event-loop tick for the task
+        # to finalize in "cancelled" state before we assert.
+        try:
+            await asyncio.wait_for(task, timeout=0.5)
+        except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
+            pass
+        assert task.done() or task.cancelled(), (
+            "drain must have cancelled the hung task"
+        )
+        warning_messages = [
+            r.message for r in caplog.records if r.levelname == "WARNING"
+        ]
+        assert any("did not complete" in msg for msg in warning_messages), (
+            f"drain should log WARNING when cancelling hung tasks (got {warning_messages})"
+        )
+
+    @pytest.mark.asyncio
+    async def test_cancellation_does_not_crash_via_wrapper(self, monkeypatch):
+        """Cancelling a cooperative-suspended extraction raises CancelledError cleanly.
+
+        Uses asyncio.sleep so cancellation is prompt. Real production flows
+        through AsyncAnthropic httpx calls, which are cancellable at every
+        await point, plus an outer asyncio.wait_for that hard-caps latency.
+        """
+        from agent import session_executor as se
+
+        async def _slow_extract(session_id, response_text, project_key=None):
+            await asyncio.sleep(30)
+
+        monkeypatch.setattr(
+            "agent.memory_extraction.run_post_session_extraction",
+            _slow_extract,
+        )
+
+        se._schedule_post_session_extraction("sess-cancel-safe", "A" * 200)
+        task = se._pending_extraction_tasks.get("sess-cancel-safe")
+
+        task.cancel()
+
+        # Awaiting a cancelled task should raise CancelledError — the
+        # critical invariant here is that it raises CancelledError
+        # cleanly, NOT a wrapped/swallowed exception that would make
+        # shutdown drainage ambiguous.
+        with pytest.raises(asyncio.CancelledError):
+            await task

--- a/tests/unit/test_memory_extraction.py
+++ b/tests/unit/test_memory_extraction.py
@@ -1004,8 +1004,7 @@ class TestEventLoopSafety:
             "must log WARNING with 'hard timeout' wording"
         )
         assert any(
-            name == "memory.extraction.error"
-            and tags.get("error_class") == "timeouterror"
+            name == "memory.extraction.error" and tags.get("error_class") == "timeouterror"
             for name, tags in recorded
         ), f"must emit memory.extraction.error with error_class=timeouterror (got {recorded})"
 
@@ -1054,8 +1053,7 @@ class TestEventLoopSafety:
         assert isinstance(result, dict), "detect_outcomes_async must never raise on timeout"
         assert elapsed < 5.0, f"hard-timeout path must return quickly (got {elapsed:.2f}s)"
         assert any(
-            name == "memory.extraction.error"
-            and tags.get("error_class") == "timeouterror"
+            name == "memory.extraction.error" and tags.get("error_class") == "timeouterror"
             for name, tags in recorded
         ), f"must emit memory.extraction.error with error_class=timeouterror (got {recorded})"
 
@@ -1104,8 +1102,7 @@ class TestEventLoopSafety:
             "must log WARNING with 'hard timeout' wording"
         )
         assert any(
-            name == "memory.extraction.error"
-            and tags.get("error_class") == "timeouterror"
+            name == "memory.extraction.error" and tags.get("error_class") == "timeouterror"
             for name, tags in recorded
         ), f"must emit memory.extraction.error with error_class=timeouterror (got {recorded})"
 
@@ -1153,8 +1150,7 @@ class TestEventLoopSafety:
         # Outer except Exception catches the SDK APITimeoutError and records
         # the metric with error_class from type(e).__name__.
         assert any(
-            name == "memory.extraction.error"
-            and tags.get("error_class") == "apitimeouterror"
+            name == "memory.extraction.error" and tags.get("error_class") == "apitimeouterror"
             for name, tags in recorded
         ), f"must emit memory.extraction.error with error_class=apitimeouterror (got {recorded})"
 

--- a/tests/unit/test_memory_extraction.py
+++ b/tests/unit/test_memory_extraction.py
@@ -3,6 +3,22 @@
 import pytest
 
 
+def _make_async_anthropic_mock(mock_message):
+    """Build a MagicMock that mimics anthropic.AsyncAnthropic for `async with` (hotfix #1055).
+
+    Returns a ``MagicMock`` instance that:
+      * supports ``async with AsyncAnthropic(...) as client:`` (__aenter__/__aexit__)
+      * exposes ``client.messages.create`` as an ``AsyncMock`` returning ``mock_message``
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.messages.create = AsyncMock(return_value=mock_message)
+    return mock_client
+
+
 class TestExtractBigrams:
     """Test agent/memory_extraction.py _extract_bigrams()."""
 
@@ -345,14 +361,13 @@ class TestPostMergeJsonParsing:
         mock_message = MagicMock()
         mock_message.content = [MagicMock(text=json_response)]
 
-        mock_client = MagicMock()
-        mock_client.messages.create.return_value = mock_message
+        mock_client = _make_async_anthropic_mock(mock_message)
 
         mock_memory = MagicMock()
         mock_memory.safe_save.return_value = MagicMock(memory_id="test-id")
 
         with (
-            patch("anthropic.Anthropic", return_value=mock_client),
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
             patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
             patch("models.memory.Memory", mock_memory),
             patch("models.memory.SOURCE_AGENT", "agent"),
@@ -380,14 +395,13 @@ class TestPostMergeJsonParsing:
             MagicMock(text="Post-query re-ranking is safer than pre-query filtering")
         ]
 
-        mock_client = MagicMock()
-        mock_client.messages.create.return_value = mock_message
+        mock_client = _make_async_anthropic_mock(mock_message)
 
         mock_memory = MagicMock()
         mock_memory.safe_save.return_value = MagicMock(memory_id="test-id")
 
         with (
-            patch("anthropic.Anthropic", return_value=mock_client),
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
             patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
             patch("models.memory.Memory", mock_memory),
             patch("models.memory.SOURCE_AGENT", "agent"),
@@ -415,14 +429,13 @@ class TestPostMergeJsonParsing:
         mock_message = MagicMock()
         mock_message.content = [MagicMock(text=json_response)]
 
-        mock_client = MagicMock()
-        mock_client.messages.create.return_value = mock_message
+        mock_client = _make_async_anthropic_mock(mock_message)
 
         mock_memory = MagicMock()
         mock_memory.safe_save.return_value = MagicMock(memory_id="test-id")
 
         with (
-            patch("anthropic.Anthropic", return_value=mock_client),
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
             patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
             patch("models.memory.Memory", mock_memory),
             patch("models.memory.SOURCE_AGENT", "agent"),
@@ -534,9 +547,14 @@ class TestPersistOutcomeMetadata:
 
 
 class TestJudgeOutcomesLlm:
-    """Test agent/memory_extraction.py _judge_outcomes_llm()."""
+    """Test agent/memory_extraction.py _judge_outcomes_llm().
 
-    def test_parses_valid_llm_response(self):
+    hotfix #1055: _judge_outcomes_llm is async-native (AsyncAnthropic). All
+    tests use @pytest.mark.asyncio and await the call.
+    """
+
+    @pytest.mark.asyncio
+    async def test_parses_valid_llm_response(self):
         import json
         from unittest.mock import MagicMock, patch
 
@@ -555,14 +573,13 @@ class TestJudgeOutcomesLlm:
 
         mock_message = MagicMock()
         mock_message.content = [MagicMock(text=llm_response)]
-        mock_client = MagicMock()
-        mock_client.messages.create.return_value = mock_message
+        mock_client = _make_async_anthropic_mock(mock_message)
 
         with (
-            patch("anthropic.Anthropic", return_value=mock_client),
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
             patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
         ):
-            result = _judge_outcomes_llm(
+            result = await _judge_outcomes_llm(
                 [("key1", "use blue-green deployment"), ("key2", "kubernetes config")],
                 "We deployed using blue-green strategy.",
             )
@@ -572,7 +589,8 @@ class TestJudgeOutcomesLlm:
         assert result["key2"]["outcome"] == "dismissed"
         assert "deployment" in result["key1"]["reasoning"]
 
-    def test_echoed_maps_to_dismissed(self):
+    @pytest.mark.asyncio
+    async def test_echoed_maps_to_dismissed(self):
         import json
         from unittest.mock import MagicMock, patch
 
@@ -590,14 +608,13 @@ class TestJudgeOutcomesLlm:
 
         mock_message = MagicMock()
         mock_message.content = [MagicMock(text=llm_response)]
-        mock_client = MagicMock()
-        mock_client.messages.create.return_value = mock_message
+        mock_client = _make_async_anthropic_mock(mock_message)
 
         with (
-            patch("anthropic.Anthropic", return_value=mock_client),
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
             patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
         ):
-            result = _judge_outcomes_llm(
+            result = await _judge_outcomes_llm(
                 [("key1", "redis connection pooling")],
                 "Redis connections are managed via pooling.",
             )
@@ -605,34 +622,37 @@ class TestJudgeOutcomesLlm:
         assert result is not None
         assert result["key1"]["outcome"] == "dismissed"
 
-    def test_returns_none_on_api_failure(self):
+    @pytest.mark.asyncio
+    async def test_returns_none_on_api_failure(self):
         from unittest.mock import patch
 
         from agent.memory_extraction import _judge_outcomes_llm
 
         with patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"):
-            with patch("anthropic.Anthropic", side_effect=Exception("API down")):
-                result = _judge_outcomes_llm(
+            with patch("anthropic.AsyncAnthropic", side_effect=Exception("API down")):
+                result = await _judge_outcomes_llm(
                     [("key1", "some thought")],
                     "some response",
                 )
 
         assert result is None
 
-    def test_returns_none_when_no_api_key(self):
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_api_key(self):
         from unittest.mock import patch
 
         from agent.memory_extraction import _judge_outcomes_llm
 
         with patch("utils.api_keys.get_anthropic_api_key", return_value=None):
-            result = _judge_outcomes_llm(
+            result = await _judge_outcomes_llm(
                 [("key1", "some thought")],
                 "some response",
             )
 
         assert result is None
 
-    def test_fills_missing_thoughts(self):
+    @pytest.mark.asyncio
+    async def test_fills_missing_thoughts(self):
         """Thoughts not covered by LLM response get dismissed by default."""
         import json
         from unittest.mock import MagicMock, patch
@@ -648,14 +668,13 @@ class TestJudgeOutcomesLlm:
 
         mock_message = MagicMock()
         mock_message.content = [MagicMock(text=llm_response)]
-        mock_client = MagicMock()
-        mock_client.messages.create.return_value = mock_message
+        mock_client = _make_async_anthropic_mock(mock_message)
 
         with (
-            patch("anthropic.Anthropic", return_value=mock_client),
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
             patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
         ):
-            result = _judge_outcomes_llm(
+            result = await _judge_outcomes_llm(
                 [("key1", "thought one"), ("key2", "thought two")],
                 "response text",
             )
@@ -664,7 +683,8 @@ class TestJudgeOutcomesLlm:
         assert result["key1"]["outcome"] == "acted"
         assert result["key2"]["outcome"] == "dismissed"
 
-    def test_caps_at_max_thoughts(self):
+    @pytest.mark.asyncio
+    async def test_caps_at_max_thoughts(self):
         """Only first 5 thoughts are sent to the LLM."""
         import json
         from unittest.mock import MagicMock, patch
@@ -683,14 +703,13 @@ class TestJudgeOutcomesLlm:
 
         mock_message = MagicMock()
         mock_message.content = [MagicMock(text=llm_response)]
-        mock_client = MagicMock()
-        mock_client.messages.create.return_value = mock_message
+        mock_client = _make_async_anthropic_mock(mock_message)
 
         with (
-            patch("anthropic.Anthropic", return_value=mock_client),
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
             patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
         ):
-            result = _judge_outcomes_llm(thoughts, "response text")
+            result = await _judge_outcomes_llm(thoughts, "response text")
 
         assert result is not None
         # Only the first 5 should be in the result
@@ -698,21 +717,21 @@ class TestJudgeOutcomesLlm:
         assert "key5" not in result
         assert "key6" not in result
 
-    def test_invalid_json_returns_none(self):
+    @pytest.mark.asyncio
+    async def test_invalid_json_returns_none(self):
         from unittest.mock import MagicMock, patch
 
         from agent.memory_extraction import _judge_outcomes_llm
 
         mock_message = MagicMock()
         mock_message.content = [MagicMock(text="not valid json at all")]
-        mock_client = MagicMock()
-        mock_client.messages.create.return_value = mock_message
+        mock_client = _make_async_anthropic_mock(mock_message)
 
         with (
-            patch("anthropic.Anthropic", return_value=mock_client),
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
             patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
         ):
-            result = _judge_outcomes_llm(
+            result = await _judge_outcomes_llm(
                 [("key1", "thought")],
                 "response",
             )
@@ -899,3 +918,315 @@ class TestPersonaPromptContainsIntentionalMemory:
         assert "When to Search" in content
         assert "--category correction" in content
         assert "--tag" in content
+
+
+# -----------------------------------------------------------------------------
+# Hotfix #1055 — event-loop safety guards for async Anthropic extraction.
+# -----------------------------------------------------------------------------
+
+
+class TestEventLoopSafety:
+    """Verify memory_extraction never blocks the worker event loop (hotfix #1055).
+
+    Tests model the exact failure mode observed in #1055: a half-open TCP
+    socket where the sync client never returns. We stub AsyncAnthropic with a
+    ``messages.create`` coroutine that calls ``time.sleep(40)`` (REAL sync
+    block, not ``asyncio.sleep`` — cooperative suspension does not model the
+    observed failure).
+    """
+
+    @staticmethod
+    def _make_hung_async_anthropic_mock():
+        """Build an AsyncAnthropic mock whose messages.create internally ``time.sleep(40)``."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        async def _hung_create(*args, **kwargs):
+            import time
+
+            time.sleep(40)  # REAL sync block — models half-open TCP socket stall
+
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.messages.create = _hung_create
+        return mock_client
+
+    @pytest.mark.asyncio
+    async def test_hard_timeout_caught_and_logged_extract_observations(self, caplog):
+        """extract_observations_async times out within ~35s on hung client."""
+        import logging
+        import time
+        from unittest.mock import patch
+
+        import agent.memory_extraction as ext
+
+        caplog.set_level(logging.WARNING, logger="agent.memory_extraction")
+
+        mock_client = self._make_hung_async_anthropic_mock()
+
+        # Tighten the outer hard timeout so the test runs in <2s while still
+        # exercising the asyncio.TimeoutError path. The sleep(40) inside the
+        # stubbed create() is synchronous and will be cancelled by the
+        # asyncio event loop when wait_for fires — except the coroutine's
+        # body is still blocking a thread. To keep the test fast while still
+        # hitting the TimeoutError branch, we mock asyncio.wait_for to raise
+        # TimeoutError immediately.
+        async def _raise_timeout(coro_or_awaitable=None, *a, **kw):
+            # Close the unwawaited coroutine to suppress RuntimeWarning, then
+            # raise TimeoutError to exercise the outer branch.
+            if coro_or_awaitable is not None and hasattr(coro_or_awaitable, "close"):
+                coro_or_awaitable.close()
+            raise __import__("asyncio").TimeoutError
+
+        # Capture analytics counter calls
+        recorded = []
+
+        def _stub_record(name, value, tags):
+            recorded.append((name, tags))
+
+        with (
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
+            patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
+            patch("asyncio.wait_for", side_effect=_raise_timeout),
+            patch("analytics.collector.record_metric", side_effect=_stub_record),
+        ):
+            start = time.time()
+            result = await ext.extract_observations_async(
+                "sess-test",
+                "A" * 200,  # >50 chars to pass the short-circuit guard
+                project_key="test-proj",
+            )
+            elapsed = time.time() - start
+
+        assert result == [], "extract_observations_async must return [] on timeout"
+        assert elapsed < 5.0, f"hard-timeout path must return quickly (got {elapsed:.2f}s)"
+        assert any("hard timeout" in rec.message.lower() for rec in caplog.records), (
+            "must log WARNING with 'hard timeout' wording"
+        )
+        assert any(
+            name == "memory.extraction.error"
+            and tags.get("error_class") == "timeouterror"
+            for name, tags in recorded
+        ), f"must emit memory.extraction.error with error_class=timeouterror (got {recorded})"
+
+    @pytest.mark.asyncio
+    async def test_hard_timeout_caught_and_logged_detect_outcomes(self, caplog):
+        """detect_outcomes_async (via _judge_outcomes_llm) times out gracefully."""
+        import logging
+        import time
+        from unittest.mock import patch
+
+        import agent.memory_extraction as ext
+
+        caplog.set_level(logging.WARNING, logger="agent.memory_extraction")
+
+        mock_client = self._make_hung_async_anthropic_mock()
+
+        async def _raise_timeout(coro_or_awaitable=None, *a, **kw):
+            # Close the unwawaited coroutine to suppress RuntimeWarning, then
+            # raise TimeoutError to exercise the outer branch.
+            if coro_or_awaitable is not None and hasattr(coro_or_awaitable, "close"):
+                coro_or_awaitable.close()
+            raise __import__("asyncio").TimeoutError
+
+        recorded = []
+
+        def _stub_record(name, value, tags):
+            recorded.append((name, tags))
+
+        with (
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
+            patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
+            patch("asyncio.wait_for", side_effect=_raise_timeout),
+            patch("analytics.collector.record_metric", side_effect=_stub_record),
+        ):
+            start = time.time()
+            # detect_outcomes_async first tries LLM; on LLM timeout, falls back
+            # to bigram. We want to confirm: (a) the TimeoutError does NOT
+            # propagate, (b) the counter is recorded, (c) the fallback still
+            # returns something sensible.
+            result = await ext.detect_outcomes_async(
+                [("key1", "some thought content text goes here")],
+                "some response text that mentions different topics entirely",
+            )
+            elapsed = time.time() - start
+
+        assert isinstance(result, dict), "detect_outcomes_async must never raise on timeout"
+        assert elapsed < 5.0, f"hard-timeout path must return quickly (got {elapsed:.2f}s)"
+        assert any(
+            name == "memory.extraction.error"
+            and tags.get("error_class") == "timeouterror"
+            for name, tags in recorded
+        ), f"must emit memory.extraction.error with error_class=timeouterror (got {recorded})"
+
+    @pytest.mark.asyncio
+    async def test_hard_timeout_caught_and_logged_post_merge_learning(self, caplog):
+        """extract_post_merge_learning times out gracefully."""
+        import logging
+        import time
+        from unittest.mock import patch
+
+        import agent.memory_extraction as ext
+
+        caplog.set_level(logging.WARNING, logger="agent.memory_extraction")
+
+        mock_client = self._make_hung_async_anthropic_mock()
+
+        async def _raise_timeout(coro_or_awaitable=None, *a, **kw):
+            # Close the unwawaited coroutine to suppress RuntimeWarning, then
+            # raise TimeoutError to exercise the outer branch.
+            if coro_or_awaitable is not None and hasattr(coro_or_awaitable, "close"):
+                coro_or_awaitable.close()
+            raise __import__("asyncio").TimeoutError
+
+        recorded = []
+
+        def _stub_record(name, value, tags):
+            recorded.append((name, tags))
+
+        with (
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
+            patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
+            patch("asyncio.wait_for", side_effect=_raise_timeout),
+            patch("analytics.collector.record_metric", side_effect=_stub_record),
+        ):
+            start = time.time()
+            result = await ext.extract_post_merge_learning(
+                "PR Title",
+                "PR body content",
+                "diff summary",
+            )
+            elapsed = time.time() - start
+
+        assert result is None, "extract_post_merge_learning must return None on timeout"
+        assert elapsed < 5.0, f"hard-timeout path must return quickly (got {elapsed:.2f}s)"
+        assert any("hard timeout" in rec.message.lower() for rec in caplog.records), (
+            "must log WARNING with 'hard timeout' wording"
+        )
+        assert any(
+            name == "memory.extraction.error"
+            and tags.get("error_class") == "timeouterror"
+            for name, tags in recorded
+        ), f"must emit memory.extraction.error with error_class=timeouterror (got {recorded})"
+
+    @pytest.mark.asyncio
+    async def test_sdk_api_timeout_caught_and_logged(self):
+        """anthropic.APITimeoutError is caught by outer except Exception and counter recorded."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import anthropic
+
+        import agent.memory_extraction as ext
+
+        # APITimeoutError is raised inside messages.create
+        async def _raise_api_timeout(*args, **kwargs):
+            # The public constructor signature varies between SDK versions;
+            # construct via __new__ to avoid coupling to arg shape.
+            try:
+                raise anthropic.APITimeoutError(request=MagicMock())
+            except TypeError:
+                # Older SDK signature: may need a message arg
+                raise anthropic.APITimeoutError("simulated timeout")
+
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.messages.create = _raise_api_timeout
+
+        recorded = []
+
+        def _stub_record(name, value, tags):
+            recorded.append((name, tags))
+
+        with (
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
+            patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
+            patch("analytics.collector.record_metric", side_effect=_stub_record),
+        ):
+            result = await ext.extract_observations_async(
+                "sess-api-timeout",
+                "A" * 200,
+                project_key="test-proj",
+            )
+
+        assert result == [], "APITimeoutError must not crash extract_observations_async"
+        # Outer except Exception catches the SDK APITimeoutError and records
+        # the metric with error_class from type(e).__name__.
+        assert any(
+            name == "memory.extraction.error"
+            and tags.get("error_class") == "apitimeouterror"
+            for name, tags in recorded
+        ), f"must emit memory.extraction.error with error_class=apitimeouterror (got {recorded})"
+
+    def test_no_sync_anthropic_client_grep_canary(self):
+        """Regression canary: no sync anthropic.Anthropic( calls in memory_extraction."""
+        import subprocess
+
+        result = subprocess.run(
+            ["grep", "-n", "anthropic\\.Anthropic(", "agent/memory_extraction.py"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1, (
+            "No sync anthropic.Anthropic( calls allowed in agent/memory_extraction.py — "
+            "use anthropic.AsyncAnthropic( with asyncio.wait_for (see hotfix #1055). "
+            f"Offending lines:\n{result.stdout}"
+        )
+
+
+def test_extract_post_merge_learning_runs_inside_asyncio_run(monkeypatch):
+    """Guards the .claude hook subprocess call path (hotfix #1055, nit 3).
+
+    Hook at .claude/hooks/hook_utils/memory_bridge.py::post_merge_extract()
+    calls asyncio.run(extract_post_merge_learning(...)) inside a short-lived
+    subprocess. Converting the function to AsyncAnthropic must NOT introduce
+    a nested ``asyncio.run()`` (which raises RuntimeError: This event loop is
+    already running). This test runs the function via asyncio.run with a
+    minimal valid AsyncAnthropic mock and asserts no such error is raised.
+
+    See docs/plans/agent_wiki.md:157 for the regression class this guards.
+    """
+    import asyncio
+    import json
+
+    from agent.memory_extraction import extract_post_merge_learning
+
+    json_response = json.dumps(
+        {
+            "observation": "Use dependency injection for testability in hooks",
+            "category": "pattern",
+            "tags": ["testing", "hooks"],
+            "file_paths": ["hooks/example.py"],
+        }
+    )
+
+    mock_message_content = [type("Block", (), {"text": json_response})()]
+    mock_message = type("Message", (), {"content": mock_message_content})()
+    mock_client = _make_async_anthropic_mock(mock_message)
+
+    # Also mock Memory.safe_save so we don't touch Redis from a subprocess-like test
+    from unittest.mock import MagicMock, patch
+
+    mock_memory_module = MagicMock()
+    mock_memory_module.safe_save.return_value = MagicMock(memory_id="mock-mem-id")
+
+    with (
+        patch("anthropic.AsyncAnthropic", return_value=mock_client),
+        patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
+        patch("models.memory.Memory", mock_memory_module),
+        patch("models.memory.SOURCE_AGENT", "agent"),
+    ):
+        # asyncio.run is the entry point used by .claude/hooks/hook_utils/memory_bridge.py.
+        # If the new AsyncAnthropic path inadvertently nested asyncio.run, this would
+        # raise "RuntimeError: This event loop is already running".
+        result = asyncio.run(
+            extract_post_merge_learning(
+                "PR title",
+                "PR body content longer than twenty chars",
+                "files_changed.py",
+            )
+        )
+
+    # Result may be a dict (memory saved) or None — the critical assertion is that
+    # asyncio.run did not raise. Accept either outcome.
+    assert result is None or isinstance(result, dict)

--- a/tests/unit/test_memory_extraction.py
+++ b/tests/unit/test_memory_extraction.py
@@ -1107,6 +1107,83 @@ class TestEventLoopSafety:
         ), f"must emit memory.extraction.error with error_class=timeouterror (got {recorded})"
 
     @pytest.mark.asyncio
+    async def test_real_asyncio_wait_for_fires_with_tightened_constants(self, caplog):
+        """Exercise the real asyncio.wait_for with tightened constants (hotfix #1055 review nit).
+
+        The three tests above patch ``asyncio.wait_for`` directly to raise
+        ``TimeoutError`` immediately, which verifies the ``except asyncio.TimeoutError``
+        code path fires and the counter is recorded — but does NOT prove that
+        ``asyncio.wait_for`` is still wired in. A future refactor that silently
+        removes the ``wait_for`` wrapper would pass those three tests.
+
+        This test tightens ``_EXTRACTION_SDK_TIMEOUT`` to 0.05s and
+        ``_EXTRACTION_HARD_TIMEOUT`` to 0.1s, then lets the REAL ``asyncio.wait_for``
+        run against a cooperatively-hung ``AsyncAnthropic`` stub. If the
+        production code no longer wraps the call in ``asyncio.wait_for``, the
+        test will hang past its 2s assertion budget and fail — catching the
+        regression that the mocked-``wait_for`` tests miss.
+        """
+        import logging
+        import time
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import agent.memory_extraction as ext
+
+        caplog.set_level(logging.WARNING, logger="agent.memory_extraction")
+
+        # Cooperative hang (asyncio.sleep, not time.sleep) so the REAL
+        # asyncio.wait_for can cancel the inner coroutine at its await point
+        # — production flows through AsyncAnthropic + httpx which are
+        # cancellable the same way.
+        async def _cooperative_hang(*args, **kwargs):
+            import asyncio as _asyncio
+
+            await _asyncio.sleep(10)  # long enough to always exceed 0.1s
+
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.messages.create = _cooperative_hang
+
+        recorded = []
+
+        def _stub_record(name, value, tags):
+            recorded.append((name, tags))
+
+        with (
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
+            patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
+            patch("analytics.collector.record_metric", side_effect=_stub_record),
+            # Tighten the module constants — the REAL asyncio.wait_for runs
+            # against these, NOT a mock. If the wrapper is removed, the test
+            # hangs past its 2s budget.
+            patch.object(ext, "_EXTRACTION_SDK_TIMEOUT", 0.05),
+            patch.object(ext, "_EXTRACTION_HARD_TIMEOUT", 0.1),
+        ):
+            start = time.time()
+            result = await ext.extract_observations_async(
+                "sess-real-timeout",
+                "A" * 200,
+                project_key="test-proj",
+            )
+            elapsed = time.time() - start
+
+        assert result == [], "extract_observations_async must return [] on real timeout"
+        assert elapsed < 2.0, (
+            f"real asyncio.wait_for must fire within ~0.1s + overhead (got {elapsed:.2f}s). "
+            "If elapsed >> 2s, the production code likely no longer wraps "
+            "messages.create in asyncio.wait_for — hotfix #1055 regression."
+        )
+        assert elapsed >= 0.05, (
+            f"elapsed ({elapsed:.2f}s) is suspiciously short — did asyncio.wait_for "
+            "short-circuit? The test must actually exercise the timeout wait."
+        )
+        assert any(
+            name == "memory.extraction.error" and tags.get("error_class") == "timeouterror"
+            for name, tags in recorded
+        ), f"must emit memory.extraction.error with error_class=timeouterror (got {recorded})"
+
+    @pytest.mark.asyncio
     async def test_sdk_api_timeout_caught_and_logged(self):
         """anthropic.APITimeoutError is caught by outer except Exception and counter recorded."""
         from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/unit/test_session_executor_extraction_decoupling.py
+++ b/tests/unit/test_session_executor_extraction_decoupling.py
@@ -1,0 +1,194 @@
+"""Unit tests for extraction-finalization decoupling (hotfix #1055).
+
+These tests verify the invariants of the fire-and-forget extraction scheduler
+that was added to ``agent/session_executor.py``:
+
+- Extraction failures never propagate out of ``_execute_agent_session``.
+- The PM nudge (``_handle_dev_session_completion``) fires while extraction
+  is still pending — proving the #987 ordering is preserved and the #1055
+  stall pattern cannot reoccur.
+- Duplicate schedules for the same session_id are deduplicated.
+- ``drain_pending_extractions`` returns immediately when no tasks are
+  pending (first-deploy case).
+"""
+
+import asyncio
+import logging
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_pending_tasks():
+    """Reset the module-level _pending_extraction_tasks between tests."""
+    from agent import session_executor as se
+
+    se._pending_extraction_tasks.clear()
+    yield
+    # Cancel any leaked tasks so test teardown is clean
+    for task in list(se._pending_extraction_tasks.values()):
+        if not task.done():
+            task.cancel()
+    se._pending_extraction_tasks.clear()
+
+
+class TestScheduleExtractionDecoupling:
+    """Verify fire-and-forget scheduler semantics."""
+
+    @pytest.mark.asyncio
+    async def test_extraction_error_does_not_propagate(self, monkeypatch):
+        """asyncio.TimeoutError inside the extraction task is swallowed by the wrapper."""
+        from agent import session_executor as se
+
+        async def _raise_timeout(session_id, response_text, project_key=None):
+            raise asyncio.TimeoutError("simulated extraction timeout")
+
+        monkeypatch.setattr(
+            "agent.memory_extraction.run_post_session_extraction",
+            _raise_timeout,
+        )
+
+        # Synchronous call — no await.
+        se._schedule_post_session_extraction("sess-err-1", "response text")
+
+        # Wait for the background task to complete (it will swallow the error).
+        task = se._pending_extraction_tasks.get("sess-err-1")
+        # If the task already ran to completion + done-callback popped it, task is None.
+        if task is not None:
+            try:
+                await asyncio.wait_for(task, timeout=2.0)
+            except asyncio.TimeoutError:
+                task.cancel()
+                raise AssertionError("wrapper task did not complete")
+
+        # If we got here, the asyncio.TimeoutError was swallowed by the wrapper.
+        # Also confirm nothing is left pending for this session_id.
+        assert "sess-err-1" not in se._pending_extraction_tasks
+
+    @pytest.mark.asyncio
+    async def test_pm_nudge_fires_while_extraction_pending(self, monkeypatch):
+        """Scheduler is synchronous; extraction task is not done when scheduler returns."""
+        from agent import session_executor as se
+
+        # Stub extraction to suspend cooperatively — the task should still be
+        # pending immediately after the scheduler returns.
+        async def _slow_extract(session_id, response_text, project_key=None):
+            await asyncio.sleep(10)
+
+        monkeypatch.setattr(
+            "agent.memory_extraction.run_post_session_extraction",
+            _slow_extract,
+        )
+
+        se._schedule_post_session_extraction("sess-slow-1", "response text")
+
+        task = se._pending_extraction_tasks.get("sess-slow-1")
+        assert task is not None, "task must be registered immediately"
+        # The critical #1055 invariant: scheduler is synchronous and returned
+        # before the extraction task completed. `.done()` is False proves it.
+        assert task.done() is False, (
+            "extraction task must still be pending when scheduler returns — "
+            "proves the PM nudge path is not blocked by extraction latency"
+        )
+
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    @pytest.mark.asyncio
+    async def test_duplicate_schedule_is_deduplicated(self, monkeypatch, caplog):
+        """Calling _schedule_post_session_extraction twice with same session_id dedupes."""
+        from agent import session_executor as se
+
+        caplog.set_level(logging.INFO, logger="agent.session_executor")
+
+        async def _slow_extract(session_id, response_text, project_key=None):
+            await asyncio.sleep(5)
+
+        monkeypatch.setattr(
+            "agent.memory_extraction.run_post_session_extraction",
+            _slow_extract,
+        )
+
+        se._schedule_post_session_extraction("s1", "first call")
+        first_task = se._pending_extraction_tasks["s1"]
+
+        se._schedule_post_session_extraction("s1", "second call")
+        # Dict entry should be identical task object — second call no-ops.
+        assert se._pending_extraction_tasks["s1"] is first_task, (
+            "second schedule must not replace the first task"
+        )
+        assert any("already in-flight for s1" in rec.message for rec in caplog.records), (
+            "must log INFO with 'already in-flight for s1'"
+        )
+
+        first_task.cancel()
+        try:
+            await first_task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    @pytest.mark.asyncio
+    async def test_drain_pending_extractions_noop_when_empty(self, caplog):
+        """drain_pending_extractions returns in ~0s and emits no WARNING when empty."""
+        import time
+
+        from agent import session_executor as se
+
+        # Ensure empty state
+        assert se._pending_extraction_tasks == {}
+
+        caplog.set_level(logging.WARNING, logger="agent.session_executor")
+
+        start = time.time()
+        await se.drain_pending_extractions(timeout=5.0)
+        elapsed = time.time() - start
+
+        assert elapsed < 0.2, (
+            f"drain must return almost immediately when no tasks are pending (got {elapsed:.2f}s) — "
+            "protects graceful shutdown from unnecessary 5s wait on first-deploy"
+        )
+        # No WARNING messages should have been emitted for the empty case
+        warning_records = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert not warning_records, (
+            f"empty-drain must not log WARNING (got {[r.message for r in warning_records]})"
+        )
+
+    @pytest.mark.asyncio
+    async def test_scheduler_is_sync_def_not_async(self):
+        """Structural invariant: _schedule_post_session_extraction is sync (review guard)."""
+        import inspect
+
+        from agent import session_executor as se
+
+        assert not inspect.iscoroutinefunction(se._schedule_post_session_extraction), (
+            "_schedule_post_session_extraction MUST be declared 'def', not 'async def' — "
+            "any awaiting would regress #987 and #1055. See hotfix #1055 docstring."
+        )
+
+    @pytest.mark.asyncio
+    async def test_cancellation_does_not_propagate_past_wrapper(self, monkeypatch):
+        """Cancelling a scheduled task raises CancelledError inside the wrapper.
+
+        The wrapper re-raises CancelledError (preserving cancellation semantics
+        for shutdown drain). The caller (scheduler or drain) is responsible for
+        not letting CancelledError propagate to user-visible paths.
+        """
+        from agent import session_executor as se
+
+        async def _slow_extract(session_id, response_text, project_key=None):
+            await asyncio.sleep(30)
+
+        monkeypatch.setattr(
+            "agent.memory_extraction.run_post_session_extraction",
+            _slow_extract,
+        )
+
+        se._schedule_post_session_extraction("sess-cancel", "text")
+        task = se._pending_extraction_tasks["sess-cancel"]
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task

--- a/tests/unit/test_session_executor_extraction_decoupling.py
+++ b/tests/unit/test_session_executor_extraction_decoupling.py
@@ -41,7 +41,7 @@ class TestScheduleExtractionDecoupling:
         from agent import session_executor as se
 
         async def _raise_timeout(session_id, response_text, project_key=None):
-            raise asyncio.TimeoutError("simulated extraction timeout")
+            raise TimeoutError("simulated extraction timeout")
 
         monkeypatch.setattr(
             "agent.memory_extraction.run_post_session_extraction",
@@ -57,7 +57,7 @@ class TestScheduleExtractionDecoupling:
         if task is not None:
             try:
                 await asyncio.wait_for(task, timeout=2.0)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 task.cancel()
                 raise AssertionError("wrapper task did not complete")
 
@@ -147,7 +147,8 @@ class TestScheduleExtractionDecoupling:
         elapsed = time.time() - start
 
         assert elapsed < 0.2, (
-            f"drain must return almost immediately when no tasks are pending (got {elapsed:.2f}s) — "
+            f"drain must return almost immediately when no tasks are pending "
+            f"(got {elapsed:.2f}s) — "
             "protects graceful shutdown from unnecessary 5s wait on first-deploy"
         )
         # No WARNING messages should have been emitted for the empty case

--- a/worker/__main__.py
+++ b/worker/__main__.py
@@ -407,6 +407,17 @@ async def _run_worker(projects: dict, dry_run: bool = False) -> None:
                 task.cancel()
             await asyncio.gather(*pending, return_exceptions=True)
 
+    # Drain in-flight post-session extractions (hotfix #1055).
+    # Ordering: after worker-task wait (so every extraction that will be scheduled
+    # has been scheduled), before health/notify/reflection cancels (so the event
+    # loop is still running and pending extractions can cooperate with cancel).
+    try:
+        from agent.session_executor import drain_pending_extractions
+
+        await drain_pending_extractions(timeout=5.0)
+    except Exception as e:
+        logger.warning(f"Extraction drain failed: {e}")
+
     # Cancel health monitor
     health_task.cancel()
     try:


### PR DESCRIPTION
## Summary

Fixes #1055: the worker process froze for ~6 hours when a synchronous Anthropic HTTP call inside `agent/memory_extraction.py` stalled on a half-open TCP socket. During the stall, heartbeats stopped, the reflection scheduler paused, session-notify events were missed, and a dev session's follow-up messages were orphaned against a "running" session that was actually frozen.

Two layers of fix, both independently deployable:

**Layer 1 — Event-loop unblock** (`agent/memory_extraction.py`): all three sync `anthropic.Anthropic(...)` call sites are converted to `async with anthropic.AsyncAnthropic(...) as client:` with a double-timeout (SDK `timeout=30s` + outer `asyncio.wait_for(timeout=35s)`). `async with` releases httpx resources deterministically on timeout. A new `_record_extraction_error()` helper emits `memory.extraction.error` analytics counters on every error path (except `CancelledError`) so silent extraction failures are visible on `/dashboard.json`.

**Layer 2 — Decouple extraction from finalization** (`agent/session_executor.py`, `agent/messenger.py`, `worker/__main__.py`): post-session extraction is no longer awaited inside `BackgroundTask._run_work`. Instead, `_execute_agent_session` calls a **synchronous** `_schedule_post_session_extraction(...)` (fire-and-forget `asyncio.create_task`) AFTER `complete_transcript` runs and BEFORE `_handle_dev_session_completion`. A hang in extraction cannot delay session finalization or the dev→PM nudge. `drain_pending_extractions(timeout=5.0)` is wired into the worker shutdown sequence.

## Changes

- `agent/memory_extraction.py`: three call sites converted to `AsyncAnthropic` with double-timeout; new module-level `_EXTRACTION_SDK_TIMEOUT=30.0` and `_EXTRACTION_HARD_TIMEOUT=35.0` constants; new `_record_extraction_error` helper; `_judge_outcomes_llm` converted to `async def`; outer `except` branches now record analytics counters.
- `agent/messenger.py`: `_run_work` no longer awaits `run_post_session_extraction`; docstring updated to prevent re-introduction.
- `agent/session_executor.py`: new module-level `_pending_extraction_tasks: dict[str, asyncio.Task]` keyed by `session_id`; new synchronous `_schedule_post_session_extraction(...)` helper with dedup; new async `drain_pending_extractions(...)` helper; scheduler wired into `_execute_agent_session` between `complete_transcript` and `_handle_dev_session_completion`.
- `worker/__main__.py`: `drain_pending_extractions(timeout=5.0)` called during shutdown after worker-task drain and before health/notify/reflection cancels.
- `docs/features/subconscious-memory.md`: new "Event-Loop Safety (hotfix #1055)" subsection documenting the async-native invariant, double-timeout rationale, fire-and-forget ordering, graceful-shutdown drain, loss tolerance, orphan safety, and `memory.extraction.error` counter.

## Testing

**90 tests across 4 files, all pass:**

- `tests/unit/test_memory_extraction.py` — new `TestEventLoopSafety` class with 5 cases (hard-timeout caught in each of the three extraction paths; APITimeoutError handled; regression canary grep), plus `test_extract_post_merge_learning_runs_inside_asyncio_run` guarding the hook-subprocess `asyncio.run` call path. Existing mocks updated from `anthropic.Anthropic` → `anthropic.AsyncAnthropic`; `TestJudgeOutcomesLlm` updated to async.
- `tests/unit/test_session_executor_extraction_decoupling.py` (NEW) — 6 cases: extraction errors don't propagate, PM nudge fires while extraction is pending, duplicate schedules deduped, drain is a no-op when empty, scheduler is sync (not async), cancellation semantics preserved.
- `tests/integration/test_session_finalization_decoupled.py` (NEW) — 3 cases: 5-second SLO for scheduler + PM nudge even with a 30s extraction stall, drain cancels cooperative tasks within budget, cancellation raises cleanly.
- `tests/unit/test_messenger.py` — 13 existing tests all pass (BackgroundTask refactor did not break the contract).

**Regression canary:** `grep -n "anthropic\\.Anthropic(" agent/memory_extraction.py` returns exit 1 (no matches) — enforced by a unit test.

**Unrelated pre-existing failures** exist in `test_agent_session_scheduler_kill`, `test_worker_entry::test_cleanup_orphaned_in_agent_queue_not_bridge`, and `test_work_request_classifier` — verified to fail on main as well, not caused by this hotfix.

## Documentation

- [x] `docs/features/subconscious-memory.md` updated per plan — new "Event-Loop Safety (hotfix #1055)" subsection under Flow 3, tracking entry added.

## Definition of Done

- [x] Built: all three layers implemented; imports clean
- [x] Tested: 90 hotfix-related tests pass, including the 5-second SLO integration test
- [x] Documented: subconscious-memory.md updated with the new invariants
- [x] Quality: `python -m ruff format .` clean; no new lint issues

Closes #1055