### PR TITLE
feat: granite CLI session visibility (dashboard, valor-session list, watchdog)

### DIFF
--- a/config/enums.py
+++ b/config/enums.py
@@ -15,11 +15,20 @@ from enum import StrEnum
 
 
 class SessionType(StrEnum):
-    """Discriminator for AgentSession: pm, teammate, or dev."""
+    """Discriminator for AgentSession: pm, teammate, dev, or granite.
+
+    ``GRANITE`` is used exclusively by the standalone ``valor-granite-loop``
+    CLI (``tools/granite_interactive_tui_poc/cli.py``). Bridge-originated
+    sessions that run through the granite PTY container are still typed as
+    ``PM`` or ``DEV`` — ``GRANITE`` labels only direct CLI invocations so
+    they appear in the dashboard and ``valor-session list`` without being
+    misclassified as bridge-originated sessions.
+    """
 
     PM = "pm"
     TEAMMATE = "teammate"
     DEV = "dev"
+    GRANITE = "granite"
 
 
 class PersonaType(StrEnum):

--- a/docs/features/granite-pty-production.md
+++ b/docs/features/granite-pty-production.md
@@ -231,6 +231,65 @@ harness path on incident:
    granite payloads; the drafter is idempotent on retried `[/user]` payloads.
 4. No manual flag toggling, no env var changes.
 
+## `valor-granite-loop` CLI AgentSession lifecycle
+
+The standalone `valor-granite-loop` CLI creates and finalizes an `AgentSession`
+record so its runs are visible in the dashboard and `valor-session list`.
+
+### Session creation (before container starts)
+
+Before `Container.run()` is called, `main()` mints a session and persists it:
+
+```python
+session_id = "local-" + uuid.uuid4().hex[:12]   # e.g. "local-a3f9b21c8d04"
+session = AgentSession.create_local(
+    session_id=session_id,
+    session_type=SessionType.GRANITE,
+    project_key="valor",
+    working_dir=args.cwd or os.getcwd(),
+)
+```
+
+**Why the `local-` prefix is required**: worker startup recovery
+(`agent/session_health.py:538`) discriminates by
+`session_id.startswith("local")`. A bare-hex id falls through to the bridge
+recovery path and would re-execute the CLI run as a bridge session on the next
+worker restart.
+
+**Why `session_type=SessionType.GRANITE`**: `create_local` defaults to
+`SESSION_TYPE_DEV`, which would silently mislabel the session. Granite CLI
+sessions carry `session_type="granite"` so `valor-session list --role granite`
+returns only CLI-originated runs, not bridge-originated dev sessions.
+
+### Session finalization (on exit)
+
+| Exit condition | Finalize status | Reason passed |
+|---|---|---|
+| `exit_reason in ("pm_complete", "pm_user")` | `completed` | `result.exit_reason` |
+| All other exit reasons | `failed` | `result.exit_reason` |
+| Unexpected exception in `container.run()` | `failed` | `repr(e)` |
+
+The except-block finalizes with `reject_from_terminal=False` to prevent a
+double-finalize raise if the post-run path already set the status to `failed`.
+
+### Operational IDs
+
+The stdout summary JSON contains two ID fields that serve different purposes:
+
+| Field | Value | Use |
+|---|---|---|
+| `agent_session_id` | The `local-`-prefixed record ID | `valor-session steer/kill/status --id` |
+| `session_id` | Container's internal trace artifact | Correlating turn traces in the results JSON |
+
+Use `agent_session_id` for all `valor-session` operations. Use `session_id` to
+look up the corresponding `ContainerResult` in the results file.
+
+### Best-effort guard
+
+Session persistence failures never affect the CLI exit code or results JSON
+output. A single `granite session not recorded: <reason>` line is emitted to
+stderr and execution continues normally.
+
 ## See also
 
 - [Granite Operator: Interactive TUI](granite-interactive-tui.md) — the PoC

