### PR TITLE
fix(terminus): Fast-Path 0 imperative regex + few-shot LLM prompt (#1318)

### DIFF
--- a/bridge/routing.py
+++ b/bridge/routing.py
@@ -552,6 +552,47 @@ async def classify_needs_response_async(text: str) -> bool:
 # Lookahead: not followed by \w+= (query param name=value pattern)
 _STANDALONE_QUESTION_RE = re.compile(r"(?<![=&\w])\?|(?<![=&])\?(?!\w+=)")
 
+# Fast-Path 0: imperative continuation verbs that must always RESPOND.
+#
+# These few-shot examples are mined from real misclassified messages where the
+# zero-shot Ollama prompt incorrectly returned SILENT. The motivating incident
+# (May 7, issue #1318): a multi-line reply to Valor where line 2 was an
+# explicit directive ("Continue to finish all stage of SDLC") was dropped by
+# the LLM. Fast-Path 0 short-circuits these to RESPOND before any LLM call.
+#
+# Verb list is deliberately narrow — only high-precision continuation
+# imperatives. Common verbs that frequently appear non-imperatively at message
+# starts (run, fix, merge, start, deploy, execute, push) are EXCLUDED here and
+# handled by the few-shot LLM prompt instead.
+#
+# Mined examples (real dropped messages, paraphrased for log privacy):
+#   ("Continue to finish all stage of SDLC", RESPOND)            # May 7, issue #1318
+#   ("I left a comment on PR 1316\n\nContinue to finish all stage of SDLC", RESPOND)
+#   ("Go ahead and merge", RESPOND)                              # May 6 cluster
+#   ("Proceed with the plan", RESPOND)                           # May 6 cluster
+#   ("retry the failed step", RESPOND)                           # May 6 cluster
+_IMPERATIVE_VERBS = (
+    "continue",
+    "proceed",
+    "resume",
+    "retry",
+    "redo",
+    "go ahead",
+    "ship it",
+    "do it",
+    "send it",
+    "try again",
+    "keep going",
+    "finish it",
+    "do this",
+    "handle it",
+    "move on",
+)
+_IMPERATIVE_LINE_RE = re.compile(
+    r"(?:^|\n)\s*(?:" + "|".join(re.escape(v) for v in _IMPERATIVE_VERBS) + r")\b",
+    re.IGNORECASE,
+)
+
 
 async def classify_conversation_terminus(
     text: str,
@@ -566,6 +607,8 @@ async def classify_conversation_terminus(
     - "SILENT"  — bot loop or acknowledgment; do nothing
 
     Fast-path order (critical — checked before LLM):
+    0. human sender + imperative continuation verb at start of any line → RESPOND
+       (issue #1318 — prevents SILENT misclassification of explicit directives)
     1. sender_is_bot + no question → SILENT  (primary loop-break signal)
     2. acknowledgment token or very short (≤1 word) → SILENT
        (unless thread_messages contains a question — then fall through, so a
@@ -583,6 +626,14 @@ async def classify_conversation_terminus(
 
     text_stripped = text.strip()
     text_lower = text_stripped.lower()
+
+    # Fast-path 0: human-sender imperative continuation verb → RESPOND.
+    # Multi-line aware: matches imperatives at the start of ANY line, so the
+    # motivating May 7 incident (line 1 = status update, line 2 = "Continue ...")
+    # short-circuits to RESPOND without an LLM call. Bot-sender check is below,
+    # so this never interferes with bot loop suppression.
+    if not sender_is_bot and _IMPERATIVE_LINE_RE.search(text_stripped):
+        return "RESPOND"
 
     # Fast-path 1: bot sender with no question → SILENT (strongest signal for loop break)
     if sender_is_bot and not _STANDALONE_QUESTION_RE.search(text_stripped):
@@ -619,6 +670,21 @@ async def classify_conversation_terminus(
         "Recent thread context (may be empty):\n"
         f"{thread_context[:400] if thread_context else '(none)'}\n\n"
         f"Sender is a bot: {sender_is_bot}\n\n"
+        "Examples:\n"
+        '"Continue to finish all stage of SDLC" → RESPOND\n'
+        '"Go ahead and merge" → RESPOND\n'
+        '"Run it again" → RESPOND\n'
+        '"Proceed with the plan" → RESPOND\n'
+        '"merge it" → RESPOND\n'
+        '"deploy when ready" → RESPOND\n'
+        '"fix the failing test" → RESPOND\n'
+        '"I left a comment on PR 1316\\n\\nContinue to finish all stage of SDLC" → RESPOND\n'
+        '"ok great" → REACT\n'
+        '"sounds good" → REACT\n'
+        '"nice work" → REACT\n'
+        '"👍" → SILENT\n'
+        '"thanks" → SILENT\n'
+        '"got it" → SILENT\n\n'
         "Instructions:\n"
         "- If the message contains a question or requests action → reply RESPOND\n"
         "- If the message is a natural conversation closer (completion language,\n"
@@ -670,6 +736,10 @@ async def classify_conversation_terminus(
     # Conservative default on any failure
     if result is None:
         result = "RESPOND"
+
+    # DEBUG log: surface classified text for future few-shot mining (issue #1318).
+    # Truncated to 80 chars to stay within log line size limits.
+    logger.debug(f"terminus: {result!r} — {text_stripped[:80]!r}")
 
     # Collapse REACT → SILENT for bot senders (no emoji spam in bot loops)
     if sender_is_bot and result == "REACT":

--- a/docs/features/agent-reply-terminus.md
+++ b/docs/features/agent-reply-terminus.md
@@ -1,7 +1,7 @@
 # Agent Reply Terminus Detection
 
 **Status:** Shipped  
-**Issues:** [#911](https://github.com/tomcounsell/ai/issues/911) (initial), [#1090](https://github.com/tomcounsell/ai/issues/1090) (question-aware Fast-Path 2)
+**Issues:** [#911](https://github.com/tomcounsell/ai/issues/911) (initial), [#1090](https://github.com/tomcounsell/ai/issues/1090) (question-aware Fast-Path 2), [#1318](https://github.com/tomcounsell/ai/issues/1318) (imperative Fast-Path 0 + few-shot prompt)
 
 ## Problem
 
@@ -41,6 +41,9 @@ async def classify_conversation_terminus(
 
 Fast-paths are checked before any LLM call, in this exact order:
 
+0. **Human sender + imperative continuation verb at start of any line** → `RESPOND`  
+   Added in [#1318](https://github.com/tomcounsell/ai/issues/1318). Short-circuits explicit action directives ("Continue to finish all stage of SDLC", "Go ahead and merge", "Proceed with the plan") to RESPOND before any LLM call. Bot-only — never fires for bot senders, so loop suppression is unaffected. See [Fast-Path 0: Imperative Verbs](#fast-path-0-imperative-verbs) below.
+
 1. **Bot sender + no standalone `?`** → `SILENT`  
    The primary loop-break signal. If the sender is a bot and the message contains no question, it's a loop continuation — silence it immediately.
 
@@ -49,6 +52,69 @@ Fast-paths are checked before any LLM call, in this exact order:
 
 3. **Standalone `?` in text** → `RESPOND`  
    Fast exit before any LLM call. Uses regex `(?<![=&\w])\?|(?<![=&])\?(?!\w+=)` to exclude URL query-string parameters like `?q=1`.
+
+#### Fast-Path 0: Imperative Verbs
+
+Added in [#1318](https://github.com/tomcounsell/ai/issues/1318) to fix a recurring SILENT misclassification: when a human replied to a Valor message with an explicit directive ("Continue to finish all stage of SDLC"), the zero-shot Ollama prompt frequently returned SILENT and the message was dropped.
+
+The fix is a module-scope compiled regex `_IMPERATIVE_LINE_RE` that matches a deliberately narrow set of high-precision continuation imperatives at the start of any line:
+
+```
+continue, proceed, resume, retry, redo,
+go ahead, ship it, do it, send it, try again,
+keep going, finish it, do this, handle it, move on
+```
+
+**Anchor:** `(?:^|\n)\s*<verb>\b` — the imperative must lead a line (start of message or after a newline). Mid-sentence usage like "I would just continue this automatically" does NOT match, because there is no preceding newline-or-start. This is critical for the May 7 motivating incident, where the directive appeared on line 2 of a multi-line reply:
+
+```
+I left a comment on PR 1316
+
+Continue to finish all stage of SDLC
+```
+
+A regex anchored only to message start (`^\s*`) would have missed this — the imperative is on line 2.
+
+**Verbs deliberately excluded:** `run`, `fix`, `merge`, `start`, `deploy`, `execute`, `push`, `complete`. These appear too frequently in declarative speech to anchor a deterministic short-circuit ("the run was successful", "fix the bug at your leisure", "start of the meeting"). The few-shot LLM prompt covers them via examples instead.
+
+**Bot-sender guard:** Fast-Path 0 is gated by `not sender_is_bot`. Bot loop suppression (Fast-Path 1) is unaffected. A bot saying "Continue with deployment" still hits Fast-Path 1 and returns SILENT.
+
+#### Few-Shot LLM Prompt
+
+The previous zero-shot prompt produced SILENT for explicit imperatives that didn't hit Fast-Path 0 (e.g., "merge it", "run it again"). The local Ollama model (`gemma4:e2b`) lacks the precision to distinguish continuation imperatives from conversation closers without examples.
+
+The prompt now includes 14 labeled few-shot examples drawn from real misclassified messages and canonical patterns:
+
+```
+"Continue to finish all stage of SDLC" → RESPOND
+"Go ahead and merge" → RESPOND
+"Run it again" → RESPOND
+"Proceed with the plan" → RESPOND
+"merge it" → RESPOND
+"deploy when ready" → RESPOND
+"fix the failing test" → RESPOND
+"I left a comment on PR 1316\n\nContinue to finish all stage of SDLC" → RESPOND
+"ok great" → REACT
+"sounds good" → REACT
+"nice work" → REACT
+"👍" → SILENT
+"thanks" → SILENT
+"got it" → SILENT
+```
+
+Cost: ~200 extra tokens per LLM call. Ollama is local — no $$ cost; latency impact is negligible.
+
+#### DEBUG Log for Future Mining
+
+After every LLM classification (i.e., when no fast-path fires), the function logs:
+
+```python
+logger.debug(f"terminus: {result!r} — {text_stripped[:80]!r}")
+```
+
+This is the operational feedback loop for verb-list drift. When a new SILENT misclassification surfaces, grep `logs/bridge.log` for `terminus: 'SILENT'` patterns, identify the missed imperative, extend `_IMPERATIVE_VERBS` and add a few-shot example. The verb list is a starting point, not a final list.
+
+To enable: set log level to DEBUG for the `bridge.routing` logger.
 
 ### LLM Classification
 
@@ -111,6 +177,18 @@ Unit tests in `tests/unit/test_routing.py` cover all required scenarios:
 - `test_classify_terminus_human_short_reply_no_question_still_silent` — human "Yes" + declarative thread → SILENT (regression guard)
 - `test_classify_terminus_bot_short_reply_to_valor_question_still_silent` — bot "Yes" + Valor question → SILENT via Fast-Path 1 (pins fast-path ordering)
 - `test_classify_terminus_url_query_in_thread_not_treated_as_question` — URL `?q=1` in thread_messages → SILENT (URL query strings stay excluded)
+
+**Fast-Path 0 imperative tests** (issue [#1318](https://github.com/tomcounsell/ai/issues/1318)):
+
+- `test_classify_terminus_imperative_single_line_returns_respond` — "Continue to finish all stage of SDLC" → RESPOND
+- `test_classify_terminus_imperative_multi_line_returns_respond` — multi-line, imperative on line 2 → RESPOND (the May 7 incident)
+- `test_classify_terminus_imperative_go_ahead_returns_respond` — "Go ahead and merge it" → RESPOND
+- `test_classify_terminus_imperative_proceed_returns_respond` — "Proceed with the plan" → RESPOND
+- `test_classify_terminus_imperative_single_word_returns_respond` — single-word "continue" → RESPOND (overrides Fast-Path 2 ≤1-word silencing)
+- `test_classify_terminus_ok_great_does_not_respond_via_fast_path_0` — "ok great" must not match `_IMPERATIVE_LINE_RE`
+- `test_classify_terminus_thanks_still_silent` — "thanks" → SILENT (regression guard)
+- `test_classify_terminus_bot_imperative_still_silent` — bot saying "Continue with deployment" → SILENT (Fast-Path 1 wins)
+- `test_imperative_line_re_does_not_match_mid_sentence` — "I would just continue this automatically" must not match (mid-line falls through to LLM)
 
 ## Related
 

--- a/tests/unit/test_routing.py
+++ b/tests/unit/test_routing.py
@@ -257,3 +257,117 @@ async def test_classify_terminus_url_query_in_thread_not_treated_as_question():
         sender_is_bot=False,
     )
     assert result == "SILENT"
+
+
+# =============================================================================
+# Fast-Path 0: imperative verb tests (issue #1318)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_imperative_single_line_returns_respond():
+    """Fast-Path 0: explicit imperative on its own line → RESPOND, no LLM call."""
+    result = await classify_conversation_terminus(
+        text="Continue to finish all stage of SDLC",
+        thread_messages=[],
+        sender_is_bot=False,
+    )
+    assert result == "RESPOND"
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_imperative_multi_line_returns_respond():
+    """Fast-Path 0: imperative on line 2 of a multi-line message → RESPOND.
+
+    This is the May 7 motivating incident from issue #1318. The reply contained
+    a status line followed by a blank line followed by the directive. Without
+    multi-line awareness, the imperative would have been missed.
+    """
+    text = "I left a comment on PR 1316\n\nContinue to finish all stage of SDLC"
+    result = await classify_conversation_terminus(
+        text=text,
+        thread_messages=[],
+        sender_is_bot=False,
+    )
+    assert result == "RESPOND"
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_imperative_go_ahead_returns_respond():
+    """Fast-Path 0: multi-word imperative 'go ahead' → RESPOND."""
+    result = await classify_conversation_terminus(
+        text="Go ahead and merge it",
+        thread_messages=[],
+        sender_is_bot=False,
+    )
+    assert result == "RESPOND"
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_imperative_proceed_returns_respond():
+    """Fast-Path 0: 'Proceed with the plan' → RESPOND."""
+    result = await classify_conversation_terminus(
+        text="Proceed with the plan",
+        thread_messages=[],
+        sender_is_bot=False,
+    )
+    assert result == "RESPOND"
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_imperative_single_word_returns_respond():
+    """Fast-Path 0: single-word imperative 'continue' → RESPOND.
+
+    Without Fast-Path 0, this would hit Fast-Path 2 (≤1 word) and return SILENT.
+    """
+    result = await classify_conversation_terminus(
+        text="continue",
+        thread_messages=[],
+        sender_is_bot=False,
+    )
+    assert result == "RESPOND"
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_ok_great_does_not_respond_via_fast_path_0():
+    """Regression: Fast-Path 0 must NOT over-fire on conversation closers.
+
+    'ok great' contains no imperative verb, so Fast-Path 0 must not match. The
+    actual classification of 'ok great' (REACT vs SILENT) is decided by the
+    LLM and is not pinned here — what we guard against is Fast-Path 0
+    incorrectly returning RESPOND.
+    """
+    assert routing._IMPERATIVE_LINE_RE.search("ok great") is None
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_thanks_still_silent():
+    """Regression: 'thanks' must still return SILENT."""
+    result = await classify_conversation_terminus(
+        text="thanks",
+        thread_messages=[],
+        sender_is_bot=False,
+    )
+    assert result == "SILENT"
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_bot_imperative_still_silent():
+    """Fast-Path 0 is human-only: a bot saying 'Continue with deployment'
+    must still hit Fast-Path 1 and return SILENT (loop break preserved)."""
+    result = await classify_conversation_terminus(
+        text="Continue with deployment",
+        thread_messages=[],
+        sender_is_bot=True,
+    )
+    assert result == "SILENT"
+
+
+def test_imperative_line_re_does_not_match_mid_sentence():
+    """Mid-sentence imperatives must NOT trigger Fast-Path 0.
+
+    'I would just continue this automatically' contains 'continue' but not as
+    the leading word of any line, so the regex must not match. The message
+    falls through to the LLM for full classification.
+    """
+    assert routing._IMPERATIVE_LINE_RE.search("I would just continue this automatically") is None


### PR DESCRIPTION
## Summary
- Adds Fast-Path 0 to `classify_conversation_terminus` — a multi-line-aware regex that short-circuits human messages containing continuation imperatives ("continue", "proceed", "go ahead", etc.) to RESPOND before any LLM call.
- Replaces the zero-shot Ollama prompt with a 14-example few-shot prompt covering imperatives, REACT-worthy closers, and SILENT-worthy acknowledgments.
- Adds a DEBUG log (`terminus: {result!r} — {text[:80]!r}`) so future SILENT misclassifications can be mined to extend the verb list.

## Why
The May 7 incident: a human reply to a Valor message containing "I left a comment on PR 1316\n\nContinue to finish all stage of SDLC" reached the Ollama LLM, which returned SILENT. The message was dropped. Multiple follow-ups were also dropped. No session was spawned for over 2 hours.

## Changes
- `bridge/routing.py` — `_IMPERATIVE_VERBS` tuple, `_IMPERATIVE_LINE_RE` regex with `(?:^|\n)\s*<verb>\b` anchor (multi-line aware), Fast-Path 0 check (human-only), few-shot prompt, DEBUG log.
- `tests/unit/test_routing.py` — 9 new tests including the May 7 multi-line incident verbatim.
- `docs/features/agent-reply-terminus.md` — new "Fast-Path 0: Imperative Verbs" subsection.

## Verb list discipline
Deliberately narrow (15 high-precision continuation imperatives). Common verbs that often appear non-imperatively at message starts (`run`, `fix`, `merge`, `start`, `deploy`, `execute`, `push`, `complete`) are EXCLUDED from Fast-Path 0 and handled by the few-shot prompt instead.

## Testing
- [x] `pytest tests/unit/test_routing.py -v` — 30 passed
- [x] `ruff check` + `ruff format --check` clean

Closes #1318