### PR TITLE
fix(#1148): inject SESSION_TYPE + load PM persona into harness sessions

### DIFF
--- a/agent/sdk_client.py
+++ b/agent/sdk_client.py
@@ -1814,6 +1814,7 @@ async def get_response_via_harness(
     session_id: str | None = None,
     full_context_message: str | None = None,
     model: str | None = None,
+    system_prompt: str | None = None,
     on_sdk_started: Callable[[int], None] | None = None,
     on_stdout_event: Callable[[], None] | None = None,
 ) -> str:
@@ -1859,6 +1860,13 @@ async def get_response_via_harness(
             When None/empty, the CLI uses its own default. Part of the per-
             session model routing cascade (see
             ``agent/session_executor.py::_resolve_session_model``).
+        system_prompt: Optional persona/role text appended to Claude Code's
+            default system prompt via ``--append-system-prompt`` (issue #1148).
+            Use ``--append`` (not ``--system-prompt``) to preserve the default
+            tool-handling protocol — the persona is additive guidance. PM
+            sessions pass ``load_pm_system_prompt(working_dir)`` here; drafter
+            and dev sessions must keep this ``None``. Strings larger than
+            512KB are dropped with a warning to avoid ARG_MAX overflows.
     """
     # Validate prior_uuid format; treat empty or invalid as None
     if prior_uuid and not _UUID_PATTERN.match(prior_uuid):
@@ -1881,6 +1889,25 @@ async def get_response_via_harness(
     if model:
         harness_cmd.extend(["--model", model])
         logger.info(f"[harness] Using --model {model} for session_id={session_id}")
+
+    # System prompt injection (issue #1148). Use --append-system-prompt
+    # (NOT --system-prompt) so Claude Code's default tool-handling protocol is
+    # preserved — the PM persona is additive guidance, not a full replacement.
+    # Defensive size cap: macOS ARG_MAX is 1MB; we cap at 512KB to leave room
+    # for the rest of the argv. The current PM persona is ~25KB.
+    if system_prompt:
+        if len(system_prompt) > 512_000:
+            logger.warning(
+                f"[harness] system_prompt is {len(system_prompt)} bytes; "
+                "exceeds 512KB soft cap, omitting to avoid ARG_MAX (session_id="
+                f"{session_id})"
+            )
+        else:
+            harness_cmd.extend(["--append-system-prompt", system_prompt])
+            logger.info(
+                f"[harness] Appending {len(system_prompt)}-char system prompt for "
+                f"session_id={session_id}"
+            )
 
     # Build subprocess env: inherit current env, merge extras, strip API key
     proc_env = dict(os.environ)

--- a/agent/sdk_client.py
+++ b/agent/sdk_client.py
@@ -1133,6 +1133,33 @@ def _check_no_direct_main_push(session_id: str, repo_root: Path | None = None) -
     )
 
 
+def _resolve_sentry_auth_token() -> str | None:
+    """Resolve Sentry auth token for PM/Teammate session env injection.
+
+    Cascade: SENTRY_PERSONAL_TOKEN env var -> SENTRY_AUTH_TOKEN env var ->
+    ~/Desktop/Valor/.env file read (only in terminal mode; launchd blocks
+    ~/Desktop under TCC).
+
+    Returns:
+        The Sentry auth token, or None if no source resolves successfully.
+    """
+    token = os.environ.get("SENTRY_PERSONAL_TOKEN") or os.environ.get("SENTRY_AUTH_TOKEN")
+    if token:
+        return token
+    if os.environ.get("VALOR_LAUNCHD"):
+        return None  # launchd cannot read ~/Desktop (macOS TCC)
+    sentry_env = Path.home() / "Desktop" / "Valor" / ".env"
+    try:
+        if not sentry_env.exists():
+            return None
+        for line in sentry_env.read_text().splitlines():
+            if line.startswith("SENTRY_PERSONAL_TOKEN="):
+                return line.split("=", 1)[1]
+    except (OSError, PermissionError):
+        return None
+    return None
+
+
 class ValorAgent:
     """
     Valor's Claude Agent SDK wrapper.
@@ -1265,23 +1292,13 @@ class ValorAgent:
             env["TELEGRAM_CHAT_ID"] = str(self.chat_id)
 
         # PM sessions: inject Sentry auth token so sentry-cli works without
-        # manual export. Token is stored in ~/Desktop/Valor/.env (iCloud-synced).
-        # Under launchd (VALOR_LAUNCHD=1), macOS TCC blocks open() on ~/Desktop
-        # files, causing indefinite hangs. Prefer the env var injected by
-        # install_worker.sh; only fall back to file read in terminal mode.
+        # manual export. Token resolution is delegated to _resolve_sentry_auth_token,
+        # which encapsulates the env-var-then-file cascade and the VALOR_LAUNCHD
+        # short-circuit (macOS TCC blocks open() on ~/Desktop files under launchd).
         if self.session_type in (SessionType.PM, SessionType.TEAMMATE):
-            sentry_token = os.environ.get("SENTRY_PERSONAL_TOKEN") or os.environ.get(
-                "SENTRY_AUTH_TOKEN"
-            )
+            sentry_token = _resolve_sentry_auth_token()
             if sentry_token:
                 env["SENTRY_AUTH_TOKEN"] = sentry_token
-            elif not os.environ.get("VALOR_LAUNCHD"):
-                sentry_env = Path.home() / "Desktop" / "Valor" / ".env"
-                if sentry_env.exists():
-                    for line in sentry_env.read_text().splitlines():
-                        if line.startswith("SENTRY_PERSONAL_TOKEN="):
-                            env["SENTRY_AUTH_TOKEN"] = line.split("=", 1)[1]
-                            break
 
         # SDLC context injection: pre-resolve session fields as env vars so
         # skills can reference $SDLC_PR_NUMBER etc. instead of guessing (issue #420).

--- a/agent/session_executor.py
+++ b/agent/session_executor.py
@@ -1267,8 +1267,10 @@ async def _execute_agent_session(session: AgentSession) -> None:
         # All session types route to CLI harness (claude -p)
         from agent.sdk_client import (
             _get_prior_session_uuid,
+            _resolve_sentry_auth_token,
             build_harness_turn_input,
             get_response_via_harness,
+            load_pm_system_prompt,
         )
 
         project_key = project_config.get("_key", "valor") if project_config else "valor"
@@ -1325,8 +1327,22 @@ async def _execute_agent_session(session: AgentSession) -> None:
             "AGENT_SESSION_ID": session.agent_session_id or "",
             "CLAUDE_CODE_TASK_LIST_ID": task_list_id or "",
         }
+        # SESSION_TYPE drives pre_tool_use hook behavior (_is_pm_session in
+        # agent/hooks/pre_tool_use.py:97-99). Without it, PM Bash restrictions
+        # are silently disabled in the harness subprocess (issue #1148).
+        if _session_type:
+            _harness_env["SESSION_TYPE"] = _session_type
         if _session_type in (SessionType.PM, SessionType.TEAMMATE) and session.agent_session_id:
             _harness_env["VALOR_PARENT_SESSION_ID"] = session.agent_session_id
+        # PM/Teammate need Telegram + Sentry auth so tools/send_telegram.py and
+        # sentry-cli work without manual export. Mirrors ValorAgent.env
+        # (sdk_client.py:1264, 1272). chat_id comes from the project config.
+        if _session_type in (SessionType.PM, SessionType.TEAMMATE):
+            if session.chat_id:
+                _harness_env["TELEGRAM_CHAT_ID"] = str(session.chat_id)
+            _sentry_token = _resolve_sentry_auth_token()
+            if _sentry_token:
+                _harness_env["SENTRY_AUTH_TOKEN"] = _sentry_token
 
         _harness_requeued = False
 

--- a/agent/session_executor.py
+++ b/agent/session_executor.py
@@ -1349,6 +1349,21 @@ async def _execute_agent_session(session: AgentSession) -> None:
         # D1 precedence cascade: session.model > settings > codebase default.
         _effective_model = _resolve_session_model(agent_session)
 
+        # PM sessions get persona-level SDLC orchestration rules via
+        # --append-system-prompt (issue #1148). Dev and Teammate sessions have
+        # no harness-side persona loader; they keep the default Claude Code
+        # protocol. Drafter call sites in session_completion.py MUST also leave
+        # system_prompt at the default None — see Risk 4 in docs/plans/sdlc-1148.md.
+        _pm_system_prompt: str | None = None
+        if _session_type == SessionType.PM:
+            try:
+                _pm_system_prompt = load_pm_system_prompt(str(working_dir))
+            except Exception as e:
+                logger.warning(
+                    f"{log_prefix} [pm-persona-missing] Failed to load PM persona: {e}; "
+                    "session will run without SDLC orchestration rules"
+                )
+
         async def do_work() -> str:
             nonlocal _harness_requeued
             raw = await get_response_via_harness(
@@ -1359,6 +1374,7 @@ async def _execute_agent_session(session: AgentSession) -> None:
                 session_id=session.session_id,
                 full_context_message=_harness_input,
                 model=_effective_model,
+                system_prompt=_pm_system_prompt,
                 # Two-tier no-progress detector callbacks (#1036). These route
                 # through messenger.notify_* wrappers so exceptions are caught
                 # and the queue-layer closures bump ORM fields on AgentSession.

--- a/docs/features/harness-abstraction.md
+++ b/docs/features/harness-abstraction.md
@@ -81,6 +81,37 @@ When `DEV_SESSION_HARNESS` is set to a non-`sdk` value, the worker runs `verify_
 - `AGENT_SESSION_ID` and `CLAUDE_CODE_TASK_LIST_ID` are passed to all session types for session isolation
 - `VALOR_PARENT_SESSION_ID` is additionally injected for PM and Teammate sessions, enabling child subprocesses (spawned via `valor_session create --parent` or the Agent tool) to link their `AgentSession` records back to the parent session in `user_prompt_submit.py`. Dev sessions do not receive this env var — they are leaf nodes in the hierarchy.
 
+### Session Environment Injection (issue #1148)
+
+The harness path mirrors the env contract that the SDK-era `ValorAgent.env` builder provided. `agent/session_executor.py` constructs `_harness_env` with the following keys, scoped by session type:
+
+| Env Var | Scope | Source | Consumer |
+|---------|-------|--------|----------|
+| `AGENT_SESSION_ID` | All typed sessions | `session.agent_session_id` | Hooks (`pre_tool_use.py`, `user_prompt_submit.py`); session isolation |
+| `CLAUDE_CODE_TASK_LIST_ID` | All typed sessions | Tier 1 thread-derived or Tier 2 slug | Task list isolation per `docs/features/session-isolation.md` |
+| `SESSION_TYPE` | All typed sessions | `session.session_type` (`pm`/`teammate`/`dev`) | `agent/hooks/pre_tool_use.py::_is_pm_session()` — drives the PM Bash allowlist + write restrictions |
+| `VALOR_PARENT_SESSION_ID` | PM, Teammate | `session.agent_session_id` | Child subprocess linkage (`user_prompt_submit.py`) |
+| `TELEGRAM_CHAT_ID` | PM, Teammate (when `chat_id` set) | `session.chat_id` | `tools/send_telegram.py` for PM-side message sends |
+| `SENTRY_AUTH_TOKEN` | PM, Teammate | `agent/sdk_client.py::_resolve_sentry_auth_token()` | `sentry-cli` (no manual export needed) |
+
+Sentry token resolution cascade: `SENTRY_PERSONAL_TOKEN` env var → `SENTRY_AUTH_TOKEN` env var → `~/Desktop/Valor/.env` file read. Under `VALOR_LAUNCHD=1` the file read is skipped (macOS TCC blocks `open()` on `~/Desktop` files under launchd).
+
+### PM Persona Injection — `--append-system-prompt` (issue #1148)
+
+PM sessions append the project-manager persona to `claude -p`'s default system prompt via `--append-system-prompt`:
+
+1. The executor calls `agent.sdk_client.load_pm_system_prompt(working_dir)` — returns the persona file plus the project-specific work-vault `CLAUDE.md` if present.
+2. The result is passed as `system_prompt=` to `get_response_via_harness()`.
+3. `get_response_via_harness()` injects `["--append-system-prompt", <text>]` into the harness argv after `--model` and before the positional message.
+
+`--append-system-prompt` (not `--system-prompt`) preserves Claude Code's default tool-handling protocol — the PM persona is additive guidance. Defensive 512KB cap avoids macOS `ARG_MAX` overflows; oversized prompts are dropped with a `logger.warning` and the session continues without the persona (degraded but functional).
+
+Failure modes:
+- Persona load raises (e.g. missing persona file on a fresh machine): logs `[pm-persona-missing]` and proceeds with `system_prompt=None`. Session runs without SDLC orchestration rules — visible to the dashboard via the structured log prefix.
+- Drafter call sites in `agent/session_completion.py` (Pass 1 + Pass 2 of `_deliver_pipeline_completion`) MUST keep `system_prompt=None`. Tainting drafter turns with PM orchestration corrupts the user-facing summary. Enforced by `tests/unit/test_session_completion.py::test_drafter_calls_omit_system_prompt_via_grep` and the AST guard alongside it.
+
+Dev and Teammate sessions do not have a harness-side persona loader; they keep the default Claude Code protocol.
+
 ## Harness Command Registry
 
 New harnesses are added to `_HARNESS_COMMANDS` in `agent/sdk_client.py`:

--- a/docs/features/harness-abstraction.md
+++ b/docs/features/harness-abstraction.md
@@ -108,7 +108,7 @@ PM sessions append the project-manager persona to `claude -p`'s default system p
 
 Failure modes:
 - Persona load raises (e.g. missing persona file on a fresh machine): logs `[pm-persona-missing]` and proceeds with `system_prompt=None`. Session runs without SDLC orchestration rules — visible to the dashboard via the structured log prefix.
-- Drafter call sites in `agent/session_completion.py` (Pass 1 + Pass 2 of `_deliver_pipeline_completion`) MUST keep `system_prompt=None`. Tainting drafter turns with PM orchestration corrupts the user-facing summary. Enforced by `tests/unit/test_session_completion.py::test_drafter_calls_omit_system_prompt_via_grep` and the AST guard alongside it.
+- Drafter call sites in `agent/session_completion.py` (Pass 1 + Pass 2 of `_deliver_pipeline_completion`) MUST keep `system_prompt=None`. Tainting drafter turns with PM orchestration corrupts the user-facing summary. Enforced by `tests/unit/test_session_completion.py::test_drafter_calls_omit_system_prompt` and the AST/anchor guards alongside it.
 
 Dev and Teammate sessions do not have a harness-side persona loader; they keep the default Claude Code protocol.
 

--- a/docs/features/personas.md
+++ b/docs/features/personas.md
@@ -138,6 +138,8 @@ prompt = load_system_prompt()                 # developer persona + WORKER_RULES
 prompt = load_pm_system_prompt("/path")       # PM persona + work-vault CLAUDE.md
 ```
 
+`load_pm_system_prompt()` is invoked from `agent/session_executor.py` for PM sessions (issue #1148). The result is passed to `get_response_via_harness(system_prompt=...)` and appended to `claude -p`'s default prompt via `--append-system-prompt`. See `docs/features/harness-abstraction.md#pm-persona-injection-append-system-prompt-issue-1148`.
+
 ## Related
 
 - `config/identity.json` -- Structured identity data (name, email, timezone, org)

--- a/docs/features/pm-channels.md
+++ b/docs/features/pm-channels.md
@@ -37,6 +37,10 @@ PM mode uses `load_pm_system_prompt()` which:
 - Does NOT include WORKER_RULES (no branch safety rails needed for PM work)
 - Raises `FileNotFoundError` if persona segments are missing (no silent fallback)
 
+The composed prompt is wired into `claude -p` via `--append-system-prompt` (issue #1148). `agent/session_executor.py` calls `load_pm_system_prompt(working_dir)` for PM sessions and passes the result through `get_response_via_harness(system_prompt=...)`. The harness appends it to Claude Code's default system prompt so the PM persona is additive guidance rather than a full replacement — see `docs/features/harness-abstraction.md#pm-persona-injection-append-system-prompt-issue-1148` for the argv-level details.
+
+Prior to #1148, the harness path silently dropped the persona entirely (the `_harness_env` did not carry `SESSION_TYPE` and the `claude -p` argv did not carry `--append-system-prompt`). PM sessions ran without their orchestration rules and the `_is_pm_session()` hook gate was bypassed. The fix restores parity with the SDK-era `ValorAgent.system_prompt` path.
+
 ### What PM Mode Skips
 
 - SDLC classification (`classify_work_request()`)

--- a/tests/integration/test_harness_env_pm_injection.py
+++ b/tests/integration/test_harness_env_pm_injection.py
@@ -1,0 +1,269 @@
+"""Integration test for PM harness env + argv injection (issue #1148).
+
+Validates the end-to-end wiring chain that issue #1148 introduces:
+
+  worker → _execute_agent_session
+    → builds _harness_env with {AGENT_SESSION_ID, CLAUDE_CODE_TASK_LIST_ID,
+      SESSION_TYPE, TELEGRAM_CHAT_ID, SENTRY_AUTH_TOKEN, VALOR_PARENT_SESSION_ID}
+    → resolves load_pm_system_prompt(working_dir) for PM sessions
+    → calls get_response_via_harness(env=..., system_prompt=..., model=...)
+        → builds claude -p argv with --model + --append-system-prompt + message
+
+The test mocks _run_harness_subprocess (the leaf I/O call) so no real
+claude binary is invoked, and asserts the constructed cmd + proc_env
+match the contract.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# A stub PM persona file; placed inside the test working_dir as CLAUDE.md so
+# that load_pm_system_prompt finds something reproducible to append.
+_STUB_CLAUDE_MD = "## Stub project CLAUDE.md\nProject-specific PM rules go here."
+
+
+def _write_repo_persona(tmp_path: Path) -> Path:
+    """Create a minimal working_dir with a CLAUDE.md so load_pm_system_prompt
+    has something deterministic to read alongside the persona file."""
+    wd = tmp_path / "wd"
+    wd.mkdir()
+    (wd / "CLAUDE.md").write_text(_STUB_CLAUDE_MD)
+    return wd
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestPMHarnessFullChain:
+    """End-to-end env + argv assembly for the PM harness path."""
+
+    @pytest.mark.asyncio
+    async def test_pm_session_full_argv_contains_persona_and_env(
+        self, monkeypatch, tmp_path
+    ):
+        """A PM session through get_response_via_harness produces the expected argv.
+
+        Asserts:
+          (a) env contains AGENT_SESSION_ID, CLAUDE_CODE_TASK_LIST_ID,
+              SESSION_TYPE=pm, TELEGRAM_CHAT_ID, SENTRY_AUTH_TOKEN
+          (b) argv contains '--append-system-prompt' followed by a non-empty
+              persona string mentioning project-manager content
+          (c) argv contains '--model' followed by 'opus'
+          (d) the positional message is the LAST element of argv
+        """
+        from agent.sdk_client import (
+            _resolve_sentry_auth_token,
+            get_response_via_harness,
+            load_pm_system_prompt,
+        )
+
+        # Sentry token comes from env var so the test is hermetic
+        monkeypatch.setenv("SENTRY_PERSONAL_TOKEN", "integ-sentry-tok-1148")
+        monkeypatch.delenv("VALOR_LAUNCHD", raising=False)
+
+        wd = _write_repo_persona(tmp_path)
+
+        # Mirror the harness env construction in session_executor.py:1324-1346.
+        # We use the same logic shape so a regression in the executor would
+        # be caught at the unit-level (test_session_spawning.py) AND any
+        # production-path drift between the executor and the harness call
+        # surfaces in integration test suites that exercise both.
+        agent_session_id = "agt_integ_1148_001"
+        chat_id = "555"
+        session_type = "pm"
+        env: dict[str, str] = {
+            "AGENT_SESSION_ID": agent_session_id,
+            "CLAUDE_CODE_TASK_LIST_ID": "thread-555-99",
+        }
+        if session_type:
+            env["SESSION_TYPE"] = session_type
+        if session_type in ("pm", "teammate"):
+            env["VALOR_PARENT_SESSION_ID"] = agent_session_id
+            env["TELEGRAM_CHAT_ID"] = chat_id
+            tok = _resolve_sentry_auth_token()
+            if tok:
+                env["SENTRY_AUTH_TOKEN"] = tok
+
+        # Resolve the persona via the production loader. Even with no work-vault
+        # persona file, load_pm_system_prompt always returns the base persona.
+        persona = load_pm_system_prompt(str(wd))
+        assert persona, "load_pm_system_prompt must return non-empty content"
+        # Sanity: persona must be the project-manager content, not the dev one.
+        # The current persona file mentions "project-manager" or "PM" content;
+        # we require something distinctive so a future swap to the dev persona
+        # would break this assertion loudly.
+        assert any(token in persona.lower() for token in ("pm", "project manager", "project-manager", "stub project claude.md")), (
+            f"Persona content must contain a PM-specific signal. First 200 chars: "
+            f"{persona[:200]!r}"
+        )
+
+        # Capture the cmd + proc_env passed to the leaf subprocess invoker.
+        captured: dict = {}
+
+        async def fake_run(cmd, working_dir, proc_env, **_kw):
+            captured["cmd"] = list(cmd)
+            captured["proc_env"] = dict(proc_env)
+            return ("ok", None, 0, None, None)
+
+        with patch(
+            "agent.sdk_client._run_harness_subprocess",
+            new=AsyncMock(side_effect=fake_run),
+        ):
+            await get_response_via_harness(
+                message="user-task-message",
+                working_dir=str(wd),
+                env=env,
+                model="opus",
+                system_prompt=persona,
+                session_id="sess-integ-1148",
+            )
+
+        cmd = captured["cmd"]
+        proc_env = captured["proc_env"]
+
+        # (a) env contract
+        assert proc_env.get("AGENT_SESSION_ID") == agent_session_id
+        assert proc_env.get("CLAUDE_CODE_TASK_LIST_ID") == "thread-555-99"
+        assert proc_env.get("SESSION_TYPE") == "pm"
+        assert proc_env.get("TELEGRAM_CHAT_ID") == "555"
+        assert proc_env.get("SENTRY_AUTH_TOKEN") == "integ-sentry-tok-1148"
+        assert proc_env.get("VALOR_PARENT_SESSION_ID") == agent_session_id
+        # ANTHROPIC_API_KEY must be stripped (CLI uses subscription auth)
+        assert "ANTHROPIC_API_KEY" not in proc_env
+
+        # (b) --append-system-prompt with persona text
+        assert "--append-system-prompt" in cmd
+        idx = cmd.index("--append-system-prompt")
+        assert cmd[idx + 1] == persona
+
+        # (c) --model opus
+        assert "--model" in cmd
+        m_idx = cmd.index("--model")
+        assert cmd[m_idx + 1] == "opus"
+        # --model precedes --append-system-prompt
+        assert m_idx < idx
+
+        # (d) positional message at the tail
+        assert cmd[-1] == "user-task-message"
+
+    @pytest.mark.asyncio
+    async def test_dev_session_no_persona_no_pm_only_env(self, monkeypatch, tmp_path):
+        """Negative case: dev sessions get no persona, no PM-only env vars."""
+        from agent.sdk_client import _resolve_sentry_auth_token, get_response_via_harness
+
+        # Even with the env var set, a dev session must not propagate it.
+        monkeypatch.setenv("SENTRY_PERSONAL_TOKEN", "should-not-leak")
+
+        wd = _write_repo_persona(tmp_path)
+
+        # Dev path: no SESSION_TYPE/VALOR_PARENT/TELEGRAM/SENTRY injection
+        agent_session_id = "agt_dev_integ_1148_001"
+        session_type = "dev"
+        env: dict[str, str] = {
+            "AGENT_SESSION_ID": agent_session_id,
+            "CLAUDE_CODE_TASK_LIST_ID": "task-list-dev",
+        }
+        if session_type:
+            env["SESSION_TYPE"] = session_type
+        # Dev session: no PM-only env vars (mirrors session_executor.py)
+        if session_type in ("pm", "teammate"):
+            env["VALOR_PARENT_SESSION_ID"] = agent_session_id
+            env["TELEGRAM_CHAT_ID"] = "555"
+            tok = _resolve_sentry_auth_token()
+            if tok:
+                env["SENTRY_AUTH_TOKEN"] = tok
+
+        captured: dict = {}
+
+        async def fake_run(cmd, working_dir, proc_env, **_kw):
+            captured["cmd"] = list(cmd)
+            captured["proc_env"] = dict(proc_env)
+            return ("ok", None, 0, None, None)
+
+        with patch(
+            "agent.sdk_client._run_harness_subprocess",
+            new=AsyncMock(side_effect=fake_run),
+        ):
+            await get_response_via_harness(
+                message="dev-task",
+                working_dir=str(wd),
+                env=env,
+                model="sonnet",
+                # system_prompt deliberately omitted: dev sessions have no persona loader
+                session_id="sess-dev-integ-1148",
+            )
+
+        cmd = captured["cmd"]
+        proc_env = captured["proc_env"]
+
+        # Dev SESSION_TYPE present, but PM-only env vars must not be
+        assert proc_env.get("SESSION_TYPE") == "dev"
+        # The leaked env-var SENTRY_PERSONAL_TOKEN flows through proc_env
+        # because it's an inherited environment variable, but
+        # SENTRY_AUTH_TOKEN (the PM-only injection) must be absent.
+        assert "SENTRY_AUTH_TOKEN" not in proc_env
+        assert "VALOR_PARENT_SESSION_ID" not in proc_env
+        assert "TELEGRAM_CHAT_ID" not in proc_env
+
+        # No persona injection
+        assert "--append-system-prompt" not in cmd
+
+        # --model still present for dev
+        assert "--model" in cmd
+        assert cmd[cmd.index("--model") + 1] == "sonnet"
+
+    @pytest.mark.asyncio
+    async def test_load_pm_system_prompt_failure_does_not_crash(
+        self, monkeypatch, tmp_path
+    ):
+        """If load_pm_system_prompt raises, the harness call still proceeds.
+
+        Mirrors the [pm-persona-missing] fail-soft path in
+        session_executor.py — degraded session is preferable to a crash.
+        """
+        from agent.sdk_client import get_response_via_harness
+
+        wd = _write_repo_persona(tmp_path)
+
+        # Caller code: try/except around load_pm_system_prompt mirrored from the
+        # executor. We deliberately raise to exercise the swallow path.
+        try:
+            raise RuntimeError("simulated persona load failure")
+        except Exception:
+            persona = None  # exec falls through to system_prompt=None
+
+        captured: dict = {}
+
+        async def fake_run(cmd, working_dir, proc_env, **_kw):
+            captured["cmd"] = list(cmd)
+            return ("ok", None, 0, None, None)
+
+        with patch(
+            "agent.sdk_client._run_harness_subprocess",
+            new=AsyncMock(side_effect=fake_run),
+        ):
+            await get_response_via_harness(
+                message="pm-task-without-persona",
+                working_dir=str(wd),
+                env={"AGENT_SESSION_ID": "agt_x", "SESSION_TYPE": "pm"},
+                model="opus",
+                system_prompt=persona,
+            )
+
+        cmd = captured["cmd"]
+        # Persona path is None → no --append-system-prompt
+        assert "--append-system-prompt" not in cmd
+        # But the rest of the argv must still be intact
+        assert "--model" in cmd
+        assert cmd[-1] == "pm-task-without-persona"

--- a/tests/integration/test_harness_env_pm_injection.py
+++ b/tests/integration/test_harness_env_pm_injection.py
@@ -16,7 +16,6 @@ match the contract.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -49,9 +48,7 @@ class TestPMHarnessFullChain:
     """End-to-end env + argv assembly for the PM harness path."""
 
     @pytest.mark.asyncio
-    async def test_pm_session_full_argv_contains_persona_and_env(
-        self, monkeypatch, tmp_path
-    ):
+    async def test_pm_session_full_argv_contains_persona_and_env(self, monkeypatch, tmp_path):
         """A PM session through get_response_via_harness produces the expected argv.
 
         Asserts:
@@ -103,10 +100,10 @@ class TestPMHarnessFullChain:
         # The current persona file mentions "project-manager" or "PM" content;
         # we require something distinctive so a future swap to the dev persona
         # would break this assertion loudly.
-        assert any(token in persona.lower() for token in ("pm", "project manager", "project-manager", "stub project claude.md")), (
-            f"Persona content must contain a PM-specific signal. First 200 chars: "
-            f"{persona[:200]!r}"
-        )
+        assert any(
+            token in persona.lower()
+            for token in ("pm", "project manager", "project-manager", "stub project claude.md")
+        ), f"Persona content must contain a PM-specific signal. First 200 chars: {persona[:200]!r}"
 
         # Capture the cmd + proc_env passed to the leaf subprocess invoker.
         captured: dict = {}
@@ -162,8 +159,14 @@ class TestPMHarnessFullChain:
         """Negative case: dev sessions get no persona, no PM-only env vars."""
         from agent.sdk_client import _resolve_sentry_auth_token, get_response_via_harness
 
-        # Even with the env var set, a dev session must not propagate it.
+        # Even with the source env vars set, a dev session must not perform
+        # the PM-only injection. We still need to clear the inherited
+        # SENTRY_AUTH_TOKEN (which may be set by the user's shell or other
+        # tests' monkeypatches) so the proc_env assertion isn't fooled by
+        # ambient state — the assertion's purpose is to confirm the dev path
+        # never INJECTS it via the executor's _harness_env logic.
         monkeypatch.setenv("SENTRY_PERSONAL_TOKEN", "should-not-leak")
+        monkeypatch.delenv("SENTRY_AUTH_TOKEN", raising=False)
 
         wd = _write_repo_persona(tmp_path)
 
@@ -224,9 +227,7 @@ class TestPMHarnessFullChain:
         assert cmd[cmd.index("--model") + 1] == "sonnet"
 
     @pytest.mark.asyncio
-    async def test_load_pm_system_prompt_failure_does_not_crash(
-        self, monkeypatch, tmp_path
-    ):
+    async def test_load_pm_system_prompt_failure_does_not_crash(self, monkeypatch, tmp_path):
         """If load_pm_system_prompt raises, the harness call still proceeds.
 
         Mirrors the [pm-persona-missing] fail-soft path in

--- a/tests/integration/test_session_spawning.py
+++ b/tests/integration/test_session_spawning.py
@@ -120,3 +120,96 @@ class TestHarnessEnvPassthrough:
         )
 
         assert dev_session.parent_agent_session_id == parent_uuid
+
+    def test_session_type_in_harness_env(self, redis_test_db):
+        """Issue #1148: SESSION_TYPE is injected into _harness_env for typed sessions.
+
+        Without SESSION_TYPE, _is_pm_session() in pre_tool_use.py:97-99 returns
+        False and the PM Bash allowlist is silently disabled. This test mirrors
+        the env-construction logic in agent/session_executor.py:1324-1346.
+        """
+        from config.enums import SessionType
+
+        for session_type in ("pm", "teammate", "dev"):
+            session = _make_session(
+                session_type, f"{session_type}-session-type-001", redis_test_db
+            )
+            _harness_env: dict[str, str] = {
+                "AGENT_SESSION_ID": session.agent_session_id or "",
+                "CLAUDE_CODE_TASK_LIST_ID": "",
+            }
+            # Mirror the real injection at session_executor.py:1333-1334
+            if session_type:
+                _harness_env["SESSION_TYPE"] = session_type
+            assert _harness_env["SESSION_TYPE"] == session_type
+
+        # Sanity: SessionType enum values match the strings stored in env
+        assert SessionType.PM == "pm"
+        assert SessionType.TEAMMATE == "teammate"
+        assert SessionType.DEV == "dev"
+
+    def test_telegram_chat_id_in_harness_env_for_pm(self, redis_test_db):
+        """Issue #1148: TELEGRAM_CHAT_ID injected for PM/Teammate when chat_id set.
+
+        Required by tools/send_telegram.py for PM-side message sends.
+        """
+        from config.enums import SessionType
+
+        pm = _make_session("pm", "pm-telegram-chat-001", redis_test_db)
+        teammate = _make_session("teammate", "tm-telegram-chat-001", redis_test_db)
+
+        for session, expected_st in ((pm, SessionType.PM), (teammate, SessionType.TEAMMATE)):
+            _harness_env: dict[str, str] = {}
+            _session_type = session.session_type
+            # Mirror session_executor.py:1340-1342
+            if _session_type in (SessionType.PM, SessionType.TEAMMATE):
+                if session.chat_id:
+                    _harness_env["TELEGRAM_CHAT_ID"] = str(session.chat_id)
+            assert _harness_env.get("TELEGRAM_CHAT_ID") == "999"
+            assert _session_type == expected_st
+
+    def test_sentry_token_in_harness_env_for_pm(self, monkeypatch, redis_test_db):
+        """Issue #1148: SENTRY_AUTH_TOKEN injected for PM/Teammate when resolvable.
+
+        Uses the shared _resolve_sentry_auth_token helper from sdk_client.
+        """
+        from agent.sdk_client import _resolve_sentry_auth_token
+        from config.enums import SessionType
+
+        monkeypatch.setenv("SENTRY_PERSONAL_TOKEN", "harness-sentry-token-xyz")
+        pm = _make_session("pm", "pm-sentry-001", redis_test_db)
+
+        _harness_env: dict[str, str] = {}
+        if pm.session_type in (SessionType.PM, SessionType.TEAMMATE):
+            tok = _resolve_sentry_auth_token()
+            if tok:
+                _harness_env["SENTRY_AUTH_TOKEN"] = tok
+
+        assert _harness_env["SENTRY_AUTH_TOKEN"] == "harness-sentry-token-xyz"
+
+    def test_dev_session_does_not_get_telegram_chat_id(self, monkeypatch, redis_test_db):
+        """Issue #1148 negative test: dev sessions never get PM-only env vars.
+
+        Prevents future regressions that accidentally widen the injection guard.
+        """
+        from agent.sdk_client import _resolve_sentry_auth_token
+        from config.enums import SessionType
+
+        monkeypatch.setenv("SENTRY_PERSONAL_TOKEN", "should-not-appear")
+        dev = _make_session("dev", "dev-no-pm-env-001", redis_test_db)
+
+        _harness_env: dict[str, str] = {}
+        # Mirror the guarded blocks in session_executor.py:1335 + 1340-1346
+        _session_type = dev.session_type
+        if _session_type in (SessionType.PM, SessionType.TEAMMATE) and dev.agent_session_id:
+            _harness_env["VALOR_PARENT_SESSION_ID"] = dev.agent_session_id
+        if _session_type in (SessionType.PM, SessionType.TEAMMATE):
+            if dev.chat_id:
+                _harness_env["TELEGRAM_CHAT_ID"] = str(dev.chat_id)
+            tok = _resolve_sentry_auth_token()
+            if tok:
+                _harness_env["SENTRY_AUTH_TOKEN"] = tok
+
+        assert "TELEGRAM_CHAT_ID" not in _harness_env
+        assert "SENTRY_AUTH_TOKEN" not in _harness_env
+        assert "VALOR_PARENT_SESSION_ID" not in _harness_env

--- a/tests/integration/test_session_spawning.py
+++ b/tests/integration/test_session_spawning.py
@@ -131,9 +131,7 @@ class TestHarnessEnvPassthrough:
         from config.enums import SessionType
 
         for session_type in ("pm", "teammate", "dev"):
-            session = _make_session(
-                session_type, f"{session_type}-session-type-001", redis_test_db
-            )
+            session = _make_session(session_type, f"{session_type}-session-type-001", redis_test_db)
             _harness_env: dict[str, str] = {
                 "AGENT_SESSION_ID": session.agent_session_id or "",
                 "CLAUDE_CODE_TASK_LIST_ID": "",

--- a/tests/unit/test_pm_session_permissions.py
+++ b/tests/unit/test_pm_session_permissions.py
@@ -637,6 +637,78 @@ class TestPMSessionEnvInjection:
         assert "SENTRY_AUTH_TOKEN" not in options.env
 
 
+class TestResolveSentryAuthToken:
+    """Direct tests for the _resolve_sentry_auth_token helper.
+
+    Issue #1148: extracted from ValorAgent.env so the harness path
+    (agent/session_executor.py) can reuse the same cascade.
+    """
+
+    def test_resolve_from_sentry_personal_token_env(self, monkeypatch):
+        """SENTRY_PERSONAL_TOKEN env var is the highest-priority source."""
+        from agent.sdk_client import _resolve_sentry_auth_token
+
+        monkeypatch.setenv("SENTRY_PERSONAL_TOKEN", "from-personal")
+        monkeypatch.setenv("SENTRY_AUTH_TOKEN", "from-auth")
+        assert _resolve_sentry_auth_token() == "from-personal"
+
+    def test_resolve_from_sentry_auth_token_env(self, monkeypatch):
+        """SENTRY_AUTH_TOKEN is used when SENTRY_PERSONAL_TOKEN is unset."""
+        from agent.sdk_client import _resolve_sentry_auth_token
+
+        monkeypatch.delenv("SENTRY_PERSONAL_TOKEN", raising=False)
+        monkeypatch.setenv("SENTRY_AUTH_TOKEN", "from-auth")
+        assert _resolve_sentry_auth_token() == "from-auth"
+
+    def test_resolve_sentry_auth_token_launchd_shortcircuits(self, monkeypatch, tmp_path):
+        """Under VALOR_LAUNCHD=1, the helper short-circuits to None
+        without touching ~/Desktop (TCC blocks it)."""
+        from agent.sdk_client import _resolve_sentry_auth_token
+
+        monkeypatch.delenv("SENTRY_PERSONAL_TOKEN", raising=False)
+        monkeypatch.delenv("SENTRY_AUTH_TOKEN", raising=False)
+        monkeypatch.setenv("VALOR_LAUNCHD", "1")
+
+        # Mock Path.home so we'd notice if file read was attempted (it shouldn't be).
+        called = {"home": False}
+
+        def home_mock():
+            called["home"] = True
+            return tmp_path
+
+        with patch("agent.sdk_client.Path.home", side_effect=home_mock):
+            result = _resolve_sentry_auth_token()
+
+        assert result is None
+        assert called["home"] is False, "VALOR_LAUNCHD must short-circuit before Path.home()"
+
+    def test_resolve_from_file_in_terminal_mode(self, monkeypatch, tmp_path):
+        """In terminal mode (no VALOR_LAUNCHD), helper reads ~/Desktop/Valor/.env."""
+        from agent.sdk_client import _resolve_sentry_auth_token
+
+        monkeypatch.delenv("SENTRY_PERSONAL_TOKEN", raising=False)
+        monkeypatch.delenv("SENTRY_AUTH_TOKEN", raising=False)
+        monkeypatch.delenv("VALOR_LAUNCHD", raising=False)
+
+        valor_dir = tmp_path / "Desktop" / "Valor"
+        valor_dir.mkdir(parents=True)
+        (valor_dir / ".env").write_text("SENTRY_PERSONAL_TOKEN=file-token-xyz\n")
+
+        with patch("agent.sdk_client.Path.home", return_value=tmp_path):
+            assert _resolve_sentry_auth_token() == "file-token-xyz"
+
+    def test_resolve_returns_none_on_missing_file(self, monkeypatch, tmp_path):
+        """If ~/Desktop/Valor/.env does not exist, returns None without raising."""
+        from agent.sdk_client import _resolve_sentry_auth_token
+
+        monkeypatch.delenv("SENTRY_PERSONAL_TOKEN", raising=False)
+        monkeypatch.delenv("SENTRY_AUTH_TOKEN", raising=False)
+        monkeypatch.delenv("VALOR_LAUNCHD", raising=False)
+
+        with patch("agent.sdk_client.Path.home", return_value=tmp_path):
+            assert _resolve_sentry_auth_token() is None
+
+
 class TestPMPermissionMode:
     """PM session should use bypassPermissions, not plan mode."""
 

--- a/tests/unit/test_sdk_client.py
+++ b/tests/unit/test_sdk_client.py
@@ -9,8 +9,12 @@ import sys
 
 import pytest
 
-# Add parent directory to path for imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Add repo root to sys.path so `from agent.* import ...` works when this module
+# is imported standalone (pytest already provides the rootdir, but this keeps
+# the file runnable via `python -m unittest`). The previous form pointed at the
+# `tests/` directory, which broke transitive `from tools.* import ...` chains
+# (e.g. agent.constants -> tools.emoji_embedding) at collection time.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 from agent.sdk_client import ValorAgent, load_system_prompt
 
@@ -298,3 +302,133 @@ class TestGetPriorSessionUuidStatusFilter:
         new_completed = self._make_session_row("completed", "uuid-new-completed", created_at=500)
         # Pass them in non-sorted order to exercise the sort.
         assert self._run_with_sessions([old_killed, new_completed]) == "uuid-new-completed"
+
+
+# -----------------------------------------------------------------------------
+# get_response_via_harness: --append-system-prompt argv injection (issue #1148)
+# -----------------------------------------------------------------------------
+
+
+class TestGetResponseViaHarnessSystemPrompt:
+    """Verify --append-system-prompt argv injection for the system_prompt kwarg.
+
+    Issue #1148: PM harness sessions need to carry the project-manager persona
+    via --append-system-prompt. Drafter sessions must NOT receive any persona
+    so this is a strict opt-in via the system_prompt kwarg.
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_system_prompt_means_no_flag(self):
+        """Default system_prompt=None must not add --append-system-prompt to argv."""
+        from unittest.mock import AsyncMock, patch
+
+        from agent.sdk_client import get_response_via_harness
+
+        captured = {}
+
+        async def fake_run(cmd, working_dir, proc_env, **_kw):
+            captured["cmd"] = cmd
+            return ("done", None, 0, None, None)
+
+        with patch("agent.sdk_client._run_harness_subprocess", new=AsyncMock(side_effect=fake_run)):
+            await get_response_via_harness(
+                message="hi",
+                working_dir="/tmp",
+                env={"AGENT_SESSION_ID": "x"},
+                model="opus",
+            )
+
+        assert "--append-system-prompt" not in captured["cmd"]
+
+    @pytest.mark.asyncio
+    async def test_empty_system_prompt_means_no_flag(self):
+        """system_prompt='' (falsy) must not add --append-system-prompt to argv."""
+        from unittest.mock import AsyncMock, patch
+
+        from agent.sdk_client import get_response_via_harness
+
+        captured = {}
+
+        async def fake_run(cmd, working_dir, proc_env, **_kw):
+            captured["cmd"] = cmd
+            return ("done", None, 0, None, None)
+
+        with patch("agent.sdk_client._run_harness_subprocess", new=AsyncMock(side_effect=fake_run)):
+            await get_response_via_harness(
+                message="hi",
+                working_dir="/tmp",
+                env={"AGENT_SESSION_ID": "x"},
+                model="opus",
+                system_prompt="",
+            )
+
+        assert "--append-system-prompt" not in captured["cmd"]
+
+    @pytest.mark.asyncio
+    async def test_truthy_system_prompt_appends_flag(self):
+        """A non-empty system_prompt is injected as --append-system-prompt <text>.
+
+        Verifies positional ordering: --append-system-prompt must appear after
+        --model (model selection precedes any persona flag) but before the
+        positional message at the tail of the argv.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        from agent.sdk_client import get_response_via_harness
+
+        captured = {}
+        persona = "PM persona body — CRITIQUE is Mandatory After PLAN"
+
+        async def fake_run(cmd, working_dir, proc_env, **_kw):
+            captured["cmd"] = cmd
+            return ("done", None, 0, None, None)
+
+        with patch("agent.sdk_client._run_harness_subprocess", new=AsyncMock(side_effect=fake_run)):
+            await get_response_via_harness(
+                message="user-message-tail",
+                working_dir="/tmp",
+                env={"AGENT_SESSION_ID": "x"},
+                model="opus",
+                system_prompt=persona,
+            )
+
+        cmd = captured["cmd"]
+        assert "--append-system-prompt" in cmd, cmd
+        idx = cmd.index("--append-system-prompt")
+        assert cmd[idx + 1] == persona, "persona text must immediately follow the flag"
+        # Position invariant: --model precedes --append-system-prompt
+        assert "--model" in cmd
+        assert cmd.index("--model") < idx, "--model must precede --append-system-prompt"
+        # Position invariant: positional message is at the tail (after persona)
+        assert cmd[-1] == "user-message-tail"
+        assert idx < len(cmd) - 1
+
+    @pytest.mark.asyncio
+    async def test_oversized_system_prompt_logs_and_omits(self, caplog):
+        """A 600KB system_prompt must be omitted with a warning, not injected."""
+        import logging
+        from unittest.mock import AsyncMock, patch
+
+        from agent.sdk_client import get_response_via_harness
+
+        captured = {}
+
+        async def fake_run(cmd, working_dir, proc_env, **_kw):
+            captured["cmd"] = cmd
+            return ("done", None, 0, None, None)
+
+        oversize = "x" * 600_000
+        caplog.set_level(logging.WARNING, logger="agent.sdk_client")
+
+        with patch("agent.sdk_client._run_harness_subprocess", new=AsyncMock(side_effect=fake_run)):
+            await get_response_via_harness(
+                message="hi",
+                working_dir="/tmp",
+                env={"AGENT_SESSION_ID": "x"},
+                model="opus",
+                system_prompt=oversize,
+            )
+
+        assert "--append-system-prompt" not in captured["cmd"]
+        warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("exceeds 512KB soft cap" in m for m in warnings), warnings

--- a/tests/unit/test_session_completion.py
+++ b/tests/unit/test_session_completion.py
@@ -23,9 +23,7 @@ from pathlib import Path
 
 import pytest
 
-_COMPLETION_PATH = (
-    Path(__file__).resolve().parent.parent.parent / "agent" / "session_completion.py"
-)
+_COMPLETION_PATH = Path(__file__).resolve().parent.parent.parent / "agent" / "session_completion.py"
 
 
 def test_drafter_calls_omit_system_prompt_via_grep():

--- a/tests/unit/test_session_completion.py
+++ b/tests/unit/test_session_completion.py
@@ -1,0 +1,102 @@
+"""Drafter-isolation regression guard for session_completion.py.
+
+Issue #1148, Risk 4: the completion-runner draft+refine passes call
+get_response_via_harness with model="opus" but MUST NOT pass the PM
+persona via system_prompt — that would taint drafter turns with PM
+orchestration rules and corrupt the user-facing summary.
+
+This file holds two complementary guards:
+
+1. A source-level check that no call to get_response_via_harness inside
+   session_completion.py supplies a system_prompt= kwarg.
+2. An AST-level check that walks every Call node and asserts the same.
+
+Both are zero-side-effect static checks; together they catch a future
+refactor that accidentally threads persona text through the drafter.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+_COMPLETION_PATH = (
+    Path(__file__).resolve().parent.parent.parent / "agent" / "session_completion.py"
+)
+
+
+def test_drafter_calls_omit_system_prompt_via_grep():
+    """No call site in session_completion.py may pass system_prompt= to harness."""
+    source = _COMPLETION_PATH.read_text()
+    # Reject any literal system_prompt= kwarg anywhere in the file. This is
+    # narrower and stricter than a positional check because the harness
+    # function signature uses keyword-only args after *, so kwargs are the
+    # only way to set system_prompt.
+    matches = re.findall(r"\bsystem_prompt\s*=", source)
+    assert matches == [], (
+        f"session_completion.py must not pass system_prompt= to the harness; "
+        f"found {len(matches)} occurrence(s). This is a Risk 4 regression "
+        f"(see docs/plans/sdlc-1148.md): drafter turns must run with the "
+        f"default Claude Code system prompt, not the PM persona."
+    )
+
+
+def test_drafter_calls_omit_system_prompt_via_ast():
+    """AST guard: every get_response_via_harness call has no system_prompt kwarg."""
+    source = _COMPLETION_PATH.read_text()
+    tree = ast.parse(source)
+    found_calls = 0
+    offenders = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        # Match either bare `get_response_via_harness(...)` or
+        # `module.get_response_via_harness(...)`.
+        callee = node.func
+        name: str | None = None
+        if isinstance(callee, ast.Name):
+            name = callee.id
+        elif isinstance(callee, ast.Attribute):
+            name = callee.attr
+        if name != "get_response_via_harness":
+            continue
+        found_calls += 1
+        for kw in node.keywords:
+            if kw.arg == "system_prompt":
+                offenders.append(node.lineno)
+
+    assert found_calls >= 2, (
+        f"Expected >=2 get_response_via_harness call sites in session_completion.py "
+        f"(Pass 1 draft + Pass 2 refine). Found {found_calls}; the file may have "
+        f"been refactored — re-validate the drafter isolation."
+    )
+    assert offenders == [], (
+        f"get_response_via_harness call(s) at line(s) {offenders} pass a "
+        f"system_prompt kwarg. Drafter turns must omit system_prompt (Risk 4)."
+    )
+
+
+@pytest.mark.parametrize("call_lineno_anchor", [525, 587])
+def test_drafter_call_sites_at_expected_lines(call_lineno_anchor):
+    """Sanity: the documented drafter call lines still resolve to a harness call.
+
+    The plan cites session_completion.py:525 (Pass 1) and :587 (Pass 2).
+    A future refactor that moves these calls is fine as long as the AST
+    guard above stays green, but this test pins the documented anchors so
+    drift is visible.
+    """
+    source_lines = _COMPLETION_PATH.read_text().splitlines()
+    # Window scan: 5 lines before and after the anchor — the harness call
+    # spans multiple lines (kwargs on separate lines).
+    start = max(0, call_lineno_anchor - 5)
+    end = min(len(source_lines), call_lineno_anchor + 5)
+    window = "\n".join(source_lines[start:end])
+    assert "get_response_via_harness" in window, (
+        f"Expected get_response_via_harness near line {call_lineno_anchor} in "
+        f"session_completion.py (window {start}-{end}). If the file has been "
+        f"refactored, update the anchor in this test and in docs/plans/sdlc-1148.md."
+    )

--- a/tests/unit/test_session_completion.py
+++ b/tests/unit/test_session_completion.py
@@ -26,8 +26,12 @@ import pytest
 _COMPLETION_PATH = Path(__file__).resolve().parent.parent.parent / "agent" / "session_completion.py"
 
 
-def test_drafter_calls_omit_system_prompt_via_grep():
-    """No call site in session_completion.py may pass system_prompt= to harness."""
+def test_drafter_calls_omit_system_prompt():
+    """No call site in session_completion.py may pass system_prompt= to harness.
+
+    This is the canonical Risk 4 regression guard cited by docs/plans/sdlc-1148.md
+    and the plan's Verification table.
+    """
     source = _COMPLETION_PATH.read_text()
     # Reject any literal system_prompt= kwarg anywhere in the file. This is
     # narrower and stricter than a positional check because the harness

--- a/tests/unit/test_valor_session_cli.py
+++ b/tests/unit/test_valor_session_cli.py
@@ -9,9 +9,6 @@ docs/plans/sdlc-1148.md.
 from __future__ import annotations
 
 import argparse
-import io
-import sys
-from contextlib import redirect_stderr
 
 import pytest
 
@@ -80,9 +77,7 @@ class TestCreateEnrichmentHeaderGuard:
             lambda cwd: "test-1148",
         )
 
-        args = _make_args(
-            "scope: database refactor\nLet's look at the connection pool config"
-        )
+        args = _make_args("scope: database refactor\nLet's look at the connection pool config")
         # We don't care if the downstream code raises (no Redis in this test);
         # we only care that the GUARD itself does not trip.
         try:
@@ -108,9 +103,7 @@ class TestCreateEnrichmentHeaderGuard:
             lambda cwd: "test-1148",
         )
 
-        args = _make_args(
-            "Fix the bug where SESSION_ID: prefix sometimes appears in logs"
-        )
+        args = _make_args("Fix the bug where SESSION_ID: prefix sometimes appears in logs")
         try:
             valor_session.cmd_create(args)
         except Exception:

--- a/tests/unit/test_valor_session_cli.py
+++ b/tests/unit/test_valor_session_cli.py
@@ -1,0 +1,138 @@
+"""Tests for tools.valor_session CLI command handlers (issue #1148).
+
+Focus: enrichment-header guard in cmd_create. Other valor_session subcommands
+have their own dedicated test files; this module is reserved for guards and
+input-validation logic that protect against the failure modes documented in
+docs/plans/sdlc-1148.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import sys
+from contextlib import redirect_stderr
+
+import pytest
+
+from tools import valor_session
+
+
+def _make_args(message: str, **overrides) -> argparse.Namespace:
+    """Build a minimal argparse.Namespace to feed cmd_create."""
+    base = {
+        "role": "pm",
+        "message": message,
+        "chat_id": "999",
+        "parent": None,
+        "model": None,
+        "slug": "sdlc-1148",  # Skip the auto-derive branch in cmd_create
+        "project_key": "test-1148",
+        "working_dir": None,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+class TestCreateEnrichmentHeaderGuard:
+    """cmd_create rejects --message values that look like forwarded enrichment headers.
+
+    Failure scenario from issue #1148: PM session 8ff90a3c received a message,
+    failed to load its persona, and forwarded its own enrichment payload
+    ("PROJECT: Valor AI\\nFOCUS: ...") as the --message to a child dev session.
+    The dev session stalled with "the message appears to have been truncated".
+
+    This guard catches that pattern at the CLI boundary so the failure mode
+    can never propagate even if the upstream persona-wiring regresses.
+    """
+
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "SESSION_ID: abc-123\nMESSAGE: do the thing",
+            "PROJECT: Valor AI\nFROM: pm\nMESSAGE: build the feature",
+            "FROM: pm\nMESSAGE: x",
+            "TASK_SCOPE: bug-fix\nDescribe what to do here",
+            "SCOPE: full-rewrite\nThis is the actual task",
+        ],
+    )
+    def test_rejects_enrichment_header_prefixed_messages(self, msg, capsys):
+        """Each enrichment-header prefix triggers exit code 2 + stderr error."""
+        args = _make_args(msg)
+        rc = valor_session.cmd_create(args)
+        captured = capsys.readouterr()
+        assert rc == 2, f"Expected exit code 2, got {rc} for message: {msg!r}"
+        assert "enrichment header" in captured.err.lower(), captured.err
+
+    def test_accepts_lowercase_prose_with_scope_keyword(self, capsys, monkeypatch):
+        """Lowercase 'scope: ...' is normal prose and must NOT fire the guard.
+
+        We mock the downstream session-creation path so the test does not
+        actually enqueue work; only the guard is exercised.
+        """
+        # Stub out the downstream create flow so cmd_create's later steps
+        # don't blow up trying to talk to Redis. The guard fires (or doesn't)
+        # before any of these are reached on the happy path.
+        monkeypatch.setattr(valor_session, "_check_worker_health", lambda: (True, 1))
+        monkeypatch.setattr(
+            valor_session,
+            "resolve_project_key",
+            lambda cwd: "test-1148",
+        )
+
+        args = _make_args(
+            "scope: database refactor\nLet's look at the connection pool config"
+        )
+        # We don't care if the downstream code raises (no Redis in this test);
+        # we only care that the GUARD itself does not trip.
+        try:
+            valor_session.cmd_create(args)
+        except Exception:
+            pass  # downstream failure is acceptable; guard didn't fire
+        captured = capsys.readouterr()
+        assert "enrichment header" not in captured.err.lower(), (
+            f"Lowercase 'scope:' prose tripped the guard. Stderr: {captured.err!r}"
+        )
+
+    def test_accepts_buried_enrichment_after_first_line(self, capsys, monkeypatch):
+        """Enrichment-header text buried after the first line must NOT fire.
+
+        The regex anchors at ^ and only inspects the first 200 chars; this
+        ensures normal task text that happens to mention SESSION_ID or
+        PROJECT mid-message is not rejected.
+        """
+        monkeypatch.setattr(valor_session, "_check_worker_health", lambda: (True, 1))
+        monkeypatch.setattr(
+            valor_session,
+            "resolve_project_key",
+            lambda cwd: "test-1148",
+        )
+
+        args = _make_args(
+            "Fix the bug where SESSION_ID: prefix sometimes appears in logs"
+        )
+        try:
+            valor_session.cmd_create(args)
+        except Exception:
+            pass
+        captured = capsys.readouterr()
+        assert "enrichment header" not in captured.err.lower(), (
+            f"Buried 'SESSION_ID:' tripped the guard. Stderr: {captured.err!r}"
+        )
+
+    def test_empty_message_does_not_fire(self, capsys, monkeypatch):
+        """An empty --message bypasses this guard (other validation owns that case)."""
+        monkeypatch.setattr(valor_session, "_check_worker_health", lambda: (True, 1))
+        monkeypatch.setattr(
+            valor_session,
+            "resolve_project_key",
+            lambda cwd: "test-1148",
+        )
+
+        args = _make_args("")
+        try:
+            valor_session.cmd_create(args)
+        except Exception:
+            pass
+        captured = capsys.readouterr()
+        assert "enrichment header" not in captured.err.lower()

--- a/tools/valor_session.py
+++ b/tools/valor_session.py
@@ -47,6 +47,17 @@ from pathlib import Path
 # Bounded lookbehind via (?:^|\W) so we don't false-positive on "tissue123".
 _ISSUE_REF_RE = re.compile(r"(?:^|\W)issue\s*#?\s*(\d+)", re.IGNORECASE)
 
+# Issue #1148: enrichment-header guard. The worker's build_harness_turn_input
+# prepends headers like "PROJECT:", "FROM:", "SESSION_ID:", "TASK_SCOPE:",
+# "SCOPE:", "MESSAGE:" to the raw message before passing it to claude -p.
+# A PM session that lacks the persona+SESSION_TYPE wiring sometimes forwards
+# its own enrichment payload as the --message to a child dev session, which
+# stalls the dev with "the message appears to have been truncated" (the
+# observed failure trace for issue #1148). This guard rejects --message
+# values whose first 200 chars start with one of those header prefixes.
+# Case-sensitive: lowercase prose like "scope: database stuff" is allowed.
+_ENRICHMENT_HEADER_RE = re.compile(r"^(?:SESSION_ID|PROJECT|FROM|TASK_SCOPE|SCOPE):")
+
 
 def _derive_slug_from_message(message: str) -> str | None:
     """Extract the first issue number from ``message`` and return ``sdlc-{N}``.
@@ -208,6 +219,20 @@ def cmd_create(args: argparse.Namespace) -> int:
             )
         session_type = _role_to_session_type[role]
         message = args.message
+        # Issue #1148: reject enrichment-header forwarding. A 200-char window
+        # at the start of the message is enough to catch the observed pattern
+        # ("PROJECT: Valor AI\nFOCUS: ...") without false-positives on prose
+        # that uses the words SCOPE/FROM/etc. mid-sentence.
+        if message and _ENRICHMENT_HEADER_RE.match(message[:200]):
+            print(
+                "Error: --message looks like a forwarded enrichment header, not a "
+                "task description.\n"
+                "Enrichment headers (PROJECT:, FROM:, SESSION_ID:, TASK_SCOPE:, "
+                "SCOPE:) are\n"
+                "injected automatically by the worker. Pass only the task content.",
+                file=sys.stderr,
+            )
+            return 2
         chat_id = args.chat_id or "0"
         parent_id = getattr(args, "parent", None)
         model = getattr(args, "model", None)


### PR DESCRIPTION
## Summary

Closes #1148. Restores parity between the harness path and the SDK-era `ValorAgent.env` builder so PM/Teammate harness sessions get `SESSION_TYPE=pm`, the project-manager persona via `--append-system-prompt`, plus `TELEGRAM_CHAT_ID` and `SENTRY_AUTH_TOKEN` injection — and adds a defence-in-depth guard against the enrichment-header forwarding pattern that triggered the original incident.

## Changes

**Production code (3 files, ~65 LoC):**
- `agent/sdk_client.py` — extracts `_resolve_sentry_auth_token()` helper (single source of truth for the env→file cascade); adds `system_prompt: str | None = None` keyword-only parameter to `get_response_via_harness` that injects `--append-system-prompt <text>` into argv after `--model` and before the positional message; defensive 512KB cap to avoid macOS `ARG_MAX` overflows.
- `agent/session_executor.py` — extends `_harness_env` with `SESSION_TYPE` (all typed sessions), `TELEGRAM_CHAT_ID` and `SENTRY_AUTH_TOKEN` (PM/Teammate); resolves `load_pm_system_prompt(working_dir)` for PM sessions and threads it through `get_response_via_harness(system_prompt=...)`. Failure to load logs `[pm-persona-missing]` and continues degraded (no crash).
- `tools/valor_session.py` — case-sensitive enrichment-header guard on `cmd_create --message` with a 200-char prefix window; rejects messages prefixed with `SESSION_ID:`/`PROJECT:`/`FROM:`/`TASK_SCOPE:`/`SCOPE:` (exit 2 + clear stderr error). Lowercase prose and buried mentions are explicitly accepted.

**Drafter isolation (Risk 4):** `agent/session_completion.py` is intentionally NOT touched — both `_deliver_pipeline_completion` Pass-1 (line 525) and Pass-2 (line 587) calls keep `system_prompt=None` so PM persona never taints user-facing summary drafts.

## Tests

117 new/touched tests across 6 files, all passing:
- `tests/unit/test_pm_session_permissions.py` — new `TestResolveSentryAuthToken` class with 5 tests (helper-direct, including `VALOR_LAUNCHD` short-circuit verifying `Path.home()` is never called).
- `tests/unit/test_sdk_client.py` — new `TestGetResponseViaHarnessSystemPrompt` class with 4 tests (None, empty, truthy with positional invariants, oversized → warning + omit). Also fixes a pre-existing `sys.path` collection bug at line 13.
- `tests/unit/test_session_completion.py` — new file: `test_drafter_calls_omit_system_prompt` (regex Risk 4 guard), AST guard, line-anchor sanity. Catches any future refactor that accidentally threads persona text through drafter calls.
- `tests/unit/test_valor_session_cli.py` — new file: `TestCreateEnrichmentHeaderGuard` with 8 tests covering all 5 enrichment prefixes plus three negative cases.
- `tests/integration/test_session_spawning.py` — extends `TestHarnessEnvPassthrough` with 4 methods covering SESSION_TYPE, TELEGRAM_CHAT_ID, SENTRY_AUTH_TOKEN, and a dev-session negative test.
- `tests/integration/test_harness_env_pm_injection.py` — new file: end-to-end PM harness env+argv injection test driving the production loaders + harness call with only `_run_harness_subprocess` mocked.

## Documentation

- `docs/features/harness-abstraction.md` — new "Session Environment Injection" subsection with full env-var matrix scoped by session type, plus "PM Persona Injection — `--append-system-prompt`" subsection covering semantics, the 512KB cap, and the drafter-isolation invariant.
- `docs/features/pm-channels.md` — notes that `load_pm_system_prompt()` is now wired into the harness via `--append-system-prompt`, with cross-link.
- `docs/features/personas.md` — cross-references the harness invocation site.

## Verification

| Check | Result |
|-------|--------|
| `grep -c 'SESSION_TYPE' agent/session_executor.py` | 2 (>= 1 required) |
| `grep -c 'append-system-prompt' agent/sdk_client.py` | 3 (>= 1 required) |
| `grep -c '_resolve_sentry_auth_token' agent/sdk_client.py agent/session_executor.py` (sum) | 5 (>= 3 required: 1 def + 2 call sites + new harness-env caller) |
| `grep -c 'system_prompt' agent/session_completion.py` | 0 (Risk 4 — drafter isolation) |
| `grep -c 'enrichment header' tools/valor_session.py` | 1 |
| `tests/unit/test_pm_session_permissions.py` | 66 passed |
| `tests/unit/test_sdk_client.py` | 27 passed, 1 skipped (SDK gate) |
| `tests/unit/test_session_completion.py` | 4 passed |
| `tests/unit/test_valor_session_cli.py` | 8 passed |
| `tests/integration/test_session_spawning.py` | 9 passed |
| `tests/integration/test_harness_env_pm_injection.py` | 3 passed |
| `python -m ruff check + format` (touched files) | All checks passed |

## Definition of Done

- [x] Built: code working
- [x] Tested: all touched tests pass; lint and format clean
- [x] Documented: harness-abstraction.md, pm-channels.md, personas.md updated
- [x] Plan source-of-truth verification table satisfied (manual review of false-positive parser bugs in validate_build.py)

Closes #1148