### PR TITLE
feat(#1112): /do-pr-review mergeability preflight

### DIFF
--- a/.claude/skills/do-pr-review/SKILL.md
+++ b/.claude/skills/do-pr-review/SKILL.md
@@ -43,7 +43,7 @@ Fall back to manual resolution if the env var is unset.
 ## Sub-Skills
 
 This skill is decomposed into focused sub-skills in `sub-skills/`:
-- `checkout.md` — Mechanical: clean git state, checkout PR branch
+- `checkout.md` — Mechanical: **mergeability preflight (runs first)**, clean git state, checkout PR branch
 - `code-review.md` — Judgment: parse PR-body disclosures, read prior reviews, traverse the 10-item Rubric, evaluate the 12-item Pre-Verdict Checklist, classify findings, derive the verdict mechanically
 - `screenshot.md` — Mechanical: start app, capture UI screenshots
 - `post-review.md` — Mechanical: format findings, post review to GitHub
@@ -51,6 +51,26 @@ This skill is decomposed into focused sub-skills in `sub-skills/`:
 Each sub-skill has a single responsibility and receives pre-resolved context.
 
 **Determinism note:** `code-review.md` includes a disclosure parser (pre-finding), a prior-review context loader (idempotency on unchanged HEAD SHA + body), an explicit 10-item Rubric with pass/fail/acknowledged/n/a per item, a Miscellaneous bucket for issues outside the rubric, and mechanical verdict derivation. These were introduced in issue #1045 to address non-deterministic verdicts across repeated runs on the same PR.
+
+## Mergeability Preflight (first action, before anything else)
+
+Before reading the diff, loading the plan, or running any code review, run the
+mergeability preflight (see `sub-skills/checkout.md` → "Mergeability Preflight").
+It is cheap (one `gh pr view` API call) and catches objective blockers that
+make any subjective code review meaningless:
+
+- If `state != OPEN` → emit `PR_CLOSED` verdict and stop.
+- If `mergeable == CONFLICTING` or `mergeStateStatus == DIRTY` → emit
+  `BLOCKED_ON_CONFLICT` verdict, cite the `mergeStateStatus`, ask for a rebase,
+  and stop.
+- If `mergeStateStatus == BEHIND` → note it and proceed (branch needs update
+  but has no conflicts).
+- Otherwise → proceed with full code review.
+
+This preflight is complementary to the subjective rubric added by #1045: #1045
+catches reviews that APPROVED a PR without the reviewer actually evaluating
+acceptance criteria; this preflight (#1112) catches reviews that APPROVED a PR
+that mechanically cannot merge.
 
 ## Stage Marker
 
@@ -101,6 +121,36 @@ if [ -z "$PLAN_PATH" ] && [ -n "$SLUG" ]; then
   PLAN_PATH="docs/plans/${SLUG}.md"
 fi
 ```
+
+**Run the mergeability preflight FIRST** (see `sub-skills/checkout.md` →
+"Mergeability Preflight" for the decision table and short-circuit behavior):
+
+```bash
+PREFLIGHT_JSON=$(gh pr view "$PR_NUMBER" --json mergeable,mergeStateStatus,state)
+PR_STATE=$(echo "$PREFLIGHT_JSON" | jq -r '.state')
+PR_MERGEABLE=$(echo "$PREFLIGHT_JSON" | jq -r '.mergeable')
+PR_MERGE_STATUS=$(echo "$PREFLIGHT_JSON" | jq -r '.mergeStateStatus')
+
+# Retry once if GitHub has not finished computing mergeability
+if [ "$PR_MERGEABLE" = "UNKNOWN" ]; then
+  sleep 2
+  PREFLIGHT_JSON=$(gh pr view "$PR_NUMBER" --json mergeable,mergeStateStatus,state)
+  PR_STATE=$(echo "$PREFLIGHT_JSON" | jq -r '.state')
+  PR_MERGEABLE=$(echo "$PREFLIGHT_JSON" | jq -r '.mergeable')
+  PR_MERGE_STATUS=$(echo "$PREFLIGHT_JSON" | jq -r '.mergeStateStatus')
+fi
+```
+
+Apply the decision table from `sub-skills/checkout.md`:
+- `state != OPEN` → post `PR_CLOSED` comment, emit `status:"fail"` OUTCOME with
+  `verdict:"PR_CLOSED"`, exit immediately. Do NOT checkout, read diff, or
+  produce a code review body.
+- `mergeable == CONFLICTING` OR `mergeStateStatus == DIRTY` → post
+  `BLOCKED_ON_CONFLICT` comment citing the `mergeStateStatus`, emit
+  `status:"fail"` OUTCOME with `verdict:"BLOCKED_ON_CONFLICT"`, exit
+  immediately.
+- Otherwise (including `BEHIND`, `UNSTABLE`, `HAS_HOOKS`, `CLEAN`, unresolved
+  `UNKNOWN`) → proceed to the checkout and full review below.
 
 **Fetch PR details:**
 ```bash
@@ -422,22 +472,41 @@ Save this URL as `{review_url}` for the output summary.
 
 After posting the review and verifying it was posted (Steps 6-6.5), emit a typed outcome as the **very last line** of output.
 
-**Success (no blockers, no tech_debt, no nits):**
+**Verdict taxonomy:**
+
+| Verdict | When | OUTCOME status |
+|---------|------|----------------|
+| `APPROVED` | Preflight clean + zero findings + pre-verdict checklist all PASS/N/A | `success` |
+| `CHANGES_REQUESTED` | Preflight clean but findings (blockers, tech_debt, or nits) exist | `partial` (tech_debt/nits only) or `fail` (blockers) |
+| `BLOCKED_ON_CONFLICT` | Preflight detected `mergeable=CONFLICTING` or `mergeStateStatus=DIRTY` — short-circuited, no code review performed | `fail` |
+| `PR_CLOSED` | Preflight detected `state != OPEN` — short-circuited, no code review performed | `fail` |
+
+**Success (APPROVED — no blockers, no tech_debt, no nits):**
 ```
-<!-- OUTCOME {"status":"success","stage":"REVIEW","artifacts":{"review_url":"{review_url}","blockers":0,"tech_debt":0,"nits":0},"notes":"Approved with no findings.","next_skill":"/do-docs"} -->
+<!-- OUTCOME {"status":"success","stage":"REVIEW","verdict":"APPROVED","artifacts":{"review_url":"{review_url}","blockers":0,"tech_debt":0,"nits":0},"notes":"Approved with no findings.","next_skill":"/do-docs"} -->
 ```
 
-**Partial (no blockers, but has tech_debt and/or nits that need patching):**
+**Partial (CHANGES_REQUESTED — no blockers, but has tech_debt and/or nits that need patching):**
 ```
-<!-- OUTCOME {"status":"partial","stage":"REVIEW","artifacts":{"review_url":"{review_url}","blockers":0,"tech_debt":2,"nits":1},"notes":"Changes requested: 2 tech_debt and 1 nit findings. Routing to /do-patch.","next_skill":"/do-patch"} -->
-```
-
-**Fail (blockers found):**
-```
-<!-- OUTCOME {"status":"fail","stage":"REVIEW","artifacts":{"review_url":"{review_url}","blockers":2,"tech_debt":1,"nits":0},"notes":"Changes requested: 2 blockers found.","failure_reason":"2 blockers must be fixed before merge","next_skill":"/do-patch"} -->
+<!-- OUTCOME {"status":"partial","stage":"REVIEW","verdict":"CHANGES_REQUESTED","artifacts":{"review_url":"{review_url}","blockers":0,"tech_debt":2,"nits":1},"notes":"Changes requested: 2 tech_debt and 1 nit findings. Routing to /do-patch.","next_skill":"/do-patch"} -->
 ```
 
-**Important**: The outcome block uses HTML comment syntax (`<!-- ... -->`) so it's invisible in rendered markdown but parseable by the pipeline. Always emit it as the very last line of output. Use `"partial"` — not `"success"` — whenever tech_debt or non-subjective nit findings exist. This ensures the pipeline routes to `/do-patch` before advancing to `/do-docs`.
+**Fail (CHANGES_REQUESTED — blockers found):**
+```
+<!-- OUTCOME {"status":"fail","stage":"REVIEW","verdict":"CHANGES_REQUESTED","artifacts":{"review_url":"{review_url}","blockers":2,"tech_debt":1,"nits":0},"notes":"Changes requested: 2 blockers found.","failure_reason":"2 blockers must be fixed before merge","next_skill":"/do-patch"} -->
+```
+
+**Fail (BLOCKED_ON_CONFLICT — preflight short-circuit):**
+```
+<!-- OUTCOME {"status":"fail","stage":"REVIEW","verdict":"BLOCKED_ON_CONFLICT","artifacts":{"review_url":"{comment_url}","mergeStateStatus":"DIRTY","mergeable":"CONFLICTING"},"notes":"Branch has merge conflicts; rebase required before review.","failure_reason":"mergeStateStatus=DIRTY — author must rebase/resolve conflicts before review can proceed","next_skill":null} -->
+```
+
+**Fail (PR_CLOSED — preflight short-circuit):**
+```
+<!-- OUTCOME {"status":"fail","stage":"REVIEW","verdict":"PR_CLOSED","artifacts":{"review_url":"{comment_url}","state":"CLOSED"},"notes":"PR is not open; review skipped.","failure_reason":"state=CLOSED — no review performed on a closed PR","next_skill":null} -->
+```
+
+**Important**: The outcome block uses HTML comment syntax (`<!-- ... -->`) so it's invisible in rendered markdown but parseable by the pipeline. Always emit it as the very last line of output. Use `"partial"` — not `"success"` — whenever tech_debt or non-subjective nit findings exist. This ensures the pipeline routes to `/do-patch` before advancing to `/do-docs`. For `BLOCKED_ON_CONFLICT` and `PR_CLOSED`, `next_skill` is `null` — the pipeline should NOT auto-advance; the author must rebase or the PM must handle the closed-PR case manually.
 
 ### Record the verdict (mandatory)
 
@@ -451,6 +520,16 @@ python -m tools.sdlc_verdict record --stage REVIEW \
 # For reviews with findings (OUTCOME status=partial or fail):
 python -m tools.sdlc_verdict record --stage REVIEW \
   --verdict "CHANGES REQUESTED" --blockers $BLOCKERS --tech-debt $TECH_DEBT \
+  --issue-number $ISSUE_NUMBER
+
+# For preflight short-circuit (branch cannot merge):
+python -m tools.sdlc_verdict record --stage REVIEW \
+  --verdict "BLOCKED_ON_CONFLICT" --blockers 0 --tech-debt 0 \
+  --issue-number $ISSUE_NUMBER
+
+# For preflight short-circuit (PR not open):
+python -m tools.sdlc_verdict record --stage REVIEW \
+  --verdict "PR_CLOSED" --blockers 0 --tech-debt 0 \
   --issue-number $ISSUE_NUMBER
 ```
 

--- a/.claude/skills/do-pr-review/sub-skills/checkout.md
+++ b/.claude/skills/do-pr-review/sub-skills/checkout.md
@@ -1,15 +1,23 @@
 # Sub-Skill: PR Checkout
 
-Mechanical setup: clean git state and checkout the PR branch.
+Mechanical setup: **mergeability preflight**, then clean git state and checkout the PR branch.
 
 ## Context Variables
 
 - `$SDLC_PR_NUMBER` — PR number to checkout (fallback: extract from nudge feedback or `gh pr list`)
 - `$SDLC_PR_BRANCH` — expected branch name (informational)
 
-## Steps
+## Mergeability Preflight (runs BEFORE any diff reading)
 
-1. **Resolve PR number:**
+**Why:** Three consecutive `/do-pr-review` passes once APPROVED PR #1100 while
+`mergeable=CONFLICTING` and `mergeStateStatus=DIRTY`. No amount of subjective
+code-review quality matters if the branch cannot mechanically merge. This
+preflight is cheap (single `gh pr view` API call, ~200ms) and MUST run before
+the checkout, diff, or any Read of PR files.
+
+### Preflight Steps
+
+1. **Resolve PR number first:**
    ```bash
    PR_NUMBER="${SDLC_PR_NUMBER:-}"
    if [ -z "$PR_NUMBER" ]; then
@@ -18,17 +26,60 @@ Mechanical setup: clean git state and checkout the PR branch.
    fi
    ```
 
-2. **Clean git state:**
+2. **Query mergeable state (single API call):**
+   ```bash
+   PREFLIGHT_JSON=$(gh pr view "$PR_NUMBER" --json mergeable,mergeStateStatus,state)
+   PR_STATE=$(echo "$PREFLIGHT_JSON" | jq -r '.state')
+   PR_MERGEABLE=$(echo "$PREFLIGHT_JSON" | jq -r '.mergeable')
+   PR_MERGE_STATUS=$(echo "$PREFLIGHT_JSON" | jq -r '.mergeStateStatus')
+   echo "Preflight: state=$PR_STATE mergeable=$PR_MERGEABLE mergeStateStatus=$PR_MERGE_STATUS"
+   ```
+
+   Note: GitHub computes `mergeable` asynchronously. On a just-opened PR the
+   first query may return `mergeable=UNKNOWN`. If so, retry once after 2s:
+   ```bash
+   if [ "$PR_MERGEABLE" = "UNKNOWN" ]; then
+     sleep 2
+     PREFLIGHT_JSON=$(gh pr view "$PR_NUMBER" --json mergeable,mergeStateStatus,state)
+     PR_STATE=$(echo "$PREFLIGHT_JSON" | jq -r '.state')
+     PR_MERGEABLE=$(echo "$PREFLIGHT_JSON" | jq -r '.mergeable')
+     PR_MERGE_STATUS=$(echo "$PREFLIGHT_JSON" | jq -r '.mergeStateStatus')
+   fi
+   ```
+
+3. **Decision table — apply in order, short-circuit on first match:**
+
+   | Condition | Action | Verdict | Proceed? |
+   |-----------|--------|---------|----------|
+   | `state != "OPEN"` (CLOSED, MERGED) | Emit `PR_CLOSED` verdict, post a short comment noting the PR is not open, skip all further review. | `PR_CLOSED` | NO |
+   | `mergeable == "CONFLICTING"` OR `mergeStateStatus == "DIRTY"` | Emit `BLOCKED_ON_CONFLICT` verdict. Post a comment that explicitly cites the `mergeStateStatus` value and asks the author to rebase/resolve. Skip checkout, diff reading, and code review. | `BLOCKED_ON_CONFLICT` | NO |
+   | `mergeStateStatus == "BEHIND"` | Note it in the preflight log — the branch is behind base but has no conflicts. Proceed with full code review; the branch will be mergeable once updated. | (informational) | YES |
+   | `mergeable == "MERGEABLE"` AND `mergeStateStatus IN ("CLEAN", "HAS_HOOKS", "UNSTABLE", "BLOCKED")` | Normal path — proceed with checkout and full code review. `BLOCKED` here is a GitHub status for missing-required-review/check, which IS what this review is supposed to produce. `UNSTABLE` means non-required checks failed; surface in findings but do not short-circuit. | (informational) | YES |
+   | `mergeable == "UNKNOWN"` after retry | Log a warning and proceed conservatively — GitHub may not have finished computing. Do not emit a short-circuit verdict purely on UNKNOWN. | (informational) | YES |
+
+4. **Short-circuit verdict emission (if preflight fails):**
+
+   Use the corresponding verdict template from `post-review.md` (§2c for
+   `PR_CLOSED`, §2b for `BLOCKED_ON_CONFLICT`). Post the comment via
+   `gh pr comment` (not `gh pr review --request-changes` — a closed PR cannot
+   take a review). Then emit the terminal OUTCOME block and exit. Do NOT
+   continue to Step 5 below.
+
+5. **Only if preflight passes:** continue to the checkout steps.
+
+## Checkout Steps
+
+1. **Clean git state:**
    ```bash
    python -c "from agent.worktree_manager import ensure_clean_git_state; from pathlib import Path; ensure_clean_git_state(Path('.'))"
    ```
 
-3. **Checkout PR branch:**
+2. **Checkout PR branch:**
    ```bash
    gh pr checkout $PR_NUMBER
    ```
 
-4. **Verify checkout:**
+3. **Verify checkout:**
    ```bash
    CURRENT_BRANCH=$(git branch --show-current)
    echo "Checked out branch: $CURRENT_BRANCH"

--- a/.claude/skills/do-pr-review/sub-skills/post-review.md
+++ b/.claude/skills/do-pr-review/sub-skills/post-review.md
@@ -9,7 +9,8 @@ Mechanical work: format findings and post the review to GitHub.
 
 ## Prerequisites
 
-Code review findings must be available from the code-review sub-skill.
+Code review findings must be available from the code-review sub-skill — UNLESS
+the mergeability preflight short-circuited (see §2b and §2c below).
 
 ## Steps
 
@@ -155,15 +156,78 @@ _Idempotent: prior review on HEAD {head_sha:0:7} / body hash {body_hash:0:7} is 
 <!-- REVIEW_CONTEXT head_sha=<HEAD_SHA> pr_body_hash=<PR_BODY_HASH> -->
 ```
 
+### 2b. Preflight Short-Circuit: BLOCKED_ON_CONFLICT
+
+When the mergeability preflight (`checkout.md` → "Mergeability Preflight")
+detected `mergeable=CONFLICTING` or `mergeStateStatus=DIRTY`, the skill MUST
+NOT read the diff, run code review, or post an approval. Instead, post this
+comment and emit the terminal OUTCOME block. The comment MUST explicitly cite
+the `mergeStateStatus` value so the author knows why review was skipped.
+
+Template:
+```
+## Review: Blocked on Conflict
+
+This PR cannot be reviewed until it merges cleanly against its base branch.
+
+- **mergeable:** `{PR_MERGEABLE}` (e.g. `CONFLICTING`)
+- **mergeStateStatus:** `{PR_MERGE_STATUS}` (e.g. `DIRTY`)
+
+### Required action
+
+Please rebase onto the current base (or merge base into your branch) and
+resolve the conflicts, then push. Re-run `/do-pr-review` after the branch is
+mergeable.
+
+> No code review was performed. The mechanical mergeability gate runs before
+> any diff reading — if the branch cannot merge, no amount of code review
+> can make the PR mergeable.
+```
+
+**Posting (always `gh pr comment` — do NOT use `gh pr review --request-changes`
+for the short-circuit path; the preflight is orthogonal to the code-review
+verdict):**
+```bash
+gh pr comment "$PR_NUMBER" --body "$REVIEW_BODY"
+```
+
+### 2c. Preflight Short-Circuit: PR_CLOSED
+
+When the mergeability preflight detected `state != OPEN` (CLOSED or MERGED),
+post a short note and exit. No full review body, no code analysis.
+
+Template:
+```
+## Review: PR Closed
+
+This PR is no longer open (`state={PR_STATE}`); review skipped.
+
+If the PR was closed in error, reopen it and re-run `/do-pr-review`. If it was
+already merged, no review is needed.
+```
+
+**Posting:**
+```bash
+gh pr comment "$PR_NUMBER" --body "$REVIEW_BODY"
+```
+
+Note: `gh pr review` requires the PR to be open, so the short-circuit paths
+always use `gh pr comment`, even on non-self-authored PRs.
+
 ### 3. Post the Review
 
-**Three-tier decision (apply in order):**
-1. **Blockers found** → `--request-changes`
-2. **No blockers, but tech_debt or nits** → `--request-changes`
-3. **Zero findings** → `--approve`
+**Decision tree (apply in order, first match wins):**
+1. **Preflight: `PR_CLOSED`** → post §2c comment via `gh pr comment`.
+2. **Preflight: `BLOCKED_ON_CONFLICT`** → post §2b comment via `gh pr comment`.
+3. **Blockers found** → `--request-changes` (or `gh pr comment` for self-authored).
+4. **No blockers, but tech_debt or nits** → `--request-changes` (or `gh pr comment`).
+5. **Zero findings** → `--approve` (or `gh pr comment`).
 
 ```bash
-if [ "$SELF_AUTHORED" = "true" ]; then
+if [ "$PREFLIGHT_VERDICT" = "PR_CLOSED" ] || [ "$PREFLIGHT_VERDICT" = "BLOCKED_ON_CONFLICT" ]; then
+  # Preflight short-circuit — always post as a plain comment.
+  gh pr comment "$PR_NUMBER" --body "$REVIEW_BODY"
+elif [ "$SELF_AUTHORED" = "true" ]; then
   gh pr comment $PR_NUMBER --body "$REVIEW_BODY"
 elif [ "$HAS_ANY_FINDINGS" = "true" ]; then
   # Blockers, tech_debt, or nits — all require changes
@@ -205,8 +269,15 @@ python -m tools.sdlc_stage_marker --stage REVIEW --status completed --issue-numb
 
 ## Completion
 
-Return the review URL and the outcome contract block:
+Return the review URL and the outcome contract block. The verdict field
+distinguishes between the normal code-review verdicts (`APPROVED`,
+`CHANGES_REQUESTED`) and the preflight short-circuit verdicts
+(`BLOCKED_ON_CONFLICT`, `PR_CLOSED`):
 
 ```
-<!-- OUTCOME {"status":"success|partial|fail","stage":"REVIEW","artifacts":{"review_url":"...","blockers":N,"tech_debt":N,"nits":N},"notes":"...","next_skill":"/do-docs|/do-patch"} -->
+<!-- OUTCOME {"status":"success|partial|fail","stage":"REVIEW","verdict":"APPROVED|CHANGES_REQUESTED|BLOCKED_ON_CONFLICT|PR_CLOSED","artifacts":{"review_url":"...","blockers":N,"tech_debt":N,"nits":N},"notes":"...","next_skill":"/do-docs|/do-patch|null"} -->
 ```
+
+See the SKILL.md "Outcome Contract" section for the full verdict taxonomy and
+examples for each variant. For `BLOCKED_ON_CONFLICT` and `PR_CLOSED`, use
+`next_skill: null` so the pipeline does not auto-advance.

--- a/docs/plans/sdlc-1112.md
+++ b/docs/plans/sdlc-1112.md
@@ -1,0 +1,240 @@
+---
+slug: sdlc-1112
+status: Planning
+type: bug
+appetite: Small
+owner: Tom Counsell
+created: 2026-04-22
+tracking: https://github.com/tomcounsell/ai/issues/1112
+last_comment_id:
+revision_applied: true
+---
+
+# /do-pr-review must verify mergeable state before emitting verdict
+
+## Problem
+
+Three consecutive `/do-pr-review` passes on PR #1100 APPROVED the PR while
+`mergeable=CONFLICTING` and `mergeStateStatus=DIRTY`. No amount of subjective
+code-review quality matters when the branch cannot mechanically merge — the
+merge step will fail and the review was wasted.
+
+Grep of the skill files on 2026-04-22 confirms that neither `mergeable`,
+`mergeStateStatus`, `CONFLICTING`, nor `DIRTY` appears anywhere in the skill
+prose prior to this change:
+
+- `.claude/skills/do-pr-review/SKILL.md`
+- `.claude/skills/do-pr-review/sub-skills/checkout.md`
+- `.claude/skills/do-pr-review/sub-skills/code-review.md`
+- `.claude/skills/do-pr-review/sub-skills/post-review.md`
+
+The skill never checks the mechanical mergeability gate.
+
+## Freshness Check
+
+**Baseline commit:** `e2369e0f` on branch `session/sdlc-1112` (the inherited
+worktree branch).
+**Issue filed at:** 2026-04-22
+**Disposition:** Unchanged — premise holds.
+
+## Prior Art
+
+- **Issue #1045 / PR #1119** (merged): subjective-rubric recalibration for the
+  code-review portion of the skill — disclosure parser, prior-review context,
+  structured rubric. **Distinct from this issue.** #1045 tightens the
+  *subjective* verdict path (content of a review the skill already chose to
+  run). This issue (#1112) adds an *objective* mechanical precondition that
+  runs BEFORE any diff reading, short-circuiting the skill when the branch
+  cannot merge. The two are complementary: #1045 makes the review more honest
+  when it happens; #1112 prevents reviews from happening at all when they
+  are moot.
+- **PR #1100** (referenced in the bug): three approvals against a conflicted
+  branch are the motivating evidence for this change.
+
+## Research
+
+No external research needed. The `gh pr view --json mergeable,mergeStateStatus,state`
+API is stable and well-documented. Purely an internal skill-prose change.
+
+## Data Flow
+
+1. User invokes `/do-pr-review` with a PR number.
+2. Skill enters `sub-skills/checkout.md`.
+3. **NEW:** Preflight runs first — `gh pr view "$PR_NUMBER" --json
+   mergeable,mergeStateStatus,state` (single API call, ~200ms).
+4. Decision table:
+   - `state != OPEN` → emit `PR_CLOSED` verdict via `gh pr comment`, record
+     verdict, emit terminal OUTCOME with `next_skill: null`, exit.
+   - `mergeable == CONFLICTING` OR `mergeStateStatus == DIRTY` → emit
+     `BLOCKED_ON_CONFLICT` verdict via `gh pr comment` with the specific
+     `mergeStateStatus` value cited in the comment, record verdict, emit
+     terminal OUTCOME with `next_skill: null`, exit.
+   - `mergeStateStatus == BEHIND` → note in preflight log, proceed to full
+     review.
+   - Otherwise (CLEAN, HAS_HOOKS, UNSTABLE, BLOCKED, UNKNOWN after retry) →
+     proceed to checkout and full review.
+5. On the "proceed" path, existing flow continues unchanged (checkout →
+   code-review → screenshot → post-review).
+
+## Architectural Impact
+
+Skill-prose only. No code changes, no new modules, no config. The preflight
+is implemented as bash inline in the skill prose (same pattern as the rest
+of the skill). The decision table lives in `sub-skills/checkout.md`; the
+verdict comment templates live in `sub-skills/post-review.md`; the OUTCOME
+contract is updated in `SKILL.md`.
+
+## Appetite
+
+Small — single skill, three files, no code, no tests.
+
+## Solution
+
+Three edits to the `/do-pr-review` skill:
+
+1. **`sub-skills/checkout.md`**: Add a "Mergeability Preflight" section at the
+   top that runs BEFORE any diff reading. Includes the `gh pr view` query,
+   UNKNOWN retry, and a decision table mapping `state`, `mergeable`, and
+   `mergeStateStatus` to either a short-circuit verdict or "proceed to
+   full review."
+
+2. **`sub-skills/post-review.md`**: Add §2b (`BLOCKED_ON_CONFLICT`) and §2c
+   (`PR_CLOSED`) comment templates. The `BLOCKED_ON_CONFLICT` template
+   explicitly cites the observed `mergeStateStatus` value and asks the
+   author to rebase. Both short-circuit paths use `gh pr comment` (not
+   `gh pr review --request-changes`) because a closed PR cannot take a
+   review. The decision tree in §3 is reordered so preflight verdicts are
+   checked first.
+
+3. **`SKILL.md`**: Reference the preflight as the first action in the flow.
+   Expand the verdict taxonomy with `BLOCKED_ON_CONFLICT` and `PR_CLOSED`.
+   Update the OUTCOME contract to carry a `verdict` field with all four
+   values. Add verdict-recorder calls for the two new verdicts.
+
+## Failure Path Test Strategy
+
+No runtime tests exercise the skill prose (the skill is text consumed by
+Claude at runtime, not executable Python). Failure paths are documented in
+prose:
+
+- `mergeable=UNKNOWN` on first query → retry once after 2s; if still UNKNOWN,
+  log a warning and proceed conservatively (do NOT emit a short-circuit
+  verdict purely on UNKNOWN, because that would regress happy-path reviews
+  during GitHub slowness).
+- `gh pr view` fails or returns non-JSON → inherit existing bash-pipeline
+  failure handling (the skill already runs `gh` commands and inherits the
+  harness's error propagation).
+- Preflight passes but the PR becomes conflicted mid-review → acceptable;
+  the preflight is a snapshot, and downstream `/do-merge` will catch a
+  regression.
+
+## Test Impact
+
+No runtime tests exercise the skill prose — the skill is a Claude-Code
+consumed prose artifact, not executable Python. Manual verification is the
+only validation path: run the skill against a conflicted PR (e.g., recreate
+a conflict on a throwaway branch) and confirm the skill emits
+`BLOCKED_ON_CONFLICT`, posts a comment citing `mergeStateStatus`, and does
+NOT approve.
+
+- [ ] Manual: run `/do-pr-review` against a conflicted PR → expect
+  `BLOCKED_ON_CONFLICT` verdict, comment cites mergeStateStatus, no diff
+  reading attempted.
+- [ ] Manual: run `/do-pr-review` against a closed PR → expect `PR_CLOSED`
+  verdict, short comment, no diff reading attempted.
+- [ ] Manual: run `/do-pr-review` against a clean PR → expect existing
+  happy-path review (no regression).
+
+## Rabbit Holes
+
+- **Not implemented**: LLM-based parsing of conflict markers to guide the
+  author. The preflight is mechanical by design; authors can read a
+  `mergeStateStatus=DIRTY` signal themselves.
+- **Not implemented**: auto-rebase on the author's behalf. The preflight
+  asks; the author acts.
+- **Not implemented**: integration with `/do-patch` to auto-route to a
+  rebase step. The preflight emits `next_skill: null` so the PM handles
+  routing explicitly.
+
+## Risks
+
+- **Risk**: preflight on a just-opened PR returns `mergeable=UNKNOWN`
+  (GitHub computes asynchronously). **Mitigation**: 2s retry, then proceed
+  conservatively — do not short-circuit on UNKNOWN.
+- **Risk**: skill-prose change has no CI validation. **Mitigation**: manual
+  verification gate in the rollout; the preflight is additive and cannot
+  make the existing happy path worse (it only adds short-circuit branches).
+
+## Race Conditions
+
+None. The preflight is a single read of remote state at the start of the
+skill; no concurrent mutation.
+
+## No-Gos (Out of Scope)
+
+- No code changes to `agent/`, `worker/`, `bridge/`, or any Python tool.
+- No new MCP servers or tools.
+- No changes to the code-review sub-skill content from #1045 (rubric,
+  disclosure parser, prior-review context) — those stay exactly as merged
+  in PR #1119.
+
+## Update System
+
+No update system changes required — this change is skill-prose only and
+ships as part of the normal `git pull` cycle. No new dependencies, no new
+config files, no migration steps.
+
+## Agent Integration
+
+No agent integration changes required — `/do-pr-review` is already wired
+as a slash-command skill in `.claude/skills/do-pr-review/`. The preflight
+runs via existing bash tool invocation inside the skill; `gh pr view` is
+already in the allowed command list for the skill. No MCP changes, no
+`.mcp.json` edits, no bridge changes.
+
+## Documentation
+
+- [ ] `.claude/skills/do-pr-review/SKILL.md` — already updated in this PR to
+  reference the preflight as the first action and to document the expanded
+  verdict taxonomy.
+- [ ] `.claude/skills/do-pr-review/sub-skills/checkout.md` — already updated
+  in this PR with the "Mergeability Preflight" section and decision table.
+- [ ] `.claude/skills/do-pr-review/sub-skills/post-review.md` — already
+  updated in this PR with `BLOCKED_ON_CONFLICT` and `PR_CLOSED` verdict
+  templates.
+- [ ] No changes needed to `docs/features/`: the do-pr-review skill does not
+  have a dedicated feature doc (it is documented within the skill prose
+  itself, as is repo convention for slash-command skills).
+
+## Success Criteria
+
+- `do-pr-review` never emits APPROVED when `mergeable=CONFLICTING`.
+- Preflight runs before any diff reading (verified by manual test).
+- Verdict taxonomy expanded: `BLOCKED_ON_CONFLICT`, `PR_CLOSED` appear in
+  `SKILL.md` and `post-review.md`.
+- Post-review comment for `BLOCKED_ON_CONFLICT` explicitly cites the
+  observed `mergeStateStatus` value.
+- #1045's subjective rubric, disclosure parser, and prior-review context
+  are preserved untouched.
+
+## Step by Step Tasks
+
+- [x] Add "Mergeability Preflight" section to `sub-skills/checkout.md` with
+  decision table.
+- [x] Add §2b (`BLOCKED_ON_CONFLICT`) and §2c (`PR_CLOSED`) templates to
+  `sub-skills/post-review.md`; reorder §3 decision tree.
+- [x] Update `SKILL.md`: reference preflight as first action, expand verdict
+  taxonomy, update OUTCOME contract examples, add verdict-recorder calls
+  for new verdicts.
+- [x] Verify #1045 content (rubric, disclosure, prior-review) is preserved.
+- [x] Commit and push.
+- [x] Open PR linking #1112.
+- [ ] Manual verification pass against a conflicted PR.
+
+## Verification
+
+Manual verification only — no runtime tests cover skill prose. The
+acceptance criterion is: run the skill against a PR with
+`mergeable=CONFLICTING` and confirm the skill emits `BLOCKED_ON_CONFLICT`,
+posts a rebase-request comment citing `mergeStateStatus`, and does NOT
+read the diff or post an approval.


### PR DESCRIPTION
Closes #1112

## Summary
Adds a mechanical mergeability preflight to /do-pr-review that runs before any diff reading. Three recent reviews on PR #1100 APPROVED it while mergeable=CONFLICTING — no amount of thumbs-up matters if the branch can't merge.

## Added
- Mergeability preflight (cheap: single gh pr view call)
- Verdict taxonomy: BLOCKED_ON_CONFLICT, PR_CLOSED
- Short-circuit paths for closed / conflicted / behind states

## Test plan
- [x] Skill prose-only — no runtime tests affected
- [ ] Manual verification: run on a conflicted PR, confirm BLOCKED_ON_CONFLICT