### PR TITLE
refactor(#1059): centralize AsyncAnthropic client in memory_extraction.py

### DIFF
--- a/agent/memory_extraction.py
+++ b/agent/memory_extraction.py
@@ -43,6 +43,50 @@ _EXTRACTION_SDK_TIMEOUT = 30.0
 _EXTRACTION_HARD_TIMEOUT = 35.0
 
 
+async def _llm_call(
+    model: str,
+    max_tokens: int,
+    messages: list,
+) -> str:
+    """Centralized Anthropic call with hotfix #1055 event-loop safety.
+
+    Every Anthropic call site in this module routes through here so the
+    double-timeout + ``async with`` invariant is enforced in one place:
+
+      * ``anthropic.AsyncAnthropic`` inside ``async with`` for deterministic
+        httpx cleanup (no half-open sockets after shutdown).
+      * ``asyncio.wait_for(..., timeout=_EXTRACTION_HARD_TIMEOUT)`` outer
+        timer that fires even when the SDK timer doesn't (e.g. half-open TCP).
+      * ``timeout=_EXTRACTION_SDK_TIMEOUT`` SDK kwarg so the SDK raises a
+        typed ``APITimeoutError`` first for cleaner logs.
+
+    Constants are read at call time (not captured) so test monkeypatching of
+    ``_EXTRACTION_SDK_TIMEOUT`` / ``_EXTRACTION_HARD_TIMEOUT`` works (see
+    ``test_real_asyncio_wait_for_fires_with_tightened_constants``).
+
+    Returns the assistant text (``msg.content[0].text.strip()``).
+    Callers handle ``TimeoutError`` and other exceptions with site-specific
+    logging and analytics.
+    """
+    import anthropic
+
+    from utils.api_keys import get_anthropic_api_key
+
+    async with anthropic.AsyncAnthropic(
+        api_key=get_anthropic_api_key(), timeout=_EXTRACTION_SDK_TIMEOUT
+    ) as client:
+        message = await asyncio.wait_for(
+            client.messages.create(
+                model=model,
+                max_tokens=max_tokens,
+                messages=messages,
+                timeout=_EXTRACTION_SDK_TIMEOUT,
+            ),
+            timeout=_EXTRACTION_HARD_TIMEOUT,
+        )
+    return message.content[0].text.strip()
+
+
 def _record_extraction_error(
     error_class: str,
     session_id: str,
@@ -138,8 +182,6 @@ async def extract_observations_async(
         return []
 
     try:
-        import anthropic
-
         from config.models import MODEL_FAST
         from utils.api_keys import get_anthropic_api_key
 
@@ -151,26 +193,19 @@ async def extract_observations_async(
         # Truncate response to avoid token limits
         truncated = response_text[:8000]
 
-        # hotfix #1055: AsyncAnthropic + double-timeout + async with for httpx cleanup.
+        # hotfix #1055: _llm_call centralizes AsyncAnthropic + async with + double-timeout.
         # Sync anthropic.Anthropic is forbidden here — it blocks the worker event loop.
         try:
-            async with anthropic.AsyncAnthropic(
-                api_key=api_key, timeout=_EXTRACTION_SDK_TIMEOUT
-            ) as client:
-                message = await asyncio.wait_for(
-                    client.messages.create(
-                        model=MODEL_FAST,
-                        max_tokens=500,
-                        messages=[
-                            {
-                                "role": "user",
-                                "content": f"{EXTRACTION_PROMPT}\n\n---\n\n{truncated}",
-                            }
-                        ],
-                        timeout=_EXTRACTION_SDK_TIMEOUT,
-                    ),
-                    timeout=_EXTRACTION_HARD_TIMEOUT,
-                )
+            raw_text = await _llm_call(
+                model=MODEL_FAST,
+                max_tokens=500,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": f"{EXTRACTION_PROMPT}\n\n---\n\n{truncated}",
+                    }
+                ],
+            )
         except TimeoutError:
             logger.warning(
                 "[memory_extraction] Anthropic call exceeded %.1fs hard timeout (non-fatal); "
@@ -180,8 +215,6 @@ async def extract_observations_async(
             )
             _record_extraction_error("TimeoutError", session_id, project_key)
             return []
-
-        raw_text = message.content[0].text.strip()
 
         if raw_text.upper() == "NONE" or not raw_text:
             logger.debug("[memory_extraction] No novel observations found")
@@ -331,8 +364,6 @@ async def extract_post_merge_learning(
         return None
 
     try:
-        import anthropic
-
         from config.models import MODEL_FAST
         from utils.api_keys import get_anthropic_api_key
 
@@ -349,25 +380,18 @@ async def extract_post_merge_learning(
             diff_summary=(diff_summary or "")[:4000],
         )
 
-        # hotfix #1055: AsyncAnthropic + double-timeout + async with.
+        # hotfix #1055: _llm_call centralizes AsyncAnthropic + async with + double-timeout.
         # Called from .claude/hooks/hook_utils/memory_bridge.py::post_merge_extract()
         # via asyncio.run(...). The async-with + asyncio.wait_for pattern is still
         # safe under asyncio.run because both helpers are reentrant-free and
         # produce no nested loops. Guarded by
         # test_extract_post_merge_learning_runs_inside_asyncio_run.
         try:
-            async with anthropic.AsyncAnthropic(
-                api_key=api_key, timeout=_EXTRACTION_SDK_TIMEOUT
-            ) as client:
-                message = await asyncio.wait_for(
-                    client.messages.create(
-                        model=MODEL_FAST,
-                        max_tokens=200,
-                        messages=[{"role": "user", "content": prompt}],
-                        timeout=_EXTRACTION_SDK_TIMEOUT,
-                    ),
-                    timeout=_EXTRACTION_HARD_TIMEOUT,
-                )
+            raw_text = await _llm_call(
+                model=MODEL_FAST,
+                max_tokens=200,
+                messages=[{"role": "user", "content": prompt}],
+            )
         except TimeoutError:
             logger.warning(
                 "[memory_extraction] Post-merge Anthropic call exceeded %.1fs hard timeout "
@@ -376,8 +400,6 @@ async def extract_post_merge_learning(
             )
             _record_extraction_error("TimeoutError", "post-merge", project_key)
             return None
-
-        raw_text = message.content[0].text.strip()
 
         # Check if response indicates no takeaway (NONE at start, empty, or too short)
         first_line = raw_text.split("\n")[0].strip()
@@ -480,8 +502,6 @@ async def _judge_outcomes_llm(
     inside ``async with`` for deterministic httpx cleanup.
     """
     try:
-        import anthropic
-
         from config.models import MODEL_FAST
         from utils.api_keys import get_anthropic_api_key
 
@@ -502,20 +522,13 @@ async def _judge_outcomes_llm(
             response=truncated_response,
         )
 
-        # hotfix #1055: AsyncAnthropic + double-timeout + async with.
+        # hotfix #1055: _llm_call centralizes AsyncAnthropic + async with + double-timeout.
         try:
-            async with anthropic.AsyncAnthropic(
-                api_key=api_key, timeout=_EXTRACTION_SDK_TIMEOUT
-            ) as client:
-                message = await asyncio.wait_for(
-                    client.messages.create(
-                        model=MODEL_FAST,
-                        max_tokens=300,
-                        messages=[{"role": "user", "content": prompt}],
-                        timeout=_EXTRACTION_SDK_TIMEOUT,
-                    ),
-                    timeout=_EXTRACTION_HARD_TIMEOUT,
-                )
+            raw_text = await _llm_call(
+                model=MODEL_FAST,
+                max_tokens=300,
+                messages=[{"role": "user", "content": prompt}],
+            )
         except TimeoutError:
             logger.warning(
                 "[memory_extraction] Outcome judgment Anthropic call exceeded %.1fs "
@@ -525,7 +538,6 @@ async def _judge_outcomes_llm(
             _record_extraction_error("TimeoutError", "outcome-judgment", None)
             return None
 
-        raw_text = message.content[0].text.strip()
         judgments = json.loads(raw_text)
 
         if not isinstance(judgments, list):

--- a/docs/plans/sdlc-1059.md
+++ b/docs/plans/sdlc-1059.md
@@ -1,0 +1,162 @@
+# Plan: Centralize AsyncAnthropic client in memory_extraction.py (#1059)
+
+## Problem
+
+`agent/memory_extraction.py` had three near-identical inline blocks:
+
+```python
+async with anthropic.AsyncAnthropic(api_key=..., timeout=_EXTRACTION_SDK_TIMEOUT) as client:
+    message = await asyncio.wait_for(
+        client.messages.create(model=..., max_tokens=..., messages=...,
+                               timeout=_EXTRACTION_SDK_TIMEOUT),
+        timeout=_EXTRACTION_HARD_TIMEOUT,
+    )
+raw_text = message.content[0].text.strip()
+```
+
+Each site also had to remember the hotfix #1055 invariant (double-timeout +
+`async with` for httpx cleanup). Future drift risk — if a new call site were
+added and skipped the pattern, the worker event loop could wedge again
+(6-hour stall observed during #1055).
+
+The other half of issue #1059 — fire-and-forget scheduling of
+`run_post_session_extraction` — is already done in
+`agent/session_executor.py:42` (`_schedule_post_session_extraction`,
+invoked at `session_executor.py:1344`). The docstring at
+`agent/messenger.py:208-215` explicitly warns against re-introducing the
+await. Drain wiring lives at `worker/__main__.py:427-429`. That scope is
+out of bounds here.
+
+## Scope
+
+Only the DRY refactor inside `agent/memory_extraction.py`.
+
+Introduce a module-private async helper `_llm_call(model, max_tokens,
+messages) -> str` that encapsulates:
+
+- `anthropic.AsyncAnthropic(...)` inside `async with` for deterministic
+  httpx cleanup (invariant per module docstring, hotfix #1055).
+- `asyncio.wait_for(..., timeout=_EXTRACTION_HARD_TIMEOUT)` outer timer.
+- SDK-level `timeout=_EXTRACTION_SDK_TIMEOUT` kwarg.
+- Returns `message.content[0].text.strip()`.
+
+The helper reads the timeout module constants at call time (not capture)
+so `test_real_asyncio_wait_for_fires_with_tightened_constants` keeps
+working under `patch.object(ext, "_EXTRACTION_SDK_TIMEOUT", 0.05)`.
+
+Callers still handle `TimeoutError` at each site because each has
+site-specific log strings and `_record_extraction_error(...)` args
+(`session_id`, `"post-merge"`, `"outcome-judgment"`).
+
+### Deviation from issue spec
+
+The issue's prescribed helper used a single `_LLM_TIMEOUT = 30` and
+constructed `AsyncAnthropic(...)` without `async with`. Following that
+literally would:
+
+1. Drop the `async with` contract → httpx cleanup regresses (hotfix #1055
+   root cause).
+2. Collapse the double-timeout into a single `asyncio.wait_for` → the
+   test `test_real_asyncio_wait_for_fires_with_tightened_constants` and
+   `test_sdk_api_timeout_caught_and_logged` (which assumes both timers
+   are wired) would fail.
+
+The actual DRY win is centralizing the *pattern*, not weakening it. This
+plan keeps the double-timeout + `async with` and centralizes them once.
+
+## Files Changed
+
+- `agent/memory_extraction.py` — add `_llm_call` helper, replace three
+  inline call sites with `await _llm_call(...)`.
+
+## No-Gos
+
+- Do NOT touch `agent/messenger.py` (fire-and-forget already landed).
+- Do NOT touch `agent/session_executor.py` (canonical tracked-task
+  pattern protected by review-guard).
+- Do NOT touch
+  `tests/unit/test_session_executor_extraction_decoupling.py` (review
+  invariants).
+- Do NOT widen the refactor to `config/`, `utils/`, `reflections/`, or
+  `.claude/hooks/...` AsyncAnthropic sites — those are tracked separately
+  in #1111.
+- Do NOT remove the module-level `_EXTRACTION_SDK_TIMEOUT` /
+  `_EXTRACTION_HARD_TIMEOUT` constants — the review-guard test
+  monkeypatches them via `patch.object`.
+
+## Update System
+
+No update system changes required — this is a purely internal Python
+refactor of one module. No new deps, config files, or migrations.
+
+## Agent Integration
+
+No agent integration required — `memory_extraction.py` is invoked
+internally by the worker via `run_post_session_extraction` (called from
+`session_executor._schedule_post_session_extraction`) and by the
+`.claude/hooks/hook_utils/memory_bridge.py::post_merge_extract()` hook
+via `asyncio.run(...)`. Neither entry point's signature changes; the
+guard test `test_extract_post_merge_learning_runs_inside_asyncio_run`
+continues to pass, proving the hook path still works.
+
+## Failure Path Test Strategy
+
+Existing tests already cover every failure path the refactor could break:
+
+- `test_hard_timeout_caught_and_logged_extract_observations` —
+  `asyncio.wait_for` timeout → `TimeoutError` branch in call site.
+- `test_hard_timeout_caught_and_logged_post_merge_learning` — same, for
+  post-merge site.
+- `test_hard_timeout_caught_and_logged_detect_outcomes` — same, for
+  outcome-judgment site.
+- `test_real_asyncio_wait_for_fires_with_tightened_constants` — real
+  `asyncio.wait_for` against a cooperatively-hung mock with tightened
+  constants, catches any regression that silently drops the
+  `wait_for` wrapper.
+- `test_sdk_api_timeout_caught_and_logged` — `APITimeoutError` raised by
+  `messages.create` propagates to outer `except Exception` and records
+  the right analytics counter.
+- `test_no_sync_anthropic_client_grep_canary` — grep canary blocks any
+  re-introduction of sync `anthropic.Anthropic(`.
+- `test_extract_post_merge_learning_runs_inside_asyncio_run` — guards
+  the `.claude` hook path where the function runs under `asyncio.run()`
+  in a subprocess.
+
+All seven must continue to pass after the refactor.
+
+## Test Impact
+
+- `tests/unit/test_memory_extraction.py` (69 tests) must all continue to
+  pass — refactor is behavior-preserving. Tests patch
+  `anthropic.AsyncAnthropic` at module level; `_llm_call` still imports
+  `anthropic` internally so the existing patch path works unchanged.
+- `tests/unit/test_session_executor_extraction_decoupling.py` (6 tests)
+  must continue to pass — the fire-and-forget invariants live in
+  `session_executor.py` which is out of scope.
+
+No tests need UPDATE, DELETE, or REPLACE — refactor is strictly
+behavior-preserving. The three existing `test_hard_timeout_caught_and_logged_*`
+cases and `test_real_asyncio_wait_for_fires_with_tightened_constants`
+continue to serve as the review-guard for the centralized helper.
+
+## Rabbit Holes
+
+- Expanding to other AsyncAnthropic sites across the repo (`config/`,
+  `reflections/`, `.claude/hooks/hook_utils/...`) — tracked separately
+  in #1111, out of scope here.
+- Changing the double-timeout to a single timeout — rejected, undoes
+  hotfix #1055.
+- Changing `extract_post_merge_learning` return shape or caller surface
+  — out of scope.
+
+## Documentation
+
+- [x] Inline module docstring in `agent/memory_extraction.py` already
+  describes the event-loop safety invariant. The new `_llm_call` helper
+  carries a docstring explaining why constants are read at call time
+  (for test monkeypatching) and why callers still handle `TimeoutError`
+  locally (site-specific log strings + analytics args).
+- No separate `docs/features/*.md` update needed — this is an internal
+  refactor with no user-visible behavior change. The subconscious-memory
+  feature doc (`docs/features/subconscious-memory.md`) does not describe
+  the Anthropic client internals, so no cascade update is required.


### PR DESCRIPTION
Closes #1059.

## Summary
- Adds async helper `_llm_call(model, max_tokens, messages)` in `agent/memory_extraction.py` that encapsulates the hotfix #1055 invariant (AsyncAnthropic inside `async with` + double timeout: SDK kwarg + `asyncio.wait_for`).
- Replaces three inline AsyncAnthropic + `wait_for` blocks in `extract_observations_async`, `extract_post_merge_learning`, and `_judge_outcomes_llm` with a single call.
- Helper reads `_EXTRACTION_SDK_TIMEOUT` / `_EXTRACTION_HARD_TIMEOUT` at call time so review-guard monkeypatching keeps working.
- Callers still handle `TimeoutError` locally — each site has distinct log strings and analytics args.

## Scope note
Issue #1059's fire-and-forget half is already done in `agent/session_executor.py:42` (`_schedule_post_session_extraction`, invoked at `session_executor.py:1344`) with drain wiring at `worker/__main__.py:427-429`. The docstring at `agent/messenger.py:208-215` warns against re-introducing the await. Scope here is only the DRY refactor inside `memory_extraction.py`. Separate issue #1111 tracks the other cross-module AsyncAnthropic sites that are out of scope here.

## Deviation from issue spec
The issue prescribed a simpler helper with a single `_LLM_TIMEOUT = 30` and no `async with`. Following that literally would (1) drop the httpx-cleanup contract and (2) collapse the double-timeout — both would regress hotfix #1055 and fail the existing review-guard tests (`test_real_asyncio_wait_for_fires_with_tightened_constants`, `test_sdk_api_timeout_caught_and_logged`). The DRY win is centralizing the pattern, not weakening it.

## Test plan
- [x] `tests/unit/test_memory_extraction.py` (69 tests) pass
- [x] `tests/unit/test_session_executor_extraction_decoupling.py` (6 tests) pass
- [x] `test_no_sync_anthropic_client_grep_canary` passes (no sync `anthropic.Anthropic(` in module)
- [x] `test_real_asyncio_wait_for_fires_with_tightened_constants` passes (real `asyncio.wait_for` still wired)
- [x] `test_extract_post_merge_learning_runs_inside_asyncio_run` passes (`.claude` hook subprocess path intact)
- [x] Ruff format + check clean on `agent/memory_extraction.py`