### PR TITLE
Watchdog hardening: idle teardown, loop-break steering, per-session token tracking (#1128)

### DIFF
--- a/agent/sdk_client.py
+++ b/agent/sdk_client.py
@@ -245,6 +245,158 @@ def _has_prior_session(session_id: str) -> bool:
     return _get_prior_session_uuid(session_id) is not None
 
 
+def _env_flag_enabled(var_name: str, default: bool = True) -> bool:
+    """Return True unless the env var is explicitly set to a falsy string.
+
+    Used by watchdog-hardening feature gates (issue #1128). Falsy values
+    (case-insensitive): "0", "false", "no". Any other value — including
+    unset — means the flag is enabled.
+    """
+    raw = os.environ.get(var_name)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in {"0", "false", "no"}
+
+
+def _usage_field(usage, name: str) -> int:
+    """Safely read a numeric field from a `usage` container.
+
+    Handles both SDK-style attribute access (dataclass-like objects) and
+    harness-style dict access on the same field name. Missing or None
+    values default to 0. Non-integer values default to 0 as well.
+
+    Accepted shapes:
+      * `None` → 0
+      * dict (harness `data["usage"]`)   → `.get(name, 0) or 0`
+      * object with attribute (SDK `msg.usage`) → `getattr(..., name, 0) or 0`
+    """
+    if usage is None:
+        return 0
+    raw: object
+    if isinstance(usage, dict):
+        raw = usage.get(name, 0)
+    else:
+        raw = getattr(usage, name, 0)
+    try:
+        return int(raw or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def accumulate_session_tokens(
+    session_id: str | None,
+    input_tokens: int | None,
+    output_tokens: int | None,
+    cache_read_tokens: int | None,
+    cost_usd: float | None,
+) -> None:
+    """Add per-turn token + cost counts to an AgentSession record.
+
+    Called as a side effect from BOTH execution paths so token accounting
+    works uniformly for every session type:
+
+      * SDK path: `ClaudeSDKClient` returns `ResultMessage.usage` + `.total_cost_usd`
+        inside the query loop (see the `ResultMessage` handler below).
+      * Harness path: `claude -p stream-json` emits `usage` + `total_cost_usd`
+        on the `result` event; `_run_harness_subprocess` extracts them and
+        threads them back to `get_response_via_harness`, which calls this
+        helper before returning (mirroring `_store_claude_session_uuid`).
+
+    Without the harness-path call, production PM/Dev/Teammate sessions —
+    which always use the harness — would report 0 tokens forever (the
+    critique B3 blocker).
+
+    Persistence: Popoto `save(update_fields=[...])` with explicit field list
+    so a concurrent write to other fields (e.g. `status`, `updated_at`) does
+    not clobber this update. Fail-quiet on any exception — token accounting
+    must never raise into the SDK / harness return path.
+
+    Gate: `WATCHDOG_TOKEN_TRACKING_ENABLED` (default on). Disabling is an
+    operator-only escape hatch for debugging or if a downstream issue is
+    traced to this helper.
+
+    Args:
+        session_id: Bridge/Telegram session_id. No-op when None.
+        input_tokens: Input token count for this turn (fallback 0 on None).
+        output_tokens: Output token count for this turn (fallback 0 on None).
+        cache_read_tokens: Cache-read input tokens for this turn (fallback 0).
+        cost_usd: Dollar cost for this turn, taken verbatim from the SDK/CLI.
+            Never recomputed. Fallback 0.0 on None.
+    """
+    if not session_id:
+        return
+    if not _env_flag_enabled("WATCHDOG_TOKEN_TRACKING_ENABLED"):
+        return
+
+    # Defensive coercion: SDK / harness occasionally omit fields on error
+    # paths or older CLI versions.
+    try:
+        in_delta = int(input_tokens or 0)
+        out_delta = int(output_tokens or 0)
+        cache_delta = int(cache_read_tokens or 0)
+        cost_delta = float(cost_usd or 0.0)
+    except (TypeError, ValueError):
+        logger.warning(
+            "accumulate_session_tokens: non-numeric inputs for session %s "
+            "(in=%r out=%r cache=%r cost=%r) — skipping",
+            session_id,
+            input_tokens,
+            output_tokens,
+            cache_read_tokens,
+            cost_usd,
+        )
+        return
+
+    # No-op when there is nothing to add (saves a Redis round-trip).
+    if in_delta == 0 and out_delta == 0 and cache_delta == 0 and cost_delta == 0.0:
+        return
+
+    try:
+        from popoto.exceptions import ModelException
+
+        from models.agent_session import AgentSession
+
+        sessions = list(AgentSession.query.filter(session_id=session_id))
+        if not sessions:
+            logger.debug(
+                "accumulate_session_tokens: no AgentSession for session_id=%s — skipping",
+                session_id,
+            )
+            return
+        # Newest record wins — matches the pattern used by
+        # `_store_claude_session_uuid`.
+        sessions.sort(key=lambda s: s.created_at or 0, reverse=True)
+        session = sessions[0]
+        try:
+            session.total_input_tokens = (session.total_input_tokens or 0) + in_delta
+            session.total_output_tokens = (session.total_output_tokens or 0) + out_delta
+            session.total_cache_read_tokens = (
+                session.total_cache_read_tokens or 0
+            ) + cache_delta
+            session.total_cost_usd = float(session.total_cost_usd or 0.0) + cost_delta
+            session.save(
+                update_fields=[
+                    "total_input_tokens",
+                    "total_output_tokens",
+                    "total_cache_read_tokens",
+                    "total_cost_usd",
+                ]
+            )
+        except ModelException as e:
+            logger.warning(
+                "accumulate_session_tokens: ModelException on save for session %s: %s",
+                session_id,
+                e,
+            )
+    except Exception as e:
+        logger.warning(
+            "accumulate_session_tokens(%s) failed: %s",
+            session_id,
+            e,
+            exc_info=False,
+        )
+
+
 def _store_claude_session_uuid(session_id: str, claude_uuid: str) -> None:
     """Store the Claude Code session UUID on the AgentSession.
 
@@ -1295,6 +1447,21 @@ class ValorAgent:
                                             record_metric("session.turns", float(turns), dims)
                                     except Exception:
                                         pass
+
+                                # Per-session token accumulation (issue #1128 —
+                                # SDK path). Harness path extracts the same
+                                # fields off the `result` event inside
+                                # `_run_harness_subprocess`; both call the
+                                # same `accumulate_session_tokens` helper.
+                                if session_id:
+                                    usage_obj = getattr(msg, "usage", None)
+                                    accumulate_session_tokens(
+                                        session_id,
+                                        _usage_field(usage_obj, "input_tokens"),
+                                        _usage_field(usage_obj, "output_tokens"),
+                                        _usage_field(usage_obj, "cache_read_input_tokens"),
+                                        msg.total_cost_usd,
+                                    )
                                 if msg.is_error and retries < max_retries:
                                     retries += 1
                                     error_text = msg.result or "(empty)"
@@ -1705,12 +1872,14 @@ async def get_response_via_harness(
     else:
         cmd = harness_cmd + [message]
 
-    result_text, session_id_from_harness, returncode = await _run_harness_subprocess(
-        cmd,
-        working_dir,
-        proc_env,
-        on_sdk_started=on_sdk_started,
-        on_stdout_event=on_stdout_event,
+    result_text, session_id_from_harness, returncode, usage, cost_usd = (
+        await _run_harness_subprocess(
+            cmd,
+            working_dir,
+            proc_env,
+            on_sdk_started=on_sdk_started,
+            on_stdout_event=on_stdout_event,
+        )
     )
 
     # Image-dimension sentinel: Claude Code returns the image-dimension error with
@@ -1725,12 +1894,14 @@ async def get_response_via_harness(
         if full_context_message is not None:
             fallback_msg = _apply_context_budget(full_context_message)
             fallback_cmd = harness_cmd + [fallback_msg]
-            result_text, session_id_from_harness, _ = await _run_harness_subprocess(
-                fallback_cmd,
-                working_dir,
-                proc_env,
-                on_sdk_started=on_sdk_started,
-                on_stdout_event=on_stdout_event,
+            result_text, session_id_from_harness, _, usage, cost_usd = (
+                await _run_harness_subprocess(
+                    fallback_cmd,
+                    working_dir,
+                    proc_env,
+                    on_sdk_started=on_sdk_started,
+                    on_stdout_event=on_stdout_event,
+                )
             )
         else:
             logger.error(
@@ -1760,12 +1931,14 @@ async def get_response_via_harness(
                     f"[harness] Fallback budget: {original_len} → {len(fallback_msg)} chars"
                 )
             fallback_cmd = harness_cmd + [fallback_msg]
-            result_text, session_id_from_harness, _ = await _run_harness_subprocess(
-                fallback_cmd,
-                working_dir,
-                proc_env,
-                on_sdk_started=on_sdk_started,
-                on_stdout_event=on_stdout_event,
+            result_text, session_id_from_harness, _, usage, cost_usd = (
+                await _run_harness_subprocess(
+                    fallback_cmd,
+                    working_dir,
+                    proc_env,
+                    on_sdk_started=on_sdk_started,
+                    on_stdout_event=on_stdout_event,
+                )
             )
         else:
             logger.error(
@@ -1777,6 +1950,21 @@ async def get_response_via_harness(
     # Store the Claude Code UUID for next-turn --resume (#976)
     if session_id and session_id_from_harness:
         _store_claude_session_uuid(session_id, session_id_from_harness)
+
+    # Accumulate tokens + cost on the AgentSession (issue #1128). Mirrors
+    # the SDK path's in-handler call in `get_response_via_sdk`. Invoked
+    # here as a side effect so the public signature stays `-> str` and
+    # no caller of `get_response_via_harness` has to change. `usage` /
+    # `cost_usd` may be None on harness error paths or older CLI
+    # versions — the helper treats missing fields as 0.
+    if session_id and (usage is not None or cost_usd is not None):
+        accumulate_session_tokens(
+            session_id,
+            _usage_field(usage, "input_tokens"),
+            _usage_field(usage, "output_tokens"),
+            _usage_field(usage, "cache_read_input_tokens"),
+            cost_usd,
+        )
 
     if result_text is not None:
         return result_text
@@ -1790,13 +1978,29 @@ async def _run_harness_subprocess(
     *,
     on_sdk_started: Callable[[int], None] | None = None,
     on_stdout_event: Callable[[], None] | None = None,
-) -> tuple[str | None, str | None, int | None]:
+) -> tuple[str | None, str | None, int | None, dict | None, float | None]:
     """Execute a harness subprocess and parse stream-json output.
 
-    Returns (result_text, session_id_from_harness, returncode). On binary-not-found,
-    returncode is None and result_text carries the error message. On stream-parse
-    success, result_text is the parsed result and returncode is the process exit
-    code (0 on success, non-zero on failure).
+    Returns `(result_text, session_id_from_harness, returncode, usage, cost_usd)`.
+
+    * `result_text`: parsed result string from the final `result` event, or
+      accumulated text from stream events when no result event fires, or
+      `None` when neither is available.
+    * `session_id_from_harness`: Claude Code UUID for next-turn `--resume`.
+    * `returncode`: process exit code (0 on success, non-zero on failure, or
+      `None` on binary-not-found).
+    * `usage`: dict from the `result` event's `usage` field (keys include
+      `input_tokens`, `output_tokens`, `cache_read_input_tokens`,
+      `cache_creation_input_tokens`). `None` when no `result` event fired or
+      the event omitted it. Consumed by `accumulate_session_tokens` in
+      `get_response_via_harness` — this is the harness-side half of the
+      two-path token tracker introduced for issue #1128.
+    * `cost_usd`: raw `total_cost_usd` from the `result` event, taken
+      verbatim and never recomputed locally so the value tracks upstream
+      Anthropic pricing automatically.
+
+    On binary-not-found, returncode is None and result_text carries the
+    error message (usage and cost_usd are both None).
 
     Optional callbacks (issue #1036):
         on_sdk_started(pid): fires once, immediately after the subprocess is
@@ -1820,7 +2024,7 @@ async def _run_harness_subprocess(
         )
     except FileNotFoundError as e:
         logger.error(f"Harness binary not found: {e}")
-        return (f"Error: CLI harness not found — {e}", None, None)
+        return (f"Error: CLI harness not found — {e}", None, None, None, None)
 
     # Fire SDK-started callback once the pid is known (#1036).
     if on_sdk_started is not None and proc.pid is not None:
@@ -1832,6 +2036,11 @@ async def _run_harness_subprocess(
     full_text = ""
     result_text = None
     session_id_from_harness = None
+    # Token + cost fields extracted off the `result` event (issue #1128).
+    # Mirrors the SDK path's `ResultMessage.usage` / `.total_cost_usd`
+    # so `accumulate_session_tokens` can be fed from either path.
+    usage: dict | None = None
+    cost_usd: float | None = None
 
     async for raw_line in proc.stdout:
         line = raw_line.decode("utf-8", errors="replace").strip()
@@ -1857,6 +2066,20 @@ async def _run_harness_subprocess(
         if event_type == "result":
             result_text = data.get("result", "")
             session_id_from_harness = data.get("session_id")
+            # Extract per-turn token + cost counts (issue #1128). These
+            # are the harness-side counterpart of `ResultMessage.usage`
+            # and `ResultMessage.total_cost_usd` from the SDK path. The
+            # `claude -p stream-json` protocol emits them on the same
+            # `result` event. `usage` is a dict; missing fields default
+            # to 0 inside `accumulate_session_tokens`. `total_cost_usd`
+            # is taken verbatim so it tracks upstream Anthropic pricing
+            # without a local price table.
+            raw_usage = data.get("usage")
+            if isinstance(raw_usage, dict):
+                usage = raw_usage
+            raw_cost = data.get("total_cost_usd")
+            if isinstance(raw_cost, (int, float)):
+                cost_usd = float(raw_cost)
             if session_id_from_harness:
                 logger.debug(f"Harness session_id for resume: {session_id_from_harness}")
             break
@@ -1880,15 +2103,15 @@ async def _run_harness_subprocess(
         logger.warning(f"Harness exited with code {returncode}: {stderr_text[:500]}")
 
     if result_text is not None:
-        return (result_text, session_id_from_harness, returncode)
+        return (result_text, session_id_from_harness, returncode, usage, cost_usd)
     if full_text:
         logger.warning(
             "Harness exited without result event, returning %d chars of accumulated text",
             len(full_text),
         )
-        return (full_text, session_id_from_harness, returncode)
+        return (full_text, session_id_from_harness, returncode, usage, cost_usd)
     logger.error("Harness exited without a result event and no accumulated text")
-    return (None, session_id_from_harness, returncode)
+    return (None, session_id_from_harness, returncode, usage, cost_usd)
 
 
 async def verify_harness_health(harness_name: str) -> bool:

--- a/agent/sdk_client.py
+++ b/agent/sdk_client.py
@@ -370,9 +370,7 @@ def accumulate_session_tokens(
         try:
             session.total_input_tokens = (session.total_input_tokens or 0) + in_delta
             session.total_output_tokens = (session.total_output_tokens or 0) + out_delta
-            session.total_cache_read_tokens = (
-                session.total_cache_read_tokens or 0
-            ) + cache_delta
+            session.total_cache_read_tokens = (session.total_cache_read_tokens or 0) + cache_delta
             session.total_cost_usd = float(session.total_cost_usd or 0.0) + cost_delta
             session.save(
                 update_fields=[
@@ -1872,14 +1870,18 @@ async def get_response_via_harness(
     else:
         cmd = harness_cmd + [message]
 
-    result_text, session_id_from_harness, returncode, usage, cost_usd = (
-        await _run_harness_subprocess(
-            cmd,
-            working_dir,
-            proc_env,
-            on_sdk_started=on_sdk_started,
-            on_stdout_event=on_stdout_event,
-        )
+    (
+        result_text,
+        session_id_from_harness,
+        returncode,
+        usage,
+        cost_usd,
+    ) = await _run_harness_subprocess(
+        cmd,
+        working_dir,
+        proc_env,
+        on_sdk_started=on_sdk_started,
+        on_stdout_event=on_stdout_event,
     )
 
     # Image-dimension sentinel: Claude Code returns the image-dimension error with
@@ -1894,14 +1896,18 @@ async def get_response_via_harness(
         if full_context_message is not None:
             fallback_msg = _apply_context_budget(full_context_message)
             fallback_cmd = harness_cmd + [fallback_msg]
-            result_text, session_id_from_harness, _, usage, cost_usd = (
-                await _run_harness_subprocess(
-                    fallback_cmd,
-                    working_dir,
-                    proc_env,
-                    on_sdk_started=on_sdk_started,
-                    on_stdout_event=on_stdout_event,
-                )
+            (
+                result_text,
+                session_id_from_harness,
+                _,
+                usage,
+                cost_usd,
+            ) = await _run_harness_subprocess(
+                fallback_cmd,
+                working_dir,
+                proc_env,
+                on_sdk_started=on_sdk_started,
+                on_stdout_event=on_stdout_event,
             )
         else:
             logger.error(
@@ -1931,14 +1937,18 @@ async def get_response_via_harness(
                     f"[harness] Fallback budget: {original_len} → {len(fallback_msg)} chars"
                 )
             fallback_cmd = harness_cmd + [fallback_msg]
-            result_text, session_id_from_harness, _, usage, cost_usd = (
-                await _run_harness_subprocess(
-                    fallback_cmd,
-                    working_dir,
-                    proc_env,
-                    on_sdk_started=on_sdk_started,
-                    on_stdout_event=on_stdout_event,
-                )
+            (
+                result_text,
+                session_id_from_harness,
+                _,
+                usage,
+                cost_usd,
+            ) = await _run_harness_subprocess(
+                fallback_cmd,
+                working_dir,
+                proc_env,
+                on_sdk_started=on_sdk_started,
+                on_stdout_event=on_stdout_event,
             )
         else:
             logger.error(

--- a/docs/features/bridge-self-healing.md
+++ b/docs/features/bridge-self-healing.md
@@ -374,6 +374,59 @@ tail -f logs/worker_watchdog.log
 
 **Installed by** `scripts/install_worker.sh` as `${SERVICE_LABEL_PREFIX}.worker-watchdog`.
 
+## Idle SDK Teardown (issue #1128)
+
+The Claude Agent SDK's persistent `ClaudeSDKClient` connections die
+silently after roughly 48 hours of idle (fleet-ops research, #1104). A
+dormant session waiting 2+ days on a human reply may be non-functional
+when resumed. The worker runs an idle sweeper
+(`worker/idle_sweeper.py::run_idle_sweep`) that proactively tears down
+those clients well inside the silent-death window, then rebuilds them
+from the stored `claude_session_uuid` via `--resume` on the next query.
+
+### Why this lives in the worker, not the watchdog
+
+The `_active_clients` registry in `agent/sdk_client.py:58` is
+**process-local** to the worker. The session-watchdog process
+(`monitoring/session_watchdog.py`) cannot reach it. So the sweeper must
+run INSIDE the worker process, alongside the registry it inspects. The
+watchdog process remains responsible for repetition / error-cascade /
+token-alert detection but never touches the registry.
+
+### Sweep loop
+
+- **Interval**: `WATCHDOG_IDLE_SWEEP_INTERVAL` (default 1800s = 30 min).
+- **Status filter**: `{dormant, paused, paused_circuit}`. Explicitly
+  excludes `running`, `pending`, `waiting_for_children`, `superseded`,
+  and all terminal states.
+- **Dormancy age**: `WATCHDOG_IDLE_TEARDOWN_THRESHOLD_SECONDS` (default
+  86400s = 24h). Uses `AgentSession.updated_at` as the clock, falling
+  back to `started_at` then `created_at`.
+- **Teardown**: iterate a `list(...)` snapshot of `_active_clients`,
+  `await client.close()` (idempotent), `_active_clients.pop(session_id,
+  None)`, then set `AgentSession.sdk_connection_torn_down_at = now` via
+  `save(update_fields=["sdk_connection_torn_down_at"])`.
+- **Resume semantics**: on next query, `get_response_via_sdk` enters
+  its `async with ClaudeSDKClient(...)` block, repopulates
+  `_active_clients`, and re-establishes context from
+  `claude_session_uuid` via the existing `--resume` plumbing.
+
+### Harness path is a no-op
+
+Production PM / Dev / Teammate sessions use
+`agent/sdk_client.py::get_response_via_harness`, which spawns a
+short-lived `claude -p stream-json` subprocess per turn. No persistent
+connection lives in `_active_clients`; the sweeper finds nothing to tear
+down.
+
+### Feature gate
+
+`WATCHDOG_IDLE_TEARDOWN_ENABLED=false` disables the sweep loop entirely
+(early-return inside `_sweep_once`). The worker still starts the task —
+it just skips its work every tick. Enable again without worker restart
+by unsetting the env var and sending SIGHUP (not implemented today; a
+worker restart is the documented path).
+
 ## Two-tier no-progress detector
 
 The periodic `_agent_session_health_check` (every 5 minutes) decides whether a

--- a/docs/features/bridge-worker-architecture.md
+++ b/docs/features/bridge-worker-architecture.md
@@ -103,6 +103,7 @@ The worker's startup sequence is deterministic:
 | 5 | `_ensure_worker(worker_key)` for each pending session | Kick per-worker-key loops for queued sessions |
 | 6 | `_agent_session_health_loop()` | Background task: periodic session health checks, orphan detection (safety net) |
 | 7 | `_session_notify_listener()` | Background task: subscribe to `valor:sessions:new` pub/sub, wake worker on new session (~1s pickup) |
+| 8 | `run_idle_sweep()` | Background task: proactively tears down idle persistent Claude SDK clients on dormant/paused sessions before the ~48h Anthropic silent-death window (issue #1128). See [Worker-Internal Idle Sweeper](#worker-internal-idle-sweeper-issue-1128). |
 
 ### Execution Harness Routing
 
@@ -151,6 +152,56 @@ _handle_dev_session_completion()  [dev sessions only, called AFTER complete_tran
 PM and teammate sessions skip the post-completion SDLC handler. See [Harness Abstraction](harness-abstraction.md) for stream-json parsing, chunk suppression, health checks, and configuration, and [Harness Session Continuity](harness-session-continuity.md) for the `--resume` UUID persistence mechanism.
 
 At runtime, the worker processes sessions via `_worker_loop(worker_key)` until the queue is empty, then waits for new enqueue events.
+
+### Worker-Internal Idle Sweeper (issue #1128)
+
+The **worker process** owns the `_active_clients` registry at
+`agent/sdk_client.py:58`, which maps `session_id → ClaudeSDKClient` for
+interactive chat sessions (the SDK-path). These persistent SDK
+connections die silently after ~48h of idle (fleet-ops finding #1104),
+so the worker spawns an idle-sweeper background task
+(`worker/idle_sweeper.py::run_idle_sweep`) to proactively tear down
+clients well before that window.
+
+```
+worker/__main__.py startup
+    |
+    v
+asyncio.create_task(run_idle_sweep(), name="idle-sweeper")
+    |
+    v
+loop every IDLE_SWEEP_INTERVAL seconds:
+    _sweep_once()
+      |
+      |-- snapshot = list(_active_clients.items())
+      |-- for (session_id, client) in snapshot:
+      |     load AgentSession.filter(session_id=session_id)
+      |     if status in {dormant, paused, paused_circuit}
+      |        AND updated_at age > IDLE_TEARDOWN_THRESHOLD:
+      |          await client.close()    -- idempotent
+      |          _active_clients.pop(session_id, None)
+      |          AgentSession.sdk_connection_torn_down_at = now
+      |          save(update_fields=["sdk_connection_torn_down_at"])
+      v
+cancel on worker SIGTERM shutdown
+```
+
+**Process locality** is the load-bearing design choice: the
+session-watchdog process (`monitoring/session_watchdog.py`) does NOT
+share memory with the worker, so it cannot reach `_active_clients`. The
+teardown MUST run inside the worker process. The watchdog remains
+responsible for repetition / error-cascade / token-alert detection and
+steering (see [Session Watchdog](session-watchdog.md)) but does not
+touch the SDK-client registry.
+
+**Harness-path sessions** (all production PM / Dev / Teammate work) are
+unaffected — `_run_harness_subprocess` spawns a short-lived `claude -p`
+subprocess per turn, leaving nothing in `_active_clients` to go stale.
+The sweeper is a no-op for harness-path sessions.
+
+**Configuration.** Defaults are generous (sweep every 30 min, tear down
+at 24h dormant); tune via env vars — see the [Session Watchdog env-var
+table](session-watchdog.md#configuration).
 
 ## Worker Key Routing (issues #831, #1085)
 

--- a/docs/features/session-steering.md
+++ b/docs/features/session-steering.md
@@ -124,6 +124,38 @@ When both drafter backends (Haiku and OpenRouter) fail, `send_response_with_file
 
 See [Message Drafter](message-drafter.md) for the current feature doc covering the drafter module. (The previous pointer to `summarizer-format.md` is gone — content migrated into `message-drafter.md`.)
 
+## Watchdog-Authored Steering (issue #1128)
+
+The session watchdog (`monitoring/session_watchdog.py`) is now an active
+steering-message **sender** alongside humans, the PM session, and the
+drafter fallback. When one of three conditions fires, the watchdog
+enqueues a targeted message via
+`_inject_watchdog_steer(session_id, reason, message)`, which calls
+`push_steering_message(..., sender="watchdog")`:
+
+| Reason | Trigger | Message template |
+|--------|---------|-------------------|
+| `repetition` | `detect_repetition` returns True | "Stop and re-check the task — you appear to be repeating the same tool call..." |
+| `error_cascade` | `detect_error_cascade` returns True | "Stop — you've hit N errors in the last 20 operations..." |
+| `token_alert` | cumulative `input+output` tokens ≥ `TOKEN_ALERT_THRESHOLD` on a `running` session | "Token budget exceeded: $X / Y tokens spent this session..." |
+
+**Sender='watchdog'** lets downstream consumers distinguish automated
+nudges from human steers:
+
+- `valor-session status --id <id>` renders the sender on each queued entry.
+- The dashboard JSON includes `sender` on queued-steering entries.
+- `agent/session_executor.py`'s steering-drain loop logs `[steering]
+  received from sender=watchdog` so operators can trace which ticks
+  corresponded to a watchdog-driven correction.
+
+**Per-reason atomic cooldown.** Redis `SET key "1" NX EX <ttl>` with a
+reason-scoped key (`watchdog:steer_cooldown:<reason>:<session_id>`)
+eliminates the read-then-write race entirely. A `repetition` steer does
+not suppress a parallel `error_cascade` or `token_alert` steer.
+
+**Feature gate.** `WATCHDOG_AUTO_STEER_ENABLED=false` disables the push
+without disabling the detection (still logged at WARNING).
+
 ## Parent-Child Steering (PM session to Dev session)
 
 In addition to Telegram reply-thread steering (user to agent), the steering queue supports **parent-child steering** where a PM session (PM persona) pushes steering messages to its spawned Dev sessions.

--- a/docs/features/session-steering.md
+++ b/docs/features/session-steering.md
@@ -5,7 +5,7 @@
 **See also:**
 - [Mid-Session Steering](mid-session-steering.md) — Telegram reply-thread flow (user-facing)
 - [Steering Queue: Historical Spec](steering-implementation-spec.md) — Original Redis list design and bridge coalescing
-- [PM Final Delivery](pm-final-delivery.md) — SDLC terminal-turn protocol. Fan-out completion invokes the completion-turn runner directly; it no longer goes through the steering inbox. The `[PIPELINE_COMPLETE]` content marker referenced in earlier docs is deprecated (issue #1058).
+- [PM Final Delivery](pm-final-delivery.md) — SDLC terminal-turn protocol. Fan-out completion invokes the completion-turn runner directly; it does not go through the steering inbox. The `[PIPELINE_COMPLETE]` content marker historically referenced in earlier docs was retired in issue #1058.
 
 External steering for `AgentSession` via `queued_steering_messages`. Any process — the PM, a CLI user, another agent — can write messages to a running session's inbox. The worker injects them at the next turn boundary.
 

--- a/docs/features/session-watchdog-reliability.md
+++ b/docs/features/session-watchdog-reliability.md
@@ -83,11 +83,46 @@ Observer Error Path
 - `tests/unit/test_observer.py` - Error classification, backoff schedule, circuit breaker state, import guard
 - `tests/unit/test_sdk_client_sdlc.py` - Activity tracking: record, get, clear, inactivity detection
 
+## Watchdog Hardening (issue #1128)
+
+Three additive reliability features layered on top of the detection
+signals documented above. None of them change the heartbeat or activity
+detection paths — they extend the actuator surface.
+
+1. **Automatic loop-break steering.** `detect_repetition` and
+   `detect_error_cascade` no longer log and return — they enqueue a
+   targeted steering message via `push_steering_message(...,
+   sender="watchdog")`. A per-reason atomic Redis `SET NX EX` cooldown
+   prevents flooding. Drain timing is the PostToolUse-hook turn
+   boundary. See [Session Watchdog](session-watchdog.md) for thresholds
+   and env-var gating.
+
+2. **Two-path per-session token tracking.** Every SDK ResultMessage AND
+   every harness `result` event feeds into a single
+   `agent/sdk_client.py::accumulate_session_tokens` helper, which
+   persists `total_input_tokens`, `total_output_tokens`,
+   `total_cache_read_tokens`, and `total_cost_usd` onto `AgentSession`.
+   Dashboards (`/dashboard.json`) surface the four fields. The watchdog
+   is READ-ONLY for these fields — writes happen only in the worker
+   process. A soft-threshold alert triggers a `token_alert` steer when
+   cumulative tokens cross `TOKEN_ALERT_THRESHOLD` on a running session.
+
+3. **Worker-internal idle SDK-client teardown.** A new
+   `worker/idle_sweeper.py` task runs inside the worker process,
+   snapshots `agent.sdk_client._active_clients`, and proactively closes
+   persistent SDK clients on dormant / paused / paused_circuit sessions
+   whose `updated_at` age exceeds `IDLE_TEARDOWN_THRESHOLD` (default 24h).
+   This sits well inside the ~48h Anthropic silent-death window (#1104).
+   The session-watchdog process is intentionally NOT involved — the
+   registry is worker-process-local.
+
 ## Related
 
 - [Session Watchdog](session-watchdog.md) - Base watchdog implementation
+- [Session Steering](session-steering.md) - Steering queue + `sender` attribution
+- [Bridge Worker Architecture](bridge-worker-architecture.md) - Process topology for idle teardown
+- [Bridge Self-Healing](bridge-self-healing.md) - Broader crash recovery system
 - [Stall Retry](stall-retry.md) - Retry mechanism for stalled sessions
 - [Chat Dev Session Architecture](pm-dev-session-architecture.md) - Session routing architecture
-- [Bridge Self-Healing](bridge-self-healing.md) - Broader crash recovery system
 - [SDLC Pipeline Integrity](sdlc-pipeline-integrity.md) - Worker post-completion stage state injection and pipeline state feedback
 - [Session Isolation: Raw-String Session Lookup](session-isolation.md#model-fields) - Canonical `AgentSession.get_by_id()` pattern (issue #765 systemic fix)

--- a/docs/features/session-watchdog.md
+++ b/docs/features/session-watchdog.md
@@ -86,6 +86,43 @@ Alerts are sent as Telegram messages to the chat where the session originated. E
 
 **Fallback**: If the Telegram client is unavailable or the send fails, the alert is logged at WARNING level and the watchdog continues.
 
+## Automatic Loop-Break Steering (issue #1128)
+
+When `detect_repetition` or `detect_error_cascade` fires, the watchdog no
+longer just logs the finding — it automatically enqueues a targeted
+steering message via `agent/steering.py::push_steering_message` tagged
+`sender="watchdog"`. The message is drained at the next tool-call
+boundary by the existing PostToolUse hook, so the agent receives the
+correction before its next repetition of the stuck tool. A token-spend
+soft-threshold alert uses the same helper to nudge sessions whose
+cumulative `total_input_tokens + total_output_tokens` crosses
+`TOKEN_ALERT_THRESHOLD` (default 5M) while `status == "running"`.
+
+**Atomic per-reason cooldown.** Each trigger reason has its own Redis
+cooldown key (`watchdog:steer_cooldown:<reason>:<session_id>`). The
+cooldown is enforced with a single atomic `SET key "1" NX EX <ttl>` —
+never a separate GET/SET — so concurrent ticks cannot double-fire.
+Because the keys are reason-scoped, a repetition steer does not
+suppress a parallel error-cascade or token-alert steer.
+
+| Reason | Cooldown env var | Default TTL |
+|--------|------------------|-------------|
+| `repetition` | `WATCHDOG_STEER_COOLDOWN` | 900s (3 ticks) |
+| `error_cascade` | `WATCHDOG_STEER_COOLDOWN` | 900s (3 ticks) |
+| `token_alert` | `WATCHDOG_TOKEN_ALERT_COOLDOWN` | 3600s (1 hour) |
+
+**Sender attribution.** Every watchdog-authored steer passes
+`sender="watchdog"` so the dashboard, `valor-session status`, and the PM
+steering-drain log can distinguish automated nudges from human steers.
+
+**Delivery timing.** Steers drain at tool-call boundaries via the
+existing PostToolUse hook. Operators should expect a one-tool-call delay
+between detection and correction; this is acceptable because stuck
+loops emit many tool calls per minute.
+
+**Feature gate.** `WATCHDOG_AUTO_STEER_ENABLED=false` disables loop-break
+steering without disabling detection (still logged at WARNING).
+
 ## Configuration
 
 All thresholds are module-level constants in `monitoring/session_watchdog.py`:
@@ -100,8 +137,27 @@ All thresholds are module-level constants in `monitoring/session_watchdog.py`:
 | `DURATION_THRESHOLD` | 7200 (2 hr) | Session age before duration alert |
 | `ALERT_COOLDOWN` | 1800 (30 min) | Minimum gap between alerts per session |
 | `TRANSCRIPT_STALE_THRESHOLD_MIN` | 15 | Minutes before transcript is considered stale |
+| `STEER_COOLDOWN` | 900 (15 min) | Per-reason cooldown for repetition/cascade steers |
+| `TOKEN_ALERT_THRESHOLD` | 5,000,000 | Soft-threshold on `input + output` tokens |
+| `TOKEN_ALERT_COOLDOWN` | 3600 (1 hr) | Cooldown for token-alert steers |
 
-No runtime configuration — edit constants directly. Intentionally static to keep the watchdog simple.
+**Environment variables (issue #1128):** every constant above that
+participates in loop-break / token-alert behavior is env-tunable and the
+behavior itself is toggleable:
+
+| Env var | Purpose | Default |
+|---------|---------|---------|
+| `WATCHDOG_AUTO_STEER_ENABLED` | Toggle auto-steer on/off | on |
+| `WATCHDOG_TOKEN_TRACKING_ENABLED` | Toggle per-session token accumulation | on |
+| `WATCHDOG_IDLE_TEARDOWN_ENABLED` | Toggle worker idle-sweeper | on |
+| `WATCHDOG_TOKEN_ALERT_THRESHOLD` | Soft-threshold tokens | 5000000 |
+| `WATCHDOG_TOKEN_ALERT_COOLDOWN` | Token-alert cooldown (s) | 3600 |
+| `WATCHDOG_STEER_COOLDOWN` | Repetition/cascade cooldown (s) | 900 |
+| `WATCHDOG_IDLE_TEARDOWN_THRESHOLD_SECONDS` | Dormancy age to trigger SDK teardown | 86400 |
+| `WATCHDOG_IDLE_SWEEP_INTERVAL` | Seconds between sweeper ticks | 1800 |
+
+Falsy values (case-insensitive `"0"`, `"false"`, `"no"`) disable the
+gated feature. Any other value — including unset — means enabled.
 
 ## Integration
 
@@ -123,17 +179,48 @@ The session watchdog is complementary — it catches sessions that go *silent* (
 
 **Stall detection**: The watchdog also runs `check_stalled_sessions()` each cycle, which flags sessions stuck in transitional states (pending >5min, running >45min, active with no recent activity). For active sessions, stall detection is activity-based: the watchdog checks both the Redis `updated_at` field and in-memory timestamps from `sdk_client.get_session_last_activity()`, using whichever is more recent. Sessions producing tool calls or log output are never interrupted regardless of total runtime. See [Session Watchdog Reliability](session-watchdog-reliability.md) for the activity-based detection system and [Session Lifecycle Diagnostics](session-lifecycle-diagnostics.md) for logging details.
 
+## Process-Locality Contract (issue #1128)
+
+The session-watchdog process (`monitoring/session_watchdog.py`) and the
+**worker-internal idle sweeper** (`worker/idle_sweeper.py`) are two
+separate actuators that share nothing but `AgentSession` records and the
+steering queue — both Redis-backed.
+
+- **Watchdog process**: owns repetition / error-cascade / token-threshold
+  detection AND their steering actuation. Reads `AgentSession` tokens
+  (never writes them). Never imports `agent.sdk_client._active_clients`
+  — the registry is worker-process-local.
+- **Worker process**: owns the `_active_clients` registry and the idle
+  sweeper. The sweeper proactively tears down persistent SDK clients on
+  dormant / paused / paused_circuit sessions whose `updated_at` age
+  exceeds `WATCHDOG_IDLE_TEARDOWN_THRESHOLD_SECONDS` (default 24h), well
+  inside the ~48h Anthropic silent-death window.
+
+See `worker/idle_sweeper.py` docstring and
+[bridge-worker-architecture.md](bridge-worker-architecture.md) for the
+full topology.
+
 ## Files
 
 | File | Purpose |
 |------|---------|
-| `monitoring/session_watchdog.py` | Watchdog implementation (all detection + alerting) |
+| `monitoring/session_watchdog.py` | Watchdog implementation (detection + loop-break steer + token alert) |
 | `monitoring/__init__.py` | Module exports |
 | `agent/health_check.py` | PostToolUse health check with watchdog_unhealthy flag and additionalContext injection |
 | `agent/agent_session_queue.py` | Nudge loop checks `is_session_unhealthy()` before auto-continuing |
-| `models/agent_session.py` | `watchdog_unhealthy` field on AgentSession |
+| `agent/sdk_client.py` | `accumulate_session_tokens` helper (SDK + harness path writers) |
+| `agent/steering.py` | `push_steering_message` with `sender="watchdog"` attribution |
+| `worker/idle_sweeper.py` | Worker-internal idle SDK client teardown (issue #1128) |
+| `worker/__main__.py` | Starts the idle sweeper alongside reflection + notify tasks |
+| `models/agent_session.py` | `watchdog_unhealthy`, token fields, `sdk_connection_torn_down_at` |
 | `bridge/telegram_bridge.py` | Integration point (launches watchdog task) |
-| `tests/unit/test_session_watchdog.py` | 30 unit tests |
-| `tests/unit/test_health_check.py` | 30 unit tests for PostToolUse health check |
-| `tests/unit/test_transcript_liveness.py` | 12 unit tests for transcript mtime check |
+| `tests/unit/test_session_watchdog.py` | Detection + steer-actuator assertions |
+| `tests/unit/test_watchdog_loop_break_steer.py` | `_inject_watchdog_steer` cooldown + sender attribution |
+| `tests/unit/test_watchdog_token_alert.py` | Token threshold → steer wiring |
+| `tests/unit/test_session_token_accumulator.py` | `accumulate_session_tokens` end-to-end |
+| `tests/unit/test_harness_token_capture.py` | Harness-path B3 fix (usage + cost from `result` event) |
+| `tests/unit/test_worker_idle_sweeper.py` | Worker-internal idle teardown |
+| `tests/unit/test_health_check.py` | PostToolUse health check |
+| `tests/unit/test_transcript_liveness.py` | Transcript mtime check |
 | `docs/plans/session-watchdog.md` | Original plan document |
+| `docs/plans/watchdog-hardening.md` | issue #1128 plan |

--- a/docs/plans/watchdog-hardening.md
+++ b/docs/plans/watchdog-hardening.md
@@ -76,16 +76,20 @@ Skipping WebSearch — the problem is purely about wiring already-identified sig
 ### spike-1: Token source in SDK ResultMessage
 - **Assumption**: "`ResultMessage` exposes per-turn input/output token counts that can be aggregated into `AgentSession`."
 - **Method**: code-read
-- **Finding**: Confirmed. `ResultMessage` fields include `usage`, `model_usage`, `total_cost_usd`, `duration_ms`, `num_turns`. `usage` is a dict-like with `input_tokens`, `output_tokens`, and typically `cache_read_input_tokens`, `cache_creation_input_tokens`. `total_cost_usd` is already captured at `agent/sdk_client.py:1233`.
+- **Finding**: Confirmed. `ResultMessage` fields include `usage`, `model_usage`, `total_cost_usd`, `duration_ms`, `num_turns`. `usage` is a dict-like with `input_tokens`, `output_tokens`, and typically `cache_read_input_tokens`, `cache_creation_input_tokens`. `total_cost_usd` is already captured at `agent/sdk_client.py:1275`.
 - **Confidence**: high
-- **Impact on plan**: Token aggregation hooks into the existing `ResultMessage` handler at `sdk_client.py:1216`. Adds 4 integer fields to `AgentSession`: `total_input_tokens`, `total_output_tokens`, `total_cache_read_tokens`, `total_cost_usd`. No new SDK integration required.
+- **Impact on plan**: Token aggregation from the SDK path hooks into the existing `ResultMessage` handler in `sdk_client.py`. Adds 4 numeric fields to `AgentSession`: `total_input_tokens`, `total_output_tokens`, `total_cache_read_tokens`, `total_cost_usd`. **However, SDK path is only one of two execution paths — see spike-5 for the harness path.**
 
-### spike-2: Idle-probe mechanism — API call vs passive-check
-- **Assumption**: "Proactively probing a dormant SDK connection requires an actual lightweight API call to detect silent death."
-- **Method**: code-read + doc-read
-- **Finding**: No built-in SDK heartbeat/ping exists. The SDK's persistent connection is managed inside the `ClaudeSDKClient` context manager. For a dormant session (status = `dormant` / `paused`), the subprocess may be torn down entirely (no persistent connection held) OR held open across turns. The 48h silent-death is a concern only when a connection IS held open. The safer, cheaper approach is to **tear down the SDK connection entirely when the session enters `dormant` state** — and rebuild on resume. This sidesteps the 48h problem without per-session probe overhead.
+### spike-2: Where does the 48h silent-death risk actually apply? (Execution path audit)
+- **Assumption**: "Dormant sessions hold live SDK connections that die silently after 48h."
+- **Method**: code-read
+- **Finding**: **The premise is path-specific.** Two distinct execution paths exist:
+  - **SDK path** (`ClaudeSDKClient` async context): populates `_active_clients: dict[str, ClaudeSDKClient]` at `agent/sdk_client.py:58`, entered at line 1233, popped at line 1420. This path holds a persistent connection across turns. Used for interactive chat sessions.
+  - **Harness path** (`_run_harness_subprocess` at `agent/sdk_client.py:1786`): spawns `claude -p stream-json` as a short-lived subprocess **per turn**, parses the result event, exits. Used by `agent/session_executor.py:1311` and `agent/session_completion.py:450` — this is the PM/Dev/Teammate session path.
+  - Call sites: `get_response_via_harness` is imported in `agent/__init__.py:36`, `agent/session_executor.py:1247`, `agent/session_completion.py:448`. `get_response_via_sdk` is used for chat routes.
+  - The 48h silent-death problem **only applies to the SDK path** (persistent `ClaudeSDKClient`). Harness-path sessions tear their subprocess down after every turn; there is no long-lived connection to go stale.
 - **Confidence**: high
-- **Impact on plan**: Replace "proactive probe" with "teardown-on-dormant + fresh rebuild on resume." The watchdog tracks `last_activity_ts` on `AgentSession` and, if a session has been in `dormant` / `paused` for >24h and a live SDK connection still exists, it forcibly closes the connection. Resume creates a fresh client. This is strictly safer than probing and matches how #1036 treats stale heartbeats.
+- **Impact on plan**: Idle-teardown targets the SDK path only. The `_active_clients` registry is **worker-process-local**, so **the watchdog process cannot reach it**. Moved idle-teardown from `monitoring/session_watchdog.py` (separate process) into a **worker-internal idle-sweeper task** that runs alongside the session execution loop in the worker process. The watchdog process does not participate. For harness-path sessions, idle-teardown is a no-op (nothing to tear down).
 
 ### spike-3: Watchdog → steering queue wiring cost
 - **Assumption**: "Wiring `session_watchdog.py` detections to `push_steering_message` is a localized change requiring no new abstractions."
@@ -101,30 +105,73 @@ Skipping WebSearch — the problem is purely about wiring already-identified sig
 - **Confidence**: high
 - **Impact on plan**: Dashboard exposure is a small, purely additive change. Does not break the existing API contract.
 
+### spike-5: Does the harness `result` JSON event carry usage + cost?
+- **Assumption**: "The `result` event emitted by `claude -p stream-json` contains `usage` (input/output/cache tokens) and `total_cost_usd`, allowing token accumulation without touching the in-memory `ResultMessage` path."
+- **Method**: code-read of `_run_harness_subprocess` + Claude CLI stream-json format inspection
+- **Finding**: Confirmed. `_run_harness_subprocess` at `agent/sdk_client.py:1855-1862` already consumes the `event_type == "result"` event but extracts only `result` and `session_id`; the event payload from `claude -p` also includes sibling fields `usage: {input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens}`, `total_cost_usd`, `num_turns`, `duration_ms`, and `duration_api_ms` (this is the same schema the SDK `ResultMessage` wraps). The extraction is a ~3-line addition: read the fields off `data` alongside `result_text` and `session_id_from_harness`, then return them from `_run_harness_subprocess` / `get_response_via_harness` for the caller to accumulate.
+- **Confidence**: high
+- **Impact on plan**: Token accumulation must hook **both** paths. SDK path: existing `ResultMessage` handler (unchanged from spike-1). Harness path: extract from `result` event inside `_run_harness_subprocess`; pass through `get_response_via_harness` return shape; call `accumulate_session_tokens` from the harness-path callers (`session_executor.py`, `session_completion.py`). Without this, harness-path token counters would always be 0 — the original design was broken for the production PM/Dev path.
+
+### spike-6: Post-fix schema for `get_response_via_harness` return type
+- **Assumption**: "We can extend `get_response_via_harness` to return `(text, usage_info)` without breaking the ~20 callers listed in Grep."
+- **Method**: code-read of call sites
+- **Finding**: All production call sites treat the return value as a plain `str` (raw = await get_response_via_harness(...)). Changing the signature to return a tuple would break every caller. **Preferred approach**: keep the `str` return, but capture `session_id` on the helper call and accumulate tokens via a **side-effect call** inside `get_response_via_harness` itself — invoked just before return when `session_id` was provided. This matches the existing side-effect pattern for `_store_claude_session_uuid(session_id, session_id_from_harness)` at `sdk_client.py:1778`.
+- **Confidence**: high
+- **Impact on plan**: No call site changes needed for harness-path token tracking. The helper absorbs the accumulation as a side effect keyed on the `session_id` it already receives.
+
 ## Data Flow
 
-### Token tracking
-1. **Entry point**: Claude Agent SDK `ResultMessage` arrives in `agent/sdk_client.py:1216`.
-2. **Capture**: Existing handler at line 1233 reads `msg.total_cost_usd`, `msg.num_turns`. We add reads for `msg.usage.input_tokens`, `msg.usage.output_tokens`, `msg.usage.cache_read_input_tokens`.
-3. **Accumulate**: Call new helper `accumulate_session_tokens(session_id, input_tokens, output_tokens, cache_read_tokens, cost_usd)` which performs a single `AgentSession` update: `total_input_tokens += …`, `total_output_tokens += …`, `total_cache_read_tokens += …`, `total_cost_usd += …`.
-4. **Redis write**: Popoto `save(update_fields=[…])` with the four fields. Fail-quiet on ModelException (same pattern as existing heartbeat writes).
-5. **Read path — dashboard**: `ui/data/sdlc.py` loads `AgentSession`, populates `PipelineProgress.total_input_tokens` etc., `_session_to_json` includes in response. `/dashboard.json` response includes four new fields per session.
-6. **Threshold check**: In the watchdog's per-session loop, if `total_input_tokens + total_output_tokens >= TOKEN_ALERT_THRESHOLD` (default 5_000_000) AND session status is `running` AND no alert has fired in the last 3600s (cooldown), push a steering message `"Token budget exceeded: $N spent this session. Stop and summarize what you've done."`.
+### Token tracking (two paths — both write to the same AgentSession fields)
 
-### Idle teardown
-1. **Trigger**: `session_watchdog._check_session_health` iterates sessions.
-2. **Filter**: Session status in `{dormant, paused}` AND `last_activity_ts` (or `updated_at`) older than `IDLE_TEARDOWN_THRESHOLD` (default 86400s = 24h).
-3. **Action**: Check whether a live SDK connection is held for this session_id in `agent/sdk_client.py` process memory (via `_active_clients` registry — new). If yes, close it. If no (subprocess not held across dormant states), no-op.
-4. **Record**: Set `AgentSession.sdk_connection_torn_down_at = now()` so resumes know to build fresh. The resume path in `sdk_client.py` already builds a fresh client per query, so this is a soft no-op on resume but gives us an observable signal.
+**Path A — SDK path** (`get_response_via_sdk`, interactive/chat sessions):
+1. Claude Agent SDK `ResultMessage` arrives at the handler in `agent/sdk_client.py:1251`.
+2. Existing code at line 1275 already reads `msg.total_cost_usd`. We extend to read `msg.usage.input_tokens`, `msg.usage.output_tokens`, `msg.usage.cache_read_input_tokens` (all safe via `getattr(msg.usage, <name>, 0) or 0` for defensive defaults).
+3. Call new helper `accumulate_session_tokens(session_id, input_tokens, output_tokens, cache_read_tokens, cost_usd)`.
+
+**Path B — Harness path** (`get_response_via_harness`, production PM/Dev/Teammate sessions):
+1. `_run_harness_subprocess` at `agent/sdk_client.py:1855` consumes `event_type == "result"`. Extend the handler to also read `data.get("usage")`, `data.get("total_cost_usd")` off the same JSON object (alongside `result` and `session_id`).
+2. Thread `usage` and `total_cost_usd` back up through `_run_harness_subprocess` return (extend from `(result_text, session_id_from_harness, returncode)` to `(result_text, session_id_from_harness, returncode, usage, cost_usd)`; internal-only, no external caller of this private helper).
+3. Inside `get_response_via_harness`, call `accumulate_session_tokens(session_id, ...)` **as a side effect** after the stale-UUID fallback branches settle — matching the existing `_store_claude_session_uuid` pattern at `sdk_client.py:1778`. Public callers (`session_executor.py`, `session_completion.py`) are unchanged; return signature stays `str`.
+
+**Shared tail (both paths):**
+4. `accumulate_session_tokens` performs a single `AgentSession` update: `total_input_tokens += …`, `total_output_tokens += …`, `total_cache_read_tokens += …`, `total_cost_usd += …`.
+5. **Redis write**: Popoto `save(update_fields=[…])` with the four fields. Fail-quiet on `ModelException` (same pattern as existing heartbeat writes). Gated by `WATCHDOG_TOKEN_TRACKING_ENABLED`.
+6. **Read path — dashboard**: `ui/data/sdlc.py` loads `AgentSession`, populates `PipelineProgress.total_input_tokens` etc., `_session_to_json` includes in response. `/dashboard.json` response includes four new fields per session, always present (default 0) for forward-compat with existing JSON consumers.
+7. **Threshold check**: In the watchdog's per-session loop, if `total_input_tokens + total_output_tokens >= TOKEN_ALERT_THRESHOLD` (default 5_000_000) AND session status is `running` AND no alert has fired in the last 3600s (cooldown), push a steering message. The watchdog only READS token counts here — it never writes them.
+
+### Idle teardown (worker-internal; watchdog process does NOT participate)
+
+The `_active_clients` registry lives in the **worker process** memory at `agent/sdk_client.py:58`. The session watchdog runs as a **separate process** and cannot reach that dict. So idle-teardown runs as a worker-internal task, co-located with the registry.
+
+1. **Trigger**: New `worker/idle_sweeper.py` async task, scheduled every `IDLE_SWEEP_INTERVAL` (default 1800s = 30 min) on the worker event loop.
+2. **Filter**: For each entry in `list(_active_clients.items())` (snapshot, not live iteration), look up the matching `AgentSession`. Teardown target: `status in {dormant, paused, paused_circuit}` AND `updated_at` (or `last_activity_ts` if populated by this plan) older than `IDLE_TEARDOWN_THRESHOLD` (default 86400s = 24h). Do NOT tear down `running`, `pending`, or any active status.
+3. **Action**: Call `client.close()` (idempotent; wrapped in try/except). Pop the session_id from `_active_clients`.
+4. **Record**: Set `AgentSession.sdk_connection_torn_down_at = now()`.
+5. **Resume semantics**: On next query, `get_response_via_sdk` enters its `async with ClaudeSDKClient(...)` block, repopulates `_active_clients`, and re-establishes context from `claude_session_uuid` via the existing `--resume` plumbing. The teardown is **safe on resume** — the SDK rebuilds state from the persisted UUID.
+6. **Harness-path sessions**: No-op. Nothing is in `_active_clients` for harness sessions because the subprocess exits after every turn.
+7. Gated by `WATCHDOG_IDLE_TEARDOWN_ENABLED` (default `true`).
 
 ### Loop-break steering
 1. **Trigger**: `detect_repetition` returns `(True, tool_name, count)` OR `detect_error_cascade` returns `(True, error_count)`.
-2. **Cooldown check**: Redis `GET watchdog:steer_cooldown:{session_id}`. If present, skip. If absent, `SETEX watchdog:steer_cooldown:{session_id} 900 "1"`.
+2. **Cooldown check (atomic)**: Redis `SET watchdog:steer_cooldown:<reason>:<session_id> "1" NX EX 900` — the `NX` (set-if-not-exists) + `EX` (TTL) combine into **one** atomic command. If the SET returns truthy, the cooldown slot was open and we may proceed. If it returns falsy (i.e., key already present), a prior tick holds the cooldown; skip. This eliminates the read-then-write race entirely. Keys are keyed by **reason** so `repetition` and `error_cascade` have independent cooldowns and do not squelch each other. The `<reason>` segment is one of `repetition`, `error_cascade`, `token_alert`.
 3. **Steering push**: Compose a targeted message:
    - Repetition: `"Stop and re-check the task — you appear to be repeating the same tool call ({tool_name}) {count} times. Summarize what you've tried, then try a different approach."`
    - Error cascade: `"Stop — you've hit {error_count} errors in the last 20 operations. Summarize the failure pattern and pause for human input rather than continuing blind."`
-4. **Delivery**: `push_steering_message(session_id, text, sender="watchdog")`. The existing PostToolUse hook drains the queue on the next tool call.
-5. **Logging**: `logger.warning("[watchdog] Loop-break steer injected for %s: %s", session_id, reason)` — visible in `logs/worker.log`.
+   - Token alert: `"Token budget exceeded: ${cost_usd:.2f} spent this session. Stop and summarize what you've done."`
+4. **Delivery**: `push_steering_message(session_id, text, sender="watchdog")`. The **`sender="watchdog"` tag is mandatory** — it distinguishes these messages from human steers so the PM session, the dashboard, and `valor-session status` can render them distinctly. `agent/steering.py::push_steering_message` already accepts a `sender` kwarg and stores it on the queued message envelope (verified by code-read).
+5. **Delivery timing**: The existing PostToolUse hook at `.claude/hooks/hook_utils/memory_bridge.py` (and the SDK PM's turn-boundary drain in `agent/session_executor.py`) drains `queued_steering_messages` before the next tool call. The loop-break steer therefore arrives **at the next tool-call boundary** — it does NOT interrupt mid-tool execution, but it DOES arrive before the next repetition of the stuck tool. Operators should expect a one-tool-call delay between detection and correction; this is acceptable because stuck loops emit many tool calls per minute.
+6. **Logging**: `logger.warning("[watchdog] Loop-break steer injected for %s: %s", session_id, reason)` — visible in `logs/worker.log`.
+
+### Pricing constants (explicit — no implicit scaling)
+
+Token accumulation sums raw counts only. `total_cost_usd` is taken verbatim from the SDK/CLI (`msg.total_cost_usd` or the harness `result` event's `total_cost_usd` field), **not** recomputed from token counts. This avoids model-pricing drift: if Anthropic changes Sonnet rates, Claude Code's own `total_cost_usd` stays authoritative and our accumulator stays correct without a code change.
+
+**Rationale for NOT maintaining a price table in this repo:**
+- The CLI and SDK emit `total_cost_usd` per turn — single source of truth.
+- Hard-coded per-model rates drift silently when Anthropic updates pricing.
+- The watchdog threshold alert uses the accumulated `total_cost_usd` directly (or falls back to the raw token sum when cost is missing, e.g., `total_cost_usd is None`).
+
+If a future diagnostic panel wants per-model breakdowns, it will use `msg.model_usage` (already in the SDK `ResultMessage`) rather than a local price table. Out of scope for this plan (No-Gos).
 
 ## Why Previous Fixes Failed
 
@@ -138,14 +185,22 @@ Skipping WebSearch — the problem is purely about wiring already-identified sig
 ## Architectural Impact
 
 - **New dependencies**: None. All building blocks exist (Popoto, Redis, SDK, steering queue).
+- **Process topology**:
+  - **Worker process** (`python -m worker`) owns: `_active_clients` registry, token accumulation (both SDK + harness paths), idle-sweeper task.
+  - **Session-watchdog process** (`monitoring/session_watchdog.py`) owns: `detect_repetition`, `detect_error_cascade`, loop-break steering push, token-threshold alert push. Reads `AgentSession.total_input_tokens` etc. to decide; never writes them.
+  - The two processes communicate **only through Redis** — via `AgentSession` fields and the steering queue. No in-process dicts shared across process boundaries.
 - **Interface changes**:
   - `AgentSession` gains 5 fields: `total_input_tokens`, `total_output_tokens`, `total_cache_read_tokens`, `total_cost_usd`, `sdk_connection_torn_down_at`.
-  - `agent/sdk_client.py` gains `accumulate_session_tokens(...)` helper (private).
-  - `monitoring/session_watchdog.py` gains `_inject_loop_break_steer(session_id, reason)` helper (private).
+  - `agent/sdk_client.py` gains `accumulate_session_tokens(...)` helper (public-to-module, called from SDK-path `ResultMessage` handler and from `get_response_via_harness`).
+  - `agent/sdk_client.py::_run_harness_subprocess` signature grows: return tuple adds `usage` + `cost_usd` (private helper, internal to the file, safe to change).
+  - `worker/idle_sweeper.py` — new module hosting `run_idle_sweep()` async task, started by `worker/__main__.py`'s startup routine.
+  - `monitoring/session_watchdog.py` gains `_inject_watchdog_steer(session_id, reason, message)` helper (private). A single helper serves repetition, error-cascade, and token-alert triggers, keyed by `reason` in the cooldown.
   - `_session_to_json` (dashboard) gains 4 token fields in output.
-- **Coupling**: Increases by one arrow — `monitoring/session_watchdog.py` now calls into `agent/steering.py`. Not a layering violation: `monitoring/` already imports `models/`, and `agent/steering.py` is a Redis-only module. No circular-import risk.
-- **Data ownership**: Token counts are owned by `AgentSession` (same owner as existing heartbeat timestamps). Dashboard reads; worker/sdk_client writes. Single-writer per session; no contention.
-- **Reversibility**: High. Token fields are additive and default to 0. Loop-break steering can be gated behind `WATCHDOG_AUTO_STEER_ENABLED` env var (default on, flipping off disables without rollback). Idle teardown only affects dormant sessions; disabling it loses no data.
+- **Coupling**:
+  - `monitoring/session_watchdog.py` → `agent/steering.py`: new arrow. Not a layering violation — `monitoring/` already imports `models/`, and `agent/steering.py` is a Redis-only module. No circular-import risk.
+  - `worker/idle_sweeper.py` → `agent/sdk_client._active_clients`: new arrow, same process — safe.
+- **Data ownership**: Token counts are owned by `AgentSession`. Writers: SDK-path `ResultMessage` handler + harness-path extraction (both in the worker process; effectively one writer per session at a time because sessions are serialized through the worker queue). Readers: watchdog (threshold alert) and dashboard. No cross-writer contention.
+- **Reversibility**: High. Token fields are additive and default to 0. Loop-break steering gated behind `WATCHDOG_AUTO_STEER_ENABLED` (default on). Token tracking gated by `WATCHDOG_TOKEN_TRACKING_ENABLED` (default on). Idle teardown gated by `WATCHDOG_IDLE_TEARDOWN_ENABLED` (default on). Flipping any flag off disables that feature without rollback.
 
 ## Appetite
 
@@ -173,60 +228,116 @@ Run all checks: `python scripts/check_prerequisites.py docs/plans/watchdog-harde
 
 ### Key Elements
 
-- **Token accumulator**: On every `ResultMessage` in `sdk_client.py`, call `accumulate_session_tokens(session_id, …)` which persists input/output/cache/cost onto `AgentSession` via `save(update_fields=[…])`.
-- **Dashboard surfacing**: Extend `PipelineProgress` + `_session_to_json` to include token fields so operators can see per-session spend on `/dashboard.json`.
-- **Token-threshold alert**: Watchdog tick checks cumulative tokens against `TOKEN_ALERT_THRESHOLD` (default 5M). If exceeded AND session is `running` AND no alert fired in last hour, steer the session with a budget warning.
-- **Loop-break steering**: In `_check_session_health`, when `detect_repetition` or `detect_error_cascade` fires, call `_inject_loop_break_steer(session_id, reason)` which (a) checks Redis cooldown, (b) composes a targeted message, (c) `push_steering_message(…)`, (d) SETEX the cooldown.
-- **Idle teardown**: New `_teardown_dormant_sdk_connections` pass in the watchdog. For sessions in `dormant` / `paused` status with activity older than 24h AND a tracked live client in `sdk_client._active_clients`, close the client. Record `sdk_connection_torn_down_at` on the session.
+- **Token accumulator (both paths)**: Single helper `accumulate_session_tokens(session_id, input_tokens, output_tokens, cache_read_tokens, cost_usd)` in `sdk_client.py`. Called from (a) the existing SDK `ResultMessage` handler and (b) `get_response_via_harness` after the harness subprocess returns. Persists to `AgentSession` via `save(update_fields=[…])`. Fail-quiet on `ModelException`.
+- **Dashboard surfacing**: Extend `PipelineProgress` + `_session_to_json` to include four token fields. Defaults to 0 (never None) for forward-compat.
+- **Token-threshold alert (watchdog)**: Watchdog tick reads `AgentSession.total_input_tokens + total_output_tokens` (Redis read, no join). If sum >= `TOKEN_ALERT_THRESHOLD` AND status == `running` AND cooldown open, steer via `_inject_watchdog_steer`. Watchdog never writes token fields — read-only.
+- **Loop-break steering (watchdog)**: Single helper `_inject_watchdog_steer(session_id, reason, message)` used for all three trigger reasons (`repetition`, `error_cascade`, `token_alert`). Uses atomic `SET NX EX` for cooldown (see Technical Approach for exact ordering). Calls `push_steering_message(session_id, message, sender="watchdog")`.
+- **Idle teardown (worker-internal)**: New `worker/idle_sweeper.py` module with an async task started from `worker/__main__.py`. Runs every `IDLE_SWEEP_INTERVAL` (default 1800s). Reads `list(_active_clients.items())` snapshot, filters to dormant+24h, calls `client.close()`, records `sdk_connection_torn_down_at`. Watchdog process does NOT touch `_active_clients`.
 
 ### Flow
 
-Session turn completes → SDK emits `ResultMessage` → sdk_client captures tokens + cost → `accumulate_session_tokens` writes to AgentSession → dashboard serializer picks up on next render.
+**SDK path session completes a turn** → SDK emits `ResultMessage` → worker captures `msg.usage.*` + `msg.total_cost_usd` → calls `accumulate_session_tokens(...)` → AgentSession updated → dashboard reflects on next render.
 
-Session enters stuck loop → watchdog tick (every 300s) calls `detect_repetition` → returns True → `_inject_loop_break_steer` checks cooldown → absent → push steering msg + SETEX cooldown 900s → PostToolUse hook drains queue on next tool call → session receives correction → the loop is broken.
+**Harness path session completes a turn** → `claude -p stream-json` subprocess emits `result` event → `_run_harness_subprocess` extracts `usage` + `total_cost_usd` from the event JSON → returns them → `get_response_via_harness` calls `accumulate_session_tokens(...)` before returning the result string → AgentSession updated.
 
-Session goes dormant → watchdog tick → `_teardown_dormant_sdk_connections` finds stale client → closes it → session record gets `sdk_connection_torn_down_at` → operator resumes → `sdk_client.query` builds fresh client → no 48h silent death.
+**Session enters stuck loop** → watchdog tick (every 300s) calls `detect_repetition` → returns True → `_inject_watchdog_steer(sid, "repetition", msg)` → `SET watchdog:steer_cooldown:repetition:<sid> "1" NX EX 900` → if OK (cooldown slot open), `push_steering_message(sid, msg, sender="watchdog")` → PostToolUse hook drains queue before next tool call → session receives correction → loop breaks.
+
+**Session token spend crosses 5M** → watchdog tick reads `total_input_tokens + total_output_tokens >= 5_000_000` on a `running` session → `_inject_watchdog_steer(sid, "token_alert", msg)` → `SET watchdog:steer_cooldown:token_alert:<sid> ... NX EX 3600` → push steer → operator sees the nudge in session history.
+
+**Session goes dormant with an open SDK client** → worker idle-sweeper tick (every 1800s) → iterates `list(_active_clients.items())` snapshot → finds entry whose `AgentSession.status in {dormant, paused, paused_circuit}` AND `updated_at > 24h` → `client.close()` (idempotent) → pop from registry → `AgentSession.sdk_connection_torn_down_at = now()` → on resume, fresh SDK client is built via existing `--resume` + stored UUID → no 48h silent death.
 
 ### Technical Approach
 
-- Keep all three subsystems in their existing files: `agent/sdk_client.py` for token capture, `monitoring/session_watchdog.py` for loop-break + idle-teardown, `ui/app.py` + `ui/data/sdlc.py` for dashboard. No new modules unless LOC crosses 200 (then split the steering helper into `monitoring/loop_break.py`).
-- Token accumulation is synchronous, fail-quiet. On `ModelException` (Popoto duplicate-key during concurrent save), log at WARNING and continue. Do NOT block the SDK query path on Redis latency — wrap the save in a try/except.
-- Cooldown keys use Redis `SETEX` with an integer TTL. Key pattern: `watchdog:steer_cooldown:{session_id}` (for loop-break) and `watchdog:token_alert_cooldown:{session_id}` (for token threshold). Separate cooldowns so they don't squelch each other.
-- Idle teardown only affects sessions with `status in {dormant, paused, paused_circuit}`. Never tear down `running` or `pending`. The `_active_clients` registry is a new `dict[str, ClaudeSDKClient]` at module scope in `sdk_client.py`; populated in the `async with` context-enter, removed in context-exit.
-- Token threshold defaults: `TOKEN_ALERT_THRESHOLD = 5_000_000` (5M combined input+output), `TOKEN_ALERT_COOLDOWN = 3600` (one alert per hour per session). Both env-overridable (`WATCHDOG_TOKEN_ALERT_THRESHOLD`, `WATCHDOG_TOKEN_ALERT_COOLDOWN`).
-- Idle teardown threshold: `IDLE_TEARDOWN_THRESHOLD = 86400` (24h). Env-overridable (`WATCHDOG_IDLE_TEARDOWN_THRESHOLD_SECONDS`). Chosen to sit well inside the 48h silent-death window with a full safety margin.
-- All three features are individually gated by env vars so they can be disabled without a rollback: `WATCHDOG_AUTO_STEER_ENABLED` (default `true`), `WATCHDOG_TOKEN_TRACKING_ENABLED` (default `true`), `WATCHDOG_IDLE_TEARDOWN_ENABLED` (default `true`).
+**Module layout (no new files outside those listed):**
+- `agent/sdk_client.py` — add `accumulate_session_tokens`; extend `_run_harness_subprocess` return tuple; add accumulate call site inside `get_response_via_harness`; extend the existing `ResultMessage` handler. Keep `_active_clients` registry — it already exists.
+- `worker/idle_sweeper.py` — **new module** hosting `run_idle_sweep()` async coroutine + constants.
+- `worker/__main__.py` — wire `run_idle_sweep()` as a background task alongside the existing session loop.
+- `monitoring/session_watchdog.py` — add `_inject_watchdog_steer` + call sites at the detection branches + token-threshold check in the per-session loop.
+- `ui/data/sdlc.py` + `ui/app.py` — add token fields to `PipelineProgress` + `_session_to_json`.
+- `models/agent_session.py` — add five new fields.
+
+**Token accumulation safety:**
+- Synchronous with `save(update_fields=[...])` — Popoto HMSET is sub-ms; no hot-path latency concern.
+- Wrap in `try/except ModelException` and `try/except Exception` at the outermost layer; log at WARNING with session_id; never raise into the SDK query path or harness return path.
+- If `WATCHDOG_TOKEN_TRACKING_ENABLED=false`, early-return from the helper with no side effects.
+- Guard against `msg.usage is None` (some SDK versions or error paths omit it): `getattr(msg.usage, "input_tokens", 0) or 0`.
+
+**Cooldown — atomic ordering (explicit):**
+```python
+# Correct: SET key value NX EX ttl — atomic set-if-not-exists with TTL
+# Popoto/redis-py:
+cooldown_slot_open = POPOTO_REDIS_DB.set(
+    f"watchdog:steer_cooldown:{reason}:{session_id}",
+    "1",
+    nx=True,
+    ex=cooldown_ttl_seconds,
+)
+# cooldown_slot_open is truthy when the key was absent and is now set;
+# falsy when the key already existed (cooldown still active).
+if not cooldown_slot_open:
+    return  # cooldown in effect
+```
+- **Never** sequence a separate GET then SET — that's racy under concurrent watchdog ticks or watchdog+worker co-triggered alerts. The `nx=True, ex=TTL` kwargs order is Redis-native single-command `SET` with both flags.
+- Cooldown key includes `reason`: `watchdog:steer_cooldown:repetition:<sid>`, `watchdog:steer_cooldown:error_cascade:<sid>`, `watchdog:steer_cooldown:token_alert:<sid>`. Three independent cooldowns; a steer of one reason does not suppress another reason.
+
+**Idle teardown — status filter (explicit):**
+- Target statuses: **`dormant`, `paused`, `paused_circuit`** (all three included explicitly — `paused` and `paused_circuit` are semantic cousins of `dormant` under the 13-state reference at `docs/features/session-lifecycle.md`).
+- Excluded: `running`, `pending`, `waiting_for_children`, `superseded`, and terminal states (`completed`, `killed`, `abandoned`, `failed`).
+- The filter is enforced in `worker/idle_sweeper.py::run_idle_sweep` before any `client.close()` call. The `_active_clients` dict is iterated as a snapshot (`list(...)`) to tolerate concurrent modification from active queries.
+
+**Steering attribution — sender visibility:**
+- All watchdog-originated steers pass `sender="watchdog"`. Verified present in `agent/steering.py::push_steering_message` signature (code-read); the sender is persisted on the queued message envelope.
+- Downstream visibility:
+  - `valor-session status --id <sid>` already renders per-message sender (verified in `tools/valor_session.py`).
+  - Dashboard JSON includes sender on queued-steering entries (already present).
+  - The PM session's steering-drain loop logs `[steering] received from sender=<s>` so the PM can distinguish `watchdog` from `human` and respond accordingly (already present in `agent/session_executor.py`).
+
+**Thresholds + env-var gates:**
+- `TOKEN_ALERT_THRESHOLD = int(os.getenv("WATCHDOG_TOKEN_ALERT_THRESHOLD", "5000000"))` — 5M combined input+output tokens.
+- `TOKEN_ALERT_COOLDOWN = int(os.getenv("WATCHDOG_TOKEN_ALERT_COOLDOWN", "3600"))` — one alert per hour per session.
+- `STEER_COOLDOWN = int(os.getenv("WATCHDOG_STEER_COOLDOWN", "900"))` — 15 min between repeat loop-break steers.
+- `IDLE_TEARDOWN_THRESHOLD = int(os.getenv("WATCHDOG_IDLE_TEARDOWN_THRESHOLD_SECONDS", "86400"))` — 24h dormant + has live client → tear down.
+- `IDLE_SWEEP_INTERVAL = int(os.getenv("WATCHDOG_IDLE_SWEEP_INTERVAL", "1800"))` — 30 min between sweeps.
+- Feature gates: `WATCHDOG_AUTO_STEER_ENABLED`, `WATCHDOG_TOKEN_TRACKING_ENABLED`, `WATCHDOG_IDLE_TEARDOWN_ENABLED` — all default `true`. Reading each returns `false` only if env var is exactly `"0"`, `"false"`, or `"no"` (case-insensitive).
 
 ## Failure Path Test Strategy
 
 ### Exception Handling Coverage
-- [ ] `accumulate_session_tokens` wraps save in try/except ModelException — test: simulate concurrent save conflict, assert logger.warning fires AND SDK query path continues without raising.
-- [ ] `_inject_loop_break_steer` wraps `push_steering_message` in try/except — test: simulate Redis unavailable, assert watchdog tick continues and logs WARNING, does not crash the watchdog loop.
-- [ ] `_teardown_dormant_sdk_connections` wraps client.close() in try/except — test: simulate client already closed, assert no exception propagates.
+- [ ] `accumulate_session_tokens` wraps save in try/except ModelException (inner) + try/except Exception (outer) — test: simulate concurrent save conflict, assert logger.warning fires AND SDK / harness return path continues without raising.
+- [ ] `_inject_watchdog_steer` wraps `push_steering_message` in try/except — test: simulate Redis unavailable, assert watchdog tick continues and logs WARNING, does not crash the watchdog loop.
+- [ ] `worker/idle_sweeper._sweep_once` wraps `client.close()` in try/except — test: simulate client already closed, assert no exception propagates and the next entry still processes.
+- [ ] `_run_harness_subprocess` tolerates a `result` event with missing/null `usage` or `total_cost_usd` — the usage extraction falls back to `None` safely; downstream `accumulate_session_tokens(... None ...)` no-ops gracefully.
 - [ ] No new `except Exception: pass` — every handler must log at WARNING or ERROR with session_id.
 
 ### Empty/Invalid Input Handling
 - [ ] `accumulate_session_tokens` called with `usage=None` (older SDK version or error message) → no-op, no crash.
+- [ ] `accumulate_session_tokens` called with missing sub-fields (e.g., `usage={"input_tokens": 100}` only) → treats the missing fields as 0, no KeyError.
 - [ ] `detect_repetition` returns `(True, None, 5)` edge case — skip steer (nothing to report on).
 - [ ] Dashboard serializer when `total_input_tokens` is None (session predates migration) → return 0, not None.
+- [ ] Worker idle sweeper on empty `_active_clients` → one `asyncio.sleep(IDLE_SWEEP_INTERVAL)`, no other side effects.
 
 ### Error State Rendering
 - [ ] Loop-break steering message is visible in session steering history (`valor-session status --id ...`) — test asserts the message appears with `sender="watchdog"`.
+- [ ] Token-alert steering message likewise tagged `sender="watchdog"` and carries `reason="token_alert"` in the cooldown trace.
 - [ ] Dashboard `/dashboard.json` returns token fields for every session, even brand-new ones (values = 0), never omitted.
 
 ## Test Impact
 
-- [ ] `tests/unit/test_session_watchdog.py` — UPDATE: existing tests assert detections fire; add new assertions that `push_steering_message` is called exactly once per detection (mock the steering module) and twice if cooldown expires.
-- [ ] `tests/unit/test_session_watchdog.py::test_repetition_detection_passive` — REPLACE: rename to `test_repetition_detection_triggers_steer` and update assertions (old test just checked the boolean return; new test checks side effect).
+- [ ] `tests/unit/test_session_watchdog.py` — UPDATE: existing tests assert detections fire but do not act; add new assertions that `_inject_watchdog_steer` is called exactly once per detection (mock the helper or the Redis client) and a second call within the cooldown window is suppressed.
+- [ ] `tests/unit/test_session_watchdog.py::test_repetition_detection_passive` — REPLACE: rename to `test_repetition_detection_triggers_steer` and update assertions (old test just checked the boolean return; new test checks the steering side effect).
 - [ ] `tests/unit/test_transcript_liveness.py` — no change; orthogonal.
 - [ ] `tests/unit/test_stall_detection.py` — no change; idle teardown is a different code path, handled in new tests.
 - [ ] `tests/unit/test_recovery_respawn_safety.py` — no change; recovery is unrelated.
 - [ ] `tests/unit/test_bridge_watchdog.py` — no change; bridge watchdog does not own these detections.
+- [ ] `tests/unit/test_harness_streaming.py` — UPDATE: existing tests validate `_run_harness_subprocess` parsing of `result` events; add new assertions that `usage` and `total_cost_usd` are captured off the `result` event JSON and threaded through the return tuple.
+- [ ] `tests/unit/test_deliver_pipeline_completion.py` — no change expected (mocks `get_response_via_harness` at the return value; signature stays `str`); verify no breakage after refactor.
 
-**New tests to add:**
-- `tests/unit/test_watchdog_loop_break_steer.py` — repetition triggers one steer, cooldown suppresses duplicates, cooldown expiry re-enables, error cascade triggers one steer, env var disable suppresses.
-- `tests/unit/test_session_token_accumulator.py` — ResultMessage with usage accumulates; None usage is no-op; concurrent save logs warning but doesn't raise; dashboard field populated.
-- `tests/unit/test_watchdog_idle_teardown.py` — dormant+24h tears down; dormant+12h does not; running+48h does not; `sdk_connection_torn_down_at` recorded; missing client no-ops cleanly.
+**New tests to add (all file paths to be created):**
+- `tests/unit/test_session_token_accumulator.py` — `accumulate_session_tokens` with normal values writes to AgentSession; None/missing fields default to 0; concurrent save logs warning but doesn't raise; `WATCHDOG_TOKEN_TRACKING_ENABLED=false` is a no-op; dashboard field populated end-to-end.
+- `tests/unit/test_harness_token_capture.py` — `_run_harness_subprocess` extracts `usage` + `total_cost_usd` off a `result` event; `get_response_via_harness` calls `accumulate_session_tokens` as a side effect with the captured values; caller's return signature remains `str`.
+- `tests/unit/test_watchdog_loop_break_steer.py` — repetition triggers one steer via `_inject_watchdog_steer`; atomic `SET NX EX` cooldown suppresses duplicates within 900s; cooldown expiry re-enables; error cascade uses independent cooldown key; `sender="watchdog"` visible in the pushed message envelope; `WATCHDOG_AUTO_STEER_ENABLED=false` suppresses.
+- `tests/unit/test_watchdog_token_alert.py` — a session with `total_input_tokens + total_output_tokens >= TOKEN_ALERT_THRESHOLD` and status=running triggers one steer with `reason="token_alert"`; cooldown of 3600s holds; same session below threshold does not trigger; watchdog reads tokens, never writes.
+- `tests/unit/test_worker_idle_sweeper.py` — `run_idle_sweep` one-iteration test: entry in `_active_clients` with AgentSession status=`dormant` AND `updated_at > 24h ago` is torn down (client.close called, registry entry popped, `sdk_connection_torn_down_at` set); entry with status=`running` is skipped; entry with status=`dormant` but `updated_at < 24h` is skipped; entry for `paused_circuit` is torn down at 24h; missing/None client does not raise; `WATCHDOG_IDLE_TEARDOWN_ENABLED=false` is a no-op.
 
 ## Rabbit Holes
 
@@ -246,9 +357,9 @@ Session goes dormant → watchdog tick → `_teardown_dormant_sdk_connections` f
 **Impact:** SDK query latency grows by however long the Popoto `save(update_fields=...)` takes per turn.
 **Mitigation:** `save(update_fields=[four_fields])` is a single Redis HMSET — sub-millisecond. Measured cost: negligible. If profiling shows otherwise, move to a fire-and-forget background task via `asyncio.create_task`.
 
-### Risk 3: Idle teardown closes a connection the worker was about to use
-**Impact:** A dormant session transitioning to running could race: watchdog tears down the client while the worker is just starting a new query on it.
-**Mitigation:** Gate teardown on `status in {dormant, paused, paused_circuit}` AND `last_activity_ts > 24h old`. The worker transitions `dormant → running` BEFORE querying, so a teardown targeting `dormant` will never race with an active query. Plus the teardown is idempotent — if the worker has already rebuilt, the registry no longer points at the old client.
+### Risk 3: Idle sweeper closes a connection the worker was about to use
+**Impact:** A dormant session transitioning to running could race: the idle sweeper tears down the client while the worker is just starting a new query on it.
+**Mitigation:** The idle sweeper runs **in the same process** as the query path (see spike-2). Status filter is `{dormant, paused, paused_circuit}` AND `updated_at > 24h old` — the worker transitions `dormant → running` BEFORE querying, so a sweep filtered on `dormant` will not target an active query. `_active_clients.pop(..., None)` is safe on missing keys; `await client.close()` is idempotent, wrapped in try/except. Worst case: sweeper loses a race and closes a just-reactivated client → the query fails once → standard retry / fresh-client rebuild proceeds. No data loss.
 
 ### Risk 4: Token threshold fires on legitimate long-running sessions
 **Impact:** A genuinely large refactor might hit 5M tokens legitimately; the steer would interrupt productive work.
@@ -274,12 +385,12 @@ Session goes dormant → watchdog tick → `_teardown_dormant_sdk_connections` f
 **State prerequisite:** None.
 **Mitigation:** Use Redis `SET ... NX EX 900` (atomic set-if-not-exists with TTL). If the SET returns False, cooldown is held; skip. This makes the check-and-set atomic in Redis itself, eliminating the race.
 
-### Race 3: SDK client teardown vs. resume
-**Location:** `agent/sdk_client.py::_active_clients` registry + `monitoring/session_watchdog.py::_teardown_dormant_sdk_connections`.
-**Trigger:** Watchdog iterates `_active_clients` while the worker is adding/removing entries.
+### Race 3: SDK client teardown vs. resume (same-process)
+**Location:** `agent/sdk_client.py::_active_clients` registry + `worker/idle_sweeper.py::_sweep_once`.
+**Trigger:** Sweeper iterates `_active_clients` while an active query is registering/removing an entry.
 **Data prerequisite:** Registry dict.
 **State prerequisite:** Client context enter/exit is mid-flight.
-**Mitigation:** Protect `_active_clients` with a `threading.Lock` (or asyncio.Lock if accessed from async code). Iterate a snapshot (`list(_active_clients.items())`), not the live dict. Closing a client that was just removed is a no-op (close() is idempotent via try/except).
+**Mitigation:** Sweeper runs in the SAME process as registry writers — this is a single-process asyncio concurrency concern, not a cross-process race. Iterate a snapshot (`list(_active_clients.items())`), not the live dict. `dict.pop(key, None)` is safe on concurrent removal. `await client.close()` is idempotent. No lock required; Python's GIL + asyncio's single-threaded event loop make the snapshot-based iteration race-safe for this use. If the sweep targets an entry whose `AgentSession.status` has just flipped to `running` between the filter read and the close, the close may interrupt an in-flight query — treated as a non-fatal fail-and-retry (see Risk 3).
 
 ## No-Gos (Out of Scope)
 
@@ -295,9 +406,9 @@ Session goes dormant → watchdog tick → `_teardown_dormant_sdk_connections` f
 
 No update-script changes required. This is a bridge/worker-internal change:
 - New `AgentSession` fields auto-materialize on save (Popoto schema is additive).
-- New env vars have safe defaults, so no `.env` template change is required. Document them in `docs/features/session-watchdog.md` for operators who want to tune.
+- New env vars (`WATCHDOG_AUTO_STEER_ENABLED`, `WATCHDOG_TOKEN_TRACKING_ENABLED`, `WATCHDOG_IDLE_TEARDOWN_ENABLED`, `WATCHDOG_TOKEN_ALERT_THRESHOLD`, `WATCHDOG_TOKEN_ALERT_COOLDOWN`, `WATCHDOG_STEER_COOLDOWN`, `WATCHDOG_IDLE_TEARDOWN_THRESHOLD_SECONDS`, `WATCHDOG_IDLE_SWEEP_INTERVAL`) have safe defaults, so no `.env` template change is required. Document them in `docs/features/session-watchdog.md`.
 - No new dependencies; `scripts/remote-update.sh` pull + restart is sufficient.
-- After deploy, `./scripts/valor-service.sh restart` cycles bridge, watchdog, and worker to pick up the new code. This is the standard restart flow per CLAUDE.md (development principle #10).
+- After deploy, `./scripts/valor-service.sh restart` cycles bridge, watchdog, **and worker** to pick up the new code. The **worker restart is specifically required** because the new `worker/idle_sweeper.py` task is started by `worker/__main__.py`; without restarting the worker, the sweeper will not run.
 
 ## Agent Integration
 
@@ -308,32 +419,38 @@ The only user-visible change is that operators (Valor, Tom) see token columns on
 ## Documentation
 
 ### Feature Documentation
-- [ ] Update `docs/features/session-watchdog.md` to cover: loop-break auto-steering, cooldown semantics, env-var tuning.
-- [ ] Update `docs/features/session-watchdog-reliability.md` to cross-reference the new loop-break actuator.
-- [ ] Update `docs/features/session-steering.md` to note that the watchdog is now a steering-message sender (alongside human operators).
-- [ ] Update `docs/features/bridge-self-healing.md` to add a section on "Idle SDK teardown" and reference `IDLE_TEARDOWN_THRESHOLD`.
-- [ ] Add entry to `docs/features/README.md` index if no entry exists, OR note that the three updated docs cover this plan.
+- [ ] Update `docs/features/session-watchdog.md` to cover: loop-break auto-steering, cooldown semantics (atomic `SET NX EX`), env-var tuning. Explicitly list the three reason-keyed cooldowns.
+- [ ] Update `docs/features/session-watchdog-reliability.md` to cross-reference the new loop-break actuator and the two-path token tracking.
+- [ ] Update `docs/features/session-steering.md` to note that the watchdog is now a steering-message sender (`sender="watchdog"`) alongside human operators.
+- [ ] Update `docs/features/bridge-worker-architecture.md` to document the **worker-internal idle sweeper** (`worker/idle_sweeper.py`) — distinct from watchdog-process responsibilities.
+- [ ] Update `docs/features/bridge-self-healing.md` to add a section on "Idle SDK teardown" (runs inside the worker process) and reference `IDLE_TEARDOWN_THRESHOLD` + `IDLE_SWEEP_INTERVAL`.
+- [ ] Add entry to `docs/features/README.md` index if no entry exists, OR note that the four updated docs cover this plan.
 
 ### Inline Documentation
-- [ ] Docstring on new `accumulate_session_tokens` in `sdk_client.py`.
-- [ ] Docstring on new `_inject_loop_break_steer` in `session_watchdog.py`.
-- [ ] Docstring on new `_teardown_dormant_sdk_connections` in `session_watchdog.py`.
-- [ ] Module-level comment block in `session_watchdog.py` updated to list: "When detections fire, they AUTOMATICALLY steer (or teardown). See `_inject_loop_break_steer`." — removing the old "logged only" wording.
+- [ ] Docstring on new `accumulate_session_tokens` in `sdk_client.py`, explicitly noting it is called from **both** the SDK `ResultMessage` handler and `get_response_via_harness` side-effect path.
+- [ ] Docstring on new `_inject_watchdog_steer` in `session_watchdog.py` listing the three reasons and the atomic cooldown contract.
+- [ ] Docstring on new `worker/idle_sweeper.py::run_idle_sweep` and `_sweep_once`, noting process-locality of `_active_clients`.
+- [ ] Module-level comment block in `session_watchdog.py` updated to list: "When detections fire, they AUTOMATICALLY steer. See `_inject_watchdog_steer`." — removing the old "logged only" wording.
+- [ ] Inline comment at `_run_harness_subprocess`'s `result` event branch explaining why usage + cost are extracted and threaded back.
 
 ### External Documentation Site
 - No Sphinx / Read the Docs site in this repo. Skip.
 
 ## Success Criteria
 
-- [ ] `AgentSession.total_input_tokens`, `total_output_tokens`, `total_cache_read_tokens`, `total_cost_usd` exist and update monotonically across a session's turns.
-- [ ] `/dashboard.json` exposes all four token fields per session, including for newly-created sessions (as 0).
-- [ ] `monitoring/session_watchdog.py`: simulated `detect_repetition=True` results in exactly ONE `push_steering_message` call per cooldown window; second detection within 900s is suppressed; detection after 900s+ fires again.
-- [ ] Simulated `detect_error_cascade=True` triggers exactly one steer via its own cooldown key.
-- [ ] A session whose cumulative tokens exceed `TOKEN_ALERT_THRESHOLD` receives exactly one steer per `TOKEN_ALERT_COOLDOWN` window.
-- [ ] A session in `dormant` status with `updated_at` >24h old gets its SDK client torn down; `sdk_connection_torn_down_at` is set; subsequent resume builds a fresh client and succeeds end-to-end.
-- [ ] `WATCHDOG_AUTO_STEER_ENABLED=false` disables loop-break steering without disabling detection (still logged).
-- [ ] `WATCHDOG_TOKEN_TRACKING_ENABLED=false` skips the accumulate call without crashing.
-- [ ] `WATCHDOG_IDLE_TEARDOWN_ENABLED=false` skips teardown without crashing.
+- [ ] `AgentSession.total_input_tokens`, `total_output_tokens`, `total_cache_read_tokens`, `total_cost_usd` exist and update monotonically across a session's turns, on **both** SDK and harness paths.
+- [ ] A harness-path session (PM or Dev) accumulates non-zero `total_cost_usd` after its first turn completes (verifies B3 fix — previously would stay 0).
+- [ ] `/dashboard.json` exposes all four token fields per session, including for newly-created sessions (as 0; never null / omitted).
+- [ ] `monitoring/session_watchdog.py`: simulated `detect_repetition=True` results in exactly ONE `push_steering_message(sender="watchdog")` call per cooldown window; second detection within 900s is suppressed via atomic `SET NX EX`; detection after 900s+ fires again.
+- [ ] Simulated `detect_error_cascade=True` triggers exactly one steer via its **own** cooldown key (independent from repetition cooldown).
+- [ ] A session whose cumulative tokens exceed `TOKEN_ALERT_THRESHOLD` receives exactly one steer per `TOKEN_ALERT_COOLDOWN` window, with `reason="token_alert"` cooldown key.
+- [ ] A **SDK-path** session in `dormant` / `paused` / `paused_circuit` status with `updated_at` >24h old gets its SDK client torn down by the worker idle sweeper; `sdk_connection_torn_down_at` is set; subsequent resume builds a fresh client and succeeds end-to-end.
+- [ ] A harness-path session is NOT affected by the idle sweeper (no `_active_clients` entry to tear down).
+- [ ] Watchdog process does NOT import or reference `_active_clients` — verified via grep.
+- [ ] `WATCHDOG_AUTO_STEER_ENABLED=false` disables loop-break steering without disabling detection (still logged at WARNING).
+- [ ] `WATCHDOG_TOKEN_TRACKING_ENABLED=false` skips the accumulate call on both paths without crashing.
+- [ ] `WATCHDOG_IDLE_TEARDOWN_ENABLED=false` skips the worker sweep without crashing.
+- [ ] All watchdog-authored steering messages are tagged `sender="watchdog"` and visible as such in `valor-session status --id <sid>`.
 - [ ] Tests pass (`/do-test`)
 - [ ] Documentation updated (`/do-docs`)
 - [ ] All three features individually toggleable; default-on in production.
@@ -352,9 +469,9 @@ The only user-visible change is that operators (Valor, Tom) see token columns on
   - Agent Type: builder
   - Resume: true
 
-- **Builder (idle-teardown)**
+- **Builder (worker idle-sweeper)**
   - Name: `teardown-builder`
-  - Role: Add `_active_clients` registry + `_teardown_dormant_sdk_connections` pass + `sdk_connection_torn_down_at` field.
+  - Role: Create `worker/idle_sweeper.py` module + wire into `worker/__main__.py` + add `sdk_connection_torn_down_at` field. The `_active_clients` registry already exists in `agent/sdk_client.py` — no registry creation needed, just consumption.
   - Agent Type: builder
   - Resume: true
 
@@ -382,90 +499,123 @@ Using core agent types: builder, test-engineer, validator, documentarian. No spe
 
 ## Step by Step Tasks
 
-### 1. Add AgentSession token fields + sdk_client accumulator
+### 1. Add AgentSession token fields + sdk_client accumulator helper
 - **Task ID**: build-token-accumulator
 - **Depends On**: none
-- **Validates**: `tests/unit/test_session_token_accumulator.py` (create), `tests/unit/test_agent_session_fields.py` (update)
-- **Informed By**: spike-1 (confirmed ResultMessage.usage structure)
+- **Validates**: `tests/unit/test_session_token_accumulator.py` (to be created)
+- **Informed By**: spike-1 (ResultMessage.usage structure), spike-5 (harness result event carries usage)
 - **Assigned To**: token-builder
 - **Agent Type**: builder
 - **Parallel**: true
-- Add `total_input_tokens`, `total_output_tokens`, `total_cache_read_tokens`, `total_cost_usd` (all `IntField(default=0)` or `FloatField(default=0.0)`) to `models/agent_session.py`.
-- Add `accumulate_session_tokens(session_id, input_tokens, output_tokens, cache_read_tokens, cost_usd)` function near `record_session_activity` in `sdk_client.py`. Use `save(update_fields=[...])`. Wrap in try/except ModelException with warning-level log.
-- Hook into existing `ResultMessage` handler at `sdk_client.py:1216` — after the existing `total_cost_usd` capture, call `accumulate_session_tokens(...)` with values from `msg.usage`.
-- Gate with `WATCHDOG_TOKEN_TRACKING_ENABLED` env var (default `true`).
+- Add `total_input_tokens`, `total_output_tokens`, `total_cache_read_tokens` as `IntField(default=0)` and `total_cost_usd` as `FloatField(default=0.0)` to `models/agent_session.py`.
+- Add `accumulate_session_tokens(session_id, input_tokens, output_tokens, cache_read_tokens, cost_usd)` function near the existing `record_session_activity` / `_store_claude_session_uuid` helpers in `agent/sdk_client.py`. Use `save(update_fields=[total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cost_usd])`. Wrap in `try/except ModelException` + outer `try/except Exception` with WARNING-level log including `session_id`.
+- Gate with `WATCHDOG_TOKEN_TRACKING_ENABLED` env var (default `true`) — early-return when disabled.
+- Guard against `None`/missing values: `getattr(usage, "input_tokens", 0) or 0`.
 
-### 2. Expose token fields on dashboard
+### 2. Wire accumulator into SDK path ResultMessage handler
+- **Task ID**: build-token-sdk-path
+- **Depends On**: build-token-accumulator
+- **Validates**: `tests/unit/test_session_token_accumulator.py` (SDK path cases)
+- **Assigned To**: token-builder
+- **Agent Type**: builder
+- **Parallel**: false
+- Locate the existing `ResultMessage` handler in `agent/sdk_client.py` (near lines 1251–1276 — the block that already captures `msg.total_cost_usd`). Extend the handler to also read `msg.usage.input_tokens`, `msg.usage.output_tokens`, `msg.usage.cache_read_input_tokens`, with safe-default fallback via `getattr`.
+- Immediately after the existing `total_cost_usd` capture, call `accumulate_session_tokens(session_id, ...)` with the captured values.
+- No signature changes to any public function; accumulator runs as a side effect.
+
+### 3. Wire accumulator into harness path (addresses critique B3)
+- **Task ID**: build-token-harness-path
+- **Depends On**: build-token-accumulator
+- **Validates**: `tests/unit/test_harness_token_capture.py` (to be created), `tests/unit/test_harness_streaming.py` (update)
+- **Informed By**: spike-5 (harness result event carries usage), spike-6 (side-effect pattern matches existing `_store_claude_session_uuid`)
+- **Assigned To**: token-builder
+- **Agent Type**: builder
+- **Parallel**: false
+- Extend `_run_harness_subprocess` in `agent/sdk_client.py` (starting around line 1786). Inside the `event_type == "result"` branch (around line 1857), extract additional fields: `usage = data.get("usage")` and `cost_usd = data.get("total_cost_usd")`.
+- Change the return tuple of `_run_harness_subprocess` from `(result_text, session_id_from_harness, returncode)` to `(result_text, session_id_from_harness, returncode, usage, cost_usd)`. Update all three internal callers inside `get_response_via_harness` (image-dimension fallback, stale-UUID fallback, and the primary call).
+- In `get_response_via_harness`, just before returning `result_text`, call `accumulate_session_tokens(session_id, usage.get("input_tokens"), usage.get("output_tokens"), usage.get("cache_read_input_tokens"), cost_usd)` **as a side effect** — mirroring the existing `_store_claude_session_uuid(session_id, session_id_from_harness)` call at line 1778. Only fire when `session_id` is set.
+- Caller signature of `get_response_via_harness` remains `-> str` — `session_executor.py` and `session_completion.py` are unchanged.
+
+### 4. Expose token fields on dashboard
 - **Task ID**: build-dashboard-tokens
 - **Depends On**: build-token-accumulator
 - **Validates**: `tests/unit/test_dashboard_json.py` (create or extend)
 - **Assigned To**: token-builder
 - **Agent Type**: builder
 - **Parallel**: false
-- Add token fields to `PipelineProgress` dataclass in `ui/data/sdlc.py`.
+- Add `total_input_tokens: int = 0`, `total_output_tokens: int = 0`, `total_cache_read_tokens: int = 0`, `total_cost_usd: float = 0.0` to `PipelineProgress` dataclass in `ui/data/sdlc.py`.
 - Populate them from `AgentSession` in the `PipelineProgress` reader.
-- Add to `_session_to_json` in `ui/app.py:244`. Default to 0 (never None) for backward compat with existing consumers.
+- Add to `_session_to_json` in `ui/app.py` around line 244. Always emit defaults (0 / 0.0) — never omit, never None — for forward-compat with existing JSON consumers.
 
-### 3. Wire loop-break steering
+### 5. Wire loop-break steering (addresses critique C1, C4, C5)
 - **Task ID**: build-loop-break-steer
 - **Depends On**: none
-- **Validates**: `tests/unit/test_watchdog_loop_break_steer.py` (create), `tests/unit/test_session_watchdog.py` (update)
-- **Informed By**: spike-3 (confirmed watchdog→steering cost is ~15 LoC per detection)
+- **Validates**: `tests/unit/test_watchdog_loop_break_steer.py` (to be created), `tests/unit/test_session_watchdog.py` (update)
+- **Informed By**: spike-3 (watchdog→steering wiring is ~15 LoC per detection)
 - **Assigned To**: steer-builder
 - **Agent Type**: builder
 - **Parallel**: true
-- Add `_inject_loop_break_steer(session_id, reason, message_template)` in `session_watchdog.py`. Use Redis `SET NX EX 900` for atomic cooldown.
-- Call it from the positive branches of `detect_repetition` (line ~403) and `detect_error_cascade` (line ~408).
-- Compose distinct messages per reason (see Data Flow section above).
-- Gate with `WATCHDOG_AUTO_STEER_ENABLED` env var (default `true`). When disabled: still log, don't push.
-- Use separate cooldown keys: `watchdog:steer_cooldown:repetition:{session_id}` and `watchdog:steer_cooldown:error_cascade:{session_id}` so the two detections don't squelch each other.
+- Add `_inject_watchdog_steer(session_id: str, reason: str, message: str)` in `monitoring/session_watchdog.py`. Single helper serves all three trigger reasons (`repetition`, `error_cascade`, `token_alert`).
+- Cooldown uses atomic `POPOTO_REDIS_DB.set(f"watchdog:steer_cooldown:{reason}:{session_id}", "1", nx=True, ex=STEER_COOLDOWN)` — explicit keyword ordering for `nx` + `ex`. Return value truthy ⇒ cooldown slot was open; falsy ⇒ key exists, skip.
+- Call `push_steering_message(session_id, message, sender="watchdog")` when cooldown is open. The `sender="watchdog"` is **required** for downstream attribution (C5).
+- Call it from the positive branches of `detect_repetition` (currently at `monitoring/session_watchdog.py:471–522`) and `detect_error_cascade` (currently at `monitoring/session_watchdog.py:525–574`).
+- Compose distinct messages per reason (see Data Flow section — verbatim templates above).
+- Gate with `WATCHDOG_AUTO_STEER_ENABLED` env var (default `true`). When disabled: still log the detection at WARNING; do not push.
+- Delivery timing (C1): the PostToolUse hook + turn-boundary drain in the PM session already consume `queued_steering_messages` before the next tool call. This task does NOT touch that consumer. Add a test that asserts a pushed message is visible via `AgentSession.queued_steering_messages` queue inspection immediately after the call.
 
-### 4. Add token-threshold alert
+### 6. Add token-threshold alert
 - **Task ID**: build-token-threshold-alert
-- **Depends On**: build-token-accumulator, build-loop-break-steer
-- **Validates**: `tests/unit/test_watchdog_token_alert.py` (create)
+- **Depends On**: build-token-accumulator, build-loop-break-steer, build-token-sdk-path, build-token-harness-path
+- **Validates**: `tests/unit/test_watchdog_token_alert.py` (to be created)
 - **Assigned To**: steer-builder
 - **Agent Type**: builder
 - **Parallel**: false
-- In `_check_session_health`, after reading `AgentSession.total_input_tokens + total_output_tokens`, compare to `TOKEN_ALERT_THRESHOLD`.
-- If exceeded AND status=running AND no cooldown, push steer `"Token budget exceeded: ${cost_usd:.2f} spent this session. Stop and summarize what you've done."` with cooldown key `watchdog:token_alert_cooldown:{session_id}` TTL 3600s.
-- Uses the same `_inject_loop_break_steer` helper with a custom cooldown key.
+- In `monitoring/session_watchdog.py::_check_session_health`, read `AgentSession.total_input_tokens + total_output_tokens` for each session. Watchdog is a **read-only** consumer of these fields — never write.
+- If sum >= `TOKEN_ALERT_THRESHOLD` (default 5M, env `WATCHDOG_TOKEN_ALERT_THRESHOLD`) AND status == `running`, call `_inject_watchdog_steer(session_id, "token_alert", msg)`.
+- Alert cooldown TTL = `TOKEN_ALERT_COOLDOWN` (default 3600s, env `WATCHDOG_TOKEN_ALERT_COOLDOWN`) — passed to the helper as the `ex` value.
+- Message: `f"Token budget exceeded: ${cost_usd:.2f} / {total_tokens:,} tokens spent this session. Stop and summarize what you've done."` — cost taken verbatim from `AgentSession.total_cost_usd` (never recomputed, per the Pricing Constants subsection above).
 
-### 5. Add idle-teardown pass
-- **Task ID**: build-idle-teardown
+### 7. Add worker idle-sweeper (addresses critique B1, B2, C3)
+- **Task ID**: build-idle-sweeper
 - **Depends On**: none
-- **Validates**: `tests/unit/test_watchdog_idle_teardown.py` (create)
-- **Informed By**: spike-2 (teardown-on-dormant preferred over API probe)
+- **Validates**: `tests/unit/test_worker_idle_sweeper.py` (to be created)
+- **Informed By**: spike-2 (execution-path audit: teardown is worker-local, not watchdog-process)
 - **Assigned To**: teardown-builder
 - **Agent Type**: builder
 - **Parallel**: true
-- Add `sdk_connection_torn_down_at = DatetimeField(null=True)` to `AgentSession`.
-- Add `_active_clients: dict[str, ClaudeSDKClient]` registry at module scope in `sdk_client.py`. Populate on context-enter, remove on context-exit. Protect with a lock.
-- Add `_teardown_dormant_sdk_connections(sessions)` pass in `session_watchdog.py`. Iterate `list(_active_clients.items())` snapshot. Filter to sessions in `{dormant, paused, paused_circuit}` with activity >24h old. Close the client. Set `sdk_connection_torn_down_at`.
-- Gate with `WATCHDOG_IDLE_TEARDOWN_ENABLED` env var (default `true`).
+- Add `sdk_connection_torn_down_at = DatetimeField(null=True)` to `AgentSession` in `models/agent_session.py`.
+- Create **new module** `worker/idle_sweeper.py`:
+  - `async def run_idle_sweep(interval: int = 1800)` — infinite loop with `await asyncio.sleep(interval)`; each tick calls `_sweep_once()`.
+  - `async def _sweep_once()` — reads `list(_active_clients.items())` snapshot from `agent.sdk_client`; for each `(session_id, client)` entry, loads `AgentSession`, filters to `status in {dormant, paused, paused_circuit}` (C3: all three explicit) AND `updated_at > IDLE_TEARDOWN_THRESHOLD`; calls `await client.close()` wrapped in `try/except`; pops the entry from `_active_clients`; sets `AgentSession.sdk_connection_torn_down_at = datetime.now(UTC)` via `save(update_fields=["sdk_connection_torn_down_at"])`.
+  - Constants: `IDLE_TEARDOWN_THRESHOLD`, `IDLE_SWEEP_INTERVAL` — both env-overridable.
+- In `worker/__main__.py`, spawn `run_idle_sweep()` as a background task alongside the main session loop (similar to how the reflection scheduler is started). Ensure cancellation on shutdown.
+- Gate with `WATCHDOG_IDLE_TEARDOWN_ENABLED` env var (default `true`) — early-return from `_sweep_once` if disabled.
+- Use `list(_active_clients.items())` (snapshot) — never iterate the live dict. `dict.pop(key, None)` is safe on missing keys.
+- Explicitly document that this module runs in the **worker process** and that the watchdog process does NOT and must NOT try to reach `_active_clients`.
 
-### 6. Write test suite
+### 8. Write test suite
 - **Task ID**: test-watchdog-hardening
-- **Depends On**: build-token-accumulator, build-dashboard-tokens, build-loop-break-steer, build-token-threshold-alert, build-idle-teardown
+- **Depends On**: build-token-accumulator, build-token-sdk-path, build-token-harness-path, build-dashboard-tokens, build-loop-break-steer, build-token-threshold-alert, build-idle-sweeper
 - **Assigned To**: watchdog-test-engineer
 - **Agent Type**: test-engineer
 - **Parallel**: false
 - Create/update the test files listed in Test Impact.
-- Cover positive path, cooldown suppression, env-var disable, concurrent-save race.
+- Cover positive path, cooldown suppression (atomic SET NX EX), env-var disable, concurrent-save race, both SDK and harness token-capture paths, worker idle-sweeper filter logic.
 - All tests use in-process Popoto + fakeredis — no network.
 
-### 7. Validate integration end-to-end
+### 9. Validate integration end-to-end
 - **Task ID**: validate-watchdog-hardening
 - **Depends On**: test-watchdog-hardening
 - **Assigned To**: watchdog-validator
 - **Agent Type**: validator
 - **Parallel**: false
-- Run full `pytest tests/unit/test_watchdog*.py tests/unit/test_session_*` suite.
-- Hit `/dashboard.json` on a live worker, assert token fields present.
+- Run full `pytest tests/unit/test_watchdog*.py tests/unit/test_session_*.py tests/unit/test_harness*.py tests/unit/test_worker_idle_sweeper.py` suite.
+- Hit `/dashboard.json` on a live worker, assert token fields present for at least one session.
 - Flip each env var off, restart worker, verify gating works.
-- Simulate a repetition loop against a real (throwaway) session and observe the steering message in `valor-session status`.
+- Simulate a repetition loop against a real (throwaway) session and observe the steering message with `sender="watchdog"` in `valor-session status`.
+- Verify the worker idle-sweeper logs a tick every 30 min in `logs/worker.log`.
 
-### 8. Documentation
+### 10. Documentation
 - **Task ID**: document-watchdog-hardening
 - **Depends On**: validate-watchdog-hardening
 - **Assigned To**: watchdog-documentarian
@@ -473,8 +623,10 @@ Using core agent types: builder, test-engineer, validator, documentarian. No spe
 - **Parallel**: false
 - Update the four feature docs listed in Documentation.
 - Add env-var table to `docs/features/session-watchdog.md`.
+- Explicitly note the **two execution paths** (SDK vs harness) in the token-tracking section so future contributors don't try to add tracking in only one place.
+- Document the worker-internal idle sweeper separately from the watchdog-process responsibilities.
 
-### 9. Final validation
+### 11. Final validation
 - **Task ID**: validate-all
 - **Depends On**: document-watchdog-hardening
 - **Assigned To**: watchdog-validator
@@ -488,20 +640,37 @@ Using core agent types: builder, test-engineer, validator, documentarian. No spe
 
 | Check | Command | Expected |
 |-------|---------|----------|
-| Unit tests pass | `pytest tests/unit/test_watchdog_loop_break_steer.py tests/unit/test_session_token_accumulator.py tests/unit/test_watchdog_idle_teardown.py tests/unit/test_watchdog_token_alert.py tests/unit/test_session_watchdog.py -x -q` | exit code 0 |
+| New watchdog/harness/worker tests pass | `pytest tests/unit/test_watchdog_loop_break_steer.py tests/unit/test_watchdog_token_alert.py tests/unit/test_session_token_accumulator.py tests/unit/test_harness_token_capture.py tests/unit/test_worker_idle_sweeper.py tests/unit/test_session_watchdog.py -x -q` | exit code 0 |
 | All unit tests pass | `pytest tests/unit/ -x -q` | exit code 0 |
 | Format clean | `python -m ruff format --check .` | exit code 0 |
 | New AgentSession fields exist | `python -c "from models.agent_session import AgentSession; assert all(hasattr(AgentSession, f) for f in ['total_input_tokens', 'total_output_tokens', 'total_cache_read_tokens', 'total_cost_usd', 'sdk_connection_torn_down_at'])"` | exit code 0 |
-| Token tracking wired into sdk_client | `grep -q 'accumulate_session_tokens' agent/sdk_client.py` | exit code 0 |
-| Loop-break steer wired into watchdog | `grep -q '_inject_loop_break_steer' monitoring/session_watchdog.py` | exit code 0 |
-| Idle teardown pass exists | `grep -q '_teardown_dormant_sdk_connections' monitoring/session_watchdog.py` | exit code 0 |
-| Dashboard exposes tokens | `python -c "import json; from ui.app import _session_to_json" && grep -q 'total_input_tokens' ui/app.py` | exit code 0 |
+| Token accumulator exists | `grep -q 'def accumulate_session_tokens' agent/sdk_client.py` | exit code 0 |
+| Accumulator called from SDK ResultMessage handler | `grep -nP 'accumulate_session_tokens\(' agent/sdk_client.py \| wc -l` | >= 2 (SDK path + harness path) |
+| Harness subprocess captures usage | `grep -q 'usage.*data.get' agent/sdk_client.py \|\| grep -q 'data.get."usage"' agent/sdk_client.py` | exit code 0 |
+| Watchdog steer helper wired | `grep -q '_inject_watchdog_steer' monitoring/session_watchdog.py` | exit code 0 |
+| Cooldown uses atomic SET NX EX | `grep -nE 'set\([^)]*nx=True' monitoring/session_watchdog.py` | non-empty |
+| Sender attribution on watchdog steers | `grep -q 'sender="watchdog"' monitoring/session_watchdog.py` | exit code 0 |
+| Worker idle sweeper module exists | `test -f worker/idle_sweeper.py` | exit code 0 |
+| Worker main starts sweeper | `grep -q 'run_idle_sweep' worker/__main__.py` | exit code 0 |
+| Dashboard exposes tokens | `grep -q 'total_input_tokens' ui/app.py && grep -q 'total_input_tokens' ui/data/sdlc.py` | exit code 0 |
 
 ## Critique Results
 
-<!-- Populated by /do-plan-critique (war room). Leave empty until critique is run. -->
+Verdict after first critique: **NEEDS REVISION** (3 blockers, 5 concerns, 3 nits). Revisions folded back into the plan; table below tracks each finding → disposition.
+
 | Severity | Critic | Finding | Addressed By | Implementation Note |
 |----------|--------|---------|--------------|---------------------|
+| Blocker | Archaeologist | B1: `_active_clients` registry is process-local to the worker; the session-watchdog runs in a separate process and cannot reach it. The original "watchdog tears down dormant clients" design was infeasible. | `build-idle-sweeper`, Data Flow → Idle teardown, Architectural Impact → Process topology | Idle-teardown moved into `worker/idle_sweeper.py`, co-located with the registry. Watchdog process no longer participates. |
+| Blocker | Archaeologist | B2: Production's PM/Dev/Teammate path uses `_run_harness_subprocess` (short-lived `claude -p` subprocess per turn), not a persistent `ClaudeSDKClient`. The 48h silent-death premise only applies to the SDK path. | spike-2 re-write, Data Flow → Idle teardown | Idle-teardown is a no-op for harness-path sessions (nothing to tear down). Scope limited to SDK-path sessions (chat routes). |
+| Blocker | Skeptic | B3: Token accumulator only hooked SDK `ResultMessage` handler; production harness path would report 0 tokens forever. | spike-5, spike-6, `build-token-harness-path` | `_run_harness_subprocess` now extracts `usage` + `total_cost_usd` from the `result` event JSON; `get_response_via_harness` calls `accumulate_session_tokens` as a side effect before returning. Both paths feed the same fields. |
+| Concern | Operator | C1: Steering delivery timing — will the loop-break steer actually arrive before the next identical tool call? | Data Flow → Loop-break steering step 5, `build-loop-break-steer` test | Delivery is at the next tool-call boundary via the existing PostToolUse hook. One-tool-call delay documented; acceptable because stuck loops emit many tool calls per minute. Test asserts message is queued immediately. |
+| Concern | Skeptic | C2: Token-to-dollar scaling — hardcoded pricing constants drift silently when Anthropic updates rates. | Data Flow → Pricing constants subsection | Do **not** maintain a local price table. Use `msg.total_cost_usd` (SDK) or `data.get("total_cost_usd")` (harness) verbatim. Costs track upstream pricing automatically. |
+| Concern | Adversary | C3: `check_all_sessions` status filter for idle-teardown must include `paused` and `paused_circuit`, not only `dormant`. | Technical Approach → Idle teardown status filter, `build-idle-sweeper` | Status filter explicitly targets `{dormant, paused, paused_circuit}`; excluded statuses enumerated; test asserts `paused_circuit` is torn down at 24h. |
+| Concern | Simplifier | C4: Cooldown `SET NX EX` keyword ordering — must be truly atomic, not a read-then-write. | Technical Approach → Cooldown atomic ordering, `build-loop-break-steer` | Explicit `POPOTO_REDIS_DB.set(key, value, nx=True, ex=ttl)` single-command pattern documented with code snippet. Verification table greps for `nx=True`. |
+| Concern | Operator | C5: `valor-session` sender-metadata visibility — watchdog-authored steers must be distinguishable from human steers. | Technical Approach → Steering attribution, `build-loop-break-steer` | `sender="watchdog"` mandatory on every `push_steering_message` call. Verification table greps for the literal string. Already supported by `agent/steering.py` + downstream consumers (verified via code-read). |
+| Nit | Archaeologist | Line-range precision in file references (`sdk_client.py:1216` was stale; real handler is at 1251). | Freshness Check, spike-1, spike-5, Task 2 | File:line references updated across the plan. |
+| Nit | Archaeologist | Test file references pointed at paths that don't yet exist without marking them as to-be-created. | Test Impact, Tasks 1–7 | All new test files explicitly marked "(to be created)"; existing files marked "(update)". |
+| Nit | Simplifier | Constant naming inconsistent between sections (e.g., `STEER_COOLDOWN` vs. an inline 900s literal). | Technical Approach → Thresholds + env-var gates, Tasks | Single authoritative constants block; all inline numbers cross-reference named constants. |
 
 ---
 

--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -283,6 +283,30 @@ class AgentSession(Model):
     # branch. Lets us measure how often the guard actually fires.
     nudge_deferred_count = IntField(default=0)
 
+    # === Per-session token + cost accounting (issue #1128) ===
+    # Cumulative counts aggregated from SDK ResultMessage.usage and from the
+    # harness `result` event payload (both paths write here via
+    # `agent/sdk_client.py::accumulate_session_tokens`). Readers: dashboard
+    # (`/dashboard.json`) and the session watchdog token-threshold alert.
+    # Writers: worker process only. Default 0 (never None) for forward-compat
+    # with existing JSON consumers.
+    total_input_tokens = IntField(default=0)
+    total_output_tokens = IntField(default=0)
+    total_cache_read_tokens = IntField(default=0)
+    # `total_cost_usd` is taken verbatim from `msg.total_cost_usd` (SDK) or
+    # `data.get("total_cost_usd")` (harness). Never recomputed from token
+    # counts — this tracks upstream pricing automatically.
+    total_cost_usd = FloatField(default=0.0)
+
+    # Set by the worker's idle sweeper (`worker/idle_sweeper.py`) when a
+    # dormant SDK-path session's persistent `ClaudeSDKClient` is proactively
+    # torn down before the ~48h Anthropic idle-kill window. On resume, a
+    # fresh client is rebuilt via `--resume` + stored UUID. Informational
+    # only — the sweeper pops the client from `_active_clients` as part of
+    # the teardown, so the field's presence (vs. None) is what operators
+    # use to audit how often teardown fires.
+    sdk_connection_torn_down_at = DatetimeField(null=True)
+
     class Meta:
         ttl = 2592000  # 30 days — hard backstop for retain_for_resume BUILD sessions
 
@@ -330,6 +354,8 @@ class AgentSession(Model):
         "last_heartbeat_at",
         "last_sdk_heartbeat_at",
         "last_stdout_at",
+        # Worker idle-sweeper teardown marker (issue #1128)
+        "sdk_connection_torn_down_at",
     }
 
     def __init__(self, **kwargs):

--- a/monitoring/session_watchdog.py
+++ b/monitoring/session_watchdog.py
@@ -5,14 +5,25 @@ Monitors active agent sessions for signs of distress:
 - Looping behavior (repeated identical tool calls)
 - Error cascades (high error rate in recent activity)
 - Excessively long sessions
+- Cumulative per-session token spend crossing a soft threshold (issue #1128)
 
 When issues are detected, the watchdog FIXES them automatically:
 - Retries stalled sessions with exponential backoff (up to MAX_STALL_RETRIES)
 - Marks stuck sessions as abandoned after retries exhausted
 - Creates GitHub issues for problems that can't be auto-fixed
 - Notifies human via Telegram after max retries exhausted
+- For looping / error-cascade / token-alert conditions (issue #1128):
+  AUTOMATICALLY enqueues a steering message via `_inject_watchdog_steer`.
+  Per-reason atomic Redis cooldowns (SET NX EX) prevent floods. No longer
+  "detected but logged only" — detections now drive actuation.
 
 NO ALERTS ARE SENT for recoverable stalls. Either retry, fix, or create an issue.
+
+**Process topology (issue #1128)**: This watchdog runs as a SEPARATE process
+from the worker. Idle SDK-client teardown is NOT implemented here because
+the `_active_clients` registry in `agent/sdk_client.py` is worker-process-
+local. Idle teardown lives in `worker/idle_sweeper.py`, co-located with
+the registry. The watchdog process must never import `_active_clients`.
 """
 
 import asyncio
@@ -74,6 +85,21 @@ STALL_THRESHOLDS = {
     "running": STALL_THRESHOLD_RUNNING,
     "active": STALL_THRESHOLD_ACTIVE,
 }
+
+# === Loop-break + token-alert steering (issue #1128) ===
+# Soft-threshold on cumulative tokens (sum of input + output) for the
+# token-alert steer. Default 5,000,000 ≈ $75 at Sonnet rates. Taken from
+# AgentSession.total_input_tokens + total_output_tokens (written by
+# agent/sdk_client.py::accumulate_session_tokens — this file only READS).
+TOKEN_ALERT_THRESHOLD = int(os.environ.get("WATCHDOG_TOKEN_ALERT_THRESHOLD", "5000000"))
+# Cooldown TTL for the token-alert steer (per session). 3600s = one alert
+# per hour per session — generous enough for a human to respond between
+# repeats, aggressive enough to avoid silent runaway.
+TOKEN_ALERT_COOLDOWN = int(os.environ.get("WATCHDOG_TOKEN_ALERT_COOLDOWN", "3600"))
+# Cooldown TTL for repetition + error-cascade steers (per session per
+# reason). 900s = 3 watchdog ticks; gives the agent room to respond to a
+# steer before the next one fires.
+STEER_COOLDOWN = int(os.environ.get("WATCHDOG_STEER_COOLDOWN", "900"))
 
 
 # Transcript liveness: if transcript.txt was modified within this many minutes,
@@ -361,6 +387,117 @@ def check_stalled_sessions() -> list[dict]:
     return stalled
 
 
+def _env_flag_enabled(var_name: str, default: bool = True) -> bool:
+    """Return True unless the env var is explicitly set to a falsy string.
+
+    Watchdog-hardening feature gates (issue #1128). Falsy (case-insensitive):
+    "0", "false", "no". Anything else — including unset — means enabled.
+    """
+    raw = os.environ.get(var_name)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in {"0", "false", "no"}
+
+
+def _inject_watchdog_steer(
+    session_id: str,
+    reason: str,
+    message: str,
+    cooldown_seconds: int = STEER_COOLDOWN,
+) -> bool:
+    """Enqueue a watchdog-authored steering message, guarded by a per-reason cooldown.
+
+    This is the single actuator for all three watchdog steering triggers
+    introduced in issue #1128:
+
+      * ``repetition`` — `detect_repetition` fired on the recent tool-call log.
+      * ``error_cascade`` — `detect_error_cascade` fired on the recent log.
+      * ``token_alert`` — cumulative tokens crossed `TOKEN_ALERT_THRESHOLD`.
+
+    Each reason gets its OWN cooldown key
+    (``watchdog:steer_cooldown:<reason>:<session_id>``) so a repetition
+    steer does NOT suppress a parallel error-cascade or token-alert steer.
+
+    Cooldown is enforced with a single atomic Redis ``SET NX EX`` — truthy
+    return means the slot was open and we may proceed; falsy means the key
+    exists and we back off. This is the full contract — never sequence a
+    separate GET then SET, which would race under concurrent watchdog ticks.
+
+    Delivery: `agent/steering.py::push_steering_message` with
+    ``sender="watchdog"`` (mandatory — downstream consumers distinguish
+    watchdog steers from human steers by this tag). The message is drained
+    at the next tool-call boundary by the existing PostToolUse hook and
+    the PM session's turn-boundary drain; it does NOT interrupt mid-tool
+    execution. Operators should expect a one-tool-call delay between
+    detection and correction.
+
+    Feature gate: ``WATCHDOG_AUTO_STEER_ENABLED`` (default on). When
+    disabled, the detection is still logged at WARNING upstream but no
+    steer is pushed.
+
+    Args:
+        session_id: The AgentSession.session_id to steer. Must be the
+            bridge/Telegram session id (not agent_session_id).
+        reason: One of ``"repetition"``, ``"error_cascade"``,
+            ``"token_alert"``. Used as part of the cooldown key.
+        message: The steering text to push. Composed by the caller so the
+            wording can vary per trigger reason.
+        cooldown_seconds: Cooldown TTL in seconds. Callers pass
+            ``STEER_COOLDOWN`` for loop-break reasons and
+            ``TOKEN_ALERT_COOLDOWN`` for token alerts.
+
+    Returns:
+        True when a steer was pushed. False when the cooldown slot was
+        closed, the feature flag was off, or any exception was caught
+        (fail-quiet so the watchdog loop never crashes on steer errors).
+    """
+    if not _env_flag_enabled("WATCHDOG_AUTO_STEER_ENABLED"):
+        logger.debug(
+            "[watchdog] auto-steer disabled via env; skipping %s steer for %s",
+            reason,
+            session_id,
+        )
+        return False
+
+    try:
+        from popoto.redis_db import POPOTO_REDIS_DB
+
+        cooldown_key = f"watchdog:steer_cooldown:{reason}:{session_id}"
+        # Atomic set-if-not-exists with TTL — single Redis command,
+        # eliminates the read-then-write race entirely.
+        cooldown_slot_open = POPOTO_REDIS_DB.set(
+            cooldown_key,
+            "1",
+            nx=True,
+            ex=cooldown_seconds,
+        )
+        if not cooldown_slot_open:
+            logger.debug(
+                "[watchdog] %s steer for %s suppressed — cooldown active",
+                reason,
+                session_id,
+            )
+            return False
+
+        from agent.steering import push_steering_message
+
+        push_steering_message(session_id, message, sender="watchdog")
+        logger.warning(
+            "[watchdog] Loop-break steer injected for %s: reason=%s",
+            session_id,
+            reason,
+        )
+        return True
+    except Exception as e:
+        logger.warning(
+            "[watchdog] Failed to inject %s steer for %s: %s",
+            reason,
+            session_id,
+            e,
+        )
+        return False
+
+
 def assess_session_health(session: AgentSession) -> dict[str, Any]:
     """Assess the health of a single session.
 
@@ -403,6 +540,21 @@ def assess_session_health(session: AgentSession) -> dict[str, Any]:
             is_looping, repeated_tool, count = detect_repetition(tool_calls)
             if is_looping:
                 issues.append(f"Looping: {repeated_tool} called {count} times consecutively")
+                # Actuate: push a loop-break steering message (issue #1128).
+                # The cooldown key includes reason='repetition', so a parallel
+                # error-cascade or token-alert steer is not suppressed.
+                if repeated_tool:
+                    _inject_watchdog_steer(
+                        session.session_id,
+                        "repetition",
+                        (
+                            f"Stop and re-check the task — you appear to be "
+                            f"repeating the same tool call ({repeated_tool}) "
+                            f"{count} times. Summarize what you've tried, "
+                            "then try a different approach."
+                        ),
+                        cooldown_seconds=STEER_COOLDOWN,
+                    )
 
             # Check for error cascade
             is_cascading, error_count = detect_error_cascade(tool_calls)
@@ -410,9 +562,57 @@ def assess_session_health(session: AgentSession) -> dict[str, Any]:
                 issues.append(
                     f"Error cascade: {error_count} errors in last {ERROR_CASCADE_WINDOW} calls"
                 )
+                # Actuate: push an error-cascade steer with an independent
+                # cooldown key (issue #1128).
+                _inject_watchdog_steer(
+                    session.session_id,
+                    "error_cascade",
+                    (
+                        f"Stop — you've hit {error_count} errors in the last "
+                        f"{ERROR_CASCADE_WINDOW} operations. Summarize the "
+                        "failure pattern and pause for human input rather "
+                        "than continuing blind."
+                    ),
+                    cooldown_seconds=STEER_COOLDOWN,
+                )
     except Exception as e:
         logger.debug(
             "[watchdog] Could not analyze tool calls for session %s: %s",
+            session.session_id,
+            e,
+        )
+
+    # Token-spend alert (issue #1128). Watchdog READS
+    # `AgentSession.total_input_tokens + total_output_tokens` only — it
+    # never writes those fields (writers are the SDK ResultMessage handler
+    # and `get_response_via_harness`, both worker-process). Only triggers
+    # for `running` sessions so a completed session that happened to rack
+    # up tokens doesn't get a steer sent into an empty queue.
+    try:
+        status_val = getattr(session, "status", None)
+        if status_val == "running":
+            in_tokens = int(getattr(session, "total_input_tokens", 0) or 0)
+            out_tokens = int(getattr(session, "total_output_tokens", 0) or 0)
+            total_tokens = in_tokens + out_tokens
+            if total_tokens >= TOKEN_ALERT_THRESHOLD:
+                issues.append(
+                    f"Token budget: {total_tokens:,} tokens, "
+                    f"${float(getattr(session, 'total_cost_usd', 0.0) or 0.0):.2f}"
+                )
+                cost_usd = float(getattr(session, "total_cost_usd", 0.0) or 0.0)
+                _inject_watchdog_steer(
+                    session.session_id,
+                    "token_alert",
+                    (
+                        f"Token budget exceeded: ${cost_usd:.2f} / "
+                        f"{total_tokens:,} tokens spent this session. Stop "
+                        "and summarize what you've done."
+                    ),
+                    cooldown_seconds=TOKEN_ALERT_COOLDOWN,
+                )
+    except Exception as e:
+        logger.debug(
+            "[watchdog] Token alert check failed for %s: %s",
             session.session_id,
             e,
         )

--- a/tests/unit/test_harness_token_capture.py
+++ b/tests/unit/test_harness_token_capture.py
@@ -1,0 +1,271 @@
+"""Unit tests for harness-path token capture (issue #1128).
+
+Covers the plan's "B3 fix" — the harness execution path must extract
+`usage` + `total_cost_usd` off the `result` event and feed them into
+`accumulate_session_tokens` so harness-served sessions (production PM /
+Dev / Teammate) no longer report zero tokens.
+
+What we validate:
+- `_run_harness_subprocess` returns a 5-tuple including usage + cost.
+- The `result` event's `usage` dict and `total_cost_usd` float are
+  threaded through unchanged.
+- Missing / malformed usage payloads default to None — the helper handles
+  them without raising.
+- `get_response_via_harness` calls `accumulate_session_tokens` as a side
+  effect with the captured values.
+- The public return signature of `get_response_via_harness` remains a
+  plain `str` (no call site changes required).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+class _AsyncLineIterator:
+    """Async iterator yielding encoded stdout lines. Mirrors test_harness_streaming."""
+
+    def __init__(self, data: str):
+        self._lines = [(line + "\n").encode("utf-8") for line in data.splitlines() if line.strip()]
+        self._index = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._index >= len(self._lines):
+            raise StopAsyncIteration
+        line = self._lines[self._index]
+        self._index += 1
+        return line
+
+
+def _async_lines(data: str) -> _AsyncLineIterator:
+    return _AsyncLineIterator(data)
+
+
+def _result_event(
+    result: str = "ok",
+    session_id: str = "sess_abc",
+    usage: dict | None = None,
+    total_cost_usd: float | None = 0.12,
+) -> str:
+    event: dict = {
+        "type": "result",
+        "result": result,
+        "session_id": session_id,
+    }
+    if usage is not None:
+        event["usage"] = usage
+    if total_cost_usd is not None:
+        event["total_cost_usd"] = total_cost_usd
+    return json.dumps(event)
+
+
+class TestRunHarnessSubprocessReturnTuple:
+    """Validate the 5-tuple return shape introduced by issue #1128."""
+
+    @pytest.mark.asyncio
+    async def test_extracts_usage_and_cost(self):
+        from agent.sdk_client import _run_harness_subprocess
+
+        usage = {
+            "input_tokens": 1234,
+            "output_tokens": 567,
+            "cache_read_input_tokens": 89,
+            "cache_creation_input_tokens": 10,
+        }
+        lines = _result_event(usage=usage, total_cost_usd=0.99)
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            mock_proc = AsyncMock()
+            mock_proc.stdout = _async_lines(lines + "\n")
+            mock_proc.stderr = AsyncMock()
+            mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+            mock_proc.returncode = 0
+            mock_exec.return_value = mock_proc
+
+            result = await _run_harness_subprocess(
+                ["claude", "-p", "test"],
+                "/tmp",
+                {},
+            )
+
+        assert isinstance(result, tuple)
+        assert len(result) == 5
+        result_text, session_id, returncode, out_usage, out_cost = result
+        assert result_text == "ok"
+        assert session_id == "sess_abc"
+        assert returncode == 0
+        assert out_usage == usage
+        assert out_cost == pytest.approx(0.99)
+
+    @pytest.mark.asyncio
+    async def test_missing_usage_returns_none(self):
+        """If the `result` event omits usage/cost, both fields are None."""
+        from agent.sdk_client import _run_harness_subprocess
+
+        lines = _result_event(usage=None, total_cost_usd=None)
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            mock_proc = AsyncMock()
+            mock_proc.stdout = _async_lines(lines + "\n")
+            mock_proc.stderr = AsyncMock()
+            mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+            mock_proc.returncode = 0
+            mock_exec.return_value = mock_proc
+
+            _, _, _, usage_out, cost_out = await _run_harness_subprocess(
+                ["claude", "-p", "test"],
+                "/tmp",
+                {},
+            )
+        assert usage_out is None
+        assert cost_out is None
+
+    @pytest.mark.asyncio
+    async def test_binary_not_found_returns_five_tuple(self):
+        from agent.sdk_client import _run_harness_subprocess
+
+        with patch("asyncio.create_subprocess_exec", side_effect=FileNotFoundError("claude")):
+            out = await _run_harness_subprocess(["claude"], "/tmp", {})
+        assert isinstance(out, tuple)
+        assert len(out) == 5
+        # On binary-not-found: usage + cost are None and returncode is None
+        assert out[2] is None
+        assert out[3] is None
+        assert out[4] is None
+
+
+class TestGetResponseViaHarnessAccumulates:
+    """End-to-end: harness returns a `result` event → accumulator fires as a side effect."""
+
+    @pytest.mark.asyncio
+    async def test_accumulate_called_with_extracted_values(self):
+        from agent import sdk_client
+        from agent.sdk_client import get_response_via_harness
+
+        usage = {
+            "input_tokens": 1000,
+            "output_tokens": 400,
+            "cache_read_input_tokens": 50,
+        }
+        stdout = _result_event(usage=usage, total_cost_usd=2.50) + "\n"
+
+        captured = {}
+
+        def fake_accumulate(sid, in_tok, out_tok, cache, cost):
+            captured["args"] = (sid, in_tok, out_tok, cache, cost)
+
+        with (
+            patch("asyncio.create_subprocess_exec") as mock_exec,
+            patch.object(sdk_client, "accumulate_session_tokens", fake_accumulate),
+            patch.object(sdk_client, "_store_claude_session_uuid", lambda *a, **k: None),
+        ):
+            mock_proc = AsyncMock()
+            mock_proc.stdout = _async_lines(stdout)
+            mock_proc.stderr = AsyncMock()
+            mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+            mock_proc.returncode = 0
+            mock_exec.return_value = mock_proc
+
+            result = await get_response_via_harness(
+                message="hello",
+                working_dir="/tmp",
+                session_id="bridge-sess-1",
+            )
+
+        assert result == "ok"  # plain str, signature unchanged
+        assert "args" in captured, "accumulate_session_tokens was not called"
+        sid, in_tok, out_tok, cache, cost = captured["args"]
+        assert sid == "bridge-sess-1"
+        assert in_tok == 1000
+        assert out_tok == 400
+        assert cache == 50
+        assert cost == pytest.approx(2.50)
+
+    @pytest.mark.asyncio
+    async def test_accumulate_not_called_when_session_id_is_none(self):
+        from agent import sdk_client
+        from agent.sdk_client import get_response_via_harness
+
+        stdout = _result_event(usage={"input_tokens": 10, "output_tokens": 5}, total_cost_usd=0.01)
+        called = []
+        with (
+            patch("asyncio.create_subprocess_exec") as mock_exec,
+            patch.object(
+                sdk_client,
+                "accumulate_session_tokens",
+                lambda *a, **k: called.append(a),
+            ),
+        ):
+            mock_proc = AsyncMock()
+            mock_proc.stdout = _async_lines(stdout + "\n")
+            mock_proc.stderr = AsyncMock()
+            mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+            mock_proc.returncode = 0
+            mock_exec.return_value = mock_proc
+
+            result = await get_response_via_harness(
+                message="hi",
+                working_dir="/tmp",
+                session_id=None,  # no id → no accumulate
+            )
+        assert result == "ok"
+        assert called == []
+
+    @pytest.mark.asyncio
+    async def test_accumulate_not_called_when_usage_and_cost_both_missing(self):
+        from agent import sdk_client
+        from agent.sdk_client import get_response_via_harness
+
+        # No usage and no total_cost_usd on the result event — both should be
+        # None inside the helper, and the accumulator is therefore skipped.
+        stdout = _result_event(usage=None, total_cost_usd=None)
+        called = []
+        with (
+            patch("asyncio.create_subprocess_exec") as mock_exec,
+            patch.object(
+                sdk_client,
+                "accumulate_session_tokens",
+                lambda *a, **k: called.append(a),
+            ),
+            patch.object(sdk_client, "_store_claude_session_uuid", lambda *a, **k: None),
+        ):
+            mock_proc = AsyncMock()
+            mock_proc.stdout = _async_lines(stdout + "\n")
+            mock_proc.stderr = AsyncMock()
+            mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+            mock_proc.returncode = 0
+            mock_exec.return_value = mock_proc
+
+            result = await get_response_via_harness(
+                message="hi",
+                working_dir="/tmp",
+                session_id="bridge-sess-2",
+            )
+        assert result == "ok"
+        # accumulate not called — neither usage nor cost was present
+        assert called == []
+
+    @pytest.mark.asyncio
+    async def test_return_signature_remains_str(self):
+        """Guard against signature regression — callers expect plain str."""
+        from agent.sdk_client import get_response_via_harness
+
+        stdout = _result_event(usage={"input_tokens": 1, "output_tokens": 1})
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            mock_proc = AsyncMock()
+            mock_proc.stdout = _async_lines(stdout + "\n")
+            mock_proc.stderr = AsyncMock()
+            mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+            mock_proc.returncode = 0
+            mock_exec.return_value = mock_proc
+
+            result = await get_response_via_harness(
+                message="hello",
+                working_dir="/tmp",
+                # No session_id — accumulator path is skipped
+            )
+        assert isinstance(result, str)

--- a/tests/unit/test_sdk_client_image_sentinel.py
+++ b/tests/unit/test_sdk_client_image_sentinel.py
@@ -6,6 +6,11 @@ The sentinel (IMAGE_DIMENSION_SENTINEL) detects Claude Code's exit-code-0 error:
 
 These tests mock _run_harness_subprocess so they run instantly without a real
 claude CLI binary, API key, or network.
+
+Note (issue #1128): `_run_harness_subprocess` now returns a 5-tuple
+`(result_text, session_id, returncode, usage, cost_usd)`. The existing
+tests below were updated to match; the extra None / None trailing pair
+stands in for "no usage emitted on this simulated turn".
 """
 
 import pytest
@@ -26,9 +31,11 @@ async def test_sentinel_fires_full_context_message(monkeypatch):
                 f"An image in the conversation {IMAGE_DIMENSION_SENTINEL} (2000px).",
                 None,
                 0,
+                None,
+                None,
             )
         # Second call (fallback): normal response
-        return ("Fallback response from full context", "new-session-uuid", 0)
+        return ("Fallback response from full context", "new-session-uuid", 0, None, None)
 
     monkeypatch.setattr("agent.sdk_client._run_harness_subprocess", fake_subprocess)
     monkeypatch.setattr("agent.sdk_client._store_claude_session_uuid", lambda *a, **kw: None)
@@ -57,6 +64,8 @@ async def test_sentinel_no_full_context_message(monkeypatch):
             f"An image in the conversation {IMAGE_DIMENSION_SENTINEL} (2000px).",
             None,
             0,
+            None,
+            None,
         )
 
     monkeypatch.setattr("agent.sdk_client._run_harness_subprocess", fake_subprocess)
@@ -90,7 +99,7 @@ async def test_sentinel_does_not_fire_on_first_turn(monkeypatch):
     async def fake_subprocess(cmd, working_dir, proc_env, **kwargs):
         nonlocal call_count
         call_count += 1
-        return (sentinel_text, None, 0)
+        return (sentinel_text, None, 0, None, None)
 
     monkeypatch.setattr("agent.sdk_client._run_harness_subprocess", fake_subprocess)
     monkeypatch.setattr("agent.sdk_client._store_claude_session_uuid", lambda *a, **kw: None)
@@ -115,7 +124,7 @@ async def test_sentinel_does_not_fire_on_empty_result(monkeypatch):
     async def fake_subprocess(cmd, working_dir, proc_env, **kwargs):
         nonlocal call_count
         call_count += 1
-        return ("", None, 0)
+        return ("", None, 0, None, None)
 
     monkeypatch.setattr("agent.sdk_client._run_harness_subprocess", fake_subprocess)
     monkeypatch.setattr("agent.sdk_client._store_claude_session_uuid", lambda *a, **kw: None)
@@ -141,7 +150,7 @@ async def test_sentinel_does_not_fire_on_normal_resume(monkeypatch):
     async def fake_subprocess(cmd, working_dir, proc_env, **kwargs):
         nonlocal call_count
         call_count += 1
-        return (normal_response, "new-uuid", 0)
+        return (normal_response, "new-uuid", 0, None, None)
 
     monkeypatch.setattr("agent.sdk_client._run_harness_subprocess", fake_subprocess)
     monkeypatch.setattr("agent.sdk_client._store_claude_session_uuid", lambda *a, **kw: None)

--- a/tests/unit/test_session_token_accumulator.py
+++ b/tests/unit/test_session_token_accumulator.py
@@ -1,0 +1,176 @@
+"""Unit tests for accumulate_session_tokens (issue #1128).
+
+Covers:
+- Normal values persist onto AgentSession and monotonically accumulate.
+- Missing / None sub-fields default to 0 without raising.
+- WATCHDOG_TOKEN_TRACKING_ENABLED=false is a no-op.
+- No-session-found is a quiet skip (fail-quiet contract).
+- Zero deltas short-circuit before the Redis round-trip.
+- ModelException during save is logged but doesn't raise.
+- _usage_field handles dict, attribute-style, and None shapes.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from agent.sdk_client import _usage_field, accumulate_session_tokens
+from models.agent_session import AgentSession
+
+
+@pytest.fixture()
+def test_session():
+    """Create a persisted AgentSession for accumulator tests."""
+    sid = f"acc-test-{id(object())}"
+    s = AgentSession(
+        session_id=sid,
+        project_key="tst-accum",
+        agent_session_id=f"as-{sid}",
+        status="running",
+    )
+    s.save()
+    yield s
+    try:
+        s.delete()
+    except Exception:
+        pass
+
+
+class TestUsageField:
+    def test_none_returns_zero(self):
+        assert _usage_field(None, "input_tokens") == 0
+
+    def test_missing_attr_returns_zero(self):
+        class Empty:
+            pass
+
+        assert _usage_field(Empty(), "input_tokens") == 0
+
+    def test_attribute_style(self):
+        class Usage:
+            input_tokens = 123
+            output_tokens = 45
+
+        u = Usage()
+        assert _usage_field(u, "input_tokens") == 123
+        assert _usage_field(u, "output_tokens") == 45
+        assert _usage_field(u, "missing") == 0
+
+    def test_dict_style(self):
+        d = {"input_tokens": 77, "output_tokens": 88}
+        assert _usage_field(d, "input_tokens") == 77
+        assert _usage_field(d, "missing") == 0
+
+    def test_non_integer_fallback(self):
+        d = {"input_tokens": "not a number"}
+        assert _usage_field(d, "input_tokens") == 0
+
+
+class TestAccumulateSessionTokens:
+    def test_none_session_id_is_noop(self, test_session):
+        # Should not raise and should not affect the test session.
+        accumulate_session_tokens(None, 100, 50, 10, 0.05)
+        reloaded = list(AgentSession.query.filter(session_id=test_session.session_id))[0]
+        assert reloaded.total_input_tokens == 0
+        assert reloaded.total_output_tokens == 0
+        assert reloaded.total_cost_usd == 0.0
+
+    def test_missing_session_is_quiet_skip(self, caplog):
+        with caplog.at_level(logging.DEBUG):
+            accumulate_session_tokens("nope-nonexistent", 100, 50, 10, 0.05)
+        # Did not raise; the helper may or may not emit a debug log — the
+        # contract is fail-quiet, so we assert nothing about log level.
+
+    def test_monotonic_accumulation(self, test_session):
+        sid = test_session.session_id
+        accumulate_session_tokens(sid, 100, 50, 25, 0.10)
+        accumulate_session_tokens(sid, 200, 80, 15, 0.30)
+
+        reloaded = list(AgentSession.query.filter(session_id=test_session.session_id))[0]
+        assert reloaded.total_input_tokens == 300
+        assert reloaded.total_output_tokens == 130
+        assert reloaded.total_cache_read_tokens == 40
+        assert abs(reloaded.total_cost_usd - 0.40) < 1e-9
+
+    def test_none_subfields_default_to_zero(self, test_session):
+        sid = test_session.session_id
+        # output_tokens None → 0; cost None → 0.0
+        accumulate_session_tokens(sid, 100, None, None, None)
+        reloaded = list(AgentSession.query.filter(session_id=test_session.session_id))[0]
+        assert reloaded.total_input_tokens == 100
+        assert reloaded.total_output_tokens == 0
+        assert reloaded.total_cache_read_tokens == 0
+        assert reloaded.total_cost_usd == 0.0
+
+    def test_all_zero_short_circuits(self, test_session):
+        """All-zero delta should not persist a no-op write."""
+        sid = test_session.session_id
+        # Make sure a prior save recorded zeros.
+        accumulate_session_tokens(sid, 0, 0, 0, 0.0)
+        reloaded = list(AgentSession.query.filter(session_id=test_session.session_id))[0]
+        assert reloaded.total_input_tokens == 0
+
+    def test_env_gate_disables(self, test_session, monkeypatch):
+        sid = test_session.session_id
+        monkeypatch.setenv("WATCHDOG_TOKEN_TRACKING_ENABLED", "false")
+        accumulate_session_tokens(sid, 100, 50, 10, 0.05)
+        reloaded = list(AgentSession.query.filter(session_id=test_session.session_id))[0]
+        assert reloaded.total_input_tokens == 0
+        assert reloaded.total_cost_usd == 0.0
+
+    def test_env_gate_other_falsy_values(self, test_session, monkeypatch):
+        sid = test_session.session_id
+        for val in ("0", "NO", "False", "no"):
+            monkeypatch.setenv("WATCHDOG_TOKEN_TRACKING_ENABLED", val)
+            accumulate_session_tokens(sid, 1, 1, 0, 0.01)
+        reloaded = list(AgentSession.query.filter(session_id=test_session.session_id))[0]
+        assert reloaded.total_input_tokens == 0
+
+    def test_non_numeric_inputs_logged_and_skipped(self, test_session, caplog):
+        sid = test_session.session_id
+        with caplog.at_level(logging.WARNING, logger="agent.sdk_client"):
+            accumulate_session_tokens(sid, "not-a-number", 50, 10, 0.05)
+        reloaded = list(AgentSession.query.filter(session_id=test_session.session_id))[0]
+        assert reloaded.total_input_tokens == 0
+        assert any(
+            "non-numeric inputs" in r.message or "accumulate_session_tokens" in r.message
+            for r in caplog.records
+        )
+
+    def test_save_exception_is_fail_quiet(self, test_session, monkeypatch, caplog):
+        """If save() raises Exception, helper logs and does not re-raise."""
+        sid = test_session.session_id
+
+        def boom(self, **kw):  # noqa: ARG001
+            raise RuntimeError("simulated save failure")
+
+        # Patch the query to return our session whose save raises.
+        monkeypatch.setattr(AgentSession, "save", boom)
+
+        with caplog.at_level(logging.WARNING, logger="agent.sdk_client"):
+            # Should not raise
+            accumulate_session_tokens(sid, 10, 5, 2, 0.01)
+
+
+class TestDashboardSurfacing:
+    """End-to-end: accumulator writes → PipelineProgress reflects values."""
+
+    def test_pipeline_progress_reads_token_fields(self, test_session):
+        from ui.data.sdlc import _session_to_pipeline
+
+        accumulate_session_tokens(
+            test_session.session_id,
+            100,
+            200,
+            50,
+            1.23,
+        )
+        reloaded = list(AgentSession.query.filter(session_id=test_session.session_id))[0]
+        progress = _session_to_pipeline(reloaded)
+        assert progress is not None
+        assert progress.total_input_tokens == 100
+        assert progress.total_output_tokens == 200
+        assert progress.total_cache_read_tokens == 50
+        assert abs(progress.total_cost_usd - 1.23) < 1e-9

--- a/tests/unit/test_session_watchdog.py
+++ b/tests/unit/test_session_watchdog.py
@@ -330,6 +330,114 @@ class TestAssessSessionHealth:
 
 
 # ===================================================================
+# assess_session_health → steering actuator (issue #1128)
+# ===================================================================
+
+
+class TestAssessSessionHealthTriggersSteer:
+    """After issue #1128, detections drive actuation: repetition / cascade
+    / token threshold fire a steering message via `_inject_watchdog_steer`.
+    """
+
+    def _patch_common(self, monkeypatch):
+        """Reset cooldown keys + return the push-captured messages list."""
+        import popoto.redis_db as _rdb
+
+        for key in _rdb.POPOTO_REDIS_DB.scan_iter("watchdog:steer_cooldown:*"):
+            _rdb.POPOTO_REDIS_DB.delete(key)
+
+    def test_repetition_triggers_steer(self, monkeypatch, session_log_dir):
+        """Repeated identical tool calls → one steering message."""
+        sid, log_dir = session_log_dir
+        self._patch_common(monkeypatch)
+
+        # Write 5 identical pre_tool_use events
+        log_file = log_dir / "tool_use.jsonl"
+        with open(log_file, "w") as f:
+            for _ in range(6):
+                f.write(
+                    json.dumps(
+                        {
+                            "event": "pre_tool_use",
+                            "tool_name": "Bash",
+                            "tool_input": {"command": "ls"},
+                        }
+                    )
+                    + "\n"
+                )
+
+        session = _make_session(session_id=sid)
+        result = assess_session_health(session)
+        assert any("Looping" in issue for issue in result["issues"])
+
+        from agent.steering import pop_all_steering_messages
+
+        msgs = pop_all_steering_messages(sid)
+        assert len(msgs) == 1
+        assert msgs[0]["sender"] == "watchdog"
+        assert "repeating the same tool call" in msgs[0]["text"]
+
+    def test_error_cascade_triggers_independent_steer(self, monkeypatch, session_log_dir):
+        """Error cascade gets its own cooldown key (independent from repetition)."""
+        sid, log_dir = session_log_dir
+        self._patch_common(monkeypatch)
+
+        log_file = log_dir / "tool_use.jsonl"
+        with open(log_file, "w") as f:
+            for _ in range(10):
+                f.write(
+                    json.dumps(
+                        {
+                            "event": "post_tool_use",
+                            "tool_name": "Bash",
+                            "tool_output_preview": "Error: something bad happened",
+                        }
+                    )
+                    + "\n"
+                )
+
+        session = _make_session(session_id=sid)
+        result = assess_session_health(session)
+        assert any("Error cascade" in issue for issue in result["issues"])
+
+        from agent.steering import pop_all_steering_messages
+
+        msgs = pop_all_steering_messages(sid)
+        assert len(msgs) == 1
+        assert msgs[0]["sender"] == "watchdog"
+        assert "hit" in msgs[0]["text"] and "errors" in msgs[0]["text"]
+
+    def test_auto_steer_disabled_suppresses_push(self, monkeypatch, session_log_dir):
+        """WATCHDOG_AUTO_STEER_ENABLED=false → detection still fires, no steer pushed."""
+        sid, log_dir = session_log_dir
+        self._patch_common(monkeypatch)
+        monkeypatch.setenv("WATCHDOG_AUTO_STEER_ENABLED", "false")
+
+        log_file = log_dir / "tool_use.jsonl"
+        with open(log_file, "w") as f:
+            for _ in range(6):
+                f.write(
+                    json.dumps(
+                        {
+                            "event": "pre_tool_use",
+                            "tool_name": "Bash",
+                            "tool_input": {"command": "ls"},
+                        }
+                    )
+                    + "\n"
+                )
+
+        session = _make_session(session_id=sid)
+        result = assess_session_health(session)
+        assert any("Looping" in issue for issue in result["issues"])
+
+        from agent.steering import pop_all_steering_messages
+
+        msgs = pop_all_steering_messages(sid)
+        assert msgs == []
+
+
+# ===================================================================
 # check_all_sessions - ModelException handling
 # ===================================================================
 

--- a/tests/unit/test_watchdog_loop_break_steer.py
+++ b/tests/unit/test_watchdog_loop_break_steer.py
@@ -1,0 +1,176 @@
+"""Unit tests for monitoring/session_watchdog.py::_inject_watchdog_steer (issue #1128).
+
+Validates the detection→steering actuator introduced by this plan:
+
+- Repetition / error_cascade / token_alert call sites push exactly ONE
+  steer per cooldown window via an atomic Redis `SET NX EX`.
+- A second call within the cooldown window is suppressed.
+- Each reason has its own cooldown key so parallel detections don't
+  squelch each other.
+- `sender="watchdog"` is persisted on the pushed message envelope.
+- `WATCHDOG_AUTO_STEER_ENABLED=false` suppresses without crashing.
+- Redis / steering failures are fail-quiet (watchdog loop keeps running).
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from agent.steering import clear_steering_queue, pop_all_steering_messages
+from monitoring.session_watchdog import (
+    STEER_COOLDOWN,
+    TOKEN_ALERT_COOLDOWN,
+    _inject_watchdog_steer,
+)
+
+
+def _db():
+    """Return the live test-patched Redis client via module lookup.
+
+    conftest's `redis_test_db` fixture rebinds
+    `popoto.redis_db.POPOTO_REDIS_DB` AFTER module import. A module-level
+    `from popoto.redis_db import POPOTO_REDIS_DB` would capture the pre-
+    patch production client — always look up the module attribute.
+    """
+    import popoto.redis_db as _rdb
+
+    return _rdb.POPOTO_REDIS_DB
+
+
+@pytest.fixture(autouse=True)
+def _clear_cooldown_keys():
+    """Purge any lingering cooldown keys between tests."""
+    db = _db()
+    for key in db.scan_iter("watchdog:steer_cooldown:*"):
+        db.delete(key)
+    yield
+    db = _db()
+    for key in db.scan_iter("watchdog:steer_cooldown:*"):
+        db.delete(key)
+
+
+@pytest.fixture()
+def test_session_id():
+    sid = f"watchdog-steer-{int(time.time() * 1000)}"
+    clear_steering_queue(sid)
+    yield sid
+    clear_steering_queue(sid)
+
+
+class TestCooldownAtomicity:
+    def test_first_call_pushes_steer(self, test_session_id):
+        assert (
+            _inject_watchdog_steer(
+                test_session_id,
+                "repetition",
+                "please stop looping",
+                cooldown_seconds=STEER_COOLDOWN,
+            )
+            is True
+        )
+        msgs = pop_all_steering_messages(test_session_id)
+        assert len(msgs) == 1
+        assert msgs[0]["text"] == "please stop looping"
+        assert msgs[0]["sender"] == "watchdog"
+
+    def test_second_call_suppressed_within_cooldown(self, test_session_id):
+        assert _inject_watchdog_steer(test_session_id, "repetition", "first") is True
+        assert _inject_watchdog_steer(test_session_id, "repetition", "second") is False
+        # Only one message on the queue
+        msgs = pop_all_steering_messages(test_session_id)
+        assert len(msgs) == 1
+        assert msgs[0]["text"] == "first"
+
+    def test_cooldown_key_is_reason_scoped(self, test_session_id):
+        """A repetition cooldown does NOT suppress an error_cascade steer."""
+        assert _inject_watchdog_steer(test_session_id, "repetition", "rep-1") is True
+        # Different reason → independent cooldown slot
+        assert _inject_watchdog_steer(test_session_id, "error_cascade", "cascade-1") is True
+        # Different reason → independent cooldown slot
+        assert (
+            _inject_watchdog_steer(
+                test_session_id, "token_alert", "budget-1", cooldown_seconds=TOKEN_ALERT_COOLDOWN
+            )
+            is True
+        )
+        msgs = pop_all_steering_messages(test_session_id)
+        assert len(msgs) == 3
+        assert {m["text"] for m in msgs} == {"rep-1", "cascade-1", "budget-1"}
+
+    def test_cooldown_key_uses_set_nx_ex(self, test_session_id):
+        """Cooldown key is set with a TTL (atomic contract).
+
+        We verify by calling _inject_watchdog_steer and then immediately
+        reading the TTL on the same connection — same test, same tx, no
+        inter-test Redis flush.
+        """
+        # First call sets the cooldown key.
+        assert _inject_watchdog_steer(test_session_id, "repetition", "hi") is True
+        key = f"watchdog:steer_cooldown:repetition:{test_session_id}"
+        db = _db()
+        # Key must exist immediately after set.
+        assert db.exists(key) == 1
+        ttl = db.ttl(key)
+        # Redis ttl() returns -2 if key doesn't exist, -1 if no TTL, >=0 otherwise.
+        # A positive TTL confirms that SET applied `ex=cooldown_seconds`.
+        assert ttl > 0
+
+
+class TestSenderAttribution:
+    def test_sender_is_watchdog(self, test_session_id):
+        _inject_watchdog_steer(test_session_id, "repetition", "loop!")
+        msgs = pop_all_steering_messages(test_session_id)
+        assert msgs[0]["sender"] == "watchdog"
+
+    def test_token_alert_message_carries_sender(self, test_session_id):
+        _inject_watchdog_steer(
+            test_session_id,
+            "token_alert",
+            "budget",
+            cooldown_seconds=TOKEN_ALERT_COOLDOWN,
+        )
+        msgs = pop_all_steering_messages(test_session_id)
+        assert msgs[0]["sender"] == "watchdog"
+
+
+class TestFeatureGate:
+    def test_disabled_env_suppresses(self, test_session_id, monkeypatch):
+        monkeypatch.setenv("WATCHDOG_AUTO_STEER_ENABLED", "false")
+        assert _inject_watchdog_steer(test_session_id, "repetition", "nope") is False
+        msgs = pop_all_steering_messages(test_session_id)
+        assert msgs == []
+
+    def test_enabled_when_unset(self, test_session_id, monkeypatch):
+        monkeypatch.delenv("WATCHDOG_AUTO_STEER_ENABLED", raising=False)
+        assert _inject_watchdog_steer(test_session_id, "repetition", "yes") is True
+
+
+class TestFailQuiet:
+    def test_redis_error_is_logged_not_raised(self, test_session_id, monkeypatch):
+        """Redis failures bubble up as a quiet False, not an exception."""
+        from monitoring import session_watchdog
+
+        class FakeDB:
+            def set(self, *a, **kw):
+                raise RuntimeError("redis down")
+
+        import popoto.redis_db as popoto_db_mod
+
+        monkeypatch.setattr(popoto_db_mod, "POPOTO_REDIS_DB", FakeDB())
+        # The import inside _inject_watchdog_steer is scoped — monkeypatch
+        # just the attribute so the fresh import picks up our fake.
+        result = session_watchdog._inject_watchdog_steer(test_session_id, "repetition", "boom")
+        assert result is False
+
+    def test_steering_push_error_is_logged_not_raised(self, test_session_id, monkeypatch):
+        """If push_steering_message raises, helper returns False quietly."""
+        # Force cooldown slot open (no prior key), then make push_steering_message fail.
+        import agent.steering as steering_mod
+
+        def boom(*a, **kw):
+            raise RuntimeError("steering broken")
+
+        monkeypatch.setattr(steering_mod, "push_steering_message", boom)
+        assert _inject_watchdog_steer(test_session_id, "repetition", "fail") is False

--- a/tests/unit/test_watchdog_token_alert.py
+++ b/tests/unit/test_watchdog_token_alert.py
@@ -1,0 +1,159 @@
+"""Unit tests for the token-threshold alert in session_watchdog (issue #1128).
+
+The watchdog reads `AgentSession.total_input_tokens + total_output_tokens`
+and steers when the sum crosses `TOKEN_ALERT_THRESHOLD` on a `running`
+session. The watchdog is READ-ONLY for these fields — writes happen in
+the worker process via `accumulate_session_tokens`.
+
+Validates:
+- Crossing the threshold on a `running` session triggers one steer.
+- Below-threshold sessions do NOT trigger.
+- Non-running sessions do NOT trigger (token alert is for live sessions).
+- Cooldown key is reason-scoped (`token_alert`) and holds for
+  `TOKEN_ALERT_COOLDOWN` seconds.
+- The message carries both the dollar cost and the token count verbatim.
+- Watchdog never writes the token fields (read-only contract).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent.steering import clear_steering_queue, pop_all_steering_messages
+from monitoring.session_watchdog import (
+    TOKEN_ALERT_THRESHOLD,
+    assess_session_health,
+)
+
+
+def _db():
+    import popoto.redis_db as _rdb
+
+    return _rdb.POPOTO_REDIS_DB
+
+
+@pytest.fixture(autouse=True)
+def _clear_cooldown_keys():
+    """Clear cooldown keys between tests."""
+    db = _db()
+    for key in db.scan_iter("watchdog:steer_cooldown:*"):
+        db.delete(key)
+    yield
+    db = _db()
+    for key in db.scan_iter("watchdog:steer_cooldown:*"):
+        db.delete(key)
+
+
+def _session(
+    session_id: str,
+    status: str,
+    in_toks: int,
+    out_toks: int,
+    cost: float = 1.23,
+    updated_at=None,
+    started_at=None,
+):
+    """Build a lightweight session-like object for assess_session_health."""
+    import time
+
+    now = time.time()
+    return SimpleNamespace(
+        session_id=session_id,
+        agent_session_id=f"as-{session_id}",
+        status=status,
+        project_key="tst-tok",
+        chat_id="test-chat",
+        updated_at=updated_at or now,
+        started_at=started_at or (now - 100),
+        total_input_tokens=in_toks,
+        total_output_tokens=out_toks,
+        total_cost_usd=cost,
+        tool_call_count=0,
+    )
+
+
+class TestTokenThresholdTriggers:
+    def test_crossing_threshold_on_running_triggers_steer(self):
+        sid = "tok-alert-1"
+        clear_steering_queue(sid)
+        s = _session(sid, "running", TOKEN_ALERT_THRESHOLD // 2, TOKEN_ALERT_THRESHOLD // 2 + 10)
+        # With read_recent_tool_calls returning [], repetition and cascade
+        # cannot fire, so only the token branch is exercised.
+        with patch("monitoring.session_watchdog.read_recent_tool_calls", return_value=[]):
+            result = assess_session_health(s)
+        assert any("Token budget" in issue for issue in result["issues"])
+        msgs = pop_all_steering_messages(sid)
+        assert len(msgs) == 1
+        assert "Token budget exceeded" in msgs[0]["text"]
+        assert msgs[0]["sender"] == "watchdog"
+
+    def test_below_threshold_does_not_trigger(self):
+        sid = "tok-alert-2"
+        clear_steering_queue(sid)
+        s = _session(sid, "running", 1000, 500)  # way below threshold
+        with patch("monitoring.session_watchdog.read_recent_tool_calls", return_value=[]):
+            result = assess_session_health(s)
+        assert not any("Token budget" in issue for issue in result["issues"])
+        msgs = pop_all_steering_messages(sid)
+        assert msgs == []
+
+    def test_non_running_status_does_not_trigger(self):
+        """Dormant / paused / completed should NOT get token-alert steers."""
+        for status in ("dormant", "paused", "completed", "failed"):
+            sid = f"tok-alert-{status}"
+            clear_steering_queue(sid)
+            s = _session(sid, status, TOKEN_ALERT_THRESHOLD, TOKEN_ALERT_THRESHOLD)
+            with patch("monitoring.session_watchdog.read_recent_tool_calls", return_value=[]):
+                assess_session_health(s)
+            msgs = pop_all_steering_messages(sid)
+            assert msgs == [], f"status={status} should not steer"
+
+
+class TestTokenAlertCooldown:
+    def test_duplicate_fire_suppressed(self):
+        sid = "tok-alert-dup"
+        clear_steering_queue(sid)
+        s = _session(sid, "running", TOKEN_ALERT_THRESHOLD, 100)
+        with patch("monitoring.session_watchdog.read_recent_tool_calls", return_value=[]):
+            assess_session_health(s)
+            assess_session_health(s)  # second tick within cooldown
+        msgs = pop_all_steering_messages(sid)
+        assert len(msgs) == 1  # cooldown absorbed the second call
+
+
+class TestReadOnlyContract:
+    def test_watchdog_does_not_mutate_token_fields(self):
+        sid = "tok-alert-readonly"
+        clear_steering_queue(sid)
+        s = _session(sid, "running", TOKEN_ALERT_THRESHOLD, 100, cost=2.0)
+        before = (
+            s.total_input_tokens,
+            s.total_output_tokens,
+            s.total_cost_usd,
+        )
+        with patch("monitoring.session_watchdog.read_recent_tool_calls", return_value=[]):
+            assess_session_health(s)
+        after = (
+            s.total_input_tokens,
+            s.total_output_tokens,
+            s.total_cost_usd,
+        )
+        assert before == after, "watchdog must not mutate token fields"
+
+
+class TestMessageFormatting:
+    def test_message_carries_cost_and_tokens(self):
+        sid = "tok-alert-msg"
+        clear_steering_queue(sid)
+        s = _session(sid, "running", TOKEN_ALERT_THRESHOLD, 0, cost=9.99)
+        with patch("monitoring.session_watchdog.read_recent_tool_calls", return_value=[]):
+            assess_session_health(s)
+        msgs = pop_all_steering_messages(sid)
+        assert len(msgs) == 1
+        text = msgs[0]["text"]
+        assert "$9.99" in text
+        # Tokens are formatted with a thousands separator
+        assert f"{TOKEN_ALERT_THRESHOLD:,}" in text

--- a/tests/unit/test_worker_idle_sweeper.py
+++ b/tests/unit/test_worker_idle_sweeper.py
@@ -1,0 +1,220 @@
+"""Unit tests for worker/idle_sweeper.py (issue #1128).
+
+The sweeper targets persistent Claude SDK clients on dormant sessions and
+tears them down before the ~48h silent-death window (#1104). Tests cover
+the status filter, dormancy-age filter, registry teardown, the
+`sdk_connection_torn_down_at` marker, and the fail-quiet contract.
+
+These tests use a `FakeClient` with an awaitable `close()` method and
+mutate `agent.sdk_client._active_clients` directly — that dict is the
+real process-local registry, which is correct for this test because the
+sweeper reads it by import.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from agent import sdk_client
+from models.agent_session import AgentSession
+from worker import idle_sweeper
+from worker.idle_sweeper import IDLE_TEARDOWN_THRESHOLD, TEARDOWN_STATUSES, _sweep_once
+
+
+class FakeClient:
+    def __init__(self):
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _clear_active_clients():
+    """Reset the active-clients registry between tests."""
+    sdk_client._active_clients.clear()
+    yield
+    sdk_client._active_clients.clear()
+
+
+def _make_session(session_id: str, status: str, updated_at: datetime):
+    """Build and persist an AgentSession with a specific `updated_at`.
+
+    `updated_at` has `auto_now=True` on the model, so a plain save() would
+    overwrite our explicit value with the current timestamp. We pass
+    `skip_auto_now=True` to Popoto so the dormancy-age test fixtures hold.
+    """
+    s = AgentSession(
+        session_id=session_id,
+        project_key="tst-sweep",
+        agent_session_id=f"as-{session_id}",
+        status=status,
+        updated_at=updated_at,
+    )
+    s.save(skip_auto_now=True)
+    return s
+
+
+class TestStatusFilter:
+    @pytest.mark.asyncio
+    async def test_dormant_session_older_than_threshold_is_torn_down(self):
+        sid = "sweep-dormant"
+        client = FakeClient()
+        sdk_client._active_clients[sid] = client
+        updated = datetime.now(UTC) - timedelta(seconds=IDLE_TEARDOWN_THRESHOLD + 3600)
+        _make_session(sid, "dormant", updated)
+
+        torn_down = await _sweep_once()
+
+        assert torn_down == 1
+        assert client.closed
+        assert sid not in sdk_client._active_clients
+        reloaded = list(AgentSession.query.filter(session_id=sid))[0]
+        assert reloaded.sdk_connection_torn_down_at is not None
+
+    @pytest.mark.asyncio
+    async def test_running_session_is_skipped(self):
+        sid = "sweep-running"
+        client = FakeClient()
+        sdk_client._active_clients[sid] = client
+        updated = datetime.now(UTC) - timedelta(seconds=IDLE_TEARDOWN_THRESHOLD + 3600)
+        _make_session(sid, "running", updated)
+
+        torn_down = await _sweep_once()
+
+        assert torn_down == 0
+        assert not client.closed
+        assert sid in sdk_client._active_clients
+
+    @pytest.mark.asyncio
+    async def test_paused_session_is_torn_down_when_idle(self):
+        sid = "sweep-paused"
+        client = FakeClient()
+        sdk_client._active_clients[sid] = client
+        updated = datetime.now(UTC) - timedelta(seconds=IDLE_TEARDOWN_THRESHOLD + 3600)
+        _make_session(sid, "paused", updated)
+
+        torn_down = await _sweep_once()
+        assert torn_down == 1
+        assert client.closed
+
+    @pytest.mark.asyncio
+    async def test_paused_circuit_session_is_torn_down_when_idle(self):
+        sid = "sweep-paused-circuit"
+        client = FakeClient()
+        sdk_client._active_clients[sid] = client
+        updated = datetime.now(UTC) - timedelta(seconds=IDLE_TEARDOWN_THRESHOLD + 3600)
+        _make_session(sid, "paused_circuit", updated)
+
+        torn_down = await _sweep_once()
+        assert torn_down == 1
+        assert client.closed
+
+
+class TestDormancyThreshold:
+    @pytest.mark.asyncio
+    async def test_dormant_below_threshold_is_skipped(self):
+        sid = "sweep-fresh-dormant"
+        client = FakeClient()
+        sdk_client._active_clients[sid] = client
+        # Only 1h dormant — well below 24h threshold
+        updated = datetime.now(UTC) - timedelta(seconds=3600)
+        _make_session(sid, "dormant", updated)
+
+        torn_down = await _sweep_once()
+        assert torn_down == 0
+        assert not client.closed
+        assert sid in sdk_client._active_clients
+
+
+class TestFailQuiet:
+    @pytest.mark.asyncio
+    async def test_close_raising_is_logged_but_registry_still_popped(self):
+        sid = "sweep-close-fails"
+
+        class BrokenClient:
+            async def close(self):
+                raise RuntimeError("already closed")
+
+        client = BrokenClient()
+        sdk_client._active_clients[sid] = client
+        updated = datetime.now(UTC) - timedelta(seconds=IDLE_TEARDOWN_THRESHOLD + 1)
+        _make_session(sid, "dormant", updated)
+
+        torn_down = await _sweep_once()
+        assert torn_down == 1
+        # Registry entry must still be popped
+        assert sid not in sdk_client._active_clients
+
+    @pytest.mark.asyncio
+    async def test_missing_session_is_quiet_skip(self):
+        """A registered client with no AgentSession record does not raise."""
+        sid = "sweep-orphan"
+        sdk_client._active_clients[sid] = FakeClient()
+        torn_down = await _sweep_once()
+        # No session record → sweep does NOT tear down (safe default).
+        assert torn_down == 0
+        assert sid in sdk_client._active_clients
+
+    @pytest.mark.asyncio
+    async def test_empty_registry_returns_zero(self):
+        # No active clients at all
+        torn_down = await _sweep_once()
+        assert torn_down == 0
+
+
+class TestFeatureGate:
+    @pytest.mark.asyncio
+    async def test_env_disable_is_noop(self, monkeypatch):
+        sid = "sweep-disabled"
+        client = FakeClient()
+        sdk_client._active_clients[sid] = client
+        updated = datetime.now(UTC) - timedelta(seconds=IDLE_TEARDOWN_THRESHOLD + 1)
+        _make_session(sid, "dormant", updated)
+
+        monkeypatch.setenv("WATCHDOG_IDLE_TEARDOWN_ENABLED", "false")
+        torn_down = await _sweep_once()
+        assert torn_down == 0
+        assert not client.closed
+
+
+class TestConcurrentModification:
+    @pytest.mark.asyncio
+    async def test_snapshot_iteration_safe(self):
+        """Adding to `_active_clients` during sweep must not raise."""
+        sid = "sweep-snap-1"
+        client = FakeClient()
+        sdk_client._active_clients[sid] = client
+        updated = datetime.now(UTC) - timedelta(seconds=IDLE_TEARDOWN_THRESHOLD + 1)
+        _make_session(sid, "dormant", updated)
+
+        # The sweeper takes a snapshot before iterating, so adding another
+        # entry mid-flight is safe.
+        async def add_during_sweep():
+            await asyncio.sleep(0)  # yield
+            sdk_client._active_clients["sweep-snap-2"] = FakeClient()
+
+        results = await asyncio.gather(_sweep_once(), add_during_sweep())
+        torn_down = results[0]
+        assert torn_down == 1
+        # The newly added entry should still be around (it was not in the snapshot).
+        assert "sweep-snap-2" in sdk_client._active_clients
+
+
+class TestConstants:
+    def test_teardown_statuses_are_the_three_documented(self):
+        assert TEARDOWN_STATUSES == frozenset({"dormant", "paused", "paused_circuit"})
+
+    def test_threshold_is_configurable(self, monkeypatch):
+        # Reimporting the module with the env override flips the constant.
+        monkeypatch.setenv("WATCHDOG_IDLE_TEARDOWN_THRESHOLD_SECONDS", "12345")
+        import importlib
+
+        reloaded = importlib.reload(idle_sweeper)
+        assert reloaded.IDLE_TEARDOWN_THRESHOLD == 12345
+        # Restore module to canonical state for downstream tests.
+        monkeypatch.delenv("WATCHDOG_IDLE_TEARDOWN_THRESHOLD_SECONDS", raising=False)
+        importlib.reload(idle_sweeper)

--- a/ui/app.py
+++ b/ui/app.py
@@ -272,6 +272,12 @@ def create_app() -> FastAPI:
             "priority": s.priority,
             "classification_type": s.classification_type,
             "is_stale": s.is_stale,
+            # Per-session token + cost accounting (issue #1128). Always
+            # emitted as numeric defaults (never None, never omitted).
+            "total_input_tokens": s.total_input_tokens,
+            "total_output_tokens": s.total_output_tokens,
+            "total_cache_read_tokens": s.total_cache_read_tokens,
+            "total_cost_usd": s.total_cost_usd,
             "children": [_session_to_json(c) for c in s.children],
             "events": [
                 {

--- a/ui/data/sdlc.py
+++ b/ui/data/sdlc.py
@@ -241,6 +241,14 @@ class PipelineProgress(BaseModel):
     classification_type: str | None = None
     is_stale: bool = False
 
+    # Per-session token + cost accounting (issue #1128).
+    # Always emitted (default 0 / 0.0) for forward-compat with existing
+    # JSON consumers — never None, never omitted.
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_cache_read_tokens: int = 0
+    total_cost_usd: float = 0.0
+
     # SDLC state
     stages: list[StageState] = []
     current_stage: str | None = None
@@ -586,6 +594,25 @@ def _session_to_pipeline(session) -> PipelineProgress:
         except (ValueError, TypeError):
             tool_call_count = None
 
+    # Per-session token + cost fields (issue #1128). Always coerced to
+    # numeric (0 / 0.0) so `/dashboard.json` never returns None here.
+    def _to_int(val, default: int = 0) -> int:
+        try:
+            return int(val or 0)
+        except (TypeError, ValueError):
+            return default
+
+    def _to_float(val, default: float = 0.0) -> float:
+        try:
+            return float(val or 0.0)
+        except (TypeError, ValueError):
+            return default
+
+    total_input_tokens = _to_int(getattr(session, "total_input_tokens", 0))
+    total_output_tokens = _to_int(getattr(session, "total_output_tokens", 0))
+    total_cache_read_tokens = _to_int(getattr(session, "total_cache_read_tokens", 0))
+    total_cost_usd = _to_float(getattr(session, "total_cost_usd", 0.0))
+
     # Resolve issue/PR links with a history fallback. When do-build /
     # do-issue run, they shell out to `gh` which emits the URL to stdout
     # but doesn't always make it back onto the AgentSession model fields.
@@ -632,6 +659,10 @@ def _session_to_pipeline(session) -> PipelineProgress:
         plan_url=_safe_str(session.plan_url),
         pr_url=pr_url,
         claude_session_uuid=_safe_str(getattr(session, "claude_session_uuid", None)),
+        total_input_tokens=total_input_tokens,
+        total_output_tokens=total_output_tokens,
+        total_cache_read_tokens=total_cache_read_tokens,
+        total_cost_usd=total_cost_usd,
     )
 
 

--- a/worker/__main__.py
+++ b/worker/__main__.py
@@ -379,6 +379,27 @@ async def _run_worker(projects: dict, dry_run: bool = False) -> None:
 
     notify_task.add_done_callback(_notify_task_done)
 
+    # Start idle SDK-client sweeper (issue #1128). Worker-internal because
+    # `_active_clients` is process-local — the session-watchdog (separate
+    # process) cannot reach the registry. See `worker/idle_sweeper.py`.
+    idle_sweep_task = None
+    try:
+        from worker.idle_sweeper import run_idle_sweep
+
+        idle_sweep_task = asyncio.create_task(run_idle_sweep(), name="idle-sweeper")
+
+        def _idle_sweep_done(t: asyncio.Task) -> None:
+            if t.cancelled():
+                return
+            exc = t.exception()
+            if exc is not None:
+                logger.error("Idle sweeper exited unexpectedly: %s", exc)
+
+        idle_sweep_task.add_done_callback(_idle_sweep_done)
+        logger.info("Idle SDK-client sweeper started")
+    except Exception as e:
+        logger.warning("Failed to start idle sweeper: %s", e)
+
     # Set up graceful shutdown
     shutdown_event = asyncio.Event()
 
@@ -449,6 +470,14 @@ async def _run_worker(projects: dict, dry_run: bool = False) -> None:
         reflection_task.cancel()
         try:
             await reflection_task
+        except asyncio.CancelledError:
+            pass
+
+    # Cancel idle-sweeper (issue #1128)
+    if idle_sweep_task is not None:
+        idle_sweep_task.cancel()
+        try:
+            await idle_sweep_task
         except asyncio.CancelledError:
             pass
 

--- a/worker/idle_sweeper.py
+++ b/worker/idle_sweeper.py
@@ -41,9 +41,7 @@ logger = logging.getLogger(__name__)
 # Dormancy age (seconds) required before we tear down an SDK client. Default
 # 86400 (24h) sits comfortably inside the ~48h silent-death window with
 # plenty of safety margin.
-IDLE_TEARDOWN_THRESHOLD = int(
-    os.environ.get("WATCHDOG_IDLE_TEARDOWN_THRESHOLD_SECONDS", "86400")
-)
+IDLE_TEARDOWN_THRESHOLD = int(os.environ.get("WATCHDOG_IDLE_TEARDOWN_THRESHOLD_SECONDS", "86400"))
 # Sweep interval (seconds). Default 1800 (30 min) — idle teardown does not
 # need to be real-time; the only deadline is the 48h Anthropic kill.
 IDLE_SWEEP_INTERVAL = int(os.environ.get("WATCHDOG_IDLE_SWEEP_INTERVAL", "1800"))

--- a/worker/idle_sweeper.py
+++ b/worker/idle_sweeper.py
@@ -1,0 +1,228 @@
+"""Worker-internal idle-SDK-client sweeper (issue #1128).
+
+Anthropic's Claude Agent SDK holds a persistent `ClaudeSDKClient` connection
+across turns on the **SDK path** (`agent.sdk_client.get_response_via_sdk`).
+Fleet-ops research (#1104) established that these connections die silently
+after roughly 48 hours of idle, so a session that waits 2+ days for a
+human reply may be non-functional when resumed. The harness path
+(`get_response_via_harness`) is unaffected — it spawns a short-lived
+`claude -p` subprocess per turn and has nothing to go stale.
+
+Solution: proactively tear down persistent SDK clients on dormant sessions
+before the 48h window. On the next query the SDK rebuilds a fresh client
+and resumes conversation state from the stored `claude_session_uuid` via
+`--resume`. No reconnect logic is needed.
+
+**Process-locality contract**: the `_active_clients` registry lives in the
+worker process. This sweeper runs INSIDE that process (started by
+`worker/__main__.py`). The session-watchdog is a separate process and must
+not touch `_active_clients`.
+
+Status filter (explicit — issue #1128 C3): target
+``{dormant, paused, paused_circuit}``. Exclude `running`, `pending`,
+`waiting_for_children`, `superseded`, and all terminal statuses.
+
+Tune via env:
+    WATCHDOG_IDLE_TEARDOWN_ENABLED     — default on; set to 0/false/no to disable.
+    WATCHDOG_IDLE_SWEEP_INTERVAL       — seconds between sweeps (default 1800 = 30 min).
+    WATCHDOG_IDLE_TEARDOWN_THRESHOLD_SECONDS — dormancy age to trigger teardown (default 86400 = 24h).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import UTC, datetime
+
+logger = logging.getLogger(__name__)
+
+# === Teardown configuration ===
+# Dormancy age (seconds) required before we tear down an SDK client. Default
+# 86400 (24h) sits comfortably inside the ~48h silent-death window with
+# plenty of safety margin.
+IDLE_TEARDOWN_THRESHOLD = int(
+    os.environ.get("WATCHDOG_IDLE_TEARDOWN_THRESHOLD_SECONDS", "86400")
+)
+# Sweep interval (seconds). Default 1800 (30 min) — idle teardown does not
+# need to be real-time; the only deadline is the 48h Anthropic kill.
+IDLE_SWEEP_INTERVAL = int(os.environ.get("WATCHDOG_IDLE_SWEEP_INTERVAL", "1800"))
+
+# Statuses for which a persistent SDK client is legitimately idle and safe
+# to tear down. Must match the 13-state reference in
+# `docs/features/session-lifecycle.md`.
+TEARDOWN_STATUSES = frozenset({"dormant", "paused", "paused_circuit"})
+
+
+def _env_flag_enabled(var_name: str, default: bool = True) -> bool:
+    """Return True unless the env var is explicitly falsy.
+
+    Accepts the same conventions as the other issue-#1128 gates:
+    case-insensitive `"0"`, `"false"`, or `"no"` disable the feature.
+    """
+    raw = os.environ.get(var_name)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in {"0", "false", "no"}
+
+
+def _to_timestamp(val) -> float | None:
+    """Coerce datetime or numeric to a Unix timestamp. None passes through."""
+    if val is None:
+        return None
+    if isinstance(val, datetime):
+        if val.tzinfo is None:
+            val = val.replace(tzinfo=UTC)
+        return val.timestamp()
+    if isinstance(val, (int, float)):
+        return float(val)
+    return None
+
+
+async def _sweep_once() -> int:
+    """Run one sweep pass over the active-client registry.
+
+    Iterates a **snapshot** of `_active_clients` (never the live dict — a
+    concurrent query might be registering or popping an entry). For each
+    (session_id, client), load the matching AgentSession, filter on the
+    allowed teardown statuses AND dormancy age, then tear down:
+
+      1. `await client.close()` — idempotent; wrapped in try/except.
+      2. `_active_clients.pop(session_id, None)` — safe on missing key.
+      3. Set `AgentSession.sdk_connection_torn_down_at = now`.
+
+    Returns the count of clients torn down this pass (useful for logging
+    and tests).
+    """
+    if not _env_flag_enabled("WATCHDOG_IDLE_TEARDOWN_ENABLED"):
+        logger.debug("[idle-sweeper] disabled via WATCHDOG_IDLE_TEARDOWN_ENABLED")
+        return 0
+
+    # Local import to avoid circular dependency (sdk_client.py is imported
+    # at session time; keeping the registry hook out of module-init order
+    # lets tests isolate the sweeper without spinning up the SDK path).
+    try:
+        from agent.sdk_client import _active_clients
+    except Exception as e:
+        logger.warning("[idle-sweeper] cannot import _active_clients registry: %s", e)
+        return 0
+
+    if not _active_clients:
+        return 0
+
+    # Snapshot — protects against concurrent mutation during iteration.
+    snapshot = list(_active_clients.items())
+    now_ts = datetime.now(UTC).timestamp()
+    torn_down = 0
+
+    try:
+        from models.agent_session import AgentSession
+    except Exception as e:
+        logger.warning("[idle-sweeper] cannot import AgentSession: %s", e)
+        return 0
+
+    for session_id, client in snapshot:
+        try:
+            sessions = list(AgentSession.query.filter(session_id=session_id))
+            if not sessions:
+                logger.debug(
+                    "[idle-sweeper] no AgentSession for session_id=%s; leaving client alone",
+                    session_id,
+                )
+                continue
+            sessions.sort(key=lambda s: s.created_at or 0, reverse=True)
+            session = sessions[0]
+            status_val = getattr(session, "status", None)
+            if status_val not in TEARDOWN_STATUSES:
+                continue
+
+            # Use updated_at as the dormancy clock. Fall back to
+            # started_at, then created_at — always in that order because
+            # `updated_at` is the last-activity signal. If all three are
+            # unset, skip: we have no way to know how long this client
+            # has been idle.
+            ref_ts = (
+                _to_timestamp(session.updated_at)
+                or _to_timestamp(getattr(session, "started_at", None))
+                or _to_timestamp(getattr(session, "created_at", None))
+            )
+            if ref_ts is None:
+                continue
+            idle_seconds = now_ts - ref_ts
+            if idle_seconds < IDLE_TEARDOWN_THRESHOLD:
+                continue
+
+            # Teardown. `client.close()` is idempotent; if a concurrent
+            # query already closed it, the call is a no-op.
+            try:
+                if client is not None and hasattr(client, "close"):
+                    close_result = client.close()
+                    if asyncio.iscoroutine(close_result):
+                        await close_result
+            except Exception as close_err:
+                logger.warning(
+                    "[idle-sweeper] client.close() failed for %s: %s",
+                    session_id,
+                    close_err,
+                )
+
+            # Pop from registry (safe on already-removed key).
+            _active_clients.pop(session_id, None)
+
+            # Record teardown on the AgentSession record (best-effort).
+            try:
+                session.sdk_connection_torn_down_at = datetime.now(UTC)
+                session.save(update_fields=["sdk_connection_torn_down_at"])
+            except Exception as save_err:
+                logger.warning(
+                    "[idle-sweeper] save() failed for %s: %s",
+                    session_id,
+                    save_err,
+                )
+
+            torn_down += 1
+            logger.info(
+                "[idle-sweeper] Torn down SDK client for %s (status=%s, idle=%.0fh)",
+                session_id,
+                status_val,
+                idle_seconds / 3600.0,
+            )
+        except Exception as e:
+            logger.warning(
+                "[idle-sweeper] Unexpected error for %s: %s",
+                session_id,
+                e,
+            )
+
+    if torn_down:
+        logger.info("[idle-sweeper] sweep complete: %d client(s) torn down", torn_down)
+    return torn_down
+
+
+async def run_idle_sweep(interval: int | None = None) -> None:
+    """Run the idle-sweeper loop indefinitely.
+
+    Sleeps `interval` seconds between sweeps (default `IDLE_SWEEP_INTERVAL`).
+    Any exception from `_sweep_once` is caught and logged so a transient
+    Redis or SDK failure cannot kill the loop. Respond to cancellation
+    cooperatively so `worker/__main__.py` can shut the task down cleanly.
+    """
+    sweep_interval = interval or IDLE_SWEEP_INTERVAL
+    logger.info(
+        "[idle-sweeper] started (interval=%ds, threshold=%ds)",
+        sweep_interval,
+        IDLE_TEARDOWN_THRESHOLD,
+    )
+    while True:
+        try:
+            await _sweep_once()
+        except asyncio.CancelledError:
+            logger.info("[idle-sweeper] cancelled, exiting loop")
+            raise
+        except Exception as e:
+            logger.error("[idle-sweeper] sweep error: %s", e, exc_info=True)
+        try:
+            await asyncio.sleep(sweep_interval)
+        except asyncio.CancelledError:
+            logger.info("[idle-sweeper] cancelled during sleep, exiting loop")
+            raise


### PR DESCRIPTION
## Summary

Three related-but-separable reliability features addressing issue #1128 — all layered on top of the existing session-watchdog and worker without changing the base detection signals.

1. **Per-session token + cost accounting** (two execution paths → one accumulator)
   - `AgentSession` gains `total_input_tokens`, `total_output_tokens`, `total_cache_read_tokens`, `total_cost_usd`.
   - New `agent/sdk_client.py::accumulate_session_tokens` helper is called from both the SDK `ResultMessage` handler AND from `get_response_via_harness` (as a side effect), so production PM / Dev / Teammate sessions now record accurate spend (fixes the B3 blocker — harness path previously reported 0).
   - `_run_harness_subprocess` extracts `usage` + `total_cost_usd` off the `result` event and threads them back through a new 5-tuple return shape. Public `get_response_via_harness` return signature stays `str`.
   - The four token fields surface on `/dashboard.json` as numeric defaults (never None).

2. **Automatic loop-break steering** (detection → actuation)
   - `detect_repetition` and `detect_error_cascade` no longer log and return — they enqueue a targeted steering message via `push_steering_message(sender="watchdog")`.
   - New `_inject_watchdog_steer(session_id, reason, message, cooldown_seconds)` helper guards against flooding with a per-reason atomic Redis `SET NX EX` cooldown. Repetition / error-cascade / token-alert each get their own cooldown key.
   - Token-threshold alert: on a `running` session whose cumulative `input + output` tokens ≥ `TOKEN_ALERT_THRESHOLD` (default 5M), the watchdog steers with `reason="token_alert"`. The watchdog is READ-ONLY on token fields (writers are worker-process).
   - Three feature gates: `WATCHDOG_AUTO_STEER_ENABLED`, `WATCHDOG_TOKEN_TRACKING_ENABLED`, `WATCHDOG_IDLE_TEARDOWN_ENABLED`.

3. **Worker-internal idle SDK-client teardown** (#1104 silent death)
   - New `worker/idle_sweeper.py::run_idle_sweep` async task, started from `worker/__main__.py` alongside the reflection and notify loops.
   - Snapshots `agent.sdk_client._active_clients`, filters on `{dormant, paused, paused_circuit}` AND dormancy age > `IDLE_TEARDOWN_THRESHOLD` (24h), calls `client.close()` idempotently, pops the registry entry, and sets `AgentSession.sdk_connection_torn_down_at`.
   - Harness-path sessions are unaffected (nothing in `_active_clients`).
   - Process-locality is load-bearing: the session-watchdog process never touches `_active_clients`.

## Changes

- `models/agent_session.py` — five new fields (four token counters + `sdk_connection_torn_down_at`).
- `agent/sdk_client.py` — `accumulate_session_tokens` helper, `_usage_field` shape-adapter, SDK path wiring, 5-tuple harness return, harness-path side-effect accumulator call.
- `monitoring/session_watchdog.py` — `_inject_watchdog_steer` with atomic `SET NX EX` cooldown, wiring from repetition / cascade / token-threshold branches, updated module docstring.
- `worker/idle_sweeper.py` — **new** module with `run_idle_sweep` + `_sweep_once`, snapshot-safe iteration, fail-quiet `close()`.
- `worker/__main__.py` — spawn and cancel the idle-sweeper task.
- `ui/data/sdlc.py` + `ui/app.py` — four new token fields on `PipelineProgress` + `/dashboard.json` output.
- Five new test files (50 tests) + updates to `test_session_watchdog.py` (+3 tests) and `test_sdk_client_image_sentinel.py` (5-tuple mocks).
- Five feature-doc updates (`session-watchdog.md`, `session-watchdog-reliability.md`, `session-steering.md`, `bridge-worker-architecture.md`, `bridge-self-healing.md`).

## Testing

- [x] Unit tests: 252 passing across all watchdog / harness / sweeper / token-tracking files.
- [x] Plan verification table: all implementation claims satisfied (3 checks gave macOS-grep false-negatives the plan's `grep -P` regex — manually verified each passes).
- [x] Format clean: `python -m ruff format --check .` returns 0.
- [x] Documentation gate: `scripts/validate_docs_changed.py` passes.
- Pre-existing test failures unrelated to this PR (missing `config/reflections.yaml` and an `_build_reply` kwarg regression in `test_email_bridge.py`) were observed but left untouched.

## Definition of Done

- [x] Built: all 11 plan tasks implemented.
- [x] Tested: new tests pass; touched existing tests pass.
- [x] Documented: five feature docs updated with env-var tables, process-locality contract, and steering sender semantics.
- [x] Quality: format check passes.

Closes #1128