### PR TITLE
fix(worker): route default reply via the spawning-bridge medium

### DIFF
--- a/agent/output_handler.py
+++ b/agent/output_handler.py
@@ -159,6 +159,93 @@ class TelegramRelayOutputHandler:
             self._redis = redis.Redis.from_url(self._redis_url, decode_responses=True)
         return self._redis
 
+    @staticmethod
+    def _resolve_transport(session: Any) -> str:
+        """Extract the transport from a session's extra_context.
+
+        Returns "telegram" when the session is None, has no extra_context, or
+        the transport key is missing. This preserves back-compat with sessions
+        created before email transport existed.
+        """
+        if session is None:
+            return "telegram"
+        extra = getattr(session, "extra_context", None) or {}
+        return extra.get("transport") or "telegram"
+
+    async def _send_via_email_outbox(
+        self,
+        chat_id: str,
+        text: str,
+        session: Any,
+    ) -> None:
+        """Queue an email reply on ``email:outbox:{session_id}``.
+
+        Builds a payload matching ``tools/send_message.py::_send_via_email``
+        and the unified shape consumed by ``bridge/email_relay.py``. Subject
+        is prefixed with ``"Re: "`` if the original subject does not already
+        start with ``re:`` (case-insensitive); ``in_reply_to`` and
+        ``references`` are sourced from ``extra_context.email_message_id``.
+
+        Implements the user-set design rule (2026-04-30): when a session was
+        spawned via the email bridge, the default Stop-drafter reply must
+        route through the email outbox even when no project-specific email
+        handler is registered. This handler is the worker's catch-all default;
+        without this branch, email-spawned sessions silently misroute to
+        telegram and the SMTP relay never sees them.
+        """
+        session_id = getattr(session, "session_id", None) or chat_id
+
+        # Pull email metadata stamped on the session by bridge/email_bridge.py
+        # (or the test skill's spawn.py). Missing fields fall back to safe
+        # defaults so a malformed session still produces a valid envelope.
+        extra = getattr(session, "extra_context", None) or {}
+        original_subject = extra.get("email_subject") or ""
+        in_reply_to = extra.get("email_message_id") or None
+
+        # Subject prefixing: match bridge/email_bridge.py::_build_reply_mime
+        # worker-reply semantics — always prepend "Re: " unless the subject
+        # already starts with "re:" (case-insensitive). Empty subject becomes
+        # "Re: (no subject)" so threading still works in the recipient's client.
+        if original_subject:
+            if original_subject.lower().startswith("re:"):
+                subject = original_subject
+            else:
+                subject = f"Re: {original_subject}"
+        else:
+            subject = "Re: (no subject)"
+
+        payload = {
+            "session_id": session_id,
+            "to": chat_id,
+            "subject": subject,
+            "body": text,
+            "attachments": [],
+            "in_reply_to": in_reply_to,
+            "references": in_reply_to,
+            "from_addr": os.environ.get("SMTP_USER", ""),
+            "timestamp": time.time(),
+        }
+
+        queue_key = f"email:outbox:{session_id}"
+        try:
+            r = self._get_redis()
+            r.rpush(queue_key, json.dumps(payload))
+            r.expire(queue_key, self.OUTBOX_TTL)
+            logger.info(
+                "Queued email output to %s (%d chars, to=%s, in_reply_to=%s)",
+                queue_key,
+                len(text),
+                chat_id,
+                bool(in_reply_to),
+            )
+        except Exception as e:
+            logger.error(f"Failed to write to Redis outbox {queue_key}: {e}")
+
+        # Dual-write to file handler for audit/debugging (matches the telegram
+        # path so worker logs preserve a record of every send attempt).
+        if self._file_handler is not None:
+            await self._file_handler.send(chat_id, text, 0, session)
+
     async def send(
         self,
         chat_id: str,
@@ -166,19 +253,41 @@ class TelegramRelayOutputHandler:
         reply_to_msg_id: int,
         session: Any = None,
     ) -> None:
-        """Write a message payload to the Redis outbox for Telegram delivery.
+        """Write a message payload to the Redis outbox.
 
-        Payload format matches ``tools/send_telegram.py:145-151``::
+        Routes by ``session.extra_context.transport``:
 
-            {"chat_id", "reply_to", "text", "session_id", "timestamp"}
+        - ``telegram`` (default): payload format matches
+          ``tools/send_telegram.py:145-151``::
+
+              {"chat_id", "reply_to", "text", "session_id", "timestamp"}
+
+          Written to ``telegram:outbox:{session_id}``.
+        - ``email``: payload matches ``tools/send_message.py::_send_via_email``
+          and ``bridge/email_relay.py``'s expected schema. Written to
+          ``email:outbox:{session_id}``. This implements the "default reply
+          follows spawning bridge" rule (user decision 2026-04-30): a session
+          spawned via the email bridge replies via email by default, even if
+          this handler is registered as the project's catch-all.
 
         Args:
