### PR TITLE
refactor(memory): unify project_key resolution into resolve_project_key (#1232)

### DIFF
--- a/.claude/hooks/hook_utils/memory_bridge.py
+++ b/.claude/hooks/hook_utils/memory_bridge.py
@@ -477,8 +477,8 @@ def recall(
         # Multi-query decomposition -- cluster keywords and retrieve via
         # _recall_with_query() per cluster (bloom_check=False inside each
         # call since we already passed the multi-keyword bloom gate above).
-        from utils.keyword_extraction import _cluster_keywords
         from config.memory_defaults import DEFAULT_PROJECT_KEY
+        from utils.keyword_extraction import _cluster_keywords
 
         _raw_pk = _get_project_key(cwd)
         project_key = _raw_pk if _raw_pk is not None else DEFAULT_PROJECT_KEY
@@ -733,7 +733,8 @@ def ingest(content: str, cwd: str | None = None) -> bool:
         project_key = _get_project_key(cwd)
         if project_key is None:
             logger.warning(
-                "[memory_bridge] ingest write skipped: resolve_project_key returned None "                "(cwd=%r, VALOR_PROJECT_KEY=%r)",
+                "[memory_bridge] ingest write skipped: resolve_project_key returned None "
+                "(cwd=%r, VALOR_PROJECT_KEY=%r)",
                 cwd,
                 os.environ.get("VALOR_PROJECT_KEY"),
             )
@@ -793,7 +794,8 @@ def extract(session_id: str, transcript_path: str | None, cwd: str | None = None
         project_key = _get_project_key(cwd)
         if project_key is None:
             logger.warning(
-                "[memory_bridge] extract write skipped: resolve_project_key returned None "                "(cwd=%r, VALOR_PROJECT_KEY=%r)",
+                "[memory_bridge] extract write skipped: resolve_project_key returned None "
+                "(cwd=%r, VALOR_PROJECT_KEY=%r)",
                 cwd,
                 os.environ.get("VALOR_PROJECT_KEY"),
             )
@@ -891,7 +893,8 @@ def post_merge_extract(pr_number: str | int | None = None, cwd: str | None = Non
         project_key = _get_project_key(cwd)
         if project_key is None:
             logger.warning(
-                "[memory_bridge] post_merge_extract write skipped: resolve_project_key returned None "                "(cwd=%r, VALOR_PROJECT_KEY=%r)",
+                "[memory_bridge] post_merge_extract write skipped: "
+                "resolve_project_key returned None (cwd=%r, VALOR_PROJECT_KEY=%r)",
                 cwd,
                 os.environ.get("VALOR_PROJECT_KEY"),
             )

--- a/.claude/hooks/hook_utils/memory_bridge.py
+++ b/.claude/hooks/hook_utils/memory_bridge.py
@@ -187,41 +187,20 @@ def _save_sidecar(session_id: str, data: dict) -> None:
         raise
 
 
-def _get_project_key(cwd: str | None = None) -> str:
-    """Resolve the project key from environment, cwd path match, or defaults.
+def _get_project_key(cwd: str | None = None) -> str | None:
+    """Resolve the project key from environment, cwd path match, or return None.
 
-    Priority: VALOR_PROJECT_KEY env var > cwd match against projects.json > default.
+    Thin wrapper around ``config.project_key_resolver.resolve_project_key``.
+    All new callsites should import and call ``resolve_project_key`` directly;
+    this wrapper exists so that existing test-patch targets
+    (``hook_utils.memory_bridge._get_project_key``) continue to work.
+
+    Returns ``str | None`` — callers that previously expected a non-None ``str``
+    must now guard against ``None`` and skip the Memory write on ``None``.
     """
-    env_key = os.environ.get("VALOR_PROJECT_KEY")
-    if env_key:
-        return env_key
+    from config.project_key_resolver import resolve_project_key
 
-    # Try to match cwd against projects.json working_directory entries
-    if cwd:
-        try:
-            projects_path = Path.home() / "Desktop" / "Valor" / "projects.json"
-            if projects_path.exists():
-                with open(projects_path) as f:
-                    data = json.load(f)
-                home = str(Path.home())
-                for key, proj in data.get("projects", {}).items():
-                    wd = proj.get("working_directory", "")
-                    if wd:
-                        wd = wd.replace("~", home)
-                        if cwd.startswith(wd):
-                            return key
-        except Exception:
-            pass
-
-        # No projects.json match -- derive from directory basename
-        return Path(cwd).name
-
-    try:
-        from config.memory_defaults import DEFAULT_PROJECT_KEY
-
-        return DEFAULT_PROJECT_KEY
-    except Exception:
-        return "default"
+    return resolve_project_key(cwd=cwd)
 
 
 def _strip_pm_boilerplate(prompt: str) -> str:
@@ -499,8 +478,10 @@ def recall(
         # _recall_with_query() per cluster (bloom_check=False inside each
         # call since we already passed the multi-keyword bloom gate above).
         from utils.keyword_extraction import _cluster_keywords
+        from config.memory_defaults import DEFAULT_PROJECT_KEY
 
-        project_key = _get_project_key(cwd)
+        _raw_pk = _get_project_key(cwd)
+        project_key = _raw_pk if _raw_pk is not None else DEFAULT_PROJECT_KEY
         existing_injected_ids = {
             str(item.get("memory_id", "") or "")
             for item in state.get("injected", [])
@@ -627,7 +608,10 @@ def prefetch(
         if normalized in TRIVIAL_PATTERNS:
             return None
 
-        project_key = _get_project_key(cwd)
+        from config.memory_defaults import DEFAULT_PROJECT_KEY
+
+        _raw_pk = _get_project_key(cwd)
+        project_key = _raw_pk if _raw_pk is not None else DEFAULT_PROJECT_KEY
 
         # Load sidecar to get current injected[] for de-dup.
         state = _load_sidecar(session_id)
@@ -747,6 +731,13 @@ def ingest(content: str, cwd: str | None = None) -> bool:
         from models.memory import SOURCE_HUMAN
 
         project_key = _get_project_key(cwd)
+        if project_key is None:
+            logger.warning(
+                "[memory_bridge] ingest write skipped: resolve_project_key returned None "                "(cwd=%r, VALOR_PROJECT_KEY=%r)",
+                cwd,
+                os.environ.get("VALOR_PROJECT_KEY"),
+            )
+            return False
 
         m = Memory.safe_save(
             agent_id=project_key,
@@ -800,6 +791,13 @@ def extract(session_id: str, transcript_path: str | None, cwd: str | None = None
 
         # Run Haiku extraction
         project_key = _get_project_key(cwd)
+        if project_key is None:
+            logger.warning(
+                "[memory_bridge] extract write skipped: resolve_project_key returned None "                "(cwd=%r, VALOR_PROJECT_KEY=%r)",
+                cwd,
+                os.environ.get("VALOR_PROJECT_KEY"),
+            )
+            return
         asyncio.run(extract_observations_async(session_id, truncated_text, project_key=project_key))
 
         # Run outcome detection using injected thoughts from sidecar
@@ -891,6 +889,13 @@ def post_merge_extract(pr_number: str | int | None = None, cwd: str | None = Non
         from agent.memory_extraction import extract_post_merge_learning
 
         project_key = _get_project_key(cwd)
+        if project_key is None:
+            logger.warning(
+                "[memory_bridge] post_merge_extract write skipped: resolve_project_key returned None "                "(cwd=%r, VALOR_PROJECT_KEY=%r)",
+                cwd,
+                os.environ.get("VALOR_PROJECT_KEY"),
+            )
+            return
         asyncio.run(
             extract_post_merge_learning(
                 pr_title=pr_title,

--- a/agent/memory_extraction.py
+++ b/agent/memory_extraction.py
@@ -426,9 +426,15 @@ async def extract_observations_async(
         from models.memory import SOURCE_AGENT, Memory
 
         if not project_key:
-            from config.memory_defaults import DEFAULT_PROJECT_KEY
+            from config.project_key_resolver import resolve_project_key
 
-            project_key = os.environ.get("VALOR_PROJECT_KEY", DEFAULT_PROJECT_KEY)
+            project_key = resolve_project_key()
+            if project_key is None:
+                logger.warning(
+                    "[memory_extraction] extract_observations write skipped: "                    "resolve_project_key returned None (VALOR_PROJECT_KEY=%r)",
+                    os.environ.get("VALOR_PROJECT_KEY"),
+                )
+                return []
 
         saved = []
         for obs_content, importance, metadata in parsed[:10]:  # cap at 10 observations
@@ -637,9 +643,15 @@ async def extract_post_merge_learning(
         from models.memory import SOURCE_AGENT, Memory
 
         if not project_key:
-            from config.memory_defaults import DEFAULT_PROJECT_KEY
+            from config.project_key_resolver import resolve_project_key
 
-            project_key = os.environ.get("VALOR_PROJECT_KEY", DEFAULT_PROJECT_KEY)
+            project_key = resolve_project_key()
+            if project_key is None:
+                logger.warning(
+                    "[memory_extraction] post_merge write skipped: "                    "resolve_project_key returned None (VALOR_PROJECT_KEY=%r)",
+                    os.environ.get("VALOR_PROJECT_KEY"),
+                )
+                return None
 
         # Try to parse structured JSON response for metadata
         content_text = raw_text

--- a/agent/memory_extraction.py
+++ b/agent/memory_extraction.py
@@ -431,7 +431,8 @@ async def extract_observations_async(
             project_key = resolve_project_key()
             if project_key is None:
                 logger.warning(
-                    "[memory_extraction] extract_observations write skipped: "                    "resolve_project_key returned None (VALOR_PROJECT_KEY=%r)",
+                    "[memory_extraction] extract_observations write skipped: "
+                    "resolve_project_key returned None (VALOR_PROJECT_KEY=%r)",
                     os.environ.get("VALOR_PROJECT_KEY"),
                 )
                 return []
@@ -648,7 +649,8 @@ async def extract_post_merge_learning(
             project_key = resolve_project_key()
             if project_key is None:
                 logger.warning(
-                    "[memory_extraction] post_merge write skipped: "                    "resolve_project_key returned None (VALOR_PROJECT_KEY=%r)",
+                    "[memory_extraction] post_merge write skipped: "
+                    "resolve_project_key returned None (VALOR_PROJECT_KEY=%r)",
                     os.environ.get("VALOR_PROJECT_KEY"),
                 )
                 return None

--- a/agent/memory_hook.py
+++ b/agent/memory_hook.py
@@ -154,7 +154,8 @@ def check_and_inject(
             project_key = resolve_project_key(project_key=None)
             if project_key is None:
                 logger.warning(
-                    "[memory_hook] check_and_inject write skipped: resolve_project_key "                    "returned None (VALOR_PROJECT_KEY=%r)",
+                    "[memory_hook] check_and_inject write skipped: resolve_project_key "
+                    "returned None (VALOR_PROJECT_KEY=%r)",
                     os.environ.get("VALOR_PROJECT_KEY"),
                 )
                 return None

--- a/agent/memory_hook.py
+++ b/agent/memory_hook.py
@@ -144,11 +144,20 @@ def check_and_inject(
         if count % WINDOW_SIZE != 0:
             return None
 
-        # Resolve project_key
+        # Resolve project_key using the canonical resolver.
+        # NOTE: check_and_inject() has no cwd parameter — it runs inside the SDK
+        # worker process where the filesystem path is not directly available.
+        # Resolution uses env-only (VALOR_PROJECT_KEY) and explicit kwarg only.
         if not project_key:
-            from config.memory_defaults import DEFAULT_PROJECT_KEY
+            from config.project_key_resolver import resolve_project_key
 
-            project_key = os.environ.get("VALOR_PROJECT_KEY", DEFAULT_PROJECT_KEY)
+            project_key = resolve_project_key(project_key=None)
+            if project_key is None:
+                logger.warning(
+                    "[memory_hook] check_and_inject write skipped: resolve_project_key "                    "returned None (VALOR_PROJECT_KEY=%r)",
+                    os.environ.get("VALOR_PROJECT_KEY"),
+                )
+                return None
 
         # Extract keywords from full buffer (last BUFFER_SIZE entries)
         all_keywords: list[str] = []

--- a/config/project_key_resolver.py
+++ b/config/project_key_resolver.py
@@ -1,0 +1,138 @@
+"""Canonical project_key resolver for Memory write paths.
+
+This module provides a single ``resolve_project_key()`` function that every
+Memory writer callsite uses.  Having one implementation means fixes and new
+resolution hints (new projects.json fields, additional env vars) propagate to
+all writers automatically.
+
+Priority chain
+--------------
+1. ``project_key`` kwarg — explicit override; return immediately.
+2. ``env`` mapping lookup for ``"VALOR_PROJECT_KEY"`` — machine-scoped env var.
+3. ``projects.json`` ``working_directory`` prefix match against ``cwd``.
+4. ``None`` — unresolvable; the caller *must* skip the ``Memory.safe_save`` call.
+
+Intentional omissions
+---------------------
+* **No ``DEFAULT_PROJECT_KEY`` fallback** — ``"default"`` means "misconfigured",
+  not "unknown but safe".  Writers that receive ``None`` should skip the write and
+  log a ``WARNING`` so the gap is visible in production logs.
+* **No ``Path(cwd).name`` (directory-basename) fallback** — basename produces
+  keys like ``"ai"`` that are not declared projects.  The previous
+  ``memory_bridge._get_project_key`` included this step; the unified helper drops
+  it to keep the resolver honest.
+
+Read paths (recall, search, stats) are **not** in scope for this module.  They
+may continue to use ``DEFAULT_PROJECT_KEY`` as a non-None default because a bad
+key on a read produces an empty result set, not a corrupted write.
+
+Circular-import safety
+----------------------
+This module imports only stdlib (``json``, ``os``, ``pathlib``) and
+``config.memory_defaults``.  It never imports from ``agent/``, ``bridge/``,
+``models/``, or ``tools/``.  Callers from all of those packages can safely
+import from here without creating a cycle.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Lazy-loaded cache: list of (expanded_working_directory, project_key) pairs
+# sorted by path-length descending so the most-specific match wins.
+_projects_cache: list[tuple[str, str]] | None = None
+_projects_cache_path: str | None = None
+
+
+def _load_projects(projects_path: Path | None = None) -> list[tuple[str, str]]:
+    """Load and cache ``(working_directory, project_key)`` pairs from projects.json.
+
+    Returns an empty list if the file is missing or unreadable — callers fall
+    through to the ``None`` return rather than raising.
+    """
+    global _projects_cache, _projects_cache_path
+
+    resolved = str(projects_path or Path.home() / "Desktop" / "Valor" / "projects.json")
+
+    # Cache hit (same path)
+    if _projects_cache is not None and _projects_cache_path == resolved:
+        return _projects_cache
+
+    pairs: list[tuple[str, str]] = []
+    try:
+        p = Path(resolved)
+        if p.exists():
+            with open(p) as f:
+                data = json.load(f)
+            home = str(Path.home())
+            for key, proj in data.get("projects", {}).items():
+                wd = proj.get("working_directory", "")
+                if wd:
+                    wd = wd.replace("~", home)
+                    wd = os.path.normpath(wd)
+                    pairs.append((wd, key))
+            # Longest match first (most-specific project wins)
+            pairs.sort(key=lambda x: len(x[0]), reverse=True)
+    except Exception as exc:
+        logger.debug("project_key_resolver: could not load %s: %s", resolved, exc)
+
+    _projects_cache = pairs
+    _projects_cache_path = resolved
+    return pairs
+
+
+def resolve_project_key(
+    cwd: str | None = None,
+    env: dict | None = None,
+    projects_path: Path | None = None,
+    project_key: str | None = None,
+) -> str | None:
+    """Resolve a project_key for a Memory write, or return ``None`` if unresolvable.
+
+    Args:
+        cwd: Working directory to match against ``projects.json``
+            ``working_directory`` entries.  Pass ``None`` when no filesystem
+            context is available (e.g., SDK PostToolUse hooks without cwd).
+        env: Environment mapping to look up ``VALOR_PROJECT_KEY``.  Defaults to
+            ``os.environ`` when ``None``.
+        projects_path: Override path to ``projects.json``.  Defaults to
+            ``~/Desktop/Valor/projects.json``.
+        project_key: Explicit override.  If non-empty, returned immediately
+            without consulting ``env`` or ``projects.json``.
+
+    Returns:
+        A non-empty project key string, or ``None`` if resolution failed.
+        Writers **must** skip ``Memory.safe_save`` when this returns ``None``
+        and log a ``WARNING`` so the skip is observable in production.
+
+    Resolution priority:
+        1. ``project_key`` kwarg (non-empty string)
+        2. ``VALOR_PROJECT_KEY`` in ``env`` (or ``os.environ``)
+        3. ``projects.json`` ``working_directory`` prefix match against ``cwd``
+        4. ``None``
+    """
+    # 1. Explicit override
+    if project_key:
+        return project_key
+
+    # 2. Environment variable
+    mapping = env if env is not None else os.environ
+    env_key = mapping.get("VALOR_PROJECT_KEY", "").strip()
+    if env_key:
+        return env_key
+
+    # 3. projects.json cwd-match
+    if cwd:
+        cwd_normalized = os.path.normpath(cwd)
+        pairs = _load_projects(projects_path)
+        for wd, key in pairs:
+            if cwd_normalized.startswith(wd):
+                return key
+
+    # 4. Unresolvable
+    return None

--- a/docs/features/subconscious-memory.md
+++ b/docs/features/subconscious-memory.md
@@ -582,19 +582,25 @@ All Memory records carry a `project_key` that scopes them to a specific project.
 |-------|--------|-------------|
 | `"valor"` | projects.json match | The main `~/src/ai` project (matched by working directory) |
 | `"dm"` | retired — DO NOT WRITE | The original Telegram-DM partition. Retired in #811 (PR #820). The bridge no longer writes here at all (#1173): messages from chats that don't resolve to a declared project skip the canonical Memory partition write entirely. `Memory.safe_save` emits a WARNING with stack trace if any caller still attempts a `"dm"` write — see `_warn_if_legacy_namespace` in `models/memory.py`. |
-| `Path(cwd).name` | cwd basename fallback | Used when projects.json is missing or has no match for the current directory |
-| `"default"` | `DEFAULT_PROJECT_KEY` | Last-resort fallback in `config/memory_defaults.py`. Still legitimate during single-machine bootstrap and test fixtures. `Memory.safe_save` emits a DEBUG-level audit log with stack trace whenever `"default"` is written; tracked under follow-up issue #1232 (unify writer project_key resolution into a single helper). |
+| `"default"` | `DEFAULT_PROJECT_KEY` | Last-resort for read paths (recall/search/stats) when no project is resolved. `Memory.safe_save` emits a DEBUG-level audit log with stack trace whenever `"default"` is written by a write path; if `_warn_if_legacy_namespace` fires on `"default"` in normal operation, it means a write path resolved incorrectly — investigate the caller. |
+| `None` | unresolvable | Returned by `resolve_project_key()` when no env var and no cwd match. Writers must skip `Memory.safe_save` on `None` and log a WARNING. |
 
-### Resolution Chain
+### Resolution (Unified Helper)
 
-`_get_project_key(cwd)` in `memory_bridge.py` (Claude Code hooks path):
+All Memory write paths use `resolve_project_key()` from `config/project_key_resolver.py` (#1232). This single function encapsulates the full resolution chain:
 
-1. `VALOR_PROJECT_KEY` env var — highest priority, used by CI/SDK-spawned sessions
-2. `projects.json` cwd match — `~/Desktop/Valor/projects.json` entries matched by path prefix
-3. `Path(cwd).name` — directory basename when no projects.json match exists
-4. `DEFAULT_PROJECT_KEY` from `config/memory_defaults.py` — final fallback when cwd is None
+1. **Explicit kwarg** — `project_key=` arg if non-empty → return immediately (explicit override)
+2. **`VALOR_PROJECT_KEY` env var** — machine-scoped env var; highest auto-resolution priority
+3. **`projects.json` cwd match** — `~/Desktop/Valor/projects.json` `working_directory` prefix match against `cwd`
+4. **`None`** — unresolvable; callers must skip the write and log a WARNING
 
-The Telegram bridge path resolves `project_key` from the message's chat (`find_project_for_dm(sender_id)` for DMs, `find_project_for_chat(chat_title)` for groups). When neither resolver matches, the bridge writes conversation history (`store_message`, `register_chat`) with `project_key=None` so `valor-telegram read` keeps working, but **skips the canonical Memory partition write entirely** — unowned messages no longer pollute any partition (#1173). The retired `"dm"` literal has been removed from `bridge/telegram_bridge.py`; see `_warn_if_legacy_namespace` in `models/memory.py` for the regression detector.
+**Intentional omissions:**
+- No `Path(cwd).name` (dirname) fallback — directory basenames are not declared project keys; using them silently mislabeled records in the past
+- No `DEFAULT_PROJECT_KEY` fallback — `"default"` means misconfigured, not unknown-but-safe; writers that fall through must skip rather than pollute
+
+**Read paths** (`recall`, `search`, `stats`, `forget`) continue to use `DEFAULT_PROJECT_KEY` as a non-None fallback because an empty result set on a bad key is safe; the `_resolve_project_key` helper in `tools/memory_search/__init__.py` and `ui/data/memories.py` handles this independently.
+
+The Telegram bridge path resolves `project_key` from the message's chat (`find_project_for_dm(sender_id)` for DMs, `find_project_for_chat(chat_title)` for groups). When neither resolver matches, the bridge writes conversation history (`store_message`, `register_chat`) with `project_key=None` so `valor-telegram read` keeps working, but **skips the canonical Memory partition write entirely** — unowned messages no longer pollute any partition (#1173, #1234). The retired `"dm"` literal has been removed from `bridge/telegram_bridge.py`; see `_warn_if_legacy_namespace` in `models/memory.py` for the regression detector.
 
 ### Migration Helper
 

--- a/tests/unit/test_memory_bridge.py
+++ b/tests/unit/test_memory_bridge.py
@@ -668,6 +668,8 @@ class TestExtract:
             "hook_utils.memory_bridge._get_sidecar_dir",
             lambda sid: tmp_path / "sidecar" / sid,
         )
+        # Provide a resolvable project_key via env var (required post-#1232)
+        monkeypatch.setenv("VALOR_PROJECT_KEY", "test-project")
 
         # Create a transcript with enough content
         transcript = tmp_path / "transcript.jsonl"
@@ -845,29 +847,31 @@ class TestGetProjectKey:
         result = _get_project_key(cwd="/some/other/path")
         assert result == "myproject"
 
-    def test_cwd_falls_back_to_dirname(self, monkeypatch):
-        """When no env var or projects.json match, returns cwd basename."""
+    def test_cwd_no_match_returns_none(self, monkeypatch):
+        """When no env var or projects.json match, returns None (no dirname fallback).
+
+        The dirname fallback (Path(cwd).name) was intentionally removed in #1232.
+        Writers that receive None must skip the Memory write rather than silently
+        using a directory name as a project key.
+        """
         from hook_utils.memory_bridge import _get_project_key
 
         monkeypatch.delenv("VALOR_PROJECT_KEY", raising=False)
-        # Patch projects.json path to nonexistent to skip that branch
-        import hook_utils.memory_bridge as mb
-
-        monkeypatch.setattr(mb, "_get_project_key", mb._get_project_key)
-
-        # Use a tmp path with no projects.json
+        # Use a path with no matching projects.json entry
         result = _get_project_key(cwd="/home/user/myrepo")
-        # Without a matching projects.json entry, returns basename
-        assert result == "myrepo"
+        assert result is None
 
-    def test_no_cwd_returns_default(self, monkeypatch):
-        """Without cwd and no env var, returns DEFAULT_PROJECT_KEY (not 'dm')."""
+    def test_no_cwd_returns_none(self, monkeypatch):
+        """Without cwd and no env var, returns None (not DEFAULT_PROJECT_KEY).
+
+        Write paths must handle None and skip the write.
+        Read paths use DEFAULT_PROJECT_KEY independently.
+        """
         from hook_utils.memory_bridge import _get_project_key
 
         monkeypatch.delenv("VALOR_PROJECT_KEY", raising=False)
         result = _get_project_key(cwd=None)
-        # Must not be "dm" -- that value is reserved for Telegram DMs
-        assert result != "dm"
+        assert result is None
 
     def test_default_project_key_not_dm(self):
         """DEFAULT_PROJECT_KEY in config/memory_defaults.py is not 'dm'."""

--- a/tests/unit/test_memory_extraction.py
+++ b/tests/unit/test_memory_extraction.py
@@ -714,6 +714,7 @@ class TestPostMergeJsonParsing:
             patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
             patch("models.memory.Memory", mock_memory),
             patch("models.memory.SOURCE_AGENT", "agent"),
+            patch("config.project_key_resolver.resolve_project_key", return_value="test"),
         ):
             result = await extract_post_merge_learning(
                 "Add recall weights", "Description", "agent/memory_hook.py"
@@ -748,6 +749,7 @@ class TestPostMergeJsonParsing:
             patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
             patch("models.memory.Memory", mock_memory),
             patch("models.memory.SOURCE_AGENT", "agent"),
+            patch("config.project_key_resolver.resolve_project_key", return_value="test"),
         ):
             result = await extract_post_merge_learning(
                 "Add recall weights", "Description", "diff summary"
@@ -782,6 +784,7 @@ class TestPostMergeJsonParsing:
             patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
             patch("models.memory.Memory", mock_memory),
             patch("models.memory.SOURCE_AGENT", "agent"),
+            patch("config.project_key_resolver.resolve_project_key", return_value="test"),
         ):
             result = await extract_post_merge_learning("Add recall weights", "Description", "diff")
 

--- a/tests/unit/test_memory_hook.py
+++ b/tests/unit/test_memory_hook.py
@@ -202,6 +202,7 @@ class TestDejaVuSignals:
         with (
             patch("agent.memory_hook.extract_topic_keywords", return_value=keywords),
             patch("models.memory.Memory", mock_memory_cls),
+            patch("config.project_key_resolver.resolve_project_key", return_value="test"),
         ):
             # Fill up to WINDOW_SIZE to trigger query
             for i in range(INJECTION_WINDOW_SIZE - 1):
@@ -323,6 +324,7 @@ class TestCheckAndInjectBloomGate:
         with (
             patch("agent.memory_hook.extract_topic_keywords", return_value=keywords),
             patch("models.memory.Memory", mock_memory_cls),
+            patch("config.project_key_resolver.resolve_project_key", return_value="test"),
         ):
             for i in range(INJECTION_WINDOW_SIZE - 1):
                 check_and_inject(session, "Read", {"file_path": f"f{i}.py"})
@@ -402,6 +404,7 @@ class TestCheckAndInjectBloomGate:
             patch("agent.memory_hook.extract_topic_keywords", return_value=keywords),
             patch("models.memory.Memory", mock_memory_cls),
             patch("agent.memory_retrieval.retrieve_memories", rm_mock),
+            patch("config.project_key_resolver.resolve_project_key", return_value="test"),
         ):
             for i in range(INJECTION_WINDOW_SIZE - 1):
                 check_and_inject(session, "Read", {"file_path": f"f{i}.py"})
@@ -443,6 +446,7 @@ class TestCheckAndInjectPassesMinScore:
             patch("agent.memory_hook.extract_topic_keywords", return_value=keywords),
             patch("models.memory.Memory", mock_memory_cls),
             patch("agent.memory_retrieval.retrieve_memories", side_effect=fake_rm),
+            patch("config.project_key_resolver.resolve_project_key", return_value="test"),
         ):
             for i in range(INJECTION_WINDOW_SIZE - 1):
                 check_and_inject(session, "Read", {"file_path": f"f{i}.py"})
@@ -773,6 +777,7 @@ class TestCheckAndInjectClaudeUuidSidecar:
                 "agent.memory_retrieval.retrieve_memories",
                 return_value=[skip_me, keep_me],
             ),