--- a/docs/plans/granite_cli_agent_session_visibility.md
+++ b/docs/plans/granite_cli_agent_session_visibility.md
@@ -366,7 +366,7 @@ needed for the agent to "see" it.
 
 ## Success Criteria
 
-- [ ] `valor-granite-loop` creates a `running` AgentSession (session_id prefixed
+- [x] `valor-granite-loop` creates a `running` AgentSession (session_id prefixed
       `local-`, session_type `granite`) before the container runs and finalizes it
       `completed`/`failed` on exit.
 - [ ] The granite `session_id` starts with `local-` so worker startup recovery

--- a/tests/unit/granite_container/test_cli.py
+++ b/tests/unit/granite_container/test_cli.py
@@ -376,6 +376,13 @@ class TestMainAgentSessionLifecycle(unittest.TestCase):
         )
         self.assertEqual(kwargs["session_type"], "granite")
         self.assertEqual(kwargs["project_key"], "valor")
+        self.assertEqual(
+            kwargs.get("status"),
+            "running",
+            "create_local must be called with status='running' so the record is "
+            "visible to dashboard/valor-session-list/watchdog immediately; "
+            f"got status={kwargs.get('status')!r}",
+        )
         # container.run() must be called after create_local (run_order populated after create)
         self.assertIn("run", run_order, "container.run must be called")
 
@@ -509,7 +516,8 @@ class TestMainAgentSessionLifecycle(unittest.TestCase):
             self.assertEqual(
                 len(recorded_lines),
                 1,
-                f"expected exactly 1 stderr line about session not recorded, got: {stderr_output!r}",
+                "expected exactly 1 stderr line about session not recorded, "
+                f"got: {stderr_output!r}",
             )
             self.assertIn("Redis down", recorded_lines[0])
 

--- a/tests/unit/granite_container/test_cli.py
+++ b/tests/unit/granite_container/test_cli.py
@@ -5,15 +5,30 @@ runs the container, writes the results JSON, and prints a one-line
 summary. The tests patch `Container.run` to a known result and
 verify the CLI's argument parsing, exit code mapping, and JSON
 output shape.
