### PR TITLE
fix(sentry): delta-based triage notify — silence static backlog

### DIFF
--- a/reflections/sentry_triage.py
+++ b/reflections/sentry_triage.py
@@ -4,10 +4,13 @@ reflections/sentry_triage.py — Sentry issue triage reflection callable.
 Queries the Sentry API for unresolved issues across all projects in the org,
 classifies them (A–E), files GitHub issues for actionable ones, and updates
 Sentry state for A/B/E (gated by SENTRY_TRIAGE_APPLY env var, default off).
-Telegram delivery is exception-only: a summary is sent ONLY when something
-needs Tom's attention (Class C actionable, Class D investigate, or an
-auto-action failure). Pure noise/transient/stale auto-actions complete
-silently — no daily all-clear ping.
+Telegram delivery is delta-based and exception-only: a summary is sent ONLY
+when a genuinely NEW Class C/D issue appears since the previous run, or an
+auto-action fails. The Class C/D human-review pile is a STANDING backlog — in
+dry-run nothing drains it, so re-announcing the same pile every day is pure
+noise. The set of already-surfaced C/D short-ids is persisted between runs; a
+static backlog stays silent (live status is always on the dashboard), and the
+first run seeds that set silently rather than replaying the whole backlog.
 
 Classification:
   A — Ignore: test/mock/harness noise        -> Sentry status=ignored (permanent)
@@ -27,6 +30,7 @@ All functions accept no arguments and return:
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import subprocess
@@ -41,6 +45,46 @@ from reflections.utils import PROJECT_ROOT, load_local_projects
 logger = logging.getLogger("reflections.sentry_triage")
 
 SENTRY_API_BASE = "https://yudame.sentry.io/api/0"
+
+# Persisted set of Class C/D issue short-ids surfaced to Tom on the previous run.
+# Delta-based notification reads this to stay silent on a static standing backlog
+# and ping only when a genuinely NEW actionable/investigate issue appears.
+_SEEN_STATE_PATH = PROJECT_ROOT / "data" / "sentry_triage_seen.json"
+
+
+def _load_seen_ids() -> set[str] | None:
+    """Return the Class C/D short-ids surfaced on the previous run.
+
+    Returns None when no state file exists yet (first run since delta-based
+    delivery shipped) so the caller can seed silently instead of re-announcing
+    the entire standing backlog. A corrupt/unreadable file is treated the same
+    as a missing one.
+    """
+    try:
+        raw = _SEEN_STATE_PATH.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as e:
+        logger.warning(f"sentry_triage: could not read seen-state: {e}")
+        return None
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    if isinstance(data, dict):
+        data = data.get("ids", [])
+    if not isinstance(data, list):
+        return None
+    return {str(x) for x in data}
+
+
+def _save_seen_ids(ids: set[str]) -> None:
+    """Persist the current Class C/D short-id set. Best-effort; never raises."""
+    try:
+        _SEEN_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _SEEN_STATE_PATH.write_text(json.dumps({"ids": sorted(ids)}, indent=0), encoding="utf-8")
+    except OSError as e:
+        logger.warning(f"sentry_triage: could not persist seen-state: {e}")
 
 
 def _apply_enabled() -> bool:
@@ -544,16 +588,28 @@ def run_sentry_triage() -> dict:
 
     logger.info(summary)
 
-    # Exception-only delivery: stay silent unless something actually needs Tom's
-    # attention. Issues that were fully auto-actioned into noise/transient/stale
-    # (tiers A/B/E) are handled without human input and must not generate a
-    # daily all-clear ping. Notify only when there is a human-review pile
-    # (Class C actionable or Class D investigate) or an auto-action failure.
-    # Live status is always available on the dashboard; see issue thread on
-    # all-clear noise (#1561 follow-up).
-    needs_attention = bool(classified["C"]) or bool(classified["D"]) or total_failed > 0
+    # Delta-based exception delivery. The human-review pile (Class C actionable +
+    # Class D investigate) is a STANDING backlog — in dry-run nothing drains it,
+    # so re-announcing the same pile every day is pure noise (the "still getting
+    # too many" #1561/#1582 follow-up). Notify only when a genuinely NEW C/D
+    # short-id appears since the last run, or an auto-action actually failed.
+    # Tiers A/B/E are handled without human input and never notify. On the very
+    # first run (no state yet) seed silently so we don't replay the whole
+    # backlog. Live status is always available on the dashboard.
+    current_cd_ids = {
+        str(issue.get("shortId") or issue.get("id"))
+        for issue, _cls, _reason in (classified["C"] + classified["D"])
+    }
+    prev_seen = _load_seen_ids()
+    new_cd_ids: set[str] = set() if prev_seen is None else (current_cd_ids - prev_seen)
+    _save_seen_ids(current_cd_ids)
+
+    needs_attention = bool(new_cd_ids) or total_failed > 0
     if not needs_attention:
