### PR TITLE
test(#1041): gate LLM tests, reorder tool guards, restore cooldown log

### DIFF
--- a/tests/integration/test_silent_failures.py
+++ b/tests/integration/test_silent_failures.py
@@ -159,7 +159,10 @@ class TestEnqueueContinuationSessionLookupLogging:
 
         with (
             caplog.at_level(logging.ERROR, logger="agent.agent_session_queue"),
-            patch("agent.agent_session_queue.enqueue_agent_session", new_callable=_AsyncMock),
+            patch(
+                "agent.agent_session_queue.enqueue_agent_session",
+                new_callable=_AsyncMock,
+            ),
         ):
             from agent.agent_session_queue import _enqueue_nudge
 
@@ -183,18 +186,18 @@ class TestLoadCooldownsLogging:
 
     def test_file_read_failure_logs_warning(self, caplog, tmp_path):
         """When cooldown file read fails, a warning is emitted."""
-        import agent.agent_session_queue as jq
-        from agent.agent_session_queue import _load_cooldowns
+        import agent.session_revival as sr
+        from agent.session_revival import _load_cooldowns
 
-        # Save and replace the cooldown file path
-        original = jq._COOLDOWN_FILE
-        jq._COOLDOWN_FILE = tmp_path / "bad_cooldowns.json"
+        # Save and replace the cooldown file path on the canonical module
+        original = sr._COOLDOWN_FILE
+        sr._COOLDOWN_FILE = tmp_path / "bad_cooldowns.json"
 
         # Write invalid JSON
-        jq._COOLDOWN_FILE.write_text("{invalid json content")
+        sr._COOLDOWN_FILE.write_text("{invalid json content")
 
         try:
-            with caplog.at_level(logging.WARNING, logger="agent.agent_session_queue"):
+            with caplog.at_level(logging.WARNING, logger="agent.session_revival"):
                 result = _load_cooldowns()
 
             # Should return empty dict on failure
@@ -205,7 +208,7 @@ class TestLoadCooldownsLogging:
                 f"Expected warning about cooldowns, got: {[r.message for r in warning_records]}"
             )
         finally:
-            jq._COOLDOWN_FILE = original
+            sr._COOLDOWN_FILE = original
 
 
 class TestSaveCooldownsLogging:
@@ -213,16 +216,16 @@ class TestSaveCooldownsLogging:
 
     def test_file_write_failure_logs_warning(self, caplog):
         """When cooldown file write fails, a warning is emitted."""
-        import agent.agent_session_queue as jq
-        from agent.agent_session_queue import _save_cooldowns
+        import agent.session_revival as sr
+        from agent.session_revival import _save_cooldowns
 
-        original = jq._COOLDOWN_FILE
+        original = sr._COOLDOWN_FILE
         # Point to a path that can't be written (permission denied simulation)
-        jq._COOLDOWN_FILE = MagicMock()
-        jq._COOLDOWN_FILE.parent.mkdir = MagicMock(side_effect=Exception("Permission denied"))
+        sr._COOLDOWN_FILE = MagicMock()
+        sr._COOLDOWN_FILE.parent.mkdir = MagicMock(side_effect=Exception("Permission denied"))
 
         try:
-            with caplog.at_level(logging.WARNING, logger="agent.agent_session_queue"):
+            with caplog.at_level(logging.WARNING, logger="agent.session_revival"):
                 _save_cooldowns({"test-project": 1234567890.0})
 
             warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
@@ -230,7 +233,7 @@ class TestSaveCooldownsLogging:
                 f"Expected warning about cooldowns, got: {[r.message for r in warning_records]}"
             )
         finally:
-            jq._COOLDOWN_FILE = original
+            sr._COOLDOWN_FILE = original
 
 
 class TestCheckRevivalBranchLogging:

