### PR TITLE
test(#1041): clean up post-#1023/#1026/#1035 test drift (health/lifecycle/reflections/emoji)

### DIFF
--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -69,8 +69,10 @@ from agent.session_executor import (  # noqa: F401
 
 # Health monitoring — re-exported here for backward compatibility.
 from agent.session_health import (  # noqa: F401
+    AGENT_SESSION_HEALTH_CHECK_INTERVAL,
     AGENT_SESSION_HEALTH_MIN_RUNNING,
     AGENT_SESSION_TIMEOUT_BUILD,
+    AGENT_SESSION_TIMEOUT_DEFAULT,
     HEARTBEAT_FRESHNESS_WINDOW,
     HEARTBEAT_WRITE_INTERVAL,
     MAX_RECOVERY_ATTEMPTS,

--- a/tests/integration/test_agent_session_lifecycle.py
+++ b/tests/integration/test_agent_session_lifecycle.py
@@ -262,10 +262,10 @@ class TestGetStatusEmoji:
         assert _get_status_emoji(sdlc_session) == "✅"
 
     def test_active_session_completion(self, session):
-        """Active session with is_completion=True (default) returns ✅."""
+        """Active session with is_completion=True (default) returns "" (milestone-selective)."""
         from bridge.message_drafter import _get_status_emoji
 
-        assert _get_status_emoji(session) == "✅"
+        assert _get_status_emoji(session) == ""
 
     def test_active_session_non_completion(self, session):
         """Active session with is_completion=False returns ⏳."""
@@ -320,8 +320,8 @@ class TestComposeStructuredDraft:
         # No stage progress (no history)
         assert "☑" not in result
         assert "☐" not in result
-        # Has emoji and text
-        assert "✅" in result
+        # Completed Teammate session with no PR link is non-milestone — no emoji
+        assert "✅" not in result
         assert "FILO" in result
 
     def test_chat_session_minimal(self, chat_session):
@@ -358,8 +358,8 @@ class TestSummarizeWithSession:
     """Tests for draft_message passing session context."""
 
     @pytest.mark.asyncio
-    async def test_short_response_still_summarized(self):
-        """All non-empty responses are now summarized (no threshold)."""
+    async def test_short_response_bypasses_drafter(self):
+        """Short non-SDLC responses (<200 chars, no artifacts/?) bypass the LLM drafter."""
         from bridge.message_drafter import StructuredDraft, draft_message
 
         mock_haiku = AsyncMock(
@@ -367,8 +367,10 @@ class TestSummarizeWithSession:
         )
         with patch("bridge.message_drafter._draft_with_haiku", mock_haiku):
             result = await draft_message("Done.", session=None)
-        assert result.was_drafted is True
-        mock_haiku.assert_called_once()
+        # Short-output early return (SHORT_OUTPUT_THRESHOLD): bypasses drafter
+        assert result.was_drafted is False
+        assert result.text == "Done."
+        mock_haiku.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_long_response_with_sdlc_session(self, sdlc_session):
@@ -735,8 +737,9 @@ class TestQALifecycle:
             is_completion=True,
         )
 
-        # Should have emoji + label + answer, no stages, no links
-        assert "✅" in result
+        # Completed Teammate session with no PR link is non-milestone — no emoji,
+        # just the answer, no stages, no links
+        assert "✅" not in result
         assert "session queue" in result.lower()
         assert "FILO" in result
         assert "☑" not in result
@@ -766,8 +769,8 @@ class TestChitChatLifecycle:
             is_completion=True,
         )
 
-        # Minimal output — emoji, label, prose
-        assert "✅" in result
+        # Minimal output — completed non-milestone session has no emoji, just prose
+        assert "✅" not in result
         assert "Working through the backlog" in result
         # No SDLC artifacts
         assert "☑" not in result

--- a/tests/unit/test_autoexperiment.py
+++ b/tests/unit/test_autoexperiment.py
@@ -103,7 +103,7 @@ class TestExtractInject:
         new_prompt = "New summarizer instructions."
         result = inject_summarizer_prompt(SAMPLE_SUMMARIZER_FILE, new_prompt)
         assert "New summarizer instructions" in result
-        assert "async def summarize():" in result
+        assert "async def draft():" in result
 
     def test_roundtrip_summarizer(self):
         """Extract then inject should preserve the prompt."""

--- a/tests/unit/test_custom_emoji_index.py
+++ b/tests/unit/test_custom_emoji_index.py
@@ -160,7 +160,7 @@ class TestUnifiedSearch:
             patch("tools.emoji_embedding._custom_embedding_cache", fake_custom),
             patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}),
             patch(
-                "tools.knowledge_search._compute_embedding",
+                "tools.emoji_embedding._compute_embedding",
                 return_value=[0.99, 0.0, 0.0],
             ),
         ):