-        logger.info("sentry_triage: nothing requires attention; suppressing all-clear notification")
+        logger.info(
+            "sentry_triage: no new actionable issues since last run "
+            f"({len(current_cd_ids)} in standing backlog); suppressing notification"
+        )
         return {
             "status": "ok",
             "findings": findings,
@@ -561,8 +617,10 @@ def run_sentry_triage() -> dict:
             "duration": elapsed,
         }
 
-    # Telegram summary (concise)
-    tg_lines = [f"Sentry triage: {len(issues)} issues"]
+    # Telegram summary (concise). Lead with the new-issue count so it's clear why
+    # the otherwise-silent triage spoke up.
+    new_suffix = f" ({len(new_cd_ids)} new)" if new_cd_ids else ""
+    tg_lines = [f"Sentry triage: {len(issues)} issues{new_suffix}"]
     for cls_label, cls_key in [
         ("Noise", "A"),
         ("Transient", "B"),

--- a/tests/unit/test_sentry_triage_apply.py
+++ b/tests/unit/test_sentry_triage_apply.py
@@ -153,10 +153,17 @@ def _stub_issue(issue_id: str, short_id: str, title: str, count: int = 5) -> dic
 
 
 def _patch_common(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Stub auth token + Telegram so triage runs without external side effects."""
+    """Stub auth token + Telegram so triage runs without external side effects.
+
+    Delta-state is stubbed to "state exists, nothing seen before" so every
+    current Class C/D issue counts as new — tests that exercise the
+    seed-silently and static-backlog paths override ``_load_seen_ids``.
+    """
     monkeypatch.setattr(sentry_triage, "_get_auth_token", lambda: "test-token")
     monkeypatch.setattr(sentry_triage, "_get_org_slug", lambda: "test-org")
     monkeypatch.setattr(sentry_triage, "_send_telegram_notification", lambda _m: None)
+    monkeypatch.setattr(sentry_triage, "_load_seen_ids", lambda: set())
+    monkeypatch.setattr(sentry_triage, "_save_seen_ids", lambda _ids: None)
 
 
 def test_dry_run_makes_zero_put_calls(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -392,3 +399,86 @@ def test_actionable_issue_triggers_notification(monkeypatch: pytest.MonkeyPatch)
 
     assert len(sent) == 1
     assert "Sentry triage" in sent[0]
+
+
+# ---------------------------------------------------------------------------
+# Delta-based notification: a STATIC backlog must stay silent; only genuinely
+# new Class C/D issues (or auto-action failures) ping. This is the "still
+# getting too many" fix — exception-only was firing daily because the standing
+# C/D pile is always non-empty in dry-run.
+# ---------------------------------------------------------------------------
+
+
+def test_first_run_seeds_silently(monkeypatch: pytest.MonkeyPatch) -> None:
+    """First run (no prior state) seeds the seen-set and sends NO notification."""
+    monkeypatch.delenv("SENTRY_TRIAGE_APPLY", raising=False)
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(sentry_triage, "_load_seen_ids", lambda: None)  # no state file yet
+
+    saved: list[set[str]] = []
+    monkeypatch.setattr(sentry_triage, "_save_seen_ids", lambda ids: saved.append(ids))
+
+    issues = [_stub_issue("1", "PROJ-C1", "NullPointer in checkout", count=5000)]  # tier C
+    monkeypatch.setattr(sentry_triage, "_fetch_unresolved_issues", lambda *_a: issues)
+
+    sent: list[str] = []
+    monkeypatch.setattr(sentry_triage, "_send_telegram_notification", lambda m: sent.append(m))
+
+    with patch.object(sentry_triage.requests, "put"):
+        sentry_triage.run_sentry_triage()
+
+    assert sent == []  # seeded, not announced
+    assert saved == [{"PROJ-C1"}]  # current pile persisted for next time
+
+
+def test_static_backlog_is_suppressed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unchanged C/D backlog (already seen last run) sends NO notification."""
+    monkeypatch.delenv("SENTRY_TRIAGE_APPLY", raising=False)
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(sentry_triage, "_load_seen_ids", lambda: {"PROJ-C1", "PROJ-D1"})
+
+    issues = [
+        _stub_issue("1", "PROJ-C1", "NullPointer in checkout", count=5000),  # tier C
+        _stub_issue("2", "PROJ-D1", "ambiguous slow query", count=2),  # tier D
+    ]
+    monkeypatch.setattr(sentry_triage, "_fetch_unresolved_issues", lambda *_a: issues)
+
+    sent: list[str] = []
+    monkeypatch.setattr(sentry_triage, "_send_telegram_notification", lambda m: sent.append(m))
+
+    with patch.object(sentry_triage.requests, "put"):
+        sentry_triage.run_sentry_triage()
+
+    assert sent == []  # nothing new — stay silent
+
+
+def test_new_issue_since_last_run_notifies(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A new C/D short-id not in the seen-set triggers exactly one notification."""
+    monkeypatch.delenv("SENTRY_TRIAGE_APPLY", raising=False)
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(sentry_triage, "_load_seen_ids", lambda: {"PROJ-C1"})  # old pile
+
+    issues = [
+        _stub_issue("1", "PROJ-C1", "NullPointer in checkout", count=5000),  # old, seen
+        _stub_issue("2", "PROJ-C2", "fresh crash in payments", count=5000),  # NEW
+    ]
+    monkeypatch.setattr(sentry_triage, "_fetch_unresolved_issues", lambda *_a: issues)
+
+    sent: list[str] = []
+    monkeypatch.setattr(sentry_triage, "_send_telegram_notification", lambda m: sent.append(m))
+
+    with patch.object(sentry_triage.requests, "put"):
+        sentry_triage.run_sentry_triage()
+
+    assert len(sent) == 1
+    assert "(1 new)" in sent[0]  # header advertises the new-issue count
+
+
+def test_seen_ids_round_trip(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """_save_seen_ids then _load_seen_ids round-trips; missing file returns None."""
+    state_file = tmp_path / "sentry_triage_seen.json"
+    monkeypatch.setattr(sentry_triage, "_SEEN_STATE_PATH", state_file)
+
+    assert sentry_triage._load_seen_ids() is None  # no file yet → first run
+    sentry_triage._save_seen_ids({"PROJ-C1", "PROJ-D9"})
+    assert sentry_triage._load_seen_ids() == {"PROJ-C1", "PROJ-D9"}


### PR DESCRIPTION
## Problem

Tom: *"Still getting too many"* — the third report of Sentry-triage notification noise.

#1582 made the Sentry triage "exception-only", gated on:

```python
needs_attention = bool(classified["C"]) or bool(classified["D"]) or total_failed > 0
```

But Class C (actionable) + Class D (investigate) form a **standing human-review backlog** — and the triage runs in **dry-run by default** (`SENTRY_TRIAGE_APPLY=0`), so nothing ever drains it. The same ~169 issues (C≈58, D≈111) re-tripped the gate **every single day**. #1582 removed the literal "all clear" ping but left a daily recitation of a static pile — which reads as "still too many".

## Fix

Notification is now **delta-based**. The set of Class C/D short-ids surfaced last run is persisted to `data/sentry_triage_seen.json`. The triage notifies only when:

- a **genuinely new** C/D short-id appears since the last run, **or**
- an auto-action actually fails (apply mode).

A static backlog stays silent — it's always visible on the dashboard. The **first run seeds the set silently** rather than replaying the whole backlog, so Tom doesn't get one last dump. The Telegram header now advertises the new count (`Sentry triage: N issues (M new)`).

Tiers A/B/E (noise/transient/stale) still auto-action without ever notifying — unchanged.

## Tests

`tests/unit/test_sentry_triage_apply.py`:
- `test_first_run_seeds_silently` — no prior state → seeds, no ping
- `test_static_backlog_is_suppressed` — unchanged pile → silent
- `test_new_issue_since_last_run_notifies` — new short-id → one ping, header shows `(1 new)`
- `test_seen_ids_round_trip` — save/load against a tmp path; missing file → `None`
- Existing exception-only tests updated to stub the delta state

24/24 pass (`-n0`), ruff clean.

## Note

This is a follow-up hotfix to a merged change (#1582); no separate plan doc. Deploy via `/update` so the running worker picks it up before the next daily triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1588
