### PR TITLE
.env.example per-variable comments + env completeness check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,12 +63,14 @@ PERPLEXITY_API_KEY=pplx-****
 # Telegram Configuration
 # =============================================================================
 
-# Telegram Developer API (get from my.telegram.org)
+# Telegram Developer API credentials (get from my.telegram.org under API Development Tools)
 TELEGRAM_API_ID=12345****
+# Telegram Developer API hash — paired with TELEGRAM_API_ID; both required for Telethon auth
 TELEGRAM_API_HASH=abcd1234****
 
 # Telegram Account (for user account auth)
 TELEGRAM_PHONE=+1234567****
+# Telegram account 2FA password (optional; only required if Two-Step Verification is enabled on the account)
 TELEGRAM_PASSWORD=your_password_****
 
 # Session name (unique per instance if sharing Telegram account)
@@ -84,6 +86,7 @@ NOTION_API_KEY=ntn_****
 
 # Sentry (for error monitoring skill)
 SENTRY_API_KEY=****
+# Sentry organization slug — found in your Sentry org URL (e.g. app.sentry.io/organizations/<slug>/)
 SENTRY_ORG_SLUG=your-org
 
 # Sentry SDK (for error tracking in the bridge process)
@@ -91,6 +94,7 @@ SENTRY_ORG_SLUG=your-org
 # since been rotated/revoked in Sentry (test events return HTTP 403). Use your
 # own DSN here — never commit a real one.
 SENTRY_DSN=https://your-key@your-org.ingest.sentry.io/your-project
+# Sentry environment tag attached to all events (e.g. production, staging, dev)
 SENTRY_ENVIRONMENT=production
 
 # GitHub (for repository skill)
@@ -163,18 +167,26 @@ OLLAMA_VISION_MODEL=llama3.2-vision:11b
 # Create an App Password for "Mail" and use it here (not your regular password).
 # Gmail IMAP: imap.gmail.com:993 (SSL), Gmail SMTP: smtp.gmail.com:587 (STARTTLS)
 
+# IMAP server hostname for inbound email polling (default: imap.gmail.com)
 IMAP_HOST=imap.gmail.com
+# IMAP server port — 993 for SSL, 143 for STARTTLS
 IMAP_PORT=993
+# IMAP login username (your Gmail address)
 IMAP_USER=valor@yuda.me
+# IMAP login password — use a Gmail App Password, not your account password
 IMAP_PASSWORD=your-gmail-app-password-here
 # Set to "false" to disable SSL (not recommended)
 IMAP_SSL=true
 # Seconds between IMAP polls (default: 30)
 IMAP_POLL_INTERVAL=30
 
+# SMTP server hostname for outbound email delivery (default: smtp.gmail.com)
 SMTP_HOST=smtp.gmail.com
+# SMTP server port — 587 for STARTTLS, 465 for SSL
 SMTP_PORT=587
+# SMTP login username (your Gmail address)
 SMTP_USER=valor@yuda.me
+# SMTP login password — use a Gmail App Password, not your account password
 SMTP_PASSWORD=your-gmail-app-password-here
 # Set to "false" to disable STARTTLS (not recommended)
 SMTP_USE_TLS=true

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -48,6 +48,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [Emoji Embedding Reactions](emoji-embedding-reactions.md) | Embedding-based emoji reaction selection with standard and Premium custom emoji support, EmojiResult type, send_telegram --react and --emoji flags, and graceful degradation | Shipped |
 | [Enforce REVIEW/DOCS Stages](enforce-review-docs-stages.md) | Hard delivery gates in Observer preventing SDLC pipeline from skipping REVIEW and DOCS stages | Shipped |
 | [Enhanced Planning](enhanced-planning.md) | Spike Resolution (Phase 1.5), RFC Review (Phase 2.8), Infrastructure Documentation, and task validation fields for /do-plan | Shipped |
