### PR TITLE
Add SDLC_HOLDER_TOKEN env seam to unblock /do-sdlc self-collision (#1971)

### DIFF
--- a/.claude/skills-global/do-sdlc/SKILL.md
+++ b/.claude/skills-global/do-sdlc/SKILL.md
@@ -63,10 +63,22 @@ SDLC_REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null ||
 # repo's plans live. Set once and exported for the lifetime of the supervision loop.
 SDLC_TARGET_REPO=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 export SDLC_TARGET_REPO
+# SDLC_HOLDER_TOKEN (issue #1971): ONE shared issue-lock ownership token for this whole
+# supervision run. /do-sdlc drives the #1954 issue lock through many short-lived `sdlc-tool`
+# subprocesses; each is a fresh OS process, so without a shared token every call mints its
+# own and the run blocks ITSELF (next-skill sees session-ensure's lock as foreign). Persist
+# it to a gitignored file because shell env does not survive across separate tool calls —
+# every state-mutating `sdlc-tool` call below re-exports it from this file. The standalone
+# worker never sets this var (keeps its own random per-process token), so the real
+# worker-vs-local guard is preserved.
+SDLC_RUN_DIR="${AI_REPO_ROOT:-$HOME/src/ai}/data/.sdlc_run"
+mkdir -p "$SDLC_RUN_DIR"
+python3 -c 'import uuid;print(uuid.uuid4().hex)' > "$SDLC_RUN_DIR/holder_{issue_number}"
+export SDLC_HOLDER_TOKEN=$(cat "$SDLC_RUN_DIR/holder_{issue_number}")
 sdlc-tool session-ensure --issue-number {issue_number} --issue-url "https://github.com/$SDLC_REPO/issues/{issue_number}" 2>/dev/null || true
 ```
 
-Idempotent — reuses the existing `sdlc-local-{N}` session on re-runs.
+Idempotent — reuses the existing `sdlc-local-{N}` session on re-runs. **Every `sdlc-tool` state call in Step 3 below MUST re-export `SDLC_HOLDER_TOKEN` from the run file first** (shown inline), or that call self-blocks on the issue lock.
 
 ## Step 3: Supervision Loop
 
@@ -75,6 +87,7 @@ Repeat the following cycle. **Iteration cap: 15 dispatches** (a happy path is 8 
 ### 3a. Ask the router
 
 ```bash
+export SDLC_HOLDER_TOKEN=$(cat "${AI_REPO_ROOT:-$HOME/src/ai}/data/.sdlc_run/holder_{issue_number}")
 sdlc-tool next-skill --issue-number {issue_number}
 ```
 
@@ -88,6 +101,7 @@ Interpret the JSON from the tool result:
 ### 3b. Record the dispatch
 
 ```bash
+export SDLC_HOLDER_TOKEN=$(cat "${AI_REPO_ROOT:-$HOME/src/ai}/data/.sdlc_run/holder_{issue_number}")
 sdlc-tool dispatch record --skill {skill} --issue-number {issue_number}
 # include --pr-number {pr} once a PR exists (review/patch/docs/merge stages)
 ```
@@ -124,6 +138,7 @@ Carry forward context between iterations: once BUILD reports a PR number, includ
 `/do-test` and `/do-patch` do not write their own stage markers — on the bridge, the worker's dev-completion handler does it. Locally, the supervisor must:
 
 ```bash
+export SDLC_HOLDER_TOKEN=$(cat "${AI_REPO_ROOT:-$HOME/src/ai}/data/.sdlc_run/holder_{issue_number}")
 sdlc-tool stage-marker --stage TEST --status completed --issue-number {issue_number} 2>/dev/null || true
 # or --status failed, per the subagent's report
 ```

--- a/docs/features/sdlc-issue-ownership-lock.md
+++ b/docs/features/sdlc-issue-ownership-lock.md
@@ -26,6 +26,12 @@ Both entry points resolve the *identical* deterministic `session_id` for a given
 
 The lock is therefore keyed on a **process-unique `holder_token`**: `uuid.uuid4().hex`, generated once per OS process and cached in a module-level variable (`_process_holder_token()`), stable for the life of that process. Two processes handling the same `session_id` -- on the same or different machines -- get distinct tokens; the same process calling repeatedly (dispatch -> heartbeat -> dispatch) reuses its own token and renews cleanly. `session_id`/`pid`/`hostname` ride along in the payload purely for human-readable display (`owner_session_id` in `IssueLockResult` and in the blocked-dispatch JSON shape) -- they are never compared for ownership.
 
+### The `SDLC_HOLDER_TOKEN` env seam (issue #1971)
+
+Per-process tokens have one failure mode: an SDLC entry point that fans out to **multiple short-lived subprocesses** blocks itself. The standalone worker calls `touch_issue_lock()` in-process (`agent/session_executor.py`), so it always holds one stable token. But a local `/do-sdlc` supervisor drives the router through separate `sdlc-tool` CLI subprocesses (`session-ensure`, then `next-skill`, then `dispatch record`), each a fresh OS process with its own random token. Process A (`session-ensure`) acquires the lock; process B (`next-skill`) peeks, sees A's token as foreign, and short-circuits to `ISSUE_LOCKED` -- the run blocks against itself before dispatching a single stage.
+
+`_process_holder_token()` resolves `SDLC_HOLDER_TOKEN` from the environment first, falling back to the random uuid when it is unset or empty. The `/do-sdlc` skill mints one token per supervision run, persists it to a gitignored run file (`data/.sdlc_run/holder_{issue}`), and re-exports it before every state-mutating `sdlc-tool` call, so all of that run's subprocesses present one consistent owner. The worker never sets the var, so it keeps its random per-process token and the worker-vs-local guard (the #1915 case) is unchanged. Concurrent local supervisors on the *same* issue is out of scope for this seam (the later run overwrites the run file); the primary duplicate-PR guard is worker-vs-local, which stays intact.
+
 ### Behavior
 
 | Scenario | Result |
@@ -122,3 +128,4 @@ A revived terminal session (via `reflections/crash_recovery.py`'s auto-resume or
 | `agent/session_executor.py` | `_tick_issue_lock_renewal()` (tier-1 heartbeat) |
 | `tools/sdlc_stage_marker.py` | `write_marker()`'s renewal call |
 | `.claude/skills/sdlc/SKILL.md` | `ISSUE_LOCKED` guard interpretation contract for `/sdlc`/`/do-sdlc` |
+| `.claude/skills-global/do-sdlc/SKILL.md` | Mints + threads the `SDLC_HOLDER_TOKEN` run token across the supervisor's `sdlc-tool` subprocesses (issue #1971) |

--- a/models/session_lifecycle.py
+++ b/models/session_lifecycle.py
@@ -790,16 +790,29 @@ _holder_token: str | None = None
 
 
 def _process_holder_token() -> str:
-    """Return this OS process's unique lock-ownership token.
+    """Return this process's lock-ownership token.
 
-    Lazily generated on first call and cached in a module-level variable for
-    the remainder of the process's lifetime. This -- not session_id -- is
-    the unit of comparison for issue-lock ownership; see the module note
-    above for why session_id cannot be used.
+    Resolution order, cached in a module-level variable for the remainder of
+    the process's lifetime:
+
+    1. ``SDLC_HOLDER_TOKEN`` env var, when set to a non-empty value. This is
+       the shared-ownership seam (issue #1971): a local ``/do-sdlc``
+       supervisor drives the router through many short-lived ``sdlc-tool``
+       subprocesses, each a fresh OS process. Without a shared token, process
+       B (``next-skill``) sees process A's (``session-ensure``) lock as
+       foreign and blocks the supervisor against itself. The supervisor mints
+       ONE token per run and exports it so all its subprocesses present one
+       consistent owner. The standalone worker calls ``touch_issue_lock()``
+       in-process (one stable token for its lifetime) and never sets this
+       var, so the real worker-vs-local guard (#1954 / #1915) is preserved.
+    2. Otherwise a random ``uuid4`` -- unique per OS process.
+
+    This token -- not session_id -- is the unit of comparison for issue-lock
+    ownership; see the module note above for why session_id cannot be used.
     """
     global _holder_token
     if _holder_token is None:
-        _holder_token = uuid.uuid4().hex
+        _holder_token = os.environ.get("SDLC_HOLDER_TOKEN") or uuid.uuid4().hex
     return _holder_token
 
 

--- a/tests/unit/test_session_lifecycle.py
+++ b/tests/unit/test_session_lifecycle.py
@@ -734,3 +734,32 @@ class TestProcessHolderToken:
         second = _process_holder_token()
         assert first == second
         assert isinstance(first, str) and len(first) > 0
+
+    def test_env_seam_shares_token_across_processes(self, monkeypatch):
+        """SDLC_HOLDER_TOKEN (issue #1971): when set, it IS the token, so
+        every `sdlc-tool` subprocess a /do-sdlc run spawns presents one
+        consistent owner instead of self-blocking on the #1954 lock."""
+        from models.session_lifecycle import _process_holder_token
+
+        monkeypatch.setenv("SDLC_HOLDER_TOKEN", "shared-run-token-xyz")
+        assert _process_holder_token() == "shared-run-token-xyz"
+
+    def test_env_seam_absent_falls_back_to_random_token(self, monkeypatch):
+        """Worker parity: with no env var the token is a random uuid, so the
+        standalone worker keeps its per-process identity and the real
+        worker-vs-local guard stays intact."""
+        from models.session_lifecycle import _process_holder_token
+
+        monkeypatch.delenv("SDLC_HOLDER_TOKEN", raising=False)
+        token = _process_holder_token()
+        assert isinstance(token, str) and len(token) == 32  # uuid4().hex
+
+    def test_env_seam_empty_value_ignored(self, monkeypatch):
+        """An empty SDLC_HOLDER_TOKEN must not become an empty owner token --
+        it falls through to a random uuid."""
+        from models.session_lifecycle import _process_holder_token
+
+        monkeypatch.setenv("SDLC_HOLDER_TOKEN", "")
+        token = _process_holder_token()
+        assert token  # non-empty
+        assert len(token) == 32


### PR DESCRIPTION
## Summary

Fixes #1971 — `/do-sdlc` was structurally blocked at Step 3a on every machine. The #1954 issue-ownership lock compares ownership by a per-**process** `holder_token`, but `/do-sdlc` drives the router through separate short-lived `sdlc-tool` CLI subprocesses. `session-ensure` (process A) acquired the lock; `next-skill` (process B) peeked, saw A's token as foreign, and short-circuited to `ISSUE_LOCKED` — the run blocked against itself before dispatching a single stage.

## Change

- **`models/session_lifecycle.py`** — `_process_holder_token()` now resolves `SDLC_HOLDER_TOKEN` from the environment first (when non-empty), falling back to the existing random `uuid4().hex`. Backward-compatible: absent env var → identical behavior.
- **`.claude/skills-global/do-sdlc/SKILL.md`** — the supervisor mints one token per run, persists it to a gitignored run file (`data/.sdlc_run/holder_{issue}`), and re-exports it before every state-mutating `sdlc-tool` call.
- **`docs/features/sdlc-issue-ownership-lock.md`** — documents the seam, its scope, and why the worker is unaffected.
- **`tests/unit/test_session_lifecycle.py`** — 3 new tests: env var shares token, absent var → random uuid (worker parity), empty var ignored.

## Why the worker is unaffected

The standalone worker calls `touch_issue_lock()` **in-process** (`agent/session_executor.py`) with one stable module-level token for its lifetime, and never sets `SDLC_HOLDER_TOKEN`. So it keeps its random per-process token and the worker-vs-local duplicate-PR guard (the #1915 incident) stays fully intact.

## Scope note

Threading is applied to `/do-sdlc` (the confirmed-broken local supervisor). The `/sdlc` router in the worker/PM context touches the lock through a different in-process interaction that works today; perturbing it without analysis risks a regression, so it is deliberately out of scope.

## Test plan
`pytest tests/unit/test_session_lifecycle.py -n0 -q` → 37 passed