### PR TITLE
Opus 4.7 audit: harden SDLC skill prompts for 4.7 behavior

### DIFF
--- a/.claude/skills/daily-integration-audit/SKILL.md
+++ b/.claude/skills/daily-integration-audit/SKILL.md
@@ -74,14 +74,15 @@ Invoke the `do-integration-audit` skill on the feature topic. In addition to the
 - **Clarity**: can a new contributor understand the feature from this doc alone?
 - **Organization**: is structure coherent? Are obvious sections missing?
 
-**Use an Opus subagent via the Agent tool** for this — the audit is read-heavy and benefits from careful reasoning. Brief the subagent with:
+**Use an Opus subagent via the Agent tool** for this — the audit is read-heavy and benefits from careful reasoning. The brief MUST be fully self-contained — the subagent will not ask follow-up questions. Pass every field below verbatim into the subagent prompt:
 
-- The feature topic
-- The seed doc path
-- A reminder that audits must run the verification pass before writing findings (re-read cited file:line, grep the whole project for negative claims, trace dynamic-behavior claims into function bodies)
-- The request to return findings in the standard `do-integration-audit` format plus a separate Documentation Audit section
-- A request for a short **"Meta-observations"** section capturing cross-cutting patterns that don't fit any single finding (e.g., "three separate findings all stem from the same god module" or "every doc in this feature describes a removed field"). These become Track C investigation checklist items.
-- A request that the final summary line in the report be machine-parseable: exactly `SUMMARY: PASS=<n> WARN=<n> FAIL=<n>` so this skill can extract the counts.
+```
+FEATURE_TOPIC: <slug>
+SEED_DOC_PATH: docs/features/<slug>.md
+VERIFICATION_PASS: required — re-read every cited file:line; grep the whole project for negative claims before asserting them; trace every dynamic-behavior claim into the relevant function body before writing a finding
+OUTPUT_FORMAT: standard do-integration-audit format, followed by a separate `## Documentation Audit` section (accuracy, clarity, organization checks on the seed doc), followed by a `## Meta-observations` section capturing cross-cutting patterns that don't fit any single finding (e.g., "three separate findings all stem from the same god module" or "every doc in this feature describes a removed field") — these become Track C investigation checklist items
+FINAL_LINE: must be exactly `SUMMARY: PASS=<n> WARN=<n> FAIL=<n>` so the parent skill can extract the counts
+```
 
 ## Step 3: Triage into three tracks
 

--- a/.claude/skills/do-plan-critique/SKILL.md
+++ b/.claude/skills/do-plan-critique/SKILL.md
@@ -181,6 +181,8 @@ After all critics complete:
 
 ### Step 5: Report
 
+Emit every section header literally; empty categories emit '## Blockers\n\nNone.' — do not omit the header.
+
 Output the final report in this format:
 
 ```markdown

--- a/.claude/skills/do-plan/SKILL.md
+++ b/.claude/skills/do-plan/SKILL.md
@@ -94,7 +94,7 @@ git log --oneline --since="$ISSUE_CREATED" -- <file1> <file2> ...
 1. If any commits touched those files since the issue was filed, read the diffs. Decide whether each change (a) is irrelevant, (b) partially addresses the problem, (c) changed the root cause, or (d) already fixes the problem.
 2. Check `docs/plans/*.md` for active plans touching the same area (`ls -lt docs/plans/` then inspect the most recent few). Overlap with an active plan is a coordination signal, not necessarily a blocker — but it must be surfaced.
 
-**For bug issues specifically**, try to reproduce the bug against current main (or at least read the code path and confirm the defect is still present). If the bug is now unreproducible or the cited symptoms no longer occur, stop and ask the user whether to close the issue rather than plan a fix for a non-bug.
+**For bug issues specifically**, reproduce the bug against current main — or, if reproduction is infeasible (e.g., the bug requires a production-only precondition), read the code path and confirm the defect is still present. If the bug is now unreproducible or the cited symptoms no longer occur, stop and ask the user whether to close the issue rather than plan a fix for a non-bug.
 
 **Produce a `## Freshness Check` section** in the plan document capturing what was re-verified, with one of four dispositions:
 
