### PR TITLE
Add commit-distance staleness trigger to merge-gate baseline (#1965)

### DIFF
--- a/scripts/baseline_gate.py
+++ b/scripts/baseline_gate.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import subprocess
 import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -41,6 +42,17 @@ from scripts._baseline_common import (
 logger = logging.getLogger(__name__)
 
 STALENESS_THRESHOLD = timedelta(days=14)
+
+# Commit-distance staleness trigger (issue #1965). The 14-day wall-clock
+# threshold missed a real incident: a baseline only 7 days old but 425 commits
+# behind HEAD silently produced 38 false-positive "new regression" flags,
+# because failing tests accrue on ``main`` per-commit, not per-day. A baseline
+# more than this many commits behind HEAD is flagged as stale regardless of
+# its wall-clock age. Chosen conservatively: at this project's observed commit
+# velocity (~60 commits/day) ~100 commits is well under two days of drift, and
+# the post-merge baseline reset keeps a healthy baseline at/near HEAD so this
+# does not fire on normal operation.
+STALE_COMMIT_DISTANCE = 100
 
 # Categories that block a merge when a PR introduces a node ID in them that
 # is NOT in the baseline (or is in the baseline but as a *different* category).
@@ -171,13 +183,71 @@ def compute_gate_verdict(baseline: dict, pr_failures: set[str]) -> dict:
     }
 
 
-def format_staleness_warning(baseline: dict, now: datetime | None = None) -> str | None:
+def commits_behind_head(
+    baseline_commit: str | None,
+    repo_root: str | Path | None = None,
+) -> int | None:
+    """Return how many commits ``HEAD`` is ahead of ``baseline_commit``.
+
+    Best-effort and never raises: returns ``None`` when the answer cannot be
+    determined (git unavailable, the recorded commit is missing/unknown, or it
+    is not an ancestor reachable from ``HEAD``). Any ``-dirty`` suffix written
+    by ``refresh_test_baseline.capture_commit`` is stripped before comparison.
+
+    The count comes from ``git rev-list --count <commit>..HEAD``, i.e. the
+    number of commits on ``HEAD`` not reachable from the baseline's commit.
+    ``0`` means the baseline is at (or newer than) ``HEAD``.
+    """
+    if not isinstance(baseline_commit, str):
+        return None
+    sha = baseline_commit.strip()
+    if sha.endswith("-dirty"):
+        sha = sha[: -len("-dirty")]
+    # ``capture_commit`` writes the literal "unknown" when git is unavailable;
+    # treat that (and empty) as "no usable commit".
+    if not sha or sha == "unknown":
+        return None
+
+    cwd = str(repo_root) if repo_root is not None else None
+    try:
+        result = subprocess.run(
+            ["git", "rev-list", "--count", f"{sha}..HEAD"],
+            cwd=cwd,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, ValueError):
+        return None
+    if result.returncode != 0:
+        # Unknown commit, not a git repo, etc.
+        return None
+    out = result.stdout.strip()
+    try:
+        return int(out)
+    except ValueError:
+        return None
+
+
+def format_staleness_warning(
+    baseline: dict,
+    now: datetime | None = None,
+    commits_behind: int | None = None,
+) -> str | None:
     """Return a warning string if the baseline is stale, or ``None``.
 
-    Three triggers:
-    - ``bootstrap: true``                   -- always warn
-    - ``commit`` ends with ``-dirty``       -- always warn
-    - ``generated_at`` more than 14 days    -- warn with age in days
+    Four triggers:
+    - ``bootstrap: true``                        -- always warn
+    - ``commit`` ends with ``-dirty``            -- always warn
+    - ``generated_at`` more than 14 days         -- warn with age in days
+    - ``commits_behind`` past ``STALE_COMMIT_DISTANCE`` -- warn with distance
+
+    ``commits_behind`` is the caller-supplied commit distance between the
+    baseline's recorded commit and current ``HEAD`` (see
+    :func:`commits_behind_head`). It is a separate axis from wall-clock age:
+    a baseline can be time-fresh yet many commits behind on a high-velocity
+    day, which is the exact blind spot the age check missed in issue #1965.
+    ``None`` (git unavailable / unknown commit) means "skip this trigger".
     """
     now = now or datetime.now(UTC)
     reasons: list[str] = []
@@ -202,6 +272,11 @@ def format_staleness_warning(baseline: dict, now: datetime | None = None) -> str
             if age > STALENESS_THRESHOLD:
                 days = age.days
                 reasons.append(f"generated_at is {days} days old (> 14)")
+
+    if isinstance(commits_behind, int) and commits_behind > STALE_COMMIT_DISTANCE:
+        reasons.append(
+            f"baseline commit is {commits_behind} commits behind HEAD (> {STALE_COMMIT_DISTANCE})"
+        )
 
     if not reasons:
         return None
@@ -441,7 +516,8 @@ def main(argv: list[str] | None = None) -> int:
             now = now.replace(tzinfo=UTC)
     else:
         now = datetime.now(UTC)
-    warning = format_staleness_warning(baseline, now=now)
+    commits_behind = commits_behind_head(baseline.get("commit"))
+    warning = format_staleness_warning(baseline, now=now, commits_behind=commits_behind)
     if warning is not None:
         verdict["staleness_warning"] = warning
         sys.stderr.write(warning + "\n")

--- a/tests/unit/test_do_merge_baseline.py
+++ b/tests/unit/test_do_merge_baseline.py
@@ -11,11 +11,14 @@ See ``docs/plans/merge-gate-baseline-refresh.md`` for motivation.
 from __future__ import annotations
 
 import json
+import subprocess
 import textwrap
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from scripts.baseline_gate import (
+    STALE_COMMIT_DISTANCE,
+    commits_behind_head,
     compute_gate_verdict,
     format_staleness_warning,
     load_baseline,
@@ -271,6 +274,131 @@ def test_staleness_warning_fires_on_dirty_commit() -> None:
     warning = format_staleness_warning(baseline, now=now)
     assert warning is not None
     assert "dirty tree" in warning
+
+
+def test_staleness_warning_fires_on_commit_distance() -> None:
+    """A time-fresh baseline that is many commits behind HEAD must still warn.
+
+    This is the #1965 blind spot: the incident baseline was only 7 days old
+    (under the 14-day time threshold) but 425 commits behind HEAD, so it
+    silently produced a wall of false-positive regressions. Commit-distance
+    is an independent trigger that catches high-velocity drift the wall-clock
+    check misses.
+    """
+    now = datetime(2026, 4, 20, tzinfo=UTC)
+    baseline = {
+        "schema_version": 2,
+        "generated_at": now.isoformat(),  # brand new -> time check silent
+        "commit": "abc1234",
+        "tests": {},
+    }
+    warning = format_staleness_warning(baseline, now=now, commits_behind=STALE_COMMIT_DISTANCE + 50)
+    assert warning is not None
+    assert "commits behind HEAD" in warning
+    assert "refresh_test_baseline.py" in warning
+
+
+def test_staleness_warning_silent_under_commit_distance() -> None:
+    now = datetime(2026, 4, 20, tzinfo=UTC)
+    baseline = {
+        "schema_version": 2,
+        "generated_at": now.isoformat(),
+        "commit": "abc1234",
+        "tests": {},
+    }
+    assert (
+        format_staleness_warning(baseline, now=now, commits_behind=STALE_COMMIT_DISTANCE - 1)
+        is None
+    )
+
+
+def test_staleness_warning_ignores_unknown_commit_distance() -> None:
+    """``commits_behind=None`` (git unavailable/unknown commit) must not warn."""
+    now = datetime(2026, 4, 20, tzinfo=UTC)
+    baseline = {
+        "schema_version": 2,
+        "generated_at": now.isoformat(),
+        "commit": "abc1234",
+        "tests": {},
+    }
+    assert format_staleness_warning(baseline, now=now, commits_behind=None) is None
+
+
+# ---------------------------------------------------------------------------
+# commits_behind_head (git-backed helper)
+# ---------------------------------------------------------------------------
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+def _init_repo(repo: Path) -> None:
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "t")
+
+
+def test_commits_behind_head_counts_distance(tmp_path: Path) -> None:
+    repo = tmp_path / "r"
+    repo.mkdir()
+    _init_repo(repo)
+    (repo / "f").write_text("0")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "c0")
+    base_sha = subprocess.check_output(
+        ["git", "rev-parse", "--short", "HEAD"], cwd=repo, text=True
+    ).strip()
+    for i in range(1, 4):
+        (repo / "f").write_text(str(i))
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-qm", f"c{i}")
+    assert commits_behind_head(base_sha, repo) == 3
+    # HEAD is zero commits behind itself.
+    head = subprocess.check_output(
+        ["git", "rev-parse", "--short", "HEAD"], cwd=repo, text=True
+    ).strip()
+    assert commits_behind_head(head, repo) == 0
+
+
+def test_commits_behind_head_returns_none_on_unknown_commit(tmp_path: Path) -> None:
+    repo = tmp_path / "r"
+    repo.mkdir()
+    _init_repo(repo)
+    (repo / "f").write_text("0")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "c0")
+    # A SHA that does not exist -> None, never raises.
+    assert commits_behind_head("deadbeef", repo) is None
+
+
+def test_commits_behind_head_strips_dirty_suffix(tmp_path: Path) -> None:
+    repo = tmp_path / "r"
+    repo.mkdir()
+    _init_repo(repo)
+    (repo / "f").write_text("0")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "c0")
+    sha = subprocess.check_output(
+        ["git", "rev-parse", "--short", "HEAD"], cwd=repo, text=True
+    ).strip()
+    (repo / "f2").write_text("x")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "c1")
+    # The recorded commit may carry a "-dirty" suffix; it must be stripped.
+    assert commits_behind_head(f"{sha}-dirty", repo) == 1
+
+
+def test_commits_behind_head_returns_none_for_missing_commit_field(tmp_path: Path) -> None:
+    repo = tmp_path / "r"
+    repo.mkdir()
+    _init_repo(repo)
+    (repo / "f").write_text("0")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "c0")
+    assert commits_behind_head(None, repo) is None
+    assert commits_behind_head("", repo) is None
+    assert commits_behind_head("unknown", repo) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #1965. The merge-gate baseline (`data/main_test_baseline.json`) could be time-fresh yet many commits behind HEAD, silently producing a wall of false-positive `new_blocking_regression` findings (the PR #1956 incident: 7 days old but 425 commits behind → 38 false positives). The existing 14-day wall-clock threshold missed this because failing tests accrue on `main` per-commit, not per-day.

Per maintainer decision, this ships the **explicit-warning** half of the issue's 'and/or' desired outcome (make staleness impossible to miss at the point of use). The scheduled auto-refresh cadence is intentionally out of scope.

## Change

- **`scripts/baseline_gate.py`**:
  - New `commits_behind_head(baseline_commit)` — best-effort `git rev-list --count <commit>..HEAD`; never raises (returns `None` on git-unavailable / unknown / `-dirty` / non-ancestor).
  - New `STALE_COMMIT_DISTANCE = 100` threshold.
  - `format_staleness_warning(...)` gains a `commits_behind` axis: warns when the baseline is >100 commits behind HEAD, independent of wall-clock age.
  - `main()` wires it in, so the `BASELINE STALE` warning fires at gate time.
- **`tests/unit/test_do_merge_baseline.py`** — new coverage for `commits_behind_head` (git-unavailable, unknown/dirty commit, ancestor counting) and the commit-distance warning trigger.

## Test plan
`~/src/ai/.venv/bin/python -m pytest tests/unit/test_do_merge_baseline.py -n0 -q` → 37 passed.

## Notes
Purely internal to the merge gate — no `/update` or launchd wiring, no production runtime code. The commit-distance check degrades gracefully (skips the trigger) whenever git can't answer.