### PR TITLE
feat(email): read incoming attachments + fix multi-file outgoing (#1567)

### DIFF
--- a/bridge/email_bridge.py
+++ b/bridge/email_bridge.py
@@ -21,12 +21,14 @@ import email.mime.base
 import email.mime.multipart
 import email.mime.text
 import email.utils
+import hashlib
 import imaplib
 import json
 import logging
 import mimetypes
 import os
 import re
+import shutil
 import smtplib
 import time
 from email import encoders
@@ -57,6 +59,27 @@ REDIS_LAST_POLL_KEY = "email:last_poll_ts"
 
 # TTL for email:msgid reverse-mapping keys (48 hours)
 EMAIL_MSGID_TTL = 48 * 3600
+
+# --- Inbound attachment storage (mirrors the Telegram inbound-media pattern) ---
+# Take these with a grain of salt: provisional, tunable defaults. Both are
+# env-overridable so a machine can loosen/tighten without a code change.
+# Cumulative cap on decoded attachment bytes persisted per inbound email (25 MiB).
+# A SINGLE cumulative knob (no per-file cap) — once exceeded, remaining parts are
+# skipped and the message is marked truncated (critique C4).
+EMAIL_ATTACHMENT_MAX_TOTAL_BYTES = int(
+    os.environ.get("EMAIL_ATTACHMENT_MAX_TOTAL_BYTES", str(25 * 1024 * 1024))
+)
+# Cheap multipart-bomb guard: cap the number of attachment parts decoded per email.
+EMAIL_ATTACHMENT_MAX_PARTS = int(os.environ.get("EMAIL_ATTACHMENT_MAX_PARTS", "50"))
+
+# On-disk location for persisted inbound attachment bytes — parallel to the
+# Telegram media path (bridge/media.py MEDIA_DIR). Redis carries metadata/paths
+# only, never bytes. Created on first use.
+EMAIL_ATTACHMENT_DIR = Path(__file__).parent.parent / "data" / "media" / "email-attachments"
+
+# Fire-and-forget vault mirror so the KnowledgeWatcher indexes inbound files,
+# mirroring bridge/telegram_bridge.py:_ingest_attachments.
+EMAIL_ATTACHMENT_VAULT_SUBDIR = Path.home() / "work-vault" / "email-attachments"
 
 
 def _get_imap_config() -> dict | None:
@@ -172,12 +195,276 @@ def _extract_body(msg: email_lib.message.Message) -> str:
         return ""
 
 
+# =============================================================================
+# Inbound attachment extraction + persistence
+#
+# Split into two phases to keep the read path side-effect-free (critique C1):
+#   1. _extract_attachment_metadata(msg) — PURE. Walks the MIME tree, decodes
+#      payloads into memory, returns metadata dicts. Called inside
+#      parse_email_message, which is ALSO invoked by the read-only
+#      `valor-email read` IMAP fallback — so it must never touch disk.
+#   2. _persist_attachments(parsed) — writes the decoded bytes to disk and
+#      fire-and-forget mirrors them to the work-vault. Called ONLY from the
+#      IMAP poll loop (_email_inbox_loop), never from the read path.
+#
+# An attachment metadata dict has the public keys
+# {filename, content_type, size, path} plus a transient private "_payload"
+# (the decoded bytes) that _persist_attachments consumes and strips. _payload
+# is NEVER serialized — use _public_attachment() at every serialization point.
+# On the read/fallback path bytes are never persisted, so `path` stays None.
+# =============================================================================
+
+# Public (JSON-safe) attachment metadata fields, in canonical order.
+_ATTACHMENT_PUBLIC_FIELDS = ("filename", "content_type", "size", "path")
+
+
+def _public_attachment(att: dict) -> dict:
+    """Project an attachment dict down to its JSON-safe public fields.
+
+    Strips the transient ``_payload`` bytes so the result is always
+    ``json.dumps``-able. Used by every serialization point (history blob,
+    read output, session context).
+    """
+    return {k: att.get(k) for k in _ATTACHMENT_PUBLIC_FIELDS}
+
+
+def _sanitize_attachment_filename(raw: str | None, index: int, content_type: str) -> str:
+    """Reduce an attachment filename to a safe basename (no path traversal).
+
+    Strategy (matches the plan's sanitization contract):
+      - Reduce to ``Path(raw).name`` so any directory components / ``..`` /
+        absolute paths collapse to a bare basename.
+      - Allow only ``[A-Za-z0-9._-]``; replace every other char with ``_``.
+      - Strip leading/trailing dots and underscores so ``.`` / ``..`` / hidden
+        dotfiles cannot survive as a traversal or empty name.
+      - If nothing usable remains, fall back to
+        ``attachment_{index}{guessed_ext}``.
+    The ``{msgid_hash}`` subdir created by _persist_attachments contains the
+    result to a single directory regardless.
+    """
+    base = Path(raw or "").name
+    cleaned = re.sub(r"[^A-Za-z0-9._-]", "_", base).strip("._")
+    if not cleaned or cleaned in (".", ".."):
+        ext = mimetypes.guess_extension(content_type or "") or ""
+        cleaned = f"attachment_{index}{ext}"
+    return cleaned
+
+
+def _is_attachment_part(part: email_lib.message.Message) -> bool:
+    """True if a MIME part should be treated as a downloadable attachment.
+
+    Captures parts with an ``attachment`` Content-Disposition, plus any
+    filename-bearing leaf part (e.g. an ``inline`` CID image) — the plan treats
+    inline/CID parts as ordinary attachments at most. Multipart containers and
+    bare text body parts (no filename, no attachment disposition) are skipped.
+    """
+    if part.is_multipart():
+        return False
+    disposition = str(part.get("Content-Disposition", "")).lower()
+    if "attachment" in disposition:
+        return True
+    try:
+        return bool(part.get_filename())
+    except Exception:
+        return False
+
+
+def _extract_attachment_metadata(
+    msg: email_lib.message.Message,
+) -> tuple[list[dict], bool]:
+    """Walk a parsed message and return (attachments, truncated). PURE — no disk.
+
+    Each attachment dict has public keys ``filename`` (sanitized),
+    ``content_type``, ``size`` (decoded byte length), ``path`` (always ``None``
+    here — set later by _persist_attachments), plus a transient ``_payload``
+    holding the decoded bytes.
+
+    Guardrails (critique C4):
+      - A running cumulative-byte total short-circuits the walk: a part whose
+        ENCODED length already pushes the total over
+        ``EMAIL_ATTACHMENT_MAX_TOTAL_BYTES`` is rejected pre-decode (estimated
+        from the base64 string length), so a multipart bomb never forces a full
+        decode of every part. ``truncated`` is set and the walk stops.
+      - ``EMAIL_ATTACHMENT_MAX_PARTS`` caps the number of parts decoded.
+    Each part is wrapped in its own try/except so one malformed/undecodable part
+    never aborts the rest — it is logged and skipped.
+    """
+    attachments: list[dict] = []
+    truncated = False
+    if not msg.is_multipart():
+        return attachments, truncated
+
+    running_total = 0
+    index = 0
+    for part in msg.walk():
+        if not _is_attachment_part(part):
+            continue
+        if len(attachments) >= EMAIL_ATTACHMENT_MAX_PARTS:
+            truncated = True
+            break
+        try:
+            ctype = part.get_content_type() or "application/octet-stream"
+            # Pre-decode size estimate from the encoded payload string so an
+            # oversized part is rejected BEFORE base64-decoding it into RAM.
+            raw_payload = part.get_payload(decode=False)
+            est = (len(raw_payload) * 3) // 4 if isinstance(raw_payload, str) else 0
+            if running_total + est > EMAIL_ATTACHMENT_MAX_TOTAL_BYTES:
+                truncated = True
+                break
+            payload = part.get_payload(decode=True)
+            if payload is None:
+                logger.warning("[email] Attachment part had no decodable payload, skipping")
+                continue
+            size = len(payload)
+            if running_total + size > EMAIL_ATTACHMENT_MAX_TOTAL_BYTES:
+                # True size exceeded the cap (estimate was low) — skip and stop.
+                truncated = True
+                break
+            running_total += size
+            filename = _sanitize_attachment_filename(part.get_filename(), index, ctype)
+            attachments.append(
+                {
+                    "filename": filename,
+                    "content_type": ctype,
+                    "size": size,
+                    "path": None,
+                    "_payload": payload,
+                }
+            )
+            index += 1
+        except Exception as e:
+            logger.warning(f"[email] Skipping malformed attachment part: {e}")
+            continue
+
+    return attachments, truncated
+
+
+def _attachment_storage_key(parsed: dict) -> str:
+    """Derive a stable, collision-resistant subdir key for an email's attachments.
+
+    Hashes the Message-ID. When the Message-ID is empty (some providers omit it),
+    falls back to ``from_addr:subject:timestamp`` so attachments from different
+    Message-ID-less emails do NOT collide into one shared subdir (critique C3).
+    """
+    mid = (parsed.get("message_id") or "").strip()
+    if not mid:
+        ts = int(parsed.get("timestamp") or time.time())
+        mid = f"{parsed.get('from_addr', '')}:{parsed.get('subject', '')}:{ts}"
+    return hashlib.sha256(mid.encode("utf-8", errors="replace")).hexdigest()[:16]
+
+
+def _persist_attachments(parsed: dict) -> list[dict]:
+    """Write decoded attachment bytes to disk + mirror to the vault. NOT pure.
+
+    Called ONLY from the IMAP poll loop (never the read path). Mutates each
+    attachment dict in place: pops the transient ``_payload``, sets ``path`` to
+    the on-disk location. Files land under
+    ``data/media/email-attachments/{msgid_hash}/{sanitized_name}``; same-email
+    filename collisions are disambiguated with an index suffix (critique Risk 3).
+    Every failure is logged and never propagates — the poll loop must not break.
+    """
+    attachments = parsed.get("attachments") or []
+    if not attachments:
+        return attachments
+
+    key = _attachment_storage_key(parsed)
+    dest_dir = EMAIL_ATTACHMENT_DIR / key
+    try:
+        dest_dir.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        logger.warning(f"[email] Could not create attachment dir {dest_dir}: {e}")
+        for att in attachments:
+            att.pop("_payload", None)
+        return attachments
+
+    dest_root = str(dest_dir.resolve())
+    used_names: set[str] = set()
+    for att in attachments:
+        payload = att.pop("_payload", None)
+        if payload is None:
+            continue
+        try:
+            name = att.get("filename") or "attachment"
+            stem, suffix = Path(name).stem, Path(name).suffix
+            final = name
+            n = 1
+            while final in used_names or (dest_dir / final).exists():
+                final = f"{stem}_{n}{suffix}"
+                n += 1
+            target = dest_dir / final
+            # Defense in depth: confirm the resolved path stays inside dest_dir.
+            if not str(target.resolve()).startswith(dest_root):
+                logger.warning(f"[email] Blocked attachment path traversal: {name!r}")
+                continue
+            target.write_bytes(payload)
+            used_names.add(final)
+            att["filename"] = final
+            att["path"] = str(target)
+        except Exception as e:
+            logger.warning(f"[email] Failed to persist attachment {att.get('filename')!r}: {e}")
+            continue
+
+    _mirror_attachments_to_vault(parsed)
+    return attachments
+
+
+def _mirror_attachments_to_vault(parsed: dict) -> None:
+    """Fire-and-forget copy of persisted attachments into the work-vault.
+
+    Mirrors bridge/telegram_bridge.py:_ingest_attachments — the KnowledgeWatcher
+    indexes anything dropped under ``~/work-vault/`` recursively, so no further
+    wiring is needed. Target names reuse the Telegram joint-key formula
+    ``{date}_{sender}_{msgid}_{filename}``, substituting the C3 storage key when
+    the Message-ID is empty. Never blocks, never raises — every failure logged.
+    """
+    try:
+        attachments = [a for a in (parsed.get("attachments") or []) if a.get("path")]
+        if not attachments:
+            return
+        EMAIL_ATTACHMENT_VAULT_SUBDIR.mkdir(parents=True, exist_ok=True)
+        ts = float(parsed.get("timestamp") or time.time())
+        date_part = time.strftime("%Y%m%d_%H%M%S", time.localtime(ts))
+        safe_sender = (
+            "".join(
+                c if (c.isalnum() or c in ("-", "_")) else "_"
+                for c in (parsed.get("from_addr") or "unknown")
+            ).strip("_")
+            or "unknown"
+        )
+        mid = (parsed.get("message_id") or "").strip() or _attachment_storage_key(parsed)
+        safe_mid = re.sub(r"[^A-Za-z0-9]", "", mid)[:24] or "nomsgid"
+        for att in attachments:
+            try:
+                src = Path(att["path"])
+                if not src.exists():
+                    continue
+                target = (
+                    EMAIL_ATTACHMENT_VAULT_SUBDIR
+                    / f"{date_part}_{safe_sender}_{safe_mid}_{src.name}"
+                )
+                shutil.copy2(src, target)
+                logger.info(f"[email] Mirrored {src.name} -> {target} (watcher will index)")
+            except Exception as inner_e:
+                logger.warning(
+                    f"[email] Failed to mirror attachment {att.get('path')!r}: {inner_e}"
+                )
+    except Exception as e:
+        logger.warning(f"[email] Vault mirror task failed: {e}")
+
+
 def parse_email_message(raw_bytes: bytes) -> dict | None:
     """Parse raw email bytes into a structured dict.
 
     Returns a dict with keys: from_addr, to_addrs, cc_addrs, subject, body,
-    message_id, in_reply_to.  Returns None if the email cannot be parsed or
-    has no usable body.
+    message_id, in_reply_to, attachments, attachments_truncated.  Returns None
+    if the email cannot be parsed or has neither a usable body nor attachments.
+
+    The ``attachments`` list holds metadata dicts
+    ``{filename, content_type, size, path}`` (plus a transient ``_payload``).
+    Extraction is PURE here — bytes are decoded into memory but NOT written to
+    disk; ``path`` is ``None`` until the poll loop calls _persist_attachments.
+    This keeps the read-only `valor-email read` IMAP fallback side-effect-free
+    (critique C1).
     """
     try:
         msg = email_lib.message_from_bytes(raw_bytes)
@@ -193,9 +480,13 @@ def parse_email_message(raw_bytes: bytes) -> dict | None:
 
     subject = _decode_header_value(msg.get("Subject", ""))
     body = _extract_body(msg)
+    attachments, attachments_truncated = _extract_attachment_metadata(msg)
 
-    if not body or not body.strip():
-        logger.debug(f"Email from {from_addr} has empty body, skipping")
+    # Empty-body guard, relaxed for attachment-only emails: a message whose body
+    # is empty but which carries attachments is legitimate (sender just sent a
+    # file) and must NOT be dropped here.
+    if (not body or not body.strip()) and not attachments:
+        logger.debug(f"Email from {from_addr} has empty body and no attachments, skipping")
         return None
 
     message_id = msg.get("Message-ID", "").strip()
@@ -212,6 +503,8 @@ def parse_email_message(raw_bytes: bytes) -> dict | None:
         "body": body.strip(),
         "message_id": message_id,
         "in_reply_to": in_reply_to,
+        "attachments": attachments,
+        "attachments_truncated": attachments_truncated,
     }
 
 
