### PR TITLE
Reflections: tighten confidence gate, delete false-positive thrash detector

### DIFF
--- a/docs/features/reflections.md
+++ b/docs/features/reflections.md
@@ -418,15 +418,20 @@ Queries Redis for recent sessions and computes quality metrics.
 - **AgentSession** — turn count, tool call count, log file path, session tags
 - **BridgeEvent** — error events correlated to sessions
 
-### Thrash Ratio
+The runner caps analysis at the 20 most interesting sessions (sorted by turn count).
 
-Measures how much agent effort was wasted:
-
-```
-failure_ratio = max(0.0, 1.0 - (turn_count / tool_call_count))
-```
-
-Sessions above `THRASH_RATIO_THRESHOLD = 0.5` (50% failure rate) are flagged for LLM reflection. The runner caps analysis at the 20 most interesting sessions (sorted by turn count).
+> **Removed: thrash-ratio detection (#1414).** A prior heuristic flagged
+> sessions as "thrashing" when `1 - (turn_count / tool_call_count) > 0.5`.
+> Because `turn_count` is *total assistant turns* (not *successful* turns),
+> any session averaging more than ~2 tool calls per turn tripped the
+> threshold — roughly 50% of healthy, completed SDLC runs. The detector was
+> removed entirely rather than left emitting false positives that auto-filed
+> duplicate bug issues. Neither candidate replacement signal (repeated
+> identical tool calls, repeated tool errors) is cheaply derivable from the
+> available data: `AgentSession` exposes only scalar aggregates, and the
+> transcript format records tool inputs/results as truncated summary strings
+> with no structured args or `is_error` flag. A missing detector is strictly
+> better than one with a 50% false-positive rate.
 
 ### Correction Detection
 
@@ -464,13 +469,21 @@ When a reflection is categorized as `code_bug` and meets the confidence threshol
 
 ### Confidence Criteria
 
-An issue is filed when a reflection meets **2 of 3** criteria:
+An issue is filed only when a reflection is a **code bug AND** carries at least
+one supporting signal (`is_high_confidence()` in `reflections/utils.py`):
 
-| Criterion | Condition |
-|-----------|----------|
-| Category | `category == "code_bug"` |
-| Prevention | `prevention` field is non-empty |
-| Pattern length | `pattern` field is at least 10 characters |
+| Criterion | Condition | Role |
+|-----------|-----------|------|
+| Category | `category == "code_bug"` | **Required** — hard gate |
+| Prevention | `prevention` field is non-empty | Supporting (either suffices) |
+| Pattern length | `pattern` field is at least 10 characters | Supporting (either suffices) |
+
+This tightened the prior **2-of-3** rule (#1414). Under 2-of-3, a non-code-bug
+reflection (e.g. `category="poor_planning"`) could clear the gate on prevention
++ pattern length alone — which is how #1414, an agent-behaviour claim rather
+than a code defect, reached "high-confidence" and auto-filed itself. The gate
+now hard-requires `code_bug`, so only genuine code defects reach the auto-fix
+path.
 
 ### Ignore Log
 

--- a/reflections/session_intelligence.py
+++ b/reflections/session_intelligence.py
@@ -19,7 +19,6 @@ from pathlib import Path
 
 from reflections.utils import (
     CORRECTION_PATTERNS,
-    THRASH_RATIO_THRESHOLD,
     has_existing_github_work,
     is_high_confidence,
     is_ignored,
@@ -36,7 +35,6 @@ def _analyze_sessions_from_redis(target_date: str) -> dict:
     result: dict = {
         "sessions_analyzed": 0,
         "corrections": [],
-        "thrash_sessions": [],
         "error_patterns": [],
     }
 
@@ -61,20 +59,6 @@ def _analyze_sessions_from_redis(target_date: str) -> dict:
         for session in target_sessions:
             result["sessions_analyzed"] += 1
             session_id = session.session_id or "unknown"
-
-            tool_calls = session.tool_call_count or 0
-            turn_count = session.turn_count or 0
-            if tool_calls > 5 and turn_count > 0:
-                failure_ratio = max(0.0, 1.0 - (turn_count / tool_calls))
-                if failure_ratio > THRASH_RATIO_THRESHOLD:
-                    result["thrash_sessions"].append(
-                        {
-                            "session_id": session_id,
-                            "tool_calls": tool_calls,
-                            "successes": turn_count,
-                            "failure_ratio": round(failure_ratio, 2),
-                        }
-                    )
 
             if session.log_path:
                 log_path = Path(session.log_path)
@@ -154,18 +138,13 @@ def run() -> dict:
             f"Detected {len(analysis['corrections'])} user corrections "
             f"across {analysis['sessions_analyzed']} sessions"
         )
-    if analysis["thrash_sessions"]:
-        findings.append(
-            f"Detected {len(analysis['thrash_sessions'])} thrashing sessions (high failure ratio)"
-        )
     error_patterns = analysis.get("error_patterns", [])
     if error_patterns:
         findings.append(f"Found {len(error_patterns)} error patterns in sessions/events")
 
     logger.info(
         f"Session analysis: sessions={analysis['sessions_analyzed']}, "
-        f"corrections={len(analysis['corrections'])}, "
-        f"thrash={len(analysis['thrash_sessions'])}"
+        f"corrections={len(analysis['corrections'])}"
     )
 
     # Sub-step 2: LLM reflection

--- a/reflections/utils.py
+++ b/reflections/utils.py
@@ -33,8 +33,6 @@ CORRECTION_PATTERNS = [
     re.compile(r"\bplease\s+(don'?t|stop)\b", re.IGNORECASE),
 ]
 
-THRASH_RATIO_THRESHOLD = 0.5
-
 
 def load_local_projects() -> list[dict]:
     """Load projects from projects.json, filtered to those present on this machine.
@@ -285,11 +283,7 @@ def run_llm_reflection(analysis: dict[str, Any]) -> list[dict[str, str]]:
     except ImportError:
         anthropic = None  # type: ignore[assignment]
 
-    if (
-        analysis.get("sessions_analyzed", 0) == 0
-        and not analysis.get("corrections")
-        and not analysis.get("thrash_sessions")
-    ):
+    if analysis.get("sessions_analyzed", 0) == 0 and not analysis.get("corrections"):
         logger.info("No session findings for reflection, skipping LLM call")
         return []
 
@@ -409,17 +403,23 @@ def extract_structured_errors(log_file: Path) -> list[dict[str, str]]:
 
 
 def is_high_confidence(reflection: dict) -> bool:
-    """Check if a reflection meets the 2-of-3 confidence criteria for auto-fix.
+    """Check if a reflection clears the high-confidence gate for auto-fix.
+
+    The gate requires the reflection be a ``code_bug`` AND carry at least one
+    supporting signal (non-empty prevention, or a pattern of >=10 chars). This
+    deliberately excludes non-code-bug categories (e.g. ``poor_planning``,
+    ``process_gap``) from the auto-fix path even when they have rich prevention
+    and pattern text — those describe agent behaviour, not code defects, and
+    must not ride into the auto-filer on length alone (see #1414).
 
     Args:
         reflection: A reflection dict with category, prevention, pattern keys.
 
     Returns:
-        True if at least 2 of 3 criteria are met.
+        True only if category == "code_bug" AND (prevention OR pattern>=10).
     """
-    criteria = [
-        reflection.get("category") == "code_bug",
-        bool(reflection.get("prevention", "").strip()),
-        len(reflection.get("pattern", "")) >= 10,
-    ]
-    return sum(criteria) >= 2
+    if reflection.get("category") != "code_bug":
+        return False
+    return (
+        bool(reflection.get("prevention", "").strip()) or len(reflection.get("pattern", "")) >= 10
+    )

--- a/tests/integration/test_reflections_redis.py
+++ b/tests/integration/test_reflections_redis.py
@@ -82,11 +82,17 @@ class TestAnalyzeSessionsFromRedis:
     """Tests for Redis-backed session analysis via reflections.session_intelligence."""
 
     def test_analyzes_sessions_from_redis(self):
-        """_analyze_sessions_from_redis queries AgentSession model."""
+        """_analyze_sessions_from_redis queries AgentSession model.
+
+        A high tool-call-to-turn ratio must NOT produce any thrash finding:
+        the false-positive thrash detector was removed (see #1414), so the
+        analysis dict no longer carries a ``thrash_sessions`` key.
+        """
         from models.agent_session import AgentSession
         from reflections.session_intelligence import _analyze_sessions_from_redis
 
-        # Create a session for today
+        # Create a session for today with a high tool-call-to-turn ratio that
+        # the old detector would have flagged as "thrashing".
         AgentSession.create(
             session_id="test-session-1",
             project_key="ai",
@@ -95,13 +101,13 @@ class TestAnalyzeSessionsFromRedis:
             started_at=time.time(),
             updated_at=datetime.now(tz=UTC),
             turn_count=5,
-            tool_call_count=20,  # High ratio = thrashing
+            tool_call_count=20,
         )
 
         today = __import__("bridge.utc", fromlist=["utc_now"]).utc_now().strftime("%Y-%m-%d")
         result = _analyze_sessions_from_redis(today)
         assert result["sessions_analyzed"] == 1
-        assert len(result["thrash_sessions"]) == 1
+        assert "thrash_sessions" not in result
 
     def test_detects_failed_sessions(self):
         """Failed sessions appear in error_patterns."""

--- a/tests/unit/test_reflections_package.py
+++ b/tests/unit/test_reflections_package.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 # --- Shared helpers ---
 
 
@@ -87,23 +89,39 @@ class TestReflectionsUtils:
         entries = [{"pattern": "redis connection", "ignored_until": "", "reason": ""}]
         assert is_ignored("unrelated bug pattern", entries) is False
 
-    def test_is_high_confidence_true(self):
-        """is_high_confidence() returns True for code_bug with pattern and prevention."""
+    @pytest.mark.parametrize(
+        "reflection,expected",
+        [
+            # code_bug with both supporting signals -> True
+            (
+                {"category": "code_bug", "pattern": "x" * 20, "prevention": "fix it"},
+                True,
+            ),
+            # code_bug with prevention only (empty pattern) -> True (plan success criterion)
+            ({"category": "code_bug", "prevention": "x", "pattern": ""}, True),
+            # code_bug with long pattern only (no prevention) -> True
+            ({"category": "code_bug", "pattern": "x" * 10, "prevention": ""}, True),
+            # code_bug pattern exactly 9 chars and no prevention -> False (neither signal)
+            ({"category": "code_bug", "pattern": "x" * 9, "prevention": "   "}, False),
+            # poor_planning with both supporting signals -> False (the #1414 failing case)
+            (
+                {"category": "poor_planning", "prevention": "x", "pattern": "x" * 20},
+                False,
+            ),
+            # process_gap with rich text -> still False (non-code-bug excluded)
+            (
+                {"category": "process_gap", "prevention": "do better", "pattern": "x" * 50},
+                False,
+            ),
+            # missing category -> False
+            ({"prevention": "x", "pattern": "x" * 20}, False),
+        ],
+    )
+    def test_is_high_confidence_gate(self, reflection, expected):
+        """Gate requires category == 'code_bug' AND (prevention OR pattern>=10)."""
         from reflections.utils import is_high_confidence
 
-        r = {
-            "category": "code_bug",
-            "pattern": "this is a long enough pattern",
-            "prevention": "fix it",
-        }
-        assert is_high_confidence(r) is True
-
-    def test_is_high_confidence_false(self):
-        """is_high_confidence() returns False when fewer than 2 criteria met."""
-        from reflections.utils import is_high_confidence
-
-        r = {"category": "misunderstanding", "pattern": "short", "prevention": ""}
-        assert is_high_confidence(r) is False
+        assert is_high_confidence(reflection) is expected
 
     def test_load_ignore_entries_empty_redis(self):
         """load_ignore_entries() returns empty list when model unavailable."""


### PR DESCRIPTION
## Summary

Part 2 of the "stop the auto-filer flood" work (context: #1413, #1414 — both closed, referenced for context only, no closing keyword). Stops the reflections system from re-filing duplicate "thrashing" bug issues and from admitting non-code-bug reflections into the auto-fix path.

Plan: `docs/plans/sdlc-1414-thrash-detector-and-confidence-gate-fixes.md`

### Fix 2 — high-confidence gate (`reflections/utils.py`)
Replaced the 2-of-3 rule with:
```python
if reflection.get("category") != "code_bug":
    return False
return bool(reflection.get("prevention", "").strip()) or len(reflection.get("pattern", "")) >= 10
```
Under 2-of-3, a non-code-bug reflection (e.g. `poor_planning`) could clear the gate on prevention + pattern length alone — exactly how the #1414 agent-behaviour claim auto-filed itself as a "code bug". The gate now hard-requires `code_bug` AND at least one supporting signal.

### Fix 1 — thrash detector (`reflections/session_intelligence.py`) — **DELETED**
Removed the `1 - turn_count/tool_calls > 0.5` block and the `THRASH_RATIO_THRESHOLD` constant.

**Thrash-signal decision: deletion, not a replacement signal.** `turn_count` is *total* assistant turns (not *successful* turns), so any session averaging >2 tool calls/turn tripped the threshold — ~50% of healthy, completed SDLC runs. Neither candidate "real signal" is cheaply derivable from existing structure:
- The detector runs off `AgentSession` **scalar aggregates** (`turn_count`, `tool_call_count`) — no per-call sequencing, so no `(tool_name, args_hash)` for "repeated identical tool calls".
- The transcript format (`bridge/session_transcript.py`) records `TOOL_CALL: tool_name(input_summary)` and `TOOL_RESULT: <truncated text>` — inputs are summary strings (no structured args) and results carry **no `is_error` flag**. Detecting "tool errors" would require fragile free-text keyword matching, which is itself false-positive-prone and violates the repo's "intelligent systems over keyword matching" principle.

Reconstructing a real signal would mean re-parsing every transcript with brittle heuristics — beyond the plan's Small appetite and itself false-positive-prone. The plan explicitly endorses deletion: *"A deleted detector beats a 50%-false-positive one."*

## Test evidence
- `tests/unit/test_reflections_package.py` — replaced the two `is_high_confidence` tests with one parametrized test covering the new rule, including the **#1414 failing case** (`poor_planning` + prevention + 20-char pattern → `False`) and both plan success criteria (`code_bug` + empty pattern → `True`).
- `tests/integration/test_reflections_redis.py` — replaced the old thrash assertion; a high tool-call ratio now asserts `"thrash_sessions" not in result`.
- `docs/features/reflections.md` — updated the "Session Analysis" and "Confidence Criteria" sections (the plan predates the `## Documentation` requirement and had no such section).

```
$ .venv/bin/python -m pytest tests/unit/test_reflections*.py -n0 -q
134 passed in 4.32s

$ .venv/bin/python -m ruff check reflections/
All checks passed!
```

Plan success criteria verified inline:
```
is_high_confidence({"category":"poor_planning","prevention":"x","pattern":"x"*20}) -> False
is_high_confidence({"category":"code_bug","prevention":"x","pattern":""})          -> True
```

## Scope
Confined to `reflections/` + tests + docs. No update-system, agent-integration, or bridge changes. Does not reopen #1414.