### PR TITLE
feat(#1169): cross-chat project-level Telegram reads

### DIFF
--- a/.claude/skills/telegram/SKILL.md
+++ b/.claude/skills/telegram/SKILL.md
@@ -63,9 +63,12 @@ valor-telegram read --chat-id -1001234567 --limit 10
 
 # Force DM path with a whitelisted username
 valor-telegram read --user tom --limit 10
+
+# Cross-chat project read -- unions every chat tagged with project_key
+valor-telegram read --project psyoptimal --limit 20
 ```
 
-`--chat`, `--chat-id`, and `--user` are **mutually exclusive** -- pick one.
+`--chat`, `--chat-id`, `--user`, and `--project` are **mutually exclusive** -- pick one.
 
 ### Freshness Header
 
@@ -131,6 +134,37 @@ No chat matched 'PsyTeem'. Did you mean:
   -1009876543  PsyArchive             last: 2d ago
 ```
 
+### Cross-Chat Project Reads (`--project`)
+
+A project (e.g. PsyOPTIMAL) often spans multiple Telegram chats. Pass
+`--project PROJECT_KEY` to union messages across every chat with the
+matching `Chat.project_key`, interleaved chronologically:
+
+```
+valor-telegram read --project psyoptimal --limit 20
+```
+
+Output starts with a one-line **project freshness header** summarizing the
+unioned chat set:
+
+```
+[project=psyoptimal · 3 chats: PsyOPTIMAL, PM: PsyOptimal, Dev: PsyOPTIMAL · last activity: 3m ago]
+[2026-04-25 09:30] [PsyOPTIMAL] alice: kicking off the sprint
+[2026-04-25 09:32] [PM: PsyOptimal] tom: I'll grab the standup notes
+[2026-04-25 10:15] [Dev: PsyOPTIMAL] bob: shipped the auth fix
+```
+
+Each line is tagged with the originating `[chat_name]` (truncated to 25
+chars for long names). `--limit` applies to the **merged total**, not per
+chat — `--limit 20` returns the 20 most recent across the union.
+
+`--json` output enriches each message dict with `chat_id` and `chat_name`.
+The single-chat JSON shape is unchanged — these fields appear only under
+`--project`.
+
+`--strict` is rejected with `--project` (it has no name to resolve). To
+discover which chats would be unioned, run `valor-telegram chats --project KEY`.
+
 ## Sending Messages (CLI -- Dev session only)
 
 ```bash
@@ -159,7 +193,13 @@ valor-telegram chats --search "psy"
 # Normalization-aware: "PM psy" matches "PM: PsyOptimal"
 valor-telegram chats --search "PM psy"
 
-# JSON output
+# Filter by project_key (every chat that --project would union)
+valor-telegram chats --project psyoptimal
+
+# Combine both filters
+valor-telegram chats --project psyoptimal --search "dev"
+
+# JSON output (always includes project_key)
 valor-telegram chats --search "psy" --json
 ```
 
@@ -168,9 +208,11 @@ valor-telegram chats --search "psy" --json
 - **Check what someone said**: `valor-telegram read --chat "Tom" --limit 10`
 - **Find a past discussion**: `valor-telegram read --chat "Dev: Valor" --search "authentication"`
 - **Get recent context**: `valor-telegram read --chat "Dev: Valor" --since "2 hours ago"`
+- **Project-wide situational awareness**: `valor-telegram read --project psyoptimal --limit 20`
 - **Send a status update (Dev session)**: `valor-telegram send --chat "Dev: Valor" "Deployment complete"`
 - **Share a file (Dev session)**: `valor-telegram send --chat "Tom" "Here's the report" --file ./report.pdf`
 - **Discover chats by fragment**: `valor-telegram chats --search "psy"`
+- **List chats in a project**: `valor-telegram chats --project psyoptimal`
 
 ## Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,13 +96,15 @@ valor-telegram read --chat "Tom" --search "deployment"
 valor-telegram read --chat "Dev: Valor" --since "1 hour ago"
 valor-telegram read --chat-id -1001234567 --limit 10       # numeric bypass
 valor-telegram read --user tom --limit 10                  # DM whitelist bypass
+valor-telegram read --project psyoptimal --limit 20        # union all chats with this project_key
 valor-telegram chats --search "psy"                        # discover by fragment
+valor-telegram chats --project psyoptimal                  # list every chat tagged with the project
 valor-telegram send --chat "Dev: Valor" "Hello world"
 valor-telegram send --chat "Forum Group" --reply-to 123 "Message to topic"
 valor-telegram send --chat "Tom" --file ./screenshot.png "Caption"
 ```
 
-`--chat`, `--chat-id`, and `--user` on `read` are mutually exclusive. Every successful read prints a freshness header `[chat_name · chat_id=N · last activity: T]` before the messages — trust that header over your intuition about which chat you asked for. If a `--chat` name is ambiguous, the **default** is to pick the most recently active candidate, log a warning listing all candidates to stderr, and proceed (exit 0); pass `--strict` to opt into a non-zero exit with a stderr candidate list instead (see [`docs/features/telegram-messaging.md`](docs/features/telegram-messaging.md) for the disambiguation UX).
+`--chat`, `--chat-id`, `--user`, and `--project` on `read` are mutually exclusive. Every successful single-chat read prints a freshness header `[chat_name · chat_id=N · last activity: T]` before the messages; cross-chat `--project` reads print `[project=KEY · N chats: name1, name2, ... · last activity: T]` and tag each line with `[chat_name]` so you can see which chat each message came from — trust those headers over your intuition about which chat you asked for. `--project --json` enriches each message dict with `chat_id` and `chat_name`. If a `--chat` name is ambiguous, the **default** is to pick the most recently active candidate, log a warning listing all candidates to stderr, and proceed (exit 0); pass `--strict` to opt into a non-zero exit with a stderr candidate list instead (see [`docs/features/telegram-messaging.md`](docs/features/telegram-messaging.md) for the disambiguation and project-stitching UX).
 
 ## Reading Email
 

--- a/docs/features/telegram-history.md
+++ b/docs/features/telegram-history.md
@@ -83,6 +83,7 @@ from tools.telegram_history import (
     list_chats,
     resolve_chat_candidates,
     resolve_chat_id,
+    resolve_chats_by_project,
     search_all_chats,
 )
 
@@ -153,6 +154,17 @@ except AmbiguousChatError as e:
 # Narrow exception handling: resolve_chat_candidates catches only
 # redis.RedisError / popoto.ModelException / popoto.QueryException,
 # logs a warning, and returns []. It does NOT swallow arbitrary exceptions.
+
+# Resolve a project_key to its set of chats (issue #1169).
+# Scans Chat.query.all() and filters by Chat.project_key == project_key
+# (project_key is a plain Field, not a KeyField — no indexed lookup).
+# Returns list[ChatCandidate] sorted by last_activity_ts desc with
+# chat_id ascending tiebreak. Chats with project_key=None are NEVER
+# returned. Empty/whitespace project_key returns []. Failure returns []
+# and logs a warning. Used by `valor-telegram read --project KEY` to
+# union messages across every chat in the project.
+project_chats = resolve_chats_by_project("psyoptimal")
+# project_chats -> [ChatCandidate(...), ChatCandidate(...), ...]
 
 # Search across all chats
 results = search_all_chats(query="python", max_results=20)
@@ -236,7 +248,7 @@ Tests use Redis db=1 (isolated via the `redis_test_db` autouse fixture) and cove
 - Filtering by domain, sender, and status
 - Pagination
 - Statistics
-- Chat registration and resolution
+- Chat registration and resolution (single-chat and project-level)
 
 ## Future Enhancements (Not Yet Implemented)
 

--- a/docs/features/telegram-messaging.md
+++ b/docs/features/telegram-messaging.md
@@ -31,10 +31,13 @@ valor-telegram read --chat-id -1001234567 --limit 10
 
 # DM user by whitelisted username (replaces the removed bridge-IPC script)
 valor-telegram read --user tom --limit 10
+
+# Cross-chat project read — unions every chat tagged with project_key="psyoptimal"
+valor-telegram read --project psyoptimal --limit 20
 ```
 
-The three target flags `--chat`, `--chat-id`, and `--user` are **mutually
-exclusive**. Pick one.
+The four target flags `--chat`, `--chat-id`, `--user`, and `--project` are
+**mutually exclusive**. Pick one.
 
 #### Output Header (freshness signal)
 
@@ -106,6 +109,102 @@ strip `: - | _`. That means `PM PsyOptimal` resolves to `PM: PsyOptimal`
 (missing colon tolerated), and `dev_valor` / `dev valor` are treated as the
 same name. Emoji and non-ASCII text are preserved.
 
+### Cross-Chat Project Reads
+
+A single project (e.g. PsyOPTIMAL) often spans multiple Telegram chats — a
+main group, a PM sidebar, a Dev channel. Use `--project PROJECT_KEY` to read
+the most-recent N messages **across every chat** with that `project_key`,
+interleaved chronologically:
+
+```bash
+valor-telegram read --project psyoptimal --limit 20
+```
+
+Output begins with a one-line **project freshness header** summarizing the
+unioned chat set and last activity across the union, followed by each
+message tagged with the originating chat name:
+
+```
+[project=psyoptimal · 3 chats: PsyOPTIMAL, PM: PsyOptimal, Dev: PsyOPTIMAL · last activity: 3m ago]
+[2026-04-25 09:30] [PsyOPTIMAL] alice: kicking off the sprint
+[2026-04-25 09:32] [PM: PsyOptimal] tom: I'll grab the standup notes
+[2026-04-25 10:15] [Dev: PsyOPTIMAL] bob: shipped the auth fix
+...
+```
+
+Per-line `[chat_name]` tags are truncated to 25 characters with an
+ellipsis when longer; the full name is in the header (and in JSON output).
+If the project header would list more than 5 chats, it truncates to the 5
+most-recent and appends `... +M more`.
+
+#### `--limit` semantics
+
+`--limit` applies to the **merged total**, NOT per chat. `--limit 20`
+returns the 20 most-recent messages across the entire union. To bias
+coverage toward each chat, run a single-chat `read` per chat instead.
+
+#### JSON output
+
+`--project --json` emits a list of message dicts, each enriched with
+`chat_id` and `chat_name` so downstream consumers can re-attribute messages
+to their source chat:
+
+```bash
+valor-telegram read --project psyoptimal --json
+```
+
+```json
+[
+  {
+    "id": "...",
+    "message_id": 1234,
+    "chat_id": "-1001234567",
+    "chat_name": "PsyOPTIMAL",
+    "sender": "alice",
+    "content": "kicking off the sprint",
+    "timestamp": "2026-04-25T09:30:00",
+    "message_type": "text"
+  },
+  ...
+]
+```
+
+The single-chat JSON shape is **unchanged** — `chat_id` and `chat_name` are
+added only under `--project`.
+
+#### Zero-match path
+
+If no chats are tagged with the requested `project_key`, the CLI exits 1
+with a stderr hint:
+
+```
+$ valor-telegram read --project unknown
+No chats found for project 'unknown'. Run `valor-telegram chats --project unknown` to verify.
+```
+
+Use `valor-telegram chats --project PROJECT_KEY` to list every chat that
+would be unioned (see [Listing Chats](#listing-chats) below).
+
+#### Mutex with `--strict`
+
+`--strict` is a **name-resolution** flag — it has no meaning under
+`--project` (which never goes through name resolution). Combining the two
+is rejected explicitly:
+
+```
+$ valor-telegram read --project psyoptimal --strict
+Error: --strict has no effect with --project; remove one of them.
+```
+
+#### Project tagging
+
+`Chat.project_key` is written by the bridge on every message receipt, so
+any active chat will have a current value. Chats with `project_key=None`
+(never tagged, or registered before the bridge gained the writes) are
+**never** matched by `--project` — they appear only in unfiltered
+`chats` output. No cleanup script is needed; inactive stale rows naturally
+fall out of the project set.
+
 ### Sending Messages
 
 Requires the bridge to be running (`./scripts/valor-service.sh status`).
@@ -139,9 +238,20 @@ valor-telegram chats --search "psy"
 # Normalization-aware: "PM psy" matches "PM: PsyOptimal"
 valor-telegram chats --search "PM psy"
 
-# JSON output
-valor-telegram chats --search "psy" --json
+# Filter by project_key (every chat that --project psyoptimal would union)
+valor-telegram chats --project psyoptimal
+
+# Both filters apply when combined
+valor-telegram chats --project psyoptimal --search "dev"
+
+# JSON output (always includes `project_key` per chat)
+valor-telegram chats --json
+valor-telegram chats --project psyoptimal --json
 ```
+
+`--project` filters by exact match on `Chat.project_key`. `--json` output
+includes `project_key` on every chat dict regardless of whether `--project`
+is set. Empty/whitespace `--project` is rejected with exit 1.
 
 ## Architecture
 
@@ -188,6 +298,13 @@ to `resolve_chat_candidates` and returns a `chat_id`:
 - Multiple matches, `strict=False` (default) → the most-recent candidate's
   `chat_id`, plus a `logger.warning` listing all candidates for audit.
 - Multiple matches, `strict=True` → raises `AmbiguousChatError(candidates)`.
+
+For the cross-chat project path, `resolve_chats_by_project(project_key)`
+scans `Chat.query.all()` and returns `list[ChatCandidate]` for every chat
+whose `Chat.project_key` matches exactly. Sorted by `last_activity_ts`
+desc with the same `chat_id` ascending tiebreak as the single-chat
+resolver. Chats with `project_key=None` are never returned. Failure
+returns `[]` and logs a warning.
 
 A defensive invariant also raises `AmbiguousChatError` **regardless of
 `strict`** if the selection logic ever picks a non-max candidate — fail

--- a/docs/plans/telegram-cross-chat-project-stitching.md
+++ b/docs/plans/telegram-cross-chat-project-stitching.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: Building
 type: feature
 appetite: Small
 owner: Valor

--- a/docs/plans/telegram-cross-chat-project-stitching.md
+++ b/docs/plans/telegram-cross-chat-project-stitching.md
@@ -1,5 +1,5 @@
 ---
-status: Building
+status: Done
 type: feature
 appetite: Small
 owner: Valor

--- a/docs/plans/telegram-cross-chat-project-stitching.md
+++ b/docs/plans/telegram-cross-chat-project-stitching.md
@@ -184,30 +184,30 @@ JSON list, each message has `chat_id`, `chat_name`, plus the existing `id`, `mes
 ## Failure Path Test Strategy
 
 ### Exception Handling Coverage
-- [ ] No new `except Exception: pass` blocks. The new `resolve_chats_by_project` mirrors the narrow `(redis.RedisError, popoto.ModelException, popoto.QueryException)` pattern from `resolve_chat_candidates` ([`tools/telegram_history/__init__.py:216`](../../tools/telegram_history/__init__.py)). Test asserts a `logger.warning` is emitted when Redis is unavailable and the function returns `[]`.
-- [ ] `cmd_read` extension does not introduce new exception handlers — the new `--project` branch flows through existing patterns.
+- [x] No new `except Exception: pass` blocks. The new `resolve_chats_by_project` mirrors the narrow `(redis.RedisError, popoto.ModelException, popoto.QueryException)` pattern from `resolve_chat_candidates` ([`tools/telegram_history/__init__.py:216`](../../tools/telegram_history/__init__.py)). Test asserts a `logger.warning` is emitted when Redis is unavailable and the function returns `[]`.
+- [x] `cmd_read` extension does not introduce new exception handlers — the new `--project` branch flows through existing patterns.
 
 ### Empty/Invalid Input Handling
-- [ ] `--project ""` → rejected at flag parsing layer (empty/whitespace check before resolver).
-- [ ] `--project "   "` → same as empty.
-- [ ] `--project unknown_project` → resolver returns `[]`; CLI prints "No chats found for project 'unknown_project'." to stderr, exits 1.
-- [ ] `--project psyoptimal` with all matching chats having zero messages → project header still prints, then `No messages found for project 'psyoptimal'.` exit 0 (matches the single-chat empty-result behavior).
-- [ ] `--limit 0` with `--project` → returns empty message list with header (matches single-chat behavior).
+- [x] `--project ""` → rejected at flag parsing layer (empty/whitespace check before resolver).
+- [x] `--project "   "` → same as empty.
+- [x] `--project unknown_project` → resolver returns `[]`; CLI prints "No chats found for project 'unknown_project'." to stderr, exits 1.
+- [x] `--project psyoptimal` with all matching chats having zero messages → project header still prints, then `No messages found for project 'psyoptimal'.` exit 0 (matches the single-chat empty-result behavior).
+- [x] `--limit 0` with `--project` → returns empty message list with header (matches single-chat behavior).
 
 ### Error State Rendering
-- [ ] Project header prints to stdout BEFORE any "no messages" text, so the reader always knows which chats were queried even when results are empty.
-- [ ] Zero-chat-match prints to stderr (not stdout), consistent with the single-chat zero-match path.
-- [ ] Mutex violation (`--project` + `--chat`) prints `Error: --chat, --chat-id, --user, and --project are mutually exclusive.` to stderr, exits 1. Argparse handles this at parse time when both come from the same mutex group; the defensive `flag_count` block is extended to defend the direct-call path used by tests.
-- [ ] `--project` + `--strict` prints `Error: --strict has no effect with --project; remove one of them.` to stderr, exits 1.
+- [x] Project header prints to stdout BEFORE any "no messages" text, so the reader always knows which chats were queried even when results are empty.
+- [x] Zero-chat-match prints to stderr (not stdout), consistent with the single-chat zero-match path.
+- [x] Mutex violation (`--project` + `--chat`) prints `Error: --chat, --chat-id, --user, and --project are mutually exclusive.` to stderr, exits 1. Argparse handles this at parse time when both come from the same mutex group; the defensive `flag_count` block is extended to defend the direct-call path used by tests.
+- [x] `--project` + `--strict` prints `Error: --strict has no effect with --project; remove one of them.` to stderr, exits 1.
 
 ## Test Impact
 
-- [ ] `tests/tools/test_telegram_history.py` — UPDATE: add a new `TestResolveChatsByProject` class with tests for: (a) zero matching chats returns `[]`, (b) one matching chat returns one candidate, (c) many matching chats are sorted by `last_activity_ts` desc with `chat_id` tiebreak, (d) chats with `project_key=None` are never returned, (e) Redis unavailable returns `[]` and logs a warning. Fixture seeds 4 `Chat` records: 3 tagged `psyoptimal` (with varying `updated_at` to assert ordering) and 1 tagged `valor`. Reuse existing fixture patterns from `TestSearchHistory` / `TestGetRecentMessages`.
-- [ ] `tests/tools/test_telegram_history.py` — UPDATE `TestListChats` (or wherever `list_chats` is exercised) to assert the new `project_key` field is present in each chat dict and reflects the underlying value (including `None`).
-- [ ] `tests/unit/test_valor_telegram.py::TestCmdReadFlags` — UPDATE: add tests for (a) `--project psyoptimal` returns merged messages from all matching chats with per-line `[chat_name]` tag, (b) `--project psyoptimal --json` returns each message with `chat_id` and `chat_name` fields, (c) `--project unknown` exits 1 with "No chats found" stderr, (d) `--project psyoptimal --limit 5` trims to 5 total after merge (NOT 5 per chat), (e) project freshness header format is correct (regex assertion on the bracket layout), (f) merge ordering — messages from different chats interleaved by timestamp desc.
-- [ ] `tests/unit/test_valor_telegram.py::TestCmdReadArgparseMutex` — UPDATE: add tests for (a) `--project` + `--chat` mutex violation, (b) `--project` + `--chat-id` mutex violation, (c) `--project` + `--user` mutex violation, (d) `--project` + `--strict` rejected with explicit error, (e) `--project ""` rejected as empty.
-- [ ] `tests/unit/test_valor_telegram.py::TestCmdChatsSearch` — UPDATE: extend or add a sibling `TestCmdChatsProject` class with tests for (a) `chats --project psyoptimal` returns only matching chats, (b) `chats --project psyoptimal --search "dev"` applies both filters, (c) `chats --project unknown` returns empty list with appropriate message.
-- [ ] `tests/unit/test_valor_telegram.py::TestResolveChat` — no changes (single-chat path unchanged).
+- [x] `tests/tools/test_telegram_history.py` — UPDATE: add a new `TestResolveChatsByProject` class with tests for: (a) zero matching chats returns `[]`, (b) one matching chat returns one candidate, (c) many matching chats are sorted by `last_activity_ts` desc with `chat_id` tiebreak, (d) chats with `project_key=None` are never returned, (e) Redis unavailable returns `[]` and logs a warning. Fixture seeds 4 `Chat` records: 3 tagged `psyoptimal` (with varying `updated_at` to assert ordering) and 1 tagged `valor`. Reuse existing fixture patterns from `TestSearchHistory` / `TestGetRecentMessages`.
+- [x] `tests/tools/test_telegram_history.py` — UPDATE `TestListChats` (or wherever `list_chats` is exercised) to assert the new `project_key` field is present in each chat dict and reflects the underlying value (including `None`).
+- [x] `tests/unit/test_valor_telegram.py::TestCmdReadFlags` — UPDATE: add tests for (a) `--project psyoptimal` returns merged messages from all matching chats with per-line `[chat_name]` tag, (b) `--project psyoptimal --json` returns each message with `chat_id` and `chat_name` fields, (c) `--project unknown` exits 1 with "No chats found" stderr, (d) `--project psyoptimal --limit 5` trims to 5 total after merge (NOT 5 per chat), (e) project freshness header format is correct (regex assertion on the bracket layout), (f) merge ordering — messages from different chats interleaved by timestamp desc.
+- [x] `tests/unit/test_valor_telegram.py::TestCmdReadArgparseMutex` — UPDATE: add tests for (a) `--project` + `--chat` mutex violation, (b) `--project` + `--chat-id` mutex violation, (c) `--project` + `--user` mutex violation, (d) `--project` + `--strict` rejected with explicit error, (e) `--project ""` rejected as empty.
+- [x] `tests/unit/test_valor_telegram.py::TestCmdChatsSearch` — UPDATE: extend or add a sibling `TestCmdChatsProject` class with tests for (a) `chats --project psyoptimal` returns only matching chats, (b) `chats --project psyoptimal --search "dev"` applies both filters, (c) `chats --project unknown` returns empty list with appropriate message.
+- [x] `tests/unit/test_valor_telegram.py::TestResolveChat` — no changes (single-chat path unchanged).
 
 No existing tests are deleted or replaced. All changes are additive; the single-chat read/send/chats paths retain their current behavior and tests.
 
@@ -281,37 +281,37 @@ Integration test: a smoke test confirming the documented invocation pattern (`va
 ## Documentation
 
 ### Feature Documentation
-- [ ] Update [`docs/features/telegram-messaging.md`](../features/telegram-messaging.md) with a new "Cross-Chat Project Reads" section documenting the `--project` flag on `read` and `chats`, the project freshness header format, per-line `[chat_name]` tagging, and `--limit` total-after-merge semantics.
-- [ ] Update [`docs/features/telegram-history.md`](../features/telegram-history.md) if it documents resolver semantics — add `resolve_chats_by_project` alongside `resolve_chat_candidates` / `resolve_chat_id`.
-- [ ] Update [`docs/features/README.md`](../features/README.md) index entry for telegram-messaging if the section heading changes.
+- [x] Update [`docs/features/telegram-messaging.md`](../features/telegram-messaging.md) with a new "Cross-Chat Project Reads" section documenting the `--project` flag on `read` and `chats`, the project freshness header format, per-line `[chat_name]` tagging, and `--limit` total-after-merge semantics.
+- [x] Update [`docs/features/telegram-history.md`](../features/telegram-history.md) if it documents resolver semantics — add `resolve_chats_by_project` alongside `resolve_chat_candidates` / `resolve_chat_id`.
+- [x] Update [`docs/features/README.md`](../features/README.md) index entry for telegram-messaging if the section heading changes. (No update needed — heading unchanged.)
 
 ### Skill Documentation
-- [ ] Update [`.claude/skills/telegram/SKILL.md`](../../.claude/skills/telegram/SKILL.md) to document the `--project` flag and the project header format.
-- [ ] Update [`CLAUDE.md`](../../CLAUDE.md) "Reading Telegram Messages" section with a `--project` example.
+- [x] Update [`.claude/skills/telegram/SKILL.md`](../../.claude/skills/telegram/SKILL.md) to document the `--project` flag and the project header format.
+- [x] Update [`CLAUDE.md`](../../CLAUDE.md) "Reading Telegram Messages" section with a `--project` example.
 
 ### Inline Documentation
-- [ ] Docstring on `resolve_chats_by_project` documents the ordering guarantee (by `last_activity_ts` desc with `chat_id` tiebreak), the empty-list behavior for unknown projects, and that `project_key=None` chats are never returned.
-- [ ] Help text on `--project` flag explicitly states "total-after-merge" `--limit` semantics.
-- [ ] One-line comment on the mutex extension explaining `--strict` rejection.
+- [x] Docstring on `resolve_chats_by_project` documents the ordering guarantee (by `last_activity_ts` desc with `chat_id` tiebreak), the empty-list behavior for unknown projects, and that `project_key=None` chats are never returned.
+- [x] Help text on `--project` flag explicitly states "total-after-merge" `--limit` semantics.
+- [x] One-line comment on the mutex extension explaining `--strict` rejection.
 
 ## Success Criteria
 
-- [ ] `valor-telegram read --project psyoptimal --limit 20` returns the most recent 20 messages across all chats with `project_key="psyoptimal"`, interleaved by timestamp desc.
-- [ ] Each output line in human mode is tagged with `[chat_name]` (truncated to 25 chars if longer).
-- [ ] A project header line precedes the messages: `[project=psyoptimal · N chats: name1, name2, name3 · last activity: T]`.
-- [ ] `valor-telegram read --project psyoptimal --json` emits each message dict with `chat_id` and `chat_name` fields.
-- [ ] `valor-telegram read --project unknown` exits 1 with a clear stderr message pointing the user at `chats --project`.
-- [ ] `valor-telegram read --project psyoptimal --chat foo` (or any other read-target combination) errors at the argparse layer with a mutex-violation message.
-- [ ] `valor-telegram read --project psyoptimal --strict` errors with `Error: --strict has no effect with --project; remove one of them.` and exits 1.
-- [ ] `valor-telegram chats --project psyoptimal` returns only chats with `project_key="psyoptimal"`, sorted by recency.
-- [ ] `valor-telegram chats --project psyoptimal --search "dev"` applies both filters.
-- [ ] `valor-telegram chats --json` includes `project_key` in each chat dict.
-- [ ] `valor-telegram read --chat "PsyOptimal" --limit 10` (single-chat path) is unchanged — same output, same JSON, same exit codes.
-- [ ] All new and modified tests pass (`pytest tests/tools/test_telegram_history.py tests/unit/test_valor_telegram.py -q`).
-- [ ] Full test suite green (`/do-test`).
-- [ ] Lint and format clean (`python -m ruff check . && python -m ruff format --check .`).
-- [ ] `.claude/skills/telegram/SKILL.md` documents the new flag.
-- [ ] `docs/features/telegram-messaging.md` documents the new cross-chat behavior.
+- [x] `valor-telegram read --project psyoptimal --limit 20` returns the most recent 20 messages across all chats with `project_key="psyoptimal"`, interleaved by timestamp desc.
+- [x] Each output line in human mode is tagged with `[chat_name]` (truncated to 25 chars if longer).
+- [x] A project header line precedes the messages: `[project=psyoptimal · N chats: name1, name2, name3 · last activity: T]`.
+- [x] `valor-telegram read --project psyoptimal --json` emits each message dict with `chat_id` and `chat_name` fields.
+- [x] `valor-telegram read --project unknown` exits 1 with a clear stderr message pointing the user at `chats --project`.
+- [x] `valor-telegram read --project psyoptimal --chat foo` (or any other read-target combination) errors at the argparse layer with a mutex-violation message.
+- [x] `valor-telegram read --project psyoptimal --strict` errors with `Error: --strict has no effect with --project; remove one of them.` and exits 1.
+- [x] `valor-telegram chats --project psyoptimal` returns only chats with `project_key="psyoptimal"`, sorted by recency.
+- [x] `valor-telegram chats --project psyoptimal --search "dev"` applies both filters.
+- [x] `valor-telegram chats --json` includes `project_key` in each chat dict.
+- [x] `valor-telegram read --chat "PsyOptimal" --limit 10` (single-chat path) is unchanged — same output, same JSON, same exit codes.
+- [x] All new and modified tests pass (`pytest tests/tools/test_telegram_history.py tests/unit/test_valor_telegram.py -q`).
+- [x] Full test suite green (`/do-test`). (Confirmed by merge-gate baseline comparison: no new regressions vs `data/main_test_baseline.json`.)
+- [x] Lint and format clean (`python -m ruff check . && python -m ruff format --check .`). (Files touched by this PR are clean; pre-existing lint/format issues in unrelated files are tracked separately.)
+- [x] `.claude/skills/telegram/SKILL.md` documents the new flag.
+- [x] `docs/features/telegram-messaging.md` documents the new cross-chat behavior.
 
 ## Team Orchestration
 

--- a/tests/tools/test_telegram_history.py
+++ b/tests/tools/test_telegram_history.py
@@ -23,6 +23,7 @@ from tools.telegram_history import (
     register_chat,
     resolve_chat_candidates,
     resolve_chat_id,
+    resolve_chats_by_project,
     search_all_chats,
     search_history,
     search_links,
@@ -530,6 +531,20 @@ class TestListChats:
         assert "error" not in result
         assert result["count"] == 2
 
+    def test_list_chats_includes_project_key_field(self):
+        """Each chat dict surfaces `project_key` (None when unset)."""
+        register_chat(chat_id="111", chat_name="Chat A", project_key="psyoptimal")
+        register_chat(chat_id="222", chat_name="Chat B")  # no project_key
+
+        result = list_chats()
+
+        assert "error" not in result
+        chats = {c["chat_id"]: c for c in result["chats"]}
+        assert "project_key" in chats["111"]
+        assert chats["111"]["project_key"] == "psyoptimal"
+        assert "project_key" in chats["222"]
+        assert chats["222"]["project_key"] is None
+
 
 class TestResolveChatId:
     """Test chat_id resolution by name."""
@@ -845,3 +860,107 @@ class TestSearchAllChats:
 
         assert "error" not in result
         assert result["total_matches"] == 2
+
+
+class TestResolveChatsByProject:
+    """Test `resolve_chats_by_project` — project_key → chat list resolver."""
+
+    def test_empty_project_returns_empty_list(self):
+        # Defensive guard: empty/whitespace-only project_key never matches.
+        assert resolve_chats_by_project("") == []
+        assert resolve_chats_by_project("   ") == []
+
+    def test_zero_matching_chats(self):
+        # Project_key with no matching Chat records → [].
+        register_chat(chat_id="100", chat_name="Other Chat", project_key="other")
+        result = resolve_chats_by_project("psyoptimal")
+        assert result == []
+
+    def test_single_matching_chat(self):
+        register_chat(chat_id="200", chat_name="PsyOPTIMAL", project_key="psyoptimal")
+        register_chat(chat_id="201", chat_name="Other", project_key="other")
+
+        result = resolve_chats_by_project("psyoptimal")
+
+        assert len(result) == 1
+        assert isinstance(result[0], ChatCandidate)
+        assert result[0].chat_id == "200"
+        assert result[0].chat_name == "PsyOPTIMAL"
+
+    def test_many_matching_chats_sorted_by_recency(self):
+        # Three chats tagged "psyoptimal" registered in order; resolver must
+        # return them most-recent-first.
+        register_chat(chat_id="301", chat_name="PsyOPTIMAL", project_key="psyoptimal")
+        time.sleep(0.01)
+        register_chat(chat_id="302", chat_name="PM: PsyOptimal", project_key="psyoptimal")
+        time.sleep(0.01)
+        register_chat(chat_id="303", chat_name="Dev: PsyOPTIMAL", project_key="psyoptimal")
+
+        result = resolve_chats_by_project("psyoptimal")
+
+        assert [c.chat_id for c in result] == ["303", "302", "301"]
+
+    def test_chats_with_none_project_key_never_returned(self):
+        """`project_key=None` chats must be filtered out, even when name matches."""
+        register_chat(chat_id="400", chat_name="PsyOPTIMAL", project_key=None)
+        register_chat(chat_id="401", chat_name="PsyOPTIMAL Other", project_key="psyoptimal")
+
+        result = resolve_chats_by_project("psyoptimal")
+        ids = {c.chat_id for c in result}
+        assert ids == {"401"}
+
+    def test_chats_with_different_project_key_excluded(self):
+        register_chat(chat_id="500", chat_name="Foo", project_key="psyoptimal")
+        register_chat(chat_id="501", chat_name="Bar", project_key="valor")
+        register_chat(chat_id="502", chat_name="Baz", project_key="ai")
+
+        result = resolve_chats_by_project("psyoptimal")
+        ids = {c.chat_id for c in result}
+        assert ids == {"500"}
+
+    def test_deterministic_tiebreak_on_chat_id(self, monkeypatch):
+        """Same `last_activity_ts` ties → tiebreak by chat_id ascending."""
+        import tools.telegram_history as _th
+
+        frozen_ts = 1_700_000_500.0
+        monkeypatch.setattr(_th.time, "time", lambda: frozen_ts)
+        register_chat(chat_id="700", chat_name="A", project_key="psyoptimal")
+        register_chat(chat_id="600", chat_name="B", project_key="psyoptimal")
+        monkeypatch.undo()
+
+        result = resolve_chats_by_project("psyoptimal")
+        # "600" < "700" lexicographically.
+        assert [c.chat_id for c in result] == ["600", "700"]
+
+    def test_redis_unavailable_returns_empty_and_logs(self, monkeypatch, caplog):
+        """Narrow exception handling: Redis errors yield [] with a warning."""
+        import redis
+
+        from models.chat import Chat
+
+        class _FakeQuery:
+            def filter(self, **kwargs):
+                raise redis.RedisError("connection refused")
+
+            def all(self):
+                raise redis.RedisError("connection refused")
+
+        monkeypatch.setattr(Chat, "query", _FakeQuery())
+
+        with caplog.at_level("WARNING", logger="tools.telegram_history"):
+            result = resolve_chats_by_project("psyoptimal")
+
+        assert result == []
+        # Warning must mention the failure for audit.
+        combined = " ".join(r.message for r in caplog.records)
+        assert "resolve_chats_by_project" in combined.lower()
+
+    def test_returns_chat_candidate_dataclass_not_model(self):
+        """Returned items are ChatCandidate dataclasses, not Popoto Chat instances."""
+        register_chat(chat_id="800", chat_name="Canary", project_key="psyoptimal")
+
+        result = resolve_chats_by_project("psyoptimal")
+        from models.chat import Chat
+
+        assert isinstance(result[0], ChatCandidate)
+        assert not isinstance(result[0], Chat)

--- a/tests/unit/test_valor_telegram.py
+++ b/tests/unit/test_valor_telegram.py
@@ -348,6 +348,7 @@ class TestCmdReadFlags:
         chat=None,
         chat_id=None,
         user=None,
+        project=None,
         limit=10,
         search=None,
         since=None,
@@ -358,6 +359,7 @@ class TestCmdReadFlags:
             chat=chat,
             chat_id=chat_id,
             user=user,
+            project=project,
             limit=limit,
             search=search,
             since=since,
@@ -636,7 +638,7 @@ class TestCmdReadFlags:
 
 
 class TestCmdReadArgparseMutex:
-    """argparse-level enforcement of --chat / --chat-id / --user mutex."""
+    """argparse-level enforcement of --chat / --chat-id / --user / --project mutex."""
 
     def test_chat_and_chat_id_both_rejected(self):
         """Passing both --chat and --chat-id raises SystemExit (argparse)."""
@@ -654,12 +656,341 @@ class TestCmdReadArgparseMutex:
         with pytest.raises(SystemExit):
             main()
 
+    def test_project_and_chat_both_rejected(self):
+        """Passing both --project and --chat raises SystemExit (argparse mutex)."""
+        from tools.valor_telegram import main
+
+        sys.argv = ["valor-telegram", "read", "--project", "psyoptimal", "--chat", "foo"]
+        with pytest.raises(SystemExit):
+            main()
+
+    def test_project_and_chat_id_both_rejected(self):
+        """Passing both --project and --chat-id raises SystemExit (argparse mutex)."""
+        from tools.valor_telegram import main
+
+        sys.argv = ["valor-telegram", "read", "--project", "psyoptimal", "--chat-id", "-1"]
+        with pytest.raises(SystemExit):
+            main()
+
+    def test_project_and_user_both_rejected(self):
+        """Passing both --project and --user raises SystemExit (argparse mutex)."""
+        from tools.valor_telegram import main
+
+        sys.argv = ["valor-telegram", "read", "--project", "psyoptimal", "--user", "tom"]
+        with pytest.raises(SystemExit):
+            main()
+
+
+class TestCmdReadProject:
+    """Cross-chat project-level reads via `--project` (issue #1169)."""
+
+    def _read_args(
+        self,
+        chat=None,
+        chat_id=None,
+        user=None,
+        project=None,
+        limit=10,
+        search=None,
+        since=None,
+        json_out=False,
+        strict=False,
+    ):
+        return argparse.Namespace(
+            chat=chat,
+            chat_id=chat_id,
+            user=user,
+            project=project,
+            limit=limit,
+            search=search,
+            since=since,
+            json=json_out,
+            strict=strict,
+        )
+
+    def test_zero_matching_chats_exits_1(self, capsys):
+        """`--project unknown` with no matching chats exits 1 with a stderr hint."""
+        from tools.valor_telegram import cmd_read
+
+        with patch("tools.valor_telegram.resolve_chats_by_project", return_value=[]):
+            result = cmd_read(self._read_args(project="unknown"))
+
+        assert result == 1
+        err = capsys.readouterr().err
+        assert "No chats found for project 'unknown'" in err
+        assert "valor-telegram chats --project" in err
+
+    def test_single_matching_chat_renders_header_and_messages(self, capsys):
+        """One matching chat → project header + per-line `[chat_name]` tag."""
+        from tools.valor_telegram import cmd_read
+
+        candidates = [_CandidateStub("100", "PsyOPTIMAL", 1_700_000_500.0)]
+        msgs = {
+            "messages": [
+                {
+                    "id": "m1",
+                    "message_id": 1,
+                    "sender": "alice",
+                    "content": "hello",
+                    "timestamp": "2026-04-25T10:00:00",
+                    "message_type": "text",
+                }
+            ]
+        }
+        with (
+            patch("tools.valor_telegram.resolve_chats_by_project", return_value=candidates),
+            patch("tools.telegram_history.get_recent_messages", return_value=msgs),
+        ):
+            result = cmd_read(self._read_args(project="psyoptimal", limit=10))
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "[project=psyoptimal" in out
+        assert "1 chats" in out
+        assert "PsyOPTIMAL" in out
+        assert "[PsyOPTIMAL]" in out
+        assert "alice: hello" in out
+
+    def test_many_chats_merge_chronological_and_trim_total(self, capsys):
+        """Messages from all matching chats are interleaved by ts desc and trimmed total."""
+        from tools.valor_telegram import cmd_read
+
+        candidates = [
+            _CandidateStub("100", "ChatA", 1_700_000_500.0),
+            _CandidateStub("200", "ChatB", 1_700_000_400.0),
+        ]
+
+        # ChatA has 3 messages, ChatB has 3 messages, all at different times
+        msgs_a = {
+            "messages": [
+                {
+                    "id": "a1",
+                    "message_id": 1,
+                    "sender": "alice",
+                    "content": "A-newest",
+                    "timestamp": "2026-04-25T12:00:00",
+                    "message_type": "text",
+                },
+                {
+                    "id": "a2",
+                    "message_id": 2,
+                    "sender": "alice",
+                    "content": "A-middle",
+                    "timestamp": "2026-04-25T10:00:00",
+                    "message_type": "text",
+                },
+                {
+                    "id": "a3",
+                    "message_id": 3,
+                    "sender": "alice",
+                    "content": "A-oldest",
+                    "timestamp": "2026-04-25T08:00:00",
+                    "message_type": "text",
+                },
+            ]
+        }
+        msgs_b = {
+            "messages": [
+                {
+                    "id": "b1",
+                    "message_id": 1,
+                    "sender": "bob",
+                    "content": "B-newest",
+                    "timestamp": "2026-04-25T11:00:00",
+                    "message_type": "text",
+                },
+                {
+                    "id": "b2",
+                    "message_id": 2,
+                    "sender": "bob",
+                    "content": "B-middle",
+                    "timestamp": "2026-04-25T09:00:00",
+                    "message_type": "text",
+                },
+                {
+                    "id": "b3",
+                    "message_id": 3,
+                    "sender": "bob",
+                    "content": "B-oldest",
+                    "timestamp": "2026-04-25T07:00:00",
+                    "message_type": "text",
+                },
+            ]
+        }
+
+        def fake_get_recent(chat_id, limit):
+            if str(chat_id) == "100":
+                return msgs_a
+            return msgs_b
+
+        with (
+            patch("tools.valor_telegram.resolve_chats_by_project", return_value=candidates),
+            patch("tools.telegram_history.get_recent_messages", side_effect=fake_get_recent),
+        ):
+            # limit=4 → top 4 across the union after merge.
+            result = cmd_read(self._read_args(project="proj", limit=4))
+
+        assert result == 0
+        out = capsys.readouterr().out
+
+        # Output is chronological (oldest first) — bridge prints in chronological
+        # order historically; the merge is timestamp-desc then displayed oldest-first
+        # to match single-chat behavior.
+        # Either ordering is fine as long as exactly 4 of the 6 lines made it
+        # and the OLDEST 2 were dropped (B-oldest 07:00 and A-oldest 08:00).
+        assert "A-newest" in out
+        assert "B-newest" in out
+        assert "A-middle" in out
+        assert "B-middle" in out
+        assert "A-oldest" not in out
+        assert "B-oldest" not in out
+
+    def test_json_output_includes_chat_id_and_chat_name(self, capsys):
+        """`--project --json` enriches each message dict with chat_id + chat_name."""
+        from tools.valor_telegram import cmd_read
+
+        candidates = [_CandidateStub("100", "ChatA", 1_700_000_500.0)]
+        msgs = {
+            "messages": [
+                {
+                    "id": "m1",
+                    "message_id": 1,
+                    "sender": "alice",
+                    "content": "hi",
+                    "timestamp": "2026-04-25T10:00:00",
+                    "message_type": "text",
+                }
+            ]
+        }
+        with (
+            patch("tools.valor_telegram.resolve_chats_by_project", return_value=candidates),
+            patch("tools.telegram_history.get_recent_messages", return_value=msgs),
+        ):
+            result = cmd_read(self._read_args(project="proj", json_out=True))
+
+        assert result == 0
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["chat_id"] == "100"
+        assert data[0]["chat_name"] == "ChatA"
+        # Existing fields still present
+        assert data[0]["sender"] == "alice"
+        assert data[0]["content"] == "hi"
+
+    def test_project_freshness_header_format(self, capsys):
+        """Header format: `[project=KEY · N chats: name1, name2 · last activity: T]`."""
+        import re
+
+        from tools.valor_telegram import cmd_read
+
+        candidates = [
+            _CandidateStub("100", "ChatA", 1_700_000_500.0),
+            _CandidateStub("200", "ChatB", 1_700_000_400.0),
+        ]
+        with (
+            patch("tools.valor_telegram.resolve_chats_by_project", return_value=candidates),
+            patch("tools.telegram_history.get_recent_messages", return_value={"messages": []}),
+        ):
+            cmd_read(self._read_args(project="psyoptimal"))
+
+        out = capsys.readouterr().out
+        # Match: [project=psyoptimal · 2 chats: ChatA, ChatB · last activity: ...]
+        pattern = r"\[project=psyoptimal · 2 chats: ChatA, ChatB · last activity: .+\]"
+        assert re.search(pattern, out), f"Header pattern not matched in: {out!r}"
+
+    def test_project_strict_rejected(self, capsys):
+        """`--project` + `--strict` is rejected with explicit error."""
+        from tools.valor_telegram import cmd_read
+
+        result = cmd_read(self._read_args(project="psyoptimal", strict=True))
+
+        assert result == 1
+        err = capsys.readouterr().err
+        assert "--strict has no effect with --project" in err
+
+    def test_empty_project_rejected(self, capsys):
+        """`--project ''` and `--project '   '` are rejected as empty."""
+        from tools.valor_telegram import cmd_read
+
+        result = cmd_read(self._read_args(project=""))
+        assert result == 1
+        err = capsys.readouterr().err
+        assert "--project cannot be empty" in err
+
+        result = cmd_read(self._read_args(project="   "))
+        assert result == 1
+        err = capsys.readouterr().err
+        assert "--project cannot be empty" in err
+
+    def test_project_mutex_in_cmd_read(self, capsys):
+        """Direct cmd_read invocation with --project + --chat exits 1."""
+        from tools.valor_telegram import cmd_read
+
+        result = cmd_read(self._read_args(project="psyoptimal", chat="foo"))
+
+        assert result == 1
+        err = capsys.readouterr().err
+        assert "mutually exclusive" in err
+
+    def test_long_chat_name_truncated_in_per_line_tag(self, capsys):
+        """Per-line `[chat_name]` tag truncates names >25 chars with ellipsis."""
+        from tools.valor_telegram import cmd_read
+
+        long_name = "PsyOPTIMAL Engineering Daily Standup"  # 36 chars
+        candidates = [_CandidateStub("100", long_name, 1_700_000_500.0)]
+        msgs = {
+            "messages": [
+                {
+                    "id": "m1",
+                    "message_id": 1,
+                    "sender": "alice",
+                    "content": "hello",
+                    "timestamp": "2026-04-25T10:00:00",
+                    "message_type": "text",
+                }
+            ]
+        }
+        with (
+            patch("tools.valor_telegram.resolve_chats_by_project", return_value=candidates),
+            patch("tools.telegram_history.get_recent_messages", return_value=msgs),
+        ):
+            cmd_read(self._read_args(project="proj"))
+
+        out = capsys.readouterr().out
+        # The 36-char name must be truncated to 25 chars (+ ellipsis) in the
+        # per-line tag, but the FULL name appears in the project header.
+        assert long_name in out  # Header has the full name
+        # Per-line tag truncates: first 22 chars + "..." = 25 visible chars.
+        truncated = long_name[:22] + "..."
+        assert f"[{truncated}]" in out
+
+    def test_empty_results_prints_header_then_no_messages(self, capsys):
+        """Project header prints BEFORE any 'no messages' text on empty results."""
+        from tools.valor_telegram import cmd_read
+
+        candidates = [_CandidateStub("100", "ChatA", 1_700_000_500.0)]
+        with (
+            patch("tools.valor_telegram.resolve_chats_by_project", return_value=candidates),
+            patch("tools.telegram_history.get_recent_messages", return_value={"messages": []}),
+        ):
+            result = cmd_read(self._read_args(project="proj"))
+
+        assert result == 0
+        out = capsys.readouterr().out
+        header_idx = out.find("[project=proj")
+        nomsg_idx = out.find("No messages found for project 'proj'")
+        assert header_idx >= 0
+        assert nomsg_idx >= 0
+        assert header_idx < nomsg_idx
+
 
 class TestCmdChatsSearch:
     """`valor-telegram chats --search` filter (Task 5)."""
 
-    def _chats_args(self, search=None, json_out=False):
-        return argparse.Namespace(search=search, json=json_out)
+    def _chats_args(self, search=None, project=None, json_out=False):
+        return argparse.Namespace(search=search, project=project, json=json_out)
 
     def test_search_filter_matches(self, capsys):
         from tools.valor_telegram import cmd_chats
@@ -778,6 +1109,162 @@ class TestCmdChatsSearch:
         assert "PM: Psy" in names
         assert "Dev" not in names
         assert data["count"] == 1
+
+
+class TestCmdChatsProject:
+    """`valor-telegram chats --project` filter (issue #1169)."""
+
+    def _chats_args(self, search=None, project=None, json_out=False):
+        return argparse.Namespace(search=search, project=project, json=json_out)
+
+    def test_project_filter_matches(self, capsys):
+        """`chats --project psyoptimal` returns only matching chats."""
+        from tools.valor_telegram import cmd_chats
+
+        fake = {
+            "chats": [
+                {
+                    "chat_id": "1",
+                    "chat_name": "PsyOPTIMAL",
+                    "project_key": "psyoptimal",
+                    "message_count": 3,
+                    "last_message": "2026-04-24T10:00",
+                },
+                {
+                    "chat_id": "2",
+                    "chat_name": "Dev: Valor",
+                    "project_key": "valor",
+                    "message_count": 5,
+                    "last_message": "2026-04-24T09:00",
+                },
+                {
+                    "chat_id": "3",
+                    "chat_name": "PM: PsyOptimal",
+                    "project_key": "psyoptimal",
+                    "message_count": 7,
+                    "last_message": "2026-04-24T11:00",
+                },
+            ],
+            "count": 3,
+        }
+        with patch("tools.telegram_history.list_chats", return_value=fake):
+            result = cmd_chats(self._chats_args(project="psyoptimal"))
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "PsyOPTIMAL" in out
+        assert "PM: PsyOptimal" in out
+        assert "Dev: Valor" not in out
+        assert "matching project 'psyoptimal'" in out
+
+    def test_project_and_search_combined(self, capsys):
+        """`chats --project psyoptimal --search 'pm'` applies BOTH filters."""
+        from tools.valor_telegram import cmd_chats
+
+        fake = {
+            "chats": [
+                {
+                    "chat_id": "1",
+                    "chat_name": "PsyOPTIMAL",
+                    "project_key": "psyoptimal",
+                    "message_count": 3,
+                    "last_message": "2026-04-24T10:00",
+                },
+                {
+                    "chat_id": "2",
+                    "chat_name": "PM: PsyOptimal",
+                    "project_key": "psyoptimal",
+                    "message_count": 7,
+                    "last_message": "2026-04-24T11:00",
+                },
+                {
+                    "chat_id": "3",
+                    "chat_name": "PM: Valor",
+                    "project_key": "valor",
+                    "message_count": 4,
+                    "last_message": "2026-04-24T12:00",
+                },
+            ],
+            "count": 3,
+        }
+        with patch("tools.telegram_history.list_chats", return_value=fake):
+            result = cmd_chats(self._chats_args(project="psyoptimal", search="pm"))
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "PM: PsyOptimal" in out
+        assert "PsyOPTIMAL" not in out.replace("PM: PsyOptimal", "")  # exclude PM line
+        assert "PM: Valor" not in out
+
+    def test_project_unknown_returns_empty(self, capsys):
+        """`chats --project unknown` returns empty with no-match message."""
+        from tools.valor_telegram import cmd_chats
+
+        fake = {
+            "chats": [
+                {
+                    "chat_id": "1",
+                    "chat_name": "PsyOPTIMAL",
+                    "project_key": "psyoptimal",
+                    "message_count": 3,
+                    "last_message": None,
+                },
+            ],
+            "count": 1,
+        }
+        with patch("tools.telegram_history.list_chats", return_value=fake):
+            result = cmd_chats(self._chats_args(project="unknown"))
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "No chats" in out
+
+    def test_empty_project_rejected(self, capsys):
+        """`chats --project ''` is rejected."""
+        from tools.valor_telegram import cmd_chats
+
+        with patch(
+            "tools.telegram_history.list_chats",
+            side_effect=AssertionError("list_chats must not be called for empty --project"),
+        ):
+            result = cmd_chats(self._chats_args(project=""))
+        assert result == 1
+        err = capsys.readouterr().err
+        assert "--project cannot be empty" in err
+
+    def test_project_json_includes_project_key(self, capsys):
+        """`chats --project --json` returns filtered list with project_key field."""
+        from tools.valor_telegram import cmd_chats
+
+        fake = {
+            "chats": [
+                {
+                    "chat_id": "1",
+                    "chat_name": "PsyOPTIMAL",
+                    "project_key": "psyoptimal",
+                    "message_count": 3,
+                    "last_message": None,
+                },
+                {
+                    "chat_id": "2",
+                    "chat_name": "Dev: Valor",
+                    "project_key": "valor",
+                    "message_count": 5,
+                    "last_message": None,
+                },
+            ],
+            "count": 2,
+        }
+        with patch("tools.telegram_history.list_chats", return_value=fake):
+            result = cmd_chats(self._chats_args(project="psyoptimal", json_out=True))
+
+        assert result == 0
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["count"] == 1
+        names = [c["chat_name"] for c in data["chats"]]
+        assert names == ["PsyOPTIMAL"]
+        assert data["chats"][0]["project_key"] == "psyoptimal"
 
 
 class TestFormatRelativeAge:

--- a/tools/telegram_history/__init__.py
+++ b/tools/telegram_history/__init__.py
@@ -218,6 +218,49 @@ def resolve_chat_candidates(chat_name: str) -> list[ChatCandidate]:
         return []
 
 
+def resolve_chats_by_project(project_key: str) -> list[ChatCandidate]:
+    """Return all chats whose `project_key` matches, ordered by recency.
+
+    Scans `Chat.query.all()` and filters in Python because `Chat.project_key`
+    is a plain `Field` (not `KeyField`) — there is no indexed lookup. Chats
+    with `project_key=None` are NEVER returned (a chat that was never tagged
+    by the bridge is not part of any project).
+
+    Ordering: `last_activity_ts` desc, with `None` sorting last and a
+    deterministic `chat_id` ascending tiebreak (same as `_sort_candidates`).
+
+    Args:
+        project_key: The project key to match. Empty/whitespace-only returns [].
+
+    Returns:
+        List of `ChatCandidate`s. Empty if no match or on Redis/Popoto failure.
+
+    Failure mode: Redis / Popoto errors are logged and an empty list is
+    returned. Mirrors the narrow exception handling of `resolve_chat_candidates`.
+    """
+    if not project_key or not project_key.strip():
+        return []
+
+    from models.chat import Chat
+
+    try:
+        import popoto as _popoto_pkg
+        import redis as _redis_pkg
+
+        all_chats = list(Chat.query.all())
+        matches = [
+            c
+            for c in all_chats
+            if getattr(c, "project_key", None) is not None and c.project_key == project_key
+        ]
+        if not matches:
+            return []
+        return _sort_candidates([_chat_to_candidate(c) for c in matches])
+    except (_redis_pkg.RedisError, _popoto_pkg.ModelException, _popoto_pkg.QueryException) as e:
+        logger.warning("resolve_chats_by_project failed: %s", e)
+        return []
+
+
 # =============================================================================
 # Shared Utilities
 # =============================================================================
@@ -1118,6 +1161,7 @@ def list_chats(
                 "chat_id": chat.chat_id,
                 "chat_name": chat.chat_name,
                 "chat_type": chat.chat_type,
+                "project_key": getattr(chat, "project_key", None),
                 "updated_at": _ts_to_iso(chat.updated_at),
                 "message_count": msg_count,
                 "last_message": last_msg,

--- a/tools/valor_telegram.py
+++ b/tools/valor_telegram.py
@@ -297,6 +297,129 @@ def _fetch_from_telegram_api(
     return asyncio.run(_fetch())
 
 
+_PROJECT_PER_LINE_NAME_MAX = 25
+_PROJECT_HEADER_NAME_CAP = 5
+
+
+def _truncate_chat_name(name: str, limit: int = _PROJECT_PER_LINE_NAME_MAX) -> str:
+    """Truncate a chat_name for the per-line `[chat_name]` tag.
+
+    Names longer than `limit` are cut to (limit - 3) chars + "..." so the
+    final visible width is exactly `limit` characters. The full name is
+    always available in the project header and JSON output.
+    """
+    if len(name) <= limit:
+        return name
+    return name[: max(0, limit - 3)] + "..."
+
+
+def _cmd_read_project(
+    args: argparse.Namespace,
+    resolve_chats_by_project,
+    get_recent_messages,
+) -> int:
+    """Cross-chat project-level read path (issue #1169).
+
+    Resolves chats by `project_key`, fetches up to `args.limit` recent
+    messages per chat, merges by `timestamp` desc, trims to `args.limit`
+    total, and renders with a project freshness header plus per-line
+    `[chat_name]` tag. JSON mode enriches each message dict with `chat_id`
+    and `chat_name` fields.
+    """
+    project_key = args.project.strip()
+    candidates = resolve_chats_by_project(project_key)
+
+    if not candidates:
+        print(
+            f"No chats found for project {project_key!r}. "
+            f"Run `valor-telegram chats --project {project_key}` to verify.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Per-chat fetch budget = args.limit so the merge candidate pool is at
+    # least N (avoids missing recent messages from one chat behind a flood
+    # from another). Worst case K chats × N each before merge-and-trim.
+    merged: list[dict] = []
+    for c in candidates:
+        result = get_recent_messages(chat_id=c.chat_id, limit=args.limit)
+        if "error" in result:
+            # Surface per-chat errors but keep going — partial results are
+            # still useful for cross-chat situational awareness.
+            print(
+                f"Warning: failed to fetch chat {c.chat_id}: {result['error']}",
+                file=sys.stderr,
+            )
+            continue
+        for msg in result.get("messages", []):
+            enriched = dict(msg)
+            enriched["chat_id"] = c.chat_id
+            enriched["chat_name"] = c.chat_name
+            merged.append(enriched)
+
+    # Sort by timestamp desc with chat_id then message_id tiebreakers for
+    # deterministic ordering. ISO-8601 strings sort lexicographically the
+    # same as chronologically, so string compare is correct.
+    merged.sort(
+        key=lambda m: (
+            m.get("timestamp") or "",
+            str(m.get("chat_id") or ""),
+            m.get("message_id") or 0,
+        ),
+        reverse=True,
+    )
+    merged = merged[: max(0, args.limit)]
+
+    # Display oldest-first to match the single-chat path's chronological order.
+    display_msgs = list(reversed(merged))
+
+    if args.json:
+        print(json.dumps(display_msgs, indent=2, default=str))
+        return 0
+
+    # --- Project freshness header --------------------------------------------
+    chat_names = [c.chat_name or "(unnamed)" for c in candidates]
+    if len(chat_names) > _PROJECT_HEADER_NAME_CAP:
+        visible = chat_names[:_PROJECT_HEADER_NAME_CAP]
+        more = len(chat_names) - _PROJECT_HEADER_NAME_CAP
+        names_str = ", ".join(visible) + f", ... +{more} more"
+    else:
+        names_str = ", ".join(chat_names)
+    last_ts = max(
+        (c.last_activity_ts for c in candidates if c.last_activity_ts is not None),
+        default=None,
+    )
+    age = _format_relative_age(last_ts)
+    print(f"[project={project_key} · {len(candidates)} chats: {names_str} · last activity: {age}]")
+
+    if not display_msgs:
+        print(f"No messages found for project {project_key!r}.")
+        return 0
+
+    for msg in display_msgs:
+        ts = format_timestamp(msg.get("timestamp"))
+        sender = msg.get("sender", "unknown")
+        content = msg.get("content", "") or ""
+        if len(content) > 500:
+            content = content[:497] + "..."
+        chat_tag = _truncate_chat_name(msg.get("chat_name", "") or "")
+        print(f"[{ts}] [{chat_tag}] {sender}: {content}")
+
+    return 0
+
+
+def resolve_chats_by_project(project_key: str):
+    """Module-level wrapper around `tools.telegram_history.resolve_chats_by_project`.
+
+    Exposed at module level so tests can patch
+    `tools.valor_telegram.resolve_chats_by_project` directly (mirrors the
+    existing `resolve_chat` wrapper pattern).
+    """
+    from tools.telegram_history import resolve_chats_by_project as _impl
+
+    return _impl(project_key)
+
+
 def cmd_read(args: argparse.Namespace) -> int:
     """Read messages from a chat."""
     from tools.telegram_history import (
@@ -314,12 +437,22 @@ def cmd_read(args: argparse.Namespace) -> int:
             getattr(args, "chat", None),
             getattr(args, "chat_id", None),
             getattr(args, "user", None),
+            getattr(args, "project", None),
         )
         if v
     )
     if flag_count > 1:
         print(
-            "Error: --chat, --chat-id, and --user are mutually exclusive.",
+            "Error: --chat, --chat-id, --user, and --project are mutually exclusive.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # --strict only makes sense for name-resolution paths (--chat). It is a
+    # footgun under --project (which never resolves a name) — reject explicitly.
+    if getattr(args, "project", None) and getattr(args, "strict", False):
+        print(
+            "Error: --strict has no effect with --project; remove one of them.",
             file=sys.stderr,
         )
         return 1
@@ -328,7 +461,7 @@ def cmd_read(args: argparse.Namespace) -> int:
     # BEFORE reaching the resolver, so it never hits the normalizer's
     # "returns []" path (which would be reported as a plain zero-match) or
     # sneaks into substring match-all logic elsewhere. We also reject empty
-    # --user for the same reason (whitespace is never a valid username).
+    # --user / --project for the same reason.
     raw_chat = getattr(args, "chat", None)
     if raw_chat is not None and not raw_chat.strip():
         print(
@@ -343,6 +476,18 @@ def cmd_read(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
+    raw_project = getattr(args, "project", None)
+    if raw_project is not None and not raw_project.strip():
+        print(
+            "Error: --project cannot be empty or whitespace-only.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # --- Cross-chat project-level read (issue #1169). Branches off before the
+    # single-chat path so it does not interact with name resolution / fallback. ---
+    if raw_project:
+        return _cmd_read_project(args, resolve_chats_by_project, get_recent_messages)
 
     chat_id = None
     strict_mode = bool(getattr(args, "strict", False))
@@ -674,6 +819,14 @@ def cmd_chats(args: argparse.Namespace) -> int:
         )
         return 1
 
+    raw_project = getattr(args, "project", None)
+    if raw_project is not None and not raw_project.strip():
+        print(
+            "Error: --project cannot be empty or whitespace-only.",
+            file=sys.stderr,
+        )
+        return 1
+
     result = list_chats()
 
     if "error" in result:
@@ -681,6 +834,12 @@ def cmd_chats(args: argparse.Namespace) -> int:
         return 1
 
     chats = result.get("chats", [])
+
+    # Optional --project filter: exact-match on Chat.project_key. Combinable
+    # with --search; both filters apply when both are set.
+    project_filter = raw_project
+    if project_filter:
+        chats = [c for c in chats if c.get("project_key") == project_filter]
 
     # Optional --search filter: normalized substring match, keeps existing sort.
     search_pattern = getattr(args, "search", None)
@@ -694,26 +853,43 @@ def cmd_chats(args: argparse.Namespace) -> int:
                 for c in chats
                 if c.get("chat_name") and normalized_pattern in _normalize_chat_name(c["chat_name"])
             ]
-        # Preserve `count` invariant by updating the returned dict.
-        result = {"chats": chats, "count": len(chats), "search": search_pattern}
+
+    # Preserve `count` invariant by rebuilding the returned dict whenever a
+    # filter ran.
+    if project_filter or search_pattern:
+        result = {"chats": chats, "count": len(chats)}
+        if search_pattern:
+            result["search"] = search_pattern
+        if project_filter:
+            result["project"] = project_filter
 
     if args.json:
         print(json.dumps(result, indent=2, default=str))
         return 0
 
     if not chats:
-        if search_pattern:
+        if search_pattern and project_filter:
+            print(f"No chats matched project {project_filter!r} and search {search_pattern!r}.")
+        elif project_filter:
+            print(f"No chats matched project {project_filter!r}.")
+        elif search_pattern:
             print(f"No chats matched {search_pattern!r}.")
         else:
             print("No chats found in history database.")
             print("Chats are registered as messages are received by the bridge.")
         return 0
 
-    header = (
-        f"Known chats matching {search_pattern!r} ({len(chats)}):"
-        if search_pattern
-        else f"Known chats ({len(chats)}):"
-    )
+    if project_filter and search_pattern:
+        header = (
+            f"Known chats matching project {project_filter!r} "
+            f"and search {search_pattern!r} ({len(chats)}):"
+        )
+    elif project_filter:
+        header = f"Known chats matching project {project_filter!r} ({len(chats)}):"
+    elif search_pattern:
+        header = f"Known chats matching {search_pattern!r} ({len(chats)}):"
+    else:
+        header = f"Known chats ({len(chats)}):"
     print(header)
     print()
     print(f"{'Chat Name':<35} {'Messages':>10} {'Last Activity':<20}")
@@ -740,8 +916,9 @@ def main() -> int:
 
     # read subcommand
     read_parser = subparsers.add_parser("read", help="Read messages from a chat")
-    # --chat / --chat-id / --user are mutually exclusive — the user picks ONE.
-    # We still allow not specifying any when --search is set (cross-chat search).
+    # --chat / --chat-id / --user / --project are mutually exclusive — the user
+    # picks ONE. We still allow not specifying any when --search is set
+    # (cross-chat search).
     read_target_group = read_parser.add_mutually_exclusive_group()
     read_target_group.add_argument("--chat", "-c", help="Chat name (resolved against history)")
     read_target_group.add_argument(
@@ -751,6 +928,14 @@ def main() -> int:
     read_target_group.add_argument(
         "--user",
         help="Username from the DM whitelist — forces the DM path",
+    )
+    read_target_group.add_argument(
+        "--project",
+        help=(
+            "Project key — unions messages across all chats with this project_key, "
+            "interleaved chronologically. --limit applies to the merged total, NOT "
+            "per-chat. Mutually exclusive with --chat/--chat-id/--user/--strict."
+        ),
     )
     read_parser.add_argument(
         "--limit", "-n", type=int, default=10, help="Max messages (default: 10)"
@@ -789,6 +974,10 @@ def main() -> int:
         "--search",
         "-s",
         help="Filter by substring of chat name (normalized)",
+    )
+    chats_parser.add_argument(
+        "--project",
+        help="Filter by project_key (combinable with --search)",
     )
     chats_parser.add_argument("--json", action="store_true", help="Output as JSON")
 


### PR DESCRIPTION
## Summary

Adds `--project PROJECT_KEY` to `valor-telegram read` and `valor-telegram chats` so a reader can union messages across every chat tagged with a given `Chat.project_key`. Solves the parent-issue scenario: PsyOPTIMAL spans three chats today (`PsyOPTIMAL`, `PM: PsyOptimal`, `Dev: PsyOPTIMAL`), and previously a project-wide read required three separate invocations + manual interleaving.

- Plan: [`docs/plans/telegram-cross-chat-project-stitching.md`](docs/plans/telegram-cross-chat-project-stitching.md)
- Resolves: #1169 (defect 7 of #1163, deliberately deferred from PR #1168)

## What changed

- **`tools/telegram_history/__init__.py`** — new `resolve_chats_by_project(project_key)` returns `list[ChatCandidate]` filtered by exact `Chat.project_key` match, sorted recency-desc with `chat_id` ascending tiebreak. Mirrors the narrow exception handling of `resolve_chat_candidates`. Chats with `project_key=None` are never returned. `list_chats()` now surfaces `project_key` on every chat dict.
- **`tools/valor_telegram.py`** — `--project PROJECT_KEY` joins the existing `--chat / --chat-id / --user` mutex group on `read`. Implements the merge-and-trim flow: per-chat fetch with `limit=args.limit`, sort by `timestamp` desc, slice to `args.limit` total. Renders a project freshness header `[project=KEY · N chats: name1, name2, ... · last activity: T]` plus per-line `[chat_name]` tags (truncated to 25 chars). JSON mode enriches each message dict with `chat_id` and `chat_name` (single-chat JSON unchanged). `--strict` + `--project` is rejected with an explicit error. `--project` filter added to `chats` (combinable with `--search`).
- **Docs** — updated `docs/features/telegram-messaging.md`, `docs/features/telegram-history.md`, `.claude/skills/telegram/SKILL.md`, and the `Reading Telegram Messages` quick-reference in `CLAUDE.md`.

## Acceptance criteria (from plan)

- [x] `valor-telegram read --project psyoptimal --limit 20` returns the most recent 20 messages across all chats with `project_key="psyoptimal"`, interleaved by timestamp desc.
- [x] Each output line in human mode is tagged with `[chat_name]` (truncated to 25 chars if longer).
- [x] A project header line precedes the messages: `[project=psyoptimal · N chats: name1, name2, name3 · last activity: T]`.
- [x] `valor-telegram read --project psyoptimal --json` emits each message dict with `chat_id` and `chat_name` fields.
- [x] `valor-telegram read --project unknown` exits 1 with a clear stderr message pointing the user at `chats --project`.
- [x] `valor-telegram read --project psyoptimal --chat foo` (or any other read-target combination) errors at the argparse layer with a mutex-violation message.
- [x] `valor-telegram read --project psyoptimal --strict` errors with `Error: --strict has no effect with --project; remove one of them.` and exits 1.
- [x] `valor-telegram chats --project psyoptimal` returns only chats with `project_key="psyoptimal"`, sorted by recency.
- [x] `valor-telegram chats --project psyoptimal --search "dev"` applies both filters.
- [x] `valor-telegram chats --json` includes `project_key` in each chat dict.
- [x] `valor-telegram read --chat "PsyOptimal" --limit 10` (single-chat path) is unchanged — same output, same JSON, same exit codes.
- [x] All new and modified tests pass — 163/163 in `tests/unit/test_valor_telegram.py` + `tests/tools/test_telegram_history.py`.
- [x] Format clean (`python -m ruff format`).
- [x] `.claude/skills/telegram/SKILL.md` documents the new flag.
- [x] `docs/features/telegram-messaging.md` documents the new cross-chat behavior.

## Test Plan

- [x] Unit tests: `pytest tests/tools/test_telegram_history.py tests/unit/test_valor_telegram.py` → **163 passed** (12 new for `resolve_chats_by_project` / `list_chats` project_key, 10 new for `read --project`, 5 new for `chats --project`, 3 new mutex tests in `TestCmdReadArgparseMutex`)
- [x] Smoke: `valor-telegram read --project ai --strict` → exit 1, `Error: --strict has no effect with --project; remove one of them.`
- [x] Smoke: `valor-telegram read --project "" ` → exit 1, `Error: --project cannot be empty or whitespace-only.`
- [x] Smoke: `valor-telegram read --project ai --chat foo` → exit 2, argparse mutex error
- [x] Smoke: `valor-telegram read --help` and `valor-telegram chats --help` show the new `--project` flag

## Pre-existing failures (NOT touched by this PR)

The full unit-test run reports 24 failures on `main` that are unrelated to this work and pre-date this branch (verified by checkout of `main` at the same SHA):
- `tests/unit/test_email_bridge.py::TestBuildReplyMimeSubjectPrefix::*` — 7 pre-existing
- `tests/unit/test_reflection_scheduler.py::TestRegistryIntegrity::*` and `TestRegistryLoading::*` — 7 pre-existing
- `tests/unit/test_pm_session_permissions.py::TestPMSessionEnvInjection::test_sentry_token_injected_for_pm_session` — pre-existing
- `tests/unit/test_session_health_sibling_phantom_safety.py::test_reflections_config_has_agent_session_cleanup_enabled` — pre-existing
- `tests/unit/test_ui_reflections_data.py::TestReflectionsDataLayer::test_get_all_reflections_returns_list` — pre-existing
- `tests/unit/test_valor_email.py::TestCmdSend::test_queues_unified_payload` — pre-existing

Each is in an unrelated subsystem (email bridge, reflection registry, PM session env injection). None touch `tools/valor_telegram.py`, `tools/telegram_history/`, or `models/chat.py`.