+| [Env Completeness Validation](env-completeness-validation.md) | Detects missing environment variables during `--verify` runs by diffing `.env` against `.env.example`; surfaces `WARN: env-completeness:` lines listing missing keys with descriptions | Shipped |
 | [Features README Sort Check](features-readme-sort-check.md) | PostToolUse hook enforcing alphabetical sort order in the feature index table with auto-fix | Shipped |
 | [Git State Guard](git-state-guard.md) | Detects and resolves dirty git state (merges, rebases, cherry-picks) before SDLC branch operations | Shipped |
 | [Goal Gates](goal-gates.md) | Deterministic enforcement gates preventing SDLC pipeline from silently skipping stages | Shipped |

--- a/docs/features/env-completeness-validation.md
+++ b/docs/features/env-completeness-validation.md
@@ -1,0 +1,93 @@
+# Env Completeness Validation
+
+Detects missing environment variables during update runs by comparing the live `.env` file against the canonical `.env.example` declaration list.
+
+## Problem
+
+New features frequently add variables to `.env.example`, but existing machines' vault `.env` files are never automatically alerted. The gap is silent — no warning appears during `scripts/update/run.py --verify`. Operators discover missing variables only when runtime errors occur.
+
+## How It Works
+
+The completeness check runs automatically as part of `python scripts/update/run.py --verify` and `--full`. It performs three steps:
+
+1. **Parse `.env.example`**: Reads all `KEY=` declarations and extracts the immediately preceding comment block. The last non-empty, non-separator comment line above each key is used as the description.
+2. **Parse live `.env`**: Reads all keys present in `.env`, treating blank values (`KEY=`) as present. The `.env` file is a symlink to `~/Desktop/Valor/.env`.
+3. **Diff**: Keys declared in `.env.example` but absent from `.env` are surfaced as a `WARN` line.
+
+### Output Format
+
+When keys are missing, the verify output shows:
+
+```
+[update]   WARN: env-completeness: 2 missing: REDIS_URL (Redis connection URL); OPENROUTER_API_KEY (OpenRouter API Key)
+```
+
+When all keys are present:
+
+```
+(no output — check passes silently)
+```
+
+The check appears in `result.valor_tools` in the `VerificationResult`. Missing keys are also appended to `result.warnings` so they appear in the final `FAILED with N error(s)` count.
+
+## .env.example Comment Convention
+
+Every `KEY=` declaration in `.env.example` must be preceded by at least one comment line. The convention:
+
+```
+# Short description of what this controls (required/optional, default if unset, where to get it)
+KEY_NAME=placeholder-value
+```
+
+For multi-line blocks, the last non-empty comment line is used as the description:
+
+```
+# Prefix used for all macOS launchd Label fields.
+# Changing this after install requires uninstall + reinstall.
+# The canonical Valor install uses com.valor.
+SERVICE_LABEL_PREFIX=com.valor
+```
+
+Section separator lines (`# ======...`) are ignored by the parser and do not contribute to descriptions.
+
+## Interpreting Warnings
+
+A `WARN: env-completeness:` line means your vault `.env` is missing one or more declared variables. For each missing variable:
+
+1. **Check the description** — it tells you what the variable controls and whether it's optional.
+2. **Add optional vars** if you want the feature they enable (e.g., `STRIPE_API_KEY` for the payment skill). Omitting optional vars is fine; the warning is informational.
+3. **Add required vars** before running dependent services. Missing required vars cause runtime errors.
+
+To add a variable: edit `~/Desktop/Valor/.env` directly (the vault), then run `--verify` again to confirm the warning clears.
+
+## Graceful Degradation
+
+The check never crashes the update run:
+
+- **`.env` not found** — returns `skipped (.env not found)`. Expected on a fresh machine before vault sync.
+- **`.env.example` not found** — returns `skipped (.env.example not found)`.
+- **`OSError` reading either file** — returns `skipped (read error)`. Covers TCC permission errors and iCloud eviction.
+
+## Implementation
+
+**`scripts/update/verify.py`**:
+- `_parse_env_example(path)` — extracts `(key, description)` pairs using a comment block accumulator
+- `_parse_env_keys(path)` — returns the set of keys present in `.env` (blank values count as present)
+- `check_env_completeness(project_dir)` — orchestrates the comparison and returns a `ToolCheck`
+- `verify_environment()` — calls `check_env_completeness()` and appends to `result.valor_tools`
+
+**`scripts/update/run.py`**:
+- New `valor_tools` loop after the `system_tools` loop (Step 6) surfaces `WARN:` lines for any `ToolCheck` with `available=False`
+
+## Tests
+
+`tests/unit/test_env_completeness.py` — 14 tests covering:
+- Missing key detection with description extraction
+- Blank-value tolerance
+- Multiple missing keys (semicolon-separated)
+- All-present happy path
+- Skipped results for missing files
+- OSError graceful recovery
+- Multi-line comment block parsing
+- Section separator exclusion
+- Comment lines in `.env` not treated as keys

