### PR TITLE
Calendar work-logging redesign + hook hardening

### DIFF
--- a/scripts/calendar_hook.sh
+++ b/scripts/calendar_hook.sh
@@ -5,7 +5,7 @@
 # in tools/valor_calendar.py behind `valor-calendar --hook --event stop`; this
 # wrapper forwards the Claude Code hook JSON (stdin) and returns immediately.
 #
-# See docs/features/calendar-work-logging.md.
+# See docs/features/google-calendar-integration.md.
 
 set +e  # a calendar hook must never fail the session
 

--- a/scripts/calendar_prompt_hook.sh
+++ b/scripts/calendar_prompt_hook.sh
@@ -7,7 +7,7 @@
 # forwards the Claude Code hook JSON (stdin) and returns immediately; the work
 # runs detached so calendar logging never delays the user's prompt.
 #
-# See docs/features/calendar-work-logging.md.
+# See docs/features/google-calendar-integration.md.
 
 set +e  # a calendar hook must never fail the session
 

--- a/tools/valor_calendar.py
+++ b/tools/valor_calendar.py
@@ -143,7 +143,6 @@ _TECH_JARGON = frozenset(
         "bug",
         "bugfix",
         "task",
-        "wip",
     }
 )
 


### PR DESCRIPTION
## Summary

Reworks `valor-calendar` work-logging around the problems seen in the last 2 weeks of real events (108 cyndra events/2wk, 83 of them 20-min stubs; ~20% bare project-name fallbacks; runaway multi-day blocks; a dead SATSOL calendar), plus folds in validated hook fixes.

### Calendar redesign (`tools/valor_calendar.py`)
- **Feature-keyed events** — work coalesces by git branch / task-list slug (or project-for-the-day for ad-hoc trunk work) instead of per-prompt slugs. Consecutive prompts *and parallel subagents* roll into ONE event.
- **Client-facing names** — jargon-stripped feature titles (deterministic for tracked work; best-effort Haiku for ad-hoc, cached per feature/day). No more `sdlc`/`prompt`/`parallel` slugs or bare project-name events.
- **Day-bounded** — rejects prior-day matches and clamps extension to end-of-day, eliminating runaway multi-day blocks.
- **Trivial-prompt gating + rate-limiting** moved into Python.
- **`--hook` consolidation** — both shell hooks are now thin *detached* wrappers around `valor-calendar --hook`, so calendar logging never delays the prompt.

### gws hang protection (`tools/google_workspace/auth.py`)
- Bounded `httplib2` API transport + timeout-enforcing `requests` refresh adapter, governed by `GWS_HTTP_TIMEOUT` (default 30s; hook uses 8s). Protects **every** gws caller from indefinite hangs.

### Hook latency / reliability
- **Memory `UserPromptSubmit` hook** — hard 8s wall-clock deadline (SIGALRM) around ingest+prefetch + resilient Redis, fixing the observed *"UserPromptSubmit hook timed out after 15s"* error.
- **`post_tool_use` catch-all** — reads sidecar state directly instead of importing the popoto-heavy `memory_bridge` on hot paths (~300ms → ~27ms warm).

### Hook de-dup
- Removed the redundant calendar registration from the repo's local `.claude/settings.json` (it only fired in the unmapped `valor` repo); the global registration remains canonical for all mapped project repos.

## Explicitly out of scope
The **SDLC hook trio** was investigated and deliberately **left alone**: the `validators/`/top-level copies are the live `sdlc_state.json` subsystem wired into `agent/sdk_client.py` with ~106 tests — reconciling the two SDLC hook designs is a separate, dedicated effort, not a side effect of this cleanup.

## Testing
143 unit tests green: calendar features, rounding, auth timeouts, memory deadline, post_tool_use fast path.

## Docs
`docs/features/google-calendar-integration.md` updated for the redesign.