### PR TITLE
fix(worker/models): stranded-parent sweep, trusted-clock freshness, ghost index reconcile (C1-C3, from #1817)

### DIFF
--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -84,6 +84,7 @@ from agent.session_health import (  # noqa: F401
     _recover_interrupted_agent_sessions_startup,
     _should_kill_no_progress,
     _sweep_dead_worker_sessions,
+    _sweep_stranded_waiting_for_children_parents,
     _tier2_reprieve_signal,
     _ts,
     _write_worker_heartbeat,

--- a/agent/session_health.py
+++ b/agent/session_health.py
@@ -1131,6 +1131,39 @@ def _never_started_past_grace(
         return False
 
 
+def _trusted_utc_now() -> datetime:
+    """Return "now" from Redis's own clock (the ``TIME`` command) rather than
+    this process's local wall-clock.
+
+    C2 (#1817): freshness checks in ``_has_progress`` compare a session's
+    last-write timestamp (``last_heartbeat_at``, ``last_tool_use_at``, ...)
+    against "now" to decide staleness. Using each reader's own local
+    wall-clock as "now" means a reader whose clock is skewed AHEAD of the
+    writer's can flag a genuinely fresh session as stale — a spurious
+    HEARTBEAT_FRESHNESS_WINDOW (90s) miss that triggers unnecessary
+    recovery/kill. Sourcing "now" from Redis's ``TIME`` command instead gives
+    every reader (across machines) the SAME shared reference clock, so an
+    individual reader's local clock skew drops out of the age computation
+    entirely — only the age relative to a single trusted source matters.
+
+    Falls back to local wall-clock on any Redis error (connection blip):
+    staleness evaluation must never hard-fail because the trusted-clock probe
+    itself failed. A rare fallback to local time on a Redis hiccup is no
+    worse than the pre-fix behavior it replaces.
+    """
+    try:
+        from popoto.redis_db import POPOTO_REDIS_DB
+
+        seconds, microseconds = POPOTO_REDIS_DB.time()
+        return datetime.fromtimestamp(seconds + microseconds / 1_000_000, tz=UTC)
+    except Exception as e:
+        logger.debug(
+            "[session-health] _trusted_utc_now: Redis TIME unavailable, using local clock: %s",
+            e,
+        )
+        return datetime.now(tz=UTC)
+
+
 def _has_progress(entry: AgentSession) -> bool:
     """Return True iff the session shows any signal that real work has begun.
 
@@ -1208,7 +1241,10 @@ def _has_progress(entry: AgentSession) -> bool:
     (``_agent_session_health_check``) then evaluates ``_tier2_reprieve_signal``
     before deciding to recover.
     """
-    now_utc = datetime.now(tz=UTC)
+    # C2 (#1817): sourced from Redis TIME, not local wall-clock, so a reader
+    # whose clock is skewed ahead of the writer's does not flag a fresh
+    # session as stale. See _trusted_utc_now() docstring.
+    now_utc = _trusted_utc_now()
 
     # Compute sdk_ever_output once — used by both sub-check A and the own-progress
     # field guard. True iff last_tool_use_at or last_turn_at has ever been written.

--- a/agent/session_health.py
+++ b/agent/session_health.py
@@ -996,6 +996,76 @@ def _sweep_dead_worker_sessions() -> int:
     return swept
 
 
+def _sweep_stranded_waiting_for_children_parents() -> int:
+    """Re-finalize parents stranded in ``waiting_for_children`` after a crash (C1, #1817).
+
+    Background: ``finalize_session()`` (``models/session_lifecycle.py:221``)
+    finalizes the parent best-effort inside a non-fatal try/except
+    (``_finalize_parent_sync``, :440-451) and ALWAYS saves the child (:474) --
+    intentionally, so the child finalizes independently even if the parent
+    lookup/save raises (parent deleted, Redis blip, stale index). This is a
+    deliberate contract that must NOT be inverted by coupling the two writes:
+    an all-or-nothing pipeline would strand the CHILD on every parent-finalize
+    hiccup instead of the rarer case this sweep targets. See
+    ``docs/plans/correctness-delivery-integrity.md`` C1.
+
+    The gap this closes: a process crash AFTER the child save but BEFORE the
+    parent transitions out of ``waiting_for_children`` leaves the parent
+    stranded forever -- nothing else re-triggers ``_finalize_parent_sync`` for
+    it once the crash window has passed.
+
+    Why this is safe to run unconditionally on every worker startup:
+    ``_finalize_parent_sync`` is itself idempotent -- it no-ops if the parent
+    is already terminal or no longer exists (``session_lifecycle.py:719-732``),
+    and it recomputes the parent's fate from the children's CURRENT statuses
+    (not replayed/stale state) each time it runs. Calling it against a parent
+    that already finalized normally, or one still legitimately waiting on a
+    non-terminal child, is a no-op -- only genuinely-stranded parents (all
+    children terminal, parent still ``waiting_for_children``) actually
+    transition here. A concurrent finalize from another process is resolved
+    by the generic CAS in ``transition_status()`` (:604-648, preserved
+    untouched by this sweep); ``_transition_parent`` already swallows the
+    resulting ``StatusConflictError`` at INFO level (:817-828), so this
+    function never needs to special-case that race.
+
+    Returns the count of parents actually re-finalized (confirmed by a
+    post-call status check) -- NOT the count of stranded-looking parents
+    scanned, most of which are expected to be legitimate no-ops.
+    """
+    from models.session_lifecycle import _finalize_parent_sync
+
+    stranded = _filter_hydrated_sessions(AgentSession.query.filter(status="waiting_for_children"))
+    if not stranded:
+        return 0
+
+    reswept = 0
+    for parent in stranded:
+        parent_id = getattr(parent, "id", None)
+        if not parent_id:
+            continue
+        try:
+            _finalize_parent_sync(parent_id)
+        except Exception as e:
+            logger.warning(
+                "[waiting-for-children-sweep] Failed to re-finalize parent %s: %s",
+                parent_id,
+                e,
+            )
+            continue
+
+        refreshed = AgentSession.get_by_id(parent_id)
+        if refreshed is not None and refreshed.status != "waiting_for_children":
+            reswept += 1
+            logger.warning(
+                "[waiting-for-children-sweep] Re-finalized stranded parent %s -> %s "
+                "(crash-window recovery, #1817)",
+                parent_id,
+                refreshed.status,
+            )
+
+    return reswept
+
+
 # === Agent Session Health Monitor ===
 
 

--- a/bridge/email_bridge.py
+++ b/bridge/email_bridge.py
@@ -1076,7 +1076,19 @@ def _query_non_terminal_sessions(project_key: str) -> list:
         List of AgentSession objects.
     """
     from models.agent_session import AgentSession
+
+    # C3 (#1817): AgentSession's 30-day TTL means a status-index ghost member
+    # (hash expired, index membership survives) can in principle outlive its
+    # backing session. query.filter() below already never returns such a
+    # ghost as a live record (popoto silently drops empty hashes), so
+    # subject-coalescing can never attach to a session that no longer exists
+    # -- this call only accelerates removing the stale index entry instead of
+    # waiting for the nightly popoto-index-cleanup sweep. Rate-limited
+    # internally; see models/ghost_reconcile.py.
+    from models.ghost_reconcile import reconcile_ghost_members
     from models.session_lifecycle import NON_TERMINAL_STATUSES
+
+    reconcile_ghost_members(AgentSession)
 
     min_created_at = time.time() - COALESCE_MAX_AGE_SECONDS
     sessions = []

--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -1015,14 +1015,27 @@ class AgentSession(Model):
 
     @classmethod
     def _heal_future_updated_at(cls) -> int:
-        """One-shot heal for future-dated updated_at values written before fix #1645.
+        """One-shot DETECTION for future-dated updated_at values written before fix #1645.
 
-        Clamps any session whose updated_at is in the future down to
-        max(created_at, now). Idempotent: a re-run clamps only still-future
-        records (partial mid-heal restart is safe because the per-record guard
-        is a strict `if record.updated_at > utc_now()` check, not a bulk update).
+        C2 (#1817): this function previously persisted a clamped
+        ``updated_at`` (a re-save call) whenever it found a future-dated
+        record. That re-save was itself a hazard, not a cure: persisting
+        rewrites the ``created_at``-based sorted index on every call, so
+        healing one future-dated straggler reshuffled the index position of
+        every OTHER recently-created record too -- corrupting freshness
+        ordering for every reader, not just the one record being healed.
 
-        Returns the number of records healed.
+        Detection is now read-only: it logs any future-dated records it
+        still finds (for operator visibility) but never mutates or persists
+        a clamped value. Health staleness no longer depends on this heal
+        having run -- see ``agent/session_health.py``'s trusted-clock fix
+        (Redis ``TIME`` instead of local wall-clock), which makes a
+        future-dated (skew-written) ``updated_at`` harmless to read even
+        without ever being clamped: age is computed from a single shared
+        clock, not from comparing two different processes' local clocks.
+
+        Returns the number of future-dated records detected (NOT healed —
+        nothing is mutated or re-saved).
         """
         from bridge.utc import utc_now
 
@@ -1048,31 +1061,13 @@ class AgentSession(Model):
                 if updated_at_utc <= now:
                     continue  # already sane, skip
 
-                # Clamp created_at first (dual-future-dated case, CONCERN — Adversary):
-                # ensures updated_at floor uses the already-clamped value so the
-                # invariant created_at <= updated_at <= now holds.
-                if record.created_at:
-                    created_at_utc = record.created_at
-                    if created_at_utc.tzinfo is None:
-                        created_at_utc = created_at_utc.replace(tzinfo=UTC)
-                    if created_at_utc > now:
-                        record.created_at = now
-                        logger.warning(
-                            f"_heal_future_updated_at: clamped future created_at on {record.id}"
-                        )
-
-                floor = record.created_at if record.created_at else now
-                # Normalize floor to tz-aware for max() comparison
-                if hasattr(floor, "tzinfo") and floor.tzinfo is None:
-                    floor = floor.replace(tzinfo=UTC)
-                record.updated_at = max(floor, now)
-                # Full save (no update_fields) so all changed fields are persisted
-                # and all popoto indexes (including SortedField created_at) are
-                # kept in sync. The save() override will re-stamp utc_now() for
-                # updated_at (idempotent — it will equal now).
-                record.save()
+                logger.warning(
+                    f"_heal_future_updated_at: detected future-dated updated_at on "
+                    f"{record.id} ({updated_at_utc.isoformat()} > now={now.isoformat()}) "
+                    "-- NOT re-saving (index-reshuffle hazard, see C2 #1817); "
+                    "staleness reads use a trusted-clock relative age instead"
+                )
                 count += 1
-                logger.info(f"_heal_future_updated_at: healed session {record.id}")
             except Exception as e:
                 logger.warning(
                     f"_heal_future_updated_at: skipped {getattr(record, 'id', '?')}: {e}"

--- a/models/dedup.py
+++ b/models/dedup.py
@@ -44,6 +44,21 @@ class DedupRecord(Model):
     @classmethod
     def get_or_create(cls, chat_id: str) -> "DedupRecord":
         """Get existing record for a chat, or create a new one."""
+        # C3 (#1817): DedupRecord's short 2h TTL makes it the most likely
+        # model to accumulate ghost index members (hash expired, class-set
+        # membership survives). get_or_create() runs on every inbound
+        # message, so it is a good place to opportunistically self-heal the
+        # index instead of waiting up to 24h for the nightly
+        # popoto-index-cleanup reflection. Rate-limited internally (at most
+        # once/60s) -- safe to call unconditionally on every read.
+        # query.filter() itself already silently drops ghost members from
+        # `existing` (never attaches a dead record's data); this only
+        # accelerates removing the ghost from the index. See
+        # models/ghost_reconcile.py for the full rationale.
+        from models.ghost_reconcile import reconcile_ghost_members
+
+        reconcile_ghost_members(cls)
+
         existing = cls.query.filter(chat_id=str(chat_id))
         if existing:
             return existing[0]

--- a/models/ghost_reconcile.py
+++ b/models/ghost_reconcile.py
@@ -1,0 +1,101 @@
+"""Reconcile-on-read for Popoto index ghost members (C3, #1817).
+
+Background
+----------
+``DedupRecord`` (``Meta.ttl=7200``) and ``AgentSession`` (``Meta.ttl=2592000``)
+set a TTL on their underlying Redis *hash*. Popoto does not extend that TTL to
+the secondary indexes (class set, KeyField sets, sorted sets) that reference
+the hash's key. Redis SETs/ZSETs have no per-member TTL, so once the hash
+expires, the index member outlives it indefinitely -- a "ghost" member whose
+backing hash is gone.
+
+What is ALREADY safe (verified empirically, see tests/unit/test_ghost_reconcile.py):
+    ``Model.query.filter()`` / ``.all()`` hydrate raw index members via a
+    pipelined HGETALL and silently skip any key that comes back empty
+    (``popoto/models/query.py::get_many_objects``, the ``if redis_hash`` guard).
+    A ghost member is therefore NEVER returned as a live record and can never
+    attach stale/live data to a session that no longer exists -- the specific
+    corruption scenario (an email subject-coalescing reply landing on a dead
+    session) is not reachable through ``.filter()``/``.all()`` today.
+
+What is NOT safe: the ghost member itself is never removed from the index.
+Left alone it is only cleaned by the nightly ``popoto-index-cleanup``
+reflection (``scripts/popoto_index_cleanup.py``, once/24h), so between hash
+expiry and that sweep:
+    - every query pays an extra round-trip per ghost and logs a
+      ``logger.error("one or more redis keys points to missing objects")``
+      line (the ghost-detection path popoto already has),
+    - the index grows unboundedly for high-churn models.
+
+Why reconcile-on-read (this module) instead of aligning member TTL to the
+hash TTL: Redis SETs/ZSETs have no per-member expiry primitive, so "TTL the
+index members" would require re-modeling every index as a ZSET keyed by
+expiry and a periodic ZREMRANGEBYSCORE sweep -- strictly more code and risk
+than reusing the SCAN-based, production-safe primitive popoto already ships
+(``Model.clean_indexes()``, the same one the nightly reflection calls).
+Reconcile-on-read just moves that primitive earlier: instead of waiting up to
+24h for the scheduled sweep, a ghost-prone read path (dedup lookups, email
+subject-coalescing) triggers it inline, rate-limited so a hot path never pays
+a full SCAN on every call.
+
+Why ``Model.clean_indexes()`` and not hand-rolled SREM/ZREM: this repo's
+convention is "never touch Popoto-managed keys with raw Redis calls -- always
+go through the ORM" (see CLAUDE.md). ``clean_indexes()`` IS the ORM's
+sanctioned cleanup primitive; using it here (rather than reimplementing
+index-member removal by hand) keeps that invariant intact even for cleanup
+code.
+"""
+
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+# Minimum seconds between clean_indexes() sweeps for a given model. Bounds
+# the cost added to a read path: a busy loop calling reconcile_ghost_members()
+# many times per second still pays the SCAN at most once per interval.
+_RECONCILE_MIN_INTERVAL_SECONDS = 60.0
+
+# Module-level, in-process rate-limit cache: {model_name: last_reconciled_ts}.
+# In-process (not Redis-backed) is intentional -- this is a best-effort
+# frequency cap, not a correctness lock; multiple workers each reconciling at
+# most once/interval is fine (clean_indexes() is idempotent and SCAN-based).
+_last_reconciled: dict[str, float] = {}
+
+
+def reconcile_ghost_members(
+    model_class, *, min_interval: float = _RECONCILE_MIN_INTERVAL_SECONDS
+) -> int:
+    """Best-effort, rate-limited ghost-member reconciliation for a Popoto model.
+
+    Call this from read paths that are prone to TTL-outlived index members
+    (e.g. before/after a ``.filter()`` in dedup lookups or session
+    subject-coalescing). It is safe to call on every read: the rate limit
+    makes repeated calls within ``min_interval`` seconds a no-op.
+
+    Never raises -- failures are logged and swallowed, since this is a
+    hygiene pass, not part of the read's correctness contract (the read
+    itself is already ghost-safe; see module docstring).
+
+    Returns:
+        Number of orphaned index entries removed. 0 if skipped due to the
+        rate limit or if none were found.
+    """
+    name = getattr(getattr(model_class, "_meta", None), "model_name", None) or getattr(
+        model_class, "__name__", "unknown"
+    )
+    now = time.time()
+    last = _last_reconciled.get(name, 0.0)
+    if now - last < min_interval:
+        return 0
+    _last_reconciled[name] = now
+
+    try:
+        removed = model_class.clean_indexes()
+    except Exception as e:
+        logger.warning(f"[ghost-reconcile] {name}: clean_indexes() failed (non-fatal): {e}")
+        return 0
+
+    if removed:
+        logger.info(f"[ghost-reconcile] {name}: removed {removed} orphaned index entr(y/ies)")
+    return removed or 0

--- a/tests/integration/test_updated_at_heal.py
+++ b/tests/integration/test_updated_at_heal.py
@@ -1,14 +1,23 @@
-"""Integration tests for AgentSession updated_at UTC heal (bug #1645).
+"""Integration tests for AgentSession updated_at UTC heal (bug #1645, revised C2 #1817).
 
 Seeds future-dated updated_at values directly into Redis (bypassing the ORM,
 which now stamps correct UTC via the save() override) and verifies that
-_heal_future_updated_at() corrects them.
+_heal_future_updated_at() DETECTS them without mutating or persisting a clamp.
+
+C2 (#1817): the heal used to clamp a future-dated updated_at down to now and
+re-save() it. That re-save reshuffled the created_at-based sorted index on
+every heal -- a real hazard, not a cure. The heal is now detection-only:
+it logs and counts future-dated records but never mutates Redis. Health
+staleness reads no longer depend on this heal having run -- see
+agent/session_health.py's _trusted_utc_now() (Redis TIME, not local
+wall-clock), which makes a still-future-dated (skew-written) updated_at
+harmless to read even though it's never clamped.
 
 Why bypass the ORM for seeding?
-    The normal save() path now stamps utc_now() for updated_at, so future values
-    can no longer be created through the ORM. To reproduce the pre-fix condition
-    (popoto auto_now writing naive local time on UTC+7 hosts), we write the raw
-    Redis hash directly.
+    The normal save() path stamps utc_now() for updated_at, so future values
+    can no longer be created through the ORM. To reproduce the pre-fix
+    condition (popoto auto_now writing naive local time on UTC+7 hosts), we
+    write the raw Redis hash directly.
 
 Seed mechanism (CONCERN — Skeptic/Adversary):
     Popoto encodes datetime fields using msgpack with the schema:
@@ -23,7 +32,6 @@ Isolation:
     before/after each test. No production data is touched.
 """
 
-import subprocess
 import uuid
 from datetime import UTC, datetime, timedelta
 
@@ -108,67 +116,63 @@ def future_session(redis_test_db):
 
 
 class TestHealIntegration:
-    """Integration tests: seed future-dated Redis records, heal, assert invariants."""
+    """Integration tests: seed future-dated Redis records, run detection,
+    assert nothing gets mutated or persisted."""
 
-    def test_heal_corrects_future_updated_at(self, future_session, redis_test_db):
-        """After heal, updated_at must be <= now (no longer in the future)."""
-        # Reload from Redis to confirm the seed took effect
+    def test_heal_detects_future_updated_at_without_persisting_a_clamp(
+        self, future_session, redis_test_db
+    ):
+        """Heal counts the future-dated record, but its persisted updated_at
+        in Redis is left completely untouched -- still future-dated."""
         reloaded = AgentSession.get_by_id(future_session.id)
         assert reloaded is not None
 
         now_before = datetime.now(UTC)
-        # Normalize to tz-aware for comparison (popoto strips tzinfo on read)
         reloaded_updated_at = _as_utc(reloaded.updated_at)
         assert reloaded_updated_at > now_before, (
             "Seed did not produce a future updated_at — test setup is broken. "
             f"updated_at={reloaded_updated_at!r}, now={now_before!r}"
         )
 
-        # Run heal
         count = AgentSession._heal_future_updated_at()
-        assert count >= 1, f"Expected at least 1 healed record, got {count}"
+        assert count >= 1, f"Expected at least 1 detected record, got {count}"
 
-        # Reload again and verify the invariant
-        healed = AgentSession.get_by_id(future_session.id)
-        assert healed is not None
-        now_after = datetime.now(UTC)
-
-        assert healed.updated_at is not None
-        healed_updated_at = _as_utc(healed.updated_at)
-        assert healed_updated_at <= now_after + timedelta(seconds=5), (
-            f"updated_at {healed_updated_at!r} is still in the future after heal "
-            f"(now={now_after!r})"
+        # Reload again — the persisted value must be UNCHANGED (still future).
+        after_heal = AgentSession.get_by_id(future_session.id)
+        assert after_heal is not None
+        after_heal_updated_at = _as_utc(after_heal.updated_at)
+        assert abs((after_heal_updated_at - reloaded_updated_at).total_seconds()) < 1, (
+            "The persisted updated_at must not change -- heal is detection-only "
+            f"(before={reloaded_updated_at!r}, after={after_heal_updated_at!r})"
+        )
+        assert after_heal_updated_at > datetime.now(UTC), (
+            "The record must STILL be future-dated after heal (no clamp/re-save)"
         )
 
-    def test_heal_preserves_created_at_lte_updated_at_invariant(
-        self, future_session, redis_test_db
-    ):
-        """After heal, created_at <= updated_at must hold."""
+    def test_heal_does_not_touch_created_at(self, future_session, redis_test_db):
+        """created_at is never read or mutated by the detection-only heal."""
+        before = AgentSession.get_by_id(future_session.id)
+        original_created_at = _as_utc(before.created_at)
+
         AgentSession._heal_future_updated_at()
 
-        healed = AgentSession.get_by_id(future_session.id)
-        assert healed is not None
-        assert healed.created_at is not None
-        assert healed.updated_at is not None
+        after = AgentSession.get_by_id(future_session.id)
+        after_created_at = _as_utc(after.created_at)
+        assert after_created_at == original_created_at
 
-        healed_created_at = _as_utc(healed.created_at)
-        healed_updated_at = _as_utc(healed.updated_at)
-
-        assert healed_created_at <= healed_updated_at, (
-            f"Invariant violated: created_at={healed_created_at!r} > "
-            f"updated_at={healed_updated_at!r}"
-        )
-
-    def test_heal_idempotent_on_redis_records(self, future_session, redis_test_db):
-        """Running heal twice must produce count=0 on the second pass."""
+    def test_heal_repeated_calls_agree_on_redis_records(self, future_session, redis_test_db):
+        """Since nothing is persisted, repeated heal calls against an
+        unchanged future-dated record detect it every time (not just once)."""
         count1 = AgentSession._heal_future_updated_at()
         count2 = AgentSession._heal_future_updated_at()
 
-        assert count1 >= 1, f"First heal should fix >=1 record, got {count1}"
-        assert count2 == 0, f"Second heal should fix 0 records (idempotent), got {count2}"
+        assert count1 >= 1, f"First heal should detect >=1 record, got {count1}"
+        assert count2 == count1, (
+            f"Repeated detection of an unmutated record must agree: {count1} != {count2}"
+        )
 
-    def test_sane_sessions_not_healed(self, redis_test_db):
-        """Sessions with updated_at already in the past are not touched by heal."""
+    def test_sane_sessions_not_detected(self, redis_test_db):
+        """Sessions with updated_at already in the past are not counted or touched."""
         uid = uuid.uuid4().hex[:8]
         session = AgentSession.create(
             session_id=f"sane-heal-{uid}",
@@ -181,78 +185,12 @@ class TestHealIntegration:
         original_updated_at = _as_utc(session.updated_at)
 
         count = AgentSession._heal_future_updated_at()
-        assert count == 0, f"Sane session must not be healed, got count={count}"
+        assert count == 0, f"Sane session must not be detected, got count={count}"
 
         reloaded = AgentSession.get_by_id(session.id)
         assert reloaded is not None
-        # updated_at should not have changed significantly (no heal save() was called)
         if original_updated_at is not None:
             reloaded_updated_at = _as_utc(reloaded.updated_at)
             assert abs((reloaded_updated_at - original_updated_at).total_seconds()) < 5, (
                 "Sane session's updated_at should not have been rewritten by heal"
             )
-
-    def test_valor_session_status_shows_no_future_timestamp(self, future_session, redis_test_db):
-        """After heal, valor-session status output must not contain a future timestamp.
-
-        This verifies the end-to-end CLI surface: operators viewing session
-        status should no longer see timestamps 7 hours in the future after
-        the heal has run.
-
-        Note: valor-session status reads from Redis via the ORM, so this also
-        verifies that the healed value was persisted to Redis correctly.
-        """
-        # First verify the session is future-dated before heal
-        pre_heal = AgentSession.get_by_id(future_session.id)
-        now = datetime.now(UTC)
-        pre_heal_updated_at = _as_utc(pre_heal.updated_at)
-        assert pre_heal_updated_at > now, (
-            f"Pre-heal session must be future-dated. "
-            f"updated_at={pre_heal_updated_at!r}, now={now!r}"
-        )
-
-        # Run heal
-        AgentSession._heal_future_updated_at()
-
-        # Reload and check that the value is now sane
-        post_heal = AgentSession.get_by_id(future_session.id)
-        now_after = datetime.now(UTC)
-        post_heal_updated_at = _as_utc(post_heal.updated_at)
-        assert post_heal_updated_at <= now_after + timedelta(seconds=5), (
-            f"Post-heal updated_at {post_heal_updated_at!r} is still in the future"
-        )
-
-        # Verify via CLI output — run valor-session status and check the timestamp
-        result = subprocess.run(
-            [
-                "python",
-                "-m",
-                "tools.valor_session",
-                "status",
-                "--id",
-                future_session.id,
-            ],
-            capture_output=True,
-            text=True,
-            timeout=15,
-        )
-        # CLI may fail if the session is in a terminal state or missing fields —
-        # we only check timestamp sanity if the command succeeds
-        if result.returncode == 0 and result.stdout:
-            output = result.stdout
-            # Parse out any timestamp-looking strings and verify none are 7h+ in future
-            # The output typically shows: "updated_at: 2026-06-12T..."
-            threshold = now_after + timedelta(hours=1)
-            import re
-
-            ts_pattern = r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}"
-            for match in re.finditer(ts_pattern, output):
-                try:
-                    ts_str = match.group(0).replace(" ", "T")
-                    ts = datetime.fromisoformat(ts_str).replace(tzinfo=UTC)
-                    assert ts <= threshold, (
-                        f"CLI output contains future timestamp {ts!r} "
-                        f"(threshold={threshold!r}): {output!r}"
-                    )
-                except ValueError:
-                    pass  # unparseable timestamp fragment, skip

--- a/tests/unit/test_agent_session_updated_at_utc.py
+++ b/tests/unit/test_agent_session_updated_at_utc.py
@@ -271,21 +271,17 @@ class TestSaveUpdatedAtOmissionAllowlist:
 
 
 class TestHealFutureUpdatedAt:
-    """_heal_future_updated_at() must clamp future-dated records to now."""
+    """_heal_future_updated_at() DETECTS future-dated records (C2, #1817).
 
-    def _build_records(self, records_spec):
-        """Build in-memory AgentSession instances from a list of (updated_at, created_at) pairs."""
-        sessions = []
-        for spec in records_spec:
-            s = _make_session_no_save()
-            s.updated_at = spec.get("updated_at")
-            s.created_at = spec.get("created_at")
-            s.id = spec.get("id", f"test-{id(s)}")
-            sessions.append(s)
-        return sessions
+    It no longer clamps or re-saves anything -- re-saving reshuffled the
+    created_at-based sorted index on every heal. See the function's
+    docstring in models/agent_session.py for the full rationale.
+    """
 
-    def test_heal_clamps_future_record(self):
-        """A session with updated_at 7h in the future must be healed."""
+    def test_heal_detects_future_record_without_saving(self):
+        """A session with updated_at 7h in the future is counted as
+        detected, but save() is never called and updated_at is left
+        untouched (still future-dated)."""
         now = datetime.now(UTC)
         future = now + timedelta(hours=7)
         past = now - timedelta(minutes=30)
@@ -297,13 +293,8 @@ class TestHealFutureUpdatedAt:
 
         save_calls = []
 
-        def mock_save(self, *args, update_fields=None, **kwargs):
-            # Simulate what our real save() does: stamp utc_now()
-            from bridge.utc import utc_now
-
-            if update_fields is None or "updated_at" in update_fields:
-                self.updated_at = utc_now()
-            save_calls.append(update_fields)
+        def mock_save(self, *args, **kwargs):
+            save_calls.append(True)
 
         with (
             patch.object(AgentSession, "query") as mock_query,
@@ -312,14 +303,15 @@ class TestHealFutureUpdatedAt:
             mock_query.all.return_value = [session]
             count = AgentSession._heal_future_updated_at()
 
-        assert count == 1, f"Expected 1 healed record, got {count}"
-        assert len(save_calls) == 1, "save() must be called once for the healed record"
-        assert session.updated_at <= datetime.now(UTC) + timedelta(seconds=2), (
-            f"updated_at should be near-now after heal, got {session.updated_at!r}"
+        assert count == 1, f"Expected 1 future-dated record detected, got {count}"
+        assert len(save_calls) == 0, "save() must never be called by the heal"
+        assert session.updated_at == future, (
+            "updated_at must be left untouched -- no clamp, no re-save "
+            f"(got {session.updated_at!r})"
         )
 
     def test_heal_skips_sane_records(self):
-        """Sessions with updated_at in the past must not be touched."""
+        """Sessions with updated_at in the past must not be counted or touched."""
         now = datetime.now(UTC)
         past = now - timedelta(hours=2)
 
@@ -340,9 +332,8 @@ class TestHealFutureUpdatedAt:
             mock_query.all.return_value = [session]
             count = AgentSession._heal_future_updated_at()
 
-        assert count == 0, "Sane record must not be counted as healed"
+        assert count == 0, "Sane record must not be counted as detected"
         assert len(save_calls) == 0, "save() must not be called for a sane record"
-        # updated_at must be unchanged
         assert session.updated_at == past
 
     def test_heal_skips_none_updated_at(self):
@@ -368,8 +359,11 @@ class TestHealFutureUpdatedAt:
         assert len(save_calls) == 0
         assert session.updated_at is None
 
-    def test_heal_is_idempotent(self):
-        """Running heal twice must produce count=0 on the second run."""
+    def test_heal_is_idempotent_repeated_calls_agree(self):
+        """Since nothing is mutated, repeated calls against an unchanged
+        future-dated record report the SAME detection count every time --
+        the new idempotency contract (no first-call-fixes-it / second-call-
+        finds-nothing-left behavior, since nothing is ever fixed)."""
         now = datetime.now(UTC)
         future = now + timedelta(hours=7)
 
@@ -378,11 +372,10 @@ class TestHealFutureUpdatedAt:
         session.created_at = now - timedelta(minutes=10)
         session.id = "idempotent-session"
 
-        def mock_save(self, *args, update_fields=None, **kwargs):
-            from bridge.utc import utc_now
+        save_calls = []
 
-            if update_fields is None or "updated_at" in update_fields:
-                self.updated_at = utc_now()
+        def mock_save(self, *args, **kwargs):
+            save_calls.append(True)
 
         with (
             patch.object(AgentSession, "query") as mock_query,
@@ -391,77 +384,11 @@ class TestHealFutureUpdatedAt:
             mock_query.all.return_value = [session]
 
             count1 = AgentSession._heal_future_updated_at()
-            # After first heal, updated_at is now near-current
-            # Second call should see updated_at <= now, skip it
             count2 = AgentSession._heal_future_updated_at()
 
-        assert count1 == 1, f"First heal should fix 1 record, got {count1}"
-        assert count2 == 0, f"Second heal should fix 0 records (idempotent), got {count2}"
-
-    def test_heal_handles_created_at_none_with_future_updated_at(self):
-        """created_at=None with future updated_at — heal must clamp to now."""
-        now = datetime.now(UTC)
-        future = now + timedelta(hours=5)
-
-        session = _make_session_no_save()
-        session.updated_at = future
-        session.created_at = None
-        session.id = "no-created-at-session"
-
-        def mock_save(self, *args, update_fields=None, **kwargs):
-            from bridge.utc import utc_now
-
-            if update_fields is None or "updated_at" in update_fields:
-                self.updated_at = utc_now()
-
-        with (
-            patch.object(AgentSession, "query") as mock_query,
-            patch.object(AgentSession, "save", mock_save),
-        ):
-            mock_query.all.return_value = [session]
-            count = AgentSession._heal_future_updated_at()
-
-        assert count == 1
-        assert session.updated_at <= datetime.now(UTC) + timedelta(seconds=2)
-
-    def test_heal_dual_future_case_invariant(self):
-        """Dual-future: both created_at and updated_at in the future.
-
-        After heal the invariant created_at <= updated_at <= now must hold.
-        """
-        now = datetime.now(UTC)
-        future_updated = now + timedelta(hours=7)
-        future_created = now + timedelta(hours=7)  # same offset — both naive-local stamped
-
-        session = _make_session_no_save()
-        session.updated_at = future_updated
-        session.created_at = future_created
-        session.id = "dual-future-session"
-
-        def mock_save(self, *args, update_fields=None, **kwargs):
-            from bridge.utc import utc_now
-
-            current_now = utc_now()
-            if update_fields is None or "updated_at" in update_fields:
-                self.updated_at = current_now
-            # created_at clamping is done before save() is called in the heal loop
-
-        with (
-            patch.object(AgentSession, "query") as mock_query,
-            patch.object(AgentSession, "save", mock_save),
-        ):
-            mock_query.all.return_value = [session]
-            count = AgentSession._heal_future_updated_at()
-
-        assert count == 1
-        # created_at was clamped to now by the heal loop before save()
-        real_now = datetime.now(UTC)
-        assert session.created_at <= real_now + timedelta(seconds=2), (
-            f"created_at should be clamped to ~now, got {session.created_at!r}"
-        )
-        assert session.updated_at <= real_now + timedelta(seconds=2), (
-            f"updated_at should be clamped to ~now, got {session.updated_at!r}"
-        )
+        assert count1 == 1
+        assert count2 == 1, "Repeated detection of an unmutated future record must agree"
+        assert len(save_calls) == 0
 
     def test_heal_returns_zero_on_query_failure(self, caplog):
         """If query.all() raises, heal must return 0 (fail-soft)."""
@@ -473,40 +400,36 @@ class TestHealFutureUpdatedAt:
         assert count == 0
         assert any("could not fetch sessions" in r.message for r in caplog.records)
 
-    def test_heal_skips_record_on_save_error(self, caplog):
-        """If a single record's save() raises, heal skips that record and continues."""
+    def test_heal_skips_record_on_per_record_error(self, caplog):
+        """If accessing a single record's fields raises, heal skips that
+        record and continues to the next -- one bad record must not abort
+        the whole detection pass."""
         now = datetime.now(UTC)
         future = now + timedelta(hours=7)
 
-        bad = _make_session_no_save()
-        bad.updated_at = future
-        bad.created_at = now - timedelta(minutes=5)
-        bad.id = "bad-save-session"
+        class _BoomOnAccess:
+            """A record whose updated_at raises when read (simulates a
+            corrupted/partial hash) instead of a normal save() failure,
+            since save() is no longer called by the heal at all."""
+
+            id = "bad-record"
+
+            @property
+            def updated_at(self):
+                raise RuntimeError("simulated corrupt field read")
+
+        bad = _BoomOnAccess()
 
         good = _make_session_no_save()
         good.updated_at = future
         good.created_at = now - timedelta(minutes=5)
-        good.id = "good-save-session"
+        good.id = "good-record"
 
-        call_count = [0]
-
-        def mock_save(self, *args, update_fields=None, **kwargs):
-            call_count[0] += 1
-            if self.id == "bad-save-session":
-                raise RuntimeError("Redis write error")
-            from bridge.utc import utc_now
-
-            if update_fields is None or "updated_at" in update_fields:
-                self.updated_at = utc_now()
-
-        with (
-            patch.object(AgentSession, "query") as mock_query,
-            patch.object(AgentSession, "save", mock_save),
-        ):
+        with patch.object(AgentSession, "query") as mock_query:
             mock_query.all.return_value = [bad, good]
             with caplog.at_level(logging.WARNING, logger="models.agent_session"):
                 count = AgentSession._heal_future_updated_at()
 
-        # Only the good record was successfully healed
+        # Only the good record was successfully detected.
         assert count == 1
         assert any("skipped" in r.message for r in caplog.records)

--- a/tests/unit/test_ghost_reconcile.py
+++ b/tests/unit/test_ghost_reconcile.py
@@ -1,0 +1,143 @@
+"""Tests for C3 (#1817): Popoto ghost index-member handling.
+
+A "ghost" member is an index/class-set entry whose backing Redis hash has
+already expired (or been deleted) but whose entry in the model's secondary
+index survives -- Redis SETs/ZSETs have no per-member TTL, so an index
+member can outlive the hash it points to.
+
+Two things are covered here:
+
+1. ``query.filter()``/``.all()`` never attach a ghost's absent data to a
+   result -- popoto's own hydration path silently skips any index member
+   whose HGETALL comes back empty. This is existing library behavior; the
+   tests below lock it in as a regression guard for this repo's usage.
+2. ``models.ghost_reconcile.reconcile_ghost_members()`` -- our reconcile-on-read
+   helper -- actually removes the ghost from the index (via the production-safe
+   ``Model.clean_indexes()``), and respects its rate limit.
+
+Seeding a ghost (hash gone, index member present) cannot be produced through
+the ORM's own ``delete()`` (which removes both) or through TTL expiry
+(too slow for a test) -- so these tests reach into
+``popoto.redis_db.POPOTO_REDIS_DB`` directly to delete only the hash, mirroring
+the seed technique already used by ``tests/integration/test_updated_at_heal.py``.
+"""
+
+import time
+
+from models.dedup import DedupRecord
+from models.ghost_reconcile import _last_reconciled, reconcile_ghost_members
+
+
+def _delete_hash_only(instance) -> None:
+    """Delete only the backing Redis hash for a Popoto instance, leaving its
+    index/class-set membership intact -- reproduces a TTL-expired ghost."""
+    import popoto.redis_db as rdb
+
+    rdb.POPOTO_REDIS_DB.delete(instance._redis_key)
+
+
+class TestQueryFilterDropsGhostMembers:
+    """query.filter()/.all() must silently skip ghost members, never raise
+    or return a malformed record for one."""
+
+    def setup_method(self):
+        _last_reconciled.clear()
+
+    def teardown_method(self):
+        for record in DedupRecord.query.all():
+            if str(record.chat_id).startswith("test_ghost"):
+                record.delete()
+        _last_reconciled.clear()
+
+    def test_filter_returns_only_live_records(self, redis_test_db):
+        """One ghost + one live member: filter() returns only the live one."""
+        ghost = DedupRecord.create(chat_id="test_ghost_a", message_ids={"1"})
+        live = DedupRecord.create(chat_id="test_ghost_b", message_ids={"2"})
+
+        _delete_hash_only(ghost)
+
+        results = list(DedupRecord.query.filter())
+        chat_ids = {r.chat_id for r in results}
+
+        assert chat_ids == {"test_ghost_b"}, (
+            f"Expected only the live record, got {chat_ids!r} "
+            "(ghost member should be silently dropped, not raised or returned empty)"
+        )
+
+        live.delete()
+
+    def test_filter_empty_when_all_members_are_ghosts(self, redis_test_db):
+        """All members ghosts: filter() returns an empty list, no error."""
+        ghost1 = DedupRecord.create(chat_id="test_ghost_c", message_ids={"1"})
+        ghost2 = DedupRecord.create(chat_id="test_ghost_d", message_ids={"2"})
+
+        _delete_hash_only(ghost1)
+        _delete_hash_only(ghost2)
+
+        results = list(DedupRecord.query.filter())
+        assert results == [], f"Expected no records (all ghosts), got {results!r}"
+
+
+class TestReconcileGhostMembers:
+    """reconcile_ghost_members() removes ghost index entries via
+    Model.clean_indexes() and respects its rate limit."""
+
+    def setup_method(self):
+        _last_reconciled.clear()
+
+    def teardown_method(self):
+        for record in DedupRecord.query.all():
+            if str(record.chat_id).startswith("test_ghost"):
+                record.delete()
+        _last_reconciled.clear()
+
+    def test_reconcile_removes_ghost_from_index(self, redis_test_db):
+        """After reconcile, the ghost's class-set membership is gone."""
+        ghost = DedupRecord.create(chat_id="test_ghost_e", message_ids={"1"})
+        _delete_hash_only(ghost)
+
+        removed = reconcile_ghost_members(DedupRecord, min_interval=0)
+
+        assert removed >= 1, f"Expected at least 1 orphan removed, got {removed}"
+
+        raw_keys = DedupRecord.query.keys()
+        assert ghost._redis_key not in raw_keys, (
+            "Ghost's index membership should have been removed by clean_indexes()"
+        )
+
+    def test_reconcile_is_rate_limited(self, redis_test_db):
+        """A second call within min_interval is a no-op (returns 0)."""
+        ghost = DedupRecord.create(chat_id="test_ghost_f", message_ids={"1"})
+        _delete_hash_only(ghost)
+
+        first = reconcile_ghost_members(DedupRecord, min_interval=60)
+        assert first >= 1
+
+        # Seed another ghost immediately -- should NOT be reconciled yet.
+        ghost2 = DedupRecord.create(chat_id="test_ghost_g", message_ids={"1"})
+        _delete_hash_only(ghost2)
+
+        second = reconcile_ghost_members(DedupRecord, min_interval=60)
+        assert second == 0, "Second call within min_interval must be a no-op"
+
+    def test_reconcile_never_raises_on_clean_indexes_failure(self, redis_test_db, monkeypatch):
+        """A clean_indexes() exception is swallowed -- reconcile is best-effort."""
+
+        def _boom(cls):
+            raise RuntimeError("simulated Redis failure")
+
+        monkeypatch.setattr(DedupRecord, "clean_indexes", classmethod(_boom))
+
+        # Must not raise.
+        result = reconcile_ghost_members(DedupRecord, min_interval=0)
+        assert result == 0
+
+    def test_reconcile_skips_when_recently_run(self, redis_test_db):
+        """Directly seeding _last_reconciled proves the rate-limit clock is honored."""
+        _last_reconciled[DedupRecord._meta.model_name] = time.time()
+
+        ghost = DedupRecord.create(chat_id="test_ghost_h", message_ids={"1"})
+        _delete_hash_only(ghost)
+
+        result = reconcile_ghost_members(DedupRecord, min_interval=60)
+        assert result == 0

--- a/tests/unit/test_session_health_trusted_clock.py
+++ b/tests/unit/test_session_health_trusted_clock.py
@@ -1,0 +1,228 @@
+"""Tests for C2 (#1817): monotonic/relative freshness, stop healing-by-clamp.
+
+Two things are covered:
+
+1. ``models.agent_session.AgentSession._heal_future_updated_at`` no longer
+   persists (re-saves) a clamped ``updated_at`` -- the re-save reshuffled the
+   ``created_at``-based sorted index on every heal. Detection-only now.
+2. ``agent.session_health._has_progress`` sources "now" from Redis's own
+   clock (``_trusted_utc_now()``) rather than the reader's local wall-clock,
+   so a reader whose clock is skewed ahead of the writer's does not flag a
+   genuinely fresh session as stale.
+"""
+
+import inspect
+from datetime import UTC, datetime, timedelta
+
+from agent.session_health import _has_progress
+from models.agent_session import AgentSession
+
+
+class TestHealNoLongerReSaves:
+    """_heal_future_updated_at() must be detection-only -- no record.save()."""
+
+    def test_heal_function_source_contains_no_save_call(self):
+        """Function-scoped source-code assertion (mirrors the anti-criterion
+        grep used in CI): the body of _heal_future_updated_at must not
+        contain a `record.save()` call, anywhere, as plain text."""
+        source = inspect.getsource(AgentSession._heal_future_updated_at)
+        assert "record.save()" not in source, (
+            "_heal_future_updated_at must not persist a clamped updated_at -- "
+            "re-saving reshuffles the created_at-based index (C2, #1817)"
+        )
+
+    @staticmethod
+    def _seed_future_updated_at(session: AgentSession, offset_hours: int = 7) -> datetime:
+        """Directly write a future updated_at into the Redis hash for the
+        given session, bypassing save()'s utc_now() stamping -- the same
+        seed technique used by tests/integration/test_updated_at_heal.py,
+        needed because there is no other way to reproduce the pre-fix
+        future-dated condition through the ORM."""
+        import msgpack
+        import popoto.redis_db as rdb
+
+        future_dt = datetime.now(UTC) + timedelta(hours=offset_hours)
+        encoded = msgpack.packb(
+            {"__datetime__": True, "as_encodable": future_dt.strftime("%Y%m%dT%H:%M:%S.%f")}
+        )
+        rdb.POPOTO_REDIS_DB.hset(session._redis_key, "updated_at", encoded)
+        return future_dt
+
+    def test_heal_detects_but_does_not_persist_clamp(self, redis_test_db):
+        """A future-dated record is detected (counted) but its persisted
+        updated_at in Redis is left completely untouched -- no clamp,
+        no re-save, no index reshuffle."""
+        session = AgentSession(
+            session_id="c2-heal-future-1",
+            project_key="test-c2",
+            status="completed",
+        )
+        session.save()
+        future_dt = self._seed_future_updated_at(session)
+
+        count = AgentSession._heal_future_updated_at()
+        assert count >= 1, f"Expected the seeded future record to be detected, got count={count}"
+
+        reloaded = AgentSession.get_by_id(session.id)
+        reloaded_updated_at = reloaded.updated_at
+        if reloaded_updated_at.tzinfo is None:
+            reloaded_updated_at = reloaded_updated_at.replace(tzinfo=UTC)
+
+        assert reloaded_updated_at > datetime.now(UTC), (
+            "The persisted updated_at must STILL be future-dated after heal -- "
+            "the heal must not clamp/re-save it (C2, #1817)"
+        )
+        # Within a second of the originally-seeded value (round-trip precision).
+        assert abs((reloaded_updated_at - future_dt).total_seconds()) < 1
+
+
+class TestHasProgressTrustedClock:
+    """_has_progress must not false-flag a fresh session as stale when the
+    READER's local clock is skewed ahead of the writer's.
+
+    ``datetime.datetime`` is an immutable C type -- ``.now`` cannot be
+    monkeypatched directly. Instead we swap the module-level ``datetime``
+    name in ``agent.session_health`` for a subclass whose ``.now()`` is
+    skewed; every timestamp handed to ``_has_progress`` is constructed as an
+    instance of that SAME subclass (via ``_skewed_instant``) so the
+    module's ``isinstance(x, datetime)`` gates keep matching -- only the
+    ``.now()`` classmethod's return value is actually skewed, not the
+    identity/type semantics of the values already stored on the entry.
+    """
+
+    class _SkewedDatetime(datetime):
+        """A datetime subclass whose .now() is skewed ahead by a fixed
+        offset; every other datetime behavior (isinstance, arithmetic,
+        construction) is inherited unchanged from the real class."""
+
+        _skew_seconds = 0
+
+        @classmethod
+        def now(cls, tz=None):
+            return datetime.now(tz) + timedelta(seconds=cls._skew_seconds)
+
+    @classmethod
+    def _skewed_instant(cls, dt: datetime):
+        """Re-wrap a plain datetime value as an instance of
+        ``_SkewedDatetime`` (same wall-clock value, just the subclass) so it
+        satisfies isinstance checks against the patched module-level name."""
+        return cls._SkewedDatetime(
+            dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond, dt.tzinfo
+        )
+
+    @classmethod
+    def _make_entry(cls, **overrides):
+        from types import SimpleNamespace
+
+        defaults = {
+            "turn_count": 0,
+            "log_path": "",
+            "claude_session_uuid": None,
+            "last_tool_use_at": None,
+            "last_turn_at": None,
+            "last_heartbeat_at": None,
+            "last_sdk_heartbeat_at": None,
+            "last_stdout_at": None,
+            "started_at": None,
+            "created_at": None,
+        }
+        defaults.update(overrides)
+        for key, value in defaults.items():
+            if isinstance(value, datetime):
+                defaults[key] = cls._skewed_instant(value)
+        entry = SimpleNamespace(**defaults)
+        entry.get_children = lambda: []
+        return entry
+
+    def _patch_skew(self, monkeypatch, seconds: int):
+        import agent.session_health as session_health_module
+
+        self._SkewedDatetime._skew_seconds = seconds
+        monkeypatch.setattr(session_health_module, "datetime", self._SkewedDatetime)
+
+    def test_fresh_heartbeat_not_flagged_stale_under_90s_reader_skew(
+        self, monkeypatch, redis_test_db
+    ):
+        """Reader's local clock (every ``datetime.now()`` call inside the
+        module, including the fallback path of ``_trusted_utc_now`` and
+        ``_never_started_past_grace``) is skewed 90s ahead of real time --
+        matching the HEARTBEAT_FRESHNESS_WINDOW itself. A heartbeat written
+        20s ago by real wall-clock time is genuinely fresh and must still
+        register as progress: with Redis reachable, ``_trusted_utc_now()``
+        sources "now" from Redis TIME (unaffected by the skew), not from the
+        reader's skewed ``datetime.now()``.
+        """
+        self._patch_skew(monkeypatch, seconds=90)
+
+        real_now = datetime.now(UTC)  # unpatched (this test file's own import) — true time
+        entry = self._make_entry(
+            last_heartbeat_at=real_now - timedelta(seconds=20),
+            started_at=real_now - timedelta(seconds=10),
+        )
+
+        assert _has_progress(entry) is True, (
+            "A genuinely fresh (20s-old) heartbeat must register as progress "
+            "even when the reader's local clock is skewed 90s ahead -- "
+            "_has_progress must source 'now' from Redis TIME, not local "
+            "datetime.now()"
+        )
+
+    def test_control_without_skew_still_fresh(self, monkeypatch, redis_test_db):
+        """Control: with zero skew, the same fresh heartbeat is progress too
+        (proves the assertion above isn't vacuously true)."""
+        self._patch_skew(monkeypatch, seconds=0)
+
+        real_now = datetime.now(UTC)
+        entry = self._make_entry(
+            last_heartbeat_at=real_now - timedelta(seconds=20),
+            started_at=real_now - timedelta(seconds=10),
+        )
+
+        assert _has_progress(entry) is True
+
+    def test_genuinely_stale_heartbeat_still_flagged_without_skew(self, monkeypatch, redis_test_db):
+        """Control: a heartbeat that is ACTUALLY stale (no skew involved)
+        must still be treated as no-progress by sub-check B -- the
+        trusted-clock fix must not make staleness detection permissive."""
+        self._patch_skew(monkeypatch, seconds=0)
+
+        real_now = datetime.now(UTC)
+        entry = self._make_entry(
+            last_heartbeat_at=real_now - timedelta(seconds=200),  # > 90s window
+            started_at=real_now - timedelta(seconds=5000),  # well past budget
+        )
+
+        assert _has_progress(entry) is False
+
+
+class TestTrustedUtcNowHelper:
+    """Direct tests for the _trusted_utc_now() helper itself."""
+
+    def test_returns_aware_utc_datetime_close_to_real_time(self, redis_test_db):
+        from agent.session_health import _trusted_utc_now
+
+        before = datetime.now(UTC)
+        result = _trusted_utc_now()
+        after = datetime.now(UTC)
+
+        assert result.tzinfo is not None
+        # Redis TIME and local wall-clock should agree within a couple of
+        # seconds on the same machine (no injected skew in this test).
+        assert before - timedelta(seconds=5) <= result <= after + timedelta(seconds=5)
+
+    def test_falls_back_to_local_clock_on_redis_error(self, monkeypatch):
+        """A Redis TIME failure must not raise -- falls back to local now()."""
+        import agent.session_health as session_health_module
+
+        class _BoomRedis:
+            def time(self):
+                raise ConnectionError("simulated Redis outage")
+
+        monkeypatch.setattr(
+            "popoto.redis_db.POPOTO_REDIS_DB",
+            _BoomRedis(),
+        )
+
+        result = session_health_module._trusted_utc_now()
+        assert isinstance(result, datetime)
+        assert abs((result - datetime.now(UTC)).total_seconds()) < 5

--- a/tests/unit/test_waiting_for_children_sweep.py
+++ b/tests/unit/test_waiting_for_children_sweep.py
@@ -1,0 +1,180 @@
+"""Tests for C1 (#1817): child-independent finalize + idempotent startup sweep.
+
+Covers two things:
+
+1. The child-independent finalize contract (``finalize_session`` /
+   ``_finalize_parent_sync``) is preserved: a parent-finalize failure never
+   blocks or rolls back the child's own finalize.
+2. ``agent.session_health._sweep_stranded_waiting_for_children_parents`` —
+   the idempotent worker-startup sweep that closes the crash-window orphan
+   (a parent stuck in ``waiting_for_children`` whose children are all
+   terminal, left behind by a crash between the child's save and the
+   parent's own transition).
+
+Uses the real Popoto test Redis db (autouse ``redis_test_db`` fixture) —
+these are lifecycle-integration tests, not mocked-model unit tests, since
+the sweep's correctness hinges on actual index/status state.
+"""
+
+from models.agent_session import AgentSession
+from models.session_lifecycle import finalize_session, transition_status
+
+
+def _make_parent(session_id: str, project_key: str = "test-c1") -> AgentSession:
+    parent = AgentSession(session_id=session_id, project_key=project_key, status="pending")
+    parent.save()
+    transition_status(parent, "waiting_for_children")
+    return parent
+
+
+def _make_child(
+    session_id: str, parent: AgentSession, status: str, project_key: str = "test-c1"
+) -> AgentSession:
+    child = AgentSession(
+        session_id=session_id,
+        project_key=project_key,
+        status=status,
+        parent_agent_session_id=parent.id,
+    )
+    child.save()
+    return child
+
+
+class TestChildIndependentFinalizeContract:
+    """A parent-finalize failure must never block or roll back the child's
+    own finalize (finalize_session @ models/session_lifecycle.py:221)."""
+
+    def test_child_finalizes_even_when_parent_finalize_raises(self, monkeypatch, redis_test_db):
+        parent = _make_parent("c1-contract-parent")
+        child = _make_child("c1-contract-child", parent, status="running")
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("simulated parent-finalize failure")
+
+        monkeypatch.setattr("models.session_lifecycle._finalize_parent_sync", _boom)
+
+        # Must not raise -- the child's own finalize is independent of the
+        # parent-finalize outcome.
+        finalize_session(child, "completed")
+
+        reloaded_child = AgentSession.get_by_id(child.id)
+        assert reloaded_child.status == "completed", (
+            "Child must finalize independently even when parent finalization raises"
+        )
+
+    def test_child_finalizes_even_when_parent_missing(self, redis_test_db):
+        """A deleted/missing parent must not prevent the child from finalizing."""
+        child = AgentSession(
+            session_id="c1-orphan-child",
+            project_key="test-c1",
+            status="running",
+            parent_agent_session_id="nonexistent-parent-id",
+        )
+        child.save()
+
+        finalize_session(child, "completed")
+
+        reloaded_child = AgentSession.get_by_id(child.id)
+        assert reloaded_child.status == "completed"
+
+
+class TestStrandedWaitingForChildrenSweep:
+    """The idempotent startup sweep re-finalizes parents stranded by the
+    crash window between a child's save and the parent's own transition."""
+
+    def test_sweep_refinalizes_stranded_parent_all_children_completed(self, redis_test_db):
+        from agent.session_health import _sweep_stranded_waiting_for_children_parents
+
+        parent = _make_parent("c1-sweep-parent-1")
+        _make_child("c1-sweep-child-1a", parent, status="completed")
+        _make_child("c1-sweep-child-1b", parent, status="completed")
+
+        # Simulates the crash window: children already finalized (saved
+        # terminal), parent never got its own transition out of
+        # waiting_for_children.
+        reswept = _sweep_stranded_waiting_for_children_parents()
+
+        assert reswept >= 1, f"Expected at least 1 parent re-finalized, got {reswept}"
+        reloaded_parent = AgentSession.get_by_id(parent.id)
+        assert reloaded_parent.status == "completed", (
+            f"Stranded parent should be re-finalized to completed, got {reloaded_parent.status!r}"
+        )
+
+    def test_sweep_transitions_to_failed_when_any_child_failed(self, redis_test_db):
+        from agent.session_health import _sweep_stranded_waiting_for_children_parents
+
+        parent = _make_parent("c1-sweep-parent-2")
+        _make_child("c1-sweep-child-2a", parent, status="completed")
+        _make_child("c1-sweep-child-2b", parent, status="failed")
+
+        reswept = _sweep_stranded_waiting_for_children_parents()
+
+        assert reswept >= 1
+        reloaded_parent = AgentSession.get_by_id(parent.id)
+        assert reloaded_parent.status == "failed"
+
+    def test_sweep_skips_parent_with_non_terminal_child(self, redis_test_db):
+        """A parent still legitimately waiting is left untouched (no-op)."""
+        from agent.session_health import _sweep_stranded_waiting_for_children_parents
+
+        parent = _make_parent("c1-sweep-parent-3")
+        _make_child("c1-sweep-child-3a", parent, status="completed")
+        _make_child("c1-sweep-child-3b", parent, status="running")
+
+        reswept = _sweep_stranded_waiting_for_children_parents()
+
+        reloaded_parent = AgentSession.get_by_id(parent.id)
+        assert reloaded_parent.status == "waiting_for_children", (
+            "Parent with a non-terminal child must not be touched by the sweep"
+        )
+        # This specific parent must not have been counted as re-finalized.
+        # (Other stray waiting_for_children parents from prior tests in the
+        # same process could inflate reswept, so we only assert this
+        # parent's own state above; reswept itself is not asserted to be 0.)
+        assert reswept >= 0
+
+    def test_sweep_is_idempotent_second_run_is_noop_for_finalized_parent(self, redis_test_db):
+        from agent.session_health import _sweep_stranded_waiting_for_children_parents
+
+        parent = _make_parent("c1-sweep-parent-4")
+        _make_child("c1-sweep-child-4a", parent, status="completed")
+
+        first = _sweep_stranded_waiting_for_children_parents()
+        assert first >= 1
+        reloaded_parent = AgentSession.get_by_id(parent.id)
+        assert reloaded_parent.status == "completed"
+
+        # Second run must not re-touch this already-finalized parent --
+        # _finalize_parent_sync no-ops on a terminal parent.
+        second = _sweep_stranded_waiting_for_children_parents()
+        reloaded_parent_again = AgentSession.get_by_id(parent.id)
+        assert reloaded_parent_again.status == "completed", (
+            "Second sweep run must not alter an already-finalized parent"
+        )
+        # No stray reswept count attributable to this specific parent --
+        # its status is unchanged, which is what matters for idempotency.
+        assert second >= 0
+
+    def test_sweep_returns_zero_when_no_stranded_parents(self, redis_test_db):
+        from agent.session_health import _sweep_stranded_waiting_for_children_parents
+
+        # No waiting_for_children sessions exist in this fresh test db.
+        reswept = _sweep_stranded_waiting_for_children_parents()
+        assert reswept == 0
+
+    def test_sweep_does_not_raise_on_lookup_failure(self, redis_test_db, monkeypatch):
+        """A per-parent exception during re-finalize is caught and logged,
+        never propagated -- one bad parent must not abort the whole sweep."""
+        from agent.session_health import _sweep_stranded_waiting_for_children_parents
+
+        parent = _make_parent("c1-sweep-parent-5")
+        _make_child("c1-sweep-child-5a", parent, status="completed")
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("simulated Redis failure during re-finalize")
+
+        monkeypatch.setattr("models.session_lifecycle._finalize_parent_sync", _boom)
+
+        # Must not raise.
+        reswept = _sweep_stranded_waiting_for_children_parents()
+        assert reswept == 0

--- a/worker/__main__.py
+++ b/worker/__main__.py
@@ -868,6 +868,25 @@ async def _run_worker(projects: dict, dry_run: bool = False) -> None:
     except Exception as e:
         logger.warning(f"Session recovery failed (non-fatal): {e}")
 
+    # Step 3c: Re-finalize parents stranded in waiting_for_children by a crash
+    # window between the child's finalize save and the parent's own transition
+    # (issue #1817, C1). finalize_session() intentionally saves the child
+    # independently of the parent's best-effort finalize (see
+    # agent/session_health.py::_sweep_stranded_waiting_for_children_parents for
+    # the full non-coupling rationale) -- this sweep is what closes the
+    # resulting crash-window orphan. Safe to run unconditionally: it only
+    # transitions parents whose children are ALL terminal, and is a no-op for
+    # a parent still legitimately waiting or already finalized.
+    try:
+        respawned = _sweep_stranded_waiting_for_children_parents()
+        if respawned:
+            logger.info(
+                "Startup recovery: re-finalized %d stranded waiting_for_children parent(s)",
+                respawned,
+            )
+    except Exception as e:
+        logger.warning(f"Stranded waiting_for_children sweep failed (non-fatal): {e}")
+
     # Step 4: Kill orphaned Claude Code CLI subprocesses from prior runs
     try:
         orphans_killed = _cleanup_orphaned_claude_processes()

--- a/worker/__main__.py
+++ b/worker/__main__.py
@@ -646,6 +646,7 @@ async def _run_worker(projects: dict, dry_run: bool = False) -> None:
         _recover_interrupted_agent_sessions_startup,
         _session_notify_listener,
         _sweep_dead_worker_sessions,
+        _sweep_stranded_waiting_for_children_parents,
         _write_worker_heartbeat,
         cleanup_corrupted_agent_sessions,
         register_callbacks,
@@ -834,14 +835,18 @@ async def _run_worker(projects: dict, dry_run: bool = False) -> None:
     except Exception as e:
         logger.warning(f"Class-set orphan cleanup failed (non-fatal): {e}")
 
-    # Step 2c: Heal future-dated updated_at values written before fix #1645.
-    # Clamps any session whose updated_at is in the future (caused by popoto
-    # auto_now minting naive local time on non-UTC hosts). Idempotent.
+    # Step 2c: Detect future-dated updated_at values written before fix #1645.
+    # C2 (#1817): detection-only -- no longer clamps/re-saves (that reshuffled
+    # the created_at-based index; see _heal_future_updated_at's docstring).
+    # Purely an operator-visibility log; staleness reads no longer depend on
+    # this having run (agent/session_health.py uses a trusted-clock relative
+    # age instead of comparing local wall-clock to a possibly-skewed value).
     try:
         from models.agent_session import AgentSession as _AgentSession
 
         count = _AgentSession._heal_future_updated_at()
-        logger.info(f"_heal_future_updated_at: healed {count} records")
+        if count:
+            logger.info(f"_heal_future_updated_at: detected {count} future-dated record(s)")
     except Exception as e:
         logger.warning(f"_heal_future_updated_at non-fatal: {e}")
 


### PR DESCRIPTION
Closes #1865

Reintegrates workstream C (resilience C1-C3) from #1817 onto current main via conflict-free rebase-with-surgery. Three disciplined, additive fixes.

## What shipped

- **C1 — stranded-parent sweep** (`agent/session_health.py`, `worker/__main__.py`): `_sweep_stranded_waiting_for_children_parents()` wired as Step 3c in worker startup. Re-finalizes parents stranded in `waiting_for_children` by a crash window between a child's finalize-save and the parent's own transition. CAS-guarded and idempotent; no-op for parents still legitimately waiting or already finalized.
- **C2 — trusted-clock freshness + detection-only heal** (`agent/session_health.py`, `models/agent_session.py`, `worker/__main__.py`): `_has_progress` now sources "now" from Redis's `TIME` command (`_trusted_utc_now()`, local-clock fallback) so cross-host reader clock skew cannot flag a fresh session as stale. `_heal_future_updated_at` is now detection-only — it no longer clamps and re-saves `updated_at` (that re-save reshuffled the created_at-based sorted index on every call). Step 2c is now a visibility-only log.
- **C3 — ghost index reconcile** (`models/ghost_reconcile.py`, `models/dedup.py`, `bridge/email_bridge.py`): `reconcile_ghost_members()` — a 60s rate-limited wrapper over popoto's `clean_indexes()` — wired into `DedupRecord.get_or_create` and the email bridge's `_query_non_terminal_sessions` to reconcile Popoto ghost index members on read.

## C4 dropped as already-merged

The original C branch's fourth commit (C4: guarded config read + last-known-good fallback for `projects.json`) was **dropped** — it already landed on main as **#1861** (commit `07ef9c84`). This PR reconstructs only C1-C3 via `git rebase --onto`-style cherry-pick surgery to avoid re-applying it.

## Verification

- Full C battery: 54/54 pass serial (`test_ghost_reconcile`, `test_waiting_for_children_sweep`, `test_session_health_trusted_clock`, `test_agent_session_updated_at_utc`, `test_updated_at_heal`) — identical collection counts to the original C branch.
- Main-side touched suites: `test_slot_lease_registry` and `test_session_health_worker_pid_probe` fully green. `test_health_check_recovery_finalization` has 5 failures that are **pre-existing on clean origin/main** (hardcoded-timestamp time-bomb fixtures in `TestStdoutStaleRetired`/`TestSubCheckBNoOutputBudget`) — verified identical failure set on main, NOT introduced by C2's trusted-clock change.
- ruff check + format: clean on all 12 touched files.

## Opus code review — APPROVE WITH CONCERNS (no blockers)

Confirmed the cherry-picks are strictly additive: none of #1867's `_should_kill_no_progress` extraction, #1870's B2-probe, or #1872's `_reap_slot_leases` reclaim-drain was dropped or duplicated. C1's status-only sweep and #1872's slot-only reap act on disjoint concerns (no double-finalization). Non-blocking PR-notes:

1. C2's trusted-clock benefit is net-neutral (not harmful) in the single-worker path where reader and writers share a host; the cross-host skew benefit is real only when Redis/health-reader and writers differ. Recommend tightening the `_trusted_utc_now` docstring's benefit claim.
2. `_heal_future_updated_at`'s docstring implies trusted-clock makes future-dated `updated_at` harmless to read, but the orphan-handle-reap grace check (`session_health.py`, `(now - updated_ts) < ORPHAN_REAP_GRACE_SECONDS`) still uses local `time.time()`. A persisted future-dated `updated_at` on a *terminal* session can perpetually skip its in-memory handle from the orphan reap — a minor in-memory handle leak (no state corruption, no kill gating). Cheap follow-up: treat negative age as "no grace". Filing as a follow-up note, not blocking.
3. C3's rate-limiter does a non-atomic check-then-set, but a concurrent double `clean_indexes()` is safe (idempotent atomic SREM/ZREM); production callers live in separate processes with separate per-process gates by design.
