### PR TITLE
fix(granite): prevent canned OPERATOR_TERMINAL_MESSAGE via prefix contract + floor

### DIFF
--- a/agent/granite_container/container.py
+++ b/agent/granite_container/container.py
@@ -236,6 +236,16 @@ PM_WRAPUP_PROMPT = (
 # OPERATOR_TERMINAL_MESSAGE instead.
 MAX_WRAPUP_ATTEMPTS = 1
 
+# Per-turn routing-prefix contract reminder appended to the Dev-report
+# handoff write so the PM cannot lose the contract across turns. One
+# short sentence — intentionally brief so it costs minimal tokens and
+# does not distract the PM from the Dev report content. Restores the
+# per-turn guarantee that was lost when #1694 deleted the
+# --append-system-prompt path.
+PM_TURN_CONTRACT_REMINDER = (
+    "\n\nBegin your reply with [/user], [/complete], or [/dev] on its own line."
+)
+
 # Fallback seed string for the wrap-up prompt when the developer did
 # not produce a captured report and the Dev PTY is no longer readable.
 DEV_REPORT_UNAVAILABLE = "The developer did not produce a captured report."
@@ -277,8 +287,11 @@ class ContainerResult:
     """Final output of a container run.
 
     `exit_reason` is one of: pm_complete, pm_user, pm_max_turns,
-    dev_hang, pm_hang, startup_unresolved, pm_no_user_message,
-    exception. The worker renders this as the run's terminal verdict.
+    pm_floor_delivered, dev_hang, pm_hang, startup_unresolved,
+    pm_no_user_message, exception. The worker renders this as the
+    run's terminal verdict. pm_floor_delivered means the wrap-up
+    floor delivered PM's final text directly (non-empty but
+    prefix-less); it is a clean exit (user got a real message).
 
     `user_facing_routed` is True when at least one [/user] or
     non-empty [/complete] payload was delivered to the user channel
@@ -1216,7 +1229,10 @@ class Container:
             # successful-shaped terminal state but PM never delivered a
             # user-facing message, drive PM to produce one. This
             # guarantees the human always receives some output.
-            _successful_exits = {"pm_complete", "pm_user", "pm_max_turns"}
+            # Failure exit_reasons (dev_hang, pm_hang, exception, startup_unresolved,
+            # pm_no_user_message) bypass this gate structurally — they are never in
+            # _successful_exits. No runtime sticky-failed guard is needed here.
+            _successful_exits = {"pm_complete", "pm_user", "pm_max_turns", "pm_floor_delivered"}
             if result.exit_reason in _successful_exits and not result.user_facing_routed:
                 self._run_wrapup_guard(result)
 
@@ -1409,7 +1425,7 @@ class Container:
         if not await_pm:
             result.exit_message = "PM did not reach idle before Dev report"
             return RouteOutcome(should_break=True, exit_reason="pm_hang")
-        self._pm_pty.write(dev_text)
+        self._pm_pty.write(dev_text + PM_TURN_CONTRACT_REMINDER)
 
         turn_record = TurnRecord(
             turn_index=turn_index,
@@ -1537,18 +1553,39 @@ class Container:
                 )
                 if pm_text:
                     wrapup_classification = classify_pm_prefix(pm_text)
+                    if wrapup_classification.destination in ("user", "complete", "dev"):
+                        # PM produced a compliant prefix — route normally.
+                        outcome = self._route_pm_classification(
+                            wrapup_classification, pm_buf, turn_index=-2, result=result
+                        )
+                        if result.user_facing_routed:
+                            result.exit_reason = outcome.exit_reason or result.exit_reason
+                            return
+                    else:
+                        # Non-empty but prefix-less — deliver pm_text directly
+                        # WITHOUT calling _route_pm_classification (which would
+                        # write PM_COMPLIANCE_NUDGE into the dying PTY at :1286).
+                        if self._on_user_payload is not None:
+                            try:
+                                self._on_user_payload(pm_text.strip())
+                                result.user_facing_routed = True
+                                result.exit_reason = "pm_floor_delivered"
+                                logger.info(
+                                    "[granite-container] wrap-up floor: "
+                                    "delivered prefix-less PM text (%d chars)",
+                                    len(pm_text),
+                                )
+                                return
+                            except Exception as e:
+                                logger.warning(
+                                    "[granite-container] wrap-up floor: direct delivery failed: %s",
+                                    e,
+                                )
                 else:
                     _log_transcript_read_diagnostic(
                         "wrap-up guard", pm_transcript, self._pm_pty, self._dev_pty
                     )
                     result.transcript_fallback_count += 1
-                    wrapup_classification = _unknown_classification()
-                outcome = self._route_pm_classification(
-                    wrapup_classification, pm_buf, turn_index=-2, result=result
-                )
-                if result.user_facing_routed:
-                    result.exit_reason = outcome.exit_reason or result.exit_reason
-                    return
 
             # PM still silent after MAX_WRAPUP_ATTEMPTS — deliver canned
             # terminal message directly so the human always gets something.

--- a/agent/session_executor.py
+++ b/agent/session_executor.py
@@ -32,16 +32,18 @@ from models.session_lifecycle import TERMINAL_STATUSES as _TERMINAL_STATUSES
 
 logger = logging.getLogger(__name__)
 
-_CLEAN_GRANITE_EXIT_REASONS = frozenset({"pm_complete", "pm_user"})
+_CLEAN_GRANITE_EXIT_REASONS = frozenset({"pm_complete", "pm_user", "pm_floor_delivered"})
 
 
 def _is_non_clean_granite_exit(agent_session) -> bool:
     """Return True when the session has a granite exit_reason that signals a real failure.
 
     None exit_reason = non-granite session or not yet set = clean (default behavior).
-    Clean granite exits: pm_complete (normal end), pm_user (user message sent).
-    Everything else (exception, pm_hang, dev_hang, startup_unresolved, pm_no_user_message,
-    pm_max_turns) is non-clean → REACTION_ERROR.
+    Clean granite exits: pm_complete (normal end), pm_user (user message sent),
+    pm_floor_delivered (wrap-up floor delivered PM's final text directly — non-empty but
+    prefix-less; user got a real message).
+    Any other exit reason (e.g. exception, pm_hang, dev_hang, startup_unresolved,
+    pm_no_user_message, pm_max_turns) is non-clean → REACTION_ERROR.
 
     This does NOT suppress the success reaction for clean+communicated=False completions
     (those still get REACTION_SUCCESS or REACTION_COMPLETE via the normal branch).

--- a/docs/features/granite-pty-production.md
+++ b/docs/features/granite-pty-production.md
@@ -184,12 +184,27 @@ the routing outcome (including dev routes). The first steady-state iteration
 then reads a **fresh** PM idle before classifying — the stale-buffer race guard
 — so the prime buffer is never double-classified.
 
-### Wrap-up guard — mandatory user-facing delivery (issue #1647)
+### Per-turn contract reminder (issue #1719)
+
+On every steady-state Dev→PM handoff write, `PM_TURN_CONTRACT_REMINDER` is
+appended to the dev_text sent to PM's PTY:
+
+```
+"Begin your reply with [/user], [/complete], or [/dev] on its own line."
+```
+
+This single sentence costs minimal tokens and prevents PM from losing the
+routing prefix contract across multi-turn cycles — a regression introduced when
+issue #1694 removed the `--append-system-prompt` path that previously
+reinforced the contract at the system-prompt level.
+
+### Wrap-up guard — mandatory user-facing delivery (issue #1647, relaxed #1719)
 
 The `_run_wrapup_guard` method fires when the run exits in a
-*successful-shaped* state (`pm_complete`, `pm_user`, `pm_max_turns`) but
-`result.user_facing_routed` is still `False`. This happens when PM performs
-only `[/dev]` routing turns and never emits `[/user]` or `[/complete]`.
+*successful-shaped* state (`pm_complete`, `pm_user`, `pm_max_turns`,
+`pm_floor_delivered`) but `result.user_facing_routed` is still `False`. This
+happens when PM performs only `[/dev]` routing turns and never emits `[/user]`
+or `[/complete]`.
 
 The guard:
 
@@ -197,15 +212,24 @@ The guard:
    call), a fresh Dev idle read, or `DEV_REPORT_UNAVAILABLE` as fallback.
 2. Writes `PM_WRAPUP_PROMPT` (seeded with the Dev report) to PM's PTY and
    waits for PM to respond — capped at `MAX_WRAPUP_ATTEMPTS = 1`.
