### PR TITLE
Route tool-call sends through canonical handler (#1369)

### DIFF
--- a/agent/output_handler.py
+++ b/agent/output_handler.py
@@ -37,6 +37,7 @@ class OutputHandler(Protocol):
         text: str,
         reply_to_msg_id: int,
         session: Any = None,
+        file_paths: list[str] | None = None,
     ) -> None:
         """Send text output to the destination.
 
@@ -45,6 +46,8 @@ class OutputHandler(Protocol):
             text: Message text to send.
             reply_to_msg_id: Original message ID to reply to.
             session: Optional session context object.
+            file_paths: Optional list of attachment file paths supplied by a
+                CLI caller. Implementations may ignore if unsupported.
         """
         ...
 
@@ -81,8 +84,14 @@ class FileOutputHandler:
         text: str,
         reply_to_msg_id: int,
         session: Any = None,
+        file_paths: list[str] | None = None,
     ) -> None:
-        """Append text output to the session's log file."""
+        """Append text output to the session's log file.
+
+        ``file_paths`` is accepted for OutputHandler protocol compatibility
+        but not written into the log entry (the entry already captures the
+        text, which is the audit signal of interest).
+        """
         if not text:
             return
 
@@ -177,14 +186,20 @@ class TelegramRelayOutputHandler:
         chat_id: str,
         text: str,
         session: Any,
+        file_paths: list[str] | None = None,
     ) -> None:
         """Queue an email reply on ``email:outbox:{session_id}``.
 
-        Builds a payload matching ``tools/send_message.py::_send_via_email``
-        and the unified shape consumed by ``bridge/email_relay.py``. Subject
-        is prefixed with ``"Re: "`` if the original subject does not already
-        start with ``re:`` (case-insensitive); ``in_reply_to`` and
-        ``references`` are sourced from ``extra_context.email_message_id``.
+        Builds a payload matching the unified shape consumed by
+        ``bridge/email_relay.py``. Subject is prefixed with ``"Re: "`` if the
+        original subject does not already start with ``re:`` (case-insensitive);
+        ``in_reply_to`` and ``references`` are sourced from
+        ``extra_context.email_message_id``. The ``to`` field is built as a
+        reply-all list combining the primary recipient (``chat_id``), the
+        session's stamped ``email_to_addrs``, and ``email_cc_addrs`` -- minus
+        the bridge's own SMTP user (mirrors the filter applied by
+        ``bridge/email_bridge.py::EmailOutputHandler.send`` so the silent and
+        CLI paths produce identical envelopes).
 
         Implements the user-set design rule (2026-04-30): when a session was
         spawned via the email bridge, the default Stop-drafter reply must
@@ -192,6 +207,16 @@ class TelegramRelayOutputHandler:
         handler is registered. This handler is the worker's catch-all default;
         without this branch, email-spawned sessions silently misroute to
         telegram and the SMTP relay never sees them.
+
+        Args:
+            chat_id: The primary recipient address (sender of the original
+                inbound message).
+            text: Drafted body text. Caller must have already routed through
+                the drafter/redundancy/RTR pipeline; this helper only writes.
+            session: AgentSession carrying ``extra_context`` with the email
+                threading metadata.
+            file_paths: Optional list of attachment paths to forward to the
+                relay (consumed as ``attachments`` by ``email_relay.py``).
         """
         session_id = getattr(session, "session_id", None) or chat_id
 
@@ -201,6 +226,8 @@ class TelegramRelayOutputHandler:
         extra = getattr(session, "extra_context", None) or {}
         original_subject = extra.get("email_subject") or ""
         in_reply_to = extra.get("email_message_id") or None
+        original_to = extra.get("email_to_addrs") or []
+        original_cc = extra.get("email_cc_addrs") or []
 
         # Subject prefixing: match bridge/email_bridge.py::_build_reply_mime
         # worker-reply semantics — always prepend "Re: " unless the subject
@@ -214,12 +241,38 @@ class TelegramRelayOutputHandler:
         else:
             subject = "Re: (no subject)"
 
+        # Build the reply-all recipient list. Mirrors the filter in
+        # bridge/email_bridge.py::EmailOutputHandler.send (lines ~591-598):
+        # primary recipient first, then everyone from To/CC except the SMTP
+        # user (our own address) and the primary recipient (dedupe).
+        own_addr = os.environ.get("SMTP_USER", "").lower()
+        primary_lower = (chat_id or "").lower()
+        reply_all = [chat_id] + [
+            a
+            for a in (list(original_to) + list(original_cc))
+            if isinstance(a, str)
+            and a.lower() != own_addr
+            and a.lower() != primary_lower
+        ]
+        # Deduplicate while preserving order in case the bridge stamped the
+        # same address twice across To and CC.
+        seen: set[str] = set()
+        to_field: list[str] = []
+        for a in reply_all:
+            if not a:
+                continue
+            key = a.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            to_field.append(a)
+
         payload = {
             "session_id": session_id,
-            "to": chat_id,
+            "to": to_field,
             "subject": subject,
             "body": text,
-            "attachments": [],
+            "attachments": list(file_paths or []),
             "in_reply_to": in_reply_to,
             "references": in_reply_to,
             "from_addr": os.environ.get("SMTP_USER", ""),
@@ -232,10 +285,11 @@ class TelegramRelayOutputHandler:
             r.rpush(queue_key, json.dumps(payload))
             r.expire(queue_key, self.OUTBOX_TTL)
             logger.info(
-                "Queued email output to %s (%d chars, to=%s, in_reply_to=%s)",
+                "Queued email output to %s (%d chars, to=%s, attachments=%d, in_reply_to=%s)",
                 queue_key,
                 len(text),
-                chat_id,
+                to_field,
+                len(payload["attachments"]),
                 bool(in_reply_to),
             )
         except Exception as e:
@@ -252,6 +306,7 @@ class TelegramRelayOutputHandler:
         text: str,
         reply_to_msg_id: int,
         session: Any = None,
+        file_paths: list[str] | None = None,
     ) -> None:
         """Write a message payload to the Redis outbox.
 
@@ -263,12 +318,24 @@ class TelegramRelayOutputHandler:
               {"chat_id", "reply_to", "text", "session_id", "timestamp"}
 
           Written to ``telegram:outbox:{session_id}``.
-        - ``email``: payload matches ``tools/send_message.py::_send_via_email``
-          and ``bridge/email_relay.py``'s expected schema. Written to
-          ``email:outbox:{session_id}``. This implements the "default reply
-          follows spawning bridge" rule (user decision 2026-04-30): a session
-          spawned via the email bridge replies via email by default, even if
-          this handler is registered as the project's catch-all.
+        - ``email``: payload matches the unified shape consumed by
+          ``bridge/email_relay.py``. Written to ``email:outbox:{session_id}``.
+          This implements the "default reply follows spawning bridge" rule
+          (user decision 2026-04-30): a session spawned via the email bridge
+          replies via email by default, even if this handler is registered as
+          the project's catch-all.
+
+        **Filters layered on every send** (single canonical entrypoint for
+        both silent worker paths and CLI ``tools/send_message.py`` callers):
+
+            drafter → redundancy filter → read-the-room → narration fallback
+            → outbox rpush
+
+        The drafter runs ONCE at the top of ``send()``, before the transport
+        branch, so telegram and email both receive identically-drafted text.
+        RTR-suppressed and redundancy-suppressed payloads bypass the outbox
+        entirely; the full payload (text + ``file_paths``) is dropped together
+        so no attachment ever queues without its accompanying text.
 
         Args:
             chat_id: Target chat identifier (Telegram chat_id or recipient
@@ -278,36 +345,35 @@ class TelegramRelayOutputHandler:
                 Ignored for email transport.
             session: Optional AgentSession providing ``session_id`` and
                 ``extra_context`` (transport, email_message_id, etc.).
+            file_paths: Optional list of attachment file paths supplied by a
+                CLI caller (``tools/send_message.py``). Merged with any
+                drafter overflow file (CLI paths first, drafter overflow
+                appended; duplicates removed preserving order).
         """
         if not text:
             return
 
-        # Transport-aware routing: redirect email-spawned sessions to the
-        # email outbox. Default (no transport key, or any non-email value) is
-        # telegram, preserving back-compat with older sessions.
         transport = self._resolve_transport(session)
-        if transport == "email":
-            await self._send_via_email_outbox(chat_id, text, session)
-            return
-
         session_id = getattr(session, "session_id", None) or chat_id
         reply_to = int(reply_to_msg_id) if reply_to_msg_id else None
 
-        # Run the drafter in-process BEFORE writing to the outbox. This is the
-        # critical fix from docs/plans/message-drafter.md §Part C — it closes
-        # the worker-bypass gap where the worker's send_cb path wrote raw text
-        # straight to Redis and bypassed all length/format compliance.
+        # ── Drafter (hoisted: runs ONCE for both telegram and email) ──────
+        # Single call site for the drafter so both transports receive
+        # identically-normalized text. Drafter errors fall through to raw
+        # text via the inner try/except — drafter is a guard, never a
+        # blocker. See docs/plans/completed/message-drafter.md §Part C.
         delivery_text = text
