### PR TITLE
Fix sdlc-local-* durability: reap on idle, not creation age (#1676)

### DIFF
--- a/docs/features/sdlc-pipeline-state.md
+++ b/docs/features/sdlc-pipeline-state.md
@@ -58,7 +58,7 @@ The message-text fallback inside `find_session_by_issue` is a secondary defense 
 
 ### Orphan cleanup
 
-Stale zombie `sdlc-local-{N}` sessions (running status, no heartbeats, older than 10 minutes) can be listed and finalized with:
+Stale zombie `sdlc-local-{N}` sessions (running status, no heartbeats, **and no activity for over 10 minutes**) can be listed and finalized with:
 
 ```bash
 # Preview without modifying (exits 0, prints JSON list)
@@ -69,6 +69,8 @@ python -m tools.sdlc_session_ensure --kill-orphans
 ```
 
 The CLI always exits 0. Per-session finalize failures are reported inside the JSON payload's `failures` count and per-session `result` list — they never raise. When non-zero zombies are detected, a single stderr line (`[sdlc_session_ensure] found N zombie sdlc-local session(s)`) surfaces the count to scheduled-cleanup operators while stdout stays machine-parseable.
+
+**Liveness is measured by last activity, not creation age (#1676).** On a skills-only (worker-less) machine, no worker writes `last_heartbeat_at`, so a *live* CLI-driven `/do-sdlc` pipeline used to match the zombie criteria by construction once its `created_at` aged past 10 minutes — and `--kill-orphans` would then `finalize(killed)` it mid-run, destroying its `stage_states` (the durable dispatch trail and verdicts the router depends on). The reaper now treats a session as a zombie only when it has BOTH no heartbeat AND no recent activity: last activity = `updated_at` (falling back to `started_at`, then `created_at`). Because every dispatch/verdict write goes through `tools.stage_states_helpers.update_stage_states` → `session.save()`, which stamps `updated_at`, a pipeline that advanced any stage within the last 10 minutes is exempt regardless of whether a worker heartbeat exists. Genuinely-dead orphans (created long ago, never advanced a stage) are still reaped on the `created_at` fallback.
 
 ## Verdict Storage and Normalization
 

--- a/tests/unit/test_sdlc_session_ensure.py
+++ b/tests/unit/test_sdlc_session_ensure.py
@@ -457,14 +457,34 @@ class TestBridgeShortCircuit:
         assert result == {"session_id": "sdlc-local-1145", "created": True}
 
 
-def _make_orphan_session(session_id, age_seconds, heartbeat=None, session_type="pm"):
-    """Build a MagicMock AgentSession with orphan-relevant fields."""
+def _make_orphan_session(
+    session_id,
+    age_seconds,
+    heartbeat=None,
+    session_type="pm",
+    last_activity_seconds=None,
+):
+    """Build a MagicMock AgentSession with orphan-relevant fields.
+
+    ``age_seconds`` sets ``created_at`` (creation age). By default the session's
+    last-activity timestamps (``updated_at``/``started_at``) mirror
+    ``created_at`` — i.e. a session that was created and never advanced a stage,
+    which is the genuinely-dead-orphan shape.
+
+    Pass ``last_activity_seconds`` to model a LIVE pipeline that was created long
+    ago but recently refreshed ``updated_at`` via a stage_states write (#1676):
+    ``created_at`` stays at ``age_seconds`` while ``updated_at`` is set to the
+    fresher ``last_activity_seconds``.
+    """
     s = MagicMock()
     s.session_id = session_id
     s.session_type = session_type
     s.status = "running"
     s.last_heartbeat_at = heartbeat
     s.created_at = datetime.now(UTC) - timedelta(seconds=age_seconds)
+    activity_age = age_seconds if last_activity_seconds is None else last_activity_seconds
+    s.updated_at = datetime.now(UTC) - timedelta(seconds=activity_age)
+    s.started_at = s.updated_at
     s.issue_url = None
     return s
 
@@ -614,6 +634,121 @@ class TestKillOrphans:
             result = _kill_orphans(dry_run=True)
 
         assert result["count"] == 0
+
+    def test_live_local_pipeline_with_fresh_updated_at_not_listed(self):
+        """#1676: a worker-less sdlc-local-N PM session with last_heartbeat_at=None
+        but a FRESH updated_at (advanced a stage recently) must NOT be reaped.
+
+        This is the core defect: on a skills-only machine no worker writes a
+        heartbeat, so a live /do-sdlc pipeline matched the old zombie criteria
+        after 10 minutes and --kill-orphans destroyed its stage_states mid-run.
+        The fix exempts it because every stage_states write refreshes updated_at.
+        """
+        from tools.sdlc_session_ensure import ORPHAN_AGE_SECONDS, _kill_orphans
+
+        # Created 1 hour ago (well past threshold), but advanced a stage 30s ago.
+        live = _make_orphan_session(
+            "sdlc-local-1676",
+            age_seconds=ORPHAN_AGE_SECONDS + 3600,
+            heartbeat=None,
+            last_activity_seconds=30,
+        )
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [live]
+
+        with patch("models.agent_session.AgentSession", mock_as):
+            result = _kill_orphans(dry_run=True)
+
+        assert result["count"] == 0
+        assert result["orphans"] == []
+
+    def test_stale_local_pipeline_no_heartbeat_still_listed(self):
+        """#1676: a worker-less sdlc-local-N PM session with last_heartbeat_at=None
+        AND a stale updated_at (no stage advanced for the full window) is still a
+        genuine zombie and MUST be reaped — preserving original dead-orphan
+        behavior for sessions that truly stalled.
+        """
+        from tools.sdlc_session_ensure import ORPHAN_AGE_SECONDS, _kill_orphans
+
+        # Created AND last-active well past the threshold.
+        stale = _make_orphan_session(
+            "sdlc-local-1677",
+            age_seconds=ORPHAN_AGE_SECONDS + 3600,
+            heartbeat=None,
+            last_activity_seconds=ORPHAN_AGE_SECONDS + 600,
+        )
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [stale]
+
+        with patch("models.agent_session.AgentSession", mock_as):
+            result = _kill_orphans(dry_run=True)
+
+        assert result["count"] == 1
+        assert result["orphans"][0]["session_id"] == "sdlc-local-1677"
+
+    def test_fresh_updated_at_exempts_even_at_creation_boundary(self):
+        """#1676: updated_at just under the threshold exempts a session whose
+        created_at is exactly at the threshold — last activity, not creation, is
+        the liveness clock.
+        """
+        from tools.sdlc_session_ensure import ORPHAN_AGE_SECONDS, _kill_orphans
+
+        s = _make_orphan_session(
+            "sdlc-local-1678",
+            age_seconds=ORPHAN_AGE_SECONDS,
+            heartbeat=None,
+            last_activity_seconds=ORPHAN_AGE_SECONDS - 1,
+        )
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [s]
+
+        with patch("models.agent_session.AgentSession", mock_as):
+            result = _kill_orphans(dry_run=True)
+
+        assert result["count"] == 0
+
+    def test_falls_back_to_started_at_when_updated_at_missing(self):
+        """#1676: when updated_at is None, _last_activity_at falls back to
+        started_at. A fresh started_at exempts an old-created_at session.
+        """
+        from tools.sdlc_session_ensure import ORPHAN_AGE_SECONDS, _kill_orphans
+
+        s = _make_orphan_session(
+            "sdlc-local-1679",
+            age_seconds=ORPHAN_AGE_SECONDS + 3600,
+            heartbeat=None,
+        )
+        s.updated_at = None
+        s.started_at = datetime.now(UTC) - timedelta(seconds=30)
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [s]
+
+        with patch("models.agent_session.AgentSession", mock_as):
+            result = _kill_orphans(dry_run=True)
+
+        assert result["count"] == 0
+
+    def test_falls_back_to_created_at_when_no_activity_timestamps(self):
+        """#1676: when both updated_at and started_at are None, the reaper falls
+        back to created_at — an old, never-advanced session is still a zombie.
+        """
+        from tools.sdlc_session_ensure import ORPHAN_AGE_SECONDS, _kill_orphans
+
+        s = _make_orphan_session(
+            "sdlc-local-1680",
+            age_seconds=ORPHAN_AGE_SECONDS + 3600,
+            heartbeat=None,
+        )
+        s.updated_at = None
+        s.started_at = None
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [s]
+
+        with patch("models.agent_session.AgentSession", mock_as):
+            result = _kill_orphans(dry_run=True)
+
+        assert result["count"] == 1
+        assert result["orphans"][0]["session_id"] == "sdlc-local-1680"
 
     def test_cli_dry_run_exits_zero_with_valid_json(self):
         env = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}

--- a/tools/sdlc_session_ensure.py
+++ b/tools/sdlc_session_ensure.py
@@ -32,9 +32,12 @@ from datetime import UTC, datetime
 
 logger = logging.getLogger(__name__)
 
-# Minimum age (in seconds) before a sdlc-local session is considered a zombie
-# orphan. Sessions younger than this are not listed or killed — they may still be
-# executing their first turn or writing their first heartbeat.
+# Idle window (in seconds) before a sdlc-local session is considered a zombie
+# orphan. A session is only reaped when it has had no activity (no heartbeat AND
+# no stage_states write refreshing updated_at) for this long. Sessions active
+# within this window are exempt — including live worker-less CLI pipelines that
+# never write last_heartbeat_at but do refresh updated_at on every stage
+# advance (#1676).
 ORPHAN_AGE_SECONDS = 600
 
 
@@ -199,6 +202,30 @@ def ensure_session(issue_number: int, issue_url: str | None = None) -> dict:
         return {}
 
 
+def _last_activity_at(session):
+    """Return the most recent liveness timestamp for a session, or None.
+
+    A CLI-driven (worker-less) ``sdlc-local-*`` pipeline never writes
+    ``last_heartbeat_at`` — that field is stamped only by the worker's session
+    executor. But every dispatch/verdict/meta write a live local pipeline makes
+    goes through ``tools.stage_states_helpers.update_stage_states``, which calls
+    ``session.save()`` and stamps ``updated_at`` (see
+    ``AgentSession.save`` → ``utc_now()``). So ``updated_at`` IS a liveness
+    signal the local pipeline produces naturally.
+
+    Precedence (most→least authoritative as a "last activity" proxy):
+    ``updated_at`` → ``started_at`` → ``created_at``. The fallbacks cover
+    sessions that were created but have not yet written stage_states (no
+    ``updated_at`` stamp) — they remain reapable on the ``created_at`` clock,
+    preserving the original genuinely-dead-orphan semantics.
+    """
+    for attr in ("updated_at", "started_at", "created_at"):
+        ts = getattr(session, attr, None)
+        if ts is not None:
+            return ts
+    return None
+
+
 def _iter_orphan_sessions():
     """Yield zombie sdlc-local PM sessions suitable for --kill-orphans.
 
@@ -207,7 +234,22 @@ def _iter_orphan_sessions():
     - ``status == "running"``
     - ``session_id`` starts with ``"sdlc-local-"``
     - ``last_heartbeat_at`` is None (never received a worker turn)
-    - ``created_at`` is older than ``ORPHAN_AGE_SECONDS`` (default 10 minutes)
+    - **last activity** is older than ``ORPHAN_AGE_SECONDS`` (default 10 min),
+      where last activity = ``updated_at`` (falling back to ``started_at``,
+      then ``created_at``).
+
+    The last-activity check (rather than a bare ``created_at`` check) is what
+    keeps a LIVE worker-less pipeline alive (#1676). On a skills-only machine
+    there is no worker to write ``last_heartbeat_at``, so a healthy CLI-driven
+    ``/do-sdlc`` run matched the old (heartbeat-None AND old-created_at) zombie
+    criteria by construction after 10 minutes — and ``--kill-orphans`` would
+    then ``finalize(killed)`` it mid-run, destroying its ``stage_states`` (the
+    durable dispatch trail and verdicts the router depends on). Because every
+    stage_states write refreshes ``updated_at`` via ``session.save()``, a
+    pipeline that advanced a stage within the last ``ORPHAN_AGE_SECONDS`` is now
+    exempt regardless of whether a worker heartbeat exists. Only a session that
+    is BOTH heartbeat-less AND has not advanced any stage for the full window is
+    treated as genuinely dead.
 
     Sessions whose ``session_id`` does not start with ``"sdlc-local-"`` are
     NEVER yielded — bridge sessions and other running PM sessions are out of
@@ -232,14 +274,14 @@ def _iter_orphan_sessions():
             continue
         if getattr(s, "last_heartbeat_at", None) is not None:
             continue
-        created = getattr(s, "created_at", None)
-        if created is None:
+        last_activity = _last_activity_at(s)
+        if last_activity is None:
             continue
         try:
-            age_seconds = (now - created).total_seconds()
+            idle_seconds = (now - last_activity).total_seconds()
         except Exception:
             continue
-        if age_seconds >= ORPHAN_AGE_SECONDS:
+        if idle_seconds >= ORPHAN_AGE_SECONDS:
             yield s
 
 


### PR DESCRIPTION
Closes #1676.

## Root cause (investigation-confirmed)

The zombie reaper `tools/sdlc_session_ensure.py::_iter_orphan_sessions` reaped any `sdlc-local-*` PM session matching: `session_type=="pm"`, `status=="running"`, `last_heartbeat_at is None`, and `created_at` older than `ORPHAN_AGE_SECONDS` (600s).

`last_heartbeat_at` is written **only** by the worker's `agent/session_executor.py`. On a worker-less (skills-only) machine, a CLI-driven `/do-sdlc` pipeline's `sdlc-local-N` session is set to `status=running` by `ensure_session` but **never receives a heartbeat** — so a *live, healthy* pipeline matched the zombie criteria by construction after 10 minutes. An invocation of `python -m tools.sdlc_session_ensure --kill-orphans` then `finalize(killed)`'d it mid-run, destroying its `stage_states` (the durable `_sdlc_dispatches` trail and `_verdicts` the router depends on). This evicted `sdlc-local-1671` during the PR #1673 run.

## Fix (prevention at the reaper site)

Every dispatch/verdict/meta write goes through `tools/stage_states_helpers.py::update_stage_states` → `session.save()`, which stamps `updated_at`. So `updated_at` is a liveness signal a worker-less pipeline produces naturally.

- New `_last_activity_at(session)` → `updated_at` → `started_at` → `created_at` (first non-None).
- `_iter_orphan_sessions` now reaps only when a session has **both** no heartbeat **and** no activity for the full `ORPHAN_AGE_SECONDS` window. A pipeline that advanced any stage within 10 minutes is exempt regardless of heartbeat; genuinely-dead orphans (old, never-advanced) are still reaped via the `created_at` fallback.

## Out of scope (by analysis, documented not ignored)

The `session_events` 21→20 `HISTORY_MAX_ENTRIES=20` truncation is **benign** — it trims only the narrative event log. Dispatch/verdict state lives in the separate `stage_states` field, which the `session_events` cap never touches. (The `stage_states` field is decoupled from *truncation* but shares the same AgentSession record, so it was vulnerable to *eviction* — which this PR fixes.)

## Tests

`tests/unit/test_sdlc_session_ensure.py` — 5 new cases: live pipeline with fresh `updated_at` NOT reaped, stale pipeline still reaped, the activity-clock boundary, and `started_at`/`created_at` fallbacks. 34 tests pass serially.

## Docs

Updated the orphan-cleanup section of `docs/features/sdlc-pipeline-state.md` to describe activity-based (not creation-based) liveness.