-3. If PM responds with a `[/user]` or `[/complete]`, that payload is delivered
-   and `user_facing_routed = True`.
-4. If PM still does not produce a user-facing message after all attempts,
+3. Three-way floor on PM's response:
+   - **Compliant prefix** (`[/user]`, `[/complete]`, or `[/dev]`): payload is
+     routed normally via `_route_pm_classification`; `user_facing_routed = True`.
+   - **Non-empty but prefix-less**: text is delivered directly via
+     `_on_user_payload(pm_text.strip())`; `user_facing_routed = True`;
+     `exit_reason = "pm_floor_delivered"`. This avoids sending
+     `PM_COMPLIANCE_NUDGE` into the dying PTY, which would have triggered
+     another idle cycle and fallen to the canned message anyway.
+   - **Empty PM transcript**: falls through to step 4.
+4. If PM's transcript is empty after all attempts (genuinely no output),
    delivers `OPERATOR_TERMINAL_MESSAGE` directly via `on_user_payload` and
    sets `exit_reason = "pm_no_user_message"`.
 
 **The human is never left with only an emoji.** The wrap-up guard guarantees
 at least `OPERATOR_TERMINAL_MESSAGE` reaches the user for every successful run,
-regardless of how the PM classified its turns internally.
+regardless of how the PM classified its turns internally. When PM produces any
+non-empty text — even without the required routing prefix — that real text is
+preferred over the canned fallback.
 
 ### Completion emoji and `user_facing_routed`
 
