### PR TITLE
Log swallowed last-resort save failure in _execute_agent_session

### DIFF
--- a/agent/session_executor.py
+++ b/agent/session_executor.py
@@ -1787,8 +1787,14 @@ async def _execute_agent_session(session: AgentSession) -> None:
                 try:
                     session.status = "failed"
                     session.save(update_fields=["status", "updated_at"])
-                except Exception:  # noqa: BLE001
-                    pass
+                except Exception as last_resort_err:  # noqa: BLE001
+                    logger.warning(
+                        "[executor-guard] last-resort status save failed for "
+                        "session %s (non-fatal): %s",
+                        session.agent_session_id,
+                        last_resort_err,
+                        exc_info=True,
+                    )
             return
 
         # All session types route through the headless session runner (plan

--- a/tests/unit/test_session_executor_runner_dispatch.py
+++ b/tests/unit/test_session_executor_runner_dispatch.py
@@ -343,6 +343,65 @@ class TestExecutorGuardEmptyTurnInput:
         ]
         assert not guard_errors, f"Guard must NOT fire; got: {guard_errors}"
 
+    @pytest.mark.asyncio
+    async def test_last_resort_save_failure_is_logged(self, redis_test_db, caplog):
+        """Issue #1959: when the empty-turn-input guard's last-resort status
+        save raises, the failure is logged (no silent ``except Exception: pass``).
+
+        Reaches the guard with an empty ``message_text``, forces
+        ``finalize_session`` to raise a non-terminal error (so the executor
+        falls back to a direct ``session.save``), then forces that save to
+        raise as well. The previously-silent swallow must now emit a WARNING
+        carrying the session id so the failure is observable in production.
+        """
+        session = AgentSession.create(
+            session_id=f"guard-save-fail-{uuid.uuid4().hex[:8]}",
+            session_type="eng",
+            project_key="test",
+            working_dir="/tmp",
+            status="pending",
+            chat_id="999",
+            message_text="",  # empty → triggers the empty_turn_input guard
+            sender_name="tester",
+            created_at=datetime.now(tz=UTC),
+            turn_count=0,
+            tool_call_count=0,
+        )
+
+        # Force the last-resort direct save on THIS session instance to raise.
+        def _boom(*args, **kwargs):
+            raise RuntimeError("redis write failed")
+
+        session.save = _boom  # instance-level; leaves the class save intact
+
+        with (
+            _patch_runner(),
+            _patch_worktree(),
+            # finalize_session raising a generic Exception drops the executor
+            # into the last-resort branch that calls session.save directly.
+            patch(
+                "models.session_lifecycle.finalize_session",
+                side_effect=RuntimeError("finalize blew up"),
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            # Must not raise: the swallow keeps its continue-past-error intent.
+            await _execute_agent_session(session)
+
+        assert not FakeSessionRunner.instances, "Runner must not be constructed on the guard path"
+        warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "last-resort status save failed" in r.message
+        ]
+        assert warnings, (
+            "Expected a WARNING when the last-resort save raises; "
+            f"got records: {[r.message for r in caplog.records]}"
+        )
+        assert any(session.agent_session_id in r.message for r in warnings), (
+            "Last-resort save warning must carry the session id for traceability"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Reaction-gating tests (runner exit-classification vocabulary)


### PR DESCRIPTION
## Problem

`_execute_agent_session` (in `agent/session_executor.py`, re-exported via `agent/agent_session_queue.py`) had a bare `except Exception: pass` around its last-resort direct status save inside the empty-turn-input guard. If `session.save()` failed there, the failure was completely silent. No log, no metric, nothing to debug from. This tripped the `TestNoSilentPassRemaining` guard test.

## Fix

Replace the silent swallow with `logger.warning(..., exc_info=True)` carrying the session id, matching the module's existing `[executor-guard]` logging idiom. The control-flow intent is unchanged: the save failure remains non-fatal and the function still returns past it. It is just observable now.

## Test

Added `test_last_resort_save_failure_is_logged` in `tests/unit/test_session_executor_runner_dispatch.py`. It drives `_execute_agent_session` into the empty-turn-input guard, forces `finalize_session` to raise (so the executor falls back to the direct save), forces that save to raise, and asserts a WARNING carrying the session id is emitted via `caplog`.

Verification:
- `tests/unit/test_session_executor_runner_dispatch.py::TestExecutorGuardEmptyTurnInput` — 7 passed
- `tests/integration/test_silent_failures.py::TestNoSilentPassRemaining::test_no_bare_pass_in_critical_functions` — 1 passed

Closes #1959