### PR TITLE
valor CLI hardening: alias-shadow warning, worktree-proof worker pre-flight (#1619)

### DIFF
--- a/agent/constants.py
+++ b/agent/constants.py
@@ -37,6 +37,13 @@ _TERMINAL_EMOJI_CONFIG: dict[str, tuple[str, str]] = {
 # A threshold of 360s gives one full check-cycle grace period before declaring unhealthy.
 HEARTBEAT_STALENESS_THRESHOLD_S: int = 360
 
+# Worker-down threshold for CLI pre-flight checks (valor-session create/status,
+# agent_session_scheduler status). The worker writes its heartbeat every 300s;
+# 600s = 2x the write cadence, tolerating one fully missed write cycle before
+# declaring the worker down. The dashboard keeps the tighter 360s
+# HEARTBEAT_STALENESS_THRESHOLD_S above for its "ok" band.
+WORKER_DOWN_THRESHOLD_S: int = 600
+
 
 def _resolve_terminal_emoji(name: str, feeling: str, fallback_emoji: str) -> object:
     """Resolve a terminal reaction emoji, caching the result.

--- a/docs/features/session-management.md
+++ b/docs/features/session-management.md
@@ -212,26 +212,26 @@ When `valor_session create` is called on a machine where the worker is stopped, 
 
 ### At session creation (`valor_session create`)
 
-After enqueuing, the CLI reads `data/last_worker_connected` and checks its modification age:
+After enqueuing, the CLI reads the worker heartbeat file and checks its modification age:
 
 - **Plain-text mode**: prints a warning to stderr if the heartbeat is stale or absent
   ```
-  WARNING: no active worker detected — session will stay pending until a worker is started (run: ./scripts/valor-service.sh worker-start)
+  WARNING: no recent worker heartbeat on this machine (720s) — session will stay pending until a worker is started (run: ./scripts/valor-service.sh worker-start)
   ```
-- **JSON mode** (`--json`): adds `"worker_healthy": false` to the output dict instead of printing to stderr
+- **JSON mode** (`--json`): includes `worker_healthy`, `worker_state`, and `worker_heartbeat_age_s` in the output dict
 
 ### At status check (`valor_session status --id <ID>`)
 
 When a session has `status: pending`, the CLI also checks worker health:
 
-- **Plain-text mode**: prints `WARNING: No active worker — session may wait indefinitely.` to stderr
-- **JSON mode** (`--json`): adds `"worker_healthy"` field to the JSON dict (always present for pending sessions)
+- **Plain-text mode**: prints the same warning template to stderr when worker is down
+- **JSON mode** (`--json`): always includes `worker_state` and `worker_heartbeat_age_s` in the JSON dict — `null` when the session is not in `pending` status (compute is skipped to avoid the git subprocess on every call)
 
 Automated pollers using `--json` receive no stderr noise — only clean JSON.
 
 ### At queue status (`agent_session_scheduler status`)
 
-The scheduler's `status` command (which always outputs JSON via `_output()`) now includes two fields in every response:
+The scheduler's `status` command (which always outputs JSON via `_output()`) includes two fields in every response:
 
 ```json
 {
@@ -240,17 +240,43 @@ The scheduler's `status` command (which always outputs JSON via `_output()`) now
 }
 ```
 
-- `worker_healthy`: `true` if heartbeat age < 360s, `false` otherwise
+- `worker_healthy`: `true` if heartbeat age < 600s, `false` otherwise
 - `worker_heartbeat_age_s`: integer age in seconds, or `null` if the file is missing/unreadable
 
 This allows automated shepherding scripts to detect the no-worker condition programmatically.
 
+### JSON contract for `--json` callers
+
+`cmd_create` always emits all three fields:
+
+```json
+{
+  "worker_healthy": true,
+  "worker_state": "ok",
+  "worker_heartbeat_age_s": 112
+}
+```
+
+`cmd_status` emits `worker_state` and `worker_heartbeat_age_s` unconditionally (never silently absent); for non-pending sessions both are `null`. `worker_healthy` is only present when the session is pending:
+
+```json
+{
+  "worker_state": null,
+  "worker_heartbeat_age_s": null
+}
+```
+
+`worker_state` is `"ok"` or `"down"`. Agent callers should branch on `worker_state` rather than the prose warning text.
+
 ### Implementation
 
-The health check reads `data/last_worker_connected` via `stat().st_mtime` — matching the pattern already in `ui/app.py:_get_worker_health()`. Threshold is 360 seconds. Missing file equals unhealthy. All `OSError` paths are caught silently; the check never raises.
+The health check resolves the heartbeat path via `_resolve_heartbeat_path()` in `tools/valor_session.py`, then reads `stat().st_mtime`. The path resolver uses `git rev-parse --path-format=absolute --git-common-dir` so CLI invocations from git worktrees (`.worktrees/{slug}/`) always read the main checkout's `data/last_worker_connected` — the only copy the worker writes. Any git subprocess failure falls back to a `__file__`-relative path. Future-dated mtimes from clock skew are clamped to age 0 (reported as healthy).
 
-- `_check_worker_health()` in `tools/valor_session.py` — canonical helper
-- Equivalent inline 5-line check in `tools/agent_session_scheduler.py:cmd_status` — no cross-file import coupling
+Threshold is `WORKER_DOWN_THRESHOLD_S = 600s` (defined in `agent/constants.py`) — 2x the worker's 300s heartbeat write cadence, giving a full missed write cycle of margin. Missing file equals down (worker has never run on this machine). All exception paths are caught silently; the check never raises.
+
+- `_resolve_heartbeat_path()` in `tools/valor_session.py` — worktree-aware path resolution
+- `_check_worker_health()` in `tools/valor_session.py` — canonical health check helper
+- `tools/agent_session_scheduler.py` — uses the shared `_resolve_heartbeat_path` import and `WORKER_DOWN_THRESHOLD_S`
 
 ## Related Features
 

--- a/docs/features/session-steering.md
+++ b/docs/features/session-steering.md
@@ -102,6 +102,36 @@ valor-session kill --all
 
 Add `--json` to any command for machine-readable output.
 
+### Worker pre-flight check (`create` and `status`)
+
+After enqueuing a session, `valor-session create` checks whether a worker is actively writing heartbeats. `valor-session status` runs the same check when the session is in `pending` status.
+
+**States:**
+
+- `ok` (heartbeat age < 600s) — silent; no output
+- `down` (heartbeat age ≥ 600s, or file missing) — warning to stderr:
+  ```
+  WARNING: no recent worker heartbeat on this machine (720s) — session will stay pending until a worker is started (run: ./scripts/valor-service.sh worker-start)
+  ```
+
+The warning never claims the session will not run — it reports the current heartbeat age so the operator can judge. The session is enqueued regardless; when a worker starts, it picks up pending sessions normally.
+
+**Threshold:** `WORKER_DOWN_THRESHOLD_S = 600s` (defined in `agent/constants.py`), 2x the worker's 300s heartbeat write cadence. This gives one full missed write cycle of margin before declaring the worker down.
+
+**Worktree-proof path resolution:** The heartbeat file lives at `data/last_worker_connected` in the main checkout. When the CLI runs from a git worktree (`.worktrees/{slug}/`), a naive `__file__`-relative path would point at the worktree's own `data/` dir, which the worker never writes. `_resolve_heartbeat_path()` uses `git rev-parse --path-format=absolute --git-common-dir` (flag order matters — `--path-format=absolute` must precede `--git-common-dir`) to locate the main checkout's `.git` dir and derive the canonical heartbeat path. Relative git output is resolved against the `__file__` anchor, never the process cwd. Any git subprocess failure falls back to the `__file__`-relative path silently.
+
+**JSON contract:** `--json` output always includes these fields:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `worker_state` | `"ok"` or `"down"` | Structured state for agent callers — always present |
+| `worker_heartbeat_age_s` | integer or `null` | Age of the heartbeat file in seconds; `null` if file is missing; clamped to ≥ 0 |
+| `worker_healthy` | boolean | `true` when `worker_state == "ok"` — kept for backward compatibility |
+
+In `cmd_create`, all three fields are always non-null. In `cmd_status`, `worker_state` and `worker_heartbeat_age_s` are unconditionally present but are `null` when the session is not `pending` (the compute is skipped to avoid running the git subprocess on every status call). `worker_healthy` only appears in `cmd_status` JSON when the session is pending.
+
+Agent callers should branch on `worker_state` rather than parsing the stderr warning text.
+
 ## Backward Compatibility
 
 All symbols that previously lived only in `agent/agent_session_queue.py` are re-exported from there for backward compatibility:

--- a/docs/guides/valor-name-references.md
+++ b/docs/guides/valor-name-references.md
@@ -104,7 +104,7 @@ References where "Valor" is a **brand/product name** for the tooling itself — 
 | `scripts/auto-revert.sh` | `valor-service.sh` reference |
 | `scripts/calendar_hook.sh` | `EXCLUDED_PROJECTS="valor"`, `valor-calendar` |
 | `scripts/calendar_prompt_hook.sh` | `EXCLUDED_PROJECTS="valor"`, `valor-calendar` |
-| `scripts/update/verify.py` | `valor-calendar` path checks |
+| `scripts/update/verify.py` | `valor-calendar` path checks; `check_valor_alias_shadow` warns on a stale `alias valor=` in `~/.zshrc` shadowing `.venv/bin/valor` |
 | `scripts/update/run.py` | `com.valor.reflections.plist` (removed service) |
 | `scripts/update/__init__.py` | `"Modular update system for Valor"` |
 | `scripts/telegram_login.py` | `valor-service.sh` reference |

--- a/docs/plans/valor-cli-hardening.md
+++ b/docs/plans/valor-cli-hardening.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: docs_complete
 type: bug
 appetite: Small
 owner: Valor Engels
@@ -219,13 +219,13 @@ No new agent integration required — `valor` and `valor-session` are already CL
 ## Documentation
 
 ### Feature Documentation
-- [ ] Update `docs/features/valor-cli-wrapper.md` — shortcoming item 1 (alias): fixed status + the verify-step guard; item 3 (pre-flight): correct the misdiagnosis ("stale Redis cache" → file-mtime path divergence + threshold semantics) and document the 600s single-threshold behavior; item 7/9 (tests): already-accurate, confirm wording. This file lands on main with PR #1612, which merges together with this work (Decision 1) — execute after #1612 merges
-- [ ] Update `docs/features/session-steering.md` (or the doc section covering `valor-session create`) with the new warning semantics and `--json` fields
-- [ ] `docs/features/README.md` index — no new entry needed (existing pages updated in place)
+- [ ] Update `docs/features/valor-cli-wrapper.md` — shortcoming item 1 (alias): fixed status + the verify-step guard; item 3 (pre-flight): correct the misdiagnosis ("stale Redis cache" → file-mtime path divergence + threshold semantics) and document the 600s single-threshold behavior; item 7/9 (tests): already-accurate, confirm wording. This file lands on main with PR #1612, which merges together with this work (Decision 1) — execute after #1612 merges. **DEFERRED — tracked in #1631** (file not on this branch; survives plan deletion at merge)
+- [x] Update `docs/features/session-steering.md` (or the doc section covering `valor-session create`) with the new warning semantics and `--json` fields
+- [x] `docs/features/README.md` index — no new entry needed (existing pages updated in place)
 
 ### Inline Documentation
-- [ ] Docstring on the reworked `_check_worker_health()` documenting the 600s threshold rationale (2× write cadence), the git-common-dir resolution, and the #980 never-raise contract
-- [ ] Comment on the verify-step check pointing at this issue for the heterogeneous-machines rationale
+- [x] Docstring on the reworked `_check_worker_health()` documenting the 600s threshold rationale (2× write cadence), the git-common-dir resolution, and the #980 never-raise contract
+- [x] Comment on the verify-step check pointing at this issue for the heterogeneous-machines rationale
 
 ## Success Criteria
 

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -330,7 +330,7 @@ python -m tools.valor_session children --id <SESSION_ID>
 python -m tools.valor_session steer --id <SESSION_ID> --message "Stop after critique"
 
 # Create a new session (project_key derived from cwd via projects.json)
-# Warns to stderr if no active worker is running; --json adds worker_healthy field
+# Warns to stderr if no recent worker heartbeat; --json adds worker_healthy, worker_state, worker_heartbeat_age_s
 # PM and dev roles both require --slug, or `issue #N` in the message for auto-derivation.
 python -m tools.valor_session create --role pm --message "Plan issue #735"
 python -m tools.valor_session create --role dev --slug fix-the-bug --message "Fix the bug" --parent <PARENT_ID>

--- a/scripts/update/verify.py
+++ b/scripts/update/verify.py
@@ -181,6 +181,55 @@ def check_python_alias() -> ToolCheck:
         return ToolCheck(name="python", available=False, error=f"python --version failed: {e}")
 
 
+def check_valor_alias_shadow(zshrc_path: Path | None = None) -> ToolCheck:
+    """Warn when a stale `alias valor=...` in ~/.zshrc shadows .venv/bin/valor.
+
+    An old `alias valor="cd ... && ./scripts/telegram_run.sh"` predates the
+    venv `valor` entry point; the script it pointed at is gone, so typing
+    `valor` in an interactive shell errors instead of running the binary.
+
+    Warn-only by design (issue #1619): machines are heterogeneous and we
+    never auto-edit user rc files, so this check must never block /update.
+    No subprocess, no interactive shell — reads the rc file directly so it
+    stays deterministic under launchd.
+    """
+    path = zshrc_path if zshrc_path is not None else Path.home() / ".zshrc"
+
+    try:
+        content = path.read_text()
+    except FileNotFoundError:
+        return ToolCheck(
+            name="valor-alias",
+            available=True,
+            version="skipped (~/.zshrc not found)",
+        )
+    except (PermissionError, OSError):
+        return ToolCheck(
+            name="valor-alias",
+            available=True,
+            version="skipped (~/.zshrc unreadable)",
+        )
+
+    # `\s*=` must immediately follow `valor` so valor-session= etc. never match.
+    alias_re = re.compile(r"^\s*alias\s+valor\s*=")
+    for lineno, line in enumerate(content.splitlines(), start=1):
+        if line.lstrip().startswith("#"):
+            continue
+        if alias_re.search(line):
+            return ToolCheck(
+                name="valor-alias",
+                available=False,
+                error=(
+                    f"stale `valor` alias shadows .venv/bin/valor — "
+                    f"~/.zshrc line {lineno}: {line.strip()} | "
+                    f"Fix: delete line {lineno} from ~/.zshrc, "
+                    f"then run: source ~/.zshrc"
+                ),
+            )
+
+    return ToolCheck(name="valor-alias", available=True, version="no shadowing alias")
+
+
 def check_system_tools() -> list[ToolCheck]:
     """Check system-level tools."""
     tools = [
@@ -966,6 +1015,7 @@ def verify_environment(project_dir: Path, check_ollama_model: bool = True) -> Ve
     result.valor_tools.append(check_telegram_session(project_dir))
     result.valor_tools.append(check_google_token(project_dir))
     result.valor_tools.append(check_env_completeness(project_dir))
+    result.valor_tools.append(check_valor_alias_shadow())
 
     if check_ollama_model:
         ollama_model = os.getenv("OLLAMA_SUMMARIZER_MODEL", "gemma4:e2b")

--- a/tests/unit/test_update_valor_alias.py
+++ b/tests/unit/test_update_valor_alias.py
@@ -1,0 +1,83 @@
+"""Tests for check_valor_alias_shadow() in scripts/update/verify.py.
+
+A stale `alias valor=...` in ~/.zshrc shadows the venv binary .venv/bin/valor
+in interactive shells. The /update verify step warns (never blocks) when such
+an alias exists. See issue #1619.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts.update.verify import check_valor_alias_shadow
+
+
+def _write_rc(tmp_path: Path, content: str) -> Path:
+    rc = tmp_path / ".zshrc"
+    rc.write_text(content)
+    return rc
+
+
+def test_passes_when_only_prefixed_and_commented_aliases(tmp_path: Path) -> None:
+    """`alias valor-session=...` and commented `# alias valor=...` must NOT warn."""
+    rc = _write_rc(
+        tmp_path,
+        "alias valor-session='python -m tools.valor_session'\n"
+        '# alias valor="cd /Users/valorengels/src/ai && ./scripts/telegram_run.sh"\n'
+        "alias valor-telegram='vt'\n"
+        "alias valordash=x\n",
+    )
+    check = check_valor_alias_shadow(rc)
+    assert check.available is True
+    assert check.error is None
+
+
+@pytest.mark.parametrize(
+    "alias_line",
+    [
+        'alias valor="cd /Users/valorengels/src/ai && ./scripts/telegram_run.sh"',
+        "  alias valor='old'",  # indented
+        "alias valor ='old'",  # space before =
+        "\talias valor\t='old'",  # tab indentation and spacing
+    ],
+)
+def test_warns_when_shadowing_alias_present(tmp_path: Path, alias_line: str) -> None:
+    rc = _write_rc(tmp_path, f"export FOO=1\n{alias_line}\n")
+    check = check_valor_alias_shadow(rc)
+    assert check.available is False
+    assert check.error is not None
+    # Message must contain line number, offending line, and copy-paste fix.
+    assert "line 2" in check.error
+    assert alias_line.strip() in check.error
+    assert "source ~/.zshrc" in check.error
+
+
+def test_commented_out_alias_only_passes(tmp_path: Path) -> None:
+    rc = _write_rc(tmp_path, '   # alias valor="old"\n#alias valor=old\n')
+    check = check_valor_alias_shadow(rc)
+    assert check.available is True
+    assert check.error is None
+
+
+def test_missing_rc_file_skips_cleanly(tmp_path: Path) -> None:
+    check = check_valor_alias_shadow(tmp_path / ".zshrc")
+    assert check.available is True
+    assert check.error is None
+    assert "skipped" in (check.version or "")
+
+
+def test_unreadable_rc_file_skips_cleanly(tmp_path: Path) -> None:
+    if os.geteuid() == 0:
+        pytest.skip("running as root — chmod 000 does not block reads")
+    rc = _write_rc(tmp_path, 'alias valor="old"\n')
+    rc.chmod(0o000)
+    try:
+        check = check_valor_alias_shadow(rc)
+    finally:
+        rc.chmod(0o644)
+    assert check.available is True
+    assert check.error is None
+    assert "skipped" in (check.version or "")

--- a/tests/unit/test_worker_health_check.py
+++ b/tests/unit/test_worker_health_check.py
@@ -1,29 +1,39 @@
-"""Unit tests for _check_worker_health() in tools/valor_session.py.
+"""Unit tests for worker heartbeat pre-flight in tools/valor_session.py.
 
-Tests cover:
-- Healthy worker (heartbeat recent)
-- Stale worker (heartbeat older than threshold)
-- Missing heartbeat file
-- JSON output includes worker_healthy field
-- Non-JSON output emits WARNING to stderr when worker is absent/stale
+Covers:
+- _check_worker_health(): healthy/stale/missing/boundary against the 600s
+  WORKER_DOWN_THRESHOLD_S, negative-age clamping, and the #980 never-raise
+  contract (permission errors, git subprocess failures).
+- _resolve_heartbeat_path(): worktree-aware resolution via
+  `git rev-parse --path-format=absolute --git-common-dir`, relative-output
+  guarding (anchored to repo_root, never process cwd), and the
+  __file__-relative fallback on any git failure.
 """
 
 import os
+import subprocess
 import sys
 import time
 from pathlib import Path
-from unittest.mock import patch
 
 # Ensure repo root is on path before importing from tools/
 _repo_root = Path(__file__).parent.parent.parent
 if str(_repo_root) not in sys.path:
     sys.path.insert(0, str(_repo_root))
 
-from agent.constants import HEARTBEAT_STALENESS_THRESHOLD_S  # noqa: E402
-from tools.valor_session import _check_worker_health  # noqa: E402
+from agent.constants import WORKER_DOWN_THRESHOLD_S  # noqa: E402
+from tools import valor_session  # noqa: E402
+from tools.valor_session import (  # noqa: E402
+    _check_worker_health,
+    _resolve_heartbeat_path,
+    _worker_down_message,
+)
 
-# Alias for backward-compat within this test module
-_WORKER_HEALTHY_THRESHOLD_S = HEARTBEAT_STALENESS_THRESHOLD_S
+
+def _patch_resolver(monkeypatch, path: Path) -> None:
+    """Point the resolver seam at a test-controlled heartbeat path."""
+    monkeypatch.setattr(valor_session, "_resolve_heartbeat_path", lambda *a, **k: path)
+
 
 # ---------------------------------------------------------------------------
 # _check_worker_health() unit tests
@@ -31,69 +41,215 @@ _WORKER_HEALTHY_THRESHOLD_S = HEARTBEAT_STALENESS_THRESHOLD_S
 
 
 class TestCheckWorkerHealth:
-    """Tests for _check_worker_health() helper."""
+    """Tests for _check_worker_health() against WORKER_DOWN_THRESHOLD_S (600s)."""
 
-    def test_healthy_worker(self, tmp_path):
+    def test_healthy_worker(self, tmp_path, monkeypatch):
         """Returns (True, age_s) when heartbeat file is recent."""
         hb = tmp_path / "last_worker_connected"
         hb.write_text("ok")
-        # File is brand-new — age should be ~0s
+        _patch_resolver(monkeypatch, hb)
 
-        with patch("tools.valor_session._WORKER_HEARTBEAT_FILE", hb):
-            healthy, age_s = _check_worker_health()
+        healthy, age_s = _check_worker_health()
 
         assert healthy is True
         assert age_s is not None
-        assert age_s < _WORKER_HEALTHY_THRESHOLD_S
+        assert age_s < WORKER_DOWN_THRESHOLD_S
 
-    def test_stale_worker(self, tmp_path):
-        """Returns (False, age_s) when heartbeat file is older than threshold."""
+    def test_age_between_old_and_new_threshold_is_healthy(self, tmp_path, monkeypatch):
+        """A 360-599s age is healthy under the 600s threshold (was stale at 360s)."""
         hb = tmp_path / "last_worker_connected"
         hb.write_text("ok")
-        # Backdate the mtime by more than the threshold
-        stale_mtime = time.time() - (_WORKER_HEALTHY_THRESHOLD_S + 60)
-        os.utime(hb, (stale_mtime, stale_mtime))
+        mtime = time.time() - 450
+        os.utime(hb, (mtime, mtime))
+        _patch_resolver(monkeypatch, hb)
 
-        with patch("tools.valor_session._WORKER_HEARTBEAT_FILE", hb):
-            healthy, age_s = _check_worker_health()
+        healthy, age_s = _check_worker_health()
+
+        assert healthy is True
+        assert age_s is not None
+        assert 360 <= age_s < WORKER_DOWN_THRESHOLD_S
+
+    def test_stale_worker(self, tmp_path, monkeypatch):
+        """Returns (False, age_s) when heartbeat is older than 600s."""
+        hb = tmp_path / "last_worker_connected"
+        hb.write_text("ok")
+        stale_mtime = time.time() - (WORKER_DOWN_THRESHOLD_S + 60)
+        os.utime(hb, (stale_mtime, stale_mtime))
+        _patch_resolver(monkeypatch, hb)
+
+        healthy, age_s = _check_worker_health()
 
         assert healthy is False
         assert age_s is not None
-        assert age_s >= _WORKER_HEALTHY_THRESHOLD_S
+        assert age_s >= WORKER_DOWN_THRESHOLD_S
 
-    def test_missing_heartbeat_file(self, tmp_path):
+    def test_missing_heartbeat_file(self, tmp_path, monkeypatch):
         """Returns (False, None) when heartbeat file does not exist."""
-        hb = tmp_path / "nonexistent_last_worker_connected"
+        _patch_resolver(monkeypatch, tmp_path / "nonexistent_last_worker_connected")
 
-        with patch("tools.valor_session._WORKER_HEARTBEAT_FILE", hb):
-            healthy, age_s = _check_worker_health()
+        healthy, age_s = _check_worker_health()
 
         assert healthy is False
         assert age_s is None
 
-    def test_does_not_raise_on_permission_error(self, tmp_path):
-        """Never raises — OSError is caught silently."""
+    def test_exact_threshold_boundary(self, tmp_path, monkeypatch):
+        """Age == 600s is treated as down (strict <)."""
+        hb = tmp_path / "last_worker_connected"
+        hb.write_text("ok")
+        boundary_mtime = time.time() - WORKER_DOWN_THRESHOLD_S
+        os.utime(hb, (boundary_mtime, boundary_mtime))
+        _patch_resolver(monkeypatch, hb)
+
+        healthy, _age_s = _check_worker_health()
+
+        assert healthy is False
+
+    def test_future_mtime_clamped_to_zero(self, tmp_path, monkeypatch):
+        """Future-dated mtime (clock skew / iCloud) clamps age to 0 == healthy."""
+        hb = tmp_path / "last_worker_connected"
+        hb.write_text("ok")
+        future_mtime = time.time() + 500
+        os.utime(hb, (future_mtime, future_mtime))
+        _patch_resolver(monkeypatch, hb)
+
+        healthy, age_s = _check_worker_health()
+
+        assert healthy is True
+        assert age_s == 0
+        assert "-" not in _worker_down_message(age_s).split("(")[1].split(")")[0]
+
+    def test_does_not_raise_on_permission_error(self, tmp_path, monkeypatch):
+        """Never raises — OSError is caught silently (#980 contract)."""
         hb = tmp_path / "last_worker_connected"
         hb.write_text("ok")
         hb.chmod(0o000)
+        _patch_resolver(monkeypatch, hb)
 
         try:
-            with patch("tools.valor_session._WORKER_HEARTBEAT_FILE", hb):
-                result = _check_worker_health()
-            # Should return (False, None) or (True/False, int) — no exception
+            result = _check_worker_health()
             assert isinstance(result, tuple)
             assert len(result) == 2
         finally:
             hb.chmod(0o644)  # restore so tmp_path cleanup works
 
-    def test_exact_threshold_boundary(self, tmp_path):
-        """Age == threshold is treated as unhealthy (strict <)."""
-        hb = tmp_path / "last_worker_connected"
-        hb.write_text("ok")
-        boundary_mtime = time.time() - _WORKER_HEALTHY_THRESHOLD_S
-        os.utime(hb, (boundary_mtime, boundary_mtime))
+    def test_git_failure_falls_back_and_reports_down(self, tmp_path, monkeypatch):
+        """Git subprocess failure → fallback path, (False, None) — never a raise.
 
-        with patch("tools.valor_session._WORKER_HEARTBEAT_FILE", hb):
-            healthy, age_s = _check_worker_health()
+        Pins the resolver's anchor to tmp_path (which has no data/ dir) and
+        makes the git binary unfindable; the real resolver must swallow the
+        error, fall back to the anchor-relative path, and the health check
+        must report down/None.
+        """
+        real_resolver = _resolve_heartbeat_path
+        monkeypatch.setattr(
+            valor_session,
+            "_resolve_heartbeat_path",
+            lambda *a, **k: real_resolver(repo_root=tmp_path),
+        )
+
+        def _boom(*args, **kwargs):
+            raise FileNotFoundError("git binary missing")
+
+        monkeypatch.setattr(subprocess, "run", _boom)
+
+        healthy, age_s = _check_worker_health()
 
         assert healthy is False
+        assert age_s is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_heartbeat_path() unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveHeartbeatPath:
+    """Tests for the worktree-aware heartbeat path resolver."""
+
+    @staticmethod
+    def _git(*args, cwd):
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.email=test@test",
+                "-c",
+                "user.name=test",
+                *args,
+            ],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+        )
+
+    def test_worktree_resolves_to_main_checkout_data_dir(self, tmp_path):
+        """From a real git worktree, the path lands under the MAIN checkout."""
+        main = tmp_path / "main"
+        main.mkdir()
+        self._git("init", cwd=main)
+        (main / "f.txt").write_text("x")
+        self._git("add", "f.txt", cwd=main)
+        self._git("commit", "-m", "init", cwd=main)
+        wt = tmp_path / "wt"
+        self._git("worktree", "add", str(wt), cwd=main)
+
+        result = _resolve_heartbeat_path(repo_root=wt)
+
+        assert result == main.resolve() / "data" / "last_worker_connected"
+
+    def test_relative_git_output_anchored_to_repo_root_not_cwd(self, tmp_path, monkeypatch):
+        """Relative common-dir output resolves under repo_root, never process cwd."""
+        anchor = tmp_path / "repo"
+        anchor.mkdir()
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+
+        def _fake_run(*args, **kwargs):
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=".git\n", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+
+        result = _resolve_heartbeat_path(repo_root=anchor)
+
+        assert result == anchor.resolve() / "data" / "last_worker_connected"
+        assert not str(result).startswith(str(elsewhere))
+
+    def test_git_nonzero_exit_falls_back_to_anchor(self, tmp_path, monkeypatch):
+        """Non-zero git exit → __file__-relative (anchor-relative) fallback."""
+
+        def _fake_run(*args, **kwargs):
+            return subprocess.CompletedProcess(
+                args=args, returncode=128, stdout="", stderr="fatal: not a git repository"
+            )
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+
+        result = _resolve_heartbeat_path(repo_root=tmp_path)
+
+        assert result == tmp_path / "data" / "last_worker_connected"
+
+    def test_git_binary_missing_falls_back_to_anchor(self, tmp_path, monkeypatch):
+        """FileNotFoundError from subprocess → anchor-relative fallback, no raise."""
+
+        def _boom(*args, **kwargs):
+            raise FileNotFoundError("git binary missing")
+
+        monkeypatch.setattr(subprocess, "run", _boom)
+
+        result = _resolve_heartbeat_path(repo_root=tmp_path)
+
+        assert result == tmp_path / "data" / "last_worker_connected"
+
+    def test_default_anchor_is_repo_root_of_module(self, monkeypatch):
+        """With no repo_root, the anchor is the module's __file__-relative root."""
+
+        def _boom(*args, **kwargs):
+            raise FileNotFoundError("git binary missing")
+
+        monkeypatch.setattr(subprocess, "run", _boom)
+
+        result = _resolve_heartbeat_path()
+
+        expected_anchor = Path(valor_session.__file__).parent.parent
+        assert result == expected_anchor / "data" / "last_worker_connected"

--- a/tools/agent_session_scheduler.py
+++ b/tools/agent_session_scheduler.py
@@ -31,7 +31,7 @@ import uuid
 from datetime import UTC, datetime
 from pathlib import Path
 
-from agent.constants import HEARTBEAT_STALENESS_THRESHOLD_S
+from agent.constants import WORKER_DOWN_THRESHOLD_S
 from config.enums import SessionType
 from models.reflection import Reflection
 from models.session_lifecycle import NON_TERMINAL_STATUSES
@@ -561,11 +561,12 @@ def cmd_status(args: argparse.Namespace) -> int:
         if killed:
             result["killed_sessions"] = [_format_agent_session_info(j) for j in killed]
 
-        # Inline worker health check — avoids cross-file import coupling
+        # Worker health check — shared worktree-aware heartbeat resolver
         try:
-            _hb = Path(__file__).parent.parent / "data" / "last_worker_connected"
-            _age_s = int(time.time() - _hb.stat().st_mtime)
-            result["worker_healthy"] = _age_s < HEARTBEAT_STALENESS_THRESHOLD_S
+            from tools.valor_session import _resolve_heartbeat_path
+
+            _age_s = max(0, int(time.time() - _resolve_heartbeat_path().stat().st_mtime))
+            result["worker_healthy"] = _age_s < WORKER_DOWN_THRESHOLD_S
             result["worker_heartbeat_age_s"] = _age_s
         except Exception:
             result["worker_healthy"] = False

--- a/tools/valor_session.py
+++ b/tools/valor_session.py
@@ -101,27 +101,85 @@ def _load_env() -> None:
         pass
 
 
-_WORKER_HEARTBEAT_FILE = _repo_root / "data" / "last_worker_connected"
+from agent.constants import WORKER_DOWN_THRESHOLD_S  # noqa: E402
 
-from agent.constants import HEARTBEAT_STALENESS_THRESHOLD_S  # noqa: E402
+
+def _resolve_heartbeat_path(repo_root: Path | None = None) -> Path:
+    """Resolve the worker heartbeat file path, worktree-aware.
+
+    The worker only ever writes ``data/last_worker_connected`` under the MAIN
+    checkout. When this CLI runs from a git worktree (``.worktrees/{slug}/``),
+    a ``__file__``-relative path points at the worktree's own ``data/`` dir,
+    which the worker never touches — producing a false "worker down" verdict.
+
+    Resolution: ``git -C <repo_root> rev-parse --path-format=absolute
+    --git-common-dir`` yields the main checkout's ``.git`` dir (flag order
+    matters — ``--path-format=absolute`` must precede ``--git-common-dir``).
+    The heartbeat lives at ``<common_dir>.parent / data / last_worker_connected``.
+
+    Relative git output is resolved against ``repo_root`` (never the process
+    cwd). Any subprocess failure — non-zero exit, missing git binary, timeout,
+    any exception — falls back to the ``__file__``-relative path. Never raises
+    (#980 never-raise contract).
+    """
+    anchor = repo_root if repo_root is not None else Path(__file__).parent.parent
+    try:
+        import subprocess
+
+        proc = subprocess.run(
+            ["git", "-C", str(anchor), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        output = proc.stdout.strip()
+        if proc.returncode == 0 and output:
+            common = Path(output)
+            abs_common = common if common.is_absolute() else (anchor / common).resolve()
+            return abs_common.parent / "data" / "last_worker_connected"
+    except Exception:
+        pass
+    return anchor / "data" / "last_worker_connected"
 
 
 def _check_worker_health() -> tuple[bool, int | None]:
     """Check worker health by reading the heartbeat file modification time.
 
-    Returns (healthy, age_s) where:
-      - healthy is True if the heartbeat was updated within the last 360 seconds
-      - age_s is the integer age in seconds, or None if the file is missing or unreadable
+    The heartbeat path comes from :func:`_resolve_heartbeat_path`, which uses
+    ``git rev-parse --path-format=absolute --git-common-dir`` so worktree
+    checkouts read the main checkout's ``data/last_worker_connected`` (the
+    only copy the worker writes).
 
-    Never raises — all OSError and unexpected exceptions are caught silently.
-    Missing file == unhealthy (worker has never run on this machine).
+    Threshold is ``WORKER_DOWN_THRESHOLD_S`` (600s) — 2x the worker's 300s
+    heartbeat write cadence (``agent/session_health.py`` health loop), giving
+    a full missed write cycle of margin before declaring the worker down.
+
+    Returns (healthy, age_s) where:
+      - healthy is True if heartbeat age < WORKER_DOWN_THRESHOLD_S
+      - age_s is the integer age in seconds, clamped to >= 0 (future-dated
+        mtimes from clock skew / iCloud report 0 == healthy), or None if the
+        file is missing or unreadable
+
+    Never raises — the #980 never-raise contract holds end to end; any
+    exception (including git failures inside the resolver) yields a fallback
+    path or (False, None). Missing file == down (worker has never run here).
     """
     try:
-        mtime = _WORKER_HEARTBEAT_FILE.stat().st_mtime
-        age_s = int(time.time() - mtime)
-        return (age_s < HEARTBEAT_STALENESS_THRESHOLD_S, age_s)
+        mtime = _resolve_heartbeat_path().stat().st_mtime
+        age_s = max(0, int(time.time() - mtime))
+        return (age_s < WORKER_DOWN_THRESHOLD_S, age_s)
     except Exception:
         return (False, None)
+
+
+def _worker_down_message(age_s: int | None) -> str:
+    """Shared warning template for the worker-down state (create + status)."""
+    age_str = f"{age_s}s" if age_s is not None else "no file"
+    return (
+        f"WARNING: no recent worker heartbeat on this machine ({age_str}) — "
+        "session will stay pending until a worker is started "
+        "(run: ./scripts/valor-service.sh worker-start)"
+    )
 
 
 class ProjectsConfigUnavailableError(RuntimeError):
@@ -462,8 +520,9 @@ def cmd_create(args: argparse.Namespace) -> int:
 
         result = asyncio.run(_create())
 
-        # Check worker health after enqueue — warn if no active worker
+        # Check worker health after enqueue — warn if no recent heartbeat
         worker_healthy, worker_age_s = _check_worker_health()
+        worker_state = "ok" if worker_healthy else "down"
 
         if args.json:
             print(
@@ -474,6 +533,8 @@ def cmd_create(args: argparse.Namespace) -> int:
                         "project_key": project_key,
                         "model": model,
                         "worker_healthy": worker_healthy,
+                        "worker_state": worker_state,
+                        "worker_heartbeat_age_s": worker_age_s,
                     },
                     indent=2,
                 )
@@ -486,12 +547,8 @@ def cmd_create(args: argparse.Namespace) -> int:
                 print(f"  Model:       {model}")
             print(f"  Message: {message[:80]}")
             print(f"  Chat ID: {chat_id}")
-            if not worker_healthy:
-                print(
-                    "WARNING: no active worker detected — session will stay pending until a "
-                    "worker is started (run: ./scripts/valor-service.sh worker-start)",
-                    file=sys.stderr,
-                )
+            if worker_state == "down":
+                print(_worker_down_message(worker_age_s), file=sys.stderr)
         return 0
 
     except Exception as e:
@@ -697,10 +754,14 @@ def cmd_status(args: argparse.Namespace) -> int:
             return 1
         full_message = getattr(args, "full_message", False)
 
-        # Check worker health when session is pending
+        # Check worker health when session is pending (compute gate avoids the
+        # git subprocess on every status call; non-pending emits null fields)
         worker_healthy: bool | None = None
+        worker_age_s: int | None = None
+        worker_state: str | None = None
         if session.status == "pending":
-            worker_healthy, _ = _check_worker_health()
+            worker_healthy, worker_age_s = _check_worker_health()
+            worker_state = "ok" if worker_healthy else "down"
 
         if args.json:
             data = {
@@ -725,13 +786,16 @@ def cmd_status(args: argparse.Namespace) -> int:
             }
             if worker_healthy is not None:
                 data["worker_healthy"] = worker_healthy
+            # Unconditionally present — null when the session is not pending
+            data["worker_state"] = worker_state
+            data["worker_heartbeat_age_s"] = worker_age_s
             print(json.dumps(data, indent=2, default=str))
             return 0
 
         print(f"Session: {session.session_id}")
         print(f"  Status:        {session.status}")
-        if worker_healthy is False:
-            print("  WARNING: No active worker — session may wait indefinitely.", file=sys.stderr)
+        if worker_state == "down":
+            print(f"  {_worker_down_message(worker_age_s)}", file=sys.stderr)
         stype = getattr(session, "session_type", "—")
         print(f"  Type:          {stype}")
         print(f"  Auto-continue: {session.auto_continue_count}")

--- a/ui/app.py
+++ b/ui/app.py
@@ -17,7 +17,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
-from agent.constants import HEARTBEAT_STALENESS_THRESHOLD_S
+from agent.constants import HEARTBEAT_STALENESS_THRESHOLD_S, WORKER_DOWN_THRESHOLD_S
 from bridge.utc import utc_now
 
 logger = logging.getLogger(__name__)
@@ -329,7 +329,7 @@ def create_app() -> FastAPI:
                 # Bridge writes last_connected every ~5min in heartbeat loop
                 if age_s < HEARTBEAT_STALENESS_THRESHOLD_S:
                     return {"status": "ok", "age_s": age_s}
-                elif age_s < 600:
+                elif age_s < WORKER_DOWN_THRESHOLD_S:
                     return {"status": "running", "age_s": age_s}
                 else:
                     return {"status": "error", "age_s": age_s}
@@ -340,6 +340,7 @@ def create_app() -> FastAPI:
     def _get_worker_health() -> dict:
         """Check worker health from last_worker_connected file freshness."""
 
+        # TODO: migrate to _resolve_heartbeat_path if the UI ever runs from a worktree
         heartbeat_file = Path(__file__).parent.parent / "data" / "last_worker_connected"
         try:
             if heartbeat_file.exists():
@@ -347,7 +348,7 @@ def create_app() -> FastAPI:
                 age_s = round(time.time() - mtime)
                 if age_s < HEARTBEAT_STALENESS_THRESHOLD_S:
                     return {"status": "ok", "age_s": age_s}
-                elif age_s < 600:
+                elif age_s < WORKER_DOWN_THRESHOLD_S:
                     return {"status": "running", "age_s": age_s}
                 else:
                     return {"status": "error", "age_s": age_s}


### PR DESCRIPTION
## Summary

Hardens the `valor` CLI front door per `docs/plans/valor-cli-hardening.md` (closes #1619).

**Part 1 — alias shadowing.** New warn-only `check_valor_alias_shadow()` in the `/update` verify step: static scan of `~/.zshrc` for `^\s*alias\s+valor\s*=` on non-comment lines (no subprocess, no interactive shell, no `valor-*` false positives), with the line number and a copy-paste fix in the warning. The stale alias on this machine has been removed; other machines get the warning on their next `/update`.

**Part 2 — trustworthy worker pre-flight.** Root cause of the false "no active worker" warning was worktree path divergence: the CLI resolved the heartbeat file against its own `__file__`, so invocations from a worktree read a `data/` dir the worker never writes. Fixes:
- `_resolve_heartbeat_path()`: resolves via `git rev-parse --path-format=absolute --git-common-dir` (flag order matters), with a relative-output guard anchored to the repo root (never cwd) and a `__file__`-relative fallback on any git failure. Never raises (#980 contract). Also the test patch seam.
- Single 600s threshold via new `WORKER_DOWN_THRESHOLD_S` (2× the worker's 300s write cadence); the dashboard's `HEARTBEAT_STALENESS_THRESHOLD_S = 360` is untouched, and `ui/app.py`'s two bare `600` literals now use the named constant.
- `tools/agent_session_scheduler.py`'s duplicate inline check switched to the shared resolver + 600s — no more contradictory `worker_healthy` answers between CLIs.
- Honest warning text: `down` names the start command and never claims a created session won't run; both harmful strings are gone (`grep -rni "active worker" tools/ agent/ scripts/` exits 1).
- JSON contract for agent callers: `worker_state` ("ok"/"down") + `worker_heartbeat_age_s` in both `cmd_create` and `cmd_status` (unconditionally present in status; null when the pending-only compute is skipped). Negative ages from future mtimes clamp to 0.

**Part 3 — wrapper tests (verify-only).** `tests/unit/test_valor_cli.py` (23 tests) already exists on PR #1612's branch (commit `6e8de6d8`); spike-1 verified 23/23 green there. No new wrapper test file.

## Validation

- `tests/unit/test_worker_health_check.py` rewritten against the new seam: **13 passed** (includes real `git worktree` layout, relative-output guard with cwd elsewhere, git-failure fallback, future-mtime clamp)
- `tests/unit/test_update_valor_alias.py` (new): **8 passed**
- `tests/unit/test_valor_session_cli.py`: **11 passed** (guards the JSON changes)
- All 9 plan Verification table rows pass; ruff check + format clean
- Live smoke test from a worktree cwd: `worker_state: ok`, `worker_heartbeat_age_s: 94`, empty stderr (session created and cleaned up via Popoto)
- Docs updated: `session-management.md`, `session-steering.md`, `tools-reference.md`

## Merge ordering (Decision 1)

PR #1612 merges first, this PR immediately after. Three items are gated on #1612 landing and must run then:
1. Fresh-shell end-to-end `zsh -ic 'valor "smoke test" --json'` (the `valor` entry point lives on #1612's branch; alias removal verified now via `zsh -ic 'whence -w valor'` → `valor: none`)
2. On-main re-run of `pytest tests/unit/test_valor_cli.py -n0` (spike-1 evidence: 23/23 at `6e8de6d8`)
3. `docs/features/valor-cli-wrapper.md` shortcoming-item updates (file exists only on #1612's branch)

Plan: `docs/plans/valor-cli-hardening.md` · Critique rounds 1–2 on the issue (verdict: READY TO BUILD with concerns, 0 blockers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
