### PR TITLE
fix(#1836): terminus link fast-path + granite PTY-PM resume gate + honest resume warning

### DIFF
--- a/agent/granite_container/bridge_adapter.py
+++ b/agent/granite_container/bridge_adapter.py
@@ -763,7 +763,43 @@ class BridgeAdapter:
                         }
                     )
             self._agent_session.resume_handles = handles
-            self._agent_session.save(update_fields=["resume_handles", "updated_at"])
+            update_fields = ["resume_handles", "updated_at"]
+
+            # Part B (#1836): also mirror the PM handle's UUID onto the
+            # legacy scalar `claude_session_uuid` field so
+            # `resume_session()`'s gate (`tools/valor_session.py`,
+            # ~line 715) stops hard-erroring with "cannot resume: no
+            # transcript UUID stored" for granite sessions. PM (not Dev)
+            # is chosen because PM owns the human-facing thread --
+            # steering messages are only ever injected into PM's PTY
+            # (see `container.py`), so PM's transcript is the one a
+            # human-initiated resume should target.
+            #
+            # This is (re)written with a *fresh* UUID on every `run()` --
+            # NOT a one-time first-population. `claude_session_uuid`
+            # therefore only ever reflects the most recent run's PM
+            # transcript; it is not a durable resume anchor. Future
+            # consumers (#1721, cold->warm transcript re-entry) must read
+            # the `resume_handles` list above, not this scalar.
+            #
+            # The granite path deliberately never calls
+            # `_store_claude_session_uuid` (`agent/sdk_client.py`) --
+            # that helper is SDK-client-only, reached only from the
+            # headless SDK-client harness path (`get_response_via_harness`).
+            #
+            # Never write None over an existing value: only assign when
+            # the PM handle's `claude_session_id` is non-null. PTY-PM has
+            # its UUID known at spawn (pre-assigned via `--session-id`),
+            # so this always fires for the (in-scope) PTY-PM transport.
+            # Headless-PM handles are written with a null UUID here (see
+            # docstring above) -- population for that transport is
+            # deferred to #1843, which owns the PM headless read loop.
+            pm_handle = next((h for h in handles if h.get("role") == "pm"), None)
+            if pm_handle and pm_handle.get("claude_session_id"):
+                self._agent_session.claude_session_uuid = pm_handle["claude_session_id"]
+                update_fields.append("claude_session_uuid")
+
+            self._agent_session.save(update_fields=update_fields)
         except Exception as e:  # noqa: BLE001
             logger.warning("[bridge-adapter] resume_handles persist failed: %s", e)
 

--- a/bridge/routing.py
+++ b/bridge/routing.py
@@ -731,6 +731,10 @@ async def classify_needs_response_async(text: str) -> bool:
 # Lookahead: not followed by \w+= (query param name=value pattern)
 _STANDALONE_QUESTION_RE = re.compile(r"(?<![=&\w])\?|(?<![=&])\?(?!\w+=)")
 
+# Regex matching bare http(s) URLs, used by Fast-Path 1.5 to detect a reply
+# that is "essentially just a link/pointer".
+_URL_RE = re.compile(r"https?://\S+")
+
 # Fast-Path 0: imperative continuation verbs that must always RESPOND.
 #
 # These few-shot examples are mined from real misclassified messages where the
