### PR TITLE
Nightly ollama canary: expected-machine alerting

### DIFF
--- a/docs/features/nightly-regression-tests.md
+++ b/docs/features/nightly-regression-tests.md
@@ -6,7 +6,8 @@ Telegram alerts only when new failures or unexpected skips appear.
 
 ## Status
 
-Shipped (issue #972); granite real-loop integration added (issue #1740)
+Shipped (issue #972); granite real-loop integration added (issue #1740); ollama
+Substrate B expected-machine alerting added (issue #1841)
 
 ## What It Does
 
@@ -15,11 +16,18 @@ Shipped (issue #972); granite real-loop integration added (issue #1740)
 - Runs `pytest tests/integration/test_granite_container_loop.py` as a **second, isolated
   invocation** with its own JSON report file and its own state key
   (`data/nightly_tests_integration_last_run.json`)
+- Runs the granite ollama Substrate B canary (`run_ollama_suite()`) as a **third, isolated
+  invocation** against a real `claude` binary talking to ollama — see
+  [`docs/features/granite-failure-simulation-harness.md`](granite-failure-simulation-harness.md)
+  for the suite's design and self-skip gate
 - Sends Telegram alerts to "Eng: Valor" when:
   - Unit suite: `delta > 0` (new failures) or collection errors appear
   - Integration suite: failures, errors, or subprocess crash/timeout
   - Skip-visibility: the integration test was skipped on a model-reachable machine
     (controlled by `NIGHTLY_MODEL_EXPECTED` env var — see below)
+  - Ollama suite: self-skip, subprocess failure, or report-parse failure on the machine
+    designated to run the canary (controlled by `NIGHTLY_OLLAMA_EXPECTED` env var — see
+    below)
 - Clean runs produce no noise
 
 ## Alert Conditions
@@ -43,6 +51,18 @@ Shipped (issue #972); granite real-loop integration added (issue #1740)
 | Skipped on model-reachable machine | `Nightly granite real-loop: N test(s) skipped on a model-reachable machine...` |
 | Clean run | Silent — no Telegram message |
 
+### Granite Ollama Substrate B Suite
+
+| Condition | Message |
+|-----------|---------|
+| Self-skip (expected machine only) | `Nightly granite ollama suite: did not run — ollama/model unreachable on the expected canary machine (NIGHTLY_OLLAMA_EXPECTED=1). Check ollama status and the pinned qwen tag.` |
+| Subprocess failure (expected machine only) | `Nightly granite ollama suite: subprocess failed on the expected canary machine (NIGHTLY_OLLAMA_EXPECTED=1): {exc}` |
+| Parse failure (expected machine only) | `Nightly granite ollama suite: JSON report unparseable on the expected canary machine (NIGHTLY_OLLAMA_EXPECTED=1): {exc}` |
+| Timeout | Already alerts unconditionally on every machine — unchanged, out of scope for issue #1841 |
+| Version-drift canary | Already alerts (and still runs the suite) unconditionally on every machine — unchanged, out of scope for issue #1841 |
+| Self-skip / subprocess failure / parse failure (unexpected machine) | Silent — logged only, no Telegram message |
+| Clean run | Silent — no Telegram message |
+
 ## Skip-Visibility Gate (issue #1740)
 
 The granite real-loop integration test is env-gated on `claude --print ping` (model
@@ -60,6 +80,49 @@ incorrectly.
   machine's role, not real-time model availability.
 - This gate only fires when the report was actually parsed (not when the subprocess
   crashed or timed out).
+
+## Ollama Canary Expected-Machine Gate (issue #1841)
+
+The ollama Substrate B suite (`run_ollama_suite()`) has three exit paths that used to
+only `log(...)` and return: self-skip (ollama/model unreachable), a subprocess
+exception, and a JSON-report parse failure. A canary that silently stops running is
+indistinguishable from one that keeps passing, so each of these paths now also sends
+a Telegram alert — but only on the machine actually expected to run the canary.
+
+**`NIGHTLY_OLLAMA_EXPECTED` is a separate env var from `NIGHTLY_MODEL_EXPECTED`, by
+design.** PR #1840 pinned the ollama backend to qwen-only tags with no fallback,
+which decoupled ollama reachability from anthropic-model reachability:
+
+- `NIGHTLY_MODEL_EXPECTED=1` is set in `com.valor.nightly-tests.plist` and installed
+  on every bridge-role machine, where the anthropic model is reachable.
+- After the qwen pin, a bridge machine can have the anthropic model reachable while
+  having no qwen tag at all — it legitimately self-skips the ollama suite every
+  night.
+- Reusing `NIGHTLY_MODEL_EXPECTED` to gate the ollama alerts would turn every bridge
+  machine into a nightly false-alarm generator. A separate `NIGHTLY_OLLAMA_EXPECTED`
+  var keeps the two reachability concerns independent.
+
+**How it works:**
+- `run_ollama_suite()` reads
+  `ollama_expected = bool(os.environ.get("NIGHTLY_OLLAMA_EXPECTED", "").strip())` once
+  near the top, mirroring the `NIGHTLY_MODEL_EXPECTED` idiom.
+- When `ollama_expected` is true, the self-skip, subprocess-exception, and
+  report-parse-failure paths each send a Telegram alert (in addition to the existing
+  `log(...)` call) naming the failure mode and carrying the reason.
+- When `ollama_expected` is false or unset, all three paths remain log-only, exactly
+  as before this change.
+
+**Provisioning is a manual operator step, not automated.** Set
+`NIGHTLY_OLLAMA_EXPECTED=1` only on the one machine designated to actually run the
+ollama canary (the skills/dev machine, per the granite failure-simulation harness
+plan's Resolved Decision #2) — for example by exporting it in that machine's shell
+profile, its launchd job's `EnvironmentVariables`, or the `.env` used for the nightly
+invocation.
+
+**Do NOT add `NIGHTLY_OLLAMA_EXPECTED` to the shared `com.valor.nightly-tests.plist`.**
+That plist installs on bridge-role machines, which lack the pinned qwen tag after PR
+#1840 — setting the flag there would reintroduce the alert-storm this gate exists to
+avoid. The plist is untouched by this change.
 
 ## Files
 

--- a/scripts/nightly_regression_tests.py
+++ b/scripts/nightly_regression_tests.py
@@ -427,11 +427,30 @@ def run_ollama_suite(dry_run: bool = False) -> None:
     version-pinned claude canary and runs the E2E as an isolated subprocess
     (``GRANITE_OLLAMA_SMOKE=1``), then surfaces failures as Telegram alerts.
     """
+    # Per-suite expected-machine gate (issue #1841, mirrors #1740's
+    # NIGHTLY_MODEL_EXPECTED pattern). This is intentionally a SEPARATE var from
+    # NIGHTLY_MODEL_EXPECTED: PR #1840 pinned the ollama backend to qwen-only
+    # tags with no fallback, so ollama reachability is now decoupled from
+    # anthropic-model reachability — a bridge machine can have
+    # NIGHTLY_MODEL_EXPECTED=1 (anthropic model reachable) while having no qwen
+    # tag at all. Reusing NIGHTLY_MODEL_EXPECTED here would alert-storm every
+    # bridge machine every night. Set NIGHTLY_OLLAMA_EXPECTED=1 ONLY on the one
+    # machine designated to actually run the ollama canary (do NOT add it to
+    # the shared com.valor.nightly-tests.plist).
+    ollama_expected = bool(os.environ.get("NIGHTLY_OLLAMA_EXPECTED", "").strip())
+
     if not ollama_reachable_for_nightly():
         log(
             "Ollama-backed granite suite skipped: ollama/model unreachable "
             "(self-skip, no subprocess spawned)."
         )
+        if ollama_expected:
+            send_telegram(
+                "Nightly granite ollama suite: did not run — ollama/model unreachable "
+                "on the expected canary machine (NIGHTLY_OLLAMA_EXPECTED=1). Check "
+                "ollama status and the pinned qwen tag.",
+                dry_run=dry_run,
+            )
         return
 
     # Version-pinned canary: alert on drift, but still run the suite.
@@ -470,12 +489,24 @@ def run_ollama_suite(dry_run: bool = False) -> None:
         return
     except Exception as exc:  # noqa: BLE001
         log(f"ERROR: ollama suite subprocess failed: {exc}")
+        if ollama_expected:
+            send_telegram(
+                f"Nightly granite ollama suite: subprocess failed on the expected "
+                f"canary machine (NIGHTLY_OLLAMA_EXPECTED=1): {exc}",
+                dry_run=dry_run,
+            )
         return
 
     try:
         report = json.loads(Path(PYTEST_JSON_OLLAMA_TMP).read_text())
     except (FileNotFoundError, json.JSONDecodeError) as exc:
         log(f"ERROR: Failed to parse ollama suite JSON report: {exc}")
+        if ollama_expected:
+            send_telegram(
+                f"Nightly granite ollama suite: JSON report unparseable on the "
+                f"expected canary machine (NIGHTLY_OLLAMA_EXPECTED=1): {exc}",
+                dry_run=dry_run,
+            )
         return
 
     summary = report.get("summary", {})

--- a/tests/README.md
+++ b/tests/README.md
@@ -310,7 +310,7 @@ tests/
 | unit | `granite_container/test_container_builder_gate.py` | 10 | `PI_SUBPROCESS_TIMEOUT_S` constant, `BuilderHarness` protocol, caller-owned gate |
 | unit | `granite_container/test_fault_injection.py` | 12 | Failure-simulation harness Substrate A — one deterministic seam-injector per failure class (red-first proven); recorded-fixture consumability; no-orphan invariant. See [`docs/features/granite-failure-simulation-harness.md`](../docs/features/granite-failure-simulation-harness.md) |
 | unit | `granite_container/test_ollama_env.py` | 12 | ollama env construction + OAuth-strip no-leak contract (the PR #1612 guard) + tool-capable model picker |
-| unit | `test_nightly_regression_tests.py` | 22 | Nightly runner incl. ollama Substrate B self-skip on unreachable ollama + version-pinned `claude` canary |
+| unit | `test_nightly_regression_tests.py` | 28 | Nightly runner incl. ollama Substrate B self-skip on unreachable ollama + version-pinned `claude` canary + `NIGHTLY_OLLAMA_EXPECTED` expected-machine alerting (issue #1841) |
 | integration | `test_granite_ollama_e2e.py` | 3 | Substrate B — real `claude` binary against ollama; gated on `GRANITE_OLLAMA_SMOKE=1` + reachable; asserts a session reaches a clean reply without wedging |
 | integration | `test_pi_builder_e2e.py` | 5 | Real `pi -p --mode json` against local `ollama/gemma4:31b`; skipped if pi/ollama absent |
 

--- a/tests/unit/test_nightly_regression_tests.py
+++ b/tests/unit/test_nightly_regression_tests.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -198,8 +198,13 @@ class TestRunOllamaSuiteSelfSkip:
     """Plan Task 6 verification: unreachable ollama self-skips with a logged
     reason and spawns NO subprocess (never hard-fails the nightly run)."""
 
-    def test_unreachable_skips_with_logged_reason_and_no_subprocess(self, tmp_path: Path) -> None:
+    def test_unreachable_skips_with_logged_reason_and_no_subprocess(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         nrt.LOG_FILE = tmp_path / "nightly.log"
+        # Deterministically exercise the unexpected-machine case regardless of
+        # ambient env (issue #1841 added an expected-machine alert branch).
+        monkeypatch.delenv("NIGHTLY_OLLAMA_EXPECTED", raising=False)
         logged: list[str] = []
         with (
             patch.object(nrt, "ollama_reachable_for_nightly", return_value=False),
@@ -222,6 +227,122 @@ class TestRunOllamaSuiteSelfSkip:
         with patch.dict("sys.modules", {"tests.granite_faults.ollama_env": None}):
             # Importing a None module raises ImportError → swallowed to False.
             assert nrt.ollama_reachable_for_nightly() is False
+
+
+class TestRunOllamaSuiteExpectedMachine:
+    """Issue #1841: NIGHTLY_OLLAMA_EXPECTED gates Telegram alerts on the three
+    previously-silent failure paths (self-skip, subprocess exception, JSON
+    report parse failure). Intentionally a SEPARATE var from
+    NIGHTLY_MODEL_EXPECTED (#1740) — PR #1840 pinned the ollama backend to
+    qwen-only tags with no fallback, decoupling ollama reachability from
+    anthropic-model reachability.
+    """
+
+    def test_self_skip_expected_machine_alerts_with_skip_reason(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        nrt.LOG_FILE = tmp_path / "nightly.log"
+        monkeypatch.setenv("NIGHTLY_OLLAMA_EXPECTED", "1")
+        with (
+            patch.object(nrt, "ollama_reachable_for_nightly", return_value=False),
+            patch.object(nrt, "subprocess") as mock_subprocess,
+            patch.object(nrt, "send_telegram") as mock_telegram,
+        ):
+            nrt.run_ollama_suite(dry_run=True)
+
+        mock_subprocess.run.assert_not_called()
+        mock_telegram.assert_called_once()
+        (msg,), kwargs = mock_telegram.call_args
+        assert "unreachable" in msg.lower()
+        assert kwargs.get("dry_run") is True
+
+    def test_subprocess_exception_expected_machine_alerts_with_exception_text(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        nrt.LOG_FILE = tmp_path / "nightly.log"
+        monkeypatch.setenv("NIGHTLY_OLLAMA_EXPECTED", "1")
+        with (
+            patch.object(nrt, "ollama_reachable_for_nightly", return_value=True),
+            patch.object(nrt, "claude_canary_alert", return_value=None),
+            patch.object(nrt.subprocess, "run", side_effect=RuntimeError("boom subprocess")),
+            patch.object(nrt, "send_telegram") as mock_telegram,
+        ):
+            nrt.run_ollama_suite(dry_run=True)
+
+        mock_telegram.assert_called_once()
+        (msg,), _kwargs = mock_telegram.call_args
+        assert "boom subprocess" in msg
+
+    def test_subprocess_exception_unexpected_machine_no_alert(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        nrt.LOG_FILE = tmp_path / "nightly.log"
+        monkeypatch.delenv("NIGHTLY_OLLAMA_EXPECTED", raising=False)
+        with (
+            patch.object(nrt, "ollama_reachable_for_nightly", return_value=True),
+            patch.object(nrt, "claude_canary_alert", return_value=None),
+            patch.object(nrt.subprocess, "run", side_effect=RuntimeError("boom subprocess")),
+            patch.object(nrt, "send_telegram") as mock_telegram,
+        ):
+            nrt.run_ollama_suite(dry_run=True)
+
+        mock_telegram.assert_not_called()
+
+    def test_json_parse_failure_expected_machine_alerts_with_parse_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        nrt.LOG_FILE = tmp_path / "nightly.log"
+        monkeypatch.setattr(
+            nrt, "PYTEST_JSON_OLLAMA_TMP", str(tmp_path / "does_not_exist_report.json")
+        )
+        monkeypatch.setenv("NIGHTLY_OLLAMA_EXPECTED", "1")
+        fake_result = MagicMock(returncode=0)
+        with (
+            patch.object(nrt, "ollama_reachable_for_nightly", return_value=True),
+            patch.object(nrt, "claude_canary_alert", return_value=None),
+            patch.object(nrt.subprocess, "run", return_value=fake_result),
+            patch.object(nrt, "send_telegram") as mock_telegram,
+        ):
+            nrt.run_ollama_suite(dry_run=True)
+
+        mock_telegram.assert_called_once()
+        (msg,), _kwargs = mock_telegram.call_args
+        assert "unparseable" in msg.lower() or "parse" in msg.lower()
+
+    def test_json_parse_failure_unexpected_machine_no_alert(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        nrt.LOG_FILE = tmp_path / "nightly.log"
+        monkeypatch.setattr(
+            nrt, "PYTEST_JSON_OLLAMA_TMP", str(tmp_path / "does_not_exist_report.json")
+        )
+        monkeypatch.delenv("NIGHTLY_OLLAMA_EXPECTED", raising=False)
+        fake_result = MagicMock(returncode=0)
+        with (
+            patch.object(nrt, "ollama_reachable_for_nightly", return_value=True),
+            patch.object(nrt, "claude_canary_alert", return_value=None),
+            patch.object(nrt.subprocess, "run", return_value=fake_result),
+            patch.object(nrt, "send_telegram") as mock_telegram,
+        ):
+            nrt.run_ollama_suite(dry_run=True)
+
+        mock_telegram.assert_not_called()
+
+    def test_empty_string_env_treated_as_falsy(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Mirrors the .strip() truthiness idiom used by NIGHTLY_MODEL_EXPECTED."""
+        nrt.LOG_FILE = tmp_path / "nightly.log"
+        monkeypatch.setenv("NIGHTLY_OLLAMA_EXPECTED", "")
+        with (
+            patch.object(nrt, "ollama_reachable_for_nightly", return_value=False),
+            patch.object(nrt, "subprocess") as mock_subprocess,
+            patch.object(nrt, "send_telegram") as mock_telegram,
+        ):
+            nrt.run_ollama_suite(dry_run=True)
+
+        mock_subprocess.run.assert_not_called()
+        mock_telegram.assert_not_called()
 
 
 class TestClaudeCanaryAlert:


### PR DESCRIPTION
## Summary
- `scripts/nightly_regression_tests.py::run_ollama_suite()` now alerts on Telegram (in addition to the existing log line) for three previously-silent failure paths — self-skip (unreachable), subprocess exception, JSON-report parse failure — but only on the machine designated to run the canary.
- Gated behind a new env var `NIGHTLY_OLLAMA_EXPECTED`, deliberately kept separate from `NIGHTLY_MODEL_EXPECTED` since PR #1840's qwen pin decoupled ollama reachability from anthropic-model reachability (a bridge machine can have the model reachable but no qwen tag, and would otherwise alert-storm).
- Unset/empty `NIGHTLY_OLLAMA_EXPECTED` preserves today's log-only behavior exactly — this only adds signal on the one machine that opts in.

## Changes
- `scripts/nightly_regression_tests.py`: added the `ollama_expected` gate and three guarded `send_telegram(...)` calls (self-skip / subprocess-exception / parse-failure paths). Timeout path, version-drift canary, and baseline/regression/clean-run logic left untouched.
- `tests/unit/test_nightly_regression_tests.py`: updated the existing self-skip test to explicitly clear the env var (unexpected-machine case), and added `TestRunOllamaSuiteExpectedMachine` (6 tests) covering alert-fires / alert-does-not-fire for all three paths plus the empty-string-is-falsy case.
- `docs/features/nightly-regression-tests.md`: added a "Granite Ollama Substrate B Suite" alert-conditions table and an "Ollama Canary Expected-Machine Gate (issue #1841)" section explaining the var, the separate-from-`NIGHTLY_MODEL_EXPECTED` rationale, and the manual operator provisioning step.
- `com.valor.nightly-tests.plist` is untouched by design — `NIGHTLY_OLLAMA_EXPECTED` must never be added to the shared bridge plist.

## Testing
- [x] Unit tests passing (`pytest tests/unit/test_nightly_regression_tests.py -q` — 28 passed)
- [x] Lint/format checks passing (`ruff check .` / `ruff format --check .` — clean)

## Documentation
- [x] `docs/features/nightly-regression-tests.md` updated per plan requirements

## Definition of Done
- [x] Built: code implemented and working
- [x] Tested: all tests passing
- [x] Documented: docs created/updated
- [x] Quality: lint and format checks pass

## Provisioning note (manual, out of scope for this PR)
`NIGHTLY_OLLAMA_EXPECTED=1` must be set manually on the one machine designated to actually run the ollama canary — this is intentionally not automated (see plan's No-Gos/Update System sections). Do not add it to `com.valor.nightly-tests.plist`.

Closes #1841
