### PR TITLE
fix(reflections): stop daily-digest burst-fire from index-rebuild race

### DIFF
--- a/agent/reflection_scheduler.py
+++ b/agent/reflection_scheduler.py
@@ -288,6 +288,33 @@ def _resolve_callable(dotted_path: str) -> Any:
     return getattr(module, func_name)
 
 
+def _latest_run_timestamp(name: str) -> float | None:
+    """Return the most recent ``ReflectionRun`` timestamp for a reflection name.
+
+    History-based fallback for ``is_reflection_due`` (burst-fire hotfix). When a
+    Reflection record's ``ran_at`` has been lost — e.g. a fresh duplicate record
+    spawned by ``get_or_create`` during a Redis index-rebuild window, where the
+    name index is transiently empty — the record looks "never run" and an
+    ``every:`` schedule would fire on every tick. ``ReflectionRun`` rows are NOT
+    in ``models.__all__`` and so are never destructively rebuilt, making their
+    timestamps a reliable record of when the job actually last ran.
+
+    Returns None if no history rows exist or on any error (fail-open to the
+    existing ``ran_at``-based behavior).
+    """
+    try:
+        from models.reflection_run import ReflectionRun
+
+        timestamps = [
+            r.timestamp
+            for r in ReflectionRun.query.filter(name=name)
+            if isinstance(r.timestamp, (int, float)) and r.timestamp > 0
+        ]
+        return max(timestamps) if timestamps else None
+    except Exception:
+        return None
+
+
 def is_reflection_due(entry: ReflectionEntry, state: Reflection, now: float) -> bool:
     """Check if a reflection is due to run.
 
@@ -308,6 +335,14 @@ def is_reflection_due(entry: ReflectionEntry, state: Reflection, now: float) -> 
     ran_at = state.ran_at if isinstance(state.ran_at, (int, float)) else None
 
     if entry.schedule:
+        # Burst-fire guard: a blank ``every:`` record (ran_at lost during an
+        # index-rebuild race) would be treated as "never run" and fire on every
+        # tick. Recover the true last-run from ReflectionRun history so the job
+        # stays suppressed until its real interval elapses. Scoped to ``every:``
+        # because ``cron:`` anchors on ``now`` (never immediately-due on a blank
+        # record) and ``at:`` is a one-shot.
+        if ran_at is None and entry.schedule.partition(":")[0].strip().lower() == "every":
+            ran_at = _latest_run_timestamp(entry.name)
         try:
             next_due = compute_next_due(entry.schedule, last_run=ran_at, now=now)
         except ValueError as e:

--- a/docs/features/popoto-index-hygiene.md
+++ b/docs/features/popoto-index-hygiene.md
@@ -50,6 +50,8 @@ Each model is processed independently -- one model failure does not abort the sw
 
 `rebuild_indexes()` uses Redis SCAN (cursor-based, non-blocking) and only adds/removes index entries to match actual hash existence. Concurrent creates and deletes are safe and self-correcting -- any inconsistency introduced by a concurrent operation is fixed on the next run.
 
+**Exception -- live `get_or_create`-per-tick models.** `rebuild_indexes()` *deletes* a model's class-set and KeyField index sets before reconstructing them. During that window, `Model.query.filter(key=...)` returns empty even though the backing hash still exists. A model whose hot path is `get_or_create(name=...)` on a tight loop will therefore spawn a **fresh duplicate record** (e.g. `Reflection.ran_at=None`) if a tick lands inside the window. For `every:`-scheduled reflections a blank record reads as "never run" and fires every tick -- the daily-digest burst-fire bug. Such models are listed in `_SCHEDULER_STATE_MODELS` and skipped by `_get_all_models()`; they are small and continuously indexed by their own `save()` hooks, so a periodic destructive rebuild buys nothing. `is_reflection_due()` adds a second, trigger-agnostic guard: when `ran_at` is lost it recovers the true last-run from `ReflectionRun` history (never rebuilt -- not in `models.__all__`) so a blank record cannot re-fire.
+
 ## Key Files
 
 | File | Purpose |

--- a/scripts/popoto_index_cleanup.py
+++ b/scripts/popoto_index_cleanup.py
@@ -19,6 +19,17 @@ logger = logging.getLogger(__name__)
 
 _REBUILD_TIMEOUT_SECONDS = 30
 
+# Live scheduler-state models excluded from the destructive rebuild_indexes()
+# sweep. rebuild_indexes() deletes a model's class-set + KeyField indexes before
+# reconstructing them; during that window Reflection.query.filter(name=...)
+# returns empty, so a concurrent scheduler tick's get_or_create() spawns a fresh
+# duplicate record with ran_at=None — which an every:-scheduled job reads as
+# "never run" and fires on every tick (the daily-digest burst-fire bug). These
+# small, continuously-save()-indexed models gain nothing from a periodic
+# destructive rebuild; their orphans are negligible. (ReflectionRun is already
+# excluded — it is not in models.__all__.)
+_SCHEDULER_STATE_MODELS = frozenset({"Reflection"})
+
 
 def _has_embedding_field(model_class) -> bool:
     """Return True if a model has any EmbeddingField.
