### PR TITLE
fix(stall-advisory): suppress never_started false positive for granite PTY sessions

### DIFF
--- a/agent/session_stall_classifier.py
+++ b/agent/session_stall_classifier.py
@@ -211,6 +211,42 @@ def read_project_health_counters(project_key: str) -> dict[str, int]:
 # ---------------------------------------------------------------------------
 
 
+def _has_demonstrable_progress(session) -> bool:
+    """Return True if the session's own fields prove it has started and is working.
+
+    The ``never_started`` probe keys off telemetry ``turn_start`` events, but
+    granite PTY sessions emit their turns to a private transcript rather than
+    the telemetry timeline this classifier reads. A healthy granite session can
+    therefore show zero ``turn_start`` events while ``turn_count`` climbs and
+    tools fire — yielding a ``never_started`` false positive. This helper
+    consults the AgentSession's own progress fields as ground truth:
+
+      * ``turn_count > 0``           → the session has taken at least one turn.
+      * ``last_tool_use_at`` fresh   → a tool fired within the suspect window.
+      * ``last_pty_activity_at`` fresh → the PTY screen painted recently.
+
+    "Fresh" means within :data:`IDLE_SUSPECT_SECS`. Missing attributes count as
+    no-progress (``getattr`` defaults), so legacy/stub sessions are unaffected.
+    Fail-soft: any error returns False, falling through to the elapsed-grace
+    check rather than masking a genuine never-started session.
+    """
+    try:
+        from bridge.utc import to_unix_ts  # local import: mirror _classify
+
+        turn_count = getattr(session, "turn_count", None)
+        if isinstance(turn_count, int) and turn_count > 0:
+            return True
+
+        now = time.time()
+        for attr in ("last_tool_use_at", "last_pty_activity_at"):
+            ts = to_unix_ts(getattr(session, attr, None))
+            if ts is not None and (now - ts) < IDLE_SUSPECT_SECS:
+                return True
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("_has_demonstrable_progress swallowed exception: %r", exc)
+    return False
+
+
 def _classify(
     events: list[dict],
     *,
@@ -269,6 +305,25 @@ def _classify(
                         },
                     )
 
