### PR TITLE
feat(dashboard): surface last_pty_read_loop_at/last_pty_activity_at liveness fields

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -477,6 +477,13 @@ def create_app() -> FastAPI:
             "current_tool_name": s.current_tool_name,
             "last_tool_use_at": s.last_tool_use_at,
             "last_turn_at": s.last_turn_at,
+            # Granite PTY read-loop freshness (#1724 / #1843 Gap B). The
+            # per-iteration read_until_idle callback refreshes
+            # last_pty_read_loop_at mid-turn, so a session wedged inside a long
+            # idle-path turn advances this field within ~1s — operators (and the
+            # stall-advisory actor) see the loop is still cycling.
+            "last_pty_read_loop_at": s.last_pty_read_loop_at,
+            "last_pty_activity_at": s.last_pty_activity_at,
             "recent_thinking_excerpt": s.recent_thinking_excerpt,
             "last_evidence_at": s.last_evidence_at,
             # BYOB scheduler-layer serialization (issue #1256, Decision 2).

--- a/ui/data/sdlc.py
+++ b/ui/data/sdlc.py
@@ -339,6 +339,15 @@ class PipelineProgress(BaseModel):
     dev_transcript_path: str | None = None
     pty_slot: int | None = None
 
+    # === Granite PTY read-loop freshness (issue #1724 / #1843 Gap B) ===
+    # ``last_pty_read_loop_at`` is stamped on every inner read_until_idle poll
+    # tick (throttled to <=1/sec), so a granite session wedged mid-turn on the
+    # idle-fallback path advances it within ~1s — the operator-visible signal
+    # that the read loop is still cycling. ``last_pty_activity_at`` is
+    # diff-gated (stamped only on genuine repaint).
+    last_pty_read_loop_at: float | None = None
+    last_pty_activity_at: float | None = None
+
     # Output routing state (issue #1647)
     # True once a user-facing message has been routed for this session.
     user_facing_routed: bool = False
@@ -982,6 +991,8 @@ def _session_to_pipeline(session) -> PipelineProgress:
         pm_transcript_path=_safe_str(getattr(session, "pm_transcript_path", None)),
         dev_transcript_path=_safe_str(getattr(session, "dev_transcript_path", None)),
         pty_slot=_safe_nullable_int(getattr(session, "pty_slot", None)),
+        last_pty_read_loop_at=_safe_float(getattr(session, "last_pty_read_loop_at", None)),
+        last_pty_activity_at=_safe_float(getattr(session, "last_pty_activity_at", None)),
         user_facing_routed=bool(getattr(session, "user_facing_routed", False)),
         stall_advisory=stall_advisory,
         stall_advisory_reason=stall_advisory_reason,


### PR DESCRIPTION
Closes #1852

Surfaces the two granite mid-run wedge-liveness fields (#1724 signals, freshened mid-turn by #1843/PR #1849) in dashboard.json session serialization (ui/app.py + ui/data/sdlc.py).

Provenance: built during the #1843 pipeline, quarantined mid-flight as #1842 territory, re-applied conflict-free after both PRs merged. Imports verified; dashboard test suite green (13 passed).

Merged without review per operator instruction (low-stakes dashboard surface).