### PR TITLE
fix(worker): call validate_agent_files() at startup

### DIFF
--- a/docs/features/agent-definition-fallback.md
+++ b/docs/features/agent-definition-fallback.md
@@ -12,7 +12,9 @@ This happens during deployment windows when code is updated but agent files have
 
 - **Missing file detection**: `_parse_agent_markdown()` checks `path.exists()` before reading. If the file is missing, it logs a warning and returns a fallback dict with a minimal prompt instead of raising.
 - **Session continues**: `get_agent_definitions()` returns a complete dict even when some or all agent files are missing. The agent operates with degraded prompts rather than crashing.
-- **Bridge startup validation**: `validate_agent_files()` is called during bridge initialization to surface missing files early via log warnings, giving operators a chance to fix the issue before users hit it.
+- **Startup validation**: `validate_agent_files()` is called during process initialization to surface missing files early via log warnings, giving operators a chance to fix the issue before users hit it. The check fires from two call sites:
+  - `bridge/telegram_bridge.py::main()` — covers Telegram bridge processes.
+  - `worker/__main__.py::main()` — covers the standalone worker, which is the actual session execution engine. A worker-only deployment (or one where the worker boots before the bridge) still gets the early-warning signal.
 
 ## Fallback Prompt
 
@@ -28,7 +30,9 @@ The agent's description is set to `"Fallback for missing {name}.md"`.
 |------|------|
 | `agent/agent_definitions.py` | Fallback logic in `_parse_agent_markdown()`, `validate_agent_files()` |
 | `bridge/telegram_bridge.py` | Calls `validate_agent_files()` at startup |
+| `worker/__main__.py` | Calls `validate_agent_files()` at startup (mirrors bridge — worker is the session execution engine) |
 | `tests/unit/test_agent_definitions.py` | Unit tests covering normal load, missing files, and validation |
+| `tests/unit/test_worker_startup_validation.py` | Static-import test asserting the worker module wires `validate_agent_files` into `main()` |
 
 ## Prior Art
 

--- a/tests/unit/test_worker_startup_validation.py
+++ b/tests/unit/test_worker_startup_validation.py
@@ -1,0 +1,71 @@
+"""Tests asserting the worker startup wires `validate_agent_files()`.
+
+Background: `validate_agent_files()` was originally only called from the
+Telegram bridge's `main()`. The worker is the actual session execution
+engine (per CLAUDE.md: "sole session execution engine"), so worker-only
+deployments — or boots where the worker comes up before the bridge —
+silently lost the early-warning hook for missing agent definition files.
+
+These tests guard against regressing back to the bridge-only call site.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from unittest.mock import patch
+
+import worker.__main__ as worker_main
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class TestWorkerCallsValidateAgentFiles:
+    """Static + behavioural assertions that worker main() invokes the validator."""
+
+    def test_worker_main_source_imports_validate_agent_files(self):
+        """The worker's main() function must reference validate_agent_files.
+
+        A static-grep test rather than a full process spawn — sufficient to
+        prevent the bridge/worker asymmetry from re-emerging.
+        """
+        source = inspect.getsource(worker_main.main)
+        assert "validate_agent_files" in source, (
+            "worker.__main__.main() must call validate_agent_files() — "
+            "the worker is the session execution engine and must surface "
+            "missing agent files at startup, not just the bridge."
+        )
+
+    def test_worker_main_file_contains_validate_agent_files(self):
+        """Defence-in-depth: also assert the call exists in the on-disk module."""
+        worker_main_path = REPO_ROOT / "worker" / "__main__.py"
+        text = worker_main_path.read_text(encoding="utf-8")
+        assert "validate_agent_files" in text, (
+            "worker/__main__.py must import and call validate_agent_files()."
+        )
+
+    def test_worker_main_invokes_validator_at_startup(self):
+        """Behavioural test: running main() up to the run-loop hits the validator.
+
+        We patch `_load_projects` to return an empty list so main() exits
+        early before launching any real worker work. The validator is
+        called *before* `_load_projects`, so the mock should still be hit.
+        """
+        with (
+            patch.object(worker_main, "_parse_args") as parse_args,
+            patch.object(worker_main, "_configure_logging"),
+            patch.object(worker_main, "_load_projects", return_value=[]),
+            patch(
+                "agent.agent_definitions.validate_agent_files",
+                return_value=[],
+            ) as validate_mock,
+        ):
+            parse_args.return_value = type("Args", (), {"project": None, "dry_run": False})()
+            try:
+                worker_main.main()
+            except SystemExit:
+                # main() exits after _load_projects returns an empty list.
+                pass
+        assert validate_mock.called, (
+            "worker.__main__.main() must call validate_agent_files() before entering the run loop."
+        )

--- a/worker/__main__.py
+++ b/worker/__main__.py
@@ -538,6 +538,17 @@ def main() -> None:
     # Set environment hint that we're running as standalone worker
     os.environ.setdefault("VALOR_WORKER_MODE", "standalone")
 
+    # Validate agent definition files exist on disk. Missing files are not
+    # fatal — the SDK falls back gracefully — but we surface warnings early
+    # so operators can fix them before users hit degraded prompts. The
+    # worker is the actual session execution engine (per CLAUDE.md), so this
+    # check must fire here in addition to the bridge startup hook.
+    from agent.agent_definitions import validate_agent_files
+
+    missing_agent_files = validate_agent_files()
+    for missing_path in missing_agent_files:
+        logger.warning("Missing agent definition file: %s", missing_path)
+
     projects = _load_projects(args.project)
 
     if not projects:


### PR DESCRIPTION
## Summary

Hotfix from the daily integration audit run on **2026-05-09** (feature: `agent-definition-fallback`).

`validate_agent_files()` was called only at **bridge** startup, even though the worker is the *actual* session execution engine (per CLAUDE.md: "sole session execution engine"). Worker-only deployments — or boots where the worker comes up before the bridge — silently lost the early-warning hook the doc promises. The graceful fallback still works at runtime; this is purely an observability gap.

## Changes

- **`worker/__main__.py`** — call `validate_agent_files()` early in `main()` (after logging is configured, before the run loop). Mirrors the existing bridge call site.
- **`docs/features/agent-definition-fallback.md`** — rename the *Bridge startup validation* bullet to *Startup validation* and list both call sites (bridge + worker). Add the worker file to the Key Files table.
- **`tests/unit/test_worker_startup_validation.py`** (new) — three assertions guarding against regression to the bridge-only call site:
  1. Source-grep on `worker.__main__.main` references `validate_agent_files`.
  2. File-grep on `worker/__main__.py` references `validate_agent_files`.
  3. Stubbed `main()` run (mocking `_parse_args`, `_configure_logging`, `_load_projects`) confirms the validator is invoked before `_load_projects`.

## Verification

```
$ pytest tests/unit/test_worker_startup_validation.py tests/unit/test_agent_definitions.py
13 passed in 50.53s
```

## Audit reference

> The standalone worker is the 'sole session execution engine' — it is the process that actually consumes `get_agent_definitions()`. So a deployment where the worker starts but the bridge does not (or where the worker comes up first) misses the early-warning signal entirely. The graceful fallback still works, but the operator-facing observability the doc promises only fires on bridge startup.