### PR TITLE
fix(#1962): don't recover a fresh-heartbeat running session as orphaned

### DIFF
--- a/agent/session_health.py
+++ b/agent/session_health.py
@@ -973,6 +973,11 @@ def _never_started_past_grace(
 
     Returns False (safe default) when:
       - ``sdk_ever_output`` is True (session has produced output).
+      - Own-progress sticky evidence is present (issue #1962):
+        ``turn_count > 0``, non-empty ``log_path``, or ``claude_session_uuid``
+        set. Any one proves the session STARTED, so it can never be "never
+        started" — even a bridge-originated remote session that lacks the
+        ``*_at`` liveness fields.
       - ``started_at`` and ``created_at`` are both None (legacy / phantom
         record) — no running_seconds to compute.
       - ``running_seconds`` is below the combined threshold.
@@ -986,6 +991,26 @@ def _never_started_past_grace(
         # agent.session_runner.liveness.
         sdk_ever_output = derive_sdk_ever_output(entry)
         if sdk_ever_output:
+            return False
+
+        # Own-progress sticky evidence (#944/#963, issue #1962): a session
+        # carrying any of ``turn_count > 0`` / ``log_path`` / ``claude_session_uuid``
+        # has demonstrably STARTED — a turn boundary was observed, a log file
+        # was opened, or the SDK authenticated. These sticky fields cannot
+        # prove *current* liveness (that is the fresh-heartbeat / sdk_ever_output
+        # concern, gated elsewhere), but "never started" is a strictly weaker
+        # claim: a started-then-stuck session is NOT a never-started one.
+        # Without this guard, a bridge-originated remote session (turn_count>0
+        # but no local log_path/uuid or ``*_at`` liveness fields) is
+        # misclassified as never-started once past the grace window, and the
+        # D0 gate in ``_has_progress`` sub-check B short-circuits the whole
+        # function to False — causing the #944 orphan net to recover a session
+        # that is actively heartbeating (issue #1962).
+        if (getattr(entry, "turn_count", 0) or 0) > 0:
+            return False
+        if (getattr(entry, "log_path", None) or "").strip():
+            return False
+        if getattr(entry, "claude_session_uuid", None):
             return False
 
         if now is None:

--- a/tests/unit/test_never_started_recovery.py
+++ b/tests/unit/test_never_started_recovery.py
@@ -119,6 +119,91 @@ class TestNeverStartedPastGrace:
         # 200s > threshold using started_at
         assert _never_started_past_grace(session) is True
 
+    def test_returns_false_for_started_session_via_turn_count(self):
+        """Issue #1962: turn_count>0 proves the session STARTED — never flag it.
+
+        A bridge-originated remote session accrues turn_count without ever
+        writing local log_path/claude_session_uuid or the ``*_at`` liveness
+        fields, so ``sdk_ever_output`` stays False. Age past grace must NOT
+        classify it as never-started.
+        """
+        from agent.session_health import _never_started_past_grace
+
+        session = _make_session(
+            created_at=datetime.now(UTC) - timedelta(seconds=14400),  # 4h, far past grace
+            turn_count=12,
+            log_path=None,
+            claude_session_uuid=None,
+        )
+        assert _never_started_past_grace(session) is False
+
+    def test_returns_false_for_started_session_via_log_path(self):
+        """Issue #1962: a non-empty log_path proves the session STARTED."""
+        from agent.session_health import _never_started_past_grace
+
+        session = _make_session(
+            created_at=datetime.now(UTC) - timedelta(seconds=14400),
+            log_path="/tmp/logs/session.log",
+        )
+        assert _never_started_past_grace(session) is False
+
+    def test_returns_false_for_started_session_via_claude_uuid(self):
+        """Issue #1962: a claude_session_uuid proves the SDK authenticated."""
+        from agent.session_health import _never_started_past_grace
+
+        session = _make_session(
+            created_at=datetime.now(UTC) - timedelta(seconds=14400),
+            claude_session_uuid="abc-123",
+        )
+        assert _never_started_past_grace(session) is False
+
+    def test_still_flags_genuinely_never_started_session(self):
+        """Issue #1962 guard: a session with NO own-progress evidence, past
+        grace, and no SDK output IS still flagged (regression protection)."""
+        from agent.session_health import _never_started_past_grace
+
+        session = _make_session(
+            created_at=datetime.now(UTC) - timedelta(seconds=200),
+            turn_count=0,
+            log_path=None,
+            claude_session_uuid=None,
+        )
+        assert _never_started_past_grace(session) is True
+
+
+class TestFreshHeartbeatStartedSessionSurvives:
+    """Issue #1962: a running session with a fresh heartbeat that has already
+    STARTED (turn_count>0) must report progress, so the #944 orphan net leaves
+    it alone — regardless of wall-clock age or missing local handle fields."""
+
+    def test_fresh_heartbeat_started_session_has_progress(self):
+        """The exact fixture from the failing integration test: 4h old,
+        turn_count=12, fresh heartbeat, no log_path/uuid → _has_progress True."""
+        from agent.session_health import _has_progress
+
+        session = _make_session(
+            started_at=datetime.now(UTC) - timedelta(hours=4),
+            last_heartbeat_at=datetime.now(UTC) - timedelta(seconds=30),
+            turn_count=12,
+            log_path=None,
+            claude_session_uuid=None,
+        )
+        assert _has_progress(session) is True
+
+    def test_stale_heartbeat_started_session_no_progress(self):
+        """Counterpart: a started session whose heartbeat has gone stale past
+        the no-output budget reports NO progress, so recovery still applies."""
+        from agent.session_health import _has_progress
+
+        session = _make_session(
+            started_at=datetime.now(UTC) - timedelta(hours=4),
+            last_heartbeat_at=datetime.now(UTC) - timedelta(seconds=3600),  # >1800s budget
+            turn_count=12,
+            log_path=None,
+            claude_session_uuid=None,
+        )
+        assert _has_progress(session) is False
+
 
 class TestSubCheckBDeniedPastGrace:
     """Test that sub-check B is denied for never-started past grace (D0 gate)."""

--- a/tests/unit/test_session_health_inference_removed.py
+++ b/tests/unit/test_session_health_inference_removed.py
@@ -241,29 +241,66 @@ def test_zombie_profile_is_not_progress():
 
 def test_own_progress_gate_fresh_heartbeat_is_progress():
     """
-    D0 gate (issue #1724): fresh heartbeat does NOT protect a session that is past
-    the never-started grace window with zero SDK output.
+    Issue #1962: an own-progress session (claude_session_uuid set — the SDK
+    authenticated) with a FRESH heartbeat is protected, even past the
+    never-started grace window.
 
-    A session running for 3600s with sdk_ever_output=False (neither last_tool_use_at
-    nor last_turn_at set) is correctly treated as never-started. The D0 gate denies
-    the fresh-heartbeat fast-path and returns False, enabling recovery.
+    The D0 gate (issue #1724) recovers sessions that NEVER started. A session
+    carrying a sticky own-progress field (turn_count / log_path /
+    claude_session_uuid) has demonstrably started, so it is exempt from the
+    never-started classification — a fresh heartbeat is then dispositive
+    evidence it is alive, and _has_progress returns True. Recovering it would
+    kill a legitimately-running (e.g. bridge-originated) long session.
 
-    Note: the class name "fresh heartbeat is progress" is now a misnomer post-D0 gate.
-    The gate fires before the heartbeat fast-path can return True.
+    Contrast test_own_progress_gate_stale_heartbeat_never_started below, which
+    keeps the D0-gate-fires behavior for a genuinely never-started session with
+    no own-progress evidence.
     """
     now = datetime.now(tz=UTC)
 
     class _S:
         last_tool_use_at = None
         last_turn_at = None
-        last_heartbeat_at = now  # FRESH — but D0 gate fires before fast-path
+        last_heartbeat_at = now  # FRESH — dispositive for a started session
         last_sdk_heartbeat_at = None
         last_stdout_at = None
         started_at = now - timedelta(seconds=3600)  # 3600s >> 150s grace
         created_at = now - timedelta(seconds=3600)
         turn_count = 0
         log_path = None
-        claude_session_uuid = "abc"  # set
+        claude_session_uuid = "abc"  # set — proves the session STARTED
+        project_key = "test"
+
+        def get_children(self):
+            return []
+
+    result = session_health._has_progress(_S())
+    assert result is True, (
+        "A started session (claude_session_uuid set) with a fresh heartbeat must "
+        "return True — issue #1962: own-progress + fresh heartbeat is not orphaned"
+    )
+
+
+def test_own_progress_gate_stale_heartbeat_never_started():
+    """
+    Issue #1724 (retained): a genuinely never-started session — no own-progress
+    evidence (turn_count=0, log_path=None, claude_session_uuid=None) and no SDK
+    output — past the grace window returns False regardless of heartbeat, so the
+    D0 gate still recovers it. This is the regression guard for #1962's exemption.
+    """
+    now = datetime.now(tz=UTC)
+
+    class _S:
+        last_tool_use_at = None
+        last_turn_at = None
+        last_heartbeat_at = now  # FRESH — but no own-progress evidence
+        last_sdk_heartbeat_at = None
+        last_stdout_at = None
+        started_at = now - timedelta(seconds=3600)  # 3600s >> 150s grace
+        created_at = now - timedelta(seconds=3600)
+        turn_count = 0
+        log_path = None
+        claude_session_uuid = None
         project_key = "test"
 
         def get_children(self):
@@ -271,8 +308,8 @@ def test_own_progress_gate_fresh_heartbeat_is_progress():
 
     result = session_health._has_progress(_S())
     assert result is False, (
-        "Session past never-started grace (3600s >> 150s) with sdk_ever_output=False "
-        "must return False — the D0 gate fires before the heartbeat fast-path"
+        "A never-started session (no own-progress fields, sdk_ever_output=False) "
+        "past grace must return False — the D0 gate fires and recovery applies"
     )
 
 


### PR DESCRIPTION
Closes #1962

## Problem

The session health monitor's `#944` "no in-scope handle" orphan net recovered a RUNNING session that had a **fresh heartbeat**, treating it as orphaned. A session that is actively heartbeating must never be swept.

Reproduced by the pre-existing acceptance test, which failed on `main`:
```
pytest tests/integration/test_agent_session_health_monitor.py::TestJobHealthCheck::test_long_running_session_with_fresh_heartbeat_survives -q -n0
```
Warning captured before the fix:
```
[session-health] Recovering session ... (kind=no_progress): no progress signal, orphaned running row
(no in-scope handle, #944), 14400s (>300s guard, ..., turn_count=12, log_path=None, claude_session_uuid=None)
```

## Root cause

The `#944` elif recovers when `not _has_progress(entry)`. `_has_progress` sub-check B contains the `#1724` D0 "never-started" gate (`_never_started_past_grace`), which does an early `return False` for the **entire function** before the own-progress block (the one that returns True for `turn_count > 0` with a fresh heartbeat) is ever reached.

`_never_started_past_grace` classified "never started" **solely** from `derive_sdk_ever_output` (the `last_tool_use_at` / `last_turn_at` / `last_stdout_at` freshness fields). A bridge-originated remote session accrues `turn_count` without ever writing those local fields, so it was misclassified as never-started once past the 150s grace window and swept as orphaned.

## Fix

`agent/session_health.py::_never_started_past_grace` now returns `False` (not never-started) when the session carries sticky own-progress evidence: `turn_count > 0`, a non-empty `log_path`, or a `claude_session_uuid`. Any one proves the session **started**, so "never started" is impossible. `_has_progress` then falls through to the own-progress block, which gates liveness on heartbeat freshness exactly as designed — a fresh heartbeat keeps the session alive; a stale heartbeat (past the no-output budget) still permits recovery. No new magic numbers; reuses the existing grace/budget/freshness constants.

## Tests

- `tests/unit/test_never_started_recovery.py` — added: started-session exemption via `turn_count` / `log_path` / `claude_session_uuid`; a still-flags-genuinely-never-started guard; and a `_has_progress` fresh-vs-stale heartbeat split for a started session.
- `tests/unit/test_session_health_inference_removed.py` — UPDATE: `test_own_progress_gate_fresh_heartbeat_is_progress` encoded the pre-#1962 stance (recover an own-progress session past grace); flipped to the #1962 semantics, plus a companion `..._stale_heartbeat_never_started` regression guard.
- `tests/integration/test_agent_session_health_monitor.py::...::test_long_running_session_with_fresh_heartbeat_survives` — now passes.

```
pytest tests/unit/test_session_health_inference_removed.py tests/unit/test_never_started_recovery.py \
  tests/integration/test_agent_session_health_monitor.py::TestJobHealthCheck::test_long_running_session_with_fresh_heartbeat_survives -n0
# 41 passed
```

Three failures in `tests/integration/test_session_heartbeat_progress.py` (`TestHeartbeatFreshness` x2, `test_reprieve_via_recent_compaction`) are pre-existing on `origin/main` and unrelated to this change (verified by re-running them without the patch).