### PR TITLE
Remove email_relay legacy text->body compat shim (#1095)

### DIFF
--- a/bridge/email_relay.py
+++ b/bridge/email_relay.py
@@ -22,14 +22,6 @@ Redis queue contract:
             "_relay_attempts": int (optional)  # managed by the relay
         }
 
-    Legacy compat: payloads with ``text`` instead of ``body`` are normalized on
-    read for one transitional release. The queue had no consumer before this
-    change so in-flight entries are unlikely but tolerated.
-
-    FIXME(#1095): Delete the ``text`` -> ``body`` compat shim (see
-    ``_normalize_payload``) and the associated unit test one release after
-    PR #1094 merges. Tracked in https://github.com/tomcounsell/ai/issues/1095.
-
 Liveness:
     Writes ``email:relay:last_poll_ts = time.time()`` with a 5-minute TTL once
     per poll cycle. Operators probe via ``GET email:relay:last_poll_ts``.
@@ -82,14 +74,9 @@ def _get_redis_connection():
 def _normalize_payload(message: dict) -> dict | None:
     """Normalize incoming payload to the unified shape.
 
-    Returns None if the payload is unrecoverable (missing ``to`` or both
-    ``body``/``text``). Callers should DLQ such payloads rather than retry.
+    Returns None if the payload is unrecoverable (missing ``to`` or ``body``).
+    Callers should DLQ such payloads rather than retry.
     """
-    # FIXME(#1095): Legacy text -> body compat shim — delete one release after
-    # PR #1094 merges. https://github.com/tomcounsell/ai/issues/1095
-    if "body" not in message and "text" in message:
-        message["body"] = message.pop("text")
-
     to_field = message.get("to") or ""
     # Normalize to list — CLI may send a single string or a list
     if isinstance(to_field, str):