@@ -362,6 +655,11 @@ def _record_history(parsed: dict, mailbox: str = "INBOX") -> None:
                 "timestamp": ts,
                 "message_id": message_id,
                 "in_reply_to": parsed.get("in_reply_to", ""),
+                # Metadata only — never bytes. Projected through _public_attachment
+                # so a stray transient _payload can never reach the blob. Old blobs
+                # written before this field hydrate as [] on read (back-compat).
+                "attachments": [_public_attachment(a) for a in (parsed.get("attachments") or [])],
+                "attachments_truncated": bool(parsed.get("attachments_truncated")),
             }
         )
 
@@ -974,6 +1272,16 @@ async def _process_inbound_email(
     if customer_id is not None:
         extra_context["customer_id"] = customer_id
 
+    # Inbound attachments: hand the agent readable on-disk paths (plus metadata)
+    # so it can open the files. Only include attachments that were actually
+    # persisted (path set by _persist_attachments); the read/fallback path never
+    # populates this since it doesn't run through _process_inbound_email.
+    _email_attachments = [
+        _public_attachment(a) for a in (parsed.get("attachments") or []) if a.get("path")
+    ]
+    if _email_attachments:
+        extra_context["email_attachments"] = _email_attachments
+
     # Enqueue the session with email transport metadata
     try:
         await enqueue_agent_session(
@@ -1113,6 +1421,16 @@ async def _email_inbox_loop(imap_config: dict, config: dict) -> None:
                     parsed = parse_email_message(raw_bytes)
                     if parsed is None:
                         continue
+                    # Persist attachment bytes to disk + vault BEFORE recording
+                    # history or enqueueing — this is the ONLY write side-effect
+                    # path (the read-only CLI fallback never reaches here, so it
+                    # never writes; critique C1). After this call each attachment
+                    # dict has a real `path` and its transient `_payload` stripped.
+                    if parsed.get("attachments"):
+                        try:
+                            _persist_attachments(parsed)
+                        except Exception as e:
+                            logger.warning(f"[email] Attachment persistence failed: {e}")
                     # Write-through to the history cache BEFORE enqueueing the
                     # AgentSession so the CLI can observe the message even when
                     # routing skips session creation. Failures are logged only.

--- a/docs/features/email-bridge.md
+++ b/docs/features/email-bridge.md
@@ -20,7 +20,7 @@ IMAP inbox (valor@yuda.me)
 
 | File | Role |
 |------|------|
-| `bridge/email_bridge.py` | IMAP polling loop, email parsing (`parse_email_message` returns `from_addr`, `to_addrs`, `cc_addrs`, `subject`, `body`, `message_id`, `in_reply_to`), sender filtering, `EmailOutputHandler` (reply-all by default), history cache write-through (`_record_history`, `_record_thread`), module-level `_build_reply_mime` with attachment support |
+| `bridge/email_bridge.py` | IMAP polling loop, email parsing (`parse_email_message` returns `from_addr`, `to_addrs`, `cc_addrs`, `subject`, `body`, `message_id`, `in_reply_to`, `attachments`, `attachments_truncated`), inbound attachment extraction + persistence (`_extract_attachment_metadata`, `_persist_attachments`, `_mirror_attachments_to_vault`), sender filtering, `EmailOutputHandler` (reply-all by default), history cache write-through (`_record_history`, `_record_thread`), module-level `_build_reply_mime` with attachment support |
 | `bridge/email_relay.py` | Async drain of `email:outbox:*` payloads via SMTP; atomic LPOP + requeue-with-counter + DLQ after `MAX_EMAIL_RELAY_RETRIES`; heartbeat key `email:relay:last_poll_ts` for liveness probing. Runs inside `run_email_bridge()` via `asyncio.gather`. |
 | `bridge/email_dead_letter.py` | Dead letter queue for failed SMTP sends |
 | `bridge/routing.py` | `find_project_for_email()`, `build_email_to_project_map()`, `get_known_email_search_terms()` |
@@ -211,6 +211,10 @@ IMAP_USER=valor@yuda.me
 IMAP_PASSWORD=<gmail-app-password>
 IMAP_MAX_BATCH=20        # max unseen messages fetched per poll cycle (default: 20)
 
+# Inbound attachments (optional — sane defaults; see "Incoming attachments")
+EMAIL_ATTACHMENT_MAX_TOTAL_BYTES=26214400   # cumulative cap per email (default: 25 MiB)
+EMAIL_ATTACHMENT_MAX_PARTS=50               # max attachment parts decoded per email
+
 # SMTP (outbound)
 SMTP_HOST=smtp.gmail.com
 SMTP_PORT=587
@@ -319,11 +323,12 @@ valor-email read --search "deployment" --since "2 hours ago"
 valor-email send --to alice@example.com --subject "Re: Deploy" "Looks good"
 valor-email send --to alice@example.com --to bob@example.com "CC both"
 valor-email send --to alice@example.com --file ./report.pdf "See attached"
+valor-email send --to alice@example.com --file ./a.pdf --file ./b.csv "Two files"
 valor-email send --to alice@example.com --reply-to "<abc@host>" "Body"
 valor-email threads
 ```
 
-`--to` accepts multiple flags (repeat for each recipient) and comma-separated values (`--to "alice@example.com,bob@example.com"`). All three subcommands accept `--json` for machine-readable output.
+`--to` accepts multiple flags (repeat for each recipient) and comma-separated values (`--to "alice@example.com,bob@example.com"`). `--file` is **repeatable** — pass it once per file to attach multiple files (`--file a.pdf --file b.csv`); each path is validated for existence and readability before enqueue, and the first invalid path fails the send. All three subcommands accept `--json` for machine-readable output.
 
 ### Read path
 
@@ -334,6 +339,28 @@ valor-email threads
 - `--search "term"` — case-insensitive substring match over subject + body.
 
 On cache miss (e.g. daemon hasn't populated the cache yet), the CLI opens a **read-only** IMAP session filtered by known senders (from `get_known_email_search_terms()`) so cross-machine SEEN semantics are preserved and no messages are leaked from another project's policy boundary.
+
+### Incoming attachments
+
+When an inbound email carries attachments, the bridge extracts, persists, and surfaces them so the agent processing the email can open the files — mirroring the Telegram inbound-media pattern (filesystem for bytes, Redis for metadata/paths only).
+
+**Pipeline (`bridge/email_bridge.py`):**
+
+1. **Pure extraction** — `parse_email_message()` calls `_extract_attachment_metadata(msg)`, which walks the MIME tree and returns a metadata dict per attachment part: `{filename, content_type, size, path}` (plus a transient in-memory payload). This step is **side-effect-free** — it never writes to disk, so the read-only `valor-email read` IMAP fallback (which also calls `parse_email_message`) never persists anything (`path` stays `null` on that path).
+2. **Persistence** — the IMAP poll loop (`_email_inbox_loop`) calls `_persist_attachments(parsed)` **only on the poll path**. Bytes are written to `data/media/email-attachments/{message_id_hash}/{sanitized_filename}`. The subdir is keyed by a SHA-256 of the Message-ID; when the Message-ID is empty it falls back to `from_addr:subject:timestamp` so attachments from different Message-ID-less emails never collide. Same-name files within one email are disambiguated with an index suffix (`image.png`, `image_1.png`).
+3. **Vault mirror** — each persisted file is fire-and-forget copied into `~/work-vault/email-attachments/` (target name `{date}_{sender}_{msgid}_{filename}`) so the KnowledgeWatcher indexes it. Every failure is logged and never fatal — a broken vault dir does not prevent disk persistence or session enqueue.
+4. **History + read output** — `_record_history()` stores the attachment **metadata only** (never bytes) in the per-message JSON blob; `valor-email read --json` surfaces the `attachments` array per message. Blobs written before this feature hydrate as `attachments: []` (back-compat).
+5. **Session context** — `_process_inbound_email()` sets `extra_context["email_attachments"]` to the list of readable stored paths + metadata, so the agent sees the files in its prompt context and can open them.
+
+**Empty-body emails** that carry attachments are processed, not dropped (the empty-body guard is relaxed when attachments are present — a file with no text is a legitimate message).
+
+**Guardrails:**
+- **Filename sanitization** — every filename is reduced to its basename and restricted to `[A-Za-z0-9._-]`; `..`, absolute paths, and traversal sequences collapse to a safe name (with an `attachment_{i}{ext}` fallback). The `{message_id_hash}` subdir contains the result regardless.
+- **Size cap** — `EMAIL_ATTACHMENT_MAX_TOTAL_BYTES` (default 25 MiB) bounds the cumulative decoded bytes per email. The cap short-circuits the decode loop (an oversized part is rejected from its *encoded* length before being base64-decoded into RAM), so a multipart bomb never forces a full decode. Once exceeded, remaining parts are skipped and the message is marked `attachments_truncated: true`.
+- **Parts cap** — `EMAIL_ATTACHMENT_MAX_PARTS` (default 50) caps the number of attachment parts decoded per email as a cheap bomb guard.
+- **Malformed parts** — each part is wrapped in its own try/except: one undecodable part is logged and skipped, never aborting the rest.
+
+No on-disk reaper ships with this feature — retention matches the existing Telegram `data/media/` behavior (accepted residual; the vault copy is the durable, indexed record).
 
 ### Send path — always via the relay
 

--- a/tests/integration/test_email_bridge.py
+++ b/tests/integration/test_email_bridge.py
@@ -414,6 +414,168 @@ class TestDomainRoutedEmailHandlerDirect:
 
 
 # ---------------------------------------------------------------------------
+# Tests: inbound attachments end-to-end (parse → persist → history → context)
+# ---------------------------------------------------------------------------
+
+
+def _raw_email_with_attachments(attachments, *, body="See attached.", message_id="<att-e2e@x>"):
+    """Build raw multipart email bytes carrying ``(filename, maintype, subtype, data)``."""
+    import email.message
+
+    msg = email.message.EmailMessage()
+    msg["From"] = "alice@example.com"
+    msg["To"] = "valor@example.com"
+    msg["Subject"] = "Docs attached"
+    if message_id:
+        msg["Message-ID"] = message_id
+    if body is not None:
+        msg.set_content(body)
+    for filename, maintype, subtype, data in attachments:
+        msg.add_attachment(data, maintype=maintype, subtype=subtype, filename=filename)
+    return msg.as_bytes()
+
+
+class TestInboundAttachmentsEndToEnd:
+    """Full inbound flow: a multipart email's attachments are persisted to disk,
+    exposed in read output, and carried into the session extra_context."""
+
+    @pytest.mark.asyncio
+    async def test_single_attachment_full_flow(self, tmp_path, monkeypatch):
+        import os
+
+        import bridge.email_bridge as eb
+        import bridge.routing as routing
+        from bridge.email_bridge import (
+            _persist_attachments,
+            _process_inbound_email,
+            _record_history,
+            parse_email_message,
+        )
+        from tools.email_history import get_recent_emails
+
+        # Redirect attachment storage + vault to tmp (no repo pollution).
+        store = tmp_path / "data" / "media" / "email-attachments"
+        vault = tmp_path / "work-vault" / "email-attachments"
+        monkeypatch.setattr(eb, "EMAIL_ATTACHMENT_DIR", store)
+        monkeypatch.setattr(eb, "EMAIL_ATTACHMENT_VAULT_SUBDIR", vault)
+
+        # Align the history reader's Redis db with the bridge writer's test db.
+        worker_id = os.environ.get("PYTEST_XDIST_WORKER", "")
+        test_db = int(worker_id[2:]) + 1 if worker_id.startswith("gw") else 1
+        monkeypatch.setenv("REDIS_URL", f"redis://localhost:6379/{test_db}")
+
+        raw = _raw_email_with_attachments(
+            [("invoice.pdf", "application", "pdf", b"%PDF-1.4 invoice bytes")]
+        )
+        parsed = parse_email_message(raw)
+        assert parsed is not None
+        assert len(parsed["attachments"]) == 1
+
+        # 1. Persist bytes to disk (poll-loop side-effect).
+        _persist_attachments(parsed)
+        stored_path = parsed["attachments"][0]["path"]
+        assert stored_path is not None
+        from pathlib import Path
+
+        assert Path(stored_path).read_bytes() == b"%PDF-1.4 invoice bytes"
+        # Vault mirror happened too.
+        assert any(vault.rglob("*invoice.pdf"))
+
+        project_key = "test-project"
+        project = _project_config(project_key)
+        config = _projects_json(project_key)
+        original_email_map = routing.EMAIL_TO_PROJECT.copy()
+        original_active = routing.ACTIVE_PROJECTS[:]
+        try:
+            routing.EMAIL_TO_PROJECT["alice@example.com"] = project
+            if project_key not in routing.ACTIVE_PROJECTS:
+                routing.ACTIVE_PROJECTS.append(project_key)
+
+            test_r = _test_redis()
+            with patch("bridge.email_bridge._get_redis", return_value=test_r):
+                # 2. Record history blob (read-output source).
+                _record_history(parsed)
+
+                # 3. Process inbound → extra_context carries readable paths.
+                mock_enqueue = AsyncMock()
+                with patch("agent.agent_session_queue.enqueue_agent_session", mock_enqueue):
+                    await _process_inbound_email(parsed, config)
+            test_r.close()
+        finally:
+            routing.EMAIL_TO_PROJECT.clear()
+            routing.EMAIL_TO_PROJECT.update(original_email_map)
+            routing.ACTIVE_PROJECTS[:] = original_active
+
+        # extra_context exposes the readable stored path + metadata.
+        extra = mock_enqueue.call_args.kwargs.get("extra_context_overrides", {})
+        email_atts = extra.get("email_attachments")
+        assert email_atts and len(email_atts) == 1
+        assert email_atts[0]["filename"] == "invoice.pdf"
+        assert email_atts[0]["path"] == stored_path
+
+        # read output (cache hit) exposes attachment metadata.
+        read = get_recent_emails(limit=5)
+        msgs = [m for m in read["messages"] if m["message_id"] == "<att-e2e@x>"]
+        assert msgs, "recorded message should appear in read output"
+        assert msgs[0]["attachments"][0]["filename"] == "invoice.pdf"
+
+    @pytest.mark.asyncio
+    async def test_multiple_attachments_full_flow(self, tmp_path, monkeypatch):
+        import bridge.email_bridge as eb
+        import bridge.routing as routing
+        from bridge.email_bridge import (
+            _persist_attachments,
+            _process_inbound_email,
+            parse_email_message,
+        )
+
+        store = tmp_path / "store"
+        vault = tmp_path / "vault"
+        monkeypatch.setattr(eb, "EMAIL_ATTACHMENT_DIR", store)
+        monkeypatch.setattr(eb, "EMAIL_ATTACHMENT_VAULT_SUBDIR", vault)
+
+        raw = _raw_email_with_attachments(
+            [
+                ("a.pdf", "application", "pdf", b"alpha"),
+                ("b.csv", "text", "csv", b"col1,col2"),
+            ],
+            message_id="<multi-e2e@x>",
+        )
+        parsed = parse_email_message(raw)
+        _persist_attachments(parsed)
+
+        from pathlib import Path
+
+        for att, expected in zip(parsed["attachments"], (b"alpha", b"col1,col2")):
+            assert Path(att["path"]).read_bytes() == expected
+
+        project_key = "test-project"
+        project = _project_config(project_key)
+        config = _projects_json(project_key)
+        original_email_map = routing.EMAIL_TO_PROJECT.copy()
+        original_active = routing.ACTIVE_PROJECTS[:]
+        try:
+            routing.EMAIL_TO_PROJECT["alice@example.com"] = project
+            if project_key not in routing.ACTIVE_PROJECTS:
+                routing.ACTIVE_PROJECTS.append(project_key)
+
+            test_r = _test_redis()
+            mock_enqueue = AsyncMock()
+            with patch("bridge.email_bridge._get_redis", return_value=test_r):
+                with patch("agent.agent_session_queue.enqueue_agent_session", mock_enqueue):
+                    await _process_inbound_email(parsed, config)
+            test_r.close()
+        finally:
+            routing.EMAIL_TO_PROJECT.clear()
+            routing.EMAIL_TO_PROJECT.update(original_email_map)
+            routing.ACTIVE_PROJECTS[:] = original_active
+
+        extra = mock_enqueue.call_args.kwargs.get("extra_context_overrides", {})
+        names = [a["filename"] for a in extra.get("email_attachments", [])]
+        assert names == ["a.pdf", "b.csv"]
+
+
+# ---------------------------------------------------------------------------
 # Tests: health timestamp in _email_inbox_loop
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_email_bridge.py
+++ b/tests/unit/test_email_bridge.py
@@ -5,12 +5,14 @@ the standard library. SMTP is mocked via unittest.mock.patch to avoid network
 calls.
 """
 
+import email.message
 import email.mime.multipart
 import email.mime.text
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import bridge.email_bridge as eb
 from bridge.email_bridge import (
     HISTORY_MSG_KEY,
     HISTORY_SET_KEY,
@@ -20,9 +22,12 @@ from bridge.email_bridge import (
     _build_reply_mime,
     _decode_header_value,
     _extract_address,
+    _persist_attachments,
     _poll_imap,
+    _public_attachment,
     _record_history,
     _record_thread,
+    _sanitize_attachment_filename,
     parse_email_message,
 )
 
@@ -163,6 +168,295 @@ class TestParseEmailMessage:
 
         assert result is not None
         assert result["from_addr"] == "upper@example.com"
+
+
+# ---------------------------------------------------------------------------
+# Inbound attachment extraction + persistence
+# ---------------------------------------------------------------------------
+
+
+def _make_email_with_attachments(
+    from_addr: str = "tom@yuda.me",
+    subject: str = "Files attached",
+    body: str | None = "Take a look at these.",
+    message_id: str = "<att-001@example.com>",
+    attachments: list[tuple[str, str, str, bytes]] | None = None,
+) -> bytes:
+    """Build a raw multipart email carrying attachments.
+
+    ``attachments`` is a list of ``(filename, maintype, subtype, data)`` tuples.
+    A ``None`` filename produces an attachment part with no filename header.
+    """
+    msg = email.message.EmailMessage()
+    msg["From"] = from_addr
+    msg["To"] = "valor@example.com"
+    msg["Subject"] = subject
+    if message_id:
+        msg["Message-ID"] = message_id
+    if body is not None:
+        msg.set_content(body)
+    for filename, maintype, subtype, data in attachments or []:
+        kwargs = {"maintype": maintype, "subtype": subtype}
+        if filename is not None:
+            kwargs["filename"] = filename
+        msg.add_attachment(data, **kwargs)
+    return msg.as_bytes()
+
+
+@pytest.fixture
+def attachment_dirs(tmp_path, monkeypatch):
+    """Redirect attachment storage + vault mirror to tmp dirs (no repo pollution)."""
+    store = tmp_path / "data" / "media" / "email-attachments"
+    vault = tmp_path / "work-vault" / "email-attachments"
+    monkeypatch.setattr(eb, "EMAIL_ATTACHMENT_DIR", store)
+    monkeypatch.setattr(eb, "EMAIL_ATTACHMENT_VAULT_SUBDIR", vault)
+    return store, vault
+
+
+class TestAttachmentExtraction:
+    """_extract_attachment_metadata() / parse_email_message() attachment fields."""
+
+    def test_single_attachment_parsed(self):
+        raw = _make_email_with_attachments(
+            attachments=[("report.pdf", "application", "pdf", b"%PDF-1.4 data")]
+        )
+        result = parse_email_message(raw)
+        assert result is not None
+        assert len(result["attachments"]) == 1
+        att = result["attachments"][0]
+        assert att["filename"] == "report.pdf"
+        assert att["content_type"] == "application/pdf"
+        assert att["size"] == len(b"%PDF-1.4 data")
+        assert att["path"] is None  # not persisted by parse (critique C1)
+        assert result["attachments_truncated"] is False
+
+    def test_multiple_attachments_parsed(self):
+        raw = _make_email_with_attachments(
+            attachments=[
+                ("a.pdf", "application", "pdf", b"aaa"),
+                ("b.csv", "text", "csv", b"col1,col2"),
+            ]
+        )
+        result = parse_email_message(raw)
+        assert result is not None
+        names = [a["filename"] for a in result["attachments"]]
+        assert names == ["a.pdf", "b.csv"]
+
+    def test_empty_body_with_attachment_is_processed(self):
+        """An attachment-only email (no text body) must NOT be dropped."""
+        raw = _make_email_with_attachments(
+            body=None,
+            attachments=[("only.pdf", "application", "pdf", b"data")],
+        )
+        result = parse_email_message(raw)
+        assert result is not None
+        assert len(result["attachments"]) == 1
+
+    def test_empty_body_no_attachment_still_dropped(self):
+        """Empty body AND no attachments still returns None (guard intact)."""
+        msg = email.message.EmailMessage()
+        msg["From"] = "tom@yuda.me"
+        msg["Subject"] = "nothing"
+        msg["Message-ID"] = "<empty@x>"
+        msg.set_content("")
+        assert parse_email_message(msg.as_bytes()) is None
+
+    def test_filename_with_path_traversal_sanitized(self):
+        raw = _make_email_with_attachments(
+            attachments=[("../../etc/passwd", "text", "plain", b"x")]
+        )
+        result = parse_email_message(raw)
+        att = result["attachments"][0]
+        assert "/" not in att["filename"]
+        assert ".." not in att["filename"]
+        assert att["filename"] == "passwd"
+
+    def test_attachment_without_filename_falls_back(self):
+        raw = _make_email_with_attachments(
+            attachments=[(None, "application", "octet-stream", b"blob")]
+        )
+        result = parse_email_message(raw)
+        atts = result["attachments"]
+        assert len(atts) == 1
+        assert atts[0]["filename"].startswith("attachment_")
+
+    def test_size_cap_truncates(self, monkeypatch):
+        """Cumulative size over the cap skips later parts and marks truncated."""
+        monkeypatch.setattr(eb, "EMAIL_ATTACHMENT_MAX_TOTAL_BYTES", 10)
+        raw = _make_email_with_attachments(
+            attachments=[
+                ("small.bin", "application", "octet-stream", b"12345"),
+                ("big.bin", "application", "octet-stream", b"X" * 1000),
+            ]
+        )
+        result = parse_email_message(raw)
+        # First fits, second is over the cap → skipped, truncated flag set.
+        assert result["attachments_truncated"] is True
+        assert all(a["size"] <= 10 for a in result["attachments"])
+
+    def test_parts_cap_truncates(self, monkeypatch):
+        monkeypatch.setattr(eb, "EMAIL_ATTACHMENT_MAX_PARTS", 2)
+        raw = _make_email_with_attachments(
+            attachments=[
+                ("a.bin", "application", "octet-stream", b"a"),
+                ("b.bin", "application", "octet-stream", b"b"),
+                ("c.bin", "application", "octet-stream", b"c"),
+            ]
+        )
+        result = parse_email_message(raw)
+        assert len(result["attachments"]) == 2
+        assert result["attachments_truncated"] is True
+
+    def test_non_multipart_email_has_empty_attachments(self):
+        raw = _make_plain_email(body="just text")
+        result = parse_email_message(raw)
+        assert result["attachments"] == []
+        assert result["attachments_truncated"] is False
+
+    def test_public_attachment_strips_payload(self):
+        att = {
+            "filename": "x.pdf",
+            "content_type": "application/pdf",
+            "size": 3,
+            "path": None,
+            "_payload": b"abc",
+        }
+        pub = _public_attachment(att)
+        assert "_payload" not in pub
+        assert set(pub.keys()) == {"filename", "content_type", "size", "path"}
+
+
+class TestSanitizeFilename:
+    def test_strips_directories(self):
+        assert _sanitize_attachment_filename("/abs/path/x.pdf", 0, "application/pdf") == "x.pdf"
+
+    def test_collapses_unsafe_chars(self):
+        out = _sanitize_attachment_filename("my file (1).pdf", 0, "application/pdf")
+        assert out == "my_file_1_.pdf" or out.endswith(".pdf")
+        assert "/" not in out and " " not in out
+
+    def test_dotdot_falls_back(self):
+        out = _sanitize_attachment_filename("..", 3, "application/pdf")
+        assert out.startswith("attachment_3")
+
+
+class TestPersistAttachments:
+    """_persist_attachments() writes bytes to disk and mirrors to the vault."""
+
+    def test_persists_bytes_and_sets_path(self, attachment_dirs):
+        store, vault = attachment_dirs
+        raw = _make_email_with_attachments(
+            attachments=[("report.pdf", "application", "pdf", b"%PDF data")]
+        )
+        parsed = parse_email_message(raw)
+        _persist_attachments(parsed)
+        att = parsed["attachments"][0]
+        assert att["path"] is not None
+        from pathlib import Path
+
+        p = Path(att["path"])
+        assert p.exists()
+        assert p.read_bytes() == b"%PDF data"
+        assert "_payload" not in att  # transient bytes stripped
+        # Vault mirror copied the file too
+        assert any(vault.rglob("*report.pdf"))
+
+    def test_same_name_collision_disambiguated(self, attachment_dirs):
+        raw = _make_email_with_attachments(
+            attachments=[
+                ("image.png", "image", "png", b"first"),
+                ("image.png", "image", "png", b"second"),
+            ]
+        )
+        parsed = parse_email_message(raw)
+        _persist_attachments(parsed)
+        paths = [a["path"] for a in parsed["attachments"]]
+        assert len(set(paths)) == 2  # distinct files, no overwrite
+        from pathlib import Path
+
+        assert {Path(p).read_bytes() for p in paths} == {b"first", b"second"}
+
+    def test_empty_message_id_does_not_collide_cross_message(self, attachment_dirs):
+        """Two Message-ID-less emails persist into distinct subdirs (critique C3)."""
+        raw1 = _make_email_with_attachments(
+            from_addr="a@x.com",
+            subject="one",
+            message_id="",
+            attachments=[("f.pdf", "application", "pdf", b"one")],
+        )
+        raw2 = _make_email_with_attachments(
+            from_addr="b@x.com",
+            subject="two",
+            message_id="",
+            attachments=[("f.pdf", "application", "pdf", b"two")],
+        )
+        p1 = parse_email_message(raw1)
+        p2 = parse_email_message(raw2)
+        _persist_attachments(p1)
+        _persist_attachments(p2)
+        from pathlib import Path
+
+        path1, path2 = p1["attachments"][0]["path"], p2["attachments"][0]["path"]
+        assert Path(path1).parent != Path(path2).parent
+        assert Path(path1).read_bytes() == b"one"
+        assert Path(path2).read_bytes() == b"two"
+
+    def test_vault_mirror_failure_is_nonfatal(self, attachment_dirs, monkeypatch):
+        """A broken vault dir must not prevent disk persistence (failure-path)."""
+        store, vault = attachment_dirs
+
+        def boom(*a, **k):
+            raise OSError("vault unwritable")
+
+        monkeypatch.setattr(eb.shutil, "copy2", boom)
+        raw = _make_email_with_attachments(attachments=[("ok.pdf", "application", "pdf", b"data")])
+        parsed = parse_email_message(raw)
+        # Should not raise despite the copy2 failure.
+        _persist_attachments(parsed)
+        from pathlib import Path
+
+        assert Path(parsed["attachments"][0]["path"]).exists()
+
+
+class TestRecordHistoryAttachments:
+    """_record_history blob carries attachment metadata only — never bytes."""
+
+    def test_blob_includes_attachments_metadata(self, attachment_dirs):
+        import json
+
+        raw = _make_email_with_attachments(
+            attachments=[("doc.pdf", "application", "pdf", b"pdfbytes")]
+        )
+        parsed = parse_email_message(raw)
+        _persist_attachments(parsed)
+
+        captured = {}
+
+        class FakePipe:
+            def set(self, k, v, ex=None):
+                captured["blob"] = v
+
+            def zadd(self, *a, **k):
+                pass
+
+            def execute(self):
+                pass
+
+        class FakeRedis:
+            def pipeline(self):
+                return FakePipe()
+
+            def zcard(self, *a, **k):
+                return 1
+
+        with patch("bridge.email_bridge._get_redis", return_value=FakeRedis()):
+            _record_history(parsed)
+
+        blob = json.loads(captured["blob"])
+        assert blob["attachments"][0]["filename"] == "doc.pdf"
+        assert blob["attachments"][0]["size"] == len(b"pdfbytes")
+        assert "_payload" not in blob["attachments"][0]
+        assert blob["attachments_truncated"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_email_history.py
+++ b/tests/unit/test_email_history.py
@@ -91,6 +91,50 @@ class TestGetRecentEmails:
         assert "error" in result
         assert "INBOX" in result["error"]
 
+    def test_old_blob_without_attachments_hydrates_as_empty_list(self, r):
+        """Back-compat: a blob written before the attachments field reads as []."""
+        from tools.email_history import get_recent_emails
+
+        # _seed_message writes a blob with NO attachments key (the old shape).
+        _seed_message(r, "<legacy@x>", time.time() - 5, subject="legacy")
+        result = get_recent_emails(limit=5)
+        assert result["messages"][0]["attachments"] == []
+
+    def test_attachments_metadata_projected(self, r):
+        from tools.email_history import get_recent_emails
+
+        set_key = HISTORY_SET_KEY.format(mailbox="INBOX")
+        msg_key = HISTORY_MSG_KEY.format(message_id="<att@x>")
+        ts = time.time()
+        r.set(
+            msg_key,
+            json.dumps(
+                {
+                    "from_addr": "a@x.com",
+                    "subject": "with file",
+                    "body": "see attached",
+                    "timestamp": ts,
+                    "message_id": "<att@x>",
+                    "in_reply_to": "",
+                    "attachments": [
+                        {
+                            "filename": "r.pdf",
+                            "content_type": "application/pdf",
+                            "size": 12,
+                            "path": "/data/media/email-attachments/ab/r.pdf",
+                        }
+                    ],
+                }
+            ),
+        )
+        r.zadd(set_key, {"<att@x>": ts})
+
+        result = get_recent_emails(limit=5)
+        atts = result["messages"][0]["attachments"]
+        assert len(atts) == 1
+        assert atts[0]["filename"] == "r.pdf"
+        assert atts[0]["content_type"] == "application/pdf"
+
     def test_since_ts_filter(self, r):
         from tools.email_history import get_recent_emails
 

--- a/tests/unit/test_valor_email.py
+++ b/tests/unit/test_valor_email.py
@@ -17,7 +17,14 @@ import time
 import pytest
 import redis
 
-from tools.valor_email import _build_session_id, _normalize_msgid, cmd_read, cmd_send, cmd_threads
+from tools.valor_email import (
+    _build_session_id,
+    _imap_fallback_fetch,
+    _normalize_msgid,
+    cmd_read,
+    cmd_send,
+    cmd_threads,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -55,6 +62,58 @@ class TestNormalizeMsgid:
     def test_whitespace_only_rejected(self):
         with pytest.raises(argparse.ArgumentTypeError):
             _normalize_msgid("   ")
+
+
+class TestImapFallbackFetchAttachments:
+    """Critique C2: the cache-miss IMAP fallback read path must project attachments."""
+
+    def test_fallback_projects_attachment_metadata(self, monkeypatch):
+        import email.message
+
+        # Build a raw multipart email with an attachment.
+        msg = email.message.EmailMessage()
+        msg["From"] = "tom@yuda.me"
+        msg["To"] = "valor@example.com"
+        msg["Subject"] = "report"
+        msg["Message-ID"] = "<fb-1@x>"
+        msg["Date"] = "Mon, 01 Jan 2026 00:00:00 +0000"
+        msg.set_content("see attached")
+        msg.add_attachment(b"%PDF data", maintype="application", subtype="pdf", filename="r.pdf")
+        raw_bytes = msg.as_bytes()
+
+        class FakeConn:
+            def login(self, *a, **k):
+                return ("OK", [b""])
+
+            def select(self, *a, **k):
+                return ("OK", [b"1"])
+
+            def uid(self, cmd, *args):
+                if cmd == "search":
+                    return ("OK", [b"1"])
+                if cmd == "fetch":
+                    return ("OK", [(b"1 (RFC822 {%d}" % len(raw_bytes), raw_bytes)])
+                return ("NO", [b""])
+
+            def logout(self):
+                return ("OK", [b""])
+
+        monkeypatch.setattr("tools.valor_email.imaplib.IMAP4_SSL", lambda *a, **k: FakeConn())
+        monkeypatch.setattr(
+            "bridge.email_bridge._get_imap_config",
+            lambda: {"host": "imap.test", "port": 993, "user": "u", "password": "p", "ssl": True},
+        )
+        monkeypatch.setattr("bridge.routing.ensure_email_routing_loaded", lambda: True)
+        monkeypatch.setattr("bridge.routing.get_known_email_search_terms", lambda: ["tom@yuda.me"])
+
+        results = _imap_fallback_fetch(limit=5, search=None, since_ts=None)
+        assert len(results) == 1
+        atts = results[0]["attachments"]
+        assert len(atts) == 1
+        assert atts[0]["filename"] == "r.pdf"
+        assert atts[0]["content_type"] == "application/pdf"
+        # Read-only path never persists bytes, so path stays None (critique C1).
+        assert atts[0]["path"] is None
 
 
 class TestBuildSessionId:
@@ -118,7 +177,8 @@ class TestCmdSend:
         assert payload["references"] == "<abc@host>"
 
     def test_rejects_missing_file(self, r, tmp_path, capsys):
-        rc = cmd_send(self._args(message="hi", file=str(tmp_path / "not-here.pdf")))
+        # ``--file`` is action="append" → runtime shape is list[str].
+        rc = cmd_send(self._args(message="hi", file=[str(tmp_path / "not-here.pdf")]))
         assert rc == 1
         captured = capsys.readouterr()
         assert "File not found" in captured.err
@@ -126,11 +186,34 @@ class TestCmdSend:
     def test_attachment_path_absolute(self, r, tmp_path):
         f = tmp_path / "payload.txt"
         f.write_text("contents")
-        rc = cmd_send(self._args(message="see attached", file=str(f)))
+        rc = cmd_send(self._args(message="see attached", file=[str(f)]))
         assert rc == 0
         keys = list(r.scan_iter(match="email:outbox:cli-*"))
         payload = json.loads(r.lpop(keys[0]))
         assert payload["attachments"] == [str(f.resolve())]
+
+    def test_multiple_files_all_land_in_payload_in_order(self, r, tmp_path):
+        # Two ``--file`` flags must collect BOTH absolute paths into the
+        # outbox ``attachments`` list, preserving CLI order (the multi-file
+        # bug: a single string arg kept only the last file).
+        a = tmp_path / "a.pdf"
+        b = tmp_path / "b.pdf"
+        a.write_text("aaa")
+        b.write_text("bbb")
+        rc = cmd_send(self._args(message="see both", file=[str(a), str(b)]))
+        assert rc == 0
+        keys = list(r.scan_iter(match="email:outbox:cli-*"))
+        assert len(keys) == 1
+        payload = json.loads(r.lpop(keys[0]))
+        assert payload["attachments"] == [str(a.resolve()), str(b.resolve())]
+
+    def test_rejects_second_invalid_file_without_skipping(self, r, tmp_path, capsys):
+        good = tmp_path / "good.txt"
+        good.write_text("ok")
+        rc = cmd_send(self._args(message="hi", file=[str(good), str(tmp_path / "missing.pdf")]))
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "File not found" in captured.err
 
     def test_ttl_set_on_queue_key(self, r):
         cmd_send(self._args(message="hi"))

--- a/tools/email_history/__init__.py
+++ b/tools/email_history/__init__.py
@@ -140,6 +140,9 @@ def get_recent_emails(
                     "body": data.get("body", ""),
                     "timestamp": _ts_to_iso(data.get("timestamp")),
                     "in_reply_to": data.get("in_reply_to", ""),
+                    # Attachment metadata (filename/content_type/size/path); old
+                    # blobs written before this field hydrate as [] (back-compat).
+                    "attachments": data.get("attachments", []),
                 }
             )
     except Exception as e:
@@ -211,6 +214,8 @@ def search_history(
                 "body": body,
                 "timestamp": _ts_to_iso(ts),
                 "in_reply_to": data.get("in_reply_to", ""),
+                # Attachment metadata; back-compat blobs hydrate as [].
+                "attachments": data.get("attachments", []),
             }
         )
         if len(results) >= max_results:

--- a/tools/valor_email.py
+++ b/tools/valor_email.py
@@ -207,6 +207,14 @@ def _imap_fallback_fetch(limit: int, search: str | None, since_ts: float | None)
                     "body": body,
                     "timestamp": datetime.fromtimestamp(ts).isoformat(),
                     "in_reply_to": parsed.get("in_reply_to", ""),
+                    # Attachment metadata (critique C2: the cache-miss IMAP
+                    # fallback must project attachments too). Drop the transient
+                    # _payload; on this read-only path bytes are never persisted,
+                    # so each `path` is None.
+                    "attachments": [
+                        {k: a.get(k) for k in ("filename", "content_type", "size", "path")}
+                        for a in parsed.get("attachments", [])
+                    ],
                 }
             )
             if len(results) >= limit:
@@ -308,6 +316,10 @@ def cmd_read(args: argparse.Namespace) -> int:
         print(f"[{ts}] {sender}")
         print(f"  Subject: {subject}")
         print(f"  {body}")
+        attachments = msg.get("attachments") or []
+        if attachments:
+            names = ", ".join(a.get("filename", "?") for a in attachments)
+            print(f"  Attachments ({len(attachments)}): {names}")
         print()
 
     return 0
@@ -340,13 +352,16 @@ def cmd_send(args: argparse.Namespace) -> int:
         1 on validation failure, missing file, or Redis push error.
     """
     body = args.message or ""
-    file_path = args.file
+    # ``--file`` uses argparse ``action="append"`` — the runtime shape is
+    # ``None`` (flag absent) or ``list[str]`` (one entry per ``--file``).
+    files = args.file or []
 
-    if not body and not file_path:
+    if not body and not files:
         print("Error: Must provide a message or --file", file=sys.stderr)
         return 1
 
-    if file_path:
+    attachments = []
+    for file_path in files:
         p = Path(file_path)
         if not p.is_file():
             print(f"Error: File not found: {file_path}", file=sys.stderr)
@@ -358,8 +373,7 @@ def cmd_send(args: argparse.Namespace) -> int:
         except OSError as e:
             print(f"Error: Cannot read file {file_path}: {e}", file=sys.stderr)
             return 1
-
-    attachments = [str(Path(file_path).resolve())] if file_path else []
+        attachments.append(str(p.resolve()))
 
     in_reply_to = None
     references = None
@@ -519,7 +533,14 @@ def main() -> int:
         help="Subject (default: '(no subject)')",
     )
     send_parser.add_argument("message", nargs="?", default="", help="Body text")
-    send_parser.add_argument("--file", "-f", help="File to attach (absolute or relative path)")
+    send_parser.add_argument(
+        "--file",
+        "-f",
+        action="append",
+        dest="file",
+        metavar="PATH",
+        help="File to attach; repeat --file for multiple files (absolute or relative path)",
+    )
     send_parser.add_argument(
         "--reply-to",
         type=_normalize_msgid,


### PR DESCRIPTION
## Summary

Closes #1567. Adds end-to-end **inbound email attachment support** (outgoing already worked) and fixes the **multi-file outgoing `--file`** bug found during recon. Mirrors the Telegram inbound-media pattern: bytes on the filesystem, metadata/paths in Redis.

Plan: `docs/plans/incoming_email_attachments.md` (critique: READY TO BUILD, 0 blockers, concerns C1–C5 + nits N1–N2 all addressed).

## What changed

**Inbound (`bridge/email_bridge.py`)**
- `_extract_attachment_metadata(msg)` — pure MIME walk, **no disk writes**, so the read-only `valor-email read` IMAP fallback never persists (**C1**).
- `_persist_attachments(parsed)` — poll-loop-only; writes bytes to `data/media/email-attachments/{msgid_hash}/{sanitized_name}`, fire-and-forget mirrors to `~/work-vault/email-attachments/` for KnowledgeWatcher indexing.
- Empty Message-ID → `from_addr:subject:timestamp` fallback key so senderless emails don't collide into one subdir (**C3**); same-name files index-suffixed.
- Size cap **short-circuits the decode loop pre-decode** + parts cap as multipart-bomb guards (**C4**); per-part try/except; filename sanitization blocks path traversal.
- Empty-body emails carrying attachments are no longer dropped.
- Metadata flows into the history blob, `get_recent_emails`/`search_history`, the `valor-email read` IMAP fallback (**C2**), and `extra_context["email_attachments"]` (readable paths for the agent).

**Outgoing (`tools/valor_email.py`)**
- `--file` is now repeatable (`action="append"`) with per-file validation, fixing the keep-only-last-file bug; help text updated (**N2**).

## Guardrails
- Filename sanitization (basename + `[A-Za-z0-9._-]`, traversal → safe name, `{hash}` subdir containment + resolved-path check).
- `EMAIL_ATTACHMENT_MAX_TOTAL_BYTES` (25 MiB) cumulative cap, `EMAIL_ATTACHMENT_MAX_PARTS` (50) — both env-overridable.
- Malformed/undecodable parts logged and skipped, never abort the rest. Vault-mirror failure is non-fatal.

## Tests
- **Unit** (`test_email_bridge.py`): extraction (single/multi), sanitization + traversal, size/parts caps + truncation, empty-body-with-attachment, persistence, same-name + cross-message collision, vault-mirror failure non-fatal, history blob metadata-only.
- **Read paths** (`test_email_history.py`, `test_valor_email.py`): cache-hit projection + back-compat (`[]`), and the cache-miss IMAP fallback projection (**C2**).
- **Integration** (`test_email_bridge.py`): full single + multi attachment inbound flow → persisted to disk, exposed in read output, carried into `extra_context`.

All touched suites green: `test_email_bridge` (unit+integration), `test_email_history`, `test_valor_email`, `test_email_relay` — 130 passed. `ruff format` clean.

## Notes
- No on-disk reaper (matches Telegram `data/media/`; vault copy is the durable indexed record) — accepted residual per plan Risk 1.
- Purely additive interfaces; old history blobs hydrate `attachments: []`.