### PR TITLE
fix(worker/bridge): version-pin drift, PTY pid persist, observable bg-task failures, notify liveness (D1-D4, from #1817)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -429,8 +429,9 @@ GRANITE_BREAKER_COOLDOWN_S=120.0
 # ~/.local/share/claude/versions/<version>/). PROVISIONAL — bumping this is a
 # deliberate procedure (re-verify the D1b markers against the new version's
 # actual TUI output first). See docs/features/deployment.md. Uncomment to
-# override the default baked into scripts/update/verify.py.
-# PINNED_CLAUDE_VERSION=2.1.197
+# override the default single-sourced in config/models.py (shared by the D1a
+# update-time drift check and the #1839 nightly ollama canary).
+# PINNED_CLAUDE_VERSION=2.1.198
 
 # D1a/D1b: shared enforce flag for the claude-CLI-contract checks (version
 # pin drift in scripts/update/verify.py, TUI-marker contract-check in

--- a/.env.example
+++ b/.env.example
@@ -421,6 +421,33 @@ GRANITE_BREAKER_COOLDOWN_S=120.0
 # GRANITE__DEV_TRANSPORT=pty
 
 # =============================================================================
+# Correctness & delivery-integrity hardening (issue #1817)
+# =============================================================================
+
+# D1a: pinned `claude` CLI version the D1b scraped-TUI-marker contract was
+# last verified against (native installer: ~/.local/bin/claude ->
+# ~/.local/share/claude/versions/<version>/). PROVISIONAL — bumping this is a
+# deliberate procedure (re-verify the D1b markers against the new version's
+# actual TUI output first). See docs/features/deployment.md. Uncomment to
+# override the default baked into scripts/update/verify.py.
+# PINNED_CLAUDE_VERSION=2.1.197
+
+# D1a/D1b: shared enforce flag for the claude-CLI-contract checks (version
+# pin drift in scripts/update/verify.py, TUI-marker contract-check in
+# worker/__main__.py). Default off (warn-only, non-blocking) — set to "1" to
+# hard-fail /update and worker startup on a detected drift. Off by default
+# for the first release since a version bump or a marker mismatch does not
+# necessarily mean anything is actually broken.
+# CLAUDE_CONTRACT_CHECK_ENFORCE=1
+
+# D4: interval (seconds) for the session-notify pubsub liveness watchdog —
+# a periodic PUBSUB NUMSUB probe on a SEPARATE short-lived Redis connection
+# (never the listen() connection) that detects a silently-dropped
+# subscription (e.g. a Redis failover) and forces a resubscribe. Provisional
+# — 15s balances quick detection against probe overhead.
+# NOTIFY_HEALTHCHECK_INTERVAL=15
+
+# =============================================================================
 # Background-task supervisor (worker fault containment Fix #4, issue #1816)
 # =============================================================================
 

--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -807,6 +807,117 @@ def _numsub_count(numsub_result: object, channel: str) -> int:
     return 0
 
 
+# D4 (issue #1817): interval (seconds) for the periodic off-path pubsub
+# liveness watchdog below. Provisional/tunable — balances quick detection of
+# a silently-dropped subscription against probe overhead. Also documented as
+# a typed catalog entry at config/settings.py Settings.notify_healthcheck_interval.
+# Read directly via os.environ here (not through the settings singleton) so
+# a value changed after process startup — e.g. test monkeypatching — takes
+# effect immediately. Override via NOTIFY_HEALTHCHECK_INTERVAL env var.
+NOTIFY_HEALTHCHECK_INTERVAL = float(os.environ.get("NOTIFY_HEALTHCHECK_INTERVAL", "15"))
+
+
+class _ListenerPubsubHandle:
+    """Mutable holder for the current listener thread's LIVE pubsub object.
+
+    Populated by `_listen_in_thread` only AFTER a subscribe is confirmed via
+    the NUMSUB self-check (so the watchdog never touches a pubsub object
+    that's still mid-establishment); cleared before that thread's own
+    teardown begins. Read by `_notify_healthcheck_watchdog` (D4) to
+    force-close a CONFIRMED-dropped subscription so the listener's blocking
+    `listen()` call returns and the outer `while True` loop in
+    `_session_notify_listener` re-subscribes. Never used to touch the
+    `listen()` connection's `socket_timeout=None` — only `.close()` to
+    unblock it.
+    """
+
+    def __init__(self) -> None:
+        self.pubsub = None
+
+
+async def _notify_healthcheck_watchdog(handle: "_ListenerPubsubHandle") -> None:
+    """Periodic OFF-PATH liveness probe for the session-notify subscription.
+
+    D4 (issue #1817). The subscribe-time NUMSUB self-check in
+    `_listen_in_thread` only catches a subscribe that failed to register in
+    the first place. It does NOT catch POST-subscribe drift — a subscription
+    that was fine, then silently drops (e.g. a Redis failover) with no
+    exception on the `listen()` connection, leaving the listener wedged for
+    up to 300s (the existing health backstop in agent/session_health.py)
+    before anything notices (the conceding comment in `_listen_in_thread`'s
+    docstring, above).
+
+    Every NOTIFY_HEALTHCHECK_INTERVAL seconds, this issues `PUBSUB NUMSUB` on
+    a SEPARATE, short-lived Redis connection — NEVER on the `listen()`
+    connection. That connection's `socket_timeout=None` MUST stay
+    unconditional: a finite timeout there previously caused spurious
+    "Timeout reading from socket" exceptions and a 10s reconnect cycle that
+    DROPPED notifications published during the dead window (see
+    `_listen_in_thread`'s docstring). This watchdog's own probe connection
+    uses a short finite timeout — that is fine, because it is a disposable
+    connection used for one NUMSUB call, never the persistent listen()
+    connection.
+
+    On a CONFIRMED NUMSUB==0 for valor:sessions:new, logs a WARNING and
+    force-closes the listener's pubsub handle so its blocking `listen()`
+    call returns, letting the outer while-True loop re-subscribe. A
+    transient probe error (Redis briefly unreachable) is logged at WARNING
+    and the tick is skipped — it must NOT tear down a healthy listener on a
+    probe-side failure, only on a CONFIRMED drop.
+    """
+    while True:
+        await asyncio.sleep(NOTIFY_HEALTHCHECK_INTERVAL)
+
+        try:
+            import redis as _redis
+            from popoto.redis_db import POPOTO_REDIS_DB
+
+            kw = POPOTO_REDIS_DB.connection_pool.connection_kwargs
+            probe_conn = _redis.Redis(
+                host=kw.get("host", "localhost"),
+                port=kw.get("port", 6379),
+                db=kw.get("db", 0),
+                username=kw.get("username"),
+                password=kw.get("password"),
+                decode_responses=kw.get("decode_responses", False),
+                # Short-lived probe connection ONLY — never the listen()
+                # connection, whose socket_timeout=None is load-bearing.
+                socket_timeout=5,
+            )
+            try:
+                numsub_result = probe_conn.pubsub_numsub("valor:sessions:new")
+                count = _numsub_count(numsub_result, "valor:sessions:new")
+            finally:
+                try:
+                    probe_conn.close()
+                except Exception:
+                    pass
+        except Exception as e:
+            logger.warning(
+                "Session notify healthcheck: NUMSUB probe raised (skipping "
+                "this tick, NOT tearing down the listener): %s",
+                e,
+            )
+            continue
+
+        if count == 0:
+            logger.warning(
+                "Session notify healthcheck: NUMSUB confirmed 0 for "
+                "valor:sessions:new — notify subscription dropped, forcing "
+                "resubscribe"
+            )
+            pubsub = handle.pubsub
+            if pubsub is not None:
+                try:
+                    pubsub.close()
+                except Exception as close_err:
+                    logger.debug(
+                        "Session notify healthcheck: pubsub.close() during "
+                        "forced resubscribe raised (non-fatal): %s",
+                        close_err,
+                    )
+
+
 async def _session_notify_listener() -> None:
     """Subscribe to valor:sessions:new and wake the worker on new sessions.
 
@@ -816,10 +927,17 @@ async def _session_notify_listener() -> None:
     Uses a queue to bridge the blocking pubsub.listen() thread and the asyncio
     event loop: the background thread puts chat_ids onto the queue, and the
     coroutine awaits them and calls _ensure_worker / sets the event.
+
+    D4 (issue #1817): alongside the blocking listener thread, each iteration
+    also runs `_notify_healthcheck_watchdog` — a periodic off-path liveness
+    probe that detects a POST-subscribe drop and forces a resubscribe. The
+    watchdog task is held (not fire-and-forget) and cancelled in `finally`
+    every iteration so it never outlives its listener generation.
     """
     while True:
         notify_queue: asyncio.Queue = asyncio.Queue()
         loop = asyncio.get_running_loop()
+        pubsub_handle = _ListenerPubsubHandle()
 
         def _listen_in_thread() -> None:
             """Blocking loop that drains pubsub and forwards chat_ids to the queue.
@@ -853,6 +971,17 @@ async def _session_notify_listener() -> None:
                     username=kw.get("username"),
                     password=kw.get("password"),
                     decode_responses=kw.get("decode_responses", False),
+                    # KEEP socket_timeout=None. Do NOT "helpfully" add a finite
+                    # timeout here (see this function's docstring, above): a
+                    # finite timeout on THIS connection previously caused
+                    # spurious "Timeout reading from socket" exceptions and a
+                    # 10s reconnect cycle that dropped notifications published
+                    # during the dead window. D4 (issue #1817) added a
+                    # SEPARATE periodic watchdog (`_notify_healthcheck_watchdog`)
+                    # that probes liveness on its OWN short-lived connection
+                    # instead of touching this one — that is the sanctioned way
+                    # to add periodic liveness checking without reintroducing
+                    # the reverted finite-timeout bug.
                     socket_timeout=None,
                     socket_connect_timeout=None,
                 )
@@ -898,6 +1027,11 @@ async def _session_notify_listener() -> None:
                     # Fall through to the existing finally teardown; the outer while True
                     # loop will re-subscribe after its 5s backoff.
                     return
+                # D4 (issue #1817): publish the confirmed-live pubsub object to
+                # the shared handle only NOW — after the NUMSUB self-check
+                # passed — so the healthcheck watchdog never force-closes a
+                # subscription that's still mid-establishment.
+                pubsub_handle.pubsub = pubsub
                 for message in pubsub.listen():
                     if message["type"] != "message":
                         continue
@@ -920,6 +1054,9 @@ async def _session_notify_listener() -> None:
             except Exception as e:
                 logger.warning("Session notify listener thread error: %s", e)
             finally:
+                # D4: clear the shared handle FIRST so the watchdog never
+                # races this thread's own teardown below.
+                pubsub_handle.pubsub = None
                 # Teardown in order: unsubscribe → close pubsub → close connection
                 # This prevents dangling Redis subscribers on reconnect cycles.
                 if pubsub is not None:
@@ -939,6 +1076,10 @@ async def _session_notify_listener() -> None:
                 # Signal the coroutine side to restart
                 loop.call_soon_threadsafe(notify_queue.put_nowait, None)
 
+        # D4: the healthcheck watchdog runs for this listener generation only.
+        # Held (not fire-and-forget) and cancelled in `finally` below so it
+        # can never outlive the listener thread it's watching.
+        watchdog_task = asyncio.create_task(_notify_healthcheck_watchdog(pubsub_handle))
         try:
             # Run the blocking pubsub loop in a thread; process results here
             listener_future = asyncio.to_thread(_listen_in_thread)
@@ -963,6 +1104,12 @@ async def _session_notify_listener() -> None:
 
         except Exception as e:
             logger.warning("Session notify listener error: %s. Retrying in 5s...", e)
+        finally:
+            watchdog_task.cancel()
+            try:
+                await watchdog_task
+            except (asyncio.CancelledError, Exception):
+                pass
 
         await asyncio.sleep(5)
 

--- a/agent/granite_container/pty_driver.py
+++ b/agent/granite_container/pty_driver.py
@@ -137,6 +137,60 @@ QUIESCENCE_S = 2.0
 # with spaces (`Esc to cancel`); \s* matches both forms.
 OVERLAY_BAR = re.compile(r"esc\s*to\s*cancel", re.IGNORECASE)
 
+# === D1b: startup contract-check golden samples (issue #1817) ===
+#
+# Fingerprint check, not a live TUI spawn: a real `claude` PTY dry-spawn was
+# considered and rejected for the startup gate — it risks the same macOS
+# TCC/TTY hang the existing `claude -p` harness smoke test already guards
+# against under launchd (see `worker/__main__.py`'s VALOR_LAUNCHD-gated
+# `verify_harness_health` call), and costs several seconds on every worker
+# boot. Instead, each golden sample below is a literal reproduction of ACTUAL
+# observed CLI output already documented in this module's comments (IDLE_BAR,
+# SPINNER_EVIDENCE_RE above) and in `startup_parser.py` (trust-folder). The
+# contract-check (`verify_tui_marker_contract`) re-runs each marker regex
+# against its golden sample at worker startup: a mismatch means a code
+# refactor silently broke the marker (this repo's own regression), which is a
+# DIFFERENT failure mode than "the installed claude CLI's actual TUI output
+# drifted" (that's what D1a's version pin + a human re-verification pass
+# after a version bump covers — see docs/features/deployment.md).
+_CONTRACT_GOLDEN_SAMPLES: dict[str, str] = {
+    "IDLE_BAR": "  bypass permissions  ",
+    "PROMPT_GLYPH": "❯ ",
+    "SPINNER_EVIDENCE_RE": "✻ Sprouting… (esc to interrupt)",
+    "TRUST_FOLDER_PROMPT": "Do you trust the files in this folder?\n❯ 1. Yes, I trust this folder",
+}
+
+
+def verify_tui_marker_contract() -> tuple[bool, list[str]]:
+    """D1b (issue #1817): confirm the PTY driver's scraped TUI markers still
+    recognize their golden (known-good) sample text.
+
+    Checks IDLE_BAR, PROMPT_GLYPH, SPINNER_EVIDENCE_RE (this module) and the
+    trust-folder prompt pattern (`agent.granite_container.startup_parser`).
+    Returns ``(ok, failed_marker_names)`` — ``ok`` is True only when every
+    marker matches its golden sample. Never raises; a missing/broken import
+    is reported as a failed marker rather than propagating, so a startup
+    caller can decide how to react (see `worker/__main__.py`).
+    """
+    from agent.granite_container.startup_parser import StartupEvent, parse_startup_frame
+
+    failed: list[str] = []
+    if not IDLE_BAR.search(_CONTRACT_GOLDEN_SAMPLES["IDLE_BAR"]):
+        failed.append("IDLE_BAR")
+    if not PROMPT_GLYPH.search(_CONTRACT_GOLDEN_SAMPLES["PROMPT_GLYPH"]):
+        failed.append("PROMPT_GLYPH")
+    if not SPINNER_EVIDENCE_RE.search(_CONTRACT_GOLDEN_SAMPLES["SPINNER_EVIDENCE_RE"]):
+        failed.append("SPINNER_EVIDENCE_RE")
+    try:
+        match = parse_startup_frame(_CONTRACT_GOLDEN_SAMPLES["TRUST_FOLDER_PROMPT"])
+        if match is None or match.event != StartupEvent.TRUST_FOLDER_PROMPT:
+            failed.append("TRUST_FOLDER_PROMPT")
+    except Exception:
+        failed.append("TRUST_FOLDER_PROMPT")
+
+    return (not failed, failed)
+
+
 # C1: the submit key. Sent as a SEPARATE keystroke after the text body.
 SUBMIT_KEY = b"\r"
 # C1: delay between sending the text body and the submit CR. The TUI's

--- a/agent/granite_container/pty_pool.py
+++ b/agent/granite_container/pty_pool.py
@@ -595,6 +595,13 @@ class PTYPool:
             # a 2-tuple so slot semantics / release lifecycle are unchanged.
             pm: PTYDriver | None = None
             dev: PTYDriver | None = None
+            # D2 (issue #1817): persist each child's pid IMMEDIATELY after its
+            # own spawn() returns, not batched after both roles spawn. Before
+            # this, a dev.spawn() failure after a successful pm.spawn() left
+            # pm's pid unpersisted and unreapable as an orphan. Guarded with
+            # `pty is not None and pty._child is not None` because a #1842
+            # headless role leaves `pty` as None — no PTY process, correctly
+            # nothing to record.
             if spec.pm_transport != "headless":
                 pm = PTYDriver(
                     role="pm",
@@ -605,6 +612,12 @@ class PTYPool:
                     settings_path=spec.pm_settings_path,
                 )
                 pm.spawn()
+                if pm is not None and pm._child is not None:
+                    pm_pid = getattr(pm._child, "pid", None)
+                    if pm_pid is not None:
+                        with self._pids_lock:
+                            self._spawned_pids.add(pm_pid)
+                        self._persist_pids()
             if spec.dev_transport != "headless":
                 dev = PTYDriver(
                     role="dev",
@@ -615,7 +628,20 @@ class PTYPool:
                     settings_path=spec.dev_settings_path,
                 )
                 dev.spawn()
+                if dev is not None and dev._child is not None:
+                    dev_pid = getattr(dev._child, "pid", None)
+                    if dev_pid is not None:
+                        with self._pids_lock:
+                            self._spawned_pids.add(dev_pid)
+                        self._persist_pids()
             slot.pty_pair = (pm, dev)
+            # D2's per-spawn blocks above already durably persisted each pid the
+            # instant it was known (so a dev.spawn() failure after pm.spawn()
+            # can't strand pm's pid). This consolidated pass re-adds under
+            # `_pids_lock` as idempotent belt-and-suspenders and, because the
+            # trailing `_persist_pids()` is unconditional, also writes the
+            # correct empty-set state for a fully-headless pair (nothing spawned,
+            # nothing to reap) rather than silently skipping the write.
             with self._pids_lock:
                 for pty in (pm, dev):
                     if pty is None:

--- a/agent/memory_extraction.py
+++ b/agent/memory_extraction.py
@@ -325,8 +325,14 @@ def _record_extraction_error(
                 "project_key": project_key or "",
             },
         )
-    except Exception:
-        pass
+    except Exception as e:
+        # D3 (issue #1817): was silently swallowed. Non-fatal by design
+        # (analytics must never crash extraction) but now observable.
+        logger.debug(
+            "[memory_extraction] record_metric(memory.extraction.error) failed for session %s: %s",
+            session_id,
+            e,
+        )
 
 
 # Extraction prompt for Haiku — structured JSON output
@@ -534,8 +540,15 @@ async def extract_observations_async(
                     )
 
                     generate_title_async(m.memory_id, strip_private(obs_content[:500]))
-                except Exception:
-                    pass
+                except Exception as e:
+                    # D3 (issue #1817): title generation is best-effort — a
+                    # missing title never blocks the memory save — but was
+                    # previously invisible on failure.
+                    logger.debug(
+                        "[memory_extraction] generate_title_async failed for memory %s: %s",
+                        getattr(m, "memory_id", "?"),
+                        e,
+                    )
 
                 saved.append(
                     {
@@ -557,8 +570,13 @@ async def extract_observations_async(
                 float(len(saved)),
                 {"session_id": session_id, "project_key": project_key},
             )
-        except Exception:
-            pass
+        except Exception as e:
+            # D3 (issue #1817): was silently swallowed.
+            logger.debug(
+                "[memory_extraction] record_metric(memory.extraction) failed for session %s: %s",
+                session_id,
+                e,
+            )
 
         return saved
 
@@ -788,8 +806,14 @@ async def extract_post_merge_learning(
                 )
 
                 generate_title_async(m.memory_id, strip_private(content_text[:500]))
-            except Exception:
-                pass
+            except Exception as e:
+                # D3 (issue #1817): title generation is best-effort — was
+                # previously invisible on failure.
+                logger.debug(
+                    "[memory_extraction] generate_title_async failed for memory %s: %s",
+                    getattr(m, "memory_id", "?"),
+                    e,
+                )
 
             logger.info(f"[memory_extraction] Post-merge learning saved: {content_text[:100]}")
             return {
@@ -1026,7 +1050,15 @@ def _persist_outcome_metadata(
 
             m.metadata = meta
             m.save()
-        except Exception:
+        except Exception as e:
+            # D3 (issue #1817): was silently swallowed ("fail-silent per
+            # record" is intentional — one bad record must not abort the
+            # rest of the batch — but the failure is now observable).
+            logger.debug(
+                "[memory_extraction] outcome update failed for memory %s: %s",
+                mid,
+                e,
+            )
             continue  # fail-silent per record
 
 

--- a/agent/sdk_client.py
+++ b/agent/sdk_client.py
@@ -1891,7 +1891,19 @@ class ValorAgent:
                 session_id,
                 query_timeout,
             )
-            asyncio.ensure_future(circuit.record_failure(TimeoutError("query timeout")))
+            # Awaited directly (D3, issue #1817) instead of fire-and-forget
+            # `asyncio.ensure_future` — a Redis write failure here used to
+            # vanish silently (the circuit breaker never trips). Wrapped so a
+            # failure to RECORD the failure can't mask the real TimeoutError.
+            try:
+                await circuit.record_failure(TimeoutError("query timeout"))
+            except Exception as breaker_exc:
+                logger.warning(
+                    "[circuit-breaker] record_failure raised — breaker may not "
+                    "trip for session %s: %s",
+                    session_id,
+                    breaker_exc,
+                )
             raise
 
         except asyncio.CancelledError:
@@ -1905,8 +1917,20 @@ class ValorAgent:
             raise
 
         except Exception as e:
-            # Record failure for circuit breaker
-            asyncio.ensure_future(circuit.record_failure(e))
+            # Record failure for circuit breaker. Awaited directly (D3, issue
+            # #1817) — a fire-and-forget `ensure_future` here meant a Redis
+            # write failure while RECORDING this very failure was invisible,
+            # so the breaker silently never tripped. Guarded so a breaker
+            # write failure can't mask the original exception `e`.
+            try:
+                await circuit.record_failure(e)
+            except Exception as breaker_exc:
+                logger.warning(
+                    "[circuit-breaker] record_failure raised — breaker may not "
+                    "trip for session %s: %s",
+                    session_id,
+                    breaker_exc,
+                )
 
             error_str = str(e)
             init_elapsed = time.time() - init_start
@@ -1971,8 +1995,17 @@ class ValorAgent:
             raise
 
         else:
-            # Query succeeded — record success for circuit breaker
-            asyncio.ensure_future(circuit.record_success())
+            # Query succeeded — record success for circuit breaker. Awaited
+            # directly (D3, issue #1817); see the `record_failure` sites above
+            # for why fire-and-forget hid Redis write failures.
+            try:
+                await circuit.record_success()
+            except Exception as breaker_exc:
+                logger.warning(
+                    "[circuit-breaker] record_success raised for session %s: %s",
+                    session_id,
+                    breaker_exc,
+                )
 
         finally:
             # Always unregister client from registry

--- a/agent/session_health.py
+++ b/agent/session_health.py
@@ -47,8 +47,21 @@ logger = logging.getLogger(__name__)
 
 # === Cross-process orphan reaper constants (issue #1271) ===
 #
-# Compiled cmdline regex patterns. Two signatures match:
-#   - Claude CLI (``claude_agent_sdk/_bundled/claude``)
+# Compiled cmdline regex patterns. Three signatures match:
+#   - Claude CLI SDK bundle (``claude_agent_sdk/_bundled/claude``)
+#   - The native/PTY granite TUI process (D2, issue #1817): a bare or
+#     absolute-path ``claude`` invocation carrying ``--permission-mode
+#     bypassPermissions`` (see ``agent/granite_container/pty_driver.py``'s
+#     ``spawn()`` argv) that is NOT a one-shot. The two leading negative
+#     lookaheads exclude any cmdline containing a standalone ``-p`` token or
+#     ``--print`` — those are headless ``claude -p`` one-shot turns
+#     (``agent/granite_container/role_driver.py``'s ``HeadlessRoleDriver``,
+#     also carrying ``--permission-mode bypassPermissions``), which are
+#     ALREADY governed by the separate, narrower, age-gated
+#     ``_is_stale_print_oneshot`` matcher below. Overlapping the two would
+#     let this broader regex fast-track-match (via ``is_claude``) an
+#     in-flight headless turn before its own one-shot matcher's age gate
+#     even applies — do not remove the lookaheads.
 #   - Any MCP server module under ``mcp_servers/``
 #
 # The worker pattern (``python -m worker``) is INTENTIONALLY EXCLUDED:
@@ -57,7 +70,10 @@ logger = logging.getLogger(__name__)
 # signature + PPID==1 filter would match every live worker. As an additional
 # defense-in-depth layer, the reaper builds a positive-ID skip-set from
 # ``worker:registered_pid:*`` Redis keys.
-_CLAUDE_CMDLINE_RE = re.compile(r"claude_agent_sdk/_bundled/claude\b")
+_CLAUDE_CMDLINE_RE = re.compile(
+    r"claude_agent_sdk/_bundled/claude\b"
+    r"|^(?!.*(?:^|\s)-p(?:\s|$))(?!.*--print(?:\s|$)).*\bclaude\b.*--permission-mode\s+bypassPermissions"
+)
 _MCP_SERVER_CMDLINE_RE = re.compile(r"mcp_servers/[\w_]+\.py\b")
 
 # Heartbeat-freshness threshold for the per-PID gate (30 minutes).

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -182,6 +182,27 @@ SHUTTING_DOWN = False
 # Pattern established by worker graceful shutdown (PR #742).
 _background_tasks: list = []
 
+
+def _log_bg_task_exception(task: asyncio.Task) -> None:
+    """Done-callback: log an unhandled exception from a fire-and-forget task.
+
+    D3 (issue #1817): a bare ``asyncio.create_task(...)`` with no held
+    reference and no done-callback lets the GC collect the task mid-flight
+    and silently drops any exception it raised (only visible, if at all, as
+    an "exception was never retrieved" warning at GC time). This callback
+    makes that failure loud without changing task semantics — task-internal
+    ``except Exception`` blocks still handle expected failures; this is the
+    defense-in-depth backstop for anything that slips past them (e.g. a bug
+    in the handler itself). ``CancelledError`` is expected during shutdown
+    and is not logged as an error.
+    """
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.warning(f"[bg-task] {task.get_name()} raised: {exc}")
+
+
 # Project directory (for running scripts, checking flags, etc.)
 _BRIDGE_PROJECT_DIR = Path(__file__).parent.parent
 
@@ -1613,7 +1634,14 @@ async def main():
             except Exception as e:
                 logger.warning(f"Emoji reaction selection failed (non-fatal): {e}")
 
-        asyncio.create_task(select_and_set_emoji_reaction())
+        # Held in _background_tasks + a done-callback (D3, issue #1817) so the
+        # GC cannot collect this task mid-flight and any exception that slips
+        # past the handler's own try/except is logged instead of vanishing.
+        _emoji_task = asyncio.create_task(
+            select_and_set_emoji_reaction(), name="select_and_set_emoji_reaction"
+        )
+        _emoji_task.add_done_callback(_log_bg_task_exception)
+        _background_tasks.append(_emoji_task)
 
         # 3. Work-type classification (separate async task, non-blocking)
         classification_result = {}  # Mutable container for async classification result
@@ -1633,7 +1661,11 @@ async def main():
             except Exception as e:
                 logger.debug(f"Work classification failed (non-fatal): {e}")
 
-        asyncio.create_task(classify_work_type())
+        # Held in _background_tasks + a done-callback (D3, issue #1817) — see
+        # the emoji-reaction task above for the rationale.
+        _classify_task = asyncio.create_task(classify_work_type(), name="classify_work_type")
+        _classify_task.add_done_callback(_log_bg_task_exception)
+        _background_tasks.append(_classify_task)
 
         # Synchronous fast-path: PR/issue references always mean SDLC work.
         # The async classifier above may not finish before enqueue_agent_session runs,

--- a/config/models.py
+++ b/config/models.py
@@ -40,6 +40,25 @@ OPUS = "claude-opus-4-5-20251101"
 
 
 # =============================================================================
+# CLAUDE CLI (native-installer) VERSION PIN
+# =============================================================================
+# Single source of truth for the pinned `claude` CLI version. The native
+# installer floats ~/.local/bin/claude -> ~/.local/share/claude/versions/<v>/
+# to latest on auto-update, so a fleet-wide bump can silently shift the scraped
+# TUI contract the granite PTY driver depends on (D1b) out from under us. Two
+# consumers pin against this constant:
+#   - scripts/update/verify.py    (D1a update-time drift check)
+#   - scripts/nightly_regression_tests.py (#1839 ollama-canary drift alert)
+# and config/settings.py mirrors it as the typed catalog entry. Read via env so
+# a fleet override or a test monkeypatch takes effect without a code change.
+# Bumping the default is DELIBERATE: re-verify the D1b markers against the new
+# version's actual TUI output first, then update this constant and the bump-log
+# in docs/features/deployment.md. Provisioning a canary against a not-yet-fleet
+# version is tracked separately in issue #1854.
+PINNED_CLAUDE_VERSION = os.environ.get("PINNED_CLAUDE_VERSION", "2.1.198")
+
+
+# =============================================================================
 # OPENROUTER API ENDPOINTS
 # Override via environment variables for custom/proxy deployments
 # =============================================================================

--- a/config/settings.py
+++ b/config/settings.py
@@ -14,6 +14,8 @@ from typing import Any
 from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from config.models import PINNED_CLAUDE_VERSION
+
 
 class LogLevel(StrEnum):
     """Supported logging levels."""
@@ -640,6 +642,50 @@ class Settings(BaseSettings):
             "Consecutive resolver failures (per project) before the "
             "email:resolver_unavailable operator alert arms. "
             "Provisional/tunable. Env: EMAIL_RESOLVER_ALERT_AFTER."
+        ),
+    )
+
+    # Correctness & delivery-integrity hardening (issue #1817). Documented
+    # here as the typed catalog entry; the runtime checks
+    # (scripts/update/verify.py, worker/__main__.py,
+    # agent/agent_session_queue.py) read these via `os.environ.get(...)`
+    # directly rather than through this `settings` singleton, so a value
+    # changed after process startup (e.g. via test monkeypatching) takes
+    # effect immediately instead of requiring a fresh Settings() instance.
+    # The version default itself lives in config/models.py
+    # (PINNED_CLAUDE_VERSION) as the single source of truth shared with the
+    # nightly ollama canary (scripts/nightly_regression_tests.py).
+    pinned_claude_version: str = Field(
+        default=PINNED_CLAUDE_VERSION,
+        description=(
+            "D1a: pinned claude CLI version the D1b scraped-TUI-marker "
+            "contract was last verified against (native installer: "
+            "~/.local/bin/claude -> "
+            "~/.local/share/claude/versions/<version>/). PROVISIONAL — "
+            "bumping requires re-verifying the D1b markers against the new "
+            "version's actual TUI output first; see "
+            "docs/features/deployment.md. Env: PINNED_CLAUDE_VERSION."
+        ),
+    )
+    claude_contract_check_enforce: bool = Field(
+        default=False,
+        description=(
+            "D1a/D1b: shared enforce flag for the claude-CLI-contract checks "
+            "(version pin drift in scripts/update/verify.py, TUI-marker "
+            "contract-check in worker/__main__.py). Default off (warn-only, "
+            "non-blocking). Env: CLAUDE_CONTRACT_CHECK_ENFORCE=1."
+        ),
+    )
+    notify_healthcheck_interval: float = Field(
+        default=15.0,
+        gt=0,
+        description=(
+            "D4: interval (seconds) for the session-notify pubsub liveness "
+            "watchdog in agent/agent_session_queue.py — a periodic PUBSUB "
+            "NUMSUB probe on a SEPARATE short-lived Redis connection (never "
+            "the listen() connection) that detects a silently-dropped "
+            "subscription and forces a resubscribe. Provisional/tunable. "
+            "Env: NOTIFY_HEALTHCHECK_INTERVAL."
         ),
     )
 

--- a/docs/features/deployment.md
+++ b/docs/features/deployment.md
@@ -276,6 +276,74 @@ headless harness path on incident:
    idempotent on retried `[/user]` payloads.
 4. No manual flag toggling, no env var changes.
 
+## `claude` CLI Version Pin (D1a, issue #1817)
+
+The live `claude` CLI is installed via the **native installer**:
+`~/.local/bin/claude` is a symlink into
+`~/.local/share/claude/versions/<version>/`. It is not an npm package — it is
+never listed in `scripts/update/npm_tools.py`'s `MANAGED_PACKAGES`, and it
+must stay that way (adding it there would either no-op, since npm doesn't own
+the binary, or force-switch the fleet onto the npm install path, which is not
+how the CLI actually got onto this machine).
+
+The native installer floats `claude` to latest on auto-update. Historically,
+a minor-version bump has reworded the interactive TUI's scraped markers
+(`IDLE_BAR`, `PROMPT_GLYPH`, `SPINNER_EVIDENCE_RE` in
+`agent/granite_container/pty_driver.py`; the trust-folder prompt pattern in
+`agent/granite_container/startup_parser.py`) with no code change on our side
+— a silent, fleet-wide PTY-session hang. Two checks guard against this:
+
+- **D1a (version pin):** `scripts/update/verify.py`'s `check_claude_version_pin()`
+  compares the installed version to `PINNED_CLAUDE_VERSION`. The value has a
+  **single source of truth** in `config/models.py` (default `2.1.198`, env-
+  overridable via `PINNED_CLAUDE_VERSION`), imported by both this D1a check and
+  the #1839 ollama-canary drift alert in
+  `scripts/nightly_regression_tests.py`, and mirrored as a typed catalog entry
+  at `config/settings.py` `Settings.pinned_claude_version`. A drift logs a
+  WARNING by default (non-blocking — a version bump does not necessarily
+  break anything). Provisioning a canary against a not-yet-fleet version is
+  tracked in issue #1854.
+- **D1b (contract-check):** `worker/__main__.py` calls
+  `agent.granite_container.pty_driver.verify_tui_marker_contract()` at
+  startup, which re-runs each scraped-marker regex against a golden sample of
+  known-good CLI output. A mismatch logs CRITICAL — but only hard-fails
+  startup when at least one role is configured `pty`-transport (a fully
+  `headless` fleet is immune to TUI-marker drift by construction; see
+  `docs/features/README.md` for the per-role transport hedge).
+
+Both checks share one enforcement flag, off by default:
+
+```bash
+# Set to "1" to hard-fail /update and worker startup on a detected
+# claude-CLI-contract drift (version pin OR TUI marker mismatch). Off by
+# default — a drift does not necessarily mean anything is actually broken.
+CLAUDE_CONTRACT_CHECK_ENFORCE=1
+```
+
+### Bump procedure
+
+Bumping `PINNED_CLAUDE_VERSION` is a **deliberate** procedure, not something
+to do reflexively on every drift warning:
+
+1. Confirm the new `claude` version is actually installed and stable on at
+   least one machine (`readlink ~/.local/bin/claude`).
+2. Re-verify the D1b scraped markers still match the new version's actual
+   TUI output — run a live PTY session (or the existing granite smoke-test
+   tooling) and confirm idle detection, the trust-folder prompt, and the
+   spinner-evidence heuristic still fire correctly. If any marker's shape
+   changed, update the regex in `pty_driver.py`/`startup_parser.py` FIRST,
+   and update `verify_tui_marker_contract()`'s golden samples to match.
+3. Update the `PINNED_CLAUDE_VERSION` default in `config/models.py` (the single
+   source of truth — `scripts/update/verify.py`, `scripts/nightly_regression_tests.py`,
+   and `config/settings.py` all read it from there) to the new version string.
+4. Note the bump here (version, date, what — if anything — changed in the
+   scraped markers):
+
+   | Version | Date | Notes |
+   |---|---|---|
+   | 2.1.197 | 2026-07-02 | Initial pin (issue #1817) |
+   | 2.1.198 | 2026-07-03 | Single-sourced the pin in `config/models.py` (shared with the #1839 nightly canary); default set to the current fleet version. Markers unchanged. |
+
 ## See Also
 
 - Run `/setup` for full machine configuration

--- a/scripts/nightly_regression_tests.py
+++ b/scripts/nightly_regression_tests.py
@@ -22,6 +22,8 @@ import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
+from config.models import PINNED_CLAUDE_VERSION
+
 PROJECT_DIR = Path(__file__).parent.parent
 DATA_DIR = PROJECT_DIR / "data"
 LAST_RUN_FILE = DATA_DIR / "nightly_tests_last_run.json"
@@ -43,8 +45,10 @@ PYTEST_OLLAMA_TIMEOUT_SECONDS = 900  # 15 minutes for the ollama-backed E2E
 # Version-pinned canary for the ollama-backed granite suite (plan Task 6 /
 # Success Criterion 4). Substrate B launches the REAL ``claude`` binary — a new
 # release is the exact thing that silently breaks production granite, so the
-# nightly run pins the version it validated against and alerts on drift.
-PINNED_CLAUDE_VERSION = "2.1.197"
+# nightly run pins the version it validated against and alerts on drift. The pin
+# (imported at module top) is the SINGLE SOURCE OF TRUTH in config/models.py,
+# shared with the D1a update-time drift check (scripts/update/verify.py); bump
+# it there. Canary provisioning against a not-yet-fleet version: issue #1854.
 
 # TTFT regression gate (issue #1227).
 # Plan target: production 90s, nightly CI 120s (allowing slack for run-to-run noise).
@@ -414,7 +418,7 @@ def claude_canary_alert() -> str | None:
         f"claude version drift (granite ollama canary): pinned "
         f"{PINNED_CLAUDE_VERSION}, live {live}. A new claude release can break "
         f"the granite PTY idle heuristic — re-validate the harness and bump "
-        f"PINNED_CLAUDE_VERSION in scripts/nightly_regression_tests.py."
+        f"PINNED_CLAUDE_VERSION in config/models.py."
     )
 
 

--- a/scripts/update/verify.py
+++ b/scripts/update/verify.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 import shutil
@@ -10,8 +11,10 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 
-from config.models import OLLAMA_CLASSIFIER_MODEL
+from config.models import OLLAMA_CLASSIFIER_MODEL, PINNED_CLAUDE_VERSION
 from scripts.update.service import is_bridge_running
+
+logger = logging.getLogger(__name__)
 
 # Ensure PATH includes common tool locations (launchd has minimal PATH)
 _EXTRA_PATHS = [
@@ -93,6 +96,124 @@ def check_command(name: str, version_flag: str = "--version") -> ToolCheck:
         return ToolCheck(name=name, available=True, error="Timeout getting version")
     except Exception as e:
         return ToolCheck(name=name, available=True, error=str(e))
+
+
+# === D1a: native-installer version-assertion pin (issue #1817) ===
+#
+# The live `claude` CLI is installed via the NATIVE installer:
+# ~/.local/bin/claude is a symlink into
+# ~/.local/share/claude/versions/<version>/. It is NOT an npm package (not in
+# node_modules) and must NEVER be added to scripts/update/npm_tools.py's
+# MANAGED_PACKAGES — that would either no-op (npm doesn't own the binary) or
+# force-switch the fleet to the npm install path, which is not how this
+# machine's `claude` got there.
+#
+# PINNED_CLAUDE_VERSION is PROVISIONAL/grain-of-salt: it records the version
+# this repo's PTY scrapers (IDLE_BAR/PROMPT_GLYPH/SPINNER_EVIDENCE_RE in
+# pty_driver.py, the trust-folder patterns in startup_parser.py — see D1b's
+# contract-check) were last verified against. A version drift does not
+# necessarily mean anything broke — it means the CLI auto-updated and the
+# scraped markers have NOT been re-verified against the new build. Bumping
+# this constant is a DELIBERATE procedure (re-verify the D1b markers against
+# the new version's actual TUI output, then update the default in
+# config/models.py and the bump-log in docs/features/deployment.md), not
+# something to do reflexively on every drift warning.
+#
+# The value is the SINGLE SOURCE OF TRUTH in config/models.py (imported at the
+# top of this module), shared with the #1839 ollama-canary drift alert
+# (scripts/nightly_regression_tests.py) and mirrored as a typed catalog entry
+# at config/settings.py Settings.pinned_claude_version. config.models resolves
+# it via os.environ.get(...) at import, so a fleet override / test monkeypatch
+# of PINNED_CLAUDE_VERSION set before that module imports takes effect. Canary
+# provisioning against a not-yet-fleet version is tracked in issue #1854.
+
+# Shared with D1b's startup contract-check (worker/__main__.py) — one flag
+# governs whether EITHER "the claude CLI contract may have shifted" signal
+# (version pin drift here, or a scraped-marker mismatch in D1b) escalates
+# from a warning to a hard failure. Off by default: a version bump or a
+# marker mismatch does not necessarily break anything at read time, and a
+# false-positive hard-fail would block a healthy fleet from starting.
+CLAUDE_CONTRACT_CHECK_ENFORCE_ENV = "CLAUDE_CONTRACT_CHECK_ENFORCE"
+
+
+def _resolve_installed_claude_version() -> str | None:
+    """Best-effort resolve the installed `claude` CLI's version string.
+
+    Prefers `claude --version` stdout/stderr (works regardless of install
+    method). Falls back to parsing the native installer's symlink target
+    directory name (~/.local/bin/claude -> .../versions/<version>/claude)
+    when the version flag doesn't resolve a clean version string. Returns
+    None if neither source resolves — callers must treat that as "unknown",
+    not as a mismatch.
+    """
+    try:
+        result = run_cmd(["claude", "--version"], timeout=10)
+        out = (result.stdout or "").strip() or (result.stderr or "").strip()
+        if out:
+            m = re.search(r"(\d+\.\d+\.\d+)", out)
+            if m:
+                return m.group(1)
+    except Exception:
+        pass
+
+    native_bin = Path.home() / ".local" / "bin" / "claude"
+    try:
+        if native_bin.is_symlink():
+            target = os.readlink(native_bin)
+            m = re.search(r"/versions/([\d.]+)/", target)
+            if m:
+                return m.group(1)
+    except OSError:
+        pass
+    return None
+
+
+def check_claude_version_pin() -> ToolCheck:
+    """Compare the installed `claude` CLI version to PINNED_CLAUDE_VERSION.
+
+    D1a (issue #1817): the native installer floats `claude` to latest on
+    auto-update; a version drift means the scraped TUI contract D1b's
+    startup probe depends on (agent/granite_container/pty_driver.py markers,
+    startup_parser.py trust-folder patterns) may have shifted underneath us
+    with no code change on our side. This check is a coarse, fast signal
+    (version string comparison); D1b's contract-check is the actual
+    behavioral proof.
+
+    Default (CLAUDE_CONTRACT_CHECK_ENFORCE unset/not "1"): drift logs a
+    WARNING and returns available=True (non-blocking) — a version bump does
+    not necessarily break anything. With CLAUDE_CONTRACT_CHECK_ENFORCE=1,
+    drift logs CRITICAL and returns available=False, matching the
+    check_projects_json / check_sdlc_tool green-light-gate convention (the
+    caller decides whether to skip a service restart on an unavailable
+    check).
+    """
+    installed = _resolve_installed_claude_version()
+    if installed is None:
+        return ToolCheck(
+            name="claude-version-pin",
+            available=True,
+            version="skipped (could not resolve installed claude version)",
+        )
+
+    if installed == PINNED_CLAUDE_VERSION:
+        return ToolCheck(
+            name="claude-version-pin",
+            available=True,
+            version=f"pinned ({installed})",
+        )
+
+    msg = (
+        f"claude CLI version drift: installed={installed}, "
+        f"pinned={PINNED_CLAUDE_VERSION}. The scraped TUI markers D1b depends "
+        "on have not been re-verified against this version. See "
+        "docs/features/deployment.md for the pin bump procedure."
+    )
+    enforce = os.environ.get(CLAUDE_CONTRACT_CHECK_ENFORCE_ENV) == "1"
+    if enforce:
+        logger.critical(msg)
+        return ToolCheck(name="claude-version-pin", available=False, error=msg)
+    logger.warning(msg)
+    return ToolCheck(name="claude-version-pin", available=True, version=f"drift: {installed}")
 
 
 def check_python_import(
@@ -1048,6 +1169,7 @@ def verify_environment(project_dir: Path, check_ollama_model: bool = True) -> Ve
     result.valor_tools.append(check_google_token(project_dir))
     result.valor_tools.append(check_env_completeness(project_dir))
     result.valor_tools.append(check_valor_alias_shadow())
+    result.valor_tools.append(check_claude_version_pin())
 
     if check_ollama_model:
         from config.settings import settings as _settings

--- a/tests/unit/granite_container/test_pty_pool.py
+++ b/tests/unit/granite_container/test_pty_pool.py
@@ -531,6 +531,145 @@ class TestSpawnOnAcquire(unittest.TestCase):
             asyncio.run(_run())
 
 
+class _PidTrackingDriver:
+    """Fake PTYDriver for D2 pid-persist tests (issue #1817): allocates a
+    unique pid per instance on spawn(), optionally raising for one role to
+    simulate a dev.spawn() failure after a successful pm.spawn()."""
+
+    _pid_counter = [20000]
+    fail_role: str | None = None  # set per-test in setUp
+
+    class _FakeChild:
+        def __init__(self, pid: int) -> None:
+            self.pid = pid
+
+    def __init__(
+        self,
+        role: str = "pm",
+        cwd: str | None = None,
+        model: str | None = None,
+        env: dict | None = None,
+        session_id: str | None = None,
+        settings_path: str | None = None,
+    ) -> None:
+        self.role = role
+        self.cwd = cwd
+        self._child = None
+        self.closed = False
+
+    def spawn(self) -> None:
+        if _PidTrackingDriver.fail_role == self.role:
+            raise RuntimeError(f"simulated {self.role} spawn failure")
+        pid = _PidTrackingDriver._pid_counter[0]
+        _PidTrackingDriver._pid_counter[0] += 1
+        self._child = _PidTrackingDriver._FakeChild(pid)
+
+    def isalive(self) -> bool:
+        return True
+
+    def close(self, force: bool = True) -> None:
+        self.closed = True
+
+
+class TestD2ImmediatePidPersist(unittest.TestCase):
+    """D2 (issue #1817): `_spawn_session_pair` persists each child's pid
+    IMMEDIATELY after its own spawn() returns, not batched after both roles
+    spawn — so a dev.spawn() failure after a successful pm.spawn() doesn't
+    strand pm's pid unreapable. A headless role (#1842) leaves `pty` as
+    None — no PTY process, correctly nothing to record."""
+
+    def setUp(self) -> None:
+        _PidTrackingDriver.fail_role = None
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".json")
+        tmp.close()
+        self.registry_path = tmp.name
+
+    def tearDown(self) -> None:
+        try:
+            os.unlink(self.registry_path)
+        except OSError:
+            pass
+
+    def _read_registry(self) -> list[int]:
+        with open(self.registry_path) as f:
+            return json.load(f).get("pids", [])
+
+    def test_pm_and_dev_pids_both_persisted_on_success(self) -> None:
+        from agent.granite_container.pty_pool import PairSpawnSpec, _Slot
+
+        async def _run():
+            pool = PTYPool(pool_size=1, pid_registry_path=self.registry_path)
+            slot = _Slot(idx=0)
+            spec = PairSpawnSpec(cwd="/x")
+            with patch("agent.granite_container.pty_pool.PTYDriver", _PidTrackingDriver):
+                await pool._spawn_session_pair(slot, spec)
+            pm, dev = slot.pty_pair
+            self.assertIn(pm._child.pid, pool.get_spawned_pids())
+            self.assertIn(dev._child.pid, pool.get_spawned_pids())
+            self.assertEqual(set(self._read_registry()), pool.get_spawned_pids())
+
+        asyncio.run(_run())
+
+    def test_dev_spawn_failure_leaves_pm_pid_persisted(self) -> None:
+        """The whole point of D2: a dev.spawn() failure after a successful
+        pm.spawn() must not strand pm's pid unpersisted/unreapable."""
+        from agent.granite_container.pty_pool import PairSpawnSpec, _Slot
+
+        _PidTrackingDriver.fail_role = "dev"
+
+        async def _run():
+            pool = PTYPool(pool_size=1, pid_registry_path=self.registry_path)
+            slot = _Slot(idx=0)
+            spec = PairSpawnSpec(cwd="/x")
+            with patch("agent.granite_container.pty_pool.PTYDriver", _PidTrackingDriver):
+                with self.assertRaises(RuntimeError):
+                    await pool._spawn_session_pair(slot, spec)
+            self.assertEqual(len(pool.get_spawned_pids()), 1)
+            self.assertEqual(set(self._read_registry()), pool.get_spawned_pids())
+
+        asyncio.run(_run())
+
+    def test_headless_pair_records_empty_pid_set_and_persists(self) -> None:
+        """A fully-headless spec spawns no PTY process; the registry is
+        still explicitly persisted with an empty pid set (not skipped)."""
+        from agent.granite_container.pty_pool import PairSpawnSpec, _Slot
+
+        # Seed stale content to prove the empty-set write actually happens.
+        with open(self.registry_path, "w") as f:
+            json.dump({"pids": [99999]}, f)
+
+        async def _run():
+            pool = PTYPool(pool_size=1, pid_registry_path=self.registry_path)
+            slot = _Slot(idx=0)
+            spec = PairSpawnSpec(cwd="/x", pm_transport="headless", dev_transport="headless")
+            with patch("agent.granite_container.pty_pool.PTYDriver", _PidTrackingDriver):
+                await pool._spawn_session_pair(slot, spec)
+            pm, dev = slot.pty_pair
+            self.assertIsNone(pm)
+            self.assertIsNone(dev)
+            self.assertEqual(pool.get_spawned_pids(), set())
+
+        asyncio.run(_run())
+        self.assertEqual(self._read_registry(), [])
+
+    def test_mixed_pty_pm_headless_dev_persists_only_pm(self) -> None:
+        from agent.granite_container.pty_pool import PairSpawnSpec, _Slot
+
+        async def _run():
+            pool = PTYPool(pool_size=1, pid_registry_path=self.registry_path)
+            slot = _Slot(idx=0)
+            spec = PairSpawnSpec(cwd="/x", dev_transport="headless")
+            with patch("agent.granite_container.pty_pool.PTYDriver", _PidTrackingDriver):
+                await pool._spawn_session_pair(slot, spec)
+            pm, dev = slot.pty_pair
+            self.assertIsNotNone(pm)
+            self.assertIsNone(dev)
+            self.assertEqual(pool.get_spawned_pids(), {pm._child.pid})
+            self.assertEqual(self._read_registry(), [pm._child.pid])
+
+        asyncio.run(_run())
+
+
 class TestNoSleepPollWait(unittest.TestCase):
     """PR #1612 review nit: `_wait_for_idle_slot` must not busy-poll
     with `asyncio.sleep` while all slots are locked — it waits on the

--- a/tests/unit/granite_container/test_tui_marker_contract.py
+++ b/tests/unit/granite_container/test_tui_marker_contract.py
@@ -1,0 +1,113 @@
+"""Tests for verify_tui_marker_contract() (D1b, issue #1817).
+
+D1b converts a routine `claude` CLI auto-update that rewords a scraped TUI
+string into a loud, operator-visible signal instead of a silent fleet-wide
+PTY-session hang. `verify_tui_marker_contract()` is a fingerprint check: it
+re-runs each marker regex (IDLE_BAR, PROMPT_GLYPH, SPINNER_EVIDENCE_RE, plus
+the trust-folder prompt pattern in startup_parser.py) against a golden
+sample of known-good CLI output, without spawning a live PTY.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from agent.granite_container.pty_driver import (
+    _CONTRACT_GOLDEN_SAMPLES,
+    verify_tui_marker_contract,
+)
+
+
+class TestGoldenSamplesMatch:
+    def test_all_markers_match_their_golden_sample(self):
+        """With unmodified markers and golden samples, the contract holds."""
+        ok, failed = verify_tui_marker_contract()
+
+        assert ok is True
+        assert failed == []
+
+    def test_golden_samples_cover_all_four_markers(self):
+        """Sanity: the fixture dict itself must name all four markers."""
+        assert set(_CONTRACT_GOLDEN_SAMPLES) == {
+            "IDLE_BAR",
+            "PROMPT_GLYPH",
+            "SPINNER_EVIDENCE_RE",
+            "TRUST_FOLDER_PROMPT",
+        }
+
+
+class TestMarkerMismatchDetected:
+    def test_idle_bar_mismatch_reported(self):
+        """A regex that stops matching its golden sample is reported by name."""
+        with patch(
+            "agent.granite_container.pty_driver._CONTRACT_GOLDEN_SAMPLES",
+            {**_CONTRACT_GOLDEN_SAMPLES, "IDLE_BAR": "totally different bottom bar text"},
+        ):
+            ok, failed = verify_tui_marker_contract()
+
+        assert ok is False
+        assert "IDLE_BAR" in failed
+
+    def test_prompt_glyph_mismatch_reported(self):
+        with patch(
+            "agent.granite_container.pty_driver._CONTRACT_GOLDEN_SAMPLES",
+            {**_CONTRACT_GOLDEN_SAMPLES, "PROMPT_GLYPH": "no glyph here"},
+        ):
+            ok, failed = verify_tui_marker_contract()
+
+        assert ok is False
+        assert "PROMPT_GLYPH" in failed
+
+    def test_spinner_evidence_mismatch_reported(self):
+        with patch(
+            "agent.granite_container.pty_driver._CONTRACT_GOLDEN_SAMPLES",
+            {**_CONTRACT_GOLDEN_SAMPLES, "SPINNER_EVIDENCE_RE": "nothing spinner-shaped"},
+        ):
+            ok, failed = verify_tui_marker_contract()
+
+        assert ok is False
+        assert "SPINNER_EVIDENCE_RE" in failed
+
+    def test_trust_folder_mismatch_reported(self):
+        with patch(
+            "agent.granite_container.pty_driver._CONTRACT_GOLDEN_SAMPLES",
+            {**_CONTRACT_GOLDEN_SAMPLES, "TRUST_FOLDER_PROMPT": "nothing about trust here"},
+        ):
+            ok, failed = verify_tui_marker_contract()
+
+        assert ok is False
+        assert "TRUST_FOLDER_PROMPT" in failed
+
+    def test_multiple_mismatches_all_reported(self):
+        with patch(
+            "agent.granite_container.pty_driver._CONTRACT_GOLDEN_SAMPLES",
+            {
+                "IDLE_BAR": "x",
+                "PROMPT_GLYPH": "x",
+                "SPINNER_EVIDENCE_RE": "x",
+                "TRUST_FOLDER_PROMPT": "x",
+            },
+        ):
+            ok, failed = verify_tui_marker_contract()
+
+        assert ok is False
+        assert set(failed) == {
+            "IDLE_BAR",
+            "PROMPT_GLYPH",
+            "SPINNER_EVIDENCE_RE",
+            "TRUST_FOLDER_PROMPT",
+        }
+
+
+class TestNeverRaises:
+    def test_startup_parser_import_failure_reported_not_raised(self):
+        """A broken startup_parser import must be reported as a failed marker,
+        not propagate and crash the worker-startup caller."""
+        with patch(
+            "agent.granite_container.startup_parser.parse_startup_frame",
+            side_effect=RuntimeError("boom"),
+        ):
+            ok, failed = verify_tui_marker_contract()
+
+        assert ok is False
+        assert "TRUST_FOLDER_PROMPT" in failed

--- a/tests/unit/test_agent_session_queue_async.py
+++ b/tests/unit/test_agent_session_queue_async.py
@@ -454,3 +454,173 @@ class TestNumsubCount:
 
     def test_empty_dict_returns_zero(self):
         assert self.fn({}, self.ch) == 0
+
+
+class TestNotifyHealthcheckWatchdog:
+    """Unit tests for the D4 periodic off-path pubsub liveness watchdog (#1817).
+
+    `_notify_healthcheck_watchdog` runs alongside `_session_notify_listener`'s
+    blocking pubsub thread and probes NUMSUB on a SEPARATE short-lived Redis
+    connection every NOTIFY_HEALTHCHECK_INTERVAL seconds. These tests drive
+    the watchdog directly (not through the full listener) so timing is fast
+    and deterministic; the listener's own subscribe/resubscribe machinery is
+    covered by TestNotifyListenerNusubSelfCheck above.
+    """
+
+    def _run_watchdog_ticks(self, handle, numsub_side_effect, interval=0.05, ticks=1):
+        """Run _notify_healthcheck_watchdog for `ticks` probe cycles then cancel."""
+        import redis as _redis_module
+
+        from agent.agent_session_queue import _notify_healthcheck_watchdog
+
+        mock_probe_conn = MagicMock()
+        mock_probe_conn.pubsub_numsub.side_effect = numsub_side_effect
+
+        mock_popoto = MagicMock()
+        mock_popoto.connection_pool.connection_kwargs = {
+            "host": "localhost",
+            "port": 6379,
+            "db": 0,
+        }
+
+        async def run():
+            with (
+                patch("agent.agent_session_queue.NOTIFY_HEALTHCHECK_INTERVAL", interval),
+                patch("popoto.redis_db.POPOTO_REDIS_DB", mock_popoto),
+                patch.object(_redis_module, "Redis", return_value=mock_probe_conn),
+            ):
+                task = asyncio.create_task(_notify_healthcheck_watchdog(handle))
+                await asyncio.sleep(interval * (ticks + 2))
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+        asyncio.run(run())
+        return mock_probe_conn
+
+    def test_confirmed_drop_closes_handle_pubsub_and_warns(self, caplog):
+        """A CONFIRMED NUMSUB==0 forces a resubscribe: closes the handle's
+        pubsub and logs a WARNING — within NOTIFY_HEALTHCHECK_INTERVAL."""
+        import logging
+
+        from agent.agent_session_queue import _ListenerPubsubHandle
+
+        handle = _ListenerPubsubHandle()
+        mock_pubsub = MagicMock()
+        handle.pubsub = mock_pubsub
+
+        with caplog.at_level(logging.WARNING, logger="agent.agent_session_queue"):
+            self._run_watchdog_ticks(
+                handle, numsub_side_effect=lambda *a, **k: [(b"valor:sessions:new", 0)]
+            )
+
+        mock_pubsub.close.assert_called()
+        assert any("notify subscription dropped" in r.getMessage() for r in caplog.records), (
+            "Expected a WARNING announcing the forced resubscribe"
+        )
+
+    def test_healthy_subscription_does_not_close_pubsub(self):
+        """NUMSUB >= 1 (healthy) must never close the listener's pubsub."""
+        from agent.agent_session_queue import _ListenerPubsubHandle
+
+        handle = _ListenerPubsubHandle()
+        mock_pubsub = MagicMock()
+        handle.pubsub = mock_pubsub
+
+        self._run_watchdog_ticks(
+            handle, numsub_side_effect=lambda *a, **k: [(b"valor:sessions:new", 1)]
+        )
+
+        mock_pubsub.close.assert_not_called()
+
+    def test_transient_probe_error_does_not_tear_down_listener(self, caplog):
+        """A probe-side exception (Redis transiently unreachable) must be
+        logged and skipped — it must NOT close the listener's pubsub."""
+        import logging
+
+        from agent.agent_session_queue import _ListenerPubsubHandle
+
+        handle = _ListenerPubsubHandle()
+        mock_pubsub = MagicMock()
+        handle.pubsub = mock_pubsub
+
+        with caplog.at_level(logging.WARNING, logger="agent.agent_session_queue"):
+            self._run_watchdog_ticks(handle, numsub_side_effect=RuntimeError("redis unreachable"))
+
+        mock_pubsub.close.assert_not_called()
+        assert any("NUMSUB probe raised" in r.getMessage() for r in caplog.records)
+
+    def test_handle_with_no_pubsub_yet_does_not_crash_on_drop(self):
+        """A confirmed drop before the listener has published its pubsub
+        (handle.pubsub is still None, e.g. mid-establishment) must not raise."""
+        from agent.agent_session_queue import _ListenerPubsubHandle
+
+        handle = _ListenerPubsubHandle()
+        assert handle.pubsub is None
+
+        # Must not raise.
+        self._run_watchdog_ticks(
+            handle, numsub_side_effect=lambda *a, **k: [(b"valor:sessions:new", 0)]
+        )
+
+
+class TestNotifyListenerPreservesNoneSocketTimeout:
+    """D4 (issue #1817): the listen() connection's socket_timeout=None must
+    stay unconditional — a finite timeout there was already tried and
+    reverted (spurious "Timeout reading from socket" + a dropped-notification
+    window). This guards against a future regression reintroducing one."""
+
+    def test_listener_connection_uses_socket_timeout_none(self):
+        import json
+
+        import redis as _redis_module
+
+        from agent.agent_session_queue import _session_notify_listener
+
+        mock_pubsub = MagicMock()
+        mock_pubsub.listen.return_value = iter([])
+
+        mock_conn = MagicMock()
+        mock_conn.pubsub.return_value = mock_pubsub
+        mock_conn.pubsub_numsub.return_value = [(b"valor:sessions:new", 1)]
+
+        mock_popoto = MagicMock()
+        mock_popoto.connection_pool.connection_kwargs = {
+            "host": "localhost",
+            "port": 6379,
+            "db": 0,
+        }
+
+        redis_calls = []
+
+        def _redis_ctor(*args, **kwargs):
+            redis_calls.append(kwargs)
+            return mock_conn
+
+        async def run():
+            with (
+                patch("popoto.redis_db.POPOTO_REDIS_DB", mock_popoto),
+                patch("agent.agent_session_queue.json", wraps=json),
+                patch.object(_redis_module, "Redis", side_effect=_redis_ctor),
+                patch("time.sleep"),
+            ):
+                task = asyncio.create_task(_session_notify_listener())
+                await asyncio.sleep(0.2)
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+        asyncio.run(run())
+
+        assert redis_calls, "Expected at least one Redis connection constructed"
+        listener_calls = [c for c in redis_calls if c.get("socket_timeout") is None]
+        assert listener_calls, (
+            "The listen() connection must be constructed with socket_timeout=None "
+            "— this was reverted once already after causing spurious timeouts "
+            "and a dropped-notification window; do not reintroduce a finite "
+            "timeout here."
+        )

--- a/tests/unit/test_d3_silent_failure_logging.py
+++ b/tests/unit/test_d3_silent_failure_logging.py
@@ -1,0 +1,216 @@
+"""D3 (issue #1817): formerly-silent failure paths now emit log lines.
+
+Covers the three D3 surfaces:
+- agent/sdk_client.py circuit-breaker writes: awaited directly (no longer
+  fire-and-forget via asyncio.ensure_future), guarded so a breaker write
+  failure logs a warning instead of masking the original exception.
+- bridge/telegram_bridge.py fire-and-forget tasks: held in _background_tasks
+  with a done-callback (`_log_bg_task_exception`) that logs any exception.
+- agent/memory_extraction.py: former `except Exception: pass` handlers now
+  log with context (still non-fatal — memory must never crash the agent).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class TestCircuitBreakerWritesAwaited:
+    """Static guards: the sdk_client circuit-breaker record calls must stay
+    awaited (fire-and-forget ensure_future was the D3 bug: if the very Redis
+    failure being recorded raised, the breaker silently never tripped)."""
+
+    def test_no_fire_and_forget_circuit_records_remain(self):
+        source = (REPO_ROOT / "agent" / "sdk_client.py").read_text()
+        assert not re.search(r"ensure_future\(\s*circuit\.record", source), (
+            "circuit.record_failure/record_success must be awaited, not "
+            "wrapped in asyncio.ensure_future (D3, issue #1817)"
+        )
+
+    def test_record_calls_are_awaited_and_guarded(self):
+        source = (REPO_ROOT / "agent" / "sdk_client.py").read_text()
+        assert source.count("await circuit.record_failure") == 2
+        assert source.count("await circuit.record_success") == 1
+        # Each awaited call is guarded so a breaker write failure is logged,
+        # never masking the original exception.
+        assert source.count("[circuit-breaker]") >= 3
+
+
+class TestBridgeBackgroundTaskDoneCallback:
+    def _run_task_with_callback(self, coro_fn):
+        from bridge.telegram_bridge import _log_bg_task_exception
+
+        async def run():
+            task = asyncio.create_task(coro_fn(), name="d3-test-task")
+            task.add_done_callback(_log_bg_task_exception)
+            try:
+                await task
+            except Exception:
+                pass
+            # Let the done-callback fire.
+            await asyncio.sleep(0)
+
+        asyncio.run(run())
+
+    def test_task_exception_is_logged(self, caplog):
+        async def boom():
+            raise RuntimeError("simulated background failure")
+
+        with caplog.at_level(logging.WARNING, logger="bridge.telegram_bridge"):
+            self._run_task_with_callback(boom)
+
+        assert any(
+            "[bg-task]" in r.getMessage() and "simulated background failure" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_successful_task_logs_nothing(self, caplog):
+        async def fine():
+            return 42
+
+        with caplog.at_level(logging.WARNING, logger="bridge.telegram_bridge"):
+            self._run_task_with_callback(fine)
+
+        assert not any("[bg-task]" in r.getMessage() for r in caplog.records)
+
+    def test_cancelled_task_logs_nothing(self, caplog):
+        from bridge.telegram_bridge import _log_bg_task_exception
+
+        async def run():
+            async def sleepy():
+                await asyncio.sleep(10)
+
+            task = asyncio.create_task(sleepy(), name="d3-cancelled")
+            task.add_done_callback(_log_bg_task_exception)
+            await asyncio.sleep(0)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            await asyncio.sleep(0)
+
+        with caplog.at_level(logging.WARNING, logger="bridge.telegram_bridge"):
+            asyncio.run(run())
+
+        assert not any("[bg-task]" in r.getMessage() for r in caplog.records)
+
+    def test_emoji_and_classify_tasks_are_held(self):
+        """The two D3 call sites must append to _background_tasks and attach
+        the done-callback (source-level guard against regressing to bare
+        create_task)."""
+        source = (REPO_ROOT / "bridge" / "telegram_bridge.py").read_text()
+        for name in ("select_and_set_emoji_reaction", "classify_work_type"):
+            create_idx = source.find(f"asyncio.create_task(\n            {name}(")
+            if create_idx == -1:
+                create_idx = source.find(f"asyncio.create_task({name}(")
+            assert create_idx != -1, f"create_task call for {name} not found"
+            window = source[create_idx : create_idx + 600]
+            assert "_background_tasks.append" in window, (
+                f"{name} task must be appended to _background_tasks (D3)"
+            )
+            assert "_log_bg_task_exception" in window, (
+                f"{name} task must have the exception-logging done-callback (D3)"
+            )
+
+
+class TestMemoryExtractionHandlersObservable:
+    def test_record_extraction_error_analytics_failure_logged(self, caplog):
+        """Handler 1 (former :328): record_metric raising inside
+        _record_extraction_error logs at DEBUG instead of vanishing."""
+        from agent.memory_extraction import _record_extraction_error
+
+        with caplog.at_level(logging.DEBUG, logger="agent.memory_extraction"):
+            with patch(
+                "analytics.collector.record_metric",
+                side_effect=RuntimeError("analytics down"),
+            ):
+                _record_extraction_error("RuntimeError", "sess-d3", "proj-d3")
+
+        assert any(
+            "record_metric(memory.extraction.error) failed" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_persist_outcome_metadata_save_failure_logged(self, caplog):
+        """Handler 5 (former :1029): a per-record save() failure in
+        _persist_outcome_metadata logs at DEBUG and continues the batch."""
+        from agent.memory_extraction import _persist_outcome_metadata
+
+        bad = MagicMock()
+        bad.memory_id = "mem-bad"
+        bad.metadata = {}
+        bad.save.side_effect = RuntimeError("redis write failed")
+        good = MagicMock()
+        good.memory_id = "mem-good"
+        good.metadata = {}
+
+        with caplog.at_level(logging.DEBUG, logger="agent.memory_extraction"):
+            _persist_outcome_metadata(
+                [bad, good],
+                {"mem-bad": "acted", "mem-good": "acted"},
+            )
+
+        assert any(
+            "outcome update failed for memory mem-bad" in r.getMessage() for r in caplog.records
+        )
+        # Non-fatal: the batch continued and the good record was saved.
+        good.save.assert_called_once()
+
+    def test_no_bare_swallow_handlers_remain_at_d3_sites(self):
+        """Source-level guard: the five D3 handlers must not regress to a
+        bare `except Exception:` + `pass` with no logging. (One out-of-scope
+        bare handler remains elsewhere in the module by design; this counts
+        that the D3-scoped sites — title generation x2, both analytics
+        record_metric wrappers, and the outcome persist — all log.)"""
+        source = (REPO_ROOT / "agent" / "memory_extraction.py").read_text()
+        assert source.count("generate_title_async failed") == 2
+        assert "record_metric(memory.extraction.error) failed" in source
+        assert "record_metric(memory.extraction) failed" in source
+        assert "outcome update failed for memory" in source
+
+
+class TestTitleGenerationFailureLogged:
+    def test_post_merge_title_failure_logged_nonfatal(self, caplog):
+        """Handler 4 (former :791): generate_title_async raising inside
+        extract_post_merge_learning logs at DEBUG; the save still succeeds."""
+        import agent.memory_extraction as mx
+        from models.memory import Memory
+
+        mock_memory = SimpleNamespace(memory_id="mem-pm")
+        learning_text = "Always gate the reaper regex on the one-shot signature first."
+
+        async def fake_llm_call(**kwargs):
+            return learning_text
+
+        with caplog.at_level(logging.DEBUG, logger="agent.memory_extraction"):
+            with (
+                patch("utils.api_keys.get_anthropic_api_key", return_value="sk-test"),
+                patch.object(mx, "_llm_call", side_effect=fake_llm_call),
+                patch.object(Memory, "safe_save", return_value=mock_memory),
+                patch(
+                    "tools.memory_search.title_generator.generate_title_async",
+                    side_effect=RuntimeError("title model down"),
+                ),
+            ):
+                result = asyncio.run(
+                    mx.extract_post_merge_learning(
+                        pr_title="Fix reaper",
+                        pr_body="body",
+                        diff_summary="agent/session_health.py",
+                        project_key="proj-d3",
+                    )
+                )
+
+        assert any(
+            "generate_title_async failed for memory mem-pm" in r.getMessage()
+            for r in caplog.records
+        )
+        assert result is not None

--- a/tests/unit/test_session_health_orphan_process_reap.py
+++ b/tests/unit/test_session_health_orphan_process_reap.py
@@ -450,15 +450,70 @@ class TestStalePrintOneshotFastKill:
         proc.terminate.assert_not_called()
 
     def test_interactive_bare_claude_not_matched_by_oneshot_signature(self, clean_state):
-        """Bare `claude` WITHOUT --print (interactive) never matches fast-kill."""
+        """Bare `claude` WITHOUT --print (interactive) never matches fast-kill.
+
+        The `_is_stale_print_oneshot` helper itself stays narrow to --print/-p
+        one-shots regardless of the broadened `_CLAUDE_CMDLINE_RE` (D2, issue
+        #1817, below) — the two matchers are deliberately disjoint.
+        """
+        assert not session_health._is_stale_print_oneshot(_BARE_INTERACTIVE_CMD, _stale_ct())
+
+    def test_interactive_bare_claude_with_live_session_not_reaped(self, clean_state):
+        """A PTY TUI `claude` process with a fresh owning session is protected.
+
+        D2 (issue #1817) broadened `_CLAUDE_CMDLINE_RE` to also match this
+        native/PTY-TUI cmdline shape (previously only the SDK-bundled path
+        matched, so an orphaned PTY child was invisible to the reaper). The
+        broadened match now goes through the general is_claude branch, which
+        (unlike the oneshot fast-kill path) is still heartbeat-gated — a
+        live session protects the process exactly like any other claude
+        signature match.
+        """
         proc = _fake_proc(pid=2102, ppid=1, cmdline=_BARE_INTERACTIVE_CMD, create_time=_stale_ct())
+        live_session = SimpleNamespace(
+            project_key="proj-pty",
+            status="running",
+            last_heartbeat_at=datetime.now(UTC) - timedelta(seconds=10),
+            claude_pid=2102,
+        )
+
+        with patch.object(psutil, "process_iter", return_value=[proc]):
+            with patch.object(
+                session_health.AgentSession, "find_by_claude_pid", return_value=live_session
+            ):
+                killed = session_health._reap_orphan_session_processes()
+
+        assert killed == 0
+        proc.terminate.assert_not_called()
+
+    def test_interactive_bare_claude_without_session_is_reaped(self, clean_state):
+        """An orphaned PTY TUI `claude` process (no owning session) IS reaped.
+
+        This is the D2 fix in action: before broadening, this cmdline shape
+        never matched any signature, so a PTY child of a dead/crashed
+        session ran forever, ungated. Now it matches the general is_claude
+        signature and — with no live session found and PPID==1 — is reaped
+        through the normal (heartbeat-gated, non-fast-kill) path.
+        """
+        proc = _fake_proc(pid=2103, ppid=1, cmdline=_BARE_INTERACTIVE_CMD, create_time=_stale_ct())
 
         with patch.object(psutil, "process_iter", return_value=[proc]):
             with patch.object(session_health.AgentSession, "find_by_claude_pid", return_value=None):
                 killed = session_health._reap_orphan_session_processes()
 
-        assert killed == 0
-        proc.terminate.assert_not_called()
+        assert killed == 1
+        proc.terminate.assert_called_once()
+
+    def test_headless_oneshot_never_matched_by_broadened_claude_signature(self, clean_state):
+        """A headless `claude -p` one-shot must NOT match the broadened
+        PTY-TUI alternative of `_CLAUDE_CMDLINE_RE` — only the separate,
+        age-gated `_is_stale_print_oneshot` matcher governs it (D2, issue
+        #1817). Both shapes carry `--permission-mode bypassPermissions`;
+        the only structural difference is `-p`/`--print`, which the
+        broadened regex's negative lookaheads must exclude.
+        """
+        cmdline_str = " ".join(_BARE_ONESHOT_CMD)
+        assert not session_health._CLAUDE_CMDLINE_RE.search(cmdline_str)
 
     def test_worker_cmdline_never_matches_oneshot_signature(self, clean_state):
         """`python -m worker --print-anything` can't match: argv[0] is not claude."""

--- a/tests/unit/test_update_claude_version_pin.py
+++ b/tests/unit/test_update_claude_version_pin.py
@@ -1,0 +1,123 @@
+"""Unit tests for check_claude_version_pin() in scripts/update/verify.py (D1a, issue #1817).
+
+The `claude` CLI is installed via the NATIVE installer
+(~/.local/bin/claude -> ~/.local/share/claude/versions/<version>/), not npm.
+This check compares the installed version to a pinned constant so a fleet-wide
+auto-update is visible instead of silently drifting the scraped TUI contract
+(D1b) out from under the PTY driver.
+
+Default: a drift logs a WARNING and stays non-blocking (available=True).
+CLAUDE_CONTRACT_CHECK_ENFORCE=1: a drift logs CRITICAL and hard-fails
+(available=False), matching the check_projects_json / check_sdlc_tool
+green-light-gate convention already used in this module.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from scripts.update.verify import (
+    CLAUDE_CONTRACT_CHECK_ENFORCE_ENV,
+    PINNED_CLAUDE_VERSION,
+    check_claude_version_pin,
+)
+
+
+def _run_cmd_stub(version_str: str):
+    def _stub(cmd, *a, **k):
+        return type("R", (), {"stdout": version_str, "stderr": "", "returncode": 0})()
+
+    return _stub
+
+
+class TestVersionMatch:
+    def test_matching_version_available_no_warning(self, caplog):
+        """Installed version == pin: available, no warning logged."""
+        with patch(
+            "scripts.update.verify.run_cmd",
+            side_effect=_run_cmd_stub(f"{PINNED_CLAUDE_VERSION} (Claude Code)"),
+        ):
+            with caplog.at_level(logging.WARNING, logger="scripts.update.verify"):
+                check = check_claude_version_pin()
+
+        assert check.available is True
+        assert PINNED_CLAUDE_VERSION in (check.version or "")
+        assert not any(r.levelno >= logging.WARNING for r in caplog.records)
+
+
+class TestVersionDriftDefault:
+    def test_drift_warns_and_stays_non_blocking_by_default(self, monkeypatch, caplog):
+        """A version mismatch with no enforce flag logs WARNING but available=True."""
+        monkeypatch.delenv(CLAUDE_CONTRACT_CHECK_ENFORCE_ENV, raising=False)
+        with patch(
+            "scripts.update.verify.run_cmd",
+            side_effect=_run_cmd_stub("9.9.9 (Claude Code)"),
+        ):
+            with caplog.at_level(logging.WARNING, logger="scripts.update.verify"):
+                check = check_claude_version_pin()
+
+        assert check.available is True
+        assert any(r.levelno == logging.WARNING for r in caplog.records)
+        assert any("9.9.9" in r.message for r in caplog.records)
+
+
+class TestVersionDriftEnforced:
+    def test_drift_hard_fails_when_enforce_flag_set(self, monkeypatch, caplog):
+        """A version mismatch with CLAUDE_CONTRACT_CHECK_ENFORCE=1 hard-fails."""
+        monkeypatch.setenv(CLAUDE_CONTRACT_CHECK_ENFORCE_ENV, "1")
+        with patch(
+            "scripts.update.verify.run_cmd",
+            side_effect=_run_cmd_stub("9.9.9 (Claude Code)"),
+        ):
+            with caplog.at_level(logging.CRITICAL, logger="scripts.update.verify"):
+                check = check_claude_version_pin()
+
+        assert check.available is False
+        assert check.error is not None
+        assert "9.9.9" in check.error
+        assert any(r.levelno == logging.CRITICAL for r in caplog.records)
+
+    def test_enforce_flag_only_triggers_on_literal_1(self, monkeypatch):
+        """Any value other than the literal string '1' is treated as off."""
+        monkeypatch.setenv(CLAUDE_CONTRACT_CHECK_ENFORCE_ENV, "true")
+        with patch(
+            "scripts.update.verify.run_cmd",
+            side_effect=_run_cmd_stub("9.9.9 (Claude Code)"),
+        ):
+            check = check_claude_version_pin()
+
+        assert check.available is True
+
+
+class TestUnresolvableVersion:
+    def test_unresolvable_version_skips_without_raising(self):
+        """When neither `claude --version` nor the native symlink resolve, skip cleanly."""
+        with (
+            patch(
+                "scripts.update.verify.run_cmd",
+                side_effect=RuntimeError("claude not found"),
+            ),
+            patch("scripts.update.verify.Path.is_symlink", return_value=False),
+        ):
+            check = check_claude_version_pin()
+
+        assert check.available is True
+        assert check.version is not None
+        assert "skipped" in check.version
+
+
+class TestNativeInstallerNotManagedByNpm:
+    def test_claude_not_in_npm_managed_packages(self):
+        """claude must never be added to npm_tools.MANAGED_PACKAGES (native install only)."""
+        from scripts.update.npm_tools import MANAGED_PACKAGES
+
+        names = {pkg for pkg, _version in MANAGED_PACKAGES}
+        assert "claude" not in names
+        assert "@anthropic-ai/claude-code" not in names
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_worker_contract_check.py
+++ b/tests/unit/test_worker_contract_check.py
@@ -1,0 +1,89 @@
+"""Tests for the D1b startup contract-check gate (issue #1817).
+
+`worker.__main__._evaluate_contract_check_gate` is the pure decision logic
+behind the startup probe added after the `shutil.which("claude")` check: it
+decides whether a scraped-TUI-marker mismatch (`verify_tui_marker_contract`,
+tested separately in test_tui_marker_contract.py) should pass silently, log
+a critical warning, or refuse to start — scoped to whether the fleet has any
+PTY-transport role configured (a #1842 headless-only fleet is immune to
+TUI-marker drift by construction).
+
+`worker.__main__._any_pty_role_configured` resolves that PTY-transport
+question across the global settings default AND every project's
+`transport.pm`/`transport.dev` override.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import worker.__main__ as worker_main
+
+
+class TestEvaluateContractCheckGate:
+    def test_contract_ok_passes_regardless_of_other_flags(self):
+        assert worker_main._evaluate_contract_check_gate(True, True, True) == "pass"
+        assert worker_main._evaluate_contract_check_gate(True, False, False) == "pass"
+
+    def test_mismatch_with_no_pty_role_skips_headless(self):
+        """A fully-headless fleet must never hard-fail on a TUI marker mismatch."""
+        assert worker_main._evaluate_contract_check_gate(False, False, True) == "skip_headless"
+        assert worker_main._evaluate_contract_check_gate(False, False, False) == "skip_headless"
+
+    def test_mismatch_with_pty_role_and_no_enforce_warns(self):
+        assert worker_main._evaluate_contract_check_gate(False, True, False) == "warn"
+
+    def test_mismatch_with_pty_role_and_enforce_hard_fails(self):
+        assert worker_main._evaluate_contract_check_gate(False, True, True) == "hard_fail"
+
+
+class TestAnyPtyRoleConfigured:
+    def test_global_default_pty_returns_true(self):
+        with patch("config.settings.settings") as mock_settings:
+            mock_settings.granite.pm_transport = "pty"
+            mock_settings.granite.dev_transport = "headless"
+            assert worker_main._any_pty_role_configured() is True
+
+    def test_global_default_fully_headless_and_no_project_override_returns_false(self):
+        with (
+            patch("config.settings.settings") as mock_settings,
+            patch("bridge.routing.load_config", return_value={"projects": {}}),
+        ):
+            mock_settings.granite.pm_transport = "headless"
+            mock_settings.granite.dev_transport = "headless"
+            assert worker_main._any_pty_role_configured() is False
+
+    def test_project_override_to_pty_returns_true_even_if_global_headless(self):
+        cfg = {
+            "projects": {
+                "acme": {"transport": {"pm": "headless", "dev": "pty"}},
+            }
+        }
+        with (
+            patch("config.settings.settings") as mock_settings,
+            patch("bridge.routing.load_config", return_value=cfg),
+        ):
+            mock_settings.granite.pm_transport = "headless"
+            mock_settings.granite.dev_transport = "headless"
+            assert worker_main._any_pty_role_configured() is True
+
+    def test_config_read_error_fails_open_to_true(self):
+        """A transient projects.json read failure must not silently disarm
+        a load-bearing contract-check — fail open (assume PTY IS configured)."""
+        with (
+            patch("config.settings.settings") as mock_settings,
+            patch("bridge.routing.load_config", side_effect=RuntimeError("boom")),
+        ):
+            mock_settings.granite.pm_transport = "headless"
+            mock_settings.granite.dev_transport = "headless"
+            assert worker_main._any_pty_role_configured() is True
+
+    def test_malformed_project_entries_are_skipped_not_fatal(self):
+        cfg = {"projects": {"bad": "not-a-dict", "ok": {"transport": "also-not-a-dict"}}}
+        with (
+            patch("config.settings.settings") as mock_settings,
+            patch("bridge.routing.load_config", return_value=cfg),
+        ):
+            mock_settings.granite.pm_transport = "headless"
+            mock_settings.granite.dev_transport = "headless"
+            assert worker_main._any_pty_role_configured() is False

--- a/worker/__main__.py
+++ b/worker/__main__.py
@@ -625,6 +625,79 @@ def _resume_deferred_granite_sessions() -> None:
         logger.warning("Could not set worker:recovering flag for granite recovery: %s", e)
 
 
+def _any_pty_role_configured() -> bool:
+    """D1b (issue #1817): True if at least one role (globally or per-project)
+    resolves to PTY transport, anywhere across the fleet.
+
+    Runs at worker startup, before any specific session/project is known, so
+    this scans EVERY project's ``transport.pm``/``transport.dev`` override in
+    projects.json in addition to the global default
+    (``settings.granite.pm_transport`` / ``dev_transport``). A single
+    project overriding to "pty" while the global default is "headless" (or
+    vice versa) still counts — the D1b contract-check only needs ONE
+    PTY-transport role anywhere in the fleet to become load-bearing; a fully
+    headless fleet must not be hard-failed by a check that only matters for
+    the interactive TUI (#1842 — a headless role's ``claude -p`` one-shot
+    carries no PTY bytes and is immune to TUI-marker drift by construction).
+
+    Fails OPEN (returns True) on any config-read error: a false "no PTY role
+    configured" would silently disarm a load-bearing contract-check, which
+    is worse than running one extra fingerprint check unnecessarily.
+    """
+    from config.settings import settings
+
+    if settings.granite.pm_transport == "pty" or settings.granite.dev_transport == "pty":
+        return True
+
+    try:
+        from bridge.routing import load_config  # noqa: PLC0415
+
+        cfg = load_config()
+        projects_cfg = cfg.get("projects", {}) if isinstance(cfg, dict) else {}
+        for project in projects_cfg.values():
+            if not isinstance(project, dict):
+                continue
+            transport = project.get("transport")
+            if not isinstance(transport, dict):
+                continue
+            if transport.get("pm") == "pty" or transport.get("dev") == "pty":
+                return True
+    except Exception as e:
+        logger.debug(
+            "[worker-startup] projects.json transport scan failed (fail-open, "
+            "assuming a PTY role IS configured): %s",
+            e,
+        )
+        return True
+
+    return False
+
+
+def _evaluate_contract_check_gate(contract_ok: bool, pty_configured: bool, enforce: bool) -> str:
+    """Pure decision function for the D1b startup contract-check gate (issue #1817).
+
+    Separated from `_run_worker`'s I/O (logging, sys.exit) so the branching
+    logic is directly unit-testable without mocking worker startup.
+
+    Returns one of:
+      - "pass": markers matched their golden sample — nothing to report.
+      - "skip_headless": markers mismatched, but no PTY-transport role is
+        configured (fully headless fleet) — a headless `claude -p` one-shot
+        carries no PTY bytes and is immune to TUI-marker drift by
+        construction (#1842), so this is NOT an operator-actionable failure.
+      - "warn": markers mismatched, a PTY-transport role IS configured, but
+        CLAUDE_CONTRACT_CHECK_ENFORCE is not set — log CRITICAL and continue.
+      - "hard_fail": markers mismatched, a PTY-transport role IS configured,
+        AND CLAUDE_CONTRACT_CHECK_ENFORCE=1 — the caller must refuse to
+        start (sys.exit) rather than let sessions silently hang to timeout.
+    """
+    if contract_ok:
+        return "pass"
+    if not pty_configured:
+        return "skip_headless"
+    return "hard_fail" if enforce else "warn"
+
+
 async def _run_worker(projects: dict, dry_run: bool = False) -> None:
     """Main worker coroutine.
 
@@ -735,6 +808,55 @@ async def _run_worker(projects: dict, dry_run: bool = False) -> None:
         sys.exit(1)
 
     logger.info("CLI harness 'claude' found on PATH")
+
+    # D1b (issue #1817): startup contract-check on the scraped TUI markers
+    # the PTY driver depends on for idle detection (IDLE_BAR, PROMPT_GLYPH,
+    # SPINNER_EVIDENCE_RE, the trust-folder prompt pattern). A routine
+    # `claude` auto-update that rewords one of these strings is otherwise a
+    # SILENT fleet-wide outage — every PTY session hangs to timeout instead
+    # of detecting idle, with no exception and no crash. This converts that
+    # into a loud, operator-visible signal. See `_evaluate_contract_check_gate`
+    # for the (independently unit-testable) decision logic.
+    try:
+        from agent.granite_container.pty_driver import verify_tui_marker_contract
+
+        _contract_ok, _failed_markers = verify_tui_marker_contract()
+        _pty_configured = True if _contract_ok else _any_pty_role_configured()
+        _enforce = os.environ.get("CLAUDE_CONTRACT_CHECK_ENFORCE") == "1"
+        _decision = _evaluate_contract_check_gate(_contract_ok, _pty_configured, _enforce)
+
+        if _decision == "pass":
+            logger.info("CLI harness contract-check passed (TUI markers OK)")
+        elif _decision == "skip_headless":
+            logger.info(
+                "CLI harness contract-check: marker(s) %s mismatched, but no "
+                "PTY-transport role is configured (fully headless fleet) — "
+                "skipping. Headless turns carry no PTY bytes and are immune "
+                "to TUI-marker drift by construction.",
+                ", ".join(_failed_markers),
+            )
+        elif _decision == "warn":
+            logger.critical(
+                "CLI harness contract-check FAILED — scraped TUI marker(s) "
+                "%s no longer match their golden sample and a PTY-transport "
+                "role is configured. A stale marker means every interactive "
+                "session silently hangs to timeout instead of detecting idle "
+                "(issue #1817 D1b). Continuing anyway — set "
+                "CLAUDE_CONTRACT_CHECK_ENFORCE=1 to refuse startup on this "
+                "condition.",
+                ", ".join(_failed_markers),
+            )
+        else:  # "hard_fail"
+            logger.critical(
+                "CLI harness contract-check FAILED — scraped TUI marker(s) "
+                "%s no longer match their golden sample and a PTY-transport "
+                "role is configured. Refusing to start "
+                "(CLAUDE_CONTRACT_CHECK_ENFORCE=1).",
+                ", ".join(_failed_markers),
+            )
+            sys.exit(1)
+    except Exception as e:
+        logger.warning(f"CLI harness contract-check error (non-fatal): {e}")
 
     # Under launchd (VALOR_LAUNCHD=1), skip the subprocess smoke test entirely.
     # asyncio.create_subprocess_exec hangs indefinitely under macOS TCC/TTY restrictions


### PR DESCRIPTION
Closes #1866

Resilience hardening workstream D (D1-D4) from epic #1817. Four brittleness fixes, each disciplined and tested.

## What landed

- **D1a — claude version pin drift check.** `scripts/update/verify.py` compares the installed native-installer `claude` version to a pin and warns (or hard-fails under `CLAUDE_CONTRACT_CHECK_ENFORCE=1`) on drift, so a fleet-wide auto-update that silently shifts the scraped-TUI contract becomes visible.
- **D1b — PTY-scoped TUI-marker fingerprint contract check.** `worker/__main__.py` runs `pty_driver.verify_tui_marker_contract()` at startup, re-matching each scraped marker regex against a golden sample. It hard-fails startup only when a `pty`-transport role is configured (a fully-headless fleet is immune by construction).
- **D2 — immediate None-aware PTY pid persist.** `pty_pool.py` persists each spawned pid the instant it is known (so a `dev.spawn()` failure after a successful `pm.spawn()` can no longer strand `pm`'s pid as an unreapable orphan), and the `session_health.py` cross-process reaper regex is broadened to match the native/PTY granite process while excluding headless `claude -p` one-shots.
- **D3 — observable background-task failures.** Circuit-breaker state writes in `agent/sdk_client.py` are awaited instead of fired off unobserved; the telegram background delivery task is held with a done-callback so its exceptions surface; `agent/memory_extraction.py` logs (rather than silently swallows) exceptions.
- **D4 — notify-listener liveness watchdog.** A periodic off-path `PUBSUB NUMSUB` probe on a SEPARATE short-lived Redis connection (never the `listen()` connection) detects a silently-dropped `valor:sessions:new` subscription and force-closes the handle to drive the existing resubscribe.

## Version-pin reconciliation (required)

Before this branch, `PINNED_CLAUDE_VERSION = "2.1.197"` existed independently in `scripts/nightly_regression_tests.py` (the #1839 ollama canary), and D1a introduced a second copy in `scripts/update/verify.py`, plus a typed catalog default in `config/settings.py`. Three copies of one fact.

**Reconciled to a single source of truth in `config/models.py`** (the module already documented as the one place model/version constants live), read via `os.environ.get("PINNED_CLAUDE_VERSION", "2.1.198")`:
- `scripts/update/verify.py` and `scripts/nightly_regression_tests.py` both import it.
- `config/settings.py` mirrors it as the typed catalog default.
- **Default set to `2.1.198`**, the current fleet version (`claude --version` on the build machine; the harness gate validated 2.1.198).
- `docs/features/deployment.md` bump procedure + bump-log and `.env.example` updated to point at `config/models.py` as the single source.
- Cross-referenced issue #1854 (canary-provisioning spike) in the `config/models.py` comment for the not-yet-fleet-version provisioning follow-up.

## Rebase / conflict resolution

Rebased onto `origin/main` (6e846f0d). Two files needed manual resolution; the rest auto-merged and were verified semantically (not just textually):

- **`agent/granite_container/pty_pool.py`** — main added a `_pids_lock` thread-safety discipline for all `_spawned_pids` mutations; D2 added unlocked per-spawn `.add()`. Reconciled by **lock-guarding D2's immediate persists** to match main's discipline and keeping main's consolidated end-of-function persist (which also covers the fully-headless empty-set case).
- **`config/settings.py`** — clean additive conflict: kept both main's `email_resolver_alert_after` (A2) and the D fields.
- Auto-merged surfaces confirmed disjoint/correct: D4 watchdog (notify-pubsub listener) vs #1867 progress-deadline cancel scope + #1872 reclaim drain (both in the separate `_worker_loop`); D2 reaper regex vs #1848 headless one-shots; D1b contract-check gate ordered before the #1874 startup recovery Steps 1-3c.

## Verification

- Branch unit suites (version pin, TUI-marker contract, worker contract-check, pty_pool, agent_session_queue async, D3 silent-failure logging, memory_extraction, circuit_breaker, session_health orphan reap): **267 passed** (`-n0`).
- Main-side conflict-surface suites (progress_deadline_cancel, slot_lease_reclaim, worker_wedge_pending): **22 passed**.
- `ruff format` (no changes) + `ruff check` (all passed) on all changed files.
- opus code-reviewer on the rebased diff: **APPROVE-WITH-NOTES, no blockers** — confirmed all three auto-merged surfaces are semantically correct.

## Review notes (non-blocking, from the opus reviewer)

1. `agent_session_queue.py` ~L1108 — the watchdog-cancel `finally` catches `(CancelledError, Exception)`; a shutdown cancel landing on the outer listener task during that await could be suppressed (microscopic window; launchd SIGKILL is the backstop). Candidate quick follow-up: only re-raise when the current task is being cancelled.
2. `bridge/telegram_bridge.py` — per-message emoji/classify tasks append to a never-pruned `_background_tasks` list (pre-existing pattern; bounded by bridge restarts). Suggest the done-callback also discard the task.
3. `agent/sdk_client.py` D3 comments justify awaiting by citing "a Redis write failure here used to vanish silently," but the breaker is pure in-memory — the change is correct, the rationale wording is not; reword to reference GC / loop-shutdown loss.
4. `PUBSUB NUMSUB` is server-global: if another process is subscribed to `valor:sessions:new`, the watchdog reads non-zero and won't detect this worker's drop (same limitation as the pre-existing subscribe-time self-check; consistent with single-machine ownership).
5. **D1b golden fixtures (#1854):** pointing `verify_tui_marker_contract` at the real recorded `tests/granite_faults/fixtures/*.frames` would give stronger coverage than the inline hand-crafted samples, but it is NON-TRIVIAL (production startup code reading `tests/` fixtures is bad coupling + deploy-path resolution + frame parsing). The self-contained inline dict is the right call for this PR; the fixture-backed upgrade is tracked under #1854.
