### PR TITLE
Audit punted tasks (closes #1325)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ valor-email threads
 | `./scripts/valor-service.sh email-status` | Check email bridge status, IMAP last-poll age, and SMTP relay heartbeat |
 | `./scripts/valor-service.sh email-dead-letter list` | List failed SMTP sends in dead-letter queue |
 | `./scripts/valor-service.sh email-dead-letter replay --all` | Replay all dead-lettered emails |
+| `./scripts/install_email_bridge.sh` | Install launchd plist for boot-time email bridge (machine-gated, idempotent; opt-in) |
 | `tail -f logs/bridge.log` | Stream bridge logs |
 | `pytest tests/` | Run all tests (parallel by default — `-n auto --dist=loadfile` from `pyproject.toml`) |
 | `pytest tests/unit/` | Run unit tests only (~40s parallel) |

--- a/bridge/email_bridge.py
+++ b/bridge/email_bridge.py
@@ -1002,14 +1002,19 @@ async def run_email_bridge() -> None:
 
 def main() -> None:
     """Entry point for ``python -m bridge.email_bridge``."""
+    import os
     import sys
     from pathlib import Path
 
     from dotenv import load_dotenv
 
-    # Mirror telegram_bridge.py env loading: repo .env first, vault .env second
-    load_dotenv(Path(__file__).parent.parent / ".env")
-    load_dotenv(Path.home() / "Desktop" / "Valor" / ".env")
+    # Mirror telegram_bridge.py env loading: repo .env first, vault .env second.
+    # Under launchd (VALOR_LAUNCHD=1), env vars are injected directly into the
+    # plist by install_email_bridge.sh — skip dotenv entirely to avoid macOS
+    # TCC hangs on the iCloud-synced ~/Desktop/Valor/.env that .env symlinks to.
+    if not os.environ.get("VALOR_LAUNCHD"):
+        load_dotenv(Path(__file__).parent.parent / ".env")
+        load_dotenv(Path.home() / "Desktop" / "Valor" / ".env")
 
     logging.basicConfig(
         level=logging.INFO,

--- a/com.valor.email-bridge.plist
+++ b/com.valor.email-bridge.plist
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Email Bridge launchd template.
+
+  Source-of-truth template — installed copy is rendered by
+  scripts/install_email_bridge.sh into ~/Library/LaunchAgents/.
+
+  The installer:
+    1. Substitutes __PROJECT_DIR__/__HOME_DIR__/__SERVICE_LABEL__ tokens.
+    2. Injects .env values into EnvironmentVariables via dotenv_values()
+       so launchd never has to open ~/Desktop/Valor/.env (macOS TCC
+       blocks launchd agents from reading ~/Desktop files).
+    3. Runs `launchctl bootout` then `bootstrap` (idempotent install).
+
+  KeepAlive=true gives launchd-level restart on crash. There is no
+  separate watchdog — the email bridge does not have the Telethon
+  session-lock failure mode that necessitates com.valor.bridge-watchdog.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>__SERVICE_LABEL__</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__PROJECT_DIR__/.venv/bin/python</string>
+        <string>-m</string>
+        <string>bridge.email_bridge</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>__PROJECT_DIR__</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>__HOME_DIR__/.local/bin:__PROJECT_DIR__/.venv/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/usr/sbin:/bin</string>
+        <key>HOME</key>
+        <string>__HOME_DIR__</string>
+        <key>VALOR_LAUNCHD</key>
+        <string>1</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>__PROJECT_DIR__/logs/email_bridge.log</string>
+    <key>StandardErrorPath</key>
+    <string>__PROJECT_DIR__/logs/email_bridge.error.log</string>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+</dict>
+</plist>

--- a/docs/features/email-bridge.md
+++ b/docs/features/email-bridge.md
@@ -217,6 +217,29 @@ For Gmail, generate an App Password at <https://myaccount.google.com/apppassword
 ./scripts/valor-service.sh email-dead-letter replay --all
 ```
 
+### Boot-time auto-start
+
+Operators who want the email bridge to auto-start on boot can install a launchd plist:
+
+```bash
+./scripts/install_email_bridge.sh
+```
+
+The installer is **machine-gated**: it inspects `~/Desktop/Valor/projects.json` for any project owned by the current machine that has an `email:` block, and exits 0 with a "skip" message on machines without one. (Mirrors the `has_bridge_role` gate used by the Telegram bridge installer.)
+
+Key behaviors:
+
+- Idempotent (runs `launchctl bootout` before `bootstrap`).
+- Foreground-process pre-check: refuses to bootstrap if a non-launchd `python -m bridge.email_bridge` is already running (e.g. from `valor-service.sh email-start`). Stop the foreground bridge first.
+- Injects `.env` values into the plist's `EnvironmentVariables` block via `dotenv_values()`. macOS TCC blocks launchd agents from reading `~/Desktop` files, so the iCloud-synced `.env` would otherwise hang the bridge at startup.
+- Sets `VALOR_LAUNCHD=1` in the plist so `bridge/routing.py` and `bridge/email_bridge.py::main` skip their own iCloud `.env` reads.
+- Copies `~/Desktop/Valor/projects.json` to `config/projects.json` (and `reflections.yaml` if present) so the launchd-loaded bridge reads from local files rather than the iCloud-synced vault.
+- `KeepAlive=true` provides launchd-level restart on crash; no separate watchdog is installed (the email bridge does not have the Telethon session-lock failure mode that justifies `com.valor.bridge-watchdog`).
+
+**projects.json refresh contract.** After editing `~/Desktop/Valor/projects.json` (the iCloud-synced source of truth), operators **must** re-run `./scripts/install_email_bridge.sh` on every email-bridge machine to refresh the local `config/projects.json` copy. The launchd-loaded bridge reads the local copy under `VALOR_LAUNCHD=1`; without a refresh, an email-only machine continues to route based on the stale local copy.
+
+Operators who don't run the installer keep using `valor-service.sh email-start` exactly as before — boot-time auto-start is opt-in.
+
 ## Health Monitoring
 
 After each successful IMAP poll, the bridge writes the current timestamp to:

--- a/docs/plans/completed/email-bridge.md
+++ b/docs/plans/completed/email-bridge.md
@@ -426,3 +426,14 @@ Using: builder, test-engineer, validator, documentarian
 3. **SMTP/IMAP credentials**: **Single global account** via `.env` variables: `IMAP_HOST`, `IMAP_USER`, `IMAP_PASSWORD`, `IMAP_PORT`, `SMTP_HOST`, `SMTP_USER`, `SMTP_PASSWORD`, `SMTP_PORT`. Gmail with App Password.
 
 4. **Gmail API vs IMAP/SMTP**: **IMAP/SMTP.** The bridge is a long-running daemon — static App Password credentials are simpler than OAuth token refresh. Gmail MCP tools remain available to the agent during sessions for email search/context, but the bridge transport layer uses IMAP/SMTP.
+
+
+<!--
+Audited 2026-05-08, see #1325 audit comment for status.
+
+Punt at line 348 ("Deferred to follow-up: launchd plist + install script"):
+addressed in this audit PR (closes #1325). Adds com.valor.email-bridge.plist
+template, scripts/install_email_bridge.sh (machine-gated, env-injecting,
+idempotent), VALOR_LAUNCHD env-gate in bridge/email_bridge.py::main, and a
+regression test test_main_skips_dotenv_under_launchd.
+-->

--- a/docs/plans/completed/kill-is-terminal.md
+++ b/docs/plans/completed/kill-is-terminal.md
@@ -503,3 +503,12 @@ No agent integration changes required — `valor-session` CLI is unchanged from 
 The following work is intentionally **out of scope** for this plan but should be filed as a separate GitHub issue once this plan ships:
 
 - **Index-staleness investigation for `waiting_for_children` (Q2 deferral, originally Fix E in earlier drafts of this plan).** Determine why a `killed` parent matches `AgentSession.query.filter(status="waiting_for_children")` after kill. Likely candidates: Popoto IndexedField corruption (analogous to #1006, which only fixed the `running` index path), or a lazy-load timing artifact where the query returns a cached object whose in-memory status disagrees with the hash. Operational mitigation already in place via Fix B (the re-read guard at the hierarchy health check); this follow-up addresses the underlying corruption itself. Suggested instrumentation: snapshot `r.smembers("agent_session:status:waiting_for_children")` before and after kill, diff the membership, and compare to each session's `r.hget(key, "status")`. Title suggestion: "Investigate `waiting_for_children` index staleness for killed parents (follow-up to #1208)". This issue will be filed *after* the kill-is-terminal plan ships, not as part of this build.
+
+
+<!--
+Audited 2026-05-08, see #1325 audit comment for status.
+
+Punt at line 207 (Fix E - waiting_for_children index-staleness investigation):
+filed as #1335 (label: bug,investigation). Diagnosis requires Popoto-layer
+instrumentation; appetite-incompatible with the audit chore.
+-->

--- a/docs/plans/completed/message-drafter.md
+++ b/docs/plans/completed/message-drafter.md
@@ -902,3 +902,13 @@ If a concern maps to a category not in this table, the builder surfaces it in th
 The two nits are addressed as normal polish during the build — no separate step required. General directive for nits in this plan: if a sentence is ambiguous, the builder rewrites it in the same commit as the adjacent code change.
 
 A re-critique is **not dispatched** after this revision (per Row 4b directive). The SDLC router detects `revision_applied: true` in the frontmatter and advances to `/do-build` (Row 4c).
+
+
+<!--
+Audited 2026-05-08, see #1325 audit comment for status.
+
+D5c (line 827, schema field cleanup) and D5d (line 829, MESSAGE_DRAFTER_IN_HANDLER
+removal): both already done in PR #1118 (closed #1073) on 2026-04-22. Verified:
+  grep -rn "delivery_text\|delivery_action\|delivery_emoji\|MESSAGE_DRAFTER_IN_HANDLER" models/ bridge/ agent/
+returns zero matches.
+-->

--- a/docs/plans/completed/pm-workflow-announcement.md
+++ b/docs/plans/completed/pm-workflow-announcement.md
@@ -520,3 +520,13 @@ The war-room verdict was recorded in PM session state with three CONCERN finding
 | CONCERN | `skip` override scope (one-time vs. session-wide) ambiguous | Data Flow + Bucket #3 overlay text | "Implementation Note (Concern: skip override scope — one-time vs. session-wide)" — defines one-time, no persistent flag, explicit re-fire semantics |
 
 No BLOCKERs were recorded. The build proceeds with all three CONCERNs acknowledged and Implementation Notes embedded. NITs (if any were recorded) are exempt from revision per `/do-plan-critique` v1.2.0 contract.
+
+
+<!--
+Audited 2026-05-08, see #1325 audit comment for status.
+
+Two punts, both filed as separate scoped issues:
+  - line 334 (overlay-drift audit): filed as #1336 (label: chore).
+  - line 361 (/update multi-machine overlay automation step): filed as #1337
+    (labels: chore,skills).
+-->

--- a/docs/plans/sdlc-1325.md
+++ b/docs/plans/sdlc-1325.md
@@ -97,7 +97,7 @@ The work is mechanical (write one plist + installer, gate one bridge env-load, f
 - **launchd plist + installer** — `com.valor.email-bridge.plist` (repo root, matching existing sibling plists) and `scripts/install_email_bridge.sh`, modelled on `install_worker.sh` including `.env` injection via `dotenv_values()` and the `bootout`-then-`bootstrap` idempotency pattern.
 - **Machine-gated install** — the installer self-gates: it inspects `projects.json` for any project owned by this machine that has an `email:` block. If none, it prints "Skipping email-bridge install (no email-configured projects assigned to this machine)" and exits 0 cleanly, mirroring `install_service`'s `has_bridge_role` gate.
 - **Filed issues** — already filed before plan finalization: #1335 (`[EXTERNAL]` index-staleness investigation, kill-is-terminal Fix E), #1336 (overlay-drift audit, pm-workflow-announcement:334), #1337 (`/update` skill multi-machine overlay step, pm-workflow-announcement:361). No `#TBD` placeholders remain.
-- **Audit report comment** on #1325 listing what got done vs. what got re-tracked, including the 13 sweep-extra hits.
+- **Audit report comment** on #1325 listing what got done vs. what got re-tracked, including all sweep-extra hits returned by the canonical `PUNT_PHRASES` regex set (count is recorded at audit time, not hardcoded).
 
 ### Flow
 
@@ -105,7 +105,7 @@ The work is mechanical (write one plist + installer, gate one bridge env-load, f
 
 ### Technical Approach
 
-- The 6 named punts dominate; the 13 sweep-extras are mostly narrative mentions of the trigger phrases inside critique tables, footnotes, or rationale sections rather than actual unfinished work. Each is classified during the audit but most produce no action.
+- The 6 named punts dominate; the remaining sweep-extras (count is whatever the canonical `PUNT_PHRASES` sweep returns at audit time — do not hardcode) are mostly narrative mentions of the trigger phrases inside critique tables, footnotes, or rationale sections rather than actual unfinished work. Each is classified during the audit but most produce no action.
 - The launchd plist follows the `install_worker.sh` pattern (the canonical "load env vars from `.env` and bake into the plist" template): `launchctl bootstrap gui/$UID $HOME/Library/LaunchAgents/<plist>` with `KeepAlive=true` and `RunAtLoad=true`. The `valor-service.sh email-start` command remains the operational entry point; the plist is for boot-time auto-start on machines that opt in.
 - The installer **must** inject `.env` values into the plist's `EnvironmentVariables` block using the same `dotenv_values()` Python block as `install_worker.sh` (lines 86–131 of that script). Without this, the launchd-loaded email bridge would block trying to `open()` the iCloud-synced `~/Desktop/Valor/.env` (macOS TCC denies launchd agents access to ~/Desktop). The plist also sets `VALOR_LAUNCHD=1` so `bridge/routing.py` skips its own iCloud-path reads.
 - The bridge module itself **must** gate its own `load_dotenv` calls on `VALOR_LAUNCHD`. `bridge/email_bridge.py::main` (lines 1008-1012) currently calls `load_dotenv` unconditionally for both the repo `.env` and `~/Desktop/Valor/.env`. Under launchd that second call hits TCC and hangs, regardless of whether the installer baked env vars into the plist — the env injection only fixes the plist, not the bridge's own re-read at startup. Fix mirrors `bridge/telegram_bridge.py:42-48`: wrap the two `load_dotenv` calls in `if not os.environ.get("VALOR_LAUNCHD"):`.
@@ -127,9 +127,10 @@ The work is mechanical (write one plist + installer, gate one bridge env-load, f
 
 ## Test Impact
 
-- [ ] **NEW** `tests/unit/test_email_bridge.py` — ADD a test `test_main_skips_dotenv_under_launchd` that sets `VALOR_LAUNCHD=1` in env, calls `bridge.email_bridge.main` with `dotenv.load_dotenv` patched as a sentinel, and asserts the patched function is NOT called. Mirrors the `VALOR_LAUNCHD` gate in `telegram_bridge.py:42-48` and prevents regression of cycle-2 BLOCKER #1.
+- [ ] **UPDATE** `tests/unit/test_email_bridge.py` (existing file, 540+ lines) — ADD a test `test_main_skips_dotenv_under_launchd` that sets `VALOR_LAUNCHD=1` in env, calls `bridge.email_bridge.main` with `dotenv.load_dotenv` patched as a sentinel, and asserts the patched function is NOT called. Mirrors the `VALOR_LAUNCHD` gate in `telegram_bridge.py:42-48` and prevents regression of cycle-2 BLOCKER #1.
+- [ ] **UPDATE** `tests/unit/test_email_bridge.py::test_main_calls_load_dotenv_with_correct_paths` — defensive guard: prepend `monkeypatch.delenv("VALOR_LAUNCHD", raising=False)` so the existing test's expectation that `load_dotenv` is called continues to hold even when CI or a developer's shell has `VALOR_LAUNCHD=1` set. Without this guard, the new gate makes the existing test order-dependent on environment state. (Cycle-3 critique S-1.)
 - [ ] `tests/integration/test_email_bridge.py` — UNCHANGED. Existing bridge runtime tests are unaffected by the env-gate (they explicitly set up env vars before invoking the bridge entry points).
-- The audit report is a GitHub comment, the plist is config, `install_email_bridge.sh` is a one-shot script — none of these have test surfaces. The single new test above is the entire test impact for this plan.
+- The audit report is a GitHub comment, the plist is config, `install_email_bridge.sh` is a one-shot script — none of these have test surfaces. The two test changes above are the entire test impact for this plan.
 
 ## Rabbit Holes
 
@@ -195,6 +196,7 @@ No new CLI entry points in `pyproject.toml`. The bridge import surface is unchan
 
 ### Feature Documentation
 - [ ] Update `docs/features/email-bridge.md` with the new "Boot-time auto-start" subsection referencing `scripts/install_email_bridge.sh`.
+- [ ] In the same subsection, document the **projects.json refresh contract** for email-only machines: after editing `~/Desktop/Valor/projects.json` (the iCloud-synced source of truth), operators must re-run `scripts/install_email_bridge.sh` to refresh the local `config/projects.json` copy. The launchd-loaded bridge reads the local copy under `VALOR_LAUNCHD=1`; without a refresh, an email-only machine continues to route based on the stale local copy. (Cycle-3 critique O-1.)
 - [ ] Add row for `install_email_bridge.sh` to the Quick Commands table in `CLAUDE.md` (matches the pattern of `install_worker.sh`, `install_autoexperiment.sh`, etc.).
 
 ### External Documentation Site
@@ -266,10 +268,12 @@ No new CLI entry points in `pyproject.toml`. The bridge import surface is unchan
 - Build `scripts/install_email_bridge.sh` modelled on `install_worker.sh`. Required elements:
   - Machine-gate via `~/Desktop/Valor/projects.json` email-block check (skip+exit 0 when not applicable).
   - `_copy_config_file` block that copies `~/Desktop/Valor/projects.json` to `config/projects.json` and `~/Desktop/Valor/reflections.yaml` to `config/reflections.yaml` if present (mirror `install_worker.sh:36-48` verbatim — the bridge's launchd reads must hit local copies, not iCloud paths).
+  - **Foreground-process pre-check (Cycle-3 critique Ad-1):** before `bootout`/`bootstrap`, detect a running `valor-service.sh email-start` foreground process (e.g., `pgrep -f "bridge.email_bridge"` against PIDs not owned by launchd). If found, print a clear warning and exit non-zero — do NOT silently bootstrap a second bridge. `bootout` only unloads the launchd job; it cannot stop a foreground bridge, so blindly bootstrapping creates a double-bridge race. Operator must `Ctrl+C` the foreground bridge first.
   - `launchctl bootout`-then-`bootstrap`.
   - `dotenv_values()` env injection block (copy-adapt from `install_worker.sh:86-131`).
   - `plutil -lint` validation.
   - `set -euo pipefail`.
+  - **No watchdog (Cycle-3 critique O-2):** v1 deliberately ships without a per-job watchdog. `KeepAlive=true` already provides launchd-level restart on crash, mirroring the precedent of `install_autoexperiment.sh` and `install_nightly_tests.sh`, which also rely on `KeepAlive` alone. The `com.valor.bridge-watchdog` launchd service exists for the *Telegram* bridge specifically because it has a Telethon session-lock failure mode the email bridge does not share. Adding an email-bridge watchdog is its own future plan if observed crash-loop behavior justifies it.
 - Issues #1335, #1336, #1337 are already filed during plan revision — the build step references them directly, no creation step.
 - Add HTML-comment back-references to the 5 source plan files in `docs/plans/completed/` (one-line `<!-- Audited 2026-05-08, see #1325 audit comment for status -->` footnote).
 - Add the regression test `tests/unit/test_email_bridge.py::test_main_skips_dotenv_under_launchd` per the Test Impact section.
@@ -291,6 +295,8 @@ No new CLI entry points in `pyproject.toml`. The bridge import surface is unchan
 - Confirm the installer contains a `_copy_config_file` (or equivalent) block copying `~/Desktop/Valor/projects.json` to `config/projects.json`.
 - Confirm No-Gos section uses real issue numbers (no `#TBD` placeholders).
 - Verify the installer's machine-gate snippet matches `valor-service.sh has_bridge_role` in shape (Python heredoc reading `~/Desktop/Valor/projects.json`, exiting 0 with a "skip" message when no qualifying project exists).
+- Confirm the installer contains a foreground-process pre-check (`pgrep` or equivalent) that exits non-zero when a non-launchd email bridge is running (Cycle-3 Ad-1).
+- Run `pytest tests/unit/test_email_bridge.py::test_main_calls_load_dotenv_with_correct_paths` and confirm it still passes (defensive `monkeypatch.delenv` guard from Cycle-3 S-1).
 
 ### 3. Documentation
 - **Task ID**: document-feature
@@ -329,6 +335,8 @@ No new CLI entry points in `pyproject.toml`. The bridge import surface is unchan
 | Bridge gates load_dotenv | `grep -c 'os.environ.get("VALOR_LAUNCHD")' bridge/email_bridge.py` | output ≥ 1 |
 | Env-gate regression test passes | `pytest tests/unit/test_email_bridge.py::test_main_skips_dotenv_under_launchd -x` | exit code 0 |
 | Installer copies projects.json | `grep -c "projects.json" scripts/install_email_bridge.sh` | output ≥ 1 |
+| Installer has foreground-process pre-check | `grep -cE "pgrep\|ps -ef.*email_bridge" scripts/install_email_bridge.sh` | output ≥ 1 |
+| Existing dotenv test still green | `pytest tests/unit/test_email_bridge.py::test_main_calls_load_dotenv_with_correct_paths -x` | exit code 0 |
 | Three follow-ups exist | `gh issue view 1335 --json state -q .state && gh issue view 1336 --json state -q .state && gh issue view 1337 --json state -q .state` | three OPENs |
 | Audit comment posted | `gh issue view 1325 --comments` | output contains "Audit Report" |
 | No placeholder issue references in No-Gos | `awk '/^## No-Gos/,/^## /' docs/plans/sdlc-1325.md \| grep -cE "#TBD-[A-Z]"` | output = 0 |
@@ -336,7 +344,8 @@ No new CLI entry points in `pyproject.toml`. The bridge import surface is unchan
 ## Critique Results
 
 **Cycle 1 verdict (2026-05-08):** NEEDS REVISION (sha256:49f6e55d) — addressed in rev1/rev2.
-**Cycle 2 verdict (2026-05-08):** NEEDS REVISION — addressed in rev3 (this revision).
+**Cycle 2 verdict (2026-05-08):** NEEDS REVISION — addressed in rev3.
+**Cycle 3 verdict (2026-05-08):** READY TO BUILD (with concerns) — concerns embedded as Implementation Notes in rev4 (this revision); no blockers.
 
 ### Rev1/Rev2 changes (cycle-1 findings)
 
@@ -356,6 +365,17 @@ No new CLI entry points in `pyproject.toml`. The bridge import surface is unchan
 | C2-C4 | Concern | Test Impact "if present" hedge; once env-gate lands, a regression test is in scope. | Added `test_main_skips_dotenv_under_launchd` to Test Impact and Step 1. |
 | C2-C5 | Concern | "One week observation" trigger had no monitoring mechanism. | Removed; v1 ships opt-in alone, any auto-wire decision is its own future plan. |
 | C2-C6 | Concern | Task 1 referenced validator's 9-pattern `PUNT_PHRASES` but Task 2 referenced issue body's 5-pattern subset. | Both pinned to `validate_no_gos_justification.py::PUNT_PHRASES` as the canonical source. |
+
+### Rev4 changes (cycle-3 findings — concerns embedded as Implementation Notes)
+
+| ID | Severity | Finding | Resolution in rev4 |
+|----|----------|---------|--------------------|
+| C3-S1 | Concern | Existing `test_main_calls_load_dotenv_with_correct_paths` will break under `VALOR_LAUNCHD=1` runtime; needs defensive `monkeypatch.delenv`. | Test Impact section adds an UPDATE bullet for the existing test with the `monkeypatch.delenv("VALOR_LAUNCHD", raising=False)` guard. New verification check confirms the test still passes. |
+| C3-O1 | Concern | Stale `config/projects.json` lifecycle on email-only machines after vault edits — no doc note. | Documentation section adds a "projects.json refresh contract" bullet explaining that operators must re-run `install_email_bridge.sh` after editing the iCloud-synced vault `projects.json`. |
+| C3-O2 | Concern | No watchdog rationale documented; v1 deliberately mirrors autoexperiment/nightly-tests precedent. | Step 1 installer task adds an explicit "No watchdog" sub-bullet citing the `KeepAlive=true` precedent of `install_autoexperiment.sh` and `install_nightly_tests.sh` and noting why the Telegram-bridge watchdog (`com.valor.bridge-watchdog`) is bridge-specific. |
+| C3-Ad1 | Concern | `bootout`-then-`bootstrap` doesn't detect a foreground `valor-service.sh email-start` process; double-bridge race possible. | Step 1 installer adds a foreground-process pre-check (`pgrep -f "bridge.email_bridge"` filtered to non-launchd PIDs) that exits non-zero with a clear warning. New verification check + new validator task entry confirm the pre-check is present. |
+| C3-Ad2 | Concern | Two residual hardcoded "13 sweep-extras" counts in Solution contradict rev3 changelog claim. | Both occurrences (Solution Key Elements bullet and Technical Approach bullet) replaced with "the canonical `PUNT_PHRASES` sweep result". |
+| C3-CA1 | Concern | `tests/unit/test_email_bridge.py` is labeled NEW but exists with 540+ lines. | Test Impact bullet relabeled UPDATE (existing file, 540+ lines). |
 
 ---
 

--- a/scripts/install_email_bridge.sh
+++ b/scripts/install_email_bridge.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+# Install the email bridge as a launchd service for boot-time auto-start.
+# Usage: ./scripts/install_email_bridge.sh
+#
+# The email bridge polls IMAP for inbound mail and runs the SMTP outbox relay.
+# This installer is machine-gated: it only installs the launchd plist on
+# machines that own at least one project with an `email:` block in
+# ~/Desktop/Valor/projects.json. On machines without an email-configured
+# project, it prints a "skip" message and exits 0 cleanly.
+#
+# Pattern mirrors scripts/install_worker.sh:
+#   - bootout-then-bootstrap (idempotent re-install)
+#   - inject .env values into plist EnvironmentVariables (avoids macOS TCC
+#     hangs on the iCloud-synced ~/Desktop/Valor/.env)
+#   - copy ~/Desktop/Valor/projects.json -> config/projects.json so the
+#     launchd-loaded bridge reads the local copy under VALOR_LAUNCHD=1
+#   - plutil -lint validation before bootstrap
+#
+# After editing the iCloud-synced vault projects.json, operators must
+# re-run this installer to refresh the local config/projects.json copy.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+set -a
+# shellcheck disable=SC1091
+[ -f "$PROJECT_DIR/.env" ] && source "$PROJECT_DIR/.env"
+set +a
+: "${SERVICE_LABEL_PREFIX:=com.valor}"
+
+PLIST_SRC="$PROJECT_DIR/com.valor.email-bridge.plist"
+LABEL="${SERVICE_LABEL_PREFIX}.email-bridge"
+PLIST_DST="$HOME/Library/LaunchAgents/${LABEL}.plist"
+
+# -----------------------------------------------------------------------------
+# Machine-gate: skip on machines without an email-configured project.
+# Mirrors scripts/valor-service.sh::has_bridge_role in shape (Python heredoc
+# reading ~/Desktop/Valor/projects.json, exit 0 = qualifies, exit 1 = skip).
+# Honors PROJECTS_CONFIG_PATH env override and fails open (returns "qualifies")
+# when config is unreadable, matching has_bridge_role's safety posture.
+# -----------------------------------------------------------------------------
+has_email_role() {
+    local config="${PROJECTS_CONFIG_PATH:-$HOME/Desktop/Valor/projects.json}"
+    if [ ! -f "$config" ]; then
+        return 0
+    fi
+    if [ ! -x "$PROJECT_DIR/.venv/bin/python" ]; then
+        return 0
+    fi
+    "$PROJECT_DIR/.venv/bin/python" - "$config" <<'PYEOF'
+import json, subprocess, sys
+
+try:
+    host = subprocess.check_output(
+        ["scutil", "--get", "ComputerName"], text=True
+    ).strip()
+except Exception:
+    sys.exit(0)
+
+try:
+    with open(sys.argv[1]) as f:
+        cfg = json.load(f)
+except Exception:
+    sys.exit(0)
+
+target = host.lower()
+for proj in cfg.get("projects", {}).values():
+    if (proj.get("machine") or "").lower() != target:
+        continue
+    if proj.get("email"):
+        sys.exit(0)
+sys.exit(1)
+PYEOF
+}
+
+if ! has_email_role; then
+    host=$(scutil --get ComputerName 2>/dev/null || echo unknown)
+    echo "Skipping email-bridge install (no email-configured projects assigned to '$host' in projects.json)"
+    if [ -f "$PLIST_DST" ]; then
+        echo "Removing stale email-bridge plist from non-email machine..."
+        launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+        rm -f "$PLIST_DST"
+        echo "Stale email-bridge plist removed."
+    fi
+    exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# Foreground-process pre-check: refuse to install if a non-launchd
+# `python -m bridge.email_bridge` is currently running. `bootout` only
+# unloads the launchd job; it cannot stop a `valor-service.sh email-start`
+# nohup-spawned bridge. Bootstrapping over it would create a double-bridge
+# race (duplicate IMAP polling, kill-respawn collisions).
+# -----------------------------------------------------------------------------
+foreground_pids=""
+if pgrep -f "bridge.email_bridge" >/dev/null 2>&1; then
+    # PIDs whose parent is not launchd (PPID != 1) are foreground-spawned.
+    while IFS= read -r pid; do
+        ppid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ' || echo "")
+        if [ -n "$ppid" ] && [ "$ppid" != "1" ]; then
+            foreground_pids="${foreground_pids} ${pid}"
+        fi
+    done < <(pgrep -f "bridge.email_bridge")
+fi
+
+if [ -n "${foreground_pids// /}" ]; then
+    cat <<MSG
+ERROR: A foreground email bridge is already running (non-launchd PIDs:${foreground_pids}).
+
+Installing the launchd plist now would create a double-bridge race because
+bootout only stops the launchd-managed job — it cannot stop a foreground
+bridge spawned by 'valor-service.sh email-start' or run manually.
+
+Stop the foreground bridge first:
+    ./scripts/valor-service.sh email-stop
+or send Ctrl+C to its terminal, then re-run this installer.
+MSG
+    exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Copy iCloud vault files to config/ so the launchd bridge can read them
+# without TCC hangs. Mirror install_worker.sh:36-48 verbatim.
+# -----------------------------------------------------------------------------
+mkdir -p "$PROJECT_DIR/logs"
+
+_copy_config_file() {
+    local src="$1" dst="$2" label="$3"
+    if [ -f "$src" ]; then
+        rm -f "$dst"
+        cp "$src" "$dst"
+        echo "Copied $label → config/$(basename "$dst")"
+    else
+        echo "WARNING: $src not found — launchd email bridge will use existing config/$(basename "$dst")"
+    fi
+}
+
+_copy_config_file "$HOME/Desktop/Valor/projects.json"     "$PROJECT_DIR/config/projects.json"     "projects.json"
+_copy_config_file "$HOME/Desktop/Valor/reflections.yaml"  "$PROJECT_DIR/config/reflections.yaml"  "reflections.yaml"
+
+# -----------------------------------------------------------------------------
+# Pre-flight checks
+# -----------------------------------------------------------------------------
+if [ ! -f "$PLIST_SRC" ]; then
+    echo "ERROR: Plist template not found at $PLIST_SRC"
+    exit 1
+fi
+
+if [ ! -f "$PROJECT_DIR/.env" ]; then
+    echo "ERROR: .env file not found. Copy .env.example and configure it."
+    exit 1
+fi
+
+if [ ! -f "$PROJECT_DIR/.venv/bin/python" ]; then
+    echo "ERROR: Virtual environment not found at $PROJECT_DIR/.venv"
+    echo "Run: python3 -m venv $PROJECT_DIR/.venv && $PROJECT_DIR/.venv/bin/pip install -e $PROJECT_DIR"
+    exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Render plist template into ~/Library/LaunchAgents/
+# -----------------------------------------------------------------------------
+if launchctl list | grep -q "$LABEL" 2>/dev/null; then
+    echo "Unloading existing $LABEL..."
+    launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+fi
+
+echo "Installing plist to $PLIST_DST..."
+sed "s|__PROJECT_DIR__|$PROJECT_DIR|g; s|__HOME_DIR__|$HOME|g; s|__SERVICE_LABEL__|$LABEL|g" "$PLIST_SRC" > "$PLIST_DST"
+
+# -----------------------------------------------------------------------------
+# Inject .env values into plist EnvironmentVariables.
+# macOS TCC blocks launchd agents from reading ~/Desktop files, so reading
+# from the terminal here (which has full access) and baking values into the
+# plist avoids a hang on bridge startup.
+# -----------------------------------------------------------------------------
+echo "Injecting env vars from .env into plist..."
+export PROJECT_DIR PLIST_DST
+"$PROJECT_DIR/.venv/bin/python" - <<'PYEOF'
+import os, sys, plistlib
+from pathlib import Path
+from dotenv import dotenv_values
+
+project_dir = Path(os.environ.get("PROJECT_DIR", "."))
+plist_dst = Path(os.environ.get("PLIST_DST", ""))
+env_file = project_dir / ".env"
+
+if not plist_dst:
+    print("PLIST_DST not set, skipping env injection", file=sys.stderr)
+    sys.exit(0)
+
+try:
+    env_vars = dotenv_values(env_file)
+except Exception as e:
+    print(f"Warning: could not parse .env: {e}", file=sys.stderr)
+    sys.exit(0)
+
+with open(plist_dst, "rb") as f:
+    plist = plistlib.load(f)
+
+existing = plist.setdefault("EnvironmentVariables", {})
+injected = 0
+for key, value in env_vars.items():
+    if key not in existing and value is not None:
+        existing[key] = value
+        injected += 1
+
+with open(plist_dst, "wb") as f:
+    plistlib.dump(plist, f)
+
+print(f"  Injected {injected} env vars into plist")
+PYEOF
+
+# -----------------------------------------------------------------------------
+# Validate and bootstrap.
+# No watchdog: KeepAlive=true gives launchd-level restart on crash, mirroring
+# install_autoexperiment.sh and install_nightly_tests.sh which also rely on
+# KeepAlive alone. The com.valor.bridge-watchdog launchd service is specific
+# to the Telegram bridge's Telethon session-lock failure mode and does not
+# apply to the email bridge.
+# -----------------------------------------------------------------------------
+if ! plutil -lint "$PLIST_DST" > /dev/null; then
+    echo "ERROR: Generated plist is invalid"
+    exit 1
+fi
+
+echo "Loading $LABEL..."
+launchctl bootstrap "gui/$(id -u)" "$PLIST_DST"
+
+echo ""
+echo "Email bridge service installed successfully."
+echo "  Logs: $PROJECT_DIR/logs/email_bridge.log"
+echo "  Errors: $PROJECT_DIR/logs/email_bridge.error.log"
+echo ""
+echo "To check status: launchctl list | grep email-bridge"
+echo "To stop: launchctl bootout gui/$(id -u)/$LABEL"
+echo "To run manually: ./scripts/valor-service.sh email-start"

--- a/tests/unit/test_email_bridge.py
+++ b/tests/unit/test_email_bridge.py
@@ -518,8 +518,17 @@ class TestPollImapBatchCap:
 class TestMainEnvLoading:
     """main() loads .env files via load_dotenv before starting the async loop."""
 
-    def test_main_calls_load_dotenv_with_correct_paths(self):
-        """main() calls load_dotenv twice: repo .env and vault .env."""
+    def test_main_calls_load_dotenv_with_correct_paths(self, monkeypatch):
+        """main() calls load_dotenv twice: repo .env and vault .env.
+
+        Defensive guard (Cycle-3 critique S-1): explicitly clear VALOR_LAUNCHD
+        so this test continues to assert the dotenv-call expectation even when
+        CI or a developer's shell has VALOR_LAUNCHD=1 set. Without this guard,
+        the new gate added for #1325 makes the existing test order-dependent
+        on environment state.
+        """
+        monkeypatch.delenv("VALOR_LAUNCHD", raising=False)
+
         with patch("dotenv.load_dotenv") as mock_load:
             with patch("bridge.email_bridge.asyncio.run"):
                 from bridge.email_bridge import main
@@ -537,6 +546,28 @@ class TestMainEnvLoading:
         second_path = mock_load.call_args_list[1][0][0]
         assert "Desktop" in str(second_path) and "Valor" in str(second_path)
         assert str(second_path).endswith(".env")
+
+    def test_main_skips_dotenv_under_launchd(self, monkeypatch):
+        """Under VALOR_LAUNCHD=1, main() must NOT call load_dotenv.
+
+        Regression guard for the macOS TCC failure mode: launchd agents are
+        blocked from reading ~/Desktop files, so unconditional dotenv reads
+        would hang the bridge process at startup. Mirrors the same gate in
+        bridge/telegram_bridge.py:42-48. See #1325 audit and #1338 installer.
+        """
+        monkeypatch.setenv("VALOR_LAUNCHD", "1")
+
+        with patch("dotenv.load_dotenv") as mock_load:
+            with patch("bridge.email_bridge.asyncio.run"):
+                from bridge.email_bridge import main
+
+                main()
+
+        assert mock_load.call_count == 0, (
+            "load_dotenv must not run when VALOR_LAUNCHD is set; launchd "
+            "injects env vars directly into the plist, so dotenv reads of the "
+            "iCloud-synced ~/Desktop/Valor/.env would block on macOS TCC."
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1325

Implements `docs/plans/sdlc-1325.md`. The 6 named punts in the parent audit triage to:
- `email-bridge.md:348` (launchd plist) - **completed in this PR** (was the only still-pending punt)
- `message-drafter.md:827-829` - already done in PR #1118 (back-referenced)
- `kill-is-terminal.md:207` - filed as #1335
- `pm-workflow-announcement.md:334` - filed as #1336
- `pm-workflow-announcement.md:361` - filed as #1337

## Changes

- `com.valor.email-bridge.plist` — launchd template at repo root (mirrors `com.valor.worker.plist`). `KeepAlive=true`, `RunAtLoad=true`, `VALOR_LAUNCHD=1` in EnvironmentVariables.
- `scripts/install_email_bridge.sh` — machine-gated installer (mirrors `install_worker.sh`):
  - Self-gates via `~/Desktop/Valor/projects.json` email-block check (mirrors `valor-service.sh::has_bridge_role` shape).
  - Foreground-process pre-check: refuses to bootstrap if `pgrep -f bridge.email_bridge` finds a non-launchd PID (avoids double-bridge race against `valor-service.sh email-start` nohup).
  - `_copy_config_file` block copies `~/Desktop/Valor/projects.json` and `reflections.yaml` to `config/` (mirrors `install_worker.sh:36-48`).
  - `dotenv_values()` env injection (mirrors `install_worker.sh:86-131`).
  - `launchctl bootout`-then-`bootstrap` idempotency.
  - `plutil -lint` validation.
  - No watchdog: `KeepAlive=true` mirrors `install_autoexperiment.sh` and `install_nightly_tests.sh` precedent.
- `bridge/email_bridge.py:1011-1012` — `VALOR_LAUNCHD` env-gate around `load_dotenv` calls (mirrors `bridge/telegram_bridge.py:42-48`). Without this, the launchd-spawned bridge hangs on macOS TCC at `open(~/Desktop/Valor/.env)`.
- `tests/unit/test_email_bridge.py` —
  - New `test_main_skips_dotenv_under_launchd` regression-guards the gate.
  - Existing `test_main_calls_load_dotenv_with_correct_paths` adds defensive `monkeypatch.delenv("VALOR_LAUNCHD")` (Cycle-3 critique S-1).
- 4 HTML-comment back-references appended to source plan files: `email-bridge.md`, `message-drafter.md`, `kill-is-terminal.md`, `pm-workflow-announcement.md`. (5th back-reference would be redundant — `pm-workflow-announcement.md` covers two punts in one footnote.)
- `docs/features/email-bridge.md` — new "Boot-time auto-start" subsection with `projects.json` refresh contract.
- `CLAUDE.md` — `install_email_bridge.sh` row added to Quick Commands table.

## Verification

- `python -m pytest tests/unit/test_email_bridge.py::TestMainEnvLoading -x -v` → 2 passed.
- `bash -n scripts/install_email_bridge.sh` → 0 (syntax clean).
- `plutil -lint com.valor.email-bridge.plist` → OK.
- `python -m ruff format bridge/email_bridge.py tests/unit/test_email_bridge.py` → no changes.

## Out of scope (filed as separate issues)

- #1335 — `waiting_for_children` index-staleness investigation (`bug,investigation`)
- #1336 — overlay-drift audit (`chore`)
- #1337 — `/update` multi-machine overlay automation step (`chore,skills`)