### PR TITLE
Fix SDLC router: guard rule 4b against re-firing once a PR exists

### DIFF
--- a/agent/sdlc_router.py
+++ b/agent/sdlc_router.py
@@ -645,7 +645,16 @@ def _rule_critique_ready_with_concerns_no_revision(
     verdict = _latest_critique_verdict(stage_states, meta).upper()
     if CRITIQUE_READY_TO_BUILD not in verdict or "WITH CONCERNS" not in verdict:
         return False
-    return not bool(meta.get("revision_applied"))
+    if bool(meta.get("revision_applied")):
+        return False
+    # Once build has produced a PR (or BUILD is already done), this row must
+    # release so routing can advance to review/merge. Without these guards the
+    # row re-dispatches /do-plan forever for a with-concerns plan whose
+    # revision flag never got set. Mirror the guards on rows 4a/4c.
+    if meta.get("pr_number"):
+        return False
+    build_status = stage_states.get("BUILD")
+    return build_status in (None, "pending", "ready")
 
 
 def _rule_critique_ready_with_concerns_revision_applied(

--- a/tests/unit/test_sdlc_router_decision.py
+++ b/tests/unit/test_sdlc_router_decision.py
@@ -129,6 +129,28 @@ class TestRow4bReadyWithConcernsNoRevision:
         assert result.skill == SKILL_DO_PLAN
         assert result.row_id == "4b"
 
+    def test_releases_once_pr_exists_even_without_revision_flag(self):
+        """Row 4b must NOT re-dispatch /do-plan after the PR is open.
+
+        Symmetry gap: row 4c got pr_number/BUILD guards but row 4b did not, so
+        a with-concerns plan whose revision_applied flag never got set would
+        loop /do-plan forever once a PR existed, never advancing to review.
+        """
+        states = {
+            "PLAN": "completed",
+            "CRITIQUE": "completed",
+            "BUILD": "completed",
+            "REVIEW": "ready",
+        }
+        meta = {
+            "latest_critique_verdict": "READY TO BUILD (with concerns)",
+            "revision_applied": False,
+            "pr_number": 466,
+        }
+        result = decide_next_dispatch(states, meta)
+        assert result.skill != SKILL_DO_PLAN
+        assert result.row_id != "4b"
+
 
 class TestRow4cReadyWithConcernsRevisionApplied:
     def test_concerns_with_revision_flag_proceeds_to_build(self):


### PR DESCRIPTION
## Context

While shepherding #1413/PR #1553 I hit the router perpetually re-dispatching `/do-build`. A concurrent fix (already on `main`) added `pr_number`/BUILD guards to **rule 4c** (`_rule_critique_ready_with_concerns_revision_applied`) — but left the sibling **rule 4b** (`_rule_critique_ready_with_concerns_no_revision`) unguarded.

## Problem

A `READY TO BUILD (with concerns)` plan whose `revision_applied` flag never got set would, once a PR exists, loop `/do-plan` forever via rule 4b and never advance to review/merge — the same class of bug that was just fixed for 4c.

## Fix

Mirror 4c's guards onto 4b: release the row once `meta["pr_number"]` is set or BUILD has progressed. Adds a 4b regression test (`test_releases_once_pr_exists_even_without_revision_flag`) alongside the existing 4c one. All 22 router-decision tests pass.