### PR TITLE
test: orphan-PENDING recovery regression for #1126

### DIFF
--- a/docs/plans/session-health-orphan-pending-test.md
+++ b/docs/plans/session-health-orphan-pending-test.md
@@ -6,6 +6,7 @@ owner: Tom Counsell
 created: 2026-04-23
 tracking: https://github.com/tomcounsell/ai/issues/1126
 last_comment_id:
+revision_applied: true
 ---
 
 # Session Health: Orphan-PENDING Recovery Regression Test
@@ -223,6 +224,34 @@ Explicit statement for the hook: **No documentation changes needed.** This test-
 - [ ] Tests pass (`/do-test`).
 - [ ] No documentation updates needed (confirmed in Documentation section).
 
+## Concerns Addressed (Revision Pass)
+
+The `/do-plan-critique` run returned **READY TO BUILD (with concerns)** with four concerns. These are **not blockers** — they are acknowledged risks whose mitigations are now inline below so the builder can apply them directly while writing the test. Each concern maps 1:1 to the correspondingly numbered item in the Risks section above; this section adds a concrete **Implementation Note** the builder must follow.
+
+### C1: Spy resolution path (maps to Risk 1)
+
+- **Concern:** Monkeypatching the wrong name would let the test silently pass on the pre-fix tree.
+- **Implementation Note:** In the test, use `monkeypatch.setattr("agent.agent_session_queue._ensure_worker", spy)` — the module-attribute form on the source module, NOT on `agent.session_health`. Do this BEFORE calling `await _agent_session_health_check()`. The production code at `agent/session_health.py:1019` does a function-local `from agent.agent_session_queue import _ensure_worker`, which re-resolves the name from the source module on every invocation, so the module-attribute monkeypatch is the only form that intercepts. A comment at the monkeypatch line must name this fact explicitly (one-line comment; the builder is instructed to copy the rationale, not paraphrase): `# Patch on the source module — session_health re-imports _ensure_worker locally on each call (agent/session_health.py:1019).`
+
+### C2: Non-local `worker_key` guard (maps to Risk 2)
+
+- **Concern:** If helper defaults produce a `"local"`-prefixed `worker_key`, the health check takes the abandoned-local branch at `agent/session_health.py:994` and never reaches the `_ensure_worker` call site.
+- **Implementation Note:** After seeding, the test MUST assert `assert not seeded_session.worker_key.startswith("local"), f"topology drift: worker_key={seeded_session.worker_key!r} — this test exercises the non-local orphan-PENDING branch"`. This assertion fires BEFORE `_agent_session_health_check()` is invoked. If a future change to `_create_test_session` defaults makes the key `"local"`-prefixed, the test fails loudly at setup with a self-explanatory message instead of silently exiting via the wrong branch.
+
+### C3: Derived `worker_key`, not hard-coded (maps to Risk 3)
+
+- **Concern:** `_create_test_session` defaults could produce either a `chat_id`-keyed or a `project_key`-keyed session depending on `session_type`; hard-coding an expected string in the assertion would make the test brittle.
+- **Implementation Note:** The spy-invocation assertion MUST derive both arguments from the seeded session rather than hard-coding: `assert spy_calls == [(seeded_session.worker_key, seeded_session.is_project_keyed)], f"spy calls: {spy_calls!r}"`. Do NOT write `assert spy_calls == [("789", False)]` — if the helper defaults change, the derived form still exercises the orphan-PENDING branch correctly, while the hard-coded form fails for the wrong reason.
+
+### C4: `_active_workers` pre-flight cleanup (maps to Risk 4)
+
+- **Concern:** A prior test's leaked task in `_active_workers` for the same `worker_key` would make `worker_alive=True` at `agent/session_health.py:977`, causing the health check to skip the orphan-PENDING branch. The class-level autouse `_cleanup_workers` fixture cleans AFTER each test, but nothing guarantees a clean slate BEFORE this one runs.
+- **Implementation Note:** The test MUST explicitly pop the seeded key before invoking the health check: `from agent.agent_session_queue import _active_workers; _active_workers.pop(seeded_session.worker_key, None)`. Place this call AFTER seeding and the topology assertions, and BEFORE the monkeypatch and the `await`. Mirror the pattern already used by `test_recovers_job_with_no_worker` at `tests/integration/test_agent_session_health_monitor.py:200`.
+
+### Revision Note
+
+All four concerns have been addressed by inline Implementation Notes in this section and by corresponding bullets in Step 1 of "Step by Step Tasks" below. No scope expansion. No new production code changes. The test remains strictly additive.
+
 ## Team Orchestration
 
 ### Team Members
@@ -251,12 +280,15 @@ Explicit statement for the hook: **No documentation changes needed.** This test-
 - **Agent Type**: test-engineer
 - **Parallel**: false
 - Add `test_recovers_orphan_pending_with_no_running_sessions` method inside `TestJobHealthCheck` in `tests/integration/test_agent_session_health_monitor.py`.
