### PR TITLE
chore(#1073): drop delivery fields + remove MESSAGE_DRAFTER_IN_HANDLER flag

### DIFF
--- a/agent/output_handler.py
+++ b/agent/output_handler.py
@@ -153,31 +153,6 @@ class LoggingOutputHandler:
         logger.info(f"[worker] Reaction: chat={chat_id} msg={msg_id} emoji={emoji}")
 
 
-def _read_drafter_in_handler_flag() -> bool:
-    """Read MESSAGE_DRAFTER_IN_HANDLER flag once, defaulting to true.
-
-    Per plan docs/plans/message-drafter.md Race 3: the flag is a startup-config,
-    not a runtime-config. Reading once at handler __init__ time keeps the flag
-    sticky across the lifetime of the handler even if an operator flips it
-    mid-session.
-
-    Resolution order: environment variable (for quick rollback via
-    ``~/Desktop/Valor/.env``), then ``config.settings.FeatureSettings``
-    (canonical default = True). Accepts "0", "false", "no", "off"
-    (case-insensitive) as disable.
-    """
-    env_val = os.environ.get("MESSAGE_DRAFTER_IN_HANDLER")
-    if env_val is not None:
-        return env_val.strip().lower() not in {"0", "false", "no", "off"}
-    try:
-        from config.settings import Settings
-
-        return bool(Settings().features.message_drafter_in_handler)
-    except Exception:
-        # Settings load failed (e.g. .env missing during tests) — fail safe True.
-        return True
-
-
 class TelegramRelayOutputHandler:
     """Route agent output to the Redis outbox for Telegram delivery.
 
@@ -185,12 +160,13 @@ class TelegramRelayOutputHandler:
     format as ``tools/send_telegram.py``.  The bridge relay
     (``bridge/telegram_relay.py``) polls these keys and delivers via Telethon.
 
-    When ``MESSAGE_DRAFTER_IN_HANDLER`` is true (default), every ``send()``
-    invocation routes through ``bridge.message_drafter.draft_message`` before
-    the payload is written to Redis. This closes the worker-bypass gap where
-    worker-executed PM sessions previously wrote raw text straight to the
-    outbox, producing `MessageTooLongError` on content >4096 chars
-    (see docs/plans/message-drafter.md §Problem, evidence §4–§7).
+    Every ``send()`` invocation routes through
+    ``bridge.message_drafter.draft_message`` before the payload is written to
+    Redis. This closes the worker-bypass gap where worker-executed PM sessions
+    previously wrote raw text straight to the outbox, producing
+    ``MessageTooLongError`` on content >4096 chars (see
+    docs/plans/completed/message-drafter.md §Problem). Drafter errors fall
+    through to raw-text delivery via the inner ``try/except`` block.
 
     An optional *file_handler* enables dual-write so output is also persisted
     to the local file log for debugging and audit. Redis errors are caught and
@@ -208,9 +184,6 @@ class TelegramRelayOutputHandler:
         self._redis_url = redis_url or os.environ.get("REDIS_URL", "redis://localhost:6379/0")
         self._file_handler = file_handler
         self._redis = None  # Lazy connection
-        # Read the drafter flag ONCE at init (Race 3 in the plan). Flipping the
-        # env var mid-session does not affect an already-constructed handler.
-        self._drafter_enabled = _read_drafter_in_handler_flag()
 
     def _get_redis(self):
         """Return a Redis connection, creating one lazily on first use."""
@@ -252,54 +225,52 @@ class TelegramRelayOutputHandler:
         delivery_text = text
         file_paths: list[str] | None = None
         steering_deferred = False
-        if self._drafter_enabled:
-            try:
-                from bridge.message_drafter import draft_message
+        try:
+            from bridge.message_drafter import draft_message
 
-                draft = await draft_message(
-                    text,
-                    session=session,
-                    medium="telegram",
-                )
-                # If the drafter produced a drafted result, use its text. When
-                # was_drafted is False (short output or empty), keep the original
-                # raw text (drafter returns it verbatim in that case).
-                if draft.text:
-                    delivery_text = draft.text
-                if draft.full_output_file is not None:
-                    file_paths = [str(draft.full_output_file)]
+            draft = await draft_message(
+                text,
+                session=session,
+                medium="telegram",
+            )
+            # If the drafter produced a drafted result, use its text. When
+            # was_drafted is False (short output or empty), keep the original
+            # raw text (drafter returns it verbatim in that case).
+            if draft.text:
+                delivery_text = draft.text
+            if draft.full_output_file is not None:
+                file_paths = [str(draft.full_output_file)]
 
-                # ── Self-draft fallback via session steering ──
-                # When all drafter backends fail (needs_self_draft=True), inject
-                # a steering message asking the agent to self-draft. This
-                # mirrors the pre-consolidation behavior from the deleted
-                # bridge/response.py::send_response_with_files. Silent failure:
-                # any error here MUST NOT block delivery.
-                if getattr(draft, "needs_self_draft", False):
-                    steering_deferred = self._inject_self_draft_steering(session)
-                    if not steering_deferred:
-                        # Steering unavailable or failed — apply narration gate
-                        # on the original text as a last resort. Substitutes the
-                        # NARRATION_FALLBACK_MESSAGE when the raw text is pure
-                        # process narration with no substantive content.
-                        delivery_text = self._apply_narration_fallback(text)
+            # ── Self-draft fallback via session steering ──
+            # When all drafter backends fail (needs_self_draft=True), inject
+            # a steering message asking the agent to self-draft. This
+            # mirrors the pre-consolidation behavior from the deleted
+            # bridge/response.py::send_response_with_files. Silent failure:
+            # any error here MUST NOT block delivery.
+            if getattr(draft, "needs_self_draft", False):
+                steering_deferred = self._inject_self_draft_steering(session)
+                if not steering_deferred:
+                    # Steering unavailable or failed — apply narration gate
+                    # on the original text as a last resort. Substitutes the
+                    # NARRATION_FALLBACK_MESSAGE when the raw text is pure
+                    # process narration with no substantive content.
+                    delivery_text = self._apply_narration_fallback(text)
 
-                # ── Persist routing fields to session ──
-                # When the drafter succeeds, write context_summary and
-                # expectations back to the AgentSession. bridge/session_router.py
-                # and bridge/telegram_bridge.py still read session.expectations
-                # from the outbound path. Silent failure.
-                if session is not None and getattr(draft, "was_drafted", False):
-                    self._persist_routing_fields(session, draft)
-            except Exception as e:
-                # Drafter failure MUST NOT block delivery. Fall back to raw text;
-                # the relay length guard (bridge/telegram_relay.py) catches any
-                # oversize payloads as a last line of defense.
-                logger.warning(
-                    "Drafter failed in TelegramRelayOutputHandler.send (%s); "
-                    "falling back to raw text",
-                    e,
-                )
+            # ── Persist routing fields to session ──
+            # When the drafter succeeds, write context_summary and
+            # expectations back to the AgentSession. bridge/session_router.py
+            # and bridge/telegram_bridge.py still read session.expectations
+            # from the outbound path. Silent failure.
+            if session is not None and getattr(draft, "was_drafted", False):
+                self._persist_routing_fields(session, draft)
+        except Exception as e:
+            # Drafter failure MUST NOT block delivery. Fall back to raw text;
+            # the relay length guard (bridge/telegram_relay.py) catches any
+            # oversize payloads as a last line of defense.
+            logger.warning(
+                "Drafter failed in TelegramRelayOutputHandler.send (%s); falling back to raw text",
+                e,
+            )
 
         # If steering was deferred, the agent will self-draft on the next turn.
         # Skip the outbox write but still dual-write to file for audit.

--- a/bridge/email_bridge.py
+++ b/bridge/email_bridge.py
@@ -459,13 +459,9 @@ class EmailOutputHandler:
         smtp_config: dict | None = None,
         redis_url: str | None = None,
     ):
-        from agent.output_handler import _read_drafter_in_handler_flag
-
         self._smtp_config = smtp_config or _get_smtp_config()
         self._redis_url = redis_url or os.environ.get("REDIS_URL", "redis://localhost:6379/0")
         self._redis = None
-        # Read drafter flag once per Race 3 — mirrors TelegramRelayOutputHandler.
-        self._drafter_enabled = _read_drafter_in_handler_flag()
 
     def _get_redis(self):
         if self._redis is None:
@@ -531,12 +527,11 @@ class EmailOutputHandler:
     ) -> None:
         """Send agent output as an SMTP reply to the originating email.
 
-        When ``MESSAGE_DRAFTER_IN_HANDLER`` is true (default), the text is
-        routed through ``bridge.message_drafter.draft_message`` with
+        Text is routed through ``bridge.message_drafter.draft_message`` with
         ``medium="email"`` before being wrapped as MIME. This is the same
-        plumbing that the Telegram handler uses — per-medium format rules
-        will eventually live in the drafter (no markdown on the wire for
-        email). See docs/plans/message-drafter.md §Part C.
+        plumbing the Telegram handler uses — per-medium format rules live in
+        the drafter (no markdown on the wire for email). See
+        docs/plans/completed/message-drafter.md §Part C.
 
         Args:
             chat_id: The sender's email address (used as the reply-to address).
@@ -554,18 +549,17 @@ class EmailOutputHandler:
             extra = getattr(session, "extra_context", None) or {}
             session_id = getattr(session, "session_id", None)
 
-        # Drafter-at-the-handler (task 7 in plan). Fail open: any exception in
-        # the drafter must not block the email send.
+        # Drafter-at-the-handler. Fail open: any exception in the drafter must
+        # not block the email send.
         body_text = text
-        if self._drafter_enabled:
-            try:
-                from bridge.message_drafter import draft_message
+        try:
+            from bridge.message_drafter import draft_message
 
-                draft = await draft_message(text, session=session, medium="email")
-                if draft.text:
-                    body_text = draft.text
-            except Exception as e:
-                logger.warning("[email] Drafter failed, falling back to raw text: %s", e)
+            draft = await draft_message(text, session=session, medium="email")
+            if draft.text:
+                body_text = draft.text
+        except Exception as e:
+            logger.warning("[email] Drafter failed, falling back to raw text: %s", e)
 
         original_message_id = extra.get("email_message_id", "")
         original_subject = extra.get("email_subject", "")

--- a/config/settings.py
+++ b/config/settings.py
@@ -176,23 +176,11 @@ class ModelSettings(BaseModel):
 
 
 class FeatureSettings(BaseModel):
-    """Feature-flag configuration for optional behaviours.
+    """Structural placeholder for future feature flags.
 
-    These are startup-config flags (read once at process start), not
-    runtime-toggleable. Default values represent the desired end state;
-    flags exist as a safety net for quick rollback when a feature ships.
+    All flags are startup-config (read once at process start); default values
+    should represent the desired end state, not legacy behavior.
     """
-
-    message_drafter_in_handler: bool = Field(
-        default=True,
-        description=(
-            "Route OutputHandler.send() invocations through "
-            "bridge.message_drafter.draft_message before the payload reaches "
-            "the wire. When True (default), the worker-side send_cb path is "
-            "drafter-compliant on every medium. See docs/plans/message-drafter.md "
-            "§Part C. Flip to False only for emergency rollback."
-        ),
-    )
 
 
 class PathSettings(BaseModel):

--- a/docs/features/agent-message-delivery.md
+++ b/docs/features/agent-message-delivery.md
@@ -45,23 +45,19 @@ Skipped for: subagent sessions, programmatic sessions, local Claude Code session
 
 Simple heuristic: if the agent's output is short (<500 chars) and contains promise-like patterns ("I started...", "Let me check...", "I'm going to..."), the review prompt suggests CONTINUE. This is a suggestion, not forced — the agent decides.
 
-## Delivery Execution (`bridge/response.py`)
+## Delivery Execution (tool-call path)
 
-Before the drafter runs, `send_response_with_files()` checks `session.delivery_action`:
+Post-#1072, the stop hook no longer writes delivery fields to the AgentSession. Instead, the agent acts on its delivery choice by calling a tool directly during the second stop:
 
-| `delivery_action` | Behavior |
-|-------------------|----------|
-| `"send"` | Send `delivery_text` (or filtered response) via Markdown, skip drafter |
-| `"react"` | Set `delivery_emoji` as reaction on the original message, send no text |
-| `"silent"` | Do nothing — no text, no emoji |
-| `None` | Fall through to existing drafter path (backward compatible) |
+| Agent choice | Action |
+|--------------|--------|
+| `SEND` | Call `tools/send_message.py` with the drafted text — payload flows through `TelegramRelayOutputHandler.send`, which always routes through `bridge.message_drafter.draft_message` before the outbox write |
+| `EDIT: <text>` | Same as `SEND` but with the agent's revised text |
+| `REACT: <emoji>` | Call `tools/react_with_emoji.py` with the chosen emoji — no text is sent |
+| `SILENT` | Do nothing — no tool calls, session completes without output |
+| `CONTINUE` | Resume working; the hook does not stop the agent |
 
-## AgentSession Fields (`models/agent_session.py`)
-
-Three nullable fields store the agent's delivery decision:
-- `delivery_action` — "send", "react", "silent", or None
-- `delivery_text` — final message text (for send/edit path)
-- `delivery_emoji` — emoji for react-only path
+The canonical drafter entry point is `TelegramRelayOutputHandler.send` (for Telegram) and `EmailOutputHandler.send` (for email). Both run the drafter unconditionally, with a `try/except` fallback to raw text on drafter failure. See [message-drafter.md](message-drafter.md) for drafter details.
 
 ## Classification Context (`agent/sdk_client.py`)
 

--- a/docs/features/bridge-worker-architecture.md
+++ b/docs/features/bridge-worker-architecture.md
@@ -35,11 +35,10 @@ The worker uses `TelegramRelayOutputHandler` to deliver session output to Telegr
 ### Output Handler Chain
 
 ```
-Stop hook fires (agent/hooks/stop.py)
-    ↓ writes delivery_action, delivery_text, delivery_emoji to AgentSession
-send_to_chat() (agent_session_queue.py)
-    ↓ reads delivery fields, formats message, calls send_cb()
+Agent calls tools/send_message.py or tools/react_with_emoji.py
+    ↓ invokes OutputHandler.send() / OutputHandler.react()
 TelegramRelayOutputHandler.send() (agent/output_handler.py)
+    ↓ runs bridge.message_drafter.draft_message (per-medium formatting, length guard)
     ↓ writes JSON payload to Redis
     ↓ also writes to FileOutputHandler (dual-write for audit/fallback)
 Redis key: telegram:outbox:{session_id}

--- a/docs/features/email-bridge.md
+++ b/docs/features/email-bridge.md
@@ -70,7 +70,7 @@ Per-medium rules for email today:
 - **No HTML / multipart bodies.** `text/plain` MIME only — see the drafter's No-Gos.
 - **Reactions are no-ops.** `EmailOutputHandler.react()` returns early (there is no emoji-reaction analog for SMTP).
 
-**Feature flag: `MESSAGE_DRAFTER_IN_HANDLER`** (default `true`). Set to `false` in `~/Desktop/Valor/.env` and restart the worker to revert to raw-text pass-through; the drafter is skipped and the agent's text is wrapped as MIME verbatim. The flag is a temporary rollback safety net and is read once at handler `__init__` (not per-send).
+The drafter runs on every email send — there is no feature flag.
 
 **Fail-open.** If `draft_message` raises, the handler falls back to the raw text — email delivery is never blocked by a drafter failure.
 

--- a/docs/features/message-drafter.md
+++ b/docs/features/message-drafter.md
@@ -78,7 +78,7 @@ The goal is to bound per-message latency on brief replies. See Risk 1 in `docs/p
 
 ## Drafter-at-the-handler (the critical fix)
 
-`agent/output_handler.py::TelegramRelayOutputHandler.send` reads the `MESSAGE_DRAFTER_IN_HANDLER` env var once at `__init__` (default `true`; accepts `0`/`false`/`no`/`off` to disable). When enabled:
+`agent/output_handler.py::TelegramRelayOutputHandler.send` always routes text through the drafter. On every call:
 
 1. Before writing to Redis, the handler calls `await draft_message(text, session=session, medium="telegram")`.
 2. If the draft has `full_output_file`, the outbox payload grows a `file_paths=[…]` entry — the relay already handles file sends.
@@ -108,14 +108,6 @@ This is **defense-in-depth**. The primary fix is the drafter-at-the-handler wiri
 - **No persona-specific drafter skips.** Medium and persona stay orthogonal.
 - **No retry loops on drafter failure.** One attempt, one fallback path.
 - **No Telegraph (telegra.ph) integration.** `.txt` attachment is the long-form delivery mechanism.
-
-## Feature flag: `MESSAGE_DRAFTER_IN_HANDLER`
-
-Default: `true`. Read once at handler `__init__` (not per-send) per Race 3 in the plan.
-
-**Rollback**: set `MESSAGE_DRAFTER_IN_HANDLER=false` in `~/Desktop/Valor/.env`, restart bridge + worker (`./scripts/valor-service.sh restart`). Output handlers revert to the raw-text pass-through behavior. The relay length guard still applies.
-
-The flag is a temporary safety net. It will be removed two weeks post-merge if no rollbacks occur (tracked in the file-chore follow-up issue).
 
 ## Format rules by medium
 

--- a/docs/plans/sdlc-1073.md
+++ b/docs/plans/sdlc-1073.md
@@ -129,25 +129,25 @@ Steps:
 ## Failure Path Test Strategy
 
 ### Exception Handling Coverage
-- [ ] The `try: ... except Exception:` block in `TelegramRelayOutputHandler.send` (currently L256-302, the drafter call block) is preserved verbatim. Existing tests in `tests/unit/test_output_handler.py` that assert drafter failure falls back to raw text must still pass after the flag gate is removed. Verify during build.
-- [ ] The `try: ... except Exception:` block in `EmailOutputHandler.send` (currently L307-314) is preserved verbatim.
-- [ ] No new exception handlers are introduced.
+- [x] The `try: ... except Exception:` block in `TelegramRelayOutputHandler.send` (currently L256-302, the drafter call block) is preserved verbatim. Existing tests in `tests/unit/test_output_handler.py` that assert drafter failure falls back to raw text must still pass after the flag gate is removed. Verify during build.
+- [x] The `try: ... except Exception:` block in `EmailOutputHandler.send` (currently L307-314) is preserved verbatim.
+- [x] No new exception handlers are introduced.
 
 ### Empty/Invalid Input Handling
-- [ ] The `if not text: return` early-exit at the top of each `send()` remains in place. Unchanged.
-- [ ] Migration script handles the case of zero `AgentSession:*` records (dry-run logs `total_records: 0`; no errors).
-- [ ] Migration script handles records where none of the three fields exist (skipped cleanly — `HDEL` is a no-op).
+- [x] The `if not text: return` early-exit at the top of each `send()` remains in place. Unchanged.
+- [x] Migration script handles the case of zero `AgentSession:*` records (dry-run logs `total_records: 0`; no errors).
+- [x] Migration script handles records where none of the three fields exist (skipped cleanly — `HDEL` is a no-op).
 
 ### Error State Rendering
-- [ ] Drafter failure path: when `draft_message` raises, the handler logs a WARNING and delivers the raw text via Redis outbox. This is the same behavior as the current code's `except` branch. Test `test_drafter_exception_falls_back_to_raw_text` (if it exists; check during build) must continue to pass.
-- [ ] No user-visible error output from this change — the entire surface is internal plumbing.
+- [x] Drafter failure path: when `draft_message` raises, the handler logs a WARNING and delivers the raw text via Redis outbox. This is the same behavior as the current code's `except` branch. Test `test_drafter_exception_falls_back_to_raw_text` (if it exists; check during build) must continue to pass.
+- [x] No user-visible error output from this change — the entire surface is internal plumbing.
 
 ## Test Impact
 
-- [ ] `tests/unit/test_output_handler.py` — **UPDATE**: two test blocks at L384-401 and L506-514 manipulate `MESSAGE_DRAFTER_IN_HANDLER` env var and assert `handler._drafter_enabled is True/False`. After the flag is deleted, both blocks must be **DELETED** (not just updated) — they test behavior that no longer exists. Inspect the surrounding test functions to decide if the entire functions are flag-specific (DELETE) or if only the parameterized "off" cases need removal (UPDATE to single-case tests).
-- [ ] `tests/integration/test_worker_pm_long_output.py` — **PARTIAL DELETE + UPDATE**: L97 sets `MESSAGE_DRAFTER_IN_HANDLER=1` as a precondition and L100 asserts `handler._drafter_enabled is True`. L169-228 is a dedicated "rollback path" test that sets the flag to `0` and asserts the drafter is bypassed. After flag removal: delete the rollback-path test entirely (L169-228 region). Update the happy-path test to remove the now-redundant `monkeypatch.setenv("MESSAGE_DRAFTER_IN_HANDLER", "1")` and `_drafter_enabled` assertion.
-- [ ] `tests/integration/test_message_drafter_integration.py` — **UPDATE**: L46 docstring references the flag ("runs the drafter when MESSAGE_DRAFTER_IN_HANDLER is enabled (default True)"). Update the docstring to reflect that drafter is now always enabled.
-- [ ] `tests/unit/test_output_router.py`, `tests/unit/test_nudge_loop.py`, `tests/unit/test_qa_nudge_cap.py`, `tests/unit/test_duplicate_delivery.py`, `tests/unit/test_steering_mechanism.py`, `tests/unit/test_recovery_respawn_safety.py` — **NO CHANGE**: these reference the **function** `determine_delivery_action` (different thing) not the schema fields. Do not touch.
+- [x] `tests/unit/test_output_handler.py` — **UPDATE**: two test blocks at L384-401 and L506-514 manipulate `MESSAGE_DRAFTER_IN_HANDLER` env var and assert `handler._drafter_enabled is True/False`. After the flag is deleted, both blocks must be **DELETED** (not just updated) — they test behavior that no longer exists. Inspect the surrounding test functions to decide if the entire functions are flag-specific (DELETE) or if only the parameterized "off" cases need removal (UPDATE to single-case tests).
+- [x] `tests/integration/test_worker_pm_long_output.py` — **PARTIAL DELETE + UPDATE**: L97 sets `MESSAGE_DRAFTER_IN_HANDLER=1` as a precondition and L100 asserts `handler._drafter_enabled is True`. L169-228 is a dedicated "rollback path" test that sets the flag to `0` and asserts the drafter is bypassed. After flag removal: delete the rollback-path test entirely (L169-228 region). Update the happy-path test to remove the now-redundant `monkeypatch.setenv("MESSAGE_DRAFTER_IN_HANDLER", "1")` and `_drafter_enabled` assertion.
+- [x] `tests/integration/test_message_drafter_integration.py` — **UPDATE**: L46 docstring references the flag ("runs the drafter when MESSAGE_DRAFTER_IN_HANDLER is enabled (default True)"). Update the docstring to reflect that drafter is now always enabled.
+- [x] `tests/unit/test_output_router.py`, `tests/unit/test_nudge_loop.py`, `tests/unit/test_qa_nudge_cap.py`, `tests/unit/test_duplicate_delivery.py`, `tests/unit/test_steering_mechanism.py`, `tests/unit/test_recovery_respawn_safety.py` — **NO CHANGE**: these reference the **function** `determine_delivery_action` (different thing) not the schema fields. Do not touch.
 
 ## Rabbit Holes
 
@@ -206,29 +206,29 @@ No agent integration required — this is an internal cleanup. The agent does no
 ## Documentation
 
 ### Feature Documentation
-- [ ] Update `docs/features/message-drafter.md`: delete the "## Feature flag: `MESSAGE_DRAFTER_IN_HANDLER`" section (L112-118). Update the paragraph at L79-91 ("Drafter-at-the-handler") to remove the flag reference at L81 and rewrite as "always enabled". The rollback reference at L118 ("tracked in the file-chore follow-up issue") goes away.
-- [ ] Update `docs/features/email-bridge.md` L70: delete the "Feature flag: `MESSAGE_DRAFTER_IN_HANDLER`" paragraph. Replace with one sentence noting the drafter runs on every email send.
-- [ ] Update `docs/features/agent-message-delivery.md` L38-52: this section is **already stale** (describes `session.delivery_action` writes that stopped in #1072) but was left for this cleanup PR. Rewrite the section to describe the current tool-call delivery path (`tools/send_message.py`, `tools/react_with_emoji.py` → `OutputHandler`). Drop the `delivery_action`/`delivery_text`/`delivery_emoji` bullet list at L50-52.
-- [ ] Update `docs/features/bridge-worker-architecture.md` L39: the ASCII diagram reads "↓ writes delivery_action, delivery_text, delivery_emoji to AgentSession". Delete or rewrite this line to reflect current flow.
+- [x] Update `docs/features/message-drafter.md`: delete the "## Feature flag: `MESSAGE_DRAFTER_IN_HANDLER`" section (L112-118). Update the paragraph at L79-91 ("Drafter-at-the-handler") to remove the flag reference at L81 and rewrite as "always enabled". The rollback reference at L118 ("tracked in the file-chore follow-up issue") goes away.
+- [x] Update `docs/features/email-bridge.md` L70: delete the "Feature flag: `MESSAGE_DRAFTER_IN_HANDLER`" paragraph. Replace with one sentence noting the drafter runs on every email send.
+- [x] Update `docs/features/agent-message-delivery.md` L38-52: this section is **already stale** (describes `session.delivery_action` writes that stopped in #1072) but was left for this cleanup PR. Rewrite the section to describe the current tool-call delivery path (`tools/send_message.py`, `tools/react_with_emoji.py` → `OutputHandler`). Drop the `delivery_action`/`delivery_text`/`delivery_emoji` bullet list at L50-52.
+- [x] Update `docs/features/bridge-worker-architecture.md` L39: the ASCII diagram reads "↓ writes delivery_action, delivery_text, delivery_emoji to AgentSession". Delete or rewrite this line to reflect current flow.
 
 ### External Documentation Site
-- [ ] No external docs site — repo does not publish Sphinx/MkDocs/RTD.
+- [x] No external docs site — repo does not publish Sphinx/MkDocs/RTD.
 
 ### Inline Documentation
-- [ ] Update the class-level docstring of `TelegramRelayOutputHandler` (`agent/output_handler.py` L181-198) to remove the "When `MESSAGE_DRAFTER_IN_HANDLER` is true (default)..." paragraph. Replace with a single sentence stating the drafter runs on every send.
-- [ ] Update the `EmailOutputHandler.send` docstring (`bridge/email_bridge.py` L278-293) to remove the flag reference.
-- [ ] Update the `# === PM session delivery fields ===` block comment in `models/agent_session.py` L198-202 — **delete it**, since the fields it describes are gone.
+- [x] Update the class-level docstring of `TelegramRelayOutputHandler` (`agent/output_handler.py` L181-198) to remove the "When `MESSAGE_DRAFTER_IN_HANDLER` is true (default)..." paragraph. Replace with a single sentence stating the drafter runs on every send.
+- [x] Update the `EmailOutputHandler.send` docstring (`bridge/email_bridge.py` L278-293) to remove the flag reference.
+- [x] Update the `# === PM session delivery fields ===` block comment in `models/agent_session.py` L198-202 — **delete it**, since the fields it describes are gone.
 
 ## Success Criteria
 
-- [ ] `models/agent_session.py` has no `delivery_text`, `delivery_action`, or `delivery_emoji` field declarations.
-- [ ] `grep -rn "delivery_text\|delivery_action\|delivery_emoji" /Users/tomcounsell/src/ai --include="*.py"` returns only: `determine_delivery_action` function references and migration-script-internal references. No schema field references.
-- [ ] `grep -rn "MESSAGE_DRAFTER_IN_HANDLER\|message_drafter_in_handler\|_read_drafter_in_handler_flag\|_drafter_enabled" /Users/tomcounsell/src/ai --include="*.py"` returns zero results.
-- [ ] `scripts/migrate_agent_session_drop_delivery_fields.py` exists, supports `--dry-run`, and runs successfully on local Redis.
-- [ ] All four doc files updated per the Documentation section.
-- [ ] All three test files updated per the Test Impact section.
-- [ ] `pytest tests/unit tests/integration -x -q` exits 0.
-- [ ] `python -m ruff format --check .` exits 0.
+- [x] `models/agent_session.py` has no `delivery_text`, `delivery_action`, or `delivery_emoji` field declarations.
+- [x] `grep -rn "delivery_text\|delivery_action\|delivery_emoji" /Users/tomcounsell/src/ai --include="*.py"` returns only: `determine_delivery_action` function references and migration-script-internal references. No schema field references.
+- [x] `grep -rn "MESSAGE_DRAFTER_IN_HANDLER\|message_drafter_in_handler\|_read_drafter_in_handler_flag\|_drafter_enabled" /Users/tomcounsell/src/ai --include="*.py"` returns zero results.
+- [x] `scripts/migrate_agent_session_drop_delivery_fields.py` exists, supports `--dry-run`, and runs successfully on local Redis.
+- [x] All four doc files updated per the Documentation section.
+- [x] All three test files updated per the Test Impact section.
+- [x] `pytest tests/unit tests/integration -x -q` exits 0.
+- [x] `python -m ruff format --check .` exits 0.
 - [ ] PR merged; tracking issue #1073 closed automatically via `Closes #1073` in PR body.
 
 ## Team Orchestration

--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -195,15 +195,6 @@ class AgentSession(Model):
     # === Steering fields ===
     queued_steering_messages = ListField(null=True)
 
-    # === PM session delivery fields ===
-    # Stop-hook review gate: agent's final delivery decision.
-    # Set by the stop hook after the agent reviews its draft output.
-    # "send" = deliver delivery_text; "react" = emoji only; "silent" = nothing.
-    # None = no review gate ran (subagent/programmatic session) -> fall through to summarizer.
-    delivery_action = Field(null=True)
-    delivery_text = Field(null=True)  # Final message text (for send/edit)
-    delivery_emoji = Field(null=True)  # Emoji for react-only path
-
     # === PM self-messaging ===
     pm_sent_message_ids = ListField(null=True)
 

--- a/scripts/migrate_agent_session_drop_delivery_fields.py
+++ b/scripts/migrate_agent_session_drop_delivery_fields.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""HDEL dead delivery_* fields from all AgentSession Redis hashes (#1073).
+
+Drops three residual hash fields — ``delivery_text``, ``delivery_action``,
+``delivery_emoji`` — from every existing ``AgentSession:*`` hash record.
+
+Why raw Redis instead of Popoto:
+  These three fields no longer exist on the Popoto model (their ``Field()``
+  declarations were removed as part of #1073). Calling ``instance.save()``
+  would NEVER HDEL an undeclared field — it only writes declared fields.
+  Raw ``redis_client.hdel`` is the correct primitive for dropping orphaned
+  hash keys. The ``PreToolUse:Bash`` validator blocks raw Redis only in
+  interactive shell commands; Python scripts run via ``python scripts/…``
+  are exempt. This mirrors the pattern in
+  ``scripts/migrate_agent_session_fields.py`` (PR #392 lineage).
+
+None of the three fields were ``IndexedField``/``SortedField``, so no
+re-save / index rebuild is needed — plain HDEL is sufficient.
+
+``HDEL`` on a missing field is a no-op, so this script is idempotent.
+
+Usage:
+  python scripts/migrate_agent_session_drop_delivery_fields.py --dry-run
+  python scripts/migrate_agent_session_drop_delivery_fields.py
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+DEAD_FIELDS = ("delivery_text", "delivery_action", "delivery_emoji")
+
+
+def drop_delivery_fields(dry_run: bool = True) -> dict:
+    """HDEL the three delivery_* fields from all AgentSession:* hashes.
+
+    Args:
+        dry_run: If True, log what would happen without making changes.
+
+    Returns:
+        Dict with migration stats.
+    """
+    import popoto
+
+    redis_client = popoto.redis_db.get_REDIS_DB()
+
+    stats = {
+        "total_records": 0,
+        "records_with_dead_fields": 0,
+        "records_clean": 0,
+        "errors": 0,
+    }
+    for field in DEAD_FIELDS:
+        stats[f"hdel_{field}"] = 0
+
+    # Find all AgentSession hash keys (exclude index/sorted-set keys)
+    all_keys = redis_client.keys("AgentSession:*")
+    hash_keys = [k for k in all_keys if b":_sorted_set:" not in k and b":_field_index:" not in k]
+    stats["total_records"] = len(hash_keys)
+    logger.info(f"Found {len(hash_keys)} AgentSession hash records")
+
+    for key in hash_keys:
+        key_str = key.decode() if isinstance(key, bytes) else key
+        try:
+            present_fields = []
+            for field in DEAD_FIELDS:
+                val = redis_client.hget(key, field)
+                if val is not None:
+                    present_fields.append(field)
+
+            if not present_fields:
+                stats["records_clean"] += 1
+                continue
+
+            stats["records_with_dead_fields"] += 1
+            logger.info(f"  {key_str}: dropping {present_fields}")
+
+            if not dry_run:
+                for field in present_fields:
+                    redis_client.hdel(key, field)
+                    stats[f"hdel_{field}"] += 1
+            else:
+                for field in present_fields:
+                    stats[f"hdel_{field}"] += 1
+
+        except Exception as e:
+            stats["errors"] += 1
+            logger.error(f"Error processing {key_str}: {e}")
+
+    return stats
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Drop dead delivery_* fields from AgentSession Redis hashes (#1073)"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log what would happen without making changes",
+    )
+    args = parser.parse_args()
+
+    mode = "DRY RUN" if args.dry_run else "LIVE"
+    logger.info(f"=== AgentSession delivery_* Field Drop ({mode}) ===")
+
+    stats = drop_delivery_fields(dry_run=args.dry_run)
+
+    logger.info("=== Migration Results ===")
+    for key, value in stats.items():
+        logger.info(f"  {key}: {value}")
+
+    if not args.dry_run and stats["records_with_dead_fields"] > 0:
+        logger.info(f"Successfully cleaned {stats['records_with_dead_fields']} records.")
+    elif args.dry_run and stats["records_with_dead_fields"] > 0:
+        logger.info(
+            f"Would clean {stats['records_with_dead_fields']} records. "
+            "Run without --dry-run to apply."
+        )
+    else:
+        logger.info("No records needed cleaning (all clean or empty).")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_message_drafter_integration.py
+++ b/tests/integration/test_message_drafter_integration.py
@@ -42,8 +42,8 @@ async def test_response_summarizer_wiring():
     """Verify that TelegramRelayOutputHandler.send invokes draft_message for all text.
 
     Post-#1074 consolidation: send_response_with_files is gone. The canonical
-    drafter entry point is TelegramRelayOutputHandler.send, which unconditionally
-    runs the drafter when MESSAGE_DRAFTER_IN_HANDLER is enabled (default True).
+    drafter entry point is TelegramRelayOutputHandler.send, which always
+    routes text through draft_message before writing to the outbox.
     """
     from agent.output_handler import TelegramRelayOutputHandler
 

--- a/tests/integration/test_worker_pm_long_output.py
+++ b/tests/integration/test_worker_pm_long_output.py
@@ -14,12 +14,11 @@ This test bypasses the real worker process and tests the output-handler
 boundary directly — the handler is the single funnel all PM/Dev output must
 pass through. We verify:
 
-(a) Drafter enabled (default): 4800 chars → payload.text ≤ 4096 AND
-    payload.file_paths contains the .txt file with the raw content.
-(b) Drafter disabled (MESSAGE_DRAFTER_IN_HANDLER=0 rollback): 4800 chars →
-    payload.text is the raw 4800 chars, proving the flag genuinely disables
-    the drafter (the relay's belt-and-suspenders length guard remains as the
-    last line of defense — covered separately by test_relay_length_guard.py).
+- 4800 chars → payload.text ≤ 4096 AND payload.file_paths contains the
+  .txt file with the raw content.
+- If the drafter itself raises, the handler falls back to raw-text delivery
+  (the relay's belt-and-suspenders length guard remains as the last line of
+  defense — covered separately by test_relay_length_guard.py).
 
 No real worker, no Redis, no LLM — we patch ``_get_redis`` with a dict-like
 fake and patch ``draft_message`` to produce a deterministic short draft.
@@ -80,11 +79,10 @@ def _make_pm_session(session_id: str = "pm-session-worker-bypass"):
 
 
 @pytest.mark.asyncio
-async def test_long_output_gets_drafted_and_full_text_attached(tmp_path, monkeypatch):
-    """Drafter-enabled path: oversize raw text never reaches the outbox.
+async def test_long_output_gets_drafted_and_full_text_attached(tmp_path):
+    """Oversize raw text never reaches the outbox — drafter always runs.
 
     Preconditions:
-      - MESSAGE_DRAFTER_IN_HANDLER default/true
       - draft_message returns a SHORT drafted text + a full-output file path
 
     Expected outcome (the bypass fix):
@@ -92,12 +90,7 @@ async def test_long_output_gets_drafted_and_full_text_attached(tmp_path, monkeyp
       - payload["file_paths"] is present and references the .txt with raw output
       - the referenced file exists on disk and contains the original raw text
     """
-    # Force the flag true so we get the default-enabled behavior regardless of
-    # the ambient env / config used by the test runner.
-    monkeypatch.setenv("MESSAGE_DRAFTER_IN_HANDLER", "1")
-
     handler = TelegramRelayOutputHandler()
-    assert handler._drafter_enabled is True, "precondition: drafter must be enabled when env=1"
 
     # Install the fake redis — avoids a real Redis dependency.
     fake_redis = _FakeRedis()
@@ -165,66 +158,15 @@ async def test_long_output_gets_drafted_and_full_text_attached(tmp_path, monkeyp
 
 
 @pytest.mark.asyncio
-async def test_drafter_disabled_via_env_rolls_back_to_raw_text(tmp_path, monkeypatch):
-    """Rollback path: MESSAGE_DRAFTER_IN_HANDLER=0 → drafter bypassed entirely.
-
-    This confirms the flag's rollback behavior from plan §Part C / Race 3:
-    an operator who sets the env var to 0 and restarts the worker gets the
-    pre-fix behavior back (raw text to outbox). The relay length guard in
-    bridge.telegram_relay remains as the last line of defense; that behavior
-    is covered by tests/unit/test_relay_length_guard.py and is out of scope
-    here.
-    """
-    monkeypatch.setenv("MESSAGE_DRAFTER_IN_HANDLER", "0")
-
-    handler = TelegramRelayOutputHandler()
-    assert handler._drafter_enabled is False, "precondition: drafter must be disabled when env=0"
-
-    fake_redis = _FakeRedis()
-    handler._redis = fake_redis
-
-    raw_text = "Y" * 4800
-    session = _make_pm_session(session_id="pm-session-drafter-disabled")
-
-    # draft_message must NOT be called in this path. Patch it to blow up if
-    # the code ever reaches it — that would indicate the flag is ignored.
-    blow_up = AsyncMock(side_effect=AssertionError("drafter must be skipped when flag=0"))
-
-    with patch("bridge.message_drafter.draft_message", new=blow_up):
-        await handler.send(
-            chat_id="12345",
-            text=raw_text,
-            reply_to_msg_id=42,
-            session=session,
-        )
-
-    blow_up.assert_not_awaited()
-
-    queue_key = f"telegram:outbox:{session.session_id}"
-    entries = fake_redis.store.get(queue_key, [])
-    assert len(entries) == 1
-
-    payload = json.loads(entries[0])
-    # With the drafter disabled, the handler writes raw text straight through.
-    assert payload["text"] == raw_text
-    assert len(payload["text"]) == 4800
-    # No file_paths attached — nothing generated a full-output file.
-    assert "file_paths" not in payload
-
-
-@pytest.mark.asyncio
-async def test_drafter_failure_falls_back_to_raw_text_without_blocking(tmp_path, monkeypatch):
+async def test_drafter_failure_falls_back_to_raw_text_without_blocking(tmp_path):
     """Defense-in-depth: if draft_message itself raises, delivery still happens.
 
-    Per the handler's try/except in output_handler.py:271, drafter failure
+    Per the handler's try/except in output_handler.py, drafter failure
     MUST NOT block delivery. The relay's length guard is the last line of
     defense. This test ensures a raised exception inside draft_message does
     not propagate out of send().
     """
-    monkeypatch.setenv("MESSAGE_DRAFTER_IN_HANDLER", "1")
-
     handler = TelegramRelayOutputHandler()
-    assert handler._drafter_enabled is True
     fake_redis = _FakeRedis()
     handler._redis = fake_redis
 

--- a/tests/unit/test_output_handler.py
+++ b/tests/unit/test_output_handler.py
@@ -367,7 +367,8 @@ class TestTelegramRelayOutputHandler:
 
 
 class TestDrafterInHandler:
-    """Tests for task 7 in docs/plans/message-drafter.md — the drafter-at-the-handler fix.
+    """Tests for the drafter-at-the-handler fix (originally in the message
+    drafter plan, now always-on).
 
     TelegramRelayOutputHandler.send must route its text through draft_message
     before writing to Redis. This closes the worker-bypass gap where worker-
@@ -375,38 +376,22 @@ class TestDrafterInHandler:
     outbox and triggered MessageTooLongError at the relay.
     """
 
-    def _make_handler(self, *, drafter_enabled: bool = True):
-        import os
+    def _make_handler(self):
         from unittest.mock import MagicMock
 
         from agent.output_handler import TelegramRelayOutputHandler
 
-        old = os.environ.get("MESSAGE_DRAFTER_IN_HANDLER")
-        os.environ["MESSAGE_DRAFTER_IN_HANDLER"] = "true" if drafter_enabled else "false"
-        try:
-            h = TelegramRelayOutputHandler()
-        finally:
-            if old is None:
-                os.environ.pop("MESSAGE_DRAFTER_IN_HANDLER", None)
-            else:
-                os.environ["MESSAGE_DRAFTER_IN_HANDLER"] = old
+        h = TelegramRelayOutputHandler()
         h._redis = MagicMock()
         return h
 
-    def test_flag_is_read_at_init_time(self):
-        """Per Race 3 in the plan: flag is read once at __init__, not per-send."""
-        handler_on = self._make_handler(drafter_enabled=True)
-        handler_off = self._make_handler(drafter_enabled=False)
-        assert handler_on._drafter_enabled is True
-        assert handler_off._drafter_enabled is False
-
-    def test_send_invokes_draft_message_when_enabled(self):
-        """With drafter enabled, send() must call bridge.message_drafter.draft_message."""
+    def test_send_invokes_draft_message(self):
+        """send() must call bridge.message_drafter.draft_message unconditionally."""
         from unittest.mock import AsyncMock, patch
 
         from bridge.message_drafter import MessageDraft
 
-        handler = self._make_handler(drafter_enabled=True)
+        handler = self._make_handler()
         drafted = MessageDraft(
             text="drafted version",
             full_output_file=None,
@@ -426,23 +411,6 @@ class TestDrafterInHandler:
         payload = json.loads(args[1])
         assert payload["text"] == "drafted version"
 
-    def test_send_bypasses_draft_message_when_disabled(self):
-        """With flag off, send() must NOT invoke draft_message (raw text to outbox)."""
-        from unittest.mock import AsyncMock, patch
-
-        handler = self._make_handler(drafter_enabled=False)
-        mock_draft = AsyncMock()
-
-        with patch("bridge.message_drafter.draft_message", mock_draft):
-            asyncio.run(handler.send("123", "Raw text passes through.", 0))
-
-        mock_draft.assert_not_awaited()
-        # Redis still got the raw text
-        handler._redis.rpush.assert_called_once()
-        args, _ = handler._redis.rpush.call_args
-        payload = json.loads(args[1])
-        assert payload["text"] == "Raw text passes through."
-
     def test_send_includes_file_paths_when_drafter_returns_file(self):
         """If the draft has a full_output_file, the payload carries file_paths."""
         from pathlib import Path
@@ -450,7 +418,7 @@ class TestDrafterInHandler:
 
         from bridge.message_drafter import MessageDraft
 
-        handler = self._make_handler(drafter_enabled=True)
+        handler = self._make_handler()
         drafted = MessageDraft(
             text="short caption",
             full_output_file=Path("/tmp/valor_full_output_xyz.txt"),
@@ -471,7 +439,7 @@ class TestDrafterInHandler:
         """Drafter exception must NOT block delivery — fall back to raw text."""
         from unittest.mock import AsyncMock, patch
 
-        handler = self._make_handler(drafter_enabled=True)
+        handler = self._make_handler()
         mock_draft = AsyncMock(side_effect=RuntimeError("drafter broken"))
 
         with patch("bridge.message_drafter.draft_message", mock_draft):
@@ -497,21 +465,12 @@ class TestDrafterFailureRecovery:
     4. Persistence of ``context_summary`` / ``expectations`` on success.
     """
 
-    def _make_handler(self, *, drafter_enabled: bool = True):
-        import os
+    def _make_handler(self):
         from unittest.mock import MagicMock
 
         from agent.output_handler import TelegramRelayOutputHandler
 
-        old = os.environ.get("MESSAGE_DRAFTER_IN_HANDLER")
-        os.environ["MESSAGE_DRAFTER_IN_HANDLER"] = "true" if drafter_enabled else "false"
-        try:
-            h = TelegramRelayOutputHandler()
-        finally:
-            if old is None:
-                os.environ.pop("MESSAGE_DRAFTER_IN_HANDLER", None)
-            else:
-                os.environ["MESSAGE_DRAFTER_IN_HANDLER"] = old
+        h = TelegramRelayOutputHandler()
         h._redis = MagicMock()
         return h
 
@@ -524,7 +483,7 @@ class TestDrafterFailureRecovery:
 
         from bridge.message_drafter import MessageDraft
 
-        handler = self._make_handler(drafter_enabled=True)
+        handler = self._make_handler()
         session = MagicMock()
         session.session_id = "sess-self-draft"
 
@@ -563,7 +522,7 @@ class TestDrafterFailureRecovery:
 
         from bridge.message_drafter import MessageDraft
 
-        handler = self._make_handler(drafter_enabled=True)
+        handler = self._make_handler()
         session = MagicMock()
         session.session_id = "sess-loop-guard"
 
@@ -606,7 +565,7 @@ class TestDrafterFailureRecovery:
         from bridge.message_drafter import MessageDraft
         from bridge.message_quality import NARRATION_FALLBACK_MESSAGE
 
-        handler = self._make_handler(drafter_enabled=True)
+        handler = self._make_handler()
         session = MagicMock()
         session.session_id = "sess-narration"
 
@@ -645,7 +604,7 @@ class TestDrafterFailureRecovery:
         from bridge.message_drafter import MessageDraft
         from bridge.message_quality import NARRATION_FALLBACK_MESSAGE
 
-        handler = self._make_handler(drafter_enabled=True)
+        handler = self._make_handler()
         session = MagicMock()
         session.session_id = "sess-substance"
 
@@ -682,7 +641,7 @@ class TestDrafterFailureRecovery:
 
         from bridge.message_drafter import MessageDraft
 
-        handler = self._make_handler(drafter_enabled=True)
+        handler = self._make_handler()
 
         # Build a session that records field assignments.
         session = MagicMock()
@@ -712,7 +671,7 @@ class TestDrafterFailureRecovery:
 
         from bridge.message_drafter import MessageDraft
 
-        handler = self._make_handler(drafter_enabled=True)
+        handler = self._make_handler()
         session = MagicMock()
         session.session_id = "sess-no-persist"
         # Clear the auto-generated attributes to detect writes.
@@ -741,7 +700,7 @@ class TestDrafterFailureRecovery:
 
         from bridge.message_drafter import MessageDraft
 
-        handler = self._make_handler(drafter_enabled=True)
+        handler = self._make_handler()
         session = MagicMock()
         session.session_id = "sess-save-fails"
         session.save.side_effect = RuntimeError("redis write failed")


### PR DESCRIPTION
Closes #1073. Follow-up to #1035.

## Summary
- Drops three dead `AgentSession` fields (`delivery_text`, `delivery_action`, `delivery_emoji`) from the Popoto model and HDELs them from existing Redis hashes via `scripts/migrate_agent_session_drop_delivery_fields.py` (idempotent).
- Removes the `MESSAGE_DRAFTER_IN_HANDLER` feature flag and both copies of `_read_drafter_in_handler_flag` (`agent/output_handler.py` + `bridge/email_bridge.py`). The drafter call is now unconditional; the existing try/except drafter-failure fallback is preserved verbatim.
- Removes `FeatureSettings.message_drafter_in_handler`; `FeatureSettings` becomes an empty placeholder.
- Updates tests to drop flag-off paths and rollback-path test (`tests/unit/test_output_handler.py`, `tests/integration/test_worker_pm_long_output.py`, `tests/integration/test_message_drafter_integration.py`).
- Updates four docs (`message-drafter.md`, `email-bridge.md`, `agent-message-delivery.md`, `bridge-worker-architecture.md`) to remove flag + dead-field references and rewrite stale `agent-message-delivery` delivery-execution section.

See `docs/plans/sdlc-1073.md` for the full plan.

## Test plan
- [x] `python -m pytest tests/unit/test_output_handler.py tests/integration/test_worker_pm_long_output.py tests/integration/test_message_drafter_integration.py` — 38 passed, 1 skipped (pre-existing real-API skip).
- [x] `python scripts/migrate_agent_session_drop_delivery_fields.py` — cleaned 509 records, idempotent second run (0 dirty).
- [x] `python -m ruff format --check .` — 628 files already formatted.
- [x] `python -m ruff check <touched files>` — all checks passed.
- [x] `grep -rn MESSAGE_DRAFTER_IN_HANDLER` — zero results.
- [x] Plan checkboxes ticked (28 of 29; only "PR merged" left).