@@ -189,7 +189,7 @@ class TestUnifiedSearch:
             patch("tools.emoji_embedding._custom_embedding_cache", fake_custom),
             patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}),
             patch(
-                "tools.knowledge_search._compute_embedding",
+                "tools.emoji_embedding._compute_embedding",
                 return_value=[1.0, 0.0, 0.0],
             ),
         ):
@@ -217,7 +217,7 @@ class TestUnifiedSearch:
             patch("tools.emoji_embedding._custom_embedding_cache", {}),
             patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}),
             patch(
-                "tools.knowledge_search._compute_embedding",
+                "tools.emoji_embedding._compute_embedding",
                 return_value=[0.9, 0.1],
             ),
         ):
@@ -299,7 +299,7 @@ class TestBuildCustomEmojiIndex:
                 patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}),
                 patch("tools.emoji_embedding.CUSTOM_CACHE_PATH", tmp_cache),
                 patch(
-                    "tools.knowledge_search._compute_embedding",
+                    "tools.emoji_embedding._compute_embedding",
                     return_value=[0.1, 0.2, 0.3],
                 ),
             ):
@@ -426,7 +426,7 @@ class TestGracefulDegradation:
             patch("tools.emoji_embedding._custom_embedding_cache", {}),
             patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}),
             patch(
-                "tools.knowledge_search._compute_embedding",
+                "tools.emoji_embedding._compute_embedding",
                 return_value=[0.9, 0.1, 0.0],
             ),
         ):

--- a/tests/unit/test_emoji_embedding.py
+++ b/tests/unit/test_emoji_embedding.py
@@ -112,7 +112,7 @@ class TestEmbeddingApiFallback:
         with (
             patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}),
             patch(
-                "tools.knowledge_search._compute_embedding",
+                "tools.emoji_embedding._compute_embedding",
                 return_value=None,
             ),
         ):
@@ -205,7 +205,7 @@ class TestEmojiSelection:
             patch("tools.emoji_embedding._custom_embedding_cache", {}),
             patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}),
             patch(
-                "tools.knowledge_search._compute_embedding",
+                "tools.emoji_embedding._compute_embedding",
                 return_value=[0.9, 0.1, 0.0],  # Close to fire
             ),
         ):
@@ -230,7 +230,7 @@ class TestEmojiSelection:
             patch("tools.emoji_embedding._custom_embedding_cache", {}),
             patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}),
             patch(
-                "tools.knowledge_search._compute_embedding",
+                "tools.emoji_embedding._compute_embedding",
                 return_value=[0.9, 0.1],
             ),
         ):

--- a/tests/unit/test_reflections_memory.py
+++ b/tests/unit/test_reflections_memory.py
@@ -48,8 +48,7 @@ class TestMemoryDecayPrune:
         mock_memory.importance = 0.05  # below WF_MIN_THRESHOLD
         mock_memory.access_count = 0
         mock_memory.superseded_by = ""
