### PR TITLE
Graceful embedding degradation for Memory records (#1904)

### DIFF
--- a/docs/features/subconscious-memory.md
+++ b/docs/features/subconscious-memory.md
@@ -59,6 +59,16 @@ The `embedding-orphan-sweep` reflection (registered in `config/reflections.yaml`
 
 For one-shot reconciliation against an existing backlog, run `python scripts/embedding_orphan_reconcile.py --dry-run` to preview, then `--apply` to act. The script enforces a positive-assertion safety check (refuses to apply if the to-delete set intersects expected-keep) and a pre-flight regression guard (refuses to apply if `$Class:Memory` is empty — defense-in-depth against the data-destruction bug that motivated this feature). `python -m tools.memory_search status --deep --json` reports both `orphan_index_count` (Redis-side, pre-existing) and `disk_orphan_count` (disk-side, new) so the two surfaces can be checked independently.
 
+### Embedding Degradation (persist without vector)
+
+The provider-not-configured degradation above covers the case where Ollama is absent at startup. A subtler case is when the provider **is** configured but the embed call fails mid-save — a read timeout under concurrent load, or a transient unreachable. In that window `EmbeddingField.on_save` (which runs inside popoto's `Model.save` field loop, before the record's main `hset` commits) raised, so the exception aborted the whole save and the record — content, BM25 index, relevance — was lost, not merely left without a vector (issue #1904).
+
+`Memory.embedding` uses `GracefulEmbeddingField` (`models/graceful_embedding_field.py`), an `EmbeddingField` subclass whose `on_save` catches provider/write failures (`RuntimeError`, `ValueError`, `OSError`) and returns the pipeline unchanged. The already-queued main `hset` then commits normally, so the record persists with `embedding = None` — the queryable "no vector" marker. Recall still serves it via the other three RRF signals (BM25, relevance, confidence). The swap is storage-identical to `EmbeddingField`, so no migration is needed.
+
+Degradation is observable without flooding the logs: a module-level throttle emits at most one `Embedding degraded …` warning per 60s window, while a counter increments on every degraded save. The count is surfaced in the `memory-embedding-backfill` reflection summary.
+
+The `memory-embedding-backfill` reflection (`reflections/memory/memory_embedding_backfill.py`, registered in `config/reflections.yaml` / vault `reflections.yaml`) heals degraded records. It runs daily, finds active records with a falsy `embedding`, and — when the provider is healthy again (`OllamaEmbeddingProvider().is_available()`) — re-embeds them so they regain the fourth (semantic-similarity) signal. It defaults to dry-run; set `MEMORY_EMBEDDING_BACKFILL_APPLY=true` to enable re-embedding. Each run caps at 500 re-embeds so a long-outage backlog does not re-saturate Ollama the moment it recovers. Re-embed is a **partial** save — `memory.save(update_fields=["embedding"])` — so only the embedding index is rewritten; a bare `memory.save()` would re-run the `relevance` `DecayingSortedField` (`auto_now=True`) and re-stamp it to "now", silently un-decaying stale memories. It emits the `memory.embedding_backfill_reembedded` metric.
+
 ## Data Flows
 
 ### Flow 1: Human Message Ingestion

--- a/models/graceful_embedding_field.py
+++ b/models/graceful_embedding_field.py
@@ -1,0 +1,141 @@
+"""models/graceful_embedding_field.py — EmbeddingField that persists on provider failure.
+
+Why this exists (issue #1904):
+    popoto's ``EmbeddingField.on_save`` calls the embedding provider (local Ollama,
+    5s read timeout) synchronously inside popoto's ``Model.save`` field loop. On a
+    provider timeout/unreachable/HTTP error the parent ``on_save`` raises
+    ``RuntimeError`` (and ``ValueError`` on a dimension mismatch, ``OSError`` on the
+    atomic ``.npy`` write). That exception propagates out of ``Model.save`` *before*
+    ``internal_pipeline.execute()`` runs, so the queued main ``hset`` never commits —
+    the entire Memory record (content, BM25 index, relevance) is lost, not merely
+    degraded. Under concurrent load (the exact condition that saturates Ollama) this
+    silently drops human messages.
+
+The contract:
+    ``GracefulEmbeddingField.on_save`` wraps the parent call in a try/except. On a
+    provider/write failure it records the degradation and returns the pipeline
+    unchanged, so the already-queued main record ``hset`` commits normally. The
+    record persists with ``embedding = None`` (the field default) — the queryable
+    "no vector" marker. Recall still serves it via the other RRF signals (BM25,
+    relevance, confidence, bloom); the ``memory-embedding-backfill`` reflection
+    re-embeds it later once the provider is healthy.
+
+Pinned-popoto constraint:
+    The parent ``on_save`` raises *before* writing the ``.npy`` file or queuing the
+    embedding ``hset`` (verified against popoto>=1.7.1, see
+    ``popoto/fields/embedding_field.py`` on_save ordering). So a caught error leaves
+    no partial embedding artifact and no half-written pipeline op. If a future popoto
+    reorders on_save to write the ``.npy`` before raising, a caught error could leave
+    an orphan ``.npy`` — that case is already self-healing via the existing
+    ``embedding-orphan-sweep`` reflection.
+
+Warning throttle (issue #1904 critique C2):
+    A per-save ``logger.warning`` would flood under the exact trigger condition
+    (Ollama saturation → every concurrent save degrades). Instead a module-level
+    monotonic-timestamp throttle emits at most one warning per throttle window, while
+    a counter increments on every degraded save. The count is surfaced in the
+    ``memory-embedding-backfill`` reflection summary so silent-embedding-loss stays
+    observable without log spam.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+
+from popoto.fields.embedding_field import EmbeddingField
+
+logger = logging.getLogger(__name__)
+
+# Emit at most one degradation warning per this many seconds. The counter below
+# still increments on every degraded save — the throttle only gates the log line
+# so a saturated Ollama does not flood the logs (critique C2).
+_WARN_THROTTLE_SECONDS = 60.0
+
+# Module-level degradation state. Guarded by a lock because concurrent worker
+# saves can degrade simultaneously (Ollama saturation is inherently concurrent).
+_state_lock = threading.Lock()
+_degradation_count = 0
+# Sentinel so the very first degradation always warns regardless of process
+# uptime: -inf means (now - _last_warn_monotonic) always exceeds the window.
+_last_warn_monotonic = float("-inf")
+
+
+def _record_degradation(model_instance, exc: Exception) -> None:
+    """Count a degraded save and emit a throttled warning.
+
+    Always increments the counter; emits ``logger.warning`` only when the throttle
+    window has elapsed since the last warning. Never raises — a broken logger must
+    not turn a graceful degradation back into a dropped record.
+    """
+    global _degradation_count, _last_warn_monotonic
+    try:
+        model_name = getattr(type(model_instance), "__name__", "Model")
+        now = time.monotonic()
+        should_warn = False
+        with _state_lock:
+            _degradation_count += 1
+            count = _degradation_count
+            if now - _last_warn_monotonic >= _WARN_THROTTLE_SECONDS:
+                _last_warn_monotonic = now
+                should_warn = True
+        if should_warn:
+            logger.warning(
+                "Embedding degraded — persisting %s without vector "
+                "(%d degraded saves since start): %s",
+                model_name,
+                count,
+                exc,
+            )
+    except Exception:
+        # Never let observability crash the writer path.
+        pass
+
+
+def get_degradation_count() -> int:
+    """Return the number of degraded (vectorless) saves observed this process.
+
+    Surfaced in the ``memory-embedding-backfill`` reflection summary so operators
+    can see in-process silent-embedding-loss even when the warning is throttled.
+    """
+    with _state_lock:
+        return _degradation_count
+
+
+def reset_degradation_state() -> None:
+    """Reset the degradation counter and throttle clock (test hook)."""
+    global _degradation_count, _last_warn_monotonic
+    with _state_lock:
+        _degradation_count = 0
+        _last_warn_monotonic = float("-inf")
+
+
+class GracefulEmbeddingField(EmbeddingField):
+    """An ``EmbeddingField`` that persists the record when embedding fails.
+
+    Storage-identical to ``EmbeddingField`` (same dimension-count int / ``None``,
+    same ``.npy`` layout) — swapping it into a model requires no data migration.
+    The only behavioral change is that a provider/write failure during ``on_save``
+    no longer aborts the enclosing ``Model.save``: the record commits without a
+    vector instead of vanishing.
+    """
+
+    @classmethod
+    def on_save(cls, model_instance, field_name, field_value, pipeline=None, **kwargs):
+        """Delegate to the parent, catching provider/write failures.
+
+        Catches ``RuntimeError`` (provider timeout/unreachable/HTTP error, re-raised
+        by the parent), ``ValueError`` (dimension mismatch), and ``OSError`` (atomic
+        ``.npy`` write failure). On any of these the queued main record ``hset``
+        stays intact, so returning the pipeline lets ``Model.save`` commit the record
+        without a vector. Any other exception type still propagates — a genuinely
+        un-persistable error should reach ``Memory.safe_save``'s backstop.
+        """
+        try:
+            return super().on_save(
+                model_instance, field_name, field_value, pipeline=pipeline, **kwargs
+            )
+        except (RuntimeError, ValueError, OSError) as exc:
+            _record_degradation(model_instance, exc)
+            return pipeline if pipeline else None

--- a/models/memory.py
+++ b/models/memory.py
@@ -1,7 +1,7 @@
 """Memory model for the subconscious memory system.
 
 Level 3 popoto model with DecayingSortedField, ConfidenceField, BM25Field,
-EmbeddingField, WriteFilterMixin, AccessTrackerMixin, and ExistenceFilter.
+GracefulEmbeddingField, WriteFilterMixin, AccessTrackerMixin, and ExistenceFilter.
 
 Memories are partitioned by project_key for per-project isolation.
 Human messages are saved with high importance (InteractionWeight.HUMAN = 6.0),
@@ -9,8 +9,11 @@ agent observations with low importance (InteractionWeight.AGENT = 1.0).
 
 The ExistenceFilter fingerprints on content, enabling O(1) bloom checks
 for topic relevance before running the BM25 + RRF fusion retrieval.
-EmbeddingField generates vector embeddings via OllamaProvider on save,
-enabling semantic similarity as a fourth RRF signal in retrieval.
+GracefulEmbeddingField generates vector embeddings via OllamaProvider on save,
+enabling semantic similarity as a fourth RRF signal in retrieval. When the
+provider is slow or unreachable it persists the record without a vector
+(issue #1904) instead of dropping it; the memory-embedding-backfill reflection
+re-embeds it once the provider is healthy.
 """
 
 import logging
@@ -27,7 +30,6 @@ from popoto import (  # noqa: E402
     ConfidenceField,
     DecayingSortedField,
     DictField,
-    EmbeddingField,
     FloatField,
     KeyField,
     Model,
@@ -35,6 +37,8 @@ from popoto import (  # noqa: E402
     WriteFilterMixin,
 )
 from popoto.fields.existence_filter import ExistenceFilter  # noqa: E402
+
+from models.graceful_embedding_field import GracefulEmbeddingField  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -151,7 +155,7 @@ class Memory(WriteFilterMixin, AccessTrackerMixin, Model):
     )
     confidence = ConfidenceField(initial_confidence=0.5)
     bm25 = BM25Field(source="content")
-    embedding = EmbeddingField(source="content")
+    embedding = GracefulEmbeddingField(source="content")
 
     # Opt-in marker for EmbeddingField.garbage_collect (Popoto >= 1.6.0).
     # Without this attribute, garbage_collect is a no-op for safety —

--- a/reflections/memory/memory_embedding_backfill.py
+++ b/reflections/memory/memory_embedding_backfill.py
@@ -1,0 +1,186 @@
+"""reflections/memory/memory_embedding_backfill.py — Re-embed vectorless Memory records.
+
+What it does: Finds active ``Memory`` records saved without an embedding vector
+    (``embedding`` falsy — the degradation marker written by
+    ``GracefulEmbeddingField`` when Ollama was unreachable, issue #1904) and, when
+    the provider is healthy again, re-embeds them so they regain the fourth RRF
+    (semantic-similarity) recall signal. Skips ``superseded_by`` records. Caps each
+    run at ``MAX_BACKFILL_PER_RUN`` so a long-outage backlog does not re-saturate
+    Ollama the moment it recovers.
+
+Re-embed mechanism (issue #1904 critique C1):
+    Re-embed is a PARTIAL save: ``memory.save(update_fields=["embedding"])``. A bare
+    ``memory.save()`` re-runs ``on_save`` for every field, which re-stamps
+    ``Memory.relevance`` (a ``DecayingSortedField`` with ``auto_now=True``) to "now"
+    — silently un-decaying stale memories and corrupting recall ranking. The partial
+    path runs ``on_save`` only for ``embedding``, leaving ``relevance`` (and all
+    other indexes) untouched. ``update_fields=[]`` is a no-op early-return in popoto,
+    so the list MUST be ``["embedding"]``.
+
+Cadence: 86400s (daily)
+Failure modes:
+    - Memory import fails -> return {"status": "error", ...}
+    - Memory.query.all() raises -> return {"status": "error", ...}
+    - Provider import/is_available() raises -> treated as unavailable, dry-run-safe
+    - Individual memory.save() raises -> logged, skipped, run continues
+Related reflections:
+    - embedding-orphan-sweep reaps orphan .npy files; this reflection is the inverse,
+      healing records that HAVE no .npy. Both are daily/low-priority and key on live
+      records, so the orphan sweep's 5-minute mtime guard covers this write window.
+Apply gating: dry-run by default (counts vectorless records, saves nothing). Set
+    MEMORY_EMBEDDING_BACKFILL_APPLY=true (also "1"/"yes") to enable re-embedding.
+    Even in apply mode, nothing is re-saved unless OllamaEmbeddingProvider is
+    available — a still-down provider short-circuits to a reported skip, never a
+    re-save storm.
+See also: config/reflections.yaml (declaration), models/graceful_embedding_field.py,
+    docs/features/subconscious-memory.md
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("reflections.memory_management")
+
+# Maximum re-embeds per run. After a long Ollama outage many records will be
+# vectorless; re-embedding them all at once would re-saturate the provider we
+# just confirmed is healthy. 500/day drains a realistic backlog over a few days
+# while keeping each run's load bounded (plan Open Question 1).
+MAX_BACKFILL_PER_RUN = 500
+
+
+async def run() -> dict:
+    """Re-embed active Memory records that were persisted without a vector.
+
+    Default: dry-run — reports how many vectorless records exist and how many
+    would be re-embedded, saving nothing. Set MEMORY_EMBEDDING_BACKFILL_APPLY=true
+    to enable re-embedding; even then, re-saves only happen when the embedding
+    provider is available. Re-embed is a partial save on ``embedding`` alone so
+    the record's ``relevance`` decay index is not re-stamped (critique C1).
+    """
+    import os
+
+    apply_mode = os.environ.get("MEMORY_EMBEDDING_BACKFILL_APPLY", "false").lower() in (
+        "true",
+        "1",
+        "yes",
+    )
+    dry_run = not apply_mode
+    mode_str = "DRY RUN" if dry_run else "APPLIED"
+
+    findings: list[str] = []
+
+    try:
+        from models.memory import Memory
+    except Exception as e:
+        logger.warning("memory-embedding-backfill: Memory import failed: %s", e)
+        return {
+            "status": "error",
+            "findings": [],
+            "summary": f"memory-embedding-backfill error: Memory import failed: {e}",
+        }
+
+    try:
+        all_memories = Memory.query.all()
+    except Exception as e:
+        logger.warning("memory-embedding-backfill: could not query memories: %s", e)
+        return {
+            "status": "error",
+            "findings": [],
+            "summary": f"memory-embedding-backfill error: query failed: {e}",
+        }
+
+    # Collect active records with a falsy embedding (None / 0 dimension count).
+    # Matches the KnowledgeDocument #1876 convention: a positive int means embedded,
+    # None/0 means "no vector — needs re-embed".
+    vectorless: list = []
+    for memory in all_memories:
+        if getattr(memory, "superseded_by", ""):
+            continue
+        if not getattr(memory, "embedding", None):
+            vectorless.append(memory)
+
+    vectorless_count = len(vectorless)
+    findings.append(f"{vectorless_count} active records without an embedding vector.")
+
+    # In-process degradation counter (throttled-warning companion, critique C2) —
+    # surfaced so silent-embedding-loss is observable even when the field's warning
+    # was throttled. Best-effort; never abort the reflection over an import.
+    degraded_since_start = 0
+    try:
+        from models.graceful_embedding_field import get_degradation_count
+
+        degraded_since_start = get_degradation_count()
+    except Exception:
+        pass
+    if degraded_since_start:
+        findings.append(
+            f"{degraded_since_start} degraded (vectorless) saves observed in-process "
+            "since worker start."
+        )
+
+    # Provider availability gate — a still-down provider means every re-embed would
+    # fail the same way, so short-circuit rather than churn.
+    provider_available = False
+    try:
+        from agent.embedding_provider import OllamaEmbeddingProvider
+
+        provider_available = OllamaEmbeddingProvider().is_available()
+    except Exception as e:
+        logger.warning("memory-embedding-backfill: provider probe failed: %s", e)
+        provider_available = False
+
+    reembedded = 0
+
+    if dry_run:
+        would = min(vectorless_count, MAX_BACKFILL_PER_RUN)
+        findings.append(
+            f"[DRY RUN] Would re-embed up to {would} records (cap={MAX_BACKFILL_PER_RUN}, "
+            f"provider_available={provider_available}). "
+            "Set MEMORY_EMBEDDING_BACKFILL_APPLY=true to enable."
+        )
+    elif not provider_available:
+        findings.append(
+            "[APPLY] Embedding provider unavailable — skipped all re-embeds "
+            "(no re-save storm). Will heal on a later run once the provider is up."
+        )
+    else:
+        for memory in vectorless[:MAX_BACKFILL_PER_RUN]:
+            try:
+                # Partial save on `embedding` ONLY — never a bare save() (critique C1):
+                # a bare save re-stamps the relevance DecayingSortedField (auto_now),
+                # un-decaying stale memories. update_fields=[] is a no-op, so the list
+                # must be ["embedding"].
+                memory.save(update_fields=["embedding"])
+                # Count it as healed only if a vector actually landed.
+                if getattr(memory, "embedding", None):
+                    reembedded += 1
+            except Exception as e:
+                logger.warning(
+                    "memory-embedding-backfill: re-embed failed for %s: %s",
+                    getattr(memory, "memory_id", "?"),
+                    e,
+                )
+        findings.append(
+            f"Re-embedded {reembedded} of {vectorless_count} vectorless records "
+            f"(cap={MAX_BACKFILL_PER_RUN})."
+        )
+
+    # Best-effort metric — never crash the reflection.
+    try:
+        from analytics.collector import record_metric
+
+        record_metric(
+            "memory.embedding_backfill_reembedded",
+            float(reembedded),
+            dimensions={"mode": mode_str.lower().replace(" ", "_")},
+        )
+    except Exception as e:
+        logger.debug("memory-embedding-backfill: metric emission failed: %s", e)
+
+    summary = (
+        f"memory-embedding-backfill [{mode_str}]: {vectorless_count} vectorless, "
+        f"{reembedded} re-embedded, {degraded_since_start} degraded-saves-since-start"
+    )
+    logger.info(summary)
+    return {"status": "ok", "findings": findings, "summary": summary}

--- a/reflections/memory_management.py
+++ b/reflections/memory_management.py
@@ -12,10 +12,12 @@ New code should import the reflection's ``run`` from its per-reflection module.
 
 from reflections.memory.embedding_orphan_sweep import run as run_embedding_orphan_sweep
 from reflections.memory.memory_decay_prune import run as run_memory_decay_prune
+from reflections.memory.memory_embedding_backfill import run as run_memory_embedding_backfill
 from reflections.memory.memory_quality_audit import run as run_memory_quality_audit
 
 __all__ = [
     "run_memory_decay_prune",
     "run_memory_quality_audit",
     "run_embedding_orphan_sweep",
+    "run_memory_embedding_backfill",
 ]

--- a/tests/unit/test_graceful_embedding_field.py
+++ b/tests/unit/test_graceful_embedding_field.py
@@ -1,0 +1,202 @@
+"""Unit tests for models/graceful_embedding_field.py (issue #1904).
+
+The GracefulEmbeddingField must let a Memory record persist when the embedding
+provider fails, instead of the failure aborting the whole save (the original bug:
+a provider timeout dropped the entire record — content, BM25 index, relevance —
+not merely the vector).
+
+These tests use real Redis (a plan prerequisite). They stub the global embedding
+provider to raise, then assert the record still persists with embedding=None, is
+retrievable via the other RRF signals, and that the degradation is observable
+(counter increments; a warning is emitted, throttled).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+@pytest.fixture
+def restore_provider():
+    """Save/restore the global embedding provider and reset degradation state."""
+    from popoto.fields.embedding_field import get_default_provider, set_default_provider
+
+    from models.graceful_embedding_field import reset_degradation_state
+
+    original = get_default_provider()
+    reset_degradation_state()
+    try:
+        yield set_default_provider
+    finally:
+        set_default_provider(original)
+        reset_degradation_state()
+
+
+class _RaisingProvider:
+    """Provider stub that mimics an Ollama timeout on every embed call."""
+
+    dimensions = 768
+
+    def embed(self, texts, input_type="document"):
+        raise RuntimeError("stubbed Ollama timeout after 5.0s")
+
+    def is_available(self):
+        return False
+
+
+class _WrongDimProvider:
+    """Provider stub that returns a vector of the wrong dimensionality."""
+
+    dimensions = 768
+
+    def embed(self, texts, input_type="document"):
+        return [[0.1, 0.2, 0.3]]  # 3 dims, provider claims 768 -> parent raises ValueError
+
+    def is_available(self):
+        return True
+
+
+def _make_memory(content: str, project_key: str):
+    from models.memory import Memory
+
+    return Memory(
+        agent_id="test-agent",
+        project_key=project_key,
+        content=content,
+        importance=6.0,  # human — well above the WriteFilter floor
+        source="human",
+    )
+
+
+class TestGracefulEmbeddingField:
+    def test_provider_timeout_persists_record_without_vector(self, restore_provider):
+        """A RuntimeError from the provider must NOT drop the record (core AC1)."""
+        from models.memory import Memory
+
+        restore_provider(_RaisingProvider())
+
+        project_key = f"test-graceful-{uuid.uuid4().hex[:8]}"
+        content = f"Graceful degradation content {uuid.uuid4().hex}"
+        m = _make_memory(content, project_key)
+
+        result = m.save()
+        assert result is not False  # not filtered out
+
+        # The record persisted and is queryable.
+        found = Memory.query.filter(project_key=project_key)
+        assert len(found) == 1, "record must persist despite embedding failure"
+        assert found[0].content == content
+        # No vector: embedding stays at the field default (None / falsy).
+        assert not found[0].embedding, "embedding must be absent on the degraded path"
+
+        for r in found:
+            r.delete()
+
+    def test_dimension_mismatch_persists_record(self, restore_provider):
+        """A ValueError (dimension mismatch) is also caught — record persists."""
+        from models.memory import Memory
+
+        restore_provider(_WrongDimProvider())
+
+        project_key = f"test-graceful-dim-{uuid.uuid4().hex[:8]}"
+        m = _make_memory(f"dim mismatch {uuid.uuid4().hex}", project_key)
+        m.save()
+
+        found = Memory.query.filter(project_key=project_key)
+        assert len(found) == 1
+        assert not found[0].embedding
+        for r in found:
+            r.delete()
+
+    def test_oserror_from_write_is_caught(self, restore_provider, monkeypatch):
+        """A post-embed OSError (atomic .npy write) must not drop the record either.
+
+        Broadening the catch to include OSError is critique-mandated: an OSError
+        during the parent's atomic write would otherwise still abort the save.
+        """
+        from popoto.fields.embedding_field import EmbeddingField
+
+        from models.graceful_embedding_field import (
+            GracefulEmbeddingField,
+            get_degradation_count,
+        )
+
+        def _raise_oserror(cls, *args, **kwargs):
+            raise OSError("disk full during .npy write")
+
+        monkeypatch.setattr(EmbeddingField, "on_save", classmethod(_raise_oserror))
+
+        sentinel_pipeline = object()
+        returned = GracefulEmbeddingField.on_save(
+            model_instance=_make_memory("os error", "test-os"),
+            field_name="embedding",
+            field_value=None,
+            pipeline=sentinel_pipeline,
+        )
+        # The pipeline (carrying the queued main hset) is returned intact, so
+        # Model.save can still commit the record.
+        assert returned is sentinel_pipeline
+        assert get_degradation_count() == 1
+
+    def test_missing_embedding_record_is_retrievable(self, restore_provider):
+        """AC2 regression: a record with no vector is still recalled via BM25/relevance."""
+        from agent.memory_retrieval import retrieve_memories
+        from models.memory import Memory
+
+        restore_provider(_RaisingProvider())
+
+        project_key = f"test-recall-{uuid.uuid4().hex[:8]}"
+        token = f"quokka{uuid.uuid4().hex[:8]}"
+        content = f"The {token} deployment finished successfully"
+        _make_memory(content, project_key).save()
+
+        results = retrieve_memories(token, project_key, limit=10)
+        assert any(getattr(r, "content", "") == content for r in results), (
+            "vectorless record must be retrievable via non-embedding RRF signals"
+        )
+
+        for r in Memory.query.filter(project_key=project_key):
+            r.delete()
+
+    def test_degradation_counter_increments_per_failed_save(self, restore_provider):
+        """The counter increments on every degraded save (surfaced in the backfill summary)."""
+        from models.graceful_embedding_field import get_degradation_count
+
+        restore_provider(_RaisingProvider())
+
+        from models.memory import Memory
+
+        project_key = f"test-counter-{uuid.uuid4().hex[:8]}"
+        assert get_degradation_count() == 0
+        _make_memory(f"c1 {uuid.uuid4().hex}", project_key).save()
+        _make_memory(f"c2 {uuid.uuid4().hex}", project_key).save()
+        assert get_degradation_count() == 2
+
+        for r in Memory.query.filter(project_key=project_key):
+            r.delete()
+
+    def test_warning_emitted_but_throttled(self, restore_provider, caplog):
+        """First degradation warns; a rapid second is throttled (no log flood, critique C2)."""
+        import logging
+
+        restore_provider(_RaisingProvider())
+
+        from models.memory import Memory
+
+        project_key = f"test-warn-{uuid.uuid4().hex[:8]}"
+        with caplog.at_level(logging.WARNING, logger="models.graceful_embedding_field"):
+            _make_memory(f"w1 {uuid.uuid4().hex}", project_key).save()
+            _make_memory(f"w2 {uuid.uuid4().hex}", project_key).save()
+
+        degrade_warnings = [
+            rec
+            for rec in caplog.records
+            if rec.name == "models.graceful_embedding_field"
+            and "Embedding degraded" in rec.getMessage()
+        ]
+        assert len(degrade_warnings) == 1, "warning must fire once and then be throttled"
+
+        for r in Memory.query.filter(project_key=project_key):
+            r.delete()

--- a/tests/unit/test_reflections_memory.py
+++ b/tests/unit/test_reflections_memory.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1563,3 +1564,281 @@ class TestEmbeddingOrphanSweep:
         # with the error noted in findings.
         assert result["status"] == "ok"
         assert any("garbage_collect error" in f for f in result["findings"])
+
+
+# ============================================================
+# run_memory_embedding_backfill (issue #1904)
+# ============================================================
+
+
+def _mock_vectorless(memory_id: str):
+    """A MagicMock Memory with no embedding whose save() sets one (mimics re-embed)."""
+    m = MagicMock()
+    m.memory_id = memory_id
+    m.embedding = None
+    m.superseded_by = ""
+
+    def _save(update_fields=None):
+        # Real re-embed would set the dimension count via on_save.
+        m.embedding = 768
+
+    m.save.side_effect = _save
+    return m
+
+
+class TestMemoryEmbeddingBackfill:
+    """Tests for run_memory_embedding_backfill() — the re-embed backfill (#1904)."""
+
+    def test_dry_run_default_saves_nothing(self):
+        from reflections.memory.memory_embedding_backfill import run
+
+        candidate = _mock_vectorless("mem_bf_1")
+        with (
+            patch("models.memory.Memory") as mock_model,
+            patch.dict("os.environ", {"MEMORY_EMBEDDING_BACKFILL_APPLY": "false"}, clear=False),
+        ):
+            mock_model.query.all.return_value = [candidate]
+            result = run_async(run())
+
+        assert_valid_result(result)
+        assert "DRY RUN" in result["summary"]
+        candidate.save.assert_not_called()
+
+    def test_apply_mode_reembeds_via_partial_save_only(self):
+        """C1: re-embed MUST be a partial save on ['embedding'] so relevance is not re-stamped."""
+        from reflections.memory.memory_embedding_backfill import run
+
+        candidate = _mock_vectorless("mem_bf_2")
+        provider = MagicMock()
+        provider.is_available.return_value = True
+
+        with (
+            patch("models.memory.Memory") as mock_model,
+            patch("agent.embedding_provider.OllamaEmbeddingProvider", return_value=provider),
+            patch.dict("os.environ", {"MEMORY_EMBEDDING_BACKFILL_APPLY": "true"}, clear=False),
+        ):
+            mock_model.query.all.return_value = [candidate]
+            result = run_async(run())
+
+        assert_valid_result(result)
+        assert "APPLIED" in result["summary"]
+        # The load-bearing critique-C1 assertion: exactly update_fields=["embedding"],
+        # never a bare save() (which would re-stamp the relevance DecayingSortedField).
+        candidate.save.assert_called_once_with(update_fields=["embedding"])
+
+    def test_apply_mode_provider_unavailable_skips(self):
+        """Apply mode with a down provider must NOT re-save (no re-embed storm)."""
+        from reflections.memory.memory_embedding_backfill import run
+
+        candidate = _mock_vectorless("mem_bf_3")
+        provider = MagicMock()
+        provider.is_available.return_value = False
+
+        with (
+            patch("models.memory.Memory") as mock_model,
+            patch("agent.embedding_provider.OllamaEmbeddingProvider", return_value=provider),
+            patch.dict("os.environ", {"MEMORY_EMBEDDING_BACKFILL_APPLY": "true"}, clear=False),
+        ):
+            mock_model.query.all.return_value = [candidate]
+            result = run_async(run())
+
+        assert_valid_result(result)
+        candidate.save.assert_not_called()
+        assert any("unavailable" in f.lower() for f in result["findings"])
+
+    def test_empty_queryset(self):
+        from reflections.memory.memory_embedding_backfill import run
+
+        with patch("models.memory.Memory") as mock_model:
+            mock_model.query.all.return_value = []
+            result = run_async(run())
+
+        assert_valid_result(result)
+        assert "0 vectorless" in result["summary"]
+
+    def test_skips_records_with_existing_embedding(self):
+        from reflections.memory.memory_embedding_backfill import run
+
+        embedded = MagicMock()
+        embedded.memory_id = "mem_has_vec"
+        embedded.embedding = 768  # already embedded
+        embedded.superseded_by = ""
+        provider = MagicMock()
+        provider.is_available.return_value = True
+
+        with (
+            patch("models.memory.Memory") as mock_model,
+            patch("agent.embedding_provider.OllamaEmbeddingProvider", return_value=provider),
+            patch.dict("os.environ", {"MEMORY_EMBEDDING_BACKFILL_APPLY": "true"}, clear=False),
+        ):
+            mock_model.query.all.return_value = [embedded]
+            result = run_async(run())
+
+        assert_valid_result(result)
+        embedded.save.assert_not_called()
+        assert "0 vectorless" in result["summary"]
+
+    def test_skips_superseded_records(self):
+        from reflections.memory.memory_embedding_backfill import run
+
+        superseded = MagicMock()
+        superseded.memory_id = "mem_superseded"
+        superseded.embedding = None
+        superseded.superseded_by = "mem_replacement"
+        provider = MagicMock()
+        provider.is_available.return_value = True
+
+        with (
+            patch("models.memory.Memory") as mock_model,
+            patch("agent.embedding_provider.OllamaEmbeddingProvider", return_value=provider),
+            patch.dict("os.environ", {"MEMORY_EMBEDDING_BACKFILL_APPLY": "true"}, clear=False),
+        ):
+            mock_model.query.all.return_value = [superseded]
+            result = run_async(run())
+
+        assert_valid_result(result)
+        superseded.save.assert_not_called()
+        assert "0 vectorless" in result["summary"]
+
+    def test_caps_reembeds_per_run(self):
+        from reflections.memory.memory_embedding_backfill import MAX_BACKFILL_PER_RUN, run
+
+        candidates = [_mock_vectorless(f"mem_cap_{i}") for i in range(MAX_BACKFILL_PER_RUN + 25)]
+        provider = MagicMock()
+        provider.is_available.return_value = True
+
+        with (
+            patch("models.memory.Memory") as mock_model,
+            patch("agent.embedding_provider.OllamaEmbeddingProvider", return_value=provider),
+            patch.dict("os.environ", {"MEMORY_EMBEDDING_BACKFILL_APPLY": "true"}, clear=False),
+        ):
+            mock_model.query.all.return_value = candidates
+            result = run_async(run())
+
+        assert_valid_result(result)
+        saved = sum(1 for c in candidates if c.save.called)
+        assert saved == MAX_BACKFILL_PER_RUN
+
+    def test_per_record_save_failure_does_not_abort_run(self):
+        from reflections.memory.memory_embedding_backfill import run
+
+        good = _mock_vectorless("mem_good")
+        bad = _mock_vectorless("mem_bad")
+        bad.save.side_effect = RuntimeError("synthetic re-embed failure")
+        provider = MagicMock()
+        provider.is_available.return_value = True
+
+        with (
+            patch("models.memory.Memory") as mock_model,
+            patch("agent.embedding_provider.OllamaEmbeddingProvider", return_value=provider),
+            patch.dict("os.environ", {"MEMORY_EMBEDDING_BACKFILL_APPLY": "true"}, clear=False),
+        ):
+            mock_model.query.all.return_value = [bad, good]
+            result = run_async(run())
+
+        assert_valid_result(result)  # status ok despite one failure
+        good.save.assert_called_once()
+
+    def test_query_failure_returns_error(self):
+        from reflections.memory.memory_embedding_backfill import run
+
+        with patch("models.memory.Memory") as mock_model:
+            mock_model.query.all.side_effect = RuntimeError("redis down")
+            result = run_async(run())
+
+        assert result["status"] == "error"
+
+    def test_reembed_preserves_relevance_decay(self):
+        """C1 (real Redis): re-embed must NOT bump the relevance sorted-set score.
+
+        A bare memory.save() re-runs relevance's auto_now on_save, jumping the
+        stored timestamp to 'now' and un-decaying the record. The partial
+        save(update_fields=['embedding']) must leave the sorted-set score exactly
+        as it was.
+        """
+        from popoto.fields.embedding_field import get_default_provider, set_default_provider
+        from popoto.redis_db import POPOTO_REDIS_DB
+
+        from models.memory import Memory
+
+        class _RaisingProvider:
+            dimensions = 8
+
+            def embed(self, texts, input_type="document"):
+                raise RuntimeError("stubbed timeout")
+
+            def is_available(self):
+                return False
+
+        class _WorkingProvider:
+            dimensions = 8
+
+            def embed(self, texts, input_type="document"):
+                return [[0.1] * 8 for _ in texts]
+
+            def is_available(self):
+                return True
+
+        original = get_default_provider()
+        project_key = f"test-bf-relevance-{uuid.uuid4().hex[:8]}"
+        m = None
+        try:
+            # 1. Persist a real record WITHOUT a vector (raising provider).
+            set_default_provider(_RaisingProvider())
+            m = Memory(
+                agent_id="test-agent",
+                project_key=project_key,
+                content=f"relevance preservation {uuid.uuid4().hex}",
+                importance=6.0,
+                source="human",
+            )
+            m.save()
+            assert not m.embedding
+
+            # Resolve the relevance sorted-set key + member and pin an OLD score,
+            # so a regression (bare save) would visibly overwrite it to ~now.
+            rel_field_cls = type(Memory._meta.fields["relevance"])
+            ss_key = rel_field_cls.get_partitioned_sortedset_db_key(m, "relevance").redis_key
+            member = m.db_key.redis_key
+            old_score = 1_000_000.0  # a fixed, unmistakably old timestamp
+            POPOTO_REDIS_DB.zadd(ss_key, {member: old_score})
+
+            # 2. Run the backfill in apply mode against ONLY this record, with a
+            #    working provider so the re-embed actually lands a vector.
+            set_default_provider(_WorkingProvider())
+            provider_probe = MagicMock()
+            provider_probe.is_available.return_value = True
+
+            from reflections.memory.memory_embedding_backfill import run
+
+            with (
+                patch("models.memory.Memory") as mock_model,
+                patch(
+                    "agent.embedding_provider.OllamaEmbeddingProvider",
+                    return_value=provider_probe,
+                ),
+                patch.dict(
+                    "os.environ",
+                    {"MEMORY_EMBEDDING_BACKFILL_APPLY": "true"},
+                    clear=False,
+                ),
+            ):
+                mock_model.query.all.return_value = [m]
+                result = run_async(run())
+
+            assert_valid_result(result)
+            # The re-embed landed a vector...
+            assert m.embedding, "re-embed should have set a vector"
+            # ...but the relevance decay score is byte-for-byte preserved (C1).
+            new_score = POPOTO_REDIS_DB.zscore(ss_key, member)
+            assert new_score == old_score, (
+                f"relevance score changed on re-embed (bare-save regression): "
+                f"{old_score} -> {new_score}"
+            )
+        finally:
+            set_default_provider(original)
+            if m is not None:
+                try:
+                    m.delete()
+                except Exception:
+                    pass


### PR DESCRIPTION
## Problem

When the embedding provider times out (observed: live Ollama under concurrent load, 5s read timeout), popoto's `EmbeddingField.on_save` re-raises as `RuntimeError` *before* the main record `hset` commits. `Memory.safe_save()` swallows it (`Memory save failed (non-fatal)`) and the record is lost entirely — not saved without an embedding. Human Telegram messages ingested as memories (importance=6.0) could vanish silently whenever Ollama is slow or down.

Closes #1904.

## Fix

**`GracefulEmbeddingField`** (`models/graceful_embedding_field.py`) subclasses popoto's `EmbeddingField` and wraps `on_save` in a try/except. On `RuntimeError` (provider timeout/unreachable/HTTP error), `ValueError` (dimension mismatch), or `OSError` (atomic `.npy` write failure) it records the degradation and returns the pipeline unchanged, so the already-queued main record `hset` commits normally. The record persists with `embedding = None` — the queryable "no vector" marker. Recall still serves it via the other RRF signals (BM25, relevance, confidence, bloom). `models/memory.py` swaps `EmbeddingField` → `GracefulEmbeddingField` (storage-identical, no migration).

**Observability (critique C2):** a module-level monotonic throttle emits at most one warning per 60s under saturation, while a counter increments on every degraded save. `get_degradation_count()` surfaces the count in the backfill reflection summary so silent-loss stays visible without log spam.

**`memory-embedding-backfill` reflection** (`reflections/memory/memory_embedding_backfill.py`) heals degraded records: it re-embeds vectorless active Memory records once the provider is healthy again, via a **partial save on `embedding` alone** (`save(update_fields=["embedding"])`) so the `relevance` `DecayingSortedField` (auto_now) is not re-stamped and stale memories are not silently un-decayed (critique C1). Dry-run by default (`MEMORY_EMBEDDING_BACKFILL_APPLY=true` to enable), capped at 500/run, and short-circuits when the provider is still down (no re-save storm).

## Acceptance criteria

- [x] Embedding timeout/failure during save still persists the record — asserted in `tests/unit/test_graceful_embedding_field.py` with a provider stub that raises
- [x] Recall paths tolerate records with missing embeddings (existing RRF fusion already treats `embedding=None` as one absent signal)
- [x] Re-embed backfill mechanism for records saved without vectors (`memory-embedding-backfill` reflection)

## Tests

`tests/unit/test_graceful_embedding_field.py` + `tests/unit/test_memory_model.py`: **25 passed**. `tests/unit/test_reflections_memory.py`: **55 passed**. Reflection registry loads `memory-embedding-backfill [new]`. Ruff format + check clean.

## Deployment note

The reflection is declared in `config/reflections.yaml`, which is **gitignored / vault-synced by design** (not part of this diff). The `memory-embedding-backfill` YAML entry must be propagated to each machine's vault-synced config via the update-system convention — see the docs stage.