### PR TITLE
fix(emoji): never react with 🖕 to user messages

### DIFF
--- a/bridge/response.py
+++ b/bridge/response.py
@@ -55,7 +55,8 @@ VALIDATED_REACTIONS = [
     # Hearts/love
     "❤", "❤‍🔥", "💔", "💘", "😍", "🥰", "😘", "💋",
     # Hands
-    "👍", "👎", "👏", "🙏", "👌", "🤝", "✍", "🖕",
+    # 🖕 is a valid Telegram reaction but offensive to send at a user — excluded.
+    "👍", "👎", "👏", "🙏", "👌", "🤝", "✍",
     # Positive faces
     "😁", "🤣", "🤩", "😇", "😎", "🤓", "🤗", "🫡",
     # Negative faces

--- a/docs/features/emoji-embedding-reactions.md
+++ b/docs/features/emoji-embedding-reactions.md
@@ -4,11 +4,11 @@ Embedding-based emoji reaction selection for Telegram messages, replacing the pr
 
 ## Overview
 
-When a Telegram message arrives, the bridge selects a contextual reaction emoji by embedding the message text and comparing it against pre-computed embeddings for all 73 validated Telegram reaction emojis via cosine similarity. This replaces the previous Ollama-based intent classifier that mapped messages to 10 hardcoded emojis with 2-10 second latency.
+When a Telegram message arrives, the bridge selects a contextual reaction emoji by embedding the message text and comparing it against pre-computed embeddings for the 72 validated Telegram reaction emojis via cosine similarity. This replaces the previous Ollama-based intent classifier that mapped messages to 10 hardcoded emojis with 2-10 second latency.
 
 The same embedding index powers the `send_telegram --react` flag, allowing the agent to set emoji reactions on messages by describing a feeling word.
 
-Premium accounts gain access to thousands of custom emoji (animated sticker-based emoji) in addition to the 73 standard reactions. The system indexes available custom emoji packs and includes them in the similarity search, with automatic fallback to standard emoji when custom emoji are unavailable.
+Premium accounts gain access to thousands of custom emoji (animated sticker-based emoji) in addition to the 72 standard reactions. The system indexes available custom emoji packs and includes them in the similarity search, with automatic fallback to standard emoji when custom emoji are unavailable.
 
 ## How It Works
 
@@ -58,7 +58,9 @@ The core module that maps feelings to emojis.
 - `clear_cache()` -- clears the in-memory cache (for testing)
 - `rebuild_custom_emoji_index(client)` -- async function to query Telethon for available custom emoji packs and rebuild the custom embedding cache
 
-**Standard emoji labels:** Each of the 73 validated Telegram reaction emojis has a descriptive label string (e.g., "fire, hot, trending, lit, exciting, impressive, awesome" for the fire emoji). These labels are embedded and compared against input text.
+**Standard emoji labels:** Each of the 72 validated Telegram reaction emojis has a descriptive label string (e.g., "fire, hot, trending, lit, exciting, impressive, awesome" for the fire emoji). These labels are embedded and compared against input text.
+
+**Blocked reactions:** `BLOCKED_REACTION_EMOJIS` is a frozenset of emojis that must never be selected as a reaction, even if a stale on-disk cache still contains their embedding. The middle finger 🖕 is blocked here — Telegram accepts it as a valid reaction, but reacting to a user's message with it is offensive. `find_best_emoji()` skips any emoji in this set at selection time, so the guarantee holds regardless of cache state: production machines may carry a `data/emoji_embeddings.json` that predates the label's removal, and the picker iterates that cached dict, so the blocklist (not just the absent label) is what keeps the emoji from ever being chosen.
 
 **Custom emoji labels:** Custom emoji from Premium sticker packs are labeled using the associated emoji character plus the sticker set title (e.g., "party celebration confetti" for a party popper custom emoji). These are embedded with the same model and stored separately.
 
@@ -143,16 +145,16 @@ The work-type classifier (`tools/classifier.py` / `classify_request_async`) was 
 
 | Metric | Old (Ollama) | New (Embedding) |
 |--------|-------------|-----------------|
-| Cold start | 2-10 seconds | ~1 second (compute 73 embeddings via API) |
+| Cold start | 2-10 seconds | ~1 second (compute 72 embeddings via API) |
 | Warm lookup | 2-10 seconds | Under 50ms (cosine similarity only) |
-| Emoji coverage | 10 hardcoded | All 73 validated reactions |
+| Emoji coverage | 10 hardcoded | All 72 validated reactions |
 | Timeout fallback | Frequent | Rare (only on API key missing) |
 
 ## Related Files
 
 | File | Purpose |
 |------|---------|
-| `tools/emoji_embedding.py` | Embedding index, `EmojiResult` dataclass, standard + custom emoji selection |
+| `tools/emoji_embedding.py` | Embedding index, `EmojiResult` dataclass, standard + custom emoji selection, `BLOCKED_REACTION_EMOJIS` blocklist |
 | `tools/send_telegram.py` | `--react` flag for agent reactions, `--emoji` flag for standalone emoji messages |
 | `bridge/telegram_bridge.py` | Message handler integration |
 | `bridge/telegram_relay.py` | Reaction and custom emoji message payload delivery |

--- a/docs/features/reaction-semantics.md
+++ b/docs/features/reaction-semantics.md
@@ -38,7 +38,11 @@ Telegram only accepts a specific subset of emoji as reactions. Common emoji that
 - Hourglass: Not a valid Telegram reaction
 - Arrows: Not a valid Telegram reaction
 
-The full list of 75+ validated working reactions is maintained in `VALIDATED_REACTIONS` in `bridge/response.py`.
+The full list of validated working reactions is maintained in `VALIDATED_REACTIONS` in `bridge/response.py`.
+
+### Blocked Reactions (policy)
+
+Some emoji are *valid* Telegram reactions but are deliberately excluded from selection on policy grounds. The middle finger 🖕 is one such case — Telegram accepts it, but reacting to a user's message with it is offensive. It is removed from both `VALIDATED_REACTIONS` and the `EMOJI_LABELS` selection set, and additionally guarded by `BLOCKED_REACTION_EMOJIS` in `tools/emoji_embedding.py`, which `find_best_emoji()` filters at selection time. The blocklist is defensive against stale on-disk embedding caches (`data/emoji_embeddings.json`) that may still contain the emoji — see [Emoji Embedding Reactions](emoji-embedding-reactions.md#components).
 
 ## Auto-Continue Integration
 

--- a/docs/features/telegram.md
+++ b/docs/features/telegram.md
@@ -137,7 +137,7 @@ During processing, the interface shows status through emoji reactions:
 
 ### Contextual Processing Emojis
 
-The processing emoji is selected via embedding cosine similarity against all 73 validated Telegram reaction emojis. The message text is embedded and compared to pre-computed emoji label embeddings, selecting the most contextually relevant reaction in under 50ms (after cache warm-up).
+The processing emoji is selected via embedding cosine similarity against the 72 validated Telegram reaction emojis. The message text is embedded and compared to pre-computed emoji label embeddings, selecting the most contextually relevant reaction in under 50ms (after cache warm-up).
 
 This replaces the previous Ollama intent classification approach, which was limited to 10 hardcoded emojis and had 2-10 second latency with frequent timeouts.
 

--- a/docs/features/tools-reference.md
+++ b/docs/features/tools-reference.md
@@ -83,7 +83,7 @@ for r in results:
 
 ### Emoji Embedding (`tools.emoji_embedding`)
 
-Embedding-based emoji selection for Telegram reactions. Maps feeling words to the nearest emoji via cosine similarity, searching both the 73 standard Telegram reaction emojis and any available Premium custom emoji packs.
+Embedding-based emoji selection for Telegram reactions. Maps feeling words to the nearest emoji via cosine similarity, searching both the 72 standard Telegram reaction emojis and any available Premium custom emoji packs.
 
 ```python
 from tools.emoji_embedding import find_best_emoji, find_best_emoji_for_message, EmojiResult

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -105,7 +105,7 @@ Paired with two PreToolUse validators (`validate_design_system_sync.py`, `valida
 
 ### Emoji Embedding (`tools.emoji_embedding`)
 
-Embedding-based emoji selection for Telegram reactions. Maps feeling words to the nearest emoji via cosine similarity, searching both the 73 standard Telegram reaction emojis and any available Premium custom emoji packs.
+Embedding-based emoji selection for Telegram reactions. Maps feeling words to the nearest emoji via cosine similarity, searching both the 72 standard Telegram reaction emojis and any available Premium custom emoji packs.
 
 ```python
 from tools.emoji_embedding import find_best_emoji, find_best_emoji_for_message, EmojiResult

--- a/tests/unit/test_emoji_embedding.py
+++ b/tests/unit/test_emoji_embedding.py
@@ -15,7 +15,7 @@ class TestEmojiLabels:
     """Test emoji label completeness and consistency."""
 
     def test_all_validated_reactions_have_labels(self):
-        """Every one of the 73 validated Telegram reactions should have a label."""
+        """Every validated Telegram reaction should have a label."""
         from bridge.response import VALIDATED_REACTIONS
         from tools.emoji_embedding import EMOJI_LABELS
 
@@ -23,7 +23,7 @@ class TestEmojiLabels:
         assert not missing, f"Missing labels for validated emojis: {missing}"
 
     def test_label_count_matches_validated(self):
-        """Label count should match the 73 validated reactions exactly."""
+        """Label count should match the validated reactions exactly."""
         from bridge.response import VALIDATED_REACTIONS
         from tools.emoji_embedding import EMOJI_LABELS
 
@@ -44,6 +44,62 @@ class TestEmojiLabels:
         for emoji, label in EMOJI_LABELS.items():
             assert isinstance(label, str), f"Label for {emoji} is not a string"
             assert label.strip(), f"Label for {emoji} is empty"
+
+
+class TestOffensiveEmojiBlocked:
+    """The middle finger 🖕 must never be selectable as a reaction."""
+
+    MIDDLE_FINGER = "\U0001f595"
+
+    def test_not_in_emoji_labels(self):
+        """🖕 must not be in the selection label set."""
+        from tools.emoji_embedding import EMOJI_LABELS
+
+        assert self.MIDDLE_FINGER not in EMOJI_LABELS
+
+    def test_not_in_validated_reactions(self):
+        """🖕 must not be in the validated reactions policy list."""
+        from bridge.response import VALIDATED_REACTIONS
+
+        assert self.MIDDLE_FINGER not in VALIDATED_REACTIONS
+
+    def test_in_blocklist(self):
+        """🖕 must be in the defensive selection-time blocklist."""
+        from tools.emoji_embedding import BLOCKED_REACTION_EMOJIS
+
+        assert self.MIDDLE_FINGER in BLOCKED_REACTION_EMOJIS
+
+    def test_never_selected_even_if_cached(self):
+        """Even a stale cache containing 🖕 must not produce it as a result.
+
+        Simulates a production machine whose on-disk cache predates the
+        removal: the blocklist filter in find_best_emoji must skip it, even
+        when its embedding is the nearest match to the query.
+        """
+        from tools.emoji_embedding import EmojiResult, clear_cache, find_best_emoji
+
+        clear_cache()
+
+        # Stale cache where 🖕 is the closest vector to the query.
+        fake_cache = {
+            self.MIDDLE_FINGER: [1.0, 0.0, 0.0],  # nearest to query below
+            "\U0001f44d": [0.0, 1.0, 0.0],  # thumbs up
+        }
+
+        with (
+            patch("tools.emoji_embedding._embedding_cache", fake_cache),
+            patch("tools.emoji_embedding._custom_embedding_cache", {}),
+            patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}),
+            patch(
+                "tools.emoji_embedding._compute_embedding",
+                return_value=[0.95, 0.05, 0.0],  # closest to 🖕 vector
+            ),
+        ):
+            result = find_best_emoji("furious")
+            assert isinstance(result, EmojiResult)
+            assert str(result) != self.MIDDLE_FINGER
+
+        clear_cache()
 
 
 class TestFallbackBehavior:

--- a/tools/emoji_embedding.py
+++ b/tools/emoji_embedding.py
@@ -1,6 +1,6 @@
 """Emoji embedding index for fast reaction selection.
 
-Maps the 73 validated Telegram reaction emojis to descriptive feeling-word
+Maps the validated Telegram reaction emojis to descriptive feeling-word
 embeddings via cosine similarity. Also supports Premium custom emoji via
 a separate cached index of custom emoji sticker packs.
 
@@ -80,6 +80,12 @@ CUSTOM_CACHE_PATH = Path(__file__).parent.parent / "data" / "custom_emoji_embedd
 # Default fallback emoji (thinking face)
 DEFAULT_EMOJI = "\U0001f914"  # 🤔
 
+# Emojis that must never be selected as a reaction, even if a stale on-disk
+# cache still contains their embedding. Telegram accepts 🖕 as a valid
+# reaction, but reacting to a user's message with it is offensive — so it is
+# blocked at selection time regardless of cache state.
+BLOCKED_REACTION_EMOJIS = frozenset({"\U0001f595"})  # 🖕 middle finger
+
 # Placeholder character used for custom emoji in message text
 CUSTOM_EMOJI_PLACEHOLDER = "\u2753"  # ❓ (replaced by entity rendering)
 
@@ -126,7 +132,7 @@ class EmojiResult:
         return str(self)
 
 
-# Descriptive labels for each of the 73 validated Telegram reaction emojis.
+# Descriptive labels for each of the validated Telegram reaction emojis.
 # These labels are embedded and compared against input text via cosine similarity.
 # fmt: off
 EMOJI_LABELS: dict[str, str] = {
@@ -147,7 +153,6 @@ EMOJI_LABELS: dict[str, str] = {
     "\U0001f44c": "perfect, okay, fine, precise, excellent, on point",
     "\U0001f91d": "agreement, deal, handshake, partnership, cooperation",
     "\u270d": "writing, noting, composing, drafting, penning",
-    "\U0001f595": "rude, angry, offensive, middle finger, frustrated",
     # Positive faces
     "\U0001f601": "happy, grinning, joyful, cheerful, beaming smile",
     "\U0001f923": "hilarious, laughing hard, rolling on floor, so funny, comedy",
@@ -318,6 +323,8 @@ def find_best_emoji(feeling: str) -> EmojiResult:
     best_standard_score = -1.0
 
     for emoji, emb in embeddings.items():
+        if emoji in BLOCKED_REACTION_EMOJIS:
+            continue
         score = _cosine_similarity(query_embedding, emb)
         if score > best_standard_score:
             best_standard_score = score


### PR DESCRIPTION
## Problem

Tom reported the Telegram message-classification emoji picker chose the 🖕 (middle finger) reaction several times — offensive to send at a user.

## Root cause

Incoming-message reactions are selected by cosine similarity over `EMOJI_LABELS` in `tools/emoji_embedding.py` (called from `bridge/telegram_bridge.py` via `find_best_emoji_for_message`). The 🖕 entry carried the label `"rude, angry, offensive, middle finger, frustrated"`, so any frustrated/angry/offensive-sounding user message could match it.

## Fix

- Remove 🖕 (`\U0001f595`) from `EMOJI_LABELS` (the selection set) and from `VALIDATED_REACTIONS` (the policy list in `bridge/response.py`).
- Add a `BLOCKED_REACTION_EMOJIS` frozenset filtered at selection time in `find_best_emoji`. This is defensive: production bridge machines have a cached `data/emoji_embeddings.json` that still contains the 🖕 embedding, and the picker iterates the cached dict — so removing the label alone wouldn't fix those machines until a cache rebuild. The blocklist guarantees it can never be selected regardless of cache state.

🖕 remains in `scripts/test_emoji_reactions.py` intentionally — that's a probe of which emojis Telegram's API accepts as reactions (it does accept 🖕), not our selection policy.

## Tests

New `TestOffensiveEmojiBlocked` class:
- not in `EMOJI_LABELS`
- not in `VALIDATED_REACTIONS`
- in `BLOCKED_REACTION_EMOJIS`
- never selected even when it is the nearest cached vector (simulates a stale production cache)

All 19 tests in `tests/unit/test_emoji_embedding.py` pass. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)