### PR TITLE
fix(#1318): terminus imperative Fast-Path 0 + few-shot prompt

### DIFF
--- a/bridge/routing.py
+++ b/bridge/routing.py
@@ -553,6 +553,42 @@ async def classify_needs_response_async(text: str) -> bool:
 _STANDALONE_QUESTION_RE = re.compile(r"(?<![=&\w])\?|(?<![=&])\?(?!\w+=)")
 
 
+# Fast-Path 0: imperative continuation verbs (issue #1318).
+# Deliberately narrow to high-precision continuation imperatives. Common verbs
+# that frequently appear non-imperatively at message starts (e.g. "fix", "run",
+# "merge", "start", "deploy", "execute", "push") are EXCLUDED here and deferred
+# to the few-shot LLM step below. The verb list grows by operational feedback —
+# when a new SILENT misclassification surfaces in `terminus:` DEBUG logs, add
+# the verb here and a labeled few-shot example to the prompt.
+_IMPERATIVE_VERBS = (
+    "continue",
+    "proceed",
+    "resume",
+    "retry",
+    "redo",
+    "go ahead",
+    "ship it",
+    "do it",
+    "send it",
+    "try again",
+    "keep going",
+    "finish it",
+    "do this",
+    "handle it",
+    "move on",
+)
+# Multi-line aware: the motivating May 7 incident (issue #1318) was a two-line
+# message where the imperative was on line 2. The `(?:^|\n)\s*` prefix matches
+# the start of the message OR any newline followed by optional whitespace, so
+# any line that *leads with* an imperative verb fires Fast-Path 0. Mid-sentence
+# usage ("I would just continue this automatically") does NOT match because
+# there is no preceding newline-or-start before the verb.
+_IMPERATIVE_LINE_RE = re.compile(
+    r"(?:^|\n)\s*(?:" + "|".join(re.escape(v) for v in _IMPERATIVE_VERBS) + r")\b",
+    re.IGNORECASE,
+)
+
+
 async def classify_conversation_terminus(
     text: str,
     thread_messages: list[str],  # recent turns, oldest first
@@ -566,6 +602,7 @@ async def classify_conversation_terminus(
     - "SILENT"  — bot loop or acknowledgment; do nothing
 
     Fast-path order (critical — checked before LLM):
+    0. human sender + leading imperative verb on any line → RESPOND  (issue #1318)
     1. sender_is_bot + no question → SILENT  (primary loop-break signal)
     2. acknowledgment token or very short (≤1 word) → SILENT
        (unless thread_messages contains a question — then fall through, so a
@@ -583,6 +620,16 @@ async def classify_conversation_terminus(
 
     text_stripped = text.strip()
     text_lower = text_stripped.lower()
+
+    # Fast-path 0 (issue #1318): human sender with a leading imperative verb on
+    # any line → RESPOND. Bot senders are handled entirely by Fast-Path 1; this
+    # check must NOT fire for bots so it never interferes with bot loop
+    # suppression. See _IMPERATIVE_LINE_RE for the verb set and multi-line
+    # anchor strategy. The motivating incident was a two-line human reply where
+    # the imperative ("Continue to finish all stage of SDLC") was on line 2.
+    if not sender_is_bot and _IMPERATIVE_LINE_RE.search(text_stripped):
+        logger.debug(f"terminus: 'RESPOND' — {text_stripped[:80]!r} (Fast-Path 0)")
+        return "RESPOND"
 
     # Fast-path 1: bot sender with no question → SILENT (strongest signal for loop break)
     if sender_is_bot and not _STANDALONE_QUESTION_RE.search(text_stripped):
@@ -610,11 +657,33 @@ async def classify_conversation_terminus(
     if _STANDALONE_QUESTION_RE.search(text_stripped):
         return "RESPOND"
 
-    # LLM classification: Ollama-first, Haiku fallback
+    # LLM classification: Ollama-first, Haiku fallback.
+    #
+    # Few-shot examples (issue #1318): zero-shot prompts on `gemma4:e2b` were
+    # too ambiguous to distinguish continuation imperatives from conversation
+    # closers, leading to SILENT misclassifications of human action directives
+    # (May 6 and May 7, 2026 incidents). The labeled examples below are drawn
+    # from real misclassified messages plus canonical edge cases. When a new
+    # SILENT misclassification surfaces in `terminus:` DEBUG logs, add a
+    # labeled example here.
     thread_context = "\n".join(thread_messages[-2:]) if thread_messages else ""
     prompt = (
         "Classify this reply in a conversation thread. "
         "The reply was sent to Valor (an AI agent).\n\n"
+        "Examples:\n"
+        '"Continue to finish all stage of SDLC" → RESPOND\n'
+        '"Go ahead and merge" → RESPOND\n'
+        '"Run it again" → RESPOND\n'
+        '"Proceed with the plan" → RESPOND\n'
+        '"I left a comment on PR 1316\\n\\nContinue to finish all stage of SDLC" → RESPOND\n'
+        '"let\'s go with that" → RESPOND\n'
+        '"please ship it when ready" → RESPOND\n'
+        '"ok great" → REACT\n'
+        '"sounds good" → REACT\n'
+        '"nice work" → REACT\n'
+        '"👍" → SILENT\n'
+        '"thanks" → SILENT\n'
+        '"got it" → SILENT\n\n'
         f"Reply text: {text_stripped[:300]}\n\n"
         "Recent thread context (may be empty):\n"
         f"{thread_context[:400] if thread_context else '(none)'}\n\n"
@@ -670,6 +739,11 @@ async def classify_conversation_terminus(
     # Conservative default on any failure
     if result is None:
         result = "RESPOND"
+
+    # Operational feedback loop (issue #1318): log every LLM-classified message
+    # so future misclassifications surface in `tail -f logs/bridge.log` and can
+    # be mined for new few-shot examples or Fast-Path 0 verbs.
+    logger.debug(f"terminus: {result!r} — {text_stripped[:80]!r}")
 
     # Collapse REACT → SILENT for bot senders (no emoji spam in bot loops)
     if sender_is_bot and result == "REACT":

--- a/docs/features/agent-reply-terminus.md
+++ b/docs/features/agent-reply-terminus.md
@@ -1,7 +1,7 @@
 # Agent Reply Terminus Detection
 
 **Status:** Shipped  
-**Issues:** [#911](https://github.com/tomcounsell/ai/issues/911) (initial), [#1090](https://github.com/tomcounsell/ai/issues/1090) (question-aware Fast-Path 2)
+**Issues:** [#911](https://github.com/tomcounsell/ai/issues/911) (initial), [#1090](https://github.com/tomcounsell/ai/issues/1090) (question-aware Fast-Path 2), [#1318](https://github.com/tomcounsell/ai/issues/1318) (imperative Fast-Path 0 + few-shot prompt)
 
 ## Problem
 
@@ -41,6 +41,9 @@ async def classify_conversation_terminus(
 
 Fast-paths are checked before any LLM call, in this exact order:
 
+0. **Human sender + leading imperative verb on any line** → `RESPOND`  
+   See [#1318](https://github.com/tomcounsell/ai/issues/1318). Human-only — the `not sender_is_bot` guard ensures bot loops containing the word "continue" never re-trigger Valor. Uses `_IMPERATIVE_LINE_RE` (multi-line aware) to match a small, deliberately-narrow set of high-precision continuation imperatives (`continue`, `proceed`, `resume`, `retry`, `redo`, `go ahead`, `ship it`, `do it`, `send it`, `try again`, `keep going`, `finish it`, `do this`, `handle it`, `move on`). Common verbs that frequently appear non-imperatively at message starts (`fix`, `run`, `merge`, `start`, `deploy`, `execute`, `push`) are EXCLUDED here and deferred to the few-shot LLM step.
+
 1. **Bot sender + no standalone `?`** → `SILENT`  
    The primary loop-break signal. If the sender is a bot and the message contains no question, it's a loop continuation — silence it immediately.
 
@@ -49,6 +52,53 @@ Fast-paths are checked before any LLM call, in this exact order:
 
 3. **Standalone `?` in text** → `RESPOND`  
    Fast exit before any LLM call. Uses regex `(?<![=&\w])\?|(?<![=&])\?(?!\w+=)` to exclude URL query-string parameters like `?q=1`.
+
+#### Fast-Path 0 Regex — Multi-Line Anchor
+
+`_IMPERATIVE_LINE_RE` is anchored with `(?:^|\n)\s*<verb>\b` so it matches an imperative at the start of the message OR at the start of any line. The motivating May 7, 2026 incident was a two-line human reply:
+
+```
+I left a comment on PR 1316
+
+Continue to finish all stage of SDLC
+```
+
+A regex anchored only to message start (`^\s*`) would have missed this. Mid-sentence usage (`"I would just continue this automatically"`) still does not match because there is no preceding newline-or-start before the verb — the sentence falls through to the LLM step, which has the few-shot examples to handle ambiguous cases.
+
+#### Few-Shot LLM Prompt
+
+The Ollama (`gemma4:e2b`) zero-shot prompt was too ambiguous to reliably distinguish continuation imperatives from conversation closers, leading to SILENT misclassifications of human action directives (May 6 and May 7, 2026 incidents). The prompt now includes labeled examples drawn from real misclassified messages plus canonical edge cases:
+
+```
+Examples:
+"Continue to finish all stage of SDLC" → RESPOND
+"Go ahead and merge" → RESPOND
+"Run it again" → RESPOND
+"Proceed with the plan" → RESPOND
+"I left a comment on PR 1316\n\nContinue to finish all stage of SDLC" → RESPOND
+"let's go with that" → RESPOND
+"please ship it when ready" → RESPOND
+"ok great" → REACT
+"sounds good" → REACT
+"nice work" → REACT
+"👍" → SILENT
+"thanks" → SILENT
+"got it" → SILENT
+```
+
+Examples cover all three labels so the model anchors on the full RESPOND/REACT/SILENT decision boundary, not just the imperative case. The prompt grows by operational feedback — when a new misclassification surfaces in `terminus:` DEBUG logs, append a labeled example here.
+
+#### DEBUG Log — Operational Feedback Loop
+
+Both Fast-Path 0 hits and LLM-classified results are logged at `DEBUG` level:
+
+```
+terminus: 'RESPOND' — 'Continue to finish all stage of SDLC' (Fast-Path 0)
+terminus: 'REACT' — 'ok great'
+terminus: 'SILENT' — 'thanks'
+```
+
+Tail with `tail -f logs/bridge.log | grep terminus:` (or grep historical files) to surface misclassifications. When a new SILENT decision should have been RESPOND, add the verb to `_IMPERATIVE_VERBS` (if it's a clean continuation imperative) and/or add a labeled few-shot example to the prompt. The 15-verb starting set is not final — it's a seed list that grows by feedback.
 
 ### LLM Classification
 
@@ -111,6 +161,18 @@ Unit tests in `tests/unit/test_routing.py` cover all required scenarios:
 - `test_classify_terminus_human_short_reply_no_question_still_silent` — human "Yes" + declarative thread → SILENT (regression guard)
 - `test_classify_terminus_bot_short_reply_to_valor_question_still_silent` — bot "Yes" + Valor question → SILENT via Fast-Path 1 (pins fast-path ordering)
 - `test_classify_terminus_url_query_in_thread_not_treated_as_question` — URL `?q=1` in thread_messages → SILENT (URL query strings stay excluded)
+
+**Fast-Path 0 imperative tests** (issue [#1318](https://github.com/tomcounsell/ai/issues/1318)):
+
+- `test_classify_terminus_imperative_single_line_returns_respond` — single-line "Continue ..." → RESPOND
+- `test_classify_terminus_imperative_multi_line_returns_respond` — May 7 incident verbatim (two-line message, imperative on line 2) → RESPOND
+- `test_classify_terminus_imperative_go_ahead_multi_word_returns_respond` — "Go ahead and merge it" → RESPOND
+- `test_classify_terminus_imperative_proceed_returns_respond` — "Proceed with the plan" → RESPOND
+- `test_classify_terminus_imperative_single_word_continue_returns_respond` — single-word "continue" → RESPOND (Fast-Path 0 fires before Fast-Path 2's ≤1-word SILENT check)
+- `test_classify_terminus_ok_great_does_not_respond` — "ok great" → REACT or SILENT, but never RESPOND
+- `test_classify_terminus_thanks_still_silent_regression` — "thanks" → SILENT (acknowledgment token unchanged)
+- `test_classify_terminus_imperative_from_bot_still_silent` — bot sender with imperative → SILENT via Fast-Path 1 (Fast-Path 0 is human-only)
+- `test_classify_terminus_mid_line_imperative_does_not_match_regex` — mid-sentence "continue" must NOT match `_IMPERATIVE_LINE_RE` (verifies regex anchor directly)
 
 ## Related
 

--- a/tests/unit/test_routing.py
+++ b/tests/unit/test_routing.py
@@ -257,3 +257,127 @@ async def test_classify_terminus_url_query_in_thread_not_treated_as_question():
         sender_is_bot=False,
     )
     assert result == "SILENT"
+
+
+# =============================================================================
+# Fast-Path 0: imperative verb tests (issue #1318)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_imperative_single_line_returns_respond():
+    """Single-line imperative directive → RESPOND via Fast-Path 0 (no LLM call)."""
+    result = await classify_conversation_terminus(
+        text="Continue to finish all stage of SDLC",
+        thread_messages=[],
+        sender_is_bot=False,
+    )
+    assert result == "RESPOND"
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_imperative_multi_line_returns_respond():
+    """Multi-line imperative on line 2 → RESPOND via Fast-Path 0.
+
+    This is the May 7 motivating incident text verbatim. A regex anchored only
+    to message start (``^\\s*``) would miss this — the imperative is on line 2.
+    """
+    result = await classify_conversation_terminus(
+        text="I left a comment on PR 1316\n\nContinue to finish all stage of SDLC",
+        thread_messages=[],
+        sender_is_bot=False,
+    )
+    assert result == "RESPOND"
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_imperative_go_ahead_multi_word_returns_respond():
+    """Multi-word imperative ``go ahead`` → RESPOND via Fast-Path 0."""
+    result = await classify_conversation_terminus(
+        text="Go ahead and merge it",
+        thread_messages=[],
+        sender_is_bot=False,
+    )
+    assert result == "RESPOND"
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_imperative_proceed_returns_respond():
+    """``Proceed with the plan`` → RESPOND via Fast-Path 0."""
+    result = await classify_conversation_terminus(
+        text="Proceed with the plan",
+        thread_messages=[],
+        sender_is_bot=False,
+    )
+    assert result == "RESPOND"
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_imperative_single_word_continue_returns_respond():
+    """Single-word ``continue`` → RESPOND via Fast-Path 0.
+
+    Fast-Path 0 must fire BEFORE Fast-Path 2's ≤1-word SILENT check so a
+    standalone imperative is never silently dropped.
+    """
+    result = await classify_conversation_terminus(
+        text="continue",
+        thread_messages=[],
+        sender_is_bot=False,
+    )
+    assert result == "RESPOND"
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_ok_great_does_not_respond():
+    """Regression guard: ``ok great`` from a human must NOT classify as RESPOND.
+
+    "ok great" is a 2-word natural closer and not in `_ACKNOWLEDGMENT_TOKENS`
+    as a multi-word phrase, so it falls through Fast-Paths 0-3 and reaches the
+    LLM. Both REACT (emoji acknowledgment) and SILENT (no reply) are correct
+    outcomes — the harm Fast-Path 0 fights is RESPOND being missed for
+    imperatives, not REACT vs SILENT for closers. Pin the non-RESPOND behavior.
+    """
+    result = await classify_conversation_terminus(
+        text="ok great",
+        thread_messages=[],
+        sender_is_bot=False,
+    )
+    assert result in ("SILENT", "REACT")
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_thanks_still_silent_regression():
+    """Regression guard: ``thanks`` from a human → SILENT (acknowledgment token)."""
+    result = await classify_conversation_terminus(
+        text="thanks",
+        thread_messages=[],
+        sender_is_bot=False,
+    )
+    assert result == "SILENT"
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_imperative_from_bot_still_silent():
+    """Bot sender with an imperative → SILENT via Fast-Path 1.
+
+    Fast-Path 0 is human-only — it must NEVER fire for bots, otherwise an AI
+    bot loop containing the word "continue" would re-trigger Valor.
+    """
+    result = await classify_conversation_terminus(
+        text="Continue with deployment",
+        thread_messages=[],
+        sender_is_bot=True,
+    )
+    assert result == "SILENT"
+
+
+def test_classify_terminus_mid_line_imperative_does_not_match_regex():
+    """Mid-sentence ``continue`` must NOT match Fast-Path 0.
+
+    The ``(?:^|\\n)\\s*`` anchor requires a preceding newline or message start,
+    so an imperative embedded mid-sentence falls through to the LLM. Verifies
+    against the compiled regex directly so the test is deterministic and does
+    not depend on LLM responses.
+    """
+    text = "I would just continue this automatically"
+    assert routing._IMPERATIVE_LINE_RE.search(text) is None


### PR DESCRIPTION
## Summary

Eliminates SILENT misclassification of human action directives ("Continue to finish all stage of SDLC", "Go ahead and merge") by the terminus classifier. The May 7 incident silently dropped a multi-line reply where the imperative was on line 2; no fast-path fired and the zero-shot Ollama prompt returned SILENT.

## Changes

- **Fast-Path 0** (\`bridge/routing.py\`): multi-line aware regex \`_IMPERATIVE_LINE_RE\` with \`(?:^|\n)\s*<verb>\b\` anchor. Returns RESPOND for human senders when any line begins with one of 15 high-precision continuation imperatives. Bot-only suppression preserved (Fast-Path 1 still wins for bots). Common verbs that frequently appear non-imperatively (\`fix\`, \`run\`, \`merge\`, \`start\`, \`deploy\`, \`execute\`, \`push\`) are deliberately excluded.
- **Few-shot LLM prompt**: replaces the zero-shot prompt with 13 labeled RESPOND/REACT/SILENT examples drawn from canonical edge cases plus the May 7 incident text verbatim.
- **DEBUG log** (\`terminus: {result!r} — {text[:80]!r}\`): operational feedback loop so future misclassifications surface in \`tail -f logs/bridge.log\`.
- **9 new unit tests** in \`tests/unit/test_routing.py\` covering all success criteria including the May 7 incident verbatim, multi-word imperatives, single-word \`continue\`, bot-sender suppression, and a regex-level mid-line non-match guard.
- **Docs** updated: \`docs/features/agent-reply-terminus.md\` documents Fast-Path 0, the multi-line anchor strategy, the few-shot prompt rationale, the DEBUG log, and the new test list.

## Testing

- [x] All 30 tests in \`tests/unit/test_routing.py\` pass
- [x] Ruff check + format clean on \`bridge/routing.py\` and \`tests/unit/test_routing.py\`
- [x] Verification table grep checks pass

## Documentation

- [x] \`docs/features/agent-reply-terminus.md\` updated

Closes #1318