### PR TITLE
docs: fix stale test refs and add tracking header (#1257, #1265, #1266)

### DIFF
--- a/docs/features/adding-reflection-tasks.md
+++ b/docs/features/adding-reflection-tasks.md
@@ -73,7 +73,9 @@ Every step must follow these conventions:
 
 ## Test Pattern
 
-Add a test class to `tests/test_reflections.py`. The standard test structure covers three cases:
+Reflection tests live in `tests/unit/test_reflections_*.py` (split by topic — see `test_reflections_scheduling.py`, `test_reflections_memory.py`, `test_reflections_auditing.py`, `test_reflections_report.py`, `test_reflections_multi_repo.py`, `test_reflections_package.py`, plus `test_reflection_model.py` and `test_reflection_scheduler.py`; integration coverage lives in `tests/integration/test_reflections_redis.py`).
+
+Add a test class to whichever file in the family best matches the area your step touches. If none fit, create a new `tests/unit/test_reflections_<topic>.py`. The standard test structure covers three cases:
 
 ```python
 class TestYourStepName:
@@ -133,9 +135,9 @@ When adding a new step:
 - [ ] Create `step_<key>` method following the template above
 - [ ] Register as `(N, "Step Name", self.step_<key>)` in `self.steps`
 - [ ] Update the module docstring step list at the top of `scripts/reflections.py`
-- [ ] Add test class to `tests/test_reflections.py` with the three standard test cases
+- [ ] Add test class to the appropriate `tests/unit/test_reflections_<topic>.py` (or create a new one if none fit) with the three standard test cases
 - [ ] Update `docs/features/reflections.md` step count and table
-- [ ] Run `pytest tests/test_reflections.py -x -q` to verify
+- [ ] Run `pytest tests/unit/test_reflections_<topic>.py -x -q` to verify (or `pytest -k reflections -x -q` for the whole family)
 
 ## Reference Implementation
 

--- a/docs/features/agent-message-delivery.md
+++ b/docs/features/agent-message-delivery.md
@@ -76,7 +76,8 @@ The Teammate persona prompt includes a DELIVERY REVIEW section explaining the ch
 ## Test Coverage
 
 - `tests/unit/test_stop_hook_review.py` — Review gate activation, transcript reading, false stop detection, choice parsing, state management, integration tests
-- `tests/unit/test_delivery_execution.py` — send/react/silent/fallthrough paths
+- `tests/unit/test_tool_call_delivery.py` — `classify_delivery_outcome`'s send/react/continue/silent outcomes (plus the legacy `send_telegram` alias) and the second-stop tool-call review-gate flow
+- `tests/unit/test_duplicate_delivery.py` — Duplicate-delivery prevention: catchup Redis dedup checks and auto-continue skips for completed sessions
 - `tests/unit/test_qa_handler.py` — Teammate prompt humility markers, review gate awareness
 - `tests/e2e/test_message_pipeline.py` — Bool classifier assertions
 

--- a/docs/plans/sdlc-1111.md
+++ b/docs/plans/sdlc-1111.md
@@ -1,5 +1,7 @@
 # Plan: Shared AsyncAnthropic rate-limit semaphore (#1111)
 
+**Tracking issue:** [#1111](https://github.com/tomcounsell/ai/issues/1111) (closed, shipped via [#1120](https://github.com/tomcounsell/ai/pull/1120))
+
 ## Problem
 
 Five independent call sites (plus one hotfix-protected site in


### PR DESCRIPTION
## Summary

Bundled doc surgery — three independent doc-only fixes consolidated into one PR (per dispatch).

- **#1257** — `docs/features/adding-reflection-tasks.md` referenced the deleted `tests/test_reflections.py`. Updated the Test Pattern intro and the contributor checklist to point at the current `tests/unit/test_reflections_*.py` family (with the integration counterpart noted), so a contributor following the doc lands in a real, runnable test file.
- **#1265** — `docs/features/agent-message-delivery.md` Test Coverage section referenced the deleted `tests/unit/test_delivery_execution.py`. Replaced with the actual current delivery-path tests:
  - `tests/unit/test_tool_call_delivery.py` — `classify_delivery_outcome`'s send/react/continue/silent outcomes (plus the legacy `send_telegram` alias) and the second-stop tool-call review-gate flow.
  - `tests/unit/test_duplicate_delivery.py` — duplicate-delivery prevention via catchup Redis dedup and completed-session auto-continue skip.
- **#1266** — `docs/plans/sdlc-1111.md` was missing a tracking-issue link (orphan-plan auditor flag). Added a `**Tracking issue:**` header pointing at issue #1111 (closed) and shipping PR #1120.

## Scope

Doc surgery only. No code, no test, no dependency changes.

## Test plan

- [x] No code changed → no tests to run
- [x] All three referenced test files verified to exist on disk before being cited
- [x] Diff is exclusively in `docs/`

Closes #1257
Closes #1265
Closes #1266