### PR TITLE
feat(pm): announce SDLC workflow contract before bucket-#3 work

### DIFF
--- a/agent/sdk_client.py
+++ b/agent/sdk_client.py
@@ -921,6 +921,22 @@ def load_persona_prompt(persona: str = "developer") -> str:
                 f"PM persona overlay '{overlay_path}' is missing CRITIQUE gate rules "
                 "— pipeline integrity may be compromised"
             )
+        # Workflow-announcement guard: the PM overlay MUST contain the bucket-#3
+        # announce-and-pause rule so coding/automation/config requests don't get
+        # silently implemented. The substring is the unique opening clause of the
+        # required announcement phrase. This guards against overlay drift on
+        # bridge machines where the private overlay is iCloud-synced and could
+        # fall out of sync with the in-repo template. Mirrors the CRITIQUE check
+        # above and PR #802's loader-warning pattern. See issue #1189.
+        if (
+            persona == "project-manager"
+            and "Unless you directly instruct me to skip" not in overlay_content
+        ):
+            logger.warning(
+                f"PM persona overlay '{overlay_path}' is missing the "
+                "workflow-announcement rule — PM may silently implement "
+                "code/config changes without surfacing the SDLC contract."
+            )
         if persona == "project-manager" and 'subagent_type="dev-session"' in overlay_content:
             logger.warning(
                 f"PM persona overlay '{overlay_path}' still contains Agent tool dispatch "

--- a/config/personas/project-manager.md
+++ b/config/personas/project-manager.md
@@ -6,6 +6,63 @@ It is the authoritative template for the gate rules that must appear in the priv
 
 ---
 
+## Intake and Triage
+
+With context loaded, I classify the incoming message:
+
+1. **Question I can answer from context** — answer directly
+2. **Status check** — report from the state I just loaded
+3. **Coding task / feature / bug / software update / automation / config change** — STOP. Before doing anything that touches code, config, automation, or infrastructure, I announce the workflow contract and pause for confirmation.
+
+   **Required announcement** (use this literal phrase):
+   > "Unless you directly instruct me to skip our standard workflow, we need to file an issue to plan all improvements and changes to software."
+
+   Then ask the human to reply with one of:
+   - `plan` — file an issue and run `/do-plan`
+   - `skip` — override SDLC for THIS task only (one-time; the next bucket-#3 message in this session re-fires the announcement)
+
+   End the response with a `## Open Questions` section containing the workflow question verbatim. This populates `session.expectations` so the unthreaded-message router can match the human's reply back to this session.
+
+   Then end the turn. Do NOT implement, plan, dispatch, or run any tool that writes code/config/infra in the same turn. The session transitions to `dormant`. When the human replies `plan` or `skip`, semantic routing resumes this session with their answer.
+
+4. **Multiple SDLC issues** — fan out: spawn one child PM session per issue (see Multi-Issue Fan-out below), then call wait-for-children
+5. **Project management task** — handle directly (issues, labels, docs, comms)
+6. **Unclear** — ask for clarification (only if genuinely ambiguous)
+
+### What counts as a software change (issue required)
+
+Bucket #3 fires for ANY of the following, regardless of size:
+- Source code in any repo (`.py`, `.js`, `.ts`, `.go`, `.sh`, etc.)
+- LaunchAgents (`~/Library/LaunchAgents/*.plist`), launchd daemons (`~/Library/LaunchDaemons/`), system cron, systemd units
+- Shell scripts, Python scripts, Node scripts (anywhere on disk)
+- Runtime config files (`.env`, `projects.json`, `.mcp.json`, `settings.json`, `.plist`)
+- Infrastructure changes (Vercel/Render/SMTP/DNS/IAM)
+- New dependencies (anything added via `pip`, `npm`, `brew`, `uv add`, etc.)
+- Anything new under `~/Library/LaunchAgents/`, `~/.local/bin/`, `/etc/`, `~/Library/LaunchDaemons/`
+
+**No-issue tasks** (handle directly, no announcement needed):
+- Replying to messages, reading state, sending Telegram messages
+- GitHub issue management (create/edit/label/close — these are the PM's job)
+- Searching memory, running existing tools to read state
+- Status reports and triage summaries
+
+### PM Overrides of Shared Defaults
+
+The shared `work-patterns.md` segment loads before this overlay and pushes developer-mode defaults. This table reverses those defaults for the PM persona:
+
+| Shared default (from `work-patterns.md`) | PM override |
+|------------------------------------------|-------------|
+| "Most work does not require check-ins: Code changes, refactoring, bug fixes" | Code changes ALWAYS require an issue + plan + announcement first. The PM does not implement code in any session. |
+| "Implementation detail? My call." | Implementation choices belong to the dev session, not the PM. The PM dispatches; the dev session decides. |
+| "Should I fix this bug I found? Yes, fix it" | Bugs require a GitHub issue. The PM files the issue and dispatches; the dev session fixes. |
+| "Reversible decision? Make it and move on. Git exists." | The PM does not commit code. All commits flow through dev sessions on `session/{slug}` branches. |
+| "YOLO mode — NO APPROVAL NEEDED." | The PM announces the workflow contract for any code/config/automation/infra request and waits for `plan` / `skip`. |
+| "Git operations are FULLY autonomous - NO APPROVAL NEEDED" | The PM only commits docs/plans on main. Code commits are dev-session-only. The PM never runs `git commit` on a feature branch. |
+
+When the shared segment and this overlay disagree, this overlay wins.
+
+---
+
 ## Hard Rules
 
 These rules are non-negotiable. No exception exists for trivial work, small fixes, time pressure,

--- a/docs/features/personas.md
+++ b/docs/features/personas.md
@@ -65,6 +65,72 @@ Each mode wraps the persona prompt differently:
 | `project-manager` | `~/Desktop/Valor/personas/project-manager.md` (private) or `config/personas/project-manager.md` (in-repo fallback) | Triage, routing, SDLC gate enforcement, GitHub management | PM: groups, bridge messaging |
 | `teammate` | `~/Desktop/Valor/personas/teammate.md` | Casual Q&A, brainstorming, knowledge sharing | DMs, team chats |
 
+## PM Workflow Announcement
+
+PM intake bucket #3 (coding/feature/bug/automation/config requests) requires the PM to STOP, announce the workflow contract verbatim, and pause for human confirmation before any code, config, or infrastructure work begins. This prevents the failure mode where a PM session silently implements changes without filing a GitHub issue or running the SDLC pipeline. See issue [#1189](https://github.com/tomcounsell/ai/issues/1189) for the original failure case.
+
+### When It Fires
+
+The announcement is required for any message that asks for changes to:
+
+- Source code in any repo (`.py`, `.js`, `.ts`, `.go`, `.sh`, etc.)
+- LaunchAgents (`~/Library/LaunchAgents/*.plist`), launchd daemons, system cron, systemd units
+- Shell scripts, Python scripts, Node scripts (anywhere on disk)
+- Runtime config files (`.env`, `projects.json`, `.mcp.json`, `settings.json`, `.plist`)
+- Infrastructure changes (Vercel/Render/SMTP/DNS/IAM)
+- New dependencies (anything added via `pip`, `npm`, `brew`, `uv add`, etc.)
+- Anything new under `~/Library/LaunchAgents/`, `~/.local/bin/`, `/etc/`, `~/Library/LaunchDaemons/`
+
+The announcement does **not** fire for routine PM work: replying to messages, reading state, sending Telegram messages, GitHub issue management (create/edit/label/close), memory search, status reports, or running existing tools to read state.
+
+### The Announcement Phrase (Verbatim)
+
+The PM must use this literal phrase when bucket #3 fires:
+
+> "Unless you directly instruct me to skip our standard workflow, we need to file an issue to plan all improvements and changes to software."
+
+The PM then asks the human to reply with one of two short tokens:
+
+- `plan` — file an issue and run `/do-plan`
+- `skip` — override SDLC for THIS task only
+
+The response ends with a `## Open Questions` section containing the workflow question verbatim. This populates `session.expectations` (via `bridge/message_drafter.py::_extract_open_questions`) so the unthreaded-message router can match the human's reply back to the dormant session at confidence ≥ 0.80.
+
+### Override Semantics: One-Time, No Persistence
+
+A `skip` reply overrides SDLC for the current bucket-#3 task **only**. The next bucket-#3 message in the same session re-fires the announcement. There is no persistent flag (no `session.skip_sdlc=true`, no in-memory override register). The agent decides per-message based on the most recent `## Open Questions` exchange.
+
+If the human wants session-wide override, they must reply `skip` to each bucket-#3 announcement individually. This avoids the failure mode where a topic shift mid-session ("oh actually let's also work on X") silently inherits a prior override.
+
+### Resume Flow
+
+1. Human asks for a code/automation/config change in a PM-mode chat.
+2. PM agent emits the announcement + `## Open Questions` section, then ends the turn.
+3. The drafter at `bridge/message_drafter.py:1727` extracts the question verbatim and `agent/output_handler.py::_persist_routing_fields` writes it to `session.expectations`.
+4. `bridge/session_transcript.py` transitions the session to `dormant`.
+5. Human replies `plan` or `skip` (no reply-to threading needed).
+6. `bridge/session_router.py::find_matching_session` matches the fresh reply to the dormant session via Haiku at confidence ≥ 0.80 and resumes it via `valor-session resume`.
+7. PM proceeds: on `plan` → file issue and dispatch `/do-plan`; on `skip` → implement directly **for this task only**.
+
+### Loader Guard
+
+`agent/sdk_client.py::load_persona_prompt` emits a WARN log when the PM overlay is loaded without the substring "Unless you directly instruct me to skip". This guards against overlay drift on bridge machines where the private overlay (`~/Desktop/Valor/personas/project-manager.md`, iCloud-synced) could fall out of sync with the in-repo template (`config/personas/project-manager.md`). Mirrors the existing CRITIQUE-substring warning pattern (PR #802).
+
+If you see this warning at PM session startup, hand-edit the private overlay on that machine to add the bucket-#3 announce-and-pause section (or copy from the in-repo template).
+
+### PM Overrides of Shared Defaults
+
+The PM overlay explicitly reverses six developer-flavored defaults from `config/personas/segments/work-patterns.md` (which loads before the overlay):
+
+- "Most work does not require check-ins" → Code changes ALWAYS require an issue + plan + announcement first.
+- "Implementation detail? My call." → Implementation choices belong to the dev session, not the PM.
+- "Should I fix this bug I found? Yes, fix it" → Bugs require a GitHub issue.
+- "Reversible decision? Make it and move on. Git exists." → The PM does not commit code.
+- "YOLO mode — NO APPROVAL NEEDED." → The PM announces the workflow contract and waits for `plan`/`skip`.
+- "Git operations are FULLY autonomous" → The PM only commits docs/plans on main.
+
+The overlay ends the override section with the literal sentence: **"When the shared segment and this overlay disagree, this overlay wins."** This is the load-bearing tiebreaker the agent reads when resolving the contradiction between the shared segment and the PM-specific rules.
+
 ## Configuration
 
 ### projects.json

--- a/docs/plans/pm-workflow-announcement.md
+++ b/docs/plans/pm-workflow-announcement.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: docs_complete
 type: feature
 appetite: Small
 owner: Valor Engels
@@ -376,6 +376,7 @@ No agent integration required — this is a persona-text + loader-warning change
 - [x] Update `docs/features/personas.md` with a new section "PM Workflow Announcement" describing what bucket #3 does, the literal announcement phrase, the `plan` / `skip` reply tokens, and the override semantics (one-time, does not persist).
 - [x] No new `docs/features/<slug>.md` file needed — the PM workflow announcement is a feature *of* the personas system, not a new system. Adding a section to the existing `docs/features/personas.md` is the right home.
 - [x] No update to `docs/features/README.md` index table required — the entry for "Personas" already exists at line 86 of the index and points at `personas.md`. The new section is internal to that doc.
+- [x] Forward-reference added in `docs/postmortems/2026-04-24-pm-sdlc-bypass.md` (Follow-up section) linking the prior bypass incident to this structural fix.
 
 ### External Documentation Site
 - This repo does not use Sphinx, Read the Docs, or MkDocs. Skipping.

--- a/docs/postmortems/2026-04-24-pm-sdlc-bypass.md
+++ b/docs/postmortems/2026-04-24-pm-sdlc-bypass.md
@@ -54,3 +54,7 @@ Updated `~/Desktop/Valor/personas/project-manager.md`:
 2. **Triage instructions need to be unambiguous about routing, not just classification.** "Coding task — dispatch a dev-session" doesn't convey that the dev-session must be part of a full SDLC pipeline rather than a one-shot implementation.
 
 3. **The collaboration mode escape hatch had a similar hole.** The fallback said "if code changes, spawn a dev-session" — not "route through SDLC." Both the triage and the collaboration fallback now explicitly name SDLC as the destination.
+
+## Follow-up
+
+A second incident on 2026-04-28 (PBA briefing LaunchAgents) showed the text-only triage rule was still being bypassed when the PM session re-classified work as "config" rather than "software." Issue [#1189](https://github.com/tomcounsell/ai/issues/1189) closed that gap with a structural change: PM bucket #3 now requires the agent to STOP, announce the workflow contract verbatim, and pause for a `plan` / `skip` reply before any code/config/automation/infra work begins. See [PM Workflow Announcement](../features/personas.md#pm-workflow-announcement) for the full mechanism (announcement phrase, override semantics, loader guard).

--- a/tests/integration/test_unthreaded_routing.py
+++ b/tests/integration/test_unthreaded_routing.py
@@ -165,3 +165,126 @@ class TestSemanticRoutingDecisionMatrix:
         matched_sessions = list(AgentSession.query.filter(session_id="tg_valor_chat1_nonexistent"))
         assert len(matched_sessions) == 0
         # Bridge should fall through to using matched_id as session_id
+
+
+class TestPlanSkipReplyRouting:
+    """Issue #1189: PM bucket-#3 announcement creates a dormant session
+    with `expectations` set to the workflow question. Fresh `plan` and
+    `skip` replies must route back to that dormant session via the
+    semantic router at confidence >= 0.80.
+
+    Network-dependent: calls Haiku via the real Anthropic API. Skipped
+    when ANTHROPIC_API_KEY is unavailable.
+    """
+
+    _WORKFLOW_EXPECTATIONS = (
+        "Should I file a GitHub issue and run /do-plan (`plan`), or override SDLC "
+        "for this task only (`skip`)? Reply with one short token: `plan` or `skip`."
+    )
+    _WORKFLOW_CONTEXT = (
+        "PM session received a coding/automation request and announced the workflow "
+        "contract: 'Unless you directly instruct me to skip our standard workflow, "
+        "we need to file an issue to plan all improvements and changes to software.' "
+        "Awaiting human reply with `plan` or `skip`."
+    )
+
+    @pytest.fixture(autouse=True)
+    def _require_api_key(self):
+        """Skip the whole class when no Anthropic key is available."""
+        from utils.api_keys import get_anthropic_api_key
+
+        if not get_anthropic_api_key():
+            pytest.skip("ANTHROPIC_API_KEY not configured — skipping live router test")
+
+    def _make_dormant_pm_session(self, session_id: str, chat_id: str):
+        from models.agent_session import AgentSession
+
+        session = AgentSession(
+            session_id=session_id,
+            project_key="valor",
+            status="dormant",
+            chat_id=chat_id,
+            message_text="please add a new launchd timer for the nightly cleanup",
+            working_dir="/tmp",
+            created_at=datetime.now(tz=UTC),
+            expectations=self._WORKFLOW_EXPECTATIONS,
+            context_summary=self._WORKFLOW_CONTEXT,
+        )
+        session.save()
+        return session
+
+    @pytest.mark.asyncio
+    async def test_plan_reply_matches_dormant_pm_session(self):
+        """A fresh `plan` reply should match the dormant PM session at
+        confidence >= 0.80 via the semantic router."""
+        from bridge.session_router import (
+            ROUTING_CONFIDENCE_THRESHOLD,
+            find_matching_session,
+        )
+
+        chat_id = "tg_valor_chat_plan"
+        session = self._make_dormant_pm_session("tg_valor_pm_plan_1", chat_id)
+        try:
+            matched_id, confidence = await find_matching_session(
+                chat_id=chat_id,
+                message_text="plan",
+                project_key="valor",
+            )
+            assert matched_id == session.session_id, (
+                f"Expected `plan` reply to match the dormant PM session, "
+                f"got matched_id={matched_id} confidence={confidence:.2f}"
+            )
+            assert confidence >= ROUTING_CONFIDENCE_THRESHOLD, (
+                f"Expected confidence >= {ROUTING_CONFIDENCE_THRESHOLD}, got {confidence:.2f}"
+            )
+        finally:
+            session.delete()
+
+    @pytest.mark.asyncio
+    async def test_skip_reply_matches_dormant_pm_session(self):
+        """A fresh `skip` reply should also match the dormant PM session
+        at confidence >= 0.80."""
+        from bridge.session_router import (
+            ROUTING_CONFIDENCE_THRESHOLD,
+            find_matching_session,
+        )
+
+        chat_id = "tg_valor_chat_skip"
+        session = self._make_dormant_pm_session("tg_valor_pm_skip_1", chat_id)
+        try:
+            matched_id, confidence = await find_matching_session(
+                chat_id=chat_id,
+                message_text="skip",
+                project_key="valor",
+            )
+            assert matched_id == session.session_id, (
+                f"Expected `skip` reply to match the dormant PM session, "
+                f"got matched_id={matched_id} confidence={confidence:.2f}"
+            )
+            assert confidence >= ROUTING_CONFIDENCE_THRESHOLD, (
+                f"Expected confidence >= {ROUTING_CONFIDENCE_THRESHOLD}, got {confidence:.2f}"
+            )
+        finally:
+            session.delete()
+
+    @pytest.mark.asyncio
+    async def test_unrelated_topic_does_not_match(self):
+        """An unrelated reply (topic shift) should NOT match the dormant
+        PM session — the router falls through to new-session creation."""
+        from bridge.session_router import find_matching_session
+
+        chat_id = "tg_valor_chat_topic_shift"
+        session = self._make_dormant_pm_session("tg_valor_pm_topic_shift_1", chat_id)
+        try:
+            matched_id, confidence = await find_matching_session(
+                chat_id=chat_id,
+                message_text=("actually, never mind that — what's the weather forecast?"),
+                project_key="valor",
+            )
+            # Either no match (preferred) or low confidence — both fall through.
+            assert matched_id is None or confidence < 0.80, (
+                f"Unrelated message should not match dormant workflow session, "
+                f"got matched_id={matched_id} confidence={confidence:.2f}"
+            )
+        finally:
+            session.delete()

--- a/tests/unit/test_open_question_gate.py
+++ b/tests/unit/test_open_question_gate.py
@@ -403,3 +403,106 @@ class TestStageAwareOpenQuestionGate:
         )
         questions = _extract_open_questions(output)
         assert questions == []  # Resolved sections are excluded
+
+
+class TestWorkflowAnnouncementExtraction:
+    """Issue #1189: PM workflow-announcement responses end with a
+    ## Open Questions section that must populate session.expectations
+    verbatim, so the unthreaded-message router can match a `plan` or
+    `skip` reply back to the dormant session.
+
+    The PM persona overlay tells the agent to emit a literal phrase
+    ("Unless you directly instruct me to skip our standard workflow...")
+    plus a `## Open Questions` section asking the human to choose between
+    `plan` and `skip`. These tests verify the extraction → expectations
+    pipeline works for that exact response shape.
+    """
+
+    def test_workflow_question_extracted_from_announcement_response(self):
+        """A PM bucket-#3 announcement response is parseable."""
+        pm_response = (
+            "Unless you directly instruct me to skip our standard workflow, "
+            "we need to file an issue to plan all improvements and changes to "
+            "software.\n\n"
+            "Reply with one of:\n"
+            "- `plan` — file an issue and run /do-plan\n"
+            "- `skip` — override SDLC for this task only\n\n"
+            "## Open Questions\n\n"
+            "1. Should I file an issue (`plan`) or skip SDLC (`skip`)?\n"
+        )
+        questions = _extract_open_questions(pm_response)
+        assert len(questions) == 1
+        assert "plan" in questions[0].lower()
+        assert "skip" in questions[0].lower()
+
+    def test_workflow_question_with_bullet_extracted(self):
+        """Bullet-style ## Open Questions for the workflow phrase still extracts."""
+        pm_response = (
+            "Unless you directly instruct me to skip our standard workflow, "
+            "we need to file an issue to plan all improvements and changes to "
+            "software.\n\n"
+            "## Open Questions\n\n"
+            "- Should I file an issue (`plan`) or skip SDLC (`skip`)?\n"
+        )
+        questions = _extract_open_questions(pm_response)
+        assert len(questions) == 1
+
+    @pytest.mark.asyncio
+    async def test_workflow_question_populates_expectations(self):
+        """When a PM response carries the workflow announcement and a
+        ## Open Questions section, draft_message populates expectations
+        from the section even if Haiku does not detect it."""
+        pm_response = (
+            "Unless you directly instruct me to skip our standard workflow, "
+            "we need to file an issue to plan all improvements and changes to "
+            "software.\n\n"
+            "Reply with `plan` to file an issue, or `skip` to override SDLC "
+            "for this task only.\n\n"
+            "## Open Questions\n\n"
+            "1. Should I file an issue (`plan`) or skip SDLC (`skip`)?\n"
+        )
+        mock_haiku = AsyncMock(
+            return_value=StructuredDraft(
+                context_summary="PM announcing workflow contract for a coding request",
+                response=(
+                    "Unless you directly instruct me to skip our standard workflow, "
+                    "we need to file an issue. Reply `plan` or `skip`."
+                ),
+                # Haiku might miss the workflow question — extraction must back-fill it
+                expectations=None,
+            )
+        )
+        with patch("bridge.message_drafter._draft_with_haiku", mock_haiku):
+            result = await draft_message(pm_response)
+
+        assert result.expectations is not None, (
+            "expectations should be populated from the verbatim ## Open Questions section "
+            "so the unthreaded-message router can match a `plan` or `skip` reply"
+        )
+        # The workflow question must contain both reply tokens for the
+        # semantic router to clear the 0.80 threshold against single-word replies.
+        assert "plan" in result.expectations.lower()
+        assert "skip" in result.expectations.lower()
+
+    @pytest.mark.asyncio
+    async def test_haiku_expectations_take_priority_for_workflow(self):
+        """If Haiku already extracts the workflow question, that wins
+        (consistent with the existing LLM-priority rule)."""
+        pm_response = (
+            "Unless you directly instruct me to skip our standard workflow, "
+            "we need to file an issue to plan all improvements and changes to "
+            "software.\n\n"
+            "## Open Questions\n\n"
+            "1. Should I file an issue (`plan`) or skip SDLC (`skip`)?\n"
+        )
+        mock_haiku = AsyncMock(
+            return_value=StructuredDraft(
+                context_summary="PM workflow announcement",
+                response="Unless you directly instruct me to skip... reply `plan` or `skip`.",
+                expectations="Should I file an issue (plan) or skip SDLC (skip)?",
+            )
+        )
+        with patch("bridge.message_drafter._draft_with_haiku", mock_haiku):
+            result = await draft_message(pm_response)
+
+        assert result.expectations == "Should I file an issue (plan) or skip SDLC (skip)?"

--- a/tests/unit/test_persona_loading.py
+++ b/tests/unit/test_persona_loading.py
@@ -9,9 +9,11 @@ Tests:
 - load_system_prompt() uses developer persona with WORKER_RULES
 - load_pm_system_prompt() uses project-manager persona
 - _resolve_overlay_path() checks Desktop/Valor first, then config/personas/
+- PM overlay loader emits WARN when missing the workflow-announcement rule (#1189)
 """
 
 import json
+import logging
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -318,3 +320,130 @@ class TestLoadSystemPromptIntegration:
         """_base.md should not exist -- replaced by segments."""
         base_path = PERSONAS_BASE_DIR / "_base.md"
         assert not base_path.exists(), "_base.md should have been deleted"
+
+
+class TestPMWorkflowAnnouncementWarning:
+    """Issue #1189: PM overlay must contain the workflow-announcement rule.
+
+    The loader at agent/sdk_client.py emits a WARN log when the PM overlay
+    is missing the substring "Unless you directly instruct me to skip".
+    Mirrors the existing CRITIQUE-substring warning pattern (PR #802).
+    """
+
+    @pytest.fixture
+    def _mock_overlay_dir_factory(self, tmp_path, monkeypatch):
+        """Build a per-test PM overlay with custom content."""
+        import agent.sdk_client as sdk_mod
+
+        overlay_dir = tmp_path / "personas"
+        overlay_dir.mkdir()
+        # Minimum non-PM overlays so the loader doesn't crash on other personas
+        (overlay_dir / "developer.md").write_text(
+            "# Developer\n\n## Permissions\n\nFull System Access\n"
+        )
+        (overlay_dir / "teammate.md").write_text(
+            "# Teammate\n\n## Communication\n\nFriendly tone\n"
+        )
+
+        def _set_pm_overlay(content: str) -> None:
+            (overlay_dir / "project-manager.md").write_text(content)
+            monkeypatch.setattr(sdk_mod, "PERSONAS_OVERLAY_DIR", overlay_dir)
+
+        return _set_pm_overlay
+
+    def test_warns_when_announcement_substring_missing(self, _mock_overlay_dir_factory, caplog):
+        """Overlay missing the announcement clause should emit WARN."""
+        # PM overlay with CRITIQUE rules but NO workflow-announcement rule
+        _mock_overlay_dir_factory(
+            "# PM Persona\n\n"
+            "## Hard Rules\n\nCRITIQUE is mandatory after PLAN.\n"
+            "REVIEW is mandatory after TEST.\n"
+        )
+
+        with caplog.at_level(logging.WARNING, logger="agent.sdk_client"):
+            load_persona_prompt("project-manager")
+
+        assert any(
+            "missing the workflow-announcement rule" in record.message for record in caplog.records
+        ), (
+            "Expected WARN log when PM overlay lacks 'Unless you directly instruct me to skip', "
+            f"got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_no_warning_when_announcement_substring_present(
+        self, _mock_overlay_dir_factory, caplog
+    ):
+        """Overlay containing the announcement clause should NOT emit the workflow WARN."""
+        _mock_overlay_dir_factory(
+            "# PM Persona\n\n"
+            "## Intake and Triage\n\n"
+            "CRITIQUE is mandatory.\n"
+            'Use this phrase: "Unless you directly instruct me to skip our standard '
+            "workflow, we need to file an issue to plan all improvements and changes "
+            'to software."\n'
+        )
+
+        with caplog.at_level(logging.WARNING, logger="agent.sdk_client"):
+            load_persona_prompt("project-manager")
+
+        assert not any(
+            "missing the workflow-announcement rule" in record.message for record in caplog.records
+        ), (
+            "Did NOT expect workflow-announcement WARN when overlay contains the phrase, "
+            f"got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_warns_on_empty_overlay(self, _mock_overlay_dir_factory, caplog):
+        """Empty PM overlay (zero-length) should emit the workflow WARN.
+
+        The substring check returns False for empty content. The loader
+        also emits the CRITIQUE warning here; we only assert ours fires.
+        """
+        _mock_overlay_dir_factory("")
+
+        with caplog.at_level(logging.WARNING, logger="agent.sdk_client"):
+            load_persona_prompt("project-manager")
+
+        assert any(
+            "missing the workflow-announcement rule" in record.message for record in caplog.records
+        )
+
+    def test_warns_on_whitespace_only_overlay(self, _mock_overlay_dir_factory, caplog):
+        """Whitespace-only PM overlay should emit the workflow WARN."""
+        _mock_overlay_dir_factory("   \n\n\t\n   \n")
+
+        with caplog.at_level(logging.WARNING, logger="agent.sdk_client"):
+            load_persona_prompt("project-manager")
+
+        assert any(
+            "missing the workflow-announcement rule" in record.message for record in caplog.records
+        )
+
+    def test_warns_when_only_partial_substring_present(self, _mock_overlay_dir_factory, caplog):
+        """Partial substring (e.g., "Unless you directly" but missing the rest)
+        should still emit the WARN — we want the unique opening clause intact."""
+        _mock_overlay_dir_factory(
+            "# PM Persona\n\nCRITIQUE rules.\n"
+            "Unless you directly handle the request differently...\n"
+        )
+
+        with caplog.at_level(logging.WARNING, logger="agent.sdk_client"):
+            load_persona_prompt("project-manager")
+
+        assert any(
+            "missing the workflow-announcement rule" in record.message for record in caplog.records
+        )
+
+    def test_repo_pm_template_has_announcement_substring(self):
+        """The in-repo PM template MUST contain the workflow-announcement clause.
+
+        This guards against the in-repo template drifting away from the rule.
+        It is the source-of-truth fallback when the private overlay is absent.
+        """
+        repo_template = PERSONAS_BASE_DIR / "project-manager.md"
+        assert repo_template.exists(), f"In-repo PM template not found at {repo_template}"
+        content = repo_template.read_text()
+        assert "Unless you directly instruct me to skip" in content, (
+            "In-repo PM template is missing the workflow-announcement clause "
+            "(issue #1189). The loader will emit a WARN at session startup."
+        )


### PR DESCRIPTION
## Summary

Implements issue #1189 (PM persona workflow announcement). PM bucket-#3 (coding/feature/bug/automation/config requests) now requires the agent to STOP, announce the workflow contract verbatim, and pause for human confirmation (`plan` or `skip`) instead of silently filing an issue or implementing directly.

This addresses the failure mode from the 2026-04-28 PBA incident where a PM session implemented LaunchAgents and shell scripts directly without filing a GitHub issue or running SDLC.

## Changes

### 1. PM persona overlay (private + in-repo template)
- Replace bucket #3 with the announce-then-pause rule and the literal phrase: *"Unless you directly instruct me to skip our standard workflow, we need to file an issue to plan all improvements and changes to software."*
- Add **What counts as a software change (issue required)** enumeration covering source code, LaunchAgents, scripts, runtime config files, infrastructure, and new dependencies. Plus a "no-issue tasks" list (replies, GitHub issue management, memory search, status reports) so the rule does not block routine PM work.
- Add **PM Overrides of Shared Defaults** table reversing 6 developer-flavored defaults from `work-patterns.md`, ending with the load-bearing tiebreaker: *"When the shared segment and this overlay disagree, this overlay wins."*
- The in-repo template (`config/personas/project-manager.md`) gets a new `## Intake and Triage` section before `## Hard Rules` so it is a usable fallback when the private overlay is absent.

### 2. Loader-warning patch (`agent/sdk_client.py`)
- Emit WARN at PM session startup if the overlay is missing the substring `"Unless you directly instruct me to skip"`. Mirrors the existing CRITIQUE-substring warning (PR #802). Guards against private-overlay drift on bridge machines.

### 3. Test coverage (88 tests pass)
- `tests/unit/test_persona_loading.py::TestPMWorkflowAnnouncementWarning` (6 tests): substring missing/present, empty overlay, whitespace-only, partial substring, and in-repo template integrity check.
- `tests/unit/test_open_question_gate.py::TestWorkflowAnnouncementExtraction` (4 tests): `## Open Questions` extraction works for the workflow phrase; `draft_message()` populates `expectations` from the section even when Haiku misses it.
- `tests/integration/test_unthreaded_routing.py::TestPlanSkipReplyRouting` (3 tests, real Haiku): `plan` and `skip` replies route back to the dormant PM session at confidence ≥ 0.80; unrelated topic shifts do not match.

### 4. Documentation
- New **PM Workflow Announcement** section in `docs/features/personas.md` describing when it fires, the verbatim phrase, override semantics (one-time, no persistence), the resume flow, and the loader guard.

## Override Semantics

A `skip` reply overrides SDLC for the **current bucket-#3 task only**. The next bucket-#3 message in the same session re-fires the announcement. There is no persistent flag — the agent decides per-message based on the most recent `## Open Questions` exchange. This avoids the failure mode where a topic shift mid-session silently inherits a prior override.

## Decision: Text-Only, No Structural Hook

The plan deliberately adopts the text-only path (no stop-hook blocking Bash/Write/Edit). Rationale documented in the plan's *Solution → Technical Approach* section. The 2-week observation window: if ≥2 confirmed bucket-#3 violations occur after merge, file a follow-up issue tagged `pm-overlay-followup` proposing the structural hook.

## Test plan

- [x] Unit tests passing (78 tests in target files including 10 new tests)
- [x] Integration tests passing (10 tests including 3 live-Haiku tests confirming `plan`/`skip` route at confidence ≥ 0.80)
- [x] Lint clean (`python -m ruff check .`)
- [x] Format clean (`python -m ruff format --check .`)
- [x] All Success Criteria checkboxes met (10/11 PASS in `validate_build.py`; the single FAIL is a pre-existing httpcore/sentry_sdk env issue on `pytest tests/` collection that also fails on `main` and is unrelated to this PR — the new tests run cleanly in isolation)
- [x] Documentation written in `docs/features/personas.md`

Closes #1189