@@ -144,7 +144,10 @@ Gather relevant external context before planning. This surfaces current document
 
 ### Phase 1: Flesh Out at High Level
 
-1. **Understand the request** - What's being asked?
+1. **Understand the request** — gather evidence before scoping. Do NOT rely on inference; execute this checklist:
+   1. Read the full issue body (not just the title). Extract the Problem, Desired Outcome, and any Acceptance Criteria checklist items verbatim.
+   2. Read the `## Recon Summary` section of the issue if present. Extract the "Confirmed," "Revised," "Pre-requisites," and "Dropped" buckets — these are direct inputs to the plan's Solution and No-Gos sections.
+   3. Follow every cited sibling issue or PR referenced in the issue body. For each, summarize its relevance to the current work in one sentence. Record these under Prior Art.
 2. **Narrow the problem** - Challenge vague requests (see `SCOPING.md` if needed)
 3. **Blast radius analysis** - If the change involves code modifications, run the code impact finder:
    ```bash

--- a/.claude/skills/do-pr-review/SKILL.md
+++ b/.claude/skills/do-pr-review/SKILL.md
@@ -229,7 +229,7 @@ Include the verification results in the review comment under a "Verification Res
   - Future enhancements
   - Only skip nits that are genuinely subjective (e.g., naming preference) — requires human approval
 
-**For each issue found, use this format:**
+**For every issue found you MUST emit exactly this block, with every field present. A finding missing any field is invalid and MUST be dropped, not shortened:**
 
 ```
 **File:** `path/to/file.py:42` (verified: read this file)
@@ -240,6 +240,8 @@ Include the verification results in the review comment under a "Verification Res
 ```
 
 The `Code:` field MUST be a verbatim quote from the file, not paraphrased. The `File:` path MUST be a file you read with the Read tool during this review. If you cannot produce both of these, do not include the finding.
+
+**Empty-section rule (MANDATORY):** If a severity category has zero findings, you MUST still emit the heading with an explicit empty marker — `### Blockers\n- None`, `### Tech Debt\n- None`, `### Nits\n- None`. Do NOT omit the heading. Downstream parsing and the three-tier decision tree in Step 6 depend on every category appearing.
 
 ### 5.5. Verify Findings (mandatory)
 

--- a/.claude/skills/do-pr-review/sub-skills/code-review.md
+++ b/.claude/skills/do-pr-review/sub-skills/code-review.md
@@ -111,6 +111,8 @@ else:
 
 Before writing the verdict, evaluate each of the following items. Every item must receive a `PASS`, `FAIL`, or `N/A` verdict. No blank entries are allowed. Items marked `FAIL` automatically become findings.
 
+Every row MUST be filled. Blank cells invalidate the review.
+
 Emit the completed checklist as a markdown table in the review comment:
 
 ```markdown
@@ -142,7 +144,7 @@ An "Approved" verdict requires all 12 items evaluated (no blanks). Items that do
 - **tech_debt**: Fix before merge, patched by `/do-patch` (code quality, missing edge case tests)
 - **nit**: Fix before merge unless purely subjective (style, naming, docs wording)
 
-For each finding, use this format:
+For every finding you MUST emit exactly this block, with every field present. A finding missing any field is invalid and MUST be dropped, not shortened:
 ```
 **File:** `path/to/file.py:42` (verified: read this file)
 **Code:** `the_actual_code_on_that_line()`
@@ -150,6 +152,8 @@ For each finding, use this format:
 **Severity:** blocker | tech_debt | nit
 **Fix:** [suggested fix]
 ```
+
+**Empty-section rule:** If a severity category has zero findings, emit the heading with an explicit empty marker (`### Blockers\n- None`, `### Tech Debt\n- None`, `### Nits\n- None`). Do NOT omit the heading.
 
 ### 7. Verify All Findings
 

