### PR TITLE
feat(#1065): hard rule to search TG history before asking in group chats

### DIFF
--- a/agent/teammate_handler.py
+++ b/agent/teammate_handler.py
@@ -29,6 +29,11 @@ def build_teammate_instructions() -> str:
         "\n\nYou are answering an informational query directly. "
         "Do NOT spawn a Dev session or use the Agent tool.\n\n"
         "RESEARCH FIRST — before answering, gather evidence:\n"
+        "0. If the question references something that may have been shared in this chat "
+        "(a link, an article, a prior message, phrases like 'as I mentioned', 'those', "
+        "'the link I shared', or a reply-to), search the chat history FIRST: "
+        "`valor-telegram read --chat <this chat> --search <keyword> --limit 20`. "
+        "Never ask the user for information that is already in the chat history.\n"
         "1. Search source code with Grep/Glob to find relevant files and implementations\n"
         '2. Query the memory system: `python -m tools.memory_search search "relevant query"`\n'
         "3. Consult knowledge base docs in docs/features/ and docs/ directories\n"

--- a/config/personas/segments/identity.md
+++ b/config/personas/segments/identity.md
@@ -97,3 +97,4 @@ Blockers or items needing PM action are flagged.
 - Send messages that could be replaced by checking the commit history
 - Hedge or qualify statements when I am confident
 - Use marketing language or excessive politeness
+- Ask in a group chat for information that is already in the chat history — I search Telegram history first (`valor-telegram read --search`) before asking the group

--- a/config/personas/segments/tools.md
+++ b/config/personas/segments/tools.md
@@ -84,13 +84,19 @@ valor-telegram chats
 > invocation only. Never include `valor-telegram send`, `--chat`, or CLI syntax
 > in response text sent to users.
 
-**When to check history**: Use `valor-telegram read --search` when context cues suggest prior messages may be relevant:
-- "what do you think of these" / "those links I shared"
-- "as I mentioned earlier" / "like we discussed"
+**HARD RULE — Check chat history before asking in group chats**: Before asking any question in a group chat that could be answered by reading recent history, run `valor-telegram read --search` first. Failure to do so is a defect: it wastes human attention on information already visible in the chat.
+
+Trigger phrases that require a history search before responding or asking:
+- "read" / "did you read" / "have you seen"
+- "reply-to" (the user is pointing at a specific prior message)
+- "mentioned earlier" / "as I mentioned" / "like we discussed" / "as discussed"
+- "check" / "check that" / "check this out"
+- "link" / "article" / "the link I shared" / "those links"
+- "what do you think of these" / "those" / "these"
 - References to recent work without explicit details
 - Any hint that the current message relates to recent conversation
 
-When in doubt, check. The cost of an unnecessary search is low; missing context is costly.
+Default: search. The cost of an unnecessary search is low; asking the group for information already in the chat is costly and embarrassing.
 
 **Link Analysis** - Analyze URLs:
 ```python

--- a/config/personas/segments/work-patterns.md
+++ b/config/personas/segments/work-patterns.md
@@ -90,10 +90,13 @@ I do NOT escalate for:
 - "Should I update the docs for this change?" -> Yes, update them
 - "There's a typo in this file" -> Fix it
 
-**NEVER re-ask answered questions:**
+**NEVER re-ask answered questions (to humans):**
+- This rule is about not pestering humans with questions they have already answered. It is NOT about avoiding tool calls.
 - If the answer was given earlier in the conversation, use it
 - If the answer is in the codebase, read it
 - If the answer is in the docs, check there first
+- If the answer may be in Telegram chat history, search it (`valor-telegram read --search ...`) — tool-based history lookup is context review, not re-asking a human
+- Context review and tool invocation (grep, memory search, chat history search) are DISTINCT from re-asking humans — always do the context review first; never ask a human for information a tool can retrieve
 
 ### Decision Heuristic
 

--- a/docs/plans/sdlc-1065.md
+++ b/docs/plans/sdlc-1065.md
@@ -1,0 +1,86 @@
+---
+slug: sdlc-1065
+status: Building
+type: enhancement
+appetite: Small
+owner: Tom Counsell
+created: 2026-04-22
+tracking: https://github.com/tomcounsell/ai/issues/1065
+---
+
+# Hard rule to search Telegram history before asking in group chats
+
+## Problem
+
+Valor asks group chat members for information that is visible in the chat history — messages posted minutes or hours earlier that any human would find by scrolling up.
+
+Root causes, all in persona prompt content:
+
+1. `config/personas/segments/tools.md:87-93` frames the Telegram history search as advisory ("when context cues suggest"), not as a hard rule. Trigger list is incomplete.
+2. `agent/teammate_handler.py:31-35` lists code / memory / docs as the `RESEARCH FIRST` steps but never mentions Telegram history — so Teammate sessions do not search the chat before answering.
+3. `config/personas/segments/identity.md:93-100` "What I Do Not Do" does not forbid asking for info already in the chat.
+4. `config/personas/segments/work-patterns.md:93-97` has a "NEVER re-ask answered questions" rule whose intent is "don't pester humans," but its phrasing can be read as forbidding tool-based lookups too — it needs carve-out wording so tool-based history search is clearly allowed.
+
+When Valor asks "could you share that article?" five messages after it was posted, the whole room sees that it did not look. That is the conversational equivalent of asking someone to re-read a document you were just handed.
+
+## Desired Outcome
+
+Every Valor persona treats searching Telegram chat history as the default first action when a message references information that may already be in the chat. Asking a human for information that is in the chat history is a last resort, not a default.
+
+## Scope
+
+Edit these four files, nothing else:
+
+- `config/personas/segments/tools.md` — rewrite "When to check history" as a HARD RULE with group-chat framing and an exhaustive trigger list including "read, reply-to, mentioned earlier, check, link, article, as discussed."
+- `agent/teammate_handler.py` in `build_teammate_instructions()` — add Telegram history search as step 0 of RESEARCH FIRST, before code search. Frame: "If the question references something that may have been shared in this chat (link, article, prior message), search the chat history first: `valor-telegram read --chat <this chat> --search <keyword> --limit 20`. Never ask for information that is in the chat history."
+- `config/personas/segments/identity.md` — add one bullet to "What I Do Not Do": "Ask in a group chat for information that is already in the chat history."
+- `config/personas/segments/work-patterns.md` — clarify the "NEVER re-ask answered questions" block so it applies to asking humans, not to tool-based history lookup. Context review and tool invocation (grep, memory search, chat history search) are explicitly distinct from re-asking humans.
+
+## No-Gos
+
+- No new persona segments. We are editing existing ones.
+- No changes to persona loading code, only to content.
+- No tests asserting exact wording of persona segments — existing persona tests do not assert wording and must continue to pass unchanged.
+- No changes to `valor-telegram` CLI itself. The tool already supports `--search`.
+
+## Update System
+
+No update system changes required — this is a pure content edit to already-deployed persona segments and one Python string in `agent/teammate_handler.py`. The `/update` flow will pick up the changes via `git pull` + existing restart paths.
+
+## Agent Integration
+
+No new agent integration required — `valor-telegram read --search` is already available to all personas via the existing CLI. This plan makes the persona instructions tell the agent to use that existing capability more aggressively.
+
+## Failure Path Test Strategy
+
+The failure this plan addresses is behavioral, not functional: "the agent asked a human for info in the chat history." That can only be measured by manual verification in a real group-chat scenario (drop a link, reply-to the message without the link, ask Valor about it — it should search the chat instead of asking for the link back).
+
+For automated coverage, the persona-loading tests guarantee the updated segments still parse and compose into a valid system prompt.
+
+## Test Impact
+
+No existing tests assert exact wording of these persona segments — verified via `grep -R "When to check history" tests/`, `grep -R "NEVER re-ask" tests/`, `grep -R "What I Do Not Do" tests/`, and `grep -R "RESEARCH FIRST" tests/`. Persona loading tests (`tests/unit/test_persona_loading.py`, `tests/unit/test_pm_persona_guards.py`, `tests/unit/test_agent_session_scheduler_persona.py`) only assert structural properties (segments load, compose, contain required sections), not exact text — they must continue to pass unchanged.
+
+## Rabbit Holes
+
+- Do not attempt to teach the agent to parse reply-to message IDs — the existing `valor-telegram read --search` keyword approach is sufficient for the 80% case.
+- Do not try to auto-trigger history search from the bridge before the agent runs — that is a separate, larger feature.
+- Do not rewrite the "NEVER re-ask" block from scratch — just carve out the tool-lookup case.
+
+## Documentation
+
+- [ ] `config/personas/segments/tools.md` — HARD RULE rewrite of "When to check history" block
+- [ ] `agent/teammate_handler.py` — new step 0 in RESEARCH FIRST of `build_teammate_instructions()`
+- [ ] `config/personas/segments/identity.md` — new bullet in "What I Do Not Do"
+- [ ] `config/personas/segments/work-patterns.md` — clarifying carve-out on "NEVER re-ask answered questions"
+
+All four edits are the documentation for this change — the persona content IS the spec that the agent reads at runtime.
+
+## Acceptance Criteria
+
+- [ ] `tools.md` block rewritten as a mandatory rule with explicit group-chat framing and exhaustive trigger list
+- [ ] `build_teammate_instructions()` includes Telegram history search as the first research step
+- [ ] `identity.md` "What I Do Not Do" includes the no-asking-for-chat-history rule
+- [ ] `work-patterns.md` "NEVER re-ask" rule carves out tool-based history lookup
+- [ ] Persona loading tests pass unchanged
+- [ ] Ruff clean


### PR DESCRIPTION
Closes #1065.

## Summary
Updates 4 persona segments so Valor searches Telegram history before asking the group for information that is already visible in the chat.

- `config/personas/segments/tools.md` — "When to check history" becomes a HARD RULE with group-chat framing and an exhaustive trigger list (read, reply-to, mentioned earlier, check, link, article, as discussed).
- `agent/teammate_handler.py::build_teammate_instructions()` — Telegram history search is step 0 of RESEARCH FIRST, before code search.
- `config/personas/segments/identity.md` — new bullet in "What I Do Not Do": "Ask in a group chat for information that is already in the chat history."
- `config/personas/segments/work-patterns.md` — "NEVER re-ask answered questions" clarified to apply to pestering humans, not to tool-based lookups; context review (grep, memory, chat history) is distinct from re-asking.

## Test plan
- [x] Ruff clean
- [x] Persona loading tests pass (61/61) — `tests/unit/test_persona_loading.py`, `tests/unit/test_pm_persona_guards.py`, `tests/unit/test_agent_session_scheduler_persona.py`
- [ ] Manual verification: trigger a group-chat scenario where info is in history — drop a link, reply-to the message without re-sharing it, ask Valor about it; expect Valor to search the chat rather than ask the group for the link back.