--- a/docs/plans/env-completeness-validation.md
+++ b/docs/plans/env-completeness-validation.md
@@ -1,5 +1,5 @@
 ---
-status: docs_complete
+status: Planning
 type: chore
 appetite: Small
 owner: Valor Engels
@@ -250,19 +250,19 @@ No agent integration required — this is an update-system internal change. The 
 
 ## Documentation
 
-- [x] Update `docs/features/env-completeness-validation.md` — new feature doc describing the completeness check behavior, how to interpret warnings, and the `.env.example` comment convention
-- [x] Add entry to `docs/features/README.md` index table for the new feature doc
+- [ ] Update `docs/features/env-completeness-validation.md` — new feature doc describing the completeness check behavior, how to interpret warnings, and the `.env.example` comment convention
+- [ ] Add entry to `docs/features/README.md` index table for the new feature doc
 
 ## Success Criteria
 
-- [x] Every variable in `.env.example` has at least one descriptive comment line above it
-- [x] `scripts/update/verify.py::check_env_completeness()` exists and parses `.env.example` for declared keys
-- [x] Running `python scripts/update/run.py --verify` with a `.env` missing a declared key surfaces `WARN: env-completeness: 1 missing: KEY_NAME (description)` in the output
-- [x] Blank values in `.env` (`KEY=`) are treated as present — no false warning
-- [x] `.env` not found returns a skipped result (no exception)
-- [x] `tests/unit/test_env_completeness.py` passes covering: missing key detection, blank-value tolerance, unreadable-file graceful skip
-- [x] Tests pass (`pytest tests/unit/test_env_completeness.py`)
-- [x] Lint/format clean (`python -m ruff check . && python -m ruff format --check .`)
+- [ ] Every variable in `.env.example` has at least one descriptive comment line above it
+- [ ] `scripts/update/verify.py::check_env_completeness()` exists and parses `.env.example` for declared keys
+- [ ] Running `python scripts/update/run.py --verify` with a `.env` missing a declared key surfaces `WARN: env-completeness: 1 missing: KEY_NAME (description)` in the output
+- [ ] Blank values in `.env` (`KEY=`) are treated as present — no false warning
+- [ ] `.env` not found returns a skipped result (no exception)
+- [ ] `tests/unit/test_env_completeness.py` passes covering: missing key detection, blank-value tolerance, unreadable-file graceful skip
+- [ ] Tests pass (`pytest tests/unit/test_env_completeness.py`)
+- [ ] Lint/format clean (`python -m ruff check . && python -m ruff format --check .`)
 
 ## Team Orchestration
 

--- a/docs/plans/env-completeness-validation.md
+++ b/docs/plans/env-completeness-validation.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: docs_complete
 type: chore
 appetite: Small
 owner: Valor Engels
@@ -250,19 +250,19 @@ No agent integration required — this is an update-system internal change. The 
 
 ## Documentation
 
-- [ ] Update `docs/features/env-completeness-validation.md` — new feature doc describing the completeness check behavior, how to interpret warnings, and the `.env.example` comment convention
-- [ ] Add entry to `docs/features/README.md` index table for the new feature doc
+- [x] Update `docs/features/env-completeness-validation.md` — new feature doc describing the completeness check behavior, how to interpret warnings, and the `.env.example` comment convention
+- [x] Add entry to `docs/features/README.md` index table for the new feature doc
 
 ## Success Criteria
 
