### PR TITLE
fix(#1206): helper-raises coverage + log enrichment for continuation-PM

### DIFF
--- a/agent/session_completion.py
+++ b/agent/session_completion.py
@@ -434,7 +434,11 @@ def _create_continuation_pm(
         )
 
     except Exception as e:
-        logger.error(f"[harness] _create_continuation_pm failed: {e}", exc_info=True)
+        logger.error(
+            f"[harness] _create_continuation_pm failed for "
+            f"parent_id={getattr(parent, 'session_id', '?')}: {e}",
+            exc_info=True,
+        )
 
 
 def _pipeline_complete_lock_key(parent_id: str) -> str:

--- a/tests/unit/test_continuation_pm.py
+++ b/tests/unit/test_continuation_pm.py
@@ -251,6 +251,52 @@ class TestCreateContinuationPM:
             f"Expected '[continuation-pm-blocked]' error log; got: {_msgs}"
         )
 
+    def test_resolve_helper_raise_is_logged_not_swallowed(self, terminal_pm, redis_test_db, caplog):
+        """If _resolve_working_dir_for_parent raises, the error is logged
+        with the [harness] tag and parent context, and no malformed continuation
+        is saved.
+
+        Issue #1206: covers the broad ``except Exception`` branch at
+        ``agent/session_completion.py:436``. The helper raising mid-spawn is a
+        plausible failure (config lookup, projects.json IO error) and the
+        previous log line lost parent context, making post-mortem triage
+        harder. This test asserts the enriched log message.
+        """
+        import logging
+
+        from agent.agent_session_queue import _create_continuation_pm
+
+        before = len(list(AgentSession.query.all()))
+        with (
+            patch(
+                "agent.session_completion._resolve_working_dir_for_parent",
+                side_effect=RuntimeError("simulated config failure"),
+            ),
+            caplog.at_level(logging.ERROR),
+        ):
+            _create_continuation_pm(
+                parent=terminal_pm,
+                agent_session=None,
+                issue_number=934,
+                stage="BUILD",
+                outcome="success",
+                result_preview="r",
+            )
+
+        after = len(list(AgentSession.query.all()))
+        assert after == before, "no malformed continuation session was saved"
+
+        msgs = [r.message for r in caplog.records]
+        assert any("[harness] _create_continuation_pm failed" in m for m in msgs), (
+            f"Expected [harness] tag in error log; got: {msgs!r}"
+        )
+        assert any(terminal_pm.session_id in m for m in msgs), (
+            f"Expected parent session_id in error log; got: {msgs!r}"
+        )
+        assert any("simulated config failure" in m for m in msgs), (
+            f"Expected the simulated RuntimeError text in error log; got: {msgs!r}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Test 2: Continuation depth cap prevents infinite chains


### PR DESCRIPTION
## Summary

Item 4 of the four `#1206` deferred-verification items — defense-in-depth coverage for the broad `except Exception` branch in `_create_continuation_pm`.

## Changes

- **`agent/session_completion.py`** — enrich the `[harness]` error log line at L437 to include `parent_id={getattr(parent, 'session_id', '?')}`. Drops nothing; adds parent context that triage relies on when the helper or any inner step raises.
- **`tests/unit/test_continuation_pm.py`** — add `test_resolve_helper_raise_is_logged_not_swallowed` to `TestCreateContinuationPM`. Mocks `_resolve_working_dir_for_parent` to raise `RuntimeError`; asserts the error reaches `caplog` with the `[harness]` tag, the parent `session_id`, and the simulated error text. Asserts no malformed `AgentSession` was saved (`before == after` count). Reuses the existing `terminal_pm` fixture and patch path from `test_working_dir_resolves_via_helper`.

## Testing

- [x] `pytest tests/unit/test_continuation_pm.py -v` — 16/16 pass (15 prior + 1 new)
- [x] `pytest tests/integration/test_continuation_pm_handoff.py -q` — 1/1 pass (validator cross-check; confirms the cosmetic log enrichment did not regress integration)
- [x] `python -m ruff check agent/session_completion.py tests/unit/test_continuation_pm.py` — clean
- [x] `python scripts/validate_docs_changed.py docs/plans/sdlc-1206.md` — passes (plan declares no doc changes needed)

## Deferred-verification items (1, 2, 3)

Items 1, 2, 3 are operator-driven post-merge work the lead agent picks up after the 24h post-PR-#1196 window elapses (`2026-04-29T16:31:29Z`). They are NOT bundled into this PR by design — see plan Step 0:

> Item 4 (helper-raises test + log enrichment) is a defense-in-depth code change independent of items 1–3 and CAN proceed in parallel with the 24h wait.

Verification artifacts (24h grep, dashboard observation, e2e fresh-issue) will be posted as comments on `#1206` after this PR merges.

## Definition of Done

- [x] Built: log enrichment + new test
- [x] Tested: unit + integration tests pass
- [x] Reviewed: lint clean
- [x] Documented: plan explicitly declares no doc changes needed (justified in `## Documentation` section)
- [x] Quality: ruff clean

Closes #1206