@@ -239,9 +263,12 @@ delivers per-turn `[/user]` payloads **mid-loop** — the user sees responses
   PM's final turn classifies as `[/user]` — this is the same model behavior,
   now visible to the operator in real time.
 - (e) A session that completes via `pm_no_user_message` (wrap-up guard
-  exhausted) sends `OPERATOR_TERMINAL_MESSAGE` — a brief canned notice that
-  the task was handled. This is a last resort; the wrap-up guard should
-  normally coax a summary from PM.
+  exhausted with empty PM transcript) sends `OPERATOR_TERMINAL_MESSAGE` — a
+  brief canned notice that the task was handled. This is a last resort; the
+  wrap-up guard should normally coax a summary from PM.
+- (f) A session where PM produced a non-empty but prefix-less final message
+  delivers that text directly via the relaxed floor (`pm_floor_delivered` exit
+  reason). The user receives PM's actual words rather than the canned fallback.
 
 ## Per-turn silence cap (not total runtime cap)
 
@@ -444,8 +471,13 @@ occupancy and the running session.
 
 `AgentSession.exit_reason` is granite-path-populated. The dashboard renders a
 warning chip for non-clean values. Clean exit reasons: `pm_complete`, `pm_user`,
-`pm_max_turns`. Anomaly exit reasons: `pm_hang`, `dev_hang`,
-`startup_unresolved`, `pm_no_user_message`, `exception`.
+`pm_max_turns`, `pm_floor_delivered` (wrap-up floor delivered PM's non-empty
+prefix-less text directly; user received a real message). Anomaly exit reasons:
+`pm_hang`, `dev_hang`, `startup_unresolved`, `pm_no_user_message`, `exception`.
+
+`pm_floor_delivered` is registered in `_CLEAN_GRANITE_EXIT_REASONS` in
+`session_executor.py` — it gets a `REACTION_COMPLETE` emoji when
+`user_facing_routed=True`, consistent with `pm_complete` and `pm_user`.
 
 The executor's reaction logic consults `exit_reason` in addition to
 `user_facing_routed`:
@@ -456,6 +488,7 @@ The executor's reaction logic consults `exit_reason` in addition to
   in dashboard) → normal reaction (the wrap-up guard fired but the session
   technically completed without user-facing output).
 - Clean `exit_reason` + `user_facing_routed=True` → `REACTION_COMPLETE`.