-        file_paths: list[str] | None = None
+        drafter_overflow_file: str | None = None
         steering_deferred = False
         draft = None  # initialized before try so it is always defined for the redundancy filter
+        drafter_medium = "email" if transport == "email" else "telegram"
         try:
             from bridge.message_drafter import draft_message
 
             draft = await draft_message(
                 text,
                 session=session,
-                medium="telegram",
+                medium=drafter_medium,
             )
             # If the drafter produced a drafted result, use its text. When
             # was_drafted is False (short output or empty), keep the original
@@ -315,7 +381,7 @@ class TelegramRelayOutputHandler:
             if draft.text:
                 delivery_text = draft.text
             if draft.full_output_file is not None:
-                file_paths = [str(draft.full_output_file)]
+                drafter_overflow_file = str(draft.full_output_file)
 
             # ── Self-draft fallback via session steering ──
             # When all drafter backends fail (needs_self_draft=True), inject
@@ -432,6 +498,13 @@ class TelegramRelayOutputHandler:
                         jaccard=_redund_verdict.jaccard,
                         matched_prior_preview=_matched_prior_preview,
                     )
+                    if transport == "email":
+                        # Email has no reaction concept and no "anchor" — a
+                        # redundant payload is dropped entirely. No outbox
+                        # write; the dual-write file log still records it.
+                        if self._file_handler is not None:
+                            await self._file_handler.send(chat_id, text, 0, session)
+                        return
                     if reply_to_msg_id is not None:
                         self._rtr_queue_reaction(
                             chat_id, reply_to_msg_id, _REDUND_EMOJI, session_id
@@ -485,6 +558,12 @@ class TelegramRelayOutputHandler:
                         revised_text=verdict.revised_text,
                         reason="trim_too_short",
                     )
+                    if transport == "email":
+                        # Email: drop the payload entirely. No reaction, no
+                        # outbox write.
+                        if self._file_handler is not None:
+                            await self._file_handler.send(chat_id, text, 0, session)
+                        return
                     if reply_to_msg_id is not None:
                         self._rtr_queue_reaction(
                             chat_id, reply_to_msg_id, RTR_SUPPRESS_EMOJI, session_id
@@ -521,6 +600,12 @@ class TelegramRelayOutputHandler:
                     draft_text=delivery_text,
                     reason=verdict.reason or "suppress",
                 )
+                if transport == "email":
+                    # Email: drop the payload entirely. No reaction, no
+                    # outbox write.
+                    if self._file_handler is not None:
+                        await self._file_handler.send(chat_id, text, 0, session)
+                    return
                 if reply_to_msg_id is not None:
                     self._rtr_queue_reaction(
                         chat_id, reply_to_msg_id, RTR_SUPPRESS_EMOJI, session_id
@@ -551,6 +636,32 @@ class TelegramRelayOutputHandler:
                 rtr_err,
             )
 
+        # ── Merge CLI-supplied file_paths with the drafter overflow file ─
+        # Precedence: CLI-supplied paths first, drafter overflow appended.
+        # Deduplicate while preserving order (a CLI caller may have passed
+        # the same overflow path the drafter just produced).
+        merged_paths: list[str] = []
+        _seen_paths: set[str] = set()
+        for fp in (file_paths or []) + (
+            [drafter_overflow_file] if drafter_overflow_file else []
+        ):
+            if not fp or fp in _seen_paths:
+                continue
+            _seen_paths.add(fp)
+            merged_paths.append(fp)
+        effective_file_paths: list[str] | None = merged_paths or None
+
+        # ── Transport branch: email vs telegram outbox ────────────────────
+        # The drafter, redundancy filter, and RTR all ran ABOVE this branch
+        # so both transports receive identically-processed text and
+        # attachments. The email helper builds its own payload shape; the
+        # telegram outbox write happens inline below.
+        if transport == "email":
+            await self._send_via_email_outbox(
+                chat_id, delivery_text, session, file_paths=effective_file_paths
+            )
+            return
+
         payload: dict[str, Any] = {
             "chat_id": chat_id,
             "reply_to": reply_to,
@@ -558,8 +669,8 @@ class TelegramRelayOutputHandler:
             "session_id": session_id,
             "timestamp": time.time(),
         }
-        if file_paths:
-            payload["file_paths"] = file_paths
+        if effective_file_paths:
+            payload["file_paths"] = effective_file_paths
 
         queue_key = f"telegram:outbox:{session_id}"
         _rpush_succeeded = False
@@ -572,7 +683,7 @@ class TelegramRelayOutputHandler:
                 "Queued output to %s (%d chars, files=%d)",
                 queue_key,
                 len(delivery_text),
-                len(file_paths or []),
+                len(effective_file_paths or []),
             )
         except Exception as e:
             logger.error(f"Failed to write to Redis outbox {queue_key}: {e}")

--- a/agent/output_handler.py
+++ b/agent/output_handler.py
@@ -250,9 +250,7 @@ class TelegramRelayOutputHandler:
         reply_all = [chat_id] + [
             a
             for a in (list(original_to) + list(original_cc))
-            if isinstance(a, str)
-            and a.lower() != own_addr
-            and a.lower() != primary_lower
+            if isinstance(a, str) and a.lower() != own_addr and a.lower() != primary_lower
         ]
         # Deduplicate while preserving order in case the bridge stamped the
         # same address twice across To and CC.
@@ -642,9 +640,7 @@ class TelegramRelayOutputHandler:
         # the same overflow path the drafter just produced).
         merged_paths: list[str] = []
         _seen_paths: set[str] = set()
-        for fp in (file_paths or []) + (
-            [drafter_overflow_file] if drafter_overflow_file else []
-        ):
+        for fp in (file_paths or []) + ([drafter_overflow_file] if drafter_overflow_file else []):
             if not fp or fp in _seen_paths:
                 continue
             _seen_paths.add(fp)

--- a/docs/features/agent-message-delivery.md
+++ b/docs/features/agent-message-delivery.md
@@ -26,7 +26,7 @@ When a user-triggered session tries to stop:
 2. **Agent acts** — the agent invokes a delivery tool (`tools/send_message.py`, `tools/react_with_emoji.py`), stops silently, or continues working. There is no string-menu protocol — the agent's choice is the tool call itself.
 3. **Second stop** — the hook inspects the transcript tail for `tool_use` blocks via `classify_delivery_outcome()`, classifies the outcome (send / react / silent / continue), and either allows completion or re-blocks with a "resume work" prompt for `continue`.
 
