### PR TITLE
feat(update): PM persona overlay drift check — Step 4.10 (#1396)

### DIFF
--- a/docs/features/remote-update.md
+++ b/docs/features/remote-update.md
@@ -73,6 +73,17 @@ if not result.projects_json_check.available:
 
 Bridge code does *not* validate on its own startup — that would crash the live process when a bad config lands on disk via iCloud sync. The gate is exclusively in the update path. See [Single-Machine Ownership](single-machine-ownership.md) for the full validator scope.
 
+### PM persona overlay drift check
+
+Step 4.10 of `scripts/update/run.py` compares the in-repo PM persona template (`config/personas/project-manager.md`) against the private per-machine vault overlay (`~/Desktop/Valor/personas/project-manager.md`). Logic lives in `scripts/update/persona_drift.py::check_pm_persona_drift` so tests exercise the real helper.
+
+The check is **surface only**: it never auto-merges, never mutates files, and never raises (any unexpected error becomes a warning). Behavior:
+
+- **In sync or either file absent (fresh machine):** silent, no warning. Logs `PM persona overlay: in sync (or files absent)` in verbose mode.
+- **Drift detected:** appends a warning of the form `PM persona overlay drift: N lines differ. Run 'diff <repo_template> <overlay>' to review.` to `result.warnings`. The operator resolves drift manually — typically by reconciling the vault overlay into the repo template or vice versa.
+
+The check matches the same pattern as the Steps 4.8/4.9 memory and BYOB MCP drift checks. Implements Phase 2 of [issue #1396](https://github.com/tomcounsell/ai/issues/1396); Phase 1 (dynamic MCP loading) is deferred.
+
 ### Technical Approach
 
 #### 1. `scripts/remote-update.sh`

--- a/docs/plans/sdlc-1396.md
+++ b/docs/plans/sdlc-1396.md
@@ -209,7 +209,7 @@ No existing tests need to be deleted or replaced. The dynamic MCP loading is add
 
 ### Phase 2 — PM-Overlay Drift Check
 - [ ] `/update` run with identical in-repo template and private overlay emits no drift warning.
-- [ ] `/update` run with a one-line difference between in-repo template and private overlay emits a visible warning naming the diverged file.
+- [x] `/update` run with a one-line difference between in-repo template and private overlay emits a visible warning naming the diverged file.
 - [ ] `/update` run on a machine where `~/Desktop/Valor/personas/project-manager.md` is absent completes without error and emits no drift warning.
 - [ ] `--verify` mode: drift is reported in `result.warnings`, not as a fatal error.
 - [ ] `pytest tests/unit/test_update_drift_check.py` passes.

--- a/scripts/update/persona_drift.py
+++ b/scripts/update/persona_drift.py
@@ -1,0 +1,87 @@
+"""PM persona overlay drift check.
+
+Compares the in-repo PM persona template against the private per-machine
+vault overlay and returns a list of human-readable warnings. The check is
+purely a surface — it never auto-merges, never mutates files, and never
+raises (any unexpected error becomes a warning).
+
+The default template path matches the actual file in the repo
+(`config/personas/project-manager.md`); the `config/personas/segments/`
+directory holds universal segments only and has no `project-manager.md`.
+
+Used by `scripts/update/run.py` Step 4.10 and exercised end-to-end by
+`tests/unit/test_update_persona_drift.py`.
+"""
+
+from __future__ import annotations
+
+import difflib
+from pathlib import Path
+
+DEFAULT_TEMPLATE_REL = Path("config/personas/project-manager.md")
+DEFAULT_OVERLAY_PATH = Path.home() / "Desktop" / "Valor" / "personas" / "project-manager.md"
+
+
+def check_pm_persona_drift(
+    project_dir: Path,
+    *,
+    template_rel: Path = DEFAULT_TEMPLATE_REL,
+    overlay_path: Path | None = None,
+) -> list[str]:
+    """Return warnings produced by the PM persona drift check.
+
+    Parameters
+    ----------
+    project_dir:
+        The repo root. The template path is resolved relative to this so the
+        check is independent of the caller's current working directory.
+    template_rel:
+        Repo-relative path to the in-repo template. Defaults to
+        ``config/personas/project-manager.md``.
+    overlay_path:
+        Absolute path to the private vault overlay. Defaults to
+        ``~/Desktop/Valor/personas/project-manager.md``.
+
+    Returns
+    -------
+    list[str]
+        Empty list when files are in sync or either file is absent.
+        A single warning string when drift is detected or an error is
+        encountered. Never raises.
+    """
+
+    warnings: list[str] = []
+    overlay = overlay_path if overlay_path is not None else DEFAULT_OVERLAY_PATH
+    repo_template = project_dir / template_rel
+
+    try:
+        if not repo_template.exists():
+            return warnings
+        if not overlay.exists():
+            return warnings
+
+        template_lines = repo_template.read_text().splitlines(keepends=True)
+        overlay_lines = overlay.read_text().splitlines(keepends=True)
+        diff = list(
+            difflib.unified_diff(
+                template_lines,
+                overlay_lines,
+                fromfile=str(repo_template),
+                tofile=str(overlay),
+            )
+        )
+        if diff:
+            diff_lines = len(
+                [
+                    line
+                    for line in diff
+                    if line.startswith(("+", "-")) and not line.startswith(("+++", "---"))
+                ]
+            )
+            warnings.append(
+                f"PM persona overlay drift: {diff_lines} lines differ. "
+                f"Run 'diff {repo_template} {overlay}' to review."
+            )
+    except Exception as exc:  # noqa: BLE001 - drift check must never crash /update
+        warnings.append(f"PM persona overlay drift check failed (WARNING): {exc}")
+    return warnings

--- a/scripts/update/run.py
+++ b/scripts/update/run.py
@@ -965,6 +965,52 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
             # --verify mode: report drift but do not warn aggressively
             result.warnings.append(f"BYOB MCP drift: {mcp_byob_result.message}")
 
+    # Step 4.10: Check PM persona overlay drift between in-repo template and private vault.
+    # Surface only — never auto-merges. Fails gracefully if vault file absent (fresh machine).
+    log("Checking PM persona overlay drift...", v)
+    try:
+        import difflib
+        from pathlib import Path
+
+        repo_template = Path("config/personas/segments/project-manager.md")
+        private_overlay = Path.home() / "Desktop" / "Valor" / "personas" / "project-manager.md"
+
+        if not repo_template.exists():
+            log("  PM persona template not found — skipping drift check", v)
+        elif not private_overlay.exists():
+            log("  No private overlay found — skipping (fresh machine)", v)
+        else:
+            template_lines = repo_template.read_text().splitlines(keepends=True)
+            overlay_lines = private_overlay.read_text().splitlines(keepends=True)
+            diff = list(
+                difflib.unified_diff(
+                    template_lines,
+                    overlay_lines,
+                    fromfile="config/personas/segments/project-manager.md",
+                    tofile="~/Desktop/Valor/personas/project-manager.md",
+                )
+            )
+            if diff:
+                diff_lines = len(
+                    [
+                        line
+                        for line in diff
+                        if line.startswith(("+", "-")) and not line.startswith(("+++", "---"))
+                    ]
+                )
+                result.warnings.append(
+                    f"PM persona overlay drift: {diff_lines} lines differ. "
+                    f"Run 'diff config/personas/segments/project-manager.md "
+                    f"~/Desktop/Valor/personas/project-manager.md' to review."
+                )
+                log(f"  PM persona overlay drift: {diff_lines} changed lines", v)
+            else:
+                log("  PM persona overlay: in sync", v)
+    except Exception as _persona_exc:
+        _persona_warn = f"PM persona overlay drift check failed (WARNING): {_persona_exc}"
+        log(f"  {_persona_warn}", v)
+        result.warnings.append(_persona_warn)
+
     # Step 4.95: Check that each active project repo has a '## Running' README section.
     # Warn only — never blocks the update. Guides devs to document startup commands
     # in their repo's README rather than relying on a generic skill to guess.

--- a/scripts/update/run.py
+++ b/scripts/update/run.py
@@ -970,7 +970,6 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
     log("Checking PM persona overlay drift...", v)
     try:
         import difflib
-        from pathlib import Path
 
         repo_template = Path("config/personas/segments/project-manager.md")
         private_overlay = Path.home() / "Desktop" / "Valor" / "personas" / "project-manager.md"

--- a/scripts/update/run.py
+++ b/scripts/update/run.py
@@ -35,6 +35,7 @@ from scripts.update import (  # noqa: E402
     migrations,
     npm_tools,
     officecli,
+    persona_drift,
     readme_check,
     reflections_yaml,
     rodney,
@@ -967,48 +968,15 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
 
     # Step 4.10: Check PM persona overlay drift between in-repo template and private vault.
     # Surface only — never auto-merges. Fails gracefully if vault file absent (fresh machine).
+    # All logic lives in scripts/update/persona_drift.py so unit tests exercise the real code.
     log("Checking PM persona overlay drift...", v)
-    try:
-        import difflib
-
-        repo_template = Path("config/personas/segments/project-manager.md")
-        private_overlay = Path.home() / "Desktop" / "Valor" / "personas" / "project-manager.md"
-
-        if not repo_template.exists():
-            log("  PM persona template not found — skipping drift check", v)
-        elif not private_overlay.exists():
-            log("  No private overlay found — skipping (fresh machine)", v)
-        else:
-            template_lines = repo_template.read_text().splitlines(keepends=True)
-            overlay_lines = private_overlay.read_text().splitlines(keepends=True)
-            diff = list(
-                difflib.unified_diff(
-                    template_lines,
-                    overlay_lines,
-                    fromfile="config/personas/segments/project-manager.md",
-                    tofile="~/Desktop/Valor/personas/project-manager.md",
-                )
-            )
-            if diff:
-                diff_lines = len(
-                    [
-                        line
-                        for line in diff
-                        if line.startswith(("+", "-")) and not line.startswith(("+++", "---"))
-                    ]
-                )
-                result.warnings.append(
-                    f"PM persona overlay drift: {diff_lines} lines differ. "
-                    f"Run 'diff config/personas/segments/project-manager.md "
-                    f"~/Desktop/Valor/personas/project-manager.md' to review."
-                )
-                log(f"  PM persona overlay drift: {diff_lines} changed lines", v)
-            else:
-                log("  PM persona overlay: in sync", v)
-    except Exception as _persona_exc:
-        _persona_warn = f"PM persona overlay drift check failed (WARNING): {_persona_exc}"
-        log(f"  {_persona_warn}", v)
-        result.warnings.append(_persona_warn)
+    _persona_warnings = persona_drift.check_pm_persona_drift(project_dir)
+    if _persona_warnings:
+        for _w in _persona_warnings:
+            log(f"  {_w}", v)
+            result.warnings.append(_w)
+    else:
+        log("  PM persona overlay: in sync (or files absent)", v)
 
     # Step 4.95: Check that each active project repo has a '## Running' README section.
     # Warn only — never blocks the update. Guides devs to document startup commands

--- a/tests/unit/test_update_persona_drift.py
+++ b/tests/unit/test_update_persona_drift.py
@@ -1,8 +1,8 @@
-"""Unit tests for PM persona overlay drift check in scripts/update/run.py.
+"""Unit tests for PM persona overlay drift check.
 
-The drift check (Step 4.10) compares the in-repo PM persona template
-(config/personas/segments/project-manager.md) against the private vault
-overlay (~Desktop/Valor/personas/project-manager.md).
+Exercises the real implementation in ``scripts.update.persona_drift`` so the
+production code (Step 4.10 in ``scripts/update/run.py``) is covered by these
+tests, not a parallel re-implementation.
 
 Verifies:
   - Identical files → no warning
@@ -11,91 +11,59 @@ Verifies:
   - Template absent → no warning, no error
   - Both absent → no warning, no error
   - IOError reading file → warning appended, no crash
+  - Default repo template path resolves to the real PM persona file
 """
 
 from __future__ import annotations
 
-import difflib
 from pathlib import Path
 from unittest.mock import patch
 
-# ---------------------------------------------------------------------------
-# Helper — replicate the drift-check logic as a callable for unit testing.
-# We test the logic directly rather than importing from run.py because run.py
-# has many heavy side effects at import time (env reads, dataclass creation).
-# The implementation in run.py follows this exact logic.
-# ---------------------------------------------------------------------------
+from scripts.update.persona_drift import (
+    DEFAULT_TEMPLATE_REL,
+    check_pm_persona_drift,
+)
 
 
-def _run_persona_drift_check(
-    repo_template: Path,
-    private_overlay: Path,
-) -> list[str]:
-    """Return list of warnings produced by the Step 4.10 drift check.
-
-    Mirrors the try/except block added to scripts/update/run.py exactly,
-    with the file paths parameterised for test isolation.
+def _setup(
+    tmp_path: Path,
+    template_text: str | None,
+    overlay_text: str | None,
+) -> tuple[Path, Path]:
+    """Create a fake project_dir with the template at the real relative path
+    and an overlay file alongside. Returns (project_dir, overlay_path).
     """
-    warnings: list[str] = []
-    try:
-        if not repo_template.exists():
-            return warnings
-        if not private_overlay.exists():
-            return warnings
-
-        template_lines = repo_template.read_text().splitlines(keepends=True)
-        overlay_lines = private_overlay.read_text().splitlines(keepends=True)
-        diff = list(
-            difflib.unified_diff(
-                template_lines,
-                overlay_lines,
-                fromfile=str(repo_template),
-                tofile=str(private_overlay),
-            )
-        )
-        if diff:
-            diff_lines = len(
-                [
-                    line
-                    for line in diff
-                    if line.startswith(("+", "-")) and not line.startswith(("+++", "---"))
-                ]
-            )
-            warnings.append(
-                f"PM persona overlay drift: {diff_lines} lines differ. "
-                f"Run 'diff {repo_template} {private_overlay}' to review."
-            )
-    except Exception as exc:
-        warnings.append(f"PM persona overlay drift check failed (WARNING): {exc}")
-    return warnings
-
-
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
+    project_dir = tmp_path / "repo"
+    project_dir.mkdir()
+    template_path = project_dir / DEFAULT_TEMPLATE_REL
+    if template_text is not None:
+        template_path.parent.mkdir(parents=True, exist_ok=True)
+        template_path.write_text(template_text)
+    overlay_path = tmp_path / "overlay-project-manager.md"
+    if overlay_text is not None:
+        overlay_path.write_text(overlay_text)
+    return project_dir, overlay_path
 
 
 def test_identical_files_no_warning(tmp_path):
     """Identical template and overlay should produce no warning."""
     content = "# PM Persona\n\nYou are a PM.\n"
-    template = tmp_path / "project-manager.md"
-    overlay = tmp_path / "overlay-project-manager.md"
-    template.write_text(content)
-    overlay.write_text(content)
+    project_dir, overlay = _setup(tmp_path, content, content)
 
-    warnings = _run_persona_drift_check(template, overlay)
+    warnings = check_pm_persona_drift(project_dir, overlay_path=overlay)
 
     assert warnings == []
 
 
 def test_one_line_difference_produces_warning(tmp_path):
     """A single line difference should append a warning with a line count."""
-    template = tmp_path / "project-manager.md"
-    overlay = tmp_path / "overlay-project-manager.md"
-    template.write_text("# PM Persona\n\nYou are a PM.\n")
-    overlay.write_text("# PM Persona\n\nYou are a senior PM.\n")
+    project_dir, overlay = _setup(
+        tmp_path,
+        "# PM Persona\n\nYou are a PM.\n",
+        "# PM Persona\n\nYou are a senior PM.\n",
+    )
 
-    warnings = _run_persona_drift_check(template, overlay)
+    warnings = check_pm_persona_drift(project_dir, overlay_path=overlay)
 
     assert len(warnings) == 1
     assert "PM persona overlay drift" in warnings[0]
@@ -105,12 +73,13 @@ def test_one_line_difference_produces_warning(tmp_path):
 
 def test_line_count_reflects_actual_diff(tmp_path):
     """Diff line count should match the number of +/- lines in the unified diff."""
-    template = tmp_path / "project-manager.md"
-    overlay = tmp_path / "overlay-project-manager.md"
-    template.write_text("line1\nline2\nline3\n")
-    overlay.write_text("line1\nchanged2\nchanged3\n")
+    project_dir, overlay = _setup(
+        tmp_path,
+        "line1\nline2\nline3\n",
+        "line1\nchanged2\nchanged3\n",
+    )
 
-    warnings = _run_persona_drift_check(template, overlay)
+    warnings = check_pm_persona_drift(project_dir, overlay_path=overlay)
 
     assert len(warnings) == 1
     # 2 removed + 2 added = 4 diff lines
@@ -119,42 +88,35 @@ def test_line_count_reflects_actual_diff(tmp_path):
 
 def test_private_overlay_absent_no_warning(tmp_path):
     """When the private overlay does not exist, no warning is emitted (fresh machine)."""
-    template = tmp_path / "project-manager.md"
-    template.write_text("# PM Persona\n")
-    # overlay intentionally not created
+    project_dir, _ = _setup(tmp_path, "# PM Persona\n", None)
 
-    warnings = _run_persona_drift_check(template, tmp_path / "nonexistent.md")
+    warnings = check_pm_persona_drift(project_dir, overlay_path=tmp_path / "nonexistent.md")
 
     assert warnings == []
 
 
 def test_template_absent_no_warning(tmp_path):
     """When the repo template does not exist, no warning is emitted."""
-    overlay = tmp_path / "overlay-project-manager.md"
-    overlay.write_text("# PM Persona\n")
-    # template intentionally not created
+    project_dir, overlay = _setup(tmp_path, None, "# PM Persona\n")
 
-    warnings = _run_persona_drift_check(tmp_path / "nonexistent.md", overlay)
+    warnings = check_pm_persona_drift(project_dir, overlay_path=overlay)
 
     assert warnings == []
 
 
 def test_both_absent_no_warning(tmp_path):
     """When neither file exists, no warning is emitted."""
-    warnings = _run_persona_drift_check(
-        tmp_path / "nonexistent-template.md",
-        tmp_path / "nonexistent-overlay.md",
-    )
+    project_dir = tmp_path / "repo"
+    project_dir.mkdir()
+
+    warnings = check_pm_persona_drift(project_dir, overlay_path=tmp_path / "nonexistent-overlay.md")
 
     assert warnings == []
 
 
 def test_ioerror_reading_file_appends_warning_no_crash(tmp_path):
     """An IOError while reading files should append a warning but not crash."""
-    template = tmp_path / "project-manager.md"
-    overlay = tmp_path / "overlay-project-manager.md"
-    template.write_text("# PM Persona\n")
-    overlay.write_text("# PM Persona\n")
+    project_dir, overlay = _setup(tmp_path, "# PM Persona\n", "# PM Persona\n")
 
     original_read_text = Path.read_text
 
@@ -164,7 +126,7 @@ def test_ioerror_reading_file_appends_warning_no_crash(tmp_path):
         return original_read_text(self, *args, **kwargs)
 
     with patch.object(Path, "read_text", failing_read_text):
-        warnings = _run_persona_drift_check(template, overlay)
+        warnings = check_pm_persona_drift(project_dir, overlay_path=overlay)
 
     assert len(warnings) == 1
     assert "WARNING" in warnings[0] or "drift check failed" in warnings[0]
@@ -172,12 +134,22 @@ def test_ioerror_reading_file_appends_warning_no_crash(tmp_path):
 
 def test_warning_contains_diff_command(tmp_path):
     """Warning message should include a diff command operators can run."""
-    template = tmp_path / "project-manager.md"
-    overlay = tmp_path / "overlay-project-manager.md"
-    template.write_text("original content\n")
-    overlay.write_text("changed content\n")
+    project_dir, overlay = _setup(tmp_path, "original content\n", "changed content\n")
 
-    warnings = _run_persona_drift_check(template, overlay)
+    warnings = check_pm_persona_drift(project_dir, overlay_path=overlay)
 
     assert len(warnings) == 1
     assert "diff" in warnings[0]
+
+
+def test_default_template_path_points_at_real_file():
+    """Regression test for the path bug in the original PR: the default repo
+    template path must resolve to an existing file at the repo root, not a
+    nonexistent `segments/project-manager.md`.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    template_path = repo_root / DEFAULT_TEMPLATE_REL
+    assert template_path.exists(), (
+        f"DEFAULT_TEMPLATE_REL ({DEFAULT_TEMPLATE_REL}) does not resolve to a real file "
+        f"at {template_path}. The drift check would silently no-op on every machine."
+    )

--- a/tests/unit/test_update_persona_drift.py
+++ b/tests/unit/test_update_persona_drift.py
@@ -1,0 +1,183 @@
+"""Unit tests for PM persona overlay drift check in scripts/update/run.py.
+
+The drift check (Step 4.10) compares the in-repo PM persona template
+(config/personas/segments/project-manager.md) against the private vault
+overlay (~Desktop/Valor/personas/project-manager.md).
+
+Verifies:
+  - Identical files → no warning
+  - One-line difference → warning appended with line count
+  - Private overlay absent → no warning, no error (fresh machine)
+  - Template absent → no warning, no error
+  - Both absent → no warning, no error
+  - IOError reading file → warning appended, no crash
+"""
+
+from __future__ import annotations
+
+import difflib
+from pathlib import Path
+from unittest.mock import patch
+
+# ---------------------------------------------------------------------------
+# Helper — replicate the drift-check logic as a callable for unit testing.
+# We test the logic directly rather than importing from run.py because run.py
+# has many heavy side effects at import time (env reads, dataclass creation).
+# The implementation in run.py follows this exact logic.
+# ---------------------------------------------------------------------------
+
+
+def _run_persona_drift_check(
+    repo_template: Path,
+    private_overlay: Path,
+) -> list[str]:
+    """Return list of warnings produced by the Step 4.10 drift check.
+
+    Mirrors the try/except block added to scripts/update/run.py exactly,
+    with the file paths parameterised for test isolation.
+    """
+    warnings: list[str] = []
+    try:
+        if not repo_template.exists():
+            return warnings
+        if not private_overlay.exists():
+            return warnings
+
+        template_lines = repo_template.read_text().splitlines(keepends=True)
+        overlay_lines = private_overlay.read_text().splitlines(keepends=True)
+        diff = list(
+            difflib.unified_diff(
+                template_lines,
+                overlay_lines,
+                fromfile=str(repo_template),
+                tofile=str(private_overlay),
+            )
+        )
+        if diff:
+            diff_lines = len(
+                [
+                    line
+                    for line in diff
+                    if line.startswith(("+", "-")) and not line.startswith(("+++", "---"))
+                ]
+            )
+            warnings.append(
+                f"PM persona overlay drift: {diff_lines} lines differ. "
+                f"Run 'diff {repo_template} {private_overlay}' to review."
+            )
+    except Exception as exc:
+        warnings.append(f"PM persona overlay drift check failed (WARNING): {exc}")
+    return warnings
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_identical_files_no_warning(tmp_path):
+    """Identical template and overlay should produce no warning."""
+    content = "# PM Persona\n\nYou are a PM.\n"
+    template = tmp_path / "project-manager.md"
+    overlay = tmp_path / "overlay-project-manager.md"
+    template.write_text(content)
+    overlay.write_text(content)
+
+    warnings = _run_persona_drift_check(template, overlay)
+
+    assert warnings == []
+
+
+def test_one_line_difference_produces_warning(tmp_path):
+    """A single line difference should append a warning with a line count."""
+    template = tmp_path / "project-manager.md"
+    overlay = tmp_path / "overlay-project-manager.md"
+    template.write_text("# PM Persona\n\nYou are a PM.\n")
+    overlay.write_text("# PM Persona\n\nYou are a senior PM.\n")
+
+    warnings = _run_persona_drift_check(template, overlay)
+
+    assert len(warnings) == 1
+    assert "PM persona overlay drift" in warnings[0]
+    # Unified diff counts the removed line AND the added line → 2 diff_lines
+    assert "2 lines differ" in warnings[0]
+
+
+def test_line_count_reflects_actual_diff(tmp_path):
+    """Diff line count should match the number of +/- lines in the unified diff."""
+    template = tmp_path / "project-manager.md"
+    overlay = tmp_path / "overlay-project-manager.md"
+    template.write_text("line1\nline2\nline3\n")
+    overlay.write_text("line1\nchanged2\nchanged3\n")
+
+    warnings = _run_persona_drift_check(template, overlay)
+
+    assert len(warnings) == 1
+    # 2 removed + 2 added = 4 diff lines
+    assert "4 lines differ" in warnings[0]
+
+
+def test_private_overlay_absent_no_warning(tmp_path):
+    """When the private overlay does not exist, no warning is emitted (fresh machine)."""
+    template = tmp_path / "project-manager.md"
+    template.write_text("# PM Persona\n")
+    # overlay intentionally not created
+
+    warnings = _run_persona_drift_check(template, tmp_path / "nonexistent.md")
+
+    assert warnings == []
+
+
+def test_template_absent_no_warning(tmp_path):
+    """When the repo template does not exist, no warning is emitted."""
+    overlay = tmp_path / "overlay-project-manager.md"
+    overlay.write_text("# PM Persona\n")
+    # template intentionally not created
+
+    warnings = _run_persona_drift_check(tmp_path / "nonexistent.md", overlay)
+
+    assert warnings == []
+
+
+def test_both_absent_no_warning(tmp_path):
+    """When neither file exists, no warning is emitted."""
+    warnings = _run_persona_drift_check(
+        tmp_path / "nonexistent-template.md",
+        tmp_path / "nonexistent-overlay.md",
+    )
+
+    assert warnings == []
+
+
+def test_ioerror_reading_file_appends_warning_no_crash(tmp_path):
+    """An IOError while reading files should append a warning but not crash."""
+    template = tmp_path / "project-manager.md"
+    overlay = tmp_path / "overlay-project-manager.md"
+    template.write_text("# PM Persona\n")
+    overlay.write_text("# PM Persona\n")
+
+    original_read_text = Path.read_text
+
+    def failing_read_text(self, *args, **kwargs):
+        if self == overlay:
+            raise OSError("Permission denied")
+        return original_read_text(self, *args, **kwargs)
+
+    with patch.object(Path, "read_text", failing_read_text):
+        warnings = _run_persona_drift_check(template, overlay)
+
+    assert len(warnings) == 1
+    assert "WARNING" in warnings[0] or "drift check failed" in warnings[0]
+
+
+def test_warning_contains_diff_command(tmp_path):
+    """Warning message should include a diff command operators can run."""
+    template = tmp_path / "project-manager.md"
+    overlay = tmp_path / "overlay-project-manager.md"
+    template.write_text("original content\n")
+    overlay.write_text("changed content\n")
+
+    warnings = _run_persona_drift_check(template, overlay)
+
+    assert len(warnings) == 1
+    assert "diff" in warnings[0]


### PR DESCRIPTION
## Summary

- Adds Step 4.10 to `scripts/update/run.py` that diffs the in-repo PM persona template (`config/personas/segments/project-manager.md`) against the private vault overlay (`~/Desktop/Valor/personas/project-manager.md`)
- When drift is detected, appends a warning to `result.warnings` with the line count and a ready-to-run `diff` command — surface only, never auto-merges
- Skips gracefully when the private overlay is absent (fresh machine) or the template is missing; wrapped in `try/except` so any IOError appends a WARNING but never crashes the update run
- Matches the exact code pattern of the existing Steps 4.8/4.9 MCP drift checks

## Test plan

- [x] `pytest tests/unit/test_update_persona_drift.py -v` — 8 passed
- [x] `python -m ruff check scripts/update/run.py` — 0 errors
- [x] `python -m ruff format --check scripts/update/run.py` — already formatted
- [ ] Manual verify: create a diverged overlay at `~/Desktop/Valor/personas/project-manager.md` and run the update script — expect a warning line in output

Closes #1396 (Phase 2 only — Phase 1 dynamic MCP loading deferred to spike)