+            # ----------------------------------------------------------
+            # 1b. demonstrable-progress probe (never_started false-positive guard)
+            # ----------------------------------------------------------
+            # A granite PTY session emits turns to its private transcript, not
+            # this telemetry timeline — so "no turn_start event" does not imply
+            # "never started". Trust the session's own progress fields to avoid a
+            # false positive on a session that is demonstrably working. This runs
+            # AFTER the granite_wedged probe so a session that progressed
+            # (turn_count > 0) and then wedged is still caught as wedged, not
+            # masked as healthy here.
+            if _has_demonstrable_progress(session):
+                return StallVerdict(
+                    "healthy",
+                    "progress_fields_fresh",
+                    {
+                        "turn_count": getattr(session, "turn_count", None),
+                        "session_status": session_status,
+                    },
+                )
             # Session is in a probe status but has never emitted a turn_start.
             started_ref = getattr(session, "started_at", None) or getattr(
                 session, "created_at", None
@@ -276,13 +331,18 @@ def _classify(
             ts = to_unix_ts(started_ref)
             if ts is not None:
                 elapsed = time.time() - ts
-                if elapsed > NEVER_STARTED_GRACE_SECS:
+                # Grace + confirmation margin: the margin covers worst-case
+                # granite cold-start latency (container spin-up + TUI boot +
+                # priming) before we are willing to call a session stalled.
+                confirm_threshold = NEVER_STARTED_GRACE_SECS + NEVER_STARTED_CONFIRM_MARGIN_SECS
+                if elapsed > confirm_threshold:
                     return StallVerdict(
                         "stalled",
                         "never_started",
                         {
                             "elapsed_secs": elapsed,
                             "grace_secs": NEVER_STARTED_GRACE_SECS,
+                            "confirm_margin_secs": NEVER_STARTED_CONFIRM_MARGIN_SECS,
                             "session_status": session_status,
                         },
                     )

--- a/tests/unit/test_session_stall_classifier.py
+++ b/tests/unit/test_session_stall_classifier.py
@@ -17,6 +17,7 @@ from agent.session_stall_classifier import (
     GRANITE_WEDGED_READLOOP_FRESH_SECS,
     IDLE_STALL_SECS,
     IDLE_SUSPECT_SECS,
+    NEVER_STARTED_CONFIRM_MARGIN_SECS,
     NEVER_STARTED_GRACE_SECS,
     RECOVERY_SUSPECT_COUNT,
     TOOL_TIMEOUT_SUSPECT_COUNT,
@@ -181,6 +182,101 @@ class TestNeverStartedRule:
         verdict = classify_session_stall([], session=session)
         assert verdict.level == "stalled"
         assert verdict.reason == "never_started"
+
+
+class TestNeverStartedProgressGuard:
+    """Granite PTY sessions emit no turn_start telemetry but still progress.
+
+    The progress-field guard must suppress the never_started false positive when
+    the AgentSession's own fields show work, while leaving genuinely-idle
+    sessions flagged.
+    """
+
+    def test_positive_turn_count_skips_never_started(self):
+        # No turn_start events, old created_at — but turn_count proves it started.
+        now = time.time()
+        session = SimpleNamespace(
+            status="running",
+            started_at=now - 700,
+            created_at=now - 700,
+            turn_count=28,
+        )
+        verdict = classify_session_stall([], session=session)
+        assert verdict.level == "healthy"
+        assert verdict.reason == "progress_fields_fresh"
+        assert verdict.signals["turn_count"] == 28
+
+    def test_fresh_last_tool_use_skips_never_started(self):
+        import datetime
+
+        now = time.time()
+        session = SimpleNamespace(
+            status="running",
+            started_at=now - 700,
+            created_at=now - 700,
+            turn_count=0,  # no completed turns yet
+            last_tool_use_at=datetime.datetime.now(datetime.UTC),  # firing now
+        )
+        verdict = classify_session_stall([], session=session)
+        assert verdict.level == "healthy"
+        assert verdict.reason == "progress_fields_fresh"
+
+    def test_fresh_last_pty_activity_skips_never_started(self):
+        import datetime
+
+        now = time.time()
+        session = SimpleNamespace(
+            status="running",
+            started_at=now - 700,
+            created_at=now - 700,
+            turn_count=0,
+            last_pty_activity_at=datetime.datetime.now(datetime.UTC),
+        )
+        verdict = classify_session_stall([], session=session)
+        assert verdict.level == "healthy"
+        assert verdict.reason == "progress_fields_fresh"
+
+    def test_stale_progress_fields_still_never_started(self):
+        # turn_count zero AND last activity well outside the suspect window →
+        # the guard must NOT fire; the session is genuinely never-started.
+        now = time.time()
+        session = SimpleNamespace(
+            status="running",
+            started_at=now - 700,
+            created_at=now - 700,
+            turn_count=0,
+            last_tool_use_at=now - (IDLE_SUSPECT_SECS + 200),
+            last_pty_activity_at=now - (IDLE_SUSPECT_SECS + 200),
+        )
+        verdict = classify_session_stall([], session=session)
+        assert verdict.level == "stalled"
+        assert verdict.reason == "never_started"
+
+    def test_confirm_margin_applied_below_threshold_is_healthy(self):
+        # Elapsed sits in the (grace, grace+margin] band → not yet stalled.
+        now = time.time()
+        elapsed = NEVER_STARTED_GRACE_SECS + (NEVER_STARTED_CONFIRM_MARGIN_SECS / 2)
+        session = SimpleNamespace(
+            status="running",
+            started_at=now - elapsed,
+            created_at=now - elapsed,
+            turn_count=0,
+        )
+        verdict = classify_session_stall([], session=session)
+        assert verdict.level == "healthy"
+        assert verdict.reason != "never_started"
+
+    def test_confirm_margin_reported_in_signals(self):
+        now = time.time()
+        session = SimpleNamespace(
+            status="running",
+            started_at=now - 700,
+            created_at=now - 700,
+            turn_count=0,
+        )
+        verdict = classify_session_stall([], session=session)
+        assert verdict.reason == "never_started"
+        assert verdict.signals["confirm_margin_secs"] == NEVER_STARTED_CONFIRM_MARGIN_SECS
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The dashboard reported healthy granite SDLC sessions as **stalled** (`reason=never_started`). Observed live: session `0_1782206109776` (SDLC #280) ran 20+ minutes with `turn_count` climbing 25→37 and tools firing every ~30s, yet was flagged `never_started` the entire time.

**Root cause:** `agent/session_stall_classifier.py`'s never-started probe keys *solely* off telemetry `turn_start` events. Granite PTY sessions emit their turns to a private transcript, not the telemetry timeline this classifier reads (worker logs show `transcript read: no-new-entry … using unknown classification`). So any granite session that hasn't yet posted to Telegram trips `never_started` once past the 120s grace — despite demonstrable progress.

The classifier is **read-only / advisory** — this never caused a kill, but it made the dashboard untrustworthy and buried real stalls in noise.

## Fix

- **`_has_demonstrable_progress()`** — before flagging `never_started`, trust the AgentSession's own fields: `turn_count > 0`, or `last_tool_use_at` / `last_pty_activity_at` fresh within `IDLE_SUSPECT_SECS`. Returns a healthy `progress_fields_fresh` verdict instead.
- **Wire in `NEVER_STARTED_CONFIRM_MARGIN_SECS` (30s)** — defined and documented but never applied; the predicate now fires at grace+margin (150s) as intended, covering worst-case granite cold-start (container spin-up + TUI boot + priming).

No change to the `session_health` tool_timeout kill path. Backward compatible: sessions without progress attributes and genuinely-idle sessions still flag `never_started`.

## Tests

- 6 new tests: positive `turn_count` guard, fresh tool-use / PTY guards, stale-fields-still-flag, confirm-margin band, confirm-margin in signals.
- `ruff` clean; **67 classifier + 43 downstream stall tests pass**.

## Out of scope (follow-up)

The *real* kill path — `session_health` `TOOL_TIMEOUT_DEFAULT_SEC=300` for default-tier Bash/Task/**Skill**/WebFetch — is too tight for SDLC sessions running long test/build commands (it killed session `163`). Recommended separately: gate the wedge kill on PTY liveness (`last_pty_activity_at` / the #1724 quiescence window) rather than elapsed-time alone, or raise/tier-split the default budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)