### PR TITLE
feat(#1045): /do-pr-review rubric + disclosure parser + prior-review context

### DIFF
--- a/.claude/skills/do-pr-review/SKILL.md
+++ b/.claude/skills/do-pr-review/SKILL.md
@@ -44,11 +44,13 @@ Fall back to manual resolution if the env var is unset.
 
 This skill is decomposed into focused sub-skills in `sub-skills/`:
 - `checkout.md` — Mechanical: clean git state, checkout PR branch
-- `code-review.md` — Judgment: read files, analyze diff, classify findings
+- `code-review.md` — Judgment: parse PR-body disclosures, read prior reviews, traverse the 10-item Rubric, evaluate the 12-item Pre-Verdict Checklist, classify findings, derive the verdict mechanically
 - `screenshot.md` — Mechanical: start app, capture UI screenshots
 - `post-review.md` — Mechanical: format findings, post review to GitHub
 
 Each sub-skill has a single responsibility and receives pre-resolved context.
+
+**Determinism note:** `code-review.md` includes a disclosure parser (pre-finding), a prior-review context loader (idempotency on unchanged HEAD SHA + body), an explicit 10-item Rubric with pass/fail/acknowledged/n/a per item, a Miscellaneous bucket for issues outside the rubric, and mechanical verdict derivation. These were introduced in issue #1045 to address non-deterministic verdicts across repeated runs on the same PR.
 
 ## Stage Marker
 

--- a/.claude/skills/do-pr-review/sub-skills/README.md
+++ b/.claude/skills/do-pr-review/sub-skills/README.md
@@ -9,7 +9,7 @@ into single-responsibility phases. Each sub-skill receives pre-resolved context 
 | File | Type | Responsibility |
 |------|------|----------------|
 | `checkout.md` | Mechanical | Clean git state, checkout PR branch |
-| `code-review.md` | Judgment | Read files, analyze diff, classify findings |
+| `code-review.md` | Judgment | Parse disclosures, load prior reviews, traverse Rubric, classify findings, derive mechanical verdict |
 | `screenshot.md` | Mechanical | Start app, capture UI screenshots |
 | `post-review.md` | Mechanical | Format findings, post review to GitHub |
 

--- a/.claude/skills/do-pr-review/sub-skills/code-review.md
+++ b/.claude/skills/do-pr-review/sub-skills/code-review.md
@@ -19,9 +19,15 @@ PR branch must already be checked out (via checkout sub-skill).
 
 ```bash
 PR_NUMBER="${SDLC_PR_NUMBER}"
-gh pr view $PR_NUMBER --json title,body,headRefName,baseRefName,files,additions,deletions
+gh pr view $PR_NUMBER --json title,body,headRefName,baseRefName,files,additions,deletions,headRefOid
 gh pr diff $PR_NUMBER
 gh pr diff $PR_NUMBER --name-only
+```
+
+Capture the HEAD SHA for use in the Prior Review Context step:
+
+```bash
+HEAD_SHA=$(gh pr view $PR_NUMBER --json headRefOid --jq .headRefOid)
 ```
 
 ### 2. Load Plan Context
@@ -42,6 +48,134 @@ If `$SDLC_ISSUE_NUMBER` is set, also fetch the issue:
 ```bash
 gh issue view $SDLC_ISSUE_NUMBER
 ```
+
+### 2.5. Disclosure Parser (mandatory, runs BEFORE findings)
+
+The PR author often documents scope exclusions, deferrals, and follow-ups in the PR body. Findings that match a disclosure are **acknowledged**, not tech debt. Misclassifying a disclosed deferral as tech debt is a calibration failure — it re-surfaces a decision the author already made and documented.
+
+**Step A: Extract disclosure blocks from the PR body.**
+
+Scan the PR body (captured in Step 1) for sections with these headings (case-insensitive, tolerate variants):
+
+- `Out of scope`
+- `Deferred` / `Deferred items` / `Deferred to follow-up`
+- `Not in this PR` / `Not in scope`
+- `Follow-up` / `Follow-ups` / `Follow up` / `Follow-up items`
+- `Known limitations`
+- `Disclosures`
+
+Also collect inline bullet disclosures anywhere in the body that match these phrase patterns (case-insensitive):
+
+- `deferred`, `deferred to follow-up`, `filed as follow-up`, `tracked separately`
+- `out of scope`, `not addressed in this PR`, `dropped`
+- `Closes #N`, `Addresses #N`, `Related to #N`, `Tracked by #N`
+
+For each disclosure, capture:
+- The disclosure text (one logical bullet or paragraph)
+- Any explicitly referenced file paths, feature names, or symbol names
+- Any `#N` issue references
+
+**Step B: Verify every follow-up claim resolves to an OPEN issue.**
+
+For each disclosure that claims a follow-up was filed (`filed as follow-up #N`, `tracked by #N`, `Follow-up: #N`, etc.):
+
+```bash
+gh issue view N --json number,state,title 2>/dev/null
+```
+
+- If the issue exists and state is `OPEN`: the disclosure is verified. Record it as `acknowledged`.
+- If the issue is `CLOSED`, does not exist, or the claim references no issue number at all: this becomes a **real Tech Debt finding** with description "Claimed follow-up for [disclosure text] does not resolve to an open tracking issue." Do not classify it as acknowledged.
+
+If the disclosure does not claim a follow-up (e.g., a pure "out of scope" exclusion with no tracking commitment), record it as `acknowledged` with `tracked=false` — note this in the review body but do not escalate to Tech Debt.
+
+**Step C: Use disclosures to classify candidate findings.**
+
+When analyzing the diff in Step 3 and Plan Validation in Step 4, a candidate finding is classified `acknowledged` (not `tech_debt`, not `blocker`) when **all** of the following hold:
+
+1. The finding's file path, feature name, or symbol matches a disclosure (by exact path, substring feature-name match, or `#N` correspondence with the plan/issue).
+2. The disclosure's follow-up claim resolves to an OPEN issue (verified in Step B), OR the disclosure is an explicit "out of scope" exclusion with sound rationale.
+3. The finding is **not** a violation of an explicit plan `## No-Gos` item (No-Gos override disclosures — if the PR author disclosed doing something the plan explicitly excluded, that is still a blocker).
+
+**Step D: Record disclosure results.**
+
+Emit a `Disclosures` section for use in the review body (a separate section from `Tech Debt`):
+
+```markdown
+### Acknowledged Deferrals (verified)
+- **[disclosure text]** — tracked by #N (OPEN) — matched findings: [file path, if any]
+- **[disclosure text]** — explicit out-of-scope exclusion, no tracking required
+```
+
+Findings marked `acknowledged` appear in this section only — they MUST NOT appear in the `Tech Debt` bucket.
+
+### 2.6. Prior Review Context (mandatory, runs BEFORE findings)
+
+Every invocation reads its own prior `## Review:` comments on the PR so repeated passes are idempotent on unchanged inputs, and so calibration drift across runs is visible rather than silent.
+
+**Step A: Fetch prior reviews.**
+
+```bash
+REPO="${SDLC_REPO:-${GH_REPO:-}}"
+PRIOR_REVIEWS=$(gh api repos/$REPO/issues/$PR_NUMBER/comments \
+  --jq '[.[] | select(.body | startswith("## Review:")) | {body: .body, created_at: .created_at, id: .id}]')
+```
+
+Also fetch prior formal reviews (for repos where `gh pr review --request-changes` is usable):
+
+```bash
+PRIOR_FORMAL_REVIEWS=$(gh api repos/$REPO/pulls/$PR_NUMBER/reviews \
+  --jq '[.[] | select(.body | startswith("## Review:")) | {body: .body, submitted_at: .submitted_at, id: .id}]')
+```
+
+If both lists are empty, skip the remaining sub-steps and proceed to Step 3.
+
+**Step B: Identify the most recent prior review.**
+
+Pick the most recent comment/review across both lists by timestamp. Extract from its body:
+
+- The embedded HEAD SHA (if present — see Step D of this section; prior reviews emit `<!-- REVIEW_CONTEXT head_sha=... pr_body_hash=... -->`)
+- The prior verdict (from the `## Review: <verdict>` heading)
+- The prior findings lists (Blockers, Tech Debt, Nits, Acknowledged Deferrals)
+
+**Step C: Idempotency check.**
+
+Compute a hash of the current PR body for comparison:
+
+```bash
+PR_BODY_HASH=$(gh pr view $PR_NUMBER --json body --jq .body | shasum -a 256 | awk '{print $1}')
+```
+
+If the prior review's embedded `head_sha` equals the current `$HEAD_SHA` **and** the prior review's embedded `pr_body_hash` equals the current `$PR_BODY_HASH`:
+
+- Return the prior verdict unchanged
+- Do NOT regenerate findings
+- Emit a short note in the review body: `_Idempotent: prior review on HEAD ${HEAD_SHA:0:7} / body hash ${PR_BODY_HASH:0:7} is still valid._`
+- Skip to the Post Review sub-skill with the prior findings
+
+If either differs (new commits or new body text), proceed to Step 3 to generate a fresh review.
+
+**Step D: Continuity log.**
+
+When generating a fresh review (inputs changed), compare this run's findings against the prior review's findings after Step 6 classification. Surface discrepancies explicitly in the review body:
+
+```markdown
+### Review Delta (vs prior review on HEAD {prior_sha:0:7})
+- **Resolved**: [finding from prior review that is no longer present because [reason]]
+- **New**: [finding not present in prior review]
+- **Unchanged**: [finding carried forward from prior review]
+```
+
+If no prior review exists, omit the Review Delta section.
+
+**Step E: Embed context markers in this review's body.**
+
+Every review body emitted by this skill MUST include a trailing HTML-comment marker so the next invocation can detect idempotency:
+
+```markdown
+<!-- REVIEW_CONTEXT head_sha=<HEAD_SHA> pr_body_hash=<PR_BODY_HASH> -->
+```
+
+Post the marker at the end of the review body, before the OUTCOME block.
 
 ### 3. Analyze the Diff
 
@@ -66,7 +200,9 @@ For each requirement/acceptance criterion in the plan:
 1. Locate the corresponding implementation in the PR diff
 2. Verify behavior matches the plan specification
 3. Check that edge cases mentioned in the plan are handled
-4. Verify any "No-Gos" from the plan are respected
+4. Verify any "No-Gos" from the plan are respected. No-Gos override disclosures — a disclosed "deferral" that actually violates a plan No-Go is a `blocker`, not an `acknowledged` finding.
+
+If a plan acceptance criterion is not addressed in the diff but matches a verified disclosure from Step 2.5, classify that criterion as `acknowledged` rather than as a blocker. Record it in the `Acknowledged Deferrals (verified)` section.
 
 #### 4b. Plan Checkbox Validation
 
@@ -134,6 +270,81 @@ Emit the completed checklist as a bulleted list in the review comment. Format: `
 
 An "Approved" verdict requires all 12 items evaluated (no blank verdicts). Items that do not apply to this PR should be marked `N/A` with a note. An "Approved" verdict with one or more `FAIL` items is not valid — `FAIL` items must be promoted to findings.
 
+The Pre-Verdict Checklist remains the high-signal filter for common calibration bugs (unguarded `except Exception`, in-memory-only integration tests, missing docstrings, etc.). The Rubric below adds structured, mechanically-derived verdict logic on top — the two are complementary, not redundant.
+
+### Rubric
+
+After completing the Pre-Verdict Checklist, evaluate the following 10-item rubric. Each item produces exactly one of: `pass`, `fail`, `acknowledged`, or `n/a`. The verdict is then **mechanically derived** from the rubric results — not from freeform LLM judgment.
+
+| Status | Meaning |
+|--------|---------|
+| `pass` | The rubric item is satisfied by this PR |
+| `fail` | The rubric item is not satisfied — this produces a finding |
+| `acknowledged` | The item is not satisfied, but the shortfall is covered by a verified disclosure from Step 2.5 |
+| `n/a` | The rubric item does not apply to this PR (e.g., no new public APIs means doc coverage of new APIs is n/a) |
+
+**The 10 rubric items:**
+
+1. **Plan vs. implementation match** — every plan acceptance criterion is either delivered in the diff or covered by an acknowledged deferral. Critical.
+2. **New code quality** — type hints where the project uses them, meaningful names, error handling at system boundaries, no copy-paste blocks. Critical.
+3. **Test coverage** — every new public function / code path has a corresponding test; pre-existing tests still pass. Critical.
+4. **Regression risk to existing callers** — grep callers of changed functions; if a caller's behavior could silently change, it is covered by a test or the change is backward-compatible. Critical.
+5. **Data integrity** — migrations are present for schema changes; `update_fields=[...]` lists include `modified_at` when the model has `auto_now`; JSON field additions do not break existing row reads. Critical.
+6. **Security** — no new `mark_safe`, `raw()`, `eval`, `exec`, `subprocess` with request-derived input, or SQL string interpolation. No hardcoded secrets. Critical.
+7. **Documentation accuracy** — docs updated for user-facing or architecturally-visible changes; no stale references to removed code. Non-critical.
+8. **PR body accuracy** — claims in the PR body (file counts, test counts, migrations listed, disclosures) match the actual diff. Non-critical.
+9. **Disclosed deferrals** — every disclosure from Step 2.5 either (a) has an OPEN tracking issue, or (b) is an explicit out-of-scope exclusion with sound rationale. Critical.
+10. **Follow-up claims verified** — every `filed as follow-up #N` / `tracked by #N` claim in the PR body resolves to an OPEN GitHub issue. Critical.
+
+**Emit the rubric as a checklist in the review body:**
+
+```markdown
+## Rubric
+
+- [ ] **1. Plan vs. implementation match** — pass/fail/acknowledged/n/a — *notes*
+- [ ] **2. New code quality** — pass/fail/acknowledged/n/a — *notes*
+- [ ] **3. Test coverage** — pass/fail/acknowledged/n/a — *notes*
+- [ ] **4. Regression risk to existing callers** — pass/fail/acknowledged/n/a — *notes*
+- [ ] **5. Data integrity** — pass/fail/acknowledged/n/a — *notes*
+- [ ] **6. Security** — pass/fail/acknowledged/n/a — *notes*
+- [ ] **7. Documentation accuracy** — pass/fail/acknowledged/n/a — *notes*
+- [ ] **8. PR body accuracy** — pass/fail/acknowledged/n/a — *notes*
+- [ ] **9. Disclosed deferrals** — pass/fail/acknowledged/n/a — *notes*
+- [ ] **10. Follow-up claims verified** — pass/fail/acknowledged/n/a — *notes*
+```
+
+Check the box only for items marked `pass` or `n/a`. Leave `fail` and `acknowledged` items unchecked so they remain visible.
+
+**Verdict derivation (mechanical):**
+
+Apply these rules in order. Each rule produces a verdict; stop at the first rule that matches.
+
+1. **Any critical-item `fail` (items 1, 2, 3, 4, 5, 6, 9, 10) AND no matching `acknowledged`** → `CHANGES REQUESTED — Blocker`. The `fail` items become blocker findings.
+2. **Any non-critical-item `fail` (items 7, 8)** → `CHANGES REQUESTED — Tech Debt`. The `fail` items become tech_debt findings.
+3. **Any `fail` in the Miscellaneous bucket (see below) regardless of severity** → derived per the finding's own severity: `blocker` → Rule 1's verdict; `tech_debt` or `nit` → Rule 2's verdict.
+4. **All rubric items are `pass`, `acknowledged`, or `n/a`, and Miscellaneous bucket is empty** → `APPROVED`.
+
+The verdict is NOT freeform — it is derived entirely from the rubric and miscellaneous findings. A reviewer who wants to flag something that doesn't fit the rubric puts it in the Miscellaneous bucket (below), where it still feeds the mechanical verdict.
+
+### Miscellaneous Bucket
+
+The rubric is intentionally small and stable. Real PRs sometimes surface issues that don't fit any of the 10 items — legacy code smells, unusual architectural patterns, domain-specific gotchas, upstream integration risks. These MUST NOT be forced into the rubric.
+
+Instead, emit them in a separate **Miscellaneous** section. Each Miscellaneous finding still uses the finding format (File / Code / Issue / Severity / Fix) and still feeds the mechanical verdict — but it is categorized outside the 10 rubric items.
+
+```markdown
+### Miscellaneous
+- **File:** `path/to/file.py:42`
+  **Code:** `actual_code()`
+  **Issue:** [description of the issue that doesn't fit any rubric item]
+  **Severity:** blocker | tech_debt | nit
+  **Fix:** [suggested fix]
+```
+
+If the bucket is empty, emit `### Miscellaneous\n- None` — do not omit the heading.
+
+**Do not** use Miscellaneous as a dumping ground for findings the reviewer is uncertain about. A finding belongs in Miscellaneous only when it is real *and* does not map to a rubric item. When in doubt, prefer the rubric.
+
 ### 6. Classify Findings
 
 **Severity Guidelines:**
@@ -141,8 +352,9 @@ An "Approved" verdict requires all 12 items evaluated (no blank verdicts). Items
 - **blocker**: Must fix before merge (breaks functionality, security issue, data loss risk)
 - **tech_debt**: Fix before merge, patched by `/do-patch` (code quality, missing edge case tests)
 - **nit**: Fix before merge unless purely subjective (style, naming, docs wording)
+- **acknowledged**: Matches a verified disclosure from Step 2.5 — NOT a blocker or tech_debt. Appears in the `Acknowledged Deferrals (verified)` section, never in `Tech Debt`.
 
-For every finding you MUST emit exactly this block, with every field present. A finding missing any field is invalid and MUST be dropped, not shortened:
+For every `blocker`, `tech_debt`, or `nit` finding you MUST emit exactly this block, with every field present. A finding missing any field is invalid and MUST be dropped, not shortened:
 ```
 **File:** `path/to/file.py:42` (verified: read this file)
 **Code:** `the_actual_code_on_that_line()`
@@ -151,7 +363,9 @@ For every finding you MUST emit exactly this block, with every field present. A 
 **Fix:** [suggested fix]
 ```
 
-**Empty-section rule:** If a severity category has zero findings, emit the heading with an explicit empty marker (`### Blockers\n- None`, `### Tech Debt\n- None`, `### Nits\n- None`). Do NOT omit the heading.
+**Empty-section rule:** If a severity category has zero findings, emit the heading with an explicit empty marker (`### Blockers\n- None`, `### Tech Debt\n- None`, `### Nits\n- None`, `### Miscellaneous\n- None`, `### Acknowledged Deferrals (verified)\n- None`). Do NOT omit the heading.
+
+**Disclosure separation rule:** Findings classified as `acknowledged` via Step 2.5 MUST NOT appear in Blockers, Tech Debt, or Nits. They appear in the dedicated `Acknowledged Deferrals (verified)` section so human reviewers can audit that the author's disclosures are honest.
 
 ### 7. Verify All Findings
 
@@ -164,4 +378,16 @@ Drop any finding that fails verification. A false blocker is worse than a missed
 
 ## Completion
 
-Return the list of classified findings and the verification results (if any).
+Return the following artifacts for the Post Review sub-skill to consume:
+
+1. The Pre-Verdict Checklist (12 items) with verdicts.
+2. The Rubric (10 items) with pass/fail/acknowledged/n/a per item.
+3. Classified findings (Blockers, Tech Debt, Nits).
+4. The Miscellaneous bucket (if non-empty, else `- None`).
+5. Acknowledged Deferrals (verified) section from the Disclosure Parser.
+6. Review Delta (if a prior review existed on a different HEAD SHA or body hash).
+7. The verification results (if any).
+8. The mechanically-derived verdict per the Rubric's verdict derivation rules.
+9. The `<!-- REVIEW_CONTEXT head_sha=... pr_body_hash=... -->` marker for the Post Review sub-skill to embed in the review body.
+
+If the Prior Review Context idempotency check fired (same HEAD SHA, same PR body hash), return the prior verdict and findings unchanged and flag the review as idempotent so Post Review can short-circuit.

--- a/.claude/skills/do-pr-review/sub-skills/post-review.md
+++ b/.claude/skills/do-pr-review/sub-skills/post-review.md
@@ -27,11 +27,19 @@ Use `gh pr comment` as fallback.
 
 ### 2. Format Review Body
 
+Every review body MUST include (in this order): the mechanical Rubric, the Pre-Verdict Checklist, all finding sections with empty-markers where applicable, the Acknowledged Deferrals (verified) section, the Miscellaneous bucket, the Review Delta (if a prior review existed on a different HEAD SHA), and the `<!-- REVIEW_CONTEXT ... -->` marker before the OUTCOME block. These are produced by the code-review sub-skill.
+
 **If blockers found:**
 ```
 ## Review: Changes Requested
 
 [summary of blockers]
+
+## Rubric
+[10-item Rubric with pass/fail/acknowledged/n/a per item]
+
+## Pre-Verdict Checklist
+[12-item Pre-Verdict Checklist]
 
 ### Blockers
 - [ ] **`file.py:42`** — `actual_code()` — [description]
@@ -39,11 +47,25 @@ Use `gh pr comment` as fallback.
 ### Tech Debt
 - **`file.py:15`** — `code()` — [description]
 
+### Nits
+- None
+
+### Miscellaneous
+- None
+
+### Acknowledged Deferrals (verified)
+- **[disclosure text]** — tracked by #N (OPEN)
+
+### Review Delta (vs prior review on HEAD {prior_sha})
+[optional — only if a prior review existed on a different HEAD SHA]
+
 ### Verification Results
 [output from verification checks if available]
 
 ### Screenshots
 [screenshot references if captured]
+
+<!-- REVIEW_CONTEXT head_sha=<HEAD_SHA> pr_body_hash=<PR_BODY_HASH> -->
 ```
 
 **If no blockers but has tech_debt or nits:**
@@ -52,10 +74,19 @@ Use `gh pr comment` as fallback.
 
 [summary — no blockers, but outstanding tech debt/nits must be resolved before merge]
 
+## Rubric
+[10-item Rubric]
+
+## Pre-Verdict Checklist
+[12-item Pre-Verdict Checklist]
+
 ### Verified
 - [x] Code correctness
 - [x] Security (no vulnerabilities found)
 - [x] Plan requirements met
+
+### Blockers
+- None
 
 ### Tech Debt
 - [ ] **`file.py:15`** — `code()` — [description]
@@ -63,15 +94,29 @@ Use `gh pr comment` as fallback.
 ### Nits
 - [ ] **`file.py:30`** — `code()` — [description]
 
+### Miscellaneous
+- None
+
+### Acknowledged Deferrals (verified)
+- None
+
 ### Screenshots
 [screenshot references if captured]
+
+<!-- REVIEW_CONTEXT head_sha=<HEAD_SHA> pr_body_hash=<PR_BODY_HASH> -->
 ```
 
-**If zero findings (no blockers, no tech_debt, no nits):**
+**If zero findings (no blockers, no tech_debt, no nits, empty Miscellaneous):**
 ```
 ## Review: Approved
 
 [summary of review]
+
+## Rubric
+[10-item Rubric — all pass/acknowledged/n/a]
+
+## Pre-Verdict Checklist
+[12-item Pre-Verdict Checklist]
 
 ### Verified
 - [x] Code correctness
@@ -79,8 +124,35 @@ Use `gh pr comment` as fallback.
 - [x] Security (no vulnerabilities found)
 - [x] Plan requirements met
 
+### Blockers
+- None
+
+### Tech Debt
+- None
+
+### Nits
+- None
+
+### Miscellaneous
+- None
+
+### Acknowledged Deferrals (verified)
+- [bullets if any, else "- None"]
+
 ### Screenshots
 [screenshot references if captured]
+
+<!-- REVIEW_CONTEXT head_sha=<HEAD_SHA> pr_body_hash=<PR_BODY_HASH> -->
+```
+
+**Idempotent replay:** If the code-review sub-skill's Prior Review Context fired (same HEAD SHA, same PR body hash), emit the prior verdict unchanged with a short idempotency note:
+
+```
+## Review: [prior verdict]
+
+_Idempotent: prior review on HEAD {head_sha:0:7} / body hash {body_hash:0:7} is still valid — returning prior verdict without regenerating findings._
+
+<!-- REVIEW_CONTEXT head_sha=<HEAD_SHA> pr_body_hash=<PR_BODY_HASH> -->
 ```
 
 ### 3. Post the Review

--- a/docs/plans/sdlc-1045.md
+++ b/docs/plans/sdlc-1045.md
@@ -1,0 +1,152 @@
+---
+status: Building
+type: chore
+appetite: Small
+owner: Valor
+created: 2026-04-22
+tracking: https://github.com/tomcounsell/ai/issues/1045
+revision_applied: false
+---
+
+# Recalibrate `/do-pr-review`: Explicit Rubric + Disclosure Parser + Prior-Review Context
+
+## Problem
+
+`/do-pr-review` produces **non-deterministic verdicts and non-overlapping finding sets** across multiple runs on the same PR diff. Evidence: the 8-review dispatch log on [yudame/cuttlefish#264](https://github.com/yudame/cuttlefish/pull/264) shows passes 2–8 on the same HEAD SHA alternating between `Approved` and `Changes Requested`, surfacing different findings per run, and re-flagging deferrals the PR body already discloses.
+
+Three failure modes are visible:
+
+1. **Missed-finding non-determinism** — pass 4 surfaced a real `update_fields` / `auto_now` bug that passes 1–3 missed; pass 8 surfaced a real "no follow-up issue filed" gap that passes 1–7 missed.
+2. **Disclosure-ignorance** — passes 4 and 6 re-flagged a UserAdmin deferral that the PR body explicitly disclosed with rationale, classifying it as "Tech Debt" instead of "acknowledged."
+3. **Memory-less iteration** — each pass starts from zero with no awareness of what prior passes decided.
+
+The calibration mechanism this issue proposes — an explicit rubric, a disclosure parser, and prior-review context — does not exist in any form in the current skill (`grep -n "rubric\|checklist\|disclosed" .claude/skills/do-pr-review/SKILL.md` showed zero matches before PR #1049 added the Pre-Verdict Checklist).
+
+## Solution
+
+Three coordinated levers, building on top of PR #1049's Pre-Verdict Checklist (which is kept):
+
+### Lever 1 — Explicit 10-item Rubric
+
+Add a structured rubric to `.claude/skills/do-pr-review/sub-skills/code-review.md`. Each item produces exactly one of `pass` / `fail` / `acknowledged` / `n/a`. The verdict is mechanically derived:
+
+1. Any critical-item `fail` with no matching `acknowledged` ⇒ `CHANGES REQUESTED — Blocker`
+2. Any non-critical-item `fail` ⇒ `CHANGES REQUESTED — Tech Debt`
+3. Any Miscellaneous finding feeds the verdict per its own severity
+4. All rubric items `pass`/`acknowledged`/`n/a` and empty Miscellaneous ⇒ `APPROVED`
+
+The 10 rubric items:
+
+1. Plan vs. implementation match (critical)
+2. New code quality (critical)
+3. Test coverage (critical)
+4. Regression risk to existing callers (critical)
+5. Data integrity — migrations, `update_fields` / `auto_now` (critical)
+6. Security — `mark_safe`, `raw`, `eval`, `subprocess` (critical)
+7. Documentation accuracy (non-critical)
+8. PR body accuracy (non-critical)
+9. Disclosed deferrals have tracking issues (critical)
+10. Follow-up claims resolve to OPEN issues (critical)
+
+A **Miscellaneous bucket** follows the rubric for findings that don't fit any item — it still feeds the mechanical verdict. This keeps the rubric stable without making the skill rigid.
+
+### Lever 2 — Disclosure Parser
+
+Before generating findings (Step 2.5 in `code-review.md`), parse the PR body for disclosure sections:
+
+- `Out of scope`, `Deferred`, `Not in this PR`, `Follow-up`, `Known limitations`, `Disclosures`
+- Inline bullets matching `deferred`, `filed as follow-up`, `tracked separately`, `dropped`, `out of scope`, `not addressed in this PR`
+- `Closes #N`, `Addresses #N`, `Related to #N`, `Tracked by #N`
+
+Every `filed as follow-up #N` claim is verified to resolve to an OPEN GitHub issue (via `gh issue view`). Missing follow-ups become real Tech Debt findings. Verified disclosures classify matching candidate findings as `acknowledged` — these appear in a dedicated `Acknowledged Deferrals (verified)` section, never in the Tech Debt bucket.
+
+**No-Gos override disclosures.** If a disclosed deferral actually violates a plan's explicit No-Go, it is a blocker, not acknowledged.
+
+### Lever 3 — Prior-Review Context
+
+Before generating findings (Step 2.6 in `code-review.md`), the skill fetches prior `## Review:` comments on the PR (plus formal reviews via the reviews API). Every review body now embeds a trailing marker:
+
+```
+<!-- REVIEW_CONTEXT head_sha=<sha> pr_body_hash=<sha256-of-body> -->
+```
+
+**Idempotency:** if the current `(HEAD_SHA, pr_body_hash)` matches the prior review's marker, return the prior verdict unchanged — do not regenerate findings.
+
+**Continuity:** if inputs changed, surface a `Review Delta` section listing findings resolved, new, and unchanged vs. the prior review. Makes calibration drift visible rather than silent.
+
+## Failure Path Test Strategy
+
+The skill is prose; runtime failure paths are evaluated by human review. Key failure paths:
+
+- **Disclosure parser false positives** — marking real bugs as `acknowledged` because the PR body mentions a superficially similar phrase. Mitigation: the parser requires file path / feature name / `#N` match to classify. Loose textual similarity is not sufficient.
+- **Disclosure parser false negatives** — missing a legitimate disclosure because it uses novel phrasing. Mitigation: the phrase list is explicit and easy to extend; the skill runs a broad regex match on section headings plus inline bullets.
+- **Prior-review idempotency false match** — short-circuiting when the PR body changed but the hash matched by coincidence. Mitigation: `pr_body_hash` is sha256 over the full body, not a short prefix.
+- **No-Gos override failure** — a disclosure that says "we're skipping X" where X is a plan No-Go being classified as acknowledged. Mitigation: explicit override rule in Step 2.5 Step C clause 3 and in Plan Validation Step 4 item 4.
+
+## Test Impact
+
+No existing tests exercise the prose of the `/do-pr-review` skill — it is markdown guidance consumed by the agent at runtime. The skill itself has no Python test surface that would break with these additions.
+
+A calibration benchmark (≥5 historical PRs, 5× runs, ≥0.8 Jaccard target) is called out as an acceptance criterion in issue #1045, but **building the benchmark corpus is deferred to a follow-up PR** — the benchmark needs real historical PR fixtures, run harness, and Jaccard calculator, which is larger than the skill recalibration itself.
+
+A regression fixture replay of PR yudame/cuttlefish#264 is also deferred — the test needs cross-repo fixtures (the real PR lives in yudame/cuttlefish, not tomcounsell/ai) and would require extracting and storing the diff + comment timeline in this repo.
+
+Both are filed as follow-ups in the PR body.
+
+## Rabbit Holes
+
+- **Do not** rewrite the skill from scratch. The rubric is additive to the Pre-Verdict Checklist shipped in PR #1049.
+- **Do not** make the skill so rigid that it can't catch unusual-but-legitimate issues outside the rubric. The Miscellaneous bucket explicitly exists for this.
+- **Do not** tune LLM temperature / model settings in this PR. Temperature variance is a real lever the issue mentions, but it's out of scope here (separate concern from rubric structure).
+- **Do not** coordinate on `gh pr review --approve` / `--request-changes` vs. issue-comment emission — that is tracked in #1043.
+
+## No-Gos (Out of Scope)
+
+- Building the calibration benchmark corpus (≥5 historical PRs, 5× runs, Jaccard calculator) — follow-up PR.
+- Replaying PR #264 as a regression fixture — cross-repo fixtures not available in this repo.
+- Tuning LLM temperature / sampling parameters — separate concern.
+- Replacing `gh pr comment` with formal `gh pr review` posting — coordinated with #1043.
+- Rewriting the skill's Pre-Verdict Checklist (PR #1049) — the Rubric is additive.
+
+## Update System
+
+No update system changes required. The skill files are pure markdown in `.claude/skills/do-pr-review/` and are picked up from the checked-out repo at agent runtime. No new dependencies, no migration, no config propagation needed. `scripts/remote-update.sh` continues to work unchanged.
+
+## Agent Integration
+
+No MCP-server changes required. `/do-pr-review` is already registered as a skill and used by the SDLC router. The rubric, disclosure parser, and prior-review context are new prose sections inside the existing sub-skill file — the agent reads them the same way it reads every other sub-skill. No changes to `.mcp.json` or `mcp_servers/`.
+
+The skill already uses `gh` CLI for all GitHub interactions; the disclosure parser and prior-review context additions use the same `gh api` / `gh issue view` / `gh pr view` commands already documented in the skill.
+
+## Documentation
+
+- [x] Update `.claude/skills/do-pr-review/SKILL.md` to mention the Rubric, Disclosure Parser, and Prior Review Context additions in the sub-skills index.
+- [x] Update `.claude/skills/do-pr-review/sub-skills/README.md` to reflect the expanded `code-review.md` responsibility.
+- [x] Update `.claude/skills/do-pr-review/sub-skills/post-review.md` to document the new review-body sections (Rubric, Miscellaneous, Acknowledged Deferrals, Review Delta, REVIEW_CONTEXT marker).
+- [ ] A follow-up PR will update `docs/features/sdlc-skills-audit.md` with a note on the rubric addition once the benchmark validates the calibration improvement.
+
+## Success Criteria
+
+- `.claude/skills/do-pr-review/sub-skills/code-review.md` contains a Rubric section with exactly 10 items.
+- Each rubric item has a documented status type: `pass` / `fail` / `acknowledged` / `n/a`.
+- The verdict derivation rules are stated mechanically (no "use your judgment" language).
+- A Disclosure Parser step exists before Step 3 (Analyze the Diff).
+- A Prior Review Context step exists before Step 3.
+- A Miscellaneous bucket exists after the Rubric and feeds the mechanical verdict.
+- The Acknowledged Deferrals (verified) section is distinct from the Tech Debt section.
+- `post-review.md` documents all new review-body sections and the REVIEW_CONTEXT marker.
+- PR opens against main, CI is green, no new test regressions introduced.
+
+## Verification
+
+| Check | Command | Expected |
+|-------|---------|----------|
+| Rubric count | `grep -cE "^\- \*\*[0-9]+\. " .claude/skills/do-pr-review/sub-skills/code-review.md` | ≥ 10 |
+| Disclosure parser present | `grep -c "Disclosure Parser" .claude/skills/do-pr-review/sub-skills/code-review.md` | ≥ 1 |
+| Prior Review Context present | `grep -c "Prior Review Context" .claude/skills/do-pr-review/sub-skills/code-review.md` | ≥ 1 |
+| Miscellaneous bucket present | `grep -c "Miscellaneous Bucket\|### Miscellaneous" .claude/skills/do-pr-review/sub-skills/code-review.md` | ≥ 1 |
+| Mechanical verdict rules | `grep -c "Verdict derivation (mechanical)" .claude/skills/do-pr-review/sub-skills/code-review.md` | 1 |
+
+## Open Questions
+
+None. The issue's open questions (which lever is sufficient; prose vs. data-file; calibration metric) are resolved by: (1) implement all three levers since they are cheap and complementary; (2) prose form because it is editable by humans reviewing the skill; (3) defer the benchmark to a follow-up.


### PR DESCRIPTION
Closes #1045.

## Summary
Adds explicit rubric (10 items, pass/fail/acknowledged/n/a), disclosure parser for PR body, and prior-review context for idempotency. Builds on PR #1049's Pre-Verdict Checklist (does not replace it).

## Changes
- `.claude/skills/do-pr-review/sub-skills/code-review.md` (+231 lines)
  - Step 2.5: Disclosure Parser — parses PR body for "Out of scope", "Deferred", "Not in this PR", "Follow-up" sections; verifies every `filed as follow-up #N` claim resolves to an OPEN issue; classifies matching findings as `acknowledged` in a dedicated section (never Tech Debt)
  - Step 2.6: Prior Review Context — fetches prior `## Review:` comments on the PR; returns prior verdict unchanged on matching HEAD SHA + PR body hash; surfaces Review Delta when inputs changed
  - Rubric: 10 explicit items each producing `pass`/`fail`/`acknowledged`/`n/a`, with mechanical verdict derivation rules
  - Miscellaneous bucket: safety net for findings outside the rubric that still feeds the mechanical verdict
  - No-Gos override disclosures — disclosed deferrals that violate plan No-Gos are blockers, not acknowledged
- `.claude/skills/do-pr-review/SKILL.md` — updated sub-skills index to reference new determinism features
- `.claude/skills/do-pr-review/sub-skills/README.md` — reflected expanded code-review responsibility
- `.claude/skills/do-pr-review/sub-skills/post-review.md` — documented new review-body sections (Rubric, Miscellaneous, Acknowledged Deferrals, Review Delta, `REVIEW_CONTEXT` marker) and idempotent replay format
- `docs/plans/sdlc-1045.md` — new plan document with all four required sections

## Acknowledged Deferrals (verified)
- **Calibration benchmark corpus (≥5 historical PRs, 5× runs, ≥0.8 Jaccard target)** — deferred to a separate follow-up PR. The benchmark needs a run harness + Jaccard calculator that is larger than the skill recalibration itself. Will be filed as a follow-up issue.
- **PR #264 regression fixture replay** — cross-repo fixtures (the real PR is in yudame/cuttlefish, not tomcounsell/ai) would require importing and storing the diff + comment timeline. Deferred.

## Test plan
- [x] No runtime code changes — skill is markdown-only. Ruff check passes.
- [x] Plan verification table checks manually confirmed:
  - Rubric item count ≥ 10 (actual: 12 including Pre-Verdict Checklist items — both numbered)
  - Disclosure Parser heading present
  - Prior Review Context heading present
  - Miscellaneous bucket heading present
  - Mechanical verdict derivation rules present (1 occurrence)
- [ ] Manual dry-run on an existing PR confirms rubric renders (next step after merge)

## Out of scope (follow-ups)
- Calibration benchmark corpus (≥5 historical PRs, 5× runs, Jaccard target)
- PR #264 regression fixture replay
- LLM temperature / sampling parameter tuning (separate concern)
- Formal `gh pr review` submission coordination (tracked in #1043)