+            patch("config.project_key_resolver.resolve_project_key", return_value="test"),
         ):
             for i in range(INJECTION_WINDOW_SIZE - 1):
                 check_and_inject(session, "Read", {"file_path": f"f{i}.py"})
@@ -821,6 +826,7 @@ class TestCheckAndInjectClaudeUuidSidecar:
             patch("agent.memory_hook.extract_topic_keywords", return_value=keywords),
             patch("models.memory.Memory", mock_memory_cls),
             patch("agent.memory_retrieval.retrieve_memories", return_value=[record]),
+            patch("config.project_key_resolver.resolve_project_key", return_value="test"),
         ):
             for i in range(INJECTION_WINDOW_SIZE - 1):
                 check_and_inject(session, "Read", {"file_path": f"f{i}.py"})
@@ -866,6 +872,7 @@ class TestCheckAndInjectClaudeUuidSidecar:
                 "agent.memory_hook._load_hooks_sidecar_injected_ids",
                 return_value=set(),
             ) as mock_loader,
+            patch("config.project_key_resolver.resolve_project_key", return_value="test"),
         ):
             for i in range(INJECTION_WINDOW_SIZE - 1):
                 check_and_inject(session, "Read", {"file_path": f"f{i}.py"})
@@ -912,6 +919,7 @@ class TestCheckAndInjectClaudeUuidSidecar:
                 "agent.memory_hook._load_hooks_sidecar_injected_ids",
                 return_value=set(),
             ) as mock_loader,
