### PR TITLE
sdlc-1302: G7 plan-revising lock — block build while critique is in revision

### DIFF
--- a/.claude/skills-global/do-build/SKILL.md
+++ b/.claude/skills-global/do-build/SKILL.md
@@ -124,6 +124,19 @@ If `TARGET_REPO == ORCHESTRATOR_REPO`, this is a same-repo build and no special 
    ```
    This is idempotent: if the worktree already exists (e.g., from an interrupted session), it returns the existing path. If not, it creates a fresh one. It also handles stale worktrees from crashed sessions, missing directories with lingering git references, and branch-already-in-use errors. Settings files are copied automatically.
    All subsequent agent work happens inside `$TARGET_REPO/.worktrees/{slug}/`, NOT the orchestrator repo directory.
+
+   **Record the plan hash at build start** (defense-in-depth against mid-build plan revisions — see guard G7):
+   ```bash
+   # PLAN_REPO may differ from TARGET_REPO for cross-repo builds (e.g. cuttlefish).
+   # Always resolve the plan's owning repo separately.
+   PLAN_REPO=$(git -C "$(dirname "$PLAN_PATH")" rev-parse --show-toplevel)
+   git -C "$PLAN_REPO" fetch origin main 2>/dev/null || true
+   PLAN_REL=$(python -c "import os; print(os.path.relpath('$PLAN_PATH', '$PLAN_REPO'))")
+   PLAN_HASH=$(git -C "$PLAN_REPO" log -1 --format=%H origin/main -- "$PLAN_REL")
+   sdlc-tool meta-set --key plan_hash_at_build_start --value "$PLAN_HASH" \
+     --issue-number {issue_number} 2>/dev/null || true
+   ```
+   If `PLAN_HASH` is empty (e.g. the plan file is not tracked by git), the `meta-set` call writes an empty string, and the Step 21 check becomes a no-op (guarded by `STORED_HASH` non-empty check).
 8. **Initialize pipeline state** - For fresh builds (no prior state), initialize now:
    ```bash
    python -c "from agent.build_pipeline import initialize; initialize('{slug}', 'session/{slug}', '$TARGET_REPO/.worktrees/{slug}', target_repo='$TARGET_REPO')"
@@ -175,6 +188,20 @@ If `TARGET_REPO == ORCHESTRATOR_REPO`, this is a same-repo build and no special 
     python -c "from agent.build_pipeline import advance_stage; advance_stage('{slug}', 'pr')"
     ```
 21. **Verify commits exist before PR** - Run `git -C $TARGET_REPO/.worktrees/{slug} log --oneline main..HEAD` and count the output lines. If zero commits exist on the session branch, **ABORT with error**: "BUILD FAILED: No commits on session/{slug}. Builder agents produced no code changes." Do NOT proceed to push or PR creation.
+
+   **Defense-in-depth: verify plan hash has not changed mid-build** (G7 second layer — catches revisions that committed during build execution):
+   ```bash
+   git -C "$PLAN_REPO" fetch origin main 2>/dev/null || true
+   CURRENT_HASH=$(git -C "$PLAN_REPO" log -1 --format=%H origin/main -- "$PLAN_REL")
+   STORED_HASH=$(sdlc-tool stage-query --issue-number {issue_number} \
+     | python -c "import sys,json; print(json.load(sys.stdin).get('_meta',{}).get('plan_hash_at_build_start') or '')")
+   if [ -n "$STORED_HASH" ] && [ "$CURRENT_HASH" != "$STORED_HASH" ]; then
+     echo "BUILD ABORT: plan revised mid-build (was=$STORED_HASH, now=$CURRENT_HASH, path=$PLAN_PATH)"
+     sdlc-tool stage-marker --stage BUILD --status failed --issue-number {issue_number} 2>/dev/null || true
+     exit 1
+   fi
+   ```
+   This check is a no-op when `STORED_HASH` is empty (sessions that pre-date this feature, or when the plan is not git-tracked). A non-empty mismatch means the plan was revised by a concurrent critique/plan cycle — abort so the router can re-route via G7 to a fresh revision round.
 22. **Push and open a PR** - `git -C $TARGET_REPO/.worktrees/{slug} push -u origin session/{slug}` then `gh pr create --repo $TARGET_GH_REPO` (use `--repo` only for cross-repo builds)
 23. **Run documentation cascade** - Invoke `/do-docs {PR-number}` to surgically update affected docs
 24. **Plan stays until merge** - Do NOT delete the plan here; `do-merge` deletes it after the PR merges (issue closes automatically via `Closes #N`)

