### PR TITLE
fix(#1090): question-aware guard in terminus Fast-Path 2

### DIFF
--- a/bridge/routing.py
+++ b/bridge/routing.py
@@ -557,6 +557,9 @@ async def classify_conversation_terminus(
     Fast-path order (critical — checked before LLM):
     1. sender_is_bot + no question → SILENT  (primary loop-break signal)
     2. acknowledgment token or very short (≤1 word) → SILENT
+       (unless thread_messages contains a question — then fall through, so a
+       human short answer like "Yes"/"No" to a Valor question is not dropped;
+       see issue #1090)
     3. standalone "?" in text (not URL query param) → RESPOND
 
     LLM (Ollama-first, Haiku fallback) handles everything else.
@@ -575,9 +578,21 @@ async def classify_conversation_terminus(
         return "SILENT"
 
     # Fast-path 2: acknowledgment token (fires AFTER sender check, never before)
+    # — but skip the check entirely when the replied-to context contained a
+    # question, so a short human reply ("Yes"/"No") to a Valor question is
+    # not silently dropped. Fast-Path 1 above already handled the bot case.
+    # NOTE (issue #1090): thread_messages is currently the single immediate
+    # replied-to message. If a future change widens this to include older
+    # Valor messages, this `?` heuristic may fire on a stale upstream question
+    # and route an unrelated short reply to RESPOND. Revisit then.
+    valor_asked_question = any(
+        _STANDALONE_QUESTION_RE.search(msg)
+        for msg in thread_messages
+        if isinstance(msg, str) and msg
+    )
     token_normalized = text_lower.rstrip("!.,").strip()
     word_count = len(text_stripped.split())
-    if token_normalized in _ACKNOWLEDGMENT_TOKENS or word_count <= 1:
+    if not valor_asked_question and (token_normalized in _ACKNOWLEDGMENT_TOKENS or word_count <= 1):
         return "SILENT"
 
     # Fast-path 3: standalone "?" → RESPOND (excludes URL query params)

--- a/docs/features/agent-reply-terminus.md
+++ b/docs/features/agent-reply-terminus.md
@@ -45,7 +45,7 @@ Fast-paths are checked before any LLM call, in this exact order:
    The primary loop-break signal. If the sender is a bot and the message contains no question, it's a loop continuation — silence it immediately.
 
 2. **Acknowledgment token or ≤1 word** → `SILENT`  
-   Checks `_ACKNOWLEDGMENT_TOKENS` set (shared with `classify_needs_response`). Fires **after** the bot check — never before — to avoid silencing human short replies.
+   Checks `_ACKNOWLEDGMENT_TOKENS` set (shared with `classify_needs_response`). Fires **after** the bot check — never before — to avoid silencing human short replies. Also skipped entirely when `thread_messages` contains a question: if Valor's prior message in the thread contained a standalone `?` (per `_STANDALONE_QUESTION_RE`), the ≤1-word check is bypassed so a human short answer like "Yes" / "No" falls through to the LLM (or the RESPOND default). See [#1090](https://github.com/tomcounsell/ai/issues/1090).
 
 3. **Standalone `?` in text** → `RESPOND`  
    Fast exit before any LLM call. Uses regex `(?<![=&\w])\?|(?<![=&])\?(?!\w+=)` to exclude URL query-string parameters like `?q=1`.

--- a/docs/features/agent-reply-terminus.md
+++ b/docs/features/agent-reply-terminus.md
@@ -1,7 +1,7 @@
 # Agent Reply Terminus Detection
 
 **Status:** Shipped  
-**Issue:** [#911](https://github.com/tomcounsell/ai/issues/911)
+**Issues:** [#911](https://github.com/tomcounsell/ai/issues/911) (initial), [#1090](https://github.com/tomcounsell/ai/issues/1090) (question-aware Fast-Path 2)
 
 ## Problem
 
@@ -104,6 +104,13 @@ Unit tests in `tests/unit/test_routing.py` cover all required scenarios:
 - `test_classify_terminus_ollama_failure_defaults_to_respond` — Ollama + Haiku both fail → RESPOND
 - `test_classify_terminus_empty_text_returns_respond` — empty text → RESPOND
 - `test_classify_terminus_bot_react_collapses_to_silent` — LLM REACT + bot sender → SILENT
+
+**Question-aware Fast-Path 2 tests** (issue [#1090](https://github.com/tomcounsell/ai/issues/1090)):
+
+- `test_classify_terminus_human_short_reply_to_valor_question_returns_respond` — human "Yes" + Valor question in thread → RESPOND
+- `test_classify_terminus_human_short_reply_no_question_still_silent` — human "Yes" + declarative thread → SILENT (regression guard)
+- `test_classify_terminus_bot_short_reply_to_valor_question_still_silent` — bot "Yes" + Valor question → SILENT via Fast-Path 1 (pins fast-path ordering)
+- `test_classify_terminus_url_query_in_thread_not_treated_as_question` — URL `?q=1` in thread_messages → SILENT (URL query strings stay excluded)
 
 ## Related
 

--- a/docs/plans/terminus_question_aware.md
+++ b/docs/plans/terminus_question_aware.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: docs_complete
 type: bug
 appetite: Small
 owner: Valor Engels

--- a/docs/plans/terminus_question_aware.md
+++ b/docs/plans/terminus_question_aware.md
@@ -227,15 +227,15 @@ No agent integration required — this is a bridge-internal change to the routin
 ## Documentation
 
 ### Feature Documentation
-- [ ] Update `docs/features/agent-reply-terminus.md` Fast-Path 2 description (currently says "Fires after the bot check — never before — to avoid silencing human short replies"). Add a sub-bullet noting that Fast-Path 2 is also skipped when the replied-to message contains a question (issue #1090). Link the issue inline.
-- [ ] Verify `docs/features/README.md` index entry for "Agent Reply Terminus Detection" is still accurate (it should be — title and scope are unchanged).
+- [x] Update `docs/features/agent-reply-terminus.md` Fast-Path 2 description (currently says "Fires after the bot check — never before — to avoid silencing human short replies"). Add a sub-bullet noting that Fast-Path 2 is also skipped when the replied-to message contains a question (issue #1090). Link the issue inline.
+- [x] Verify `docs/features/README.md` index entry for "Agent Reply Terminus Detection" is still accurate (it should be — title and scope are unchanged). Verified 2026-04-22 via `/do-docs` cascade — entry unchanged, still accurate.
 
 ### External Documentation Site
 This repo does not use Sphinx/ReadTheDocs/MkDocs. Skip.
 
 ### Inline Documentation
-- [ ] Inline comment on the new guard explaining *why* it exists (1-line reference to issue #1090) — see Solution > Technical Approach for the proposed comment text.
-- [ ] Update the docstring of `classify_conversation_terminus()` (lines 524-539) to add Fast-Path 2 to the fast-path order list with the question-aware caveat. Current docstring lists "2. acknowledgment token or very short (≤1 word) → SILENT" — append "(unless thread_messages contains a question — then fall through)".
+- [x] Inline comment on the new guard explaining *why* it exists (1-line reference to issue #1090) — see Solution > Technical Approach for the proposed comment text.
+- [x] Update the docstring of `classify_conversation_terminus()` (lines 524-539) to add Fast-Path 2 to the fast-path order list with the question-aware caveat. Current docstring lists "2. acknowledgment token or very short (≤1 word) → SILENT" — append "(unless thread_messages contains a question — then fall through)".
 
 ## Success Criteria
 

--- a/docs/plans/terminus_question_aware.md
+++ b/docs/plans/terminus_question_aware.md
@@ -147,33 +147,33 @@ The new guard lives *inside* Fast-Path 2 (after Fast-Path 1's bot check). A bot 
 ## Failure Path Test Strategy
 
 ### Exception Handling Coverage
-- [ ] No new `except` blocks are introduced. The function already has try/except around Ollama and Haiku calls (lines ~585+). Those are unchanged.
-- [ ] If `_STANDALONE_QUESTION_RE.search()` were to raise (it won't on a string input), the exception would propagate up — but `re.search` on a string is total. No new silent failure surface.
+- [x] No new `except` blocks are introduced. The function already has try/except around Ollama and Haiku calls (lines ~585+). Those are unchanged.
+- [x] If `_STANDALONE_QUESTION_RE.search()` were to raise (it won't on a string input), the exception would propagate up — but `re.search` on a string is total. No new silent failure surface.
 
 ### Empty/Invalid Input Handling
-- [ ] Empty `thread_messages` list: `any(...)` over empty iterable returns `False` → `valor_asked_question = False` → original Fast-Path 2 behavior preserved. (Test case: `test_classify_terminus_acknowledgment_token_returns_silent` already covers this and must continue to pass.)
-- [ ] `thread_messages` containing empty string: `if msg` filter skips it → same as empty list above.
-- [ ] `thread_messages` containing `None` (defensive): `if msg` filter skips it → no `re.search(None)` crash.
-- [ ] Empty reply `text`: handled by the existing guard at line 541-542, returns RESPOND. Unchanged.
+- [x] Empty `thread_messages` list: `any(...)` over empty iterable returns `False` → `valor_asked_question = False` → original Fast-Path 2 behavior preserved. (Test case: `test_classify_terminus_acknowledgment_token_returns_silent` already covers this and must continue to pass.)
+- [x] `thread_messages` containing empty string: `if msg` filter skips it → same as empty list above.
+- [x] `thread_messages` containing `None` (defensive): `if msg` filter skips it → no `re.search(None)` crash.
+- [x] Empty reply `text`: handled by the existing guard at line 541-542, returns RESPOND. Unchanged.
 
 ### Error State Rendering
-- [ ] No user-visible output. The function returns a string consumed by `should_respond_async()`. Bridge logs the terminus result at line 1038. No change to logging.
+- [x] No user-visible output. The function returns a string consumed by `should_respond_async()`. Bridge logs the terminus result at line 1038. No change to logging.
 
 ## Test Impact
 
-- [ ] `tests/unit/test_routing.py::test_classify_terminus_human_short_reply_to_valor_question_returns_respond` — ADD: new test verifying that `text="Yes"`, `thread_messages=["Should I select the Yudame workspace?"]`, `sender_is_bot=False` returns `"RESPOND"` (not `"SILENT"`).
-- [ ] `tests/unit/test_routing.py::test_classify_terminus_human_short_reply_no_question_still_silent` — ADD: regression test verifying that `text="Yes"`, `thread_messages=["Here is the report you asked for."]`, `sender_is_bot=False` returns `"SILENT"` (existing Fast-Path 2 behavior preserved).
-- [ ] `tests/unit/test_routing.py::test_classify_terminus_bot_short_reply_to_valor_question_still_silent` — ADD: regression test verifying that `text="Yes"`, `thread_messages=["Should I do X?"]`, `sender_is_bot=True` returns `"SILENT"` via Fast-Path 1 (the bot loop break must still fire even when Valor asked a question — bots don't answer questions, they loop).
-- [ ] `tests/unit/test_routing.py::test_classify_terminus_url_query_in_thread_not_treated_as_question` — ADD: edge case verifying that `text="Yes"`, `thread_messages=["See https://example.com?q=1"]`, `sender_is_bot=False` returns `"SILENT"` (URL query string `?q=1` must not count as a question, so Fast-Path 2 still fires).
-- [ ] `tests/unit/test_routing.py::test_classify_terminus_acknowledgment_token_returns_silent` (line ~113) — UNCHANGED: must continue to pass. Calls with `thread_messages=[]` so the new guard is a no-op.
-- [ ] `tests/unit/test_routing.py::test_classify_terminus_acknowledgment_fires_after_bot_check` (line ~124) — UNCHANGED: must continue to pass. Bot sender, `thread_messages=[]`, fires via Fast-Path 1.
-- [ ] `tests/unit/test_routing.py::test_classify_terminus_bot_no_question_returns_silent` — UNCHANGED: must continue to pass.
-- [ ] `tests/unit/test_routing.py::test_classify_terminus_human_question_returns_respond` — UNCHANGED: must continue to pass.
-- [ ] `tests/unit/test_routing.py::test_classify_terminus_url_with_query_param_not_respond` — UNCHANGED: must continue to pass.
-- [ ] `tests/unit/test_routing.py::test_classify_terminus_ollama_failure_defaults_to_respond` — UNCHANGED: must continue to pass.
-- [ ] `tests/unit/test_routing.py::test_classify_terminus_empty_text_returns_respond` — UNCHANGED: must continue to pass.
-- [ ] `tests/unit/test_routing.py::test_classify_terminus_bot_react_collapses_to_silent` — UNCHANGED: must continue to pass.
-- [ ] `tests/unit/test_config_driven_routing.py` (terminus mock at line 397) — UNCHANGED: mocks the classifier entirely so it is unaffected.
+- [x] `tests/unit/test_routing.py::test_classify_terminus_human_short_reply_to_valor_question_returns_respond` — ADD: new test verifying that `text="Yes"`, `thread_messages=["Should I select the Yudame workspace?"]`, `sender_is_bot=False` returns `"RESPOND"` (not `"SILENT"`).
+- [x] `tests/unit/test_routing.py::test_classify_terminus_human_short_reply_no_question_still_silent` — ADD: regression test verifying that `text="Yes"`, `thread_messages=["Here is the report you asked for."]`, `sender_is_bot=False` returns `"SILENT"` (existing Fast-Path 2 behavior preserved).
+- [x] `tests/unit/test_routing.py::test_classify_terminus_bot_short_reply_to_valor_question_still_silent` — ADD: regression test verifying that `text="Yes"`, `thread_messages=["Should I do X?"]`, `sender_is_bot=True` returns `"SILENT"` via Fast-Path 1 (the bot loop break must still fire even when Valor asked a question — bots don't answer questions, they loop).
+- [x] `tests/unit/test_routing.py::test_classify_terminus_url_query_in_thread_not_treated_as_question` — ADD: edge case verifying that `text="Yes"`, `thread_messages=["See https://example.com?q=1"]`, `sender_is_bot=False` returns `"SILENT"` (URL query string `?q=1` must not count as a question, so Fast-Path 2 still fires).
+- [x] `tests/unit/test_routing.py::test_classify_terminus_acknowledgment_token_returns_silent` (line ~113) — UNCHANGED: must continue to pass. Calls with `thread_messages=[]` so the new guard is a no-op.
+- [x] `tests/unit/test_routing.py::test_classify_terminus_acknowledgment_fires_after_bot_check` (line ~124) — UNCHANGED: must continue to pass. Bot sender, `thread_messages=[]`, fires via Fast-Path 1.
+- [x] `tests/unit/test_routing.py::test_classify_terminus_bot_no_question_returns_silent` — UNCHANGED: must continue to pass.
+- [x] `tests/unit/test_routing.py::test_classify_terminus_human_question_returns_respond` — UNCHANGED: must continue to pass.
+- [x] `tests/unit/test_routing.py::test_classify_terminus_url_with_query_param_not_respond` — UNCHANGED: must continue to pass.
+- [x] `tests/unit/test_routing.py::test_classify_terminus_ollama_failure_defaults_to_respond` — UNCHANGED: must continue to pass.
+- [x] `tests/unit/test_routing.py::test_classify_terminus_empty_text_returns_respond` — UNCHANGED: must continue to pass.
+- [x] `tests/unit/test_routing.py::test_classify_terminus_bot_react_collapses_to_silent` — UNCHANGED: must continue to pass.
+- [x] `tests/unit/test_config_driven_routing.py` (terminus mock at line 397) — UNCHANGED: mocks the classifier entirely so it is unaffected.
 
 ## Rabbit Holes
 
@@ -239,13 +239,13 @@ This repo does not use Sphinx/ReadTheDocs/MkDocs. Skip.
 
 ## Success Criteria
 
-- [ ] `classify_conversation_terminus(text="Yes", thread_messages=["Should I select the workspace?"], sender_is_bot=False)` returns `"RESPOND"` (covered by new test).
-- [ ] `classify_conversation_terminus(text="Yes", thread_messages=["Here is the file."], sender_is_bot=False)` returns `"SILENT"` (covered by new test, existing behavior preserved).
-- [ ] `classify_conversation_terminus(text="Yes", thread_messages=["Should I do X?"], sender_is_bot=True)` returns `"SILENT"` (covered by new test — bot loop break still wins via Fast-Path 1).
-- [ ] All 7 existing terminus tests in `tests/unit/test_routing.py` continue to pass.
-- [ ] `docs/features/agent-reply-terminus.md` updated to describe the question-aware guard.
-- [ ] Tests pass (`/do-test` → `pytest tests/unit/test_routing.py -q`).
-- [ ] Lint and format clean (`python -m ruff check bridge/routing.py tests/unit/test_routing.py` and `python -m ruff format bridge/routing.py tests/unit/test_routing.py`).
+- [x] `classify_conversation_terminus(text="Yes", thread_messages=["Should I select the workspace?"], sender_is_bot=False)` returns `"RESPOND"` (covered by new test).
+- [x] `classify_conversation_terminus(text="Yes", thread_messages=["Here is the file."], sender_is_bot=False)` returns `"SILENT"` (covered by new test, existing behavior preserved).
+- [x] `classify_conversation_terminus(text="Yes", thread_messages=["Should I do X?"], sender_is_bot=True)` returns `"SILENT"` (covered by new test — bot loop break still wins via Fast-Path 1).
+- [x] All 7 existing terminus tests in `tests/unit/test_routing.py` continue to pass.
+- [x] `docs/features/agent-reply-terminus.md` updated to describe the question-aware guard.
+- [x] Tests pass (`/do-test` → `pytest tests/unit/test_routing.py -q`).
+- [x] Lint and format clean (`python -m ruff check bridge/routing.py tests/unit/test_routing.py` and `python -m ruff format bridge/routing.py tests/unit/test_routing.py`).
 
 ## Team Orchestration
 

--- a/tests/unit/test_routing.py
+++ b/tests/unit/test_routing.py
@@ -191,3 +191,69 @@ async def test_classify_terminus_bot_react_collapses_to_silent(monkeypatch):
         sender_is_bot=True,
     )
     assert result == "SILENT"  # REACT must collapse to SILENT for bots
+
+
+# =============================================================================
+# Question-aware Fast-Path 2 tests (issue #1090)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_human_short_reply_to_valor_question_returns_respond(
+    monkeypatch,
+):
+    """Human "Yes" replying to a Valor question must NOT be silenced (issue #1090).
+
+    Fast-Path 2 should skip its ≤1-word check because the replied-to Valor
+    message contained a standalone ``?``. The message falls through to the LLM
+    fallback; with both Ollama and Haiku mocked unavailable, the classifier's
+    conservative default of RESPOND is returned.
+    """
+    # Force both LLM paths to fail so we hit the conservative default.
+    monkeypatch.setattr(routing, "OLLAMA_LOCAL_MODEL", "nonexistent-model-xyz")
+    monkeypatch.setattr(routing, "get_anthropic_api_key", lambda: None)
+
+    result = await classify_conversation_terminus(
+        text="Yes",
+        thread_messages=["Should I select the Yudame workspace?"],
+        sender_is_bot=False,
+    )
+    assert result == "RESPOND"
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_human_short_reply_no_question_still_silent():
+    """Regression: when the replied-to message is NOT a question, Fast-Path 2
+    still fires and a 1-word human reply is SILENT (existing behavior)."""
+    result = await classify_conversation_terminus(
+        text="Yes",
+        thread_messages=["Here is the report you asked for."],
+        sender_is_bot=False,
+    )
+    assert result == "SILENT"
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_bot_short_reply_to_valor_question_still_silent():
+    """Bot-loop suppression: a bot "Yes" reply to a Valor question is still
+    silenced via Fast-Path 1, because the reply text contains no ``?``. This
+    test pins the Fast-Path 1 → Fast-Path 2 ordering — if reordered, it fails.
+    """
+    result = await classify_conversation_terminus(
+        text="Yes",
+        thread_messages=["Should I do X?"],
+        sender_is_bot=True,
+    )
+    assert result == "SILENT"
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_url_query_in_thread_not_treated_as_question():
+    """URL query-string ``?`` in thread_messages must NOT count as a question.
+    Fast-Path 2 should still fire and SILENT the short reply."""
+    result = await classify_conversation_terminus(
+        text="Yes",
+        thread_messages=["See https://example.com?q=1"],
+        sender_is_bot=False,
+    )
+    assert result == "SILENT"


### PR DESCRIPTION
## Summary

When Valor asks a question mid-session and a human replies with a short answer (e.g. "Yes"/"No"), Fast-Path 2 of `classify_conversation_terminus()` silenced the reply before any LLM fallback or session-resume logic could see it. Sessions would stall waiting for answers that had already been given (real incident: 2026-04-21, session `tg_cuttlefish_-5295380350_9046`).

This PR adds a question-aware guard: Fast-Path 2 now consults `thread_messages` for a standalone `?` via the existing `_STANDALONE_QUESTION_RE` (same regex Fast-Paths 1 and 3 use, so URL query strings stay excluded). When Valor asked a question, the ≤1-word check is skipped and the message falls through to the LLM (or RESPOND default).

## Changes

- `bridge/routing.py` — added question-aware guard in Fast-Path 2 of `classify_conversation_terminus`, plus an issue-tagged tripwire comment for any future widening of `thread_messages`. Entries are type-checked (`isinstance(msg, str)`) so a non-string defensive value can't raise inside the genexpr.
- `tests/unit/test_routing.py` — added 4 new tests: human-short-answer-to-question → RESPOND, human short-reply-no-question → SILENT, bot short-reply to question → SILENT via Fast-Path 1, URL `?q=1` in thread → not a question (SILENT).
- `docs/features/agent-reply-terminus.md` — Fast-Path 2 description updated to describe the new question-aware bypass.

## Testing

- [x] `pytest tests/unit/test_routing.py -v` — 21/21 pass (17 existing + 4 new)
- [x] `pytest tests/unit/test_config_driven_routing.py -v` — 25/25 pass (non-regression for Teammate-persona reply path)
- [x] `pytest tests/unit/` — 4609 passed, 1 failed (unrelated pre-existing failure: `test_sentry_token_injected_for_pm_session` fails on main too)
- [x] Ruff check + format clean on touched files

## Documentation

- [x] Updated `docs/features/agent-reply-terminus.md` Fast-Path 2 section with issue link
- [x] `docs/features/README.md` verified accurate (title + scope unchanged)
- [x] Inline comment in `bridge/routing.py` references issue #1090 for future maintainers

## Definition of Done

- [x] Built: code implemented and working
- [x] Tested: all new + existing terminus tests passing, Teammate passive-listener regression test preserved
- [x] Documented: feature doc updated, inline tripwire comment added
- [x] Quality: ruff check and format pass

## Risks

- **Rhetorical/embedded `?` false positives** — accepted per Risks §1; conservative RESPOND default is intentional.
- **Single-element `thread_messages` assumption** — documented inline (issue #1090 tripwire); any future widening must revisit the guard.

Closes #1090