### PR TITLE
fix(#1899): self-healing key resolver + message-preserving async classification fallback

### DIFF
--- a/agent/health_check.py
+++ b/agent/health_check.py
@@ -342,7 +342,7 @@ def _extract_gh_commands(session_id: str) -> list[str]:
         return []
 
 
-def _get_api_key() -> str:
+def _get_api_key() -> str | None:
     """Resolve Anthropic API key from env or shared .env files."""
 
     return get_anthropic_api_key()

--- a/docs/features/bridge-worker-architecture.md
+++ b/docs/features/bridge-worker-architecture.md
@@ -204,6 +204,16 @@ Defense in depth lives in two layers:
 
 **Explicit non-goal**: this work does not fix the upstream Popoto stale-index root cause. That is tracked under #617 / #860 — orphan-index hygiene is its own ongoing reflection. sdlc-1330 makes intake resilient to that condition; the root cause is unaffected.
 
+### Classification Key-Resolution Resilience (issue #1899)
+
+Inbound messages trigger up to three classification calls that share one key resolver, `utils/api_keys.py::get_anthropic_api_key`: the terminus decision (`bridge/routing.py::classify_conversation_terminus`), the background work-type classifier (`tools/classifier.py::classify_request_async`, fired non-blocking from `classify_work_type()`), and the intent classifier (`agent/intent_classifier.py`). A message never depends on classification succeeding — each path carries a message-preserving default:
+
+- **Terminus → `RESPOND`**: the Haiku fallback is guarded by `if api_key:` and defaults conservatively.
+- **Work-type → sentinel `type=None`**: a missing key logs a single `WARNING` and returns `{"type": None, "confidence": 0.0, "reason": "..."}`. The bridge maps `type=None` to its most conservative routing (`"question"`, no spurious SDLC spawn). Genuine API/parse failures keep their `ERROR`-level (Sentry-visible) logging.
+- **Intent → `new_work`**: defaults internally on any error.
+
+**Resolver self-heal**: `get_anthropic_api_key()` returns `str | None` and caches **only a truthy** resolution. An absent resolution returns `None` without caching it, so the next call re-reads env/`.env` rather than short-circuiting on a poisoned empty cache. This removes a persistence amplifier: a transient startup window (LaunchAgent env or `.env` symlink not yet readable when the first classification ran) previously cached `""` and forced every subsequent classification in that process to fail until restart. Now the miss clears itself on the next inbound message once the environment settles. A *permanently* keyless process is not hidden by the work-type `WARNING` downgrade — the same resolver feeds the terminus fallback, the intent classifier, the health check, and every live session's model client, so a genuinely keyless bridge surfaces loudly through those paths.
+
 ### Execution Harness Routing
 
 All session types (dev, pm, teammate) execute via the CLI harness (`claude -p`). There is no SDK execution branch — the `DEV_SESSION_HARNESS` feature flag was eliminated in issue #912.

--- a/tests/unit/test_api_keys.py
+++ b/tests/unit/test_api_keys.py
@@ -1,0 +1,80 @@
+"""Tests for utils.api_keys — self-healing empty-cache behavior (#1899).
+
+Sentry reported "No Anthropic API key found for classification" persisting for
+the lifetime of a process after a single transient resolution failure. Root
+cause: the module cached an empty resolution just like a real key, so a
+one-time startup race (env/.env not yet readable) poisoned every subsequent
+call. These tests pin the fix: only a truthy key is cached; an absent
+resolution returns None without caching, so the next call re-reads env/.env.
+"""
+
+import inspect
+from pathlib import Path
+
+import utils.api_keys as api_keys_module
+from utils.api_keys import get_anthropic_api_key
+
+
+def _reset_cache():
+    api_keys_module._cached_anthropic_key = None
+
+
+def _force_no_env_files_found(monkeypatch):
+    """Make every candidate .env path resolve to nonexistent, regardless of
+    what's actually on disk on the machine running the tests.
+    """
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+
+
+def test_absent_resolution_returns_none_and_does_not_cache(monkeypatch):
+    """No env var and no .env files found -> returns None, cache stays empty
+    (never poisoned with "")."""
+    _reset_cache()
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    _force_no_env_files_found(monkeypatch)
+
+    result = get_anthropic_api_key()
+
+    assert result is None
+    assert api_keys_module._cached_anthropic_key is None
+
+
+def test_empty_cache_self_heals_on_next_call(monkeypatch):
+    """A prior empty/no-key resolution must not poison later calls: once the
+    env var becomes available, the very next call must pick it up instead of
+    returning a stale empty result.
+    """
+    _reset_cache()
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    _force_no_env_files_found(monkeypatch)
+
+    first = get_anthropic_api_key()
+    assert first is None
+
+    # Simulate the startup race settling: env var becomes readable.
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-key-123")
+    second = get_anthropic_api_key()
+
+    assert second == "sk-ant-test-key-123"
+
+
+def test_truthy_key_is_cached(monkeypatch):
+    """A populated key is cached and returned on subsequent calls unchanged
+    (no behavior change vs. before the fix)."""
+    _reset_cache()
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-cached-key")
+
+    first = get_anthropic_api_key()
+    assert first == "sk-ant-cached-key"
+    assert api_keys_module._cached_anthropic_key == "sk-ant-cached-key"
+
+    # Even if env changes afterward, the cached truthy value wins.
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-different-key")
+    second = get_anthropic_api_key()
+    assert second == "sk-ant-cached-key"
+
+
+def test_return_type_allows_none():
+    """The resolver's annotation must be str | None (ref #1899)."""
+    sig = inspect.signature(get_anthropic_api_key)
+    assert sig.return_annotation in ("str | None", str | None)

--- a/tests/unit/test_classify_request_async_missing_key.py
+++ b/tests/unit/test_classify_request_async_missing_key.py
@@ -1,0 +1,70 @@
+"""Regression tests for the missing-API-key path in classify_request_async.
+
+Covers #1899: a missing Anthropic API key should degrade quietly (WARNING log,
+message-preserving sentinel default) instead of raising a ValueError that
+surfaces as an ERROR-level Sentry event.
+"""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from tools.classifier import classify_request_async
+
+
+@pytest.mark.asyncio
+async def test_missing_key_returns_sentinel_default_without_raising(caplog):
+    """Missing key returns a message-preserving default instead of raising."""
+    with patch("tools.classifier.get_anthropic_api_key", return_value=None):
+        with caplog.at_level(logging.WARNING, logger="tools.classifier"):
+            result = await classify_request_async("Fix the login bug")
+
+    assert result["type"] is None
+    assert result["confidence"] == 0.0
+    assert "reason" in result
+
+
+@pytest.mark.asyncio
+async def test_missing_key_logs_warning_not_error(caplog):
+    """The missing-key path logs at WARNING, never ERROR."""
+    with patch("tools.classifier.get_anthropic_api_key", return_value=None):
+        with caplog.at_level(logging.DEBUG, logger="tools.classifier"):
+            await classify_request_async("Fix the login bug")
+
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+
+    assert not error_records, f"Expected no ERROR logs, got: {[r.message for r in error_records]}"
+    assert warning_records, "Expected at least one WARNING log for the missing-key path"
+
+
+@pytest.mark.asyncio
+async def test_missing_key_empty_string_also_handled(caplog):
+    """An empty-string key (legacy resolver behavior) is treated the same as absent."""
+    with patch("tools.classifier.get_anthropic_api_key", return_value=""):
+        with caplog.at_level(logging.WARNING, logger="tools.classifier"):
+            result = await classify_request_async("Fix the login bug")
+
+    assert result["type"] is None
+    assert result["confidence"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_real_api_error_still_logs_error(caplog):
+    """A genuine API failure (key present) keeps ERROR-level visibility.
+
+    The missing-key downgrade must not swallow real failures: with a valid key,
+    an exception from the Anthropic client still hits the outer handler and logs
+    at ERROR (feeding Sentry), then re-raises. This is the counterpart to the
+    quiet missing-key path (#1899).
+    """
+    with patch("tools.classifier.get_anthropic_api_key", return_value="sk-ant-real"):
+        with patch("tools.classifier.anthropic_slot", side_effect=RuntimeError("boom")):
+            with caplog.at_level(logging.DEBUG, logger="tools.classifier"):
+                with pytest.raises(RuntimeError):
+                    await classify_request_async("Fix the login bug")
+
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert error_records, "Expected an ERROR log for a genuine API failure"
+    assert any("Classification failed (async)" in r.message for r in error_records)

--- a/tools/classifier.py
+++ b/tools/classifier.py
@@ -168,7 +168,15 @@ async def classify_request_async(message: str, context: str = "") -> dict:
     try:
         api_key = get_anthropic_api_key()
         if not api_key:
-            raise ValueError("No Anthropic API key found for classification")
+            logger.warning(
+                "Anthropic API key missing — skipping async classification, "
+                "message preserved with sentinel default"
+            )
+            return {
+                "type": None,
+                "confidence": 0.0,
+                "reason": "no anthropic api key — classification skipped",
+            }
 
         # Build prompt
         prompt = CLASSIFICATION_PROMPT.format(

--- a/utils/api_keys.py
+++ b/utils/api_keys.py
@@ -11,14 +11,20 @@ from pathlib import Path
 _cached_anthropic_key: str | None = None
 
 
-def get_anthropic_api_key() -> str:
+def get_anthropic_api_key() -> str | None:
     """Resolve Anthropic API key from env or .env files.
 
     Checks os.environ first (skipping empty strings), then reads
-    directly from .env files as fallback. Caches the result.
+    directly from .env files as fallback. Caches only a successfully
+    resolved (truthy) key.
     """
     global _cached_anthropic_key
-    if _cached_anthropic_key is not None:
+    # Only short-circuit on a truthy cached value. Do NOT short-circuit on a
+    # falsy cached value (None/"") -- caching an empty resolution poisons
+    # every subsequent call in this process for its entire lifetime if the
+    # miss was caused by a transient startup race (env/.env not yet readable
+    # when this ran first). See #1899.
+    if _cached_anthropic_key:
         return _cached_anthropic_key
 
     key = os.environ.get("ANTHROPIC_API_KEY", "")
@@ -41,5 +47,10 @@ def get_anthropic_api_key() -> str:
                         _cached_anthropic_key = val
                         return val
 
-    _cached_anthropic_key = ""
-    return ""
+    # Absent/empty resolution: return None WITHOUT caching it. This is the
+    # self-heal -- the next call re-reads env/.env instead of hitting a
+    # poisoned cache, so a transient miss (e.g. LaunchAgent env sourcing not
+    # yet settled at process start) clears itself on the next attempt
+    # rather than persisting "no key found" for the rest of the process
+    # lifetime. See #1899.
+    return None


### PR DESCRIPTION
Fixes #1899.

## Root cause
`utils/api_keys.py::get_anthropic_api_key()` cached an **empty** resolution (`_cached_anthropic_key = ""`) at the tail. A transient startup window (LaunchAgent env vs `.env` sourcing race) where the key resolved empty poisoned the module cache for the whole process lifetime, so every subsequent classification failed until bridge restart. The visible damage was recurring `Classification failed (async): No Anthropic API key found for classification` ERROR/Sentry noise on `Valor-the-Captain.local` (6 events / 4 days). The issue's attribution to `classify_conversation_terminus` was a misdiagnosis: terminus already guards its fallback with `if api_key:` and returns `RESPOND`. The real emitter is `classify_request_async` (work-type classifier), whose caller already treats failure as non-fatal, so no human message was dropped.

## Fix
- **`utils/api_keys.py`** — cache **only truthy** resolutions; an absent resolution returns `None` (`str | None`) without caching, so the next call re-reads env/`.env` and self-heals once the environment settles.
- **`tools/classifier.py`** — `classify_request_async` degrades a missing key to a single `WARNING` and returns a message-preserving sentinel `{"type": None, "confidence": 0.0, ...}` instead of raising. Genuine API/parse failures keep ERROR-level (Sentry) visibility.
- **`agent/health_check.py`** — widen `_get_api_key` annotation to `str | None`.

## Acceptance criteria
- [x] Root cause identified with the exact call site (`utils/api_keys.py` empty-cache; emitter `tools/classifier.py:classify_request_async`)
- [x] Fix ensures the async classification path authenticates or falls back safely (never silent-drop): terminus→RESPOND, work-type→sentinel default, intent→new_work
- [x] Regression tests for the key-missing path

## Tests
`tests/unit/test_api_keys.py` (4) + `tests/unit/test_classify_request_async_missing_key.py` (4). Targeted run: **61 passed, 1 skipped** (`test_api_keys.py`, `test_classify_request_async_missing_key.py`, `test_routing.py`).

## Docs
`docs/features/bridge-worker-architecture.md` — added "Classification Key-Resolution Resilience (issue #1899)" section.

## Deployment
Captain deployment happens later via `/update`; out of scope for this PR. No live bridge touched.