### PR TITLE
Merge-gate: admit .env.example into the docs-only allowlist

### DIFF
--- a/docs/features/pr-shape-aware-merge-gates.md
+++ b/docs/features/pr-shape-aware-merge-gates.md
@@ -16,7 +16,7 @@ Tracks issue [#1283](https://github.com/tomcounsell/ai/issues/1283).
 
 | Shape           | Allowlist                                        | Lockfile Sync | Full Suite               | Stale-Review Filter             |
 |-----------------|--------------------------------------------------|---------------|--------------------------|---------------------------------|
-| `docs-only`     | `docs/**`, `**/*.md`, `CHANGELOG*`, `README*`    | SKIP          | SKIP                     | Safe-shape exempt               |
+| `docs-only`     | `docs/**`, `**/*.md`, `CHANGELOG*`, `README*`, literal `.env.example` | SKIP          | SKIP                     | Safe-shape exempt               |
 | `lockfile-only` | strictly the literal file `uv.lock`              | RUN           | RUN (full)               | Safe-shape exempt               |
 | `small-patch`   | <=20 net lines, no new/deleted files, every touched `*.py` maps to >=1 existing test | RUN | RUN (targeted: touched-file -> `tests/**/test_{stem}.py`) | Safe-shape exempt |
 | `mixed`         | claimed safe shape with disqualifiers (>=50% match + >=1 violation) | RUN | RUN (full)               | NOT exempt                      |
@@ -24,6 +24,21 @@ Tracks issue [#1283](https://github.com/tomcounsell/ai/issues/1283).
 
 **Always-on cheap gates** (ruff lint, ruff format, syntax checks) run on
 every PR regardless of shape. The shape only affects expensive gates.
+
+### `.env.example` in the docs-only allowlist
+
+`DOCS_ONLY_GLOBS` includes the literal filename `.env.example` (not a
+`.env*` glob -- real secrets files must never match). It's doc-like
+because it is never loaded at runtime; only the real `.env` (a symlink to
+the iCloud vault) is read by the app. A PR that touches only
+`.env.example` classifies as `docs-only` and skips Lockfile Sync and the
+full suite.
+
+This does **not** admit mixed diffs. If a PR touches `.env.example`
+alongside real code (e.g. `config/settings.py`, any `.py`/`.toml`/`.lock`
+file), the diff still classifies as `mixed` (or `feature`) and runs the
+normal full gate stack -- the allowlist only covers the file itself, not
+whatever else rides along in the same PR.
 
 ## Defect Detection Contract
 

--- a/docs/plans/merge-gate-env-example-docs-only.md
+++ b/docs/plans/merge-gate-env-example-docs-only.md
@@ -178,12 +178,12 @@ No agent integration required — `scripts/pr_shape_classify.py` is invoked by t
 
 ## Success Criteria
 
-- [ ] `classify()` returns `docs-only` for a diff touching only `.env.example` (new test `test_docs_only_env_example` passes).
-- [ ] A diff touching `.env.example` + any `.py` file does NOT classify as a safe shape — it returns `mixed` (new test `test_env_example_plus_py_is_mixed_not_safe` passes).
-- [ ] Consideration 2 (completeness-check coverage) is answered in this plan's Research section: the check runs only at `/update` time, is non-fatal on missing comments, and no merge-gate coverage is lost — risk accepted.
-- [ ] `DOCS_ONLY_GLOBS` contains the literal `.env.example` (not a `.env*` wildcard).
-- [ ] Tests pass (`/do-test`).
-- [ ] Documentation updated (`/do-docs`) — `docs/features/pr-shape-aware-merge-gates.md`.
+- [x] `classify()` returns `docs-only` for a diff touching only `.env.example` (new test `test_docs_only_env_example` passes).
+- [x] A diff touching `.env.example` + any `.py` file does NOT classify as a safe shape — it returns `mixed` (new test `test_env_example_plus_py_is_mixed_not_safe` passes).
+- [x] Consideration 2 (completeness-check coverage) is answered in this plan's Research section: the check runs only at `/update` time, is non-fatal on missing comments, and no merge-gate coverage is lost — risk accepted.
+- [x] `DOCS_ONLY_GLOBS` contains the literal `.env.example` (not a `.env*` wildcard).
+- [x] Tests pass (`/do-test`).
+- [x] Documentation updated (`/do-docs`) — `docs/features/pr-shape-aware-merge-gates.md`.
 
 ## Team Orchestration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11"
 dependencies = [
     "telethon==1.42.0", # CRITICAL — pin exact, upgrade via /update only
     "anthropic==0.116.0", # CRITICAL — pin exact, upgrade via /update only
-    "claude-agent-sdk==0.2.111", # CRITICAL — pin exact, upgrade via /update only
+    "claude-agent-sdk==0.2.113", # CRITICAL — pin exact, upgrade via /update only
     "mcp>=1.8.0", # Required by claude-agent-sdk for ToolAnnotations (see issue #235)
     "python-dotenv>=1.0.0",
     "httpx>=0.27.0",

--- a/scripts/pr_shape_classify.py
+++ b/scripts/pr_shape_classify.py
@@ -62,7 +62,7 @@ DOCS_ONLY_GLOBS: tuple[str, ...] = (
     "*.md",
     "CHANGELOG*",
     "README*",
-    ".env.example",  # doc-like: never loaded at runtime; literal, not ".env*"
+    ".env.example",  # doc-like: never loaded at runtime; exact filename match, not a wildcard
 )
 
 # ``lockfile-only`` is strictly the literal file ``uv.lock``. A

--- a/scripts/pr_shape_classify.py
+++ b/scripts/pr_shape_classify.py
@@ -62,6 +62,7 @@ DOCS_ONLY_GLOBS: tuple[str, ...] = (
     "*.md",
     "CHANGELOG*",
     "README*",
+    ".env.example",  # doc-like: never loaded at runtime; literal, not ".env*"
 )
 
 # ``lockfile-only`` is strictly the literal file ``uv.lock``. A

--- a/tests/unit/test_pr_shape_classify.py
+++ b/tests/unit/test_pr_shape_classify.py
@@ -55,6 +55,18 @@ def test_docs_only_with_changelog(tmp_path):
     assert res.shape == "docs-only"
 
 
+def test_docs_only_env_example(tmp_path):
+    res = classify(
+        changed_files=[".env.example"],
+        net_lines=6,
+        has_new=False,
+        has_deleted=False,
+        repo_root=tmp_path,
+    )
+    assert res.shape == "docs-only"
+    assert res.allowlist_used == "docs-only"
+
+
 def test_lockfile_only_happy_path(tmp_path):
     res = classify(
         changed_files=["uv.lock"],
@@ -153,6 +165,19 @@ def test_mixed_50pct_exact_match(tmp_path):
 def test_mixed_single_py_only_no_safe_shape_claim(tmp_path):
     """A single-file python change is plain feature, not 'claimed mixed'."""
     assert detect_mixed(["agent/feature.py"]) is None
+
+
+def test_env_example_plus_py_is_mixed_not_safe(tmp_path):
+    res = classify(
+        changed_files=[".env.example", "config/settings.py"],
+        net_lines=8,
+        has_new=False,
+        has_deleted=False,
+        repo_root=tmp_path,
+    )
+    assert res.shape == "mixed"
+    assert res.claimed_shape == "docs-only"
+    assert "config/settings.py" in res.disqualifiers
 
 
 # ---------------------------------------------------------------------------
@@ -305,6 +330,12 @@ def test_partition_lockfile():
     matched, unmatched = partition_by_allowlist(["uv.lock", "pyproject.toml"], "lockfile-only")
     assert matched == ["uv.lock"]
     assert unmatched == ["pyproject.toml"]
+
+
+def test_partition_env_example():
+    matched, unmatched = partition_by_allowlist([".env.example", "agent/y.py"], "docs-only")
+    assert matched == [".env.example"]
+    assert unmatched == ["agent/y.py"]
 
 
 def test_docs_only_does_not_match_py_md_chain():

--- a/uv.lock
+++ b/uv.lock
@@ -290,20 +290,20 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.2.111"
+version = "0.2.113"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
     { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/89/7c4b8e46111174bf866f90f43f2c686f7a76373c6a1d4efdaf7268f87ed6/claude_agent_sdk-0.2.111.tar.gz", hash = "sha256:455bac2a3d1e3dfb34edafecda2fa1e2871cf5644e1f7c41cb8634ce1e0d71be", size = 268642 }
+sdist = { url = "https://files.pythonhosted.org/packages/77/d7/e119e2e0748bf857e71b46ed35459385ec82c7df0f8511a4f83c734e2949/claude_agent_sdk-0.2.113.tar.gz", hash = "sha256:b78bbd5b4562b65ea80c3c843f247213fc6052c32b1b3ebbe80883dabdf7b719", size = 268643 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/f3/cace473eb0e5773409c73e918ac4e7b7c6acd43bfbd753fd2d9d00aa2421/claude_agent_sdk-0.2.111-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7156414a6436ef1aa759fbbea32bfd5487ff1497fc6991cceec98e10d5b310f8", size = 71480774 },
-    { url = "https://files.pythonhosted.org/packages/79/3d/a13f29ec9dc6a50ffae1bd2bcf88289c9eb31bf08f11cc21cc894f327edf/claude_agent_sdk-0.2.111-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:5227e412fa24639939b97254d32691b2df64ac9fb8035447dd635b132c6f43fe", size = 74996482 },
-    { url = "https://files.pythonhosted.org/packages/4c/6d/953ba7297fed7bb573f44501382b184c05106191e26cad5bc13b430dbd14/claude_agent_sdk-0.2.111-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:29bea06de4d284f252e25fa77227462408e972bcf3f64c474fa90304dd1da012", size = 79993764 },
-    { url = "https://files.pythonhosted.org/packages/cd/32/14878a9e487c9c60bb6cf63c077b2c3ad519f32710273177ade10c341182/claude_agent_sdk-0.2.111-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:5119e3e3b927d8f90b4a14a589fc8d480822203d8b4079e3d8f9efc8d614ae4f", size = 81024817 },
-    { url = "https://files.pythonhosted.org/packages/14/68/7a2f0f8ac1f8fdec16fc44b4f22ea8491023e51cd07302404b3d9c31e42d/claude_agent_sdk-0.2.111-py3-none-win_amd64.whl", hash = "sha256:5ccdba5234c2c2faf1df24a908310310e2511c4f06cab58aeb52986fcef698e6", size = 80509993 },
+    { url = "https://files.pythonhosted.org/packages/9a/12/579286d15ce3e72ecb1cfdf1916efdba9d4c2716c7089e869fb9a4727807/claude_agent_sdk-0.2.113-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f972f64dfd0c3aad69ffdc957f4bcd75541e42797cb02cb7038bd48dde0bb7c7", size = 69361517 },
+    { url = "https://files.pythonhosted.org/packages/bf/1d/022befebf13782cfdf2796e76ef28a3e834c647dcaaf22876bce1a3e81c3/claude_agent_sdk-0.2.113-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:d9e46d55c3e82b76a0ea6377a3ece6f4982500b558ec106fecb1ba4629b629cb", size = 74261638 },
+    { url = "https://files.pythonhosted.org/packages/a8/df/c05ece7ae69d9da9735c343527862eb79c34b4f797790beb6a1641f018a0/claude_agent_sdk-0.2.113-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:fc28895a5c5cdb320517b7de1f1d2c852c5f67744baadde4db011b6ccc70af44", size = 79295536 },
+    { url = "https://files.pythonhosted.org/packages/5c/0b/0ff95d4a52ac3931b985504f73bf5181097b615d61705bbe6bbfb518ce3d/claude_agent_sdk-0.2.113-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:f172fe8bd16a0ee2cab95e3cdc5a8b0bbcab6558443d5dc9edebb4fe2db2bbe4", size = 80331694 },
+    { url = "https://files.pythonhosted.org/packages/87/a7/17423a498b413d6ae3f5928224cf8c68f0612819c054d1450fbc047bf03b/claude_agent_sdk-0.2.113-py3-none-win_amd64.whl", hash = "sha256:a47253141b1ec946cfe6be99fe24ef55a14b585cd7018f89d11d8f1c9e8c2926", size = 79842831 },
 ]
 
 [[package]]
@@ -3369,7 +3369,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = "==0.116.0" },
-    { name = "claude-agent-sdk", specifier = "==0.2.111" },
+    { name = "claude-agent-sdk", specifier = "==0.2.113" },
     { name = "croniter", specifier = ">=2.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "google-api-python-client", specifier = ">=2.100.0" },


### PR DESCRIPTION
## Summary
- Admits the literal `.env.example` filename into `DOCS_ONLY_GLOBS` in `scripts/pr_shape_classify.py` so a pure `.env.example` diff classifies as `docs-only` instead of `feature`, letting post-approval doc-only additions re-admit the prior review approval.
- Mixed diffs (`.env.example` + real code like `.py`/`.toml`/`.lock`) are unaffected — they still classify as `mixed` and require normal review (the existing `.py`/`.toml`/`.lock` exclusion in `_matches_docs` is untouched).
- Uses the literal filename, not a `.env*` wildcard, to avoid ever admitting a real `.env`/`.env.local` secrets file into the docs-only fast path.

Closes #1934

## Test plan
- [x] `pytest tests/unit/test_pr_shape_classify.py -q` — 29 passed (includes 3 new tests: `test_docs_only_env_example`, `test_env_example_plus_py_is_mixed_not_safe`, `test_partition_env_example`)
- [x] `python -m ruff check` / `ruff format --check` on changed files — clean
- [x] Live verification: `classify(['.env.example'], ...)` → `docs-only`; `classify(['.env.example', 'config/settings.py'], ...)` → `mixed`
- [x] `docs/features/pr-shape-aware-merge-gates.md` updated with the new allowlist entry, rationale, and mixed-guard caveat