### PR TITLE
fix(bridge/worker): atomic per-message + pending→running claims (B1/B2, from #1817)

### DIFF
--- a/agent/session_health.py
+++ b/agent/session_health.py
@@ -85,6 +85,32 @@ _SHELL_WRAPPER_NAMES = frozenset({"sh", "zsh", "bash", "dash"})
 WORKER_REGISTERED_PID_KEY_PREFIX = "worker:registered_pid:"
 WORKER_REGISTERED_PID_TTL_SECONDS = 86400  # 24h
 
+# --- B2-probe: observability-only duplicate-worker detection (issue #1817) --
+#
+# A SEPARATE, additive key namespace from WORKER_REGISTERED_PID_KEY_PREFIX
+# above -- this probe never reads or writes the reaper's positive-ID
+# self-protection keys, so it cannot regress that mechanism. One key per
+# (host, role): ``worker:role_pid:{hostname}:{role}`` holds the pid of the
+# most recently registered worker for that role, and
+# ``worker:pid_heartbeat_ts:{hostname}:{pid}`` holds a per-pid unix timestamp
+# refreshed alongside every registration write, used as the liveness
+# freshness signal (reuses HEARTBEAT_FRESHNESS_WINDOW as the staleness
+# threshold -- see ``_probe_duplicate_worker_registration``).
+_WORKER_ROLE_PID_KEY_PREFIX = "worker:role_pid:"
+_WORKER_PID_HEARTBEAT_TS_KEY_PREFIX = "worker:pid_heartbeat_ts:"
+
+
+def _current_worker_role() -> str:
+    """Return this process's worker role for B2-probe scoping.
+
+    Mirrors the ``VALOR_PROJECT_KEY`` fallback used elsewhere (e.g.
+    ``agent/session_pickup.py``): empty/whitespace falls back to a stable
+    default so writers and readers agree on the namespace.
+    """
+    v = os.environ.get("VALOR_PROJECT_KEY", "").strip()
+    return v or "default"
+
+
 # SIGKILL escalation queue for cross-process orphans.
 # Stages ``(pid, create_time)`` tuples. At drain time the reaper reconstructs
 # ``psutil.Process(pid)`` and verifies ``proc.create_time() == staged`` BEFORE
@@ -3223,6 +3249,14 @@ def register_worker_pid() -> None:
     live worker is never reaped even if a future code change re-adds the
     worker pattern to the cmdline regex set. Failure is non-fatal: the reaper
     still has ``os.getpid()`` in its skip-set.
+
+    B2-probe (issue #1817, optional/observability-only): additionally runs a
+    liveness-gated duplicate-worker check scoped to the same host + role and
+    logs a WARNING when a genuinely live second worker is found. This probe
+    is diagnostic-only: it always lets registration proceed, never exits,
+    and never blocks -- see ``_probe_duplicate_worker_registration`` for the
+    full rationale. The original additive ``_R.set`` write above is
+    unchanged.
     """
     try:
         from popoto.redis_db import POPOTO_REDIS_DB as _R
@@ -3232,6 +3266,121 @@ def register_worker_pid() -> None:
         _R.set(key, pid, ex=WORKER_REGISTERED_PID_TTL_SECONDS)
     except Exception as e:
         logger.debug("[session-health] register_worker_pid write failed: %s", e)
+
+    try:
+        _probe_duplicate_worker_registration(os.getpid())
+    except Exception as e:
+        logger.debug("[session-health] duplicate-worker probe failed (non-fatal): %s", e)
+
+
+def _probe_duplicate_worker_registration(pid: int) -> None:
+    """Observability-only liveness-gated duplicate-worker probe (issue #1817 B2-probe).
+
+    Scoped to the SAME host + role: a different machine, or a worker running
+    a different role (``VALOR_PROJECT_KEY``), legitimately owns its own
+    registration and is never compared against. ``pid`` is always
+    ``os.getpid()`` of the caller -- a worker never flags itself, since the
+    comparison only considers a *different* pid found under the role key.
+
+    A competitor pid is only treated as a genuine conflict when it is
+    CONFIRMED LIVE: it must pass ``os.kill(pid, 0)`` AND have a heartbeat
+    timestamp fresher than ``HEARTBEAT_FRESHNESS_WINDOW``. A pid that fails
+    either check is dead-worker residue (the exact launchd-respawn case) --
+    it is silently superseded (this registration overwrites the role key)
+    with no log line, since logging a "conflict" for routine respawn churn
+    would be noise, not signal.
+
+    Only when a competitor pid is CONFIRMED LIVE does this emit
+    ``logger.warning`` and supersede the role key. Still never
+    exits/blocks/refuses in either branch.
+
+    Why this must NEVER refuse to start: under launchd ``KeepAlive``, an
+    unclean worker exit leaves the dead pid's TTL'd key present until its
+    TTL expires. A refuse-guard here would block the HEALTHY RESPAWNED
+    worker for that entire window -- an availability outage. The atomic
+    pending->running run-claim (``models.session_lifecycle.claim_pending_run``,
+    issue #1817 B2) is what makes exactly-one-actor-per-session correctness
+    hold; this probe is diagnostic only and always allows registration to
+    proceed.
+    """
+    from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+    role = _current_worker_role()
+    role_key = f"{_WORKER_ROLE_PID_KEY_PREFIX}{_ORPHAN_REAP_HOSTNAME}:{role}"
+
+    existing_raw = _R.get(role_key)
+    if existing_raw is not None:
+        try:
+            existing_pid = int(existing_raw)
+        except (TypeError, ValueError):
+            existing_pid = None
+
+        if existing_pid is not None and existing_pid != pid:
+            is_live = _pid_is_live(existing_pid)
+            heartbeat_fresh = is_live and _worker_pid_heartbeat_fresh(existing_pid)
+
+            if is_live and heartbeat_fresh:
+                logger.warning(
+                    "[session-health] second live worker for host=%s role=%s "
+                    "(existing pid=%d, new pid=%d) -- superseding pid registration",
+                    _ORPHAN_REAP_HOSTNAME,
+                    role,
+                    existing_pid,
+                    pid,
+                )
+            # else: dead/stale residue (liveness or heartbeat check failed) --
+            # silently supersede, no log. This is the routine launchd-respawn
+            # case, not a real conflict.
+
+    # Additive: this registration always proceeds and always overwrites the
+    # role key + this pid's heartbeat timestamp, regardless of the liveness
+    # outcome above. Never refuses.
+    now_ts = datetime.now(UTC).timestamp()
+    _R.set(role_key, pid, ex=WORKER_REGISTERED_PID_TTL_SECONDS)
+    _R.set(
+        f"{_WORKER_PID_HEARTBEAT_TS_KEY_PREFIX}{_ORPHAN_REAP_HOSTNAME}:{pid}",
+        now_ts,
+        ex=WORKER_REGISTERED_PID_TTL_SECONDS,
+    )
+
+
+def _pid_is_live(pid: int) -> bool:
+    """Return True if ``pid`` appears to be a live process on this host.
+
+    ``os.kill(pid, 0)`` sends no signal, only checks existence/permission.
+    A ``PermissionError`` means the process exists but is owned by another
+    user -- treated conservatively as live (we cannot confirm death, so we
+    do not silently supersede without evidence). Any other failure
+    (``ProcessLookupError``, etc.) means the pid is dead-worker residue.
+    """
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except Exception:
+        return False
+
+
+def _worker_pid_heartbeat_fresh(pid: int) -> bool:
+    """Return True if ``pid``'s last B2-probe heartbeat timestamp is fresh.
+
+    Reuses ``HEARTBEAT_FRESHNESS_WINDOW`` as the staleness threshold. Missing
+    or unparseable timestamps are treated as stale (fail toward "silently
+    supersede", not toward "log a conflict").
+    """
+    try:
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+        raw = _R.get(f"{_WORKER_PID_HEARTBEAT_TS_KEY_PREFIX}{_ORPHAN_REAP_HOSTNAME}:{pid}")
+        if raw is None:
+            return False
+        ts = float(raw)
+        return (datetime.now(UTC).timestamp() - ts) < HEARTBEAT_FRESHNESS_WINDOW
+    except Exception:
+        return False
 
 
 def _write_worker_heartbeat() -> None:

--- a/agent/session_pickup.py
+++ b/agent/session_pickup.py
@@ -475,6 +475,21 @@ async def _pop_agent_session(
         if chosen is None:
             return None
 
+        # Narrow SETNX run-claim (issue #1817 B2): gates ONLY this
+        # pending->running acquisition against other actors (CLI resume,
+        # catchup/reflections drip) that may independently target the same
+        # session_id. The generic CAS inside transition_status() is left
+        # completely untouched -- see the comment above
+        # models.session_lifecycle.claim_pending_run for the full rationale.
+        from models.session_lifecycle import claim_pending_run
+
+        if not claim_pending_run(chosen.session_id, worker_id=worker_key):
+            logger.info(
+                f"[worker:{worker_key}] Lost run-claim for session {chosen.id} "
+                f"(session {chosen.session_id}) -- another actor is handling it, skipping"
+            )
+            return None
+
         # Direct field mutation -- status is an IndexedField, not a KeyField,
         # so save() correctly updates the secondary index.
         logger.info(
@@ -609,6 +624,19 @@ async def _pop_agent_session_with_fallback(
             break
 
         if chosen is None:
+            return None
+
+        # Narrow SETNX run-claim (issue #1817 B2) -- same shared key as the
+        # async path above, so the two paths (and any other actor) contend
+        # for the SAME claim per session_id. See
+        # models.session_lifecycle.claim_pending_run for the full rationale.
+        from models.session_lifecycle import claim_pending_run
+
+        if not claim_pending_run(chosen.session_id, worker_id=worker_key):
+            logger.info(
+                f"[worker:{worker_key}] Sync fallback: lost run-claim for session {chosen.id} "
+                f"(session {chosen.session_id}) -- another actor is handling it, skipping"
+            )
             return None
 
         # Direct field mutation -- status is an IndexedField, not a KeyField.

--- a/bridge/catchup.py
+++ b/bridge/catchup.py
@@ -254,23 +254,47 @@ async def scan_for_missed_messages(
                     )
                     session_type = SessionType.ENG
 
-                await enqueue_agent_session_fn(
-                    project_key=project_key,
-                    session_id=session_id,
-                    working_dir=working_dir,
-                    message_text=text,
-                    sender_name=sender_name,
-                    chat_id=str(chat_id),
-                    telegram_message_id=message.id,
-                    chat_title=chat_title,
-                    priority="low",  # Lower priority than real-time messages
-                    sender_id=sender_id,
-                    session_type=session_type,
-                    project_config=project,
-                )
+                # Atomic per-message producer claim (issue #1817 B1, BLOCKER):
+                # shared key with the live handler (bridge/dispatch.py) and
+                # bridge/reconciler.py so a peer producer racing on this SAME
+                # message loses cleanly instead of double-enqueueing. A lost
+                # claim means a peer already won (or is winning) this message
+                # -- skip WITHOUT recording durable dedup, so a winner-death
+                # self-heals via the next reconciler scan re-picking the
+                # message instead of being silently dropped forever.
+                from bridge.dedup import claim_message, release_message_claim
 
-                # Record in Redis dedup to prevent re-enqueue on next scan,
-                # and advance the per-chat last-processed cursor (issue #1408).
+                if not await claim_message(chat_id, message.id):
+                    logger.info(
+                        f"[catchup] lost message claim for chat={chat_id} "
+                        f"msg={message.id} -- a peer producer won, skipping"
+                    )
+                    continue
+
+                try:
+                    await enqueue_agent_session_fn(
+                        project_key=project_key,
+                        session_id=session_id,
+                        working_dir=working_dir,
+                        message_text=text,
+                        sender_name=sender_name,
+                        chat_id=str(chat_id),
+                        telegram_message_id=message.id,
+                        chat_title=chat_title,
+                        priority="low",  # Lower priority than real-time messages
+                        sender_id=sender_id,
+                        session_type=session_type,
+                        project_config=project,
+                    )
+                except BaseException:
+                    # No orphan: release the claim so a retry (this scan's
+                    # next tick, or a peer) is not locked out for the TTL.
+                    await release_message_claim(chat_id, message.id)
+                    raise
+
+                # Only the winner writes the durable 2h membership record,
+                # and only AFTER its own successful enqueue -- see the
+                # BLOCKER rationale in bridge/dispatch.py's module docstring.
                 from bridge.dedup import record_last_processed, record_message_processed
 
                 await record_message_processed(chat_id, message.id)

--- a/bridge/dedup.py
+++ b/bridge/dedup.py
@@ -130,6 +130,89 @@ def _get_redis():
     return redis.Redis.from_url(redis_url, decode_responses=True)
 
 
+# --- Per-message atomic producer claim (issue #1817, workstream B1) ----------
+#
+# `bridge:msgclaim:{chat_id}:{message_id}` is a plain (non-Popoto-managed)
+# SETNX gate that stops two near-simultaneous producers -- e.g. two machines
+# both live during iCloud `projects.json` sync lag -- from BOTH passing the
+# pre-enqueue `is_duplicate_message` check and both enqueueing the same
+# inbound message. It is NOT a replacement for the durable 2h DedupRecord
+# membership set above: that set covers catchup/reconciler replay across the
+# ~1h sync-lag window. This claim only needs to survive the brief overlap
+# between two producers racing on the SAME message.
+#
+# GRAIN OF SALT: keep CLAIM_TTL_SECONDS short. A long TTL here was a BLOCKER
+# in an earlier critique round -- it would orphan the claim key for up to an
+# hour on a mid-window process death, and the reconciler's retry (which also
+# calls claim_message) would then hit the orphaned key, fail SET NX, wrongly
+# conclude "a peer won", and silently drop the message for up to an hour --
+# recreating the exact bug this claim exists to fix. Sized to cross-actor
+# processing skew (seconds), not the sync-lag/replay window.
+_MSG_CLAIM_KEY_PREFIX = "bridge:msgclaim:"
+
+
+def _claim_ttl_seconds() -> int:
+    """Resolve the provisional short TTL, env-overridable via config/settings.py."""
+    try:
+        from config.settings import settings
+
+        return settings.features.bridge_msg_claim_ttl_seconds
+    except Exception:
+        # Settings unavailable (e.g. isolated unit test import order) -- fall
+        # back to the documented provisional default.
+        return 60
+
+
+CLAIM_TTL_SECONDS = _claim_ttl_seconds()
+
+
+async def claim_message(chat_id, message_id: int, ttl: int | None = None) -> bool:
+    """Atomically claim the right to enqueue/handle this message.
+
+    Returns ``True`` if this caller won the claim (must proceed to
+    enqueue/handle the message). Returns ``False`` if another producer
+    already holds the claim (a peer won -- this caller must skip the
+    message without enqueuing or recording durable dedup).
+
+    Fails OPEN (returns ``True``) on Redis errors -- a Redis hiccup must not
+    silently drop messages; the durable 2h membership set and the caller's
+    own dedup checks remain as the fallback safety net.
+    """
+    try:
+        r = _get_redis()
+        key = f"{_MSG_CLAIM_KEY_PREFIX}{chat_id}:{message_id}"
+        acquired = r.set(key, "1", nx=True, ex=ttl if ttl is not None else CLAIM_TTL_SECONDS)
+        return bool(acquired)
+    except Exception as e:
+        logger.warning(
+            "message claim failed for chat=%s msg=%s (failing open): %s",
+            chat_id,
+            message_id,
+            e,
+        )
+        return True
+
+
+async def release_message_claim(chat_id, message_id: int) -> None:
+    """Release the claim on this message so a retry can re-acquire it.
+
+    Callers use this on the fail-safe path: if enqueue raises after the
+    claim was won, the claim must be released so a peer's retry (or this
+    same actor's own retry) is not permanently locked out by an orphaned
+    key sitting at its TTL. Never raises; best-effort.
+    """
+    try:
+        r = _get_redis()
+        r.delete(f"{_MSG_CLAIM_KEY_PREFIX}{chat_id}:{message_id}")
+    except Exception as e:
+        logger.warning(
+            "message claim release failed for chat=%s msg=%s: %s",
+            chat_id,
+            message_id,
+            e,
+        )
+
+
 async def record_last_event(chat_id, event_ts=None) -> None:
     """Record the timestamp of the most recent received event for a chat.
 

--- a/bridge/dispatch.py
+++ b/bridge/dispatch.py
@@ -13,9 +13,22 @@ enqueuing -- the reconciler treats the message as handled and skips it on its
 next 3-minute scan.
 
 Recovery paths (``bridge/catchup.py``, ``bridge/reconciler.py``) intentionally
-do NOT use this wrapper. They know they are writing to dedup and keep their
-explicit two-step pairing so future maintainers can see that these paths are
-different from the live handler's dispatch.
+do NOT use this wrapper function. They know they are writing to dedup and
+keep their explicit two-step pairing so future maintainers can see that these
+paths are different from the live handler's dispatch. The bypass is about the
+wrapper function only, NOT about skipping the concurrency gate: both recovery
+paths ALSO call :func:`bridge.dedup.claim_message` immediately before their
+own enqueue call sites, sharing the SAME claim key
+(``bridge:msgclaim:{chat_id}:{message_id}``) as this module (issue #1817,
+workstream B1, BLOCKER). Using a shared key -- not a distinct per-path key --
+is what closes the cross-path double-enqueue race: the live handler and a
+recovery scan racing on the same message contend for the same claim, so at
+most one of them wins and enqueues.
+
+The claim gate releases on ANY enqueue exception (see
+:func:`dispatch_telegram_session` below and the equivalent try/except around
+each recovery path's enqueue call) so a mid-flight process death never
+orphans the claim key beyond its short TTL.
 """
 
 from __future__ import annotations
@@ -23,7 +36,12 @@ from __future__ import annotations
 import logging
 
 from agent.agent_session_queue import enqueue_agent_session
-from bridge.dedup import record_last_processed, record_message_processed
+from bridge.dedup import (
+    claim_message,
+    record_last_processed,
+    record_message_processed,
+    release_message_claim,
+)
 from config.enums import SessionType
 
 logger = logging.getLogger(__name__)
@@ -90,7 +108,7 @@ async def dispatch_telegram_session(
     extra_context_overrides: dict | None = None,
     requires_real_chrome: bool = False,
     message_ts=None,
-) -> int:
+) -> int | None:
     """Enqueue a Telegram-originating session and record dedup.
 
     Signature mirrors :func:`agent.agent_session_queue.enqueue_agent_session`
@@ -101,39 +119,62 @@ async def dispatch_telegram_session(
     NOT record dedup -- the reconciler will pick the message up on its next
     scan, which is the correct recovery behavior.
 
-    This wrapper does NOT catch exceptions from ``enqueue_agent_session``.
-    A failed enqueue propagates so the caller can log/handle, and leaves
-    dedup unrecorded so the reconciler can retry.
+    Atomic per-message claim (issue #1817 B1, BLOCKER): before enqueueing,
+    this function claims ``(chat_id, telegram_message_id)`` via
+    :func:`bridge.dedup.claim_message`. If the claim is lost, a peer producer
+    (e.g. another machine live during iCloud config sync lag, or a recovery
+    scan racing the same message) already won -- this call returns ``None``
+    without enqueuing or recording dedup. If ``enqueue_agent_session`` raises
+    after the claim was won, the claim is released before re-raising so the
+    short TTL never orphans past what it takes to retry -- preserving the
+    documented propagate-and-retry contract (dedup stays unrecorded, the
+    reconciler will pick the message up on its next scan).
 
     Returns:
-        The queue depth returned by ``enqueue_agent_session``.
+        The queue depth returned by ``enqueue_agent_session``, or ``None``
+        if a peer producer already claimed this message.
     """
-    depth = await enqueue_agent_session(
-        project_key=project_key,
-        session_id=session_id,
-        working_dir=working_dir,
-        message_text=message_text,
-        sender_name=sender_name,
-        chat_id=chat_id,
-        telegram_message_id=telegram_message_id,
-        chat_title=chat_title,
-        priority=priority,
-        revival_context=revival_context,
-        sender_id=sender_id,
-        slug=slug,
-        task_list_id=task_list_id,
-        classification_type=classification_type,
-        auto_continue_count=auto_continue_count,
-        correlation_id=correlation_id,
-        scheduled_at=scheduled_at,
-        parent_agent_session_id=parent_agent_session_id,
-        telegram_message_key=telegram_message_key,
-        session_type=session_type,
-        scheduling_depth=scheduling_depth,
-        project_config=project_config,
-        extra_context_overrides=extra_context_overrides,
-        requires_real_chrome=requires_real_chrome,
-    )
+    if not await claim_message(chat_id, telegram_message_id):
+        logger.info(
+            "dispatch: lost message claim for chat=%s msg=%s -- a peer producer won, skipping",
+            chat_id,
+            telegram_message_id,
+        )
+        return None
+
+    try:
+        depth = await enqueue_agent_session(
+            project_key=project_key,
+            session_id=session_id,
+            working_dir=working_dir,
+            message_text=message_text,
+            sender_name=sender_name,
+            chat_id=chat_id,
+            telegram_message_id=telegram_message_id,
+            chat_title=chat_title,
+            priority=priority,
+            revival_context=revival_context,
+            sender_id=sender_id,
+            slug=slug,
+            task_list_id=task_list_id,
+            classification_type=classification_type,
+            auto_continue_count=auto_continue_count,
+            correlation_id=correlation_id,
+            scheduled_at=scheduled_at,
+            parent_agent_session_id=parent_agent_session_id,
+            telegram_message_key=telegram_message_key,
+            session_type=session_type,
+            scheduling_depth=scheduling_depth,
+            project_config=project_config,
+            extra_context_overrides=extra_context_overrides,
+            requires_real_chrome=requires_real_chrome,
+        )
+    except BaseException:
+        # No orphan: release the claim so a retry is not locked out for the
+        # TTL. Preserves the propagate-and-retry contract documented above.
+        await release_message_claim(chat_id, telegram_message_id)
+        raise
+
     # Record inbound message in the session's chat_message_log (issue #1192).
     # Called after enqueue so the AgentSession record exists in Redis.
     # Failures are non-fatal — the chat log is enrichment, not a critical path.
@@ -167,7 +208,20 @@ async def record_telegram_message_handled(chat_id, telegram_message_id: int) -> 
     outcomes from the enqueue path. The underlying
     :func:`bridge.dedup.record_message_processed` already swallows exceptions
     and logs at warning level, so this function never raises either.
+
+    Gated by the same atomic per-message claim as
+    :func:`dispatch_telegram_session` (issue #1817 B1) so a peer producer
+    racing on this SAME message is claimed exactly once, regardless of
+    whether the winner takes the enqueue branch or this non-enqueue branch.
     """
+    if not await claim_message(chat_id, telegram_message_id):
+        logger.debug(
+            "telegram message handled without enqueue: lost claim for chat=%s msg=%s "
+            "-- a peer producer won, skipping",
+            chat_id,
+            telegram_message_id,
+        )
+        return
     logger.debug(
         "telegram message handled without enqueue: chat=%s msg=%s",
         chat_id,

--- a/bridge/reconciler.py
+++ b/bridge/reconciler.py
@@ -13,9 +13,11 @@ import logging
 from datetime import UTC, datetime, timedelta
 
 from bridge.dedup import (
+    claim_message,
     is_duplicate_message,
     record_last_processed,
     record_message_processed,
+    release_message_claim,
 )
 from bridge.routing import persona_to_session_type, resolve_persona
 from bridge.silent_stream import SilentStreamState, check_silent_chat
@@ -236,21 +238,47 @@ async def reconcile_once(
                     )
                     session_type = SessionType.ENG
 
-                await enqueue_agent_session_fn(
-                    project_key=project_key,
-                    session_id=session_id,
-                    working_dir=working_dir,
-                    message_text=text,
-                    sender_name=sender_name,
-                    chat_id=str(chat_id),
-                    telegram_message_id=message.id,
-                    chat_title=chat_title,
-                    priority="low",
-                    sender_id=sender_id,
-                    session_type=session_type,
-                    project_config=project,
-                )
+                # Atomic per-message producer claim (issue #1817 B1, BLOCKER):
+                # shared key with the live handler (bridge/dispatch.py) and
+                # bridge/catchup.py so a peer producer racing on this SAME
+                # message loses cleanly instead of double-enqueueing. A lost
+                # claim means a peer already won (or is winning) this message
+                # -- skip WITHOUT recording durable dedup, so a winner-death
+                # self-heals via the next reconciler scan re-picking the
+                # message instead of being silently dropped forever.
+                if not await claim_message(chat_id, message.id):
+                    logger.info(
+                        "[reconciler] lost message claim for chat=%s msg=%s "
+                        "-- a peer producer won, skipping",
+                        chat_id,
+                        message.id,
+                    )
+                    continue
 
+                try:
+                    await enqueue_agent_session_fn(
+                        project_key=project_key,
+                        session_id=session_id,
+                        working_dir=working_dir,
+                        message_text=text,
+                        sender_name=sender_name,
+                        chat_id=str(chat_id),
+                        telegram_message_id=message.id,
+                        chat_title=chat_title,
+                        priority="low",
+                        sender_id=sender_id,
+                        session_type=session_type,
+                        project_config=project,
+                    )
+                except BaseException:
+                    # No orphan: release the claim so a retry (this scan's
+                    # next tick, or a peer) is not locked out for the TTL.
+                    await release_message_claim(chat_id, message.id)
+                    raise
+
+                # Only the winner writes the durable 2h membership record,
+                # and only AFTER its own successful enqueue -- see the
+                # BLOCKER rationale in bridge/dispatch.py's module docstring.
                 await record_message_processed(chat_id, message.id)
                 await record_last_processed(chat_id, message.id, message.date)
                 recovered += 1

--- a/config/settings.py
+++ b/config/settings.py
@@ -344,6 +344,31 @@ class FeatureSettings(BaseModel):
         ),
     )
 
+    # --- Per-message producer claim (issue #1817 B1) ---
+    # GRAIN OF SALT: this TTL must stay SHORT -- sized to cross-actor
+    # processing skew (seconds), NOT the ~1h iCloud projects.json sync-lag
+    # window. The durable 2h DedupRecord membership set (models/dedup.py)
+    # already covers the sync-lag/replay window; this gate only needs to
+    # survive the brief overlap between two producers racing on the SAME
+    # message. A long TTL here was a BLOCKER in an earlier critique round:
+    # it would orphan the claim key for up to an hour on a mid-window
+    # process death, causing the reconciler's retry to wrongly conclude a
+    # peer won and silently drop the message for that entire window --
+    # recreating the exact bug this claim exists to fix.
+    bridge_msg_claim_ttl_seconds: int = Field(
+        default=60,
+        ge=5,
+        le=300,
+        description=(
+            "Provisional short TTL (seconds) for the bridge:msgclaim:* SETNX "
+            "gate in bridge/dedup.py that prevents two near-simultaneous "
+            "producers (e.g. two machines during iCloud config sync lag) from "
+            "both enqueueing the same inbound Telegram message. Must stay "
+            "short (cross-actor skew, not sync-lag window) -- see the "
+            "comment above this field. Env: FEATURES__BRIDGE_MSG_CLAIM_TTL_SECONDS."
+        ),
+    )
+
 
 class GraniteSettings(BaseModel):
     """Granite PTY container configuration (plan #1572).

--- a/models/session_lifecycle.py
+++ b/models/session_lifecycle.py
@@ -684,6 +684,67 @@ def transition_status(
             pass
 
 
+# Short-TTL SETNX gate protecting ONLY the pending->running acquisition
+# (issue #1817, workstream B2). GRAIN OF SALT for future maintainers:
+#
+# This is a narrow, ADDITIVE gate -- it is not, and must never become, a
+# replacement for the generic optimistic-concurrency CAS inside
+# transition_status() above (the `on_disk_status != current_status` compare).
+# That CAS governs EVERY non-terminal status edge in the system -- paused,
+# superseded, kill, finalize, and this same plan's own C1 fix, which
+# transitions a parent out of waiting_for_children via transition_status().
+# An earlier critique round flagged deleting/replacing that CAS as a
+# BLOCKER: it would strip optimistic-concurrency protection from every
+# other edge, a correctness regression far worse than the bug this claim
+# fixes. Do not delete it, and do not fold this claim's logic into it.
+#
+# Why pending->running specifically needs an extra gate: multiple
+# independent actors (the worker's pop loop, the valor-session CLI resume
+# path, catchup/reflections drip) can each read the SAME pending session
+# and race to become the one that runs it. The run-claim SETNX makes the
+# read-then-transition sequence atomic from the caller's perspective: only
+# the actor that wins the SETNX proceeds to call
+# transition_status(session, "running", ...); the loser skips the
+# candidate entirely. This guarantees at most one actor ever attempts the
+# transition for a given session_id -- the CAS above remains as the
+# second line of defense for the transition the winner performs, and as
+# the ONLY defense for every other status edge.
+RUN_CLAIM_TTL_SECONDS = 30  # short: only needs to cover the query -> transition_status window
+
+
+def claim_pending_run(session_id: str, worker_id: str, ttl: int = RUN_CLAIM_TTL_SECONDS) -> bool:
+    """Atomically claim the right to transition ``session_id`` from pending to running.
+
+    Returns ``True`` if this caller won the claim -- it must proceed to call
+    ``transition_status(session, "running", ...)``. Returns ``False`` if
+    another actor already holds the claim -- the caller must skip this
+    session (a peer is handling it, or already did).
+
+    Backed by a plain (non-Popoto-managed) Redis key
+    ``session:runclaim:{session_id}``, matching the existing ``SET NX``
+    idiom used elsewhere for short-lived coordination locks (see
+    ``agent/session_health.py`` and ``agent/session_pickup.py``). This is
+    NOT a general-purpose lock manager -- it exists solely to gate this one
+    transition.
+
+    Fails OPEN (returns ``True``) on Redis errors: a Redis hiccup degrades
+    to today's CAS-only protection rather than starving the pending queue.
+    """
+    try:
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+        key = f"session:runclaim:{session_id}"
+        acquired = _R.set(key, worker_id, nx=True, ex=ttl)
+        return bool(acquired)
+    except Exception as e:
+        logger.warning(
+            "[session-lifecycle] run-claim acquisition failed for %s (failing open): %s",
+            session_id,
+            e,
+        )
+        return True
+
+
 def _finalize_parent_sync(
     parent_id: str,
     completing_child_id: str | None = None,

--- a/scripts/migrate_steering_queue_drain.py
+++ b/scripts/migrate_steering_queue_drain.py
@@ -114,6 +114,10 @@ def migrate(apply: bool = False) -> dict:
                 f"into steering:{session_id}"
             )
             if apply:
+                # Deliberate at-least-once: push-all then hdel is not atomic, so a
+                # death between the two re-delivers these entries on the next --apply
+                # run. Duplicating an ephemeral steer is preferable to losing a human
+                # course-correction.
                 for text in entries:
                     push_steering_message(session_id, str(text), "migration-drain")
                 redis_client.hdel(key, "queued_steering_messages")

--- a/tests/unit/bridge/test_dispatch.py
+++ b/tests/unit/bridge/test_dispatch.py
@@ -1,0 +1,116 @@
+"""Unit tests for bridge/dispatch.py's atomic per-message claim (issue #1817 B1).
+
+Covers the live-handler wrapper's claim-before-enqueue gate and the
+delete-on-exception fail-safe. These are the BLOCKER-level behaviors flagged
+in the plan's critique rounds:
+
+1. A lost claim (a peer producer already won) must skip enqueue entirely.
+2. If ``enqueue_agent_session`` raises after the claim was won, the claim
+   key must be released (no orphan) BEFORE the exception propagates, and
+   dedup must stay unrecorded so the message remains re-enqueueable.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from bridge.dispatch import dispatch_telegram_session
+
+
+def _base_kwargs(**overrides):
+    kwargs = dict(
+        project_key="test-project",
+        session_id="test-session-1",
+        working_dir="/tmp/test",
+        message_text="hello",
+        sender_name="Tom",
+        chat_id="test-chat-1",
+        telegram_message_id=101,
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+class TestDispatchClaimGate:
+    @pytest.mark.asyncio
+    async def test_lost_claim_skips_enqueue(self):
+        """A lost claim must skip enqueue and return None without recording dedup."""
+        with (
+            patch("bridge.dispatch.claim_message", new=AsyncMock(return_value=False)),
+            patch("bridge.dispatch.enqueue_agent_session", new=AsyncMock()) as mock_enqueue,
+            patch("bridge.dispatch.record_message_processed", new=AsyncMock()) as mock_record,
+            patch("bridge.dispatch.record_last_processed", new=AsyncMock()),
+            patch("bridge.dispatch.release_message_claim", new=AsyncMock()) as mock_release,
+        ):
+            result = await dispatch_telegram_session(**_base_kwargs())
+
+        assert result is None
+        mock_enqueue.assert_not_called()
+        mock_record.assert_not_called()
+        # Nothing to release -- the claim was never won by this caller.
+        mock_release.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_won_claim_proceeds_to_enqueue(self):
+        """A won claim must proceed to enqueue and record dedup as before."""
+        with (
+            patch("bridge.dispatch.claim_message", new=AsyncMock(return_value=True)),
+            patch(
+                "bridge.dispatch.enqueue_agent_session", new=AsyncMock(return_value=3)
+            ) as mock_enqueue,
+            patch("bridge.dispatch.record_message_processed", new=AsyncMock()) as mock_record,
+            patch("bridge.dispatch.record_last_processed", new=AsyncMock()),
+            patch("bridge.dispatch._append_inbound_chat_log"),
+        ):
+            result = await dispatch_telegram_session(**_base_kwargs())
+
+        assert result == 3
+        mock_enqueue.assert_awaited_once()
+        mock_record.assert_awaited_once_with("test-chat-1", 101)
+
+    @pytest.mark.asyncio
+    async def test_enqueue_exception_releases_claim_no_orphan(self):
+        """A fault-injected enqueue exception must release the claim (no
+        orphan) before propagating, and dedup must stay unrecorded so the
+        message remains re-enqueueable (BLOCKER, issue #1817).
+        """
+        boom = RuntimeError("enqueue boom")
+        with (
+            patch("bridge.dispatch.claim_message", new=AsyncMock(return_value=True)),
+            patch("bridge.dispatch.enqueue_agent_session", new=AsyncMock(side_effect=boom)),
+            patch("bridge.dispatch.record_message_processed", new=AsyncMock()) as mock_record,
+            patch("bridge.dispatch.record_last_processed", new=AsyncMock()) as mock_cursor,
+            patch("bridge.dispatch.release_message_claim", new=AsyncMock()) as mock_release,
+        ):
+            with pytest.raises(RuntimeError, match="enqueue boom"):
+                await dispatch_telegram_session(**_base_kwargs())
+
+        mock_release.assert_awaited_once_with("test-chat-1", 101)
+        mock_record.assert_not_called()
+        mock_cursor.assert_not_called()
+
+
+class TestRecordTelegramMessageHandledClaimGate:
+    @pytest.mark.asyncio
+    async def test_lost_claim_skips_record(self):
+        from bridge.dispatch import record_telegram_message_handled
+
+        with (
+            patch("bridge.dispatch.claim_message", new=AsyncMock(return_value=False)),
+            patch("bridge.dispatch.record_message_processed", new=AsyncMock()) as mock_record,
+        ):
+            await record_telegram_message_handled("test-chat-1", 202)
+
+        mock_record.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_won_claim_records(self):
+        from bridge.dispatch import record_telegram_message_handled
+
+        with (
+            patch("bridge.dispatch.claim_message", new=AsyncMock(return_value=True)),
+            patch("bridge.dispatch.record_message_processed", new=AsyncMock()) as mock_record,
+        ):
+            await record_telegram_message_handled("test-chat-1", 202)
+
+        mock_record.assert_awaited_once_with("test-chat-1", 202)

--- a/tests/unit/test_catchup_claim.py
+++ b/tests/unit/test_catchup_claim.py
@@ -82,9 +82,9 @@ class TestCatchupClaimGate:
         """A lost claim skips enqueue AND leaves no durable dedup (BLOCKER).
 
         This is the exact round-4 scenario: a peer producer already won this
-        message. The loser must not call record_message_processed, so a
-        winner-death self-heals via the next scan instead of the message
-        being silently dropped forever.
+        message. The loser must not call record_message_processed (it does
+        not double-record), so if the winner dies before enqueue a re-scan
+        self-heals instead of the message being silently dropped forever.
         """
         dialog = _make_dialog("Test Group", entity_id=400)
         msg = _make_message(700, text="missed message")

--- a/tests/unit/test_catchup_claim.py
+++ b/tests/unit/test_catchup_claim.py
@@ -1,0 +1,182 @@
+"""Unit tests for the atomic per-message claim in bridge/catchup.py (issue #1817 B1).
+
+``scan_for_missed_messages`` is the startup recovery scanner. It intentionally
+bypasses ``bridge/dispatch.py``'s wrapper function but shares the SAME
+``claim_message``/``release_message_claim`` gate (same Redis key shape) so a
+peer producer (the live handler, or the periodic reconciler) racing on the
+SAME message loses cleanly instead of double-enqueueing.
+
+These tests mock the Telethon client, routing, and enqueue functions; they
+patch ``bridge.dedup.claim_message`` / ``bridge.dedup.release_message_claim``
+directly since ``bridge/catchup.py`` imports them with a local (in-function)
+``from bridge.dedup import ...`` -- patching the source module's attribute is
+what actually takes effect for a fresh local import on each call.
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bridge.catchup import scan_for_missed_messages
+
+
+def _make_message(msg_id, text="hello", out=False, minutes_ago=1):
+    msg = MagicMock()
+    msg.id = msg_id
+    msg.text = text
+    msg.out = out
+    msg.date = datetime.now(UTC) - timedelta(minutes=minutes_ago)
+    msg.reply_to_msg_id = None
+
+    sender = MagicMock()
+    sender.first_name = "TestUser"
+    sender.username = "testuser"
+    sender.id = 12345
+    msg.get_sender = AsyncMock(return_value=sender)
+    return msg
+
+
+def _make_dialog(chat_title, entity_id=100, chat_id=None):
+    dialog = MagicMock()
+    dialog.entity = MagicMock()
+    dialog.entity.title = chat_title
+    dialog.entity.id = entity_id
+    dialog.id = chat_id if chat_id is not None else -(1000000000000 + entity_id)
+    return dialog
+
+
+def _make_project(key="testproj", working_dir="/tmp/test"):
+    return {"_key": key, "working_directory": working_dir}
+
+
+def _client_for(dialog, message):
+    """A client whose get_messages returns the message for the main scan and
+    an empty list for the ``_check_if_handled`` re-read (distinguished by the
+    presence of ``min_id``)."""
+    client = AsyncMock()
+    client.get_dialogs = AsyncMock(return_value=[dialog])
+
+    async def _get_messages(entity, limit=None, min_id=None):
+        if min_id is not None:
+            return []  # _check_if_handled: no reply found
+        return [message]
+
+    client.get_messages = AsyncMock(side_effect=_get_messages)
+    return client
+
+
+_PATCH_TARGETS = (
+    "bridge.dedup.is_duplicate_message",
+    "bridge.dedup.get_last_processed",
+    "bridge.dedup.record_message_processed",
+    "bridge.dedup.record_last_processed",
+    "bridge.dedup.claim_message",
+    "bridge.dedup.release_message_claim",
+)
+
+
+class TestCatchupClaimGate:
+    @pytest.mark.asyncio
+    async def test_lost_claim_skips_enqueue_and_dedup(self):
+        """A lost claim skips enqueue AND leaves no durable dedup (BLOCKER).
+
+        This is the exact round-4 scenario: a peer producer already won this
+        message. The loser must not call record_message_processed, so a
+        winner-death self-heals via the next scan instead of the message
+        being silently dropped forever.
+        """
+        dialog = _make_dialog("Test Group", entity_id=400)
+        msg = _make_message(700, text="missed message")
+        client = _client_for(dialog, msg)
+        enqueue_fn = AsyncMock()
+
+        with (
+            patch("bridge.dedup.is_duplicate_message", new_callable=AsyncMock, return_value=False),
+            patch("bridge.dedup.get_last_processed", new_callable=AsyncMock, return_value=None),
+            patch("bridge.dedup.record_message_processed", new_callable=AsyncMock) as rec_processed,
+            patch("bridge.dedup.record_last_processed", new_callable=AsyncMock) as rec_last,
+            patch("bridge.dedup.claim_message", new_callable=AsyncMock, return_value=False),
+            patch("bridge.dedup.release_message_claim", new_callable=AsyncMock) as release,
+        ):
+            queued = await scan_for_missed_messages(
+                client=client,
+                monitored_groups=["test group"],
+                projects_config={},
+                should_respond_fn=AsyncMock(return_value=(True, False)),
+                enqueue_agent_session_fn=enqueue_fn,
+                find_project_fn=MagicMock(return_value=_make_project()),
+            )
+
+        assert queued == 0
+        enqueue_fn.assert_not_called()
+        rec_processed.assert_not_called()
+        rec_last.assert_not_called()
+        # Nothing to release -- the claim was never won by this caller.
+        release.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_won_claim_enqueues_and_records_dedup(self):
+        """A won claim proceeds to enqueue and records durable dedup as before."""
+        dialog = _make_dialog("Test Group", entity_id=401)
+        msg = _make_message(701, text="missed message")
+        client = _client_for(dialog, msg)
+        enqueue_fn = AsyncMock()
+
+        with (
+            patch("bridge.dedup.is_duplicate_message", new_callable=AsyncMock, return_value=False),
+            patch("bridge.dedup.get_last_processed", new_callable=AsyncMock, return_value=None),
+            patch("bridge.dedup.record_message_processed", new_callable=AsyncMock) as rec_processed,
+            patch("bridge.dedup.record_last_processed", new_callable=AsyncMock) as rec_last,
+            patch("bridge.dedup.claim_message", new_callable=AsyncMock, return_value=True),
+            patch("bridge.dedup.release_message_claim", new_callable=AsyncMock) as release,
+        ):
+            queued = await scan_for_missed_messages(
+                client=client,
+                monitored_groups=["test group"],
+                projects_config={},
+                should_respond_fn=AsyncMock(return_value=(True, False)),
+                enqueue_agent_session_fn=enqueue_fn,
+                find_project_fn=MagicMock(return_value=_make_project()),
+            )
+
+        assert queued == 1
+        enqueue_fn.assert_called_once()
+        rec_processed.assert_called_once_with(dialog.id, 701)
+        rec_last.assert_called_once_with(dialog.id, 701, msg.date)
+        release.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_enqueue_exception_releases_claim_no_orphan(self):
+        """A fault-injected enqueue exception releases the claim before the
+        per-group except/continue swallows it, and dedup stays unrecorded.
+        """
+        dialog = _make_dialog("Test Group", entity_id=402)
+        msg = _make_message(702, text="missed message")
+        client = _client_for(dialog, msg)
+        enqueue_fn = AsyncMock(side_effect=RuntimeError("enqueue boom"))
+
+        with (
+            patch("bridge.dedup.is_duplicate_message", new_callable=AsyncMock, return_value=False),
+            patch("bridge.dedup.get_last_processed", new_callable=AsyncMock, return_value=None),
+            patch("bridge.dedup.record_message_processed", new_callable=AsyncMock) as rec_processed,
+            patch("bridge.dedup.record_last_processed", new_callable=AsyncMock),
+            patch("bridge.dedup.claim_message", new_callable=AsyncMock, return_value=True),
+            patch("bridge.dedup.release_message_claim", new_callable=AsyncMock) as release,
+        ):
+            # scan_for_missed_messages wraps the per-group body in a broad
+            # try/except that logs and continues to the next group -- the
+            # exception does not propagate out of the function, but the
+            # claim release must have happened before it was swallowed.
+            queued = await scan_for_missed_messages(
+                client=client,
+                monitored_groups=["test group"],
+                projects_config={},
+                should_respond_fn=AsyncMock(return_value=(True, False)),
+                enqueue_agent_session_fn=enqueue_fn,
+                find_project_fn=MagicMock(return_value=_make_project()),
+            )
+
+        assert queued == 0
+        release.assert_called_once_with(dialog.id, 702)
+        rec_processed.assert_not_called()

--- a/tests/unit/test_dedup.py
+++ b/tests/unit/test_dedup.py
@@ -128,3 +128,65 @@ class TestDedupFunctions:
         with patch("models.dedup.DedupRecord.get_or_create", side_effect=RuntimeError("boom")):
             # Should not raise
             await record_message_processed("test_err", 1)
+
+
+class TestMessageClaim:
+    """Tests for the atomic per-message producer claim (issue #1817 B1).
+
+    ``claim_message``/``release_message_claim`` are backed by a plain
+    (non-Popoto-managed) Redis SETNX key, distinct from the DedupRecord
+    membership set above. Tests use the real Redis client via
+    ``bridge.dedup._get_redis()`` and clean up their own keys.
+    """
+
+    def _cleanup(self, chat_id, message_id):
+        from bridge.dedup import _MSG_CLAIM_KEY_PREFIX, _get_redis
+
+        _get_redis().delete(f"{_MSG_CLAIM_KEY_PREFIX}{chat_id}:{message_id}")
+
+    def teardown_method(self):
+        self._cleanup("test_claim_chat", 1)
+        self._cleanup("test_claim_chat", 2)
+        self._cleanup("test_claim_release", 1)
+
+    @pytest.mark.asyncio
+    async def test_claim_fresh_id_succeeds(self):
+        """claim_message on a fresh (chat_id, message_id) returns True."""
+        from bridge.dedup import claim_message
+
+        result = await claim_message("test_claim_chat", 1)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_claim_already_claimed_fails(self):
+        """A second claim on the same (chat_id, message_id) returns False."""
+        from bridge.dedup import claim_message
+
+        first = await claim_message("test_claim_chat", 2)
+        second = await claim_message("test_claim_chat", 2)
+        assert first is True
+        assert second is False
+
+    @pytest.mark.asyncio
+    async def test_release_message_claim_deletes_key(self):
+        """release_message_claim deletes the key so a retry can re-acquire it."""
+        from bridge.dedup import claim_message, release_message_claim
+
+        assert await claim_message("test_claim_release", 1) is True
+        await release_message_claim("test_claim_release", 1)
+        # Re-acquisition succeeds only if the key was actually deleted.
+        assert await claim_message("test_claim_release", 1) is True
+
+    def test_claim_ttl_is_seconds_scoped_and_short(self):
+        """CLAIM_TTL_SECONDS must be short (cross-actor skew), decoupled from
+        the 2h DedupRecord membership TTL used for sync-lag/replay coverage.
+        """
+        from bridge.dedup import CLAIM_TTL_SECONDS
+        from models.dedup import DedupRecord
+
+        assert isinstance(CLAIM_TTL_SECONDS, int)
+        # "Short" per the plan: sized to cross-actor processing skew
+        # (seconds), not the ~1h sync-lag window. Generous upper bound of
+        # 5 minutes still rules out anything resembling the durable window.
+        assert 0 < CLAIM_TTL_SECONDS <= 300
+        assert CLAIM_TTL_SECONDS != DedupRecord._meta.ttl

--- a/tests/unit/test_migrate_steering_queue_drain.py
+++ b/tests/unit/test_migrate_steering_queue_drain.py
@@ -95,11 +95,6 @@ def residual_key():
 
 
 @pytest.fixture()
-def clean_key():
-    return b"AgentSession:def456:eng:test-project:completed"
-
-
-@pytest.fixture()
 def index_keys():
     return [
         b"AgentSession:_sorted_set:session_type:eng",
@@ -181,20 +176,51 @@ class TestLiveRun:
 
 
 class TestIdempotency:
-    def test_second_run_finds_nothing_to_migrate(self, clean_key):
-        hash_data = {clean_key: {"session_id": "sess-def456"}}
-        redis_mock = _make_redis([clean_key], hash_data)
+    def test_true_double_run_is_idempotent(self, residual_key):
+        """Two consecutive --apply runs against the same state.
+
+        The first run drains the residual field onto the steering list. The
+        second run sees a genuinely-drained record: it migrates zero and adds
+        no duplicate entries to the list the first run built.
+        """
+        hash_data = {
+            residual_key: {
+                "session_id": "sess-abc123",
+                "queued_steering_messages": json.dumps(["focus on OAuth", "check tests"]),
+            },
+        }
+        redis_mock = _make_redis([residual_key], hash_data)
         popoto_mod = _make_popoto(redis_mock)
-        push_mock = MagicMock()
+
+        # Model the steering list so we can assert its content across both runs.
+        steering_list: list[tuple[str, str]] = []
+
+        def push_side_effect(session_id, text, sender):
+            steering_list.append((session_id, text))
+
+        push_mock = MagicMock(side_effect=push_side_effect)
         mod = _load_module()
 
         with _patched_modules(popoto_mod, push_mock):
-            stats = mod.migrate(apply=True)
+            stats_first = mod.migrate(apply=True)
+            stats_second = mod.migrate(apply=True)
 
-        push_mock.assert_not_called()
-        redis_mock.hdel.assert_not_called()
-        assert stats["drained"] == 0
-        assert stats["already_clean"] == 1
+        expected_list = [
+            ("sess-abc123", "focus on OAuth"),
+            ("sess-abc123", "check tests"),
+        ]
+
+        # First run drained both messages onto the list.
+        assert stats_first["drained"] == 1
+        assert stats_first["messages_migrated"] == 2
+        assert steering_list == expected_list
+
+        # Second run: nothing left to migrate, no duplicate pushes, list unchanged.
+        assert stats_second["drained"] == 0
+        assert stats_second["messages_migrated"] == 0
+        assert stats_second["already_clean"] == 1
+        assert push_mock.call_count == 2  # no additional pushes on the second run
+        assert steering_list == expected_list
 
     def test_empty_list_field_is_cleaned_without_pushing(self, residual_key):
         hash_data = {

--- a/tests/unit/test_reconciler.py
+++ b/tests/unit/test_reconciler.py
@@ -111,6 +111,7 @@ class TestReconcileOnce:
             patch(
                 "bridge.reconciler.is_duplicate_message", new_callable=AsyncMock, return_value=False
             ),
+            patch("bridge.reconciler.claim_message", new_callable=AsyncMock, return_value=True),
             patch("bridge.reconciler.record_message_processed", new_callable=AsyncMock),
         ):
             result = await reconcile_once(
@@ -140,6 +141,7 @@ class TestReconcileOnce:
             patch(
                 "bridge.reconciler.is_duplicate_message", new_callable=AsyncMock, return_value=False
             ),
+            patch("bridge.reconciler.claim_message", new_callable=AsyncMock, return_value=True),
             patch("bridge.reconciler.record_message_processed", new_callable=AsyncMock),
         ):
             result = await reconcile_once(
@@ -169,6 +171,7 @@ class TestReconcileOnce:
             patch(
                 "bridge.reconciler.is_duplicate_message", new_callable=AsyncMock, return_value=False
             ),
+            patch("bridge.reconciler.claim_message", new_callable=AsyncMock, return_value=True),
             patch("bridge.reconciler.record_message_processed", new_callable=AsyncMock),
         ):
             result = await reconcile_once(
@@ -199,6 +202,7 @@ class TestReconcileOnce:
             patch(
                 "bridge.reconciler.is_duplicate_message", new_callable=AsyncMock, return_value=False
             ),
+            patch("bridge.reconciler.claim_message", new_callable=AsyncMock, return_value=True),
             patch("bridge.reconciler.record_message_processed", new_callable=AsyncMock),
         ):
             result = await reconcile_once(
@@ -231,6 +235,7 @@ class TestReconcileOnce:
             patch(
                 "bridge.reconciler.is_duplicate_message", new_callable=AsyncMock, return_value=False
             ),
+            patch("bridge.reconciler.claim_message", new_callable=AsyncMock, return_value=True),
             patch("bridge.reconciler.record_message_processed", record_fn),
             patch("bridge.reconciler.record_last_processed", cursor_fn),
         ):
@@ -256,6 +261,96 @@ class TestReconcileOnce:
         cursor_fn.assert_called_once_with(expected_chat_id, 555, msg.date)
 
     @pytest.mark.asyncio
+    async def test_lost_claim_skips_enqueue_and_leaves_no_dedup(self):
+        """A lost message claim skips enqueue AND leaves no durable dedup (BLOCKER).
+
+        Issue #1817 B1, round-4 BLOCKER: this is the exact scenario where a
+        peer producer (the live handler, or catchup) already won the SAME
+        message. The loser must not call record_message_processed, so a
+        winner-death self-heals via the next reconciler scan re-picking the
+        never-enqueued message instead of silently dropping it forever.
+        """
+        dialog = _make_dialog("Test Group", entity_id=250)
+        msg = _make_message(556, text="raced message")
+
+        client = AsyncMock()
+        client.get_dialogs = AsyncMock(return_value=[dialog])
+        client.get_messages = AsyncMock(return_value=[msg])
+
+        should_respond_fn = AsyncMock(return_value=(True, False))
+        enqueue_fn = AsyncMock()
+        record_fn = AsyncMock()
+        cursor_fn = AsyncMock()
+        release_fn = AsyncMock()
+
+        with (
+            patch(
+                "bridge.reconciler.is_duplicate_message", new_callable=AsyncMock, return_value=False
+            ),
+            patch("bridge.reconciler.claim_message", new_callable=AsyncMock, return_value=False),
+            patch("bridge.reconciler.release_message_claim", release_fn),
+            patch("bridge.reconciler.record_message_processed", record_fn),
+            patch("bridge.reconciler.record_last_processed", cursor_fn),
+        ):
+            result = await reconcile_once(
+                client=client,
+                monitored_groups=["test group"],
+                should_respond_fn=should_respond_fn,
+                enqueue_agent_session_fn=enqueue_fn,
+                find_project_fn=MagicMock(return_value=_make_project()),
+            )
+
+        assert result == 0
+        enqueue_fn.assert_not_called()
+        record_fn.assert_not_called()
+        cursor_fn.assert_not_called()
+        # Nothing to release -- the claim was never won by this caller.
+        release_fn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_enqueue_exception_releases_claim_no_orphan(self):
+        """A fault-injected enqueue exception releases the claim before
+        propagating, preserving the propagate-and-retry contract (dedup
+        stays unrecorded so the message is re-enqueueable).
+        """
+        dialog = _make_dialog("Test Group", entity_id=251)
+        msg = _make_message(557, text="doomed message")
+
+        client = AsyncMock()
+        client.get_dialogs = AsyncMock(return_value=[dialog])
+        client.get_messages = AsyncMock(return_value=[msg])
+
+        should_respond_fn = AsyncMock(return_value=(True, False))
+        enqueue_fn = AsyncMock(side_effect=RuntimeError("enqueue boom"))
+        record_fn = AsyncMock()
+        release_fn = AsyncMock()
+
+        with (
+            patch(
+                "bridge.reconciler.is_duplicate_message", new_callable=AsyncMock, return_value=False
+            ),
+            patch("bridge.reconciler.claim_message", new_callable=AsyncMock, return_value=True),
+            patch("bridge.reconciler.release_message_claim", release_fn),
+            patch("bridge.reconciler.record_message_processed", record_fn),
+            patch("bridge.reconciler.record_last_processed", new_callable=AsyncMock),
+        ):
+            # reconcile_once wraps the per-group body in a broad try/except
+            # that logs and continues -- the exception does not propagate
+            # out of reconcile_once, but the claim release must have
+            # happened before it was swallowed.
+            result = await reconcile_once(
+                client=client,
+                monitored_groups=["test group"],
+                should_respond_fn=should_respond_fn,
+                enqueue_agent_session_fn=enqueue_fn,
+                find_project_fn=MagicMock(return_value=_make_project()),
+            )
+
+        assert result == 0
+        release_fn.assert_called_once_with(dialog.id, 557)
+        record_fn.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_old_message_outside_lookback_is_skipped(self):
         """Messages older than the lookback window are not processed."""
         dialog = _make_dialog("Test Group")
@@ -272,6 +367,7 @@ class TestReconcileOnce:
             patch(
                 "bridge.reconciler.is_duplicate_message", new_callable=AsyncMock, return_value=False
             ),
+            patch("bridge.reconciler.claim_message", new_callable=AsyncMock, return_value=True),
             patch("bridge.reconciler.record_message_processed", new_callable=AsyncMock),
         ):
             result = await reconcile_once(
@@ -308,6 +404,7 @@ class TestReconcileOnce:
             patch(
                 "bridge.reconciler.is_duplicate_message", new_callable=AsyncMock, return_value=False
             ),
+            patch("bridge.reconciler.claim_message", new_callable=AsyncMock, return_value=True),
             patch("bridge.reconciler.record_message_processed", new_callable=AsyncMock),
             patch("bridge.reconciler.record_last_processed", new_callable=AsyncMock),
         ):
@@ -382,6 +479,7 @@ class TestReconcileOnce:
             patch(
                 "bridge.reconciler.is_duplicate_message", new_callable=AsyncMock, return_value=False
             ),
+            patch("bridge.reconciler.claim_message", new_callable=AsyncMock, return_value=True),
             patch("bridge.reconciler.record_message_processed", new_callable=AsyncMock),
             patch("bridge.reconciler.record_last_processed", new_callable=AsyncMock),
         ):
@@ -458,6 +556,7 @@ class TestReconcileOnceSilentStream:
                 new_callable=AsyncMock,
                 return_value=False,
             ),
+            patch("bridge.reconciler.claim_message", new_callable=AsyncMock, return_value=True),
             patch("bridge.reconciler.record_message_processed", new_callable=AsyncMock),
             patch("bridge.reconciler.record_last_processed", new_callable=AsyncMock),
             patch("bridge.silent_stream.get_last_event_ts", new_callable=AsyncMock) as evt,
@@ -499,6 +598,7 @@ class TestReconcileOnceSilentStream:
                 new_callable=AsyncMock,
                 return_value=False,
             ),
+            patch("bridge.reconciler.claim_message", new_callable=AsyncMock, return_value=True),
             patch("bridge.reconciler.record_message_processed", new_callable=AsyncMock),
             patch("bridge.reconciler.record_last_processed", new_callable=AsyncMock),
             patch(
@@ -547,6 +647,7 @@ class TestReconcilePersonaSessionType:
             patch(
                 "bridge.reconciler.is_duplicate_message", new_callable=AsyncMock, return_value=False
             ),
+            patch("bridge.reconciler.claim_message", new_callable=AsyncMock, return_value=True),
             patch("bridge.reconciler.record_message_processed", new_callable=AsyncMock),
             patch("bridge.reconciler.record_last_processed", new_callable=AsyncMock),
         ):
@@ -581,6 +682,7 @@ class TestReconcilePersonaSessionType:
             patch(
                 "bridge.reconciler.is_duplicate_message", new_callable=AsyncMock, return_value=False
             ),
+            patch("bridge.reconciler.claim_message", new_callable=AsyncMock, return_value=True),
             patch("bridge.reconciler.record_message_processed", new_callable=AsyncMock),
             patch("bridge.reconciler.record_last_processed", new_callable=AsyncMock),
         ):

--- a/tests/unit/test_reconciler.py
+++ b/tests/unit/test_reconciler.py
@@ -266,9 +266,10 @@ class TestReconcileOnce:
 
         Issue #1817 B1, round-4 BLOCKER: this is the exact scenario where a
         peer producer (the live handler, or catchup) already won the SAME
-        message. The loser must not call record_message_processed, so a
-        winner-death self-heals via the next reconciler scan re-picking the
-        never-enqueued message instead of silently dropping it forever.
+        message. The loser must not call record_message_processed (it does
+        not double-record), so if the winner dies before enqueue the next
+        reconciler scan re-picks the never-enqueued message instead of
+        silently dropping it forever.
         """
         dialog = _make_dialog("Test Group", entity_id=250)
         msg = _make_message(556, text="raced message")

--- a/tests/unit/test_session_health_worker_pid_probe.py
+++ b/tests/unit/test_session_health_worker_pid_probe.py
@@ -1,0 +1,189 @@
+"""Unit tests for the B2-probe duplicate-worker registration check (issue #1817).
+
+``register_worker_pid()`` gained an OPTIONAL, observability-only,
+liveness-gated probe that detects a second LIVE worker for the same
+host+role and logs a WARNING. It NEVER refuses to start, NEVER exits, and
+NEVER blocks -- the atomic pending->running run-claim (B2 proper, in
+models/session_lifecycle.py) is what makes exactly-one-actor-per-session
+correctness hold. This probe is diagnostic only.
+
+Tests use the real Redis client (matching the existing SETNX-idiom test
+style elsewhere, e.g. tests/unit/test_dedup.py) plus targeted mocking of the
+liveness/heartbeat helpers for deterministic control over the decision
+matrix.
+"""
+
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from agent.session_health import (
+    _ORPHAN_REAP_HOSTNAME,
+    _WORKER_PID_HEARTBEAT_TS_KEY_PREFIX,
+    _WORKER_ROLE_PID_KEY_PREFIX,
+    HEARTBEAT_FRESHNESS_WINDOW,
+    WORKER_REGISTERED_PID_KEY_PREFIX,
+    _pid_is_live,
+    _probe_duplicate_worker_registration,
+    _worker_pid_heartbeat_fresh,
+    register_worker_pid,
+)
+
+ROLE = "test-probe-role"
+
+
+def _role_key() -> str:
+    return f"{_WORKER_ROLE_PID_KEY_PREFIX}{_ORPHAN_REAP_HOSTNAME}:{ROLE}"
+
+
+def _hb_key(pid: int) -> str:
+    return f"{_WORKER_PID_HEARTBEAT_TS_KEY_PREFIX}{_ORPHAN_REAP_HOSTNAME}:{pid}"
+
+
+@pytest.fixture(autouse=True)
+def _role_env(monkeypatch):
+    monkeypatch.setenv("VALOR_PROJECT_KEY", ROLE)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _cleanup():
+    from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+    yield
+    _R.delete(_role_key())
+    _R.delete(f"{WORKER_REGISTERED_PID_KEY_PREFIX}{_ORPHAN_REAP_HOSTNAME}:{os.getpid()}")
+    for pid in (1, 999999, os.getpid(), os.getpid() + 1, 424242, 424243, 424244):
+        _R.delete(_hb_key(pid))
+
+
+class TestPidIsLive:
+    def test_current_process_is_live(self):
+        assert _pid_is_live(os.getpid()) is True
+
+    def test_dead_pid_is_not_live(self):
+        # A pid vanishingly unlikely to exist on any machine running this suite.
+        assert _pid_is_live(999999) is False
+
+    def test_permission_error_treated_as_live(self):
+        """A process owned by another user can't be confirmed dead -- treat
+        conservatively as live rather than silently superseding without
+        evidence."""
+        with patch("agent.session_health.os.kill", side_effect=PermissionError()):
+            assert _pid_is_live(1) is True
+
+
+class TestWorkerPidHeartbeatFresh:
+    def test_missing_heartbeat_is_stale(self):
+        assert _worker_pid_heartbeat_fresh(424242) is False
+
+    def test_fresh_heartbeat_is_fresh(self):
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+        pid = 424243
+        _R.set(_hb_key(pid), datetime.now(UTC).timestamp(), ex=60)
+        assert _worker_pid_heartbeat_fresh(pid) is True
+
+    def test_stale_heartbeat_is_stale(self):
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+        pid = 424244
+        old_ts = (
+            datetime.now(UTC) - timedelta(seconds=HEARTBEAT_FRESHNESS_WINDOW + 30)
+        ).timestamp()
+        _R.set(_hb_key(pid), old_ts, ex=60)
+        assert _worker_pid_heartbeat_fresh(pid) is False
+
+
+class TestProbeDuplicateWorkerRegistration:
+    def test_never_flags_self(self, caplog):
+        """os.getpid() must never be compared against itself as a conflict."""
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+        pid = os.getpid()
+        _R.set(_role_key(), pid, ex=100)
+        with caplog.at_level(logging.WARNING, logger="agent.session_health"):
+            _probe_duplicate_worker_registration(pid)
+        assert not any("second live worker" in r.message for r in caplog.records)
+
+    def test_dead_competitor_silently_superseded(self, caplog):
+        """A dead pid under the role key produces no WARNING and is superseded."""
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+        dead_pid = 999999
+        _R.set(_role_key(), dead_pid, ex=100)
+        with caplog.at_level(logging.WARNING, logger="agent.session_health"):
+            _probe_duplicate_worker_registration(os.getpid())
+        assert not any("second live worker" in r.message for r in caplog.records)
+        # Additive: registration always proceeds and overwrites the role key.
+        assert int(_R.get(_role_key())) == os.getpid()
+
+    def test_live_but_stale_heartbeat_silently_superseded(self, caplog):
+        """A live pid with a stale/missing heartbeat is dead-worker residue --
+        no WARNING, no refusal (the exact launchd-respawn case)."""
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+        other_pid = os.getpid() + 1
+        _R.set(_role_key(), other_pid, ex=100)
+        # No heartbeat key written for other_pid -> stale by definition.
+        with (
+            patch("agent.session_health._pid_is_live", return_value=True),
+            caplog.at_level(logging.WARNING, logger="agent.session_health"),
+        ):
+            _probe_duplicate_worker_registration(os.getpid())
+        assert not any("second live worker" in r.message for r in caplog.records)
+
+    def test_confirmed_live_and_fresh_logs_warning(self, caplog):
+        """Only a CONFIRMED LIVE + fresh-heartbeat competitor logs a WARNING."""
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+        other_pid = os.getpid() + 1
+        _R.set(_role_key(), other_pid, ex=100)
+        with (
+            patch("agent.session_health._pid_is_live", return_value=True),
+            patch("agent.session_health._worker_pid_heartbeat_fresh", return_value=True),
+            caplog.at_level(logging.WARNING, logger="agent.session_health"),
+        ):
+            _probe_duplicate_worker_registration(os.getpid())
+        warnings = [r for r in caplog.records if "second live worker" in r.message]
+        assert warnings, "a confirmed-live same-host+role duplicate must log a WARNING"
+        # Never refuses: registration still proceeds and overwrites the role key.
+        assert int(_R.get(_role_key())) == os.getpid()
+
+    def test_cross_role_pid_never_compared(self):
+        """A pid registered under a DIFFERENT role is never even looked up."""
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+        other_role_key = f"{_WORKER_ROLE_PID_KEY_PREFIX}{_ORPHAN_REAP_HOSTNAME}:some-other-role"
+        _R.set(other_role_key, 999999, ex=100)
+        try:
+            _probe_duplicate_worker_registration(os.getpid())
+            assert int(_R.get(other_role_key)) == 999999
+        finally:
+            _R.delete(other_role_key)
+
+
+class TestRegisterWorkerPidNeverRefuses:
+    def test_register_worker_pid_does_not_raise_on_probe_failure(self):
+        """A probe failure must never prevent the additive registration write."""
+        with patch(
+            "agent.session_health._probe_duplicate_worker_registration",
+            side_effect=RuntimeError("boom"),
+        ):
+            register_worker_pid()  # must not raise
+
+    def test_register_worker_pid_never_exits_or_raises_on_confirmed_duplicate(self):
+        """Even with a confirmed-live duplicate, register_worker_pid must not
+        exit or raise -- it only logs."""
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+        other_pid = os.getpid() + 1
+        _R.set(_role_key(), other_pid, ex=100)
+        with (
+            patch("agent.session_health._pid_is_live", return_value=True),
+            patch("agent.session_health._worker_pid_heartbeat_fresh", return_value=True),
+        ):
+            register_worker_pid()  # must not raise or sys.exit

--- a/tests/unit/test_session_lifecycle.py
+++ b/tests/unit/test_session_lifecycle.py
@@ -14,8 +14,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from models.session_lifecycle import (
+    RUN_CLAIM_TTL_SECONDS,
     StatusConflictError,
+    claim_pending_run,
     finalize_session,
+    transition_status,
 )
 
 
@@ -302,3 +305,149 @@ class TestFinalizeSessionRejectFromTerminal:
             finalize_session(session, "killed")
 
         session.save.assert_not_called()
+
+
+# ===================================================================
+# claim_pending_run — narrow SETNX gate for pending->running (issue #1817 B2)
+# ===================================================================
+
+
+class TestClaimPendingRun:
+    """Tests for the narrow pending->running run-claim.
+
+    Uses the real Redis client (matching the existing SETNX-idiom test style
+    elsewhere, e.g. tests/unit/test_dedup.py::TestMessageClaim) since
+    claim_pending_run is a thin, real-Redis SETNX wrapper -- mocking it would
+    just re-test the mock.
+    """
+
+    def _cleanup(self, session_id):
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+        _R.delete(f"session:runclaim:{session_id}")
+
+    def teardown_method(self):
+        self._cleanup("test-runclaim-fresh")
+        self._cleanup("test-runclaim-contested")
+
+    def test_claim_fresh_session_succeeds(self):
+        assert claim_pending_run("test-runclaim-fresh", worker_id="worker-A") is True
+
+    def test_second_claim_on_same_session_fails(self):
+        """Two concurrent claimants on the SAME session_id: exactly one wins."""
+        first = claim_pending_run("test-runclaim-contested", worker_id="worker-A")
+        second = claim_pending_run("test-runclaim-contested", worker_id="worker-B")
+        assert first is True
+        assert second is False
+
+    def test_claim_fails_open_on_redis_error(self):
+        """A Redis error must fail OPEN (return True), not starve the queue."""
+        with patch("popoto.redis_db.POPOTO_REDIS_DB") as mock_redis:
+            mock_redis.set.side_effect = RuntimeError("redis down")
+            result = claim_pending_run("test-runclaim-fresh", worker_id="worker-A")
+        assert result is True
+
+    def test_ttl_is_short(self):
+        """RUN_CLAIM_TTL_SECONDS must be short -- only needs to cover the
+        query -> transition_status window, not a long-lived lock."""
+        assert isinstance(RUN_CLAIM_TTL_SECONDS, int)
+        assert 0 < RUN_CLAIM_TTL_SECONDS <= 120
+
+
+class TestConcurrentPendingRunClaim:
+    """End-to-end (within this module) proof that the run-claim + generic CAS
+    together guarantee exactly one actor transitions a pending session to
+    running (issue #1817 B2).
+    """
+
+    def _cleanup(self, session_id):
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+        _R.delete(f"session:runclaim:{session_id}")
+
+    def teardown_method(self):
+        self._cleanup("test-runclaim-e2e-1")
+        self._cleanup("test-runclaim-e2e-2")
+
+    def test_two_claimants_exactly_one_wins_and_transitions(self):
+        """Winner transitions to running; loser is stopped by the run-claim
+        alone (never even attempts transition_status)."""
+        session_id = "test-runclaim-e2e-1"
+        session = _make_session(session_id=session_id, status="pending")
+
+        winner_claim = claim_pending_run(session_id, worker_id="worker-A")
+        loser_claim = claim_pending_run(session_id, worker_id="worker-B")
+        assert winner_claim is True
+        assert loser_claim is False
+
+        # Only the winner proceeds to call transition_status -- mirrors the
+        # real call-site pattern in agent/session_pickup.py.
+        with patch("models.session_lifecycle.get_authoritative_session") as mock_cas:
+            mock_fresh = MagicMock()
+            mock_fresh.status = "pending"
+            mock_cas.return_value = mock_fresh
+
+            transition_status(session, "running", reason="worker picked up session")
+
+        assert session.status == "running"
+        session.save.assert_called()
+
+    def test_claim_bypass_still_blocked_by_generic_cas(self):
+        """Anti-criterion (round-4 BLOCKER): even if a caller somehow bypasses
+        the run-claim, the generic CAS inside transition_status() -- the
+        ``on_disk_status != current_status`` compare -- remains a second line
+        of defense and rejects the stale-status transition.
+        """
+        session_id = "test-runclaim-e2e-2"
+        # Caller's in-memory snapshot still says "pending", but the on-disk
+        # record (as re-read by transition_status's CAS) already says
+        # "running" -- e.g. a peer won and completed the transition first.
+        stale_session = _make_session(session_id=session_id, status="pending")
+
+        with patch("models.session_lifecycle.get_authoritative_session") as mock_cas:
+            mock_fresh = MagicMock()
+            mock_fresh.status = "running"
+            mock_cas.return_value = mock_fresh
+
+            with pytest.raises(StatusConflictError) as exc_info:
+                transition_status(stale_session, "running", reason="stale bypass attempt")
+
+        assert exc_info.value.expected_status == "pending"
+        assert exc_info.value.actual_status == "running"
+        stale_session.save.assert_not_called()
+
+
+class TestGenericCasStillGovernsWaitingForChildren:
+    """Anti-criterion (round-4 BLOCKER): the generic CAS compare must still be
+    present in models/session_lifecycle.py and still govern C1's
+    waiting_for_children transition. An earlier plan draft proposed deleting
+    this compare; a critique round flagged that as a BLOCKER because it
+    would strip optimistic-concurrency protection from every non-terminal
+    status edge in the system, not just pending->running.
+    """
+
+    def test_cas_compare_present_in_source(self):
+        import inspect
+
+        import models.session_lifecycle as lifecycle_module
+
+        source = inspect.getsource(lifecycle_module)
+        assert "on_disk_status != current_status" in source, (
+            "the generic optimistic-concurrency CAS compare must remain in "
+            "transition_status() -- see the BLOCKER rationale in "
+            "docs/plans/correctness-delivery-integrity.md"
+        )
+
+    def test_finalize_parent_sync_still_calls_transition_status_for_waiting_for_children(self):
+        """C1's waiting_for_children transition still routes through
+        transition_status() (and therefore through the generic CAS), rather
+        than through some bypass path added alongside the new run-claim."""
+        import inspect
+
+        import models.session_lifecycle as lifecycle_module
+
+        source = inspect.getsource(lifecycle_module._finalize_parent_sync)
+        assert 'transition_status(parent, "waiting_for_children"' in source, (
+            "C1's parent transition must still call the shared transition_status() "
+            "helper so the generic CAS applies to it"
+        )

--- a/tools/sdlc_session_ensure.py
+++ b/tools/sdlc_session_ensure.py
@@ -191,11 +191,22 @@ def ensure_session(issue_number: int, issue_url: str | None = None) -> dict:
             **kwargs,
         )
 
-        # Transition from default pending to running via lifecycle module
+        # Transition from default pending to running via lifecycle module.
+        # Narrow SETNX run-claim (issue #1817 B2): this session was just
+        # created by this call, so contention is unlikely, but the claim is
+        # applied uniformly at every pending->running call site so no actor
+        # (worker pop loop, CLI resume, catchup/reflections drip) is exempt.
+        # See models.session_lifecycle.claim_pending_run for the rationale.
         try:
-            from models.session_lifecycle import transition_status
+            from models.session_lifecycle import claim_pending_run, transition_status
 
-            transition_status(session, "running", "local SDLC session started")
+            if claim_pending_run(session.session_id, worker_id="sdlc-session-ensure"):
+                transition_status(session, "running", "local SDLC session started")
+            else:
+                logger.debug(
+                    "sdlc_session_ensure: lost run-claim for %s -- leaving pending",
+                    session.session_id,
+                )
         except Exception as e:
             logger.debug(f"sdlc_session_ensure: transition_status failed: {e}")
             # Session is created but in pending state — still usable


### PR DESCRIPTION
Closes #1864

Workstream B of the correctness-delivery-integrity plan (#1817): atomic per-message delivery claims (B1) and a narrow pending→running run-claim (B2).

## B1 — atomic per-message claim (cross-machine double-enqueue race)
`bridge/dedup.py` gains `claim_message()` / `release_message_claim()` — a Redis `SET NX` claim with a short `CLAIM_TTL_SECONDS` TTL, decoupled from the 2h dedup-membership window. Wired into `bridge/dispatch.py` and both recovery paths (`bridge/catchup.py`, `bridge/reconciler.py`) with release-on-exception. The claim **loser continues WITHOUT** `record_message_processed` (no durable dedup) so a winner-death before enqueue self-heals via the next scan rather than silently dropping the message forever.

## B2 — narrow SETNX run-claim gates pending→running only
`models/session_lifecycle.py::claim_pending_run` adds a `session:runclaim:{session_id}` SETNX key gating **only** the pending→running edge (wired at `agent/session_pickup.py` and `tools/sdlc_session_ensure.py`). The generic optimistic-concurrency CAS in `transition_status()` (`on_disk_status != current_status`) is preserved fully intact and still guards every other edge (waiting_for_children, paused, superseded, kill, finalize).

## B2-probe — liveness-gated duplicate-worker WARNING (independently revertable)
`agent/session_health.py::register_worker_pid` gains a diagnostic-only `_probe_duplicate_worker_registration` on a separate key namespace. It logs a WARNING on a confirmed-live duplicate worker and **never** refuses, exits, or blocks registration. This probe is **independently revertable** — dropping the third commit removes it without affecting B1 or B2.

## Review notes (non-blocking, from opus code review)
- **At-least-once posture (intentional):** if a winner dies in the narrow window between enqueue-success and its durable-dedup write, the reconciler re-enqueues once the claim TTL expires — a duplicate session, never a lost message. Documented in the migration-drain comment too.
- **TTL-expiry-during-enqueue:** a >60s stall on the sub-second enqueue write concurrent with a recovery tick could double-enqueue. Bounded and acceptable; lengthening the TTL was itself a prior-round BLOCKER (orphans claims across the sync-lag window and risks silent drops), so the short TTL is the deliberate trade.
- **TTL constant** is captured at module import (static tuning knob; env override honored at process start).

## Verification
Targeted suites green foreground/serial (`-n0`): `test_dedup`, `bridge/test_dispatch`, `test_catchup_claim`, `test_reconciler`, `test_session_lifecycle`, `test_session_health_worker_pid_probe` — 75 passed. All 11 workstream-B plan verification greps pass. Rebased onto latest main (#1867 lease-slot changes); session_health.py probe coexists cleanly with #1867's reprieve restructuring.
