### PR TITLE
test(#1041): update symbol drift (signatures, counts, sentinels, greps)

### DIFF
--- a/tests/integration/test_remote_update.py
+++ b/tests/integration/test_remote_update.py
@@ -303,7 +303,7 @@ class TestWorkerRestartCheck:
 
         call_count = 0
 
-        async def pop_side_effect(project_key):
+        async def pop_side_effect(worker_key, is_project_keyed):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -372,7 +372,10 @@ class TestServiceManager:
 
     def test_update_plist_defined(self):
         source = Path(self.SERVICE_SCRIPT).read_text()
-        assert "com.valor.update" in source
+        # Label is built from ${SERVICE_LABEL_PREFIX}.update (defaulting to com.valor),
+        # not hardcoded. Assert the dynamic form.
+        assert "${SERVICE_LABEL_PREFIX}.update" in source
+        assert "SERVICE_LABEL_PREFIX:=com.valor" in source
 
     def test_install_creates_both_plists(self):
         source = Path(self.SERVICE_SCRIPT).read_text()

--- a/tests/integration/test_worker_concurrency.py
+++ b/tests/integration/test_worker_concurrency.py
@@ -121,16 +121,18 @@ class TestGlobalSemaphore:
     async def test_semaphore_limits_concurrent_sessions(self):
         """At most MAX_CONCURRENT_SESSIONS sessions should execute simultaneously.
 
-        Enqueues 3 sessions with the same chat_id and patches _execute_agent_session
-        to use a controlled delay. Verifies that at most 1 session is running per
-        chat_id at any point in time (per-chat serialization).
+        Enqueues sessions across distinct chat_ids and patches
+        _execute_agent_session with a controlled delay. Verifies the global
+        semaphore caps peak concurrent executions.
         """
+        import agent.session_state as _ss
+
         max_sessions = 2
-        original_semaphore = _queue._global_session_semaphore
+        original_semaphore = _ss._global_session_semaphore
 
         try:
             # Set up a semaphore with a low ceiling for testing
-            _queue._global_session_semaphore = asyncio.Semaphore(max_sessions)
+            _ss._global_session_semaphore = asyncio.Semaphore(max_sessions)
 
             chat_id_a = "test-semaphore-chat-a"
             chat_id_b = "test-semaphore-chat-b"
@@ -168,7 +170,7 @@ class TestGlobalSemaphore:
                 f"MAX_CONCURRENT_SESSIONS={max_sessions}"
             )
         finally:
-            _queue._global_session_semaphore = original_semaphore
+            _ss._global_session_semaphore = original_semaphore
             # Clean up workers
             for task in list(_active_workers.values()):
                 task.cancel()
@@ -266,11 +268,18 @@ class TestPerChatSerialization:
     async def test_global_ceiling_across_multiple_chat_ids(self):
         """Global semaphore ceiling must apply across all chat_ids combined.
 
-        With MAX_CONCURRENT_SESSIONS=2, at most 2 sessions should run at
-        any point regardless of how many different chat_ids are active.
+        Post-#1029 default is MAX_CONCURRENT_SESSIONS=8. We enqueue 12 sessions
+        across distinct chat_ids with a faster-than-ceiling arrival rate and
+        verify the semaphore caps peak concurrency at 8.
+
+        The runtime reads the semaphore from agent.session_state, not from
+        agent.agent_session_queue's import-time alias — so the test patches
+        the canonical module.
         """
-        max_sessions = 2
-        chat_ids = [f"global-ceil-chat-{i}" for i in range(4)]
+        import agent.session_state as _ss
+
+        max_sessions = 8
+        chat_ids = [f"global-ceil-chat-{i}" for i in range(max_sessions + 4)]
 
         running_count = [0]
         peak_running = [0]
@@ -284,27 +293,37 @@ class TestPerChatSerialization:
                 running_count[0] += 1
                 peak_running[0] = max(peak_running[0], running_count[0])
 
-            await asyncio.sleep(0.05)
+            # Hold long enough that all 12 sessions overlap if the semaphore
+            # wasn't enforced — at 50ms work + ~12 workers, an unbounded run
+            # would briefly hit peak=12.
+            await asyncio.sleep(0.1)
 
             async with count_lock:
                 running_count[0] -= 1
 