--- a/docs/features/email-bridge.md
+++ b/docs/features/email-bridge.md
@@ -279,7 +279,7 @@ Sends write the **unified outbox payload** to `email:outbox:{session_id}` with a
 }
 ```
 
-The `session_id` format (`cli-{secs}-{pid}-{token_hex(4)}`) gives 32 bits of per-call randomness so concurrent invocations in the same second collide effectively never. `tools/send_message.py::_send_via_email` emits the same shape so the relay has a single contract to drain. The `"to"` field is always `list[str]`; the relay's `_normalize_payload()` coerces any legacy single-string `"to"` value to `list[str]` for backward compatibility.
+The `session_id` format (`cli-{secs}-{pid}-{token_hex(4)}`) gives 32 bits of per-call randomness so concurrent invocations in the same second collide effectively never. `tools/send_message.py::_send_via_email` emits the same shape so the relay has a single contract to drain. The `"to"` field is canonically `list[str]`; the relay's `_normalize_payload()` also accepts a single comma-separated string and splits it into `list[str]`.
 
 The relay (`bridge/email_relay.py`) polls `email:outbox:*` every 100 ms. For each key it performs atomic `LPOP`, builds the MIME message via `_build_reply_mime()` (switching to `MIMEMultipart` when attachments are present), and dispatches over SMTP in `asyncio.to_thread`. On failure it increments `_relay_attempts`, `RPUSH`es back, and DLQs via `bridge.email_dead_letter.write_dead_letter()` after `MAX_EMAIL_RELAY_RETRIES` (default 3) attempts. The relay writes `email:relay:last_poll_ts` once per cycle (5-minute TTL) for operator liveness probes.
 

--- a/docs/features/email-bridge.md
+++ b/docs/features/email-bridge.md
@@ -283,8 +283,6 @@ The `session_id` format (`cli-{secs}-{pid}-{token_hex(4)}`) gives 32 bits of per
 
 The relay (`bridge/email_relay.py`) polls `email:outbox:*` every 100 ms. For each key it performs atomic `LPOP`, builds the MIME message via `_build_reply_mime()` (switching to `MIMEMultipart` when attachments are present), and dispatches over SMTP in `asyncio.to_thread`. On failure it increments `_relay_attempts`, `RPUSH`es back, and DLQs via `bridge.email_dead_letter.write_dead_letter()` after `MAX_EMAIL_RELAY_RETRIES` (default 3) attempts. The relay writes `email:relay:last_poll_ts` once per cycle (5-minute TTL) for operator liveness probes.
 
-**Transitional payload compat.** The relay's `_normalize_payload` accepts the prior `{session_id, to, text, timestamp}` shape (aliasing `text` → `body`) for one transitional release so in-flight entries from before this change never get stranded.
-
 **`EmailOutputHandler.send()` does NOT write to the outbox** — it sends directly from the worker. The relay and the handler do not race on the same session's output (Risk 3 in the plan).
 
 ### Threads

--- a/tests/unit/test_email_relay.py
+++ b/tests/unit/test_email_relay.py
@@ -1,8 +1,7 @@
 """Unit tests for ``bridge.email_relay``.
 
 Covers the unified payload drain path: atomic LPOP, requeue-with-counter on
-failure, DLQ after ``MAX_EMAIL_RELAY_RETRIES`` attempts, legacy ``text``
-field compatibility, and heartbeat writes.
+failure, DLQ after ``MAX_EMAIL_RELAY_RETRIES`` attempts, and heartbeat writes.
 
 Uses live local Redis via the xdist-aware ``redis_test_url`` fixture so
 ``pytest -n auto`` is safe (each worker gets its own db number).
@@ -38,17 +37,11 @@ def r(monkeypatch, redis_test_url):
 
 
 class TestNormalizePayload:
-    def test_text_aliases_to_body(self):
-        msg = {"session_id": "s", "to": "a@x", "text": "legacy", "timestamp": 1.0}
-        result = _normalize_payload(dict(msg))
-        assert result["body"] == "legacy"
-        assert "text" not in result
-
     def test_missing_to_rejected(self):
         msg = {"session_id": "s", "body": "hi", "timestamp": 1.0}
         assert _normalize_payload(dict(msg)) is None
 
-    def test_missing_body_and_text_rejected(self):
+    def test_missing_body_rejected(self):
         msg = {"session_id": "s", "to": "a@x", "timestamp": 1.0}
         assert _normalize_payload(dict(msg)) is None
 
@@ -175,8 +168,15 @@ class TestProcessOutboxSend:
         assert dl_calls[0]["session_id"] == "cli-dlq-1"
 
     @pytest.mark.asyncio
-    async def test_drains_legacy_text_payload(self, r):
-        """Legacy payload shape: {session_id, to, text, timestamp}."""
+    async def test_text_payload_dlqd_as_malformed(self, r):
+        """A legacy ``text``-only payload is DLQ'd — the compat shim is gone.
+
+        Pins ``body == ""`` on the DLQ record: ``_dead_letter_message`` reads
+        ``message.get("body", "")``, and with the shim removed the ``text``
+        content is dropped at the DLQ boundary rather than aliased to
+        ``body``. If a future change reintroduces ``text`` aliasing inside
+        the DLQ path, this assertion fails.
+        """
         key = "email:outbox:legacy-1"
         payload = {
             "session_id": "legacy-1",
@@ -186,23 +186,29 @@ class TestProcessOutboxSend:
         }
         r.rpush(key, json.dumps(payload))
 
-        captured = {}
+        dl_calls = []
 
-        def fake_send(to_addr, mime_msg, from_addr):
-            captured["to"] = to_addr
-            captured["body"] = mime_msg.get_payload(decode=True).decode("utf-8")
+        def fake_write_dead_letter(**kwargs):
+            dl_calls.append(kwargs)
 
-        with patch("bridge.email_relay._send_smtp_sync", side_effect=fake_send):
-            sent = await process_outbox()
+        with patch("bridge.email_relay._send_smtp_sync") as mock_send:
+            with patch("bridge.email_dead_letter.write_dead_letter", fake_write_dead_letter):
+                sent = await process_outbox()
 
-        assert sent == 1
-        assert captured["to"] == "alice@example.com"
-        assert "Legacy body via text field" in captured["body"]
+        assert sent == 0
+        # No SMTP send occurred — payload rejected before the network path.
+        assert mock_send.call_count == 0
+        # Queue is empty — LPOPped and not re-pushed.
+        assert r.llen(key) == 0
+        # DLQ invoked exactly once.
+        assert len(dl_calls) == 1
+        # Content-loss pin: ``text`` is not aliased to ``body`` on DLQ.
+        assert dl_calls[0]["body"] == ""
 
     @pytest.mark.asyncio
     async def test_malformed_payload_dlqd_without_retry(self, r):
         key = "email:outbox:malformed-1"
-        # Missing `to` AND missing body/text — not recoverable
+        # Missing `to` AND missing `body` — not recoverable
         r.rpush(key, json.dumps({"session_id": "malformed-1", "timestamp": 1.0}))
 
         dl_calls = []


### PR DESCRIPTION
## Summary

Deletes the one-release transitional `text` → `body` compat shim that PR #1094 introduced in `bridge/email_relay.py::_normalize_payload`. Every current producer (`tools/send_message.py::_send_via_email`, `tools/valor_email.py`) emits `body`; the queue had no consumer before PR #1094, so in-flight entries with the legacy shape are effectively zero. The transitional safety margin has been held; now it is dead code.

Closes #1095

## Changes

- **`bridge/email_relay.py`** — drop the `if "body" not in message and "text" in message: message["body"] = message.pop("text")` branch and its `FIXME(#1095)` comment. Strip the "Legacy compat" + `FIXME(#1095)` paragraphs from the module docstring. Tighten `_normalize_payload` docstring to "missing `to` or `body`".
- **`tests/unit/test_email_relay.py`** — delete `test_text_aliases_to_body` and `test_drains_legacy_text_payload`. Rename `test_missing_body_and_text_rejected` → `test_missing_body_rejected`. Replace the drain-path test with `test_text_payload_dlqd_as_malformed`, which pins the new behavior: a `text`-only payload is DLQ'd (not silently aliased), LPOPped without re-push, and the DLQ record's `body == ""`. The `body == ""` assertion is the load-bearing pin — `_dead_letter_message` reads `message.get("body", "")`, so with the shim gone the `text` content is *dropped* rather than preserved on the DLQ record. A future regression that reintroduces `text` aliasing at the DLQ boundary will fail this assertion. Strip the "legacy `text` field compatibility" phrase from the module docstring.
- **`docs/features/email-bridge.md`** — remove the "Transitional payload compat" paragraph (line 286 on baseline `61a11980`). The surrounding outbox contract already names `body` as the canonical key. Reword the neighboring `to`-field coercion description to drop the word "legacy" — that coercion is an accepted ongoing input shape, not a transitional compat, and the docs validator treats "legacy" as a stale marker in changed docs. Semantics unchanged.

## Testing

- [x] `pytest tests/unit/test_email_relay.py -x -q` — 13 passed
- [x] `python -m ruff format --check bridge/email_relay.py tests/unit/test_email_relay.py` — clean
- [x] `grep -n "1095" bridge/email_relay.py tests/unit/test_email_relay.py` — no matches
- [x] `grep -n '"text"' bridge/email_relay.py` — no matches (as payload-key)
- [x] `grep -En "test_.*(legacy_text|text_aliases)" tests/unit/test_email_relay.py` — no matches
- [x] `grep -rn '"text"' docs/features/ | grep -i email` — no matches

## Documentation

- [x] `docs/features/email-bridge.md` updated — transitional compat paragraph removed; outbox payload contract untouched since it already names `body` canonically.

## Definition of Done

- [x] Built: shim removed, tests rewritten
- [x] Tested: 13/13 unit tests passing
- [x] Documented: feature doc paragraph removed
- [x] Quality: ruff format clean

## Risk

Two risks documented in the plan, both mitigated:

1. *A straggler producer still emits `text`* — grep confirms zero such producers.
2. *An in-flight `text` payload sits in Redis at deploy time* — queue has been drained continuously since PR #1094 merged (2 days ago).

Both failure modes are recoverable via `./scripts/valor-service.sh email-dead-letter list` + `replay --all`. Not catastrophic.