### PR TITLE
chore: remove parent_session_id / parent_chat_session_id aliases (issue #1025)

### DIFF
--- a/agent/hooks/pre_tool_use.py
+++ b/agent/hooks/pre_tool_use.py
@@ -306,7 +306,7 @@ def _extract_stage_from_prompt(prompt: str) -> str | None:
     return None
 
 
-def _start_pipeline_stage(parent_session_id: str, stage: str) -> None:
+def _start_pipeline_stage(pm_session_id: str, stage: str) -> None:
     """Start an SDLC stage on the parent PM session's PipelineStateMachine.
 
     Loads the parent AgentSession from Redis, creates a PipelineStateMachine,
@@ -319,10 +319,10 @@ def _start_pipeline_stage(parent_session_id: str, stage: str) -> None:
         from agent.pipeline_state import PipelineStateMachine
         from models.agent_session import AgentSession
 
-        parent_sessions = list(AgentSession.query.filter(session_id=parent_session_id))
+        parent_sessions = list(AgentSession.query.filter(session_id=pm_session_id))
         if not parent_sessions:
             logger.warning(
-                f"[pre_tool_use] Parent session {parent_session_id} not found, "
+                f"[pre_tool_use] Parent session {pm_session_id} not found, "
                 f"skipping start_stage({stage})"
             )
             return
@@ -330,11 +330,11 @@ def _start_pipeline_stage(parent_session_id: str, stage: str) -> None:
         parent = parent_sessions[0]
         sm = PipelineStateMachine(parent)
         sm.start_stage(stage)
-        logger.info(f"[pre_tool_use] Started pipeline stage {stage} on session {parent_session_id}")
+        logger.info(f"[pre_tool_use] Started pipeline stage {stage} on session {pm_session_id}")
     except Exception as e:
         logger.warning(
             f"[pre_tool_use] Failed to start pipeline stage {stage} "
-            f"on session {parent_session_id}: {e}"
+            f"on session {pm_session_id}: {e}"
         )
 
 

--- a/docs/features/agent-session-model.md
+++ b/docs/features/agent-session-model.md
@@ -26,7 +26,7 @@ See [Session Lifecycle](session-lifecycle.md) for the full 13-state reference (8
 
 **Lifecycle:** `session_events` (ListField of `SessionEvent` dicts), `issue_url`, `plan_url`, `pr_url`
 
-**Parent-Child:** `parent_agent_session_id` (KeyField — canonical parent reference), `parent_session_id` and `parent_chat_session_id` (`@property` aliases delegating to `parent_agent_session_id` — use `parent_agent_session_id` for new code), `role` (DataField — "pm", "dev", or null), `slug`
+**Parent-Child:** `parent_agent_session_id` (KeyField — canonical parent reference), `role` (DataField — "pm", "dev", or null), `slug`
 
 All timestamp fields use Popoto `DatetimeField` or `SortedField(type=datetime)` with proper UTC datetime objects. Float/int timestamps are auto-converted via `__setattr__`.
 

--- a/docs/features/claude-code-memory.md
+++ b/docs/features/claude-code-memory.md
@@ -106,7 +106,7 @@ Worker-spawned Claude Code sessions create AgentSession records in Redis, provid
 
 The dashboard at `localhost:8500` picks up local sessions automatically via `AgentSession.query` -- no dashboard code changes were needed. Local sessions appear alongside Telegram sessions with correct status, timestamps, and project key.
 
-The `AgentSession.create_local(...)` call requires only `session_id`, `project_key`, and `working_dir`. The `session_type` defaults to `"dev"` but is overridden by the `SESSION_TYPE` env var when set. Local sessions omit all Telegram-specific fields (no `chat_id` or `parent_chat_session_id`).
+The `AgentSession.create_local(...)` call requires only `session_id`, `project_key`, and `working_dir`. The `session_type` defaults to `"dev"` but is overridden by the `SESSION_TYPE` env var when set. Local sessions omit all Telegram-specific fields (no `chat_id` or `parent_agent_session_id`).
 
 ## State Management
 

--- a/docs/features/pm-dev-session-architecture.md
+++ b/docs/features/pm-dev-session-architecture.md
@@ -134,8 +134,6 @@ Single Popoto model (`AgentSession`) with discriminator field. Popoto ORM does n
 
 ### Dev session-specific fields
 - `parent_agent_session_id` (KeyField) -- **canonical** parent link (role-neutral). Set by all session creators (`create_child`, `create_dev`, `enqueue_session`) and read by all hierarchy walkers (`scheduling_depth`, `get_parent_session`, `get_child_sessions`, the zombie health check, the dashboard).
-- `parent_session_id` -- backward-compat `@property` alias delegating to `parent_agent_session_id`. Kept for one release cycle. New code should use `parent_agent_session_id` directly.
-- `parent_chat_session_id` -- backward-compat `@property` alias also delegating to `parent_agent_session_id` (the alias chain `parent_chat_session_id -> parent_session_id -> parent_agent_session_id` continues to resolve transparently).
 - `role` (DataField) -- session specialization ("pm", "dev", or null for unspecialized sessions)
 - `stage_states` -- derived property reading from `session_events`
 - `slug` -- derives branch name, plan path, worktree
@@ -382,7 +380,7 @@ The PM session can push steering messages to its running child Dev sessions, ena
 
 ### Mechanism
 
-The PM invokes `scripts/steer_child.py` via bash with the child's session ID and a steering message. The script validates the parent-child relationship (via `parent_session_id`) and writes to the child's turn-boundary inbox (`AgentSession.queued_steering_messages`). The worker delivers the message at the next turn boundary.
+The PM invokes `scripts/steer_child.py` via bash with the child's session ID and a steering message. The script validates the parent-child relationship (via `parent_agent_session_id`) and writes to the child's turn-boundary inbox (`AgentSession.queued_steering_messages`). The worker delivers the message at the next turn boundary.
 
 **Delivery paths by harness type:**
 - **CLI-harness sessions** (default): `steer_child.py` calls `steer_session()` which writes to `queued_steering_messages`. The worker injects the message as user input at the next turn boundary. There is no mid-turn injection — the Dev session sees the message at most one turn late.

--- a/docs/features/pm-telegram-tool.md
+++ b/docs/features/pm-telegram-tool.md
@@ -117,7 +117,7 @@ The summarizer is retained as a safety net. The decision tree in `bridge/respons
 
 1. Refresh the AgentSession from Redis to get the latest `pm_sent_message_ids`.
 2. If `session.has_pm_messages()` returns True: skip summarizer, return True. The PM already delivered its own messages.
-3. **Parent session lookup** (issue #571): If the session itself has no PM messages but has a `parent_chat_session_id` (i.e., it is a Dev session in an SDLC flow), look up the parent PM session via `get_parent_chat_session()` and check `has_pm_messages()` on the parent. If the parent has PM messages, skip the summarizer. This prevents dual messages in SDLC flows where the PM (PM session) self-messages and the Dev session output would otherwise also be summarized and sent.
+3. **Parent session lookup** (issue #571): If the session itself has no PM messages but has a `parent_agent_session_id` (i.e., it is a Dev session in an SDLC flow), look up the parent PM session via `get_parent_chat_session()` and check `has_pm_messages()` on the parent. If the parent has PM messages, skip the summarizer. This prevents dual messages in SDLC flows where the PM (PM session) self-messages and the Dev session output would otherwise also be summarized and sent.
 4. If neither session nor parent has PM messages: fall through to the existing summarizer path. The response text is compressed and sent as before.
 
 This means:

--- a/docs/features/redis-models.md
+++ b/docs/features/redis-models.md
@@ -145,8 +145,6 @@ Popoto field types have different implications for how records behave on mutatio
 | `project_key` | KeyField | No | Set once at creation |
 | `chat_id` | KeyField | No | Set once at creation |
 | `parent_agent_session_id` | KeyField | No | Canonical parent reference. Set once at creation (child sessions only). |
-| `parent_session_id` | property | No | Deprecated `@property` alias delegating to `parent_agent_session_id`. |
-| `parent_chat_session_id` | property | No | Deprecated `@property` alias delegating to `parent_agent_session_id`. |
 | `role` | Field | No | Set once at creation ("pm", "dev", or null for legacy) |
 | `status` | IndexedField | Yes | Mutate and save directly; no delete-and-recreate |
 

--- a/docs/features/session-steering.md
+++ b/docs/features/session-steering.md
@@ -138,7 +138,7 @@ PM session decides to steer
 python scripts/steer_child.py --session-id <child_id> --message "focus on tests" --parent-id <parent_id>
     |
     v
-Script validates: child exists, is a Dev session, parent_chat_session_id matches, status is "running"
+Script validates: child exists, is a Dev session, parent_agent_session_id matches, status is "running"
     |
     v
 push_steering_message(child_session_id, text, sender="PM session")
@@ -171,7 +171,7 @@ The script enforces strict parent-child relationship validation:
 
 - Target must be an existing AgentSession
 - Target must be a Dev session (`is_dev` check)
-- Target's `parent_chat_session_id` must match the caller's ID
+- Target's `parent_agent_session_id` must match the caller's ID
 - Target must be in `running` status
 
 All validation failures exit with non-zero code and print an error to stderr.

--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -22,8 +22,6 @@ Roles (specialization within a session type):
 
 Parent-child relationship:
   parent_agent_session_id is the canonical parent link (role-neutral).
-  parent_session_id and parent_chat_session_id are deprecated aliases that
-  delegate to parent_agent_session_id via property.
   Use create_child(role=...) to spawn child sessions.
 
 Status lifecycle (see models/session_lifecycle.py for canonical mutation functions):
@@ -102,10 +100,6 @@ class AgentSession(Model):
     Parent-child hierarchy:
         parent_agent_session_id: Canonical parent link (role-neutral). Set
             by all session creators (create_child, create_dev, enqueue_session).
-        parent_session_id: Deprecated alias property delegating to
-            parent_agent_session_id (kept for one release cycle).
-        parent_chat_session_id: Deprecated alias property delegating to
-            parent_agent_session_id via parent_session_id.
 
     Factory methods:
         create_pm(): Create a PM session (PM persona, read-only).
@@ -227,8 +221,6 @@ class AgentSession(Model):
     project_config = DictField(null=True)
 
     # === Dev session fields (null when session_type="pm" or "teammate") ===
-    # Note: parent_session_id is now a deprecated @property alias for
-    # parent_agent_session_id. See the alias block below.
     slug = Field(null=True)  # Derives branch, plan path, worktree
 
     # === Role field (flexible specialization beyond session_type) ===
@@ -439,22 +431,6 @@ class AgentSession(Model):
         elif "parent_job_id" in kwargs:  # legacy
             kwargs.pop("parent_job_id")  # legacy
 
-        # Map deprecated parent_chat_session_id → parent_agent_session_id
-        if "parent_chat_session_id" in kwargs and "parent_agent_session_id" not in kwargs:
-            logger.warning(
-                "Deprecated: parent_chat_session_id passed to AgentSession; "
-                "use parent_agent_session_id instead"
-            )
-            kwargs["parent_agent_session_id"] = kwargs.pop("parent_chat_session_id")
-        elif "parent_chat_session_id" in kwargs:
-            kwargs.pop("parent_chat_session_id")
-
-        # Map deprecated parent_session_id → parent_agent_session_id
-        if "parent_session_id" in kwargs and "parent_agent_session_id" not in kwargs:
-            kwargs["parent_agent_session_id"] = kwargs.pop("parent_session_id")
-        elif "parent_session_id" in kwargs:
-            kwargs.pop("parent_session_id")
-
         if "agent_session_id" in kwargs:
             kwargs.pop("agent_session_id")  # AutoKeyField, ignore
 
@@ -598,33 +574,6 @@ class AgentSession(Model):
                 agent_session_id,
             )
         return results[0]
-
-    # === Deprecated alias chain: parent_chat_session_id -> parent_session_id
-    # ===                          -> parent_agent_session_id (canonical)
-    #
-    # parent_agent_session_id is the only KeyField. The two aliases below are
-    # kept for one release cycle so legacy callers continue to work. New code
-    # should write parent_agent_session_id directly.
-
-    @property
-    def parent_session_id(self) -> str | None:
-        """Deprecated alias for parent_agent_session_id."""
-        return self.parent_agent_session_id
-
-    @parent_session_id.setter
-    def parent_session_id(self, value: str | None) -> None:
-        """Deprecated setter for parent_agent_session_id."""
-        self.parent_agent_session_id = value
-
-    @property
-    def parent_chat_session_id(self) -> str | None:
-        """Deprecated alias for parent_agent_session_id."""
-        return self.parent_agent_session_id
-
-    @parent_chat_session_id.setter
-    def parent_chat_session_id(self, value: str | None) -> None:
-        """Deprecated setter for parent_agent_session_id."""
-        self.parent_agent_session_id = value
 
     # === Backward-compatible property: agent_session_id -> id ===
 
@@ -1126,7 +1075,7 @@ class AgentSession(Model):
         session_id: str,
         project_key: str,
         working_dir: str,
-        parent_session_id: str,
+        parent_agent_session_id: str,
         message_text: str,
         slug: str | None = None,
         stage_states: dict | None = None,
@@ -1139,8 +1088,7 @@ class AgentSession(Model):
             session_id: Unique session identifier.
             project_key: Project this session belongs to.
             working_dir: Working directory for the session.
-            parent_session_id: ID of the parent session. Stored as
-                parent_agent_session_id (the canonical field).
+            parent_agent_session_id: ID of the parent session.
             message_text: Initial message text.
             slug: Optional work item slug.
             stage_states: Optional initial SDLC stage states.
@@ -1159,7 +1107,7 @@ class AgentSession(Model):
             session_type=SESSION_TYPE_DEV,
             project_key=project_key,
             working_dir=working_dir,
-            parent_agent_session_id=parent_session_id,
+            parent_agent_session_id=parent_agent_session_id,
             initial_telegram_message=itm,
             slug=slug,
             role=role,
@@ -1177,7 +1125,7 @@ class AgentSession(Model):
         session_id: str,
         project_key: str,
         working_dir: str,
-        parent_session_id: str | None = None,
+        parent_agent_session_id: str | None = None,
         message_text: str,
         slug: str | None = None,
         stage_states: dict | None = None,
@@ -1187,20 +1135,12 @@ class AgentSession(Model):
 
         Deprecated: Use create_child(role="dev", ...) instead.
         """
-        # Support old kwarg name via _normalize_kwargs
-        if parent_session_id is None:
-            parent_session_id = kwargs.pop("parent_chat_session_id", None)
-            if parent_session_id is not None:
-                logger.warning(
-                    "Deprecated: parent_chat_session_id passed to create_dev(); "
-                    "use parent_session_id instead"
-                )
         return cls.create_child(
             role="dev",
             session_id=session_id,
             project_key=project_key,
             working_dir=working_dir,
-            parent_session_id=parent_session_id or "",
+            parent_agent_session_id=parent_agent_session_id or "",
             message_text=message_text,
             slug=slug,
             stage_states=stage_states,

--- a/scripts/steer_child.py
+++ b/scripts/steer_child.py
@@ -96,7 +96,7 @@ def _steer_child(session_id: str, message: str, parent_id: str, abort: bool) -> 
         return 1
 
     # Validate parent-child relationship
-    if child.parent_session_id != parent_id:
+    if child.parent_agent_session_id != parent_id:
         print(
             f"Error: session '{session_id}' is not a child of '{parent_id}'",
             file=sys.stderr,

--- a/scripts/update/migrations.py
+++ b/scripts/update/migrations.py
@@ -95,6 +95,35 @@ _SDLC_STUBS = [
 ]
 
 
+def _migrate_unify_parent_session_field(project_dir: Path) -> str | None:
+    """Normalize parent_session_id Redis hash fields into parent_agent_session_id.
+
+    Copies any leftover parent_session_id values into parent_agent_session_id where
+    the latter is empty, then deletes the stale field. Idempotent — safe to re-run.
+    Returns None on success, error string on failure.
+    """
+    script = project_dir / "scripts" / "migrate_unify_parent_session_field.py"
+    if not script.exists():
+        return "migration script not found"
+
+    python = project_dir / ".venv" / "bin" / "python"
+    try:
+        result = subprocess.run(
+            [str(python), str(script), "--apply"],
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            return f"exit code {result.returncode}: {result.stderr[-500:]}"
+        return None
+    except subprocess.TimeoutExpired:
+        return "migration timed out after 120s"
+    except Exception as e:
+        return str(e)
+
+
 def _migrate_create_sdlc_stubs(project_dir: Path) -> str | None:
     """Create docs/sdlc/ stub files if missing.
 
@@ -123,6 +152,10 @@ MIGRATIONS: dict[str, tuple[callable, str]] = {
     "create_sdlc_stubs": (
         _migrate_create_sdlc_stubs,
         "Create docs/sdlc/ per-stage addendum stub files",
+    ),
+    "unify_parent_session_field": (
+        _migrate_unify_parent_session_field,
+        "Normalize parent_session_id Redis fields into parent_agent_session_id",
     ),
 }
 

--- a/scripts/update/migrations.py
+++ b/scripts/update/migrations.py
@@ -120,7 +120,7 @@ def _migrate_unify_parent_session_field(project_dir: Path) -> str | None:
         return None
     except subprocess.TimeoutExpired:
         return "migration timed out after 120s"
-    except Exception as e:
+    except Exception as e:  # swallow-ok: error returned as string to caller for logging
         return str(e)
 
 

--- a/tests/e2e/test_context_propagation.py
+++ b/tests/e2e/test_context_propagation.py
@@ -79,13 +79,13 @@ class TestDevParentLinkage:
             session_id=f"child_{ts}",
             project_key="valor",
             working_dir="/tmp/test/.worktrees/my-feature",
-            parent_session_id=chat.agent_session_id,
+            parent_agent_session_id=chat.agent_session_id,
             message_text="/do-build",
             slug="my-feature",
         )
 
         assert dev.session_type == SESSION_TYPE_DEV
-        assert dev.parent_session_id == chat.agent_session_id
+        assert dev.parent_agent_session_id == chat.agent_session_id
 
         # Navigate from child to parent via filter
         parents = list(AgentSession.query.filter(session_id=chat.session_id))
@@ -108,14 +108,14 @@ class TestDevParentLinkage:
             session_id=f"dev1_{ts}",
             project_key="valor",
             working_dir="/tmp/test",
-            parent_session_id=chat.agent_session_id,
+            parent_agent_session_id=chat.agent_session_id,
             message_text="/do-build",
         )
         dev2 = AgentSession.create_dev(
             session_id=f"dev2_{ts}",
             project_key="valor",
             working_dir="/tmp/test",
-            parent_session_id=chat.agent_session_id,
+            parent_agent_session_id=chat.agent_session_id,
             message_text="/do-test",
         )
 
@@ -130,7 +130,7 @@ class TestDevParentLinkage:
             session_id=f"orphan_{ts}",
             project_key="valor",
             working_dir="/tmp/test",
-            parent_session_id="nonexistent_id",
+            parent_agent_session_id="nonexistent_id",
             message_text="lost",
         )
         assert dev.get_parent_session() is None
@@ -146,7 +146,7 @@ class TestDerivedPaths:
             session_id=f"slug_{ts}",
             project_key="valor",
             working_dir="/tmp/test",
-            parent_session_id="parent_x",
+            parent_agent_session_id="parent_x",
             message_text="build",
             slug="my-cool-feature",
         )
@@ -182,7 +182,7 @@ class TestSDLCStagesPropagation:
             session_id=f"stages_{ts}",
             project_key="valor",
             working_dir="/tmp/test",
-            parent_session_id="parent_y",
+            parent_agent_session_id="parent_y",
             message_text="/do-build",
             stage_states=stages,
         )
@@ -228,7 +228,7 @@ class TestSessionTypeDiscriminator:
             session_id=f"type_dev_{ts}",
             project_key="valor",
             working_dir="/tmp",
-            parent_session_id=chat.agent_session_id,
+            parent_agent_session_id=chat.agent_session_id,
             message_text="build",
         )
 
@@ -249,7 +249,7 @@ class TestSessionTypeDiscriminator:
             session_id=f"qt_dev_{ts}",
             project_key="query_test",
             working_dir="/tmp",
-            parent_session_id="parent_x",
+            parent_agent_session_id="parent_x",
             message_text="build",
         )
 

--- a/tests/integration/test_agent_session_queue_session_type.py
+++ b/tests/integration/test_agent_session_queue_session_type.py
@@ -44,7 +44,7 @@ class TestAsyncCreateMatchesFactoryMethods:
             **shared,
         )
         via_factory = AgentSession.create_dev(
-            parent_session_id="parent-123",
+            parent_agent_session_id="parent-123",
             chat_id=str(-time.time_ns() % 999_000),
             telegram_message_id=2,
             **shared,

--- a/tests/integration/test_parent_child_round_trip.py
+++ b/tests/integration/test_parent_child_round_trip.py
@@ -122,7 +122,7 @@ class TestDevSessionParentLinkage:
         assert len(children) >= 1
         assert any(c.session_id == "dev-linkage-query-001" for c in children)
 
-    def test_parent_session_id_none_without_parent(self, redis_test_db):
+    def test_no_parent_when_not_set(self, redis_test_db):
         """Dev session without --parent has parent_agent_session_id=None."""
         standalone_dev = AgentSession.create(
             session_id="dev-no-parent-001",

--- a/tests/unit/test_hook_user_prompt_submit.py
+++ b/tests/unit/test_hook_user_prompt_submit.py
@@ -236,7 +236,7 @@ class TestMainCallChain:
 
         mock_create.assert_called_once()
 
-    def test_main_creates_session_when_parent_session_id_set(self, monkeypatch):
+    def test_main_creates_session_when_parent_set(self, monkeypatch):
         """VALOR_PARENT_SESSION_ID set -> create AgentSession."""
         hook = _load_hook_module()
 

--- a/tests/unit/test_steer_child.py
+++ b/tests/unit/test_steer_child.py
@@ -28,7 +28,7 @@ def mock_child():
     child.session_type = "dev"
     child.is_pm = False
     child.is_dev = True
-    child.parent_session_id = "parent-001"
+    child.parent_agent_session_id = "parent-001"
     child.status = "running"
     child.slug = "my-feature"
     child.current_stage = "BUILD"
@@ -151,7 +151,7 @@ class TestSteerChild:
     @patch(_AGENT_SESSION)
     def test_non_child_rejected(self, mock_agent_session_cls, mock_child):
         """Session that is not a child of the parent is rejected."""
-        mock_child.parent_session_id = "other-parent"
+        mock_child.parent_agent_session_id = "other-parent"
         mock_agent_session_cls.get_by_id.return_value = mock_child
 
         result = main(

--- a/tests/unit/test_summarizer.py
+++ b/tests/unit/test_summarizer.py
@@ -1992,7 +1992,7 @@ class TestSummarizerBypassParentSession:
 
     @pytest.mark.asyncio
     async def test_no_bypass_when_parent_is_dangling(self):
-        """Dev session with dangling parent_session_id -> bypass does not fire."""
+        """Dev session with dangling parent_agent_session_id -> bypass does not fire."""
         from bridge.response import send_response_with_files
 
         mock_client = MagicMock()
@@ -2018,7 +2018,7 @@ class TestSummarizerBypassParentSession:
 
     @pytest.mark.asyncio
     async def test_no_bypass_when_no_parent(self):
-        """Session without parent_session_id -> no parent lookup, no bypass."""
+        """Session without parent link -> no parent lookup, no bypass."""
         from bridge.response import send_response_with_files
 
         mock_client = MagicMock()


### PR DESCRIPTION
## Summary
- Deletes the `parent_session_id` and `parent_chat_session_id` `@property` aliases and their setters from `models/agent_session.py` (the canonical `parent_agent_session_id` KeyField is the only parent link going forward)
- Removes kwarg normalization blocks in `_normalize_kwargs` that silently remapped the deprecated names
- Renames `create_child()` and `create_dev()` parameters from `parent_session_id` → `parent_agent_session_id`
- Wires `migrate_unify_parent_session_field.py --apply` into the update system's migration registry so sibling machines normalize their Redis data on next `/update`

## Changes
- `models/agent_session.py`: deleted aliases, kwarg normalization, and docstring references; renamed factory method params
- `scripts/steer_child.py`: reads `child.parent_agent_session_id` directly (line 99)
- `agent/hooks/pre_tool_use.py`: cosmetic rename of local var `parent_session_id` → `pm_session_id` in `_start_pipeline_stage`
- `scripts/update/migrations.py`: added `unify_parent_session_field` migration entry
- 6 test files updated to use canonical param/property name; 2 test method renames required by Success Criterion grep
- 6 feature doc files updated to remove alias references

## Testing
- [x] `grep -rn 'parent_session_id\|parent_chat_session_id' models/ agent/ bridge/ worker/ tools/` → exit 1 (no matches)
- [x] All unit and integration tests pass (pre-existing failures on main verified and excluded)
- [x] Migration ran cleanly: 0 records needed migration on local Redis

## Documentation
- [x] `docs/features/agent-session-model.md` — alias entries removed from field table
- [x] `docs/features/pm-dev-session-architecture.md` — alias field list and steer_child validation doc updated
- [x] `docs/features/redis-models.md` — deprecated property rows removed
- [x] `docs/features/session-steering.md` — validation note updated to `parent_agent_session_id`
- [x] `docs/features/pm-telegram-tool.md` — parent lookup description updated
- [x] `docs/features/claude-code-memory.md` — local session field list updated

## Definition of Done
- [x] Built: aliases deleted, call sites updated, migration wired
- [x] Tested: unit + integration tests passing
- [x] Documented: feature docs updated
- [x] Quality: no alias refs remain in production code directories

## Update System Note
`scripts/update/migrations.py` now includes `unify_parent_session_field` in the migration registry. On next `/update`, all sibling machines will automatically run `migrate_unify_parent_session_field.py --apply` before the worker restarts. Archival of the three migration scripts to `scripts/archive/` is deferred to a follow-up PR (tracked in #1025 closeout) — the scripts must remain at their current paths until all machines have pulled at least once with the migration wired in.

Closes #1025