### PR TITLE
Liveness recovery confirms subprocess death before requeue (#1537)

### DIFF
--- a/agent/session_health.py
+++ b/agent/session_health.py
@@ -12,6 +12,7 @@ See ``docs/features/pm-session-liveness.md`` for the full model.
 """
 
 import asyncio
+import functools
 import logging
 import os
 import re
@@ -21,6 +22,7 @@ import time
 from collections.abc import Iterable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import NamedTuple
 
 from agent.session_state import SessionHandle, _active_events, _active_sessions, _active_workers
 from analytics.collector import record_metric
@@ -955,9 +957,16 @@ def _increment_subprocess_kill_counter(session, *, escalated: bool) -> None:
     """Best-effort Redis counter for the recovery subprocess-kill escalation (#1537).
 
     ``escalated=True``  -> ``{project_key}:session-health:subprocess_kill_escalated``
-        (a kill was issued because ``task.cancel()`` left the subprocess alive).
+        (a kill signal — SIGTERM and/or SIGKILL — was actually delivered because
+        ``task.cancel()`` left the subprocess alive).
     ``escalated=False`` -> ``{project_key}:session-health:subprocess_kill_failed``
         (the subprocess could not be confirmed dead; session escalates to ``failed``).
+
+    The escalated counter intentionally does NOT fire on the *already-dead* path
+    (``task.cancel()`` sufficed and no signal was sent): counting that as an
+    escalation would inflate the metric and hide how often the SDK subprocess
+    genuinely ignores cancellation. See ``_confirm_subprocess_dead`` →
+    ``SubprocessKillResult.signal_sent``.
 
     A counter-backend failure must never propagate out of recovery.
     """
@@ -971,7 +980,26 @@ def _increment_subprocess_kill_counter(session, *, escalated: bool) -> None:
         logger.debug("[session-health] subprocess_kill counter failed (non-fatal): %s", e)
 
 
-def _confirm_subprocess_dead(pid: "int | None", *, timeout: float) -> bool:
+class SubprocessKillResult(NamedTuple):
+    """Outcome of ``_confirm_subprocess_dead`` (issue #1537).
+
+    ``confirmed_dead``
+        ``True`` when the PID is confirmed gone; ``False`` when it cannot be
+        confirmed dead (still alive after SIGKILL, ``PermissionError``, or any
+        unexpected error). Drives the caller's requeue-vs-``failed`` branch.
+    ``signal_sent``
+        ``True`` only when a kill signal (SIGTERM and/or SIGKILL) was actually
+        delivered — i.e. the subprocess survived ``task.cancel()`` and had to be
+        escalated. ``False`` on the *already-dead* path (cancel sufficed, no PID,
+        or the very first liveness probe reports the process gone), so the caller
+        does NOT over-count those as kill escalations.
+    """
+
+    confirmed_dead: bool
+    signal_sent: bool
+
+
+def _confirm_subprocess_dead(pid: "int | None", *, timeout: float) -> SubprocessKillResult:
     """Confirm a recovery target's ``claude -p`` subprocess is gone, escalating signals (#1537).
 
     ``task.cancel()`` does not guarantee the underlying SDK subprocess exited — a
@@ -979,11 +1007,24 @@ def _confirm_subprocess_dead(pid: "int | None", *, timeout: float) -> bool:
     gap: it verifies liveness, then escalates SIGTERM -> SIGKILL, polling for exit
     within a short ``timeout`` so the liveness loop is never stalled.
 
-    Returns ``True`` only when the PID is confirmed gone (``os.kill(pid, 0)`` raises
-    ``ProcessLookupError``); ``False`` when it cannot be confirmed dead (still alive
-    after SIGKILL, ``PermissionError``, or any unexpected error). A non-confirmed
-    result is the signal for the caller to escalate the session to ``failed`` so the
-    orphan reaper owns cleanup, rather than requeuing an invisible orphan to ``pending``.
+    Returns a :class:`SubprocessKillResult` ``(confirmed_dead, signal_sent)``:
+
+    * ``confirmed_dead=True`` only when the PID is confirmed gone
+      (``os.kill(pid, 0)`` raises ``ProcessLookupError``); ``False`` when it cannot
+      be confirmed dead (still alive after SIGKILL, ``PermissionError``, or any
+      unexpected error). A non-confirmed result is the signal for the caller to
+      escalate the session to ``failed`` so the orphan reaper owns cleanup, rather
+      than requeuing an invisible orphan to ``pending``.
+    * ``signal_sent=True`` only when SIGTERM and/or SIGKILL was actually delivered.
+      It stays ``False`` on the already-dead path (no PID, or the process was gone
+      at the first probe because ``task.cancel()`` terminated it) so the caller can
+      distinguish "cancel sufficed" from "we had to kill it" and avoid inflating the
+      escalated counter.
+
+    NOTE: this helper is synchronous and uses ``time.sleep`` while polling. It must
+    NOT be awaited directly on the worker event loop; ``_apply_recovery_transition``
+    offloads it via ``run_in_executor`` so the kill grace period (up to ``timeout``
+    seconds) never stalls other worker coroutines.
 
     PID-reuse caveat: a recorded ``claude_pid`` could in principle be recycled by an
     unrelated process before recovery runs. The window is the sub-second recovery
@@ -992,7 +1033,7 @@ def _confirm_subprocess_dead(pid: "int | None", *, timeout: float) -> bool:
     generations.
     """
     if pid is None or pid <= 0:
-        return True
+        return SubprocessKillResult(confirmed_dead=True, signal_sent=False)
 
     deadline = time.monotonic() + max(timeout, 0.0)
 
@@ -1009,15 +1050,15 @@ def _confirm_subprocess_dead(pid: "int | None", *, timeout: float) -> bool:
             return False
         return False
 
-    # Already gone (e.g. task.cancel() did terminate it)?
+    # Already gone (e.g. task.cancel() did terminate it)? No signal was sent.
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
-        return True
+        return SubprocessKillResult(confirmed_dead=True, signal_sent=False)
     except PermissionError:
-        return False
+        return SubprocessKillResult(confirmed_dead=False, signal_sent=False)
     except OSError:
-        return False
+        return SubprocessKillResult(confirmed_dead=False, signal_sent=False)
 
     def _poll_until_dead() -> bool:
         while time.monotonic() < deadline:
@@ -1026,28 +1067,30 @@ def _confirm_subprocess_dead(pid: "int | None", *, timeout: float) -> bool:
             time.sleep(_SUBPROCESS_KILL_POLL_INTERVAL)
         return _is_dead()
 
-    # Escalation step 1: SIGTERM, then poll for graceful exit.
+    # Escalation step 1: SIGTERM, then poll for graceful exit. From here on a
+    # signal has been delivered, so signal_sent is True regardless of the outcome.
     try:
         os.kill(pid, signal.SIGTERM)
     except ProcessLookupError:
-        return True
+        # Raced to exit between the probe and SIGTERM — no signal landed.
+        return SubprocessKillResult(confirmed_dead=True, signal_sent=False)
     except (PermissionError, OSError) as e:
         logger.debug("[session-health] SIGTERM failed for recovery pid=%s: %s", pid, e)
-        return _is_dead()
+        return SubprocessKillResult(confirmed_dead=_is_dead(), signal_sent=False)
 
     if _poll_until_dead():
-        return True
+        return SubprocessKillResult(confirmed_dead=True, signal_sent=True)
 
     # Escalation step 2: SIGKILL only when SIGTERM failed to terminate it.
     try:
         os.kill(pid, signal.SIGKILL)
     except ProcessLookupError:
-        return True
+        return SubprocessKillResult(confirmed_dead=True, signal_sent=True)
     except (PermissionError, OSError) as e:
         logger.debug("[session-health] SIGKILL failed for recovery pid=%s: %s", pid, e)
-        return _is_dead()
+        return SubprocessKillResult(confirmed_dead=_is_dead(), signal_sent=True)
 
-    return _poll_until_dead()
+    return SubprocessKillResult(confirmed_dead=_poll_until_dead(), signal_sent=True)
 
 
 async def _apply_recovery_transition(
@@ -1217,14 +1260,26 @@ async def _apply_recovery_transition(
     # ``running``. Escalate SIGTERM -> SIGKILL against the recorded ``claude_pid``
     # and capture whether the process is confirmed gone. The requeue ``else``
     # branch below uses this to avoid silently parking an orphan at ``pending``.
-    _subprocess_confirmed_dead = _confirm_subprocess_dead(
-        getattr(entry, "claude_pid", None),
-        timeout=SUBPROCESS_KILL_TIMEOUT,
+    # ``_confirm_subprocess_dead`` is synchronous and may ``time.sleep`` for up to
+    # ``SUBPROCESS_KILL_TIMEOUT`` while polling a signalled PID. Offload it to a
+    # thread so the genuine-hang path never stalls the worker event loop (and every
+    # other coroutine sharing it). The helper keeps its sync signature so its unit
+    # tests stay unchanged.
+    _kill_result = await asyncio.get_running_loop().run_in_executor(
+        None,
+        functools.partial(
+            _confirm_subprocess_dead,
+            getattr(entry, "claude_pid", None),
+            timeout=SUBPROCESS_KILL_TIMEOUT,
+        ),
     )
+    _subprocess_confirmed_dead = _kill_result.confirmed_dead
     if not _subprocess_confirmed_dead:
         _increment_subprocess_kill_counter(entry, escalated=False)
-    elif getattr(entry, "claude_pid", None):
-        # A PID was recorded and is now confirmed gone — the kill path ran.
+    elif _kill_result.signal_sent:
+        # The subprocess survived task.cancel() and a SIGTERM/SIGKILL was actually
+        # delivered to terminate it — a true escalation. The already-dead path
+        # (cancel sufficed, signal_sent=False) is deliberately NOT counted.
         _increment_subprocess_kill_counter(entry, escalated=True)
 
     from models.session_lifecycle import (

--- a/agent/session_health.py
+++ b/agent/session_health.py
@@ -943,6 +943,113 @@ def _tier2_reprieve_signal(
     return None
 
 
+# Total wall-clock budget for the SIGTERM->SIGKILL escalation in
+# ``_confirm_subprocess_dead``. Kept to single-digit seconds so the liveness
+# loop is never stalled by a slow kill (issue #1537 No-Go: short grace only).
+SUBPROCESS_KILL_TIMEOUT = 3.0
+# Poll interval while waiting for a signalled PID to exit.
+_SUBPROCESS_KILL_POLL_INTERVAL = 0.1
+
+
+def _increment_subprocess_kill_counter(session, *, escalated: bool) -> None:
+    """Best-effort Redis counter for the recovery subprocess-kill escalation (#1537).
+
+    ``escalated=True``  -> ``{project_key}:session-health:subprocess_kill_escalated``
+        (a kill was issued because ``task.cancel()`` left the subprocess alive).
+    ``escalated=False`` -> ``{project_key}:session-health:subprocess_kill_failed``
+        (the subprocess could not be confirmed dead; session escalates to ``failed``).
+
+    A counter-backend failure must never propagate out of recovery.
+    """
+    try:
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+        project_key = getattr(session, "project_key", None) or "unknown"
+        suffix = "subprocess_kill_escalated" if escalated else "subprocess_kill_failed"
+        _R.incr(f"{project_key}:session-health:{suffix}")
+    except Exception as e:
+        logger.debug("[session-health] subprocess_kill counter failed (non-fatal): %s", e)
+
+
+def _confirm_subprocess_dead(pid: "int | None", *, timeout: float) -> bool:
+    """Confirm a recovery target's ``claude -p`` subprocess is gone, escalating signals (#1537).
+
+    ``task.cancel()`` does not guarantee the underlying SDK subprocess exited — a
+    true hang ignores cancellation and orphans the PID. This helper closes that
+    gap: it verifies liveness, then escalates SIGTERM -> SIGKILL, polling for exit
+    within a short ``timeout`` so the liveness loop is never stalled.
+
+    Returns ``True`` only when the PID is confirmed gone (``os.kill(pid, 0)`` raises
+    ``ProcessLookupError``); ``False`` when it cannot be confirmed dead (still alive
+    after SIGKILL, ``PermissionError``, or any unexpected error). A non-confirmed
+    result is the signal for the caller to escalate the session to ``failed`` so the
+    orphan reaper owns cleanup, rather than requeuing an invisible orphan to ``pending``.
+
+    PID-reuse caveat: a recorded ``claude_pid`` could in principle be recycled by an
+    unrelated process before recovery runs. The window is the sub-second recovery
+    path and this matches the existing PPID==1 reaper's assumptions (issue #1537
+    Race Condition Analysis); we accept the residual risk rather than tracking PID
+    generations.
+    """
+    if pid is None or pid <= 0:
+        return True
+
+    deadline = time.monotonic() + max(timeout, 0.0)
+
+    def _is_dead() -> bool:
+        """``True`` iff signal 0 reports the PID is gone."""
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        except PermissionError:
+            # Process exists but is owned by another user — cannot confirm death.
+            return False
+        except OSError:
+            return False
+        return False
+
+    # Already gone (e.g. task.cancel() did terminate it)?
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        return False
+    except OSError:
+        return False
+
+    def _poll_until_dead() -> bool:
+        while time.monotonic() < deadline:
+            if _is_dead():
+                return True
+            time.sleep(_SUBPROCESS_KILL_POLL_INTERVAL)
+        return _is_dead()
+
+    # Escalation step 1: SIGTERM, then poll for graceful exit.
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return True
+    except (PermissionError, OSError) as e:
+        logger.debug("[session-health] SIGTERM failed for recovery pid=%s: %s", pid, e)
+        return _is_dead()
+
+    if _poll_until_dead():
+        return True
+
+    # Escalation step 2: SIGKILL only when SIGTERM failed to terminate it.
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return True
+    except (PermissionError, OSError) as e:
+        logger.debug("[session-health] SIGKILL failed for recovery pid=%s: %s", pid, e)
+        return _is_dead()
+
+    return _poll_until_dead()
+
+
 async def _apply_recovery_transition(
     entry: AgentSession,
     *,
@@ -1104,6 +1211,22 @@ async def _apply_recovery_transition(
             entry.agent_session_id,
         )
 
+    # Confirm the SDK subprocess actually exited (issue #1537). ``task.cancel()``
+    # does not guarantee a hung ``claude -p`` exited; if it ignored cancellation
+    # it becomes an orphan that no detector tracks once the session leaves
+    # ``running``. Escalate SIGTERM -> SIGKILL against the recorded ``claude_pid``
+    # and capture whether the process is confirmed gone. The requeue ``else``
+    # branch below uses this to avoid silently parking an orphan at ``pending``.
+    _subprocess_confirmed_dead = _confirm_subprocess_dead(
+        getattr(entry, "claude_pid", None),
+        timeout=SUBPROCESS_KILL_TIMEOUT,
+    )
+    if not _subprocess_confirmed_dead:
+        _increment_subprocess_kill_counter(entry, escalated=False)
+    elif getattr(entry, "claude_pid", None):
+        # A PID was recorded and is now confirmed gone — the kill path ran.
+        _increment_subprocess_kill_counter(entry, escalated=True)
+
     from models.session_lifecycle import (
         StatusConflictError,
         finalize_session,
@@ -1149,6 +1272,34 @@ async def _apply_recovery_transition(
                 "[session-health] Finalized session %s as failed after %s recovery attempts",
                 entry.agent_session_id,
                 entry.recovery_attempts,
+            )
+        elif not _subprocess_confirmed_dead:
+            # Issue #1537: the recorded subprocess survived cancel + SIGTERM +
+            # SIGKILL (or could not be confirmed dead). Requeuing to ``pending``
+            # would park a live orphan that no detector tracks — the exact defect
+            # that wedged the worker for 25.5h on 2026-05-31. Escalate to the
+            # ``failed`` terminal status so the in-process orphan reaper
+            # (_TERMINAL_STATUSES) owns cleanup. Do NOT null ``started_at`` into
+            # a pending record.
+            finalize_session(
+                entry,
+                "failed",
+                reason=(
+                    f"health check: subprocess {getattr(entry, 'claude_pid', None)} "
+                    f"survived cancel+SIGTERM+SIGKILL; escalating to failed so the "
+                    f"orphan reaper owns cleanup (chat={worker_key}, "
+                    f"attempt {entry.recovery_attempts}, kind={reason_kind})"
+                ),
+            )
+            logger.warning(
+                "[session-health] Escalated session %s to failed — subprocess "
+                "pid=%s not confirmed dead after cancel+SIGTERM+SIGKILL "
+                "(chat=%s, attempt %s, kind=%s)",
+                entry.agent_session_id,
+                getattr(entry, "claude_pid", None),
+                worker_key,
+                entry.recovery_attempts,
+                reason_kind,
             )
         else:
             entry.priority = "high"

--- a/docs/features/session-lifecycle.md
+++ b/docs/features/session-lifecycle.md
@@ -71,6 +71,20 @@ For non-terminal transitions. Logs the lifecycle transition and updates the stat
 
 See [Session Recovery Mechanisms](session-recovery-mechanisms.md) for the full audit of all recovery paths.
 
+### Recovery Confirms Subprocess Death (issue #1537)
+
+When the liveness check recovers a no-progress `running` session, `_apply_recovery_transition()` (`agent/session_health.py`) calls `handle.task.cancel()` with a `TASK_CANCEL_TIMEOUT` of 0.25s. Cancellation alone does **not** guarantee the underlying `claude -p` subprocess exited — a true hang ignores `CancelledError` and orphans the PID. Once the DB record leaves `running`, that orphan is invisible to every detector (the forward scan only queries `status="running"`; the in-process and PPID==1 reapers only act on terminal-status / launchd-reparented processes), so it wedges the worker's execution slot until a human runs `worker-restart`. This was the root cause of the 2026-05-31 incident (a 25.5h hang).
+
+Recovery now confirms subprocess termination before deciding how to transition:
+
+1. **`_confirm_subprocess_dead(pid, *, timeout)`** runs after the `task.cancel()` await. It probes liveness with `os.kill(pid, 0)`, then escalates **SIGTERM → SIGKILL** against the recorded `entry.claude_pid`, polling for exit within a short single-digit-second grace (`SUBPROCESS_KILL_TIMEOUT = 3.0`). SIGKILL is sent **only** when SIGTERM fails to terminate the PID. It returns `True` only when the PID is confirmed gone (`ProcessLookupError`); a `None`/non-positive PID short-circuits to `True` (nothing to kill); `PermissionError` or a PID that survives SIGKILL returns `False`.
+2. **The requeue `else` branch** (below `MAX_RECOVERY_ATTEMPTS`) branches on that boolean:
+   - **Confirmed dead** → the existing requeue-to-`pending` path runs (nulls `started_at`, bumps priority to `high`, `transition_status(..., "pending")`).
+   - **Not confirmed dead** → `finalize_session(entry, "failed", ...)` escalates the session to the `failed` terminal status so the in-process orphan reaper (which acts on `TERMINAL_STATUSES`) owns cleanup. `started_at` is **not** nulled into a `pending` record. This is the exact fix for #1537: a hung subprocess can never be silently parked at `pending` as an untracked orphan.
+3. **Observability:** best-effort Redis counters (failure never propagates out of recovery) — `{project_key}:session-health:subprocess_kill_escalated` when a recorded PID was confirmed dead via the kill path, and `:subprocess_kill_failed` when the subprocess could not be confirmed dead.
+
+**PID-reuse caveat:** a recorded `claude_pid` could in principle be recycled by an unrelated process before recovery runs. The window is the sub-second recovery path and this matches the existing PPID==1 reaper's assumptions; the residual risk is accepted rather than tracking PID generations.
+
 ## Kill-is-Terminal Invariant
 
 `valor-session kill` is a hard guarantee. Once a session is killed (or in any terminal state), no routine pipeline-progression code path may transition it to a different terminal status. This invariant is enforced symmetrically by both lifecycle entry points:

--- a/tests/unit/test_session_health_subprocess_kill.py
+++ b/tests/unit/test_session_health_subprocess_kill.py
@@ -26,31 +26,44 @@ from agent import session_health
 
 
 class TestConfirmSubprocessDead:
-    """Direct tests of the SIGTERM->SIGKILL escalation helper."""
+    """Direct tests of the SIGTERM->SIGKILL escalation helper.
 
-    def test_none_pid_returns_true(self):
-        """No PID recorded → nothing to kill → confirmed dead."""
+    The helper returns a :class:`session_health.SubprocessKillResult`
+    ``(confirmed_dead, signal_sent)``. ``signal_sent`` distinguishes the
+    already-dead path (cancel sufficed, no signal) from a genuine SIGTERM/SIGKILL
+    escalation so the caller does not over-count the escalated counter.
+    """
+
+    def test_none_pid_returns_confirmed_no_signal(self):
+        """No PID recorded → nothing to kill → confirmed dead, no signal sent."""
         with patch.object(session_health.os, "kill") as mock_kill:
-            assert session_health._confirm_subprocess_dead(None, timeout=3.0) is True
+            result = session_health._confirm_subprocess_dead(None, timeout=3.0)
+        assert result == session_health.SubprocessKillResult(confirmed_dead=True, signal_sent=False)
         mock_kill.assert_not_called()
 
-    def test_nonpositive_pid_returns_true(self):
+    def test_nonpositive_pid_returns_confirmed_no_signal(self):
         """pid <= 0 is not a real process → confirmed dead, no signals."""
         with patch.object(session_health.os, "kill") as mock_kill:
-            assert session_health._confirm_subprocess_dead(0, timeout=3.0) is True
-            assert session_health._confirm_subprocess_dead(-1, timeout=3.0) is True
+            assert session_health._confirm_subprocess_dead(0, timeout=3.0) == (True, False)
+            assert session_health._confirm_subprocess_dead(-1, timeout=3.0) == (True, False)
         mock_kill.assert_not_called()
 
-    def test_already_dead_returns_true_without_signals(self):
-        """First liveness probe (signal 0) raises ProcessLookupError → already gone."""
+    def test_already_dead_returns_confirmed_without_signals(self):
+        """First liveness probe (signal 0) raises ProcessLookupError → already gone.
+
+        cancel() sufficed: confirmed_dead=True but signal_sent=False, so the caller
+        must NOT count this as a kill escalation.
+        """
         with patch.object(session_health.os, "kill", side_effect=ProcessLookupError) as mock_kill:
-            assert session_health._confirm_subprocess_dead(1234, timeout=3.0) is True
+            result = session_health._confirm_subprocess_dead(1234, timeout=3.0)
+        assert result.confirmed_dead is True
+        assert result.signal_sent is False
         # Only the initial signal-0 probe; no SIGTERM/SIGKILL.
         assert mock_kill.call_count == 1
         assert mock_kill.call_args_list[0].args == (1234, 0)
 
-    def test_sigterm_suffices_no_sigkill(self):
-        """PID alive at probe, dies after SIGTERM → SIGKILL is never sent."""
+    def test_sigterm_suffices_reports_signal_sent(self):
+        """PID alive at probe, dies after SIGTERM → SIGKILL never sent, signal_sent True."""
         # Sequence of os.kill behaviors:
         #   probe(0) -> alive (returns)
         #   SIGTERM  -> returns (signal delivered)
@@ -67,13 +80,14 @@ class TestConfirmSubprocessDead:
             raise ProcessLookupError
 
         with patch.object(session_health.os, "kill", side_effect=fake_kill):
-            assert session_health._confirm_subprocess_dead(1234, timeout=3.0) is True
+            result = session_health._confirm_subprocess_dead(1234, timeout=3.0)
 
+        assert result == session_health.SubprocessKillResult(confirmed_dead=True, signal_sent=True)
         assert session_health.signal.SIGTERM in calls
         assert session_health.signal.SIGKILL not in calls
 
     def test_sigkill_sent_only_when_sigterm_insufficient(self):
-        """PID survives SIGTERM grace → SIGKILL is escalated, then dies."""
+        """PID survives SIGTERM grace → SIGKILL is escalated, then dies; signal_sent True."""
         sent_signals = []
 
         def fake_kill(pid, sig):
@@ -99,13 +113,14 @@ class TestConfirmSubprocessDead:
                 side_effect=[0.0, 0.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0],
             ),
         ):
-            assert session_health._confirm_subprocess_dead(1234, timeout=3.0) is True
+            result = session_health._confirm_subprocess_dead(1234, timeout=3.0)
 
+        assert result == session_health.SubprocessKillResult(confirmed_dead=True, signal_sent=True)
         assert session_health.signal.SIGTERM in sent_signals
         assert session_health.signal.SIGKILL in sent_signals
 
-    def test_survives_sigterm_and_sigkill_returns_false(self):
-        """PID stays alive through SIGTERM and SIGKILL → cannot confirm dead."""
+    def test_survives_sigterm_and_sigkill_reports_not_confirmed_signal_sent(self):
+        """PID stays alive through SIGTERM and SIGKILL → not confirmed, but signal_sent True."""
 
         def fake_kill(pid, sig):
             # Process never dies: signal 0 always returns (alive), signals deliver.
@@ -120,15 +135,21 @@ class TestConfirmSubprocessDead:
                 side_effect=[0.0] + [100.0] * 20,  # deadline immediately in the past after start
             ),
         ):
-            assert session_health._confirm_subprocess_dead(1234, timeout=3.0) is False
+            result = session_health._confirm_subprocess_dead(1234, timeout=3.0)
 
-    def test_permission_error_on_probe_returns_false(self):
-        """PermissionError on the initial liveness probe → not confirmed dead."""
+        # A real SIGTERM/SIGKILL was delivered even though it didn't take.
+        assert result == session_health.SubprocessKillResult(confirmed_dead=False, signal_sent=True)
+
+    def test_permission_error_on_probe_returns_not_confirmed_no_signal(self):
+        """PermissionError on the initial liveness probe → not confirmed, no signal."""
         with patch.object(session_health.os, "kill", side_effect=PermissionError):
-            assert session_health._confirm_subprocess_dead(1234, timeout=3.0) is False
+            result = session_health._confirm_subprocess_dead(1234, timeout=3.0)
+        assert result == session_health.SubprocessKillResult(
+            confirmed_dead=False, signal_sent=False
+        )
 
-    def test_permission_error_on_sigterm_returns_false(self):
-        """Probe says alive, SIGTERM raises PermissionError → not confirmed dead."""
+    def test_permission_error_on_sigterm_returns_not_confirmed_no_signal(self):
+        """Probe says alive, SIGTERM raises PermissionError → not confirmed, no signal landed."""
 
         def fake_kill(pid, sig):
             if sig == 0:
@@ -136,7 +157,11 @@ class TestConfirmSubprocessDead:
             raise PermissionError
 
         with patch.object(session_health.os, "kill", side_effect=fake_kill):
-            assert session_health._confirm_subprocess_dead(1234, timeout=3.0) is False
+            result = session_health._confirm_subprocess_dead(1234, timeout=3.0)
+        # SIGTERM was rejected, so no signal actually landed.
+        assert result == session_health.SubprocessKillResult(
+            confirmed_dead=False, signal_sent=False
+        )
 
 
 # ==========================================================================
@@ -232,7 +257,8 @@ class TestRecoveryBranching:
     def test_subprocess_survives_escalates_to_failed(self, recovery_patches):
         """Subprocess not confirmed dead → finalize_session('failed'), no requeue."""
         entry = _make_entry()
-        with patch.object(session_health, "_confirm_subprocess_dead", return_value=False):
+        survived = session_health.SubprocessKillResult(confirmed_dead=False, signal_sent=True)
+        with patch.object(session_health, "_confirm_subprocess_dead", return_value=survived):
             assert _run_recovery(entry) is True
 
         # Finalized to failed; never requeued to pending.
@@ -243,9 +269,10 @@ class TestRecoveryBranching:
         assert entry.started_at is not None
 
     def test_subprocess_confirmed_dead_requeues_to_pending(self, recovery_patches):
-        """Subprocess confirmed dead → existing requeue-to-pending path runs."""
+        """Subprocess confirmed dead via SIGTERM/SIGKILL → existing requeue path runs."""
         entry = _make_entry()
-        with patch.object(session_health, "_confirm_subprocess_dead", return_value=True):
+        killed = session_health.SubprocessKillResult(confirmed_dead=True, signal_sent=True)
+        with patch.object(session_health, "_confirm_subprocess_dead", return_value=killed):
             assert _run_recovery(entry) is True
 
         recovery_patches["transition"].assert_called_once()
@@ -267,22 +294,39 @@ class TestRecoveryBranching:
         recovery_patches["transition"].assert_called_once()
         assert recovery_patches["transition"].call_args.args[1] == "pending"
 
-    def test_escalated_counter_increments_on_confirmed_dead_with_pid(self, recovery_patches):
-        """Confirmed-dead WITH a recorded PID → escalated counter increments."""
+    def test_escalated_counter_increments_when_signal_was_sent(self, recovery_patches):
+        """Confirmed-dead because a SIGTERM/SIGKILL landed → escalated counter increments."""
         entry = _make_entry(claude_pid=4321)
+        killed = session_health.SubprocessKillResult(confirmed_dead=True, signal_sent=True)
         with (
-            patch.object(session_health, "_confirm_subprocess_dead", return_value=True),
+            patch.object(session_health, "_confirm_subprocess_dead", return_value=killed),
             patch.object(session_health, "_increment_subprocess_kill_counter") as mock_counter,
         ):
             _run_recovery(entry)
         mock_counter.assert_called_once()
         assert mock_counter.call_args.kwargs["escalated"] is True
 
+    def test_escalated_counter_skipped_when_cancel_sufficed(self, recovery_patches):
+        """Confirmed-dead WITHOUT a signal (task.cancel sufficed) → no counter increment.
+
+        This is the over-counting fix: an already-dead subprocess must NOT inflate
+        the ``subprocess_kill_escalated`` metric.
+        """
+        entry = _make_entry(claude_pid=4321)
+        already_dead = session_health.SubprocessKillResult(confirmed_dead=True, signal_sent=False)
+        with (
+            patch.object(session_health, "_confirm_subprocess_dead", return_value=already_dead),
+            patch.object(session_health, "_increment_subprocess_kill_counter") as mock_counter,
+        ):
+            _run_recovery(entry)
+        mock_counter.assert_not_called()
+
     def test_failed_counter_increments_on_survival(self, recovery_patches):
         """Not-confirmed-dead → failed counter increments."""
         entry = _make_entry()
+        survived = session_health.SubprocessKillResult(confirmed_dead=False, signal_sent=True)
         with (
-            patch.object(session_health, "_confirm_subprocess_dead", return_value=False),
+            patch.object(session_health, "_confirm_subprocess_dead", return_value=survived),
             patch.object(session_health, "_increment_subprocess_kill_counter") as mock_counter,
         ):
             _run_recovery(entry)

--- a/tests/unit/test_session_health_subprocess_kill.py
+++ b/tests/unit/test_session_health_subprocess_kill.py
@@ -1,0 +1,290 @@
+"""Unit tests for the recovery subprocess-kill escalation (issue #1537).
+
+When the liveness check recovers a no-progress ``running`` session, it must
+confirm the underlying ``claude -p`` subprocess actually exited before requeuing
+the DB record to ``pending``. If the subprocess ignores ``task.cancel()`` (a true
+hang), the recovery path escalates SIGTERM -> SIGKILL against the recorded
+``claude_pid``; a subprocess that cannot be confirmed dead escalates the session
+to ``failed`` (terminal) so the orphan reaper owns cleanup, rather than parking an
+invisible orphan at ``pending`` that wedges the worker slot.
+
+Covers ``_confirm_subprocess_dead`` (the signal-escalation helper) and the
+``_apply_recovery_transition`` requeue/finalize branching.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent import session_health
+
+# ==========================================================================
+# _confirm_subprocess_dead — signal escalation helper
+# ==========================================================================
+
+
+class TestConfirmSubprocessDead:
+    """Direct tests of the SIGTERM->SIGKILL escalation helper."""
+
+    def test_none_pid_returns_true(self):
+        """No PID recorded → nothing to kill → confirmed dead."""
+        with patch.object(session_health.os, "kill") as mock_kill:
+            assert session_health._confirm_subprocess_dead(None, timeout=3.0) is True
+        mock_kill.assert_not_called()
+
+    def test_nonpositive_pid_returns_true(self):
+        """pid <= 0 is not a real process → confirmed dead, no signals."""
+        with patch.object(session_health.os, "kill") as mock_kill:
+            assert session_health._confirm_subprocess_dead(0, timeout=3.0) is True
+            assert session_health._confirm_subprocess_dead(-1, timeout=3.0) is True
+        mock_kill.assert_not_called()
+
+    def test_already_dead_returns_true_without_signals(self):
+        """First liveness probe (signal 0) raises ProcessLookupError → already gone."""
+        with patch.object(session_health.os, "kill", side_effect=ProcessLookupError) as mock_kill:
+            assert session_health._confirm_subprocess_dead(1234, timeout=3.0) is True
+        # Only the initial signal-0 probe; no SIGTERM/SIGKILL.
+        assert mock_kill.call_count == 1
+        assert mock_kill.call_args_list[0].args == (1234, 0)
+
+    def test_sigterm_suffices_no_sigkill(self):
+        """PID alive at probe, dies after SIGTERM → SIGKILL is never sent."""
+        # Sequence of os.kill behaviors:
+        #   probe(0) -> alive (returns)
+        #   SIGTERM  -> returns (signal delivered)
+        #   poll probe(0) -> ProcessLookupError (now dead)
+        calls = []
+
+        def fake_kill(pid, sig):
+            calls.append(sig)
+            if sig == 0 and len(calls) == 1:
+                return  # initial probe: alive
+            if sig == session_health.signal.SIGTERM:
+                return  # SIGTERM delivered
+            # Any subsequent signal-0 poll: process has exited.
+            raise ProcessLookupError
+
+        with patch.object(session_health.os, "kill", side_effect=fake_kill):
+            assert session_health._confirm_subprocess_dead(1234, timeout=3.0) is True
+
+        assert session_health.signal.SIGTERM in calls
+        assert session_health.signal.SIGKILL not in calls
+
+    def test_sigkill_sent_only_when_sigterm_insufficient(self):
+        """PID survives SIGTERM grace → SIGKILL is escalated, then dies."""
+        sent_signals = []
+
+        def fake_kill(pid, sig):
+            sent_signals.append(sig)
+            if sig == session_health.signal.SIGKILL:
+                return  # SIGKILL delivered; subsequent probe will report dead
+            if sig in (0, session_health.signal.SIGTERM):
+                # Initial probe + SIGTERM + all SIGTERM-grace polls: still alive,
+                # until SIGKILL has been issued.
+                if session_health.signal.SIGKILL in sent_signals and sig == 0:
+                    raise ProcessLookupError
+                return
+            raise ProcessLookupError
+
+        # Force the SIGTERM grace poll to expire immediately so the test does not
+        # actually sleep for SUBPROCESS_KILL_TIMEOUT seconds.
+        with (
+            patch.object(session_health.os, "kill", side_effect=fake_kill),
+            patch.object(session_health.time, "sleep"),
+            patch.object(
+                session_health.time,
+                "monotonic",
+                side_effect=[0.0, 0.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0],
+            ),
+        ):
+            assert session_health._confirm_subprocess_dead(1234, timeout=3.0) is True
+
+        assert session_health.signal.SIGTERM in sent_signals
+        assert session_health.signal.SIGKILL in sent_signals
+
+    def test_survives_sigterm_and_sigkill_returns_false(self):
+        """PID stays alive through SIGTERM and SIGKILL → cannot confirm dead."""
+
+        def fake_kill(pid, sig):
+            # Process never dies: signal 0 always returns (alive), signals deliver.
+            return
+
+        with (
+            patch.object(session_health.os, "kill", side_effect=fake_kill),
+            patch.object(session_health.time, "sleep"),
+            patch.object(
+                session_health.time,
+                "monotonic",
+                side_effect=[0.0] + [100.0] * 20,  # deadline immediately in the past after start
+            ),
+        ):
+            assert session_health._confirm_subprocess_dead(1234, timeout=3.0) is False
+
+    def test_permission_error_on_probe_returns_false(self):
+        """PermissionError on the initial liveness probe → not confirmed dead."""
+        with patch.object(session_health.os, "kill", side_effect=PermissionError):
+            assert session_health._confirm_subprocess_dead(1234, timeout=3.0) is False
+
+    def test_permission_error_on_sigterm_returns_false(self):
+        """Probe says alive, SIGTERM raises PermissionError → not confirmed dead."""
+
+        def fake_kill(pid, sig):
+            if sig == 0:
+                return  # alive
+            raise PermissionError
+
+        with patch.object(session_health.os, "kill", side_effect=fake_kill):
+            assert session_health._confirm_subprocess_dead(1234, timeout=3.0) is False
+
+
+# ==========================================================================
+# _increment_subprocess_kill_counter — best-effort Redis counters
+# ==========================================================================
+
+
+class TestSubprocessKillCounter:
+    """The counters are best-effort and never propagate a backend failure."""
+
+    def _session(self):
+        return SimpleNamespace(project_key="test-proj")
+
+    def test_escalated_increments_escalated_key(self):
+        with patch("popoto.redis_db.POPOTO_REDIS_DB") as mock_redis:
+            session_health._increment_subprocess_kill_counter(self._session(), escalated=True)
+        mock_redis.incr.assert_called_once_with(
+            "test-proj:session-health:subprocess_kill_escalated"
+        )
+
+    def test_failed_increments_failed_key(self):
+        with patch("popoto.redis_db.POPOTO_REDIS_DB") as mock_redis:
+            session_health._increment_subprocess_kill_counter(self._session(), escalated=False)
+        mock_redis.incr.assert_called_once_with("test-proj:session-health:subprocess_kill_failed")
+
+    def test_counter_backend_failure_never_propagates(self):
+        with patch("popoto.redis_db.POPOTO_REDIS_DB") as mock_redis:
+            mock_redis.incr.side_effect = RuntimeError("redis down")
+            # Must not raise.
+            session_health._increment_subprocess_kill_counter(self._session(), escalated=False)
+
+
+# ==========================================================================
+# _apply_recovery_transition — requeue vs failed branching
+# ==========================================================================
+
+
+def _make_entry(*, claude_pid=4321, recovery_attempts=0):
+    """Minimal AgentSession-like stub for the recovery else branch.
+
+    ``recovery_attempts=0`` keeps us below MAX_RECOVERY_ATTEMPTS so the
+    ``else`` requeue/failed branch (not the attempts-exhausted branch) is taken.
+    """
+    return SimpleNamespace(
+        agent_session_id="sess-1537",
+        session_id="sid-1537",
+        project_key="test-proj",
+        chat_id="chat-1",
+        claude_pid=claude_pid,
+        recovery_attempts=recovery_attempts,
+        reprieve_count=0,
+        priority="normal",
+        started_at="2026-06-03T00:00:00Z",
+        response_delivered_at=None,
+        exit_returncode=0,
+        is_project_keyed=False,
+        save=lambda **kw: None,
+    )
+
+
+@pytest.fixture
+def recovery_patches():
+    """Patch the lifecycle helpers and worker-ensure side effects.
+
+    Yields a dict of the mocks for assertions. ``_tier2_reprieve_signal`` returns
+    ``None`` so the recovery is not reprieved; ``_ensure_worker`` is a no-op.
+    """
+    with (
+        patch("models.session_lifecycle.finalize_session") as mock_finalize,
+        patch("models.session_lifecycle.transition_status") as mock_transition,
+        patch.object(session_health, "_tier2_reprieve_signal", return_value=None),
+        patch("agent.agent_session_queue._ensure_worker"),
+        patch("popoto.redis_db.POPOTO_REDIS_DB"),
+    ):
+        yield {"finalize": mock_finalize, "transition": mock_transition}
+
+
+def _run_recovery(entry):
+    return asyncio.run(
+        session_health._apply_recovery_transition(
+            entry,
+            reason="no progress",
+            reason_kind="no_progress",
+            handle=None,
+            worker_key="worker-1",
+        )
+    )
+
+
+class TestRecoveryBranching:
+    """The requeue ``else`` branch finalizes to failed when the subprocess survives."""
+
+    def test_subprocess_survives_escalates_to_failed(self, recovery_patches):
+        """Subprocess not confirmed dead → finalize_session('failed'), no requeue."""
+        entry = _make_entry()
+        with patch.object(session_health, "_confirm_subprocess_dead", return_value=False):
+            assert _run_recovery(entry) is True
+
+        # Finalized to failed; never requeued to pending.
+        recovery_patches["finalize"].assert_called_once()
+        assert recovery_patches["finalize"].call_args.args[1] == "failed"
+        recovery_patches["transition"].assert_not_called()
+        # started_at must NOT be nulled into a pending record.
+        assert entry.started_at is not None
+
+    def test_subprocess_confirmed_dead_requeues_to_pending(self, recovery_patches):
+        """Subprocess confirmed dead → existing requeue-to-pending path runs."""
+        entry = _make_entry()
+        with patch.object(session_health, "_confirm_subprocess_dead", return_value=True):
+            assert _run_recovery(entry) is True
+
+        recovery_patches["transition"].assert_called_once()
+        assert recovery_patches["transition"].call_args.args[1] == "pending"
+        # Healthy recovery path nulls started_at and bumps priority.
+        assert entry.started_at is None
+        assert entry.priority == "high"
+        # Not finalized as failed.
+        for call in recovery_patches["finalize"].call_args_list:
+            assert call.args[1] != "failed"
+
+    def test_no_pid_recorded_requeues_normally(self, recovery_patches):
+        """entry.claude_pid is None → _confirm_subprocess_dead True → requeue."""
+        entry = _make_entry(claude_pid=None)
+        # Do not mock _confirm_subprocess_dead: exercise the real None short-circuit.
+        with patch.object(session_health.os, "kill") as mock_kill:
+            assert _run_recovery(entry) is True
+        mock_kill.assert_not_called()
+        recovery_patches["transition"].assert_called_once()
+        assert recovery_patches["transition"].call_args.args[1] == "pending"
+
+    def test_escalated_counter_increments_on_confirmed_dead_with_pid(self, recovery_patches):
+        """Confirmed-dead WITH a recorded PID → escalated counter increments."""
+        entry = _make_entry(claude_pid=4321)
+        with (
+            patch.object(session_health, "_confirm_subprocess_dead", return_value=True),
+            patch.object(session_health, "_increment_subprocess_kill_counter") as mock_counter,
+        ):
+            _run_recovery(entry)
+        mock_counter.assert_called_once()
+        assert mock_counter.call_args.kwargs["escalated"] is True
+
+    def test_failed_counter_increments_on_survival(self, recovery_patches):
+        """Not-confirmed-dead → failed counter increments."""
+        entry = _make_entry()
+        with (
+            patch.object(session_health, "_confirm_subprocess_dead", return_value=False),
+            patch.object(session_health, "_increment_subprocess_kill_counter") as mock_counter,
+        ):
+            _run_recovery(entry)
+        mock_counter.assert_called_once()
+        assert mock_counter.call_args.kwargs["escalated"] is False


### PR DESCRIPTION
Closes #1537

## Problem

When the liveness check recovers a no-progress `running` session, `_apply_recovery_transition` calls `task.cancel()` (0.25s `TASK_CANCEL_TIMEOUT`) and requeues the DB record to `pending` — but **never confirms the underlying `claude -p` subprocess exited**. A true hang ignores cancellation and orphans the PID. Once the record leaves `running` it is invisible to every detector (forward scan queries only `status="running"`; in-process + PPID==1 reapers don't cover a live-parent `pending` orphan), so it wedges the worker slot until a human runs `worker-restart`. This was the root cause of the 2026-05-31 incident (25.5h hang).

## Change (confined to `agent/session_health.py`)

- **`_confirm_subprocess_dead(pid, *, timeout)`** — new module-level helper. Probes liveness with `os.kill(pid, 0)`, then escalates **SIGTERM → SIGKILL** against the recorded `entry.claude_pid`, polling for exit within a short grace (`SUBPROCESS_KILL_TIMEOUT = 3.0`). SIGKILL is sent **only** when SIGTERM fails. Returns `True` only when the PID is confirmed gone (`ProcessLookupError`); `None`/non-positive PID short-circuits to `True`; `PermissionError` or survival → `False`.
- **Wired into the cancel path** after the `task.cancel()` await; the boolean is captured.
- **Requeue `else` branch** branches on it: confirmed dead → existing requeue-to-`pending`; **not confirmed dead → `finalize_session(entry, "failed", ...)`** so the in-process orphan reaper (acts on `TERMINAL_STATUSES`) owns cleanup. `started_at` is never nulled into a `pending` orphan.
- **Best-effort Redis counters** `…:subprocess_kill_escalated` / `…:subprocess_kill_failed`, mirroring `_increment_orphan_process_counter`; a counter-backend failure never propagates out of recovery.

No `AgentSession` schema change. No bridge/worker/nudge change.

## Test evidence

New: `tests/unit/test_session_health_subprocess_kill.py` — **16 passed** (`-n0`). Covers every Failure Path scenario:
- helper: none/non-positive PID, already-dead, SIGTERM-suffices (no SIGKILL), SIGKILL-only-when-needed, survives-both → `False`, `PermissionError` on probe and on SIGTERM
- branching: survives → `finalize('failed')` + no requeue + `started_at` preserved; confirmed-dead → requeue-to-`pending`; no PID → normal requeue (real `os.kill` never called); escalated/failed counter increments
- counters: correct keys + backend failure never propagates

```
tests/unit/test_session_health_subprocess_kill.py .... 16 passed
ruff check agent/session_health.py … All checks passed!
```

## Docs

`docs/features/session-lifecycle.md` — new subsection "Recovery Confirms Subprocess Death (issue #1537)".

## Out-of-scope note

6 pre-existing source-grep tests in `test_health_check_recovery_finalization.py` / `test_harness_oom_backoff.py` fail identically on clean `main` (HEAD `2cfc4d0`) because they grep `_agent_session_health_check` for logic that already lives in `_apply_recovery_transition`. Not introduced by this PR; left untouched to stay within the plan's named files. Also note `config/reflections.yaml` is gitignored and absent in worktrees, causing one unrelated `FileNotFoundError` in `test_session_health_sibling_phantom_safety.py`.