-        mock_memory.created_at = MagicMock()
-        mock_memory.created_at.timestamp.return_value = old_time
+        mock_memory.created_at = old_time
 
         with (
             patch("models.memory.Memory") as mock_model,
@@ -73,8 +72,7 @@ class TestMemoryDecayPrune:
         mock_memory.importance = 0.05
         mock_memory.access_count = 0
         mock_memory.superseded_by = ""
-        mock_memory.created_at = MagicMock()
-        mock_memory.created_at.timestamp.return_value = old_time
+        mock_memory.created_at = old_time
 
         with (
             patch("models.memory.Memory") as mock_model,
@@ -99,8 +97,7 @@ class TestMemoryDecayPrune:
             m.importance = 0.05
             m.access_count = 0
             m.superseded_by = ""
-            m.created_at = MagicMock()
-            m.created_at.timestamp.return_value = old_time
+            m.created_at = old_time
             return m
 
         candidates = [make_candidate(i) for i in range(MAX_PRUNE_PER_RUN + 20)]
@@ -137,8 +134,7 @@ class TestMemoryDecayPrune:
         important_memory.importance = 7.5  # above exempt threshold
         important_memory.access_count = 0
         important_memory.superseded_by = ""
-        important_memory.created_at = MagicMock()
-        important_memory.created_at.timestamp.return_value = old_time
+        important_memory.created_at = old_time
 
         with (
             patch("models.memory.Memory") as mock_model,
@@ -160,8 +156,7 @@ class TestMemoryDecayPrune:
         accessed_memory.importance = 0.05
         accessed_memory.access_count = 3  # has been accessed
         accessed_memory.superseded_by = ""
-        accessed_memory.created_at = MagicMock()
-        accessed_memory.created_at.timestamp.return_value = old_time
+        accessed_memory.created_at = old_time
 
         with (
             patch("models.memory.Memory") as mock_model,
@@ -185,8 +180,7 @@ class TestMemoryDecayPrune:
             m.importance = 0.05
             m.access_count = 0
             m.superseded_by = ""
-            m.created_at = MagicMock()
-            m.created_at.timestamp.return_value = old_time
+            m.created_at = old_time
             if fail:
                 m.delete.side_effect = Exception("already deleted")
             return m
@@ -245,8 +239,7 @@ class TestMemoryQualityAudit:
         old_memory.importance = 1.0
         old_memory.access_count = 0
         old_memory.superseded_by = ""
-        old_memory.created_at = MagicMock()
-        old_memory.created_at.timestamp.return_value = old_time
+        old_memory.created_at = old_time
         old_memory.confidence = 0.5
 
         with patch("models.memory.Memory") as mock_model:
@@ -267,8 +260,7 @@ class TestMemoryQualityAudit:
         low_conf_memory.importance = 1.0
         low_conf_memory.access_count = 5
         low_conf_memory.superseded_by = ""
-        low_conf_memory.created_at = MagicMock()
-        low_conf_memory.created_at.timestamp.return_value = new_time
+        low_conf_memory.created_at = new_time
         low_conf_memory.confidence = 0.05  # very low confidence
 
         with patch("models.memory.Memory") as mock_model:
@@ -289,8 +281,7 @@ class TestMemoryQualityAudit:
         superseded.importance = 0.05
         superseded.access_count = 0
         superseded.superseded_by = "mem_new"  # superseded
-        superseded.created_at = MagicMock()
-        superseded.created_at.timestamp.return_value = old_time
+        superseded.created_at = old_time
         superseded.confidence = 0.05
 
         with patch("models.memory.Memory") as mock_model:

--- a/tools/emoji_embedding.py
+++ b/tools/emoji_embedding.py
@@ -28,6 +28,49 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+OPENROUTER_EMBEDDINGS_URL = "https://openrouter.ai/api/v1/embeddings"
+EMBEDDING_MODEL = "openai/text-embedding-3-small"
+
+
+def _compute_embedding(text: str, api_key: str) -> list[float] | None:
+    """Compute embedding for text using OpenRouter."""
+    import requests
+
+    try:
+        response = requests.post(
+            OPENROUTER_EMBEDDINGS_URL,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": EMBEDDING_MODEL,
+                "input": text[:8000],
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+        result = response.json()
+        return result.get("data", [{}])[0].get("embedding")
+    except Exception:
+        return None
+
+
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Compute cosine similarity between two vectors."""
+    if not a or not b or len(a) != len(b):
+        return 0.0
+
+    dot_product = sum(x * y for x, y in zip(a, b, strict=False))
+    norm_a = sum(x * x for x in a) ** 0.5
+    norm_b = sum(x * x for x in b) ** 0.5
+
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+
+    return dot_product / (norm_a * norm_b)
+
+
 # Cache location for pre-computed emoji embeddings
 CACHE_PATH = Path(__file__).parent.parent / "data" / "emoji_embeddings.json"
 
@@ -212,8 +255,6 @@ def _load_or_compute_embeddings() -> dict[str, list[float]]:
         _embedding_cache = {}
         return _embedding_cache
 
-    from tools.knowledge_search import _compute_embedding
-
     logger.info(f"Computing emoji embeddings for {len(EMOJI_LABELS)} emojis...")
     embeddings: dict[str, list[float]] = {}
 
@@ -266,8 +307,6 @@ def find_best_emoji(feeling: str) -> EmojiResult:
     api_key = os.environ.get("OPENROUTER_API_KEY")
     if not api_key:
         return default_result
-
-    from tools.knowledge_search import _compute_embedding, _cosine_similarity
 
     start = time.time()
     query_embedding = _compute_embedding(feeling.strip(), api_key)
@@ -457,8 +496,6 @@ async def build_custom_emoji_index(client) -> dict[str, list[float]]:
         return {}
 
     # Compute embeddings
-    from tools.knowledge_search import _compute_embedding
-
     logger.info(f"Computing custom emoji embeddings for {len(labels)} emoji...")
     embeddings: dict[str, list[float]] = {}
 


### PR DESCRIPTION
## Summary

Session 4 of 5 in the parallelized cleanup of issue #1041 (test-suite debt). Resolves new debt surfaced in commits between the parent plan's baseline `ba51c088` and HEAD — drift introduced by the #1023 (agent_session_queue split), #1026 (session_mode/session_type collapse), and #1035 (message_drafter rename) refactors — plus the trimmed portion of Cluster A (knowledge_search namespace).

## Changes

**Shim re-export (Cluster I adjacent / #1023 drift)**
- `agent/agent_session_queue.py` — re-export `AGENT_SESSION_HEALTH_CHECK_INTERVAL` and `AGENT_SESSION_TIMEOUT_DEFAULT`. Fixes 5 `tests/integration/test_agent_session_health_monitor.py` failures in `TestGetJobTimeout` + `TestJobHealthCheck` + `TestJobHealthConstants`.

**Lifecycle/drafter drift (#1035)**
- `tests/integration/test_agent_session_lifecycle.py` — update 5 tests for the milestone-selective emoji logic shipped in #1035: `_get_status_emoji` now returns `""` for routine completions (reserving ✅ for milestones like merged PR / failed session), and `draft_message` short-output bypass (<200 chars, no artifacts, no ?) returns `was_drafted=False`.
- `tests/unit/test_autoexperiment.py::TestExtractInject::test_inject_summarizer_prompt` — assert `async def draft():` instead of `async def summarize():` (drafter rename fallout).

**Memory mocks (drift)**
- `tests/unit/test_reflections_memory.py` — 5 failures in `TestMemoryDecayPrune` + `TestMemoryQualityAudit` caused by `MagicMock.timestamp()` no longer flowing through `bridge.utc.to_unix_ts` (which accepts datetime/int/float/str only, not MagicMock). Switched to raw unix timestamps.

**Broken production imports (Cluster A, trimmed)**
- `tools/emoji_embedding.py` — inline `_compute_embedding` and `_cosine_similarity` directly instead of importing from the long-deleted `tools/knowledge_search` module (deleted by commit 3accddaa). The broken imports were never exercised in the green-path unit tests but would ImportError on any real call. Functions are copied verbatim from the original module.
- `tests/unit/test_custom_emoji_index.py`, `tests/unit/test_emoji_embedding.py` — retarget `patch("tools.knowledge_search._compute_embedding", ...)` to `tools.emoji_embedding._compute_embedding`.

## Verification

- `pytest tests/integration/test_agent_session_health_monitor.py tests/integration/test_agent_session_lifecycle.py tests/unit/test_reflections_memory.py tests/unit/test_autoexperiment.py tests/unit/test_custom_emoji_index.py tests/unit/test_emoji_embedding.py` → 135 passed
- Smoke-tested adjacent unit + integration suites (`emoji`, `drafter`, `session_queue`, `session_health`, `lifecycle`, `health`) — 428 passed, 5 skipped, 0 regressions.

References #1041.

## Test plan

- [ ] CI green on `pytest tests/unit tests/integration tests/tools`
- [ ] No regressions in adjacent test suites
- [ ] Production `tools.emoji_embedding` no longer imports from the deleted `tools.knowledge_search` module