### PR TITLE
fix(#1967): serialize concurrent full-suite pytest runs with advisory lock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ valor-email threads
 | `pytest tests/unit/` | Run unit tests only (~40s parallel) |
 | `pytest tests/unit/ -n0` | Force serial unit run (e.g. for debugging) |
 | `pytest tests/integration/` | Run integration tests only (~125s parallel) |
-| `scripts/pytest-clean.sh <pytest-args>` | Run pytest with automatic xdist worker reaping (drop-in for `pytest`) |
+| `scripts/pytest-clean.sh <pytest-args>` | Run pytest with automatic xdist worker reaping (drop-in for `pytest`). Full-suite runs also take an advisory lock (`data/full-suite-running.lock`) so a second concurrent full-suite run waits instead of oversubscribing cores — see `docs/features/full-suite-pytest-lock.md`. Disable with `PYTEST_SUITE_LOCK=0`. |
 | `scripts/reap-xdist.sh` | Kill any orphan xdist workers on the system (one-shot reaper, idempotent) |
 | `pytest -m sdlc` | Run tests for a specific feature (see `tests/README.md`) |
 | `python -m ruff format . && python -m ruff check .` | Format and lint |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -65,6 +65,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [Enhanced Planning](enhanced-planning.md) | Spike Resolution (Phase 1.5), RFC Review (Phase 2.8), Infrastructure Documentation, and task validation fields for /do-plan | Shipped |
 | [Env Completeness Validation](env-completeness-validation.md) | Detects missing environment variables during `--verify` runs by diffing `.env` against `.env.example`; surfaces `WARN: env-completeness:` lines listing missing keys with descriptions | Shipped |
 | [Features README Sort Check](features-readme-sort-check.md) | PostToolUse hook enforcing alphabetical sort order in the feature index table with auto-fix | Shipped |
+| [Full-suite pytest lock](full-suite-pytest-lock.md) | Advisory lock serializing concurrent full-suite `-n auto` runs so overlapping invocations wait instead of oversubscribing CPU cores | Shipped |
 | [Git State Guard](git-state-guard.md) | Detects and resolves dirty git state (merges, rebases, cherry-picks) before SDLC branch operations | Shipped |
 | [Goal Gates](goal-gates.md) | Deterministic enforcement gates preventing SDLC pipeline from silently skipping stages | Shipped |
 | [Google Calendar Integration](google-calendar-integration.md) | Work session logging as Google Calendar events with segment rounding | Shipped |

--- a/docs/features/full-suite-pytest-lock.md
+++ b/docs/features/full-suite-pytest-lock.md
@@ -1,0 +1,76 @@
+# Full-suite pytest advisory lock
+
+The default pytest config (`pyproject.toml`) runs the suite with
+`-n auto --dist=loadfile` — one xdist worker per CPU core. When two *full-suite*
+runs overlap (a manual run racing `/do-test`, `/do-docs`, or
+`scripts/refresh_test_baseline.py`), total workers exceed cores and every worker
+starves. During PR #1956 the load average reached 79-82 on a 10-core machine;
+one baseline run accumulated 15 seconds of CPU across 90 minutes of wall-clock
+before it was killed — not deadlocked, just almost never scheduled (issue #1967, F1).
+
+## The guard
+
+`scripts/pytest-clean.sh` acquires an advisory lock before launching a
+full-suite run and releases it on exit. A second concurrent full-suite run
+**waits** for the first to finish rather than piling on. The lock reuses the
+`mkdir`-atomic lock-dir pattern already used by `scripts/remote-update.sh`.
+
+The policy lives in `scripts/suite_lock.py`:
+
+| Situation | Behavior |
+|-----------|----------|
+| No other full-suite run | Acquire instantly — **single-run behavior is unchanged** |
+| Another full-suite run is active | Wait (poll every 2s) until it releases, then acquire |
+| Owner process crashed (PID gone) | Reclaim the stale lock immediately |
+| Owner alive but past a 1-hour backstop | Reclaim (guards against a wedged owner) |
+| Waited past `--timeout` (default 30 min) | Proceed **unlocked** with a warning rather than deadlock |
+
+The lock is **narrowly scoped to full-suite runs**. `scripts/suite_lock.py`
+decides full-suite-ness from the pytest arguments:
+
+- Full-suite: `pytest`, `pytest tests`, `pytest tests/` (with any flags).
+- **Not** full-suite (never touches the lock): any narrower path (`tests/unit/`,
+  a `.py` file, a `::` node id) or a serial / xdist-disabled run (`-n0`,
+  `-n 0`, `--numprocesses=0`, `-p no:xdist`).
+
+So quick focused runs keep their unchanged parallelism and never wait.
+
+## Knobs
+
+| Env var | Default | Effect |
+|---------|---------|--------|
+| `PYTEST_SUITE_LOCK` | `1` | Set to `0` to disable the guard entirely (e.g. nested runs) |
+| `PYTEST_SUITE_LOCK_TIMEOUT` | `1800` | Max seconds to wait for another full-suite run before proceeding unlocked |
+
+Lock location: `data/full-suite-running.lock/` (a directory containing
+`owner.pid`), relative to the pytest rootdir — so a worktree run coordinates
+against its own worktree, not the primary checkout.
+
+## CLI
+
+`scripts/suite_lock.py` is also usable directly:
+
+```bash
+python scripts/suite_lock.py is-full-suite -- tests          # exit 0 (yes)
+python scripts/suite_lock.py is-full-suite -- tests/unit/     # exit 1 (no)
+python scripts/suite_lock.py acquire --owner-pid $$ -- tests  # prints ACQUIRED / SKIPPED_NOT_FULL_SUITE / PROCEEDED_UNLOCKED
+python scripts/suite_lock.py release --owner-pid $$
+```
+
+## Scope and follow-ups
+
+This lock fixes F1 (CPU starvation) and the **cross-run** dimension of F2
+(two full-suite runs racing on the same hardcoded Redis sentinel, e.g.
+`test_sdlc_sessionless_e2e.py`'s `ISSUE_NUMBER = 999137`) — serialized runs can
+no longer collide.
+
+The **within-run** dimension of F2 (xdist workers inside a *single* run sharing
+Redis `db=1`) is not addressed here; it needs per-worker namespacing of fixed
+test identifiers and is tracked separately in issue #1967.
+
+## Tests
+
+`tests/unit/test_suite_lock.py` covers full-suite detection, the
+take/wait/steal policy, and real filesystem acquire/release — including a second
+waiter backing off when the owner is alive and a crashed owner's stale lock
+being reclaimed.

--- a/scripts/pytest-clean.sh
+++ b/scripts/pytest-clean.sh
@@ -84,11 +84,52 @@ reap_workers() {
     done
 }
 
+# ── Full-suite advisory lock (issue #1967) ──────────────────────────
+# Concurrent full-suite `-n auto` runs oversubscribe CPU cores: two runs
+# on a 10-core box spawn ~20 workers and every worker starves (load avg
+# 79-82 was observed during PR #1956). This lock serializes full-suite
+# runs — a second full-suite invocation waits for the first rather than
+# piling on. It is advisory and narrowly scoped:
+#   * A lone run acquires instantly; single-run behavior is unchanged.
+#   * Targeted / serial runs (a path below tests/, or -n0) are NOT
+#     full-suite and never touch the lock — quick focused runs keep
+#     their unchanged parallelism.
+#   * scripts/suite_lock.py decides full-suite-ness from the pytest args.
+# Opt out entirely with PYTEST_SUITE_LOCK=0 (e.g. nested runs).
+SUITE_LOCK_HELD=0
+SUITE_LOCK_PY="$REPO_ROOT/scripts/suite_lock.py"
+SUITE_LOCK_DIR="$REPO_ROOT/data/full-suite-running.lock"
+SUITE_LOCK_TIMEOUT="${PYTEST_SUITE_LOCK_TIMEOUT:-1800}"
+
+if [ "${PYTEST_SUITE_LOCK:-1}" != "0" ] && [ -f "$SUITE_LOCK_PY" ]; then
+    LOCK_STATUS=$(python3 "$SUITE_LOCK_PY" acquire \
+        --owner-pid "$$" \
+        --timeout "$SUITE_LOCK_TIMEOUT" \
+        --lock-dir "$SUITE_LOCK_DIR" \
+        -- "$@" 2>/dev/null | tail -n1)
+    if [ "$LOCK_STATUS" = "ACQUIRED" ]; then
+        SUITE_LOCK_HELD=1
+    fi
+fi
+
+release_suite_lock() {
+    [ "$SUITE_LOCK_HELD" = "1" ] || return 0
+    SUITE_LOCK_HELD=0  # idempotent: run at most once
+    python3 "$SUITE_LOCK_PY" release --owner-pid "$$" --lock-dir "$SUITE_LOCK_DIR" \
+        2>/dev/null || true
+}
+
+# Combined cleanup: reap orphan workers AND release the suite lock.
+cleanup() {
+    reap_workers
+    release_suite_lock
+}
+
 # Trap every interesting signal. The leading "-" on the action tells
 # bash to ignore the signal's own failure if the trap fires during
 # shutdown; without it, a final SIGTERM to the wrapper can race with
 # the reap and abort the cleanup.
-trap reap_workers EXIT INT TERM HUP PIPE
+trap cleanup EXIT INT TERM HUP PIPE
 
 # Reap pre-existing orphans first. A prior crash may have left
 # workers behind; pytest would spawn its own fresh set on top and

--- a/scripts/suite_lock.py
+++ b/scripts/suite_lock.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Advisory cross-process lock serializing concurrent full-suite pytest runs.
+
+Fixes issue #1967 (F1): the default pytest config runs ``-n auto`` (one xdist
+worker per CPU core). When two *full-suite* runs overlap — a manual run racing
+``/do-test``, ``/do-docs``, or ``scripts/refresh_test_baseline.py`` — total
+workers exceed cores and every worker starves. During PR #1956 the load average
+reached 79-82 on a 10-core machine; one baseline run accumulated 15 seconds of
+CPU across 90 minutes of wall-clock before being killed.
+
+The guard mirrors the ``mkdir``-atomic lock-dir pattern already used by
+``scripts/remote-update.sh``: a full-suite invocation acquires
+``data/full-suite-running.lock`` before launching pytest and releases it on
+exit. A second concurrent full-suite run *waits* for the first to finish rather
+than piling on. The lock is advisory:
+
+* A lone run acquires instantly — single-run behavior is unchanged.
+* Targeted / serial runs (``-n0``, ``-p no:xdist``, or a narrower path than the
+  whole ``tests/`` tree) are not full-suite and never touch the lock, so quick
+  focused runs keep their unchanged parallelism.
+* A crashed owner leaves a stale lock; the next run reclaims it by checking the
+  owner PID's liveness (``os.kill(pid, 0)``) and a generous age backstop.
+* After an overall ``--timeout`` the waiter proceeds *unlocked* with a warning
+  rather than deadlocking forever.
+
+Shell contract (see ``scripts/pytest-clean.sh``)::
+
+    python scripts/suite_lock.py acquire --owner-pid $$ --timeout 1800 -- "$@"
+    # ... run pytest ...
+    python scripts/suite_lock.py release --owner-pid $$
+
+``acquire`` prints one status token on the last line of stdout:
+
+* ``ACQUIRED``               — lock now held by ``--owner-pid``; caller must release.
+* ``SKIPPED_NOT_FULL_SUITE`` — not a full-suite run; caller must NOT release.
+* ``PROCEEDED_UNLOCKED``     — waited past ``--timeout``; caller must NOT release.
+
+``release`` removes the lock only when its recorded owner PID matches
+``--owner-pid`` (so a run that proceeded unlocked, or whose lock was stolen,
+never yanks the lock out from under the real owner).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+# Value-taking pytest flags: when one appears as its own token, the following
+# token is the flag's value, not a positional test path. (Flags written with
+# ``=`` are self-contained and need no look-ahead.)
+_VALUE_FLAGS = {
+    "-k",
+    "-m",
+    "-n",
+    "-p",
+    "-c",
+    "-o",
+    "-r",
+    "-W",
+    "--dist",
+    "--rootdir",
+    "--maxfail",
+    "--junitxml",
+    "--deselect",
+    "--ignore",
+}
+
+# Owner alive but the lock has out-lived any sane serialized full-suite run:
+# reclaim it. With serialization in force a real run finishes in minutes, so an
+# hour is a wide safety margin against a wedged-but-alive owner.
+DEFAULT_STALE_AFTER = 3600.0
+
+DEFAULT_TIMEOUT = 1800.0
+DEFAULT_POLL_INTERVAL = 2.0
+
+
+def _default_lock_dir() -> Path:
+    return Path.cwd() / "data" / "full-suite-running.lock"
+
+
+def is_full_suite(args: list[str]) -> bool:
+    """Return True when ``args`` describe a whole-``tests/`` pytest invocation.
+
+    A run is *not* full-suite when it narrows to a subset: a positional path
+    that points below ``tests/`` (contains ``/`` or ends in ``.py`` and is not
+    exactly ``tests``/``tests/``), or a serial/no-xdist mode (``-n0``,
+    ``-n 0``, ``-p no:xdist``) where oversubscription cannot occur. A bare
+    ``pytest`` (no path) collects the whole tree and counts as full-suite.
+    """
+    i = 0
+    n = len(args)
+    while i < n:
+        tok = args[i]
+
+        # Serial / xdist-disabled runs cannot oversubscribe cores.
+        if tok in ("-n0", "-n=0"):
+            return False
+        if tok == "-n" and i + 1 < n and args[i + 1] in ("0", "no"):
+            return False
+        if tok.startswith("--numprocesses"):
+            if tok in ("--numprocesses=0", "--numprocesses=no"):
+                return False
+        if tok == "--numprocesses" and i + 1 < n and args[i + 1] in ("0", "no"):
+            return False
+        if tok in ("-p", "--plugin") and i + 1 < n and args[i + 1] == "no:xdist":
+            return False
+        if tok in ("-pno:xdist", "-p=no:xdist", "--plugin=no:xdist"):
+            return False
+
+        # Skip a value-taking flag's separate value token so it is never
+        # mistaken for a narrowing path (e.g. ``-k some/expr``).
+        if tok in _VALUE_FLAGS and i + 1 < n:
+            i += 2
+            continue
+
+        if tok.startswith("-"):
+            i += 1
+            continue
+
+        # Positional token. Is it a narrowing test path?
+        stripped = tok.rstrip("/")
+        if stripped == "tests" or tok == "tests/":
+            i += 1
+            continue
+        if "/" in tok or tok.endswith(".py") or "::" in tok:
+            return False
+        # Bare word positional (e.g. a stray marker) — ignore for detection.
+        i += 1
+
+    return True
+
+
+def evaluate_lock_state(
+    *,
+    exists: bool,
+    owner_pid: int | None,
+    owner_alive: bool,
+    age_seconds: float,
+    stale_after: float,
+) -> str:
+    """Decide what to do about the current lock: ``take``, ``wait``, or ``steal``.
+
+    Pure decision function (no I/O) so the policy is unit-testable:
+
+    * no lock                       -> ``take``
+    * owner PID unreadable, aged    -> ``steal`` (malformed/abandoned)
+    * owner PID unreadable, fresh   -> ``wait``  (owner may still be writing it)
+    * owner process gone            -> ``steal``
+    * owner alive but past backstop -> ``steal``
+    * owner alive and fresh         -> ``wait``
+    """
+    if not exists:
+        return "take"
+    if owner_pid is None:
+        return "steal" if age_seconds >= stale_after else "wait"
+    if not owner_alive:
+        return "steal"
+    if age_seconds >= stale_after:
+        return "steal"
+    return "wait"
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return True if a process with ``pid`` exists (signal 0 probe)."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Exists but owned by another user — still alive for our purposes.
+        return True
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def _read_owner_pid(lock_dir: Path) -> int | None:
+    try:
+        raw = (lock_dir / "owner.pid").read_text().strip()
+        return int(raw)
+    except (OSError, ValueError):
+        return None
+
+
+def _lock_age(lock_dir: Path, now: float) -> float:
+    try:
+        return max(0.0, now - lock_dir.stat().st_mtime)
+    except OSError:
+        return 0.0
+
+
+def _write_owner(lock_dir: Path, owner_pid: int) -> None:
+    try:
+        (lock_dir / "owner.pid").write_text(f"{owner_pid}\n")
+    except OSError:
+        pass
+
+
+def acquire(
+    lock_dir: Path,
+    owner_pid: int,
+    *,
+    timeout: float = DEFAULT_TIMEOUT,
+    poll_interval: float = DEFAULT_POLL_INTERVAL,
+    stale_after: float = DEFAULT_STALE_AFTER,
+    now_fn=time.monotonic,
+    sleep_fn=time.sleep,
+    alive_fn=_pid_alive,
+    log=lambda msg: print(msg, file=sys.stderr),
+) -> str:
+    """Acquire the advisory lock for ``owner_pid``. Returns a status token.
+
+    Blocks (polling every ``poll_interval`` seconds) until the lock is free or
+    reclaimable, up to ``timeout`` seconds of *waiting*. Returns:
+
+    * ``ACQUIRED``           — the lock dir now exists and records ``owner_pid``.
+    * ``PROCEEDED_UNLOCKED`` — waited past ``timeout``; caller runs without the lock.
+    """
+    lock_dir.parent.mkdir(parents=True, exist_ok=True)
+    deadline = now_fn() + timeout
+    waited = False
+
+    while True:
+        try:
+            lock_dir.mkdir()  # atomic on POSIX — the actual mutual exclusion
+            _write_owner(lock_dir, owner_pid)
+            if waited:
+                log("[suite-lock] acquired after waiting for another full-suite run")
+            return "ACQUIRED"
+        except FileExistsError:
+            pass
+
+        owner = _read_owner_pid(lock_dir)
+        alive = alive_fn(owner) if owner is not None else False
+        age = _lock_age(lock_dir, time.time())
+        decision = evaluate_lock_state(
+            exists=True,
+            owner_pid=owner,
+            owner_alive=alive,
+            age_seconds=age,
+            stale_after=stale_after,
+        )
+
+        if decision == "steal":
+            log(
+                f"[suite-lock] reclaiming stale lock "
+                f"(owner_pid={owner}, alive={alive}, age={age:.0f}s)"
+            )
+            _force_remove(lock_dir)
+            continue  # retry mkdir immediately
+
+        # decision == "wait"
+        if now_fn() >= deadline:
+            log(
+                f"[suite-lock] waited {timeout:.0f}s for another full-suite run "
+                f"(owner_pid={owner}); proceeding UNLOCKED"
+            )
+            return "PROCEEDED_UNLOCKED"
+
+        if not waited:
+            log(
+                f"[suite-lock] another full-suite run is active "
+                f"(owner_pid={owner}); waiting up to {timeout:.0f}s"
+            )
+            waited = True
+        sleep_fn(poll_interval)
+
+
+def _force_remove(lock_dir: Path) -> None:
+    try:
+        (lock_dir / "owner.pid").unlink()
+    except OSError:
+        pass
+    try:
+        lock_dir.rmdir()
+    except OSError:
+        # Someone else may have won the race and repopulated it; leave it.
+        pass
+
+
+def release(lock_dir: Path, owner_pid: int) -> bool:
+    """Release the lock only if its recorded owner matches ``owner_pid``.
+
+    Returns True if this call removed the lock, False otherwise (not held, or
+    held by a different owner — e.g. after a steal or a PROCEEDED_UNLOCKED run).
+    """
+    if not lock_dir.exists():
+        return False
+    owner = _read_owner_pid(lock_dir)
+    if owner is not None and owner != owner_pid:
+        return False
+    _force_remove(lock_dir)
+    return True
+
+
+def _split_double_dash(argv: list[str]) -> tuple[list[str], list[str]]:
+    """Split ``argv`` at the first ``--`` into (lock-flags, pytest-args)."""
+    if "--" in argv:
+        idx = argv.index("--")
+        return argv[:idx], argv[idx + 1 :]
+    return argv, []
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if not argv:
+        print("usage: suite_lock.py {acquire,release,is-full-suite} ...", file=sys.stderr)
+        return 2
+    command = argv[0]
+    rest = argv[1:]
+    lock_flags, pytest_args = _split_double_dash(rest)
+
+    parser = argparse.ArgumentParser(prog="suite_lock.py")
+    parser.add_argument("--owner-pid", type=int, default=os.getpid())
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
+    parser.add_argument("--poll-interval", type=float, default=DEFAULT_POLL_INTERVAL)
+    parser.add_argument("--stale-after", type=float, default=DEFAULT_STALE_AFTER)
+    parser.add_argument("--lock-dir", type=Path, default=None)
+    args = parser.parse_args(lock_flags)
+
+    lock_dir = args.lock_dir or _default_lock_dir()
+
+    if command == "is-full-suite":
+        return 0 if is_full_suite(pytest_args) else 1
+
+    if command == "acquire":
+        if not is_full_suite(pytest_args):
+            print("SKIPPED_NOT_FULL_SUITE")
+            return 0
+        status = acquire(
+            lock_dir,
+            args.owner_pid,
+            timeout=args.timeout,
+            poll_interval=args.poll_interval,
+            stale_after=args.stale_after,
+        )
+        print(status)
+        return 0
+
+    if command == "release":
+        release(lock_dir, args.owner_pid)
+        return 0
+
+    print(f"unknown command: {command}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_suite_lock.py
+++ b/tests/unit/test_suite_lock.py
@@ -1,0 +1,212 @@
+"""Unit tests for the full-suite pytest advisory lock (issue #1967, F1).
+
+The lock serializes concurrent full-suite ``-n auto`` runs so overlapping
+invocations wait instead of oversubscribing CPU cores. These tests cover the
+three pure/testable seams:
+
+1. ``is_full_suite`` — which invocations the lock applies to.
+2. ``evaluate_lock_state`` — the take/wait/steal policy.
+3. ``acquire``/``release`` — real filesystem lock-dir behavior, including a
+   second waiter backing off and a crashed owner's stale lock being reclaimed.
+"""
+
+import os
+
+import pytest
+
+from scripts import suite_lock
+
+
+class TestIsFullSuite:
+    @pytest.mark.parametrize(
+        "args",
+        [
+            [],  # bare pytest collects the whole tree
+            ["tests"],
+            ["tests/"],
+            ["-n", "auto", "--dist=loadfile"],
+            ["-k", "test_thing"],  # -k value is not a path
+            ["-m", "sdlc"],
+            ["tests", "-v", "--tb=short"],
+            ["-p", "no:postgresql"],  # value flag, not xdist-disabling
+        ],
+    )
+    def test_full_suite_invocations(self, args):
+        assert suite_lock.is_full_suite(args) is True
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ["tests/unit/"],  # narrower path
+            ["tests/unit/test_suite_lock.py"],
+            ["tests/integration/test_foo.py::TestBar::test_baz"],
+            ["-n0"],  # serial
+            ["-n", "0"],
+            ["--numprocesses=0"],
+            ["-p", "no:xdist"],  # xdist disabled
+            ["tests/unit/", "-k", "lock"],
+        ],
+    )
+    def test_narrowed_or_serial_invocations(self, args):
+        assert suite_lock.is_full_suite(args) is False
+
+    def test_k_expression_containing_slash_is_not_a_path(self):
+        # A value-taking flag's argument must never be read as a narrowing path.
+        assert suite_lock.is_full_suite(["-k", "a/b or c"]) is True
+
+
+class TestEvaluateLockState:
+    def test_no_lock_takes(self):
+        assert (
+            suite_lock.evaluate_lock_state(
+                exists=False, owner_pid=None, owner_alive=False, age_seconds=0, stale_after=3600
+            )
+            == "take"
+        )
+
+    def test_live_owner_fresh_waits(self):
+        assert (
+            suite_lock.evaluate_lock_state(
+                exists=True, owner_pid=123, owner_alive=True, age_seconds=10, stale_after=3600
+            )
+            == "wait"
+        )
+
+    def test_dead_owner_steals(self):
+        assert (
+            suite_lock.evaluate_lock_state(
+                exists=True, owner_pid=123, owner_alive=False, age_seconds=10, stale_after=3600
+            )
+            == "steal"
+        )
+
+    def test_live_owner_past_backstop_steals(self):
+        assert (
+            suite_lock.evaluate_lock_state(
+                exists=True, owner_pid=123, owner_alive=True, age_seconds=7200, stale_after=3600
+            )
+            == "steal"
+        )
+
+    def test_unreadable_owner_fresh_waits(self):
+        assert (
+            suite_lock.evaluate_lock_state(
+                exists=True, owner_pid=None, owner_alive=False, age_seconds=1, stale_after=3600
+            )
+            == "wait"
+        )
+
+    def test_unreadable_owner_aged_steals(self):
+        assert (
+            suite_lock.evaluate_lock_state(
+                exists=True, owner_pid=None, owner_alive=False, age_seconds=9999, stale_after=3600
+            )
+            == "steal"
+        )
+
+
+class TestAcquireRelease:
+    def test_lone_run_acquires_and_releases(self, tmp_path):
+        lock = tmp_path / "full-suite-running.lock"
+        assert suite_lock.acquire(lock, owner_pid=os.getpid()) == "ACQUIRED"
+        assert lock.exists()
+        assert (lock / "owner.pid").read_text().strip() == str(os.getpid())
+
+        assert suite_lock.release(lock, owner_pid=os.getpid()) is True
+        assert not lock.exists()
+
+    def test_release_noop_when_not_held(self, tmp_path):
+        lock = tmp_path / "full-suite-running.lock"
+        assert suite_lock.release(lock, owner_pid=os.getpid()) is False
+
+    def test_release_refuses_when_owner_differs(self, tmp_path):
+        lock = tmp_path / "full-suite-running.lock"
+        suite_lock.acquire(lock, owner_pid=os.getpid())
+        # A run that proceeded unlocked (different owner) must not steal it.
+        assert suite_lock.release(lock, owner_pid=os.getpid() + 1) is False
+        assert lock.exists()
+        assert suite_lock.release(lock, owner_pid=os.getpid()) is True
+
+    def test_second_waiter_backs_off_when_owner_alive(self, tmp_path):
+        """A live owner holds the lock; a second run waits, then proceeds unlocked."""
+        lock = tmp_path / "full-suite-running.lock"
+        # First run (this process) holds the lock.
+        assert suite_lock.acquire(lock, owner_pid=os.getpid()) == "ACQUIRED"
+
+        clock = {"t": 0.0}
+        sleeps: list[float] = []
+
+        def fake_now():
+            return clock["t"]
+
+        def fake_sleep(seconds):
+            sleeps.append(seconds)
+            clock["t"] += seconds
+
+        # Second waiter: owner (this process) is alive, so it must wait the
+        # whole timeout and then proceed unlocked rather than double-run.
+        status = suite_lock.acquire(
+            lock,
+            owner_pid=os.getpid() + 1,
+            timeout=6.0,
+            poll_interval=2.0,
+            now_fn=fake_now,
+            sleep_fn=fake_sleep,
+            alive_fn=lambda pid: True,
+            log=lambda msg: None,
+        )
+        assert status == "PROCEEDED_UNLOCKED"
+        assert sleeps, "waiter should have polled at least once"
+        # The original owner's lock is untouched.
+        assert (lock / "owner.pid").read_text().strip() == str(os.getpid())
+
+    def test_stale_lock_from_dead_owner_is_reclaimed(self, tmp_path):
+        """A crashed owner's lock is reclaimed by the next run immediately."""
+        lock = tmp_path / "full-suite-running.lock"
+        dead_pid = 999_999_999  # not a live process
+        suite_lock.acquire(lock, owner_pid=dead_pid, alive_fn=lambda pid: False)
+        assert (lock / "owner.pid").read_text().strip() == str(dead_pid)
+
+        # New run sees a dead owner and steals the lock without waiting.
+        status = suite_lock.acquire(
+            lock,
+            owner_pid=os.getpid(),
+            timeout=1.0,
+            alive_fn=lambda pid: False,
+            log=lambda msg: None,
+        )
+        assert status == "ACQUIRED"
+        assert (lock / "owner.pid").read_text().strip() == str(os.getpid())
+
+
+class TestCli:
+    def test_acquire_skips_non_full_suite(self, tmp_path, capsys):
+        rc = suite_lock.main(
+            [
+                "acquire",
+                "--lock-dir",
+                str(tmp_path / "l.lock"),
+                "--",
+                "tests/unit/test_suite_lock.py",
+            ]
+        )
+        assert rc == 0
+        assert capsys.readouterr().out.strip() == "SKIPPED_NOT_FULL_SUITE"
+
+    def test_acquire_then_release_roundtrip_via_cli(self, tmp_path, capsys):
+        lock = tmp_path / "l.lock"
+        pid = os.getpid()
+        rc = suite_lock.main(
+            ["acquire", "--owner-pid", str(pid), "--lock-dir", str(lock), "--", "tests"]
+        )
+        assert rc == 0
+        assert capsys.readouterr().out.strip() == "ACQUIRED"
+        assert lock.exists()
+
+        rc = suite_lock.main(["release", "--owner-pid", str(pid), "--lock-dir", str(lock)])
+        assert rc == 0
+        assert not lock.exists()
+
+    def test_is_full_suite_exit_codes(self, tmp_path):
+        assert suite_lock.main(["is-full-suite", "--", "tests"]) == 0
+        assert suite_lock.main(["is-full-suite", "--", "tests/unit/"]) == 1


### PR DESCRIPTION
## Problem

The default pytest config runs `-n auto --dist=loadfile` — one xdist worker per CPU core. When two **full-suite** runs overlap (a manual run racing `/do-test`, `/do-docs`, or `scripts/refresh_test_baseline.py`), total workers exceed cores and every worker starves. During PR #1956 the load average reached 79-82 on a 10-core machine; one baseline run accumulated 15 seconds of CPU across 90 minutes of wall-clock before being killed — not deadlocked, just almost never scheduled (issue #1967, F1).

## Fix

`scripts/pytest-clean.sh` now takes an advisory lock before launching a full-suite run and releases it on exit. A second concurrent full-suite run **waits** for the first to finish rather than piling on. The lock reuses the `mkdir`-atomic lock-dir pattern already used by `scripts/remote-update.sh`.

The policy lives in a new, unit-testable `scripts/suite_lock.py`:

- **Lone run acquires instantly** — single-run behavior is unchanged.
- **Narrowly scoped to full-suite runs.** Targeted paths (`tests/unit/`, a `.py` file, a `::` node id) and serial/xdist-disabled runs (`-n0`, `-p no:xdist`) are not full-suite and never touch the lock — quick focused runs keep their unchanged parallelism.
- **Crashed owner** leaves a stale lock; the next run reclaims it by PID-liveness (`os.kill(pid, 0)`) plus a 1-hour age backstop.
- **Advisory timeout:** after `PYTEST_SUITE_LOCK_TIMEOUT` (default 30 min) a waiter proceeds *unlocked* with a warning rather than deadlocking.
- Opt out entirely with `PYTEST_SUITE_LOCK=0`.

This fixes F1 (CPU starvation) and the **cross-run** dimension of F2 (two runs racing on the same hardcoded Redis sentinel). The **within-run** dimension of F2 (xdist workers inside one run sharing Redis `db=1`) is out of scope and still tracked in the issue.

## Tests

`tests/unit/test_suite_lock.py` — 31 tests: full-suite detection, take/wait/steal policy, and real filesystem acquire/release (including a second waiter backing off when the owner is alive, and a crashed owner's stale lock being reclaimed). Plus manual end-to-end verification of the shell wrapper acquiring and releasing the lock around a stubbed pytest.

```
$ .venv/bin/python -m pytest tests/unit/test_suite_lock.py -n0 -q
31 passed in 0.33s
```

## Files changed

- `scripts/suite_lock.py` (new) — full-suite detection, lock policy, acquire/release, CLI
- `scripts/pytest-clean.sh` — acquire before pytest, release in the exit trap
- `tests/unit/test_suite_lock.py` (new) — 31 tests
- `docs/features/full-suite-pytest-lock.md` (new) + README index + CLAUDE.md quick-ref row

Closes #1967