### PR TITLE
fix(#1289): xdist-safe integration tests + -n auto by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,10 +143,10 @@ valor-email threads
 | `./scripts/valor-service.sh email-dead-letter list` | List failed SMTP sends in dead-letter queue |
 | `./scripts/valor-service.sh email-dead-letter replay --all` | Replay all dead-lettered emails |
 | `tail -f logs/bridge.log` | Stream bridge logs |
-| `pytest tests/` | Run all tests |
-| `pytest tests/unit/` | Run unit tests only (fast, ~60s) |
-| `pytest tests/unit/ -n auto` | Run unit tests in parallel |
-| `pytest tests/integration/` | Run integration tests only |
+| `pytest tests/` | Run all tests (parallel by default — `-n auto --dist=loadfile` from `pyproject.toml`) |
+| `pytest tests/unit/` | Run unit tests only (~40s parallel) |
+| `pytest tests/unit/ -n0` | Force serial unit run (e.g. for debugging) |
+| `pytest tests/integration/` | Run integration tests only (~125s parallel) |
 | `pytest -m sdlc` | Run tests for a specific feature (see `tests/README.md`) |
 | `python -m ruff format . && python -m ruff check .` | Format and lint |
 | `python -m ui.app` | Start web UI server on localhost:8500 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,16 @@ python_files = ["test_*.py"]
 python_functions = ["test_*"]
 # -p no:postgresql: disable pytest-postgresql plugin which crashes on systems where
 # psycopg/libpq is not installed (see issue #265)
-addopts = "--tb=short -p no:postgresql"
+# -n auto: parallelize via pytest-xdist (workers per CPU). Tests that require
+# raw Redis access must use the per-worker `redis_test_url` fixture or read
+# `PYTEST_XDIST_WORKER` to pick the matching db (see tests/conftest.py).
+# --dist=loadfile: keep all tests in one file on the same worker. Three
+# integration files (test_design_system_pipeline.py, test_remote_update.py,
+# test_stage_comment.py) share global resources between their tests (npm
+# caches, host lockfiles, a single GitHub issue) and would otherwise fail
+# under inter-test parallelism. Loadfile is the simplest scheduler that
+# fixes that while preserving inter-file parallelism.
+addopts = "--tb=short -p no:postgresql -n auto --dist=loadfile"
 asyncio_mode = "auto"
 markers = [
     "unit: Pure logic tests, no external dependencies",

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,12 +5,15 @@ Organized by test level and tagged by feature. Run `pytest --collect-only -q` fo
 ## Running Tests
 
 ```bash
-# By level
-pytest tests/unit/               # Unit tests (~60s)
-pytest tests/unit/ -n auto       # Unit tests in parallel
-pytest tests/integration/        # Integration tests (needs Redis)
+# By level (parallel by default — `-n auto --dist=loadfile` from pyproject.toml)
+pytest tests/unit/               # Unit tests (~40s parallel, ~250s serial)
+pytest tests/integration/        # Integration tests (~125s parallel, ~330s serial; needs Redis)
 pytest -m e2e                    # E2E tests
 pytest -m slow                   # Performance benchmarks
+
+# Force serial (for debugging xdist races or running with breakpoints)
+pytest tests/unit/ -n0
+pytest tests/integration/ -n0
 
 # By feature (works across all levels)
 pytest -m sdlc                   # All SDLC pipeline tests (516)
@@ -22,6 +25,13 @@ pytest -m "sdlc or sessions"     # Combine features
 pytest tests/unit/test_observer.py           # Single file
 pytest tests/unit/test_observer.py::TestX    # Single class
 ```
+
+### Parallel Execution Notes
+
+`pytest-xdist` runs tests across N worker subprocesses (one per CPU). Two patterns matter when authoring tests:
+
+1. **Per-worker Redis db.** The autouse `redis_test_db` fixture (`tests/conftest.py`) maps each worker to its own db (`gw0` → db=1, `gw1` → db=2, …). Tests that build a raw `redis.Redis(...)` client or set `REDIS_URL` for a subprocess must use the per-worker db, not a hardcoded `db=1`. Use the `redis_test_url` fixture or read `PYTEST_XDIST_WORKER` to derive it (`gw{N}` → db={N+1}, default db=1 when unset).
+2. **File-level grouping (`--dist=loadfile`).** All tests in one file land on the same worker. Files whose tests share global resources (npm/npx caches, host-level lockfiles, a single GitHub issue, an in-process module variable) rely on this — they otherwise collide under inter-test parallelism.
 
 ## Feature Markers
 

--- a/tests/integration/test_agent_session_scheduler.py
+++ b/tests/integration/test_agent_session_scheduler.py
@@ -24,15 +24,26 @@ _PROJECT_ROOT = str(Path(__file__).parent.parent.parent)
 def _subprocess_env(**extra) -> dict:
     """Build env dict for subprocess calls that routes them to the test Redis DB.
 
-    Popoto picks up REDIS_URL at import time. By pointing subprocesses at
-    db=1 (the same DB the redis_test_db fixture uses for non-xdist runs),
-    we prevent test sessions from leaking into production db=0.
+    Popoto picks up REDIS_URL at import time. We must point subprocesses at
+    the SAME per-worker test DB that the autouse ``redis_test_db`` fixture
+    selects (``tests/conftest.py``), otherwise under ``pytest -n auto`` the
+    parent worker reads/writes one DB while its subprocess reads/writes a
+    different one, and ``gw0`` and ``gw1`` subprocesses corrupt each other
+    in db=1.
+
+    pytest-xdist sets ``PYTEST_XDIST_WORKER`` in the worker process
+    environment (e.g. ``gw0``, ``gw1``); when unset (serial run) we fall
+    back to db=1, matching the autouse fixture's serial branch.
     """
     import os
 
     env = {**os.environ, **extra}
-    # Use the same test DB that the redis_test_db conftest fixture selects
-    env["REDIS_URL"] = "redis://127.0.0.1:6379/1"
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER", "")
+    if worker_id.startswith("gw"):
+        test_db = int(worker_id[2:]) + 1  # gw0->db1, gw1->db2, ...
+    else:
+        test_db = 1  # serial run
+    env["REDIS_URL"] = f"redis://127.0.0.1:6379/{test_db}"
     return env
 
 

--- a/tests/integration/test_design_system_pipeline.py
+++ b/tests/integration/test_design_system_pipeline.py
@@ -4,10 +4,19 @@ Exercises the full pipeline (generate + lint + DTCG/Tailwind export +
 check). Requires Node; skipped when `npx` is absent. Runs the generator
 against a tempdir copy of the fixture so the test does not mutate the
 committed fixture tree.
+
+Each test in this module runs the ``@google/design.md`` npm package via
+``npx`` against a shared ``node_modules`` cache. Concurrent npx invocations
+race on that cache (resolver / extract / link phases), producing
+intermittent non-zero exits. ``--dist=loadfile`` (set in
+``pyproject.toml``) keeps all tests in this file on a single xdist worker
+so the npx invocations execute serially without losing inter-file
+parallelism.
 """
 
 from __future__ import annotations
 
+import functools
 import json
 import shutil
 import subprocess
@@ -20,16 +29,40 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 FIXTURE_DIR = REPO_ROOT / "tests/fixtures/design_system"
 
 
+@functools.lru_cache(maxsize=1)
 def _npx_present() -> bool:
+    """Memoized npx availability probe.
+
+    Each ``@pytest.mark.skipif(not _npx_present(), ...)`` decorator evaluates
+    this at collection time. Without memoization, every test in the module
+    spawns an ``npx`` subprocess during collection — and under ``pytest -n
+    auto`` every worker collects in parallel. Two of those concurrent
+    ``npx --no-install`` probes can race against each other inside npm's
+    cache (``~/.npm/_cacache``) and one will spuriously report the package
+    as missing, masking the real test signal.
+
+    A short retry loop covers the residual race where multiple xdist
+    workers run this probe at collection time even after the lru_cache
+    eliminates intra-worker repeats.
+    """
+    import time as _time
+
     if shutil.which("npx") is None:
         return False
-    result = subprocess.run(
-        ["npx", "--no-install", "@google/design.md", "--version"],
-        capture_output=True,
-        text=True,
-        cwd=str(REPO_ROOT),
-    )
-    return result.returncode == 0 and "0.1.1" in result.stdout
+    for attempt in range(3):
+        result = subprocess.run(
+            ["npx", "--no-install", "@google/design.md", "--version"],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+        if result.returncode == 0 and "0.1.1" in result.stdout:
+            return True
+        # npm cache races sometimes report "missing packages" spuriously
+        # when another concurrent npx is mutating ~/.npm/_cacache. Brief
+        # backoff then retry.
+        _time.sleep(0.5 * (attempt + 1))
+    return False
 
 
 @pytest.fixture

--- a/tests/integration/test_email_bridge.py
+++ b/tests/integration/test_email_bridge.py
@@ -10,7 +10,8 @@ Design:
   in tests — the unit under test is the routing/dispatch logic in
   _process_inbound_email(), not Popoto internals.
 - Thread-continuation Redis lookups are exercised against the real test Redis
-  db (via a patched _get_redis() that points at db=1).
+  db (via a patched _get_redis() that points at the per-worker test db,
+  matching the autouse ``redis_test_db`` fixture).
 - Unknown sender, active-project guard, and extra_context propagation are
   all verified by inspecting mock call args.
 """
@@ -67,8 +68,23 @@ def _projects_json(project_key: str = "test-project") -> dict:
 
 
 def _test_redis() -> redis.Redis:
-    """Return a Redis connection to the test db (db=1, matching conftest fixture)."""
-    return redis.Redis(db=1, decode_responses=True)
+    """Return a Redis connection to the per-worker test db (matching conftest's
+    autouse ``redis_test_db`` fixture).
+
+    pytest-xdist sets ``PYTEST_XDIST_WORKER`` (e.g. ``gw0``, ``gw1``) inside
+    each worker process, mirroring the worker_id used by the autouse
+    fixture. Hardcoding ``db=1`` here causes ``-n auto`` collisions when
+    ``gw1+`` workers run this test against db=1 while their popoto state
+    lives in db=2+.
+    """
+    import os
+
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER", "")
+    if worker_id.startswith("gw"):
+        test_db = int(worker_id[2:]) + 1  # gw0->db1, gw1->db2, ...
+    else:
+        test_db = 1  # serial run
+    return redis.Redis(db=test_db, decode_responses=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_remote_update.py
+++ b/tests/integration/test_remote_update.py
@@ -1,4 +1,12 @@
-"""Tests for remote update: shell script, bridge intercept, restart flag lifecycle."""
+"""Tests for remote update: shell script, bridge intercept, restart flag lifecycle.
+
+Each test in this module exercises ``scripts/remote-update.sh`` against the
+real repository state (``data/update.lock``, ``data/restart-requested``).
+The script's lockfile and restart flag are host-global, so concurrent
+invocations would collide. ``--dist=loadfile`` (set in ``pyproject.toml``)
+keeps every test in this file on the same xdist worker so they run
+serially within the worker pool.
+"""
 
 import asyncio
 import os

--- a/tests/integration/test_stage_comment.py
+++ b/tests/integration/test_stage_comment.py
@@ -2,6 +2,11 @@
 
 Posts a comment to a real GitHub issue, fetches it back, and verifies
 the format is correct. Uses the actual `gh` CLI.
+
+Every test posts to (and reads from) the SAME real GitHub issue, so the
+file relies on ``--dist=loadfile`` (set in ``pyproject.toml``) to pin all
+tests in the module to one xdist worker — concurrent posts otherwise race
+on the shared remote state.
 """
 
 import pytest


### PR DESCRIPTION
Closes #1289.

## Problem

Five integration tests failed under `pytest -n auto` but passed serial, blocking us from making xdist parallelism the default. Issue #1289 lists them all.

## Root causes

1. **`tests/integration/test_agent_session_scheduler.py::_subprocess_env`** hardcoded `REDIS_URL=redis://127.0.0.1:6379/1`. Subprocesses spawned from `gw1+` workers read/wrote a different db than their popoto state — `gw0` and `gw1` subprocesses corrupted each other in db=1.
2. **`tests/integration/test_email_bridge.py::_test_redis()`** hardcoded `db=1` for the same reason.
3. **`test_design_system_pipeline.py`, `test_remote_update.py`, `test_stage_comment.py`** have intra-file collisions on shared global resources (npm cache, host lockfile at `data/update.lock`, the same real GitHub issue #520).

## Fix

- Both subprocess-env helpers now read `PYTEST_XDIST_WORKER` and pick the matching per-worker db (`gw0` → db=1, `gw1` → db=2, …), falling back to db=1 for serial runs. Same math as the autouse `redis_test_db` fixture in `tests/conftest.py`.
- `pyproject.toml [tool.pytest.ini_options].addopts` now reads `--tb=short -p no:postgresql -n auto --dist=loadfile`. `--dist=loadfile` keeps tests in one file on one worker, fixing intra-file resource collisions while preserving inter-file parallelism.
- `_npx_present()` in `test_design_system_pipeline.py` is memoized via `functools.lru_cache` with a short retry loop for transient npm cache races during collection.
- Docs updated: `CLAUDE.md` Quick Commands table and `tests/README.md` reflect the new parallel default and the per-worker db convention.

## Verification

### All 5 issue-listed tests pass under both modes (5 consecutive runs each)

```
$ pytest tests/integration/test_design_system_pipeline.py::test_check_detects_mutation \
         tests/integration/test_design_system_pipeline.py::test_fixture_design_md_passes_lint \
         tests/integration/test_stage_comment.py::TestStageCommentIntegration::test_post_and_fetch_stage_comment \
         tests/integration/test_agent_session_scheduler.py::TestKillCommandIntegration::test_status_shows_killed_count \
         tests/integration/test_agent_session_scheduler.py::TestJobSchedulerCLI::test_push_and_pop \
         -p no:cacheprovider
5 passed in 8.21s   # -n auto (default)

$ pytest <same five> -n0 -p no:cacheprovider
5 passed in 11.09s  # serial
```

### Full integration suite under `-n auto`

```
$ pytest tests/integration/ -p no:cacheprovider
681 passed, 11 skipped, 37 warnings in 127.54s
```

### Full unit suite under `-n auto`

```
$ pytest tests/unit/ -p no:cacheprovider
6 failed, 6344 passed, 1 skipped in 41.93s
```

The 6 unit failures are **pre-existing source-audit failures on `main`** (`test_health_check_recovery_finalization.py`, `test_harness_oom_backoff.py`, etc.) — they fail identically under serial, are not introduced by this PR.

## Timing — before vs after `-n auto`

| Suite        | Serial (`-n0`) | `-n auto` (default) | Speedup |
|--------------|---------------:|--------------------:|--------:|
| Unit         | 251.94s        | 41.93s              | **6.0×** |
| Integration  | 333.04s        | 127.54s             | **2.6×** |

Numbers from a 10-core macOS machine. The merge gate's full-suite invocation (`pytest tests/`) automatically inherits the speedup.

## Files changed

- `tests/integration/test_agent_session_scheduler.py` — `_subprocess_env` reads `PYTEST_XDIST_WORKER`.
- `tests/integration/test_email_bridge.py` — `_test_redis()` reads `PYTEST_XDIST_WORKER`.
- `tests/integration/test_design_system_pipeline.py` — `_npx_present` memoized + retry; module docstring documents the `--dist=loadfile` reliance.
- `tests/integration/test_remote_update.py` — module docstring documents the `--dist=loadfile` reliance.
- `tests/integration/test_stage_comment.py` — module docstring documents the `--dist=loadfile` reliance.
- `pyproject.toml` — `addopts` adds `-n auto --dist=loadfile`.
- `CLAUDE.md` — Quick Commands table reflects parallel-by-default.
- `tests/README.md` — running-tests section + parallel-execution authoring notes.
