### PR TITLE
chore(reflections): scrub monolith-migration annotations

### DIFF
--- a/docs/features/reflections.md
+++ b/docs/features/reflections.md
@@ -43,6 +43,8 @@ reflections:
 | `enabled` | bool | Whether this reflection is active (default: true) |
 | `timeout` | int | Optional per-reflection timeout in seconds. Defaults: 1800 (30 min) for function, 3600 (60 min) for agent |
 
+**Convention:** Reflections are addressed by `name` (this YAML field) and dispatched by `callable` (dotted path). Numbered-step references (`step_X`) are historical and should not be reintroduced into source, comments, or docs.
+
 ### Registry Location (Vault-First)
 
 The scheduler resolves `config/reflections.yaml` via a three-level fallback:

--- a/docs/plans/scrub-reflections-migration-annotations.md
+++ b/docs/plans/scrub-reflections-migration-annotations.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: docs_complete
 type: chore
 appetite: Small
 owner: Tom Counsell

--- a/docs/plans/scrub-reflections-migration-annotations.md
+++ b/docs/plans/scrub-reflections-migration-annotations.md
@@ -1,5 +1,5 @@
 ---
-status: docs_complete
+status: Planning
 type: chore
 appetite: Small
 owner: Tom Counsell

--- a/docs/plans/scrub-reflections-migration-annotations.md
+++ b/docs/plans/scrub-reflections-migration-annotations.md
@@ -152,19 +152,19 @@ Line numbers above are approximate (pre-edit) and provided as anchors. The build
 ## Failure Path Test Strategy
 
 ### Exception Handling Coverage
-- [ ] No exception handlers are added or modified by this work — handlers in scope are unchanged. Existing tests that cover the handlers continue to apply.
+- [x] No exception handlers are added or modified by this work — handlers in scope are unchanged. Existing tests that cover the handlers continue to apply.
 
 ### Empty/Invalid Input Handling
-- [ ] No function signatures, parameters, or input validation are touched. No new edge cases are introduced.
+- [x] No function signatures, parameters, or input validation are touched. No new edge cases are introduced.
 
 ### Error State Rendering
-- [ ] No user-visible output paths are touched. Reflection scheduler tests already cover error propagation (`tests/unit/test_reflection_scheduler.py`).
+- [x] No user-visible output paths are touched. Reflection scheduler tests already cover error propagation (`tests/unit/test_reflection_scheduler.py`).
 
 ## Test Impact
 
-- [ ] `tests/unit/test_reflections_package.py` — VERIFY: imports each `reflections/*` module by dotted path. After scrub, re-import must still succeed (this is the primary regression guard for "I deleted text and accidentally broke a docstring or import"). No code changes expected; success means the test is green without modification.
-- [ ] `tests/unit/test_reflection_scheduler.py` — VERIFY: scheduler resolves callables via `importlib`. Unchanged behavior, no edit needed.
-- [ ] `tests/unit/test_reflections_memory.py`, `test_reflections_scheduling.py`, `test_reflections_multi_repo.py`, `test_reflections_report.py`, `tests/integration/test_reflections_redis.py` — VERIFY: all green without changes. Pure docstring edits should not perturb any test.
+- [x] `tests/unit/test_reflections_package.py` — VERIFY: imports each `reflections/*` module by dotted path. After scrub, re-import must still succeed (this is the primary regression guard for "I deleted text and accidentally broke a docstring or import"). No code changes expected; success means the test is green without modification.
+- [x] `tests/unit/test_reflection_scheduler.py` — VERIFY: scheduler resolves callables via `importlib`. Unchanged behavior, no edit needed.
+- [x] `tests/unit/test_reflections_memory.py`, `test_reflections_scheduling.py`, `test_reflections_multi_repo.py`, `test_reflections_report.py`, `tests/integration/test_reflections_redis.py` — VERIFY: all green without changes. Pure docstring edits should not perturb any test.
 
 No existing tests UPDATE / DELETE / REPLACE — all "VERIFY" because the scrub is text-only inside docstrings/comments. If any test fails after the scrub, that is a bug in the scrub (an accidentally-removed code line), not a planned test churn.
 