-- [ ] Every variable in `.env.example` has at least one descriptive comment line above it
-- [ ] `scripts/update/verify.py::check_env_completeness()` exists and parses `.env.example` for declared keys
-- [ ] Running `python scripts/update/run.py --verify` with a `.env` missing a declared key surfaces `WARN: env-completeness: 1 missing: KEY_NAME (description)` in the output
-- [ ] Blank values in `.env` (`KEY=`) are treated as present — no false warning
-- [ ] `.env` not found returns a skipped result (no exception)
-- [ ] `tests/unit/test_env_completeness.py` passes covering: missing key detection, blank-value tolerance, unreadable-file graceful skip
-- [ ] Tests pass (`pytest tests/unit/test_env_completeness.py`)
-- [ ] Lint/format clean (`python -m ruff check . && python -m ruff format --check .`)
+- [x] Every variable in `.env.example` has at least one descriptive comment line above it
+- [x] `scripts/update/verify.py::check_env_completeness()` exists and parses `.env.example` for declared keys
+- [x] Running `python scripts/update/run.py --verify` with a `.env` missing a declared key surfaces `WARN: env-completeness: 1 missing: KEY_NAME (description)` in the output
+- [x] Blank values in `.env` (`KEY=`) are treated as present — no false warning
+- [x] `.env` not found returns a skipped result (no exception)
+- [x] `tests/unit/test_env_completeness.py` passes covering: missing key detection, blank-value tolerance, unreadable-file graceful skip
+- [x] Tests pass (`pytest tests/unit/test_env_completeness.py`)
+- [x] Lint/format clean (`python -m ruff check . && python -m ruff format --check .`)
 
 ## Team Orchestration
 

--- a/scripts/update/run.py
+++ b/scripts/update/run.py
@@ -1041,6 +1041,12 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
                 if tool.name not in optional_tools:
                     result.warnings.append(f"{tool.name}: {tool.error}")
 
+        # Report valor tool checks (env-completeness, etc.)
+        for tool in result.verification.valor_tools:
+            if not tool.available and tool.error:
+                log(f"  WARN: {tool.name}: {tool.error}", v, always=True)
+                result.warnings.append(f"{tool.name}: {tool.error}")
+
         # Migrate legacy Desktop/claude_code paths in settings.json
         log("Migrating settings.json paths...", v)
         settings_migration = verify.migrate_settings_json_paths()

--- a/scripts/update/verify.py
+++ b/scripts/update/verify.py
@@ -843,6 +843,105 @@ def check_google_token(project_dir: Path) -> ToolCheck:
         )
 
 
