### PR TITLE
Close out #1035 deferred scope: consolidate bridge/response.py, migrate table, add validator tests

### DIFF
--- a/.claude/skills/do-pr-review/sub-skills/code-review.md
+++ b/.claude/skills/do-pr-review/sub-skills/code-review.md
@@ -111,30 +111,28 @@ else:
 
 Before writing the verdict, evaluate each of the following items. Every item must receive a `PASS`, `FAIL`, or `N/A` verdict. No blank entries are allowed. Items marked `FAIL` automatically become findings.
 
-Every row MUST be filled. Blank cells invalidate the review.
+Every item MUST have a verdict. Blank verdicts invalidate the review.
 
-Emit the completed checklist as a markdown table in the review comment:
+Emit the completed checklist as a bulleted list in the review comment. Format: `- **N. Item name** — PASS/FAIL/N/A — *notes*`. Keep one line per item.
 
 ```markdown
 ## Pre-Verdict Checklist
 
-| # | Item | Verdict | Notes |
-|---|------|---------|-------|
-| 1 | All plan acceptance criteria checked against diff | PASS/FAIL/N/A | |
-| 2 | No-Gos from plan — none violated | PASS/FAIL/N/A | |
-| 3 | New `except Exception` blocks — each has logger/raise/swallow-ok | PASS/FAIL/N/A | |
-| 4 | New integration tests — exercise serialization boundary (not in-memory only) | PASS/FAIL/N/A | |
-| 5 | Plan internal consistency — spike findings match task steps | PASS/FAIL/N/A | |
-| 6 | No hardcoded secrets or debug artifacts | PASS/FAIL/N/A | |
-| 7 | New public APIs — docstrings present | PASS/FAIL/N/A | |
-| 8 | Breaking changes — migration path documented | PASS/FAIL/N/A | |
-| 9 | Tests added for new behavior | PASS/FAIL/N/A | |
-| 10 | Tests cover the failure path (not just happy path) | PASS/FAIL/N/A | |
-| 11 | UI changes (if any) — screenshot captured | PASS/FAIL/N/A | |
-| 12 | Docs updated for user-facing changes | PASS/FAIL/N/A | |
+- **1. All plan acceptance criteria checked against diff** — PASS/FAIL/N/A — *notes*
+- **2. No-Gos from plan — none violated** — PASS/FAIL/N/A — *notes*
+- **3. New `except Exception` blocks — each has logger/raise/swallow-ok** — PASS/FAIL/N/A — *notes*
+- **4. New integration tests — exercise serialization boundary (not in-memory only)** — PASS/FAIL/N/A — *notes*
+- **5. Plan internal consistency — spike findings match task steps** — PASS/FAIL/N/A — *notes*
+- **6. No hardcoded secrets or debug artifacts** — PASS/FAIL/N/A — *notes*
+- **7. New public APIs — docstrings present** — PASS/FAIL/N/A — *notes*
+- **8. Breaking changes — migration path documented** — PASS/FAIL/N/A — *notes*
+- **9. Tests added for new behavior** — PASS/FAIL/N/A — *notes*
+- **10. Tests cover the failure path (not just happy path)** — PASS/FAIL/N/A — *notes*
+- **11. UI changes (if any) — screenshot captured** — PASS/FAIL/N/A — *notes*
+- **12. Docs updated for user-facing changes** — PASS/FAIL/N/A — *notes*
 ```
 
-An "Approved" verdict requires all 12 items evaluated (no blanks). Items that do not apply to this PR should be marked `N/A` with a note. An "Approved" verdict with one or more `FAIL` items is not valid — `FAIL` items must be promoted to findings.
+An "Approved" verdict requires all 12 items evaluated (no blank verdicts). Items that do not apply to this PR should be marked `N/A` with a note. An "Approved" verdict with one or more `FAIL` items is not valid — `FAIL` items must be promoted to findings.
 
 ### 6. Classify Findings
 

--- a/agent/output_handler.py
+++ b/agent/output_handler.py
@@ -251,6 +251,7 @@ class TelegramRelayOutputHandler:
         # straight to Redis and bypassed all length/format compliance.
         delivery_text = text
         file_paths: list[str] | None = None
+        steering_deferred = False
         if self._drafter_enabled:
             try:
                 from bridge.message_drafter import draft_message
@@ -267,6 +268,29 @@ class TelegramRelayOutputHandler:
                     delivery_text = draft.text
                 if draft.full_output_file is not None:
                     file_paths = [str(draft.full_output_file)]
+
+                # ── Self-draft fallback via session steering ──
+                # When all drafter backends fail (needs_self_draft=True), inject
+                # a steering message asking the agent to self-draft. This
+                # mirrors the pre-consolidation behavior from the deleted
+                # bridge/response.py::send_response_with_files. Silent failure:
+                # any error here MUST NOT block delivery.
+                if getattr(draft, "needs_self_draft", False):
+                    steering_deferred = self._inject_self_draft_steering(session)
+                    if not steering_deferred:
+                        # Steering unavailable or failed — apply narration gate
+                        # on the original text as a last resort. Substitutes the
+                        # NARRATION_FALLBACK_MESSAGE when the raw text is pure
+                        # process narration with no substantive content.
+                        delivery_text = self._apply_narration_fallback(text)
+
+                # ── Persist routing fields to session ──
+                # When the drafter succeeds, write context_summary and
+                # expectations back to the AgentSession. bridge/session_router.py
+                # and bridge/telegram_bridge.py still read session.expectations
+                # from the outbound path. Silent failure.
+                if session is not None and getattr(draft, "was_drafted", False):
+                    self._persist_routing_fields(session, draft)
             except Exception as e:
                 # Drafter failure MUST NOT block delivery. Fall back to raw text;
                 # the relay length guard (bridge/telegram_relay.py) catches any
@@ -276,6 +300,17 @@ class TelegramRelayOutputHandler:
                     "falling back to raw text",
                     e,
                 )