+
+AgentSession lifecycle tests (added for issue #1571) patch
+``AgentSession.create_local`` and ``finalize_session`` so unit tests
+never need a live Redis instance. The lifecycle assertions verify:
+
+- A ``running`` session is created before ``container.run()``.
+- The session is finalized ``completed`` for pm_complete/pm_user and
+  ``failed`` for all other exit reasons.
+- An empty ``--user-message`` skips session creation entirely.
+- A Redis failure in ``create_local`` does not affect exit codes or
+  results JSON (best-effort guard).
+- A double-finalize (post-run sets status, then except-block calls
+  finalize again with reject_from_terminal=False) does not raise.
 """
 
 from __future__ import annotations
 
+import io
 import json
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from agent.granite_container.container import ContainerResult
 from tools.granite_interactive_tui_poc.cli import _build_arg_parser, main
@@ -27,6 +42,14 @@ def _fake_result(exit_reason: str = "pm_complete") -> ContainerResult:
         exit_reason=exit_reason,
         exit_message="test",
     )
+
+
+def _make_fake_session(agent_session_id: str = "fake-agent-session-id") -> MagicMock:
+    """Build a minimal fake AgentSession for lifecycle assertions."""
+    session = MagicMock()
+    session.agent_session_id = agent_session_id
+    session.status = "running"
+    return session
 
 
 class TestArgParser(unittest.TestCase):
@@ -74,15 +97,27 @@ class TestArgParser(unittest.TestCase):
 
 
 class TestMainRejectsEmpty(unittest.TestCase):
-    """The CLI rejects empty user messages with exit code 5."""
+    """The CLI rejects empty user messages with exit code 5.
+
+    Empty messages return before session creation — no AgentSession
+    should be created or finalized.
+    """
 
     def test_whitespace_only(self) -> None:
-        rc = main(["--user-message", "  "])
+        with patch(
+            "tools.granite_interactive_tui_poc.cli.AgentSession.create_local"
+        ) as mock_create:
+            rc = main(["--user-message", "  "])
         self.assertEqual(rc, 5)
+        mock_create.assert_not_called()
 
     def test_empty_string(self) -> None:
-        rc = main(["--user-message", ""])
+        with patch(
+            "tools.granite_interactive_tui_poc.cli.AgentSession.create_local"
+        ) as mock_create:
+            rc = main(["--user-message", ""])
         self.assertEqual(rc, 5)
+        mock_create.assert_not_called()
 
 
 class TestMainRunPath(unittest.TestCase):
@@ -91,7 +126,15 @@ class TestMainRunPath(unittest.TestCase):
     def test_pm_complete_writes_json_and_exits_0(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             out_path = Path(tmp) / "results.json"
-            with patch("agent.granite_container.container.Container.run") as mock_run:
+            fake_session = _make_fake_session()
+            with (
+                patch(
+                    "tools.granite_interactive_tui_poc.cli.AgentSession.create_local",
+                    return_value=fake_session,
+                ),
+                patch("tools.granite_interactive_tui_poc.cli.finalize_session"),
+                patch("agent.granite_container.container.Container.run") as mock_run,
+            ):
                 mock_run.return_value = _fake_result("pm_complete")
                 rc = main(
                     [
@@ -113,7 +156,15 @@ class TestMainRunPath(unittest.TestCase):
         # exception fallback.
         with tempfile.TemporaryDirectory() as tmp:
             out_path = Path(tmp) / "results.json"
-            with patch("agent.granite_container.container.Container.run") as mock_run:
+            fake_session = _make_fake_session()
+            with (
+                patch(
+                    "tools.granite_interactive_tui_poc.cli.AgentSession.create_local",
+                    return_value=fake_session,
+                ),
+                patch("tools.granite_interactive_tui_poc.cli.finalize_session"),
+                patch("agent.granite_container.container.Container.run") as mock_run,
+            ):
                 mock_run.return_value = _fake_result("pm_user")
                 rc = main(
                     [
@@ -130,7 +181,15 @@ class TestMainRunPath(unittest.TestCase):
     def test_pm_max_turns_exits_1(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             out_path = Path(tmp) / "results.json"
-            with patch("agent.granite_container.container.Container.run") as mock_run:
+            fake_session = _make_fake_session()
+            with (
+                patch(
+                    "tools.granite_interactive_tui_poc.cli.AgentSession.create_local",
+                    return_value=fake_session,
+                ),
+                patch("tools.granite_interactive_tui_poc.cli.finalize_session"),
+                patch("agent.granite_container.container.Container.run") as mock_run,
+            ):
                 mock_run.return_value = _fake_result("pm_max_turns")
                 rc = main(
                     [
@@ -145,7 +204,15 @@ class TestMainRunPath(unittest.TestCase):
     def test_dev_hang_exits_2(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             out_path = Path(tmp) / "results.json"
-            with patch("agent.granite_container.container.Container.run") as mock_run:
+            fake_session = _make_fake_session()
+            with (
+                patch(
+                    "tools.granite_interactive_tui_poc.cli.AgentSession.create_local",
+                    return_value=fake_session,
+                ),
+                patch("tools.granite_interactive_tui_poc.cli.finalize_session"),
+                patch("agent.granite_container.container.Container.run") as mock_run,
+            ):
                 mock_run.return_value = _fake_result("dev_hang")
                 rc = main(
                     [
@@ -160,7 +227,15 @@ class TestMainRunPath(unittest.TestCase):
     def test_pm_hang_exits_2(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             out_path = Path(tmp) / "results.json"
-            with patch("agent.granite_container.container.Container.run") as mock_run:
+            fake_session = _make_fake_session()
+            with (
+                patch(
+                    "tools.granite_interactive_tui_poc.cli.AgentSession.create_local",
+                    return_value=fake_session,
+                ),
+                patch("tools.granite_interactive_tui_poc.cli.finalize_session"),
+                patch("agent.granite_container.container.Container.run") as mock_run,
+            ):
                 mock_run.return_value = _fake_result("pm_hang")
                 rc = main(
                     [
@@ -175,7 +250,15 @@ class TestMainRunPath(unittest.TestCase):
     def test_startup_unresolved_exits_3(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             out_path = Path(tmp) / "results.json"
-            with patch("agent.granite_container.container.Container.run") as mock_run:
+            fake_session = _make_fake_session()
+            with (
+                patch(
+                    "tools.granite_interactive_tui_poc.cli.AgentSession.create_local",
+                    return_value=fake_session,
+                ),
+                patch("tools.granite_interactive_tui_poc.cli.finalize_session"),
+                patch("agent.granite_container.container.Container.run") as mock_run,
+            ):
                 mock_run.return_value = _fake_result("startup_unresolved")
                 rc = main(
                     [
@@ -190,7 +273,15 @@ class TestMainRunPath(unittest.TestCase):
     def test_exception_exits_4(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             out_path = Path(tmp) / "results.json"
-            with patch("agent.granite_container.container.Container.run") as mock_run:
+            fake_session = _make_fake_session()
+            with (
+                patch(
+                    "tools.granite_interactive_tui_poc.cli.AgentSession.create_local",
+                    return_value=fake_session,
+                ),
+                patch("tools.granite_interactive_tui_poc.cli.finalize_session"),
+                patch("agent.granite_container.container.Container.run") as mock_run,
+            ):
                 mock_run.return_value = _fake_result("exception")
                 rc = main(
                     [
@@ -207,12 +298,17 @@ class TestMainStdoutSummary(unittest.TestCase):
     """The CLI prints a one-line JSON summary to stdout."""
 
     def test_summary_emitted(self) -> None:
-        import io
-        from contextlib import redirect_stdout
-
         with tempfile.TemporaryDirectory() as tmp:
             out_path = Path(tmp) / "results.json"
-            with patch("agent.granite_container.container.Container.run") as mock_run:
+            fake_session = _make_fake_session("test-agent-session-xyz")
+            with (
+                patch(
+                    "tools.granite_interactive_tui_poc.cli.AgentSession.create_local",
+                    return_value=fake_session,
+                ),
+                patch("tools.granite_interactive_tui_poc.cli.finalize_session"),
+                patch("agent.granite_container.container.Container.run") as mock_run,
+            ):
                 mock_run.return_value = _fake_result("pm_complete")
                 buf = io.StringIO()
                 with redirect_stdout(buf):
@@ -230,6 +326,270 @@ class TestMainStdoutSummary(unittest.TestCase):
             self.assertEqual(payload["session_id"], "cli-test")
             self.assertEqual(payload["turns"], 0)
             self.assertIn("output_path", payload)
+            # agent_session_id from the created session record
+            self.assertEqual(payload["agent_session_id"], "test-agent-session-xyz")
+
+
+class TestMainAgentSessionLifecycle(unittest.TestCase):
+    """AgentSession is created before container.run() and finalized on exit."""
+
+    def test_session_created_before_run_with_correct_fields(self) -> None:
+        """A running AgentSession is minted before container.run() is called.
+
+        - session_id starts with 'local-'
+        - session_type is 'granite'
+        - project_key is 'valor'
+        """
+        create_calls: list[dict] = []
+
+        def _capture_create(**kwargs):
+            create_calls.append(kwargs)
+            return _make_fake_session()
+
+        run_order: list[str] = []
+
+        def _track_run(self):
+            run_order.append("run")
+            return _fake_result("pm_complete")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out_path = Path(tmp) / "results.json"
+            with (
+                patch(
+                    "tools.granite_interactive_tui_poc.cli.AgentSession.create_local",
+                    side_effect=_capture_create,
+                ),
+                patch("tools.granite_interactive_tui_poc.cli.finalize_session"),
+                patch(
+                    "agent.granite_container.container.Container.run",
+                    _track_run,
+                ),
+            ):
+                rc = main(["--user-message", "hello", "--output", str(out_path)])
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(create_calls), 1, "create_local must be called exactly once")
+        kwargs = create_calls[0]
+        self.assertTrue(
+            kwargs["session_id"].startswith("local-"),
+            f"session_id must start with 'local-', got {kwargs['session_id']!r}",
+        )
+        self.assertEqual(kwargs["session_type"], "granite")
+        self.assertEqual(kwargs["project_key"], "valor")
+        # container.run() must be called after create_local (run_order populated after create)
+        self.assertIn("run", run_order, "container.run must be called")
+
+    def test_session_finalized_completed_for_pm_complete(self) -> None:
+        """pm_complete exit_reason finalizes the session as 'completed'."""
+        fake_session = _make_fake_session()
+        finalize_calls: list[tuple] = []
+
+        def _capture_finalize(session, status, reason="", **kwargs):
+            finalize_calls.append((session, status, reason))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out_path = Path(tmp) / "results.json"
+            with (
+                patch(
+                    "tools.granite_interactive_tui_poc.cli.AgentSession.create_local",
+                    return_value=fake_session,
+                ),
+                patch(
+                    "tools.granite_interactive_tui_poc.cli.finalize_session",
+                    side_effect=_capture_finalize,
+                ),
+                patch("agent.granite_container.container.Container.run") as mock_run,
+            ):
+                mock_run.return_value = _fake_result("pm_complete")
+                main(["--user-message", "hello", "--output", str(out_path)])
+
+        self.assertEqual(len(finalize_calls), 1)
+        _, status, reason = finalize_calls[0]
+        self.assertEqual(status, "completed")
+        self.assertEqual(reason, "pm_complete")
+
+    def test_session_finalized_completed_for_pm_user(self) -> None:
+        """pm_user exit_reason also finalizes the session as 'completed'."""
+        fake_session = _make_fake_session()
+        finalize_calls: list[tuple] = []
+
+        def _capture_finalize(session, status, reason="", **kwargs):
+            finalize_calls.append((session, status, reason))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out_path = Path(tmp) / "results.json"
+            with (
+                patch(
+                    "tools.granite_interactive_tui_poc.cli.AgentSession.create_local",
+                    return_value=fake_session,
+                ),
+                patch(
+                    "tools.granite_interactive_tui_poc.cli.finalize_session",
+                    side_effect=_capture_finalize,
+                ),
+                patch("agent.granite_container.container.Container.run") as mock_run,
+            ):
+                mock_run.return_value = _fake_result("pm_user")
+                main(["--user-message", "hello", "--output", str(out_path)])
+
+        self.assertEqual(len(finalize_calls), 1)
+        _, status, _ = finalize_calls[0]
+        self.assertEqual(status, "completed")
+
+    def test_session_finalized_failed_for_non_clean_exit_reasons(self) -> None:
+        """dev_hang, pm_max_turns, startup_unresolved, exception → 'failed'."""
+        non_clean = ["dev_hang", "pm_max_turns", "pm_hang", "startup_unresolved", "exception"]
+        for exit_reason in non_clean:
+            with self.subTest(exit_reason=exit_reason):
+                fake_session = _make_fake_session()
+                finalize_calls: list[tuple] = []
+
+                def _capture_finalize(session, status, reason="", **kwargs):
+                    finalize_calls.append((session, status, reason))
+
+                with tempfile.TemporaryDirectory() as tmp:
+                    out_path = Path(tmp) / "results.json"
+                    with (
+                        patch(
+                            "tools.granite_interactive_tui_poc.cli.AgentSession.create_local",
+                            return_value=fake_session,
+                        ),
+                        patch(
+                            "tools.granite_interactive_tui_poc.cli.finalize_session",
+                            side_effect=_capture_finalize,
+                        ),
+                        patch("agent.granite_container.container.Container.run") as mock_run,
+                    ):
+                        mock_run.return_value = _fake_result(exit_reason)
+                        main(["--user-message", "hello", "--output", str(out_path)])
+
+                self.assertEqual(len(finalize_calls), 1, f"exit_reason={exit_reason}")
+                _, status, _ = finalize_calls[0]
+                self.assertEqual(
+                    status, "failed", f"exit_reason={exit_reason} should finalize as failed"
+                )
+
+    def test_persistence_failure_does_not_change_exit_code(self) -> None:
+        """When create_local raises, the CLI exits normally with exit code 0.
+
+        - exit code is unchanged
+        - results JSON is still written
+        - exactly one stderr line: 'granite session not recorded: <reason>'
+        """
+        import sys as _sys
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out_path = Path(tmp) / "results.json"
+            stderr_buf = io.StringIO()
+            with (
+                patch(
+                    "tools.granite_interactive_tui_poc.cli.AgentSession.create_local",
+                    side_effect=ConnectionError("Redis down"),
+                ),
+                patch("tools.granite_interactive_tui_poc.cli.finalize_session"),
+                patch("agent.granite_container.container.Container.run") as mock_run,
+            ):
+                mock_run.return_value = _fake_result("pm_complete")
+                old_stderr = _sys.stderr
+                _sys.stderr = stderr_buf
+                try:
+                    rc = main(["--user-message", "hello", "--output", str(out_path)])
+                finally:
+                    _sys.stderr = old_stderr
+
+            self.assertEqual(rc, 0, "persistence failure must not change exit code")
+            self.assertTrue(out_path.exists(), "results JSON must still be written")
+            stderr_output = stderr_buf.getvalue()
+            # Exactly one 'granite session not recorded' line on stderr
+            recorded_lines = [
+                line
+                for line in stderr_output.splitlines()
+                if "granite session not recorded" in line
+            ]
+            self.assertEqual(
+                len(recorded_lines),
+                1,
+                f"expected exactly 1 stderr line about session not recorded, got: {stderr_output!r}",
+            )
+            self.assertIn("Redis down", recorded_lines[0])
+
+    def test_persistence_failure_does_not_affect_stdout_json(self) -> None:
+        """When create_local raises, the stdout JSON shape is unchanged."""
+        with tempfile.TemporaryDirectory() as tmp:
+            out_path = Path(tmp) / "results.json"
+            with (
+                patch(
+                    "tools.granite_interactive_tui_poc.cli.AgentSession.create_local",
+                    side_effect=RuntimeError("no redis"),
+                ),
+                patch("tools.granite_interactive_tui_poc.cli.finalize_session"),
+                patch("agent.granite_container.container.Container.run") as mock_run,
+            ):
+                mock_run.return_value = _fake_result("pm_complete")
+                buf = io.StringIO()
+                import sys as _sys
+
+                old_stderr = _sys.stderr
+                _sys.stderr = io.StringIO()  # suppress stderr in test output
+                try:
+                    with redirect_stdout(buf):
+                        main(["--user-message", "hello", "--output", str(out_path)])
+                finally:
+                    _sys.stderr = old_stderr
+
+        payload = json.loads(buf.getvalue().strip())
+        self.assertEqual(payload["exit_reason"], "pm_complete")
+        self.assertEqual(payload["session_id"], "cli-test")
+        # agent_session_id is None when create_local failed
+        self.assertIsNone(payload["agent_session_id"])
+
+    def test_double_finalize_does_not_raise(self) -> None:
+        """When container.run() raises after post-run finalize sets failed,
+        the except-block finalize with reject_from_terminal=False is a no-op.
+
+        Simulates the double-finalize path: post-run finalize sets 'failed',
+        then the except-block tries to finalize again. This must not raise.
+        """
+        from models.session_lifecycle import StatusConflictError
+
+        fake_session = _make_fake_session()
+        call_count = [0]
+
+        def _finalize_raises_on_second(session, status, reason="", **kwargs):
+            call_count[0] += 1
+            if call_count[0] >= 2 and kwargs.get("reject_from_terminal") is False:
+                # reject_from_terminal=False path should not raise even if
+                # the session is already terminal — this tests the guard.
+                return
+            if call_count[0] >= 2:
+                raise StatusConflictError(
+                    session_id="fake",
+                    expected_status="running",
+                    actual_status="failed",
+                    reason="already terminal",
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out_path = Path(tmp) / "results.json"
+            with (
+                patch(
+                    "tools.granite_interactive_tui_poc.cli.AgentSession.create_local",
+                    return_value=fake_session,
+                ),
+                patch(
+                    "tools.granite_interactive_tui_poc.cli.finalize_session",
+                    side_effect=_finalize_raises_on_second,
+                ),
+                patch(
+                    "agent.granite_container.container.Container.run",
+                    side_effect=RuntimeError("boom"),
+                ),
+            ):
+                # Must not propagate any exception
+                rc = main(["--user-message", "hello", "--output", str(out_path)])
+
+        # The except-block returns exit 4, so the rc must be 4 (not a crash)
+        self.assertEqual(rc, 4)
 
 
 if __name__ == "__main__":

--- a/tools/granite_interactive_tui_poc/cli.py
+++ b/tools/granite_interactive_tui_poc/cli.py
@@ -132,6 +132,7 @@ def main(argv: list[str] | None = None) -> int:
             session_type=SessionType.GRANITE,
             project_key="valor",
             working_dir=working_dir,
+            status="running",
         )
     except Exception as e:
         print(f"granite session not recorded: {e}", file=sys.stderr)

--- a/tools/granite_interactive_tui_poc/cli.py
+++ b/tools/granite_interactive_tui_poc/cli.py
@@ -9,6 +9,26 @@ does not wire to the bridge, does not dispatch child sessions, and
 does not invoke /sdlc. The PoC is local to the dev machine; the
 operator invokes it directly.
 
+AgentSession lifecycle
+----------------------
+Before the container starts, ``main()`` mints a ``local-``-prefixed
+session ID and creates a ``running`` AgentSession record in Redis
+(session_type=``granite``, project_key=``valor``). On clean exit the
+session is finalized as ``completed`` (exit_reason in
+{pm_complete, pm_user}) or ``failed`` (all other exit reasons). On
+unexpected exception the session is also finalized as ``failed``
+with ``reject_from_terminal=False`` to prevent a double-finalize
+raise if the post-run path already set the status.
+
+Session persistence is best-effort: a Redis failure prints exactly
+one ``granite session not recorded: <reason>`` line to stderr and
+the CLI proceeds normally. Exit codes and results JSON are never
+affected by a persistence failure.
+
+The ``agent_session_id`` field in the stdout summary JSON is the
+operational ID for ``valor-session`` operations (steer/kill). The
+``session_id`` field is the container's internal trace artifact.
+
 Usage:
     valor-granite-loop --user-message "Build a CLI todo app"
     valor-granite-loop --user-message "Plan a 3-step architecture" \\
@@ -20,10 +40,15 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import sys
+import uuid
 from pathlib import Path
 
 from agent.granite_container.container import Container, result_to_json
+from config.enums import SessionType
+from models.agent_session import AgentSession
+from models.session_lifecycle import finalize_session
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +117,25 @@ def main(argv: list[str] | None = None) -> int:
         print("valor-granite-loop: --user-message must be non-empty", file=sys.stderr)
         return 5
 
+    # Mint a local- prefixed session ID. The local- prefix is REQUIRED:
+    # worker startup recovery (agent/session_health.py:538) discriminates by
+    # session_id.startswith("local") to avoid re-executing CLI sessions as
+    # bridge sessions. A bare-hex id would fall through to the bridge recovery
+    # path and could re-execute this run.
+    session_id = "local-" + uuid.uuid4().hex[:12]
+    working_dir = args.cwd or os.getcwd()
+
+    session: AgentSession | None = None
+    try:
+        session = AgentSession.create_local(
+            session_id=session_id,
+            session_type=SessionType.GRANITE,
+            project_key="valor",
+            working_dir=working_dir,
+        )
+    except Exception as e:
+        print(f"granite session not recorded: {e}", file=sys.stderr)
+
     try:
         container = Container(
             user_message=args.user_message,
@@ -103,11 +147,29 @@ def main(argv: list[str] | None = None) -> int:
         result = container.run()
     except ValueError as e:
         print(f"valor-granite-loop: {e}", file=sys.stderr)
+        if session is not None:
+            try:
+                finalize_session(session, "failed", reason=repr(e), reject_from_terminal=False)
+            except Exception as fe:
+                logger.warning("granite session not recorded: %s", fe)
         return 5
     except Exception as e:
         logger.exception("container.run failed: %s", e)
         print(f"valor-granite-loop: container.run failed: {e}", file=sys.stderr)
+        if session is not None:
+            try:
+                finalize_session(session, "failed", reason=repr(e), reject_from_terminal=False)
+            except Exception as fe:
+                logger.warning("granite session not recorded: %s", fe)
         return 4
+
+    # Finalize the session based on exit_reason.
+    if session is not None:
+        try:
+            status = "completed" if result.exit_reason in ("pm_complete", "pm_user") else "failed"
+            finalize_session(session, status, reason=result.exit_reason)
+        except Exception as e:
+            logger.warning("granite session not recorded: %s", e)
 
     # Write the results JSON.
     try:
@@ -121,6 +183,7 @@ def main(argv: list[str] | None = None) -> int:
     print(
         json.dumps(
             {
+                "agent_session_id": session.agent_session_id if session is not None else None,
                 "session_id": result.session_id,
                 "exit_reason": result.exit_reason,
                 "turns": len(result.turns),


### PR DESCRIPTION
## Summary

Wires `AgentSession` create/finalize into the `valor-granite-loop` standalone CLI so granite runs are visible to the dashboard, `valor-session list`, and watchdog coverage. The production/bridge path was already covered by #1612; this fix closes the remaining gap for the CLI-only path.

## Changes

- `config/enums.py` — adds `SessionType.GRANITE = "granite"` with docstring note
- `tools/granite_interactive_tui_poc/cli.py` — mints `session_id = "local-" + uuid.uuid4().hex[:12]` (the `local-` prefix is load-bearing for worker startup recovery safety), creates a `running` AgentSession before `container.run()`, finalizes `completed`/`failed` on exit with best-effort guards
- `tests/unit/granite_container/test_cli.py` — 7 new lifecycle assertion tests: session creation fields, finalization statuses, empty-message no-session path, persistence-failure best-effort behavior, double-finalize safety
- `docs/features/granite-pty-production.md` — new `valor-granite-loop CLI AgentSession lifecycle` section documenting the operational ID distinction (`agent_session_id` vs `session_id`)

## Testing

- [x] Unit tests passing: `pytest tests/unit/granite_container/test_cli.py tests/unit/test_session_executor_granite.py` — 23 passed
- [x] Lint clean: `python -m ruff check tools/granite_interactive_tui_poc/ config/enums.py`
- [x] All 7 verification checks pass (validate_build.py)

## Documentation

- [x] `docs/features/granite-pty-production.md` updated with CLI AgentSession lifecycle section
- [x] CLI module docstring updated to reflect new lifecycle

## Definition of Done

- [x] Built: Code implemented and working
- [x] Tested: All tests passing
- [x] Documented: Docs created/updated
- [x] Quality: Lint and format checks pass

Closes #1571