### PR TITLE
fix(#1147): dedup sdlc_session_ensure against bridge-initiated PM sessions

### DIFF
--- a/.claude/skills/sdlc/SKILL.md
+++ b/.claude/skills/sdlc/SKILL.md
@@ -47,7 +47,7 @@ SDLC_REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null ||
 python -m tools.sdlc_session_ensure --issue-number {issue_number} --issue-url "https://github.com/$SDLC_REPO/issues/{issue_number}" 2>/dev/null || true
 ```
 
-This is idempotent -- running it multiple times for the same issue reuses the same session. Do NOT export `AGENT_SESSION_ID` -- env vars do not persist across Claude Code bash blocks. Instead, pass `--issue-number` to all subsequent `sdlc_stage_marker` and `sdlc_stage_query` invocations.
+This is idempotent -- running it multiple times for the same issue reuses the same session. Inside a bridge-initiated session (where `VALOR_SESSION_ID` is set), the call is a true no-op — it returns the already-active session without creating a new record. Do NOT export `AGENT_SESSION_ID` -- env vars do not persist across Claude Code bash blocks. Instead, pass `--issue-number` to all subsequent `sdlc_stage_marker` and `sdlc_stage_query` invocations.
 
 ## Step 2: Assess Current State
 

--- a/docs/features/sdlc-pipeline-state.md
+++ b/docs/features/sdlc-pipeline-state.md
@@ -47,7 +47,7 @@ Inside a bridge-initiated session (where `VALOR_SESSION_ID` is exported by `agen
 3. Confirm `session_type == "pm"` and `status not in TERMINAL_STATUSES`.
 4. Return the bridge session id with `created: false` — no `sdlc-local-{N}` record is created.
 
-The short-circuit falls through to the legacy create path when:
+The short-circuit falls through to the issue-number lookup and create path when:
 
 - The env var is unset or empty.
 - The env-resolved session does not exist in Redis (stale env).
@@ -58,7 +58,7 @@ The message-text fallback inside `find_session_by_issue` is a secondary defense 
 
 ### Orphan cleanup
 
-Legacy zombie `sdlc-local-{N}` sessions (running status, no heartbeats, older than 10 minutes) can be listed and finalized with:
+Stale zombie `sdlc-local-{N}` sessions (running status, no heartbeats, older than 10 minutes) can be listed and finalized with:
 
 ```bash
 # Preview without modifying (exits 0, prints JSON list)

--- a/docs/features/sdlc-pipeline-state.md
+++ b/docs/features/sdlc-pipeline-state.md
@@ -38,6 +38,38 @@ python -m tools.sdlc_session_ensure --issue-number 941 --issue-url "https://gith
 
 This creates an `AgentSession` with `session_id="sdlc-local-941"` and `session_type="pm"`. It's idempotent — running it again returns the existing session.
 
+### Bridge short-circuit
+
+Inside a bridge-initiated session (where `VALOR_SESSION_ID` is exported by `agent/sdk_client.py`), `ensure_session` short-circuits immediately:
+
+1. Read `VALOR_SESSION_ID` (or `AGENT_SESSION_ID`) from the environment.
+2. Resolve the session via `tools._sdlc_utils.find_session(session_id=...)`.
+3. Confirm `session_type == "pm"` and `status not in TERMINAL_STATUSES`.
+4. Return the bridge session id with `created: false` — no `sdlc-local-{N}` record is created.
+
+The short-circuit falls through to the legacy create path when:
+
+- The env var is unset or empty.
+- The env-resolved session does not exist in Redis (stale env).
+- The env-resolved session has `session_type != "pm"` (e.g., a Dev session during cross-role debugging).
+- The env-resolved session has a terminal status (completed, killed, abandoned, failed, cancelled).
+
+The message-text fallback inside `find_session_by_issue` is a secondary defense for degraded scenarios where `VALOR_SESSION_ID` is missing but a bridge session exists with `issue_url=None` and `message_text="SDLC issue {N}"`. It matches the issue number inside `message_text` using a word-boundary regex (`\bissue\s*#?\s*{N}\b`, case-insensitive) so `tissue 1147` does not false-match.
+
+### Orphan cleanup
+
+Legacy zombie `sdlc-local-{N}` sessions (running status, no heartbeats, older than 10 minutes) can be listed and finalized with:
+
+```bash
+# Preview without modifying (exits 0, prints JSON list)
+python -m tools.sdlc_session_ensure --kill-orphans --dry-run
+
+# Finalize each via models.session_lifecycle.finalize_session
+python -m tools.sdlc_session_ensure --kill-orphans
+```
+
+The CLI always exits 0. Per-session finalize failures are reported inside the JSON payload's `failures` count and per-session `result` list — they never raise. When non-zero zombies are detected, a single stderr line (`[sdlc_session_ensure] found N zombie sdlc-local session(s)`) surfaces the count to scheduled-cleanup operators while stdout stays machine-parseable.
+
 ## Key Files
 
 | File | Purpose |
@@ -50,7 +82,7 @@ This creates an `AgentSession` with `session_id="sdlc-local-941"` and `session_t
 
 ## Bridge vs Local
 
-- **Bridge sessions**: Worker injects `VALOR_SESSION_ID` env var. Markers resolve via env var. Hooks also fire.
-- **Local sessions**: No env var available. `--issue-number` resolves via `find_session_by_issue()` scanning PM sessions by `issue_url` suffix.
+- **Bridge sessions**: Worker injects `VALOR_SESSION_ID` env var. Markers resolve via env var. `sdlc_session_ensure` short-circuits and does not create an `sdlc-local-{N}` record. Hooks also fire.
+- **Local sessions**: No env var available. `--issue-number` resolves via `find_session_by_issue()` scanning PM sessions by `issue_url` suffix and (fallback) by `message_text` regex.
 
 Both paths write to the same `stage_states` field on the PM session, so the merge gate and stage query work identically.

--- a/docs/features/sdlc-stage-tracking.md
+++ b/docs/features/sdlc-stage-tracking.md
@@ -50,7 +50,7 @@ Exit code is always 0. Returns `{}` on error, `{"stage": "DOCS", "status": "comp
 
 - Infer stages from plan files on disk
 - Query GitHub PRs to infer BUILD/TEST/REVIEW/DOCS completion
-- Accept a `slug=` parameter (removed in #729)
+- Accept a `slug=` parameter (the keyword was dropped in #729)
 
 This was intentional. Artifact inference caused stage skipping (#723, #729): a plan file created by `/do-build` as a deliverable would incorrectly satisfy DOCS without `/do-docs` ever running.
 

--- a/docs/features/sdlc-stage-tracking.md
+++ b/docs/features/sdlc-stage-tracking.md
@@ -67,6 +67,8 @@ The gate is a reminder, not a hard blocker. The agent can choose to proceed, but
 
 For local Claude Code sessions, the SDLC router ensures a trackable session exists before dispatching sub-skills via `tools/sdlc_session_ensure.py`. This creates an `AgentSession` keyed by `sdlc-local-{issue_number}` so that downstream markers have a session to write to. The operation is idempotent — running it multiple times for the same issue reuses the same session.
 
+Inside a bridge-initiated session (where `VALOR_SESSION_ID` is set), the call short-circuits: it returns the already-active bridge PM session without creating a new `sdlc-local-{N}` record. This prevents the zombie-duplicate dashboard entries that used to appear when SDLC was driven over Telegram. See the "Bridge short-circuit" subsection in `docs/features/sdlc-pipeline-state.md` for the full gate conditions and the `--kill-orphans` operator tool for cleaning up pre-existing zombies.
+
 ```bash
 SDLC_REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || git remote get-url origin | sed 's/.*github.com[:/]//;s/.git$//')
 python -m tools.sdlc_session_ensure --issue-number 941 --issue-url "https://github.com/$SDLC_REPO/issues/941"

--- a/docs/plans/sdlc-session-ensure-dedup.md
+++ b/docs/plans/sdlc-session-ensure-dedup.md
@@ -164,22 +164,22 @@ Operator runs `python -m tools.sdlc_session_ensure --kill-orphans --dry-run` →
 ## Failure Path Test Strategy
 
 ### Exception Handling Coverage
-- [ ] The existing `try/except Exception` in `ensure_session()` (`tools/sdlc_session_ensure.py:96`) wraps the whole function and returns `{}` on error. The env short-circuit sits inside this same try block so Redis failures during the `find_session` call degrade gracefully to the existing path. Test: simulate `find_session` raising `ConnectionError` and assert `ensure_session` still falls through to legacy create.
-- [ ] The new `--kill-orphans` path must not crash when a session transition fails. Each transition runs inside its own try/except; failures are recorded in the output JSON, never raised. Test: mock `transition_status` to raise, confirm CLI still exits 0 and reports the failure in the payload.
+- [x] The existing `try/except Exception` in `ensure_session()` (`tools/sdlc_session_ensure.py:96`) wraps the whole function and returns `{}` on error. The env short-circuit sits inside this same try block so Redis failures during the `find_session` call degrade gracefully to the existing path. Test: simulate `find_session` raising `ConnectionError` and assert `ensure_session` still falls through to legacy create.
+- [x] The new `--kill-orphans` path must not crash when a session transition fails. Each transition runs inside its own try/except; failures are recorded in the output JSON, never raised. Test: mock `transition_status` to raise, confirm CLI still exits 0 and reports the failure in the payload.
 
 ### Empty/Invalid Input Handling
-- [ ] `VALOR_SESSION_ID=""` (empty string) behaves identically to unset — short-circuit does not activate, falls through. Test: `os.environ["VALOR_SESSION_ID"] = ""` with no real session, assert create path runs.
-- [ ] `find_session_by_issue(0)` and `(-1)` still return None (existing guard). No new tests needed; existing `test_returns_empty_for_invalid_issue_number` covers.
-- [ ] `message_text` containing `"issue 1147"` as a substring of a larger word (e.g., `"tissue 1147"`) must NOT match. The `\b` word boundaries in the regex handle this. Test: add regression assertion.
+- [x] `VALOR_SESSION_ID=""` (empty string) behaves identically to unset — short-circuit does not activate, falls through. Test: `os.environ["VALOR_SESSION_ID"] = ""` with no real session, assert create path runs.
+- [x] `find_session_by_issue(0)` and `(-1)` still return None (existing guard). No new tests needed; existing `test_returns_empty_for_invalid_issue_number` covers.
+- [x] `message_text` containing `"issue 1147"` as a substring of a larger word (e.g., `"tissue 1147"`) must NOT match. The `\b` word boundaries in the regex handle this. Test: add regression assertion.
 
 ### Error State Rendering
-- [ ] CLI always prints valid JSON on stdout and exits 0 (documented contract). Add a test that runs `--kill-orphans --dry-run` and asserts `json.loads(stdout)` succeeds.
-- [ ] If the env short-circuit branch returns a session ID, the caller (SDLC skill) must observe `created: False`. Add a test that patches env, provides a mock PM session, and asserts the result dict.
+- [x] CLI always prints valid JSON on stdout and exits 0 (documented contract). Add a test that runs `--kill-orphans --dry-run` and asserts `json.loads(stdout)` succeeds.
+- [x] If the env short-circuit branch returns a session ID, the caller (SDLC skill) must observe `created: False`. Add a test that patches env, provides a mock PM session, and asserts the result dict.
 
 ## Test Impact
 
-- [ ] `tests/unit/test_sdlc_session_ensure.py` — UPDATE: keep all six existing tests (they exercise the fallback paths that remain). Add new tests listed in Step 5 below.
-- [ ] No other test files touch this code path. `grep -rn "sdlc_session_ensure\|find_session_by_issue\|sdlc-local-" tests/` returns only the one file.
+- [x] `tests/unit/test_sdlc_session_ensure.py` — UPDATE: keep all six existing tests (they exercise the fallback paths that remain). Add new tests listed in Step 5 below.
+- [x] No other test files touch this code path. `grep -rn "sdlc_session_ensure\|find_session_by_issue\|sdlc-local-" tests/` returns only the one file.
 
 ## Rabbit Holes
 
@@ -234,30 +234,30 @@ No agent integration required — `sdlc_session_ensure` is not exposed as an MCP
 ## Documentation
 
 ### Feature Documentation
-- [ ] Update `docs/features/sdlc-pipeline-state.md`: add a short subsection under "Local SDLC sessions" explaining the env-var short-circuit and what happens when Step 1.5 runs inside a bridge session. Note the `--kill-orphans` operator tool and link to its usage.
-- [ ] Update `docs/features/sdlc-stage-tracking.md`: the existing paragraph at line 68 describes `sdlc_session_ensure` for local sessions. Append a note that bridge sessions short-circuit and do not create records.
+- [x] Update `docs/features/sdlc-pipeline-state.md`: add a short subsection under "Local SDLC sessions" explaining the env-var short-circuit and what happens when Step 1.5 runs inside a bridge session. Note the `--kill-orphans` operator tool and link to its usage.
+- [x] Update `docs/features/sdlc-stage-tracking.md`: the existing paragraph at line 68 describes `sdlc_session_ensure` for local sessions. Append a note that bridge sessions short-circuit and do not create records.
 
 ### Inline Documentation
-- [ ] `ensure_session()` docstring: document the env-var short-circuit behavior and when it falls through.
-- [ ] `find_session_by_issue()` docstring: document the two-pass match (`issue_url` first, then `message_text` regex) and the known limitation (first match wins on multi-mention).
-- [ ] `_iter_orphan_sessions()` helper: docstring covering the zombie criteria (pattern, age floor, heartbeat).
+- [x] `ensure_session()` docstring: document the env-var short-circuit behavior and when it falls through.
+- [x] `find_session_by_issue()` docstring: document the two-pass match (`issue_url` first, then `message_text` regex) and the known limitation (first match wins on multi-mention).
+- [x] `_iter_orphan_sessions()` helper: docstring covering the zombie criteria (pattern, age floor, heartbeat).
 
 ### Skill Documentation
-- [ ] `.claude/skills/sdlc/SKILL.md` Step 1.5: correct the comment so "no-op for bridge-initiated sessions" matches real behavior after fix.
+- [x] `.claude/skills/sdlc/SKILL.md` Step 1.5: correct the comment so "no-op for bridge-initiated sessions" matches real behavior after fix.
 
 ## Success Criteria
 
-- [ ] `ensure_session(1140)` called with `VALOR_SESSION_ID=tg_valor_-1003449100931_691` in env AND a live PM session matching that ID returns `{"session_id": "tg_valor_-1003449100931_691", "created": false}`. No new session created.
-- [ ] `ensure_session(1140)` called with `VALOR_SESSION_ID=stale_id` where no session exists falls through to the legacy path and creates `sdlc-local-1140` (preserves degraded-mode behavior).
-- [ ] `find_session_by_issue(1140)` returns a Telegram PM session whose `message_text="SDLC issue 1140"` and `issue_url is None`.
-- [ ] `find_session_by_issue(1147)` does NOT match a session whose `message_text` contains `"tissue 1147"` (word-boundary regression).
-- [ ] Running SDLC on a bridge-initiated session produces exactly one PM session on the dashboard (curl `/dashboard.json`, count `pm` sessions for this issue). Zero `sdlc-local-{N}` duplicates.
-- [ ] `python -m tools.sdlc_session_ensure --kill-orphans --dry-run` lists existing zombies without modifying them. Output is valid JSON, exit 0.
-- [ ] `python -m tools.sdlc_session_ensure --kill-orphans` transitions zombie sessions to `killed` and reports per-session results in JSON.
-- [ ] Tests in `tests/unit/test_sdlc_session_ensure.py` cover: bridge short-circuit (happy path), stale env fallback, message_text fallback match, message_text word-boundary negative case, orphan listing, orphan killing, transition failure handling in orphan killer.
-- [ ] `.claude/skills/sdlc/SKILL.md` Step 1.5 comment reads accurately.
-- [ ] Tests pass (`/do-test`).
-- [ ] Documentation updated (`/do-docs`).
+- [x] `ensure_session(1140)` called with `VALOR_SESSION_ID=tg_valor_-1003449100931_691` in env AND a live PM session matching that ID returns `{"session_id": "tg_valor_-1003449100931_691", "created": false}`. No new session created.
+- [x] `ensure_session(1140)` called with `VALOR_SESSION_ID=stale_id` where no session exists falls through to the legacy path and creates `sdlc-local-1140` (preserves degraded-mode behavior).
+- [x] `find_session_by_issue(1140)` returns a Telegram PM session whose `message_text="SDLC issue 1140"` and `issue_url is None`.
+- [x] `find_session_by_issue(1147)` does NOT match a session whose `message_text` contains `"tissue 1147"` (word-boundary regression).
+- [x] Running SDLC on a bridge-initiated session produces exactly one PM session on the dashboard (curl `/dashboard.json`, count `pm` sessions for this issue). Zero `sdlc-local-{N}` duplicates.
+- [x] `python -m tools.sdlc_session_ensure --kill-orphans --dry-run` lists existing zombies without modifying them. Output is valid JSON, exit 0.
+- [x] `python -m tools.sdlc_session_ensure --kill-orphans` transitions zombie sessions to `killed` and reports per-session results in JSON.
+- [x] Tests in `tests/unit/test_sdlc_session_ensure.py` cover: bridge short-circuit (happy path), stale env fallback, message_text fallback match, message_text word-boundary negative case, orphan listing, orphan killing, transition failure handling in orphan killer.
+- [x] `.claude/skills/sdlc/SKILL.md` Step 1.5 comment reads accurately.
+- [x] Tests pass (`/do-test`).
+- [x] Documentation updated (`/do-docs`).
 
 ## Team Orchestration
 

--- a/tests/integration/test_sdlc_session_ensure_integration.py
+++ b/tests/integration/test_sdlc_session_ensure_integration.py
@@ -1,0 +1,107 @@
+"""Integration test for tools.sdlc_session_ensure bridge short-circuit.
+
+Drives the headline dashboard claim for #1147: a bridge-initiated PM session
+with no issue_url (only message_text) must NOT produce a duplicate
+``sdlc-local-{N}`` record when /sdlc Step 1.5 runs ``ensure_session``.
+
+Uses real Popoto Redis writes (no mocks) to validate the end-to-end flow:
+1. Create a PM AgentSession mimicking bridge creation (session_type=pm,
+   message_text="SDLC issue 9999", issue_url=None).
+2. Set VALOR_SESSION_ID=<bridge_session_id>.
+3. Invoke ensure_session(9999).
+4. Assert: result reuses the bridge session id, created=False.
+5. Assert: no ``sdlc-local-9999`` exists in Redis.
+
+Cleanup happens in teardown via ``instance.delete()`` per CLAUDE.md's manual
+testing hygiene rule — every test session is created with a recognizable
+``project_key`` prefix and deleted through the Popoto ORM.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from models.agent_session import AgentSession
+
+# Recognizable project_key prefix so teardown can scope cleanup narrowly and any
+# leaked records are easy to spot on the dashboard.
+TEST_PROJECT_KEY = "test-sdlc-ensure-int"
+
+
+@pytest.fixture
+def cleanup_test_sessions():
+    """Delete every AgentSession created under TEST_PROJECT_KEY before and after."""
+
+    def _cleanup():
+        try:
+            stale = [
+                s
+                for s in AgentSession.query.all()
+                if getattr(s, "project_key", None) == TEST_PROJECT_KEY
+            ]
+        except Exception:
+            return
+        for s in stale:
+            try:
+                s.delete()
+            except Exception:
+                pass
+
+    _cleanup()
+    yield
+    _cleanup()
+
+
+def test_bridge_short_circuit_produces_no_duplicate(monkeypatch, cleanup_test_sessions):
+    """End-to-end: bridge PM session + VALOR_SESSION_ID => no sdlc-local-N duplicate."""
+    from tools.sdlc_session_ensure import ensure_session
+
+    bridge_session_id = "tg_valor_test_9999"
+
+    # Create a bridge-style PM session the way the Telegram bridge would.
+    bridge_session = AgentSession.create_pm(
+        session_id=bridge_session_id,
+        project_key=TEST_PROJECT_KEY,
+        working_dir="/tmp",
+        chat_id="test_chat_9999",
+        telegram_message_id=1,
+        message_text="SDLC issue 9999",
+        sender_name="IntegrationTest",
+    )
+
+    # Transition to running so it looks like a live worker turn.
+    try:
+        from models.session_lifecycle import transition_status
+
+        transition_status(bridge_session, "running", "integration test setup")
+    except Exception:
+        # Not critical for this test — the short-circuit still activates as long
+        # as status is non-terminal, and "pending" is non-terminal.
+        pass
+
+    # Simulate what agent/sdk_client.py does for bridge-initiated sessions.
+    monkeypatch.setenv("VALOR_SESSION_ID", bridge_session_id)
+    monkeypatch.delenv("AGENT_SESSION_ID", raising=False)
+
+    result = ensure_session(issue_number=9999)
+
+    # The short-circuit must return the bridge session id and NOT create a new
+    # sdlc-local-9999 record.
+    assert result == {"session_id": bridge_session_id, "created": False}
+
+    # Confirm via direct Popoto query: the duplicate zombie must not exist.
+    zombie = list(AgentSession.query.filter(session_id="sdlc-local-9999"))
+    assert zombie == [], (
+        "ensure_session must NOT create sdlc-local-9999 when "
+        "VALOR_SESSION_ID points at a live PM session"
+    )
+
+    # And there should be exactly one PM session in our test project_key.
+    pm_sessions = [
+        s
+        for s in AgentSession.query.all()
+        if getattr(s, "project_key", None) == TEST_PROJECT_KEY
+        and getattr(s, "session_type", None) == "pm"
+    ]
+    assert len(pm_sessions) == 1
+    assert pm_sessions[0].session_id == bridge_session_id

--- a/tests/unit/test_sdlc_session_ensure.py
+++ b/tests/unit/test_sdlc_session_ensure.py
@@ -253,9 +253,7 @@ class TestBridgeShortCircuit:
         # Must NOT return the dev session id; must fall through to create.
         assert result == {"session_id": "sdlc-local-1143", "created": True}
 
-    def test_short_circuit_falls_through_for_terminal_status_pm_session(
-        self, monkeypatch
-    ):
+    def test_short_circuit_falls_through_for_terminal_status_pm_session(self, monkeypatch):
         """Env points at a terminal-status PM session (AD1) — fall through."""
         from tools.sdlc_session_ensure import ensure_session
 
@@ -436,9 +434,7 @@ class TestKillOrphans:
     def test_boundary_at_threshold_is_listed(self):
         from tools.sdlc_session_ensure import _kill_orphans, ORPHAN_AGE_SECONDS
 
-        at_boundary = _make_orphan_session(
-            "sdlc-local-9996", ORPHAN_AGE_SECONDS
-        )
+        at_boundary = _make_orphan_session("sdlc-local-9996", ORPHAN_AGE_SECONDS)
         mock_as = MagicMock()
         mock_as.query.filter.return_value = [at_boundary]
 
@@ -451,9 +447,7 @@ class TestKillOrphans:
     def test_boundary_one_second_under_not_listed(self):
         from tools.sdlc_session_ensure import _kill_orphans, ORPHAN_AGE_SECONDS
 
-        under = _make_orphan_session(
-            "sdlc-local-9997", ORPHAN_AGE_SECONDS - 1
-        )
+        under = _make_orphan_session("sdlc-local-9997", ORPHAN_AGE_SECONDS - 1)
         mock_as = MagicMock()
         mock_as.query.filter.return_value = [under]
 
@@ -465,9 +459,7 @@ class TestKillOrphans:
     def test_boundary_one_second_over_is_listed(self):
         from tools.sdlc_session_ensure import _kill_orphans, ORPHAN_AGE_SECONDS
 
-        over = _make_orphan_session(
-            "sdlc-local-9998", ORPHAN_AGE_SECONDS + 1
-        )
+        over = _make_orphan_session("sdlc-local-9998", ORPHAN_AGE_SECONDS + 1)
         mock_as = MagicMock()
         mock_as.query.filter.return_value = [over]
 
@@ -480,9 +472,7 @@ class TestKillOrphans:
         from tools.sdlc_session_ensure import _kill_orphans, ORPHAN_AGE_SECONDS
 
         # A bridge session matching all other zombie criteria must be skipped.
-        bridge = _make_orphan_session(
-            "tg_valor_-1003449100931_691", ORPHAN_AGE_SECONDS + 3600
-        )
+        bridge = _make_orphan_session("tg_valor_-1003449100931_691", ORPHAN_AGE_SECONDS + 3600)
         mock_as = MagicMock()
         mock_as.query.filter.return_value = [bridge]
 

--- a/tests/unit/test_sdlc_session_ensure.py
+++ b/tests/unit/test_sdlc_session_ensure.py
@@ -6,13 +6,17 @@ Tests cover:
 - Handles Redis errors gracefully
 - CLI output format
 - Invalid input handling
+- Env-var short-circuit for bridge-initiated sessions
+- --kill-orphans zombie cleanup
 """
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -136,3 +140,392 @@ class TestCLI:
             cwd=REPO_ROOT,
         )
         assert result.returncode != 0
+
+
+class TestBridgeShortCircuit:
+    """Tests for the VALOR_SESSION_ID / AGENT_SESSION_ID env short-circuit."""
+
+    def test_short_circuit_returns_env_session_when_live_pm(self, monkeypatch):
+        """Env var set + live PM session returns it without creating anything."""
+        from tools.sdlc_session_ensure import ensure_session
+
+        monkeypatch.setenv("VALOR_SESSION_ID", "tg_valor_-1003449100931_691")
+        monkeypatch.delenv("AGENT_SESSION_ID", raising=False)
+
+        bridge_session = MagicMock()
+        bridge_session.session_id = "tg_valor_-1003449100931_691"
+        bridge_session.session_type = "pm"
+        bridge_session.status = "running"
+
+        # find_session_by_issue must NOT be called on the happy short-circuit path.
+        fsbi = MagicMock()
+
+        with (
+            patch("tools._sdlc_utils.find_session", return_value=bridge_session),
+            patch("tools._sdlc_utils.find_session_by_issue", fsbi),
+        ):
+            result = ensure_session(issue_number=1140)
+
+        assert result == {
+            "session_id": "tg_valor_-1003449100931_691",
+            "created": False,
+        }
+        fsbi.assert_not_called()
+
+    def test_short_circuit_falls_through_when_env_session_missing(self, monkeypatch):
+        """Env var set but no live session — fall through to legacy create path."""
+        from tools.sdlc_session_ensure import ensure_session
+
+        monkeypatch.setenv("VALOR_SESSION_ID", "stale_session_id")
+        monkeypatch.delenv("AGENT_SESSION_ID", raising=False)
+
+        mock_new_session = MagicMock()
+        mock_new_session.session_id = "sdlc-local-1141"
+
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = []
+        mock_as.create_local.return_value = mock_new_session
+
+        with (
+            patch("tools._sdlc_utils.find_session", return_value=None),
+            patch("tools._sdlc_utils.find_session_by_issue", return_value=None),
+            patch("models.agent_session.AgentSession", mock_as),
+            patch("models.session_lifecycle.transition_status"),
+        ):
+            result = ensure_session(issue_number=1141)
+
+        assert result == {"session_id": "sdlc-local-1141", "created": True}
+
+    def test_empty_env_var_does_not_short_circuit(self, monkeypatch):
+        """Empty-string env var behaves identically to unset."""
+        from tools.sdlc_session_ensure import ensure_session
+
+        monkeypatch.setenv("VALOR_SESSION_ID", "")
+        monkeypatch.delenv("AGENT_SESSION_ID", raising=False)
+
+        mock_new_session = MagicMock()
+        mock_new_session.session_id = "sdlc-local-1142"
+
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = []
+        mock_as.create_local.return_value = mock_new_session
+
+        find_session_mock = MagicMock()
+        with (
+            patch("tools._sdlc_utils.find_session", find_session_mock),
+            patch("tools._sdlc_utils.find_session_by_issue", return_value=None),
+            patch("models.agent_session.AgentSession", mock_as),
+            patch("models.session_lifecycle.transition_status"),
+        ):
+            result = ensure_session(issue_number=1142)
+
+        assert result == {"session_id": "sdlc-local-1142", "created": True}
+        # find_session should NOT be called when env vars are empty
+        find_session_mock.assert_not_called()
+
+    def test_short_circuit_falls_through_for_non_pm_session(self, monkeypatch):
+        """Env var points at a Dev session — short-circuit must NOT activate (C2)."""
+        from tools.sdlc_session_ensure import ensure_session
+
+        monkeypatch.setenv("VALOR_SESSION_ID", "dev_session_id")
+        monkeypatch.delenv("AGENT_SESSION_ID", raising=False)
+
+        dev_session = MagicMock()
+        dev_session.session_id = "dev_session_id"
+        dev_session.session_type = "dev"
+        dev_session.status = "running"
+
+        mock_new_session = MagicMock()
+        mock_new_session.session_id = "sdlc-local-1143"
+
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = []
+        mock_as.create_local.return_value = mock_new_session
+
+        with (
+            patch("tools._sdlc_utils.find_session", return_value=dev_session),
+            patch("tools._sdlc_utils.find_session_by_issue", return_value=None),
+            patch("models.agent_session.AgentSession", mock_as),
+            patch("models.session_lifecycle.transition_status"),
+        ):
+            result = ensure_session(issue_number=1143)
+
+        # Must NOT return the dev session id; must fall through to create.
+        assert result == {"session_id": "sdlc-local-1143", "created": True}
+
+    def test_short_circuit_falls_through_for_terminal_status_pm_session(
+        self, monkeypatch
+    ):
+        """Env points at a terminal-status PM session (AD1) — fall through."""
+        from tools.sdlc_session_ensure import ensure_session
+
+        monkeypatch.setenv("VALOR_SESSION_ID", "completed_pm_id")
+        monkeypatch.delenv("AGENT_SESSION_ID", raising=False)
+
+        for terminal_status in (
+            "completed",
+            "failed",
+            "killed",
+            "abandoned",
+            "cancelled",
+        ):
+            terminal_session = MagicMock()
+            terminal_session.session_id = "completed_pm_id"
+            terminal_session.session_type = "pm"
+            terminal_session.status = terminal_status
+
+            mock_new_session = MagicMock()
+            mock_new_session.session_id = "sdlc-local-1144"
+
+            mock_as = MagicMock()
+            mock_as.query.filter.return_value = []
+            mock_as.create_local.return_value = mock_new_session
+
+            with (
+                patch("tools._sdlc_utils.find_session", return_value=terminal_session),
+                patch("tools._sdlc_utils.find_session_by_issue", return_value=None),
+                patch("models.agent_session.AgentSession", mock_as),
+                patch("models.session_lifecycle.transition_status"),
+            ):
+                result = ensure_session(issue_number=1144)
+
+            # Must fall through and create a fresh session; not reuse the
+            # terminal-status bridge session.
+            assert result == {
+                "session_id": "sdlc-local-1144",
+                "created": True,
+            }, f"failed for terminal status {terminal_status!r}"
+
+    def test_short_circuit_degrades_on_find_session_error(self, monkeypatch):
+        """Redis error during env lookup falls through without crashing."""
+        from tools.sdlc_session_ensure import ensure_session
+
+        monkeypatch.setenv("VALOR_SESSION_ID", "some_id")
+        monkeypatch.delenv("AGENT_SESSION_ID", raising=False)
+
+        mock_new_session = MagicMock()
+        mock_new_session.session_id = "sdlc-local-1145"
+
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = []
+        mock_as.create_local.return_value = mock_new_session
+
+        with (
+            patch(
+                "tools._sdlc_utils.find_session",
+                side_effect=ConnectionError("Redis down"),
+            ),
+            patch("tools._sdlc_utils.find_session_by_issue", return_value=None),
+            patch("models.agent_session.AgentSession", mock_as),
+            patch("models.session_lifecycle.transition_status"),
+        ):
+            result = ensure_session(issue_number=1145)
+
+        # Degrades gracefully to the create path.
+        assert result == {"session_id": "sdlc-local-1145", "created": True}
+
+
+def _make_orphan_session(session_id, age_seconds, heartbeat=None, session_type="pm"):
+    """Build a MagicMock AgentSession with orphan-relevant fields."""
+    s = MagicMock()
+    s.session_id = session_id
+    s.session_type = session_type
+    s.status = "running"
+    s.last_heartbeat_at = heartbeat
+    s.created_at = datetime.now(timezone.utc) - timedelta(seconds=age_seconds)
+    s.issue_url = None
+    return s
+
+
+class TestKillOrphans:
+    """Tests for the --kill-orphans zombie-cleanup CLI path."""
+
+    def test_dry_run_lists_without_modifying(self):
+        from tools.sdlc_session_ensure import _kill_orphans, ORPHAN_AGE_SECONDS
+
+        orphan = _make_orphan_session("sdlc-local-9991", ORPHAN_AGE_SECONDS + 60)
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [orphan]
+
+        with patch("models.agent_session.AgentSession", mock_as):
+            result = _kill_orphans(dry_run=True)
+
+        assert result["count"] == 1
+        assert result["killed"] is False
+        assert result["orphans"][0]["session_id"] == "sdlc-local-9991"
+
+    def test_real_run_finalizes_orphans_via_finalize_session(self):
+        from tools.sdlc_session_ensure import _kill_orphans, ORPHAN_AGE_SECONDS
+
+        orphan = _make_orphan_session("sdlc-local-9992", ORPHAN_AGE_SECONDS + 60)
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [orphan]
+
+        finalize_mock = MagicMock()
+        with (
+            patch("models.agent_session.AgentSession", mock_as),
+            patch("models.session_lifecycle.finalize_session", finalize_mock),
+        ):
+            result = _kill_orphans(dry_run=False)
+
+        assert result["count"] == 1
+        assert result["killed"] is True
+        assert result["failures"] == 0
+        assert result["results"][0] == {
+            "session_id": "sdlc-local-9992",
+            "result": "killed",
+        }
+        # Verify finalize_session was called with correct args (not transition_status).
+        finalize_mock.assert_called_once()
+        _args, kwargs = finalize_mock.call_args
+        assert kwargs["reason"] == "zombie sdlc-local session cleanup"
+        assert kwargs["skip_auto_tag"] is True
+        assert kwargs["skip_checkpoint"] is True
+        assert kwargs["skip_parent"] is True
+
+    def test_finalize_session_failure_does_not_crash(self):
+        from tools.sdlc_session_ensure import _kill_orphans, ORPHAN_AGE_SECONDS
+
+        orphan = _make_orphan_session("sdlc-local-9993", ORPHAN_AGE_SECONDS + 60)
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [orphan]
+
+        with (
+            patch("models.agent_session.AgentSession", mock_as),
+            patch(
+                "models.session_lifecycle.finalize_session",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            result = _kill_orphans(dry_run=False)
+
+        assert result["count"] == 1
+        assert result["failures"] == 1
+        assert result["results"][0]["result"] == "failed"
+        assert "boom" in result["results"][0]["error"]
+
+    def test_newer_than_threshold_not_listed(self):
+        from tools.sdlc_session_ensure import _kill_orphans, ORPHAN_AGE_SECONDS
+
+        fresh = _make_orphan_session("sdlc-local-9994", 60)  # 1 minute old
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [fresh]
+
+        with patch("models.agent_session.AgentSession", mock_as):
+            result = _kill_orphans(dry_run=True)
+
+        assert result["count"] == 0
+        assert result["orphans"] == []
+
+    def test_session_with_heartbeat_never_listed(self):
+        from tools.sdlc_session_ensure import _kill_orphans, ORPHAN_AGE_SECONDS
+
+        old_but_alive = _make_orphan_session(
+            "sdlc-local-9995",
+            age_seconds=ORPHAN_AGE_SECONDS + 3600,
+            heartbeat=datetime.now(timezone.utc),
+        )
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [old_but_alive]
+
+        with patch("models.agent_session.AgentSession", mock_as):
+            result = _kill_orphans(dry_run=True)
+
+        assert result["count"] == 0
+
+    def test_boundary_at_threshold_is_listed(self):
+        from tools.sdlc_session_ensure import _kill_orphans, ORPHAN_AGE_SECONDS
+
+        at_boundary = _make_orphan_session(
+            "sdlc-local-9996", ORPHAN_AGE_SECONDS
+        )
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [at_boundary]
+
+        with patch("models.agent_session.AgentSession", mock_as):
+            result = _kill_orphans(dry_run=True)
+
+        # At-threshold means age >= threshold is True.
+        assert result["count"] == 1
+
+    def test_boundary_one_second_under_not_listed(self):
+        from tools.sdlc_session_ensure import _kill_orphans, ORPHAN_AGE_SECONDS
+
+        under = _make_orphan_session(
+            "sdlc-local-9997", ORPHAN_AGE_SECONDS - 1
+        )
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [under]
+
+        with patch("models.agent_session.AgentSession", mock_as):
+            result = _kill_orphans(dry_run=True)
+
+        assert result["count"] == 0
+
+    def test_boundary_one_second_over_is_listed(self):
+        from tools.sdlc_session_ensure import _kill_orphans, ORPHAN_AGE_SECONDS
+
+        over = _make_orphan_session(
+            "sdlc-local-9998", ORPHAN_AGE_SECONDS + 1
+        )
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [over]
+
+        with patch("models.agent_session.AgentSession", mock_as):
+            result = _kill_orphans(dry_run=True)
+
+        assert result["count"] == 1
+
+    def test_non_sdlc_local_session_never_listed(self):
+        from tools.sdlc_session_ensure import _kill_orphans, ORPHAN_AGE_SECONDS
+
+        # A bridge session matching all other zombie criteria must be skipped.
+        bridge = _make_orphan_session(
+            "tg_valor_-1003449100931_691", ORPHAN_AGE_SECONDS + 3600
+        )
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [bridge]
+
+        with patch("models.agent_session.AgentSession", mock_as):
+            result = _kill_orphans(dry_run=True)
+
+        assert result["count"] == 0
+
+    def test_cli_dry_run_exits_zero_with_valid_json(self):
+        env = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "tools.sdlc_session_ensure",
+                "--kill-orphans",
+                "--dry-run",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+            env=env,
+        )
+        assert result.returncode == 0
+        # stdout must be parseable JSON
+        payload = json.loads(result.stdout)
+        assert "count" in payload
+        assert payload["killed"] is False
+
+    def test_cli_rejects_issue_number_with_kill_orphans(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "tools.sdlc_session_ensure",
+                "--kill-orphans",
+                "--issue-number",
+                "1",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+        )
+        # argparse .error() exits 2
+        assert result.returncode != 0
+        assert "mutually exclusive" in result.stderr.lower()

--- a/tests/unit/test_sdlc_utils.py
+++ b/tests/unit/test_sdlc_utils.py
@@ -183,9 +183,7 @@ class TestMessageTextFallback:
 
         # In query order: first has message_text match only, second has issue_url.
         text_match = self._session(message_text="SDLC issue 1147")
-        url_match = self._session(
-            issue_url="https://github.com/tomcounsell/ai/issues/1147"
-        )
+        url_match = self._session(issue_url="https://github.com/tomcounsell/ai/issues/1147")
         mock_as = MagicMock()
         mock_as.query.filter.return_value = [text_match, url_match]
 

--- a/tests/unit/test_sdlc_utils.py
+++ b/tests/unit/test_sdlc_utils.py
@@ -71,6 +71,8 @@ class TestFindSessionByIssue:
 
         mock_session = MagicMock()
         mock_session.issue_url = None
+        # Also ensure message_text does not accidentally match.
+        mock_session.message_text = ""
 
         mock_as = MagicMock()
         mock_as.query.filter.return_value = [mock_session]
@@ -79,3 +81,117 @@ class TestFindSessionByIssue:
             result = find_session_by_issue(941)
 
         assert result is None
+
+
+class TestMessageTextFallback:
+    """Tests for the message_text fallback pass in find_session_by_issue."""
+
+    def _session(self, *, issue_url=None, message_text=None):
+        s = MagicMock()
+        s.issue_url = issue_url
+        s.message_text = message_text
+        return s
+
+    def test_matches_sdlc_issue_phrase(self):
+        from tools._sdlc_utils import find_session_by_issue
+
+        bridge = self._session(message_text="SDLC issue 1147")
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [bridge]
+
+        with patch("tools._sdlc_utils.AgentSession", mock_as):
+            result = find_session_by_issue(1147)
+
+        assert result is bridge
+
+    def test_matches_issue_hash(self):
+        from tools._sdlc_utils import find_session_by_issue
+
+        bridge = self._session(message_text="please work on issue #1147 today")
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [bridge]
+
+        with patch("tools._sdlc_utils.AgentSession", mock_as):
+            result = find_session_by_issue(1147)
+
+        assert result is bridge
+
+    def test_case_insensitive(self):
+        from tools._sdlc_utils import find_session_by_issue
+
+        bridge = self._session(message_text="ISSUE 1147 is urgent")
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [bridge]
+
+        with patch("tools._sdlc_utils.AgentSession", mock_as):
+            result = find_session_by_issue(1147)
+
+        assert result is bridge
+
+    def test_word_boundary_rejects_tissue(self):
+        """'tissue 1147' must NOT match — word boundary protection."""
+        from tools._sdlc_utils import find_session_by_issue
+
+        decoy = self._session(message_text="tissue 1147 sample count")
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [decoy]
+
+        with patch("tools._sdlc_utils.AgentSession", mock_as):
+            result = find_session_by_issue(1147)
+
+        assert result is None
+
+    def test_does_not_match_different_number(self):
+        from tools._sdlc_utils import find_session_by_issue
+
+        other = self._session(message_text="SDLC issue 1140")
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [other]
+
+        with patch("tools._sdlc_utils.AgentSession", mock_as):
+            result = find_session_by_issue(1147)
+
+        assert result is None
+
+    def test_none_message_text_does_not_match(self):
+        from tools._sdlc_utils import find_session_by_issue
+
+        s = self._session(message_text=None)
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [s]
+
+        with patch("tools._sdlc_utils.AgentSession", mock_as):
+            result = find_session_by_issue(1147)
+
+        assert result is None
+
+    def test_empty_message_text_does_not_match(self):
+        from tools._sdlc_utils import find_session_by_issue
+
+        s = self._session(message_text="")
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [s]
+
+        with patch("tools._sdlc_utils.AgentSession", mock_as):
+            result = find_session_by_issue(1147)
+
+        assert result is None
+
+    def test_issue_url_priority_over_message_text(self):
+        """If both could match, the issue_url match wins (preserves priority)."""
+        from tools._sdlc_utils import find_session_by_issue
+
+        # In query order: first has message_text match only, second has issue_url.
+        text_match = self._session(message_text="SDLC issue 1147")
+        url_match = self._session(
+            issue_url="https://github.com/tomcounsell/ai/issues/1147"
+        )
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [text_match, url_match]
+
+        with patch("tools._sdlc_utils.AgentSession", mock_as):
+            result = find_session_by_issue(1147)
+
+        # The url_match must win because the issue_url pass runs first across
+        # the whole list before the message_text fallback pass begins.
+        assert result is url_match

--- a/tools/_sdlc_utils.py
+++ b/tools/_sdlc_utils.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from pathlib import Path
 
 from models.agent_session import AgentSession
@@ -20,8 +21,21 @@ logger = logging.getLogger(__name__)
 def find_session_by_issue(issue_number: int):
     """Find a PM session tracking the given issue number.
 
-    Scans recent PM sessions for an issue_url containing the issue number.
-    Returns the session object or None.
+    Two-pass match over PM sessions:
+
+    1. Primary pass: ``issue_url`` endswith ``/issues/{issue_number}``.
+    2. Fallback pass: ``message_text`` matches the case-insensitive regex
+       ``\\bissue\\s*#?\\s*{issue_number}\\b``. This catches Telegram-
+       originated PM sessions that have no ``issue_url`` (the bridge builds
+       sessions from message text, not URLs) so operators running SDLC over
+       the bridge are still findable by issue number.
+
+    The ``issue_url`` pass takes priority: if any session matches there, it
+    is returned without running the ``message_text`` scan. When multiple
+    sessions could match via ``message_text`` alone (e.g., a conversation
+    mentioning two issue numbers), the first iterated session wins — this is
+    an acceptable limitation because bridge sessions today carry a single
+    originating message and multi-issue mentions are rare.
 
     Args:
         issue_number: GitHub issue number to search for.
@@ -42,6 +56,16 @@ def find_session_by_issue(issue_number: int):
             issue_url = getattr(s, "issue_url", None) or ""
             if issue_url.endswith(target_suffix):
                 return s
+
+        # Fallback: match by message_text for bridge-originated sessions that
+        # have no issue_url. Word boundaries prevent matches like
+        # "tissue 1147" — only "issue 1147", "issue #1147", "SDLC issue 1147".
+        pattern = re.compile(rf"\bissue\s*#?\s*{issue_number}\b", re.IGNORECASE)
+        for s in pm_sessions:
+            message_text = getattr(s, "message_text", None) or ""
+            if message_text and pattern.search(message_text):
+                return s
+
         return None
     except Exception as e:
         logger.debug(f"find_session_by_issue failed: {e}")

--- a/tools/sdlc_session_ensure.py
+++ b/tools/sdlc_session_ensure.py
@@ -84,19 +84,10 @@ def ensure_session(issue_number: int, issue_url: str | None = None) -> dict:
                         # Gate on non-terminal status (AD1): if the bridge session
                         # finalized between env injection and this call, fall
                         # through so we do not write stage state to a dead record.
-                        try:
-                            from models.session_lifecycle import TERMINAL_STATUSES
+                        from models.session_lifecycle import TERMINAL_STATUSES
 
-                            status = getattr(resolved, "status", None)
-                            if status not in TERMINAL_STATUSES:
-                                return {"session_id": env_session_id, "created": False}
-                        except Exception as e:
-                            logger.debug(
-                                f"sdlc_session_ensure: terminal-status gate failed: {e}"
-                            )
-                            # If TERMINAL_STATUSES import fails for any reason,
-                            # degrade to honoring only the PM check (safer than
-                            # creating a zombie duplicate).
+                        status = getattr(resolved, "status", None)
+                        if status not in TERMINAL_STATUSES:
                             return {"session_id": env_session_id, "created": False}
             except Exception as e:
                 logger.debug(f"sdlc_session_ensure: env short-circuit failed: {e}")

--- a/tools/sdlc_session_ensure.py
+++ b/tools/sdlc_session_ensure.py
@@ -6,6 +6,8 @@ sessions where no bridge-injected session ID is available.
 Usage:
     python -m tools.sdlc_session_ensure --issue-number 941
     python -m tools.sdlc_session_ensure --issue-number 941 --issue-url https://github.com/tomcounsell/ai/issues/941
+    python -m tools.sdlc_session_ensure --kill-orphans --dry-run
+    python -m tools.sdlc_session_ensure --kill-orphans
     python -m tools.sdlc_session_ensure --help
 
 Exit codes:
@@ -15,6 +17,8 @@ Output:
     {"session_id": "<id>", "created": true}  -- new session created
     {"session_id": "<id>", "created": false} -- existing session found
     {} on error
+    {"orphans": [...], "count": N, "killed": false} -- --kill-orphans --dry-run
+    {"results": [...], "count": N, "failures": M, "killed": true} -- --kill-orphans
 """
 
 from __future__ import annotations
@@ -24,15 +28,33 @@ import json
 import logging
 import os
 import sys
+from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
+
+# Minimum age (in seconds) before a sdlc-local session is considered a zombie
+# orphan. Sessions younger than this are not listed or killed — they may still be
+# executing their first turn or writing their first heartbeat.
+ORPHAN_AGE_SECONDS = 600
 
 
 def ensure_session(issue_number: int, issue_url: str | None = None) -> dict:
     """Ensure a local AgentSession exists for the given issue number.
 
-    If a PM session already tracks this issue, returns it.
-    Otherwise, creates a new local session with session_id="sdlc-local-{issue_number}".
+    Resolution order:
+    1. **Env-var short-circuit**: If VALOR_SESSION_ID or AGENT_SESSION_ID is set
+       in the environment and resolves to a live PM session with non-terminal
+       status, return it without creating anything. Bridge-initiated sessions
+       hit this path and the call is a true no-op.
+    2. **Issue-based lookup**: Scan PM sessions for a matching issue_url or
+       message_text (case-insensitive word-boundary regex).
+    3. **Create**: Fall through to creating a new sdlc-local-{N} session.
+
+    The short-circuit falls through to the legacy path when:
+    - The env var is unset or empty
+    - The env-resolved session does not exist in Redis (stale env)
+    - The env-resolved session is not a PM session (e.g., a Dev session)
+    - The env-resolved session is in a terminal status (completed, killed, etc.)
 
     Args:
         issue_number: GitHub issue number.
@@ -46,6 +68,40 @@ def ensure_session(issue_number: int, issue_url: str | None = None) -> dict:
         return {}
 
     try:
+        # Env-var short-circuit: bridge-initiated sessions inject VALOR_SESSION_ID
+        # into the subprocess environment. When set to a live PM session, return
+        # it immediately — no scan, no create.
+        env_session_id = os.environ.get("VALOR_SESSION_ID") or os.environ.get("AGENT_SESSION_ID")
+        if env_session_id:
+            try:
+                from tools._sdlc_utils import find_session
+
+                resolved = find_session(session_id=env_session_id)
+                if resolved is not None:
+                    # Gate on PM session type so PM stage_states never land on
+                    # a Dev/Teammate session during cross-role debugging.
+                    if getattr(resolved, "session_type", None) == "pm":
+                        # Gate on non-terminal status (AD1): if the bridge session
+                        # finalized between env injection and this call, fall
+                        # through so we do not write stage state to a dead record.
+                        try:
+                            from models.session_lifecycle import TERMINAL_STATUSES
+
+                            status = getattr(resolved, "status", None)
+                            if status not in TERMINAL_STATUSES:
+                                return {"session_id": env_session_id, "created": False}
+                        except Exception as e:
+                            logger.debug(
+                                f"sdlc_session_ensure: terminal-status gate failed: {e}"
+                            )
+                            # If TERMINAL_STATUSES import fails for any reason,
+                            # degrade to honoring only the PM check (safer than
+                            # creating a zombie duplicate).
+                            return {"session_id": env_session_id, "created": False}
+            except Exception as e:
+                logger.debug(f"sdlc_session_ensure: env short-circuit failed: {e}")
+                # Fall through to the legacy path on any error.
+
         from tools._sdlc_utils import find_session_by_issue
 
         existing = find_session_by_issue(issue_number)
@@ -98,6 +154,122 @@ def ensure_session(issue_number: int, issue_url: str | None = None) -> dict:
         return {}
 
 
+def _iter_orphan_sessions():
+    """Yield zombie sdlc-local PM sessions suitable for --kill-orphans.
+
+    A session is considered a zombie orphan when ALL of these hold:
+    - ``session_type == "pm"``
+    - ``status == "running"``
+    - ``session_id`` starts with ``"sdlc-local-"``
+    - ``last_heartbeat_at`` is None (never received a worker turn)
+    - ``created_at`` is older than ``ORPHAN_AGE_SECONDS`` (default 10 minutes)
+
+    Sessions whose ``session_id`` does not start with ``"sdlc-local-"`` are
+    NEVER yielded — bridge sessions and other running PM sessions are out of
+    scope for this cleanup (the bridge watchdog handles stuck bridge sessions).
+
+    Yields:
+        AgentSession instances matching the orphan criteria.
+    """
+    from models.agent_session import AgentSession
+
+    now = datetime.now(timezone.utc)
+
+    try:
+        pm_running = list(AgentSession.query.filter(session_type="pm", status="running"))
+    except Exception as e:
+        logger.debug(f"_iter_orphan_sessions: query failed: {e}")
+        return
+
+    for s in pm_running:
+        sid = getattr(s, "session_id", None) or ""
+        if not sid.startswith("sdlc-local-"):
+            continue
+        if getattr(s, "last_heartbeat_at", None) is not None:
+            continue
+        created = getattr(s, "created_at", None)
+        if created is None:
+            continue
+        try:
+            age_seconds = (now - created).total_seconds()
+        except Exception:
+            continue
+        if age_seconds >= ORPHAN_AGE_SECONDS:
+            yield s
+
+
+def _kill_orphans(dry_run: bool) -> dict:
+    """Execute the --kill-orphans CLI path.
+
+    Args:
+        dry_run: If True, list zombies without modifying. If False, finalize each
+            via ``finalize_session()`` (never ``transition_status()`` — that helper
+            rejects terminal statuses by design).
+
+    Returns:
+        JSON-serializable dict with orphan/result details. Exit code is always 0
+        at the CLI layer regardless of per-session failures; callers inspect the
+        ``failures`` count.
+    """
+    orphans = list(_iter_orphan_sessions())
+
+    # Observability signal (O1): emit a single stderr line when non-zero count
+    # so scheduled cleanup runs log evidence of any regression in the
+    # short-circuit. Stdout stays parseable as JSON.
+    if orphans:
+        print(
+            f"[sdlc_session_ensure] found {len(orphans)} zombie sdlc-local session(s)",
+            file=sys.stderr,
+        )
+
+    if dry_run:
+        return {
+            "orphans": [
+                {
+                    "session_id": getattr(s, "session_id", None),
+                    "created_at": (
+                        getattr(s, "created_at", None).isoformat()
+                        if getattr(s, "created_at", None)
+                        else None
+                    ),
+                    "issue_url": getattr(s, "issue_url", None),
+                }
+                for s in orphans
+            ],
+            "count": len(orphans),
+            "killed": False,
+        }
+
+    # Real run: finalize each session. Each call runs inside its own try/except
+    # so per-session failures are reported in the payload, never raised.
+    from models.session_lifecycle import finalize_session
+
+    results = []
+    failures = 0
+    for s in orphans:
+        sid = getattr(s, "session_id", None)
+        try:
+            finalize_session(
+                s,
+                "killed",
+                reason="zombie sdlc-local session cleanup",
+                skip_auto_tag=True,
+                skip_checkpoint=True,
+                skip_parent=True,
+            )
+            results.append({"session_id": sid, "result": "killed"})
+        except Exception as e:
+            failures += 1
+            results.append({"session_id": sid, "result": "failed", "error": str(e)})
+
+    return {
+        "results": results,
+        "count": len(orphans),
+        "failures": failures,
+        "killed": True,
+    }
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Ensure a local SDLC session exists for an issue",
@@ -107,13 +279,24 @@ def main() -> None:
     parser.add_argument(
         "--issue-number",
         type=int,
-        required=True,
-        help="GitHub issue number",
+        default=None,
+        help="GitHub issue number (required unless --kill-orphans is set)",
     )
     parser.add_argument(
         "--issue-url",
         default=None,
         help="Full GitHub issue URL (optional, used for issue_url field)",
+    )
+    parser.add_argument(
+        "--kill-orphans",
+        action="store_true",
+        help="Finalize zombie sdlc-local-* PM sessions (status=running, no heartbeat, "
+        "older than ORPHAN_AGE_SECONDS). Mutually exclusive with --issue-number.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="With --kill-orphans: list zombie sessions without modifying them.",
     )
     parser.add_argument(
         "--verbose",
@@ -125,6 +308,20 @@ def main() -> None:
 
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
+
+    if args.kill_orphans:
+        if args.issue_number is not None:
+            parser.error("--kill-orphans is mutually exclusive with --issue-number")
+        try:
+            result = _kill_orphans(dry_run=args.dry_run)
+        except Exception as e:
+            logger.debug(f"sdlc_session_ensure: --kill-orphans failed: {e}")
+            result = {}
+        print(json.dumps(result))
+        return
+
+    if args.issue_number is None:
+        parser.error("--issue-number is required unless --kill-orphans is set")
 
     result = ensure_session(
         issue_number=args.issue_number,


### PR DESCRIPTION
## Summary

Fixes the zombie `sdlc-local-{N}` PM session that `/sdlc` Step 1.5 created alongside every Telegram-originated PM session. The orchestrator's `ensure_session` now short-circuits when `VALOR_SESSION_ID` resolves to a live, non-terminal PM session — the call becomes a true no-op inside a bridge-initiated session, matching the SKILL.md description.

## Changes

- **`tools/sdlc_session_ensure.py`**
  - Env-var short-circuit at the top of `ensure_session()`. Reads `VALOR_SESSION_ID` / `AGENT_SESSION_ID`, confirms via `find_session`, and gates on both `session_type == "pm"` (no cross-role writes) and non-terminal status (no writes to finalized records — AD1).
  - Falls through to the issue-number lookup / create path on stale env, non-PM sessions, terminal-status sessions, or any Redis error.
  - New `--kill-orphans` CLI path using `finalize_session()` (never `transition_status()`, which rejects terminal targets). Supports `--dry-run`; always exits 0 regardless of per-session failures.
  - `ORPHAN_AGE_SECONDS = 600` module constant. Orphan criteria: `session_type=pm`, `status=running`, `session_id.startswith("sdlc-local-")`, `last_heartbeat_at is None`, age `>= ORPHAN_AGE_SECONDS`.
  - Stderr observability line on non-zero zombie count (O1); stdout stays JSON-parseable.
- **`tools/_sdlc_utils.py`**
  - `find_session_by_issue()` gains a second-pass fallback matching `message_text` via the case-insensitive word-boundary regex `\bissue\s*#?\s*{N}\b`. Catches bridge sessions whose `issue_url` is None. Word boundaries reject false positives like `"tissue 1147"`.
  - `issue_url` match priority preserved (first pass finishes before fallback begins).
- **`.claude/skills/sdlc/SKILL.md`** — Step 1.5 comment updated so "no-op for bridge-initiated sessions" matches real behavior after the fix.
- **`docs/features/sdlc-pipeline-state.md`** — new Bridge short-circuit and Orphan cleanup subsections; Bridge vs Local comparison refreshed.
- **`docs/features/sdlc-stage-tracking.md`** — bridge short-circuit note appended to Local Session Creation with pointer to the pipeline-state doc.

## Testing

- **Unit** — 25 new tests across `tests/unit/test_sdlc_session_ensure.py` and `tests/unit/test_sdlc_utils.py` covering: env short-circuit happy path, stale env, empty env string, non-PM session gate, each of the five terminal-status values (parametrized), Redis error, all `message_text` regex scenarios (SDLC prefix, `#` hash, case-insensitive, word-boundary rejection of `"tissue 1147"`, None/empty inputs, `issue_url` priority preserved), and all `--kill-orphans` paths (dry-run, real finalize, finalize-failure, age boundaries at/+1s/-1s threshold, heartbeat guard, non-`sdlc-local-` skip, CLI JSON contract, mutually-exclusive flag).
- **Integration** — `tests/integration/test_sdlc_session_ensure_integration.py` creates a real bridge-style PM AgentSession in Redis and asserts that `ensure_session(9999)` returns the bridge id with `created=false` and produces zero `sdlc-local-9999` duplicates.
- **Related** — `tests/unit/test_sdlc_stage_marker.py` and `tests/unit/test_sdlc_stage_query.py` (which patch `find_session_by_issue`) remain unchanged and still pass — 42 passing. Signature is preserved, only behavior extended.
- **Verification** — all plan verification table checks pass; `python -m tools.sdlc_session_ensure --kill-orphans --dry-run` exits 0 with `{"orphans": [], "count": 0, "killed": false}` against live dev Redis.

## Definition of Done

- [x] Built: env short-circuit, message_text fallback, `--kill-orphans` CLI, SKILL.md fix
- [x] Tested: 40 passing (14 existing + 25 unit + 1 integration), related stage-marker/query tests still green
- [x] Reviewed: deterministic plan validator 6 PASS (2 validator script false-positives on piped grep — confirmed manually)
- [x] Documented: `sdlc-pipeline-state.md` and `sdlc-stage-tracking.md` updated, SKILL.md Step 1.5 comment corrected
- [x] Quality: `python -m ruff format --check` clean on all changed files

Closes #1147