@@ -224,7 +224,7 @@ No agent integration required. Reflections are dispatched by the scheduler (`age
 ## Documentation
 
 ### Feature Documentation
-- [ ] **Optional, single-line addition**: append a "Convention" bullet to `docs/features/reflections.md` (or, if no natural home there, to the "Development Principles" block in `CLAUDE.md`) stating: "Numbered-step references (`step_X`) are historical and should not be reintroduced — reflections are addressed by name in `config/reflections.yaml`." If a clean insertion point cannot be found within 2 minutes of looking, skip — the convention is implicit in the now-clean source.
+- [x] **Optional, single-line addition**: append a "Convention" bullet to `docs/features/reflections.md` (or, if no natural home there, to the "Development Principles" block in `CLAUDE.md`) stating: "Numbered-step references (`step_X`) are historical and should not be reintroduced — reflections are addressed by name in `config/reflections.yaml`." If a clean insertion point cannot be found within 2 minutes of looking, skip — the convention is implicit in the now-clean source.
 
 No other documentation changes. The deeper docs cascade is **#1032**'s scope.
 
@@ -232,20 +232,20 @@ No other documentation changes. The deeper docs cascade is **#1032**'s scope.
 N/A — this repo doesn't publish a docs site for `reflections/`.
 
 ### Inline Documentation
-- [ ] Confirm each edited docstring still describes what the module/callable does (the whole point of the scrub is preserving useful inline docs while removing migration narration).
+- [x] Confirm each edited docstring still describes what the module/callable does (the whole point of the scrub is preserving useful inline docs while removing migration narration).
 
 ## Success Criteria
 
-- [ ] `grep -rn 'scripts/reflections.py\|Extracted from\|Maps to monolith\|monolith\|ReflectionRun' reflections/` returns zero matches.
+- [x] `grep -rn 'scripts/reflections.py\|Extracted from\|Maps to monolith\|monolith\|ReflectionRun' reflections/` returns zero matches.
 
   > **Implementation Note (concern: grep verification scope):** This is the canonical pre-merge guard. Run it exactly as written, against `reflections/` only — do NOT broaden to repo-wide. The patterns intentionally target the five known annotation forms: bare module path (`scripts/reflections.py`), docstring header phrase (`Extracted from`), inline step marker (`Maps to monolith`), bare term (`monolith`), and the deleted class root (`ReflectionRun` — matches both `ReflectionRun` and `ReflectionRunner`). The bare-term `monolith` may collide with prose elsewhere in the repo; that's why scope is `reflections/` only. If the grep returns matches in `tests/unit/test_reflections_multi_repo.py` or `docs/plans/completed/`, those are intentional historical references — out of scope per No-Gos #7.
 
-- [ ] `git diff main -- reflections/` shows only docstring/comment changes — zero changes inside function bodies.
-- [ ] `pytest tests/unit/test_reflections_package.py tests/unit/test_reflection_scheduler.py tests/unit/test_reflections_memory.py tests/unit/test_reflections_scheduling.py tests/unit/test_reflections_multi_repo.py tests/unit/test_reflections_report.py tests/integration/test_reflections_redis.py -x -q` is green.
-- [ ] `python -m ruff format --check reflections/` passes (i.e., black/ruff finds nothing to reformat after edits).
-- [ ] Each edited module's docstring reads as a complete, present-tense description of what the module does — no orphaned sentence fragments, no comparative framing against a deleted system.
-- [ ] (If the convention note ships) `docs/features/reflections.md` contains a one-line guard against reintroducing `step_X` references.
-- [ ] PR description links #1132 with `Closes #1132`.
+- [x] `git diff main -- reflections/` shows only docstring/comment changes — zero changes inside function bodies.
+- [x] `pytest tests/unit/test_reflections_package.py tests/unit/test_reflection_scheduler.py tests/unit/test_reflections_memory.py tests/unit/test_reflections_scheduling.py tests/unit/test_reflections_multi_repo.py tests/unit/test_reflections_report.py tests/integration/test_reflections_redis.py -x -q` is green.
+- [x] `python -m ruff format --check reflections/` passes (i.e., black/ruff finds nothing to reformat after edits).
+- [x] Each edited module's docstring reads as a complete, present-tense description of what the module does — no orphaned sentence fragments, no comparative framing against a deleted system.
+- [x] (If the convention note ships) `docs/features/reflections.md` contains a one-line guard against reintroducing `step_X` references.
+- [x] PR description links #1132 with `Closes #1132`.
 
 ## Team Orchestration
 

--- a/reflections/__init__.py
+++ b/reflections/__init__.py
@@ -6,5 +6,4 @@ can invoke by dotted path. All functions:
   - Accept no arguments
   - Return a dict: {"status": "ok"|"error", "findings": [...], "summary": str}
   - Handle redis.exceptions.ConnectionError gracefully
-  - Have no dependency on ReflectionRun or the legacy monolith class
 """

--- a/reflections/auditing.py
+++ b/reflections/auditing.py
@@ -1,14 +1,6 @@
 """
 reflections/auditing.py — Auditing reflection callables.
 
-Extracted from scripts/reflections.py steps:
-  - step_review_logs         → run_log_review
-  - step_audit_docs          → run_documentation_audit
-  - step_skills_audit        → run_skills_audit
-  - step_hooks_audit         → run_hooks_audit
-  - step_feature_docs_audit  → run_feature_docs_audit
-  - step_pr_review_audit     → run_pr_review_audit
-
 All functions accept no arguments and return:
   {"status": "ok"|"error", "findings": [...], "summary": str}
 """
@@ -69,7 +61,7 @@ def _read_log_tail_lines(log_file: Path, n: int = 1000) -> list[str]:
     return lines[-n:]
 
 
-# PR Review audit helper patterns (from monolith module level)
+# PR Review audit helper patterns
 _FINDING_SEVERITY_RE = re.compile(r"\*\*Severity:\*\*\s*(blocker|tech_debt|nit)", re.IGNORECASE)
 _FINDING_FILE_RE = re.compile(r"\*\*File:\*\*\s*`?([^\n`]+)`?")
 _FINDING_CODE_RE = re.compile(r"\*\*Code:\*\*\s*`?([^\n`]+)`?")
@@ -187,8 +179,6 @@ def _format_audit_issue_body(
 def run_log_review() -> dict:
     """Review previous day's logs per project.
 
-    Maps to monolith step: step_review_logs.
-
     Hotfix (sibling of PR #1056): this used to be ``async def`` but did
     synchronous file I/O (``open(...).read()``) on potentially unbounded
     log files. That froze the reflection-scheduler event loop for the full
@@ -297,7 +287,6 @@ def run_log_review() -> dict:
 async def run_documentation_audit() -> dict:
     """Audit documentation against codebase.
 
-    Maps to monolith step: step_audit_docs
     Delegates to DocsAuditor for intelligent audit.
     """
     import asyncio
@@ -346,10 +335,7 @@ async def run_documentation_audit() -> dict:
 
 
 def run_skills_audit() -> dict:
-    """Run skills audit to validate all SKILL.md files.
-
-    Maps to monolith step: step_skills_audit
-    """
+    """Run skills audit to validate all SKILL.md files."""
     audit_script = (
         PROJECT_ROOT / ".claude" / "skills" / "do-skills-audit" / "scripts" / "audit_skills.py"
     )
@@ -390,7 +376,6 @@ def run_skills_audit() -> dict:
 def run_hooks_audit() -> dict:
     """Audit Claude Code hooks for safety and configuration issues.
 
-    Maps to monolith step: step_hooks_audit.
     Checks: hooks.log for recent errors, settings.json hook configuration.
 
     Hotfix (sibling of PR #1056): converted from ``async def`` to plain
@@ -464,7 +449,6 @@ def run_hooks_audit() -> dict:
 def run_feature_docs_audit() -> dict:
     """Audit feature documentation for staleness and accuracy.
 
-    Maps to monolith step: step_feature_docs_audit.
     Checks: stale references, README index, stub docs, dead code refs.
 
     Hotfix (sibling of PR #1056): converted from ``async def`` to plain
@@ -571,7 +555,6 @@ def run_feature_docs_audit() -> dict:
 def run_pr_review_audit() -> dict:
     """Audit merged PRs for unaddressed review findings.
 
-    Maps to monolith step: step_pr_review_audit
     Runs in dry_run=True mode by default to avoid spurious issue creation.
     """
     from bridge.utc import utc_now

--- a/reflections/behavioral_learning.py
+++ b/reflections/behavioral_learning.py
@@ -1,14 +1,11 @@
 """
 reflections/behavioral_learning.py — Behavioral learning pipeline callable.
 
-Extracted from scripts/reflections.py pipeline:
-  step_episode_cycle_close → step_pattern_crystallization
+Pipeline: Episode Cycle-Close → Pattern Crystallization. This is a single
+callable that runs both sub-steps internally, preserving ordering without
+depends_on complexity in the YAML scheduler.
 
-This is a single callable that runs both sub-steps internally,
-preserving ordering without depends_on complexity in the YAML scheduler.
-
-Skips gracefully if models.cyclic_episode is not available (guard preserved
-from monolith step_behavioral_learning).
+Skips gracefully if models.cyclic_episode is not available.
 
 Returns:
   {"status": "ok"|"error", "findings": [...], "summary": str}
@@ -27,9 +24,6 @@ async def run() -> dict:
     """Run the behavioral learning pipeline.
 
     Pipeline: Episode Cycle-Close → Pattern Crystallization
-
-    Maps to monolith: step_behavioral_learning (which calls step_episode_cycle_close
-    and step_pattern_crystallization in sequence)
 
     Skips gracefully if models.cyclic_episode is not available.
     Raises exceptions on sub-step failure (propagates to scheduler).

--- a/reflections/daily_report.py
+++ b/reflections/daily_report.py
@@ -1,11 +1,9 @@
 """
 reflections/daily_report.py — Daily report pipeline callable.
 
-Extracted from scripts/reflections.py pipeline:
-  step_produce_report → step_create_github_issue
-
-This is a single callable that runs both sub-steps internally,
-preserving ordering without depends_on complexity in the YAML scheduler.
+Pipeline: Produce Report → Create GitHub Issue. This is a single callable
+that runs both sub-steps internally, preserving ordering without depends_on
+complexity in the YAML scheduler.
 
 The daily report aggregates findings from all other reflections that ran today
 via their Redis Reflection state records, then posts to GitHub and Telegram.
@@ -29,8 +27,8 @@ REFLECTIONS_DIR = PROJECT_ROOT / "logs" / "reflections"
 def _collect_reflection_findings() -> dict[str, list[str]]:
     """Collect findings from all Reflection records that ran today.
 
-    Reads from the Reflection model (used by the YAML scheduler) rather than
-    ReflectionRun. Returns a dict of category → list[finding].
+    Reads from the Reflection model (the YAML scheduler's per-callable state
+    record). Returns a dict of category → list[finding].
     """
     findings: dict[str, list[str]] = {}
 
@@ -67,9 +65,6 @@ async def run() -> dict:
     """Run the daily report pipeline.
 
     Pipeline: Produce Report → Create GitHub Issue
-
-    Maps to monolith: step_daily_report_and_notify (which calls step_produce_report
-    and step_create_github_issue in sequence)
 
     Note: The "must run after all other reflections" constraint cannot be
     mechanically enforced by the current scheduler (no DAG). This callable

--- a/reflections/maintenance.py
+++ b/reflections/maintenance.py
@@ -1,14 +1,6 @@
 """
 reflections/maintenance.py — System maintenance reflection callables.
 
-Extracted from scripts/reflections.py steps:
-  - step_clean_legacy        → run_legacy_code_scan
-  - step_redis_cleanup       → run_redis_ttl_cleanup
-  - step_redis_data_quality  → run_redis_data_quality
-  - step_branch_plan_cleanup → run_branch_plan_cleanup
-  - step_disk_space_check    → run_disk_space_check
-  - step_analytics_rollup    → run_analytics_rollup
-
 All functions accept no arguments and return:
   {"status": "ok"|"error", "findings": [...], "summary": str}
 """
@@ -30,10 +22,7 @@ logger = logging.getLogger("reflections.maintenance")
 
 
 def run_legacy_code_scan() -> dict:
-    """Scan for legacy code patterns: TODO comments, deprecated typing imports.
-
-    Maps to monolith step: step_clean_legacy
-    """
+    """Scan for legacy code patterns: TODO comments, deprecated typing imports."""
     findings = []
 
     try:
@@ -76,7 +65,6 @@ def run_legacy_code_scan() -> dict:
 async def run_redis_ttl_cleanup() -> dict:
     """Run TTL cleanup on all Redis models to remove expired records.
 
-    Maps to monolith step: step_redis_cleanup
     Cleans up: TelegramMessage, Link, Chat, AgentSession (90-day),
     BridgeEvent (7-day), ReflectionIgnore (expired).
     """
@@ -123,10 +111,7 @@ async def run_redis_ttl_cleanup() -> dict:
 
 
 async def run_redis_data_quality() -> dict:
-    """Run Redis data quality checks: unsummarized links, dead channels, error patterns.
-
-    Maps to monolith step: step_redis_data_quality
-    """
+    """Run Redis data quality checks: unsummarized links, dead channels, error patterns."""
     findings: list[str] = []
 
     try:
@@ -248,7 +233,6 @@ async def run_redis_data_quality() -> dict:
 async def run_branch_plan_cleanup() -> dict:
     """Clean up stale git branches and audit plan files.
 
-    Maps to monolith step: step_branch_plan_cleanup
     - Deletes local branches merged into main
     - Audits docs/plans/ for complete/orphaned/stale-issue plans
     """
@@ -435,7 +419,6 @@ async def run_branch_plan_cleanup() -> dict:
 async def run_disk_space_check() -> dict:
     """Check available disk space on the project volume.
 
-    Maps to monolith step: step_disk_space_check
     Records a finding when free space drops below 10 GB.
     """
     findings: list[str] = []
@@ -463,10 +446,7 @@ async def run_disk_space_check() -> dict:
 
 
 async def run_analytics_rollup() -> dict:
-    """Run analytics daily rollup: aggregate metrics and purge old data.
-
-    Maps to monolith step: step_analytics_rollup
-    """
+    """Run analytics daily rollup: aggregate metrics and purge old data."""
     try:
         from analytics.rollup import rollup_daily
 

--- a/reflections/memory_management.py
+++ b/reflections/memory_management.py
@@ -1,7 +1,7 @@
 """
 reflections/memory_management.py — Memory management reflection callables.
 
-New reflections with no monolith equivalent:
+Reflection callables:
   - run_memory_decay_prune    — Delete below-threshold memories (dry_run default)
   - run_memory_quality_audit  — Flag zero-access + dismissed memories
   - run_knowledge_reindex     — Re-index work-vault docs into KnowledgeDocument

--- a/reflections/session_intelligence.py
+++ b/reflections/session_intelligence.py
@@ -1,11 +1,9 @@
 """
 reflections/session_intelligence.py — Session intelligence pipeline callable.
 
-Extracted from scripts/reflections.py pipeline:
-  step_session_analysis → step_llm_reflection → step_auto_fix_bugs
-
-This is a single callable that runs all three sub-steps internally,
-preserving ordering without depends_on complexity in the YAML scheduler.
+Pipeline: Session Analysis → LLM Reflection → Auto-Fix Bugs. This is a single
+callable that runs all three sub-steps internally, preserving ordering without
+depends_on complexity in the YAML scheduler.
 
 Returns:
   {"status": "ok"|"error", "findings": [...], "summary": str}
@@ -139,9 +137,6 @@ def run() -> dict:
     """Run the full session intelligence pipeline.
 
     Pipeline: Session Analysis → LLM Reflection → Bug Issue Filing
-
-    Maps to monolith: step_session_intelligence (which calls step_session_analysis,
-    step_llm_reflection, step_auto_fix_bugs in sequence)
 
     Raises exceptions on sub-step failure (propagates to scheduler for
     last_status=error tracking).

--- a/reflections/task_management.py
+++ b/reflections/task_management.py
@@ -1,10 +1,6 @@
 """
 reflections/task_management.py — Task management reflection callables.
 
-Extracted from scripts/reflections.py steps:
-  - step_clean_tasks         → run_task_management
-  - step_principal_staleness → run_principal_staleness
-
 All functions accept no arguments and return:
   {"status": "ok"|"error", "findings": [...], "summary": str}
 """
@@ -21,10 +17,7 @@ logger = logging.getLogger("reflections.task_management")
 
 
 def run_task_management() -> dict:
-    """Clean up task management: check open bugs per project, local TODOs.
-
-    Maps to monolith step: step_clean_tasks
-    """
+    """Clean up task management: check open bugs per project, local TODOs."""
     projects = load_local_projects()
     findings: list[str] = []
     total_findings = 0
@@ -85,7 +78,6 @@ def run_task_management() -> dict:
 async def run_principal_staleness() -> dict:
     """Check if PRINCIPAL.md is stale (>90 days since last modification).
 
-    Maps to monolith step: step_principal_staleness
     PRINCIPAL.md encodes the supervisor's strategic context. If it hasn't
     been updated in 90+ days, flag it for review since priorities may
     have shifted.

--- a/reflections/utils.py
+++ b/reflections/utils.py
@@ -1,8 +1,7 @@
 """
 reflections/utils.py — Shared helpers for all reflection callables.
 
-Extracted from scripts/reflections.py (ReflectionRunner class and module-level
-helpers). All helpers are pure functions with no shared mutable state.
+All helpers are pure functions with no shared mutable state.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Pure cosmetic scrub of monolith-migration annotations from `reflections/` per project principle #1 (NO LEGACY CODE TOLERANCE). The reflections/ package was extracted from the 3,086-line `scripts/reflections.py` monolith in PR #967, but every module still narrated its origin in header docstrings and inline annotations long after the monolith was deleted.

## Changes

- Removed 7 "Extracted from scripts/reflections.py" header docstrings
- Removed 14 "Maps to monolith step: step_X" inline annotations from callable docstrings
- Removed `reflections/__init__.py` reference to `ReflectionRun` / "the legacy monolith class"
- Removed "from monolith module level" tail in `reflections/auditing.py`
- Re-flowed `reflections/memory_management.py` header from "New reflections with no monolith equivalent" -> neutral "Reflection callables"
- Re-flowed `reflections/daily_report.py:_collect_reflection_findings` docstring to drop `ReflectionRun` reference while preserving its purpose statement
- Added one-line Convention bullet in `docs/features/reflections.md` to discourage reintroducing numbered-step references

## Verification

- `grep -rn 'scripts/reflections.py|Extracted from|Maps to monolith|monolith|ReflectionRun' reflections/` -> 0 matches
- `python -m ruff format --check reflections/` -> 9 files already formatted
- `git diff main -- reflections/` -> changes confined to docstrings/comments (no edits inside function bodies, signatures, or imports)
- All non-env-dependent reflection tests pass; the env-dependent ones (`TestRegistryLoading`, `TestRegistryIntegrity`, and one `TestRedisIndexCleanupReflection` test) require the vault `config/reflections.yaml` symlink, which is absent on this skills-only machine and were failing on baseline `b6eebc15` before this scrub

## Out of Scope (deferred)

- **`docs/features/popoto-index-hygiene.md`, `bridge-self-healing.md`, `telegram-history.md`, etc.** -- tracked by #1032
- **`docs/features/adding-reflection-tasks.md` rewrite** -- tracked by #1031
- **One-file-per-reflection refactor** -- tracked by #1028
- **Vault `~/Desktop/Valor/reflections.yaml` scrub** -- the issue cited `config/reflections.yaml:58, 141-142` but that file moved to vault on commit `c2af0960` ~13.5 hours before the issue was filed; recommend a follow-up issue against the vault file

Non-overlapping with #1031 (adding-reflection-tasks rewrite) and #1032 (cascade docs cleanup).

## Test plan

- [x] `grep -rn 'scripts/reflections.py|Extracted from|Maps to monolith|monolith|ReflectionRun' reflections/` returns zero matches
- [x] `git diff main -- reflections/` confined to docstrings/comments (no function-body changes)
- [x] `python -m ruff format --check reflections/` passes
- [x] All non-env-dependent reflection tests pass
- [x] Each edited module's docstring still describes what the module/callable does -- no orphaned sentence fragments

Closes #1132