### PR TITLE
Media docs + integration tests for size-aware timeout (closes #1344)

### DIFF
--- a/docs/features/image-vision.md
+++ b/docs/features/image-vision.md
@@ -63,7 +63,7 @@ Agent receives enriched text and can discuss the image directly.
 
 | Case | Behavior |
 |------|----------|
-| Bridge download timeout (10s) | `media_download_error="timeout after 10s"`; worker logs WARNING and proceeds with bare caption. |
+| Bridge download timeout (size-aware) | Per-attempt timeout = `max(10s, min(120s, 5s + size_bytes/MB))` with one 2x-leash retry (see [media-enrichment.md](media-enrichment.md#bridge-intake-telemetry)). On terminal failure: `media_download_error="timeout after Xs (retried)"`; worker logs WARNING and proceeds with bare caption. |
 | Bridge download exception | `media_download_error=<exc>`; same as above. |
 | Worker can't read the file | Logs `[enrichment] media file at {path} not readable` and proceeds with bare caption. |
 | Vision model error | Logged in worker; falls back to `[User sent an image - saved to {filename}]`. |

--- a/docs/features/media-enrichment.md
+++ b/docs/features/media-enrichment.md
@@ -1,7 +1,7 @@
 # Media Enrichment
 
 **Status**: Implemented
-**Last revised**: 2026-05-07 (sdlc-1297)
+**Last revised**: 2026-05-09 (sdlc-1344, follows sdlc-1322 / sdlc-1297)
 **Related**: [image-vision.md](image-vision.md), [bridge-worker-architecture.md](bridge-worker-architecture.md)
 
 ## Why this doc exists
@@ -18,11 +18,16 @@ Telegram
    v
 bridge.telegram_bridge.handler():
    1. Persist TelegramMessage(has_media=True, media_type=...)
-   2. await asyncio.wait_for(download_media(client, msg), timeout=10s)
+   2. await _download_media_with_retry(client, msg, prefix=media_type)
+        - Per-attempt timeout = compute_media_timeout(message.file.size)
+          (5s + size_bytes/MB, floored at 10s, capped at 120s)
+        - On TimeoutError: retry once with 2x leash (still capped at 120s)
         - On success: TelegramMessage.media_local_path = abs_path
-        - On timeout/error: TelegramMessage.media_download_error = "..."
+        - On terminal timeout: media_download_error = "timeout after Xs (retried)"
+        - On other error: media_download_error = "<ExceptionType>: <msg>"
    3. dispatch_telegram_session(...)  -> AgentSession enqueued in Redis
    4. Log: [bridge] intake_duration_ms=<ms> has_media=<bool> ...
+        Plus per-attempt: [media] download attempt=N outcome=... size_bytes=... computed_timeout_s=...
    |
    v  (Redis queue)
    |
@@ -46,7 +51,7 @@ The bridge and worker share the filesystem — `media_local_path` is an absolute
 | `has_media` | bool | Set true at intake when `message.media` is non-null. Pre-existing. |
 | `media_type` | str \| None | `"photo" \| "voice" \| "audio" \| "document"` etc. Pre-existing. |
 | `media_local_path` | str \| None | **(sdlc-1297)** Absolute filesystem path the bridge wrote at intake, or `None` if the download failed. |
-| `media_download_error` | str \| None | **(sdlc-1297)** Reason the bridge-side download failed (e.g. `"timeout after 10s"`). Inspected by the worker. |
+| `media_download_error` | str \| None | **(sdlc-1297, refined sdlc-1322)** Reason the bridge-side download failed. Distinct strings: `"timeout after Xs (retried)"` (both attempts timed out, where X is the second-attempt budget); `"<ExceptionType>: <msg>"` for non-timeout failures (no retry). Inspected by the worker. |
 
 All three new fields are nullable additive Popoto fields; existing records read `None` and the worker treats that as a normal "no path → skip AI" branch.
 
@@ -77,7 +82,9 @@ The handler emits
 
 at the end of every successful message intake (after enqueue). This is the observation point for the success criterion *p95 intake under 2s for media-bearing messages*.
 
-`download_media` is wrapped in `asyncio.wait_for(..., timeout=10.0)`. On `TimeoutError`, the bridge persists `media_download_error="timeout after 10s"` and proceeds to enqueue. The worker reads that on its side and falls through to the bare caption.
+`download_media` is invoked through `_download_media_with_retry` (in `bridge/telegram_bridge.py`), which uses a size-aware per-attempt timeout from `compute_media_timeout()` at `bridge/media.py:258`. The formula is `max(10.0, min(120.0, 5.0 + size_bytes/MB))` — so a 1MB photo gets the 10s baseline, a 10MB voice note gets ~15s, a 100MB document gets ~105s, and anything ≥ ~115MB is capped at 120s. `message.file.size` being absent (some thumbnails) falls back to the 10s baseline.
+
+On `TimeoutError`, the helper retries **once** with a 2x leash (still capped at 120s). If the retry also times out, the bridge persists `media_download_error="timeout after Xs (retried)"` (X = the second-attempt budget) and proceeds to enqueue. The `(retried)` suffix lets downstream logs distinguish "we tried twice and the file is just too big" from a first-attempt-unlucky failure. Non-timeout exceptions are not retried — the error string is stored as `"<ExceptionType>: <msg>"`. The worker reads `media_download_error` on its side and falls through to the bare caption with summary `media=skipped:download_failed`.
 
 ## Reply-chain note
 
@@ -85,8 +92,8 @@ The reply-chain branch in `bridge/enrichment.py` still requires a Telethon clien
 
 ## Implementation files
 
-- `bridge/telegram_bridge.py` — handler, intake timing, bridge-side download, persistence.
-- `bridge/media.py` — `download_media`, `process_incoming_media`, `process_downloaded_media`, `describe_image`, `transcribe_voice`, `extract_document_text`.
+- `bridge/telegram_bridge.py` — handler, intake timing, bridge-side download, persistence. Hosts `_download_media_with_retry` (size-aware timeout + 1-retry wrapper around `download_media`).
+- `bridge/media.py` — `download_media`, `compute_media_timeout` (size-aware timeout helper, line 258), `process_incoming_media`, `process_downloaded_media`, `describe_image`, `transcribe_voice`, `extract_document_text`.
 - `bridge/enrichment.py` — worker-side `enrich_message`.
 - `models/telegram.py` — `TelegramMessage` field definitions.
 - `agent/session_executor.py` — call site that passes the loaded `TelegramMessage` to `enrich_message`.
@@ -94,5 +101,6 @@ The reply-chain branch in `bridge/enrichment.py` still requires a Telethon clien
 ## Tests
 
 - `tests/unit/test_enrichment_media.py` — happy path + four failure-mode branches.
-- `tests/integration/test_media_enrichment_pipeline.py` — TelegramMessage round-trip through `enrich_message` (process_downloaded_media mocked).
+- `tests/unit/test_telegram_bridge_media_timeout.py` — `compute_media_timeout` table tests + `_download_media_with_retry` retry/success/no-retry paths (sdlc-1322).
+- `tests/integration/test_media_enrichment_pipeline.py` — TelegramMessage round-trip through `enrich_message` (process_downloaded_media mocked); also covers the size-aware retry path: `test_bridge_retries_slow_download_once` (first-attempt timeout, second succeeds) and `test_bridge_gives_up_after_retry` (both attempts time out, persisted error carries `(retried)` suffix).
 - `tests/unit/test_youtube_transcription.py` — verifies the YouTube branch is unaffected by the signature change.

--- a/tests/integration/test_media_enrichment_pipeline.py
+++ b/tests/integration/test_media_enrichment_pipeline.py
@@ -1,4 +1,4 @@
-"""Integration test for sdlc-1297: full media enrichment path.
+"""Integration test for sdlc-1297 + sdlc-1322 follow-up (sdlc-1344).
 
 Stitches a TelegramMessage record (representing a bridge-side download) through
 ``enrich_message`` (worker-side AI) without standing up a real Telegram client.
@@ -6,14 +6,22 @@ Verifies that the agent receives ``[User sent an image]\\nImage description: ...
 when the bridge has populated ``media_local_path``, and that the failure path
 (``media_download_error`` set, ``media_local_path=None``) gracefully returns the
 bare caption with the expected log lines.
+
+The size-aware retry tests (``test_bridge_retries_slow_download_once``,
+``test_bridge_gives_up_after_retry``) exercise the bridge's
+``_download_media_with_retry`` wrapper end-to-end through a TelegramMessage
+record so we know the persisted ``media_local_path`` / ``media_download_error``
+contract matches what the worker reads in ``enrich_message``.
 """
 
 from __future__ import annotations
 
+import asyncio
 import shutil
 import uuid
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -113,5 +121,121 @@ async def test_media_enrichment_failure_path(caplog):
         assert enriched == "caption only"
         assert any("media download failed at intake" in r.message for r in caplog.records)
         assert any("media=skipped:download_failed" in r.message for r in caplog.records)
+    finally:
+        tm.delete()
+
+
+# =============================================================================
+# Size-aware retry path (sdlc-1322 follow-up, issue #1344)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_bridge_retries_slow_download_once(media_fixture: Path):
+    """First download attempt times out; the bridge retries once with a 2x leash
+    and the second attempt succeeds.
+
+    Asserts the persistence-shape the worker reads:
+    - ``media_local_path`` is set to the resolved absolute path.
+    - ``media_download_error`` is None (transient failure swallowed by retry).
+    """
+    from bridge import telegram_bridge
+
+    fake_message = MagicMock()
+    fake_message.file = SimpleNamespace(size=10 * 1024 * 1024)  # 10MB -> 15s/30s
+    fake_message.id = 4242
+    fake_client = MagicMock()
+
+    call_count = {"n": 0}
+
+    async def flaky_wait_for(*_args, **_kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise TimeoutError()
+        return media_fixture
+
+    with patch.object(asyncio, "wait_for", new=AsyncMock(side_effect=flaky_wait_for)):
+        local_path, error = await telegram_bridge._download_media_with_retry(
+            fake_client,
+            fake_message,
+            prefix="photo",
+        )
+
+    assert local_path == media_fixture, "second attempt should return the downloaded path"
+    assert error is None, "transient timeout cleared by successful retry"
+    assert call_count["n"] == 2, "retry helper must invoke wait_for twice"
+
+    # End-to-end persistence shape: this is what the bridge writes to the record
+    # and what the worker subsequently reads.
+    from models.telegram import TelegramMessage
+
+    tm = TelegramMessage.create(
+        chat_id="test-1344-retry-ok",
+        message_id=4242,
+        direction="in",
+        sender="tester",
+        content="late but here",
+        timestamp=0.0,
+        message_type="photo",
+        project_key="test-media-1344",
+        has_media=True,
+        media_type="photo",
+        media_local_path=str(local_path.resolve()) if local_path else None,
+        media_download_error=error,
+    )
+    try:
+        assert tm.media_local_path == str(media_fixture.resolve())
+        assert tm.media_download_error is None
+    finally:
+        tm.delete()
+
+
+@pytest.mark.asyncio
+async def test_bridge_gives_up_after_retry():
+    """Both download attempts time out; the bridge persists
+    ``media_download_error="timeout after Xs (retried)"`` so the worker can
+    distinguish a terminal too-big-for-our-budget failure from a first-attempt
+    fluke."""
+    from bridge import telegram_bridge
+
+    fake_message = MagicMock()
+    # 30MB -> first timeout = 35s, second = 70s (still under 120s cap)
+    fake_message.file = SimpleNamespace(size=30 * 1024 * 1024)
+    fake_message.id = 9001
+    fake_client = MagicMock()
+
+    with patch.object(asyncio, "wait_for", new=AsyncMock(side_effect=TimeoutError())):
+        local_path, error = await telegram_bridge._download_media_with_retry(
+            fake_client,
+            fake_message,
+            prefix="document",
+        )
+
+    assert local_path is None
+    assert error is not None
+    assert "(retried)" in error, f"terminal failure must carry the (retried) suffix: {error!r}"
+    assert error.startswith("timeout after "), f"unexpected error shape: {error!r}"
+
+    # End-to-end persistence shape — the worker keys off this exact string.
+    from models.telegram import TelegramMessage
+
+    tm = TelegramMessage.create(
+        chat_id="test-1344-retry-fail",
+        message_id=9001,
+        direction="in",
+        sender="tester",
+        content="too big",
+        timestamp=0.0,
+        message_type="document",
+        project_key="test-media-1344",
+        has_media=True,
+        media_type="document",
+        media_local_path=None,
+        media_download_error=error,
+    )
+    try:
+        assert tm.media_local_path is None
+        assert tm.media_download_error == error
+        assert "(retried)" in tm.media_download_error
     finally:
         tm.delete()


### PR DESCRIPTION
Closes #1344

Follow-up to PR #1326 (closed #1322).

## Changes
- `docs/features/media-enrichment.md` — updated lines 21, 49, 80 to reflect the size-aware formula + retry semantics. Now references `compute_media_timeout()` at `bridge/media.py:258` and the `_download_media_with_retry` wrapper. Added the distinct error string `"timeout after Xs (retried)"` for terminal failure.
- `docs/features/image-vision.md:66` — updated stale 10s reference to point at the new size-aware formula + retry.
- New integration tests in `tests/integration/test_media_enrichment_pipeline.py`:
  - `test_bridge_retries_slow_download_once` — first attempt times out, second succeeds; verifies persistence shape (`media_local_path` set, `media_download_error` None).
  - `test_bridge_gives_up_after_retry` — both attempts time out; verifies `media_download_error == "timeout after Xs (retried)"`.

## Verification
```
$ python -m pytest tests/integration/test_media_enrichment_pipeline.py -x -v
4 passed, 1 warning in 2.93s
```