### PR TITLE
fix(#1092): local dev sessions survive worker restart

### DIFF
--- a/agent/session_health.py
+++ b/agent/session_health.py
@@ -318,7 +318,9 @@ def _recover_interrupted_agent_sessions_startup() -> int:
                 finalize_session(
                     entry,
                     "abandoned",
-                    reason="startup recovery: local PM/teammate session cannot be resumed by worker",
+                    reason=(
+                        "startup recovery: local PM/teammate session cannot be resumed by worker"
+                    ),
                     skip_auto_tag=True,
                 )
                 abandoned += 1

--- a/agent/session_health.py
+++ b/agent/session_health.py
@@ -11,8 +11,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from agent.session_state import SessionHandle, _active_events, _active_sessions, _active_workers
-from config.enums import SessionType
-from models.agent_session import AgentSession
+from models.agent_session import AgentSession, SessionType
 from models.session_lifecycle import TERMINAL_STATUSES as _TERMINAL_STATUSES
 
 logger = logging.getLogger(__name__)

--- a/agent/session_health.py
+++ b/agent/session_health.py
@@ -11,6 +11,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from agent.session_state import SessionHandle, _active_events, _active_sessions, _active_workers
+from config.enums import SessionType
 from models.agent_session import AgentSession
 from models.session_lifecycle import TERMINAL_STATUSES as _TERMINAL_STATUSES
 
@@ -174,9 +175,15 @@ def _recover_interrupted_agent_sessions_startup() -> int:
     where a worker transitions a session to running, then startup recovery resets it
     back to pending -- orphaning the already-spawned SDK subprocess.
 
-    Local CLI sessions (session_id starts with "local") are never re-queued. They are
-    marked "abandoned" instead. The worker cannot deliver output for local sessions, so
-    re-queuing them would spawn a second harness competing with the interactive CLI.
+    Local CLI sessions (session_id starts with "local") are handled by session_type:
+    - PM and Teammate local sessions are marked "abandoned". A live human CLI may hold
+      the same claude_session_uuid, so resuming would spawn a second harness competing
+      with the interactive CLI at that UUID (the #986 hijack rationale).
+    - Dev local sessions are re-queued to "pending" like bridge sessions. Dev sessions
+      are worker-owned (spawned via ``valor-session create --role dev`` by the PM) with
+      no human competitor — completion flows via _handle_dev_session_completion, which
+      steers the PM and never uses a user-facing send callback (#1092).
+    - Legacy records with ``session_type=None`` fall through to the safer abandon path.
 
     Note: The timing guard (AGENT_SESSION_HEALTH_MIN_RUNNING) is the primary defense
     against the hook-reactivation race. Hook reactivation transitions running→running
@@ -184,7 +191,9 @@ def _recover_interrupted_agent_sessions_startup() -> int:
     it — but truly stale sessions (>300s old) predate any active typing activity.
 
     Status is an IndexedField, so direct mutation and save is safe.
-    Returns the number of recovered bridge sessions (local sessions are not counted).
+    Returns the combined count of recovered bridge + local-dev sessions.
+    Abandoned local PM/teammate sessions are reported separately in the summary log
+    line but are NOT included in the return value.
     """
     # Phantom guard: drop records whose fields are still Popoto Field descriptors
     # (orphan $IndexF members). Destructive path — filter MUST run before any
@@ -248,27 +257,75 @@ def _recover_interrupted_agent_sessions_startup() -> int:
 
     logger.warning("[startup-recovery] Found %d stale session(s) to process", len(stale_sessions))
 
-    count = 0
+    bridge_count = 0
+    local_dev_count = 0
     abandoned = 0
     for entry in stale_sessions:
         wk = entry.worker_key
         is_local = entry.session_id.startswith("local")  # session_id is the reliable discriminator
+        session_type = getattr(entry, "session_type", None)
 
-        if is_local:
-            # Local CLI sessions cannot be resumed by the bridge worker.
-            # Mark abandoned so the originating CLI can reclaim on next turn.
+        # Gate the dev re-queue path on explicit equality with SessionType.DEV so that:
+        # (a) legacy records with session_type=None fall through to the safer abandon path,
+        # (b) any future SessionType member (e.g., REFLECTION, WORKFLOW) also falls through
+        #     to abandon rather than being silently re-queued (#1092 Risk 2).
+        if is_local and session_type == SessionType.DEV:
+            # Local dev sessions are worker-owned — no human CLI is competing for the
+            # claude_session_uuid. Re-queue like a bridge session so the worker resumes
+            # the transcript on next pickup (#1092). CAS on expected_status="running"
+            # protects against a concurrent health-check kill that already transitioned
+            # the record away from running (same pattern as the bridge path below).
+            logger.warning(
+                "[startup-recovery] Recovering interrupted local dev session %s "
+                "(session=%s, worker=%s, msg=%.80r...)",
+                entry.agent_session_id,
+                entry.session_id,
+                wk,
+                entry.message_text or "",
+            )
+            try:
+                from models.session_lifecycle import update_session
+
+                update_session(
+                    entry.session_id,
+                    new_status="pending",
+                    fields={"priority": "high", "started_at": None},
+                    expected_status="running",
+                    reason="startup recovery: local dev session",
+                )
+                logger.info(
+                    "[startup-recovery] Recovered local dev session %s",
+                    entry.agent_session_id,
+                )
+                local_dev_count += 1
+            except Exception as e:
+                logger.warning(
+                    "[startup-recovery] Failed to recover local dev session %s, deleting: %s",
+                    entry.session_id,
+                    e,
+                )
+                try:
+                    entry.delete()
+                except Exception:
+                    pass
+        elif is_local:
+            # Local PM/teammate (or legacy session_type=None) session. A live human CLI
+            # may hold the same claude_session_uuid — resuming would produce a second
+            # harness competing at that UUID (the #986 hijack rationale).
             try:
                 from models.session_lifecycle import StatusConflictError, finalize_session
 
                 finalize_session(
                     entry,
                     "abandoned",
-                    reason="startup recovery: local session cannot be resumed by worker",
+                    reason="startup recovery: local PM/teammate session cannot be resumed by worker",
                     skip_auto_tag=True,
                 )
                 abandoned += 1
                 logger.info(
-                    "[startup-recovery] Abandoned local session %s (session_id=%s, worker_key=%s)",
+                    "[startup-recovery] Abandoned local %s session %s "
+                    "(session_id=%s, worker_key=%s)",
+                    session_type or "unknown-type",
                     entry.agent_session_id,
                     entry.session_id,
                     wk,
@@ -311,7 +368,7 @@ def _recover_interrupted_agent_sessions_startup() -> int:
                     reason="startup recovery",
                 )
                 logger.info("[startup-recovery] Recovered session %s", entry.agent_session_id)
-                count += 1
+                bridge_count += 1
             except Exception as e:
                 logger.warning(
                     "[startup-recovery] Failed to recover session %s, deleting: %s",
@@ -324,11 +381,13 @@ def _recover_interrupted_agent_sessions_startup() -> int:
                     pass
 
     logger.warning(
-        "[startup-recovery] Recovered %d bridge session(s), abandoned %d local session(s)",
-        count,
+        "[startup-recovery] Recovered %d bridge session(s), %d local dev session(s), "
+        "abandoned %d local PM/teammate session(s)",
+        bridge_count,
+        local_dev_count,
         abandoned,
     )
-    return count
+    return bridge_count + local_dev_count
 
 
 # === Agent Session Health Monitor ===

--- a/docs/features/bridge-worker-architecture.md
+++ b/docs/features/bridge-worker-architecture.md
@@ -289,12 +289,22 @@ Worker restarts (SIGTERM, crash, or explicit `./scripts/valor-service.sh worker-
 
 When the worker process is killed mid-execution, the `asyncio.CancelledError` handler does **not** finalize the session. The session remains in `running` state in Redis. On the next worker startup, step 3 of the startup sequence (`_recover_interrupted_agent_sessions_startup()`) detects stale `running` sessions and transitions them back to `pending` so they are retried by the new worker.
 
+### Local session recovery is `session_type`-aware (#1092)
+
+A session whose `session_id` starts with `local` was spawned from a local Claude Code CLI rather than the Telegram bridge. Startup recovery handles these by `session_type`:
+
+- **Local dev sessions** (`session_type == DEV`) are re-queued to `pending` just like bridge sessions. Dev sessions are worker-owned (spawned by the PM via `valor-session create --role dev`) with no human competitor holding the same `claude_session_uuid`. Completion flows through `_handle_dev_session_completion`, which steers the parent PM and never invokes a user-facing send callback — so the worker does not need to be able to deliver output to a chat. This lets long-running PM-orchestrated pipelines (build + test + review + docs + merge) survive scheduled worker restarts on skills-only machines.
+- **Local PM and Teammate sessions** continue to be abandoned. A live human CLI may hold the same `claude_session_uuid`; resuming would spawn a second harness competing at that UUID (the #986 hijack rationale).
+- **Legacy records with `session_type == None`** fall through to the abandon path — a conservative default that also catches any future `SessionType` member added without explicit handling here.
+
 ### Summary
 
 | Session state at restart | What happens |
 |--------------------------|--------------|
 | `pending` | Left untouched; new worker picks it up naturally |
-| `running` | Stays `running`; new worker startup re-queues it to `pending` |
+| `running` (bridge) | Stays `running`; new worker startup re-queues it to `pending` |
+| `running` (local `dev`) | Re-queued to `pending` (#1092); worker resumes via `claude --resume <UUID>` |
+| `running` (local `pm`/`teammate`/legacy) | Finalized as `abandoned`; human CLI may reclaim |
 | `complete` / `failed` / `killed` | Terminal — no action taken |
 
 ## Redis Communication Contract

--- a/docs/features/bridge-worker-architecture.md
+++ b/docs/features/bridge-worker-architecture.md
@@ -295,7 +295,7 @@ A session whose `session_id` starts with `local` was spawned from a local Claude
 
 - **Local dev sessions** (`session_type == DEV`) are re-queued to `pending` just like bridge sessions. Dev sessions are worker-owned (spawned by the PM via `valor-session create --role dev`) with no human competitor holding the same `claude_session_uuid`. Completion flows through `_handle_dev_session_completion`, which steers the parent PM and never invokes a user-facing send callback — so the worker does not need to be able to deliver output to a chat. This lets long-running PM-orchestrated pipelines (build + test + review + docs + merge) survive scheduled worker restarts on skills-only machines.
 - **Local PM and Teammate sessions** continue to be abandoned. A live human CLI may hold the same `claude_session_uuid`; resuming would spawn a second harness competing at that UUID (the #986 hijack rationale).
-- **Legacy records with `session_type == None`** fall through to the abandon path — a conservative default that also catches any future `SessionType` member added without explicit handling here.
+- **Pre-migration records with `session_type == None`** fall through to the abandon path — a conservative default that also catches any future `SessionType` member added without explicit handling here.
 
 ### Summary
 
@@ -304,7 +304,7 @@ A session whose `session_id` starts with `local` was spawned from a local Claude
 | `pending` | Left untouched; new worker picks it up naturally |
 | `running` (bridge) | Stays `running`; new worker startup re-queues it to `pending` |
 | `running` (local `dev`) | Re-queued to `pending` (#1092); worker resumes via `claude --resume <UUID>` |
-| `running` (local `pm`/`teammate`/legacy) | Finalized as `abandoned`; human CLI may reclaim |
+| `running` (local `pm`/`teammate`/pre-migration) | Finalized as `abandoned`; human CLI may reclaim |
 | `complete` / `failed` / `killed` | Terminal — no action taken |
 
 ## Redis Communication Contract

--- a/docs/features/pm-dev-session-architecture.md
+++ b/docs/features/pm-dev-session-architecture.md
@@ -139,6 +139,8 @@ Single Popoto model (`AgentSession`) with discriminator field. Popoto ORM does n
 - `slug` -- derives branch name, plan path, worktree
 - `issue_url`, `plan_url`, `pr_url` -- SDLC link URLs
 
+**Worker-restart persistence:** Local dev sessions (those with `session_id` starting `local`) persist across worker restarts; PM/teammate local sessions do not (issue #1092). Dev sessions are worker-owned — the PM spawned them via `valor-session create --role dev`, and no human CLI is holding the same `claude_session_uuid`, so startup recovery re-queues them to `pending` like bridge sessions. See the "Local session recovery is `session_type`-aware" section in [`bridge-worker-architecture.md`](bridge-worker-architecture.md) for the full rationale.
+
 ### Session Creation
 Sessions are created via factory methods:
 - `AgentSession.create_pm(...)` -- creates a PM session

--- a/docs/features/session-recovery-mechanisms.md
+++ b/docs/features/session-recovery-mechanisms.md
@@ -16,11 +16,11 @@ The session system has 9 mechanisms that can revive, recover, or re-enqueue sess
 |----------|-------|
 | Location | `agent/session_health.py` (re-exported from `agent/agent_session_queue.py`) |
 | Trigger | Worker process startup (`worker/__main__.py`) |
-| What it does | Resets stale `running` bridge sessions to `pending` (orphaned from previous process); abandons stale local CLI sessions |
+| What it does | Resets stale `running` bridge sessions to `pending` (orphaned from previous process); for local CLI sessions, re-queues dev sessions but abandons PM/teammate sessions |
 | Terminal safety | **Safe by query scope** -- only queries `status="running"`, never touches terminal sessions |
-| Guard | Query filter (`status="running"`) + timing guard (`AGENT_SESSION_HEALTH_MIN_RUNNING`, 300s) + local session guard |
+| Guard | Query filter (`status="running"`) + timing guard (`AGENT_SESSION_HEALTH_MIN_RUNNING`, 300s) + session_type-aware local session guard |
 | Timing guard | Sessions with `started_at` within the last 300s are skipped -- they were likely started by a worker in the current process, not orphaned from the previous one. Sessions with `started_at=None` are always recovered. Matches the same guard used by the periodic health check (mechanism 2). Added by issue #727 to fix a race where a worker picks up a session before startup recovery fires. |
-| Local session guard | Sessions with `session_id.startswith("local")` are finalized as `"abandoned"` instead of being reset to `"pending"`. The bridge worker cannot deliver output for local CLI sessions; re-queuing them would spawn a second harness (`claude --resume <uuid>`) competing with the interactive CLI that already holds the session UUID — causing garbled transcripts and duplicate tool calls. `session_id` is the reliable discriminator: `create_local()` always sets `session_id=f"local-{uuid}"`. Using `worker_key` would be unreliable (DEV sessions without a slug return `project_key` as `worker_key`). Added by issue #986. |
+| Local session guard | Sessions with `session_id.startswith("local")` are routed by `session_type`. **Dev** local sessions are re-queued to `"pending"` like bridge sessions (issue #1092): the PM spawned them via `valor-session create --role dev`, so there is no interactive CLI holding the same `claude_session_uuid` and the worker can safely resume via `claude --resume <uuid>`. **PM and Teammate** local sessions (plus pre-migration records with `session_type=None`) are finalized as `"abandoned"` — a human CLI may be holding the UUID, and resuming would spawn a second harness competing with the interactive CLI (the issue #986 hijack rationale). The `SessionType.DEV` gate uses explicit equality so any future enum member falls through to the safer abandon path. `session_id` is the reliable prefix discriminator (`create_local()` always sets `session_id=f"local-{uuid}"`). |
 
 ### 2. Health Check (`_agent_session_health_check`)
 
@@ -210,11 +210,15 @@ All mechanisms are covered by `tests/unit/test_recovery_respawn_safety.py`:
 | `test_revival_skips_completed_session_branch` | check_revival | Branches with terminal siblings filtered out |
 | `test_rejects_from_terminal_by_default` | transition_status | Default rejects all 5 terminal->non-terminal |
 | `test_allows_from_terminal_when_explicitly_permitted` | transition_status | Explicit opt-out works |
-| `test_startup_recovery_only_queries_running` | startup recovery | Only queries running, not terminal; local sessions are not re-queued |
-| `test_startup_recovery_does_not_requeue_local_session` | startup recovery | `update_session("pending")` never called for local sessions |
-| `test_startup_recovery_abandons_local_sessions` | startup recovery (local guard) | Local session finalized as "abandoned", count=0 |
+| `test_startup_recovery_only_queries_running` | startup recovery | Only queries running, not terminal |
+| `test_startup_recovery_does_not_requeue_local_pm_session` | startup recovery | `update_session("pending")` never called for local PM sessions |
+| `test_startup_recovery_requeues_local_dev_session` | startup recovery (#1092) | Local dev session re-queued to "pending" with CAS on running |
+| `test_startup_recovery_abandons_local_pm_sessions` | startup recovery (local guard) | Local PM session finalized as "abandoned", count=0 |
+| `test_startup_recovery_abandons_local_teammate_sessions` | startup recovery (local guard) | Local teammate session finalized as "abandoned", count=0 |
+| `test_startup_recovery_recovers_local_dev_sessions` | startup recovery (#1092) | Local dev session re-queued and counted as recovered |
+| `test_startup_recovery_local_dev_session_type_none_defaults_to_abandon` | startup recovery (#1092) | Pre-migration record with session_type=None falls through to abandon |
 | `test_startup_recovery_recovers_bridge_sessions` | startup recovery (local guard) | Bridge session reset to "pending", count=1 |
-| `test_startup_recovery_mixed_local_and_bridge` | startup recovery (local guard) | Mixed set: local→abandoned, bridge→pending, count=1 |
+| `test_startup_recovery_mixed_local_and_bridge` | startup recovery (local guard) | Mixed set: PM→abandoned, dev→pending, bridge→pending, count=2 |
 | `test_recent_session_skipped_by_timing_guard` | startup recovery | Sessions started <300s ago are skipped |
 | `test_old_session_recovered_by_timing_guard` | startup recovery | Sessions started >300s ago are recovered |
 | `test_none_started_at_is_recovered` | startup recovery | Sessions with no started_at are always recovered |
@@ -264,3 +268,4 @@ Additional coverage in `tests/integration/test_session_heartbeat_progress.py` (i
 - Issue #917 -- Health-check recovery finalization gap (fallback else branch)
 - Issue #986 -- Startup recovery local session guard (do not hijack interactive CLI sessions)
 - Issue #1036 -- Two-tier no-progress detector (dual heartbeat + Tier 2 reprieve gates)
+- Issue #1092 -- Session_type-aware local session recovery (local dev sessions survive worker restart; PM/teammate still abandoned)

--- a/tests/unit/test_recovery_respawn_safety.py
+++ b/tests/unit/test_recovery_respawn_safety.py
@@ -539,10 +539,7 @@ class TestStartupRecoveryLocalSessionGuard:
         # finalize_session (abandon) MUST be called for legacy records
         mock_finalize.assert_called_once()
         call_args = mock_finalize.call_args
-        assert (
-            call_args[0][1] == "abandoned"
-            or call_args[1].get("status") == "abandoned"
-        )
+        assert call_args[0][1] == "abandoned" or call_args[1].get("status") == "abandoned"
         # update_session must NOT be called for legacy records
         mock_update.assert_not_called()
 

--- a/tests/unit/test_recovery_respawn_safety.py
+++ b/tests/unit/test_recovery_respawn_safety.py
@@ -25,6 +25,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from config.enums import SessionType
 from models.session_lifecycle import TERMINAL_STATUSES, transition_status
 
 
@@ -45,6 +46,7 @@ def _mock_agent_session(**kwargs):
         "auto_continue_count": 0,
         "task_list_id": None,
         "slug": None,
+        "session_type": None,  # default None so tests must opt into a specific type
         "initial_telegram_message": {"message_text": "test", "sender_name": "user"},
     }
     defaults.update(kwargs)
@@ -310,8 +312,8 @@ class TestStartupRecoverySkipsTerminal:
         # Verify it only queried "running" status
         mock_as.query.filter.assert_called_once_with(status="running")
 
-    def test_startup_recovery_does_not_requeue_local_session(self):
-        """Startup recovery does not call update_session('pending') for local sessions."""
+    def test_startup_recovery_does_not_requeue_local_pm_session(self):
+        """Startup recovery does not call update_session('pending') for local PM sessions."""
         import time
 
         from agent.agent_session_queue import (
@@ -319,10 +321,11 @@ class TestStartupRecoverySkipsTerminal:
             _recover_interrupted_agent_sessions_startup,
         )
 
-        # Build a stale local session (started_at well before the cutoff)
+        # Build a stale local PM session (started_at well before the cutoff)
         local_session = _mock_agent_session(
             session_id="local-abc123",
             agent_session_id="agent-local-001",
+            session_type=SessionType.PM,
             started_at=time.time() - AGENT_SESSION_HEALTH_MIN_RUNNING - 600,
         )
 
@@ -337,10 +340,48 @@ class TestStartupRecoverySkipsTerminal:
 
             count = _recover_interrupted_agent_sessions_startup()
 
-        # Local sessions do not increment the count
+        # Local PM sessions do not increment the count
         assert count == 0
-        # update_session (re-queue to pending) must NOT be called for local sessions
+        # update_session (re-queue to pending) must NOT be called for local PM sessions
         mock_update.assert_not_called()
+
+    def test_startup_recovery_requeues_local_dev_session(self):
+        """Startup recovery calls update_session('pending') for local dev sessions (#1092)."""
+        import time
+
+        from agent.agent_session_queue import (
+            AGENT_SESSION_HEALTH_MIN_RUNNING,
+            _recover_interrupted_agent_sessions_startup,
+        )
+
+        # Build a stale local dev session (started_at well before the cutoff)
+        local_dev_session = _mock_agent_session(
+            session_id="local-dev-xyz",
+            agent_session_id="agent-local-dev-001",
+            session_type=SessionType.DEV,
+            started_at=time.time() - AGENT_SESSION_HEALTH_MIN_RUNNING - 600,
+        )
+
+        with (
+            patch("agent.session_health.AgentSession") as mock_as,
+            patch("agent.session_health.time") as mock_time,
+            patch("models.session_lifecycle.finalize_session") as mock_finalize,
+            patch("models.session_lifecycle.update_session") as mock_update,
+        ):
+            mock_time.time.return_value = time.time()
+            mock_as.query.filter.return_value = [local_dev_session]
+
+            count = _recover_interrupted_agent_sessions_startup()
+
+        # Local dev sessions ARE counted as recovered
+        assert count == 1
+        # update_session must be called with new_status="pending" and CAS on running
+        mock_update.assert_called_once()
+        call_kwargs = mock_update.call_args[1]
+        assert call_kwargs.get("new_status") == "pending"
+        assert call_kwargs.get("expected_status") == "running"
+        # finalize_session must NOT be called for local dev sessions
+        mock_finalize.assert_not_called()
 
 
 class TestStartupRecoveryLocalSessionGuard:
@@ -362,8 +403,8 @@ class TestStartupRecoveryLocalSessionGuard:
         defaults.update(kwargs)
         return _mock_agent_session(**defaults)
 
-    def test_startup_recovery_abandons_local_sessions(self):
-        """Local session (session_id starts with 'local') is finalized as 'abandoned'."""
+    def test_startup_recovery_abandons_local_pm_sessions(self):
+        """Local PM session (session_id starts with 'local') is finalized as 'abandoned'."""
         import time
 
         from agent.agent_session_queue import _recover_interrupted_agent_sessions_startup
@@ -371,6 +412,7 @@ class TestStartupRecoveryLocalSessionGuard:
         local_session = self._stale_session(
             session_id="local-abc123",
             agent_session_id="agent-local-001",
+            session_type=SessionType.PM,
         )
 
         with (
@@ -383,7 +425,7 @@ class TestStartupRecoveryLocalSessionGuard:
 
             count = _recover_interrupted_agent_sessions_startup()
 
-        # Count must be 0 — local sessions are not "recovered" (they are abandoned)
+        # Count must be 0 — local PM sessions are not "recovered" (they are abandoned)
         assert count == 0
         # finalize_session must have been called with "abandoned"
         mock_finalize.assert_called_once()
@@ -393,6 +435,116 @@ class TestStartupRecoveryLocalSessionGuard:
             or call_args[1].get("status") == "abandoned"
             or (len(call_args[0]) >= 2 and call_args[0][1] == "abandoned")
         )
+
+    def test_startup_recovery_abandons_local_teammate_sessions(self):
+        """Local teammate session (session_id starts with 'local') is finalized as 'abandoned'.
+
+        The #986 hijack rationale applies to teammate sessions just as it does to PM —
+        both are conversational sessions a human may be interactively driving via the
+        Claude Code CLI at the same claude_session_uuid.
+        """
+        import time
+
+        from agent.agent_session_queue import _recover_interrupted_agent_sessions_startup
+
+        local_session = self._stale_session(
+            session_id="local-teammate-abc",
+            agent_session_id="agent-local-teammate-001",
+            session_type=SessionType.TEAMMATE,
+        )
+
+        with (
+            patch("agent.session_health.AgentSession") as mock_as,
+            patch("agent.session_health.time") as mock_time,
+            patch("models.session_lifecycle.finalize_session") as mock_finalize,
+            patch("models.session_lifecycle.update_session") as mock_update,
+        ):
+            mock_time.time.return_value = time.time()
+            mock_as.query.filter.return_value = [local_session]
+
+            count = _recover_interrupted_agent_sessions_startup()
+
+        assert count == 0
+        mock_finalize.assert_called_once()
+        # update_session must NOT be called for teammate sessions
+        mock_update.assert_not_called()
+
+    def test_startup_recovery_recovers_local_dev_sessions(self):
+        """Local dev session is re-queued to pending via update_session (#1092).
+
+        Dev sessions are worker-owned (spawned by the PM via
+        `valor-session create --role dev`), so there is no human CLI competing for
+        the claude_session_uuid. Re-queue on worker restart instead of abandoning.
+        """
+        import time
+
+        from agent.agent_session_queue import _recover_interrupted_agent_sessions_startup
+
+        local_session = self._stale_session(
+            session_id="local-dev-abc",
+            agent_session_id="agent-local-dev-001",
+            session_type=SessionType.DEV,
+        )
+
+        with (
+            patch("agent.session_health.AgentSession") as mock_as,
+            patch("agent.session_health.time") as mock_time,
+            patch("models.session_lifecycle.finalize_session") as mock_finalize,
+            patch("models.session_lifecycle.update_session") as mock_update,
+        ):
+            mock_time.time.return_value = time.time()
+            mock_as.query.filter.return_value = [local_session]
+
+            count = _recover_interrupted_agent_sessions_startup()
+
+        # Local dev sessions are counted as recovered
+        assert count == 1
+        # update_session must be called with new_status="pending" and CAS on running
+        mock_update.assert_called_once()
+        call_kwargs = mock_update.call_args[1]
+        assert call_kwargs.get("new_status") == "pending"
+        assert call_kwargs.get("expected_status") == "running"
+        # finalize_session must NOT be called for local dev sessions
+        mock_finalize.assert_not_called()
+
+    def test_startup_recovery_local_dev_session_type_none_defaults_to_abandon(self):
+        """Legacy record (session_type=None) on a local session routes to abandon (#1092).
+
+        session_type is gated on explicit equality with SessionType.DEV, so legacy
+        pre-migration records with session_type=None fall through to the safer
+        abandon path — same as PM/teammate. This locks in the conservative default.
+        """
+        import time
+
+        from agent.agent_session_queue import _recover_interrupted_agent_sessions_startup
+
+        local_session = self._stale_session(
+            session_id="local-legacy-abc",
+            agent_session_id="agent-local-legacy-001",
+            session_type=None,  # legacy record
+        )
+
+        with (
+            patch("agent.session_health.AgentSession") as mock_as,
+            patch("agent.session_health.time") as mock_time,
+            patch("models.session_lifecycle.finalize_session") as mock_finalize,
+            patch("models.session_lifecycle.update_session") as mock_update,
+        ):
+            mock_time.time.return_value = time.time()
+            mock_as.query.filter.return_value = [local_session]
+
+            count = _recover_interrupted_agent_sessions_startup()
+
+        assert count == 0
+        # finalize_session (abandon) MUST be called for legacy records
+        mock_finalize.assert_called_once()
+        call_args = mock_finalize.call_args
+        assert (
+            call_args[0][1] == "abandoned"
+            or call_args[1].get("status") == "abandoned"
+        )
+        # update_session must NOT be called for legacy records
+        mock_update.assert_not_called()
 
     def test_startup_recovery_recovers_bridge_sessions(self):
         """Bridge session (session_id does NOT start with 'local') is reset to pending."""
@@ -422,14 +574,24 @@ class TestStartupRecoveryLocalSessionGuard:
         assert call_kwargs.get("new_status") == "pending"
 
     def test_startup_recovery_mixed_local_and_bridge(self):
-        """Mixed stale sessions: local → abandoned, bridge → pending, count=1."""
+        """Mixed stale sessions: local PM → abandoned, local dev → pending, bridge → pending.
+
+        Per #1092, local dev sessions are re-queued like bridge sessions. Only local
+        PM/teammate (and legacy session_type=None) sessions are abandoned.
+        """
         import time
 
         from agent.agent_session_queue import _recover_interrupted_agent_sessions_startup
 
-        local_session = self._stale_session(
-            session_id="local-abc",
-            agent_session_id="agent-local-002",
+        local_pm_session = self._stale_session(
+            session_id="local-pm-abc",
+            agent_session_id="agent-local-pm-002",
+            session_type=SessionType.PM,
+        )
+        local_dev_session = self._stale_session(
+            session_id="local-dev-def",
+            agent_session_id="agent-local-dev-002",
+            session_type=SessionType.DEV,
         )
         bridge_session = self._stale_session(
             session_id="tg-xyz",
@@ -452,20 +614,27 @@ class TestStartupRecoveryLocalSessionGuard:
             patch("models.session_lifecycle.update_session", side_effect=fake_update),
         ):
             mock_time.time.return_value = time.time()
-            mock_as.query.filter.return_value = [local_session, bridge_session]
+            mock_as.query.filter.return_value = [
+                local_pm_session,
+                local_dev_session,
+                bridge_session,
+            ]
 
             count = _recover_interrupted_agent_sessions_startup()
 
-        # Only the bridge session is counted as "recovered"
-        assert count == 1
-        # Local session finalized as abandoned
+        # Bridge + local dev both count as recovered (#1092)
+        assert count == 2
+        # Only the local PM session is finalized as abandoned
         assert len(finalize_calls) == 1
-        assert finalize_calls[0][0] is local_session
+        assert finalize_calls[0][0] is local_pm_session
         assert finalize_calls[0][1] == "abandoned"
-        # Bridge session updated to pending
-        assert len(update_calls) == 1
-        assert update_calls[0][0] == "tg-xyz"
-        assert update_calls[0][1]["new_status"] == "pending"
+        # Both local dev and bridge are re-queued to pending
+        assert len(update_calls) == 2
+        updated_session_ids = {c[0] for c in update_calls}
+        assert updated_session_ids == {"local-dev-def", "tg-xyz"}
+        for _session_id, kwargs in update_calls:
+            assert kwargs["new_status"] == "pending"
+            assert kwargs["expected_status"] == "running"
 
 
 class TestSessionWatchdogSafe:


### PR DESCRIPTION
## Summary

Split the `is_local` branch in `_recover_interrupted_agent_sessions_startup` into three paths keyed on `session_type` so local **dev** sessions survive worker restart, while local **PM/teammate** sessions (plus pre-migration records with `session_type=None`) continue to be abandoned.

## Problem

On skills-only machines (no Telegram bridge), every dev session spawned by the PM has `session_id` starting `local-`. The prior startup-recovery guard abandoned all such sessions unconditionally, losing the in-flight transcript, tool cache, and reasoning state on every worker restart — even though the dev session had no competing human CLI process writing to the same `claude_session_uuid`. Long-running PM pipelines (build + test + review + docs + merge) could never complete across a worker restart.

## Changes

### Production code (`agent/session_health.py`)
- Import `SessionType` alongside `AgentSession`.
- Split the `is_local` branch into three paths keyed on `session_type`:
  - **`SessionType.DEV`**: re-queue to `pending` with CAS on `running` (same pattern as bridge path)
  - **`SessionType.PM` / `SessionType.TEAMMATE`**: existing `finalize_session(..., "abandoned", ...)` flow preserved
  - **`session_type == None`** (pre-migration records): fall through to the abandon branch as the safer default
- The dev branch uses explicit equality with `SessionType.DEV` so future enum members (e.g. `REFLECTION`, `WORKFLOW`) also fall through to abandon.
- The summary log line now reports three counters: recovered bridge, recovered local-dev, abandoned local-PM/teammate.
- Updated the rationale comment at lines 177-187 to describe the split.
- Return value is `bridge_count + local_dev_count` (both are "sessions the worker will resume"); abandoned PM/teammate are still reported in the log line but not added to the return value.

### Tests (`tests/unit/test_recovery_respawn_safety.py`)
- `_mock_agent_session` now defaults `session_type=None` so tests must opt into a type.
- Renamed `test_startup_recovery_does_not_requeue_local_session` → `..._local_pm_session` and set `SessionType.PM`.
- Renamed `test_startup_recovery_abandons_local_sessions` → `..._local_pm_sessions` and set `SessionType.PM`.
- **New tests**:
  - `test_startup_recovery_requeues_local_dev_session` (dev → pending, CAS preserved)
  - `test_startup_recovery_recovers_local_dev_sessions` (dev → pending, `count=1`)
  - `test_startup_recovery_abandons_local_teammate_sessions` (teammate → abandoned)
  - `test_startup_recovery_local_dev_session_type_none_defaults_to_abandon` (pre-migration record → abandon)
- `test_startup_recovery_mixed_local_and_bridge` updated for the new 3-session scenario: PM abandoned, dev + bridge both re-queued, `count == 2`.

### Docs
- `docs/features/bridge-worker-architecture.md` — added "Local session recovery is `session_type`-aware (#1092)" subsection under Worker Restart Recovery and extended the summary table with local-dev and local-PM/teammate rows.
- `docs/features/pm-dev-session-architecture.md` — added a "Worker-restart persistence" callout under Dev session-specific fields.
- `docs/features/session-recovery-mechanisms.md` — updated the Startup Recovery row (what it does, local session guard wording) and the test-coverage table; added #1092 to Related Issues.

## Testing

- [x] `tests/unit/test_recovery_respawn_safety.py` (54 tests) — all pass, including 4 new #1092 tests
- [x] `tests/unit/test_session_health_phantom_guard.py` + `test_session_health_sibling_phantom_safety.py` — all pass
- [x] `python -m ruff format --check .` — passes
- [x] `python -m ruff check agent/session_health.py` — passes
- Note: `tests/unit/test_pm_session_permissions.py::test_sentry_token_injected_for_pm_session` fails on `main`; pre-existing failure unrelated to this change.

## Reproduction

**Before:** `./scripts/valor-service.sh worker-restart` with a running local dev session produces `Recovered 0 bridge session(s), abandoned 1 local session(s)`. PM's next turn re-creates the dev from scratch.

**After:** Same restart produces `Recovered 0 bridge session(s), 1 local dev session(s), abandoned 0 local PM/teammate session(s)`. Worker picks the session back up via `claude --resume <UUID>` on next scan.

## Definition of Done

- [x] Built: code implemented and working
- [x] Tested: 54 tests pass (4 new + all updated)
- [x] Reviewed: plan critique concerns embedded as Implementation Notes and addressed
- [x] Documented: 3 feature docs updated
- [x] Quality: ruff format + lint clean on touched file

Closes #1092