### PR TITLE
docs(#1032): cascade reflections monolith-deletion cleanup

### DIFF
--- a/docs/features/bridge-self-healing.md
+++ b/docs/features/bridge-self-healing.md
@@ -8,7 +8,7 @@ The bridge includes a multi-layered self-healing system to recover from crashes 
 
 **Solution**: The `_parse_api_id()` helper in `bridge/telegram_bridge.py` wraps the `int()` conversion and returns `0` on any invalid or missing input, logging a warning to stderr. Module import now always succeeds regardless of env contents. The existing runtime credential check (`if not API_ID or not API_HASH`) remains the authoritative "fail loudly and exit" path once the bridge actually tries to connect.
 
-The same defensive `try/except ValueError` pattern was applied to `tools/valor_telegram.py` and `scripts/reflections.py` where lazy `int(os.environ.get(...))` calls existed inside functions.
+The same defensive `try/except ValueError` pattern was applied to `tools/valor_telegram.py` where lazy `int(os.environ.get(...))` calls existed inside functions.
 
 ## Components
 
@@ -109,7 +109,6 @@ Log rotation uses a three-layer approach: Python-managed rotation for applicatio
 **Python-managed logs** (auto-rotate on write via `RotatingFileHandler`, 10MB max, 5 backups):
 - `bridge.log` — configured in `bridge/telegram_bridge.py`
 - `watchdog.log` — configured in `monitoring/bridge_watchdog.py`
-- `reflections.log` — configured in `scripts/reflections.py`
 
 **Shell-rotated logs** (`rotate_log()` in `valor-service.sh`, runs at bridge startup, 10MB max, 3 backups):
 - `bridge.error.log`, `reflections_error.log`

--- a/docs/features/popoto-index-hygiene.md
+++ b/docs/features/popoto-index-hygiene.md
@@ -26,13 +26,9 @@ When AgentSession records expire (via TTL), crash, or are deleted without proper
 
 Worker startup calls `run_cleanup()` from `scripts/popoto_index_cleanup` to rebuild indexes for **all** Popoto models (not just AgentSession). This runs as Step 1 of the startup sequence, before corrupted session cleanup and recovery. The total time is logged for monitoring.
 
-### Cleanup Reflection (Scheduler)
+### Cleanup Reflection
 
-`scripts/popoto_index_cleanup.py` provides a `run_cleanup()` function registered as the `redis-index-cleanup` reflection in `config/reflections.yaml`. The `ReflectionScheduler` (bridge-hosted) dispatches this daily when the bridge is running.
-
-### Cleanup Reflection (Runner)
-
-`ReflectionRunner` in `scripts/reflections.py` includes a `step_popoto_index_cleanup` step that calls `run_cleanup()` as a standalone safety net. This step runs after `redis_ttl_cleanup` (which deletes expired records) to clean up any orphaned index entries left behind. The runner executes via launchd regardless of bridge status.
+`scripts/popoto_index_cleanup.py` provides a `run_cleanup()` function registered as the `redis-index-cleanup` reflection in `config/reflections.yaml`. The `ReflectionScheduler` (worker-embedded in `python -m worker`) dispatches this daily while the worker process runs.
 
 ### How `run_cleanup()` Works
 
@@ -43,13 +39,12 @@ Worker startup calls `run_cleanup()` from `scripts/popoto_index_cleanup` to rebu
 
 Each model is processed independently -- one model failure does not abort the sweep. The SCAN-based `rebuild_indexes()` is safe to run concurrently with normal operations.
 
-### Three Cleanup Paths
+### Cleanup Paths
 
 | Path | Trigger | Scope |
 |------|---------|-------|
 | Worker startup | `python -m worker` | All models via `run_cleanup()` |
-| ReflectionScheduler | Bridge tick (daily) | All models via `run_cleanup()` |
-| ReflectionRunner | `python scripts/reflections.py` (launchd) | All models via `step_popoto_index_cleanup` → `run_cleanup()` |
+| ReflectionScheduler | Worker scheduler tick (daily) | All models via `run_cleanup()` |
 
 ## Concurrency Safety
 
@@ -65,7 +60,6 @@ Each model is processed independently -- one model failure does not abort the sw
 | `agent/agent_session_queue.py` | Refactored diagnostic fallback |
 | `worker/__main__.py` | Worker startup using `run_cleanup()` for all-model rebuild (step 1) |
 | `scripts/popoto_index_cleanup.py` | Cleanup function (`run_cleanup()`) and model discovery (`_get_all_models()`) |
-| `scripts/reflections.py` | `ReflectionRunner.step_popoto_index_cleanup` standalone safety net |
 | `config/reflections.yaml` | Reflection registry entry for `ReflectionScheduler` |
 
 ## Inline Orphan Prevention (Defensive srem)

--- a/docs/features/telegram-history.md
+++ b/docs/features/telegram-history.md
@@ -32,7 +32,7 @@ All data is stored in **Redis** via Popoto ORM models. SQLite was removed as of 
 - `content` - Full message content (up to 50,000 chars, no truncation)
 - `timestamp` - Unix timestamp (SortedField, partitioned by chat_id)
 - `message_type` - text, photo, voice, response, etc. (KeyField)
-- TTL: 90 days (cleaned by reflections step 13)
+- TTL: 90 days (cleaned by the `redis-ttl-cleanup` reflection)
 
 **`Link`** (`models/link.py`) - URLs shared in chats
 - `link_id` - Auto-generated key
@@ -44,18 +44,18 @@ All data is stored in **Redis** via Popoto ORM models. SQLite was removed as of 
 - `timestamp` - Unix timestamp (SortedField)
 - `tags` - ListField for categorization
 - `ai_summary` - AI-generated summary (up to 50,000 chars)
-- TTL: 90 days (cleaned by reflections step 13)
+- TTL: 90 days (cleaned by the `redis-ttl-cleanup` reflection)
 
 **`Chat`** (`models/chat.py`) - Chat ID to name mapping
 - `chat_id` - Telegram chat ID (UniqueKeyField)
 - `chat_name` - Human-readable name (KeyField)
 - `chat_type` - private, group, supergroup, channel (KeyField)
 - `updated_at` - Unix timestamp (SortedField)
-- TTL: 90 days (cleaned by reflections step 13)
+- TTL: 90 days (cleaned by the `redis-ttl-cleanup` reflection)
 
 ### Data Retention
 
-- Redis models: 90-day TTL, cleaned by reflections `step_redis_cleanup()` (step 13)
+- Redis models: 90-day TTL, cleaned by the `redis-ttl-cleanup` reflection (`reflections.maintenance.run_redis_ttl_cleanup`)
 - No SQLite backup after 2026-02-24 migration
 
 ## Configuration

--- a/docs/guides/claude-code-feature-swot.md
+++ b/docs/guides/claude-code-feature-swot.md
@@ -411,22 +411,13 @@ Operational (ready)          Configured (needs_setup)
 | Bridge | `com.valor.bridge` | `scripts/start_bridge.sh` | Always on |
 | Watchdog | `com.valor.bridge-watchdog` | `monitoring/bridge_watchdog.py` | Every 60s |
 | Issue Poller | `com.valor.issue-poller` | Issue polling script | Every 5min |
-| Reflections | `com.valor.reflections` | `scripts/reflections.py` | Scheduled |
 | AutoExperiment | `com.valor.autoexperiment` | `scripts/autoexperiment.py` | Nightly |
 
-**Code example — reflections maintenance:**
-```bash
-# Run reflections with dry-run
-python scripts/reflections.py --dry-run
+Reflections no longer run via launchd; the scheduler is embedded in the worker (`python -m worker`). See [Reflections](../features/reflections.md) for details.
 
-# Tasks performed:
-# 1. Legacy code cleanup scan
-# 2. Log review and error pattern detection  
-# 3. Sentry error monitoring
-# 4. Task management cleanup
-# 5. Documentation staleness check
-# 6. Daily report generation
-```
+**Code example — reflections maintenance:**
+
+Reflections are declared in `config/reflections.yaml` (a vault-symlinked registry). Each entry maps to a callable in the `reflections/` package (e.g., `reflections.maintenance.run_redis_ttl_cleanup`). The `ReflectionScheduler` in `agent/reflection_scheduler.py` — run as an asyncio task inside the standalone worker — enqueues due reflections at their declared intervals. There is no direct CLI invocation.
 
 **Remote triggers (via /schedule skill):**
 ```bash

--- a/docs/guides/valor-name-references.md
+++ b/docs/guides/valor-name-references.md
@@ -85,19 +85,16 @@ References where "Valor" is a **brand/product name** for the tooling itself — 
 
 | File | Service Labels |
 |------|---------------|
-| `com.valor.reflections.plist` | `com.valor.reflections` |
 | `scripts/valor-service.sh` | `com.valor.bridge`, `com.valor.update`, `com.valor.bridge-watchdog` |
-| `scripts/update/service.py` | `com.valor.reflections`, `com.valor.daydream` (old), `com.valor.caffeinate` |
+| `scripts/update/service.py` | `com.valor.reflections` (removed service), `com.valor.daydream` (old), `com.valor.caffeinate` |
 | `monitoring/bridge_watchdog.py` | `com.valor.bridge` |
-| `scripts/install_reflections.sh` | `com.valor.reflections`, `com.valor.daydream` |
-| `scripts/remote-update.sh` | `com.valor.reflections`, `com.valor.daydream` |
+| `scripts/remote-update.sh` | `com.valor.reflections` (removed service), `com.valor.daydream` |
 
 ### B4. Data Paths
 
 | Path | Used By |
 |------|---------|
 | `~/.valor/test_results/` | `tools/test_scheduler/__init__.py` |
-| `data/valor.session` | `scripts/reflections.py` (Telegram session) |
 
 ### B5. Scripts (branded filenames & strings)
 
@@ -108,7 +105,7 @@ References where "Valor" is a **brand/product name** for the tooling itself — 
 | `scripts/calendar_hook.sh` | `EXCLUDED_PROJECTS="valor"`, `valor-calendar` |
 | `scripts/calendar_prompt_hook.sh` | `EXCLUDED_PROJECTS="valor"`, `valor-calendar` |
 | `scripts/update/verify.py` | `valor-calendar` path checks |
-| `scripts/update/run.py` | `com.valor.reflections.plist` |
+| `scripts/update/run.py` | `com.valor.reflections.plist` (removed service) |
 | `scripts/update/__init__.py` | `"Modular update system for Valor"` |
 | `scripts/telegram_login.py` | `valor-service.sh` reference |
 

--- a/docs/research/claude-code-feature-swot.md
+++ b/docs/research/claude-code-feature-swot.md
@@ -411,22 +411,13 @@ Operational (ready)          Configured (needs_setup)
 | Bridge | `com.valor.bridge` | `scripts/start_bridge.sh` | Always on |
 | Watchdog | `com.valor.bridge-watchdog` | `monitoring/bridge_watchdog.py` | Every 60s |
 | Issue Poller | `com.valor.issue-poller` | Issue polling script | Every 5min |
-| Reflections | `com.valor.reflections` | `scripts/reflections.py` | Scheduled |
 | AutoExperiment | `com.valor.autoexperiment` | `scripts/autoexperiment.py` | Nightly |
 
-**Code example — reflections maintenance:**
-```bash
-# Run reflections with dry-run
-python scripts/reflections.py --dry-run
+Reflections no longer run via launchd; the scheduler is embedded in the worker (`python -m worker`). See [Reflections](../features/reflections.md) for details.
 
-# Tasks performed:
-# 1. Legacy code cleanup scan
-# 2. Log review and error pattern detection  
-# 3. Sentry error monitoring
-# 4. Task management cleanup
-# 5. Documentation staleness check
-# 6. Daily report generation
-```
+**Code example — reflections maintenance:**
+
+Reflections are declared in `config/reflections.yaml` (a vault-symlinked registry). Each entry maps to a callable in the `reflections/` package (e.g., `reflections.maintenance.run_redis_ttl_cleanup`). The `ReflectionScheduler` in `agent/reflection_scheduler.py` — run as an asyncio task inside the standalone worker — enqueues due reflections at their declared intervals. There is no direct CLI invocation.
 
 **Remote triggers (via /schedule skill):**
 ```bash


### PR DESCRIPTION
## Summary

Cascade the doc cleanup left behind by #748 (`scripts/reflections.py` monolith deletion) across six feature/guide/research docs. Scope is strictly the six files called out in the issue; #1031 covers the `adding-reflection-tasks.md` rewrite separately, and #1134 deferred these six files to this issue.

## Changes

- `docs/features/popoto-index-hygiene.md` — removed "Cleanup Reflection (Runner)" section; renamed "Cleanup Reflection (Scheduler)" → "Cleanup Reflection"; fixed "bridge-hosted" → "worker-embedded in `python -m worker`" (blocker); updated Three Cleanup Paths table row 2 Trigger "Bridge tick" → "Worker scheduler tick" and collapsed to two rows ("Cleanup Paths"); removed `scripts/reflections.py` row from Key Files table.
- `docs/features/bridge-self-healing.md` — removed `scripts/reflections.py` from the defensive `int()` pattern list (line 11); dropped the `reflections.log — configured in scripts/reflections.py` bullet entirely (no module in `reflections/` writes it; `reflections_error.log` already appears in the Shell-rotated bucket).
- `docs/features/telegram-history.md` — fixed ALL FOUR step-13 references (lines 35/47/54 "step 13" and line 58 `step_redis_cleanup()`). All now cite `redis-ttl-cleanup` reflection with the callable name.
- `docs/research/claude-code-feature-swot.md` and `docs/guides/claude-code-feature-swot.md` (lockstep) — removed the Reflections row from the launchd table; added a one-sentence note pointing to `../features/reflections.md`; replaced the `python scripts/reflections.py --dry-run` code example and numbered "Tasks performed" list with a one-paragraph description of the registry-driven flow.
- `docs/guides/valor-name-references.md` — applied pre-computed dispositions: DELETE rows 88 (`com.valor.reflections.plist`, file does not exist), 92 (`scripts/install_reflections.sh`, does not exist), 100 (`data/valor.session` → deleted script); ANNOTATE rows for `scripts/update/service.py`, `scripts/remote-update.sh`, `scripts/update/run.py` with the exact string `(removed service)`.

## Scope boundary (per plan No-Gos)

This PR touches ONLY the six files listed in #1032. It is non-overlapping with #1031 (which will rewrite `adding-reflection-tasks.md`) and #1134 (which already scrubbed the migration annotations from `reflections/*.py`).

The acceptance-criteria grep `grep -rn "scripts/reflections.py\|ReflectionRunner\|com.valor.reflections" docs/features docs/guides docs/research` returns hits only in:
- **Three annotated rows** in `docs/guides/valor-name-references.md` (89, 91, 108) — each carries the standard `(removed service)` annotation and is intentionally preserved as historical inventory.
- **Seven deferred out-of-scope files** (per plan Rabbit Hole #3, accepted as tangential history, no follow-up issue tracked): `docs/features/documentation-audit.md`, `docs/features/session-lifecycle.md`, `docs/features/pm-dev-session-architecture.md`, `docs/features/sustainable-self-healing.md`, `docs/features/unified-analytics.md`, `docs/features/bridge-resilience.md`, `docs/features/session-lifecycle-diagnostics.md`. Each references the monolith in an incidental/contextual way — not as a live-architecture claim a reader would act on. An intentional scope boundary, not forgotten work.
- **`docs/features/adding-reflection-tasks.md`** — in scope for #1031, not this PR.

## Testing

- `diff docs/research/claude-code-feature-swot.md docs/guides/claude-code-feature-swot.md | grep -E "reflections|reflections.py|com.valor.reflections"` → exit 1 (SWOT copies in lockstep; only pre-existing ChatSession/PM session differences remain).
- `grep -n "step 13\|step_redis_cleanup" docs/features/telegram-history.md` → exit 1 (all four references fixed).
- `python -m ruff format --check .` → 642 files already formatted.
- `git diff --name-only main -- docs/` → exactly the six files listed in #1032.

## Definition of Done

- [x] Built: All six files edited per plan Solution section (pre-computed dispositions applied, no builder discretion).
- [x] Tested: All six verification-table checks pass (manual run).
- [x] Documented: The PR **is** the documentation work.
- [x] Quality: Format check clean.

Closes #1032