### PR TITLE
docs(claude): add Knowledge Base (KB) section convention

### DIFF
--- a/.claude/hooks/validators/validate_knowledge_base_section.py
+++ b/.claude/hooks/validators/validate_knowledge_base_section.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""
+Validate that a project's CLAUDE.md or README.md has a ## Knowledge Base (KB) section.
+
+This is a SOFT validator — exit code is always 0. Warnings go to stderr.
+Wire into CI or a pre-commit hook per-project if you want enforcement.
+
+Convention: docs/conventions/knowledge-base-section.md
+
+The section must name two things:
+  1. A vault directory path under ~/work-vault/
+  2. A memory project_key (matched by `--project <key>` or `project_key=<key>`)
+
+Usage:
+  uv run validate_knowledge_base_section.py CLAUDE.md
+  uv run validate_knowledge_base_section.py README.md
+  uv run validate_knowledge_base_section.py path/to/CLAUDE.md
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+CONVENTION_URL = "docs/conventions/knowledge-base-section.md"
+
+MISSING_SECTION_WARNING = """
+WARNING: '{file}' is missing a ## Knowledge Base (KB) section.
+
+This is a soft convention. See {convention} for the template.
+
+Quick add (replace placeholders):
+
+## Knowledge Base (KB)
+
+**1. Vault (curated docs, iCloud-synced)**
+- Location: `~/work-vault/<VAULT_DIR>/`
+- Index: see that directory's `README.md` for the file index
+
+**2. Memory system (Redis, agent-learned observations)**
+- Project key: `<PROJECT_KEY>` (see `config/projects.json`)
+- Search: `python -m tools.memory_search search "<query>" --project <PROJECT_KEY>`
+"""
+
+MISSING_VAULT_WARNING = """
+WARNING: '{file}' has a ## Knowledge Base (KB) section but no vault path.
+
+The section should name a directory under ~/work-vault/, e.g.:
+  - Location: `~/work-vault/My Project/`
+
+See {convention} for the full template.
+"""
+
+MISSING_PROJECT_KEY_WARNING = """
+WARNING: '{file}' has a ## Knowledge Base (KB) section but no project_key reference.
+
+The section should name the memory project_key, e.g.:
+  - Project key: `my-project` (see `config/projects.json`)
+  - Search: `python -m tools.memory_search search "..." --project my-project`
+
+See {convention} for the full template.
+"""
+
+
+def extract_kb_section(content: str) -> str | None:
+    """Extract the ## Knowledge Base (KB) section from file content.
+
+    Matches either '## Knowledge Base (KB)' or '## Knowledge Base'.
+    """
+    match = re.search(
+        r"^## Knowledge Base(?: \(KB\))?\s*$(.*?)(?=^## |\Z)",
+        content,
+        re.MULTILINE | re.DOTALL,
+    )
+    if match:
+        return match.group(1).strip()
+    return None
+
+
+def has_vault_path(section: str) -> bool:
+    """Check the section references a ~/work-vault/ path."""
+    return bool(re.search(r"~/work-vault/", section))
+
+
+def has_project_key(section: str) -> bool:
+    """Check the section references a project_key.
+
+    Accepts any of:
+      - `--project <key>`
+      - `project_key=<key>` or `project_key: <key>`
+      - 'Project key: `<key>`' (the template form)
+    """
+    patterns = [
+        r"--project\s+\S",
+        r"project_key\s*[:=]\s*\S",
+        r"[Pp]roject\s+key\s*[:=]\s*`",
+    ]
+    return any(re.search(p, section) for p in patterns)
+
+
+def validate(filepath: str) -> tuple[int, list[str]]:
+    """Validate a file. Returns (warning_count, messages)."""
+    try:
+        content = Path(filepath).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as e:
+        return 1, [f"WARNING: failed to read '{filepath}': {e}"]
+
+    section = extract_kb_section(content)
+    if section is None:
+        return 1, [MISSING_SECTION_WARNING.format(file=filepath, convention=CONVENTION_URL)]
+
+    warnings = []
+    if not has_vault_path(section):
+        warnings.append(MISSING_VAULT_WARNING.format(file=filepath, convention=CONVENTION_URL))
+    if not has_project_key(section):
+        warnings.append(
+            MISSING_PROJECT_KEY_WARNING.format(file=filepath, convention=CONVENTION_URL)
+        )
+
+    return len(warnings), warnings
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Soft validator for ## Knowledge Base (KB) section"
+    )
+    parser.add_argument(
+        "file",
+        nargs="?",
+        default="CLAUDE.md",
+        help="Path to CLAUDE.md or README.md (default: CLAUDE.md)",
+    )
+    args = parser.parse_args()
+
+    # Consume stdin if provided (SDK passes context via stdin)
+    try:
+        json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        pass
+
+    if not Path(args.file).exists():
+        # Soft: not an error if the target file doesn't exist
+        print(json.dumps({"result": "continue", "message": f"skipped: {args.file} not found"}))
+        sys.exit(0)
+
+    warning_count, messages = validate(args.file)
+
+    if warning_count == 0:
+        print(
+            json.dumps(
+                {
+                    "result": "continue",
+                    "message": f"Knowledge Base section present and well-formed in {args.file}",
+                }
+            )
+        )
+    else:
+        for msg in messages:
+            print(msg, file=sys.stderr)
+        print(
+            json.dumps(
+                {
+                    "result": "continue",
+                    "message": f"{warning_count} KB warning(s) in {args.file} (non-blocking)",
+                }
+            )
+        )
+
+    # Always exit 0 — this is warn-only.
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -545,6 +545,7 @@ No existing tests affected — this is a greenfield feature with no prior test c
 | `docs/features/README.md` | Feature index — look up how things work |
 | `docs/sdlc/` | Per-stage repo-specific addenda — read by SDLC skills at runtime |
 | `tests/README.md` | Test suite index — feature markers, blind spots, contribution guide |
