### PR TITLE
Fix stale test asserting wrong _deliver_sync no-loop return contract

### DIFF
--- a/agent/granite_container/bridge_adapter.py
+++ b/agent/granite_container/bridge_adapter.py
@@ -1074,9 +1074,13 @@ class BridgeAdapter:
         captured loop ref is mandatory for async send_cbs. A sync
         send_cb is called directly on the calling thread.
 
-        Returns True on confirmed delivery, False on any failure or
-        timeout. The caller (_make_user_callback / _make_complete_callback)
-        uses the return value to set self._user_facing_routed (issue #1647).
+        Returns True when the payload is delivered synchronously or
+        re-enqueued to the outbox before returning; False when neither
+        happened (sync send_cb raised, a pre-scheduling error occurred,
+        or the same-thread fire-and-forget path where outbox recovery
+        is deferred to a done-callback). The caller
+        (_make_user_callback / _make_complete_callback) uses the return
+        value to set self._user_facing_routed (issue #1647).
 
         On a missing/closed loop or a delivery timeout, the error
         is logged and a session_events entry is appended. The

--- a/tests/unit/granite_container/test_bridge_adapter.py
+++ b/tests/unit/granite_container/test_bridge_adapter.py
@@ -739,7 +739,8 @@ class TestBridgeAdapterSpawnOnAcquire(unittest.TestCase):
 
 
 class TestDeliverSyncReturnsBool(unittest.TestCase):
-    """_deliver_sync returns True on confirmed delivery, False on failure (concern C1, #1647)."""
+    """_deliver_sync returns True on delivery or outbox recovery, False on
+    failure (concern C1, #1647)."""
 
     def _make_adapter_with_sync_cb(self, cb):
         """Adapter with a sync send_cb (not a coroutine) for testing."""
@@ -783,16 +784,24 @@ class TestDeliverSyncReturnsBool(unittest.TestCase):
         result = adapter._deliver_sync(_failing_cb, 1, "hello", None, None, 5.0)
         self.assertFalse(result)
 
-    def test_no_loop_returns_false(self) -> None:
-        """No captured event loop → False."""
+    def test_no_loop_returns_outbox_recovery_result(self) -> None:
+        """No captured event loop → returns whatever _enqueue_to_outbox reports."""
 
         async def _async_cb(chat_id, payload, reply_to, session):
             pass
 
         adapter = self._make_adapter_with_sync_cb(_async_cb)
         adapter._loop = None  # No loop captured
-        result = adapter._deliver_sync(_async_cb, 1, "hello", None, None, 5.0)
+
+        with patch.object(adapter, "_enqueue_to_outbox", return_value=True) as mock_enqueue:
+            result = adapter._deliver_sync(_async_cb, 1, "hello", None, None, 5.0)
+        self.assertTrue(result)
+        mock_enqueue.assert_called_once_with(1, "hello", None)
+
+        with patch.object(adapter, "_enqueue_to_outbox", return_value=False) as mock_enqueue:
+            result = adapter._deliver_sync(_async_cb, 1, "hello", None, None, 5.0)
         self.assertFalse(result)
+        mock_enqueue.assert_called_once_with(1, "hello", None)
 
 
 class TestUserFacingRoutedPropagation(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Renamed `test_no_loop_returns_false` to `test_no_loop_returns_outbox_recovery_result` in `tests/unit/granite_container/test_bridge_adapter.py`, rewriting it to assert both branches of `BridgeAdapter._deliver_sync`'s no-loop path (mocking `_enqueue_to_outbox` to return `True`/`False`) instead of a stale hardcoded `assertFalse`.
- Clarified the `_deliver_sync` docstring in `agent/granite_container/bridge_adapter.py` to state the precise return contract: delivered-or-queued -> `True`; neither -> `False`. No production control flow or return statements changed.

## Investigation resolution (per the plan)
PR #1812 (issue #1805) intentionally changed the no-loop path to re-enqueue to the outbox and return the recovery result, so a reply is never silently lost. The test was not updated at the time, creating a stale-test/correct-code mismatch. This PR fixes the test to match the deliberate, correct production behavior.

## Changes
- `tests/unit/granite_container/test_bridge_adapter.py` — renamed/rewrote the no-loop test, updated class docstring
- `agent/granite_container/bridge_adapter.py` — docstring-only clarification on `_deliver_sync`

## Testing
- [x] `pytest tests/unit/granite_container/test_bridge_adapter.py -n0 -q` -> 32 passed
- [x] `pytest tests/unit/granite_container/ -n0 -q` -> 554 passed, 5 skipped, 9 subtests passed
- [x] `git diff main -- agent/granite_container/bridge_adapter.py | grep -E "^[-+].*return (recovered|False|True)"` -> zero matches (no return statement changed)
- [x] Format clean (`ruff format --check`)

## Documentation
- [x] Plan explicitly states no `docs/features/` doc needed; inline docstring clarification is the deliverable

## Definition of Done
- [x] Built: test rewrite + docstring clarification implemented
- [x] Tested: full granite unit suite green (554 passed, 5 skipped)
- [x] Documented: docstrings updated
- [x] Quality: ruff format/check pass

Closes #1838