--- a/tests/tools/test_classifier.py
+++ b/tests/tools/test_classifier.py
@@ -4,9 +4,16 @@ Tests the classify_request() function with real-world test cases.
 Validates classifications, confidence scores, and reasoning.
 """
 
+import os
+
 import pytest
 
 from tools.classifier import classify_request
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("ANTHROPIC_API_KEY"),
+    reason="requires ANTHROPIC_API_KEY",
+)
 
 
 class TestClassifierBasicCases:

--- a/tests/unit/test_cross_wire_fixes.py
+++ b/tests/unit/test_cross_wire_fixes.py
@@ -55,6 +55,10 @@ class TestClassifierInformationalCompletion:
         if result.output_type is not None:
             assert result.output_type != OutputType.STATUS_UPDATE
 
+    @pytest.mark.skipif(
+        not os.getenv("ANTHROPIC_API_KEY"),
+        reason="requires ANTHROPIC_API_KEY",
+    )
     @pytest.mark.asyncio
     async def test_qa_answer_classified_as_completion(self):
         """Full classifier should classify informational answers as COMPLETION."""

--- a/tests/unit/test_intake_classifier.py
+++ b/tests/unit/test_intake_classifier.py
@@ -9,6 +9,7 @@ Integration tests call the real Haiku API for accuracy validation.
 """
 
 import json
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -79,7 +80,11 @@ class TestMockedClassification:
     def test_interjection_classification(self):
         """High-confidence interjection is returned correctly."""
         mock_client = self._mock_haiku_response(
-            {"intent": "interjection", "confidence": 0.95, "reason": "Course correction"}
+            {
+                "intent": "interjection",
+                "confidence": 0.95,
+                "reason": "Course correction",
+            }
         )
         with (
             patch("tools.classifier.anthropic.Anthropic", return_value=mock_client),
@@ -111,7 +116,11 @@ class TestMockedClassification:
     def test_acknowledgment_classification(self):
         """Acknowledgment is returned correctly."""
         mock_client = self._mock_haiku_response(
-            {"intent": "acknowledgment", "confidence": 0.92, "reason": "User approves work"}
+            {
+                "intent": "acknowledgment",
+                "confidence": 0.92,
+                "reason": "User approves work",
+            }
         )
         with (
             patch("tools.classifier.anthropic.Anthropic", return_value=mock_client),
@@ -129,7 +138,11 @@ class TestMockedClassification:
     def test_low_confidence_defaults_to_new_work(self):
         """Below 0.80 confidence threshold, intent defaults to new_work."""
         mock_client = self._mock_haiku_response(
-            {"intent": "interjection", "confidence": 0.60, "reason": "Unclear follow-up"}
+            {
+                "intent": "interjection",
+                "confidence": 0.60,
+                "reason": "Unclear follow-up",
+            }
         )
         with (
             patch("tools.classifier.anthropic.Anthropic", return_value=mock_client),
@@ -302,6 +315,10 @@ class TestSessionSteeringIntegration:
 # =============================================================================
 
 
+@pytest.mark.skipif(
+    not os.getenv("ANTHROPIC_API_KEY"),
+    reason="requires ANTHROPIC_API_KEY",
+)
 class TestRealHaikuClassification:
     """Integration tests using real Haiku API calls.
 

--- a/tests/unit/test_work_request_classifier.py
+++ b/tests/unit/test_work_request_classifier.py
@@ -5,6 +5,8 @@ should be routed through SDLC (orchestrator in ai/) or directly to the
 target project (Teammate mode).
 """
 
+import os
+
 import pytest
 
 from bridge.routing import classify_work_request
@@ -101,6 +103,10 @@ class TestFastPathSdlc:
         assert classify_work_request(message) == "sdlc"
 
 
+@pytest.mark.skipif(
+    not os.getenv("ANTHROPIC_API_KEY"),
+    reason="requires ANTHROPIC_API_KEY",
+)
 class TestLlmClassification:
     """Messages that require LLM classification.
 

--- a/tools/doc_summary/__init__.py
+++ b/tools/doc_summary/__init__.py
@@ -51,15 +51,6 @@ def summarize(
             - word_count: Summary word count
             - compression_ratio: Original vs summary size
     """
-    # Try Anthropic first, fall back to OpenRouter
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
-    use_anthropic = bool(api_key)
-
-    if not use_anthropic:
-        api_key = os.environ.get("OPENROUTER_API_KEY")
-        if not api_key:
-            return {"error": "ANTHROPIC_API_KEY or OPENROUTER_API_KEY required"}
-
     # If content looks like a file path, try to read it
     if content and len(content) < 500 and "\n" not in content:
         path = Path(content)
@@ -71,6 +62,15 @@ def summarize(
 
     if not content or not content.strip():
         return {"error": "Content cannot be empty"}
+
+    # Try Anthropic first, fall back to OpenRouter
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    use_anthropic = bool(api_key)
+
+    if not use_anthropic:
+        api_key = os.environ.get("OPENROUTER_API_KEY")
+        if not api_key:
+            return {"error": "ANTHROPIC_API_KEY or OPENROUTER_API_KEY required"}
 
     original_word_count = len(content.split())
 

--- a/tools/test_judge/__init__.py
+++ b/tools/test_judge/__init__.py
@@ -60,6 +60,12 @@ def judge_test_result(
             - criteria_results: Pass/fail for each criterion
             - suggestions: Improvement suggestions
     """
+    if not test_output:
+        return {"error": "Test output cannot be empty"}
+
+    if not expected_criteria:
+        return {"error": "Expected criteria cannot be empty"}
+
     # Try Anthropic first, fall back to OpenRouter
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     use_anthropic = bool(api_key)
@@ -68,12 +74,6 @@ def judge_test_result(
         api_key = os.environ.get("OPENROUTER_API_KEY")
         if not api_key:
             return {"error": "ANTHROPIC_API_KEY or OPENROUTER_API_KEY required"}
-
-    if not test_output:
-        return {"error": "Test output cannot be empty"}
-
-    if not expected_criteria:
-        return {"error": "Expected criteria cannot be empty"}
 
     strictness_instructions = {
         "lenient": "Be generous in interpretation. Accept reasonable approximations.",


### PR DESCRIPTION
## Summary

Session 2 of the #1041 parallelization playbook (Clusters K, L, Unit-1, Unit-8). Ref #1041.

- Reorder guards in `tools/doc_summary/__init__.py` and `tools/test_judge/__init__.py` so empty-input validation runs before the `ANTHROPIC_API_KEY`/`OPENROUTER_API_KEY` check — empty inputs now return the "empty" error even without an API key in the environment.
- Gate live-Haiku suites behind `@pytest.mark.skipif(not os.getenv("ANTHROPIC_API_KEY"))`:
  - `tests/tools/test_classifier.py` (module-level `pytestmark` — 22 cases)
  - `tests/unit/test_intake_classifier.py::TestRealHaikuClassification` (class-level — 10 cases)
  - `tests/unit/test_work_request_classifier.py::TestLlmClassification` (class-level — 12 cases)
  - `tests/unit/test_cross_wire_fixes.py::TestClassifierInformationalCompletion::test_qa_answer_classified_as_completion` (single case — the heuristic fallback returns QUESTION without a key)
- Cluster L investigation: `_load_cooldowns`/`_save_cooldowns` live in `agent/session_revival.py` and are re-exported through `agent.agent_session_queue`. The tests patched `agent.agent_session_queue._COOLDOWN_FILE` and captured the `agent.agent_session_queue` logger, but the runtime reads the module-level `_COOLDOWN_FILE` in `session_revival` and logs under `agent.session_revival`. The production `logger.warning` calls at `agent/session_revival.py:32,42` were already in place and are preserved; only the tests needed to target the canonical module and logger.

## Test plan

- [x] `pytest tests/tools/test_classifier.py tests/tools/test_doc_summary.py tests/tools/test_test_judge.py tests/unit/test_intake_classifier.py tests/unit/test_work_request_classifier.py tests/unit/test_cross_wire_fixes.py tests/integration/test_silent_failures.py` → 88 passed, 66 skipped (skips are ANTHROPIC_API_KEY-gated as expected)
- [x] The three Cluster K tests that were failing now pass: `test_doc_summary.py::TestSummarizeValidation::test_empty_content_returns_error`, `test_test_judge.py::TestJudgeValidation::test_empty_test_output_returns_error`, `test_test_judge.py::TestJudgeValidation::test_empty_criteria_returns_error`
- [x] Both Cluster L cooldown tests pass with a real exception trigger (invalid JSON / mocked-mkdir failure)