### PR TITLE
fix(bridge): consolidate filter_tool_logs to bridge.response (#1359)

### DIFF
--- a/bridge/context.py
+++ b/bridge/context.py
@@ -8,6 +8,9 @@ from pathlib import Path
 
 from telethon import TelegramClient
 
+# Reuse the canonical tool-log filter from bridge.response (single source of truth).
+# See docs/features/bridge-response-improvements.md and issue #1359.
+from bridge.response import filter_tool_logs
 from tools.link_analysis import (
     extract_urls,
     get_metadata,
@@ -94,58 +97,6 @@ DEICTIC_CONTEXT_PATTERNS = [
     re.compile(r"\bdid\s+we\s+", re.IGNORECASE),
     re.compile(r"\bwhat\s+about\s+(that|the)\b", re.IGNORECASE),
 ]
-
-
-# =============================================================================
-# Tool Log Filtering
-# =============================================================================
-
-
-def filter_tool_logs(response: str) -> str:
-    """
-    Remove tool execution traces from response.
-
-    Agent may include lines like "🛠️ exec: ls -la" in stdout.
-    These are internal logs, not meant for the user.
-
-    Returns:
-        Filtered response, or empty string if only logs remain.
-    """
-    if not response:
-        return ""
-
-    lines = response.split("\n")
-    filtered = []
-
-    # Generic pattern: emoji followed by word and colon (catches most tool logs)
-    generic_tool_pattern = re.compile(
-        r"^[\U0001F300-\U0001F9FF\u2600-\u26FF\u2700-\u27BF]\s*\w+:", re.UNICODE
-    )
-
-    for line in lines:
-        stripped = line.strip()
-
-        # Skip empty lines in sequence (but keep some structure)
-        if not stripped:
-            # Only add blank line if last line wasn't blank
-            if filtered and filtered[-1].strip():
-                filtered.append(line)
-            continue
-
-        # Skip lines that match the generic tool log pattern
-        if generic_tool_pattern.match(stripped):
-            continue
-
-        # If we got here, keep the line
-        filtered.append(line)
-
-    # Remove leading/trailing blank lines
-    while filtered and not filtered[0].strip():
-        filtered.pop(0)
-    while filtered and not filtered[-1].strip():
-        filtered.pop()
-
-    return "\n".join(filtered)
 
 
 # =============================================================================

--- a/docs/features/bridge-response-improvements.md
+++ b/docs/features/bridge-response-improvements.md
@@ -28,7 +28,10 @@ Filters out tool execution traces from agent responses before sending to Telegra
 
 If filtering removes everything, no message is sent (reaction emoji suffices).
 
-**Location**: `bridge/telegram_bridge.py:filter_tool_logs()`
+**Location**: `bridge/response.py:filter_tool_logs()` (single source of truth).
+`bridge/context.py` re-exports this canonical implementation for reply-chain
+hydration (`build_conversation_history` and `format_reply_chain`); see
+issue #1359 for the consolidation history.
 
 ### 2. Reply-Based Session Continuity ✅
 

--- a/docs/plans/consolidate_filter_tool_logs_duplicate.md
+++ b/docs/plans/consolidate_filter_tool_logs_duplicate.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: docs_complete
 type: bug
 appetite: Small
 owner: Tom Counsell

--- a/docs/plans/consolidate_filter_tool_logs_duplicate.md
+++ b/docs/plans/consolidate_filter_tool_logs_duplicate.md
@@ -122,9 +122,10 @@ No prerequisites — this work has no external dependencies. All affected files 
 
 - **`bridge/response.py`**: Unchanged. Remains canonical owner of `filter_tool_logs`.
 - **`bridge/context.py`**: Loses its local `def filter_tool_logs` (lines 104-148) and the surrounding section header. Gains `from bridge.response import filter_tool_logs` near the existing top-of-file imports. Both internal call sites (`build_conversation_history` line 375, `format_reply_chain` line 485) keep their bare-name `filter_tool_logs(...)` call — the import resolves the same symbol they used before.
-- **New unit test** `tests/unit/test_context_module.py::test_filter_tool_logs_is_response_canonical`: asserts `bridge.context.filter_tool_logs is bridge.response.filter_tool_logs`. This is a single-line identity check that fails immediately if anyone re-introduces a local copy.
-- **New integration test** in `tests/integration/test_reply_delivery.py`: invokes `format_reply_chain` against a chain whose Valor message contains `🛠️ exec: ls` (with the U+FE0F variation selector) and a `📖 read:` line, asserts the formatted output contains neither emoji-prefixed line.
-- **New unit test** in `tests/unit/test_context_module.py` (or alongside the parity test): builds a chain whose Valor message would filter down to `< 5` chars after `filter_tool_logs`, asserts that message is omitted entirely from `format_reply_chain` output (because the canonical version returns `""` on the floor, and lines 486-487 already `continue` on empty content).
+- **New unit test class** `tests/unit/test_context_helpers.py::TestFilterToolLogsParity` containing three tests:
+  1. `test_filter_tool_logs_is_response_canonical`: asserts `bridge.context.filter_tool_logs is bridge.response.filter_tool_logs`. Single-line identity check that fails immediately if anyone re-introduces a local copy.
+  2. `test_format_reply_chain_drops_variation_selector_and_backtick_echo`: builds a chain whose Valor message contains `🛠️ exec: ls` (with the U+FE0F variation selector), `📖 read: file.py`, and a backtick-shell-echo line; asserts the formatted output contains none of those three filter targets.
+  3. `test_format_reply_chain_omits_messages_below_length_floor`: builds a chain whose Valor message filters down to `<5` chars after `filter_tool_logs`; asserts the message is omitted entirely from `format_reply_chain` output (because the canonical version returns `""` on the floor, and lines 486-487 already `continue` on empty content).
 
 ### Flow
 
@@ -153,9 +154,9 @@ No prerequisites — this work has no external dependencies. All affected files 
 
 ## Test Impact
 
-- [ ] `tests/integration/test_reply_delivery.py::TestFilterToolLogsFallback` — UPDATE: existing tests already import from `bridge.response` (verified at lines 196, 203, 210, 217, 223). They continue to pass unchanged. Add one new test in this class exercising `format_reply_chain` with a U+FE0F-prefixed tool trace, asserting the output has no `🛠️` or `📖` line.
-- [ ] `tests/unit/test_context_module.py` — REPLACE/CREATE: new file (file does not currently exist). Contains the identity assertion (`bridge.context.filter_tool_logs is bridge.response.filter_tool_logs`) and the length-floor-via-`format_reply_chain` test. If a reviewer prefers, the parity test alone could live in `tests/unit/test_context_helpers.py` (existing file at line 23 already tests context-module helpers); the length-floor test still wants a home alongside it. Builder picks one of: (a) new file `test_context_module.py`, (b) extend `test_context_helpers.py`. Document the choice in PR description.
-- [ ] `tests/e2e/test_message_pipeline.py:241` — UPDATE: this test currently calls `filter_tool_logs(raw)` imported from `bridge.response`. It exercises the canonical version. After consolidation it remains unchanged (still imports from `bridge.response`). No code edit needed; just verify it still passes.
+- [ ] `tests/integration/test_reply_delivery.py::TestFilterToolLogsFallback` — UNCHANGED: existing tests already import from `bridge.response` (verified at lines 196, 203, 210, 217, 223). They continue to pass unchanged. (Per resolved decisions, the variation-selector + backtick-echo test moves into `tests/unit/test_context_helpers.py::TestFilterToolLogsParity` rather than this class, because it asserts behavior through `format_reply_chain` — the live impact path — not through `filter_tool_logs` directly.)
+- [ ] `tests/unit/test_context_helpers.py` — UPDATE: extend with `TestFilterToolLogsParity` class containing three tests (identity assertion, variation-selector + backtick-echo through `format_reply_chain`, length-floor through `format_reply_chain`). The file is already scoped to `bridge/context.py` helpers per its module docstring at lines 1-7.
+- [ ] `tests/e2e/test_message_pipeline.py:241` — UNCHANGED: this test currently calls `filter_tool_logs(raw)` imported from `bridge.response`. It exercises the canonical version. After consolidation it remains unchanged. No code edit needed; just verify it still passes.
 
 ## Rabbit Holes
 
@@ -211,9 +212,8 @@ No agent integration required — this is a bridge-internal change. `filter_tool
 - [ ] `bridge/context.py` imports `filter_tool_logs` from `bridge.response` near the top of the file.
 - [ ] `bridge.context.filter_tool_logs is bridge.response.filter_tool_logs` evaluates `True` at runtime (asserted by unit test).
 - [ ] Both call sites at `bridge/context.py:375` (`build_conversation_history`) and `:485` (`format_reply_chain`) call the imported function unchanged in source — only the binding moves.
-- [ ] New integration test exercises `format_reply_chain` with a chain containing a Valor message with U+FE0F-prefixed tool traces; output contains no `🛠️` or `📖` lines.
-- [ ] New unit test asserts length-floor behavior: a Valor message that filters down to `< 5` chars is omitted entirely from the formatted reply chain.
-- [ ] `pytest tests/unit/test_context_helpers.py tests/unit/test_context_module.py tests/integration/test_reply_delivery.py tests/e2e/test_message_pipeline.py` passes.
+- [ ] `tests/unit/test_context_helpers.py::TestFilterToolLogsParity` contains three tests: identity assertion, variation-selector + backtick-echo through `format_reply_chain`, and length-floor through `format_reply_chain`.
+- [ ] `pytest tests/unit/test_context_helpers.py tests/integration/test_reply_delivery.py tests/e2e/test_message_pipeline.py` passes.
 - [ ] Tests pass (`/do-test`)
 - [ ] Documentation updated (`/do-docs`)
 
@@ -240,18 +240,18 @@ Single builder + validator pair. The work is small enough that one builder can c
 ### 1. Consolidate filter_tool_logs and add tests
 - **Task ID**: build-consolidate-filter-tool-logs
 - **Depends On**: none
-- **Validates**: `tests/unit/test_context_module.py` (create), `tests/integration/test_reply_delivery.py` (extend), `tests/unit/test_context_helpers.py` (re-run unchanged), `tests/e2e/test_message_pipeline.py` (re-run unchanged)
-- **Informed By**: Issue #1359 file:line targets, Freshness Check (all references re-verified at commit 53a64e7c)
+- **Validates**: `tests/unit/test_context_helpers.py` (extend with `TestFilterToolLogsParity`), `tests/integration/test_reply_delivery.py` (re-run unchanged), `tests/e2e/test_message_pipeline.py` (re-run unchanged)
+- **Informed By**: Issue #1359 file:line targets, Freshness Check (all references re-verified at commit 53a64e7c), Resolved Decisions section
 - **Assigned To**: filter-tool-logs-consolidator
 - **Agent Type**: builder
 - **Parallel**: false
 - Delete the duplicate `def filter_tool_logs(response: str) -> str:` block at `bridge/context.py:104-148` and the surrounding section-header comment at lines 99-102.
 - Add `from bridge.response import filter_tool_logs` near the top of `bridge/context.py`. Place it adjacent to existing `from bridge.` imports if any exist; otherwise add a new top-level import line. Add a one-line comment above it explaining the single-source-of-truth intent.
 - Verify via `grep -rn "def filter_tool_logs" bridge/` that exactly one match remains (the canonical one in `response.py`).
-- Create `tests/unit/test_context_module.py` containing two tests:
+- Extend `tests/unit/test_context_helpers.py` with a new `TestFilterToolLogsParity` class containing three tests:
   1. `test_filter_tool_logs_is_response_canonical`: imports `bridge.context` and `bridge.response`, asserts `bridge.context.filter_tool_logs is bridge.response.filter_tool_logs`.
-  2. `test_format_reply_chain_omits_messages_below_length_floor`: builds a chain whose Valor message would filter to `< 5` chars, calls `format_reply_chain`, asserts the message is omitted from the output (the existing `if not content: continue` at lines 486-487 handles this once `filter_tool_logs` returns `""` per the canonical floor).
-- Add a new test in `tests/integration/test_reply_delivery.py::TestFilterToolLogsFallback` (or a new sibling class) that constructs a reply chain whose Valor message contains a U+FE0F-prefixed `🛠️ exec:` line and a `📖 read:` line, calls `format_reply_chain(chain)`, asserts the result contains neither `🛠️` nor `📖`.
+  2. `test_format_reply_chain_drops_variation_selector_and_backtick_echo`: builds a chain whose Valor message contains `🛠️ exec: ls` (with U+FE0F variation selector), `📖 read: file.py`, and a backtick-shell-echo line; calls `format_reply_chain`; asserts none of those filter targets remain in the output.
+  3. `test_format_reply_chain_omits_messages_below_length_floor`: builds a chain whose Valor message would filter to `< 5` chars; calls `format_reply_chain`; asserts the message is omitted from the output (the existing `if not content: continue` at lines 486-487 handles this once `filter_tool_logs` returns `""` per the canonical floor).
 - Update `docs/features/bridge-response-improvements.md` near the existing `filter_tool_logs` reference (around line 31) with a one-line cross-reference: `bridge/context.py` re-exports `filter_tool_logs` from `bridge/response.py` for reply-chain hydration; this is the single source of truth.
 
 ### 2. Validate consolidation
@@ -262,8 +262,8 @@ Single builder + validator pair. The work is small enough that one builder can c
 - **Parallel**: false
 - Run `grep -rn "def filter_tool_logs" bridge/` — assert output is exactly one line, in `bridge/response.py`.
 - Run `python -c "import bridge.context, bridge.response; assert bridge.context.filter_tool_logs is bridge.response.filter_tool_logs; print('PARITY OK')"` and confirm `PARITY OK` is printed.
-- Run `pytest tests/unit/test_context_module.py tests/unit/test_context_helpers.py tests/integration/test_reply_delivery.py tests/e2e/test_message_pipeline.py -x -q` — assert exit code 0.
-- Run `python -m ruff check bridge/context.py tests/unit/test_context_module.py` and `python -m ruff format --check bridge/context.py tests/unit/test_context_module.py` — assert exit code 0.
+- Run `pytest tests/unit/test_context_helpers.py tests/integration/test_reply_delivery.py tests/e2e/test_message_pipeline.py -x -q` — assert exit code 0.
+- Run `python -m ruff check bridge/context.py tests/unit/test_context_helpers.py` and `python -m ruff format --check bridge/context.py tests/unit/test_context_helpers.py` — assert exit code 0.
 - Confirm `docs/features/bridge-response-improvements.md` contains the new cross-reference line.
 - Report pass/fail with the exact commands run.
 
@@ -283,9 +283,9 @@ Single builder + validator pair. The work is small enough that one builder can c
 |-------|---------|----------|
 | Single definition | `grep -rn "def filter_tool_logs" bridge/` | exit code 0, exactly one match line in output |
 | Symbol identity | `python -c "import bridge.context, bridge.response; assert bridge.context.filter_tool_logs is bridge.response.filter_tool_logs"` | exit code 0 |
-| Targeted tests pass | `pytest tests/unit/test_context_module.py tests/unit/test_context_helpers.py tests/integration/test_reply_delivery.py tests/e2e/test_message_pipeline.py -x -q` | exit code 0 |
-| Lint clean | `python -m ruff check bridge/context.py tests/unit/test_context_module.py` | exit code 0 |
-| Format clean | `python -m ruff format --check bridge/context.py tests/unit/test_context_module.py` | exit code 0 |
+| Targeted tests pass | `pytest tests/unit/test_context_helpers.py tests/integration/test_reply_delivery.py tests/e2e/test_message_pipeline.py -x -q` | exit code 0 |
+| Lint clean | `python -m ruff check bridge/context.py tests/unit/test_context_helpers.py` | exit code 0 |
+| Format clean | `python -m ruff format --check bridge/context.py tests/unit/test_context_helpers.py` | exit code 0 |
 | Docs cross-ref present | `grep -n "context.py" docs/features/bridge-response-improvements.md` | exit code 0, output contains a line referencing the re-export |
 
 ## Critique Results
@@ -297,7 +297,16 @@ Single builder + validator pair. The work is small enough that one builder can c
 
 ---
 
-## Open Questions
+## Resolved Decisions
 
-1. **Test file placement**: Should the parity assertion live in a new file `tests/unit/test_context_module.py` or be appended to the existing `tests/unit/test_context_helpers.py`? Default in this plan: new file (cleanly separates module-level structural tests from per-helper behavioral tests). Override if you prefer the single-file pattern.
-2. **Length-floor test scope**: Is asserting the floor *through `format_reply_chain`* sufficient (current plan), or do you also want a direct `filter_tool_logs("🛠️ exec: ls\nok") == ""` assertion in `tests/unit/test_context_module.py`? The canonical floor is already exercised in `tests/integration/test_reply_delivery.py::TestFilterToolLogsFallback`, so the plan defaults to no — but a duplicate direct assertion in the new file would make this plan's contribution self-contained.
+1. **Test file placement — extend `tests/unit/test_context_helpers.py`.** Add a `TestFilterToolLogsParity` class to the existing file. Reasoning: `tests/unit/test_context_helpers.py:1-7` is explicitly scoped to `bridge/context.py` — its docstring says "Unit tests for bridge/context.py helper functions". It already groups multiple `bridge.context` concerns (`TestReplyThreadContextHeader`, `TestReferencesPriorContextDeictic`, `TestBuildCompletedResumeText`). Adding a new file for two tests would be an outlier in this codebase. All references to `tests/unit/test_context_module.py` in this plan are superseded by `tests/unit/test_context_helpers.py::TestFilterToolLogsParity`.
+
+2. **Length-floor test scope — through `format_reply_chain` only.** One assertion: build a chain where a Valor message's filtered remainder is `<5` chars; assert it's omitted from the formatted output. Do not add a duplicate direct `filter_tool_logs(...)` length-floor unit test — the existing tests at `tests/integration/test_reply_delivery.py:191-229` and `tests/e2e/test_message_pipeline.py:239-246` cover the function directly; a through-pipeline test adds new coverage. The `< 5` floor is currently UNCOVERED through the pipeline (verified via grep — no length-floor assertions in `tests/`), so this is a genuine gap-closer.
+
+### Net new coverage in this plan
+
+1. **Identity assertion** — `bridge.context.filter_tool_logs is bridge.response.filter_tool_logs` (permanent regression guard).
+2. **Length-floor through `format_reply_chain`** — chain with Valor message that filters to `<5` chars; assert message vanishes from output.
+3. **Variation-selector + backtick-echo through `format_reply_chain`** — chain with Valor message containing `🛠️ exec: ls` (with U+FE0F variation selector), `📖 read: file.py`, and a backtick-shell-echo line; assert all three filter targets are dropped from the formatted output.
+
+All three tests live in `tests/unit/test_context_helpers.py::TestFilterToolLogsParity`.

--- a/docs/plans/consolidate_filter_tool_logs_duplicate.md
+++ b/docs/plans/consolidate_filter_tool_logs_duplicate.md
@@ -94,7 +94,7 @@ future re-introduction of a local copy fails CI immediately.
 
 ## Architectural Impact
 
-- **New dependencies**: None at the package level. `bridge/context.py` already uses other helpers from `bridge/response.py` is currently false — context.py imports `bridge.response.set_reaction` is also false. After this change `bridge/context.py` will import `filter_tool_logs` from `bridge.response`. This creates a new module-level dependency `bridge.context → bridge.response` for one symbol.
+- **New dependencies**: None at the package level. `bridge/context.py` does not currently import from `bridge.response` (verified via grep). After this change, `bridge/context.py` will import `filter_tool_logs` from `bridge.response`, creating a new module-level dependency `bridge.context → bridge.response` for that one symbol.
 - **Interface changes**: None. The function name, signature, and module-public access on `bridge.context` (`bridge.context.filter_tool_logs`) all remain unchanged via the re-export. External callers that already import `from bridge.context import filter_tool_logs` (none in the current tree, verified) would continue to work.
 - **Coupling**: Increases coupling between `bridge.context` and `bridge.response` by one symbol. Both modules already coexist in the `bridge/` package and are co-imported by `bridge/telegram_bridge.py` (`bridge/telegram_bridge.py:95` and `:124`). The directional dependency is: response.py → (no bridge deps for filter logic) ← context.py reuses. No cycle risk.
 - **Data ownership**: Unchanged. `bridge.response` remains the owner of the tool-log filtering logic.
@@ -177,7 +177,7 @@ No prerequisites — this work has no external dependencies. All affected files 
 
 ### Risk 3: Future reintroduction of a local `filter_tool_logs` in `bridge/context.py`
 **Impact:** Restores the original bug.
-**Mitigation:** The identity-assertion unit test (`bridge.context.filter_tool_logs is bridge.response.filter_tool_logs`) fails the moment a local `def filter_tool_logs` shadows the import. Any duplicate triggers a CI failure on the very PR that introduces it.
+**Mitigation:** The identity-assertion unit test (`bridge.context.filter_tool_logs is bridge.response.filter_tool_logs`) fails the moment a direct local `def filter_tool_logs` shadows the import. Note this guard catches the exact pattern that produced this bug (local `def` redefinition) but does not catch all possible re-divergences — e.g. a third-module copy at `bridge/foo.py:filter_tool_logs` would not trigger it. Treated as "good-enough regression protection for the observed failure mode," not absolute coverage.
 
 ## Race Conditions
 
@@ -198,7 +198,7 @@ No agent integration required — this is a bridge-internal change. `filter_tool
 ## Documentation
 
 ### Feature Documentation
-- [ ] Update `docs/features/bridge-response-improvements.md` — add a one-line cross-reference noting that `bridge/context.py` reuses `filter_tool_logs` from `bridge/response.py` for reply-chain hydration. Append near the existing `filter_tool_logs` reference at line 31 of that file.
+- [ ] Update `docs/features/bridge-response-improvements.md` line 31 — fix the stale `**Location**: bridge/telegram_bridge.py:filter_tool_logs()` reference (function actually lives in `bridge/response.py`) and add a one-line cross-reference noting that `bridge/context.py` reuses `filter_tool_logs` from `bridge/response.py` for reply-chain hydration.
 
 ### External Documentation Site
 - No external documentation site involved — this repo uses `docs/` markdown directly, no Sphinx/MkDocs build step in scope.
@@ -252,7 +252,7 @@ Single builder + validator pair. The work is small enough that one builder can c
   1. `test_filter_tool_logs_is_response_canonical`: imports `bridge.context` and `bridge.response`, asserts `bridge.context.filter_tool_logs is bridge.response.filter_tool_logs`.
   2. `test_format_reply_chain_drops_variation_selector_and_backtick_echo`: builds a chain whose Valor message contains `🛠️ exec: ls` (with U+FE0F variation selector), `📖 read: file.py`, and a backtick-shell-echo line; calls `format_reply_chain`; asserts none of those filter targets remain in the output.
   3. `test_format_reply_chain_omits_messages_below_length_floor`: builds a chain whose Valor message would filter to `< 5` chars; calls `format_reply_chain`; asserts the message is omitted from the output (the existing `if not content: continue` at lines 486-487 handles this once `filter_tool_logs` returns `""` per the canonical floor).
-- Update `docs/features/bridge-response-improvements.md` near the existing `filter_tool_logs` reference (around line 31) with a one-line cross-reference: `bridge/context.py` re-exports `filter_tool_logs` from `bridge/response.py` for reply-chain hydration; this is the single source of truth.
+- Update `docs/features/bridge-response-improvements.md` line 31 — the existing `**Location**: bridge/telegram_bridge.py:filter_tool_logs()` reference is stale (the function lives in `bridge/response.py`, not `telegram_bridge.py`). Replace it with two lines: (1) corrected canonical location `**Location**: bridge/response.py:filter_tool_logs()`, and (2) cross-reference: `bridge/context.py` re-exports `filter_tool_logs` from `bridge/response.py` for reply-chain hydration; this is the single source of truth.
 
 ### 2. Validate consolidation
 - **Task ID**: validate-consolidate-filter-tool-logs
@@ -290,10 +290,14 @@ Single builder + validator pair. The work is small enough that one builder can c
 
 ## Critique Results
 
-<!-- Populated by /do-plan-critique. Leave empty until critique is run. -->
+Verdict: READY TO BUILD (with concerns) — recorded `sha256:86f16bf9...`.
 
 | Severity | Critic | Finding | Addressed By | Implementation Note |
 |----------|--------|---------|--------------|---------------------|
+| Concern | Skeptic | Corrupted sentence in Architectural Impact line 97 (two clauses spliced, self-contradictory). | Plan revision | Replaced with a single declarative sentence about the new `bridge.context → bridge.response` dependency. |
+| Concern | Archaeologist | `docs/features/bridge-response-improvements.md` line 31 says the function lives in `bridge/telegram_bridge.py`; it actually lives in `bridge/response.py`. | Plan revision + builder | Step 1 now instructs the builder to fix the stale Location reference and append the cross-reference in the same edit. |
+| Concern | Operator | Original Open Question 1 left the test file undecided while validator/Verification commands hard-coded `tests/unit/test_context_module.py`. | Resolved Decisions section | Q1 resolved to extend `tests/unit/test_context_helpers.py`; all validator commands and Verification table updated to match. |
+| Concern | Adversary | Risk 3 framed `is`-check as "permanent regression protection" — overclaim. | Plan revision | Risk 3 now scopes the guard to "the exact pattern that produced this bug" and notes it doesn't catch all re-divergences. |
 
 ---
 

--- a/tests/unit/test_context_helpers.py
+++ b/tests/unit/test_context_helpers.py
@@ -211,3 +211,96 @@ class TestBuildCompletedResumeText:
             self._fake_session("ctx"), "msg", reply_chain_context=chain_block
         )
         assert result.count(REPLY_THREAD_CONTEXT_HEADER) == 1
+
+
+class TestFilterToolLogsParity:
+    """`bridge.context.filter_tool_logs` must be the canonical version
+    in `bridge.response`.
+
+    History: a stale local `def filter_tool_logs` lived in
+    `bridge/context.py` and silently diverged from the canonical
+    `bridge/response.py` implementation (variation-selector handling,
+    backtick-shell echoes, `<5` char length floor — all weaker in the
+    stale copy). PR #1077 consolidated `bridge/response.py` but its
+    audit only grepped for *imports* of the canonical path, missing
+    the orphan `def`. Issue #1359 closes the duplicate and these tests
+    are the permanent guard against the same audit miss recurring.
+    """
+
+    def test_filter_tool_logs_is_response_canonical(self):
+        """Identity assertion: any future re-introduction of a local
+        `def filter_tool_logs` in `bridge/context.py` will shadow the
+        import and fail this test, breaking CI on the offending PR."""
+        import bridge.context
+        import bridge.response
+
+        assert bridge.context.filter_tool_logs is bridge.response.filter_tool_logs
+
+    def test_format_reply_chain_drops_variation_selector_and_backtick_echo(self):
+        """Through-pipeline assertion: `format_reply_chain` must drop
+        U+FE0F-prefixed tool traces (`🛠️ exec:`, `📖 read:`) and
+        backtick-wrapped shell echoes from Valor messages.
+
+        Asserts the canonical filter (which handles variation selectors
+        and the `_SHELL_COMMAND_HINTS` echo filter) reaches the live
+        impact path that feeds `_build_completed_resume_text` at
+        `bridge/telegram_bridge.py:1740` and `:2259`.
+        """
+        from bridge.context import format_reply_chain
+
+        # U+FE0F variation selector after wrench emoji, plus a book emoji,
+        # plus a backtick-wrapped shell command echo.
+        valor_message = (
+            "Here is the analysis you asked for.\n"
+            "\U0001f6e0️ exec: ls -la\n"
+            "\U0001f4d6 read: bridge/context.py\n"
+            "`cd bridge && ls -la`\n"
+            "The duplicate definition is at line 104."
+        )
+        chain = [
+            {"sender": "Tom", "content": "what's in bridge/?", "message_id": 1, "date": None},
+            {"sender": "Valor", "content": valor_message, "message_id": 2, "date": None},
+        ]
+
+        formatted = format_reply_chain(chain)
+
+        # All three filter targets must be absent from the output.
+        assert "\U0001f6e0" not in formatted, "wrench emoji tool trace leaked"
+        assert "\U0001f4d6" not in formatted, "book emoji tool trace leaked"
+        assert "`cd bridge && ls -la`" not in formatted, "backtick shell echo leaked"
+        # The meaningful prose must still be present.
+        assert "Here is the analysis you asked for." in formatted
+        assert "The duplicate definition is at line 104." in formatted
+
+    def test_format_reply_chain_omits_messages_below_length_floor(self):
+        """Through-pipeline assertion: when `filter_tool_logs` returns `""`
+        because the post-filter remainder is below the `<5` char floor,
+        `format_reply_chain` must omit the Valor message entirely
+        (the existing `if not content: continue` at `bridge/context.py:486-487`
+        handles this once the canonical floor returns `""`).
+
+        This floor is currently UNCOVERED through `format_reply_chain` — the
+        existing direct-function tests at
+        `tests/integration/test_reply_delivery.py:191-229` and
+        `tests/e2e/test_message_pipeline.py:239-246` only exercise
+        `filter_tool_logs` in isolation.
+        """
+        from bridge.context import format_reply_chain
+
+        # After filter_tool_logs runs, only "ok" remains (2 chars, below
+        # the `<5` floor) so the canonical version returns "".
+        valor_short = "\U0001f6e0️ exec: ls\nok"
+        chain = [
+            {"sender": "Tom", "content": "run ls", "message_id": 1, "date": None},
+            {"sender": "Valor", "content": valor_short, "message_id": 2, "date": None},
+            {"sender": "Tom", "content": "thanks", "message_id": 3, "date": None},
+        ]
+
+        formatted = format_reply_chain(chain)
+
+        # The Valor message must be omitted entirely.
+        assert "ok" not in formatted, "below-floor remainder should not reach the output"
+        assert "Valor:" not in formatted, "Valor message should be omitted, not just emptied"
+        # The surrounding messages must still be present.
+        assert "Tom: run ls" in formatted
+        assert "Tom: thanks" in formatted


### PR DESCRIPTION
## Summary

Closes #1359. Deletes the stale duplicate `def filter_tool_logs` at `bridge/context.py:104-148`. `bridge/context.py` now imports the canonical implementation from `bridge.response`, restoring single source of truth. Both call sites in `bridge/context.py` (`build_conversation_history` line 326 and `format_reply_chain` line 436) keep their bare-name calls — only the binding moves.

PR #1077 consolidated `bridge/response.py` but its audit only grepped for *imports* of the canonical path, missing the orphan `def` in `bridge/context.py`. The duplicate had silently diverged in three ways, all weaker:

| Behavior | `bridge/response.py` (canonical) | `bridge/context.py` (stale, now deleted) |
|----------|----------------------------------|------------------------------------------|
| U+FE0F variation selector after emoji | Yes (line 130) | No |
| Backtick shell-command echo filter | Yes (`_SHELL_COMMAND_HINTS`) | No |
| `<5` char length floor | Yes (line 180) | No |

`format_reply_chain` is spliced into `_build_completed_resume_text` at `bridge/telegram_bridge.py:1740` and `:2259`, so wrench-with-VS tool traces were leaking into resumed-session prompts. The agent then saw its own previous tool noise inside conversation history and could interpret `🛠️ exec: ls` as instruction.

## Plan

Plan: `docs/plans/consolidate_filter_tool_logs_duplicate.md`. Critique recorded verdict `READY TO BUILD (with concerns)`; the four concerns surfaced were all addressed in commit `929fca42`:

1. Corrupted sentence in Architectural Impact line 97 — fixed.
2. Stale `Location` reference at `docs/features/bridge-response-improvements.md:31` (claimed the function lived in `telegram_bridge.py`; it lives in `response.py`) — fixed in this PR.
3. Test file placement — Open Question 1 resolved to extend `tests/unit/test_context_helpers.py` (file is already scoped to `bridge/context.py` per its module docstring); validator commands updated to match.
4. Risk 3 over-claim — softened to "good-enough regression protection for the observed failure mode."

## Tests

`tests/unit/test_context_helpers.py::TestFilterToolLogsParity` adds three guards:

1. `test_filter_tool_logs_is_response_canonical` — identity assertion (`bridge.context.filter_tool_logs is bridge.response.filter_tool_logs`). Fails the moment a future PR re-introduces a local `def`.
2. `test_format_reply_chain_drops_variation_selector_and_backtick_echo` — through-pipeline test for the variation-selector and backtick-echo filter targets that the stale copy missed.
3. `test_format_reply_chain_omits_messages_below_length_floor` — through-pipeline test for the `<5` char floor (gap-closer: not previously asserted through the pipeline; existing direct-function tests at `tests/integration/test_reply_delivery.py:191-229` and `tests/e2e/test_message_pipeline.py:239-246` only exercise `filter_tool_logs` in isolation).

```
$ pytest tests/unit/test_context_helpers.py tests/integration/test_reply_delivery.py tests/e2e/test_message_pipeline.py -x -q
107 passed in 3.44s
```

```
$ grep -rn "def filter_tool_logs" bridge/
bridge/response.py:138:def filter_tool_logs(response: str) -> str:
```

```
$ python -c "import bridge.context, bridge.response; assert bridge.context.filter_tool_logs is bridge.response.filter_tool_logs; print('PARITY OK')"
PARITY OK
```

## Documentation

`docs/features/bridge-response-improvements.md:31` — fixed stale `Location` reference (was `bridge/telegram_bridge.py:filter_tool_logs()`, now `bridge/response.py:filter_tool_logs()`) and added a one-line cross-reference noting the `bridge/context.py` re-export.

## Out of Scope

- No update system changes (purely internal bridge refactor).
- No agent integration changes (helper is internal to `bridge/`).
- No new dependencies; the `bridge.context → bridge.response` import is the only new edge.