+_KEY_RE = re.compile(r"^([A-Z][A-Z0-9_]*)=")
+_SECTION_RE = re.compile(r"^#\s*={10,}")  # section separator lines (# ===...)
+
+
+def _parse_env_example(path: Path) -> list[tuple[str, str]]:
+    """Return list of (key, description) pairs from a .env.example file.
+
+    Description is the last non-blank, non-separator comment line immediately
+    above the key declaration. Blank lines reset the comment accumulator.
+    """
+    lines = path.read_text().splitlines()
+    result = []
+    comment_block: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if _SECTION_RE.match(stripped):
+            # Section separator — reset accumulator without contributing to description
+            comment_block = []
+        elif stripped.startswith("#"):
+            comment_block.append(stripped.lstrip("#").strip())
+        elif m := _KEY_RE.match(stripped):
+            key = m.group(1)
+            # Use last non-empty comment line as the description
+            description = next((c for c in reversed(comment_block) if c), "")
+            result.append((key, description))
+            comment_block = []
+        else:
+            comment_block = []  # blank line resets comment accumulation
+    return result
+
+
+def _parse_env_keys(path: Path) -> set[str]:
+    """Return set of all keys present in .env (blank values are present)."""
+    keys = set()
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            key = line.split("=", 1)[0].strip()
+            if _KEY_RE.match(key + "="):
+                keys.add(key)
+    return keys
+
+
+def check_env_completeness(project_dir: Path) -> ToolCheck:
+    """Check that .env contains all keys declared in .env.example.
+
+    Returns a single ToolCheck:
+    - available=True, version="all N vars present" when .env has all declared keys
+    - available=False, error="N missing: KEY1 (desc); KEY2 (desc)" when gaps exist
+    - available=True, version="skipped (.env not found)" when .env doesn't exist
+    - available=True, version="skipped (read error)" on OSError
+    """
+    try:
+        env_example = project_dir / ".env.example"
+        env_file = project_dir / ".env"
+
+        if not env_example.exists():
+            return ToolCheck(
+                name="env-completeness",
+                available=True,
+                version="skipped (.env.example not found)",
+            )
+
+        declared = _parse_env_example(env_example)
+
+        if not env_file.exists():
+            return ToolCheck(
+                name="env-completeness",
+                available=True,
+                version="skipped (.env not found)",
+            )
+
+        present = _parse_env_keys(env_file)
+        declared_keys = {k for k, _ in declared}
+        missing_keys = declared_keys - present
+
+        if not missing_keys:
+            return ToolCheck(
+                name="env-completeness",
+                available=True,
+                version=f"all {len(declared_keys)} vars present",
+            )
+
+        desc_map = dict(declared)
+        parts = [
+            f"{k} ({desc_map.get(k, 'no description')})" if desc_map.get(k) else k
+            for k in sorted(missing_keys)
+        ]
+        error = f"{len(missing_keys)} missing: {'; '.join(parts)}"
+        return ToolCheck(name="env-completeness", available=False, error=error)
+
+    except OSError:
+        return ToolCheck(
+            name="env-completeness",
+            available=True,
+            version="skipped (read error)",
+        )
+
+
 def verify_environment(project_dir: Path, check_ollama_model: bool = True) -> VerificationResult:
     """Run all environment verification checks."""
     result = VerificationResult()
@@ -853,6 +952,7 @@ def verify_environment(project_dir: Path, check_ollama_model: bool = True) -> Ve
     result.valor_tools = check_valor_tools(project_dir)
     result.valor_tools.append(check_telegram_session(project_dir))
     result.valor_tools.append(check_google_token(project_dir))
+    result.valor_tools.append(check_env_completeness(project_dir))
 
     if check_ollama_model:
         ollama_model = os.getenv("OLLAMA_SUMMARIZER_MODEL", "gemma4:e2b")