@@ -789,6 +793,10 @@ async def classify_conversation_terminus(
     0. human sender + imperative continuation verb at start of any line → RESPOND
        (issue #1318 — prevents SILENT misclassification of explicit directives)
     1. sender_is_bot + no question → SILENT  (primary loop-break signal)
+    1.5. human sender + reply is essentially just a bare link/pointer → RESPOND
+       (issue #1836 — prevents REACT/SILENT misclassification dropping a
+       shared link; must run before word_count is computed in Fast-Path 2,
+       since a bare URL is a single token)
     2. acknowledgment token or very short (≤1 word) → SILENT
        (unless thread_messages contains a question — then fall through, so a
        human short answer like "Yes"/"No" to a Valor question is not dropped;
@@ -817,6 +825,42 @@ async def classify_conversation_terminus(
     # Fast-path 1: bot sender with no question → SILENT (strongest signal for loop break)
     if sender_is_bot and not _STANDALONE_QUESTION_RE.search(text_stripped):
         return "SILENT"
+
+    # Fast-path 1.5: human sender + reply that is essentially just a bare
+    # link/pointer → RESPOND.
+    #
+    # Mined example (real dropped message, issue #1836, July 1 2026): a reply
+    # to a Valor message that ended with an open question — "look here:
+    # https://github.com/BuilderIO/agent-native/tree/main/plans" — has no
+    # "?", no imperative verb (Fast-Path 0's narrow verb list doesn't cover
+    # "look"), and is not an acknowledgment token, so it fell through to the
+    # LLM classifier, which plausibly returned REACT (the "adds nothing new
+    # or is redundant with prior context" rule). `should_respond_async` maps
+    # REACT to `should_respond=False`, so the message was silently dropped
+    # (👍 emoji reaction only, no reply). A human sharing a new link is new
+    # information, not a conversation closer, and should never be silenced.
+    #
+    # Placement is load-bearing — this MUST run before `word_count` is
+    # computed (Fast-Path 2 below): a bare URL is a single token
+    # (word_count == 1), so if this branch ran after Fast-Path 2, that path
+    # would return SILENT first and pre-empt this fix.
+    #
+    # Deliberately narrow: gated on `not sender_is_bot` (Fast-Path 1 above
+    # already routes bot-sender bare URLs to SILENT, preserving loop-break
+    # behavior) and on the presence of an actual URL — prose/non-URL
+    # pointers (e.g. "see the PR description") are explicitly out of scope
+    # and continue to the LLM classifier unchanged.
+    if not sender_is_bot and _URL_RE.search(text_stripped):
+        text_without_urls = _URL_RE.sub("", text_stripped).strip()
+        remainder_normalized = text_without_urls.lower().rstrip("!.,:").strip()
+        # "Trivially short" = at most a few leading/trailing pointer words
+        # ("look here:", "see this", "") — not a substantive ack token,
+        # which is handled (and should keep being handled) by Fast-Path 2.
+        if (
+            remainder_normalized not in _ACKNOWLEDGMENT_TOKENS
+            and len(text_without_urls.split()) <= 3
+        ):
+            return "RESPOND"
 
     # Fast-path 2: acknowledgment token (fires AFTER sender check, never before)
     # — but skip the check entirely when the replied-to context contained a

--- a/docs/features/agent-session-model.md
+++ b/docs/features/agent-session-model.md
@@ -26,6 +26,8 @@ See [Session Lifecycle](session-lifecycle.md) for the full 14-state reference (9
 
 **Lifecycle:** `session_events` (ListField of `SessionEvent` dicts), `issue_url`, `plan_url`, `pr_url`
 
+**Resume:** `claude_session_uuid`, `resume_handles`. `resume_session()` (`tools/valor_session.py`) gates every `valor-session resume` on `claude_session_uuid` being non-null. The SDK-client path populates it via `_store_claude_session_uuid` (`agent/sdk_client.py`). Granite sessions populate it from the **PM** role handle in `BridgeAdapter._persist_resume_handles` (issue #1836): the PM handle's `claude_session_id` is mirrored onto `claude_session_uuid` so the gate passes. This is **PTY-PM only** (headless-PM is deferred to #1843) and is **rewritten with a fresh UUID on every run** — it reflects only the most recent run's PM transcript, not a durable resume anchor. `resume_handles` (the per-role list added by #1842) is the anchor #1721's cold→warm re-entry consumer reads; the scalar exists only to satisfy the gate.
+
 **Parent-Child:** `parent_agent_session_id` (KeyField — canonical parent reference), `slug` (KeyField — derives branch, plan path, worktree; indexed so the slug-keyed worker-pop filter can find slugged eng sessions — see [Bridge/Worker Architecture §Three Worker Loop Archetypes](bridge-worker-architecture.md#three-worker-loop-archetypes)). The session role is carried by the `session_type` discriminator (`"eng"`/`"teammate"`/`"granite"`), not a separate `role` field.
 
 All timestamp fields use Popoto `DatetimeField` or `SortedField(type=datetime)` with proper UTC datetime objects. Float/int timestamps are auto-converted via `__setattr__`.
@@ -272,7 +274,11 @@ a quality + reliability gate. It runs independently of the session cascade:
   Claude Code UUID is NOT written over the PM's `claude_session_uuid`.
   Pass 2 uses `prior_uuid=None` + `session_id=None` — the review prompt is
   self-contained (Pass 1's draft is embedded verbatim), so there's no need
-  to resume the PM session and polluting its history is undesirable.
+  to resume the PM session and polluting its history is undesirable. Note
+  this is passive isolation, not an active guard: the drafter path never
+  reads or branches on `claude_session_uuid`; it simply declines to write by
+  passing `session_id=None`. It therefore neither protects nor collides with
+  the granite PM-handle mirror added in #1836.
 - **Ollama fallback deferred** — see issue #1137. Until that lands,
   Anthropic-down manifests as a visible degraded-fallback message + ERROR
   log + Redis counter

--- a/docs/features/granite-pty-production.md
+++ b/docs/features/granite-pty-production.md
@@ -1194,6 +1194,46 @@ Session persistence failures never affect the CLI exit code or results JSON
 output. A single `granite session not recorded: <reason>` line is emitted to
 stderr and execution continues normally.
 
+## Resume gate: `claude_session_uuid` population (issue #1836)
+
+`resume_session()` (`tools/valor_session.py`) hard-gates every
+`valor-session resume` on `claude_session_uuid` being non-null. Granite PTY is
+the primary bridge Eng execution path, and before #1836 that field was never
+populated for granite sessions, so every granite resume hard-errored with
+`cannot resume: no transcript UUID stored`.
+
+`BridgeAdapter._persist_resume_handles` now mirrors the **PM** role handle's
+`claude_session_id` onto `agent_session.claude_session_uuid` so the gate passes.
+The PM role is chosen because it owns the human-facing conversational thread
+(steering messages inject into PM's PTY), so its transcript is the correct
+target for a human-initiated resume.
+
+Key properties:
+
+- **PTY-PM only.** The PM PTY's UUID is known at spawn (pre-assigned via
+  `claude --session-id`), so the write always fires for the in-scope PTY-PM
+  transport. Headless-PM UUID population is deferred to #1843, which owns the PM
+  headless read loop; PM-headless has no run path today.
+- **Rewritten every run, not a durable anchor.** `_persist_resume_handles`
+  runs on every `run()` with a freshly generated PM UUID, so
+  `claude_session_uuid` always reflects only the most recent run's PM
+  transcript. Never write `None` over an existing value — the mirror only fires
+  when the PM handle's `claude_session_id` is non-null.
+- **Gate-unblock, not re-entry.** Populating the field lets the resume gate pass
+  and the session transition to `pending`; the worker then cold-spawns from
+  turn 0. True cold→warm transcript re-entry (reading `resume_handles`, feeding
+  the stored UUID into `--resume`, cursor replay, skip-priming) is #1721's
+  scope. The #1721 consumer must read the per-role `resume_handles` list, **not**
+  this overwritten-each-run scalar.
+- **Honest resume signal.** For a granite gate-pass (`resume_handles` present),
+  `resume_session()` returns a `ResumeResult.warning`
+  (`"resumed as a fresh session; prior-transcript re-entry pending #1721"`),
+  surfaced by `cmd_resume`, so an operator reads the limitation at the call site
+  rather than mistaking a bare `success=True` for full continuation.
+
+The granite path deliberately never calls the SDK-client-only
+`_store_claude_session_uuid` helper (`agent/sdk_client.py`).
+
 ## Completion-Cleanup Safety Floor (issue #1646)
 
 Dev sessions commit work to `session/dev-{id}` branches inside `.worktrees/dev-{id}`.

--- a/docs/plans/reply-drop-terminus-granite-resume.md
+++ b/docs/plans/reply-drop-terminus-granite-resume.md
@@ -116,7 +116,7 @@ No relevant external findings — this is purely internal (LLM-classifier prompt
 **Part B (resume attempt):**
 1. **Entry point**: `python -m tools.valor_session resume --id <granite-session-id> --message "..."` → `cmd_resume` → `resume_session()` (`tools/valor_session.py:674`).
 2. **Gate**: `resume_session()` checks `claude_session_uuid is None` (715). Today: None for granite → hard error. After fix: populated → passes.
-3. **Population (fix)**: at granite spawn, `_persist_resume_handles` (`bridge_adapter.py:714`) builds per-role handles; the PTY PM handle's `claude_session_id` is also written to `agent_session.claude_session_uuid`. Headless PM: `outcome.claude_session_id` is captured at first turn inside `HeadlessRoleDriver.run_turn` (`role_driver.py:413-418`); a **net-new post-`run_turn` persist** (guarded `role == "pm" and outcome.claude_session_id`) writes it back to `claude_session_uuid`.
+3. **Population (fix)**: at granite spawn, `_persist_resume_handles` (`bridge_adapter.py:714`) builds per-role handles; the PTY PM handle's `claude_session_id` is also written to `agent_session.claude_session_uuid`. **PTY-PM only** — headless-PM UUID population is deferred to #1843 (which owns the PM headless read loop); PM-headless has no run path today, so nothing writes the field for that transport in this plan's scope.
 4. **Output**: gate passes → steering message pushed to Redis → `transition_status(..., "pending")` → worker re-picks the session. (Actual transcript re-entry from turn N is #1721.)
 
 ## Why Previous Fixes Failed
@@ -134,7 +134,7 @@ No relevant external findings — this is purely internal (LLM-classifier prompt
 - **New dependencies**: none.
 - **Interface changes**: `classify_conversation_terminus` signature unchanged; `claude_session_uuid` is an existing `AgentSession` field. One additive `ResumeResult.warning` field (default `None`, Part C).
 - **Coupling**: Part B reuses the `resume_handles` PM entry captured by #1842 — no new cross-component coupling; if anything it makes the existing field consistent across transports.
-- **Data ownership**: `claude_session_uuid` for granite sessions becomes owned by the granite adapter's spawn/first-turn path, mirroring how the SDK-client path owns it via `_store_claude_session_uuid`. It is rewritten each run with the current run's fresh PM UUID — a per-run value, not a durable resume anchor (that role is #1721's `resume_handles`).
+- **Data ownership**: `claude_session_uuid` for granite sessions becomes owned by the granite adapter's spawn-time PTY-PM path (`_persist_resume_handles`). The granite path deliberately does **not** reuse the SDK-client-only `_store_claude_session_uuid` helper. It is rewritten each run with the current run's fresh PM UUID — a per-run value, not a durable resume anchor (that role is #1721's `resume_handles`). (Headless-PM ownership is deferred to #1843.)
 - **Reversibility**: trivial — all three changes are additive (one fast-path branch, one field write, one optional-string result field) and revert cleanly.
 
 ## Appetite
@@ -225,8 +225,8 @@ No existing test is broken or deleted — the fixes are purely additive (a new f
 **Trigger:** An operator runs `valor-session resume` against a session that is mid-spawn.
 **Data prerequisite:** `claude_session_uuid` must be persisted before a resume is attempted.
 **State prerequisite:** Resume only targets sessions in `RESUMABLE_STATUSES` (completed/killed/failed/abandoned) — a mid-spawn session is `running`/`pending` and is rejected by the status gate (694-714) before the UUID gate is reached.
-**Headless-PM note (advisory fold-in):** for the headless-PM transport the UUID is **not** written at spawn — it lands only after the first `run_turn` completes (the net-new post-`run_turn` persist). The invariant still holds because a session cannot reach a `RESUMABLE_STATUS` without having run at least one turn (the first turn is what produces any terminal status), so by the time a headless-PM session is resumable its first-turn persist has already fired. If a headless-PM session terminates *before* its first turn ever completes (e.g. spawn crash), `claude_session_uuid` stays null and `resume_session()` returns the honest `cannot resume: no transcript UUID stored` error — the correct outcome, not a silent success.
-**Mitigation:** The status gate already excludes non-terminal sessions, so the UUID is fully persisted (spawn-time for PTY PM, first-turn for headless PM) by the time a session is resumable — with the pre-first-turn crash exception above degrading to the honest null-UUID error. No new synchronization needed; note it in the test.
+**Headless-PM note:** headless-PM UUID population is **out of scope — deferred to #1843**. PM-headless has no run path today, so this plan writes `claude_session_uuid` only for the PTY-PM transport (at spawn). Headless-PM's race analysis lands with #1843.
+**Mitigation:** The status gate already excludes non-terminal sessions, so the PTY-PM UUID is fully persisted at spawn by the time a session is resumable. No new synchronization needed; note it in the test.
 
 ## No-Gos (Out of Scope)
 

--- a/tests/unit/test_routing.py
+++ b/tests/unit/test_routing.py
@@ -383,6 +383,44 @@ async def test_classify_terminus_bot_bare_url_still_silent():
     assert result == "SILENT"
 
 
+@pytest.mark.asyncio
+async def test_classify_terminus_url_with_substantive_prose_falls_through_to_llm(
+    monkeypatch,
+):
+    """URL followed by substantive prose (>3 words after URL removal) must NOT be
+    force-RESPONDed by Fast-Path 1.5 — the ≤3-word remainder guard holds.
+
+    The message has no ``?``, no imperative verb, is not an ack token, and its
+    URL-stripped remainder is many words, so no fast-path fires and it reaches
+    the LLM. We pin the LLM to SILENT via an injected fake ``ollama`` module
+    (Haiku disabled by nulling the API key). If Fast-Path 1.5 had incorrectly
+    fired, the result would be RESPOND; asserting SILENT proves the guard held.
+    """
+
+    class FakeOllama:
+        @staticmethod
+        def chat(**kwargs):
+            return {"message": {"content": "SILENT"}}
+
+    import sys
+    import types
+
+    fake_module = types.ModuleType("ollama")
+    fake_module.chat = FakeOllama.chat
+    monkeypatch.setitem(sys.modules, "ollama", fake_module)
+    monkeypatch.setattr(routing, "get_anthropic_api_key", lambda: None)
+
+    result = await classify_conversation_terminus(
+        text=(
+            "https://example.com/report and here are my detailed thoughts on why "
+            "this approach fails badly in production"
+        ),
+        thread_messages=[],
+        sender_is_bot=False,
+    )
+    assert result == "SILENT"
+
+
 # =============================================================================
 # Fast-Path 0: imperative verb tests (issue #1318)
 # =============================================================================

--- a/tests/unit/test_routing.py
+++ b/tests/unit/test_routing.py
@@ -322,6 +322,68 @@ async def test_classify_terminus_url_query_in_thread_not_treated_as_question():
 
 
 # =============================================================================
+# Fast-Path 1.5: link/pointer tests (issue #1836)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_human_bare_url_returns_respond():
+    """Human sender + bare URL (no other text) → RESPOND via Fast-Path 1.5.
+
+    Without this fast-path, a bare URL is word_count == 1 and would hit
+    Fast-Path 2's ≤1-word SILENT branch before reaching the LLM.
+    """
+    result = await classify_conversation_terminus(
+        text="https://github.com/BuilderIO/agent-native/tree/main/plans",
+        thread_messages=[],
+        sender_is_bot=False,
+    )
+    assert result == "RESPOND"
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_human_look_here_url_returns_respond():
+    """Motivating example from issue #1836: 'look here: <url>' → RESPOND.
+
+    No '?', no imperative verb, not an ack token — previously fell through
+    to the LLM classifier, which plausibly returned REACT and silently
+    dropped the message.
+    """
+    result = await classify_conversation_terminus(
+        text="look here: https://github.com/BuilderIO/agent-native/tree/main/plans",
+        thread_messages=["Which approach do you want to use for this?"],
+        sender_is_bot=False,
+    )
+    assert result == "RESPOND"
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_human_multi_url_returns_respond():
+    """Human sender + multiple bare URLs, no other content → RESPOND."""
+    result = await classify_conversation_terminus(
+        text="https://example.com/a https://example.com/b",
+        thread_messages=[],
+        sender_is_bot=False,
+    )
+    assert result == "RESPOND"
+
+
+@pytest.mark.asyncio
+async def test_classify_terminus_bot_bare_url_still_silent():
+    """Bot sender + bare URL must still be SILENT via Fast-Path 1 (unchanged).
+
+    Fast-Path 1 fires before Fast-Path 1.5 is ever reached — the link/pointer
+    fast-path is `not sender_is_bot`-gated and must not resurrect bot loops.
+    """
+    result = await classify_conversation_terminus(
+        text="https://github.com/BuilderIO/agent-native/tree/main/plans",
+        thread_messages=[],
+        sender_is_bot=True,
+    )
+    assert result == "SILENT"
+
+
+# =============================================================================
 # Fast-Path 0: imperative verb tests (issue #1318)
 # =============================================================================
 

--- a/tests/unit/test_session_executor_granite.py
+++ b/tests/unit/test_session_executor_granite.py
@@ -34,6 +34,7 @@ from agent.granite_container.bridge_adapter import BridgeAdapter
 from agent.granite_container.pty_pool import PTYPool
 from agent.session_executor import _execute_agent_session
 from models.agent_session import AgentSession
+from tools.valor_session import resume_session
 
 
 def _make_pool(size: int = 1) -> PTYPool:
@@ -731,4 +732,124 @@ class TestReactionGating:
         assert actual_is_error == is_error, (
             f"exit_reason={exit_reason!r}, user_facing_routed={user_facing_routed} → "
             f"expected is_error={is_error}, got emoji={actual_emoji!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Part B (#1836): PM-handle claude_session_uuid population via
+# _persist_resume_handles, so the resume gate stops hard-erroring for granite.
+# PTY-PM only (headless-PM UUID population is deferred to #1843).
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter(session: AgentSession) -> BridgeAdapter:
+    """Construct a BridgeAdapter around a real AgentSession for calling
+    _persist_resume_handles directly. The pool/callbacks are never touched by
+    _persist_resume_handles, so a MagicMock pool is sufficient."""
+    return BridgeAdapter(
+        agent_session=session,
+        project_key="test",
+        transport="telegram",
+        pool=MagicMock(spec=PTYPool),
+    )
+
+
+class TestPersistResumeHandlesUuidPopulation:
+    """`_persist_resume_handles` mirrors the PTY-PM handle's UUID onto the
+    scalar `claude_session_uuid` so `resume_session()`'s gate passes (#1836
+    Part B). PTY-PM only."""
+
+    def test_pty_pm_run_populates_claude_session_uuid(self, redis_test_db):
+        """After a PTY-PM granite spawn, the record has a non-null
+        `claude_session_uuid` equal to the PM handle's `claude_session_id`,
+        and `resume_session()` succeeds against it (gate passes)."""
+        import uuid as uuid_module
+
+        # Unique session_id per test — the redis test DB can be shared across
+        # concurrent SDLC lanes, so a fixed id risks a cross-run collision on
+        # the reload (a foreign record shadowing this one).
+        sid = f"granite-resume-{uuid_module.uuid4().hex[:12]}"
+        session = _make_session(session_id=sid)
+        # Resume only targets terminal sessions; move it to a resumable status.
+        session.status = "completed"
+        session.save(update_fields=["status"])
+
+        adapter = _make_adapter(session)
+        pm_uuid = str(uuid_module.uuid4())
+        dev_uuid = str(uuid_module.uuid4())
+        adapter._persist_resume_handles(
+            "/tmp/wd",
+            {"pm": pm_uuid, "dev": dev_uuid},
+            {"pm": "pty", "dev": "pty"},
+        )
+
+        # Reload from Redis to confirm the write was persisted, not just set
+        # on the in-memory instance.
+        reloaded = AgentSession.query.filter(session_id=sid).all()[0]
+        assert reloaded.claude_session_uuid == pm_uuid, (
+            "PTY-PM run must mirror the PM handle's claude_session_id onto claude_session_uuid"
+        )
+        # resume_handles carries the per-role schema #1721 consumes.
+        pm_handle = next(h for h in reloaded.resume_handles if h["role"] == "pm")
+        assert pm_handle["claude_session_id"] == pm_uuid
+
+        # The resume gate now passes for this granite session.
+        result = resume_session(reloaded, "continue where we left off", source="test")
+        assert result.success is True, (
+            f"resume_session must succeed once claude_session_uuid is populated; "
+            f"got error={result.error!r}"
+        )
+        assert result.warning and "#1721" in result.warning, (
+            "granite gate-pass must carry the #1721 re-entry-deferral warning"
+        )
+
+    def test_null_pm_uuid_does_not_clobber_existing_value(self, redis_test_db):
+        """A null PM `claude_session_id` at spawn (headless-at-spawn) must NOT
+        write None over an existing `claude_session_uuid` (Risk 3)."""
+        import uuid as uuid_module
+
+        sid = f"granite-resume-neg-{uuid_module.uuid4().hex[:12]}"
+        existing_uuid = str(uuid_module.uuid4())
+        session = _make_session(session_id=sid)
+        session.claude_session_uuid = existing_uuid
+        session.save(update_fields=["claude_session_uuid"])
+
+        adapter = _make_adapter(session)
+        # Headless transport → the handle's claude_session_id is null at spawn.
+        adapter._persist_resume_handles(
+            "/tmp/wd",
+            {"pm": None, "dev": None},
+            {"pm": "headless", "dev": "headless"},
+        )
+
+        reloaded = AgentSession.query.filter(session_id=sid).all()[0]
+        assert reloaded.claude_session_uuid == existing_uuid, (
+            "a null PM claude_session_id must never clobber an existing claude_session_uuid"
+        )
+
+    def test_persist_failure_logs_warning_and_does_not_crash(self, redis_test_db, caplog):
+        """`_persist_resume_handles` wraps its body in `except Exception`: a
+        persist failure logs a warning and does not raise (fail-silent —
+        observability must never crash the run)."""
+        import uuid as uuid_module
+
+        session = _make_session(session_id=f"granite-resume-exc-{uuid_module.uuid4().hex[:12]}")
+        adapter = _make_adapter(session)
+
+        with (
+            patch(
+                "agent.granite_container.bridge_adapter._transcript_path_from_spec",
+                side_effect=RuntimeError("boom"),
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            # Must not raise despite the injected failure.
+            adapter._persist_resume_handles(
+                "/tmp/wd",
+                {"pm": "pm-uuid-x", "dev": "dev-uuid-y"},
+                {"pm": "pty", "dev": "pty"},
+            )
+
+        assert any("resume_handles persist failed" in r.message for r in caplog.records), (
+            "a persist failure must log the [bridge-adapter] warning"
         )

--- a/tests/unit/test_session_executor_granite.py
+++ b/tests/unit/test_session_executor_granite.py
@@ -760,59 +760,76 @@ class TestPersistResumeHandlesUuidPopulation:
     Part B). PTY-PM only."""
 
     def test_pty_pm_run_populates_claude_session_uuid(self, redis_test_db):
-        """After a PTY-PM granite spawn, the record has a non-null
-        `claude_session_uuid` equal to the PM handle's `claude_session_id`,
-        and `resume_session()` succeeds against it (gate passes)."""
+        """A PTY-PM granite spawn mirrors the PM handle's `claude_session_id`
+        onto `claude_session_uuid` (persisting it via `save(update_fields=...)`),
+        and `resume_session()` succeeds against the session (gate passes).
+
+        We assert on the same in-memory instance the adapter mutates (it holds
+        `self._agent_session is session`) and spy on `save` to prove the field
+        is persisted — a class-set reload would be flaky here because the redis
+        test DB is shared across concurrent SDLC lanes that flush it.
+        """
         import uuid as uuid_module
 
-        # Unique session_id per test — the redis test DB can be shared across
-        # concurrent SDLC lanes, so a fixed id risks a cross-run collision on
-        # the reload (a foreign record shadowing this one).
         sid = f"granite-resume-{uuid_module.uuid4().hex[:12]}"
         session = _make_session(session_id=sid)
-        # Resume only targets terminal sessions; move it to a resumable status.
+        # Resume only targets terminal sessions; a completed status clears the
+        # status gate (read in-memory by resume_session).
         session.status = "completed"
-        session.save(update_fields=["status"])
 
         adapter = _make_adapter(session)
         pm_uuid = str(uuid_module.uuid4())
         dev_uuid = str(uuid_module.uuid4())
-        adapter._persist_resume_handles(
-            "/tmp/wd",
-            {"pm": pm_uuid, "dev": dev_uuid},
-            {"pm": "pty", "dev": "pty"},
-        )
+        with patch.object(session, "save", wraps=session.save) as spy_save:
+            adapter._persist_resume_handles(
+                "/tmp/wd",
+                {"pm": pm_uuid, "dev": dev_uuid},
+                {"pm": "pty", "dev": "pty"},
+            )
 
-        # Reload from Redis to confirm the write was persisted, not just set
-        # on the in-memory instance.
-        reloaded = AgentSession.query.filter(session_id=sid).all()[0]
-        assert reloaded.claude_session_uuid == pm_uuid, (
+        assert session.claude_session_uuid == pm_uuid, (
             "PTY-PM run must mirror the PM handle's claude_session_id onto claude_session_uuid"
         )
         # resume_handles carries the per-role schema #1721 consumes.
-        pm_handle = next(h for h in reloaded.resume_handles if h["role"] == "pm")
+        pm_handle = next(h for h in session.resume_handles if h["role"] == "pm")
         assert pm_handle["claude_session_id"] == pm_uuid
+        # The write was persisted: claude_session_uuid was in the save's update_fields.
+        persisted_fields = [c.kwargs.get("update_fields") or [] for c in spy_save.call_args_list]
+        assert any("claude_session_uuid" in fields for fields in persisted_fields), (
+            "claude_session_uuid must be included in the persisted update_fields"
+        )
 
-        # The resume gate now passes for this granite session.
-        result = resume_session(reloaded, "continue where we left off", source="test")
+        # The resume gate now passes for this granite session. The real Redis
+        # transition (CAS + steering push) is covered by
+        # test_valor_session_resume_release.py; mock it here so this test stays
+        # deterministic under the shared, concurrently-flushed redis test DB.
+        with (
+            patch("models.session_lifecycle.transition_status") as mock_transition,
+            patch("agent.steering.push_steering_message"),
+        ):
+            result = resume_session(session, "continue where we left off", source="test")
         assert result.success is True, (
             f"resume_session must succeed once claude_session_uuid is populated; "
             f"got error={result.error!r}"
         )
+        mock_transition.assert_called_once()
         assert result.warning and "#1721" in result.warning, (
             "granite gate-pass must carry the #1721 re-entry-deferral warning"
         )
 
     def test_null_pm_uuid_does_not_clobber_existing_value(self, redis_test_db):
         """A null PM `claude_session_id` at spawn (headless-at-spawn) must NOT
-        write None over an existing `claude_session_uuid` (Risk 3)."""
+        write None over an existing `claude_session_uuid` (Risk 3).
+
+        Asserted on the in-memory instance the adapter mutates — a class-set
+        reload is avoided (shared, concurrently-flushed redis test DB).
+        """
         import uuid as uuid_module
 
         sid = f"granite-resume-neg-{uuid_module.uuid4().hex[:12]}"
         existing_uuid = str(uuid_module.uuid4())
         session = _make_session(session_id=sid)
         session.claude_session_uuid = existing_uuid
-        session.save(update_fields=["claude_session_uuid"])
 
         adapter = _make_adapter(session)
         # Headless transport → the handle's claude_session_id is null at spawn.
@@ -822,10 +839,12 @@ class TestPersistResumeHandlesUuidPopulation:
             {"pm": "headless", "dev": "headless"},
         )
 
-        reloaded = AgentSession.query.filter(session_id=sid).all()[0]
-        assert reloaded.claude_session_uuid == existing_uuid, (
+        assert session.claude_session_uuid == existing_uuid, (
             "a null PM claude_session_id must never clobber an existing claude_session_uuid"
         )
+        # And claude_session_uuid must NOT appear in the resume_handles-only save.
+        pm_handle = next(h for h in session.resume_handles if h["role"] == "pm")
+        assert pm_handle["claude_session_id"] is None
 
     def test_persist_failure_logs_warning_and_does_not_crash(self, redis_test_db, caplog):
         """`_persist_resume_handles` wraps its body in `except Exception`: a

--- a/tests/unit/test_valor_session_resume_release.py
+++ b/tests/unit/test_valor_session_resume_release.py
@@ -48,6 +48,7 @@ def _make_session(
     slug: str = "",
     claude_session_uuid: str | None = "uuid-default",
     model: str | None = None,
+    resume_handles: list | None = None,
 ) -> MagicMock:
     s = MagicMock()
     s.session_id = session_id
@@ -62,6 +63,11 @@ def _make_session(
     s.claude_session_uuid = claude_session_uuid
     s.model = model
     s.created_at = 0
+    # resume_handles is the granite-only signal (populated by
+    # BridgeAdapter._persist_resume_handles) that Part C (#1836) keys the
+    # honest re-entry warning on. Default None so a generic/SDK-client
+    # session gets warning=None; granite tests pass an explicit list.
+    s.resume_handles = resume_handles
     return s
 
 
@@ -344,6 +350,58 @@ class TestCmdResumeNullUuidGuard:
         assert "no transcript UUID stored" in err
 
 
+class TestResumeGraniteReentryWarning:
+    """Part C (#1836): resume_session attaches an honest re-entry warning for
+    granite sessions (resume_handles populated) and none for SDK-client sessions.
+
+    The warning gives the operator a runtime signal at the call site that the
+    granite gate-pass cold-spawns from turn 0 (true prior-transcript re-entry is
+    deferred to #1721) rather than reading a bare success=True as full
+    continuation.
+    """
+
+    def _resume(self, session):
+        with (
+            patch("tools.valor_session._load_env"),
+            patch("agent.steering.push_steering_message"),
+            patch.dict(
+                "sys.modules",
+                {
+                    "models.session_lifecycle": MagicMock(
+                        transition_status=MagicMock(),
+                        RESUMABLE_STATUSES=_RESUMABLE_STATUSES,
+                    ),
+                },
+            ),
+        ):
+            return resume_session(session, "continue", source="test")
+
+    def test_granite_session_resume_returns_reentry_warning(self):
+        """A granite session (resume_handles truthy) resumes with the #1721 warning."""
+        session = _make_session(
+            "sess-granite",
+            status="completed",
+            claude_session_uuid="pm-uuid-abc",
+            resume_handles=[{"role": "pm", "claude_session_id": "pm-uuid-abc"}],
+        )
+        result = self._resume(session)
+        assert result.success is True
+        assert result.warning is not None
+        assert "#1721" in result.warning
+
+    def test_sdk_client_session_resume_has_no_warning(self):
+        """An SDK-client session (no resume_handles) resumes with warning=None."""
+        session = _make_session(
+            "sess-sdk",
+            status="completed",
+            claude_session_uuid="sdk-uuid",
+            resume_handles=None,
+        )
+        result = self._resume(session)
+        assert result.success is True
+        assert result.warning is None
+
+
 class TestCmdResumeStatusGuardExactMessage:
     """The operator-facing wording of the status guard must be stable."""
 
@@ -590,6 +648,56 @@ class TestResumeSessionCore:
 
         assert result.success is False
         assert "Could not transition" in result.error
+
+    def test_granite_resume_carries_1721_warning(self):
+        """A granite session (has `resume_handles`) that clears the gate must
+        carry the #1836 Part C warning naming the #1721 re-entry deferral —
+        mirror-inverted from the null-UUID rejection. Populating
+        `claude_session_uuid` only clears the gate; it does not re-enter the
+        prior transcript."""
+        session = self._make_mock_session(status="completed", uuid="pm-uuid-granite")
+        # A granite session is the only writer of resume_handles.
+        session.resume_handles = [
+            {
+                "role": "pm",
+                "claude_session_id": "pm-uuid-granite",
+                "transcript_path": "/tmp/pm.jsonl",
+                "transport": "pty",
+            }
+        ]
+        patch_ctx, mock_transition = self._patch_lifecycle()
+
+        with (
+            patch("tools.valor_session._load_env"),
+            patch("agent.steering.push_steering_message"),
+            patch_ctx,
+        ):
+            result = resume_session(session, "continue", source="test")
+
+        assert result.success is True
+        assert result.warning is not None
+        assert "#1721" in result.warning, (
+            "granite gate-pass warning must name the #1721 re-entry deferral"
+        )
+        mock_transition.assert_called_once()
+
+    def test_non_granite_resume_has_no_warning(self):
+        """A non-granite (SDK-client) resume has no `resume_handles`, so no
+        warning is attached — the additive field defaults to None and does not
+        affect existing callers."""
+        session = self._make_mock_session(status="completed", uuid="sdk-uuid")
+        session.resume_handles = None
+        patch_ctx, _ = self._patch_lifecycle()
+
+        with (
+            patch("tools.valor_session._load_env"),
+            patch("agent.steering.push_steering_message"),
+            patch_ctx,
+        ):
+            result = resume_session(session, "continue", source="test")
+
+        assert result.success is True
+        assert result.warning is None
 
 
 # ---------------------------------------------------------------------------

--- a/tools/valor_session.py
+++ b/tools/valor_session.py
@@ -669,6 +669,16 @@ class ResumeResult:
     error: str | None = None
     model: str | None = None
     claude_session_uuid: str | None = None
+    # Set on a successful granite-session resume (#1836 Part C). Populating
+    # `claude_session_uuid` from the PM handle (Part B) only clears the
+    # resume gate -- it does NOT make the worker re-enter the prior PM
+    # transcript. Cold->warm re-entry (reading `resume_handles`, feeding the
+    # stored UUID into `--resume`, cursor replay) is #1721's scope and is
+    # not landed. Without this warning, a bare `success=True` reads to an
+    # operator as full continuation; this gives a runtime signal at the
+    # call site instead of relying on docs alone. `None` for non-granite
+    # (SDK-client) resumes, which are unaffected.
+    warning: str | None = None
 
 
 def resume_session(session, message: str, *, source: str = "cli") -> "ResumeResult":
@@ -743,11 +753,24 @@ def resume_session(session, message: str, *, source: str = "cli") -> "ResumeResu
             error=f"Could not transition to pending: {e}",
         )
 
+    # Granite sessions are the only writer of `resume_handles` (populated
+    # by `BridgeAdapter._persist_resume_handles`) -- its presence is the
+    # signal that the gate above just passed via the PM-handle mirror
+    # (Part B), not a durable SDK-client `claude_session_uuid` write via
+    # `_store_claude_session_uuid`. Surface the honest re-entry caveat
+    # (#1836 Part C) so the operator doesn't read a bare `success=True`
+    # as full transcript continuation -- true cold->warm re-entry is
+    # #1721, not landed.
+    _warning = None
+    if getattr(session, "resume_handles", None):
+        _warning = "resumed as a fresh session; prior-transcript re-entry pending #1721"
+
     return ResumeResult(
         success=True,
         session_id=session_id,
         model=getattr(session, "model", None),
         claude_session_uuid=getattr(session, "claude_session_uuid", None),
+        warning=_warning,
     )
 
 
@@ -815,23 +838,23 @@ def cmd_resume(args: argparse.Namespace) -> int:
         uuid = result.claude_session_uuid
 
         if args.json:
-            print(
-                json.dumps(
-                    {
-                        "session_id": session_id,
-                        "status": "resumed",
-                        "model": model,
-                        "claude_session_uuid": uuid,
-                    },
-                    indent=2,
-                )
-            )
+            _payload = {
+                "session_id": session_id,
+                "status": "resumed",
+                "model": model,
+                "claude_session_uuid": uuid,
+            }
+            if result.warning:
+                _payload["warning"] = result.warning
+            print(json.dumps(_payload, indent=2))
         else:
             print(f"Resumed session: {session_id}")
             if model:
                 print(f"  Model:               {model}")
             if uuid:
                 print(f"  Claude session UUID: {uuid}")
+            if result.warning:
+                print(f"  Warning: {result.warning}")
             print(f"  Message: {new_message[:80]}")
         return 0
 


### PR DESCRIPTION
Fixes #1836.

Two independent, confirmed bugs surfaced by a dropped reply-to-Valor message ("look here: <url>"):

## Part A — reply misclassified (bridge/routing.py)
Added **Fast-Path 1.5** to `classify_conversation_terminus`: a `not sender_is_bot`-gated branch, placed **between Fast-Path 1 and Fast-Path 2 (before `word_count` is computed)**, that returns RESPOND when a human reply is essentially a bare link/pointer (URL present, ≤3-word residual after URL removal, not an ack token). Bot-sender bare URLs still hit Fast-Path 1 → SILENT, unchanged. No LLM-prompt change; prose/non-URL pointers stay out of scope. (committed in `9ef1835f`)

## Part B — granite PTY sessions couldn't clear the resume gate (agent/granite_container/bridge_adapter.py)
`_persist_resume_handles` now mirrors the **PM** role handle's `claude_session_id` onto `agent_session.claude_session_uuid` so `resume_session()`'s gate stops hard-erroring (`cannot resume: no transcript UUID stored`). PM owns the human-facing thread (steering injects into PM's PTY). **PTY-PM only** — headless-PM population is deferred to #1843 (no PM-headless run path exists today). Rewritten each run with the current run's fresh PM UUID; never writes `None` over an existing value. The granite path deliberately does not call the SDK-client-only `_store_claude_session_uuid`.

## Part C — honest resume signal (tools/valor_session.py)
Added `ResumeResult.warning`. For a granite gate-pass (keyed on `resume_handles` being populated), `resume_session()` attaches `"resumed as a fresh session; prior-transcript re-entry pending #1721"`, surfaced by `cmd_resume`. SDK-client resumes return `warning=None`. True cold→warm transcript re-entry stays #1721's scope (its consumer reads `resume_handles`, not this overwritten-each-run scalar).

## Tests
- `test_routing.py` — human bare-URL → RESPOND; "look here: <url>" → RESPOND; multi-URL → RESPOND; bot-sender bare-URL → SILENT (unchanged); URL + substantive prose falls through to LLM (≤3-word guard holds).
- `test_session_executor_granite.py::TestPersistResumeHandlesUuidPopulation` — PTY-PM populates `claude_session_uuid`; `resume_session()` succeeds with the #1721 warning; null PM UUID does not clobber; persist failure logs and does not crash.
- `test_valor_session_resume_release.py::TestResumeGraniteReentryWarning` — granite resume returns the #1721 warning; SDK-client resume returns `warning=None`.

**Test results:** 102 passed, 1 skipped for the files/classes exercising these changes (serial run). Pre-existing failures in `TestExecutorGraniteWiring`/`TestReactionGating` are environmental (the real executor tries `git worktree add` under a non-git parent dir on this machine) and are untouched by this diff.

## Docs
- `docs/features/granite-pty-production.md` — new "Resume gate: `claude_session_uuid` population" section.
- `docs/features/agent-session-model.md` — Resume fields entry + drafter passive-isolation clarification.
- Scrubbed stale headless-PM fragments from the plan doc (deferred to #1843).