@@ -39,7 +50,9 @@ def _get_all_models() -> list:
     """Import and return all Popoto models from models/__init__.__all__.
 
     Excludes models with EmbeddingField — those require live Ollama calls
-    during rebuild_indexes() and are handled separately.
+    during rebuild_indexes() and are handled separately — and live
+    scheduler-state models (``_SCHEDULER_STATE_MODELS``) whose indexes must not
+    be destructively dropped while the scheduler is ticking.
     """
     try:
         import models as models_pkg
@@ -48,6 +61,12 @@ def _get_all_models() -> list:
         for name in models_pkg.__all__:
             obj = getattr(models_pkg, name, None)
             if obj is not None and hasattr(obj, "rebuild_indexes"):
+                if name in _SCHEDULER_STATE_MODELS:
+                    logger.debug(
+                        f"[popoto-cleanup] Skipping {name} "
+                        "(live scheduler-state — rebuild races get_or_create)"
+                    )
+                    continue
                 if _has_embedding_field(obj):
                     logger.debug(
                         f"[popoto-cleanup] Skipping {name} (has EmbeddingField — requires Ollama)"

--- a/tests/unit/test_reflection_scheduler.py
+++ b/tests/unit/test_reflection_scheduler.py
@@ -313,6 +313,46 @@ class TestScheduleEvaluation:
         state.ran_at = now - 300
         assert is_reflection_due(entry, state, now) is True
 
+    def test_blank_record_with_recent_history_not_due(self, monkeypatch):
+        """Burst-fire guard: a blank every: record (ran_at lost during an
+        index-rebuild race) must NOT re-fire when ReflectionRun history shows a
+        recent run. Regression for the daily-digest burst-fire bug."""
+        import agent.reflection_scheduler as sched
+
+        now = time.time()
+        entry = ReflectionEntry(
+            name="system-health-digest",
+            description="",
+            schedule="every: 86400s",  # daily
+            priority="low",
+            execution_type="agent",
+            command="send digest",
+        )
+        state = MagicMock()
+        state.ran_at = None  # lost during the rebuild window
+        # History says it actually ran 1h ago — well within the daily interval.
+        monkeypatch.setattr(sched, "_latest_run_timestamp", lambda name: now - 3600)
+        assert is_reflection_due(entry, state, now) is False
+
+    def test_blank_record_without_history_is_due(self, monkeypatch):
+        """A genuinely never-run every: record (no ran_at, no history) stays due —
+        the guard must not suppress first-ever runs."""
+        import agent.reflection_scheduler as sched
+
+        now = time.time()
+        entry = ReflectionEntry(
+            name="system-health-digest",
+            description="",
+            schedule="every: 86400s",
+            priority="low",
+            execution_type="agent",
+            command="send digest",
+        )
+        state = MagicMock()
+        state.ran_at = None
+        monkeypatch.setattr(sched, "_latest_run_timestamp", lambda name: None)
+        assert is_reflection_due(entry, state, now) is True
+
 
 # === Skip-if-Running Tests ===
 


### PR DESCRIPTION
Closes #1560

## Problem

Tom received ~15 `Daily System Health Digest` messages in one day. The `system-health-digest` reflection (`every: 86400s`) was firing repeatedly, yet `run_count=1` on the surviving record — a tell that each fire hit a *different*, freshly-created record.

## Root cause

`rebuild_indexes()` (run by `run_cleanup()` at worker startup) **deletes** a model's class-set and KeyField index sets before reconstructing them. During that window, `Reflection.query.filter(name="system-health-digest")` returns empty even though the backing hash still exists. A concurrent scheduler tick's `get_or_create()` then spawns a **fresh duplicate** `Reflection` record with `ran_at=None`. For an `every:` schedule, `compute_next_due(last_run=None)` returns `now` → immediately due → fires. Multiple ticks inside the window (e.g. an old worker's scheduler still alive during a restart overlap) → burst-fire.

## Fix (two-part, defense in depth)

1. **Eliminate the race source** — `scripts/popoto_index_cleanup.py`: exclude live `get_or_create`-per-tick scheduler-state models (`_SCHEDULER_STATE_MODELS = {"Reflection"}`) from the destructive rebuild sweep. They are small and continuously indexed by their own `save()` hooks, so a periodic destructive rebuild buys nothing while creating the empty-index window. (`ReflectionRun` is already excluded — not in `models.__all__`.)

2. **Trigger-agnostic guard** — `agent/reflection_scheduler.py`: in `is_reflection_due()`, when an `every:` record's `ran_at` is lost, recover the true last-run from `ReflectionRun` history (a reliable source — never destructively rebuilt). A blank record can no longer re-fire until its real interval elapses, regardless of *how* `ran_at` went missing.

## Tests

- `test_blank_record_with_recent_history_not_due` — blank record + recent history → **not** due (regression).
- `test_blank_record_without_history_is_due` — genuinely never-run → still due (no over-suppression).
- Existing `is_reflection_due` / cleanup tests pass. The 3 remaining failures in `test_reflection_scheduler.py` are pre-existing format drift (old tests hardcode the legacy `interval:` key; the vault registry uses `every:`) and fail identically on main — unrelated to this change.

## Deployment

Takes effect on the next worker restart (`./scripts/valor-service.sh restart`) after merge. Live state is currently stable (single clean record), so this prevents recurrence on the next restart-race rather than putting out an active fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)