### PR TITLE
Size-aware media download timeout (closes #1322)

### DIFF
--- a/bridge/media.py
+++ b/bridge/media.py
@@ -245,6 +245,43 @@ def get_media_type(message) -> str | None:
 # =============================================================================
 
 
+# Baseline timeout when size is unknown or non-positive.
+_DOWNLOAD_TIMEOUT_BASELINE_S = 10.0
+# Hard cap for a single download attempt; protects against extreme files
+# blocking the bridge intake path.
+_DOWNLOAD_TIMEOUT_CAP_S = 120.0
+# Per-MB allowance added on top of a 5s startup constant.
+_DOWNLOAD_TIMEOUT_PER_MB_S = 1.0
+_DOWNLOAD_TIMEOUT_BASE_OVERHEAD_S = 5.0
+
+
+def compute_media_timeout(size_bytes: int | None) -> float:
+    """Compute a per-attempt download timeout that scales with declared size.
+
+    Formula (when ``size_bytes`` is a positive int)::
+
+        max(10.0, min(120.0, 5.0 + size_bytes / (1024*1024)))
+
+    Returns the 10s baseline for ``None``, ``0``, and negative inputs so the
+    behaviour matches the pre-#1322 hard-coded timeout when Telethon's
+    ``message.file.size`` is missing (e.g. some photo thumbnails).
+
+    Examples (approximate):
+        - None / 0 / negative -> 10s (baseline)
+        - 1MB                 -> 10s (floored)
+        - 10MB                -> 15s
+        - 100MB               -> 105s
+        - 200MB+              -> 120s (cap)
+
+    See issue #1322 / docs/plans/sdlc-1322.md.
+    """
+    if size_bytes is None or size_bytes <= 0:
+        return _DOWNLOAD_TIMEOUT_BASELINE_S
+    mb = size_bytes / (1024 * 1024)
+    raw = _DOWNLOAD_TIMEOUT_BASE_OVERHEAD_S + _DOWNLOAD_TIMEOUT_PER_MB_S * mb
+    return max(_DOWNLOAD_TIMEOUT_BASELINE_S, min(_DOWNLOAD_TIMEOUT_CAP_S, raw))
+
+
 async def download_media(client: TelegramClient, message, prefix: str = "media") -> Path | None:
     """
     Download media from a Telegram message.

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -112,6 +112,7 @@ from bridge.media import (  # noqa: E402
     MEDIA_DIR,  # noqa: F401
     VISION_EXTENSIONS,  # noqa: F401
     VOICE_EXTENSIONS,  # noqa: F401
+    compute_media_timeout,
     describe_image,  # noqa: F401
     download_media,  # noqa: F401
     extract_document_text,  # noqa: F401
@@ -657,6 +658,88 @@ from bridge.update import (  # noqa: E402
 )
 
 
+async def _download_media_with_retry(
+    client,
+    message,
+    prefix: str = "media",
+) -> tuple[Path | None, str | None]:
+    """Download a Telegram media attachment with size-aware timeout + 1 retry.
+
+    Issue #1322 — the original code used a hard-coded 10s timeout; large files
+    on slow links failed silently. This wrapper:
+
+      1. Reads ``message.file.size`` (None-safe for thumbnails).
+      2. Computes a per-attempt timeout via ``compute_media_timeout`` (capped
+         at 120s).
+      3. Attempts the download. On ``TimeoutError``, retries once with a
+         **2x leash** (still capped at 120s).
+      4. Returns ``(local_path, error_string)``. On terminal timeout the error
+         string is ``"timeout after Xs (retried)"`` so downstream can tell
+         "too big" from "first attempt was just unlucky".
+
+    Telemetry: emits one ``logger.info`` line per attempt with
+    ``size_bytes``, ``computed_timeout_s``, ``duration_ms``, ``attempt``,
+    ``outcome``.
+    """
+    size_bytes: int | None = None
+    try:
+        size_bytes = getattr(getattr(message, "file", None), "size", None)
+    except Exception:
+        size_bytes = None
+
+    first_timeout = compute_media_timeout(size_bytes)
+    second_timeout = min(120.0, max(first_timeout, 2.0 * first_timeout))
+
+    msg_id = getattr(message, "id", None)
+
+    async def _attempt(timeout_s: float, attempt_n: int) -> tuple[Path | None, str | None]:
+        started = time.monotonic()
+        try:
+            path = await asyncio.wait_for(
+                download_media(client, message, prefix=prefix),
+                timeout=timeout_s,
+            )
+            duration_ms = int((time.monotonic() - started) * 1000)
+            outcome = "success" if path is not None else "no_path"
+            logger.info(
+                f"[media] download attempt={attempt_n} outcome={outcome} "
+                f"size_bytes={size_bytes} computed_timeout_s={timeout_s:.1f} "
+                f"duration_ms={duration_ms} msg_id={msg_id}"
+            )
+            return path, None
+        except TimeoutError:
+            duration_ms = int((time.monotonic() - started) * 1000)
+            logger.info(
+                f"[media] download attempt={attempt_n} outcome=timeout "
+                f"size_bytes={size_bytes} computed_timeout_s={timeout_s:.1f} "
+                f"duration_ms={duration_ms} msg_id={msg_id}"
+            )
+            return None, "timeout"
+        except Exception as e:
+            duration_ms = int((time.monotonic() - started) * 1000)
+            logger.info(
+                f"[media] download attempt={attempt_n} outcome=error "
+                f"size_bytes={size_bytes} computed_timeout_s={timeout_s:.1f} "
+                f"duration_ms={duration_ms} msg_id={msg_id} err={type(e).__name__}"
+            )
+            return None, f"{type(e).__name__}: {e}"
+
+    path, err = await _attempt(first_timeout, attempt_n=1)
+    if path is not None:
+        return path, None
+    if err != "timeout":
+        # Non-timeout error: do not retry — return the error as-is.
+        return None, err
+
+    # First attempt timed out — retry with 2x leash.
+    path, err = await _attempt(second_timeout, attempt_n=2)
+    if path is not None:
+        return path, None
+    if err == "timeout":
+        return None, f"timeout after {second_timeout:.0f}s (retried)"
+    return None, err
+
+
 def _build_completed_resume_text(
     completed_session,
     follow_up_text: str,
@@ -1142,30 +1225,29 @@ async def main():
             except Exception as e:
                 logger.warning(f"Memory save failed (non-fatal): {e}")
 
-        # === sdlc-1297: bridge-side media download ===
-        # The bridge owns Telethon RPC; the worker owns AI work. We download the
-        # media file synchronously here (with a 10s timeout) and persist the
-        # absolute path on the TelegramMessage record so the worker can run
+        # === sdlc-1297 + sdlc-1322: bridge-side media download ===
+        # The bridge owns Telethon RPC; the worker owns AI work. We download
+        # the media file synchronously here and persist the absolute path on
+        # the TelegramMessage record so the worker can run
         # vision/Whisper/extraction without ever touching Telethon.
+        #
+        # Issue #1322: timeout is now size-aware (5s + 1s/MB, capped at 120s)
+        # with one retry on TimeoutError using a 2x leash. Terminal failures
+        # set ``media_download_error`` to ``"timeout after Xs (retried)"`` so
+        # downstream can distinguish "first attempt was unlucky" from
+        # "we tried twice and the file is just too big".
         if message.media and stored_msg_id is not None:
             _media_type_for_download = get_media_type(message) or "media"
-            _local_path: Path | None = None
-            _download_error: str | None = None
-            try:
-                _local_path = await asyncio.wait_for(
-                    download_media(client, message, prefix=_media_type_for_download),
-                    timeout=10.0,
-                )
-            except TimeoutError:
-                _download_error = "timeout after 10s"
+            _local_path, _download_error = await _download_media_with_retry(
+                client,
+                message,
+                prefix=_media_type_for_download,
+            )
+            if _download_error:
                 logger.warning(
-                    f"[media] download timeout after 10s "
-                    f"(chat_id={event.chat_id}, msg_id={message.id})"
-                )
-            except Exception as e:
-                _download_error = f"{type(e).__name__}: {e}"
-                logger.warning(
-                    f"[media] download failed (chat_id={event.chat_id}, msg_id={message.id}): {e}"
+                    f"[media] download failed "
+                    f"(chat_id={event.chat_id}, msg_id={message.id}): "
+                    f"{_download_error}"
                 )
 
             try:

--- a/tests/unit/test_telegram_bridge_media_timeout.py
+++ b/tests/unit/test_telegram_bridge_media_timeout.py
@@ -1,0 +1,170 @@
+"""Tests for size-aware media download timeout + retry (issue #1322).
+
+Covers:
+- `compute_media_timeout(size_bytes)`: pure helper. None / 0 / negative
+  fall back to baseline (10s); positive sizes scale; cap at 120s.
+- Retry path emits the `(retried)` suffix on terminal failure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from bridge.media import compute_media_timeout
+
+# ---------------------------------------------------------------------------
+# compute_media_timeout: pure helper
+# ---------------------------------------------------------------------------
+
+
+class TestComputeMediaTimeout:
+    """The formula: max(10.0, min(120.0, 5.0 + size_bytes / (1024*1024)))
+    with None / non-positive falling back to 10.0."""
+
+    def test_none_returns_baseline(self):
+        assert compute_media_timeout(None) == 10.0
+
+    def test_zero_returns_baseline(self):
+        # Zero-byte file shouldn't get less than the floor.
+        assert compute_media_timeout(0) == 10.0
+
+    def test_negative_returns_baseline(self):
+        # Defensive: negative is nonsense -> baseline.
+        assert compute_media_timeout(-1) == 10.0
+        assert compute_media_timeout(-1024 * 1024) == 10.0
+
+    def test_small_file_returns_baseline_floor(self):
+        # 1MB -> 5 + 1 = 6, floored to 10.
+        assert compute_media_timeout(1 * 1024 * 1024) == 10.0
+
+    def test_medium_file_scales(self):
+        # 10MB -> 5 + 10 = 15.
+        assert compute_media_timeout(10 * 1024 * 1024) == 15.0
+
+    def test_large_file_scales(self):
+        # 50MB -> 5 + 50 = 55.
+        assert compute_media_timeout(50 * 1024 * 1024) == 55.0
+
+    def test_cap_at_120s(self):
+        # 200MB -> would be 205, but capped at 120.
+        assert compute_media_timeout(200 * 1024 * 1024) == 120.0
+
+    def test_huge_file_still_capped(self):
+        # 1GB -> still 120.
+        assert compute_media_timeout(1024 * 1024 * 1024) == 120.0
+
+
+# ---------------------------------------------------------------------------
+# Retry path: error string carries `(retried)` after both attempts time out
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_emits_retried_suffix_on_terminal_timeout():
+    """Both download attempts time out -> `media_download_error` set on the
+    record contains "(retried)" so downstream can distinguish first-attempt
+    failures from terminal ones.
+
+    We exercise the actual code path in `telegram_bridge` by importing the
+    module-level coroutine and mocking the wait_for to time out twice.
+    """
+    # Import lazily — we only need the symbol that wraps the retry logic.
+    from bridge import telegram_bridge
+
+    # Sanity check: the helper is wired to bridge code.
+    assert hasattr(telegram_bridge, "_download_media_with_retry"), (
+        "telegram_bridge must expose `_download_media_with_retry` "
+        "for the size-aware retry path (issue #1322)."
+    )
+
+    fake_message = MagicMock()
+    # message.file.size for a 30MB file -> first timeout = 35s, second = 70s
+    fake_message.file = SimpleNamespace(size=30 * 1024 * 1024)
+    fake_message.id = 42
+
+    fake_client = MagicMock()
+
+    # Patch wait_for to time out on every attempt — that's the only seam
+    # the retry helper relies on.
+    with patch.object(asyncio, "wait_for", new=AsyncMock(side_effect=TimeoutError())):
+        local_path, error = await telegram_bridge._download_media_with_retry(
+            fake_client,
+            fake_message,
+            prefix="media",
+        )
+
+    assert local_path is None
+    assert error is not None
+    assert "(retried)" in error
+    # Sanity: the second-attempt timeout should be reflected (~70s, capped at 120).
+    assert "70" in error or "120" in error or "after" in error
+
+
+@pytest.mark.asyncio
+async def test_retry_succeeds_on_second_attempt():
+    """First wait_for raises TimeoutError, second returns a path -> success
+    with no error string."""
+    from bridge import telegram_bridge
+
+    fake_message = MagicMock()
+    fake_message.file = SimpleNamespace(size=10 * 1024 * 1024)  # 10MB
+    fake_message.id = 17
+    fake_client = MagicMock()
+
+    success_path = Path("/tmp/fake_media.bin")
+
+    call_count = {"n": 0}
+
+    async def flaky(*_args, **_kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise TimeoutError()
+        return success_path
+
+    with patch.object(asyncio, "wait_for", new=AsyncMock(side_effect=flaky)):
+        local_path, error = await telegram_bridge._download_media_with_retry(
+            fake_client,
+            fake_message,
+            prefix="media",
+        )
+
+    assert local_path == success_path
+    assert error is None
+    assert call_count["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_first_attempt_success_no_retry():
+    """First attempt succeeds -> single call, no retry telemetry."""
+    from bridge import telegram_bridge
+
+    fake_message = MagicMock()
+    fake_message.file = SimpleNamespace(size=1024)  # tiny
+    fake_message.id = 99
+    fake_client = MagicMock()
+    success_path = Path("/tmp/ok.bin")
+
+    call_count = {"n": 0}
+
+    async def succeed(*_args, **_kwargs):
+        call_count["n"] += 1
+        return success_path
+
+    with patch.object(asyncio, "wait_for", new=AsyncMock(side_effect=succeed)):
+        local_path, error = await telegram_bridge._download_media_with_retry(
+            fake_client,
+            fake_message,
+            prefix="media",
+        )
+
+    assert local_path == success_path
+    assert error is None
+    assert call_count["n"] == 1


### PR DESCRIPTION
Closes #1322

Implements docs/plans/sdlc-1322.md.

## Changes

- `bridge/media.py` — new `compute_media_timeout(size_bytes)` helper. Formula: `max(10.0, min(120.0, 5.0 + size_bytes/MB))`. None / 0 / negative -> 10s baseline. Capped at 120s.
- `bridge/telegram_bridge.py` — new `_download_media_with_retry()` helper replaces the inline `asyncio.wait_for(..., timeout=10.0)` block at the intake call site. On `TimeoutError`, retries once with a 2x leash (also capped at 120s).
- Distinct error string: after retry-and-fail, `media_download_error` is set to `"timeout after Xs (retried)"` so downstream can distinguish transient blip from give-up.
- Per-attempt structured telemetry: one `logger.info` line per attempt with `size_bytes`, `computed_timeout_s`, `duration_ms`, `attempt`, `outcome`, `msg_id`.

## Testing

- `tests/unit/test_telegram_bridge_media_timeout.py` — 11 tests covering `compute_media_timeout` for None/0/negative/1MB/10MB/50MB/200MB cap/1GB cap, plus retry path (terminal-timeout emits `(retried)` suffix, retry-then-succeed, first-attempt success).
- Existing `tests/unit/test_enrichment_media.py` and `tests/unit/test_media_handling.py` continue to pass.
- 29 passed, 4 skipped (pre-existing skips), 0 failures.

## Verification

- `grep -n 'def compute_media_timeout' bridge/media.py` → present at line 258.
- `grep -n 'timeout=10.0' bridge/telegram_bridge.py` → no matches (hard-coded value removed).