### PR TITLE
feat(memory): inline <private> tag for memory-ingestion exclusion (#1179)

### DIFF
--- a/.claude/hooks/hook_utils/memory_bridge.py
+++ b/.claude/hooks/hook_utils/memory_bridge.py
@@ -612,9 +612,13 @@ def prefetch(
         if not prompt or not isinstance(prompt, str):
             return None
 
+        # sdlc-1179: strip <private> regions before BM25 query so wrapped
+        # content does not seed the lookup vector against past memories.
+        from agent.private_tag import strip_private
+
         # Strip PM boilerplate first so length / triviality checks apply
         # to the actual user payload, not the routing template.
-        stripped = _strip_pm_boilerplate(prompt).strip()
+        stripped = _strip_pm_boilerplate(strip_private(prompt)).strip()
 
         if len(stripped) < MIN_PROMPT_LENGTH:
             return None
@@ -709,6 +713,13 @@ def ingest(content: str, cwd: str | None = None) -> bool:
     try:
         if not content or not isinstance(content, str):
             return False
+
+        # sdlc-1179: strip <private> regions before any persistence so wrapped
+        # content never lands in Memory.content. Idempotent and safe on no-tag
+        # input (returns the original string bit-identically).
+        from agent.private_tag import strip_private
+
+        content = strip_private(content)
 
         # Quality filter: minimum length
         stripped = content.strip()

--- a/agent/private_tag.py
+++ b/agent/private_tag.py
@@ -90,8 +90,10 @@ def strip_private(text: str) -> str:
     Returns:
         The input with all ``<private>...</private>`` regions removed.
     """
-    if not text or not isinstance(text, str):
-        return text or ""
+    if not isinstance(text, str):
+        return ""
+    if not text:
+        return text
     stripped, n = _PRIVATE_TAG_RE.subn("", text)
     if n == 0:
         # No tags matched -- return input unchanged (no whitespace collapse).

--- a/agent/private_tag.py
+++ b/agent/private_tag.py
@@ -1,0 +1,106 @@
+"""Private-tag stripper for user-input preprocessing.
+
+The subconscious memory system saves every Telegram message and Claude Code
+prompt that clears the trivial-pattern + min-length filters. Sometimes a user
+needs an inline opt-out for a specific phrase (an API key paste, a
+confidential client name, a one-off speculative comment) without disabling
+memory ingestion globally.
+
+This module provides ``strip_private(text)`` -- a pure stdlib helper that
+removes ``<private>...</private>`` regions from a string. It is invoked at
+every persistent-write boundary that handles raw user input:
+
+    bridge/telegram_bridge.py
+        - store_message(content=...)               (TelegramMessage.content)
+        - Memory.safe_save(content=...)            (subconscious memory)
+        - logger.info(... text[:50] ...)           (bridge.log)
+        - AgentSession.message_text                (via clean_message + reply chain)
+
+    .claude/hooks/hook_utils/memory_bridge.py
+        - ingest()    : Memory.safe_save() of user prompts
+        - prefetch()  : BM25 query against past memories
+
+The wrapped content stays visible to the live agent in the current turn -- the
+user is masking *future recall*, not hiding from Claude in the moment. The
+``config/personas/segments/private-tag.md`` segment instructs the agent to
+treat wrapped content as do-not-quote-back so it does not re-enter Memory via
+post-session extraction.
+
+Design constraints:
+
+- Single-level (no nesting). Supporting nested tags requires a real parser
+  rather than a regex; the marginal value is zero.
+- Case-sensitive. ``<private>`` only -- ``<PRIVATE>`` and ``<Private>`` are
+  treated as literal text. Users learn the lowercase form.
+- Idempotent. ``strip_private(strip_private(x)) == strip_private(x)``.
+- Pure: no side effects (other than a DEBUG log on full-strip-to-empty for
+  diagnosability).
+- Forward-only. Existing records are unaffected; this is preprocessing for
+  the next write, not a backfill or migration.
+
+Usage:
+
+    >>> from agent.private_tag import strip_private
+    >>> strip_private("the key is <private>sk-abc123</private>, why?")
+    'the key is, why?'
+    >>> strip_private("nothing to strip")
+    'nothing to strip'
+
+See also: ``docs/features/subconscious-memory.md`` (the "Excluding content
+with `<private>` tags" section), and tests at
+``tests/unit/test_private_tag.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+_PRIVATE_TAG_RE = re.compile(r"<private>(.*?)</private>", re.DOTALL)
+_MULTI_SPACE_RE = re.compile(r"[ \t]{2,}")
+
+logger = logging.getLogger(__name__)
+
+
+def strip_private(text: str) -> str:
+    """Remove all ``<private>...</private>`` regions from ``text``.
+
+    Non-greedy, single-level (no nesting), case-sensitive. Unmatched
+    ``<private>`` openers without a matching ``</private>`` are left as
+    literal text. Idempotent.
+
+    Collapses the multi-space residue left when a tagged region sat between
+    two whitespace-bearing tokens, but ONLY when at least one tag was
+    actually stripped (sdlc-1179 C2 fix). On no-tag input, the input is
+    returned bit-identically -- no whitespace changes whatsoever -- so the
+    function is a true no-op for the overwhelming majority of messages.
+
+    Newlines are never touched, so multi-line prompt structure is preserved.
+
+    Emits a DEBUG log line when stripping reduces the content to
+    empty / whitespace-only (sdlc-1179 N3): operationally this means the
+    downstream length filter in ``ingest()`` will drop the record, and a
+    user diagnosing "why didn't my message land?" can grep
+    ``private_tag.strip_to_empty`` in the logs.
+
+    Args:
+        text: Arbitrary user input. Non-string and ``None`` inputs return
+            the empty string defensively.
+
+    Returns:
+        The input with all ``<private>...</private>`` regions removed.
+    """
+    if not text or not isinstance(text, str):
+        return text or ""
+    stripped, n = _PRIVATE_TAG_RE.subn("", text)
+    if n == 0:
+        # No tags matched -- return input unchanged (no whitespace collapse).
+        return text
+    stripped = _MULTI_SPACE_RE.sub(" ", stripped)
+    if not stripped.strip():
+        logger.debug(
+            "private_tag.strip_to_empty original_len=%d tags_stripped=%d",
+            len(text),
+            n,
+        )
+    return stripped

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -90,6 +90,7 @@ from telethon import TelegramClient, events  # noqa: E402
 from telethon.errors import FloodWaitError  # noqa: E402
 
 from agent import build_harness_turn_input  # noqa: F401, E402
+from agent.private_tag import strip_private  # noqa: E402
 from agent.steering import ABORT_KEYWORDS, push_steering_message  # noqa: E402
 from bridge.context import (  # noqa: E402
     REPLY_THREAD_CONTEXT_HEADER,  # noqa: F401
@@ -1038,6 +1039,12 @@ async def main():
         # Get message details
         message = event.message
         text = message.text or ""
+        # sdlc-1179: compute the persistence-safe variant once. The original
+        # `text` stays in scope for live-agent inputs (the SDK prompt the worker
+        # spawns must see <private> wrapped content this turn so the agent can
+        # reason about it). `safe_text` is what flows into Memory, TelegramMessage,
+        # bridge logs, and AgentSession.message_text via `safe_clean_text` below.
+        safe_text = strip_private(text)
         is_dm = event.is_private
         chat = await event.get_chat()
         chat_title = getattr(chat, "title", None)
@@ -1064,9 +1071,12 @@ async def main():
         _early_project_key = project.get("_key") if project else None
         stored_msg_id = None  # Track for telegram_message_key cross-reference
         try:
+            # sdlc-1179: persist safe_text so wrapped <private> regions never
+            # land in TelegramMessage.content (and therefore never surface via
+            # `valor-telegram read --search` or the conversation-history prefetch).
             store_result = store_message(
                 chat_id=str(event.chat_id),
-                content=text,
+                content=safe_text,
                 sender=sender_name,
                 message_id=message.id,
                 timestamp=message.date,
@@ -1103,10 +1113,12 @@ async def main():
 
                     from models.memory import Memory
 
+                    # sdlc-1179: persist safe_text so wrapped <private> regions never
+                    # land in Memory.content (subconscious memory recall surface).
                     Memory.safe_save(
                         agent_id=sender_name or "unknown",
                         project_key=_early_project_key,
-                        content=text[:500],
+                        content=safe_text[:500],
                         importance=InteractionWeight.HUMAN,
                         source="human",
                     )
@@ -1164,11 +1176,12 @@ async def main():
 
         project_name = project.get("name", "DM") if project else "DM"
         message_id = message.id
+        # sdlc-1179: log safe_text so bridge.log never contains wrapped content.
         logger.info(
             f"[{project_name}] Message {message_id} from "
-            f"{sender_name} in {chat_title or 'DM'}: {text[:50]}..."
+            f"{sender_name} in {chat_title or 'DM'}: {safe_text[:50]}..."
         )
-        logger.debug(f"[{project_name}] Full message text: {text}")
+        logger.debug(f"[{project_name}] Full message text: {safe_text}")
 
         # Log incoming message event
         log_event(
@@ -1183,10 +1196,18 @@ async def main():
             has_media=bool(message.media),
         )
 
-        # Clean the message text (no media/YouTube/link enrichment here)
+        # Clean the message text (no media/YouTube/link enrichment here).
+        # sdlc-1179: derive both variants. `clean_text` (built from raw `text`)
+        # feeds the live-agent SDK prompt -- the agent must see <private> tags
+        # this turn to reason about wrapped content. `safe_clean_text`
+        # (built from `safe_text`) flows into AgentSession.message_text and
+        # any other persisted derivative.
         clean_text = clean_message(text, project)
         if not clean_text:
             clean_text = "--file attachment only--" if message.media else "--empty message--"
+        safe_clean_text = clean_message(safe_text, project)
+        if not safe_clean_text:
+            safe_clean_text = "--file attachment only--" if message.media else "--empty message--"
 
         # Extract YouTube URLs (lightweight -- no transcription yet)
         youtube_urls = extract_youtube_urls(text)
@@ -1577,6 +1598,10 @@ async def main():
                                 )
                                 if chain:
                                     reply_chain_context = format_reply_chain(chain)
+                                    # sdlc-1179 B1: a legacy reply chain may contain
+                                    # <private> markers persisted before this PR.
+                                    # Strip before splicing into augmented_text.
+                                    reply_chain_context = strip_private(reply_chain_context)
                             except TimeoutError:
                                 logger.warning(
                                     "RESUME_REPLY_CHAIN_FAIL timeout "
@@ -1593,9 +1618,13 @@ async def main():
                                     f"error={rc_exc!r}"
                                 )
 
+                        # sdlc-1179 B1: both inputs to augmented_text are
+                        # pre-stripped (safe_clean_text is built from safe_text,
+                        # reply_chain_context was passed through strip_private
+                        # immediately after format_reply_chain returned).
                         augmented_text = _build_completed_resume_text(
                             completed,
-                            clean_text,
+                            safe_clean_text,
                             reply_chain_context=reply_chain_context,
                         )
                         # Compute working_dir inline (not yet defined at this point in the handler)
@@ -2001,7 +2030,12 @@ async def main():
         #
         # Honors env kill-switch REPLY_CONTEXT_DIRECTIVE_DISABLED (truthy = off)
         # so Change C can be disabled in-place without a code deploy (IN-5).
-        enqueued_message_text = clean_text
+        # sdlc-1179: enqueued_message_text persists into AgentSession.message_text
+        # via the dispatch_telegram_session call below; use safe_clean_text so
+        # wrapped <private> regions do not land there. Pattern detection
+        # (references_prior_context / matched_context_patterns) runs on the
+        # safe variant too -- a private region is irrelevant to the heuristic.
+        enqueued_message_text = safe_clean_text
         _directive_disabled = os.getenv("REPLY_CONTEXT_DIRECTIVE_DISABLED", "").strip().lower() in (
             "1",
             "true",
@@ -2011,9 +2045,9 @@ async def main():
         if (
             not _directive_disabled
             and not message.reply_to_msg_id
-            and references_prior_context(clean_text)
+            and references_prior_context(safe_clean_text)
         ):
-            matched_patterns = matched_context_patterns(clean_text)
+            matched_patterns = matched_context_patterns(safe_clean_text)
             context_directive = (
                 "[CONTEXT DIRECTIVE] This message references context not in "
                 "the current turn. If the auto-recalled memory below does not "
@@ -2024,13 +2058,13 @@ async def main():
                 "if an issue or PR is implied. Skip this directive entirely if "
                 "the prior context is obvious from the auto-recalled memory."
             )
-            enqueued_message_text = f"{context_directive}\n\n{clean_text}"
+            enqueued_message_text = f"{context_directive}\n\n{safe_clean_text}"
             logger.info(
                 "implicit_context_directive_injected "
                 f"session_id={session_id} "
                 f"chat_id={telegram_chat_id} "
                 f"matched_patterns={matched_patterns} "
-                f"text_preview={clean_text[:80]!r}"
+                f"text_preview={safe_clean_text[:80]!r}"
             )
 
         # === FRESH-SESSION NON-VALOR REPLY PRE-HYDRATION (Issue #1064) ===
@@ -2083,6 +2117,10 @@ async def main():
                 )
                 if chain:
                     reply_chain_context = format_reply_chain(chain)
+                    # sdlc-1179 B1: prehydrated reply-chain is stripped
+                    # before splice so a legacy <private> marker in upstream
+                    # messages does not leak into AgentSession.message_text.
+                    reply_chain_context = strip_private(reply_chain_context)
             except TimeoutError:
                 logger.warning(
                     "FRESH_REPLY_CHAIN_FAIL timeout "
@@ -2539,6 +2577,14 @@ async def main():
                     # after the actual Telethon send); stored as None and the
                     # relay's _record_sent_message fills the gap on the session
                     # record. This preserves sender/content/timestamp tracking.
+                    #
+                    # sdlc-1179 C4: outbound text is the agent's own utterance,
+                    # not user-tagged input. Persona segment (private-tag.md) +
+                    # Risk 3 cover quote-back leakage. Do not strip here; that
+                    # would blur the line between "user marked this private" and
+                    # "the system sometimes deletes agent text". If empirical
+                    # leak rate is non-zero post-ship, the right fix is a
+                    # follow-up scoped to agent/memory_extraction.py.
                     try:
                         store_message(
                             chat_id=chat_id,

--- a/config/personas/segments/manifest.json
+++ b/config/personas/segments/manifest.json
@@ -3,6 +3,7 @@
   "segments": [
     "identity.md",
     "work-patterns.md",
-    "tools.md"
+    "tools.md",
+    "private-tag.md"
   ]
 }

--- a/config/personas/segments/private-tag.md
+++ b/config/personas/segments/private-tag.md
@@ -1,0 +1,13 @@
+# Private-Tag Handling
+
+When the user wraps content in `<private>...</private>` tags, treat that content as **ephemeral**: visible to you in the current turn for context, but do NOT quote it back verbatim in your response, do NOT include it in summaries, and do NOT echo it into tool calls whose output is logged or persisted (`Bash` commands that print it, file writes, GitHub issue/PR bodies, Telegram or email messages, memory saves).
+
+The user has marked it as do-not-persist. Quoting it back risks re-introducing it into stored agent outputs (`TelegramMessage.content`, post-session memory extraction, bridge logs), which defeats the user's opt-out.
+
+If you must reference the wrapped content, describe it abstractly. For example:
+
+- User: `the API key is <private>sk-abc123</private>, can you check it?`
+- You: "I see the key starts with `sk-` and is 11 characters — looks like an OpenAI-style key."
+- Not: "I see your key `sk-abc123` is 11 characters..."
+
+The tag is case-sensitive (`<private>`, lowercase) and single-level (no nesting).

--- a/docs/features/subconscious-memory.md
+++ b/docs/features/subconscious-memory.md
@@ -94,7 +94,7 @@ The helper `strip_private(text)` in `agent/private_tag.py` is invoked at every p
   - `Memory.safe_save(content=safe_text[:500], ...)` (subconscious memory)
   - `logger.info(... safe_text[:50] ...)` (bridge.log)
   - `clean_message(safe_text, project)` → `safe_clean_text` → fed into `AgentSession.message_text` via `enqueued_message_text` and the directive splice
-  - Both reply-chain hydration paths (completed-resume at line ~1416, fresh-message prehydration at line ~1922) call `strip_private(reply_chain_context)` immediately after `format_reply_chain` returns, closing the leak channel where a legacy chain might still carry `<private>` markers from messages persisted before this feature shipped (B1).
+  - Both reply-chain hydration paths (completed-resume at line ~1416, fresh-message prehydration at line ~1922) call `strip_private(reply_chain_context)` immediately after `format_reply_chain` returns, closing the leak channel where a stored chain could still carry `<private>` markers from messages persisted before this feature shipped (B1).
 
 - `.claude/hooks/hook_utils/memory_bridge.py`:
   - `ingest()` — applied at the top before the length filter, so wrapped content never reaches `Memory.safe_save`.

--- a/docs/features/subconscious-memory.md
+++ b/docs/features/subconscious-memory.md
@@ -73,6 +73,72 @@ Telegram messages are saved as Memory records immediately on receipt in `bridge/
 
 Empty text, bot messages, and media-only messages are skipped.
 
+#### Excluding content with `<private>` tags (issue #1179)
+
+A user can wrap any portion of a Telegram message or Claude Code prompt in `<private>...</private>` tags to exclude that region from every persistent surface — Memory, `TelegramMessage.content`, `AgentSession.message_text`, and bridge logs. The tag is a per-message escape hatch, not a global toggle: each invocation only affects the current message.
+
+**Syntax:**
+
+```
+the api key is <private>sk-abc123</private>, can you check it?
+```
+
+The tag is **case-sensitive** (`<private>` only, not `<PRIVATE>` or `<Private>`), **single-level** (no nesting), and matched by a non-greedy regex so multiple wrapped regions in one message are stripped independently. An unmatched opening `<private>` with no closing `</private>` is left as literal text — nothing gets greedily consumed to end-of-message.
+
+**Scope of stripping:**
+
+The helper `strip_private(text)` in `agent/private_tag.py` is invoked at every persistent-write call site that handles raw user input:
+
+- `bridge/telegram_bridge.py`:
+  - `store_message(content=safe_text, ...)` (TelegramMessage.content)
+  - `Memory.safe_save(content=safe_text[:500], ...)` (subconscious memory)
+  - `logger.info(... safe_text[:50] ...)` (bridge.log)
+  - `clean_message(safe_text, project)` → `safe_clean_text` → fed into `AgentSession.message_text` via `enqueued_message_text` and the directive splice
+  - Both reply-chain hydration paths (completed-resume at line ~1416, fresh-message prehydration at line ~1922) call `strip_private(reply_chain_context)` immediately after `format_reply_chain` returns, closing the leak channel where a legacy chain might still carry `<private>` markers from messages persisted before this feature shipped (B1).
+
+- `.claude/hooks/hook_utils/memory_bridge.py`:
+  - `ingest()` — applied at the top before the length filter, so wrapped content never reaches `Memory.safe_save`.
+  - `prefetch()` — applied before BM25 query so wrapped content does not seed the lookup vector against past memories.
+
+**What the agent sees vs. what gets stored:**
+
+The wrapped content **stays visible to the live agent in the current turn** — the user is masking *future recall*, not hiding from Claude in the moment. This is intentional and contradicts the natural intuition "private = invisible to Claude":
+
+| Channel | Sees `<private>SECRET</private>`? | Why |
+|---------|-----------------------------------|-----|
+| Live agent prompt (this turn) | Yes — agent sees `SECRET` and the tags | The agent must be able to reason about what the user just asked. The `clean_text` variable (built from raw `text`) is what the worker spawns into the SDK. |
+| `Memory.content` (Telegram path) | No — stripped | `Memory.safe_save` receives `safe_text[:500]`. |
+| `Memory.content` (Claude Code path) | No — stripped | `ingest()` strips before the length filter. |
+| `TelegramMessage.content` | No — stripped | `store_message(content=safe_text, ...)`. Persisted text never carries the secret, so `valor-telegram read --search SECRET` returns nothing. |
+| `AgentSession.message_text` | No — stripped | Built from `safe_clean_text` (and `safe_chain` for reply-thread context). |
+| `logs/bridge.log` | No — stripped | The 50-char log prefix uses `safe_text[:50]`. |
+| Post-session memory extraction | Soft — depends on agent | The Haiku extractor runs on the **agent's response**, not the user's input. The persona segment `config/personas/segments/private-tag.md` instructs the agent to **not quote wrapped content back** — but compliance is behavioral, not enforced. Risk 3 in the plan covers this. |
+
+**Worked Telegram example:**
+
+```
+User: the api key is <private>sk-abc123</private>, can you check it?
+
+Agent (this turn): I see the key starts with sk- and is 11 chars long — looks like an OpenAI-style key.
+
+# Later — the secret is gone from every persistent surface:
+$ python -m tools.memory_search search sk-abc123
+(no results)
+
+$ valor-telegram read --search sk-abc123
+(no results)
+
+$ grep sk-abc123 logs/bridge.log
+(no hits)
+```
+
+**Limits and trade-offs:**
+
+- **Forward-only.** Existing records are unaffected. Use `python -m tools.memory_search forget --id <ID> --confirm` to remove an already-persisted secret one record at a time.
+- **Not a credential scanner.** Auto-detection of API keys, credit cards, addresses, etc. is out of scope (see No-Gos in plan `docs/plans/sdlc-1179.md`). Tagging is opt-in only.
+- **Search scrollback intentionally loses tagged content.** `valor-telegram read --search` will not find wrapped content. This is the trade-off the user opted into by tagging.
+- **Bloom fingerprint deploy boundary.** The `Memory` model uses an ExistenceFilter keyed on `content`. A near-duplicate message sent before AND after the deploy will have two different bloom fingerprints (unstripped vs. stripped) — neither dedupes the other. At most one extra record per crossover pair appears for in-flight messages around the deploy. Documented for operators so they don't chase a "duplicate Memory" anomaly in the first hour after shipping.
+
 ### Flow 2: Thought Injection
 
 The PostToolUse hook in `agent/health_check.py` checks for relevant memories on every tool call:

--- a/tests/integration/test_private_tag_ingestion.py
+++ b/tests/integration/test_private_tag_ingestion.py
@@ -26,15 +26,11 @@ from agent.private_tag import strip_private
 from bridge.response import clean_message
 from bridge.telegram_bridge import _build_completed_resume_text
 
-
 SECRET = "sk-int-test-secret-redacted"
 OLDSECRET = "OLDSECRETFROMLEGACYCHAIN"
 PRIVATE_WRAPPED = f"<private>{SECRET}</private>"
 
-USER_TEXT = (
-    f"Refactor the auth handler. The current key is {PRIVATE_WRAPPED}. "
-    "Should we rotate?"
-)
+USER_TEXT = f"Refactor the auth handler. The current key is {PRIVATE_WRAPPED}. Should we rotate?"
 
 
 def _bridge_compute_safe_pair(text: str, project: dict | None = None) -> tuple[str, str, str, str]:

--- a/tests/integration/test_private_tag_ingestion.py
+++ b/tests/integration/test_private_tag_ingestion.py
@@ -1,0 +1,273 @@
+"""Integration tests for the <private>...</private> ingestion exclusion.
+
+These tests exercise the same transformations the Telegram bridge performs:
+- Compute safe_text = strip_private(text) once.
+- Pass safe_text to the persistence sites (Memory.safe_save, TelegramMessage,
+  AgentSession.message_text via clean_message).
+- Pre-strip reply_chain_context in BOTH the completed-resume path
+  (bridge/telegram_bridge.py:1416) and the fresh-message prehydration path
+  (bridge/telegram_bridge.py:1922).
+- Keep the original `text`/`clean_text` for the live-agent SDK prompt input.
+
+The tests are kept at integration level (not full bridge spawn) because the
+bridge's decision is purely a string-flow composition; spinning up Telethon
+adds noise without added signal. The actual call sites in
+``bridge/telegram_bridge.py`` are also covered by the verification grep
+checks in the plan's Verification table.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+from agent.private_tag import strip_private
+from bridge.response import clean_message
+from bridge.telegram_bridge import _build_completed_resume_text
+
+
+SECRET = "sk-int-test-secret-redacted"
+OLDSECRET = "OLDSECRETFROMLEGACYCHAIN"
+PRIVATE_WRAPPED = f"<private>{SECRET}</private>"
+
+USER_TEXT = (
+    f"Refactor the auth handler. The current key is {PRIVATE_WRAPPED}. "
+    "Should we rotate?"
+)
+
+
+def _bridge_compute_safe_pair(text: str, project: dict | None = None) -> tuple[str, str, str, str]:
+    """Mirror the bridge handler's text computation:
+    text → safe_text, clean_text (live), safe_clean_text (persisted).
+    """
+    safe_text = strip_private(text)
+    clean_text = clean_message(text, project) or text
+    safe_clean_text = clean_message(safe_text, project) or safe_text
+    return text, safe_text, clean_text, safe_clean_text
+
+
+class TestInboundPersistence:
+    """Path A from the plan's Data Flow: Telegram message ingestion.
+
+    Persistent writes (Memory.safe_save, TelegramMessage.store_message,
+    bridge log, AgentSession.message_text) all consume safe_text /
+    safe_clean_text — wrapped content must not appear.
+    """
+
+    def test_safe_text_excludes_wrapped_region(self):
+        text, safe_text, _clean_text, _safe_clean_text = _bridge_compute_safe_pair(USER_TEXT)
+        assert PRIVATE_WRAPPED in text  # raw text retains tags
+        assert SECRET not in safe_text
+        assert "<private>" not in safe_text
+        assert "</private>" not in safe_text
+        # Real (non-private) content is preserved.
+        assert "Refactor the auth handler" in safe_text
+        assert "rotate" in safe_text
+
+    def test_safe_clean_text_excludes_wrapped_region(self):
+        _text, _safe_text, _clean_text, safe_clean_text = _bridge_compute_safe_pair(USER_TEXT)
+        assert SECRET not in safe_clean_text
+        assert "<private>" not in safe_clean_text
+
+    def test_log_truncation_uses_safe_text(self):
+        """The bridge logs `safe_text[:50]`; ensure that prefix never reveals
+        the secret even when it's near the start of the message.
+        """
+        text = f"{PRIVATE_WRAPPED} prefix wraps the start of the message"
+        _text, safe_text, _ct, _sct = _bridge_compute_safe_pair(text)
+        log_prefix = safe_text[:50]
+        assert SECRET not in log_prefix
+
+    def test_memory_save_call_arg_excludes_wrapped(self):
+        """The bridge calls Memory.safe_save(content=safe_text[:500], ...).
+        Confirm safe_text[:500] never carries the wrapped content even when
+        the secret would have appeared inside the first 500 chars.
+        """
+        text = f"prelude {PRIVATE_WRAPPED} {'x' * 600}"
+        _text, safe_text, _ct, _sct = _bridge_compute_safe_pair(text)
+        # The bridge does Memory.safe_save(content=safe_text[:500], ...)
+        memory_payload = safe_text[:500]
+        assert SECRET not in memory_payload
+
+    def test_telegram_history_store_uses_safe_text(self):
+        """TelegramMessage.content is written with `safe_text` (no truncation).
+        Confirm full safe_text is also clean.
+        """
+        _text, safe_text, _ct, _sct = _bridge_compute_safe_pair(USER_TEXT)
+        # Simulate TelegramMessage.content = safe_text
+        telegram_message_content = safe_text
+        assert SECRET not in telegram_message_content
+
+
+class TestLiveAgentVisibility:
+    """OQ1 resolution: live agent prompt construction uses the ORIGINAL `text`
+    so the agent can reason about wrapped content this turn.
+
+    Verifies we did not over-strip — without this, the user's tag would
+    silently break the agent's ability to answer in-turn questions about
+    wrapped content (a UX regression).
+    """
+
+    def test_clean_text_retains_wrapped_for_live_path(self):
+        text, _safe_text, clean_text, _safe_clean_text = _bridge_compute_safe_pair(USER_TEXT)
+        assert PRIVATE_WRAPPED in text
+        # clean_message is built from raw text (live SDK prompt input).
+        # It MUST retain the wrapped region so the agent sees the tags this turn.
+        assert SECRET in clean_text
+        assert "<private>" in clean_text
+
+
+class TestReplyChainLeakClosure:
+    """B1 closure: a legacy reply-chain that contains <private> markers
+    (e.g. persisted before this PR shipped) must be stripped before splice
+    into AgentSession.message_text.
+
+    Plan references:
+    - completed-resume path (bridge/telegram_bridge.py:1416 + 1462-1466 →
+      dispatch_telegram_session at line ~1465)
+    - fresh-message prehydration (bridge/telegram_bridge.py:1922 + 1947-1949)
+    """
+
+    def test_completed_resume_reply_chain_stripped_before_augmented_text(self):
+        """Mirror the completed-resume code path:
+            reply_chain_context = format_reply_chain(chain)
+            reply_chain_context = strip_private(reply_chain_context)  # sdlc-1179
+            augmented_text = _build_completed_resume_text(
+                completed, safe_clean_text, reply_chain_context=reply_chain_context
+            )
+        Both inputs must be pre-stripped.
+        """
+
+        # Simulate format_reply_chain output containing a leftover <private>
+        # marker from a legacy persisted message.
+        legacy_chain = (
+            "REPLY THREAD CONTEXT (oldest to newest):\n"
+            f"  • Tom (3m ago): the api key is <private>{OLDSECRET}</private>\n"
+            "  • Valor (2m ago): noted, will rotate\n"
+        )
+        # Bridge applies strip_private to the chain immediately after format.
+        safe_chain = strip_private(legacy_chain)
+        assert OLDSECRET not in safe_chain
+        assert "<private>" not in safe_chain
+
+        # safe_clean_text feeds into augmented_text (also pre-stripped).
+        _t, _st, _ct, safe_clean_text = _bridge_compute_safe_pair(USER_TEXT)
+
+        class _FakeCompleted:
+            context_summary = "discussion of auth rotation"
+
+        augmented = _build_completed_resume_text(
+            _FakeCompleted(),
+            safe_clean_text,
+            reply_chain_context=safe_chain,
+        )
+        # Neither secret leaks into AgentSession.message_text.
+        assert OLDSECRET not in augmented
+        assert SECRET not in augmented
+        assert "<private>" not in augmented
+        # The non-private context is preserved.
+        assert "auth rotation" in augmented
+        assert "rotate" in augmented
+
+    def test_fresh_message_prehydration_reply_chain_stripped(self):
+        """Mirror the fresh-message prehydration code path:
+            reply_chain_context = format_reply_chain(chain)
+            reply_chain_context = strip_private(reply_chain_context)  # sdlc-1179
+            enqueued_message_text = (
+                f"{reply_chain_context}\n\nCURRENT MESSAGE:\n{enqueued_message_text}"
+            )
+        The splice components must be pre-stripped.
+        """
+        legacy_chain = (
+            "REPLY THREAD CONTEXT (oldest to newest):\n"
+            f"  • Tom (5m ago): we use <private>{OLDSECRET}</private> for staging\n"
+        )
+        safe_chain = strip_private(legacy_chain)
+        assert OLDSECRET not in safe_chain
+
+        _t, _st, _ct, safe_clean_text = _bridge_compute_safe_pair(USER_TEXT)
+        # safe_clean_text seeds enqueued_message_text in the fresh path.
+        enqueued_message_text = safe_clean_text
+
+        # Fresh-path prehydration splice (line ~1948-1949).
+        spliced = f"{safe_chain}\n\nCURRENT MESSAGE:\n{enqueued_message_text}"
+
+        # Neither secret leaks into the persisted enqueued_message_text.
+        assert OLDSECRET not in spliced
+        assert SECRET not in spliced
+        assert "<private>" not in spliced
+
+
+class TestIngestEndToEnd:
+    """End-to-end through hook_utils.memory_bridge.ingest with patched Memory.
+
+    Confirms the strip happens at the ingest layer, not just at call sites.
+    """
+
+    def test_ingest_strips_private_before_safe_save(self):
+        # Load the live ingest function (no monkey-patching of strip_private).
+        spec = importlib.util.spec_from_file_location(
+            "memory_bridge_module",
+            str(
+                Path(__file__).resolve().parent.parent.parent
+                / ".claude/hooks/hook_utils/memory_bridge.py"
+            ),
+        )
+        assert spec is not None and spec.loader is not None
+        mb = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mb)
+
+        from unittest.mock import MagicMock, patch
+
+        captured = {}
+
+        def fake_safe_save(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        mock_bloom = MagicMock()
+        mock_bloom.might_exist = MagicMock(return_value=False)
+
+        mock_memory_cls = MagicMock()
+        mock_memory_cls._meta.fields.get.return_value = mock_bloom
+        mock_memory_cls.safe_save.side_effect = fake_safe_save
+
+        with (
+            patch("models.memory.Memory", mock_memory_cls),
+            patch("models.memory.SOURCE_HUMAN", "human"),
+            patch.object(mb, "_get_project_key", return_value="test"),
+        ):
+            ok = mb.ingest(USER_TEXT)
+
+        assert ok is True
+        saved = captured["content"]
+        assert SECRET not in saved
+        assert "<private>" not in saved
+        assert "Refactor the auth handler" in saved
+
+
+class TestStripPrivateContractInvariants:
+    """Sanity checks that downstream code can rely on."""
+
+    def test_idempotent_under_repeated_application(self):
+        for text in (
+            USER_TEXT,
+            f"{PRIVATE_WRAPPED}",
+            "no tags",
+            "  multi space  no tag  ",
+            "<private>line1\nline2</private> after",
+        ):
+            once = strip_private(text)
+            twice = strip_private(once)
+            assert once == twice, f"Not idempotent for: {text!r}"
+
+    def test_secret_pattern_never_in_safe_text_when_wrapped(self):
+        """For a secret with a recognizable pattern, the safe variant must
+        never match the pattern even after multiple ingestion-style
+        transformations."""
+        text = f"please use {PRIVATE_WRAPPED} for staging"
+        _t, safe_text, _ct, _sct = _bridge_compute_safe_pair(text)
+        # Accept any pattern matching `sk-int-test-secret-...` -> none should
+        # remain.
+        assert not re.search(r"sk-int-test-secret", safe_text)

--- a/tests/unit/test_hook_user_prompt_submit.py
+++ b/tests/unit/test_hook_user_prompt_submit.py
@@ -680,3 +680,55 @@ class TestPrefetchWiring:
             hook.main()
 
         mock_prefetch.assert_not_called()
+
+
+class TestPrivateTagHookIngestion:
+    """sdlc-1179: a Claude Code prompt with <private>X</private> wrapping must
+    not result in a Memory record containing X.
+
+    The hook calls memory_bridge.ingest(prompt) on UserPromptSubmit; the
+    helper applies strip_private(content) before any Memory.safe_save call.
+    """
+
+    def test_ingest_called_via_hook_strips_private_before_save(self, monkeypatch):
+        """End-to-end via the live hook + live memory_bridge.ingest:
+
+        Patch only Memory.safe_save and bloom; let the actual ingest() run so
+        the strip_private path is exercised. Assert the saved content excludes
+        the wrapped region.
+        """
+        from hook_utils.memory_bridge import ingest
+
+        captured = {}
+
+        def fake_safe_save(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()  # Non-None = saved
+
+        mock_bloom = MagicMock()
+        mock_bloom.might_exist = MagicMock(return_value=False)
+
+        mock_memory_cls = MagicMock()
+        mock_memory_cls._meta.fields.get.return_value = mock_bloom
+        mock_memory_cls.safe_save.side_effect = fake_safe_save
+
+        prompt = (
+            "Refactor the auth handler. The current key is "
+            "<private>sk-very-secret-redacted</private>. Should we rotate?"
+        )
+
+        with (
+            patch("models.memory.Memory", mock_memory_cls),
+            patch("models.memory.SOURCE_HUMAN", "human"),
+            patch("hook_utils.memory_bridge._get_project_key", return_value="test"),
+        ):
+            result = ingest(prompt)
+
+        assert result is True
+        saved_content = captured.get("content", "")
+        assert "sk-very-secret-redacted" not in saved_content
+        assert "<private>" not in saved_content
+        assert "</private>" not in saved_content
+        # Real (non-private) content survives.
+        assert "Refactor the auth handler" in saved_content
+        assert "rotate" in saved_content.lower()

--- a/tests/unit/test_memory_bridge.py
+++ b/tests/unit/test_memory_bridge.py
@@ -575,6 +575,59 @@ class TestIngest:
             assert result is False
             mock_memory_cls.safe_save.assert_not_called()
 
+    def test_ingest_strips_private_tag_from_saved_content(self):
+        """sdlc-1179: <private>...</private> regions are stripped before Memory.safe_save.
+
+        The user's wrapped content must not appear in the persisted Memory.content.
+        """
+        from hook_utils.memory_bridge import ingest
+
+        prompt = (
+            "What does this key mean for our auth flow? "
+            "<private>sk-redacted-secret-here</private> "
+            "Please explain the implications."
+        )
+
+        mock_bloom = MagicMock()
+        mock_bloom.might_exist = MagicMock(return_value=False)
+
+        mock_memory_cls = MagicMock()
+        mock_memory_cls._meta.fields.get.return_value = mock_bloom
+        mock_memory_cls.safe_save.return_value = MagicMock()
+
+        with (
+            patch("models.memory.Memory", mock_memory_cls),
+            patch("models.memory.SOURCE_HUMAN", "human"),
+            patch("hook_utils.memory_bridge._get_project_key", return_value="test"),
+        ):
+            result = ingest(prompt)
+            assert result is True
+            mock_memory_cls.safe_save.assert_called_once()
+            saved_content = mock_memory_cls.safe_save.call_args.kwargs["content"]
+            assert "sk-redacted-secret-here" not in saved_content
+            assert "<private>" not in saved_content
+            assert "</private>" not in saved_content
+            # The non-wrapped portions must still be saved.
+            assert "auth flow" in saved_content
+            assert "implications" in saved_content
+
+    def test_ingest_full_strip_to_empty_returns_false(self):
+        """sdlc-1179: when wrapping the entire prompt, content drops below MIN_PROMPT_LENGTH.
+
+        The downstream length filter correctly rejects the now-empty record;
+        no Memory record is created.
+        """
+        from hook_utils.memory_bridge import ingest
+
+        # Wrap everything; after strip_private the content is empty.
+        prompt = "<private>this entire prompt is private content do not save</private>"
+
+        mock_memory_cls = MagicMock()
+        with patch("models.memory.Memory", mock_memory_cls):
+            result = ingest(prompt)
+            assert result is False
+            mock_memory_cls.safe_save.assert_not_called()
+
 
 class TestExtract:
     """Test the extract() function."""
@@ -1186,6 +1239,49 @@ class TestPrefetch:
         )
         # Trivial pattern (after lowercase + strip), padded with spaces to meet length
         assert prefetch("sess", "yes" + " " * 60) is None
+
+    def test_prefetch_strips_private_before_bm25_query(self, tmp_path, monkeypatch):
+        """sdlc-1179: prefetch wraps the prompt with strip_private before BM25 query.
+
+        Wrapped <private> content must not seed the lookup vector against past
+        memories. This is defense-in-depth: even though the wrapped content is
+        not persisted (ingest strips it too), letting it leak into the BM25
+        query would cause the bloom-hit set to skew toward past records that
+        happen to share trivial words with the secret.
+        """
+        from hook_utils.memory_bridge import prefetch
+
+        monkeypatch.setattr(
+            "hook_utils.memory_bridge._get_sidecar_dir",
+            lambda sid: tmp_path / sid,
+        )
+
+        captured_query = []
+
+        def mock_recall_with_query(query, project_key, **kwargs):
+            captured_query.append(query)
+            return []
+
+        with (
+            patch(
+                "hook_utils.memory_bridge._recall_with_query",
+                side_effect=mock_recall_with_query,
+            ),
+            patch("hook_utils.memory_bridge._get_project_key", return_value="test"),
+        ):
+            prompt = (
+                "What does this key mean for our auth flow? "
+                "<private>sk-redacted-secret-here</private> Please explain."
+            )
+            prefetch("sess", prompt)
+
+        assert len(captured_query) == 1
+        query = captured_query[0]
+        assert "sk-redacted-secret-here" not in query
+        assert "<private>" not in query
+        assert "</private>" not in query
+        # Non-wrapped tokens must still seed the query.
+        assert "auth flow" in query
 
     def test_prefetch_no_window_gate(self, tmp_path, monkeypatch):
         """Prefetch fires immediately -- no WINDOW_SIZE gating."""

--- a/tests/unit/test_memory_ingestion.py
+++ b/tests/unit/test_memory_ingestion.py
@@ -53,6 +53,60 @@ class TestMemoryIngestion:
         # depending on how popoto handles None keys
 
 
+class TestPrivateTagIngestion:
+    """sdlc-1179: <private>...</private> regions are excluded at the ingest layer.
+
+    This is the parallel coverage to test_memory_bridge.TestIngest's private-tag
+    cases, but at the ingestion entry point used by the Telegram bridge (via
+    Memory.safe_save direct invocation, not the hook).
+    """
+
+    def test_strip_private_excludes_wrapped_content(self):
+        """The strip_private helper removes wrapped regions before persistence."""
+        from agent.private_tag import strip_private
+
+        text = "Auth question: <private>sk-redacted</private> please advise"
+        out = strip_private(text)
+        assert "sk-redacted" not in out
+        assert "<private>" not in out
+        assert "Auth question" in out
+        assert "please advise" in out
+
+    def test_strip_private_no_op_on_no_tag(self):
+        """No-tag input must be returned bit-identically."""
+        from agent.private_tag import strip_private
+
+        text = "no private regions in this message"
+        assert strip_private(text) == text
+
+    def test_memory_safe_save_with_pre_stripped_content(self):
+        """Memory.safe_save persists exactly what the caller passes; the bridge's
+        responsibility is to pre-strip via strip_private before calling.
+
+        This documents the contract: Memory itself does NOT know about
+        <private> tags. The bridge / hook ingestion layer is the strip site.
+        """
+        from agent.private_tag import strip_private
+        from models.memory import Memory
+
+        raw = "Deploy plan: <private>internal-rocket-fuel-formula</private> stage"
+        safe = strip_private(raw)
+        m = Memory.safe_save(
+            agent_id="test-private-tag-user",
+            project_key="test-private-tag",
+            content=safe,
+            importance=6.0,
+            source="human",
+        )
+        if m is not None:
+            assert "internal-rocket-fuel-formula" not in m.content
+            assert "<private>" not in m.content
+            try:
+                m.delete()
+            except Exception:
+                pass
+
+
 class TestSystemPromptPriming:
     """Test that thought priming appears in work-patterns.md segment."""
 

--- a/tests/unit/test_private_tag.py
+++ b/tests/unit/test_private_tag.py
@@ -1,0 +1,208 @@
+"""Unit tests for agent.private_tag.strip_private.
+
+Covers:
+- Single tag, multiple tags, no tags (no-op).
+- Unmatched opener (literal pass-through).
+- Whitespace cleanup ONLY when at least one tag was actually stripped
+  (the C2 fix from sdlc-1179 critique cycle 1).
+- Empty / None input (defensive guard).
+- Idempotency.
+- Performance bound on a 10KB adversarial input (Risk 2).
+- DEBUG log emission on full-strip-to-empty (sdlc-1179 N3).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from agent.private_tag import strip_private
+
+
+class TestSingleTag:
+    def test_strips_single_tag(self) -> None:
+        out = strip_private("the key is <private>sk-abc123</private>, why?")
+        # The regex strip leaves two spaces between "is" and ","; the
+        # multi-space collapse runs ONLY because at least one tag was
+        # stripped, leaving a single space.
+        assert out == "the key is , why?"
+
+    def test_inline_tag_no_surrounding_space(self) -> None:
+        out = strip_private("prefix<private>secret</private>suffix")
+        assert out == "prefixsuffix"
+
+    def test_tag_at_start(self) -> None:
+        out = strip_private("<private>x</private>tail")
+        assert out == "tail"
+
+    def test_tag_at_end(self) -> None:
+        out = strip_private("head<private>x</private>")
+        assert out == "head"
+
+
+class TestMultipleTags:
+    def test_two_tags_in_one_message(self) -> None:
+        out = strip_private("a <private>x</private> b <private>y</private> c")
+        assert out == "a b c"
+
+    def test_three_tags(self) -> None:
+        out = strip_private("<private>1</private><private>2</private><private>3</private>")
+        assert out == ""
+
+    def test_non_greedy_does_not_collapse_separate_tags(self) -> None:
+        # Verify <private>A</private> ... <private>B</private> doesn't
+        # match across the gap (non-greedy regex behavior).
+        out = strip_private("<private>A</private> KEEP <private>B</private>")
+        assert "KEEP" in out
+        assert "A" not in out
+        assert "B" not in out
+
+
+class TestNoTagInput:
+    """C2 fix: no-tag input must be returned bit-identically (no whitespace collapse)."""
+
+    def test_no_tag_input_is_unchanged_simple(self) -> None:
+        assert strip_private("hello world") == "hello world"
+
+    def test_no_tag_input_is_unchanged_double_space(self) -> None:
+        # Pre-existing multi-space sequences must survive.
+        text = "hello    world"
+        assert strip_private(text) == text
+
+    def test_no_tag_input_is_unchanged_with_tabs(self) -> None:
+        text = "col1\t\tcol2\t\tcol3"
+        assert strip_private(text) == text
+
+    def test_no_tag_input_is_unchanged_with_newlines(self) -> None:
+        text = "line1\n\nline2\n\n\nline3"
+        assert strip_private(text) == text
+
+    def test_no_tag_input_is_unchanged_mixed_whitespace(self) -> None:
+        text = "a  b\t\tc\n\nd    e"
+        assert strip_private(text) == text
+
+
+class TestUnmatchedOpener:
+    """An opening <private> with no closing </private> is left as literal text."""
+
+    def test_unmatched_opener_alone(self) -> None:
+        text = "<private>open without close"
+        assert strip_private(text) == text
+
+    def test_unmatched_opener_then_unrelated_close(self) -> None:
+        text = "<private>open </other>"
+        assert strip_private(text) == text
+
+
+class TestEmptyAndNoneInput:
+    def test_empty_string(self) -> None:
+        assert strip_private("") == ""
+
+    def test_none_input(self) -> None:
+        # type: ignore[arg-type]
+        assert strip_private(None) == ""  # type: ignore[arg-type]
+
+    def test_whitespace_only(self) -> None:
+        # Whitespace-only is not a tag; pass through unchanged.
+        assert strip_private("   ") == "   "
+
+    def test_non_string_input(self) -> None:
+        # Defensive: a non-string non-None falls into the `not text` branch
+        # for falsy values (0, []), which return "". For a truthy non-string
+        # like `123`, isinstance check returns the empty string.
+        assert strip_private(123) == ""  # type: ignore[arg-type]
+
+
+class TestEmptyAfterStripping:
+    """Wrapping the entire content yields empty output."""
+
+    def test_full_content_wrapped(self) -> None:
+        assert strip_private("<private>everything</private>") == ""
+
+    def test_full_content_wrapped_with_padding(self) -> None:
+        # Strip leaves "  " between the (now-gone) tag and trailing whitespace,
+        # collapsed to single space. .strip() is the caller's job.
+        out = strip_private("  <private>everything</private>  ")
+        # Whitespace-only output (multi-space collapsed once tags were stripped).
+        assert out.strip() == ""
+
+
+class TestIdempotency:
+    def test_idempotent_simple(self) -> None:
+        x = strip_private("a <private>b</private> c")
+        assert strip_private(x) == x
+
+    def test_idempotent_no_tag(self) -> None:
+        x = "no tags here at all"
+        assert strip_private(strip_private(x)) == x
+
+
+class TestNewlinePreservation:
+    def test_newlines_around_tag_preserved(self) -> None:
+        out = strip_private("line1\n<private>secret</private>\nline2")
+        assert "line1" in out and "line2" in out
+        assert "secret" not in out
+        # newlines must not be touched.
+        assert "\n" in out
+
+    def test_double_newlines_preserved(self) -> None:
+        text = "para1\n\npara2"
+        # No tag -> bit-identical
+        assert strip_private(text) == text
+
+
+class TestMultilineTagBody:
+    def test_multiline_body_stripped(self) -> None:
+        # re.DOTALL allows the .*? to span newlines.
+        text = "before\n<private>line1\nline2\nline3</private>\nafter"
+        out = strip_private(text)
+        assert "line1" not in out
+        assert "line2" not in out
+        assert "line3" not in out
+        assert "before" in out
+        assert "after" in out
+
+
+class TestPerformance:
+    """Risk 2 mitigation: regex must complete in <50ms on 10KB adversarial input."""
+
+    def test_large_input_with_many_tags(self) -> None:
+        # 100 tags with ~100 chars of body each -> ~10KB
+        body = "x" * 100
+        chunk = f"prefix <private>{body}</private> suffix "
+        text = chunk * 100  # ~25KB
+        start = time.perf_counter()
+        out = strip_private(text)
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        assert "x" * 100 not in out
+        # Generous bound for slow CI; the regex itself runs in well under 5ms.
+        assert elapsed_ms < 50, f"strip_private took {elapsed_ms:.2f}ms (>50ms bound)"
+
+
+class TestStripToEmptyLogsDebug:
+    """N3: emit a DEBUG log when content was reduced to empty / whitespace-only.
+
+    Operationally, this gives users a grep target for diagnosing dropped
+    messages: ``grep private_tag.strip_to_empty logs/...``.
+    """
+
+    def test_strip_to_empty_logs_debug(self, caplog) -> None:
+        with caplog.at_level(logging.DEBUG, logger="agent.private_tag"):
+            out = strip_private("<private>everything</private>")
+        assert out == ""
+        assert any("private_tag.strip_to_empty" in r.message for r in caplog.records), (
+            f"Expected private_tag.strip_to_empty in DEBUG logs; got: "
+            f"{[r.message for r in caplog.records]}"
+        )
+
+    def test_partial_strip_does_not_log_strip_to_empty(self, caplog) -> None:
+        with caplog.at_level(logging.DEBUG, logger="agent.private_tag"):
+            out = strip_private("hello <private>secret</private> world")
+        assert "secret" not in out
+        # Only logs when the post-strip text is whitespace-only.
+        assert not any("private_tag.strip_to_empty" in r.message for r in caplog.records)
+
+    def test_no_tag_input_does_not_log(self, caplog) -> None:
+        with caplog.at_level(logging.DEBUG, logger="agent.private_tag"):
+            strip_private("nothing private here")
+        assert not any("private_tag" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Adds an inline `<private>...</private>` opt-out tag that lets users exclude any portion of a Telegram message or Claude Code prompt from every persistent surface (Memory, `TelegramMessage.content`, `AgentSession.message_text`, bridge logs) — without disabling memory ingestion globally.

The wrapped content **stays visible to the live agent in the current turn** (the user is masking *future recall*, not hiding from Claude in the moment). A persona segment instructs the agent not to quote wrapped content back, closing the post-session extraction leak channel.

Plan: `docs/plans/sdlc-1179.md`. Critique cleared READY TO BUILD.

## Changes

**Parser (`agent/private_tag.py`):**
- `strip_private(text)` — non-greedy regex, single-level, case-sensitive, idempotent.
- No-tag input is returned bit-identically (C2: multi-space collapse only fires when a tag was actually stripped).
- DEBUG log on full-strip-to-empty (N3) for diagnosability.

**Persona segment (`config/personas/segments/private-tag.md` + `manifest.json`):**
- One-paragraph directive instructing the agent to treat wrapped content as do-not-quote-back.
- Loaded universally (PM/Dev/Teammate) per C3 — defense-in-depth covers PM/Dev sessions that read outbound Telegram, plus the Claude Code path where the live prompt still carries tags.

**Bridge call sites (`bridge/telegram_bridge.py`):**
- Compute `safe_text = strip_private(text)` once after `text = message.text`.
- Use `safe_text` at three inbound persistence sites: `store_message`, `Memory.safe_save`, `logger.info(... text[:50] ...)`.
- Compute both `clean_text` (live SDK input — retains tags) and `safe_clean_text` (persisted — stripped). Wire `safe_clean_text` into `enqueued_message_text`, the directive splice, and the completed-resume `augmented_text`.
- **B1 closure**: strip `reply_chain_context` immediately after `format_reply_chain` in BOTH the completed-resume path (line ~1416) AND the fresh-message prehydration path (line ~1922).
- **C4 acceptance**: outbound `store_message` at line ~2379 deliberately NOT stripped (agent's own utterance); inline comment records the rationale and the right follow-up if empirical leak rate is non-zero.

**Hook ingestion (`.claude/hooks/hook_utils/memory_bridge.py`):**
- `ingest()` strips before the length filter.
- `prefetch()` strips before the BM25 query.

**Tests:**
- `tests/unit/test_private_tag.py` (new, 29 cases): single/multi tags, no-tag bit-identical pass-through (C2), unmatched openers, empty/None, whitespace preservation, idempotency, 10KB <50ms perf bound (Risk 2), N3 strip-to-empty DEBUG log.
- `tests/unit/test_memory_bridge.py` (UPDATE): three new ingest/prefetch cases proving wrapped content never reaches `Memory.safe_save` and the BM25 query is also stripped.
- `tests/unit/test_memory_ingestion.py` (UPDATE): contract checks + real-Memory persistence check.
- `tests/unit/test_hook_user_prompt_submit.py` (UPDATE): end-to-end live `ingest()` with patched `Memory.safe_save`.
- `tests/integration/test_private_tag_ingestion.py` (new, 11 cases): bridge text-flow composition, live-agent visibility, B1 reply-chain leak closure for both completed-resume and prehydration paths.

**Documentation:**
- `docs/features/subconscious-memory.md` — new "Excluding content with `<private>` tags" subsection under Flow 1 with a worked Telegram example and the visibility-vs-persistence asymmetry table (N2).

## Testing

- [x] All plan-required tests passing: `pytest tests/unit/test_private_tag.py tests/unit/test_memory_bridge.py tests/unit/test_hook_user_prompt_submit.py tests/integration/test_private_tag_ingestion.py` — **146 passed**.
- [x] Lint clean (`python -m ruff check .`).
- [x] Format clean (`python -m ruff format --check .`).
- [x] Bridge call-site grep verification: `safe_text` count = 12 (>3), `strip_private(reply_chain_context)` count = 2 (>=2), hook `strip_private` count = 4 (>1).
- [x] Persona segment renders in live `load_persona_prompt('teammate')` with the do-NOT-quote directive present (C5).
- [x] Manifest contains `private-tag.md` (C5).

## Documentation

- [x] `docs/features/subconscious-memory.md` documents the `<private>` syntax, scope, agent-visibility model, worked example, and limits/trade-offs.

## Definition of Done

- [x] Built: parser + persona segment + 6 call sites updated.
- [x] Tested: 146 dedicated tests + integration suite passing; pre-existing test failures in `tests/unit/test_email_bridge.py`, `test_worker_idle_sweeper.py`, `test_watchdog_loop_break_steer.py`, etc. are unrelated to this change.
- [x] Documented: `docs/features/subconscious-memory.md` updated.
- [x] Quality: ruff check + format clean.

Closes #1179