### PR TITLE
Wire session.model through harness CLI + harden PM final-delivery drafter (#1129)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -156,6 +156,18 @@ OLLAMA_URL=http://localhost:11434
 OLLAMA_VISION_MODEL=llama3.2-vision:11b
 
 # =============================================================================
+# Session Model Routing
+# =============================================================================
+
+# Codebase default for Claude sessions (PM, Teammate, Dev) when AgentSession.model
+# is not explicitly set. Precedence cascade (closest to LLM call wins):
+#   1. AgentSession.model (per-session, via `valor-session create --model <name>`)
+#   2. MODELS__SESSION_DEFAULT_MODEL (this var — machine-local override)
+#   3. codebase default ("opus")
+# Short aliases: opus, sonnet, haiku. Full names also accepted.
+# MODELS__SESSION_DEFAULT_MODEL=opus
+
+# =============================================================================
 # Email Bridge (IMAP/SMTP)
 # =============================================================================
 

--- a/agent/sdk_client.py
+++ b/agent/sdk_client.py
@@ -1631,6 +1631,7 @@ async def get_response_via_harness(
     prior_uuid: str | None = None,
     session_id: str | None = None,
     full_context_message: str | None = None,
+    model: str | None = None,
     on_sdk_started: Callable[[int], None] | None = None,
     on_stdout_event: Callable[[], None] | None = None,
 ) -> str:
@@ -1670,6 +1671,12 @@ async def get_response_via_harness(
         prior_uuid: Claude Code session UUID from a prior turn (enables --resume).
         session_id: Bridge/Telegram session ID for UUID storage after the turn.
         full_context_message: Full-context first-turn message for stale-UUID fallback.
+        model: Short alias (``opus``/``sonnet``/``haiku``) or full Claude model
+            name to pin this turn to. When truthy, ``--model <value>`` is
+            injected into ``harness_cmd`` so the Claude CLI honors the choice.
+            When None/empty, the CLI uses its own default. Part of the per-
+            session model routing cascade (see
+            ``agent/session_executor.py::_resolve_session_model``).
     """
     # Validate prior_uuid format; treat empty or invalid as None
     if prior_uuid and not _UUID_PATTERN.match(prior_uuid):
@@ -1680,6 +1687,18 @@ async def get_response_via_harness(
 
     if harness_cmd is None:
         harness_cmd = list(_HARNESS_COMMANDS["claude-cli"])
+    else:
+        # Defensive copy — callers may hand us a shared constant (e.g. test
+        # fixtures sharing a module-level list). We must not mutate their
+        # list when appending --model below.
+        harness_cmd = list(harness_cmd)
+
+    # Inject per-session model when caller supplied one. --model must live
+    # inside harness_cmd so it precedes the positional message (and any
+    # --resume <uuid>) in the final argv assembly below.
+    if model:
+        harness_cmd.extend(["--model", model])
+        logger.info(f"[harness] Using --model {model} for session_id={session_id}")
 
     # Build subprocess env: inherit current env, merge extras, strip API key
     proc_env = dict(os.environ)

--- a/agent/session_completion.py
+++ b/agent/session_completion.py
@@ -69,6 +69,7 @@ def _build_degraded_fallback(summary_context: str) -> str:
         return f"[drafter unavailable — pipeline completed] {context[:1500]}"
     return "[drafter unavailable — pipeline completed, see session history for details]"
 
+
 # Background tasks spawned by `_deliver_pipeline_completion`. Drained by the
 # worker shutdown sequence so in-flight completion turns either finish or are
 # cancelled cleanly.
@@ -541,8 +542,7 @@ async def _deliver_pipeline_completion(
             pass1_failed = True
             pass1_failure_mode = "exception"
             logger.error(
-                "[completion-runner][DEGRADED] Pass 1 failure mode=exception "
-                "session_id=%s err=%s",
+                "[completion-runner][DEGRADED] Pass 1 failure mode=exception session_id=%s err=%s",
                 session_id,
                 harness_err,
                 exc_info=True,

--- a/agent/session_completion.py
+++ b/agent/session_completion.py
@@ -499,8 +499,11 @@ async def _deliver_pipeline_completion(
     # - Both passes pin model="opus" regardless of PM session's model.
     # - Ollama fallback for Anthropic-down path is deferred to #1137; until
     #   then, Pass 1 failure → visible degraded-fallback message.
+    # Sentinel init — must be overwritten by every path below (refined text,
+    # Pass 1 draft, or degraded fallback). D6(c) "never return empty" — any
+    # code path that reaches send_cb with this value is a bug.
     delivery_attempted = False
-    final_text = ""
+    final_text: str = "[completion-runner internal error — no final_text assigned]"
     cancelled = False
     try:
         from agent.session_executor import (  # noqa: PLC0415

--- a/agent/session_completion.py
+++ b/agent/session_completion.py
@@ -13,17 +13,61 @@ from models.session_lifecycle import TERMINAL_STATUSES as _TERMINAL_STATUSES
 
 logger = logging.getLogger(__name__)
 
-# PM final-delivery protocol (issue #1058).
+# PM final-delivery protocol (issue #1058 + D6 hardening from #1129).
 #
 # When the pipeline reaches a terminal state, the worker runs a dedicated
 # "compose final summary" turn and delivers the result directly via send_cb,
 # bypassing the nudge loop. See `docs/features/pm-final-delivery.md`.
-_COMPLETION_PROMPT = (
-    "The SDLC pipeline has finished. Context: {context}\n\n"
+#
+# D6 contract (from plan docs/plans/session-model-routing-fallback.md):
+#   - Always Opus on both passes (quality trumps cost for this one call).
+#   - 2-pass drafter: Pass 1 drafts, Pass 2 self-reviews / refines.
+#   - No-silent-fail: drafter failures log at ERROR + deliver a visible
+#     degraded fallback; Pass 2 failures log at WARNING + fall back to
+#     Pass 1's draft. The final_text is guaranteed non-empty before send_cb.
+#   - Always-finalize: `finalize_session(parent, "completed", ...)` runs in
+#     a `finally` block so the PM session reaches terminal state even when
+#     the drafter or delivery step misbehaves.
+#   - Ollama fallback: deferred to #1137. Until that ships, Anthropic-down
+#     manifests as a visible degraded-fallback message + ERROR log.
+#
+# Both prompts use a PREFIX + concatenation pattern (not `.format()`) so that
+# literal ``{`` / ``}`` characters in the embedded context or draft (e.g. a
+# dict repr or JSON snippet from a Dev session summary) do not crash the
+# prompt construction (ADV-1 fix).
+_COMPLETION_PROMPT_PREFIX = (
+    "The SDLC pipeline has finished. "
     "This is your final turn. Write a 2-3 sentence summary for the user covering "
     "what was accomplished and any notable outcomes. Do NOT use any special "
-    "markers or format instructions — just write the summary directly."
+    "markers or format instructions — just write the summary directly.\n\n"
+    "CONTEXT:\n"
 )
+
+_COMPLETION_REVIEW_PROMPT_PREFIX = (
+    "Below is a draft final-delivery message for the user. Review it against "
+    "these criteria and return a refined version:\n\n"
+    "1. SHORT — no wasted words. Cut anything that isn't load-bearing.\n"
+    "2. DENSE — maximum information per word. Preserve concrete outcomes.\n"
+    "3. THOUGHTFUL — phrase like a colleague writing with care, not a template.\n\n"
+    "Return ONLY the refined message. No preamble, no meta-commentary, no "
+    "markdown headers. Just the message as it should be sent.\n\n"
+    "DRAFT:\n"
+)
+
+
+def _build_degraded_fallback(summary_context: str) -> str:
+    """Compose a visible-but-explicit fallback when the drafter fails.
+
+    Satisfies D6(c) simultaneously: (a) non-empty, (b) visibly loud (operator
+    can see this was a degraded delivery), (c) preserves whatever context the
+    pipeline did gather. Used when Pass 1 fails, returns empty, or returns
+    the ``_HARNESS_NOT_FOUND_PREFIX`` sentinel. See #1137 for the Ollama-
+    backed recovery that will eventually replace this fallback.
+    """
+    context = (summary_context or "").strip()
+    if context:
+        return f"[drafter unavailable — pipeline completed] {context[:1500]}"
+    return "[drafter unavailable — pipeline completed, see session history for details]"
 
 # Background tasks spawned by `_deliver_pipeline_completion`. Drained by the
 # worker shutdown sequence so in-flight completion turns either finish or are
@@ -441,34 +485,151 @@ async def _deliver_pipeline_completion(
         logger.warning("[completion-runner] UUID lookup failed: %s", uuid_err)
         pm_uuid = None
 
-    prompt = _COMPLETION_PROMPT.format(context=summary_context[:3000])
+    # Build the Pass 1 prompt via concat (not .format()) so literal ``{`` / ``}``
+    # in summary_context (e.g. JSON snippets, dict reprs) cannot crash us (ADV-1).
+    prompt = _COMPLETION_PROMPT_PREFIX + (summary_context or "")[:3000]
+
+    # D6 v2: 2-pass drafter + no-silent-fail + always-finalize.
+    # - Pass 1 uses session_id=None (S-1): do NOT write the drafter's UUID
+    #   over the PM's claude_session_uuid. Drafter UUID is discarded.
+    # - Pass 2 uses prior_uuid=None, session_id=None (ADV-2): review prompt is
+    #   self-contained (Pass 1 draft embedded); resuming the PM session here
+    #   would pollute PM history with drafter + review turns.
+    # - Both passes pin model="opus" regardless of PM session's model.
+    # - Ollama fallback for Anthropic-down path is deferred to #1137; until
+    #   then, Pass 1 failure → visible degraded-fallback message.
+    delivery_attempted = False
+    final_text = ""
+    cancelled = False
+    try:
+        from agent.session_executor import (  # noqa: PLC0415
+            _HARNESS_NOT_FOUND_PREFIX,
+        )
+    except Exception:
+        # Defence in depth: fall back to the known literal if the import
+        # fails (e.g. during partial reloads in tests).
+        _HARNESS_NOT_FOUND_PREFIX = "Error: CLI harness not found"
 
     try:
-        try:
-            from agent.sdk_client import get_response_via_harness  # noqa: PLC0415
+        from agent.sdk_client import get_response_via_harness  # noqa: PLC0415
 
-            raw = await get_response_via_harness(
+        # --- Pass 1: Draft ---
+        draft_text: str = ""
+        pass1_failed = False
+        pass1_failure_mode = ""
+        try:
+            raw1 = await get_response_via_harness(
                 message=prompt,
                 working_dir=working_dir,
                 prior_uuid=pm_uuid,
-                session_id=session_id,
+                session_id=None,  # S-1: discard drafter UUID; don't pollute PM record
                 full_context_message=prompt,
+                model="opus",  # D6(a): always Opus on final-delivery drafter
+                # NOTE: When #1137 lands (Ollama credit-exhaust fallback for the
+                # harness), this call site is the priority consumer. On
+                # Anthropic-down, Ollama will back-fill instead of triggering
+                # the degraded-fallback branch below.
             )
-            final_text = (raw or "").strip()
+            draft_text = (raw1 or "").strip()
+            if not draft_text:
+                pass1_failed = True
+                pass1_failure_mode = "empty"
+            elif draft_text.startswith(_HARNESS_NOT_FOUND_PREFIX):
+                pass1_failed = True
+                pass1_failure_mode = "sentinel"
         except Exception as harness_err:
-            logger.warning(
-                "[completion-runner] Harness failed (%s) — delivering fallback summary",
+            pass1_failed = True
+            pass1_failure_mode = "exception"
+            logger.error(
+                "[completion-runner][DEGRADED] Pass 1 failure mode=exception "
+                "session_id=%s err=%s",
+                session_id,
                 harness_err,
-            )
-            final_text = ""
-
-        if not final_text:
-            final_text = summary_context.strip() or (
-                "The pipeline has completed. See session history for details."
+                exc_info=True,
             )
 
-        # Deliver.
+        if pass1_failed:
+            if pass1_failure_mode != "exception":
+                logger.error(
+                    "[completion-runner][DEGRADED] Pass 1 failure mode=%s session_id=%s",
+                    pass1_failure_mode,
+                    session_id,
+                )
+            # Best-effort metric: bump a daily counter so operators can detect
+            # a spike in degraded deliveries (e.g. when Anthropic is down).
+            try:
+                from popoto.redis_db import POPOTO_REDIS_DB  # noqa: PLC0415
+
+                counter_key = (
+                    f"completion_runner:degraded_fallback:daily:"
+                    f"{datetime.now(UTC).strftime('%Y%m%d')}"
+                )
+                POPOTO_REDIS_DB.incr(counter_key)
+                POPOTO_REDIS_DB.expire(counter_key, 604800)  # 7-day TTL
+            except Exception as metric_err:
+                logger.warning(
+                    "[completion-runner] Degraded-fallback metric emit failed: %s",
+                    metric_err,
+                )
+            final_text = _build_degraded_fallback(summary_context)
+        else:
+            # --- Pass 2: Self-Review / Refine ---
+            # Embed Pass 1's draft by concatenation (not .format()) so literal
+            # {/} in the draft (code snippets, JSON) don't crash us (ADV-1).
+            review_prompt = _COMPLETION_REVIEW_PROMPT_PREFIX + draft_text
+            refined_text: str = ""
+            pass2_failed = False
+            pass2_failure_mode = ""
+            try:
+                raw2 = await get_response_via_harness(
+                    message=review_prompt,
+                    working_dir=working_dir,
+                    prior_uuid=None,  # ADV-2: isolate from PM session history
+                    session_id=None,  # ADV-2: no UUID writeback
+                    full_context_message=None,
+                    model="opus",
+                )
+                refined_text = (raw2 or "").strip()
+                if not refined_text:
+                    pass2_failed = True
+                    pass2_failure_mode = "empty"
+                elif refined_text.startswith(_HARNESS_NOT_FOUND_PREFIX):
+                    pass2_failed = True
+                    pass2_failure_mode = "sentinel"
+            except Exception as refine_err:
+                pass2_failed = True
+                pass2_failure_mode = "exception"
+                logger.warning(
+                    "[completion-runner] Pass 2 exception session_id=%s err=%s — "
+                    "falling back to Pass 1 draft",
+                    session_id,
+                    refine_err,
+                    exc_info=True,
+                )
+
+            if pass2_failed:
+                if pass2_failure_mode == "sentinel":
+                    logger.error(
+                        "[completion-runner] Pass 2 returned _HARNESS_NOT_FOUND_PREFIX "
+                        "sentinel session_id=%s — falling back to Pass 1 draft",
+                        session_id,
+                    )
+                elif pass2_failure_mode == "empty":
+                    logger.warning(
+                        "[completion-runner] Pass 2 empty session_id=%s — "
+                        "falling back to Pass 1 draft",
+                        session_id,
+                    )
+                final_text = draft_text
+            else:
+                final_text = refined_text
+
+        # final_text is guaranteed non-empty at this point (either refined,
+        # Pass 1 draft, or degraded fallback). D6(c) "never return empty".
+
+        # --- Deliver ---
         if send_cb is not None and chat_id:
+            delivery_attempted = True
             try:
                 await send_cb(chat_id, final_text, telegram_message_id, parent)
                 logger.info(
@@ -477,6 +638,10 @@ async def _deliver_pipeline_completion(
                     len(final_text),
                 )
             except Exception as send_err:
+                # D6(c) v2: send_cb failure stays log-and-continue (no re-raise).
+                # Upstream retry ladder does not exist; re-raising would strand
+                # the session mid-flight. The "no silent fail" contract is
+                # enforced at the drafter layer, not the transport layer.
                 logger.error(
                     "[completion-runner] send_cb failed for %s: %s",
                     parent_id,
@@ -487,34 +652,13 @@ async def _deliver_pipeline_completion(
                 "[completion-runner] No send_cb or chat_id for %s; skipping delivery",
                 parent_id,
             )
-
-        # Stamp response_delivered_at and transition to completed. Runner owns
-        # this transition (Race 1 / Race 4 mitigation).
-        try:
-            parent.response_delivered_at = datetime.now(UTC)
-            parent.save(update_fields=["response_delivered_at", "updated_at"])
-        except Exception as stamp_err:
-            logger.warning(
-                "[completion-runner] Failed to stamp response_delivered_at: %s",
-                stamp_err,
-            )
-
-        try:
-            from models.session_lifecycle import finalize_session  # noqa: PLC0415
-
-            finalize_session(
-                parent, "completed", reason="pipeline complete: final summary delivered"
-            )
-        except Exception as finalize_err:
-            logger.error(
-                "[completion-runner] finalize_session(completed) failed for %s: %s",
-                parent_id,
-                finalize_err,
-            )
-
     except asyncio.CancelledError:
         # Shutdown during runner. Best-effort "interrupted" message with
         # flap-dedup (Risk 6), then re-raise to preserve asyncio semantics.
+        # Set `cancelled=True` so the finally block below skips both the
+        # response_delivered_at stamp (nothing was delivered) and
+        # finalize_session (the shutdown path owns that transition).
+        cancelled = True
         if send_cb is not None and chat_id and session_id:
             try:
                 await _send_interrupted_message(
@@ -523,6 +667,41 @@ async def _deliver_pipeline_completion(
             except Exception as int_err:  # pragma: no cover - best-effort
                 logger.warning("[completion-runner] interrupted send failed: %s", int_err)
         raise
+    finally:
+        # On cancellation, the except branch above has already emitted an
+        # "interrupted" message and is about to re-raise. Skip both stamping
+        # and finalization — the shutdown path owns those.
+        if not cancelled:
+            # ADV-2 gate: only stamp response_delivered_at when we actually
+            # tried to deliver. Preserves the existing "time the user
+            # received the final message" contract; a no-send_cb path
+            # leaves it unset.
+            if delivery_attempted:
+                try:
+                    parent.response_delivered_at = datetime.now(UTC)
+                    parent.save(update_fields=["response_delivered_at", "updated_at"])
+                except Exception as stamp_err:
+                    logger.warning(
+                        "[completion-runner] Failed to stamp response_delivered_at: %s",
+                        stamp_err,
+                    )
+
+            # D6(c) always-finalize: run regardless of drafter / delivery
+            # outcome so the PM session reaches a terminal state. Previously
+            # this lived inside the main try-block and silently got skipped
+            # when an earlier exception escaped.
+            try:
+                from models.session_lifecycle import finalize_session  # noqa: PLC0415
+
+                finalize_session(
+                    parent, "completed", reason="pipeline complete: final summary delivered"
+                )
+            except Exception as finalize_err:
+                logger.error(
+                    "[completion-runner] finalize_session(completed) failed for %s: %s",
+                    parent_id,
+                    finalize_err,
+                )
 
 
 def _resolve_working_dir_for_parent(parent: AgentSession) -> str:

--- a/agent/session_executor.py
+++ b/agent/session_executor.py
@@ -24,10 +24,34 @@ from agent.session_state import (
 )
 from agent.worktree_manager import WORKTREES_DIR, validate_workspace
 from config.enums import SessionType
+from config.settings import settings
 from models.agent_session import AgentSession
 from models.session_lifecycle import TERMINAL_STATUSES as _TERMINAL_STATUSES
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_session_model(session: AgentSession | None) -> str | None:
+    """D1 precedence cascade for session model.
+
+    Order (closest to LLM call wins):
+      1. ``session.model`` (explicit per-session, via
+         ``valor-session create --model <name>``)
+      2. ``settings.models.session_default_model`` (machine-local override,
+         env var ``MODELS__SESSION_DEFAULT_MODEL``)
+      3. codebase default ``"opus"`` (set on the pydantic Field default in
+         ``config/settings.py``)
+
+    Returns the resolved model alias (e.g. ``"opus"``, ``"sonnet"``), or
+    ``None`` if the cascade resolves to an empty string (operator-
+    misconfigured settings default to ``""``). ``None`` is treated by
+    ``get_response_via_harness()`` as "omit ``--model``, use CLI default."
+    """
+    explicit = getattr(session, "model", None) if session else None
+    if explicit:
+        return explicit
+    fallback = settings.models.session_default_model
+    return fallback or None
 
 
 def _tick_backstop_check_compaction(
@@ -1306,6 +1330,9 @@ async def _execute_agent_session(session: AgentSession) -> None:
 
         _harness_requeued = False
 
+        # D1 precedence cascade: session.model > settings > codebase default.
+        _effective_model = _resolve_session_model(agent_session)
+
         async def do_work() -> str:
             nonlocal _harness_requeued
             raw = await get_response_via_harness(
@@ -1315,6 +1342,7 @@ async def _execute_agent_session(session: AgentSession) -> None:
                 prior_uuid=_prior_uuid,
                 session_id=session.session_id,
                 full_context_message=_harness_input,
+                model=_effective_model,
                 # Two-tier no-progress detector callbacks (#1036). These route
                 # through messenger.notify_* wrappers so exceptions are caught
                 # and the queue-layer closures bump ORM fields on AgentSession.

--- a/config/settings.py
+++ b/config/settings.py
@@ -173,6 +173,15 @@ class ModelSettings(BaseModel):
         default="llama3.2-vision:11b",
         description="Ollama vision model for local image analysis (env: OLLAMA_VISION_MODEL)",
     )
+    session_default_model: str = Field(
+        default="opus",
+        description=(
+            "Fallback Claude model for sessions where AgentSession.model is None/empty. "
+            "Part of the precedence cascade: session.model > settings > codebase default 'opus'. "
+            "Short aliases (opus, sonnet, haiku) preferred; full names (claude-opus-4-7) also accepted. "
+            "Env: MODELS__SESSION_DEFAULT_MODEL."
+        ),
+    )
 
 
 class FeatureSettings(BaseModel):

--- a/docs/features/agent-session-model.md
+++ b/docs/features/agent-session-model.md
@@ -183,16 +183,121 @@ Only four fields change during continuation: `status` (reset to "pending"), `ini
 
 ## Per-Session Model Selection
 
-`model` (`Field(null=True)`) stores the Claude model name to use for a dev session (e.g., `"sonnet"`, `"opus"`).
-`None` inherits the environment or CLI default (backward-compatible — all pre-existing sessions have `model=None`).
+`model` (`Field(null=True)`) stores the Claude model alias (e.g. `"opus"`,
+`"sonnet"`, `"haiku"`) or full name (e.g. `"claude-opus-4-7"`) to use for this
+session. The value flows end-to-end to the `claude -p` subprocess via the
+CLI harness live path (not the dormant `ValorAgent → ClaudeAgentOptions` path
+from PR #909 — that wiring remains in place for unit-test fixtures but is
+unreachable in production).
 
-**How it flows:**
-1. PM calls `python -m tools.valor_session create --role dev --model sonnet --message "..."`.
-2. `_push_agent_session(model="sonnet")` stores the value on the `AgentSession` record.
-3. `sdk_client.get_agent_response_sdk()` reads `session.model` and passes it to `ValorAgent(model=...)`.
-4. `ValorAgent._create_options()` includes `model="sonnet"` in `ClaudeAgentOptions` when set.
+### Precedence Cascade (D1)
 
-See [pm-sdlc-decision-rules.md](pm-sdlc-decision-rules.md) for the PM's per-stage model selection table.
+The value that applies is the one explicitly set closest to the LLM call.
+When nothing explicit is set, the cascade falls back with codebase defaults
+at the bottom:
+
+1. **`AgentSession.model`** (per-session, explicit) — set via
+   `valor-session create --model <name>`, persisted on the record.
+2. **`settings.models.session_default_model`** (machine-local override) —
+   pydantic-settings field, env var `MODELS__SESSION_DEFAULT_MODEL`, sourced
+   from `~/Desktop/Valor/.env` (iCloud-synced).
+3. **Codebase default `"opus"`** — hard-coded as the pydantic `Field`
+   default in `config/settings.py::ModelSettings`.
+
+Implemented in `agent.session_executor._resolve_session_model()`:
+
+```python
+explicit = getattr(session, "model", None) if session else None
+if explicit:
+    return explicit
+fallback = settings.models.session_default_model
+return fallback or None
+```
+
+When the cascade resolves to `None` (operator set
+`MODELS__SESSION_DEFAULT_MODEL=""`), `get_response_via_harness` omits the
+`--model` flag and the Claude CLI uses its own default — graceful
+degradation rather than a hard error.
+
+### How It Flows
+
+1. PM or human calls
+   `python -m tools.valor_session create --role dev --model sonnet --message "..."`.
+2. `tools/valor_session.py::cmd_create` constructs the AgentSession via
+   `enqueue_agent_session(model="sonnet")`; the value is persisted on the
+   Redis record.
+3. Worker pops the session; `agent/session_executor.py::_execute_agent_session`
+   resolves the effective model via `_resolve_session_model(agent_session)`.
+4. `agent/sdk_client.py::get_response_via_harness(model=...)` appends
+   `["--model", <value>]` into `harness_cmd` (before positional `message`
+   and before any `--resume <uuid>`).
+5. Subprocess argv: `claude -p ... --model sonnet [--resume UUID] <message>`.
+6. The Claude CLI honors the flag and the session runs on the requested
+   model. INFO log `[harness] Using --model <value> for session_id=<id>`
+   confirms the resolved value each turn.
+
+### Override via `.env`
+
+Operators can flip the default on a per-machine basis:
+
+```bash
+# ~/Desktop/Valor/.env
+MODELS__SESSION_DEFAULT_MODEL=sonnet
+```
+
+Short aliases (`opus`/`sonnet`/`haiku`) are preferred; full version names
+(`claude-opus-4-7`) also accepted and passed verbatim to the CLI.
+
+### PM Final-Delivery Drafter (2-Pass, Always-Opus)
+
+The PM-to-CEO final-delivery drafter in
+`agent/session_completion.py::_deliver_pipeline_completion` is hardened as
+a quality + reliability gate. It runs independently of the session cascade:
+
+- **Always Opus** — both harness calls pin `model="opus"` regardless of the
+  PM session's configured model. Quality trumps cost for this single call.
+- **Two passes** — Pass 1 drafts from `summary_context`; Pass 2 reviews and
+  refines Pass 1's draft against "short, dense, thoughtful" criteria. The
+  refined text is the message the user receives.
+- **No silent fail** — Pass 1 failures (empty, exception, or
+  `Error: CLI harness not found` sentinel) log at ERROR and deliver a
+  visible `[drafter unavailable — pipeline completed] <truncated context>`
+  fallback message. Pass 2 failures log at WARNING and fall back to the
+  Pass 1 draft. The `final_text` is guaranteed non-empty before `send_cb`.
+- **Always finalize** — the session always transitions to `completed` (via
+  `finalize_session` in a `finally` block) regardless of drafter or delivery
+  outcome. Cancellation during drafter execution is the one exception: the
+  shutdown path owns that transition via an "interrupted" message.
+- **UUID isolation** — Pass 1 uses `session_id=None` so the drafter's
+  Claude Code UUID is NOT written over the PM's `claude_session_uuid`.
+  Pass 2 uses `prior_uuid=None` + `session_id=None` — the review prompt is
+  self-contained (Pass 1's draft is embedded verbatim), so there's no need
+  to resume the PM session and polluting its history is undesirable.
+- **Ollama fallback deferred** — see issue #1137. Until that lands,
+  Anthropic-down manifests as a visible degraded-fallback message + ERROR
+  log + Redis counter
+  `completion_runner:degraded_fallback:daily:<YYYYMMDD>` (7-day TTL) so
+  operators can detect outage spikes.
+
+### PM Stage Dispatch Table
+
+The PM persona's Stage→Model Dispatch Table
+(`config/personas/project-manager.md`) assigns Sonnet to
+BUILD/TEST/PATCH/DOCS and Opus to PLAN/CRITIQUE/REVIEW. The PM explicitly
+passes `--model sonnet` (or `--model opus`) when spawning Dev sessions,
+which sets `session.model` on the Dev's AgentSession record and wins the
+cascade. This is the canonical way to vary models per stage — stage
+routing lives in PM persona prose, NOT in settings.
+
+See [pm-sdlc-decision-rules.md](pm-sdlc-decision-rules.md) for the full
+stage table.
+
+### Regression Guard
+
+`tests/unit/test_harness_model_coverage.py` AST-walks `agent/*.py` and
+fails any `get_response_via_harness(...)` call site that lacks a `model=`
+kwarg — prevents the re-regression pattern that made PR #909's wiring
+dormant on the worker path.
 
 ## BUILD Session Retention (`retain_for_resume`)
 

--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -220,8 +220,15 @@ class AgentSession(Model):
     parent_agent_session_id = KeyField(null=True)
 
     # === Per-session model selection ===
-    # Stores the Claude model name to use for this session (e.g. "sonnet", "opus").
-    # None means inherit from the environment/parent (backward-compatible default).
+    # Claude model name for this session (short aliases preferred: "opus",
+    # "sonnet", "haiku"; full names like "claude-opus-4-7" also accepted).
+    #
+    # Flows to the CLI harness subprocess as `--model <value>` via
+    # `agent.session_executor._resolve_session_model()` and
+    # `agent.sdk_client.get_response_via_harness(model=...)`. When None/empty,
+    # the D1 precedence cascade falls through to
+    # `settings.models.session_default_model` and finally the codebase
+    # default "opus". See `docs/features/agent-session-model.md` for details.
     model = Field(null=True)
 
     # === BUILD session retention for hard-PATCH resume ===

--- a/tests/integration/test_pm_final_delivery.py
+++ b/tests/integration/test_pm_final_delivery.py
@@ -110,12 +110,21 @@ class TestHappyPathMergeSuccess:
 
 
 # -----------------------------------------------------------------------------
-# Empty harness → fallback summary delivered
+# Empty / failing harness → degraded-fallback message delivered (D6 v2)
 # -----------------------------------------------------------------------------
 
 
-class TestEmptyHarnessFallback:
-    async def test_empty_harness_result_delivers_fallback(self, parent):
+class TestDegradedFallbackDelivery:
+    """Under the D6(c) v2 contract from plan #1129:
+    - Drafter failures (empty / exception / _HARNESS_NOT_FOUND_PREFIX) MUST
+      still deliver a user-visible message (no silent fail, never return
+      empty).
+    - That message is the `_build_degraded_fallback` output — visibly
+      prefixed so operators can see the drafter was unavailable.
+    - Session still finalizes to 'completed'.
+    """
+
+    async def test_empty_harness_delivers_degraded_fallback(self, parent):
         send_cb = AsyncMock(return_value=None)
         fallback_ctx = "Stage MERGE completed with outcome=success. Result preview: tests green."
 
@@ -132,11 +141,14 @@ class TestEmptyHarnessFallback:
             await asyncio.wait_for(task, timeout=10.0)
 
         send_cb.assert_awaited_once()
-        # Runner must have delivered the fallback context verbatim (stripped).
-        assert send_cb.await_args.args[1] == fallback_ctx
+        delivered = send_cb.await_args.args[1]
+        # D6 v2 contract: degraded-fallback prefix + truncated context.
+        assert delivered.startswith("[drafter unavailable — pipeline completed]")
+        assert fallback_ctx in delivered
         _fs.assert_called_once()
+        assert _fs.call_args.args[1] == "completed"
 
-    async def test_harness_exception_also_delivers_fallback(self, parent):
+    async def test_harness_exception_delivers_degraded_fallback(self, parent):
         send_cb = AsyncMock(return_value=None)
 
         async def _boom(**_kw):
@@ -156,8 +168,43 @@ class TestEmptyHarnessFallback:
             await asyncio.wait_for(task, timeout=10.0)
 
         send_cb.assert_awaited_once()
-        assert send_cb.await_args.args[1] == fallback_ctx
+        delivered = send_cb.await_args.args[1]
+        assert delivered.startswith("[drafter unavailable — pipeline completed]")
+        assert fallback_ctx in delivered
         _fs.assert_called_once()
+
+
+# -----------------------------------------------------------------------------
+# Two-pass flow: both passes fire, both pinned to model=opus
+# -----------------------------------------------------------------------------
+
+
+class TestTwoPassFlow:
+    async def test_two_passes_both_use_opus(self, parent):
+        send_cb = AsyncMock(return_value=None)
+        captured_models: list = []
+
+        async def _capture(**kw):
+            captured_models.append(kw.get("model"))
+            return "draft" if len(captured_models) == 1 else "refined"
+
+        with (
+            patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_ok()),
+            patch("agent.sdk_client.get_response_via_harness", new=_capture),
+            patch("agent.sdk_client._get_prior_session_uuid", return_value="pm-uuid"),
+            patch("models.session_lifecycle.finalize_session"),
+        ):
+            task = session_completion.schedule_pipeline_completion(
+                parent, "ctx", send_cb, parent.chat_id, None
+            )
+            assert task is not None
+            await asyncio.wait_for(task, timeout=10.0)
+
+        # Both passes fired and both pinned model="opus".
+        assert len(captured_models) == 2, f"Expected 2 harness calls, got {captured_models}"
+        assert captured_models == ["opus", "opus"]
+        # Refined text wins.
+        assert send_cb.await_args.args[1] == "refined"
 
 
 # -----------------------------------------------------------------------------

--- a/tests/unit/test_completion_runner_two_pass.py
+++ b/tests/unit/test_completion_runner_two_pass.py
@@ -189,9 +189,7 @@ class TestPass1Failures:
             )
 
         send_cb.assert_awaited_once()
-        assert send_cb.await_args.args[1].startswith(
-            "[drafter unavailable — pipeline completed]"
-        )
+        assert send_cb.await_args.args[1].startswith("[drafter unavailable — pipeline completed]")
         _fs.assert_called_once()
 
     async def test_pass1_sentinel_delivers_degraded_fallback(self, parent, send_cb):
@@ -229,9 +227,9 @@ class TestPass1Failures:
 
         # Counter key should be hit.
         incr_keys = [call.args[0] for call in redis_db.incr.call_args_list]
-        assert any(
-            k.startswith("completion_runner:degraded_fallback:daily:") for k in incr_keys
-        ), f"No degraded_fallback counter key incremented; keys: {incr_keys}"
+        assert any(k.startswith("completion_runner:degraded_fallback:daily:") for k in incr_keys), (
+            f"No degraded_fallback counter key incremented; keys: {incr_keys}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_completion_runner_two_pass.py
+++ b/tests/unit/test_completion_runner_two_pass.py
@@ -1,0 +1,427 @@
+"""Unit tests for `_deliver_pipeline_completion` 2-pass flow (plan #1129 D6).
+
+Focused on D6(b) 2-pass drafter + D6(c) no-silent-fail + always-finalize
+contract. Companion to `test_deliver_pipeline_completion.py` (which covers
+locking, CancelledError, and dedup).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent import session_completion
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirror test_deliver_pipeline_completion.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def parent():
+    p = MagicMock()
+    p.agent_session_id = "parent-abc-123"
+    p.session_id = "tg_valor_-123_456"
+    p.chat_id = "-123"
+    p.telegram_message_id = 456
+    p.project_key = "valor"
+    p.transport = None
+    p.project_config = {"working_directory": "/tmp"}
+    p.response_delivered_at = None
+    p.save = MagicMock()
+    return p
+
+
+@pytest.fixture
+def send_cb():
+    return AsyncMock(return_value=None)
+
+
+def _redis_ok():
+    db = MagicMock()
+    db.set = MagicMock(return_value=True)
+    db.exists = MagicMock(return_value=False)
+    db.incr = MagicMock(return_value=1)
+    db.expire = MagicMock(return_value=True)
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Happy path: both passes succeed
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    async def test_two_passes_refined_text_delivered(self, parent, send_cb):
+        """Pass 1 drafts, Pass 2 refines, refined text wins."""
+        # Alternate: first call returns Pass 1 draft, second returns refined.
+        harness = AsyncMock(side_effect=["first draft text", "refined polished text"])
+        with (
+            patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_ok()),
+            patch("agent.sdk_client.get_response_via_harness", new=harness),
+            patch("agent.sdk_client._get_prior_session_uuid", return_value="pm-uuid-1"),
+            patch("models.session_lifecycle.finalize_session") as _fs,
+        ):
+            await session_completion._deliver_pipeline_completion(
+                parent, "pipeline summary", send_cb, parent.chat_id, None
+            )
+
+        assert harness.await_count == 2
+        send_cb.assert_awaited_once()
+        assert send_cb.await_args.args[1] == "refined polished text"
+        _fs.assert_called_once()
+        assert _fs.call_args.args[1] == "completed"
+
+    async def test_both_passes_use_model_opus(self, parent, send_cb):
+        harness = AsyncMock(side_effect=["draft", "refined"])
+        with (
+            patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_ok()),
+            patch("agent.sdk_client.get_response_via_harness", new=harness),
+            patch("agent.sdk_client._get_prior_session_uuid", return_value="pm-uuid-1"),
+            patch("models.session_lifecycle.finalize_session"),
+        ):
+            await session_completion._deliver_pipeline_completion(
+                parent, "pipeline summary", send_cb, parent.chat_id, None
+            )
+
+        assert harness.await_args_list[0].kwargs["model"] == "opus"
+        assert harness.await_args_list[1].kwargs["model"] == "opus"
+
+    async def test_pass1_session_id_is_none(self, parent, send_cb):
+        """S-1: Pass 1 must use session_id=None to avoid UUID writeback."""
+        harness = AsyncMock(side_effect=["draft", "refined"])
+        with (
+            patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_ok()),
+            patch("agent.sdk_client.get_response_via_harness", new=harness),
+            patch("agent.sdk_client._get_prior_session_uuid", return_value="pm-uuid-1"),
+            patch("models.session_lifecycle.finalize_session"),
+        ):
+            await session_completion._deliver_pipeline_completion(
+                parent, "ctx", send_cb, parent.chat_id, None
+            )
+
+        pass1_kwargs = harness.await_args_list[0].kwargs
+        assert pass1_kwargs["session_id"] is None
+        # Pass 1 DOES keep prior_uuid (resumes from PM).
+        assert pass1_kwargs["prior_uuid"] == "pm-uuid-1"
+
+    async def test_pass2_uuid_isolation(self, parent, send_cb):
+        """ADV-2: Pass 2 must use prior_uuid=None AND session_id=None."""
+        harness = AsyncMock(side_effect=["draft", "refined"])
+        with (
+            patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_ok()),
+            patch("agent.sdk_client.get_response_via_harness", new=harness),
+            patch("agent.sdk_client._get_prior_session_uuid", return_value="pm-uuid-1"),
+            patch("models.session_lifecycle.finalize_session"),
+        ):
+            await session_completion._deliver_pipeline_completion(
+                parent, "ctx", send_cb, parent.chat_id, None
+            )
+
+        pass2_kwargs = harness.await_args_list[1].kwargs
+        assert pass2_kwargs["prior_uuid"] is None
+        assert pass2_kwargs["session_id"] is None
+        assert pass2_kwargs["full_context_message"] is None
+
+    async def test_pass2_prompt_embeds_draft(self, parent, send_cb):
+        """Pass 2's prompt must include Pass 1's draft verbatim."""
+        draft = "This is Pass 1 output containing unique token ZZZBACON."
+        harness = AsyncMock(side_effect=[draft, "refined"])
+        with (
+            patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_ok()),
+            patch("agent.sdk_client.get_response_via_harness", new=harness),
+            patch("agent.sdk_client._get_prior_session_uuid", return_value="u"),
+            patch("models.session_lifecycle.finalize_session"),
+        ):
+            await session_completion._deliver_pipeline_completion(
+                parent, "ctx", send_cb, parent.chat_id, None
+            )
+
+        pass2_message = harness.await_args_list[1].kwargs["message"]
+        assert "ZZZBACON" in pass2_message
+        assert pass2_message.startswith(session_completion._COMPLETION_REVIEW_PROMPT_PREFIX)
+
+
+# ---------------------------------------------------------------------------
+# Pass 1 failure modes
+# ---------------------------------------------------------------------------
+
+
+class TestPass1Failures:
+    async def test_pass1_empty_delivers_degraded_fallback(self, parent, send_cb):
+        harness = AsyncMock(return_value="")
+        with (
+            patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_ok()),
+            patch("agent.sdk_client.get_response_via_harness", new=harness),
+            patch("agent.sdk_client._get_prior_session_uuid", return_value="u"),
+            patch("models.session_lifecycle.finalize_session") as _fs,
+        ):
+            # Must NOT raise.
+            await session_completion._deliver_pipeline_completion(
+                parent, "context body", send_cb, parent.chat_id, None
+            )
+
+        # Pass 2 is skipped when Pass 1 fails.
+        assert harness.await_count == 1
+        send_cb.assert_awaited_once()
+        delivered = send_cb.await_args.args[1]
+        assert delivered.startswith("[drafter unavailable — pipeline completed]")
+        assert "context body" in delivered
+        # Session is still finalized.
+        _fs.assert_called_once()
+        assert _fs.call_args.args[1] == "completed"
+
+    async def test_pass1_exception_delivers_degraded_fallback(self, parent, send_cb):
+        async def _raise(**_kw):
+            raise RuntimeError("anthropic down")
+
+        with (
+            patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_ok()),
+            patch("agent.sdk_client.get_response_via_harness", new=_raise),
+            patch("agent.sdk_client._get_prior_session_uuid", return_value="u"),
+            patch("models.session_lifecycle.finalize_session") as _fs,
+        ):
+            # Must NOT raise — must deliver degraded fallback.
+            await session_completion._deliver_pipeline_completion(
+                parent, "context body", send_cb, parent.chat_id, None
+            )
+
+        send_cb.assert_awaited_once()
+        assert send_cb.await_args.args[1].startswith(
+            "[drafter unavailable — pipeline completed]"
+        )
+        _fs.assert_called_once()
+
+    async def test_pass1_sentinel_delivers_degraded_fallback(self, parent, send_cb):
+        """Harness-not-found sentinel MUST NOT be delivered as a user message."""
+        sentinel = "Error: CLI harness not found — some detail here"
+        harness = AsyncMock(return_value=sentinel)
+        with (
+            patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_ok()),
+            patch("agent.sdk_client.get_response_via_harness", new=harness),
+            patch("agent.sdk_client._get_prior_session_uuid", return_value="u"),
+            patch("models.session_lifecycle.finalize_session"),
+        ):
+            await session_completion._deliver_pipeline_completion(
+                parent, "context body", send_cb, parent.chat_id, None
+            )
+
+        # Only Pass 1 ran (Pass 2 is skipped on sentinel).
+        assert harness.await_count == 1
+        delivered = send_cb.await_args.args[1]
+        assert "Error: CLI harness not found" not in delivered
+        assert delivered.startswith("[drafter unavailable — pipeline completed]")
+
+    async def test_pass1_failure_emits_degraded_counter(self, parent, send_cb):
+        redis_db = _redis_ok()
+        harness = AsyncMock(return_value="")  # Pass 1 empty
+        with (
+            patch("popoto.redis_db.POPOTO_REDIS_DB", redis_db),
+            patch("agent.sdk_client.get_response_via_harness", new=harness),
+            patch("agent.sdk_client._get_prior_session_uuid", return_value="u"),
+            patch("models.session_lifecycle.finalize_session"),
+        ):
+            await session_completion._deliver_pipeline_completion(
+                parent, "ctx", send_cb, parent.chat_id, None
+            )
+
+        # Counter key should be hit.
+        incr_keys = [call.args[0] for call in redis_db.incr.call_args_list]
+        assert any(
+            k.startswith("completion_runner:degraded_fallback:daily:") for k in incr_keys
+        ), f"No degraded_fallback counter key incremented; keys: {incr_keys}"
+
+
+# ---------------------------------------------------------------------------
+# Pass 2 failure modes
+# ---------------------------------------------------------------------------
+
+
+class TestPass2Failures:
+    async def test_pass2_empty_falls_back_to_pass1_draft(self, parent, send_cb):
+        harness = AsyncMock(side_effect=["pass1 real draft", ""])
+        with (
+            patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_ok()),
+            patch("agent.sdk_client.get_response_via_harness", new=harness),
+            patch("agent.sdk_client._get_prior_session_uuid", return_value="u"),
+            patch("models.session_lifecycle.finalize_session") as _fs,
+        ):
+            await session_completion._deliver_pipeline_completion(
+                parent, "ctx", send_cb, parent.chat_id, None
+            )
+
+        assert harness.await_count == 2
+        assert send_cb.await_args.args[1] == "pass1 real draft"
+        _fs.assert_called_once()
+
+    async def test_pass2_exception_falls_back_to_pass1_draft(self, parent, send_cb):
+        # Side-effect: first call OK, second raises.
+        async def _side(**kw):
+            if _side.count == 0:
+                _side.count += 1
+                return "pass1 real draft"
+            raise RuntimeError("refine failed")
+
+        _side.count = 0
+        with (
+            patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_ok()),
+            patch("agent.sdk_client.get_response_via_harness", new=_side),
+            patch("agent.sdk_client._get_prior_session_uuid", return_value="u"),
+            patch("models.session_lifecycle.finalize_session") as _fs,
+        ):
+            # Must NOT re-raise (downgraded from v1).
+            await session_completion._deliver_pipeline_completion(
+                parent, "ctx", send_cb, parent.chat_id, None
+            )
+
+        assert send_cb.await_args.args[1] == "pass1 real draft"
+        _fs.assert_called_once()
+
+    async def test_pass2_sentinel_falls_back_to_pass1_draft(self, parent, send_cb):
+        sentinel = "Error: CLI harness not found — detail"
+        harness = AsyncMock(side_effect=["pass1 real draft", sentinel])
+        with (
+            patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_ok()),
+            patch("agent.sdk_client.get_response_via_harness", new=harness),
+            patch("agent.sdk_client._get_prior_session_uuid", return_value="u"),
+            patch("models.session_lifecycle.finalize_session"),
+        ):
+            await session_completion._deliver_pipeline_completion(
+                parent, "ctx", send_cb, parent.chat_id, None
+            )
+
+        delivered = send_cb.await_args.args[1]
+        assert delivered == "pass1 real draft"
+        assert "Error: CLI harness not found" not in delivered
+
+
+# ---------------------------------------------------------------------------
+# send_cb + response_delivered_at gate (ADV-2)
+# ---------------------------------------------------------------------------
+
+
+class TestDeliveryGate:
+    async def test_no_send_cb_skips_stamp_but_finalizes(self, parent):
+        """ADV-2: no send_cb means no delivery_attempted → no stamp, still finalize."""
+        harness = AsyncMock(side_effect=["draft", "refined"])
+        with (
+            patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_ok()),
+            patch("agent.sdk_client.get_response_via_harness", new=harness),
+            patch("agent.sdk_client._get_prior_session_uuid", return_value="u"),
+            patch("models.session_lifecycle.finalize_session") as _fs,
+        ):
+            await session_completion._deliver_pipeline_completion(
+                parent, "ctx", None, parent.chat_id, None
+            )
+
+        # Stamp must NOT fire when send_cb is None.
+        assert parent.response_delivered_at is None
+        # finalize_session still runs.
+        _fs.assert_called_once()
+
+    async def test_no_chat_id_skips_stamp_but_finalizes(self, parent, send_cb):
+        harness = AsyncMock(side_effect=["draft", "refined"])
+        with (
+            patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_ok()),
+            patch("agent.sdk_client.get_response_via_harness", new=harness),
+            patch("agent.sdk_client._get_prior_session_uuid", return_value="u"),
+            patch("models.session_lifecycle.finalize_session") as _fs,
+        ):
+            await session_completion._deliver_pipeline_completion(
+                parent, "ctx", send_cb, None, None
+            )
+
+        send_cb.assert_not_awaited()
+        assert parent.response_delivered_at is None
+        _fs.assert_called_once()
+
+    async def test_send_cb_failure_stamps_and_finalizes(self, parent):
+        """If send_cb was attempted but failed, stamp fires; finalize still runs."""
+
+        async def _boom(*a, **kw):
+            raise RuntimeError("transport down")
+
+        harness = AsyncMock(side_effect=["draft", "refined"])
+        with (
+            patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_ok()),
+            patch("agent.sdk_client.get_response_via_harness", new=harness),
+            patch("agent.sdk_client._get_prior_session_uuid", return_value="u"),
+            patch("models.session_lifecycle.finalize_session") as _fs,
+        ):
+            # Must NOT re-raise.
+            await session_completion._deliver_pipeline_completion(
+                parent, "ctx", _boom, parent.chat_id, None
+            )
+
+        # delivery_attempted=True (boom came after send_cb was called) → stamp.
+        assert parent.response_delivered_at is not None
+        _fs.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Always-finalize on Pass 1 raise (D6(c))
+# ---------------------------------------------------------------------------
+
+
+class TestAlwaysFinalize:
+    async def test_pass1_exception_still_finalizes(self, parent, send_cb):
+        async def _raise(**_kw):
+            raise RuntimeError("drafter dead")
+
+        with (
+            patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_ok()),
+            patch("agent.sdk_client.get_response_via_harness", new=_raise),
+            patch("agent.sdk_client._get_prior_session_uuid", return_value="u"),
+            patch("models.session_lifecycle.finalize_session") as _fs,
+        ):
+            await session_completion._deliver_pipeline_completion(
+                parent, "ctx", send_cb, parent.chat_id, None
+            )
+
+        _fs.assert_called_once()
+        assert _fs.call_args.args[1] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# ADV-1 brace-safety (literal { / } in summary_context and draft)
+# ---------------------------------------------------------------------------
+
+
+class TestBraceSafety:
+    async def test_pass1_prompt_survives_braces_in_summary(self, parent, send_cb):
+        """Literal `{`/`}` in summary_context must not crash Pass 1 prompt build."""
+        summary_with_braces = "Output: {'status': 'ok', 'count': 3}"
+        harness = AsyncMock(side_effect=["draft", "refined"])
+        with (
+            patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_ok()),
+            patch("agent.sdk_client.get_response_via_harness", new=harness),
+            patch("agent.sdk_client._get_prior_session_uuid", return_value="u"),
+            patch("models.session_lifecycle.finalize_session"),
+        ):
+            # No KeyError/IndexError/ValueError from .format().
+            await session_completion._deliver_pipeline_completion(
+                parent, summary_with_braces, send_cb, parent.chat_id, None
+            )
+
+        # Pass 1's prompt should contain the braces verbatim.
+        pass1_message = harness.await_args_list[0].kwargs["message"]
+        assert "{'status': 'ok', 'count': 3}" in pass1_message
+
+    async def test_pass2_prompt_survives_braces_in_draft(self, parent, send_cb):
+        """Literal `{`/`}` in Pass 1 draft must not crash Pass 2 prompt build."""
+        draft_with_braces = "Run succeeded: {'files': 3, 'tests': 12}"
+        harness = AsyncMock(side_effect=[draft_with_braces, "refined"])
+        with (
+            patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_ok()),
+            patch("agent.sdk_client.get_response_via_harness", new=harness),
+            patch("agent.sdk_client._get_prior_session_uuid", return_value="u"),
+            patch("models.session_lifecycle.finalize_session"),
+        ):
+            await session_completion._deliver_pipeline_completion(
+                parent, "ctx", send_cb, parent.chat_id, None
+            )
+
+        pass2_message = harness.await_args_list[1].kwargs["message"]
+        assert "{'files': 3, 'tests': 12}" in pass2_message