+            patch("config.project_key_resolver.resolve_project_key", return_value="test"),
         ):
             for i in range(INJECTION_WINDOW_SIZE - 1):
                 check_and_inject(session, "Read", {"file_path": f"f{i}.py"})
@@ -956,6 +964,7 @@ class TestCheckAndInjectClaudeUuidSidecar:
                 "agent.memory_hook._load_hooks_sidecar_injected_ids",
                 return_value=set(),
             ) as mock_loader,
+            patch("config.project_key_resolver.resolve_project_key", return_value="test"),
         ):
             for i in range(INJECTION_WINDOW_SIZE - 1):
                 check_and_inject(session, "Read", {"file_path": f"f{i}.py"})

--- a/tests/unit/test_project_key_resolver.py
+++ b/tests/unit/test_project_key_resolver.py
@@ -1,0 +1,255 @@
+"""Unit tests for config.project_key_resolver.resolve_project_key.
+
+Covers the full priority chain:
+  1. Explicit project_key kwarg
+  2. VALOR_PROJECT_KEY env var
+  3. projects.json working_directory prefix match against cwd
+  4. None return when all inputs are absent/empty
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from config.project_key_resolver import resolve_project_key, _load_projects
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_projects_json(tmp_path: Path, projects: dict) -> Path:
+    """Write a minimal projects.json to a temp directory."""
+    p = tmp_path / "projects.json"
+    p.write_text(json.dumps({"projects": projects}))
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Priority 1: explicit project_key kwarg
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_project_key_returned_immediately():
+    result = resolve_project_key(project_key="myproject")
+    assert result == "myproject"
+
+
+def test_explicit_project_key_bypasses_env(monkeypatch):
+    monkeypatch.setenv("VALOR_PROJECT_KEY", "env-project")
+    result = resolve_project_key(project_key="explicit")
+    assert result == "explicit"
+
+
+def test_empty_string_project_key_falls_through(monkeypatch, tmp_path):
+    """Empty string is treated as absent — falls through to env lookup."""
+    monkeypatch.setenv("VALOR_PROJECT_KEY", "env-project")
+    result = resolve_project_key(project_key="")
+    assert result == "env-project"
+
+
+# ---------------------------------------------------------------------------
+# Priority 2: VALOR_PROJECT_KEY env var
+# ---------------------------------------------------------------------------
+
+
+def test_env_var_used_when_no_explicit_key(monkeypatch):
+    monkeypatch.setenv("VALOR_PROJECT_KEY", "valor")
+    result = resolve_project_key()
+    assert result == "valor"
+
+
+def test_env_dict_override(monkeypatch):
+    monkeypatch.delenv("VALOR_PROJECT_KEY", raising=False)
+    result = resolve_project_key(env={"VALOR_PROJECT_KEY": "from-dict"})
+    assert result == "from-dict"
+
+
+def test_env_dict_takes_precedence_over_os_environ(monkeypatch):
+    monkeypatch.setenv("VALOR_PROJECT_KEY", "os-env")
+    result = resolve_project_key(env={"VALOR_PROJECT_KEY": "dict-env"})
+    assert result == "dict-env"
+
+
+def test_empty_env_var_falls_through(monkeypatch, tmp_path):
+    """VALOR_PROJECT_KEY set to empty string is treated as absent."""
+    monkeypatch.setenv("VALOR_PROJECT_KEY", "")
+    result = resolve_project_key(cwd=None)
+    assert result is None
+
+
+def test_whitespace_env_var_falls_through(monkeypatch):
+    monkeypatch.setenv("VALOR_PROJECT_KEY", "   ")
+    result = resolve_project_key()
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Priority 3: projects.json cwd match
+# ---------------------------------------------------------------------------
+
+
+def test_cwd_match_returns_project_key(monkeypatch, tmp_path):
+    monkeypatch.delenv("VALOR_PROJECT_KEY", raising=False)
+    projects_path = _make_projects_json(
+        tmp_path,
+        {"myrepo": {"working_directory": str(tmp_path)}},
+    )
+    result = resolve_project_key(
+        cwd=str(tmp_path / "subdir"),
+        projects_path=projects_path,
+    )
+    assert result == "myrepo"
+
+
+def test_cwd_exact_match(monkeypatch, tmp_path):
+    monkeypatch.delenv("VALOR_PROJECT_KEY", raising=False)
+    projects_path = _make_projects_json(
+        tmp_path,
+        {"exactrepo": {"working_directory": str(tmp_path)}},
+    )
+    result = resolve_project_key(cwd=str(tmp_path), projects_path=projects_path)
+    assert result == "exactrepo"
+
+
+def test_longest_match_wins(monkeypatch, tmp_path):
+    """Most-specific (longest) working_directory prefix should win."""
+    monkeypatch.delenv("VALOR_PROJECT_KEY", raising=False)
+    sub = tmp_path / "workspace" / "sub"
+    projects_path = _make_projects_json(
+        tmp_path,
+        {
+            "parent-proj": {"working_directory": str(tmp_path / "workspace")},
+            "sub-proj": {"working_directory": str(sub)},
+        },
+    )
+    result = resolve_project_key(
+        cwd=str(sub / "code"),
+        projects_path=projects_path,
+    )
+    assert result == "sub-proj"
+
+
+def test_no_cwd_match_returns_none(monkeypatch, tmp_path):
+    monkeypatch.delenv("VALOR_PROJECT_KEY", raising=False)
+    projects_path = _make_projects_json(
+        tmp_path,
+        {"someproject": {"working_directory": "/other/path"}},
+    )
+    result = resolve_project_key(cwd="/completely/different", projects_path=projects_path)
+    assert result is None
+
+
+def test_cwd_none_skips_projects_json(monkeypatch, tmp_path):
+    monkeypatch.delenv("VALOR_PROJECT_KEY", raising=False)
+    projects_path = _make_projects_json(
+        tmp_path,
+        {"someproject": {"working_directory": str(tmp_path)}},
+    )
+    result = resolve_project_key(cwd=None, projects_path=projects_path)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Priority 4: None return
+# ---------------------------------------------------------------------------
+
+
+def test_all_none_returns_none(monkeypatch, tmp_path):
+    monkeypatch.delenv("VALOR_PROJECT_KEY", raising=False)
+    projects_path = _make_projects_json(tmp_path, {})
+    result = resolve_project_key(cwd=None, projects_path=projects_path)
+    assert result is None
+
+
+def test_no_inputs_at_all_returns_none(monkeypatch, tmp_path):
+    """When nothing is provided and no env var set, result is None."""
+    monkeypatch.delenv("VALOR_PROJECT_KEY", raising=False)
+    # Pass a projects_path with no matching projects
+    projects_path = _make_projects_json(tmp_path, {})
+    result = resolve_project_key(projects_path=projects_path)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Resilience: corrupt / missing projects.json
+# ---------------------------------------------------------------------------
+
+
+def test_corrupt_projects_json_falls_through_to_none(monkeypatch, tmp_path):
+    monkeypatch.delenv("VALOR_PROJECT_KEY", raising=False)
+    bad_file = tmp_path / "projects.json"
+    bad_file.write_text("NOT VALID JSON{{{")
+    result = resolve_project_key(cwd=str(tmp_path), projects_path=bad_file)
+    # Cannot match cwd — returns None (no dirname fallback)
+    assert result is None
+
+
+def test_missing_projects_json_returns_none(monkeypatch, tmp_path):
+    monkeypatch.delenv("VALOR_PROJECT_KEY", raising=False)
+    nonexistent = tmp_path / "no_such_file.json"
+    result = resolve_project_key(cwd=str(tmp_path), projects_path=nonexistent)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_cwd_string_treated_as_absent(monkeypatch, tmp_path):
+    monkeypatch.delenv("VALOR_PROJECT_KEY", raising=False)
+    projects_path = _make_projects_json(
+        tmp_path,
+        {"repo": {"working_directory": str(tmp_path)}},
+    )
+    result = resolve_project_key(cwd="", projects_path=projects_path)
+    assert result is None
+
+
+def test_env_kwarg_empty_dict_falls_through_to_none(tmp_path):
+    projects_path = _make_projects_json(tmp_path, {})
+    result = resolve_project_key(env={}, cwd=None, projects_path=projects_path)
+    assert result is None
+
+
+def test_projects_json_without_working_directory_skipped(monkeypatch, tmp_path):
+    """Projects without working_directory should not match."""
+    monkeypatch.delenv("VALOR_PROJECT_KEY", raising=False)
+    projects_path = _make_projects_json(
+        tmp_path,
+        {"no-wd-proj": {"name": "no working dir here"}},
+    )
+    result = resolve_project_key(cwd=str(tmp_path), projects_path=projects_path)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Cache invalidation
+# ---------------------------------------------------------------------------
+
+
+def test_cache_reloads_on_new_path(monkeypatch, tmp_path):
+    """Calling with a different projects_path flushes the cache."""
+    monkeypatch.delenv("VALOR_PROJECT_KEY", raising=False)
+
+    p1_dir = tmp_path / "p1"
+    p1_dir.mkdir(exist_ok=True)
+    path1 = _make_projects_json(p1_dir, {"proj1": {"working_directory": str(tmp_path)}})
+
+    p2_dir = tmp_path / "p2"
+    p2_dir.mkdir(exist_ok=True)
+    path2 = _make_projects_json(p2_dir, {"proj2": {"working_directory": str(tmp_path)}})
+
+    result1 = resolve_project_key(cwd=str(tmp_path), projects_path=path1)
+    assert result1 == "proj1"
+
+    result2 = resolve_project_key(cwd=str(tmp_path), projects_path=path2)
+    assert result2 == "proj2"

--- a/tests/unit/test_project_key_resolver.py
+++ b/tests/unit/test_project_key_resolver.py
@@ -10,15 +10,9 @@ Covers the full priority chain:
 from __future__ import annotations
 
 import json
-import os
-import tempfile
 from pathlib import Path
-from unittest.mock import patch
 
-import pytest
-
-from config.project_key_resolver import resolve_project_key, _load_projects
-
+from config.project_key_resolver import resolve_project_key
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tools/memory_search/__init__.py
+++ b/tools/memory_search/__init__.py
@@ -233,12 +233,12 @@ def save(
             importance = 6.0  # InteractionWeight.HUMAN
 
         from config.project_key_resolver import resolve_project_key
-        from config.memory_defaults import DEFAULT_PROJECT_KEY
 
         project_key = resolve_project_key(project_key=project_key)
         if project_key is None:
             logger.warning(
-                "[memory_search] save write skipped: resolve_project_key returned None "                "(VALOR_PROJECT_KEY=%r)",
+                "[memory_search] save write skipped: resolve_project_key returned None "
+                "(VALOR_PROJECT_KEY=%r)",
                 os.environ.get("VALOR_PROJECT_KEY"),
             )
             return None

--- a/tools/memory_search/__init__.py
+++ b/tools/memory_search/__init__.py
@@ -40,7 +40,13 @@ def _fetch_all_records(project_key: str) -> list:
 
 
 def _resolve_project_key(project_key: str | None = None) -> str:
-    """Resolve project_key from argument or environment."""
+    """Resolve project_key for READ paths (search, inspect, forget, status).
+
+    Returns a non-empty string — always falls back to DEFAULT_PROJECT_KEY so
+    read paths never receive None (an empty result set is safe on a bad key).
+
+    Write paths (save()) call resolve_project_key() directly and handle None.
+    """
     if project_key:
         return project_key
     from config.memory_defaults import DEFAULT_PROJECT_KEY
@@ -226,7 +232,16 @@ def save(
         if importance is None:
             importance = 6.0  # InteractionWeight.HUMAN
 
-        project_key = _resolve_project_key(project_key)
+        from config.project_key_resolver import resolve_project_key
+        from config.memory_defaults import DEFAULT_PROJECT_KEY
+
+        project_key = resolve_project_key(project_key=project_key)
+        if project_key is None:
+            logger.warning(
+                "[memory_search] save write skipped: resolve_project_key returned None "                "(VALOR_PROJECT_KEY=%r)",
+                os.environ.get("VALOR_PROJECT_KEY"),
+            )
+            return None
 
         from models.memory import Memory
 

--- a/ui/data/memories.py
+++ b/ui/data/memories.py
@@ -28,10 +28,13 @@ KNOWN_CATEGORIES = ("correction", "decision", "pattern", "surprise", "default")
 
 
 def _resolve_project_key(project_key: str | None) -> str:
-    """Resolve project_key, falling back to env / default.
+    """Resolve project_key for READ operations in this view module.
 
-    Empty string and None both fall back. Mirrors
-    `tools.memory_search._resolve_project_key`.
+    This module is read-only (never calls Memory.safe_save). Falls back to
+    DEFAULT_PROJECT_KEY so read paths always get a non-None key (an empty
+    result set is safe on a bad key, whereas write skips need None signaling).
+
+    Empty string and None both fall back.
     """
     if project_key:
         return project_key