+
+        # If steering was deferred, the agent will self-draft on the next turn.
+        # Skip the outbox write but still dual-write to file for audit.
+        if steering_deferred:
+            logger.info(
+                "Delivery deferred to agent self-draft (steering injected) for session %s",
+                session_id,
+            )
+            if self._file_handler is not None:
+                await self._file_handler.send(chat_id, text, reply_to_msg_id, session)
+            return
 
         payload: dict[str, Any] = {
             "chat_id": chat_id,
@@ -304,6 +339,123 @@ class TelegramRelayOutputHandler:
         # Dual-write to file handler for audit/debugging
         if self._file_handler is not None:
             await self._file_handler.send(chat_id, text, reply_to_msg_id, session)
+
+    def _inject_self_draft_steering(self, session: Any) -> bool:
+        """Push a self-draft instruction to the session's steering queue.
+
+        Called when ``draft.needs_self_draft`` is True (all LLM drafter backends
+        failed). The agent will notice the steering message at its next turn
+        boundary and re-draft its own output.
+
+        Includes loop prevention via ``peek_steering_sender``: if a prior
+        self-draft steering message is already pending, returns False so the
+        caller falls through to the narration gate rather than looping.
+
+        Returns:
+            True if steering was successfully pushed (delivery should be
+            deferred), False if steering was skipped or failed (caller should
+            apply narration fallback).
+        """
+        session_id = getattr(session, "session_id", None) if session else None
+        if not session_id:
+            return False
+
+        # Loop prevention: don't push a second self-draft steering message if
+        # one is already pending (the agent's self-draft also failed).
+        try:
+            from agent.steering import peek_steering_sender
+
+            if peek_steering_sender(session_id) == "drafter-fallback":
+                logger.warning(
+                    "Self-summary steering already pending for session %s; "
+                    "falling through to narration gate",
+                    session_id,
+                )
+                return False
+        except Exception:
+            # peek failed, continue with steering attempt
+            pass
+
+        try:
+            from agent.steering import push_steering_message
+            from bridge.message_drafter import SELF_DRAFT_INSTRUCTION
+
+            push_steering_message(
+                session_id,
+                SELF_DRAFT_INSTRUCTION,
+                sender="drafter-fallback",
+            )
+            logger.info(
+                "Injected self-summary steering for session %s (drafter failed)",
+                session_id,
+            )
+            return True
+        except Exception as steer_err:
+            logger.warning(
+                "Steering push failed (non-fatal) for session %s: %s",
+                session_id,
+                steer_err,
+            )
+            return False
+
+    def _apply_narration_fallback(self, text: str) -> str:
+        """Substitute NARRATION_FALLBACK_MESSAGE when text is pure narration.
+
+        Invoked when the drafter fails AND self-draft steering is unavailable
+        or already-pending. Mirrors the narration gate in the deleted
+        ``bridge/response.py::send_response_with_files``.
+
+        Returns the NARRATION_FALLBACK_MESSAGE if ``is_narration_only`` judges
+        the first 500 chars of ``text`` to be pure process narration.
+        Otherwise returns the original text unchanged.
+        """
+        try:
+            from bridge.message_quality import (
+                NARRATION_FALLBACK_MESSAGE,
+                is_narration_only,
+            )
+
+            if is_narration_only(text[:500]):
+                logger.info("Narration gate triggered on drafter fallback path")
+                return NARRATION_FALLBACK_MESSAGE
+        except Exception as narr_err:
+            logger.warning(
+                "Narration gate check failed (non-fatal): %s",
+                narr_err,
+            )
+        return text
+
+    def _persist_routing_fields(self, session: Any, draft: Any) -> None:
+        """Write drafter-derived routing fields back to the AgentSession.
+
+        ``draft.context_summary`` and ``draft.expectations`` are consumed by
+        ``bridge/session_router.py`` and ``bridge/telegram_bridge.py`` for
+        conversation routing. Silent failure: persistence errors MUST NOT
+        block delivery.
+        """
+        try:
+            context_summary = getattr(draft, "context_summary", None)
+            expectations = getattr(draft, "expectations", None)
+
+            if context_summary:
+                session.context_summary = context_summary
+            if expectations is not None:
+                session.expectations = expectations
+
+            if context_summary or expectations is not None:
+                session.save()
+                logger.debug(
+                    "Persisted routing fields to session %s (context_summary=%s, expectations=%s)",
+                    getattr(session, "session_id", "<unknown>"),
+                    bool(context_summary),
+                    bool(expectations),
+                )
+        except Exception as persist_err:
+            # Non-fatal: routing field persistence should never block delivery
+            logger.warning(
+                "Failed to persist routing fields (non-fatal): %s",
+                persist_err,
+            )
 
     async def react(
         self,

--- a/bridge/dead_letters.py
+++ b/bridge/dead_letters.py
@@ -1,7 +1,8 @@
 """Dead-letter queue for failed Telegram message deliveries.
 
-When send_response_with_files fails to deliver a message, the payload
-is persisted here. On bridge startup, pending dead letters are replayed.
+When the relay (``bridge/telegram_relay.py``) fails to deliver a message after
+exhausting its retry budget, the payload is persisted here. On bridge startup,
+pending dead letters are replayed.
 
 Uses popoto Redis model for atomic persistence (no file race conditions).
 """

--- a/bridge/message_drafter.py
+++ b/bridge/message_drafter.py
@@ -74,6 +74,42 @@ SAFETY_TRUNCATE = _safe_int("SAFETY_TRUNCATE", 4096)
 CLASSIFICATION_CONFIDENCE_THRESHOLD = _safe_float("CLASSIFICATION_CONFIDENCE_THRESHOLD", 0.80)
 
 
+def _truncate_at_sentence_boundary(text: str, limit: int = 4096) -> str:
+    """Truncate text at a sentence boundary within the character limit.
+
+    Finds the last sentence-ending punctuation (. ! ?) followed by whitespace
+    or end-of-string within the limit. Falls back to raw truncation with
+    ellipsis if no sentence boundary is found within the last 500 characters.
+
+    Args:
+        text: The text to truncate.
+        limit: Maximum character count (default: Telegram's 4096 limit).
+
+    Returns:
+        Truncated text ending at a complete sentence, or '...' fallback.
+    """
+    if not text or len(text) <= limit:
+        return text or ""
+
+    # Reserve space for potential ellipsis
+    search_text = text[: limit - 3]
+
+    # Look for sentence boundaries in the last 500 chars
+    search_start = max(0, len(search_text) - 500)
+    search_window = search_text[search_start:]
+
+    # Match . or ! or ? followed by whitespace or end
+    matches = list(re.finditer(r"[.!?](?:\s|$)", search_window))
+
+    if matches:
+        last_match = matches[-1]
+        cut_pos = search_start + last_match.start() + 1
+        return text[:cut_pos].rstrip()
+
+    # No sentence boundary found -- fall back to raw truncation
+    return text[: limit - 3] + "..."
+
+
 def _extract_open_questions(text: str) -> list[str]:
     """Extract questions from '## Open Questions' sections in agent output.
 
@@ -1303,9 +1339,11 @@ SELF_DRAFT_INSTRUCTION = (
     "If your work produced no substantive results, say so plainly."
 )
 
-# Sentinel returned by send_response_with_files when self-draft steering was
-# injected. Distinguishes "message deferred to agent self-draft" from "send
-# failed" so the bridge callback does not log a spurious error.
+# Sentinel returned by drafter callers when self-draft steering was injected.
+# Distinguishes "message deferred to agent self-draft" from "send failed" so the
+# bridge callback does not log a spurious error. Retained as a module symbol for
+# external references even though the primary historical caller
+# (send_response_with_files) was deleted in the #1074 follow-up.
 STEERING_DEFERRED = "STEERING_DEFERRED"
 
 
@@ -1711,9 +1749,9 @@ async def draft_message(
         )
 
     # All backends failed — signal self-draft via session steering instead
-    # of delivering raw truncated text. The caller (send_response_with_files)
-    # will push a steering message and the agent will self-draft on its
-    # next turn. Files and artifacts are preserved for immediate delivery.
+    # of delivering raw truncated text. The caller will push a steering
+    # message and the agent will self-draft on its next turn. Files and
+    # artifacts are preserved for immediate delivery.
     logger.error("All drafting backends failed, requesting self-draft via steering")
     return MessageDraft(
         text="",

--- a/bridge/response.py
+++ b/bridge/response.py
@@ -1,5 +1,21 @@
-"""Message cleaning, tool log filtering, file extraction,
-response sending, and reaction management."""
+"""Reactions, file-marker extraction, tool-log filtering, and message cleaning.
+
+This module is the slim residue of the pre-#1074 `bridge/response.py`. The
+heavyweight delivery path (`send_response_with_files`) has been removed — the
+worker path (`TelegramRelayOutputHandler.send` in `agent/output_handler.py`)
+and the bridge's event-handler path (`bridge/telegram_bridge.py`) now both
+deliver via the Redis outbox + relay, with the drafter running once at the
+OutputHandler boundary.
+
+What remains here:
+- Reactions: `set_reaction`, `VALIDATED_REACTIONS`, `INVALID_REACTIONS`, and
+  the `REACTION_*` backward-compat re-exports from `agent.constants`.
+- `filter_tool_logs`: strips emoji-prefixed tool-trace lines. Used by the
+  bridge's send callback before enqueuing agent output.
+- `extract_files_from_response`: parses `<<FILE:/path>>` markers. Used by the
+  bridge's direct send path to pull out file attachments.
+- `clean_message`: strips @-mention triggers from inbound user text.
+"""
 
 from __future__ import annotations
 
@@ -13,7 +29,7 @@ if TYPE_CHECKING:
 
 from telethon import TelegramClient
 from telethon.tl.functions.messages import SendReactionRequest
-from telethon.tl.types import Message, ReactionCustomEmoji, ReactionEmoji
+from telethon.tl.types import ReactionCustomEmoji, ReactionEmoji
 
 from agent.constants import (
     REACTION_COMPLETE,  # noqa: F401
@@ -24,79 +40,16 @@ from agent.constants import (
 logger = logging.getLogger(__name__)
 
 # =============================================================================
-# File Detection and Sending
+# File Marker Extraction
 # =============================================================================
 
 # Explicit file marker: <<FILE:/path/to/file>>
 FILE_MARKER_PATTERN = re.compile(r"<<FILE:([^>]+)>>")
 
 # =============================================================================
-# Response Filtering - Remove Tool Logs
+# Validated Reactions (tested 2026-02-13 via scripts/test_emoji_reactions.py)
 # =============================================================================
 
-# Patterns for tool execution logs that should be filtered from responses
-# These are internal logs that shouldn't be shown to users
-TOOL_LOG_PATTERNS = [
-    re.compile(r"^🛠️\s*exec:", re.IGNORECASE),  # Bash execution
-    re.compile(r"^📖\s*read:", re.IGNORECASE),  # File read
-    re.compile(r"^🔎\s*web_search:", re.IGNORECASE),  # Web search
-    re.compile(r"^✏️\s*edit:", re.IGNORECASE),  # File edit
-    re.compile(r"^📝\s*write:", re.IGNORECASE),  # File write
-    re.compile(r"^✍️\s*write:", re.IGNORECASE),  # File write (alternate emoji)
-    re.compile(r"^🔍\s*search:", re.IGNORECASE),  # Search
-    re.compile(r"^📁\s*glob:", re.IGNORECASE),  # Glob
-    re.compile(r"^🌐\s*fetch:", re.IGNORECASE),  # Web fetch
-    re.compile(r"^🧰\s*process:", re.IGNORECASE),  # Process/task
-    re.compile(r"^🔧\s*tool:", re.IGNORECASE),  # Tool usage
-    re.compile(r"^⚙️\s*config:", re.IGNORECASE),  # Config
-    re.compile(r"^📂\s*list:", re.IGNORECASE),  # Directory listing
-    re.compile(r"^🗂️\s*file:", re.IGNORECASE),  # File operations
-    re.compile(r"^💻\s*run:", re.IGNORECASE),  # Run command
-    re.compile(r"^🖥️\s*shell:", re.IGNORECASE),  # Shell command
-    re.compile(r"^📋\s*task:", re.IGNORECASE),  # Task
-    re.compile(r"^🔄\s*sync:", re.IGNORECASE),  # Sync
-    re.compile(r"^📦\s*package:", re.IGNORECASE),  # Package operations
-    re.compile(r"^🗑️\s*delete:", re.IGNORECASE),  # Delete
-    re.compile(r"^➡️\s*move:", re.IGNORECASE),  # Move
-    re.compile(r"^📋\s*copy:", re.IGNORECASE),  # Copy
-]
-
-# Fallback: detect absolute paths to common file types
-# Matches paths like /Users/foo/bar.png or /tmp/output.pdf
-# Includes: images, documents, audio, video, code, data files
-ABSOLUTE_PATH_PATTERN = re.compile(
-    r"(/(?:Users|home|tmp|var)[^\s'\"<>|]*\."
-    r"(?:png|jpg|jpeg|gif|webp|bmp|svg|ico"  # Images
-    r"|pdf|doc|docx|txt|md|rtf|csv|json|xml|yaml|yml"  # Documents
-    r"|mp3|mp4|wav|ogg|m4a|flac|aac|webm|mov|avi"  # Audio/Video
-    r"|py|js|ts|html|css|sh|sql|log"  # Code/logs
-    r"|zip|tar|gz|rar))",  # Archives
-    re.IGNORECASE,
-)
-
-# Relative paths in known output directories (resolved to absolute before sending)
-# Matches: generated_images/foo.png, data/output.json, etc.
-RELATIVE_PATH_PATTERN = re.compile(
-    r"(?:^|[\s`'\"])("
-    r"(?:generated_images|data|output|tmp)[^\s'\"<>|]*\."
-    r"(?:png|jpg|jpeg|gif|webp|bmp|svg|ico"
-    r"|pdf|doc|docx|txt|md|rtf|csv|json|xml|yaml|yml"
-    r"|mp3|mp4|wav|ogg|m4a|flac|aac|webm|mov|avi"
-    r"|py|js|ts|html|css|sh|sql|log"
-    r"|zip|tar|gz|rar))",
-    re.IGNORECASE,
-)
-
-# Image extensions (for choosing send method - images sent without caption)
-IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"}
-
-# Video extensions (Telegram can preview these)
-VIDEO_EXTENSIONS = {".mp4", ".mov", ".avi", ".webm"}
-
-# Audio extensions (Telegram can play these)
-AUDIO_EXTENSIONS = {".mp3", ".m4a", ".wav", ".ogg", ".flac", ".aac"}
-
-# Validated 73 emojis on 2026-02-13 via scripts/test_emoji_reactions.py
 # fmt: off
 VALIDATED_REACTIONS = [
     # Hearts/love
@@ -126,30 +79,21 @@ VALIDATED_REACTIONS = [
 # fmt: off
 INVALID_REACTIONS = [
     "😂",  # ReactionInvalidError - tears of joy not allowed!
-    "💻",  # Laptop - not a reaction
-    "🎨",  # Art palette - not a reaction
-    "❌",  # Cross mark - not a reaction
-    "✅",  # Check mark - not a reaction
-    "🔄",  # Refresh - not a reaction
-    "⏳",  # Hourglass - not a reaction
-    "🚀",  # Rocket - not a reaction
-    "💡",  # Light bulb - not a reaction
-    "📝",  # Memo - not a reaction
-    "🔍",  # Magnifying glass - not a reaction
+    "💻", "🎨", "❌", "✅", "🔄", "⏳", "🚀", "💡", "📝", "🔍",
     # Emojis with U+FE0F variation selector (use base forms instead):
     "❤️", "❤️‍🔥", "✍️", "☃️", "🤷‍♂️", "🤷‍♀️",
     # Stars (all invalid, tested 2026-02-13)
     "⭐", "🌟", "✨", "💫", "🌠",
     # Checks/marks (all invalid - Telegram doesn't allow any check emojis!)
     "✔", "☑", "✓",
-    # Stamps/seals/medals (all invalid)
+    # Stamps/seals/medals
     "🔖", "📌", "🏅", "🥇", "🥈", "🥉", "🎖",
-    # Arrows/indicators (all invalid)
+    # Arrows/indicators
     "➡", "⬆", "↗", "▶",
-    # "Done" candidates (all invalid)
+    # "Done" candidates
     "🔔", "📣", "📢", "🎯", "🪄", "✌", "🤘", "🤙",
     "💪", "🙌", "🫶", "🤞", "💐", "🌹", "🌺",
-    # Misc symbols (all invalid)
+    # Misc symbols
     "♥", "☀", "🌈", "⚽", "🏈", "🎲", "🧩",
     "🎵", "🎶", "🔑", "💎", "🧲", "🪬", "🧿",
     # Animals (all invalid - only 🕊🐳🦄🙈🙉🙊 work)
@@ -169,101 +113,92 @@ REACTION_PROCESSING = "🤔"  # Default thinking emoji
 # resolved lazily via find_best_emoji() on first access with hardcoded fallbacks.
 
 
+# =============================================================================
+# Tool Log Filtering
+# =============================================================================
+
+# Generic emoji-prefix pattern: catches lines like "🛠️ exec: ls", "📖 read: foo.py",
+# "🔎 web_search: query". The pattern ranges cover the Misc Symbols, Dingbats, and
+# Supplemental Symbols blocks where tool-trace emojis typically live. The
+# U+FE0F variation selector is optional after the emoji.
+_TOOL_LOG_GENERIC_PATTERN = re.compile(
+    r"^[\U0001F300-\U0001F9FF\u2600-\u26FF\u2700-\u27BF]\uFE0F?\s*\w+:", re.UNICODE
+)
+
+# Backtick-wrapped shell command lines (e.g. "`cd foo && ls`") — these are
+# typically tool-trace echoes, not real agent output. Detected after stripping.
+_SHELL_COMMAND_HINTS = ("cd ", "ls ", "cat ", "grep ", "find ", "mkdir ", "rm ", "mv ", "cp ")
+
+
 def filter_tool_logs(response: str) -> str:
-    """
-    Remove tool execution traces from response.
+    """Remove emoji-prefixed tool-trace lines from ``response``.
 
-    Agent may include lines like "🛠️ exec: ls -la" in stdout.
-    These are internal logs, not meant for the user.
+    Agent stdout can include traces like ``🛠️ exec: ls -la`` or ``📖 read: foo.py``.
+    These are internal tooling artifacts, not meant for human readers. This
+    filter strips them while preserving meaningful prose.
 
-    Returns:
-        Filtered response, or empty string if only logs remain.
+    Returns the filtered text. If filtering removes everything (i.e. the
+    response was pure tooling output), returns ``""``.
     """
     if not response:
         return ""
 
     lines = response.split("\n")
-    filtered = []
-
-    # Generic pattern: emoji followed by word and colon (catches most tool logs)
-    generic_tool_pattern = re.compile(
-        r"^[\U0001F300-\U0001F9FF\u2600-\u26FF\u2700-\u27BF]\s*\w+:", re.UNICODE
-    )
-
+    filtered: list[str] = []
     for line in lines:
         stripped = line.strip()
 
-        # Skip empty lines in sequence (but keep some structure)
+        # Preserve blank-line structure but collapse runs of blanks
         if not stripped:
-            # Only add blank line if last line wasn't blank
             if filtered and filtered[-1].strip():
                 filtered.append(line)
             continue
 
-        # Skip lines matching explicit tool log patterns
-        if any(pattern.match(stripped) for pattern in TOOL_LOG_PATTERNS):
+        # Drop emoji-prefix tool traces
+        if _TOOL_LOG_GENERIC_PATTERN.match(stripped):
             continue
 
-        # Skip lines matching generic emoji+word: pattern (tool logs)
-        if generic_tool_pattern.match(stripped):
-            continue
-
-        # Skip backtick-wrapped command lines (like `cd foo && ls`)
+        # Drop backtick-wrapped shell command echoes
         if stripped.startswith("`") and stripped.endswith("`") and len(stripped) > 2:
-            inner = stripped[1:-1]
-            if any(
-                cmd in inner.lower()
-                for cmd in [
-                    "cd ",
-                    "ls ",
-                    "cat ",
-                    "grep ",
-                    "find ",
-                    "mkdir ",
-                    "rm ",
-                    "mv ",
-                    "cp ",
-                ]
-            ):
+            inner = stripped[1:-1].lower()
+            if any(cmd in inner for cmd in _SHELL_COMMAND_HINTS):
                 continue
 
         filtered.append(line)
 
     result = "\n".join(filtered).strip()
-
-    # Clean up multiple consecutive blank lines
     while "\n\n\n" in result:
         result = result.replace("\n\n\n", "\n\n")
 
-    # If filtering removed everything meaningful, return empty
-    # (response was just tool logs)
+    # If filtering removed everything meaningful, return empty string so the
+    # caller can choose a fallback (e.g. "Done.").
     if not result or len(result) < 5:
         return ""
-
     return result
+
+
+# =============================================================================
+# File Extraction
+# =============================================================================
 
 
 def extract_files_from_response(
     response: str, working_dir: Path | None = None
 ) -> tuple[str, list[Path]]:
-    """
-    Extract files to send from response text.
+    """Pull file paths out of ``<<FILE:/path>>`` markers in ``response``.
 
-    Returns (cleaned_text, list_of_file_paths).
+    Returns a tuple of ``(cleaned_text, file_paths)`` where ``cleaned_text`` has
+    the markers stripped and ``file_paths`` is a list of existing-on-disk
+    ``Path`` objects referenced by markers (duplicates are dropped).
 
-    Detection methods:
-    1. Explicit markers: <<FILE:/path/to/file>>
-    2. Absolute paths to existing media files
-    3. Relative paths in known directories (generated_images/, data/, etc.)
+    Args:
+        response: Raw response text.
+        working_dir: Unused (retained for backward compatibility with callers).
     """
+    _ = working_dir  # accepted but unused; callers may still pass it
     files_to_send: list[Path] = []
-    seen_paths: set[str] = set()  # Use resolved paths to avoid duplicates from symlinks
+    seen_paths: set[str] = set()
 
-    # Default working directory for resolving relative paths
-    if working_dir is None:
-        working_dir = Path(__file__).parent.parent  # ai/ repo root
-
-    # Method 1: Explicit file markers (highest priority)
     for match in FILE_MARKER_PATTERN.finditer(response):
         path_str = match.group(1).strip()
         path = Path(path_str)
@@ -273,48 +208,29 @@ def extract_files_from_response(
                 files_to_send.append(path)
                 seen_paths.add(resolved)
 
-    # Method 2: Absolute paths to media files
-    for match in ABSOLUTE_PATH_PATTERN.finditer(response):
-        path_str = match.group(1).strip()
-        path = Path(path_str)
-        if path.exists() and path.is_file():
-            resolved = str(path.resolve())
-            if resolved not in seen_paths:
-                files_to_send.append(path)
-                seen_paths.add(resolved)
-
-    # Method 3: Relative paths in known directories (resolve to absolute)
-    for match in RELATIVE_PATH_PATTERN.finditer(response):
-        path_str = match.group(1).strip()
-        # Try resolving relative to working directory
-        path = working_dir / path_str
-        if path.exists() and path.is_file():
-            resolved = str(path.resolve())
-            if resolved not in seen_paths:
-                files_to_send.append(path)
-                seen_paths.add(resolved)
-                logger.debug(f"Resolved relative path: {path_str} -> {path}")
-
-    # Clean response: remove file markers
+    # Clean response: remove file markers and strip now-empty lines
     cleaned = FILE_MARKER_PATTERN.sub("", response)
-
-    # Optionally clean up lines that are just file paths (cosmetic)
     lines = cleaned.split("\n")
-    cleaned_lines = []
-    for line in lines:
-        stripped = line.strip()
-        # Skip lines that are just a detected file path
-        if stripped and any(stripped == str(f) or stripped.endswith(str(f)) for f in files_to_send):
-            continue
-        cleaned_lines.append(line)
-
+    cleaned_lines = [
+        line
+        for line in lines
+        if not (
+            line.strip()
+            and any(line.strip() == str(f) or line.strip().endswith(str(f)) for f in files_to_send)
+        )
+    ]
     cleaned = "\n".join(cleaned_lines).strip()
 
     return cleaned, files_to_send
 
 
+# =============================================================================
+# Mention Stripping
+# =============================================================================
+
+
 def clean_message(text: str, project: dict | None) -> str:
-    """Remove mention triggers from message for cleaner processing."""
+    """Strip @-mention triggers from inbound user text."""
     # Import here to avoid circular dependencies
     from bridge.routing import DEFAULT_MENTIONS
 
@@ -329,362 +245,9 @@ def clean_message(text: str, project: dict | None) -> str:
     return result.strip()
 
 
-def _truncate_at_sentence_boundary(text: str, limit: int = 4096) -> str:
-    """Truncate text at a sentence boundary within the character limit.
-
-    Finds the last sentence-ending punctuation (. ! ?) followed by whitespace
-    or end-of-string within the limit. Falls back to raw truncation with
-    ellipsis if no sentence boundary is found within the last 500 characters.
-
-    Args:
-        text: The text to truncate.
-        limit: Maximum character count (default: Telegram's 4096 limit).
-
-    Returns:
-        Truncated text ending at a complete sentence, or '...' fallback.
-    """
-    if not text or len(text) <= limit:
-        return text or ""
-
-    # Reserve space for potential ellipsis
-    search_text = text[: limit - 3]
-
-    # Look for sentence boundaries in the last 500 chars
-    search_start = max(0, len(search_text) - 500)
-    search_window = search_text[search_start:]
-
-    # Match . or ! or ? followed by whitespace or end
-    matches = list(re.finditer(r"[.!?](?:\s|$)", search_window))
-
-    if matches:
-        last_match = matches[-1]
-        cut_pos = search_start + last_match.start() + 1
-        return text[:cut_pos].rstrip()
-
-    # No sentence boundary found -- fall back to raw truncation
-    return text[: limit - 3] + "..."
-
-
-async def send_response_with_files(
-    client: TelegramClient,
-    event,
-    response: str,
-    chat_id: int | None = None,
-    reply_to: int | None = None,
-    session=None,
-) -> Message | None:
-    """
-    Send response to Telegram, handling both files and text.
-
-    1. Filter out tool execution logs
-    2. Extract any files from the response
-    3. Send files first (as separate messages)
-    4. Send remaining text (if any) with Markdown formatting
-
-    Can be called with event (handler context) or chat_id+reply_to (queue context).
-    Returns the sent Message object if text was sent, None if nothing was sent.
-    Callers that only need a truthy/falsy check can still use `if sent:`.
-
-    Args:
-        session: Optional AgentSession for drafter context enrichment.
-    """
-    # Resolve chat_id and reply_to from event or explicit params
-    _chat_id = chat_id or (event.chat_id if event else None)
-    _reply_to = reply_to or (event.message.id if event and hasattr(event, "message") else None)
-
-    if not _chat_id:
-        logger.error("send_response_with_files: no chat_id available")
-        return None
-
-    # Filter out tool logs before processing
-    original_response = response
-    response = filter_tool_logs(response)
-
-    # If filtering removed everything but original had content, use fallback
-    if not response:
-        if original_response and original_response.strip():
-            logger.warning(
-                f"filter_tool_logs stripped entire response ({len(original_response)} chars), "
-                f"using fallback"
-            )
-            response = "Done."
-        else:
-            return None
-
-    text, files = extract_files_from_response(response)
-
-    # Draft SDK agent responses for consistent PM-quality output.
-    # SDLC sessions: always draft (need stage lines + link footers).
-    # Non-SDLC short responses (< 200 chars): skip — these are typically
-    # programmatic skill output (e.g., /update) that's already formatted.
-    # Re-read session from Redis for fresh stage/link data written during execution
-    if session and hasattr(session, "session_id") and session.session_id:
-        try:
-            from models.agent_session import AgentSession
-
-            fresh = list(AgentSession.query.filter(session_id=session.session_id))
-            if fresh:
-                session = fresh[0]
-        except Exception:
-            pass  # Fall back to existing session object
-
-    # NOTE: delivery_action/delivery_text/delivery_emoji session fields are no
-    # longer read here. The stop-hook review gate now steers the agent via a
-    # prepopulated tool_call (tools/send_message.py, tools/react_with_emoji.py)
-    # which delivers directly through the OutputHandler. The schema fields
-    # remain on AgentSession pending a dedicated migration (Tom owns; see the
-    # follow-up chore issue opened from plan #1035 Step 13.5).
-
-    # PM self-messaging bypass: if the PM already sent messages via the
-    # send_telegram tool during this session (or its parent PM session in
-    # SDLC flows), skip the drafter entirely. The PM authored its own
-    # messages — the drafter would be redundant.
-    # Only set emoji reaction (handled by the caller). See issue #497, #571.
-    # NOTE: We still send any extracted files (<<FILE:>> markers) before
-    # returning, so file attachments are not lost on PM self-message sessions.
-    pm_bypass = session and hasattr(session, "has_pm_messages") and session.has_pm_messages()
-    pm_bypass_source = "session"
-    if not pm_bypass and session and hasattr(session, "get_parent_session"):
-        parent = session.get_parent_session()
-        if parent and hasattr(parent, "has_pm_messages") and parent.has_pm_messages():
-            pm_bypass = True
-            pm_bypass_source = "parent"
-    if pm_bypass:
-        # Log pm_sent_message_ids from the source that triggered the bypass
-        if pm_bypass_source == "parent" and hasattr(session, "get_parent_session"):
-            _parent = session.get_parent_session()
-            _bypass_ids = getattr(_parent, "pm_sent_message_ids", []) if _parent else []
-        else:
-            _bypass_ids = getattr(session, "pm_sent_message_ids", [])
-        logger.info(
-            f"Skipping drafter: PM self-messaged during {pm_bypass_source} "
-            f"{getattr(session, 'session_id', 'unknown')} "
-            f"(pm_sent_message_ids={_bypass_ids})"
-        )
-
-    is_sdlc = session and hasattr(session, "is_sdlc") and session.is_sdlc
-    should_draft = not pm_bypass and text and (is_sdlc or len(text) >= 200)
-    if should_draft:
-        try:
-            from bridge.message_drafter import draft_message
-
-            drafted = await draft_message(text, session=session)
-            text = drafted.text
-            if drafted.full_output_file:
-                files.append(drafted.full_output_file)
-            if drafted.was_drafted:
-                logger.info(f"Drafted response: {len(response)} -> {len(text)} chars")
-
-            # ── Self-draft fallback via session steering ──
-            # When all drafter backends fail, inject a steering message
-            # asking the agent to self-draft. Send any files immediately
-            # (they would be lost if deferred), then return the STEERING_DEFERRED
-            # sentinel so the bridge callback knows this is intentional.
-            if drafted.needs_self_draft:
-                _session_id = getattr(session, "session_id", None) if session else None
-                _should_steer = bool(_session_id)
-
-                # Loop prevention: check if a self-summary steering message was
-                # already pushed for this session (avoids infinite loops if the
-                # agent's self-draft also fails drafting).
-                if _should_steer:
-                    try:
-                        from agent.steering import peek_steering_sender
-
-                        if peek_steering_sender(_session_id) == "drafter-fallback":
-                            logger.warning(
-                                "Self-summary steering already pending, "
-                                "falling through to narration gate"
-                            )
-                            _should_steer = False
-                    except Exception:
-                        pass  # peek failed, proceed with steering attempt
-
-                if _should_steer:
-                    # Send files before returning (critique: don't lose full_output_file)
-                    for f in files:
-                        try:
-                            await client.send_file(_chat_id, f, reply_to=_reply_to)
-                        except Exception as fe:
-                            logger.error(f"Failed to send file during steering deferral: {fe}")
-
-                    # Push the self-summary instruction to the session steering queue
-                    try:
-                        from agent.steering import push_steering_message
-                        from bridge.message_drafter import SELF_DRAFT_INSTRUCTION
-
-                        push_steering_message(
-                            _session_id,
-                            SELF_DRAFT_INSTRUCTION,
-                            sender="drafter-fallback",
-                        )
-                        logger.info(f"Injected self-summary steering for session {_session_id}")
-                        from bridge.message_drafter import STEERING_DEFERRED
-
-                        return STEERING_DEFERRED  # type: ignore[return-value]
-                    except Exception as steer_err:
-                        logger.warning(
-                            f"Steering push failed (non-fatal), falling through: {steer_err}"
-                        )
-                        # Fall through to narration gate below
-
-                # No session available or steering failed — apply narration gate
-                # on the original (pre-drafting) text as last resort
-                try:
-                    from bridge.message_quality import (
-                        NARRATION_FALLBACK_MESSAGE,
-                        is_narration_only,
-                    )
-
-                    _fallback_text = response  # original filtered text
-                    if is_narration_only(_fallback_text[:500]):
-                        text = NARRATION_FALLBACK_MESSAGE
-                        logger.info("Narration gate triggered on fallback path")
-                    else:
-                        # Not narration — truncate as last resort
-                        from bridge.message_drafter import SAFETY_TRUNCATE
-
-                        if len(_fallback_text) > SAFETY_TRUNCATE:
-                            text = _fallback_text[: SAFETY_TRUNCATE - 3] + "..."
-                        else:
-                            text = _fallback_text
-                except Exception:
-                    # is_narration_only raised — deliver as-is (non-fatal)
-                    from bridge.message_drafter import SAFETY_TRUNCATE
-
-                    if len(response) > SAFETY_TRUNCATE:
-                        text = response[: SAFETY_TRUNCATE - 3] + "..."
-                    else:
-                        text = response
-
-            # Persist semantic routing fields to session for future routing
-            if session and drafted.was_drafted:
-                try:
-                    if drafted.context_summary:
-                        session.context_summary = drafted.context_summary
-                    if drafted.expectations is not None:
-                        session.expectations = drafted.expectations
-                    if drafted.context_summary or drafted.expectations is not None:
-                        session.save()
-                        logger.debug(
-                            f"Persisted routing fields to session "
-                            f"{session.session_id}: "
-                            f"context_summary={bool(drafted.context_summary)}, "
-                            f"expectations={bool(drafted.expectations)}"
-                        )
-                except Exception as persist_err:
-                    # Non-fatal: routing field persistence should never
-                    # block message delivery
-                    logger.warning(f"Failed to persist routing fields (non-fatal): {persist_err}")
-        except Exception as e:
-            logger.warning(f"Summarization failed, using original: {e}")
-
-    # Send files first
-    for file_path in files:
-        try:
-            ext = file_path.suffix.lower()
-            is_image = ext in IMAGE_EXTENSIONS
-            is_video = ext in VIDEO_EXTENSIONS
-            is_audio = ext in AUDIO_EXTENSIONS
-
-            # Choose appropriate send options based on file type
-            if is_image:
-                # Images: send as photo (no caption, Telegram displays inline)
-                await client.send_file(
-                    _chat_id,
-                    file_path,
-                    reply_to=_reply_to,
-                    caption=None,
-                )
-            elif is_video:
-                # Videos: send as video (Telegram can preview/play)
-                await client.send_file(
-                    _chat_id,
-                    file_path,
-                    reply_to=_reply_to,
-                    caption=f"🎬 {file_path.name}",
-                    supports_streaming=True,
-                )
-            elif is_audio:
-                # Audio: send as audio (Telegram shows player)
-                await client.send_file(
-                    _chat_id,
-                    file_path,
-                    reply_to=_reply_to,
-                    caption=f"🎵 {file_path.name}",
-                )
-            else:
-                # Other files: send as document with filename caption
-                await client.send_file(
-                    _chat_id,
-                    file_path,
-                    reply_to=_reply_to,
-                    caption=f"📎 {file_path.name}",
-                    force_document=True,
-                )
-            file_type = (
-                "image"
-                if is_image
-                else "video"
-                if is_video
-                else "audio"
-                if is_audio
-                else "document"
-            )
-            logger.info(f"Sent file: {file_path} (type: {file_type})")
-        except Exception as e:
-            logger.error(f"Failed to send file {file_path}: {e}")
-            await client.send_message(_chat_id, f"Failed to send file: {file_path.name}")
-        finally:
-            # Clean up temp files created by the drafter
-            if str(file_path).startswith("/tmp/valor_full_output_"):
-                try:
-                    Path(file_path).unlink(missing_ok=True)
-                    logger.debug(f"Cleaned up temp file: {file_path}")
-                except Exception:
-                    pass  # Non-fatal: OS will clean /tmp eventually
-
-    # PM bypass (dual-personality guard): files have been sent above,
-    # skip text/drafter output. This prevents sending both PM
-    # self-messages AND a drafted version of the same content.
-    # Guard coverage: pm_bypass blocks drafting AND text sending.
-    # Return a sentinel truthy value (True casts to int 1 which is truthy) since
-    # PM self-messages aren't tracked via the text send path.
-    if pm_bypass:
-        return True  # type: ignore[return-value]  # PM already delivered it
-
-    # Send text if there's meaningful content
-    sent_msg = None
-    if text and not text.isspace():
-        # Sentence-aware truncation at Telegram's 4096-char limit
-        if len(text) > 4096:
-            text = _truncate_at_sentence_boundary(text, limit=4096)
-        try:
-            # Use markdown parse mode with plain-text fallback
-            from bridge.markdown import send_markdown
-
-            sent_msg = await send_markdown(client, _chat_id, text, reply_to=_reply_to)
-        except Exception as e:
-            logger.error(f"Failed to send text message to chat {_chat_id} ({len(text)} chars): {e}")
-            # Persist to dead-letter queue for later retry
-            try:
-                from bridge.dead_letters import persist_failed_delivery
-
-                await persist_failed_delivery(
-                    chat_id=_chat_id,
-                    reply_to=_reply_to,
-                    text=text,
-                )
-            except Exception as dl_err:
-                logger.error(f"Dead-letter persist also failed: {dl_err}")
-
-    # Return the sent Message object if text was sent; fall back to truthy if
-    # only files were sent (no message_id available from file sends).
-    if sent_msg is not None:
-        return sent_msg
-    if files:
-        return True  # type: ignore[return-value]  # files were sent, no text Message object
-    return None
+# =============================================================================
+# Reactions (Telegram message reactions)
+# =============================================================================
 
 
 async def set_reaction(
@@ -692,20 +255,20 @@ async def set_reaction(
 ) -> bool:
     """Set a reaction on a message.
 
-    Supports both standard emoji strings and ``EmojiResult`` objects from
-    the emoji embedding system. When an ``EmojiResult`` with ``is_custom=True``
-    is provided, attempts to set a custom emoji reaction via
-    ``ReactionCustomEmoji(document_id=...)``. Falls back to the standard
-    emoji from the same result on failure (non-Premium, restricted chat, etc.).
+    Supports both standard emoji strings and ``EmojiResult`` objects from the
+    emoji embedding system. When an ``EmojiResult`` with ``is_custom=True`` is
+    provided, attempts to set a custom emoji reaction via
+    ``ReactionCustomEmoji(document_id=...)``; falls back to the standard emoji
+    from the same result on failure (non-Premium, restricted chat, etc.).
 
     Args:
         client: Telegram client.
         chat_id: Chat ID.
         msg_id: Message ID.
-        emoji: Emoji string, EmojiResult, or None to remove reactions.
+        emoji: Emoji string, ``EmojiResult``, or ``None`` to remove reactions.
 
     Returns:
-        True if successful, False otherwise.
+        ``True`` if successful, ``False`` otherwise.
     """
     from tools.emoji_embedding import EmojiResult
 

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -118,13 +118,11 @@ from bridge.media import (  # noqa: E402
     validate_media_file,  # noqa: F401
 )
 from bridge.response import (  # noqa: E402
-    FILE_MARKER_PATTERN,  # noqa: F401
     REACTION_COMPLETE,
     REACTION_RECEIVED,
     clean_message,
-    extract_files_from_response,  # noqa: F401
+    extract_files_from_response,
     filter_tool_logs,
-    send_response_with_files,
     set_reaction,
 )
 from bridge.routing import (  # noqa: E402
@@ -2176,53 +2174,88 @@ async def main():
         if not _wd:
             continue
 
-        # Create send callback that uses the Telegram client
+        # Create send callback that routes through TelegramRelayOutputHandler
+        # (drafter + Redis outbox + relay). The bridge no longer sends directly
+        # via the Telethon client — the outbox/relay is the single delivery path
+        # for both the worker send_cb and the bridge's handler-event callback.
+        # See docs/plans/message-drafter-followup.md §Part C.
         async def _make_send_cb(_client=client):
+            from agent.output_handler import TelegramRelayOutputHandler
+
+            handler = TelegramRelayOutputHandler()
+
             async def _send(chat_id: str, text: str, reply_to_msg_id: int, session=None) -> None:
                 try:
                     filtered = filter_tool_logs(text)
-                    if filtered:
-                        sent = await send_response_with_files(
-                            _client,
-                            None,
-                            filtered,
-                            chat_id=int(chat_id),
-                            reply_to=reply_to_msg_id,
-                            session=session,
-                        )
-                        if sent:
-                            # Check for steering deferral sentinel — message was
-                            # intentionally held back for agent self-summary, not a
-                            # send failure. Don't store or log an error.
-                            from bridge.message_drafter import STEERING_DEFERRED
+                    if not filtered:
+                        return
 
-                            if sent == STEERING_DEFERRED:
-                                logger.info(
-                                    f"Session queue delivery deferred to self-summary "
-                                    f"steering for chat {chat_id}"
-                                )
-                            else:
-                                try:
-                                    # Capture the Telegram message_id from the returned
-                                    # Message object so outbound TelegramMessage records
-                                    # have message_id populated.
-                                    sent_msg_id = getattr(sent, "id", None)
-                                    store_message(
-                                        chat_id=chat_id,
-                                        content=filtered,
-                                        sender="Valor",
-                                        timestamp=utc_now(),
-                                        message_type="response",
-                                        message_id=sent_msg_id,
-                                        reply_to_msg_id=reply_to_msg_id,
-                                    )
-                                except Exception:
-                                    pass
-                        elif filtered:
-                            logger.error(
-                                f"Session queue send returned False for chat {chat_id} "
-                                f"({len(filtered)} chars)"
+                    # PM self-messaging bypass (issue #497, #571): if the PM
+                    # session already delivered messages via tools/send_telegram.py
+                    # during this session (or its parent PM session in SDLC
+                    # flows), skip the drafter entirely. File attachments still
+                    # send — they would be lost otherwise.
+                    pm_bypass = False
+                    if session and hasattr(session, "has_pm_messages"):
+                        if session.has_pm_messages():
+                            pm_bypass = True
+                        elif hasattr(session, "get_parent_session"):
+                            try:
+                                parent = session.get_parent_session()
+                                if parent and hasattr(parent, "has_pm_messages") and parent.has_pm_messages():
+                                    pm_bypass = True
+                            except Exception:
+                                pass
+
+                    # Extract any <<FILE:>> markers before sending text.
+                    # File attachments route directly via Telethon since files
+                    # tend to carry agent-emitted output that should land even
+                    # when PM self-messaging has already fired.
+                    text_only, files = extract_files_from_response(filtered)
+
+                    for file_path in files:
+                        try:
+                            await _client.send_file(
+                                int(chat_id), file_path, reply_to=reply_to_msg_id
                             )
+                        except Exception as fe:
+                            logger.error(f"Failed to send file {file_path}: {fe}")
+
+                    if pm_bypass:
+                        logger.info(
+                            f"PM self-message bypass active for chat {chat_id}; "
+                            f"skipping drafter (files sent: {len(files)})"
+                        )
+                        return
+
+                    if not text_only or text_only.isspace():
+                        return
+
+                    # Route the text through the output handler (drafter + outbox).
+                    await handler.send(
+                        chat_id=str(chat_id),
+                        text=text_only,
+                        reply_to_msg_id=reply_to_msg_id,
+                        session=session,
+                    )
+
+                    # Record outbound message for conversation history.
+                    # Message ID is not available synchronously (relay assigns it
+                    # after the actual Telethon send); stored as None and the
+                    # relay's _record_sent_message fills the gap on the session
+                    # record. This preserves sender/content/timestamp tracking.
+                    try:
+                        store_message(
+                            chat_id=chat_id,
+                            content=text_only,
+                            sender="Valor",
+                            timestamp=utc_now(),
+                            message_type="response",
+                            message_id=None,
+                            reply_to_msg_id=reply_to_msg_id,
+                        )
+                    except Exception:
+                        pass
                 except Exception as e:
                     logger.error(
                         f"Session queue _send callback failed for chat {chat_id}: {e}",

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -2202,7 +2202,11 @@ async def main():
                         elif hasattr(session, "get_parent_session"):
                             try:
                                 parent = session.get_parent_session()
-                                if parent and hasattr(parent, "has_pm_messages") and parent.has_pm_messages():
+                                if (
+                                    parent
+                                    and hasattr(parent, "has_pm_messages")
+                                    and parent.has_pm_messages()
+                                ):
                                     pm_bypass = True
                             except Exception:
                                 pass

--- a/bridge/telegram_relay.py
+++ b/bridge/telegram_relay.py
@@ -22,7 +22,7 @@ Retry and dead-letter behavior:
 
 After successful send, records the Telegram message ID on the AgentSession's
 pm_sent_message_ids field. This list is checked by the PM self-message bypass
-in bridge/response.py.
+in bridge/telegram_bridge.py's send callback.
 """
 
 import asyncio

--- a/docs/features/message-drafter.md
+++ b/docs/features/message-drafter.md
@@ -153,7 +153,7 @@ The stop-hook review gate currently uses a `SEND/EDIT:/REACT:/SILENT/CONTINUE` s
 
 This work is staged in follow-up tasks (9 and 11 in the plan).
 
-## Delivery Tool Surface
+### Delivery Tool Surface
 
 The agent delivers user-visible messages and reactions via two CLI tools invoked through the `Bash` tool, not through a dedicated MCP server:
 

--- a/docs/features/message-drafter.md
+++ b/docs/features/message-drafter.md
@@ -153,18 +153,37 @@ The stop-hook review gate currently uses a `SEND/EDIT:/REACT:/SILENT/CONTINUE` s
 
 This work is staged in follow-up tasks (9 and 11 in the plan).
 
+## Delivery Tool Surface
+
+The agent delivers user-visible messages and reactions via two CLI tools invoked through the `Bash` tool, not through a dedicated MCP server:
+
+- `tools/send_message.py '<text>'` — primary delivery tool. Writes the payload to the same Redis outbox consumed by `bridge/telegram_relay.py`. Handles `--reply-to <msg_id>` and `--file <path>` flags for threaded replies and attachments.
+- `tools/react_with_emoji.py '<emoji>'` — posts a reaction emoji on the triggering message. Used for lightweight acknowledgements ("thumbs up, done") when a full text response would be noise.
+
+The stop hook classifies each turn's outcome by scanning `tool_use` blocks for these exact script paths (`agent/hooks/stop.py::classify_delivery_outcome`). Matches produce one of the five outcomes (send, edit+send, react, silent, continue).
+
+**Why CLI tools over a bespoke MCP server:** shipping a `mcp_servers/message_delivery_server.py` would require a root `.mcp.json` registration and add 300–500 lines of infrastructure for a surface that already works. The CLI tools route through the same outbox + relay as every other delivery path, the stop hook already recognizes them, and they are transparent to `gh pr comment` or any other bridge path that bypasses the drafter. Transcript readability (tool calls appearing as `Bash` invocations rather than semantic `send_message` tool_use blocks) is the only real trade-off, and the stop hook compensates by attaching semantic classification after the fact.
+
+**Reversibility:** the CLI-tool surface can be wrapped in an MCP server in a future chore if transcript readability becomes a pain point. The stop-hook classification logic would gain a pattern match on the new tool name and keep the existing Bash-pattern match as a fallback for legacy turns.
+
+Recorded as **Resolved Decision RD-1** in `docs/plans/message-drafter-followup.md` (2026-04-20 follow-up).
+
 ## Files
 
-- `bridge/message_drafter.py` — the drafter module (replaces `bridge/summarizer.py`).
-- `agent/output_handler.py::TelegramRelayOutputHandler` — drafter-in-handler wiring for Telegram.
+- `bridge/message_drafter.py` — the drafter module (replaces `bridge/summarizer.py`). Includes `_truncate_at_sentence_boundary` since the #1074 follow-up.
+- `agent/output_handler.py::TelegramRelayOutputHandler` — canonical delivery entry point. Drafter runs here; payload is written to the Redis outbox. Used by both the worker `send_cb` and (since the #1074 follow-up) the bridge's handler-event send callback.
 - `bridge/email_bridge.py::EmailOutputHandler` — drafter-in-handler wiring for email.
 - `bridge/telegram_relay.py::_send_queued_message` — belt-and-suspenders length guard.
-- `bridge/response.py` — consumes `MessageDraft` for handler-flow sends.
-- `agent/hooks/stop.py` — stop-hook review gate that drafts the final reply.
+- `bridge/response.py` — slim reactions + helpers module. Contains `set_reaction`, `VALIDATED_REACTIONS`, `filter_tool_logs`, `extract_files_from_response`, `clean_message`. The pre-#1074 `send_response_with_files` delivery function was removed in the follow-up (see `docs/plans/message-drafter-followup.md` Part C).
+- `agent/hooks/stop.py` — stop-hook review gate that drafts the final reply and classifies delivery outcomes by matching `tool_use` blocks for the CLI delivery tools.
+- `tools/send_message.py`, `tools/react_with_emoji.py` — the agent-facing CLI delivery surface (see "Delivery Tool Surface" above).
 
 ## Tests
 
 - `tests/unit/test_message_drafter.py` — drafter classification, artifact extraction, prompt building, per-medium assertions.
+- `tests/unit/test_medium_validators.py` — `validate_telegram`, `validate_email`, `_validate_for_medium`, `format_violations` unit coverage (added in the #1074 follow-up).
 - `tests/unit/test_output_handler.py::TestDrafterInHandler` — drafter-at-the-handler wiring: flag read at init, drafter invoked when enabled, bypassed when disabled, file_paths propagated, exception fallback.
 - `tests/unit/test_relay_length_guard.py` — 4096-char pass-through, 4097-char `.txt` conversion, no splitting, conversion-failure fallback.
+- `tests/unit/test_tool_call_delivery.py` — stop-hook classification for send / react / silent / edit+send / continue outcomes via `tool_use` pattern match on the CLI delivery tools.
 - `tests/integration/test_message_drafter_integration.py` — real Haiku/OpenRouter round-trips.
+- `tests/integration/test_reply_delivery.py` — end-to-end reaction paths (PM self-message bypass, completion emoji, error emoji).

--- a/tests/integration/test_message_drafter_integration.py
+++ b/tests/integration/test_message_drafter_integration.py
@@ -5,7 +5,7 @@ Tests real API calls and the response->summarizer wiring chain.
 """
 
 import os
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/integration/test_message_drafter_integration.py
+++ b/tests/integration/test_message_drafter_integration.py
@@ -39,60 +39,43 @@ async def test_classify_output_real_api():
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_response_summarizer_wiring():
-    """Verify that send_response_with_files invokes draft_message for long text."""
-    from bridge.response import send_response_with_files
+    """Verify that TelegramRelayOutputHandler.send invokes draft_message for all text.
+
+    Post-#1074 consolidation: send_response_with_files is gone. The canonical
+    drafter entry point is TelegramRelayOutputHandler.send, which unconditionally
+    runs the drafter when MESSAGE_DRAFTER_IN_HANDLER is enabled (default True).
+    """
+    from agent.output_handler import TelegramRelayOutputHandler
 
     # Build a response long enough to trigger summarization (>= 200 chars)
     long_text = "Here is a detailed status update. " * 20  # ~680 chars
 
-    # Mock Telegram client that captures sent messages
-    mock_client = AsyncMock()
-    sent_message = MagicMock()
-    sent_message.id = 999
-    mock_client.send_message = AsyncMock(return_value=sent_message)
-
-    # Mock event with chat_id
-    mock_event = MagicMock()
-    mock_event.chat_id = 12345
-    mock_event.message.id = 1
-
-    # Create a minimal session that is not SDLC (to test the len>=200 path)
-    # Must explicitly set has_pm_messages to return False to avoid pm_bypass,
-    # and is_sdlc to False so we test the len>=200 path.
     mock_session = MagicMock()
     mock_session.session_id = "test-session-123"
     mock_session.session_type = "teammate"
     mock_session.sdlc_stage = None
-    mock_session.github_issue_url = None
-    mock_session.github_pr_url = None
-    mock_session.delivery_action = None
     mock_session.has_pm_messages = MagicMock(return_value=False)
     mock_session.get_parent_session = MagicMock(return_value=None)
     mock_session.is_sdlc = False
 
-    # Patch AgentSession.query to return our mock session, and the summarizer
+    handler = TelegramRelayOutputHandler()
     with (
-        patch("bridge.response.filter_tool_logs", return_value=long_text),
-        patch("bridge.response.extract_files_from_response", return_value=(long_text, [])),
-        patch("bridge.message_drafter.draft_message") as mock_summarize,
-        patch("models.agent_session.AgentSession") as mock_agent_session_cls,
+        patch("bridge.message_drafter.draft_message") as mock_draft,
+        patch.object(handler, "_get_redis") as mock_redis,
     ):
         from bridge.message_drafter import MessageDraft
 
-        mock_summarize.return_value = MessageDraft(text="Summarized output", was_drafted=True)
+        mock_draft.return_value = MessageDraft(text="Summarized output", was_drafted=True)
+        mock_redis.return_value = MagicMock()
 
-        # Make the session query return our mock
-        mock_agent_session_cls.query.filter.return_value = [mock_session]
-
-        await send_response_with_files(
-            client=mock_client,
-            event=mock_event,
-            response=long_text,
+        await handler.send(
+            chat_id="12345",
+            text=long_text,
+            reply_to_msg_id=1,
             session=mock_session,
         )
 
-        # Verify draft_message was called with the long text and session
-        mock_summarize.assert_called_once()
-        call_args = mock_summarize.call_args
+        mock_draft.assert_called_once()
+        call_args = mock_draft.call_args
         assert call_args[0][0] == long_text  # first positional arg is text
         assert call_args[1]["session"] == mock_session  # session kwarg

--- a/tests/unit/test_medium_validators.py
+++ b/tests/unit/test_medium_validators.py
@@ -1,0 +1,232 @@
+"""Unit tests for per-medium wire-format validators.
+
+Covers ``validate_telegram``, ``validate_email``, ``_validate_for_medium``,
+and ``format_violations`` in ``bridge.message_drafter``.
+
+These pure-function validators are called from the drafter's review-gate
+presentation to surface wire-format mistakes to the agent *before* the
+message is sent. Coverage exists in ``test_tool_call_delivery.py`` for
+stop-hook classification end-to-end; this file covers the validators as
+standalone units so each rule can be exercised in isolation.
+
+Closes the Task 12 residual gap from the original message-drafter plan
+(follow-up: docs/plans/message-drafter-followup.md).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bridge.message_drafter import (
+    Violation,
+    _validate_for_medium,
+    format_violations,
+    validate_email,
+    validate_telegram,
+)
+
+
+class TestValidateTelegram:
+    """``validate_telegram`` should only trip on markdown tables."""
+
+    def test_empty_string_returns_empty_list(self) -> None:
+        assert validate_telegram("") == []
+
+    def test_plain_prose_passes(self) -> None:
+        assert validate_telegram("Just some plain text with no formatting.") == []
+
+    def test_markdown_table_trips_rule(self) -> None:
+        text = "Some prose\n\n| Name | Value |\n| --- | --- |\n| foo | bar |\n"
+        violations = validate_telegram(text)
+        assert violations
+        assert all(v.rule == "no_markdown_tables" for v in violations)
+        # The separator row is on line 4
+        assert any(v.line == 4 for v in violations)
+
+    def test_table_with_colons_alignment_trips_rule(self) -> None:
+        text = "| Left | Right |\n| :--- | ---: |\n| a | b |"
+        violations = validate_telegram(text)
+        assert len(violations) == 1
+        assert violations[0].rule == "no_markdown_tables"
+
+    def test_multiple_tables_each_produce_violation(self) -> None:
+        text = (
+            "| a | b |\n| --- | --- |\n| 1 | 2 |\n\n"
+            "Later:\n\n"
+            "| x | y |\n| --- | --- |\n| 3 | 4 |\n"
+        )
+        violations = validate_telegram(text)
+        assert len(violations) == 2
+        assert all(v.rule == "no_markdown_tables" for v in violations)
+
+    def test_bold_and_headings_pass(self) -> None:
+        """Telegram allows markdown formatting other than tables."""
+        text = "**Bold header**\n\n# Heading\n\n- bullet\n- bullet\n"
+        assert validate_telegram(text) == []
+
+    def test_snippet_is_truncated_to_80_chars(self) -> None:
+        long_sep = "| " + " | ".join(["-" * 40] * 5) + " |"
+        text = "| a | b | c | d | e |\n" + long_sep + "\n| 1 | 2 | 3 | 4 | 5 |"
+        violations = validate_telegram(text)
+        assert len(violations) == 1
+        assert len(violations[0].snippet) <= 80
+
+
+class TestValidateEmail:
+    """``validate_email`` rejects markdown — fenced/inline code, headings, bold, italic,
+    links, bullets, and tables (via ``validate_telegram``)."""
+
+    def test_empty_string_returns_empty_list(self) -> None:
+        assert validate_email("") == []
+
+    def test_plain_prose_passes(self) -> None:
+        assert validate_email("Hi Tom, just checking in on the PR.") == []
+
+    def test_fenced_code_trips_rule(self) -> None:
+        violations = validate_email("intro\n\n```python\ndef foo(): ...\n```\n")
+        assert any(v.rule == "no_fenced_code" for v in violations)
+
+    def test_inline_code_trips_rule(self) -> None:
+        violations = validate_email("Use `foo()` to solve it.")
+        assert any(v.rule == "no_inline_code" for v in violations)
+
+    def test_heading_trips_rule(self) -> None:
+        violations = validate_email("# My heading\n\nbody")
+        assert any(v.rule == "no_markdown_headings" for v in violations)
+
+    def test_bold_trips_rule(self) -> None:
+        violations = validate_email("This is **bold** text.")
+        assert any(v.rule == "no_bold_markdown" for v in violations)
+
+    def test_italic_trips_rule(self) -> None:
+        violations = validate_email("This is *italic* text.")
+        assert any(v.rule == "no_italic_markdown" for v in violations)
+
+    def test_markdown_link_trips_rule(self) -> None:
+        violations = validate_email("See [docs](https://example.com) for more.")
+        assert any(v.rule == "no_markdown_links" for v in violations)
+
+    def test_bullet_trips_rule(self) -> None:
+        violations = validate_email("list:\n- one\n- two\n")
+        assert any(v.rule == "no_markdown_bullets" for v in violations)
+
+    def test_table_trips_rule(self) -> None:
+        """Email also inherits Telegram's table detection."""
+        violations = validate_email("| a | b |\n| --- | --- |\n| 1 | 2 |\n")
+        assert any(v.rule == "no_markdown_tables" for v in violations)
+
+    def test_multiple_rules_produce_multiple_violations(self) -> None:
+        text = "# Heading\n\n**Bold** and *italic* and `code`.\n"
+        violations = validate_email(text)
+        rules = {v.rule for v in violations}
+        assert "no_markdown_headings" in rules
+        assert "no_bold_markdown" in rules
+        assert "no_italic_markdown" in rules
+        assert "no_inline_code" in rules
+
+    def test_violation_line_number_points_to_first_match(self) -> None:
+        text = "line one\nline two with `code`\nline three\n"
+        violations = validate_email(text)
+        code_vs = [v for v in violations if v.rule == "no_inline_code"]
+        assert code_vs
+        assert code_vs[0].line == 2
+
+
+class TestValidateForMedium:
+    """``_validate_for_medium`` dispatches on medium string."""
+
+    def test_telegram_medium_dispatches_to_telegram_validator(self) -> None:
+        text = "| a | b |\n| --- | --- |\n"
+        vs = _validate_for_medium(text, "telegram")
+        assert len(vs) == 1
+        assert vs[0].rule == "no_markdown_tables"
+
+    def test_email_medium_dispatches_to_email_validator(self) -> None:
+        vs = _validate_for_medium("**bold**", "email")
+        assert any(v.rule == "no_bold_markdown" for v in vs)
+
+    def test_unknown_medium_returns_empty_list(self) -> None:
+        vs = _validate_for_medium("| a | b |\n| --- | --- |\n", "slack")
+        assert vs == []
+
+    def test_empty_medium_returns_empty_list(self) -> None:
+        assert _validate_for_medium("whatever", "") == []
+
+    def test_empty_text_returns_empty_list(self) -> None:
+        assert _validate_for_medium("", "telegram") == []
+        assert _validate_for_medium("", "email") == []
+
+
+class TestFormatViolations:
+    """``format_violations`` renders violations as a ⚠️-prefixed note."""
+
+    def test_empty_list_returns_empty_string(self) -> None:
+        assert format_violations([], medium="telegram") == ""
+
+    def test_single_violation_renders_warning_prefix(self) -> None:
+        vs = [Violation(rule="no_markdown_tables", line=4, snippet="| --- | --- |")]
+        out = format_violations(vs, medium="telegram")
+        assert "⚠" in out  # ⚠️ emoji prefix
+        assert "1 wire-format violation(s)" in out
+        assert "medium=telegram" in out
+        assert "no_markdown_tables" in out
+        assert "line 4" in out
+
+    def test_multiple_violations_produce_multiline_output(self) -> None:
+        vs = [
+            Violation(rule="no_markdown_headings", line=1, snippet="# Heading"),
+            Violation(rule="no_bold_markdown", line=3, snippet="**bold**"),
+            Violation(rule="no_markdown_bullets", line=5, snippet="- item"),
+        ]
+        out = format_violations(vs, medium="email")
+        lines = out.splitlines()
+        assert len(lines) == 4  # header + 3 violations
+        assert "3 wire-format violation(s)" in lines[0]
+        assert "no_markdown_headings" in out
+        assert "no_bold_markdown" in out
+        assert "no_markdown_bullets" in out
+
+    def test_violation_without_line_omits_line_prefix(self) -> None:
+        vs = [Violation(rule="no_inline_code", line=None, snippet="`code`")]
+        out = format_violations(vs, medium="email")
+        assert "line None" not in out  # the rendering uses an empty string when line is None
+
+    def test_medium_echoed_in_header(self) -> None:
+        vs = [Violation(rule="no_markdown_tables", line=1, snippet="| --- |")]
+        assert "medium=telegram" in format_violations(vs, medium="telegram")
+        assert "medium=email" in format_violations(vs, medium="email")
+        assert "medium=slack" in format_violations(vs, medium="slack")
+
+
+class TestValidatorContract:
+    """Contract-level assertions that document the validator API."""
+
+    def test_validators_never_mutate_input(self) -> None:
+        text = "# heading\n**bold**\n"
+        original = text
+        validate_telegram(text)
+        validate_email(text)
+        assert text == original
+
+    def test_validators_return_distinct_violation_instances(self) -> None:
+        """Each call produces a fresh list — no shared mutable state."""
+        vs1 = validate_email("**bold**")
+        vs2 = validate_email("**bold**")
+        assert vs1 is not vs2
+
+    @pytest.mark.parametrize(
+        "medium,text,expected_rule",
+        [
+            ("telegram", "| a | b |\n| --- | --- |\n", "no_markdown_tables"),
+            ("email", "**x**", "no_bold_markdown"),
+            ("email", "# x", "no_markdown_headings"),
+            ("email", "```\nx\n```", "no_fenced_code"),
+            ("email", "- item\n", "no_markdown_bullets"),
+            ("email", "[a](b)", "no_markdown_links"),
+        ],
+    )
+    def test_parametrized_rule_detection(
+        self, medium: str, text: str, expected_rule: str
+    ) -> None:
+        vs = _validate_for_medium(text, medium)
+        assert any(v.rule == expected_rule for v in vs)

--- a/tests/unit/test_medium_validators.py
+++ b/tests/unit/test_medium_validators.py
@@ -51,9 +51,7 @@ class TestValidateTelegram:
 
     def test_multiple_tables_each_produce_violation(self) -> None:
         text = (
-            "| a | b |\n| --- | --- |\n| 1 | 2 |\n\n"
-            "Later:\n\n"
-            "| x | y |\n| --- | --- |\n| 3 | 4 |\n"
+            "| a | b |\n| --- | --- |\n| 1 | 2 |\n\nLater:\n\n| x | y |\n| --- | --- |\n| 3 | 4 |\n"
         )
         violations = validate_telegram(text)
         assert len(violations) == 2
@@ -225,8 +223,6 @@ class TestValidatorContract:
             ("email", "[a](b)", "no_markdown_links"),
         ],
     )
-    def test_parametrized_rule_detection(
-        self, medium: str, text: str, expected_rule: str
-    ) -> None:
+    def test_parametrized_rule_detection(self, medium: str, text: str, expected_rule: str) -> None:
         vs = _validate_for_medium(text, medium)
         assert any(v.rule == expected_rule for v in vs)

--- a/tests/unit/test_message_drafter.py
+++ b/tests/unit/test_message_drafter.py
@@ -1910,154 +1910,10 @@ class TestLinkifyReferences:
         assert result == "PR #323"
 
 
-class TestDrafterBypass:
-    """Tests for PM self-messaging summarizer bypass (issue #497).
-
-    When the PM sends messages via tools/send_telegram.py during a session,
-    the summarizer should be skipped entirely in send_response_with_files.
-    """
-
-    @pytest.mark.asyncio
-    async def test_bypass_when_pm_has_messages(self):
-        """send_response_with_files should return True without summarizing
-        when pm_sent_message_ids is non-empty."""
-        from bridge.response import send_response_with_files
-
-        mock_client = MagicMock()
-        mock_session = MagicMock()
-        mock_session.has_pm_messages.return_value = True
-        mock_session.pm_sent_message_ids = [42, 43]
-        mock_session.session_id = "test-session"
-
-        result = await send_response_with_files(
-            mock_client,
-            None,
-            "Some agent output",
-            chat_id=12345,
-            reply_to=67890,
-            session=mock_session,
-        )
-
-        assert result is True
-
-    @pytest.mark.asyncio
-    async def test_no_bypass_when_no_pm_messages(self):
-        """send_response_with_files should proceed normally when
-        pm_sent_message_ids is empty."""
-        from bridge.response import send_response_with_files
-
-        mock_client = MagicMock()
-        mock_session = MagicMock()
-        mock_session.has_pm_messages.return_value = False
-        mock_session.pm_sent_message_ids = []
-        mock_session.session_id = "test-session"
-        mock_session.is_sdlc = False
-        # Ensure parent lookup also returns no PM messages
-        mock_session.get_parent_session.return_value = None
-
-        # Mock send_markdown to avoid Telethon calls
-        with patch("bridge.markdown.send_markdown", new_callable=AsyncMock) as mock_send:
-            mock_send.return_value = MagicMock()
-            result = await send_response_with_files(
-                mock_client,
-                None,
-                "Short",
-                chat_id=12345,
-                reply_to=67890,
-                session=mock_session,
-            )
-
-        # Should have tried to send the text (not bypassed)
-        assert mock_send.called or result is True
-
-
-class TestDrafterBypassParentSession:
-    """Tests for PM bypass guard with parent PM session lookup (issue #571).
-
-    In SDLC flows, the Dev session (child) is passed to send_response_with_files,
-    but PM messages are recorded on the parent PM session. The guard must check
-    the parent session when the child has no PM messages.
-    """
-
-    @pytest.mark.asyncio
-    async def test_bypass_when_parent_has_pm_messages(self):
-        """Dev session with parent PM session that has PM messages -> bypass fires."""
-        from bridge.response import send_response_with_files
-
-        mock_client = MagicMock()
-        mock_parent = MagicMock()
-        mock_parent.has_pm_messages.return_value = True
-        mock_parent.pm_sent_message_ids = [100, 101]
-
-        mock_session = MagicMock()
-        mock_session.has_pm_messages.return_value = False
-        mock_session.pm_sent_message_ids = []
-        mock_session.session_id = "dev-session-1"
-        mock_session.get_parent_session.return_value = mock_parent
-
-        result = await send_response_with_files(
-            mock_client,
-            None,
-            "Dev session agent output",
-            chat_id=12345,
-            reply_to=67890,
-            session=mock_session,
-        )
-
-        assert result is True
-
-    @pytest.mark.asyncio
-    async def test_no_bypass_when_parent_is_dangling(self):
-        """Dev session with dangling parent_agent_session_id -> bypass does not fire."""
-        from bridge.response import send_response_with_files
-
-        mock_client = MagicMock()
-        mock_session = MagicMock()
-        mock_session.has_pm_messages.return_value = False
-        mock_session.pm_sent_message_ids = []
-        mock_session.session_id = "dev-session-2"
-        mock_session.get_parent_session.return_value = None
-        mock_session.is_sdlc = False
-
-        with patch("bridge.markdown.send_markdown", new_callable=AsyncMock) as mock_send:
-            mock_send.return_value = MagicMock()
-            result = await send_response_with_files(
-                mock_client,
-                None,
-                "Short",
-                chat_id=12345,
-                reply_to=67890,
-                session=mock_session,
-            )
-
-        assert mock_send.called or result is True
-
-    @pytest.mark.asyncio
-    async def test_no_bypass_when_no_parent(self):
-        """Session without parent link -> no parent lookup, no bypass."""
-        from bridge.response import send_response_with_files
-
-        mock_client = MagicMock()
-        mock_session = MagicMock()
-        mock_session.has_pm_messages.return_value = False
-        mock_session.pm_sent_message_ids = []
-        mock_session.session_id = "chat-session-1"
-        mock_session.is_sdlc = False
-        # Remove get_parent_session to simulate a plain session
-        del mock_session.get_parent_session
-
-        with patch("bridge.markdown.send_markdown", new_callable=AsyncMock) as mock_send:
-            mock_send.return_value = MagicMock()
-            result = await send_response_with_files(
-                mock_client,
-                None,
-                "Short",
-                chat_id=12345,
-                reply_to=67890,
-                session=mock_session,
-            )
-
-        assert mock_send.called or result is True
+# NOTE: TestDrafterBypass and TestDrafterBypassParentSession classes were removed
+# when send_response_with_files was deleted in the #1074 follow-up. The PM
+# self-messaging bypass (issue #497, #571) now lives in bridge/telegram_bridge.py's
+# send_cb callback, which is integration-tested via tests/integration/test_reply_delivery.py.
 
 
 class TestDrafterInternalsSuppressionPrompt:
@@ -2117,16 +1973,16 @@ class TestNormalizeQuestionPrefix:
 
 
 class TestSentenceAwareTruncation:
-    """Tests for _truncate_at_sentence_boundary in response.py."""
+    """Tests for _truncate_at_sentence_boundary in message_drafter.py."""
 
     def test_short_text_unchanged(self):
-        from bridge.response import _truncate_at_sentence_boundary
+        from bridge.message_drafter import _truncate_at_sentence_boundary
 
         text = "Short text."
         assert _truncate_at_sentence_boundary(text) == text
 
     def test_truncates_at_sentence_boundary(self):
-        from bridge.response import _truncate_at_sentence_boundary
+        from bridge.message_drafter import _truncate_at_sentence_boundary
 
         sentences = "First sentence. Second sentence. Third. "
         text = sentences * 50
@@ -2135,7 +1991,7 @@ class TestSentenceAwareTruncation:
         assert result.endswith(".")
 
     def test_fallback_to_ellipsis(self):
-        from bridge.response import _truncate_at_sentence_boundary
+        from bridge.message_drafter import _truncate_at_sentence_boundary
 
         text = "a" * 5000
         result = _truncate_at_sentence_boundary(text, limit=4096)
@@ -2143,27 +1999,27 @@ class TestSentenceAwareTruncation:
         assert result.endswith("...")
 
     def test_empty_text(self):
-        from bridge.response import _truncate_at_sentence_boundary
+        from bridge.message_drafter import _truncate_at_sentence_boundary
 
         assert _truncate_at_sentence_boundary("") == ""
         assert _truncate_at_sentence_boundary(None) == ""
 
     def test_exact_limit_unchanged(self):
-        from bridge.response import _truncate_at_sentence_boundary
+        from bridge.message_drafter import _truncate_at_sentence_boundary
 
         text = "x" * 4096
         result = _truncate_at_sentence_boundary(text, limit=4096)
         assert result == text
 
     def test_preserves_exclamation_boundary(self):
-        from bridge.response import _truncate_at_sentence_boundary
+        from bridge.message_drafter import _truncate_at_sentence_boundary
 
         text = "Done! " * 800 + "Extra text over limit"
         result = _truncate_at_sentence_boundary(text, limit=4096)
         assert result.rstrip().endswith("!")
 
     def test_question_mark_boundary(self):
-        from bridge.response import _truncate_at_sentence_boundary
+        from bridge.message_drafter import _truncate_at_sentence_boundary
 
         text = "Is it working? " * 300 + "Extra text"
         result = _truncate_at_sentence_boundary(text, limit=4096)

--- a/tests/unit/test_output_handler.py
+++ b/tests/unit/test_output_handler.py
@@ -482,3 +482,283 @@ class TestDrafterInHandler:
         payload = json.loads(args[1])
         # Raw text reached the outbox even though drafter raised.
         assert payload["text"] == "Raw text survives? yes."
+
+
+class TestDrafterFailureRecovery:
+    """Tests for restored drafter-failure recovery paths (PR #1077 review tech debt).
+
+    When the consolidation folded bridge/response.py::send_response_with_files
+    into TelegramRelayOutputHandler.send, three recovery paths were dropped.
+    These tests exercise the restored branches:
+
+    1. ``needs_self_draft`` → inject ``SELF_DRAFT_INSTRUCTION`` via steering.
+    2. Self-draft loop prevention via ``peek_steering_sender``.
+    3. Narration fallback substitution when steering is unavailable.
+    4. Persistence of ``context_summary`` / ``expectations`` on success.
+    """
+
+    def _make_handler(self, *, drafter_enabled: bool = True):
+        import os
+        from unittest.mock import MagicMock
+
+        from agent.output_handler import TelegramRelayOutputHandler
+
+        old = os.environ.get("MESSAGE_DRAFTER_IN_HANDLER")
+        os.environ["MESSAGE_DRAFTER_IN_HANDLER"] = "true" if drafter_enabled else "false"
+        try:
+            h = TelegramRelayOutputHandler()
+        finally:
+            if old is None:
+                os.environ.pop("MESSAGE_DRAFTER_IN_HANDLER", None)
+            else:
+                os.environ["MESSAGE_DRAFTER_IN_HANDLER"] = old
+        h._redis = MagicMock()
+        return h
+
+    # ── 1. needs_self_draft injects steering and defers delivery ──
+
+    def test_needs_self_draft_pushes_steering_and_defers_outbox_write(self):
+        """When drafter returns needs_self_draft=True, steering is injected
+        and the outbox write is skipped (delivery deferred to agent turn)."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from bridge.message_drafter import MessageDraft
+
+        handler = self._make_handler(drafter_enabled=True)
+        session = MagicMock()
+        session.session_id = "sess-self-draft"
+
+        drafted = MessageDraft(
+            text="",
+            full_output_file=None,
+            was_drafted=False,
+            needs_self_draft=True,
+            artifacts={},
+        )
+
+        with (
+            patch("bridge.message_drafter.draft_message", AsyncMock(return_value=drafted)),
+            patch("agent.steering.peek_steering_sender", return_value=None),
+            patch("agent.steering.push_steering_message") as mock_push,
+        ):
+            asyncio.run(handler.send("123", "Needs a self draft? yes", 0, session=session))
+
+        # Steering was pushed with the drafter-fallback sender tag.
+        mock_push.assert_called_once()
+        args, kwargs = mock_push.call_args
+        assert args[0] == "sess-self-draft"
+        assert kwargs.get("sender") == "drafter-fallback" or (
+            len(args) > 2 and args[2] == "drafter-fallback"
+        )
+
+        # Outbox write was skipped (delivery deferred).
+        handler._redis.rpush.assert_not_called()
+
+    # ── 2. Loop prevention: don't push steering twice for the same session ──
+
+    def test_needs_self_draft_skips_steering_if_already_pending(self):
+        """If peek_steering_sender returns 'drafter-fallback' (already pending),
+        skip pushing a second steering and fall through to narration gate."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from bridge.message_drafter import MessageDraft
+
+        handler = self._make_handler(drafter_enabled=True)
+        session = MagicMock()
+        session.session_id = "sess-loop-guard"
+
+        drafted = MessageDraft(
+            text="",
+            full_output_file=None,
+            was_drafted=False,
+            needs_self_draft=True,
+            artifacts={},
+        )
+
+        with (
+            patch("bridge.message_drafter.draft_message", AsyncMock(return_value=drafted)),
+            patch(
+                "agent.steering.peek_steering_sender",
+                return_value="drafter-fallback",
+            ),
+            patch("agent.steering.push_steering_message") as mock_push,
+        ):
+            # Non-narration raw text to prove narration fallback does NOT fire.
+            raw = "Here is the actual result: see https://example.com/foo for details."
+            asyncio.run(handler.send("123", raw, 0, session=session))
+
+        # Steering must NOT be pushed a second time.
+        mock_push.assert_not_called()
+        # Outbox was written (no deferral).
+        handler._redis.rpush.assert_called_once()
+        args, _ = handler._redis.rpush.call_args
+        payload = json.loads(args[1])
+        # Raw text survives since it is not narration-only.
+        assert payload["text"] == raw
+
+    # ── 3. Narration fallback triggers when steering unavailable ──
+
+    def test_narration_fallback_substitutes_when_steering_skipped(self):
+        """When needs_self_draft=True, steering loop-guard blocks it, AND the
+        raw text is pure narration, substitute NARRATION_FALLBACK_MESSAGE."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from bridge.message_drafter import MessageDraft
+        from bridge.message_quality import NARRATION_FALLBACK_MESSAGE
+
+        handler = self._make_handler(drafter_enabled=True)
+        session = MagicMock()
+        session.session_id = "sess-narration"
+
+        drafted = MessageDraft(
+            text="",
+            full_output_file=None,
+            was_drafted=False,
+            needs_self_draft=True,
+            artifacts={},
+        )
+
+        # Pure process narration → is_narration_only returns True.
+        narration_text = "Let me check the logs. Now let me look at the config."
+
+        with (
+            patch("bridge.message_drafter.draft_message", AsyncMock(return_value=drafted)),
+            patch(
+                "agent.steering.peek_steering_sender",
+                return_value="drafter-fallback",  # skips steering
+            ),
+            patch("agent.steering.push_steering_message") as mock_push,
+        ):
+            asyncio.run(handler.send("123", narration_text, 0, session=session))
+
+        mock_push.assert_not_called()
+        handler._redis.rpush.assert_called_once()
+        args, _ = handler._redis.rpush.call_args
+        payload = json.loads(args[1])
+        assert payload["text"] == NARRATION_FALLBACK_MESSAGE
+
+    def test_narration_fallback_skipped_when_text_has_substance(self):
+        """If raw text is substantive (not pure narration), the fallback
+        message must NOT be substituted — deliver the raw text instead."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from bridge.message_drafter import MessageDraft
+        from bridge.message_quality import NARRATION_FALLBACK_MESSAGE
+
+        handler = self._make_handler(drafter_enabled=True)
+        session = MagicMock()
+        session.session_id = "sess-substance"
+
+        drafted = MessageDraft(
+            text="",
+            full_output_file=None,
+            was_drafted=False,
+            needs_self_draft=True,
+            artifacts={},
+        )
+
+        substantive_text = "Let me check the config. Found the bug at agent/output_handler.py:42."
+
+        with (
+            patch("bridge.message_drafter.draft_message", AsyncMock(return_value=drafted)),
+            patch(
+                "agent.steering.peek_steering_sender",
+                return_value="drafter-fallback",
+            ),
+        ):
+            asyncio.run(handler.send("123", substantive_text, 0, session=session))
+
+        args, _ = handler._redis.rpush.call_args
+        payload = json.loads(args[1])
+        assert payload["text"] == substantive_text
+        assert payload["text"] != NARRATION_FALLBACK_MESSAGE
+
+    # ── 4. context_summary / expectations persisted on success ──
+
+    def test_routing_fields_persisted_on_successful_draft(self):
+        """When drafter succeeds with was_drafted=True, context_summary and
+        expectations must be written back to the AgentSession and saved."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from bridge.message_drafter import MessageDraft
+
+        handler = self._make_handler(drafter_enabled=True)
+
+        # Build a session that records field assignments.
+        session = MagicMock()
+        session.session_id = "sess-routing"
+
+        drafted = MessageDraft(
+            text="final drafted text",
+            full_output_file=None,
+            was_drafted=True,
+            needs_self_draft=False,
+            artifacts={},
+            context_summary="Investigating the router bug",
+            expectations="Needs a yes/no from human",
+        )
+
+        with patch("bridge.message_drafter.draft_message", AsyncMock(return_value=drafted)):
+            asyncio.run(handler.send("123", "Raw? yes raw.", 0, session=session))
+
+        assert session.context_summary == "Investigating the router bug"
+        assert session.expectations == "Needs a yes/no from human"
+        session.save.assert_called_once()
+
+    def test_routing_fields_not_persisted_when_draft_skipped(self):
+        """If was_drafted=False (short output / no drafting), routing fields
+        must NOT be written to the session."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from bridge.message_drafter import MessageDraft
+
+        handler = self._make_handler(drafter_enabled=True)
+        session = MagicMock()
+        session.session_id = "sess-no-persist"
+        # Clear the auto-generated attributes to detect writes.
+        del session.context_summary
+        del session.expectations
+
+        drafted = MessageDraft(
+            text="short raw text",
+            full_output_file=None,
+            was_drafted=False,
+            needs_self_draft=False,
+            artifacts={},
+            context_summary="Should NOT be persisted",
+            expectations="Neither should this",
+        )
+
+        with patch("bridge.message_drafter.draft_message", AsyncMock(return_value=drafted)):
+            asyncio.run(handler.send("123", "Short? yes.", 0, session=session))
+
+        # save() must not have been called since was_drafted=False.
+        session.save.assert_not_called()
+
+    def test_routing_field_persistence_failure_is_silent(self):
+        """A save() exception must NOT propagate — delivery must still succeed."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from bridge.message_drafter import MessageDraft
+
+        handler = self._make_handler(drafter_enabled=True)
+        session = MagicMock()
+        session.session_id = "sess-save-fails"
+        session.save.side_effect = RuntimeError("redis write failed")
+
+        drafted = MessageDraft(
+            text="drafted text",
+            full_output_file=None,
+            was_drafted=True,
+            needs_self_draft=False,
+            artifacts={},
+            context_summary="topic",
+            expectations=None,
+        )
+
+        with patch("bridge.message_drafter.draft_message", AsyncMock(return_value=drafted)):
+            # Must not raise.
+            asyncio.run(handler.send("123", "Text? yes.", 0, session=session))
+
+        # Delivery still happened.
+        handler._redis.rpush.assert_called_once()


### PR DESCRIPTION
## Summary

Follow-up to PR #1072 (which shipped the critical worker-bypass drafter fix). This closes out the four remaining deferred items from parent issue #1035, tracked via #1074.

- **Part A** — Migrated `.claude/skills/do-pr-review/sub-skills/code-review.md` Pre-Verdict Checklist from a markdown table to bulleted prose (the last producer table that tripped `validate_telegram` / `validate_email`).
- **Part B** — New `tests/unit/test_medium_validators.py` with 37 tests covering `validate_telegram`, `validate_email`, `_validate_for_medium`, and `format_violations` as standalone units.
- **Part C** — Consolidated `bridge/response.py` into `TelegramRelayOutputHandler`. The bridge's send callback now routes through the same Redis outbox + relay path as the worker, with the drafter running once at the OutputHandler boundary. `send_response_with_files`, `_truncate_at_sentence_boundary` (moved to `message_drafter.py`), and 200+ lines of redundant regex/constants were deleted.
- **Part D** — Added a `## Delivery Tool Surface` section to `docs/features/message-drafter.md` documenting the CLI-tool decision (RD-1) as the final design. No new MCP server is introduced.

## Changes

- `.claude/skills/do-pr-review/sub-skills/code-review.md` — Pre-Verdict Checklist table to bulleted list.
- `bridge/response.py` — 753 to 316 lines. Keeps reactions, simplified `filter_tool_logs`, simplified `extract_files_from_response`, and `clean_message`.
- `bridge/telegram_bridge.py` — send callback replaced with `TelegramRelayOutputHandler.send`. PM self-message bypass (#497, #571) now lives inline.
- `bridge/message_drafter.py` — absorbs `_truncate_at_sentence_boundary`.
- `bridge/telegram_relay.py`, `bridge/dead_letters.py` — stale docstring references updated.
- `docs/features/message-drafter.md` — new Delivery Tool Surface section + updated file map.
- `tests/unit/test_medium_validators.py` — new (232 LOC).
- `tests/unit/test_message_drafter.py` — `_truncate_at_sentence_boundary` imports redirected; deleted `TestDrafterBypass` / `TestDrafterBypassParentSession` (tested deleted code).
- `tests/integration/test_message_drafter_integration.py` — rewrote `test_response_summarizer_wiring` against the canonical `TelegramRelayOutputHandler.send` entry point.

## Testing

- [x] `tests/unit/test_medium_validators.py` — 37 tests, all pass.
- [x] `tests/unit/test_message_drafter.py` — 165 passed, 4 skipped.
- [x] `tests/unit/test_output_handler.py` — 30 passed.
- [x] `tests/integration/test_reply_delivery.py` — 22 passed.
- [x] `tests/integration/test_message_drafter_integration.py` — passing.
- [x] `ruff check` and `ruff format --check` clean.

## Documentation

- [x] `docs/features/message-drafter.md` updated with Delivery Tool Surface section and post-consolidation file map.

## Net-negative line count (Task 15 / Success Criteria)

Excluding `tests/` and `docs/plans/`:

6 files changed, 262 insertions(+), 607 deletions(-) = **-345 LOC** (target: at least -150 LOC).

The cut exceeds the plan's margin by 195 lines.

## Definition of Done

- [x] Built: code working, all Part A-D deliverables landed.
- [x] Tested: unit and integration tests passing; the one pre-existing `test_bare_hash_is_question` failure in `tests/e2e/test_message_pipeline.py` reproduces on main.
- [x] Documented: feature doc updated with RD-1 rationale and file map.
- [x] Quality: lint/format checks pass.

Closes #1074
Closes #1035