-            chat_id: Target Telegram chat identifier.
+            chat_id: Target chat identifier (Telegram chat_id or recipient
+                email address depending on transport).
             text: Message text to send.
             reply_to_msg_id: Original message ID to reply to (may be None).
-            session: Optional AgentSession providing ``session_id``.
+                Ignored for email transport.
+            session: Optional AgentSession providing ``session_id`` and
+                ``extra_context`` (transport, email_message_id, etc.).
         """
         if not text:
+            return
+
+        # Transport-aware routing: redirect email-spawned sessions to the
+        # email outbox. Default (no transport key, or any non-email value) is
+        # telegram, preserving back-compat with older sessions.
+        transport = self._resolve_transport(session)
+        if transport == "email":
+            await self._send_via_email_outbox(chat_id, text, session)
             return
 
         session_id = getattr(session, "session_id", None) or chat_id

--- a/tests/unit/test_output_handler.py
+++ b/tests/unit/test_output_handler.py
@@ -1016,3 +1016,291 @@ class TestReadTheRoomWiring:
                 os.environ.pop("READ_THE_ROOM_ENABLED", None)
             else:
                 os.environ["READ_THE_ROOM_ENABLED"] = old
+
+
+class TestTransportAwareRouting:
+    """Tests for transport-aware default routing in TelegramRelayOutputHandler.
+
+    Design rule (set by user 2026-04-30): the default Stop drafter / OutputHandler
+    routes the agent's final reply through the **same medium that spawned the
+    session**. ``extra_context.transport == "email"`` redirects writes from
+    ``telegram:outbox:<sid>`` to ``email:outbox:<sid>`` with an email-shaped
+    payload that ``bridge/email_relay.py`` can deliver. Sessions without a
+    transport key, or with ``transport == "telegram"``, preserve the existing
+    Telegram behavior.
+
+    Reactions (``react()``) are nonsensical for email — there is no email
+    equivalent of an emoji reaction. For ``transport=email`` sessions,
+    ``react()`` becomes a silent no-op (single INFO log).
+    """
+
+    def _make_handler(self, mock_redis=None):
+        from agent.output_handler import TelegramRelayOutputHandler
+
+        h = TelegramRelayOutputHandler(redis_url="redis://localhost:6379/0")
+        if mock_redis is not None:
+            h._redis = mock_redis
+        else:
+            h._redis = MagicMock()
+        return h
+
+    def _email_session(
+        self,
+        session_id: str = "email-sess",
+        message_id: str = "<orig-msg@example.com>",
+        from_addr: str = "customer@example.com",
+        subject: str = "Original subject",
+        to_addrs=None,
+        cc_addrs=None,
+    ):
+        """Build a fake email-spawned session matching bridge/email_bridge.py."""
+        s = MagicMock()
+        s.session_id = session_id
+        s.extra_context = {
+            "transport": "email",
+            "email_message_id": message_id,
+            "email_from": from_addr,
+            "email_to_addrs": to_addrs or [],
+            "email_cc_addrs": cc_addrs or [],
+            "email_subject": subject,
+        }
+        return s
+
+    # ── 1. Telegram-spawned session writes to telegram outbox (regression) ──
+
+    def test_telegram_session_writes_to_telegram_outbox(self):
+        """Sessions with transport=telegram (or no transport set) must continue
+        to write to telegram:outbox — back-compat with the existing behavior."""
+        handler = self._make_handler()
+
+        s = MagicMock()
+        s.session_id = "tg-sess"
+        s.extra_context = {"transport": "telegram"}
+
+        # Stub the drafter so we don't need its internals.
+        with patch(
+            "bridge.message_drafter.draft_message",
+            AsyncMock(side_effect=RuntimeError("skip drafter")),
+        ):
+            asyncio.run(handler.send("123456", "Hello world", 0, session=s))
+
+        handler._redis.rpush.assert_called_once()
+        key = handler._redis.rpush.call_args[0][0]
+        assert key == "telegram:outbox:tg-sess"
+
+        payload = json.loads(handler._redis.rpush.call_args[0][1])
+        assert payload["chat_id"] == "123456"
+        assert payload["text"] == "Hello world"
+        assert payload["session_id"] == "tg-sess"
+
+    # ── 2. Email-spawned session writes to email outbox with correct payload ──
+
+    def test_email_session_writes_to_email_outbox(self):
+        """transport=email must route writes to email:outbox with the unified
+        payload shape (matching tools/send_message.py::_send_via_email and the
+        relay's expected schema in bridge/email_relay.py)."""
+        handler = self._make_handler()
+
+        session = self._email_session(
+            session_id="email-sess",
+            message_id="<orig@example.com>",
+            from_addr="customer@example.com",
+            subject="My setup question",
+        )
+
+        with patch(
+            "bridge.message_drafter.draft_message",
+            AsyncMock(side_effect=RuntimeError("skip drafter")),
+        ):
+            asyncio.run(
+                handler.send(
+                    chat_id="customer@example.com",
+                    text="Here is the answer.",
+                    reply_to_msg_id=0,
+                    session=session,
+                )
+            )
+
+        handler._redis.rpush.assert_called_once()
+        key = handler._redis.rpush.call_args[0][0]
+        assert key == "email:outbox:email-sess", f"Expected email outbox key, got {key}"
+
+        payload = json.loads(handler._redis.rpush.call_args[0][1])
+        # Match the unified email payload schema from bridge/email_relay.py.
+        assert payload["session_id"] == "email-sess"
+        assert payload["to"] == "customer@example.com"
+        # Subject prefixed with "Re:" (worker-reply semantics).
+        assert payload["subject"] == "Re: My setup question"
+        assert payload["body"] == "Here is the answer."
+        assert payload["in_reply_to"] == "<orig@example.com>"
+        assert payload["references"] == "<orig@example.com>"
+        assert "timestamp" in payload
+        # No telegram-only fields leak through.
+        assert "chat_id" not in payload
+        assert "reply_to" not in payload
+
+    # ── 3. Email-spawned session with "Re:" subject does NOT double-prefix ──
+
+    def test_email_session_does_not_double_prefix_re(self):
+        """If the original subject already starts with "Re:" (any case), the
+        reply must not become "Re: Re: ...". Match the worker reply semantics
+        in bridge/email_bridge.py::_build_reply_mime."""
+        handler = self._make_handler()
+
+        session = self._email_session(subject="Re: My setup question")
+
+        with patch(
+            "bridge.message_drafter.draft_message",
+            AsyncMock(side_effect=RuntimeError("skip drafter")),
+        ):
+            asyncio.run(handler.send("customer@example.com", "ok", 0, session=session))
+
+        payload = json.loads(handler._redis.rpush.call_args[0][1])
+        assert payload["subject"] == "Re: My setup question"
+
+    def test_email_session_does_not_double_prefix_re_lowercase(self):
+        """Case-insensitive: "re: foo" should not become "Re: re: foo"."""
+        handler = self._make_handler()
+
+        session = self._email_session(subject="re: lowercase")
+
+        with patch(
+            "bridge.message_drafter.draft_message",
+            AsyncMock(side_effect=RuntimeError("skip drafter")),
+        ):
+            asyncio.run(handler.send("customer@example.com", "ok", 0, session=session))
+
+        payload = json.loads(handler._redis.rpush.call_args[0][1])
+        # The original casing is preserved verbatim (no prefix added).
+        assert payload["subject"] == "re: lowercase"
+
+    # ── 4. Reactions on email sessions are dropped silently ──
+
+    def test_email_session_send_never_queues_reaction_payload(self):
+        """For transport=email sessions, send() must NOT queue any reaction
+        payload (including the RTR suppress 👀 reaction). Email has no emoji-
+        reaction concept; queueing one would orphan a payload that nothing
+        consumes. The transport-aware short-circuit at the top of send()
+        bypasses the entire RTR/reaction path.
+        """
+        handler = self._make_handler()
+        session = self._email_session()
+
+        # Force the RTR module to return "suppress" — if the email branch
+        # didn't short-circuit, this would queue a reaction.
+        from bridge.read_the_room import RoomVerdict
+
+        suppress_verdict = RoomVerdict(action="suppress", reason="testing", revised_text=None)
+
+        # Set the env flag so RTR would otherwise run.
+        import os as _os
+
+        old_rtr = _os.environ.get("READ_THE_ROOM_ENABLED")
+        _os.environ["READ_THE_ROOM_ENABLED"] = "1"
+        try:
+            with (
+                patch(
+                    "bridge.message_drafter.draft_message",
+                    AsyncMock(side_effect=RuntimeError("skip drafter")),
+                ),
+                patch(
+                    "bridge.read_the_room.read_the_room",
+                    AsyncMock(return_value=suppress_verdict),
+                ),
+            ):
+                asyncio.run(
+                    handler.send(
+                        chat_id="customer@example.com",
+                        text="Body that would normally be RTR-suppressed.",
+                        reply_to_msg_id=42,  # truthy so the RTR suppress would fire
+                        session=session,
+                    )
+                )
+        finally:
+            if old_rtr is None:
+                _os.environ.pop("READ_THE_ROOM_ENABLED", None)
+            else:
+                _os.environ["READ_THE_ROOM_ENABLED"] = old_rtr
+
+        # Exactly one rpush — the email message itself. No reaction.
+        assert handler._redis.rpush.call_count == 1
+        key = handler._redis.rpush.call_args[0][0]
+        assert key.startswith("email:outbox:"), f"Expected email outbox write, got {key}"
+        payload = json.loads(handler._redis.rpush.call_args[0][1])
+        assert payload.get("type") != "reaction"
+        assert "body" in payload  # email-shaped, not reaction-shaped
+
+    def test_send_with_empty_text_for_email_is_noop(self):
+        """Empty text on an email session must NOT queue an empty email."""
+        handler = self._make_handler()
+
+        session = self._email_session()
+
+        asyncio.run(handler.send("customer@example.com", "", 0, session=session))
+
+        handler._redis.rpush.assert_not_called()
+
+    # ── 5. Missing transport defaults to telegram (back-compat) ──
+
+    def test_missing_transport_defaults_to_telegram(self):
+        """A session whose extra_context lacks the transport key — older
+        sessions, or any session created before the email path existed —
+        must continue to route to telegram:outbox."""
+        handler = self._make_handler()
+
+        s = MagicMock()
+        s.session_id = "no-transport"
+        s.extra_context = {}  # no transport key
+
+        with patch(
+            "bridge.message_drafter.draft_message",
+            AsyncMock(side_effect=RuntimeError("skip drafter")),
+        ):
+            asyncio.run(handler.send("123", "Hello", 0, session=s))
+
+        key = handler._redis.rpush.call_args[0][0]
+        assert key == "telegram:outbox:no-transport"
+
+    def test_extra_context_none_defaults_to_telegram(self):
+        """If extra_context itself is None, default to telegram."""
+        handler = self._make_handler()
+
+        s = MagicMock()
+        s.session_id = "ctx-none"
+        s.extra_context = None
+
+        with patch(
+            "bridge.message_drafter.draft_message",
+            AsyncMock(side_effect=RuntimeError("skip drafter")),
+        ):
+            asyncio.run(handler.send("123", "Hello", 0, session=s))
+
+        key = handler._redis.rpush.call_args[0][0]
+        assert key == "telegram:outbox:ctx-none"
+
+    # ── 6. Email payload includes from_addr from SMTP_USER env ──
+
+    def test_email_payload_includes_from_addr_from_env(self):
+        """When SMTP_USER is set, the payload's from_addr must mirror it so
+        the email_relay sends with the correct envelope sender."""
+        import os as _os
+
+        handler = self._make_handler()
+        session = self._email_session()
+
+        old_smtp_user = _os.environ.get("SMTP_USER")
+        _os.environ["SMTP_USER"] = "valor@yuda.me"
+        try:
+            with patch(
+                "bridge.message_drafter.draft_message",
+                AsyncMock(side_effect=RuntimeError("skip drafter")),
+            ):
+                asyncio.run(handler.send("customer@example.com", "Hi", 0, session=session))
+        finally:
+            if old_smtp_user is None:
+                _os.environ.pop("SMTP_USER", None)
+            else:
+                _os.environ["SMTP_USER"] = old_smtp_user
+
+        payload = json.loads(handler._redis.rpush.call_args[0][1])
+        assert payload["from_addr"] == "valor@yuda.me"


### PR DESCRIPTION
## Summary

Fixes Bug 3 from the test-cuttlefish-setup-podcast follow-up brief: email-spawned `AgentSession`s whose project has no `EmailOutputHandler` registered (e.g. `cuttlefish`, where `projects.json -> projects.cuttlefish.email = {}`) were silently routing the agent's final reply to `telegram:outbox:<sid>` instead of `email:outbox:<sid>`. The SMTP relay therefore never saw the draft, and the test skill's `popped_count: 0` on `email:outbox:` looked like the agent stayed silent (it didn't — it just routed to the wrong queue).

**Design rule (user decision, 2026-04-30):** the default Stop-drafter / OutputHandler reply routes through **the same medium that spawned the session**. Telegram-spawned → `telegram:outbox:`. Email-spawned → `email:outbox:`. The agent can still call `Valor-Telegram` or `Valor-Email` explicitly mid-session to override per-message, but the *default* follows the spawning bridge.

## What changed

- `TelegramRelayOutputHandler.send()` now reads `session.extra_context.transport` at the top of the method. When it is `"email"`, the new `_send_via_email_outbox()` helper writes a unified email payload (matching `tools/send_message.py::_send_via_email` and `bridge/email_relay.py`'s expected schema) to `email:outbox:<session_id>` and returns. All other paths (no transport key, `transport=="telegram"`, missing `extra_context`) keep the existing telegram-outbox behavior.
- The email branch runs **before** the drafter, RTR, and any reaction-payload paths. Email-spawned sessions therefore can't accidentally queue 👀 reactions either — there is no email equivalent and dropping them is intentional.
- Subject is `"Re:"`-prefixed unless the original already starts with `re:` (case-insensitive). `in_reply_to` / `references` come from `extra_context.email_message_id`. `from_addr` comes from `SMTP_USER`. The new email payload mirrors the worker-reply semantics in `bridge/email_bridge.py::_build_reply_mime` (`force_reply_prefix=True`).

The fix lives in the worker's catch-all default handler so it covers projects that lack a registered email handler. Projects that do register `EmailOutputHandler` (via `worker/__main__.py::_should_register_email_handler`) continue to use that handler directly via the `(project_key, "email")` composite callback key — this fix is a fallback safety net for the design-rule contract.

## Test cases (all GREEN)

`tests/unit/test_output_handler.py::TestTransportAwareRouting`:
1. Telegram-spawned session writes to `telegram:outbox` (regression).
2. Email-spawned session writes to `email:outbox` with the correct payload shape (`session_id`, `to`, `subject`, `body`, `in_reply_to`, `references`, `from_addr`, `timestamp`, `attachments=[]`).
3. Subject `"Re: My setup question"` is **not** double-prefixed to `"Re: Re: ..."`.
4. Subject `"re: lowercase"` is preserved verbatim (case-insensitive prefix check).
5. Email-spawned session: `send()` with an RTR `suppress` verdict still produces zero reaction payloads (the email branch short-circuits the entire RTR path).
6. Empty text on email session is a no-op.
7. Missing `extra_context.transport` defaults to telegram (back-compat for older sessions).
8. `extra_context=None` defaults to telegram.
9. Email payload `from_addr` mirrors `SMTP_USER` env var.

Run: `pytest tests/unit/test_output_handler.py tests/unit/test_output_router.py tests/unit/test_output_router_compaction_guard.py` — **79 passed, 0 failed.**

## Smoke test (cuttlefish project, contact2@tomcounsell.com)

After restarting the worker on the fix branch, ran the test skill's `spawn.py` against `contact2@tomcounsell.com`. Session completed in 31.5s. Worker log:

```
2026-04-30 08:18:20 UTC agent.output_handler INFO Queued email output to
  email:outbox:email_cuttlefish_contact2_at_tomcounsell_com_1777537068
  (1038 chars, to=contact2@tomcounsell.com, in_reply_to=True)
```

Email relay confirmed delivery:

```
2026-04-30 15:18:24,674 INFO bridge.email_relay Email relay: sent to
  ['contact2@tomcounsell.com'] (session=email_cuttlefish_contact2_at_tomcounsell_com_1777537068,
  body=1038 chars, attach=0)
```

The 1038-char drafted reply was customer-service-voiced and referenced cuttlefish-specific tooling (`manage.py customer provision`, `apps/podcast/feed_url.py`) — confirms both persona resolution (Bug 2 fix from #1222) and transport routing (this fix) work end-to-end.

`pop_outbox.py` reported `popped_count: 0` on **both** queues, but for a new reason: the email relay drains `email:outbox:*` every 100ms, so by the time `pop_outbox.py` ran the queue was already empty. The test-cuttlefish-setup-podcast skill's interpretation note ("`popped_count: 0` means agent stayed silent") needs updating — that's a follow-up on the skill, not this PR.

## Test plan

- [x] `pytest tests/unit/test_output_handler.py tests/unit/test_output_router.py tests/unit/test_output_router_compaction_guard.py` (79 passed)
- [x] `python -m ruff format .` (clean)
- [x] Manual smoke test against cuttlefish via `spawn.py contact2@tomcounsell.com` (queued to email outbox; relay delivered)
- [x] Worker log shows `Queued email output to email:outbox:<sid>` for the test session
- [x] Cleanup verified: no stale cuttlefish test sessions remain (`AgentSession.query.all()` filtered for `cuttlefish_contact` is empty)
- [ ] After merge: restart worker on bridge machine to pick up the fix — owner: user