### PR TITLE
Fix stale judge-model assertion in test_default_config (#1963)

### DIFF
--- a/tests/ai_judge/test_ai_judge.py
+++ b/tests/ai_judge/test_ai_judge.py
@@ -59,12 +59,17 @@ class TestJudgeConfig:
 
     def test_default_config(self):
         """Test default configuration values."""
-        from config.settings import settings
+        from config.settings import ModelSettings, settings
 
         config = JudgeConfig()
-        # The judge default now reads the configured generation model.
+        # The judge default reads the configured generation model — the
+        # process-wide singleton, which reflects any machine-local
+        # MODELS__OLLAMA_GENERATION_MODEL override.
         assert config.model == settings.models.ollama_generation_model
-        assert config.model == "gemma4:31b-cloud"
+        # Assert the CODE default env-independently via a bare ModelSettings():
+        # reading the singleton here would test the machine, not the default
+        # (mirrors tests/unit/test_ollama_consolidation.py::test_generation_model_default).
+        assert ModelSettings().ollama_generation_model == "gemma4:31b-cloud"
         assert config.temperature == 0.1
         assert config.strict_mode is True
         assert config.fallback_to_heuristics is True


### PR DESCRIPTION
## Summary

`tests/ai_judge/test_ai_judge.py::TestJudgeConfig::test_default_config` failed on this machine's HEAD:

```
assert config.model == "gemma4:31b-cloud"
AssertionError: assert 'gemma4:31b' == 'gemma4:31b-cloud'
```

The assertion was **machine-dependent**. `JudgeConfig().model` reads the process-wide `settings` singleton, which reflects any local `MODELS__OLLAMA_GENERATION_MODEL` override. On hosts that set the override (e.g. a local-Ollama machine → `gemma4:31b`) the literal `"gemma4:31b-cloud"` assertion failed; on clean/CI hosts (code default `gemma4:31b-cloud`) it passed.

Simply flipping the literal to `gemma4:31b` — the naive read of the issue — would merely invert the breakage: green locally, red in CI. The issue's own Recon Summary flags this exact inversion.

## Fix

Assert the **code** default env-independently via a bare `ModelSettings()`, the established repo convention (mirrors `tests/unit/test_ollama_consolidation.py::test_generation_model_default`). The retained `config.model == settings.models.ollama_generation_model` line still verifies the judge default wires to the singleton.

The test now passes on both override and clean/CI hosts. No production code or config touched — the `gemma4:31b-cloud` runtime default is intentional (#1636/#1679).

## Verification

```
$ .venv/bin/python -m pytest tests/ai_judge/test_ai_judge.py -n0 -q
........................  (24 passed, exit 0)

$ .venv/bin/python -m pytest tests/ai_judge/test_ai_judge.py::TestJudgeConfig::test_default_config -n0 -q
1 passed in 0.13s
```

Closes #1963