### PR TITLE
fix(agent-session): downgrade liveness save() log noise to DEBUG

### DIFF
--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -907,18 +907,34 @@ class AgentSession(Model):
         return await super().async_create(**kwargs)
 
     # Fields whose partial saves intentionally omit ``updated_at`` at high
-    # frequency (liveness heartbeats and PID bookkeeping). Omitting the stamp
-    # here is by-design — the dedicated heartbeat fields carry freshness — so a
-    # WARNING per write is pure log noise (2 lines per 60s heartbeat per
-    # session) that buries genuine warnings. We downgrade these to DEBUG; any
-    # other omission (e.g. ``status``) still warns.
+    # frequency (liveness heartbeats, PID bookkeeping, and the granite
+    # wedge-detector's cross-tick state). Omitting the stamp here is by-design —
+    # the dedicated heartbeat/freshness fields ARE the freshness signal, so
+    # advancing ``updated_at`` would be redundant — and a WARNING per write is
+    # pure log noise (several lines per heartbeat per session, far worse for
+    # granite-container sessions whose PTY read-loop and per-tool boundaries
+    # fire at >=1 Hz) that buries genuine warnings. We downgrade these to DEBUG;
+    # any other omission (e.g. ``status``) still warns. A combined partial save
+    # is only downgraded when EVERY field in it is on this allowlist.
     _UPDATED_AT_OMISSION_OK_FIELDS = frozenset(
         {
+            # SDK / worker liveness heartbeats and PID bookkeeping
             "last_heartbeat_at",
             "last_sdk_heartbeat_at",
             "last_stdout_at",
             "claude_pid",
             "harness_pid",
+            # Turn-boundary liveness (sdk_client result handler + granite on_turn)
+            "last_turn_at",
+            # Tool-boundary liveness (Pre/PostToolUse hooks, fires per tool call)
+            "current_tool_name",
+            "last_tool_use_at",
+            # Granite PTY read-loop liveness stamps (#1724; fire at >=1 Hz)
+            "last_pty_read_loop_at",
+            "last_pty_activity_at",
+            # Granite stage-1 wedge-detector cross-tick state (per health tick)
+            "mid_run_quiescent_since",
+            "mid_run_pty_snapshot",
         }
     )
 

--- a/tests/unit/test_agent_session_updated_at_utc.py
+++ b/tests/unit/test_agent_session_updated_at_utc.py
@@ -9,6 +9,8 @@ import logging
 from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
+import pytest
+
 from models.agent_session import AgentSession
 
 # ---------------------------------------------------------------------------
@@ -178,6 +180,89 @@ class TestSaveUpdateFieldsGuard:
             AgentSession.save(s)  # update_fields defaults to None
 
         assert s.updated_at > old_ts, "Full save (update_fields=None) must stamp updated_at"
