### PR TITLE
Wire gws auth bootstrap into /update (#1622)

### DIFF
--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -193,6 +193,26 @@ result = verify.verify_environment(project_dir)
 # result.valor_tools, result.ollama, result.sdk_auth, result.mcp_servers
 ```
 
+### Google Workspace CLI auth (`gws_auth.py`)
+
+```python
+from scripts.update import gws_auth
+
+result = gws_auth.configure_gws_auth(project_dir)
+# result.action: "already_ok" | "needs_auth" | "skipped" | "failed"
+```
+
+Runs right after the `gh` auth step. `gws` (the `@googleworkspace/cli` binary)
+is installed automatically by the npm prereq step, but first use needs a
+one-time **human** OAuth step — `gws auth login` opens a browser for Google
+consent and `gws auth setup` requires `gcloud` + a GCP project. Those are
+human-gated and `/update` also runs non-interactively (launchd polling), so this
+step is **detection only** — it never opens a browser or blocks:
+
+- `gws` not on PATH → `skipped` (nothing to authenticate yet).
+- authenticated (`gws auth status` reports `auth_method != "none"`) → `already_ok`, silent and idempotent.
+- installed but unauthenticated → `needs_auth`: surfaces an actionable warning with the exact command (`gws auth setup --login`) and appends it to `result.warnings` so it shows at the end of the run. The human completes it once, at their next interactive moment.
+
 ### Calendar Integration (`calendar.py`)
 
 ```python

--- a/docs/features/email-google-workspace-skills.md
+++ b/docs/features/email-google-workspace-skills.md
@@ -83,7 +83,7 @@ gws --version
 
 The `/update` verify check (`scripts/update/verify.py`) uses an **optional-style** gate — it surfaces `gws` version/status when the binary is present, and stays silent (no warning, exit 0) when absent. This mirrors the `sentry-cli` pattern: machines that never use Google Workspace are not nagged.
 
-### Auth (one-time human step — NOT automated)
+### Auth (one-time human step, surfaced by `/update`)
 
 Installing the binary does not authenticate it. First use requires a human-completed OAuth flow:
 
@@ -92,7 +92,7 @@ gws auth setup   # provision a Google Cloud project and OAuth client
 gws auth login   # browser-based consent; credentials stored in OS keyring
 ```
 
-This step cannot be automated by the agent (it requires clicking through a Google consent screen). It is an `[EXTERNAL]` prerequisite documented in the plan.
+The OAuth *consent* itself cannot be automated (it requires clicking through a Google screen, and `gws auth setup` needs `gcloud` + a GCP project). But `/update` no longer treats this as an undocumented external footnote: the `gws_auth.py` step (`scripts/update/gws_auth.py`, run right after the `gh` auth step) **detects** the auth state on every run via `gws auth status` and surfaces the exact command to run when the binary is installed but unauthenticated — appending it to the run's warnings so the human sees it at the end of `/update`. It is detection-only and cron-safe: it never opens a browser or blocks a non-interactive (launchd) run, and stays silent once authenticated (`auth_method != "none"` → idempotent skip).
 
 After auth, credentials are encrypted at rest in the OS keyring (or `~/.config/gws/.encryption_key`). The agent never sees or stores Google credentials.
 
@@ -122,6 +122,7 @@ The `/email` skill echoes the draft-first rule: "prefer a draft the user reviews
 - `.claude/skills-global/google-workspace/SKILL.md` — `/google-workspace` skill (per-service table, behavioral guidance)
 - `scripts/update/npm_tools.py` — `MANAGED_PACKAGES` entry for `@googleworkspace/cli`
 - `scripts/update/verify.py` — optional-style `gws` presence check in `check_system_tools`
+- `scripts/update/gws_auth.py` — detects `gws` auth state and surfaces the one-time OAuth step during `/update`
 - `scripts/update/hardlinks.py` — hardlink sync that propagates both skills globally
 - `docs/plans/email-google-workspace-skill-upgrade.md` — full plan with research, critiques, and acceptance criteria
 - `docs/features/skills-global.md` — global skills library overview

--- a/scripts/update/gws_auth.py
+++ b/scripts/update/gws_auth.py
@@ -1,0 +1,119 @@
+"""Google Workspace CLI (`gws`) authentication bootstrap.
+
+Surfaces the one-time `gws` OAuth step as a first-class part of every `/update`
+run, rather than an undocumented external footnote. Companion to `gh_auth.py`,
+but with a deliberately different contract:
+
+`gh` can be authenticated non-interactively with a stored PAT, so `gh_auth`
+*configures* auth. `gws` cannot — `gws auth login` opens a browser for Google
+OAuth **consent**, and `gws auth setup` additionally requires `gcloud` plus a
+GCP project. Those are human-gated, and `/update` also runs non-interactively
+via launchd polling, so we never auto-run them. Instead this module *detects*
+the auth state and surfaces an actionable instruction when setup is needed:
+
+- `gws` not on PATH        -> skipped (not installed yet; installed by /update)
+- authenticated            -> already_ok (idempotent, silent)
+- present-but-unauthed     -> needs_auth (actionable WARN, non-blocking)
+
+The step is idempotent and cron-safe: it never blocks, never opens a browser,
+and only emits a warning the human can act on at their next interactive moment.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+# Exact commands a human runs to complete first-time auth. `gws auth setup`
+# provisions the GCP project + OAuth client (needs gcloud); `--login` chains
+# the browser consent flow immediately after.
+SETUP_HINT = "gws auth setup --login   (or: gws auth setup && gws auth login)"
+
+
+@dataclass
+class GwsAuthResult:
+    """Result of the gws auth bootstrap check."""
+
+    success: bool
+    action: str  # "already_ok", "needs_auth", "skipped", "failed"
+    detail: str | None = None
+    error: str | None = None
+
+
+def configure_gws_auth(project_dir: Path | None = None) -> GwsAuthResult:
+    """Check `gws` auth state and surface the one-time setup step if needed.
+
+    Detection only — never runs the interactive OAuth flow (see module docstring
+    for why). Safe to call on every update run, interactive or not.
+
+    Args:
+        project_dir: Project root (unused; kept for API consistency with the
+            other update modules).
+
+    Returns:
+        GwsAuthResult describing the auth state and, when unauthenticated, the
+        command the human should run.
+    """
+    gws_bin = shutil.which("gws")
+    if not gws_bin:
+        # Not installed yet — the npm install step earlier in the run handles
+        # presence; nothing to authenticate against. Silent skip.
+        return GwsAuthResult(
+            success=True,
+            action="skipped",
+            detail="gws not on PATH — install via `/update` (@googleworkspace/cli)",
+        )
+
+    try:
+        proc = subprocess.run(
+            [gws_bin, "auth", "status"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except subprocess.TimeoutExpired:
+        return GwsAuthResult(
+            success=False,
+            action="failed",
+            error="gws auth status timed out after 15s",
+        )
+    except OSError as exc:
+        return GwsAuthResult(
+            success=False,
+            action="failed",
+            error=f"gws auth status exec error: {exc}",
+        )
+
+    # `gws auth status` exits 0 even when unauthenticated and emits a JSON blob
+    # whose `auth_method` is "none" until OAuth completes. Parse it; fall back to
+    # a substring check if the output shape ever changes so we fail soft.
+    authed = False
+    method = "unknown"
+    try:
+        status = json.loads(proc.stdout)
+        method = str(status.get("auth_method", "none"))
+        authed = method != "none"
+    except (json.JSONDecodeError, ValueError):
+        # Unexpected output — treat a literal '"auth_method": "none"' as the
+        # only confident unauthenticated signal; otherwise assume authed so we
+        # don't nag on a parsing quirk.
+        authed = '"auth_method": "none"' not in proc.stdout
+
+    if authed:
+        return GwsAuthResult(
+            success=True,
+            action="already_ok",
+            detail=f"gws authenticated (auth_method={method})",
+        )
+
+    return GwsAuthResult(
+        success=True,
+        action="needs_auth",
+        detail=(
+            "gws is installed but not authenticated — first use needs a "
+            f"one-time human OAuth step: {SETUP_HINT}"
+        ),
+    )

--- a/scripts/update/run.py
+++ b/scripts/update/run.py
@@ -27,6 +27,7 @@ from scripts.update import (  # noqa: E402
     env_sync,
     gh_auth,
     git,
+    gws_auth,
     hardlinks,
     hooks,
     kokoro,
@@ -450,6 +451,22 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
     elif not gh_auth_result.success:
         log(f"WARN: gh auth: {gh_auth_result.error}", v, always=True)
         result.warnings.append(f"gh auth: {gh_auth_result.error}")
+
+    # Step 1.69: Check Google Workspace CLI (`gws`) auth state.
+    # Detection only — the OAuth consent flow is human-gated and browser-based,
+    # so we surface an actionable step rather than auto-running it (cron-safe).
+    log("Checking gws auth...", v)
+    gws_auth_result = gws_auth.configure_gws_auth(project_dir)
+    if gws_auth_result.action == "already_ok":
+        log(f"gws auth: {gws_auth_result.detail}", v)
+    elif gws_auth_result.action == "skipped":
+        log(f"gws auth: skipped — {gws_auth_result.detail}", v)
+    elif gws_auth_result.action == "needs_auth":
+        log(f"WARN: gws auth: {gws_auth_result.detail}", v, always=True)
+        result.warnings.append(f"gws auth: {gws_auth_result.detail}")
+    elif not gws_auth_result.success:
+        log(f"WARN: gws auth: {gws_auth_result.error}", v, always=True)
+        result.warnings.append(f"gws auth: {gws_auth_result.error}")
 
     # Step 1.7: Audit skill hooks for dangerous patterns
     log("Auditing skill hooks...", v)

--- a/tests/unit/test_gws_auth.py
+++ b/tests/unit/test_gws_auth.py
@@ -1,0 +1,102 @@
+"""Unit tests for the gws (Google Workspace CLI) auth bootstrap in /update.
+
+Covers the four branches of `configure_gws_auth`:
+- not installed  -> skipped (silent, success)
+- authenticated  -> already_ok (idempotent)
+- unauthenticated -> needs_auth (actionable, non-blocking)
+- status errors  -> failed (soft, never raises)
+
+Detection only — the module must never run the interactive OAuth flow, so all
+tests assert it shells out to `gws auth status` and nothing else.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import patch
+
+from scripts.update.gws_auth import SETUP_HINT, configure_gws_auth
+
+
+def _status_proc(stdout: str, returncode: int = 0):
+    return subprocess.CompletedProcess(
+        args=["gws", "auth", "status"], returncode=returncode, stdout=stdout, stderr=""
+    )
+
+
+def test_skipped_when_not_installed():
+    """No `gws` on PATH -> silent skip, success True, no subprocess call."""
+    with (
+        patch("scripts.update.gws_auth.shutil.which", return_value=None),
+        patch("scripts.update.gws_auth.subprocess.run") as run,
+    ):
+        result = configure_gws_auth()
+
+    assert result.action == "skipped"
+    assert result.success is True
+    run.assert_not_called()
+
+
+def test_already_ok_when_authenticated():
+    """`auth_method` != none -> idempotent already_ok."""
+    authed = json.dumps({"auth_method": "oauth", "storage": "keyring"})
+    with (
+        patch("scripts.update.gws_auth.shutil.which", return_value="/usr/local/bin/gws"),
+        patch(
+            "scripts.update.gws_auth.subprocess.run",
+            return_value=_status_proc(authed),
+        ),
+    ):
+        result = configure_gws_auth()
+
+    assert result.action == "already_ok"
+    assert result.success is True
+    assert "oauth" in (result.detail or "")
+
+
+def test_needs_auth_when_unauthenticated():
+    """`auth_method: none` -> needs_auth with the actionable setup hint."""
+    unauthed = json.dumps({"auth_method": "none", "storage": "none"})
+    with (
+        patch("scripts.update.gws_auth.shutil.which", return_value="/usr/local/bin/gws"),
+        patch(
+            "scripts.update.gws_auth.subprocess.run",
+            return_value=_status_proc(unauthed),
+        ),
+    ):
+        result = configure_gws_auth()
+
+    assert result.action == "needs_auth"
+    assert result.success is True  # non-blocking: success True, surfaced as a warning
+    assert SETUP_HINT in (result.detail or "")
+
+
+def test_failed_on_timeout_does_not_raise():
+    """A status timeout returns a failed result, never propagates the exception."""
+    with (
+        patch("scripts.update.gws_auth.shutil.which", return_value="/usr/local/bin/gws"),
+        patch(
+            "scripts.update.gws_auth.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="gws auth status", timeout=15),
+        ),
+    ):
+        result = configure_gws_auth()
+
+    assert result.action == "failed"
+    assert result.success is False
+    assert "timed out" in (result.error or "")
+
+
+def test_unparseable_output_fails_soft_to_authed():
+    """Non-JSON output without the explicit none-signal assumes authed (no nag)."""
+    with (
+        patch("scripts.update.gws_auth.shutil.which", return_value="/usr/local/bin/gws"),
+        patch(
+            "scripts.update.gws_auth.subprocess.run",
+            return_value=_status_proc("garbage not json"),
+        ),
+    ):
+        result = configure_gws_auth()
+
+    assert result.action == "already_ok"


### PR DESCRIPTION
## Summary

Follow-up to #1615 / PR #1621. That PR installed the `gws` CLI via `/update` but left first-use auth as a passive `[EXTERNAL]` footnote in `CLAUDE.md`. Per feedback, that setup now belongs **in the `/update` skill**.

`/update` already bootstraps `gh` auth (`gh_auth.py`); this adds the parallel `gws_auth.py`. Unlike `gh` (PAT, non-interactive), `gws` needs Google OAuth **consent** in a browser and `gws auth setup` needs `gcloud` + a GCP project — both human-gated. And `/update` also runs non-interactively via launchd. So the module is **detection-only**:

- `gws` not on PATH → `skipped` (silent).
- `gws auth status` reports `auth_method != "none"` → `already_ok` (idempotent, silent).
- installed but unauthenticated → `needs_auth`: surfaces the exact command (`gws auth setup --login`) and appends it to the run's warnings so the human acts on it at their next interactive moment.

It never opens a browser, never blocks a cron/launchd run.

## Changes

- `scripts/update/gws_auth.py` (new) — the detection module, modeled on `gh_auth.py`.
- `scripts/update/run.py` — wired in at Step 1.69, right after the `gh` auth step; `needs_auth`/`failed` append to `result.warnings`.
- `.claude/skills/update/SKILL.md` — documents the step.
- `docs/features/email-google-workspace-skills.md` — auth section updated (no longer "NOT automated"; now surfaced by `/update`).
- `tests/unit/test_gws_auth.py` (new) — covers skipped / already_ok / needs_auth / failed-on-timeout / soft-parse branches.

## Tests

`pytest tests/unit/test_gws_auth.py tests/unit/test_gws_prereq.py tests/unit/test_update_hardlinks.py tests/unit/test_sentry_cli_update.py tests/unit/test_symlinks.py` → **38 passed**. ruff-format clean. Verified against the real `gws 0.22.5` CLI (`gws auth status` JSON shape, `auth_method: "none"` when unauthenticated).

Closes #1622.