### PR DESCRIPTION
## Summary

- Introduces `config/project_key_resolver.py` with a single canonical `resolve_project_key()` helper that all Memory writer callsites now use
- Migrates five writer callsites (`agent/memory_hook.py`, `agent/memory_extraction.py`, `.claude/hooks/hook_utils/memory_bridge.py`, `tools/memory_search/__init__.py`, `ui/data/memories.py`) to the canonical resolver
- All write paths now return `None` on unresolvable project_key and skip `Memory.safe_save` with a `WARNING` log (observable in production, unlike the original silent `"default"` namespace writes)
- Read paths (`search`, `recall`, `stats`) retain `DEFAULT_PROJECT_KEY` fallback as before — empty result sets on bad keys are safe

## Changes

- **`config/project_key_resolver.py`** (new) — `resolve_project_key(cwd, env, projects_path, project_key)` with priority chain: explicit kwarg → `VALOR_PROJECT_KEY` env → projects.json cwd-match → `None`. No dirname fallback, no `DEFAULT_PROJECT_KEY` fallback for write paths.
- **`.claude/hooks/hook_utils/memory_bridge.py`** — `_get_project_key()` becomes a thin wrapper delegating to `resolve_project_key`; write paths (`ingest`, `extract`, `post_merge_extract`) add None guards with WARNING logs; read paths (`recall`, `prefetch`) retain `DEFAULT_PROJECT_KEY` fallback
- **`agent/memory_hook.py`** — `check_and_inject()` uses `resolve_project_key()`, returns `None` on unresolved key
- **`agent/memory_extraction.py`** — both `extract_observations_async` and `extract_post_merge_learning` use `resolve_project_key()` with None-skip guards
- **`tools/memory_search/__init__.py`** — `save()` write path uses `resolve_project_key()` with None-skip guard; `_resolve_project_key()` kept for read paths only (documented as read-only)
- **`ui/data/memories.py`** — docstring updated to clarify read-only resolver usage
- **`docs/features/subconscious-memory.md`** — Project Key Partitioning section updated with unified resolver description, removal of dirname fallback row, None contract documented

## Testing

- [x] 21 new tests in `tests/unit/test_project_key_resolver.py` covering full priority chain
- [x] Updated `tests/unit/test_memory_bridge.py` — `_get_project_key` no-match now returns `None` (not dirname)
- [x] Updated `tests/unit/test_memory_hook.py` — 9 tests updated to patch `resolve_project_key`
- [x] Updated `tests/unit/test_memory_extraction.py` — 3 tests updated to patch `resolve_project_key`
- [x] Updated `tests/unit/test_memory_bridge.py::TestExtract` — set `VALOR_PROJECT_KEY` env var
- [x] All 257 directly-affected tests pass
- [x] Ruff lint passes on all modified files

## Documentation

- [x] `docs/features/subconscious-memory.md` updated — Project Key Partitioning section rewritten
- [x] `config/project_key_resolver.py` fully documented with priority chain, intentional omissions, and circular-import safety notes

## Definition of Done

- [x] Built: `config/project_key_resolver.py` exists and all 5 writer callsites migrated
- [x] Tested: 21 new tests + all affected tests pass
- [x] Reviewed: lint clean
- [x] Documented: subconscious-memory.md updated, inline docs complete
- [x] Quality: ruff check passes

Closes #1232