### PR TITLE
fix(granite): canned-fallback diagnostic + catchup/reconciler persona resolution (#1708)

### DIFF
--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -134,6 +134,12 @@ from models.agent_session import AgentSession
 
 logger = logging.getLogger(__name__)
 
+# Sentinel for enqueue_agent_session(session_type=...) so we can distinguish a
+# caller that explicitly passed SessionType.ENG (intentional eng) from one that
+# omitted the kwarg entirely (likely dropped persona resolution). The effective
+# default remains SessionType.ENG.
+_SESSION_TYPE_UNSET = object()
+
 # 4-tier priority ranking: lower number = higher priority
 PRIORITY_RANK = {"urgent": 0, "high": 1, "normal": 2, "low": 3}
 
@@ -1080,7 +1086,7 @@ async def enqueue_agent_session(
     scheduled_at: float | None = None,
     parent_agent_session_id: str | None = None,
     telegram_message_key: str | None = None,
-    session_type: str = SessionType.ENG,
+    session_type: str = _SESSION_TYPE_UNSET,  # type: ignore[assignment]
     scheduling_depth: int = 0,  # ignored, now derived
     project_config: dict | None = None,
     extra_context_overrides: dict | None = None,
@@ -1107,6 +1113,19 @@ async def enqueue_agent_session(
     Returns queue depth after push.
     """
     from tools.field_utils import log_large_field
+
+    # Greppable warning when a caller omits BOTH session_type and project_config:
+    # this is the signature of a scanner that dropped persona resolution and would
+    # silently default a teammate-configured chat to an eng PM<->Dev loop. The
+    # effective default stays SessionType.ENG; intentional eng callers that pass
+    # session_type=SessionType.ENG explicitly do not trip this.
+    if session_type is _SESSION_TYPE_UNSET and project_config is None:
+        logger.warning(
+            "[enqueue] session_type omitted AND project_config omitted; "
+            "defaulting to eng — caller may have dropped persona resolution"
+        )
+    if session_type is _SESSION_TYPE_UNSET:
+        session_type = SessionType.ENG
 
     log_large_field("message_text", message_text)
     if revival_context:

--- a/agent/granite_container/bridge_adapter.py
+++ b/agent/granite_container/bridge_adapter.py
@@ -95,6 +95,11 @@ def _transcript_path_from_spec(cwd: str, session_id: str) -> str:
     Claude Code names transcripts: ~/.claude/projects/{cwd.replace("/", "-")}/{uuid}.jsonl
     This is deterministic because we set the UUID via `claude --session-id`.
     """
+    # Resolve symlinks before slugging so the slug matches Claude Code's
+    # own realpath-based naming. Guard on truthiness: os.path.realpath("")
+    # returns the process CWD, which would silently corrupt the slug.
+    if cwd:
+        cwd = os.path.realpath(cwd)
     slug = cwd.replace("/", "-")
     home = os.path.expanduser("~")
     return os.path.join(home, ".claude", "projects", slug, f"{session_id}.jsonl")

--- a/agent/granite_container/container.py
+++ b/agent/granite_container/container.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import shutil
 import subprocess
@@ -214,7 +215,9 @@ DEV_REPORT_UNAVAILABLE = "The developer did not produce a captured report."
 # Fallback user-visible message delivered directly (bypassing PM) when
 # the wrap-up guard exhausts MAX_WRAPUP_ATTEMPTS without PM emitting a
 # user-facing prefix. Guarantees the human always gets some message.
-OPERATOR_TERMINAL_MESSAGE = "Your request was completed; a summary could not be generated."
+OPERATOR_TERMINAL_MESSAGE = (
+    "I wasn't able to produce a response to this — please rephrase or follow up."
+)
 
 
 @dataclass
@@ -293,6 +296,11 @@ def _transcript_path(cwd: str, session_id: str | None) -> str | None:
     """
     if not session_id:
         return None
+    # Resolve symlinks before slugging so the slug matches Claude Code's
+    # own realpath-based naming. Guard on truthiness: os.path.realpath("")
+    # returns the process CWD, which would silently corrupt the slug.
+    if cwd:
+        cwd = os.path.realpath(cwd)
     cwd_slug = cwd.replace("/", "-")
     return str(Path.home() / ".claude" / "projects" / cwd_slug / f"{session_id}.jsonl")
 
@@ -330,6 +338,55 @@ def _truncate_exit_message(text: str) -> str:
     if len(text) <= EXIT_MESSAGE_MAX_CHARS:
         return text
     return text[: EXIT_MESSAGE_MAX_CHARS - 3] + "..."
+
+
+def _transcript_read_branch(pm_transcript: str | None) -> str:
+    """Classify why a PM transcript read produced no text into a greppable branch.
+
+    Returns one of three STABLE, greppable substrings:
+      - ``transcript read: path-None``     — the resolved path is None.
+      - ``transcript read: file-missing``  — path set but file absent on disk.
+      - ``transcript read: no-new-entry``  — file present but no new text-bearing
+        entry past baseline (valid file, PM emitted nothing this cycle).
+
+    These substrings are load-bearing for log-grep diagnostics; do not rename.
+    """
+    if not pm_transcript:
+        return "transcript read: path-None"
+    if not os.path.exists(pm_transcript):
+        return "transcript read: file-missing"
+    return "transcript read: no-new-entry"
+
+
+def _log_transcript_read_diagnostic(
+    site: str,
+    pm_transcript: str | None,
+    pm_pty: Any,
+    dev_pty: Any,
+) -> None:
+    """Emit a WARNING explaining why a PM transcript read came back empty.
+
+    `site` labels the read site (prime-turn / steady-state / wrap-up guard).
+    Logs the greppable branch substring plus the fully-resolved attempted
+    path, the presence of `spec.pm_session_id` / `spec.dev_session_id`
+    (sourced from each PTY driver's `_session_id`), and the live PM PTY's
+    `_session_id` — the trio needed to root-cause a path/slug or session-id
+    mismatch.
+    """
+    branch = _transcript_read_branch(pm_transcript)
+    pm_session_id = getattr(pm_pty, "_session_id", None)
+    dev_session_id = getattr(dev_pty, "_session_id", None)
+    logger.warning(
+        "[granite-container] %s: %s; path=%r "
+        "pm_session_id=%r dev_session_id=%r pty_session_id=%r; "
+        "using unknown classification",
+        site,
+        branch,
+        pm_transcript,
+        pm_session_id,
+        dev_session_id,
+        pm_session_id,
+    )
 
 
 def _unknown_classification() -> ClassificationResult:
@@ -848,9 +905,8 @@ class Container:
                 if pm_prime_text:
                     prime_classification = classify_pm_prefix(pm_prime_text)
                 else:
-                    logger.warning(
-                        "[granite-container] prime-turn: PM transcript read empty; "
-                        "using unknown classification"
+                    _log_transcript_read_diagnostic(
+                        "prime-turn", pm_transcript, self._pm_pty, self._dev_pty
                     )
                     result.transcript_fallback_count += 1
                     prime_classification = _unknown_classification()
@@ -920,10 +976,11 @@ class Container:
                     if pm_text:
                         classification = classify_pm_prefix(pm_text)
                     else:
-                        logger.warning(
-                            "[granite-container] steady-state turn %d: PM transcript read empty; "
-                            "using unknown classification",
-                            turn,
+                        _log_transcript_read_diagnostic(
+                            f"steady-state turn {turn}",
+                            pm_transcript,
+                            self._pm_pty,
+                            self._dev_pty,
                         )
                         result.transcript_fallback_count += 1
                         classification = _unknown_classification()
@@ -1243,9 +1300,8 @@ class Container:
                 if pm_text:
                     wrapup_classification = classify_pm_prefix(pm_text)
                 else:
-                    logger.warning(
-                        "[granite-container] wrap-up guard: PM transcript read empty; "
-                        "using unknown classification"
+                    _log_transcript_read_diagnostic(
+                        "wrap-up guard", pm_transcript, self._pm_pty, self._dev_pty
                     )
                     result.transcript_fallback_count += 1
                     wrapup_classification = _unknown_classification()

--- a/agent/granite_container/pty_pool.py
+++ b/agent/granite_container/pty_pool.py
@@ -389,11 +389,16 @@ class PTYPool:
     def _needs_session_spawn(self, spec: PairSpawnSpec | None) -> bool:
         """Whether `spec` requires a fresh per-session spawn.
 
-        Env vars and the system-prompt overlay can only be injected at
-        process spawn, and a cwd differing from the pool's spawn cwd
-        means the pre-warmed pair is running in the wrong directory
-        (the #887 worktree-contamination class). Conservative: any
-        per-session requirement triggers spawn-on-acquire.
+        Returns True if the spec carries ANY per-session identity: env,
+        model, cwd-override, OR session-id. Env vars and the system-prompt
+        overlay can only be injected at process spawn; a cwd differing from
+        the pool's spawn cwd means the pre-warmed pair is running in the
+        wrong directory (the #887 worktree-contamination class); and a spec
+        carrying pm/dev session-ids must spawn so the PTYs resume those exact
+        sessions (otherwise the transcript path the container computes from
+        the spec's session-ids would never match the prewarmed pair's own
+        ids). Conservative: any per-session requirement triggers
+        spawn-on-acquire.
         """
         if spec is None:
             return False
@@ -402,6 +407,8 @@ class PTYPool:
             or spec.pm_model
             or spec.dev_model
             or (spec.cwd is not None and spec.cwd != self._cwd)
+            or spec.pm_session_id
+            or spec.dev_session_id
         )
 
     async def _spawn_session_pair(self, slot: _Slot, spec: PairSpawnSpec) -> None:

--- a/bridge/catchup.py
+++ b/bridge/catchup.py
@@ -8,6 +8,9 @@ any messages that should have triggered a response.
 import logging
 from datetime import UTC, datetime, timedelta
 
+from bridge.routing import persona_to_session_type, resolve_persona
+from config.enums import SessionType
+
 logger = logging.getLogger(__name__)
 
 # How far back to look for missed messages (default: 1 hour)
@@ -232,6 +235,25 @@ async def scan_for_missed_messages(
                 # Build session ID for this message
                 session_id = f"tg_{project_key}_{chat_id}_{message.id}"
 
+                # Resolve persona here for parity with the live handler
+                # (bridge/telegram_bridge.py). Without this, the scanner would
+                # let session_type default to eng and a teammate-configured chat
+                # would wrongly run as an eng PM<->Dev loop. The try/except is
+                # NARROW (per-message): a persona failure falls back to the eng
+                # default and continues the scan rather than aborting the chat.
+                try:
+                    persona = resolve_persona(project, chat_title, is_dm=False)
+                    session_type = persona_to_session_type(persona)
+                except Exception as e:
+                    logger.warning(
+                        "[catchup] persona resolution failed for chat %s (%s); "
+                        "defaulting to eng: %s",
+                        chat_id,
+                        chat_title,
+                        e,
+                    )
+                    session_type = SessionType.ENG
+
                 await enqueue_agent_session_fn(
                     project_key=project_key,
                     session_id=session_id,
@@ -243,6 +265,8 @@ async def scan_for_missed_messages(
                     chat_title=chat_title,
                     priority="low",  # Lower priority than real-time messages
                     sender_id=sender_id,
+                    session_type=session_type,
+                    project_config=project,
                 )
 
                 # Record in Redis dedup to prevent re-enqueue on next scan,

--- a/bridge/reconciler.py
+++ b/bridge/reconciler.py
@@ -17,7 +17,9 @@ from bridge.dedup import (
     record_last_processed,
     record_message_processed,
 )
+from bridge.routing import persona_to_session_type, resolve_persona
 from bridge.silent_stream import SilentStreamState, check_silent_chat
+from config.enums import SessionType
 
 logger = logging.getLogger(__name__)
 
@@ -208,6 +210,25 @@ async def reconcile_once(
                     text[:80],
                 )
 
+                # Resolve persona here for parity with the live handler
+                # (bridge/telegram_bridge.py). Without this, the scanner would
+                # let session_type default to eng and a teammate-configured chat
+                # would wrongly run as an eng PM<->Dev loop. The try/except is
+                # NARROW (per-message): a persona failure falls back to the eng
+                # default and continues the scan rather than aborting the chat.
+                try:
+                    persona = resolve_persona(project, chat_title, is_dm=False)
+                    session_type = persona_to_session_type(persona)
+                except Exception as e:
+                    logger.warning(
+                        "[reconciler] persona resolution failed for chat %s (%s); "
+                        "defaulting to eng: %s",
+                        chat_id,
+                        chat_title,
+                        e,
+                    )
+                    session_type = SessionType.ENG
+
                 await enqueue_agent_session_fn(
                     project_key=project_key,
                     session_id=session_id,
@@ -219,6 +240,8 @@ async def reconcile_once(
                     chat_title=chat_title,
                     priority="low",
                     sender_id=sender_id,
+                    session_type=session_type,
+                    project_config=project,
                 )
 
                 await record_message_processed(chat_id, message.id)

--- a/bridge/routing.py
+++ b/bridge/routing.py
@@ -7,7 +7,7 @@ import logging
 import re
 from pathlib import Path
 
-from config.enums import ClassificationType, PersonaType
+from config.enums import ClassificationType, PersonaType, SessionType
 from config.models import OLLAMA_CLASSIFIER_MODEL
 from utils.api_keys import get_anthropic_api_key
 
@@ -392,6 +392,27 @@ def resolve_persona(
 
     # Unconfigured -- caller should fall through to existing behavior
     return None
+
+
+def persona_to_session_type(persona: str | None) -> str:
+    """Map a resolved persona to the AgentSession session_type.
+
+    Single source of truth for the persona -> session_type mapping, shared by
+    the live Telegram handler and the catchup / reconciler scanners so the
+    scanners cannot silently regress to an eng-only default (see the
+    granite_canned_fallback_persona_resolve bug: scanners defaulted every
+    teammate-configured chat to an eng PM<->Dev loop).
+
+    Args:
+        persona: A PersonaType member or None (unconfigured).
+
+    Returns:
+        SessionType.TEAMMATE for PersonaType.TEAMMATE; SessionType.ENG for
+        PersonaType.ENGINEER, any other persona, or None.
+    """
+    if persona == PersonaType.TEAMMATE:
+        return SessionType.TEAMMATE
+    return SessionType.ENG
 
 
 # =============================================================================

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -2199,18 +2199,15 @@ async def main():
         # ENGINEER persona → Eng session (full permissions, engineer persona)
         # TEAMMATE persona → Teammate session (read-only, no orchestration)
         # None/other → Eng session (default)
-        from bridge.routing import resolve_persona
+        from bridge.routing import persona_to_session_type, resolve_persona
 
         _classification = classification_result.get("type")
         _persona = resolve_persona(project, chat_title, is_dm=is_dm)
-        if _persona == PersonaType.TEAMMATE:
-            _session_type = SessionType.TEAMMATE  # Teammate session — read-only, no orchestration
-        else:
-            _session_type = SessionType.ENG  # Eng session — engineer persona, full permissions
-            if _persona == PersonaType.ENGINEER:
-                logger.info(
-                    f"[{project_name}] Eng mode (config-driven): {chat_title!r} → session_type=eng"
-                )
+        _session_type = persona_to_session_type(_persona)
+        if _persona == PersonaType.ENGINEER:
+            logger.info(
+                f"[{project_name}] Eng mode (config-driven): {chat_title!r} → session_type=eng"
+            )
 
         # Refresh the coalescing guard timestamp right before enqueue.
         # The initial guard was set early (before awaits) to close the race window;

--- a/docs/features/eng-session-architecture.md
+++ b/docs/features/eng-session-architecture.md
@@ -27,6 +27,33 @@ Session type derivation from resolved persona:
 
 There are three session types: `eng`, `teammate`, and `granite`. The first two are bridge-originated and worker-executed. `granite` is exclusively for standalone `valor-granite-loop` CLI runs -- it is created and finalized by the CLI itself, never by the worker or bridge. `session_type` is the **sole discriminator** for routing, permission injection, summarizer formatting, and nudge cap selection. See [Config-Driven Chat Mode](config-driven-chat-mode.md) for the config schema and resolution order.
 
+### Persona resolution on all ingest paths (issue #1708)
+
+Persona resolution applies on **every** ingest path, not just the live Telegram handler:
+
+| Path | Location | Persona-resolved since |
+|------|----------|------------------------|
+| Live handler | `bridge/telegram_bridge.py` | original |
+| Catchup scanner | `bridge/catchup.py` | issue #1708 |
+| Reconciler scanner | `bridge/reconciler.py` | issue #1708 |
+
+All three paths call `resolve_persona(project, chat_title)` →
+`persona_to_session_type(persona)` (a shared helper in `bridge/routing.py`) and
+pass `session_type=` + `project_config=project` to `enqueue_agent_session`.
+
+**Practical consequence:** a chat configured `persona: teammate` in
+`projects.json` now runs as `teammate` on *every* ingest path. Before issue
+#1708, catchup- and reconciler-re-ingested messages defaulted to
+`SessionType.ENG` regardless of the chat's configured persona, causing an
+eng PM↔Dev work-loop to run for conversational teammate chats. The fix removes
+this asymmetry — the persona the bridge resolves for a live message is
+identical to the one resolved for any re-ingested or reconciled message from
+the same chat.
+
+A `logger.warning` is emitted at `agent_session_queue.py` when a caller omits
+both `session_type` and `project_config` (so the silent `ENG` default remains
+but is no longer invisible).
+
 ## Enforcement -- Teammate Session Write Restrictions
 
 Teammate sessions (`SESSION_TYPE=teammate`) get the following shape:

--- a/docs/features/granite-pty-production.md
+++ b/docs/features/granite-pty-production.md
@@ -328,6 +328,56 @@ by an mtime snapshot before each idle poll, but not fully eliminated. The determ
 complement is followup issue **#1688** ("Hook-driven turn returns for granite PTY
 shuttle"), which replaces idle-poll heuristics with hook-driven turn boundaries.
 
+### Transcript-read diagnostic (issue #1708)
+
+When the steady-state loop, prime-turn read, or wrap-up-guard read finds no
+new PM output, a `WARNING` is emitted to `logs/worker.log` (the granite
+container's `logging.getLogger(__name__)` output). The warning names one of
+three greppable branches:
+
+| Substring | Meaning |
+|-----------|---------|
+| `transcript read: path-None` | `pm_transcript` is `None` — the path was never resolved (session-id absent at spawn) |
+| `transcript read: file-missing` | path was resolved but the file does not exist on disk |
+| `transcript read: no-new-entry` | file exists but `last_assistant_text()` returned empty (valid file, no new text-bearing entry past the baseline count) |
+
+Each warning also logs the fully-resolved attempted path string,
+`spec.pm_session_id` / `spec.dev_session_id` presence, and
+`pty._session_id`, so an on-call can distinguish a spawn-threading gap (spec
+carried IDs, PTY did not) from a slug mismatch.
+
+`grep "transcript read:" logs/worker.log` is the primary triage command for
+empty-read investigations.
+
+**The `no-new-entry` branch is the only legitimate path to `OPERATOR_TERMINAL_MESSAGE`.**
+The other two branches (`path-None`, `file-missing`) indicate a configuration
+or spawn-threading defect rather than a PM that genuinely produced no output.
+
+#### `_needs_session_spawn` session-id invariant
+
+`PTYPool._needs_session_spawn()` returns `True` whenever the spec carries any
+per-session identity: `env`, `pm_model`, `cwd` override, OR `pm_session_id` /
+`dev_session_id`. This ensures that a spec carrying explicit session-ids always
+forces a per-session spawn — even if `env` happens to be empty — preventing a
+prewarmed pair (which has no `--session-id` binding) from being reused for a
+session that needs a deterministic transcript path.
+
+#### Realpath-resolved transcript slug
+
+Both `_transcript_path()` in `container.py` and the slug computation in
+`bridge_adapter.py` apply `os.path.realpath(cwd)` (only when `cwd` is truthy)
+before `cwd.replace("/", "-")`. This matches the slug that `claude` itself
+computes for its project directory, which also resolves symlinks. Without this
+step, a working directory that crosses a symlink (e.g. a `.worktrees/` path
+under a symlinked checkout root) would produce a slug that does not match the
+transcript file `claude` actually writes, and every steady-state read would
+return empty (`transcript read: file-missing`).
+
+Note: `os.path.realpath("")` returns the process CWD, which would corrupt the
+slug for falsy values. The `if not session_id: return None` guard in
+`_transcript_path` is checked *before* the realpath call, so the path-None
+diagnostic branch is never bypassed.
+
 ### Granite identity fields
 
 `AgentSession` now carries four first-class granite identity fields (issue

--- a/tests/integration/test_catchup_revival.py
+++ b/tests/integration/test_catchup_revival.py
@@ -212,6 +212,143 @@ class TestCatchupRevival:
         enqueue_agent_session_fn.assert_not_called()
 
 
+class TestCatchupPersonaResolution:
+    """Catchup must resolve persona for parity with the live handler.
+
+    Finding 2 bug: catchup enqueued every chat with the eng default, so a
+    teammate-configured chat wrongly ran as an eng PM<->Dev loop.
+    """
+
+    @staticmethod
+    def _teammate_project():
+        return {
+            "_key": "cyndra",
+            "working_directory": "/tmp/cyndra",
+            "telegram": {
+                "groups": {"Cyndra Dev Team": {"persona": "teammate"}},
+            },
+        }
+
+    @staticmethod
+    def _eng_project():
+        return {"_key": "popoto", "working_directory": "/tmp/popoto"}
+
+    @pytest.mark.asyncio
+    async def test_teammate_chat_enqueues_teammate_session(self):
+        """A teammate-configured chat enqueues session_type=teammate + project_config."""
+        from config.enums import SessionType
+
+        client = AsyncMock()
+        dialog = _make_dialog(chat_id=300, title="Cyndra Dev Team")
+        client.get_dialogs.return_value = [dialog]
+        message = _make_message(msg_id=7, text="@valor please look")
+        client.get_messages.return_value = [message]
+
+        enqueue_agent_session_fn = AsyncMock()
+        project = self._teammate_project()
+        find_project_fn = MagicMock(return_value=project)
+
+        with (
+            patch("bridge.dedup.is_duplicate_message", new_callable=AsyncMock) as mock_dedup,
+            patch("bridge.catchup._check_if_handled", new_callable=AsyncMock) as mock_handled,
+            patch("bridge.dedup.record_message_processed", new_callable=AsyncMock),
+            patch("bridge.dedup.record_last_processed", new_callable=AsyncMock),
+        ):
+            mock_dedup.return_value = False
+            mock_handled.return_value = False
+
+            queued = await scan_for_missed_messages(
+                client=client,
+                monitored_groups=["cyndra dev team"],
+                projects_config={},
+                should_respond_fn=AsyncMock(return_value=(True, False)),
+                enqueue_agent_session_fn=enqueue_agent_session_fn,
+                find_project_fn=find_project_fn,
+            )
+
+        assert queued == 1
+        call_kwargs = enqueue_agent_session_fn.call_args[1]
+        assert call_kwargs["session_type"] == SessionType.TEAMMATE
+        assert call_kwargs["project_config"] is project
+
+    @pytest.mark.asyncio
+    async def test_eng_chat_enqueues_eng_session(self):
+        """A chat with no teammate persona still enqueues an eng session."""
+        from config.enums import SessionType
+
+        client = AsyncMock()
+        dialog = _make_dialog(chat_id=400, title="Dev: Popoto")
+        client.get_dialogs.return_value = [dialog]
+        message = _make_message(msg_id=8, text="fix the build")
+        client.get_messages.return_value = [message]
+
+        enqueue_agent_session_fn = AsyncMock()
+        find_project_fn = MagicMock(return_value=self._eng_project())
+
+        with (
+            patch("bridge.dedup.is_duplicate_message", new_callable=AsyncMock) as mock_dedup,
+            patch("bridge.catchup._check_if_handled", new_callable=AsyncMock) as mock_handled,
+            patch("bridge.dedup.record_message_processed", new_callable=AsyncMock),
+            patch("bridge.dedup.record_last_processed", new_callable=AsyncMock),
+        ):
+            mock_dedup.return_value = False
+            mock_handled.return_value = False
+
+            queued = await scan_for_missed_messages(
+                client=client,
+                monitored_groups=["dev: popoto"],
+                projects_config={},
+                should_respond_fn=AsyncMock(return_value=(True, False)),
+                enqueue_agent_session_fn=enqueue_agent_session_fn,
+                find_project_fn=find_project_fn,
+            )
+
+        assert queued == 1
+        call_kwargs = enqueue_agent_session_fn.call_args[1]
+        assert call_kwargs["session_type"] == SessionType.ENG
+
+    @pytest.mark.asyncio
+    async def test_persona_failure_warns_and_continues_with_eng(self, caplog):
+        """A persona-resolution exception falls back to eng and the scan continues."""
+        import logging
+
+        from config.enums import SessionType
+
+        client = AsyncMock()
+        dialog = _make_dialog(chat_id=500, title="Dev: Popoto")
+        client.get_dialogs.return_value = [dialog]
+        message = _make_message(msg_id=9, text="status?")
+        client.get_messages.return_value = [message]
+
+        enqueue_agent_session_fn = AsyncMock()
+        find_project_fn = MagicMock(return_value=self._eng_project())
+
+        with (
+            patch("bridge.dedup.is_duplicate_message", new_callable=AsyncMock) as mock_dedup,
+            patch("bridge.catchup._check_if_handled", new_callable=AsyncMock) as mock_handled,
+            patch("bridge.dedup.record_message_processed", new_callable=AsyncMock),
+            patch("bridge.dedup.record_last_processed", new_callable=AsyncMock),
+            patch("bridge.catchup.resolve_persona", side_effect=RuntimeError("boom")),
+            caplog.at_level(logging.WARNING),
+        ):
+            mock_dedup.return_value = False
+            mock_handled.return_value = False
+
+            queued = await scan_for_missed_messages(
+                client=client,
+                monitored_groups=["dev: popoto"],
+                projects_config={},
+                should_respond_fn=AsyncMock(return_value=(True, False)),
+                enqueue_agent_session_fn=enqueue_agent_session_fn,
+                find_project_fn=find_project_fn,
+            )
+
+        assert queued == 1
+        call_kwargs = enqueue_agent_session_fn.call_args[1]
+        assert call_kwargs["session_type"] == SessionType.ENG
+        assert any("[catchup] persona resolution failed" in r.getMessage() for r in caplog.records)
+
+
 class TestCatchupLookbackOverride:
     """Verify the lookback_override parameter controls the catchup window."""
 

--- a/tests/integration/test_per_chat_catchup_cutoff.py
+++ b/tests/integration/test_per_chat_catchup_cutoff.py
@@ -164,3 +164,84 @@ class TestPerChatCatchupCutoff:
 
         assert queued == 0
         enqueue_fn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_teammate_chat_recovered_with_teammate_session_type(self):
+        """A recovered message in a teammate-configured chat enqueues teammate + project_config.
+
+        Finding 2: the per-chat catchup path must resolve persona like the live
+        handler. A teammate chat recovered here must NOT default to an eng
+        PM<->Dev loop.
+        """
+        from config.enums import SessionType
+
+        cursor_dt = datetime.now(UTC) - timedelta(minutes=10)
+        await record_last_processed(TEST_CHAT_ID, 1000, cursor_dt)
+
+        dialog = _make_dialog(TEST_CHAT_ID, "Cyndra Dev Team")
+        client = AsyncMock()
+        client.get_dialogs.return_value = [dialog]
+        missed = _make_message(1005, "@valor please look", minutes_ago=8)
+        client.get_messages.return_value = [missed]
+
+        enqueue_fn = AsyncMock()
+        project = {
+            "_key": "cyndra",
+            "working_directory": "/tmp/cyndra",
+            "telegram": {"groups": {"Cyndra Dev Team": {"persona": "teammate"}}},
+        }
+
+        with (
+            patch("bridge.catchup._check_if_handled", new_callable=AsyncMock, return_value=False),
+            patch("bridge.dedup.is_duplicate_message", new_callable=AsyncMock, return_value=False),
+        ):
+            queued = await scan_for_missed_messages(
+                client=client,
+                monitored_groups=["cyndra dev team"],
+                projects_config={},
+                should_respond_fn=AsyncMock(return_value=(True, False)),
+                enqueue_agent_session_fn=enqueue_fn,
+                find_project_fn=MagicMock(return_value=project),
+                lookback_override=timedelta(minutes=3),
+            )
+
+        assert queued == 1
+        call_kwargs = enqueue_fn.call_args[1]
+        assert call_kwargs["session_type"] == SessionType.TEAMMATE
+        assert call_kwargs["project_config"] is project
+
+    @pytest.mark.asyncio
+    async def test_default_chat_recovered_with_eng_session_type(self):
+        """A recovered message in a non-teammate chat still enqueues an eng session."""
+        from config.enums import SessionType
+
+        cursor_dt = datetime.now(UTC) - timedelta(minutes=10)
+        await record_last_processed(TEST_CHAT_ID, 1000, cursor_dt)
+
+        dialog = _make_dialog(TEST_CHAT_ID, "Cyndra Dev")
+        client = AsyncMock()
+        client.get_dialogs.return_value = [dialog]
+        missed = _make_message(1005, "fix the build", minutes_ago=8)
+        client.get_messages.return_value = [missed]
+
+        enqueue_fn = AsyncMock()
+        project = {"_key": "cyndra", "working_directory": "/tmp/cyndra"}
+
+        with (
+            patch("bridge.catchup._check_if_handled", new_callable=AsyncMock, return_value=False),
+            patch("bridge.dedup.is_duplicate_message", new_callable=AsyncMock, return_value=False),
+        ):
+            queued = await scan_for_missed_messages(
+                client=client,
+                monitored_groups=["cyndra dev"],
+                projects_config={},
+                should_respond_fn=AsyncMock(return_value=(True, False)),
+                enqueue_agent_session_fn=enqueue_fn,
+                find_project_fn=MagicMock(return_value=project),
+                lookback_override=timedelta(minutes=3),
+            )
+
+        assert queued == 1
+        call_kwargs = enqueue_fn.call_args[1]
+        assert call_kwargs["session_type"] == SessionType.ENG
+        assert call_kwargs["project_config"] is project

--- a/tests/integration/test_reconciler.py
+++ b/tests/integration/test_reconciler.py
@@ -242,3 +242,140 @@ class TestReconcilerExtendedLookback:
         assert result == 1
         assert len(enqueued) == 1
         assert enqueued[0]["telegram_message_id"] == 900
+
+
+class TestReconcilerPersonaResolution:
+    """Reconciler must resolve persona for parity with the live handler.
+
+    Finding 2 bug: reconciler enqueued every chat with the eng default, so a
+    teammate-configured chat wrongly ran as an eng PM<->Dev loop.
+    """
+
+    @pytest.mark.asyncio
+    async def test_teammate_chat_enqueues_teammate_session(self):
+        """A teammate-configured chat enqueues session_type=teammate + project_config."""
+        from config.enums import SessionType
+
+        dialog = _make_dialog("Cyndra Dev Team", entity_id=800)
+        missed = _make_message(901, text="@valor look here", minutes_ago=5)
+
+        client = AsyncMock()
+        client.get_dialogs = AsyncMock(return_value=[dialog])
+        client.get_messages = AsyncMock(return_value=[missed])
+
+        enqueued = []
+
+        async def mock_enqueue(**kwargs):
+            enqueued.append(kwargs)
+
+        project = {
+            "_key": "cyndra",
+            "working_directory": "/tmp/cyndra",
+            "telegram": {"groups": {"Cyndra Dev Team": {"persona": "teammate"}}},
+        }
+
+        with (
+            patch(
+                "bridge.reconciler.is_duplicate_message",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch("bridge.reconciler.record_message_processed", new_callable=AsyncMock),
+            patch("bridge.reconciler.record_last_processed", new_callable=AsyncMock),
+        ):
+            result = await reconcile_once(
+                client=client,
+                monitored_groups=["cyndra dev team"],
+                should_respond_fn=AsyncMock(return_value=(True, False)),
+                enqueue_agent_session_fn=mock_enqueue,
+                find_project_fn=MagicMock(return_value=project),
+            )
+
+        assert result == 1
+        assert enqueued[0]["session_type"] == SessionType.TEAMMATE
+        assert enqueued[0]["project_config"] is project
+
+    @pytest.mark.asyncio
+    async def test_eng_chat_enqueues_eng_session(self):
+        """A chat with no teammate persona still enqueues an eng session."""
+        from config.enums import SessionType
+
+        dialog = _make_dialog("Dev: Popoto", entity_id=810)
+        missed = _make_message(902, text="fix the build", minutes_ago=5)
+
+        client = AsyncMock()
+        client.get_dialogs = AsyncMock(return_value=[dialog])
+        client.get_messages = AsyncMock(return_value=[missed])
+
+        enqueued = []
+
+        async def mock_enqueue(**kwargs):
+            enqueued.append(kwargs)
+
+        project = {"_key": "popoto", "working_directory": "/tmp/popoto"}
+
+        with (
+            patch(
+                "bridge.reconciler.is_duplicate_message",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch("bridge.reconciler.record_message_processed", new_callable=AsyncMock),
+            patch("bridge.reconciler.record_last_processed", new_callable=AsyncMock),
+        ):
+            result = await reconcile_once(
+                client=client,
+                monitored_groups=["dev: popoto"],
+                should_respond_fn=AsyncMock(return_value=(True, False)),
+                enqueue_agent_session_fn=mock_enqueue,
+                find_project_fn=MagicMock(return_value=project),
+            )
+
+        assert result == 1
+        assert enqueued[0]["session_type"] == SessionType.ENG
+
+    @pytest.mark.asyncio
+    async def test_persona_failure_warns_and_continues_with_eng(self, caplog):
+        """A persona-resolution exception falls back to eng and the scan continues."""
+        import logging
+
+        from config.enums import SessionType
+
+        dialog = _make_dialog("Dev: Popoto", entity_id=820)
+        missed = _make_message(903, text="status?", minutes_ago=5)
+
+        client = AsyncMock()
+        client.get_dialogs = AsyncMock(return_value=[dialog])
+        client.get_messages = AsyncMock(return_value=[missed])
+
+        enqueued = []
+
+        async def mock_enqueue(**kwargs):
+            enqueued.append(kwargs)
+
+        project = {"_key": "popoto", "working_directory": "/tmp/popoto"}
+
+        with (
+            patch(
+                "bridge.reconciler.is_duplicate_message",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch("bridge.reconciler.record_message_processed", new_callable=AsyncMock),
+            patch("bridge.reconciler.record_last_processed", new_callable=AsyncMock),
+            patch("bridge.reconciler.resolve_persona", side_effect=RuntimeError("boom")),
+            caplog.at_level(logging.WARNING),
+        ):
+            result = await reconcile_once(
+                client=client,
+                monitored_groups=["dev: popoto"],
+                should_respond_fn=AsyncMock(return_value=(True, False)),
+                enqueue_agent_session_fn=mock_enqueue,
+                find_project_fn=MagicMock(return_value=project),
+            )
+
+        assert result == 1
+        assert enqueued[0]["session_type"] == SessionType.ENG
+        assert any(
+            "[reconciler] persona resolution failed" in r.getMessage() for r in caplog.records
+        )

--- a/tests/unit/granite_container/test_bridge_adapter.py
+++ b/tests/unit/granite_container/test_bridge_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import unittest
 from dataclasses import dataclass, field
 from typing import Any
@@ -53,14 +54,25 @@ def _make_initialized_pool(size: int = 1, cwd: str | None = "/tmp") -> PTYPool:
     return pool
 
 
+@contextlib.contextmanager
 def _patch_container_run_with_result(result_factory: Any):
     """Patch `Container.run` to call result_factory() and return its
-    output. The adapter is single-shot, so this lets us exercise the
-    adapter's flow without driving a real container."""
-    return patch(
-        "agent.granite_container.bridge_adapter.Container.run",
-        lambda self: result_factory(),
-    )
+    output, AND neutralize `PTYDriver.spawn` for the duration.
+
+    The adapter is single-shot, so this lets us exercise the adapter's
+    flow without driving a real container. The spawn patch is required
+    because BridgeAdapter always carries per-session session-ids, so
+    `_needs_session_spawn` now forces a spawn-on-acquire inside
+    `acquire_pair` (Finding 1) — without neutralizing spawn the adapter
+    would exec the real `claude` binary (issue #1632)."""
+    with (
+        patch(
+            "agent.granite_container.bridge_adapter.Container.run",
+            lambda self: result_factory(),
+        ),
+        _patch_spawn(),
+    ):
+        yield
 
 
 def _make_container_result(
@@ -332,35 +344,44 @@ class TestBridgeAdapterPrewarmedPair(unittest.TestCase):
     """
 
     def test_run_passes_pool_pair_to_container(self) -> None:
-        """BridgeAdapter.run forwards the acquired (pm, dev) pair
-        to Container as pm_pty/dev_pty kwargs, and Container does
-        NOT call PTYDriver.spawn.
+        """BridgeAdapter.run forwards the pool-acquired (pm, dev) pair
+        to Container as pm_pty/dev_pty kwargs, and Container does NOT
+        spawn a fresh pair on top of it.
 
-        The pool is initialized with the SAME cwd the session runs
-        in and the adapter carries no per-session env/persona, so
-        the spawn spec matches the pool defaults and the pre-warmed
-        pair is used as-is (no spawn-on-acquire)."""
+        BridgeAdapter always carries per-session session-ids, so the
+        pool performs a spawn-on-acquire (Finding 1): the prewarmed
+        pair is spawned at pool.initialize, then replaced by a
+        per-session pair at acquire time. That is the pool's job — the
+        regression this guards is Container spawning ADDITIONAL PTYs on
+        top of the pair it already received. We assert Container got a
+        non-None pool pair and did not invoke spawn itself."""
         from unittest.mock import patch as _patch
 
         pool = _make_pool(size=1)
         session = _FakeSession()
 
-        # Capture which (role, id) pairs are spawned. The pool's
-        # prewarm is the only spawn that should happen. We patch
-        # the spawn AT the module level (the path pty_driver.spawn
-        # looks up at call time) and init the pool inside the
-        # patch so prewarm is captured. The fake is a FULL fake —
-        # never call through to the original spawn body, which
-        # execs the real `claude` binary (issue #1632 mode 3:
-        # orphaned ~250MB claude processes memory-crash the box).
-        spawned: list[tuple[str, int]] = []
+        # Track every spawn and the pair handed to Container. The fake
+        # spawn is a FULL fake — never call through to the original
+        # spawn body, which execs the real `claude` binary (issue #1632
+        # mode 3: orphaned ~250MB claude processes memory-crash the box).
+        spawned: list[str] = []
+        seen: dict = {}
 
         def _tracking_spawn(self):  # type: ignore[no-untyped-def]
-            spawned.append((self.role, id(self)))
+            spawned.append(self.role)
+
+        def _fake_container(**kwargs):
+            seen.update(kwargs)
+            container = MagicMock()
+            container.run = lambda: _make_container_result()
+            return container
 
         with (
-            _patch("agent.granite_container.pty_driver.PTYDriver.spawn", _tracking_spawn),
-            _patch_container_run_with_result(lambda: _make_container_result()),
+            _patch("agent.granite_container.pty_pool.PTYDriver.spawn", _tracking_spawn),
+            _patch(
+                "agent.granite_container.bridge_adapter.Container",
+                side_effect=_fake_container,
+            ),
         ):
             asyncio.run(pool.initialize(cwd="/tmp"))
             adapter = BridgeAdapter(
@@ -370,37 +391,46 @@ class TestBridgeAdapterPrewarmedPair(unittest.TestCase):
                 pool=pool,
                 resolve_callbacks=lambda p, t: (None, None),
             )
+            spawned.clear()  # ignore prewarm spawns from initialize()
             asyncio.run(adapter.run("hello", "/tmp"))
 
-        # Exactly one pm + one dev spawn — both from the pool's
-        # prewarm. Zero additional spawns from Container.
-        roles = sorted(r for r, _ in spawned)
-        self.assertEqual(roles, ["dev", "pm"])
-        # No duplicate roles (i.e., Container did NOT spawn).
-        role_counts: dict[str, int] = {}
-        for r, _ in spawned:
-            role_counts[r] = role_counts.get(r, 0) + 1
-        for r, count in role_counts.items():
-            self.assertEqual(
-                count, 1, f"role {r!r} spawned {count}x, expected 1x (Container spawned fresh)"
-            )
+        # Container received the pool's acquired pair...
+        self.assertIsNotNone(seen.get("pm_pty"))
+        self.assertIsNotNone(seen.get("dev_pty"))
+        # ...and the per-session spawn-on-acquire produced exactly one
+        # pm + one dev — no extra spawns leaking past pool_size × 2.
+        self.assertEqual(sorted(spawned), ["dev", "pm"])
 
     def test_run_marks_pool_pair_as_released(self) -> None:
-        """The pool's (pm, dev) PTYs are marked _released_to_pool=True
-        so Container._close_pair does not double-close them. The pool
-        cwd matches the session cwd so the prewarmed pair is reused."""
+        """The (pm, dev) pair handed to Container is marked
+        _released_to_pool=True so Container._close_pair does not
+        double-close them — the pool's __aexit__ owns the close.
+
+        BridgeAdapter always carries per-session session-ids, so the
+        pool performs a spawn-on-acquire and the pair the container
+        receives is the per-session respawned pair, NOT the original
+        prewarmed pair (Finding 1). The release contract applies to
+        whichever pair is actually active for the session."""
         pool = _make_pool(size=1)
         with _patch_spawn():
             asyncio.run(pool.initialize(cwd="/tmp"))
         session = _FakeSession()
 
-        # Find the prewarmed pair.
-        slots = pool._slots
-        self.assertEqual(len(slots), 1)
-        prewarmed_pm, prewarmed_dev = slots[0].pty_pair
+        # Capture the pair actually handed to the Container.
+        seen: dict = {}
+
+        def _fake_container(**kwargs):
+            seen.update(kwargs)
+            container = MagicMock()
+            container.run = lambda: _make_container_result()
+            return container
 
         with (
-            _patch_container_run_with_result(lambda: _make_container_result()),
+            patch(
+                "agent.granite_container.bridge_adapter.Container",
+                side_effect=_fake_container,
+            ),
+            _patch_spawn(),
         ):
             adapter = BridgeAdapter(
                 agent_session=session,
@@ -411,9 +441,13 @@ class TestBridgeAdapterPrewarmedPair(unittest.TestCase):
             )
             asyncio.run(adapter.run("hello", "/tmp"))
 
-        # Both prewarmed PTYs are marked as pool-owned.
-        self.assertTrue(getattr(prewarmed_pm, "_released_to_pool", False))
-        self.assertTrue(getattr(prewarmed_dev, "_released_to_pool", False))
+        # The active pair handed to Container is marked pool-owned.
+        active_pm = seen.get("pm_pty")
+        active_dev = seen.get("dev_pty")
+        self.assertIsNotNone(active_pm)
+        self.assertIsNotNone(active_dev)
+        self.assertTrue(getattr(active_pm, "_released_to_pool", False))
+        self.assertTrue(getattr(active_dev, "_released_to_pool", False))
 
 
 @dataclass
@@ -564,9 +598,12 @@ class TestBridgeAdapterLastTurnAt(unittest.TestCase):
             pool=pool,
             resolve_callbacks=lambda p, t: (None, None),
         )
-        with patch(
-            "agent.granite_container.bridge_adapter.Container",
-            side_effect=_fake_container,
+        with (
+            patch(
+                "agent.granite_container.bridge_adapter.Container",
+                side_effect=_fake_container,
+            ),
+            _patch_spawn(),
         ):
             asyncio.run(adapter.run("test", "/tmp"))
 
@@ -662,9 +699,15 @@ class TestBridgeAdapterSpawnOnAcquire(unittest.TestCase):
         for d in prewarmed:
             self.assertTrue(d.closed, f"prewarmed {d.role} PTY was not closed")
 
-    def test_no_session_requirements_reuses_prewarmed_pair(self) -> None:
+    def test_session_ids_force_spawn_even_without_env_or_model(self) -> None:
         """A spec matching the pool defaults (same cwd, no env, no
-        persona, no model) uses the pre-warmed pair as-is."""
+        persona, no model) STILL spawns a per-session pair, because
+        BridgeAdapter always carries per-session session-ids and
+        `_needs_session_spawn` now treats session-ids as a per-session
+        identity (Finding 1, latent bug 1). Without this, the prewarmed
+        pair (whose claude auto-generates its own UUID) would be reused
+        and the transcript path the container computes from the spec's
+        session-ids would never match — the empty-read churn."""
         session = _FakeSession()
 
         with patch("agent.granite_container.pty_pool.PTYDriver", _SpecFakeDriver):
@@ -680,8 +723,13 @@ class TestBridgeAdapterSpawnOnAcquire(unittest.TestCase):
             with _patch_container_run_with_result(lambda: _make_container_result()):
                 asyncio.run(adapter.run("hello", "/tmp"))
 
-        # Only the 2 prewarm spawns — no per-session pair.
-        self.assertEqual(len(_SpecFakeDriver.instances), 2)
+        # 2 prewarm + 2 per-session spawns: the session-ids force a spawn.
+        self.assertEqual(len(_SpecFakeDriver.instances), 4)
+        # The per-session pair carries the spec's session-ids.
+        session_pms = [
+            d for d in _SpecFakeDriver.instances if d.role == "pm" and d._session_id is not None
+        ]
+        self.assertEqual(len(session_pms), 1)
 
 
 class TestDeliverSyncReturnsBool(unittest.TestCase):

--- a/tests/unit/granite_container/test_bridge_adapter_delivery.py
+++ b/tests/unit/granite_container/test_bridge_adapter_delivery.py
@@ -81,7 +81,8 @@ class TestDeliverFromWorkerThread(unittest.TestCase):
 
         class _Ctx:
             async def __aenter__(self):
-                return (pm, dev)
+                # acquire_pair yields a 3-tuple (pm, dev, pty_slot) since #1663.
+                return (pm, dev, 0)
 
             async def __aexit__(self, *a):
                 return False

--- a/tests/unit/granite_container/test_container.py
+++ b/tests/unit/granite_container/test_container.py
@@ -1267,7 +1267,8 @@ class TestWrapupGuard(unittest.TestCase):
         self.assertGreaterEqual(
             result.transcript_fallback_count,
             1,
-            "wrap-up seed-build DEV_REPORT_UNAVAILABLE branch must increment transcript_fallback_count",
+            "wrap-up seed-build DEV_REPORT_UNAVAILABLE branch must increment "
+            "transcript_fallback_count",
         )
 
     def test_terminal_message_sent_when_pm_silent(self) -> None:
@@ -1425,6 +1426,141 @@ class TestContainerResultPtySlot(unittest.TestCase):
         )
         result.pty_slot = 2
         self.assertEqual(result.pty_slot, 2)
+
+
+class TestTranscriptPathRealpath(unittest.TestCase):
+    """`_transcript_path` realpath-resolves the cwd slug and guards on session_id.
+
+    Finding 1, latent bug 2: Claude Code names transcript dirs from the
+    realpath-resolved cwd. A symlink-crossing cwd must slug to the
+    resolved path, and the None-guard must precede the realpath so a
+    falsy session_id still yields None (never a wrong path).
+    """
+
+    def test_none_session_id_returns_none_even_with_symlink_cwd(self) -> None:
+        """None-guard precedes realpath: falsy session_id always returns None."""
+        import os
+        import tempfile
+
+        from agent.granite_container.container import _transcript_path
+
+        with tempfile.TemporaryDirectory() as tmp:
+            real = os.path.join(tmp, "real")
+            link = os.path.join(tmp, "link")
+            os.mkdir(real)
+            os.symlink(real, link)
+            self.assertIsNone(_transcript_path(link, None))
+            self.assertIsNone(_transcript_path(link, ""))
+
+    def test_symlink_cwd_slug_is_realpath_resolved(self) -> None:
+        """A symlink-crossing cwd produces the realpath slug, not the link slug."""
+        import os
+        import tempfile
+
+        from agent.granite_container.container import _transcript_path
+
+        with tempfile.TemporaryDirectory() as tmp:
+            # Resolve tmp itself (macOS /var -> /private/var) so the
+            # expected slug is computed from the same realpath base.
+            real = os.path.realpath(os.path.join(tmp, "real"))
+            link = os.path.join(tmp, "link")
+            os.mkdir(real)
+            os.symlink(real, link)
+
+            path = _transcript_path(link, "sess-uuid")
+            self.assertIsNotNone(path)
+            expected_slug = real.replace("/", "-")
+            link_slug = os.path.realpath(link)  # same as real, sanity
+            self.assertEqual(link_slug, real)
+            self.assertIn(expected_slug, path)
+            self.assertTrue(path.endswith("sess-uuid.jsonl"))
+
+    def test_empty_cwd_does_not_crash_and_skips_realpath(self) -> None:
+        """Empty cwd is not realpath'd (would return process CWD); slug stays empty-rooted."""
+        from agent.granite_container.container import _transcript_path
+
+        path = _transcript_path("", "sess-uuid")
+        # cwd == "" -> realpath skipped -> slug "" -> path ends with the file.
+        self.assertIsNotNone(path)
+        self.assertTrue(path.endswith("sess-uuid.jsonl"))
+
+
+class TestTranscriptReadDiagnostic(unittest.TestCase):
+    """The three-way transcript-read diagnostic (Finding 1 lead change).
+
+    A single 'PM transcript read empty' message hid three distinct
+    failure modes. The split must emit stable, greppable substrings:
+    path-None / file-missing / no-new-entry.
+    """
+
+    def test_branch_classifier_path_none(self) -> None:
+        from agent.granite_container.container import _transcript_read_branch
+
+        self.assertEqual(_transcript_read_branch(None), "transcript read: path-None")
+
+    def test_branch_classifier_file_missing(self) -> None:
+        from agent.granite_container.container import _transcript_read_branch
+
+        self.assertEqual(
+            _transcript_read_branch("/no/such/transcript.jsonl"),
+            "transcript read: file-missing",
+        )
+
+    def test_branch_classifier_no_new_entry(self) -> None:
+        import tempfile
+
+        from agent.granite_container.container import _transcript_read_branch
+
+        with tempfile.NamedTemporaryFile(suffix=".jsonl") as fh:
+            self.assertEqual(
+                _transcript_read_branch(fh.name),
+                "transcript read: no-new-entry",
+            )
+
+    def test_log_diagnostic_path_none_substring(self) -> None:
+        from agent.granite_container.container import _log_transcript_read_diagnostic
+
+        pm = MagicMock()
+        pm._session_id = "pm-uuid"
+        dev = MagicMock()
+        dev._session_id = "dev-uuid"
+        with self.assertLogs("agent.granite_container.container", level="WARNING") as cm:
+            _log_transcript_read_diagnostic("prime-turn", None, pm, dev)
+        joined = "\n".join(cm.output)
+        self.assertIn("transcript read: path-None", joined)
+        self.assertIn("prime-turn", joined)
+        self.assertIn("pm-uuid", joined)
+
+    def test_log_diagnostic_file_missing_substring(self) -> None:
+        from agent.granite_container.container import _log_transcript_read_diagnostic
+
+        pm = MagicMock()
+        pm._session_id = "pm-uuid"
+        dev = MagicMock()
+        dev._session_id = "dev-uuid"
+        with self.assertLogs("agent.granite_container.container", level="WARNING") as cm:
+            _log_transcript_read_diagnostic(
+                "steady-state turn 3", "/no/such/transcript.jsonl", pm, dev
+            )
+        joined = "\n".join(cm.output)
+        self.assertIn("transcript read: file-missing", joined)
+        self.assertIn("steady-state turn 3", joined)
+
+    def test_log_diagnostic_no_new_entry_substring(self) -> None:
+        import tempfile
+
+        from agent.granite_container.container import _log_transcript_read_diagnostic
+
+        pm = MagicMock()
+        pm._session_id = "pm-uuid"
+        dev = MagicMock()
+        dev._session_id = "dev-uuid"
+        with tempfile.NamedTemporaryFile(suffix=".jsonl") as fh:
+            with self.assertLogs("agent.granite_container.container", level="WARNING") as cm:
+                _log_transcript_read_diagnostic("wrap-up guard", fh.name, pm, dev)
+        joined = "\n".join(cm.output)
+        self.assertIn("transcript read: no-new-entry", joined)
+        self.assertIn("wrap-up guard", joined)
 
 
 if __name__ == "__main__":

--- a/tests/unit/granite_container/test_pty_pool_hardening.py
+++ b/tests/unit/granite_container/test_pty_pool_hardening.py
@@ -192,5 +192,48 @@ class TestPidRegistryLoadOrder(_PoolTestBase):
         self.assertIn(987654, on_disk)
 
 
+class TestNeedsSessionSpawn(_PoolTestBase):
+    """`_needs_session_spawn` forces a per-session spawn for any per-session identity."""
+
+    def _spec(self, **kwargs):
+        from agent.granite_container.pty_pool import PairSpawnSpec
+
+        return PairSpawnSpec(**kwargs)
+
+    def test_session_ids_force_spawn_even_with_empty_env(self) -> None:
+        """A spec carrying session-ids but EMPTY env must still spawn.
+
+        This is the Finding-1 latent bug: the prewarmed pair has no
+        session-id, so reusing it for a spec that names specific
+        session-ids would produce a transcript at the wrong slug.
+        """
+        pool = PTYPool(pool_size=1, pid_registry_path=self.registry)
+        spec = self._spec(
+            env={},  # empty env — the masking condition
+            pm_session_id="pm-uuid-1234",
+            dev_session_id="dev-uuid-5678",
+        )
+        self.assertTrue(pool._needs_session_spawn(spec))
+
+    def test_only_pm_session_id_forces_spawn(self) -> None:
+        pool = PTYPool(pool_size=1, pid_registry_path=self.registry)
+        spec = self._spec(env={}, pm_session_id="pm-uuid-1234")
+        self.assertTrue(pool._needs_session_spawn(spec))
+
+    def test_only_dev_session_id_forces_spawn(self) -> None:
+        pool = PTYPool(pool_size=1, pid_registry_path=self.registry)
+        spec = self._spec(env={}, dev_session_id="dev-uuid-5678")
+        self.assertTrue(pool._needs_session_spawn(spec))
+
+    def test_bare_spec_does_not_force_spawn(self) -> None:
+        """A spec with no per-session identity at all reuses the prewarmed pair."""
+        pool = PTYPool(pool_size=1, pid_registry_path=self.registry)
+        self.assertFalse(pool._needs_session_spawn(self._spec()))
+
+    def test_none_spec_does_not_force_spawn(self) -> None:
+        pool = PTYPool(pool_size=1, pid_registry_path=self.registry)
+        self.assertFalse(pool._needs_session_spawn(None))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/unit/test_agent_session_queue_async.py
+++ b/tests/unit/test_agent_session_queue_async.py
@@ -215,3 +215,74 @@ class TestEnqueueContinuationAsyncWrapping:
                         # transition_status should be called directly
                         # (no update_session wrapper — saves a Redis re-read)
                         mock_transition.assert_called_once()
+
+
+class TestEnqueueSessionTypeOmissionWarning:
+    """enqueue_agent_session warns when both session_type and project_config are omitted.
+
+    Finding 2 safety net: a scanner that dropped persona resolution silently
+    defaults a teammate-configured chat to an eng PM<->Dev loop. The greppable
+    warning surfaces that call shape without changing the eng default.
+    """
+
+    def _run_enqueue(self, **overrides):
+        from agent.agent_session_queue import enqueue_agent_session
+
+        kwargs = dict(
+            project_key="testproj",
+            session_id="s1",
+            working_dir="/tmp/test",
+            message_text="hello",
+            sender_name="Alice",
+            chat_id="100",
+            telegram_message_id=1,
+        )
+        kwargs.update(overrides)
+
+        with (
+            patch(
+                "agent.agent_session_queue._push_agent_session",
+                new_callable=AsyncMock,
+                return_value=1,
+            ) as push,
+            patch("agent.agent_session_queue._ensure_worker"),
+        ):
+            asyncio.run(enqueue_agent_session(**kwargs))
+        return push
+
+    def test_warns_when_both_omitted(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="agent.agent_session_queue"):
+            push = self._run_enqueue()
+        assert any(
+            "[enqueue] session_type omitted AND project_config omitted" in r.getMessage()
+            for r in caplog.records
+        )
+        # Effective default is still eng.
+        from config.enums import SessionType
+
+        assert push.call_args[1]["session_type"] == SessionType.ENG
+
+    def test_no_warning_when_project_config_passed(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="agent.agent_session_queue"):
+            self._run_enqueue(project_config={"_key": "testproj"})
+        assert not any(
+            "[enqueue] session_type omitted AND project_config omitted" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_no_warning_when_session_type_passed(self, caplog):
+        import logging
+
+        from config.enums import SessionType
+
+        with caplog.at_level(logging.WARNING, logger="agent.agent_session_queue"):
+            push = self._run_enqueue(session_type=SessionType.ENG)
+        assert not any(
+            "[enqueue] session_type omitted AND project_config omitted" in r.getMessage()
+            for r in caplog.records
+        )
+        assert push.call_args[1]["session_type"] == SessionType.ENG

--- a/tests/unit/test_reconciler.py
+++ b/tests/unit/test_reconciler.py
@@ -519,3 +519,78 @@ class TestReconcileOnceSilentStream:
         # Recovery still succeeded despite the silent-gap check raising.
         assert result == 1
         enqueue_fn.assert_called_once()
+
+
+class TestReconcilePersonaSessionType:
+    """Reconciler resolves persona -> session_type for parity with the live handler."""
+
+    @pytest.mark.asyncio
+    async def test_teammate_persona_enqueues_teammate(self):
+        """A teammate-configured chat enqueues session_type=teammate + project_config."""
+        from config.enums import SessionType
+
+        dialog = _make_dialog("Cyndra Dev Team", entity_id=210)
+        msg = _make_message(601, text="@valor please look")
+
+        client = AsyncMock()
+        client.get_dialogs = AsyncMock(return_value=[dialog])
+        client.get_messages = AsyncMock(return_value=[msg])
+
+        enqueue_fn = AsyncMock()
+        project = {
+            "_key": "cyndra",
+            "working_directory": "/tmp/cyndra",
+            "telegram": {"groups": {"Cyndra Dev Team": {"persona": "teammate"}}},
+        }
+
+        with (
+            patch(
+                "bridge.reconciler.is_duplicate_message", new_callable=AsyncMock, return_value=False
+            ),
+            patch("bridge.reconciler.record_message_processed", new_callable=AsyncMock),
+            patch("bridge.reconciler.record_last_processed", new_callable=AsyncMock),
+        ):
+            result = await reconcile_once(
+                client=client,
+                monitored_groups=["cyndra dev team"],
+                should_respond_fn=AsyncMock(return_value=(True, False)),
+                enqueue_agent_session_fn=enqueue_fn,
+                find_project_fn=MagicMock(return_value=project),
+            )
+
+        assert result == 1
+        call_kwargs = enqueue_fn.call_args[1]
+        assert call_kwargs["session_type"] == SessionType.TEAMMATE
+        assert call_kwargs["project_config"] is project
+
+    @pytest.mark.asyncio
+    async def test_default_persona_enqueues_eng(self):
+        """A chat with no teammate persona enqueues an eng session."""
+        from config.enums import SessionType
+
+        dialog = _make_dialog("Test Group", entity_id=220)
+        msg = _make_message(602, text="fix the build")
+
+        client = AsyncMock()
+        client.get_dialogs = AsyncMock(return_value=[dialog])
+        client.get_messages = AsyncMock(return_value=[msg])
+
+        enqueue_fn = AsyncMock()
+
+        with (
+            patch(
+                "bridge.reconciler.is_duplicate_message", new_callable=AsyncMock, return_value=False
+            ),
+            patch("bridge.reconciler.record_message_processed", new_callable=AsyncMock),
+            patch("bridge.reconciler.record_last_processed", new_callable=AsyncMock),
+        ):
+            result = await reconcile_once(
+                client=client,
+                monitored_groups=["test group"],
+                should_respond_fn=AsyncMock(return_value=(True, False)),
+                enqueue_agent_session_fn=enqueue_fn,
+                find_project_fn=MagicMock(return_value=_make_project()),
+            )
+
+        assert result == 1
+        assert enqueue_fn.call_args[1]["session_type"] == SessionType.ENG

--- a/tests/unit/test_routing.py
+++ b/tests/unit/test_routing.py
@@ -21,7 +21,28 @@ from bridge.routing import (
     get_valor_usernames,
     is_message_for_others,
     is_message_for_valor,
+    persona_to_session_type,
 )
+from config.enums import PersonaType, SessionType
+
+
+@pytest.mark.parametrize(
+    "persona, expected",
+    [
+        (PersonaType.TEAMMATE, SessionType.TEAMMATE),
+        (PersonaType.ENGINEER, SessionType.ENG),
+        (None, SessionType.ENG),
+        (PersonaType.CUSTOMER_SERVICE, SessionType.ENG),
+    ],
+)
+def test_persona_to_session_type(persona, expected):
+    """TEAMMATE persona -> TEAMMATE session; ENGINEER/None/other -> ENG session.
+
+    This mapping is the single source of truth shared by the live handler and
+    the catchup/reconciler scanners; a regression here is exactly the bug that
+    let teammate chats default to an eng PM<->Dev loop.
+    """
+    assert persona_to_session_type(persona) == expected
 
 
 def _install_fake_ollama(monkeypatch, content: str):


### PR DESCRIPTION
Closes #1708

## Summary

Fixes two confirmed defects the granite startup-hang (3a3ff1ab) had been masking, surfaced by a live cyndra end-to-end test where the container shipped the canned `OPERATOR_TERMINAL_MESSAGE` ("Your request was completed; a summary could not be generated").

### Finding 1 — "PM transcript read empty" churn (diagnostic-first)
- **Diagnostic split (lead change):** the single conflated `PM transcript read empty` log at all three read sites (prime-turn, steady-state, wrap-up guard) is split into three stably-named greppable branches — `transcript read: path-None` / `file-missing` / `no-new-entry`. Each WARNING also logs the resolved attempted path, pm/dev session-id presence, and live PTY session-id, landing in `logs/worker.log`.
- **Latent path hardening (correct-regardless, production no-op today):**
  - `_needs_session_spawn` now also forces a per-session spawn when a spec carries `pm_session_id`/`dev_session_id` even with empty env; docstring restated as the full per-session-identity invariant.
  - `_transcript_path` and `bridge_adapter` slug computation now `realpath`-resolve the cwd (only when truthy) before slugging, matching claude's symlink-resolved project-dir slug. None-guard precedes realpath.
- Reworded `OPERATOR_TERMINAL_MESSAGE` so it no longer falsely claims completion.

### Finding 2 — catchup/reconciler re-ingest ran as `eng` for a `teammate` chat
- New `persona_to_session_type` helper in `bridge/routing.py`; live handler refactored to call it.
- `bridge/catchup.py` and `bridge/reconciler.py` now resolve `resolve_persona(...)` → `persona_to_session_type(...)` and pass `session_type=` + `project_config=` to `enqueue_agent_session`, matching the live path. Wrapped in a narrow per-message try/except with a greppable WARNING that falls back to eng without aborting the scan.
- Defense-in-depth: `enqueue_agent_session` emits a greppable WARNING when both `session_type` and `project_config` are omitted (sentinel default), keeping the eng default for intentional callers.

## Note on Finding 1 fail-closed criteria
Per the plan, the two latent path fixes are admitted production no-ops today (recon eliminated all three originally-hypothesized live causes). The diagnostic is the gating deliverable — confirming which branch the live cyndra session hits (criteria 1a/1b) requires a live repro and is a verification-phase step. If the live branch is `no-new-entry`, that escalates to a follow-up issue with the now-disambiguated evidence.

## Tests
- `tests/unit/granite_container/` — 311 passed (diagnostic branches via caplog; predicate True for session-id + empty env; realpath slug with None-guard precedence)
- catchup + reconciler + routing — 77 passed (teammate→TEAMMATE, default→ENG on both scanner paths; failure-WARNING; enqueue-omission WARNING)

## Docs
- `docs/features/granite-pty-production.md` — three-way transcript-read diagnostic, `_needs_session_spawn` invariant, realpath-slug rule
- `docs/features/eng-session-architecture.md` — persona resolution on all ingest paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)