### PR TITLE
fix(worker): expand ~ in working_directory + log persona resolution per session

### DIFF
--- a/agent/sdk_client.py
+++ b/agent/sdk_client.py
@@ -1776,6 +1776,79 @@ def _build_error_recovery_message(error_text: str) -> str:
     )
 
 
+def _load_persona_overlay_with_log(
+    persona: str,
+    request_id: str,
+    session_id: str | None,
+    fallback: str | None = None,
+) -> str | None:
+    """Load a persona overlay and emit one canonical log line.
+
+    Wraps :func:`load_persona_prompt` with structured per-session logging so
+    the test-cuttlefish-* skills (and any future test) can grep
+    ``Persona overlay`` filtered by ``session_id=<sid>`` and get exactly one
+    definitive answer per session. Without this funnel, the existing
+    ``Resolved persona:`` and harness ``Appending N-char system prompt`` lines
+    were not always emitted in worker.log, leaving the test unable to confirm
+    whether the requested persona had loaded.
+
+    Behavior:
+
+    - Success: emits ``Persona overlay loaded: name=<persona> prompt_chars=<N>
+      session_id=<sid>`` at INFO and returns the prompt.
+    - Missing overlay with successful fallback: emits a single
+      ``Persona overlay missing: requested=<persona> fell_back_to=<fallback>
+      session_id=<sid>`` at WARNING and returns the fallback prompt. The
+      ``Persona overlay loaded:`` line is intentionally NOT emitted in this
+      branch — the WARNING is the canonical signal.
+    - Missing overlay with no fallback (or fallback also missing): emits a
+      WARNING and returns ``None``.
+
+    Args:
+        persona: The persona name to load (e.g. "customer-service",
+            "teammate").
+        request_id: The per-call correlation/request id used as the log
+            prefix (matches sibling log lines like ``[{request_id}]``).
+        session_id: The session id (for grep correlation). May be ``None``
+            for callers that don't have one in scope.
+        fallback: Optional persona name to try when the requested overlay
+            file is missing. ``None`` means no fallback.
+
+    Returns:
+        The persona prompt string, or ``None`` if both the requested overlay
+        and the fallback are missing.
+    """
+    try:
+        prompt = load_persona_prompt(persona)
+        logger.info(
+            f"[{request_id}] Persona overlay loaded: name={persona} "
+            f"prompt_chars={len(prompt) if prompt else 0} "
+            f"session_id={session_id}"
+        )
+        return prompt
+    except FileNotFoundError:
+        if fallback:
+            try:
+                fallback_prompt = load_persona_prompt(fallback)
+                logger.warning(
+                    f"[{request_id}] Persona overlay missing: requested={persona} "
+                    f"fell_back_to={fallback} session_id={session_id}"
+                )
+                return fallback_prompt
+            except FileNotFoundError:
+                logger.warning(
+                    f"[{request_id}] Persona overlay missing: requested={persona} "
+                    f"fell_back_to={fallback} session_id={session_id} "
+                    "(fallback also missing, returning None)"
+                )
+                return None
+        logger.warning(
+            f"[{request_id}] Persona overlay missing: requested={persona} "
+            f"fell_back_to=None session_id={session_id}"
+        )
+        return None
+
+
 def _resolve_persona(
     project: dict | None,
     chat_title: str | None,
@@ -3104,26 +3177,35 @@ async def get_agent_response_sdk(
             # cat docs/, python -m tools.valor_session status, etc.).
             # Any mutation must be dispatched to a dev-session subagent.
             custom_system_prompt = load_pm_system_prompt(working_dir)
+            logger.info(
+                f"[{request_id}] Persona overlay loaded: name=project-manager "
+                f"prompt_chars={len(custom_system_prompt) if custom_system_prompt else 0} "
+                f"session_id={session_id}"
+            )
             logger.info(f"[{request_id}] PM session mode: PM persona, bypassPermissions")
         elif project_mode == "pm":
             # PM mode: use PM system prompt (no WORKER_RULES, loads work-vault CLAUDE.md)
             custom_system_prompt = load_pm_system_prompt(working_dir)
+            logger.info(
+                f"[{request_id}] Persona overlay loaded: name=project-manager "
+                f"prompt_chars={len(custom_system_prompt) if custom_system_prompt else 0} "
+                f"session_id={session_id}"
+            )
         elif persona == PersonaType.CUSTOMER_SERVICE:
             # Customer-service persona: action-oriented, can run tools/skills, no code writes
-            try:
-                custom_system_prompt = load_persona_prompt("customer-service")
-            except FileNotFoundError:
-                logger.warning("Customer-service persona not available, falling back to teammate")
-                try:
-                    custom_system_prompt = load_persona_prompt("teammate")
-                except FileNotFoundError:
-                    pass
+            custom_system_prompt = _load_persona_overlay_with_log(
+                "customer-service",
+                request_id=request_id,
+                session_id=session_id,
+                fallback="teammate",
+            )
         elif persona == PersonaType.TEAMMATE:
             # Teammate persona: casual mode, no WORKER_RULES
-            try:
-                custom_system_prompt = load_persona_prompt("teammate")
-            except FileNotFoundError:
-                logger.warning("Teammate persona not available, falling back to default")
+            custom_system_prompt = _load_persona_overlay_with_log(
+                "teammate",
+                request_id=request_id,
+                session_id=session_id,
+            )
         # Developer persona uses default (load_system_prompt via ValorAgent.__init__)
 
         # Determine gh_repo for cross-repo SDLC requests (issue #375).

--- a/agent/worktree_manager.py
+++ b/agent/worktree_manager.py
@@ -44,7 +44,14 @@ def validate_workspace(
         return allowed_root
 
     try:
-        resolved = Path(path).resolve()
+        # Expand ~ before resolve(): Path.resolve() does NOT expand ~ and would
+        # concatenate it under cwd, producing nonsense like
+        # "/Users/<user>/src/ai/~/src/cuttlefish". projects.json may store
+        # working_directory as the literal string "~/src/foo" (load_config()
+        # in bridge/routing.py expands it, but out-of-band session creators
+        # — test skills, manual valor_session calls — may bypass that funnel).
+        # Expanding here makes the worker chokepoint resilient.
+        resolved = Path(path).expanduser().resolve()
     except OSError as e:
         logger.warning(
             f"Workspace validation: failed to resolve '{path}': {e}, falling back to {allowed_root}"

--- a/tests/unit/test_persona_loading.py
+++ b/tests/unit/test_persona_loading.py
@@ -25,6 +25,7 @@ from agent.sdk_client import (
     PERSONAS_BASE_DIR,
     PERSONAS_OVERLAY_DIR,
     PERSONAS_SEGMENTS_DIR,
+    _load_persona_overlay_with_log,
     _resolve_overlay_path,
     _resolve_persona,
     load_identity,
@@ -446,4 +447,113 @@ class TestPMWorkflowAnnouncementWarning:
         assert "Unless you directly instruct me to skip" in content, (
             "In-repo PM template is missing the workflow-announcement clause "
             "(issue #1189). The loader will emit a WARN at session startup."
+        )
+
+
+class TestPersonaOverlayLogging:
+    """Tests for _load_persona_overlay_with_log() — the canonical persona-load
+    log line.
+
+    Background: the test-cuttlefish-setup-podcast skill could not confirm
+    from logs whether the customer-service persona had loaded for an email
+    session. Existing logs (`Resolved persona:` and the harness
+    `Appending N-char system prompt`) did not appear in worker.log for the
+    test session. The test cannot answer its headline question without a
+    canonical log line.
+
+    Contract: every persona load emits exactly one line matching
+    "Persona overlay loaded:" (or "Persona overlay missing:" on fallback)
+    that includes the request_id, persona name, prompt_chars, and session_id.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _mock_overlay_dir(self, tmp_path, monkeypatch):
+        """Provide minimal overlay files for the persona loader."""
+        import agent.sdk_client as sdk_mod
+
+        overlay_dir = tmp_path / "personas"
+        overlay_dir.mkdir()
+        (overlay_dir / "customer-service.md").write_text(
+            "# Customer Service Persona\n\nHelpful, action-oriented voice."
+        )
+        (overlay_dir / "teammate.md").write_text(
+            "# Teammate Persona\n\n## Communication Style\n\nKeep it casual."
+        )
+        monkeypatch.setattr(sdk_mod, "PERSONAS_OVERLAY_DIR", overlay_dir)
+
+    def test_logs_canonical_line_on_successful_load(self, caplog):
+        """Successful load emits 'Persona overlay loaded:' at INFO with all fields."""
+        with caplog.at_level(logging.INFO, logger="agent.sdk_client"):
+            prompt = _load_persona_overlay_with_log(
+                "customer-service",
+                request_id="req-abc",
+                session_id="email_test_123",
+            )
+
+        assert prompt is not None
+        assert len(prompt) > 0
+
+        loaded_lines = [r for r in caplog.records if "Persona overlay loaded:" in r.getMessage()]
+        assert len(loaded_lines) == 1, (
+            f"Expected exactly one 'Persona overlay loaded:' line, got {len(loaded_lines)}: "
+            f"{[r.getMessage() for r in loaded_lines]}"
+        )
+        msg = loaded_lines[0].getMessage()
+        assert "[req-abc]" in msg
+        assert "name=customer-service" in msg
+        assert "prompt_chars=" in msg
+        assert "session_id=email_test_123" in msg
+        # prompt_chars must be a positive integer
+        import re
+
+        m = re.search(r"prompt_chars=(\d+)", msg)
+        assert m is not None and int(m.group(1)) > 0
+
+    def test_logs_missing_with_fallback_when_overlay_absent(self, caplog, monkeypatch):
+        """When the requested overlay is missing but the fallback succeeds,
+        emit a single WARNING with requested= and fell_back_to= fields."""
+        import agent.sdk_client as sdk_mod
+
+        # Point overlay dir at one with only teammate available.
+        # customer-service.md is missing; load_persona_prompt will raise.
+        # _load_persona_overlay_with_log should fall back to teammate.
+        empty_dir = sdk_mod.PERSONAS_OVERLAY_DIR
+        # Remove customer-service overlay to simulate missing
+        (empty_dir / "customer-service.md").unlink()
+
+        with caplog.at_level(logging.WARNING, logger="agent.sdk_client"):
+            prompt = _load_persona_overlay_with_log(
+                "customer-service",
+                request_id="req-xyz",
+                session_id="email_test_456",
+                fallback="teammate",
+            )
+
+        # Fallback succeeded
+        assert prompt is not None
+        missing_lines = [r for r in caplog.records if "Persona overlay missing:" in r.getMessage()]
+        assert len(missing_lines) == 1, (
+            f"Expected one 'Persona overlay missing:' line, got {len(missing_lines)}"
+        )
+        msg = missing_lines[0].getMessage()
+        assert "[req-xyz]" in msg
+        assert "requested=customer-service" in msg
+        assert "fell_back_to=teammate" in msg
+        assert "session_id=email_test_456" in msg
+
+    def test_canonical_line_grep_pattern_returns_one_per_session(self, caplog):
+        """A grep for 'Persona overlay' filtered by session_id must return
+        exactly one line per session — the property the cuttlefish brief asks
+        for ('grep "Persona overlay" worker.log | grep session_id=<sid>')."""
+        sid = "session-grep-test"
+        with caplog.at_level(logging.INFO, logger="agent.sdk_client"):
+            _load_persona_overlay_with_log("customer-service", request_id="r1", session_id=sid)
+
+        matched = [
+            r
+            for r in caplog.records
+            if "Persona overlay" in r.getMessage() and f"session_id={sid}" in r.getMessage()
+        ]
+        assert len(matched) == 1, (
+            f"grep recipe must return exactly one line per session, got {len(matched)}"
         )

--- a/tests/unit/test_workspace_safety.py
+++ b/tests/unit/test_workspace_safety.py
@@ -158,3 +158,49 @@ class TestFallbackBehavior:
             result = validate_workspace(broken, tmp_workspace)
         assert result == tmp_workspace
         assert "does not exist" in caplog.text
+
+
+class TestTildeExpansion:
+    """Invariant 4: Paths beginning with ~ must be expanded before resolution.
+
+    Regression guard for the cuttlefish hotfix: projects.json may store
+    working_directory as the literal string "~/src/cuttlefish" and pass it
+    untouched to the worker. Without expansion, Path.resolve() concatenates
+    the tilde under cwd ("/Users/<user>/src/ai/~/src/cuttlefish"), which
+    fails containment and falls back to allowed_root with a noisy warning.
+    """
+
+    def test_tilde_path_expanded_before_validation(self, tmp_path, monkeypatch):
+        """A "~/foo" string must resolve to <home>/foo, not cwd/~/foo."""
+        # Pretend HOME is tmp_path so we can construct a real "~/foo" target
+        monkeypatch.setenv("HOME", str(tmp_path))
+        target = tmp_path / "foo"
+        target.mkdir()
+        result = validate_workspace("~/foo", tmp_path)
+        # Must resolve under the expanded home, not cwd/~/foo
+        assert result == target.resolve()
+        assert "~" not in str(result)
+
+    def test_tilde_path_passed_as_path_object_expanded(self, tmp_path, monkeypatch):
+        """Path("~/foo") must also be expanded; Path() does not auto-expand."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        target = tmp_path / "foo"
+        target.mkdir()
+        result = validate_workspace(Path("~/foo"), tmp_path)
+        assert result == target.resolve()
+        assert "~" not in str(result)
+
+    def test_tilde_path_does_not_warn_about_missing_directory(self, tmp_path, monkeypatch, caplog):
+        """Project dict with working_directory="~/foo" must not produce a
+        'does not exist' warning concatenating ~ under cwd. This is the
+        regression scenario from the cuttlefish brief."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        target = tmp_path / "foo"
+        target.mkdir()
+        with caplog.at_level(logging.WARNING):
+            result = validate_workspace("~/foo", tmp_path)
+        assert result == target.resolve()
+        # The literal "~" must NOT appear in any warning text — that is the
+        # exact symptom from the cuttlefish run.
+        for record in caplog.records:
+            assert "~" not in record.getMessage(), f"Tilde leaked into log: {record.getMessage()}"


### PR DESCRIPTION
## Summary

Two surgical hotfixes surfaced by `test-cuttlefish-setup-podcast`. Brief:
`~/.claude/skills/test-cuttlefish-setup-podcast/FOLLOWUP_AGENT_BRIEF.md`.

### Bug 1 — `~` not expanded in `working_directory`

`projects.json` may store `working_directory` as the literal string
`"~/src/cuttlefish"`. `bridge/routing.py::load_config()` already expands
`~` at config-load time, but out-of-band session creators (test skills,
manual `valor_session` calls, the cuttlefish test skill) bypass that
funnel and pass the unexpanded string straight to the worker.

`Path("~/foo").resolve()` does NOT expand `~` — it concatenates it under
cwd, producing nonsense like `/Users/tomcounsell/src/ai/~/src/cuttlefish`,
which fails containment and falls back to `allowed_root` with a noisy
warning:

```
agent.worktree_manager WARNING Workspace validation:
  '/Users/tomcounsell/src/ai/~/src/cuttlefish' does not exist or is not a
  directory, falling back to /Users/tomcounsell/src
```

Subsequent git ops in the cuttlefish run then crashed (cannot change to
`~/src/cuttlefish`, not a git repository).

**Fix:** call `.expanduser()` before `.resolve()` in
`agent/worktree_manager.py::validate_workspace`, the single chokepoint
shared by `agent/session_executor.py:695` and
`agent/sdk_client.py::ValorAgent.__init__:1319`. All worker reads of a
session's working_dir flow through this funnel.

**Tests:** new `TestTildeExpansion` class in
`tests/unit/test_workspace_safety.py` with three regression tests
covering the exact cuttlefish scenario.

### Bug 2 — No per-session persona-load log line

The cuttlefish run produced no signal in `logs/worker.log` confirming
which persona had loaded. The existing `Resolved persona:` log line and
the harness `Appending N-char system prompt` did not appear, and the
ad-hoc fallback `logger.warning("Customer-service persona not available,
falling back to teammate")` did not fire either. The test cannot answer
its headline question without a canonical signal.

**Fix:** add `agent/sdk_client.py::_load_persona_overlay_with_log` —
a thin wrapper around `load_persona_prompt` that emits exactly one
structured line per call:

```
[<request_id>] Persona overlay loaded: name=<persona>
  prompt_chars=<N> session_id=<sid>
```

On fallback (overlay missing but a fallback was specified):

```
[<request_id>] Persona overlay missing: requested=<persona>
  fell_back_to=<fallback> session_id=<sid>
```

Wired into `get_agent_response_sdk`'s elif chain. The PM session and
`project_mode == "pm"` branches emit the same shape inline, so:

```
grep "Persona overlay" logs/worker.log | grep session_id=<sid>
```

returns exactly one definitive line per session regardless of which
branch fired.

**Tests:** new `TestPersonaOverlayLogging` class in
`tests/unit/test_persona_loading.py` covering successful load, fallback
on missing overlay, and the grep-recipe property (one line per session).

## What is intentionally NOT in this PR

**Bug 3 — email-transport sessions write replies to `telegram:outbox:`,
not `email:outbox:`.** The brief flags this as a separate investigation
item. It needs an A/B design call (agent-always-uses-`send_message` vs
`OutputHandler` branches on transport) before any code lands. Will be
filed as a separate `investigation` issue.

## Test plan

- [x] `pytest tests/unit/test_workspace_safety.py` — 21 passed (3 new)
- [x] `pytest tests/unit/test_persona_loading.py` — 47 passed (3 new)
- [x] `pytest tests/unit/test_sdk_client_sdlc.py` — 65 passed (no regressions)
- [x] `python -m ruff format .` clean
- [ ] User restarts services post-merge: `./scripts/valor-service.sh restart`
- [ ] Re-run `test-cuttlefish-setup-podcast` to verify Bug 3 is now
      visible in logs (Bug 1+2 are prerequisites for that diagnosis).