### PR TITLE
Tech-debt: tool-budget + reclaim-bridge advisory cleanup (#1873)

### DIFF
--- a/agent/session_health.py
+++ b/agent/session_health.py
@@ -136,6 +136,14 @@ RECLAIM_REQUESTS_MAX = int(os.environ.get("RECLAIM_REQUESTS_MAX", "256"))
 # the #1815 deadman staleness threshold default (90s).
 BRIDGE_WORKER_BEACON_STALE_S = int(os.environ.get("BRIDGE_WORKER_BEACON_STALE_S", "90"))
 
+# Sentinel distinct from ``None`` for the read-only bridge-contract-stale owner
+# map (#1873, item 2). A per-owner lookup that raises stores ``_ABSENT`` (a
+# transient DB error) so it is distinguishable from a positive not-found
+# (``None``). The stale-check treats BOTH as not-terminal → skip; only the
+# autonomous Phase-2 reaper (which re-reads fresh, never this map) treats
+# not-found ``None`` as terminal — the deliberate #1868 divergence.
+_ABSENT = object()
+
 # --- B2-probe: observability-only duplicate-worker detection (issue #1817) --
 #
 # A SEPARATE, additive key namespace from WORKER_REGISTERED_PID_KEY_PREFIX
@@ -2953,6 +2961,20 @@ def _reap_slot_leases() -> None:
       (concurrently-running sessions > max) and re-imposing exactly the
       wall-clock duration cap issue #1172 removed.
 
+    Between the phases (always-run region) the pass drains bridge-pushed
+    reclaim-requests and runs the read-only ``bridge_contract_stale`` check.
+    #1873 item 2: ``_drain_reclaim_requests`` now returns ``drained: int`` and no
+    longer calls the stale-check. This pass builds an owner→record map ONCE (only
+    when ``drained == 0``, the sole case the stale-check inspects owners; a
+    per-owner lookup error stores ``_ABSENT`` and logs) and calls
+    ``_maybe_emit_bridge_contract_stale(drained, owner_records)`` directly. That
+    map is for the read-only stale-check ONLY — Phase 2 above NEVER consults it
+    and re-reads each owner FRESH at reclaim time, which is what prevents a
+    ``valor-session resume`` during the bounded drain window from having its live
+    permit stripped. The #1868 divergence is preserved: the stale-check treats
+    ``None``/``_ABSENT`` as unknown → skip; Phase 2's fresh read treats a
+    not-found ``None`` as terminal → reclaim.
+
     Never raises into the health check — a single bad lease is logged and
     the pass continues; the whole function is exception-wrapped.
     """
@@ -3016,7 +3038,36 @@ def _reap_slot_leases() -> None:
         # under SLOT_LEASE_REAP_DISABLED=1, where it is the ONLY reclaim lever (the
         # autonomous Phase-2 reclaim is gated off). Placing it in/after the Phase-2
         # loop would silently defeat the feature's headline capability (concern #5).
-        _drain_reclaim_requests(registry, leases_snapshot)
+        drained = _drain_reclaim_requests(registry)
+
+        # === Fix #5 (#1821) / #1873 item 2: read-only bridge-contract-stale check ===
+        # Decoupled from the drain (which now returns ``drained: int`` and no longer
+        # calls the stale-check). Build the owner→record map HERE, in the always-run
+        # region (before the Phase-2 ``if reap_disabled: return`` gate, so it still
+        # fires under SLOT_LEASE_REAP_DISABLED=1). ``owner_records`` is initialized
+        # unconditionally so the ``drained > 0`` path (which just records the beacon)
+        # never references an undefined name; it is only populated when ``drained == 0``
+        # (the sole case the stale-check inspects owners), matching the shipped read
+        # cost. A per-owner lookup error stores ``_ABSENT`` (distinct from a not-found
+        # ``None``) and logs — the transient-DB-error signal must survive. This map is
+        # for the read-only stale-check ONLY and is NEVER consulted by Phase-2, which
+        # re-reads each owner FRESH at reclaim time (the resume-during-drain
+        # live-permit-strip guard — see Phase-2 loop below).
+        owner_records: dict[str, object] = {}
+        if drained == 0:
+            for lease in leases_snapshot:
+                owner_id = lease.owner_session_id
+                try:
+                    owner_records[owner_id] = AgentSession.get_by_id(owner_id)
+                except Exception:
+                    owner_records[owner_id] = _ABSENT
+                    logger.warning(
+                        "[session-health] bridge-contract-stale owner lookup failed for "
+                        "owner=%s (recording _ABSENT, non-fatal)",
+                        owner_id,
+                        exc_info=True,
+                    )
+        _maybe_emit_bridge_contract_stale(drained, owner_records)
 
         # === Phase 2: reclaim — gated on SLOT_LEASE_REAP_DISABLED ===
         if reap_disabled:
@@ -3089,8 +3140,101 @@ def _publish_slot_leases(registry, leases_snapshot) -> None:
         logger.debug("[session-health] slot-lease snapshot publish failed (non-fatal): %s", e)
 
 
-def _drain_reclaim_requests(registry, leases_snapshot) -> None:
+def _maybe_emit_bridge_contract_stale(drained: int, owner_records: dict[str, object]) -> None:
+    """Emit ``bridge_contract_stale`` when a terminal-owner leak is observed but no
+    reclaim-request has been drained for a sustained window (concern #5, #1821).
+
+    Detects the new-worker / old-bridge direction: the worker keeps ONE Redis
+    timestamp (``worker:slot:last_reclaim_request_drain:{host}``, set whenever the
+    drain pops ≥1 request). On a tick where a terminal-owner leak IS present but
+    ``now − last_drain_ts > BRIDGE_WORKER_BEACON_STALE_S`` (the REUSED beacon
+    threshold — no new staleness var), emit ``bridge_contract_stale`` once (dedup
+    ``SET NX EX``) so the contract gap is operator-visible rather than a silent drop.
+
+    #1873 item 2: this read-only check no longer runs its own owner-refetch loop.
+    It consumes ``owner_records`` — an owner_session_id → record map that
+    ``_reap_slot_leases`` built once this tick (only when ``drained == 0``). A map
+    value of ``None`` (positively not found) or ``_ABSENT`` (a lookup error) is NOT
+    terminal → skip, preserving the #1868 stale-side policy (``None``/``_ABSENT`` →
+    unknown). The autonomous Phase-2 reaper's opposite ``None``→terminal policy is
+    unaffected — it re-reads each owner FRESH and never consults this map.
+
+    Fail-quiet — an observability signal must never raise into the reap pass.
+    """
+    try:
+        from popoto.redis_db import POPOTO_REDIS_DB as _R  # noqa: PLC0415
+
+        host = _ORPHAN_REAP_HOSTNAME
+        last_drain_key = f"{WORKER_SLOT_LAST_RECLAIM_DRAIN_KEY_PREFIX}{host}"
+        now = time.time()
+
+        if drained > 0:
+            # We drained a request → the contract is live; record the timestamp.
+            _R.set(last_drain_key, str(now), ex=WORKER_SLOT_KEY_TTL_SECONDS)
+            return
+
+        # No request drained this tick. Only interesting if a terminal-owner leak
+        # actually exists (else there is nothing for the bridge to have requested).
+        # Read the pre-built owner map — no owner refetch here (#1873 item 2). A
+        # ``None`` (not found) or ``_ABSENT`` (lookup error) value is NOT terminal →
+        # skip (the #1868 stale-side policy).
+        terminal_owner_present = False
+        for rec in owner_records.values():
+            if rec is None or rec is _ABSENT:
+                continue
+            if getattr(rec, "status", None) in _TERMINAL_STATUSES:
+                terminal_owner_present = True
+                break
+        if not terminal_owner_present:
+            return
+
+        raw = _R.get(last_drain_key)
+        last_drain_ts = None
+        if raw is not None:
+            if isinstance(raw, bytes):
+                raw = raw.decode("utf-8", "replace")
+            try:
+                last_drain_ts = float(raw)
+            except (TypeError, ValueError):
+                last_drain_ts = None
+
+        stale = last_drain_ts is None or (now - last_drain_ts) > BRIDGE_WORKER_BEACON_STALE_S
+        if not stale:
+            return
+
+        # Dedup so a persistent gap logs once per stale window, not every tick.
+        dedup_key = f"worker:slot:bridge_contract_stale_applied:{host}"
+        if not _R.set(dedup_key, "1", nx=True, ex=BRIDGE_WORKER_BEACON_STALE_S):
+            return
+
+        logger.warning(
+            "[session-health] bridge_contract_stale: terminal-owner lease present but no "
+            "reclaim-request drained for >%ss — bridge reclaim-request channel may be "
+            "absent (new-worker/old-bridge). Autonomous reap still covers the leak.",
+            BRIDGE_WORKER_BEACON_STALE_S,
+        )
+        _append_watchdog_action(
+            _R,
+            host,
+            {"action": "bridge_contract_stale", "ts": now},
+        )
+        try:
+            _R.incr(f"{host}:worker-watchdog:bridge_contract_stale")
+        except Exception as e:
+            logger.debug("[session-health] bridge_contract_stale counter increment failed: %s", e)
+    except Exception as e:
+        logger.debug("[session-health] bridge_contract_stale check failed (non-fatal): %s", e)
+
+
+def _drain_reclaim_requests(registry) -> int:
     """Drain bridge-pushed reclaim-requests and reclaim genuinely-terminal owners.
+
+    Returns the number of reclaim-requests popped this tick (``drained``). The
+    read-only bridge-contract-stale check is NO LONGER called from here (#1873
+    item 2) — it is called directly by ``_reap_slot_leases`` off an owner map that
+    pass builds, decoupling the stale-check from the drain. The drain reads a
+    DISTINCT owner set (request ids popped from Redis), never the lease snapshot,
+    so it no longer takes ``leases_snapshot`` (no tramp parameter).
 
     The out-of-domain half of Fix #5 (#1821): the bridge's
     ``check_worker_liveness_and_slots`` pushes owner ids onto
@@ -3116,7 +3260,7 @@ def _drain_reclaim_requests(registry, leases_snapshot) -> None:
         from popoto.redis_db import POPOTO_REDIS_DB as _R  # noqa: PLC0415
     except Exception as e:
         logger.debug("[session-health] reclaim-request drain: redis unavailable: %s", e)
-        return
+        return 0
 
     drained = 0
     try:
@@ -3182,84 +3326,7 @@ def _drain_reclaim_requests(registry, leases_snapshot) -> None:
             "[session-health] reclaim-request drain failed (non-fatal): %s", e, exc_info=True
         )
 
