### PR TITLE
docs: remove stale _load_dev_session_prompt reference from agent-definition-fallback doc

### DIFF
--- a/docs/features/agent-definition-fallback.md
+++ b/docs/features/agent-definition-fallback.md
@@ -30,10 +30,6 @@ The agent's description is set to `"Fallback for missing {name}.md"`.
 | `bridge/telegram_bridge.py` | Calls `validate_agent_files()` at startup |
 | `tests/unit/test_agent_definitions.py` | Unit tests covering normal load, missing files, and validation |
 
-## Prior Art
-
-The `_load_dev_session_prompt()` function in the same module already implemented this pattern with an `.exists()` check and hardcoded fallback prompt. This change extends the pattern to all agent definitions.
-
 ## Related
 
 - Plan: `docs/plans/sdk_graceful_agent_fallback.md`


### PR DESCRIPTION
## Summary

Removes the stale `## Prior Art` section from `docs/features/agent-definition-fallback.md`. The section cited `_load_dev_session_prompt()` as the precedent inspiration, but that function was removed during Phase 5 dev-session cleanup. A project-wide grep confirms zero remaining `.py` references.

## Verification

```
$ grep -rn '_load_dev_session_prompt' --include='*.py' .
(zero matches)
```

The `.exists()` pattern is still self-evident from the **Behavior** section ("_parse_agent_markdown() checks path.exists() before reading") and the **Key Files** table, so dropping the Prior Art section entirely matches the audit's "drop it entirely" suggestion without losing signal. Per the audit message: "Either drop it entirely or describe the .exists()-fallback pattern in the abstract without citing _load_dev_session_prompt by name."

## Tests

```
pytest -k "agent_definition or features_readme or documentation_section"
38 passed
```

(One unrelated pre-existing collection error in tests/unit/test_skills_audit.py — missing audit_skills module — not introduced by this change.)

## Out of scope

docs/plans/sdk_graceful_agent_fallback.md also references _load_dev_session_prompt() (lines 25, 54, 74, 224). Plan docs capture state at planning time and are typically left as historical artifacts; the audit scope was the feature doc only. Worth a separate migration to docs/plans/migrated/ since the feature shipped in #546.

## Audit run

Daily integration audit, 2026-05-09, feature: agent-definition-fallback. Hotfix track.