### PR TITLE
feat: PostCompact re-grounding hook for CLI sessions (#1139)

### DIFF
--- a/.claude/hooks/post_compact.py
+++ b/.claude/hooks/post_compact.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Hook: PostCompact - Re-ground the agent after context compaction.
+
+This hook fires after every context compaction event (auto or manual). It emits
+a short, imperative nudge directing the agent to re-read the plan doc, check SDLC
+stage progress, look at any PROGRESS.md scratchpad, and review the TodoWrite task
+list. Exit code 0 causes the Claude CLI to surface the nudge as a user-visible
+message at the start of the next turn.
+
+Hook contract:
+    Input (stdin): JSON with fields:
+        hook_event_name: "PostCompact"
+        session_id: claude session UUID (same as AgentSession.claude_session_uuid)
+        trigger: "auto" | "manual"
+        compact_summary: compacted summary text
+        transcript_path: path to the JSONL transcript
+        cwd: working directory of the Claude session
+
+    Output (stdout, exit 0): nudge message text, or empty string if no output.
+    Exit code: always 0 -- hook must never block the session.
+
+Why CLI-only (not in build_hooks_config):
+    The Claude SDK HookEvent type does not include PostCompact. Bridge sessions
+    (SDK-based) rely on the existing defer_post_compact nudge guard in the output
+    router and issue #1130 prompt instructions in builder.md. This hook is scoped
+    to local interactive Claude Code CLI sessions only.
+
+Bail-out guarantee:
+    All exceptions are swallowed. On any error, the hook prints nothing and exits 0.
+    This ensures the Claude CLI is never interrupted by hook failures.
+"""
+
+import logging
+import os
+import re
+import sys
+from pathlib import Path
+
+# Standalone script -- sys.path mutation is safe (never imported as library)
+# Add project root to path for model imports
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+# Add hook_utils to path
+HOOKS_DIR = str(Path(__file__).resolve().parent)
+sys.path.insert(0, HOOKS_DIR)
+
+from hook_utils.constants import log_hook_error, read_hook_input  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_issue_number(issue_url):
+    """Extract trailing issue number from a GitHub issue URL.
+
+    Args:
+        issue_url: e.g. "https://github.com/org/repo/issues/1139"
+
+    Returns:
+        Integer issue number, or None if not parseable.
+    """
+    if not issue_url:
+        return None
+    match = re.search(r"/(\d+)/?$", issue_url.strip())
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def _lookup_session(claude_session_uuid):
+    """Look up an AgentSession by claude_session_uuid.
+
+    Returns:
+        Tuple of (plan_url, issue_url, stage_states_json).
+        All three are None on any exception or if no row is found.
+    """
+    try:
+        from models.agent_session import AgentSession
+
+        rows = list(AgentSession.query.filter(claude_session_uuid=claude_session_uuid))
+        if not rows:
+            return None, None, None
+
+        session = rows[0]
+        plan_url = getattr(session, "plan_url", None) or None
+        issue_url = getattr(session, "issue_url", None) or None
+
+        # stage_states is a property returning a JSON string or None
+        stage_states_json = None
+        try:
+            raw = session.stage_states
+            if raw and isinstance(raw, str) and raw.strip() not in ("null", ""):
+                stage_states_json = raw
+        except Exception:
+            pass
+
+        return plan_url, issue_url, stage_states_json
+
+    except Exception as exc:
+        logger.warning("[post_compact] AgentSession lookup failed: %s", exc)
+        return None, None, None
+
+
+def _build_regrounding_nudge(plan_url, issue_url, stage_states_json, cwd):
+    """Build the re-grounding nudge message.
+
+    The nudge is directive, not descriptive. Each item is conditionally included
+    only when its data is available. Token budget: < 300 tokens in all paths.
+
+    Args:
+        plan_url: URL to the plan document, or None.
+        issue_url: GitHub issue URL (used to extract issue number), or None.
+        stage_states_json: JSON string of SDLC stage states, or None.
+        cwd: Working directory of the Claude session (may be empty string).
+
+    Returns:
+        The nudge string (non-empty). Always includes the header and TodoWrite item.
+    """
+    lines = ["Context was just compacted. Re-ground:"]
+    item_num = 1
+
+    if plan_url:
+        lines.append(f"{item_num}. Re-read the plan: `{plan_url}`")
+        item_num += 1
+
+    if stage_states_json:
+        issue_number = _extract_issue_number(issue_url)
+        if issue_number:
+            lines.append(
+                f"{item_num}. Check SDLC stage progress: "
+                f"`python -m tools.sdlc_stage_query --issue-number {issue_number}`"
+            )
+        else:
+            lines.append(
+                f"{item_num}. Check SDLC stage progress (stage_states are set on session)."
+            )
+        item_num += 1
+
+    # Check for PROGRESS.md in cwd (guard against empty/missing cwd)
+    effective_cwd = cwd or ""
+    if effective_cwd and os.path.exists(os.path.join(effective_cwd, "PROGRESS.md")):
+        lines.append(f"{item_num}. Re-read `PROGRESS.md` for working state.")
+        item_num += 1
+
+    lines.append(f"{item_num}. Re-read your current TodoWrite task list.")
+
+    return "\n".join(lines)
+
+
+def main():
+    """Main hook entry point."""
+    hook_input = read_hook_input()
+    if not hook_input:
+        return
+
+    session_id = hook_input.get("session_id")
+    if not session_id:
+        # No session_id -- emit nothing (bare invocation with no context)
+        return
+
+    cwd = hook_input.get("cwd") or ""
+
+    plan_url, issue_url, stage_states_json = _lookup_session(session_id)
+
+    nudge = _build_regrounding_nudge(plan_url, issue_url, stage_states_json, cwd)
+    if nudge:
+        print(nudge)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        log_hook_error("post_compact", str(e))

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -139,6 +139,18 @@
           }
         ]
       }
+    ],
+    "PostCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post_compact.py || true",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   }
 }

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -82,6 +82,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [Pipeline Graph](pipeline-graph.md) | Canonical directed graph for SDLC stage routing with cycle support for test-failure and review-feedback loops | Shipped |
 | [Pipeline State Machine](pipeline-state-machine.md) | Programmatic stage tracking replacing inference-based detection with direct state recording at transition points | Shipped |
 | [Plan Completion Gate](plan-completion-gate.md) | Deterministic validation preventing plan completion and PR merge while checkboxes remain unchecked | Shipped |
+| [Post-Compact Re-Grounding](post-compact-regrounding.md) | Short re-grounding nudge delivered after context compaction: re-read plan, check SDLC stage progress, review PROGRESS.md scratchpad, check TodoWrite task list; degrades gracefully to minimal nudge when no AgentSession context exists | Shipped |
 | [Plan Prerequisites Validation](plan-prerequisites.md) | Declare and validate environment requirements before plan execution | Shipped |
 | [PM Channels](pm-channels.md) | Project manager mode routing Telegram groups to work-vault folders with SDLC bypass | Shipped |
 | [PM Final Delivery](pm-final-delivery.md) | Marker-free PM terminal-turn protocol: predicate detects pipeline completion, dedicated runner composes and delivers final summary via harness `--resume`, CancelledError handler preserves user-visible interrupt line during shutdown | Shipped |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -82,7 +82,6 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [Pipeline Graph](pipeline-graph.md) | Canonical directed graph for SDLC stage routing with cycle support for test-failure and review-feedback loops | Shipped |
 | [Pipeline State Machine](pipeline-state-machine.md) | Programmatic stage tracking replacing inference-based detection with direct state recording at transition points | Shipped |
 | [Plan Completion Gate](plan-completion-gate.md) | Deterministic validation preventing plan completion and PR merge while checkboxes remain unchecked | Shipped |
-| [Post-Compact Re-Grounding](post-compact-regrounding.md) | Short re-grounding nudge delivered after context compaction: re-read plan, check SDLC stage progress, review PROGRESS.md scratchpad, check TodoWrite task list; degrades gracefully to minimal nudge when no AgentSession context exists | Shipped |
 | [Plan Prerequisites Validation](plan-prerequisites.md) | Declare and validate environment requirements before plan execution | Shipped |
 | [PM Channels](pm-channels.md) | Project manager mode routing Telegram groups to work-vault folders with SDLC bypass | Shipped |
 | [PM Final Delivery](pm-final-delivery.md) | Marker-free PM terminal-turn protocol: predicate detects pipeline completion, dedicated runner composes and delivers final summary via harness `--resume`, CancelledError handler preserves user-visible interrupt line during shutdown | Shipped |
@@ -95,6 +94,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [PM/Dev Session Architecture](pm-dev-session-architecture.md) | PM/Dev session split — session type discriminator splitting orchestration from execution | Shipped |
 | [Popoto Index Hygiene](popoto-index-hygiene.md) | Automated cleanup of orphaned Popoto index entries, Meta.ttl on AgentSession, raw Redis migration to Popoto models, daily rebuild_indexes reflection | Shipped |
 | [Popoto Redis Expansion](popoto-redis-expansion.md) | Migration from JSONL/JSON file state to Redis for atomicity and queries | Shipped |
+| [Post-Compact Re-Grounding](post-compact-regrounding.md) | Short re-grounding nudge delivered after context compaction: re-read plan, check SDLC stage progress, review PROGRESS.md scratchpad, check TodoWrite task list; degrades gracefully to minimal nudge when no AgentSession context exists | Shipped |
 | [Race Condition Analysis](race-condition-analysis.md) | Structured concurrency analysis section in plan template with soft validator for async code | Shipped |
 | [Reaction Semantics](reaction-semantics.md) | Emoji reaction protocol for message delivery feedback and silent loss prevention | Shipped |
 | [Redis Model Relationships](redis-models.md) | Cross-references between Popoto models, project_key on all models, enrichment metadata ownership on TelegramMessage, field type semantics (KeyField vs IndexedField) | Shipped |

--- a/docs/features/post-compact-regrounding.md
+++ b/docs/features/post-compact-regrounding.md
@@ -34,7 +34,8 @@ The nudge always includes the header ("Context was just compacted. Re-ground:") 
 | AgentSession with plan_url + stage_states + PROGRESS.md | Full 4-item nudge |
 | AgentSession with plan_url only | Header + plan item + TodoWrite |
 | AgentSession with no plan_url or stage_states | Header + TodoWrite (minimal nudge) |
-| No AgentSession row (bare CLI session, no session_id) | Nothing emitted |
+| session_id present, no matching AgentSession row | Header + TodoWrite (minimal nudge) |
+| No session_id in hook input | Nothing emitted |
 
 The minimal nudge (header + TodoWrite) is universally useful — even in one-off Claude Code sessions with no SDLC context, reminding the agent to check its task list is sound.
 

--- a/docs/features/post-compact-regrounding.md
+++ b/docs/features/post-compact-regrounding.md
@@ -1,0 +1,112 @@
+# Post-Compact Re-Grounding
+
+Short re-grounding nudge delivered to the agent immediately after context compaction, directing it to re-read the plan, check SDLC stage progress, review any PROGRESS.md scratchpad, and check the TodoWrite task list.
+
+## Status
+
+Shipped — issue [#1139](https://github.com/tomcounsell/ai/issues/1139).
+
+## Problem
+
+After context compaction, dev sessions resume against a compacted summary that rarely preserves working-state precision. Without a targeted nudge, multi-hour builds routinely drift from plan, repeat already-completed steps, or abandon in-progress work because the agent has no signal that a compaction just happened.
+
+## Behavior
+
+Immediately after every compaction event, `.claude/hooks/post_compact.py` emits a short imperative nudge to stdout. The Claude CLI surfaces this as a user-visible message at the start of the next turn.
+
+### Nudge content
+
+The nudge is directive, not descriptive. Each item is conditionally included only when its data is available:
+
+1. **Plan doc** (if `AgentSession.plan_url` is set): "Re-read the plan: `<plan_url>`"
+2. **SDLC stage progress** (if `AgentSession.stage_states` is set): "Check SDLC stage progress: `python -m tools.sdlc_stage_query --issue-number <N>`" — issue number is extracted from `AgentSession.issue_url`
+3. **PROGRESS.md scratchpad** (if `PROGRESS.md` exists in the session's `cwd`): "Re-read `PROGRESS.md` for working state."
+4. **TodoWrite task list** (always): "Re-read your current TodoWrite task list."
+
+The nudge always includes the header ("Context was just compacted. Re-ground:") and the TodoWrite item. All other items degrade gracefully when the underlying data is absent.
+
+**Token budget**: The full 4-item nudge runs ~80-120 tokens. Well under the 300-token ceiling.
+
+### Degradation behavior
+
+| Context available | Nudge content |
+|-------------------|---------------|
+| AgentSession with plan_url + stage_states + PROGRESS.md | Full 4-item nudge |
+| AgentSession with plan_url only | Header + plan item + TodoWrite |
+| AgentSession with no plan_url or stage_states | Header + TodoWrite (minimal nudge) |
+| No AgentSession row (bare CLI session, no session_id) | Nothing emitted |
+
+The minimal nudge (header + TodoWrite) is universally useful — even in one-off Claude Code sessions with no SDLC context, reminding the agent to check its task list is sound.
+
+## Why CLI-only
+
+The Claude SDK's `HookEvent` type does not include `PostCompact`. Registering this hook in `build_hooks_config()` (used by bridge/SDK-based sessions) would require SDK changes that are out of scope and unnecessary — bridge sessions rely on:
+
+1. The existing `defer_post_compact` nudge guard in `agent/output_router.py` (shipped in #1127/#1135).
+2. Issue #1130's prompt instructions in `builder.md` directing the agent to re-read `PROGRESS.md` after compaction.
+
+This hook is scoped purely to local interactive Claude Code CLI sessions.
+
+## Hook Contract
+
+**Input** (stdin JSON):
+- `hook_event_name`: `"PostCompact"`
+- `session_id`: Claude session UUID — same as `AgentSession.claude_session_uuid`
+- `trigger`: `"auto"` or `"manual"`
+- `compact_summary`: compacted summary text
+- `transcript_path`: path to the JSONL transcript
+- `cwd`: working directory of the Claude session
+
+**Output** (stdout, exit code 0): nudge message text, or empty if no context available (no `session_id` in input).
+
+**Exit code**: always 0. The hook must never block the session.
+
+**Bail-out guarantee**: All exceptions are swallowed. On any error, the hook prints nothing and exits 0. This ensures the Claude CLI is never interrupted by hook failures.
+
+## Registration
+
+`.claude/settings.json`:
+
+```json
+"PostCompact": [
+  {
+    "matcher": "",
+    "hooks": [
+      {
+        "type": "command",
+        "command": "python \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post_compact.py || true",
+        "timeout": 10
+      }
+    ]
+  }
+]
+```
+
+The `|| true` ensures the CLI is never blocked if the hook process exits non-zero. Timeout is 10 seconds — generous enough for a Redis lookup on a cold connection.
+
+## Relationship to Compaction Hardening (#1127/#1135)
+
+[Compaction Hardening](compaction-hardening.md) handles the *before-compaction* side:
+- PreCompact hook takes a JSONL backup
+- 5-minute cooldown prevents backup thrashing
+- 30-second post-compact nudge guard in the output router prevents immediate nudge-on-compaction
+
+This feature handles the *after-compaction* side: the agent's re-grounding at the start of the first post-compaction turn.
+
+The two features are complementary and independent. Disabling either does not affect the other.
+
+## Relationship to Long-Task Checkpointing (#1130)
+
+Issue #1130 adds prompt instructions in `builder.md` directing the agent to write `PROGRESS.md` during long tasks and to re-read it after compaction. This hook is the CLI-level enforcement of the same re-grounding intent — it fires automatically without requiring the agent to remember.
+
+If `PROGRESS.md` exists in `cwd`, the hook includes it as item 3 in the nudge. Issue #1130 need not have merged for this hook to be useful.
+
+## Cross-References
+
+- Plan: [`docs/plans/postcompact-regrounding-hook.md`](../plans/postcompact-regrounding-hook.md)
+- Issue: [#1139](https://github.com/tomcounsell/ai/issues/1139)
+- Hook: `.claude/hooks/post_compact.py`
+- Registration: `.claude/settings.json` (PostCompact key)
+- Tests: `tests/unit/hooks/test_post_compact_hook.py`
+- Related: [Compaction Hardening](compaction-hardening.md) — PreCompact backup + nudge guard
+- Related: [Claude Code Memory](claude-code-memory.md) — sibling CLI hook pattern

--- a/tests/unit/hooks/test_post_compact_hook.py
+++ b/tests/unit/hooks/test_post_compact_hook.py
@@ -6,11 +6,10 @@ success/failure/no-session paths, stdout output format, and bail-out guarantee.
 
 from __future__ import annotations
 
-import os
 import sys
 import uuid
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -19,12 +18,12 @@ HOOKS_DIR = Path(__file__).resolve().parent.parent.parent.parent / ".claude" / "
 if str(HOOKS_DIR) not in sys.path:
     sys.path.insert(0, str(HOOKS_DIR))
 
-from post_compact import (
+from models.agent_session import AgentSession  # noqa: E402, I001
+from post_compact import (  # noqa: E402, I001
     _build_regrounding_nudge,
     _extract_issue_number,
     _lookup_session,
 )
-from models.agent_session import AgentSession
 
 
 # ---------------------------------------------------------------------------
@@ -32,7 +31,9 @@ from models.agent_session import AgentSession
 # ---------------------------------------------------------------------------
 
 
-def _make_session(claude_uuid: str, plan_url=None, issue_url=None, stage_states=None) -> AgentSession:
+def _make_session(
+    claude_uuid: str, plan_url=None, issue_url=None, stage_states=None
+) -> AgentSession:
     """Create a minimal AgentSession for testing."""
     session = AgentSession(
         session_id=f"test-{claude_uuid[:8]}",
@@ -272,14 +273,6 @@ class TestMainFunction:
 class TestNoAsyncio:
     def test_does_not_import_asyncio(self):
         """Hook must not import asyncio -- it is fully synchronous."""
-        import importlib
-        import importlib.util
-
-        spec = importlib.util.spec_from_file_location(
-            "_post_compact_check",
-            HOOKS_DIR / "post_compact.py",
-        )
-        mod = importlib.util.module_from_spec(spec)
         # Do NOT exec the module to avoid side effects -- just check source
         src = (HOOKS_DIR / "post_compact.py").read_text()
         assert "import asyncio" not in src, "Hook must not import asyncio"

--- a/tests/unit/hooks/test_post_compact_hook.py
+++ b/tests/unit/hooks/test_post_compact_hook.py
@@ -1,0 +1,306 @@
+"""Tests for .claude/hooks/post_compact.py.
+
+Issue #1139. Covers the re-grounding nudge builder, AgentSession lookup
+success/failure/no-session paths, stdout output format, and bail-out guarantee.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add .claude/hooks to sys.path so we can import post_compact directly
+HOOKS_DIR = Path(__file__).resolve().parent.parent.parent.parent / ".claude" / "hooks"
+if str(HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(HOOKS_DIR))
+
+from post_compact import (
+    _build_regrounding_nudge,
+    _extract_issue_number,
+    _lookup_session,
+)
+from models.agent_session import AgentSession
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_session(claude_uuid: str, plan_url=None, issue_url=None, stage_states=None) -> AgentSession:
+    """Create a minimal AgentSession for testing."""
+    session = AgentSession(
+        session_id=f"test-{claude_uuid[:8]}",
+        session_type="dev",
+        project_key="test-postcompact",
+        claude_session_uuid=claude_uuid,
+    )
+    if plan_url is not None:
+        session.plan_url = plan_url
+    if issue_url is not None:
+        session.issue_url = issue_url
+    session.save()
+    return session
+
+
+# ---------------------------------------------------------------------------
+# _extract_issue_number
+# ---------------------------------------------------------------------------
+
+
+class TestExtractIssueNumber:
+    def test_standard_github_url(self):
+        url = "https://github.com/tomcounsell/ai/issues/1139"
+        assert _extract_issue_number(url) == 1139
+
+    def test_url_with_trailing_slash(self):
+        url = "https://github.com/org/repo/issues/42/"
+        assert _extract_issue_number(url) == 42
+
+    def test_none_returns_none(self):
+        assert _extract_issue_number(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert _extract_issue_number("") is None
+
+    def test_no_trailing_number_returns_none(self):
+        assert _extract_issue_number("https://github.com/org/repo/issues/") is None
+
+    def test_plan_url_has_no_issue_number(self):
+        """Plan URLs don't end with issue numbers -- returns None."""
+        url = "https://github.com/org/repo/blob/main/docs/plans/foo.md"
+        assert _extract_issue_number(url) is None
+
+
+# ---------------------------------------------------------------------------
+# _build_regrounding_nudge
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRegroundingNudge:
+    def test_full_nudge_with_all_context(self, tmp_path):
+        """All 4 items present when plan, stage_states, PROGRESS.md, and cwd all exist."""
+        progress_md = tmp_path / "PROGRESS.md"
+        progress_md.write_text("## Working State")
+
+        nudge = _build_regrounding_nudge(
+            plan_url="https://github.com/org/repo/blob/main/docs/plans/foo.md",
+            issue_url="https://github.com/org/repo/issues/1139",
+            stage_states_json='{"build": "complete"}',
+            cwd=str(tmp_path),
+        )
+
+        assert "Context was just compacted" in nudge
+        assert "Re-read the plan" in nudge
+        assert "SDLC stage progress" in nudge
+        assert "1139" in nudge
+        assert "PROGRESS.md" in nudge
+        assert "TodoWrite" in nudge
+
+    def test_minimal_nudge_no_session(self):
+        """No session context -- minimal nudge: header + TodoWrite item only."""
+        nudge = _build_regrounding_nudge(
+            plan_url=None,
+            issue_url=None,
+            stage_states_json=None,
+            cwd="",
+        )
+
+        assert "Context was just compacted" in nudge
+        assert "TodoWrite" in nudge
+        # Plan and stage items absent
+        assert "Re-read the plan" not in nudge
+        assert "SDLC stage progress" not in nudge
+        assert "PROGRESS.md" not in nudge
+
+    def test_partial_nudge_no_plan(self):
+        """AgentSession found but plan_url is None -- plan item absent."""
+        nudge = _build_regrounding_nudge(
+            plan_url=None,
+            issue_url="https://github.com/org/repo/issues/42",
+            stage_states_json='{"build": "complete"}',
+            cwd="",
+        )
+
+        assert "Re-read the plan" not in nudge
+        assert "SDLC stage progress" in nudge
+        assert "TodoWrite" in nudge
+
+    def test_partial_nudge_no_progress_md(self, tmp_path):
+        """Plan and stage_states present but no PROGRESS.md -- PROGRESS.md item absent."""
+        # tmp_path exists but has no PROGRESS.md
+        nudge = _build_regrounding_nudge(
+            plan_url="https://github.com/org/repo/blob/main/docs/plans/foo.md",
+            issue_url="https://github.com/org/repo/issues/99",
+            stage_states_json='{"build": "complete"}',
+            cwd=str(tmp_path),
+        )
+
+        assert "Re-read the plan" in nudge
+        assert "SDLC stage progress" in nudge
+        assert "PROGRESS.md" not in nudge
+        assert "TodoWrite" in nudge
+
+    def test_nudge_under_token_budget(self, tmp_path):
+        """Full 4-item nudge word count must be < 250 (proxy for < 300 tokens)."""
+        progress_md = tmp_path / "PROGRESS.md"
+        progress_md.write_text("## Working State")
+
+        nudge = _build_regrounding_nudge(
+            plan_url="https://github.com/org/repo/blob/main/docs/plans/foo.md",
+            issue_url="https://github.com/org/repo/issues/1139",
+            stage_states_json='{"build": "complete"}',
+            cwd=str(tmp_path),
+        )
+
+        word_count = len(nudge.split())
+        assert word_count < 250, f"Nudge too long: {word_count} words"
+
+    def test_empty_cwd_no_progress_md_check(self):
+        """Empty cwd string -- PROGRESS.md item never included."""
+        nudge = _build_regrounding_nudge(
+            plan_url=None,
+            issue_url=None,
+            stage_states_json=None,
+            cwd="",
+        )
+        assert "PROGRESS.md" not in nudge
+
+    def test_stage_states_no_issue_url(self):
+        """stage_states set but no issue_url -- stage item included but without issue number."""
+        nudge = _build_regrounding_nudge(
+            plan_url=None,
+            issue_url=None,
+            stage_states_json='{"build": "complete"}',
+            cwd="",
+        )
+        assert "SDLC stage progress" in nudge
+        # No issue number in the nudge since issue_url is None
+        assert "--issue-number" not in nudge
+
+
+# ---------------------------------------------------------------------------
+# _lookup_session
+# ---------------------------------------------------------------------------
+
+
+class TestLookupSession:
+    def test_session_found_returns_fields(self):
+        """Session exists -- returns (plan_url, issue_url, stage_states_json)."""
+        claude_uuid = str(uuid.uuid4())
+        _make_session(
+            claude_uuid,
+            plan_url="https://github.com/org/repo/blob/main/docs/plans/foo.md",
+            issue_url="https://github.com/org/repo/issues/1139",
+        )
+
+        plan_url, issue_url, stage_states_json = _lookup_session(claude_uuid)
+
+        assert plan_url == "https://github.com/org/repo/blob/main/docs/plans/foo.md"
+        assert issue_url == "https://github.com/org/repo/issues/1139"
+        # No stage_states set -- should be None
+        assert stage_states_json is None
+
+    def test_no_session_returns_nones(self):
+        """No matching session -- returns (None, None, None)."""
+        plan_url, issue_url, stage_states_json = _lookup_session(str(uuid.uuid4()))
+        assert plan_url is None
+        assert issue_url is None
+        assert stage_states_json is None
+
+    def test_lookup_exception_returns_nones(self):
+        """AgentSession.query raises -- returns (None, None, None) without raising."""
+        with patch("models.agent_session.AgentSession.query") as mock_query:
+            mock_query.filter.side_effect = ConnectionError("redis down")
+            plan_url, issue_url, stage_states_json = _lookup_session(str(uuid.uuid4()))
+
+        assert plan_url is None
+        assert issue_url is None
+        assert stage_states_json is None
+
+
+# ---------------------------------------------------------------------------
+# main() / subprocess contract
+# ---------------------------------------------------------------------------
+
+
+class TestMainFunction:
+    def test_no_session_id_in_input(self, capsys):
+        """Input missing session_id -- nothing written to stdout."""
+        from post_compact import main
+
+        hook_input = {"hook_event_name": "PostCompact", "trigger": "auto"}
+        # Patch at the module level where it was imported (not the source module)
+        with patch("post_compact.read_hook_input", return_value=hook_input):
+            main()
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_no_session_row_emits_minimal_nudge(self, capsys):
+        """No AgentSession row -- still emits minimal nudge (header + TodoWrite)."""
+        from post_compact import main
+
+        claude_uuid = str(uuid.uuid4())
+        hook_input = {
+            "hook_event_name": "PostCompact",
+            "session_id": claude_uuid,
+            "trigger": "auto",
+            "cwd": "/tmp",
+        }
+        # Patch at the module level where it was imported (not the source module)
+        with patch("post_compact.read_hook_input", return_value=hook_input):
+            main()
+
+        captured = capsys.readouterr()
+        assert "Context was just compacted" in captured.out
+        assert "TodoWrite" in captured.out
+        # No plan or stage items
+        assert "Re-read the plan" not in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Standalone import guard
+# ---------------------------------------------------------------------------
+
+
+class TestNoAsyncio:
+    def test_does_not_import_asyncio(self):
+        """Hook must not import asyncio -- it is fully synchronous."""
+        import importlib
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "_post_compact_check",
+            HOOKS_DIR / "post_compact.py",
+        )
+        mod = importlib.util.module_from_spec(spec)
+        # Do NOT exec the module to avoid side effects -- just check source
+        src = (HOOKS_DIR / "post_compact.py").read_text()
+        assert "import asyncio" not in src, "Hook must not import asyncio"
+        assert "asyncio." not in src, "Hook must not use asyncio"
+
+
+# ---------------------------------------------------------------------------
+# Autouse fixture: clean up test sessions
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_agent_sessions():
+    """Drop all AgentSession rows with test prefix after each test."""
+    yield
+    try:
+        for s in AgentSession.query.all():
+            try:
+                if getattr(s, "project_key", "").startswith("test-postcompact"):
+                    s.delete()
+            except Exception:
+                pass
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary

- Adds `.claude/hooks/post_compact.py`: fires after every context compaction and emits a short (<300 token) re-grounding nudge directing the agent to re-read the plan, check SDLC stage progress, review `PROGRESS.md`, and check the TodoWrite task list
- Registers `PostCompact` event in `.claude/settings.json` with 10s timeout
- Adds 19 unit tests covering nudge builder, AgentSession lookup, main() paths, and asyncio guard

## Changes

- `.claude/hooks/post_compact.py` — new standalone CLI hook
- `.claude/settings.json` — PostCompact hook registration
- `tests/unit/hooks/test_post_compact_hook.py` — 19 unit tests
- `docs/features/post-compact-regrounding.md` — feature documentation
- `docs/features/README.md` — index entry added alphabetically

## Testing

- [x] All 19 unit tests passing (`pytest tests/unit/hooks/test_post_compact_hook.py -v`)
- [x] All 33 hook tests passing (includes pre_compact tests)
- [x] Linting clean (`python -m ruff check .`)
- [x] Format clean (`python -m ruff format --check .`)

## Documentation

- [x] `docs/features/post-compact-regrounding.md` created
- [x] `docs/features/README.md` index entry added

## Definition of Done

- [x] Built: Hook implemented and working
- [x] Tested: All tests passing
- [x] Documented: Feature doc and README updated
- [x] Quality: Lint and format checks pass

Closes #1139