### PR TITLE
fix(#1098): extend worker health-check poll window to 30s

### DIFF
--- a/docs/plans/sdlc-1098.md
+++ b/docs/plans/sdlc-1098.md
@@ -1,0 +1,86 @@
+---
+status: In Progress
+type: bug
+appetite: Small
+owner: Tom Counsell
+created: 2026-04-22
+tracking: https://github.com/tomcounsell/ai/issues/1098
+---
+
+# sdlc-1098 — Extend Worker Health-Check Poll Window to 30s
+
+## Problem
+
+Every `/update` run logs a false-positive error even when the worker starts successfully:
+
+```
+ERROR: Worker not running after kickstart retry — system degraded
+```
+
+The orchestrator's kickstart-retry poll window (`scripts/update/run.py` ~line 857) was 8 iterations × 2s = 16 seconds. Under realistic conditions — launchd `ThrottleInterval: 10` delay plus worker startup (module imports, Redis verify, Popoto index rebuild, session recovery, orphan cleanup, claude smoke test) — the worker frequently needs more than 16 seconds to reach heartbeat. The result: `result.success = False` and a spurious "system degraded" log on almost every `/update` run.
+
+## Solution
+
+Minimal-scope fix, consistent with the narrow bug remit:
+
+1. `scripts/update/run.py` — extend the kickstart-retry loop from 8 iterations (16s) to 15 iterations (30s), keeping the 2s poll cadence. Update the error message to reflect the new ceiling.
+2. `scripts/valor-service.sh` `restart_worker()` — bump the post-`launchctl kickstart -k` `sleep 2` to `sleep 5` so the ad-hoc `worker-restart` command matches realistic worker startup (~5s headroom).
+3. Add an inline comment citing issue #1098 so future readers understand why the window is 30s rather than the prior 16s.
+
+No code path other than the retry window is modified. The primary 30-second first-pass poll at line 817 is unchanged. The heartbeat-write timing in `worker/__main__.py` is unchanged. No new config, no new env vars, no behavioral change when the worker legitimately fails (`result.success = False` still fires — just after a longer, realistic window).
+
+## Failure Path Test Strategy
+
+The orchestrator's service-restart path is not unit-testable (requires a live launchd session). Manual validation:
+
+- Run `/update` on a machine where the worker was previously idle — confirm no "system degraded" line in the log output
+- Kill the worker plist to simulate a genuine failure, re-run `/update`, confirm the error still surfaces correctly after the 30s window
+- Observe `tail -f logs/worker.log` during an update run to confirm heartbeat is written within the new window
+
+## Test Impact
+
+- [ ] No existing tests affected — the orchestrator's service-restart logic is not covered by unit or integration tests (it requires a live launchd environment). `tests/unit/test_worker_health_check.py` (if present) covers the in-process `_get_worker_health()` reader, not the orchestrator poll loop. Adding launchd-dependent tests is out of scope for this minimal fix (tracked by the parent plan `docs/plans/worker-kickstart-race.md`).
+
+## Rabbit Holes
+
+- **Moving heartbeat earlier in worker startup** (Angle B from #1098): Out of scope. Requires coordinating `worker_watchdog.py` and `ui/app.py` freshness thresholds. Deferred.
+- **Making the timeout env-configurable** (Angle C): Out of scope. Premature abstraction for a single call site.
+- **Restructuring the `install_worker + kickstart fallback + retry` logic**: Out of scope. Minimal fix only — do not refactor.
+
+## No-Gos (Out of Scope)
+
+- No changes to `worker/__main__.py` startup ordering
+- No changes to `monitoring/worker_watchdog.py` freshness threshold (remains 360s)
+- No changes to `com.valor.worker.plist` `ThrottleInterval`
+- No new tests (covered by parent plan `worker-kickstart-race.md` if/when launchd-integration harness lands)
+
+## Update System
+
+No update system changes required — the `/update` skill already invokes `scripts/update/run.py`; the modified poll window takes effect the next time `/update` runs. `scripts/remote-update.sh` is unchanged. No new deps, no new config files, no migration steps.
+
+## Agent Integration
+
+No agent integration required — this is a purely internal change to the update orchestrator's service-health poll loop. The bridge does not import `scripts/update/run.py`. No MCP server surface changes. No `.mcp.json` changes.
+
+## Documentation
+
+- [ ] Update `docs/features/bridge-self-healing.md` to describe the new 30s kickstart-retry poll window (currently references the old 16s window in the self-healing section if it's mentioned there — grep-confirm before editing).
+- [ ] Cross-reference from `docs/features/bridge-self-healing.md` to this plan (`docs/plans/sdlc-1098.md`) and the parent plan (`docs/plans/worker-kickstart-race.md`).
+
+## Success Criteria
+
+- [x] `scripts/update/run.py` kickstart-retry loop iterates 15 × 2s (30s total) instead of 8 × 2s (16s)
+- [x] `scripts/valor-service.sh` `restart_worker()` `sleep` increased from 2s to 5s
+- [x] Error log message reflects the new "30s kickstart retry window"
+- [x] Ruff format and check pass on modified file
+- [ ] Manual `/update` run on this machine no longer logs "system degraded" when worker is healthy (verified post-merge)
+- [ ] Genuine worker failures still surface `result.success = False` (unchanged behavior)
+
+## Step by Step Tasks
+
+1. [x] Create worktree `session/sdlc-1098` from `origin/main`
+2. [x] Edit `scripts/update/run.py`: extend retry loop from `range(8)` to `range(15)`, update comment + error message
+3. [x] Edit `scripts/valor-service.sh`: bump `sleep 2` to `sleep 5` in `restart_worker()`
+4. [x] Create this plan document
+5. [x] Run `python -m ruff format scripts/update/run.py` and `python -m ruff check scripts/update/run.py`
+6. [x] Commit + push + open PR closing #1098

--- a/scripts/update/run.py
+++ b/scripts/update/run.py
@@ -853,8 +853,16 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
                             )
                         except Exception as e:
                             log(f"launchctl kickstart failed: {e}", v, always=True)
-                        # Re-poll for 15 more seconds
-                        for _ in range(8):
+                        # Re-poll up to 30s for worker heartbeat after kickstart.
+                        # Worker startup (module imports, Redis connect, Popoto index
+                        # rebuild, session recovery, orphan cleanup, claude binary
+                        # smoke test) can take 10–20s on a loaded system; the previous
+                        # 16s retry window would race and falsely report system
+                        # degraded on every /update run. 15 iterations × 2s = 30s
+                        # ceiling provides realistic headroom while keeping a 2s
+                        # poll cadence for responsiveness when the worker comes up
+                        # quickly. See issue #1098.
+                        for _ in range(15):
                             _time.sleep(2)
                             if service.is_worker_running():
                                 worker_pid = service.get_worker_pid()
@@ -874,12 +882,13 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
                                     pass
                         if not worker_healthy:
                             log(
-                                "ERROR: Worker not running after kickstart retry — system degraded",
+                                "ERROR: Worker not running after 30s kickstart retry window — "
+                                "system degraded",
                                 v,
                                 always=True,
                             )
                             result.warnings.append(
-                                "Worker not running after install and kickstart retry"
+                                "Worker not running after install and kickstart retry (30s window)"
                             )
                             result.success = False
             else:

--- a/scripts/valor-service.sh
+++ b/scripts/valor-service.sh
@@ -673,7 +673,9 @@ restart_worker() {
 
     if is_worker_launchd_loaded; then
         launchctl kickstart -k "gui/$(id -u)/$WORKER_PLIST_NAME"
-        sleep 2
+        # Worker startup (imports, Redis, Popoto index rebuild, recovery) takes
+        # ~5s under normal conditions; wait that long before probing. See #1098.
+        sleep 5
         if is_worker_running; then
             local pid=$(get_worker_pid)
             echo "Worker restarted (PID: $pid)"


### PR DESCRIPTION
Closes #1098

## Summary
Extends the kickstart-retry poll window in `scripts/update/run.py` from 16s (8 iterations x 2s) to 30s (15 iterations x 2s). The previous window raced against realistic worker startup time — launchd `ThrottleInterval: 10s` plus module imports, Redis verify, Popoto index rebuild, session recovery, orphan cleanup, and claude smoke test — causing every `/update` run to falsely log `ERROR: Worker not running after kickstart retry — system degraded` even when the worker was healthy seconds later.

Also bumps the `sleep 2` in `scripts/valor-service.sh` `restart_worker()` to `sleep 5` so the ad-hoc `worker-restart` command aligns with the realistic ~5s startup baseline.

## Changes
- `scripts/update/run.py`: kickstart-retry loop `range(8)` -> `range(15)`, clarified comment and error message
- `scripts/valor-service.sh`: `restart_worker()` post-kickstart `sleep 2` -> `sleep 5`
- `docs/plans/sdlc-1098.md`: plan document

## What is unchanged
- Primary 30s first-pass heartbeat poll (line 817) unchanged
- Heartbeat-write timing in `worker/__main__.py` unchanged
- `monitoring/worker_watchdog.py` freshness threshold (360s) unchanged
- Genuine worker failures still surface `result.success = False` (after the new 30s window)

## Test plan
- [x] Ruff format + check clean (`python -m ruff format scripts/update/run.py && python -m ruff check scripts/update/run.py`)
- [x] Existing tests pass (`pytest tests/unit/test_worker_health_check.py tests/unit/test_update_newsyslog.py` — 11/11)
- [ ] Manual `/update` run on this machine no longer logs "system degraded" when worker is healthy
- [ ] Kill worker plist to simulate genuine failure; confirm error still surfaces after 30s window