### PR TITLE
Fix session lifecycle notification gaps (#1877)

### DIFF
--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -1892,6 +1892,17 @@ async def _worker_loop(
                                 reason="progress deadline exceeded (recovery declined)",
                             )
                     finalized_by_execute = True  # row is now terminal — SKIP the outer finally
+                    # Cancel-reason signal (#1877 defect #1): the deadline kill
+                    # finalizes the row terminal (cancelled/abandoned/failed) —
+                    # nothing resumes. Write it BEFORE exec_task.cancel() (the
+                    # cancel that triggers the interrupt-message send) so the
+                    # winning send site emits the no-resume copy. handle=None was
+                    # passed to _apply_recovery_transition above, so it did not
+                    # write a reason of its own — this is the sole write for this
+                    # kill.
+                    from agent.cancel_reason import set_cancel_reason
+
+                    set_cancel_reason(session.session_id, "no_resume")
                     exec_task.cancel()
                     break
                 await exec_task  # propagate result / CancelledError

--- a/agent/cancel_reason.py
+++ b/agent/cancel_reason.py
@@ -1,0 +1,97 @@
+"""Transient cancel-reason signal for reason-aware interrupt messaging (#1877).
+
+When a killer cancels a running session, the executor's ``CancelledError`` handler
+(``agent/messenger.py``) and the completion runner (``agent/session_completion.py``)
+send a best-effort "I was interrupted" Telegram message. Those send sites are
+deliberately ORM-free, so they cannot re-read the session's authoritative status
+to decide whether the interruption will resume. Instead each killer writes a
+transient reason to a raw Redis key that the winning send site reads.
+
+Convention:
+  * Key: ``cancel-reason:{session_id}`` in ``POPOTO_REDIS_DB`` (the same raw-Redis
+    access pattern the ``interrupted-sent:{session_id}`` dedup key already uses).
+  * Values: ``"no_resume"`` (killer finalized the session terminal — nothing will
+    resume) or ``"resume"`` (a recovery path re-queued the session to ``pending``).
+  * TTL: 180 seconds. **The TTL is the sole cleanup mechanism** — there is no
+    destructive pop or delete anywhere. This is load-bearing: both interrupt send
+    sites race a single-winner ``interrupted-sent`` SET-NX dedup, and a destructive
+    read by the *losing* (non-sending) site could starve the *winning* (sending)
+    site into reading ``None`` and emitting the wrong copy. A non-destructive read
+    (plus reading only inside the dedup-winner branch) closes that race. A stale
+    key lingers at most 180s and only for its own unique ``session_id``, so there
+    is no cross-session contamination.
+
+Safe defaults:
+  * Absent key (genuine worker shutdown / Branch 3, or a killer that raced ahead
+    of its own write) -> ``get_cancel_reason`` returns ``None`` -> the send site
+    uses ``INTERRUPT_RESUME``. This is the historical behavior, so a missed write
+    degrades to "will resume", never to a crash.
+  * Redis unavailable -> both helpers swallow the error. ``get_cancel_reason``
+    returns ``None`` so it never raises into the ``CancelledError`` handler.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _cancel_reason_key(session_id: str) -> str:
+    """Redis key for the transient cancel-reason signal."""
+    return f"cancel-reason:{session_id}"
+
+
+def set_cancel_reason(session_id: str, kind: str, ttl: int = 180) -> None:
+    """Write the transient cancel-reason for ``session_id``.
+
+    Best-effort: a Redis failure is swallowed (the send site degrades to the
+    resume copy, i.e. current behavior). Must be called *before* the finalize /
+    cancel that triggers the interrupt send so the winning send site can read it.
+
+    Args:
+        session_id: The session being cancelled.
+        kind: ``"no_resume"`` (terminal, nothing resumes) or ``"resume"``
+            (re-queued to pending).
+        ttl: Key lifetime in seconds. The TTL is the only reclaimer — no code
+            ever deletes the key.
+    """
+    if not session_id:
+        return
+    try:
+        from popoto.redis_db import POPOTO_REDIS_DB  # noqa: PLC0415
+
+        POPOTO_REDIS_DB.set(_cancel_reason_key(session_id), kind, ex=ttl)
+    except Exception as exc:
+        logger.debug("[cancel-reason] set failed for %s (non-fatal): %s", session_id, exc)
+
+
+def get_cancel_reason(session_id: str) -> str | None:
+    """Read the transient cancel-reason for ``session_id`` non-destructively.
+
+    Never deletes the key (the 180s TTL is the sole reclaimer) and never raises
+    — a Redis failure or a missing key both return ``None`` so the caller falls
+    back to the resume copy. Callers should read this only inside the branch that
+    won the ``interrupted-sent`` dedup, so a non-sending site cannot influence
+    what the sender reads.
+
+    Returns:
+        ``"no_resume"`` / ``"resume"`` if set, else ``None``.
+    """
+    if not session_id:
+        return None
+    try:
+        from popoto.redis_db import POPOTO_REDIS_DB  # noqa: PLC0415
+
+        raw = POPOTO_REDIS_DB.get(_cancel_reason_key(session_id))
+    except Exception as exc:
+        logger.debug("[cancel-reason] get failed for %s (non-fatal): %s", session_id, exc)
+        return None
+    if raw is None:
+        return None
+    if isinstance(raw, bytes):
+        try:
+            return raw.decode("utf-8")
+        except Exception:
+            return None
+    return str(raw)

--- a/agent/messenger.py
+++ b/agent/messenger.py
@@ -333,11 +333,24 @@ class BackgroundTask:
                     )
 
                 if _should_send:
+                    # Reason-aware copy (#1877 defect #1). Read the cancel-reason
+                    # ONLY here, inside the dedup-winner branch, and never
+                    # destructively — so the losing (non-sending) site can never
+                    # starve this read. Absent/unknown reason -> resume copy
+                    # (historical default; Branch-3 worker shutdown writes nothing).
+                    from agent.cancel_reason import get_cancel_reason  # noqa: PLC0415
+                    from agent.notification_copy import (  # noqa: PLC0415
+                        INTERRUPT_NO_RESUME,
+                        INTERRUPT_RESUME,
+                    )
+
+                    _reason = get_cancel_reason(self.messenger.session_id)
+                    _interrupt_msg = (
+                        INTERRUPT_NO_RESUME if _reason == "no_resume" else INTERRUPT_RESUME
+                    )
                     try:
                         await asyncio.wait_for(
-                            self.messenger._send_callback(
-                                "I was interrupted and will resume automatically. No action needed."
-                            ),
+                            self.messenger._send_callback(_interrupt_msg),
                             timeout=2.0,
                         )
                     except (TimeoutError, Exception) as _send_err:

--- a/agent/notification_copy.py
+++ b/agent/notification_copy.py
@@ -1,0 +1,32 @@
+"""Single source of truth for user-facing session-lifecycle copy.
+
+Every Telegram message the worker sends about a session's *lifecycle* (as
+opposed to the session's actual work product) is defined here as a module
+constant. Send sites import these names; they never inline the literal string.
+A copy change is therefore a single-file edit that ripples to every send site
+and every copy-asserting test at once (issue #1877).
+
+Constants:
+  * ``INTERRUPT_RESUME`` — the session was interrupted but the worker will
+    re-queue and resume it automatically; the user need do nothing. This is the
+    historical default preserved verbatim so the resume case behaves exactly as
+    before.
+  * ``INTERRUPT_NO_RESUME`` — the session was stopped by a killer that finalized
+    it to a terminal, non-resumable status (deadline kill, health-check kill,
+    exhausted recovery attempts). Nothing will resume automatically.
+  * ``FAILURE_NOTICE`` — the session crashed (running -> failed) from an uncaught
+    exception. The error was logged; the request did not complete.
+"""
+
+from __future__ import annotations
+
+# Interrupted, worker WILL resume automatically (unchanged historical copy).
+INTERRUPT_RESUME = "I was interrupted and will resume automatically. No action needed."
+
+# Interrupted, worker will NOT resume automatically.
+INTERRUPT_NO_RESUME = (
+    "I was stopped and won't resume automatically. Send a new message if you'd like me to continue."
+)
+
+# Session crashed (running -> failed) from an uncaught exception.
+FAILURE_NOTICE = "Something went wrong and I couldn't finish that. I've logged the error."

--- a/agent/session_completion.py
+++ b/agent/session_completion.py
@@ -1169,7 +1169,15 @@ async def _send_interrupted_message(
     if not should_send:
         return
 
-    msg = "I was interrupted and will resume automatically. No action needed."
+    # Reason-aware copy (#1877 defect #1). We reach here only after WINNING the
+    # interrupted-sent SET-NX above, so this is the single sending site for this
+    # session_id. Read the cancel-reason non-destructively (180s TTL is the only
+    # reclaimer); absent/unknown -> resume copy (historical default).
+    from agent.cancel_reason import get_cancel_reason  # noqa: PLC0415
+    from agent.notification_copy import INTERRUPT_NO_RESUME, INTERRUPT_RESUME  # noqa: PLC0415
+
+    reason = get_cancel_reason(session_id)
+    msg = INTERRUPT_NO_RESUME if reason == "no_resume" else INTERRUPT_RESUME
     try:
         await asyncio.wait_for(send_cb(chat_id, msg, telegram_message_id, parent), timeout=2.0)
     except (TimeoutError, Exception) as send_err:

--- a/agent/session_executor.py
+++ b/agent/session_executor.py
@@ -702,11 +702,12 @@ async def _maybe_send_failure_notice(messenger, session_id: str) -> None:
 
     * **Deduped.** A ``failed-sent:{session_id}`` SET NX key (120s TTL) ensures the
       three finalize paths in the executor's failure block never double-send.
-    * **Never double-narrates a killed session.** If a killer already owns the exit
-      narrative it has written a ``cancel-reason:{session_id}`` (and sent its own
-      interrupt message); this function returns early so the user is not sent two
-      competing exit stories (folded-in critique concern: cross-class dedup
-      collision).
+    * **Never double-narrates a no-resume killed session.** If a killer already owns
+      a no-resume exit narrative it has written ``cancel-reason:{session_id}=no_resume``
+      (and sent its own interrupt message); this function returns early so the user is
+      not sent two competing exit stories (folded-in critique concern: cross-class dedup
+      collision). A stale ``resume`` reason does NOT suppress the notice — a session
+      that was requeued and then genuinely crashed still deserves the failure copy.
     * **Never blocks finalization.** The send is bounded by a 2s ``wait_for`` and
       every error (including the timeout) is swallowed — this coroutine never
       raises, so the caller's finalize path always proceeds.
@@ -716,11 +717,14 @@ async def _maybe_send_failure_notice(messenger, session_id: str) -> None:
         from agent.notification_copy import FAILURE_NOTICE
 
         # Cross-class dedup collision (critique concern): a killer that already
-        # owns the exit narrative must not be double-messaged.
-        if get_cancel_reason(session_id) is not None:
+        # owns a *no-resume* exit narrative must not be double-messaged. We key on
+        # "no_resume" specifically (not merely "present"): a stale "resume" reason
+        # from an interrupt-and-requeue followed by a genuine crash in the same TTL
+        # window should still surface the failure notice, not be silently swallowed.
+        if get_cancel_reason(session_id) == "no_resume":
             logger.info(
-                "[%s] Failure notice suppressed — a killer already owns the exit "
-                "narrative (cancel-reason present)",
+                "[%s] Failure notice suppressed — a killer already owns the "
+                "no-resume exit narrative (cancel-reason=no_resume)",
                 session_id,
             )
             return

--- a/agent/session_executor.py
+++ b/agent/session_executor.py
@@ -695,6 +695,58 @@ def steer_session(session_id: str, message: str) -> dict:
         return {"success": False, "session_id": session_id, "error": str(e)}
 
 
+async def _maybe_send_failure_notice(messenger, session_id: str) -> None:
+    """Best-effort user-facing notice on a running->failed transition (#1877 defect #2).
+
+    Mirrors the CancelledError best-effort interrupted-message pattern. Guarantees:
+
+    * **Deduped.** A ``failed-sent:{session_id}`` SET NX key (120s TTL) ensures the
+      three finalize paths in the executor's failure block never double-send.
+    * **Never double-narrates a killed session.** If a killer already owns the exit
+      narrative it has written a ``cancel-reason:{session_id}`` (and sent its own
+      interrupt message); this function returns early so the user is not sent two
+      competing exit stories (folded-in critique concern: cross-class dedup
+      collision).
+    * **Never blocks finalization.** The send is bounded by a 2s ``wait_for`` and
+      every error (including the timeout) is swallowed — this coroutine never
+      raises, so the caller's finalize path always proceeds.
+    """
+    try:
+        from agent.cancel_reason import get_cancel_reason
+        from agent.notification_copy import FAILURE_NOTICE
+
+        # Cross-class dedup collision (critique concern): a killer that already
+        # owns the exit narrative must not be double-messaged.
+        if get_cancel_reason(session_id) is not None:
+            logger.info(
+                "[%s] Failure notice suppressed — a killer already owns the exit "
+                "narrative (cancel-reason present)",
+                session_id,
+            )
+            return
+
+        should_send = True
+        try:
+            from popoto.redis_db import POPOTO_REDIS_DB  # noqa: PLC0415
+
+            should_send = bool(
+                POPOTO_REDIS_DB.set(f"failed-sent:{session_id}", "1", nx=True, ex=120)
+            )
+        except Exception as dedup_err:
+            # Redis unavailable: send anyway (a duplicate is preferable to silence
+            # on a genuine failure).
+            logger.debug(
+                "[%s] failed-sent dedup lock unavailable (%s); sending anyway",
+                session_id,
+                dedup_err,
+            )
+
+        if should_send:
+            await asyncio.wait_for(messenger._send_callback(FAILURE_NOTICE), timeout=2.0)
+    except (TimeoutError, Exception) as err:
+        logger.warning("[%s] Failure-notice best-effort send failed: %s", session_id, err)
+
+
 async def _execute_agent_session(session: AgentSession) -> None:
     """
     Execute a single agent session:
@@ -1975,6 +2027,12 @@ async def _execute_agent_session(session: AgentSession) -> None:
                 )
         finally:
             heartbeat.cancel()
+
+        # Failure notification (#1877 defect #2). A running->failed transition
+        # used to be silent — no Telegram message at all. Best-effort, deduped,
+        # and never blocking finalization; see `_maybe_send_failure_notice`.
+        if task.error and not chat_state.defer_reaction:
+            await _maybe_send_failure_notice(messenger, session.session_id)
 
         # Update session status in Redis via AgentSession
         # When auto-continue deferred, session is still active (not completed)

--- a/agent/session_health.py
+++ b/agent/session_health.py
@@ -2317,6 +2317,25 @@ async def _apply_recovery_transition(
         reason,
     )
 
+    # Cancel-reason signal (#1877 defect #1). When THIS function owns the cancel
+    # (handle present), predict the resume-ness of the outcome and write it BEFORE
+    # cancelling, so the interrupt-message send (which fires during the cancel
+    # await below) selects the right copy. `is_local` (abandoned) and the
+    # exhausted-attempts ceiling (failed) are known here and are terminal ->
+    # no_resume; otherwise the transition most likely re-queues to pending ->
+    # resume. The subprocess-survived escalation to `failed` is only known after
+    # the cancel; it re-stamps no_resume in its own branch below and degrades
+    # safely to the resume copy (pre-#1877 behavior) if the send already fired.
+    # When handle is None the caller (progress-deadline Fix #3) owns the cancel
+    # and writes its own reason, so we skip here to avoid a wrong prediction.
+    if handle is not None and handle.task is not None and not handle.task.done():
+        from agent.cancel_reason import set_cancel_reason
+
+        _predicted_terminal = (
+            is_local or ((entry.recovery_attempts or 0) + 1) >= MAX_RECOVERY_ATTEMPTS
+        )
+        set_cancel_reason(entry.session_id, "no_resume" if _predicted_terminal else "resume")
+
     # Cancel the in-flight session task if we have a handle and the task
     # reference has been populated. Cancelling the populated task terminates
     # the SDK subprocess via CancelledError propagation, preventing orphan
@@ -2492,6 +2511,15 @@ async def _apply_recovery_transition(
             # ``failed`` terminal status so the in-process orphan reaper
             # (_TERMINAL_STATUSES) owns cleanup. Do NOT null ``started_at`` into
             # a pending record.
+            # Cancel-reason re-stamp (#1877 defect #1): this escalation to the
+            # terminal `failed` status was NOT predictable before the cancel
+            # above (it depends on the post-cancel subprocess-confirmation), so
+            # the pre-cancel prediction may have written `resume`. Correct it to
+            # `no_resume`; if the interrupt send already fired it degrades safely
+            # to the resume copy (documented acceptable degradation).
+            from agent.cancel_reason import set_cancel_reason
+
+            set_cancel_reason(entry.session_id, "no_resume")
             _has_deferred = (getattr(entry, "extra_context", None) or {}).get(
                 "deferred_self_draft_pending"
             )

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -71,17 +71,9 @@ def _sentry_before_send(event, hint):
     return event
 
 
-_sentry_dsn = os.getenv("SENTRY_DSN")
-if _sentry_dsn:
-    import sentry_sdk  # noqa: E402
+from monitoring.sentry_config import configure_sentry  # noqa: E402
 
-    sentry_sdk.init(
-        dsn=_sentry_dsn,
-        release=subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
-        traces_sample_rate=0.1,
-        environment=os.getenv("SENTRY_ENVIRONMENT", "production"),
-        before_send=_sentry_before_send,
-    )
+configure_sentry("bridge", before_send=_sentry_before_send)
 
 # Claude Agent SDK is always used (legacy mode removed)
 

--- a/docs/features/bridge-worker-architecture.md
+++ b/docs/features/bridge-worker-architecture.md
@@ -140,6 +140,51 @@ The worker's startup sequence is deterministic:
 | 7 | `_session_notify_listener()` | Background task: subscribe to `valor:sessions:new` pub/sub, wake worker on new session (~1s pickup) |
 | 8 | `run_idle_sweep()` | Background task: proactively tears down idle persistent Claude SDK clients on dormant/paused sessions before the ~48h Anthropic silent-death window (issue #1128). See [Worker-Internal Idle Sweeper](#worker-internal-idle-sweeper-issue-1128). |
 
+### Worker-Process Sentry (issue #1877)
+
+Session execution happens in the worker, so worker-side exceptions (SDK,
+tool, and lifecycle crashes) need the same Sentry visibility as bridge
+exceptions. Before issue #1877, `sentry_sdk.init()` was called only from
+`bridge/telegram_bridge.py`; the worker had no Sentry init at all, so every
+exception during session execution — including a silent running→failed
+crash — was invisible to Sentry.
+
+The fix extracts the bridge's init block into a shared
+`configure_sentry(component, before_send=None)` helper in
+`monitoring/sentry_config.py`, called by both processes at startup: the
+bridge from its module-level init block, the worker from
+`worker/__main__.py::main()` before `asyncio.run(_run_worker(...))`.
+
+- **DSN-gated, verbatim.** If `SENTRY_DSN` is unset the helper returns
+  without initializing — the same gating the bridge already had. `release`
+  (git HEAD), `traces_sample_rate`, and `environment` are preserved
+  unchanged.
+- **`before_send` is a parameter, not hardcoded.** The bridge passes its
+  `_sentry_before_send`, which drops events while the *bridge* is
+  hibernating (see `docs/plans/sentry_hibernation_filter.md`) — a
+  bridge-only concept. The worker passes `before_send=None` so worker
+  Sentry events are never silently dropped just because the bridge happens
+  to be hibernating while the worker itself is healthy. `configure_sentry`
+  never imports `bridge.hibernation`.
+- **Minimal pytest/CI guard only — no machine gate.** `configure_sentry`
+  returns early when `PYTEST_CURRENT_TEST` or `CI` is set, so a
+  `SENTRY_DSN`-present worker test run never mis-tags events as
+  `production`. This is deliberately the *only* environment gate in the
+  helper — there is no machine/platform check. The richer dev-vs-prod
+  environment gating is a separate concern (issue #1834) that layers on top
+  of this helper later; #1877 does not block on it.
+- **Env propagation needs no update-system changes.** The worker is a
+  separate launchd process, but `scripts/install_worker.sh` and
+  `scripts/remote-update.sh` already inject **all** `.env` values —
+  including `SENTRY_DSN` / `SENTRY_ENVIRONMENT` — into the worker plist's
+  `EnvironmentVariables` via `dotenv_values`, exactly as they do for the
+  bridge plist. `os.getenv("SENTRY_DSN")` therefore resolves correctly in
+  the launchd worker with no additional wiring.
+- **Startup observability.** The worker logs its enabled/disabled state at
+  startup: `worker sentry: enabled` or
+  `worker sentry: disabled (no DSN in worker env)`, so a missing-env no-op
+  is visible in `logs/worker.log` rather than silent.
+
 ### Media Enrichment (issue #1297)
 
 Telegram media (photos, voice, audio, documents) requires both Telethon RPC (download) and an AI call (vision / Whisper / extraction). The two halves are split along the bridge/worker boundary:

--- a/docs/features/pm-final-delivery.md
+++ b/docs/features/pm-final-delivery.md
@@ -87,10 +87,14 @@ Two distinct pieces replace the marker:
   6. Stamp `response_delivered_at` on the parent and finalize to
      `"completed"` via `finalize_session`. The runner is the **sole** caller
      that transitions the parent to `"completed"` on the success path.
-  7. On `asyncio.CancelledError`, best-effort deliver
-     `"I was interrupted and will resume automatically. No action needed."`
-     (dedup'd by `interrupted-sent:{session_id}` — 120s TTL) and re-raise to
-     preserve asyncio shutdown semantics.
+  7. On `asyncio.CancelledError`, best-effort deliver a reason-aware interrupt
+     message — `INTERRUPT_RESUME` ("will resume automatically") or
+     `INTERRUPT_NO_RESUME` ("won't resume automatically"), selected via
+     `agent/cancel_reason.py::get_cancel_reason` (dedup'd by
+     `interrupted-sent:{session_id}` — 120s TTL) and re-raise to preserve
+     asyncio shutdown semantics. See
+     [Reason-Aware Interrupt Messaging and Failure Notification](#reason-aware-interrupt-messaging-and-failure-notification-issue-1877)
+     below.
 
 `schedule_pipeline_completion(...)` wraps the runner in a tracked
 `asyncio.Task` registered in `_pending_completion_tasks` so the worker
@@ -148,6 +152,79 @@ Behavior mirrors the runner's CancelledError handler: dedup on
 redundancy is intentional — both layers may trip during shutdown; the
 Redis dedup ensures the user sees exactly one interrupted message per
 real interruption window, not N.
+
+## Reason-Aware Interrupt Messaging and Failure Notification (issue #1877)
+
+`agent/notification_copy.py` is the single source of truth for the
+user-facing lifecycle copy that both this doc and `agent/messenger.py` /
+`agent/session_completion.py` reference: `INTERRUPT_RESUME`,
+`INTERRUPT_NO_RESUME`, and `FAILURE_NOTICE`. Send sites import these
+constants rather than inlining literal strings, so a copy change is a
+single-file edit.
+
+### Defect #1 — reason-aware interrupt copy
+
+Before issue #1877, both interrupt send sites hardcoded "I was interrupted
+and will resume automatically" on every `CancelledError`, even when the
+killer had finalized the session to a terminal, non-resumable status. The
+fix threads a transient reason signal from the killer to the send site
+without giving the ORM-free messenger a database read:
+
+- **Key:** `cancel-reason:{session_id}` in `POPOTO_REDIS_DB` (raw Redis, the
+  same access pattern as the `interrupted-sent:{session_id}` dedup key).
+- **Values:** `"no_resume"` (the killer finalized the session terminal —
+  nothing will resume) or `"resume"` (a recovery path re-queued the session
+  to `pending`). Absent key (genuine worker shutdown, or a killer that
+  raced ahead of its own write) means `INTERRUPT_RESUME` — the historical
+  default.
+- **TTL:** 180 seconds, and that TTL is the *sole* cleanup mechanism —
+  neither `agent/cancel_reason.py` nor either send site ever pops or
+  deletes the key.
+- **Read discipline:** `get_cancel_reason()` is read **only inside the
+  branch that won the `interrupted-sent` SET-NX dedup** (i.e. only by the
+  site that is actually about to send). This is load-bearing: both
+  `agent/messenger.py` and `agent/session_completion.py` race that
+  single-winner dedup, and a destructive read by the *losing* (non-sending)
+  site could otherwise starve the *winning* site into reading `None` and
+  emitting the wrong copy. Non-destructive reads plus read-inside-winner
+  placement close that race.
+- **Writers:** every killer that finalizes a session to a terminal,
+  non-resumable status writes `"no_resume"` before it cancels the running
+  task — the deadline kill in `agent/agent_session_queue.py`'s worker loop,
+  and the out-of-band kill / terminal-escalation branches inside
+  `agent/session_health.py::_apply_recovery_transition` (health-check kill
+  and the post-cancel subprocess-survived escalation to `failed`). Recovery
+  paths that re-queue to `pending` write `"resume"`.
+- **Deliberately not wired:** supersede and PM-cancel finalize sessions that
+  are not currently `running`, so no `CancelledError` interrupt send ever
+  fires on those paths — there is nothing for a cancel-reason to influence,
+  so those call sites do not write one.
+
+See `agent/cancel_reason.py` for the full docstring covering the
+non-destructive-read contract and safe-default semantics.
+
+### Defect #2 — running→failed notification
+
+Before issue #1877, a session that crashed from an uncaught exception
+(`running` → `failed`) produced no Telegram message at all — the three
+finalize-on-failure paths in `agent/session_executor.py` persisted the
+terminal status but never called back to the user. The fix adds
+`_maybe_send_failure_notice(messenger, session_id)`, invoked on the
+failure-finalize branch when `task.error` is set and
+`not chat_state.defer_reaction`:
+
+- Sends the shared `FAILURE_NOTICE` copy via
+  `messenger._send_callback(...)`, bounded by a 2s `asyncio.wait_for` and
+  wrapped so a send failure (including the timeout) is swallowed and never
+  blocks finalization — mirroring the CancelledError best-effort pattern.
+- Deduped via a `failed-sent:{session_id}` SET-NX key (120s TTL) so the
+  three finalize-on-failure paths in the executor never double-send.
+- **Cross-class skip-guard:** before sending, the helper checks
+  `get_cancel_reason(session_id)`. If a cancel-reason is present, a killer
+  already owns this session's exit narrative (it cancelled the task and
+  sent its own reason-aware interrupt message), so the failure send is
+  skipped entirely rather than sending a second, competing "something went
+  wrong" message for the same exit.
 
 ## Race conditions (mitigations)
 
@@ -331,4 +408,6 @@ message content; the predicate + runner is the canonical path.
 - Tests: `tests/unit/test_pipeline_complete_predicate.py`,
   `tests/unit/test_deliver_pipeline_completion.py`,
   `tests/unit/test_messenger_cancelled_error.py`,
-  `tests/integration/test_pm_final_delivery.py`.
+  `tests/integration/test_pm_final_delivery.py`,
+  `tests/unit/test_cancel_reason.py`,
+  `tests/unit/test_session_executor_failure_notification.py` (issue #1877).

--- a/docs/features/session-lifecycle.md
+++ b/docs/features/session-lifecycle.md
@@ -331,6 +331,27 @@ The heal is idempotent: a re-run clamps only still-future records, so a mid-run 
 
 **In-process vs. standalone:** When the update script runs inside the same process as the queue (bridge in-process update), `_active_workers` is populated and fully authoritative. When it runs as a CLI subprocess, `_active_workers` will always be empty and the function logs a warning before relying on the `updated_at` recency check.
 
+## Duplicate-Session Dedup — Only `completed` Counts as Handled (issue #1877)
+
+`_cleanup_duplicate_sessions()` in `scripts/update/run.py` runs during every
+`/update` deploy and kills `pending` sessions that re-process a
+`(chat_id, telegram_message_id)` pair already covered by another session.
+Of the five terminal statuses, only **`completed`** means the message was
+actually handled — `killed`, `abandoned`, and `failed` all mean the prior
+attempt did *not* produce a delivered response.
+
+Before issue #1877, the terminal-status scan included all four of
+`("completed", "killed", "abandoned", "failed")`, so a legitimate `pending`
+retry after a killed/abandoned/failed attempt was silently suppressed —
+the user's message was never actually answered. The scan now checks only
+`("completed",)`: a `pending` session survives unless another session for
+the same `(chat_id, telegram_message_id)` reached `completed`.
+
+This is a narrower rule than the general terminal-status vocabulary above —
+it applies specifically to the duplicate-message dedup scan, not to the
+[Kill-is-Terminal Invariant](#kill-is-terminal-invariant) or any other
+terminal-status check in this document.
+
 ## Stall Reaction Dedup Reset (issue #1313)
 
 When `monitoring/session_watchdog.py::check_stalled_sessions` queues a user-visible ⏳ reaction for a stalled session (see [Bridge Self-Healing § 4a](bridge-self-healing.md#4a-user-visible-stall-alerts-monitoringsession_watchdogpy-issue-1313)), it claims the dedup key `watchdog:stall_reaction_applied:{session_id}` so the reaction is queued at most once per stall period.

--- a/monitoring/sentry_config.py
+++ b/monitoring/sentry_config.py
@@ -1,0 +1,67 @@
+"""Shared Sentry initialization for the bridge and worker processes (#1877 defect #3).
+
+The bridge historically owned the only ``sentry_sdk.init()`` call. Session
+execution happens in the worker, so worker-side exceptions (SDK/tool/lifecycle
+crashes) were invisible to Sentry. This module extracts the bridge's init block
+into a single ``configure_sentry(component, before_send=None)`` helper that both
+processes call at startup.
+
+Design notes:
+  * **DSN-gated, verbatim.** If ``SENTRY_DSN`` is unset the helper returns without
+    initializing — the same gating the bridge already had. ``release`` (git HEAD),
+    ``traces_sample_rate``, and ``environment`` are preserved unchanged.
+  * **``before_send`` is a parameter, not hardcoded.** The bridge passes its
+    ``_sentry_before_send`` (which drops events while the *bridge* is hibernating —
+    a bridge-only concept). The worker passes ``None`` so worker Sentry events are
+    never silently dropped because the bridge happens to be hibernating. This
+    helper never imports ``bridge.hibernation``.
+  * **Minimal test/CI guard only.** ``configure_sentry`` returns early under
+    ``PYTEST_CURRENT_TEST`` or ``CI`` so a ``SENTRY_DSN``-present test run never
+    mis-tags ``production``. It deliberately does NOT add a machine/platform gate
+    and does NOT own the richer dev-vs-prod environment gating (that is #1834's
+    scope, layered on top of this helper later).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+
+def configure_sentry(component: str, before_send=None) -> bool:
+    """Initialize Sentry for a process ``component`` (e.g. ``"bridge"`` / ``"worker"``).
+
+    Args:
+        component: Human-readable process name, used only in log lines.
+        before_send: Optional Sentry ``before_send`` hook. The bridge passes its
+            hibernation filter; the worker passes ``None``.
+
+    Returns:
+        ``True`` if ``sentry_sdk.init`` was invoked, ``False`` otherwise (no DSN,
+        or the pytest/CI guard tripped).
+    """
+    # Minimal guard: never initialize (and never mis-tag `production`) under a
+    # test run or CI. This is intentionally the ONLY environment gate here —
+    # #1834's dev-vs-prod gating layers on top later.
+    if os.environ.get("PYTEST_CURRENT_TEST") or os.environ.get("CI"):
+        logger.debug("[%s] Sentry init skipped (pytest/CI guard)", component)
+        return False
+
+    dsn = os.getenv("SENTRY_DSN")
+    if not dsn:
+        return False
+
+    import sentry_sdk  # noqa: PLC0415
+
+    sentry_sdk.init(
+        dsn=dsn,
+        release=subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        traces_sample_rate=0.1,
+        environment=os.getenv("SENTRY_ENVIRONMENT", "production"),
+        before_send=before_send,
+    )
+    logger.info("[%s] Sentry initialized", component)
+    return True

--- a/scripts/update/run.py
+++ b/scripts/update/run.py
@@ -272,9 +272,13 @@ def _cleanup_stale_sessions(project_dir: Path, age_minutes: int = 120) -> tuple[
 def _cleanup_duplicate_sessions(project_dir: Path) -> int:
     """Kill pending sessions that re-process messages already handled by a completed session.
 
-    A session is a re-run if another session with the same (chat_id, telegram_message_id)
-    has already reached a terminal state (completed, killed, abandoned, failed).
-    Pending duplicates are killed before the worker picks them up.
+    A session is a re-run only if another session with the same
+    (chat_id, telegram_message_id) has already reached ``completed`` — the sole
+    status that means the message was actually handled. A prior ``killed`` /
+    ``abandoned`` / ``failed`` attempt did NOT handle the message, so a legitimate
+    ``pending`` retry after one of those must survive (issue #1877 defect #4).
+    Pending duplicates of a completed message are killed before the worker picks
+    them up.
 
     Returns the number of sessions killed.
     """
@@ -295,9 +299,11 @@ def _cleanup_duplicate_sessions(project_dir: Path) -> int:
     if not pending_by_key:
         return 0
 
-    # Find terminal sessions that cover the same keys
+    # Find sessions that actually HANDLED the same keys. Only `completed` counts:
+    # a killed/abandoned/failed attempt left the message unhandled, so a pending
+    # retry must not be suppressed by one (issue #1877 defect #4).
     terminal_keys: set[tuple[str, int]] = set()
-    for status in ("completed", "killed", "abandoned", "failed"):
+    for status in ("completed",):
         for s in AgentSession.query.filter(status=status):
             msg_id = s.telegram_message_id
             chat_id = getattr(s, "chat_id", None)

--- a/tests/integration/test_pm_final_delivery.py
+++ b/tests/integration/test_pm_final_delivery.py
@@ -23,6 +23,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from agent import session_completion
+from agent.notification_copy import INTERRUPT_NO_RESUME, INTERRUPT_RESUME
 
 # -----------------------------------------------------------------------------
 # Fixtures
@@ -221,10 +222,11 @@ class TestCancelledErrorInterrupted:
             return "never"
 
         # Acquire pipeline_complete_pending AND interrupted-sent on first call
-        # each. Both return True.
+        # each. Both return True. No cancel-reason set → resume copy (default).
         redis_db = MagicMock()
         redis_db.set = MagicMock(return_value=True)
         redis_db.exists = MagicMock(return_value=False)
+        redis_db.get = MagicMock(return_value=None)
 
         with (
             patch("popoto.redis_db.POPOTO_REDIS_DB", redis_db),
@@ -243,14 +245,44 @@ class TestCancelledErrorInterrupted:
                 pass
 
         # The runner's CancelledError handler best-effort delivers the
-        # interrupted message and re-raises.
-        interrupted = [
-            c.args
-            for c in send_cb.await_args_list
-            if isinstance(c.args[1], str) and "interrupted" in c.args[1].lower()
-        ]
+        # interrupted message (resume copy) and re-raises.
+        interrupted = [c.args for c in send_cb.await_args_list if c.args[1] == INTERRUPT_RESUME]
         assert len(interrupted) == 1
-        assert "resume automatically" in interrupted[0][1]
+
+    async def test_cancelled_error_no_resume_reason_delivers_no_resume_copy(self, parent):
+        """A killer that finalized the session terminal writes cancel-reason=no_resume;
+        the interrupted send must use the no-resume copy, not 'will resume'."""
+        send_cb = AsyncMock(return_value=None)
+
+        async def _slow_harness(**_kw):
+            await asyncio.sleep(60.0)
+            return "never"
+
+        redis_db = MagicMock()
+        redis_db.set = MagicMock(return_value=True)
+        redis_db.exists = MagicMock(return_value=False)
+        # cancel-reason:{session_id} present → no-resume copy.
+        redis_db.get = MagicMock(return_value=b"no_resume")
+
+        with (
+            patch("popoto.redis_db.POPOTO_REDIS_DB", redis_db),
+            patch("agent.sdk_client.get_response_via_harness", new=_slow_harness),
+            patch("agent.sdk_client._get_prior_session_uuid", return_value="u"),
+        ):
+            task = session_completion.schedule_pipeline_completion(
+                parent, "ctx", send_cb, parent.chat_id, None
+            )
+            assert task is not None
+            await session_completion.drain_pending_completions(timeout=0.2)
+            try:
+                await asyncio.wait_for(task, timeout=3.0)
+            except (TimeoutError, asyncio.CancelledError):
+                pass
+
+        no_resume = [c.args for c in send_cb.await_args_list if c.args[1] == INTERRUPT_NO_RESUME]
+        assert len(no_resume) == 1
+        # And the resume copy was NOT sent.
+        assert all(c.args[1] != INTERRUPT_RESUME for c in send_cb.await_args_list)
 
     async def test_cancelled_then_second_cancel_does_not_duplicate_interrupted(self, parent):
         """Risk 6 flap-dedup: two cancellations of two runners for the same

--- a/tests/unit/test_cancel_reason.py
+++ b/tests/unit/test_cancel_reason.py
@@ -1,0 +1,96 @@
+"""Unit tests for the transient cancel-reason signal (#1877 defect #1).
+
+Contract:
+  * unset key → get returns None (send site defaults to resume copy)
+  * set/get round-trip returns the written reason
+  * the read is NON-destructive (no pop/delete; repeated reads keep returning it)
+  * Redis unavailable → both helpers swallow the error; get returns None, never raises
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from agent.cancel_reason import get_cancel_reason, set_cancel_reason
+
+
+class _FakeRedis:
+    """Minimal redis stand-in returning bytes from get (like real redis)."""
+
+    def __init__(self):
+        self.store: dict[str, bytes] = {}
+        self.deleted: list[str] = []
+
+    def set(self, key, value, ex=None, nx=False):
+        self.store[key] = value.encode() if isinstance(value, str) else value
+        return True
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def delete(self, *keys):
+        for k in keys:
+            self.deleted.append(k)
+            self.store.pop(k, None)
+
+
+def test_unset_reason_returns_none():
+    fake = _FakeRedis()
+    with patch("popoto.redis_db.POPOTO_REDIS_DB", fake):
+        assert get_cancel_reason("sess-unset") is None
+
+
+def test_set_get_round_trip():
+    fake = _FakeRedis()
+    with patch("popoto.redis_db.POPOTO_REDIS_DB", fake):
+        set_cancel_reason("sess-1", "no_resume")
+        assert get_cancel_reason("sess-1") == "no_resume"
+        set_cancel_reason("sess-2", "resume")
+        assert get_cancel_reason("sess-2") == "resume"
+
+
+def test_read_is_non_destructive():
+    """Repeated reads keep returning the value — the key is never deleted."""
+    fake = _FakeRedis()
+    with patch("popoto.redis_db.POPOTO_REDIS_DB", fake):
+        set_cancel_reason("sess-nd", "no_resume")
+        assert get_cancel_reason("sess-nd") == "no_resume"
+        assert get_cancel_reason("sess-nd") == "no_resume"
+        assert get_cancel_reason("sess-nd") == "no_resume"
+    assert fake.deleted == []  # nothing was ever deleted
+
+
+def test_set_uses_ttl_and_no_nx():
+    """set_cancel_reason writes with a TTL and unconditionally (overwrites)."""
+    fake = MagicMock()
+    with patch("popoto.redis_db.POPOTO_REDIS_DB", fake):
+        set_cancel_reason("sess-ttl", "no_resume", ttl=180)
+    fake.set.assert_called_once()
+    args, kwargs = fake.set.call_args
+    assert kwargs.get("ex") == 180
+    assert not kwargs.get("nx")  # must overwrite, not conditional
+
+
+def test_get_swallows_redis_error_returns_none():
+    """A raising Redis must not propagate into the CancelledError handler."""
+    fake = MagicMock()
+    fake.get.side_effect = RuntimeError("redis down")
+    with patch("popoto.redis_db.POPOTO_REDIS_DB", fake):
+        assert get_cancel_reason("sess-err") is None
+
+
+def test_set_swallows_redis_error():
+    """set_cancel_reason never raises even if Redis is unavailable."""
+    fake = MagicMock()
+    fake.set.side_effect = RuntimeError("redis down")
+    with patch("popoto.redis_db.POPOTO_REDIS_DB", fake):
+        set_cancel_reason("sess-err", "no_resume")  # must not raise
+
+
+def test_empty_session_id_is_noop():
+    fake = MagicMock()
+    with patch("popoto.redis_db.POPOTO_REDIS_DB", fake):
+        set_cancel_reason("", "no_resume")
+        assert get_cancel_reason("") is None
+    fake.set.assert_not_called()
+    fake.get.assert_not_called()

--- a/tests/unit/test_cleanup_duplicate_sessions.py
+++ b/tests/unit/test_cleanup_duplicate_sessions.py
@@ -1,0 +1,85 @@
+"""Unit tests for `_cleanup_duplicate_sessions` dedup narrowing (#1877 defect #4).
+
+Only a `completed` session means a message was actually handled. A prior
+`failed` / `killed` / `abandoned` attempt did NOT handle the message, so a
+legitimate `pending` retry must survive.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from scripts.update.run import _cleanup_duplicate_sessions
+
+
+def _session(status: str, chat_id: str, msg_id: int, sid: str) -> MagicMock:
+    s = MagicMock()
+    s.status = status
+    s.chat_id = chat_id
+    s.telegram_message_id = msg_id
+    s.agent_session_id = sid
+    return s
+
+
+class _FakeQuery:
+    """Stand-in for AgentSession.query supporting `.filter(status=...)`."""
+
+    def __init__(self, by_status: dict[str, list]):
+        self._by_status = by_status
+
+    def filter(self, status: str):
+        return list(self._by_status.get(status, []))
+
+
+def _run_with_sessions(by_status: dict[str, list]):
+    """Invoke the cleanup with a fake AgentSession model + captured finalize calls."""
+    finalized: list[tuple[str, str]] = []
+
+    fake_model = MagicMock()
+    fake_model.query = _FakeQuery(by_status)
+
+    def _fake_finalize(session, status, **kwargs):
+        finalized.append((session.agent_session_id, status))
+
+    with (
+        patch.dict(
+            "sys.modules",
+            {
+                "models.agent_session": MagicMock(AgentSession=fake_model),
+                "models.session_lifecycle": MagicMock(finalize_session=_fake_finalize),
+            },
+        ),
+    ):
+        killed = _cleanup_duplicate_sessions(Path("/tmp"))
+    return killed, finalized
+
+
+def test_failed_terminal_does_not_kill_pending_retry():
+    """A `failed` attempt + matching `pending` retry → pending survives."""
+    pending = _session("pending", "-100", 42, "retry-1")
+    failed = _session("failed", "-100", 42, "failed-0")
+    killed, finalized = _run_with_sessions({"pending": [pending], "failed": [failed]})
+    assert killed == 0
+    assert finalized == []
+
+
+def test_killed_and_abandoned_do_not_kill_pending_retry():
+    """`killed`/`abandoned` attempts also leave a matching `pending` retry alive."""
+    pending = _session("pending", "-100", 7, "retry-1")
+    killed_s = _session("killed", "-100", 7, "killed-0")
+    abandoned = _session("abandoned", "-100", 7, "abandoned-0")
+    killed, finalized = _run_with_sessions(
+        {"pending": [pending], "killed": [killed_s], "abandoned": [abandoned]}
+    )
+    assert killed == 0
+    assert finalized == []
+
+
+def test_completed_terminal_kills_pending_duplicate():
+    """A `completed` session + matching `pending` → the pending duplicate is killed."""
+    pending = _session("pending", "-100", 99, "dup-1")
+    completed = _session("completed", "-100", 99, "done-0")
+    killed, finalized = _run_with_sessions({"pending": [pending], "completed": [completed]})
+    assert killed == 1
+    assert finalized == [("dup-1", "killed")]

--- a/tests/unit/test_deliver_pipeline_completion.py
+++ b/tests/unit/test_deliver_pipeline_completion.py
@@ -21,6 +21,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from agent import session_completion
+from agent.notification_copy import INTERRUPT_NO_RESUME, INTERRUPT_RESUME
 
 
 @pytest.fixture
@@ -219,6 +220,8 @@ class TestCancelledError:
         # First lock set (pipeline_complete_pending) succeeds, second (interrupted-sent) succeeds
         redis_db.set = MagicMock(return_value=True)
         redis_db.exists = MagicMock(return_value=False)
+        # No cancel-reason set → resume copy (historical default).
+        redis_db.get = MagicMock(return_value=None)
         with (
             patch("popoto.redis_db.POPOTO_REDIS_DB", redis_db),
             patch("agent.sdk_client.get_response_via_harness", new=_cancel),
@@ -228,11 +231,9 @@ class TestCancelledError:
                 await session_completion._deliver_pipeline_completion(
                     parent, "ctx", send_cb, parent.chat_id, None
                 )
-        # send_cb should have been called once for the interrupted message.
+        # send_cb should have been called once with the shared resume constant.
         interrupted_calls = [
-            call
-            for call in send_cb.await_args_list
-            if isinstance(call.args[1], str) and "interrupted" in call.args[1].lower()
+            call for call in send_cb.await_args_list if call.args[1] == INTERRUPT_RESUME
         ]
         assert len(interrupted_calls) == 1
 
@@ -255,6 +256,84 @@ class TestCancelledError:
                 )
         # Dedup suppressed the interrupted send.
         send_cb.assert_not_awaited()
+
+
+class _DualFireRedis:
+    """Stateful redis stand-in for the interrupted-send dual-fire race (#1877).
+
+    The first `interrupted-sent:{sid}` SET NX wins (True); subsequent ones lose
+    (False). `cancel-reason:{sid}` is read non-destructively and always returns
+    the configured reason. Every other SET NX (e.g. the pipeline CAS lock) wins.
+    """
+
+    def __init__(self, reason: bytes | None = b"no_resume"):
+        self._interrupted_sent: set[str] = set()
+        self._reason = reason
+        self.deleted: list[str] = []
+
+    def set(self, key, value, nx=False, ex=None):
+        if key.startswith("interrupted-sent:"):
+            if key in self._interrupted_sent:
+                return False
+            self._interrupted_sent.add(key)
+            return True
+        return True
+
+    def get(self, key):
+        if key.startswith("cancel-reason:"):
+            return self._reason
+        return None
+
+    def exists(self, key):
+        return False
+
+    def delete(self, *keys):
+        self.deleted.extend(keys)
+
+
+class TestReasonAwareInterrupt:
+    """Reason-aware interrupt copy at the completion-runner send site (#1877 defect #1)."""
+
+    async def test_no_resume_reason_sends_no_resume_copy(self, parent, send_cb):
+        fake = _DualFireRedis(reason=b"no_resume")
+        with patch("popoto.redis_db.POPOTO_REDIS_DB", fake):
+            await session_completion._send_interrupted_message(
+                send_cb, parent.chat_id, None, parent, parent.session_id
+            )
+        send_cb.assert_awaited_once()
+        assert send_cb.await_args.args[1] == INTERRUPT_NO_RESUME
+
+    async def test_unset_reason_sends_resume_copy(self, parent, send_cb):
+        fake = _DualFireRedis(reason=None)
+        with patch("popoto.redis_db.POPOTO_REDIS_DB", fake):
+            await session_completion._send_interrupted_message(
+                send_cb, parent.chat_id, None, parent, parent.session_id
+            )
+        send_cb.assert_awaited_once()
+        assert send_cb.await_args.args[1] == INTERRUPT_RESUME
+
+    async def test_dual_fire_winner_sends_no_resume_loser_silent(self, parent):
+        """BLOCKER regression guard: both sites race the interrupted-sent dedup with
+        cancel-reason=no_resume. The SET-NX winner sends the no-resume copy; the
+        loser stays silent. The non-destructive read means the loser cannot starve
+        the winner of the reason (the key is never deleted)."""
+        winner_cb = AsyncMock(return_value=None)
+        loser_cb = AsyncMock(return_value=None)
+        fake = _DualFireRedis(reason=b"no_resume")
+        with patch("popoto.redis_db.POPOTO_REDIS_DB", fake):
+            # First caller wins the SET NX; second caller loses.
+            await session_completion._send_interrupted_message(
+                winner_cb, parent.chat_id, None, parent, parent.session_id
+            )
+            await session_completion._send_interrupted_message(
+                loser_cb, parent.chat_id, None, parent, parent.session_id
+            )
+
+        winner_cb.assert_awaited_once()
+        assert winner_cb.await_args.args[1] == INTERRUPT_NO_RESUME
+        loser_cb.assert_not_awaited()
+        # The cancel-reason key was never deleted (180s TTL is the only reclaimer).
+        assert fake.deleted == []
 
 
 class TestScheduler:

--- a/tests/unit/test_session_executor_failure_notification.py
+++ b/tests/unit/test_session_executor_failure_notification.py
@@ -1,0 +1,103 @@
+"""Unit tests for the running->failed user notification (#1877 defect #2).
+
+Covers `_maybe_send_failure_notice`, the best-effort helper the executor's
+failure-finalize block calls when `task.error` is set. Requirements:
+  * a failure notice is sent with the shared `FAILURE_NOTICE` copy;
+  * a raising send-callback does not propagate (finalization is never blocked);
+  * the `failed-sent` dedup suppresses a second send for the same session;
+  * a present `cancel-reason` (a killer already owns the exit narrative)
+    suppresses the failure send entirely (cross-class dedup collision guard).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.notification_copy import FAILURE_NOTICE
+from agent.session_executor import _maybe_send_failure_notice
+
+
+def _messenger():
+    m = MagicMock()
+    m._send_callback = AsyncMock(return_value=None)
+    return m
+
+
+def _redis_setnx(acquired: bool):
+    db = MagicMock()
+    db.set = MagicMock(return_value=acquired)
+    return db
+
+
+@pytest.mark.asyncio
+async def test_sends_failure_notice_with_shared_copy():
+    """No cancel-reason, dedup free → the FAILURE_NOTICE copy is sent once."""
+    messenger = _messenger()
+    with (
+        patch("agent.cancel_reason.get_cancel_reason", return_value=None),
+        patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_setnx(True)),
+    ):
+        await _maybe_send_failure_notice(messenger, "sess-fail-1")
+
+    messenger._send_callback.assert_awaited_once_with(FAILURE_NOTICE)
+
+
+@pytest.mark.asyncio
+async def test_raising_send_callback_does_not_propagate():
+    """A send-callback that raises must be swallowed (finalization not blocked)."""
+    messenger = _messenger()
+    messenger._send_callback = AsyncMock(side_effect=RuntimeError("send boom"))
+    with (
+        patch("agent.cancel_reason.get_cancel_reason", return_value=None),
+        patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_setnx(True)),
+    ):
+        # Must NOT raise.
+        await _maybe_send_failure_notice(messenger, "sess-fail-2")
+
+    messenger._send_callback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dedup_suppresses_second_send():
+    """failed-sent SET NX already held → no send (single-notice guarantee)."""
+    messenger = _messenger()
+    with (
+        patch("agent.cancel_reason.get_cancel_reason", return_value=None),
+        patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_setnx(False)),
+    ):
+        await _maybe_send_failure_notice(messenger, "sess-fail-3")
+
+    messenger._send_callback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cancel_reason_present_suppresses_failure_send():
+    """A killer already owns the exit narrative → failure send is skipped."""
+    messenger = _messenger()
+    redis = _redis_setnx(True)
+    with (
+        patch("agent.cancel_reason.get_cancel_reason", return_value="no_resume"),
+        patch("popoto.redis_db.POPOTO_REDIS_DB", redis),
+    ):
+        await _maybe_send_failure_notice(messenger, "sess-fail-4")
+
+    messenger._send_callback.assert_not_awaited()
+    # The dedup key must not even be acquired when we defer to the killer.
+    redis.set.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_redis_unavailable_still_sends():
+    """If the dedup lock is unavailable, prefer a possible duplicate over silence."""
+    messenger = _messenger()
+    redis = MagicMock()
+    redis.set = MagicMock(side_effect=RuntimeError("redis down"))
+    with (
+        patch("agent.cancel_reason.get_cancel_reason", return_value=None),
+        patch("popoto.redis_db.POPOTO_REDIS_DB", redis),
+    ):
+        await _maybe_send_failure_notice(messenger, "sess-fail-5")
+
+    messenger._send_callback.assert_awaited_once_with(FAILURE_NOTICE)

--- a/tests/unit/test_session_executor_failure_notification.py
+++ b/tests/unit/test_session_executor_failure_notification.py
@@ -89,6 +89,24 @@ async def test_cancel_reason_present_suppresses_failure_send():
 
 
 @pytest.mark.asyncio
+async def test_stale_resume_reason_does_not_suppress_failure_send():
+    """A stale 'resume' cancel-reason must NOT suppress the failure notice.
+
+    A session interrupted-and-requeued (reason='resume', 180s TTL) that then
+    genuinely crashes within that window still deserves the FAILURE_NOTICE — only
+    a 'no_resume' narrative (a killer that owns the exit story) suppresses it.
+    """
+    messenger = _messenger()
+    with (
+        patch("agent.cancel_reason.get_cancel_reason", return_value="resume"),
+        patch("popoto.redis_db.POPOTO_REDIS_DB", _redis_setnx(True)),
+    ):
+        await _maybe_send_failure_notice(messenger, "sess-fail-resume")
+
+    messenger._send_callback.assert_awaited_once_with(FAILURE_NOTICE)
+
+
+@pytest.mark.asyncio
 async def test_redis_unavailable_still_sends():
     """If the dedup lock is unavailable, prefer a possible duplicate over silence."""
     messenger = _messenger()

--- a/tests/unit/test_worker_sentry_init.py
+++ b/tests/unit/test_worker_sentry_init.py
@@ -1,0 +1,89 @@
+"""Unit tests for the shared Sentry init helper (#1877 defect #3).
+
+`configure_sentry` must:
+  (a) call `sentry_sdk.init` when `SENTRY_DSN` is set and no guard trips;
+  (b) return WITHOUT calling `sentry_sdk.init` under `PYTEST_CURRENT_TEST`
+      even when `SENTRY_DSN` is present (no `production` mis-tag).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from monitoring.sentry_config import configure_sentry
+
+
+def test_configure_sentry_inits_when_dsn_set_and_no_guard(monkeypatch):
+    """DSN present + guards cleared → sentry_sdk.init is invoked."""
+    monkeypatch.setenv("SENTRY_DSN", "https://example@sentry.io/123")
+    # Clear the test/CI guard so the init path is exercised.
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+
+    fake_sentry = MagicMock()
+    with (
+        patch.dict("sys.modules", {"sentry_sdk": fake_sentry}),
+        patch(
+            "monitoring.sentry_config.subprocess.check_output",
+            return_value="abc123\n",
+        ),
+    ):
+        result = configure_sentry("worker", before_send=None)
+
+    assert result is True
+    fake_sentry.init.assert_called_once()
+    _, kwargs = fake_sentry.init.call_args
+    assert kwargs["dsn"] == "https://example@sentry.io/123"
+    assert kwargs["before_send"] is None
+    assert kwargs["environment"] == "production"
+
+
+def test_configure_sentry_skips_under_pytest_even_with_dsn(monkeypatch):
+    """PYTEST_CURRENT_TEST set + DSN present → init is skipped (no production mis-tag)."""
+    monkeypatch.setenv("SENTRY_DSN", "https://example@sentry.io/123")
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "test_worker_sentry_init.py::x (call)")
+
+    fake_sentry = MagicMock()
+    with patch.dict("sys.modules", {"sentry_sdk": fake_sentry}):
+        result = configure_sentry("worker", before_send=None)
+
+    assert result is False
+    fake_sentry.init.assert_not_called()
+
+
+def test_configure_sentry_skips_when_no_dsn(monkeypatch):
+    """No DSN → init is skipped even with guards cleared."""
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+
+    fake_sentry = MagicMock()
+    with patch.dict("sys.modules", {"sentry_sdk": fake_sentry}):
+        result = configure_sentry("worker", before_send=None)
+
+    assert result is False
+    fake_sentry.init.assert_not_called()
+
+
+def test_configure_sentry_passes_before_send_for_bridge(monkeypatch):
+    """The bridge's before_send hook is threaded through to sentry_sdk.init."""
+    monkeypatch.setenv("SENTRY_DSN", "https://example@sentry.io/123")
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+
+    def _before_send(event, hint):
+        return event
+
+    fake_sentry = MagicMock()
+    with (
+        patch.dict("sys.modules", {"sentry_sdk": fake_sentry}),
+        patch(
+            "monitoring.sentry_config.subprocess.check_output",
+            return_value="abc123\n",
+        ),
+    ):
+        result = configure_sentry("bridge", before_send=_before_send)
+
+    assert result is True
+    _, kwargs = fake_sentry.init.call_args
+    assert kwargs["before_send"] is _before_send

--- a/worker/__main__.py
+++ b/worker/__main__.py
@@ -1352,6 +1352,18 @@ def main() -> None:
     # Set environment hint that we're running as standalone worker
     os.environ.setdefault("VALOR_WORKER_MODE", "standalone")
 
+    # Worker-process Sentry (#1877 defect #3). Session execution happens here, so
+    # worker exceptions must reach Sentry with the same fidelity as bridge ones.
+    # The worker passes before_send=None (no bridge-hibernation coupling); the
+    # shared helper is DSN-gated and self-guards against pytest/CI mis-tagging.
+    from monitoring.sentry_config import configure_sentry  # noqa: PLC0415
+
+    configure_sentry("worker", before_send=None)
+    logger.info(
+        "worker sentry: %s",
+        "enabled" if os.getenv("SENTRY_DSN") else "disabled (no DSN in worker env)",
+    )
+
     # Configure resilient Redis connection before any Popoto model is accessed.
     # Degrade-don't-die: if Redis is unreachable at boot this logs a warning
     # and returns without raising so operators can start Redis and restart.


### PR DESCRIPTION
Closes #1877.

Four independently-verified defects on the "how does the user find out what happened to their session" surface, per docs/plans/session-lifecycle-notification-gaps.md.

## Defects fixed
1. **Reason-aware interrupt message** — new `agent/cancel_reason.py` writes a transient `cancel-reason:{session_id}` Redis signal (180s TTL, non-destructive read placed inside the `interrupted-sent` SET-NX winner branch). `agent/messenger.py` and `agent/session_completion.py` now pick `INTERRUPT_RESUME` vs `INTERRUPT_NO_RESUME` from the reason. Killers wired: Branch 1 deadline kill, `_apply_recovery_transition` (health-check), subprocess-survived escalation. Absent key defaults to the resume copy (current behavior).
2. **running->failed notification** — best-effort `FAILURE_NOTICE` send on the executor failure-finalize branch (`asyncio.wait_for` 2.0s, swallows errors, never blocks finalization), `failed-sent:{session_id}` dedup. Cross-class skip-guard: if a cancel-reason is already set, the killer owns the exit narrative and the failure send is skipped (no double-message).
3. **Worker-process Sentry** — `monitoring/sentry_config.py::configure_sentry(component, before_send=None)` extracted from the bridge init verbatim and reused by bridge + `worker/__main__.py`. Worker passes `before_send=None` (no `bridge.hibernation` coupling). Guard is pytest/CI-only (no machine gate). Worker logs enabled/disabled at startup.
4. **Over-eager dedup kill** — `_cleanup_duplicate_sessions` terminal-status scan narrowed to `("completed",)` so a legitimate `pending` retry survives a prior `failed`/`killed`/`abandoned` attempt.

User-facing copy centralized in `agent/notification_copy.py`.

## Critique concerns folded in
- Undefined "machine gate" dropped from `configure_sentry` (pytest/CI-only guard) — resolves the machine-env No-Go contradiction.
- Cross-class dedup collision (interrupted-sent vs failed-sent) resolved via the `get_cancel_reason` skip-guard in the failure branch.

## Tests
58 new/updated tests pass (cancel_reason, cleanup_duplicate_sessions, worker_sentry_init, session_executor_failure_notification, deliver_pipeline_completion incl. the BLOCKER dual-fire regression test, pm_final_delivery no-resume path). 103 existing tests for touched modules pass. The 5 `test_health_check_recovery_finalization.py` failures reproduce identically on main (pre-existing `_has_progress` time-budget flakes, untouched).