### PR TITLE
fix(worktree): branch-mismatch guard prevents silent MERGE-stage hangs (#1377)

### DIFF
--- a/agent/session_executor.py
+++ b/agent/session_executor.py
@@ -878,6 +878,29 @@ async def _execute_agent_session(session: AgentSession) -> None:
                 f"main checkout contamination (issue #887)."
             )
 
+        # Branch-mismatch guard (issue #1377): a reused worktree handed off
+        # between SDLC stages may still be checked out to the previous stage's
+        # branch. If we proceed without verifying, the Claude Code subprocess
+        # launches on the wrong branch, produces no output, and is killed by
+        # startup-recovery 6+ minutes later. verify_worktree_branch
+        # auto-recovers clean worktrees and raises on dirty ones — the latter
+        # surfaces as a session failure with last_error populated instead of
+        # a silent hang.
+        if _stype == "dev" and slug and WORKTREES_DIR in str(working_dir):
+            from agent.worktree_manager import (  # noqa: PLC0415
+                WorktreeBranchMismatchError,
+                verify_worktree_branch,
+            )
+
+            try:
+                verify_worktree_branch(working_dir, branch_name)
+            except WorktreeBranchMismatchError as e:
+                logger.error(
+                    f"[worktree-branch-guard] Session {session.session_id} "
+                    f"slug={slug}: {e} — refusing to launch harness (issue #1377)"
+                )
+                raise
+
         # Compute task list ID for sub-agent task isolation
         # Tier 2: planned work uses the slug directly
         # Tier 1: ad-hoc sessions use thread-{chat_id}-{root_msg_id}

--- a/agent/worktree_manager.py
+++ b/agent/worktree_manager.py
@@ -18,6 +18,171 @@ WORKTREES_DIR = ".worktrees"
 VALID_SLUG_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
 
 