-    _maybe_emit_bridge_contract_stale(drained, leases_snapshot)
-
-
-def _maybe_emit_bridge_contract_stale(drained: int, leases_snapshot) -> None:
-    """Emit ``bridge_contract_stale`` when a terminal-owner leak is observed but no
-    reclaim-request has been drained for a sustained window (concern #5, #1821).
-
-    Detects the new-worker / old-bridge direction: the worker keeps ONE Redis
-    timestamp (``worker:slot:last_reclaim_request_drain:{host}``, set whenever the
-    drain pops ≥1 request). On a tick where a terminal-owner leak IS present but
-    ``now − last_drain_ts > BRIDGE_WORKER_BEACON_STALE_S`` (the REUSED beacon
-    threshold — no new staleness var), emit ``bridge_contract_stale`` once (dedup
-    ``SET NX EX``) so the contract gap is operator-visible rather than a silent drop.
-
-    Fail-quiet — an observability signal must never raise into the reap pass.
-    """
-    try:
-        from popoto.redis_db import POPOTO_REDIS_DB as _R  # noqa: PLC0415
-
-        host = _ORPHAN_REAP_HOSTNAME
-        last_drain_key = f"{WORKER_SLOT_LAST_RECLAIM_DRAIN_KEY_PREFIX}{host}"
-        now = time.time()
-
-        if drained > 0:
-            # We drained a request → the contract is live; record the timestamp.
-            _R.set(last_drain_key, str(now), ex=WORKER_SLOT_KEY_TTL_SECONDS)
-            return
-
-        # No request drained this tick. Only interesting if a terminal-owner leak
-        # actually exists (else there is nothing for the bridge to have requested).
-        terminal_owner_present = False
-        for lease in leases_snapshot:
-            try:
-                fresh = AgentSession.get_by_id(lease.owner_session_id)
-            except Exception:
-                continue
-            if fresh is not None and getattr(fresh, "status", None) in _TERMINAL_STATUSES:
-                terminal_owner_present = True
-                break
-        if not terminal_owner_present:
-            return
-
-        raw = _R.get(last_drain_key)
-        last_drain_ts = None
-        if raw is not None:
-            if isinstance(raw, bytes):
-                raw = raw.decode("utf-8", "replace")
-            try:
-                last_drain_ts = float(raw)
-            except (TypeError, ValueError):
-                last_drain_ts = None
-
-        stale = last_drain_ts is None or (now - last_drain_ts) > BRIDGE_WORKER_BEACON_STALE_S
-        if not stale:
-            return
-
-        # Dedup so a persistent gap logs once per stale window, not every tick.
-        dedup_key = f"worker:slot:bridge_contract_stale_applied:{host}"
-        if not _R.set(dedup_key, "1", nx=True, ex=BRIDGE_WORKER_BEACON_STALE_S):
-            return
-
-        logger.warning(
-            "[session-health] bridge_contract_stale: terminal-owner lease present but no "
-            "reclaim-request drained for >%ss — bridge reclaim-request channel may be "
-            "absent (new-worker/old-bridge). Autonomous reap still covers the leak.",
-            BRIDGE_WORKER_BEACON_STALE_S,
-        )
-        _append_watchdog_action(
-            _R,
-            host,
-            {"action": "bridge_contract_stale", "ts": now},
-        )
-        try:
-            _R.incr(f"{host}:worker-watchdog:bridge_contract_stale")
-        except Exception as e:
-            logger.debug("[session-health] bridge_contract_stale counter increment failed: %s", e)
-    except Exception as e:
-        logger.debug("[session-health] bridge_contract_stale check failed (non-fatal): %s", e)
+    return drained
 
 
 def _append_watchdog_action(redis_client, host: str, entry: dict) -> None:

--- a/agent/tool_budget.py
+++ b/agent/tool_budget.py
@@ -202,10 +202,18 @@ def record_budget_trip(session, verdict: BudgetVerdict) -> None:
         from popoto.redis_db import POPOTO_REDIS_DB
 
         # Dedup the SIDE EFFECTS (not the block) to once per session.
-        dedup_key = f"{project_key}:tool-budget:tripped_applied:{session_id}"
-        first = POPOTO_REDIS_DB.set(dedup_key, "1", nx=True, ex=TRIP_DEDUP_TTL)
-        if not first:
-            return  # already surfaced this session; the block still fired in the caller
+        # #1873 item 3: an id-less session (no session_id AND no agent_session_id)
+        # must NOT collapse into a shared ``...:tripped_applied:None`` slot — that
+        # single key would silently dedup away every id-less trip after the first.
+        if not session_id:
+            # Bypass the NX dedup gate entirely: fall through to counter/log/flag
+            # and surface on every id-less deny (never write a shared :None key).
+            pass
+        else:
+            dedup_key = f"{project_key}:tool-budget:tripped_applied:{session_id}"
+            first = POPOTO_REDIS_DB.set(dedup_key, "1", nx=True, ex=TRIP_DEDUP_TTL)
+            if not first:
+                return  # already surfaced this session; the block still fired in the caller
 
         try:
             POPOTO_REDIS_DB.incr(f"{project_key}:tool-budget:tripped")

