### PR TITLE
Auto-prune empty rule-19 husk directories in skills audit --fix

### DIFF
--- a/.claude/skills-global/do-skills-audit/SKILL.md
+++ b/.claude/skills-global/do-skills-audit/SKILL.md
@@ -62,8 +62,11 @@ probe step deferring to the per-repo skill-context seam. Project-only skills are
 **Rot & hygiene (15–16, 18–20):** referenced paths resolve (skills decay as repos move —
 missing own assets FAIL, other unresolvable paths WARN) · no tracked junk files
 (README/CHANGELOG/pyc) · every bundled sub-file is referenced by SKILL.md or a sibling ·
-no husk directories (a dir without SKILL.md is a move leftover) · user-level
-`~/.claude/skills/` copies trace back to a repo source and haven't diverged.
+no husk directories (a dir without SKILL.md is a move leftover — `--fix` auto-prunes ones
+that are truly empty, i.e. contain nothing but `__pycache__`/`.DS_Store`; husks holding real
+orphaned files are never auto-deleted and keep failing rule 19 until a human deletes or
+restores them) · user-level `~/.claude/skills/` copies trace back to a repo source and
+haven't diverged.
 
 The audit must pass on itself: `--skill do-skills-audit` is the first check of a fleet run.
 
@@ -86,6 +89,10 @@ standards. Runs by default; `--no-sync` skips, `--apply` updates our template/va
 
 - `--fix` corrects trivial mechanical findings only. Merges, splits, and description
   rewrites change trigger behavior — always human-reviewed, never auto-applied.
+- One-command husk cleanup: `python .claude/skills-global/do-skills-audit/scripts/audit_skills.py --fix --no-sync`
+  prunes every empty rule-19 husk directory across both skill roots. Anything it leaves
+  behind still failing rule 19 holds real orphaned files — inspect and delete or restore
+  manually.
 - FAIL findings that persist across 2 consecutive runs are auto-filed as GitHub issues by
   the `skills-audit` reflection (daily).
 - Accepted `--arch` dispositions become one GitHub issue each, carrying the

--- a/.claude/skills-global/do-skills-audit/scripts/audit_skills.py
+++ b/.claude/skills-global/do-skills-audit/scripts/audit_skills.py
@@ -6,6 +6,12 @@ Runs 20 deterministic validation rules over every skills root the repo has
 user-level orphans, and optionally syncs against Anthropic's latest published
 best practices.
 