+class WorktreeBranchMismatchError(RuntimeError):
+    """Raised when a reused worktree's HEAD does not match the expected branch
+    and cannot be auto-recovered (issue #1377).
+
+    The recoverable case (clean working tree) is handled by
+    ``verify_worktree_branch`` itself via ``git checkout``; this exception is
+    only raised when the worktree has uncommitted state or when the underlying
+    git command fails.
+
+    Attributes:
+        worktree_path: The worktree directory that was checked.
+        expected_branch: The branch the executor wanted the worktree on.
+        actual_branch: The branch git reported (may be empty / detached HEAD).
+        dirty_files: List of porcelain status lines explaining why auto-recovery
+            was refused (empty when the failure was a subprocess error).
+    """
+
+    def __init__(
+        self,
+        worktree_path: Path | str,
+        expected_branch: str,
+        actual_branch: str,
+        dirty_files: list[str] | None = None,
+        cause: str | None = None,
+    ) -> None:
+        self.worktree_path = Path(worktree_path)
+        self.expected_branch = expected_branch
+        self.actual_branch = actual_branch
+        self.dirty_files = list(dirty_files or [])
+        msg = (
+            f"Worktree branch mismatch at {self.worktree_path}: "
+            f"expected={expected_branch!r}, actual={actual_branch!r}"
+        )
+        if self.dirty_files:
+            msg += f", dirty_files={self.dirty_files}"
+        if cause:
+            msg += f" ({cause})"
+        super().__init__(msg)
+
+
+def verify_worktree_branch(worktree_path: Path, expected_branch: str) -> None:
+    """Verify a reused worktree is checked out to the expected branch.
+
+    This is the missing primitive identified by issue #1377: after a BUILD
+    session left ``.worktrees/{slug}/`` on ``session/{slug}``, a subsequent
+    MERGE dev session reusing the same path could end up running with the
+    wrong branch context, silently producing no output until the startup
+    watchdog killed it.
+
+    Behavior:
+      * Matching branch — return silently (no log noise).
+      * Mismatch + clean working tree — run ``git checkout <expected_branch>``
+        and log at INFO with slug/from/to. This is the "operator-friendly"
+        recovery path; the alternative would be to refuse every reused
+        worktree and force a manual cleanup.
+      * Mismatch + dirty working tree — raise :class:`WorktreeBranchMismatchError`
+        with the dirty file list, preserving uncommitted work for inspection.
+      * Underlying git failure (detached HEAD that cannot be parsed, corrupted
+        worktree, etc.) — raise :class:`WorktreeBranchMismatchError` with the
+        git stderr as the cause.
+
+    Args:
+        worktree_path: Absolute path to the worktree to check.
+        expected_branch: The branch name the caller expects (e.g. ``"main"``
+            or ``"session/sdlc-1377"``).
+
+    Raises:
+        TypeError: If ``worktree_path`` is None.
+        ValueError: If ``expected_branch`` is empty / whitespace-only.
+        WorktreeBranchMismatchError: If the worktree path is missing, the
+            branch differs and the worktree is dirty, or the underlying git
+            command fails.
+    """
+    if worktree_path is None:
+        raise TypeError("worktree_path must not be None")
+    if not isinstance(expected_branch, str) or not expected_branch.strip():
+        raise ValueError("expected_branch must be a non-empty string")
+
+    worktree_path = Path(worktree_path)
+    if not worktree_path.exists():
+        raise WorktreeBranchMismatchError(
+            worktree_path,
+            expected_branch,
+            "",
+            cause=f"worktree path does not exist: {worktree_path}",
+        )
+
+    try:
+        head = subprocess.run(
+            ["git", "-C", str(worktree_path), "rev-parse", "--abbrev-ref", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        raise WorktreeBranchMismatchError(
+            worktree_path,
+            expected_branch,
+            "",
+            cause=f"git rev-parse failed: {e.stderr.strip() if e.stderr else e}",
+        ) from e
+    except FileNotFoundError as e:  # pragma: no cover - git always installed
+        raise WorktreeBranchMismatchError(
+            worktree_path,
+            expected_branch,
+            "",
+            cause=f"git executable not found: {e}",
+        ) from e
+
+    actual_branch = head.stdout.strip()
+    if actual_branch == expected_branch:
+        return
+
+    # Branch differs — inspect working tree cleanliness.
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(worktree_path), "status", "--porcelain"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        raise WorktreeBranchMismatchError(
+            worktree_path,
+            expected_branch,
+            actual_branch,
+            cause=f"git status failed: {e.stderr.strip() if e.stderr else e}",
+        ) from e
+
+    dirty = [line for line in status.stdout.splitlines() if line.strip()]
+    if dirty:
+        raise WorktreeBranchMismatchError(
+            worktree_path,
+            expected_branch,
+            actual_branch,
+            dirty_files=dirty,
+        )
+
+    # Clean — auto-recover by checking out the expected branch.
+    try:
+        subprocess.run(
+            ["git", "-C", str(worktree_path), "checkout", expected_branch],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        raise WorktreeBranchMismatchError(
+            worktree_path,
+            expected_branch,
+            actual_branch,
+            cause=f"git checkout failed: {e.stderr.strip() if e.stderr else e}",
+        ) from e
+
+    slug = worktree_path.name
+    logger.info(
+        "[worktree-branch-recovery] slug=%s path=%s from=%s to=%s "
+        "(auto-checkout of clean worktree, issue #1377)",
+        slug,
+        worktree_path,
+        actual_branch,
+        expected_branch,
+    )
+
+
 def worktree_busy_check(repo_root: Path, slug: str) -> tuple[str, str] | None:
     """Check whether any non-terminal AgentSession references this worktree.
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -183,6 +183,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [Worker Hibernation](worker-hibernation.md) | Mid-execution session pause and drip resume on Anthropic API failures: `paused` status, `worker:hibernating` Redis flag, `circuit-health-gate` and `session-recovery-drip` reflections | Shipped |
 | [Worker Service](worker-service.md) | Standalone worker process for AgentSession processing, OutputHandler protocol, TelegramRelayOutputHandler (Redis outbox), FileOutputHandler fallback, launchd service | Shipped |
 | [Workspace Safety Invariants](workspace-safety-invariants.md) | Pre-launch validation of agent working directories with CWD existence, path containment, and slug sanitization | Shipped |
+| [Worktree Manager](worktree-manager.md) | Branch verification on worktree reuse — `verify_worktree_branch` auto-checks-out clean worktrees and raises `WorktreeBranchMismatchError` on dirty ones, preventing silent MERGE-stage hangs from slug reuse (#1377) | Shipped |
 | [Worktree SDK Compatibility Experiment](worktree-sdk-compatibility.md) | Experiment results for Claude Agent SDK compatibility with git worktrees | Archived |
 | [xfail Hygiene](xfail-hygiene.md) | Three-layer xfail hygiene system preventing stale test markers after bug fixes land | Shipped |
 | [YouTube Search](youtube-search.md) | Search YouTube by query using yt-dlp, returning structured results (title, URL, duration, views) via `valor-youtube-search` CLI | Shipped |

--- a/docs/features/session-isolation.md
+++ b/docs/features/session-isolation.md
@@ -105,6 +105,10 @@ The three #887 layers above all live on the worker / agent code path. Nothing pr
 
 **Relationship to #887 and #1272:** sibling enforcement on a different surface. #887 covers the worker-side AgentSession executor; #1272 closes the slugless residual hole; #1288 covers the git-side path (`git commit` from the wrong CWD on a session branch). Together they make the invariant — "`session/{slug}` lives only in `.worktrees/{slug}/`" — a closed system across worker, CLI, and git surfaces.
 
+### Branch verification on worktree reuse (#1377)
+
+A worktree handed between SDLC stages may still be checked out to the previous stage's branch (e.g. BUILD leaves `.worktrees/{slug}/` on `session/{slug}`; a follow-up MERGE dev session expects `main`). The executor calls `verify_worktree_branch` after the #887 main-checkout guard and before launching the Claude Code subprocess. Clean worktrees are auto-checked-out to the expected branch with an INFO `[worktree-branch-recovery]` log; dirty worktrees raise `WorktreeBranchMismatchError` so the session fails loudly with `last_error` populated instead of hanging silently. See `docs/features/worktree-manager.md` for the full behavior table and rationale.
+
 ### Early Worktree Provisioning via `--slug`
 
 The `valor-session create` CLI command accepts a `--slug` flag that provisions a worktree at session creation time, before the session is enqueued:

--- a/docs/features/worktree-manager.md
+++ b/docs/features/worktree-manager.md
@@ -1,0 +1,104 @@
+# Worktree Manager
+
+`agent/worktree_manager.py` owns the lifecycle of git worktrees used for
+session filesystem isolation. Each work item (slug) gets its own directory
+under `.worktrees/{slug}/` checked out to branch `session/{slug}`.
+
+This document covers the **branch verification** subsystem added by issue
+[#1377](https://github.com/tomcounsell/ai/issues/1377). For the broader
+lifecycle (creation, cleanup, busy-checking) see `session-isolation.md`.
+
+## Why branch verification exists
+
+A BUILD-stage dev session creates `.worktrees/{slug}/` checked out to
+`session/{slug}`. When the PM later dispatches a follow-up dev session (e.g.
+MERGE) reusing the same slug, the worker reads the existing path and asks
+`resolve_branch_for_stage(slug, stage)` what branch to use. If
+`current_stage` is `None` on the AgentSession — or maps to `main` — the
+resolver returns `("main", False)` and worktree provisioning is skipped.
+Without a verification step, the executor would launch the Claude Code
+subprocess inside the worktree while it was still on `session/{slug}`,
+producing zero output until the startup watchdog killed it 6+ minutes
+later.
+
+`verify_worktree_branch` closes that gap. It is invoked from
+`session_executor.py` after the main-checkout protection guard (issue #887)
+and before the harness launches.
+
+## Behavior
+
+`verify_worktree_branch(worktree_path: Path, expected_branch: str) -> None`
+
+| Condition | Outcome | Log |
+|-----------|---------|-----|
+| `worktree_path` is `None` | `TypeError` | — |
+| `expected_branch` is empty/whitespace | `ValueError` | — |
+| `worktree_path` does not exist | `WorktreeBranchMismatchError` | — |
+| HEAD branch equals expected | return silently | (silent) |
+| HEAD branch differs, working tree clean | run `git checkout <expected>`, return | INFO `[worktree-branch-recovery]` with slug/from/to |
+| HEAD branch differs, working tree dirty | `WorktreeBranchMismatchError(dirty_files=[...])` | — |
+| Underlying git command fails | `WorktreeBranchMismatchError(cause=...)` | — |
+
+### Why auto-checkout on clean
+
+Two policies were considered: always raise, or auto-recover when safe. The
+"always raise" policy maximizes signal — every stale-slug condition becomes
+a visible session failure — but it also turns every benign stage handoff
+(BUILD finishes clean, MERGE picks up) into an operator chore. The
+auto-checkout policy is the conservative middle ground: it can only run
+when the working tree is clean (so no uncommitted work is at risk), it
+emits a structured `[worktree-branch-recovery]` log line so dashboard
+reflections can still surface the condition, and it raises on the
+dangerous case (dirty tree on the wrong branch).
+
+### Why raise on dirty
+
+Auto-checking-out a dirty worktree would either silently move uncommitted
+changes to a different branch (data loss risk) or fail mid-checkout in a
+git-specific way that does not name the underlying problem. Raising
+`WorktreeBranchMismatchError` with `dirty_files` populated preserves the
+work for human inspection and produces a `last_error` value the dashboard
+can render.
+
+## Invocation site
+
+```python
+# agent/session_executor.py (just after the issue #887 main-checkout guard)
+if _stype == "dev" and slug and WORKTREES_DIR in str(working_dir):
+    from agent.worktree_manager import (
+        WorktreeBranchMismatchError,
+        verify_worktree_branch,
+    )
+    try:
+        verify_worktree_branch(working_dir, branch_name)
+    except WorktreeBranchMismatchError as e:
+        logger.error(...)
+        raise
+```
+
+The guard fires for **every dev session with a slug**, not just MERGE —
+defense-in-depth that covers any future regression where stage inference
+returns the wrong branch.
+
+## Failure surface
+
+When the guard raises, the executor propagates the exception. The session
+ends with `status=failed` and `last_error` populated with the rendered
+exception message (including expected branch, actual branch, worktree
+path, and dirty file list). This is a visible failure mode, in contrast to
+the silent `communicated=False` hang it replaces.
+
+## Related
+
+- Issue [#1377](https://github.com/tomcounsell/ai/issues/1377) — bug
+  report and root cause.
+- PR #1367 — refuse-busy guard. Complementary; checks "is another session
+  using this worktree", not "is it on the expected branch".
+- PR #1291 — pre-commit guard against `session/*` commits outside
+  `.worktrees`.
+- PR #1280 — synthetic-slug funnel that routes every dev session through
+  `get_or_create_worktree`, concentrating traffic through the
+  now-guarded code path.
+- Issue #887 — main-checkout protection guard. The branch-mismatch guard
+  runs immediately after it in `session_executor.py`.
+- `docs/features/session-isolation.md` — overall worktree lifecycle.

--- a/tests/integration/test_merge_stage_slug_reuse.py
+++ b/tests/integration/test_merge_stage_slug_reuse.py
@@ -1,0 +1,88 @@
+"""Integration test for MERGE-stage slug-reuse failure mode (issue #1377).
+
+A BUILD dev session leaves ``.worktrees/{slug}/`` checked out to
+``session/{slug}``. When the PM later dispatches a MERGE dev session reusing
+the same slug, ``resolve_branch_for_stage`` may return ``("main", False)``
+(if ``current_stage`` is None or maps to main), and the executor used to
+launch the Claude Code subprocess inside the worktree while it was still on
+the wrong branch — producing zero output until the startup watchdog killed
+the session 6+ minutes later.
+
+This test exercises ``verify_worktree_branch`` against a worktree that
+mirrors the failure shape: a real on-disk worktree checked out to
+``session/{slug}`` where the executor's expected branch is ``main``.
+
+  * Clean worktree → auto-checkout, ends up on the expected branch.
+  * Dirty worktree → fails loudly with ``WorktreeBranchMismatchError``,
+    never silently hangs.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agent.worktree_manager import (
+    WorktreeBranchMismatchError,
+    verify_worktree_branch,
+)
+
+
+def _make_worktree_like_session(tmp_path: Path, slug: str) -> Path:
+    """Create a real git worktree checked out to session/{slug}.
+
+    This mirrors the on-disk shape ``valor-session create --role dev`` leaves
+    behind after a BUILD stage: a directory at ``.worktrees/{slug}/`` with HEAD
+    pointing at ``session/{slug}``.
+    """
+    repo = tmp_path / "wt"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main", str(repo)], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "t@example.com"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
+    (repo / "seed.txt").write_text("seed\n")
+    subprocess.run(["git", "-C", str(repo), "add", "seed.txt"], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-q", "-m", "seed"], check=True)
+    subprocess.run(["git", "-C", str(repo), "checkout", "-q", "-b", f"session/{slug}"], check=True)
+    return repo
+
+
+@pytest.mark.timeout(30)
+def test_merge_slug_reuse_clean_worktree_auto_recovers(tmp_path):
+    """The MERGE bug shape with a clean worktree: guard auto-recovers."""
+    slug = "sdlc-1377-merge"
+    worktree = _make_worktree_like_session(tmp_path, slug)
+
+    # Executor would resolve branch=main for a MERGE-stage dev session whose
+    # current_stage was not populated (the #1377 failure mode).
+    verify_worktree_branch(worktree, "main")
+
+    head = subprocess.run(
+        ["git", "-C", str(worktree), "rev-parse", "--abbrev-ref", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert head == "main", "guard should have checked out main on a clean worktree"
+
+
+@pytest.mark.timeout(30)
+def test_merge_slug_reuse_dirty_worktree_fails_loudly(tmp_path):
+    """Dirty worktree on the wrong branch: fail fast instead of silent hang."""
+    slug = "sdlc-1377-merge"
+    worktree = _make_worktree_like_session(tmp_path, slug)
+    (worktree / "wip.txt").write_text("uncommitted work\n")
+
+    with pytest.raises(WorktreeBranchMismatchError) as ei:
+        verify_worktree_branch(worktree, "main")
+
+    # The error must carry actionable detail so the caller (executor) can
+    # surface it in AgentSession.last_error and the dashboard can render it.
+    assert ei.value.expected_branch == "main"
+    assert ei.value.actual_branch == f"session/{slug}"
+    assert ei.value.dirty_files, "dirty_files must be populated"
+    msg = str(ei.value)
+    assert "main" in msg
+    assert f"session/{slug}" in msg

--- a/tests/unit/test_worktree_manager.py
+++ b/tests/unit/test_worktree_manager.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agent.worktree_manager import (
+    WorktreeBranchMismatchError,
     _cleanup_stale_worktree,
     _find_worktree_for_branch,
     _validate_slug,
@@ -14,6 +15,7 @@ from agent.worktree_manager import (
     create_worktree,
     get_or_create_worktree,
     remove_worktree,
+    verify_worktree_branch,
     worktree_busy_check,
 )
 
@@ -748,3 +750,88 @@ class TestCleanupAfterMergeBusyBlock:
         # to emit the distinct exit-2 path).
         assert any("blocked: worktree in use" in e for e in result["errors"])
         assert result["already_clean"] is False
+
+
+# ---------------------------------------------------------------------------
+# Issue #1377: verify_worktree_branch
+# ---------------------------------------------------------------------------
+
+
+def _init_git_worktree(tmp_path: Path, branch: str) -> Path:
+    """Create a real git repo at tmp_path checked out to ``branch``.
+
+    Uses subprocess + actual git for fidelity — the behavior under test
+    depends on real git semantics (rev-parse, status, checkout). Branch
+    ``main`` is created via the initial commit; additional branches are
+    created with ``git checkout -b``.
+    """
+    import subprocess as _sp
+
+    repo = tmp_path / "wt"
+    repo.mkdir()
+    _sp.run(["git", "init", "-q", "-b", "main", str(repo)], check=True)
+    _sp.run(["git", "-C", str(repo), "config", "user.email", "t@example.com"], check=True)
+    _sp.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
+    (repo / "seed.txt").write_text("seed\n")
+    _sp.run(["git", "-C", str(repo), "add", "seed.txt"], check=True)
+    _sp.run(["git", "-C", str(repo), "commit", "-q", "-m", "seed"], check=True)
+    if branch != "main":
+        _sp.run(["git", "-C", str(repo), "checkout", "-q", "-b", branch], check=True)
+    return repo
+
+
+class TestVerifyWorktreeBranch:
+    """Tests for verify_worktree_branch (issue #1377)."""
+
+    def test_matching_branch_is_noop(self, tmp_path, caplog):
+        repo = _init_git_worktree(tmp_path, "main")
+        with caplog.at_level("INFO", logger="agent.worktree_manager"):
+            verify_worktree_branch(repo, "main")
+        assert not any("worktree-branch-recovery" in r.message for r in caplog.records)
+
+    def test_mismatch_clean_auto_checks_out(self, tmp_path, caplog):
+        repo = _init_git_worktree(tmp_path, "session/sdlc-1377")
+        with caplog.at_level("INFO", logger="agent.worktree_manager"):
+            verify_worktree_branch(repo, "main")
+        import subprocess as _sp
+
+        head = _sp.run(
+            ["git", "-C", str(repo), "rev-parse", "--abbrev-ref", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        assert head == "main"
+        log_msgs = " ".join(r.message for r in caplog.records)
+        assert "worktree-branch-recovery" in log_msgs
+        assert "session/sdlc-1377" in log_msgs  # from-branch
+        assert "main" in log_msgs  # to-branch
+
+    def test_mismatch_dirty_raises(self, tmp_path):
+        repo = _init_git_worktree(tmp_path, "session/sdlc-1377")
+        (repo / "dirty.txt").write_text("uncommitted\n")
+        with pytest.raises(WorktreeBranchMismatchError) as ei:
+            verify_worktree_branch(repo, "main")
+        msg = str(ei.value)
+        assert "session/sdlc-1377" in msg
+        assert "main" in msg
+        assert ei.value.dirty_files  # non-empty
+        assert ei.value.expected_branch == "main"
+        assert ei.value.actual_branch == "session/sdlc-1377"
+
+    def test_missing_path_raises(self, tmp_path):
+        missing = tmp_path / "does-not-exist"
+        with pytest.raises(WorktreeBranchMismatchError) as ei:
+            verify_worktree_branch(missing, "main")
+        assert "does not exist" in str(ei.value)
+
+    def test_empty_expected_branch_raises_value_error(self, tmp_path):
+        repo = _init_git_worktree(tmp_path, "main")
+        with pytest.raises(ValueError):
+            verify_worktree_branch(repo, "")
+        with pytest.raises(ValueError):
+            verify_worktree_branch(repo, "   ")
+
+    def test_none_path_raises_type_error(self):
+        with pytest.raises(TypeError):
+            verify_worktree_branch(None, "main")


### PR DESCRIPTION
## Summary

A BUILD dev session leaves `.worktrees/{slug}/` checked out to `session/{slug}`. When the PM later dispatches a MERGE dev session reusing the same slug, `resolve_branch_for_stage` may return `("main", False)` — worktree provisioning is skipped, the executor launches Claude Code while the worktree is still on `session/{slug}`, and the agent produces zero output until the startup watchdog kills it 6+ minutes later.

This PR adds the missing branch-mismatch primitive and wires it into the executor.

## Changes

- `agent/worktree_manager.py`: new `verify_worktree_branch(path, expected)` plus `WorktreeBranchMismatchError`. Match → no-op. Mismatch + clean → `git checkout` with INFO `[worktree-branch-recovery]` log. Mismatch + dirty → raise with expected, actual, path, dirty file list. Missing path or git failure → raise with cause.
- `agent/session_executor.py`: invoke the guard after the #887 main-checkout guard for every dev session with a slug (defense-in-depth, not just MERGE).
- `tests/unit/test_worktree_manager.py::TestVerifyWorktreeBranch`: six tests covering match, mismatch+clean (auto-checkout + INFO log), mismatch+dirty (raises with both branches in message), missing path, empty expected, None path. Uses a real git init fixture.
- `tests/integration/test_merge_stage_slug_reuse.py`: reproduces the MERGE bug shape end-to-end.
- `docs/features/worktree-manager.md` (new), `session-isolation.md` cross-reference, README index entry.

## Testing

- [x] 6 new unit tests pass
- [x] 2 new integration tests pass
- [x] 51 existing worktree_manager tests still pass
- [x] ruff check + format clean

Closes #1377