### PR TITLE
Fix stale PM-era terminology in sdlc-pipeline-state.md (#1970)

### DIFF
--- a/docs/features/sdlc-pipeline-state.md
+++ b/docs/features/sdlc-pipeline-state.md
@@ -1,25 +1,25 @@
 # SDLC Pipeline State Tracking
 
-Stage progress for the SDLC pipeline is tracked in Redis via `PipelineStateMachine` on the PM session's `stage_states` field.
+Stage progress for the SDLC pipeline is tracked in Redis via `PipelineStateMachine` on the Eng session's `stage_states` field.
 
 ## How It Works
 
 Each SDLC sub-skill (do-plan, do-build, do-docs, etc.) writes stage markers at start and completion:
 
 ```bash
-python -m tools.sdlc_stage_marker --stage PLAN --status in_progress --issue-number 941
-python -m tools.sdlc_stage_marker --stage PLAN --status completed --issue-number 941
+sdlc-tool stage-marker --stage PLAN --status in_progress --issue-number 941
+sdlc-tool stage-marker --stage PLAN --status completed --issue-number 941
 ```
 
 The SDLC router queries current state before dispatching:
 
 ```bash
-python -m tools.sdlc_stage_query --issue-number 941
+sdlc-tool stage-query --issue-number 941
 ```
 
 ## Session Resolution
 
-The stage marker resolves the PM session in this order:
+The stage marker resolves the Eng session in this order:
 
 1. `--session-id` argument (explicit)
 2. `VALOR_SESSION_ID` env var (bridge-injected)
@@ -33,10 +33,10 @@ For local sessions, `--issue-number` is the primary path since env vars don't pe
 Before dispatching sub-skills, the SDLC router ensures a local session exists:
 
 ```bash
-python -m tools.sdlc_session_ensure --issue-number 941 --issue-url "https://github.com/owner/repo/issues/941"
+sdlc-tool session-ensure --issue-number 941 --issue-url "https://github.com/owner/repo/issues/941"
 ```
 
-This creates an `AgentSession` with `session_id="sdlc-local-941"` and `session_type="pm"`. It's idempotent — running it again returns the existing session.
+This creates an `AgentSession` with `session_id="sdlc-local-941"` and `session_type="eng"`. It's idempotent — running it again returns the existing session.
 
 ### Bridge short-circuit
 
@@ -44,14 +44,14 @@ Inside a bridge-initiated session (where `VALOR_SESSION_ID` is exported by `agen
 
 1. Read `VALOR_SESSION_ID` (or `AGENT_SESSION_ID`) from the environment.
 2. Resolve the session via `tools._sdlc_utils.find_session(session_id=...)`.
-3. Confirm `session_type == "pm"` and `status not in TERMINAL_STATUSES`.
+3. Confirm `session_type == "eng"` and `status not in TERMINAL_STATUSES`.
 4. Return the bridge session id with `created: false` — no `sdlc-local-{N}` record is created.
 
 The short-circuit falls through to the issue-number lookup and create path when:
 
 - The env var is unset or empty.
 - The env-resolved session does not exist in Redis (stale env).
-- The env-resolved session has `session_type != "pm"` (e.g., a Dev session during cross-role debugging).
+- The env-resolved session has `session_type != "eng"` (e.g., a teammate session).
 - The env-resolved session has a terminal status (completed, killed, abandoned, failed, cancelled).
 
 The message-text fallback inside `find_session_by_issue` is a secondary defense for degraded scenarios where `VALOR_SESSION_ID` is missing but a bridge session exists with `issue_url=None` and `message_text="SDLC issue {N}"`. It matches the issue number inside `message_text` using a word-boundary regex (`\bissue\s*#?\s*{N}\b`, case-insensitive) so `tissue 1147` does not false-match.
@@ -62,10 +62,10 @@ Stale zombie `sdlc-local-{N}` sessions (running status, no heartbeats, **and no 
 
 ```bash
 # Preview without modifying (exits 0, prints JSON list)
-python -m tools.sdlc_session_ensure --kill-orphans --dry-run
+sdlc-tool session-ensure --kill-orphans --dry-run
 
 # Finalize each via models.session_lifecycle.finalize_session
-python -m tools.sdlc_session_ensure --kill-orphans
+sdlc-tool session-ensure --kill-orphans
 ```
 
 The CLI always exits 0. Per-session finalize failures are reported inside the JSON payload's `failures` count and per-session `result` list — they never raise. When non-zero zombies are detected, a single stderr line (`[sdlc_session_ensure] found N zombie sdlc-local session(s)`) surfaces the count to scheduled-cleanup operators while stdout stays machine-parseable.
@@ -78,7 +78,7 @@ Verdicts stored in `stage_states._verdicts[stage]["verdict"]` are always in cano
 
 ## `_meta` Keys
 
-`python -m tools.sdlc_stage_query --issue-number N` returns an enriched `_meta` dict alongside the stage statuses. Current keys:
+`sdlc-tool stage-query --issue-number N` returns an enriched `_meta` dict alongside the stage statuses. Current keys:
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -111,6 +111,6 @@ Verdicts stored in `stage_states._verdicts[stage]["verdict"]` are always in cano
 ## Bridge vs Local
 
 - **Bridge sessions**: Worker injects `VALOR_SESSION_ID` env var. Markers resolve via env var. `sdlc_session_ensure` short-circuits and does not create an `sdlc-local-{N}` record. Hooks also fire.
-- **Local sessions**: No env var available. `--issue-number` resolves via `find_session_by_issue()` scanning PM sessions by `issue_url` suffix and (fallback) by `message_text` regex.
+- **Local sessions**: No env var available. `--issue-number` resolves via `find_session_by_issue()` scanning Eng sessions by `issue_url` suffix and (fallback) by `message_text` regex.
 
-Both paths write to the same `stage_states` field on the PM session, so the merge gate and stage query work identically.
+Both paths write to the same `stage_states` field on the Eng session, so the merge gate and stage query work identically.


### PR DESCRIPTION
Closes #1970.

## What changed
Docs-only edit to `docs/features/sdlc-pipeline-state.md`, correcting pre-existing drift that predates the PM/Dev role-merge (#1691/#1900):

1. **`session_type="pm"` -> `session_type="eng"`** and all "PM session" prose -> "Eng session". Verified against `tools/_sdlc_utils.py` (filters on `session_type="eng"` at lines 168/197/284/309) and `tools/sdlc_session_ensure.py` (creates with `session_type="eng"` at line 241).
2. **`python -m tools.sdlc_*` invocation examples -> unified `sdlc-tool` subcommands** (`stage-marker`, `stage-query`, `session-ensure`). Subcommand names confirmed against `sdlc-tool --help` and `scripts/sdlc-tool` `ALLOWED_SUBCOMMANDS`. The kebab->snake mapping means the args pass through verbatim.
3. The non-eng short-circuit example was updated from "a Dev session during cross-role debugging" to "a teammate session" (the natural non-eng session type post-merge).

## Verification
Every claim checked against current code. No stale `session_type="pm"`, "PM session", "Dev session", or `python -m tools.sdlc` references remain in the file. `session_id="sdlc-local-{N}"` and the "Key Files" module-path table are still accurate and left intact.

## Scope
Single file, no code changes, no test impact. Sibling doc `sdlc-tool-resolver.md` carries similar language but was explicitly out of scope for this issue.