### PR TITLE
Multi-judge consensus follow-ups (closes #1345)

### DIFF
--- a/.claude/skills-global/do-pr-review/SKILL.md
+++ b/.claude/skills-global/do-pr-review/SKILL.md
@@ -528,6 +528,29 @@ After posting the review and verifying it was posted (Steps 6-6.5), emit a typed
 
 **Important**: The outcome block uses HTML comment syntax (`<!-- ... -->`) so it's invisible in rendered markdown but parseable by the pipeline. Always emit it as the very last line of output. Use `"partial"` — not `"success"` — whenever tech_debt or non-subjective nit findings exist. This ensures the pipeline routes to `/do-patch` before advancing to `/do-docs`. For `BLOCKED_ON_CONFLICT` and `PR_CLOSED`, `next_skill` is `null` — the pipeline should NOT auto-advance; the author must rebase or the PM must handle the closed-PR case manually.
 
+**Multi-judge OUTCOME variants:** when the multi-judge path runs (≥2 judges
+dispatched), include `judges_run` and `consensus_disagreement` inside
+`artifacts`. These mirror the side-fields recorded by `compute_consensus` and
+let operators grep session state for disagreement events without round-tripping
+through Redis. Single-judge / docs-only / lockfile-only / preflight short-circuit
+paths MUST NOT include these fields (they would mislead consumers into thinking
+multi-judge ran).
+
+**Multi-judge success (APPROVED via 2-of-2 consensus, all judges aligned):**
+```
+<!-- OUTCOME {"status":"success","stage":"REVIEW","verdict":"APPROVED","artifacts":{"review_url":"{review_url}","blockers":0,"tech_debt":0,"nits":0,"judges_run":2,"consensus_disagreement":false},"notes":"Approved via 2-of-2 consensus (code-quality, risk).","next_skill":"/do-docs"} -->
+```
+
+**Multi-judge fail (CHANGES_REQUESTED — judges disagreed, any-blocker-wins triggered):**
+```
+<!-- OUTCOME {"status":"fail","stage":"REVIEW","verdict":"CHANGES_REQUESTED","artifacts":{"review_url":"{review_url}","blockers":1,"tech_debt":0,"nits":0,"judges_run":2,"consensus_disagreement":true},"notes":"Changes requested via 2-of-2 consensus: risk judge raised 1 blocker, code-quality approved.","failure_reason":"1 blocker must be fixed before merge","next_skill":"/do-patch"} -->
+```
+
+**Multi-judge partial (CHANGES_REQUESTED — judges aligned on tech_debt/nits, no blockers):**
+```
+<!-- OUTCOME {"status":"partial","stage":"REVIEW","verdict":"CHANGES_REQUESTED","artifacts":{"review_url":"{review_url}","blockers":0,"tech_debt":2,"nits":1,"judges_run":2,"consensus_disagreement":false},"notes":"Changes requested via 2-of-2 consensus: 2 tech_debt and 1 nit findings. Routing to /do-patch.","next_skill":"/do-patch"} -->
+```
+
 ### Multi-judge consensus (optional, opt-in)
 
 When `SDLC_REVIEW_JUDGES` enables ≥2 judges, this skill orchestrates parallel
@@ -565,10 +588,26 @@ See `docs/features/multi-judge-consensus.md` and
    per-judge comment is confirmed posted. This is the comment
    `do-merge.md`'s regex picks up.
 
-**Cost containment:** docs-only / lockfile-only PRs reuse the existing
-`do-merge.md` shape classifier and force the legacy single-judge path.
-`SDLC_REVIEW_JUDGES=none` and `SDLC_REVIEW_K=1` are independent operator
-kill switches.
+**Cost containment:** before spawning judge forks, classify the PR's diff via
+the same module `/do-merge` uses:
+
+```bash
+SHAPE_JSON=$(python -m scripts.pr_shape_classify --pr "$PR_NUMBER" 2>/dev/null \
+  || echo '{"shape":"feature"}')
+SHAPE=$(echo "$SHAPE_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin).get('shape','feature'))")
+case "$SHAPE" in
+  docs-only|lockfile-only)
+    # Force legacy single-judge path — skip multi-judge orchestration.
+    SDLC_REVIEW_JUDGES=none
+    ;;
+esac
+```
+
+`scripts/pr_shape_classify.py` is the single source of truth — both
+`/do-merge` (`.claude/commands/do-merge.md`) and this skill invoke it via
+`python -m scripts.pr_shape_classify`. Do NOT inline shape logic or fork a
+parallel classifier. `SDLC_REVIEW_JUDGES=none` and `SDLC_REVIEW_K=1` remain
+independent operator kill switches.
 
 **Monitoring:** when multi-judge runs, the OUTCOME block records
 `judges_run` (count) and `consensus_disagreement` (bool, true when any pair

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -85,6 +85,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [Message Pipeline](message-pipeline.md) | Deferred enrichment pipeline for fast message acknowledgment and zero-loss restarts | Shipped |
 | [Message Reconciler](message-reconciler.md) | Periodic background scan detecting and recovering Telegram messages missed during live bridge connections | Shipped |
 | [Mid-Session Steering](mid-session-steering.md) | End-to-end steering flow for injecting reply-to messages into running agent sessions | Shipped |
+| [Multi-Judge Consensus at Review](multi-judge-consensus.md) | Optional opt-in K-of-N parallel review judges (`code-quality`, `risk`) with `compute_consensus("any-blocker-wins")` aggregation; per-judge comments + single aggregate `## Review:` post; OUTCOME side-fields `judges_run` / `consensus_disagreement`; docs-only / lockfile-only PRs reuse `python -m scripts.pr_shape_classify` to force the legacy single-judge path for cost containment | Shipped |
 | [Nightly Regression Tests](nightly-regression-tests.md) | Scheduled nightly unit test run with Telegram delta alerting — only notifies on new failures, silent on clean runs | Shipped |
 | [OfficeCLI Integration](officecli-integration.md) | OfficeCLI binary install/update via update system, CLAUDE.md documentation, and agent skill file for .docx/.xlsx/.pptx manipulation | Shipped |
 | [OOP Audit](do-oop-audit.md) | Prompt-only audit skill scanning Python classes for 14 structural anti-patterns with framework detection and severity grouping | Shipped |

--- a/docs/sdlc/do-pr-review.md
+++ b/docs/sdlc/do-pr-review.md
@@ -32,6 +32,29 @@ If the PR adds new environment variables, verify they are in `.env.example` and 
 
 If the PR modifies `bridge/`, `agent/`, or `worker/`, flag for restart-after-deploy. The reviewer should note whether the change requires a service restart on all machines.
 
+## Multi-Judge Consensus
+
+This repo opts in to multi-judge consensus at the REVIEW stage by default
+(`SDLC_REVIEW_JUDGES=code-quality,risk`, `SDLC_REVIEW_K=2`). Reviewers should
+expect:
+
+- Two per-judge comments (`## Review (Judge code-quality):`, `## Review (Judge risk):`)
+  posted **before** the aggregate `## Review:` comment that `/do-merge` reads.
+- The aggregate verdict is derived by `agent.sdlc_review_consensus.compute_consensus`
+  with `rule="any-blocker-wins"` — any judge raising a blocker forces
+  `CHANGES_REQUESTED`.
+- The OUTCOME block includes `judges_run` (int) and `consensus_disagreement` (bool)
+  side-fields when multi-judge runs.
+- Cost containment: `docs-only` / `lockfile-only` PRs (classified by
+  `python -m scripts.pr_shape_classify --pr $PR_NUMBER`, the same module
+  `/do-merge` invokes) force the legacy single-judge path. Operators can also
+  set `SDLC_REVIEW_JUDGES=none` or `SDLC_REVIEW_K=1` as independent kill
+  switches.
+
+Full design: [`docs/features/multi-judge-consensus.md`](../features/multi-judge-consensus.md).
+The shape classifier is shared with `/do-merge` — see
+[`docs/features/pr-shape-aware-merge-gates.md`](../features/pr-shape-aware-merge-gates.md).
+
 ## UI Screenshots
 
 For any PR that touches `ui/`, include before/after screenshots of the actual running app (not mockups). Capture via BYOB MCP (`mcp__byob__browser_*`) — the only browser surface — so the screenshot reflects the user's real, logged-in Chrome session. See `.claude/skills/do-pr-review/SKILL.md` and `sub-skills/screenshot.md`.


### PR DESCRIPTION
Closes #1345

Follow-up to PR #1343 (closed #1309).

## Changes

- `docs/features/README.md` — index entry for Multi-Judge Consensus at Review (alphabetically sorted; sort-check validator passes)
- `docs/sdlc/do-pr-review.md` — multi-judge convention section pointing to the feature doc and explaining the shape-classifier cost-containment behavior
- `.claude/skills-global/do-pr-review/SKILL.md`:
  - Concretized the cost-containment paragraph: it now shows the actual `python -m scripts.pr_shape_classify --pr $PR_NUMBER` invocation (same module `/do-merge` uses) instead of handwaving 'reuse do-merge.md classifier'
  - Added three OUTCOME-block variants for the multi-judge path: success (aligned), fail (with disagreement), partial (aligned tech_debt/nits) — each showing the `judges_run` and `consensus_disagreement` artifacts side-fields

## Shape classifier path: REUSE (not extracted to tools/)

The plan asked: *if classifier ≥30 lines, extract to `tools/pr_shape.py` so both `do-merge.md` and `do-pr-review.md` call the same tool.*

The classifier was **already extracted** in PR #1343 to `scripts/pr_shape_classify.py` (524 lines, with a JSON CLI: `python -m scripts.pr_shape_classify`). `do-merge.md` already invokes it. Per *no legacy code tolerance*, the right move is to keep one source of truth and have `do-pr-review`'s multi-judge dispatch call the same module — which this PR makes explicit. Duplicating it under `tools/pr_shape.py` would create exactly the kind of half-migration that policy forbids.

## Verification

- `python .claude/hooks/validators/validate_features_readme_sort.py --check` → exit 0
- `docs/sdlc/do-pr-review.md` is 62 lines (cap is 300)
- No Python touched, so no `ruff format` / unit tests needed