### PR TITLE
Fix granite PTY space-stripping: reconstruct cursor-advance spacing (#1634)

### DIFF
--- a/agent/granite_container/pty_driver.py
+++ b/agent/granite_container/pty_driver.py
@@ -155,6 +155,25 @@ TURN_TEXT_MAX_CHARS = 256_000
 _ANSI_CSI_RE = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
 _ANSI_OSC_RE = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
 
+# Cursor-advance CSI sequences the TUI uses to position the next glyph
+# INSTEAD of emitting literal spaces. The Ink/React renderer paints
+# `word1 word2` as `word1<cursor-forward>word2`, so the inter-word gap
+# lives entirely in the escape sequence — never as a space character.
+# A naive `_ANSI_CSI_RE.sub("", ...)` deletes the gap and collapses the
+# words (`word1word2`), which is the issue-#1634 space-stripping bug.
+# We translate these to literal spaces BEFORE the blanket CSI strip so
+# the visible spacing survives into the classifier payload.
+#   - `\x1b[<N>C` (Cursor Forward, CUF): advance N columns -> N spaces.
+#     A bare `\x1b[C` (no count) advances 1 column -> 1 space.
+#   - `\x1b[<N>G` / `\x1b[G` (Cursor Horizontal Absolute, CHA): jump to
+#     an absolute column. We can't reconstruct the absolute target
+#     without full terminal emulation, but the only thing downstream
+#     matching needs is that the word boundary is preserved, so we emit
+#     a single space. (Adjacent runs collapse via the final whitespace
+#     normalization the classifier already does with `.strip()`.)
+_ANSI_CURSOR_FORWARD_RE = re.compile(r"\x1b\[([0-9]*)C")
+_ANSI_CURSOR_ABS_COL_RE = re.compile(r"\x1b\[[0-9]*G")
+
 # The default content floor for post-reply idle. The TUI briefly
 # re-renders the bar while the model is still loading a response; that
 # false-positive doesn't have response content behind it, so we require
@@ -207,7 +226,16 @@ def _strip_ansi(text: str) -> str:
     out of scope. The classifier layer only needs the visible text.
     Whitespace is preserved so that downstream matching (bypass bar,
     overlay bar, content checks) can use readable substrings.
+
+    Cursor-advance sequences (CUF `\x1b[NC`, CHA `\x1b[NG`) are the
+    TUI's way of painting inter-word spacing without literal spaces; we
+    translate them to spaces BEFORE the blanket CSI strip so the gaps
+    survive into the classifier payload (issue #1634). Order matters:
+    the CUF/CHA substitutions MUST run before `_ANSI_CSI_RE`, which
+    would otherwise delete the spacing outright.
     """
+    text = _ANSI_CURSOR_FORWARD_RE.sub(lambda m: " " * max(1, int(m.group(1) or "1")), text)
+    text = _ANSI_CURSOR_ABS_COL_RE.sub(" ", text)
     text = _ANSI_CSI_RE.sub("", text)
     text = _ANSI_OSC_RE.sub("", text)
     # TUI cursor-positioning and similar non-CSI controls. We keep the

--- a/tests/unit/granite_container/test_granite_classifier.py
+++ b/tests/unit/granite_container/test_granite_classifier.py
@@ -223,6 +223,76 @@ class TestAnsiStripping(unittest.TestCase):
         self.assertIn("add a function", result.payload)
 
 
+class TestCursorPositionedSpacingSurvives(unittest.TestCase):
+    """Issue #1634: inter-word spacing painted as cursor-advance CSI
+    sequences must survive the screen-capture -> payload reconstruction.
+
+    The Ink/React TUI renderer paints `word1 word2` as
+    `word1<cursor-forward>word2` — the gap lives entirely in the escape
+    sequence, never as a literal space. The original `_strip_ansi` deleted
+    those CSI sequences outright, collapsing the words (`word1word2`) and
+    delivering space-stripped text to CEO-facing chats. The fix translates
+    cursor-advance sequences (CUF `\\x1b[NC`, CHA `\\x1b[NG`) to spaces
+    before the blanket CSI strip. These tests pin that invariant at the
+    classifier boundary — the same boundary that feeds the outbox.
+    """
+
+    def test_cursor_forward_preserves_interior_spaces(self) -> None:
+        """CUF (`\\x1b[1C`) between words must reconstruct as a space, not vanish."""
+        from agent.granite_container.pty_driver import _strip_ansi
+
+        painted = "Online\x1b[1Cand\x1b[1Cready."
+        self.assertEqual(_strip_ansi(painted), "Online and ready.")
+
+    def test_cursor_forward_count_maps_to_n_spaces(self) -> None:
+        """A CUF with an explicit count (`\\x1b[3C`) advances N columns -> N spaces."""
+        from agent.granite_container.pty_driver import _strip_ansi
+
+        self.assertEqual(_strip_ansi("a\x1b[3Cb"), "a   b")
+
+    def test_bare_cursor_forward_maps_to_one_space(self) -> None:
+        """A countless CUF (`\\x1b[C`) advances one column -> one space."""
+        from agent.granite_container.pty_driver import _strip_ansi
+
+        self.assertEqual(_strip_ansi("a\x1b[Cb"), "a b")
+
+    def test_cursor_horizontal_absolute_preserves_word_boundary(self) -> None:
+        """CHA (`\\x1b[NG`) jumps to an absolute column; reconstruction keeps
+        the word boundary as a space rather than collapsing the words."""
+        from agent.granite_container.pty_driver import _strip_ansi
+
+        self.assertEqual(_strip_ansi("Online\x1b[7Gand\x1b[11Gready."), "Online and ready.")
+
+    def test_strip_is_idempotent_after_cursor_expansion(self) -> None:
+        """Re-stripping already-reconstructed text is a no-op (the helper is
+        called at several points in the read path)."""
+        from agent.granite_container.pty_driver import _strip_ansi
+
+        once = _strip_ansi("Online\x1b[1Cand\x1b[1Cready.")
+        self.assertEqual(_strip_ansi(once), once)
+
+    def test_realistic_multiline_capture_payload_keeps_spaces(self) -> None:
+        """End-to-end: a realistic multi-line painted capture (the exact
+        artifact from issue #1634 — `Onlineandrouting—PM...`) must
+        reconstruct to spaced text in the routed payload, not collapse."""
+        capture = (
+            "❯ /granite-poc:prime-pm-role Send a one-line confirmation.\n"
+            "\x1b[2K────────────────────────────\n"
+            "✻ Sprouting…\n"
+            "⏺ [/user]\x1b[2COnline\x1b[1Cand\x1b[1Crouting\x1b[1C—"
+            "\x1b[1CPM\x1b[1Csession\x1b[1Cfor\x1b[1CPR\x1b[1C#1612\x1b[1Cis\x1b[1Clive.\n"
+            "────────────────────────────\n"
+            "⏵⏵ bypass permissions on (shift+tab to cycle)\n"
+        )
+        result = classify_pm_prefix(capture)
+        self.assertEqual(result.destination, "user")
+        self.assertEqual(result.payload, "Online and routing — PM session for PR #1612 is live.")
+        self.assertFalse(result.compliance_miss)
+        # The space-stripped artifact must NOT appear in the payload.
+        self.assertNotIn("Onlineand", result.payload)
+        self.assertNotIn("PMsession", result.payload)
+
+
 # ---------------------------------------------------------------------------
 # extract_dev_prompt / summarize_for_pm: mocked ollama path
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1634

## Root cause

The granite PTY container delivered space-stripped replies (`Onlineandrouting—PMsession...` instead of `Online and routing — PM session...`). The Ink/React TUI renderer paints inter-word spacing as **cursor-advance CSI sequences** (`word1<cursor-forward>word2`) rather than literal space characters — the gap lives entirely in the escape sequence. The blanket `_ANSI_CSI_RE.sub("", ...)` in `_strip_ansi` (`agent/granite_container/pty_driver.py`) deleted those sequences outright, collapsing words before the classifier extracted the payload (`granite_classifier.py:277` delegates to `_strip_ansi`).

## Fix

Translate cursor-advance sequences to spaces **before** the blanket CSI strip:
- **CUF** (`\x1b[NC`, Cursor Forward): advance N columns → N spaces; bare `\x1b[C` → 1 space.
- **CHA** (`\x1b[NG`, Cursor Horizontal Absolute): → 1 space (preserves the word boundary; reconstructing the absolute column would require full terminal emulation, and downstream matching only needs the boundary).

Ordering is load-bearing and documented in the helper docstring: the CUF/CHA substitutions must precede `_ANSI_CSI_RE`, which would otherwise eat the spacing. The strip remains idempotent.

## Acceptance

- [x] Unit coverage for payload extraction preserving interior whitespace from a realistic multi-line screen capture — `TestCursorPositionedSpacingSurvives` (6 cases), including the exact issue-#1634 artifact reconstructing to `Online and routing — PM session for PR #1612 is live.`
- The new realistic test is non-vacuous: without the fix it reproduces `Onlineandrouting—PMsessionforPR#1612islive.` and fails.

The live-smoke assertion in the issue acceptance requires the Telegram bridge/worker (not available on this skills-only machine); it is covered by the deterministic end-to-end test exercising the full `classify_pm_prefix` path (anchored `⏺ [/user]` token + frame-artifact trimming).

## Scope

Confined to ANSI reconstruction in `_strip_ansi` plus its test. PM-relay routing logic (#1647/#1644) untouched.

## Verification

- `tests/unit/granite_container/test_granite_classifier.py` — 42 passed
- `tests/unit/granite_container/` — 217 passed, 5 skipped, no regressions
- ruff format clean