### PR TITLE
fix(#1881): deliver PM's terminal turn when PM completes before Dev primes

### DIFF
--- a/agent/granite_container/container.py
+++ b/agent/granite_container/container.py
@@ -493,6 +493,15 @@ class ContainerResult:
     # startup_plateau_cycles: number of consecutive identical fingerprint cycles
     # that triggered the plateau bail (None for ceiling exits).
     startup_plateau_cycles: int | None = None
+    # startup_settle_reason: which startup settle path fired (issue #1881).
+    #   "both_idle"           — classic same-cycle PM+Dev idle.
+    #   "pm_latched_dev_idle" — PM went idle on an earlier cycle (latched via
+    #                           pm_ever_idle); Dev reached idle later.
+    #   "pm_terminal_fast"    — PM produced a terminal [/complete]/[/user] turn
+    #                           and startup settled immediately, without waiting
+    #                           for Dev (decouples PM→user delivery from Dev).
+    # None on a startup that never settles (plateau / ceiling).
+    startup_settle_reason: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -1809,6 +1818,25 @@ class Container:
             # the prime text, not in the omission of the message).
             logger.info("container: priming PM")
             _pm_prime_cmd = _resolve_pm_prime_cmd(self._session_type)
+            # Relay baseline snapshot (issue #1881): snapshot the count of
+            # text-bearing PM assistant entries BEFORE PM emits any
+            # task-response output — i.e. before _prime_session(pm) below.
+            # This MUST precede PM's prime turn: the prime-turn relay's
+            # freshness guard `last_assistant_text(..., baseline_text_count=
+            # pm_prime_baseline)` returns "" when len(texts) <= baseline. If
+            # the baseline were snapshotted after the startup loop (its old
+            # site) it would already count PM's [/complete] in the fast-PM/
+            # slow-Dev race — PM's terminal turn flushes cycles before the
+            # loop breaks — so the relay would drop the reply and exit a
+            # compliance nudge instead of pm_complete. Captured here, PM's
+            # terminal turn is always a NEW text-bearing entry, so the relay
+            # delivers it for a both-idle, latch, or fast-settle break alike.
+            # result.pm_transcript_path was populated by _capture_pty_identity
+            # above; tolerate None → 0 (matches the prior post-loop behavior).
+            _pm_relay_transcript = result.pm_transcript_path
+            pm_prime_baseline = (
+                text_bearing_count(_pm_relay_transcript) if _pm_relay_transcript else 0
+            )
             self._prime_session(self._pm_pty, _pm_prime_cmd, include_user_message=True)
             logger.info("container: PM prime done")
             # A headless Dev role has no PTY to prime here — HeadlessRoleDriver
@@ -1838,6 +1866,15 @@ class Container:
             startup_settled = False
             startup_deadline = time.monotonic() + STARTUP_HARD_CEILING_S
             cycle = 0
+            # PM-idle latch (issue #1881). Idle detection is edge-triggered per
+            # cycle, so in the fast-PM/slow-Dev race PM's idle is observed in an
+            # early cycle and Dev's idle in a later one, never together — the old
+            # same-cycle `pm_saw_idle and dev_saw_idle` gate then never fires and
+            # the run burns to the ceiling. Latching PM idle once observed lets a
+            # later Dev-idle cycle settle startup. (Headless Dev already forces
+            # dev_saw_idle=True, so once PM is idle the gate reduces to PM alone,
+            # byte-identical to before.)
+            pm_ever_idle = False
             # Plateau detection state.
             # Fingerprint is the parser's verdict (response) ALONE. The idle bools
             # are NOT included in the fingerprint key because they can flicker on
@@ -1863,6 +1900,11 @@ class Container:
                     dev_idle = self._startup_cycle_idle(self._dev_pty)
                 pm_saw_idle, pm_edge, pm_level, pm_marker, pm_ms = pm_idle
                 dev_saw_idle, dev_edge, dev_level, dev_marker, dev_ms = dev_idle
+
+                # Latch PM idle (issue #1881): once PM is observed idle in any
+                # cycle, remember it so the settle gate no longer requires PM
+                # and Dev to be idle in the SAME cycle.
+                pm_ever_idle = pm_ever_idle or pm_saw_idle
 
                 # Update level tails for frame capture at any exit point.
                 _last_pm_level_tail = pm_level.strip() or pm_edge
@@ -1971,11 +2013,71 @@ class Container:
                     result.startup_plateau_cycles = _plateau_count
                     return result
 
+                # Terminal-turn fast settle (issue #1881). When PM has gone idle
+                # THIS cycle (gated strictly on the current cycle's pm_saw_idle,
+                # never the pm_ever_idle latch — a latched idle can be stale
+                # while PM is mid-turn on a later cycle; Race 2), classify PM's
+                # prime transcript against the SAME pre-loop pm_prime_baseline
+                # the relay uses. A non-empty [/complete] or a [/user] turn is
+                # user-facing and Dev-independent, so settle startup immediately
+                # and fall through to the single prime-turn relay for delivery —
+                # without waiting for Dev at all. This is READ-ONLY: it only
+                # decides to break; it snapshots no second baseline and forwards
+                # no payload/_prime_relayed state into the relay, which remains
+                # the sole delivery authority. Mere idle (empty [/complete],
+                # unknown chatter) does NOT fast-settle — it falls through to the
+                # latched pm_ever_idle AND dev_saw_idle gate, so a genuinely
+                # stuck PM still reaches plateau/ceiling (Risk 3).
+                if pm_saw_idle and result.pm_transcript_path:
+                    try:
+                        _fast_text = last_assistant_text(
+                            result.pm_transcript_path,
+                            baseline_text_count=pm_prime_baseline,
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "[granite-container] fast-settle transcript read raised: %s", e
+                        )
+                        _fast_text = ""
+                    if _fast_text:
+                        _fast_cls = classify_pm_prefix(_fast_text)
+                        _is_terminal = _fast_cls.destination == "user" or (
+                            _fast_cls.destination == "complete" and _fast_cls.payload.strip()
+                        )
+                        if _is_terminal:
+                            logger.info(
+                                "container: startup fast settle on PM terminal turn "
+                                "(dest=%s) — delivering without waiting for Dev",
+                                _fast_cls.destination,
+                            )
+                            startup_settled = True
+                            result.startup_settle_reason = "pm_terminal_fast"
+                            result.startup_events.append(
+                                {"cycle": cycle, "settle_reason": "pm_terminal_fast"}
+                            )
+                            break
+
                 if response is None:
-                    # No startup event in this window -- break if
-                    # both PTYs are idle, otherwise keep watching.
-                    if pm_saw_idle and dev_saw_idle:
-                        logger.info("container: startup both idle, breaking")
+                    # No startup event in this window -- break if PM has been
+                    # idle (latched via pm_ever_idle; issue #1881) and Dev is
+                    # idle this cycle, otherwise keep watching. The latch is why
+                    # this reads pm_ever_idle rather than pm_saw_idle: PM may have
+                    # gone idle several cycles earlier (fast-PM/slow-Dev race).
+                    # Headless Dev forces dev_saw_idle=True, so once PM is idle
+                    # this reduces to PM alone — byte-identical to the old gate.
+                    if pm_ever_idle and dev_saw_idle:
+                        # both_idle: classic same-cycle settle. pm_latched_dev_idle:
+                        # PM idled on an earlier cycle and Dev caught up now.
+                        result.startup_settle_reason = (
+                            "both_idle" if pm_saw_idle else "pm_latched_dev_idle"
+                        )
+                        logger.info(
+                            "container: startup settled (%s), breaking",
+                            result.startup_settle_reason,
+                        )
+                        result.startup_events.append(
+                            {"cycle": cycle, "settle_reason": result.startup_settle_reason}
+                        )
                         startup_settled = True
                         break
                     cycle += 1
@@ -2012,11 +2114,13 @@ class Container:
             # destination (user/complete/dev) during its prime response
             # rather than waiting for the first steady-state idle.
             pm_transcript = result.pm_transcript_path
-            # Snapshot the count of text-bearing PM assistant entries before the
-            # idle read so last_assistant_text can require a NEW text-bearing
-            # entry this cycle (content-identity guard; immune to intra-turn
-            # tool_use/tool_result writes that defeated the old mtime guard).
-            pm_prime_baseline = text_bearing_count(pm_transcript) if pm_transcript else 0
+            # pm_prime_baseline was snapshotted BEFORE _prime_session(pm)
+            # (issue #1881) so it predates PM's task-response output. The
+            # freshness guard `last_assistant_text(..., baseline_text_count=
+            # pm_prime_baseline)` therefore requires a NEW text-bearing entry
+            # (content-identity guard; immune to intra-turn tool_use/tool_result
+            # writes that defeated the old mtime guard) and delivers PM's
+            # already-flushed [/complete] regardless of which break reason fired.
             prime_wait = self._cycle_turn(
                 self._pm_pty, self._pm_consumer, self._pm_session_id, role="pm"
             )

--- a/docs/features/granite-pty-production.md
+++ b/docs/features/granite-pty-production.md
@@ -248,6 +248,46 @@ the routing outcome (including dev routes). The first steady-state iteration
 then reads a **fresh** PM idle before classifying — the stale-buffer race guard
 — so the prime buffer is never double-classified.
 
+### Startup settle conditions (issue #1881)
+
+PM→user delivery is decoupled from whether the Dev PTY has finished priming.
+The startup loop watches both PTYs and settles by one of three paths, recorded
+on `ContainerResult.startup_settle_reason` and appended to `startup_events`:
+
+| `startup_settle_reason` | Condition | When it fires |
+|--------------------------|-----------|---------------|
+| `both_idle` | PM and Dev both idle in the **same** cycle | Classic cold start where the two PTYs quiesce together. |
+| `pm_latched_dev_idle` | PM went idle on an **earlier** cycle (latched via `pm_ever_idle`), Dev reaches idle later | Fast PM, slow Dev — PM finishes and quiesces before Dev primes, Dev catches up a few cycles later. |
+| `pm_terminal_fast` | PM produces a terminal `[/complete]`/`[/user]` turn and settles **immediately**, without waiting for Dev at all | PM-only requests (status check, Q&A, board update) that never need the Dev PTY. |
+
+`startup_settle_reason` is `None` when startup never settles (plateau or ceiling
+exit).
+
+Two mechanisms make this work:
+
+- **PM-idle latch (`pm_ever_idle`).** Idle detection is edge-triggered per cycle,
+  so in the fast-PM/slow-Dev race PM's idle is observed in an early cycle and
+  Dev's in a later one, never together. The latch remembers that PM was idle, so
+  the settle gate reads `pm_ever_idle and dev_saw_idle` rather than requiring both
+  in the same cycle. (A headless Dev already forces `dev_saw_idle=True`, so once
+  PM is idle the gate reduces to PM alone — byte-identical to the pre-#1881 gate.)
+- **Terminal-turn fast settle.** When PM has gone idle **this cycle**, the loop
+  classifies PM's prime transcript (read-only) against the same pre-loop baseline
+  the relay uses. A non-empty `[/complete]` or a `[/user]` turn is user-facing and
+  Dev-independent, so startup settles immediately and falls through to the single
+  prime-turn relay for delivery. An empty `[/complete]` or non-terminal chatter
+  does **not** fast-settle — it falls through to the latched gate, so a genuinely
+  stuck PM still reaches plateau/ceiling.
+
+The relay is the single delivery site for all three paths. Its `pm_prime_baseline`
+snapshot is taken **before** `_prime_session(pm)` — before PM emits any
+task-response output — so the relay's `last_assistant_text(...,
+baseline_text_count=pm_prime_baseline)` freshness guard always sees PM's terminal
+turn as a new text-bearing entry and delivers it, whichever break reason fired.
+Snapshotting the baseline after the loop (its pre-#1881 site) would already count
+a fast PM's `[/complete]` that flushed cycles earlier, so the guard returned `""`
+and the reply was silently dropped as a compliance nudge instead of `pm_complete`.
+
 ### Per-turn prefix-contract reminder (issue #1719)
 
 On every Dev-report handoff (when the PM's `[/dev]` classification routes

--- a/tests/unit/granite_container/test_container.py
+++ b/tests/unit/granite_container/test_container.py
@@ -9,8 +9,10 @@ integration test.
 from __future__ import annotations
 
 import json
+import shutil
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from agent.granite_container.container import (
@@ -18,6 +20,7 @@ from agent.granite_container.container import (
     ContainerResult,
     TurnRecord,
     _make_sandbox_cwd,
+    _transcript_path,
     result_to_json,
 )
 from agent.granite_container.pty_driver import PTYDriver
@@ -112,8 +115,14 @@ class TestContainerRunWithMockedPtys(unittest.TestCase):
         dev_mock.read_until_idle.return_value = _idle_result("", saw_idle=True)
 
         # PM transcript texts: startup (empty → _unknown_classification falls through
-        # before classify), then prime-relay "[/complete]\nShipped PR #42.".
-        pm_transcript_texts = iter(["[/complete]\nShipped PR #42."])
+        # before classify), then prime-relay "[/complete]\nShipped PR #42.". The text
+        # is duplicated: the startup loop's terminal-turn fast settle (issue #1881)
+        # reads the transcript once at the cycle where pm_saw_idle is true (a
+        # read-only classification that only decides whether to break), and the
+        # prime-turn relay independently re-reads the SAME on-disk transcript to
+        # deliver — in production both reads hit the same file and return
+        # identical content; the stub must mirror that idempotency.
+        pm_transcript_texts = iter(["[/complete]\nShipped PR #42.", "[/complete]\nShipped PR #42."])
 
         def _lat_stub(path, *, baseline_text_count=None):
             if not path or "mock-session-dev" in path:
@@ -186,8 +195,14 @@ class TestContainerRunWithMockedPtys(unittest.TestCase):
 
         # last_assistant_text is called for each PM classify and each Dev read.
         # PM path contains "mock-session-pm"; Dev path contains "mock-session-dev".
+        # The leading "" is duplicated: the startup loop's terminal-turn fast
+        # settle (issue #1881) reads the transcript once at the cycle where
+        # pm_saw_idle is true (read-only, empty text never fast-settles), and the
+        # prime-turn relay independently re-reads the SAME on-disk transcript —
+        # in production both reads hit the same file and return identical content.
         pm_transcript_texts = iter(
             [
+                "",  # startup: fast-settle read (empty → no fast settle)
                 "",  # prime-relay (unknown, compliance miss)
                 "[/dev]\nturn 0",  # turn 0 steady-state
                 "[/dev]\nturn 1",  # turn 1
@@ -280,8 +295,15 @@ class TestContainerRunWithMockedPtys(unittest.TestCase):
 
         # PM transcript texts (one per PM classify call):
         # prime-relay → no prefix (unknown), turn 0 → [/complete]\nDone.
+        # The leading text is duplicated: the startup loop's terminal-turn fast
+        # settle (issue #1881) reads the transcript once at the cycle where
+        # pm_saw_idle is true (read-only, unknown text never fast-settles), and
+        # the prime-turn relay independently re-reads the SAME on-disk
+        # transcript — in production both reads hit the same file and return
+        # identical content.
         pm_transcript_texts = iter(
             [
+                "I'm thinking out loud about the design.",  # startup: fast-settle read
                 "I'm thinking out loud about the design.",  # prime-relay: unknown
                 "[/complete]\nDone.",  # turn 0: complete
             ]
@@ -362,8 +384,13 @@ class TestContainerUserAddress(unittest.TestCase):
         pm_mock.read_until_idle.side_effect = lambda **kw: buffers.pop(0)
         dev_mock.read_until_idle.return_value = _idle_result("", saw_idle=True)
 
-        # PM transcript: only the prime-relay call matters (returns [/user] text).
-        pm_transcript_texts = iter(["[/user]\nstatus update 1"])
+        # PM transcript: duplicated because the startup loop's terminal-turn
+        # fast settle (issue #1881) reads the transcript once at the cycle
+        # where pm_saw_idle is true — here that read itself classifies
+        # destination="user" and fast-settles — and the prime-turn relay
+        # independently re-reads the SAME on-disk transcript to deliver; in
+        # production both reads hit the same file and return identical content.
+        pm_transcript_texts = iter(["[/user]\nstatus update 1", "[/user]\nstatus update 1"])
 
         def _lat_stub(path, *, baseline_text_count=None):
             if not path or "mock-session-dev" in path:
@@ -554,8 +581,13 @@ class TestContainerStartupHardCeiling(unittest.TestCase):
         pm_mock.read_until_idle.side_effect = lambda **kw: next(pm_buffers)
         dev_mock.read_until_idle.return_value = _idle_result("", saw_idle=True)
 
-        # PM transcript: prime-relay returns [/complete]\nDone.
-        pm_transcript_texts = iter(["[/complete]\nDone."])
+        # PM transcript: duplicated because the startup loop's terminal-turn
+        # fast settle (issue #1881) reads the transcript once at startup cycle
+        # 2 (the first cycle where pm_saw_idle is true — a non-empty [/complete]
+        # fast-settles immediately), and the prime-turn relay independently
+        # re-reads the SAME on-disk transcript to deliver; in production both
+        # reads hit the same file and return identical content.
+        pm_transcript_texts = iter(["[/complete]\nDone.", "[/complete]\nDone."])
 
         def _lat_stub(path, *, baseline_text_count=None):
             if not path or "mock-session-dev" in path:
@@ -780,9 +812,13 @@ class TestContainerOnTurnHook(unittest.TestCase):
         pm_mock.read_until_idle.side_effect = lambda **kw: next(pm_buffers)
         dev_mock.read_until_idle.return_value = _idle_result("", saw_idle=True)
 
-        # PM transcript texts: prime-relay (unknown), turn 0 (complete).
+        # PM transcript texts: startup (fast-settle read, issue #1881),
+        # prime-relay (unknown), turn 0 (complete). The startup and
+        # prime-relay entries are duplicated because both reads hit the
+        # same on-disk transcript in production and return identical content.
         pm_transcript_texts_hook = iter(
             [
+                "no prefix here",  # startup: fast-settle read
                 "no prefix here",  # prime-relay: unknown
                 "[/complete]\nDone.",  # turn 0: complete
             ]
@@ -967,10 +1003,15 @@ class TestPrimeTurnRelay(unittest.TestCase):
 
         dev_mock.write.side_effect = _track_dev_write
 
-        # PM transcript texts: prime-relay (dev), then turn 0 steady-state (complete).
+        # PM transcript texts: startup (fast-settle read, issue #1881; a "dev"
+        # destination never fast-settles), prime-relay (dev), then turn 0
+        # steady-state (complete). The startup and prime-relay entries are
+        # duplicated because both reads hit the same on-disk transcript in
+        # production and return identical content.
         # Dev transcript: verbatim dev text.
         pm_transcript_texts = iter(
             [
+                "[/dev]\nBuild X",  # startup: fast-settle read
                 "[/dev]\nBuild X",  # prime-relay
                 "[/complete]\nDone.",  # turn 0 steady-state
             ]
@@ -1035,8 +1076,13 @@ class TestPrimeTurnRelay(unittest.TestCase):
         pm_mock.read_until_idle.side_effect = lambda **kw: pm_buffers.pop(0)
         dev_mock.read_until_idle.return_value = _idle_result("", saw_idle=True)
 
-        # PM transcript: prime-relay returns [/user] text.
-        pm_transcript_texts = iter(["[/user]\nStatus: all good."])
+        # PM transcript: duplicated because the startup loop's terminal-turn
+        # fast settle (issue #1881) reads the transcript once at the cycle
+        # where pm_saw_idle is true — here that read itself classifies
+        # destination="user" and fast-settles — and the prime-turn relay
+        # independently re-reads the SAME on-disk transcript to deliver; in
+        # production both reads hit the same file and return identical content.
+        pm_transcript_texts = iter(["[/user]\nStatus: all good.", "[/user]\nStatus: all good."])
 
         def _lat_stub(path, *, baseline_text_count=None):
             if not path or "mock-session-dev" in path:
@@ -1283,9 +1329,14 @@ class TestWrapupGuard(unittest.TestCase):
         pm_mock.read_until_idle.side_effect = lambda **kw: pm_buffers.pop(0)
         dev_mock.read_until_idle.return_value = _idle_result("", saw_idle=True)
 
-        # PM transcript: prime-relay (unknown/empty), wrapup response (prefix-less).
+        # PM transcript: startup (fast-settle read, issue #1881; empty text
+        # never fast-settles), prime-relay (unknown/empty), wrapup response
+        # (prefix-less). The startup and prime-relay entries are duplicated
+        # because both reads hit the same on-disk transcript in production
+        # and return identical content.
         pm_transcript_texts = iter(
             [
+                "",  # startup: fast-settle read
                 "",  # prime-relay: unknown (empty → fallback)
                 "Here is what I did: fixed the bug.",  # wrapup: non-empty, no prefix
             ]
@@ -1416,9 +1467,19 @@ class TestWrapupGuard(unittest.TestCase):
         pm_mock.read_until_idle.side_effect = lambda **kw: pm_buffers.pop(0)
         dev_mock.read_until_idle.return_value = _idle_result("", saw_idle=True)
 
-        # PM transcript: prime-relay (empty [/complete]), wrapup ([/user]\nReal summary.).
+        # PM transcript: startup (fast-settle read, issue #1881), prime-relay
+        # (both empty [/complete]), wrapup ([/user]\nReal summary.). The
+        # startup and prime-relay entries are duplicated because both reads
+        # hit the same on-disk transcript in production and return identical
+        # content. This exercises the new fast-settle branch directly: an
+        # empty-body [/complete] read at the pm_saw_idle-true cycle must NOT
+        # fast-settle (mirrors the relay's own "empty complete is not
+        # user-facing" guard) — it falls through to the ordinary settle and
+        # the wrap-up guard delivers the real [/user] summary, exactly as
+        # before the fast-settle branch existed.
         pm_transcript_texts = iter(
             [
+                "[/complete]",  # startup: fast-settle read (empty → no fast settle)
                 "[/complete]",  # prime-relay: empty complete body (not user-facing)
                 "[/user]\nReal summary.",  # wrapup response: delivers to user
             ]
@@ -1567,8 +1628,15 @@ class TestPerTurnContractReminder(unittest.TestCase):
         )
 
         dev_transcript_text = "Dev finished the task."
+        # The startup and prime-relay entries are duplicated: the startup
+        # loop's terminal-turn fast settle (issue #1881) reads the transcript
+        # once at the cycle where pm_saw_idle is true (a "dev" destination
+        # never fast-settles), and the prime-turn relay independently re-reads
+        # the SAME on-disk transcript — in production both reads hit the same
+        # file and return identical content.
         pm_transcript_texts = iter(
             [
+                "[/dev]\ndo the task",  # startup: fast-settle read
                 "[/dev]\ndo the task",  # prime-relay → dev route
                 "",  # turn 0: unknown (empty → compliance miss)
             ]
@@ -1661,8 +1729,6 @@ class TestTranscriptPathRealpath(unittest.TestCase):
         import os
         import tempfile
 
-        from agent.granite_container.container import _transcript_path
-
         with tempfile.TemporaryDirectory() as tmp:
             real = os.path.join(tmp, "real")
             link = os.path.join(tmp, "link")
@@ -1675,8 +1741,6 @@ class TestTranscriptPathRealpath(unittest.TestCase):
         """A symlink-crossing cwd produces the realpath slug, not the link slug."""
         import os
         import tempfile
-
-        from agent.granite_container.container import _transcript_path
 
         with tempfile.TemporaryDirectory() as tmp:
             # Resolve tmp itself (macOS /var -> /private/var) so the
@@ -1704,7 +1768,6 @@ class TestTranscriptPathRealpath(unittest.TestCase):
         shipped instead of the PM's real reply. Must stay in sync with
         bridge_adapter._transcript_path_from_spec.
         """
-        from agent.granite_container.container import _transcript_path
 
         # Non-existent path: realpath is an identity transform, so the slug is
         # deterministic without touching the filesystem.
@@ -1716,7 +1779,6 @@ class TestTranscriptPathRealpath(unittest.TestCase):
 
     def test_empty_cwd_does_not_crash_and_skips_realpath(self) -> None:
         """Empty cwd is not realpath'd (would return process CWD); slug stays empty-rooted."""
-        from agent.granite_container.container import _transcript_path
 
         path = _transcript_path("", "sess-uuid")
         # cwd == "" -> realpath skipped -> slug "" -> path ends with the file.
@@ -1800,6 +1862,211 @@ class TestTranscriptReadDiagnostic(unittest.TestCase):
         joined = "\n".join(cm.output)
         self.assertIn("transcript read: no-new-entry", joined)
         self.assertIn("wrap-up guard", joined)
+
+
+class TestStartupPmCompleteBeforeDevPrimes(unittest.TestCase):
+    """Issue #1881: PM emits [/complete] and goes idle before Dev primes.
+
+    These reproduction tests drive the REAL ``last_assistant_text`` reader
+    against an on-disk JSONL transcript fixture — NO stub. The fast-PM/slow-Dev
+    race the bug lives in is exactly a freshness-guard failure
+    (``last_assistant_text(..., baseline_text_count=pm_prime_baseline)`` returns
+    "" when ``len(texts) <= baseline``), so a stubbed reader would go green while
+    the bug persisted. The fixture is flushed to disk DURING the loop (after the
+    relocated pre-loop baseline snapshot), matching real PM ordering — PM primes,
+    works, emits [/complete], then goes idle — so the genuine content-identity
+    guard is what delivers the already-flushed terminal turn.
+    """
+
+    def _write_pm_transcript(self, path: str, text: str) -> None:
+        """Write a single text-bearing assistant JSONL entry to ``path``.
+
+        Mirrors Claude Code's transcript format closely enough for
+        ``_text_bearing_assistant_texts`` to parse: one ``{"type":"assistant",
+        "message":{"content":[{"type":"text","text": ...}]}}`` line.
+        """
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        entry = {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": text}]},
+        }
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+
+    def _fixture_paths(self) -> tuple[str, str]:
+        """Make a unique cwd + compute the PM transcript path the code will use.
+
+        Registers cleanup of both the temp cwd and the (home-rooted) transcript
+        directory so the test leaves no residue under ``~/.claude/projects/``.
+        """
+        cwd = tempfile.mkdtemp(prefix="granite-1881-")
+        self.addCleanup(shutil.rmtree, cwd, ignore_errors=True)
+        pm_path = _transcript_path(cwd, "mock-session-pm")
+        assert pm_path is not None
+        self.addCleanup(shutil.rmtree, str(Path(pm_path).parent), ignore_errors=True)
+        return cwd, pm_path
+
+    def test_pm_complete_before_dev_primes_delivers(self) -> None:
+        """Reported production incident: PM emits a non-empty [/complete] and
+        goes idle at an early cycle; Dev never reaches idle. The terminal-turn
+        fast settle delivers the payload and exits pm_complete (SC#1b).
+
+        Drives the REAL reader: the [/complete] is flushed to disk on PM's first
+        loop read (AFTER the pre-loop baseline snapshot of 0), so it is a genuinely
+        NEW text-bearing entry and the real
+        ``last_assistant_text(baseline_text_count=0)`` freshness guard returns it.
+        """
+        cwd, pm_path = self._fixture_paths()
+
+        delivered: list[str] = []
+        c = Container(
+            user_message="hello",
+            max_turns=3,
+            cwd=cwd,
+            on_complete_payload=lambda p: delivered.append(p),
+        )
+        pm_mock, dev_mock = _mock_pm(""), _mock_dev("")
+
+        # PM flushes its terminal [/complete] to disk on its first loop read
+        # (after the pre-loop baseline snapshot), then stays idle. Dev NEVER
+        # idles (the "Dev never primes" case) — only the fast settle can rescue.
+        def _pm_read(**kw):
+            self._write_pm_transcript(pm_path, "[/complete]\nDone.")
+            return _idle_result("", saw_idle=True)
+
+        pm_mock.read_until_idle.side_effect = _pm_read
+        dev_mock.read_until_idle.return_value = _idle_result("", saw_idle=False)
+
+        with (
+            patch.object(c, "_spawn_pair"),
+            patch.object(c, "_close_pair"),
+            patch.object(c, "_prime_session"),
+            patch.object(c, "_close_pair_and_reap"),
+            patch.object(c, "_run_wrapup_guard"),
+        ):
+            c._pm_pty = pm_mock
+            c._dev_pty = dev_mock
+            result = c.run()
+
+        self.assertEqual(
+            result.exit_reason,
+            "pm_complete",
+            f"got {result.exit_reason!r}: {result.exit_message!r}",
+        )
+        self.assertTrue(result.user_facing_routed, "PM [/complete] must reach the send path")
+        self.assertEqual(delivered, ["Done."])
+        self.assertEqual(len(delivered), 1, "on_complete_payload must fire exactly once")
+        self.assertIsNone(result.startup_failure_kind)
+        self.assertEqual(result.startup_settle_reason, "pm_terminal_fast")
+
+    def test_pm_latched_dev_idle_delivers_complete(self) -> None:
+        """SC#1a via the latch: PM goes idle early, Dev reaches idle on a LATER
+        cycle. The pm_ever_idle latch settles startup and the relocated pre-loop
+        baseline lets the relay deliver PM's already-flushed [/complete].
+
+        Fast settle is deliberately NOT the settling mechanism here: the
+        transcript is empty while PM is idle (cycle 0), so the fast-settle read
+        returns "" and skips; the [/complete] lands only when Dev idles (cycle 2),
+        at which point PM is no longer idle-this-cycle, so the latch gate fires.
+        """
+        cwd, pm_path = self._fixture_paths()
+
+        delivered: list[str] = []
+        c = Container(
+            user_message="hello",
+            max_turns=3,
+            cwd=cwd,
+            on_complete_payload=lambda p: delivered.append(p),
+        )
+        pm_mock, dev_mock = _mock_pm(""), _mock_dev("")
+        # PM idle cycle 0 (transcript still empty → fast settle skips), busy on
+        # cycles 1-2, then turn-end at the relay read.
+        pm_seq = [
+            _idle_result("", saw_idle=True),  # cycle 0: idle, no terminal turn yet
+            _idle_result("", saw_idle=False),  # cycle 1: busy
+            _idle_result("", saw_idle=False),  # cycle 2: busy (fast settle skipped)
+            _idle_result("", saw_idle=True),  # relay _cycle_idle: PM turn-end
+        ]
+        pm_mock.read_until_idle.side_effect = lambda **kw: pm_seq.pop(0)
+
+        dev_reads = {"n": 0}
+
+        def _dev_read(**kw):
+            dev_reads["n"] += 1
+            if dev_reads["n"] >= 3:
+                # Dev reaches idle on cycle 2 (~the reported-incident timing);
+                # PM's [/complete] has now flushed to disk.
+                self._write_pm_transcript(pm_path, "[/complete]\nDone.")
+                return _idle_result("", saw_idle=True)
+            return _idle_result("", saw_idle=False)
+
+        dev_mock.read_until_idle.side_effect = _dev_read
+
+        with (
+            patch.object(c, "_spawn_pair"),
+            patch.object(c, "_close_pair"),
+            patch.object(c, "_prime_session"),
+            patch.object(c, "_close_pair_and_reap"),
+            patch.object(c, "_run_wrapup_guard"),
+        ):
+            c._pm_pty = pm_mock
+            c._dev_pty = dev_mock
+            result = c.run()
+
+        self.assertEqual(
+            result.exit_reason,
+            "pm_complete",
+            f"got {result.exit_reason!r}: {result.exit_message!r}",
+        )
+        self.assertTrue(result.user_facing_routed)
+        self.assertEqual(delivered, ["Done."])
+        self.assertEqual(result.startup_settle_reason, "pm_latched_dev_idle")
+
+    def test_empty_complete_at_startup_not_user_facing(self) -> None:
+        """An empty-body [/complete] during startup must NOT fast-settle-deliver.
+
+        The fast settle requires a non-empty terminal classification, so an empty
+        [/complete] falls through; the container still settles (both idle) and the
+        relay routes the empty complete as NON user-facing — no delivery, no
+        on_complete_payload call. Drives the real reader (concern note #3).
+        """
+        cwd, pm_path = self._fixture_paths()
+
+        delivered: list[str] = []
+        c = Container(
+            user_message="hello",
+            max_turns=2,
+            cwd=cwd,
+            on_complete_payload=lambda p: delivered.append(p),
+        )
+        pm_mock, dev_mock = _mock_pm(""), _mock_dev("")
+
+        # PM flushes an EMPTY-body [/complete] on its first loop read (after the
+        # pre-loop baseline of 0) so the relay sees it as a new entry but routes
+        # it as non-user-facing.
+        def _pm_read(**kw):
+            self._write_pm_transcript(pm_path, "[/complete]")
+            return _idle_result("", saw_idle=True)
+
+        pm_mock.read_until_idle.side_effect = _pm_read
+        dev_mock.read_until_idle.return_value = _idle_result("", saw_idle=True)
+
+        with (
+            patch.object(c, "_spawn_pair"),
+            patch.object(c, "_close_pair"),
+            patch.object(c, "_prime_session"),
+            patch.object(c, "_close_pair_and_reap"),
+            patch.object(c, "_run_wrapup_guard"),  # isolate: no wrap-up delivery
+        ):
+            c._pm_pty = pm_mock
+            c._dev_pty = dev_mock
+            result = c.run()
+
+        self.assertEqual(result.exit_reason, "pm_complete")
+        self.assertFalse(result.user_facing_routed, "empty [/complete] is not user-facing")
+        self.assertEqual(delivered, [], "on_complete_payload must NOT fire for empty [/complete]")
+        # Empty [/complete] does not fast-settle; it settles via the both-idle gate.
+        self.assertEqual(result.startup_settle_reason, "both_idle")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Fixes #1881 — the granite startup handshake dropped PM's `[/complete]` reply when the PM finished before the Dev PTY primed.

A fast PM-only request (status check, Q&A, board update) primes, does its work, emits a clean `[/complete]`, and quiesces **before** the Dev PTY has finished (or even begun) priming. The old startup loop only settled when PM and Dev were observed idle in the **same** cycle, so the two never coincided, the prime-turn relay never ran, and the container burned to the 600s ceiling and exited `startup_unresolved` — the user's request was fulfilled but the confirmation was silently dropped. Reproduced in production (session `c220a40996b74cad9da696fb18afc042`).

## Changes (all in `agent/granite_container/container.py`)

**Task 2a — latch + relay-baseline relocation (fixes the reported incident end-to-end):**
- **Relocated the relay's `pm_prime_baseline` snapshot** from after the startup loop to **before** `_prime_session(pm)`, reading `result.pm_transcript_path`. This is the blocker fix: with the baseline captured before PM emits any task-response output, PM's terminal turn is always a *new* text-bearing entry, so the relay's `last_assistant_text(..., baseline_text_count=...)` freshness guard delivers it for any break reason. Snapshotting after the loop already counted a fast PM's flushed `[/complete]`, so the guard returned `""` and the reply was dropped.
- **Added the `pm_ever_idle` latch** so PM's idle observation persists across cycles; the settle gate now reads `pm_ever_idle and dev_saw_idle` instead of requiring both in the same cycle. Headless-Dev path is byte-identical (it already forces `dev_saw_idle=True`).

**Task 2b — terminal-turn fast settle (decouples PM→user from Dev):**
- Read-only classification gated strictly on the current cycle's `pm_saw_idle` (never the latch; Race 2). A non-empty `[/complete]` or a `[/user]` turn settles startup immediately and falls through to the single prime-turn relay for delivery, without waiting for Dev. Empty `[/complete]`/non-terminal chatter does not fast-settle — a genuinely stuck PM still reaches plateau/ceiling.

**Observability:** additive `ContainerResult.startup_settle_reason` (`both_idle` | `pm_latched_dev_idle` | `pm_terminal_fast`), recorded at each settle site and appended to `startup_events`.

The prime-turn relay remains the **sole** delivery site — no in-loop delivery, no double-send.

## Tests

New reproduction tests in `tests/unit/granite_container/test_container.py::TestStartupPmCompleteBeforeDevPrimes` drive the **real** `last_assistant_text` against an on-disk JSONL transcript fixture (no stub), so the `len(texts) <= baseline_text_count` freshness guard — exactly where the reply was dropped — is actually exercised:
- `test_pm_complete_before_dev_primes_delivers` — PM `[/complete]` early, Dev never idles → fast settle delivers, exits `pm_complete`, `startup_settle_reason == "pm_terminal_fast"` (SC#1b).
- `test_pm_latched_dev_idle_delivers_complete` — PM idle early, Dev idles later → latch settles, relay delivers, `startup_settle_reason == "pm_latched_dev_idle"` (SC#1a).
- `test_empty_complete_at_startup_not_user_facing` — empty `[/complete]` does not fast-settle-deliver; `user_facing_routed` False, `on_complete_payload` not called (concern note #3).

**Red-state verified:** against the pre-fix container these repro scenarios exit `startup_unresolved` / `ceiling` with nothing delivered.

`pytest tests/unit/granite_container/test_container.py -n0` → **47 passed**. Existing stubs were updated to idempotent content-mirroring reads to reflect the relay's flush-safe re-read.

## Notes

- `tests/unit/test_granite_startup_diagnostic.py` has 7 pre-existing failures (`AttributeError: Container does not have '_run_pkill_fallback'`) present identically on the branch base — unrelated to this change.
