### PR TITLE
Fix valor-email --file bare-string path bug (#1960)

### DIFF
--- a/tests/unit/test_valor_email.py
+++ b/tests/unit/test_valor_email.py
@@ -21,6 +21,7 @@ from tools.valor_email import (
     EMAIL_DRAFT_INLINE_MAX_TOTAL_BYTES,
     _build_session_id,
     _imap_fallback_fetch,
+    _normalize_file_args,
     _normalize_msgid,
     _validate_attachment_files,
     cmd_draft,
@@ -65,6 +66,23 @@ class TestNormalizeMsgid:
     def test_whitespace_only_rejected(self):
         with pytest.raises(argparse.ArgumentTypeError):
             _normalize_msgid("   ")
+
+
+class TestNormalizeFileArgs:
+    """Regression for #1960: normalize the ``--file`` arg into a list of paths."""
+
+    def test_none_returns_empty_list(self):
+        assert _normalize_file_args(None) == []
+
+    def test_empty_list_returns_empty_list(self):
+        assert _normalize_file_args([]) == []
+
+    def test_bare_string_wrapped_not_iterated(self):
+        # The bug: iterating "/abs/path" walks characters. Must wrap as one path.
+        assert _normalize_file_args("/abs/path/doc.txt") == ["/abs/path/doc.txt"]
+
+    def test_list_passed_through(self):
+        assert _normalize_file_args(["/a.pdf", "/b.pdf"]) == ["/a.pdf", "/b.pdf"]
 
 
 class TestImapFallbackFetchAttachments:
@@ -223,6 +241,19 @@ class TestCmdSend:
         keys = list(r.scan_iter(match="email:outbox:cli-*"))
         ttl = r.ttl(keys[0])
         assert 0 < ttl <= 3600
+
+    def test_bare_string_file_arg_attaches_full_path(self, r, tmp_path, capsys):
+        # Regression for #1960: a bare-string ``--file`` value (single path, not
+        # wrapped in a list) must attach the whole path, not be iterated
+        # character-by-character. The old code reported "File not found: /"
+        # because the first character of an absolute path is ``/``.
+        f = tmp_path / "doc.txt"
+        f.write_text("payload")
+        rc = cmd_send(self._args(message="see attached", file=str(f)))
+        assert rc == 0, capsys.readouterr().err
+        keys = list(r.scan_iter(match="email:outbox:cli-*"))
+        payload = json.loads(r.lpop(keys[0]))
+        assert payload["attachments"] == [str(f.resolve())]
 
 
 class TestCmdRead:

--- a/tools/valor_email.py
+++ b/tools/valor_email.py
@@ -353,6 +353,22 @@ def _build_session_id() -> str:
     return f"{_SESSION_ID_PREFIX}-{int(time.time())}-{os.getpid()}-{secrets.token_hex(4)}"
 
 
+def _normalize_file_args(raw: object) -> list[str]:
+    """Normalize the ``--file`` argument into a list of path strings.
+
+    argparse ``action="append"`` yields ``None`` (flag absent) or ``list[str]``,
+    but a bare string (e.g. from a programmatic caller or test Namespace) must be
+    treated as a single path, not iterated character-by-character. Without this,
+    ``for file_path in "/abs/path"`` walks individual characters and the first
+    one (``/``) fails the existence check with "File not found: /".
+    """
+    if not raw:
+        return []
+    if isinstance(raw, str):
+        return [raw]
+    return list(raw)
+
+
 def _validate_attachment_files(
     files: list[str], *, read_bytes: bool = False
 ) -> list[str] | dict[str, bytes] | None:
@@ -403,7 +419,8 @@ def cmd_send(args: argparse.Namespace) -> int:
     body = args.message or ""
     # ``--file`` uses argparse ``action="append"`` — the runtime shape is
     # ``None`` (flag absent) or ``list[str]`` (one entry per ``--file``).
-    files = args.file or []
+    # Normalize so a bare string is a single path, never iterated per-character.
+    files = _normalize_file_args(args.file)
 
     if not body and not files:
         print("Error: Must provide a message or --file", file=sys.stderr)
@@ -515,7 +532,7 @@ def cmd_draft(args: argparse.Namespace) -> int:
     from bridge.email_bridge import _build_reply_mime
 
     body = args.message or ""
-    files = args.file or []
+    files = _normalize_file_args(args.file)
 
     if not body and not files:
         print("Error: Must provide a message or --file", file=sys.stderr)


### PR DESCRIPTION
## Problem

`valor-email send --file <path>` failed with `Error: File not found: /` even for an existing absolute path.

## Root cause

`cmd_send` (and `cmd_draft`) did `files = args.file or []` then `for file_path in files`. When `args.file` was a bare string (a single path, as produced by a programmatic caller or a test `Namespace`), iterating the string walked it **character-by-character**. The first character of an absolute path is `/`, so `Path("/").is_file()` was `False` and the CLI reported `File not found: /`.

## Fix

Added `_normalize_file_args(raw)` which:
- returns `[]` for `None`/empty,
- wraps a bare `str` into a single-element list (never iterated per-character),
- passes an existing list through unchanged.

`cmd_send` and `cmd_draft` now normalize `args.file` through it. The existing argparse `action="append"` list behavior and multi-value `--to` handling are untouched.

## Tests

- `TestNormalizeFileArgs` — unit coverage for the normalizer (None, empty, bare string, list).
- `TestCmdSend::test_bare_string_file_arg_attaches_full_path` — regression reproducing the exact `--file` bare-string bug; attaches the full resolved path.
- Existing `test_end_to_end_with_attachment` integration repro now passes.

```
27 passed, 1 warning in 5.32s
```

Closes #1960