### PR TITLE
Disambiguate exit_reason=pm_user: split pm_needs_human from real [/user] answers (#1922)

### DIFF
--- a/agent/session_executor.py
+++ b/agent/session_executor.py
@@ -17,6 +17,7 @@ from agent.session_completion import (
 from agent.session_health import HEARTBEAT_WRITE_INTERVAL
 from agent.session_logs import save_session_snapshot
 from agent.session_revival import _session_branch_name
+from agent.session_runner.router import CLEAN_EXIT_REASONS as _CLEAN_RUNNER_EXIT_REASONS
 from agent.session_state import (
     SessionHandle,
     _active_sessions,
@@ -32,16 +33,14 @@ from models.session_lifecycle import TERMINAL_STATUSES as _TERMINAL_STATUSES
 
 logger = logging.getLogger(__name__)
 
-_CLEAN_RUNNER_EXIT_REASONS = frozenset(
-    {"pm_complete", "pm_user", "pm_floor_delivered", "steer_abort"}
-)
-
 
 def _is_non_clean_runner_exit(agent_session) -> bool:
     """Return True when the session has a runner exit_reason that signals a real failure.
 
     None exit_reason = not yet set = clean (default behavior).
-    Clean runner exits: pm_complete (normal end), pm_user (user message sent),
+    Clean runner exits: pm_complete (normal end), pm_user (real ``[/user]`` answer
+    the PM chose to deliver), pm_needs_human (runner-forwarded needs-input prompt
+    from a ``needs_human`` hook edge on an unroutable turn — distinct from pm_user),
     pm_floor_delivered (wrap-up guard delivered PM's last assistant message directly
     when the PM produced a real but prefix-less response — issue #1719),
     steer_abort (operator-requested abort via a steering message; the user-facing

--- a/agent/session_runner/router.py
+++ b/agent/session_runner/router.py
@@ -20,7 +20,11 @@ This module also owns the exit-classification tables: which
 ``exit_reason`` values are clean, which trigger the wrap-up guard, and which
 are anomalies. Historical vocabulary (``pm_complete`` / ``pm_user`` /
 ``dev_hang`` ...) is preserved for telemetry continuity; only the PTY-only
-producers (``startup_unresolved``, plateau) have no place here.
+producers (``startup_unresolved``, plateau) have no place here. ``pm_user``
+is a real ``[/user]`` answer the PM chose to deliver; ``pm_needs_human`` is
+a runner-forwarded needs-input prompt (a ``needs_human`` hook edge firing on
+an otherwise-unroutable turn) — both are clean exits but distinguishable
+downstream.
 """
 
 from __future__ import annotations
@@ -149,6 +153,7 @@ CLEAN_EXIT_REASONS = frozenset(
     {
         "pm_complete",
         "pm_user",
+        "pm_needs_human",
         "pm_floor_delivered",
         "steer_abort",
     }
@@ -162,6 +167,7 @@ WRAPUP_ELIGIBLE_EXIT_REASONS = frozenset(
     {
         "pm_complete",
         "pm_user",
+        "pm_needs_human",
         "pm_max_turns",
         "pm_floor_delivered",
     }

--- a/agent/session_runner/runner.py
+++ b/agent/session_runner/runner.py
@@ -13,6 +13,8 @@ Routing is the simplified regex table (:mod:`agent.session_runner.router`):
 - ``[/user]``      → deliver via the adapter's user callback, exit ``pm_user``
 - ``[/complete]``  → deliver the summary, exit ``pm_complete`` (wrap-up guard
   backstops an empty delivery)
+- needs_human edge on an unroutable turn → deliver the PM's text, exit
+  ``pm_needs_human`` (distinct from a real ``[/user]`` answer, see below)
 - anything else    → continue (bounded compliance nudge, then the wrap-up
   guard — never an infinite loop)
 
@@ -1056,10 +1058,14 @@ class SessionRunner:
 
         # A substantive needs-human edge alongside an unroutable turn: the
         # hook already filtered boilerplate (#1919), so this message is a
-        # genuine question for the human — deliver the PM's text.
+        # genuine question for the human — deliver the PM's text. Tagged
+        # ``pm_needs_human`` (not ``pm_user``) since this is a runner-forwarded
+        # needs-input prompt, not a real ``[/user]`` answer the PM chose to send.
         if outcome.needs_human is not None and text.strip():
             self._adapter.on_user_payload(text.strip())
-            return _RouteDecision(should_break=True, exit_reason="pm_user", compliance_miss=miss)
+            return _RouteDecision(
+                should_break=True, exit_reason="pm_needs_human", compliance_miss=miss
+            )
 
         # Anything else — legacy [/dev], unknown prefix, empty payload —
         # continues the loop with a bounded compliance nudge.

--- a/docs/features/headless-session-runner.md
+++ b/docs/features/headless-session-runner.md
@@ -24,7 +24,7 @@ process pool, no idle-scraping startup phase.
 |--------|------|
 | `runner.py` | The single-session turn loop for every session type: spawn one `claude -p` per turn, route the PM's output, run the steer-preempt watcher, own resume-scalar persistence timing. |
 | `role_driver.py` | `HeadlessRoleDriver` — builds the subprocess invocation (prime slash command vs. resume), parses stream-json, reconciles the hook-edge snapshot against the turn's own edges. |
-| `router.py` | `classify_pm_prefix` (regex, zero LLM calls; strips the matched routing token from a fallback-classified payload so no raw routing string ever reaches the human) and the exit-classification vocabulary (`CLEAN_EXIT_REASONS`, `WRAPUP_ELIGIBLE_EXIT_REASONS`, `ANOMALY_EXIT_REASONS`). |
+| `router.py` | `classify_pm_prefix` (regex, zero LLM calls; strips the matched routing token from a fallback-classified payload so no raw routing string ever reaches the human) and the exit-classification vocabulary (`CLEAN_EXIT_REASONS`, `WRAPUP_ELIGIBLE_EXIT_REASONS`, `ANOMALY_EXIT_REASONS`). `pm_user` (a real `[/user]` answer the PM chose to deliver) and `pm_needs_human` (a runner-forwarded needs-input prompt, from a `needs_human` hook edge firing on an otherwise-unroutable turn) are both clean, wrap-up-eligible exits — kept distinct so the dashboard and reaction gate can tell "the PM answered" from "the PM paused, waiting on the human" (issue #1922). |
 | `hook_edge.py` / `hook_forwarder.py` | The turn-end/needs-human signal path: a fail-silent NDJSON forwarder writes each hook event to a per-session file; the consumer tails it with a durable `(event_cursor, byte_offset, fingerprint)` cursor. |
 | `transcript_tailer.py` | Incremental JSONL transcript reads for dashboard telemetry (byte-offset cadence, unchanged from the prior implementation). |
 | `adapter.py` | Executor-facing construction: delivery callbacks, the four-scalar resume persistence, exit-summary publication. |
@@ -189,6 +189,14 @@ even when partial streamed text accumulated; any non-clean `exit_reason`
 finalizes the `AgentSession` as `failed` with a persona-safe user message —
 never a false `completed` (closing the class of failure documented in the
 [PTY-fragility postmortem](../postmortems/2026-07-06-granite-pty-fragility.md)).
+
+`exit_reason=pm_needs_human` (added in issue #1922) is a clean exit, not a
+liveness failure: it fires when a `needs_human` hook edge accompanies an
+otherwise-unroutable turn, and the runner delivers the PM's text as a genuine
+question to the human. `session_executor.py` recognizes it via the single
+imported `CLEAN_EXIT_REASONS` set (no separate literal to drift out of sync),
+so it never falls into the `failed`/error-reaction path that a genuinely
+non-clean `exit_reason` would.
 
 ## Supersedes
 

--- a/docs/plans/disambiguate-exit-reason-pm-user.md
+++ b/docs/plans/disambiguate-exit-reason-pm-user.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: docs_complete
 type: chore
 appetite: Small
 owner: Valor Engels

--- a/docs/plans/disambiguate-exit-reason-pm-user.md
+++ b/docs/plans/disambiguate-exit-reason-pm-user.md
@@ -193,14 +193,14 @@ No agent integration required — this is a runner/executor-internal change. No 
 
 ## Success Criteria
 
-- [ ] `runner.py:1062` emits `exit_reason="pm_needs_human"`; `1047` and `1088` still emit `pm_user`.
-- [ ] `pm_needs_human` is a member of both `CLEAN_EXIT_REASONS` and `WRAPUP_ELIGIBLE_EXIT_REASONS` in `router.py`.
-- [ ] `session_executor.py` recognizes `pm_needs_human` as clean via a single imported set (no second literal to maintain).
-- [ ] A needs-human-edge exit yields REACTION_COMPLETE + terminal `completed` (asserted in `test_session_executor_runner_dispatch.py`).
-- [ ] `docs/features/headless-session-runner.md` documents the new reason.
-- [ ] Tests pass (`/do-test`)
-- [ ] Documentation updated (`/do-docs`)
-- [ ] `grep` confirms `session_executor.py` imports `CLEAN_EXIT_REASONS` from `agent.session_runner.router` (no duplicated literal set).
+- [x] `runner.py:1062` emits `exit_reason="pm_needs_human"`; `1047` and `1088` still emit `pm_user`.
+- [x] `pm_needs_human` is a member of both `CLEAN_EXIT_REASONS` and `WRAPUP_ELIGIBLE_EXIT_REASONS` in `router.py`.
+- [x] `session_executor.py` recognizes `pm_needs_human` as clean via a single imported set (no second literal to maintain).
+- [x] A needs-human-edge exit yields REACTION_COMPLETE + terminal `completed` (asserted in `test_session_executor_runner_dispatch.py`).
+- [x] `docs/features/headless-session-runner.md` documents the new reason.
+- [x] Tests pass (`/do-test`)
+- [x] Documentation updated (`/do-docs`)
+- [x] `grep` confirms `session_executor.py` imports `CLEAN_EXIT_REASONS` from `agent.session_runner.router` (no duplicated literal set).
 
 ## Team Orchestration
 

--- a/tests/unit/session_runner/test_runner_liveness.py
+++ b/tests/unit/session_runner/test_runner_liveness.py
@@ -134,7 +134,11 @@ async def test_subprocess_death_classifies_error_never_completed():
     summary = await runner.run("do the thing")
 
     assert summary.exit_reason == "error", "a dead subprocess must classify as error"
-    assert summary.exit_reason not in ("pm_complete", "pm_user"), "never a clean completion"
+    assert summary.exit_reason not in (
+        "pm_complete",
+        "pm_user",
+        "pm_needs_human",
+    ), "never a clean completion"
     # Persona-safe delivery: the canned message, never the raw exit string.
     assert deliveries == [RUNNER_ERROR_USER_MESSAGE]
     assert all("broken pipe" not in d for d in deliveries), (

--- a/tests/unit/session_runner/test_runner_turns.py
+++ b/tests/unit/session_runner/test_runner_turns.py
@@ -92,6 +92,9 @@ def make_runner(script, *, session=None, steering=None, **kwargs):
 
 
 async def test_user_route_delivers_and_exits():
+    # A real [/user] answer stays "pm_user" — distinct from the needs_human-edge
+    # fallback (test_needs_human_edge_with_unroutable_text_delivers below), which
+    # now exits "pm_needs_human". This assertion pins the real-answer branch.
     runner, deliveries, session, driver = make_runner(["[/user]\nhello human"])
     summary = await runner.run("do the thing")
     assert deliveries == ["hello human"]
@@ -190,7 +193,8 @@ async def test_needs_human_edge_with_unroutable_text_delivers():
     runner, deliveries, _, _ = make_runner([outcome])
     summary = await runner.run("go")
     assert deliveries == ["Which environment should I target?"]
-    assert summary.exit_reason == "pm_user"
+    assert summary.exit_reason == "pm_needs_human"
+    assert summary.user_facing_routed is True
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit/test_session_executor_runner_dispatch.py
+++ b/tests/unit/test_session_executor_runner_dispatch.py
@@ -358,6 +358,10 @@ class TestIsNonCleanRunnerExit:
             # Clean exits → False
             ("pm_complete", False),
             ("pm_user", False),
+            # pm_needs_human: runner-forwarded needs-input prompt (needs_human
+            # hook edge on an unroutable turn) — distinct from pm_user, still
+            # clean (issue #1922).
+            ("pm_needs_human", False),
             # pm_floor_delivered: wrap-up guard delivered PM's real (prefix-less)
             # last message — a genuine delivery, not a canned fallback (#1719).
             ("pm_floor_delivered", False),
@@ -401,6 +405,9 @@ class TestReactionGating:
             ("pm_complete", False, False),
             ("pm_complete", True, False),
             ("pm_user", False, False),
+            # pm_needs_human: runner-forwarded needs-input prompt, clean like
+            # pm_user (issue #1922).
+            ("pm_needs_human", True, False),
             ("pm_floor_delivered", True, False),
             ("pm_floor_delivered", False, False),
             # Non-clean exits → REACTION_ERROR (regardless of delivery)
@@ -502,6 +509,7 @@ class TestRunnerFinalStatus:
             (None, "turn_timeout", "failed"),
             (None, "pm_max_turns", "failed"),
             (None, "pm_complete", "completed"),
+            (None, "pm_needs_human", "completed"),
             (None, "steer_abort", "completed"),
             (None, None, "completed"),
             (RuntimeError("boom"), "pm_complete", "failed"),


### PR DESCRIPTION
## Summary

Disambiguates the overloaded `exit_reason=pm_user` in the headless session runner (issue #1922, item 2). Previously `pm_user` was emitted both for a **real `[/user]` answer** the PM chose to deliver AND for a **needs-input prompt** the runner forwarded because a `needs_human` hook edge fired on an otherwise-unroutable turn. On the dashboard, in `session_events`, and in the executor's reaction gate, "the PM answered the human" read identically to "the PM paused, waiting on the human."

This adds a new distinct clean exit reason, `pm_needs_human`, for the needs-input-prompt path only. Real `[/user]` answers keep `pm_user`. Zero behavioral change — only the telemetry label becomes unambiguous.

(Item 1 of #1922 — ts-order `turn_end` vs `needs_human` — was already delivered by #1930; this PR is item 2 only.)

## Changes

- **`agent/session_runner/runner.py`** — the `needs_human`-edge fallback inside `_route_turn` (the `if outcome.needs_human is not None and text.strip():` block) now returns `exit_reason="pm_needs_human"`. The two real `[/user]` delivery sites (destination-`user` delivery and the wrap-up-guard `[/user]`) are untouched — still `pm_user`. Module docstring and branch comment updated.
- **`agent/session_runner/router.py`** — `pm_needs_human` added to both `CLEAN_EXIT_REASONS` and `WRAPUP_ELIGIBLE_EXIT_REASONS` (parity with `pm_user`). Vocabulary docstring updated.
- **`agent/session_executor.py`** — replaced the duplicated `_CLEAN_RUNNER_EXIT_REASONS` frozenset literal with `from agent.session_runner.router import CLEAN_EXIT_REASONS as _CLEAN_RUNNER_EXIT_REASONS`. Single source of truth — removes the drift hazard (a `#1708`-class regression risk) so a new clean reason can never be misclassified as a failure. Docstring updated.
- **Tests** — `test_runner_turns.py` (needs_human-edge path now asserts `pm_needs_human` + `user_facing_routed`; real `[/user]` path pinned to `pm_user`), `test_runner_liveness.py` (clean-completion guard tuple extended), `test_session_executor_runner_dispatch.py` (`pm_needs_human` row added to `TestIsNonCleanRunnerExit` and `TestReactionGating`, asserting clean / non-error handling).
- **`docs/features/headless-session-runner.md`** — documents `pm_needs_human` as a distinct clean exit.

No migration: `exit_reason` is a free-form string on `AgentSession`; existing `pm_user` records remain valid and are not backfilled.

## Verification

- `pytest tests/unit/session_runner/ tests/unit/test_session_executor_runner_dispatch.py -q` → **167 passed**
- `python -m ruff check .` → clean; `python -m ruff format --check .` → clean
- Independent validator agent confirmed all 8 success criteria PASS: exactly one `pm_needs_human` producer at the correct call site, two `pm_user` sites untouched, router frozensets updated, executor deduplication confirmed, docs updated, no spurious migration.

Closes #1922

🤖 Generated with [Claude Code](https://claude.com/claude-code)
