### PR TITLE
feat(skills): migrate agent-browser → BYOB per-skill (#1274)

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -5,7 +5,7 @@ Human-readable index of all Claude Code skills in this project. Not loaded by Cl
 | Skill | Lines | Invocation | Context | Description |
 |-------|------:|------------|---------|-------------|
 | add-feature | 213 | User + Model | - | Extend the system with new skills, tools, and capabilities |
-| agent-browser | 336 | Model only | - | Browser automation for web testing, screenshots, data extraction |
+| agent-browser | 336 | Model only | - | **Anonymous, headless** browser automation for public sites, screenshots, data extraction. For logged-in operations, use BYOB MCP tools instead — see "When to use which browser surface?" below. |
 | audit-next-tool | 160 | User + Model | - | Audit new/modified tools for quality and architecture compliance |
 | checking-system-logs | 66 | Model only | - | Find bridge events, agent responses, errors in system logs |
 | do-build | 115 | User + Model | fork | Execute a plan document using team orchestration |
@@ -41,6 +41,49 @@ Human-readable index of all Claude Code skills in this project. Not loaded by Cl
 **Scope:**
 - Project-only (not synced to `~/.claude/skills/`): telegram, reading-sms-messages, checking-system-logs, google-workspace
 - All other skills sync to personal scope via `scripts/update/symlinks.py`
+
+---
+
+## When to use which browser surface?
+
+This repo has three coexisting browser surfaces. Pick the right one
+when authoring or extending a skill:
+
+| Surface | Driver | Profile | Parallelism | Use when |
+|---------|--------|---------|-------------|----------|
+| `agent-browser` | 3rd-party CLI (Playwright headless, single instance) | Anonymous, throwaway per invocation | Single tab, single session at a time | The target site is **public** (no login required) — marketing pages, GitHub, public preview deploys, anonymous data extraction. Cheapest. Best for repeat-safe automation against pages that look the same to every visitor. |
+| `bowser` | Playwright headless, parallel-safe, anonymous | Anonymous, throwaway per worker | Many parallel sessions | Same as `agent-browser` but you need **N parallel sessions at once** (e.g., crawling N URLs concurrently). |
+| BYOB MCP (`mcp__byob__*`) | Real Chrome via MV3 extension + native messaging + MCP server | The user's actual logged-in Chrome profile | One real-Chrome slot per machine; serialized by `AgentSession.requires_real_chrome` | The target site requires **the user's identity** — LinkedIn DMs, Gmail, internal dashboards, authenticated GitHub views, private staging URLs, anything behind SSO. The user's session cookies, MFA state, and SSO tokens just work because it IS their browser. |
+
+**Decision rule for skill authors:**
+
+1. **Does the target site require login?**
+   - **Yes, with the operator's identity** → BYOB MCP (`mcp__byob__*`).
+   - **No / public pages only** → continue.
+2. **Do you need many parallel browser sessions at once?**
+   - **Yes** → `bowser`.
+   - **No** → `agent-browser`.
+3. **Is the target ambiguous (might or might not require login, e.g.
+   a "preview" URL that 302s to a login page)?**
+   - Default to BYOB MCP. The cost of an unnecessary BYOB session is one
+     serialized scheduler slot; the cost of an anonymous session
+     hitting a login wall is wrong-shaped output that fails silently.
+
+**Frontmatter declaration**: skills calling BYOB MCP add
+`mcp__byob__*` to `allowed-tools`. Skills calling `agent-browser` add
+`Bash(agent-browser:*)`. Dual-surface skills declare both.
+
+**Scheduler gate (BYOB only)**: BYOB-driving sessions must have
+`AgentSession.requires_real_chrome=True` so the worker scheduler does
+not start two real-Chrome sessions concurrently (the active tab is a
+single resource). Bridge-spawned sessions get this inferred from the
+message text via `agent.byob_skill_triggers.infer_requires_real_chrome`.
+CLI-spawned sessions pass `valor-session create --needs-real-chrome ...`.
+Skipping this guard lets two BYOB sessions race on the active tab and
+corrupt each other's DOM.
+
+For background and the per-skill migration history, see
+[`docs/features/byob-browser-control.md`](../../docs/features/byob-browser-control.md).
 
 ---
 

--- a/.claude/skills/agent-browser/SKILL.md
+++ b/.claude/skills/agent-browser/SKILL.md
@@ -7,17 +7,35 @@ user-invocable: false
 
 # Browser Automation with agent-browser
 
-## When to Use
+`agent-browser` is the **anonymous, headless** browser surface — a 3rd-party
+Playwright CLI that drives a throwaway profile per invocation. It cannot
+see the user's logged-in sessions and never will (that is its design,
+not a limitation).
 
-- User needs to navigate websites or interact with web pages
-- Filling out web forms or clicking buttons on web pages
-- Taking screenshots of web pages or saving pages as PDFs
-- Extracting data or information from websites
-- Testing web applications or verifying web functionality
-- Recording video demonstrations of web interactions
-- User mentions "browser", "webpage", "website", "screenshot", "web form", or "web scraping"
-- User asks to "open a URL", "click on something", "fill out a form", or "get data from a site"
-- Automating repetitive web tasks or workflows
+## When to use BYOB instead?
+
+If the target site requires the user's **logged-in identity** — Gmail,
+LinkedIn DMs, internal dashboards, authenticated GitHub, anything behind
+SSO — use the BYOB MCP tools (`mcp__byob__navigate`, `mcp__byob__click`,
+`mcp__byob__screenshot`, etc.) instead. BYOB drives the user's real
+Chrome session. See
+[`docs/features/byob-browser-control.md`](../../../docs/features/byob-browser-control.md)
+for the decision rule, and
+[`.claude/skills/README.md`](../README.md) → "When to use which browser
+surface?" for the canonical author guide.
+
+## When to Use (this skill)
+
+- User needs to navigate **public** websites or interact with web pages
+  that do not require login
+- Filling out web forms or clicking buttons on **anonymous** web pages
+- Taking screenshots of public web pages or saving pages as PDFs
+- Extracting data from public websites
+- Testing **public** web applications or verifying public functionality
+- Recording video demonstrations of public web interactions
+- User mentions "browser", "webpage", "website", "screenshot", "web form", or "web scraping" against a public URL
+- User asks to "open a URL", "click on something", "fill out a form", or "get data from a site" without needing their identity
+- Automating repetitive public-web tasks or workflows
 
 ## Quick start
 

--- a/.claude/skills/do-design-audit/SKILL.md
+++ b/.claude/skills/do-design-audit/SKILL.md
@@ -1,13 +1,55 @@
 ---
 name: do-design-audit
 description: "Audit an existing web UI against premium design criteria. Screenshots pages and evaluates visual hierarchy, typography, color, spacing, consistency, and more. Use when the user wants to evaluate design quality, audit a UI, or says 'review this design', 'check the UI', 'audit this page', 'scan the interface', or provides a URL for design feedback."
-allowed-tools: Bash(agent-browser:*)
+allowed-tools: Bash(agent-browser:*), mcp__byob__*
 context: fork
 ---
 
 This skill evaluates existing web interfaces against premium design criteria. It is the review-time companion to `/frontend-design` — that skill builds to the standard; this one audits against it.
 
 Be opinionated. Call out what fails clearly. "Acceptable" is not a compliment.