-- Seed one PENDING `AgentSession` with `chat_id="789"`, `created_at=time.time() - (AGENT_SESSION_HEALTH_MIN_RUNNING + 60)`, `session_id="orphan_pending_session"`.
-- Pre-assert: `AgentSession.query.filter(project_key="test", status="running")` is empty; `seeded_session.worker_key` does NOT start with `"local"`; `_active_workers.get(seeded_session.worker_key)` is None.
-- Monkeypatch `agent.agent_session_queue._ensure_worker` to a spy that records `(worker_key, is_project_keyed)` tuples on a captured list (use `pytest`'s `monkeypatch` fixture).
+- Seed one PENDING `AgentSession` with `chat_id="789"`, `created_at=time.time() - (AGENT_SESSION_HEALTH_MIN_RUNNING + 60)`, `session_id="orphan_pending_session"`. Save the returned object as `seeded_session`.
+- **Pre-assertion block (covers C2 + C4):**
+  - Assert `AgentSession.query.filter(project_key="test", status="running")` is empty.
+  - Assert `not seeded_session.worker_key.startswith("local")` with a message naming the drift (C2 Implementation Note).
+  - `from agent.agent_session_queue import _active_workers; _active_workers.pop(seeded_session.worker_key, None)` — explicit pre-flight cleanup (C4 Implementation Note). Mirrors the pattern at `tests/integration/test_agent_session_health_monitor.py:200`.
+- **Monkeypatch (covers C1):** `monkeypatch.setattr("agent.agent_session_queue._ensure_worker", spy)` where `spy` is a plain callable that appends `(worker_key, is_project_keyed)` tuples to a list captured in the test's local scope. Include a one-line comment above the monkeypatch explaining WHY the source-module form is required: `# Patch on the source module — session_health re-imports _ensure_worker locally on each call (agent/session_health.py:1019).`
 - `await _agent_session_health_check()`.
-- Assert spy was called exactly once with `(seeded_session.worker_key, seeded_session.is_project_keyed)`.
-- Assert `caplog.records` contains no record whose message matches `UnboundLocalError` or `cannot access local variable '_ensure_worker'` (use `caplog` fixture at `WARNING` level).
+- **Spy-call assertion (covers C3):** Assert `spy_calls == [(seeded_session.worker_key, seeded_session.is_project_keyed)]`. Do NOT hard-code the tuple — derive both elements from `seeded_session` so the test remains robust if helper defaults change the `worker_key` or `is_project_keyed` value.
+- Assert `caplog.records` contains no record whose message matches `UnboundLocalError` or `cannot access local variable '_ensure_worker'` (use `caplog` fixture at `WARNING` level). This is the belt-and-braces check for the case where the bug returns AND its log is silently swallowed.
 - Run `python -m ruff format tests/integration/test_agent_session_health_monitor.py`.
 
 ### 2. Verify the test catches the original bug

--- a/tests/integration/test_agent_session_health_monitor.py
+++ b/tests/integration/test_agent_session_health_monitor.py
@@ -325,6 +325,99 @@ class TestJobHealthCheck:
         pending = AgentSession.query.filter(project_key="test", status="pending")
         assert len(pending) == 1
 
+    @pytest.mark.asyncio
+    async def test_recovers_orphan_pending_with_no_running_sessions(self, monkeypatch, caplog):
+        """Regression for #1124/#1126: orphan-PENDING recovery must reach _ensure_worker.
+
+        Topology: zero RUNNING sessions + one orphan PENDING session older than
+        AGENT_SESSION_HEALTH_MIN_RUNNING with a non-local worker_key.
+
+        Pre-fix, agent/session_health.py's orphan-PENDING branch raised
+        UnboundLocalError on the `from agent.agent_session_queue import _ensure_worker`
+        line at what is now line 1019 — Python treats the name as function-local due
+        to the RUNNING-branch import at line 948, so the import statement itself
+        raised before the call at line 1021 could execute. The per-entry
+        `except Exception: logger.exception(...)` at line 1023 caught the error and
+        logged it, so the function did not propagate — instead, _ensure_worker was
+        silently never invoked.
+
+        This test guards the fix by asserting the spy WAS called exactly once with
+        the seeded session's worker_key and is_project_keyed, AND that no log
+        record mentions UnboundLocalError.
+        """
+        import logging
+
+        from agent.agent_session_queue import (
+            AGENT_SESSION_HEALTH_MIN_RUNNING,
+            _active_workers,
+            _agent_session_health_check,
+        )
+
+        # Seed one PENDING session with a non-local worker_key (chat_id="789")
+        # and a created_at past the 5-minute age threshold.
+        seeded_session = _create_test_session(
+            status="pending",
+            chat_id="789",
+            session_id="orphan_pending_session",
+            created_at=time.time() - (AGENT_SESSION_HEALTH_MIN_RUNNING + 60),
+        )
+
+        # Pre-assertion: topology — zero RUNNING sessions.
+        running_pre = AgentSession.query.filter(project_key="test", status="running")
+        assert len(running_pre) == 0, (
+            f"topology drift: expected zero RUNNING sessions, got {len(running_pre)}"
+        )
+
+        # Pre-assertion: worker_key is non-local. If helper defaults ever change to
+        # produce a "local"-prefixed key, this test would exercise the abandoned-local
+        # branch at agent/session_health.py:994 instead of the orphan-PENDING-with-
+        # _ensure_worker branch, and the spy would silently never be called.
+        assert not seeded_session.worker_key.startswith("local"), (
+            f"topology drift: worker_key={seeded_session.worker_key!r} — this test "
+            "exercises the non-local orphan-PENDING branch"
+        )
+
+        # Pre-flight cleanup of _active_workers. Mirrors the pattern at
+        # test_recovers_job_with_no_worker (line 200). A leaked live worker for the
+        # same worker_key would set worker_alive=True at agent/session_health.py:977
+        # and cause the health check to skip the orphan-PENDING branch entirely.
+        _active_workers.pop(seeded_session.worker_key, None)
+
+        # Spy on _ensure_worker.
+        # Patch on the source module — session_health re-imports _ensure_worker
+        # locally on each call (agent/session_health.py:1019).
+        spy_calls: list[tuple[str, bool]] = []
+
+        def spy(worker_key: str, is_project_keyed: bool = False) -> None:
+            spy_calls.append((worker_key, is_project_keyed))
+
+        monkeypatch.setattr("agent.agent_session_queue._ensure_worker", spy)
+
+        # Capture WARNING/ERROR-level logs for the belt-and-braces check below.
+        caplog.set_level(logging.WARNING)
+
+        await _agent_session_health_check()
+
+        # Primary assertion: the spy was called exactly once with the derived
+        # (worker_key, is_project_keyed) pair from the seeded session. On the
+        # pre-fix tree, the UnboundLocalError at line 1019 prevented the call
+        # site from ever being reached, so spy_calls would be empty.
+        assert spy_calls == [(seeded_session.worker_key, seeded_session.is_project_keyed)], (
+            f"spy calls: {spy_calls!r}"
+        )
+
+        # Belt-and-braces: no log record should mention UnboundLocalError. On the
+        # pre-fix tree, the per-entry `except Exception: logger.exception(...)` at
+        # agent/session_health.py:1023 would write this string to the log.
+        for record in caplog.records:
+            message = record.getMessage()
+            assert "UnboundLocalError" not in message, (
+                f"pre-fix bug regression detected in log: {message!r}"
+            )
+            assert "cannot access local variable '_ensure_worker'" not in message, (
+                f"pre-fix bug regression detected in log: {message!r}"
+            )
+
 
 class TestJobHealthConstants:
     """Tests for health check constants."""


### PR DESCRIPTION
## Summary

Adds a regression test for the orphan-PENDING branch of `_agent_session_health_check` in `agent/session_health.py`. Guards the fix from commit `b40a2b73` against silent regression.

## Changes

- `tests/integration/test_agent_session_health_monitor.py`: new method `TestJobHealthCheck::test_recovers_orphan_pending_with_no_running_sessions` (93 lines, strictly additive).

## What the test does

Seeds the exact topology that exposed the bug:
- zero RUNNING sessions
- one orphan PENDING session past `AGENT_SESSION_HEALTH_MIN_RUNNING`
- non-local `worker_key` (so the abandoned-local branch at `session_health.py:994` is skipped)

Then monkeypatches `agent.agent_session_queue._ensure_worker` (on the source module — the production code re-imports it locally on each call) and asserts:
1. The spy was called exactly once with `(seeded_session.worker_key, seeded_session.is_project_keyed)` — derived from the seeded session, not hard-coded.
2. No log record mentions `UnboundLocalError` or `cannot access local variable '_ensure_worker'`.

## Verification

- Locally reverted the `from agent.agent_session_queue import _ensure_worker` import at `agent/session_health.py:1019`.
- Confirmed the new test FAILS with `AssertionError: spy calls: []` and captured log: `UnboundLocalError: cannot access local variable '_ensure_worker' where it is not associated with a value`.
- Restored the import; test PASSES.
- `git diff main -- agent/` is empty (no production changes).
- Full `tests/integration/test_agent_session_health_monitor.py` (21 tests) passes.

## Testing

- [x] New regression test passes
- [x] Full integration file passes (21/21)
- [x] `ruff format` clean
- [x] Verified test catches the original bug via local revert
- [x] No production code changes (`git diff main -- agent/` empty)

## Definition of Done

- [x] Built: test added
- [x] Tested: passes on main, fails on pre-fix tree
- [x] Quality: `ruff format` clean
- [x] Documented: plan explicitly states no docs changes needed (test-only regression)

Closes #1126