### PR TITLE
Spike (#1611): Headroom context-compression evaluation — findings + go/no-go

### DIFF
--- a/docs/plans/headroom_evaluation.md
+++ b/docs/plans/headroom_evaluation.md
@@ -1,0 +1,141 @@
+---
+status: Ready
+type: chore
+appetite: Small
+owner: Valor Engels
+created: 2026-06-23
+tracking: https://github.com/tomcounsell/ai/issues/1611
+last_comment_id:
+revision_applied: true
+---
+
+# Spike: Headroom Context-Compression Evaluation
+
+## Problem
+
+Several routine reads recur on every PM/dev session and are token-heavy:
+`dashboard.json` dumps, log tails, `gh` CLI JSON output, and large SDLC stage
+reads (plan docs). They inflate context windows and cost on every turn.
+
+[Headroom](https://github.com/chopratejas/headroom) (PyPI `headroom-ai`,
+Apache 2.0) is a third-party context-compression layer claiming **60-95%
+token reduction** by squeezing tool outputs, logs, RAG chunks, and history
+*before* they reach the model. This spike answers a **fit + risk** question:
+do the claimed savings hold on **our** content shapes without dropping
+load-bearing detail or fighting Anthropic prompt caching?
+
+**Current behavior:** No compression of raw tool/log bytes. Our existing
+context-fidelity-modes layer (#329) operates at the *skill-dispatch* layer
+(how much session state forwards to sub-agents), not at the raw-byte layer —
+so the two are complementary, not competing.
+
+**Desired outcome:** A findings writeup with measured per-content-type
+token-reduction numbers, latency, a quality-regression check, a KV-cache
+verdict, and a clear **go / no-go** recommendation.
+
+## Freshness Check
+
+**Baseline commit:** plan authored on `session/headroom-evaluation` worktree, main at `9af25e38`.
+**Issue filed at:** recently (same-day spike approved by Tom in Agent Builders Chat).
+**Disposition:** Unchanged — this is a self-contained evaluation spike independent of any in-flight code. `docs/features/context-fidelity-modes.md` re-read and confirmed to describe a different (skill-dispatch) layer, so no conflation risk.
+**Active plans overlapping:** none.
+
+## Prior Art
+
+- **#329 / `docs/features/context-fidelity-modes.md`** — our in-house FULL/COMPACT/MINIMAL/STEERING context compression at the skill-dispatch layer. Complementary to Headroom (different layer). Not a prior attempt at raw-byte compression.
+- No prior issue attempted third-party raw-output compression.
+
+## Research
+
+Queries: "headroom-ai pypi extras", "headroom context compression CacheAligner KV cache", "Anthropic prompt caching 5 minute TTL".
+
+Key findings:
+- PyPI package is **`headroom-ai`** (not `headroom`), current **0.27.0**, `requires_python >=3.10`, Apache 2.0. (Our venv is Python 3.14 — compatible.)
+- Extras confirmed on PyPI: `[proxy] [mcp] [ml] [code] [memory] [relevance] [image] [agno] [langchain] [evals] [pytorch-mps]`. Issue scope = `[mcp]` + `[code]` + `[ml]` (NOT `[all]`, NOT `[memory]`).
+- Three integration surfaces: library `compress(messages, model=...)`, HTTP proxy (`headroom proxy --port 8787`), MCP server (`headroom_compress`/`headroom_retrieve`/`headroom_stats`).
+- Anthropic prompt caching: 5-min (300s) TTL, cache-write 1.25x, cache-read 0.1x — matched exactly by Headroom's `AnthropicCacheOptimizer` constants.
+
+## Solution (Spike Methodology)
+
+This is a time-boxed evaluation, **not** a production integration. The work:
+
+1. **Isolated install.** Install `headroom-ai[mcp,code,ml]` into a throwaway venv (`/tmp/headroom-spike/venv`) — never the production `.venv`, never the live harness. No `headroom wrap claude-code`.
+2. **Real corpus.** Capture genuine fixtures of our pain points: live `dashboard.json` (73KB), worker log tail (37KB), `gh pr list` JSON (PR-list shape), a large plan doc as an SDLC stage read (129KB), and real source (`ui/app.py`).
+3. **Measure per content type** via the library `compress()` API and the underlying transforms (`SmartCrusher`, `LogCompressor`, `CodeAwareCompressor`): tokens before/after, % reduction, latency (cold + warm).
+4. **Quality regression check.** Verify load-bearing tokens (error/WARN markers and session IDs) survive compression — byte counts alone are insufficient.
+5. **KV-cache verdict.** Determine whether `CacheAligner` mutates prefixes (it would fight Anthropic caching) and whether compressing recurring reads busts the 5-min prefix cache.
+6. **Recommend a surface** and a go/no-go.
+
+**Lowest-risk surface to prototype first:** library `compress()` on captured fixtures — measures savings without intercepting live traffic.
+
+## Spike Results
+
+Full numbers and analysis (including the separate `compress()`-API vs direct-transform tables) live in the deliverable: **`docs/research/headroom-evaluation.md`**. Headline findings (numbers below are direct-transform / best-case capability unless marked `via compress()`):
+
+| Content type | Compressor | Reduction (real fixture) | Lossless? |
+|---|---|---|---|
+| `gh` JSON array | SmartCrusher lossless-table | 45.1% direct / 44.9% via `compress()` | yes |
+| dashboard sub-arrays (sessions/reflections) | SmartCrusher lossless-table | 30-37% | yes |
+| **whole `dashboard.json`** (nested dict) | router gates it out | **27.4% direct but 0% via `compress()`** (router won't descend nested dict) | lossless if reachable |
+| worker log tail | LogCompressor (dedup) | **73.5% direct / 73.3% via `compress()`** | lossy-but-signal-safe |
+| python source (`ui/app.py`) | CodeAwareCompressor | **0%** (self-rejected: invalid syntax) | n/a |
+| markdown / prose (plan doc) | Kompress (ML) | **0%** (model not loaded; `embedding_available=False`) | n/a |
+
+- **Latency:** warm ~3-5ms; one-time cold ~11-70ms. Negligible per-call once warm.
+- **Quality:** LogCompressor retained all error/WARN markers and all 9 unique session IDs (the two signal classes measured) while cutting 73.5% — it deduplicates repeated lines, doesn't drop unique signal.
+- **KV-cache:** `CacheAligner` is **detector-only** in 0.27.0 (`enabled=False` default; never mutates messages) — so it will NOT fight Anthropic caching. The real tension is that compressing a *recurring* read changes its bytes and busts the 5-min prefix cache for that message.
+- **Footprint:** `[ml]` pulls torch+transformers = **1.3 GB**, yet the prose model never engaged via the library API. The ML extra delivered zero measured value in this spike.
+
+**Go/no-go:** see deliverable. Recommendation = **conditional no-go on broad integration; narrow yes on a `gh`/log-specific helper behind a default-OFF flag.**
+
+## Success Criteria
+
+The spike is complete when the deliverable demonstrates all of the following with evidence from real fixtures:
+
+- [x] `headroom-ai[mcp,code,ml]` installed in an isolated venv (compression extras only; no `[all]`, no `[memory]`); production `.venv`/`pyproject.toml` and live harness untouched.
+- [x] Token-reduction measured **per content type** (JSON / logs / code / prose) on a real corpus of our heavy reads, with before/after token counts.
+- [x] Latency overhead recorded (cold and warm).
+- [x] Quality-regression check performed: compressed vs raw, verifying load-bearing tokens (error/WARN markers and session IDs) survive — not just byte counts.
+- [x] KV-cache / Anthropic-prompt-caching interaction verified and documented (CacheAligner mutation behavior + recurring-read prefix-cache busting).
+- [x] Findings writeup at `docs/research/headroom-evaluation.md` with a clear go/no-go and, if go, the recommended surface and rollout shape.
+
+## No-Gos
+
+- Do NOT integrate Headroom's **SharedContext** / `headroom learn` (collides with subconscious memory).
+- Do NOT run `headroom wrap claude-code` or wrap the production bridge/worker.
+- Do NOT install `[all]` or `[memory]`.
+- Do NOT add Headroom to the production `.venv` or `pyproject.toml` as part of this spike. Any experimental flag stays default-OFF.
+
+## Update System
+
+No update-system changes required — this is an evaluation spike. Nothing is added to the production environment, `pyproject.toml`, or the `/update` flow. If a future follow-up integrates a narrow helper, that work will carry its own Update System section.
+
+## Agent Integration
+
+No agent integration required — the spike runs in a throwaway venv and produces a findings doc. No CLI entry point in `pyproject.toml [project.scripts]`, no bridge import. A future narrow-integration follow-up (if approved) would add a CLI/helper at that time, behind a default-OFF flag.
+
+## Failure Path Test Strategy
+
+The deliverable's quality-regression check **is** the failure-path test: compressed output is diffed against the original for dropped load-bearing tokens (error markers, session IDs, SHAs). A "passing" compressor must cut bytes without dropping unique signal; CodeAwareCompressor's self-rejection on invalid-syntax output is the safety behavior we want and is documented as such.
+
+## Test Impact
+
+No existing tests affected — this is a self-contained spike that adds only a findings doc plus a throwaway, default-OFF experiment script; it changes no production code paths and therefore breaks no existing test. Any future narrow integration would add its own targeted tests.
+
+## Rabbit Holes
+
+- Tuning `kompress_model` / downloading the HuggingFace prose model to chase markdown savings — out of appetite; the ML extra already cost 1.3 GB for zero measured value.
+- Recursively descending nested dicts so SmartCrusher reaches dashboard sub-arrays — that's a Headroom-internal pipeline limitation, not our work to fix in a spike.
+- Proxy/MCP surface latency benchmarking under live traffic — explicitly out of scope (no live-harness wrapping).
+
+## Documentation
+
+The findings doc is the spike's primary deliverable. Concrete tasks:
+
+- [ ] Create `docs/research/headroom-evaluation.md` with: a results table of measured per-content-type token reduction (JSON / logs / code / prose) on real fixtures; cold/warm latency numbers; the quality-regression check (load-bearing-token survival diff); the KV-cache / Anthropic-prompt-caching verdict; the install-footprint note (1.3 GB `[ml]` for zero measured value); and an explicit go/no-go recommendation with the recommended surface if go.
+- [ ] In that doc, add a short "Relationship to context-fidelity-modes" note clarifying Headroom operates at the raw-byte layer vs. #329 at the skill-dispatch layer (complementary, not competing) — do NOT edit `docs/features/context-fidelity-modes.md` itself, since nothing about that feature changes.
+- [ ] No changes to `docs/features/README.md` index — a research spike doc is not a shipped feature.
+
+## Open Questions
+
+None blocking — the spike resolved the open questions in the issue (which surface, how to measure, CacheAligner interaction). The go/no-go is a recommendation for human review on the PR.

--- a/docs/research/headroom-evaluation.md
+++ b/docs/research/headroom-evaluation.md
@@ -1,0 +1,116 @@
+# Headroom Context-Compression Evaluation — Findings
+
+**Spike for [#1611](https://github.com/tomcounsell/ai/issues/1611). Status: complete.**
+**Recommendation: NO-GO on broad integration. Conditional narrow-YES on a `gh`/log compression helper behind a default-OFF flag (optional follow-up).**
+
+## TL;DR
+
+[Headroom](https://github.com/chopratejas/headroom) (`headroom-ai` 0.27.0, Apache 2.0) is a real, working context-compression layer. On **our** content it delivers strong, lossless-or-signal-safe savings on exactly **two** of our four pain points — `gh` JSON output and log tails — and **zero** on the other two (`dashboard.json` and prose/markdown SDLC reads) as actually invoked through its library API. The headline "60-95%" holds only for idealized shapes (uniform JSON arrays, repetitive logs), not our heterogeneous nested JSON or our plan-doc prose. Combined with a 1.3 GB dependency footprint that produced **zero** measured value, and a genuine (if not catastrophic) tension with Anthropic's 5-minute prompt cache, the cost/benefit does not justify broad adoption now.
+
+## Method
+
+- Installed `headroom-ai[mcp,code,ml]` into a **throwaway** venv (`/tmp/headroom-spike/venv`, Python 3.14) — never the production `.venv`, never `pyproject.toml`, never the live harness. No `headroom wrap claude-code`. Per issue scope: `[mcp]` + `[code]` + `[ml]`, **not** `[all]`, **not** `[memory]`.
+- Captured a **real corpus** of our heavy reads:
+  - `dashboard.json` — live `curl localhost:8500/dashboard.json` (73 KB).
+  - `worker_log_tail.txt` — `tail -300 logs/worker.log` (37 KB).
+  - `gh_pr_list.json` — `gh pr list --json ...` shape (PR-list JSON array).
+  - `sdlc_stage_read.md` — a real 129 KB plan doc (`docs/plans/sdlc-1219.md`), standing in for a large SDLC stage read.
+  - `code_sample.py` — real source (`ui/app.py`, 23 KB).
+- Measured via the lowest-risk surface — the **library `compress()` API** on captured fixtures (no live-traffic interception) — plus the underlying transforms directly (`SmartCrusher`, `LogCompressor`, `CodeAwareCompressor`) to separate true compressor capability from pipeline-router gating.
+- Token counts are Headroom's own (`CompressResult.tokens_before/after`, tiktoken-based). Latency via `time.perf_counter()`, cold + warm.
+
+## Results — token reduction per content type
+
+Measured through the library `compress()` API with `compress_user_messages=True, protect_recent=0` (the config an integration would *have* to set, since our heavy reads arrive as `role:user` tool results, which Headroom protects by default):
+
+| Fixture | Content type | bytes | tok before | tok after | **reduction** | latency |
+|---|---|---:|---:|---:|---:|---:|
+| `gh_pr_list.json` | uniform JSON array | 22,787 | 6,533 | 3,599 | **44.9%** | 28 ms |
+| `worker_log_tail.txt` | logs | 37,451 | 10,722 | 2,861 | **73.3%** | 28 ms |
+| `dashboard.json` | nested heterogeneous JSON | 73,002 | 20,880 | 20,880 | **0.0%** | 122 ms |
+| `code_sample.py` | python source | 23,067 | 6,613 | 6,613 | **0.0%** | 1,302 ms |
+| `sdlc_stage_read.md` | prose / markdown | 128,589 | 36,762 | 36,762 | **0.0%** | 11 ms |
+
+### Why the zeros happen (this is the important part)
+
+The zeros are not bugs in our test — they're how Headroom 0.27.0 actually behaves on our shapes:
+
+- **`dashboard.json` (0% via `compress()`, but the data IS compressible).** Calling `SmartCrusher.crush()` directly on the whole file cuts **27.4%** (73,002 → 53,023 bytes) via a *lossless table* strategy, and the individual sub-arrays compress well — `dashboard.sessions` **30.8%**, `dashboard.reflections` **36.9%**. But the `compress()` pipeline's `ContentRouter` does **not recursively descend a top-level dict** to find the compressible nested arrays, so end-to-end it returns 0%. Our #1 pain point is *theoretically* a 27-37% win but the shipped library API leaves it on the table.
+- **`code_sample.py` (0%).** `CodeAwareCompressor` ran, produced output, then **self-rejected**: *"Code compression produced invalid syntax for python, returning original."* This is the *correct* safety behavior — better 0% than corrupted code — but it means no code savings on our real source.
+- **`sdlc_stage_read.md` (0%).** Prose compression needs the Kompress ML model, which was **never loaded** (`headroom.embedding_available()` → `False`) despite installing `[ml]` (1.3 GB of torch + transformers). The prose path delivered nothing through the library API.
+
+### Direct-transform numbers (true compressor capability, bypassing the router gate)
+
+| Transform | Fixture | byte reduction | strategy / note |
+|---|---|---:|---|
+| SmartCrusher | `gh_pr_list.json` | **45.1%** | `lossless:table` |
+| SmartCrusher | `dashboard.json` (whole) | **27.4%** | `lossless:table` ×2 — *but router won't invoke this end-to-end* |
+| LogCompressor | `worker_log_tail.txt` | **73.5%** | line dedup |
+| CodeAwareCompressor | `ui/app.py` | **0%** | self-rejected (invalid syntax) |
+
+## Latency
+
+- **Warm:** ~3-5 ms per compress for logs and gh-JSON. Negligible.
+- **Cold (first call):** 11-122 ms typical; one outlier at **1.3 s** (the code path, attempting AST parse before rejecting). One-time per process.
+- Verdict: latency is **not** a blocker for the content types that actually compress.
+
+## Quality regression check
+
+Byte counts alone are insufficient — the real question is whether load-bearing detail survives. Diffed the compressed worker-log output against the original for unique signal (two signal classes measured on the log fixture; SHAs/flags were not separately present in this corpus and were not measured):
+
+| Signal class | unique in original | retained | dropped |
+|---|---:|---:|---:|
+| ERROR/WARN/CRITICAL/Traceback markers | 2 | 2 | **0** |
+| session-ish IDs (8+ hex/alnum) | 9 | 9 | **0** |
+| exception class names | 0 | 0 | 0 |
+
+**LogCompressor is signal-safe.** It works by **deduplicating repeated log lines**, not by dropping unique content — every error marker and every distinct session ID survived the 73.5% cut. SmartCrusher's table strategy is explicitly **lossless**. CodeAwareCompressor's self-rejection means it never ships lossy code. No quality regression was observed on any path that actually compressed.
+
+## KV-cache / Anthropic prompt-caching verdict
+
+The issue's central worry — *"`CacheAligner` rewrites prefixes, could fight the 5-min KV cache"* — is **already neutralized in 0.27.0**:
+
+- `CacheAligner` is now **detector-only** (per their "P2-23 fix"): it *warns* about volatile content but **never mutates, moves, or normalizes** messages. Its config defaults to `enabled=False`. So it will **not** fight Anthropic caching.
+- Headroom's `AnthropicCacheOptimizer` models the real constants correctly: **TTL 300 s**, cache-write **1.25×**, cache-read **0.1×**.
+
+The *actual* tension is subtler and inherent to any compressor: **compressing a recurring read changes its bytes, which busts the Anthropic prefix cache covering that message.** Our worst pain points (`dashboard.json`, log tails) recur every turn — precisely the content a 5-min prefix cache would otherwise serve at 0.1× cost. Compressing them trades a one-time token cut against repeated cache-write penalties. For high-recurrence reads this can be net-negative on cost even when token count drops. This must be modeled before any integration, not assumed.
+
+## Install footprint
+
+`headroom-ai[mcp,code,ml]` = **1.3 GB** installed (torch 2.12, transformers 5.12, tokenizers, tree-sitter language packs). The `[ml]` extra — the bulk of that footprint — produced **zero** measured value in this spike (prose model never loaded, `embedding_available=False`). If any narrow integration proceeds, drop `[ml]` entirely.
+
+## Integration surface comparison
+
+| Surface | Fit | Risk |
+|---|---|---|
+| **Library `compress()`** | Best for measurement and for a narrow, explicit helper. We control exactly what gets compressed. | Low. Requires non-default config; nested-dict router gating limits reach. |
+| **HTTP proxy (`:8787`)** | Zero-code drop-in, but it sits on the live request path. | **High** — intercepts the production harness; explicitly out of scope. |
+| **MCP server** | Clean tool boundary (`headroom_compress`/`retrieve`/`stats`). | Medium — adds a server process + CCR retrieval round-trips; overkill for lossless table cuts. |
+
+Lowest-risk surface, if anything: **library `compress()` invoked explicitly** on `gh`/log output, never the proxy/wrap path.
+
+## Relationship to context-fidelity-modes (#329)
+
+Our in-house [context-fidelity-modes](../features/context-fidelity-modes.md) operate at the **skill-dispatch layer** — how much session state (FULL/COMPACT/MINIMAL/STEERING) forwards to a sub-agent. Headroom operates at the **raw-byte layer** — squeezing the actual tool/log/output text. They are **complementary, not competing**, and this spike does not change anything about #329.
+
+## Go / No-Go
+
+**NO-GO on broad integration.** Reasons:
+
+1. Only **2 of 4** pain points actually compress via the shipped API; our #1 pain point (`dashboard.json`) returns 0% end-to-end because the router won't descend nested dicts.
+2. The `[ml]` extra is **1.3 GB for zero value** — the headline prose/code claims didn't materialize on our content.
+3. The KV-cache trade-off on high-recurrence reads is real and unmodeled; compressing every-turn reads can bust a cheap prefix cache.
+4. We already have a complementary in-house layer (#329); adding a heavy third-party dependency for a partial win violates our "intelligent systems over rigid patterns / minimal dependencies" posture.
+
+**Conditional narrow-YES (optional follow-up, not this spike):** A small, explicit helper that runs `SmartCrusher` on `gh` JSON output and `LogCompressor` on log tails — installed `headroom-ai[code]` only (no `[ml]`, no proxy, no MCP), behind a **default-OFF** feature flag — would capture the genuine 45%/73% lossless-and-signal-safe wins on the two content types that work, with negligible warm latency. It must first model the prompt-cache cost interaction for recurring reads. If that follow-up is not pursued, the simpler path is to **build the same table-dedup behavior in-house** (the lossless transforms are not complex) and avoid the dependency entirely.
+
+## Reproduction
+
+All measurements are reproducible from `/tmp/headroom-spike/` (throwaway):
+```
+python -m venv venv
+./venv/bin/pip install "headroom-ai[mcp,code,ml]"
+./venv/bin/python measure.py    # cold pass (shows default-config protection)
+./venv/bin/python measure2.py   # realistic configs, per-content-type
+```
+Fixtures captured from live `dashboard.json`, `logs/worker.log`, a real plan doc, and `ui/app.py`.


### PR DESCRIPTION
## Summary

Time-boxed **spike** for #1611 evaluating [Headroom](https://github.com/chopratejas/headroom) (`headroom-ai` 0.27.0, Apache 2.0), a third-party context-compression layer claiming 60-95% token reduction, against our real token pain points. **Deliverable is a findings writeup with a go/no-go — not a production integration.**

- Plan: `docs/plans/headroom_evaluation.md`
- **Findings deliverable: `docs/research/headroom-evaluation.md`**

## What was done

- Installed `headroom-ai[mcp,code,ml]` into a **throwaway venv** (`/tmp/headroom-spike`) — production `.venv`, `pyproject.toml`, and the live harness **untouched**. No `headroom wrap claude-code`. No `[all]`, no `[memory]` (per scope).
- Measured per-content-type on a **real corpus**: live `dashboard.json` (73KB), worker log tail (37KB), `gh pr list` JSON, a 129KB plan doc (SDLC stage read), and `ui/app.py`.
- Library `compress()` surface + direct transforms, with token counts, latency, a quality-regression diff, and a KV-cache verdict.

## Headline findings

| Content | Reduction | Notes |
|---|---|---|
| `gh` JSON array | **~45%** | SmartCrusher lossless table |
| worker log tail | **73%** | LogCompressor dedup; all error markers + 9 unique session IDs retained (signal-safe) |
| whole `dashboard.json` | **0% via `compress()`** | router won't descend nested dict (sub-arrays cut 27-37% directly) |
| python source | **0%** | CodeAwareCompressor self-rejected (invalid syntax) |
| prose/markdown | **0%** | Kompress ML model never loaded despite 1.3GB `[ml]` install |

- **Latency:** warm ~3-5ms; cold 11ms-1.3s one-time. Not a blocker.
- **KV-cache:** `CacheAligner` is detector-only in 0.27.0 (won't fight Anthropic's 5-min prompt cache), but compressing every-turn recurring reads busts the prefix cache — a real, unmodeled cost tension.
- **Footprint:** `[ml]` = 1.3GB for zero measured value.

## Recommendation

**NO-GO on broad integration.** Conditional **narrow-YES** on an optional follow-up: a small explicit helper running SmartCrusher on `gh` JSON + LogCompressor on log tails, `headroom-ai[code]` only (drop `[ml]`), behind a **default-OFF** flag — after modeling the prompt-cache cost interaction. Or build the equivalent lossless transforms in-house and skip the dependency.

## Scope hygiene
- No production code changed; no experimental code added to the repo (spike scripts live in throwaway `/tmp`, reproduction steps documented in the deliverable).
- Headroom operates at the raw-byte layer; context-fidelity-modes (#329) at the skill-dispatch layer — complementary, not conflated.

## Review notes
For **human review** — please do not auto-merge. This is a research deliverable; the go/no-go is a recommendation, not an executed decision.

Refs #1611

🤖 Generated with [Claude Code](https://claude.com/claude-code)