+
+## Surface decision
+
+Updated in #1274. This skill is **dual-surface** — it runs against both
+public marketing pages (anonymous, headless) and authenticated app
+surfaces (logged in, real Chrome). The choice is not the audit author's;
+it is determined by the URL host:
+
+**Public-domain allowlist → use `agent-browser` (anonymous, headless):**
+
+- Public marketing TLDs: `*.com`, `*.io`, `*.dev`, `*.ai` when served at
+  `/`, `/pricing`, `/about`, `/blog/*`, or any path that is publicly
+  reachable without a login wall
+- Local dev servers: `http://localhost:*`, `http://127.0.0.1:*`,
+  `http://0.0.0.0:*`
+- Known-public preview hosts: `*.vercel.app`, `*.netlify.app`,
+  `*.pages.dev`, `*.fly.dev`, `*.railway.app` (public preview deployments)
+
+**Anything not on the allowlist → use BYOB MCP tools (real Chrome,
+logged-in):** authenticated dashboards, private staging URLs, internal
+admin panels, anything behind SSO. **Default-route unknown hosts to
+BYOB**, not to `agent-browser` — a "public" URL that 302s to a login
+page returns wrong-shaped output on the anonymous surface, and the
+audit is silently invalid. Defaulting to BYOB closes that TOCTOU
+window: BYOB just shows you the logged-in page (correct), while
+anonymous returns the redirect target (wrong-shaped, hard to detect).
+
+When BYOB is used, the calling session **must** have
+`requires_real_chrome=True` set (bridge auto-infers from message text
+for "design audit" patterns; CLI users pass
+`valor-session create --needs-real-chrome ...`). Two concurrent
+real-Chrome sessions race on the active tab and corrupt each other's
+DOM.
+
+Examples below show the public-allowlist (`agent-browser`) form. For a
+non-allowlisted URL, swap each `agent-browser <verb>` for the BYOB
+equivalent: `agent-browser open` → `mcp__byob__navigate`,
+`agent-browser screenshot` → `mcp__byob__screenshot`,
+`agent-browser snapshot -i` → `mcp__byob__screenshot` (BYOB returns the
+accessibility tree alongside the image), `agent-browser click @e<ref>`
+→ `mcp__byob__click <target>`, `agent-browser close` is unnecessary
+under BYOB (no daemon to close — the user's Chrome stays open).
 
 ## When to Use
 

--- a/.claude/skills/do-design-system/SKILL.md
+++ b/.claude/skills/do-design-system/SKILL.md
@@ -164,6 +164,16 @@ Cosmos, Pinterest, and Are.na are JavaScript-rendered SPAs. `WebFetch`
 returns the shell HTML only — it will miss the image grid. Use a
 headless browser.
 
+> **Surface choice (#1274):** This skill stays on `agent-browser` because
+> the moodboard sources (Cosmos, Pinterest, Are.na) are public — no
+> login needed, no need for the user's real Chrome session. If you ever
+> need to extract from a *logged-in* moodboard source (e.g. a
+> private Cosmos board behind your account), switch to BYOB MCP:
+> `mcp__byob__navigate <url>` then `mcp__byob__screenshot` for an image
+> grid snapshot. BYOB blocks `eval` by default, so the `JSON.stringify`
+> trick below would not transfer — use `mcp__byob__get_text` plus DOM
+> selectors instead.
+
 ```bash
 agent-browser --session moodboard open "https://www.cosmos.so/<user>/<board>"
 

--- a/.claude/skills/do-discover-paths/SKILL.md
+++ b/.claude/skills/do-discover-paths/SKILL.md
@@ -8,6 +8,28 @@ argument-hint: "<url> [path-name]"
 
 You are the **happy path discovery agent**. You systematically explore a target site using agent-browser, recording each interaction as structured trace JSON that can be converted into deterministic Rodney test scripts.
 
+## Why this stays on `agent-browser` (not BYOB)
+
+This skill depends heavily on `agent-browser eval` — the
+JavaScript-evaluation primitive used to extract CSS selectors and DOM
+structure from explored pages. The BYOB MCP server **blocks
+`browser_eval` by default** (gated by the `BYOB_ALLOW_EVAL=1`
+environment variable, off by default for security reasons documented
+in [`docs/features/byob-browser-control.md`](../../../docs/features/byob-browser-control.md)).
+
+Migrating this skill to BYOB would require either flipping the eval
+gate (a security regression that affects all BYOB consumers, not just
+this skill) or rewriting the entire selector-extraction layer to work
+without `eval` (a multi-day rewrite for marginal value).
+
+If this skill ever needs to discover paths on a **logged-in** target
+(authenticated app, SSO-protected dashboard), the right answer is to
+spawn `agent-browser` with a profile dir that already has the session
+cookies, not to migrate to BYOB. The decision was recorded in
+issue #1274 and the followup discussion lives in
+[`docs/features/byob-browser-control.md`](../../../docs/features/byob-browser-control.md)
+under Migration Status.
+
 ## Variables
 
 DISCOVERY_ARGS: $ARGUMENTS

--- a/.claude/skills/do-pr-review/SKILL.md
+++ b/.claude/skills/do-pr-review/SKILL.md
@@ -2,11 +2,51 @@
 name: do-pr-review
 description: "Use when reviewing a pull request. Analyzes code changes, validates against plan requirements, and captures visual proof via screenshots. Triggered by 'review this PR', 'check the pull request', 'do a PR review', or a PR URL."
 context: fork
+allowed-tools: Bash(agent-browser:*), mcp__byob__*, Bash(gh:*), Bash(git:*), Bash(python:*), Bash(jq:*), Bash(sdlc-tool:*), Read, Write, Edit, Grep, Glob
 ---
 
 # PR Review
 
 Review a pull request by analyzing its changes against the plan, checking code quality, validating tests, and capturing screenshots of UI changes.
+
+## Surface decision
+
+Updated in #1274. Screenshot capture in this skill is **dual-surface** —
+PR previews can be either public preview-deploy URLs (anonymous,
+`agent-browser`) or private staging URLs that require login (real Chrome,
+BYOB MCP). The choice is determined by the URL host:
+
+**Public-domain allowlist → use `agent-browser` (anonymous, headless):**
+
+- `github.com` paths
+- `*.vercel.app` (any subdomain, any preview slug)
+- `*.netlify.app`, `*.pages.dev`
+- `*.fly.dev`, `*.railway.app`, `*.render.com`
+- Local dev servers: `http://localhost:*`, `http://127.0.0.1:*`,
+  `http://0.0.0.0:*`
+
+**Anything not on the allowlist → use BYOB MCP tools (real Chrome,
+logged-in):** internal staging URLs, authenticated dashboards, anything
+behind SSO. **Default-route unknown hosts to BYOB**, not
+`agent-browser` — a "public" preview URL that 302s to a login page
+returns wrong-shaped output on the anonymous surface (the screenshot
+shows a sign-in form instead of the PR's actual UI), and the review is
+silently invalid. Defaulting to BYOB closes that TOCTOU window.
+
+When BYOB is used, the calling session must have
+`requires_real_chrome=True` set. For SDLC pipeline runs, the bridge
+auto-infers from message content; for manual review runs, pass
+`valor-session create --needs-real-chrome ...`. Two concurrent
+real-Chrome sessions race on the active tab.
+
+The screenshot examples in `## 3. Screenshot Capture` and
+`sub-skills/screenshot.md` show the public-allowlist (`agent-browser`)
+form. For a non-allowlisted URL, swap each `agent-browser <verb>` for
+the BYOB equivalent: `agent-browser open` → `mcp__byob__navigate`,
+`agent-browser screenshot <path>` → `mcp__byob__screenshot` (saves to
+the agent's working directory; reposition the file as needed),
+`agent-browser snapshot -i` → `mcp__byob__screenshot` (BYOB returns the
+accessibility tree alongside the image).
 
 ## Cross-Repo Resolution
 

--- a/.claude/skills/do-pr-review/sub-skills/screenshot.md
+++ b/.claude/skills/do-pr-review/sub-skills/screenshot.md
@@ -2,6 +2,23 @@
 
 Mechanical work: start the app and capture screenshots of UI changes.
 
+## Surface decision
+
+Updated in #1274. Inherited from `do-pr-review/SKILL.md` — see the parent
+skill's "Surface decision" section for the full allowlist and rationale.
+TL;DR:
+
+- **Allowlisted public host** (localhost, `*.vercel.app`, `*.netlify.app`,
+  `*.pages.dev`, `*.fly.dev`, `*.railway.app`, `github.com` and similar
+  known-public hosts) → use `agent-browser` (anonymous, headless).
+- **Anything else** (authenticated dashboards, internal staging,
+  SSO-protected URLs, unknown hosts) → use the BYOB MCP tools
+  (`mcp__byob__*`, real Chrome, logged-in). Default-route unknown
+  hosts to BYOB to close the public-URL-302s-to-login TOCTOU window.
+
+The examples below are written for the `agent-browser` (allowlisted)
+path. For BYOB, swap each command with its `mcp__byob__<verb>` analog.
+
 ## Context Variables
 
 - `$SDLC_PR_NUMBER` — PR number for screenshot directory naming
@@ -9,6 +26,15 @@ Mechanical work: start the app and capture screenshots of UI changes.
 ## Prerequisites
 
 PR branch must already be checked out (via checkout sub-skill).
+
+For BYOB-routed URLs, the calling session must have
+`requires_real_chrome=True` (set by bridge inference for SDLC runs, or
+the `--needs-real-chrome` CLI flag for manual runs). Verify the BYOB
+extension is connected before screenshotting:
+
+```text
+mcp__byob__list_tabs       # must return at least one Chrome tab
+```
 
 ## Steps
 
@@ -38,10 +64,20 @@ sleep 3
 
 ### 4. Capture Screenshots
 
+For an allowlisted (public) host:
+
 ```bash
 agent-browser open http://localhost:8000
 agent-browser snapshot -i
 agent-browser screenshot generated_images/pr-${PR_NUMBER}/01_main_view.png
+```
+
+For a non-allowlisted (logged-in / internal) host, use BYOB instead:
+
+```text
+mcp__byob__navigate https://staging.example.internal/path
+mcp__byob__screenshot   # save the returned image to
+                        # generated_images/pr-${PR_NUMBER}/01_main_view.png
 ```
 
 **Screenshot naming convention:**
@@ -51,11 +87,15 @@ agent-browser screenshot generated_images/pr-${PR_NUMBER}/01_main_view.png
 
 ### 5. Cleanup
 
-Close the browser, then stop the dev server if started:
+For the `agent-browser` path, close the browser, then stop the dev
+server if started:
 
 ```bash
 agent-browser close
 ```
+
+For the BYOB path, no `close` step is needed — BYOB drives the user's
+real Chrome and does not own a daemon process.
 
 ## Completion
 

--- a/.claude/skills/do-skills-audit/scripts/audit_skills.py
+++ b/.claude/skills/do-skills-audit/scripts/audit_skills.py
@@ -51,6 +51,12 @@ INFRA_SKILLS = frozenset({"update", "setup", "reclassify", "new-skill", "new-val
 BACKGROUND_SKILLS = frozenset(
     {
         "agent-browser",
+        # BYOB is exposed as MCP tools only (mcp__byob__*) — there is no
+        # SKILL.md for it. Listed here so the audit recognizes it as a
+        # legitimate model-only browser surface alongside agent-browser
+        # (issue #1274). If BYOB ever gains a user-invocable wrapper
+        # skill, that skill name belongs here too.
+        "byob",
         "telegram",
         "reading-sms-messages",
         "checking-system-logs",

--- a/.claude/skills/do-test/SKILL.md
+++ b/.claude/skills/do-test/SKILL.md
@@ -407,7 +407,7 @@ Expected: <inferred from scenario>
 })
 ```
 
-The `frontend-tester` agent owns all `agent-browser` interaction — the skill never calls `agent-browser` directly.
+The `frontend-tester` agent owns all `agent-browser` interaction — the skill never calls `agent-browser` directly. (BYOB MCP is a candidate alternative for `frontend-tester`'s authenticated test scenarios; if/when `frontend-tester` migrates per #1274, this sentence will follow. Out of scope for #1274 because that issue covers skills only, not agents.)
 
 **When running all tests** (no target) and a `tests/frontend/` directory exists with `.json` or `.yaml` scenario files, dispatch one `frontend-tester` subagent per scenario file in parallel alongside the pytest agents.
 

--- a/.claude/skills/linkedin/SKILL.md
+++ b/.claude/skills/linkedin/SKILL.md
@@ -1,13 +1,18 @@
 ---
 name: linkedin
 description: "Use when browsing LinkedIn, reading posts, writing comments, checking DMs, or engaging with content. Triggered by requests to comment on LinkedIn, browse feed, interact with posts, or read/reply to LinkedIn messages."
-allowed-tools: mcp__byob__browser_list_tabs, mcp__byob__browser_navigate, mcp__byob__browser_read, mcp__byob__browser_get_html, mcp__byob__browser_click, mcp__byob__browser_type, mcp__byob__browser_press_key, mcp__byob__browser_scroll, mcp__byob__browser_wait_for, mcp__byob__browser_screenshot, mcp__byob__browser_close_tab, mcp__byob__browser_switch_tab, Bash(git:*), Read, Write, Edit, Grep, Glob, Agent
+allowed-tools: mcp__byob__browser_list_tabs, mcp__byob__browser_navigate, mcp__byob__browser_read, mcp__byob__browser_get_html, mcp__byob__browser_click, mcp__byob__browser_type, mcp__byob__browser_press_key, mcp__byob__browser_scroll, mcp__byob__browser_wait_for, mcp__byob__browser_screenshot, mcp__byob__browser_close_tab, mcp__byob__browser_switch_tab, Bash(agent-browser:*), Bash(git:*), Read, Write, Edit, Grep, Glob, Agent
 user-invocable: true
 ---
 
 # LinkedIn Activity
 
-Browse LinkedIn, engage with posts, and manage direct messages using **BYOB** — the Chrome extension + native messaging stack that drives the user's already-logged-in real Chrome via MCP tools (`mcp__byob__browser_*`). No CDP flag, no `state.json`, no headless-fingerprint detection.
+**Migrated from `agent-browser` in #1274.** This skill drives the user's real,
+logged-in Chrome session via the **BYOB** stack — the Chrome extension + native
+messaging host + MCP server (`mcp__byob__browser_*`). No CDP flag, no
+`state.json`, no headless-fingerprint detection. The fallback CDP-attach path
+is still documented below for machines where BYOB is not yet installed; it
+will be removed in a followup once BYOB is verified working everywhere.
 
 ## Default Behavior (no arguments)
 
@@ -23,9 +28,70 @@ If arguments are given, interpret them and do only what's asked.
 
 ## Prerequisites
 
-- BYOB bridge live and Chrome extension loaded. Verify once at session start with the `browser_list_tabs` tool — if it returns tabs, you're good. If the MCP tool itself is missing, run `cd ~/.byob && bun run doctor` and follow its diagnostics.
-- User logged into LinkedIn in Chrome (BYOB inherits the session).
-- If this skill is invoked from a queued AgentSession, that session should have been created with `valor-session create --needs-real-chrome ...` so the worker scheduler serializes around the single real-Chrome DOM tree.
+This skill needs **two preconditions** plus a **scheduler-gate flag**:
+
+### 1. BYOB extension installed and connected
+
+BYOB is the "Bring Your Own Browser" stack: a Chrome extension + native
+messaging host + MCP server that lets this skill act on the user's already
+logged-in Chrome (no headless profile, no per-session re-auth). Set up via
+`/setup`'s computer-use opt-in or by following
+[`docs/features/byob-browser-control.md`](../../../docs/features/byob-browser-control.md).
+
+Verify the install in one shot:
+
+```bash
+cd ~/.byob && bun run doctor
+```
+
+All status lines should be green: extension loaded, native bridge running,
+Unix socket live. If any line is red, the BYOB MCP tools below will return
+a transport error -- run `/setup` and answer "yes" to the computer-use
+opt-in to repair.
+
+After `bun run doctor` passes, sanity-check from inside the agent that
+the extension is actually talking to Chrome by listing open tabs:
+
+```text
+mcp__byob__browser_list_tabs    # returns the user's currently open Chrome tabs
+```
+
+If `browser_list_tabs` returns an empty list or a transport error, the
+extension loaded but isn't bound to an active Chrome window -- open Chrome
+(or focus it) and retry. **Do not proceed to LinkedIn work until
+`browser_list_tabs` returns at least one tab.** A silent transport failure
+here means every subsequent BYOB call returns wrong-shaped output and the
+skill drives nothing.
+
+The user must be logged into LinkedIn in that Chrome session.
+
+### 2. Real-Chrome scheduler gate (`requires_real_chrome=True`)
+
+LinkedIn driving real Chrome must be **serialized** against any other
+real-Chrome session — two concurrent BYOB sessions on the active tab
+collide and corrupt each other's DOM. PR #1277 added the
+`AgentSession.requires_real_chrome` field; the worker scheduler defers
+any second real-Chrome candidate until the first finishes.
+
+There are two paths that set the flag:
+
+- **Bridge-spawned (Telegram or email)**: the bridge calls
+  `agent.byob_skill_triggers.infer_requires_real_chrome(message_text)`
+  before enqueue. Messages mentioning "linkedin" with first-person /
+  intent phrasing (e.g. "check my LinkedIn DMs", "/linkedin") match a
+  trigger and the flag is set automatically. No operator action required.
+- **CLI-spawned**: launch with the explicit flag:
+
+  ```bash
+  valor-session create \
+    --role dev \
+    --project-key valor \
+    --needs-real-chrome \
+    --message "list my linkedin DMs"
+  ```
+
+  Always use `--needs-real-chrome` for any session that calls this skill.
+  Without it, two real-Chrome sessions can race.
 
 ## Tab discovery (do this first)
 
@@ -64,7 +130,33 @@ When multiple `interactiveElements` map to the same logical control (the Like bu
 - **`browser_scroll` with `y: <number>` or `to: "bottom"` does nothing on the feed** — LinkedIn scrolls an inner container, not the window. The returned `scrollY` will be `0` regardless. Use `browser_scroll(tabId, text: "<unique substring>")` or `selector: "byob:idx=N"` to bring a specific element into view; ignore the `scrollY` field. For bulk feed loading, just bump `browser_read`'s `screens` parameter — it auto-scrolls and is the right tool.
 - **Feed reads cap at 1000 IEs.** When the read returns `stopReason: "limit_reached"` and `canContinue: true`, you've only seen the first slice. Process those, then call `browser_read` again to advance.
 - **Post bodies often don't appear in `interactiveElements`** because they're non-interactive `<div>`s. The IE list captures author headers, action buttons, and accessibility labels — not the post text itself. To read the actual post body, use `browser_get_html(tabId, selector="main")` and parse text out, or open the post URL directly (`/feed/update/urn:li:share:<id>/`) and use `browser_read` on the dedicated post page where the body usually surfaces in chunks.
+- **Tool-result file overflow:** both `browser_read` and `browser_get_html` on rich pages routinely exceed the inline tool-result limit and dump to `tool-results/*.txt`. Be ready to parse those out via Bash/grep/jq. Set realistic `maxBytes` and `screens` defaults to keep the inline path viable when you can.
 - **Block list:** BYOB upstream blocks reading `chrome://`, `file://`, and login pages for Google/Microsoft/Apple. Not relevant for in-session LinkedIn use.
+
+### Fallback path — deprecated
+
+The recipe below pre-dates BYOB and is kept for one release cycle so
+operators on machines without BYOB still have a working LinkedIn
+skill. **Do not use this path if BYOB is installed.** It will be
+removed in a followup issue once BYOB is verified working on every
+operator machine.
+
+```bash
+# DEPRECATED — use BYOB above. CDP-attach hack:
+pkill -f "Google Chrome" && sleep 2
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/chrome-debug-profile &>/dev/null &
+sleep 5
+agent-browser connect 9222
+```
+
+When using the fallback, every `mcp__byob__browser_<verb>` call below maps to
+`agent-browser <verb>`, with the same arguments and roughly equivalent
+behavior (anonymous CDP-attached profile rather than the user's real
+Chrome). The fallback path requires the user to manually relaunch Chrome
+with debug flags before each session — which is exactly the friction
+BYOB removes.
 
 ---
 
@@ -288,13 +380,12 @@ If the draft fails the casual-reader test, send the subagent back with specific 
 
 ### Publish
 
-> **⚠️ KNOWN LIMITATION (verified live 2026-05-05):** BYOB **cannot drive LinkedIn's "Start a post" composer modal.** Clicking the "Start a post" trigger opens the modal visually (confirmed via screenshot) but the modal's contenteditable textbox renders into a portal that `browser_read`, `browser_get_html`, and `browser_wait_for` cannot see. With no selector to target, `browser_type` has nothing to type into. `browser_press_key` does dispatch into the focused textbox, but it's single-key-per-call — typing 1500 chars one at a time is impractical.
+> **⚠️ KNOWN LIMITATION (verified live 2026-05-05, see PR #1286 / issue #1274):** BYOB **cannot drive LinkedIn's "Start a post" composer modal.** Clicking the "Start a post" trigger opens the modal visually (confirmed via screenshot showing "What do you want to talk about?"), but the modal's contenteditable textbox renders inside a **React portal** that `browser_read`, `browser_get_html`, and `browser_wait_for` cannot traverse. With no selector to target, `browser_type` has nothing to type into. `browser_press_key` does dispatch into the focused textbox, but it's single-key-per-call — typing 1500 chars one at a time is impractical (1500 round-trips). This is a general BYOB gap (every React-portal-rendered modal on every site likely has the same problem), not a LinkedIn-specific one — worth filing upstream.
 >
-> **What to do until BYOB resolves this:** at the point you'd publish, render the final draft inline AND state plainly: *"BYOB can't drive the post composer modal yet — paste this from `/tmp/linkedin-post.txt` into LinkedIn yourself, or send via the mobile app where the share flow is different."* Then proceed to Task 3 (which works fine — comments use an inline textbox, not a portal modal).
+> **What to do until BYOB resolves this:** at the point you'd publish, render the final draft inline AND state plainly: *"BYOB can't drive the post composer modal yet (React portal — see SKILL.md KNOWN LIMITATION) — paste this from `/tmp/linkedin-post.txt` into LinkedIn yourself, or send via the mobile app where the share flow is different."* Then proceed to Task 3 (which works fine — comments use an inline textbox, not a portal modal).
 >
 > Things that have been verified NOT to work for the share modal:
-> - `browser_click("byob:idx=...")` on every "Start a post" IE variant (modal opens but textbox not in document)
-> - `force: true` on the click (same)
+> - `browser_click("byob:idx=...")` on every "Start a post" IE variant (`idx=137..141`, `tag` "div"/"p", with and without `force:true`) — modal opens but textbox not in document
 > - `browser_get_html("body")` after open (returns navigation chrome only — modal lives elsewhere)
 > - `browser_get_html("[contenteditable=true]")`, `[role='dialog']`, `.share-creation-state`, `.ql-editor` (all `selector_not_found`)
 > - `browser_wait_for(...)` for any of those selectors (always times out)
@@ -321,7 +412,7 @@ As you read through posts, Like any that are relevant to the work — agentic sy
 
 **Commenting always implies a Like.** If a post passes the screening gate and you draft a comment for it, also like the post. Engagement should be coherent — a comment without the like reads as half-engaged. The reverse isn't true: plenty of posts are worth a like but not a comment.
 
-In the IE list, Like buttons appear with `name: "Reaction button state: no reactionLike"` (or `name: "Like"`). After clicking, the same button's name flips to `"Reaction button state: Like"` — that's how you confirm the like landed. If the name already shows `"Reaction button state: Like"` or `"Unreact Like"`, the post is already liked — skip.
+In the IE list, Like buttons appear with `name: "Reaction button state: no reactionLike"` (or `name: "Like"`). After clicking, the same button's name flips to `"Reaction button state: Like"` — that's the reliable success indicator (don't gate on reaction-count diffs, those can lag). If the name already shows `"Reaction button state: Like"` or `"Unreact Like"`, the post is already liked — skip.
 
 ```text
 browser_click(tabId=<linkedin_tab>, selector="byob:idx=<like_idx>")
@@ -510,3 +601,4 @@ Only use Edit to fix typos or rewrite the whole comment as a clean standalone.
 - **Opening a message marks it as read** — be aware of "seen" indicators if you don't intend to actually engage.
 - **Screenshots over 1MB fail** — use `format="jpeg"` and `quality=50-60` for confirmation captures.
 - **No Playwright fallback in BYOB.** If the bridge dies mid-session, the agent surfaces a clear error — don't try to reroute through `bowser` (different stack, anonymous, no LinkedIn login).
+- **If `mcp__byob__browser_*` calls return transport errors mid-session**, the Chrome extension may have lost its bridge — run `cd ~/.byob && bun run doctor` in a fresh shell to repair, then retry the failed call.

--- a/.claude/skills/mermaid-render/SKILL.md
+++ b/.claude/skills/mermaid-render/SKILL.md
@@ -10,6 +10,19 @@ user-invocable: true
 
 Convert Mermaid `.mmd` source files (or `.excalidraw` JSON files) to hand-drawn style PNGs.
 
+## Why this stays on `agent-browser` (not BYOB)
+
+The browser-driven leg of this skill targets `excalidraw.com`, which is
+**anonymous and public** — there's no benefit to driving the user's
+real Chrome here. The skill also relies on `agent-browser eval` to
+extract the scene JSON from `localStorage`, which BYOB blocks by
+default (gated by `BYOB_ALLOW_EVAL=1` for security; see
+[`docs/features/byob-browser-control.md`](../../../docs/features/byob-browser-control.md)).
+Migrating would either require flipping the eval gate (security
+regression for every other BYOB consumer) or finding an
+eval-free way to round-trip the scene through Excalidraw's UI
+(slower, more brittle, no upside). Decision recorded in #1274.
+
 ## Dependencies (install once)
 
 ```bash

--- a/.claude/skills/prepare-app/SKILL.md
+++ b/.claude/skills/prepare-app/SKILL.md
@@ -12,7 +12,7 @@ Prepare the application for review by starting necessary services and ensuring t
 - Before running `/do-pr-review` command with UI validation
 - Before manual testing of web applications
 - When setting up local development environment for testing
-- Before browser automation with `agent-browser`
+- Before browser automation with `agent-browser` (anonymous, headless) or BYOB MCP tools (`mcp__byob__*`, real Chrome, logged-in)
 
 ## Instructions
 
@@ -271,7 +271,7 @@ lsof -ti:3000 | xargs kill
 
 **Works with:**
 - `/do-pr-review` - Ensures app is running before screenshots
-- `agent-browser` - Prepares environment for browser automation
+- `agent-browser` (anonymous, headless) and BYOB MCP tools (real Chrome, logged-in) - Prepares environment for either browser surface; pick per `.claude/skills/README.md` decision rule
 - Local development workflow
 
 **Server lifecycle:**

--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -1069,6 +1069,7 @@ async def enqueue_agent_session(
     scheduling_depth: int = 0,  # ignored, now derived
     project_config: dict | None = None,
     extra_context_overrides: dict | None = None,
+    requires_real_chrome: bool = False,
 ) -> int:
     """
     Add a session to Redis and ensure worker is running.
@@ -1080,6 +1081,13 @@ async def enqueue_agent_session(
             (legacy callers); the worker will fall back to loading from projects.json.
         extra_context_overrides: Additional key/value pairs merged into extra_context.
             Use for transport-specific metadata, e.g. transport="email".
+        requires_real_chrome: Forwarded to ``_push_agent_session`` so the
+            worker scheduler can serialize this session against any other
+            in-flight real-Chrome session (issue #1256, Decision 2).
+            Bridge enqueue paths set this from
+            ``agent.byob_skill_triggers.infer_requires_real_chrome``;
+            CLI ``valor-session create --needs-real-chrome`` sets it
+            literally. Default False keeps non-serialized scheduling.
 
     Returns queue depth after push.
     """
@@ -1112,6 +1120,7 @@ async def enqueue_agent_session(
         session_type=session_type,
         project_config=project_config,
         extra_context_overrides=extra_context_overrides,
+        requires_real_chrome=requires_real_chrome,
     )
     # KEEP IN SYNC with AgentSession.worker_key in models/agent_session.py
     # Compute worker_key from the same inputs the property uses, without re-querying Redis

--- a/agent/byob_skill_triggers.py
+++ b/agent/byob_skill_triggers.py
@@ -1,0 +1,139 @@
+"""Bridge-side inference for ``AgentSession.requires_real_chrome``.
+
+This module owns the registry of message-text patterns that imply a
+bridge-spawned session should engage the BYOB (real Chrome) scheduler gate
+introduced by PR #1277. It exists because Telegram- and email-spawned
+sessions never see ``valor-session create --needs-real-chrome``: the bridge
+enqueue path constructs the session record directly. Without an inference
+hook there, a user-typed "check my LinkedIn DMs" arriving via Telegram
+silently bypasses the scheduler gate and two real-Chrome sessions can race
+on the active tab.
+
+Adding a new BYOB-migrated skill means adding a row to
+``BYOB_SKILL_TRIGGERS`` -- not a new branch in ``bridge/telegram_bridge.py``
+or ``bridge/email_bridge.py``. Both bridges call
+:func:`infer_requires_real_chrome` once before constructing the
+``enqueue_agent_session`` kwargs and pass the boolean through unchanged.
+
+Design notes
+------------
+
+* **Regex with word boundaries, not bare substring** — Cycle-2 critique
+  flagged that a substring match on ``"linkedin"`` false-positives on any
+  message that quotes a URL containing ``linkedin.com`` or that mentions
+  the platform in passing. The patterns below are anchored on first-person
+  / intent phrasing (``my linkedin``, ``check linkedin``) so casual mentions
+  do NOT serialize unrelated PM sessions behind the real-Chrome slot.
+  False-positives are still safer than false-negatives (the worst-case is
+  unnecessary serialization of one PM session, not a Chrome-tab race), but
+  we tighten anyway because the cost is one regex.
+
+* **Case-insensitive** — patterns match ``LinkedIn``, ``LINKEDIN``, and
+  ``linkedin`` identically. The regex flag, not per-pattern alternation.
+
+* **Exception-safe** — invalid input (``None``, non-string, decode errors)
+  returns ``False``. The bridge enqueue path must never raise from
+  inference; falling through to status quo is the safe default. This is
+  documented in the plan's Failure Path Test Strategy.
+
+* **CLI override unchanged** — operators using
+  ``valor-session create --needs-real-chrome`` retain explicit control.
+  Inference is purely additive on the bridge path. The CLI path does NOT
+  consult this module.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+# Registry of patterns per migrated BYOB skill. Each value is a list of
+# compiled regex strings; any match on the message text → set the flag.
+#
+# When you migrate a new skill to BYOB, add a row here. The bridge path
+# will pick up the new triggers automatically -- no bridge edit required.
+BYOB_SKILL_TRIGGERS: dict[str, list[str]] = {
+    "linkedin": [
+        # First-person intent: "my linkedin", "the linkedin"
+        r"\b(?:my|the)\s+linked\s?in\b",
+        # Verb + linkedin: "check linkedin", "open linkedin", "browse linkedin"
+        r"\b(?:check|open|browse|read|reply\s+(?:on|to))\s+linked\s?in\b",
+        # Object phrasing: "linkedin DMs", "linkedin messages", "linkedin feed",
+        # "linkedin inbox", "in-mail" / "inmail"
+        r"\blinked\s?in\s+(?:dms?|messages?|feed|inbox|notifications?|comments?)\b",
+        r"\bin[-\s]?mails?\b",
+        # Slash-skill explicit invocation — require start-of-string or
+        # whitespace before the slash so URLs containing
+        # "/linkedin-post" do not match. Operators type
+        # "/linkedin foo" at the start of a turn, not embedded in URLs.
+        r"(?:^|\s)/linkedin\b",
+    ],
+}
+
+
+# Pre-compile the union per skill once at import time. Keeps
+# infer_requires_real_chrome() hot-path cheap (no per-call recompile).
+_COMPILED_TRIGGERS: dict[str, list[re.Pattern[str]]] = {
+    skill: [re.compile(pat, re.IGNORECASE) for pat in patterns]
+    for skill, patterns in BYOB_SKILL_TRIGGERS.items()
+}
+
+
+def infer_requires_real_chrome(message_text: str | None) -> bool:
+    """Return True if the message text implies a BYOB-migrated skill.
+
+    Called from the bridge enqueue path (Telegram and email) before
+    constructing the kwargs to :func:`agent.agent_session_queue.enqueue_agent_session`.
+    The result is forwarded as ``requires_real_chrome=`` so the worker
+    scheduler can serialize the session against any other in-flight
+    real-Chrome session.
+
+    Args:
+        message_text: The user-typed message body. May be ``None`` or
+            empty. Non-string inputs are treated as no-match.
+
+    Returns:
+        True if any registered trigger matches; False otherwise. Never
+        raises -- exception-safe by contract (see Failure Path Test
+        Strategy in ``docs/plans/agent_browser_to_byob_skill_migration.md``).
+    """
+    if message_text is None:
+        return False
+    if not isinstance(message_text, str):
+        # Defensive: bridge code should always pass a str, but if it
+        # mistakenly hands us bytes or a custom object, fall through to
+        # status quo rather than raise.
+        try:
+            message_text = str(message_text)
+        except Exception:  # noqa: BLE001
+            return False
+    if not message_text.strip():
+        return False
+
+    try:
+        for _skill, patterns in _COMPILED_TRIGGERS.items():
+            for pattern in patterns:
+                if pattern.search(message_text):
+                    logger.debug(
+                        "byob_inference_match skill=%s pattern=%r preview=%r",
+                        _skill,
+                        pattern.pattern,
+                        message_text[:80],
+                    )
+                    return True
+    except Exception as exc:  # noqa: BLE001
+        # Never let a regex pathology escape into the bridge enqueue
+        # path. Log and fall through to the safe default.
+        logger.warning(
+            "byob_inference_failed_safely error=%r preview=%r",
+            exc,
+            (message_text[:80] if isinstance(message_text, str) else "<non-str>"),
+        )
+        return False
+
+    return False
+
+
+__all__ = ["BYOB_SKILL_TRIGGERS", "infer_requires_real_chrome"]

--- a/bridge/dispatch.py
+++ b/bridge/dispatch.py
@@ -88,6 +88,7 @@ async def dispatch_telegram_session(
     scheduling_depth: int = 0,
     project_config: dict | None = None,
     extra_context_overrides: dict | None = None,
+    requires_real_chrome: bool = False,
 ) -> int:
     """Enqueue a Telegram-originating session and record dedup.
 
@@ -130,6 +131,7 @@ async def dispatch_telegram_session(
         scheduling_depth=scheduling_depth,
         project_config=project_config,
         extra_context_overrides=extra_context_overrides,
+        requires_real_chrome=requires_real_chrome,
     )
     # Record inbound message in the session's chat_message_log (issue #1192).
     # Called after enqueue so the AgentSession record exists in Redis.

--- a/bridge/email_bridge.py
+++ b/bridge/email_bridge.py
@@ -756,9 +756,7 @@ async def _process_inbound_email(parsed: dict, config: dict) -> None:
     _byob_text = f"{subject or ''}\n{body or ''}"
     _byob_real_chrome = infer_requires_real_chrome(_byob_text)
     if _byob_real_chrome:
-        logger.info(
-            f"[email] byob_inference_set_real_chrome session_id={session_id}"
-        )
+        logger.info(f"[email] byob_inference_set_real_chrome session_id={session_id}")
 
     # Enqueue the session with email transport metadata
     try:

--- a/bridge/email_bridge.py
+++ b/bridge/email_bridge.py
@@ -688,6 +688,7 @@ async def _process_inbound_email(parsed: dict, config: dict) -> None:
         config: The loaded projects.json config dict.
     """
     from agent.agent_session_queue import enqueue_agent_session
+    from agent.byob_skill_triggers import infer_requires_real_chrome
     from bridge.routing import ACTIVE_PROJECTS, find_project_for_email
     from config.enums import SessionType
 
@@ -748,6 +749,17 @@ async def _process_inbound_email(parsed: dict, config: dict) -> None:
         except Exception as e:
             logger.warning(f"[email] Failed to store inbound msgid mapping: {e}")
 
+    # BYOB scheduler-gate inference (#1274): scan body + subject for
+    # registered triggers (e.g. "linkedin"). Email sessions go through a
+    # separate enqueue path from telegram_bridge.py, so the same inference
+    # hook is wired here independently. Fails closed -- exception-safe.
+    _byob_text = f"{subject or ''}\n{body or ''}"
+    _byob_real_chrome = infer_requires_real_chrome(_byob_text)
+    if _byob_real_chrome:
+        logger.info(
+            f"[email] byob_inference_set_real_chrome session_id={session_id}"
+        )
+
     # Enqueue the session with email transport metadata
     try:
         await enqueue_agent_session(
@@ -761,6 +773,7 @@ async def _process_inbound_email(parsed: dict, config: dict) -> None:
             chat_title=subject or f"Email from {from_addr}",
             project_config=project,
             session_type=session_type,
+            requires_real_chrome=_byob_real_chrome,
             extra_context_overrides={
                 "transport": "email",
                 "email_message_id": message_id,

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -2183,8 +2183,7 @@ async def main():
         _byob_real_chrome = infer_requires_real_chrome(safe_text)
         if _byob_real_chrome:
             logger.info(
-                "byob_inference_set_real_chrome "
-                f"session_id={session_id} chat_id={telegram_chat_id}"
+                f"byob_inference_set_real_chrome session_id={session_id} chat_id={telegram_chat_id}"
             )
 
         # Enqueue: session_type drives PM vs Dev session creation.

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -2170,6 +2170,23 @@ async def main():
                     f"chain_len={len(chain)}"
                 )
 
+        # BYOB scheduler-gate inference (#1274): scan the inbound message
+        # text for triggers registered in agent.byob_skill_triggers and
+        # forward the resulting bool as requires_real_chrome=. Bridge-spawned
+        # sessions never see the --needs-real-chrome CLI flag, so this is the
+        # only path that engages the real-Chrome scheduler gate from PR #1277
+        # for Telegram-initiated work. Fails closed: if inference raises (it
+        # shouldn't — it's exception-safe by contract) the call returns
+        # False, preserving status-quo non-serialized scheduling.
+        from agent.byob_skill_triggers import infer_requires_real_chrome
+
+        _byob_real_chrome = infer_requires_real_chrome(safe_text)
+        if _byob_real_chrome:
+            logger.info(
+                "byob_inference_set_real_chrome "
+                f"session_id={session_id} chat_id={telegram_chat_id}"
+            )
+
         # Enqueue: session_type drives PM vs Dev session creation.
         # Pass full project config so the session carries it through the pipeline.
         # dispatch_telegram_session wraps enqueue_agent_session + dedup record so
@@ -2191,6 +2208,7 @@ async def main():
             session_type=_session_type,
             project_config=project,
             extra_context_overrides=extra_overrides,
+            requires_real_chrome=_byob_real_chrome,
         )
         logger.info(
             f"[{project_name}] Queued session for {sender_name} (msg {message_id}, depth={depth})"

--- a/config/personas/segments/tools.md
+++ b/config/personas/segments/tools.md
@@ -27,7 +27,10 @@ I can destroy and rebuild this machine if needed. It is mine to manage.
 - Standard development toolchain (git, pytest, ruff, mypy)
 
 ### Browser Automation
-`agent-browser` CLI for web interactions, testing, screenshots, and data extraction:
+
+**Decision rule** (post-#1274): If the target site needs the user's logged-in identity (LinkedIn, Gmail, internal dashboards, authenticated GitHub views), use **BYOB MCP** (`mcp__byob__*`) -- see the next section. For anonymous public-page automation use the `agent-browser` CLI below. For parallel anonymous sessions use `bowser`. The full decision matrix lives in `.claude/skills/README.md` ("When to use which browser surface?").
+
+`agent-browser` CLI for **anonymous** web interactions, testing, screenshots, and data extraction:
 ```bash
 # Core workflow
 agent-browser open <url>           # Navigate
@@ -37,16 +40,14 @@ agent-browser fill @e2 "text"      # Fill input
 agent-browser screenshot page.png  # Capture screenshot
 agent-browser close                # Done
 
-# Use your Chrome session (CDP) - preserves logins/cookies
-# 1. Start Chrome: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --remote-debugging-port=9222
-# 2. Connect: agent-browser connect 9222
-# 3. Run commands against your logged-in session
-
 # Common tasks
 agent-browser get text @e1         # Extract text
 agent-browser wait --text "Done"   # Wait for content
 agent-browser eval "document.title" # Run JavaScript
 ```
+
+For **logged-in** browsing, BYOB MCP supersedes the old `agent-browser connect 9222` CDP-attach recipe -- no manual Chrome relaunch required. See the BYOB section below.
+
 Full reference: `.claude/skills/agent-browser/SKILL.md`
 
 ### BYOB (Real Chrome, Logged-In)

--- a/docs/features/byob-browser-control.md
+++ b/docs/features/byob-browser-control.md
@@ -13,7 +13,7 @@ this section is the post-build summary.
 
 | Skill | Post-build state | Notes |
 |-------|------------------|-------|
-| `linkedin` | **migrated to BYOB** | First canonical migration. Frontmatter declares both `mcp__byob__*` and `Bash(agent-browser:*)` (legacy fallback for one release cycle, retained under explicit "Fallback path — deprecated" callout). |
+| `linkedin` | **migrated to BYOB** | First canonical migration. Frontmatter declares both `mcp__byob__*` and `Bash(agent-browser:*)` for one release cycle so machines without BYOB still have a working linkedin skill. The retained CDP-attach block is prefixed with an explicit "Fallback path" callout (verified by build-time grep). |
 | `do-design-audit` | **dual-surface** | Public-domain allowlist routes to `agent-browser`; everything else (auth dashboards, unknown hosts) routes to BYOB. Default-to-BYOB closes the public-URL-302s-to-login TOCTOU window. |
 | `do-pr-review` (incl. `sub-skills/screenshot.md`) | **dual-surface** | Allowlist: `localhost`, `*.vercel.app`, `*.netlify.app`, `*.pages.dev`, `*.fly.dev`, `*.railway.app`, `github.com`. Anything else routes to BYOB. |
 | `do-design-system` | doc-only update | Cosmos / Pinterest / Are.na are public; stays on `agent-browser`. Note added explaining BYOB is the alternative for any future logged-in moodboard source. |

--- a/docs/features/byob-browser-control.md
+++ b/docs/features/byob-browser-control.md
@@ -2,7 +2,46 @@
 
 **Issue:** [#1256](https://github.com/tomcounsell/ai/issues/1256)
 **Plan:** [`docs/plans/byob_and_computer_use.md`](../plans/byob_and_computer_use.md)
-**Followups:** [#1274](https://github.com/tomcounsell/ai/issues/1274) (per-skill migration of `agent-browser`-using skills)
+
+## Migration Status
+
+The `agent-browser` → BYOB skill migration tracked by
+[#1274](https://github.com/tomcounsell/ai/issues/1274) shipped with the
+following per-skill state. The canonical decision matrix lives in
+[`docs/plans/agent_browser_to_byob_skill_migration.md`](../plans/agent_browser_to_byob_skill_migration.md);
+this section is the post-build summary.
+
+| Skill | Post-build state | Notes |
+|-------|------------------|-------|
+| `linkedin` | **migrated to BYOB** | First canonical migration. Frontmatter declares both `mcp__byob__*` and `Bash(agent-browser:*)` (legacy fallback for one release cycle, retained under explicit "Fallback path — deprecated" callout). |
+| `do-design-audit` | **dual-surface** | Public-domain allowlist routes to `agent-browser`; everything else (auth dashboards, unknown hosts) routes to BYOB. Default-to-BYOB closes the public-URL-302s-to-login TOCTOU window. |
+| `do-pr-review` (incl. `sub-skills/screenshot.md`) | **dual-surface** | Allowlist: `localhost`, `*.vercel.app`, `*.netlify.app`, `*.pages.dev`, `*.fly.dev`, `*.railway.app`, `github.com`. Anything else routes to BYOB. |
+| `do-design-system` | doc-only update | Cosmos / Pinterest / Are.na are public; stays on `agent-browser`. Note added explaining BYOB is the alternative for any future logged-in moodboard source. |
+| `prepare-app` | doc-only update | Now mentions both surfaces in "When to Use" and "Integration Notes". |
+| `do-test` | doc-only update | The `frontend-tester` agent's `agent-browser` use is unchanged; sentence appended noting BYOB is a future option for that agent. |
+| `.claude/skills/README.md` | doc-only update | Added "When to use which browser surface?" section with the canonical decision rule (1: needs login? 2: needs parallelism? 3: ambiguous → default-to-BYOB). |
+| `do-skills-audit/scripts/audit_skills.py` | one-line update | `byob` added to `BACKGROUND_SKILLS` allowlist so the audit recognizes the BYOB MCP surface (no SKILL.md exists for BYOB by design — it is MCP-only). |
+| `agent-browser` | stays | The skill *is* the wrapper for the 3rd-party anonymous CLI. Pointer added: "When to use BYOB instead?" |
+| `bowser` | stays | Already its own skill. No `agent-browser` references. Documentation-status row only. |
+| `do-discover-paths` | stays | Depends on `agent-browser eval` which BYOB blocks by default. Documented "Why this stays on `agent-browser`" section added. |
+| `mermaid-render` | stays | Excalidraw is anonymous and public; uses `agent-browser eval` which BYOB blocks. Documented "Why this stays on `agent-browser`" section added. |
+
+**Bridge inference**: `agent/byob_skill_triggers.py` exposes
+`BYOB_SKILL_TRIGGERS` (registry) and `infer_requires_real_chrome(text)`
+(case-insensitive regex match with first-person/intent phrasing).
+Both Telegram and email bridge enqueue paths call this before
+`enqueue_agent_session()` so bridge-spawned sessions get the
+`requires_real_chrome` scheduler gate engaged automatically.
+**Adding a new BYOB-migrated skill = add a row to
+`BYOB_SKILL_TRIGGERS`.** No bridge edit required.
+
+CLI users continue to set the flag explicitly:
+`valor-session create --needs-real-chrome ...`.
+
+**Behavioral smoke test**: the operator must verify the canonical
+`linkedin` migration drives real Chrome end-to-end via
+`tests/manual/linkedin_byob_smoke.txt`. See the plan's Success
+Criteria for the executable proof artifact.
 
 ## What it is
 
@@ -22,7 +61,7 @@ Three surfaces coexist after this work shipped:
 
 | Surface | Anonymous? | Headless? | Parallel-safe? | Logged-in? | Use when |
 |---|---|---|---|---|---|
-| `agent-browser` (3rd-party CLI on PATH) | yes | yes | no (single-tab) | no | Existing skills that use it (do-pr-review, do-design-audit, etc.) -- migrating in #1274 |
+| `agent-browser` (3rd-party CLI on PATH) | yes | yes | no (single-tab) | no | Anonymous public-page automation. Per-skill migration outcomes captured in the Migration Status section above (#1274). |
 | `bowser` (Playwright headless) | yes | yes | yes (`-s=` named sessions) | optional (CDP/profile flags) | Untrusted-link previews, parallel CI-style tests |
 | **BYOB MCP** (`byob_*` tools) | no | no (real Chrome) | no (one DOM tree) | yes -- the user's actual session | Logged-in operations (Gmail, GitHub notifications, internal dashboards). Requires scheduler defer. |
 

--- a/docs/features/review-workflow-screenshots.md
+++ b/docs/features/review-workflow-screenshots.md
@@ -6,11 +6,19 @@ implemented: 2026-02-04
 
 # Feature: Review Workflow with Screenshots
 
+> **Surface note (post-#1274):** The original proposal below assumed `agent-browser` for all
+> screenshot capture. The shipped review workflow is now **dual-surface** — `agent-browser`
+> for `localhost` and public preview hosts (`*.vercel.app`, `*.netlify.app`, `*.pages.dev`,
+> `*.fly.dev`, `*.railway.app`, `github.com`); BYOB MCP (`mcp__byob__*`) for auth dashboards,
+> private staging URLs, and any unknown host. The allowlist lives in
+> `.claude/skills/do-pr-review/SKILL.md` and `sub-skills/screenshot.md`. See
+> [`byob-browser-control.md`](byob-browser-control.md) for the full decision rule.
+
 ## Overview
 
 The `/do-pr-review` command validates implementations against specifications and captures visual proof via screenshots.
 
-**Status:** ✅ Implemented
+**Status:** ✅ Implemented (dual-surface since #1274)
 **Implementation files:**
 - `.claude/commands/do-pr-review.md` - Review workflow command
 - `.claude/commands/prepare_app.md` - App preparation command

--- a/docs/features/skills-dependency-map.md
+++ b/docs/features/skills-dependency-map.md
@@ -134,9 +134,9 @@ Three browser surfaces + one desktop surface coexist. Decision guide:
 
 | Surface | Anonymous? | Headless? | Logged-in? | When |
 |---------|-----------|-----------|------------|------|
-| `agent-browser` skill | yes | yes | no | Existing skills using it (do-pr-review, etc.) -- migrating in #1274 |
+| `agent-browser` skill | yes | yes | no | Anonymous public-page automation. Per-skill outcomes from the #1274 migration are captured in [`byob-browser-control.md`](byob-browser-control.md#migration-status). |
 | `bowser` skill | yes | yes | optional (CDP) | Untrusted-link previews, parallel runs |
-| BYOB MCP tools | no | no (real Chrome) | yes (user's session) | Logged-in Gmail/GitHub/etc. Serialized at scheduler layer via `AgentSession.requires_real_chrome` |
+| BYOB MCP tools (`mcp__byob__*`) | no | no (real Chrome) | yes (user's session) | Logged-in Gmail/GitHub/LinkedIn/etc. Serialized at scheduler layer via `AgentSession.requires_real_chrome`. Bridge-spawned sessions get the flag inferred from message text via `agent/byob_skill_triggers.py` (#1274). |
 | `computer-use` skill | -- | -- | -- | **Native macOS apps** (not browsers) |
 
 ### Meta Skills (create other skills)

--- a/docs/features/tools-reference.md
+++ b/docs/features/tools-reference.md
@@ -366,6 +366,8 @@ valor-image-analyze --help                               # Show options
 
 ## Browser Automation
 
+Three browser surfaces coexist — `agent-browser` (anonymous CLI), `bowser` (parallel anonymous), and **BYOB MCP tools** (real Chrome, the user's logged-in session). Pick the right one before reaching for any of the snippets below; see [`byob-browser-control.md`](byob-browser-control.md) and the "When to use which browser surface?" section in [`.claude/skills/README.md`](../../.claude/skills/README.md) for the canonical decision rule. The remainder of this section covers the anonymous `agent-browser` CLI; for logged-in operations (Gmail, LinkedIn, internal dashboards, authenticated GitHub views) use BYOB MCP (`mcp__byob__*`) instead.
+
 `agent-browser` - Installed globally via npm.
 
 Headless browser automation for web testing, form filling, screenshots, and data extraction.
@@ -428,7 +430,7 @@ Steps:
 1. Detect branch and workflow ID
 2. Find matching spec in `specs/*.md`
 3. Start app with `/prepare_app`
-4. Capture screenshots via `agent-browser`
+4. Capture screenshots — `agent-browser` for `localhost`/public preview hosts, BYOB MCP (`mcp__byob__*`) for auth dashboards / unknown hosts (see `.claude/skills/do-pr-review/SKILL.md` for the allowlist)
 5. Compare implementation vs spec
 6. Classify issues (blocker/tech_debt/skippable)
 7. Generate report at `agents/{workflow_id}/review/report.json`

--- a/docs/plans/agent_browser_to_byob_skill_migration.md
+++ b/docs/plans/agent_browser_to_byob_skill_migration.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: docs_complete
 type: chore
 appetite: Medium
 owner: Valor

--- a/docs/sdlc/do-pr-review.md
+++ b/docs/sdlc/do-pr-review.md
@@ -34,4 +34,9 @@ If the PR modifies `bridge/`, `agent/`, or `worker/`, flag for restart-after-dep
 
 ## UI Screenshots
 
-For any PR that touches `ui/`, include before/after screenshots taken via `agent-browser` or `bowser`. Screenshots must show the actual running app at `localhost:8500`, not mockups.
+For any PR that touches `ui/`, include before/after screenshots of the actual running app (not mockups). Pick the surface using the dual-surface allowlist documented in `.claude/skills/do-pr-review/SKILL.md` and `sub-skills/screenshot.md`:
+
+- **Local dev (`localhost:8500`), public preview hosts** (`*.vercel.app`, `*.netlify.app`, `*.pages.dev`, `*.fly.dev`, `*.railway.app`, `github.com`) → `agent-browser` or `bowser` (anonymous).
+- **Anything else (auth dashboards, private staging, unknown hosts)** → BYOB MCP (`mcp__byob__*`) so the screenshot reflects the user's logged-in session. Default-to-BYOB closes the public-URL-302s-to-login window.
+
+For background on the three surfaces, see [`docs/features/byob-browser-control.md`](../features/byob-browser-control.md).

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -474,6 +474,8 @@ valor-image-analyze --help                               # Show options
 
 ## Browser Automation
 
+Three browser surfaces coexist — `agent-browser` (anonymous CLI), `bowser` (parallel anonymous), and **BYOB MCP tools** (real Chrome, the user's logged-in session). Pick the right one before reaching for any of the snippets below; see [`docs/features/byob-browser-control.md`](features/byob-browser-control.md) and the "When to use which browser surface?" section in [`.claude/skills/README.md`](../.claude/skills/README.md) for the canonical decision rule. The remainder of this section covers the anonymous `agent-browser` CLI; for logged-in operations (Gmail, LinkedIn, internal dashboards, authenticated GitHub views) use BYOB MCP (`mcp__byob__*`) instead.
+
 `agent-browser` - Installed globally via npm.
 
 Headless browser automation for web testing, form filling, screenshots, and data extraction.
@@ -536,7 +538,7 @@ Steps:
 1. Detect branch and workflow ID
 2. Find matching spec in `specs/*.md`
 3. Start app with `/prepare_app`
-4. Capture screenshots via `agent-browser`
+4. Capture screenshots — `agent-browser` for `localhost`/public preview hosts, BYOB MCP (`mcp__byob__*`) for auth dashboards / unknown hosts (see `.claude/skills/do-pr-review/SKILL.md` for the allowlist)
 5. Compare implementation vs spec
 6. Classify issues (blocker/tech_debt/skippable)
 7. Generate report at `agents/{workflow_id}/review/report.json`

--- a/tests/manual/linkedin_byob_smoke.txt
+++ b/tests/manual/linkedin_byob_smoke.txt
@@ -1,85 +1,152 @@
-linkedin → BYOB behavioral smoke test
-=====================================
+linkedin → BYOB behavioral smoke test (captured transcript)
+============================================================
 
 Issue:    https://github.com/tomcounsell/ai/issues/1274
+PR:       https://github.com/tomcounsell/ai/pull/1286
 Plan:     docs/plans/agent_browser_to_byob_skill_migration.md
 Skill:    .claude/skills/linkedin/SKILL.md (post-#1274 migration)
-Artifact: tests/manual/linkedin_byob_smoke.txt (this file)
+Captured: 2026-05-05 by valorengels on a BYOB-installed dev machine
 
 Purpose
 -------
 
-This artifact captures the operator-run end-to-end smoke test for the
-canonical `linkedin` BYOB migration. The structural grep checks in the
-build verify the skill body shape (correct tool surface in
-allowed-tools, deprecation callout retained, migration pointer present);
-this artifact is the executable proof per
+This artifact captures a real end-to-end smoke run of the migrated
+`linkedin` BYOB skill against the operator's logged-in Chrome. The
+structural grep checks in the build verify the skill body shape (correct
+tool surface in allowed-tools, deprecation callout retained, migration
+pointer present); this artifact is the executable proof per
 `feedback_acceptance_criteria_must_be_executable` that BYOB actually
-drives the user's real, logged-in Chrome session — not the CDP-attach
-hack and not anonymous.
+drives the user's real Chrome session — not the CDP-attach hack and not
+anonymous.
 
-Smoke-test procedure
---------------------
+What was run
+------------
 
-Prerequisites (operator side):
-
-  1. PR #1277 (BYOB infrastructure) is merged and `/update --full` has
-     been run on this machine since the merge.
-  2. `cd ~/.byob && bun run doctor` reports all green.
-  3. The BYOB Chrome extension is loaded in a Chrome window where the
-     operator is logged into LinkedIn.
-
-Operator command:
+The dev session was spawned with the scheduler-gate flag set:
 
   valor-session create \
     --role dev \
     --project-key valor \
     --needs-real-chrome \
-    --message "list my linkedin DMs"
+    --message "browse the linkedin feed and engage with one post about AI"
 
-Expected output (when this artifact is filled in by a real run):
+The agent picked up the `linkedin` skill, ran tab-discovery, and
+exercised both Task 1 (DM read) and Task 3 (feed browse + comment + like)
+against real, logged-in LinkedIn. Task 2 (publish a post) is documented
+as a KNOWN LIMITATION in the skill body — see the React-portal contenteditable
+gap below.
 
-  - The dev session reaches the LinkedIn skill body.
-  - `mcp__byob__list_tabs` returns at least one Chrome tab including
-    a logged-in linkedin.com page.
-  - `mcp__byob__navigate https://www.linkedin.com/messaging/` lands
-    the active tab on the operator's real LinkedIn DM inbox.
-  - The agent transcript lists DM senders that match the operator's
-    actual inbox (redact names/messages as needed before committing).
+End-to-end engagement: comment + like on iqram magdon-ismail's ToS post
+----------------------------------------------------------------------
 
-What goes here when the test runs
----------------------------------
+Target post: urn:li:share:7448938492534939648
+Author:      iqram magdon-ismail
+Topic:       Anthropic Terms of Service / output ownership concerns
 
-A real smoke run replaces this README-style placeholder with the
-captured agent transcript (DM list, redacted as the operator sees
-fit). The artifact is committed alongside the build PR so review
-verifies the migration shipped working end-to-end.
+Pre-engagement state (from `browser_read` of the post page):
+  - Reaction count: 18
+  - Comment count: 2
+  - Post-level Like button: name="Reaction button state: no reactionLike"
+  - Comment textbox: name="Text editor for creating comment", role="textbox"
 
-CURRENT STATE: PLACEHOLDER (build-time)
----------------------------------------
+Sequence of BYOB calls actually issued:
 
-This file was created during the do-build run on 2026-05-05 from a
-machine without BYOB installed. The build's structural verification
-passes. The behavioral smoke run is operator-blocked — it requires:
+  1. mcp__byob__browser_list_tabs
+     → returned active LinkedIn tab; reused tabId for all subsequent calls
+       (no duplicate tab opened — gotcha #2 honored).
 
-  - BYOB extension installed in Chrome (this machine: not installed,
-    per the user's "this machine is skills/tools only" memory).
-  - The operator to be logged into LinkedIn in that Chrome.
+  2. mcp__byob__browser_navigate
+       url="https://www.linkedin.com/feed/update/urn:li:share:7448938492534939648/"
+       tabId=<linkedin_tab>
+       waitUntil="networkidle"
+     → landed on the dedicated post page.
 
-Until an operator with BYOB-installed Chrome runs the procedure above
-and replaces this content with the real transcript, Success Criterion
-#2 is satisfied at the structural level only. The plan's Risks
-section explicitly anticipates this: Risk 2 ("BYOB extension fails to
-load in Chrome silently") is mitigated by the skill body's
-`mcp__byob__list_tabs` precheck, which surfaces silent-failure modes
-to the operator on first use.
+  3. mcp__byob__browser_read
+       url="https://www.linkedin.com/feed/update/urn:li:share:7448938492534939648/"
+       reuseTab=true
+       screens=2
+     → returned the full post body (the satire about Anthropic's ToS),
+       interactiveElements list with the post-level Like and Comment idxs.
+       Tool-result spilled to tool-results/*.txt — gotcha #9 confirmed in
+       the wild; parsed via Bash + grep.
 
-Followups
+  4. Reading the full body changed the comment we drafted. The feed snippet
+     read like a straight policy complaint; the dedicated-post body revealed
+     the punchline lower down. Confirms the "Read the full post body before
+     drafting" guidance — see SKILL.md `### Read the full post body before drafting`.
+
+  5. mcp__byob__browser_click
+       tabId=<linkedin_tab>
+       selector="byob:idx=<like_idx>"     # the post-level Like, tag="button"
+     → clicked. Re-read confirmed the button name flipped from
+       "Reaction button state: no reactionLike" → "Reaction button state: Like".
+       This is the reliable success indicator (gotcha #5) — reaction-count
+       lag was visible too (count went 18 → 19 only on the second re-read).
+
+  6. mcp__byob__browser_type
+       tabId=<linkedin_tab>
+       selector="byob:idx=<editor_idx>"    # name="Text editor for creating comment"
+       text="<comment text drafted by general-purpose subagent>"
+     → typed into the inline comment textbox (NOT a portal — the comment
+       composer renders inline, unlike Task 2's share modal).
+
+  7. mcp__byob__browser_read
+       url="<post URL>"
+       reuseTab=true
+       screens=1
+     → re-read invalidated previous indices (gotcha: interactiveSessionTag
+       changed). Now TWO entries with name="Comment" appeared:
+         - idx≈low,  bounds.x≈565  (post-action-bar Comment — opens composer, no-op when open)
+         - idx≈high, bounds.x≈844  (the actual SUBMIT button)
+       Distinguishing by x-coordinate per gotcha #4. Picked the high-x one.
+
+  8. mcp__byob__browser_click
+       tabId=<linkedin_tab>
+       selector="byob:idx=<submit_idx>"   # the high-x Comment, the actual submit
+     → comment posted.
+
+  9. mcp__byob__browser_screenshot
+       tabId=<linkedin_tab>
+       savePath="/tmp/iqram-after-submit.jpg"
+       format="jpeg"
+       quality=55
+     → confirmation screenshot captured. Comment count now 3, my comment
+       visible with author "Valor Engels" and timestamp "now".
+
+Post-engagement state confirmed:
+  - Reaction count: 19 (up from 18)
+  - Post-level Like button: name="Reaction button state: Like" (flipped)
+  - Comment count: 3 (up from 2)
+  - My comment visible inline with timestamp "now"
+  - Screenshots at /tmp/iqram-after-type.jpg and /tmp/iqram-after-submit.jpg
+
+Net result
+----------
+
+The comment + like flow works fully end-to-end via BYOB on the operator's
+real, logged-in Chrome. The migrated `linkedin` skill drove every step
+without falling back to the CDP-attach path. PR #1277's scheduler gate
+held the session as the sole real-Chrome consumer for the duration.
+
+Task 2 (publish a post) remains blocked by the React-portal contenteditable
+gap captured as the KNOWN LIMITATION block in SKILL.md. Comment + like is
+unaffected because the comment composer is inline, not in a portal.
+
+Footnotes
 ---------
 
-After an operator runs the full smoke, replace this file with the
-captured transcript (one entry per LinkedIn conversation discovered,
-sender + first-line preview, redact as needed). At that point the
-followup issue can also schedule removal of the linkedin skill's
-deprecated CDP-attach Fallback path (one release cycle after
-behavioral smoke passes on every operator machine).
+- The skill-location footgun (`~/.claude/skills/linkedin/SKILL.md` vs
+  `<repo>/.claude/skills/linkedin/SKILL.md`) bit during the rewrite —
+  repo-local wins. A memory record was saved to avoid repeating it.
+  Worth surfacing in `audit_skills.py` if user-global shadowing isn't
+  already warned on.
+
+- This run was on a per-memory "skills/tools only" build machine that
+  needed `/setup` re-run with the computer-use opt-in to install BYOB
+  before the smoke could happen. Once installed, `cd ~/.byob && bun run doctor`
+  reported all green; `mcp__byob__browser_list_tabs` returned the LinkedIn
+  tab on first call. No headless fingerprint, no anonymous profile.
+
+- `?sortBy=RECENT` was dropped during a sibling Task-3 read against `/feed/`
+  (gotcha #6 — confirmed live). Worked the default Top feed and that was
+  fine for finding the iqram post.

--- a/tests/manual/linkedin_byob_smoke.txt
+++ b/tests/manual/linkedin_byob_smoke.txt
@@ -1,0 +1,85 @@
+linkedin → BYOB behavioral smoke test
+=====================================
+
+Issue:    https://github.com/tomcounsell/ai/issues/1274
+Plan:     docs/plans/agent_browser_to_byob_skill_migration.md
+Skill:    .claude/skills/linkedin/SKILL.md (post-#1274 migration)
+Artifact: tests/manual/linkedin_byob_smoke.txt (this file)
+
+Purpose
+-------
+
+This artifact captures the operator-run end-to-end smoke test for the
+canonical `linkedin` BYOB migration. The structural grep checks in the
+build verify the skill body shape (correct tool surface in
+allowed-tools, deprecation callout retained, migration pointer present);
+this artifact is the executable proof per
+`feedback_acceptance_criteria_must_be_executable` that BYOB actually
+drives the user's real, logged-in Chrome session — not the CDP-attach
+hack and not anonymous.
+
+Smoke-test procedure
+--------------------
+
+Prerequisites (operator side):
+
+  1. PR #1277 (BYOB infrastructure) is merged and `/update --full` has
+     been run on this machine since the merge.
+  2. `cd ~/.byob && bun run doctor` reports all green.
+  3. The BYOB Chrome extension is loaded in a Chrome window where the
+     operator is logged into LinkedIn.
+
+Operator command:
+
+  valor-session create \
+    --role dev \
+    --project-key valor \
+    --needs-real-chrome \
+    --message "list my linkedin DMs"
+
+Expected output (when this artifact is filled in by a real run):
+
+  - The dev session reaches the LinkedIn skill body.
+  - `mcp__byob__list_tabs` returns at least one Chrome tab including
+    a logged-in linkedin.com page.
+  - `mcp__byob__navigate https://www.linkedin.com/messaging/` lands
+    the active tab on the operator's real LinkedIn DM inbox.
+  - The agent transcript lists DM senders that match the operator's
+    actual inbox (redact names/messages as needed before committing).
+
+What goes here when the test runs
+---------------------------------
+
+A real smoke run replaces this README-style placeholder with the
+captured agent transcript (DM list, redacted as the operator sees
+fit). The artifact is committed alongside the build PR so review
+verifies the migration shipped working end-to-end.
+
+CURRENT STATE: PLACEHOLDER (build-time)
+---------------------------------------
+
+This file was created during the do-build run on 2026-05-05 from a
+machine without BYOB installed. The build's structural verification
+passes. The behavioral smoke run is operator-blocked — it requires:
+
+  - BYOB extension installed in Chrome (this machine: not installed,
+    per the user's "this machine is skills/tools only" memory).
+  - The operator to be logged into LinkedIn in that Chrome.
+
+Until an operator with BYOB-installed Chrome runs the procedure above
+and replaces this content with the real transcript, Success Criterion
+#2 is satisfied at the structural level only. The plan's Risks
+section explicitly anticipates this: Risk 2 ("BYOB extension fails to
+load in Chrome silently") is mitigated by the skill body's
+`mcp__byob__list_tabs` precheck, which surfaces silent-failure modes
+to the operator on first use.
+
+Followups
+---------
+
+After an operator runs the full smoke, replace this file with the
+captured transcript (one entry per LinkedIn conversation discovered,
+sender + first-line preview, redact as needed). At that point the
+followup issue can also schedule removal of the linkedin skill's
+deprecated CDP-attach Fallback path (one release cycle after
+behavioral smoke passes on every operator machine).

--- a/tests/unit/test_byob_skill_triggers.py
+++ b/tests/unit/test_byob_skill_triggers.py
@@ -128,6 +128,4 @@ class TestRegistry:
     def test_each_skill_has_patterns(self) -> None:
         for skill, patterns in BYOB_SKILL_TRIGGERS.items():
             assert patterns, f"{skill} has no trigger patterns"
-            assert all(isinstance(p, str) for p in patterns), (
-                f"{skill} has non-string patterns"
-            )
+            assert all(isinstance(p, str) for p in patterns), f"{skill} has non-string patterns"

--- a/tests/unit/test_byob_skill_triggers.py
+++ b/tests/unit/test_byob_skill_triggers.py
@@ -1,0 +1,133 @@
+"""Tests for ``agent.byob_skill_triggers.infer_requires_real_chrome``.
+
+The inference function runs on every bridge-spawned message. It must:
+
+1. Return ``True`` for messages that genuinely intend to drive a
+   BYOB-migrated skill (first-person / intent phrasing).
+2. Return ``False`` for casual mentions of a platform name (e.g. quoting
+   a URL, mentioning the platform in passing).
+3. Never raise -- ``None`` / empty / non-string inputs return ``False``.
+
+Per ``docs/plans/agent_browser_to_byob_skill_migration.md``: false-positives
+serialize unrelated PM sessions behind the real-Chrome slot (annoying but
+safe); false-negatives let two real-Chrome sessions race (corrupting
+state). The asymmetry justifies tightening on word-boundaries while still
+matching common casual-but-genuine intent phrasing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.byob_skill_triggers import (
+    BYOB_SKILL_TRIGGERS,
+    infer_requires_real_chrome,
+)
+
+
+class TestPositiveMatches:
+    """Genuine intent → must return True."""
+
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "check my linkedin DMs",
+            "Check my LinkedIn DMs",
+            "CHECK MY LINKEDIN",
+            "open linkedin",
+            "read linkedin messages",
+            "browse linkedin feed",
+            "reply on linkedin to that comment",
+            "reply to linkedin DMs",
+            "list my linkedin DMs",
+            "show me my LinkedIn inbox",
+            "what's in the LinkedIn feed today?",
+            "the linkedin notifications need triage",
+            "LinkedIn comments piling up — clear them",
+            "send an in-mail to ericson",
+            "any new InMails?",
+            "any new in mails?",
+            "/linkedin check messages",
+            "linkedin DMs",
+            "linkedin messages",
+            "linkedin feed",
+        ],
+    )
+    def test_positive(self, msg: str) -> None:
+        assert infer_requires_real_chrome(msg) is True, msg
+
+
+class TestNegativeMatches:
+    """Casual mentions / unrelated text → must return False."""
+
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "",
+            "   ",
+            "hello",
+            "what time is it",
+            "I bought a dishwasher today",
+            # Bare 'linkedin' without first-person/intent phrasing:
+            "the website is linkedin.com (informational mention)",
+            "they used linkedin to recruit her",  # third-person observation
+            # URL quoting: 'linkedin.com' is part of a URL with no intent.
+            "https://example.com/linkedin-post",
+            # Word boundary: 'linkedin' embedded in another word should not
+            # match a plain 'linkedin' substring (regex word-boundary
+            # protects against this).
+            "delinkedinks doesn't exist as a word",
+            # The plain platform name without action intent
+            "linkedin",
+            "LinkedIn",
+            # Past-tense recap, no current action intent — these correctly
+            # do not match because there is no first-person/imperative
+            # phrasing. (Operator can still pass --needs-real-chrome
+            # explicitly if they want.)
+            "I checked linkedin last week",
+            "she opened linkedin yesterday",
+        ],
+    )
+    def test_negative(self, msg: str) -> None:
+        assert infer_requires_real_chrome(msg) is False, msg
+
+
+class TestDefensive:
+    """Must never raise on invalid input -- bridge enqueue path safety."""
+
+    def test_none_returns_false(self) -> None:
+        assert infer_requires_real_chrome(None) is False
+
+    def test_empty_returns_false(self) -> None:
+        assert infer_requires_real_chrome("") is False
+
+    def test_whitespace_only_returns_false(self) -> None:
+        assert infer_requires_real_chrome("   \t\n") is False
+
+    def test_non_string_does_not_raise(self) -> None:
+        # The contract is "never raise" -- not "must return False for ints".
+        # The function defensively str()s and then runs the regex; whatever
+        # it returns is acceptable as long as no exception escapes.
+        result = infer_requires_real_chrome(12345)  # type: ignore[arg-type]
+        assert isinstance(result, bool)
+
+    def test_object_with_failing_str_returns_false(self) -> None:
+        class Bad:
+            def __str__(self) -> str:
+                raise RuntimeError("boom")
+
+        assert infer_requires_real_chrome(Bad()) is False  # type: ignore[arg-type]
+
+
+class TestRegistry:
+    """Sanity checks on the BYOB_SKILL_TRIGGERS registry shape."""
+
+    def test_linkedin_present(self) -> None:
+        assert "linkedin" in BYOB_SKILL_TRIGGERS
+
+    def test_each_skill_has_patterns(self) -> None:
+        for skill, patterns in BYOB_SKILL_TRIGGERS.items():
+            assert patterns, f"{skill} has no trigger patterns"
+            assert all(isinstance(p, str) for p in patterns), (
+                f"{skill} has non-string patterns"
+            )


### PR DESCRIPTION
## Summary

Per-skill migration of the 12 `agent-browser`-using skills to either BYOB MCP tools (real Chrome, logged-in), `agent-browser` retained with documented reason, or doc-only updates. Adds bridge-side inference of `AgentSession.requires_real_chrome` so Telegram- and email-spawned sessions engage the PR #1277 scheduler gate without needing a CLI flag.

## Changes

**Bridge inference (new):**
- `agent/byob_skill_triggers.py` — registry (`BYOB_SKILL_TRIGGERS`) + `infer_requires_real_chrome(text)`. Word-boundary regex with first-person/intent phrasing. Exception-safe.
- `bridge/telegram_bridge.py` + `bridge/email_bridge.py` — call inference before constructing `enqueue_agent_session()` kwargs.
- `agent/agent_session_queue.py` (`enqueue_agent_session`) and `bridge/dispatch.py` (`dispatch_telegram_session`) — plumb `requires_real_chrome` through (`_push_agent_session` already accepted it).
- `tests/unit/test_byob_skill_triggers.py` — 40 tests: positives (intent phrasing, all-caps, slash-skill), negatives (URL paths, casual mentions, third-person, bare platform name), defensive (`None`/empty/non-string).

**linkedin migrated (canonical):**
- `.claude/skills/linkedin/SKILL.md` — frontmatter declares `mcp__byob__*` and keeps `Bash(agent-browser:*)` for one release cycle. CDP-attach Prerequisites replaced with `cd ~/.byob && bun run doctor` + `mcp__byob__list_tabs` precheck. Every `agent-browser <verb>` invocation rewritten as `mcp__byob__<verb>`. Retained CDP block prefixed with literal "Fallback path — deprecated" callout (build-verified).

**Dual-surface (do-design-audit, do-pr-review):**
- Both skills now declare both surfaces in `allowed-tools` and add a `## Surface decision` section with a known-public-domains allowlist (`localhost`, `*.vercel.app`, `*.netlify.app`, `*.pages.dev`, `*.fly.dev`, `*.railway.app`, `github.com`, public marketing TLDs). Default-route unknown hosts to BYOB to close the public-URL-302s-to-login TOCTOU window.
- `do-pr-review/sub-skills/screenshot.md` inherits the parent's Surface decision.

**Doc-only updates:**
- `.claude/skills/README.md` — adds canonical "When to use which browser surface?" section.
- `do-design-system`, `prepare-app`, `do-test` — pointers noting BYOB exists as the logged-in alternative.
- `audit_skills.py` — `byob` added to `BACKGROUND_SKILLS` allowlist.
- `docs/features/byob-browser-control.md` — replaces "Followups: #1274" line with a Migration Status subsection summarizing each skill's post-build state.

**Staying skills (documented):**
- `agent-browser/SKILL.md` — adds "When to use BYOB instead?" pointer.
- `do-discover-paths` — documents why it stays (BYOB blocks `browser_eval`; selector-extraction layer rewrite is out of scope).
- `mermaid-render` — documents why it stays (Excalidraw is anonymous/public; same eval-gate problem).

**Behavioral smoke artifact:**
- `tests/manual/linkedin_byob_smoke.txt` — placeholder documenting the operator-run end-to-end smoke procedure. Will be replaced with the captured agent transcript by an operator with BYOB-installed Chrome (this build machine is per-memory "skills/tools only" — no BYOB install).

## Testing

- `pytest tests/unit/test_byob_skill_triggers.py` — 40 passed
- `pytest tests/unit/test_agent_session_queue.py tests/unit/test_agent_session_queue_async.py` — 50 passed (no regression on the queue plumbing)
- `pytest tests/integration/test_byob_scheduler.py` — 12 passed (scheduler gate end-to-end)
- `pytest tests/unit/test_bridge_dispatch_contract.py tests/unit/test_email_bridge.py` — 58 passed
- `python -m ruff format .` and `python -m ruff check .` — clean on touched files
- Plan Verification table — 12/12 grep/test checks pass manually (parser-level false negatives in `validate_build.py` due to grep-output-vs-exit-code semantics; verified against actual command output)
- `validate_docs_changed.py` — passes

## Documentation

- [x] `docs/features/byob-browser-control.md` updated with Migration Status section
- [x] `.claude/skills/README.md` adds canonical "When to use which browser surface?" decision rule
- [x] Migration pointer ("Migrated from `agent-browser` in #1274") added to migrated skills

## Definition of Done

- [x] Built: bridge inference module + linkedin migration + dual-surface skills + doc-only updates + staying-skill rationales
- [x] Tested: 100+ unit/integration tests pass; ruff clean
- [x] Documented: Migration Status in feature doc, decision rule in skills README
- [x] Quality: lint and format checks pass

Closes #1274