### PR TITLE
fix(sdlc): accept CRITIQUE='ready' in plan_not_critiqued router rule

### DIFF
--- a/agent/sdlc_router.py
+++ b/agent/sdlc_router.py
@@ -464,7 +464,11 @@ def _rule_plan_not_critiqued(stage_states: dict, meta: dict, context: dict) -> b
     """Plan exists, not yet critiqued."""
     plan_status = stage_states.get("PLAN")
     critique_status = stage_states.get("CRITIQUE")
-    return plan_status in (STATUS_COMPLETED, "ready") and critique_status in (None, "pending")
+    return plan_status in (STATUS_COMPLETED, "ready") and critique_status in (
+        None,
+        "pending",
+        "ready",
+    )
 
 
 def _rule_critique_needs_revision(stage_states: dict, meta: dict, context: dict) -> bool:

--- a/tests/unit/test_sdlc_router_decision.py
+++ b/tests/unit/test_sdlc_router_decision.py
@@ -78,6 +78,18 @@ class TestRow2PlanNotCritiqued:
         assert result.skill == SKILL_DO_PLAN_CRITIQUE
         assert result.row_id == "2"
 
+    def test_plan_completed_critique_ready_dispatches_critique(self):
+        # When PLAN completes, the state machine auto-transitions CRITIQUE
+        # from "pending" to "ready". Row 2 must accept the "ready" status
+        # too (regression for the issue #1262 dispatch failure).
+        states = _states_all_pending()
+        states["PLAN"] = "completed"
+        states["CRITIQUE"] = "ready"
+        result = decide_next_dispatch(states, {})
+        assert isinstance(result, Dispatch)
+        assert result.skill == SKILL_DO_PLAN_CRITIQUE
+        assert result.row_id == "2"
+
 
 class TestRow3CritiqueNeedsRevision:
     def test_needs_revision_without_loop_dispatches_plan(self):


### PR DESCRIPTION
## Summary

- Fixes a router dispatch bug where `/sdlc` returned `blocked: no matching dispatch rule` after PLAN completed.
- When PLAN completes, the state machine auto-transitions CRITIQUE from `pending` to `ready` (`agent/pipeline_state.py:543,582`). Row 2's `_rule_plan_not_critiqued` only accepted `(None, "pending")` for `critique_status`, missing `"ready"`.
- The mirror rules for BUILD (line 482) and REVIEW (line 529) already include `"ready"` in their allowlists — this was a copy-paste oversight.

## Repro

Discovered during `/sdlc 1262` after PLAN was marked completed:
```
$ sdlc-tool next-skill
{"blocked": true, "reason": "no matching dispatch rule", "guard_id": null}
```

State at the time: `PLAN=completed, CRITIQUE=ready`. Expected next dispatch: `/do-plan-critique`.

## Test plan

- [x] New regression test `test_plan_completed_critique_ready_dispatches_critique` covers the `(PLAN=completed, CRITIQUE=ready)` case
- [x] All 20 router-decision tests pass (`pytest tests/unit/test_sdlc_router_decision.py`)
- [ ] Re-running `/sdlc 1262` after merge dispatches `/do-plan-critique` as expected