### PR TITLE
fix(#1645): AgentSession.updated_at stamped in UTC (remove auto_now, explicit utc_now() in save())

### DIFF
--- a/docs/features/session-lifecycle.md
+++ b/docs/features/session-lifecycle.md
@@ -294,6 +294,22 @@ A stale caller can at worst append a spurious `session_events` entry. It cannot 
 
 `scripts/reflections.py` scans bridge logs daily for `"Stale index entry"` warnings. A non-zero count triggers a finding tagged `(regression marker for #898)`. The `finalized_by_execute` fix should eliminate all such warnings; a reappearance indicates a regression.
 
+## Timestamp Convention — `updated_at` is Explicit UTC
+
+`AgentSession.updated_at` is always an explicit UTC wall-clock timestamp. It is stamped inside the `save()` override using `bridge.utc.utc_now()`, not by a Popoto `auto_now` field.
+
+**Why:** Popoto's `auto_now` calls `datetime.now()` (no `tz` argument), which mints a naive datetime in the host's local timezone. On non-UTC hosts the stored value is naive-local, but every downstream reader (watchdog, dashboard, stale-cleanup) interprets it as UTC. The result is a future-dated `updated_at` for sessions created on hosts running ahead of UTC, causing the watchdog/dashboard to report sessions as perpetually "fresh" and stale-cleanup to skip them forever.
+
+**The fix (issue #1645):** `auto_now` was removed from the field declaration. The `save()` override stamps `self.updated_at = utc_now()` unconditionally unless `update_fields` is provided *without* `"updated_at"` — in which case the stamp is skipped entirely (no in-memory mutation without a matching persist, to avoid memory/Redis desync).
+
+**Rule for new fields:** Do not use `auto_now=True` on any `DatetimeField`. Always stamp explicitly with `utc_now()` at the appropriate call site. The `auto_now` ban is enforced by the comment on the field declaration at `models/agent_session.py` line 153–155 (#1645).
+
+### First-deploy callout
+
+`_heal_future_updated_at()` (a classmethod on `AgentSession`) runs once at worker startup after the fix is deployed. It clamps any `updated_at` that is in the future down to `max(created_at, now)`. After the clamp, those previously-future-dated records appear newly-updated to the watchdog and dashboard staleness checks for exactly one staleness window — operators should **not** interpret this momentary freshness as real session activity. No threshold change is required; the clamp only moves timestamps from future to now.
+
+The heal is idempotent: a re-run clamps only still-future records, so a mid-run restart is safe.
+
 ## Stale Session Cleanup
 
 `_cleanup_stale_sessions()` in `scripts/update/run.py` runs during every `/update` deploy and terminates `running` or `pending` sessions that have no live process. It is a safety net for sessions that were never finalized due to a crash or abrupt restart.

--- a/docs/features/session-lifecycle.md
+++ b/docs/features/session-lifecycle.md
@@ -302,7 +302,7 @@ A stale caller can at worst append a spurious `session_events` entry. It cannot 
 
 **The fix (issue #1645):** `auto_now` was removed from the field declaration. The `save()` override stamps `self.updated_at = utc_now()` unconditionally unless `update_fields` is provided *without* `"updated_at"` — in which case the stamp is skipped entirely (no in-memory mutation without a matching persist, to avoid memory/Redis desync).
 
-**Rule for new fields:** Do not use `auto_now=True` on any `DatetimeField`. Always stamp explicitly with `utc_now()` at the appropriate call site. The `auto_now` ban is enforced by the comment on the field declaration at `models/agent_session.py` line 153–155 (#1645).
+**Rule for new fields:** `auto_now=True` must not be added to any `DatetimeField`. Always stamp explicitly with `utc_now()` at the appropriate call site. This constraint is documented on the field declaration at `models/agent_session.py` line 153–155 (#1645).
 
 ### First-deploy callout
 

--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -894,12 +894,11 @@ class AgentSession(Model):
                 if hasattr(floor, "tzinfo") and floor.tzinfo is None:
                     floor = floor.replace(tzinfo=UTC)
                 record.updated_at = max(floor, now)
-                # Save via the override (which will re-stamp utc_now(), which == now — idempotent).
-                # Use update_fields to limit the write to only the fields we changed.
-                update_fields_list = ["updated_at"]
-                if record.created_at and record.created_at == now:
-                    update_fields_list.append("created_at")
-                record.save(update_fields=update_fields_list)
+                # Full save (no update_fields) so all changed fields are persisted
+                # and all popoto indexes (including SortedField created_at) are
+                # kept in sync. The save() override will re-stamp utc_now() for
+                # updated_at (idempotent — it will equal now).
+                record.save()
                 count += 1
                 logger.info(f"_heal_future_updated_at: healed session {record.id}")
             except Exception as e:

--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -151,7 +151,8 @@ class AgentSession(Model):
     created_at = SortedField(type=datetime, partition_by="project_key")
     started_at = DatetimeField(null=True)  # Cannot be SortedField because it starts as None
     updated_at = DatetimeField(null=True)
-    # auto_now removed deliberately (see #1645) — do not re-add; popoto auto_now mints naive-local time. UTC stamp is set in save() override.
+    # auto_now removed deliberately (see #1645) — do not re-add;
+    # popoto auto_now mints naive-local time. UTC stamp is in save() override.
     completed_at = DatetimeField(null=True)
     response_delivered_at = DatetimeField(null=True)
     working_dir = Field()
@@ -865,19 +866,33 @@ class AgentSession(Model):
             try:
                 if record.updated_at is None:
                     continue  # None is safe — save() will stamp on next write
-                if record.updated_at <= now:
+
+                # Popoto strips tzinfo on load — treat naive datetimes as UTC
+                # (consistent with bridge/utc.py::to_unix_ts).
+                updated_at_utc = record.updated_at
+                if updated_at_utc.tzinfo is None:
+                    updated_at_utc = updated_at_utc.replace(tzinfo=UTC)
+
+                if updated_at_utc <= now:
                     continue  # already sane, skip
 
                 # Clamp created_at first (dual-future-dated case, CONCERN — Adversary):
                 # ensures updated_at floor uses the already-clamped value so the
                 # invariant created_at <= updated_at <= now holds.
-                if record.created_at and record.created_at > now:
-                    record.created_at = now
-                    logger.warning(
-                        f"_heal_future_updated_at: clamped future created_at on {record.id}"
-                    )
+                if record.created_at:
+                    created_at_utc = record.created_at
+                    if created_at_utc.tzinfo is None:
+                        created_at_utc = created_at_utc.replace(tzinfo=UTC)
+                    if created_at_utc > now:
+                        record.created_at = now
+                        logger.warning(
+                            f"_heal_future_updated_at: clamped future created_at on {record.id}"
+                        )
 
                 floor = record.created_at if record.created_at else now
+                # Normalize floor to tz-aware for max() comparison
+                if hasattr(floor, "tzinfo") and floor.tzinfo is None:
+                    floor = floor.replace(tzinfo=UTC)
                 record.updated_at = max(floor, now)
                 # Save via the override (which will re-stamp utc_now(), which == now — idempotent).
                 # Use update_fields to limit the write to only the fields we changed.

--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -150,7 +150,8 @@ class AgentSession(Model):
     scheduled_at = DatetimeField(null=True)  # UTC datetime; _pop_job() skips if > now()
     created_at = SortedField(type=datetime, partition_by="project_key")
     started_at = DatetimeField(null=True)  # Cannot be SortedField because it starts as None
-    updated_at = DatetimeField(auto_now=True, null=True)  # Renamed from last_activity
+    updated_at = DatetimeField(null=True)
+    # auto_now removed deliberately (see #1645) — do not re-add; popoto auto_now mints naive-local time. UTC stamp is set in save() override.
     completed_at = DatetimeField(null=True)
     response_delivered_at = DatetimeField(null=True)
     working_dir = Field()
@@ -816,6 +817,82 @@ class AgentSession(Model):
         """Create an AgentSession asynchronously with backward-compatible field name support."""
         kwargs = cls._normalize_kwargs(kwargs)
         return await super().async_create(**kwargs)
+
+    def save(self, *args, update_fields=None, **kwargs):
+        """Override to stamp updated_at with UTC wall-clock time.
+
+        Popoto auto_now mints naive local time (bug #1645); instead we stamp
+        explicitly so the stored value is always UTC wall-clock, consistent
+        with how created_at/started_at are handled (see bridge/utc.py::utc_now).
+
+        update_fields guard: if update_fields omits 'updated_at', skip the stamp
+        entirely (no in-memory mutation without a matching persist, to avoid
+        memory/Redis desync).
+        """
+        from bridge.utc import utc_now
+
+        if update_fields is not None and "updated_at" not in update_fields:
+            logger.warning(
+                "save() called with update_fields missing 'updated_at'; "
+                "timestamp not persisted to avoid memory/Redis desync"
+            )
+            return super().save(*args, update_fields=update_fields, **kwargs)
+        self.updated_at = utc_now()
+        return super().save(*args, update_fields=update_fields, **kwargs)
+
+    @classmethod
+    def _heal_future_updated_at(cls) -> int:
+        """One-shot heal for future-dated updated_at values written before fix #1645.
+
+        Clamps any session whose updated_at is in the future down to
+        max(created_at, now). Idempotent: a re-run clamps only still-future
+        records (partial mid-heal restart is safe because the per-record guard
+        is a strict `if record.updated_at > utc_now()` check, not a bulk update).
+
+        Returns the number of records healed.
+        """
+        from bridge.utc import utc_now
+
+        now = utc_now()
+        count = 0
+        try:
+            all_sessions = cls.query.all()
+        except Exception as e:
+            logger.warning(f"_heal_future_updated_at: could not fetch sessions: {e}")
+            return 0
+
+        for record in all_sessions:
+            try:
+                if record.updated_at is None:
+                    continue  # None is safe — save() will stamp on next write
+                if record.updated_at <= now:
+                    continue  # already sane, skip
+
+                # Clamp created_at first (dual-future-dated case, CONCERN — Adversary):
+                # ensures updated_at floor uses the already-clamped value so the
+                # invariant created_at <= updated_at <= now holds.
+                if record.created_at and record.created_at > now:
+                    record.created_at = now
+                    logger.warning(
+                        f"_heal_future_updated_at: clamped future created_at on {record.id}"
+                    )
+
+                floor = record.created_at if record.created_at else now
+                record.updated_at = max(floor, now)
+                # Save via the override (which will re-stamp utc_now(), which == now — idempotent).
+                # Use update_fields to limit the write to only the fields we changed.
+                update_fields_list = ["updated_at"]
+                if record.created_at and record.created_at == now:
+                    update_fields_list.append("created_at")
+                record.save(update_fields=update_fields_list)
+                count += 1
+                logger.info(f"_heal_future_updated_at: healed session {record.id}")
+            except Exception as e:
+                logger.warning(
+                    f"_heal_future_updated_at: skipped {getattr(record, 'id', '?')}: {e}"
+                )
+
+        return count
 
     @classmethod
     def get_by_id(cls, agent_session_id: str | None) -> "AgentSession | None":

--- a/tests/integration/test_updated_at_heal.py
+++ b/tests/integration/test_updated_at_heal.py
@@ -1,0 +1,219 @@
+"""Integration tests for AgentSession updated_at UTC heal (bug #1645).
+
+Seeds future-dated updated_at values directly into Redis (bypassing the ORM,
+which now stamps correct UTC via the save() override) and verifies that
+_heal_future_updated_at() corrects them.
+
+Why bypass the ORM for seeding?
+    The normal save() path now stamps utc_now() for updated_at, so future values
+    can no longer be created through the ORM. To reproduce the pre-fix condition
+    (popoto auto_now writing naive local time on UTC+7 hosts), we write the raw
+    Redis hash directly, using the same datetime encoding format popoto uses:
+    "%Y%m%dT%H:%M:%S.%f" (strftime).
+
+Isolation:
+    All tests depend on the `redis_test_db` fixture (autouse=True in conftest.py),
+    which redirects Popoto to a per-worker Redis test database and flushes it
+    before/after each test. No production data is touched.
+"""
+
+import subprocess
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from models.agent_session import AgentSession
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_POPOTO_DT_FMT = "%Y%m%dT%H:%M:%S.%f"
+
+
+def _popoto_encode_dt(dt: datetime) -> str:
+    """Encode a datetime as popoto's DatetimeField wire format."""
+    # Popoto strips tzinfo on save (it's stored as a naive-looking string).
+    # We replicate that here so the seeded value looks exactly like what
+    # popoto auto_now would have written on a UTC+7 host.
+    return dt.strftime(_POPOTO_DT_FMT)
+
+
+def _seed_future_updated_at(session: AgentSession, offset_hours: int = 7) -> datetime:
+    """Directly write a future updated_at into the Redis hash for the given session.
+
+    Returns the future datetime that was seeded.
+
+    This bypasses the ORM save() path (which now stamps correct UTC) to
+    reproduce the pre-fix condition where popoto auto_now wrote naive local time.
+    """
+    import popoto.redis_db as rdb
+
+    future_dt = datetime.now(UTC) + timedelta(hours=offset_hours)
+    # Encode without tzinfo (popoto's naive-looking wire format)
+    encoded = _popoto_encode_dt(future_dt)
+
+    redis_key = f"AgentSession:{session.id}"
+    rdb.POPOTO_REDIS_DB.hset(redis_key, "updated_at", encoded)
+    return future_dt
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def future_session(redis_test_db):
+    """Create an AgentSession and seed its updated_at ~7h in the future."""
+    session = AgentSession.create(
+        session_id="heal-integration-1",
+        project_key="test-heal",
+        status="completed",
+        chat_id="heal-chat-1",
+        working_dir="/tmp/test-heal",
+    )
+    _seed_future_updated_at(session, offset_hours=7)
+    return session
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestHealIntegration:
+    """Integration tests: seed future-dated Redis records, heal, assert invariants."""
+
+    def test_heal_corrects_future_updated_at(self, future_session, redis_test_db):
+        """After heal, updated_at must be <= now (no longer in the future)."""
+        # Reload from Redis to confirm the seed took effect
+        reloaded = AgentSession.get_by_id(future_session.id)
+        assert reloaded is not None
+
+        now_before = datetime.now(UTC)
+        assert reloaded.updated_at > now_before, (
+            "Seed did not produce a future updated_at — test setup is broken"
+        )
+
+        # Run heal
+        count = AgentSession._heal_future_updated_at()
+        assert count >= 1, f"Expected at least 1 healed record, got {count}"
+
+        # Reload again and verify the invariant
+        healed = AgentSession.get_by_id(future_session.id)
+        assert healed is not None
+        now_after = datetime.now(UTC)
+
+        assert healed.updated_at is not None
+        assert healed.updated_at <= now_after + timedelta(seconds=5), (
+            f"updated_at {healed.updated_at!r} is still in the future after heal "
+            f"(now={now_after!r})"
+        )
+
+    def test_heal_preserves_created_at_lte_updated_at_invariant(
+        self, future_session, redis_test_db
+    ):
+        """After heal, created_at <= updated_at must hold."""
+        AgentSession._heal_future_updated_at()
+
+        healed = AgentSession.get_by_id(future_session.id)
+        assert healed is not None
+        assert healed.created_at is not None
+        assert healed.updated_at is not None
+
+        assert healed.created_at <= healed.updated_at, (
+            f"Invariant violated: created_at={healed.created_at!r} > "
+            f"updated_at={healed.updated_at!r}"
+        )
+
+    def test_heal_idempotent_on_redis_records(self, future_session, redis_test_db):
+        """Running heal twice must produce count=0 on the second pass."""
+        count1 = AgentSession._heal_future_updated_at()
+        count2 = AgentSession._heal_future_updated_at()
+
+        assert count1 >= 1, f"First heal should fix >=1 record, got {count1}"
+        assert count2 == 0, f"Second heal should fix 0 records (idempotent), got {count2}"
+
+    def test_sane_sessions_not_healed(self, redis_test_db):
+        """Sessions with updated_at already in the past are not touched by heal."""
+        session = AgentSession.create(
+            session_id="sane-heal-1",
+            project_key="test-heal",
+            status="completed",
+            chat_id="heal-chat-sane",
+            working_dir="/tmp/test-heal-sane",
+        )
+        # ORM save() already stamps correct UTC — no seeding needed
+        original_updated_at = session.updated_at
+
+        count = AgentSession._heal_future_updated_at()
+        assert count == 0, f"Sane session must not be healed, got count={count}"
+
+        reloaded = AgentSession.get_by_id(session.id)
+        assert reloaded is not None
+        # updated_at should not have changed (no heal save() was called)
+        if original_updated_at is not None:
+            assert abs((reloaded.updated_at - original_updated_at).total_seconds()) < 5, (
+                "Sane session's updated_at should not have been rewritten by heal"
+            )
+
+    def test_valor_session_status_shows_no_future_timestamp(self, future_session, redis_test_db):
+        """After heal, valor-session status output must not contain a future timestamp.
+
+        This verifies the end-to-end CLI surface: operators viewing session
+        status should no longer see timestamps 7 hours in the future after
+        the heal has run.
+
+        Note: valor-session status reads from Redis via the ORM, so this also
+        verifies that the healed value was persisted to Redis correctly.
+        """
+        # First verify the session is future-dated before heal
+        pre_heal = AgentSession.get_by_id(future_session.id)
+        now = datetime.now(UTC)
+        assert pre_heal.updated_at > now, "Pre-heal session must be future-dated"
+
+        # Run heal
+        AgentSession._heal_future_updated_at()
+
+        # Reload and check that the value is now sane
+        post_heal = AgentSession.get_by_id(future_session.id)
+        now_after = datetime.now(UTC)
+        assert post_heal.updated_at <= now_after + timedelta(seconds=5), (
+            f"Post-heal updated_at {post_heal.updated_at!r} is still in the future"
+        )
+
+        # Verify via CLI output — run valor-session status and check the timestamp
+        result = subprocess.run(
+            [
+                "python",
+                "-m",
+                "tools.valor_session",
+                "status",
+                "--id",
+                future_session.id,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        # CLI may fail if the session is in a terminal state or missing fields —
+        # we only check timestamp sanity if the command succeeds
+        if result.returncode == 0 and result.stdout:
+            output = result.stdout
+            # Parse out any timestamp-looking strings and verify none are 7h+ in future
+            # The output typically shows: "updated_at: 2026-06-12T..."
+            threshold = now_after + timedelta(hours=1)
+            import re
+
+            ts_pattern = r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}"
+            for match in re.finditer(ts_pattern, output):
+                try:
+                    ts_str = match.group(0).replace(" ", "T")
+                    ts = datetime.fromisoformat(ts_str).replace(tzinfo=UTC)
+                    assert ts <= threshold, (
+                        f"CLI output contains future timestamp {ts!r} "
+                        f"(threshold={threshold!r}): {output!r}"
+                    )
+                except ValueError:
+                    pass  # unparseable timestamp fragment, skip

--- a/tests/integration/test_updated_at_heal.py
+++ b/tests/integration/test_updated_at_heal.py
@@ -8,8 +8,14 @@ Why bypass the ORM for seeding?
     The normal save() path now stamps utc_now() for updated_at, so future values
     can no longer be created through the ORM. To reproduce the pre-fix condition
     (popoto auto_now writing naive local time on UTC+7 hosts), we write the raw
-    Redis hash directly, using the same datetime encoding format popoto uses:
-    "%Y%m%dT%H:%M:%S.%f" (strftime).
+    Redis hash directly.
+
+Seed mechanism (CONCERN — Skeptic/Adversary):
+    Popoto encodes datetime fields using msgpack with the schema:
+        {'__datetime__': True, 'as_encodable': '20260613T00:03:13.103209'}
+    and stores them in the Redis hash key at `session._redis_key`.
+    The seed step writes this encoded value directly to Redis; the heal and
+    all assertions still go through the ORM.
 
 Isolation:
     All tests depend on the `redis_test_db` fixture (autouse=True in conftest.py),
@@ -18,8 +24,10 @@ Isolation:
 """
 
 import subprocess
+import uuid
 from datetime import UTC, datetime, timedelta
 
+import msgpack
 import pytest
 
 from models.agent_session import AgentSession
@@ -28,33 +36,49 @@ from models.agent_session import AgentSession
 # Helpers
 # ---------------------------------------------------------------------------
 
-_POPOTO_DT_FMT = "%Y%m%dT%H:%M:%S.%f"
+
+def _as_utc(dt: datetime) -> datetime:
+    """Attach UTC tzinfo to a naive datetime (popoto strips tzinfo on load).
+
+    This is the same logic used by bridge/utc.py::to_unix_ts and the
+    AgentSession read-back normalization: naive == UTC.
+    """
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt
 
 
-def _popoto_encode_dt(dt: datetime) -> str:
-    """Encode a datetime as popoto's DatetimeField wire format."""
-    # Popoto strips tzinfo on save (it's stored as a naive-looking string).
-    # We replicate that here so the seeded value looks exactly like what
-    # popoto auto_now would have written on a UTC+7 host.
-    return dt.strftime(_POPOTO_DT_FMT)
+def _popoto_encode_datetime(dt: datetime) -> bytes:
+    """Encode a datetime as popoto's msgpack wire format.
+
+    Popoto's DatetimeField stores datetimes as:
+        msgpack({'__datetime__': True, 'as_encodable': '20260613T00:03:13.103209'})
+    with tzinfo stripped (the strftime format drops tz).
+    """
+    dt_str = dt.strftime("%Y%m%dT%H:%M:%S.%f")
+    return msgpack.packb({"__datetime__": True, "as_encodable": dt_str})
 
 
 def _seed_future_updated_at(session: AgentSession, offset_hours: int = 7) -> datetime:
     """Directly write a future updated_at into the Redis hash for the given session.
 
-    Returns the future datetime that was seeded.
+    Returns the future datetime that was seeded (tz-aware UTC).
 
     This bypasses the ORM save() path (which now stamps correct UTC) to
     reproduce the pre-fix condition where popoto auto_now wrote naive local time.
+
+    Uses:
+    - session._redis_key  — the full composite Redis hash key
+    - msgpack encoding    — the wire format popoto's DatetimeField uses
     """
     import popoto.redis_db as rdb
 
     future_dt = datetime.now(UTC) + timedelta(hours=offset_hours)
-    # Encode without tzinfo (popoto's naive-looking wire format)
-    encoded = _popoto_encode_dt(future_dt)
+    encoded = _popoto_encode_datetime(future_dt)
 
-    redis_key = f"AgentSession:{session.id}"
-    rdb.POPOTO_REDIS_DB.hset(redis_key, "updated_at", encoded)
+    rdb.POPOTO_REDIS_DB.hset(session._redis_key, "updated_at", encoded)
     return future_dt
 
 
@@ -66,11 +90,12 @@ def _seed_future_updated_at(session: AgentSession, offset_hours: int = 7) -> dat
 @pytest.fixture
 def future_session(redis_test_db):
     """Create an AgentSession and seed its updated_at ~7h in the future."""
+    uid = uuid.uuid4().hex[:8]
     session = AgentSession.create(
-        session_id="heal-integration-1",
+        session_id=f"heal-integration-{uid}",
         project_key="test-heal",
         status="completed",
-        chat_id="heal-chat-1",
+        chat_id=f"heal-chat-{uid}",
         working_dir="/tmp/test-heal",
     )
     _seed_future_updated_at(session, offset_hours=7)
@@ -92,8 +117,11 @@ class TestHealIntegration:
         assert reloaded is not None
 
         now_before = datetime.now(UTC)
-        assert reloaded.updated_at > now_before, (
-            "Seed did not produce a future updated_at — test setup is broken"
+        # Normalize to tz-aware for comparison (popoto strips tzinfo on read)
+        reloaded_updated_at = _as_utc(reloaded.updated_at)
+        assert reloaded_updated_at > now_before, (
+            "Seed did not produce a future updated_at — test setup is broken. "
+            f"updated_at={reloaded_updated_at!r}, now={now_before!r}"
         )
 
         # Run heal
@@ -106,8 +134,9 @@ class TestHealIntegration:
         now_after = datetime.now(UTC)
 
         assert healed.updated_at is not None
-        assert healed.updated_at <= now_after + timedelta(seconds=5), (
-            f"updated_at {healed.updated_at!r} is still in the future after heal "
+        healed_updated_at = _as_utc(healed.updated_at)
+        assert healed_updated_at <= now_after + timedelta(seconds=5), (
+            f"updated_at {healed_updated_at!r} is still in the future after heal "
             f"(now={now_after!r})"
         )
 
@@ -122,9 +151,12 @@ class TestHealIntegration:
         assert healed.created_at is not None
         assert healed.updated_at is not None
 
-        assert healed.created_at <= healed.updated_at, (
-            f"Invariant violated: created_at={healed.created_at!r} > "
-            f"updated_at={healed.updated_at!r}"
+        healed_created_at = _as_utc(healed.created_at)
+        healed_updated_at = _as_utc(healed.updated_at)
+
+        assert healed_created_at <= healed_updated_at, (
+            f"Invariant violated: created_at={healed_created_at!r} > "
+            f"updated_at={healed_updated_at!r}"
         )
 
     def test_heal_idempotent_on_redis_records(self, future_session, redis_test_db):
@@ -137,24 +169,26 @@ class TestHealIntegration:
 
     def test_sane_sessions_not_healed(self, redis_test_db):
         """Sessions with updated_at already in the past are not touched by heal."""
+        uid = uuid.uuid4().hex[:8]
         session = AgentSession.create(
-            session_id="sane-heal-1",
+            session_id=f"sane-heal-{uid}",
             project_key="test-heal",
             status="completed",
-            chat_id="heal-chat-sane",
+            chat_id=f"heal-chat-sane-{uid}",
             working_dir="/tmp/test-heal-sane",
         )
         # ORM save() already stamps correct UTC — no seeding needed
-        original_updated_at = session.updated_at
+        original_updated_at = _as_utc(session.updated_at)
 
         count = AgentSession._heal_future_updated_at()
         assert count == 0, f"Sane session must not be healed, got count={count}"
 
         reloaded = AgentSession.get_by_id(session.id)
         assert reloaded is not None
-        # updated_at should not have changed (no heal save() was called)
+        # updated_at should not have changed significantly (no heal save() was called)
         if original_updated_at is not None:
-            assert abs((reloaded.updated_at - original_updated_at).total_seconds()) < 5, (
+            reloaded_updated_at = _as_utc(reloaded.updated_at)
+            assert abs((reloaded_updated_at - original_updated_at).total_seconds()) < 5, (
                 "Sane session's updated_at should not have been rewritten by heal"
             )
 
@@ -171,7 +205,11 @@ class TestHealIntegration:
         # First verify the session is future-dated before heal
         pre_heal = AgentSession.get_by_id(future_session.id)
         now = datetime.now(UTC)
-        assert pre_heal.updated_at > now, "Pre-heal session must be future-dated"
+        pre_heal_updated_at = _as_utc(pre_heal.updated_at)
+        assert pre_heal_updated_at > now, (
+            f"Pre-heal session must be future-dated. "
+            f"updated_at={pre_heal_updated_at!r}, now={now!r}"
+        )
 
         # Run heal
         AgentSession._heal_future_updated_at()
@@ -179,8 +217,9 @@ class TestHealIntegration:
         # Reload and check that the value is now sane
         post_heal = AgentSession.get_by_id(future_session.id)
         now_after = datetime.now(UTC)
-        assert post_heal.updated_at <= now_after + timedelta(seconds=5), (
-            f"Post-heal updated_at {post_heal.updated_at!r} is still in the future"
+        post_heal_updated_at = _as_utc(post_heal.updated_at)
+        assert post_heal_updated_at <= now_after + timedelta(seconds=5), (
+            f"Post-heal updated_at {post_heal_updated_at!r} is still in the future"
         )
 
         # Verify via CLI output — run valor-session status and check the timestamp

--- a/tests/unit/test_agent_session_updated_at_utc.py
+++ b/tests/unit/test_agent_session_updated_at_utc.py
@@ -1,0 +1,427 @@
+"""Unit tests for AgentSession.save() UTC timestamp stamping and _heal_future_updated_at.
+
+Covers bug #1645: popoto auto_now minted naive local time; fix stamps UTC via save() override.
+
+Tests are pure-logic (no Redis) — they patch save() to avoid touching Redis.
+"""
+
+import logging
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+from models.agent_session import AgentSession
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_session_no_save(**kwargs):
+    """Instantiate an AgentSession without touching Redis.
+
+    Patches save() at the class level during construction so test sessions
+    are pure in-memory objects.
+    """
+    defaults = {
+        "project_key": "test-utc",
+        "chat_id": "chat-utc-1",
+        "session_id": "sid-utc-1",
+        "working_dir": "/tmp/test-utc",
+    }
+    defaults.update(kwargs)
+    original_save = AgentSession.save
+    AgentSession.save = lambda self, *a, **kw: None
+    try:
+        s = AgentSession(**defaults)
+    finally:
+        AgentSession.save = original_save
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Tests: save() stamps UTC
+# ---------------------------------------------------------------------------
+
+
+class TestSaveStampsUTC:
+    """save() override always stamps a tz-aware UTC datetime into updated_at."""
+
+    def test_save_stamps_utc_aware_datetime(self):
+        """save() must set updated_at to a tz-aware UTC datetime (not naive local)."""
+        s = _make_session_no_save()
+        save_calls = []
+
+        def fake_super_save(self, *args, update_fields=None, **kwargs):
+            save_calls.append((args, update_fields, kwargs))
+
+        with patch.object(AgentSession.__bases__[0], "save", fake_super_save, create=True):
+            # Directly invoke our override (super() is patched, no Redis call)
+            before = datetime.now(UTC)
+            AgentSession.save(s)
+            after = datetime.now(UTC)
+
+        assert s.updated_at is not None, "updated_at must not be None after save()"
+        assert s.updated_at.tzinfo is not None, (
+            "updated_at must be tz-aware (was naive — the bug this test catches)"
+        )
+        assert s.updated_at.tzinfo == UTC, (
+            f"updated_at must be UTC, got tzinfo={s.updated_at.tzinfo!r}"
+        )
+        assert before <= s.updated_at <= after, (
+            "updated_at must be close to wall-clock now, "
+            f"got {s.updated_at!r} outside [{before!r}, {after!r}]"
+        )
+
+    def test_save_stamps_updated_at_not_naive_local(self):
+        """updated_at after save() must be tz-aware, ruling out naive datetime.now()."""
+        s = _make_session_no_save()
+        s.updated_at = None
+
+        with patch.object(AgentSession.__bases__[0], "save", lambda self, *a, **kw: None):
+            AgentSession.save(s)
+
+        # The critical invariant: tzinfo is set (not naive)
+        assert s.updated_at is not None
+        assert s.updated_at.tzinfo is not None, (
+            "Bug #1645: popoto auto_now minted naive datetime.now(); "
+            "our override must mint tz-aware UTC instead"
+        )
+
+    def test_save_updates_updated_at_monotonically(self):
+        """Each successive save() call must produce an equal-or-later updated_at."""
+        s = _make_session_no_save()
+
+        timestamps = []
+
+        def capture_save(self, *args, update_fields=None, **kwargs):
+            timestamps.append(self.updated_at)
+
+        with patch.object(AgentSession.__bases__[0], "save", capture_save):
+            AgentSession.save(s)
+            t1 = s.updated_at
+            AgentSession.save(s)
+            t2 = s.updated_at
+
+        assert t2 >= t1, f"Second save must not go backwards: {t1!r} → {t2!r}"
+
+    def test_save_delegates_to_super(self):
+        """save() must call super().save() exactly once with the same positional args."""
+        s = _make_session_no_save()
+        super_calls = []
+
+        def recording_super_save(self, *args, update_fields=None, **kwargs):
+            super_calls.append({"args": args, "update_fields": update_fields, "kwargs": kwargs})
+
+        with patch.object(AgentSession.__bases__[0], "save", recording_super_save):
+            AgentSession.save(s, update_fields=["status", "updated_at"])
+
+        assert len(super_calls) == 1, f"Expected 1 super().save() call, got {len(super_calls)}"
+        assert super_calls[0]["update_fields"] == ["status", "updated_at"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: save() update_fields guard
+# ---------------------------------------------------------------------------
+
+
+class TestSaveUpdateFieldsGuard:
+    """save() must NOT mutate updated_at when update_fields omits it."""
+
+    def test_save_skips_stamp_when_updated_at_not_in_update_fields(self, caplog):
+        """If update_fields omits 'updated_at', in-memory value must NOT be overwritten."""
+        s = _make_session_no_save()
+        # Set a known sentinel value
+        sentinel = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+        s.updated_at = sentinel
+
+        super_save_called = []
+
+        def recording_super_save(self, *args, update_fields=None, **kwargs):
+            super_save_called.append(update_fields)
+
+        with caplog.at_level(logging.WARNING, logger="models.agent_session"):
+            with patch.object(AgentSession.__bases__[0], "save", recording_super_save):
+                AgentSession.save(s, update_fields=["status"])
+
+        # updated_at must NOT have been overwritten
+        assert s.updated_at == sentinel, (
+            f"updated_at was mutated to {s.updated_at!r} even though "
+            "update_fields=['status'] did not include 'updated_at'"
+        )
+        # A warning must be logged
+        assert any("updated_at" in record.message for record in caplog.records), (
+            "Expected a warning about missing 'updated_at' in update_fields"
+        )
+        # super().save() still called once (partial save still happens)
+        assert len(super_save_called) == 1
+
+    def test_save_stamps_when_updated_at_in_update_fields(self):
+        """If update_fields includes 'updated_at', stamp must happen."""
+        s = _make_session_no_save()
+        old_ts = datetime(2020, 1, 1, tzinfo=UTC)
+        s.updated_at = old_ts
+
+        with patch.object(AgentSession.__bases__[0], "save", lambda self, *a, **kw: None):
+            AgentSession.save(s, update_fields=["status", "updated_at"])
+
+        assert s.updated_at > old_ts, (
+            f"updated_at should have been stamped forward from {old_ts!r}, got {s.updated_at!r}"
+        )
+
+    def test_save_stamps_when_update_fields_is_none(self):
+        """update_fields=None (the default full-save path) must stamp updated_at."""
+        s = _make_session_no_save()
+        old_ts = datetime(2020, 1, 1, tzinfo=UTC)
+        s.updated_at = old_ts
+
+        with patch.object(AgentSession.__bases__[0], "save", lambda self, *a, **kw: None):
+            AgentSession.save(s)  # update_fields defaults to None
+
+        assert s.updated_at > old_ts, "Full save (update_fields=None) must stamp updated_at"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _heal_future_updated_at
+# ---------------------------------------------------------------------------
+
+
+class TestHealFutureUpdatedAt:
+    """_heal_future_updated_at() must clamp future-dated records to now."""
+
+    def _build_records(self, records_spec):
+        """Build in-memory AgentSession instances from a list of (updated_at, created_at) pairs."""
+        sessions = []
+        for spec in records_spec:
+            s = _make_session_no_save()
+            s.updated_at = spec.get("updated_at")
+            s.created_at = spec.get("created_at")
+            s.id = spec.get("id", f"test-{id(s)}")
+            sessions.append(s)
+        return sessions
+
+    def test_heal_clamps_future_record(self):
+        """A session with updated_at 7h in the future must be healed."""
+        now = datetime.now(UTC)
+        future = now + timedelta(hours=7)
+        past = now - timedelta(minutes=30)
+
+        session = _make_session_no_save()
+        session.updated_at = future
+        session.created_at = past
+        session.id = "future-session-1"
+
+        save_calls = []
+
+        def mock_save(self, *args, update_fields=None, **kwargs):
+            # Simulate what our real save() does: stamp utc_now()
+            from bridge.utc import utc_now
+
+            if update_fields is None or "updated_at" in update_fields:
+                self.updated_at = utc_now()
+            save_calls.append(update_fields)
+
+        with (
+            patch.object(AgentSession, "query") as mock_query,
+            patch.object(AgentSession, "save", mock_save),
+        ):
+            mock_query.all.return_value = [session]
+            count = AgentSession._heal_future_updated_at()
+
+        assert count == 1, f"Expected 1 healed record, got {count}"
+        assert len(save_calls) == 1, "save() must be called once for the healed record"
+        assert session.updated_at <= datetime.now(UTC) + timedelta(seconds=2), (
+            f"updated_at should be near-now after heal, got {session.updated_at!r}"
+        )
+
+    def test_heal_skips_sane_records(self):
+        """Sessions with updated_at in the past must not be touched."""
+        now = datetime.now(UTC)
+        past = now - timedelta(hours=2)
+
+        session = _make_session_no_save()
+        session.updated_at = past
+        session.created_at = past - timedelta(minutes=5)
+        session.id = "sane-session"
+
+        save_calls = []
+
+        def mock_save(self, *args, **kwargs):
+            save_calls.append(True)
+
+        with (
+            patch.object(AgentSession, "query") as mock_query,
+            patch.object(AgentSession, "save", mock_save),
+        ):
+            mock_query.all.return_value = [session]
+            count = AgentSession._heal_future_updated_at()
+
+        assert count == 0, "Sane record must not be counted as healed"
+        assert len(save_calls) == 0, "save() must not be called for a sane record"
+        # updated_at must be unchanged
+        assert session.updated_at == past
+
+    def test_heal_skips_none_updated_at(self):
+        """Sessions with updated_at=None must be left untouched."""
+        session = _make_session_no_save()
+        session.updated_at = None
+        session.created_at = datetime.now(UTC) - timedelta(hours=1)
+        session.id = "none-ts-session"
+
+        save_calls = []
+
+        def mock_save(self, *args, **kwargs):
+            save_calls.append(True)
+
+        with (
+            patch.object(AgentSession, "query") as mock_query,
+            patch.object(AgentSession, "save", mock_save),
+        ):
+            mock_query.all.return_value = [session]
+            count = AgentSession._heal_future_updated_at()
+
+        assert count == 0
+        assert len(save_calls) == 0
+        assert session.updated_at is None
+
+    def test_heal_is_idempotent(self):
+        """Running heal twice must produce count=0 on the second run."""
+        now = datetime.now(UTC)
+        future = now + timedelta(hours=7)
+
+        session = _make_session_no_save()
+        session.updated_at = future
+        session.created_at = now - timedelta(minutes=10)
+        session.id = "idempotent-session"
+
+        def mock_save(self, *args, update_fields=None, **kwargs):
+            from bridge.utc import utc_now
+
+            if update_fields is None or "updated_at" in update_fields:
+                self.updated_at = utc_now()
+
+        with (
+            patch.object(AgentSession, "query") as mock_query,
+            patch.object(AgentSession, "save", mock_save),
+        ):
+            mock_query.all.return_value = [session]
+
+            count1 = AgentSession._heal_future_updated_at()
+            # After first heal, updated_at is now near-current
+            # Second call should see updated_at <= now, skip it
+            count2 = AgentSession._heal_future_updated_at()
+
+        assert count1 == 1, f"First heal should fix 1 record, got {count1}"
+        assert count2 == 0, f"Second heal should fix 0 records (idempotent), got {count2}"
+
+    def test_heal_handles_created_at_none_with_future_updated_at(self):
+        """created_at=None with future updated_at — heal must clamp to now."""
+        now = datetime.now(UTC)
+        future = now + timedelta(hours=5)
+
+        session = _make_session_no_save()
+        session.updated_at = future
+        session.created_at = None
+        session.id = "no-created-at-session"
+
+        def mock_save(self, *args, update_fields=None, **kwargs):
+            from bridge.utc import utc_now
+
+            if update_fields is None or "updated_at" in update_fields:
+                self.updated_at = utc_now()
+
+        with (
+            patch.object(AgentSession, "query") as mock_query,
+            patch.object(AgentSession, "save", mock_save),
+        ):
+            mock_query.all.return_value = [session]
+            count = AgentSession._heal_future_updated_at()
+
+        assert count == 1
+        assert session.updated_at <= datetime.now(UTC) + timedelta(seconds=2)
+
+    def test_heal_dual_future_case_invariant(self):
+        """Dual-future: both created_at and updated_at in the future.
+
+        After heal the invariant created_at <= updated_at <= now must hold.
+        """
+        now = datetime.now(UTC)
+        future_updated = now + timedelta(hours=7)
+        future_created = now + timedelta(hours=7)  # same offset — both naive-local stamped
+
+        session = _make_session_no_save()
+        session.updated_at = future_updated
+        session.created_at = future_created
+        session.id = "dual-future-session"
+
+        def mock_save(self, *args, update_fields=None, **kwargs):
+            from bridge.utc import utc_now
+
+            current_now = utc_now()
+            if update_fields is None or "updated_at" in update_fields:
+                self.updated_at = current_now
+            # created_at clamping is done before save() is called in the heal loop
+
+        with (
+            patch.object(AgentSession, "query") as mock_query,
+            patch.object(AgentSession, "save", mock_save),
+        ):
+            mock_query.all.return_value = [session]
+            count = AgentSession._heal_future_updated_at()
+
+        assert count == 1
+        # created_at was clamped to now by the heal loop before save()
+        real_now = datetime.now(UTC)
+        assert session.created_at <= real_now + timedelta(seconds=2), (
+            f"created_at should be clamped to ~now, got {session.created_at!r}"
+        )
+        assert session.updated_at <= real_now + timedelta(seconds=2), (
+            f"updated_at should be clamped to ~now, got {session.updated_at!r}"
+        )
+
+    def test_heal_returns_zero_on_query_failure(self, caplog):
+        """If query.all() raises, heal must return 0 (fail-soft)."""
+        with patch.object(AgentSession, "query") as mock_query:
+            mock_query.all.side_effect = RuntimeError("Redis connection error")
+            with caplog.at_level(logging.WARNING, logger="models.agent_session"):
+                count = AgentSession._heal_future_updated_at()
+
+        assert count == 0
+        assert any("could not fetch sessions" in r.message for r in caplog.records)
+
+    def test_heal_skips_record_on_save_error(self, caplog):
+        """If a single record's save() raises, heal skips that record and continues."""
+        now = datetime.now(UTC)
+        future = now + timedelta(hours=7)
+
+        bad = _make_session_no_save()
+        bad.updated_at = future
+        bad.created_at = now - timedelta(minutes=5)
+        bad.id = "bad-save-session"
+
+        good = _make_session_no_save()
+        good.updated_at = future
+        good.created_at = now - timedelta(minutes=5)
+        good.id = "good-save-session"
+
+        call_count = [0]
+
+        def mock_save(self, *args, update_fields=None, **kwargs):
+            call_count[0] += 1
+            if self.id == "bad-save-session":
+                raise RuntimeError("Redis write error")
+            from bridge.utc import utc_now
+
+            if update_fields is None or "updated_at" in update_fields:
+                self.updated_at = utc_now()
+
+        with (
+            patch.object(AgentSession, "query") as mock_query,
+            patch.object(AgentSession, "save", mock_save),
+        ):
+            mock_query.all.return_value = [bad, good]
+            with caplog.at_level(logging.WARNING, logger="models.agent_session"):
+                count = AgentSession._heal_future_updated_at()
+
+        # Only the good record was successfully healed
+        assert count == 1
+        assert any("skipped" in r.message for r in caplog.records)

--- a/worker/__main__.py
+++ b/worker/__main__.py
@@ -325,6 +325,17 @@ async def _run_worker(projects: dict, dry_run: bool = False) -> None:
     except Exception as e:
         logger.warning(f"Class-set orphan cleanup failed (non-fatal): {e}")
 
+    # Step 2c: Heal future-dated updated_at values written before fix #1645.
+    # Clamps any session whose updated_at is in the future (caused by popoto
+    # auto_now minting naive local time on non-UTC hosts). Idempotent.
+    try:
+        from models.agent_session import AgentSession as _AgentSession
+
+        count = _AgentSession._heal_future_updated_at()
+        logger.info(f"_heal_future_updated_at: healed {count} records")
+    except Exception as e:
+        logger.warning(f"_heal_future_updated_at non-fatal: {e}")
+
     # Step 3: Recover any sessions that were running when the previous process died
     try:
         recovered = _recover_interrupted_agent_sessions_startup()


### PR DESCRIPTION
## Summary

- Removes `auto_now=True` from `AgentSession.updated_at`; adds a `save()` override that stamps `utc_now()` (UTC wall-clock) so the stored value is always correct regardless of host timezone
- Adds `_heal_future_updated_at()` classmethod that clamps legacy future-dated records at worker startup
- Fixes the live-observed symptom: `valor-session status` printing `Updated: 2026-06-12 17:49:42 UTC` when actual UTC was 10:49:42 (UTC+7 host)

## Root cause

popoto's `DatetimeField(auto_now=True)` called `datetime.now()` (no tz arg → naive local wall-clock). Downstream readers all re-attach `tz=UTC` to naive values (correct convention), but the stored wall-clock was local time — so on a UTC+7 host every `updated_at` was stamped 7h ahead of real UTC.

## Changes

- `models/agent_session.py`: drop `auto_now=True`; add `save()` override with UTC stamp + `update_fields` guard; add `_heal_future_updated_at` classmethod (dual-future, idempotent, fail-soft, returns count)
- `worker/__main__.py`: invoke heal at startup alongside index rebuild, with `try/except` + count logging
- `tests/unit/test_agent_session_updated_at_utc.py` (new): 15 unit tests covering UTC stamp, round-trip, heal edge cases
- `tests/integration/test_updated_at_heal.py` (new): 5 integration tests seeding future-dated records via Redis HSET + msgpack, verifying heal corrects them
- `docs/features/session-lifecycle.md`: new "Timestamp Convention" section with first-deploy callout

## Testing

- [x] New unit tests: 15 passed
- [x] Heal integration tests: 5 passed
- [x] Consumer regression suite: 73 passed (watchdog, status, stale-cleanup, liveness)
- [x] No `auto_now=True` in model declarations
- [x] Ruff format/lint clean

## First-deploy note

`_heal_future_updated_at()` runs once at worker startup and clamps future `updated_at` records down to now. Healed sessions will appear momentarily fresh to staleness checks for one window post-deploy — this is expected behavior, not real activity. See `docs/features/session-lifecycle.md` for full callout.

## Follow-up

#1653 tracks the upstream popoto fix (minting `datetime.now(UTC)` for `auto_now`/`auto_now_add`) as defense-in-depth so any future `auto_now` field is correct by default.

Closes #1645