### PR TITLE
chore(#1019): remove stale MAX_CONCURRENT_DEV_SESSIONS from .env.example (W5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,11 +46,6 @@ USE_API_BILLING=false
 # Minimum value is 1 (enforced by the worker). Default: 8
 # MAX_CONCURRENT_SESSIONS=8
 
-# Maximum number of slugged dev sessions that can execute simultaneously.
-# Must be <= MAX_CONCURRENT_SESSIONS. Default 1 preserves sequential behavior.
-# Minimum value is 1 (enforced by the worker). Default: 1
-# MAX_CONCURRENT_DEV_SESSIONS=1
-
 # =============================================================================
 # API Keys
 # =============================================================================


### PR DESCRIPTION
## Summary

Removes a four-line stale documentation block from `.env.example` that
documents `MAX_CONCURRENT_DEV_SESSIONS` — an env var the worker no longer
reads.

## What changed

`.env.example` lines 49-52 previously described `MAX_CONCURRENT_DEV_SESSIONS`
as an opt-in dev-session concurrency cap. PR #1029 collapsed the dual-
semaphore design into a single `MAX_CONCURRENT_SESSIONS=8` cap and removed
the runtime reader, but the `.env.example` block was missed in that diff.

Without this fix, an operator setting `MAX_CONCURRENT_DEV_SESSIONS=3` in
`~/Desktop/Valor/.env` gets silent no-op behavior. This PR deletes the
stale block so the example file only documents env vars the worker
actually reads.

## Verification

| Check | Command | Result |
|-------|---------|--------|
| Stale var gone from `.env.example` | `grep -n MAX_CONCURRENT_DEV_SESSIONS .env.example` | exit 1 (no match) |
| Live var still in `.env.example` | `grep -n MAX_CONCURRENT_SESSIONS .env.example` | `47:# MAX_CONCURRENT_SESSIONS=8` |
| No live readers of stale var | `grep -rn MAX_CONCURRENT_DEV_SESSIONS agent/ worker/ config/ ui/ tests/ docs/features/` | exit 1 (no match) |
| Worker concurrency tests pass | `pytest tests/unit/test_worker_startup.py tests/integration/test_worker_concurrency.py` | 19 passed |
| Format clean | `python -m ruff format --check .` | exit 0 |

## Test Plan

- [x] `pytest tests/unit/test_worker_startup.py tests/integration/test_worker_concurrency.py -x -q` — 19/19 passing
- [x] `grep -rn MAX_CONCURRENT_DEV_SESSIONS agent/ worker/ config/ ui/ tests/ docs/features/` — no live references
- [x] `python -m ruff format --check .` — 613 files formatted, exit 0

Note: `docs/plans/worktree-parallel-sdlc.md` (status: Shipped) retains historical references to `MAX_CONCURRENT_DEV_SESSIONS` as a record of the shipped-then-reverted feature. Intentionally left untouched — Shipped plans are immutable history.

Part of #1019