-        original_semaphore = _queue._global_session_semaphore
+        original_semaphore = _ss._global_session_semaphore
         try:
-            _queue._global_session_semaphore = asyncio.Semaphore(max_sessions)
+            _ss._global_session_semaphore = asyncio.Semaphore(max_sessions)
 
             with patch("agent.agent_session_queue._execute_agent_session", new=fake_execute):
                 for cid in chat_ids:
                     _ensure_worker(cid)
-                await asyncio.sleep(0.8)
+                await asyncio.sleep(1.2)
 
             assert peak_running[0] <= max_sessions, (
                 f"Peak concurrent sessions ({peak_running[0]}) exceeded "
                 f"MAX_CONCURRENT_SESSIONS={max_sessions}. "
                 "Global semaphore is not working correctly."
             )
+            # Sanity: the ceiling should actually have been hit at least once,
+            # otherwise we're not exercising the cap.
+            assert peak_running[0] >= 2, (
+                f"Peak concurrent sessions ({peak_running[0]}) was too low to "
+                "meaningfully test the ceiling. Raise the arrival rate or "
+                "hold time."
+            )
         finally:
-            _queue._global_session_semaphore = original_semaphore
+            _ss._global_session_semaphore = original_semaphore
             for cid in chat_ids:
                 task = _active_workers.pop(cid, None)
                 if task:

--- a/tests/integration/test_worker_drain.py
+++ b/tests/integration/test_worker_drain.py
@@ -8,6 +8,7 @@ All tests use redis_test_db fixture (autouse=True in conftest.py) for isolation.
 
 import asyncio
 import time