+With `--fix`, husk directories that are empty except for build artifacts
+(`__pycache__`, `.DS_Store`) are also auto-pruned before rule 19 runs, so a
+freshly-pruned husk doesn't reappear as a FAIL in the same invocation. Husks
+that still contain real files are left untouched for a human delete-or-restore
+decision.
+
 JSON contract (consumed by reflections/audits/skills_audit.py):
   {"summary": {"total_skills": N, "pass": N, "warn": N, "fail": N,
                "description_total_chars": N, "description_budget": N},
@@ -21,6 +27,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import re
 import shutil
 import subprocess
@@ -29,6 +36,8 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -652,6 +661,54 @@ def rule_19_husk_directories(skills_dir: Path, dir_label: str) -> list[Finding]:
     return findings
 
 
+def _is_empty_husk(d: Path) -> bool:
+    """Same "empty" predicate as rule_19_husk_directories: a directory with no
+    SKILL.md and no files besides build artifacts (__pycache__, .DS_Store)."""
+    contents = [
+        p
+        for p in d.rglob("*")
+        if p.is_file() and "__pycache__" not in p.parts and p.name != ".DS_Store"
+    ]
+    return not contents
+
+
+def prune_husk_directories(skills_dir: Path, dir_label: str) -> list[str]:
+    """Auto-fix companion to rule_19_husk_directories: actually remove husks.
+
+    Uses the identical "empty" predicate as rule 19 — a directory lacking
+    SKILL.md whose only contents (if any) are build artifacts (__pycache__,
+    .DS_Store). Only those genuinely-empty husks are pruned; a husk that still
+    holds real orphaned files is left on disk for a human delete-or-restore
+    decision (and will still surface as a rule 19 FAIL).
+
+    Returns a list of human-readable descriptions of husks actually removed,
+    suitable for reporting as "Fixed: ..." findings. Never raises — a failed
+    rmtree on one husk is logged and skipped so the sweep continues.
+    """
+    removed: list[str] = []
+    if not skills_dir.is_dir():
+        return removed
+    for d in sorted(skills_dir.iterdir()):
+        if not d.is_dir() or d.name.startswith(("_", ".")):
+            continue
+        if (d / "SKILL.md").exists():
+            continue
+        if not _is_empty_husk(d):
+            continue
+        # TOCTOU guard: re-check immediately before the irreversible delete —
+        # a file could have landed in the directory since the scan above.
+        if not _is_empty_husk(d):
+            continue
+        resolved = d.resolve()
+        logger.warning("Pruning empty husk directory: %s", resolved)
+        try:
+            shutil.rmtree(d)
+        except OSError:
+            continue
+        removed.append(f"Removed husk directory: {d.name} ({dir_label})")
+    return removed
+
+
 def rule_20_user_level_orphans(repo_skill_dirs: dict[str, Path]) -> list[Finding]:
     """Skills in ~/.claude/skills/ should be hardlink-synced from a repo source.
     A user-level skill with no repo source is an orphan (stale leftover or
@@ -981,6 +1038,10 @@ def main() -> int:
         report.add(rule_14_fleet_description_budget(all_descriptions))
         for f in rule_17_near_duplicate_descriptions(all_descriptions):
             report.add(f)
+        if args.fix:
+            for label, root in roots:
+                for desc in prune_husk_directories(root, label):
+                    report.add(Finding(root.name, 0, "PASS", f"Fixed: {desc}", dir=label))
         for label, root in roots:
             for f in rule_19_husk_directories(root, label):
                 report.add(f)

--- a/docs/features/do-skills-audit.md
+++ b/docs/features/do-skills-audit.md
@@ -42,7 +42,7 @@ Main validation script with 20 deterministic rules:
 | 16 | No git-tracked junk files in skill dirs (README/CHANGELOG/pyc/__pycache__) | WARN |
 | 17 | No near-duplicate trigger surfaces (word-overlap Jaccard >= 0.5) | WARN |
 | 18 | Every bundled sub-file referenced by SKILL.md or a sibling file | WARN |
-| 19 | No husk directories (a dir in a skills root without SKILL.md is a move leftover) | FAIL |
+| 19 | No husk directories (a dir in a skills root without SKILL.md is a move leftover) — `--fix` auto-prunes ones that are empty except for build artifacts; husks with real orphaned files are left for a human to delete or restore | FAIL |
 | 20 | User-level `~/.claude/skills/` copies trace to a repo source and haven't diverged | WARN |
 
 Rules 10, 14, 17, 19, 20 are fleet-level and run only on full-fleet invocations (not
@@ -101,7 +101,8 @@ python .claude/skills-global/do-skills-audit/scripts/audit_skills.py --no-sync
 # Audit single skill
 python .claude/skills-global/do-skills-audit/scripts/audit_skills.py --skill telegram
 
-# Auto-fix trivial issues (missing name, whitespace, untracked build artifacts)
+# Auto-fix trivial issues (missing name, whitespace, untracked build artifacts,
+# and empty rule-19 husk directories)
 python .claude/skills-global/do-skills-audit/scripts/audit_skills.py --fix
 
 # JSON output for CI / reflections

--- a/docs/plans/skills-audit-husk-autoprune.md
+++ b/docs/plans/skills-audit-husk-autoprune.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: docs_complete
 type: bug
 appetite: Small
 owner: Valor Engels

--- a/docs/plans/skills-audit-husk-autoprune.md
+++ b/docs/plans/skills-audit-husk-autoprune.md
@@ -1,11 +1,12 @@
 ---
-status: Planning
+status: Ready
 type: bug
 appetite: Small
 owner: Valor Engels
 created: 2026-07-05
 tracking: https://github.com/tomcounsell/ai/issues/1902
 last_comment_id:
+revision_applied: true
 ---
 
 # skills-audit: auto-prune rule-19 "empty" husk directories under --fix
@@ -38,13 +39,19 @@ issue #1902.
   remediation. An operator must `rm -rf` it by hand.
 
 **Desired outcome:**
-`audit_skills.py --fix` prunes rule-19 "empty" husk directories automatically —
-directories with no `SKILL.md` whose only remaining contents are `__pycache__` /
-`.DS_Store`. Husks that still contain real orphaned files are left untouched and
-still surface as FAIL findings, preserving the human delete-or-restore decision
-for anything that might hold real work. A one-command operator remediation
-(`audit_skills.py --fix --no-sync`) is documented so a future husk is cleared in
-one step instead of a manual `rm -rf`.
+An **operator** who sees a recurring rule-19 husk FAIL can clear it with one
+command — `audit_skills.py --fix --no-sync` — instead of a manual `rm -rf`. Under
+`--fix`, the audit prunes rule-19 "empty" husk directories: directories with no
+`SKILL.md` whose only remaining contents are `__pycache__` / `.DS_Store`. Husks
+that still contain real orphaned files are left untouched and still surface as FAIL
+findings, preserving the human delete-or-restore decision for anything that might
+hold real work.
+
+This is deliberately **operator-invoked remediation, not reflection-automated
+deletion.** The nightly `skills-audit` reflection stays strictly read-only — it
+files issues and never mutates a target repo (see Rabbit Holes). The deletion path
+runs only when a human explicitly passes `--fix`, so the irreversible `rmtree` is
+always a conscious one-command action, never a background job.
 
 ## Freshness Check
 
@@ -144,8 +151,12 @@ No prerequisites — this work has no external dependencies. Standard library on
 - **`prune_husk_directories(skills_dir, dir_label)` helper**: mirrors rule 19's
   "empty" test (contents after excluding `__pycache__`/`.DS_Store`). For each
   directory with no `SKILL.md`, not `_`/`.`-prefixed, and no real contents, it
-  removes the directory (`shutil.rmtree`) and returns a description string. Husks
-  WITH real contents are left in place and returned as skipped (not pruned).
+  removes the directory (`shutil.rmtree`) and returns a description string. The
+  return value contains ONLY the husks actually removed — there is no "skipped"
+  concept. Husks WITH real contents are left untouched and simply are not returned;
+  rule 19 already surfaces them as a FAIL (`delete or restore`), so `main()`'s
+  `Fixed:` reporting stays truthful (a real-content husk stays a rule-19 FAIL and
+  is never reported as fixed).
 - **Fleet-level `--fix` wiring**: in `main()`, when `args.fix` is set and this is a
   full-fleet run (`not args.skill`), call the prune helper for each root BEFORE
   rule-19 detection, and record each prune as a `Fixed:` PASS finding (consistent
@@ -167,10 +178,19 @@ report FAIL → exit 0 when no FAILs remain.
   (`p.is_file() and "__pycache__" not in p.parts and p.name != ".DS_Store"`) so
   "empty" means the same thing in both places — a husk is pruned only if rule 19
   would have labelled it `(empty)`.
-- Safety guardrails on the delete path:
+- Safety guardrails on the delete path (`shutil.rmtree` on an untracked husk is
+  irreversible — git cannot restore an untracked directory, so these guards are
+  the only safety net):
   - Only operate on direct children of a known skills root (`skills_dir.iterdir()`).
   - Skip `SKILL.md`-bearing dirs, `_`-prefixed and `.`-prefixed dirs (matches rule 19 exemptions).
   - Skip any dir with real (non-junk) contents — those stay as FAIL for human decision.
+  - **TOCTOU guard**: re-evaluate the exact "empty except build artifacts" predicate
+    *immediately* before calling `shutil.rmtree` (not only at the top of the loop).
+    A file could land in the directory between the initial scan and the delete; the
+    re-check ensures a husk that gained real contents in that window is NOT deleted.
+  - **WARN log before deletion**: emit a `logging.warning(...)` (or the module's
+    equivalent) recording the resolved absolute path being removed, so the operator
+    has an audit trail of exactly what `--fix` deleted.
   - Wrap `shutil.rmtree` in `try/except OSError` and continue (never crash the audit).
 - In `main()` (`:984`), before the `rule_19_husk_directories` loop, add:
   `if args.fix: for label, root in roots: for desc in prune_husk_directories(root, label): report.add(Finding(<dir>, 0, "PASS", f"Fixed: {desc}", dir=label))`.
@@ -191,7 +211,11 @@ report FAIL → exit 0 when no FAILs remain.
 - [ ] This is not agent-output processing — no silent-loop risk.
 
 ### Error State Rendering
-- [ ] A husk that CANNOT be pruned (real orphaned file present) must still render as a rule-19 FAIL in both human and JSON output — assert the FAIL survives a `--fix` run. This is the key "don't silently swallow real orphans" guarantee.
+- [ ] A husk that is left in place (real orphaned file present) must still render as a rule-19 FAIL in both human and JSON output — assert the FAIL survives a `--fix` run. This is the key "don't silently swallow real orphans" guarantee, and it is exactly the gating test named in the Verification table.
+
+### TOCTOU / Irreversible-Delete Safety
+- [ ] `shutil.rmtree` on an untracked husk cannot be undone by git. Assert a WARN log records the absolute path before each deletion (audit trail).
+- [ ] Assert the predicate is re-checked immediately before `rmtree`: a directory empty at initial scan but holding a real file at delete time is left in place (not removed).
 
 ## Test Impact
 
@@ -279,9 +303,11 @@ home for the operator remediation note.
 
 ## Success Criteria
 
-- [ ] `prune_husk_directories` exists and removes a husk whose only contents are `__pycache__`/`.DS_Store`.
-- [ ] A husk with a real orphaned file is NOT pruned and still reports rule-19 FAIL after a `--fix` run.
-- [ ] `audit_skills.py --fix` on a fleet containing an empty husk removes it and reports a `Fixed:` PASS.
+- [ ] `prune_husk_directories` exists, removes a husk whose only contents are `__pycache__`/`.DS_Store`, and returns ONLY the descriptions of husks actually removed (no "skipped" entries).
+- [ ] **Gating test**: a husk with one real orphaned file is NOT pruned and still reports a rule-19 FAIL after a `--fix` run; a junk-only husk IS pruned and emits no rule-19 FAIL. (This is the authoritative safety criterion.)
+- [ ] `audit_skills.py --fix` on a fleet containing an empty husk removes it and reports a `Fixed:` PASS — and reports NO `Fixed:` for a real-content husk.
+- [ ] A WARN log line records the resolved absolute path of every directory removed by `--fix`.
+- [ ] The TOCTOU guard re-checks the "empty except build artifacts" predicate immediately before `rmtree`; a test proves a directory that gains a real file between scan and delete is not removed.
 - [ ] Rule 19 has unit-test coverage (empty husk, real-content husk, `SKILL.md` dir, `_`-prefixed dir).
 - [ ] The JSON contract is unchanged (reflection still parses findings; `rule == 19` FAILs only for real-content husks).
 - [ ] Tests pass (`/do-test`)
@@ -340,7 +366,8 @@ Tier 1 core agents as listed in the template. No specialist tier needed.
 - **Parallel**: false
 - Import `prune_husk_directories` in the test module.
 - `TestRule19HuskDirectories`: husk with only `__pycache__` → FAIL `(empty)`; husk with a real file → FAIL `(contains: ...)`; dir with `SKILL.md` → no finding; `_`-prefixed dir → exempt; non-existent dir → `[]`.
-- `TestPruneHuskDirectories`: empty husk (only junk) is removed and reported; real-content husk is preserved; `SKILL.md` dir untouched; `_`-prefixed dir untouched; OSError on one husk does not abort the sweep.
+- `TestPruneHuskDirectories`: empty husk (only junk) is removed and reported (return list contains only removed husks); real-content husk is preserved and is NOT in the return list; `SKILL.md` dir untouched; `_`-prefixed dir untouched; OSError on one husk does not abort the sweep; a WARN log records each removed absolute path (assert via `caplog`); TOCTOU — a directory that is empty at scan time but gains a real file before `rmtree` is NOT removed (simulate by patching the predicate/`iterdir` or dropping a file via a side-effect).
+- **Gating test** (`test_prune_real_content_husk_preserved_and_fails`, `test_prune_junk_only_husk_removed_no_fail`): run the full `--fix` path over a temp fleet; assert the real-content husk still exists on disk AND a `rule == 19` FAIL is present in the findings, while the junk-only husk is gone AND no `rule == 19` FAIL is present. Keyed so `pytest -k "prune and (real_content or junk_only)"` selects them (matches the Verification table row).
 
 ### 3. Update skill documentation
 - **Task ID**: document-remediation
@@ -370,17 +397,37 @@ Tier 1 core agents as listed in the template. No specialist tier needed.
 | Prune helper exists | `grep -c "def prune_husk_directories" .claude/skills-global/do-skills-audit/scripts/audit_skills.py` | output contains 1 |
 | Wired under --fix | `grep -n "prune_husk_directories" .claude/skills-global/do-skills-audit/scripts/audit_skills.py` | output contains main |
 | No live rule-19 FAILs | `python .claude/skills-global/do-skills-audit/scripts/audit_skills.py --json --no-sync \| python3 -c "import json,sys; d=json.load(sys.stdin); print(sum(1 for f in d['findings'] if f.get('rule')==19 and f.get('severity')=='FAIL'))"` | output contains 0 |
-| Anti-criterion: real-content husks not force-deleted | `grep -n "rmtree" .claude/skills-global/do-skills-audit/scripts/audit_skills.py \| grep -c "prune_husk"` | match count == 0 |
+| **Gating test: real-content husk preserved AND still FAILs; junk-only husk pruned AND no FAIL** | `pytest tests/unit/test_skills_audit.py -q -k "prune and (real_content or junk_only)"` | exit code 0 |
 
-<!-- Anti-criterion note: the last row is a proxy guard — it asserts `rmtree` in the
-     prune path is not applied unconditionally on the same line as the function name
-     (i.e. deletion is guarded by the empty-contents check, not a blanket sweep). The
-     authoritative guarantee is the unit test asserting a real-content husk survives
-     `--fix`; this grep is the cheap mechanical companion. -->
+<!-- Anti-criterion note: the "don't silently delete real orphans" guarantee is
+     asserted by a real behavioral unit test, not a proxy grep. The gating test
+     exercises both halves of the contract end-to-end through a `--fix` run:
+       (a) a husk containing one real orphan file → after `--fix`, the directory
+           still exists AND a rule-19 FAIL is still emitted for it;
+       (b) a husk whose only contents are `__pycache__` / `.DS_Store` → after
+           `--fix`, the directory is removed AND no rule-19 FAIL is emitted.
+     A tautological grep such as `grep rmtree | grep -c prune_husk == 0` can never
+     fail (rmtree and the helper name will simply not co-occur on one line), so it
+     is deliberately excluded — behavior, not source-text shape, is the criterion. -->
 
 ## Critique Results
 
-<!-- Populated by /do-plan-critique (war room). Leave empty until critique is run. -->
+**Verdict (2026-07-05):** READY TO BUILD (WITH CONCERNS). Three concerns raised;
+all folded into this plan in the revision pass:
+
+- **C1 — truthful `Fixed:` reporting.** `prune_husk_directories()` now returns ONLY
+  the descriptions of husks actually removed (rmtree'd); the "skipped" concept is
+  dropped entirely. Real-content husks are left untouched and surface as a rule-19
+  FAIL rather than being reported as fixed. (Solution → Key Elements; Success Criteria.)
+- **C2 — remove tautological verification.** The `grep rmtree | grep -c prune_husk == 0`
+  row (which can never fail) is deleted. It is replaced by a real gating unit test as
+  the acceptance criterion: real-content husk survives `--fix` and still FAILs;
+  junk-only husk is removed with no FAIL. (Verification table; Success Criteria; Step 2.)
+- **C3 — irreversible `rmtree` safety.** Added (a) a WARN log of each pruned absolute
+  path, (b) a TOCTOU guard re-checking the empty-except-build-artifacts predicate
+  immediately before `rmtree`, and (c) reframed Problem/Desired-Outcome as
+  operator-invoked `--fix` remediation (the reflection stays strictly read-only).
+  (Technical Approach; Desired outcome; Failure Path Test Strategy.)
 
 ---
 

--- a/docs/plans/skills-audit-husk-autoprune.md
+++ b/docs/plans/skills-audit-husk-autoprune.md
@@ -1,0 +1,390 @@
+---
+status: Planning
+type: bug
+appetite: Small
+owner: Valor Engels
+created: 2026-07-05
+tracking: https://github.com/tomcounsell/ai/issues/1902
+last_comment_id:
+---
+
+# skills-audit: auto-prune rule-19 "empty" husk directories under --fix
+
+## Problem
+
+When `do-skills-audit` moved from `.claude/skills/` to `.claude/skills-global/`
+(commit `19937d75`), git left the old `.claude/skills/do-skills-audit/` directory
+behind in every working tree. Git does not track empty directories, so after the
+tracked files moved, all that remained on disk was build junk (`scripts/__pycache__`).
+Rule 19 (`rule_19_husk_directories`) excludes `__pycache__`/`.DS_Store` from its
+contents list, so it saw an otherwise-empty directory and reported:
+
+> Husk directory: no SKILL.md (empty) — delete or restore
+
+The `skills-audit` reflection observed this FAIL on 2 consecutive runs and filed
+issue #1902.
+
+**Current behavior:**
+- Rule 19 **detects** husks (`audit_skills.py:625`) and runs at the fleet level
+  (`audit_skills.py:985`), but nothing ever prunes them.
+- `apply_fixes()` (`audit_skills.py:705`) — the only auto-fix path — runs
+  **per-skill** for directories that HAVE a `SKILL.md` (called at `:795`). A husk
+  has no `SKILL.md`, so `--fix` never touches it.
+- The reflection invokes the audit with `--no-sync --json` only
+  (`reflections/audits/skills_audit.py:262`) — no `--fix` — so the reflection is
+  detection-only by design.
+- Net result: an "empty" husk (contents are only ignored build artifacts) recurs
+  indefinitely on any machine where the stale directory lingers, with no automated
+  remediation. An operator must `rm -rf` it by hand.
+
+**Desired outcome:**
+`audit_skills.py --fix` prunes rule-19 "empty" husk directories automatically —
+directories with no `SKILL.md` whose only remaining contents are `__pycache__` /
+`.DS_Store`. Husks that still contain real orphaned files are left untouched and
+still surface as FAIL findings, preserving the human delete-or-restore decision
+for anything that might hold real work. A one-command operator remediation
+(`audit_skills.py --fix --no-sync`) is documented so a future husk is cleared in
+one step instead of a manual `rm -rf`.
+
+## Freshness Check
+
+**Baseline commit:** `63e43118578bdca30ee0d653737549f28e26f981`
+**Issue filed at:** 2026-07-05T04:47:25Z
+**Disposition:** Minor drift (acute symptom already resolved; prevention work stands)
+
+**File:line references re-verified (against `.worktrees/sdlc-1902`):**
+- `.claude/skills-global/do-skills-audit/scripts/audit_skills.py:625` — `rule_19_husk_directories` detects husks, exempts `__pycache__`/`.DS_Store` from contents — still holds.
+- `.claude/skills-global/do-skills-audit/scripts/audit_skills.py:705` / `:795` — `apply_fixes()` runs per-skill only, on dirs with a `SKILL.md` — still holds.
+- `.claude/skills-global/do-skills-audit/scripts/audit_skills.py:984-988` — fleet-level rules (rule 19, rule 20) run but no prune step exists — still holds.
+- `reflections/audits/skills_audit.py:262` — reflection invokes `[python, audit_script, "--no-sync", "--json"]`, no `--fix` — still holds.
+
+**Cited sibling issues/PRs re-checked:**
+- #1901 — sibling rule-19 FAIL for the `logs` skill, handled by a parallel agent. OUT OF SCOPE here; do not touch the `logs` skill or its files.
+- #1883 (commit `56124515`) — renovated the 20-rule lint that introduced rule 19. Merged; provides the code this plan extends.
+
+**Commits on main since issue was filed (touching referenced files):** none.
+`git log --since=2026-07-05T04:47:00Z -- audit_skills.py test_skills_audit.py` returns nothing.
+
+**Active plans in `docs/plans/` overlapping this area:**
+- `skills-architecture-audit.md` (#1883, status Planning) — a broad architecture audit
+  of the whole skill fleet (dispositions, model tiers). It does NOT touch husk
+  auto-pruning. No scope conflict; this narrow tooling fix can land independently.
+
+**Notes:** The acute husk is already gone from the primary checkout —
+`audit_skills.py --json --no-sync` currently reports zero rule-19 findings. A pure
+cleanup PR would be empty, so this plan is the durable prevention fix per the
+project's "prevention over cleanup, guards at creation sites" principle.
+
+## Prior Art
+
+- **Issue #1901**: `skills-audit FAIL: logs (rule 19)` — same rule-19 husk failure
+  for a different directory. Handled by a parallel agent. Confirms the husk class is
+  systemic, not a one-off — a durable auto-prune is the right lever.
+- **PR #1883** (`56124515`): "Renovate do-skills-audit: 20-rule lint..." — introduced
+  rule 19 and the `apply_fixes()` auto-fix path. This plan extends both.
+- **Commit `19937d75`**: the `skills/` → `skills-global/` split that created the husk.
+  Establishes root cause: git's inability to track empty-dir removal on a move.
+
+No prior attempt to auto-prune husks exists — this is the first fix for that gap.
+
+## Research
+
+No relevant external findings — proceeding with codebase context and training data.
+This is a purely internal Python tooling change (standard library `shutil`/`pathlib`
+only); no external libraries, APIs, or ecosystem patterns involved.
+
+## Data Flow
+
+1. **Entry point**: operator or reflection runs `audit_skills.py` (optionally `--fix`).
+2. **Per-skill audit** (`audit_skill`, `:779`): for dirs WITH a `SKILL.md`, `--fix`
+   calls `apply_fixes()` which already strips `__pycache__`/`.DS_Store` inside skill dirs.
+3. **Fleet-level rules** (`main`, `:978-988`): husk detection (`rule_19_husk_directories`)
+   and orphan detection run once across each root. **This is where the new prune step lands.**
+4. **Output**: findings serialized to human/JSON; the reflection reads JSON `findings`
+   with `rule == 19` to drive its FAIL-streak counter and issue filing.
+
+The fix adds a prune step at stage 3, gated on `--fix`, that runs BEFORE rule-19
+detection so a pruned husk no longer appears as a FAIL in the same run.
+
+## Why Previous Fixes Failed
+
+| Prior Fix | What It Did | Why It Failed / Was Incomplete |
+|-----------|-------------|-------------------------------|
+| PR #1883 | Added rule 19 husk detection + per-skill `apply_fixes()` | Detection surfaces the husk but `--fix` only remediates dirs that have a `SKILL.md`; a husk (no `SKILL.md`) is never pruned, so the FAIL recurs every run. |
+
+**Root cause pattern:** the auto-fix path is keyed to skills (things with a
+`SKILL.md`), but husks are by definition non-skills. Remediation must live at the
+fleet level alongside husk detection, not inside the per-skill loop.
+
+## Appetite
+
+**Size:** Small
+
+**Team:** Solo dev + validator
+
+**Interactions:**
+- PM check-ins: 0
+- Review rounds: 1
+
+Single-file behavior addition plus focused unit tests. The bottleneck is careful
+safety review of the delete path, not coding volume.
+
+## Prerequisites
+
+No prerequisites — this work has no external dependencies. Standard library only.
+
+| Requirement | Check Command | Purpose |
+|-------------|---------------|---------|
+| Python venv | `python -c "import shutil, pathlib, yaml"` | Audit script runs |
+
+## Solution
+
+### Key Elements
+
+- **`prune_husk_directories(skills_dir, dir_label)` helper**: mirrors rule 19's
+  "empty" test (contents after excluding `__pycache__`/`.DS_Store`). For each
+  directory with no `SKILL.md`, not `_`/`.`-prefixed, and no real contents, it
+  removes the directory (`shutil.rmtree`) and returns a description string. Husks
+  WITH real contents are left in place and returned as skipped (not pruned).
+- **Fleet-level `--fix` wiring**: in `main()`, when `args.fix` is set and this is a
+  full-fleet run (`not args.skill`), call the prune helper for each root BEFORE
+  rule-19 detection, and record each prune as a `Fixed:` PASS finding (consistent
+  with how `apply_fixes` reports).
+- **Test coverage**: new tests for rule 19 (currently ZERO coverage) and for the
+  prune helper — empty husk pruned, real-content husk preserved, `SKILL.md` dir
+  ignored, `_`-prefixed dir exempt.
+
+### Flow
+
+Operator runs `audit_skills.py --fix` → fleet-level prune sweep removes empty
+husks → rule 19 detection runs on what remains → only real-content husks (if any)
+report FAIL → exit 0 when no FAILs remain.
+
+### Technical Approach
+
+- Add `prune_husk_directories(skills_dir: Path, dir_label: str) -> list[str]` next
+  to `rule_19_husk_directories`. Reuse the exact contents predicate rule 19 uses
+  (`p.is_file() and "__pycache__" not in p.parts and p.name != ".DS_Store"`) so
+  "empty" means the same thing in both places — a husk is pruned only if rule 19
+  would have labelled it `(empty)`.
+- Safety guardrails on the delete path:
+  - Only operate on direct children of a known skills root (`skills_dir.iterdir()`).
+  - Skip `SKILL.md`-bearing dirs, `_`-prefixed and `.`-prefixed dirs (matches rule 19 exemptions).
+  - Skip any dir with real (non-junk) contents — those stay as FAIL for human decision.
+  - Wrap `shutil.rmtree` in `try/except OSError` and continue (never crash the audit).
+- In `main()` (`:984`), before the `rule_19_husk_directories` loop, add:
+  `if args.fix: for label, root in roots: for desc in prune_husk_directories(root, label): report.add(Finding(<dir>, 0, "PASS", f"Fixed: {desc}", dir=label))`.
+  Running prune first means a freshly-pruned husk does not also emit a FAIL in the
+  same run (self-consistent single-pass remediation).
+- No JSON-contract change: pruned dirs appear as existing `Fixed:` PASS findings
+  (rule 0), which the reflection already ignores (it only counts `rule == 19` FAILs).
+
+## Failure Path Test Strategy
+
+### Exception Handling Coverage
+- [ ] The new `prune_husk_directories` wraps `shutil.rmtree` in `try/except OSError: continue`. Add a test that a permission/OS error on one husk does not abort the sweep or crash the audit (assert the audit still returns and other husks are still processed).
+- [ ] No pre-existing `except Exception: pass` blocks are introduced.
+
+### Empty/Invalid Input Handling
+- [ ] Test `prune_husk_directories` against a non-existent / non-dir `skills_dir` — must return `[]` and not raise (mirror rule 19's `if not skills_dir.is_dir(): return`).
+- [ ] Test an empty skills root (no children) returns `[]`.
+- [ ] This is not agent-output processing — no silent-loop risk.
+
+### Error State Rendering
+- [ ] A husk that CANNOT be pruned (real orphaned file present) must still render as a rule-19 FAIL in both human and JSON output — assert the FAIL survives a `--fix` run. This is the key "don't silently swallow real orphans" guarantee.
+
+## Test Impact
+
+- [ ] `tests/unit/test_skills_audit.py` — UPDATE: add `from audit_skills import prune_husk_directories` to the import block and two new test classes (`TestRule19HuskDirectories`, `TestPruneHuskDirectories`). Rule 19 currently has zero coverage, so nothing existing breaks; the change is purely additive.
+
+No other existing tests are affected — the change adds a new fleet-level function
+and one `--fix`-gated call site; it does not modify any existing rule, the JSON
+contract, or `apply_fixes()` behavior, so `test_skills_audit_reflection.py`,
+`test_skills_audit.py`'s existing cases, and `test_reflections_package.py` remain valid.
+
+## Rabbit Holes
+
+- **Do NOT touch the `logs` skill or issue #1901's files** — that sibling rule-19
+  husk is owned by a parallel agent; overlap causes merge conflicts.
+- **Do NOT make the reflection invoke `--fix`.** The reflection is deliberately
+  read-only (it files issues, does not mutate repos). Auto-mutating a target repo
+  from a nightly reflection is a much larger blast radius and a separate decision.
+  Ship `--fix`-gated pruning + documented one-command remediation instead.
+- **Do NOT generalize to auto-deleting husks with real contents.** Real orphaned
+  files may hold un-migrated work; the human delete-or-restore decision must remain.
+- **Do NOT add a `.gitignore` husk-prevention mechanism** or try to make git track
+  empty-dir removal — that is a losing battle and out of scope.
+
+## Risks
+
+### Risk 1: Over-eager deletion removes a directory that held real work
+**Impact:** Silent loss of un-migrated orphaned files.
+**Mitigation:** Prune only when the exact rule-19 "empty" predicate holds (no files
+after excluding `__pycache__`/`.DS_Store`). Real-content husks are never deleted —
+they still FAIL. A dedicated test asserts a real-content husk survives `--fix`.
+
+### Risk 2: Pruning a dir outside the intended skills roots
+**Impact:** Accidental deletion elsewhere on disk.
+**Mitigation:** Iterate only direct children of a known root (`SKILLS_DIR` /
+`PROJECT_SKILLS_DIR` via `roots`); honor rule 19's `_`/`.`-prefix exemptions;
+never recurse into arbitrary paths for deletion (only `shutil.rmtree` the child dir).
+
+## Race Conditions
+
+No race conditions identified — `audit_skills.py` is a synchronous, single-threaded
+CLI. Fleet-level pruning runs once, sequentially, after per-skill audits complete.
+No shared mutable state, no async, no cross-process coordination.
+
+## No-Gos (Out of Scope)
+
+- [SEPARATE-SLUG #1901] Rule-19 husk failure for the `logs` skill — filed as its
+  own issue and handled by a parallel agent. Touching it here would collide.
+- [DESTRUCTIVE] Auto-pruning husks that contain real (non-junk) orphaned files —
+  deliberately excluded; the human delete-or-restore decision is the safety
+  mechanism for anything that might hold real work. Anti-criterion asserted in
+  `## Verification`.
+
+## Update System
+
+No update system changes required — this is a change to an existing script
+(`.claude/skills-global/do-skills-audit/scripts/audit_skills.py`) already synced to
+every machine by `scripts/update/hardlinks.py` (`sync_claude_dirs()` hardlinks the
+whole `do-skills-audit` dir). No new dependencies, config files, or migration steps.
+The next `/update` propagates the fixed script automatically.
+
+## Agent Integration
+
+No agent integration required — this is a change to an existing audit script and its
+nightly reflection consumer. No new CLI entry point, no `pyproject.toml [project.scripts]`
+change, no `.mcp.json`/MCP surface, and no bridge import. The reflection
+(`reflections/audits/skills_audit.py`) already invokes the script and reads its JSON
+contract, which is unchanged.
+
+## Documentation
+
+### Feature Documentation
+- [ ] Update `.claude/skills-global/do-skills-audit/SKILL.md` (or its `references/`)
+      to document the new `--fix` husk-pruning behavior and the one-command operator
+      remediation: `python .claude/skills-global/do-skills-audit/scripts/audit_skills.py --fix --no-sync`.
+- [ ] Update the module docstring in `audit_skills.py` to note that `--fix` now
+      prunes rule-19 "empty" husks (the docstring currently lists detection only).
+
+### Inline Documentation
+- [ ] Docstring on `prune_husk_directories` explaining the "empty" predicate and the
+      real-content preservation guarantee.
+
+No `docs/features/` entry is warranted — this is a maintenance behavior on an existing
+internal lint, not a user-facing feature. The skill's own SKILL.md is the correct
+home for the operator remediation note.
+
+## Success Criteria
+
+- [ ] `prune_husk_directories` exists and removes a husk whose only contents are `__pycache__`/`.DS_Store`.
+- [ ] A husk with a real orphaned file is NOT pruned and still reports rule-19 FAIL after a `--fix` run.
+- [ ] `audit_skills.py --fix` on a fleet containing an empty husk removes it and reports a `Fixed:` PASS.
+- [ ] Rule 19 has unit-test coverage (empty husk, real-content husk, `SKILL.md` dir, `_`-prefixed dir).
+- [ ] The JSON contract is unchanged (reflection still parses findings; `rule == 19` FAILs only for real-content husks).
+- [ ] Tests pass (`/do-test`)
+- [ ] Documentation updated (`/do-docs`)
+- [ ] `grep` confirms `main()` references `prune_husk_directories` under an `args.fix` guard.
+
+## Team Orchestration
+
+The lead agent orchestrates; it does not build directly.
+
+### Team Members
+
+- **Builder (audit-prune)**
+  - Name: `audit-prune-builder`
+  - Role: Implement `prune_husk_directories`, wire it into `main()` under `--fix`, update docstrings/SKILL.md.
+  - Agent Type: builder
+  - Domain: none (stdlib file ops)
+  - Resume: true
+
+- **Builder (tests)**
+  - Name: `audit-test-builder`
+  - Role: Add `TestRule19HuskDirectories` + `TestPruneHuskDirectories` to `tests/unit/test_skills_audit.py`.
+  - Agent Type: test-engineer
+  - Resume: true
+
+- **Validator (audit-prune)**
+  - Name: `audit-prune-validator`
+  - Role: Verify success criteria, run the audit against a synthetic husk fixture, confirm real-content husk survives.
+  - Agent Type: validator
+  - Resume: true
+
+### Available Agent Types
+
+Tier 1 core agents as listed in the template. No specialist tier needed.
+
+## Step by Step Tasks
+
+### 1. Implement husk pruning
+- **Task ID**: build-prune
+- **Depends On**: none
+- **Validates**: tests/unit/test_skills_audit.py (create new cases)
+- **Assigned To**: audit-prune-builder
+- **Agent Type**: builder
+- **Parallel**: false
+- Add `prune_husk_directories(skills_dir: Path, dir_label: str) -> list[str]` in `audit_skills.py`, adjacent to `rule_19_husk_directories`. Reuse the exact rule-19 contents predicate; delete only when no real contents remain; wrap `shutil.rmtree` in `try/except OSError: continue`; return description strings for pruned dirs.
+- In `main()` (before the `rule_19_husk_directories` loop at `:984`, gated on `if args.fix and not args.skill`), call the helper per root and add each result as a `Finding(<dir>, 0, "PASS", f"Fixed: {desc}", dir=label)`.
+- Update the `audit_skills.py` module docstring to state `--fix` prunes rule-19 empty husks.
+- Add a docstring to `prune_husk_directories`.
+
+### 2. Add test coverage
+- **Task ID**: build-tests
+- **Depends On**: build-prune
+- **Validates**: tests/unit/test_skills_audit.py
+- **Assigned To**: audit-test-builder
+- **Agent Type**: test-engineer
+- **Parallel**: false
+- Import `prune_husk_directories` in the test module.
+- `TestRule19HuskDirectories`: husk with only `__pycache__` → FAIL `(empty)`; husk with a real file → FAIL `(contains: ...)`; dir with `SKILL.md` → no finding; `_`-prefixed dir → exempt; non-existent dir → `[]`.
+- `TestPruneHuskDirectories`: empty husk (only junk) is removed and reported; real-content husk is preserved; `SKILL.md` dir untouched; `_`-prefixed dir untouched; OSError on one husk does not abort the sweep.
+
+### 3. Update skill documentation
+- **Task ID**: document-remediation
+- **Depends On**: build-prune
+- **Assigned To**: audit-prune-builder
+- **Agent Type**: documentarian
+- **Parallel**: false
+- Document the `--fix` pruning behavior and the one-command operator remediation in `do-skills-audit`'s SKILL.md / references.
+
+### 4. Final validation
+- **Task ID**: validate-all
+- **Depends On**: build-prune, build-tests, document-remediation
+- **Assigned To**: audit-prune-validator
+- **Agent Type**: validator
+- **Parallel**: false
+- Run `pytest tests/unit/test_skills_audit.py -q`.
+- Build a synthetic fixture: an empty husk (only `__pycache__`) plus a real-content husk under a temp skills root; assert `--fix` prunes the former, keeps the latter, and the latter still FAILs.
+- Confirm all success criteria met; generate report.
+
+## Verification
+
+| Check | Command | Expected |
+|-------|---------|----------|
+| Audit unit tests pass | `pytest tests/unit/test_skills_audit.py -q` | exit code 0 |
+| Lint clean | `python -m ruff check .claude/skills-global/do-skills-audit/scripts/audit_skills.py` | exit code 0 |
+| Format clean | `python -m ruff format --check .claude/skills-global/do-skills-audit/scripts/audit_skills.py tests/unit/test_skills_audit.py` | exit code 0 |
+| Prune helper exists | `grep -c "def prune_husk_directories" .claude/skills-global/do-skills-audit/scripts/audit_skills.py` | output contains 1 |
+| Wired under --fix | `grep -n "prune_husk_directories" .claude/skills-global/do-skills-audit/scripts/audit_skills.py` | output contains main |
+| No live rule-19 FAILs | `python .claude/skills-global/do-skills-audit/scripts/audit_skills.py --json --no-sync \| python3 -c "import json,sys; d=json.load(sys.stdin); print(sum(1 for f in d['findings'] if f.get('rule')==19 and f.get('severity')=='FAIL'))"` | output contains 0 |
+| Anti-criterion: real-content husks not force-deleted | `grep -n "rmtree" .claude/skills-global/do-skills-audit/scripts/audit_skills.py \| grep -c "prune_husk"` | match count == 0 |
+
+<!-- Anti-criterion note: the last row is a proxy guard — it asserts `rmtree` in the
+     prune path is not applied unconditionally on the same line as the function name
+     (i.e. deletion is guarded by the empty-contents check, not a blanket sweep). The
+     authoritative guarantee is the unit test asserting a real-content husk survives
+     `--fix`; this grep is the cheap mechanical companion. -->
+
+## Critique Results
+
+<!-- Populated by /do-plan-critique (war room). Leave empty until critique is run. -->
+
+---
+
+## Open Questions
+
+None. Scope is well-bounded: the root cause, prevention surface (exact file:line),
+and sibling-issue boundary (#1901) are all verified in code. Ready for critique.

--- a/tests/README.md
+++ b/tests/README.md
@@ -125,7 +125,7 @@ tests/
 | Level | File | Tests | Description |
 |-------|------|------:|-------------|
 | unit | `test_observer.py` | 81 | Stage detection, routing, progression |
-| unit | `test_skills_audit.py` | 53 | Skills directory structure validation |
+| unit | `test_skills_audit.py` | 77 | Skills directory structure validation, rule-19 husk detection, `--fix` auto-prune |
 | unit | `test_pipeline_integrity.py` | 31 | Pipeline state preservation |
 | unit | `test_post_tool_use_sdlc.py` | 31 | Post-tool SDLC hook execution |
 | unit | `test_pipeline_graph.py` | 29 | Pipeline graph visualization |

--- a/tests/unit/test_skills_audit.py
+++ b/tests/unit/test_skills_audit.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+import shutil
 import sys
 from pathlib import Path
 
@@ -25,6 +27,7 @@ from audit_skills import (  # noqa: E402
     audit_skill,
     discover_skills,
     parse_frontmatter,
+    prune_husk_directories,
     rule_01_line_count,
     rule_02_frontmatter_exists,
     rule_03_name_field,
@@ -38,6 +41,7 @@ from audit_skills import (  # noqa: E402
     rule_11_known_fields,
     rule_12_argument_hint,
     rule_13_coupling_signals,
+    rule_19_husk_directories,
 )
 from sync_best_practices import (  # noqa: E402
     compare_fields,
@@ -603,3 +607,233 @@ class TestRule13CouplingSignals:
         )
         exit_code = audit_mod.main()
         assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Rule 19: husk directories (issue #1902)
+# ---------------------------------------------------------------------------
+
+
+class TestRule19HuskDirectories:
+    def test_empty_husk_fails_with_empty_message(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        husk = skills_dir / "empty-husk"
+        husk.mkdir(parents=True)
+        pycache = husk / "__pycache__"
+        pycache.mkdir()
+        (pycache / "mod.cpython-311.pyc").write_text("compiled")
+        (husk / ".DS_Store").write_text("mac metadata")
+
+        findings = rule_19_husk_directories(skills_dir, "global")
+
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.severity == "FAIL"
+        assert f.rule == 19
+        assert "(empty)" in f.message
+
+    def test_real_content_husk_fails_with_contains_message(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        husk = skills_dir / "orphan-husk"
+        husk.mkdir(parents=True)
+        (husk / "notes.md").write_text("orphaned content")
+
+        findings = rule_19_husk_directories(skills_dir, "global")
+
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.severity == "FAIL"
+        assert "(contains:" in f.message
+        assert "notes.md" in f.message
+
+    def test_dir_with_skill_md_is_not_a_husk(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        valid = skills_dir / "real-skill"
+        valid.mkdir(parents=True)
+        (valid / "SKILL.md").write_text("---\nname: real-skill\n---\n")
+
+        findings = rule_19_husk_directories(skills_dir, "global")
+
+        assert findings == []
+
+    def test_underscore_prefixed_dir_is_exempt(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        shared = skills_dir / "_shared"
+        shared.mkdir(parents=True)
+        (shared / "helper.py").write_text("# shared helper, no SKILL.md here")
+
+        findings = rule_19_husk_directories(skills_dir, "global")
+
+        assert findings == []
+
+    def test_nonexistent_skills_dir_returns_empty_list(self, tmp_path):
+        missing = tmp_path / "does-not-exist"
+
+        findings = rule_19_husk_directories(missing, "global")
+
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# prune_husk_directories: rule 19 auto-fix companion (issue #1902)
+# ---------------------------------------------------------------------------
+
+
+class TestPruneHuskDirectories:
+    def test_empty_husk_is_removed_and_reported(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        husk = skills_dir / "empty-husk"
+        husk.mkdir(parents=True)
+        (husk / "__pycache__").mkdir()
+        (husk / "__pycache__" / "mod.cpython-311.pyc").write_text("compiled")
+
+        removed = prune_husk_directories(skills_dir, "global")
+
+        assert not husk.exists()
+        assert len(removed) == 1
+        assert "empty-husk" in removed[0]
+
+    def test_husk_containing_orphaned_file_is_preserved_and_not_reported(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        husk = skills_dir / "orphan-husk"
+        husk.mkdir(parents=True)
+        (husk / "notes.md").write_text("orphaned content")
+
+        removed = prune_husk_directories(skills_dir, "global")
+
+        assert husk.exists()
+        assert (husk / "notes.md").exists()
+        assert removed == []
+
+    def test_dir_with_skill_md_is_left_untouched(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        valid = skills_dir / "real-skill"
+        valid.mkdir(parents=True)
+        (valid / "SKILL.md").write_text("---\nname: real-skill\n---\n")
+
+        removed = prune_husk_directories(skills_dir, "global")
+
+        assert valid.exists()
+        assert (valid / "SKILL.md").exists()
+        assert removed == []
+
+    def test_underscore_prefixed_dir_is_left_untouched(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        shared = skills_dir / "_shared"
+        shared.mkdir(parents=True)
+
+        removed = prune_husk_directories(skills_dir, "global")
+
+        assert shared.exists()
+        assert removed == []
+
+    def test_oserror_on_one_husk_does_not_abort_sweep(self, tmp_path, monkeypatch):
+        skills_dir = tmp_path / "skills"
+        bad_husk = skills_dir / "bad-husk"
+        good_husk = skills_dir / "good-husk"
+        bad_husk.mkdir(parents=True)
+        good_husk.mkdir(parents=True)
+        (bad_husk / "__pycache__").mkdir()
+        (good_husk / "__pycache__").mkdir()
+
+        real_rmtree = shutil.rmtree
+
+        def flaky_rmtree(path, *args, **kwargs):
+            if Path(path).name == "bad-husk":
+                raise OSError("simulated permission failure")
+            return real_rmtree(path, *args, **kwargs)
+
+        monkeypatch.setattr(shutil, "rmtree", flaky_rmtree)
+
+        removed = prune_husk_directories(skills_dir, "global")
+
+        assert bad_husk.exists()  # failed delete leaves the dir behind
+        assert not good_husk.exists()  # sweep continues past the failure
+        assert len(removed) == 1
+        assert "good-husk" in removed[0]
+
+    def test_warns_with_resolved_absolute_path_before_delete(self, tmp_path, caplog):
+        skills_dir = tmp_path / "skills"
+        husk = skills_dir / "log-husk"
+        husk.mkdir(parents=True)
+        (husk / "__pycache__").mkdir()
+        resolved_path = str(husk.resolve())
+
+        with caplog.at_level(logging.WARNING, logger="audit_skills"):
+            removed = prune_husk_directories(skills_dir, "global")
+
+        assert len(removed) == 1
+        assert not husk.exists()
+        messages = [record.getMessage() for record in caplog.records]
+        assert any(resolved_path in message for message in messages)
+
+    def test_toctou_guard_skips_dir_that_gained_a_file(self, tmp_path, monkeypatch):
+        """A husk that looked empty at the initial scan but gained a real file
+        before the immediate pre-delete re-check must NOT be removed."""
+        skills_dir = tmp_path / "skills"
+        husk = skills_dir / "toctou-husk"
+        husk.mkdir(parents=True)
+
+        real_is_empty_husk = audit_mod._is_empty_husk
+        call_count = {"n": 0}
+
+        def fake_is_empty_husk(d):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                # Simulate a file landing in the directory between the
+                # initial scan and the TOCTOU re-check immediately before
+                # the delete.
+                (d / "late_arrival.txt").write_text("real content, not a husk")
+                return True
+            return real_is_empty_husk(d)
+
+        monkeypatch.setattr(audit_mod, "_is_empty_husk", fake_is_empty_husk)
+
+        removed = prune_husk_directories(skills_dir, "global")
+
+        assert call_count["n"] == 2
+        assert removed == []
+        assert husk.exists()
+        assert (husk / "late_arrival.txt").exists()
+
+
+# ---------------------------------------------------------------------------
+# Prune-then-detect gating: the safety guarantee named in the plan
+# (issue #1902) — a --fix run must never silently delete real orphans.
+# ---------------------------------------------------------------------------
+
+
+class TestPruneDetectGating:
+    def test_prune_junk_only_husk_removed_no_fail(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        husk = skills_dir / "junk-only-husk"
+        husk.mkdir(parents=True)
+        (husk / "__pycache__").mkdir()
+        (husk / "__pycache__" / "mod.cpython-311.pyc").write_text("compiled")
+        (husk / ".DS_Store").write_text("mac metadata")
+
+        # Simulate the --fix prune-then-detect order: prune first, then
+        # re-run rule 19 detection on whatever remains.
+        removed = prune_husk_directories(skills_dir, "global")
+        findings = rule_19_husk_directories(skills_dir, "global")
+
+        assert len(removed) == 1
+        assert not husk.exists()
+        assert findings == []  # nothing left to FAIL on
+
+    def test_prune_real_content_husk_preserved_and_fails(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        husk = skills_dir / "real-content-husk"
+        husk.mkdir(parents=True)
+        (husk / "orphaned_notes.md").write_text("real orphaned content")
+
+        # Same prune-then-detect sequence as a --fix run.
+        removed = prune_husk_directories(skills_dir, "global")
+        findings = rule_19_husk_directories(skills_dir, "global")
+
+        assert removed == []
+        assert husk.exists()
+        assert (husk / "orphaned_notes.md").exists()
+        assert len(findings) == 1
+        assert findings[0].severity == "FAIL"
+        assert "real-content-husk" in findings[0].skill


### PR DESCRIPTION
## Summary
- Adds `prune_husk_directories()` to `.claude/skills-global/do-skills-audit/scripts/audit_skills.py`, wired into `main()` under `--fix`, so genuinely-empty husk directories (containing nothing but `__pycache__`/`.DS_Store`) are auto-removed before rule 19 runs.
- Husks holding real orphaned files are left untouched and continue to surface as rule 19 FAILs — pruning is never destructive to real content.
- Includes a TOCTOU guard: the "empty" predicate is re-checked immediately before the irreversible `rmtree`.
- Logs a WARN with the resolved absolute path of every husk actually pruned.
- Adds full unit test coverage for rule 19 (previously zero) and for the new pruning helper, including junk-only-husk removal, real-content-husk preservation, OSError resilience across a sweep, and the TOCTOU race guard. All fixtures use `tmp_path`, never the live skills roots.
- Documents the new `--fix` behavior and one-command remediation invocation in `do-skills-audit/SKILL.md`.

Closes #1902

## Test plan
- [x] `tests/unit/test_skills_audit.py` — 77 passed (`scripts/pytest-clean.sh tests/unit/test_skills_audit.py -q`)
- [x] `python -m ruff format --check` on both changed Python files — already formatted