--- a/tests/unit/test_deliver_pipeline_completion.py
+++ b/tests/unit/test_deliver_pipeline_completion.py
@@ -90,10 +90,12 @@ class TestLock:
 
 
 class TestHarnessResult:
-    async def test_empty_harness_delivers_fallback(self, parent, send_cb):
+    async def test_empty_pass1_delivers_degraded_fallback(self, parent, send_cb):
+        """Pass 1 empty → degraded fallback, Pass 2 skipped (D6(c) v2)."""
+        harness = AsyncMock(return_value="")
         with (
             patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_ok()),
-            patch("agent.sdk_client.get_response_via_harness", new=AsyncMock(return_value="")),
+            patch("agent.sdk_client.get_response_via_harness", new=harness),
             patch("agent.sdk_client._get_prior_session_uuid", return_value="uuid-1"),
             patch("models.session_lifecycle.finalize_session"),
         ):
@@ -101,9 +103,13 @@ class TestHarnessResult:
                 parent, "fallback summary context", send_cb, parent.chat_id, None
             )
         send_cb.assert_awaited_once()
-        assert send_cb.await_args.args[1] == "fallback summary context"
+        assert send_cb.await_args.args[1] == (
+            "[drafter unavailable — pipeline completed] fallback summary context"
+        )
+        # Pass 2 must be skipped when Pass 1 fails.
+        assert harness.await_count == 1
 
