### PR TITLE
fix(#1980): preserve valid completion when resumed turn exits non-zero after a result event

### DIFF
--- a/agent/sdk_client.py
+++ b/agent/sdk_client.py
@@ -2383,9 +2383,13 @@ async def get_response_via_harness(
     and pathological large single messages it bounds the argv to prevent the
     binary's "Separator is found" overflow crash.
 
-    If the resumed subprocess exits with **any** non-zero return code, retries
-    once using ``full_context_message`` without ``--resume`` (no stderr substring
-    gate — substring matching is brittle across CLI versions and locales).
+    If the resumed subprocess exits with **any** non-zero return code **without
+    having emitted a ``result`` event**, retries once using
+    ``full_context_message`` without ``--resume`` (no stderr substring gate —
+    substring matching is brittle across CLI versions and locales). Issue #1980:
+    a non-zero exit that follows a fired ``result`` event keeps the captured
+    completion and does NOT retry — the ``result`` event is the protocol's
+    completion signal, and a fresh retry would clobber a valid answer.
 
     A separate exit-code-0 sentinel check (``IMAGE_DIMENSION_SENTINEL``) is placed
     **above** the ``returncode != 0`` guard to handle Claude Code's image-dimension
@@ -2520,6 +2524,26 @@ async def get_response_via_harness(
             "model": model or "default",
         }
 
+    # Capture whether the PRIMARY invocation emitted a `result` event (issue
+    # #1980). `_run_harness_subprocess` reports this as the second arg of
+    # `on_exit_status(returncode, result_event_fired)` — it is the ONLY precise
+    # signal for "a result event fired." The returned `result_text` cannot stand
+    # in for it: `_run_harness_subprocess` returns a non-None string both when a
+    # result event fired (BRANCH A) AND when no result event fired but partial
+    # streamed text accumulated (BRANCH B), so `result_text is None` is true only
+    # in BRANCH C. The stale-UUID fallback below gates on this boolean so a
+    # resumed turn that produced a valid completion is never discarded by a
+    # destructive fresh-session retry on a post-turn non-zero exit.
+    primary_result_event_fired = False
+
+    def _capture_primary_exit(rc: int | None, fired: bool) -> None:
+        nonlocal primary_result_event_fired
+        primary_result_event_fired = fired
+        # Chain to the caller's callback so the role driver's exit_statuses
+        # list still receives every subprocess invocation (residual #1916).
+        if on_exit_status is not None:
+            on_exit_status(rc, fired)
+
     # Call site 1 of 3 — primary harness invocation. 8-tuple unpack
     # (issue #1099 Mode 1 added stderr_snippet; issue #1245 added num_turns
     # and tool_call_count).
@@ -2541,7 +2565,7 @@ async def get_response_via_harness(
         on_sdk_finished=on_sdk_finished,
         on_stdout_event=on_stdout_event,
         on_init=on_init,
-        on_exit_status=on_exit_status,
+        on_exit_status=_capture_primary_exit,
         ttft_metadata=_ttft_meta,
         true_session_id=session_id,
     )
@@ -2600,11 +2624,23 @@ async def get_response_via_harness(
             )
 
     # Mandatory stale-UUID fallback: when prior_uuid was set and the subprocess
-    # exits with ANY non-zero return code, retry once without --resume using the
-    # full-context message. The fallback does NOT inspect stderr — substring
-    # matching is brittle across CLI versions and locales, and an unnecessary
-    # retry on a non-stale-UUID error costs only one extra subprocess spawn.
-    if prior_uuid and returncode is not None and returncode != 0:
+    # exits with ANY non-zero return code WITHOUT having emitted a `result` event,
+    # retry once without --resume using the full-context message. The fallback
+    # does NOT inspect stderr — substring matching is brittle across CLI versions
+    # and locales, and an unnecessary retry on a non-stale-UUID error costs only
+    # one extra subprocess spawn.
+    #
+    # Issue #1980: gate on `not primary_result_event_fired`. A resumed turn that
+    # emitted a `result` event is a SUCCESSFUL resume; its completion is the
+    # protocol's completion signal (mirrors the role driver's residual-#1916
+    # contract at role_driver.py: "a nonzero exit AFTER a result event keeps the
+    # result"). Without this gate, a valid completion followed by a post-turn
+    # non-zero exit triggered a fresh-session retry whose empty output clobbered
+    # the good result_text — the wrap-up guard then delivered the canned
+    # OPERATOR_TERMINAL_MESSAGE instead of the real answer. The fallback still
+    # fires when no result event fired (BRANCH B partial text, or BRANCH C genuine
+    # stale UUID), preserving all pre-existing recovery.
+    if prior_uuid and returncode is not None and returncode != 0 and not primary_result_event_fired:
         if full_context_message is not None:
             logger.warning(
                 f"[harness] Stale UUID {prior_uuid} for session_id={session_id}, "
@@ -2652,6 +2688,18 @@ async def get_response_via_harness(
                 "falling back to first-turn path — no full_context_message available"
             )
             result_text = None
+    elif prior_uuid and returncode is not None and returncode != 0 and primary_result_event_fired:
+        # Issue #1980 observability: a resumed turn exited non-zero but a result
+        # event fired first, so the stale-UUID fallback is deliberately skipped
+        # and the captured completion is kept. Logged so incident triage can tell
+        # this apart from a fallback that fired.
+        logger.info(
+            "[harness] Resumed turn exited %s AFTER a result event for "
+            "session_id=%s — keeping the completion, skipping stale-UUID fallback "
+            "(issue #1980)",
+            returncode,
+            session_id,
+        )
 
     # Store the Claude Code UUID for next-turn --resume (#976)
     if session_id and session_id_from_harness:

--- a/docs/features/headless-session-runner.md
+++ b/docs/features/headless-session-runner.md
@@ -158,6 +158,40 @@ Stale or invalid scalars (missing `runner_cwd`, unknown `claude_session_uuid`)
 discard cleanly to a cold start with a full first-turn prime — there is no
 crash on a bad resume pointer.
 
+### Stale-UUID fallback vs. the result-event completion signal (issue #1980)
+
+A resumed (`--resume`) turn whose subprocess exits **non-zero** may need one
+fresh-session retry — a genuinely stale/invalid UUID makes `claude --resume`
+error out before producing any output. `get_response_via_harness`
+(`agent/sdk_client.py`) runs exactly that retry once, without `--resume`, using
+the caller's `full_context_message`.
+
+That retry is **gated on whether the primary invocation emitted a `result`
+event**, not on whether it exited zero. The invariant: *a `result` event is the
+protocol's completion signal.* If the resumed subprocess emitted a `result`
+event (`stop_reason: end_turn`) and only *then* exited non-zero — a post-turn or
+cleanup artifact — the captured completion is authoritative and the fallback is
+**skipped**, keeping the real answer. This mirrors, one layer down, the role
+driver's residual-#1916 rule (`role_driver.py`: "a nonzero exit AFTER a result
+event keeps the result").
+
+The gate keys off the true `result_event_fired` boolean, captured from the
+primary invocation's `on_exit_status(returncode, result_event_fired)` callback —
+**not** off the returned `result_text`. `result_text` is a non-empty string in
+two distinct cases (a fired result event, or accumulated partial text with *no*
+result event from a crashed subprocess), so `result_text is None` cannot
+distinguish "resume succeeded" from "crashed with partial text." The fallback
+therefore still fires whenever no result event fired (partial text or a genuine
+stale UUID), preserving all recovery.
+
+Before this gate existed, a valid completion followed by a non-zero exit
+triggered the retry, whose empty output overwrote the good `result_text`;
+`get_response_via_harness` returned `""`, `HeadlessRoleDriver.run_turn`'s
+`if not reply:` guard set `exit_reason="empty_output"`, and the wrap-up guard
+delivered the canned `OPERATOR_TERMINAL_MESSAGE` instead of the real answer.
+`OPERATOR_TERMINAL_MESSAGE` is now reserved for a genuinely empty PM turn (no
+result event and no recoverable text).
+
 ## Auth
 
 The runner sets `CLAUDE_CODE_OAUTH_TOKEN` and strips `ANTHROPIC_API_KEY` in

--- a/docs/plans/wrapup-guard-reply-text-loss.md
+++ b/docs/plans/wrapup-guard-reply-text-loss.md
@@ -1,11 +1,12 @@
 ---
-status: Planning
+status: Ready
 type: bug
 appetite: Small
 owner: Valor Engels
 created: 2026-07-09
 tracking: https://github.com/tomcounsell/ai/issues/1980
 last_comment_id:
+revision_applied: true
 ---
 
 # Wrap-up Guard Reply-Text Loss (stale-UUID fallback clobbers a valid result)
@@ -125,14 +126,26 @@ No prerequisites — this work has no external dependencies. The regression test
 
 ### Key Elements
 
-- **Stale-UUID fallback gate (`agent/sdk_client.py:2607`)**: add a `result_text is None`
-  clause so the destructive fresh-session retry fires only when the resumed subprocess
-  produced no `result` event at all (the genuine stale/invalid-UUID case, where `claude
-  --resume` errors out before emitting any result). A resumed turn that emitted a `result`
-  event is a successful resume; a subsequent non-zero exit must not discard the completion.
-- **Comment update**: document that the fallback is gated on "no result event fired," and
-  that this enforces at the harness layer the same "result event is the completion signal"
-  invariant that `role_driver.py:453-454` documents at the driver layer.
+- **Stale-UUID fallback gate (`agent/sdk_client.py:2607`)**: gate the destructive
+  fresh-session retry on the *true* "did a `result` event fire on the primary invocation?"
+  boolean, so it fires only when **no** result event fired. A resumed turn that emitted a
+  `result` event is a successful resume; a subsequent non-zero exit must not discard the
+  completion. The retry still fires for a genuinely stale/invalid UUID (`claude --resume`
+  errors before any result event) AND for a crashed subprocess that streamed only partial
+  text with no result event (BRANCH B, below) — preserving all pre-existing recovery.
+- **Capture the boolean precisely, not via `result_text`**: `_run_harness_subprocess`'s
+  returned `result_text` does NOT cleanly encode "result event fired." It has three branches
+  (`sdk_client.py:3093-3129`): **A** result event fired → returns `""` or text (non-None);
+  **B** no result event but accumulated `full_text` → returns a **non-empty string**
+  (non-None); **C** nothing → returns `None`. So `result_text is None` is true only in
+  BRANCH C — it would wrongly skip the fallback in BRANCH B. The precise fact already exists:
+  `_run_harness_subprocess` calls `on_exit_status(returncode, result_text is not None)`
+  (`sdk_client.py:3089`) where the second arg is exactly `result_event_fired`. Capture it
+  for the primary invocation and gate on `not result_event_fired`.
+- **Comment + log update**: document that the fallback is gated on "no result event fired,"
+  enforcing at the harness layer the same "result event is the completion signal" invariant
+  that `role_driver.py:453-454` documents at the driver layer; add a log line at the gate
+  recording `prior_uuid`, `returncode`, and the fallback-fired decision for incident triage.
 
 ### Flow
 
@@ -144,23 +157,42 @@ the real text.
 
 ### Technical Approach
 
+- Capture the primary invocation's `result_event_fired` boolean. Immediately before the
+  primary `_run_harness_subprocess` call (site 1, `sdk_client.py:2526`), define a wrapper
+  around the caller's `on_exit_status` that records the `fired` flag into a local, then
+  chains to the original callback (so the role driver's `exit_statuses` list still receives
+  every invocation for its residual-#1916 logic):
+  ```python
+  primary_result_event_fired = False
+
+  def _capture_primary_exit(rc, fired):
+      nonlocal primary_result_event_fired
+      primary_result_event_fired = fired
+      if on_exit_status is not None:
+          on_exit_status(rc, fired)
+  ```
+  Pass `on_exit_status=_capture_primary_exit` at call site 1 only. (Sites 2 and 3 keep the
+  raw `on_exit_status`; the gate decision precedes any fallback, so the primary's value is
+  authoritative at gate-evaluation time.)
 - Change the gate at `agent/sdk_client.py:2607` from:
   ```python
   if prior_uuid and returncode is not None and returncode != 0:
   ```
   to:
   ```python
-  if prior_uuid and returncode is not None and returncode != 0 and result_text is None:
+  if prior_uuid and returncode is not None and returncode != 0 and not primary_result_event_fired:
   ```
-  `result_text is None` iff no `result` event fired on the primary invocation (the
-  `_run_harness_subprocess` return contract: `result_text` is non-None exactly when a
-  result event fired — see `sdk_client.py:3085-3129` and the `on_exit_status(returncode,
-  result_text is not None)` call at line 3089). An empty-but-present result (`""`) is a
-  genuinely empty turn and correctly does NOT trigger the fallback, satisfying acceptance
-  criterion #3.
+  This fires the fallback in BRANCH B (partial `full_text`, no result event — a crashed
+  subprocess worth a fresh retry) and BRANCH C (genuine stale UUID, nothing produced),
+  matching the pre-existing behavior, and skips it only in BRANCH A (a result event fired —
+  the completion is authoritative). An empty-but-present result event (`""`, BRANCH A with
+  empty text) correctly does NOT trigger the fallback and returns `""`, so
+  OPERATOR_TERMINAL_MESSAGE stays reserved for a genuinely empty turn (acceptance #3).
+- Add a `logger.info` at the gate recording the branch decision (skip vs. fire) with
+  `prior_uuid`, `returncode`, `primary_result_event_fired`.
 - Leave the image-dimension fallback (`sdk_client.py:2559-2600`) untouched — it is gated
-  independently on `IMAGE_DIMENSION_SENTINEL` and a truthy `result_text`, and does not
-  interact with this change (that path runs on `returncode == 0`).
+  independently on `IMAGE_DIMENSION_SENTINEL` and a truthy `result_text`, and runs on
+  `returncode == 0`, so it does not interact with this change.
 - No change to `role_driver.py` or `runner.py`: once the harness stops clobbering, the
   existing residual-#1916 guard and wrap-up-guard classification deliver the text correctly.
 
@@ -172,11 +204,19 @@ the real text.
 - State: "No exception handlers added in scope."
 
 ### Empty/Invalid Input Handling
-- The core behavior under test IS empty-output handling. New tests assert:
-  - Non-empty `result` event + non-zero exit + `prior_uuid` → real text returned (fallback skipped).
-  - `result_text is None` (no result event) + non-zero exit + `prior_uuid` → fallback still fires (stale-UUID recovery preserved).
-  - Empty-string `result` event (`""`) + non-zero exit → fallback NOT fired; returns `""` (genuinely empty; OPERATOR_TERMINAL_MESSAGE is then correct downstream).
-- Verifies empty output does not trigger a silent loop: the fallback is bounded to one retry and now only fires when there is genuinely nothing to preserve.
+- The core behavior under test IS empty-output handling. New tests assert, keyed to the
+  three `_run_harness_subprocess` return branches:
+  - **BRANCH A (fired=True)**: result event fired + non-zero exit + `prior_uuid` → real text
+    returned, fallback skipped (the bug fix).
+  - **BRANCH A empty (fired=True, `""`)**: empty result event + non-zero exit → fallback NOT
+    fired; returns `""` (genuinely empty; OPERATOR_TERMINAL_MESSAGE correct downstream).
+  - **BRANCH B (fired=False, partial `full_text`)**: no result event + accumulated partial
+    text + non-zero exit + `prior_uuid` → fallback STILL fires (crashed-subprocess recovery
+    preserved; NOT a regression).
+  - **BRANCH C (fired=False, `None`)**: no result event, nothing produced + non-zero exit +
+    `prior_uuid` → fallback STILL fires (genuine stale-UUID recovery preserved).
+- Verifies empty output does not trigger a silent loop: the fallback is bounded to one retry
+  and only skipped when a result event genuinely fired.
 
 ### Error State Rendering
 - End-to-end `run_turn` test asserts that a nonzero-exit-with-result turn yields a non-empty
@@ -186,7 +226,7 @@ the real text.
 ## Test Impact
 
 - [ ] `tests/unit/test_harness_retry.py::TestHarnessRetry::test_first_retry_increments_counter_and_returns_empty` — REVIEW/no change expected: this covers the AgentSession-level agent retry (different mechanism), not the stale-UUID subprocess fallback. Verify it still passes; no edit anticipated.
-- [ ] `tests/integration/test_harness_resume.py::test_stale_uuid_triggers_fallback` — REVIEW/no change expected: a genuinely stale UUID produces NO result event on the primary, so `result_text is None` and the fallback still fires. Confirm this integration test still passes unchanged.
+- [ ] `tests/integration/test_harness_resume.py::test_stale_uuid_triggers_fallback` — UPDATE (required re-run + CI coverage): a genuinely stale UUID produces NO result event on the primary (`fired=False`, BRANCH C), so the fallback still fires. This is a **live** test (does not mock `_run_harness_subprocess`) and is skipped in binary-free CI, so it cannot be relied on to catch a regression of the gate. The new unit test file MUST include a mocked BRANCH C case (fired=False → fallback fires) so the guard runs without a `claude` binary. Confirm the live test still passes where a binary is present.
 - [ ] `tests/unit/test_sdk_client_harness_counters.py` — REVIEW/no change expected: counter accumulation across primary+fallback is unaffected when the fallback is legitimately skipped. Confirm green.
 
 No existing test asserts the buggy behavior (clobber-on-nonzero-exit-with-result), so no
@@ -208,13 +248,15 @@ test needs DELETE/REPLACE — the fix is additive to the gate and the regression
 
 ### Risk 1: A genuinely stale UUID that somehow emits a result event before erroring
 **Impact:** If `claude --resume <bad-uuid>` could emit a `result` event and *then* fail, the
-gated fallback would be skipped and we'd return that (possibly partial) result instead of
-retrying fresh.
+gated fallback would be skipped and we'd return that result instead of retrying fresh.
 **Mitigation:** By protocol, `claude --resume` on an unrecognized UUID errors during startup
-*before* producing any `result` event — `result_text` stays `None`, so the fallback still
-fires. The integration test `test_stale_uuid_triggers_fallback` guards this empirically. If a
-result event fired, the resume demonstrably succeeded and its output is authoritative
-(consistent with the role-driver's documented contract).
+*before* producing any `result` event — `primary_result_event_fired` stays `False`, so the
+fallback still fires. The integration test `test_stale_uuid_triggers_fallback` guards this
+empirically where a binary is present, and the new mocked BRANCH C unit test guards it in CI.
+If a result event fired, the resume demonstrably succeeded and its output is authoritative
+(consistent with the role-driver's documented contract). Note this gate keys off the true
+`result_event_fired` boolean, NOT `result_text is None` — so BRANCH B (partial `full_text`,
+no result event) still correctly triggers the fallback.
 
 ### Risk 2: Masking a real failure by delivering a result from a subprocess that exited non-zero
 **Impact:** Delivering content from a subprocess that ultimately exited non-zero.
@@ -270,19 +312,24 @@ tests exercise `get_response_via_harness` and `HeadlessRoleDriver.run_turn` dire
 
 ## Success Criteria
 
-- [ ] Root cause documented: stale-UUID fallback at `sdk_client.py:2607` clobbers a valid
+- [ ] **User-facing outcome**: on a resumed wrap-up turn whose subprocess emits a valid
+  `[/complete]`/`[/user]` final message and then exits non-zero, the human receives the real
+  completion text — NOT the canned `OPERATOR_TERMINAL_MESSAGE`. Verified by the
+  `HeadlessRoleDriver.run_turn` end-to-end test (non-empty `reply_text`, `exit_reason !=
+  "empty_output"`). (Acceptance #2)
+- [ ] Root cause documented: stale-UUID fallback at `sdk_client.py:2607` clobbered a valid
   `result_text` on a non-zero exit that followed a fired `result` event. (Acceptance #1)
-- [ ] Regression test: a turn whose primary subprocess emits valid final text and exits
-  non-zero returns that text (fallback skipped), and `HeadlessRoleDriver.run_turn` propagates
-  it (non-empty `reply_text`, `exit_reason != "empty_output"`) — real text delivered, not
-  `OPERATOR_TERMINAL_MESSAGE`. (Acceptance #2)
-- [ ] Test: `result_text is None` + non-zero exit + `prior_uuid` still triggers the fallback
-  (stale-UUID recovery preserved).
-- [ ] Test: empty-string result event does not spuriously trigger the fallback and yields
-  `""` — OPERATOR_TERMINAL_MESSAGE remains reserved for a genuinely empty PM turn. (Acceptance #3)
+- [ ] Test BRANCH A (fired=True): valid final text + non-zero exit + `prior_uuid` → text
+  returned, fallback skipped.
+- [ ] Test BRANCH B (fired=False, partial text) + non-zero exit + `prior_uuid` → fallback
+  STILL fires (crashed-subprocess recovery preserved, not regressed).
+- [ ] Test BRANCH C (fired=False, `None`) + non-zero exit + `prior_uuid` → fallback STILL
+  fires (stale-UUID recovery preserved). Runs mocked in binary-free CI.
+- [ ] Test empty-string result event (fired=True, `""`) → fallback NOT fired; returns `""`.
+  OPERATOR_TERMINAL_MESSAGE remains reserved for a genuinely empty PM turn. (Acceptance #3)
 - [ ] Tests pass (`/do-test`)
 - [ ] Documentation updated (`/do-docs`)
-- [ ] `grep -n "result_text is None" agent/sdk_client.py` confirms the gate change is present.
+- [ ] `grep -n "not primary_result_event_fired" agent/sdk_client.py` confirms the gate change is present.
 
 ## Team Orchestration
 
@@ -339,7 +386,7 @@ Small single-file fix; solo builder + code reviewer.
 
 | Check | Command | Expected |
 |-------|---------|----------|
-| Gate change present | `grep -n "returncode != 0 and result_text is None" agent/sdk_client.py` | exit code 0 |
+| Gate change present | `grep -n "not primary_result_event_fired" agent/sdk_client.py` | exit code 0 |
 | Regression tests pass | `pytest tests/unit/test_harness_stale_uuid_result_preservation.py -q` | exit code 0 |
 | Existing harness tests pass | `pytest tests/unit/test_harness_retry.py tests/unit/test_sdk_client_harness_counters.py tests/unit/test_sdk_client.py -q` | exit code 0 |
 | Lint clean | `python -m ruff check agent/sdk_client.py tests/unit/test_harness_stale_uuid_result_preservation.py` | exit code 0 |
@@ -348,6 +395,10 @@ Small single-file fix; solo builder + code reviewer.
 
 ## Critique Results
 
-<!-- Populated by /do-plan-critique (war room). Leave empty until critique is run. -->
+<!-- Populated by /do-plan-critique (war room). -->
 | Severity | Critic | Finding | Addressed By | Implementation Note |
 |----------|--------|---------|--------------|---------------------|
+| BLOCKER | Risk & Robustness + History & Consistency | `result_text is None` gate is not equivalent to "no result event fired" — BRANCH B (partial `full_text`, no result event) returns non-None, so the gate would silently skip the fallback and regress crashed-subprocess recovery. | Gate now keys off the true `result_event_fired` boolean (captured from the primary invocation's `on_exit_status`), gating on `not primary_result_event_fired`. Technical Approach + Solution rewritten; false "iff" claim removed. | Capture `fired` via a wrapper around `on_exit_status` at primary call site 1; chain to the original so role-driver's `exit_statuses` still receives every invocation. |
+| CONCERN | Risk & Robustness | BRANCH B adversarial path untested (matrix only covered A and C). | Added BRANCH B unit test (fired=False, partial text → fallback fires) to the test matrix and Success Criteria. | Mock returns `("partial…", sid, 1, ...)` with `on_exit_status(1, False)`; assert fallback fires. |
+| CONCERN | Risk & Robustness + History & Consistency | Stale-UUID safety rested only on a CI-skippable live test; no gate observability. | Added a mocked BRANCH C unit test (runs in binary-free CI); upgraded Test Impact disposition to UPDATE/required-re-run; added a `logger.info` at the gate recording the skip-vs-fire decision. | Live `test_stale_uuid_triggers_fallback` remains as an empirical guard where a binary exists. |
+| NIT | Scope & Value | Success criteria were almost entirely mechanical. | Promoted the user-facing outcome (human receives the real completion, not the canned message) to an explicit, user-phrased Success Criterion. | — |

--- a/docs/plans/wrapup-guard-reply-text-loss.md
+++ b/docs/plans/wrapup-guard-reply-text-loss.md
@@ -1,0 +1,353 @@
+---
+status: Planning
+type: bug
+appetite: Small
+owner: Valor Engels
+created: 2026-07-09
+tracking: https://github.com/tomcounsell/ai/issues/1980
+last_comment_id:
+---
+
+# Wrap-up Guard Reply-Text Loss (stale-UUID fallback clobbers a valid result)
+
+## Problem
+
+A PM turn (including the wrap-up guard's bounded extra turn) can produce a fully valid,
+complete `[/complete]`/`[/user]` final message — persisted in the raw Claude Code
+transcript with `stop_reason: "end_turn"` — and the human still receives the canned
+`OPERATOR_TERMINAL_MESSAGE` ("I wasn't able to produce a response to this. Please rephrase
+or follow up.") instead of the real ~1,300-character completion.
+
+**Current behavior:**
+Inside `get_response_via_harness` (`agent/sdk_client.py`), a resumed (`--resume`) subprocess
+can emit a valid `result` event carrying the completion text and *then* exit non-zero (a
+post-turn/cleanup non-zero exit, not an external kill). The stale-UUID fallback at
+`agent/sdk_client.py:2607` fires on `prior_uuid and returncode is not None and returncode != 0`
+**without checking whether a `result` event already fired**. It re-runs a fresh session
+(no `--resume`, using `full_context_message`); that retry's empty/different output overwrites
+the good `result_text`, so `get_response_via_harness` returns `""`.
+`HeadlessRoleDriver.run_turn`'s `if not reply:` empty-output guard
+(`agent/session_runner/role_driver.py:433-436`) then sets `outcome.reply_text = ""` /
+`exit_reason = "empty_output"`, and `_run_wrapup_guard` (`agent/session_runner/runner.py:1178-1180`)
+delivers `OPERATOR_TERMINAL_MESSAGE`.
+
+This defeats a contract the role driver *already documents* but cannot enforce, because the
+clobber happens one layer below it. `role_driver.py:453-454`: *"A nonzero exit AFTER a
+result event keeps the result: the event is the protocol's completion signal."* The role
+driver's residual-#1916 guard (`role_driver.py:457-468`) only keeps a result on a nonzero
+exit when a result event fired — but by the time it runs, `get_response_via_harness` has
+already discarded the text via the fallback retry.
+
+**Desired outcome:**
+When the underlying harness subprocess produces a valid `result` event, that text propagates
+to `HeadlessRoleDriver.run_turn`'s return value and is delivered to the human — even on a
+non-zero exit, even inside the wrap-up guard's bounded turn. `OPERATOR_TERMINAL_MESSAGE`
+fires only when the PM turn genuinely produced no result event and no accumulated text.
+
+## Freshness Check
+
+**Baseline commit:** d875ae226fed1e066e47eed00b4aad2c792e7bc1
+**Issue filed at:** 2026-07-09T10:45:25Z
+**Disposition:** Unchanged
+
+**File:line references re-verified:**
+- `agent/sdk_client.py:2607` — stale-UUID fallback gate `if prior_uuid and returncode is not None and returncode != 0:` — still holds verbatim.
+- `agent/sdk_client.py:2949-2996` — `result` event handler `result_text = data.get("result", "")` then `break` — still holds.
+- `agent/sdk_client.py:2751-2753` — `if result_text is not None: return result_text` / `return ""` — still holds.
+- `agent/session_runner/role_driver.py:433-436` — `if not reply:` empty-output guard — still holds.
+- `agent/session_runner/role_driver.py:451-468` — residual-#1916 "nonzero exit WITHOUT a result event is a failed turn" guard, comment at 453-454 documents the intended "result event is the completion signal" contract — still holds.
+- `agent/session_runner/runner.py:1149-1183` — `_run_wrapup_guard`, OPERATOR_TERMINAL_MESSAGE fallback at 1178-1180 — still holds.
+
+**Cited sibling issues/PRs re-checked:**
+- #1979 — sticky `response_delivered_at` premature finalization; issue explicitly ruled it out as the same root cause (different timing window). Not a blocker.
+- #1916 (residual) — the role-driver guard this bug defeats one layer up. Confirms the intended contract; our fix enforces it at the correct layer.
+
+**Commits on main since issue was filed (touching referenced files):** none (`git log --since=<createdAt> -- agent/sdk_client.py agent/session_runner/role_driver.py agent/session_runner/runner.py` returned empty).
+
+**Active plans in `docs/plans/` overlapping this area:** none.
+
+**Notes:** No drift. All line references cited in the issue are exact against baseline.
+
+## Prior Art
+
+- **#1063**: "sdk_client --resume returns image-dimension error text (exit 0) — fallback never fires" — established the image-dimension sentinel path that sits *above* the stale-UUID fallback (`agent/sdk_client.py:2559`). Confirms the fallback ladder shape; our change touches only the stale-UUID gate, not the image path.
+- **#1916**: added the role-driver residual guard (`role_driver.py:451-468`) that keeps a result on a nonzero exit iff a result event fired. This bug is the missing counterpart *one layer down* — `get_response_via_harness` must not clobber the result before that guard runs.
+- **#1058**: "replace [PIPELINE_COMPLETE] marker with reliable PM final-delivery protocol" — same delivery-reliability theme; not the same root cause.
+- No prior issue/PR found for "stale-UUID fallback discards a valid result event." This is a first fix for this specific path.
+
+## Why Previous Fixes Failed
+
+| Prior Fix | What It Did | Why It Failed / Was Incomplete |
+|-----------|-------------|-------------------------------|
+| #1916 (role_driver residual guard) | On a nonzero exit, keep the result iff a `result` event fired; else classify as failed turn. | Correct policy, wrong layer for THIS path. It runs in `HeadlessRoleDriver.run_turn` *after* `get_response_via_harness` returns. The stale-UUID fallback inside `get_response_via_harness` already overwrote `result_text` with the fresh-retry's empty output, so the guard never sees the completion. |
+
+**Root cause pattern:** the "a `result` event is the protocol's completion signal" invariant
+is enforced at the role-driver layer but violated at the harness layer. The fix moves the
+invariant down to where the clobber happens.
+
+## Data Flow
+
+1. **Entry point**: `SessionRunner._run_wrapup_guard` (`runner.py:1159`) calls `self._driver.run_turn(PM_WRAPUP_PROMPT...)`.
+2. **`HeadlessRoleDriver.run_turn`** (`role_driver.py:381`): `reply = await asyncio.wait_for(harness_fn(...), timeout=turn_timeout_s)` where `harness_fn` is `get_response_via_harness`. This turn rides `--resume` (`prior_uuid` set from earlier turns).
+3. **`get_response_via_harness`** (`sdk_client.py`): primary `_run_harness_subprocess` call (site 1, line 2526) parses stream-json; the `result` event sets `result_text` = the completion (line 2950); subprocess then exits non-zero → `returncode != 0`.
+4. **Clobber (the bug)**: `sdk_client.py:2607` `if prior_uuid and returncode != 0:` → fallback re-runs `_run_harness_subprocess` (site 3, line 2635) with `full_context_message`, no `--resume`; that retry returns empty `result_text`, overwriting the good value.
+5. **Return**: `if result_text is not None: return result_text` (line 2751) — now `""` (or `None` → `""`).
+6. **`run_turn`**: `if not reply:` (line 433) → `outcome.reply_text=""`, `exit_reason="empty_output"`.
+7. **Output**: `_run_wrapup_guard` sees empty text → `on_user_payload(OPERATOR_TERMINAL_MESSAGE)` (`runner.py:1179`). Real completion lost.
+
+The fix intercepts at step 4: skip the fallback when step 3 already produced a `result` event
+(`result_text is not None`).
+
+## Architectural Impact
+
+- **New dependencies**: none.
+- **Interface changes**: none. `get_response_via_harness` signature and return type unchanged.
+- **Coupling**: unchanged. One conditional gains a clause using a local already in scope (`result_text`).
+- **Data ownership**: unchanged.
+- **Reversibility**: trivial — the change is one added boolean clause; revert is a one-line diff.
+
+## Appetite
+
+**Size:** Small
+
+**Team:** Solo dev, code reviewer
+
+**Interactions:**
+- PM check-ins: 0 (root cause pinned via code recon; no scope ambiguity)
+- Review rounds: 1 (code review before merge)
+
+## Prerequisites
+
+No prerequisites — this work has no external dependencies. The regression tests mock
+`_run_harness_subprocess`, so no live `claude` binary or network is required.
+
+## Solution
+
+### Key Elements
+
+- **Stale-UUID fallback gate (`agent/sdk_client.py:2607`)**: add a `result_text is None`
+  clause so the destructive fresh-session retry fires only when the resumed subprocess
+  produced no `result` event at all (the genuine stale/invalid-UUID case, where `claude
+  --resume` errors out before emitting any result). A resumed turn that emitted a `result`
+  event is a successful resume; a subsequent non-zero exit must not discard the completion.
+- **Comment update**: document that the fallback is gated on "no result event fired," and
+  that this enforces at the harness layer the same "result event is the completion signal"
+  invariant that `role_driver.py:453-454` documents at the driver layer.
+
+### Flow
+
+Resumed wrap-up turn → subprocess emits valid `result` event (completion text captured)
+→ subprocess exits non-zero → **fallback gate now sees `result_text is not None` and skips
+the retry** → `get_response_via_harness` returns the completion → `run_turn` returns it
+(residual-#1916 guard keeps it) → `_run_wrapup_guard` classifies `[/complete]` and delivers
+the real text.
+
+### Technical Approach
+
+- Change the gate at `agent/sdk_client.py:2607` from:
+  ```python
+  if prior_uuid and returncode is not None and returncode != 0:
+  ```
+  to:
+  ```python
+  if prior_uuid and returncode is not None and returncode != 0 and result_text is None:
+  ```
+  `result_text is None` iff no `result` event fired on the primary invocation (the
+  `_run_harness_subprocess` return contract: `result_text` is non-None exactly when a
+  result event fired — see `sdk_client.py:3085-3129` and the `on_exit_status(returncode,
+  result_text is not None)` call at line 3089). An empty-but-present result (`""`) is a
+  genuinely empty turn and correctly does NOT trigger the fallback, satisfying acceptance
+  criterion #3.
+- Leave the image-dimension fallback (`sdk_client.py:2559-2600`) untouched — it is gated
+  independently on `IMAGE_DIMENSION_SENTINEL` and a truthy `result_text`, and does not
+  interact with this change (that path runs on `returncode == 0`).
+- No change to `role_driver.py` or `runner.py`: once the harness stops clobbering, the
+  existing residual-#1916 guard and wrap-up-guard classification deliver the text correctly.
+
+## Failure Path Test Strategy
+
+### Exception Handling Coverage
+- No new `except Exception: pass` blocks introduced. The touched function already has
+  fail-quiet Popoto/token side effects guarded elsewhere; this change adds no handlers.
+- State: "No exception handlers added in scope."
+
+### Empty/Invalid Input Handling
+- The core behavior under test IS empty-output handling. New tests assert:
+  - Non-empty `result` event + non-zero exit + `prior_uuid` → real text returned (fallback skipped).
+  - `result_text is None` (no result event) + non-zero exit + `prior_uuid` → fallback still fires (stale-UUID recovery preserved).
+  - Empty-string `result` event (`""`) + non-zero exit → fallback NOT fired; returns `""` (genuinely empty; OPERATOR_TERMINAL_MESSAGE is then correct downstream).
+- Verifies empty output does not trigger a silent loop: the fallback is bounded to one retry and now only fires when there is genuinely nothing to preserve.
+
+### Error State Rendering
+- End-to-end `run_turn` test asserts that a nonzero-exit-with-result turn yields a non-empty
+  `outcome.reply_text` and `exit_reason != "empty_output"` — i.e. the real content reaches
+  the delivery path rather than being swallowed into the canned message.
+
+## Test Impact
+
+- [ ] `tests/unit/test_harness_retry.py::TestHarnessRetry::test_first_retry_increments_counter_and_returns_empty` — REVIEW/no change expected: this covers the AgentSession-level agent retry (different mechanism), not the stale-UUID subprocess fallback. Verify it still passes; no edit anticipated.
+- [ ] `tests/integration/test_harness_resume.py::test_stale_uuid_triggers_fallback` — REVIEW/no change expected: a genuinely stale UUID produces NO result event on the primary, so `result_text is None` and the fallback still fires. Confirm this integration test still passes unchanged.
+- [ ] `tests/unit/test_sdk_client_harness_counters.py` — REVIEW/no change expected: counter accumulation across primary+fallback is unaffected when the fallback is legitimately skipped. Confirm green.
+
+No existing test asserts the buggy behavior (clobber-on-nonzero-exit-with-result), so no
+test needs DELETE/REPLACE — the fix is additive to the gate and the regression coverage is new.
+
+## Rabbit Holes
+
+- **Reading the transcript `.jsonl` as a recovery source** when the stdout `result` event is
+  missing/null. Tempting (the transcript had the text) but a much larger change and NOT this
+  bug — here the `result` event DID fire; the problem is discarding it. Out of scope.
+- **Reworking `content_block_start` full_text reset** (`sdk_client.py:3014-3015` resets
+  `full_text` per content block). A latent hardening concern for the no-result-event fallback
+  path, but unrelated to this bug (which has a result event). Do not touch.
+- **Turn-timeout tuning** for the wrap-up guard vs. main loop. The issue floated a timeout
+  race as an open question; recon rules it out (no kill/timeout log line; the clobber fully
+  explains the symptom). Do not chase timeout tuning.
+
+## Risks
+
+### Risk 1: A genuinely stale UUID that somehow emits a result event before erroring
+**Impact:** If `claude --resume <bad-uuid>` could emit a `result` event and *then* fail, the
+gated fallback would be skipped and we'd return that (possibly partial) result instead of
+retrying fresh.
+**Mitigation:** By protocol, `claude --resume` on an unrecognized UUID errors during startup
+*before* producing any `result` event — `result_text` stays `None`, so the fallback still
+fires. The integration test `test_stale_uuid_triggers_fallback` guards this empirically. If a
+result event fired, the resume demonstrably succeeded and its output is authoritative
+(consistent with the role-driver's documented contract).
+
+### Risk 2: Masking a real failure by delivering a result from a subprocess that exited non-zero
+**Impact:** Delivering content from a subprocess that ultimately exited non-zero.
+**Mitigation:** This is the *intended* contract, already documented at `role_driver.py:453-454`
+("a nonzero exit AFTER a result event keeps the result"). A `result` event with
+`stop_reason: end_turn` is a clean model completion; a subsequent non-zero exit is a
+post-turn/cleanup artifact, not a reason to discard a user's answer. The residual-#1916 guard
+still classifies a nonzero exit *without* a result event as a failed turn.
+
+## Race Conditions
+
+No race conditions identified. `get_response_via_harness` is a single async coroutine; the
+primary and fallback subprocess calls are sequential `await`s within one turn. `result_text`
+is a local variable read and written on the same coroutine with no concurrent access. The
+change adds a read of an already-materialized local to a synchronous conditional.
+
+## No-Gos (Out of Scope)
+
+- [SEPARATE-SLUG #1979] Sticky `response_delivered_at` premature-finalization fix — a distinct
+  root cause on the same session, tracked separately.
+
+## Update System
+
+No update system changes required — this is a purely internal behavioral fix to a single
+conditional in `agent/sdk_client.py`. No new dependencies, config files, migrations, or
+`scripts/update/` changes. No Popoto schema changes.
+
+## Agent Integration
+
+No agent integration required — this is a bridge/worker-internal change to the headless
+session runner's harness call path. No new CLI entry point, no `.mcp.json`/`mcp_servers/`
+change, and the bridge (`bridge/telegram_bridge.py`) does not need to import anything new.
+The fix restores correct delivery through the *existing* agent output path; the regression
+tests exercise `get_response_via_harness` and `HeadlessRoleDriver.run_turn` directly.
+
+## Documentation
+
+### Feature Documentation
+- [ ] Update `docs/features/headless-session-runner.md` — add a subsection under the harness
+  fallback / turn-outcome discussion documenting the "a `result` event is the completion
+  signal; the stale-UUID fallback only fires when no result event fired" invariant, and how it
+  pairs with the role-driver residual-#1916 guard.
+
+### External Documentation Site
+- No external docs site in this repo. N/A.
+
+### Inline Documentation
+- [ ] Update the comment block at `agent/sdk_client.py:2602-2606` to state the fallback is
+  gated on "no result event fired (`result_text is None`)" and why (don't discard a valid
+  completion on a post-turn non-zero exit).
+- [ ] Ensure the function docstring's fallback description (`sdk_client.py:2386-2388`) reflects
+  the `result_text is None` condition.
+
+## Success Criteria
+
+- [ ] Root cause documented: stale-UUID fallback at `sdk_client.py:2607` clobbers a valid
+  `result_text` on a non-zero exit that followed a fired `result` event. (Acceptance #1)
+- [ ] Regression test: a turn whose primary subprocess emits valid final text and exits
+  non-zero returns that text (fallback skipped), and `HeadlessRoleDriver.run_turn` propagates
+  it (non-empty `reply_text`, `exit_reason != "empty_output"`) — real text delivered, not
+  `OPERATOR_TERMINAL_MESSAGE`. (Acceptance #2)
+- [ ] Test: `result_text is None` + non-zero exit + `prior_uuid` still triggers the fallback
+  (stale-UUID recovery preserved).
+- [ ] Test: empty-string result event does not spuriously trigger the fallback and yields
+  `""` — OPERATOR_TERMINAL_MESSAGE remains reserved for a genuinely empty PM turn. (Acceptance #3)
+- [ ] Tests pass (`/do-test`)
+- [ ] Documentation updated (`/do-docs`)
+- [ ] `grep -n "result_text is None" agent/sdk_client.py` confirms the gate change is present.
+
+## Team Orchestration
+
+Small single-file fix; solo builder + code reviewer.
+
+### Team Members
+
+- **Builder (harness-fallback-gate)**
+  - Name: harness-fix-builder
+  - Role: Apply the one-clause gate change, update comments/docstring, write the regression tests.
+  - Agent Type: builder
+  - Domain: async/concurrency
+  - Resume: true
+
+- **Code Reviewer (harness-fallback-gate)**
+  - Name: harness-fix-reviewer
+  - Role: Verify the gate change preserves stale-UUID recovery and does not mask real failures; verify tests genuinely reproduce the failure.
+  - Agent Type: code-reviewer
+  - Resume: true
+
+### Step by Step Tasks
+
+### 1. Implement fallback gate + tests
+- **Task ID**: build-harness-gate
+- **Depends On**: none
+- **Validates**: tests/unit/test_harness_stale_uuid_result_preservation.py (create), tests/unit/test_sdk_client_harness_counters.py, tests/integration/test_harness_resume.py
+- **Assigned To**: harness-fix-builder
+- **Agent Type**: builder
+- **Parallel**: false
+- Add `and result_text is None` to the stale-UUID fallback gate at `agent/sdk_client.py:2607`.
+- Update the comment at `sdk_client.py:2602-2606` and the docstring fallback note.
+- Create `tests/unit/test_harness_stale_uuid_result_preservation.py` with three unit tests
+  (result-event-preserved, no-result-event-still-fallbacks, empty-result-not-fallbacked) plus
+  one `HeadlessRoleDriver.run_turn` end-to-end test (nonzero exit + result event → non-empty
+  reply_text, `exit_reason != "empty_output"`).
+
+### 2. Documentation
+- **Task ID**: document-feature
+- **Depends On**: build-harness-gate
+- **Assigned To**: harness-fix-builder
+- **Agent Type**: builder
+- **Parallel**: false
+- Update `docs/features/headless-session-runner.md` per the Documentation section.
+
+### 3. Final Validation
+- **Task ID**: validate-all
+- **Depends On**: build-harness-gate, document-feature
+- **Assigned To**: harness-fix-reviewer
+- **Agent Type**: validator
+- **Parallel**: false
+- Run the Verification table; confirm all success criteria.
+
+## Verification
+
+| Check | Command | Expected |
+|-------|---------|----------|
+| Gate change present | `grep -n "returncode != 0 and result_text is None" agent/sdk_client.py` | exit code 0 |
+| Regression tests pass | `pytest tests/unit/test_harness_stale_uuid_result_preservation.py -q` | exit code 0 |
+| Existing harness tests pass | `pytest tests/unit/test_harness_retry.py tests/unit/test_sdk_client_harness_counters.py tests/unit/test_sdk_client.py -q` | exit code 0 |
+| Lint clean | `python -m ruff check agent/sdk_client.py tests/unit/test_harness_stale_uuid_result_preservation.py` | exit code 0 |
+| Format clean | `python -m ruff format --check agent/sdk_client.py tests/unit/test_harness_stale_uuid_result_preservation.py` | exit code 0 |
+| No stale xfails | `grep -rn 'xfail' tests/unit/test_harness_stale_uuid_result_preservation.py` | exit code 1 |
+
+## Critique Results
+
+<!-- Populated by /do-plan-critique (war room). Leave empty until critique is run. -->
+| Severity | Critic | Finding | Addressed By | Implementation Note |
+|----------|--------|---------|--------------|---------------------|

--- a/tests/unit/test_harness_stale_uuid_result_preservation.py
+++ b/tests/unit/test_harness_stale_uuid_result_preservation.py
@@ -1,0 +1,249 @@
+"""Regression tests for issue #1980 — the stale-UUID fallback must not clobber
+a valid ``result`` event.
+
+Root cause: ``get_response_via_harness`` (``agent/sdk_client.py``) ran a
+destructive fresh-session retry whenever a resumed (``--resume``) subprocess
+exited non-zero, WITHOUT checking whether that subprocess had already emitted a
+``result`` event. A resumed wrap-up turn that produced a valid ``[/complete]``
+completion and then exited non-zero had its good ``result_text`` overwritten by
+the empty output of the fresh retry, so ``get_response_via_harness`` returned
+``""``. ``HeadlessRoleDriver.run_turn``'s ``if not reply:`` guard then set
+``exit_reason="empty_output"`` and the wrap-up guard delivered the canned
+``OPERATOR_TERMINAL_MESSAGE`` instead of the real answer.
+
+The fix gates the fallback on the true ``result_event_fired`` boolean (captured
+from the primary invocation's ``on_exit_status`` callback), NOT on
+``result_text is None`` — which is imprecise because ``_run_harness_subprocess``
+returns a non-None string in BOTH the result-event branch (A) and the
+accumulated-partial-text branch (B). The tests below pin all four branches.
+
+``_run_harness_subprocess`` return tuple (8-tuple):
+    (result_text, session_id_from_harness, returncode, usage, cost_usd,
+     stderr_snippet, num_turns, tool_call_count)
+Its ``on_exit_status(returncode, result_event_fired)`` callback is the ONLY
+precise signal for "a result event fired." The fakes below invoke it faithfully.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+VALID_UUID = "36514af3-c4e9-455d-9087-f5850101990e"
+
+COMPLETION_TEXT = (
+    "Merged and verified. `origin/main` now has the hotfix at the top.\n\n"
+    "[/complete]\nSend Reminders hotfix shipped to main — PR #604 merged."
+)
+
+
+def _make_fake_run(responses):
+    """Build a fake ``_run_harness_subprocess`` that replays ``responses``.
+
+    Each item is a dict with keys: ``result_text``, ``returncode``, ``fired``,
+    and optional ``session_id`` / ``num_turns`` / ``tool_calls``. The fake
+    invokes the passed ``on_exit_status(returncode, fired)`` callback exactly as
+    the real helper does (``sdk_client.py`` line ~3089) before returning the
+    8-tuple. It records the number of invocations on ``.calls``.
+    """
+    state = {"i": 0, "calls": 0}
+
+    async def _fake(cmd, working_dir, proc_env, *, on_exit_status=None, **_kw):
+        spec = responses[state["i"]] if state["i"] < len(responses) else responses[-1]
+        state["i"] += 1
+        state["calls"] += 1
+        rc = spec["returncode"]
+        fired = spec["fired"]
+        if on_exit_status is not None:
+            on_exit_status(rc, fired)
+        return (
+            spec["result_text"],
+            spec.get("session_id"),
+            rc,
+            None,  # usage
+            None,  # cost_usd
+            None,  # stderr_snippet
+            spec.get("num_turns", 0),
+            spec.get("tool_calls", 0),
+        )
+
+    _fake.state = state  # type: ignore[attr-defined]
+    return _fake
+
+
+# ---------------------------------------------------------------------------
+# get_response_via_harness — the four return branches of _run_harness_subprocess
+# ---------------------------------------------------------------------------
+
+
+class TestStaleUuidFallbackGate:
+    """The fallback fires iff no ``result`` event fired on the primary turn."""
+
+    @pytest.mark.asyncio
+    async def test_branch_a_result_event_kept_on_nonzero_exit(self):
+        """BRANCH A (the bug): a resumed subprocess emits a valid result event
+        and then exits non-zero. The completion must be returned verbatim and
+        the destructive fallback must NOT fire."""
+        from agent.sdk_client import get_response_via_harness
+
+        fake = _make_fake_run(
+            [
+                # Primary: valid result event, but non-zero exit afterward.
+                {
+                    "result_text": COMPLETION_TEXT,
+                    "returncode": 1,
+                    "fired": True,
+                    "session_id": VALID_UUID,
+                },
+                # A fallback, IF it wrongly fired, would return empty — the
+                # pre-fix clobber. Its presence lets us prove it is NOT reached.
+                {"result_text": "", "returncode": 0, "fired": False},
+            ]
+        )
+        with patch("agent.sdk_client._run_harness_subprocess", new=AsyncMock(side_effect=fake)):
+            reply = await get_response_via_harness(
+                message="wrap it up",
+                working_dir="/tmp",
+                env={"AGENT_SESSION_ID": "x"},
+                prior_uuid=VALID_UUID,
+                full_context_message="full context for a cold retry",
+            )
+
+        assert reply == COMPLETION_TEXT, "valid completion must survive a post-turn non-zero exit"
+        assert fake.state["calls"] == 1, "fallback must NOT fire when a result event fired"
+
+    @pytest.mark.asyncio
+    async def test_branch_a_empty_result_event_is_genuinely_empty(self):
+        """BRANCH A with an empty result event (``""``): a result event fired but
+        carried no text. The fallback must NOT fire (a fired result event is the
+        completion signal) and the empty string is returned — OPERATOR_TERMINAL_
+        MESSAGE stays reserved for a genuinely empty PM turn (acceptance #3)."""
+        from agent.sdk_client import get_response_via_harness
+
+        fake = _make_fake_run(
+            [
+                {"result_text": "", "returncode": 1, "fired": True, "session_id": VALID_UUID},
+                {"result_text": "SHOULD-NOT-APPEAR", "returncode": 0, "fired": True},
+            ]
+        )
+        with patch("agent.sdk_client._run_harness_subprocess", new=AsyncMock(side_effect=fake)):
+            reply = await get_response_via_harness(
+                message="wrap it up",
+                working_dir="/tmp",
+                env={"AGENT_SESSION_ID": "x"},
+                prior_uuid=VALID_UUID,
+                full_context_message="full context",
+            )
+
+        assert reply == "", "an empty result event is a genuinely empty turn"
+        assert fake.state["calls"] == 1, "fallback must NOT fire when a result event fired"
+
+    @pytest.mark.asyncio
+    async def test_branch_b_partial_text_no_result_event_still_fallbacks(self):
+        """BRANCH B: no result event, but partial streamed text accumulated, then
+        a non-zero exit. This is a crashed subprocess worth a fresh retry — the
+        fallback MUST still fire (no regression of pre-existing recovery)."""
+        from agent.sdk_client import get_response_via_harness
+
+        fake = _make_fake_run(
+            [
+                # Primary: partial accumulated text, NO result event, crash exit.
+                {"result_text": "partial streamed text", "returncode": 1, "fired": False},
+                # Fallback (fresh session) recovers with a full answer.
+                {
+                    "result_text": "fresh full answer",
+                    "returncode": 0,
+                    "fired": True,
+                    "session_id": VALID_UUID,
+                },
+            ]
+        )
+        with patch("agent.sdk_client._run_harness_subprocess", new=AsyncMock(side_effect=fake)):
+            reply = await get_response_via_harness(
+                message="wrap it up",
+                working_dir="/tmp",
+                env={"AGENT_SESSION_ID": "x"},
+                prior_uuid=VALID_UUID,
+                full_context_message="full context",
+            )
+
+        assert reply == "fresh full answer", "BRANCH B must still recover via the fallback"
+        assert fake.state["calls"] == 2, "fallback MUST fire when no result event fired"
+
+    @pytest.mark.asyncio
+    async def test_branch_c_stale_uuid_no_output_still_fallbacks(self):
+        """BRANCH C: a genuinely stale UUID — ``claude --resume`` errors before
+        producing any output (no result event, no accumulated text, non-zero
+        exit). The fallback MUST still fire (stale-UUID recovery preserved). This
+        runs mocked so it exercises the gate in binary-free CI, unlike the live
+        ``test_stale_uuid_triggers_fallback`` integration test."""
+        from agent.sdk_client import get_response_via_harness
+
+        fake = _make_fake_run(
+            [
+                {"result_text": None, "returncode": 1, "fired": False},
+                {
+                    "result_text": "recovered fresh",
+                    "returncode": 0,
+                    "fired": True,
+                    "session_id": VALID_UUID,
+                },
+            ]
+        )
+        with patch("agent.sdk_client._run_harness_subprocess", new=AsyncMock(side_effect=fake)):
+            reply = await get_response_via_harness(
+                message="wrap it up",
+                working_dir="/tmp",
+                env={"AGENT_SESSION_ID": "x"},
+                prior_uuid=VALID_UUID,
+                full_context_message="full context",
+            )
+
+        assert reply == "recovered fresh", "BRANCH C (stale UUID) must recover via the fallback"
+        assert fake.state["calls"] == 2, "fallback MUST fire for a genuinely stale UUID"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through HeadlessRoleDriver.run_turn — the delivered outcome
+# ---------------------------------------------------------------------------
+
+
+class TestRunTurnPropagatesCompletion:
+    """The real get_response_via_harness → HeadlessRoleDriver.run_turn path must
+    surface the completion (non-empty reply_text, not the empty-output guard) so
+    the wrap-up guard delivers the real text, not OPERATOR_TERMINAL_MESSAGE."""
+
+    @pytest.mark.asyncio
+    async def test_run_turn_returns_completion_on_nonzero_exit_with_result(self, tmp_path):
+        from agent.session_runner.role_driver import HeadlessRoleDriver
+
+        fake = _make_fake_run(
+            [
+                {
+                    "result_text": COMPLETION_TEXT,
+                    "returncode": 1,
+                    "fired": True,
+                    "session_id": VALID_UUID,
+                },
+                {"result_text": "", "returncode": 0, "fired": False},
+            ]
+        )
+        driver = HeadlessRoleDriver(
+            role="pm",
+            session_id="test-1980-e2e",
+            working_dir=str(tmp_path),
+            project_root=str(tmp_path),
+            full_context_message="full context for a cold retry",
+            # harness_fn=None → uses the real get_response_via_harness, so the
+            # #1980 gate is exercised end-to-end.
+        )
+        # Ride --resume so prior_uuid is set (the fallback only runs on resume).
+        driver.seed_resume(VALID_UUID)
+
+        with patch("agent.sdk_client._run_harness_subprocess", new=AsyncMock(side_effect=fake)):
+            outcome = await driver.run_turn("send your wrap-up now")
+
+        assert outcome.reply_text == COMPLETION_TEXT, "real completion must reach run_turn's return"
+        assert outcome.exit_reason != "empty_output", "must NOT hit the empty-output guard"
+        assert fake.state["calls"] == 1, "fallback must not have clobbered the completion"


### PR DESCRIPTION
Closes #1980

## Problem

A PM turn (including the wrap-up guard's bounded extra turn) could produce a fully valid, complete `[/complete]`/`[/user]` final message — persisted in the raw transcript with `stop_reason: "end_turn"` — and the human still received the canned `OPERATOR_TERMINAL_MESSAGE` instead of the real content.

## Root cause

In `get_response_via_harness` (`agent/sdk_client.py`), the stale-UUID fallback fired on `prior_uuid and returncode != 0` **without checking whether the primary `--resume` subprocess had already emitted a `result` event**. When a resumed subprocess emitted a valid completion (`result` event) and then exited non-zero (a post-turn/cleanup artifact, not an external kill), the fallback re-ran a fresh session whose empty output **clobbered** the good `result_text`. `get_response_via_harness` returned `""`, `HeadlessRoleDriver.run_turn`'s `if not reply:` guard set `exit_reason="empty_output"`, and `_run_wrapup_guard` delivered `OPERATOR_TERMINAL_MESSAGE`.

This defeated a contract the role driver already documents but cannot enforce (`role_driver.py`: *"a nonzero exit AFTER a result event keeps the result — the event is the protocol's completion signal"*), because the clobber happened one layer below it.

## Fix

Gate the fallback on the true `result_event_fired` boolean, captured from the primary invocation's `on_exit_status(returncode, result_event_fired)` callback, and gate on `not primary_result_event_fired`. Critically this is **not** `result_text is None`: `_run_harness_subprocess` returns a non-None string both when a result event fired (BRANCH A) and when partial streamed text accumulated with no result event (BRANCH B), so `result_text is None` would wrongly skip the fallback in BRANCH B. Keying off the real boolean:

- **BRANCH A** (result event fired) + non-zero exit → fallback **skipped**, completion kept (the fix).
- **BRANCH B** (partial text, no result event) + non-zero exit → fallback **still fires** (crashed-subprocess recovery preserved).
- **BRANCH C** (genuine stale UUID, no output) + non-zero exit → fallback **still fires** (stale-UUID recovery preserved).
- Empty-string result event (`""`, fired=True) → fallback skipped, returns `""` — `OPERATOR_TERMINAL_MESSAGE` stays reserved for a genuinely empty PM turn.

Added a `logger.info` at the gate recording the skip-vs-fire decision for incident triage.

## Acceptance criteria (issue #1980)

1. ✅ Root cause identified — the stale-UUID fallback clobber in `get_response_via_harness`.
2. ✅ Regression test reproduces the failure mode and asserts the real text is delivered (not `OPERATOR_TERMINAL_MESSAGE`) — `test_branch_a_result_event_kept_on_nonzero_exit` + the end-to-end `test_run_turn_returns_completion_on_nonzero_exit_with_result`.
3. ✅ `OPERATOR_TERMINAL_MESSAGE` only fires on a genuinely empty turn — `test_branch_a_empty_result_event_is_genuinely_empty`, plus BRANCH B/C tests proving recovery is not regressed.

## Testing

- New: `tests/unit/test_harness_stale_uuid_result_preservation.py` (5 tests, all four branches + run_turn e2e) — passing.
- Regression sweep: `test_harness_retry.py`, `test_sdk_client_harness_counters.py`, `test_sdk_client.py`, `test_sdk_client_image_sentinel.py`, `test_headless_role_driver.py`, `test_runner_resume.py` — all passing.
- `ruff check` + `ruff format --check` clean.

## Plan & docs

- Plan: `docs/plans/wrapup-guard-reply-text-loss.md` (critique verdict addressed: gate corrected from `result_text is None` to the true `result_event_fired` boolean).
- Docs: `docs/features/headless-session-runner.md` — new subsection on the stale-UUID fallback vs. result-event completion signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)