### PR TITLE
Kill daily all-clear pings: exception-only health digest + Sentry triage

### DIFF
--- a/agent/sustainability.py
+++ b/agent/sustainability.py
@@ -617,22 +617,3 @@ def sustainability_digest() -> None:
             )
     except Exception:
         logger.exception("[system-health-digest] Unhandled exception — skipping tick")
-
-
-def _send_telegram(message: str) -> None:
-    """Send a message to the 'Dev: Valor' chat via valor-telegram CLI."""
-    try:
-        result = subprocess.run(
-            ["valor-telegram", "send", "--chat", "Dev: Valor", message],
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        if result.returncode != 0:
-            logger.error(
-                "[system-health-digest] valor-telegram send failed (rc=%d): %s",
-                result.returncode,
-                result.stderr.strip(),
-            )
-    except Exception as e:
-        logger.error("[system-health-digest] Failed to send Telegram message: %s", e)

--- a/agent/sustainability.py
+++ b/agent/sustainability.py
@@ -5,7 +5,7 @@ Seven standalone reflection functions, each registered in config/reflections.yam
 - session_recovery_drip: drip paused_circuit and paused sessions back to pending one at a time
 - session_count_throttle: throttle sessions per hour to prevent runaway execution
 - failure_loop_detector: deduplicate GitHub issues for repeated error patterns
-- sustainability_digest: daily Telegram health summary
+- sustainability_digest: daily health check, exception-only Telegram delivery (silent when nominal)
 - send_hibernation_notification: enqueue a Telegram notification for hibernation entry or wake
 
 All functions are synchronous (run in executor by the reflection scheduler).
@@ -493,13 +493,16 @@ def _file_github_issue(fingerprint: str, sessions: list, session_ids: list) -> N
 
 
 def sustainability_digest() -> None:
-    """Send a daily health summary to Telegram.
+    """Daily health check with exception-only Telegram delivery.
 
-    Checks all health signals locally. If everything is nominal, sends a
-    one-line "all clear" directly via valor-telegram (no agent session needed).
-    Only spins up a full agent session when there are anomalies worth reporting.
+    Checks all health signals locally. If everything is nominal, sends
+    NOTHING — the daily all-clear is intentional noise; live status is always
+    on the dashboard. Only spins up a full agent session to report when there
+    are anomalies worth Tom's attention.
 
-    This reflection is registered with interval 86400s (daily).
+    This reflection is registered with interval 86400s (daily) as a
+    function-type callable, so the silence-on-healthy contract is deterministic
+    rather than relying on an LLM agent to choose to send nothing.
     """
     try:
         from models.agent_session import AgentSession
@@ -561,9 +564,10 @@ def sustainability_digest() -> None:
         )
 
         if is_nominal:
-            # Send a one-liner directly — no agent session needed
-            _send_telegram("🩺 Daily health check — all clear, no surprises.")
-            logger.info("[system-health-digest] All nominal — sent one-liner")
+            # Exception-only delivery: on a healthy day, send NOTHING. The daily
+            # all-clear is intentional noise Tom does not want — live status is
+            # always on the dashboard (localhost:8500). Sending nothing is success.
+            logger.info("[system-health-digest] All nominal — staying silent (no all-clear ping)")
         else:
             # Something noteworthy — spin up an agent to investigate and report
             anomalies = []

--- a/reflections/sentry_triage.py
+++ b/reflections/sentry_triage.py
@@ -4,7 +4,10 @@ reflections/sentry_triage.py — Sentry issue triage reflection callable.
 Queries the Sentry API for unresolved issues across all projects in the org,
 classifies them (A–E), files GitHub issues for actionable ones, and updates
 Sentry state for A/B/E (gated by SENTRY_TRIAGE_APPLY env var, default off).
-A summary is sent to Telegram on every run.
+Telegram delivery is exception-only: a summary is sent ONLY when something
+needs Tom's attention (Class C actionable, Class D investigate, or an
+auto-action failure). Pure noise/transient/stale auto-actions complete
+silently — no daily all-clear ping.
 
 Classification:
   A — Ignore: test/mock/harness noise        -> Sentry status=ignored (permanent)
@@ -540,6 +543,23 @@ def run_sentry_triage() -> dict:
         summary += f", {issues_filed} GitHub issues filed"
 
     logger.info(summary)
+
+    # Exception-only delivery: stay silent unless something actually needs Tom's
+    # attention. Issues that were fully auto-actioned into noise/transient/stale
+    # (tiers A/B/E) are handled without human input and must not generate a
+    # daily all-clear ping. Notify only when there is a human-review pile
+    # (Class C actionable or Class D investigate) or an auto-action failure.
+    # Live status is always available on the dashboard; see issue thread on
+    # all-clear noise (#1561 follow-up).
+    needs_attention = bool(classified["C"]) or bool(classified["D"]) or total_failed > 0
+    if not needs_attention:
+        logger.info("sentry_triage: nothing requires attention; suppressing all-clear notification")
+        return {
+            "status": "ok",
+            "findings": findings,
+            "summary": summary,
+            "duration": elapsed,
+        }
 
     # Telegram summary (concise)
     tg_lines = [f"Sentry triage: {len(issues)} issues"]

--- a/tests/unit/test_sentry_triage_apply.py
+++ b/tests/unit/test_sentry_triage_apply.py
@@ -292,7 +292,13 @@ def test_dry_run_digest_marks_no_state_changes(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.delenv("SENTRY_TRIAGE_APPLY", raising=False)
     _patch_common(monkeypatch)
 
-    issues = [_stub_issue("1", "PROJ-A1", "test_noise")]
+    # Pair the noise (A) issue with a tier-D issue so the run has something
+    # needing attention and a notification fires; otherwise exception-only
+    # delivery suppresses the message (see test_all_clear_suppressed below).
+    issues = [
+        _stub_issue("1", "PROJ-A1", "test_noise"),  # tier A
+        _stub_issue("2", "PROJ-D1", "weird thing happened", count=3),  # tier D
+    ]
     monkeypatch.setattr(sentry_triage, "_fetch_unresolved_issues", lambda *_a: issues)
 
     captured: dict[str, str] = {}
@@ -334,3 +340,55 @@ def test_no_auto_actionable_issues_omits_block(monkeypatch: pytest.MonkeyPatch) 
     msg = captured["msg"]
     assert "Auto-actioned" not in msg
     assert "Would auto-action" not in msg
+
+
+def test_all_clear_suppressed_when_nothing_needs_attention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exception-only delivery: pure noise/transient/stale auto-actions send NO Telegram.
+
+    Issues that were fully auto-actioned into tiers A/B/E (and no C/D, no
+    failures) require no human input, so the daily all-clear ping is suppressed.
+    """
+    monkeypatch.setenv("SENTRY_TRIAGE_APPLY", "1")
+    _patch_common(monkeypatch)
+
+    stale_issue = _stub_issue("3", "PROJ-E1", "ancient regression", count=1)
+    stale_issue["lastSeen"] = "2020-01-01T00:00:00Z"  # tier E
+    issues = [
+        _stub_issue("1", "PROJ-A1", "test_something exploded"),  # tier A
+        _stub_issue("2", "PROJ-B1", "Connection refused upstream"),  # tier B
+        stale_issue,  # tier E
+    ]
+    monkeypatch.setattr(sentry_triage, "_fetch_unresolved_issues", lambda *_a: issues)
+
+    sent: list[str] = []
+    monkeypatch.setattr(sentry_triage, "_send_telegram_notification", lambda m: sent.append(m))
+
+    with patch.object(sentry_triage.requests, "put") as mock_put:
+        mock_put.return_value = _mock_resp(200, "{}")
+        result = sentry_triage.run_sentry_triage()
+
+    # Auto-actions still ran (3 PUTs), but no Telegram message was sent.
+    assert mock_put.call_count == 3
+    assert sent == []
+    assert result["status"] == "ok"
+
+
+def test_actionable_issue_triggers_notification(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Class C (actionable) issue must still produce a Telegram notification."""
+    monkeypatch.delenv("SENTRY_TRIAGE_APPLY", raising=False)
+    _patch_common(monkeypatch)
+
+    # High event count → tier C (actionable).
+    issues = [_stub_issue("1", "PROJ-C1", "NullPointer in checkout", count=5000)]
+    monkeypatch.setattr(sentry_triage, "_fetch_unresolved_issues", lambda *_a: issues)
+
+    sent: list[str] = []
+    monkeypatch.setattr(sentry_triage, "_send_telegram_notification", lambda m: sent.append(m))
+
+    with patch.object(sentry_triage.requests, "put"):
+        sentry_triage.run_sentry_triage()
+
+    assert len(sent) == 1
+    assert "Sentry triage" in sent[0]

--- a/tests/unit/test_sustainability.py
+++ b/tests/unit/test_sustainability.py
@@ -681,6 +681,49 @@ class TestDigestAnomalyPromptPlainLanguage(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# TestDigestSilentWhenNominal
+# ---------------------------------------------------------------------------
+
+
+class TestDigestSilentWhenNominal(unittest.TestCase):
+    """sustainability_digest() must send NOTHING and enqueue NOTHING on a healthy day."""
+
+    def test_digest_nominal_stays_silent(self):
+        """All signals nominal → no Telegram send, no agent session enqueued."""
+        import models.agent_session as asm
+        from agent.sustainability import sustainability_digest
+
+        # Healthy: closed circuits, throttle none, queue not paused, no clusters.
+        health_mod, resilience_mod, _cb = _build_health_stubs("closed")
+
+        r = MagicMock()
+        r.get.return_value = b"none"  # throttle_level = "none"
+        r.exists.return_value = 0  # queue not paused
+        r.scard.return_value = 0  # no fingerprint clusters
+
+        fake_session_cls = MagicMock()
+        fake_session_cls.query.filter.return_value = []  # no sessions → failed_24h = 0
+
+        with (
+            patch("agent.sustainability._get_redis", return_value=r),
+            patch("agent.sustainability._get_project_key", return_value="testproj"),
+            patch("agent.sustainability._send_telegram") as mock_send,
+            patch.object(asm, "AgentSession", fake_session_cls),
+            patch.dict(
+                sys.modules,
+                {
+                    "bridge.health": health_mod,
+                    "bridge.resilience": resilience_mod,
+                },
+            ),
+        ):
+            sustainability_digest()
+
+        mock_send.assert_not_called()
+        fake_session_cls.create_and_enqueue.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # TestCircuitHealthGateRegistered
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_sustainability.py
+++ b/tests/unit/test_sustainability.py
@@ -707,7 +707,6 @@ class TestDigestSilentWhenNominal(unittest.TestCase):
         with (
             patch("agent.sustainability._get_redis", return_value=r),
             patch("agent.sustainability._get_project_key", return_value="testproj"),
-            patch("agent.sustainability._send_telegram") as mock_send,
             patch.object(asm, "AgentSession", fake_session_cls),
             patch.dict(
                 sys.modules,
@@ -719,7 +718,8 @@ class TestDigestSilentWhenNominal(unittest.TestCase):
         ):
             sustainability_digest()
 
-        mock_send.assert_not_called()
+        # Silent on healthy: no agent session enqueued. There is no Telegram
+        # path left on the nominal branch — it logs and returns.
         fake_session_cls.create_and_enqueue.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
Tom is tired of the daily **System Health Digest** and **Sentry triage** all-clear pings on healthy days. This makes both reflections **exception-only**: they notify only when something needs his attention. Live status stays available on the dashboard (localhost:8500) at all times.

Follow-up to #1561 (which fixed the burst-fire), addressing the residual once-a-day all-clear noise.

## Root causes & fixes
- **system-health-digest** was `execution_type: agent` and relied on the LLM choosing to send nothing on a nominal day — it did not comply (sent full all-clear digests). Rewired to `execution_type: function` → `agent.sustainability.sustainability_digest`, so silence-on-healthy is now **deterministic**. `sustainability_digest` no longer emits a one-liner all-clear when nominal; it stays silent and only enqueues an agent session to report **anomalies**. _(Reflection config lives in the iCloud vault, not the repo.)_
- **reflections.sentry_triage.run_sentry_triage** sent a Telegram summary on **every** run. Now exception-only: notifies only when there is a human-review pile (Class C actionable / Class D investigate) or an auto-action failure. Pure noise/transient/stale auto-actions complete silently (the auto-actions still run; only the ping is suppressed).

## Decision
Tom approved killing the all-clear pings entirely (vs. a once-a-day heartbeat). Chose **full silence-on-healthy** — the dashboard already provides always-on liveness, so a heartbeat would just be more of the noise he flagged.

## Tests
- `TestDigestSilentWhenNominal` — nominal signals → no Telegram, no agent session enqueued.
- `test_all_clear_suppressed_when_nothing_needs_attention` — A/B/E auto-actions run but send nothing.
- `test_actionable_issue_triggers_notification` — Class C still notifies.
- Updated `test_dry_run_digest_marks_no_state_changes` to include a tier-D issue so a notification still fires under exception-only delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1583