-    async def test_whitespace_harness_delivers_fallback(self, parent, send_cb):
+    async def test_whitespace_pass1_delivers_degraded_fallback(self, parent, send_cb):
         with (
             patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_ok()),
             patch(
@@ -115,9 +121,13 @@ class TestHarnessResult:
             await session_completion._deliver_pipeline_completion(
                 parent, "ctx fallback", send_cb, parent.chat_id, None
             )
-        assert send_cb.await_args.args[1] == "ctx fallback"
+        assert send_cb.await_args.args[1] == (
+            "[drafter unavailable — pipeline completed] ctx fallback"
+        )
 
-    async def test_harness_raises_delivers_fallback(self, parent, send_cb):
+    async def test_pass1_raises_delivers_degraded_fallback(self, parent, send_cb):
+        """Pass 1 exception → ERROR log + degraded fallback; no raise escapes."""
+
         async def _raise(**_kw):
             raise RuntimeError("harness boom")
 
@@ -127,12 +137,16 @@ class TestHarnessResult:
             patch("agent.sdk_client._get_prior_session_uuid", return_value="uuid-1"),
             patch("models.session_lifecycle.finalize_session"),
         ):
+            # Must NOT raise — degraded fallback is delivered instead.
             await session_completion._deliver_pipeline_completion(
                 parent, "ctx after harness fail", send_cb, parent.chat_id, None
             )
