### PR TITLE
fix(bridge): media persist loud failure + worker self-heal (#1330)

### DIFF
--- a/bridge/enrichment.py
+++ b/bridge/enrichment.py
@@ -74,9 +74,44 @@ async def enrich_message(
         media_download_error = getattr(telegram_message, "media_download_error", None)
         media_type = getattr(telegram_message, "media_type", None)
 
+        if not media_local_path and not media_download_error:
+            # Self-heal path (see sdlc-1330): the bridge persist block may
+            # have silently no-op'd due to a transient Popoto stale-index
+            # condition, leaving the file on disk but the record with
+            # `media_local_path=None`. We recover by searching
+            # `bridge/data/media/` for a file whose filename contains the
+            # message_id. The filename pattern is fully determined by
+            # `bridge/media.py` (download_media): each downloaded file is
+            # named `{prefix}_{timestamp}_{message.id}{ext}`. We require
+            # exactly one match — zero or multiple matches fall through to
+            # the existing "legacy record?" warning so ambiguity is surfaced
+            # rather than silently misrouted.
+            msg_id_for_search = getattr(telegram_message, "message_id", None)
+            if msg_id_for_search:
+                try:
+                    from bridge.media import MEDIA_DIR
+
+                    matches = list(MEDIA_DIR.glob(f"*_{msg_id_for_search}.*"))
+                    if len(matches) == 1:
+                        media_local_path = str(matches[0].resolve())
+                        logger.info(
+                            f"[enrichment] self-heal: recovered orphan media file "
+                            f"{media_local_path} for message_id={msg_id_for_search}"
+                        )
+                    elif len(matches) > 1:
+                        logger.warning(
+                            f"[enrichment] self-heal: multiple matches for "
+                            f"message_id={msg_id_for_search} in {MEDIA_DIR} "
+                            f"({[str(p) for p in matches]}); skipping to avoid "
+                            f"adopting wrong file"
+                        )
+                except Exception as e:
+                    logger.warning(f"[enrichment] self-heal lookup failed: {e}")
+
         if not media_local_path:
             # Bridge attempted the download but it failed (or the bridge ran
-            # before this code shipped, in which case the field is None).
+            # before this code shipped, in which case the field is None),
+            # and self-heal could not recover a unique file.
             if media_download_error:
                 logger.warning(
                     f"[enrichment] media download failed at intake "

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -1253,7 +1253,34 @@ async def main():
             try:
                 from models.telegram import TelegramMessage
 
+                # Two silent failure modes are addressed here (see sdlc-1330):
+                #   1. `query.get(stored_msg_id)` can transiently return `None`
+                #      during a Popoto stale-index condition. The previous
+                #      code silently no-op'd the persist block; we now log a
+                #      WARNING and do ONE bounded re-query. We deliberately
+                #      do NOT call `keys(clean=True)` here — it's a heavy,
+                #      index-mutating call and the worker-side self-heal in
+                #      `bridge/enrichment.py` is the durable safety net.
+                #   2. `_download_media_with_retry` can return `(None, None)`
+                #      ("no_path" outcome) when `client.download_media`
+                #      reports success but the file is missing post-download.
+                #      The persist block sees no error, no path, and was
+                #      previously silent. We now log a WARNING so the
+                #      condition is observable in logs.
                 _record = TelegramMessage.query.get(stored_msg_id)
+                if _record is None:
+                    # Single bounded re-query before giving up.
+                    _record = TelegramMessage.query.get(stored_msg_id)
+                    if _record is None:
+                        logger.warning(
+                            f"[media] TelegramMessage.query.get returned None "
+                            f"(stored_msg_id={stored_msg_id} "
+                            f"chat_id={event.chat_id} "
+                            f"message_id={message.id} "
+                            f"local_path={_local_path} "
+                            f"download_error={_download_error}); "
+                            f"persist skipped, worker self-heal will attempt recovery"
+                        )
                 if _record is not None:
                     if _local_path is not None:
                         # Persist as absolute path so the worker can read it
@@ -1262,6 +1289,22 @@ async def main():
                     if _download_error is not None:
                         _record.media_download_error = _download_error
                     _record.save()
+
+                # Second silent path: download wrapper returned (None, None)
+                # with no error string. message.media truthy means there WAS
+                # media to download.
+                if (
+                    _local_path is None
+                    and _download_error is None
+                    and getattr(message, "media", None)
+                ):
+                    logger.warning(
+                        f"[media] download returned no path with no error "
+                        f"(stored_msg_id={stored_msg_id} "
+                        f"chat_id={event.chat_id} "
+                        f"message_id={message.id}); "
+                        f"file may be missing post-download, worker self-heal will attempt recovery"
+                    )
             except Exception as e:
                 logger.warning(f"[media] failed to persist media_local_path: {e}")
 

--- a/docs/features/bridge-worker-architecture.md
+++ b/docs/features/bridge-worker-architecture.md
@@ -143,6 +143,17 @@ Telegram media (photos, voice, audio, documents) requires both Telethon RPC (dow
 
 Full contract and field-level reference live in [media-enrichment.md](media-enrichment.md). The sibling reply-chain branch in `bridge/enrichment.py` still requires a Telethon client and is silently skipped in the worker until a follow-up issue lands; that is **not** considered fixed by sdlc-1297.
 
+### Media Intake Resilience (issue #1330)
+
+The sdlc-1297 contract assumes (a) `TelegramMessage.query.get(stored_msg_id)` always returns the record the bridge just created, and (b) `_download_media_with_retry` returns either a path or a populated error string. Both assumptions can fail transiently — a Popoto stale-index condition can return `None` from `query.get`, and the size-aware retry wrapper can return `(None, None)` ("no_path" outcome) when `client.download_media` reports success but the file is missing post-download. Either case left the file orphaned on disk and the agent seeing only the `[media]` placeholder.
+
+Defense in depth lives in two layers:
+
+- **Bridge persist (loud failure)**: After `query.get(stored_msg_id)`, a single bounded re-query covers transient stale-index reads; if both calls return `None`, the bridge logs a `WARNING` with `stored_msg_id`, `chat_id`, `message_id`, `local_path`, and `download_error` and proceeds. Separately, if the download wrapper returned `(_local_path=None, _download_error=None)` while `message.media` is truthy, a second `WARNING` records the no-path-no-error condition. Neither path is silent anymore. The bridge deliberately does **not** call `query.keys(clean=True)` here — index-mutating calls on the hot intake path are too expensive; the worker-side fallback below is the durable safety net.
+- **Worker self-heal**: In `bridge/enrichment.py`, when `has_media=True` AND `media_local_path` is unset AND `media_download_error` is also unset, the worker globs `bridge.media.MEDIA_DIR` for `*_{message_id}.*` (the filename pattern is fully determined by `bridge/media.py::download_media`). On exactly one match it adopts the file with an `INFO` log (`self-heal: recovered orphan media file ...`) and runs AI enrichment as if `media_local_path` had been persisted. Zero matches or multiple matches fall through to the existing "legacy record?" `WARNING` so ambiguity surfaces rather than silently misroutes.
+
+**Explicit non-goal**: this work does not fix the upstream Popoto stale-index root cause. That is tracked under #617 / #860 — orphan-index hygiene is its own ongoing reflection. sdlc-1330 makes intake resilient to that condition; the root cause is unaffected.
+
 ### Execution Harness Routing
 
 All session types (dev, pm, teammate) execute via the CLI harness (`claude -p`). There is no SDK execution branch — the `DEV_SESSION_HARNESS` feature flag was eliminated in issue #912.

--- a/docs/features/media-enrichment.md
+++ b/docs/features/media-enrichment.md
@@ -65,7 +65,7 @@ The worker's `enrich_message` emits a single summary log line per call; `media=`
 | `media=yes` | AI enrichment succeeded; description prepended to text. |
 | `media=skipped:no_record` | No `TelegramMessage` record was loaded (manual session, ad-hoc invocation). Normal path. |
 | `media=skipped:download_failed` | `media_local_path is None and media_download_error is not None`. |
-| `media=skipped:no_path` | `media_local_path is None` and no error recorded — usually a pre-migration record. |
+| `media=skipped:no_path` | `media_local_path is None` and no error recorded — after the **(sdlc-1330)** orphan self-heal runs first. If exactly one file matches `*_{message_id}.*` under `MEDIA_DIR`, the worker adopts it, logs an `INFO` self-heal line, and proceeds to AI enrichment (i.e. summary becomes `media=yes`). Zero or multiple matches fall through to this summary — usually a pre-migration record or genuinely missing intake. |
 | `media=skipped:file_unreadable` | The file at `media_local_path` is missing or not readable. |
 | `media=skipped:no_description` | AI ran but produced empty output. |
 | `media=failed` | AI processing raised; logged with traceback. |
@@ -94,7 +94,7 @@ The reply-chain branch in `bridge/enrichment.py` still requires a Telethon clien
 
 - `bridge/telegram_bridge.py` — handler, intake timing, bridge-side download, persistence. Hosts `_download_media_with_retry` (size-aware timeout + 1-retry wrapper around `download_media`).
 - `bridge/media.py` — `download_media`, `compute_media_timeout` (size-aware timeout helper, line 258), `process_incoming_media`, `process_downloaded_media`, `describe_image`, `transcribe_voice`, `extract_document_text`.
-- `bridge/enrichment.py` — worker-side `enrich_message`.
+- `bridge/enrichment.py` — worker-side `enrich_message`; hosts the **(sdlc-1330)** orphan-file self-heal that globs `MEDIA_DIR` for `*_{message_id}.*` when `has_media=True` but neither `media_local_path` nor `media_download_error` is set.
 - `models/telegram.py` — `TelegramMessage` field definitions.
 - `agent/session_executor.py` — call site that passes the loaded `TelegramMessage` to `enrich_message`.
 

--- a/docs/plans/sdlc-1330.md
+++ b/docs/plans/sdlc-1330.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: docs_complete
 type: bug
 appetite: Small
 owner: Valor

--- a/tests/integration/test_media_enrichment_pipeline.py
+++ b/tests/integration/test_media_enrichment_pipeline.py
@@ -126,6 +126,82 @@ async def test_media_enrichment_failure_path(caplog):
 
 
 # =============================================================================
+# sdlc-1330: worker-side self-heal of orphan media files
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_voice_message_persists_path_when_query_get_returns_none(
+    tmp_path, caplog, monkeypatch
+):
+    """sdlc-1330 end-to-end: simulate the incident where the bridge downloaded
+    a voice message to disk but ``TelegramMessage.query.get`` returned None due
+    to a transient Popoto stale-index condition, so ``media_local_path`` was
+    never persisted on the record.
+
+    The worker-side self-heal must find the orphan file in MEDIA_DIR by
+    ``message_id`` and run AI enrichment so the agent receives the
+    transcription rather than the bare ``--file attachment only--`` sentinel.
+    """
+    import bridge.media as media_mod
+
+    # Redirect MEDIA_DIR to the test tmp_path so we don't pollute the real
+    # bridge/data/media/ directory.
+    monkeypatch.setattr(media_mod, "MEDIA_DIR", tmp_path)
+
+    msg_id = 99730  # avoid collision with other tests
+    orphan = tmp_path / f"voice_20260508_111815_{msg_id}.ogg"
+    orphan.write_bytes(b"OggS\x00fake-voice-payload")
+
+    from models.telegram import TelegramMessage
+
+    # The record reflects what the bridge would persist when the Popoto
+    # stale-index condition silently no-op'd the persist block:
+    # has_media=True but media_local_path=None and no download error.
+    tm = TelegramMessage.create(
+        chat_id="test-1330-self-heal",
+        message_id=msg_id,
+        direction="in",
+        sender="tester",
+        content="--file attachment only--",
+        timestamp=0.0,
+        message_type="voice",
+        project_key="test-media-1330",
+        has_media=True,
+        media_type="voice",
+        media_local_path=None,
+        media_download_error=None,
+    )
+    try:
+        from bridge.enrichment import enrich_message
+
+        fake_transcription = "[Voice transcription] Hello from the orphan voice note."
+        with patch(
+            "bridge.media.process_downloaded_media",
+            new_callable=AsyncMock,
+            return_value=(fake_transcription, [orphan]),
+        ) as proc:
+            with caplog.at_level("INFO"):
+                enriched = await enrich_message(
+                    message_text="--file attachment only--",
+                    telegram_message=tm,
+                )
+
+        # Self-heal recovered the orphan file and ran AI enrichment.
+        assert "[Voice transcription]" in enriched
+        assert "Hello from the orphan voice note." in enriched
+        proc.assert_called_once()
+        # Self-heal log line is present at INFO level.
+        assert any("self-heal: recovered orphan media file" in r.message for r in caplog.records)
+        # Existing "legacy record?" warning must NOT fire — self-heal succeeded.
+        assert not any(
+            "has_media=True but media_local_path is unset" in r.message for r in caplog.records
+        )
+    finally:
+        tm.delete()
+
+
+# =============================================================================
 # Size-aware retry path (sdlc-1322 follow-up, issue #1344)
 # =============================================================================
 

--- a/tests/unit/test_enrichment_media.py
+++ b/tests/unit/test_enrichment_media.py
@@ -117,6 +117,135 @@ async def test_enrich_message_no_telegram_message_record_is_a_normal_path(caplog
 
 
 @pytest.mark.asyncio
+async def test_enrichment_self_heals_orphan_media_file(tmp_path, caplog, monkeypatch):
+    """sdlc-1330: when media_local_path is None and media_download_error is None
+    AND a unique file matching *_{message_id}.* exists in MEDIA_DIR, the worker
+    adopts it and runs AI enrichment instead of dropping the message."""
+    import bridge.enrichment as enrichment_mod
+    import bridge.media as media_mod
+
+    # Redirect MEDIA_DIR to the test tmp_path
+    monkeypatch.setattr(media_mod, "MEDIA_DIR", tmp_path)
+
+    orphan = tmp_path / "voice_20260508_111815_9730.ogg"
+    orphan.write_bytes(b"OggS\x00")  # minimal OGG header
+
+    tm = SimpleNamespace(
+        has_media=True,
+        media_type="voice",
+        media_local_path=None,
+        media_download_error=None,
+        message_id=9730,
+    )
+
+    fake_transcription = "Hello from the orphan file"
+    with patch(
+        "bridge.media.process_downloaded_media",
+        new_callable=AsyncMock,
+        return_value=(fake_transcription, [orphan]),
+    ) as proc:
+        with caplog.at_level("INFO"):
+            result = await enrichment_mod.enrich_message(
+                message_text="--file attachment only--",
+                telegram_message=tm,
+            )
+
+    assert "Hello from the orphan file" in result
+    assert "--file attachment only--" not in result or result.startswith(fake_transcription)
+    proc.assert_called_once()
+    assert any("self-heal: recovered orphan media file" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_enrichment_skips_self_heal_on_multiple_matches(tmp_path, caplog, monkeypatch):
+    """sdlc-1330: when two files match the same message_id, skip self-heal to
+    avoid adopting the wrong file. The existing 'legacy record?' warning still
+    fires."""
+    import bridge.media as media_mod
+
+    monkeypatch.setattr(media_mod, "MEDIA_DIR", tmp_path)
+
+    (tmp_path / "voice_20260508_111815_9730.ogg").write_bytes(b"OggS\x00")
+    (tmp_path / "voice_20260509_120000_9730.ogg").write_bytes(b"OggS\x00")
+
+    tm = SimpleNamespace(
+        has_media=True,
+        media_type="voice",
+        media_local_path=None,
+        media_download_error=None,
+        message_id=9730,
+    )
+
+    from bridge.enrichment import enrich_message
+
+    with caplog.at_level("WARNING"):
+        result = await enrich_message(
+            message_text="caption",
+            telegram_message=tm,
+        )
+
+    assert result == "caption"
+    assert any("multiple matches" in r.message for r in caplog.records)
+    assert any("has_media=True but media_local_path is unset" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_enrichment_skips_self_heal_when_message_id_missing(tmp_path, caplog, monkeypatch):
+    """sdlc-1330: with message_id unset, self-heal can't run and we fall
+    through to the existing 'legacy record?' warning."""
+    import bridge.media as media_mod
+
+    monkeypatch.setattr(media_mod, "MEDIA_DIR", tmp_path)
+
+    tm = SimpleNamespace(
+        has_media=True,
+        media_type="voice",
+        media_local_path=None,
+        media_download_error=None,
+        message_id=None,
+    )
+
+    from bridge.enrichment import enrich_message
+
+    with caplog.at_level("WARNING"):
+        result = await enrich_message(
+            message_text="caption",
+            telegram_message=tm,
+        )
+
+    assert result == "caption"
+    assert any("has_media=True but media_local_path is unset" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_enrichment_skips_self_heal_when_no_matches(tmp_path, caplog, monkeypatch):
+    """sdlc-1330: with message_id set but MEDIA_DIR empty, fall through to the
+    existing 'legacy record?' warning."""
+    import bridge.media as media_mod
+
+    monkeypatch.setattr(media_mod, "MEDIA_DIR", tmp_path)
+
+    tm = SimpleNamespace(
+        has_media=True,
+        media_type="voice",
+        media_local_path=None,
+        media_download_error=None,
+        message_id=9730,
+    )
+
+    from bridge.enrichment import enrich_message
+
+    with caplog.at_level("WARNING"):
+        result = await enrich_message(
+            message_text="caption",
+            telegram_message=tm,
+        )
+
+    assert result == "caption"
+    assert any("has_media=True but media_local_path is unset" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
 async def test_enrich_message_no_media_summary_says_no(caplog):
     """has_media=False → summary line shows media=no, idempotent vs raw text."""
     from bridge.enrichment import enrich_message

--- a/tests/unit/test_telegram_bridge_media_timeout.py
+++ b/tests/unit/test_telegram_bridge_media_timeout.py
@@ -141,6 +141,46 @@ async def test_retry_succeeds_on_second_attempt():
     assert call_count["n"] == 2
 
 
+# ---------------------------------------------------------------------------
+# sdlc-1330: silent persist branches now log WARNING
+# ---------------------------------------------------------------------------
+
+
+def test_persist_warns_when_record_none_string_in_source():
+    """sdlc-1330: the bridge persist block must emit a WARNING when
+    TelegramMessage.query.get returns None twice. We assert the exact log
+    string is present in the source so the wiring can't silently regress.
+
+    The persist block is inline in a deep event handler; a full mock-based
+    test would require patching the entire Telethon stack. The Verification
+    table in docs/plans/sdlc-1330.md greps for the same string."""
+    src = Path(__file__).parent.parent.parent / "bridge" / "telegram_bridge.py"
+    text = src.read_text()
+    assert "TelegramMessage.query.get returned None" in text, (
+        "Expected the sdlc-1330 WARNING string in bridge/telegram_bridge.py"
+    )
+    # Verify single bounded re-query is wired (two get() calls in a row inside
+    # the persist try-block).
+    assert text.count("TelegramMessage.query.get(stored_msg_id)") >= 2, (
+        "Expected at least 2 calls to query.get(stored_msg_id) for the single-retry pattern"
+    )
+
+
+def test_persist_warns_when_download_returns_no_path_with_no_error_string_in_source():
+    """sdlc-1330: the second silent branch (`_local_path is None AND
+    _download_error is None AND message.media`) must log a WARNING. Assert
+    the log string and the conjunction is wired in source."""
+    src = Path(__file__).parent.parent.parent / "bridge" / "telegram_bridge.py"
+    text = src.read_text()
+    assert "download returned no path with no error" in text, (
+        "Expected the sdlc-1330 no-path WARNING string in bridge/telegram_bridge.py"
+    )
+    # The conjunction guards against false positives when there's no media at
+    # all (skipping persist entirely is the normal case).
+    assert "_local_path is None" in text
+    assert "_download_error is None" in text
+
+
 @pytest.mark.asyncio
 async def test_first_attempt_success_no_retry():
     """First attempt succeeds -> single call, no retry telemetry."""


### PR DESCRIPTION
## Summary

A Telegram voice message could land on disk via Telethon, get an AgentSession enqueued, but never reach the agent as a transcription — leaving an orphan file in `bridge/data/media/` and the agent saying "no file attached." Two silent failure modes in the bridge intake path were responsible: `TelegramMessage.query.get` returning `None` during a transient Popoto stale-index condition, and `_download_media_with_retry` returning `(None, None)` when `client.download_media` reports success but the file is missing post-download.

This PR makes both failure modes loud at the bridge and adds a worker-side self-heal that can recover the orphan file from disk.

## Changes

- **bridge/telegram_bridge.py**: `query.get` returning `None` now triggers a single bounded re-query, then a `WARNING` with `stored_msg_id`, `chat_id`, `message_id`, `local_path`, `download_error`. The `(None, None)` no-path-no-error outcome now logs its own `WARNING`. Deliberately no `keys(clean=True)` — the worker self-heal is the durable safety net.
- **bridge/enrichment.py**: When `has_media=True` and both `media_local_path` and `media_download_error` are unset, glob `bridge.media.MEDIA_DIR` for `*_{message_id}.*`. On exactly one match, adopt the file with an `INFO` self-heal log and run AI enrichment. Zero or multiple matches fall through to the existing "legacy record?" warning so ambiguity surfaces.
- **docs/features/bridge-worker-architecture.md**: New "Media Intake Resilience" subsection documenting the two silent paths now made loud, the worker self-heal, and the explicit non-goal of fixing the Popoto stale-index root cause (tracked under #617 / #860).
- **Tests**: 4 new unit tests in `test_enrichment_media.py` (self-heal happy + 3 skip paths), 2 source-presence tests in `test_telegram_bridge_media_timeout.py` for the bridge warnings, 1 end-to-end integration test in `test_media_enrichment_pipeline.py` driving the worker self-heal through a real `TelegramMessage` record.

## Testing

- [x] Unit tests passing (`pytest tests/unit/test_enrichment_media.py tests/unit/test_telegram_bridge_media_timeout.py`)
- [x] Integration tests passing (`pytest tests/integration/test_media_enrichment_pipeline.py`)
- [x] Lint passing for touched files
- [x] Format clean

## Definition of Done
- [x] Built: bridge warnings + worker self-heal wired
- [x] Tested: 7 new test cases pass, all existing media tests still green
- [x] Documented: bridge-worker-architecture.md updated
- [x] Quality: lint + format clean for touched files

Closes #1330