### PR TITLE
Fix docs-auditor deleted-target flood: filtering + live-tracker dedup

### DIFF
--- a/docs/features/docs-auditor.md
+++ b/docs/features/docs-auditor.md
@@ -60,12 +60,55 @@ writes the SDLC stage marker and updates the plan frontmatter.
 
 | Detector | What it catches | Action |
 |----------|-----------------|--------|
-| Deleted target | `` `path.py` `` references with no rename in history | `gh issue create` (deduped) |
+| Deleted target | `` `path.py` `` references with no rename in history, after placeholder / fenced-block / deletion-heading filtering | `gh issue create` (deduped) |
 | Stub doc | Docs with <5 content lines | `gh issue create` (deduped) |
 | Orphan plan | `docs/plans/*.md` lacking a tracking-issue link | `gh issue create` (deduped) |
 
-Issues are deduped by SHA-256 of the title via `docs_audit:issues_filed:{hash}`
-Redis keys (30-day TTL).
+#### Deleted-target false-positive filtering
+
+The deleted-target detector runs three suppression passes before emitting a
+finding, so it never floods the tracker with illustrative or
+intentionally-documented paths:
+
+- **Placeholder / example paths** (`_is_placeholder_path`): a path is skipped if
+  any component (or the final file's stem) is a well-known stand-in — `foo`,
+  `bar`, `baz`, `qux`, `quux`, `example`, `your-module`, `mymodule`, `sample` —
+  or a single-letter directory. This suppresses paths like `foo/bar.py` and
+  `agent/docs_handler/foo.py`.
+- **Fenced code blocks** (`_build_line_context`): a single line-scan over the
+  doc tracks fenced ```` ``` ```` block state. Matches inside a fenced block are
+  treated as illustrative and skipped. Inline single-backtick code is **not**
+  suppressed — that is the normal way genuine references are written.
+- **Deletion headings & prose** (`_is_documented_deletion`): a match is skipped
+  if its nearest preceding heading names a deletion (`migration`, `removed`,
+  `deleted`, `deprecated`) or if its line / an adjacent line carries a deletion
+  cue (`deleted module`, `no longer in the codebase`, `no longer exists`,
+  `previously in`, `formerly`). This suppresses paths like `intent/__init__.py`
+  documented under a `## Migration ...` heading.
+
+Every suppressed match is logged at DEBUG so an operator can audit exactly what
+the filter dropped.
+
+#### Two-tier dedup
+
+Issue filing uses a two-tier dedup gate:
+
+1. **Local-Redis fast-path** (`docs_audit:issues_filed:{hash}`, SHA-256 of the
+   title, 30-day TTL): a per-machine cache. If the key exists, filing is skipped
+   without any GitHub call.
+2. **Live-tracker gate** (`_open_issue_exists`): the **authoritative**
+   cross-machine check. Before filing, it runs
+   `gh issue list --state open --label documentation --search "<title>"` and
+   confirms a hit with an exact normalized-title comparison (the title encodes
+   both the path and the doc, so it is a natural composite key). Local Redis
+   alone is insufficient because each machine keeps its own Redis, so the same
+   finding would otherwise be filed once per machine.
+
+The tracker query **fails open**: on any `gh` failure, non-zero exit, or
+malformed output it logs a warning and degrades to Redis-only dedup rather than
+silently dropping a genuine finding. This shrinks the cross-machine duplicate
+window to a brief TOCTOU race (two machines querying within a few seconds of
+each other) instead of one duplicate per machine per 30 days.
 
 ## Rotation State
 

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -789,7 +789,9 @@ def _file_issue_if_new(finding: dict, repo_root: Path) -> bool:
         if redis_client is not None:
             try:
                 redis_client.set(dedup_key, "1", ex=86400 * 30)
-            except Exception:
+            except (
+                Exception
+            ):  # swallow-ok: best-effort cache write; tracker already confirmed dedup
                 pass
         return False
 
@@ -822,7 +824,7 @@ def _file_issue_if_new(finding: dict, repo_root: Path) -> bool:
         if redis_client is not None:
             try:
                 redis_client.set(dedup_key, "1", ex=86400 * 30)
-            except Exception:
+            except Exception:  # swallow-ok: best-effort cache write after successful issue create
                 pass
         return True
     except Exception as e:

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -487,11 +487,139 @@ def _apply_fixes_to_file(path: Path, repo_root: Path, fixes: list[tuple[str, str
 # ---------------------------------------------------------------------------
 
 
+# Path components that are obvious illustrative stand-ins, not real module names.
+_PLACEHOLDER_PATH_COMPONENTS = frozenset(
+    {"foo", "bar", "baz", "qux", "quux", "example", "your-module", "mymodule", "sample"}
+)
+
+# Heading keywords whose presence means the doc is deliberately recording a deletion.
+_DELETION_HEADING_KEYWORDS = ("migration", "removed", "deleted", "deprecated")
+
+# Prose cues that a nearby line is documenting a deletion rather than a live reference.
+_DELETION_PROSE_CUES = (
+    "deleted module",
+    "no longer in the codebase",
+    "no longer exists",
+    "previously in",
+    "formerly",
+)
+
+
+def _is_placeholder_path(path: str) -> bool:
+    """Return True if a path is an illustrative placeholder, not a real module path.
+
+    A path is a placeholder when any of its components is a well-known stand-in
+    (``foo``, ``bar``, ``example`` ...) or a single lowercase letter directory.
+    Empty or single-segment paths return False (the detector regex guarantees a
+    ``dir/file.py`` shape, so this only guards malformed/odd input).
+    """
+    if not path or "/" not in path:
+        return False
+    components = path.split("/")
+    for i, component in enumerate(components):
+        # For the final component, compare the file stem (strip the .py suffix)
+        # so ``agent/docs_handler/foo.py`` is caught on its ``foo`` stem.
+        is_last = i == len(components) - 1
+        candidate = component[:-3] if is_last and component.endswith(".py") else component
+        lowered = candidate.lower()
+        if lowered in _PLACEHOLDER_PATH_COMPONENTS:
+            return True
+        # A single lowercase letter directory (e.g. ``a/foo.py``) is illustrative.
+        if len(candidate) == 1 and candidate.isalpha() and candidate.islower():
+            return True
+    return False
+
+
+def _build_line_context(content: str) -> tuple[list[bool], list[str]]:
+    """Single-scan precompute of per-line context for deletion-aware filtering.
+
+    Returns ``(in_fence, heading_for_line)`` where:
+    - ``in_fence[i]`` is True if line ``i`` sits inside a fenced ``` code block.
+    - ``heading_for_line[i]`` is the text of the nearest preceding Markdown
+      heading for line ``i`` (lowercased), or ``""`` if none precedes it.
+
+    No I/O; pure string scan over ``content``.
+    """
+    lines = content.splitlines()
+    in_fence: list[bool] = []
+    heading_for_line: list[str] = []
+    fence_open = False
+    current_heading = ""
+    for line in lines:
+        stripped = line.lstrip()
+        is_fence_marker = stripped.startswith("```")
+        # A fence marker line is itself part of the block boundary; treat the
+        # marker line as inside the fence so matches on it are suppressed too.
+        if is_fence_marker:
+            in_fence.append(True)
+            fence_open = not fence_open
+        else:
+            in_fence.append(fence_open)
+        # Track nearest preceding heading only outside fenced blocks.
+        if not fence_open and not is_fence_marker and stripped.startswith("#"):
+            current_heading = stripped.lstrip("#").strip().lower()
+        heading_for_line.append(current_heading)
+    return in_fence, heading_for_line
+
+
+def _is_documented_deletion(
+    line_idx: int, lines: list[str], in_fence: list[bool], heading_for_line: list[str]
+) -> bool:
+    """Return True if a match at ``line_idx`` is an illustrative or documented deletion.
+
+    Three conservative cues (any one suppresses the finding):
+    1. The match falls inside a fenced code block (illustrative example).
+    2. The nearest preceding heading names a deletion (migration/removed/
+       deleted/deprecated).
+    3. The match's line or an immediately adjacent line carries a deletion-prose
+       cue ("deleted module", "no longer exists", ...).
+
+    Inline single-backtick code is NOT suppressed — that is how genuine
+    references are written.
+    """
+    if line_idx < len(in_fence) and in_fence[line_idx]:
+        return True
+    if line_idx < len(heading_for_line):
+        heading = heading_for_line[line_idx]
+        if any(kw in heading for kw in _DELETION_HEADING_KEYWORDS):
+            return True
+    for adj in (line_idx - 1, line_idx, line_idx + 1):
+        if 0 <= adj < len(lines):
+            lowered = lines[adj].lower()
+            if any(cue in lowered for cue in _DELETION_PROSE_CUES):
+                return True
+    return False
+
+
 def _detect_deleted_target_issues(doc_path: Path, content: str, repo_root: Path) -> list[dict]:
-    """File issues for references to deleted (non-renamed) targets."""
+    """File issues for references to deleted (non-renamed) targets.
+
+    Suppresses three classes of false positive before emitting a finding:
+    placeholder/example paths (``foo/bar.py``), paths inside fenced illustrative
+    code blocks, and paths under a deletion-recording heading or deletion prose.
+    Every suppressed match is logged at DEBUG so operators can audit the filter.
+    """
     findings: list[dict] = []
+    lines = content.splitlines()
+    in_fence, heading_for_line = _build_line_context(content)
     for m in re.finditer(r"`((?:[\w.-]+/)+[\w.-]+\.py)`", content):
         path = m.group(1)
+        if _is_placeholder_path(path):
+            logger.debug(
+                "docs_auditor: suppressed deleted-target finding for placeholder path %s in %s",
+                path,
+                doc_path,
+            )
+            continue
+        line_idx = content.count("\n", 0, m.start())
+        if _is_documented_deletion(line_idx, lines, in_fence, heading_for_line):
+            logger.debug(
+                "docs_auditor: suppressed deleted-target finding for %s in %s "
+                "(fenced block or documented deletion)",
+                path,
+                doc_path,
+            )
+            continue
         if (repo_root / path).exists():
             continue
         renames = _git_log_follow_renames(path, repo_root)
@@ -567,8 +695,80 @@ def refresh_docs_in_memory(touched_paths: list[str]) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _normalize_title(title: str) -> str:
+    """Collapse internal whitespace and strip — for exact title comparison."""
+    return " ".join(title.split())
+
+
+def _open_issue_exists(title: str, repo_root: Path) -> bool:
+    """Return True if an open `documentation` issue already has this exact title.
+
+    This is the authoritative cross-machine dedup gate: local Redis dedup keys
+    are per-machine and invisible across hosts, so two machines would otherwise
+    file the same finding. Queries the live tracker via
+    ``gh issue list --search`` (REST-backed full-text search) and confirms with
+    an exact normalized-title comparison in Python (the title already encodes
+    both the path and the doc, making it a natural composite key).
+
+    Fails open: on any `gh` failure, non-zero exit, or malformed output, log a
+    WARNING and return False so a genuine finding is never silently dropped —
+    the worst case is the duplicate this gate was meant to prevent, which the
+    Redis fast-path still suppresses on the next run.
+    """
+    normalized_query = _normalize_title(title)
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--state",
+                "open",
+                "--label",
+                "documentation",
+                "--search",
+                title,
+                "--json",
+                "number,title",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+            cwd=str(repo_root),
+        )
+        if result.returncode != 0:
+            logger.warning(
+                "docs_auditor: gh issue list (dedup) failed for '%s' (rc=%d): %s "
+                "— falling back to Redis-only dedup",
+                title,
+                result.returncode,
+                result.stderr.strip()[:200],
+            )
+            return False
+        issues = json.loads(result.stdout or "[]")
+        for issue in issues:
+            if _normalize_title(issue.get("title", "")) == normalized_query:
+                return True
+        return False
+    except Exception as e:
+        logger.warning(
+            "docs_auditor: gh issue list (dedup) errored for '%s': %s "
+            "— falling back to Redis-only dedup",
+            title,
+            e,
+        )
+        return False
+
+
 def _file_issue_if_new(finding: dict, repo_root: Path) -> bool:
-    """File a GitHub issue via gh CLI, deduped by title hash. Returns True if filed."""
+    """File a GitHub issue via gh CLI, deduped by title. Returns True if filed.
+
+    Two-tier dedup: a local Redis fast-path (per-machine cache) gates the
+    expensive live-tracker query, and `_open_issue_exists` is the authoritative
+    cross-machine gate. Local Redis alone is insufficient because each machine
+    keeps its own Redis, so the same finding would be filed once per machine.
+    """
     title = finding.get("title", "").strip()
     if not title:
         return False
@@ -577,11 +777,21 @@ def _file_issue_if_new(finding: dict, repo_root: Path) -> bool:
     redis_client = None
     try:
         redis_client = _get_redis()
-        # Pre-check existence without writing — only commit dedup key after gh succeeds.
+        # Fast-path: if this machine already filed it, skip the tracker query entirely.
         if redis_client.exists(dedup_key):
             return False  # already filed
     except Exception:
         redis_client = None  # If Redis is unavailable, attempt to file without dedup
+
+    # Authoritative cross-machine gate: another machine may have already filed this.
+    if _open_issue_exists(title, repo_root):
+        # Record the local fast-path key so subsequent runs skip the tracker query.
+        if redis_client is not None:
+            try:
+                redis_client.set(dedup_key, "1", ex=86400 * 30)
+            except Exception:
+                pass
+        return False
 
     try:
         result = subprocess.run(

--- a/tests/unit/test_docs_auditor_substrate.py
+++ b/tests/unit/test_docs_auditor_substrate.py
@@ -542,3 +542,197 @@ class TestDraftModeAbsent:
         # Also check the source file to be sure
         src = Path(docs_auditor.__file__).read_text()
         assert "DRAFT_MODE" not in src
+
+
+# ---------------------------------------------------------------------------
+# TestDeletedTargetFiltering — placeholder / fenced / deletion-heading suppression
+# ---------------------------------------------------------------------------
+
+
+def _mk_finding(content: str, repo: Path) -> list[dict]:
+    """Run the detector against a doc with the given content."""
+    return docs_auditor._detect_deleted_target_issues(Path("docs/features/x.md"), content, repo)
+
+
+class TestDeletedTargetFiltering:
+    def test_is_placeholder_path_stand_ins(self):
+        assert docs_auditor._is_placeholder_path("foo/bar.py") is True
+        assert docs_auditor._is_placeholder_path("agent/docs_handler/foo.py") is True
+        assert docs_auditor._is_placeholder_path("pkg/example.py") is True
+        assert docs_auditor._is_placeholder_path("a/thing.py") is True  # single-letter dir
+
+    def test_is_placeholder_path_real_paths(self):
+        assert docs_auditor._is_placeholder_path("reflections/docs_auditor.py") is False
+        assert docs_auditor._is_placeholder_path("agent/output_router.py") is False
+
+    def test_is_placeholder_path_empty_and_single_segment(self):
+        assert docs_auditor._is_placeholder_path("") is False
+        assert (
+            docs_auditor._is_placeholder_path("foo.py") is False
+        )  # no slash, not reached normally
+
+    def test_placeholder_paths_suppressed(self, repo: Path):
+        content = (
+            "## Examples\n"
+            "An illustrative path like `foo/bar.py` should not be flagged.\n"
+            "Neither should `agent/docs_handler/foo.py` (path-matching example).\n"
+        )
+        assert _mk_finding(content, repo) == []
+
+    def test_fenced_block_paths_suppressed(self, repo: Path):
+        content = "Intro prose.\n```\nsee deleted/gone_module.py for context\n```\nOutro.\n"
+        assert _mk_finding(content, repo) == []
+
+    def test_deletion_heading_paths_suppressed(self, repo: Path):
+        content = (
+            "## Migration from Ollama Intent Classification\n\n"
+            "The `intent/__init__.py` module is gone.\n"
+        )
+        assert _mk_finding(content, repo) == []
+
+    def test_deprecated_heading_suppressed(self, repo: Path):
+        content = "### Deprecated\n\nWe used to import `old/legacy_thing.py` here.\n"
+        assert _mk_finding(content, repo) == []
+
+    def test_deletion_prose_cue_suppressed(self, repo: Path):
+        content = (
+            "## Architecture\n\n"
+            "The `some/removed_module.py` is no longer in the codebase as of the refactor.\n"
+        )
+        assert _mk_finding(content, repo) == []
+
+    def test_genuine_dead_reference_not_suppressed(self, repo: Path):
+        # Normal prose, normal heading, inline code, path does not exist on disk.
+        content = (
+            "## Architecture\n\n"
+            "The handler lives in `agent/totally_made_up_handler_xyz.py` and runs the loop.\n"
+        )
+        with patch.object(docs_auditor, "_git_log_follow_renames", return_value=[]):
+            findings = _mk_finding(content, repo)
+        assert len(findings) == 1
+        assert "agent/totally_made_up_handler_xyz.py" in findings[0]["title"]
+        assert findings[0]["category"] == "deleted-target"
+
+    def test_existing_path_not_flagged(self, repo: Path):
+        # A path that exists on disk is skipped even if it survives the filters.
+        (repo / "agent").mkdir()
+        (repo / "agent" / "real_module.py").write_text("x = 1\n")
+        content = "## Architecture\n\nSee `agent/real_module.py`.\n"
+        assert _mk_finding(content, repo) == []
+
+    def test_empty_content_returns_empty(self, repo: Path):
+        assert _mk_finding("", repo) == []
+
+    def test_inline_code_not_blanket_suppressed(self, repo: Path):
+        # Inline single-backtick code is the normal way real refs are written —
+        # it must NOT be suppressed merely for being inline code.
+        content = "The module `agent/inline_ref_xyz.py` is referenced inline in prose.\n"
+        with patch.object(docs_auditor, "_git_log_follow_renames", return_value=[]):
+            findings = _mk_finding(content, repo)
+        assert len(findings) == 1
+
+
+# ---------------------------------------------------------------------------
+# TestCrossMachineDedup — live-tracker gate + Redis fast-path
+# ---------------------------------------------------------------------------
+
+
+def _gh_list_result(stdout: str, returncode: int = 0):
+    return subprocess.CompletedProcess(args=["gh"], returncode=returncode, stdout=stdout, stderr="")
+
+
+class TestCrossMachineDedup:
+    def test_open_issue_exists_exact_match(self, repo: Path):
+        title = "Doc references deleted target: a/b.py (in docs/x.md)"
+        out = f'[{{"number": 5, "title": "{title}"}}]'
+        with patch("subprocess.run", return_value=_gh_list_result(out)):
+            assert docs_auditor._open_issue_exists(title, repo) is True
+
+    def test_open_issue_exists_whitespace_normalized(self, repo: Path):
+        title = "Doc references deleted target: a/b.py (in docs/x.md)"
+        # Tracker title has collapsed/extra whitespace — still an exact match.
+        tracker_title = "Doc references deleted   target: a/b.py (in docs/x.md)"
+        out = f'[{{"number": 5, "title": "{tracker_title}"}}]'
+        with patch("subprocess.run", return_value=_gh_list_result(out)):
+            assert docs_auditor._open_issue_exists(title, repo) is True
+
+    def test_open_issue_exists_no_match(self, repo: Path):
+        title = "Doc references deleted target: a/b.py (in docs/x.md)"
+        out = '[{"number": 5, "title": "Some unrelated issue"}]'
+        with patch("subprocess.run", return_value=_gh_list_result(out)):
+            assert docs_auditor._open_issue_exists(title, repo) is False
+
+    def test_open_issue_exists_empty_list(self, repo: Path):
+        with patch("subprocess.run", return_value=_gh_list_result("[]")):
+            assert docs_auditor._open_issue_exists("anything", repo) is False
+
+    def test_open_issue_exists_nonzero_rc_fails_open(self, repo: Path, caplog):
+        with patch("subprocess.run", return_value=_gh_list_result("", returncode=1)):
+            assert docs_auditor._open_issue_exists("t", repo) is False
+        assert any("dedup" in r.message.lower() for r in caplog.records)
+
+    def test_open_issue_exists_malformed_json_fails_open(self, repo: Path, caplog):
+        with patch("subprocess.run", return_value=_gh_list_result("not json{{")):
+            assert docs_auditor._open_issue_exists("t", repo) is False
+        assert any("dedup" in r.message.lower() for r in caplog.records)
+
+    def test_open_issue_exists_subprocess_raises_fails_open(self, repo: Path, caplog):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("gh", 20)):
+            assert docs_auditor._open_issue_exists("t", repo) is False
+        assert any("dedup" in r.message.lower() for r in caplog.records)
+
+    def test_open_match_skips_filing(self, repo: Path, patch_redis):
+        patch_redis.exists.return_value = False
+        finding = {"title": "Doc references deleted target: a/b.py (in docs/x.md)", "body": "b"}
+        with (
+            patch.object(docs_auditor, "_open_issue_exists", return_value=True),
+            patch("subprocess.run") as run,
+        ):
+            filed = docs_auditor._file_issue_if_new(finding, repo)
+        assert filed is False
+        # gh issue create must NOT have been called.
+        assert run.call_count == 0
+        # The local fast-path key is recorded so later runs skip the tracker query.
+        patch_redis.set.assert_called_once()
+
+    def test_no_open_match_files(self, repo: Path, patch_redis):
+        patch_redis.exists.return_value = False
+        finding = {"title": "Doc references deleted target: a/b.py (in docs/x.md)", "body": "b"}
+        with (
+            patch.object(docs_auditor, "_open_issue_exists", return_value=False),
+            patch("subprocess.run", return_value=_gh_list_result("https://gh/issues/9")) as run,
+        ):
+            filed = docs_auditor._file_issue_if_new(finding, repo)
+        assert filed is True
+        assert run.call_count == 1  # gh issue create invoked
+        create_cmd = run.call_args.args[0]
+        assert create_cmd[:3] == ["gh", "issue", "create"]
+
+    def test_redis_fast_path_skips_tracker_query(self, repo: Path, patch_redis):
+        # If the local Redis key already exists, the tracker query is skipped.
+        patch_redis.exists.return_value = True
+        finding = {"title": "Doc references deleted target: a/b.py (in docs/x.md)", "body": "b"}
+        with patch.object(docs_auditor, "_open_issue_exists") as gate:
+            filed = docs_auditor._file_issue_if_new(finding, repo)
+        assert filed is False
+        gate.assert_not_called()
+
+    def test_tracker_failure_falls_back_to_filing(self, repo: Path, patch_redis, caplog):
+        # Simulate gh issue list failing inside _open_issue_exists (fail-open ->
+        # _open_issue_exists returns False) so filing proceeds via gh create.
+        patch_redis.exists.return_value = False
+        finding = {"title": "Doc references deleted target: a/b.py (in docs/x.md)", "body": "b"}
+
+        def fake_run(cmd, *a, **k):
+            if cmd[:3] == ["gh", "issue", "list"]:
+                return _gh_list_result("", returncode=1)  # tracker query fails
+            return _gh_list_result("https://gh/issues/9")  # create succeeds
+
+        with patch("subprocess.run", side_effect=fake_run):
+            filed = docs_auditor._file_issue_if_new(finding, repo)
+        assert filed is True
+        # The fail-open warning was logged.
+        assert any("dedup" in r.message.lower() for r in caplog.records)
+
+    def test_empty_title_returns_false(self, repo: Path, patch_redis):
+        assert docs_auditor._file_issue_if_new({"title": "", "body": "b"}, repo) is False


### PR DESCRIPTION
## Summary
Fixes the docs-auditor deleted-target detector flooding the issue tracker with duplicate and false-positive `documentation`-labelled issues (~45 in two weeks, all bulk-closed manually). Three independent root-cause defects are fixed, all scoped to the issue-filing path in `reflections/docs_auditor.py`.

## Changes
- **Placeholder/example-path suppression** (`_is_placeholder_path`): skips paths whose components or final-file stem are illustrative stand-ins (`foo`, `bar`, `example`, ...) or single-letter dirs. Kills `foo/bar.py` and `agent/docs_handler/foo.py`.
- **Fenced-block + deletion-heading/prose awareness** (`_build_line_context`, `_is_documented_deletion`): single line-scan over content (no extra I/O). Skips matches inside fenced code blocks, under `migration`/`removed`/`deleted`/`deprecated` headings, or beside deletion-prose cues. Kills `intent/__init__.py` under `## Migration from Ollama`. Every suppressed match logged at DEBUG.
- **Live-tracker cross-machine dedup gate** (`_open_issue_exists`): queries `gh issue list --search` before filing and confirms with exact normalized-title comparison. Authoritative gate behind the local-Redis fast-path; fails open with a logged warning so a real finding is never silently dropped.
- Auto-fix regex in `_detect_renamed_symbol_fixes` left untouched (scope guard).
- Batching / rolling-issue deferred per the plan's resolved decision.

## Testing
- [x] 58 unit tests pass in `tests/unit/test_docs_auditor_substrate.py` (34 existing + 24 new across `TestDeletedTargetFiltering` and `TestCrossMachineDedup`)
- [x] Real cited docs verified: `intent/__init__.py`, `foo/bar.py`, `agent/docs_handler/foo.py` all suppressed; genuine references still flagged
- [x] Linting (ruff check + format) passing

## Documentation
- [x] `docs/features/docs-auditor.md` updated with the three suppression passes and the two-tier dedup model

## Definition of Done
- [x] Built: filtering + live-tracker dedup implemented
- [x] Tested: filtering, dedup, fail-open, and regression-guard coverage added
- [x] Documented: docs-auditor.md reflects new behavior
- [x] Quality: ruff check and format pass

Closes #1543

🤖 Generated with [Claude Code](https://claude.com/claude-code)