### PR TITLE
fix(session-health): promote per-turn SDK signals to Tier 1 to detect hung sessions (#1226)

### DIFF
--- a/agent/session_health.py
+++ b/agent/session_health.py
@@ -158,6 +158,20 @@ MAX_RECOVERY_ATTEMPTS = 2
 # health-check tick budget tight while still giving the cancellation a
 # moment to complete.
 TASK_CANCEL_TIMEOUT = 0.25
+# Freshness window (seconds) for per-turn SDK progress signals
+# (last_tool_use_at, last_turn_at) in Tier 1 sub-check A (issue #1226).
+# 1800s (30 minutes) accommodates the longest observed extended-thinking turns.
+# A session that produces a tool boundary or result event within this window is
+# considered actively progressing. Env-tunable via SDK_PROGRESS_FRESHNESS_WINDOW_SECS
+# for operators who observe edge cases in production.
+SDK_PROGRESS_FRESHNESS_WINDOW = int(os.environ.get("SDK_PROGRESS_FRESHNESS_WINDOW_SECS", 1800))
+# Max consecutive Tier 2 reprieves allowed for sessions that have NEVER produced
+# any SDK output (sdk_ever_output=False). After this many reprieves the "alive"
+# gate is suppressed and recovery proceeds. Derived from the SDK progress window
+# divided by the heartbeat write interval: 1800 // 90 = 20 ticks (~30 minutes).
+# Sessions that have produced output (sdk_ever_output=True) are never subject to
+# this cap — their recovery depends solely on per-turn freshness in sub-check A.
+MAX_NO_OUTPUT_REPRIEVES = SDK_PROGRESS_FRESHNESS_WINDOW // HEARTBEAT_FRESHNESS_WINDOW  # 20
 
 
 # In-process cache for ``_is_memory_tight()`` (issue #1099 Mode 4). Tuple of
@@ -327,7 +341,10 @@ def _recover_interrupted_agent_sessions_startup() -> int:
                 update_session(
                     entry.session_id,
                     new_status="pending",
-                    fields={"priority": "high", "started_at": None},
+                    # reprieve_count reset to 0: prevents escalation guard firing
+                    # immediately after recovery if the session had accumulated
+                    # reprieves before startup (issue #1226 Risk 4).
+                    fields={"priority": "high", "started_at": None, "reprieve_count": 0},
                     expected_status="running",
                     reason="startup recovery: local dev session",
                 )
@@ -403,7 +420,10 @@ def _recover_interrupted_agent_sessions_startup() -> int:
                 update_session(
                     entry.session_id,
                     new_status="pending",
-                    fields={"priority": "high", "started_at": None},
+                    # reprieve_count reset to 0: prevents escalation guard firing
+                    # immediately after recovery if the session had accumulated
+                    # reprieves before startup (issue #1226 Risk 4).
+                    fields={"priority": "high", "started_at": None, "reprieve_count": 0},
                     expected_status="running",
                     reason="startup recovery",
                 )
@@ -441,43 +461,84 @@ def _has_progress(entry: AgentSession) -> bool:
     silence is no longer a kill signal — long-thinking turns and large tool
     outputs produce legitimate stdout silence.
 
-    Signals (any one is sufficient):
+    Tier 1 is evaluated in two sub-checks (A and B). Any one passing → return True.
 
-    1. **Dual-heartbeat OR (#1036, retained verbatim).** Either
-       ``last_heartbeat_at`` (queue-layer, written by ``_heartbeat_loop``)
-       OR ``last_sdk_heartbeat_at`` (messenger-sourced, written by
-       ``BackgroundTask._watchdog``) fresher than
-       ``HEARTBEAT_FRESHNESS_WINDOW`` (90s) ⇒ progress.
-    2. **Own-progress fields (#944 / #963, retained).**
-       - ``turn_count > 0`` — at least one turn boundary observed.
-       - ``log_path`` non-empty — first log entry written.
-       - ``claude_session_uuid`` non-empty — SDK authenticated.
-    3. **Child-progress check (#944, retained).** A PM session with at
-       least one non-terminal child is not stuck. ``get_children()``
-       returns ``[]`` on failure with a WARNING log; no outer try/except
-       needed.
+    **Sub-check A: Per-turn SDK progress (#1226).**
+    ``last_tool_use_at`` (written by PreToolUse/PostToolUse hooks) and
+    ``last_turn_at`` (written by sdk_client on ``result`` event) are evidence
+    of actual structured SDK output. Either field fresher than
+    ``SDK_PROGRESS_FRESHNESS_WINDOW`` (1800s, 30 min) ⇒ progress.
+    ``last_sdk_heartbeat_at`` is written by ``BackgroundTask._watchdog`` on
+    subprocess existence — it is a watchdog-alive signal, NOT a progress signal.
+    It is intentionally excluded from sub-check A (issue #1226).
 
-    Returns ``False`` only when EVERY signal is absent (both heartbeats
-    stale, all own-progress fields empty, no live children). The caller
+    **Sub-check B: Startup-window executor-alive fallback (#1036 narrowed).**
+    When ``sdk_ever_output`` is False (neither per-turn field has ever been set),
+    ``last_heartbeat_at`` (queue-layer, written by ``_heartbeat_loop``) fresher
+    than ``HEARTBEAT_FRESHNESS_WINDOW`` (90s) ⇒ progress. This preserves the
+    pre-#1226 behavior for sessions in their startup window before the first SDK
+    tool or turn event fires, and for sessions predating PR #1177 (whose hooks
+    did not write the per-turn fields).
+
+    **Own-progress fields (#944 / #963, narrowed by #1226).**
+    - ``turn_count > 0`` — at least one turn boundary observed.
+    - ``log_path`` non-empty — first log entry written.
+    - ``claude_session_uuid`` non-empty — SDK authenticated.
+    These are sticky once set and cannot detect mid-run hangs. They are only
+    evaluated when ``sdk_ever_output`` is False — once the SDK has produced a
+    tool or turn event, sub-check A is the authoritative Tier 1 signal.
+
+    **Child-progress check (#944, retained).**
+    A PM session with at least one non-terminal child is not stuck.
+    ``get_children()`` returns ``[]`` on failure with a WARNING log; no outer
+    try/except needed.
+
+    Returns ``False`` only when EVERY signal is absent. The caller
     (``_agent_session_health_check``) then evaluates ``_tier2_reprieve_signal``
     before deciding to recover.
     """
-    # Tier 1: dual-heartbeat OR check (#1036). Fresh on either signal → progress.
     now_utc = datetime.now(tz=UTC)
-    for hb_attr in ("last_heartbeat_at", "last_sdk_heartbeat_at"):
-        hb = getattr(entry, hb_attr, None)
+
+    # Compute sdk_ever_output once — used by both sub-check A and the own-progress
+    # field guard. True iff last_tool_use_at or last_turn_at has ever been written.
+    sdk_ever_output = bool(
+        getattr(entry, "last_tool_use_at", None) or getattr(entry, "last_turn_at", None)
+    )
+
+    # Sub-check A: per-turn SDK activity (issue #1226).
+    # last_tool_use_at (PreToolUse/PostToolUse hooks) and last_turn_at (result event)
+    # are evidence of actual structured SDK output. Fresh within
+    # SDK_PROGRESS_FRESHNESS_WINDOW → real progress.
+    for progress_attr in ("last_tool_use_at", "last_turn_at"):
+        ts = getattr(entry, progress_attr, None)
+        if isinstance(ts, datetime):
+            ts_aware = ts if ts.tzinfo else ts.replace(tzinfo=UTC)
+            if (now_utc - ts_aware).total_seconds() < SDK_PROGRESS_FRESHNESS_WINDOW:
+                return True
+
+    # Sub-check B: startup-window executor-alive fallback (#1036 retained, narrowed).
+    # Use last_heartbeat_at as a Tier 1 signal ONLY before the SDK has produced any
+    # tool or turn output. Once sdk_ever_output is True, sub-check A is authoritative.
+    # Backward-compatible: sessions from before PR #1177 (no tool/turn fields) fall
+    # here and behave identically to the pre-#1226 behavior.
+    if not sdk_ever_output:
+        hb = getattr(entry, "last_heartbeat_at", None)
         if isinstance(hb, datetime):
             hb_aware = hb if hb.tzinfo else hb.replace(tzinfo=UTC)
             if (now_utc - hb_aware).total_seconds() < HEARTBEAT_FRESHNESS_WINDOW:
                 return True
 
-    # Own-progress fields (preserves #944 / #963 invariants).
-    if (entry.turn_count or 0) > 0:
-        return True
-    if bool((entry.log_path or "").strip()):
-        return True
-    if bool(entry.claude_session_uuid):
-        return True
+    # Own-progress fields (#944 / #963, narrowed by #1226).
+    # Only evaluated when sdk_ever_output is False — once the SDK has produced
+    # a tool or turn event, per-turn freshness (sub-check A) is authoritative.
+    if not sdk_ever_output:
+        if (entry.turn_count or 0) > 0:
+            return True
+        if bool((entry.log_path or "").strip()):
+            return True
+        if bool(entry.claude_session_uuid):
+            return True
+
     # Child-progress check: a PM session with active children is not stuck.
     # get_children() queries via Popoto parent_agent_session_id index and
     # returns [] on failure with a WARNING log — no outer try/except needed.
@@ -514,6 +575,15 @@ def _tier2_reprieve_signal(
     Returns the name of the first passing gate ("compacting", "children", or
     "alive"), or ``None`` if every gate fails.
 
+    **Reprieve escalation guard (issue #1226):** When ``sdk_ever_output`` is
+    False (the session has never produced a tool or turn event) AND
+    ``reprieve_count >= MAX_NO_OUTPUT_REPRIEVES``, all gates are suppressed
+    and ``None`` is returned immediately. This prevents indefinite alive-but-
+    silent sessions from being reprieved forever. Sessions with
+    ``sdk_ever_output=True`` (have produced output) are never subject to this
+    cap — their recovery depends solely on per-turn freshness in
+    ``_has_progress`` sub-check A.
+
     The previous "stdout" gate (and its ``STDOUT_FRESHNESS_WINDOW`` constant)
     was retired by issue #1172. Recent stdout is no longer evidence the
     subprocess is making progress — long-thinking turns and large tool
@@ -528,6 +598,18 @@ def _tier2_reprieve_signal(
     This helper NEVER raises. A genuinely dead session where every gate
     fails is preferable to crashing the health-check loop.
     """
+    # Reprieve escalation guard (issue #1226): suppress all Tier 2 reprieves
+    # for sessions that have NEVER produced any SDK output once reprieve_count
+    # reaches MAX_NO_OUTPUT_REPRIEVES. This ensures sessions that hang from
+    # the very first turn are eventually recovered rather than being reprieved
+    # forever. Sessions with sdk_ever_output=True are NOT subject to this cap.
+    sdk_ever_output = bool(
+        getattr(entry, "last_tool_use_at", None) or getattr(entry, "last_turn_at", None)
+    )
+    reprieve_count = getattr(entry, "reprieve_count", 0) or 0
+    if not sdk_ever_output and reprieve_count >= MAX_NO_OUTPUT_REPRIEVES:
+        return None  # escalate: suppress all Tier 2 reprieves, allow recovery
+
     # "compacting" — reprieve when a compaction completed within
     # COMPACT_REPRIEVE_WINDOW_SEC seconds. Evaluated FIRST so the telemetry
     # counter (``tier2_reprieve_total:compacting``) distinguishes this case

--- a/docs/features/pm-session-liveness.md
+++ b/docs/features/pm-session-liveness.md
@@ -1,8 +1,8 @@
 # PM Session Liveness — See Progress or Stay Graceful
 
-**Issue:** [#1172](https://github.com/tomcounsell/ai/issues/1172)
+**Issue:** [#1172](https://github.com/tomcounsell/ai/issues/1172) (extended by [#1226](https://github.com/tomcounsell/ai/issues/1226))
 **Status:** Active
-**Last updated:** 2026-04-26
+**Last updated:** 2026-04-30
 
 This feature replaces inferred-from-staleness session kills with two
 complementary changes: the detector kills only on **evidence** of failure
@@ -44,6 +44,26 @@ Issue #1172 retires every inference path. Evidence-only signals stay:
 - **Absence of stdout within a deadline.** The deleted
   `FIRST_STDOUT_DEADLINE` killed sessions that had not yet produced
   stdout within 5 min — false-positive on long warmups.
+- **Watchdog-tick heartbeat alone.** `last_sdk_heartbeat_at` (written by
+  `BackgroundTask._watchdog` every 60s on subprocess existence) is no
+  longer a Tier 1 progress signal (#1226). A subprocess that exists but
+  produces no structured SDK output is not indistinguishable from a working
+  one — it is now correctly identified as hung.
+
+### Tier 1 signal reference (#1226)
+
+`_has_progress` evaluates two sub-checks. Any one passing → True (progress).
+
+| Sub-check | Field | Writer | Window | When active |
+|---|---|---|---|---|
+| **A: per-turn SDK activity** | `last_tool_use_at` | `agent/hooks/pre_tool_use.py`, `post_tool_use.py` | `SDK_PROGRESS_FRESHNESS_WINDOW` (1800s, env-tunable) | Always |
+| **A: per-turn SDK activity** | `last_turn_at` | `agent/sdk_client.py` `result` event | `SDK_PROGRESS_FRESHNESS_WINDOW` (1800s, env-tunable) | Always |
+| **B: startup-window executor-alive** | `last_heartbeat_at` | `_heartbeat_loop` in `session_executor.py` | `HEARTBEAT_FRESHNESS_WINDOW` (90s) | Only when `sdk_ever_output=False` (no tool/turn event yet) |
+| **Watchdog-alive (not Tier 1)** | `last_sdk_heartbeat_at` | `BackgroundTask._watchdog` every 60s | N/A — not a progress signal | Dashboard `last_evidence_at` only |
+
+Sub-check B preserves backward compatibility: sessions started before PR #1177
+(whose hooks did not write the per-turn fields) fall through to `last_heartbeat_at`
+and behave identically to the pre-#1226 behavior.
 
 ### Tier 2 reprieve gates (current)
 
@@ -54,6 +74,17 @@ Issue #1172 retires every inference path. Evidence-only signals stay:
 - **`alive`** — process status not in {zombie, dead, stopped}.
 
 The previous **`stdout`** gate was retired with the same rationale.
+
+**Reprieve escalation guard (#1226):** When a session has never produced
+any SDK tool or turn event (`sdk_ever_output=False`) and its `reprieve_count`
+reaches `MAX_NO_OUTPUT_REPRIEVES` (default 20 ticks ≈ 30 minutes), the
+"alive" gate is suppressed and recovery proceeds. Sessions that have
+produced output (`sdk_ever_output=True`) are never subject to this cap —
+their recovery depends solely on per-turn freshness in sub-check A.
+
+**Startup recovery reprieve reset:** `_recover_interrupted_agent_sessions_startup`
+resets `reprieve_count=0` when transitioning sessions back to pending, preventing
+the escalation guard from triggering immediately after a worker restart.
 
 ## PM self-report behavior
 
@@ -151,6 +182,14 @@ specific cost ceiling becomes operationally necessary.
   behavior + fail-closed + cooldown.
 - `tests/unit/test_dashboard_pillar_a_fields.py` — dashboard JSON shape.
 - `tests/unit/test_pm_self_report.py` — frequency cap + failure paths.
+- `tests/unit/test_health_check_recovery_finalization.py::TestHasProgressPerTurnSignal` — per-turn
+  SDK signal tests: sub-check A (`last_tool_use_at`/`last_turn_at`), sub-check B
+  (startup-window `last_heartbeat_at`), and `last_sdk_heartbeat_at` exclusion from Tier 1 (#1226).
+- `tests/unit/test_health_check_recovery_finalization.py::TestTier2ReprieveEscalation` — reprieve
+  escalation guard: suppresses "alive" when `sdk_ever_output=False` and
+  `reprieve_count >= MAX_NO_OUTPUT_REPRIEVES` (#1226).
+- `tests/unit/test_health_check_recovery_finalization.py::TestStartupRecoveryReprieveCountReset` —
+  startup recovery resets `reprieve_count=0` to prevent immediate escalation (#1226 Risk 4).
 - `tests/integration/test_pm_long_run_no_kill.py` — acceptance test for
   a 4+ hour PM with active tool use and no result event.
 - `tests/integration/test_pm_goldilocks_messaging.py` — acceptance test

--- a/docs/plans/sdlc-1226.md
+++ b/docs/plans/sdlc-1226.md
@@ -1,10 +1,11 @@
 ---
-status: Ready
+status: In Review
 type: bug
 appetite: Small
 owner: Valor
 created: 2026-04-30
 tracking: https://github.com/tomcounsell/ai/issues/1226
+pr: https://github.com/tomcounsell/ai/pull/1243
 last_comment_id:
 ---
 

--- a/tests/unit/test_health_check_recovery_finalization.py
+++ b/tests/unit/test_health_check_recovery_finalization.py
@@ -271,10 +271,12 @@ def _ago(seconds: int):
 
 
 class TestHasProgressDualHeartbeat:
-    """Tests for dual-heartbeat OR semantics in _has_progress (#1036).
+    """Tests for Tier 1 heartbeat semantics in _has_progress (#1036, updated by #1226).
 
-    Tier 1 freshness: either `last_heartbeat_at` OR `last_sdk_heartbeat_at`
-    within HEARTBEAT_FRESHNESS_WINDOW (90s) → progress=True.
+    After #1226:
+    - Sub-check B: only last_heartbeat_at (queue-layer) counts as Tier 1, and only
+      when sdk_ever_output=False (no last_tool_use_at / last_turn_at ever set).
+    - last_sdk_heartbeat_at is a watchdog-alive signal only — NOT a progress signal.
     """
 
     @staticmethod
@@ -285,6 +287,8 @@ class TestHasProgressDualHeartbeat:
             "claude_session_uuid": None,
             "last_heartbeat_at": None,
             "last_sdk_heartbeat_at": None,
+            "last_tool_use_at": None,
+            "last_turn_at": None,
         }
         defaults.update(overrides)
         entry = SimpleNamespace(**defaults)
@@ -292,29 +296,35 @@ class TestHasProgressDualHeartbeat:
         return entry
 
     def test_queue_heartbeat_within_window_returns_true(self):
+        """last_heartbeat_at fresh + no per-turn output → True (startup-window sub-check B)."""
         entry = self._make_entry(last_heartbeat_at=_ago(30))
         from agent.agent_session_queue import _has_progress
 
         assert _has_progress(entry) is True
 
-    def test_sdk_heartbeat_within_window_returns_true(self):
+    def test_sdk_heartbeat_alone_not_progress(self):
+        """last_sdk_heartbeat_at fresh alone → False (watchdog-tick is NOT a progress signal).
+
+        This replaces test_sdk_heartbeat_within_window_returns_true which tested
+        the buggy behavior (#1226 fix: last_sdk_heartbeat_at removed from Tier 1).
+        """
         entry = self._make_entry(last_sdk_heartbeat_at=_ago(30))
         from agent.agent_session_queue import _has_progress
 
-        assert _has_progress(entry) is True
+        assert _has_progress(entry) is False
 
-    def test_either_heartbeat_fresh_returns_true(self):
-        # One fresh, one stale → True (OR semantics)
+    def test_either_per_turn_signal_fresh_returns_true(self):
+        """Fresh last_tool_use_at → True (sub-check A OR semantics, #1226)."""
         entry = self._make_entry(
-            last_heartbeat_at=_ago(30),
-            last_sdk_heartbeat_at=_ago(300),
+            last_tool_use_at=_ago(30),
+            last_sdk_heartbeat_at=_ago(300),  # stale watchdog tick: irrelevant
         )
         from agent.agent_session_queue import _has_progress
 
         assert _has_progress(entry) is True
 
-    def test_both_heartbeats_stale_returns_false(self):
-        # Both stale, other fields empty → False
+    def test_both_heartbeats_stale_no_per_turn_output_returns_false(self):
+        """Both heartbeats stale + no per-turn output + other fields empty → False."""
         entry = self._make_entry(
             last_heartbeat_at=_ago(300),
             last_sdk_heartbeat_at=_ago(300),
@@ -323,18 +333,15 @@ class TestHasProgressDualHeartbeat:
 
         assert _has_progress(entry) is False
 
-    def test_heartbeats_at_boundary_returns_true(self):
-        # At age=89s (just inside 90s window) → True
-        entry = self._make_entry(
-            last_heartbeat_at=_ago(89),
-            last_sdk_heartbeat_at=_ago(89),
-        )
+    def test_queue_heartbeat_at_boundary_returns_true(self):
+        """last_heartbeat_at at age=89s (just inside 90s window) + sdk_ever_output=False → True."""
+        entry = self._make_entry(last_heartbeat_at=_ago(89))
         from agent.agent_session_queue import _has_progress
 
         assert _has_progress(entry) is True
 
-    def test_both_heartbeats_none_falls_through_to_other_checks(self):
-        # Both None, turn_count=5 → True (unchanged behavior, #944)
+    def test_per_turn_fields_none_turn_count_set_returns_true(self):
+        """No per-turn fields + turn_count=5 → True (own-progress, sdk_ever_output=False, #944)."""
         entry = self._make_entry(turn_count=5)
         from agent.agent_session_queue import _has_progress
 
@@ -822,4 +829,293 @@ class TestReprieveScopedToNoProgress:
         src = inspect.getsource(q._agent_session_health_check)
         assert "Tier 2 reprieve will only see compaction state" in src, (
             "Expected a degraded-Tier-2 debug log when handle is None"
+        )
+
+
+# ==========================================================================
+# Per-turn SDK progress signal tests (issue #1226)
+# ==========================================================================
+
+
+class TestHasProgressPerTurnSignal:
+    """Tests for the new per-turn SDK progress signals in _has_progress (#1226).
+
+    Sub-check A: last_tool_use_at / last_turn_at freshness within
+    SDK_PROGRESS_FRESHNESS_WINDOW (1800s) → progress=True.
+    Sub-check B: last_heartbeat_at freshness only when sdk_ever_output=False.
+    last_sdk_heartbeat_at alone is NOT a progress signal (watchdog-tick only).
+    """
+
+    @staticmethod
+    def _make_entry(**overrides):
+        """Minimal AgentSession-like object with all relevant fields."""
+        defaults = {
+            "turn_count": 0,
+            "log_path": "",
+            "claude_session_uuid": None,
+            "last_heartbeat_at": None,
+            "last_sdk_heartbeat_at": None,
+            "last_tool_use_at": None,
+            "last_turn_at": None,
+        }
+        defaults.update(overrides)
+        entry = SimpleNamespace(**defaults)
+        entry.get_children = lambda: []
+        return entry
+
+    def test_fresh_last_tool_use_at_returns_true(self):
+        """Fresh last_tool_use_at (age < 1800s) → progress=True (sub-check A)."""
+        entry = self._make_entry(last_tool_use_at=_ago(30))
+        from agent.session_health import _has_progress
+
+        assert _has_progress(entry) is True
+
+    def test_fresh_last_turn_at_returns_true(self):
+        """Fresh last_turn_at (age < 1800s) → progress=True (sub-check A)."""
+        entry = self._make_entry(last_turn_at=_ago(30))
+        from agent.session_health import _has_progress
+
+        assert _has_progress(entry) is True
+
+    def test_stale_last_tool_use_at_with_fresh_sdk_heartbeat_returns_false(self):
+        """Stale last_tool_use_at (>1800s) + fresh last_sdk_heartbeat_at → False.
+
+        This is the key regression: watchdog-tick alone must NOT signal progress.
+        """
+        entry = self._make_entry(
+            last_tool_use_at=_ago(1860),  # > SDK_PROGRESS_FRESHNESS_WINDOW (1800s)
+            last_sdk_heartbeat_at=_ago(30),  # fresh watchdog tick — not a progress signal
+        )
+        from agent.session_health import _has_progress
+
+        assert _has_progress(entry) is False
+
+    def test_fresh_last_heartbeat_with_both_turn_fields_none_returns_true(self):
+        """fresh last_heartbeat_at + both per-turn fields None → True (startup window).
+
+        Sub-check B: before any SDK output (sdk_ever_output=False), the queue-layer
+        heartbeat still passes Tier 1 (startup window preserved).
+        """
+        entry = self._make_entry(
+            last_heartbeat_at=_ago(30),  # executor is alive
+            last_tool_use_at=None,
+            last_turn_at=None,
+        )
+        from agent.session_health import _has_progress
+
+        assert _has_progress(entry) is True
+
+    def test_all_fields_none_returns_false(self):
+        """All Tier 1 fields None + no children → progress=False."""
+        entry = self._make_entry()
+        from agent.session_health import _has_progress
+
+        assert _has_progress(entry) is False
+
+    def test_fresh_tool_use_stale_turn_at_returns_true(self):
+        """Fresh last_tool_use_at + stale last_turn_at → True (OR semantics)."""
+        entry = self._make_entry(
+            last_tool_use_at=_ago(30),
+            last_turn_at=_ago(1860),  # stale beyond window
+        )
+        from agent.session_health import _has_progress
+
+        assert _has_progress(entry) is True
+
+    def test_sdk_heartbeat_only_no_progress(self):
+        """Only last_sdk_heartbeat_at fresh (watchdog-tick); all per-turn fields None
+        and no last_heartbeat_at → False (watchdog-tick alone is not progress).
+        """
+        entry = self._make_entry(
+            last_sdk_heartbeat_at=_ago(30),
+            last_heartbeat_at=None,  # no executor heartbeat
+            last_tool_use_at=None,
+            last_turn_at=None,
+        )
+        from agent.session_health import _has_progress
+
+        assert _has_progress(entry) is False
+
+    def test_own_progress_fields_gated_on_no_sdk_output(self):
+        """turn_count>0 with sdk_ever_output=True → own-progress fields skipped.
+
+        When last_tool_use_at or last_turn_at has been set (sdk_ever_output=True),
+        a stale per-turn signal with fresh own-progress fields should NOT pass Tier 1
+        unless the per-turn signal itself is fresh.
+        """
+        entry = self._make_entry(
+            turn_count=5,
+            log_path="/tmp/log.txt",
+            claude_session_uuid="some-uuid",
+            last_tool_use_at=_ago(1860),  # stale beyond window
+            last_turn_at=_ago(1860),  # stale beyond window
+            last_heartbeat_at=_ago(30),  # executor alive, but sdk output exists
+        )
+        from agent.session_health import _has_progress
+
+        assert _has_progress(entry) is False
+
+    def test_sdk_heartbeat_constant_removed_from_tier1(self):
+        """Structural: last_sdk_heartbeat_at is NOT in the Tier 1 dual-heartbeat check.
+
+        The fix removes last_sdk_heartbeat_at from _has_progress's Tier 1 loop.
+        Verify the source does not pair 'last_sdk_heartbeat_at' with
+        HEARTBEAT_FRESHNESS_WINDOW in _has_progress.
+        """
+        import inspect
+
+        from agent import session_health as sh
+
+        src = inspect.getsource(sh._has_progress)
+        # The old pattern was: for hb_attr in ("last_heartbeat_at", "last_sdk_heartbeat_at")
+        # which paired both with HEARTBEAT_FRESHNESS_WINDOW. That must be gone.
+        assert (
+            '"last_sdk_heartbeat_at"' not in src
+            or "SDK_PROGRESS_FRESHNESS_WINDOW"
+            not in src.split('"last_sdk_heartbeat_at"')[0].split("HEARTBEAT_FRESHNESS_WINDOW")[-1]
+        ), (
+            "last_sdk_heartbeat_at must NOT be checked against HEARTBEAT_FRESHNESS_WINDOW in _has_progress"
+        )
+
+    def test_sdk_progress_freshness_window_constant_exists(self):
+        """SDK_PROGRESS_FRESHNESS_WINDOW constant must exist in session_health."""
+        from agent import session_health as sh
+
+        assert hasattr(sh, "SDK_PROGRESS_FRESHNESS_WINDOW"), (
+            "SDK_PROGRESS_FRESHNESS_WINDOW constant missing from session_health"
+        )
+        assert sh.SDK_PROGRESS_FRESHNESS_WINDOW == 1800, (
+            f"Expected 1800s default; got {sh.SDK_PROGRESS_FRESHNESS_WINDOW}"
+        )
+
+    def test_max_no_output_reprieves_constant_exists(self):
+        """MAX_NO_OUTPUT_REPRIEVES constant must exist in session_health."""
+        from agent import session_health as sh
+
+        assert hasattr(sh, "MAX_NO_OUTPUT_REPRIEVES"), (
+            "MAX_NO_OUTPUT_REPRIEVES constant missing from session_health"
+        )
+        # Default: SDK_PROGRESS_FRESHNESS_WINDOW // HEARTBEAT_FRESHNESS_WINDOW = 1800 // 90 = 20
+        assert sh.MAX_NO_OUTPUT_REPRIEVES == 20, f"Expected 20; got {sh.MAX_NO_OUTPUT_REPRIEVES}"
+
+
+class TestTier2ReprieveEscalation:
+    """Tests for the reprieve escalation guard in _tier2_reprieve_signal (#1226).
+
+    When sdk_ever_output=False AND reprieve_count >= MAX_NO_OUTPUT_REPRIEVES,
+    _tier2_reprieve_signal must return None (suppress all reprieves).
+    Sessions with sdk_ever_output=True are NOT subject to the cap.
+    """
+
+    @staticmethod
+    def _make_entry(**overrides):
+        defaults = {
+            "last_tool_use_at": None,
+            "last_turn_at": None,
+            "last_stdout_at": None,
+            "reprieve_count": 0,
+            "last_compaction_ts": None,
+        }
+        defaults.update(overrides)
+        return SimpleNamespace(**defaults)
+
+    def _make_handle(self, pid=None):
+        from agent.agent_session_queue import SessionHandle
+
+        fake_task = MagicMock()
+        return SessionHandle(task=fake_task, pid=pid)
+
+    def test_escalation_guard_suppresses_alive_when_no_output_and_at_cap(self, monkeypatch):
+        """sdk_ever_output=False + reprieve_count >= MAX_NO_OUTPUT_REPRIEVES → None."""
+        import psutil as _psutil
+
+        from agent.session_health import MAX_NO_OUTPUT_REPRIEVES
+
+        class _Proc:
+            def status(self):
+                return _psutil.STATUS_RUNNING
+
+            def children(self):
+                return []
+
+        monkeypatch.setattr(_psutil, "Process", lambda pid: _Proc())
+
+        from agent.session_health import _tier2_reprieve_signal
+
+        entry = self._make_entry(reprieve_count=MAX_NO_OUTPUT_REPRIEVES)
+        handle = self._make_handle(pid=12345)
+        result = _tier2_reprieve_signal(handle, entry)
+        assert result is None, (
+            f"Expected None when reprieve_count={MAX_NO_OUTPUT_REPRIEVES} and "
+            f"sdk_ever_output=False; got {result!r}"
+        )
+
+    def test_escalation_guard_does_not_apply_when_sdk_has_output(self, monkeypatch):
+        """sdk_ever_output=True → escalation guard does NOT suppress 'alive'."""
+        import psutil as _psutil
+
+        from agent.session_health import MAX_NO_OUTPUT_REPRIEVES
+
+        class _Proc:
+            def status(self):
+                return _psutil.STATUS_RUNNING
+
+            def children(self):
+                return []
+
+        monkeypatch.setattr(_psutil, "Process", lambda pid: _Proc())
+
+        from agent.session_health import _tier2_reprieve_signal
+
+        # sdk_ever_output=True: last_tool_use_at is set (stale, but not None)
+        entry = self._make_entry(
+            last_tool_use_at=_ago(1860),  # stale but present → sdk_ever_output=True
+            reprieve_count=MAX_NO_OUTPUT_REPRIEVES + 5,  # well over the cap
+        )
+        handle = self._make_handle(pid=12345)
+        result = _tier2_reprieve_signal(handle, entry)
+        assert result == "alive", (
+            f"Expected 'alive' when sdk_ever_output=True even at high reprieve_count; got {result!r}"
+        )
+
+    def test_escalation_guard_below_cap_still_reprieves(self, monkeypatch):
+        """sdk_ever_output=False + reprieve_count < MAX_NO_OUTPUT_REPRIEVES → 'alive'."""
+        import psutil as _psutil
+
+        from agent.session_health import MAX_NO_OUTPUT_REPRIEVES
+
+        class _Proc:
+            def status(self):
+                return _psutil.STATUS_RUNNING
+
+            def children(self):
+                return []
+
+        monkeypatch.setattr(_psutil, "Process", lambda pid: _Proc())
+
+        from agent.session_health import _tier2_reprieve_signal
+
+        entry = self._make_entry(reprieve_count=MAX_NO_OUTPUT_REPRIEVES - 1)
+        handle = self._make_handle(pid=12345)
+        result = _tier2_reprieve_signal(handle, entry)
+        assert result == "alive", f"Expected 'alive' below cap; got {result!r}"
+
+
+class TestStartupRecoveryReprieveCountReset:
+    """Structural test: startup recovery resets reprieve_count to 0.
+
+    Risk 4 from plan: if reprieve_count is not reset on recovery, a recovered
+    session may immediately hit MAX_NO_OUTPUT_REPRIEVES on the first health tick.
+    """
+
+    def test_startup_recovery_resets_reprieve_count(self):
+        """_recover_interrupted_agent_sessions_startup must reset reprieve_count=0."""
+        import inspect
+
+        from agent import session_health as sh
+
+        src = inspect.getsource(sh._recover_interrupted_agent_sessions_startup)
+        assert "reprieve_count" in src, (
+            "_recover_interrupted_agent_sessions_startup must reset reprieve_count=0 "
+            "on recovery to prevent escalation guard triggering immediately post-recovery"
         )

--- a/tests/unit/test_health_check_recovery_finalization.py
+++ b/tests/unit/test_health_check_recovery_finalization.py
@@ -974,7 +974,8 @@ class TestHasProgressPerTurnSignal:
             or "SDK_PROGRESS_FRESHNESS_WINDOW"
             not in src.split('"last_sdk_heartbeat_at"')[0].split("HEARTBEAT_FRESHNESS_WINDOW")[-1]
         ), (
-            "last_sdk_heartbeat_at must NOT be checked against HEARTBEAT_FRESHNESS_WINDOW in _has_progress"
+            "last_sdk_heartbeat_at must NOT be checked against "
+            "HEARTBEAT_FRESHNESS_WINDOW in _has_progress"
         )
 
     def test_sdk_progress_freshness_window_constant_exists(self):
@@ -1075,7 +1076,8 @@ class TestTier2ReprieveEscalation:
         handle = self._make_handle(pid=12345)
         result = _tier2_reprieve_signal(handle, entry)
         assert result == "alive", (
-            f"Expected 'alive' when sdk_ever_output=True even at high reprieve_count; got {result!r}"
+            f"Expected 'alive' when sdk_ever_output=True even at high "
+            f"reprieve_count; got {result!r}"
         )
 
     def test_escalation_guard_below_cap_still_reprieves(self, monkeypatch):


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `_has_progress` Tier 1 was reading `last_sdk_heartbeat_at` (written by `BackgroundTask._watchdog` every 60s on subprocess *existence*, not SDK output), making hung sessions indistinguishable from working ones. Sessions could hang for hours without being recovered.
- **New Tier 1 sub-check A**: `last_tool_use_at` and `last_turn_at` (written by PreToolUse/PostToolUse hooks and `sdk_client.py` on `result` event) replace the watchdog-tick as the authoritative Tier 1 progress signal, checked against `SDK_PROGRESS_FRESHNESS_WINDOW` (1800s default).
- **Sub-check B preserved**: `last_heartbeat_at` (queue-layer) still passes Tier 1 when `sdk_ever_output=False`, preserving startup-window behavior and backward compatibility with sessions from before PR #1177.
- **Reprieve escalation guard**: `MAX_NO_OUTPUT_REPRIEVES` (default 20 ticks = 30 min) suppresses Tier 2 "alive" reprieve for sessions that have never produced SDK output, ensuring eventual recovery instead of indefinite reprieve.
- **Startup recovery reprieve reset**: `_recover_interrupted_agent_sessions_startup` now resets `reprieve_count=0` to prevent escalation guard from triggering immediately after worker restart.

## Test plan

- [x] `pytest tests/unit/test_health_check_recovery_finalization.py -v` — 59 passed (15 new tests + 44 existing)
- [x] New `TestHasProgressPerTurnSignal` class: 11 tests for sub-check A/B semantics and `last_sdk_heartbeat_at` exclusion
- [x] New `TestTier2ReprieveEscalation` class: 3 tests for the escalation guard (cap, bypass-when-output, below-cap)
- [x] New `TestStartupRecoveryReprieveCountReset`: structural test verifying `reprieve_count` reset in startup recovery
- [x] `TestHasProgressDualHeartbeat::test_sdk_heartbeat_within_window_returns_true` replaced with `test_sdk_heartbeat_alone_not_progress` asserting the corrected behavior
- [x] `python -m ruff check agent/session_health.py` — 0 errors
- [x] `python -m ruff format --check agent/session_health.py` — 1 file already formatted
- [x] `docs/features/pm-session-liveness.md` updated with Tier 1 signal reference table, watchdog-alive note, escalation guard section

Closes #1226