+| `docs/conventions/knowledge-base-section.md` | KB-section convention every project's `CLAUDE.md`/`README.md` should follow |
 
 ## GitHub Issue Labels
 
@@ -562,6 +563,24 @@ Use these labels consistently when creating or editing issues:
 
 Do NOT use a `feature` label — it adds no signal.
 
-## Business Context
+## Knowledge Base (KB)
 
-For business context, project notes, and assets see the work vault: `~/src/work-vault/AI Valor Engels System/`
+This project's knowledge has two sources. Pull from both before answering substantive questions.
+
+**1. Vault (curated docs, iCloud-synced)**
+- Location: `~/work-vault/AI Valor Engels System/`
+- Index: see that directory's `README.md` for the file index
+- Source of truth for business context, project notes, decisions, and assets
+- Ingest binaries into the indexer with `valor-ingest <path>` (creates `.md` sidecars; `--scan` for backfill)
+
+**2. Memory system (Redis, agent-learned observations)**
+- Project key: `valor` (partitions memories for this project — see `config/projects.json`)
+- Search: `python -m tools.memory_search search "<query>" --project valor`
+- Save: `python -m tools.memory_search save "<content>" --project valor`
+- Status: `python -m tools.memory_search status --project valor`
+- MCP recall: `mcp__memory__memory_search`, `mcp__memory__memory_get`
+- See `docs/features/subconscious-memory.md` for ingestion, scoring, and consolidation
+
+Curated vault = what humans wrote. Memory = what the agent learned (corrections, decisions, patterns, surprises). Both partition by project — don't leak cross-project context.
+
+This is a convention every project should follow — see [`docs/conventions/knowledge-base-section.md`](docs/conventions/knowledge-base-section.md).