--- a/.claude/skills-global/do-plan-critique/SKILL.md
+++ b/.claude/skills-global/do-plan-critique/SKILL.md
@@ -251,6 +251,25 @@ Where `$VERDICT_STRING` is the exact verdict string emitted in Step 5 (e.g. `"NE
 
 The recorder exits non-zero on failure (e.g. Redis unreachable) so the operator sees the error in their session log, but it still prints `{}` to stdout for callers parsing JSON. A failed recording surfaces loudly; it does not silently corrupt verdict state.
 
+### Step 5.6: Set plan-revising lock (mandatory when revision is needed)
+
+After recording the verdict, set the `plan_revising` lock on the PM session whenever the verdict requires a revision pass AND `revision_applied` is not already set in the plan frontmatter. This lock activates guard G7 in the SDLC router, which blocks `/do-build` until `/do-plan` completes the revision and clears the lock.
+
+Set the lock when the verdict is one of:
+- `NEEDS REVISION`
+- `MAJOR REWORK`
+- `READY TO BUILD (with concerns)` — and `revision_applied` is not already `true` in the plan frontmatter
+
+```bash
+# Set plan_revising lock after verdict record, when revision is needed
+sdlc-tool meta-set --key plan_revising --value true \
+  --issue-number $ISSUE_NUMBER 2>/dev/null || true
+```
+
+**Do NOT set the lock** when the verdict is `READY TO BUILD (no concerns)` — no revision pass is needed and the lock would incorrectly block build dispatch.
+
+**Do NOT set the lock** when `revision_applied: true` is already in the plan frontmatter — the revision has already been applied and the lock would be immediately self-healed by G7 anyway.
+
 ## Outcome Contract
 
 The skill returns a structured verdict that the SDLC pipeline can use:

--- a/.claude/skills-global/do-plan/SKILL.md
+++ b/.claude/skills-global/do-plan/SKILL.md
@@ -441,6 +441,25 @@ After receiving answers:
 
 1. **Update plan** - Incorporate feedback, remove Open Questions section
 2. **Mark as finalized** - Update frontmatter: `status: Ready`
+
+**If this is a revision pass** (critique returned NEEDS REVISION / MAJOR REWORK / READY TO BUILD with concerns AND the plan has been revised based on critique findings):
+
+2a. **Set `revision_applied: true`** in the plan frontmatter — this is the canonical signal that the plan has settled and the lock is no longer needed:
+```bash
+# In the plan frontmatter, set revision_applied: true
+# Then commit and push
+git add docs/plans/{slug}.md && git commit -m "Plan revision ({slug}): address critique findings"
+git push
+```
+
+2b. **Clear the plan-revising lock** — immediately after committing and pushing, clear the lock so the SDLC router can route to build. The lock and `revision_applied` must move together; both reflect "plan is settled":
+```bash
+# Clear the plan_revising lock (G7 guard will self-heal even if this is skipped,
+# but clearing explicitly is the correct signal that the revision is complete)
+sdlc-tool meta-set --key plan_revising --value false \
+  --issue-number {issue_number} 2>/dev/null || true
+```
+
 3. **Invite discussion**:
 
 ```

--- a/.claude/skills-global/sdlc/SKILL.md
+++ b/.claude/skills-global/sdlc/SKILL.md
@@ -152,10 +152,13 @@ The canonical Python implementation is `agent.sdlc_router.decide_next_dispatch()
 | G4: Oscillation (universal) | `same_stage_dispatch_count >= 3` | Escalate: `blocked` with reason `stage oscillation — {skill} dispatched {N} times without state change` |
 | G5: Unchanged critique artifact | `_verdicts["CRITIQUE"]` has `artifact_hash` AND current plan file hash matches | Use cached verdict: `/do-plan` (NEEDS REVISION) or `/do-build` (READY TO BUILD). Never re-dispatch `/do-plan-critique` on an unchanged plan. |
 | G6: Terminal merge ready | `pr_number` set AND `pr_merge_state == "CLEAN"` AND `ci_all_passing == True` AND `DOCS == "completed"` AND `_verdicts["REVIEW"]` contains `APPROVED` | `/do-merge {pr_number}` |
+| G7: Plan-revising lock | `pr_number` is None AND `plan_revising == True` AND `revision_applied != True` | `/do-plan` (if `last_dispatched_skill == /do-plan-critique`); Escalate `blocked` (if no `/do-plan` in last `MAX_PLAN_REVISING_DISPATCHES + 1` turns) |
 
 **G4 is universal** — it applies to EVERY stage, including DOCS and MERGE. Repeated dispatches of `/do-docs` or `/do-merge` without state change WILL trip the guard.
 
 **G5 applies to CRITIQUE only**, not REVIEW. Review verdicts legitimately change on unchanged diffs (CI flips, new comments, linked issues). G4 handles REVIEW non-determinism instead.
+
+**G7 blocks build while plan revision is in flight.** The lock is set by `/do-plan-critique` (Step 5.6) when the verdict requires a revision pass. It is cleared by `/do-plan` (Phase 4, Step 2b) after committing and pushing the revision. G7 self-heals when `revision_applied: true` is in the plan frontmatter even if the explicit lock-clear step was skipped. G7 is gated on `pr_number is None` so an already-shipped PR is never blocked.
 
 After evaluating guards, record the dispatch decision via `sdlc-tool dispatch record` BEFORE invoking the sub-skill. This preserves the G4 oscillation signal even if the sub-skill crashes mid-execution.
 

--- a/agent/sdlc_router.py
+++ b/agent/sdlc_router.py
@@ -46,6 +46,12 @@ logger = logging.getLogger(__name__)
 # without the pipeline state changing; the fourth would trip G4.
 MAX_SAME_STAGE_DISPATCHES = 3
 
+# Maximum number of router turns that G7 will wait for a /do-plan dispatch
+# after the plan_revising lock is set. After this many turns with no /do-plan
+# in the recent dispatch history, G7 escalates to Blocked so a human can
+# intervene. Value of 2 allows one self-healing turn before escalating.
+MAX_PLAN_REVISING_DISPATCHES = 2
+
 # Maximum number of entries retained in ``_sdlc_dispatches``. Older entries are
 # FIFO-evicted. Picked to be comfortably larger than ``MAX_SAME_STAGE_DISPATCHES``
 # so G4 has enough history to detect sustained oscillation while still bounding
@@ -381,6 +387,93 @@ def guard_g5_artifact_hash_cache(
     return None
 
 
+def guard_g7_plan_revising(
+    stage_states: dict, meta: dict, context: dict
+) -> Dispatch | Blocked | None:
+    """G7: block /do-build while the plan-revising lock is set.
+
+    The lock (``_meta["plan_revising"]``) is set by ``/do-plan-critique`` when
+    its verdict is NEEDS REVISION, MAJOR REWORK, or READY TO BUILD (with
+    concerns) and the revision pass has not yet run. It is cleared by
+    ``/do-plan`` in the same step that writes ``revision_applied: true``.
+
+    **Predicate (evaluated in order):**
+    1. If ``pr_number`` is set → return None (G3/G6 own PR-stage routing; an
+       already-shipped PR is never blocked by plan revisions).
+    2. If ``plan_revising`` is falsy → return None (lock not set, fall through).
+    3. Self-heal: if ``plan_revising`` is truthy AND ``revision_applied`` is also
+       truthy → return None (plan was revised but the lock-clear step never ran,
+       e.g. skill crashed mid-step; revision_applied is the source of truth).
+    4. If lock is set AND ``last_dispatched_skill`` is ``/do-plan-critique``
+       (critique just finished) → return Dispatch(/do-plan): the obvious next
+       step is to apply the revision.
+    5. If lock is set AND no ``/do-plan`` appears in the last
+       ``MAX_PLAN_REVISING_DISPATCHES + 1`` dispatch history entries → return
+       Blocked: the lock has been set for multiple turns with no plan dispatch,
+       indicating the pipeline is stuck and a human should intervene.
+    6. Otherwise → return None: a plan dispatch is already in the recent history;
+       allow the dispatch table to route normally (the plan may still be in
+       flight).
+
+    **Ordering:** G7 is evaluated AFTER G6 (terminal merge fast-path) so that
+    an already-mergeable PR is never blocked by a stale plan_revising flag.
+    G7 is gated on ``pr_number is None`` for the same reason.
+
+    **Deadlock backstop:** If the lock leaks (critique crashes after setting it
+    but before /do-plan runs), G7 escalates to Blocked after
+    ``MAX_PLAN_REVISING_DISPATCHES`` turns. The operator can clear the lock
+    manually via ``sdlc-tool meta-set --key plan_revising --value false``.
+    """
+    # Gate 1: PR exists — G3/G6 own routing at this stage.
+    if meta.get("pr_number"):
+        return None
+
+    # Gate 2: Lock not set — nothing to do.
+    if not meta.get("plan_revising"):
+        return None
+
+    # Gate 3: Self-heal — revision_applied supersedes the lock.
+    if meta.get("revision_applied"):
+        return None
+
+    # The lock is set and the plan has not been marked as revised.
+    last_skill = meta.get("last_dispatched_skill") or ""
+    history = stage_states.get("_sdlc_dispatches") or []
+    if not isinstance(history, list):
+        history = []
+
+    # Gate 4: Critique just finished — route to plan revision.
+    if last_skill == SKILL_DO_PLAN_CRITIQUE:
+        return Dispatch(
+            skill=SKILL_DO_PLAN,
+            reason=(
+                "G7: plan_revising lock is set and critique just ran — "
+                "apply the revision pass before building"
+            ),
+            row_id="G7",
+        )
+
+    # Gate 5: Check recent dispatch history for a /do-plan entry.
+    # Look back MAX_PLAN_REVISING_DISPATCHES + 1 entries so one self-healing
+    # turn is allowed before escalating.
+    recent = history[-(MAX_PLAN_REVISING_DISPATCHES + 1) :]
+    recent_skills = [e.get("skill") for e in recent if isinstance(e, dict)]
+    if SKILL_DO_PLAN not in recent_skills:
+        return Blocked(
+            reason=(
+                f"G7: plan_revising lock set but no /do-plan dispatched in the "
+                f"last {MAX_PLAN_REVISING_DISPATCHES + 1} turns. "
+                f"Pipeline may be stuck. Clear the lock manually via "
+                f"'sdlc-tool meta-set --key plan_revising --value false' if the "
+                f"revision is already complete."
+            ),
+            guard_id="G7",
+        )
+
+    # A plan dispatch is already in the recent history — let dispatch table route.
+    return None
+
+
 def guard_g6_terminal_merge_ready(stage_states: dict, meta: dict, context: dict) -> Dispatch | None:
     """G6: PR is mergeable, CI green, DOCS done, review APPROVED — fast-path to /do-merge.
 
@@ -430,6 +523,7 @@ GUARDS: list[Callable[[dict, dict, dict], Dispatch | Blocked | None]] = [
     guard_g4_oscillation,
     guard_g5_artifact_hash_cache,
     guard_g6_terminal_merge_ready,
+    guard_g7_plan_revising,
 ]
 
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -124,6 +124,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [SDLC Critique Stage](sdlc-critique-stage.md) | Automated plan validation between PLAN and BUILD stages with parallel war-room critics and inline source file verification | Shipped |
 | [SDLC Enforcement](sdlc-enforcement.md) | Quality gates for code sessions: user-level hooks, pipeline stage model, settings merger, cross-repo enforcement | Shipped |
 | [SDLC Observer](sdlc-observer.md) | Web dashboard for real-time SDLC pipeline tracking with stage indicators, event timelines, and artifact links at `/sdlc/` | Shipped |
+| [SDLC Pipeline](sdlc-pipeline.md) | Pipeline routing overview, G1–G7 legal dispatch guards, `_meta` field reference, plan-revising lock (G7), and CLI tool reference | Shipped |
 | [SDLC Pipeline Integrity](sdlc-pipeline-integrity.md) | Session continuation hardening, deterministic URL construction, merge guard hook, MERGE pipeline stage, and structured review comment enforcement | Shipped |
 | [SDLC Pipeline State](sdlc-pipeline-state.md) | Local Claude Code session state tracking via `--issue-number` flag and `sdlc_session_ensure` tool, enabling stage markers to write to Redis without bridge env vars | Shipped |
 | [SDLC Repo Addenda](sdlc-repo-addenda.md) | Per-stage `docs/sdlc/` notes injected into global SDLC skills at runtime; reflection agent proposes updates every 3 days | Shipped |

--- a/docs/features/sdlc-pipeline.md
+++ b/docs/features/sdlc-pipeline.md
@@ -1,0 +1,108 @@
+# SDLC Pipeline
+
+Overview of the SDLC pipeline routing, guards, and key metadata fields used by the SDLC router (`agent/sdlc_router.py`).
+
+## Pipeline Flow
+
+```
+ISSUE → PLAN → CRITIQUE → BUILD → TEST → PATCH → REVIEW → DOCS → MERGE
+```
+
+Each stage is tracked in `AgentSession.stage_states` as a JSON dict with stage-status keys (e.g. `{"ISSUE": "completed", "PLAN": "completed", ...}`). The SDLC router reads this state (via `sdlc-tool stage-query`) and dispatches one sub-skill per invocation.
+
+## Legal Dispatch Guards (G1–G7)
+
+Guards are evaluated in order before the dispatch table. If any guard fires, its decision overrides the table.
+
+| Guard | Condition | Forced Dispatch |
+|-------|-----------|-----------------|
+| G1: Critique loop | Verdict NEEDS REVISION or MAJOR REWORK AND last dispatch was critique | `/do-plan` |
+| G2: Critique cycle cap | `critique_cycle_count >= MAX_CRITIQUE_CYCLES` AND CRITIQUE not completed | `blocked` |
+| G3: PR lock | PR open AND last/proposed dispatch is plan-stage skill | Redirect to appropriate PR-stage skill |
+| G4: Oscillation | Same skill dispatched `MAX_SAME_STAGE_DISPATCHES` times without state change | `blocked` |
+| G5: Unchanged plan hash | Critique verdict exists with matching `artifact_hash` | Reuse cached verdict |
+| G6: Terminal merge | PR open, CI green, DOCS done, review APPROVED | `/do-merge` |
+| G7: Plan-revising lock | `plan_revising=True` AND `revision_applied!=True` AND no open PR | `/do-plan` or `blocked` |
+
+## Plan-Revising Lock (G7)
+
+G7 prevents `/do-build` from being dispatched while a critique-driven revision is still in flight.
+
+### Problem it solves
+
+Without G7, the pipeline had a race condition: a second critique round could revise the plan _after_ build had already consumed it and opened a PR. The cuttlefish #350 incident captured this failure: round-2 critique flagged a defect and revised the plan _after_ `/do-build` had shipped — the defect was rediscovered downstream as a review blocker, requiring a `/do-patch` round to apply the fix the critique had prescribed hours earlier.
+
+### How it works
+
+1. **Critique sets the lock**: `/do-plan-critique` Step 5.6 calls `sdlc-tool meta-set --key plan_revising --value true` when the verdict is NEEDS REVISION, MAJOR REWORK, or READY TO BUILD (with concerns) _and_ `revision_applied` is not already true in the plan frontmatter.
+
+2. **Router blocks build**: G7 in `agent/sdlc_router.py::guard_g7_plan_revising` fires when `_meta.plan_revising` is truthy and `revision_applied` is falsy. If critique just ran (last dispatch was `/do-plan-critique`), G7 returns `Dispatch(/do-plan)`. If the lock has been set for more than `MAX_PLAN_REVISING_DISPATCHES + 1` router turns with no `/do-plan` in the recent dispatch history, G7 escalates to `Blocked`.
+
+3. **Plan clears the lock**: `/do-plan` Phase 4 calls `sdlc-tool meta-set --key plan_revising --value false` in the same step that writes `revision_applied: true` to the plan frontmatter. The two signals always move together.
+
+4. **Build proceeds normally**: Once the lock is cleared and `revision_applied: true` is set, the dispatch table routes to `/do-build` via Row 4c.
+
+### Self-healing
+
+If the lock-clear step is skipped (e.g. the plan skill crashes after writing `revision_applied: true` but before calling `meta-set`), G7 self-heals:
+
+```python
+# G7 gate 3: self-heal
+if meta.get("revision_applied"):
+    return None  # Lock informational only; revision_applied is the source of truth
+```
+
+### Deadlock backstop
+
+If the lock is set but no `/do-plan` dispatch occurs within `MAX_PLAN_REVISING_DISPATCHES` (default 2) turns, G7 escalates to `Blocked`. The operator can manually clear the lock:
+
+```bash
+sdlc-tool meta-set --key plan_revising --value false --issue-number {N}
+```
+
+### Storage
+
+The lock is stored as `stage_states["_plan_revising"]` (bool) on the PM session. It is surfaced in `_meta.plan_revising` by `tools/sdlc_stage_query.py::_compute_meta()`.
+
+A second metadata field, `_plan_hash_at_build_start` (str|None), is written by `/do-build` Step 7 and verified at Step 21 as a defense-in-depth check. If the plan's git commit hash changes mid-build, the build aborts.
+
+## `_meta` Fields
+
+The enriched stage query output (`sdlc-tool stage-query`) includes a `_meta` dict alongside `stages`:
+
+| Field | Type | Source | Description |
+|-------|------|--------|-------------|
+| `patch_cycle_count` | int | `_patch_cycle_count` | Number of patch cycles run |
+| `critique_cycle_count` | int | `_critique_cycle_count` | Number of critique cycles run |
+| `latest_critique_verdict` | str\|None | `_verdicts["CRITIQUE"]` | Most recent critique verdict text |
+| `latest_review_verdict` | str\|None | `_verdicts["REVIEW"]` | Most recent review verdict text |
+| `revision_applied` | bool | Plan frontmatter | Whether `revision_applied: true` is in the plan doc |
+| `pr_number` | int\|None | Session attr or `gh pr list` | Open PR number for this issue |
+| `pr_merge_state` | str\|None | GitHub API | `mergeStateStatus` from `gh pr view` |
+| `ci_all_passing` | bool\|None | GitHub API | Whether all status checks pass |
+| `same_stage_dispatch_count` | int | `_sdlc_dispatches` | Consecutive same-skill same-state dispatches |
+| `last_dispatched_skill` | str\|None | `_sdlc_dispatches` | Most recent skill dispatched |
+| `plan_revising` | bool | `_plan_revising` | Plan-revising lock state (G7) |
+| `plan_hash_at_build_start` | str\|None | `_plan_hash_at_build_start` | Git commit hash of plan doc at build start |
+
+## CLI Tools
+
+| Tool | Purpose |
+|------|---------|
+| `sdlc-tool stage-query --issue-number N` | Query current pipeline state |
+| `sdlc-tool stage-marker --stage S --status X` | Mark stage progress |
+| `sdlc-tool verdict record --stage S --verdict V` | Record critique/review verdict |
+| `sdlc-tool dispatch record --skill /do-X` | Record a dispatch event |
+| `sdlc-tool next-skill --issue-number N` | Get next dispatch decision |
+| `sdlc-tool meta-set --key K --value V` | Set a whitelisted _meta key |
+| `sdlc-tool session-ensure --issue-number N` | Ensure a PM session exists |
+
+## See Also
+
+- `agent/sdlc_router.py` — canonical dispatch algorithm
+- `agent/pipeline_graph.py` — pipeline stage edges
+- `agent/pipeline_state.py` — stage state machine
+- `tools/sdlc_stage_query.py` — enriched query and `_compute_meta()`
+- `tools/sdlc_meta_set.py` — whitelisted metadata writes
+- `docs/sdlc/` — per-stage skill addenda
+- `.claude/skills-global/sdlc/SKILL.md` — runtime routing instructions

--- a/docs/sdlc/plan-revising-lock.md
+++ b/docs/sdlc/plan-revising-lock.md
@@ -1,0 +1,67 @@
+# SDLC Addendum: Plan-Revising Lock (`_meta.plan_revising`)
+
+**Introduced in:** issue #1302 — "SDLC state machine: build must block on in-flight plan critique"
+
+## Overview
+
+`_meta.plan_revising` is a bool flag stored in `stage_states["_plan_revising"]` on the PM session. It signals that a critique-driven revision pass is pending — the critique has identified issues that require plan edits before build can proceed.
+
+The flag activates guard G7 in `agent/sdlc_router.py`, which blocks `/do-build` dispatch and redirects the pipeline to `/do-plan`.
+
+## Set and Clear Contract
+
+| Who | When | Action |
+|-----|------|--------|
+| `/do-plan-critique` Step 5.6 | Verdict is NEEDS REVISION, MAJOR REWORK, or READY TO BUILD (with concerns) AND `revision_applied` not yet true | `sdlc-tool meta-set --key plan_revising --value true --issue-number N` |
+| `/do-plan` Phase 4 Step 2b | After committing the revised plan and writing `revision_applied: true` to frontmatter | `sdlc-tool meta-set --key plan_revising --value false --issue-number N` |
+
+**Important:** `plan_revising` and `revision_applied` must move together. Both reflect "the plan is settled." If the lock-clear step is skipped (e.g. skill crash after `revision_applied: true` was written), G7 self-heals automatically via the `revision_applied` conjunction.
+
+## G7 Guard Logic
+
+```
+guard_g7_plan_revising(stage_states, meta, context):
+  1. pr_number is set → None (G3/G6 own PR-stage routing)
+  2. plan_revising is falsy → None (lock not set)
+  3. plan_revising AND revision_applied → None (self-heal)
+  4. plan_revising AND last_skill == /do-plan-critique → Dispatch(/do-plan)
+  5. plan_revising AND no /do-plan in recent MAX+1 history → Blocked(G7)
+  6. otherwise → None (plan dispatch already in recent history)
+```
+
+## Manual Recovery
+
+If the lock is stuck (critique set it but no plan dispatch occurred):
+
+```bash
+# Clear the lock manually
+sdlc-tool meta-set --key plan_revising --value false --issue-number N
+
+# Verify it was cleared
+sdlc-tool stage-query --issue-number N | python -c "import sys,json; d=json.load(sys.stdin); print(d['_meta']['plan_revising'])"
+```
+
+## Related Meta Field: `plan_hash_at_build_start`
+
+A companion field, `_plan_hash_at_build_start` (str|None), stores the git commit hash of the plan document at the moment `/do-build` begins. This enables a defense-in-depth check at Step 21 (pre-PR) that aborts the build if the plan was revised mid-execution.
+
+The hash is set by `/do-build` Step 7 and verified at Step 21:
+
+```bash
+# Step 7: record hash
+PLAN_REPO=$(git -C "$(dirname "$PLAN_PATH")" rev-parse --show-toplevel)
+git -C "$PLAN_REPO" fetch origin main 2>/dev/null || true
+PLAN_HASH=$(git -C "$PLAN_REPO" log -1 --format=%H origin/main -- "$PLAN_REL")
+sdlc-tool meta-set --key plan_hash_at_build_start --value "$PLAN_HASH" --issue-number N
+
+# Step 21: verify (aborts if changed)
+CURRENT_HASH=$(git -C "$PLAN_REPO" log -1 --format=%H origin/main -- "$PLAN_REL")
+STORED_HASH=$(sdlc-tool stage-query --issue-number N | python -c "...")
+if [ -n "$STORED_HASH" ] && [ "$CURRENT_HASH" != "$STORED_HASH" ]; then
+  echo "BUILD ABORT: plan revised mid-build"
+  sdlc-tool stage-marker --stage BUILD --status failed --issue-number N
+  exit 1
+fi
+```
+
+The check is a no-op when `STORED_HASH` is empty (pre-#1302 sessions, or untracked plan files).

--- a/scripts/sdlc-tool
+++ b/scripts/sdlc-tool
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-ALLOWED_SUBCOMMANDS=(verdict dispatch stage-marker stage-query session-ensure next-skill)
+ALLOWED_SUBCOMMANDS=(verdict dispatch stage-marker stage-query session-ensure next-skill meta-set)
 
 usage() {
     cat <<EOF >&2
@@ -29,6 +29,7 @@ Subcommands:
   stage-query      Query current SDLC pipeline state (best-effort)
   session-ensure   Ensure an AgentSession exists for the issue (best-effort)
   next-skill       Compute the next dispatch decision (production routing)
+  meta-set         Set a whitelisted _meta key on the PM session (best-effort)
 
 Environment:
   AI_REPO_ROOT     Path to the ai/ repo (default: \$HOME/src/ai).

--- a/tests/integration/test_sdlc_pipeline_lock.py
+++ b/tests/integration/test_sdlc_pipeline_lock.py
@@ -1,0 +1,211 @@
+"""Integration test for SDLC pipeline G7 plan-revising lock (issue #1302).
+
+Simulates the full critique → plan_revising=True → router blocks build →
+plan clears lock → router routes to build flow using a real AgentSession
+in Redis.
+
+Uses project_key prefix "test-1302-lock-" so test sessions are easy to identify
+and clean up. All cleanup goes through the ORM only — never raw Redis.
+
+Markers:
+    sdlc  — SDLC pipeline test
+    integration — requires Redis
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.sdlc
+
+
+def _make_session(project_key: str, issue_number: int | None = None):
+    """Create a minimal PM AgentSession for testing.
+
+    Returns the session or None if AgentSession is unavailable.
+    """
+    try:
+        from models.agent_session import AgentSession
+
+        session = AgentSession()
+        session.session_id = f"test-1302-{uuid.uuid4().hex[:8]}"
+        session.session_type = "pm"
+        session.project_key = project_key
+        session.status = "active"
+        if issue_number:
+            session.issue_number = issue_number
+        session.stage_states = json.dumps(
+            {
+                "ISSUE": "completed",
+                "PLAN": "completed",
+                "CRITIQUE": "completed",
+                "BUILD": "pending",
+                # Use READY TO BUILD (with concerns) so G1 does not fire
+                # (G1 only trips on NEEDS REVISION / MAJOR REWORK + critique-just-ran)
+                "_verdicts": {"CRITIQUE": {"verdict": "READY TO BUILD (with concerns)"}},
+            }
+        )
+        session.save()
+        return session
+    except Exception as e:
+        pytest.skip(f"Cannot create test session (Redis unavailable?): {e}")
+
+
+def _cleanup_sessions(project_key_prefix: str):
+    """Delete all test sessions matching the project_key prefix via ORM only."""
+    try:
+        from models.agent_session import AgentSession
+
+        sessions = list(AgentSession.query.all())
+        for s in sessions:
+            if getattr(s, "project_key", "").startswith(project_key_prefix):
+                try:
+                    s.delete()
+                except Exception:
+                    pass
+    except Exception:
+        pass
+
+
+PROJECT_KEY_PREFIX = "test-1302-lock-"
+
+
+@pytest.fixture(autouse=True)
+def cleanup_test_sessions():
+    """Auto-cleanup test sessions before and after each test."""
+    _cleanup_sessions(PROJECT_KEY_PREFIX)
+    yield
+    _cleanup_sessions(PROJECT_KEY_PREFIX)
+
+
+class TestPlanRevisingLockIntegration:
+    """Integration tests for G7 using real AgentSession in Redis."""
+
+    def test_critique_sets_lock_blocks_build_plan_clears_lock_routes_build(self):
+        """Full flow: critique sets lock → build is blocked → plan clears → build dispatches."""
+        from agent.sdlc_router import decide_next_dispatch
+        from tools.sdlc_meta_set import write_meta
+        from tools.stage_states_helpers import update_stage_states
+
+        project_key = f"{PROJECT_KEY_PREFIX}full-flow-{uuid.uuid4().hex[:6]}"
+        session = _make_session(project_key)
+
+        # Step 1: Simulate critique writing the plan_revising lock.
+        def set_lock(states: dict) -> dict:
+            states["_plan_revising"] = True
+            return states
+
+        success = update_stage_states(session, set_lock)
+        assert success, "update_stage_states failed to set _plan_revising"
+
+        # Reload session to see the updated stage_states.
+        from models.agent_session import AgentSession
+
+        sessions = list(AgentSession.query.filter(session_id=session.session_id))
+        assert sessions, "Session not found after save"
+        reloaded = sessions[0]
+
+        raw = json.loads(reloaded.stage_states or "{}")
+        assert raw.get("_plan_revising") is True, "Lock was not set"
+
+        # Step 2: Build the meta dict simulating what sdlc_stage_query returns.
+        meta_with_lock = {
+            "plan_revising": True,
+            "revision_applied": False,
+            "pr_number": None,
+            # Use READY TO BUILD (with concerns) so G1 does not fire.
+            # G1 only fires on NEEDS REVISION / MAJOR REWORK + critique-just-ran.
+            # G7 fires on any plan_revising=True + critique-just-ran.
+            "latest_critique_verdict": "READY TO BUILD (with concerns)",
+            "last_dispatched_skill": "/do-plan-critique",
+            "same_stage_dispatch_count": 0,
+            "critique_cycle_count": 1,
+            "patch_cycle_count": 0,
+            "latest_review_verdict": None,
+            "pr_merge_state": None,
+            "ci_all_passing": None,
+            "plan_hash_at_build_start": None,
+        }
+
+        # Step 3: Assert router routes to /do-plan (not /do-build) with lock set.
+        stage_states = raw
+        result = decide_next_dispatch(stage_states, meta_with_lock, {})
+
+        from agent.sdlc_router import Dispatch
+
+        assert isinstance(result, Dispatch), f"Expected Dispatch, got {result!r}"
+        assert result.skill == "/do-plan", f"Expected /do-plan with lock set, got {result.skill!r}"
+        assert result.row_id == "G7", f"Expected G7, got {result.row_id!r}"
+
+        # Step 4: Simulate plan clearing the lock (write_meta with plan_revising=false).
+        with patch("tools.sdlc_meta_set._find_session", return_value=reloaded):
+            clear_result = write_meta(key="plan_revising", value="false")
+
+        assert clear_result == {"key": "plan_revising", "value": False}, (
+            f"write_meta failed to clear lock: {clear_result!r}"
+        )
+
+        # Reload and verify lock is cleared.
+        sessions2 = list(AgentSession.query.filter(session_id=session.session_id))
+        reloaded2 = sessions2[0]
+        raw2 = json.loads(reloaded2.stage_states or "{}")
+        assert raw2.get("_plan_revising") is False, "Lock was not cleared"
+
+        # Step 5: With lock cleared, assert router routes to /do-build.
+        meta_cleared = {
+            **meta_with_lock,
+            "plan_revising": False,
+            "revision_applied": True,
+            "last_dispatched_skill": "/do-plan",
+        }
+
+        result2 = decide_next_dispatch(raw2, meta_cleared, {})
+        assert isinstance(result2, Dispatch), f"Expected Dispatch after lock clear, got {result2!r}"
+        assert result2.skill == "/do-build", (
+            f"Expected /do-build after lock cleared, got {result2.skill!r}"
+        )
+
+    def test_write_meta_persists_plan_revising(self):
+        """write_meta correctly persists plan_revising=True to stage_states."""
+        from tools.sdlc_meta_set import write_meta
+
+        project_key = f"{PROJECT_KEY_PREFIX}persist-{uuid.uuid4().hex[:6]}"
+        session = _make_session(project_key)
+
+        with patch("tools.sdlc_meta_set._find_session", return_value=session):
+            result = write_meta(key="plan_revising", value="true")
+
+        assert result == {"key": "plan_revising", "value": True}
+
+        # Verify persistence by reloading from Redis.
+        from models.agent_session import AgentSession
+
+        sessions = list(AgentSession.query.filter(session_id=session.session_id))
+        reloaded = sessions[0]
+        raw = json.loads(reloaded.stage_states or "{}")
+        assert raw.get("_plan_revising") is True
+
+    def test_write_meta_persists_plan_hash(self):
+        """write_meta correctly persists plan_hash_at_build_start to stage_states."""
+        from tools.sdlc_meta_set import write_meta
+
+        project_key = f"{PROJECT_KEY_PREFIX}hash-{uuid.uuid4().hex[:6]}"
+        session = _make_session(project_key)
+        test_hash = "deadbeef1234567890"
+
+        with patch("tools.sdlc_meta_set._find_session", return_value=session):
+            result = write_meta(key="plan_hash_at_build_start", value=test_hash)
+
+        assert result == {"key": "plan_hash_at_build_start", "value": test_hash}
+
+        from models.agent_session import AgentSession
+
+        sessions = list(AgentSession.query.filter(session_id=session.session_id))
+        reloaded = sessions[0]
+        raw = json.loads(reloaded.stage_states or "{}")
+        assert raw.get("_plan_hash_at_build_start") == test_hash

--- a/tests/unit/test_sdlc_meta_set.py
+++ b/tests/unit/test_sdlc_meta_set.py
@@ -1,0 +1,265 @@
+"""Unit tests for tools.sdlc_meta_set CLI tool (issue #1302).
+
+Tests cover:
+- Valid key sets stage_states["_<key>"] via update_stage_states()
+- Unknown key exits with code 2
+- Missing session is fail-soft (returns {})
+- Bool coercion for plan_revising
+- String coercion for plan_hash_at_build_start
+- Whitelist enforcement
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+class TestMetaSetWriteMeta:
+    """Tests for the write_meta() function."""
+
+    def test_valid_bool_key_sets_value(self):
+        """write_meta with plan_revising=True writes _plan_revising=True."""
+        from tools.sdlc_meta_set import write_meta
+
+        mock_session = MagicMock()
+        mock_session.stage_states = "{}"
+        mock_session.session_type = "pm"
+
+        def fake_update_stage_states(session, update_fn, **kwargs):
+            # Simulate applying the update to an empty dict
+            result = update_fn({})
+            assert result.get("_plan_revising") is True
+            return True
+
+        with (
+            patch("tools.sdlc_meta_set._find_session", return_value=mock_session),
+            patch(
+                "tools.stage_states_helpers.update_stage_states",
+                side_effect=fake_update_stage_states,
+            ),
+        ):
+            result = write_meta(key="plan_revising", value="true")
+
+        assert result == {"key": "plan_revising", "value": True}
+
+    def test_valid_bool_key_false_clears_value(self):
+        """write_meta with plan_revising=false writes _plan_revising=False."""
+        from tools.sdlc_meta_set import write_meta
+
+        mock_session = MagicMock()
+        mock_session.stage_states = '{"_plan_revising": true}'
+        mock_session.session_type = "pm"
+
+        def fake_update_stage_states(session, update_fn, **kwargs):
+            result = update_fn({"_plan_revising": True})
+            assert result.get("_plan_revising") is False
+            return True
+
+        with (
+            patch("tools.sdlc_meta_set._find_session", return_value=mock_session),
+            patch(
+                "tools.stage_states_helpers.update_stage_states",
+                side_effect=fake_update_stage_states,
+            ),
+        ):
+            result = write_meta(key="plan_revising", value="false")
+
+        assert result == {"key": "plan_revising", "value": False}
+
+    def test_valid_str_key_sets_value(self):
+        """write_meta with plan_hash_at_build_start sets the string value."""
+        from tools.sdlc_meta_set import write_meta
+
+        mock_session = MagicMock()
+        mock_session.stage_states = "{}"
+        mock_session.session_type = "pm"
+        test_hash = "abc123def456"
+
+        def fake_update_stage_states(session, update_fn, **kwargs):
+            result = update_fn({})
+            assert result.get("_plan_hash_at_build_start") == test_hash
+            return True
+
+        with (
+            patch("tools.sdlc_meta_set._find_session", return_value=mock_session),
+            patch(
+                "tools.stage_states_helpers.update_stage_states",
+                side_effect=fake_update_stage_states,
+            ),
+        ):
+            result = write_meta(key="plan_hash_at_build_start", value=test_hash)
+
+        assert result == {"key": "plan_hash_at_build_start", "value": test_hash}
+
+    def test_unknown_key_returns_empty_dict(self):
+        """write_meta with an unknown key returns {} (fail-soft)."""
+        from tools.sdlc_meta_set import write_meta
+
+        result = write_meta(key="nonexistent_key", value="anything")
+        assert result == {}
+
+    def test_missing_session_returns_empty_dict(self):
+        """write_meta returns {} when no session can be found (fail-soft)."""
+        from tools.sdlc_meta_set import write_meta
+
+        with patch("tools.sdlc_meta_set._find_session", return_value=None):
+            result = write_meta(key="plan_revising", value="true")
+
+        assert result == {}
+
+    def test_update_stage_states_failure_returns_empty_dict(self):
+        """write_meta returns {} when update_stage_states returns False."""
+        from tools.sdlc_meta_set import write_meta
+
+        mock_session = MagicMock()
+        mock_session.stage_states = "{}"
+
+        with (
+            patch("tools.sdlc_meta_set._find_session", return_value=mock_session),
+            patch("tools.stage_states_helpers.update_stage_states", return_value=False),
+        ):
+            result = write_meta(key="plan_revising", value="true")
+
+        assert result == {}
+
+    def test_bool_coercion_numeric_strings(self):
+        """write_meta coerces '1'/'0' to True/False for bool keys."""
+        from tools.sdlc_meta_set import write_meta
+
+        mock_session = MagicMock()
+        mock_session.stage_states = "{}"
+
+        def fake_update_true(session, update_fn, **kwargs):
+            result = update_fn({})
+            assert result["_plan_revising"] is True
+            return True
+
+        def fake_update_false(session, update_fn, **kwargs):
+            result = update_fn({})
+            assert result["_plan_revising"] is False
+            return True
+
+        with (
+            patch("tools.sdlc_meta_set._find_session", return_value=mock_session),
+            patch("tools.stage_states_helpers.update_stage_states", side_effect=fake_update_true),
+        ):
+            r1 = write_meta(key="plan_revising", value="1")
+        assert r1["value"] is True
+
+        with (
+            patch("tools.sdlc_meta_set._find_session", return_value=mock_session),
+            patch("tools.stage_states_helpers.update_stage_states", side_effect=fake_update_false),
+        ):
+            r2 = write_meta(key="plan_revising", value="0")
+        assert r2["value"] is False
+
+    def test_invalid_bool_value_returns_empty_dict(self):
+        """write_meta with an unrecognized bool value returns {} fail-soft."""
+        from tools.sdlc_meta_set import write_meta
+
+        mock_session = MagicMock()
+        mock_session.stage_states = "{}"
+
+        with patch("tools.sdlc_meta_set._find_session", return_value=mock_session):
+            result = write_meta(key="plan_revising", value="not_a_bool")
+
+        assert result == {}
+
+
+class TestMetaSetWhitelist:
+    """Tests for the key whitelist enforcement."""
+
+    def test_whitelist_contains_expected_keys(self):
+        """_KEY_REGISTRY must contain exactly the two whitelisted keys."""
+        from tools.sdlc_meta_set import _KEY_REGISTRY
+
+        assert "plan_revising" in _KEY_REGISTRY
+        assert "plan_hash_at_build_start" in _KEY_REGISTRY
+
+    def test_whitelist_maps_to_underscore_internal_keys(self):
+        """Internal storage keys must use leading underscore convention."""
+        from tools.sdlc_meta_set import _KEY_REGISTRY
+
+        for public_key, (internal_key, _) in _KEY_REGISTRY.items():
+            assert internal_key.startswith("_"), (
+                f"Internal key for {public_key!r} must start with '_'; got {internal_key!r}"
+            )
+
+
+class TestMetaSetCLI:
+    """Subprocess tests for the CLI entry point."""
+
+    def test_unknown_key_exits_2(self):
+        """CLI exits 2 when an unknown key is provided."""
+        proc = subprocess.run(
+            [sys.executable, "-m", "tools.sdlc_meta_set", "--key", "unknown_key", "--value", "x"],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+        assert proc.returncode == 2
+
+    def test_missing_key_arg_exits_nonzero(self):
+        """CLI exits nonzero when --key is missing."""
+        proc = subprocess.run(
+            [sys.executable, "-m", "tools.sdlc_meta_set", "--value", "true"],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+        assert proc.returncode != 0
+
+    def test_missing_value_arg_exits_nonzero(self):
+        """CLI exits nonzero when --value is missing."""
+        proc = subprocess.run(
+            [sys.executable, "-m", "tools.sdlc_meta_set", "--key", "plan_revising"],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+        assert proc.returncode != 0
+
+    def test_no_session_id_exits_0_with_empty_json(self):
+        """CLI exits 0 with {} output when no session can be found (fail-soft)."""
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "tools.sdlc_meta_set",
+                "--key",
+                "plan_revising",
+                "--value",
+                "true",
+                "--issue-number",
+                "999999999",  # unlikely to match any real session
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            env={
+                **__import__("os").environ,
+                # Remove session env vars so lookup falls through to issue number
+                "VALOR_SESSION_ID": "",
+                "AGENT_SESSION_ID": "",
+            },
+        )
+        # Fail-soft: should exit 0 even when session not found
+        assert proc.returncode == 0
+        output = proc.stdout.strip()
+        assert output == "{}", f"Expected '{{}}' but got: {output!r}"
+
+    def test_help_exits_0(self):
+        """CLI --help exits 0."""
+        proc = subprocess.run(
+            [sys.executable, "-m", "tools.sdlc_meta_set", "--help"],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+        assert proc.returncode == 0

--- a/tests/unit/test_sdlc_router.py
+++ b/tests/unit/test_sdlc_router.py
@@ -1,0 +1,240 @@
+"""Unit tests for agent.sdlc_router — G7 plan-revising lock guard.
+
+Tests the guard_g7_plan_revising function in isolation and through
+decide_next_dispatch().
+
+The existing router decision tests live in test_sdlc_router_decision.py.
+This file focuses exclusively on the G7 guard added for issue #1302.
+"""
+
+from __future__ import annotations
+
+from agent.sdlc_router import (
+    MAX_PLAN_REVISING_DISPATCHES,
+    SKILL_DO_BUILD,
+    SKILL_DO_PLAN,
+    SKILL_DO_PLAN_CRITIQUE,
+    Blocked,
+    Dispatch,
+    decide_next_dispatch,
+    guard_g7_plan_revising,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _base_meta(**overrides) -> dict:
+    """Return a minimal meta dict with G7-relevant defaults."""
+    base = {
+        "patch_cycle_count": 0,
+        "critique_cycle_count": 0,
+        "latest_critique_verdict": "READY TO BUILD",
+        "latest_review_verdict": None,
+        "revision_applied": False,
+        "pr_number": None,
+        "pr_merge_state": None,
+        "ci_all_passing": None,
+        "same_stage_dispatch_count": 0,
+        "last_dispatched_skill": None,
+        "plan_revising": False,
+        "plan_hash_at_build_start": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def _base_states(**overrides) -> dict:
+    """Return minimal stage_states with CRITIQUE completed and no BUILD yet."""
+    base = {
+        "ISSUE": "completed",
+        "PLAN": "completed",
+        "CRITIQUE": "completed",
+        "BUILD": "pending",
+        "TEST": "pending",
+        "REVIEW": "pending",
+        "DOCS": "pending",
+        "MERGE": "pending",
+    }
+    base.update(overrides)
+    return base
+
+
+def _dispatch_history(*skills) -> list[dict]:
+    """Build a simple dispatch history list from skill names."""
+    return [{"skill": s, "at": "2026-05-06T00:00:00Z", "stage_snapshot": {}} for s in skills]
+
+
+# ---------------------------------------------------------------------------
+# G7 guard — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestG7PlanRevisingGuardDirect:
+    """Direct unit tests for guard_g7_plan_revising."""
+
+    def test_no_lock_returns_none(self):
+        """G7 falls through when plan_revising is False."""
+        states = _base_states()
+        meta = _base_meta(plan_revising=False)
+        result = guard_g7_plan_revising(states, meta, {})
+        assert result is None
+
+    def test_pr_open_returns_none(self):
+        """G7 falls through when pr_number is set (PR-stage routing takes over)."""
+        states = _base_states()
+        meta = _base_meta(plan_revising=True, pr_number=42)
+        result = guard_g7_plan_revising(states, meta, {})
+        assert result is None
+
+    def test_self_heal_revision_applied_returns_none(self):
+        """G7 self-heals when plan_revising=True but revision_applied=True."""
+        states = _base_states()
+        meta = _base_meta(plan_revising=True, revision_applied=True)
+        result = guard_g7_plan_revising(states, meta, {})
+        assert result is None
+
+    def test_lock_plus_critique_just_ran_returns_do_plan(self):
+        """G7 routes to /do-plan when lock is set and last dispatch was /do-plan-critique."""
+        states = _base_states()
+        meta = _base_meta(
+            plan_revising=True,
+            last_dispatched_skill=SKILL_DO_PLAN_CRITIQUE,
+        )
+        result = guard_g7_plan_revising(states, meta, {})
+        assert isinstance(result, Dispatch)
+        assert result.skill == SKILL_DO_PLAN
+        assert result.row_id == "G7"
+
+    def test_lock_no_recent_plan_dispatch_returns_blocked(self):
+        """G7 escalates to Blocked when lock is set and no /do-plan in recent history."""
+        states = _base_states(
+            _sdlc_dispatches=_dispatch_history(
+                SKILL_DO_BUILD,
+                SKILL_DO_BUILD,
+                SKILL_DO_PLAN_CRITIQUE,
+            )
+        )
+        meta = _base_meta(
+            plan_revising=True,
+            last_dispatched_skill=SKILL_DO_BUILD,
+        )
+        result = guard_g7_plan_revising(states, meta, {})
+        assert isinstance(result, Blocked)
+        assert result.guard_id == "G7"
+        assert "G7" in result.reason
+        assert "plan_revising" in result.reason
+
+    def test_lock_with_recent_plan_dispatch_returns_none(self):
+        """G7 falls through when lock is set but /do-plan is in recent history."""
+        # Build a history where /do-plan appears within the look-back window.
+        history = _dispatch_history(*([SKILL_DO_PLAN] + [SKILL_DO_BUILD]))
+        states = _base_states(_sdlc_dispatches=history)
+        meta = _base_meta(
+            plan_revising=True,
+            last_dispatched_skill=SKILL_DO_BUILD,
+        )
+        result = guard_g7_plan_revising(states, meta, {})
+        assert result is None
+
+    def test_lock_empty_dispatch_history_returns_blocked(self):
+        """G7 escalates when lock is set and dispatch history is empty (no /do-plan found)."""
+        states = _base_states()  # no _sdlc_dispatches key
+        meta = _base_meta(
+            plan_revising=True,
+            last_dispatched_skill=SKILL_DO_BUILD,
+        )
+        result = guard_g7_plan_revising(states, meta, {})
+        # No /do-plan in history → Blocked
+        assert isinstance(result, Blocked)
+        assert result.guard_id == "G7"
+
+    def test_max_plan_revising_dispatches_constant_is_positive(self):
+        """MAX_PLAN_REVISING_DISPATCHES must be a positive integer."""
+        assert isinstance(MAX_PLAN_REVISING_DISPATCHES, int)
+        assert MAX_PLAN_REVISING_DISPATCHES > 0
+
+
+# ---------------------------------------------------------------------------
+# G7 through decide_next_dispatch()
+# ---------------------------------------------------------------------------
+
+
+class TestG7ThroughDecideNextDispatch:
+    """Integration-style tests driving G7 through the full router."""
+
+    def test_lock_set_critique_just_ran_routes_to_plan_via_g7(self):
+        """G7 routes to /do-plan when lock is set and critique just ran (via guard, not dispatch table).
+
+        Uses READY TO BUILD (with concerns) verdict so G1 doesn't fire first.
+        G1 only fires on NEEDS REVISION / MAJOR REWORK; G7 fires on any
+        plan_revising=True with last_dispatched_skill=critique.
+        """
+        states = _base_states()
+        meta = _base_meta(
+            plan_revising=True,
+            # Use a verdict that does NOT trigger G1 (G1 needs NEEDS REVISION/MAJOR REWORK)
+            latest_critique_verdict="READY TO BUILD (with concerns)",
+            last_dispatched_skill=SKILL_DO_PLAN_CRITIQUE,
+        )
+        result = decide_next_dispatch(states, meta, {})
+        assert isinstance(result, Dispatch)
+        assert result.skill == SKILL_DO_PLAN
+        assert result.row_id == "G7"
+
+    def test_lock_set_no_recent_plan_dispatch_is_blocked(self):
+        """Router blocks when lock is set and no /do-plan in recent dispatch history."""
+        states = _base_states(
+            _sdlc_dispatches=_dispatch_history(
+                SKILL_DO_BUILD,
+                SKILL_DO_BUILD,
+                SKILL_DO_PLAN_CRITIQUE,
+            )
+        )
+        meta = _base_meta(
+            plan_revising=True,
+            latest_critique_verdict="READY TO BUILD",
+            last_dispatched_skill=SKILL_DO_BUILD,
+        )
+        result = decide_next_dispatch(states, meta, {})
+        assert isinstance(result, Blocked)
+        assert result.guard_id == "G7"
+
+    def test_no_lock_routes_to_build(self):
+        """Router routes to /do-build normally when G7 lock is clear."""
+        states = _base_states()
+        meta = _base_meta(
+            plan_revising=False,
+            latest_critique_verdict="READY TO BUILD",
+            revision_applied=False,
+        )
+        result = decide_next_dispatch(states, meta, {})
+        assert isinstance(result, Dispatch)
+        assert result.skill == SKILL_DO_BUILD
+
+    def test_lock_with_revision_applied_routes_to_build(self):
+        """G7 self-heals when revision_applied=True; router routes to /do-build."""
+        states = _base_states()
+        meta = _base_meta(
+            plan_revising=True,
+            revision_applied=True,
+            latest_critique_verdict="READY TO BUILD",
+        )
+        result = decide_next_dispatch(states, meta, {})
+        assert isinstance(result, Dispatch)
+        assert result.skill == SKILL_DO_BUILD
+
+    def test_pr_open_ignores_lock(self):
+        """G7 does not fire when pr_number is set; router continues to PR-stage."""
+        states = _base_states(REVIEW="pending")
+        meta = _base_meta(
+            plan_revising=True,
+            pr_number=99,
+            latest_critique_verdict="READY TO BUILD",
+        )
+        result = decide_next_dispatch(states, meta, {})
+        # With pr_number set and REVIEW pending, router should route to /do-pr-review
+        assert isinstance(result, Dispatch)
+        assert result.skill != SKILL_DO_PLAN  # G7 did not fire

--- a/tests/unit/test_sdlc_skill_md_parity.py
+++ b/tests/unit/test_sdlc_skill_md_parity.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from agent.sdlc_router import DISPATCH_RULES, GUARDS
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
-SKILL_MD = REPO_ROOT / ".claude" / "skills" / "sdlc" / "SKILL.md"
+SKILL_MD = REPO_ROOT / ".claude" / "skills-global" / "sdlc" / "SKILL.md"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_sdlc_stage_query.py
+++ b/tests/unit/test_sdlc_stage_query.py
@@ -409,6 +409,91 @@ class TestEnrichedPayload:
         assert meta["pr_merge_state"] is None
         assert meta["ci_all_passing"] is None
 
+    def test_default_meta_includes_plan_revising_and_hash(self):
+        """_default_meta includes plan_revising (False) and plan_hash_at_build_start (None)."""
+        from tools.sdlc_stage_query import _default_meta
+
+        meta = _default_meta()
+        assert "plan_revising" in meta
+        assert "plan_hash_at_build_start" in meta
+        assert meta["plan_revising"] is False
+        assert meta["plan_hash_at_build_start"] is None
+
+    def test_compute_meta_plan_revising_defaults_false_when_absent(self):
+        """_compute_meta surfaces plan_revising=False when _plan_revising key is absent."""
+        from tools.sdlc_stage_query import query_enriched
+
+        mock_session = MagicMock()
+        mock_session.stage_states = json.dumps({"ISSUE": "completed"})
+        mock_session.pr_number = None
+
+        with patch("tools.sdlc_stage_query._find_session_by_id", return_value=mock_session):
+            with patch("tools.sdlc_stage_query._lookup_pr_number", return_value=None):
+                with patch(
+                    "tools.sdlc_stage_query._fetch_pr_merge_state", return_value=(None, None)
+                ):
+                    with patch("tools.sdlc_stage_query._find_plan_path", return_value=None):
+                        result = query_enriched(session_id="sid")
+
+        assert result["_meta"]["plan_revising"] is False
+
+    def test_compute_meta_plan_revising_true_when_set(self):
+        """_compute_meta surfaces plan_revising=True when _plan_revising=True in stage_states."""
+        from tools.sdlc_stage_query import query_enriched
+
+        mock_session = MagicMock()
+        mock_session.stage_states = json.dumps({"ISSUE": "completed", "_plan_revising": True})
+        mock_session.pr_number = None
+
+        with patch("tools.sdlc_stage_query._find_session_by_id", return_value=mock_session):
+            with patch("tools.sdlc_stage_query._lookup_pr_number", return_value=None):
+                with patch(
+                    "tools.sdlc_stage_query._fetch_pr_merge_state", return_value=(None, None)
+                ):
+                    with patch("tools.sdlc_stage_query._find_plan_path", return_value=None):
+                        result = query_enriched(session_id="sid")
+
+        assert result["_meta"]["plan_revising"] is True
+
+    def test_compute_meta_plan_hash_at_build_start_surfaced(self):
+        """_compute_meta surfaces plan_hash_at_build_start from raw stage_states."""
+        from tools.sdlc_stage_query import query_enriched
+
+        test_hash = "abc123def456"
+        mock_session = MagicMock()
+        mock_session.stage_states = json.dumps(
+            {"ISSUE": "completed", "_plan_hash_at_build_start": test_hash}
+        )
+        mock_session.pr_number = None
+
+        with patch("tools.sdlc_stage_query._find_session_by_id", return_value=mock_session):
+            with patch("tools.sdlc_stage_query._lookup_pr_number", return_value=None):
+                with patch(
+                    "tools.sdlc_stage_query._fetch_pr_merge_state", return_value=(None, None)
+                ):
+                    with patch("tools.sdlc_stage_query._find_plan_path", return_value=None):
+                        result = query_enriched(session_id="sid")
+
+        assert result["_meta"]["plan_hash_at_build_start"] == test_hash
+
+    def test_compute_meta_plan_hash_defaults_none_when_absent(self):
+        """_compute_meta returns plan_hash_at_build_start=None when key is absent."""
+        from tools.sdlc_stage_query import query_enriched
+
+        mock_session = MagicMock()
+        mock_session.stage_states = json.dumps({"ISSUE": "completed"})
+        mock_session.pr_number = None
+
+        with patch("tools.sdlc_stage_query._find_session_by_id", return_value=mock_session):
+            with patch("tools.sdlc_stage_query._lookup_pr_number", return_value=None):
+                with patch(
+                    "tools.sdlc_stage_query._fetch_pr_merge_state", return_value=(None, None)
+                ):
+                    with patch("tools.sdlc_stage_query._find_plan_path", return_value=None):
+                        result = query_enriched(session_id="sid")
+
+        assert result["_meta"]["plan_hash_at_build_start"] is None
+
 
 class TestFetchPrMergeState:
     """Tests for the _fetch_pr_merge_state helper."""

--- a/tools/sdlc_meta_set.py
+++ b/tools/sdlc_meta_set.py
@@ -1,0 +1,244 @@
+"""CLI tool for writing SDLC pipeline metadata keys to a PM session's stage_states.
+
+Invoked by SDLC skills (do-plan-critique, do-plan, do-build) to set or clear
+plan-level metadata flags without depending on bridge hooks.
+
+Whitelisted keys and their types:
+  plan_revising          bool   — set by critique on NEEDS REVISION / MAJOR REWORK /
+                                  READY TO BUILD (with concerns); cleared by plan after
+                                  revision commit. Consumed by guard G7 in sdlc_router.
+  plan_hash_at_build_start  str — git commit hash of the plan doc at build start.
+                                  Recorded by do-build Step 7; verified at Step 21.
+
+Unknown keys are rejected with exit 2 — the whitelist is intentional and must be
+explicit so stale meta keys don't accumulate silently.
+
+Usage:
+    python -m tools.sdlc_meta_set --key plan_revising --value true --issue-number 1302
+    python -m tools.sdlc_meta_set --key plan_revising --value false --issue-number 1302
+    python -m tools.sdlc_meta_set --key plan_hash_at_build_start --value abc123 --issue-number 1302
+    python -m tools.sdlc_meta_set --help
+
+Environment variables (checked in order if --session-id not provided):
+    VALOR_SESSION_ID   — bridge-injected PM session ID
+    AGENT_SESSION_ID   — alternative session ID env var
+
+When no session ID is available (local Claude Code sessions), use --issue-number
+to resolve the session by GitHub issue number.
+
+Exit codes:
+    0 — success, or fail-soft error (no session found, Redis down, etc.)
+    2 — invalid arguments (unknown key, missing required args)
+
+Output:
+    {} on error (no session found, write failed, etc.)
+    {"key": "plan_revising", "value": true} on success
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+
+logger = logging.getLogger(__name__)
+
+# Whitelisted keys and their storage/coercion rules.
+# Maps key name -> ("_<internal_key>", coerce_fn)
+_KEY_REGISTRY: dict[str, tuple[str, type]] = {
+    "plan_revising": ("_plan_revising", bool),
+    "plan_hash_at_build_start": ("_plan_hash_at_build_start", str),
+}
+
+_BOOL_TRUE_VALUES = frozenset(["true", "1", "yes", "on"])
+_BOOL_FALSE_VALUES = frozenset(["false", "0", "no", "off"])
+
+
+def _coerce_bool(value: str) -> bool:
+    """Coerce a string value to bool. Raises ValueError on unrecognized input."""
+    if value.lower() in _BOOL_TRUE_VALUES:
+        return True
+    if value.lower() in _BOOL_FALSE_VALUES:
+        return False
+    raise ValueError(
+        f"Cannot coerce {value!r} to bool. "
+        f"Accepted true values: {sorted(_BOOL_TRUE_VALUES)}. "
+        f"Accepted false values: {sorted(_BOOL_FALSE_VALUES)}."
+    )
+
+
+def _coerce_value(key: str, raw_value: str):
+    """Coerce a raw string value to the expected type for the given key.
+
+    Returns the coerced value, or raises ValueError on type mismatch.
+    """
+    _, target_type = _KEY_REGISTRY[key]
+    if target_type is bool:
+        return _coerce_bool(raw_value)
+    if target_type is str:
+        return str(raw_value)
+    # Future types would go here
+    return raw_value
+
+
+def _find_session(session_id: str | None, issue_number: int | None = None):
+    """Find a PM AgentSession by explicit ID, env vars, or issue number.
+
+    Resolution order:
+    1. --session-id argument (if provided)
+    2. VALOR_SESSION_ID env var
+    3. AGENT_SESSION_ID env var
+    4. --issue-number argument (primary path for local Claude Code sessions)
+
+    Returns the session object or None.
+    """
+    resolved_id = (
+        session_id or os.environ.get("VALOR_SESSION_ID") or os.environ.get("AGENT_SESSION_ID")
+    )
+    if not resolved_id:
+        if issue_number is not None:
+            try:
+                from tools._sdlc_utils import find_session_by_issue
+
+                session = find_session_by_issue(issue_number)
+                if session:
+                    return session
+            except Exception as e:
+                logger.debug(f"sdlc_meta_set: issue-number lookup failed: {e}")
+        logger.debug("sdlc_meta_set: no session ID available (no arg, no env vars, no issue)")
+        return None
+
+    try:
+        from models.agent_session import AgentSession
+
+        sessions = list(AgentSession.query.filter(session_id=resolved_id))
+        if not sessions:
+            logger.debug(f"sdlc_meta_set: no session found for ID {resolved_id!r}")
+            return None
+        # Prefer PM sessions (they own stage_states)
+        for s in sessions:
+            if getattr(s, "session_type", None) == "pm":
+                return s
+        return sessions[0]
+    except Exception as e:
+        logger.debug(f"sdlc_meta_set: _find_session failed: {e}")
+        return None
+
+
+def write_meta(
+    key: str,
+    value: str,
+    session_id: str | None = None,
+    issue_number: int | None = None,
+) -> dict:
+    """Write a metadata key to stage_states["_<key>"] via update_stage_states().
+
+    Args:
+        key: Whitelisted key name (e.g., "plan_revising").
+        value: Raw string value — will be coerced to the key's type.
+        session_id: Optional explicit session ID (falls back to env vars).
+        issue_number: Optional issue number for local session resolution.
+
+    Returns:
+        Dict with key/value on success, empty dict on any failure.
+    """
+    if key not in _KEY_REGISTRY:
+        logger.debug(f"sdlc_meta_set: unknown key {key!r}")
+        return {}
+
+    try:
+        coerced = _coerce_value(key, value)
+    except ValueError as e:
+        logger.debug(f"sdlc_meta_set: value coercion failed for key {key!r}: {e}")
+        return {}
+
+    session = _find_session(session_id, issue_number=issue_number)
+    if not session:
+        return {}
+
+    internal_key, _ = _KEY_REGISTRY[key]
+
+    def _apply_update(states: dict) -> dict:
+        states[internal_key] = coerced
+        return states
+
+    try:
+        from tools.stage_states_helpers import update_stage_states
+
+        success = update_stage_states(session, _apply_update)
+        if not success:
+            logger.debug(f"sdlc_meta_set: update_stage_states returned False for key {key!r}")
+            return {}
+    except Exception as e:
+        logger.debug(f"sdlc_meta_set: write_meta failed: {e}")
+        return {}
+
+    return {"key": key, "value": coerced}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Write SDLC pipeline metadata to a PM session's stage_states",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--key",
+        required=True,
+        help=(
+            f"Metadata key to set. Whitelisted keys: {sorted(_KEY_REGISTRY.keys())}. "
+            "Unknown keys exit with code 2."
+        ),
+    )
+    parser.add_argument(
+        "--value",
+        required=True,
+        help="Value to set. Booleans accept true/false/1/0/yes/no.",
+    )
+    parser.add_argument(
+        "--session-id",
+        default=None,
+        help="PM session ID (falls back to VALOR_SESSION_ID / AGENT_SESSION_ID env vars)",
+    )
+    parser.add_argument(
+        "--issue-number",
+        type=int,
+        default=None,
+        help="GitHub issue number (for local sessions without VALOR_SESSION_ID)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging",
+    )
+
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
+
+    # Unknown key → exit 2 (invalid argument, not a runtime error)
+    if args.key not in _KEY_REGISTRY:
+        print(
+            f"sdlc_meta_set: unknown key {args.key!r}. "
+            f"Whitelisted keys: {sorted(_KEY_REGISTRY.keys())}",
+            file=sys.stderr,
+        )
+        print("{}")
+        sys.exit(2)
+
+    result = write_meta(
+        key=args.key,
+        value=args.value,
+        session_id=args.session_id,
+        issue_number=args.issue_number,
+    )
+    print(json.dumps(result))
+    # Always exit 0 (fail-soft: runtime errors return {} but don't crash the skill)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/sdlc_stage_query.py
+++ b/tools/sdlc_stage_query.py
@@ -292,6 +292,14 @@ def _compute_meta(
         plan_path = _find_plan_path(issue_number)
         revision_applied = _parse_revision_applied(plan_path)
 
+    # Plan-revising lock (G7): set by critique skill, cleared by plan skill.
+    plan_revising_raw = raw_states.get("_plan_revising")
+    plan_revising = bool(plan_revising_raw) if plan_revising_raw is not None else False
+
+    plan_hash_at_build_start = raw_states.get("_plan_hash_at_build_start") or None
+    if isinstance(plan_hash_at_build_start, str) and not plan_hash_at_build_start:
+        plan_hash_at_build_start = None
+
     return {
         "patch_cycle_count": int(raw_states.get("_patch_cycle_count", 0) or 0),
         "critique_cycle_count": int(raw_states.get("_critique_cycle_count", 0) or 0),
@@ -303,6 +311,8 @@ def _compute_meta(
         "ci_all_passing": ci_all_passing,
         "same_stage_dispatch_count": int(same_stage_count),
         "last_dispatched_skill": last_skill,
+        "plan_revising": plan_revising,
+        "plan_hash_at_build_start": plan_hash_at_build_start,
     }
 
 
@@ -319,6 +329,8 @@ def _default_meta() -> dict:
         "ci_all_passing": None,
         "same_stage_dispatch_count": 0,
         "last_dispatched_skill": None,
+        "plan_revising": False,
+        "plan_hash_at_build_start": None,
     }
 
 


### PR DESCRIPTION
## Summary

- Adds guard G7 (`guard_g7_plan_revising`) in `agent/sdlc_router.py` that blocks `/do-build` from dispatching while `_meta.plan_revising` is true and `revision_applied` is false
- Creates `tools/sdlc_meta_set.py` — new CLI tool for writing whitelisted `_meta` keys (`plan_revising`, `plan_hash_at_build_start`) with fail-soft semantics
- Extends `tools/sdlc_stage_query.py` (`_compute_meta`, `_default_meta`) to surface the two new fields
- Updates `scripts/sdlc-tool` to add `meta-set` to `ALLOWED_SUBCOMMANDS`
- Updates SKILL.md files: critique sets lock (Step 5.6), plan clears lock (Phase 4 Step 2b), build records/verifies plan hash (Steps 7 and 21), sdlc/SKILL.md guard table updated with G7 row
- Adds defense-in-depth plan-hash check in do-build to abort if plan is revised mid-build

## Test plan

- [x] `tests/unit/test_sdlc_router.py` — G7 guard: lock+critique-just-ran → /do-plan; lock+no-recent-plan → Blocked; revision_applied=true → self-heal; no lock → fall-through; PR open → fall-through
- [x] `tests/unit/test_sdlc_meta_set.py` — valid key sets field; unknown key exits 2; missing session fail-soft; bool coercion; whitelist enforcement
- [x] `tests/unit/test_sdlc_stage_query.py` — new fields surfaced in `_compute_meta()` and `_default_meta()`
- [x] `tests/integration/test_sdlc_pipeline_lock.py` — full flow: critique sets lock → build blocked → plan clears lock → build dispatches
- [x] `tests/unit/test_sdlc_skill_md_parity.py` — G7 in SKILL.md guard table matches Python GUARDS list; also fixes pre-existing path bug (`.claude/skills/sdlc/` → `.claude/skills-global/sdlc/`)
- All 75 tests pass

Closes #1302