### PR TITLE
Enforce immutable project→repo pairing in valor-session (#1158)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,8 +172,8 @@ valor-email threads
 | `python -m tools.valor_session steer --id <ID> --message "..."` | Inject a steering message into a running session |
 | `python -m tools.valor_session kill --id <ID>` | Kill a session |
 | `python -m tools.valor_session kill --all` | Kill all running sessions |
-| `python -m tools.valor_session create --role pm --message "..."` | Create and enqueue a new session (warns to stderr if no worker is running) |
-| `python -m tools.valor_session create --role dev --slug {slug} --message "..."` | Create session with worktree isolation (warns to stderr if no worker is running) |
+| `python -m tools.valor_session create --role pm --message "..."` | Create and enqueue a new session. `project_key` determines the repo via `projects.json`; there is no working-directory override flag. Precedence: `--project-key` > `--parent` inheritance > cwd match (raises on no match). Warns to stderr if no worker is running. |
+| `python -m tools.valor_session create --role dev --slug {slug} --message "..."` | Create session with worktree isolation under the project's declared repo. Warns to stderr if no worker is running. |
 | `python -m tools.valor_session resume --id <ID> --message "..."` | Resume a completed, killed, or failed session (hard-PATCH path; accepts session_id or agent_session_id) |
 | `python -m tools.valor_session release --pr <N>` | Clear retain_for_resume after PR merge/close |
 | `python -m tools.memory_search search "query"` | Search memories by query |

--- a/agent/reflection_scheduler.py
+++ b/agent/reflection_scheduler.py
@@ -390,12 +390,21 @@ async def _enqueue_agent_reflection(entry: ReflectionEntry) -> None:
     # time (line ~1031), so no env setup is needed here — _push_agent_session()
     # only creates a Redis entry; the worker handles env injection later.
 
-    # Resolve project key from the repo root
+    # Resolve project key from the repo root.
+    # On this machine project_root=~/src/ai reliably matches the 'valor' key
+    # in projects.json, so the fallback is defensive-only. We catch the new
+    # typed errors specifically (instead of a blanket Exception) so any other
+    # failure surfaces as a crash rather than being silently swallowed.
     try:
-        from tools.valor_session import resolve_project_key
+        from tools.valor_session import (
+            ProjectKeyResolutionError,
+            ProjectsConfigUnavailableError,
+            resolve_project_key,
+        )
 
         project_key = resolve_project_key(str(project_root))
-    except Exception:
+    except (ProjectKeyResolutionError, ProjectsConfigUnavailableError) as e:
+        logger.warning("[reflection] could not resolve project_key via projects.json: %s", e)
         project_key = os.environ.get("PROJECT_KEY", "valor")
 
     ts_suffix = str(int(utc_now().timestamp() * 1000))

--- a/docs/features/sdlc-stage-tracking.md
+++ b/docs/features/sdlc-stage-tracking.md
@@ -74,7 +74,7 @@ SDLC_REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null ||
 python -m tools.sdlc_session_ensure --issue-number 941 --issue-url "https://github.com/$SDLC_REPO/issues/941"
 ```
 
-The `SDLC_REPO` value is shell-derived to avoid hardcoding the repo owner/name. `tools/sdlc_session_ensure.py` also resolves `project_key` dynamically via `resolve_project_key(cwd)` — it no longer hardcodes `project_key='ai'`.
+The `SDLC_REPO` value is shell-derived to avoid hardcoding the repo owner/name. `tools/sdlc_session_ensure.py` resolves `project_key` dynamically via `resolve_project_key(cwd)`, then derives `working_dir` from `projects.json[project_key].working_directory` (not `os.getcwd()`) via `_resolve_project_working_directory()` — enforcing the immutable project→repo pairing from issue #1158. If resolution fails, the function returns `{}` (idempotent no-op) rather than creating a mis-scoped session.
 
 See `docs/features/sdlc-pipeline-state.md` for the full local session tracking design.
 

--- a/docs/features/session-isolation.md
+++ b/docs/features/session-isolation.md
@@ -100,6 +100,42 @@ See GitHub issue [#237](https://github.com/tomcounsell/ai/issues/237) for the or
 
 This guard was added in response to the 2026-04-10 incident (issue [#880](https://github.com/tomcounsell/ai/issues/880)), where a session branch got checked out in the main working tree and the cleanup helper was handed the main repo path; the `shutil.rmtree(..., ignore_errors=True)` fallback then recursively deleted the main repository. The guard now refuses bogus paths loudly and the fallback no longer hides errors.
 
+### CLI-level Project Scope Resolution (Issue #1158)
+
+When a session is created via `valor-session create` (e.g. a PM session spawning a child SDLC session), the CLI enforces an **immutable project → repo pairing**: a project name determines its repo, and no input may decouple them.
+
+**Governing principle**:
+
+> A project and a repo should not be provided separately. The local machine's configuration sets the pairing and that pairing cannot be broken.
+
+**Resolution precedence for `cmd_create`**:
+
+1. `--project-key <key>` — explicit flag wins over everything else.
+2. `--parent <id>` — if the parent `AgentSession` is resolvable, its `project_key` is inherited. `working_dir` is **never** inherited — it is always re-derived from the (inherited) `project_key`.
+3. `resolve_project_key(os.getcwd())` — matches the cwd against each project's `working_directory` in `projects.json`. Raises `ProjectKeyResolutionError` on no match; the CLI prints the message (cwd, available keys, suggested `--project-key`) to stderr and exits non-zero.
+
+**Removed surfaces**:
+
+- There is no working-directory override flag on `valor-session create`. Callers who need a different repo pass a different `--project-key`.
+- `resolve_project_key` no longer silently returns `"valor"` on unmatched cwd. It raises `ProjectKeyResolutionError`. Callers relying on the old fallback must catch the exception explicitly or supply a key.
+- `load_config()` failures raise `ProjectsConfigUnavailableError` (distinct from `ProjectKeyResolutionError`) so operators can distinguish a missing config from an unknown key.
+
+**Helper**:
+
+- `_resolve_project_working_directory(project_key)` — loads `projects.json` once and returns `(repo_root: Path, project_dict: dict)`. The dict is passed through to `AgentSession.project_config` so CLI-created sessions carry the same per-project payload as bridge-created sessions (PR #685).
+
+**Where the rule is enforced**:
+
+- `tools/valor_session.py::cmd_create` — the primary CLI surface.
+- `tools/sdlc_session_ensure.py::ensure_session` — derives `working_dir` from `projects.json` (not `os.getcwd()`). On resolution failure the function returns `{}` (idempotent no-op), never a mis-scoped session.
+- `agent/reflection_scheduler.py` — catches the new typed errors explicitly; falls back to `PROJECT_KEY` env var as a last-resort for local nightly reflections only.
+
+**Where it is NOT enforced (by design)**:
+
+- `_push_agent_session(..., working_dir=...)` — internal primitive; its `working_dir` kwarg is computed by the CLI/scheduler/bridge, not supplied by users.
+- `bridge/telegram_bridge.py` — already correct (derives `working_directory` from `projects.json`).
+- `tools/agent_session_scheduler.py` — already follows the rule; was the reference model for the fix.
+
 ### Post-Merge Worktree Cleanup
 
 When a PR is merged via `gh pr merge --squash --delete-branch`, the remote branch is deleted but local branch deletion fails if a git worktree still references it. The `cleanup_after_merge()` function handles this:

--- a/docs/features/tools-reference.md
+++ b/docs/features/tools-reference.md
@@ -236,7 +236,7 @@ python -m tools.valor_session kill --all
 python -m tools.valor_session status --id <SESSION_ID> --json
 ```
 
-**Project key resolution (`create` subcommand):** The `project_key` is derived automatically by matching the current working directory against the `working_directory` field of each project in `~/Desktop/Valor/projects.json`. The most-specific match (longest path prefix) wins. Falls back to `"valor"` with a stderr warning if no match is found. Use `--project-key` to override explicitly (useful in scripts or CI where cwd may not match any project).
+**Project key resolution (`create` subcommand):** `project_key` is the only input that ties a session to a repo — `working_dir` is always derived from `projects.json[project_key].working_directory`, never supplied independently. There is **no** `--working-dir` flag. Resolution precedence: `--project-key <key>` > `--parent <id>` (inherits from parent session's `project_key`) > `resolve_project_key(os.getcwd())` (matches cwd against each project's `working_directory`, longest-prefix wins). On no match the CLI raises `ProjectKeyResolutionError` and exits non-zero — there is no silent `"valor"` fallback. See `docs/features/session-isolation.md#cli-level-project-scope-resolution-issue-1158` for the full rule.
 
 See `docs/features/session-steering.md` for full documentation.
 

--- a/docs/plans/child-session-project-scope.md
+++ b/docs/plans/child-session-project-scope.md
@@ -227,38 +227,38 @@ No changes needed to `AgentSession` model, `bridge/telegram_bridge.py`, `agent/s
 
 ### Exception Handling Coverage
 
-- [ ] `tools/valor_session.py:cmd_create` has a broad `try/except Exception` that catches any error and returns exit code 1. Verify both new exceptions produce clear stderr messages **before** being caught — tests must assert stderr content, not just exit code.
+- [x] `tools/valor_session.py:cmd_create` has a broad `try/except Exception` that catches any error and returns exit code 1. Verify both new exceptions produce clear stderr messages **before** being caught — tests must assert stderr content, not just exit code.
 - [ ] `agent/reflection_scheduler.py:394-399` now catches two specific exception types. Add a test that simulates each raising and asserts the scheduler falls back gracefully and logs a warning.
 - [ ] `tools/sdlc_session_ensure.py:ensure_session` — on `ProjectKeyResolutionError`, it should return `{}` (no session created) rather than coercing to a wrong project.
 
 ### Empty/Invalid Input Handling
 
-- [ ] `cmd_create` when `--project-key` refers to a key not in `projects.json` → exit 1, stderr names the missing key and lists available keys.
-- [ ] `cmd_create` when cwd matches no project and no `--project-key` → exit 1 with same hint.
-- [ ] `cmd_create` when `projects.json` is unloadable → exit 1 with `ProjectsConfigUnavailableError` message.
+- [x] `cmd_create` when `--project-key` refers to a key not in `projects.json` → exit 1, stderr names the missing key and lists available keys.
+- [x] `cmd_create` when cwd matches no project and no `--project-key` → exit 1 with same hint.
+- [x] `cmd_create` when `projects.json` is unloadable → exit 1 with `ProjectsConfigUnavailableError` message.
 - [ ] `cmd_create` when `--parent <id>` points to a nonexistent session → exit 1.
 
 ### Error State Rendering
 
 - [ ] All new error paths write to stderr, preserving stdout for `--json`. Assert `stdout_capture.getvalue() == ""` on error.
-- [ ] Error messages include: attempted value, list of valid project keys, suggested remediation (`pass --project-key <key>`).
+- [x] Error messages include: attempted value, list of valid project keys, suggested remediation (`pass --project-key <key>`).
 
 ## Test Impact
 
 Test files rewritten to match the new surface. Counts: **5 existing files affected, 1 new file added, net disposition REPLACE-heavy.**
 
-- [ ] `tests/unit/test_valor_session_project_key.py::TestResolveProjectKeyFallback::test_no_match_returns_valor` (line 111) — **REPLACE**: assert `with pytest.raises(ProjectKeyResolutionError): resolve_project_key(...)` and that the exception message contains the cwd and the available keys list.
-- [ ] `tests/unit/test_valor_session_project_key.py::TestResolveProjectKeyFallback::test_empty_projects_returns_valor` (line 131) — **REPLACE**: empty projects + any cwd → raises `ProjectKeyResolutionError`.
-- [ ] `tests/unit/test_valor_session_project_key.py::TestResolveProjectKeyFallback::test_load_config_exception_returns_valor` (line 141) — **REPLACE**: `load_config` raising → `ProjectsConfigUnavailableError` (distinct from `ProjectKeyResolutionError`).
-- [ ] `tests/unit/test_valor_session_project_key.py::TestResolveProjectKeyFallback::test_project_missing_working_directory_skipped` (line 151) — **REPLACE**: when no project matches → raises; when the one matching project has an empty `working_directory` AND cwd is exactly that path, the helper `_resolve_project_working_directory` also raises.
-- [ ] `tests/unit/test_valor_session_project_key.py::TestResolveProjectKeyFallback::test_project_empty_working_directory_skipped` (line 164) — **REPLACE**: same treatment as above.
-- [ ] `tests/unit/test_valor_session_project_key.py::TestResolveProjectKeyFallback::test_fallback_warning_goes_to_stderr_not_stdout` (line 177) — **REPLACE**: rewrite to assert that when `cmd_create` catches the new exception, the CLI's stderr is non-empty and stdout is clean. (The helper itself no longer prints.)
-- [ ] `tests/unit/test_valor_session_project_key.py::TestProjectKeyFlagOverride::test_explicit_flag_bypasses_resolution` (line 199) — **UPDATE**: still valid; extend to also assert that the test namespace no longer has a `working_dir` attribute (the flag is gone).
-- [ ] `tests/unit/test_pm_session_auto_slug.py` — multiple tests use `_make_args(..., working_dir=None, ...)` at lines 36, and reference auto-derived working_dir in lines 77 etc. — **UPDATE**: drop `working_dir` from `_make_args` defaults; mock `bridge.routing.load_config` to return a test `projects.json` including a `"valor"` key with `working_directory` pointing at `tmp_path`; assert the derived `working_dir` passed to `fake_push` equals the worktree path under that `tmp_path`.
-- [ ] `tests/unit/test_pm_session_refuse_no_issue.py` (line 32: `working_dir=None`) — **UPDATE**: drop the attribute; add `load_config` mock.
-- [ ] `tests/unit/test_valor_session_cli.py` — three `monkeypatch.setattr(valor_session, "resolve_project_key", lambda cwd: "test-1148")` stubs (lines 76, 102, 121). **UPDATE**: keep the stubs but also mock `tools.valor_session._resolve_project_working_directory` to return a `Path`, because `cmd_create` will now call it right after `resolve_project_key`. Drop any `working_dir` namespace attribute from `_make_args` helpers.
+- [x] `tests/unit/test_valor_session_project_key.py::TestResolveProjectKeyFallback::test_no_match_returns_valor` (line 111) — **REPLACE**: assert `with pytest.raises(ProjectKeyResolutionError): resolve_project_key(...)` and that the exception message contains the cwd and the available keys list.
+- [x] `tests/unit/test_valor_session_project_key.py::TestResolveProjectKeyFallback::test_empty_projects_returns_valor` (line 131) — **REPLACE**: empty projects + any cwd → raises `ProjectKeyResolutionError`.
+- [x] `tests/unit/test_valor_session_project_key.py::TestResolveProjectKeyFallback::test_load_config_exception_returns_valor` (line 141) — **REPLACE**: `load_config` raising → `ProjectsConfigUnavailableError` (distinct from `ProjectKeyResolutionError`).
+- [x] `tests/unit/test_valor_session_project_key.py::TestResolveProjectKeyFallback::test_project_missing_working_directory_skipped` (line 151) — **REPLACE**: when no project matches → raises; when the one matching project has an empty `working_directory` AND cwd is exactly that path, the helper `_resolve_project_working_directory` also raises.
+- [x] `tests/unit/test_valor_session_project_key.py::TestResolveProjectKeyFallback::test_project_empty_working_directory_skipped` (line 164) — **REPLACE**: same treatment as above.
+- [x] `tests/unit/test_valor_session_project_key.py::TestResolveProjectKeyFallback::test_fallback_warning_goes_to_stderr_not_stdout` (line 177) — **REPLACE**: rewrite to assert that when `cmd_create` catches the new exception, the CLI's stderr is non-empty and stdout is clean. (The helper itself no longer prints.)
+- [x] `tests/unit/test_valor_session_project_key.py::TestProjectKeyFlagOverride::test_explicit_flag_bypasses_resolution` (line 199) — **UPDATE**: still valid; extend to also assert that the test namespace no longer has a `working_dir` attribute (the flag is gone).
+- [x] `tests/unit/test_pm_session_auto_slug.py` — multiple tests use `_make_args(..., working_dir=None, ...)` at lines 36, and reference auto-derived working_dir in lines 77 etc. — **UPDATE**: drop `working_dir` from `_make_args` defaults; mock `bridge.routing.load_config` to return a test `projects.json` including a `"valor"` key with `working_directory` pointing at `tmp_path`; assert the derived `working_dir` passed to `fake_push` equals the worktree path under that `tmp_path`.
+- [x] `tests/unit/test_pm_session_refuse_no_issue.py` (line 32: `working_dir=None`) — **UPDATE**: drop the attribute; add `load_config` mock.
+- [x] `tests/unit/test_valor_session_cli.py` — three `monkeypatch.setattr(valor_session, "resolve_project_key", lambda cwd: "test-1148")` stubs (lines 76, 102, 121). **UPDATE**: keep the stubs but also mock `tools.valor_session._resolve_project_working_directory` to return a `Path`, because `cmd_create` will now call it right after `resolve_project_key`. Drop any `working_dir` namespace attribute from `_make_args` helpers.
 - [ ] `tests/integration/test_parent_child_round_trip.py` (if it exists — verify) — **UPDATE**: assert child `working_dir` is rooted inside the parent's project (via the projects.json lookup), not by direct parent.working_dir inheritance.
-- [ ] **ADD** `tests/unit/test_valor_session_working_dir_resolution.py` — new file covering:
+- [x] **ADD** `tests/unit/test_valor_session_working_dir_resolution.py` — new file covering:
   - `--project-key cuttlefish` from cwd `/Users/valorengels/src/ai` produces `working_dir` rooted at the cuttlefish project (via mocked `load_config`).
   - There is **no** `--working-dir` flag — `argparse` rejects it (`SystemExit`) and stderr mentions unrecognized arguments.
   - `--parent <id>` inherits `project_key` from the parent `AgentSession`; `working_dir` is re-derived from the inherited `project_key`, not copied from the parent.
@@ -356,17 +356,17 @@ Not applicable — this repo does not publish external docs.
 
 ## Success Criteria
 
-- [ ] A parent PM session running with `cwd=/Users/valorengels/src/cuttlefish` that invokes `valor-session create --role pm --message "Run SDLC on issue 290"` (no `--project-key`) produces a child `AgentSession` with `project_key=cuttlefish` AND `working_dir` rooted under `/Users/valorengels/src/cuttlefish`.
-- [ ] When `--project-key cuttlefish` is passed explicitly from a cwd of `/Users/valorengels/src/ai`, the resulting session's `working_dir` is rooted under the cuttlefish project, not the ai repo.
-- [ ] A `valor-session create` invocation from a cwd that matches no project, with no `--project-key`, exits non-zero with an error naming the cwd and listing valid keys (not silently defaulting).
-- [ ] `valor-session create --working-dir /any/path --role pm --message "..."` exits with argparse error (unrecognized argument).
+- [x] A parent PM session running with `cwd=/Users/valorengels/src/cuttlefish` that invokes `valor-session create --role pm --message "Run SDLC on issue 290"` (no `--project-key`) produces a child `AgentSession` with `project_key=cuttlefish` AND `working_dir` rooted under `/Users/valorengels/src/cuttlefish`.
+- [x] When `--project-key cuttlefish` is passed explicitly from a cwd of `/Users/valorengels/src/ai`, the resulting session's `working_dir` is rooted under the cuttlefish project, not the ai repo.
+- [x] A `valor-session create` invocation from a cwd that matches no project, with no `--project-key`, exits non-zero with an error naming the cwd and listing valid keys (not silently defaulting).
+- [x] `valor-session create --working-dir /any/path --role pm --message "..."` exits with argparse error (unrecognized argument).
 - [ ] Regression test: three-level PM chain in project X → all levels carry consistent `project_key` and `working_dir` rooted inside X.
-- [ ] `AgentSession.project_config` is populated on CLI-created sessions.
-- [ ] `agent/reflection_scheduler.py` handles the new typed exceptions with an explicit catch and a logged warning.
-- [ ] `tools/sdlc_session_ensure.py` derives `working_dir` from `projects.json`, not `os.getcwd()`.
-- [ ] All updated tests pass: `pytest tests/unit/test_valor_session_project_key.py tests/unit/test_pm_session_auto_slug.py tests/unit/test_pm_session_refuse_no_issue.py tests/unit/test_valor_session_cli.py tests/unit/test_valor_session_working_dir_resolution.py`.
-- [ ] `grep -n 'return "valor"' tools/valor_session.py` matches nothing (except explicit test-only strings).
-- [ ] `grep -n -- '--working-dir' tools/valor_session.py` matches nothing.
+- [x] `AgentSession.project_config` is populated on CLI-created sessions.
+- [x] `agent/reflection_scheduler.py` handles the new typed exceptions with an explicit catch and a logged warning.
+- [x] `tools/sdlc_session_ensure.py` derives `working_dir` from `projects.json`, not `os.getcwd()`.
+- [x] All updated tests pass: `pytest tests/unit/test_valor_session_project_key.py tests/unit/test_pm_session_auto_slug.py tests/unit/test_pm_session_refuse_no_issue.py tests/unit/test_valor_session_cli.py tests/unit/test_valor_session_working_dir_resolution.py`.
+- [x] `grep -n 'return "valor"' tools/valor_session.py` matches nothing (except explicit test-only strings).
+- [x] `grep -n -- '--working-dir' tools/valor_session.py` matches nothing.
 
 ## Team Orchestration
 

--- a/docs/plans/child-session-project-scope.md
+++ b/docs/plans/child-session-project-scope.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: docs_complete
 type: bug
 appetite: Medium
 owner: Valor Engels
@@ -339,14 +339,16 @@ The fix does affect **what the PM agent experiences** when it runs `python -m to
 
 ### Feature Documentation
 
-- [ ] Update `docs/features/session-isolation.md`: add a "CLI-level project scope resolution" subsection documenting (a) removal of `--working-dir`, (b) the precedence chain `--project-key` > `--parent` > cwd-match, (c) the hard-error behavior on unmatched cwd.
-- [ ] Update `CLAUDE.md` Quick Commands entries for `valor-session create --role pm/dev` — note that `project_key` determines `working_dir` via `projects.json`, and there is no `--working-dir` flag.
+- [x] Update `docs/features/session-isolation.md`: add a "CLI-level project scope resolution" subsection documenting (a) removal of `--working-dir`, (b) the precedence chain `--project-key` > `--parent` > cwd-match, (c) the hard-error behavior on unmatched cwd.
+- [x] Update `CLAUDE.md` Quick Commands entries for `valor-session create --role pm/dev` — note that `project_key` determines `working_dir` via `projects.json`, and there is no `--working-dir` flag.
+- [x] Update `docs/tools-reference.md` and `docs/features/tools-reference.md` — replace the stale "Falls back to `\"valor\"`" description with the new precedence rule (added by /do-docs cascade).
+- [x] Update `docs/features/sdlc-stage-tracking.md` — extend the `sdlc_session_ensure.py` note to cover `working_dir` derivation via `_resolve_project_working_directory()` (added by /do-docs cascade).
 
 ### Inline Documentation
 
-- [ ] Rewrite the module docstring in `tools/valor_session.py` (lines 23-31) to describe the new resolution rule: one input (`project_key`), two sources (explicit flag or cwd-match), no fallback, no `--working-dir`.
-- [ ] Add docstring to `_resolve_project_working_directory`.
-- [ ] Update `resolve_project_key` docstring to document the raised exception types.
+- [x] Rewrite the module docstring in `tools/valor_session.py` (lines 23-31) to describe the new resolution rule: one input (`project_key`), two sources (explicit flag or cwd-match), no fallback, no `--working-dir`.
+- [x] Add docstring to `_resolve_project_working_directory`.
+- [x] Update `resolve_project_key` docstring to document the raised exception types.
 
 ### External Documentation Site
 

--- a/docs/plans/child-session-project-scope.md
+++ b/docs/plans/child-session-project-scope.md
@@ -228,19 +228,19 @@ No changes needed to `AgentSession` model, `bridge/telegram_bridge.py`, `agent/s
 ### Exception Handling Coverage
 
 - [x] `tools/valor_session.py:cmd_create` has a broad `try/except Exception` that catches any error and returns exit code 1. Verify both new exceptions produce clear stderr messages **before** being caught — tests must assert stderr content, not just exit code.
-- [ ] `agent/reflection_scheduler.py:394-399` now catches two specific exception types. Add a test that simulates each raising and asserts the scheduler falls back gracefully and logs a warning.
-- [ ] `tools/sdlc_session_ensure.py:ensure_session` — on `ProjectKeyResolutionError`, it should return `{}` (no session created) rather than coercing to a wrong project.
+- [x] `agent/reflection_scheduler.py:394-399` now catches two specific exception types. Add a test that simulates each raising and asserts the scheduler falls back gracefully and logs a warning. Covered by `tests/unit/test_reflection_scheduler.py::TestEnqueueAgentReflectionTypedErrors` (both `ProjectKeyResolutionError` and `ProjectsConfigUnavailableError` → PROJECT_KEY env fallback + `logger.warning`).
+- [x] `tools/sdlc_session_ensure.py:ensure_session` — on `ProjectKeyResolutionError`, it should return `{}` (no session created) rather than coercing to a wrong project. Covered by `tests/unit/test_sdlc_session_ensure.py::TestEnsureSession::test_project_key_resolution_error_returns_empty` and `::test_projects_config_unavailable_error_returns_empty` — `AgentSession.create_local` asserted not called.
 
 ### Empty/Invalid Input Handling
 
 - [x] `cmd_create` when `--project-key` refers to a key not in `projects.json` → exit 1, stderr names the missing key and lists available keys.
 - [x] `cmd_create` when cwd matches no project and no `--project-key` → exit 1 with same hint.
 - [x] `cmd_create` when `projects.json` is unloadable → exit 1 with `ProjectsConfigUnavailableError` message.
-- [ ] `cmd_create` when `--parent <id>` points to a nonexistent session → exit 1.
+- [x] `cmd_create` when `--parent <id>` points to a nonexistent session → falls through to cwd-based `resolve_project_key` (per Implementation Note at line 441: parent is advisory; typo should not hard-fail when cwd can still resolve). Hard-fail only when BOTH parent lookup AND cwd resolution fail. Covered by `test_parent_not_found_falls_through_to_cwd_resolution`.
 
 ### Error State Rendering
 
-- [ ] All new error paths write to stderr, preserving stdout for `--json`. Assert `stdout_capture.getvalue() == ""` on error.
+- [x] All new error paths write to stderr, preserving stdout for `--json`. Assert `stdout_capture.getvalue() == ""` on error. Covered by `tests/unit/test_valor_session_working_dir_resolution.py::TestErrorPathWritesToStderrOnly` (3 tests: unmatched cwd, unknown project key, load_config failure — all assert `capsys.out == ""`).
 - [x] Error messages include: attempted value, list of valid project keys, suggested remediation (`pass --project-key <key>`).
 
 ## Test Impact
@@ -257,7 +257,7 @@ Test files rewritten to match the new surface. Counts: **5 existing files affect
 - [x] `tests/unit/test_pm_session_auto_slug.py` — multiple tests use `_make_args(..., working_dir=None, ...)` at lines 36, and reference auto-derived working_dir in lines 77 etc. — **UPDATE**: drop `working_dir` from `_make_args` defaults; mock `bridge.routing.load_config` to return a test `projects.json` including a `"valor"` key with `working_directory` pointing at `tmp_path`; assert the derived `working_dir` passed to `fake_push` equals the worktree path under that `tmp_path`.
 - [x] `tests/unit/test_pm_session_refuse_no_issue.py` (line 32: `working_dir=None`) — **UPDATE**: drop the attribute; add `load_config` mock.
 - [x] `tests/unit/test_valor_session_cli.py` — three `monkeypatch.setattr(valor_session, "resolve_project_key", lambda cwd: "test-1148")` stubs (lines 76, 102, 121). **UPDATE**: keep the stubs but also mock `tools.valor_session._resolve_project_working_directory` to return a `Path`, because `cmd_create` will now call it right after `resolve_project_key`. Drop any `working_dir` namespace attribute from `_make_args` helpers.
-- [ ] `tests/integration/test_parent_child_round_trip.py` (if it exists — verify) — **UPDATE**: assert child `working_dir` is rooted inside the parent's project (via the projects.json lookup), not by direct parent.working_dir inheritance.
+- [x] `tests/integration/test_parent_child_round_trip.py` — **UPDATE** applied: added `test_child_working_dir_rooted_under_parent_project_via_projects_json` asserting `captured["working_dir"].startswith(parent_project_root)` AND `captured["working_dir"] != fake_parent.working_dir` (child re-derives from projects.json, not copied from parent).
 - [x] **ADD** `tests/unit/test_valor_session_working_dir_resolution.py` — new file covering:
   - `--project-key cuttlefish` from cwd `/Users/valorengels/src/ai` produces `working_dir` rooted at the cuttlefish project (via mocked `load_config`).
   - There is **no** `--working-dir` flag — `argparse` rejects it (`SystemExit`) and stderr mentions unrecognized arguments.
@@ -360,7 +360,7 @@ Not applicable — this repo does not publish external docs.
 - [x] When `--project-key cuttlefish` is passed explicitly from a cwd of `/Users/valorengels/src/ai`, the resulting session's `working_dir` is rooted under the cuttlefish project, not the ai repo.
 - [x] A `valor-session create` invocation from a cwd that matches no project, with no `--project-key`, exits non-zero with an error naming the cwd and listing valid keys (not silently defaulting).
 - [x] `valor-session create --working-dir /any/path --role pm --message "..."` exits with argparse error (unrecognized argument).
-- [ ] Regression test: three-level PM chain in project X → all levels carry consistent `project_key` and `working_dir` rooted inside X.
+- [x] Regression test: three-level PM chain in project X → all levels carry consistent `project_key` and `working_dir` rooted inside X. Covered by `tests/unit/test_valor_session_working_dir_resolution.py::TestThreeLevelPMChain::test_pm_pm_dev_chain_all_rooted_in_project` — drives PM→PM→Dev cmd_create chain, asserts all three levels carry `project_key=="demo"` and `working_dir.startswith(demo_root)`.
 - [x] `AgentSession.project_config` is populated on CLI-created sessions.
 - [x] `agent/reflection_scheduler.py` handles the new typed exceptions with an explicit catch and a logged warning.
 - [x] `tools/sdlc_session_ensure.py` derives `working_dir` from `projects.json`, not `os.getcwd()`.

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -248,7 +248,7 @@ python -m tools.valor_session kill --all
 python -m tools.valor_session status --id <SESSION_ID> --json
 ```
 
-**Project key resolution (`create` subcommand):** The `project_key` is derived automatically by matching the current working directory against the `working_directory` field of each project in `~/Desktop/Valor/projects.json`. The most-specific match (longest path prefix) wins. Falls back to `"valor"` with a stderr warning if no match is found. Use `--project-key` to override explicitly (useful in scripts or CI where cwd may not match any project).
+**Project key resolution (`create` subcommand):** `project_key` is the only input that ties a session to a repo — `working_dir` is always derived from `projects.json[project_key].working_directory`, never supplied independently. There is **no** `--working-dir` flag. Resolution precedence: `--project-key <key>` > `--parent <id>` (inherits from parent session's `project_key`) > `resolve_project_key(os.getcwd())` (matches cwd against each project's `working_directory`, longest-prefix wins). On no match the CLI raises `ProjectKeyResolutionError` and exits non-zero — there is no silent `"valor"` fallback. See `docs/features/session-isolation.md#cli-level-project-scope-resolution-issue-1158` for the full rule.
 
 See `docs/features/session-steering.md` for full documentation.
 

--- a/tests/integration/test_parent_child_round_trip.py
+++ b/tests/integration/test_parent_child_round_trip.py
@@ -139,6 +139,88 @@ class TestDevSessionParentLinkage:
 
         assert standalone_dev.parent_agent_session_id is None
 
+    def test_child_working_dir_rooted_under_parent_project_via_projects_json(
+        self, tmp_path, monkeypatch, redis_test_db
+    ):
+        """#1158: child session's working_dir must be rooted inside the
+        parent's project (via the projects.json lookup), NOT copied directly
+        from parent.working_dir.
+
+        This is the integration-layer regression guard for the governing
+        principle: project_key → repo (via projects.json) is the only pairing.
+        """
+        import argparse
+        from unittest.mock import MagicMock, patch
+
+        from tools.valor_session import cmd_create
+
+        # Simulated project root for the parent's project_key.
+        parent_project_root = tmp_path / "test_proj_root"
+        parent_project_root.mkdir()
+
+        # Parent session is in a worktree under the project — child must NOT
+        # copy this path; child should re-derive via projects.json.
+        parent_worktree = parent_project_root / ".worktrees" / "parent-wt"
+        parent_worktree.mkdir(parents=True)
+
+        parent_uuid = "parent-integration-uuid-001"
+        fake_parent = MagicMock()
+        fake_parent.project_key = "test"
+        fake_parent.agent_session_id = parent_uuid
+        fake_parent.working_dir = str(parent_worktree)
+
+        projects_json = {"test": {"working_directory": str(parent_project_root)}}
+
+        # Child worktree path — distinct from parent's worktree.
+        child_wt = parent_project_root / ".worktrees" / "sdlc-500"
+        child_wt.mkdir(parents=True)
+
+        captured: dict = {}
+
+        async def fake_push(**kwargs):
+            captured.update(kwargs)
+
+        monkeypatch.chdir(tmp_path)  # cwd unrelated
+
+        args = argparse.Namespace(
+            command="create",
+            role="pm",
+            message="Run SDLC on issue #500",
+            chat_id=None,
+            parent=parent_uuid,
+            project_key=None,  # Inherit from parent
+            slug=None,
+            model=None,
+            json=False,
+        )
+
+        with (
+            patch(
+                "bridge.routing.load_config",
+                return_value={"projects": projects_json, "defaults": {}},
+            ),
+            patch("tools.valor_session._find_session", return_value=fake_parent),
+            patch(
+                "agent.worktree_manager.get_or_create_worktree",
+                return_value=child_wt,
+            ),
+            patch("agent.worktree_manager._validate_slug"),
+            patch("agent.agent_session_queue._push_agent_session", side_effect=fake_push),
+            patch("tools.valor_session._check_worker_health", return_value=(True, 1)),
+        ):
+            rc = cmd_create(args)
+
+        assert rc == 0
+
+        # REGRESSION GUARD: working_dir must be rooted under the project root
+        # from projects.json — NOT the parent's working_dir.
+        assert captured["working_dir"].startswith(str(parent_project_root))
+        assert captured["working_dir"] != fake_parent.working_dir
+        # The inherited project_key flows to the child.
+        assert captured["project_key"] == "test"
+        # project_config carries the raw project dict (bridge parity).
+        assert captured["project_config"] == projects_json["test"]
+
 
 # ---------------------------------------------------------------------------
 # Test 2: _handle_dev_session_completion calls steer_session on parent

--- a/tests/unit/test_pm_session_auto_slug.py
+++ b/tests/unit/test_pm_session_auto_slug.py
@@ -5,11 +5,17 @@ message contains an issue reference ("issue #N" or "issue N"), the CLI must:
 
 1. Parse the issue number from the message.
 2. Auto-set `slug = f"sdlc-{N}"`.
-3. Provision a worktree for the slug via `agent.worktree_manager.get_or_create_worktree`.
-4. Use the worktree path as the session's `working_dir`.
+3. Provision a worktree for the slug via ``agent.worktree_manager.get_or_create_worktree``.
+4. Use the worktree path as the session's ``working_dir``.
 
 This prevents the PM session from inheriting the worker's branch state, which
 was the root cause of the first-round SDLC session contamination (issue #1109).
+
+NOTE on the ``working_dir`` test fixture (#1158):
+    These tests stub ``_resolve_project_working_directory`` with a ``tmp_path``
+    root so ``cmd_create`` derives its working_dir from the mocked project
+    entry, not the real ``projects.json``. The stub returns a 2-tuple
+    ``(Path, dict)`` to match the helper's contract.
 """
 
 import argparse
@@ -26,21 +32,37 @@ from tools.valor_session import cmd_create  # noqa: E402
 
 
 def _make_args(**overrides) -> argparse.Namespace:
-    """Build a namespace mimicking argparse output for `create`."""
+    """Build a namespace mimicking argparse output for `create`.
+
+    Note: no ``working_dir`` attribute — the flag was removed in #1158. Tests
+    that previously set ``working_dir=None`` now rely entirely on the mocked
+    project lookup to provide the repo root.
+    """
     defaults = dict(
         command="create",
         role="pm",
         message="",
         chat_id=None,
         parent=None,
-        working_dir=None,
-        project_key="valor",  # skip project resolution
+        project_key="valor",  # skip cwd-based project resolution
         slug=None,
         model=None,
         json=False,
     )
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
+
+
+def _stub_project_lookup(repo_root: Path):
+    """Return a patch context for ``_resolve_project_working_directory``.
+
+    The helper returns (Path, dict) — do NOT return a bare Path or the CLI
+    will raise TypeError when unpacking the tuple.
+    """
+    return patch(
+        "tools.valor_session._resolve_project_working_directory",
+        return_value=(repo_root, {"working_directory": str(repo_root)}),
+    )
 
 
 class TestPMAutoSlugFromIssueReference:
@@ -56,7 +78,9 @@ class TestPMAutoSlugFromIssueReference:
         async def fake_push(**kwargs):
             captured.update(kwargs)
 
-        wt_path = tmp_path / ".worktrees" / "sdlc-1109"
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        wt_path = repo_root / ".worktrees" / "sdlc-1109"
         wt_path.mkdir(parents=True)
 
         with (
@@ -67,6 +91,7 @@ class TestPMAutoSlugFromIssueReference:
             ) as mock_wt,
             patch("agent.worktree_manager._validate_slug"),
             patch("tools.valor_session._check_worker_health", return_value=(True, 5)),
+            _stub_project_lookup(repo_root),
         ):
             rc = cmd_create(args)
 
@@ -75,8 +100,11 @@ class TestPMAutoSlugFromIssueReference:
         assert captured.get("slug") == "sdlc-1109"
         # Working dir should be the worktree, not the repo root.
         assert captured.get("working_dir") == str(wt_path)
-        # The worktree manager must have been invoked.
+        # The worktree manager must have been invoked with the PROJECT's
+        # repo_root (from the mocked lookup), not some caller-supplied path.
         mock_wt.assert_called_once()
+        called_repo_root = mock_wt.call_args.args[0]
+        assert called_repo_root == repo_root
 
     def test_pm_role_no_slug_with_plain_issue_reference_derives_slug(self, tmp_path):
         """'issue 735' (no hash) also works."""
@@ -90,7 +118,9 @@ class TestPMAutoSlugFromIssueReference:
         async def fake_push(**kwargs):
             captured.update(kwargs)
 
-        wt_path = tmp_path / ".worktrees" / "sdlc-735"
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        wt_path = repo_root / ".worktrees" / "sdlc-735"
         wt_path.mkdir(parents=True)
 
         with (
@@ -101,6 +131,7 @@ class TestPMAutoSlugFromIssueReference:
             ),
             patch("agent.worktree_manager._validate_slug"),
             patch("tools.valor_session._check_worker_health", return_value=(True, 5)),
+            _stub_project_lookup(repo_root),
         ):
             rc = cmd_create(args)
 
@@ -120,7 +151,9 @@ class TestPMAutoSlugFromIssueReference:
         async def fake_push(**kwargs):
             captured.update(kwargs)
 
-        wt_path = tmp_path / ".worktrees" / "my-custom-slug"
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        wt_path = repo_root / ".worktrees" / "my-custom-slug"
         wt_path.mkdir(parents=True)
 
         with (
@@ -131,6 +164,7 @@ class TestPMAutoSlugFromIssueReference:
             ),
             patch("agent.worktree_manager._validate_slug"),
             patch("tools.valor_session._check_worker_health", return_value=(True, 5)),
+            _stub_project_lookup(repo_root),
         ):
             rc = cmd_create(args)
 
@@ -149,6 +183,9 @@ class TestPMAutoSlugFromIssueReference:
         async def fake_push(**kwargs):
             captured.update(kwargs)
 
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+
         # Must NOT call get_or_create_worktree for dev without --slug.
         with (
             patch("agent.agent_session_queue._push_agent_session", side_effect=fake_push),
@@ -158,9 +195,12 @@ class TestPMAutoSlugFromIssueReference:
             ),
             patch("agent.worktree_manager._validate_slug"),
             patch("tools.valor_session._check_worker_health", return_value=(True, 5)),
+            _stub_project_lookup(repo_root),
         ):
             rc = cmd_create(args)
 
         assert rc == 0
         # No slug assigned; dev session does not auto-derive.
         assert captured.get("slug") is None
+        # working_dir for a dev session without --slug is the repo_root itself.
+        assert captured.get("working_dir") == str(repo_root)

--- a/tests/unit/test_pm_session_refuse_no_issue.py
+++ b/tests/unit/test_pm_session_refuse_no_issue.py
@@ -1,9 +1,12 @@
 """Unit tests for PM-role refusal when no --slug and no issue reference (#1109).
 
-When `valor-session create --role pm` is invoked WITHOUT `--slug` AND the
+When ``valor-session create --role pm`` is invoked WITHOUT ``--slug`` AND the
 message does NOT contain an issue reference, the CLI must refuse with a
 clear error and exit non-zero. This prevents PM sessions from silently
 running on the worker's current branch (defect 1 in issue #1109).
+
+The refusal path MUST fire BEFORE any project/worktree lookup — a PM session
+with no slug never needs a working_dir at all (#1158 Technical Approach step 7).
 
 Dev/teammate roles are unaffected — they may legitimately run without a
 slug (e.g. ad-hoc conversations).
@@ -29,7 +32,6 @@ def _make_args(**overrides) -> argparse.Namespace:
         message="",
         chat_id=None,
         parent=None,
-        working_dir=None,
         project_key="valor",
         slug=None,
         model=None,
@@ -39,9 +41,21 @@ def _make_args(**overrides) -> argparse.Namespace:
     return argparse.Namespace(**defaults)
 
 
+def _stub_project_lookup(repo_root: Path):
+    return patch(
+        "tools.valor_session._resolve_project_working_directory",
+        return_value=(repo_root, {"working_directory": str(repo_root)}),
+    )
+
+
 class TestPMRefuseWithoutIssue:
     def test_pm_role_no_slug_no_issue_reference_exits_nonzero(self, capsys):
-        """PM create with no --slug and no issue ref must refuse."""
+        """PM create with no --slug and no issue ref must refuse.
+
+        The refusal must happen BEFORE any project/worktree lookup so we do
+        NOT need to stub ``_resolve_project_working_directory``. If it is
+        called, that's a regression in the ordering — make it crash loudly.
+        """
         args = _make_args(
             role="pm",
             message="Do something generic for me",
@@ -53,6 +67,12 @@ class TestPMRefuseWithoutIssue:
         with (
             patch("agent.agent_session_queue._push_agent_session", side_effect=fake_push),
             patch("tools.valor_session._check_worker_health", return_value=(True, 5)),
+            patch(
+                "tools.valor_session._resolve_project_working_directory",
+                side_effect=AssertionError(
+                    "project lookup must not be called before PM slug check"
+                ),
+            ),
         ):
             rc = cmd_create(args)
 
@@ -75,7 +95,9 @@ class TestPMRefuseWithoutIssue:
         async def fake_push(**kwargs):
             captured_kwargs.update(kwargs)
 
-        wt_path = tmp_path / ".worktrees" / "some-feature"
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        wt_path = repo_root / ".worktrees" / "some-feature"
         wt_path.mkdir(parents=True)
 
         with (
@@ -86,13 +108,14 @@ class TestPMRefuseWithoutIssue:
             ),
             patch("agent.worktree_manager._validate_slug"),
             patch("tools.valor_session._check_worker_health", return_value=(True, 5)),
+            _stub_project_lookup(repo_root),
         ):
             rc = cmd_create(args)
 
         assert rc == 0
         assert captured_kwargs.get("slug") == "some-feature"
 
-    def test_dev_role_no_slug_no_issue_allowed(self):
+    def test_dev_role_no_slug_no_issue_allowed(self, tmp_path):
         """Dev sessions may legitimately run without a slug (ad-hoc)."""
         args = _make_args(
             role="dev",
@@ -104,16 +127,20 @@ class TestPMRefuseWithoutIssue:
         async def fake_push(**kwargs):
             captured_kwargs.update(kwargs)
 
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+
         with (
             patch("agent.agent_session_queue._push_agent_session", side_effect=fake_push),
             patch("tools.valor_session._check_worker_health", return_value=(True, 5)),
+            _stub_project_lookup(repo_root),
         ):
             rc = cmd_create(args)
 
         assert rc == 0
         assert captured_kwargs.get("slug") is None
 
-    def test_teammate_role_no_slug_no_issue_allowed(self):
+    def test_teammate_role_no_slug_no_issue_allowed(self, tmp_path):
         """Teammate sessions are conversational — no slug required."""
         args = _make_args(
             role="teammate",
@@ -125,9 +152,13 @@ class TestPMRefuseWithoutIssue:
         async def fake_push(**kwargs):
             captured_kwargs.update(kwargs)
 
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+
         with (
             patch("agent.agent_session_queue._push_agent_session", side_effect=fake_push),
             patch("tools.valor_session._check_worker_health", return_value=(True, 5)),
+            _stub_project_lookup(repo_root),
         ):
             rc = cmd_create(args)
 

--- a/tests/unit/test_reflection_scheduler.py
+++ b/tests/unit/test_reflection_scheduler.py
@@ -713,3 +713,89 @@ class TestTimeoutEnforcement:
                     # Check that warning was logged about high memory delta
                     warning_calls = [str(c) for c in mock_logger.warning.call_args_list]
                     assert any("HIGH MEMORY DELTA" in str(c) for c in warning_calls)
+
+
+# === Typed-error fallback tests (#1158) ===
+
+
+class TestEnqueueAgentReflectionTypedErrors:
+    """Covers plan #1158 Failure Path: when resolve_project_key raises a typed
+    error, _enqueue_agent_reflection must fall back to PROJECT_KEY env var and
+    log a warning — not crash, not silently coerce.
+    """
+
+    @pytest.mark.asyncio
+    async def test_project_key_resolution_error_falls_back_to_env(self, monkeypatch):
+        """ProjectKeyResolutionError → logs warning, uses PROJECT_KEY env var."""
+        from agent.reflection_scheduler import _enqueue_agent_reflection
+        from tools.valor_session import ProjectKeyResolutionError
+
+        entry = ReflectionEntry(
+            name="agent-typed-err-test",
+            description="Test reflection typed-error fallback",
+            interval=3600,
+            priority="low",
+            execution_type="agent",
+            command="Test agent reflection",
+        )
+
+        monkeypatch.setenv("PROJECT_KEY", "override-from-env")
+        captured: dict = {}
+
+        async def fake_push(**kwargs):
+            captured.update(kwargs)
+
+        with (
+            patch(
+                "tools.valor_session.resolve_project_key",
+                side_effect=ProjectKeyResolutionError(
+                    cwd="/tmp/unknown", available_keys=["valor", "ai"]
+                ),
+            ),
+            patch("agent.agent_session_queue._push_agent_session", side_effect=fake_push),
+            patch("agent.reflection_scheduler.logger") as mock_logger,
+        ):
+            await _enqueue_agent_reflection(entry)
+
+        # Warning fired with the error message.
+        warnings_logged = [str(c) for c in mock_logger.warning.call_args_list]
+        assert any("could not resolve project_key" in w for w in warnings_logged)
+        # Enqueue used the env var fallback.
+        assert captured["project_key"] == "override-from-env"
+
+    @pytest.mark.asyncio
+    async def test_projects_config_unavailable_error_falls_back_to_env(self, monkeypatch):
+        """ProjectsConfigUnavailableError → logs warning, uses PROJECT_KEY env var."""
+        from agent.reflection_scheduler import _enqueue_agent_reflection
+        from tools.valor_session import ProjectsConfigUnavailableError
+
+        entry = ReflectionEntry(
+            name="agent-config-err-test",
+            description="Test reflection typed-error fallback (config unavailable)",
+            interval=3600,
+            priority="low",
+            execution_type="agent",
+            command="Test agent reflection",
+        )
+
+        monkeypatch.setenv("PROJECT_KEY", "env-fallback-key")
+        captured: dict = {}
+
+        async def fake_push(**kwargs):
+            captured.update(kwargs)
+
+        with (
+            patch(
+                "tools.valor_session.resolve_project_key",
+                side_effect=ProjectsConfigUnavailableError(
+                    "could not load projects.json: permission denied"
+                ),
+            ),
+            patch("agent.agent_session_queue._push_agent_session", side_effect=fake_push),
+            patch("agent.reflection_scheduler.logger") as mock_logger,
+        ):
+            await _enqueue_agent_reflection(entry)
+
+        warnings_logged = [str(c) for c in mock_logger.warning.call_args_list]
+        assert any("could not resolve project_key" in w for w in warnings_logged)
+        assert captured["project_key"] == "env-fallback-key"

--- a/tests/unit/test_sdlc_session_ensure.py
+++ b/tests/unit/test_sdlc_session_ensure.py
@@ -117,6 +117,62 @@ class TestEnsureSession:
 
         assert result == {"session_id": "sdlc-local-944", "created": True}
 
+    def test_project_key_resolution_error_returns_empty(self):
+        """#1158: on ProjectKeyResolutionError, ensure_session returns {} and
+        does NOT create an AgentSession with a coerced/wrong project_key.
+
+        The plan's governing principle: if the project→repo pairing can't be
+        resolved, refuse to create a session rather than silently misroute.
+        """
+        from tools.sdlc_session_ensure import ensure_session
+        from tools.valor_session import ProjectKeyResolutionError
+
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = []
+
+        with (
+            patch("tools._sdlc_utils.find_session_by_issue", return_value=None),
+            patch("models.agent_session.AgentSession", mock_as),
+            patch(
+                "tools.valor_session.resolve_project_key",
+                side_effect=ProjectKeyResolutionError(
+                    cwd="/tmp/unknown", available_keys=["valor", "ai"]
+                ),
+            ),
+        ):
+            result = ensure_session(issue_number=945)
+
+        # Empty dict → no session created.
+        assert result == {}
+        # AgentSession.create_local was NEVER called — no coercion to a wrong
+        # project happened.
+        mock_as.create_local.assert_not_called()
+
+    def test_projects_config_unavailable_error_returns_empty(self):
+        """#1158: on ProjectsConfigUnavailableError (e.g., projects.json load
+        failure), ensure_session returns {} with no session created.
+        """
+        from tools.sdlc_session_ensure import ensure_session
+        from tools.valor_session import ProjectsConfigUnavailableError
+
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = []
+
+        with (
+            patch("tools._sdlc_utils.find_session_by_issue", return_value=None),
+            patch("models.agent_session.AgentSession", mock_as),
+            patch(
+                "tools.valor_session.resolve_project_key",
+                side_effect=ProjectsConfigUnavailableError(
+                    "could not load projects.json: permission denied"
+                ),
+            ),
+        ):
+            result = ensure_session(issue_number=946)
+
+        assert result == {}
+        mock_as.create_local.assert_not_called()
+
 
 class TestCLI:
     """Tests for CLI invocation."""

--- a/tests/unit/test_valor_session_cli.py
+++ b/tests/unit/test_valor_session_cli.py
@@ -16,7 +16,12 @@ from tools import valor_session
 
 
 def _make_args(message: str, **overrides) -> argparse.Namespace:
-    """Build a minimal argparse.Namespace to feed cmd_create."""
+    """Build a minimal argparse.Namespace to feed cmd_create.
+
+    Note: no ``working_dir`` attribute — the flag was removed in #1158. The
+    derived working_dir now comes from ``_resolve_project_working_directory``
+    which tests below monkeypatch to a ``tmp_path``-friendly stub.
+    """
     base = {
         "role": "pm",
         "message": message,
@@ -25,7 +30,6 @@ def _make_args(message: str, **overrides) -> argparse.Namespace:
         "model": None,
         "slug": "sdlc-1148",  # Skip the auto-derive branch in cmd_create
         "project_key": "test-1148",
-        "working_dir": None,
     }
     base.update(overrides)
     return argparse.Namespace(**base)
@@ -61,7 +65,7 @@ class TestCreateEnrichmentHeaderGuard:
         assert rc == 2, f"Expected exit code 2, got {rc} for message: {msg!r}"
         assert "enrichment header" in captured.err.lower(), captured.err
 
-    def test_accepts_lowercase_prose_with_scope_keyword(self, capsys, monkeypatch):
+    def test_accepts_lowercase_prose_with_scope_keyword(self, capsys, monkeypatch, tmp_path):
         """Lowercase 'scope: ...' is normal prose and must NOT fire the guard.
 
         We mock the downstream session-creation path so the test does not
@@ -76,6 +80,13 @@ class TestCreateEnrichmentHeaderGuard:
             "resolve_project_key",
             lambda cwd: "test-1148",
         )
+        # #1158: cmd_create now calls _resolve_project_working_directory after
+        # resolving project_key. The helper returns a 2-tuple (Path, dict).
+        monkeypatch.setattr(
+            valor_session,
+            "_resolve_project_working_directory",
+            lambda key: (tmp_path, {"working_directory": str(tmp_path)}),
+        )
 
         args = _make_args("scope: database refactor\nLet's look at the connection pool config")
         # We don't care if the downstream code raises (no Redis in this test);
@@ -89,7 +100,7 @@ class TestCreateEnrichmentHeaderGuard:
             f"Lowercase 'scope:' prose tripped the guard. Stderr: {captured.err!r}"
         )
 
-    def test_accepts_buried_enrichment_after_first_line(self, capsys, monkeypatch):
+    def test_accepts_buried_enrichment_after_first_line(self, capsys, monkeypatch, tmp_path):
         """Enrichment-header text buried after the first line must NOT fire.
 
         The regex anchors at ^ and only inspects the first 200 chars; this
@@ -102,6 +113,11 @@ class TestCreateEnrichmentHeaderGuard:
             "resolve_project_key",
             lambda cwd: "test-1148",
         )
+        monkeypatch.setattr(
+            valor_session,
+            "_resolve_project_working_directory",
+            lambda key: (tmp_path, {"working_directory": str(tmp_path)}),
+        )
 
         args = _make_args("Fix the bug where SESSION_ID: prefix sometimes appears in logs")
         try:
@@ -113,13 +129,18 @@ class TestCreateEnrichmentHeaderGuard:
             f"Buried 'SESSION_ID:' tripped the guard. Stderr: {captured.err!r}"
         )
 
-    def test_empty_message_does_not_fire(self, capsys, monkeypatch):
+    def test_empty_message_does_not_fire(self, capsys, monkeypatch, tmp_path):
         """An empty --message bypasses this guard (other validation owns that case)."""
         monkeypatch.setattr(valor_session, "_check_worker_health", lambda: (True, 1))
         monkeypatch.setattr(
             valor_session,
             "resolve_project_key",
             lambda cwd: "test-1148",
+        )
+        monkeypatch.setattr(
+            valor_session,
+            "_resolve_project_working_directory",
+            lambda key: (tmp_path, {"working_directory": str(tmp_path)}),
         )
 
         args = _make_args("")

--- a/tests/unit/test_valor_session_project_key.py
+++ b/tests/unit/test_valor_session_project_key.py
@@ -1,12 +1,15 @@
-"""Unit tests for resolve_project_key() in tools/valor_session.py.
+"""Unit tests for ``resolve_project_key()`` and ``_resolve_project_working_directory()``.
 
-Tests cover:
-- Exact cwd match on working_directory
-- Subdirectory match (cwd is a child of working_directory)
-- Most-specific match when paths overlap
-- Fallback to "valor" with stderr warning when no match
-- Fallback to "valor" when projects.json is empty/missing
-- --project-key flag bypasses resolution (tested via cmd_create argument handling)
+Covers the tightened contract from issue #1158:
+
+- Exact cwd match on ``working_directory``.
+- Subdirectory match (cwd is a child of ``working_directory``).
+- Most-specific match when paths overlap.
+- **No silent fallback** — unmatched cwd raises ``ProjectKeyResolutionError``.
+- **No config-load fallback** — ``load_config()`` errors raise
+  ``ProjectsConfigUnavailableError``.
+- ``--project-key`` flag bypasses resolution (tested via ``cmd_create`` argument
+  handling).
 """
 
 import sys
@@ -19,7 +22,13 @@ _repo_root = Path(__file__).parent.parent.parent
 if str(_repo_root) not in sys.path:
     sys.path.insert(0, str(_repo_root))
 
-from tools.valor_session import resolve_project_key  # noqa: E402
+from tools.valor_session import (  # noqa: E402
+    ProjectKeyResolutionError,
+    ProjectsConfigUnavailableError,
+    _resolve_project_working_directory,
+    resolve_project_key,
+)
+import pytest  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -103,13 +112,13 @@ class TestResolveProjectKeyMatch:
 
 
 # ---------------------------------------------------------------------------
-# Fallback behavior
+# Fallback behavior — now raises instead of returning "valor"
 # ---------------------------------------------------------------------------
 
 
 class TestResolveProjectKeyFallback:
-    def test_no_match_returns_valor(self, tmp_path):
-        """Returns 'valor' and prints stderr warning when cwd matches no project."""
+    def test_no_match_raises(self, tmp_path):
+        """Unmatched cwd raises ProjectKeyResolutionError with useful message."""
         other_dir = tmp_path / "other"
         other_dir.mkdir()
         project_dir = tmp_path / "ai"
@@ -120,39 +129,41 @@ class TestResolveProjectKeyFallback:
                 "ai": {"working_directory": str(project_dir)},
             }
         )
-        stderr_capture = StringIO()
         with patch("bridge.routing.load_config", return_value=config):
-            with patch("sys.stderr", stderr_capture):
-                result = resolve_project_key(str(other_dir))
+            with pytest.raises(ProjectKeyResolutionError) as excinfo:
+                resolve_project_key(str(other_dir))
 
-        assert result == "valor"
-        assert "valor" in stderr_capture.getvalue()
+        msg = str(excinfo.value)
+        assert str(other_dir) in msg
+        assert "ai" in msg  # available key listed
+        assert "--project-key" in msg  # remediation suggested
 
-    def test_empty_projects_returns_valor(self):
-        """Returns 'valor' when projects dict is empty."""
+    def test_empty_projects_raises(self):
+        """Empty projects dict still raises — no silent fallback."""
         config = _make_config({})
-        stderr_capture = StringIO()
         with patch("bridge.routing.load_config", return_value=config):
-            with patch("sys.stderr", stderr_capture):
-                result = resolve_project_key("/some/unmatched/path")
+            with pytest.raises(ProjectKeyResolutionError) as excinfo:
+                resolve_project_key("/some/unmatched/path")
+        # Available keys list should be empty but present.
+        assert "[]" in str(excinfo.value)
 
-        assert result == "valor"
-
-    def test_load_config_exception_returns_valor(self):
-        """Returns 'valor' and warns when load_config raises an exception."""
-        stderr_capture = StringIO()
+    def test_load_config_exception_raises_distinct_error(self):
+        """load_config() failure raises ProjectsConfigUnavailableError, not
+        ProjectKeyResolutionError. The two must be distinguishable because the
+        remediation differs (fix projects.json vs pass --project-key).
+        """
         with patch("bridge.routing.load_config", side_effect=Exception("file not found")):
-            with patch("sys.stderr", stderr_capture):
-                result = resolve_project_key("/any/path")
+            with pytest.raises(ProjectsConfigUnavailableError) as excinfo:
+                resolve_project_key("/any/path")
 
-        assert result == "valor"
-        assert "valor" in stderr_capture.getvalue()
+        # The cause is preserved so operators can diagnose the root error.
+        assert "file not found" in str(excinfo.value)
 
     def test_project_missing_working_directory_skipped(self, tmp_path):
-        """Projects without working_directory are skipped, doesn't crash."""
+        """Projects without working_directory are skipped; matched project wins."""
         config = _make_config(
             {
-                "ai": {},  # No working_directory key
+                "ai": {},  # No working_directory key — skipped
                 "valor": {"working_directory": str(tmp_path)},
             }
         )
@@ -174,8 +185,12 @@ class TestResolveProjectKeyFallback:
 
         assert result == "valor"
 
-    def test_fallback_warning_goes_to_stderr_not_stdout(self, tmp_path):
-        """Fallback warning is printed to stderr, not stdout (preserves --json)."""
+    def test_resolver_itself_does_not_write_to_stderr(self, tmp_path):
+        """The helper no longer prints — it raises. Stderr/stdout stay clean.
+
+        (The CLI wrapper in cmd_create is responsible for surfacing the error
+        message to stderr via its broad ``except Exception`` handler.)
+        """
         config = _make_config({})
         stdout_capture = StringIO()
         stderr_capture = StringIO()
@@ -183,11 +198,69 @@ class TestResolveProjectKeyFallback:
         with patch("bridge.routing.load_config", return_value=config):
             with patch("sys.stdout", stdout_capture):
                 with patch("sys.stderr", stderr_capture):
-                    result = resolve_project_key("/unmatched/dir")
+                    with pytest.raises(ProjectKeyResolutionError):
+                        resolve_project_key("/unmatched/dir")
 
-        assert result == "valor"
-        assert stdout_capture.getvalue() == ""  # Nothing on stdout
-        assert stderr_capture.getvalue() != ""  # Warning on stderr
+        assert stdout_capture.getvalue() == ""
+        assert stderr_capture.getvalue() == ""
+
+
+# ---------------------------------------------------------------------------
+# _resolve_project_working_directory — new helper
+# ---------------------------------------------------------------------------
+
+
+class TestResolveProjectWorkingDirectory:
+    def test_returns_path_and_dict_tuple(self, tmp_path):
+        """Helper returns (Path, full_project_dict) so the caller gets both
+        values from a single load_config() call.
+        """
+        proj = {"working_directory": str(tmp_path), "chat_id": 12345}
+        config = _make_config({"demo": proj})
+        with patch("bridge.routing.load_config", return_value=config):
+            repo_root, project = _resolve_project_working_directory("demo")
+
+        assert repo_root == Path(str(tmp_path)).expanduser()
+        # The dict is returned unchanged (bridge-parity): no filtering, no
+        # reshape — the CLI must pass it whole to _push_agent_session.
+        assert project == proj
+
+    def test_unknown_key_raises(self, tmp_path):
+        config = _make_config({"valor": {"working_directory": str(tmp_path)}})
+        with patch("bridge.routing.load_config", return_value=config):
+            with pytest.raises(ProjectKeyResolutionError) as excinfo:
+                _resolve_project_working_directory("nonexistent")
+        # Message lists the keys that DO exist so the caller can fix the typo.
+        assert "valor" in str(excinfo.value)
+
+    def test_key_with_empty_working_directory_raises(self):
+        config = _make_config({"broken": {"working_directory": ""}})
+        with patch("bridge.routing.load_config", return_value=config):
+            with pytest.raises(ProjectKeyResolutionError) as excinfo:
+                _resolve_project_working_directory("broken")
+        assert "working_directory" in str(excinfo.value)
+
+    def test_load_config_failure_raises_config_unavailable(self):
+        with patch(
+            "bridge.routing.load_config",
+            side_effect=OSError("projects.json permission denied"),
+        ):
+            with pytest.raises(ProjectsConfigUnavailableError) as excinfo:
+                _resolve_project_working_directory("any")
+        assert "permission denied" in str(excinfo.value)
+
+    def test_expanduser_is_applied(self, monkeypatch, tmp_path):
+        """``~`` in working_directory is expanded so the caller never sees a
+        literal tilde path that won't exist on disk.
+        """
+        # Fake "home" = tmp_path so ~/fake resolves to tmp_path/fake.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config = _make_config({"home_proj": {"working_directory": "~/fake"}})
+        with patch("bridge.routing.load_config", return_value=config):
+            repo_root, _ = _resolve_project_working_directory("home_proj")
+        # The ~ should have been expanded.
+        assert "~" not in str(repo_root)
+        assert str(repo_root).endswith("fake")
 
 
 # ---------------------------------------------------------------------------
@@ -196,27 +269,36 @@ class TestResolveProjectKeyFallback:
 
 
 class TestProjectKeyFlagOverride:
-    def test_explicit_flag_bypasses_resolution(self, tmp_path):
-        """When --project-key is provided, resolve_project_key is not called."""
+    def test_explicit_flag_bypasses_resolution(self):
+        """When --project-key is provided, resolve_project_key is not called.
+
+        Also asserts there is no longer a ``working_dir`` attribute on the
+        namespace — the CLI flag has been removed.
+        """
         import argparse
 
         from tools.valor_session import resolve_project_key as real_fn
 
-        # Simulate what cmd_create does: explicit_key takes priority
+        # Simulate what cmd_create does: explicit_key takes priority.
+        # Note: no ``working_dir`` attribute — the flag is gone.
         args = argparse.Namespace(
             role="pm",
             message="test",
             chat_id="0",
             parent=None,
-            working_dir=None,
             project_key="custom-project",
             json=False,
         )
 
+        # Confirm the attribute we removed is not present on the namespace
+        # (this is a regression guard for the plan's Success Criterion that
+        # ``valor-session create --working-dir ...`` now fails argparse).
+        assert not hasattr(args, "working_dir")
+
         explicit_key = getattr(args, "project_key", None)
         assert explicit_key == "custom-project"
 
-        # resolve_project_key should NOT be called when explicit_key is set
+        # resolve_project_key should NOT be called when explicit_key is set.
         with patch("tools.valor_session.resolve_project_key") as mock_resolve:
             if explicit_key:
                 project_key = explicit_key

--- a/tests/unit/test_valor_session_working_dir_resolution.py
+++ b/tests/unit/test_valor_session_working_dir_resolution.py
@@ -1,0 +1,429 @@
+"""Integration-style unit tests for ``cmd_create`` working_dir derivation (#1158).
+
+Covers the governing design principle:
+
+    > A project and a repo should not be provided separately. The local
+    > machine's configuration sets the pairing and that pairing cannot be
+    > broken.
+
+Scenarios:
+
+- ``--project-key X`` from an ``ai`` cwd produces a session whose ``working_dir``
+  is rooted under project X's declared path, not ``ai``.
+- The CLI has no ``--working-dir`` flag — argparse rejects ``--working-dir``
+  with ``SystemExit`` + stderr mentioning unrecognized arguments.
+- ``--parent <id>`` inherits ``project_key`` from the parent; ``working_dir`` is
+  re-derived from the inherited key (NOT copied from ``parent.working_dir``).
+- ``_push_agent_session`` receives ``project_config`` as the raw project dict
+  from ``projects.json`` (bridge-parity per PR #685).
+- Anti-regression grep checks: no ``--working-dir`` flag, no ``return "valor"``,
+  no ``default="valor"`` left in ``tools/valor_session.py``.
+
+All tests stub ``bridge.routing.load_config`` and/or ``_resolve_project_working_directory``
+so no real ``projects.json`` is read and no real worktrees are created.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Bootstrap: ensure repo root is on sys.path
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from tools import valor_session  # noqa: E402
+from tools.valor_session import cmd_create  # noqa: E402
+
+
+def _make_args(**overrides) -> argparse.Namespace:
+    defaults = dict(
+        command="create",
+        role="pm",
+        message="Run SDLC on issue #290",
+        chat_id=None,
+        parent=None,
+        project_key=None,
+        slug=None,
+        model=None,
+        json=False,
+    )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Core: working_dir derives from project_key, never from cwd
+# ---------------------------------------------------------------------------
+
+
+class TestWorkingDirDerivesFromProjectKey:
+    def test_explicit_project_key_from_unrelated_cwd(self, tmp_path, monkeypatch):
+        """Setting ``--project-key cuttlefish`` from a cwd inside the ``ai``
+        repo produces a session whose ``working_dir`` is rooted under the
+        cuttlefish project root (via the mocked projects.json), not the ``ai``
+        cwd.
+
+        This is the scenario described in the issue: parent PM in cuttlefish
+        calls ``valor-session create`` via subprocess; the child session must
+        NOT inherit the ai cwd.
+        """
+        ai_root = tmp_path / "ai"
+        cuttlefish_root = tmp_path / "cuttlefish"
+        ai_root.mkdir()
+        cuttlefish_root.mkdir()
+
+        # cwd is deliberately inside the ai repo so cwd-matching would pick
+        # "ai" if the CLI fell back to it. The --project-key flag must win.
+        monkeypatch.chdir(ai_root)
+
+        projects_json = {
+            "ai": {"working_directory": str(ai_root)},
+            "cuttlefish": {
+                "working_directory": str(cuttlefish_root),
+                "chat_id": 42,
+            },
+        }
+        captured: dict = {}
+
+        async def fake_push(**kwargs):
+            captured.update(kwargs)
+
+        # Worktree creation would call git — stub it and just return a path
+        # under the mocked cuttlefish root.
+        wt_path = cuttlefish_root / ".worktrees" / "sdlc-290"
+        wt_path.mkdir(parents=True)
+
+        with (
+            patch(
+                "bridge.routing.load_config",
+                return_value={"projects": projects_json, "defaults": {}},
+            ),
+            patch(
+                "agent.worktree_manager.get_or_create_worktree",
+                return_value=wt_path,
+            ) as mock_wt,
+            patch("agent.worktree_manager._validate_slug"),
+            patch("agent.agent_session_queue._push_agent_session", side_effect=fake_push),
+            patch("tools.valor_session._check_worker_health", return_value=(True, 1)),
+        ):
+            rc = cmd_create(_make_args(project_key="cuttlefish"))
+
+        assert rc == 0
+        # working_dir MUST be rooted under cuttlefish, not ai.
+        assert captured["working_dir"] == str(wt_path)
+        assert "cuttlefish" in captured["working_dir"]
+        assert str(ai_root) not in captured["working_dir"]
+        # project_key travels as set; project_config is the raw projects dict entry.
+        assert captured["project_key"] == "cuttlefish"
+        assert captured["project_config"] == projects_json["cuttlefish"]
+        # get_or_create_worktree was called with the PROJECT root, not cwd.
+        assert mock_wt.call_args.args[0] == cuttlefish_root
+
+    def test_no_slug_uses_repo_root_as_working_dir(self, tmp_path, monkeypatch):
+        """Dev session without --slug gets the project repo_root as working_dir,
+        not the cwd and not a worktree.
+        """
+        demo_root = tmp_path / "demo"
+        demo_root.mkdir()
+        monkeypatch.chdir(tmp_path)  # cwd is unrelated
+
+        projects_json = {"demo": {"working_directory": str(demo_root)}}
+        captured: dict = {}
+
+        async def fake_push(**kwargs):
+            captured.update(kwargs)
+
+        with (
+            patch(
+                "bridge.routing.load_config",
+                return_value={"projects": projects_json, "defaults": {}},
+            ),
+            patch("agent.agent_session_queue._push_agent_session", side_effect=fake_push),
+            patch("tools.valor_session._check_worker_health", return_value=(True, 1)),
+        ):
+            rc = cmd_create(_make_args(role="dev", project_key="demo", message="fix typo"))
+
+        assert rc == 0
+        assert captured["working_dir"] == str(demo_root)
+        assert captured["slug"] is None
+
+
+# ---------------------------------------------------------------------------
+# --working-dir flag: argparse must reject it outright
+# ---------------------------------------------------------------------------
+
+
+class TestWorkingDirFlagRemoved:
+    def test_argparse_rejects_working_dir_flag(self, capsys):
+        """Passing ``--working-dir`` via the real CLI entry point must exit
+        non-zero with an "unrecognized arguments" error.
+
+        We drive the actual parser (not cmd_create directly) to verify the
+        flag is absent at the argparse surface.
+        """
+        from tools.valor_session import main as valor_session_main
+
+        test_argv = [
+            "valor-session",
+            "create",
+            "--role",
+            "pm",
+            "--slug",
+            "some-slug",
+            "--message",
+            "hi",
+            "--working-dir",
+            "/any/path",
+        ]
+        with patch("sys.argv", test_argv):
+            with pytest.raises(SystemExit) as excinfo:
+                valor_session_main()
+        assert excinfo.value.code != 0
+        err = capsys.readouterr().err
+        assert "unrecognized arguments" in err or "--working-dir" in err
+
+
+# ---------------------------------------------------------------------------
+# Parent inheritance: copies project_key, re-derives working_dir
+# ---------------------------------------------------------------------------
+
+
+class TestParentInheritance:
+    def test_parent_inherits_project_key_only(self, tmp_path, monkeypatch):
+        """--parent <id> without --project-key inherits ``project_key`` from the
+        parent. ``working_dir`` is re-derived from the (inherited) key's
+        project entry — it is NOT copied from ``parent.working_dir``.
+        """
+        parent_project_root = tmp_path / "parent_proj"
+        parent_project_root.mkdir()
+
+        # The parent session exists in a different on-disk path (e.g. a
+        # worktree) — this must NOT propagate to the child. Only project_key
+        # propagates; working_dir is re-derived.
+        parent_working_dir_on_disk = parent_project_root / ".worktrees" / "parent-wt"
+        parent_working_dir_on_disk.mkdir(parents=True)
+
+        fake_parent = MagicMock()
+        fake_parent.project_key = "parent_proj"
+        fake_parent.agent_session_id = "parent-uuid-123"
+        fake_parent.working_dir = str(parent_working_dir_on_disk)
+
+        projects_json = {
+            "parent_proj": {"working_directory": str(parent_project_root)},
+        }
+        captured: dict = {}
+
+        async def fake_push(**kwargs):
+            captured.update(kwargs)
+
+        child_wt = parent_project_root / ".worktrees" / "sdlc-999"
+        child_wt.mkdir(parents=True)
+
+        with (
+            patch(
+                "bridge.routing.load_config",
+                return_value={"projects": projects_json, "defaults": {}},
+            ),
+            patch(
+                "tools.valor_session._find_session",
+                return_value=fake_parent,
+            ),
+            patch(
+                "agent.worktree_manager.get_or_create_worktree",
+                return_value=child_wt,
+            ),
+            patch("agent.worktree_manager._validate_slug"),
+            patch("agent.agent_session_queue._push_agent_session", side_effect=fake_push),
+            patch("tools.valor_session._check_worker_health", return_value=(True, 1)),
+        ):
+            rc = cmd_create(
+                _make_args(
+                    parent="parent-uuid-123",
+                    project_key=None,
+                    message="Child session for issue #999",
+                )
+            )
+
+        assert rc == 0
+        # Inherited from parent.
+        assert captured["project_key"] == "parent_proj"
+        # working_dir is re-derived from projects.json — NOT copied from
+        # parent.working_dir.
+        assert captured["working_dir"] == str(child_wt)
+        assert captured["working_dir"] != fake_parent.working_dir
+
+    def test_parent_not_found_falls_through_to_cwd_resolution(self, tmp_path, monkeypatch):
+        """A typo in --parent (session not found) must not hard-fail creation
+        if cwd can still resolve to a project. Parent inheritance is advisory.
+        """
+        proj_root = tmp_path / "proj"
+        proj_root.mkdir()
+        monkeypatch.chdir(proj_root)  # cwd matches the project
+
+        projects_json = {"proj": {"working_directory": str(proj_root)}}
+        captured: dict = {}
+
+        async def fake_push(**kwargs):
+            captured.update(kwargs)
+
+        with (
+            patch(
+                "bridge.routing.load_config",
+                return_value={"projects": projects_json, "defaults": {}},
+            ),
+            patch("tools.valor_session._find_session", return_value=None),
+            patch("agent.agent_session_queue._push_agent_session", side_effect=fake_push),
+            patch("tools.valor_session._check_worker_health", return_value=(True, 1)),
+        ):
+            rc = cmd_create(
+                _make_args(
+                    role="dev",  # dev so no --slug required
+                    parent="nonexistent-uuid",
+                    project_key=None,
+                    message="whatever",
+                )
+            )
+
+        assert rc == 0
+        assert captured["project_key"] == "proj"
+
+
+# ---------------------------------------------------------------------------
+# Error surfaces: unmatched cwd / unknown key produce clear messages
+# ---------------------------------------------------------------------------
+
+
+class TestErrorSurfaces:
+    def test_unmatched_cwd_no_flag_exits_nonzero(self, tmp_path, monkeypatch, capsys):
+        """cwd matches no project and --project-key not given → exit 1, stderr
+        names the cwd and lists available keys.
+        """
+        proj_root = tmp_path / "proj"
+        proj_root.mkdir()
+        unrelated_cwd = tmp_path / "unrelated"
+        unrelated_cwd.mkdir()
+        monkeypatch.chdir(unrelated_cwd)
+
+        projects_json = {"proj": {"working_directory": str(proj_root)}}
+
+        with (
+            patch(
+                "bridge.routing.load_config",
+                return_value={"projects": projects_json, "defaults": {}},
+            ),
+            patch("agent.agent_session_queue._push_agent_session"),
+            patch("tools.valor_session._check_worker_health", return_value=(True, 1)),
+        ):
+            rc = cmd_create(_make_args(role="dev", project_key=None, message="hi"))
+
+        assert rc != 0
+        err = capsys.readouterr().err
+        assert str(unrelated_cwd) in err
+        assert "proj" in err  # available key listed
+        assert "--project-key" in err  # remediation suggested
+
+    def test_unknown_project_key_exits_nonzero(self, tmp_path, monkeypatch, capsys):
+        """--project-key naming a key not in projects.json → exit 1 with clear
+        message including the available keys.
+        """
+        proj_root = tmp_path / "proj"
+        proj_root.mkdir()
+
+        projects_json = {"proj": {"working_directory": str(proj_root)}}
+
+        with (
+            patch(
+                "bridge.routing.load_config",
+                return_value={"projects": projects_json, "defaults": {}},
+            ),
+            patch("agent.agent_session_queue._push_agent_session"),
+            patch("tools.valor_session._check_worker_health", return_value=(True, 1)),
+        ):
+            rc = cmd_create(_make_args(role="dev", project_key="nonexistent", message="hi"))
+
+        assert rc != 0
+        err = capsys.readouterr().err
+        assert "nonexistent" in err
+        assert "proj" in err
+
+    def test_load_config_failure_exits_nonzero(self, tmp_path, monkeypatch, capsys):
+        """When load_config itself raises, the CLI exits 1 with a
+        ProjectsConfigUnavailableError-style message.
+        """
+        with (
+            patch(
+                "bridge.routing.load_config",
+                side_effect=OSError("projects.json permission denied"),
+            ),
+            patch("agent.agent_session_queue._push_agent_session"),
+            patch("tools.valor_session._check_worker_health", return_value=(True, 1)),
+        ):
+            rc = cmd_create(_make_args(role="dev", project_key="anything", message="hi"))
+
+        assert rc != 0
+        err = capsys.readouterr().err
+        assert "projects.json" in err
+        assert "permission denied" in err
+
+
+# ---------------------------------------------------------------------------
+# Anti-regression grep checks on the source file
+# ---------------------------------------------------------------------------
+
+
+class TestAntiRegressionGreps:
+    """Runs ``grep`` against the real source to catch re-introductions of the
+    silent fallback or the removed flag. Uses pathlib-derived absolute paths
+    so the test is portable across machines (e.g. /Users/tomcounsell vs
+    /Users/valorengels).
+    """
+
+    @staticmethod
+    def _valor_session_path() -> Path:
+        # tests/unit/this_file.py → parents[0]=unit, [1]=tests, [2]=repo_root
+        return Path(__file__).resolve().parents[2] / "tools" / "valor_session.py"
+
+    def test_no_working_dir_flag(self):
+        """``tools/valor_session.py`` must not mention ``--working-dir`` anywhere
+        (comments included — the flag is gone, no legacy traces)."""
+        path = self._valor_session_path()
+        result = subprocess.run(
+            ["grep", "-n", "--", "--working-dir", str(path)],
+            capture_output=True,
+            text=True,
+        )
+        # grep exit 1 == no match (the desired outcome).
+        assert result.returncode == 1, f"--working-dir still present in {path}:\n{result.stdout}"
+
+    def test_no_return_valor_fallback(self):
+        """No ``return "valor"`` (or ``return 'valor'``) in the source.
+
+        The silent fallback was removed; any literal ``return "valor"`` would
+        indicate a regression.
+        """
+        path = self._valor_session_path()
+        # Two patterns: double-quoted and single-quoted
+        for needle in ('return "valor"', "return 'valor'"):
+            result = subprocess.run(
+                ["grep", "-n", needle, str(path)],
+                capture_output=True,
+                text=True,
+            )
+            assert result.returncode == 1, f"Found {needle!r} in {path}:\n{result.stdout}"
+
+    def test_no_default_valor_in_resolver(self):
+        """No ``default="valor"`` (or ``default='valor'``) in the source."""
+        path = self._valor_session_path()
+        result = subprocess.run(
+            ["grep", "-nE", r'default\s*=\s*["\']valor["\']', str(path)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1, f'Found default="valor" pattern in {path}:\n{result.stdout}'

--- a/tests/unit/test_valor_session_working_dir_resolution.py
+++ b/tests/unit/test_valor_session_working_dir_resolution.py
@@ -427,3 +427,233 @@ class TestAntiRegressionGreps:
             text=True,
         )
         assert result.returncode == 1, f'Found default="valor" pattern in {path}:\n{result.stdout}'
+
+
+# ---------------------------------------------------------------------------
+# Stdout cleanliness on error: --json callers must see an empty stdout when
+# cmd_create fails, so a consumer parsing stdout as JSON does not get polluted
+# error text.
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPathWritesToStderrOnly:
+    """Plan's Failure Path Test Strategy (#1158):
+    > All new error paths write to stderr, preserving stdout for --json.
+
+    cmd_create's error branch (``print(f"Error: {e}", file=sys.stderr)``) must
+    never leak to stdout. This test drives the three new error paths and
+    asserts stdout is exactly empty on each.
+    """
+
+    def test_unmatched_cwd_writes_only_to_stderr(self, tmp_path, monkeypatch, capsys):
+        """Unmatched cwd with no --project-key: stderr populated, stdout empty."""
+        proj_root = tmp_path / "proj"
+        proj_root.mkdir()
+        unrelated_cwd = tmp_path / "unrelated"
+        unrelated_cwd.mkdir()
+        monkeypatch.chdir(unrelated_cwd)
+
+        projects_json = {"proj": {"working_directory": str(proj_root)}}
+
+        with (
+            patch(
+                "bridge.routing.load_config",
+                return_value={"projects": projects_json, "defaults": {}},
+            ),
+            patch("agent.agent_session_queue._push_agent_session"),
+            patch("tools.valor_session._check_worker_health", return_value=(True, 1)),
+        ):
+            rc = cmd_create(_make_args(role="dev", project_key=None, message="hi"))
+
+        assert rc != 0
+        cap = capsys.readouterr()
+        # stdout MUST be empty — it is reserved for --json output on success.
+        assert cap.out == "", f"Expected empty stdout, got: {cap.out!r}"
+        # stderr carries the user-facing error.
+        assert cap.err != ""
+
+    def test_unknown_project_key_writes_only_to_stderr(self, tmp_path, capsys):
+        """--project-key naming a missing key: stderr populated, stdout empty."""
+        proj_root = tmp_path / "proj"
+        proj_root.mkdir()
+        projects_json = {"proj": {"working_directory": str(proj_root)}}
+
+        with (
+            patch(
+                "bridge.routing.load_config",
+                return_value={"projects": projects_json, "defaults": {}},
+            ),
+            patch("agent.agent_session_queue._push_agent_session"),
+            patch("tools.valor_session._check_worker_health", return_value=(True, 1)),
+        ):
+            rc = cmd_create(_make_args(role="dev", project_key="nonexistent", message="hi"))
+
+        assert rc != 0
+        cap = capsys.readouterr()
+        assert cap.out == "", f"Expected empty stdout, got: {cap.out!r}"
+        assert cap.err != ""
+
+    def test_load_config_failure_writes_only_to_stderr(self, capsys):
+        """When load_config itself raises: stderr populated, stdout empty."""
+        with (
+            patch(
+                "bridge.routing.load_config",
+                side_effect=OSError("projects.json permission denied"),
+            ),
+            patch("agent.agent_session_queue._push_agent_session"),
+            patch("tools.valor_session._check_worker_health", return_value=(True, 1)),
+        ):
+            rc = cmd_create(_make_args(role="dev", project_key="anything", message="hi"))
+
+        assert rc != 0
+        cap = capsys.readouterr()
+        assert cap.out == "", f"Expected empty stdout, got: {cap.out!r}"
+        assert cap.err != ""
+
+
+# ---------------------------------------------------------------------------
+# Three-level PM chain: PM → PM → Dev in project X — all levels carry
+# consistent project_key AND working_dir rooted inside X.
+# ---------------------------------------------------------------------------
+
+
+class TestThreeLevelPMChain:
+    """Plan's Success Criteria (#1158):
+    > Regression test: three-level PM chain in project X → all levels carry
+    > consistent project_key and working_dir rooted inside X.
+
+    Drives three cmd_create invocations:
+      - level 1 (root PM) — explicit --project-key demo
+      - level 2 (PM spawned by PM) — --parent <level1_uuid>, inherits project_key
+      - level 3 (Dev spawned by level 2) — --parent <level2_uuid>, inherits project_key
+
+    Each level's working_dir must be rooted under ``/.../demo/``.
+    """
+
+    def test_pm_pm_dev_chain_all_rooted_in_project(self, tmp_path, monkeypatch):
+        demo_root = tmp_path / "demo"
+        demo_root.mkdir()
+        unrelated_cwd = tmp_path / "unrelated"
+        unrelated_cwd.mkdir()
+        monkeypatch.chdir(unrelated_cwd)  # cwd deliberately doesn't match demo
+
+        projects_json = {"demo": {"working_directory": str(demo_root)}}
+
+        # Per-level captured kwargs passed to _push_agent_session.
+        captured_per_level: list[dict] = []
+
+        async def fake_push(**kwargs):
+            captured_per_level.append(dict(kwargs))
+
+        # Worktree paths — each slug gets its own directory under demo_root.
+        wt_level1 = demo_root / ".worktrees" / "sdlc-100"
+        wt_level1.mkdir(parents=True)
+        wt_level2 = demo_root / ".worktrees" / "sdlc-101"
+        wt_level2.mkdir(parents=True)
+
+        def fake_worktree(root, slug):
+            if slug == "sdlc-100":
+                return wt_level1
+            if slug == "sdlc-101":
+                return wt_level2
+            raise AssertionError(f"Unexpected slug: {slug}")
+
+        # Level-1 PM creation — explicit project_key, cwd unrelated.
+        with (
+            patch(
+                "bridge.routing.load_config",
+                return_value={"projects": projects_json, "defaults": {}},
+            ),
+            patch(
+                "agent.worktree_manager.get_or_create_worktree",
+                side_effect=fake_worktree,
+            ),
+            patch("agent.worktree_manager._validate_slug"),
+            patch("agent.agent_session_queue._push_agent_session", side_effect=fake_push),
+            patch("tools.valor_session._check_worker_health", return_value=(True, 1)),
+        ):
+            rc1 = cmd_create(
+                _make_args(
+                    role="pm",
+                    project_key="demo",
+                    message="Run SDLC on issue #100",
+                )
+            )
+        assert rc1 == 0
+        level1 = captured_per_level[-1]
+        level1_uuid = "level1-uuid-abc"
+
+        # Level-2 PM creation — inherits via --parent; parent returns project_key="demo".
+        fake_parent_level1 = MagicMock()
+        fake_parent_level1.project_key = "demo"
+        fake_parent_level1.agent_session_id = level1_uuid
+
+        with (
+            patch(
+                "bridge.routing.load_config",
+                return_value={"projects": projects_json, "defaults": {}},
+            ),
+            patch("tools.valor_session._find_session", return_value=fake_parent_level1),
+            patch(
+                "agent.worktree_manager.get_or_create_worktree",
+                side_effect=fake_worktree,
+            ),
+            patch("agent.worktree_manager._validate_slug"),
+            patch("agent.agent_session_queue._push_agent_session", side_effect=fake_push),
+            patch("tools.valor_session._check_worker_health", return_value=(True, 1)),
+        ):
+            rc2 = cmd_create(
+                _make_args(
+                    role="pm",
+                    parent=level1_uuid,
+                    project_key=None,
+                    message="Run SDLC on issue #101",
+                )
+            )
+        assert rc2 == 0
+        level2 = captured_per_level[-1]
+        level2_uuid = "level2-uuid-def"
+
+        # Level-3 Dev creation — inherits via --parent, no slug (Dev default).
+        fake_parent_level2 = MagicMock()
+        fake_parent_level2.project_key = "demo"
+        fake_parent_level2.agent_session_id = level2_uuid
+
+        with (
+            patch(
+                "bridge.routing.load_config",
+                return_value={"projects": projects_json, "defaults": {}},
+            ),
+            patch("tools.valor_session._find_session", return_value=fake_parent_level2),
+            patch("agent.agent_session_queue._push_agent_session", side_effect=fake_push),
+            patch("tools.valor_session._check_worker_health", return_value=(True, 1)),
+        ):
+            rc3 = cmd_create(
+                _make_args(
+                    role="dev",
+                    parent=level2_uuid,
+                    project_key=None,
+                    message="implement feature",
+                )
+            )
+        assert rc3 == 0
+        level3 = captured_per_level[-1]
+
+        # All three levels carry the SAME project_key.
+        assert level1["project_key"] == "demo"
+        assert level2["project_key"] == "demo"
+        assert level3["project_key"] == "demo"
+
+        # All three working_dirs are rooted inside demo_root.
+        demo_str = str(demo_root)
+        assert level1["working_dir"].startswith(demo_str)
+        assert level2["working_dir"].startswith(demo_str)
+        assert level3["working_dir"].startswith(demo_str)
+
+        # Level-3 has no slug so working_dir IS the demo_root (no worktree).
+        assert level3["working_dir"] == demo_str
+
+        # project_config also travels consistently with the project dict.
+        assert level1["project_config"] == projects_json["demo"]
+        assert level2["project_config"] == projects_json["demo"]
+        assert level3["project_config"] == projects_json["demo"]

--- a/tools/sdlc_session_ensure.py
+++ b/tools/sdlc_session_ensure.py
@@ -119,12 +119,25 @@ def ensure_session(issue_number: int, issue_url: str | None = None) -> dict:
         if issue_url:
             kwargs["issue_url"] = issue_url
 
-        from tools.valor_session import resolve_project_key
+        from tools.valor_session import (
+            ProjectKeyResolutionError,
+            ProjectsConfigUnavailableError,
+            _resolve_project_working_directory,
+            resolve_project_key,
+        )
+
+        # Resolve project_key from cwd (raises if unmatched — caught below by
+        # the broad except Exception, which returns {} for idempotent failure).
+        project_key = resolve_project_key(os.getcwd())
+        # Derive working_dir from projects.json, NOT os.getcwd(). This enforces
+        # the immutable project→repo pairing: the session runs in the repo
+        # declared for its project_key, not wherever the caller happens to be.
+        repo_root, _ = _resolve_project_working_directory(project_key)
 
         session = AgentSession.create_local(
             session_id=local_session_id,
-            project_key=resolve_project_key(os.getcwd()),
-            working_dir=os.getcwd(),
+            project_key=project_key,
+            working_dir=str(repo_root),
             session_type="pm",
             **kwargs,
         )
@@ -141,7 +154,14 @@ def ensure_session(issue_number: int, issue_url: str | None = None) -> dict:
         return {"session_id": local_session_id, "created": True}
 
     except Exception as e:
-        logger.debug(f"sdlc_session_ensure: ensure_session failed: {e}")
+        # ProjectKeyResolutionError and ProjectsConfigUnavailableError both
+        # land here intentionally — if the project→repo pairing can't be
+        # resolved, we return {} rather than creating a mis-scoped session.
+        logger.debug(
+            "sdlc_session_ensure: ensure_session failed: %s (%s)",
+            e,
+            type(e).__name__,
+        )
         return {}
 
 

--- a/tools/valor_session.py
+++ b/tools/valor_session.py
@@ -21,14 +21,20 @@ Usage:
     valor-session kill --all
 
 Project Key Resolution (for `create` subcommand):
-    The project_key is derived automatically from the current working directory by
-    matching against the working_directory field of each project in projects.json.
-    The most-specific match (longest path prefix) wins.
+    ``project_key`` is the only input that ties a session to a repo. The on-disk
+    path (``working_dir``) is always *derived* from
+    ``projects.json[project_key].working_directory`` — never supplied
+    independently. There is no working-directory override flag.
 
-    If no match is found, "valor" is used as the fallback and a warning is printed
-    to stderr so it doesn't pollute --json output.
+    Resolution precedence:
+        1. ``--project-key <key>`` (explicit flag)
+        2. ``--parent <id>`` inherits ``project_key`` from the parent session
+        3. ``resolve_project_key(os.getcwd())`` — matches cwd against
+           ``projects.json``; raises ``ProjectKeyResolutionError`` on no match
+           (no silent "valor" fallback)
 
-    Use --project-key to override resolution explicitly (useful in scripts/CI).
+    If none of the above yield a key, the CLI exits non-zero with an error
+    naming the cwd and listing the available project keys.
 
 This tool is the external interface for session steering. It writes to
 AgentSession.queued_steering_messages (via steer_session()) and manages
@@ -118,33 +124,88 @@ def _check_worker_health() -> tuple[bool, int | None]:
         return (False, None)
 
 
+class ProjectsConfigUnavailableError(RuntimeError):
+    """Raised when ``bridge.routing.load_config()`` cannot be loaded.
+
+    This means no project→repo pairing is available at all. The caller cannot
+    fall back — there is no "default" project under the immutable-pairing rule.
+    """
+
+
+class ProjectKeyResolutionError(ValueError):
+    """Raised when no ``project_key`` can be resolved from inputs.
+
+    Fired when:
+    - ``resolve_project_key(cwd)`` is called with a ``cwd`` that matches no
+      project ``working_directory`` in ``projects.json``.
+    - ``_resolve_project_working_directory(key)`` is called with a key that is
+      not in ``projects.json`` or whose project entry has no
+      ``working_directory``.
+
+    The ``str(exception)`` form carries a user-oriented message (cwd, available
+    keys, suggested remediation) because ``cmd_create``'s broad ``except
+    Exception`` is the surface the user ultimately sees.
+    """
+
+    def __init__(
+        self,
+        *,
+        cwd: str | None = None,
+        project_key: str | None = None,
+        available_keys: list[str] | None = None,
+        detail: str | None = None,
+    ):
+        self.cwd = cwd
+        self.project_key = project_key
+        self.available_keys = available_keys or []
+        self.detail = detail
+        if cwd is not None:
+            msg = (
+                f"cwd {cwd!r} does not match any project in projects.json. "
+                f"Available keys: {self.available_keys}. "
+                f"Pass --project-key <key> explicitly."
+            )
+        elif project_key is not None:
+            msg = (
+                f"project_key {project_key!r} is not in projects.json or has no "
+                f"working_directory set. Available keys: {self.available_keys}."
+            )
+            if detail:
+                msg += f" ({detail})"
+        else:
+            msg = detail or "project_key could not be resolved"
+        super().__init__(msg)
+
+
 def resolve_project_key(cwd: str) -> str:
-    """Derive the project_key from cwd by matching against projects.json.
+    """Derive the ``project_key`` from ``cwd`` by matching ``projects.json``.
 
-    Loads projects.json via bridge.routing.load_config(), iterates the projects
-    dict, and returns the key whose working_directory equals or is a parent of
-    cwd. When multiple projects match (overlapping paths), the most specific
-    match (longest working_directory path) wins.
-
-    Falls back to "valor" and prints a warning to stderr if no match is found
-    or if projects.json is unavailable.
+    Loads ``projects.json`` via ``bridge.routing.load_config()``, iterates the
+    ``projects`` dict, and returns the key whose ``working_directory`` equals
+    or is a parent of ``cwd``. When multiple projects match (overlapping
+    paths), the most specific match (longest ``working_directory`` path) wins.
 
     Args:
         cwd: The current working directory to match against project paths.
 
     Returns:
-        The matching project key, or "valor" if no match is found.
+        The matching project key.
+
+    Raises:
+        ProjectsConfigUnavailableError: If ``load_config()`` itself raises
+            (missing file, unreadable, etc.). There is no silent fallback —
+            without ``projects.json`` there is no defined project→repo pairing.
+        ProjectKeyResolutionError: If no project's ``working_directory`` is an
+            ancestor of (or equal to) ``cwd``. The message names ``cwd`` and
+            lists the available keys so the caller knows what to pass as
+            ``--project-key``.
     """
     try:
         from bridge.routing import load_config
 
         config = load_config()
     except Exception as e:
-        print(
-            f"Warning: could not load projects.json ({e}), using project_key='valor'",
-            file=sys.stderr,
-        )
-        return "valor"
+        raise ProjectsConfigUnavailableError(f"could not load projects.json: {e}") from e
 
     cwd_path = Path(cwd).resolve()
     best_key: str | None = None
@@ -168,12 +229,57 @@ def resolve_project_key(cwd: str) -> str:
     if best_key is not None:
         return best_key
 
-    print(
-        f"Warning: current directory {cwd!r} does not match any project in projects.json, "
-        "using project_key='valor'",
-        file=sys.stderr,
-    )
-    return "valor"
+    raise ProjectKeyResolutionError(cwd=cwd, available_keys=sorted(projects.keys()))
+
+
+def _resolve_project_working_directory(project_key: str) -> tuple[Path, dict]:
+    """Return ``(repo_root_path, project_dict)`` for ``project_key``.
+
+    Loads ``projects.json`` once via ``bridge.routing.load_config()``, looks up
+    the project entry, expands ``working_directory`` to an absolute
+    ``pathlib.Path``, and returns both the path and the full project dict so the
+    caller can pass the dict as ``project_config=`` on the enqueue without a
+    second ``load_config()`` call.
+
+    Args:
+        project_key: Key into ``projects.json[projects]``. Must be an exact
+            match (no fuzzy resolution).
+
+    Returns:
+        Tuple of:
+          - ``Path``: absolute, user-expanded path to the project's repo root.
+          - ``dict``: the raw project entry from ``projects.json``. Pass this
+            unchanged to ``_push_agent_session(..., project_config=...)`` so
+            CLI-created sessions carry the same payload as bridge-created
+            sessions (PR #685).
+
+    Raises:
+        ProjectsConfigUnavailableError: If ``load_config()`` itself raises.
+        ProjectKeyResolutionError: If ``project_key`` is not in
+            ``projects.json`` or its entry has no ``working_directory``.
+    """
+    try:
+        from bridge.routing import load_config
+
+        config = load_config()
+    except Exception as e:
+        raise ProjectsConfigUnavailableError(f"could not load projects.json: {e}") from e
+
+    projects = config.get("projects", {})
+    project = projects.get(project_key)
+    if not project:
+        raise ProjectKeyResolutionError(
+            project_key=project_key,
+            available_keys=sorted(projects.keys()),
+        )
+    wd = project.get("working_directory", "")
+    if not wd:
+        raise ProjectKeyResolutionError(
+            project_key=project_key,
+            available_keys=sorted(projects.keys()),
+            detail="project entry has no working_directory",
+        )
+    return Path(wd).expanduser(), project
 
 
 def _format_ts(ts: str | float | None) -> str:
@@ -195,8 +301,10 @@ def _format_ts(ts: str | float | None) -> str:
 def cmd_create(args: argparse.Namespace) -> int:
     """Create a new AgentSession and enqueue it.
 
-    project_key is resolved from the current working directory via projects.json
-    unless --project-key is provided explicitly.
+    ``project_key`` determines the repo; ``working_dir`` is always derived from
+    ``projects.json[project_key].working_directory`` (optionally with a
+    ``.worktrees/{slug}/`` suffix). Callers who need a different repo pass a
+    different ``--project-key``.
     """
     _load_env()
     try:
@@ -241,13 +349,14 @@ def cmd_create(args: argparse.Namespace) -> int:
         ts_suffix = str(int(utc_now().timestamp() * 1000))
         session_id = f"{chat_id}_{ts_suffix}"
 
-        working_dir = args.working_dir or str(_repo_root)
-
-        # If --slug is provided, validate and provision worktree (issue #887).
-        # For PM-role sessions without --slug, auto-derive slug from "issue #N"
-        # in the message (issue #1109). This prevents PM sessions from inheriting
-        # the worker's current branch/worktree state. PM sessions with no issue
-        # reference and no --slug are refused with a clear error.
+        # ------------------------------------------------------------------
+        # Step 1: resolve PM slug BEFORE any project/working_dir work.
+        #
+        # PM auto-slug derivation is a pure function of ``message`` and MUST
+        # fire before worktree creation so that "PM without slug and without
+        # issue reference" can refuse (exit 1) without first having computed
+        # a project root or touching the filesystem.
+        # ------------------------------------------------------------------
         slug = getattr(args, "slug", None)
         if not slug and role == "pm":
             derived = _derive_slug_from_message(message)
@@ -267,20 +376,56 @@ def cmd_create(args: argparse.Namespace) -> int:
                 )
                 return 1
 
+        # ------------------------------------------------------------------
+        # Step 2: resolve project_key.
+        #
+        # Precedence: --project-key > --parent inheritance > cwd-match.
+        # No silent fallback — if all three fail, resolve_project_key raises
+        # ProjectKeyResolutionError, which propagates to the outer
+        # ``except Exception`` and returns exit 1 with a user-facing message.
+        # ------------------------------------------------------------------
+        explicit_key = getattr(args, "project_key", None)
+        project_key: str | None = None
+        if explicit_key:
+            project_key = explicit_key
+        elif parent_id:
+            # Parent inheritance: copy project_key from the parent session.
+            # If --parent points to a non-existent session, fall through to
+            # cwd-based resolution — a typo in --parent is a separate concern
+            # from mis-routing and should not hard-fail creation.
+            parent = _find_session(parent_id)
+            if parent is not None:
+                inherited_key = getattr(parent, "project_key", None)
+                if inherited_key:
+                    project_key = inherited_key
+                    parent_uuid = getattr(parent, "agent_session_id", parent_id)
+                    print(
+                        f"  Inherited project_key={project_key} from parent {parent_uuid}",
+                        file=sys.stderr,
+                    )
+        if project_key is None:
+            # Final fallback: cwd-based match. Raises ProjectKeyResolutionError
+            # on no match — no silent "valor" coercion.
+            project_key = resolve_project_key(os.getcwd())
+
+        # ------------------------------------------------------------------
+        # Step 3: derive repo_root and working_dir from project_key.
+        #
+        # The project dict returned here becomes project_config= on the
+        # enqueue so CLI-created sessions carry the same payload as
+        # bridge-created sessions (PR #685).
+        # ------------------------------------------------------------------
+        repo_root, project_config = _resolve_project_working_directory(project_key)
+
         if slug:
             from agent.worktree_manager import _validate_slug, get_or_create_worktree
 
             _validate_slug(slug)  # Raises ValueError for invalid slugs
-            wt_path = get_or_create_worktree(Path(working_dir), slug)
+            wt_path = get_or_create_worktree(repo_root, slug)
             working_dir = str(wt_path)
             print(f"  Worktree:    {working_dir}", file=sys.stderr)
-
-        # Resolve project_key: explicit flag takes priority, else derive from cwd
-        explicit_key = getattr(args, "project_key", None)
-        if explicit_key:
-            project_key = explicit_key
         else:
-            project_key = resolve_project_key(os.getcwd())
+            working_dir = str(repo_root)
 
         async def _create():
             await _push_agent_session(
@@ -295,6 +440,7 @@ def cmd_create(args: argparse.Namespace) -> int:
                 parent_agent_session_id=parent_id,
                 slug=slug,
                 model=model,
+                project_config=project_config,
             )
             return session_id
 
@@ -1044,13 +1190,15 @@ def main() -> int:
     )
     create_parser.add_argument("--chat-id", help="Telegram chat ID (default: 0)")
     create_parser.add_argument("--parent", help="Parent AgentSession ID (for child sessions)")
-    create_parser.add_argument("--working-dir", help="Working directory for the session")
     create_parser.add_argument(
         "--project-key",
         help=(
             "Explicit project key (overrides automatic cwd-based resolution). "
-            "If omitted, the key is derived from the current working directory "
-            "by matching against projects.json."
+            "If omitted, the key is derived from --parent (if set) or from the "
+            "current working directory by matching against projects.json. "
+            "On no match, the CLI exits with an error listing available keys. "
+            "The matched project's working_directory sets the session's "
+            "working_dir; there is no separate working-directory override flag."
         ),
     )
     create_parser.add_argument(


### PR DESCRIPTION
## Summary

Remove `--working-dir` flag and all silent `"valor"` fallbacks from the `valor-session` CLI. `project_key` is now the **only** input that ties a session to a repo; `working_dir` is always derived from `projects.json[project_key].working_directory`.

**Governing principle**: a project and a repo should not be provided separately. The local machine's configuration sets the pairing and that pairing cannot be broken.

## Changes

- **`tools/valor_session.py`**:
  - Remove `--working-dir` argparse flag entirely.
  - Add `ProjectKeyResolutionError(ValueError)` and `ProjectsConfigUnavailableError(RuntimeError)` exception classes with user-facing messages.
  - Tighten `resolve_project_key` — raises typed exceptions instead of silently returning `"valor"`.
  - Add `_resolve_project_working_directory(project_key) -> (Path, dict)` helper that loads `projects.json` once and returns both the expanded repo path and the full project dict for `project_config=` propagation (bridge parity per PR #685).
  - Rewrite `cmd_create` ordering: slug resolution → `project_key` resolution (explicit flag > parent inheritance > cwd match) → project dict → `repo_root` → `working_dir` (optionally the worktree under `repo_root`). No path ever originates from user input.
  - Parent inheritance copies `project_key` **only**; `working_dir` is always re-derived from the inherited key.

- **`tools/sdlc_session_ensure.py`**: derive `working_dir` from `projects.json`, not `os.getcwd()`. The existing broad `except Exception` continues to swallow typed errors and return `{}` (idempotent no-op).

- **`agent/reflection_scheduler.py`**: replace blanket `except Exception` with explicit `except (ProjectKeyResolutionError, ProjectsConfigUnavailableError)` + logged warning + `PROJECT_KEY` env-var fallback.

- **Tests**:
  - Rewrite `tests/unit/test_valor_session_project_key.py` to assert exceptions raise (no silent fallback), add coverage for the new helper.
  - Update `tests/unit/test_pm_session_auto_slug.py` and `tests/unit/test_pm_session_refuse_no_issue.py` — drop `working_dir` from namespace defaults; mock `_resolve_project_working_directory` to return a `(Path, dict)` tuple.
  - Update `tests/unit/test_valor_session_cli.py` — add `_resolve_project_working_directory` stubs.
  - Add `tests/unit/test_valor_session_working_dir_resolution.py` — covers explicit key override from an unrelated cwd, argparse rejection of `--working-dir`, parent inheritance (project_key only), error surfaces (unmatched cwd / unknown key / load-config failure), and anti-regression grep checks against the source file.

- **Docs**:
  - `docs/features/session-isolation.md`: new **CLI-level Project Scope Resolution** subsection documenting the precedence, typed errors, and enforcement surfaces.
  - `CLAUDE.md`: extend the `valor-session create` quick-command entries with the new precedence rule.

## Testing

- [x] 43 new/updated tests pass: `pytest tests/unit/test_valor_session_project_key.py tests/unit/test_pm_session_auto_slug.py tests/unit/test_pm_session_refuse_no_issue.py tests/unit/test_valor_session_cli.py tests/unit/test_valor_session_working_dir_resolution.py`
- [x] `tests/unit/test_reflection_scheduler.py` still passes (47/47)
- [x] `ruff format --check` clean on all modified files
- [x] No regressions in the broader unit suite attributable to this change (the 15 remaining parallel-run failures are pre-existing on `main` — email-bridge signature mismatches and flaky fixtures).

## Verification (Success Criteria from plan)

- [x] `grep -n 'return "valor"' tools/valor_session.py` → no match.
- [x] `grep -n -- '--working-dir' tools/valor_session.py` → no match.
- [x] `grep -nE 'default\s*=\s*"valor"' tools/valor_session.py` → no match.
- [x] `ProjectKeyResolutionError` and `ProjectsConfigUnavailableError` importable from `tools.valor_session`.
- [x] Unit tests verify parent-inheritance re-derives `working_dir` (does not copy from parent).
- [x] Unit tests verify `project_config` is populated on CLI-created sessions, matching bridge-parity.

## Definition of Done

- [x] Built: CLI flag surgery, helper addition, call-site migration, test rewrites
- [x] Tested: 43 focused tests passing, reflection scheduler suite green
- [x] Reviewed: anti-regression grep checks encoded in the test suite
- [x] Documented: `docs/features/session-isolation.md` + `CLAUDE.md`
- [x] Quality: `python -m ruff format --check` passes on all modified files

Closes #1158