### PR TITLE
Update teammate skills path example

### DIFF
--- a/docs/features/teammate-session-permissions.md
+++ b/docs/features/teammate-session-permissions.md
@@ -65,7 +65,7 @@ path, not a substring match. This means:
 - `agent/docs_handler/foo.py` does **not** match the `docs/` rule (would be
   a positional promiscuity bug otherwise).
 - `tools/wiki_scraper.py` does **not** match the `wiki/` rule.
-- `agent/skills_router.py` does **not** match the `skills/` rule.
+- `agent/byob_skill_triggers.py` does **not** match the `skills/` rule.
 
 A `len(parts) > 1` guard ensures a bare file literally named `docs` (no
 extension) at the project root does **not** match the directory rule.


### PR DESCRIPTION
## Summary
Update the teammate session permissions doc so the skills-rule negative example points at a current file path instead of the deleted `agent/skills_router.py` path.

## Changes
- Replaced `agent/skills_router.py` with `agent/byob_skill_triggers.py` in `docs/features/teammate-session-permissions.md`.
- Preserved the documentation point that files under `agent/` do not match the root `skills/` allowlist rule.

## Testing
- [x] Confirmed `agent/skills_router.py` no longer appears in `docs/features/teammate-session-permissions.md`
- [x] Confirmed `agent/byob_skill_triggers.py` exists
- [ ] Unit tests passing (not run; docs-only change)
- [ ] Integration tests passing (not run; docs-only change)

Closes #1608