--- a/tests/unit/test_env_completeness.py
+++ b/tests/unit/test_env_completeness.py
@@ -1,0 +1,213 @@
+"""Unit tests for check_env_completeness() in scripts/update/verify.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.update.verify import check_env_completeness
+
+
+@pytest.fixture()
+def env_dir(tmp_path: Path) -> Path:
+    """Return a tmp directory pre-configured with minimal .env.example and .env files."""
+    return tmp_path
+
+
+def write_example(env_dir: Path, content: str) -> None:
+    (env_dir / ".env.example").write_text(content)
+
+
+def write_env(env_dir: Path, content: str) -> None:
+    (env_dir / ".env").write_text(content)
+
+
+class TestMissingKeyReported:
+    def test_missing_key_reported(self, env_dir: Path) -> None:
+        """A key declared in .env.example but absent from .env surfaces as unavailable."""
+        write_example(env_dir, "# Redis connection URL\nREDIS_URL=redis://localhost\n")
+        write_env(env_dir, "# empty env\n")
+
+        result = check_env_completeness(env_dir)
+
+        assert result.available is False
+        assert result.error is not None
+        assert "REDIS_URL" in result.error
+        assert "missing" in result.error.lower()
+
+    def test_description_extracted_from_comment(self, env_dir: Path) -> None:
+        """The description from the comment above a key appears in the error message."""
+        write_example(
+            env_dir,
+            "# Redis connection URL for the cache layer\nREDIS_URL=redis://localhost\n",
+        )
+        write_env(env_dir, "OTHER_KEY=value\n")
+
+        result = check_env_completeness(env_dir)
+
+        assert result.available is False
+        assert result.error is not None
+        assert "Redis connection URL for the cache layer" in result.error
+
+    def test_multiple_missing_keys_semicolon_separated(self, env_dir: Path) -> None:
+        """Multiple missing keys are semicolon-separated in a single error string."""
+        write_example(
+            env_dir,
+            "# Key A\nKEY_A=val\n# Key B\nKEY_B=val\n",
+        )
+        write_env(env_dir, "# nothing\n")
+
+        result = check_env_completeness(env_dir)
+
+        assert result.available is False
+        assert result.error is not None
+        assert "KEY_A" in result.error
+        assert "KEY_B" in result.error
+        assert "2 missing" in result.error
+
+
+class TestBlankValueIsPresent:
+    def test_blank_value_is_present(self, env_dir: Path) -> None:
+        """A key present in .env with a blank value is treated as present (no warning)."""
+        write_example(env_dir, "# Redis URL\nREDIS_URL=redis://localhost\n")
+        write_env(env_dir, "REDIS_URL=\n")
+
+        result = check_env_completeness(env_dir)
+
+        assert result.available is True
+        assert result.error is None
+
+    def test_blank_value_with_spaces(self, env_dir: Path) -> None:
+        """A key with whitespace-only value is still considered present."""
+        write_example(env_dir, "# API key\nAPI_KEY=sk-****\n")
+        write_env(env_dir, "API_KEY=   \n")
+
+        # The key name itself exists in .env — the parser splits on first '='
+        result = check_env_completeness(env_dir)
+
+        assert result.available is True
+
+
+class TestAllPresent:
+    def test_all_present(self, env_dir: Path) -> None:
+        """When .env contains all declared keys the check returns available=True."""
+        write_example(
+            env_dir,
+            "# Key A\nKEY_A=val\n# Key B\nKEY_B=val\n",
+        )
+        write_env(env_dir, "KEY_A=something\nKEY_B=other\n")
+
+        result = check_env_completeness(env_dir)
+
+        assert result.available is True
+        assert "all" in (result.version or "").lower()
+        assert result.error is None
+
+    def test_all_present_version_includes_count(self, env_dir: Path) -> None:
+        """Version string includes the total variable count."""
+        write_example(env_dir, "# Key A\nKEY_A=val\n")
+        write_env(env_dir, "KEY_A=x\n")
+
+        result = check_env_completeness(env_dir)
+
+        assert result.available is True
+        assert "1" in (result.version or "")
+
+
+class TestEnvNotFoundReturnsSkipped:
+    def test_env_not_found_returns_skipped(self, env_dir: Path) -> None:
+        """When .env is absent the check returns available=True with a skipped version."""
+        write_example(env_dir, "# Key\nKEY_A=val\n")
+        # Deliberately do NOT create .env
+
+        result = check_env_completeness(env_dir)
+
+        assert result.available is True
+        assert result.version is not None
+        assert "skipped" in result.version.lower()
+        assert ".env not found" in result.version.lower()
+
+    def test_env_example_not_found_returns_skipped(self, env_dir: Path) -> None:
+        """When .env.example is absent the check returns available=True with skipped."""
+        # Neither file exists
+        result = check_env_completeness(env_dir)
+
+        assert result.available is True
+        assert result.version is not None
+        assert "skipped" in result.version.lower()
+
+
+class TestUnreadableEnvReturnsSkipped:
+    def test_unreadable_env_returns_skipped(self, env_dir: Path) -> None:
+        """If reading a file raises OSError the function returns a skipped ToolCheck."""
+        write_example(env_dir, "# Key\nKEY_A=val\n")
+        write_env(env_dir, "KEY_A=x\n")
+
+        with patch(
+            "scripts.update.verify._parse_env_example",
+            side_effect=OSError("permission denied"),
+        ):
+            result = check_env_completeness(env_dir)
+
+        assert result.available is True
+        assert result.version is not None
+        assert "skipped" in result.version.lower()
+        assert "read error" in result.version.lower()
+
+
+class TestParsingEdgeCases:
+    def test_multiline_comment_block_uses_last_line(self, env_dir: Path) -> None:
+        """Multi-line comment blocks use the last non-empty line as description."""
+        write_example(
+            env_dir,
+            ("# First line of comment\n# Second line — the actual description\nMY_KEY=value\n"),
+        )
+        write_env(env_dir, "# empty\n")
+
+        result = check_env_completeness(env_dir)
+
+        assert result.available is False
+        assert result.error is not None
+        assert "Second line" in result.error
+
+    def test_section_separator_does_not_bleed_into_description(self, env_dir: Path) -> None:
+        """Section separator lines (# ===) are not used as descriptions."""
+        write_example(
+            env_dir,
+            (
+                "# ==============================\n"
+                "# Infrastructure\n"
+                "# ==============================\n"
+                "# Actual description\n"
+                "REDIS_URL=redis://localhost\n"
+            ),
+        )
+        write_env(env_dir, "# empty\n")
+
+        result = check_env_completeness(env_dir)
+
+        assert result.available is False
+        assert result.error is not None
+        # Section separators should not appear; actual description should
+        assert "Actual description" in result.error
+        assert "===" not in result.error
+
+    def test_comment_lines_in_env_are_ignored(self, env_dir: Path) -> None:
+        """Comment lines in .env are not treated as keys."""
+        write_example(env_dir, "# API key\nAPI_KEY=sk-****\n")
+        write_env(env_dir, "# API_KEY=should-not-match\nAPI_KEY=real-value\n")
+
+        result = check_env_completeness(env_dir)
+
+        assert result.available is True
+
+    def test_no_keys_in_env_example_returns_available(self, env_dir: Path) -> None:
+        """.env.example with no KEY= declarations yields available=True (nothing to check)."""
+        write_example(env_dir, "# Just comments\n# No keys here\n")
+        write_env(env_dir, "SOMETHING=value\n")
+
+        result = check_env_completeness(env_dir)
+
+        assert result.available is True


### PR DESCRIPTION
## Summary
- Annotates all previously bare `KEY=value` lines in `.env.example` with descriptive comment blocks (12 variables: TELEGRAM_API_HASH, TELEGRAM_PASSWORD, SENTRY_ORG_SLUG, SENTRY_ENVIRONMENT, all IMAP_*/SMTP_* vars)
- Adds `check_env_completeness()` to `scripts/update/verify.py` that diffs `.env` against `.env.example` and returns a `ToolCheck` with a semicolon-separated error listing missing keys and their descriptions
- Wires the check into `verify_environment()` and adds a `valor_tools` reporting loop to `run.py` Step 6 so missing-key `WARN:` lines surface during `--verify` runs instead of being silently discarded
- 14 unit tests covering all acceptance criteria

## Changes
- `.env.example` — all variables now have at least one comment line above them
- `scripts/update/verify.py` — new `_parse_env_example()`, `_parse_env_keys()`, `check_env_completeness()` functions
- `scripts/update/run.py` — new `valor_tools` loop in Step 6
- `tests/unit/test_env_completeness.py` — 14 tests (missing key detection, blank-value tolerance, skipped on missing file, OSError graceful recovery, multi-line comment parsing, section separator exclusion)
- `docs/features/env-completeness-validation.md` — new feature doc
- `docs/features/README.md` — index entry added

## Testing
- [x] `pytest tests/unit/test_env_completeness.py -v` — 14/14 passed
- [x] `python -m ruff check` — clean
- [x] `python -m ruff format --check` — clean
- [x] Programmatic check: no bare `KEY=` lines in `.env.example`
- [x] `grep -n "valor_tools" scripts/update/run.py` — loop present

## Documentation
- [x] `docs/features/env-completeness-validation.md` created
- [x] `docs/features/README.md` index entry added (alphabetically sorted)

## Definition of Done
- [x] Built: Code implemented and working
- [x] Tested: All tests passing
- [x] Documented: Docs created/updated
- [x] Quality: Lint and format checks pass

Closes #1140