### PR TITLE
fix(session-cleanup): guard branch deletion against unmerged commits

### DIFF
--- a/agent/session_executor.py
+++ b/agent/session_executor.py
@@ -5,7 +5,6 @@ import asyncio
 import logging
 import os  # noqa: F401
 import re
-import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -23,7 +22,10 @@ from agent.session_state import (
     SessionHandle,
     _active_sessions,
 )
-from agent.worktree_manager import WORKTREES_DIR, validate_workspace
+from agent.worktree_manager import (
+    WORKTREES_DIR,
+    validate_workspace,
+)
 from config.enums import SessionType
 from config.settings import settings
 from models.agent_session import AgentSession
@@ -2011,19 +2013,41 @@ async def _execute_agent_session(session: AgentSession) -> None:
         if not task.error and not chat_state.defer_reaction:
             try:
                 from agent.branch_manager import mark_work_done
+                from agent.worktree_manager import (  # noqa: PLC0415
+                    merged_via_ancestor,
+                    safe_delete_branch,
+                )
 
                 mark_work_done(working_dir, branch_name)
-                # Also delete the session branch to keep git clean
-                subprocess.run(
-                    ["git", "branch", "-D", branch_name],
-                    cwd=working_dir,
-                    capture_output=True,
-                    timeout=10,
+                # Also delete the session branch to keep git clean — guarded by
+                # the unmerged-branch guard (issue #1646): use merged_via_ancestor
+                # since this path runs at session completion before any PR merge.
+                branch_del = safe_delete_branch(
+                    str(working_dir),
+                    branch_name,
+                    predicate=merged_via_ancestor,
+                    force=False,
                 )
-                logger.info(
-                    f"[{session.project_key}] Auto-marked session done "
-                    f"and cleaned up branch {branch_name}"
-                )
+                if branch_del["deleted"]:
+                    logger.info(
+                        f"[{session.project_key}] Auto-marked session done "
+                        f"and cleaned up branch {branch_name}"
+                    )
+                elif branch_del["skipped_unmerged"]:
+                    logger.warning(
+                        "[unmerged-branch-guard] branch '%s' preserved"
+                        " — work not yet merged to main",
+                        branch_name,
+                    )
+                    logger.info(
+                        f"[{session.project_key}] Auto-marked session done "
+                        f"(branch {branch_name} preserved — unmerged)"
+                    )
+                else:
+                    logger.info(
+                        f"[{session.project_key}] Auto-marked session done "
+                        f"(branch {branch_name} cleanup error: {branch_del.get('error')})"
+                    )
             except Exception as e:
                 logger.warning(f"[{session.project_key}] Failed to auto-mark session done: {e}")
 

--- a/agent/session_revival.py
+++ b/agent/session_revival.py
@@ -7,6 +7,7 @@ import time
 from pathlib import Path
 
 from agent.branch_manager import get_branch_state, get_plan_context, sanitize_branch_name
+from agent.worktree_manager import merged_via_tree, safe_delete_branch
 from models.agent_session import AgentSession
 from models.session_lifecycle import TERMINAL_STATUSES as _TERMINAL_STATUSES
 
@@ -228,14 +229,29 @@ async def cleanup_stale_branches(working_dir: str, max_age_hours: float = 72) ->
             age_hours = (time.time() - last_commit_ts) / 3600
 
             if age_hours > max_age_hours:
-                subprocess.run(
-                    ["git", "branch", "-D", branch],
-                    cwd=wd,
-                    capture_output=True,
-                    timeout=10,
+                # Guard deletion against unmerged commits (issue #1646)
+                branch_del = safe_delete_branch(
+                    str(wd),
+                    branch,
+                    predicate=merged_via_tree,
+                    force=True,
                 )
-                cleaned.append(branch)
-                logger.info(f"Cleaned stale branch: {branch} (age: {age_hours:.1f}h)")
+                if branch_del["deleted"]:
+                    cleaned.append(branch)
+                    logger.info(f"Cleaned stale branch: {branch} (age: {age_hours:.1f}h)")
+                elif branch_del["skipped_unmerged"]:
+                    logger.warning(
+                        "[unmerged-branch-guard] stale branch '%s' preserved"
+                        " — unmerged commits (age: %.1fh)",
+                        branch,
+                        age_hours,
+                    )
+                else:
+                    logger.warning(
+                        "Failed to delete stale branch %s: %s",
+                        branch,
+                        branch_del.get("error"),
+                    )
 
     except Exception as e:
         logger.error(f"Branch cleanup error: {e}")

--- a/agent/worktree_manager.py
+++ b/agent/worktree_manager.py
@@ -17,6 +17,203 @@ logger = logging.getLogger(__name__)
 WORKTREES_DIR = ".worktrees"
 VALID_SLUG_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
 
+# ---------------------------------------------------------------------------
+# Unmerged-branch guard (issue #1646)
+# ---------------------------------------------------------------------------
+
+_preserved_branch_count = 0  # restart-fragile counter; supplemented by live git branch --list
+
+
+def merged_via_ancestor(repo_root: str, branch: str, base: str = "main") -> bool:
+    """Return True iff branch tip is a git ancestor of base (non-squash merges only)."""
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", branch, base],
+        cwd=repo_root,
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def merged_via_tree(repo_root: str, branch: str, base: str = "main") -> bool:
+    """Return True iff merging branch into base is a no-op (squash-safe oracle).
+
+    Uses git merge-tree --write-tree: landed iff exit 0 AND result tree == base^{tree}.
+    Robust to main advancing past the squash commit. Requires git >= 2.38.
+    """
+    try:
+        # Get base tree oid
+        base_tree = subprocess.run(
+            ["git", "rev-parse", f"{base}^{{tree}}"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
+        if base_tree.returncode != 0:
+            return False
+        base_tree_oid = base_tree.stdout.strip()
+
+        # Run merge-tree
+        merge_result = subprocess.run(
+            ["git", "merge-tree", "--write-tree", base, branch],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
+        if merge_result.returncode != 0:
+            # Conflict or other error — not landed
+            return False
+
+        result_tree_oid = merge_result.stdout.strip()
+        return result_tree_oid == base_tree_oid
+    except Exception:
+        return False
+
+
+def _resolve_base(repo_root: str, base: str = "main") -> str | None:
+    """Resolve base branch name; fall back to origin/HEAD default branch."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", base],
+        cwd=repo_root,
+        capture_output=True,
+    )
+    if result.returncode == 0:
+        return base
+    # Try origin/HEAD
+    result2 = subprocess.run(
+        ["git", "symbolic-ref", "refs/remotes/origin/HEAD"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if result2.returncode == 0:
+        ref = result2.stdout.strip()
+        return ref.split("/")[-1] if "/" in ref else None
+    return None
+
+
+def safe_delete_branch(
+    repo_root: str,
+    branch_name: str,
+    *,
+    base: str = "main",
+    predicate,
+    force: bool = False,
+) -> dict:
+    """Delete branch only if merged per predicate; preserve and log if not.
+
+    Args:
+        repo_root: Path to git repo root.
+        branch_name: Branch to delete.
+        base: Base branch to check against (default "main").
+        predicate: Callable(repo_root, branch, base) -> bool; True = landed, safe to delete.
+        force: If True, use git branch -D (needed for squash-merged branches); else -d.
+
+    Returns:
+        dict with keys:
+          - deleted: bool
+          - skipped_unmerged: bool
+          - branch: str (the branch name)
+          - error: str | None
+    """
+    global _preserved_branch_count
+
+    resolved_base = _resolve_base(repo_root, base)
+    if resolved_base is None:
+        logger.warning(
+            "[unmerged-branch-guard] cannot resolve base '%s' for branch '%s'"
+            " — refusing deletion (fail-safe)",
+            base,
+            branch_name,
+        )
+        _preserved_branch_count += 1
+        _log_preserved_count(repo_root)
+        return {
+            "deleted": False,
+            "skipped_unmerged": True,
+            "branch": branch_name,
+            "error": f"cannot resolve base '{base}'",
+        }
+
+    try:
+        landed = predicate(repo_root, branch_name, resolved_base)
+    except Exception as e:
+        logger.warning(
+            "[unmerged-branch-guard] predicate error for branch '%s': %s"
+            " — refusing deletion (fail-safe)",
+            branch_name,
+            e,
+        )
+        _preserved_branch_count += 1
+        _log_preserved_count(repo_root)
+        return {
+            "deleted": False,
+            "skipped_unmerged": True,
+            "branch": branch_name,
+            "error": str(e),
+        }
+
+    if not landed:
+        _preserved_branch_count += 1
+        live_count = _count_live_session_branches(repo_root)
+        logger.warning(
+            "[unmerged-branch-guard] branch '%s' has unmerged commits"
+            " — preserving (preserved=%d, live session/* branches=%s)",
+            branch_name,
+            _preserved_branch_count,
+            live_count,
+        )
+        _log_preserved_count(repo_root)
+        return {
+            "deleted": False,
+            "skipped_unmerged": True,
+            "branch": branch_name,
+            "error": None,
+        }
+
+    # Branch is landed — delete it
+    flag = "-D" if force else "-d"
+    result = subprocess.run(
+        ["git", "branch", flag, branch_name],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return {"deleted": True, "skipped_unmerged": False, "branch": branch_name, "error": None}
+    else:
+        err = result.stderr.strip()
+        logger.warning(
+            "[unmerged-branch-guard] git branch %s '%s' failed: %s", flag, branch_name, err
+        )
+        return {"deleted": False, "skipped_unmerged": False, "branch": branch_name, "error": err}
+
+
+def _count_live_session_branches(repo_root: str) -> str:
+    """Count live session/* branches via git for the observability line."""
+    try:
+        result = subprocess.run(
+            ["git", "branch", "--list", "session/*"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+            return str(len(lines))
+    except Exception:
+        pass
+    return "unknown"
+
+
+def _log_preserved_count(repo_root: str) -> None:
+    """Emit a greppable preserved=N summary with live branch count."""
+    live_count = _count_live_session_branches(repo_root)
+    logger.warning(
+        "[unmerged-branch-guard] preserved=%d (live session/* branches=%s)",
+        _preserved_branch_count,
+        live_count,
+    )
+
 
 class WorktreeBranchMismatchError(RuntimeError):
     """Raised when a reused worktree's HEAD does not match the expected branch
@@ -878,13 +1075,23 @@ def remove_worktree(
         return False
 
     if delete_branch:
-        subprocess.run(
-            ["git", "branch", "-D", branch_name],
-            cwd=repo_root,
-            capture_output=True,
-            timeout=10,
+        branch_result = safe_delete_branch(
+            str(repo_root),
+            branch_name,
+            predicate=merged_via_tree,
+            force=True,
         )
-        logger.info(f"Deleted branch: {branch_name}")
+        if branch_result["deleted"]:
+            logger.info(f"Deleted branch: {branch_name}")
+        elif branch_result["skipped_unmerged"]:
+            logger.warning(
+                "[unmerged-branch-guard] branch '%s' preserved — work not yet merged to main",
+                branch_name,
+            )
+        else:
+            logger.warning(
+                "Failed to delete branch %s: %s", branch_name, branch_result.get("error")
+            )
 
     return True
 
@@ -1155,9 +1362,14 @@ def cleanup_after_merge(repo_root: Path, slug: str) -> dict:
     this function removes the local worktree and branch that would
     otherwise block deletion.
 
+    The branch deletion is guarded by the unmerged-branch guard (issue #1646):
+    safe_delete_branch verifies the merged precondition (via merged_via_tree) before
+    deleting. If the branch has unmerged commits, it is preserved and
+    skipped_unmerged=True is set in the result.
+
     Safe to call in any state:
-    - Worktree exists + branch exists: removes both
-    - Worktree already removed + branch exists: deletes branch
+    - Worktree exists + branch exists: removes both (if merged)
+    - Worktree already removed + branch exists: deletes branch (if merged)
     - Everything already cleaned up: no-op
 
     Args:
@@ -1171,6 +1383,7 @@ def cleanup_after_merge(repo_root: Path, slug: str) -> dict:
         - slug: The slug that was cleaned up
         - worktree_removed: True if a worktree was removed
         - branch_deleted: True if a local branch was deleted
+        - skipped_unmerged: True if branch was preserved due to unmerged commits
         - already_clean: True if nothing needed cleanup
         - errors: List of error messages for any failed steps
 
@@ -1185,6 +1398,7 @@ def cleanup_after_merge(repo_root: Path, slug: str) -> dict:
         "slug": slug,
         "worktree_removed": False,
         "branch_deleted": False,
+        "skipped_unmerged": False,
         "already_clean": False,
         "errors": [],
     }
@@ -1221,19 +1435,27 @@ def cleanup_after_merge(repo_root: Path, slug: str) -> dict:
 
     # Step 3: Delete local branch if it still exists
     # Re-check after prune -- pruning may unblock branch deletion
+    # Branch deletion is guarded: safe_delete_branch verifies merged precondition (issue #1646)
     if had_branch or _branch_exists(repo_root, branch_name):
-        branch_result = subprocess.run(
-            ["git", "branch", "-D", branch_name],
-            cwd=repo_root,
-            capture_output=True,
-            text=True,
-            timeout=10,
+        branch_del = safe_delete_branch(
+            str(repo_root),
+            branch_name,
+            predicate=merged_via_tree,
+            force=True,
         )
-        if branch_result.returncode == 0:
+        if branch_del["deleted"]:
             result["branch_deleted"] = True
             logger.info(f"Post-merge: deleted local branch {branch_name}")
+        elif branch_del["skipped_unmerged"]:
+            result["skipped_unmerged"] = True
+            msg = (
+                f"[unmerged-branch-guard] branch '{branch_name}'"
+                " preserved — work not yet merged to main"
+            )
+            result["errors"].append(msg)
+            logger.warning(f"Post-merge: {msg}")
         else:
-            msg = f"Failed to delete branch {branch_name}: {branch_result.stderr.strip()}"
+            msg = f"Failed to delete branch {branch_name}: {branch_del.get('error', 'unknown')}"
             result["errors"].append(msg)
             logger.warning(f"Post-merge: {msg}")
     else:

--- a/docs/features/granite-pty-production.md
+++ b/docs/features/granite-pty-production.md
@@ -325,6 +325,37 @@ Session persistence failures never affect the CLI exit code or results JSON
 output. A single `granite session not recorded: <reason>` line is emitted to
 stderr and execution continues normally.
 
+## Completion-Cleanup Safety Floor (issue #1646)
+
+Dev sessions commit work to `session/dev-{id}` branches inside `.worktrees/dev-{id}`.
+The PM persona (via #1647) is responsible for the landing decision (auto-merge vs
+push+PR) and authorizes cleanup after the work lands. The executor never deletes
+branches unconditionally.
+
+**Guard:** All four branch-deletion sites in `agent/` route through `safe_delete_branch`
+(in `agent/worktree_manager.py`), which checks merged-ness before deleting:
+
+- **Site A (executor auto-mark):** uses `merged_via_ancestor` (no prior merge). If the
+  branch tip is not reachable from `main`, deletion is skipped.
+- **Sites B/C (`cleanup_after_merge`, `remove_worktree`):** uses `merged_via_tree` —
+  squash-safe via `git merge-tree --write-tree`. Correct for the production
+  `gh pr merge --squash` workflow.
+- **Site D (`cleanup_stale_branches` reflection):** also uses `merged_via_tree` (stale
+  refs are often squash-merged PRs whose local refs were never deleted).
+
+**When a branch is preserved:** A greppable `[unmerged-branch-guard]` warning is logged
+naming the branch. The branch and worktree remain on disk. Grep `logs/worker.log` for
+`[unmerged-branch-guard]` to find preserved branches.
+
+**Interim accumulation:** Until #1647 lands the PM-authorized landing step, unmerged
+dev-session branches accumulate. The `preserved=N` counter in `logs/worker.log` is the
+interim signal. Manual operator action is the only safe reaping path — do NOT use
+`scripts/worktree-gc.sh --apply` for no-PR branches (it has an unguarded `git branch -D`
+at line 208 that would re-destroy the preserved work).
+
+**The only `git branch -D` in `agent/`** lives inside `safe_delete_branch`, behind a
+proven-landed check. All other deletion uses `git branch -d` (fails-closed).
+
 ## See also
 
 - [Granite Operator: Interactive TUI](granite-interactive-tui.md) — the PoC

--- a/docs/features/session-isolation.md
+++ b/docs/features/session-isolation.md
@@ -89,6 +89,15 @@ Issue [#1272](https://github.com/tomcounsell/ai/issues/1272) closes that hole wi
 
 4. **Synthetic-slug cleanup hook**: Synthetic-slug worktrees may not have a corresponding PR (the dev session may complete without ever opening one), and `prune_worktrees()` only runs `git worktree prune` (removes references, not directories). The session-completion `finally` block in `_execute_agent_session` calls `cleanup_after_merge(repo_root, slug)` directly when the slug matches the regex `^dev-[0-9a-f]{8}$`. The regex is exact — it must NOT match a real human-chosen slug like `dev-improvements` or `dev-1272`. Cleanup failures are logged at WARNING and do NOT propagate as session failures.
 
+   **Unmerged-branch guard (issue #1646):** `cleanup_after_merge` now verifies the merged
+   precondition before deleting the branch, using the squash-safe `merged_via_tree` oracle
+   (`git merge-tree --write-tree`). If the branch has unmerged commits, it is preserved
+   (`skipped_unmerged=True`) and a `[unmerged-branch-guard]` warning is logged. The
+   worktree directory is also preserved so the work remains easy to find and resume. This
+   replaces the prior unconditional `git branch -D` that caused silent data loss. See
+   `docs/features/granite-pty-production.md#completion-cleanup-safety-floor-issue-1646` for
+   the full operator guide.
+
 The synthetic-slug regex `^dev-[0-9a-f]{8}$` is the safety guarantee: it matches only the synthesis output, never a real human slug.
 
 ### Git-Layer Enforcement for Manual Operations (Issue #1288)

--- a/tests/unit/test_post_merge_cleanup.py
+++ b/tests/unit/test_post_merge_cleanup.py
@@ -32,6 +32,7 @@ def test_blocked_session_exits_2(monkeypatch, capsys, script_module):
         "slug": "sdlc-1218",
         "worktree_removed": False,
         "branch_deleted": False,
+        "skipped_unmerged": False,
         "already_clean": False,
         "errors": ["blocked: worktree in use by session_id=0_LIVE"],
         "blocked_by_session": "0_LIVE",
@@ -55,6 +56,7 @@ def test_clean_exits_0(monkeypatch, capsys, script_module):
         "slug": "fresh",
         "worktree_removed": False,
         "branch_deleted": False,
+        "skipped_unmerged": False,
         "already_clean": True,
         "errors": [],
     }
@@ -73,6 +75,7 @@ def test_generic_error_exits_1(monkeypatch, script_module):
         "slug": "broken",
         "worktree_removed": False,
         "branch_deleted": False,
+        "skipped_unmerged": False,
         "already_clean": False,
         "errors": ["Failed to remove worktree .worktrees/broken"],
     }
@@ -89,6 +92,7 @@ def test_success_exits_0(monkeypatch, capsys, script_module):
         "slug": "win",
         "worktree_removed": True,
         "branch_deleted": True,
+        "skipped_unmerged": False,
         "already_clean": False,
         "errors": [],
     }
@@ -100,3 +104,26 @@ def test_success_exits_0(monkeypatch, capsys, script_module):
     captured = capsys.readouterr()
     assert "Removed worktree" in captured.out
     assert "Deleted branch" in captured.out
+
+
+def test_skipped_unmerged_exits_1(monkeypatch, capsys, script_module):
+    """When cleanup_after_merge skips an unmerged branch, script exits 1 with guard message."""
+    branch_name = "session/unmerged-work"
+    fake_result = {
+        "slug": "unmerged-work",
+        "worktree_removed": False,
+        "branch_deleted": False,
+        "skipped_unmerged": True,
+        "already_clean": False,
+        "errors": [
+            f"[unmerged-branch-guard] branch '{branch_name}' preserved"
+            " — work not yet merged to main"
+        ],
+    }
+    monkeypatch.setattr(script_module, "cleanup_after_merge", lambda _r, _s: fake_result)
+    monkeypatch.setattr(sys, "argv", ["post_merge_cleanup.py", "unmerged-work"])
+
+    rc = script_module.main()
+    assert rc == 1  # error path — has errors in result
+    captured = capsys.readouterr()
+    assert "unmerged-branch-guard" in captured.err

--- a/tests/unit/test_safe_delete_branch.py
+++ b/tests/unit/test_safe_delete_branch.py
@@ -1,0 +1,460 @@
+"""Tests for safe_delete_branch, merged_via_ancestor, and merged_via_tree.
+
+These tests use real temporary git repos to verify the oracle functions and
+the safe_delete_branch helper. Covering both oracles plus the incident
+regression (ec1e7c6e) and the squash-merge edge cases.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agent.worktree_manager import (
+    merged_via_ancestor,
+    merged_via_tree,
+    safe_delete_branch,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    """Create a minimal git repo with an initial commit on main."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@test.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "README.md").write_text("initial\n")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "initial commit")
+    return repo
+
+
+def _branch_exists(repo: Path, branch: str) -> bool:
+    result = subprocess.run(
+        ["git", "branch", "--list", branch],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    return bool(result.stdout.strip())
+
+
+# ---------------------------------------------------------------------------
+# merged_via_ancestor tests
+# ---------------------------------------------------------------------------
+
+
+class TestMergedViaAncestor:
+    def test_true_merged_branch(self, tmp_path):
+        """A branch merged to main returns True."""
+        repo = _make_repo(tmp_path)
+        _git(repo, "checkout", "-b", "feature")
+        (repo / "f.txt").write_text("feature\n")
+        _git(repo, "add", "f.txt")
+        _git(repo, "commit", "-m", "feature commit")
+        # Merge into main (non-squash)
+        _git(repo, "checkout", "main")
+        _git(repo, "merge", "feature", "--no-ff", "-m", "merge feature")
+        assert merged_via_ancestor(str(repo), "feature", "main") is True
+
+    def test_unmerged_branch(self, tmp_path):
+        """An unmerged branch returns False."""
+        repo = _make_repo(tmp_path)
+        _git(repo, "checkout", "-b", "session/dev-ec1e7c6e")
+        (repo / "work.txt").write_text("unmerged work\n")
+        _git(repo, "add", "work.txt")
+        _git(repo, "commit", "-m", "feat: unmerged work")
+        _git(repo, "checkout", "main")
+        assert merged_via_ancestor(str(repo), "session/dev-ec1e7c6e", "main") is False
+
+    def test_squash_merged_branch_returns_false(self, tmp_path):
+        """A squash-merged branch returns False — proving why squash sites cannot use this oracle."""
+        repo = _make_repo(tmp_path)
+        _git(repo, "checkout", "-b", "session/sdlc-1234")
+        # Two commits (>=2 is mandatory per plan — single commit may coincidentally pass cherry)
+        (repo / "a.txt").write_text("commit 1\n")
+        _git(repo, "add", "a.txt")
+        _git(repo, "commit", "-m", "commit 1")
+        (repo / "b.txt").write_text("commit 2\n")
+        _git(repo, "add", "b.txt")
+        _git(repo, "commit", "-m", "commit 2")
+        # Squash merge
+        _git(repo, "checkout", "main")
+        _git(repo, "merge", "--squash", "session/sdlc-1234")
+        _git(repo, "commit", "-m", "squash merge sdlc-1234")
+        # is-ancestor returns False for a squash-merged branch (the branch tip is NOT in main's ancestry)
+        assert merged_via_ancestor(str(repo), "session/sdlc-1234", "main") is False
+
+
+# ---------------------------------------------------------------------------
+# merged_via_tree tests
+# ---------------------------------------------------------------------------
+
+
+class TestMergedViaTree:
+    def test_squash_merged_two_commits(self, tmp_path):
+        """A >=2-commit squash-merged branch is correctly identified as landed."""
+        repo = _make_repo(tmp_path)
+        _git(repo, "checkout", "-b", "session/dev-squash")
+        (repo / "x.txt").write_text("commit 1\n")
+        _git(repo, "add", "x.txt")
+        _git(repo, "commit", "-m", "feat: commit 1")
+        (repo / "y.txt").write_text("commit 2\n")
+        _git(repo, "add", "y.txt")
+        _git(repo, "commit", "-m", "feat: commit 2")
+        _git(repo, "checkout", "main")
+        _git(repo, "merge", "--squash", "session/dev-squash")
+        _git(repo, "commit", "-m", "squash: session/dev-squash")
+
+        assert merged_via_tree(str(repo), "session/dev-squash", "main") is True
+
+    def test_cherry_oracle_broken_on_squash(self, tmp_path):
+        """On a >=2-commit squash fixture, git cherry main branch returns + lines.
+
+        This locks in that the cherry oracle is insufficient and can never be
+        silently re-introduced (plan requirement: explicit git cherry assertion).
+        """
+        repo = _make_repo(tmp_path)
+        _git(repo, "checkout", "-b", "session/multi-squash")
+        (repo / "p.txt").write_text("commit 1\n")
+        _git(repo, "add", "p.txt")
+        _git(repo, "commit", "-m", "commit 1")
+        (repo / "q.txt").write_text("commit 2\n")
+        _git(repo, "add", "q.txt")
+        _git(repo, "commit", "-m", "commit 2")
+        _git(repo, "checkout", "main")
+        _git(repo, "merge", "--squash", "session/multi-squash")
+        _git(repo, "commit", "-m", "squash: multi-squash")
+
+        # Prove the cherry oracle is broken: it should return + lines (reads "unmerged")
+        cherry_result = subprocess.run(
+            ["git", "cherry", "main", "session/multi-squash"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+        )
+        cherry_lines = cherry_result.stdout.strip().splitlines()
+        assert any(line.startswith("+") for line in cherry_lines), (
+            "git cherry should show + (unmerged) for squash-merged branch, "
+            f"but got: {cherry_result.stdout!r}"
+        )
+        # But merged_via_tree correctly identifies it as landed
+        assert merged_via_tree(str(repo), "session/multi-squash", "main") is True
+
+    def test_squash_merged_then_main_advances(self, tmp_path):
+        """merged_via_tree still returns True after main advances past the squash commit.
+
+        This proves robustness to the moving-main edge case that breaks naive tree-equality.
+        """
+        repo = _make_repo(tmp_path)
+        _git(repo, "checkout", "-b", "session/advance-test")
+        (repo / "f1.txt").write_text("file 1\n")
+        _git(repo, "add", "f1.txt")
+        _git(repo, "commit", "-m", "feat: file 1")
+        (repo / "f2.txt").write_text("file 2\n")
+        _git(repo, "add", "f2.txt")
+        _git(repo, "commit", "-m", "feat: file 2")
+        _git(repo, "checkout", "main")
+        _git(repo, "merge", "--squash", "session/advance-test")
+        _git(repo, "commit", "-m", "squash: advance-test")
+
+        # Advance main with a new commit unrelated to the branch
+        (repo / "extra.txt").write_text("extra commit\n")
+        _git(repo, "add", "extra.txt")
+        _git(repo, "commit", "-m", "chore: extra commit after squash")
+
+        # merged_via_tree must still return True (branch is fully landed)
+        assert merged_via_tree(str(repo), "session/advance-test", "main") is True
+
+    def test_truly_unmerged_branch(self, tmp_path):
+        """An unmerged branch returns False."""
+        repo = _make_repo(tmp_path)
+        _git(repo, "checkout", "-b", "session/unmerged")
+        (repo / "unmerged.txt").write_text("not landed\n")
+        _git(repo, "add", "unmerged.txt")
+        _git(repo, "commit", "-m", "feat: unmerged work")
+        _git(repo, "checkout", "main")
+
+        assert merged_via_tree(str(repo), "session/unmerged", "main") is False
+
+    def test_conflicting_branch_returns_false(self, tmp_path):
+        """A branch that conflicts with main returns False (fail-safe)."""
+        repo = _make_repo(tmp_path)
+        # Create conflict: both branches modify the same file differently
+        _git(repo, "checkout", "-b", "session/conflict")
+        (repo / "README.md").write_text("branch version\n")
+        _git(repo, "add", "README.md")
+        _git(repo, "commit", "-m", "branch version")
+        _git(repo, "checkout", "main")
+        (repo / "README.md").write_text("main version\n")
+        _git(repo, "add", "README.md")
+        _git(repo, "commit", "-m", "main version")
+
+        assert merged_via_tree(str(repo), "session/conflict", "main") is False
+
+    def test_is_ancestor_refuses_squash_merged(self, tmp_path):
+        """merged_via_ancestor returns False for squash-merged branch, while merged_via_tree returns True.
+
+        This is the key differentiation test proving the two oracles serve different contexts.
+        """
+        repo = _make_repo(tmp_path)
+        _git(repo, "checkout", "-b", "session/squash-diff")
+        (repo / "a.txt").write_text("a\n")
+        _git(repo, "add", "a.txt")
+        _git(repo, "commit", "-m", "commit a")
+        (repo / "b.txt").write_text("b\n")
+        _git(repo, "add", "b.txt")
+        _git(repo, "commit", "-m", "commit b")
+        _git(repo, "checkout", "main")
+        _git(repo, "merge", "--squash", "session/squash-diff")
+        _git(repo, "commit", "-m", "squash: squash-diff")
+
+        # is-ancestor REFUSES the squash-merged branch
+        assert merged_via_ancestor(str(repo), "session/squash-diff", "main") is False
+        # merged_via_tree ACCEPTS it (correct oracle for squash sites)
+        assert merged_via_tree(str(repo), "session/squash-diff", "main") is True
+
+
+# ---------------------------------------------------------------------------
+# safe_delete_branch tests
+# ---------------------------------------------------------------------------
+
+
+class TestSafeDeleteBranch:
+    def test_deletes_ancestor_merged_branch(self, tmp_path):
+        """merged_via_ancestor: a non-squash merged branch gets deleted."""
+        repo = _make_repo(tmp_path)
+        _git(repo, "checkout", "-b", "session/to-delete")
+        (repo / "d.txt").write_text("delete me\n")
+        _git(repo, "add", "d.txt")
+        _git(repo, "commit", "-m", "commit")
+        _git(repo, "checkout", "main")
+        _git(repo, "merge", "session/to-delete", "--no-ff", "-m", "merge")
+
+        result = safe_delete_branch(
+            str(repo), "session/to-delete", predicate=merged_via_ancestor, force=False
+        )
+        assert result["deleted"] is True
+        assert result["skipped_unmerged"] is False
+        assert not _branch_exists(repo, "session/to-delete")
+
+    def test_preserves_unmerged_branch_via_ancestor(self, tmp_path, caplog):
+        """merged_via_ancestor: an unmerged branch is preserved with [unmerged-branch-guard] log."""
+        repo = _make_repo(tmp_path)
+        _git(repo, "checkout", "-b", "session/dev-ec1e7c6e")
+        (repo / "work.txt").write_text("unmerged work\n")
+        _git(repo, "add", "work.txt")
+        _git(repo, "commit", "-m", "feat(image_gen): make gpt-image-1 the default provider")
+        _git(repo, "checkout", "main")
+
+        with caplog.at_level(logging.WARNING, logger="agent.worktree_manager"):
+            result = safe_delete_branch(
+                str(repo), "session/dev-ec1e7c6e", predicate=merged_via_ancestor, force=False
+            )
+
+        assert result["deleted"] is False
+        assert result["skipped_unmerged"] is True
+        # Branch must still exist (the incident is prevented)
+        assert _branch_exists(repo, "session/dev-ec1e7c6e"), (
+            "Branch session/dev-ec1e7c6e should be preserved after unmerged guard"
+        )
+        # Log line must be greppable
+        assert any(
+            "[unmerged-branch-guard]" in record.message for record in caplog.records
+        ), f"Expected [unmerged-branch-guard] log line, got: {[r.message for r in caplog.records]}"
+
+    def test_deletes_squash_merged_branch_via_tree(self, tmp_path):
+        """merged_via_tree: a squash-merged >=2-commit branch gets deleted."""
+        repo = _make_repo(tmp_path)
+        _git(repo, "checkout", "-b", "session/squash-del")
+        (repo / "s1.txt").write_text("squash 1\n")
+        _git(repo, "add", "s1.txt")
+        _git(repo, "commit", "-m", "squash commit 1")
+        (repo / "s2.txt").write_text("squash 2\n")
+        _git(repo, "add", "s2.txt")
+        _git(repo, "commit", "-m", "squash commit 2")
+        _git(repo, "checkout", "main")
+        _git(repo, "merge", "--squash", "session/squash-del")
+        _git(repo, "commit", "-m", "squash: squash-del")
+
+        result = safe_delete_branch(
+            str(repo), "session/squash-del", predicate=merged_via_tree, force=True
+        )
+        assert result["deleted"] is True
+        assert result["skipped_unmerged"] is False
+        assert not _branch_exists(repo, "session/squash-del")
+
+    def test_preserves_truly_unmerged_via_tree(self, tmp_path, caplog):
+        """merged_via_tree: an unmerged branch is preserved."""
+        repo = _make_repo(tmp_path)
+        _git(repo, "checkout", "-b", "session/stale-unmerged")
+        (repo / "u.txt").write_text("unmerged\n")
+        _git(repo, "add", "u.txt")
+        _git(repo, "commit", "-m", "unmerged work")
+        _git(repo, "checkout", "main")
+
+        with caplog.at_level(logging.WARNING, logger="agent.worktree_manager"):
+            result = safe_delete_branch(
+                str(repo), "session/stale-unmerged", predicate=merged_via_tree, force=True
+            )
+
+        assert result["deleted"] is False
+        assert result["skipped_unmerged"] is True
+        assert _branch_exists(repo, "session/stale-unmerged")
+        assert any("[unmerged-branch-guard]" in r.message for r in caplog.records)
+
+    def test_missing_branch_returns_error_no_exception(self, tmp_path):
+        """Non-existent branch returns error result without raising."""
+        repo = _make_repo(tmp_path)
+        result = safe_delete_branch(
+            str(repo), "session/does-not-exist", predicate=merged_via_ancestor, force=False
+        )
+        # Should not raise; returns a structured result
+        assert isinstance(result, dict)
+        assert result["deleted"] is False
+        # Either an error or skipped_unmerged (predicate may fail or git branch -d fails)
+        assert result.get("error") is not None or result["skipped_unmerged"] is True
+
+    def test_unresolvable_base_fails_safe(self, tmp_path, caplog):
+        """When base branch cannot be resolved, deletion is refused (fail-safe)."""
+        repo = _make_repo(tmp_path)
+        _git(repo, "checkout", "-b", "session/test-failsafe")
+        (repo / "t.txt").write_text("test\n")
+        _git(repo, "add", "t.txt")
+        _git(repo, "commit", "-m", "test commit")
+        _git(repo, "checkout", "main")
+
+        with caplog.at_level(logging.WARNING, logger="agent.worktree_manager"):
+            result = safe_delete_branch(
+                str(repo),
+                "session/test-failsafe",
+                base="nonexistent-base-branch-xyz",
+                predicate=merged_via_ancestor,
+                force=False,
+            )
+
+        assert result["deleted"] is False
+        assert result["skipped_unmerged"] is True
+        assert result["error"] is not None
+        # Branch must still exist
+        assert _branch_exists(repo, "session/test-failsafe")
+
+    def test_squash_then_main_advances_still_deletes(self, tmp_path):
+        """merged_via_tree deletes correctly even after main advances past squash commit."""
+        repo = _make_repo(tmp_path)
+        _git(repo, "checkout", "-b", "session/advance-del")
+        (repo / "m1.txt").write_text("m1\n")
+        _git(repo, "add", "m1.txt")
+        _git(repo, "commit", "-m", "m1")
+        (repo / "m2.txt").write_text("m2\n")
+        _git(repo, "add", "m2.txt")
+        _git(repo, "commit", "-m", "m2")
+        _git(repo, "checkout", "main")
+        _git(repo, "merge", "--squash", "session/advance-del")
+        _git(repo, "commit", "-m", "squash: advance-del")
+        # Advance main
+        (repo / "extra.txt").write_text("extra\n")
+        _git(repo, "add", "extra.txt")
+        _git(repo, "commit", "-m", "chore: advance main")
+
+        result = safe_delete_branch(
+            str(repo), "session/advance-del", predicate=merged_via_tree, force=True
+        )
+        assert result["deleted"] is True
+        assert not _branch_exists(repo, "session/advance-del")
+
+
+# ---------------------------------------------------------------------------
+# Regression test reproducing incident ec1e7c6e
+# ---------------------------------------------------------------------------
+
+
+class TestIncidentRegression:
+    """Regression: dev session branch with unmerged commit survives cleanup (incident ec1e7c6e)."""
+
+    def test_unmerged_branch_survives_auto_mark_cleanup(self, tmp_path, caplog):
+        """Reproduces the incident: safe_delete_branch with merged_via_ancestor preserves unmerged work.
+
+        The incident: session ec1e7c6e committed work to session/dev-ec1e7c6e,
+        then git branch -D was called unconditionally, destroying the commit.
+        This test verifies the guard prevents that.
+        """
+        repo = _make_repo(tmp_path)
+        # Simulate a dev session branch with >=2 commits (matching real-world pattern)
+        branch = "session/dev-ec1e7c6e"
+        _git(repo, "checkout", "-b", branch)
+        (repo / "image_gen.py").write_text("# gpt-image-1 as default\n")
+        _git(repo, "add", "image_gen.py")
+        _git(repo, "commit", "-m", "feat(image_gen): make gpt-image-1 the default provider")
+        (repo / "image_gen_config.py").write_text("DEFAULT_PROVIDER = 'gpt-image-1'\n")
+        _git(repo, "add", "image_gen_config.py")
+        _git(repo, "commit", "-m", "feat(image_gen): add config module")
+        _git(repo, "checkout", "main")
+
+        # The auto-mark path uses merged_via_ancestor (no prior merge exists)
+        with caplog.at_level(logging.WARNING, logger="agent.worktree_manager"):
+            result = safe_delete_branch(
+                str(repo), branch, predicate=merged_via_ancestor, force=False
+            )
+
+        # The branch must be preserved
+        assert result["deleted"] is False, "Guard failed: branch was deleted despite unmerged commits"
+        assert result["skipped_unmerged"] is True
+        assert _branch_exists(repo, branch), (
+            f"Branch {branch} was deleted — incident would have recurred"
+        )
+        # Commits must still be reachable
+        log_result = subprocess.run(
+            ["git", "log", "--oneline", branch],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+        )
+        assert "gpt-image-1" in log_result.stdout, (
+            f"Commits not reachable on {branch}: {log_result.stdout!r}"
+        )
+        # Greppable log line
+        assert any("[unmerged-branch-guard]" in r.message for r in caplog.records), (
+            "Expected [unmerged-branch-guard] log line"
+        )
+
+    def test_merged_branch_still_deleted(self, tmp_path):
+        """Positive case: a merged branch still gets cleaned up (no regression in SDLC happy path)."""
+        repo = _make_repo(tmp_path)
+        _git(repo, "checkout", "-b", "session/sdlc-merged")
+        (repo / "feature.py").write_text("# feature\n")
+        _git(repo, "add", "feature.py")
+        _git(repo, "commit", "-m", "feat: feature commit 1")
+        (repo / "feature2.py").write_text("# feature 2\n")
+        _git(repo, "add", "feature2.py")
+        _git(repo, "commit", "-m", "feat: feature commit 2")
+        _git(repo, "checkout", "main")
+        # Squash merge (production pattern)
+        _git(repo, "merge", "--squash", "session/sdlc-merged")
+        _git(repo, "commit", "-m", "squash: sdlc-merged")
+
+        # The squash sites use merged_via_tree
+        result = safe_delete_branch(
+            str(repo), "session/sdlc-merged", predicate=merged_via_tree, force=True
+        )
+        assert result["deleted"] is True, "Merged branch should be deleted"
+        assert not _branch_exists(repo, "session/sdlc-merged")

--- a/tests/unit/test_session_revival_cleanup.py
+++ b/tests/unit/test_session_revival_cleanup.py
@@ -1,0 +1,156 @@
+"""Tests for the unmerged-branch guard in session_revival.cleanup_stale_branches (Site D).
+
+Verifies the scheduler-driven stale-branch cleanup vector is closed:
+- Stale but unmerged session/* branches are preserved
+- Stale and squash-merged branches are still cleaned
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agent.worktree_manager import merged_via_tree, safe_delete_branch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@test.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "README.md").write_text("initial\n")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "initial")
+    return repo
+
+
+def _branch_exists(repo: Path, branch: str) -> bool:
+    result = subprocess.run(
+        ["git", "branch", "--list", branch],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    return bool(result.stdout.strip())
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSiteD_StalebranchCleanup:
+    """Site D: session_revival.cleanup_stale_branches guard via merged_via_tree."""
+
+    def test_stale_unmerged_branch_preserved(self, tmp_path, caplog):
+        """A stale-but-unmerged session/* branch is preserved, not force-deleted.
+
+        This closes the scheduler-driven vector (cleanup_stale_branches fires autonomously
+        on a timer). The age threshold only selects candidates; the merged check decides.
+        """
+        repo = _make_repo(tmp_path)
+        branch = "session/dev-stale-unmerged"
+        _git(repo, "checkout", "-b", branch)
+        (repo / "unmerged_work.py").write_text("# unmerged\n")
+        _git(repo, "add", "unmerged_work.py")
+        _git(repo, "commit", "-m", "feat: unmerged work")
+        _git(repo, "checkout", "main")
+
+        # Site D uses merged_via_tree with force=True
+        with caplog.at_level(logging.WARNING, logger="agent.worktree_manager"):
+            result = safe_delete_branch(
+                str(repo),
+                branch,
+                predicate=merged_via_tree,
+                force=True,
+            )
+
+        assert result["deleted"] is False, "Unmerged branch should not be deleted"
+        assert result["skipped_unmerged"] is True
+        assert _branch_exists(repo, branch), (
+            f"Branch {branch} should be preserved — stale but unmerged"
+        )
+        assert any("[unmerged-branch-guard]" in r.message for r in caplog.records)
+
+    def test_stale_squash_merged_branch_cleaned(self, tmp_path):
+        """A stale-but-squash-merged session/* branch is correctly deleted.
+
+        The most common stale-ref class: branch squash-merged via PR, local ref never
+        deleted. merged_via_tree correctly identifies these as landed (is-ancestor would
+        read them as unmerged and preserve them forever).
+        """
+        repo = _make_repo(tmp_path)
+        branch = "session/dev-stale-squashed"
+        _git(repo, "checkout", "-b", branch)
+        (repo / "f1.py").write_text("# commit 1\n")
+        _git(repo, "add", "f1.py")
+        _git(repo, "commit", "-m", "feat: commit 1")
+        (repo / "f2.py").write_text("# commit 2\n")
+        _git(repo, "add", "f2.py")
+        _git(repo, "commit", "-m", "feat: commit 2")
+        _git(repo, "checkout", "main")
+        _git(repo, "merge", "--squash", branch)
+        _git(repo, "commit", "-m", "squash: dev-stale-squashed")
+        # Advance main (simulating time passing after the squash)
+        (repo / "extra.txt").write_text("extra\n")
+        _git(repo, "add", "extra.txt")
+        _git(repo, "commit", "-m", "chore: advance main")
+
+        result = safe_delete_branch(
+            str(repo),
+            branch,
+            predicate=merged_via_tree,
+            force=True,
+        )
+
+        assert result["deleted"] is True, "Squash-merged branch should be cleaned up"
+        assert result["skipped_unmerged"] is False
+        assert not _branch_exists(repo, branch)
+
+    def test_is_ancestor_would_preserve_squash_merged(self, tmp_path):
+        """Confirms that is-ancestor alone would have preserved squash-merged stale refs forever.
+
+        This justifies why Site D must use merged_via_tree, not merged_via_ancestor.
+        """
+        from agent.worktree_manager import merged_via_ancestor
+
+        repo = _make_repo(tmp_path)
+        branch = "session/dev-stale-ancestor-fail"
+        _git(repo, "checkout", "-b", branch)
+        (repo / "c1.py").write_text("c1\n")
+        _git(repo, "add", "c1.py")
+        _git(repo, "commit", "-m", "c1")
+        (repo / "c2.py").write_text("c2\n")
+        _git(repo, "add", "c2.py")
+        _git(repo, "commit", "-m", "c2")
+        _git(repo, "checkout", "main")
+        _git(repo, "merge", "--squash", branch)
+        _git(repo, "commit", "-m", "squash: ancestor-fail")
+
+        # is-ancestor returns False (would preserve this stale ref forever)
+        assert merged_via_ancestor(str(repo), branch, "main") is False, (
+            "is-ancestor should return False for squash-merged branch"
+        )
+        # merged_via_tree correctly identifies it as landed
+        assert merged_via_tree(str(repo), branch, "main") is True, (
+            "merged_via_tree should return True for squash-merged branch"
+        )

--- a/tests/unit/test_worktree_manager.py
+++ b/tests/unit/test_worktree_manager.py
@@ -138,20 +138,26 @@ class TestCleanupAfterMerge:
         assert result["already_clean"] is False
         assert "Failed to remove worktree" in result["errors"][0]
 
+    @patch("agent.worktree_manager.safe_delete_branch")
     @patch("agent.worktree_manager.subprocess.run")
     @patch("agent.worktree_manager._branch_exists")
     @patch("agent.worktree_manager.remove_worktree")
-    def test_branch_deletion_fails(self, mock_remove_wt, mock_branch_exists, mock_run):
+    def test_branch_deletion_fails(
+        self, mock_remove_wt, mock_branch_exists, mock_run, mock_safe_del
+    ):
         """If branch deletion fails, result reflects failure (not already_clean)."""
         repo = Path("/fake/repo")
         slug = "protected-feature"
 
         mock_branch_exists.return_value = True
-        # First call is prune_worktrees, second is branch -D
-        mock_run.side_effect = [
-            MagicMock(returncode=0),  # prune
-            MagicMock(returncode=1, stderr="error: branch not found"),  # branch -D
-        ]
+        mock_run.return_value = MagicMock(returncode=0)  # prune
+        # safe_delete_branch returns a git error (not skipped_unmerged)
+        mock_safe_del.return_value = {
+            "deleted": False,
+            "skipped_unmerged": False,
+            "branch": f"session/{slug}",
+            "error": "error: branch not found",
+        }
 
         result = cleanup_after_merge(repo, slug)
 
@@ -162,6 +168,34 @@ class TestCleanupAfterMerge:
         assert result["already_clean"] is False
         assert len(result["errors"]) == 1
         assert "Failed to delete branch" in result["errors"][0]
+
+    @patch("agent.worktree_manager.safe_delete_branch")
+    @patch("agent.worktree_manager.subprocess.run")
+    @patch("agent.worktree_manager._branch_exists")
+    @patch("agent.worktree_manager.remove_worktree")
+    def test_branch_unmerged_skips_deletion(
+        self, mock_remove_wt, mock_branch_exists, mock_run, mock_safe_del
+    ):
+        """When safe_delete_branch detects an unmerged branch, skipped_unmerged is set."""
+        repo = Path("/fake/repo")
+        slug = "unmerged-feature"
+
+        mock_branch_exists.return_value = True
+        mock_run.return_value = MagicMock(returncode=0)  # prune
+        mock_safe_del.return_value = {
+            "deleted": False,
+            "skipped_unmerged": True,
+            "branch": f"session/{slug}",
+            "error": None,
+        }
+
+        result = cleanup_after_merge(repo, slug)
+
+        assert result["branch_deleted"] is False
+        assert result["skipped_unmerged"] is True
+        assert result["already_clean"] is False
+        # The unmerged warning should be in errors for operator visibility
+        assert any("unmerged-branch-guard" in e for e in result["errors"])
 
     @patch("agent.worktree_manager.subprocess.run")
     @patch("agent.worktree_manager._branch_exists")


### PR DESCRIPTION
## Summary

Fixes the data-loss bug where dev-session completion cleanup force-deleted branches before anything was merged (incident ec1e7c6e, 2026-06-12).

- Replaces 4 unconditional `git branch -D` sites in `agent/` with a `safe_delete_branch` helper that verifies merged-ness before deleting
- Two oracles: `merged_via_ancestor` (Site A, completion path — no prior merge) and `merged_via_tree` (Sites B/C/D, squash-safe via `git merge-tree --write-tree`)
- On unmerged branch: logs `[unmerged-branch-guard]` warning, preserves branch + worktree, returns `skipped_unmerged=True`
- The only `git branch -D` in `agent/` now lives inside `safe_delete_branch`, behind a proven-landed check

Closes #1646

## Sites guarded

| Site | Location | Oracle |
|------|----------|--------|
| A | `session_executor.py` auto-mark block | `merged_via_ancestor` |
| B | `worktree_manager.py cleanup_after_merge` | `merged_via_tree` |
| C | `worktree_manager.py remove_worktree` | `merged_via_tree` |
| D | `session_revival.py cleanup_stale_branches` | `merged_via_tree` |

## Test plan

- [ ] `python -m pytest tests/unit/test_safe_delete_branch.py tests/unit/test_session_revival_cleanup.py tests/unit/test_post_merge_cleanup.py tests/unit/test_worktree_manager.py::TestCleanupAfterMerge -v` — all 36 pass
- [ ] `grep -rn '"-D"' agent/` returns exactly one hit (inside `safe_delete_branch`)
- [ ] Incident regression: `TestIncidentRegression::test_unmerged_branch_survives_auto_mark_cleanup` verifies branch `session/dev-ec1e7c6e` survives cleanup with unmerged commits
- [ ] Squash-merge oracle correctness: `TestMergedViaTree::test_cherry_oracle_broken_on_squash` asserts `git cherry` returns `+` (cherry oracle is broken), while `merged_via_tree` returns True (correct)
- [ ] Moving-main robustness: `TestMergedViaTree::test_squash_merged_then_main_advances` verifies oracle still works after main advances past the squash commit