### PR TITLE
Fix duplicate reaction emoji in reply-delivery constants (#1961)

### DIFF
--- a/bridge/response.py
+++ b/bridge/response.py
@@ -109,7 +109,7 @@ INVALID_REACTIONS = [
 
 # Reaction emojis for different stages (all validated 2026-02-13)
 REACTION_RECEIVED = "👀"  # Message acknowledged
-REACTION_PROCESSING = "🤔"  # Default thinking emoji
+REACTION_PROCESSING = "✍"  # Actively composing a reply (distinct from REACTION_ERROR's pinned 🤔)
 # REACTION_ABORT parallels REACTION_RECEIVED for the steering-ack path: when a
 # user's follow-up matches an abort keyword, the bridge salutes (🫡 = "understood,
 # standing down") instead of the standard "noted" eyes. Selected inside

--- a/tests/integration/test_reply_delivery.py
+++ b/tests/integration/test_reply_delivery.py
@@ -178,7 +178,11 @@ class TestReactionEmojiSelection:
             str(REACTION_COMPLETE),  # EmojiResult -> str via __str__
             str(REACTION_ERROR),  # EmojiResult -> str via __str__
         ]
-        assert len(set(all_reaction_strs)) == len(all_reaction_strs)
+        duplicates = [e for e in set(all_reaction_strs) if all_reaction_strs.count(e) > 1]
+        assert len(set(all_reaction_strs)) == len(all_reaction_strs), (
+            f"Reply-delivery reaction constants must be pairwise distinct; "
+            f"duplicated emoji: {duplicates} in {all_reaction_strs}"
+        )
 
     def test_no_validated_reaction_in_invalid_list(self):
         """No emoji should be in both VALIDATED_REACTIONS and INVALID_REACTIONS."""


### PR DESCRIPTION
Closes #1961

## Problem
`REACTION_PROCESSING` was `🤔`, colliding with `REACTION_ERROR`, which is pinned to `🤔` in `agent/constants.py` (it must equal `DEFAULT_EMOJI` for the terminal-emoji degraded-path check). Two reply-delivery reaction constants mapping to the same glyph broke the distinctness invariant guarded by `test_reaction_constants_are_distinct`.

## Fix
- `bridge/response.py`: reassigned `REACTION_PROCESSING` from `🤔` to `✍` (present in `VALIDATED_REACTIONS`), which fits the "actively composing a reply" processing stage and is distinct from every other delivery reaction. `REACTION_ERROR` keeps its intentional `🤔` pin.
- `tests/integration/test_reply_delivery.py`: strengthened the distinctness assertion to report the duplicated glyph on failure.

## Validation
```
.venv/bin/python -m pytest tests/integration/test_reply_delivery.py::TestReactionEmojiSelection -n0 -q
7 passed
```