### PR TITLE
Fix stale AgentSession.create_pm test references (#1958)

### DIFF
--- a/docs/plans/fix_stale_create_pm_test_references.md
+++ b/docs/plans/fix_stale_create_pm_test_references.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: docs_complete
 type: bug
 appetite: Small
 owner: Valor

--- a/docs/plans/fix_stale_create_pm_test_references.md
+++ b/docs/plans/fix_stale_create_pm_test_references.md
@@ -179,13 +179,13 @@ in `docs/features/eng-session-architecture.md`.
 
 ## Success Criteria
 
-- [ ] All 24 `create_pm` call sites across the 5 files replaced with `create_eng`.
-- [ ] `is_pm` assertions in `test_session_lifecycle.py` replaced with `is_eng`.
-- [ ] `session_type == "pm"` filter in `test_sdlc_session_ensure_integration.py` replaced with `"eng"`.
-- [ ] The 18 previously-failing tests pass.
-- [ ] `tests/unit/test_pm_session_factory.py::test_create_pm_does_not_exist` still passes (guard intact).
-- [ ] Tests pass (`/do-test`).
-- [ ] Format clean (`python -m ruff format`).
+- [x] All 24 `create_pm` call sites across the 5 files replaced with `create_eng`.
+- [x] `is_pm` assertions in `test_session_lifecycle.py` replaced with `is_eng`.
+- [x] `session_type == "pm"` filter in `test_sdlc_session_ensure_integration.py` replaced with `"eng"`.
+- [x] The 18 previously-failing tests pass.
+- [x] `tests/unit/test_pm_session_factory.py::test_create_pm_does_not_exist` still passes (guard intact).
+- [x] Tests pass (`/do-test`).
+- [x] Format clean (`python -m ruff format`).
 
 ## Team Orchestration
 

--- a/tests/e2e/test_error_boundaries.py
+++ b/tests/e2e/test_error_boundaries.py
@@ -21,7 +21,7 @@ class TestSessionErrorIsolation:
         chat_id = f"iso_chat_{ts}"
 
         # Create two sessions in the same chat
-        session1 = AgentSession.create_pm(
+        session1 = AgentSession.create_eng(
             session_id=f"iso_s1_{ts}",
             project_key="valor",
             working_dir="/tmp/test",
@@ -29,7 +29,7 @@ class TestSessionErrorIsolation:
             telegram_message_id=1,
             message_text="task 1",
         )
-        session2 = AgentSession.create_pm(
+        session2 = AgentSession.create_eng(
             session_id=f"iso_s2_{ts}",
             project_key="valor",
             working_dir="/tmp/test",
@@ -66,7 +66,7 @@ class TestSessionErrorIsolation:
         """A session that encounters an error should be marked 'failed'."""
         ts = int(time.time())
 
-        session = AgentSession.create_pm(
+        session = AgentSession.create_eng(
             session_id=f"err_status_{ts}",
             project_key="valor",
             working_dir="/tmp/test",
@@ -90,7 +90,7 @@ class TestSessionErrorIsolation:
         ts = int(time.time())
 
         # Session in chat A fails
-        s_a = AgentSession.create_pm(
+        s_a = AgentSession.create_eng(
             session_id=f"cross_a_{ts}",
             project_key="valor",
             working_dir="/tmp/test",
@@ -102,7 +102,7 @@ class TestSessionErrorIsolation:
         s_a.save()
 
         # Session in chat B should be unaffected
-        s_b = AgentSession.create_pm(
+        s_b = AgentSession.create_eng(
             session_id=f"cross_b_{ts}",
             project_key="valor",
             working_dir="/tmp/test",

--- a/tests/e2e/test_nudge_loop.py
+++ b/tests/e2e/test_nudge_loop.py
@@ -41,7 +41,7 @@ class TestNudgeLoopOutcomes:
         ts = int(time.time())
         session_id = f"nudge_empty_{ts}"
 
-        session = AgentSession.create_pm(
+        session = AgentSession.create_eng(
             session_id=session_id,
             project_key="valor",
             working_dir="/tmp/test",
@@ -79,7 +79,7 @@ class TestNudgeLoopOutcomes:
         ts = int(time.time())
         session_id = f"nudge_deliver_{ts}"
 
-        session = AgentSession.create_pm(
+        session = AgentSession.create_eng(
             session_id=session_id,
             project_key="valor",
             working_dir="/tmp/test",
@@ -173,7 +173,7 @@ class TestNudgeLoopOutcomes:
         ts = int(time.time())
         session_id = f"nudge_completed_{ts}"
 
-        session = AgentSession.create_pm(
+        session = AgentSession.create_eng(
             session_id=session_id,
             project_key="valor",
             working_dir="/tmp/test",

--- a/tests/e2e/test_queue_isolation.py
+++ b/tests/e2e/test_queue_isolation.py
@@ -18,7 +18,7 @@ class TestPerChatQueueIsolation:
 
     def test_sessions_from_different_chats_are_independent(self):
         """Two chats creating sessions should not interfere."""
-        AgentSession.create_pm(
+        AgentSession.create_eng(
             session_id=f"iso_a_{int(time.time())}",
             project_key="valor",
             working_dir="/tmp/test",
@@ -27,7 +27,7 @@ class TestPerChatQueueIsolation:
             message_text="Hello from chat A",
             sender_name="Alice",
         )
-        AgentSession.create_pm(
+        AgentSession.create_eng(
             session_id=f"iso_b_{int(time.time())}",
             project_key="valor",
             working_dir="/tmp/test",
@@ -49,7 +49,7 @@ class TestPerChatQueueIsolation:
 
     def test_steering_messages_isolated_between_sessions(self):
         """Steering messages pushed to one session must not appear in another."""
-        s1 = AgentSession.create_pm(
+        s1 = AgentSession.create_eng(
             session_id=f"steer_a_{int(time.time())}",
             project_key="valor",
             working_dir="/tmp/test",
@@ -57,7 +57,7 @@ class TestPerChatQueueIsolation:
             telegram_message_id=10,
             message_text="msg1",
         )
-        s2 = AgentSession.create_pm(
+        s2 = AgentSession.create_eng(
             session_id=f"steer_b_{int(time.time())}",
             project_key="valor",
             working_dir="/tmp/test",
@@ -81,7 +81,7 @@ class TestPerChatQueueIsolation:
     def test_same_project_different_chats_are_parallel(self):
         """Two chats for the same project should create independent sessions."""
         ts = int(time.time())
-        AgentSession.create_pm(
+        AgentSession.create_eng(
             session_id=f"par_a_{ts}",
             project_key="shared_project",
             working_dir="/tmp/test",
@@ -89,7 +89,7 @@ class TestPerChatQueueIsolation:
             telegram_message_id=100,
             message_text="task 1",
         )
-        AgentSession.create_pm(
+        AgentSession.create_eng(
             session_id=f"par_b_{ts}",
             project_key="shared_project",
             working_dir="/tmp/test",
@@ -110,7 +110,7 @@ class TestPerChatQueueIsolation:
         """Message dedup should be per-chat, not global."""
         ts = int(time.time())
         # Same message_id in two different chats — both should be created
-        s1 = AgentSession.create_pm(
+        s1 = AgentSession.create_eng(
             session_id=f"dedup_a_{ts}",
             project_key="valor",
             working_dir="/tmp/test",
@@ -118,7 +118,7 @@ class TestPerChatQueueIsolation:
             telegram_message_id=999,
             message_text="same message",
         )
-        s2 = AgentSession.create_pm(
+        s2 = AgentSession.create_eng(
             session_id=f"dedup_b_{ts}",
             project_key="valor",
             working_dir="/tmp/test",

--- a/tests/e2e/test_session_lifecycle.py
+++ b/tests/e2e/test_session_lifecycle.py
@@ -29,7 +29,7 @@ class TestSessionCreationFromMessage:
         )
 
         ts = int(time.time())
-        session = AgentSession.create_pm(
+        session = AgentSession.create_eng(
             session_id=f"tg_valor_{event.chat_id}_{event.message.id}_{ts}",
             project_key="valor",
             working_dir="/Users/test/src/ai",
@@ -42,7 +42,7 @@ class TestSessionCreationFromMessage:
         )
 
         assert session.status == "pending"
-        assert session.is_pm
+        assert session.is_eng
         assert session.message_text == "build feature X"
         assert session.sender_name == "Tom"
         assert session.chat_id == str(event.chat_id)
@@ -56,7 +56,7 @@ class TestSessionCreationFromMessage:
         )
 
         ts = int(time.time())
-        session = AgentSession.create_pm(
+        session = AgentSession.create_eng(
             session_id=f"tg_valor_{event.chat_id}_{event.message.id}_{ts}",
             project_key="valor",
             working_dir="/Users/test/src/ai",
@@ -65,7 +65,7 @@ class TestSessionCreationFromMessage:
             message_text=event.message.text,
         )
 
-        assert session.is_pm
+        assert session.is_eng
         assert session.message_text == "what is the weather?"
 
 
@@ -75,7 +75,7 @@ class TestSessionStatusTransitions:
 
     def test_full_lifecycle(self):
         ts = int(time.time())
-        session = AgentSession.create_pm(
+        session = AgentSession.create_eng(
             session_id=f"lifecycle_{ts}",
             project_key="valor",
             working_dir="/tmp/test",
@@ -115,7 +115,7 @@ class TestSessionStatusTransitions:
 
     def test_dormant_on_open_question(self):
         ts = int(time.time())
-        session = AgentSession.create_pm(
+        session = AgentSession.create_eng(
             session_id=f"dormant_{ts}",
             project_key="valor",
             working_dir="/tmp/test",
@@ -134,7 +134,7 @@ class TestSessionStatusTransitions:
 
     def test_failed_session(self):
         ts = int(time.time())
-        session = AgentSession.create_pm(
+        session = AgentSession.create_eng(
             session_id=f"failed_{ts}",
             project_key="valor",
             working_dir="/tmp/test",
@@ -178,7 +178,7 @@ class TestHistoryAccumulation:
 
     def test_history_appends_entries(self):
         ts = int(time.time())
-        session = AgentSession.create_pm(
+        session = AgentSession.create_eng(
             session_id=f"hist_{ts}",
             project_key="valor",
             working_dir="/tmp/test",
@@ -200,7 +200,7 @@ class TestHistoryAccumulation:
 
     def test_link_tracking(self):
         ts = int(time.time())
-        session = AgentSession.create_pm(
+        session = AgentSession.create_eng(
             session_id=f"links_{ts}",
             project_key="valor",
             working_dir="/tmp/test",

--- a/tests/integration/test_sdlc_session_ensure_integration.py
+++ b/tests/integration/test_sdlc_session_ensure_integration.py
@@ -1,11 +1,11 @@
 """Integration test for tools.sdlc_session_ensure bridge short-circuit.
 
-Drives the headline dashboard claim for #1147: a bridge-initiated PM session
+Drives the headline dashboard claim for #1147: a bridge-initiated Eng session
 with no issue_url (only message_text) must NOT produce a duplicate
 ``sdlc-local-{N}`` record when /sdlc Step 1.5 runs ``ensure_session``.
 
 Uses real Popoto Redis writes (no mocks) to validate the end-to-end flow:
-1. Create a PM AgentSession mimicking bridge creation (session_type=pm,
+1. Create an Eng AgentSession mimicking bridge creation (session_type=eng,
    message_text="SDLC issue 9999", issue_url=None).
 2. Set VALOR_SESSION_ID=<bridge_session_id>.
 3. Invoke ensure_session(9999).
@@ -53,12 +53,12 @@ def cleanup_test_sessions():
 
 
 def test_bridge_short_circuit_produces_no_duplicate(monkeypatch, cleanup_test_sessions):
-    """End-to-end: bridge PM session + VALOR_SESSION_ID => no sdlc-local-N duplicate."""
+    """End-to-end: bridge Eng session + VALOR_SESSION_ID => no sdlc-local-N duplicate."""
     from tools.sdlc_session_ensure import ensure_session
 
     bridge_session_id = "tg_valor_test_9999"
 
-    # Create a bridge-style PM session the way the Telegram bridge would.
+    # Create a bridge-style Eng session the way the Telegram bridge would.
     bridge_session = AgentSession.create_eng(
         session_id=bridge_session_id,
         project_key=TEST_PROJECT_KEY,
@@ -93,15 +93,15 @@ def test_bridge_short_circuit_produces_no_duplicate(monkeypatch, cleanup_test_se
     zombie = list(AgentSession.query.filter(session_id="sdlc-local-9999"))
     assert zombie == [], (
         "ensure_session must NOT create sdlc-local-9999 when "
-        "VALOR_SESSION_ID points at a live PM session"
+        "VALOR_SESSION_ID points at a live Eng session"
     )
 
-    # And there should be exactly one PM session in our test project_key.
-    pm_sessions = [
+    # And there should be exactly one Eng session in our test project_key.
+    eng_sessions = [
         s
         for s in AgentSession.query.all()
         if getattr(s, "project_key", None) == TEST_PROJECT_KEY
-        and getattr(s, "session_type", None) == "pm"
+        and getattr(s, "session_type", None) == "eng"
     ]
-    assert len(pm_sessions) == 1
-    assert pm_sessions[0].session_id == bridge_session_id
+    assert len(eng_sessions) == 1
+    assert eng_sessions[0].session_id == bridge_session_id

--- a/tests/integration/test_sdlc_session_ensure_integration.py
+++ b/tests/integration/test_sdlc_session_ensure_integration.py
@@ -59,7 +59,7 @@ def test_bridge_short_circuit_produces_no_duplicate(monkeypatch, cleanup_test_se
     bridge_session_id = "tg_valor_test_9999"
 
     # Create a bridge-style PM session the way the Telegram bridge would.
-    bridge_session = AgentSession.create_pm(
+    bridge_session = AgentSession.create_eng(
         session_id=bridge_session_id,
         project_key=TEST_PROJECT_KEY,
         working_dir="/tmp",


### PR DESCRIPTION
## Summary

Migrates 24 `AgentSession.create_pm(...)` call sites across 5 test files to the current `AgentSession.create_eng(...)` API (removed during the PM/Dev role-merge, #1691/#1900). Keyword signature is identical, so the rename is a mechanical drop-in.

Also fixes the residual drift the pure rename leaves behind:
- `is_pm` -> `is_eng` assertions in `tests/e2e/test_session_lifecycle.py`
- `session_type == "pm"` -> `"eng"` filter and "PM session" wording in `tests/integration/test_sdlc_session_ensure_integration.py`

Closes #1958.

## Files changed
- `tests/e2e/test_error_boundaries.py` (5 sites)
- `tests/e2e/test_nudge_loop.py` (3 sites)
- `tests/e2e/test_queue_isolation.py` (8 sites)
- `tests/e2e/test_session_lifecycle.py` (7 sites + `is_pm` -> `is_eng`)
- `tests/integration/test_sdlc_session_ensure_integration.py` (1 site + `session_type`/wording)

## Not touched (by design)
- `tests/unit/test_pm_session_factory.py` — guard test asserting `create_pm` stays removed (stays green)
- `tests/integration/test_steering.py::_create_pm_session` — local constructor helper, already on current API

## Verification
- 25 tests pass (`pytest ... -n0`), including the guard test
- 0 residual `create_pm(` / `is_pm` / `session_type == "pm"` in the 5 target files
- 24 `create_eng` call sites confirmed (5+3+8+7+1)
- `ruff format --check` clean

## Test plan
- [x] Affected e2e + integration tests pass
- [x] Guard test `test_create_pm_does_not_exist` still green
- [x] No residual removed-API references