### PR TITLE
Fix SDLC router stale-critique dead-end (#1639) + war-room finalize (#1654)

### DIFF
--- a/.claude/skills-global/do-plan-critique/SKILL.md
+++ b/.claude/skills-global/do-plan-critique/SKILL.md
@@ -15,12 +15,14 @@ At the very start of this skill, write an in_progress marker:
 sdlc-tool stage-marker --stage CRITIQUE --status in_progress --issue-number {issue_number} 2>/dev/null || true
 ```
 
-After posting the verdict (Step 5), write the completion marker if READY TO BUILD, leave in_progress otherwise:
+The completion marker is written in **Step 5.5**, co-located with the verdict record so the two can never desync. On a READY TO BUILD verdict, write the completion marker; on any other verdict, leave it `in_progress`. Step 5.5 is mandatory and reached on every exit path — see that step for the self-contained verdict-record + marker block:
 
 ```bash
-# On READY TO BUILD verdict:
+# On READY TO BUILD verdict (written in Step 5.5, immediately after `verdict record`):
 sdlc-tool stage-marker --stage CRITIQUE --status completed --issue-number {issue_number} 2>/dev/null || true
 ```
+
+Do NOT write the completion marker before the verdict is recorded, and do NOT record an APPROVED/READY verdict without the matching completion marker. They are a single unit.
 
 
 ## What this skill does
@@ -166,9 +168,19 @@ IMPLEMENTATION NOTE: [Required for CONCERN and BLOCKER severity. Exempt for NIT.
 
 NITs are exempt from the Implementation Note field. For CONCERN and BLOCKER findings, the note must be concrete: a specific guard condition (e.g., `if event: event.set()`), a call signature, or a "why" explanation that prevents naive application of the fix.
 
+### Step 3.5: Wait and Collect (mandatory)
+
+The six critics from Step 3 were spawned with `run_in_background: true`. Before doing ANY aggregation, you MUST **wait and collect**: block on every one of the six background critic agents and retrieve each critic's complete findings.
+
+- Poll/await all six background agents until each has returned (use the Agent tool's blocking retrieval, e.g. `TaskOutput(block: true)` per critic, or await every background task). Do not proceed while any critic is still running.
+- Collect the full findings text from all six. A critic that returned zero findings still counts as collected — record it as "0 findings", do not skip it.
+- If a critic failed or returned nothing retrievable, re-spawn it and wait again. Never aggregate a partial set.
+
+**This skill owns finalization end to end.** It does NOT yield to a supervisor for aggregation or verdict recording. The wait-and-collect barrier here is precisely the synchronization that the old "After all critics complete" wording assumed but never enforced — without it, Steps 4, 5, 5.5 silently never run and the critique stalls at `in_progress`. Only after all six are collected do you proceed to Step 4.
+
 ### Step 4: Aggregate and Deduplicate
 
-After all critics complete:
+You have now collected all six critics' findings (Step 3.5). Aggregate:
 
 1. Collect all findings (structural + critic)
 2. **Deduplicate**: If two critics flagged the same issue, keep the higher-severity version and note which critics agreed
@@ -238,18 +250,31 @@ Output the final report in this format:
 - **MAJOR REWORK** — Fundamental issues identified. Recommend re-planning.
 ```
 
-### Step 5.5: Record the verdict (mandatory)
+### Step 5.5: Finalize — record verdict AND write completion marker (mandatory, self-contained)
 
-After printing the verdict, record it on the PM session so the SDLC router's Legal Dispatch Guards (G1, G5) can consume it:
+This step is **mandatory and reached on EVERY exit path** — every verdict (READY TO BUILD, NEEDS REVISION, MAJOR REWORK) must pass through it. There is no path out of this skill that skips Step 5.5. Do not return control to a supervisor before completing it.
+
+After printing the verdict (Step 5), record it on the PM session so the SDLC router's Legal Dispatch Guards (G1, G5) can consume it. On a READY TO BUILD verdict, **co-locate** the completion stage-marker write with the verdict record so the verdict and the marker can never desync:
 
 ```bash
+# 1. Record the verdict (ALL verdicts) — mandatory.
 sdlc-tool verdict record --stage CRITIQUE \
   --verdict "$VERDICT_STRING" --issue-number $ISSUE_NUMBER
+
+# 2. On a READY TO BUILD verdict ONLY, write the completion marker in the
+#    SAME block, immediately after the verdict record. Verdict + marker are a
+#    single unit: never record one without the other on the READY path.
+case "$VERDICT_STRING" in
+  *"READY TO BUILD"*)
+    sdlc-tool stage-marker --stage CRITIQUE --status completed \
+      --issue-number $ISSUE_NUMBER 2>/dev/null || true
+    ;;
+esac
 ```
 
 Where `$VERDICT_STRING` is the exact verdict string emitted in Step 5 (e.g. `"NEEDS REVISION"`, `"READY TO BUILD (with concerns)"`). If `$ISSUE_NUMBER` is unknown, omit the `--issue-number` flag — the recorder falls back to `VALOR_SESSION_ID` / `AGENT_SESSION_ID` env vars and the artifact_hash will be None.
 
-The recorder exits non-zero on failure (e.g. Redis unreachable) so the operator sees the error in their session log, but it still prints `{}` to stdout for callers parsing JSON. A failed recording surfaces loudly; it does not silently corrupt verdict state.
+The recorder exits non-zero on failure (e.g. Redis unreachable) so the operator sees the error in their session log, but it still prints `{}` to stdout for callers parsing JSON. A failed recording surfaces loudly; it does not silently corrupt verdict state. On a non-READY verdict, leave the CRITIQUE marker at `in_progress` (the router's row 3 / row 2b handle re-routing).
 
 ### Step 5.6: Set plan-revising lock (mandatory when revision is needed)
 
@@ -294,6 +319,7 @@ Use **"READY TO BUILD (no concerns)"** when there are zero CONCERN or BLOCKER fi
 
 ## Version history
 
+- v1.3.0 (2026-06-13): Add explicit Step 3.5 "Wait and Collect" barrier (block on all six background critics before aggregating); make Step 5.5 a mandatory, self-contained verdict-record + completion-marker block reached on every exit path; reinforce the Stage Marker note so the verdict and marker cannot desync (#1654)
 - v1.2.0 (2026-04-07): Fix Step 5 Verdict template to show both READY TO BUILD variants so critics output the correct form for SDLC routing
 - v1.1.0 (2026-03-23): Add SOURCE_FILES inline context to prevent critic hallucination (Step 1.5)
 - v1.0.0 (2026-03-21): Initial — war room critique with six parallel critics + structural checks

--- a/.claude/skills-global/do-pr-review/SKILL.md
+++ b/.claude/skills-global/do-pr-review/SKILL.md
@@ -183,15 +183,16 @@ Parse the JSON output:
 - `{"status": "degraded", ...}` — **announce at the top of your run**: "running in degraded mode (state not persisted)". The review itself depends only on `gh` and the diff, not the substrate, so proceed.
 - Non-zero exit — substrate present but the write genuinely failed; report the stderr diagnostic and proceed (do not silently swallow it).
 
-After posting the review (Step 6), on approval (no blockers):
+After posting the review (Step 6), on approval (no blockers), the REVIEW completion marker is written in the **"Record the verdict (mandatory)"** section, **co-located in the same block as the APPROVED verdict record** (#1642). Do NOT write the completion marker as a separate, earlier step — verdict-record and completion-marker are a single unit on the approval path so the REVIEW marker can never desync from an APPROVED verdict:
 
 ```bash
+# Written immediately after `sdlc-tool verdict record ... --verdict "APPROVED"`:
 sdlc-tool stage-marker --stage REVIEW --status completed --issue-number {issue_number}
 ```
 
 Apply the same degraded-vs-loud interpretation to the completion marker.
 
-Note: If blockers found, leave as in_progress — the SDLC dispatcher will invoke /do-patch and then re-run review, which will complete the stage after fixes.
+Note: If blockers/findings exist, record `CHANGES REQUESTED` and leave the marker as in_progress — the SDLC dispatcher will invoke /do-patch and then re-run review, which will complete the stage after fixes. The completion marker is written ONLY on the APPROVED path, and ONLY co-located with the APPROVED verdict record.
 
 ## Goal Alignment
 
@@ -693,8 +694,13 @@ After emitting the OUTCOME block, record the review verdict on the PM session so
 ```bash
 # Single-judge (legacy / SDLC_REVIEW_JUDGES=none / docs-only / preflight):
 # For APPROVED reviews (OUTCOME status=success):
+# #1642: the verdict record AND the REVIEW completion marker are ONE mandatory,
+# self-contained unit on the approval path — never record APPROVED without
+# immediately writing the completion marker, or the marker desyncs from the
+# verdict and router row 9 (/do-docs) stalls on REVIEW != completed.
 sdlc-tool verdict record --stage REVIEW \
   --verdict "APPROVED" --blockers 0 --tech-debt 0 --issue-number $ISSUE_NUMBER
+sdlc-tool stage-marker --stage REVIEW --status completed --issue-number $ISSUE_NUMBER
 
 # For reviews with findings (OUTCOME status=partial or fail):
 sdlc-tool verdict record --stage REVIEW \

--- a/agent/sdlc_router.py
+++ b/agent/sdlc_router.py
@@ -654,7 +654,16 @@ def _rule_plan_not_critiqued(stage_states: dict, meta: dict, context: dict) -> b
 
 
 def _rule_critique_needs_revision(stage_states: dict, meta: dict, context: dict) -> bool:
-    """Plan critiqued (NEEDS REVISION)."""
+    """Plan critiqued (NEEDS REVISION).
+
+    Staleness step-aside (#1639): if the critique verdict predates the latest
+    ``/do-plan`` dispatch, the plan was already revised, so this row steps aside
+    (returns False) and lets row 2b re-dispatch ``/do-plan-critique`` for a
+    fresh critique. Mirrors the ``_review_verdict_is_stale`` step-aside in
+    ``_rule_review_has_findings``.
+    """
+    if _critique_verdict_is_stale(stage_states):
+        return False
     verdict = normalize_verdict(_latest_critique_verdict(stage_states, meta))
     return CRITIQUE_NEEDS_REVISION in verdict
 
@@ -773,6 +782,59 @@ def _review_verdict_is_stale(stage_states: dict) -> bool:
         return False
 
 
+def _critique_verdict_is_stale(stage_states: dict) -> bool:
+    """Return True if the CRITIQUE verdict predates the latest /do-plan dispatch (stale).
+
+    Structural twin of :func:`_review_verdict_is_stale` (mirrors PR #1657's
+    REVIEW pattern for the CRITIQUE path, #1639). A critique verdict is stale
+    once the plan it judged has been revised — i.e. a ``/do-plan`` dispatch is
+    recorded *after* the verdict's ``recorded_at``. A stale NEEDS REVISION
+    verdict must route back to ``/do-plan-critique`` (row 2b) rather than
+    dead-ending on ``/do-plan`` (row 3).
+
+    Fails safe to False (not stale) on any missing data or parse error.
+
+    Edge cases:
+    - ``_verdicts.CRITIQUE`` absent / not a dict → False (not stale)
+    - missing ``recorded_at`` → False (not stale)
+    - no prior ``/do-plan`` dispatch → False (not stale)
+    - equal timestamps → False (not stale, strict ``<``)
+    - parse failure (non-iso timestamp) → False (not stale)
+    """
+    try:
+        verdict_dict = stage_states.get("_verdicts", {}).get("CRITIQUE", {})
+        if not isinstance(verdict_dict, dict):
+            return False
+        recorded_at = verdict_dict.get("recorded_at")
+        if not recorded_at:
+            return False
+        latest_plan_at = _latest_dispatch_at(stage_states, SKILL_DO_PLAN)
+        if not latest_plan_at:
+            return False
+        verdict_dt = datetime.fromisoformat(recorded_at)
+        plan_dt = datetime.fromisoformat(latest_plan_at)
+        return verdict_dt < plan_dt
+    except Exception:
+        return False
+
+
+def _rule_critique_verdict_stale(stage_states: dict, meta: dict, context: dict) -> bool:
+    """Critique verdict is stale (plan revised since the verdict was recorded).
+
+    Fires row 2b (``/do-plan-critique``) when the CRITIQUE verdict predates the
+    latest ``/do-plan`` dispatch AND a non-empty critique verdict text exists.
+    Marker-agnostic by design: the #1639 dead-end leaves CRITIQUE at
+    ``in_progress``, so this rule must NOT require any particular marker value.
+
+    Loop-bound: G5 (``guard_g5_artifact_hash_cache``) runs before this row and
+    short-circuits re-critique when the plan hash is unchanged, so this rule can
+    only progress on a genuinely revised plan. See the docstring on row 2b.
+    """
+    if not _critique_verdict_is_stale(stage_states):
+        return False
+    return bool(_latest_critique_verdict(stage_states, meta).strip())
+
+
 def _rule_pr_exists_no_review(stage_states: dict, meta: dict, context: dict) -> bool:
     """PR exists, no review."""
     if not meta.get("pr_number"):
@@ -864,6 +926,7 @@ def _rule_stage_states_unavailable_pr_open(stage_states: dict, meta: dict, conte
 # these to cross-check SKILL.md row state cells. Keep in sync with SKILL.md.
 _rule_no_plan.__doc__ = "No plan exists"
 _rule_plan_not_critiqued.__doc__ = "Plan exists, not yet critiqued"
+_rule_critique_verdict_stale.__doc__ = "Critique verdict is stale (plan revised since)"
 _rule_critique_needs_revision.__doc__ = "Plan critiqued (NEEDS REVISION)"
 _rule_critique_ready_no_concerns.__doc__ = (
     "Plan critiqued (READY TO BUILD, zero concerns), no branch/PR"
@@ -905,6 +968,19 @@ DISPATCH_RULES: list[DispatchRule] = [
         state_predicate=_rule_plan_not_critiqued,
         skill=SKILL_DO_PLAN_CRITIQUE,
         reason="Plan must pass critique before build",
+    ),
+    # Row 2b (#1639): a stale CRITIQUE verdict (recorded before the latest
+    # /do-plan dispatch) means the plan was revised since the verdict — re-run
+    # the critique rather than dead-ending on /do-plan. Placed BEFORE row 3 so
+    # stale → re-critique wins over row 3's stale-text → /do-plan match. Mirrors
+    # REVIEW row 8b. Disjoint from G1 (which fires only when the last dispatch
+    # was /do-plan-critique; the #1639 dead-end has last dispatch = /do-plan),
+    # and bounded by G5 (re-critique short-circuits on an unchanged plan hash).
+    DispatchRule(
+        row_id="2b",
+        state_predicate=_rule_critique_verdict_stale,
+        skill=SKILL_DO_PLAN_CRITIQUE,
+        reason="Critique verdict is stale (plan revised since) — re-critique",
     ),
     DispatchRule(
         row_id="3",

--- a/docs/features/sdlc-router-oscillation-guard.md
+++ b/docs/features/sdlc-router-oscillation-guard.md
@@ -182,6 +182,31 @@ All edge cases fail safe to "not stale":
 
 This prevents the router from dispatching `/do-patch` against review findings that were already addressed by a prior patch cycle, which would create an oscillation between row 8 and row 8b.
 
+## Stale-Verdict Supersession — CRITIQUE (Row 2b / Row 3)
+
+The REVIEW staleness pattern above is mirrored for the CRITIQUE path (#1639), fixing the stale-critique dead-end: after a plan is revised in response to a plain `NEEDS REVISION` verdict, the router previously kept matching the stale cached verdict text and re-dispatching `/do-plan` forever.
+
+- A CRITIQUE verdict is **stale** iff its `recorded_at` timestamp predates the latest `/do-plan` dispatch timestamp in `_sdlc_dispatches`. The plan was demonstrably revised after the verdict.
+- This is encoded as `_critique_verdict_is_stale(stage_states)` — a structural twin of `_review_verdict_is_stale`, swapping `REVIEW`→`CRITIQUE` and `/do-patch`→`/do-plan`. The two helpers are kept as parallel functions intentionally (no DRY merge) to keep the already-shipped REVIEW path's blast radius zero.
+- **Row 3** (`_rule_critique_needs_revision`) steps aside (returns False) when the verdict is stale.
+- **Row 2b** (`_rule_critique_verdict_stale`, inserted before row 3) dispatches `/do-plan-critique` for a fresh critique. It is marker-agnostic — the dead-end leaves CRITIQUE at `in_progress`, so the rule must not require any particular marker value; it requires only a stale verdict AND non-empty verdict text.
+
+**Row 2b / Row 3 behavior with staleness check:**
+
+| Condition | Next dispatch |
+|-----------|---------------|
+| CRITIQUE verdict `NEEDS REVISION`, verdict fresh (recorded after latest `/do-plan`) | `/do-plan` (row 3) — revise |
+| CRITIQUE verdict `NEEDS REVISION`, verdict stale (plan revised since) | `/do-plan-critique` (row 2b) — re-critique |
+| No CRITIQUE verdict / empty verdict text | Row 2b does not fire |
+
+All edge cases fail safe to "not stale" (missing/unparseable `recorded_at`, no prior `/do-plan`, equal timestamps, any parse exception), exactly as in the REVIEW twin.
+
+**G5 is the loop-breaker (NOT G4).** The row-2b (`/do-plan-critique`) ↔ row-3 (`/do-plan`) cycle alternates *two different* skills, so `guard_g4_oscillation` (which keys on the *same* skill repeated) never trips it, and `guard_g2_critique_cycle_cap` (which only increments via `fail_stage("CRITIQUE")`) is never reached. The terminating bound is **G5 (`guard_g5_artifact_hash_cache`)**: it runs before the dispatch rows and, when the current plan-file hash equals the cached CRITIQUE verdict's `artifact_hash`, short-circuits the re-critique to the cached verdict's downstream dispatch. Re-critique therefore cannot loop on an unchanged plan — row 2b only progresses when the plan hash genuinely changed.
+
+**G5 activation in the CLI path.** G5 only fires if `context["current_plan_hash"]` is populated. Previously `tools/sdlc_next_skill.py::_build_context` never set it, leaving G5 inert via `sdlc-tool next-skill` (a latent inertness that also affected nothing else, since G5 is CRITIQUE-only). `_build_context` now computes `current_plan_hash = compute_plan_hash(find_plan_path(issue_number))` (None-safe: no plan or unreadable file leaves the key unset), so G5's loop bound on row 2b is real in production.
+
+**Disjointness from G1.** G1 (`guard_g1_critique_loop`) fires only when `last_dispatched_skill == /do-plan-critique` (the critique just ran; plan unchanged) and routes to `/do-plan`. The #1639 dead-end has `last_dispatched_skill == /do-plan` (plan just revised). The two conditions are disjoint on `last_dispatched_skill`, so G1 and row 2b never fire each other's skill.
+
 ## Single-Writer Invariant
 
 There is exactly ONE writer for the `_verdicts` metadata key:

--- a/docs/plans/sdlc-1639-1654.md
+++ b/docs/plans/sdlc-1639-1654.md
@@ -1,11 +1,12 @@
 ---
-status: Planning
+status: Ready
 type: bug
 appetite: Small
 owner: Valor Engels
 created: 2026-06-13
 tracking: https://github.com/tomcounsell/ai/issues/1639
 last_comment_id:
+revision_applied: true
 ---
 
 # SDLC router stale-critique dead-end (#1639) + war-room never finalizes (#1654)
@@ -122,8 +123,17 @@ No prerequisites — both fixes are internal to the router and the global critiq
 3. Add `_rule_critique_verdict_stale(stage_states, meta, context) -> bool`: returns `_critique_verdict_is_stale(stage_states)` AND there is a non-empty critique verdict text (guard against firing on no verdict). It must NOT require a particular CRITIQUE marker value (the dead-end marker is `in_progress`).
 4. Insert a new `DispatchRule(row_id="2b", state_predicate=_rule_critique_verdict_stale, skill=SKILL_DO_PLAN_CRITIQUE, reason="Critique verdict is stale (plan revised since) — re-critique")` into `DISPATCH_RULES` **between row 2 and row 3**.
 5. Update `tests/unit/test_sdlc_skill_md_parity.py::test_dispatch_rules_cover_expected_row_ids` `expected` set (L132) to include `"2b"`.
+6. **Activate G5 in the CLI path** — in `tools/sdlc_next_skill.py::_build_context`, set `context["current_plan_hash"] = compute_plan_hash(find_plan_path(issue_number))` (import `compute_plan_hash` from `tools.sdlc_verdict`, `find_plan_path` from `tools._sdlc_utils`). Guard with a None-safe check (no plan → leave the key unset). Without this, G5's `current_hash` is None and the loop-breaker never fires.
 
 **Guard mutual-exclusivity (G1 vs new row 2b/row 3):** G1 fires only when `last_dispatched_skill == /do-plan-critique` (the critique just ran; plan unchanged). The #1639 dead-end has `last_dispatched_skill == /do-plan` (plan just revised). Guards run before `DISPATCH_RULES`, so when G1's precondition holds it short-circuits to `/do-plan` and the new rules never run; when the dead-end holds, G1 returns None and row 2b fires `/do-plan-critique`. The two conditions are disjoint on `last_dispatched_skill`, so no oscillation. The build task must add a unit test asserting both orderings.
+
+**Loop-bound safety — CORRECTED (Concern 1).** The loop-breaker is **G5 (`guard_g5_artifact_hash_cache`, agent/sdlc_router.py:415), NOT G4.** The new row-2b (`/do-plan-critique`) ↔ row-3 (`/do-plan`) cycle alternates *two different skills*; `guard_g4_oscillation` (L383) keys on `same_stage_dispatch_count` (the *same* skill repeated), so a two-skill alternation never trips G4. `guard_g2_critique_cycle_cap` (L304) reads `critique_cycle_count`, which only increments via `fail_stage("CRITIQUE")` (pipeline_state.py ~L537) — a path the row-2b re-critique never takes. So neither G2 nor G4 bounds this cycle.
+
+G5 is the correct, terminating bound: guards run *before* dispatch rows (`GUARDS` list, L590), and G5 is CRITIQUE-only. When row 2b would dispatch `/do-plan-critique`, G5 fires first — if the cached CRITIQUE verdict's `artifact_hash` equals the current plan-file hash (`context["current_plan_hash"]`, compared at L434-438), G5 short-circuits the re-critique and returns the cached verdict's downstream dispatch. Therefore re-critique **cannot loop on an unchanged plan**: the only way row 2b progresses is when the plan hash actually changed (a genuine revision happened since the verdict), which is exactly the terminating, correct case.
+
+**BLOCKER-CLASS GAP found during revision — `current_plan_hash` is never populated in the CLI path.** `_build_context` in `tools/sdlc_next_skill.py` (the function that builds the `context` dict for `decide_next_dispatch`) populates `proposed_skill` and `branch_exists` but **does not set `current_plan_hash`**. With `current_plan_hash` absent, G5's `if not cached_hash or not current_hash: return None` (L436-437) makes G5 inert — meaning the loop-breaker does not actually run via `sdlc-tool next-skill`. This must be fixed as part of this work, or row 2b has no bound in production. **Fix:** in `_build_context`, set `context["current_plan_hash"] = compute_plan_hash(find_plan_path(issue_number))` (both helpers already exist: `compute_plan_hash` in `tools/sdlc_verdict.py:94`, `find_plan_path` in `tools/_sdlc_utils.py`). This activates G5 for the existing REVIEW-path G5 logic too (a latent pre-existing inertness, now corrected). Add an integration-style unit test asserting `_build_context` returns a non-None `current_plan_hash` when a plan file exists for the issue.
+
+**Staleness sourcing (Concern 2).** `_critique_verdict_is_stale` intentionally sources `recorded_at` ONLY from `stage_states["_verdicts"]["CRITIQUE"]` (meta carries no timestamp), mirroring `_review_verdict_is_stale` exactly — this is correct. But the verdict *text* used by row 3 (`_latest_critique_verdict`, L265-274) prefers `meta["latest_critique_verdict"]`. The two signals come from different sources, so the #1639 dead-end reproduction test MUST populate BOTH: `stage_states["_verdicts"]["CRITIQUE"] = {"verdict": "NEEDS REVISION", "recorded_at": T0}` AND `meta["latest_critique_verdict"] = "NEEDS REVISION"`, with `_sdlc_dispatches` containing `/do-plan` at `T1 > T0`. Otherwise the test could pass for the wrong reason (e.g., empty verdict text) and mask a real routing regression.
 
 **Fix 2 — `.claude/skills-global/do-plan-critique/SKILL.md` (skill-layer):**
 
@@ -153,9 +163,13 @@ No prerequisites — both fixes are internal to the router and the global critiq
 ## Test Impact
 
 - [ ] `tests/unit/test_sdlc_skill_md_parity.py::test_dispatch_rules_cover_expected_row_ids` — UPDATE: add `"2b"` to the `expected` row-id set (L132). Without this the parity test fails on the new rule.
-- [ ] `tests/unit/test_sdlc_router_decision.py::TestReviewVerdictStaleness` — UPDATE (additive): add a sibling `TestCritiqueVerdictStaleness` class mirroring all six REVIEW staleness cases for CRITIQUE (stale→re-critique, fresh→/do-plan, missing recorded_at→not stale, no prior /do-plan→not stale, equal timestamps→not stale, non-iso→not stale) plus a decision-level test reproducing the #1639 dead-end state. No existing REVIEW test is modified — the new class is added alongside.
+- [ ] `tests/unit/test_sdlc_router_decision.py::TestReviewVerdictStaleness` — UPDATE (additive): add a sibling `TestCritiqueVerdictStaleness` class mirroring all six REVIEW staleness cases for CRITIQUE (stale→re-critique, fresh→/do-plan, missing recorded_at→not stale, no prior /do-plan→not stale, equal timestamps→not stale, non-iso→not stale). No existing REVIEW test is modified — the new class is added alongside.
+- [ ] `tests/unit/test_sdlc_router_decision.py` — UPDATE (additive): add the **#1639 combined-sourcing dead-end test** populating BOTH `_verdicts["CRITIQUE"]` (with `recorded_at`) AND `meta["latest_critique_verdict"]`, asserting the router routes to `/do-plan-critique` (Concern 2).
+- [ ] `tests/unit/test_sdlc_router_decision.py` — UPDATE (additive): add the **G5 loop-bound tests** (Concern 1): (a) stale verdict + unchanged plan hash → G5 returns cached downstream dispatch (no re-critique loop); (b) stale verdict + changed plan hash → `/do-plan-critique` runs once. Both pass `context={"current_plan_hash": ...}` explicitly.
 - [ ] `tests/unit/test_sdlc_router_decision.py` (G1 region) — UPDATE (additive): add a test asserting G1 (last dispatch = critique) and row 2b (last dispatch = /do-plan, stale verdict) are mutually exclusive — neither fires the other's skill.
-- No critique-skill SKILL.md has executable tests; #1654 + #1642 are validated structurally (the parity/structure of the skill steps) and behaviorally via the router tests above. SKILL.md edits to `do-plan-critique` and `do-pr-review` are documentation-of-procedure changes with no pytest coverage; their correctness is asserted by the router no-longer-stalling once markers/verdicts are reliably written.
+- [ ] `tests/unit/test_sdlc_router_decision.py` — UPDATE (additive): add the **#1642 marker-desync test**: state `{pr_number set, REVIEW verdict=APPROVED, REVIEW marker != completed, DOCS != completed}` asserts the router does NOT fire row 9 (`/do-docs`) — documenting that the skill-layer completion-marker write is what advances REVIEW. This is the router-observable proof for the #1642 fix.
+- [ ] `tests/unit/test_sdlc_next_skill.py` (or equivalent) — UPDATE/ADD: assert `_build_context(proposed_skill, issue_number)` returns a non-None `current_plan_hash` when a plan file exists for the issue (G5 activation regression guard).
+- The `do-plan-critique` and `do-pr-review` SKILL.md edits are procedure changes with no direct pytest coverage; their correctness is asserted *behaviorally* by the router tests above (row 9 stall on a desynced REVIEW marker; the critique path reaching verdict-record). The skill edits make those writes reliably reached.
 
 ## Rabbit Holes
 
@@ -167,8 +181,8 @@ No prerequisites — both fixes are internal to the router and the global critiq
 ## Risks
 
 ### Risk 1: New row 2b causes a critique↔plan oscillation
-**Impact:** If row 2b fired while G1's condition also held, the pipeline could ping-pong between `/do-plan-critique` and `/do-plan`.
-**Mitigation:** G1 and row 2b are disjoint on `last_dispatched_skill` (critique vs plan), and guards run before dispatch rows. A dedicated mutual-exclusivity unit test locks this in. Guard G4 (3-identical-dispatch backstop) remains as a final safety net.
+**Impact:** If row 2b re-dispatched `/do-plan-critique` on a plan that never actually changed, the pipeline could ping-pong between `/do-plan-critique` and `/do-plan`. G4 does NOT catch this — it keys on the *same* skill repeated, and this cycle alternates two skills (verified in Technical Approach).
+**Mitigation:** The terminating bound is **G5 (`guard_g5_artifact_hash_cache`)**, which runs before the dispatch rows and, on an unchanged plan hash, short-circuits the re-critique to the cached verdict's downstream dispatch. The cycle can only progress when the plan hash genuinely changed — i.e., a real revision — so it terminates. **This mitigation is only real once `_build_context` populates `current_plan_hash` (see the blocker-class gap in Technical Approach); that fix is in scope for this work.** Tests: (a) row 2b + stale verdict + unchanged hash → G5 returns the cached downstream dispatch (no re-critique loop); (b) row 2b + stale verdict + changed hash → `/do-plan-critique` runs once then settles; (c) `_build_context` returns a non-None `current_plan_hash` when the plan exists. G1-vs-row-2b disjointness on `last_dispatched_skill` is locked by a separate mutual-exclusivity test.
 
 ### Risk 2: Over-suppression — a genuinely fresh NEEDS REVISION gets re-critiqued instead of revised
 **Impact:** A plan that legitimately needs revision could be sent to re-critique, wasting an opus run.
@@ -180,8 +194,9 @@ No race conditions identified. The router decision is a synchronous, single-thre
 
 ## No-Gos (Out of Scope)
 
-- [SEPARATE-SLUG #1642] If the skill-layer tightening of `do-pr-review/SKILL.md` proves insufficient to keep the REVIEW marker in sync (e.g., review confirms a deeper tools-layer desync), the residual REVIEW-marker fix is filed as a dedicated issue (labels `bug`, `skills`) rather than expanded into a `record_verdict` refactor on this branch. The skill-layer fix IS attempted here; only an unresolved residual is deferred. (Issue to be filed during build if needed; this entry is a conditional carve-out, not a silent drop.)
 - [EXTERNAL] Verifying the global skill propagation on other machines requires running `/update` on each machine — a human/world action outside this repo. The edit lands in `.claude/skills-global/` and auto-propagates; cross-machine verification is operational, not part of this build.
+
+Nothing else deferred — the #1642 REVIEW-marker fix is fully in scope on this branch (Concern 3 resolved to path (a)): the `do-pr-review/SKILL.md` approval-path tightening ships here AND is asserted by a router-level test (the row-9 stall on a desynced REVIEW marker). No conditional carve-out remains.
 
 ## Update System
 
@@ -197,8 +212,8 @@ No agent integration required. Both fixes are internal:
 ## Documentation
 
 ### Feature Documentation
-- [ ] Update `docs/features/sdlc-router-determinism.md` (or the existing SDLC router determinism/dispatch doc) to document the new CRITIQUE staleness supersession (row 2b) alongside the existing REVIEW staleness note from #1657. If no such doc exists, add the note to the closest SDLC pipeline feature doc and link it from `docs/features/README.md`.
-- [ ] Update any `docs/sdlc/` per-stage addendum that enumerates dispatch rows to include row 2b.
+- [ ] Update `docs/features/sdlc-router-oscillation-guard.md` (resolved: this is the existing doc covering the router guards + REVIEW staleness from #1657) to document the new CRITIQUE staleness supersession (row 2b), the G5-is-the-loop-breaker correction, and the `_build_context` `current_plan_hash` activation.
+- [ ] Update `docs/sdlc/do-plan-critique.md` and `docs/sdlc/do-pr-review.md` (resolved: the per-stage addenda) to reflect the mandatory wait-and-collect + finalize-marker behavior.
 
 ### External Documentation Site
 - [ ] Not applicable — repo has no external docs site for SDLC internals.
@@ -215,6 +230,8 @@ No agent integration required. Both fixes are internal:
 - [ ] All six CRITIQUE staleness edge cases (missing recorded_at, no prior /do-plan, equal timestamps, non-iso timestamp, not-a-dict, empty verdict) covered by unit tests mirroring `TestReviewVerdictStaleness`.
 - [ ] `test_dispatch_rules_cover_expected_row_ids` passes with `"2b"` in the expected set.
 - [ ] G1-vs-row-2b mutual-exclusivity test passes.
+- [ ] `_build_context` populates `current_plan_hash` so G5 actually fires in the CLI path, asserted by a unit test; G5 loop-bound tests pass (unchanged-hash → cached; changed-hash → settles).
+- [ ] #1642 marker-desync router test passes: `{REVIEW verdict=APPROVED, REVIEW marker != completed}` does NOT route to `/do-docs`.
 - [ ] `do-plan-critique/SKILL.md` contains an explicit wait-and-collect step before aggregation and a mandatory, self-contained verdict-record + completion-marker block.
 - [ ] `do-pr-review/SKILL.md` approval path co-locates the verdict-record + completion-marker writes as a mandatory block (addresses #1642).
 - [ ] Tests pass (`/do-test`)
@@ -252,7 +269,8 @@ Single builder; this is a Small, tightly-scoped two-file-plus-tests change.
 - Add the step-aside in `_rule_critique_needs_revision` (row 3).
 - Add `_rule_critique_verdict_stale` predicate (stale AND non-empty verdict; marker-agnostic).
 - Insert `DispatchRule(row_id="2b", ...)` between rows 2 and 3 in `DISPATCH_RULES`.
-- Add docstrings + comments per the Documentation section.
+- **Activate G5 in the CLI path**: in `tools/sdlc_next_skill.py::_build_context`, set `context["current_plan_hash"] = compute_plan_hash(find_plan_path(issue_number))` (None-safe). Without this G5 never fires and row 2b has no loop bound.
+- Add docstrings + comments per the Documentation section (note G5, not G4, is the loop-breaker).
 
 ### 2. Router staleness tests
 - **Task ID**: build-router-tests
@@ -262,9 +280,12 @@ Single builder; this is a Small, tightly-scoped two-file-plus-tests change.
 - **Agent Type**: builder
 - **Parallel**: false
 - Add `TestCritiqueVerdictStaleness` mirroring all six REVIEW cases for CRITIQUE.
-- Add the #1639 dead-end decision-level test (asserts `/do-plan-critique`).
+- Add the #1639 combined-sourcing dead-end test — populate BOTH `_verdicts["CRITIQUE"]` (with `recorded_at`) AND `meta["latest_critique_verdict"]`; assert `/do-plan-critique` (Concern 2).
 - Add the fresh-verdict test (asserts `/do-plan` via row 3).
+- Add the G5 loop-bound tests: (a) stale + unchanged hash → cached downstream dispatch; (b) stale + changed hash → `/do-plan-critique` once (Concern 1). Pass `context={"current_plan_hash": ...}`.
+- Add the `_build_context` G5-activation test (non-None `current_plan_hash` when plan exists).
 - Add the G1-vs-row-2b mutual-exclusivity test.
+- Add the #1642 marker-desync router test: `{REVIEW verdict=APPROVED, REVIEW marker != completed}` → router does NOT fire row 9 (Concern 3, path a).
 - Update `test_dispatch_rules_cover_expected_row_ids` expected set with `"2b"`.
 
 ### 3. Critique skill wait-and-collect + finalize
@@ -286,7 +307,7 @@ Single builder; this is a Small, tightly-scoped two-file-plus-tests change.
 - **Agent Type**: builder
 - **Parallel**: true
 - Co-locate the approval-path verdict-record + completion-marker writes as one mandatory block.
-- If review later shows this is insufficient, file the residual as issue (labels bug, skills) per No-Gos.
+- This is fully in scope (no defer): correctness is asserted by the #1642 marker-desync router test in task 2.
 
 ### 5. Documentation
 - **Task ID**: document-feature
@@ -314,13 +335,20 @@ Single builder; this is a Small, tightly-scoped two-file-plus-tests change.
 | Parity test passes | `pytest tests/unit/test_sdlc_skill_md_parity.py -q` | exit code 0 |
 | Row 2b present | `grep -c 'row_id="2b"' agent/sdlc_router.py` | output > 0 |
 | Critique staleness helper present | `grep -c '_critique_verdict_is_stale' agent/sdlc_router.py` | output > 0 |
-| REVIEW staleness helper unchanged | `git diff -- agent/sdlc_router.py \| grep -c '_review_verdict_is_stale'` | (manual: no body change) |
-| Wait-and-collect step present | `grep -ci 'wait' .claude/skills-global/do-plan-critique/SKILL.md` | output > 0 |
+| G5 activated in CLI path | `grep -c 'current_plan_hash' tools/sdlc_next_skill.py` | output > 0 |
+| REVIEW staleness helper unchanged | Manual reviewer check: `git diff agent/sdlc_router.py` shows no edit inside the `_review_verdict_is_stale` function body (additive-only diff for the new `_critique_verdict_is_stale`). | (manual) |
+| Wait-and-collect step present | `grep -ci 'wait and collect\|wait-and-collect' .claude/skills-global/do-plan-critique/SKILL.md` | output > 0 |
 | Lint clean | `python -m ruff check agent/sdlc_router.py tests/unit/test_sdlc_router_decision.py` | exit code 0 |
 | Format clean | `python -m ruff format --check agent/sdlc_router.py` | exit code 0 |
 
 ## Critique Results
 
-<!-- Populated by /do-plan-critique (war room). Leave empty until critique is run. -->
+War-room critique 2026-06-12: **READY TO BUILD (with concerns)** — 0 blockers, 3 concerns, 2 nits. All concerns embedded in this revision; the revision also surfaced a blocker-class gap (`current_plan_hash` never populated) now in scope.
+
 | Severity | Critic | Finding | Addressed By | Implementation Note |
 |----------|--------|---------|--------------|---------------------|
+| CONCERN | Skeptic / Adversary | Loop-safety claim "G4 is the backstop" is wrong — row-2b↔row-3 alternates two skills; G4 keys on same-skill repeats; G2's `critique_cycle_count` only increments via `fail_stage("CRITIQUE")`, never reached. | Technical Approach "Loop-bound safety — CORRECTED" + Risk 1 rewritten | G5 (`guard_g5_artifact_hash_cache`, L415) is the real loop-breaker: on unchanged plan hash it short-circuits re-critique to the cached verdict. **But `_build_context` never sets `current_plan_hash`, so G5 is currently inert via the CLI — fixed in scope (task 1) + G5 loop-bound tests (task 2).** |
+| CONCERN | Skeptic | `_critique_verdict_is_stale` sources `recorded_at` from `_verdicts`, but row 3 sources verdict text from `meta["latest_critique_verdict"]` — split sourcing can let the dead-end test pass for the wrong reason. | #1639 combined-sourcing test (task 2) + Technical Approach note | Dead-end test sets BOTH `_verdicts["CRITIQUE"]={"verdict":"NEEDS REVISION","recorded_at":T0}` AND `meta["latest_critique_verdict"]="NEEDS REVISION"`, `_sdlc_dispatches` `/do-plan` at T1>T0. Staleness intentionally reads `recorded_at` only from `_verdicts` (mirrors `_review_verdict_is_stale`). |
+| CONCERN | Operator | #1642 do-pr-review marker fix rode on faith — prose edit, no behavioral test. | Resolved to path (a): test it here (task 2, #1642 marker-desync router test); No-Go carve-out removed | Row 9 (`_rule_review_approved_docs_not_done`) requires `REVIEW==completed`; a desynced `{verdict=APPROVED, marker!=completed}` state is router-observable — assert the router does NOT fire row 9, documenting that the skill-layer marker write is what advances REVIEW. |
+| NIT | Adversary | Verification row "REVIEW staleness helper unchanged" used a non-machine-checkable git-diff grep. | Verification table reworded | Now an explicit manual reviewer check (no edit inside `_review_verdict_is_stale` body; additive-only diff). |
+| NIT | User | Documentation referenced a doc path that may not exist ("or the existing doc"). | Documentation section resolved | Resolved to `docs/features/sdlc-router-oscillation-guard.md` + `docs/sdlc/do-plan-critique.md` + `docs/sdlc/do-pr-review.md` (all confirmed to exist). |

--- a/docs/sdlc/do-plan-critique.md
+++ b/docs/sdlc/do-plan-critique.md
@@ -19,6 +19,16 @@ If the plan touches any Popoto model, the critique must verify:
 - The migration is registered in `MIGRATIONS`
 - The plan avoids raw Redis operations
 
+## Wait-and-Collect + Mandatory Finalize (#1654)
+
+The six war-room critics are spawned with `run_in_background: true`. The global skill's **Step 3.5 (Wait and Collect)** is a hard barrier: the skill MUST block on all six background critics and retrieve every critic's findings before aggregating. The skill owns finalization end to end — it does not yield to a supervisor for aggregation or verdict recording.
+
+**Step 5.5 is mandatory and reached on every exit path.** Every verdict (READY TO BUILD, NEEDS REVISION, MAJOR REWORK) flows through a single self-contained block that:
+1. Records the verdict via `sdlc-tool verdict record --stage CRITIQUE` so the router's G1/G5 guards can consume it.
+2. On a READY TO BUILD verdict ONLY, writes the completion stage-marker (`sdlc-tool stage-marker --stage CRITIQUE --status completed`) **co-located in the same block** so the verdict and marker can never desync.
+
+Without the wait barrier, Steps 4/5/5.5 silently never ran and the critique stalled at `in_progress` — the #1654 defect this fix removes.
+
 ## Multi-Machine Deployment
 
 This repo runs on multiple machines (see `docs/deployment.md`). The Archaeologist critic should check:

--- a/docs/sdlc/do-pr-review.md
+++ b/docs/sdlc/do-pr-review.md
@@ -24,6 +24,12 @@ A PR must not merge with:
 
 These are hard gates. No exceptions.
 
+## Mandatory Finalize — Verdict + Marker Co-Write (#1642)
+
+On the approval path, the REVIEW verdict record AND the REVIEW completion marker are a **single, self-contained, mandatory block**: `sdlc-tool verdict record --stage REVIEW --verdict "APPROVED" ...` is immediately followed by `sdlc-tool stage-marker --stage REVIEW --status completed ...` in the same block. Never record an APPROVED verdict without immediately writing the completion marker.
+
+This closes the #1642 desync: if the marker write is a separable later step and the skill exits before reaching it, the REVIEW marker stays non-`completed` while the verdict says APPROVED. Router **row 9** (`_rule_review_approved_docs_not_done`) requires `REVIEW == completed`, so a desynced state stalls `/do-docs` — the skill-layer completion-marker write is what advances REVIEW. On any non-APPROVED verdict, leave the marker at `in_progress`.
+
 ## Multi-Machine Compatibility
 
 If the PR adds new environment variables, verify they are in `.env.example` and `config/settings.py`. If the PR adds new migrations, verify they are registered in `MIGRATIONS` in `scripts/update/migrations.py`.

--- a/tests/unit/test_sdlc_next_skill.py
+++ b/tests/unit/test_sdlc_next_skill.py
@@ -1,0 +1,52 @@
+"""Unit tests for tools.sdlc_next_skill._build_context.
+
+Covers the G5 activation regression (#1639): _build_context must populate
+``current_plan_hash`` when a plan file exists for the issue, otherwise G5's
+loop bound on router row 2b is inert in the CLI path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools import sdlc_next_skill
+
+
+def test_build_context_sets_current_plan_hash_when_plan_exists(tmp_path, monkeypatch):
+    """A real plan file for the issue → context["current_plan_hash"] is non-None."""
+    plan = tmp_path / "sdlc-1639.md"
+    plan.write_text("# Plan\n\nbody content\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "tools._sdlc_utils.find_plan_path",
+        lambda issue_number: plan,
+    )
+
+    context = sdlc_next_skill._build_context(proposed_skill=None, issue_number=1639)
+
+    assert context.get("current_plan_hash") is not None
+    assert context["current_plan_hash"].startswith("sha256:")
+
+
+def test_build_context_omits_hash_when_no_plan(monkeypatch):
+    """No plan file for the issue → current_plan_hash key is left unset (None-safe)."""
+    monkeypatch.setattr(
+        "tools._sdlc_utils.find_plan_path",
+        lambda issue_number: None,
+    )
+
+    context = sdlc_next_skill._build_context(proposed_skill=None, issue_number=999999)
+
+    assert "current_plan_hash" not in context
+
+
+def test_build_context_omits_hash_when_plan_unreadable(monkeypatch):
+    """find_plan_path returns a missing path → compute_plan_hash None → key unset."""
+    monkeypatch.setattr(
+        "tools._sdlc_utils.find_plan_path",
+        lambda issue_number: Path("/nonexistent/does-not-exist-plan.md"),
+    )
+
+    context = sdlc_next_skill._build_context(proposed_skill=None, issue_number=1639)
+
+    assert "current_plan_hash" not in context

--- a/tests/unit/test_sdlc_router_decision.py
+++ b/tests/unit/test_sdlc_router_decision.py
@@ -596,3 +596,249 @@ class TestReviewVerdictStaleness:
         result = decide_next_dispatch(states, meta)
         assert isinstance(result, Dispatch)
         assert result.skill == SKILL_DO_PATCH
+
+
+class TestCritiqueVerdictStaleness:
+    """Stale CRITIQUE verdict (older than latest /do-plan dispatch) must re-critique (#1639).
+
+    Mirrors TestReviewVerdictStaleness for the CRITIQUE path. A NEEDS REVISION
+    verdict recorded before the plan was revised (a later /do-plan dispatch)
+    routes to /do-plan-critique (row 2b) instead of dead-ending on /do-plan
+    (row 3).
+    """
+
+    def _base_states(self, verdict_at: str, plan_at: str) -> dict:
+        return {
+            "PLAN": "completed",
+            "CRITIQUE": "in_progress",
+            "_verdicts": {
+                "CRITIQUE": {
+                    "verdict": "NEEDS REVISION",
+                    "recorded_at": verdict_at,
+                }
+            },
+            "_sdlc_dispatches": [
+                {"skill": "/do-plan", "at": plan_at},
+            ],
+        }
+
+    def test_stale_critique_verdict_after_plan_dispatches_recritique(self):
+        """verdict T0 < plan T1 → stale → /do-plan-critique (row 2b)."""
+        states = self._base_states(
+            verdict_at="2026-01-01T10:00:00",
+            plan_at="2026-01-01T11:00:00",
+        )
+        meta = {"last_dispatched_skill": SKILL_DO_PLAN}
+        result = decide_next_dispatch(states, meta)
+        assert isinstance(result, Dispatch)
+        assert result.skill == SKILL_DO_PLAN_CRITIQUE
+
+    def test_fresh_critique_verdict_after_plan_dispatches_plan(self):
+        """verdict T2 > plan T1 → fresh → /do-plan (row 3), no over-suppression."""
+        states = self._base_states(
+            verdict_at="2026-01-01T12:00:00",
+            plan_at="2026-01-01T11:00:00",
+        )
+        meta = {"last_dispatched_skill": SKILL_DO_PLAN}
+        result = decide_next_dispatch(states, meta)
+        assert isinstance(result, Dispatch)
+        assert result.skill == SKILL_DO_PLAN
+
+    def test_critique_verdict_stale_missing_recorded_at_not_suppressed(self):
+        """Missing recorded_at → not stale → row 3 fires (/do-plan)."""
+        states = {
+            "PLAN": "completed",
+            "CRITIQUE": "in_progress",
+            "_verdicts": {
+                "CRITIQUE": {
+                    "verdict": "NEEDS REVISION",
+                    # no recorded_at
+                }
+            },
+            "_sdlc_dispatches": [{"skill": "/do-plan", "at": "2026-01-01T11:00:00"}],
+        }
+        meta = {"last_dispatched_skill": SKILL_DO_PLAN}
+        result = decide_next_dispatch(states, meta)
+        assert isinstance(result, Dispatch)
+        assert result.skill == SKILL_DO_PLAN
+
+    def test_critique_verdict_stale_no_prior_plan_not_suppressed(self):
+        """No /do-plan in dispatch history → not stale → row 3 fires."""
+        states = {
+            "PLAN": "completed",
+            "CRITIQUE": "in_progress",
+            "_verdicts": {
+                "CRITIQUE": {
+                    "verdict": "NEEDS REVISION",
+                    "recorded_at": "2026-01-01T10:00:00",
+                }
+            },
+            "_sdlc_dispatches": [],  # no /do-plan entries
+        }
+        meta = {"last_dispatched_skill": SKILL_DO_PLAN}
+        result = decide_next_dispatch(states, meta)
+        assert isinstance(result, Dispatch)
+        assert result.skill == SKILL_DO_PLAN
+
+    def test_critique_verdict_equal_timestamps_fresh(self):
+        """Equal timestamps → not stale (strict <) → row 3 fires (/do-plan)."""
+        ts = "2026-01-01T10:00:00"
+        states = self._base_states(verdict_at=ts, plan_at=ts)
+        meta = {"last_dispatched_skill": SKILL_DO_PLAN}
+        result = decide_next_dispatch(states, meta)
+        assert isinstance(result, Dispatch)
+        assert result.skill == SKILL_DO_PLAN
+
+    def test_critique_verdict_stale_non_iso_timestamp_not_suppressed(self):
+        """Malformed recorded_at → parse failure → not stale → row 3 fires."""
+        states = {
+            "PLAN": "completed",
+            "CRITIQUE": "in_progress",
+            "_verdicts": {
+                "CRITIQUE": {
+                    "verdict": "NEEDS REVISION",
+                    "recorded_at": "not-a-date",
+                }
+            },
+            "_sdlc_dispatches": [{"skill": "/do-plan", "at": "2026-01-01T11:00:00"}],
+        }
+        meta = {"last_dispatched_skill": SKILL_DO_PLAN}
+        result = decide_next_dispatch(states, meta)
+        assert isinstance(result, Dispatch)
+        assert result.skill == SKILL_DO_PLAN
+
+    def test_combined_sourcing_dead_end_routes_recritique(self):
+        """#1639 dead-end: BOTH _verdicts.CRITIQUE and meta.latest_critique_verdict set.
+
+        Staleness sources recorded_at from _verdicts only; row-3 text sources from
+        meta. Populate both so the test cannot pass for the wrong reason (Concern 2).
+        """
+        states = {
+            "PLAN": "completed",
+            "CRITIQUE": "in_progress",
+            "_verdicts": {
+                "CRITIQUE": {
+                    "verdict": "NEEDS REVISION",
+                    "recorded_at": "2026-01-01T10:00:00",  # T0
+                }
+            },
+            "_sdlc_dispatches": [
+                {"skill": "/do-plan", "at": "2026-01-01T11:00:00"},  # T1 > T0
+            ],
+        }
+        meta = {
+            "latest_critique_verdict": "NEEDS REVISION",
+            "last_dispatched_skill": SKILL_DO_PLAN,
+            "revision_applied": True,
+        }
+        result = decide_next_dispatch(states, meta)
+        assert isinstance(result, Dispatch)
+        assert result.skill == SKILL_DO_PLAN_CRITIQUE
+
+
+class TestCritiqueStaleG5LoopBound:
+    """Row 2b re-critique is bounded by G5 on an unchanged plan hash (Concern 1)."""
+
+    def _stale_states(self, artifact_hash: str | None = None) -> dict:
+        verdict: dict = {
+            "verdict": "NEEDS REVISION",
+            "recorded_at": "2026-01-01T10:00:00",  # T0
+        }
+        if artifact_hash is not None:
+            verdict["artifact_hash"] = artifact_hash
+        return {
+            "PLAN": "completed",
+            "CRITIQUE": "in_progress",
+            "_verdicts": {"CRITIQUE": verdict},
+            "_sdlc_dispatches": [
+                {"skill": "/do-plan", "at": "2026-01-01T11:00:00"},  # T1 > T0
+            ],
+        }
+
+    def test_stale_unchanged_hash_g5_short_circuits(self):
+        """Stale verdict + cached hash == current hash → G5 returns cached dispatch.
+
+        G5 fires before row 2b and, on an unchanged plan hash, routes the cached
+        NEEDS REVISION verdict to /do-plan (its downstream dispatch) — NOT a
+        re-critique loop.
+        """
+        states = self._stale_states(artifact_hash="sha256:abc")
+        meta = {"last_dispatched_skill": SKILL_DO_PLAN}
+        result = decide_next_dispatch(states, meta, context={"current_plan_hash": "sha256:abc"})
+        assert isinstance(result, Dispatch)
+        assert result.row_id == "G5"
+        assert result.skill == SKILL_DO_PLAN
+
+    def test_stale_changed_hash_dispatches_recritique(self):
+        """Stale verdict + cached hash != current hash → row 2b → /do-plan-critique."""
+        states = self._stale_states(artifact_hash="sha256:old")
+        meta = {"last_dispatched_skill": SKILL_DO_PLAN}
+        result = decide_next_dispatch(states, meta, context={"current_plan_hash": "sha256:new"})
+        assert isinstance(result, Dispatch)
+        assert result.skill == SKILL_DO_PLAN_CRITIQUE
+
+
+class TestG1VsRow2bMutualExclusivity:
+    """G1 (last=critique) and row 2b (last=/do-plan, stale) never fire each other's skill."""
+
+    def _states(self) -> dict:
+        return {
+            "PLAN": "completed",
+            "CRITIQUE": "in_progress",
+            "_verdicts": {
+                "CRITIQUE": {
+                    "verdict": "NEEDS REVISION",
+                    "recorded_at": "2026-01-01T10:00:00",
+                }
+            },
+            "_sdlc_dispatches": [
+                {"skill": "/do-plan", "at": "2026-01-01T11:00:00"},
+            ],
+        }
+
+    def test_g1_fires_when_last_dispatch_was_critique(self):
+        """last = /do-plan-critique → G1 → /do-plan (not /do-plan-critique)."""
+        states = self._states()
+        meta = {"last_dispatched_skill": SKILL_DO_PLAN_CRITIQUE}
+        result = decide_next_dispatch(states, meta)
+        assert isinstance(result, Dispatch)
+        assert result.skill == SKILL_DO_PLAN
+
+    def test_row2b_fires_when_last_dispatch_was_plan(self):
+        """last = /do-plan + stale verdict → row 2b → /do-plan-critique (not /do-plan)."""
+        states = self._states()
+        meta = {"last_dispatched_skill": SKILL_DO_PLAN}
+        result = decide_next_dispatch(states, meta)
+        assert isinstance(result, Dispatch)
+        assert result.skill == SKILL_DO_PLAN_CRITIQUE
+
+
+class TestReviewMarkerDesync:
+    """#1642: an APPROVED REVIEW verdict with a non-completed REVIEW marker must NOT advance docs.
+
+    Row 9 (_rule_review_approved_docs_not_done) requires REVIEW == completed in
+    stage_states. A desynced {verdict=APPROVED, marker!=completed} state is
+    router-observable: the router does NOT fire /do-docs, documenting that the
+    skill-layer completion-marker write is what advances REVIEW.
+    """
+
+    def test_approved_verdict_but_review_marker_not_completed_no_docs(self):
+        states = {
+            "PLAN": "completed",
+            "CRITIQUE": "completed",
+            "BUILD": "completed",
+            "TEST": "completed",
+            "REVIEW": "in_progress",  # marker NOT completed despite APPROVED verdict
+            "DOCS": "pending",
+            "_verdicts": {
+                "REVIEW": {
+                    "verdict": "APPROVED",
+                    "recorded_at": "2026-01-01T10:00:00",
+                }
+            },
+        }
+        meta = {"pr_number": 99, "latest_review_verdict": "APPROVED"}
+        result = decide_next_dispatch(states, meta)
+        # Must NOT route to /do-docs (row 9 requires REVIEW == completed).
+        if isinstance(result, Dispatch):
+            assert result.skill != SKILL_DO_DOCS

--- a/tests/unit/test_sdlc_skill_md_parity.py
+++ b/tests/unit/test_sdlc_skill_md_parity.py
@@ -129,7 +129,7 @@ def test_every_dispatch_rule_has_documented_predicate():
 
 def test_dispatch_rules_cover_expected_row_ids():
     """DISPATCH_RULES must cover the canonical row set (1–10b)."""
-    expected = {"1", "2", "3", "4a", "4b", "4c", "5", "6", "7", "8", "8b", "9", "10", "10b"}
+    expected = {"1", "2", "2b", "3", "4a", "4b", "4c", "5", "6", "7", "8", "8b", "9", "10", "10b"}
     actual = {r.row_id for r in DISPATCH_RULES}
     missing = expected - actual
     extra = actual - expected

--- a/tools/sdlc_next_skill.py
+++ b/tools/sdlc_next_skill.py
@@ -80,10 +80,30 @@ def _build_context(proposed_skill: str | None, issue_number: int | None) -> dict
     - ``proposed_skill``: the skill the LLM was about to invoke (used by G3
       to detect plan-family redirects when a PR is already open).
     - ``branch_exists``: whether the session branch already exists (Row 5).
+    - ``current_plan_hash``: sha256 of the plan file (used by G5 to short-circuit
+      re-critique on an unchanged plan; #1639). Without this, G5's loop bound on
+      router row 2b is inert in the CLI path.
     """
     context: dict = {}
     if proposed_skill:
         context["proposed_skill"] = proposed_skill
+
+    # G5 activation (#1639): supply the current plan-file hash so
+    # guard_g5_artifact_hash_cache can compare it against the cached CRITIQUE
+    # verdict's artifact_hash and bound the row-2b re-critique loop. None-safe:
+    # no plan path or unreadable file leaves the key unset (G5 then no-ops).
+    if issue_number:
+        try:
+            from tools._sdlc_utils import find_plan_path
+            from tools.sdlc_verdict import compute_plan_hash
+
+            plan_path = find_plan_path(issue_number)
+            if plan_path is not None:
+                plan_hash = compute_plan_hash(plan_path)
+                if plan_hash is not None:
+                    context["current_plan_hash"] = plan_hash
+        except Exception:
+            pass
 
     # Check whether the issue-specific session branch already exists (informs Row 5).
     # Uses `session/sdlc-{issue_number}` — the canonical branch name for SDLC work.


### PR DESCRIPTION
## Summary

Two confirmed SDLC reliability defects that compound on unattended runs:

- **#1639 — Router stale-critique dead-end.** After a plan is revised in response to a plain `NEEDS REVISION` critique, the router had no route back to re-critique — it kept matching the stale cached verdict text and re-dispatching `/do-plan` forever. Fixed by mirroring the REVIEW staleness pattern (PR #1657) onto the CRITIQUE path.
- **#1654 — War-room never finalizes.** `/do-plan-critique` spawned six background critics with no explicit wait gate, so the verdict-record + completion-marker were not reliably reached and the stage stalled at `in_progress`. Fixed by an explicit wait-and-collect barrier and a mandatory, self-contained finalize block.
- **#1642 (in scope)** — REVIEW-marker desync: co-located the APPROVED verdict-record + REVIEW completion-marker in `do-pr-review` so the marker can't desync from an APPROVED verdict.

## Changes

- `agent/sdlc_router.py`: new `_critique_verdict_is_stale` (strict `<`, fail-safe False), row-3 step-aside, new `_rule_critique_verdict_stale` + `DispatchRule` row `2b` (`/do-plan-critique`, inserted before row 3, marker-agnostic, G5-bounded).
- `tools/sdlc_next_skill.py::_build_context`: populate `current_plan_hash` (None-safe) so G5 actually fires in the CLI path — the load-bearing loop bound for row 2b.
- `.claude/skills-global/do-plan-critique/SKILL.md`: Step 3.5 Wait and Collect; mandatory self-contained Step 5.5 verdict-record + completion-marker; reinforced Stage Marker note; v1.3.0.
- `.claude/skills-global/do-pr-review/SKILL.md`: APPROVED verdict-record + REVIEW completion-marker co-located in one mandatory block (#1642).
- Docs: `docs/features/sdlc-router-oscillation-guard.md` (CRITIQUE staleness, G5-is-the-loop-breaker, `current_plan_hash` activation), `docs/sdlc/do-plan-critique.md`, `docs/sdlc/do-pr-review.md`.

## Testing

- [x] `tests/unit/test_sdlc_router_decision.py` — `TestCritiqueVerdictStaleness` (six REVIEW-mirror cases), combined-sourcing dead-end, G5 loop-bound (unchanged-hash cached / changed-hash re-critique), G1-vs-row-2b mutual exclusivity, #1642 marker-desync router test.
- [x] `tests/unit/test_sdlc_next_skill.py` — `_build_context` G5-activation regression guard.
- [x] `tests/unit/test_sdlc_skill_md_parity.py` — expected row set adds `2b`.
- [x] 62 passed (`pytest tests/unit/test_sdlc_router_decision.py tests/unit/test_sdlc_skill_md_parity.py tests/unit/test_sdlc_next_skill.py`); no regressions in `test_sdlc_router.py`/`test_sdlc_router_oscillation.py`/`test_sdlc_router_multidispatch.py` (72 passed).
- [x] `ruff format` clean.

## Invariants

- `_review_verdict_is_stale` body unchanged (additive-only; new `_critique` helper is separate).
- `tools/sdlc_verdict.py::record_verdict` untouched (no tools-layer marker co-write — rejected in Rabbit Holes).
- No router refactor, no new abstractions.

## Definition of Done

- [x] Built: code implemented and working
- [x] Tested: all targeted unit tests passing
- [x] Documented: feature doc + per-stage addenda updated
- [x] Quality: ruff format clean

Closes #1639
Closes #1654