-The hook does **not** write a `delivery_action` or `delivery_text` field to the `AgentSession` — delivery is driven entirely by the tool call the agent makes during the second stop. Tool-call payloads route through `TelegramRelayOutputHandler.send` (or `EmailOutputHandler.send`) which always runs the drafter before the outbox write.
+The hook does **not** write a `delivery_action` or `delivery_text` field to the `AgentSession` — delivery is driven entirely by the tool call the agent makes during the second stop. Tool-call payloads route through `TelegramRelayOutputHandler.send` — the single canonical queue-side handler for both telegram and email transports. The handler runs the drafter once before the transport branch, so both outbox writes inherit the same drafter / redundancy filter / read-the-room / narration-fallback pipeline. See [Filters layered on every send](#filters-layered-on-every-send).
 
 ### Activation Rules
 
@@ -36,6 +36,8 @@ The review gate only fires when:
 - Session has non-empty transcript output
 
 Skipped for: subagent sessions, programmatic sessions, and any session without one of the transport env vars above.
+
+**`VALOR_TRANSPORT` accepted values:** `telegram` or `email` (case-insensitive). When set, it overrides the inferred transport (which otherwise picks `email` if `EMAIL_REPLY_TO` is set, else `telegram` when `TELEGRAM_CHAT_ID` is set). Any other value is rejected by the tool with a non-zero exit.
 
 ### False Stop Detection
 
@@ -47,12 +49,30 @@ Post-#1072 the stop hook does not write delivery fields to the `AgentSession`. T
 
 | Classified outcome | Agent action that produces it | Effect |
 |--------------------|-------------------------------|--------|
-| `send` | Invoked `python tools/send_message.py "<text>"` (the draft as-is, or a revised text — both classify the same) — also matches the legacy `tools/send_telegram.py` for the PM self-messaging path | Payload flows through `TelegramRelayOutputHandler.send` (or `EmailOutputHandler.send`), which always routes through `bridge.message_drafter.draft_message` before the outbox write |
+| `send` | Invoked `python tools/send_message.py "<text>"` (the draft as-is, or a revised text — both classify the same) — also matches the legacy `tools/send_telegram.py` for the PM self-messaging path | Payload flows through `TelegramRelayOutputHandler.send` (single canonical handler for both telegram and email), which routes through `bridge.message_drafter.draft_message` exactly once before the outbox write |
 | `react` | Invoked `python tools/react_with_emoji.py "<feeling>"` | Telegram reaction is set on the original message; no text sent |
 | `silent` | Stopped without any tool invocation | Session completes with no output |
 | `continue` | Other `tool_use` activity present (still working) | Hook re-blocks with a "resume work" prompt; review state is reset so the next stop re-enters the gate |
 
-The canonical drafter entry point is `TelegramRelayOutputHandler.send` (for Telegram) and `EmailOutputHandler.send` (for email). Both run the drafter unconditionally, with a `try/except` fallback to raw text on drafter failure. See [message-drafter.md](message-drafter.md) for drafter details.
+The canonical drafter entry point is `TelegramRelayOutputHandler.send`. Despite the type name, it is the single canonical queue-side entrypoint for both telegram and email transports — the handler hoists the drafter to a single call site above the transport branch, so the email outbox write inherits identically-drafted text without a second drafter call. Drafter failures fall through to raw text via a `try/except`; the relay length guard catches oversize payloads as a last line of defense. See [message-drafter.md](message-drafter.md) for drafter details.
+
+The synchronous SMTP path in `bridge/email_bridge.py::EmailOutputHandler.send` continues to exist for the silent worker registration on email-routing projects (`worker/__main__.py`). The CLI tool (`tools/send_message.py`) never imports `EmailOutputHandler`; the SMTP layer is the wrong abstraction for a queue-only writer.
+
+### Filters layered on every send
+
+Both the silent worker path and the CLI tool-call path (`tools/send_message.py`) reach `TelegramRelayOutputHandler.send`, which runs these filters in order on every invocation:
+
+1. **Drafter** (`bridge.message_drafter.draft_message`) — per-medium length / format compliance. Runs once, before the transport branch, with `medium="telegram"` or `medium="email"` based on `extra_context.transport`.
+2. **Redundancy filter** ([`bridge/redundancy_filter.py`](../../bridge/redundancy_filter.py)) — deterministic bigram-Jaccard guard for SDLC sessions, compares the drafted text against `session.recent_sent_drafts`. On `suppress` the payload is dropped; for telegram the handler queues a 👀 reaction on the anchor message.
+3. **Read-the-Room** ([`bridge/read_the_room.py`](../../bridge/read_the_room.py)) — Haiku-judged appropriateness gate (`READ_THE_ROOM_ENABLED`). Returns `send` | `trim` | `suppress`; on `suppress` for telegram the handler queues a 👀 reaction and skips the outbox.
+4. **Narration fallback** — when the drafter fails AND self-draft steering is unavailable, the handler substitutes a fixed message rather than emitting pure process narration.
+5. **Outbox rpush** — `telegram:outbox:{session_id}` or `email:outbox:{session_id}` (the latter carries a reply-all `to` list).
+
+For email sessions, suppression (RTR or redundancy) drops the payload entirely with no reaction — email has no equivalent reaction mechanism. The CLI tool's promise gate runs **before** the handler call (gate → linkify → handler-drafter → handler-filters → outbox) so a session with an outstanding promise short-circuits without paying the Haiku / Popoto / Redis cost.
+
+### Diagnostic fallback: `ALLOW_LEGACY_RPUSH_FALLBACK`
+
+When the CLI tool cannot reconstitute its `AgentSession` from Popoto (race, dev environment, or misconfiguration), the **default behavior is fail-closed** — the tool exits non-zero so the harness sees the failure. Setting `ALLOW_LEGACY_RPUSH_FALLBACK=1` opts into a legacy raw-rpush path that bypasses the canonical handler (no drafter, no RTR, no redundancy filter) and logs a warning. This is intended for short-lived diagnostic use only; never set in production worker env.
 
 ## Classification Context (`agent/sdk_client.py`)
 
@@ -71,10 +91,10 @@ The Teammate persona prompt includes a DELIVERY REVIEW section explaining the ch
 ## Test Coverage
 
 - `tests/unit/test_stop_hook_review.py` — Review gate activation, transcript reading, false stop detection, choice parsing, state management, integration tests
-- `tests/unit/test_tool_call_delivery.py` — `classify_delivery_outcome`'s send/react/continue/silent outcomes (plus the legacy `send_telegram` alias) and the second-stop tool-call review-gate flow
+- `tests/unit/test_tool_call_delivery.py` — `classify_delivery_outcome`'s send/react/continue/silent outcomes (plus the legacy `send_telegram` alias), the second-stop tool-call review-gate flow, and the tool → canonical-handler routing assertions for both transports
 - `tests/unit/test_duplicate_delivery.py` — Duplicate-delivery prevention: catchup Redis dedup checks and auto-continue skips for completed sessions
 - `tests/unit/test_qa_handler.py` — Teammate prompt humility markers, review gate awareness
-- `tests/e2e/test_message_pipeline.py` — Bool classifier assertions
+- `tests/unit/test_output_handler.py` — `TestDrafterHoistedAboveTransport`: the drafter is invoked exactly once for both telegram and email sessions; email payload carries the reply-all `to` list; CLI-supplied file paths propagate to both outboxes
 
 ## Related
 

--- a/docs/features/bridge-worker-architecture.md
+++ b/docs/features/bridge-worker-architecture.md
@@ -78,7 +78,7 @@ Defined in `agent/output_handler.py`. Implements the `OutputHandler` protocol.
 | Redis key (telegram) | `telegram:outbox:{session_id}` |
 | Redis key (email) | `email:outbox:{session_id}` (when `extra_context.transport == "email"`) |
 | Telegram payload | `{"chat_id", "reply_to", "text", "session_id", "timestamp"}` -- same as `tools/send_telegram.py` |
-| Email payload | `{"session_id", "to", "subject", "body", "in_reply_to", "references", "from_addr", "attachments", "timestamp"}` -- matches `tools/send_message.py::_send_via_email` and the `email_relay.py` contract (see [Email Bridge](email-bridge.md) "Send path"). The handler reads `email_subject`, `email_message_id`, `email_from` from `session.extra_context` to populate `subject`, `in_reply_to`, and `to`. |
+| Email payload | `{"session_id", "to", "subject", "body", "in_reply_to", "references", "from_addr", "attachments", "timestamp"}` -- the unified shape consumed by `bridge/email_relay.py` (see [Email Bridge](email-bridge.md) "Send path"). The handler reads `email_subject`, `email_message_id`, `email_to_addrs`, `email_cc_addrs` from `session.extra_context` to populate `subject`, `in_reply_to`, and the reply-all `to` list. `tools/send_message.py::_send_via_email` delegates to this handler rather than emitting its own payload (issue #1369). |
 | TTL | 3600 seconds (1 hour) |
 | Redis operation | `RPUSH` (append to list) + `EXPIRE` |
 | Error handling | Caught and logged; never propagates to caller |

--- a/docs/features/email-bridge.md
+++ b/docs/features/email-bridge.md
@@ -332,7 +332,7 @@ Sends write the **unified outbox payload** to `email:outbox:{session_id}` with a
 }
 ```
 
-The `session_id` format (`cli-{secs}-{pid}-{token_hex(4)}`) gives 32 bits of per-call randomness so concurrent invocations in the same second collide effectively never. `tools/send_message.py::_send_via_email` emits the same shape so the relay has a single contract to drain. The `"to"` field is canonically `list[str]`; the relay's `_normalize_payload()` also accepts a single comma-separated string and splits it into `list[str]`.
+The `session_id` format (`cli-{secs}-{pid}-{token_hex(4)}`) gives 32 bits of per-call randomness so concurrent invocations in the same second collide effectively never. `tools/send_message.py::_send_via_email` reconstitutes the `AgentSession` from `VALOR_SESSION_ID` and delegates to `agent.output_handler.TelegramRelayOutputHandler.send`, which then writes through `_send_via_email_outbox` — so the outbox payload shape is emitted from the handler, not the tool. The relay has a single contract to drain. The `"to"` field is canonically `list[str]`; the relay's `_normalize_payload()` also accepts a single comma-separated string and splits it into `list[str]`.
 
 The relay (`bridge/email_relay.py`) polls `email:outbox:*` every 100 ms. For each key it performs atomic `LPOP`, builds the MIME message via `_build_reply_mime()` (switching to `MIMEMultipart` when attachments are present), and dispatches over SMTP in `asyncio.to_thread`. On failure it increments `_relay_attempts`, `RPUSH`es back, and DLQs via `bridge.email_dead_letter.write_dead_letter()` after `MAX_EMAIL_RELAY_RETRIES` (default 3) attempts. The relay writes `email:relay:last_poll_ts` once per cycle (5-minute TTL) for operator liveness probes.
 

--- a/docs/features/message-drafter.md
+++ b/docs/features/message-drafter.md
@@ -149,7 +149,7 @@ This work is staged in follow-up tasks (9 and 11 in the plan).
 
 The agent delivers user-visible messages and reactions via two CLI tools invoked through the `Bash` tool, not through a dedicated MCP server:
 
-- `tools/send_message.py '<text>'` — primary delivery tool. Writes the payload to the same Redis outbox consumed by `bridge/telegram_relay.py`. Handles `--reply-to <msg_id>` and `--file <path>` flags for threaded replies and attachments.
+- `tools/send_message.py '<text>'` — primary delivery tool. Reconstitutes the `AgentSession` from `VALOR_SESSION_ID` and delegates to `agent.output_handler.TelegramRelayOutputHandler.send` for both telegram and email transports, so the drafter / redundancy filter / read-the-room gate run identically on the tool-call path and the silent-worker path. Handles `--reply-to <msg_id>` and `--file <path>` flags for threaded replies and attachments. Fail-closed on missing session; `ALLOW_LEGACY_RPUSH_FALLBACK=1` opts into a diagnostic-only legacy raw rpush.
 - `tools/react_with_emoji.py '<emoji>'` — posts a reaction emoji on the triggering message. Used for lightweight acknowledgements ("thumbs up, done") when a full text response would be noise.
 
 The stop hook classifies each turn's outcome by scanning `tool_use` blocks for these exact script paths (`agent/hooks/stop.py::classify_delivery_outcome`). Matches produce one of the five outcomes (send, edit+send, react, silent, continue).

--- a/docs/plans/agent-message-delivery-tool-call-routing.md
+++ b/docs/plans/agent-message-delivery-tool-call-routing.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: docs_complete
 type: bug
 appetite: Medium
 owner: Valor Engels

--- a/tests/unit/test_output_handler.py
+++ b/tests/unit/test_output_handler.py
@@ -1127,8 +1127,11 @@ class TestTransportAwareRouting:
 
         payload = json.loads(handler._redis.rpush.call_args[0][1])
         # Match the unified email payload schema from bridge/email_relay.py.
+        # The handler emits ``to`` as a list to carry the reply-all recipient
+        # set (primary + To/CC minus self). With no extra recipients stamped
+        # on the session, the list collapses to just the primary recipient.
         assert payload["session_id"] == "email-sess"
-        assert payload["to"] == "customer@example.com"
+        assert payload["to"] == ["customer@example.com"]
         # Subject prefixed with "Re:" (worker-reply semantics).
         assert payload["subject"] == "Re: My setup question"
         assert payload["body"] == "Here is the answer."
@@ -1222,13 +1225,11 @@ class TestTransportAwareRouting:
             else:
                 _os.environ["READ_THE_ROOM_ENABLED"] = old_rtr
 
-        # Exactly one rpush — the email message itself. No reaction.
-        assert handler._redis.rpush.call_count == 1
-        key = handler._redis.rpush.call_args[0][0]
-        assert key.startswith("email:outbox:"), f"Expected email outbox write, got {key}"
-        payload = json.loads(handler._redis.rpush.call_args[0][1])
-        assert payload.get("type") != "reaction"
-        assert "body" in payload  # email-shaped, not reaction-shaped
+        # Per the unified-handler contract: when RTR suppresses on an email
+        # session, the payload is dropped entirely. Email has no reaction
+        # concept and the canonical pipeline now runs RTR for both transports,
+        # so an email suppression is fully silent (zero rpush, zero reaction).
+        assert handler._redis.rpush.call_count == 0
 
     def test_send_with_empty_text_for_email_is_noop(self):
         """Empty text on an email session must NOT queue an empty email."""

--- a/tests/unit/test_output_handler.py
+++ b/tests/unit/test_output_handler.py
@@ -1659,3 +1659,216 @@ class TestRedundancyFilterWiring:
         assert ev["matched_prior_preview"] == "previous status message here", (
             "matched_prior_preview must be the text of the matched prior draft"
         )
+
+
+class TestDrafterHoistedAboveTransport:
+    """Issue #1369: the drafter must run ONCE for both telegram and email
+    transports, before the transport branch. These tests confirm the hoist
+    and the email-side propagation (reply-all ``to`` list, attachments,
+    suppression-drops-payload contract)."""
+
+    def _make_handler(self):
+        h = TelegramRelayOutputHandler(redis_url="redis://localhost:6379/0")
+        h._redis = MagicMock()
+        return h
+
+    def _telegram_session(self, session_id="hoist-tg"):
+        s = MagicMock()
+        s.session_id = session_id
+        s.extra_context = {"transport": "telegram"}
+        s.is_sdlc = False
+        s.recent_sent_drafts = []
+        return s
+
+    def _email_session(
+        self,
+        session_id="hoist-email",
+        to_addrs=None,
+        cc_addrs=None,
+        subject="The thread",
+        message_id="<orig@example.com>",
+    ):
+        s = MagicMock()
+        s.session_id = session_id
+        s.extra_context = {
+            "transport": "email",
+            "email_subject": subject,
+            "email_message_id": message_id,
+            "email_to_addrs": to_addrs or [],
+            "email_cc_addrs": cc_addrs or [],
+        }
+        s.is_sdlc = False
+        s.recent_sent_drafts = []
+        return s
+
+    def test_drafter_called_once_for_telegram(self):
+        """A telegram send must invoke ``draft_message`` exactly once."""
+        handler = self._make_handler()
+        session = self._telegram_session()
+        draft_stub = MagicMock(
+            text="drafted telegram text",
+            full_output_file=None,
+            was_drafted=True,
+            artifacts={},
+            needs_self_draft=False,
+            expectations=None,
+            context_summary=None,
+        )
+
+        with patch(
+            "bridge.message_drafter.draft_message",
+            AsyncMock(return_value=draft_stub),
+        ) as mock_draft:
+            asyncio.run(handler.send("123", "raw text", 0, session=session))
+
+        assert mock_draft.await_count == 1
+        # Drafted text reached the outbox, not raw.
+        payload = json.loads(handler._redis.rpush.call_args[0][1])
+        assert payload["text"] == "drafted telegram text"
+
+    def test_drafter_called_once_for_email(self):
+        """An email send must invoke ``draft_message`` exactly once. This is
+        the regression that closes #1369: previously the email branch never
+        ran the drafter."""
+        handler = self._make_handler()
+        session = self._email_session()
+        draft_stub = MagicMock(
+            text="drafted email body",
+            full_output_file=None,
+            was_drafted=True,
+            artifacts={},
+            needs_self_draft=False,
+            expectations=None,
+            context_summary=None,
+        )
+
+        with patch(
+            "bridge.message_drafter.draft_message",
+            AsyncMock(return_value=draft_stub),
+        ) as mock_draft:
+            asyncio.run(handler.send("customer@example.com", "raw", 0, session=session))
+
+        assert mock_draft.await_count == 1
+        # The drafter ran with ``medium="email"`` so the per-medium format
+        # rules apply (no markdown on the wire for email).
+        assert mock_draft.await_args.kwargs["medium"] == "email"
+        # Drafted body landed in the email payload.
+        payload = json.loads(handler._redis.rpush.call_args[0][1])
+        assert payload["body"] == "drafted email body"
+
+    def test_email_payload_carries_reply_all_recipients(self):
+        """The email outbox payload's ``to`` field is a list combining the
+        primary recipient with ``extra_context.email_to_addrs`` and
+        ``email_cc_addrs``, minus the SMTP user (own address)."""
+        handler = self._make_handler()
+        session = self._email_session(
+            to_addrs=["primary@example.com", "team@example.com"],
+            cc_addrs=["watcher@example.com"],
+        )
+
+        import os as _os
+
+        old_smtp = _os.environ.get("SMTP_USER")
+        _os.environ["SMTP_USER"] = "bot@ourdomain.com"
+        try:
+            with patch(
+                "bridge.message_drafter.draft_message",
+                AsyncMock(side_effect=RuntimeError("skip drafter")),
+            ):
+                asyncio.run(
+                    handler.send(
+                        "primary@example.com",
+                        "reply body",
+                        0,
+                        session=session,
+                    )
+                )
+        finally:
+            if old_smtp is None:
+                _os.environ.pop("SMTP_USER", None)
+            else:
+                _os.environ["SMTP_USER"] = old_smtp
+
+        payload = json.loads(handler._redis.rpush.call_args[0][1])
+        # Primary first, then To/CC entries (dedup the primary; drop SMTP user).
+        assert payload["to"] == [
+            "primary@example.com",
+            "team@example.com",
+            "watcher@example.com",
+        ]
+
+    def test_email_payload_drops_own_smtp_user_from_reply_all(self):
+        """When the SMTP user appears in the original To/CC, it is filtered
+        out of the reply-all list (we don't reply to ourselves)."""
+        handler = self._make_handler()
+        session = self._email_session(
+            to_addrs=["bot@ourdomain.com", "team@example.com"],
+            cc_addrs=["bot@ourdomain.com"],
+        )
+
+        import os as _os
+
+        old_smtp = _os.environ.get("SMTP_USER")
+        _os.environ["SMTP_USER"] = "bot@ourdomain.com"
+        try:
+            with patch(
+                "bridge.message_drafter.draft_message",
+                AsyncMock(side_effect=RuntimeError("skip drafter")),
+            ):
+                asyncio.run(handler.send("customer@example.com", "body", 0, session=session))
+        finally:
+            if old_smtp is None:
+                _os.environ.pop("SMTP_USER", None)
+            else:
+                _os.environ["SMTP_USER"] = old_smtp
+
+        payload = json.loads(handler._redis.rpush.call_args[0][1])
+        # bot@ourdomain.com must NOT appear anywhere in the to list.
+        addrs_lower = [a.lower() for a in payload["to"]]
+        assert "bot@ourdomain.com" not in addrs_lower
+
+    def test_cli_file_paths_propagate_to_telegram_outbox(self):
+        """CLI-supplied ``file_paths`` are forwarded into the telegram outbox
+        payload (and merged with any drafter overflow file)."""
+        handler = self._make_handler()
+        session = self._telegram_session()
+
+        with patch(
+            "bridge.message_drafter.draft_message",
+            AsyncMock(side_effect=RuntimeError("skip drafter")),
+        ):
+            asyncio.run(
+                handler.send(
+                    "12345",
+                    "body",
+                    0,
+                    session=session,
+                    file_paths=["/tmp/a.png", "/tmp/b.txt"],
+                )
+            )
+
+        payload = json.loads(handler._redis.rpush.call_args[0][1])
+        assert payload["file_paths"] == ["/tmp/a.png", "/tmp/b.txt"]
+
+    def test_cli_file_paths_propagate_to_email_outbox(self):
+        """CLI-supplied ``file_paths`` are forwarded into the email outbox
+        payload as ``attachments`` (the relay's expected key)."""
+        handler = self._make_handler()
+        session = self._email_session()
+
+        with patch(
+            "bridge.message_drafter.draft_message",
+            AsyncMock(side_effect=RuntimeError("skip drafter")),
+        ):
+            asyncio.run(
+                handler.send(
+                    "customer@example.com",
+                    "see attached",
+                    0,
+                    session=session,
+                    file_paths=["/tmp/report.pdf"],
+                )
+            )
+
+        payload = json.loads(handler._redis.rpush.call_args[0][1])
+        assert payload["attachments"] == ["/tmp/report.pdf"]

--- a/tests/unit/test_send_message.py
+++ b/tests/unit/test_send_message.py
@@ -101,9 +101,7 @@ class TestSendViaEmail:
         monkeypatch.setattr(sm, "_lookup_session", lambda sid: fake_session)
 
         mock_send = AsyncMock(return_value=None)
-        with patch(
-            "agent.output_handler.TelegramRelayOutputHandler.send", new=mock_send
-        ):
+        with patch("agent.output_handler.TelegramRelayOutputHandler.send", new=mock_send):
             sm._send_via_email("Body text here")
 
         mock_send.assert_awaited_once()

--- a/tests/unit/test_send_message.py
+++ b/tests/unit/test_send_message.py
@@ -64,42 +64,110 @@ class TestResolveTransport:
 
 
 class TestSendViaEmail:
-    def test_unified_payload_shape(self, r, monkeypatch, capsys):
-        from tools.send_message import _send_via_email
+    """Issue #1369: ``_send_via_email`` no longer writes to the email outbox
+    directly — it reconstitutes the AgentSession and delegates to
+    ``TelegramRelayOutputHandler.send``, which owns the email outbox write.
+
+    The unified email payload SHAPE is now asserted at the handler layer in
+    ``tests/unit/test_output_handler.py`` (``TestTransportAwareRouting`` /
+    ``TestDrafterHoistedAboveTransport``). The tests below assert the
+    CLI-side contract: env validation, session lookup, fail-closed default
+    on missing session, and the env-gated legacy fallback.
+    """
+
+    def test_invokes_canonical_handler_with_email_session(self, monkeypatch):
+        """Happy path: when the session exists, the tool delegates to
+        ``TelegramRelayOutputHandler.send`` with the recipient address as
+        chat_id and ``reply_to_msg_id=0``."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import tools.send_message as sm
 
         monkeypatch.setenv("VALOR_SESSION_ID", "sess-1")
         monkeypatch.setenv("EMAIL_REPLY_TO", "alice@example.com")
         monkeypatch.setenv("EMAIL_SUBJECT", "Re: hi")
         monkeypatch.setenv("EMAIL_IN_REPLY_TO", "<orig@x>")
+        monkeypatch.delenv("ALLOW_LEGACY_RPUSH_FALLBACK", raising=False)
+
+        fake_session = MagicMock()
+        fake_session.session_id = "sess-1"
+        fake_session.extra_context = {
+            "transport": "email",
+            "email_subject": "Re: hi",
+            "email_message_id": "<orig@x>",
+            "email_to_addrs": [],
+            "email_cc_addrs": [],
+        }
+        monkeypatch.setattr(sm, "_lookup_session", lambda sid: fake_session)
+
+        mock_send = AsyncMock(return_value=None)
+        with patch(
+            "agent.output_handler.TelegramRelayOutputHandler.send", new=mock_send
+        ):
+            sm._send_via_email("Body text here")
+
+        mock_send.assert_awaited_once()
+        positional = list(mock_send.call_args.args)
+        assert "alice@example.com" in positional
+        assert "Body text here" in positional
+        assert 0 in positional  # reply_to_msg_id sentinel for email
+        assert mock_send.call_args.kwargs["session"] is fake_session
+
+    def test_missing_session_fails_closed(self, monkeypatch):
+        """Default behavior when the AgentSession lookup returns ``None``:
+        non-zero exit (the tool refuses to silently bypass the handler)."""
+        import tools.send_message as sm
+
+        monkeypatch.setenv("VALOR_SESSION_ID", "sess-missing")
+        monkeypatch.setenv("EMAIL_REPLY_TO", "alice@example.com")
+        monkeypatch.delenv("ALLOW_LEGACY_RPUSH_FALLBACK", raising=False)
+        monkeypatch.setattr(sm, "_lookup_session", lambda sid: None)
+
+        with pytest.raises(SystemExit) as ei:
+            sm._send_via_email("hi")
+        assert ei.value.code == 1
+
+    def test_legacy_fallback_writes_unified_payload(self, r, monkeypatch):
+        """When ``ALLOW_LEGACY_RPUSH_FALLBACK=1`` AND the session is missing,
+        the tool writes the unified payload shape directly to
+        ``email:outbox:{session_id}``. This is the diagnostic opt-in path
+        — the tests below assert the legacy payload contract still holds."""
+        from tools.send_message import _send_via_email
+
+        monkeypatch.setenv("VALOR_SESSION_ID", "sess-legacy")
+        monkeypatch.setenv("EMAIL_REPLY_TO", "alice@example.com")
+        monkeypatch.setenv("EMAIL_SUBJECT", "Re: hi")
+        monkeypatch.setenv("EMAIL_IN_REPLY_TO", "<orig@x>")
+        monkeypatch.setenv("ALLOW_LEGACY_RPUSH_FALLBACK", "1")
+        # Force the lookup to fail so the legacy path engages.
+        monkeypatch.setattr("tools.send_message._lookup_session", lambda sid: None)
 
         _send_via_email("Body text here")
 
-        key = "email:outbox:sess-1"
-        raw = r.lpop(key)
+        raw = r.lpop("email:outbox:sess-legacy")
         assert raw is not None
         payload = json.loads(raw)
-
-        assert payload["session_id"] == "sess-1"
+        assert payload["session_id"] == "sess-legacy"
         assert payload["to"] == "alice@example.com"
         assert payload["subject"] == "Re: hi"
-        # Body field is the unified shape; legacy `text` is not emitted anymore
         assert payload["body"] == "Body text here"
-        assert "text" not in payload
         assert payload["attachments"] == []
         assert payload["in_reply_to"] == "<orig@x>"
         assert payload["references"] == "<orig@x>"
         assert payload["from_addr"] == "valor@test.local"
-        assert isinstance(payload["timestamp"], float)
 
-    def test_ttl_set_on_queue(self, r, monkeypatch):
+    def test_legacy_fallback_ttl_set_on_queue(self, r, monkeypatch):
+        """The legacy fallback still applies the 3600s TTL to the outbox key."""
         from tools.send_message import _send_via_email
 
-        monkeypatch.setenv("VALOR_SESSION_ID", "sess-2")
+        monkeypatch.setenv("VALOR_SESSION_ID", "sess-legacy-ttl")
         monkeypatch.setenv("EMAIL_REPLY_TO", "alice@example.com")
+        monkeypatch.setenv("ALLOW_LEGACY_RPUSH_FALLBACK", "1")
+        monkeypatch.setattr("tools.send_message._lookup_session", lambda sid: None)
 
         _send_via_email("hi")
 
-        ttl = r.ttl("email:outbox:sess-2")
+        ttl = r.ttl("email:outbox:sess-legacy-ttl")
         assert 0 < ttl <= 3600
 
     def test_missing_session_id_exits(self, monkeypatch):
@@ -122,16 +190,21 @@ class TestSendViaEmail:
             _send_via_email("hi")
         assert ei.value.code == 1
 
-    def test_missing_subject_defaults(self, r, monkeypatch):
+    def test_legacy_fallback_missing_subject_defaults(self, r, monkeypatch):
+        """Legacy fallback applies ``(no subject)`` when EMAIL_SUBJECT is
+        unset. The canonical path lets the handler's ``_send_via_email_outbox``
+        derive the subject from ``extra_context.email_subject`` instead."""
         from tools.send_message import _send_via_email
 
-        monkeypatch.setenv("VALOR_SESSION_ID", "sess-3")
+        monkeypatch.setenv("VALOR_SESSION_ID", "sess-legacy-nosubject")
         monkeypatch.setenv("EMAIL_REPLY_TO", "alice@example.com")
+        monkeypatch.setenv("ALLOW_LEGACY_RPUSH_FALLBACK", "1")
         monkeypatch.delenv("EMAIL_SUBJECT", raising=False)
         monkeypatch.delenv("EMAIL_IN_REPLY_TO", raising=False)
+        monkeypatch.setattr("tools.send_message._lookup_session", lambda sid: None)
 
         _send_via_email("hi")
-        payload = json.loads(r.lpop("email:outbox:sess-3"))
+        payload = json.loads(r.lpop("email:outbox:sess-legacy-nosubject"))
         assert payload["subject"] == "(no subject)"
         assert payload["in_reply_to"] is None
         assert payload["references"] is None

--- a/tests/unit/test_tool_call_delivery.py
+++ b/tests/unit/test_tool_call_delivery.py
@@ -230,3 +230,146 @@ class TestStopHookReviewGateFlow:
             assert session_id not in _review_state
         finally:
             os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# Tool -> canonical-handler routing (issue #1369)
+#
+# These tests assert that ``tools/send_message.py`` ALWAYS routes through
+# ``agent.output_handler.TelegramRelayOutputHandler.send`` for both telegram
+# and email transports — there must be exactly one canonical handler call
+# site, no raw rpush in the default tool path, and no import of the
+# synchronous SMTP ``EmailOutputHandler`` from the tool process.
+# ---------------------------------------------------------------------------
+
+
+class TestToolCallHandlerRouting:
+    """The tool process delegates to TelegramRelayOutputHandler.send for both
+    transports. Each test mocks the handler and asserts call arity + kwargs.
+    """
+
+    def _stub_session(self, monkeypatch, session=object()):
+        """Patch ``tools.send_message._lookup_session`` to return ``session``."""
+        import tools.send_message as sm
+
+        monkeypatch.setattr(sm, "_lookup_session", lambda sid: session)
+        # Bypass the promise gate; it's tested elsewhere.
+        from bridge import promise_gate
+
+        monkeypatch.setattr(promise_gate, "cli_check_or_exit", lambda *a, **kw: None)
+
+    def test_telegram_path_invokes_canonical_handler(self, monkeypatch):
+        """``_send_via_telegram`` must call TelegramRelayOutputHandler.send
+        exactly once with the chat_id, drafted text, reply-to int, the
+        reconstituted session, and the CLI-supplied file_paths."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import tools.send_message as sm
+
+        monkeypatch.setenv("TELEGRAM_CHAT_ID", "12345")
+        monkeypatch.setenv("TELEGRAM_REPLY_TO", "7")
+        monkeypatch.setenv("VALOR_SESSION_ID", "sess-tg")
+        monkeypatch.delenv("ALLOW_LEGACY_RPUSH_FALLBACK", raising=False)
+
+        fake_session = MagicMock()
+        fake_session.session_id = "sess-tg"
+        fake_session.extra_context = {"transport": "telegram"}
+        self._stub_session(monkeypatch, session=fake_session)
+
+        mock_send = AsyncMock(return_value=None)
+        with patch("agent.output_handler.TelegramRelayOutputHandler.send", new=mock_send):
+            sm._send_via_telegram("hello world", None)
+
+        mock_send.assert_awaited_once()
+        args, kwargs = mock_send.call_args
+        # When ``send`` is patched on the class, the bound-method call from
+        # the tool's handler instance descriptor-binds ``self`` AHEAD of
+        # AsyncMock, so call_args records (self, chat_id, text, reply_to_msg_id).
+        # Confirm by searching for the chat_id wherever it landed.
+        positional = list(args)
+        assert "12345" in positional, f"chat_id missing from args: {positional}"
+        assert "hello world" in positional, f"text missing from args: {positional}"
+        assert 7 in positional, f"reply_to_msg_id missing from args: {positional}"
+        assert kwargs["session"] is fake_session
+        assert kwargs.get("file_paths") is None
+
+    def test_email_path_invokes_same_canonical_handler(self, monkeypatch):
+        """``_send_via_email`` must call THE SAME handler class
+        (TelegramRelayOutputHandler.send) — NOT EmailOutputHandler.send.
+        This asserts the single-canonical-handler convergence."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import tools.send_message as sm
+
+        monkeypatch.setenv("VALOR_SESSION_ID", "sess-email")
+        monkeypatch.setenv("EMAIL_REPLY_TO", "customer@example.com")
+        monkeypatch.setenv("EMAIL_SUBJECT", "Re: hi")
+        monkeypatch.delenv("ALLOW_LEGACY_RPUSH_FALLBACK", raising=False)
+
+        fake_session = MagicMock()
+        fake_session.session_id = "sess-email"
+        fake_session.extra_context = {"transport": "email"}
+        self._stub_session(monkeypatch, session=fake_session)
+
+        mock_send = AsyncMock(return_value=None)
+        with patch("agent.output_handler.TelegramRelayOutputHandler.send", new=mock_send):
+            sm._send_via_email("hello via email", None)
+
+        mock_send.assert_awaited_once()
+        args, kwargs = mock_send.call_args
+        positional = list(args)
+        assert "customer@example.com" in positional, f"recipient missing from args: {positional}"
+        assert "hello via email" in positional, f"text missing from args: {positional}"
+        assert 0 in positional, f"reply_to_msg_id sentinel missing: {positional}"
+        assert kwargs["session"] is fake_session
+
+    def test_missing_session_fails_closed_by_default(self, monkeypatch):
+        """Missing AgentSession + ALLOW_LEGACY_RPUSH_FALLBACK unset must
+        cause a non-zero exit — the tool refuses to silently bypass the
+        canonical handler."""
+        import tools.send_message as sm
+
+        monkeypatch.setenv("TELEGRAM_CHAT_ID", "12345")
+        monkeypatch.setenv("VALOR_SESSION_ID", "missing-sess")
+        monkeypatch.delenv("ALLOW_LEGACY_RPUSH_FALLBACK", raising=False)
+        monkeypatch.setattr(sm, "_lookup_session", lambda sid: None)
+        from bridge import promise_gate
+
+        monkeypatch.setattr(promise_gate, "cli_check_or_exit", lambda *a, **kw: None)
+
+        with pytest.raises(SystemExit) as excinfo:
+            sm._send_via_telegram("hi", None)
+        assert excinfo.value.code != 0
+
+    def test_missing_session_with_fallback_flag_uses_raw_rpush(self, monkeypatch):
+        """Missing AgentSession + ALLOW_LEGACY_RPUSH_FALLBACK=1 must call the
+        legacy raw-rpush helper and exit 0 (diagnostic opt-in path)."""
+        from unittest.mock import patch
+
+        import tools.send_message as sm
+
+        monkeypatch.setenv("TELEGRAM_CHAT_ID", "12345")
+        monkeypatch.setenv("VALOR_SESSION_ID", "missing-sess")
+        monkeypatch.setenv("ALLOW_LEGACY_RPUSH_FALLBACK", "1")
+        monkeypatch.setattr(sm, "_lookup_session", lambda sid: None)
+        from bridge import promise_gate
+
+        monkeypatch.setattr(promise_gate, "cli_check_or_exit", lambda *a, **kw: None)
+
+        with patch.object(sm, "_legacy_telegram_rpush") as mock_legacy:
+            sm._send_via_telegram("hi", None)
+            mock_legacy.assert_called_once()
+
+    def test_tool_does_not_import_email_output_handler(self):
+        """Static guarantee: ``tools/send_message.py`` must NOT reference
+        EmailOutputHandler. The tool talks only to the queue-side handler;
+        importing the synchronous SMTP handler would couple it to the wrong
+        layer (per #1369 design decision)."""
+        from pathlib import Path
+
+        src = Path(__file__).resolve().parents[2] / "tools" / "send_message.py"
+        contents = src.read_text()
+        assert "EmailOutputHandler" not in contents, (
+            "tools/send_message.py must not reference EmailOutputHandler — "
+            "the canonical queue-side handler is TelegramRelayOutputHandler."
+        )

--- a/tools/send_message.py
+++ b/tools/send_message.py
@@ -1,39 +1,43 @@
 #!/usr/bin/env python3
 """Polymorphic send_message CLI — medium-agnostic message delivery.
 
-Introduced by the message-drafter refactor (plan #1035 Part E). Replaces the
-string-menu review gate with a prepopulated tool_call that the agent invokes
-to deliver its response.
+Routes the agent's tool-call deliveries through the SAME canonical handler
+(``agent.output_handler.TelegramRelayOutputHandler.send``) that the silent
+worker path uses. The handler hoists the drafter to a single call site above
+its transport branch, so both telegram and email writes inherit the full
+``drafter → redundancy filter → read-the-room → narration fallback → outbox``
+pipeline. The tool is a thin wrapper: it does the linkify pass, runs the
+promise gate, looks up the AgentSession, and delegates everything else.
 
-The tool routes by ``session.extra_context.transport``:
-- telegram (default): writes a payload to the Redis outbox (same shape as
-  tools/send_telegram.py). The bridge relay picks it up and delivers.
-- email: writes an ``email:outbox:{session_id}`` payload handled by the
-  EmailOutputHandler (future extension point; today the handler sends
-  directly from the worker, so email delivery simply calls the handler).
+This closes the long-standing gap where ``tools/send_message.py`` wrote raw
+payloads straight to the Redis outbox and bypassed every safety net the
+worker path enjoys (see ``docs/features/agent-message-delivery.md`` and
+issue #1369).
 
 Usage:
     python tools/send_message.py "your draft text"
     python tools/send_message.py "caption" --file path/to/attachment.png
-    python tools/send_message.py --react excited
     python tools/send_message.py --stdin    # read text from stdin
 
 Environment variables (injected by sdk_client.py):
-    VALOR_SESSION_ID      - Required; session ID for routing
-    TELEGRAM_CHAT_ID      - Set for Telegram-triggered sessions
-    TELEGRAM_REPLY_TO     - Set for Telegram replies
-    EMAIL_REPLY_TO        - Set for email-triggered sessions (sender address)
-    VALOR_TRANSPORT       - Explicit override; otherwise inferred from chat_id/email
-
-This tool is polymorphic — one verb, one implementation, transport chosen at
-call time. Future Slack/SMS support adds a branch here without any new tool
-for the agent to learn.
+    VALOR_SESSION_ID                Required; session ID for routing
+    TELEGRAM_CHAT_ID                Set for Telegram-triggered sessions
+    TELEGRAM_REPLY_TO               Set for Telegram replies
+    EMAIL_REPLY_TO                  Set for email-triggered sessions (sender address)
+    VALOR_TRANSPORT                 Explicit transport override (``telegram`` or
+                                    ``email``, case-insensitive). Otherwise inferred
+                                    from chat_id/email vars.
+    ALLOW_LEGACY_RPUSH_FALLBACK     Diagnostic only — when set to ``1``, a missing
+                                    AgentSession row falls back to the legacy raw
+                                    rpush path. Default unset → fail closed.
 """
 
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
+import logging
 import os
 import sys
 import time
@@ -41,12 +45,15 @@ import time
 TELEGRAM_MAX_LENGTH = 4096
 TELEGRAM_MAX_ALBUM_SIZE = 10
 
+logger = logging.getLogger(__name__)
+
 
 def _resolve_transport() -> str:
     """Pick the transport based on env vars.
 
     Priority:
-    1. VALOR_TRANSPORT explicit override
+    1. VALOR_TRANSPORT explicit override (``telegram`` or ``email``,
+       case-insensitive)
     2. EMAIL_REPLY_TO set -> email
     3. TELEGRAM_CHAT_ID set -> telegram
     4. Default: telegram
@@ -68,8 +75,103 @@ def _get_redis():
     return redis.Redis.from_url(redis_url, decode_responses=True)
 
 
+def _lookup_session(session_id: str):
+    """Reconstitute the AgentSession from Popoto.
+
+    Returns the session row, or ``None`` when the row is missing (caller
+    decides between fail-closed exit and the env-gated legacy rpush path).
+    Re-raises non-row-not-found Popoto/Redis errors so the harness sees them.
+    """
+    from models.agent_session import AgentSession
+
+    return AgentSession.query.filter(session_id=session_id).first()
+
+
+def _legacy_telegram_rpush(
+    text: str,
+    file_paths: list[str] | None,
+    *,
+    chat_id: str,
+    reply_to: str | None,
+    session_id: str,
+) -> None:
+    """Last-resort raw rpush to ``telegram:outbox:{session_id}``.
+
+    Only reachable when ``ALLOW_LEGACY_RPUSH_FALLBACK=1`` is set AND the
+    AgentSession lookup returned ``None``. Logs a warning so the bypass is
+    not silent.
+    """
+    logger.warning(
+        "ALLOW_LEGACY_RPUSH_FALLBACK active; writing raw payload to "
+        "telegram:outbox:%s without drafter/RTR/redundancy filtering",
+        session_id,
+    )
+    payload = {
+        "chat_id": chat_id,
+        "reply_to": int(reply_to) if reply_to else None,
+        "text": text,
+        "session_id": session_id,
+        "timestamp": time.time(),
+    }
+    if file_paths:
+        payload["file_paths"] = file_paths
+    queue_key = f"telegram:outbox:{session_id}"
+    try:
+        r = _get_redis()
+        r.rpush(queue_key, json.dumps(payload))
+        r.expire(queue_key, 3600)
+    except Exception as e:
+        print(f"Error: Redis write failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    print(
+        f"Queued ({len(text)} chars{', ' + str(len(file_paths)) + ' files' if file_paths else ''}) [legacy]"
+    )
+
+
+def _legacy_email_rpush(text: str, *, recipient: str, session_id: str) -> None:
+    """Last-resort raw rpush to ``email:outbox:{session_id}``.
+
+    Counterpart to ``_legacy_telegram_rpush`` for the email transport. Same
+    semantics: only reachable under ``ALLOW_LEGACY_RPUSH_FALLBACK=1`` with a
+    missing AgentSession row.
+    """
+    logger.warning(
+        "ALLOW_LEGACY_RPUSH_FALLBACK active; writing raw email payload to "
+        "email:outbox:%s without drafter filtering",
+        session_id,
+    )
+    in_reply_to = os.environ.get("EMAIL_IN_REPLY_TO") or None
+    subject = os.environ.get("EMAIL_SUBJECT") or "(no subject)"
+    payload = {
+        "session_id": session_id,
+        "to": recipient,
+        "subject": subject,
+        "body": text,
+        "attachments": [],
+        "in_reply_to": in_reply_to,
+        "references": in_reply_to,
+        "from_addr": os.environ.get("SMTP_USER", ""),
+        "timestamp": time.time(),
+    }
+    queue_key = f"email:outbox:{session_id}"
+    try:
+        r = _get_redis()
+        r.rpush(queue_key, json.dumps(payload))
+        r.expire(queue_key, 3600)
+    except Exception as e:
+        print(f"Error: Redis write failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    print(f"Queued email ({len(text)} chars) [legacy]")
+
+
 def _send_via_telegram(text: str, file_paths: list[str] | None) -> None:
-    """Route to the Redis outbox for Telegram delivery (same shape as send_telegram.py)."""
+    """Route through ``TelegramRelayOutputHandler.send`` for Telegram delivery.
+
+    The handler runs the canonical pipeline (drafter → redundancy filter →
+    RTR → narration fallback → outbox rpush). This tool retains responsibility
+    for the upstream concerns the handler does not own: env var validation,
+    file existence checks, linkify, and the promise gate.
+    """
     chat_id = os.environ.get("TELEGRAM_CHAT_ID")
     reply_to = os.environ.get("TELEGRAM_REPLY_TO")
     session_id = os.environ.get("VALOR_SESSION_ID")
@@ -117,27 +219,58 @@ def _send_via_telegram(text: str, file_paths: list[str] | None) -> None:
             pass
 
     # Promise gate — see docs/features/promise-gate.md (polymorphic transport).
+    # Runs BEFORE the handler so we short-circuit before the drafter Haiku call
+    # and before the Popoto session lookup when the agent owes a promise.
     from bridge.promise_gate import cli_check_or_exit
 
     cli_check_or_exit(text, transport="polymorphic", session_id=session_id)
 
-    payload = {
-        "chat_id": chat_id,
-        "reply_to": int(reply_to) if reply_to else None,
-        "text": text,
-        "session_id": session_id,
-        "timestamp": time.time(),
-    }
-    if file_paths:
-        payload["file_paths"] = file_paths
-
-    queue_key = f"telegram:outbox:{session_id}"
+    # Reconstitute the AgentSession so the handler can read transport,
+    # extra_context, and recent_sent_drafts. Fail-closed default; the legacy
+    # raw-rpush path is opt-in via env flag for short-lived diagnostic use.
     try:
-        r = _get_redis()
-        r.rpush(queue_key, json.dumps(payload))
-        r.expire(queue_key, 3600)
+        session = _lookup_session(session_id)
     except Exception as e:
-        print(f"Error: Redis write failed: {e}", file=sys.stderr)
+        print(
+            f"Error: AgentSession lookup failed (Popoto/Redis error): {e}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if session is None:
+        if os.environ.get("ALLOW_LEGACY_RPUSH_FALLBACK") == "1":
+            _legacy_telegram_rpush(
+                text,
+                file_paths,
+                chat_id=chat_id,
+                reply_to=reply_to,
+                session_id=session_id,
+            )
+            return
+        print(
+            f"Error: AgentSession {session_id!r} not found; refusing to bypass "
+            "the canonical handler. Set ALLOW_LEGACY_RPUSH_FALLBACK=1 for "
+            "diagnostic raw rpush.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    from agent.output_handler import TelegramRelayOutputHandler
+
+    handler = TelegramRelayOutputHandler()
+    reply_to_int = int(reply_to) if reply_to else 0
+    try:
+        asyncio.run(
+            handler.send(
+                chat_id,
+                text,
+                reply_to_int,
+                session=session,
+                file_paths=file_paths,
+            )
+        )
+    except Exception as e:
+        print(f"Error: handler.send failed: {e}", file=sys.stderr)
         sys.exit(1)
 
     print(
@@ -145,20 +278,15 @@ def _send_via_telegram(text: str, file_paths: list[str] | None) -> None:
     )
 
 
-def _send_via_email(text: str) -> None:
-    """Route to the email outbox for SMTP delivery via ``bridge/email_relay.py``.
+def _send_via_email(text: str, file_paths: list[str] | None = None) -> None:
+    """Route through the SAME ``TelegramRelayOutputHandler.send`` for email.
 
-    Writes the unified outbox payload shape (see ``bridge/email_relay.py``
-    docstring) consumed by the relay. The relay accepts legacy ``text`` as a
-    synonym for ``body`` for one transitional release, but this writer always
-    emits ``body`` so the transitional path is unused.
-
-    Required env:
-        VALOR_SESSION_ID: session ID that originated this send.
-        EMAIL_REPLY_TO:   recipient address (sender of the original inbound).
-        EMAIL_SUBJECT:    optional; defaults to "(no subject)".
-        EMAIL_IN_REPLY_TO: optional RFC-2822 Message-ID for threading.
-        SMTP_USER:        optional from-address override (relay defaults to SMTP_USER).
+    Despite the type name, this method is the single canonical queue-side
+    entrypoint for both transports. The handler's internal email branch
+    builds the email-shaped outbox payload (reply-all ``to`` list, subject,
+    threading headers) so the CLI never imports ``EmailOutputHandler``. Doing
+    so would couple the tool to synchronous SMTP, which is the wrong layer
+    for a queue-only writer.
     """
     session_id = os.environ.get("VALOR_SESSION_ID")
     reply_to_addr = os.environ.get("EMAIL_REPLY_TO")
@@ -169,33 +297,73 @@ def _send_via_email(text: str) -> None:
         print("Error: EMAIL_REPLY_TO not set.", file=sys.stderr)
         sys.exit(1)
 
-    in_reply_to = os.environ.get("EMAIL_IN_REPLY_TO") or None
-    subject = os.environ.get("EMAIL_SUBJECT") or "(no subject)"
-
-    # Promise gate — see docs/features/promise-gate.md
+    # Promise gate runs first — short-circuits before any handler/Popoto cost.
     from bridge.promise_gate import cli_check_or_exit
 
     cli_check_or_exit(text, transport="email", session_id=session_id)
 
-    payload = {
-        "session_id": session_id,
-        "to": reply_to_addr,
-        "subject": subject,
-        "body": text,
-        "attachments": [],
-        "in_reply_to": in_reply_to,
-        "references": in_reply_to,
-        "from_addr": os.environ.get("SMTP_USER", ""),
-        "timestamp": time.time(),
-    }
-    queue_key = f"email:outbox:{session_id}"
     try:
-        r = _get_redis()
-        r.rpush(queue_key, json.dumps(payload))
-        r.expire(queue_key, 3600)
+        session = _lookup_session(session_id)
     except Exception as e:
-        print(f"Error: Redis write failed: {e}", file=sys.stderr)
+        print(
+            f"Error: AgentSession lookup failed (Popoto/Redis error): {e}",
+            file=sys.stderr,
+        )
         sys.exit(1)
+
+    if session is None:
+        if os.environ.get("ALLOW_LEGACY_RPUSH_FALLBACK") == "1":
+            _legacy_email_rpush(text, recipient=reply_to_addr, session_id=session_id)
+            return
+        print(
+            f"Error: AgentSession {session_id!r} not found; refusing to bypass "
+            "the canonical handler. Set ALLOW_LEGACY_RPUSH_FALLBACK=1 for "
+            "diagnostic raw rpush.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Defensive: if the bridge spawned this session before EMAIL_SUBJECT /
+    # EMAIL_IN_REPLY_TO were canonicalised onto extra_context, stamp them now
+    # so the handler's email branch can read them uniformly.
+    try:
+        extra = getattr(session, "extra_context", None)
+        if isinstance(extra, dict):
+            dirty = False
+            if "email_subject" not in extra and os.environ.get("EMAIL_SUBJECT"):
+                extra["email_subject"] = os.environ["EMAIL_SUBJECT"]
+                dirty = True
+            if "email_message_id" not in extra and os.environ.get("EMAIL_IN_REPLY_TO"):
+                extra["email_message_id"] = os.environ["EMAIL_IN_REPLY_TO"]
+                dirty = True
+            if dirty:
+                session.extra_context = extra
+                try:
+                    session.save(update_fields=["extra_context"])
+                except Exception:
+                    # Non-fatal: stamping is a defensive backfill, not a
+                    # prerequisite for delivery.
+                    pass
+    except Exception:
+        pass
+
+    from agent.output_handler import TelegramRelayOutputHandler
+
+    handler = TelegramRelayOutputHandler()
+    try:
+        asyncio.run(
+            handler.send(
+                reply_to_addr,
+                text,
+                0,
+                session=session,
+                file_paths=file_paths,
+            )
+        )
+    except Exception as e:
+        print(f"Error: handler.send failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
     print(f"Queued email ({len(text)} chars)")
 
 
@@ -205,12 +373,7 @@ def send_message(text: str, file_paths: list[str] | None = None) -> None:
     if transport == "telegram":
         _send_via_telegram(text, file_paths)
     elif transport == "email":
-        if file_paths:
-            print(
-                "Warning: --file ignored for email transport (not supported)",
-                file=sys.stderr,
-            )
-        _send_via_email(text)
+        _send_via_email(text, file_paths=file_paths)
     else:
         print(f"Error: unsupported transport '{transport}'", file=sys.stderr)
         sys.exit(1)

--- a/tools/send_message.py
+++ b/tools/send_message.py
@@ -123,9 +123,8 @@ def _legacy_telegram_rpush(
     except Exception as e:
         print(f"Error: Redis write failed: {e}", file=sys.stderr)
         sys.exit(1)
-    print(
-        f"Queued ({len(text)} chars{', ' + str(len(file_paths)) + ' files' if file_paths else ''}) [legacy]"
-    )
+    _files_suffix = f", {len(file_paths)} files" if file_paths else ""
+    print(f"Queued ({len(text)} chars{_files_suffix}) [legacy]")
 
 
 def _legacy_email_rpush(text: str, *, recipient: str, session_id: str) -> None:
@@ -284,9 +283,8 @@ def _send_via_email(text: str, file_paths: list[str] | None = None) -> None:
     Despite the type name, this method is the single canonical queue-side
     entrypoint for both transports. The handler's internal email branch
     builds the email-shaped outbox payload (reply-all ``to`` list, subject,
-    threading headers) so the CLI never imports ``EmailOutputHandler``. Doing
-    so would couple the tool to synchronous SMTP, which is the wrong layer
-    for a queue-only writer.
+    threading headers). The CLI deliberately does NOT import the synchronous
+    SMTP handler — that is the wrong layer for a queue-only writer.
     """
     session_id = os.environ.get("VALOR_SESSION_ID")
     reply_to_addr = os.environ.get("EMAIL_REPLY_TO")


### PR DESCRIPTION
## Summary

Closes the gap where ``tools/send_message.py`` wrote raw payloads
straight to the Redis outbox and bypassed every safety net the silent
worker path enjoys. Both telegram and email tool-call sends now route
through ``TelegramRelayOutputHandler.send`` — the single canonical
queue-side entrypoint — which runs the drafter once before the
transport branch.

## Changes

- Handler (agent/output_handler.py): hoist drafter / redundancy filter /
  RTR ABOVE the transport branch so both writes inherit identical text.
  send() gains optional file_paths kwarg; _send_via_email_outbox builds
  reply-all 'to' list and forwards attachments. RTR/redundancy suppress
  on email drops the payload entirely (no reaction, no outbox write).
- Tool (tools/send_message.py): reconstitute AgentSession from
  VALOR_SESSION_ID and delegate to TelegramRelayOutputHandler.send for
  both transports. The tool no longer imports EmailOutputHandler.
  Fail-closed default on missing session; ALLOW_LEGACY_RPUSH_FALLBACK=1
  opts into legacy raw rpush (diagnostic only).
- Tests: new TestToolCallHandlerRouting and TestDrafterHoistedAboveTransport
  plus updated tests/unit/test_send_message.py.
- Docs: agent-message-delivery.md — claims at :29/:50 become true; new
  'Filters layered on every send' subsection; VALOR_TRANSPORT
  enumeration; ALLOW_LEGACY_RPUSH_FALLBACK documentation; stale e2e
  reference removed.

## Testing

- 130/130 delivery-related unit tests pass
- ruff check + format clean on every touched file
- Other unit-suite failures are pre-existing on main, unrelated

Closes #1369