### PR TITLE
fix(#1113): prevent zombie session revival + cascade-kill children

### DIFF
--- a/.claude/hooks/user_prompt_submit.py
+++ b/.claude/hooks/user_prompt_submit.py
@@ -66,20 +66,40 @@ def main():
                     if matches:
                         agent_session = matches[0]
                         # Use lifecycle module for consistent transition logging
-                        from models.session_lifecycle import transition_status
-
-                        agent_session.updated_at = time.time()
-                        agent_session.completed_at = None
-                        transition_status(
-                            agent_session,
-                            "running",
-                            reason="subsequent prompt reactivated local session",
-                            reject_from_terminal=False,
+                        from models.session_lifecycle import (
+                            TERMINAL_STATUSES,
+                            transition_status,
                         )
-                        # If transition was idempotent (already running), field
-                        # changes above were not saved. Ensure they persist.
-                        if agent_session.status == "running":
-                            agent_session.save(update_fields=["updated_at", "completed_at"])
+
+                        # Guard: do NOT re-activate sessions already in a terminal
+                        # state (killed/completed/failed/abandoned/cancelled).
+                        # Without this check, a killed PM session would resurrect
+                        # every time a new prompt hit the hook — the #1113 zombie
+                        # revival bug. Terminal sessions are operator-resumable
+                        # only via explicit `valor-session resume`.
+                        current_status = getattr(agent_session, "status", None)
+                        if current_status in TERMINAL_STATUSES:
+                            import logging
+
+                            logging.getLogger(__name__).warning(
+                                "[user_prompt_submit] Refusing to re-activate "
+                                "terminal session %s (status=%s). Use "
+                                "`valor-session resume` to resume intentionally.",
+                                getattr(agent_session, "agent_session_id", "?"),
+                                current_status,
+                            )
+                        else:
+                            agent_session.updated_at = time.time()
+                            agent_session.completed_at = None
+                            transition_status(
+                                agent_session,
+                                "running",
+                                reason="subsequent prompt reactivated local session",
+                            )
+                            # If transition was idempotent (already running), field
+                            # changes above were not saved. Ensure they persist.
+                            if agent_session.status == "running":
+                                agent_session.save(update_fields=["updated_at", "completed_at"])
                 except Exception:
                     pass  # Non-fatal
             else:

--- a/docs/plans/sdlc-1113.md
+++ b/docs/plans/sdlc-1113.md
@@ -1,0 +1,138 @@
+# Plan: Prevent Zombie Session Revival (#1113)
+
+Fix three compound defects that caused killed PM sessions to resurrect up
+to 4 times per shepherding run, pinning the worker for hours.
+
+## Context
+
+During a single shepherding run we observed a killed PM session reviving
+4+ times. Each revival burned worker cycles, rewrote audit logs, and made
+`valor-session kill` effectively useless — the session kept coming back.
+
+Three root causes compounded:
+
+1. **Terminal-guard bypass** — `.claude/hooks/user_prompt_submit.py`
+   called `transition_status(..., "running", reject_from_terminal=False)`
+   on every subsequent prompt. The guard in
+   `models/session_lifecycle.py:472` (see
+   `docs/features/session-lifecycle.md`) was intentionally bypassed,
+   allowing any killed/completed/failed session to be resurrected by a
+   single new prompt.
+2. **Missing cascade-kill** — `tools/agent_session_scheduler._kill_agent_session()`
+   finalized only the target. Dev children linked via
+   `parent_agent_session_id` stayed running and kept driving their own
+   lifecycles, which in turn re-finalized the PM parent through
+   `_finalize_parent_sync`.
+3. **Pending-index staleness** — `python -m tools.agent_session_scheduler status`
+   counted `pending_count` by raw IndexedField length. Zombie entries
+   (hash status=killed but still present in the pending index) inflated
+   the count and nudged the worker to re-pick them up (mirrors #1006).
+
+## Goal
+
+- Kill means kill. Terminal sessions must stay terminal until an
+  operator explicitly resumes them via `valor-session resume`.
+- Killing a PM cascades to its dev children in one operation.
+- `status` output reflects the authoritative hash status, not the stale
+  index membership.
+
+## Approach
+
+### Fix 1 — Hook refuses to re-activate terminal sessions
+In `user_prompt_submit.py`, before calling `transition_status`, read
+`agent_session.status` and compare against
+`models.session_lifecycle.TERMINAL_STATUSES`. If terminal, log a
+warning and return. Never pass `reject_from_terminal=False`.
+
+### Fix 2 — Kill cascades to non-terminal dev children
+In `_kill_agent_session()`, after finalizing the target, query
+`AgentSession.query.filter(parent_agent_session_id=target.agent_session_id)`.
+For each child whose `status` is not in `TERMINAL_STATUSES`, kill the
+child subprocess (if running) and call `finalize_session(child,
+"killed", reason="parent <id> killed: cascade")`. Add a
+`cascaded_children` field to the kill result so CLI output is honest
+about what got killed.
+
+### Fix 3 — Status filters terminal index entries
+In `cmd_status()`, after each index query, filter out sessions whose
+hash `status` is in `TERMINAL_STATUSES`. Mirrors the
+`agent/session_health.py:229-252` zombie guard from #1006.
+
+## Non-Goals
+
+- Index integrity repair at the Popoto level — out of scope. The
+  defensive srem in `finalize_session` is responsible for clean index
+  removal; this plan does not touch that path.
+- Reviving operator-resume semantics — `valor-session resume` is
+  untouched. It still works for intentional terminal-to-active
+  transitions.
+- Rebuilding the session_health phantom guard — #1006 already handles
+  that path. This plan only mirrors the pattern in `cmd_status`.
+
+## No-Gos
+
+- Do NOT rename `TERMINAL_STATUSES` or any public lifecycle constant.
+- Do NOT touch `transition_status` / `finalize_session` behavior — the
+  guard is already correct; the hook was misusing it.
+- Do NOT skip hooks or git safety gates.
+
+## Update System
+No update system changes required — fix is purely internal to the
+session lifecycle and scheduler. No new dependencies, config files, or
+migrations. Existing `/update` flow propagates changes via `git pull`.
+
+## Agent Integration
+No agent integration required — the scheduler kill path and the
+UserPromptSubmit hook are both bridge-internal. No MCP tool changes,
+no `.mcp.json` edits. The agent never directly calls these paths; it
+invokes `valor-session kill` via bash, whose behavior is the subject
+of the fix.
+
+## Failure Path Test Strategy
+
+- **Hook revives terminal session** — parametrized across all 5
+  terminal statuses. `transition_status` must not be called; hash
+  status must remain terminal.
+- **Cascade-kill skips already-terminal children** — killing a PM
+  whose one child is completed and another is running must only
+  cascade to the running child.
+- **Status filter under zombie index** — `cmd_status` with a killed
+  session lingering in the pending index must report
+  `pending_count == (real pending only)`.
+
+## Test Impact
+
+- [ ] `tests/unit/test_terminal_session_hook_guard.py` — NEW: hook
+  refuses re-activation on all 5 terminal statuses + control case for
+  dormant
+- [ ] `tests/unit/test_kill_cascades_to_children.py` — NEW: PM kill
+  cascades to dev children, terminal children not re-finalized, no
+  children returns empty cascade, CLI output reports cascade
+- [ ] `tests/unit/test_scheduler_status_excludes_terminal.py` — NEW:
+  killed-in-pending-index excluded, running-index mirror, normal case
+  unchanged
+- No existing test cases UPDATE/DELETE/REPLACE — the existing hook
+  test (`test_hook_user_prompt_submit.py`) and kill test
+  (`test_agent_session_scheduler_kill.py`) only cover orthogonal
+  behavior (env var pass-through, process kill semantics), which this
+  plan does not touch.
+
+## Rabbit Holes
+
+- **Full IndexedField zombie repair** — would require rebuilding every
+  indexed set on a schedule. Not needed for this fix; the defensive
+  srem already handles the happy path, and the `cmd_status` filter
+  handles the zombie display case.
+- **Retroactive session revival audit** — tempting to scan prod for
+  zombies now and kill them, but out of scope. The fix prevents future
+  zombies; existing ones can be cleaned via the existing
+  `agent_session_scheduler cleanup` command.
+
+## Documentation
+
+- [ ] Update `docs/features/session-lifecycle.md` to mention the
+  `user_prompt_submit` hook's new terminal-guard behavior alongside
+  the existing `reject_from_terminal` documentation
+- [ ] Add a bullet to `docs/features/pm-dev-session-architecture.md`
+  under the kill/cleanup section noting that `valor-session kill`
+  cascades to dev children

--- a/tests/unit/test_kill_cascades_to_children.py
+++ b/tests/unit/test_kill_cascades_to_children.py
@@ -1,0 +1,226 @@
+"""Regression test for issue #1113 (Root Cause 2).
+
+When a PM session is killed, its Dev children (linked via
+parent_agent_session_id) must also be killed. Previously, killing the PM
+left its Dev children in pending/running state — orphans the worker kept
+picking up after the parent was gone.
+
+This test covers the fix: `_kill_agent_session()` must cascade the kill to
+any non-terminal dev children.
+"""
+
+import argparse
+import json
+from unittest.mock import patch
+
+from tools.agent_session_scheduler import _kill_agent_session, cmd_kill
+
+
+class _FakeSession:
+    def __init__(
+        self,
+        agent_session_id="session-123",
+        session_id="sess-abc",
+        status="running",
+        parent_agent_session_id=None,
+        **extra,
+    ):
+        self.agent_session_id = agent_session_id
+        self.session_id = session_id
+        self.status = status
+        self.parent_agent_session_id = parent_agent_session_id
+        self.priority = extra.get("priority", "normal")
+        self.message_text = extra.get("message_text", "/sdlc test")
+        self.created_at = extra.get("created_at", 1700000000)
+        self.started_at = extra.get("started_at", None)
+        self.scheduled_at = extra.get("scheduled_at", None)
+        self.issue_url = extra.get("issue_url", None)
+        self.completed_at = extra.get("completed_at", None)
+
+    def delete(self):
+        pass
+
+
+class _FakeQuery:
+    """Minimal stand-in for AgentSession.query with filter()."""
+
+    def __init__(self, sessions_by_status=None, by_parent=None):
+        self._sessions = sessions_by_status or {}
+        self._by_parent = by_parent or {}
+
+    def filter(self, **kwargs):
+        if "parent_agent_session_id" in kwargs:
+            parent_id = kwargs["parent_agent_session_id"]
+            return self._by_parent.get(parent_id, [])
+        status = kwargs.get("status")
+        return self._sessions.get(status, [])
+
+
+def _make_args(**kwargs):
+    defaults = {
+        "agent_session_id": None,
+        "session_id": None,
+        "all": False,
+        "project": "valor",
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+class TestKillCascadesToChildren:
+    def test_killing_pm_cascades_to_dev_child(self):
+        """Killing a PM session also transitions its dev child to killed."""
+        pm = _FakeSession(
+            agent_session_id="agt_pm_fac44139",
+            session_id="local-pm-sid",
+            status="running",
+        )
+        dev_child = _FakeSession(
+            agent_session_id="agt_dev_0efe5fd5",
+            session_id="local-0efe5fd5",
+            status="running",
+            parent_agent_session_id="agt_pm_fac44139",
+        )
+
+        fake_query = _FakeQuery(
+            sessions_by_status={"running": [pm, dev_child]},
+            by_parent={"agt_pm_fac44139": [dev_child]},
+        )
+
+        finalize_calls = []
+
+        def fake_finalize(session, status, **kwargs):
+            finalize_calls.append((session.agent_session_id, status, kwargs.get("reason", "")))
+
+        with (
+            patch("models.agent_session.AgentSession.query", fake_query),
+            patch("models.session_lifecycle.finalize_session", side_effect=fake_finalize),
+            patch("tools.agent_session_scheduler._find_process_by_session_id", return_value=None),
+        ):
+            result = _kill_agent_session(pm)
+
+        # PM finalized as killed
+        pm_finalizes = [c for c in finalize_calls if c[0] == "agt_pm_fac44139"]
+        assert len(pm_finalizes) == 1
+        assert pm_finalizes[0][1] == "killed"
+
+        # Dev child ALSO finalized as killed with cascade reason
+        child_finalizes = [c for c in finalize_calls if c[0] == "agt_dev_0efe5fd5"]
+        assert len(child_finalizes) == 1, (
+            f"Dev child was NOT cascade-killed (zombie leak). finalize_calls={finalize_calls!r}"
+        )
+        assert child_finalizes[0][1] == "killed"
+        assert (
+            "cascade" in child_finalizes[0][2].lower() or "parent" in child_finalizes[0][2].lower()
+        )
+
+        # Result reports killed children
+        assert "cascaded_children" in result
+        assert len(result["cascaded_children"]) == 1
+        assert result["cascaded_children"][0]["agent_session_id"] == "agt_dev_0efe5fd5"
+
+    def test_terminal_children_not_recascaded(self):
+        """Children already in terminal states are NOT re-finalized."""
+        pm = _FakeSession(
+            agent_session_id="agt_pm_2",
+            session_id="local-pm-2",
+            status="running",
+        )
+        already_done = _FakeSession(
+            agent_session_id="agt_dev_done",
+            session_id="local-dev-done",
+            status="completed",
+            parent_agent_session_id="agt_pm_2",
+        )
+        active_child = _FakeSession(
+            agent_session_id="agt_dev_active",
+            session_id="local-dev-active",
+            status="running",
+            parent_agent_session_id="agt_pm_2",
+        )
+
+        fake_query = _FakeQuery(
+            sessions_by_status={"running": [pm, active_child]},
+            by_parent={"agt_pm_2": [already_done, active_child]},
+        )
+
+        finalize_calls = []
+
+        def fake_finalize(session, status, **kwargs):
+            finalize_calls.append((session.agent_session_id, status))
+
+        with (
+            patch("models.agent_session.AgentSession.query", fake_query),
+            patch("models.session_lifecycle.finalize_session", side_effect=fake_finalize),
+            patch("tools.agent_session_scheduler._find_process_by_session_id", return_value=None),
+        ):
+            result = _kill_agent_session(pm)
+
+        # Only the active child cascades; completed child is left alone
+        cascaded_ids = [c["agent_session_id"] for c in result.get("cascaded_children", [])]
+        assert "agt_dev_active" in cascaded_ids
+        assert "agt_dev_done" not in cascaded_ids
+
+        # finalize_session called for PM and active_child only, not already_done
+        finalized_ids = [c[0] for c in finalize_calls]
+        assert "agt_pm_2" in finalized_ids
+        assert "agt_dev_active" in finalized_ids
+        assert "agt_dev_done" not in finalized_ids
+
+    def test_no_children_returns_empty_cascade(self):
+        """Sessions without children kill cleanly without cascaded_children errors."""
+        solo = _FakeSession(
+            agent_session_id="agt_solo",
+            session_id="local-solo",
+            status="running",
+        )
+
+        fake_query = _FakeQuery(
+            sessions_by_status={"running": [solo]},
+            by_parent={},
+        )
+
+        with (
+            patch("models.agent_session.AgentSession.query", fake_query),
+            patch("models.session_lifecycle.finalize_session"),
+            patch("tools.agent_session_scheduler._find_process_by_session_id", return_value=None),
+        ):
+            result = _kill_agent_session(solo)
+
+        assert result["status"] == "killed"
+        # cascaded_children field should exist and be empty
+        assert result.get("cascaded_children", []) == []
+
+
+class TestCmdKillCascadeCount:
+    def test_cmd_kill_reports_cascade_count(self, capsys):
+        """CLI output includes cascaded_children per session."""
+        pm = _FakeSession(
+            agent_session_id="agt_pm_kill",
+            session_id="local-pm-kill",
+            status="running",
+        )
+        child = _FakeSession(
+            agent_session_id="agt_child_kill",
+            session_id="local-child-kill",
+            status="running",
+            parent_agent_session_id="agt_pm_kill",
+        )
+
+        fake_query = _FakeQuery(
+            sessions_by_status={"running": [pm]},
+            by_parent={"agt_pm_kill": [child]},
+        )
+
+        with (
+            patch("models.agent_session.AgentSession.query", fake_query),
+            patch("models.session_lifecycle.finalize_session"),
+            patch("tools.agent_session_scheduler._find_process_by_session_id", return_value=None),
+        ):
+            ret = cmd_kill(_make_args(agent_session_id="agt_pm_kill"))
+
+        assert ret == 0
+        output = json.loads(capsys.readouterr().out)
+        assert output["status"] == "killed"
+        assert len(output["sessions"]) == 1
+        assert len(output["sessions"][0].get("cascaded_children", [])) == 1

--- a/tests/unit/test_scheduler_status_excludes_terminal.py
+++ b/tests/unit/test_scheduler_status_excludes_terminal.py
@@ -1,0 +1,173 @@
+"""Regression test for issue #1113 (Root Cause 3).
+
+`python -m tools.agent_session_scheduler status` reports pending_count by
+querying the pending IndexedField set. After a session is killed, its hash
+status flips to "killed" but stale entries can linger in the pending index,
+inflating pending_count. This mirrors the #1006 running-index zombie bug.
+
+This test covers the fix: cmd_status must filter out sessions whose actual
+(hash) status is terminal, even when they appear in the pending index.
+"""
+
+import argparse
+import json
+from unittest.mock import patch
+
+from tools.agent_session_scheduler import cmd_status
+
+
+class _FakeSession:
+    def __init__(
+        self,
+        agent_session_id="session-123",
+        session_id="sess-abc",
+        status="pending",
+        **extra,
+    ):
+        self.agent_session_id = agent_session_id
+        self.session_id = session_id
+        self.status = status
+        self.priority = extra.get("priority", "normal")
+        self.message_text = extra.get("message_text", "test")
+        self.created_at = extra.get("created_at", 1700000000)
+        self.started_at = extra.get("started_at", None)
+        self.scheduled_at = extra.get("scheduled_at", None)
+        self.issue_url = extra.get("issue_url", None)
+        self.parent_agent_session_id = extra.get("parent_agent_session_id", None)
+        self.completed_at = extra.get("completed_at", None)
+
+
+class _FakeQuery:
+    def __init__(self, sessions_by_status=None):
+        self._sessions = sessions_by_status or {}
+
+    def filter(self, **kwargs):
+        status = kwargs.get("status")
+        return list(self._sessions.get(status, []))
+
+
+def _make_status_args(**kwargs):
+    defaults = {"project": "valor"}
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+class TestStatusExcludesTerminalSessions:
+    def test_killed_session_in_pending_index_excluded(self, capsys):
+        """A killed session that lingers in the pending index must not inflate pending_count.
+
+        Simulates the #1006 pattern: pending IndexedField set contains a member
+        whose hash status has already flipped to 'killed'. pending_count should
+        count only non-terminal members.
+        """
+        # Real pending session (healthy)
+        real_pending = _FakeSession(
+            agent_session_id="agt_pend_real",
+            session_id="local-real",
+            status="pending",
+        )
+        # Zombie: hash status=killed but still in pending index set
+        zombie = _FakeSession(
+            agent_session_id="agt_zombie",
+            session_id="local-zombie",
+            status="killed",  # actual hash status is terminal
+        )
+
+        # Index query returns both — the pending IndexedField set is stale
+        fake_query = _FakeQuery(
+            sessions_by_status={
+                "pending": [real_pending, zombie],
+                "running": [],
+                "completed": [],
+                "waiting_for_children": [],
+                "killed": [zombie],  # zombie also lives in killed index (correctly)
+            }
+        )
+
+        with (
+            patch("models.agent_session.AgentSession.query", fake_query),
+            patch(
+                "agent.agent_session_queue.PRIORITY_RANK",
+                {"urgent": 0, "high": 1, "normal": 2, "low": 3},
+            ),
+        ):
+            ret = cmd_status(_make_status_args())
+
+        assert ret == 0
+        output = json.loads(capsys.readouterr().out)
+        # pending_count must EXCLUDE the zombie (1, not 2)
+        assert output["pending_count"] == 1, (
+            f"Expected pending_count=1 (zombie excluded), got {output['pending_count']}"
+        )
+        # Only the real pending session should appear in pending_sessions
+        pending_ids = [s["agent_session_id"] for s in output.get("pending_sessions", [])]
+        assert "agt_pend_real" in pending_ids
+        assert "agt_zombie" not in pending_ids
+
+    def test_no_zombies_normal_case(self, capsys):
+        """When no stale index entries exist, pending_count equals index size."""
+        a = _FakeSession(agent_session_id="a", session_id="la", status="pending")
+        b = _FakeSession(agent_session_id="b", session_id="lb", status="pending")
+
+        fake_query = _FakeQuery(
+            sessions_by_status={
+                "pending": [a, b],
+                "running": [],
+                "completed": [],
+                "waiting_for_children": [],
+                "killed": [],
+            }
+        )
+
+        with (
+            patch("models.agent_session.AgentSession.query", fake_query),
+            patch(
+                "agent.agent_session_queue.PRIORITY_RANK",
+                {"urgent": 0, "high": 1, "normal": 2, "low": 3},
+            ),
+        ):
+            ret = cmd_status(_make_status_args())
+
+        assert ret == 0
+        output = json.loads(capsys.readouterr().out)
+        assert output["pending_count"] == 2
+
+    def test_running_index_zombie_also_excluded(self, capsys):
+        """Mirror #1006: running index zombies excluded from running_count too.
+
+        Consistency — if we're filtering pending_count, we should filter
+        running_count with the same rule.
+        """
+        real_running = _FakeSession(
+            agent_session_id="agt_run", session_id="local-run", status="running"
+        )
+        zombie_running = _FakeSession(
+            agent_session_id="agt_run_zombie",
+            session_id="local-run-zombie",
+            status="killed",
+        )
+
+        fake_query = _FakeQuery(
+            sessions_by_status={
+                "pending": [],
+                "running": [real_running, zombie_running],
+                "completed": [],
+                "waiting_for_children": [],
+                "killed": [zombie_running],
+            }
+        )
+
+        with (
+            patch("models.agent_session.AgentSession.query", fake_query),
+            patch(
+                "agent.agent_session_queue.PRIORITY_RANK",
+                {"urgent": 0, "high": 1, "normal": 2, "low": 3},
+            ),
+        ):
+            ret = cmd_status(_make_status_args())
+
+        assert ret == 0
+        output = json.loads(capsys.readouterr().out)
+        assert output["running_count"] == 1, (
+            f"Expected running_count=1 (zombie excluded), got {output['running_count']}"
+        )

--- a/tests/unit/test_terminal_session_hook_guard.py
+++ b/tests/unit/test_terminal_session_hook_guard.py
@@ -1,0 +1,119 @@
+"""Regression test for issue #1113 (Root Cause 1).
+
+The UserPromptSubmit hook previously called transition_status with
+reject_from_terminal=False, which bypassed the terminal guard and re-activated
+killed sessions every time a new prompt arrived. Once a PM session was killed
+via `valor-session kill --id ...`, the next prompt would resurrect it — the
+worker picked it back up as "running", producing a zombie.
+
+This test covers the fix: the hook MUST check the current status BEFORE
+transitioning, and refuse to re-activate sessions that are in terminal states
+(killed, completed, failed, abandoned, cancelled).
+"""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_HOOK_PATH = (
+    Path(__file__).resolve().parent.parent.parent / ".claude" / "hooks" / "user_prompt_submit.py"
+)
+
+
+def _load_hook_module():
+    spec = importlib.util.spec_from_file_location("user_prompt_submit", str(_HOOK_PATH))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestTerminalSessionNotReactivated:
+    """Killed/completed/failed sessions must NOT be re-activated by the hook."""
+
+    @pytest.mark.parametrize(
+        "terminal_status",
+        ["killed", "completed", "failed", "abandoned", "cancelled"],
+    )
+    def test_terminal_session_is_not_reactivated(self, terminal_status, monkeypatch):
+        """UserPromptSubmit hook on a terminal AgentSession must be a no-op.
+
+        Reproduces the zombie revival: a killed PM session should stay killed
+        even when a new prompt arrives via the same session_id.
+        """
+        hook = _load_hook_module()
+
+        fake_hook_input = {
+            "prompt": "Keep going!",
+            "session_id": "test-session-zombie",
+            "cwd": "/tmp",
+        }
+        # Sidecar has an agent_session_id -> subsequent-prompt branch fires
+        fake_sidecar = {"agent_session_id": "agt_killed_123"}
+
+        # Existing terminal session in Redis
+        fake_session = MagicMock()
+        fake_session.status = terminal_status
+        fake_session.session_id = "local-test-session-zombie"
+        fake_session.agent_session_id = "agt_killed_123"
+
+        # query.filter(session_id=...) returns the terminal session
+        fake_query = MagicMock()
+        fake_query.filter = MagicMock(return_value=iter([fake_session]))
+
+        monkeypatch.delenv("SESSION_TYPE", raising=False)
+        monkeypatch.delenv("VALOR_PARENT_SESSION_ID", raising=False)
+
+        with (
+            patch.object(hook, "read_hook_input", return_value=fake_hook_input),
+            patch("hook_utils.memory_bridge.ingest"),
+            patch("hook_utils.memory_bridge.load_agent_session_sidecar", return_value=fake_sidecar),
+            patch("hook_utils.memory_bridge.save_agent_session_sidecar"),
+            patch("models.agent_session.AgentSession.query", fake_query),
+            patch("models.session_lifecycle.transition_status") as mock_transition,
+        ):
+            hook.main()
+
+        # transition_status must NOT be called on a terminal session
+        assert not mock_transition.called, (
+            f"Hook called transition_status on a {terminal_status!r} session "
+            f"(zombie revival path bypassed terminal guard)"
+        )
+        # Status must remain terminal
+        assert fake_session.status == terminal_status
+
+    def test_running_session_is_still_reactivated(self, monkeypatch):
+        """Non-terminal sessions SHOULD still be re-activated (control case)."""
+        hook = _load_hook_module()
+
+        fake_hook_input = {
+            "prompt": "Continue work",
+            "session_id": "test-session-alive",
+            "cwd": "/tmp",
+        }
+        fake_sidecar = {"agent_session_id": "agt_alive_456"}
+
+        fake_session = MagicMock()
+        fake_session.status = "dormant"  # non-terminal
+        fake_session.session_id = "local-test-session-alive"
+        fake_session.agent_session_id = "agt_alive_456"
+
+        fake_query = MagicMock()
+        fake_query.filter = MagicMock(return_value=iter([fake_session]))
+
+        monkeypatch.delenv("SESSION_TYPE", raising=False)
+        monkeypatch.delenv("VALOR_PARENT_SESSION_ID", raising=False)
+
+        with (
+            patch.object(hook, "read_hook_input", return_value=fake_hook_input),
+            patch("hook_utils.memory_bridge.ingest"),
+            patch("hook_utils.memory_bridge.load_agent_session_sidecar", return_value=fake_sidecar),
+            patch("hook_utils.memory_bridge.save_agent_session_sidecar"),
+            patch("models.agent_session.AgentSession.query", fake_query),
+            patch("models.session_lifecycle.transition_status") as mock_transition,
+        ):
+            hook.main()
+
+        # transition_status SHOULD be called for non-terminal sessions
+        assert mock_transition.called, "Non-terminal session must still be re-activated"

--- a/tools/agent_session_scheduler.py
+++ b/tools/agent_session_scheduler.py
@@ -442,6 +442,8 @@ def cmd_status(args: argparse.Namespace) -> int:
     project_key = args.project or _get_env_context()["project_key"]
 
     try:
+        from models.session_lifecycle import TERMINAL_STATUSES as _TERMINAL_STATUSES
+
         pending = list(AgentSession.query.filter(project_key=project_key, status="pending"))
         running = list(AgentSession.query.filter(project_key=project_key, status="running"))
         completed = list(AgentSession.query.filter(project_key=project_key, status="completed"))
@@ -449,6 +451,15 @@ def cmd_status(args: argparse.Namespace) -> int:
             AgentSession.query.filter(project_key=project_key, status="waiting_for_children")
         )
         killed = list(AgentSession.query.filter(project_key=project_key, status="killed"))
+
+        # Zombie-index guard (#1113, mirrors #1006 running-index pattern): filter
+        # out sessions whose actual hash status is terminal, even if they still
+        # appear in the pending/running IndexedField set. Without this, a killed
+        # session that remained in the pending index would inflate pending_count
+        # and let the worker re-pick it up.
+        pending = [p for p in pending if getattr(p, "status", None) not in _TERMINAL_STATUSES]
+        running = [r for r in running if getattr(r, "status", None) not in _TERMINAL_STATUSES]
+        waiting = [w for w in waiting if getattr(w, "status", None) not in _TERMINAL_STATUSES]
 
         # Sort pending by priority then FIFO
         from agent.agent_session_queue import PRIORITY_RANK
@@ -822,12 +833,14 @@ def _kill_agent_session(target, *, skip_process_kill: bool = False) -> dict:
 
     Returns a dict with kill result details.
     """
-    from models.session_lifecycle import finalize_session
+    from models.agent_session import AgentSession
+    from models.session_lifecycle import TERMINAL_STATUSES, finalize_session
 
     result = {
         "agent_session_id": target.agent_session_id,
         "session_id": target.session_id,
         "previous_status": target.status,
+        "cascaded_children": [],
     }
 
     # Kill subprocess if running
@@ -851,6 +864,51 @@ def _kill_agent_session(target, *, skip_process_kill: bool = False) -> dict:
         f"Killed session {result['agent_session_id']} (session={result['session_id']}, "
         f"previous_status={result['previous_status']})"
     )
+
+    # Cascade-kill: any non-terminal dev children of this session are orphans
+    # without their parent and must be killed too (#1113). Without this, the
+    # worker keeps picking up a dev child after the PM is gone, which then
+    # re-drives the PM lifecycle and produces a zombie session.
+    try:
+        parent_id = target.agent_session_id
+        if parent_id:
+            children = list(AgentSession.query.filter(parent_agent_session_id=parent_id))
+            for child in children:
+                child_status = getattr(child, "status", None)
+                if child_status in TERMINAL_STATUSES:
+                    continue  # already done, leave alone
+                # Kill child subprocess if it's running
+                child_process_result = None
+                if child_status == "running":
+                    child_pid = _find_process_by_session_id(child.session_id)
+                    if child_pid:
+                        child_process_result = _kill_process(child_pid)
+                try:
+                    finalize_session(
+                        child,
+                        "killed",
+                        reason=f"parent {parent_id} killed: cascade",
+                        skip_auto_tag=True,
+                        skip_checkpoint=True,
+                    )
+                except Exception as e:
+                    logger.warning(f"Cascade-kill of child {child.agent_session_id} failed: {e}")
+                    continue
+                child_entry = {
+                    "agent_session_id": child.agent_session_id,
+                    "session_id": child.session_id,
+                    "previous_status": child_status,
+                    "status": "killed",
+                }
+                if child_process_result is not None:
+                    child_entry["process"] = child_process_result
+                result["cascaded_children"].append(child_entry)
+                logger.info(
+                    f"Cascade-killed child {child.agent_session_id} "
+                    f"(session={child.session_id}, parent={parent_id})"
+                )
+    except Exception as e:
+        logger.warning(f"Cascade-kill lookup failed for {target.agent_session_id}: {e}")
 
     return result
 


### PR DESCRIPTION
Closes #1113

## Summary
Killed PM sessions were reviving up to 4x per run during shepherding. Three compound defects fixed.

## Defects
1. UserPromptSubmit hook called transition_status with reject_from_terminal=False, bypassing the terminal guard
2. Scheduler kill only killed the target, leaving dev children orphaned
3. pending_count was inflated by killed sessions remaining in the pending index

## Test plan
- [x] New regression tests for all three defects
- [x] Existing session lifecycle tests pass
- [x] Ruff clean