### PR TITLE
fix: anchor design-system-sync hook log path to repo root (#1901)

### DIFF
--- a/.claude/hooks/validators/validate_design_system_sync.py
+++ b/.claude/hooks/validators/validate_design_system_sync.py
@@ -50,7 +50,11 @@ _COMMAND_REGEX = re.compile(
     r"(?![A-Za-z0-9.])"
 )
 
-_LOG_PATH = Path("logs/validate_design_system_sync.jsonl")
+# Anchored to the repo root (not cwd) so the hook never creates a stray
+# cwd-relative logs/ directory (e.g. inside a skills root), which would
+# trip rule_19_husk_directories in the skills-audit reflection.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_LOG_PATH = _REPO_ROOT / "logs" / "validate_design_system_sync.jsonl"
 
 
 def _log(entry: dict) -> None:

--- a/.claude/hooks/validators/validate_design_system_sync.py
+++ b/.claude/hooks/validators/validate_design_system_sync.py
@@ -53,6 +53,9 @@ _COMMAND_REGEX = re.compile(
 # Anchored to the repo root (not cwd) so the hook never creates a stray
 # cwd-relative logs/ directory (e.g. inside a skills root), which would
 # trip rule_19_husk_directories in the skills-audit reflection.
+# Assumption: this only ignores cwd because __file__ is absolute at
+# invocation time. Claude Code hooks are registered via `$CLAUDE_PROJECT_DIR`
+# in .claude/settings.json (an absolute path), so that assumption holds.
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _LOG_PATH = _REPO_ROOT / "logs" / "validate_design_system_sync.jsonl"
 

--- a/docs/features/design-system-tooling.md
+++ b/docs/features/design-system-tooling.md
@@ -181,15 +181,18 @@ open on internal error** (exits 0 with stderr warning) so a broken
 validator cannot block all commits.
 
 Every invocation appends one JSON line to
-`logs/validate_design_system_sync.jsonl`:
+`logs/validate_design_system_sync.jsonl`, anchored to the repo root
+(derived from the hook file's own location, not the invoking process's
+cwd) so a session working from any directory always lands the log in
+the same place instead of scattering stray `logs/` husks:
 
 ```json
 {"ts": "...", "tool_name": "Bash", "matched": true, "result": "ok", "duration_ms": 42, "reason": null, "error": null}
 ```
 
 Operators can `tail -f logs/validate_design_system_sync.jsonl | jq 'select(.result=="error")'`
-to detect silently-broken hooks post-hoc. This is the observability
-surface that closes the fail-open gap.
+(from the repo root) to detect silently-broken hooks post-hoc. This is
+the observability surface that closes the fail-open gap.
 
 ### `validate_design_system_readonly.py` (Write|Edit matcher)
 

--- a/docs/plans/design-system-sync-log-path.md
+++ b/docs/plans/design-system-sync-log-path.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: docs_complete
 type: bug
 appetite: Small
 owner: Valor Engels

--- a/docs/plans/design-system-sync-log-path.md
+++ b/docs/plans/design-system-sync-log-path.md
@@ -274,17 +274,17 @@ no stray husk is created" is sufficient and covered under Inline Documentation.
 
 ## Success Criteria
 
-- [ ] `_LOG_PATH` in `validate_design_system_sync.py` is anchored to the repo root
+- [x] `_LOG_PATH` in `validate_design_system_sync.py` is anchored to the repo root
   via `Path(__file__).resolve().parents[3]` (no cwd-relative `Path("logs/...")`).
-- [ ] Running the hook from a non-repo-root cwd creates NO `logs/` directory under
+- [x] Running the hook from a non-repo-root cwd creates NO `logs/` directory under
   that cwd; the log line lands at `<repo_root>/logs/validate_design_system_sync.jsonl`.
-- [ ] New regression test in `test_validate_design_system_sync.py` covers the
+- [x] New regression test in `test_validate_design_system_sync.py` covers the
   non-repo-root-cwd case and passes.
-- [ ] Existing `test_jsonl_log_records_each_invocation` and
+- [x] Existing `test_jsonl_log_records_each_invocation` and
   `test_jsonl_log_captures_bypass` still pass unchanged.
-- [ ] `skills-audit` rule 19 reports no `logs` husk finding
+- [x] `skills-audit` rule 19 reports no `logs` husk finding
   (`python .claude/skills-global/do-skills-audit/scripts/audit_skills.py` clean for rule 19).
-- [ ] Tests pass (`/do-test`)
+- [x] Tests pass (`/do-test`)
 - [ ] Documentation reviewed (`/do-docs`) — inline comment added; no feature-doc change.
 
 ## Team Orchestration

--- a/tests/unit/hooks/test_validate_design_system_sync.py
+++ b/tests/unit/hooks/test_validate_design_system_sync.py
@@ -150,3 +150,31 @@ def test_jsonl_log_captures_bypass():
     assert len(after) >= len(before) + 1
     latest = json.loads(after[-1])
     assert latest["result"] == "bypassed"
+
+
+def test_log_path_anchored_to_repo_root_not_cwd(tmp_path: Path):
+    """Regression for #1901: running from a non-repo-root cwd must not
+    create a stray cwd-relative logs/ directory (flagged as a husk by the
+    skills-audit reflection's rule_19_husk_directories).
+    """
+    log_path = REPO_ROOT / "logs/validate_design_system_sync.jsonl"
+    before = log_path.read_text(encoding="utf-8").splitlines() if log_path.is_file() else []
+
+    env = os.environ.copy()
+    env.setdefault("PYTHONPATH", str(REPO_ROOT))
+    proc = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps({"tool_name": "Bash", "tool_input": {"command": "git add README.md"}}),
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(tmp_path),
+    )
+    assert proc.returncode == 0
+
+    after = log_path.read_text(encoding="utf-8").splitlines() if log_path.is_file() else []
+    assert len(after) >= len(before) + 1
+    latest = json.loads(after[-1])
+    assert latest["tool_name"] == "Bash"
+
+    assert not (tmp_path / "logs").exists()


### PR DESCRIPTION
## Summary
- Anchors `.claude/hooks/validators/validate_design_system_sync.py`'s `_LOG_PATH` to the repo root (`Path(__file__).resolve().parents[3]`) instead of the process cwd, so the hook never scatters stray `logs/` husk directories wherever a session's cwd happens to be — the root cause of the recurring `rule_19_husk_directories` skills-audit failure.
- Adds a regression test (`test_log_path_anchored_to_repo_root_not_cwd`) that invokes the hook with `cwd=tmp_path` (a non-repo-root directory) and asserts the log line lands at `REPO_ROOT/logs/validate_design_system_sync.jsonl` with no stray `logs/` created under `tmp_path`. Verified this test fails against the pre-fix code (sanity-checked by reverting the fix locally and re-running).
- Notes inline that the cwd-independence relies on `__file__` being absolute at invocation time, which holds because Claude Code hooks are registered via the absolute `$CLAUDE_PROJECT_DIR` in `.claude/settings.json`.

Fixes #1901.

## Test plan
- [x] `pytest tests/unit/hooks/test_validate_design_system_sync.py` — 10/10 passed
- [x] New regression test confirmed to fail against pre-fix code (manual revert-and-rerun)
- [x] `grep -c '_REPO_ROOT = Path(__file__).resolve().parents\[3\]'` on the hook file returns exactly 1 (inline comment avoids a second literal `parents[3]` match)
- [x] `python -m ruff format` run on changed files