### PR TITLE
feat(#1111): shared AsyncAnthropic semaphore across all call sites

### DIFF
--- a/agent/anthropic_client.py
+++ b/agent/anthropic_client.py
@@ -1,0 +1,135 @@
+"""Shared AsyncAnthropic client with rate-limit semaphore (#1111).
+
+Every call site across ``bridge/``, ``tools/``, and ``agent/`` goes through
+this module instead of constructing its own ``anthropic.AsyncAnthropic``.
+A process-wide ``asyncio.Semaphore`` gates concurrent API calls so fan-out
+never breaches Anthropic's per-minute request limits.
+
+Two entry points:
+
+* ``anthropic_slot()`` — the ergonomic context manager. Acquires a slot,
+  constructs a fresh ``AsyncAnthropic`` client, yields it, then releases
+  the slot on exit. Use for the common case::
+
+      async with anthropic_slot() as client:
+          msg = await client.messages.create(...)
+
+* ``semaphore_slot()`` — semaphore-only variant. Acquires a slot but does
+  NOT construct a client. Use at sites with site-specific client
+  invariants (e.g. ``agent/memory_extraction.py`` needs
+  ``async with anthropic.AsyncAnthropic(timeout=...) as client:`` for
+  hotfix #1055 httpx cleanup)::
+
+      async with semaphore_slot():
+          async with anthropic.AsyncAnthropic(timeout=...) as client:
+              await client.messages.create(...)
+
+Both acquire the same module-level semaphore, so mixing them is fine.
+
+Configuration:
+    ``settings.features.anthropic_concurrency`` (default 5, range 1-50).
+    Override with the ``FEATURES__ANTHROPIC_CONCURRENCY`` env var.
+
+Design notes:
+    * Slot count is read once at module import time. Changing the setting
+      at runtime requires a process restart (this matches the rest of
+      ``FeatureSettings``, which is startup-config).
+    * ``_semaphore`` is a module-level private for test monkeypatching.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import anthropic
+
+from config.settings import settings
+from utils.api_keys import get_anthropic_api_key
+
+# Module-level semaphore — slot count read once at import time from
+# ``settings.features.anthropic_concurrency``. Tests monkeypatch this attr
+# directly to simulate tight/loose limits.
+_semaphore: asyncio.Semaphore = asyncio.Semaphore(settings.features.anthropic_concurrency)
+
+
+class _AnthropicGuard:
+    """Async context manager that acquires a semaphore slot then yields a client.
+
+    On ``__aenter__``: acquire the shared semaphore, then construct and
+    return a fresh ``anthropic.AsyncAnthropic`` client keyed with the
+    resolved API key. On ``__aexit__``: release the slot (always, even
+    on exception).
+
+    The returned client is ephemeral — each ``anthropic_slot()`` call
+    creates a new ``AsyncAnthropic`` instance so httpx connection pools
+    are not shared across call sites. This matches the prior per-site
+    behaviour; the only new thing is the gating semaphore.
+    """
+
+    def __init__(self) -> None:
+        self._client: anthropic.AsyncAnthropic | None = None
+        self._acquired = False
+
+    async def __aenter__(self) -> anthropic.AsyncAnthropic:
+        await _semaphore.acquire()
+        self._acquired = True
+        self._client = anthropic.AsyncAnthropic(api_key=get_anthropic_api_key())
+        return self._client
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        if self._acquired:
+            _semaphore.release()
+            self._acquired = False
+        # Do not swallow exceptions.
+        return None
+
+
+class _SemaphoreOnlyGuard:
+    """Async context manager that only acquires/releases the semaphore slot.
+
+    Used at call sites with bespoke client invariants (e.g.
+    ``agent/memory_extraction.py`` which needs ``async with
+    anthropic.AsyncAnthropic(timeout=...) as client:`` for hotfix #1055
+    httpx cleanup). The caller constructs the client; this guard just
+    gates concurrency.
+    """
+
+    def __init__(self) -> None:
+        self._acquired = False
+
+    async def __aenter__(self) -> None:
+        await _semaphore.acquire()
+        self._acquired = True
+        return None
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        if self._acquired:
+            _semaphore.release()
+            self._acquired = False
+        return None
+
+
+def anthropic_slot() -> _AnthropicGuard:
+    """Return a fresh context manager that gates on the shared semaphore.
+
+    Use as::
+
+        async with anthropic_slot() as client:
+            msg = await client.messages.create(...)
+    """
+    return _AnthropicGuard()
+
+
+def semaphore_slot() -> _SemaphoreOnlyGuard:
+    """Return a fresh context manager that acquires the slot without a client.
+
+    Use when a call site needs its own ``AsyncAnthropic`` construction
+    (e.g. with ``timeout=``, inside its own ``async with`` for httpx
+    cleanup). The slot is released on exit so the caller can still
+    create the client inside the slot's lifetime::
+
+        async with semaphore_slot():
+            async with anthropic.AsyncAnthropic(timeout=30.0) as client:
+                msg = await client.messages.create(...)
+    """
+    return _SemaphoreOnlyGuard()

--- a/agent/health_check.py
+++ b/agent/health_check.py
@@ -353,7 +353,7 @@ async def _judge_health(activity: str, session_context: str = "") -> dict[str, A
         activity: Formatted tool call activity summary.
         session_context: Optional session context preamble (session_type + task).
     """
-    import anthropic
+    from agent.anthropic_client import anthropic_slot
 
     api_key = _get_api_key()
     if not api_key:
@@ -366,12 +366,13 @@ async def _judge_health(activity: str, session_context: str = "") -> dict[str, A
         session_context=session_context,
     )
 
-    client = anthropic.AsyncAnthropic(api_key=api_key)
-    response = await client.messages.create(
-        model=MODEL_FAST,
-        max_tokens=150,
-        messages=[{"role": "user", "content": prompt}],
-    )
+    # Shared semaphore-gated client (#1111)
+    async with anthropic_slot() as client:
+        response = await client.messages.create(
+            model=MODEL_FAST,
+            max_tokens=150,
+            messages=[{"role": "user", "content": prompt}],
+        )
 
     text = response.content[0].text if response.content else ""
 

--- a/agent/memory_extraction.py
+++ b/agent/memory_extraction.py
@@ -60,6 +60,13 @@ async def _llm_call(
       * ``timeout=_EXTRACTION_SDK_TIMEOUT`` SDK kwarg so the SDK raises a
         typed ``APITimeoutError`` first for cleaner logs.
 
+    Also gated by the shared ``agent.anthropic_client.semaphore_slot()``
+    (#1111) so memory-extraction fan-out counts against the process-wide
+    concurrency budget. The semaphore slot wraps the whole call, including
+    ``async with anthropic.AsyncAnthropic(...)`` and
+    ``asyncio.wait_for(...)``, so the slot is held for the entire
+    in-flight API request.
+
     Constants are read at call time (not captured) so test monkeypatching of
     ``_EXTRACTION_SDK_TIMEOUT`` / ``_EXTRACTION_HARD_TIMEOUT`` works (see
     ``test_real_asyncio_wait_for_fires_with_tightened_constants``).
@@ -70,20 +77,22 @@ async def _llm_call(
     """
     import anthropic
 
+    from agent.anthropic_client import semaphore_slot
     from utils.api_keys import get_anthropic_api_key
 
-    async with anthropic.AsyncAnthropic(
-        api_key=get_anthropic_api_key(), timeout=_EXTRACTION_SDK_TIMEOUT
-    ) as client:
-        message = await asyncio.wait_for(
-            client.messages.create(
-                model=model,
-                max_tokens=max_tokens,
-                messages=messages,
-                timeout=_EXTRACTION_SDK_TIMEOUT,
-            ),
-            timeout=_EXTRACTION_HARD_TIMEOUT,
-        )
+    async with semaphore_slot():
+        async with anthropic.AsyncAnthropic(
+            api_key=get_anthropic_api_key(), timeout=_EXTRACTION_SDK_TIMEOUT
+        ) as client:
+            message = await asyncio.wait_for(
+                client.messages.create(
+                    model=model,
+                    max_tokens=max_tokens,
+                    messages=messages,
+                    timeout=_EXTRACTION_SDK_TIMEOUT,
+                ),
+                timeout=_EXTRACTION_HARD_TIMEOUT,
+            )
     return message.content[0].text.strip()
 
 

--- a/bridge/message_drafter.py
+++ b/bridge/message_drafter.py
@@ -27,9 +27,9 @@ from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 
-import anthropic
 import httpx
 
+from agent.anthropic_client import anthropic_slot
 from bridge.message_quality import PROCESS_NARRATION_PATTERNS as _PROCESS_NARRATION_PATTERNS
 from config.enums import SessionType
 from config.models import MODEL_FAST, OPENROUTER_HAIKU, OPENROUTER_URL
@@ -895,20 +895,20 @@ async def classify_output(text: str) -> ClassificationResult:
             _write_classification_audit(text, result, source="heuristic")
             return result
 
-        client = anthropic.AsyncAnthropic(api_key=api_key)
-
         # Truncate very long text to save tokens — classification
         # only needs the beginning and end of the output
         classify_text = text
         if len(text) > 2000:
             classify_text = text[:1000] + "\n\n[...truncated...]\n\n" + text[-1000:]
 
-        response = await client.messages.create(
-            model=MODEL_FAST,
-            max_tokens=256,
-            system=CLASSIFIER_SYSTEM_PROMPT,
-            messages=[{"role": "user", "content": classify_text}],
-        )
+        # Shared semaphore-gated client (#1111)
+        async with anthropic_slot() as client:
+            response = await client.messages.create(
+                model=MODEL_FAST,
+                max_tokens=256,
+                system=CLASSIFIER_SYSTEM_PROMPT,
+                messages=[{"role": "user", "content": classify_text}],
+            )
 
         raw_response = response.content[0].text.strip()
         result = _parse_classification_response(raw_response)
@@ -1361,18 +1361,17 @@ async def _draft_with_haiku(prompt: str) -> StructuredDraft | None:
             logger.warning("No Anthropic API key found for drafting")
             return None
 
-        client = anthropic.AsyncAnthropic(api_key=api_key)
-
-        # Try tool_use for structured output
+        # Try tool_use for structured output (shared semaphore-gated client, #1111)
         try:
-            response = await client.messages.create(
-                model=MODEL_FAST,
-                max_tokens=1024,
-                system=DRAFTER_SYSTEM_PROMPT,
-                messages=[{"role": "user", "content": prompt}],
-                tools=[STRUCTURED_DRAFT_TOOL],
-                tool_choice={"type": "tool", "name": "structured_draft"},
-            )
+            async with anthropic_slot() as client:
+                response = await client.messages.create(
+                    model=MODEL_FAST,
+                    max_tokens=1024,
+                    system=DRAFTER_SYSTEM_PROMPT,
+                    messages=[{"role": "user", "content": prompt}],
+                    tools=[STRUCTURED_DRAFT_TOOL],
+                    tool_choice={"type": "tool", "name": "structured_draft"},
+                )
 
             # Parse tool_use response — tool_use returns the input dict directly
             for block in response.content:
@@ -1388,13 +1387,15 @@ async def _draft_with_haiku(prompt: str) -> StructuredDraft | None:
         except Exception as e:
             logger.warning(f"Haiku tool_use failed, falling back to text-only: {e}")
 
-        # Fallback: text-only Haiku (no structured routing fields)
-        response = await client.messages.create(
-            model=MODEL_FAST,
-            max_tokens=512,
-            system=DRAFTER_SYSTEM_PROMPT,
-            messages=[{"role": "user", "content": prompt}],
-        )
+        # Fallback: text-only Haiku (no structured routing fields). Reacquire
+        # a semaphore slot for the second API call (#1111).
+        async with anthropic_slot() as client:
+            response = await client.messages.create(
+                model=MODEL_FAST,
+                max_tokens=512,
+                system=DRAFTER_SYSTEM_PROMPT,
+                messages=[{"role": "user", "content": prompt}],
+            )
         text_result = response.content[0].text
         return StructuredDraft(
             context_summary="",

--- a/bridge/session_router.py
+++ b/bridge/session_router.py
@@ -12,8 +12,7 @@ Always-on (no feature flag). Confidence threshold: >= 0.80 for auto-routing.
 import json
 import logging
 
-import anthropic
-
+from agent.anthropic_client import anthropic_slot
 from config.models import MODEL_FAST
 from utils.api_keys import get_anthropic_api_key
 
@@ -121,12 +120,13 @@ Rules:
             logger.warning("No API key for semantic routing, skipping")
             return (None, 0.0)
 
-        client = anthropic.AsyncAnthropic(api_key=api_key)
-        response = await client.messages.create(
-            model=MODEL_FAST,
-            max_tokens=256,
-            messages=[{"role": "user", "content": classifier_prompt}],
-        )
+        # Shared semaphore-gated client (#1111)
+        async with anthropic_slot() as client:
+            response = await client.messages.create(
+                model=MODEL_FAST,
+                max_tokens=256,
+                messages=[{"role": "user", "content": classifier_prompt}],
+            )
 
         raw = response.content[0].text.strip()
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -176,11 +176,26 @@ class ModelSettings(BaseModel):
 
 
 class FeatureSettings(BaseModel):
-    """Structural placeholder for future feature flags.
+    """Feature-flag configuration for optional behaviours.
 
     All flags are startup-config (read once at process start); default values
     should represent the desired end state, not legacy behavior.
     """
+
+    anthropic_concurrency: int = Field(
+        default=5,
+        ge=1,
+        le=50,
+        description=(
+            "Maximum concurrent AsyncAnthropic API calls across all call sites "
+            "in bridge/, tools/, and agent/. Enforced by a shared asyncio.Semaphore "
+            "in agent/anthropic_client.py. Conservative default of 5 covers all "
+            "migrated sites fanning out at once without breaching Anthropic's "
+            "per-minute request limits on a solo-dev account. Override via "
+            "FEATURES__ANTHROPIC_CONCURRENCY env var (pydantic-settings nested "
+            "delimiter). See issue #1111."
+        ),
+    )
 
 
 class PathSettings(BaseModel):

--- a/docs/plans/sdlc-1111.md
+++ b/docs/plans/sdlc-1111.md
@@ -1,0 +1,225 @@
+# Plan: Shared AsyncAnthropic rate-limit semaphore (#1111)
+
+## Problem
+
+Five independent call sites (plus one hotfix-protected site in
+`agent/memory_extraction.py` and a watchdog in `agent/health_check.py`)
+construct `anthropic.AsyncAnthropic(...)` clients independently. There
+is no shared rate limiting across them. The currently-serialized worker
+masks the issue (roughly 1-2 concurrent calls in steady state), but any
+move to concurrent session execution — or any fan-out during burst
+activity (rapid session classification, message drafting, and semantic
+routing firing together on a Telegram storm) — could breach Anthropic's
+per-minute request limits on the solo-dev account.
+
+The call sites are:
+
+- `tools/classifier.py:179` — async work-request classification
+- `tools/classifier.py:411` — async intent classification
+- `bridge/message_drafter.py:898` — async output-type classification
+- `bridge/message_drafter.py:1364` — async draft-with-haiku (structured
+  and text-only fallback: two API calls in one function)
+- `bridge/session_router.py:124` — async semantic session routing
+- `agent/memory_extraction.py:_llm_call` — three call sites routed
+  through one helper (hotfix #1055 invariants apply)
+- `agent/health_check.py:369` — watchdog judge
+
+## Scope
+
+Introduce a process-wide `asyncio.Semaphore` in a new shared module
+`agent/anthropic_client.py`. Every AsyncAnthropic construction in
+`bridge/`, `tools/`, and `agent/` must acquire a slot on this
+semaphore before making an API call. Slot count is configurable via
+`settings.features.anthropic_concurrency` (default 5, env var
+`FEATURES__ANTHROPIC_CONCURRENCY`).
+
+### Two entry points
+
+The shared module exposes two complementary context managers:
+
+1. `anthropic_slot()` — the ergonomic default. Acquires a slot,
+   constructs a fresh `AsyncAnthropic`, yields it, releases the slot
+   on exit. Use at the five primary sites.
+
+2. `semaphore_slot()` — slot-only. Acquires the slot but does not
+   construct a client. Used at `agent/memory_extraction.py::_llm_call`
+   where the site must preserve hotfix #1055 invariants
+   (`async with anthropic.AsyncAnthropic(timeout=...)` + double-timeout
+   with `asyncio.wait_for` for httpx cleanup).
+
+## Files Changed
+
+- `agent/anthropic_client.py` (new) — shared module with semaphore +
+  two context managers.
+- `config/settings.py` — add `anthropic_concurrency` field to
+  `FeatureSettings` (default 5, range 1-50).
+- `tools/classifier.py` — migrate two AsyncAnthropic sites to
+  `anthropic_slot()`.
+- `bridge/message_drafter.py` — migrate two AsyncAnthropic sites.
+  The `_draft_with_haiku` function has two API calls (tool_use then
+  text-only fallback); each gets its own slot.
+- `bridge/session_router.py` — migrate the one site.
+- `agent/health_check.py` — migrate the watchdog judge site.
+- `agent/memory_extraction.py::_llm_call` — wrap the existing
+  `async with anthropic.AsyncAnthropic(...)` block in
+  `async with semaphore_slot():` so extraction fan-out counts
+  against the shared budget.
+
+## Tests
+
+- `tests/unit/test_anthropic_client_semaphore.py` (new):
+  - Concurrent-acquisition test proving a monkey-patched N=3 semaphore
+    serializes 10 tasks to peak 3 in-flight.
+  - Exception-release test: a slot held through a raising body is
+    returned, and the next acquisition does not deadlock.
+  - Settings test: the field exists, is ge=1, and the module-level
+    `_semaphore._value` at import equals
+    `settings.features.anthropic_concurrency`.
+  - Regression canary grep: no `anthropic.AsyncAnthropic(` outside
+    the two approved modules (`agent/anthropic_client.py` and
+    `agent/memory_extraction.py`).
+  - `agent/memory_extraction.py` must contain `semaphore_slot` so the
+    hotfix site is gated too.
+- `tests/unit/test_message_drafter.py` — two patch targets retargeted
+  from `bridge.message_drafter.anthropic.AsyncAnthropic` to
+  `agent.anthropic_client.anthropic.AsyncAnthropic` (the module
+  `anthropic` import was removed from `bridge/message_drafter.py`).
+
+## Failure Path Test Strategy
+
+- Exception inside the `async with` body: covered by
+  `test_slot_released_on_exception`. Proves the slot is never orphaned
+  even if the API call raises (which is the common production path
+  when Anthropic returns 429/5xx).
+- Concurrency bound: `test_only_n_slots_run_concurrently` monkey-patches
+  `_semaphore` with a deliberately-tight N=3 and asserts peak
+  concurrency never exceeds N even when 10 tasks are queued. Fails
+  loudly if the context manager regresses (e.g. someone removes the
+  `await _semaphore.acquire()`).
+
+## Test Impact
+
+- [x] `tests/unit/test_message_drafter.py` — UPDATE: eight `patch(...)`
+      targets in `TestClassifyOutput` move from
+      `bridge.message_drafter.anthropic.AsyncAnthropic` to
+      `agent.anthropic_client.anthropic.AsyncAnthropic`. The `import
+      anthropic` at module level in `bridge/message_drafter.py` was
+      dropped because the module no longer references it directly.
+- [x] `tests/unit/test_memory_extraction.py` — NO CHANGE NEEDED: tests
+      patch `anthropic.AsyncAnthropic` globally (module-level), and the
+      shared module also imports `anthropic` and calls
+      `anthropic.AsyncAnthropic(...)`, so global patches still apply.
+      The hotfix #1055 review-guard tests (`test_sdk_api_timeout_caught_and_logged`,
+      `test_real_asyncio_wait_for_fires_with_tightened_constants`,
+      `test_no_sync_anthropic_client_grep_canary`,
+      `test_extract_post_merge_learning_runs_inside_asyncio_run`) all
+      continue to pass — verified.
+- [x] `tests/unit/test_intake_classifier.py`, `tests/unit/test_intent_classifier.py`,
+      `tests/unit/test_work_request_classifier.py` — NO CHANGE: these
+      tests don't patch AsyncAnthropic directly; they exercise logic
+      paths around `get_anthropic_api_key` returning empty. Verified.
+- [x] `tests/unit/test_health_check.py` — NO CHANGE: tests mock the
+      judge path at the function level, not the AsyncAnthropic level.
+      Verified.
+- [x] `tests/unit/test_coalescing_guard.py` — NO CHANGE: tests don't
+      touch session_router's AsyncAnthropic usage.
+
+## Rabbit Holes
+
+- Do NOT migrate the two sync `anthropic.Anthropic(...)` calls in
+  `tools/classifier.py` (lines 84 and 322). `asyncio.Semaphore` can
+  only gate async code; the sync paths are a separate concern outside
+  the scope of #1111.
+- Do NOT touch the OpenRouter fallback path in
+  `bridge/message_drafter.py::_draft_with_openrouter`. It uses httpx
+  directly against OpenRouter's API, not Anthropic's, so the
+  semaphore does not apply.
+- Do NOT extend the semaphore to span `asyncio.wait_for` timeouts.
+  In `memory_extraction.py`, the slot wraps the `async with
+  anthropic.AsyncAnthropic(...)` block which wraps the `wait_for`;
+  this ordering means a timeout releases the slot as soon as the
+  outer context managers exit. Inverting this would risk the slot
+  never being released if the SDK timer doesn't fire.
+- Do NOT make the slot count runtime-reconfigurable. The value is read
+  once at module import; consistent with the rest of `FeatureSettings`.
+
+## Risks
+
+- **Risk 1: Worker starvation at tight concurrency**
+  If the operator sets `FEATURES__ANTHROPIC_CONCURRENCY=1` and the
+  worker handles multiple Telegram sessions fanning out, each session
+  waits in line. Mitigation: default is 5, range is 1-50, and the
+  field's docstring explicitly calls out the operational meaning.
+- **Risk 2: Test patches go stale**
+  `bridge/message_drafter.py` no longer directly imports `anthropic`,
+  so `patch("bridge.message_drafter.anthropic.AsyncAnthropic")` fails
+  with AttributeError. Mitigation: the 8 affected tests have been
+  retargeted to `agent.anthropic_client.anthropic.AsyncAnthropic` in
+  this PR.
+- **Risk 3: memory_extraction hotfix regression**
+  If someone later refactors `_llm_call` and drops the
+  `semaphore_slot()` wrapper, memory-extraction burst on post-session
+  Haiku calls could bypass the budget. Mitigation: the new test
+  `test_memory_extraction_acquires_shared_semaphore` scans source for
+  `semaphore_slot` and fails if it disappears.
+
+## Race Conditions
+
+None introduced. `asyncio.Semaphore` is designed for single-threaded
+asyncio event loops; the worker is single-threaded. All slot
+acquisitions are serialized through the event loop.
+
+## No-Gos (Out of Scope)
+
+- Do not rewrite the sync `anthropic.Anthropic` paths in
+  `tools/classifier.py` to async.
+- Do not introduce a retry/backoff layer — that is a separate feature
+  tracked elsewhere.
+- Do not share httpx connection pools across call sites. Each
+  `anthropic_slot()` call builds a fresh `AsyncAnthropic` (matches
+  pre-migration behaviour; the semaphore is the only new primitive).
+- Do not change the OpenRouter fallback path.
+- Do not touch `reflections/` module code — the reflections loop reads
+  Anthropic indirectly through existing helpers that will transit the
+  semaphore naturally once this lands.
+
+## Update System
+
+No update-system changes required. The new setting
+`FEATURES__ANTHROPIC_CONCURRENCY` has a safe default (5) so unset
+environments inherit the conservative limit automatically. No new
+dependencies, no migration, no config file to propagate. The `/update`
+skill's standard git-pull + dependency-sync covers this change
+automatically.
+
+## Agent Integration
+
+No agent integration required. This is a bridge/tools/agent-internal
+rate-limiting primitive invisible to the LLM. The agent receives no
+new tool and the bridge API is unchanged. MCP surface is unaffected.
+
+## Documentation
+
+- [x] Create `docs/plans/sdlc-1111.md` (this file) documenting the
+      design and rationale.
+- [x] Inline documentation: `agent/anthropic_client.py` has a thorough
+      module docstring describing the two entry points and their
+      use cases.
+- [x] Inline documentation: `agent/memory_extraction.py::_llm_call`
+      docstring updated to mention the shared semaphore.
+- [x] Add entry to `docs/features/` index if one exists for
+      infrastructure primitives — deferred because no equivalent
+      feature doc exists for comparable primitives like
+      `utils/api_keys.py`. Module docstring is the canonical reference.
+
+## Success Criteria
+
+- [x] `grep -rn 'anthropic.AsyncAnthropic(' --include='*.py' agent/ bridge/ tools/` shows hits ONLY in `agent/anthropic_client.py` and `agent/memory_extraction.py`.
+- [x] `pytest tests/unit/test_anthropic_client_semaphore.py` — 6 tests pass.
+- [x] `pytest tests/unit/test_memory_extraction.py` — 70 tests pass (hotfix #1055 invariants preserved).
+- [x] `pytest tests/unit/test_message_drafter.py` — 165 pass, 4 skipped (the 8 retargeted patch tests all green).
+- [x] `pytest tests/unit/test_intake_classifier.py tests/unit/test_intent_classifier.py tests/unit/test_work_request_classifier.py` — 138 pass, 22 skipped.
+- [x] `pytest tests/unit/test_health_check.py` — 33 pass.
+- [x] `python -m ruff format --check .` exits 0 on all changed files.
+- [x] `python -m ruff check .` exits 0 on all changed files.
+- [ ] PR merged; tracking issue #1111 closed automatically via `Closes #1111` in PR body.

--- a/tests/unit/test_anthropic_client_semaphore.py
+++ b/tests/unit/test_anthropic_client_semaphore.py
@@ -1,0 +1,195 @@
+"""Unit tests for the shared AsyncAnthropic semaphore (#1111).
+
+Every bridge/tools/agent call site must go through ``agent.anthropic_client``
+so that an asyncio.Semaphore gates concurrent API calls. This prevents
+fan-out from breaching Anthropic's per-minute request limits.
+
+These tests prove:
+
+1. The semaphore actually serializes concurrent acquisitions to the
+   configured slot count (``anthropic_slot()`` is the public entry point).
+2. The configured value is read from ``settings.features.anthropic_concurrency``
+   (and therefore from the ``ANTHROPIC_CONCURRENCY`` env var by pydantic-settings
+   resolution).
+3. The context manager releases the slot on exception, not just on success.
+4. No stray ``anthropic.AsyncAnthropic(`` instantiations exist outside the
+   shared module (regression canary).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+class TestSemaphoreSerialization:
+    """Prove the shared semaphore actually gates concurrent slots."""
+
+    @pytest.mark.asyncio
+    async def test_only_n_slots_run_concurrently(self, monkeypatch):
+        """With the default configured value, only N slots run at once.
+
+        Spawn 10 tasks, hold each slot with a short sleep, count the
+        maximum observed concurrency. Must equal the configured limit
+        (not 10).
+        """
+        # Force a deterministic small limit for the test — re-build module-level
+        # semaphore against the monkeypatched settings value.
+        from agent import anthropic_client
+
+        monkeypatch.setattr(anthropic_client, "_semaphore", asyncio.Semaphore(3))
+
+        concurrent = 0
+        max_concurrent = 0
+        lock = asyncio.Lock()
+
+        async def worker():
+            nonlocal concurrent, max_concurrent
+            async with anthropic_client.anthropic_slot():
+                async with lock:
+                    concurrent += 1
+                    max_concurrent = max(max_concurrent, concurrent)
+                # Hold the slot briefly so other tasks have a chance to queue
+                await asyncio.sleep(0.05)
+                async with lock:
+                    concurrent -= 1
+
+        await asyncio.gather(*[worker() for _ in range(10)])
+
+        assert max_concurrent == 3, (
+            f"semaphore must serialize to 3 slots, observed peak concurrency of {max_concurrent}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_slot_released_on_exception(self, monkeypatch):
+        """The context manager must release the slot even if the body raises.
+
+        Acquire all slots with a failing body, then prove a follow-up
+        acquisition still succeeds. If the exception leaked the slot,
+        the follow-up would deadlock (we cap with asyncio.wait_for).
+        """
+        from agent import anthropic_client
+
+        monkeypatch.setattr(anthropic_client, "_semaphore", asyncio.Semaphore(1))
+
+        async def failing():
+            async with anthropic_client.anthropic_slot():
+                raise RuntimeError("simulated API error")
+
+        # Drain the one slot via an exception
+        with pytest.raises(RuntimeError, match="simulated API error"):
+            await failing()
+
+        # Second acquisition must complete quickly — if the slot leaked,
+        # wait_for would TimeoutError.
+        async def second():
+            async with anthropic_client.anthropic_slot() as client:
+                return client
+
+        client = await asyncio.wait_for(second(), timeout=1.0)
+        assert client is not None, "post-exception acquisition must yield a client"
+
+
+class TestSemaphoreConfiguration:
+    """Prove the semaphore reads its value from settings.features."""
+
+    def test_default_value_is_configured(self):
+        """settings.features.anthropic_concurrency must have a sane default.
+
+        The default of 5 is conservative enough for a solo-dev Anthropic
+        account even if all five migrated call sites fan out at once.
+        """
+        from config.settings import settings
+
+        # Field exists and is a positive int
+        assert hasattr(settings.features, "anthropic_concurrency")
+        value = settings.features.anthropic_concurrency
+        assert isinstance(value, int)
+        assert value >= 1, "anthropic_concurrency must be at least 1"
+
+    def test_module_semaphore_initialized_from_settings(self):
+        """The module-level _semaphore must be built from the settings value.
+
+        Read the semaphore's internal counter via asyncio.Semaphore._value
+        (private attr; only used in tests) and confirm it matches
+        settings.features.anthropic_concurrency at import time.
+        """
+        from agent import anthropic_client
+        from config.settings import settings
+
+        # _value is the remaining slot count on a freshly-imported semaphore
+        # (no tasks holding slots at module load). It equals the configured limit.
+        assert anthropic_client._semaphore._value == settings.features.anthropic_concurrency
+
+
+class TestSharedModuleIsTheOnlyConstructor:
+    """Regression canary: every AsyncAnthropic construction must be semaphore-gated.
+
+    All call sites in ``bridge/``, ``tools/``, and ``agent/`` that construct
+    ``anthropic.AsyncAnthropic(...)`` must either:
+
+    * go through ``agent/anthropic_client.py::anthropic_slot()`` (the common
+      case — the shared module both acquires the slot and constructs the
+      client), OR
+    * be the module ``agent/memory_extraction.py`` (which acquires the slot
+      via ``semaphore_slot()`` then constructs its own client with hotfix
+      #1055 invariants: ``async with AsyncAnthropic(timeout=...)`` +
+      double-timeout for httpx cleanup).
+
+    Any other direct instantiation bypasses the shared semaphore and
+    regresses #1111.
+    """
+
+    # Modules allowed to construct AsyncAnthropic directly. Each must acquire
+    # the shared semaphore through ``agent.anthropic_client`` in some form.
+    _ALLOWED_DIRECT_CONSTRUCTORS = frozenset(
+        {
+            "agent/anthropic_client.py",  # the shared module itself
+            "agent/memory_extraction.py",  # hotfix #1055 invariants
+        }
+    )
+
+    def test_no_unguarded_async_anthropic_instantiation(self):
+        """Every ``anthropic.AsyncAnthropic(`` must be in an approved module."""
+        import subprocess
+
+        result = subprocess.run(
+            [
+                "grep",
+                "-rn",
+                "anthropic.AsyncAnthropic(",
+                "--include=*.py",
+                "agent/",
+                "bridge/",
+                "tools/",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        hits = [
+            line
+            for line in result.stdout.splitlines()
+            if line and not any(mod in line for mod in self._ALLOWED_DIRECT_CONSTRUCTORS)
+        ]
+        assert not hits, (
+            "anthropic.AsyncAnthropic( outside approved modules "
+            f"{sorted(self._ALLOWED_DIRECT_CONSTRUCTORS)}; found:\n" + "\n".join(hits)
+        )
+
+    def test_memory_extraction_acquires_shared_semaphore(self):
+        """``agent/memory_extraction.py`` must route through ``semaphore_slot()``.
+
+        Even though it constructs its own ``AsyncAnthropic`` for hotfix #1055
+        reasons, the shared semaphore must still gate the call so memory
+        extraction counts against the global concurrency budget (#1111).
+        """
+        from pathlib import Path
+
+        source = Path("agent/memory_extraction.py").read_text()
+        assert "semaphore_slot" in source, (
+            "agent/memory_extraction.py must import and use "
+            "agent.anthropic_client.semaphore_slot to gate the #1111 semaphore "
+            "around its bespoke AsyncAnthropic construction."
+        )

--- a/tests/unit/test_message_drafter.py
+++ b/tests/unit/test_message_drafter.py
@@ -866,7 +866,7 @@ class TestClassifyOutput:
 
         with (
             patch("bridge.message_drafter.get_anthropic_api_key", return_value="sk-test"),
-            patch("bridge.message_drafter.anthropic.AsyncAnthropic", return_value=mock_client),
+            patch("agent.anthropic_client.anthropic.AsyncAnthropic", return_value=mock_client),
         ):
             result = await classify_output("Should I use approach A or B?")
 
@@ -885,7 +885,7 @@ class TestClassifyOutput:
 
         with (
             patch("bridge.message_drafter.get_anthropic_api_key", return_value="sk-test"),
-            patch("bridge.message_drafter.anthropic.AsyncAnthropic", return_value=mock_client),
+            patch("agent.anthropic_client.anthropic.AsyncAnthropic", return_value=mock_client),
         ):
             result = await classify_output("Some ambiguous output")
 
@@ -899,7 +899,7 @@ class TestClassifyOutput:
         with (
             patch("bridge.message_drafter.get_anthropic_api_key", return_value="sk-test"),
             patch(
-                "bridge.message_drafter.anthropic.AsyncAnthropic",
+                "agent.anthropic_client.anthropic.AsyncAnthropic",
                 side_effect=Exception("API error"),
             ),
         ):
@@ -926,7 +926,7 @@ class TestClassifyOutput:
 
         with (
             patch("bridge.message_drafter.get_anthropic_api_key", return_value="sk-test"),
-            patch("bridge.message_drafter.anthropic.AsyncAnthropic", return_value=mock_client),
+            patch("agent.anthropic_client.anthropic.AsyncAnthropic", return_value=mock_client),
         ):
             result = await classify_output("Done. Committed abc1234.")
 
@@ -946,7 +946,7 @@ class TestClassifyOutput:
 
         with (
             patch("bridge.message_drafter.get_anthropic_api_key", return_value="sk-test"),
-            patch("bridge.message_drafter.anthropic.AsyncAnthropic", return_value=mock_client),
+            patch("agent.anthropic_client.anthropic.AsyncAnthropic", return_value=mock_client),
         ):
             result = await classify_output(long_text)
 
@@ -973,7 +973,7 @@ class TestClassifyOutput:
 
         with (
             patch("bridge.message_drafter.get_anthropic_api_key", return_value="sk-test"),
-            patch("bridge.message_drafter.anthropic.AsyncAnthropic", return_value=mock_client),
+            patch("agent.anthropic_client.anthropic.AsyncAnthropic", return_value=mock_client),
         ):
             result = await classify_output("I think the bug is fixed now. Should work.")
 
@@ -997,7 +997,7 @@ class TestClassifyOutput:
 
         with (
             patch("bridge.message_drafter.get_anthropic_api_key", return_value="sk-test"),
-            patch("bridge.message_drafter.anthropic.AsyncAnthropic", return_value=mock_client),
+            patch("agent.anthropic_client.anthropic.AsyncAnthropic", return_value=mock_client),
         ):
             result = await classify_output("All tests pass. Task complete.")
 
@@ -1021,7 +1021,7 @@ class TestClassifyOutput:
 
         with (
             patch("bridge.message_drafter.get_anthropic_api_key", return_value="sk-test"),
-            patch("bridge.message_drafter.anthropic.AsyncAnthropic", return_value=mock_client),
+            patch("agent.anthropic_client.anthropic.AsyncAnthropic", return_value=mock_client),
         ):
             result = await classify_output(
                 "All 42 tests passed. Committed abc1234. PR: https://github.com/org/repo/pull/99"

--- a/tools/classifier.py
+++ b/tools/classifier.py
@@ -33,6 +33,7 @@ import logging
 
 import anthropic
 
+from agent.anthropic_client import anthropic_slot
 from config.models import MODEL_FAST
 from utils.api_keys import get_anthropic_api_key
 
@@ -175,13 +176,13 @@ async def classify_request_async(message: str, context: str = "") -> dict:
             context=context if context else "(none provided)",
         )
 
-        # Call Haiku
-        client = anthropic.AsyncAnthropic(api_key=api_key)
-        response = await client.messages.create(
-            model=MODEL_FAST,
-            max_tokens=200,
-            messages=[{"role": "user", "content": prompt}],
-        )
+        # Call Haiku via shared semaphore-gated client (#1111)
+        async with anthropic_slot() as client:
+            response = await client.messages.create(
+                model=MODEL_FAST,
+                max_tokens=200,
+                messages=[{"role": "user", "content": prompt}],
+            )
 
         # Extract and parse JSON response
         content = response.content[0].text.strip()
@@ -408,12 +409,13 @@ async def classify_message_intent_async(
             session_status=session_status if session_status else "(unknown)",
         )
 
-        client = anthropic.AsyncAnthropic(api_key=api_key)
-        response = await client.messages.create(
-            model=MODEL_FAST,
-            max_tokens=200,
-            messages=[{"role": "user", "content": prompt}],
-        )
+        # Shared semaphore-gated client (#1111)
+        async with anthropic_slot() as client:
+            response = await client.messages.create(
+                model=MODEL_FAST,
+                max_tokens=200,
+                messages=[{"role": "user", "content": prompt}],
+            )
 
         content = response.content[0].text.strip()
         result = _parse_json_response(content)


### PR DESCRIPTION
Closes #1111.

## Summary

Introduces `agent/anthropic_client.py` with an `asyncio.Semaphore` gating all `AsyncAnthropic` API calls across `bridge/`, `tools/`, and `agent/`. Config-driven value (`FEATURES__ANTHROPIC_CONCURRENCY` env var, default 5) prevents fan-out from breaching Anthropic's per-minute request limits on the solo-dev account.

Two entry points:
- `anthropic_slot()` — ergonomic default: acquires a slot and yields a fresh `AsyncAnthropic`.
- `semaphore_slot()` — slot-only: for sites with bespoke client invariants (e.g. `agent/memory_extraction.py` needs `async with AsyncAnthropic(timeout=...)` + double-timeout for hotfix #1055 httpx cleanup).

## Migrated call sites

- `tools/classifier.py` (2 sites: async work-request + intent classification)
- `bridge/message_drafter.py` (2 sites: output classification + draft-with-haiku tool_use + text fallback = two slot acquisitions in one function)
- `bridge/session_router.py` (semantic routing)
- `agent/health_check.py` (watchdog judge)
- `agent/memory_extraction.py::_llm_call` (gates all three extraction call sites via `semaphore_slot()` wrapping the hotfix #1055 invariants)

## Tests

- 6 new tests in `tests/unit/test_anthropic_client_semaphore.py`:
  - Concurrency: 10 tasks with N=3 semaphore peak at 3 in-flight.
  - Exception path: body that raises still releases the slot.
  - Configuration: `anthropic_concurrency` field exists with sane default; module semaphore is built from settings.
  - Regression canary: grep enforces `anthropic.AsyncAnthropic(` outside approved modules fails the build.
  - Hotfix guard: `agent/memory_extraction.py` must contain `semaphore_slot`.
- 8 patch targets updated in `tests/unit/test_message_drafter.py` (pointing at `agent.anthropic_client.anthropic.AsyncAnthropic`).
- All 70 `test_memory_extraction.py` tests pass — hotfix #1055 invariants preserved.
- `pytest tests/unit/test_anthropic_client_semaphore.py tests/unit/test_memory_extraction.py tests/unit/test_intake_classifier.py tests/unit/test_intent_classifier.py tests/unit/test_work_request_classifier.py tests/unit/test_message_drafter.py tests/unit/test_message_drafter_linkify.py tests/unit/test_drafter_validators.py tests/unit/test_health_check.py`: 449 passed, 26 skipped.

## Test plan

- [x] New unit test proves 10 concurrent slots serialize to the configured limit.
- [x] New unit test proves the slot is released on exception.
- [x] Regression canary grep shows `anthropic.AsyncAnthropic(` only in `agent/anthropic_client.py` and `agent/memory_extraction.py`.
- [x] Hotfix #1055 review-guard tests all pass (httpx cleanup, double-timeout, no sync Anthropic, asyncio.run safety).
- [x] Ruff format + check pass.