### PR TITLE
test: speed up unit suite via slow marks, fixture cache, terser output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ python_files = ["test_*.py"]
 python_functions = ["test_*"]
 # -p no:postgresql: disable pytest-postgresql plugin which crashes on systems where
 # psycopg/libpq is not installed (see issue #265)
-addopts = "-v --tb=short -p no:postgresql"
+addopts = "--tb=short -p no:postgresql"
 asyncio_mode = "auto"
 markers = [
     "unit: Pure logic tests, no external dependencies",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,30 @@ def mock_claude_sdk_cleanup():
             del sys.modules[mod_key]
 
 
+# Cache of popoto modules that hold a `POPOTO_REDIS_DB` symbol. Built lazily
+# and refreshed only when sys.modules grows, so we don't walk all of
+# sys.modules per test (was ~1500 entries × thousands of tests).
+_POPOTO_MODULE_CACHE: list[object] = []
+_POPOTO_MODULE_CACHE_KEY: int = -1
+
+
+def _popoto_modules_with_redis_db():
+    """Return the list of popoto submodules holding a `POPOTO_REDIS_DB` symbol,
+    refreshing the cache only when sys.modules has grown since last call."""
+    import sys as _sys
+
+    global _POPOTO_MODULE_CACHE, _POPOTO_MODULE_CACHE_KEY
+    cur = len(_sys.modules)
+    if cur != _POPOTO_MODULE_CACHE_KEY:
+        _POPOTO_MODULE_CACHE = [
+            mod
+            for name, mod in _sys.modules.items()
+            if mod is not None and name.startswith("popoto") and hasattr(mod, "POPOTO_REDIS_DB")
+        ]
+        _POPOTO_MODULE_CACHE_KEY = cur
+    return _POPOTO_MODULE_CACHE
+
+
 @pytest.fixture(autouse=True)
 def redis_test_db(request):
     """Switch popoto to a dedicated test Redis client for ALL tests.
@@ -98,6 +122,15 @@ def redis_test_db(request):
     Also resets the async Redis connection to use the same db, since popoto v1.0.0b2
     maintains a separate _POPOTO_ASYNC_REDIS_DB connection.
     """
+    import sys as _sys
+
+    # Fast path: if popoto isn't imported yet, this test cannot touch Redis
+    # via Popoto. Pure-logic tests that run before any popoto import skip
+    # flushdb + the patching dance entirely.
+    if "popoto.redis_db" not in _sys.modules:
+        yield
+        return
+
     import popoto.redis_db as rdb
     import redis
     import redis.asyncio as aioredis
@@ -124,15 +157,10 @@ def redis_test_db(request):
     # module that has a local POPOTO_REDIS_DB symbol. Without this, sync
     # reads/writes route to whichever db was active at import (often
     # production), and async vs. sync reads diverge.
-    import sys as _sys
-
     _patched_popoto_modules: list[tuple[object, object]] = []
-    for _modname, _mod in list(_sys.modules.items()):
-        if _mod is None or not _modname.startswith("popoto"):
-            continue
-        if hasattr(_mod, "POPOTO_REDIS_DB"):
-            _patched_popoto_modules.append((_mod, _mod.POPOTO_REDIS_DB))
-            _mod.POPOTO_REDIS_DB = test_client
+    for _mod in _popoto_modules_with_redis_db():
+        _patched_popoto_modules.append((_mod, _mod.POPOTO_REDIS_DB))
+        _mod.POPOTO_REDIS_DB = test_client
 
     # Reset async Redis connection to point at the same test db.
     rdb._POPOTO_ASYNC_REDIS_DB = aioredis.Redis(db=test_db)

--- a/tests/unit/test_media_handling.py
+++ b/tests/unit/test_media_handling.py
@@ -205,6 +205,7 @@ class TestProcessIncomingMedia:
             assert files == []
 
 
+@pytest.mark.slow
 class TestDescribeImage:
     """Tests for describe_image function using Claude Haiku 4.5 vision.
 

--- a/tests/unit/test_message_drafter.py
+++ b/tests/unit/test_message_drafter.py
@@ -254,6 +254,7 @@ class TestDraftMessage:
         assert result.was_drafted is True
 
 
+@pytest.mark.slow
 class TestDraftMessageIntegration:
     """Integration test with real Haiku API call."""
 

--- a/tests/unit/test_pr_shape_cache.py
+++ b/tests/unit/test_pr_shape_cache.py
@@ -245,6 +245,7 @@ def test_concurrent_writers_serialize(cache_paths):
     assert e2 is not None
 
 
+@pytest.mark.slow
 def test_lock_timeout_skips_write_without_raising(cache_paths, monkeypatch):
     """Holding the lock for >timeout causes write_verdict to log + return False."""
     cache, lock, baseline = cache_paths

--- a/tests/unit/test_steering_mechanism.py
+++ b/tests/unit/test_steering_mechanism.py
@@ -7,6 +7,8 @@ Covers:
 4. valor-session CLI — help output and basic argument parsing
 """
 
+import pytest
+
 
 class TestOutputRouterExports:
     """Verify agent.output_router exports all expected symbols."""
@@ -287,6 +289,7 @@ class TestValorSessionCLI:
         assert hasattr(vs, "main")
         assert callable(vs.main)
 
+    @pytest.mark.slow
     def test_help_exits_zero(self):
         """--help should exit with code 0."""
         import subprocess
@@ -300,6 +303,7 @@ class TestValorSessionCLI:
         assert result.returncode == 0
         assert "valor-session" in result.stdout
 
+    @pytest.mark.slow
     def test_subcommands_present_in_help(self):
         import subprocess
         import sys
@@ -312,6 +316,7 @@ class TestValorSessionCLI:
         for cmd in ("create", "steer", "status", "list", "kill"):
             assert cmd in result.stdout, f"Subcommand '{cmd}' missing from help output"
 
+    @pytest.mark.slow
     def test_steer_requires_message(self):
         """valor-session steer --id X should fail without --message."""
         import subprocess

--- a/tests/unit/test_worker_entry.py
+++ b/tests/unit/test_worker_entry.py
@@ -59,6 +59,7 @@ class TestWorkerArgParsing:
         assert args.dry_run is True
 
 
+@pytest.mark.slow
 class TestWorkerDryRun:
     """Test worker dry-run mode via subprocess."""
 

--- a/tests/unit/test_youtube_search.py
+++ b/tests/unit/test_youtube_search.py
@@ -229,6 +229,7 @@ class TestCLI:
 
 
 @pytest.mark.integration
+@pytest.mark.slow
 class TestSearchIntegration:
     """Integration tests that hit real YouTube. Require network."""
 


### PR DESCRIPTION
## Summary

Three of four candidate speedups from a post-#1285 experiment land here. The fourth (`-n auto` in default `addopts`) was rolled back because it breaks 5 xdist-unsafe integration tests — those are tracked in #1289 as the next step.

**Measured on `tests/unit/` (6185 tests, 1 skipped):**

| Variant | Time | Δ |
|---|---|---|
| Baseline (serial, `-v`) | 235s | — |
| With this PR (serial) | 168s | **-28%** |
| With this PR + `-n auto` | **56s** | **-76%** |

The 4× win is already available via the existing documented inner-loop command `pytest tests/unit/ -n auto`; this PR makes that path faster too and trims the default-output path for environments that can't use xdist (e.g. the merge gate's full-suite run, until #1289 lands).

## Changes

- **`pyproject.toml`**: drop `-v` from default `addopts`. `-v` writes ~6000 lines per full run and forces flushes; saves ~20s serial. Merge gate already overrides with `-q` so unaffected there.
- **`tests/conftest.py`**: cache the popoto-modules-with-`POPOTO_REDIS_DB` list with a `sys.modules`-length sentinel, refreshing only when modules grow. Was walking ~1500 entries per test; now O(1) on cache hit. Also adds a fast-path that skips the whole patching dance for tests that haven't imported `popoto.redis_db` yet.
- **5 unit tests** get `@pytest.mark.slow`: subprocess-spawning and real-API tests (worker dry-run, valor-session CLI help, real Haiku summarization, real image description, real YouTube search, `pr_shape_cache` lock-timeout). Default suite still runs them — opt-out via `-m "not slow"`. **No semantic change to the merge gate.**

## Why not all four?

The fourth candidate was `-n auto` in default `addopts` — saves 75% but breaks 5 integration tests under xdist:

- `test_design_system_pipeline.py::test_check_detects_mutation`, `::test_fixture_design_md_passes_lint`
- `test_stage_comment.py::TestStageCommentIntegration::test_post_and_fetch_stage_comment`
- `test_agent_session_scheduler.py::TestKillCommandIntegration::test_status_shows_killed_count`, `::TestJobSchedulerCLI::test_push_and_pop`

All pass serially. Root cause for the scheduler tests is confirmed at `tests/integration/test_agent_session_scheduler.py:35` (`env["REDIS_URL"] = "redis://127.0.0.1:6379/1"` hardcodes db=1, ignoring xdist worker isolation). Tracked in #1289.

## Test plan

- [x] `pytest tests/unit/ -q --tb=no -p no:cacheprovider` — 6185 passed, 1 skipped (matches baseline counts)
- [x] `pytest tests/unit/ -n auto -q --tb=no -p no:cacheprovider` — 6185 passed, 1 skipped (no xdist regressions in unit)
- [x] `pytest tests/unit/ -q --tb=no -m "not slow" -p no:cacheprovider` — 6172 passed, 1 skipped, 13 deselected (slow filter behaves)
- [x] Verified via timing that the durations top-20 dropped by ~70s when `-m "not slow"` is applied
- [ ] Merge gate cycle once on this branch to confirm `pytest tests/ -q --tb=no --junitxml=...` still produces a valid junit XML and matching baseline (the merge gate overrides addopts with `-q`, so dropping `-v` is a pure no-op for it)

Closes nothing on its own — companion follow-up is #1289.