### PR TITLE
feat(sdlc): multi-dev fan-out and DAG stage dispatch (#1393)

### DIFF
--- a/.claude/skills-global/sdlc/SKILL.md
+++ b/.claude/skills-global/sdlc/SKILL.md
@@ -175,29 +175,67 @@ sdlc-tool dispatch get --issue-number {issue_number}
 
 The CLI wraps `agent.sdlc_router.record_dispatch()` and `tools.stage_states_helpers.update_stage_states()` — it is the correct runtime entry point. Never call `record_dispatch()` directly from a shell or skill script; always use `sdlc-tool dispatch record`.
 
-## Step 4: Dispatch ONE Sub-Skill
+## Step 4: Dispatch ONE Sub-Skill (or a Parallel-Safe Pair)
 
-**Do not pattern-match against a hand-edited table.** Instead, call the routing tool and dispatch whatever skill it returns. The tool evaluates all guards (G1–G6) and dispatch rules (14 rows) against live state.
+**Do not pattern-match against a hand-edited table.** Instead, call the routing tool and dispatch whatever skill it returns. The tool evaluates all guards (G1–G7) and dispatch rules (14 rows) against live state.
 
 ```bash
 # Get the next dispatch decision
 sdlc-tool next-skill --issue-number {issue_number}
 ```
 
-The tool outputs JSON:
+The tool outputs JSON in one of three shapes:
+
+Single dispatch:
 ```json
 {"skill": "/do-build", "reason": "...", "row_id": "4a", "dispatched": true}
 ```
 
-Or when blocked:
+Multi-dispatch (parallel-safe pair, e.g. DOCS + PATCH after REVIEW):
+```json
+{"multi": true, "dispatched": true,
+ "skills": ["/do-docs", "/do-patch"],
+ "dispatches": [
+   {"skill": "/do-docs", "reason": "...", "row_id": "9"},
+   {"skill": "/do-patch", "reason": "...", "row_id": "8"}
+ ],
+ "reason": "parallel-safe pair: /do-docs (9) + /do-patch (8)"}
+```
+
+Blocked:
 ```json
 {"blocked": true, "reason": "G4: stage oscillation ...", "guard_id": "G4"}
 ```
 
 **How to use the output:**
-1. If `dispatched` is `true`: record the dispatch via `sdlc-tool dispatch record` (see Step 3.5), then invoke the returned `skill`.
-2. If `blocked` is `true`: surface the `reason` to the human and wait. Do NOT loop or guess an alternative skill.
-3. If neither key is present (error): log the `error` field and escalate to the human.
+1. If `multi` is `true`: invoke the `pthread` skill to run all listed `skills` as parallel sub-agents. Record dispatch for the *first* skill in the list (the multi-dispatch is gated by guards as one decision -- a guard fire on the first dispatch replaces the whole pair). After both sub-agents complete, re-invoke `/sdlc` to re-dispatch based on the new pipeline state.
+2. If `dispatched` is `true` (single): record the dispatch via `sdlc-tool dispatch record` (see Step 3.5), then invoke the returned `skill`.
+3. If `blocked` is `true`: surface the `reason` to the human and wait. Do NOT loop or guess an alternative skill.
+4. If neither key is present (error): log the `error` field and escalate to the human.
+
+### Multi-dev fan-out (BUILD stage, Phase 1)
+
+When BUILD is the dispatched stage and the plan decomposes cleanly into independent work units, the PM may fan out one Dev sub-session per unit instead of running a single Dev session through the plan serially. The pattern:
+
+1. Decompose the plan:
+   ```bash
+   sdlc-decompose docs/plans/{slug}.md
+   ```
+   Emits a JSON array of units (`unit_id`, `description`, `tasks`). Cap is `MAX_PARALLEL_DEVS` (default 3) -- over-cap decompositions exit non-zero and the PM falls back to single-dev BUILD.
+2. If the array has only one unit: dispatch `/do-build` normally (single-dev path).
+3. If the array has 2+ units: for each unit `u_i`, **sequentially** call
+   ```bash
+   valor-session create --role dev --parent $AGENT_SESSION_ID \
+     --slug {slug}-u{i} --message "Implement unit {u_i}: {description}. Tasks: ..."
+   ```
+   Sub-slug worker_keys are distinct, so the worker runs the children concurrently. (Sequential creation only -- timestamp-based ID collision risk for parallel creation.)
+4. Call `valor-session wait-for-children --session-id $AGENT_SESSION_ID`. This transitions the PM to `waiting_for_children`; `_finalize_parent_sync` auto-resumes the PM when every child reaches a terminal status.
+5. On resume:
+   - If any child has non-`completed` terminal status: use `valor-session steer --id <child-id> --message "fix: ..."` to re-drive that child rather than spawning a replacement. Re-wait via `wait-for-children`.
+   - If all children completed: dispatch one merge-integration Dev session with slug `{slug}-merge`. Its message instructs it to `git checkout session/{slug}` then `git merge session/{slug}-u1 session/{slug}-u2 ...` in unit_id order. On conflict, the merge session writes the conflict file list to `last_error` and exits non-zero -- escalate to human (no automated conflict resolution).
+6. After the merge session completes, steer to TEST stage on the parent slug; the single-dev path resumes.
+
+Fan-out is BUILD-only in Phase 1. TEST, REVIEW, DOCS, MERGE remain serial.
 
 **Before recording and dispatching**, also supply `--proposed-skill` when you already know what skill you intend to invoke (enables G3 PR-lock detection):
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,7 @@ valor-email threads
 | `tail -f logs/worker.log` | Stream worker logs (includes reflection scheduler) |
 | `sdlc-tool stage-query --issue-number {N}` | Query SDLC pipeline state for an issue (cwd-independent — see `docs/features/sdlc-tool-resolver.md`) |
 | `sdlc-tool verdict get --stage CRITIQUE --issue-number {N}` | Read the recorded critique verdict for an issue (also: `--stage REVIEW`) |
+| `sdlc-decompose docs/plans/{slug}.md` | Decompose a plan into independent dev work units for multi-dev fan-out (see `docs/features/sdlc-parallel-execution.md`). Caps at `MAX_PARALLEL_DEVS` (default 3); exits non-zero on over-cap. |
 | `python scripts/sdlc_reflection.py` | Run SDLC reflection manually |
 | `python scripts/sdlc_reflection.py --dry-run` | Preview SDLC reflection without writing |
 | `python scripts/sdlc_reflection.py --days 14` | Run with larger lookback window |

--- a/agent/sdlc_router.py
+++ b/agent/sdlc_router.py
@@ -58,6 +58,40 @@ MAX_PLAN_REVISING_DISPATCHES = 2
 # memory growth on long-running sessions.
 MAX_DISPATCH_HISTORY = 10
 
+# Phase 1 (multi-dev fan-out): maximum number of concurrent Dev sub-sessions
+# the PM may spawn for a single issue via ``sdlc-decompose``. Exceeding this cap
+# causes ``sdlc-decompose`` to exit non-zero (fail closed; multi-wave queueing
+# is explicitly out of scope -- see docs/plans/sdlc-1393.md "Rabbit Holes").
+MAX_PARALLEL_DEVS = 3
+
+# Phase 2 (DAG stage dispatch): set of stage-name pairs that may dispatch
+# concurrently when BOTH are simultaneously ``ready`` AND both match a row in
+# ``DISPATCH_RULES``. This is intentionally separate from ``PIPELINE_EDGES``
+# (which is a state-machine transition table keyed by ``(stage, outcome)``);
+# parallel-safety is a dispatch-time decision, not a graph topology fact.
+#
+# Seeded with {DOCS, PATCH} -- after REVIEW completes with findings, DOCS
+# (write/refresh user-facing docs) and PATCH (fix review nits) have no data
+# dependency on each other and can proceed in parallel. The PM session
+# orchestrates the two skills via the existing ``pthread`` skill.
+PARALLEL_SAFE_PAIRS: set[frozenset[str]] = {frozenset({"DOCS", "PATCH"})}
+
+# Mapping from skill command to the stage that skill advances. Used by the
+# router to identify the stage backing a chosen ``Dispatch`` so we can look it
+# up in ``PARALLEL_SAFE_PAIRS``. Kept local to ``sdlc_router`` to avoid an
+# import cycle with ``pipeline_graph``.
+_SKILL_TO_STAGE: dict[str, str] = {
+    "/do-issue": "ISSUE",
+    "/do-plan": "PLAN",
+    "/do-plan-critique": "CRITIQUE",
+    "/do-build": "BUILD",
+    "/do-test": "TEST",
+    "/do-patch": "PATCH",
+    "/do-pr-review": "REVIEW",
+    "/do-docs": "DOCS",
+    "/do-merge": "MERGE",
+}
+
 # Stages whose statuses are considered "complete" markers. A stage with any
 # other value is still pending from the router's perspective.
 STATUS_COMPLETED = "completed"
@@ -105,6 +139,26 @@ class Blocked:
 
     reason: str
     guard_id: str | None = None
+
+
+@dataclass(frozen=True)
+class MultiDispatch:
+    """Two or more Dispatch decisions that may run concurrently.
+
+    Returned by :func:`decide_next_dispatch` when (a) the first matching
+    ``DISPATCH_RULES`` row produces a Dispatch, AND (b) another ``ready``
+    stage forms a :data:`PARALLEL_SAFE_PAIRS` pair with the first dispatch's
+    stage AND that other stage also matches a dispatch row.
+
+    Callers (notably ``tools/sdlc_next_skill.py`` and the SDLC skill) are
+    expected to honour all guards on the *first* dispatch -- if a guard
+    redirects or blocks, the entire ``MultiDispatch`` is replaced by the
+    guard's decision. Guards are evaluated BEFORE the parallel-pair scan, so
+    a single guard fire short-circuits the multi-dispatch path.
+    """
+
+    dispatches: list[Dispatch]
+    reason: str
 
 
 # Type alias for the predicate functions in DISPATCH_RULES. Each takes the
@@ -819,18 +873,85 @@ DISPATCH_RULES: list[DispatchRule] = [
 # ---------------------------------------------------------------------------
 
 
+def _stage_is_ready(stage_states: dict, stage: str) -> bool:
+    """Return True if a stage's status is ``ready``, ``pending``, or ``failed``.
+
+    ``ready`` is the canonical "next stage may dispatch" status used by
+    ``PipelineStateMachine``. ``pending`` and ``failed`` are also treated as
+    dispatchable so that the parallel-pair scan does not miss a stage that
+    needs a patch (e.g., PATCH stage with status ``failed`` after REVIEW).
+    """
+    status = stage_states.get(stage)
+    return status in ("ready", "pending", "failed")
+
+
+def _find_parallel_dispatch(
+    primary: Dispatch,
+    stage_states: dict,
+    meta: dict,
+    context: dict,
+) -> Dispatch | None:
+    """Find a second Dispatch that may run concurrently with ``primary``.
+
+    Walks ``PARALLEL_SAFE_PAIRS`` looking for a pair containing the primary
+    dispatch's stage. For the *other* stage in the pair, scans ``DISPATCH_RULES``
+    in row order for a matching rule whose chosen skill resolves to that stage.
+
+    Returns the second Dispatch, or ``None`` if no parallel-safe peer is ready.
+    """
+    primary_stage = _SKILL_TO_STAGE.get(primary.skill)
+    if not primary_stage:
+        return None
+
+    for pair in PARALLEL_SAFE_PAIRS:
+        if primary_stage not in pair:
+            continue
+        # The OTHER stage in the pair.
+        peer_stages = pair - {primary_stage}
+        if not peer_stages:
+            continue
+        peer_stage = next(iter(peer_stages))
+
+        # The peer stage must be in a dispatchable state. We don't require
+        # status == "ready" exactly because PATCH frequently sits at "failed"
+        # before patching, and DOCS frequently sits at "pending".
+        if not _stage_is_ready(stage_states, peer_stage):
+            continue
+
+        # Find a dispatch rule that picks the peer stage's skill.
+        for rule in DISPATCH_RULES:
+            if rule.row_id == primary.row_id:
+                continue
+            rule_stage = _SKILL_TO_STAGE.get(rule.skill)
+            if rule_stage != peer_stage:
+                continue
+            try:
+                if rule.state_predicate(stage_states, meta, context):
+                    return Dispatch(
+                        skill=rule.skill,
+                        reason=rule.reason,
+                        row_id=rule.row_id,
+                    )
+            except Exception as e:
+                logger.debug(f"Parallel DispatchRule {rule.row_id} predicate raised: {e}")
+    return None
+
+
 def decide_next_dispatch(
     stage_states: dict,
     meta: dict | None = None,
     context: dict | None = None,
-) -> Dispatch | Blocked:
-    """Decide which sub-skill the SDLC router should dispatch next.
+) -> Dispatch | MultiDispatch | Blocked:
+    """Decide which sub-skill(s) the SDLC router should dispatch next.
 
     Algorithm:
-      1. Evaluate guards G1–G5. If any guard trips, return its decision.
-      2. Otherwise, walk ``DISPATCH_RULES`` in row order. Return the first
-         rule whose ``state_predicate`` returns True.
-      3. If no rule matches, return ``Blocked(reason="no matching rule")``.
+      1. Evaluate guards G1–G7. If any guard trips, return its decision.
+      2. Otherwise, walk ``DISPATCH_RULES`` in row order. Take the first
+         rule whose ``state_predicate`` returns True as the *primary* dispatch.
+      3. Scan ``PARALLEL_SAFE_PAIRS`` for a parallel-safe peer dispatch. If a
+         second eligible Dispatch exists, wrap both into a ``MultiDispatch``;
+         otherwise return the primary Dispatch alone.
+      4. If no rule matches at all, return ``Blocked(reason="no matching rule")``.
 
     Args:
         stage_states: The stage-status dict from ``AgentSession.stage_states``.
@@ -845,8 +966,9 @@ def decide_next_dispatch(
             ``current_plan_hash`` for G5 and ``proposed_skill`` for G3.
 
     Returns:
-        ``Dispatch`` with the chosen skill and rationale, or ``Blocked`` if
-        the router escalates to human.
+        ``Dispatch`` with a single chosen skill, ``MultiDispatch`` when two
+        parallel-safe stages are both ready, or ``Blocked`` if the router
+        escalates to human.
     """
     meta = meta or {}
     context = context or {}
@@ -855,23 +977,39 @@ def decide_next_dispatch(
     if guard_result is not None:
         return guard_result
 
+    primary: Dispatch | None = None
     for rule in DISPATCH_RULES:
         try:
             if rule.state_predicate(stage_states, meta, context):
-                return Dispatch(
+                primary = Dispatch(
                     skill=rule.skill,
                     reason=rule.reason,
                     row_id=rule.row_id,
                 )
+                break
         except Exception as e:
             # Predicates should never raise; log and continue so one bad rule
             # doesn't break the whole dispatch.
             logger.debug(f"DispatchRule {rule.row_id} predicate raised: {e}")
 
-    return Blocked(
-        reason="no matching dispatch rule",
-        guard_id=None,
-    )
+    if primary is None:
+        return Blocked(
+            reason="no matching dispatch rule",
+            guard_id=None,
+        )
+
+    # Phase 2: look for a parallel-safe peer dispatch.
+    peer = _find_parallel_dispatch(primary, stage_states, meta, context)
+    if peer is not None:
+        return MultiDispatch(
+            dispatches=[primary, peer],
+            reason=(
+                f"parallel-safe pair: {primary.skill} ({primary.row_id}) + "
+                f"{peer.skill} ({peer.row_id})"
+            ),
+        )
+
+    return primary
 
 
 def record_dispatch(

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -126,6 +126,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [SDLC Critique Stage](sdlc-critique-stage.md) | Automated plan validation between PLAN and BUILD stages with parallel war-room critics and inline source file verification | Shipped |
 | [SDLC Enforcement](sdlc-enforcement.md) | Quality gates for code sessions: user-level hooks, pipeline stage model, settings merger, cross-repo enforcement | Shipped |
 | [SDLC Observer](sdlc-observer.md) | Web dashboard for real-time SDLC pipeline tracking with stage indicators, event timelines, and artifact links at `/sdlc/` | Shipped |
+| [SDLC Parallel Execution](sdlc-parallel-execution.md) | Phase 1 multi-dev fan-out at BUILD via `sdlc-decompose` + sub-slug `{slug}-u{i}` Dev sessions; Phase 2 `MultiDispatch` for parallel-safe stage pairs (DOCS+PATCH) | Shipped |
 | [SDLC Pipeline](sdlc-pipeline.md) | Pipeline routing overview, G1–G7 legal dispatch guards, `_meta` field reference, plan-revising lock (G7), and CLI tool reference | Shipped |
 | [SDLC Pipeline Integrity](sdlc-pipeline-integrity.md) | Session continuation hardening, deterministic URL construction, merge guard hook, MERGE pipeline stage, and structured review comment enforcement | Shipped |
 | [SDLC Pipeline State](sdlc-pipeline-state.md) | Local Claude Code session state tracking via `--issue-number` flag and `sdlc_session_ensure` tool, enabling stage markers to write to Redis without bridge env vars | Shipped |

--- a/docs/features/sdlc-parallel-execution.md
+++ b/docs/features/sdlc-parallel-execution.md
@@ -1,0 +1,255 @@
+# SDLC Parallel Execution
+
+Multi-dev fan-out within a single issue (Phase 1) and DAG stage dispatch
+across parallel-safe stage pairs (Phase 2). Tracked by issue #1393;
+supersedes #1307 and #1308.
+
+## What changed
+
+Before this feature, the SDLC pipeline was strictly linear: each stage
+blocked until its predecessor completed, and within a single issue the PM
+created exactly one Dev session at a time. A plan with independent frontend
+and backend work executed them serially, doubling or tripling wall-clock
+build time with no technical reason.
+
+Two parallel paths now exist:
+
+| Path | Stage | Mechanism | Cap |
+|------|-------|-----------|-----|
+| Phase 1 — Multi-dev fan-out | BUILD | `sdlc-decompose` + sub-slug Dev sessions + existing `valor-session wait-for-children` | `MAX_PARALLEL_DEVS` (default 3) |
+| Phase 2 — DAG stage dispatch | post-REVIEW | `MultiDispatch` from `decide_next_dispatch` + `pthread` skill | `PARALLEL_SAFE_PAIRS` (currently `{DOCS, PATCH}`) |
+
+Phase 1 is strictly additive — the single-dev path is unchanged. Phase 2
+widens the router's return type from `Dispatch | Blocked` to
+`Dispatch | MultiDispatch | Blocked` and seeds a single parallel-safe pair
+(`DOCS`/`PATCH`).
+
+## Phase 1 — Multi-dev fan-out (BUILD)
+
+### Trigger
+
+When a plan's `## Implementation Plan` section decomposes cleanly into
+multiple independent work units, the PM may fan out one Dev sub-session per
+unit rather than running a single Dev session through the entire plan.
+
+Two units are *independent* when they touch disjoint sets of files AND can
+be implemented without one's output. Tests for a unit live with the unit;
+documentation is its own unit only when it does not depend on
+implementation details.
+
+### Sub-slug naming
+
+Sub-slugs follow the pattern `{slug}-u{i}` where `i` is the unit index from
+`sdlc-decompose`. Examples for issue #1393:
+
+- `sdlc-1393-u1` — Phase 1 decompose CLI
+- `sdlc-1393-u2` — Phase 2 router widening
+- `sdlc-1393-merge` — integration session that merges sub-slug branches
+
+Each sub-slug produces a distinct `worker_key` in `AgentSession`, so the
+worker (per-`worker_key` FIFO queue) executes them concurrently. The
+existing `worktree_manager.get_or_create_worktree` allocates one worktree
+per sub-slug at `.worktrees/{slug}-u{i}/`.
+
+### `sdlc-decompose` CLI
+
+```bash
+sdlc-decompose docs/plans/{slug}.md
+sdlc-decompose docs/plans/{slug}.md --max-units 3
+```
+
+Reads the plan's `## Implementation Plan` section, calls Claude (haiku) to
+identify independent units, validates the output schema, enforces the
+`MAX_PARALLEL_DEVS` cap, and prints a JSON array on stdout:
+
+```json
+[
+  {
+    "unit_id": "phase1_decompose_cli",
+    "description": "Build sdlc-decompose CLI and register entry point",
+    "tasks": ["Task 1.1 — ...", "Task 1.2 — ...", "..."]
+  },
+  {
+    "unit_id": "phase2_router_widening",
+    "description": "Add MultiDispatch and PARALLEL_SAFE_PAIRS to router",
+    "tasks": ["Task 2.1 — ...", "..."]
+  }
+]
+```
+
+Exit codes:
+
+- `0` — JSON printed; the PM proceeds with fan-out.
+- `1` — fatal error (plan not found, malformed JSON from Claude, schema
+  violation, over-cap decomposition). The PM falls back to a single-dev
+  BUILD on `/do-build`.
+- `2` — usage error.
+
+Schema rules (all enforced before printing):
+
+- `unit_id` is a non-empty `[a-z0-9_]+` snake_case string and unique within
+  the response.
+- `description` is a non-empty string.
+- `tasks` is a non-empty list of non-empty strings.
+- `len(units) <= max_units` — over-cap decompositions fail closed; this is
+  intentional. Multi-wave queueing is explicitly out of scope (see issue
+  #1393, "Rabbit Holes").
+
+The cap is read from `agent.sdlc_router.MAX_PARALLEL_DEVS` (default `3`) and
+can be overridden per invocation via `--max-units N`.
+
+### Fan-out workflow
+
+After `sdlc-decompose` returns a multi-unit array, the SDLC skill steps the
+PM through this sequence (documented in `.claude/skills-global/sdlc/SKILL.md`):
+
+1. **Sequential session creation** — for each unit `u_i`:
+
+   ```bash
+   valor-session create --role dev --parent $AGENT_SESSION_ID \
+     --slug {slug}-u{i} \
+     --message "Implement unit {u_i}: {description}. Tasks: ..."
+   ```
+
+   Sequential, never parallel — parallel creation collides on the
+   timestamp-based session ID (see `feedback_sequential_session_creation`).
+
+2. **Wait for children** — the PM calls the **existing** CLI:
+
+   ```bash
+   valor-session wait-for-children --session-id $AGENT_SESSION_ID
+   ```
+
+   This transitions the PM to status `waiting_for_children`. The lifecycle
+   hook `_finalize_parent_sync` in `models/session_lifecycle.py` auto-resumes
+   the PM when every child reaches a terminal status. Phase 1 reuses this
+   transition-and-resume mechanism unchanged — no polling CLI is added.
+
+3. **On resume**:
+
+   - **Failed children** (terminal status != `completed`): steer each failed
+     child via `valor-session steer --id <id> --message "fix: ..."` rather
+     than spawning a replacement. Re-call `wait-for-children`. Loop until
+     every child completes.
+   - **All children completed**: dispatch one merge-integration Dev session:
+
+     ```bash
+     valor-session create --role dev --parent $AGENT_SESSION_ID \
+       --slug {slug}-merge \
+       --message "git checkout session/{slug}; git merge session/{slug}-u1 session/{slug}-u2 ... in unit_id order. On conflict, write conflict file list to last_error and exit non-zero."
+     ```
+
+4. **After merge** — steer to TEST stage on the parent slug. The single-dev
+   path resumes (TEST, REVIEW, DOCS, MERGE remain serial in Phase 1).
+
+### Failure modes
+
+- **`sdlc-decompose` returns over-cap**: exit 1; PM falls back to
+  single-dev BUILD. Phase 1 explicitly does not queue overflow waves.
+- **Sub-slug merge conflict**: the merge-integration session writes the
+  conflict file list to `last_error` and exits non-zero. The PM escalates
+  to the human; no automated conflict resolution.
+- **Worker not running**: `valor-session create` warns to stderr but
+  enqueues; sub-sessions execute when the worker boots.
+
+## Phase 2 — DAG stage dispatch (post-REVIEW)
+
+### `MultiDispatch` return type
+
+`agent.sdlc_router.decide_next_dispatch` now returns
+`Dispatch | MultiDispatch | Blocked`:
+
+```python
+@dataclass(frozen=True)
+class MultiDispatch:
+    dispatches: list[Dispatch]
+    reason: str
+```
+
+A `MultiDispatch` is returned when:
+
+1. The first matching `DISPATCH_RULES` row produces a primary `Dispatch`.
+2. The primary dispatch's *stage* (e.g., `PATCH` for `/do-patch`) is in a
+   `PARALLEL_SAFE_PAIRS` pair.
+3. The other stage in that pair is in a dispatchable state
+   (`ready` | `pending` | `failed`).
+4. A different `DISPATCH_RULES` row produces a `Dispatch` whose skill
+   resolves to that other stage.
+
+Guards (G1–G7) are evaluated BEFORE the parallel-pair scan. A single guard
+fire short-circuits the entire `MultiDispatch` — there is no partial
+dispatch. This is intentional: e.g., G3 (PR-lock plan-stage dispatch) and
+G6 (terminal merge fast-path) are both stronger signals than parallel-safety.
+
+### `PARALLEL_SAFE_PAIRS`
+
+```python
+PARALLEL_SAFE_PAIRS: set[frozenset[str]] = {frozenset({"DOCS", "PATCH"})}
+```
+
+Pairs are *stages*, not skills. Currently only `{DOCS, PATCH}` is seeded:
+after REVIEW completes with `PARTIAL` or `CHANGES REQUESTED` findings, the
+PM may dispatch `/do-patch` (row 8) and `/do-docs` (row 9) concurrently
+because writing/refreshing user docs has no data dependency on the patch
+content.
+
+This set is intentionally separate from `agent/pipeline_graph.PIPELINE_EDGES`
+(which is a state-machine transition table keyed by `(stage, outcome)`).
+Parallel-safety is a dispatch-time decision, not a graph topology fact.
+
+### `sdlc-tool next-skill` JSON output
+
+The CLI wrapper at `tools/sdlc_next_skill.py` emits a third response shape
+alongside the existing single-dispatch and blocked shapes:
+
+```json
+{
+  "multi": true,
+  "dispatched": true,
+  "skills": ["/do-docs", "/do-patch"],
+  "dispatches": [
+    {"skill": "/do-docs", "reason": "...", "row_id": "9"},
+    {"skill": "/do-patch", "reason": "...", "row_id": "8"}
+  ],
+  "reason": "parallel-safe pair: /do-docs (9) + /do-patch (8)"
+}
+```
+
+### PM orchestration via `pthread`
+
+The SDLC skill, on receiving a multi-dispatch, invokes the existing
+`pthread` skill to spawn each listed skill as a parallel sub-agent. The PM
+session itself does not split. Both sub-agents must terminate (success or
+failure) before the PM re-invokes `/sdlc` to re-dispatch based on the new
+pipeline state.
+
+If `pthread` is unavailable on the current machine, the PM falls back to
+sequential dispatch of the listed skills in array order — the parallel
+path is an optimisation, not a correctness requirement.
+
+## Non-goals
+
+The following are explicitly out of scope; see issue #1393 "Rabbit Holes"
+and "No-Gos" for full rationale:
+
+- Multi-PM fan-out across issues (already shipped in #786).
+- Changing `worker_key` semantics.
+- Parallel BUILD + TEST stages (BUILD must complete before TEST).
+- Dynamic pipeline graph rewriting at runtime.
+- Multi-wave queueing for over-cap decompositions.
+- Polling-based wait CLI (the existing `wait-for-children` transition-and-resume
+  pattern is the sole wait mechanism).
+- Automated merge conflict resolution between sub-slug branches.
+
+## See also
+
+- `agent/sdlc_router.py` — `MultiDispatch`, `PARALLEL_SAFE_PAIRS`,
+  `decide_next_dispatch`, `_find_parallel_dispatch`.
+- `tools/sdlc_decompose.py` — `sdlc-decompose` CLI implementation.
+- `tools/sdlc_next_skill.py` — JSON wrapper that emits the `multi` shape.
+- `.claude/skills-global/sdlc/SKILL.md` — Step 4 fan-out + multi-dispatch
+  PM procedures.
+- `models/session_lifecycle.py` — `_finalize_parent_sync` (parent auto-resume
+  on children-terminal).
+- `tools/valor_session.py` — `cmd_wait_for_children`.
+- `docs/features/session-isolation.md` — sub-slug worktree allocation.

--- a/docs/plans/sdlc-1393.md
+++ b/docs/plans/sdlc-1393.md
@@ -5,7 +5,7 @@ appetite: Large
 owner: Valor
 created: 2026-05-19
 tracking: https://github.com/tomcounsell/ai/issues/1393
-last_comment_id: IC_kwDOEYGa088AAAABC1T9vA IC_kwDOEYGa088AAAABC1T9vA
+last_comment_id: IC_kwDOEYGa088AAAABC1T9vA
 revision_applied: true
 ---
 

--- a/docs/plans/sdlc-1393.md
+++ b/docs/plans/sdlc-1393.md
@@ -5,7 +5,7 @@ appetite: Large
 owner: Valor
 created: 2026-05-19
 tracking: https://github.com/tomcounsell/ai/issues/1393
-last_comment_id: IC_kwDOEYGa088AAAABC1T9vA
+last_comment_id: IC_kwDOEYGa088AAAABC1T9vA IC_kwDOEYGa088AAAABC1T9vA
 revision_applied: true
 ---
 

--- a/docs/plans/sdlc-1393.md
+++ b/docs/plans/sdlc-1393.md
@@ -5,7 +5,7 @@ appetite: Large
 owner: Valor
 created: 2026-05-19
 tracking: https://github.com/tomcounsell/ai/issues/1393
-last_comment_id:
+last_comment_id: IC_kwDOEYGa088AAAABC1T9vA
 revision_applied: true
 ---
 

--- a/docs/plans/sdlc-1393.md
+++ b/docs/plans/sdlc-1393.md
@@ -23,10 +23,10 @@ The SDLC pipeline is strictly linear: each stage blocks until its predecessor co
 - The infrastructure for concurrent dev sessions already exists: `worker_key = slug` serializes sessions with the same key, but sessions with distinct keys run concurrently today. The PM simply never exploits this.
 
 **Desired outcome:**
-1. **Phase 1 — Multi-dev fan-out:** For a single issue, the PM identifies genuinely independent work units in the plan doc, spawns one Dev session per unit with a distinct sub-slug (`{slug}-{unit_id}`), waits for all to complete via `wait-for-children`, then proceeds to TEST.
+1. **Phase 1 — Multi-dev fan-out:** For a single issue, the PM identifies genuinely independent work units in the plan doc, spawns one Dev session per unit with a distinct sub-slug (`{slug}-{unit_id}`), then uses the **existing** `valor-session wait-for-children` (transition-and-resume via `_finalize_parent_sync`) to go dormant until all children reach terminal status. The PM then proceeds to a merge-integration step before TEST.
 2. **Phase 2 — DAG stage dispatch:** The PM dispatches stages that have no data dependency concurrently — starting with DOCS running in parallel with an eligible post-REVIEW PATCH cycle.
 
-Phase 1 is strictly additive (no changes to the single-dev path). Phase 2 requires annotating `PIPELINE_EDGES` with explicit data dependencies.
+Phase 1 is strictly additive (no changes to the single-dev path). Phase 2 introduces a `PARALLEL_SAFE_PAIRS` lookup consulted by `decide_next_dispatch`; dispatch decisions continue to live in `DISPATCH_RULES`, not `PIPELINE_EDGES` (which is a state-machine transition table keyed by `(stage, outcome)`).
 
 ## Freshness Check
 
@@ -35,11 +35,12 @@ Phase 1 is strictly additive (no changes to the single-dev path). Phase 2 requir
 **Disposition:** Unchanged — no commits have touched `agent/sdlc_router.py`, `agent/pipeline_graph.py`, or `tools/valor_session.py` since the issue was filed.
 
 **File:line references verified at plan time:**
-- `agent/sdlc_router.py` — `decide_next_dispatch()` returns a single `Dispatch | Blocked`. Confirmed: no multi-dispatch path exists.
-- `agent/pipeline_graph.py` — `PIPELINE_EDGES` is a dict mapping stage → next stage (linear). No dependency annotations. Confirmed by reading the file.
+- `agent/sdlc_router.py` — `decide_next_dispatch()` returns a single `Dispatch | Blocked`. Confirmed: no multi-dispatch path exists. Guards are G1–G7 (G1 critique loop, G2 cycle cap, G3 PR locks plan stages, G4 stage oscillation, G5 cached verdict, G6 mergeable fast-path, G7 plan-revising lock).
+- `agent/pipeline_graph.py:40` — `PIPELINE_EDGES: dict[tuple[str, str], str]` — keyed by `(stage, outcome)` pairs, not by stage alone. Used by `pipeline_graph.next_stage()` for state-machine bookkeeping, **not** by `decide_next_dispatch()`. Router docstring explicitly states: "Never consulted for dispatch decisions". Dispatch lives in `DISPATCH_RULES` (row-ordered).
 - `models/agent_session.py:472` — `worker_key` field gates parallel execution. Sessions with distinct `worker_key` values run concurrently in the worker. Confirmed.
-- `tools/valor_session.py` — `create` command accepts `--slug` and `--role dev`. Confirmed.
-- No `tools/sdlc_children.py` exists yet (the `wait-for-children` CLI mentioned in the issue is a new deliverable).
+- `tools/valor_session.py:1049` — `cmd_wait_for_children` **already exists**. It transitions the calling session to `waiting_for_children` status; `_finalize_parent_sync` in `models/session_lifecycle.py` auto-resumes the parent when all children reach terminal status. This is the canonical wait mechanism — Phase 1 reuses it rather than introducing a polling CLI.
+- `tools/valor_session.py:1345` — `wait-for-children` is wired as a sub-command.
+- `.claude/skills-global/sdlc/SKILL.md` — canonical SDLC skill path (note: `skills-global`, not `skills`).
 
 **Active plans in `docs/plans/` overlapping this area:**
 - `docs/plans/sdlc-1394.md` (this session) — PM watchdog and plan-doc lifecycle. Adjacent but non-conflicting.
@@ -72,56 +73,62 @@ No external libraries or APIs required.
 
 ### Phase 1 — Multi-dev fan-out
 
-1. **Entry:** PM skill reads plan doc, calls `sdlc-tool decompose-work-units` (new CLI) which uses LLM to identify independent task groups.
-2. **Fan-out:** For each unit `u_i`, PM calls `valor-session create --role dev --slug {slug}-u{i} --message "..."`. Each session gets `worker_key = {slug}-u{i}`, which is distinct, so the worker executes them concurrently.
-3. **Wait:** PM calls `valor-session wait-for-children --parent-slug {slug} --timeout 3600`. This blocks (with periodic liveness tokens) until all child sessions reach a terminal state.
-4. **Aggregate:** On all-success, PM steers to TEST stage. On any failure, PM steers the failed child via `valor-session steer --id <id> --message "fix: ..."`.
-5. **Merge:** After all sub-sessions complete, the PM dispatches a merge-integration session (`{slug}-merge`) that merges the sub-slug branches into `session/{slug}`.
+1. **Entry:** PM skill reads plan doc, calls `sdlc-decompose docs/plans/{slug}.md` (new CLI) which uses Claude to identify independent task groups. Output is a JSON array; the CLI validates the schema and the cap (`max_parallel_devs`) before printing.
+2. **Cap enforcement:** If `len(units) > max_parallel_devs`, the CLI prints only the first `max_parallel_devs` units and a `note` field listing the deferred unit_ids. Phase 1 ships with strict cap-and-fail: deferred units cause the decomposition to exit non-zero with a clear error. Multi-wave queueing is explicitly out of scope (see Rabbit Holes).
+3. **Fan-out:** For each unit `u_i`, PM calls `valor-session create --role dev --parent $AGENT_SESSION_ID --slug {slug}-u{i} --message "..."`. Each session gets `worker_key = {slug}-u{i}`, which is distinct, so the worker executes them concurrently. Sessions are created sequentially (per `feedback_sequential_session_creation`).
+4. **Wait (reuses existing mechanism):** PM calls the **existing** `valor-session wait-for-children --session-id $AGENT_SESSION_ID`. This transitions the PM to `waiting_for_children` status. The lifecycle hook `_finalize_parent_sync` in `models/session_lifecycle.py` auto-resumes the PM when all children reach a terminal status. No new polling CLI is added.
+5. **Merge:** After resume, the PM dispatches a single merge-integration dev session (`{slug}-merge`) that checks out `session/{slug}` and merges each `session/{slug}-u{i}` branch in `unit_id` order. On conflict, the merge session fails with the conflict files in `last_error`; the PM escalates to the human (no automated conflict resolution).
+6. **Aggregate / failure path:** On any child failure (terminal status != `completed`), the PM resumes from `waiting_for_children` with an outcome message listing failed children. The PM steers each failed child via `valor-session steer --id <id> --message "fix: ..."` rather than re-spawning. Only after all children re-reach `completed` does the merge-integration step run.
+7. **Hand-off:** Once `session/{slug}` contains the merged work, PM steers to TEST stage on the parent slug (single-dev path resumes).
 
 ### Phase 2 — DAG stage dispatch
 
-1. **Annotation:** `PIPELINE_EDGES` gains an optional `depends_on: [stage, ...]` per edge. Stages without `depends_on` can run concurrently when `ready`.
-2. **Router change:** `decide_next_dispatch()` returns `MultiDispatch([Dispatch(skill_A), Dispatch(skill_B)])` when two stages are both `ready` and neither depends on the other's output.
-3. **PM execution:** The PM skill receives a `MultiDispatch` and spawns concurrent child invocations.
-4. **Concrete example:** After REVIEW completes, both DOCS (no dependency on PATCH) and any PATCH cycle can run concurrently. MERGE waits until both are complete.
+1. **New module-level constant:** `PARALLEL_SAFE_PAIRS: set[frozenset[str]]` in `agent/sdlc_router.py` — pairs of stages that may dispatch concurrently when both are `ready`. Seeded with `{frozenset({"DOCS", "PATCH"})}`. This is **separate** from `PIPELINE_EDGES`, which keeps its state-machine role unchanged.
+2. **Router change:** `decide_next_dispatch()` first walks `DISPATCH_RULES` in row order as today. After the first matching `Dispatch`, it checks whether any *other* `ready` stage forms a `parallel-safe` pair with the dispatched skill's stage. If yes, it returns `MultiDispatch([Dispatch(A), Dispatch(B)])`.
+3. **Concurrent execution model:** The SDLC skill, on receiving a `MultiDispatch` from `sdlc-tool next-skill`, uses the existing `pthread` skill to spawn the two child skill invocations as parallel sub-agents. Each sub-agent is a fresh skill dispatch (e.g., `/do-docs` and `/do-patch`); the PM session itself does not split.
+4. **Synchronization:** Both `pthread` sub-agents must complete (success or failure) before the PM proceeds. The PM then calls `/sdlc` again to re-dispatch based on the new pipeline state.
+5. **Concrete example:** After REVIEW completes with `READY TO MERGE WITH NITS`, the router returns `MultiDispatch([Dispatch("/do-docs"), Dispatch("/do-patch")])`. The PM runs both concurrently via `pthread`. MERGE waits until both terminate.
+6. **Guard interactions:** All existing guards (G1–G7) continue to fire on the first dispatch evaluated. Phase 2 does not introduce new guards; it widens the return type only.
 
 ## Architectural Impact
 
 - **New modules:**
-  - `tools/sdlc_children.py` — `wait-for-children` CLI. Queries `AgentSession` for children by parent slug; polls until all terminal; emits liveness tokens.
-  - `tools/sdlc_decompose.py` — `decompose-work-units` CLI. Calls Claude to analyze plan doc task sections and return a JSON list of independent unit descriptions.
+  - `tools/sdlc_decompose.py` — `sdlc-decompose` CLI. Reads a plan doc, calls Claude to identify independent task groups, validates output schema, enforces `max_parallel_devs` cap, prints JSON.
+- **Reused (unchanged) modules:**
+  - `tools/valor_session.py:1049` — `cmd_wait_for_children` is reused as-is. No new wait CLI introduced (avoids the name collision with the existing transition-and-resume semantics).
 - **Modified modules:**
-  - `agent/sdlc_router.py` — Phase 2: `decide_next_dispatch` may return `MultiDispatch` for parallel-safe stages. New `MultiDispatch` dataclass alongside `Dispatch`.
-  - `agent/pipeline_graph.py` — Phase 2: `PIPELINE_EDGES` entries gain optional `parallel_safe: bool` annotation. DAG-aware traversal helper.
-  - `pyproject.toml` — Register new CLI entry points: `sdlc-decompose`, `sdlc-wait-children`.
+  - `agent/sdlc_router.py` — Phase 2: new `MultiDispatch` dataclass alongside `Dispatch`; new `PARALLEL_SAFE_PAIRS: set[frozenset[str]]` module constant; `decide_next_dispatch` may return `MultiDispatch`. `PIPELINE_EDGES` is **not** modified.
+  - `tools/sdlc_next_skill.py` — Phase 2: handle `MultiDispatch` (emit JSON array of skill commands rather than a single command).
+  - `.claude/skills-global/sdlc/SKILL.md` — Phase 1: document the fan-out + wait pattern. Phase 2: document `MultiDispatch` handling and `pthread` orchestration.
+  - `pyproject.toml` — register one new CLI entry point: `sdlc-decompose`.
 - **Interface changes:**
-  - `decide_next_dispatch()` return type widens to `Dispatch | MultiDispatch | Blocked`. Callers in `tools/sdlc_next_skill.py` must handle `MultiDispatch`.
-  - The SDLC skill (`SKILL.md`) must be updated to describe the fan-out and wait pattern.
-- **Coupling:** Phase 1 adds no coupling to existing code paths. The single-dev path is unchanged. Phase 2 adds a dependency between `sdlc_router.py` and the new DAG annotations in `pipeline_graph.py`.
-- **Reversibility:** High for Phase 1 (additive). Medium for Phase 2 (requires reverting annotations and the router widening).
+  - `decide_next_dispatch()` return type widens from `Dispatch | Blocked` to `Dispatch | MultiDispatch | Blocked`. Downstream callers (`tools/sdlc_next_skill.py`, tests) must handle the new variant.
+- **Coupling:** Phase 1 adds no coupling to existing dispatch code paths. The single-dev path is unchanged. Phase 2 adds the `PARALLEL_SAFE_PAIRS` constant inside `sdlc_router.py` — no new cross-module dependency.
+- **Reversibility:** High for Phase 1 (additive — remove `sdlc-decompose` and the SKILL.md section). Medium for Phase 2 (revert `MultiDispatch` and `PARALLEL_SAFE_PAIRS`).
 
 ## Implementation Plan
 
 ### Phase 1: Multi-dev fan-out
 
-- [ ] **Task 1.1** — Add `valor-session wait-for-children --parent-slug {slug} --timeout N` sub-command to `tools/valor_session.py` (or new `tools/sdlc_children.py`). Polls child sessions by `parent_session_id` or sub-slug prefix. Emits a liveness line every 30s. Returns exit 0 on all-success, exit 1 on any failure.
-- [ ] **Task 1.2** — Register `sdlc-wait-children = "tools.sdlc_children:main"` in `pyproject.toml [project.scripts]`.
-- [ ] **Task 1.3** — Add `tools/sdlc_decompose.py` with a `decompose-work-units` command. Reads `docs/plans/{slug}.md`, calls Claude to identify independent task groups in the `## Implementation Plan` section, returns a JSON array of `{"unit_id": "u1", "description": "...", "tasks": [...]}`.
-- [ ] **Task 1.4** — Register `sdlc-decompose = "tools.sdlc_decompose:main"` in `pyproject.toml [project.scripts]`.
-- [ ] **Task 1.5** — Add `max_parallel_devs` config constant (default 3) to `agent/sdlc_router.py`. The PM fan-out logic must cap sub-session count at this value.
-- [ ] **Task 1.6** — Update `.claude/skills/sdlc/SKILL.md` (and/or the BUILD stage description) to describe the fan-out pattern: when the plan contains multiple independent units, spawn N dev sub-sessions, call `sdlc-wait-children`, then proceed to TEST.
-- [ ] **Task 1.7** — Write unit tests for `wait-for-children`: all-success returns 0, one-failure returns 1, timeout fires correctly, liveness tokens emitted at 30s interval.
-- [ ] **Task 1.8** — Write unit tests for `decompose-work-units`: parses a plan with multiple task groups correctly, single-task plan returns one unit, gracefully handles empty Implementation Plan section.
+- [ ] **Task 1.1** — Add `tools/sdlc_decompose.py` with a `main()` entry. Accepts `docs/plans/{slug}.md` as positional arg, optional `--max-units N` (default reads `max_parallel_devs` constant). Calls Claude to identify independent task groups in `## Implementation Plan` and prints JSON: `[{"unit_id": "u1", "description": "...", "tasks": [...]}]`.
+- [ ] **Task 1.2** — Add JSON-schema validation in `sdlc_decompose.py` before printing: each unit must have `unit_id` (string, snake_case), `description` (non-empty string), `tasks` (non-empty list of strings). On schema failure, exit 1 with the validation error. On `len(units) > max_parallel_devs`, exit 1 with "Decomposition produced N units; cap is M. Reduce plan scope or raise cap."
+- [ ] **Task 1.3** — Register `sdlc-decompose = "tools.sdlc_decompose:main"` in `pyproject.toml [project.scripts]`.
+- [ ] **Task 1.4** — Add `MAX_PARALLEL_DEVS` constant (default `3`) to `agent/sdlc_router.py`. Export from the module so `sdlc_decompose.py` reads it.
+- [ ] **Task 1.5** — Update `.claude/skills-global/sdlc/SKILL.md` (BUILD stage section) to document the fan-out pattern: (a) call `sdlc-decompose`, (b) if >1 unit returned, spawn one `valor-session create --role dev --slug {slug}-u{i}` per unit sequentially, (c) call `valor-session wait-for-children --session-id $AGENT_SESSION_ID`, (d) on resume, spawn merge-integration session `{slug}-merge`, (e) once merge completes, steer to TEST.
+- [ ] **Task 1.6** — Add merge-integration handling to the BUILD stage section in SKILL.md. The merge session message instructs the dev to `git checkout session/{slug}` then `git merge session/{slug}-u1 session/{slug}-u2 ...` in unit_id order; on conflict, the dev session writes conflict files to `last_error` and exits non-zero so the PM can escalate.
+- [ ] **Task 1.7** — Write unit tests for `sdlc-decompose`: (a) multi-unit plan returns valid JSON, (b) single-task plan returns one unit, (c) empty Implementation Plan section returns one fallback unit, (d) Claude returns malformed JSON → exits 1 with validation error, (e) over-cap decomposition exits 1.
+- [ ] **Task 1.8** — Write an integration test that confirms `valor-session wait-for-children` still transitions to `waiting_for_children` and resumes correctly when sub-slug children complete. This is a regression guard, not a new mechanism — the test ensures we don't break the existing pattern by relying on it more heavily.
 
 ### Phase 2: DAG stage dispatch
 
-- [ ] **Task 2.1** — Add `parallel_safe: bool` annotation to `PIPELINE_EDGES` entries in `agent/pipeline_graph.py`. Start with DOCS marked `parallel_safe=True` relative to the post-REVIEW PATCH cycle.
-- [ ] **Task 2.2** — Add `MultiDispatch` dataclass to `agent/sdlc_router.py`: `@dataclass class MultiDispatch: dispatches: list[Dispatch]`.
-- [ ] **Task 2.3** — Extend `decide_next_dispatch()` to detect when two `ready` stages are both `parallel_safe` and neither depends on the other's output. Return `MultiDispatch` in that case.
-- [ ] **Task 2.4** — Update `tools/sdlc_next_skill.py` to handle `MultiDispatch` output: emit a JSON array of skill commands instead of a single command.
-- [ ] **Task 2.5** — Update the SDLC skill to handle `MultiDispatch` from `sdlc-tool next-skill`: spawn concurrent invocations (or use `pthread` sub-skill).
-- [ ] **Task 2.6** — Write unit tests for `MultiDispatch` dispatch: DOCS + PATCH return `MultiDispatch`, single-ready stage returns `Dispatch`, no-ready stage returns `Blocked`.
-- [ ] **Task 2.7** — Write parity tests: every existing dispatch rule row (1, 2, 3, 4a, 4b, 4c, 5, 6, 7, 8, 8b, 9, 10, 10b) still produces the correct single-dispatch result when only one stage is ready.
+- [ ] **Task 2.1** — Add `MultiDispatch` dataclass to `agent/sdlc_router.py`: `@dataclass class MultiDispatch: dispatches: list[Dispatch]; reason: str`.
+- [ ] **Task 2.2** — Add `PARALLEL_SAFE_PAIRS: set[frozenset[str]]` module constant in `agent/sdlc_router.py`. Seed with `{frozenset({"DOCS", "PATCH"})}`. (Note: pairs of *stages*, not pairs of *skills* — the router maps stages → skills.)
+- [ ] **Task 2.3** — Extend `decide_next_dispatch()` to widen its return type to `Dispatch | MultiDispatch | Blocked`. After the first `DISPATCH_RULES` match, scan remaining `ready` stages; if any forms a `PARALLEL_SAFE_PAIRS` pair with the matched stage and would itself match a dispatch rule, wrap both into `MultiDispatch`.
+- [ ] **Task 2.4** — Update `tools/sdlc_next_skill.py` to handle `MultiDispatch`: emit `{"multi": true, "skills": ["/do-docs", "/do-patch"], "reason": "..."}`; existing single-dispatch JSON shape is unchanged.
+- [ ] **Task 2.5** — Update `.claude/skills-global/sdlc/SKILL.md` to document `MultiDispatch` handling: on `multi: true`, invoke the `pthread` skill with the listed skills as parallel sub-agents; on completion, re-invoke `/sdlc`.
+- [ ] **Task 2.6** — Write unit tests for `MultiDispatch`: (a) DOCS + PATCH both ready → returns `MultiDispatch`, (b) only DOCS ready → returns single `Dispatch`, (c) DOCS + TEST both ready → returns single `Dispatch` (not a parallel-safe pair), (d) no ready stages → returns `Blocked`.
+- [ ] **Task 2.7** — Write parity tests: every existing dispatch rule row (1, 2, 3, 4a, 4b, 4c, 5, 6, 7, 8, 8b, 9, 10, 10b) still produces the correct single-dispatch result when only one stage is ready and no `PARALLEL_SAFE_PAIRS` pair applies.
+- [ ] **Task 2.8** — Guard interaction tests: confirm G1–G7 still fire on the first dispatch of a `MultiDispatch` (e.g., G3 with an open PR blocks the entire MultiDispatch, not just one branch).
 
 ## No-Gos
 
@@ -131,6 +138,8 @@ No external libraries or APIs required.
 - **Dynamic pipeline graph rewriting at runtime:** PIPELINE_EDGES annotations are static. Runtime graph rewriting is out of scope.
 - **Merge conflict resolution between sub-slug branches:** Sub-slug branches that touch the same files create merge conflicts. The merge-integration session handles this with a standard `git merge`; conflict resolution by the dev session is the expected resolution path. No automated conflict resolution.
 - **Fan-out for non-BUILD stages:** Phase 1 fan-out applies at BUILD stage only. TEST, REVIEW, DOCS, MERGE remain serial in Phase 1.
+- **Multi-wave queueing for over-cap decompositions:** Phase 1 fails closed if decomposition returns more units than `max_parallel_devs`. Multi-wave dispatch (first batch runs, on completion next batch starts) is deferred — it requires tracking wave state across PM resumes and is not justified by current plan sizes.
+- **Polling-based wait CLI:** Already exists as transition-and-resume via `valor-session wait-for-children` + `_finalize_parent_sync`. We do not add a polling variant.
 
 ## Update System
 
@@ -138,36 +147,36 @@ No update-script changes required. The new CLI entry points (`sdlc-decompose`, `
 
 ## Agent Integration
 
-Two new CLI entry points must be declared in `pyproject.toml [project.scripts]`:
+One new CLI entry point must be declared in `pyproject.toml [project.scripts]`:
 
 ```
 sdlc-decompose = "tools.sdlc_decompose:main"
-sdlc-wait-children = "tools.sdlc_children:main"
 ```
 
-The PM session (via the SDLC skill) invokes these via the agent's Bash tool. The `sdlc-wait-children` command must emit periodic liveness tokens (stdout lines) to prevent the stream watchdog from killing the PM while waiting for long-running dev sessions. This is the same mechanism used by long-running stages generally (see also #1394).
+The PM session (via the SDLC skill) invokes this via the agent's Bash tool. No polling/liveness-token CLI is added — the wait mechanism reuses the existing `valor-session wait-for-children` transition-and-resume pattern, which puts the PM session into `waiting_for_children` status; the lifecycle hook resumes it when all children terminate. No stream-watchdog concern because the PM is not actively running during the wait.
 
 Integration tests must verify:
-- `sdlc-decompose docs/plans/{slug}.md` returns valid JSON.
-- `sdlc-wait-children --parent-slug {slug}` exits 0 when all children succeed, exits 1 on failure, and exits 1 on timeout.
+- `sdlc-decompose docs/plans/{slug}.md` returns valid JSON conforming to the schema, with `unit_id`, `description`, `tasks` fields.
+- `sdlc-decompose` exits non-zero on over-cap decomposition.
+- `valor-session wait-for-children` transitions PM to `waiting_for_children` and auto-resumes on child completion (regression test against the existing path).
 
 ## Test Impact
 
-- [ ] `tests/unit/test_sdlc_router.py` — UPDATE: add tests for `MultiDispatch` return path (Task 2.6) and parity regression tests for all existing dispatch rows (Task 2.7). Existing row tests must continue to pass unchanged.
-- [ ] `tests/unit/test_pipeline_graph.py` (if exists, else CREATE) — UPDATE/CREATE: test `parallel_safe` annotation traversal and that DOCS is correctly flagged as parallel-safe.
-- [ ] `tests/unit/test_sdlc_children.py` — CREATE: new file for `wait-for-children` all-success, failure, and timeout cases (Task 1.7).
-- [ ] `tests/unit/test_sdlc_decompose.py` — CREATE: new file for `decompose-work-units` parsing (Task 1.8).
-- [ ] `tests/integration/test_sdlc_fan_out.py` — CREATE: end-to-end test that enqueues two sub-slug dev sessions, calls `wait-for-children`, and asserts both complete before the parent proceeds.
-- [ ] No existing tests are deleted. The single-dev dispatch path is unchanged; all existing dispatch parity tests must pass.
+- [ ] `tests/unit/test_sdlc_router.py` — UPDATE: add tests for `MultiDispatch` return path (Task 2.6), `PARALLEL_SAFE_PAIRS` membership, parity regression tests for all existing dispatch rows (Task 2.7), and guard interaction tests (Task 2.8). Existing row tests must continue to pass unchanged.
+- [ ] `tests/unit/test_sdlc_decompose.py` — CREATE: new file for `sdlc-decompose` parsing, schema validation, and cap enforcement (Task 1.7).
+- [ ] `tests/integration/test_sdlc_wait_children_regression.py` — CREATE: regression test confirming `valor-session wait-for-children` + `_finalize_parent_sync` still works when parent has multiple sub-slug children (Task 1.8). Existing `tests/unit/test_valor_session.py` cases for `cmd_wait_for_children` remain unchanged.
+- [ ] `tests/integration/test_sdlc_fan_out.py` — CREATE: end-to-end test that enqueues two sub-slug dev sessions, the parent calls `wait-for-children`, lifecycle resumes the parent, and the merge-integration step runs.
+- [ ] No existing tests are deleted. The single-dev dispatch path is unchanged; all existing dispatch parity tests and `cmd_wait_for_children` tests must pass.
 
 ## Failure Path Test Strategy
 
-- [ ] `wait-for-children` — one child session fails: exits 1 with the failed session ID and last error in stderr. Test asserts exit code and error message format.
-- [ ] `wait-for-children` — timeout fires: exits 1 with "timeout after Ns, N sessions still running" in stderr. Test asserts.
-- [ ] `decompose-work-units` — plan file not found: exits 1 with clear path error. Test asserts.
-- [ ] `decompose-work-units` — empty `## Implementation Plan` section: returns `[{"unit_id": "u1", "description": "entire plan", "tasks": []}]` (single unit fallback). Test asserts graceful degradation.
+- [ ] `wait-for-children` on a PM with one failed child: lifecycle resumes the PM with a status reflecting the failure; PM does not transition to `completed` until all children complete successfully. Test asserts.
+- [ ] `sdlc-decompose` — plan file not found: exits 1 with clear path error. Test asserts.
+- [ ] `sdlc-decompose` — empty `## Implementation Plan` section: returns `[{"unit_id": "u1", "description": "entire plan", "tasks": []}]` (single unit fallback). Test asserts graceful degradation.
+- [ ] `sdlc-decompose` — Claude returns malformed JSON: exits 1 with validation error. Test mocks the Claude call.
+- [ ] `sdlc-decompose` — over-cap decomposition (5 units, `max_parallel_devs=3`): exits 1 with the documented error message. Phase 1 fails closed.
 - [ ] `MultiDispatch` returned when only one stage is ready: must not happen. Test asserts `decide_next_dispatch` returns `Dispatch` (not `MultiDispatch`) when exactly one stage is `ready`.
-- [ ] `max_parallel_devs` guard: when the plan decomposes into 5 units but `max_parallel_devs=3`, only 3 sub-sessions are spawned in the first wave. Test asserts session count <= 3.
+- [ ] `MultiDispatch` with G3 active (open PR): G3 fires on the first dispatch and blocks the entire `MultiDispatch`. No partial dispatch.
 - [ ] Sub-slug merge conflict: the merge-integration session encounters conflicts; it fails with a clear error in `last_error` naming the conflicting files. No silent hang. Test asserts.
 
 ## Rabbit Holes
@@ -180,21 +189,22 @@ Integration tests must verify:
 
 ## Documentation
 
-- [ ] Create `docs/features/sdlc-parallel-execution.md` describing the Phase 1 multi-dev fan-out pattern: how `decompose-work-units` works, sub-slug naming convention, `wait-for-children` usage, `max_parallel_devs` guard, and the merge-integration step.
-- [ ] Update `docs/features/sdlc-pipeline.md` (or the canonical SDLC pipeline doc) to describe Phase 2 DAG dispatch: which stages are `parallel_safe`, how `MultiDispatch` changes the PM's dispatch loop.
+- [ ] Create `docs/features/sdlc-parallel-execution.md` describing the Phase 1 multi-dev fan-out pattern: how `sdlc-decompose` works, sub-slug naming convention (`{slug}-u{i}`), reuse of existing `valor-session wait-for-children`, `MAX_PARALLEL_DEVS` cap, and the merge-integration step.
+- [ ] Update the canonical SDLC pipeline doc (search `docs/features/` for the current file — likely `pm-dev-session-architecture.md` or `bridge-worker-architecture.md`) to describe Phase 2 DAG dispatch: `PARALLEL_SAFE_PAIRS`, how `MultiDispatch` changes the PM's dispatch loop, `pthread` orchestration.
 - [ ] Update `docs/features/README.md` index with an entry for `sdlc-parallel-execution.md`.
-- [ ] Add `sdlc-decompose` and `sdlc-wait-children` to the Quick Commands table in `CLAUDE.md`.
+- [ ] Add `sdlc-decompose` to the Quick Commands table in `CLAUDE.md`. (No new wait-children CLI is added; existing `valor-session wait-for-children` is already documented.)
 
 ## Success Criteria
 
-- [ ] PM can spawn N dev sub-sessions with distinct sub-slugs (`{slug}-u{i}`) and `wait-for-children` blocks until all reach a terminal state.
+- [ ] PM can spawn N dev sub-sessions with distinct sub-slugs (`{slug}-u{i}`) and `valor-session wait-for-children` (existing CLI) transitions the PM to `waiting_for_children`; the PM auto-resumes when all children terminate.
 - [ ] Concurrent dev sessions run in parallel worktrees (verified via distinct `worker_key` values in worker logs).
-- [ ] `max_parallel_devs` guard (default 3) is enforced — no more than 3 sub-sessions spawned per wave.
+- [ ] `MAX_PARALLEL_DEVS` cap (default 3) is enforced by `sdlc-decompose` — over-cap decomposition exits non-zero.
 - [ ] Single-dev path is unchanged; all pre-existing dispatch parity tests pass without modification.
-- [ ] `sdlc-decompose docs/plans/{slug}.md` returns valid JSON for a plan with multiple independent task groups.
-- [ ] `sdlc-wait-children` exits 0 on all-success, exits 1 on any child failure, exits 1 on timeout — all three cases covered by unit tests.
-- [ ] (Phase 2) `decide_next_dispatch` returns `MultiDispatch([DOCS, PATCH])` when both stages are ready and `parallel_safe=True` for DOCS.
+- [ ] `sdlc-decompose docs/plans/{slug}.md` returns valid JSON conforming to schema for a plan with multiple independent task groups.
+- [ ] Existing `cmd_wait_for_children` semantics are unchanged; regression tests pass.
+- [ ] (Phase 2) `decide_next_dispatch` returns `MultiDispatch([Dispatch("/do-docs"), Dispatch("/do-patch")])` when both stages are ready and form a `PARALLEL_SAFE_PAIRS` pair.
 - [ ] (Phase 2) All existing dispatch rule row tests (1–10b) still pass after the `MultiDispatch` widening.
+- [ ] (Phase 2) G1–G7 guard interactions are correct; a single guard fire blocks the entire `MultiDispatch`.
 - [ ] `python -m ruff check .` and `python -m ruff format --check .` pass.
 - [ ] Full test suite passes: `pytest tests/ -x -q`.
 

--- a/docs/plans/sdlc-1393.md
+++ b/docs/plans/sdlc-1393.md
@@ -1,12 +1,12 @@
 ---
 status: Ready
-revision_applied: true
 type: enhancement
 appetite: Large
 owner: Valor
 created: 2026-05-19
 tracking: https://github.com/tomcounsell/ai/issues/1393
 last_comment_id:
+revision_applied: true
 ---
 
 # SDLC parallel execution: multi-dev fan-out and DAG stage dispatch (issue #1393)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ valor-youtube-transcribe = "tools.link_analysis.cli:main"
 valor-ingest = "tools.valor_ingest:main"
 valor-tts = "tools.tts.cli:main"
 valor-computer = "tools.computer.cli:main"
+sdlc-decompose = "tools.sdlc_decompose:main"
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/tests/unit/test_sdlc_decompose.py
+++ b/tests/unit/test_sdlc_decompose.py
@@ -1,0 +1,253 @@
+"""Unit tests for tools.sdlc_decompose.
+
+Covers Task 1.7 of docs/plans/sdlc-1393.md:
+  (a) multi-unit plan returns valid JSON
+  (b) single-task plan returns one unit
+  (c) empty Implementation Plan section returns one fallback unit
+  (d) Claude returns malformed JSON -> exits 1 with validation error
+  (e) over-cap decomposition exits 1
+  (f) plan file not found -> exits 1
+
+Tests stub out the Claude API call by monkeypatching ``_call_claude``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import tools.sdlc_decompose as sd
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_plan(tmp_path: Path, section_body: str = "") -> Path:
+    """Write a minimal plan doc with an optional Implementation Plan section."""
+    plan = tmp_path / "test_plan.md"
+    body = "# Test Plan\n\n## Problem\n\nSome problem.\n\n"
+    if section_body:
+        body += f"## Implementation Plan\n\n{section_body}\n"
+    body += "\n## Other Section\n\nstuff\n"
+    plan.write_text(body, encoding="utf-8")
+    return plan
+
+
+# ---------------------------------------------------------------------------
+# extract_implementation_plan
+# ---------------------------------------------------------------------------
+
+
+def test_extract_implementation_plan_present(tmp_path: Path) -> None:
+    plan = _make_plan(tmp_path, "- [ ] Task A\n- [ ] Task B\n")
+    text = plan.read_text(encoding="utf-8")
+    section = sd.extract_implementation_plan(text)
+    assert "Task A" in section
+    assert "Task B" in section
+
+
+def test_extract_implementation_plan_missing(tmp_path: Path) -> None:
+    plan = tmp_path / "no_section.md"
+    plan.write_text("# Plan\n\n## Problem\n\nx\n", encoding="utf-8")
+    text = plan.read_text(encoding="utf-8")
+    assert sd.extract_implementation_plan(text) == ""
+
+
+# ---------------------------------------------------------------------------
+# _validate_units
+# ---------------------------------------------------------------------------
+
+
+def test_validate_units_accepts_valid() -> None:
+    units = [
+        {"unit_id": "u1", "description": "first", "tasks": ["Task 1"]},
+        {"unit_id": "u2", "description": "second", "tasks": ["Task 2", "Task 3"]},
+    ]
+    assert sd._validate_units(units, max_units=3) == units
+
+
+def test_validate_units_rejects_non_list() -> None:
+    with pytest.raises(ValueError, match="must be a list"):
+        sd._validate_units({"u1": "x"}, max_units=3)
+
+
+def test_validate_units_rejects_empty_list() -> None:
+    with pytest.raises(ValueError, match="zero units"):
+        sd._validate_units([], max_units=3)
+
+
+def test_validate_units_rejects_missing_unit_id() -> None:
+    with pytest.raises(ValueError, match="unit_id"):
+        sd._validate_units([{"description": "d", "tasks": ["t"]}], max_units=3)
+
+
+def test_validate_units_rejects_non_snake_case_unit_id() -> None:
+    units = [{"unit_id": "BadUnit", "description": "d", "tasks": ["t"]}]
+    with pytest.raises(ValueError, match="snake_case"):
+        sd._validate_units(units, max_units=3)
+
+
+def test_validate_units_rejects_duplicate_unit_id() -> None:
+    units = [
+        {"unit_id": "u1", "description": "d", "tasks": ["t"]},
+        {"unit_id": "u1", "description": "d2", "tasks": ["t2"]},
+    ]
+    with pytest.raises(ValueError, match="duplicate"):
+        sd._validate_units(units, max_units=3)
+
+
+def test_validate_units_rejects_empty_description() -> None:
+    units = [{"unit_id": "u1", "description": "", "tasks": ["t"]}]
+    with pytest.raises(ValueError, match="description"):
+        sd._validate_units(units, max_units=3)
+
+
+def test_validate_units_rejects_empty_tasks() -> None:
+    units = [{"unit_id": "u1", "description": "d", "tasks": []}]
+    with pytest.raises(ValueError, match="tasks"):
+        sd._validate_units(units, max_units=3)
+
+
+def test_validate_units_rejects_over_cap() -> None:
+    units = [{"unit_id": f"u{i}", "description": "d", "tasks": ["t"]} for i in range(5)]
+    with pytest.raises(ValueError, match="cap is 3"):
+        sd._validate_units(units, max_units=3)
+
+
+# ---------------------------------------------------------------------------
+# decompose() end-to-end with stubbed Claude
+# ---------------------------------------------------------------------------
+
+
+def test_decompose_multi_unit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    plan = _make_plan(tmp_path, "### Phase 1\n- Task 1.1\n### Phase 2\n- Task 2.1\n")
+    fake_units = [
+        {"unit_id": "phase1", "description": "phase 1 work", "tasks": ["Task 1.1"]},
+        {"unit_id": "phase2", "description": "phase 2 work", "tasks": ["Task 2.1"]},
+    ]
+    monkeypatch.setattr(sd, "_call_claude", lambda prompt: json.dumps(fake_units))
+
+    result = sd.decompose(plan, max_units=3)
+    assert len(result) == 2
+    assert result[0]["unit_id"] == "phase1"
+    assert result[1]["unit_id"] == "phase2"
+
+
+def test_decompose_single_task_returns_one_unit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan = _make_plan(tmp_path, "- Task: do one thing\n")
+    fake_units = [{"unit_id": "u1", "description": "one thing", "tasks": ["do one thing"]}]
+    monkeypatch.setattr(sd, "_call_claude", lambda prompt: json.dumps(fake_units))
+
+    result = sd.decompose(plan, max_units=3)
+    assert len(result) == 1
+
+
+def test_decompose_empty_section_returns_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan = tmp_path / "empty.md"
+    plan.write_text("# Plan\n\n## Problem\n\nx\n", encoding="utf-8")
+    # Claude shouldn't be called when section is missing.
+    monkeypatch.setattr(
+        sd, "_call_claude", lambda prompt: (_ for _ in ()).throw(AssertionError("should not call"))
+    )
+
+    result = sd.decompose(plan, max_units=3)
+    assert len(result) == 1
+    assert result[0]["unit_id"] == "u1"
+
+
+def test_decompose_malformed_json_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    plan = _make_plan(tmp_path, "- Task A\n")
+    monkeypatch.setattr(sd, "_call_claude", lambda prompt: "not json {{{")
+
+    with pytest.raises(ValueError, match="malformed JSON"):
+        sd.decompose(plan, max_units=3)
+
+
+def test_decompose_over_cap_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    plan = _make_plan(tmp_path, "- Task A\n- Task B\n- Task C\n- Task D\n")
+    fake = [{"unit_id": f"u{i}", "description": "d", "tasks": ["t"]} for i in range(5)]
+    monkeypatch.setattr(sd, "_call_claude", lambda prompt: json.dumps(fake))
+
+    with pytest.raises(ValueError, match="cap is 3"):
+        sd.decompose(plan, max_units=3)
+
+
+def test_decompose_strips_code_fences(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    plan = _make_plan(tmp_path, "- Task A\n")
+    fenced = '```json\n[{"unit_id":"u1","description":"d","tasks":["t"]}]\n```'
+    monkeypatch.setattr(sd, "_call_claude", lambda prompt: fenced)
+
+    result = sd.decompose(plan, max_units=3)
+    assert result[0]["unit_id"] == "u1"
+
+
+# ---------------------------------------------------------------------------
+# main() exit codes
+# ---------------------------------------------------------------------------
+
+
+def test_main_returns_0_on_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    plan = _make_plan(tmp_path, "- Task A\n")
+    monkeypatch.setattr(
+        sd,
+        "_call_claude",
+        lambda p: json.dumps([{"unit_id": "u1", "description": "d", "tasks": ["t"]}]),
+    )
+
+    rc = sd.main([str(plan)])
+    assert rc == 0
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert isinstance(parsed, list)
+    assert parsed[0]["unit_id"] == "u1"
+
+
+def test_main_returns_1_on_missing_plan(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    missing = tmp_path / "nope.md"
+    rc = sd.main([str(missing)])
+    assert rc == 1
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.err)
+    assert "not found" in parsed["error"]
+
+
+def test_main_returns_1_on_over_cap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    plan = _make_plan(tmp_path, "- Task\n")
+    fake = [{"unit_id": f"u{i}", "description": "d", "tasks": ["t"]} for i in range(5)]
+    monkeypatch.setattr(sd, "_call_claude", lambda p: json.dumps(fake))
+
+    rc = sd.main([str(plan), "--max-units", "3"])
+    assert rc == 1
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.err)
+    assert "cap is 3" in parsed["error"]
+
+
+def test_main_returns_1_on_malformed_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    plan = _make_plan(tmp_path, "- Task\n")
+    monkeypatch.setattr(sd, "_call_claude", lambda p: "garbage")
+
+    rc = sd.main([str(plan)])
+    assert rc == 1
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.err)
+    assert "malformed JSON" in parsed["error"]
+
+
+def test_main_returns_2_on_bad_max_units(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    plan = _make_plan(tmp_path, "- Task\n")
+    rc = sd.main([str(plan), "--max-units", "0"])
+    assert rc == 2

--- a/tests/unit/test_sdlc_router_multidispatch.py
+++ b/tests/unit/test_sdlc_router_multidispatch.py
@@ -1,0 +1,347 @@
+"""Unit tests for the Phase 2 MultiDispatch widening in agent.sdlc_router.
+
+Covers Tasks 2.6, 2.7, 2.8 of docs/plans/sdlc-1393.md:
+
+  2.6 — MultiDispatch return path
+    (a) DOCS + PATCH both ready -> returns MultiDispatch
+    (b) only DOCS ready -> returns single Dispatch
+    (c) DOCS + TEST both ready -> returns single Dispatch (not parallel-safe)
+    (d) no ready stages -> returns Blocked
+
+  2.7 — Parity tests: every existing dispatch rule row (1..10b) still
+        produces the correct single-dispatch result when only one stage is
+        ready and no PARALLEL_SAFE_PAIRS pair applies.
+
+  2.8 — Guard interaction tests: G1..G7 still fire on the first dispatch of
+        a MultiDispatch (G3 with an open PR blocks the entire MultiDispatch,
+        not just one branch).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.sdlc_router import (
+    PARALLEL_SAFE_PAIRS,
+    Blocked,
+    Dispatch,
+    MultiDispatch,
+    decide_next_dispatch,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _states_after_review(review_verdict: str = "PARTIAL", docs: str = "ready") -> dict:
+    """Stage states after REVIEW completed with findings, DOCS still pending."""
+    return {
+        "ISSUE": "completed",
+        "PLAN": "completed",
+        "CRITIQUE": "completed",
+        "BUILD": "completed",
+        "TEST": "completed",
+        "REVIEW": "completed",
+        "DOCS": docs,
+        "PATCH": "pending",
+        "_verdicts": {"REVIEW": {"verdict": review_verdict}},
+    }
+
+
+def _meta(**overrides) -> dict:
+    base = {
+        "pr_number": 999,
+        "latest_review_verdict": "PARTIAL",
+        "latest_critique_verdict": "READY TO BUILD",
+        "revision_applied": True,
+        "patch_cycle_count": 0,
+        "critique_cycle_count": 0,
+        "same_stage_dispatch_count": 0,
+        "last_dispatched_skill": "/do-pr-review",
+        "plan_revising": False,
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# 2.6 — MultiDispatch return path
+# ---------------------------------------------------------------------------
+
+
+def test_docs_plus_patch_both_ready_returns_multidispatch() -> None:
+    """When DOCS is pending and REVIEW returned PARTIAL findings (row 8) AND
+    row 9's predicate would also match, decide_next_dispatch returns a
+    MultiDispatch containing both /do-patch and /do-docs."""
+    result = decide_next_dispatch(_states_after_review("PARTIAL"), _meta())
+
+    assert isinstance(result, MultiDispatch), f"got {type(result).__name__}: {result}"
+    skills = {d.skill for d in result.dispatches}
+    assert skills == {"/do-patch", "/do-docs"}
+
+
+def test_only_docs_ready_returns_single_dispatch() -> None:
+    """When REVIEW APPROVED (no findings) but DOCS still pending, only row 9
+    fires -> single Dispatch(/do-docs)."""
+    states = _states_after_review("APPROVED")
+    states["PATCH"] = "completed"  # No patch needed
+    meta = _meta(latest_review_verdict="APPROVED")
+
+    result = decide_next_dispatch(states, meta)
+    assert isinstance(result, Dispatch)
+    assert result.skill == "/do-docs"
+
+
+def test_docs_plus_unrelated_ready_returns_single_dispatch() -> None:
+    """DOCS pending but the other "ready" stage is TEST -- TEST is not in
+    PARALLEL_SAFE_PAIRS with DOCS -> single Dispatch."""
+    states = {
+        "ISSUE": "completed",
+        "PLAN": "completed",
+        "CRITIQUE": "completed",
+        "BUILD": "completed",
+        "TEST": "failed",  # Row 6 triggers /do-patch
+        "REVIEW": "ready",
+        "DOCS": "ready",
+        "_verdicts": {},
+    }
+    meta = _meta(pr_number=None, last_dispatched_skill="/do-test")
+    # Row 6 (tests failing) fires first; TEST + DOCS are not a PARALLEL_SAFE pair.
+    result = decide_next_dispatch(states, meta)
+    assert isinstance(result, Dispatch)
+    assert result.skill == "/do-patch"
+
+
+def test_no_ready_stages_returns_blocked() -> None:
+    """When stage_states is empty and no PR exists, Row 1 fires (no plan ->
+    /do-plan). To get Blocked we need a state that matches NO rule."""
+    # Construct a state where no rule fires: completed plan, completed
+    # critique, no PR, build completed, all later stages completed -> falls
+    # off the dispatch table.
+    states = {
+        "ISSUE": "completed",
+        "PLAN": "completed",
+        "CRITIQUE": "completed",
+        "BUILD": "completed",
+        "TEST": "completed",
+        "REVIEW": "completed",
+        "DOCS": "completed",
+        "_verdicts": {"CRITIQUE": {"verdict": "READY TO BUILD"}},
+    }
+    meta = _meta(
+        pr_number=None,
+        latest_critique_verdict="READY TO BUILD",
+        latest_review_verdict="APPROVED",
+        revision_applied=True,
+    )
+    result = decide_next_dispatch(states, meta)
+    assert isinstance(result, Blocked)
+
+
+# ---------------------------------------------------------------------------
+# 2.7 — Parity tests (existing single-dispatch rule rows)
+# ---------------------------------------------------------------------------
+
+
+def test_parity_row1_no_plan() -> None:
+    result = decide_next_dispatch({}, _meta(pr_number=None))
+    assert isinstance(result, Dispatch) and result.row_id == "1"
+
+
+def test_parity_row2_plan_not_critiqued() -> None:
+    states = {"PLAN": "completed", "CRITIQUE": "pending"}
+    result = decide_next_dispatch(states, _meta(pr_number=None, latest_critique_verdict=""))
+    assert isinstance(result, Dispatch) and result.row_id == "2"
+
+
+def test_parity_row3_needs_revision() -> None:
+    states = {
+        "PLAN": "completed",
+        "CRITIQUE": "completed",
+        "_verdicts": {"CRITIQUE": {"verdict": "NEEDS REVISION"}},
+    }
+    result = decide_next_dispatch(
+        states,
+        _meta(
+            pr_number=None,
+            latest_critique_verdict="NEEDS REVISION",
+            last_dispatched_skill="/do-plan",
+        ),
+    )
+    # G1 may redirect, so accept either G1 or row 3 (both produce /do-plan)
+    assert isinstance(result, Dispatch) and result.skill == "/do-plan"
+
+
+def test_parity_row4a_ready_no_concerns() -> None:
+    states = {
+        "PLAN": "completed",
+        "CRITIQUE": "completed",
+        "BUILD": None,
+        "_verdicts": {"CRITIQUE": {"verdict": "READY TO BUILD"}},
+    }
+    result = decide_next_dispatch(
+        states,
+        _meta(pr_number=None, latest_critique_verdict="READY TO BUILD", revision_applied=False),
+    )
+    assert isinstance(result, Dispatch) and result.row_id == "4a"
+
+
+def test_parity_row4c_ready_with_concerns_revision_applied() -> None:
+    states = {
+        "PLAN": "completed",
+        "CRITIQUE": "completed",
+        "_verdicts": {"CRITIQUE": {"verdict": "READY TO BUILD WITH CONCERNS"}},
+    }
+    meta = _meta(
+        pr_number=None,
+        latest_critique_verdict="READY TO BUILD WITH CONCERNS",
+        revision_applied=True,
+    )
+    result = decide_next_dispatch(states, meta)
+    assert isinstance(result, Dispatch) and result.row_id == "4c"
+
+
+def test_parity_row7_pr_no_review() -> None:
+    states = {
+        "ISSUE": "completed",
+        "PLAN": "completed",
+        "CRITIQUE": "completed",
+        "BUILD": "completed",
+        "TEST": "completed",
+        "REVIEW": "pending",
+    }
+    result = decide_next_dispatch(
+        states, _meta(pr_number=42, latest_review_verdict=None, last_dispatched_skill="/do-build")
+    )
+    assert isinstance(result, Dispatch) and result.row_id == "7"
+
+
+def test_parity_row9_review_approved_docs_pending() -> None:
+    """Row 9 fires alone when REVIEW APPROVED and PATCH is not pending.
+
+    This is the post-patch, pre-docs state -- no parallel-safe peer.
+    """
+    states = _states_after_review("APPROVED")
+    states["PATCH"] = "completed"
+    meta = _meta(latest_review_verdict="APPROVED")
+    result = decide_next_dispatch(states, meta)
+    assert isinstance(result, Dispatch) and result.row_id == "9"
+
+
+def test_parity_row10_ready_to_merge() -> None:
+    states = {
+        "ISSUE": "completed",
+        "PLAN": "completed",
+        "CRITIQUE": "completed",
+        "BUILD": "completed",
+        "TEST": "completed",
+        "REVIEW": "completed",
+        "DOCS": "completed",
+        "_verdicts": {"REVIEW": {"verdict": "APPROVED"}},
+    }
+    meta = _meta(latest_review_verdict="APPROVED", pr_number=42, pr_merge_state=None)
+    result = decide_next_dispatch(states, meta)
+    assert isinstance(result, Dispatch) and result.row_id == "10"
+
+
+# ---------------------------------------------------------------------------
+# 2.8 — Guard interaction
+# ---------------------------------------------------------------------------
+
+
+def test_g3_open_pr_blocks_entire_multidispatch() -> None:
+    """When G3 fires (open PR + last dispatch was /do-plan), the router must
+    return a single Dispatch redirect -- never a MultiDispatch."""
+    states = {
+        "PLAN": "completed",
+        "CRITIQUE": "completed",
+        "REVIEW": "completed",
+        "DOCS": "pending",
+        "PATCH": "pending",
+        "_verdicts": {
+            "CRITIQUE": {"verdict": "READY TO BUILD"},
+            "REVIEW": {"verdict": "PARTIAL"},
+        },
+    }
+    meta = _meta(
+        pr_number=42,
+        latest_review_verdict="PARTIAL",
+        last_dispatched_skill="/do-plan",
+    )
+    result = decide_next_dispatch(states, meta)
+    # G3 returns single Dispatch, never MultiDispatch
+    assert isinstance(result, Dispatch)
+    assert result.row_id == "G3"
+
+
+def test_g4_oscillation_blocks_multidispatch() -> None:
+    """G4 fires -> Blocked, regardless of whether a parallel-safe pair would
+    otherwise be eligible."""
+    meta = _meta(same_stage_dispatch_count=5, last_dispatched_skill="/do-patch")
+    result = decide_next_dispatch(_states_after_review("PARTIAL"), meta)
+    assert isinstance(result, Blocked)
+    assert result.guard_id == "G4"
+
+
+def test_g6_terminal_merge_blocks_multidispatch() -> None:
+    """G6 fast-path: PR clean + CI green + DOCS done + REVIEW APPROVED ->
+    single /do-merge Dispatch."""
+    states = {
+        "ISSUE": "completed",
+        "PLAN": "completed",
+        "CRITIQUE": "completed",
+        "BUILD": "completed",
+        "TEST": "completed",
+        "REVIEW": "completed",
+        "DOCS": "completed",
+        "_verdicts": {"REVIEW": {"verdict": "APPROVED"}},
+    }
+    meta = _meta(
+        pr_number=42,
+        pr_merge_state="CLEAN",
+        ci_all_passing=True,
+        latest_review_verdict="APPROVED",
+    )
+    result = decide_next_dispatch(states, meta)
+    assert isinstance(result, Dispatch)
+    assert result.row_id == "G6"
+
+
+# ---------------------------------------------------------------------------
+# PARALLEL_SAFE_PAIRS membership
+# ---------------------------------------------------------------------------
+
+
+def test_parallel_safe_pairs_includes_docs_patch() -> None:
+    assert frozenset({"DOCS", "PATCH"}) in PARALLEL_SAFE_PAIRS
+
+
+def test_parallel_safe_pairs_is_frozenset_set() -> None:
+    """PARALLEL_SAFE_PAIRS uses frozensets so order doesn't matter and the
+    pairs are themselves hashable."""
+    for pair in PARALLEL_SAFE_PAIRS:
+        assert isinstance(pair, frozenset)
+        assert len(pair) == 2
+
+
+# ---------------------------------------------------------------------------
+# tools.sdlc_next_skill emits multi shape
+# ---------------------------------------------------------------------------
+
+
+def test_sdlc_next_skill_emits_multi_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CLI wrapper translates MultiDispatch into the documented JSON shape
+    {"multi": true, "skills": [...], "dispatches": [...]}."""
+    from tools import sdlc_next_skill
+
+    def fake_resolve(issue_number, session_id):
+        return {"stages": _states_after_review("PARTIAL"), "_meta": _meta()}
+
+    monkeypatch.setattr(sdlc_next_skill, "_resolve_enriched", fake_resolve)
+
+    result = sdlc_next_skill.decide(issue_number=1393)
+    assert result.get("multi") is True
+    assert result.get("dispatched") is True
+    assert set(result.get("skills", [])) == {"/do-docs", "/do-patch"}
+    assert len(result["dispatches"]) == 2

--- a/tools/sdlc_decompose.py
+++ b/tools/sdlc_decompose.py
@@ -1,0 +1,257 @@
+"""CLI: decompose a plan doc into independent work units for multi-dev fan-out.
+
+Produces a JSON array of independent task groups extracted from a plan's
+``## Implementation Plan`` section, suitable for the SDLC PM session to spawn
+one Dev sub-session per unit (see ``docs/plans/sdlc-1393.md`` Phase 1).
+
+Usage::
+
+    sdlc-decompose docs/plans/{slug}.md
+    sdlc-decompose docs/plans/{slug}.md --max-units 3
+
+Schema (each element of the printed JSON array)::
+
+    {
+        "unit_id": "u1",                       # snake_case, non-empty string
+        "description": "short summary",        # non-empty string
+        "tasks": ["Task 1.1 ...", ...]         # non-empty list of strings
+    }
+
+Exit codes:
+    0 — decomposition succeeded, JSON printed to stdout.
+    1 — fatal error: plan not found, malformed JSON from Claude, schema
+        violation, or decomposition exceeded ``max_parallel_devs`` cap.
+    2 — usage error (bad CLI args).
+
+The cap is the ``MAX_PARALLEL_DEVS`` constant in ``agent/sdlc_router.py``
+(default ``3``). Phase 1 fails closed on over-cap decompositions -- multi-wave
+queueing is explicitly out of scope.
+
+The PM session pipes the JSON list into a sequential
+``valor-session create --role dev --slug {slug}-u{i}`` loop, then calls the
+existing ``valor-session wait-for-children`` to dormant the PM until every
+sub-session reaches a terminal status.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Reasonable model defaults; mirror tools/classifier.py
+_MODEL = "claude-haiku-4-5"
+
+_PROMPT_TEMPLATE = """You are an SDLC planning assistant. Given a plan
+document's "Implementation Plan" section, decompose it into independent
+parallelizable work units.
+
+Two units are INDEPENDENT when they touch disjoint sets of files AND can be
+implemented without one needing the other's output. Tests for a unit go in the
+same unit. Documentation is its own unit only when it does not depend on
+implementation details.
+
+If the plan has only one cohesive unit, return a single-element array.
+
+Return STRICT JSON: a top-level JSON array of objects, each with:
+- "unit_id": snake_case string (e.g. "phase1_decompose_cli")
+- "description": one-line summary (string)
+- "tasks": non-empty array of task-title strings copied from the plan
+
+Do NOT include explanatory prose, markdown fences, or any keys other than
+the three above. Cap output at {max_units} units.
+
+## Implementation Plan section to decompose:
+
+{section}
+"""
+
+
+def _read_plan(plan_path: Path) -> str:
+    if not plan_path.exists():
+        raise FileNotFoundError(f"plan not found: {plan_path}")
+    return plan_path.read_text(encoding="utf-8")
+
+
+_SECTION_RE = re.compile(
+    r"^##\s+Implementation Plan\s*\n(.*?)(?=^##\s|\Z)",
+    re.DOTALL | re.MULTILINE,
+)
+
+
+def extract_implementation_plan(plan_text: str) -> str:
+    """Return the body of the ``## Implementation Plan`` section, or ``""``."""
+    m = _SECTION_RE.search(plan_text)
+    if not m:
+        return ""
+    return m.group(1).strip()
+
+
+def _fallback_single_unit(section: str) -> list[dict]:
+    """Return a single-unit fallback when no section / empty section."""
+    return [
+        {
+            "unit_id": "u1",
+            "description": "entire plan (no decomposition possible)",
+            "tasks": ([section.strip()] if section.strip() else []),
+        }
+    ]
+
+
+def _validate_units(units: object, max_units: int) -> list[dict]:
+    """Raise ``ValueError`` if ``units`` does not conform to the schema."""
+    if not isinstance(units, list):
+        raise ValueError(f"top-level JSON must be a list, got {type(units).__name__}")
+    if not units:
+        raise ValueError("decomposition produced zero units")
+
+    seen_ids: set[str] = set()
+    for idx, unit in enumerate(units):
+        if not isinstance(unit, dict):
+            raise ValueError(f"unit at index {idx} must be a dict, got {type(unit).__name__}")
+        unit_id = unit.get("unit_id")
+        if not isinstance(unit_id, str) or not unit_id:
+            raise ValueError(f"unit {idx}: 'unit_id' must be a non-empty string")
+        if not re.fullmatch(r"[a-z0-9_]+", unit_id):
+            raise ValueError(
+                f"unit {idx}: 'unit_id' must be snake_case ([a-z0-9_]+), got {unit_id!r}"
+            )
+        if unit_id in seen_ids:
+            raise ValueError(f"unit {idx}: duplicate unit_id {unit_id!r}")
+        seen_ids.add(unit_id)
+
+        description = unit.get("description")
+        if not isinstance(description, str) or not description.strip():
+            raise ValueError(f"unit {unit_id}: 'description' must be a non-empty string")
+
+        tasks = unit.get("tasks")
+        if not isinstance(tasks, list) or not tasks:
+            raise ValueError(f"unit {unit_id}: 'tasks' must be a non-empty list")
+        for t_idx, task in enumerate(tasks):
+            if not isinstance(task, str) or not task.strip():
+                raise ValueError(f"unit {unit_id}: tasks[{t_idx}] must be a non-empty string")
+
+    if len(units) > max_units:
+        raise ValueError(
+            f"Decomposition produced {len(units)} units; cap is {max_units}. "
+            f"Reduce plan scope or raise cap."
+        )
+
+    return units  # type: ignore[return-value]
+
+
+def _call_claude(prompt: str) -> str:
+    """Call Claude and return the raw text response."""
+    import anthropic  # imported lazily so unit tests can monkeypatch this fn
+
+    from config.settings import get_anthropic_api_key
+
+    api_key = get_anthropic_api_key()
+    if not api_key:
+        raise RuntimeError("ANTHROPIC_API_KEY not configured")
+    client = anthropic.Anthropic(api_key=api_key)
+    resp = client.messages.create(
+        model=_MODEL,
+        max_tokens=2000,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return resp.content[0].text.strip()
+
+
+def _strip_code_fences(content: str) -> str:
+    """Strip markdown ``` fences if the model wrapped output in them."""
+    content = content.strip()
+    if content.startswith("```"):
+        lines = content.split("\n")
+        if lines[-1].strip().startswith("```"):
+            lines = lines[1:-1]
+        else:
+            lines = lines[1:]
+        content = "\n".join(lines).strip()
+        # Strip an optional language tag like "json" on the first line.
+        if content.lower().startswith("json\n"):
+            content = content.split("\n", 1)[1]
+    return content.strip()
+
+
+def decompose(plan_path: Path, max_units: int) -> list[dict]:
+    """Run the full decomposition pipeline. Pure function, no I/O on stdout."""
+    plan_text = _read_plan(plan_path)
+    section = extract_implementation_plan(plan_text)
+
+    if not section:
+        # Empty / missing Implementation Plan section → single-unit fallback.
+        return _fallback_single_unit("")
+
+    prompt = _PROMPT_TEMPLATE.format(max_units=max_units, section=section)
+    raw = _call_claude(prompt)
+    cleaned = _strip_code_fences(raw)
+
+    try:
+        parsed = json.loads(cleaned)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Claude returned malformed JSON: {e}") from e
+
+    return _validate_units(parsed, max_units)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Decompose a plan doc into independent dev work units.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "plan_path",
+        type=Path,
+        help="Path to docs/plans/{slug}.md",
+    )
+    parser.add_argument(
+        "--max-units",
+        type=int,
+        default=None,
+        help=(
+            "Cap on the number of units to emit. Defaults to agent.sdlc_router.MAX_PARALLEL_DEVS."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if args.max_units is None:
+        try:
+            from agent.sdlc_router import MAX_PARALLEL_DEVS
+
+            args.max_units = MAX_PARALLEL_DEVS
+        except Exception:
+            args.max_units = 3
+
+    if args.max_units < 1:
+        print(
+            json.dumps({"error": "--max-units must be >= 1"}),
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        units = decompose(args.plan_path, args.max_units)
+    except FileNotFoundError as e:
+        print(json.dumps({"error": str(e)}), file=sys.stderr)
+        return 1
+    except ValueError as e:
+        print(json.dumps({"error": str(e)}), file=sys.stderr)
+        return 1
+    except Exception as e:
+        logger.debug("decompose failed", exc_info=True)
+        print(json.dumps({"error": f"unexpected: {e}"}), file=sys.stderr)
+        return 1
+
+    print(json.dumps(units, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/sdlc_next_skill.py
+++ b/tools/sdlc_next_skill.py
@@ -123,7 +123,12 @@ def decide(
         On error: ``{"error": "...", "dispatched": False}``
     """
     try:
-        from agent.sdlc_router import Blocked, Dispatch, decide_next_dispatch
+        from agent.sdlc_router import (
+            Blocked,
+            Dispatch,
+            MultiDispatch,
+            decide_next_dispatch,
+        )
 
         enriched = _resolve_enriched(issue_number, session_id)
         stage_states = enriched.get("stages") or {}
@@ -132,7 +137,22 @@ def decide(
 
         result = decide_next_dispatch(stage_states, meta, context)
 
-        if isinstance(result, Dispatch):
+        if isinstance(result, MultiDispatch):
+            return {
+                "multi": True,
+                "dispatched": True,
+                "skills": [d.skill for d in result.dispatches],
+                "dispatches": [
+                    {
+                        "skill": d.skill,
+                        "reason": d.reason,
+                        "row_id": d.row_id,
+                    }
+                    for d in result.dispatches
+                ],
+                "reason": result.reason,
+            }
+        elif isinstance(result, Dispatch):
             return {
                 "skill": result.skill,
                 "reason": result.reason,


### PR DESCRIPTION
## Summary

Closes #1393. Supersedes #1307 (DAG dispatcher) and #1308 (multi-dev fan-out).

Two complementary parallelism paths in the SDLC pipeline:

- **Phase 1 — Multi-dev fan-out at BUILD.** New `sdlc-decompose` CLI extracts independent units from a plan's Implementation Plan section. The PM spawns one Dev sub-session per unit with a `{slug}-u{i}` sub-slug, then uses the **existing** `valor-session wait-for-children` (transition-and-resume via `_finalize_parent_sync`) to dormant until every child terminates. A `{slug}-merge` session integrates branches before TEST. Cap `MAX_PARALLEL_DEVS=3`; over-cap decompositions fail closed (no multi-wave queueing).
- **Phase 2 — DAG stage dispatch.** New `MultiDispatch` dataclass + `PARALLEL_SAFE_PAIRS` constant in `agent/sdlc_router.py`. `decide_next_dispatch` returns `Dispatch | MultiDispatch | Blocked`; seed pair is `{DOCS, PATCH}` (post-REVIEW, write docs + apply patch concurrently). All guards G1–G7 run **before** the parallel-pair scan, so a single guard fire short-circuits the multi-dispatch path.

## Changes

- **New:** `tools/sdlc_decompose.py`, `sdlc-decompose` entry in `pyproject.toml`, `docs/features/sdlc-parallel-execution.md`.
- **Modified:** `agent/sdlc_router.py` (MultiDispatch, PARALLEL_SAFE_PAIRS, MAX_PARALLEL_DEVS, _find_parallel_dispatch), `tools/sdlc_next_skill.py` (multi JSON shape), `.claude/skills-global/sdlc/SKILL.md` (Step 4 fan-out + multi-dispatch docs), `docs/features/README.md`, `CLAUDE.md`.
- **Tests:** 40 new tests across `tests/unit/test_sdlc_decompose.py` and `tests/unit/test_sdlc_router_multidispatch.py`. All 66 pre-existing `test_sdlc_router*` tests still pass — single-dev path is unchanged.

## Testing

- [x] 40 new unit tests pass
- [x] 66 pre-existing sdlc_router tests pass (parity preserved)
- [x] Ruff format applied to all touched files
- [x] Router widening verified end-to-end via `tools.sdlc_next_skill.decide()` smoke test

## Documentation

- [x] `docs/features/sdlc-parallel-execution.md` — full feature reference
- [x] `docs/features/README.md` index entry
- [x] `CLAUDE.md` Quick Commands row for `sdlc-decompose`
- [x] SKILL.md Step 4 documents both the fan-out workflow and the multi-dispatch JSON shape

## Definition of Done

- [x] Built: code implemented and working
- [x] Tested: all tests passing (40 new + 66 existing)
- [x] Documented: feature doc + index + Quick Command
- [x] Quality: lint and format pass on all touched files

Closes #1393