+import uuid
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -22,14 +23,28 @@ from agent.agent_session_queue import (
 from models.agent_session import AgentSession
 
 
+@pytest.fixture(autouse=True)
+def _force_bridge_mode(monkeypatch):
+    """Ensure _worker_loop runs in bridge mode (DRAIN_TIMEOUT honored) regardless
+    of the developer's shell env. Standalone mode waits indefinitely on event.wait()
+    which would hang every test in this file — the drain timeout is the whole
+    point of these tests."""
+    monkeypatch.delenv("VALOR_WORKER_MODE", raising=False)
+
+
 def _create_test_session(**overrides) -> AgentSession:
-    """Create an AgentSession with sensible defaults for testing."""
+    """Create an AgentSession with sensible defaults for testing.
+
+    Each session gets a unique session_id so transition_status's CAS re-read
+    (which tie-breaks by status='running') can't cross-match records within the
+    same test run.
+    """
     defaults = {
         "project_key": "test",
         "status": "pending",
         "priority": "normal",
         "created_at": time.time(),
-        "session_id": "test_session",
+        "session_id": f"test_session_{uuid.uuid4().hex[:8]}",
         "working_dir": "/tmp/test",
         "message_text": "test message",
         "sender_name": "Test",

--- a/tests/unit/test_agent_session_scheduler_kill.py
+++ b/tests/unit/test_agent_session_scheduler_kill.py
@@ -586,6 +586,7 @@ class TestRecoveryExcludesKilled:
         local_session.worker_key = "ai"
         local_session.started_at = time.time() - AGENT_SESSION_HEALTH_MIN_RUNNING - 600
         local_session.message_text = "test"
+        local_session.status = "running"
         local_session.save = MagicMock()
         local_session.delete = MagicMock()
 
@@ -603,8 +604,14 @@ class TestRecoveryExcludesKilled:
         def fake_finalize(entry, status, **kwargs):
             finalize_calls.append((entry, status, kwargs))
 
+        # _recover_interrupted_agent_sessions_startup was moved to
+        # agent.session_health post-#1023; it looks up AgentSession from that
+        # module, so patch the canonical location (not the re-export).
+        # finalize_session / update_session are imported lazily inside the
+        # function body, so patch at their definition site instead.
         with (
-            patch("agent.agent_session_queue.AgentSession") as mock_cls,
+            patch("agent.session_health.AgentSession") as mock_cls,
+            patch("agent.session_health._filter_hydrated_sessions", side_effect=lambda x: list(x)),
             patch("models.session_lifecycle.finalize_session", side_effect=fake_finalize),
             patch("models.session_lifecycle.update_session") as mock_update,
         ):
@@ -614,7 +621,9 @@ class TestRecoveryExcludesKilled:
         # Count is 0 — local sessions are abandoned, not recovered
         assert result == 0
         # The function should filter on status="running"
-        assert any(c.get("status") == "running" for c in calls)
+        assert any(c.get("status") == "running" for c in calls), (
+            f"expected filter(status='running') call, got {calls!r}"
+        )
         # No call should filter on status="killed"
         assert not any(c.get("status") == "killed" for c in calls)
         # Local session must be abandoned, not re-queued

--- a/tests/unit/test_duplicate_delivery.py
+++ b/tests/unit/test_duplicate_delivery.py
@@ -147,60 +147,72 @@ class TestCompletedSessionGuard:
     """Fix 3: Auto-continue skips when session is already completed."""
 
     def test_completed_session_skips_auto_continue(self):
-        """When session_status is terminal, output is delivered without nudge."""
-        # Verify the guard exists in the code — now in output_router.py (extracted from queue)
-        from pathlib import Path
+        """When session_status is terminal, the router returns deliver_already_completed
+        (not a nudge action) so the executor delivers to chat and skips auto-continue."""
+        from agent.output_router import determine_delivery_action
+        from models.session_lifecycle import TERMINAL_STATUSES
 
-        router_code = Path("agent/output_router.py").read_text()
-        queue_code = Path("agent/agent_session_queue.py").read_text()
+        # Every terminal status must short-circuit to deliver_already_completed,
+        # regardless of output content or stop_reason.
+        for status in TERMINAL_STATUSES:
+            action = determine_delivery_action(
+                msg="some agent output",
+                stop_reason="end_turn",
+                auto_continue_count=0,
+                max_nudge_count=50,
+                session_status=status,
+            )
+            assert action == "deliver_already_completed", (
+                f"status={status!r} should short-circuit to deliver_already_completed, "
+                f"got {action!r}"
+            )
 
-        # The guard should check session_status against all TERMINAL_STATUSES
-        # (was previously just == "completed", now checks all terminal statuses)
-        # Guard may be in output_router.py (canonical) or agent_session_queue.py (legacy)
-        assert (
-            "session_status in _TERMINAL_STATUSES" in router_code
-            or "session_status in _TERMINAL_STATUSES" in queue_code
+        # Also holds for empty output — must not emit a nudge action.
+        empty_action = determine_delivery_action(
+            msg="",
+            stop_reason="end_turn",
+            auto_continue_count=0,
+            max_nudge_count=50,
+            session_status=next(iter(TERMINAL_STATUSES)),
         )
-        # It should deliver to chat without nudge (this message is in the executor, not the router)
-        assert "delivering without nudge" in queue_code
+        assert empty_action == "deliver_already_completed"
+        assert "nudge" not in empty_action
 
     def test_guard_is_before_nudge_routing(self):
-        """The completed-session guard must come before the nudge routing logic.
+        """The completed-session guard must win over every nudge branch.
 
-        The guard now lives in output_router.determine_delivery_action() which
-        is called before any _enqueue_nudge() in the send_to_chat() execution path.
-        The test verifies the guard exists and that the nudge call site exists.
+        Behavioral check: for every (stop_reason, msg) permutation that would
+        otherwise drive a nudge action, a terminal session_status must still
+        return deliver_already_completed — proving the guard runs first.
         """
-        from pathlib import Path
+        from agent.output_router import determine_delivery_action
+        from models.session_lifecycle import TERMINAL_STATUSES
 
-        router_code = Path("agent/output_router.py").read_text()
-        queue_code = Path("agent/agent_session_queue.py").read_text()
+        terminal = next(iter(TERMINAL_STATUSES))
 
-        # Guard is now in output_router.py — confirm it returns deliver_already_completed
-        assert "deliver_already_completed" in router_code, (
-            "deliver_already_completed guard not found in output_router.py"
-        )
-        # Guard must check session_status against terminal statuses
-        assert "session_status in _TERMINAL_STATUSES" in router_code, (
-            "terminal status guard not found in output_router.py"
-        )
-        # The nudge call site should still exist in the queue executor (inside send_to_chat)
-        # Note: re_enqueue_session() also calls _enqueue_nudge, so find the one in send_to_chat
-        send_to_chat_pos = queue_code.find("async def send_to_chat(")
-        assert send_to_chat_pos > 0, "send_to_chat not found in agent_session_queue.py"
-        nudge_pos = queue_code.find("await _enqueue_nudge(", send_to_chat_pos)
-        assert nudge_pos > 0, "await _enqueue_nudge() call not found in send_to_chat"
+        # These inputs would produce a nudge for a non-terminal session.
+        nudge_inducing_cases = [
+            {"msg": "", "stop_reason": "end_turn"},  # nudge_empty
+            {"msg": "work", "stop_reason": "rate_limited"},  # nudge_rate_limited
+            {
+                "msg": "work",
+                "stop_reason": "end_turn",
+                "session_type": "pm",
+                "classification_type": "sdlc",
+            },  # nudge_continue
+        ]
 
-        # The executor must check the routing action before calling _enqueue_nudge
-        # i.e. action == "deliver_already_completed" check appears before the nudge call
-        deliver_check_pos = queue_code.find('"deliver_already_completed"', send_to_chat_pos)
-        assert deliver_check_pos > 0, (
-            "deliver_already_completed action check not found in agent_session_queue.py"
-        )
-        assert deliver_check_pos < nudge_pos, (
-            "deliver_already_completed check should appear before "
-            "_enqueue_nudge call in send_to_chat"
-        )
+        for case in nudge_inducing_cases:
+            action = determine_delivery_action(
+                auto_continue_count=0,
+                max_nudge_count=50,
+                session_status=terminal,
+                **case,
+            )
+            assert action == "deliver_already_completed", (
+                f"terminal session with nudge-inducing inputs {case!r} must still return "
+                f"deliver_already_completed, got {action!r} — guard is not firing first"
+            )
 
 
 class TestCatchupCodeStructure:

--- a/tests/unit/test_email_bridge.py
+++ b/tests/unit/test_email_bridge.py
@@ -407,19 +407,25 @@ class TestPollImapBatchCap:
 
     @pytest.mark.asyncio
     async def test_batch_cap_limits_fetched_messages(self):
-        """When IMAP returns more than IMAP_MAX_BATCH unseen messages, only
-        IMAP_MAX_BATCH are fetched (store + fetch) and returned."""
+        """When IMAP returns more than IMAP_MAX_BATCH unseen UIDs, only
+        IMAP_MAX_BATCH are stored+fetched and returned."""
         total_unseen = IMAP_MAX_BATCH + 10
-        # Build fake message IDs as bytes (IMAP returns space-separated byte IDs)
-        fake_msg_ids = b" ".join(str(i).encode() for i in range(1, total_unseen + 1))
+        fake_uids = b" ".join(str(i).encode() for i in range(1, total_unseen + 1))
+
+        def _uid_side_effect(command, *args):
+            cmd = command.lower()
+            if cmd == "search":
+                return ("OK", [fake_uids])
+            if cmd == "store":
+                return ("OK", [])
+            if cmd == "fetch":
+                return ("OK", [(b"1", b"raw email bytes")])
+            return ("OK", [])
 
         mock_conn = MagicMock()
         mock_conn.login.return_value = ("OK", [])
         mock_conn.select.return_value = ("OK", [])
-        mock_conn.search.return_value = ("OK", [fake_msg_ids])
-        mock_conn.store.return_value = ("OK", [])
-        # conn.fetch returns a tuple with raw bytes for each message
-        mock_conn.fetch.return_value = ("OK", [(b"1", b"raw email bytes")])
+        mock_conn.uid.side_effect = _uid_side_effect
 
         imap_config = {
             "host": "imap.example.com",
@@ -435,24 +441,34 @@ class TestPollImapBatchCap:
                 "bridge.email_bridge.asyncio.to_thread",
                 side_effect=lambda fn: fn(),
             ):
-                result = await _poll_imap(imap_config)
+                result = await _poll_imap(imap_config, known_senders=["sender@example.com"])
 
-        assert mock_conn.store.call_count == IMAP_MAX_BATCH
-        assert mock_conn.fetch.call_count == IMAP_MAX_BATCH
+        store_calls = [c for c in mock_conn.uid.call_args_list if c.args[0].lower() == "store"]
+        fetch_calls = [c for c in mock_conn.uid.call_args_list if c.args[0].lower() == "fetch"]
+        assert len(store_calls) == IMAP_MAX_BATCH
+        assert len(fetch_calls) == IMAP_MAX_BATCH
         assert len(result) == IMAP_MAX_BATCH
 
     @pytest.mark.asyncio
     async def test_batch_cap_exact_boundary(self):
-        """When IMAP returns exactly IMAP_MAX_BATCH messages, all are fetched
+        """When IMAP returns exactly IMAP_MAX_BATCH UIDs, all are fetched
         (no truncation)."""
-        fake_msg_ids = b" ".join(str(i).encode() for i in range(1, IMAP_MAX_BATCH + 1))
+        fake_uids = b" ".join(str(i).encode() for i in range(1, IMAP_MAX_BATCH + 1))
+
+        def _uid_side_effect(command, *args):
+            cmd = command.lower()
+            if cmd == "search":
+                return ("OK", [fake_uids])
+            if cmd == "store":
+                return ("OK", [])
+            if cmd == "fetch":
+                return ("OK", [(b"1", b"raw email bytes")])
+            return ("OK", [])
 
         mock_conn = MagicMock()
         mock_conn.login.return_value = ("OK", [])
         mock_conn.select.return_value = ("OK", [])
-        mock_conn.search.return_value = ("OK", [fake_msg_ids])
-        mock_conn.store.return_value = ("OK", [])
-        mock_conn.fetch.return_value = ("OK", [(b"1", b"raw email bytes")])
+        mock_conn.uid.side_effect = _uid_side_effect
 
         imap_config = {
             "host": "imap.example.com",
@@ -467,10 +483,12 @@ class TestPollImapBatchCap:
                 "bridge.email_bridge.asyncio.to_thread",
                 side_effect=lambda fn: fn(),
             ):
-                result = await _poll_imap(imap_config)
+                result = await _poll_imap(imap_config, known_senders=["sender@example.com"])
 
-        assert mock_conn.store.call_count == IMAP_MAX_BATCH
-        assert mock_conn.fetch.call_count == IMAP_MAX_BATCH
+        store_calls = [c for c in mock_conn.uid.call_args_list if c.args[0].lower() == "store"]
+        fetch_calls = [c for c in mock_conn.uid.call_args_list if c.args[0].lower() == "fetch"]
+        assert len(store_calls) == IMAP_MAX_BATCH
+        assert len(fetch_calls) == IMAP_MAX_BATCH
         assert len(result) == IMAP_MAX_BATCH
 
 

--- a/tests/unit/test_enums.py
+++ b/tests/unit/test_enums.py
@@ -67,7 +67,7 @@ class TestPersonaType:
         assert PersonaType.TEAMMATE == "teammate"
 
     def test_all_members(self):
-        assert len(list(PersonaType)) == 3
+        assert len(list(PersonaType)) == 4
 
 
 class TestClassificationType:

--- a/tests/unit/test_reflections_scheduling.py
+++ b/tests/unit/test_reflections_scheduling.py
@@ -52,7 +52,18 @@ class TestInstallMechanism:
 
     def test_remote_update_no_silent_failures(self):
         """remote-update.sh must not use || true on launchctl calls, except
-        for intentional migration guards (daydream and reflections legacy unload)."""
+        for intentional migration guards and fallback-of-fallback paths.
+
+        Justified exceptions (each has a real error surface nearby):
+        - com.valor.daydream: legacy service, may not exist on all machines.
+        - REFLECTIONS_LABEL / com.valor.reflections: legacy unload,
+          same migration guard rationale.
+        - WORKER_LABEL bootout inside the kickstart-fallback block:
+          only runs after ``launchctl kickstart -k`` already failed, and the
+          subsequent ``launchctl bootstrap`` surfaces real errors via
+          ``echo "ERROR: Failed to bootstrap $WORKER_LABEL"``. Swallowing a
+          failed bootout here guards against a racy already-unloaded state.
+        """
         script = PROJECT_ROOT / "scripts" / "remote-update.sh"
         content = script.read_text()
         # Find all launchctl bootstrap/bootout lines and ensure none have || true
@@ -66,6 +77,10 @@ class TestInstallMechanism:
                     # NOTE: reflections legacy-unload bootout uses || true as a
                     # migration guard — the old service may not be loaded on all
                     # machines. This is intentional, not a silent failure swallower.
+                    continue
+                if "WORKER_LABEL" in line and "bootout" in line:
+                    # WORKER_LABEL bootout is only reached after kickstart -k
+                    # already failed; the next bootstrap surfaces real errors.
                     continue
                 assert "|| true" not in line, (
                     f"launchctl call should not swallow errors with || true: {line}"

--- a/tests/unit/test_steer_child.py
+++ b/tests/unit/test_steer_child.py
@@ -25,6 +25,7 @@ def mock_child():
     """Create a mock child Dev session."""
     child = MagicMock()
     child.agent_session_id = "child-001"
+    child.session_id = "child-001"
     child.session_type = "dev"
     child.is_pm = False
     child.is_dev = True
@@ -38,16 +39,18 @@ def mock_child():
 # Patch targets: imports happen inside functions, so patch the source modules
 _AGENT_SESSION = "models.agent_session.AgentSession"
 _PUSH_STEERING = "agent.steering.push_steering_message"
+_STEER_SESSION = "agent.agent_session_queue.steer_session"
 
 
 class TestSteerChild:
     """Tests for the steer command (--session-id + --message)."""
 
-    @patch(_PUSH_STEERING)
+    @patch(_STEER_SESSION)
     @patch(_AGENT_SESSION)
-    def test_valid_steering(self, mock_agent_session_cls, mock_push, mock_child):
+    def test_valid_steering(self, mock_agent_session_cls, mock_steer, mock_child):
         """Successful steering pushes message and exits 0."""
         mock_agent_session_cls.get_by_id.return_value = mock_child
+        mock_steer.return_value = {"success": True, "session_id": "child-001", "error": None}
 
         result = main(
             [
@@ -61,11 +64,9 @@ class TestSteerChild:
         )
 
         assert result == 0
-        mock_push.assert_called_once_with(
+        mock_steer.assert_called_once_with(
             session_id="child-001",
-            text="focus on tests",
-            sender="pm",
-            is_abort=False,
+            message="focus on tests",
         )
 
     @patch(_PUSH_STEERING)
@@ -249,11 +250,12 @@ class TestSteerChild:
 
             assert result == 1
 
-    @patch(_PUSH_STEERING)
+    @patch(_STEER_SESSION)
     @patch(_AGENT_SESSION)
-    def test_parent_id_from_env(self, mock_agent_session_cls, mock_push, mock_child):
+    def test_parent_id_from_env(self, mock_agent_session_cls, mock_steer, mock_child):
         """VALOR_SESSION_ID env var is used when --parent-id not given."""
         mock_agent_session_cls.get_by_id.return_value = mock_child
+        mock_steer.return_value = {"success": True, "session_id": "child-001", "error": None}
 
         with patch.dict("os.environ", {"VALOR_SESSION_ID": "parent-001"}):
             result = main(
@@ -266,7 +268,7 @@ class TestSteerChild:
             )
 
         assert result == 0
-        mock_push.assert_called_once()
+        mock_steer.assert_called_once()
 
     @patch(_AGENT_SESSION)
     def test_session_lookup_exception(self, mock_agent_session_cls):

--- a/tests/unit/test_update_newsyslog.py
+++ b/tests/unit/test_update_newsyslog.py
@@ -59,7 +59,7 @@ class TestCheckNewsyslog:
 
         assert status.installed is False
         assert status.needs_sudo is True
-        assert "sudo cp" in status.action_message
+        assert "sudo tee" in status.action_message
         assert str(fake_dst) in status.action_message
         assert "missing" in status.action_message
 

--- a/tests/unit/test_worker_entry.py
+++ b/tests/unit/test_worker_entry.py
@@ -327,16 +327,21 @@ class TestWorkerStartupSequence:
         )
 
     def test_cleanup_orphaned_in_agent_queue_not_bridge(self):
-        """_cleanup_orphaned_claude_processes must be defined in agent_session_queue, not bridge."""
-        aq_source = (
-            Path(__file__).parent.parent.parent / "agent" / "agent_session_queue.py"
+        """_cleanup_orphaned_claude_processes must live under agent/, not bridge/.
+
+        Post-#1023 the function was moved from agent_session_queue.py to
+        agent/session_health.py. The invariant remains the same: the bridge
+        must not own process cleanup — it's an agent-side concern.
+        """
+        health_source = (
+            Path(__file__).parent.parent.parent / "agent" / "session_health.py"
         ).read_text()
         bridge_source = (
             Path(__file__).parent.parent.parent / "bridge" / "telegram_bridge.py"
         ).read_text()
 
-        assert "def _cleanup_orphaned_claude_processes" in aq_source, (
-            "_cleanup_orphaned_claude_processes should be defined in agent/agent_session_queue.py"
+        assert "def _cleanup_orphaned_claude_processes" in health_source, (
+            "_cleanup_orphaned_claude_processes should be defined in agent/session_health.py"
         )
         assert "def _cleanup_orphaned_claude_processes" not in bridge_source, (
             "_cleanup_orphaned_claude_processes must NOT be defined in bridge/telegram_bridge.py"


### PR DESCRIPTION
## Summary

Session 3 of 5 in the parallel cleanup of GitHub issue #1041. Fixes symbol drift
across 8 clusters (D, E, G, H, M, N, O, R) — signature mismatches, stale
member counts, MagicMock sentinels, source-string greps, and install-script
error-handling assertions.

Refs #1041 (does NOT close — other sessions own the remaining clusters).

### Clusters addressed

- **D** — `test_remote_update.py`: `pop_side_effect` takes 2 args now, not 1;
  `com.valor.update` is dynamic (`${SERVICE_LABEL_PREFIX}.update`).
- **E** — `test_worker_drain.py`: force bridge mode via autouse fixture so
  `DRAIN_TIMEOUT` is honored; unique `session_id` per test so CAS re-read
  tie-break can't cross-match.
- **G** — `test_steer_child.py`: configure `MagicMock` with
  `session_id='child-001'`; switch patch target to
  `agent.agent_session_queue.steer_session` on the 2 failing cases.
- **H** — `test_enums.py`: `PersonaType` count 3 → 4;
  `test_update_newsyslog.py`: `"sudo cp"` → `"sudo tee"`.
- **M** — `test_worker_concurrency.py`: rewrite
  `test_global_ceiling_across_multiple_chat_ids` against
  `MAX_CONCURRENT_SESSIONS=8` (post-#1029); patch
  `agent.session_state._global_session_semaphore` (canonical module) in
  both semaphore tests.
- **N** — `test_email_bridge.py` (2 cases): pass `known_senders` to
  `_poll_imap`; use `conn.uid` side_effect for `search`/`store`/`fetch`
  (post-UID refactor).
- **O** — behavioral assertions replacing source-string greps
  (`test_duplicate_delivery` ×2, `test_worker_entry`,
  `test_agent_session_scheduler_kill`).
- **R** — `test_reflections_scheduling.py`: extend the intentional
  migration-guard allowlist to cover the `WORKER_LABEL` bootout inside the
  `kickstart -k` fallback block (error is only swallowed after kickstart
  already failed, and the subsequent `launchctl bootstrap` surfaces real
  errors).

## Test plan

- [x] `pytest tests/unit/test_steer_child.py tests/unit/test_email_bridge.py
  tests/unit/test_duplicate_delivery.py tests/unit/test_worker_entry.py
  tests/unit/test_agent_session_scheduler_kill.py
  tests/unit/test_reflections_scheduling.py tests/unit/test_enums.py
  tests/unit/test_update_newsyslog.py` — 150 passed.
- [x] `pytest tests/integration/test_worker_drain.py
  tests/integration/test_worker_concurrency.py` — 17 passed.
- [x] `pytest tests/integration/test_remote_update.py` (minus the unrelated
  pre-existing hang in `test_worker_checks_flag_when_queue_empty`) — 28
  passed, 2 skipped.