+
+
+# ---------------------------------------------------------------------------
+# Tests: save() liveness-field omission allowlist (DEBUG vs WARNING)
+# ---------------------------------------------------------------------------
+
+
+class TestSaveUpdatedAtOmissionAllowlist:
+    """Liveness/detector-state partial saves log DEBUG; genuine omissions WARN.
+
+    The allowlist (``_UPDATED_AT_OMISSION_OK_FIELDS``) downgrades the
+    "missing 'updated_at'" log to DEBUG for high-frequency liveness/PID/wedge-
+    detector fields whose freshness is carried elsewhere — eliminating the
+    worker-log flood (especially from granite-container sessions) while keeping
+    the WARNING for genuine accidental omissions.
+    """
+
+    @staticmethod
+    def _save_and_capture(update_fields, caplog):
+        """Run save() with super() stubbed; return captured records at DEBUG+."""
+        s = _make_session_no_save()
+        sentinel = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+        s.updated_at = sentinel
+
+        with caplog.at_level(logging.DEBUG, logger="models.agent_session"):
+            with patch.object(AgentSession.__bases__[0], "save", lambda self, *a, **kw: None):
+                AgentSession.save(s, update_fields=update_fields)
+
+        # The guard must never advance updated_at when the stamp is omitted —
+        # the memory/Redis desync guarantee holds regardless of log level.
+        assert s.updated_at == sentinel, (
+            "updated_at must NOT be mutated when update_fields omits it "
+            f"(update_fields={update_fields!r})"
+        )
+        return caplog.records
+
+    @pytest.mark.parametrize(
+        "update_fields",
+        [
+            ["last_turn_at"],
+            ["last_stdout_at"],
+            ["last_heartbeat_at"],
+            ["last_sdk_heartbeat_at"],
+            ["claude_pid"],
+            ["harness_pid"],
+            ["current_tool_name", "last_tool_use_at"],
+            ["last_pty_read_loop_at", "last_pty_activity_at"],
+            ["mid_run_quiescent_since", "mid_run_pty_snapshot"],
+            ["mid_run_quiescent_since"],
+        ],
+    )
+    def test_allowlisted_liveness_fields_log_debug_not_warning(self, update_fields, caplog):
+        """An all-allowlisted partial save logs at DEBUG, never WARNING."""
+        records = self._save_and_capture(update_fields, caplog)
+
+        assert not any(r.levelno >= logging.WARNING for r in records), (
+            f"update_fields={update_fields!r} (all-allowlisted) must NOT emit a WARNING; "
+            f"got {[(r.levelname, r.message) for r in records]}"
+        )
+        assert any(r.levelno == logging.DEBUG and "updated_at" in r.message for r in records), (
+            f"Expected a DEBUG log about the omitted 'updated_at' for {update_fields!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "update_fields",
+        [
+            ["status"],
+            ["nudge_deferred_count"],
+            ["reprieve_count"],
+            ["exit_returncode"],
+            # Mixed: one allowlisted + one not → still a genuine omission, WARN.
+            ["last_turn_at", "status"],
+            ["mid_run_quiescent_since", "status"],
+        ],
+    )
+    def test_non_allowlisted_omission_still_warns(self, update_fields, caplog):
+        """A non-allowlisted (or mixed) omission keeps the WARNING."""
+        records = self._save_and_capture(update_fields, caplog)
+
+        assert any(r.levelno == logging.WARNING and "updated_at" in r.message for r in records), (
+            f"update_fields={update_fields!r} must still emit a WARNING about missing "
+            f"'updated_at'; got {[(r.levelname, r.message) for r in records]}"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The worker log floods with this WARNING during normal operation (especially granite-container sessions):

```
models.agent_session WARNING save() called with update_fields missing 'updated_at'; timestamp not persisted to avoid memory/Redis desync
```

`AgentSession.save()` intentionally skips stamping `updated_at` when `update_fields` omits it (no in-memory mutation without a matching persist — avoids memory/Redis desync). It logs DEBUG for an allowlist of known liveness/PID fields and WARNING for everything else. The flood came from legitimate high-frequency liveness/wedge-detector saves whose field was **not** on the allowlist — `last_turn_at` (granite `on_turn`), the granite PTY read-loop stamps, the per-tool boundary writes, and the stage-1 quiescence detector's cross-tick state. In a granite session these fire at >= 1 Hz, so each emits a WARNING and buries genuine warnings.

## Categorization decisions

I audited every `update_fields=` caller in `agent/`, `models/`, `bridge/`, `tools/`, `worker/` that omits `updated_at`. **Every steady-state flood contributor is category (a)** — a liveness/freshness/PID/wedge-detector signal whose freshness is carried elsewhere, NOT a real session state change. So all fixes were allowlist additions; **no caller was changed to include `updated_at`** (none represents a modified-time-advancing state change).

Added to `_UPDATED_AT_OMISSION_OK_FIELDS` (logs DEBUG):

| Field | Why it's liveness, not state |
|---|---|
| `last_turn_at` | Turn-boundary liveness — `sdk_client` result handler + granite `on_turn` (`bridge_adapter.py:724`) |
| `current_tool_name` | Tool-boundary liveness — Pre/PostToolUse hooks (`liveness_writers.py`), fires per tool call |
| `last_tool_use_at` | Tool-boundary liveness — paired with `current_tool_name` |
| `last_pty_read_loop_at` | Granite PTY read-loop liveness (#1724), unconditional per read (>= 1 Hz) |
| `last_pty_activity_at` | Granite PTY repaint liveness — saved with `last_pty_read_loop_at` |
| `mid_run_quiescent_since` | Granite stage-1 wedge-detector cross-tick state (`session_health.py:2652`) |
| `mid_run_pty_snapshot` | Granite stage-1 wedge-detector cross-tick state — saved with `mid_run_quiescent_since` per health tick |

**Deliberately left OFF the allowlist** (low-frequency, not flood contributors — WARNING keeps its diagnostic purpose): `nudge_deferred_count`, `reprieve_count`, `recent_thinking_excerpt` (cooldown-gated), `sdk_connection_torn_down_at`, `exit_returncode`.

## Guarantee preserved

Core guard semantics are unchanged: `save()` still skips stamping `updated_at` whenever it's omitted (memory/Redis desync guarantee intact). Only the **log level** changes — and only when **every** field in the partial save is allowlisted (the existing `set(update_fields) <= allowlist` subset check). A mixed save like `["last_turn_at", "status"]` still WARNs.

## Tests

Extended `tests/unit/test_agent_session_updated_at_utc.py` with `TestSaveUpdatedAtOmissionAllowlist`:
- Parametrized: each allowlisted single/combined save logs DEBUG, never WARNING, and never advances `updated_at`.
- Parametrized: non-allowlisted (`status`, counters) and mixed saves still WARN.

```
31 passed in 2.35s   (full test file)
ruff format + ruff check: clean
```

(6 unrelated pre-existing failures in `test_agent_session_queue.py` / `test_session_isolation_bypass.py` fail identically on `main` — verified via `git stash`.)