-        assert send_cb.await_args.args[1] == "ctx after harness fail"
+        assert send_cb.await_args.args[1] == (
+            "[drafter unavailable — pipeline completed] ctx after harness fail"
+        )
 
     async def test_missing_uuid_still_invokes_harness(self, parent, send_cb):
+        # Return real text so Pass 2 kicks in (to verify both still run).
         harness = AsyncMock(return_value="ok")
         with (
             patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_ok()),
@@ -143,14 +157,13 @@ class TestHarnessResult:
             await session_completion._deliver_pipeline_completion(
                 parent, "ctx", send_cb, parent.chat_id, None
             )
-        # Verify prior_uuid was None (no UUID fallback path).
-        harness.assert_awaited_once()
-        assert harness.await_args.kwargs["prior_uuid"] is None
-        # full_context_message should equal the prompt for first-turn fallback.
-        assert (
-            harness.await_args.kwargs["full_context_message"]
-            == harness.await_args.kwargs["message"]
-        )
+        # Pass 1 and Pass 2 both fire.
+        assert harness.await_count == 2
+        # Pass 1's prior_uuid is None (no UUID to resume from).
+        pass1_call = harness.await_args_list[0]
+        assert pass1_call.kwargs["prior_uuid"] is None
+        # Pass 1 uses session_id=None (S-1 UUID isolation).
+        assert pass1_call.kwargs["session_id"] is None
 
 
 class TestDelivery:

--- a/tests/unit/test_harness_model_coverage.py
+++ b/tests/unit/test_harness_model_coverage.py
@@ -97,6 +97,5 @@ def test_all_harness_call_sites_pass_model_kwarg() -> None:
     violations = _find_violations()
     assert not violations, (
         "get_response_via_harness must receive a model= kwarg at every call "
-        "site (plan #1129 A-1 regression guard):\n  "
-        + "\n  ".join(violations)
+        "site (plan #1129 A-1 regression guard):\n  " + "\n  ".join(violations)
     )

--- a/tests/unit/test_harness_model_coverage.py
+++ b/tests/unit/test_harness_model_coverage.py
@@ -1,0 +1,102 @@
+"""A-1 regression guard: every `get_response_via_harness(...)` call site must
+pass ``model=`` as a keyword argument (or live in a documented whitelist).
+
+Prevents the exact re-regression pattern that made PR #909 dormant for 10
+days: a new call site added without the ``model`` kwarg silently bypasses
+per-session model routing. This test AST-walks all ``agent/*.py`` modules
+and asserts the invariant.
+
+See plan ``docs/plans/session-model-routing-fallback.md`` §Test Impact A-1.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+# Files that are permitted to call get_response_via_harness WITHOUT model=.
+# Reserved for in-progress work. Should stay empty; if adding a new entry,
+# include a comment explaining why.
+_WHITELIST: set[str] = set()
+
+
+_TARGET_FUNC_NAME = "get_response_via_harness"
+
+
+def _call_func_name(node: ast.Call) -> str | None:
+    """Return the simple name of the function being called (handles ``fn()`` and ``mod.fn()``)."""
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _call_has_model_kwarg(node: ast.Call) -> bool:
+    """True iff the Call node has ``model=`` in its keywords (or **kwargs splat)."""
+    for kw in node.keywords:
+        # Explicit `model=...`
+        if kw.arg == "model":
+            return True
+        # `**some_kwargs` — we can't tell statically, be permissive.
+        if kw.arg is None:
+            return True
+    return False
+
+
+def _agent_py_files() -> list[Path]:
+    """Collect all ``agent/*.py`` files (excluding __init__.py and subdirs).
+
+    The harness function is invoked only from the agent layer; this keeps
+    the AST walk fast and focused.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    agent_dir = repo_root / "agent"
+    if not agent_dir.is_dir():
+        return []
+    # Only top-level .py files; sub-packages are unlikely to call harness directly
+    # but include them too for safety (rglob).
+    return sorted(p for p in agent_dir.rglob("*.py") if p.is_file())
+
+
+def _find_violations() -> list[str]:
+    violations: list[str] = []
+    repo_root = Path(__file__).resolve().parents[2]
+    for path in _agent_py_files():
+        rel = str(path.relative_to(repo_root))
+        if rel in _WHITELIST:
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=str(path))
+        except (OSError, SyntaxError):
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if _call_func_name(node) != _TARGET_FUNC_NAME:
+                continue
+            if _call_has_model_kwarg(node):
+                continue
+            violations.append(
+                f"{rel}:{node.lineno}: {_TARGET_FUNC_NAME}(...) called without model= kwarg"
+            )
+    return violations
+
+
+def test_all_harness_call_sites_pass_model_kwarg() -> None:
+    """Regression guard: every production call site must pass ``model=``.
+
+    If a new call site is added without model=, the linter-style walk below
+    fails with file:line coordinates. Either add ``model=`` or — if the caller
+    is in an in-progress branch — add the file to ``_WHITELIST`` with a
+    justification comment AND a follow-up issue.
+    """
+    violations = _find_violations()
+    assert not violations, (
+        "get_response_via_harness must receive a model= kwarg at every call "
+        "site (plan #1129 A-1 regression guard):\n  "
+        + "\n  ".join(violations)
+    )

--- a/tests/unit/test_session_model_routing.py
+++ b/tests/unit/test_session_model_routing.py
@@ -1,0 +1,289 @@
+"""Unit tests for per-session model routing (plan docs/plans/session-model-routing-fallback.md).
+
+Covers:
+- `_resolve_session_model()` D1 precedence cascade (3 levels + empty-settings edge).
+- `get_response_via_harness(model=...)` argv injection.
+- Argv ordering: `--model` precedes positional `message` AND `--resume <uuid>`.
+- INFO log line fires with the resolved value.
+"""
+
+import json
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors fixtures used in test_harness_streaming.py)
+# ---------------------------------------------------------------------------
+
+
+async def _async_lines_empty():
+    """Return an async iterator that yields nothing (empty stdout)."""
+    if False:
+        yield  # pragma: no cover
+
+
+async def _async_lines(payload: str):
+    """Yield each line of ``payload`` as bytes, as the harness reader expects."""
+    for line in payload.splitlines(keepends=True):
+        yield line.encode("utf-8")
+
+
+def _stub_subprocess(mock_exec, result_text: str = "ok", session_id: str = "sess_abc"):
+    """Wire ``asyncio.create_subprocess_exec`` to return a fake claude -p process."""
+    stdout_data = (
+        json.dumps(
+            {
+                "type": "result",
+                "result": result_text,
+                "session_id": session_id,
+            }
+        )
+        + "\n"
+    )
+    mock_proc = AsyncMock()
+    mock_proc.stdout = _async_lines(stdout_data)
+    mock_proc.stderr = AsyncMock()
+    mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+    mock_proc.returncode = 0
+    mock_exec.return_value = mock_proc
+    return mock_proc
+
+
+# ---------------------------------------------------------------------------
+# _resolve_session_model() cascade
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSessionModelCascade:
+    """D1 precedence: session.model > settings > codebase default 'opus'."""
+
+    def test_explicit_session_model_wins(self):
+        from agent.session_executor import _resolve_session_model
+
+        session = MagicMock()
+        session.model = "sonnet"
+        # Even if settings has a different default, session.model wins.
+        with patch(
+            "agent.session_executor.settings",
+            MagicMock(models=MagicMock(session_default_model="haiku")),
+        ):
+            assert _resolve_session_model(session) == "sonnet"
+
+    def test_session_model_none_falls_through_to_settings(self):
+        from agent.session_executor import _resolve_session_model
+
+        session = MagicMock()
+        session.model = None
+        with patch(
+            "agent.session_executor.settings",
+            MagicMock(models=MagicMock(session_default_model="haiku")),
+        ):
+            assert _resolve_session_model(session) == "haiku"
+
+    def test_session_model_empty_string_falls_through_to_settings(self):
+        from agent.session_executor import _resolve_session_model
+
+        session = MagicMock()
+        session.model = ""
+        with patch(
+            "agent.session_executor.settings",
+            MagicMock(models=MagicMock(session_default_model="sonnet")),
+        ):
+            assert _resolve_session_model(session) == "sonnet"
+
+    def test_settings_default_is_opus(self):
+        """Codebase default (settings default) is 'opus' when operator doesn't override."""
+        from agent.session_executor import _resolve_session_model
+        from config.settings import settings
+
+        session = MagicMock()
+        session.model = None
+        # Use live settings (pydantic default is 'opus').
+        assert settings.models.session_default_model == "opus"
+        assert _resolve_session_model(session) == "opus"
+
+    def test_empty_settings_default_returns_none(self):
+        """Operator misconfiguration (empty string) → cascade returns None gracefully."""
+        from agent.session_executor import _resolve_session_model
+
+        session = MagicMock()
+        session.model = None
+        with patch(
+            "agent.session_executor.settings",
+            MagicMock(models=MagicMock(session_default_model="")),
+        ):
+            assert _resolve_session_model(session) is None
+
+    def test_none_session_returns_settings_default(self):
+        """O2 guard: _resolve_session_model(None) doesn't crash."""
+        from agent.session_executor import _resolve_session_model
+
+        with patch(
+            "agent.session_executor.settings",
+            MagicMock(models=MagicMock(session_default_model="opus")),
+        ):
+            assert _resolve_session_model(None) == "opus"
+
+    def test_session_without_model_attr(self):
+        """Session object missing .model attr (edge case)."""
+        from agent.session_executor import _resolve_session_model
+
+        class Bare:
+            pass
+
+        with patch(
+            "agent.session_executor.settings",
+            MagicMock(models=MagicMock(session_default_model="opus")),
+        ):
+            assert _resolve_session_model(Bare()) == "opus"
+
+
+# ---------------------------------------------------------------------------
+# get_response_via_harness(model=...) argv injection
+# ---------------------------------------------------------------------------
+
+
+class TestHarnessModelArgvInjection:
+    """Confirms --model flows from kwarg to subprocess argv."""
+
+    @pytest.mark.asyncio
+    async def test_model_injected_into_argv(self):
+        from agent.sdk_client import get_response_via_harness
+
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            _stub_subprocess(mock_exec)
+
+            await get_response_via_harness(
+                message="hello",
+                working_dir="/tmp/test",
+                model="opus",
+            )
+
+            # Positional argv is the first positional call arg.
+            argv = mock_exec.call_args.args
+            assert "--model" in argv, f"--model missing from argv: {argv}"
+            idx = argv.index("--model")
+            assert argv[idx + 1] == "opus"
+
+    @pytest.mark.asyncio
+    async def test_model_none_omits_flag(self):
+        from agent.sdk_client import get_response_via_harness
+
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            _stub_subprocess(mock_exec)
+
+            await get_response_via_harness(
+                message="hello",
+                working_dir="/tmp/test",
+                model=None,
+            )
+
+            argv = mock_exec.call_args.args
+            assert "--model" not in argv, f"--model should not be in argv when None: {argv}"
+
+    @pytest.mark.asyncio
+    async def test_empty_model_string_omits_flag(self):
+        """model='' is falsy → no --model injected (graceful degradation)."""
+        from agent.sdk_client import get_response_via_harness
+
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            _stub_subprocess(mock_exec)
+
+            await get_response_via_harness(
+                message="hello",
+                working_dir="/tmp/test",
+                model="",
+            )
+
+            argv = mock_exec.call_args.args
+            assert "--model" not in argv
+
+    @pytest.mark.asyncio
+    async def test_model_precedes_positional_message(self):
+        """--model must live in harness_cmd, before the positional message."""
+        from agent.sdk_client import get_response_via_harness
+
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            _stub_subprocess(mock_exec)
+
+            await get_response_via_harness(
+                message="THE_MESSAGE_TOKEN",
+                working_dir="/tmp/test",
+                model="sonnet",
+            )
+
+            argv = list(mock_exec.call_args.args)
+            model_idx = argv.index("--model")
+            msg_idx = argv.index("THE_MESSAGE_TOKEN")
+            assert model_idx < msg_idx, f"--model must precede message: {argv}"
+
+    @pytest.mark.asyncio
+    async def test_model_precedes_resume(self):
+        """On resume, --model must still precede --resume <uuid>."""
+        from agent.sdk_client import get_response_via_harness
+
+        valid_uuid = "12345678-1234-1234-1234-123456789abc"
+        with (
+            patch("asyncio.create_subprocess_exec") as mock_exec,
+            patch("agent.sdk_client._store_claude_session_uuid"),
+        ):
+            _stub_subprocess(mock_exec)
+
+            await get_response_via_harness(
+                message="hello",
+                working_dir="/tmp/test",
+                prior_uuid=valid_uuid,
+                model="opus",
+            )
+
+            argv = list(mock_exec.call_args.args)
+            model_idx = argv.index("--model")
+            resume_idx = argv.index("--resume")
+            assert model_idx < resume_idx, (
+                f"--model must precede --resume: {argv}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_defensive_copy_of_caller_harness_cmd(self):
+        """Caller-supplied harness_cmd must not be mutated (S1 fix)."""
+        from agent.sdk_client import get_response_via_harness
+
+        caller_cmd = ["fake-claude", "-p", "--flag"]
+        caller_cmd_before = list(caller_cmd)
+
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            _stub_subprocess(mock_exec)
+
+            await get_response_via_harness(
+                message="hello",
+                working_dir="/tmp/test",
+                harness_cmd=caller_cmd,
+                model="opus",
+            )
+
+            assert caller_cmd == caller_cmd_before, (
+                f"Caller harness_cmd was mutated: {caller_cmd} != {caller_cmd_before}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_info_log_emitted_with_model(self, caplog):
+        from agent.sdk_client import get_response_via_harness
+
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            _stub_subprocess(mock_exec)
+
+            with caplog.at_level(logging.INFO, logger="agent.sdk_client"):
+                await get_response_via_harness(
+                    message="hi",
+                    working_dir="/tmp/test",
+                    model="sonnet",
+                )
+
+            matching = [r for r in caplog.records if "Using --model sonnet" in r.getMessage()]
+            assert matching, (
+                f"Expected INFO log with 'Using --model sonnet'; got: "
+                f"{[r.getMessage() for r in caplog.records]}"
+            )

--- a/tests/unit/test_session_model_routing.py
+++ b/tests/unit/test_session_model_routing.py
@@ -242,9 +242,7 @@ class TestHarnessModelArgvInjection:
             argv = list(mock_exec.call_args.args)
             model_idx = argv.index("--model")
             resume_idx = argv.index("--resume")
-            assert model_idx < resume_idx, (
-                f"--model must precede --resume: {argv}"
-            )
+            assert model_idx < resume_idx, f"--model must precede --resume: {argv}"
 
     @pytest.mark.asyncio
     async def test_defensive_copy_of_caller_harness_cmd(self):


### PR DESCRIPTION
## Summary

Plan: `docs/plans/session-model-routing-fallback.md`
Issue: Closes #1129

Wires `AgentSession.model` through the live CLI-harness path so
`valor-session create --model <name>` actually takes effect, and hardens
the PM-to-CEO final-delivery drafter into a 2-pass + no-silent-fail
quality gate.

## Changes

### Session Model Routing (D1 cascade + live-path wiring)
- `agent/sdk_client.py`: `get_response_via_harness` gains a `model` kwarg;
  when truthy, injects `["--model", model]` into `harness_cmd` before the
  positional message and before any `--resume <uuid>`. Defensive copy of
  caller-supplied `harness_cmd` (S1 fix). INFO log confirms the resolved
  model each turn.
- `agent/session_executor.py`: new `_resolve_session_model(session)` helper
  implements the D1 precedence cascade (`session.model` >
  `settings.models.session_default_model` > codebase default `"opus"`).
  The resolved value is passed into `get_response_via_harness` at the live
  harness call site.
- `config/settings.py`: `ModelSettings.session_default_model: str = "opus"`
  with env var `MODELS__SESSION_DEFAULT_MODEL`.
- `.env.example`: documents the new variable with the full precedence
  cascade.
- `models/agent_session.py`: field docstring updated to reflect the
  harness-CLI live path and the D1 cascade.

### Completion-Runner Hardening (D6 scope expansion)
- `agent/session_completion.py`:
  - `_COMPLETION_PROMPT_PREFIX` + `_COMPLETION_REVIEW_PROMPT_PREFIX` use
    string concatenation (not `.format()`) — safe against literal
    `{`/`}` in `summary_context` or draft bodies (ADV-1 fix).
  - `_build_degraded_fallback(summary_context)` composes a visible
    `[drafter unavailable — pipeline completed] <context>` message.
  - `_deliver_pipeline_completion` rewritten as 2-pass:
    - **Pass 1 (Draft)**: `model="opus"`, `session_id=None` (S-1:
      discard drafter UUID, do NOT pollute PM's `claude_session_uuid`).
      Empty / exception / `_HARNESS_NOT_FOUND_PREFIX` sentinel → ERROR
      log + Redis counter `completion_runner:degraded_fallback:daily:
      <YYYYMMDD>` (O-1) + degraded fallback + skip Pass 2.
    - **Pass 2 (Refine)**: `model="opus"`, `prior_uuid=None`,
      `session_id=None`, `full_context_message=None` (ADV-2 isolation).
      Empty / exception → WARNING + fall back to Pass 1 draft.
      Sentinel → ERROR + fall back to Pass 1 draft.
  - Always-finalize: `try/finally` wraps work so
    `finalize_session(parent, "completed", ...)` runs regardless of
    drafter / delivery outcome. `response_delivered_at` is stamped only
    when `delivery_attempted = True` (ADV-2 gate). CancelledError path
    sets `cancelled=True` and skips both — the shutdown path owns that
    transition.
  - Removed the silent `final_text = ""` + bland "pipeline completed"
    filler. `final_text` is guaranteed non-empty before `send_cb`.

### Documentation
- `docs/features/agent-session-model.md`: rewrote "Per-Session Model
  Selection" with the live path, D1 cascade, `.env` override, PM
  final-delivery drafter policy, PM stage dispatch reference, and the
  regression guard.

## Testing

### New Test Files
- `tests/unit/test_session_model_routing.py` (14 tests) — D1 cascade
  branches, argv injection, argv ordering (model before message +
  before `--resume`), defensive copy, INFO log assertion.
- `tests/unit/test_completion_runner_two_pass.py` (18 tests) — happy
  path, both passes use Opus, S-1 `session_id=None` on Pass 1, ADV-2
  isolation on Pass 2, Pass 1 empty/exception/sentinel → degraded
  fallback + O-1 counter + finalize, Pass 2 empty/exception/sentinel
  → Pass 1 fallback, no-send_cb / no-chat_id stamp gate, always-
  finalize on Pass 1 raise, ADV-1 brace-safety on both prompts.
- `tests/unit/test_harness_model_coverage.py` (A-1 regression guard) —
  AST-walks `agent/*.py` and fails any `get_response_via_harness(...)`
  call site without a `model=` kwarg.

### Updated Tests
- `tests/unit/test_deliver_pipeline_completion.py`: flipped old silent-
  fail expectations to match the v2 contract (degraded fallback).
- `tests/integration/test_pm_final_delivery.py`: renamed / updated
  `TestDegradedFallbackDelivery`, added `TestTwoPassFlow` asserting both
  passes fire with `model="opus"` and refined text wins.

### Results

- 106 affected unit + integration tests passing.
- 3 failures (`test_email_bridge`, `test_email_relay`, `test_pm_session_permissions`)
  are PRE-EXISTING on `main` and unrelated to this work (verified by
  checking out main and re-running).

## Test plan

- [x] Unit tests: `pytest tests/unit/test_session_model_routing.py tests/unit/test_completion_runner_two_pass.py tests/unit/test_harness_model_coverage.py tests/unit/test_deliver_pipeline_completion.py -q`
- [x] Integration tests: `pytest tests/integration/test_session_spawning.py tests/integration/test_harness_resume.py tests/integration/test_pm_final_delivery.py -q`
- [x] Format: `python -m ruff format .`
- [ ] Manual smoke: `python -m tools.valor_session create --role dev --slug test-model-wiring --message "say hello"` with worker running — confirm log line `[harness] Using --model opus`.

## Definition of Done

- [x] Built: `session.model` flows to argv via the harness live path.
- [x] Tested: 106 affected tests pass.
- [x] Documented: `docs/features/agent-session-model.md` rewritten.
- [x] Quality: ruff format clean.
- [x] A-1 regression guard prevents future dormancy.
- [x] Completion-runner satisfies Tom's three co-stated D6 requirements.

Closes #1129