--- a/docs/conventions/knowledge-base-section.md
+++ b/docs/conventions/knowledge-base-section.md
@@ -1,0 +1,75 @@
+# Convention: `## Knowledge Base (KB)` section
+
+Every project's `CLAUDE.md` (or `README.md` if there is no `CLAUDE.md`) should include a `## Knowledge Base (KB)` section. Soft requirement — same shape as the existing `## Running` convention referenced from `/do-pr-review` and across `docs/features/`.
+
+## Why
+
+A project's knowledge lives in two distinct places, and agents/teammates conflate them constantly:
+
+1. **The vault** — a curated Markdown corpus under `~/work-vault/<project>/`, iCloud-synced, human-written. This is the source of truth for business context, decisions, assets, notes.
+2. **The memory system** — Redis-backed `Memory` records, partitioned by `project_key`, learned by the agent from conversations, PR merges, and corrections.
+
+The KB section makes both sources explicit at the top of every project so anyone (or any agent) knows where to look and what `project_key` to scope memory queries to.
+
+## Required fields
+
+Every KB section names exactly two things:
+
+1. **Vault directory** — absolute path under `~/work-vault/`, plus a pointer to its `README.md` index
+2. **Memory project key** — the `project_key` from `config/projects.json`, plus the CLI command to search it
+
+## Template
+
+Copy this verbatim into a new project, replacing `<VAULT_DIR>` and `<PROJECT_KEY>`:
+
+```markdown
+## Knowledge Base (KB)
+
+This project's knowledge has two sources. Pull from both before answering substantive questions.
+
+**1. Vault (curated docs, iCloud-synced)**
+- Location: `~/work-vault/<VAULT_DIR>/`
+- Index: see that directory's `README.md` for the file index
+- Source of truth for business context, project notes, decisions, and assets
+
+**2. Memory system (Redis, agent-learned observations)**
+- Project key: `<PROJECT_KEY>` (see `config/projects.json`)
+- Search: `python -m tools.memory_search search "<query>" --project <PROJECT_KEY>`
+- Save: `python -m tools.memory_search save "<content>" --project <PROJECT_KEY>`
+- Status: `python -m tools.memory_search status --project <PROJECT_KEY>`
+
+Curated vault = what humans wrote. Memory = what the agent learned. Both partition by project — don't leak cross-project context.
+```
+
+## Placement
+
+- **If the project has a `CLAUDE.md`**: KB section lives there (agent-facing, near the bottom alongside the `## See Also` block)
+- **If the project has only a `README.md`**: KB section lives in `README.md` (human + agent both read it)
+- **Never both** — pick one to be authoritative; the other can link to it
+
+## Where it gets referenced
+
+The KB section is meant to be linked from any skill or tool that needs project-specific knowledge:
+
+- `/do-plan` and `/do-build` should pull from the vault when scoping work
+- `/do-pr-review` should check the vault for design briefs and acceptance criteria
+- Memory searches in tools and reflections should use the documented `project_key`
+
+This is the same pattern as the `## Running` convention, which is referenced from `.claude/skills-global/do-pr-review/SKILL.md` and `docs/features/review-workflow-screenshots.md`.
+
+## Validation
+
+A warn-only soft validator at `.claude/hooks/validators/validate_knowledge_base_section.py` checks for the section's presence and structure. It is **not** wired into any blocking hook — invoke manually:
+
+```bash
+uv run .claude/hooks/validators/validate_knowledge_base_section.py CLAUDE.md
+uv run .claude/hooks/validators/validate_knowledge_base_section.py README.md
+```
+
+Exit code is always 0 (warnings on stderr). Wire into CI or a pre-commit hook per-project if you want enforcement.
+
+## See also
+
+- `config/projects.json` — declares each project's `knowledge_base` path and project key
+- `docs/features/subconscious-memory.md` — memory system architecture, scoring, consolidation
+- `docs/features/markitdown-ingestion.md` — `valor-ingest` for getting non-Markdown sources into the vault corpus


### PR DESCRIPTION
## Summary

Establishes a soft convention: every project's `CLAUDE.md` should include a `## Knowledge Base (KB)` section naming two knowledge sources:

1. **Vault** — sub-directory under `~/work-vault/` (curated, human-written docs)
2. **Memory system** — `project_key` from `config/projects.json` (Redis-backed agent observations)

Same shape as the existing `## Running` README convention referenced from `/do-pr-review`.

## Changes

- **`CLAUDE.md`** — `## Knowledge Base (KB)` section replaces the thin `Business Context` line. Names vault path + `valor` project_key + memory CLI invocations. Added a row to `## See Also`.
- **`docs/conventions/knowledge-base-section.md`** (new file, new dir) — convention doc with copy-paste template, placement rules (CLAUDE.md vs README.md), validation invocation.
- **`.claude/hooks/validators/validate_knowledge_base_section.py`** (new) — warn-only validator. Exit code is always 0; warnings go to stderr. **Not** wired into blocking hooks. Invoke manually:
  ```bash
  uv run .claude/hooks/validators/validate_knowledge_base_section.py CLAUDE.md
  ```

## Rollout

Companion branches `feat/knowledge-base-section` pushed to 8 other repos with `knowledge_base` declared in `config/projects.json`:

- popoto, django-project-template, satsol, psyoptimal, royop, mondayflowers, mondayflowers-org, yudame

`cuttlefish` skipped — had unrelated WIP on branding docs at rollout time.

## Why

Before this PR, the agent (and humans onboarding) had no consistent place to learn:
- Where each project's curated docs live (`~/work-vault/<X>/`)
- What `project_key` to scope memory searches to

The vault path was buried in a one-line `Business Context` mention; the project_key was only discoverable by reading `config/projects.json`. Now both are first-class in every project's `CLAUDE.md`.