--- a/docs/features/sdlc-skills-audit.md
+++ b/docs/features/sdlc-skills-audit.md
@@ -83,3 +83,31 @@ PR #1039 exposed five recurring patterns where each layer of the SDLC pipeline's
 | `.claude/commands/do-merge.md` | Added Full Suite Gate with red-main recovery path and baseline comparison |
 | `.claude/skills/do-pr-review/sub-skills/code-review.md` | Added mandatory 12-item Pre-Verdict Checklist |
 | `docs/features/sdlc-skills-audit.md` | This document |
+
+---
+
+## Opus 4.7 Audit (2026-04-20)
+
+Anthropic shipped Opus 4.7 on 2026-04-16. This audit pass reviewed the four SDLC skills that explicitly dispatch via `--model opus` against the 4.7 behavioral model, and hardened their prompts where the older Opus behavior was load-bearing.
+
+**Skills reviewed:** `/do-plan`, `/do-plan-critique`, `/do-pr-review`, `daily-integration-audit`.
+
+**Three behavioral deltas checked** (sources: [Simon Willison's 4.7 system-prompt diff](https://simonwillison.net/2026/Apr/18/opus-system-prompt/), [keepmyprompts.com migration guide](https://www.keepmyprompts.com/en/blog/claude-opus-4-7-prompting-guide-whats-changed)):
+
+1. **Conciseness shift** — 4.7's system prompt adds explicit brevity instructions; soft format requests ("use this format") are the first casualty when the model judges the task simple. Remedy: promote "use this format" → "you MUST emit exactly this block, every field present."
+2. **Proactive tool-checking** — 4.7 calls `tool_search` before concluding it lacks a capability. Behavioral "announce-your-tools" scaffolding is redundant. Remedy: remove such announcements; keep `ToolSearch("select:X")` schema-loading (technical requirement, unaffected).
+3. **Reduced clarification** — 4.7 attempts the task instead of asking. Skills that relied on Opus surfacing ambiguity must front-load context. Remedy: expand evidence-gathering checklists; rewrite subagent briefs to be fully self-contained.
+
+**Edits applied:**
+
+| Skill | Edit |
+|------|------|
+| `.claude/skills/do-plan/SKILL.md` | Phase 1 Step 1 expanded into a 3-step evidence-gathering checklist (read issue body, read Recon Summary, follow sibling issues); "try to reproduce the bug" hedge replaced with direct directive. |
+| `.claude/skills/do-plan-critique/SKILL.md` | Added canonical sentence above Step 5: *"Emit every section header literally; empty categories emit '## Blockers\n\nNone.' — do not omit the header."* Critic subagent prompts (Sonnet) unchanged. |
+| `.claude/skills/do-pr-review/SKILL.md` | Step 5 format block promoted from "use this format" to hard "you MUST emit exactly this block, every field present" directive. Explicit empty-section rule added for Blockers / Tech Debt / Nits headings. |
+| `.claude/skills/do-pr-review/sub-skills/code-review.md` | "Every row MUST be filled; blank cells invalidate the review" added above the 12-row Pre-Verdict Checklist. Section 6 format block tightened to match parent SKILL.md. |
+| `.claude/skills/daily-integration-audit/SKILL.md` | Step 2 Opus subagent brief rewritten into a self-contained structured block (`FEATURE_TOPIC` / `SEED_DOC_PATH` / `VERIFICATION_PASS` / `OUTPUT_FORMAT` / `FINAL_LINE`). |
+
+**Out of scope (explicitly dropped):** version-pinning `opus` to `claude-opus-4-7` — Anthropic's alias routes `opus` to the current Opus and pinning creates maintenance burden without predictability gain.
+
+**Plan:** `docs/plans/opus-skill-prompts-4-7.md` (issue #1066).

--- a/docs/plans/opus-skill-prompts-4-7.md
+++ b/docs/plans/opus-skill-prompts-4-7.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: docs_complete
 type: chore
 appetite: Small
 owner: Valor Engels
@@ -306,17 +306,17 @@ Integration validation for the smoke-test (AC #6): after the edit merges, invoke
 This is an internal prompt-text edit. No user-facing feature documentation is needed, but a brief note in the SDLC skill docs captures the audit.
 
 ### Feature Documentation
-- [ ] **Append** a new dated sub-section (`## Opus 4.7 Audit (2026-04-20)`) to the END of `docs/features/sdlc-skills-audit.md` recording: the four skills were audited for Opus 4.7 behavior on 2026-04-20, the three behavioral deltas checked, and the outcome (which skills were edited, which weren't). This gives future readers a pointer when `/do-plan-critique` or `/do-pr-review` is re-audited for a future Opus version. The file **already exists** with prior audit content from 2026-04-18 (#1042 "Five Blind Spots Closed") — do NOT overwrite or edit the existing body; append only.
-- [ ] No update to `docs/features/README.md` index — this is an addendum to an existing feature doc.
+- [x] **Append** a new dated sub-section (`## Opus 4.7 Audit (2026-04-20)`) to the END of `docs/features/sdlc-skills-audit.md` recording: the four skills were audited for Opus 4.7 behavior on 2026-04-20, the three behavioral deltas checked, and the outcome (which skills were edited, which weren't). This gives future readers a pointer when `/do-plan-critique` or `/do-pr-review` is re-audited for a future Opus version. The file **already exists** with prior audit content from 2026-04-18 (#1042 "Five Blind Spots Closed") — do NOT overwrite or edit the existing body; append only.
+- [x] No update to `docs/features/README.md` index — this is an addendum to an existing feature doc.
 
 <!-- Implementation Note (C5, continued): The Documentation section and Task 9 BOTH say "append to existing file". This is intentional consistency — the file is real, the prior content is real, and the builder must not use a "create if missing" fallback branch. If the builder finds the file missing at build time, they MUST stop and investigate (someone deleted it) before proceeding. -->
 
 
 ### External Documentation Site
-- [ ] N/A — repo does not publish to Sphinx/RTD/MkDocs for this area.
+- [x] N/A — repo does not publish to Sphinx/RTD/MkDocs for this area.
 
 ### Inline Documentation
-- [ ] Not applicable — no code changes. Markdown edits are self-documenting.
+- [x] Not applicable — no code changes. Markdown edits are self-documenting.
 
 ## Success Criteria
 


### PR DESCRIPTION
## Summary

Targeted prompt edits across the four Opus-dispatch SDLC skills to address three documented Opus 4.7 behavioral deltas: conciseness shift, proactive tool-checking, and reduced clarification. Prompt-only edits — no code changes, no output-format changes.

Plan: `docs/plans/opus-skill-prompts-4-7.md`
Issue: Closes #1066

## Changes

- **`.claude/skills/do-plan/SKILL.md`** — Phase 1 Step 1 expanded into a 3-step evidence-gathering checklist (read issue body, read Recon Summary, follow sibling issues). Vague hedge replaced with direct directive. `ToolSearch("select:WebSearch")` line in Phase 0.7 preserved verbatim.
- **`.claude/skills/do-plan-critique/SKILL.md`** — Added canonical sentence above Step 5 instructing synthesis to emit every section header literally and emit empty categories as `## Blockers\n\nNone.` rather than omitting.
- **`.claude/skills/do-pr-review/SKILL.md`** — Step 5 format block promoted from "use this format" to hard "you MUST emit exactly this block, every field present" directive. Explicit empty-section rule added for Blockers / Tech Debt / Nits.
- **`.claude/skills/do-pr-review/sub-skills/code-review.md`** — Format block tightened, Pre-Verdict Checklist now asserts "every row MUST be filled".
- **`.claude/skills/daily-integration-audit/SKILL.md`** — Step 2 Opus subagent brief rewritten into self-contained structured block (FEATURE_TOPIC / SEED_DOC_PATH / VERIFICATION_PASS / OUTPUT_FORMAT / FINAL_LINE).
- **`docs/features/sdlc-skills-audit.md`** — Appended dated "Opus 4.7 Audit (2026-04-20)" subsection recording the three deltas checked, the edits applied, and the explicit out-of-scope decision (no version-pinning to `claude-opus-4-7`).

## Acceptance Criteria (from Issue #1066)

- [x] AC #1: `/do-plan` reviewed — Phase 1 Step 1 expanded; hedges replaced; ToolSearch preserved
- [x] AC #2: `/do-plan-critique` reviewed — canonical empty-header sentence added above Step 5
- [x] AC #3: `/do-pr-review` reviewed — hard "you MUST emit" directive; empty-section rule; code-review.md tightened
- [x] AC #4: `daily-integration-audit` reviewed — subagent brief rewritten to self-contained structured block
- [x] AC #5: Tool-announcement phrasing removed — pre-edit grep found zero instances across the four files; trivially satisfied (documented)
- [x] AC #6: Smoke-test — executed during build (recorded in validator output)

## Field Preservation (Risk 1 mitigation)

**Group A — Pre-existing fields preserved (no decreases):**
- `**File:**`, `**Code:**`, `**Severity:**`, `**Fix:**`, `**Issue:**` — preserved in `do-pr-review/SKILL.md` and `sub-skills/code-review.md`
- `## Verdict`, `READY TO BUILD`, `NEEDS REVISION`, `MAJOR REWORK` — preserved in `do-plan-critique/SKILL.md`
- `SUMMARY: PASS=` footer — preserved in `daily-integration-audit/SKILL.md`
- `SEVERITY:`, `LOCATION:`, `FINDING:`, `SUGGESTION:`, `IMPLEMENTATION NOTE:` — preserved

**Group B — Newly-introduced fields (0 → N expected):**
- `FEATURE_TOPIC:`, `SEED_DOC_PATH:`, `VERIFICATION_PASS:`, `OUTPUT_FORMAT:`, `FINAL_LINE:` — introduced exclusively in `daily-integration-audit/SKILL.md`

## Testing

- [x] Unit tests passing (pytest tests/unit/ -x -q) — validated during build review
- [x] Lint clean (`python -m ruff check .`) — no Python code changed
- [x] Format clean (`python -m ruff format --check .`) — no Python code changed
- [x] Field preservation grep verification — all Group A counts preserved, Group B fields introduced
- [x] `ToolSearch("select:WebSearch")` preserved in `do-plan/SKILL.md` Phase 0.7
- [x] No `claude-opus-4-7` version-pin accidentally added
- [x] `/sdlc` dispatch table unchanged (still uses `opus` alias)

## Documentation

- [x] `docs/features/sdlc-skills-audit.md` — appended "Opus 4.7 Audit (2026-04-20)" subsection (no overwrite of prior 2026-04-18 content from #1042)
- [x] No update to `docs/features/README.md` index (addendum to existing file)

## Definition of Done

- [x] Built: All prompt edits applied per Technical Approach
- [x] Tested: All tests passing, field preservation grep verified
- [x] Reviewed: Review stage completed (no blocking issues)
- [x] Documented: Audit record appended to `sdlc-skills-audit.md`
- [x] Quality: No lint/format regressions (prompt-only edits)

## Out of Scope (per Issue Recon Summary)

- Version-pinning `opus` → `claude-opus-4-7` (explicitly dropped — Anthropic alias routes to current Opus)
- Rewriting any skill wholesale
- Editing critic subagent prompts in `CRITICS.md` (critics run on Sonnet, not Opus)
- Auditing non-Opus-targeting skills (Sonnet behavioral model is different)

## Critique Nits (Informational)

From `/do-plan-critique` on 2026-04-20 (NIT severity, non-blocking):

- **N1** — Test Impact justification for `test_skills_audit.py` describes a nonexistent keyword-grep test. Disposition (UPDATE NOT REQUIRED) is correct; only justification wording is inaccurate. Acknowledged, no follow-up action.
- **N2** — Smoke-test skill choice (`/do-plan-critique`) is self-referential. The current critique invocation serves as smoke test N=0. Future re-audits should refresh the smoke-test count.
- **N3** — Freshness Check baseline pinned to `c5c24ee3`. Plan-to-build window was <24h so re-freshness check not needed; noted for future reference.

Closes #1066