### PR TITLE
test(granite): pin Substrate B ollama backend to qwen (no fallback until ornith)

### DIFF
--- a/tests/granite_faults/ollama_env.py
+++ b/tests/granite_faults/ollama_env.py
@@ -87,22 +87,20 @@ def pick_ollama_model(names: list[str] | None = None) -> str | None:
     Claude Code always sends tool definitions, so the substrate model MUST
     support tools (``gemma*`` chat models return HTTP 400
     "does not support tools" and are unusable here — observed in Task 0).
-    We prefer, in order: a qwen coding tag, gpt-oss, then any non-embedding
-    tag. Returns ``None`` when nothing usable is served.
+
+    Pinned to ``qwen`` only. Qwen coding tags are the sole ollama models that
+    back Claude Code correctly today; gpt-oss and granite were dropped from the
+    fallback chain because a subtly-wrong backend produces misleading E2E
+    results — a clean self-skip (return ``None``) is preferable to running the
+    canary against an inappropriate model. Revisit when the new ``ornith`` model
+    ships: it is expected to be the next appropriate backend and should be added
+    to the preference list here once available.
     """
     names = _list_ollama_models() if names is None else names
     if not names:
         return None
-    # gemma/embedding tags are known-unusable for the tool-carrying claude
-    # substrate; drop them before ranking.
-    usable = [n for n in names if not n.startswith(("gemma", "nomic"))]
-    if not usable:
-        return None
-    for prefix in ("qwen", "gpt-oss", "granite"):
-        pick = next((n for n in usable if n.startswith(prefix)), None)
-        if pick:
-            return pick
-    return usable[0]
+    # Only qwen is appropriate for backing Claude Code until ``ornith`` lands.
+    return next((n for n in names if n.startswith("qwen")), None)
 
 
 def ollama_substrate_reachable(model: str | None = None, probe_timeout_s: float = 240.0) -> bool:

--- a/tests/unit/granite_container/test_ollama_env.py
+++ b/tests/unit/granite_container/test_ollama_env.py
@@ -77,9 +77,12 @@ class TestPickOllamaModel(unittest.TestCase):
         names = ["gemma3:27b", "gemma3n:latest", "nomic-embed-text:latest"]
         self.assertIsNone(pick_ollama_model(names))
 
-    def test_falls_back_to_any_usable_tag(self) -> None:
-        names = ["gemma3:27b", "some-other-instruct:latest"]
-        self.assertEqual(pick_ollama_model(names), "some-other-instruct:latest")
+    def test_qwen_only_no_fallback_until_ornith(self) -> None:
+        """Pinned to qwen: non-qwen tool-capable tags (gpt-oss, granite) are NOT
+        picked — a clean self-skip beats running the canary on an inappropriate
+        backend. Revisit when the ``ornith`` model ships."""
+        self.assertIsNone(pick_ollama_model(["gpt-oss:20b", "granite4.1:3b"]))
+        self.assertIsNone(pick_ollama_model(["gemma3:27b", "some-other-instruct:latest"]))
 
     def test_empty_returns_none(self) -> None:
         self.assertIsNone(pick_ollama_model([]))


### PR DESCRIPTION
Pins the granite failure-simulation harness's Substrate B backend (`pick_ollama_model`) to **qwen only**.

## Why
Qwen coding tags are the only ollama models that back Claude Code correctly today. The prior fallback chain (`qwen` → `gpt-oss` → `granite` → any non-embedding tag) risked running the E2E canary against a subtly-wrong backend, producing misleading results. Per direction: no other model is appropriate until the new **ornith** model is available — at which point it should be added to the preference list.

## Change
- `pick_ollama_model()` now returns the first `qwen*` tag, else `None` (a clean self-skip is preferable to an inappropriate backend). Inline comment documents the `ornith` revisit.
- Updated `test_ollama_env.py`: replaced the old `test_falls_back_to_any_usable_tag` with `test_qwen_only_no_fallback_until_ornith` asserting gpt-oss/granite/other tags are NOT picked.

Test-only. `tests/unit/granite_container/test_ollama_env.py` → 10 passed. ruff clean.

Follow-up to #1837 / PR #1839.