+  Applies to `pm_complete`, `pm_user`, and `pm_floor_delivered`.
 
 ### Liveness (two-tier no-progress detector)
 

--- a/docs/features/granite-pty-production.md
+++ b/docs/features/granite-pty-production.md
@@ -166,7 +166,7 @@ receive the user message as `$ARGUMENTS` (issue #1692):
   message omission).
 
 Persona is delivered entirely via these prime commands. No `--append-system-prompt`
-flag is set at spawn time (removed in issue #1692). The shared WORKER rails
+flag is set at spawn time. The shared WORKER rails
 (no-push-to-main, principal context, completion criteria) live in
 `.claude/commands/granite/_prime-rails.md` and each role prime references it.
 
@@ -298,7 +298,7 @@ The adapter writes non-user-visible progress to `agent_session.session_events`
 | `granite_user_routed` | on each `[/user]` payload routing attempt | `event_type`, `text` (payload size + delivery result) |
 | `granite_complete_routed` | on each `[/complete]` payload routing attempt | `event_type`, `text` (payload size + delivery result) |
 | `granite_delivery_failure` | a mid-loop `send_cb` raised | `event_type`, `text`, `payload_chars`, `reason`, `ts` |
-| `delivery_failure` | a mid-loop `send_cb` raised (legacy alias) | `payload_chars`, `reason`, `ts` |
+| `delivery_failure` | a mid-loop `send_cb` raised (alias for `granite_delivery_failure`) | `payload_chars`, `reason`, `ts` |
 
 Normal completions (`pm_complete`, `pm_user`, `pm_max_turns`) do **not** emit
 `exit_anomaly`, because they are expected outcomes. `pm_no_user_message` emits
@@ -830,9 +830,9 @@ branches unconditionally.
 naming the branch. The branch and worktree remain on disk. Grep `logs/worker.log` for
 `[unmerged-branch-guard]` to find preserved branches.
 
-**Interim accumulation:** Until #1647 lands the PM-authorized landing step, unmerged
-dev-session branches accumulate. The `preserved=N` counter in `logs/worker.log` is the
-interim signal. Manual operator action is the only safe reaping path — do NOT use
+**Interim accumulation:** Unmerged dev-session branches accumulate until the
+PM-authorized landing step. The `preserved=N` counter in `logs/worker.log` is the
+signal. Manual operator action is the only safe reaping path — avoid
 `scripts/worktree-gc.sh --apply` for no-PR branches (it has an unguarded `git branch -D`
 at line 208 that would re-destroy the preserved work).
 

--- a/tests/unit/granite_container/test_container.py
+++ b/tests/unit/granite_container/test_container.py
@@ -1280,12 +1280,78 @@ class TestWrapupGuard(unittest.TestCase):
             "transcript_fallback_count",
         )
 
