### PR TITLE
hotfix(reflections): unblock event loop in run_log_review (sibling of #1056)

### DIFF
--- a/reflections/auditing.py
+++ b/reflections/auditing.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import subprocess
 import sys
@@ -26,6 +27,47 @@ from pathlib import Path
 from reflections.utils import PROJECT_ROOT, extract_structured_errors, load_local_projects
 
 logger = logging.getLogger("reflections.auditing")
+
+# Hotfix (sibling of PR #1056): bound the bytes read from any single log file so
+# a runaway log (e.g. `logs/worker.log`) cannot stall the reflection scheduler.
+# If a file exceeds _LOG_READ_MAX_BYTES, we tail-read only the last
+# _LOG_READ_TAIL_BYTES. These callables are now plain `def` (dispatched via
+# `run_in_executor`) so even a slow disk read does not freeze the event loop,
+# but the size guard still keeps memory and CPU bounded.
+_LOG_READ_MAX_BYTES = 50 * 1024 * 1024  # 50 MB trip point
+_LOG_READ_TAIL_BYTES = 1 * 1024 * 1024  # Tail-read the last 1 MB
+
+
+def _read_log_text_bounded(log_file: Path) -> str:
+    """Read a log file as text, tail-reading if it exceeds the size cap.
+
+    Returns the decoded text content (errors replaced). Always closes the
+    file. If the file is larger than ``_LOG_READ_MAX_BYTES``, only the last
+    ``_LOG_READ_TAIL_BYTES`` are returned (with a leading truncation marker).
+    """
+    try:
+        size = os.path.getsize(log_file)
+    except OSError:
+        size = 0
+
+    if size > _LOG_READ_MAX_BYTES:
+        # Seek from end to avoid loading a multi-GB file into memory.
+        with open(log_file, "rb") as f:
+            f.seek(-_LOG_READ_TAIL_BYTES, os.SEEK_END)
+            chunk = f.read()
+        text = chunk.decode("utf-8", errors="replace")
+        return f"[... truncated: showing last {_LOG_READ_TAIL_BYTES} bytes of {size} ...]\n{text}"
+
+    with open(log_file, encoding="utf-8", errors="replace") as f:
+        return f.read()
+
+
+def _read_log_tail_lines(log_file: Path, n: int = 1000) -> list[str]:
+    """Return the last ``n`` lines of a log file, honoring the size cap."""
+    text = _read_log_text_bounded(log_file)
+    lines = text.splitlines(keepends=True)
+    return lines[-n:]
+
 
 # PR Review audit helper patterns (from monolith module level)
 _FINDING_SEVERITY_RE = re.compile(r"\*\*Severity:\*\*\s*(blocker|tech_debt|nit)", re.IGNORECASE)
@@ -142,10 +184,19 @@ def _format_audit_issue_body(
     return "\n".join(lines)
 
 
-async def run_log_review() -> dict:
+def run_log_review() -> dict:
     """Review previous day's logs per project.
 
-    Maps to monolith step: step_review_logs
+    Maps to monolith step: step_review_logs.
+
+    Hotfix (sibling of PR #1056): this used to be ``async def`` but did
+    synchronous file I/O (``open(...).read()``) on potentially unbounded
+    log files. That froze the reflection-scheduler event loop for the full
+    duration of the read, killing the worker heartbeat. It is now plain
+    ``def`` so ``ReflectionScheduler`` dispatches it via
+    ``loop.run_in_executor(None, func)``. All reads go through
+    :func:`_read_log_text_bounded` / :func:`_read_log_tail_lines` which
+    tail-read when a file exceeds 50 MB.
     """
     from bridge.utc import utc_now
 
@@ -217,8 +268,7 @@ async def run_log_review() -> dict:
                         msg = error["message"][:200]
                         findings.append(f"  [{error['level']}] {error['timestamp']}: {msg}")
 
-                with open(log_file) as f:
-                    lines = f.readlines()[-1000:]
+                lines = _read_log_tail_lines(log_file, n=1000)
                 warning_count = sum(1 for line in lines if "WARNING" in line)
                 if warning_count > 10:
                     findings.append(
@@ -226,8 +276,7 @@ async def run_log_review() -> dict:
                     )
 
                 # Detect nudge-stomp regression
-                with open(log_file) as f:
-                    log_content = f.read()
+                log_content = _read_log_text_bounded(log_file)
                 stale_index_count = log_content.count("Stale index entry")
                 if stale_index_count > 0:
                     findings.append(
@@ -338,11 +387,17 @@ def run_skills_audit() -> dict:
         return {"status": "error", "findings": [], "summary": f"Skills audit error: {e}"}
 
 
-async def run_hooks_audit() -> dict:
+def run_hooks_audit() -> dict:
     """Audit Claude Code hooks for safety and configuration issues.
 
-    Maps to monolith step: step_hooks_audit
+    Maps to monolith step: step_hooks_audit.
     Checks: hooks.log for recent errors, settings.json hook configuration.
+
+    Hotfix (sibling of PR #1056): converted from ``async def`` to plain
+    ``def`` so the reflection scheduler runs it via ``run_in_executor``
+    instead of inline on the event loop. The body does only sync I/O
+    (``extract_structured_errors``, ``json.loads``, ``Path.read_text``,
+    ``Path.exists``) with no awaits.
     """
     findings: list[str] = []
     error_count = 0
@@ -406,11 +461,16 @@ async def run_hooks_audit() -> dict:
     return {"status": "ok", "findings": findings, "summary": summary}
 
 
-async def run_feature_docs_audit() -> dict:
+def run_feature_docs_audit() -> dict:
     """Audit feature documentation for staleness and accuracy.
 
-    Maps to monolith step: step_feature_docs_audit
+    Maps to monolith step: step_feature_docs_audit.
     Checks: stale references, README index, stub docs, dead code refs.
+
+    Hotfix (sibling of PR #1056): converted from ``async def`` to plain
+    ``def`` so the reflection scheduler runs it via ``run_in_executor``.
+    The body does only sync I/O (``Path.read_text``, ``Path.glob``, regex)
+    with no awaits.
     """
     findings: list[str] = []
     features_dir = PROJECT_ROOT / "docs" / "features"

--- a/reflections/utils.py
+++ b/reflections/utils.py
@@ -227,9 +227,26 @@ def extract_structured_errors(log_file: Path) -> list[dict[str, str]]:
         r"(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})" r".*?(ERROR|CRITICAL)\s*[-:]\s*(.*)"
     )
 
+    # Hotfix (sibling of PR #1056): guard against unbounded log files. If the
+    # file is over 50 MB, seek to the last 1 MB instead of loading the whole
+    # thing into memory just to discard all but the last 1000 lines.
+    max_bytes = 50 * 1024 * 1024
+    tail_bytes = 1 * 1024 * 1024
+
     try:
-        with open(log_file) as f:
-            lines = f.readlines()[-1000:]
+        try:
+            size = os.path.getsize(log_file)
+        except OSError:
+            size = 0
+
+        if size > max_bytes:
+            with open(log_file, "rb") as f:
+                f.seek(-tail_bytes, os.SEEK_END)
+                chunk = f.read()
+            lines = chunk.decode("utf-8", errors="replace").splitlines(keepends=True)[-1000:]
+        else:
+            with open(log_file, encoding="utf-8", errors="replace") as f:
+                lines = f.readlines()[-1000:]
 
         for i, line in enumerate(lines):
             match = log_pattern.search(line)

--- a/tests/unit/test_reflections_package.py
+++ b/tests/unit/test_reflections_package.py
@@ -18,8 +18,18 @@ from unittest.mock import MagicMock, patch
 
 
 def run_async(coro):
-    """Run a coroutine synchronously."""
-    return asyncio.run(coro)
+    """Run a coroutine synchronously.
+
+    If given a non-coroutine value (e.g. a sync function's already-returned
+    dict), return it as-is. This lets tests call reflection callables
+    uniformly whether they are sync or async — the sibling-of-#1056 hotfix
+    converted several callables from ``async def`` to plain ``def`` so they
+    get dispatched via ``run_in_executor`` by the reflection scheduler and
+    no longer block its event loop.
+    """
+    if asyncio.iscoroutine(coro):
+        return asyncio.run(coro)
+    return coro
 
 
 def assert_valid_result(result: dict, expected_status: str = "ok") -> None:
@@ -317,6 +327,56 @@ class TestAuditingCallables:
         with patch("reflections.auditing.PROJECT_ROOT", tmp_path):
             result = run_async(run_feature_docs_audit())
         assert_valid_result(result)
+
+    def test_event_loop_safe_callables_are_sync(self):
+        """Regression canary (sibling of PR #1056).
+
+        These three callables did synchronous file I/O on unbounded log
+        files while being declared ``async def``. That froze the reflection
+        scheduler's event loop. They are now plain ``def`` so
+        ``ReflectionScheduler.execute_function_reflection`` dispatches them
+        via ``loop.run_in_executor(None, func)`` instead of running inline.
+
+        If anyone re-declares these as ``async def`` without also guarding
+        every blocking read with ``asyncio.to_thread`` + ``wait_for``, this
+        canary fails loudly.
+        """
+        import inspect
+
+        from reflections.auditing import (
+            run_feature_docs_audit,
+            run_hooks_audit,
+            run_log_review,
+        )
+
+        for fn in (run_log_review, run_hooks_audit, run_feature_docs_audit):
+            assert not inspect.iscoroutinefunction(fn), (
+                f"{fn.__name__} must stay sync `def` — it does blocking file I/O "
+                "that would freeze the reflection scheduler's event loop if "
+                "declared `async def`. See PR #1056 (memory_extraction) for the "
+                "async-native alternative if a rewrite is ever needed."
+            )
+
+    def test_read_log_text_bounded_tails_large_files(self, tmp_path):
+        """_read_log_text_bounded returns only the tail for files over the size cap."""
+        from reflections import auditing
+
+        log_file = tmp_path / "huge.log"
+        # Build a file larger than the 50 MB trip point cheaply.
+        chunk = b"x" * (1024 * 1024)  # 1 MB of 'x'
+        size_mb = 55
+        with open(log_file, "wb") as f:
+            for _ in range(size_mb):
+                f.write(chunk)
+            # Trailing marker we expect to see after the truncation header.
+            f.write(b"TAIL_MARKER\n")
+
+        text = auditing._read_log_text_bounded(log_file)
+        # Truncation notice is present and we still saw the final marker.
+        assert "truncated: showing last" in text
+        assert "TAIL_MARKER" in text
+        # The returned string is bounded: 1 MB tail + a short header, not 55 MB.
+        assert len(text) < 2 * 1024 * 1024
 
     def test_run_pr_review_audit_no_projects(self):
         """run_pr_review_audit() returns valid dict with no projects."""


### PR DESCRIPTION
## Summary

Same bug family as #1056 (memory_extraction event-loop freeze). Three `async def` reflection callables in `reflections/auditing.py` did synchronous, unbounded file I/O on their event loop, freezing the reflection scheduler and starving the worker heartbeat while a large `logs/worker.log` was read.

- `run_log_review` — did `open(log_file).read()` on `logs/worker.log` with no `await`. Dominant trigger.
- `run_hooks_audit` — entirely sync body (json/Path reads, `extract_structured_errors`).
- `run_feature_docs_audit` — entirely sync body (`Path.read_text`, regex, glob).

## Fix

- Converted all three callables from `async def` to plain `def`. `ReflectionScheduler.execute_function_reflection` already dispatches sync functions via `loop.run_in_executor(None, func)` (see `agent/reflection_scheduler.py` L258-263), so the blocking work now runs in a worker thread rather than on the loop.
- Added `_read_log_text_bounded()` / `_read_log_tail_lines()` helpers in `reflections/auditing.py`: if the file is over 50 MB, seek to the last 1 MB with `os.SEEK_END` instead of reading the whole file. A truncation header is prepended so audits still know the read was clipped.
- Applied the same 50 MB / 1 MB tail-read guard inside `reflections/utils.py::extract_structured_errors`, which had the same latent memory-bomb on multi-GB logs.
- `run_documentation_audit` stays `async def` — it already awaits `asyncio.to_thread(auditor.run)` correctly.

## Noted during diagnosis

`config/reflections.yaml` already has `daily-log-review: enabled: true` on main. The TEMP mitigation described in the hotfix brief was already flipped back by a prior change, so no config edit was needed in this PR.

## Files touched

- `reflections/auditing.py` — sync conversion, size-guarded helpers, updated docstrings.
- `reflections/utils.py` — tail-read guard in `extract_structured_errors`.
- `tests/unit/test_reflections_package.py` — regression canary asserts the three callables stay sync; new test verifies `_read_log_text_bounded` clips a 55 MB file to under 2 MB.

## Verification

```
$ python -m pytest tests/unit/test_reflections_package.py -x -q
30 passed in 0.67s

$ python -m pytest tests/unit/test_reflection_scheduler.py -x -q
47 passed in 1.38s

$ python -m ruff check .
All checks passed!

$ python -m ruff format --check .
608 files already formatted
```

## Test plan

- [x] Reflections package unit tests green (30/30)
- [x] Reflection scheduler unit tests green (47/47) — dispatch path for sync vs async callables
- [x] Regression canary blocks re-introducing `async def` on these three
- [x] Size-guard test confirms 55 MB file returns under 2 MB with trailing marker preserved
- [x] Ruff check + format clean across the repo

Reference: #1056 (same family — `memory_extraction` event-loop freeze).