### PR TITLE
Add user-visible stall reaction (closes #1313)

### DIFF
--- a/docs/features/bridge-self-healing.md
+++ b/docs/features/bridge-self-healing.md
@@ -102,6 +102,36 @@ Zombie cleanup is integrated into recovery levels 2+ to free memory before resta
 
 This is distinct from the loop-level crash guard (which marks sessions as `failed`). The `_safe_abandon_session()` helper handles the common case of race conditions during the abandon flow itself.
 
+### 4a. User-Visible Stall Alerts (`monitoring/session_watchdog.py`, issue #1313)
+
+**Problem**: When `check_stalled_sessions()` detected a stalled session, it logged a `LIFECYCLE_STALL` warning to `worker.log` and did nothing else. The user (CEO) saw silence on Telegram and assumed "agent is thinking." Silent failure compounded short outages into long ones because no human-visible signal triggered an investigation.
+
+**Solution**: After the existing `LIFECYCLE_STALL` warning fires, the watchdog also calls `_apply_stall_reaction(session)`, which queues a ⏳ reaction emoji on the user's originating Telegram message. The bridge's existing `bridge/telegram_relay.py::_send_queued_reaction` drain delivers it on the next poll. The warning log is preserved unchanged — the reaction is an *additional* user-visible channel.
+
+**How the queueing works**:
+- The watchdog stays Telethon-free. It writes a reaction payload (`type: "reaction"`, `chat_id`, `reply_to`, `emoji: "⏳"`, `session_id`, `timestamp`) directly to `telegram:outbox:{session_id}` via `RPUSH` + `EXPIRE` (3600s TTL, matches `OutputHandler.OUTBOX_TTL`).
+- The payload schema is byte-for-byte identical to `agent/output_handler.py::_build_reaction_payload`. A unit test (`test_payload_matches_build_reaction_payload`) enforces this so any drift fails CI.
+- The bridge relay drains the same outbox key on its normal poll loop and calls `set_reaction` over Telethon.
+
+**Idempotency**:
+- A single atomic `SET NX EX` on `watchdog:stall_reaction_applied:{session_id}` (TTL = 1 day, `STALL_REACTION_DEDUP_TTL`) ensures exactly one reaction per stall period. Same shape as the per-reason cooldowns from issue #1128.
+- When the next watchdog tick observes the session in a healthy (non-stall) state, the dedup key is `DELETE`d so a re-stall queues a fresh reaction. There is a ≤5-minute window where ⏳ can briefly persist after recovery before the next tick clears the dedup; the user will see the bot's recovery message land before the reaction is reset, so this is acceptable.
+
+**Skip conditions** (return False, no Redis writes, no log spam):
+- `WATCHDOG_STALL_REACTION_ENABLED` env var is set falsy (`0`, `false`, `no`). Default is on.
+- Session has no `chat_id` (e.g. local Claude Code sessions, no Telegram origin).
+- Session has no `telegram_message_id` (originating message not captured).
+- Session has no resolvable `session_id`/`agent_session_id`.
+
+**Failure modes**:
+- Redis exception → fail-quiet `logger.warning`, watchdog loop continues.
+- Bridge relay down longer than `OUTBOX_TTL` → outbox key expires, reaction lost. The warning log still fires, and the next tick re-queues once the bridge returns and the dedup key TTL expires. A bridge-down >TTL is a bigger-than-watchdog incident.
+- ⏳ not in Telegram's allowed reactions for a chat → the relay's `set_reaction` already handles unknown-emoji failure (logs and moves on). Swap `STALL_REACTION_EMOJI = "⚠️"` is a one-line change.
+
+**Configuration**:
+- `WATCHDOG_STALL_REACTION_ENABLED`: default on. Set to `0`/`false`/`no` to disable, mirror of `WATCHDOG_AUTO_STEER_ENABLED`.
+- Constants live at the top of `monitoring/session_watchdog.py` near `STEER_COOLDOWN`: `STALL_REACTION_EMOJI`, `STALL_REACTION_DEDUP_TTL`, `STALL_REACTION_OUTBOX_TTL`.
+
 ### 5. Log Rotation
 
 Log rotation uses a three-layer approach: Python-managed rotation for application logs, shell rotation at service startup for launchd-managed stderr/stdout logs, and a user-space LaunchAgent for between-restart coverage. See [Log Rotation](log-rotation.md) for the full design.

--- a/docs/features/session-lifecycle-diagnostics.md
+++ b/docs/features/session-lifecycle-diagnostics.md
@@ -48,6 +48,7 @@ For active sessions, `updated_at` is checked first — if recent activity exists
 When a stall is detected:
 - A `LIFECYCLE_STALL` warning is logged with session ID, status, duration, and last history entry
 - The stalled session info is returned for potential alerting
+- **User-visible reaction** (#1313): for active sessions with an originating Telegram message, `_apply_stall_reaction()` queues a ⏳ reaction emoji on the user's message via `telegram:outbox:{session_id}`. The bridge relay drains the same key and delivers the reaction. Idempotent per stall period via `watchdog:stall_reaction_applied:{session_id}`; cleared on healthy-state observation so re-stalls re-fire. See [Bridge Self-Healing § 4a](bridge-self-healing.md#4a-user-visible-stall-alerts-monitoringsession_watchdogpy-issue-1313).
 - **Pending stalls** (#342, #402): `_recover_stalled_pending()` kills the stuck worker via `_kill_stalled_worker()`, applies exponential backoff, and re-enqueues via `_enqueue_stall_retry()`. After `STALL_MAX_RETRIES` exhausted, the session is abandoned with a Telegram notification. See [stall-retry.md](stall-retry.md) for full details.
 
 ### Stale Save Guard (#342)

--- a/docs/features/session-lifecycle.md
+++ b/docs/features/session-lifecycle.md
@@ -275,6 +275,14 @@ A stale caller can at worst append a spurious `session_events` entry. It cannot 
 
 **In-process vs. standalone:** When the update script runs inside the same process as the queue (bridge in-process update), `_active_workers` is populated and fully authoritative. When it runs as a CLI subprocess, `_active_workers` will always be empty and the function logs a warning before relying on the `updated_at` recency check.
 
+## Stall Reaction Dedup Reset (issue #1313)
+
+When `monitoring/session_watchdog.py::check_stalled_sessions` queues a user-visible ⏳ reaction for a stalled session (see [Bridge Self-Healing § 4a](bridge-self-healing.md#4a-user-visible-stall-alerts-monitoringsession_watchdogpy-issue-1313)), it claims the dedup key `watchdog:stall_reaction_applied:{session_id}` so the reaction is queued at most once per stall period.
+
+**Reset on healthy observation:** the same iteration loop in `check_stalled_sessions` calls `_clear_stall_reaction_dedup(session_id)` whenever the session's duration is within its threshold. This is the only point where the dedup key is deleted — there is no lifecycle hook in `models/agent_session.py` for this, by design. The watchdog-side placement keeps the diff inside `monitoring/session_watchdog.py` only and avoids threading reaction state through the broader transition machinery in this module.
+
+**Implication:** there is a ≤5-minute window (one watchdog tick interval) where ⏳ can briefly persist on the user's message after the session recovers, before the next tick clears the dedup. The recovery message itself lands first, so the user sees the recovery before the reaction is reset for a future stall.
+
 ## Design Constraints
 
 - **Import safety**: The module uses lazy imports for `tools.session_tags` and `agent.agent_session_queue` so it can be imported from `.claude/hooks/stop.py` subprocess context where those modules may not be on `sys.path`.

--- a/docs/features/session-watchdog.md
+++ b/docs/features/session-watchdog.md
@@ -123,6 +123,49 @@ loops emit many tool calls per minute.
 **Feature gate.** `WATCHDOG_AUTO_STEER_ENABLED=false` disables loop-break
 steering without disabling detection (still logged at WARNING).
 
+## User-Visible Stall Reaction (issue #1313)
+
+When `check_stalled_sessions()` observes an active session past its stall
+threshold, the watchdog also calls `_apply_stall_reaction(session)` to queue
+a ⏳ reaction emoji on the user's originating Telegram message. Until #1313,
+stalls were `LIFECYCLE_STALL`-logged only — the user saw silence and
+assumed "agent is thinking," compounding short outages into long ones. The
+existing warning log is preserved unchanged; the reaction is an *additional*
+user-visible channel.
+
+**How it's wired.** The watchdog stays Telethon-free. It writes a reaction
+payload (`type: "reaction"`, `chat_id`, `reply_to`, `emoji: "⏳"`,
+`session_id`, `timestamp`) directly to `telegram:outbox:{session_id}` via
+`RPUSH` + `EXPIRE STALL_REACTION_OUTBOX_TTL` (3600s, matches
+`OutputHandler.OUTBOX_TTL`). The payload schema is byte-for-byte identical
+to `agent/output_handler.py::_build_reaction_payload`; a unit test
+(`test_payload_matches_build_reaction_payload`) enforces parity. The
+bridge's existing `bridge/telegram_relay.py::_send_queued_reaction` drain
+delivers the reaction on its next poll.
+
+**Idempotency.** A single atomic `SET NX EX` on
+`watchdog:stall_reaction_applied:{session_id}` (TTL =
+`STALL_REACTION_DEDUP_TTL` = 1 day) ensures exactly one reaction per stall
+period. When the next watchdog tick observes the session in a healthy
+(non-stall) state, `_clear_stall_reaction_dedup()` `DELETE`s the dedup key
+so a re-stall queues a fresh reaction. There is a ≤5-minute window
+(one watchdog tick) where ⏳ can briefly persist after recovery before the
+next tick clears the dedup; the recovery message lands first, so this is
+acceptable.
+
+**Skip conditions** (return False, no Redis writes, no log spam): feature
+flag falsy, session has no `chat_id`, no `telegram_message_id`, or no
+resolvable `session_id`/`agent_session_id`.
+
+**Failure modes.** Redis exception → fail-quiet `logger.warning`, watchdog
+loop continues. Bridge relay down >`OUTBOX_TTL` → outbox key expires,
+reaction lost; the warning log still fires, and the next tick re-queues
+once the dedup TTL expires.
+
+**Feature gate.** `WATCHDOG_STALL_REACTION_ENABLED=false` disables the
+reaction without disabling stall detection (still logged at WARNING).
+Mirrors `WATCHDOG_AUTO_STEER_ENABLED`.
+
 ## Configuration
 
 All thresholds are module-level constants in `monitoring/session_watchdog.py`:
@@ -140,6 +183,9 @@ All thresholds are module-level constants in `monitoring/session_watchdog.py`:
 | `STEER_COOLDOWN` | 900 (15 min) | Per-reason cooldown for repetition/cascade steers |
 | `TOKEN_ALERT_THRESHOLD` | 5,000,000 | Soft-threshold on `input + output` tokens |
 | `TOKEN_ALERT_COOLDOWN` | 3600 (1 hr) | Cooldown for token-alert steers |
+| `STALL_REACTION_EMOJI` | `⏳` | Emoji queued on the user's message when a session stalls (issue #1313) |
+| `STALL_REACTION_DEDUP_TTL` | 86400 (1 day) | Dedup key TTL for one-reaction-per-stall-period |
+| `STALL_REACTION_OUTBOX_TTL` | 3600 | Outbox key TTL; matches `OutputHandler.OUTBOX_TTL` |
 
 **Environment variables (issue #1128):** every constant above that
 participates in loop-break / token-alert behavior is env-tunable and the
@@ -148,6 +194,7 @@ behavior itself is toggleable:
 | Env var | Purpose | Default |
 |---------|---------|---------|
 | `WATCHDOG_AUTO_STEER_ENABLED` | Toggle auto-steer on/off | on |
+| `WATCHDOG_STALL_REACTION_ENABLED` | Toggle user-visible ⏳ reaction on stall (issue #1313) | on |
 | `WATCHDOG_TOKEN_TRACKING_ENABLED` | Toggle per-session token accumulation | on |
 | `WATCHDOG_IDLE_TEARDOWN_ENABLED` | Toggle worker idle-sweeper | on |
 | `WATCHDOG_TOKEN_ALERT_THRESHOLD` | Soft-threshold tokens | 5000000 |
@@ -217,6 +264,8 @@ full topology.
 | `tests/unit/test_session_watchdog.py` | Detection + steer-actuator assertions |
 | `tests/unit/test_watchdog_loop_break_steer.py` | `_inject_watchdog_steer` cooldown + sender attribution |
 | `tests/unit/test_watchdog_token_alert.py` | Token threshold → steer wiring |
+| `tests/unit/test_stall_detection.py` | `_apply_stall_reaction` payload, dedup, skip conditions (issue #1313) |
+| `tests/integration/test_watchdog_to_bridge.py` | End-to-end: watchdog outbox write → bridge relay drain (issue #1313) |
 | `tests/unit/test_session_token_accumulator.py` | `accumulate_session_tokens` end-to-end |
 | `tests/unit/test_harness_token_capture.py` | Harness-path B3 fix (usage + cost from `result` event) |
 | `tests/unit/test_worker_idle_sweeper.py` | Worker-internal idle teardown |

--- a/monitoring/session_watchdog.py
+++ b/monitoring/session_watchdog.py
@@ -16,6 +16,11 @@ When issues are detected, the watchdog FIXES them automatically:
   AUTOMATICALLY enqueues a steering message via `_inject_watchdog_steer`.
   Per-reason atomic Redis cooldowns (SET NX EX) prevent floods. No longer
   "detected but logged only" — detections now drive actuation.
+- For stalled sessions with an originating Telegram message (issue #1313):
+  AUTOMATICALLY queues a ⏳ reaction emoji on the user's original message
+  via `_apply_stall_reaction`. Atomic `SET NX EX` dedup key per session
+  prevents repeats within a stall period. Reset on healthy-state observation
+  so re-stalls trigger a fresh reaction.
 
 NO ALERTS ARE SENT for recoverable stalls. Either retry, fix, or create an issue.
 
@@ -100,6 +105,21 @@ TOKEN_ALERT_COOLDOWN = int(os.environ.get("WATCHDOG_TOKEN_ALERT_COOLDOWN", "3600
 # reason). 900s = 3 watchdog ticks; gives the agent room to respond to a
 # steer before the next one fires.
 STEER_COOLDOWN = int(os.environ.get("WATCHDOG_STEER_COOLDOWN", "900"))
+
+# === User-visible stall alert (issue #1313) ===
+# Reaction emoji queued on the originating Telegram message when a session
+# is observed stalled. ⏳ chosen for "stalled / waiting too long"; visually
+# distinct from existing bridge reactions (👀 received, 🔥 drafting, 👍 done).
+STALL_REACTION_EMOJI = "⏳"
+# Dedup TTL: the reaction is queued at most once per session per stall
+# period. 1 day is well over any realistic stall lifetime; the key is also
+# explicitly DELETEd when the session is observed in a healthy state, so
+# this TTL is just a safety bound for orphaned keys.
+STALL_REACTION_DEDUP_TTL = 86400
+# OUTBOX TTL: matches `agent/output_handler.py::OutputHandler.OUTBOX_TTL`
+# (3600s) — the bridge's reaction relay drains the same key with this TTL
+# applied via EXPIRE on each rpush.
+STALL_REACTION_OUTBOX_TTL = 3600
 
 
 # Transcript liveness: if transcript.txt was modified within this many minutes,
@@ -374,6 +394,16 @@ def check_stalled_sessions() -> list[dict]:
                         getattr(session, "project_key", "?"),
                         last_history,
                     )
+
+                    # Issue #1313: queue a user-visible ⏳ reaction on the
+                    # originating Telegram message. Idempotent within the
+                    # stall period; cleared below when the session recovers.
+                    _apply_stall_reaction(session)
+                else:
+                    # Session observed in a healthy (non-stall) state. Clear
+                    # the dedup key so a future re-stall triggers a fresh
+                    # reaction. Cheap no-op when the key doesn't exist.
+                    _clear_stall_reaction_dedup(session_id)
             except Exception as e:
                 logger.error("[watchdog] Error checking session for stall: %s", e)
 
@@ -496,6 +526,124 @@ def _inject_watchdog_steer(
             e,
         )
         return False
+
+
+def _apply_stall_reaction(session: AgentSession) -> bool:
+    """Queue a user-visible ⏳ reaction on the originating Telegram message.
+
+    Issue #1313: when `check_stalled_sessions` observes a session past its
+    stall threshold, this helper writes a reaction payload to
+    ``telegram:outbox:{session_id}`` so the bridge relay's existing
+    `_send_queued_reaction` drain delivers the emoji on the user's
+    original message. The existing ``LIFECYCLE_STALL`` warning log is
+    preserved unchanged — this is an *additional* user-visible channel,
+    not a replacement.
+
+    Idempotency: a single atomic ``SET NX EX`` on
+    ``watchdog:stall_reaction_applied:{session_id}`` (TTL =
+    ``STALL_REACTION_DEDUP_TTL``) ensures exactly one reaction per
+    session per stall period. The key is DELETEd elsewhere when the
+    session is observed in a healthy state so re-stalls trigger a fresh
+    reaction.
+
+    Skip conditions (return ``False``, no Redis writes, no warning):
+      * Feature flag ``WATCHDOG_STALL_REACTION_ENABLED`` is set falsy.
+      * Session has no ``chat_id`` (e.g. local sessions, no Telegram origin).
+      * Session has no ``telegram_message_id`` (originating message not
+        captured — typical for non-Telegram session creators).
+      * Session has no resolvable ``session_id`` / ``agent_session_id``.
+      * Dedup key already exists for this stall period.
+
+    Schema parity: the inlined payload literal MUST stay byte-for-byte
+    identical to ``agent/output_handler.OutputHandler._build_reaction_payload``
+    so the bridge relay accepts both writers' messages from the same outbox.
+    The unit test ``test_payload_matches_build_reaction_payload`` enforces
+    this. We do NOT import `_build_reaction_payload` directly because that
+    module is async-handler code and the import path risks cycles; the test
+    is the only mechanical defense against schema drift.
+
+    Args:
+        session: The AgentSession observed as stalled. Must expose
+            ``session_id`` (or ``agent_session_id``), ``chat_id``, and
+            ``telegram_message_id``.
+
+    Returns:
+        True when a reaction payload was queued. False on any skip
+        condition or any caught exception (fail-quiet so the watchdog
+        loop never crashes on reaction errors).
+    """
+    if not _env_flag_enabled("WATCHDOG_STALL_REACTION_ENABLED"):
+        return False
+
+    try:
+        chat_id = getattr(session, "chat_id", None)
+        msg_id = getattr(session, "telegram_message_id", None)
+        session_id = getattr(session, "session_id", None) or getattr(
+            session, "agent_session_id", None
+        )
+        if not (chat_id and msg_id and session_id):
+            return False
+
+        from popoto.redis_db import POPOTO_REDIS_DB
+
+        dedup_key = f"watchdog:stall_reaction_applied:{session_id}"
+        slot_open = POPOTO_REDIS_DB.set(
+            dedup_key,
+            "1",
+            nx=True,
+            ex=STALL_REACTION_DEDUP_TTL,
+        )
+        if not slot_open:
+            return False
+
+        payload = {
+            "type": "reaction",
+            "chat_id": str(chat_id),
+            "reply_to": int(msg_id),
+            "emoji": STALL_REACTION_EMOJI,
+            "session_id": session_id,
+            "timestamp": time.time(),
+        }
+        queue_key = f"telegram:outbox:{session_id}"
+        POPOTO_REDIS_DB.rpush(queue_key, json.dumps(payload))
+        POPOTO_REDIS_DB.expire(queue_key, STALL_REACTION_OUTBOX_TTL)
+        logger.warning(
+            "[watchdog] Stall reaction queued for %s (chat=%s msg=%s emoji=%s)",
+            session_id,
+            chat_id,
+            msg_id,
+            STALL_REACTION_EMOJI,
+        )
+        return True
+    except Exception as e:
+        logger.warning(
+            "[watchdog] Failed to queue stall reaction for %s: %s",
+            getattr(session, "session_id", "?"),
+            e,
+        )
+        return False
+
+
+def _clear_stall_reaction_dedup(session_id: str) -> None:
+    """Delete the stall-reaction dedup key so re-stalls trigger a fresh reaction.
+
+    Called from the iteration loop in `check_stalled_sessions` whenever a
+    session is observed in a healthy (non-stall) state. Fail-quiet: any
+    Redis exception is swallowed; orphaned keys age out via
+    ``STALL_REACTION_DEDUP_TTL``.
+    """
+    if not session_id:
+        return
+    try:
+        from popoto.redis_db import POPOTO_REDIS_DB
+
+        POPOTO_REDIS_DB.delete(f"watchdog:stall_reaction_applied:{session_id}")
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug(
+            "[watchdog] Failed to clear stall reaction dedup for %s: %s",
+            session_id,
+            e,
+        )
 
 
 def assess_session_health(session: AgentSession) -> dict[str, Any]:

--- a/tests/integration/test_watchdog_to_bridge.py
+++ b/tests/integration/test_watchdog_to_bridge.py
@@ -1,0 +1,173 @@
+"""Integration test: stalled-session detection -> outbox handoff to bridge relay.
+
+Issue #1313. Drives one watchdog tick against a stale-pending fixture session
+and asserts the reaction payload lands in ``telegram:outbox:{session_id}`` with
+the right schema, then asserts ``bridge.telegram_relay._send_queued_reaction``
+recognizes the payload shape (called as a unit with a stub Telethon client).
+
+Uses an in-memory Redis stub so this test does not depend on a live Redis
+instance and never touches production keys.
+"""
+
+import asyncio
+import json
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+
+class _FakeRedis:
+    """Minimal in-memory Redis stub matching the `set NX EX`, `rpush`,
+    `expire`, `delete` surface used by the watchdog."""
+
+    def __init__(self):
+        self.store: dict[str, str] = {}
+        self.lists: dict[str, list[str]] = {}
+        self.expires: dict[str, int] = {}
+
+    def set(self, key, value, nx=False, ex=None):
+        if nx and key in self.store:
+            return None
+        self.store[key] = value
+        if ex is not None:
+            self.expires[key] = ex
+        return True
+
+    def rpush(self, key, value):
+        self.lists.setdefault(key, []).append(value)
+        return len(self.lists[key])
+
+    def expire(self, key, ttl):
+        self.expires[key] = ttl
+        return True
+
+    def delete(self, key):
+        self.store.pop(key, None)
+        self.lists.pop(key, None)
+        self.expires.pop(key, None)
+        return 1
+
+
+def _make_stale_pending_session(session_id="tg_user_-100_42"):
+    """Build a SimpleNamespace mimicking AgentSession for a stale-pending fixture."""
+    now = time.time()
+    return SimpleNamespace(
+        session_id=session_id,
+        agent_session_id="as-001",
+        status="pending",
+        # Stale: created well past the 300s pending threshold.
+        started_at=None,
+        created_at=now - 600,
+        updated_at=now - 600,
+        project_key="testproj",
+        chat_id="-100",
+        # initial_telegram_message provides telegram_message_id via property,
+        # but SimpleNamespace can expose it directly.
+        telegram_message_id=42,
+    )
+
+
+def _query_filter_for(sessions_by_status):
+    def filter_fn(**kwargs):
+        return sessions_by_status.get(kwargs.get("status", ""), [])
+
+    return SimpleNamespace(filter=filter_fn)
+
+
+def test_watchdog_tick_writes_reaction_to_outbox(monkeypatch):
+    """A stalled pending session triggers a reaction payload in the outbox."""
+    from monitoring import session_watchdog
+
+    fake = _FakeRedis()
+    monkeypatch.setattr("popoto.redis_db.POPOTO_REDIS_DB", fake)
+    monkeypatch.delenv("WATCHDOG_STALL_REACTION_ENABLED", raising=False)
+
+    session = _make_stale_pending_session()
+
+    # The session needs `_get_history_list` (read by check_stalled_sessions).
+    session._get_history_list = lambda: []
+
+    sessions_by_status = {"pending": [session], "running": [], "active": []}
+    with patch(
+        "monitoring.session_watchdog.AgentSession.query",
+        _query_filter_for(sessions_by_status),
+    ):
+        stalled = session_watchdog.check_stalled_sessions()
+
+    # Watchdog must have detected the stall.
+    assert any(s["session_id"] == "tg_user_-100_42" for s in stalled)
+
+    # And queued exactly one reaction payload to the session's outbox.
+    queue_key = "telegram:outbox:tg_user_-100_42"
+    assert queue_key in fake.lists
+    assert len(fake.lists[queue_key]) == 1
+
+    payload = json.loads(fake.lists[queue_key][0])
+    assert payload["type"] == "reaction"
+    assert payload["chat_id"] == "-100"
+    assert payload["reply_to"] == 42
+    assert payload["emoji"] == "⏳"
+    assert payload["session_id"] == "tg_user_-100_42"
+    assert "timestamp" in payload
+
+    # Outbox TTL applied so the relay-down case eventually clears.
+    assert fake.expires[queue_key] == 3600
+
+    # Dedup key claimed.
+    assert "watchdog:stall_reaction_applied:tg_user_-100_42" in fake.store
+
+
+def test_relay_send_queued_reaction_accepts_watchdog_payload(monkeypatch):
+    """The bridge's _send_queued_reaction must accept the watchdog's payload shape.
+
+    Patches `bridge.response.set_reaction` to avoid a real Telethon call; the
+    test only verifies the payload validation/parse path returns True.
+    """
+    from bridge.telegram_relay import _send_queued_reaction
+    from monitoring import session_watchdog
+
+    fake = _FakeRedis()
+    monkeypatch.setattr("popoto.redis_db.POPOTO_REDIS_DB", fake)
+    monkeypatch.delenv("WATCHDOG_STALL_REACTION_ENABLED", raising=False)
+
+    session = _make_stale_pending_session()
+    assert session_watchdog._apply_stall_reaction(session) is True
+
+    queue_key = "telegram:outbox:tg_user_-100_42"
+    payload = json.loads(fake.lists[queue_key][0])
+
+    fake_set_reaction = AsyncMock(return_value=True)
+    with patch("bridge.response.set_reaction", fake_set_reaction):
+        result = asyncio.run(_send_queued_reaction(telegram_client=object(), message=payload))
+
+    assert result is True
+    fake_set_reaction.assert_awaited_once()
+    # Verify the relay parsed chat_id, reply_to, emoji correctly.
+    args, kwargs = fake_set_reaction.call_args
+    # set_reaction(client, chat_id, msg_id, emoji)
+    assert args[1] == -100
+    assert args[2] == 42
+    assert args[3] == "⏳"
+
+
+def test_second_tick_does_not_double_queue(monkeypatch):
+    """Two ticks observing the same stalled session queue the reaction once."""
+    from monitoring import session_watchdog
+
+    fake = _FakeRedis()
+    monkeypatch.setattr("popoto.redis_db.POPOTO_REDIS_DB", fake)
+    monkeypatch.delenv("WATCHDOG_STALL_REACTION_ENABLED", raising=False)
+
+    session = _make_stale_pending_session()
+    session._get_history_list = lambda: []
+
+    sessions_by_status = {"pending": [session], "running": [], "active": []}
+    with patch(
+        "monitoring.session_watchdog.AgentSession.query",
+        _query_filter_for(sessions_by_status),
+    ):
+        session_watchdog.check_stalled_sessions()
+        session_watchdog.check_stalled_sessions()
+
+    queue_key = "telegram:outbox:tg_user_-100_42"
+    assert len(fake.lists[queue_key]) == 1

--- a/tests/unit/test_stall_detection.py
+++ b/tests/unit/test_stall_detection.py
@@ -299,3 +299,217 @@ class TestToTimestamp:
 
     def test_unrecognized_type_returns_none(self):
         assert _to_timestamp("not-a-datetime") is None
+
+
+# ===================================================================
+# _apply_stall_reaction (issue #1313)
+# ===================================================================
+
+
+def _make_stall_session(
+    session_id="tg_user_-100_42",
+    chat_id="-100",
+    telegram_message_id=42,
+    agent_session_id="as-001",
+):
+    """Build a SimpleNamespace mimicking AgentSession for stall-reaction tests."""
+    return SimpleNamespace(
+        session_id=session_id,
+        agent_session_id=agent_session_id,
+        chat_id=chat_id,
+        telegram_message_id=telegram_message_id,
+    )
+
+
+class _FakeRedis:
+    """Minimal in-memory Redis stub supporting set NX EX, rpush, expire, delete."""
+
+    def __init__(self):
+        self.store: dict[str, str] = {}
+        self.lists: dict[str, list[str]] = {}
+        self.expires: dict[str, int] = {}
+
+    def set(self, key, value, nx=False, ex=None):
+        if nx and key in self.store:
+            return None
+        self.store[key] = value
+        if ex is not None:
+            self.expires[key] = ex
+        return True
+
+    def rpush(self, key, value):
+        self.lists.setdefault(key, []).append(value)
+        return len(self.lists[key])
+
+    def expire(self, key, ttl):
+        self.expires[key] = ttl
+        return True
+
+    def delete(self, key):
+        self.store.pop(key, None)
+        self.lists.pop(key, None)
+        self.expires.pop(key, None)
+        return 1
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    fr = _FakeRedis()
+    monkeypatch.setattr("popoto.redis_db.POPOTO_REDIS_DB", fr)
+    return fr
+
+
+class TestStallReaction:
+    def test_reaction_queued_on_first_stall(self, fake_redis, monkeypatch):
+        from monitoring.session_watchdog import _apply_stall_reaction
+
+        monkeypatch.delenv("WATCHDOG_STALL_REACTION_ENABLED", raising=False)
+        session = _make_stall_session()
+        result = _apply_stall_reaction(session)
+        assert result is True
+        # Dedup key claimed
+        assert "watchdog:stall_reaction_applied:tg_user_-100_42" in fake_redis.store
+        # Outbox payload written
+        queue_key = "telegram:outbox:tg_user_-100_42"
+        assert queue_key in fake_redis.lists
+        import json as _json
+
+        payload = _json.loads(fake_redis.lists[queue_key][0])
+        assert payload["type"] == "reaction"
+        assert payload["chat_id"] == "-100"
+        assert payload["reply_to"] == 42
+        assert payload["emoji"] == "⏳"
+        assert payload["session_id"] == "tg_user_-100_42"
+        assert "timestamp" in payload
+        # TTL set on the queue
+        assert fake_redis.expires[queue_key] == 3600
+
+    def test_reaction_deduped_on_second_call(self, fake_redis, monkeypatch):
+        from monitoring.session_watchdog import _apply_stall_reaction
+
+        monkeypatch.delenv("WATCHDOG_STALL_REACTION_ENABLED", raising=False)
+        session = _make_stall_session()
+        first = _apply_stall_reaction(session)
+        second = _apply_stall_reaction(session)
+        assert first is True
+        assert second is False
+        # Only one payload was queued
+        queue_key = "telegram:outbox:tg_user_-100_42"
+        assert len(fake_redis.lists[queue_key]) == 1
+
+    def test_skip_when_no_telegram_message_id(self, fake_redis, monkeypatch):
+        from monitoring.session_watchdog import _apply_stall_reaction
+
+        monkeypatch.delenv("WATCHDOG_STALL_REACTION_ENABLED", raising=False)
+        session = _make_stall_session(telegram_message_id=None)
+        assert _apply_stall_reaction(session) is False
+        assert fake_redis.store == {}
+        assert fake_redis.lists == {}
+
+    def test_skip_when_no_chat_id(self, fake_redis, monkeypatch):
+        from monitoring.session_watchdog import _apply_stall_reaction
+
+        monkeypatch.delenv("WATCHDOG_STALL_REACTION_ENABLED", raising=False)
+        session = _make_stall_session(chat_id=None)
+        assert _apply_stall_reaction(session) is False
+        assert fake_redis.store == {}
+
+    def test_skip_when_telegram_message_id_zero(self, fake_redis, monkeypatch):
+        from monitoring.session_watchdog import _apply_stall_reaction
+
+        monkeypatch.delenv("WATCHDOG_STALL_REACTION_ENABLED", raising=False)
+        # 0 is treated as falsy -- no real Telegram message id is 0.
+        session = _make_stall_session(telegram_message_id=0)
+        assert _apply_stall_reaction(session) is False
+        assert fake_redis.store == {}
+
+    def test_skip_when_session_id_empty(self, fake_redis, monkeypatch):
+        from monitoring.session_watchdog import _apply_stall_reaction
+
+        monkeypatch.delenv("WATCHDOG_STALL_REACTION_ENABLED", raising=False)
+        session = _make_stall_session(session_id="", agent_session_id=None)
+        assert _apply_stall_reaction(session) is False
+
+    def test_skip_when_flag_disabled(self, fake_redis, monkeypatch):
+        from monitoring.session_watchdog import _apply_stall_reaction
+
+        monkeypatch.setenv("WATCHDOG_STALL_REACTION_ENABLED", "0")
+        session = _make_stall_session()
+        assert _apply_stall_reaction(session) is False
+        # No Redis writes when disabled
+        assert fake_redis.store == {}
+        assert fake_redis.lists == {}
+
+    def test_redis_exception_is_fail_quiet(self, monkeypatch):
+        from monitoring.session_watchdog import _apply_stall_reaction
+
+        class _BoomRedis:
+            def set(self, *a, **kw):
+                raise RuntimeError("redis down")
+
+            def rpush(self, *a, **kw):
+                raise RuntimeError("redis down")
+
+            def expire(self, *a, **kw):
+                raise RuntimeError("redis down")
+
+            def delete(self, *a, **kw):
+                raise RuntimeError("redis down")
+
+        monkeypatch.setattr("popoto.redis_db.POPOTO_REDIS_DB", _BoomRedis())
+        monkeypatch.delenv("WATCHDOG_STALL_REACTION_ENABLED", raising=False)
+        session = _make_stall_session()
+        # Must not raise
+        assert _apply_stall_reaction(session) is False
+
+    def test_payload_matches_build_reaction_payload(self, fake_redis, monkeypatch):
+        """Schema parity test: the watchdog's inlined payload literal must match
+        agent.output_handler.OutputHandler._build_reaction_payload byte-for-byte.
+
+        This is the ONLY mechanical defense against schema drift between the
+        two outbox writers. If this test fails, either reconcile the watchdog's
+        literal or update _build_reaction_payload (and probably the bridge relay).
+        """
+        from agent.output_handler import TelegramRelayOutputHandler
+        from monitoring.session_watchdog import _apply_stall_reaction
+
+        monkeypatch.delenv("WATCHDOG_STALL_REACTION_ENABLED", raising=False)
+        session = _make_stall_session()
+        assert _apply_stall_reaction(session) is True
+        import json as _json
+
+        queue_key = "telegram:outbox:tg_user_-100_42"
+        actual = _json.loads(fake_redis.lists[queue_key][0])
+
+        expected = TelegramRelayOutputHandler._build_reaction_payload(
+            chat_id=str(session.chat_id),
+            reply_to_msg_id=session.telegram_message_id,
+            emoji="⏳",
+            session_id=session.session_id,
+            timestamp=actual["timestamp"],
+        )
+        assert actual == expected
+
+    def test_clear_dedup_removes_key(self, fake_redis, monkeypatch):
+        from monitoring.session_watchdog import (
+            _apply_stall_reaction,
+            _clear_stall_reaction_dedup,
+        )
+
+        monkeypatch.delenv("WATCHDOG_STALL_REACTION_ENABLED", raising=False)
+        session = _make_stall_session()
+        # Apply once, then clear, then apply again -- should succeed twice.
+        assert _apply_stall_reaction(session) is True
+        _clear_stall_reaction_dedup(session.session_id)
+        assert "watchdog:stall_reaction_applied:tg_user_-100_42" not in fake_redis.store
+        # Second apply succeeds because the dedup key was cleared.
+        assert _apply_stall_reaction(session) is True
+        queue_key = "telegram:outbox:tg_user_-100_42"
+        assert len(fake_redis.lists[queue_key]) == 2
+
+    def test_clear_dedup_empty_session_id_is_noop(self, fake_redis):
+        from monitoring.session_watchdog import _clear_stall_reaction_dedup
+
+        # Should not raise, no Redis call needed.
+        _clear_stall_reaction_dedup("")
+        _clear_stall_reaction_dedup(None)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

When the watchdog detects a stalled session past its threshold, it now queues a ⏳ reaction on the originating Telegram message via the existing reaction outbox, in addition to the LIFECYCLE_STALL warning log.

## Changes
- New `_apply_stall_reaction()` helper in `monitoring/session_watchdog.py` mirroring `_inject_watchdog_steer` (env flag, atomic `SET NX EX` dedup, fail-quiet)
- Module constants `STALL_REACTION_EMOJI = "⏳"` and `STALL_REACTION_DEDUP_TTL = 86400`
- Env flag `WATCHDOG_STALL_REACTION_ENABLED` (default on)
- Dedup key `watchdog:stall_reaction_applied:{session_id}` cleared on next healthy-state observation, so re-stalls trigger fresh reactions
- Schema parity unit test guards drift from `_build_reaction_payload`
- Integration test verifies bridge relay accepts queued payload
- Docs updated in `bridge-self-healing.md` and `session-lifecycle.md`

## Testing
- [x] Unit tests passing (32 in `tests/unit/test_stall_detection.py`)
- [x] Integration test passing (3 in `tests/integration/test_watchdog_to_bridge.py`)
- [x] Lint and format clean
- [x] Schema parity test green

Closes #1313