-    def test_terminal_message_sent_when_pm_silent(self) -> None:
-        """After the bounded wrap-up yields nothing, OPERATOR_TERMINAL_MESSAGE
-        is delivered via on_user_payload so the human always gets a real message
+    def test_floor_delivers_prefixless_wrapup_response(self) -> None:
+        """Wrap-up guard floor: non-empty but prefix-less PM text is delivered
+        directly via on_user_payload with exit_reason=pm_floor_delivered.
+
+        This replaces the old test_terminal_message_sent_when_pm_silent
+        behaviour: a PM that produces text (even without a routing prefix)
+        should have its text delivered to the user, NOT the canned
+        OPERATOR_TERMINAL_MESSAGE. Concern C2 (#1647) is satisfied because
+        the human always receives real output.
+        """
+        terminal_deliveries: list[str] = []
+
+        def _on_user(payload: str) -> None:
+            terminal_deliveries.append(payload)
+
+        c = Container(user_message="do the work", max_turns=0, on_user_payload=_on_user)
+        pm_mock, dev_mock = _mock_pm(""), _mock_dev("")
+
+        pm_buffers = [
+            _idle_result("", saw_idle=True),  # startup
+            _idle_result("", saw_idle=True),  # prime-relay
+            # wrap-up guard: PM produces text but no prefix
+            _idle_result("", saw_idle=True),  # await PM idle
+            _idle_result("no prefix — still responding", saw_idle=True),  # PM wrapup response
+        ]
+        pm_mock.read_until_idle.side_effect = lambda **kw: pm_buffers.pop(0)
+        dev_mock.read_until_idle.return_value = _idle_result("", saw_idle=True)
+
+        # PM transcript: prime-relay (unknown/empty), wrapup (prefix-less text).
+        pm_transcript_texts = iter(
+            [
+                "",  # prime-relay: unknown (empty → fallback)
+                "no prefix — still responding",  # wrapup response: prefix-less but non-empty
+            ]
+        )
+
+        def _lat_stub(path, *, baseline_text_count=None):
+            if not path or "mock-session-dev" in path:
+                return ""
+            try:
+                return next(pm_transcript_texts)
+            except StopIteration:
+                return ""
+
+        with (
+            patch.object(c, "_spawn_pair"),
+            patch.object(c, "_close_pair"),
+            patch.object(c, "_prime_session"),
+            patch.object(c, "_run_pkill_fallback"),
+            patch(
+                "agent.granite_container.container.last_assistant_text",
+                side_effect=_lat_stub,
+            ),
+        ):
+            c._pm_pty = pm_mock
+            c._dev_pty = dev_mock
+            result = c.run()
+
+        # Floor delivers the prefix-less text — NOT the canned message.
+        self.assertEqual(terminal_deliveries, ["no prefix — still responding"])
+        self.assertTrue(result.user_facing_routed)
+        self.assertEqual(result.exit_reason, "pm_floor_delivered")
+
+    def test_terminal_message_sent_when_pm_truly_silent(self) -> None:
+        """After wrap-up, when PM produces no text at all (truly silent),
+        OPERATOR_TERMINAL_MESSAGE is delivered so the human always gets something
         (concern C2, issue #1647).
 
-        Also verifies user_facing_routed=True and exit_reason=pm_no_user_message.
+        The distinction from test_floor_delivers_prefixless_wrapup_response:
+        here last_assistant_text returns "" for the wrapup response (the PM
+        did not write anything to its transcript), so the floor cannot deliver
+        real text and falls through to the canned message.
         """
         from agent.granite_container.container import OPERATOR_TERMINAL_MESSAGE
 
@@ -1300,20 +1366,15 @@ class TestWrapupGuard(unittest.TestCase):
         pm_buffers = [
             _idle_result("", saw_idle=True),  # startup
             _idle_result("", saw_idle=True),  # prime-relay
-            # wrap-up guard: PM never produces user-facing output
+            # wrap-up guard: PM produces no transcript text
             _idle_result("", saw_idle=True),  # await PM idle
-            _idle_result("no prefix — still silent", saw_idle=True),  # PM wrapup response
+            _idle_result("", saw_idle=True),  # PM wrapup response (buffer empty too)
         ]
         pm_mock.read_until_idle.side_effect = lambda **kw: pm_buffers.pop(0)
         dev_mock.read_until_idle.return_value = _idle_result("", saw_idle=True)
 
-        # PM transcript: prime-relay (unknown), wrapup response (still no prefix).
-        pm_transcript_texts = iter(
-            [
-                "",  # prime-relay: unknown (empty → fallback)
-                "no prefix — still silent",  # wrapup response: unknown (no prefix)
-            ]
-        )
+        # PM transcript: prime-relay (empty), wrapup response (empty — truly silent).
+        pm_transcript_texts = iter(["", ""])
 
         def _lat_stub(path, *, baseline_text_count=None):
             if not path or "mock-session-dev" in path:

--- a/tests/unit/granite_container/test_wrapup_guard_floor.py
+++ b/tests/unit/granite_container/test_wrapup_guard_floor.py
@@ -1,0 +1,285 @@
+"""Unit tests for the wrap-up guard floor (pm_floor_delivered).
+
+Covers the two fixes introduced to prevent OPERATOR_TERMINAL_MESSAGE
+from being returned instead of a real response:
+
+1. Non-empty prefix-less PM text is delivered directly via
+   _on_user_payload with exit_reason=pm_floor_delivered, and
+   _route_pm_classification is NOT called.
+2. Empty pm_text still falls through to the transcript fallback path.
+3. _is_non_clean_granite_exit() returns False for pm_floor_delivered.
+4. PM_TURN_CONTRACT_REMINDER is appended to the dev_text handoff write.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.granite_container.container import (
+    PM_TURN_CONTRACT_REMINDER,
+    Container,
+    ContainerResult,
+)
+from agent.granite_container.granite_classifier import ClassificationResult
+from agent.granite_container.pty_driver import IdleResult, PTYDriver
+from agent.session_executor import _CLEAN_GRANITE_EXIT_REASONS, _is_non_clean_granite_exit
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _idle_result(buffer_text: str = "fake", saw_idle: bool = True) -> IdleResult:
+    return IdleResult(
+        saw_idle=saw_idle,
+        buffer=buffer_text,
+        idle_marker="bypass permissions on",
+        elapsed_ms=100,
+    )
+
+
+def _mock_driver(session_id: str = "mock-pm") -> MagicMock:
+    mock = MagicMock(spec=PTYDriver)
+    mock.read_until_idle.return_value = _idle_result()
+    mock.last_resume_uuid.return_value = None
+    mock.isalive.return_value = True
+    mock._session_id = session_id
+    return mock
+
+
+def _make_container(on_user_payload=None) -> Container:
+    """Build a minimal Container with mocked PTYs."""
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".json")
+    tmp.close()
+    c = Container.__new__(Container)
+    c._pm_pty = _mock_driver("pm-session")
+    c._dev_pty = _mock_driver("dev-session")
+    c._on_user_payload = on_user_payload
+    c._last_dev_report = "Dev built the feature."
+    c.max_turns = 3
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Non-empty prefix-less text → pm_floor_delivered
+# ---------------------------------------------------------------------------
+
+
+def test_wrapup_floor_delivers_prefixless_text():
+    """Non-empty prefix-less PM text is delivered via on_user_payload with
+    exit_reason=pm_floor_delivered. _route_pm_classification is not called."""
+    delivered = []
+    container = _make_container(on_user_payload=delivered.append)
+
+    result = ContainerResult(
+        session_id="s1",
+        user_message="hello",
+        exit_reason="pm_complete",
+        user_facing_routed=False,
+    )
+    # Set a non-None transcript path so last_assistant_text is actually called
+    # (the guard's `if pm_transcript else ""` short-circuits to "" otherwise).
+    result.pm_transcript_path = "/fake/pm_transcript.jsonl"
+
+    # patch last_assistant_text to return prefix-less text
+    # patch classify_pm_prefix to return an unknown (prefix-less) classification
+    prefixless_text = "Here is the summary without any prefix token."
+    prefixless_classification = ClassificationResult(
+        destination="unknown",
+        payload="",
+        compliance_miss=True,
+        raw_first_line="Here is the summary",
+    )
+
+    with (
+        patch(
+            "agent.granite_container.container.last_assistant_text",
+            return_value=prefixless_text,
+        ),
+        patch(
+            "agent.granite_container.container.text_bearing_count",
+            return_value=0,
+        ),
+        patch(
+            "agent.granite_container.container.classify_pm_prefix",
+            return_value=prefixless_classification,
+        ) as mock_classify,
+        patch.object(container, "_route_pm_classification") as mock_route,
+    ):
+        # _cycle_idle must return (True, ...) for the guard loop to proceed
+        with patch.object(
+            container,
+            "_cycle_idle",
+            return_value=(True, "pm buffer", "idle-mark", 100),
+        ):
+            container._run_wrapup_guard(result)
+
+    # Payload delivered
+    assert delivered == [prefixless_text.strip()]
+    assert result.user_facing_routed is True
+    assert result.exit_reason == "pm_floor_delivered"
+
+    # classify_pm_prefix was called (to check destination)
+    mock_classify.assert_called_once()
+
+    # _route_pm_classification was NOT called (bypassed for prefix-less text)
+    mock_route.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Empty pm_text → transcript fallback incremented, no delivery
+# ---------------------------------------------------------------------------
+
+
+def test_wrapup_guard_empty_pm_text_increments_fallback():
+    """Empty pm_text from last_assistant_text goes to transcript fallback
+    and eventually delivers OPERATOR_TERMINAL_MESSAGE."""
+    from agent.granite_container.container import OPERATOR_TERMINAL_MESSAGE
+
+    delivered = []
+    container = _make_container(on_user_payload=delivered.append)
+
+    result = ContainerResult(
+        session_id="s2",
+        user_message="hello",
+        exit_reason="pm_complete",
+        user_facing_routed=False,
+    )
+    # Set a non-None transcript path so last_assistant_text is called (not short-circuited).
+    result.pm_transcript_path = "/fake/pm_transcript.jsonl"
+
+    with (
+        patch("agent.granite_container.container.last_assistant_text", return_value=""),
+        patch("agent.granite_container.container.text_bearing_count", return_value=0),
+        patch("agent.granite_container.container._log_transcript_read_diagnostic") as mock_diag,
+    ):
+        with patch.object(
+            container,
+            "_cycle_idle",
+            return_value=(True, "pm buffer", "idle-mark", 100),
+        ):
+            container._run_wrapup_guard(result)
+
+    # transcript fallback logged
+    mock_diag.assert_called_once()
+    assert result.transcript_fallback_count >= 1
+
+    # canned message delivered
+    assert OPERATOR_TERMINAL_MESSAGE in delivered
+    assert result.exit_reason == "pm_no_user_message"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: _is_non_clean_granite_exit returns False for pm_floor_delivered
+# ---------------------------------------------------------------------------
+
+
+def test_pm_floor_delivered_is_clean_exit():
+    """pm_floor_delivered must be in _CLEAN_GRANITE_EXIT_REASONS so
+    _is_non_clean_granite_exit returns False (no REACTION_ERROR)."""
+    assert "pm_floor_delivered" in _CLEAN_GRANITE_EXIT_REASONS
+
+    session = MagicMock()
+    session.exit_reason = "pm_floor_delivered"
+    assert _is_non_clean_granite_exit(session) is False
+
+
+@pytest.mark.parametrize(
+    "exit_reason,expected_non_clean",
+    [
+        ("pm_complete", False),
+        ("pm_user", False),
+        ("pm_floor_delivered", False),
+        ("pm_no_user_message", True),
+        ("pm_max_turns", True),
+        ("dev_hang", True),
+        ("pm_hang", True),
+        ("exception", True),
+        ("startup_unresolved", True),
+    ],
+)
+def test_clean_exit_reason_classification(exit_reason, expected_non_clean):
+    """Verify the full clean/non-clean classification table."""
+    session = MagicMock()
+    session.exit_reason = exit_reason
+    result = _is_non_clean_granite_exit(session)
+    assert result is expected_non_clean, (
+        f"exit_reason={exit_reason!r}: expected non_clean={expected_non_clean}, got {result}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: PM_TURN_CONTRACT_REMINDER appended to dev_text handoff write
+# ---------------------------------------------------------------------------
+
+
+def test_pm_turn_contract_reminder_appended_in_dev_handoff():
+    """The PM_TURN_CONTRACT_REMINDER constant is appended to dev_text
+    in the _route_pm_classification dev branch, so the PM cannot lose
+    the routing-prefix contract across turns."""
+    assert PM_TURN_CONTRACT_REMINDER, "Constant must be non-empty"
+    assert "[/user]" in PM_TURN_CONTRACT_REMINDER
+    assert "[/complete]" in PM_TURN_CONTRACT_REMINDER
+    assert "[/dev]" in PM_TURN_CONTRACT_REMINDER
+
+    dev_report = "The feature is done."
+    container = _make_container()
+
+    result = ContainerResult(
+        session_id="s4",
+        user_message="build this",
+        exit_reason="in_progress",
+    )
+    result.dev_transcript_path = "/fake/dev.jsonl"
+
+    # Build a fake dev builder with proper attributes for the dev route.
+    fake_builder = MagicMock()
+    fake_builder.last_dev_ms = 42
+    fake_builder.last_dev_marker = "idle-mark"
+    fake_builder.last_hung = False
+    fake_builder.last_dev_buf = b"some output"
+    fake_builder.run_turn.return_value = dev_report
+
+    # A classification that says [/dev] with non-empty payload (avoids the
+    # empty-payload short-circuit that writes PM_COMPLIANCE_NUDGE instead).
+    dev_classification = ClassificationResult(
+        destination="dev",
+        payload="build the feature",
+        compliance_miss=False,
+        raw_first_line="[/dev]",
+        harness=None,
+    )
+
+    with (
+        patch.object(container, "_get_builder", return_value=fake_builder),
+        patch.object(
+            container,
+            "_cycle_idle",
+            return_value=(True, "pm buffer", "idle-mark", 100),
+        ),
+        patch(
+            "agent.granite_container.container.last_assistant_text",
+            return_value=dev_report,
+        ),
+    ):
+        container._route_pm_classification(
+            dev_classification,
+            pm_buf="[/dev]\nbuild the feature",
+            turn_index=0,
+            result=result,
+        )
+
+    # Confirm _pm_pty.write was called and that the reminder was appended
+    write_calls = container._pm_pty.write.call_args_list
+    assert write_calls, "_pm_pty.write must have been called at least once"
+    last_written = write_calls[-1][0][0]  # positional arg of last call
+    assert PM_TURN_CONTRACT_REMINDER in last_written, (
+        f"PM_TURN_CONTRACT_REMINDER not found in last write to PM PTY.\nWritten: {last_written!r}"
+    )
+    # Confirm the dev report text is also present (reminder is appended, not replacing)
+    assert dev_report in last_written, (
+        f"dev_report text not found in PM write. Written: {last_written!r}"
+    )


### PR DESCRIPTION
## Summary

Fixes the critical regression (#1719) where every Telegram message to the granite Eng session returns the canned string "I wasn't able to produce a response to this..." instead of a real response.

Root cause: Two compounding failures downstream of #1694:
1. Per-turn prefix contract decay — the PM only receives the routing prefix contract once at session start; without per-turn re-assertion it drifts off-prefix after ~10 turns
2. Wrap-up floor re-gates on the prefix — a non-empty but prefix-less PM wrap-up response was discarded instead of delivered

## Changes

- **Change 1 (primary fix):** Add `PM_TURN_CONTRACT_REMINDER` constant and append it to every Dev→PM handoff write in the steady-state loop (`container.py:1428`). The PM now receives "Begin your reply with [/user], [/complete], or [/dev] on its own line." on every turn, preventing contract decay across multi-turn cycles.

- **Change 2 (defense in depth):** Relax `_run_wrapup_guard` floor — when PM produces a non-empty but prefix-less final message, deliver it directly via `_on_user_payload(pm_text.strip())` with `exit_reason="pm_floor_delivered"` instead of firing `PM_COMPLIANCE_NUDGE` into the dying PTY and falling to `OPERATOR_TERMINAL_MESSAGE`. Canned fallback now fires only on a genuinely empty PM transcript.

- **Change 2b (mandatory):** Add `"pm_floor_delivered"` to `_CLEAN_GRANITE_EXIT_REASONS` in `session_executor.py` so floor-delivered sessions get `REACTION_COMPLETE` instead of `REACTION_ERROR`.

## Testing

- [x] New unit test file `tests/unit/granite_container/test_wrapup_guard_floor.py` — 13 tests covering all floor branches + PM_TURN_CONTRACT_REMINDER assertion + `_is_non_clean_granite_exit()` assertion for `pm_floor_delivered`
- [x] Updated `test_container.py` — split `test_terminal_message_sent_when_pm_silent` into two precise behavioral tests
- [x] All 363 granite unit tests passing, 5 skipped

## Documentation

- [x] `docs/features/granite-pty-production.md` updated — new per-turn contract reminder section, three-way floor logic documented, `pm_floor_delivered` added to exit reason reference, clean markers updated
- [x] `ContainerResult` docstring updated to include `pm_floor_delivered`
- [x] `_is_non_clean_granite_exit` docstring updated

## Definition of Done

- [x] Built: Code implemented and working
- [x] Tested: 363 unit tests passing
- [x] Reviewed: Build validator + docs gate passing
- [x] Documented: Docs created/updated
- [x] Quality: Lint and format checks pass

Closes #1719