--- a/docs/features/out-of-domain-recovery.md
+++ b/docs/features/out-of-domain-recovery.md
@@ -236,6 +236,43 @@ granite may eventually want a higher `MAX_TOOL_CALLS_PER_SESSION` — not a
 reason to gate the deny off by default, which would leave the backstop inert
 exactly where it matters most.
 
+**Id-less deny surfacing (#1873 item 3).** The deny-surfacing dedup gate keys
+on `session_id or agent_session_id`. When a session resolves neither id, the
+gate would otherwise form a single shared `{project_key}:tool-budget:tripped_applied:None`
+slot that collapses every id-less deny together — the first surfaces and every
+later one is silently deduped away. `record_budget_trip` therefore bypasses the
+`SET NX` gate entirely when no id resolves and surfaces on every id-less deny
+(observable via the WARNING log and the `{project_key}:tool-budget:tripped`
+counter; the `budget_tripped` flag cannot persist for a keyless, unsaved
+session). Id-less sessions do not arise on the shipped hook paths (both pass a
+persisted `AgentSession`), so this is defensive hardening — the log/counter
+volume stays bounded in practice.
+
+### Deny-but-don't-halt: the metering tradeoff
+
+With `TOOL_BUDGET_AUTO_PAUSE` off (the shipped default), a denied headless/SDK
+session is blocked on each over-budget tool call but is **not halted** — the
+session keeps issuing tool calls, each denied inline, metering one harness
+round-trip per denied call until it reaches max-turns on its own. The deny is a
+per-call backstop, not a session terminator.
+
+Whether those wasted round-trips justify a behavior change — flipping the
+auto-pause default on, or adding a consecutive-denial hard-stop — cannot be
+answered without live denial-distribution data. The current `tripped` counter
+increments once per session (gated by the dedup above), not once per denied
+call, so it does not measure the per-call metering cost. Making that decision
+needs a per-denial instrument.
+
+That observe-first tuning work is owned by **[#1886]** — both the per-denial
+`denied_calls` counter (the instrument that would collect the distribution) and
+the eventual data-gated default decision. It is deliberately deferred here
+pending production data; this feature ships the deny backstop and its
+documentation only, with no speculative default change. When #1886 adds the
+`denied_calls` counter, its `INCR` must carry its own isolated inner
+`try/except` (mirroring the `tripped` counter) so a Redis blip on that one
+increment cannot swallow the dedup-key write, the WARNING log, the
+`budget_tripped` flag, or the auto-pause.
+
 ## Mixed-version-deploy detectability
 
 Fix #5 spans both the bridge and worker processes, so a rolling deploy can
@@ -260,6 +297,31 @@ made operator-visible rather than silently dropped:
   reaper still reclaims the leak in this direction (unless
   `SLOT_LEASE_REAP_DISABLED=1`), so no slot is actually lost — the signal
   exists purely to make the contract gap visible rather than a quiet drop.
+
+**Stale-check decoupled from the drain (#1873 item 2).** The read-only
+`bridge_contract_stale` check no longer runs its own per-owner `get_by_id` loop
+over the lease snapshot. `_drain_reclaim_requests` now returns `drained: int`
+and no longer calls the stale-check; `_reap_slot_leases` builds an owner→record
+map once — only when `drained == 0`, the sole case the stale-check inspects
+owners — and calls `_maybe_emit_bridge_contract_stale(drained, owner_records)`
+directly, in the always-run region before the Phase-2 reap gate. A per-owner
+lookup error stores an `_ABSENT` sentinel (distinct from a positively not-found
+`None`) and logs a WARNING, so the transient-DB-error signal survives. The
+autonomous **Phase-2 reclaim loop is left unchanged**: it re-reads each owner
+FRESH via `get_by_id` at reclaim time and never consults the map. This fresh
+read is load-bearing — a `valor-session resume` during the bounded drain window
+can un-terminal an owner that was terminal moments earlier, and reclaiming off a
+pre-drain snapshot would strip the now-live session's permit (semaphore
+over-admission). Total Redis reads are unchanged; this is a structural
+decoupling of the stale-check, not a read reduction. The deliberate #1868
+divergence is preserved exactly: the read-only stale-check treats `None`/`_ABSENT`
+as unknown → skip, while the autonomous reaper's fresh read treats a not-found
+`None` as terminal → reclaim.
+
+The healthy-tick reclaim-dedup clear (`_clear_reclaim_dedup`) enumerates its
+per-owner markers with a non-blocking `scan_iter` and deletes them in bounded
+batches, replacing the blocking `KEYS` scan that held the Redis event loop at
+scale. It stays fail-quiet; orphaned markers also age out via their TTL.
 
 The contract is intentionally not hard version-gated. An explicit version
 field would add a migration surface for no safety gain, since both directions

--- a/docs/features/slot-lease-ownership.md
+++ b/docs/features/slot-lease-ownership.md
@@ -103,6 +103,20 @@ starvation case). The pass has two phases:
   `registry.reclaim(owner)` and increments the `slot_reclaims` counter. There is
   no wall-clock reclaim arm.
 
+Between the two phases the tick drains bridge-pushed reclaim-requests and runs a
+read-only `bridge_contract_stale` observability check. As of #1873 the drain
+(`_drain_reclaim_requests`) returns `drained: int` and no longer calls the
+stale-check; `_reap_slot_leases` builds an owner→record map once (only when
+`drained == 0`) and passes it to `_maybe_emit_bridge_contract_stale`, decoupling
+that read-only check from the drain. Phase-2 reclaim is unaffected — it still
+re-reads each owner FRESH at reclaim time and never consults the map, which is
+what prevents a `valor-session resume` during the bounded drain window from
+having its live permit stripped. The healthy-tick reclaim-dedup clear now
+enumerates its markers with a non-blocking `scan_iter` + batched delete instead
+of a blocking `KEYS` scan. See
+[`out-of-domain-recovery.md`](out-of-domain-recovery.md) for the full stale-check
+and drain contract.
+
 ### Prompt reclaim in the killer
 
 `_apply_recovery_transition` (the out-of-band killer) also calls

--- a/monitoring/session_watchdog.py
+++ b/monitoring/session_watchdog.py
@@ -917,13 +917,22 @@ def _clear_reclaim_dedup(redis_client, host: str) -> None:
     """Clear per-owner reclaim-request dedup markers on a healthy tick (Fix #5).
 
     So a future re-leak of a previously-requested owner re-triggers a fresh
-    reclaim-request. Fail-quiet; orphaned markers also age out via their TTL.
+    reclaim-request. Enumerates via a non-blocking ``scan_iter`` and deletes in
+    bounded batches (the old ``KEYS`` scan blocked the Redis event loop at
+    scale). Fail-quiet; orphaned markers also age out via their TTL. These are
+    plain watchdog marker keys (prefix ``WORKER_SLOT_RECLAIM_DEDUP_KEY_PREFIX``),
+    not Popoto-managed model keys, so raw ``scan_iter``/``delete`` is permitted.
     """
     try:
         pattern = f"{WORKER_SLOT_RECLAIM_DEDUP_KEY_PREFIX}{host}:*"
-        keys = list(redis_client.keys(pattern))
-        if keys:
-            redis_client.delete(*keys)
+        batch: list = []
+        for key in redis_client.scan_iter(match=pattern, count=100):
+            batch.append(key)
+            if len(batch) >= 500:
+                redis_client.delete(*batch)
+                batch = []
+        if batch:
+            redis_client.delete(*batch)
     except Exception as e:
         logger.debug("[watchdog] reclaim-dedup clear failed (non-fatal): %s", e)
 

--- a/tests/integration/test_out_of_domain_reclaim.py
+++ b/tests/integration/test_out_of_domain_reclaim.py
@@ -129,7 +129,7 @@ async def test_acceptance_1_reclaim_driven_from_non_worker_process(registry):
     assert any(a["action"] == "reclaim_requested" for a in _actions())
 
     # Worker-side drain performs the actual reclaim (loop-affinity physics).
-    sh._drain_reclaim_requests(registry, registry.leases())
+    sh._drain_reclaim_requests(registry)
 
     assert registry.permits_free() == before + 1, "permit must be freed by the drain"
     assert session.id not in {lease.owner_session_id for lease in registry.leases()}
@@ -224,7 +224,7 @@ async def test_running_requested_owner_not_reclaimed(registry):
     before = registry.permits_free()
     _redis().rpush(_RECLAIM_KEY, session.id)
 
-    sh._drain_reclaim_requests(registry, registry.leases())
+    sh._drain_reclaim_requests(registry)
 
     assert registry.permits_free() == before, "live owner's permit must be preserved"
     assert session.id in {lease.owner_session_id for lease in registry.leases()}
@@ -238,7 +238,7 @@ async def test_none_lookup_requested_owner_skipped(registry):
     _redis().rpush(_RECLAIM_KEY, "ghost-owner-none")
 
     # No AgentSession row for this owner → get_by_id returns None.
-    sh._drain_reclaim_requests(registry, registry.leases())
+    sh._drain_reclaim_requests(registry)
 
     assert registry.permits_free() == before, "unknown owner must NOT be reclaimed"
     assert "ghost-owner-none" in {lease.owner_session_id for lease in registry.leases()}
@@ -252,7 +252,7 @@ async def test_lookup_exception_requested_owner_skipped(registry):
     _redis().rpush(_RECLAIM_KEY, session.id)
 
     with patch.object(AgentSession, "get_by_id", side_effect=RuntimeError("redis blip")):
-        sh._drain_reclaim_requests(registry, registry.leases())
+        sh._drain_reclaim_requests(registry)
 
     assert registry.permits_free() == before, "lookup exception must NOT reclaim"
 
@@ -304,7 +304,7 @@ async def test_healthy_tick_clears_reclaim_dedup(registry):
     assert _redis().get(dedup_key) is not None
 
     # Resolve the leak: drain frees the permit, republish an empty lease snapshot.
-    sh._drain_reclaim_requests(registry, registry.leases())
+    sh._drain_reclaim_requests(registry)
     sh._publish_slot_leases(registry, registry.leases())
     sw.check_worker_liveness_and_slots()
 
@@ -319,12 +319,153 @@ async def test_healthy_tick_clears_reclaim_dedup(registry):
 @pytest.mark.asyncio
 async def test_bridge_contract_stale_emitted_when_no_bridge_pushes(registry):
     """Terminal-owner leak present but the reclaim-request channel is always empty
-    (no bridge pushing) → worker emits bridge_contract_stale rather than dropping."""
+    (no bridge pushing) → worker emits bridge_contract_stale rather than dropping.
+
+    #1873 item 2: the stale-check now reads the owner map built by
+    ``_reap_slot_leases`` (drained == 0 path), not its own ``get_by_id`` loop, so
+    this drives the full reap tick end-to-end.
+    """
     await _orphan_slot(registry, status="completed")
     assert _redis().llen(_RECLAIM_KEY) == 0  # old-bridge never pushes
+    _last_drain_key = f"{sh.WORKER_SLOT_LAST_RECLAIM_DRAIN_KEY_PREFIX}{_HOST}"
+    _redis().delete(_last_drain_key)  # no prior drain ts → stale
 
-    # Drain sees an empty request list + a terminal-owner lease + no prior drain ts.
-    sh._drain_reclaim_requests(registry, registry.leases())
+    # Full reap tick: drained == 0 → owner map built → stale-check reads the map.
+    with patch.dict("os.environ", {"SLOT_LEASE_REAP_DISABLED": "1"}):
+        sh._reap_slot_leases()  # gate Phase-2 off so the terminal lease survives
 
     assert _counter(f"{_HOST}:worker-watchdog:bridge_contract_stale") == 1
     assert any(a["action"] == "bridge_contract_stale" for a in _actions())
+
+
+# ---------------------------------------------------------------------------
+# #1873 item 2 — reap tick drives the stale-check off the owner map; Phase-2
+# reclaim reads FRESH (the #1868 None-divergence + the resume-during-drain guard)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reap_phase2_reclaims_terminal_owner_fresh_read(registry):
+    """Phase-2 re-reads each owner FRESH and reclaims a genuinely terminal one."""
+    session = await _orphan_slot(registry, status="completed")
+    before = registry.permits_free()
+
+    sh._reap_slot_leases()  # full tick, Phase-2 enabled
+
+    assert registry.permits_free() == before + 1, "terminal owner's permit must be reclaimed"
+    assert session.id not in {lease.owner_session_id for lease in registry.leases()}
+
+
+@pytest.mark.asyncio
+async def test_reap_not_found_owner_reclaimed_but_no_stale(registry):
+    """A not-found (None) owner: Phase-2 reclaims (reaper-side #1868 policy), but the
+    read-only stale-check treats None as unknown → NO stale emission."""
+    await reg_acquire_ghost(registry, "ghost-owner-reap-none")
+    before = registry.permits_free()
+    _redis().delete(f"{_HOST}:worker-watchdog:bridge_contract_stale")
+
+    sh._reap_slot_leases()  # get_by_id → None for the ghost owner
+
+    assert registry.permits_free() == before + 1, "not-found owner reclaimed by the reaper"
+    assert "ghost-owner-reap-none" not in {lease.owner_session_id for lease in registry.leases()}
+    assert _counter(f"{_HOST}:worker-watchdog:bridge_contract_stale") == 0, (
+        "None owner is unknown for the stale-check → no emission"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reap_lookup_error_owner_no_reclaim_no_stale(registry):
+    """A lookup-error (_ABSENT) owner: Phase-2 skips reclaim (fresh read raised) AND
+    the stale-check records _ABSENT (not terminal) → no reclaim, no stale, no crash."""
+    session = await _orphan_slot(registry, status="completed")
+    before = registry.permits_free()
+    _redis().delete(f"{_HOST}:worker-watchdog:bridge_contract_stale")
+
+    with patch.object(AgentSession, "get_by_id", side_effect=RuntimeError("redis blip")):
+        sh._reap_slot_leases()  # must not raise
+
+    assert registry.permits_free() == before, "lookup-error owner must NOT be reclaimed"
+    assert session.id in {lease.owner_session_id for lease in registry.leases()}
+    assert _counter(f"{_HOST}:worker-watchdog:bridge_contract_stale") == 0, (
+        "_ABSENT owner is not terminal for the stale-check → no emission"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reap_resume_during_drain_not_reclaimed(registry):
+    """Regression guard: an owner terminal at owner-map-snapshot time but re-reads
+    NON-terminal at Phase-2 reclaim time (a resume-during-drain simulation) must NOT
+    be reclaimed — proving Phase-2's FRESH re-read prevents the live-permit strip."""
+    from types import SimpleNamespace
+
+    session = await _orphan_slot(registry, status="completed")
+    before = registry.permits_free()
+
+    terminal_rec = SimpleNamespace(status="completed", project_key="test")
+    live_rec = SimpleNamespace(status="running", project_key="test")
+    calls = {"n": 0}
+
+    def _fake_get_by_id(_owner_id):
+        calls["n"] += 1
+        # Call #1 = owner-map snapshot (terminal); call #2 = Phase-2 fresh read (live).
+        return terminal_rec if calls["n"] == 1 else live_rec
+
+    with patch.object(AgentSession, "get_by_id", side_effect=_fake_get_by_id):
+        sh._reap_slot_leases()
+
+    assert registry.permits_free() == before, "resumed (now-live) owner's permit must survive"
+    assert session.id in {lease.owner_session_id for lease in registry.leases()}
+
+
+@pytest.mark.asyncio
+async def test_reap_drained_positive_records_beacon_no_stale(registry):
+    """C2 guard: on the ``drained > 0`` path the owner map is never built, the drain
+    beacon IS written, and no stale is emitted (owner_records defaults to {})."""
+    session = await _orphan_slot(registry, status="completed")
+    _redis().rpush(_RECLAIM_KEY, session.id)  # bridge pushed one request
+    last_drain_key = f"{sh.WORKER_SLOT_LAST_RECLAIM_DRAIN_KEY_PREFIX}{_HOST}"
+    _redis().delete(last_drain_key)
+    _redis().delete(f"{_HOST}:worker-watchdog:bridge_contract_stale")
+
+    sh._reap_slot_leases()  # drain pops 1 → drained == 1
+
+    assert _redis().get(last_drain_key) is not None, "drained>0 must record the drain beacon"
+    assert _counter(f"{_HOST}:worker-watchdog:bridge_contract_stale") == 0, (
+        "drained>0 path must not emit stale"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #1873 item 1 — SCAN-based reclaim-dedup clear (non-blocking, fail-quiet)
+# ---------------------------------------------------------------------------
+
+
+def test_clear_reclaim_dedup_scan_deletes_matching_markers():
+    """SCAN enumerate + batched delete removes every matching dedup marker."""
+    r = _redis()
+    keys = [f"{sw.WORKER_SLOT_RECLAIM_DEDUP_KEY_PREFIX}{_HOST}:owner-{i}" for i in range(7)]
+    for k in keys:
+        r.set(k, "1", ex=sw.WORKER_SLOT_KEY_TTL_SECONDS)
+
+    sw._clear_reclaim_dedup(r, _HOST)
+
+    for k in keys:
+        assert r.get(k) is None, f"{k} must be cleared via the SCAN sweep"
+
+
+def test_clear_reclaim_dedup_zero_match_no_raise():
+    """Zero matching keys → no delete issued, no raise (empty-batch guard)."""
+    r = _redis()
+    # A host with no markers at all.
+    sw._clear_reclaim_dedup(r, f"nohost-{time.time()}")
+
+
+def test_clear_reclaim_dedup_is_fail_quiet():
+    """A raising Redis client is swallowed — the clear never raises (fail-quiet)."""
+
+    class _BoomRedis:
+        def scan_iter(self, *_a, **_k):
+            raise RuntimeError("simulated scan failure")
+
+    # Must not raise.
+    sw._clear_reclaim_dedup(_BoomRedis(), _HOST)

--- a/tests/integration/test_tool_budget_enforcement.py
+++ b/tests/integration/test_tool_budget_enforcement.py
@@ -325,3 +325,53 @@ def test_surfacing_error_is_fail_quiet(make_session, monkeypatch):
     record_budget_trip(s, verdict)
     # The race-free flag still lands (independent best-effort step).
     assert _reason_of(s.session_id)
+
+
+def test_id_less_session_does_not_collapse_dedup(caplog):
+    """#1873 item 3: two id-less sessions (no session_id AND no agent_session_id)
+    must BOTH surface — never collapse into a shared ``...:tripped_applied:None``
+    dedup slot that silently drops the second trip.
+
+    Observable surface for an id-less deny is the WARNING log + the ``tripped``
+    counter increment ONLY (a keyless ``save()`` cannot persist the flag, so flag
+    persistence is deliberately not asserted).
+    """
+    import logging
+
+    from popoto.redis_db import POPOTO_REDIS_DB
+
+    from agent.tool_budget import BudgetVerdict, record_budget_trip
+
+    class _IdLessSession:
+        def __init__(self, project_key):
+            self.project_key = project_key
+            self.session_id = None
+            self.agent_session_id = None
+
+    pk = f"test-idless-{uuid.uuid4().hex[:8]}"
+    counter_key = f"{pk}:tool-budget:tripped"
+    none_dedup_key = f"{pk}:tool-budget:tripped_applied:None"
+    POPOTO_REDIS_DB.delete(counter_key)
+    POPOTO_REDIS_DB.delete(none_dedup_key)
+
+    verdict = BudgetVerdict(allow=False, reason="per-tool budget reached")
+    s1 = _IdLessSession(pk)
+    s2 = _IdLessSession(pk)
+
+    with caplog.at_level(logging.WARNING, logger="agent.tool_budget"):
+        record_budget_trip(s1, verdict)
+        record_budget_trip(s2, verdict)
+
+    # Both id-less trips surfaced: two WARNING "tripped budget" logs.
+    tripped_logs = [r for r in caplog.records if "tripped budget" in r.getMessage()]
+    assert len(tripped_logs) == 2, "both id-less trips must surface a WARNING (not deduped)"
+
+    # The counter incremented once per trip — the second was NOT deduped away.
+    assert int(POPOTO_REDIS_DB.get(counter_key)) == 2
+
+    # No shared ``:None`` dedup slot was ever written.
+    assert POPOTO_REDIS_DB.get(none_dedup_key) is None, (
+        "id-less path must bypass the NX gate, never write a shared :None key"
+    )
+
+    POPOTO_REDIS_DB.delete(counter_key)

--- a/tests/integration/test_worker_concurrency.py
+++ b/tests/integration/test_worker_concurrency.py
@@ -208,7 +208,7 @@ class TestGlobalSemaphore:
             POPOTO_REDIS_DB.rpush(f"worker:slot:reclaim_requests:{host}", session.agent_session_id)
 
             # Worker on-loop drain performs the actual reclaim.
-            _sh._drain_reclaim_requests(reg, reg.leases())
+            _sh._drain_reclaim_requests(reg)
 
             assert reg.permits_free() == before + 1
             assert session.agent_session_id not in {


### PR DESCRIPTION
Closes #1873.

Advisory-item cleanup from the #1872 review. Three isolated hardening fixes plus documentation; no load-bearing behavior change.

## Items
1. **`monitoring/session_watchdog.py::_clear_reclaim_dedup`** — swap the blocking Redis `KEYS` for `scan_iter` accumulate + batched `delete` (production Redis blocking hazard at scale). Fail-quiet + TTL fallback preserved.
2. **`agent/session_health.py`** — decouple the read-only bridge-contract-stale check from the drain. `_drain_reclaim_requests` now returns `drained: int`; `_reap_slot_leases` builds an owner→record map once (only when `drained == 0`) and passes it to `_maybe_emit_bridge_contract_stale`, which reads the map instead of re-reading owners. The Phase-2 reclaim loop is unchanged: it re-reads each owner FRESH at reclaim time, guarding the resume-during-drain live-permit-strip race. The deliberate #1868 None-divergence (stale-check: None → skip; reaper: None → reclaim) is preserved.
3. **`agent/tool_budget.py::record_budget_trip`** — `if not session_id:` guard bypasses the NX dedup gate when no session id resolves, so distinct id-less sessions never collapse into a shared `...:tripped_applied:None` slot.
4. **Deferred (item 4)** — the deny-but-don't-halt default tuning is deferred pending live production denial-distribution data; documented and tracked in #1886, which owns the per-denial `denied_calls` instrument and the data-gated default decision. No behavior change here.

## Tests
`tests/integration/test_tool_budget_enforcement.py` + `tests/integration/test_out_of_domain_reclaim.py` — 31 passed serially. Adds `test_id_less_session_does_not_collapse_dedup`, end-to-end `_reap_slot_leases()` coverage (terminal reclaim, not-found `None` reclaim, lookup-error `_ABSENT` no-reclaim, resume-during-drain regression, `drained > 0` beacon path), and SCAN-clear tests.

Plan: `docs/plans/tool-budget-reclaim-bridge-advisory-cleanup.md`
Critique: READY TO BUILD (0 blockers, 5 concerns; C1/C2 correctness notes honored in the build).