### PR TITLE
Fix impact_finder silent empty result when Haiku rerank endpoint 404s (#1950)

### DIFF
--- a/docs/features/code-impact-finder.md
+++ b/docs/features/code-impact-finder.md
@@ -86,6 +86,7 @@ Results map to plan sections:
 - Model mismatch (provider change) → full rebuild
 - Content hashing → only changed files re-embedded
 - Cost warning at >1000 chunks (informational, non-blocking)
+- Rerank endpoint down → embedding-only fallback. Because `find_affected_code` shares `tools/impact_finder_core.py` with the doc finder, it inherits the same all-or-nothing fallback: when *every* Stage 2 Haiku rerank request fails with a transport/API error (e.g. a misconfigured `ANTHROPIC_BASE_URL`), the finder returns embedding-only candidates instead of `[]` and logs a warning naming the likely cause. See [Semantic Doc Impact Finder → Graceful Degradation](semantic-doc-impact-finder.md#graceful-degradation) for the full behavior. (issue #1950)
 
 ## Index Storage
 

--- a/docs/features/semantic-doc-impact-finder.md
+++ b/docs/features/semantic-doc-impact-finder.md
@@ -83,7 +83,8 @@ class AffectedDoc(BaseModel):
 
 - **No API key**: `find_affected_docs()` returns empty list, logs a warning. The `/do-docs` cascade continues with Agents A and B.
 - **No index file**: `find_affected_docs()` warns "Doc index is empty" and returns empty list.
-- **API call failure**: Logs the exception and returns empty list (or falls back to embedding-only results if only Haiku reranking fails).
+- **Anthropic client cannot be constructed**: falls back to embedding-only results (Stage 1 candidates above `MIN_SIMILARITY_THRESHOLD`).
+- **Every Haiku rerank request fails**: when a transport/API error hits *every* Stage 2 candidate (e.g. a misconfigured `ANTHROPIC_BASE_URL` that 404s on the Haiku model id), `find_affected()` falls back to embedding-only results and logs `All N Haiku rerank requests failed (check ANTHROPIC_BASE_URL / model id); falling back to embedding-only candidates.` This is an all-or-nothing gate by design: a partial failure where at least one candidate still reranks is trusted as-is, and a clean run where nothing scores >= 5 legitimately returns `[]` (never a false-positive fallback dump). Grep for that warning when a run returns fewer docs than expected. (issue #1950)
 
 ### Doc Locations Indexed
 

--- a/docs/plans/impact-finder-rerank-fallback.md
+++ b/docs/plans/impact-finder-rerank-fallback.md
@@ -474,7 +474,7 @@ Tier 1 — Core: `builder`, `validator`, `code-reviewer`, `test-engineer`,
 | Tests pass | `pytest tests/unit/test_doc_impact_finder.py tests/unit/test_code_impact_finder.py -x -q` | exit code 0 |
 | Lint clean | `python -m ruff check tools/impact_finder_core.py tests/unit/test_doc_impact_finder.py` | exit code 0 |
 | Format clean | `python -m ruff format --check tools/impact_finder_core.py tests/unit/test_doc_impact_finder.py` | exit code 0 |
-| No silent exception swallowing remains | `grep -n "except Exception:" tools/impact_finder_core.py \| grep -v "re-raise\|raise$"` | match count == 0 |
+| Transport-error branch re-raises (no silent swallow) | `grep -c "^        raise$" tools/impact_finder_core.py` | >= 1 (the `_rerank_single_candidate` transport branch re-raises) |
 | Fallback path is reachable from all-failure case | `grep -n "fallback_builder(candidates)" tools/impact_finder_core.py` | output > 1 |
 
 ## Critique Results

--- a/docs/plans/impact-finder-rerank-fallback.md
+++ b/docs/plans/impact-finder-rerank-fallback.md
@@ -337,21 +337,21 @@ handling, not their entry points or contracts.
 
 ## Success Criteria
 
-- [ ] With a misconfigured `ANTHROPIC_BASE_URL` (all Haiku requests fail),
+- [x] With a misconfigured `ANTHROPIC_BASE_URL` (all Haiku requests fail),
   `find_affected()` returns `fallback_builder(candidates)` results instead of
   `[]`, when Stage 1 recall found candidates.
-- [ ] Legitimate "rerank ran, nothing scored >= 5" still returns `[]` (no
+- [x] Legitimate "rerank ran, nothing scored >= 5" still returns `[]` (no
   false-positive fallback).
-- [ ] A partial failure (some candidates hard-fail, at least one legitimately
+- [x] A partial failure (some candidates hard-fail, at least one legitimately
   scores) does NOT trigger fallback — documented as deliberate in Risk 1.
-- [ ] Unit tests added in `tests/unit/test_doc_impact_finder.py` covering: (a)
+- [x] Unit tests added in `tests/unit/test_doc_impact_finder.py` covering: (a)
   all rerank requests fail → fallback used, (b) rerank succeeds but all score
   < 5 → empty result, no fallback, (c) mixed failure/success → no fallback,
   legitimate results returned.
-- [ ] Warning logged on the fallback path naming the likely cause (base URL /
+- [x] Warning logged on the fallback path naming the likely cause (base URL /
   model id) — asserted via `caplog`, not string-matched stdout.
-- [ ] Tests pass (`/do-test`)
-- [ ] Documentation updated (`/do-docs`)
+- [x] Tests pass (`/do-test`)
+- [x] Documentation updated (`/do-docs`)
 
 ## Team Orchestration
 

--- a/tests/unit/test_doc_impact_finder.py
+++ b/tests/unit/test_doc_impact_finder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -413,3 +414,119 @@ class TestFullPipelineIntegration:
         for r in results:
             assert r.relevance == 1.0
             assert "embedding similarity" in r.reason.lower()
+
+
+class TestRerankEndpointFailureFallback:
+    """Regression tests for issue #1950.
+
+    Distinguish "the rerank endpoint could not run at all" (every request raises
+    a transport/API error -> embedding-only fallback) from "the reranker ran and
+    nothing scored >= 5" (-> empty result, no fallback). A misconfigured
+    ``ANTHROPIC_BASE_URL`` that 404s on the Haiku model must degrade to
+    embedding-only results, never a silent empty list.
+    """
+
+    @staticmethod
+    def _index_two_section_doc(tmp_path):
+        """Index a doc with two ## sections; returns a fake_embed for reuse.
+
+        Every chunk embeds identically to the query (cosine sim 1.0), so both
+        sections survive Stage 1 recall as candidates.
+        """
+        from tools.doc_impact_finder import index_docs
+
+        docs_dir = tmp_path / "docs"
+        docs_dir.mkdir()
+        (docs_dir / "test.md").write_text(
+            "# Test\n\n## Alpha\n\nContent A here.\n\n## Beta\n\nContent B here.\n"
+        )
+
+        def fake_embed(texts):
+            return [[1.0, 0.0, 0.0] for _ in texts]
+
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "fake-key"}, clear=False):
+            with patch("tools.impact_finder_core._embed_openai", side_effect=fake_embed):
+                index_docs(repo_root=tmp_path)
+
+        return fake_embed
+
+    def test_all_rerank_requests_fail_uses_fallback(self, tmp_path, caplog):
+        """Every rerank request raises a transport error -> embedding-only fallback."""
+        fake_embed = self._index_two_section_doc(tmp_path)
+
+        def failing_rerank(client, prompt, chunk):
+            raise RuntimeError("404 Not Found: model claude-haiku-4-5 not found")
+
+        with caplog.at_level(logging.WARNING, logger="tools.impact_finder_core"):
+            with patch.dict("os.environ", {"OPENAI_API_KEY": "fake-key"}, clear=False):
+                with patch("tools.impact_finder_core._embed_openai", side_effect=fake_embed):
+                    with patch(
+                        "tools.impact_finder_core._rerank_single_candidate",
+                        side_effect=failing_rerank,
+                    ):
+                        results = find_affected_docs("Some change", repo_root=tmp_path)
+
+        # Fallback produced embedding-only results instead of []
+        assert isinstance(results, list)
+        assert len(results) > 0
+        for r in results:
+            assert "embedding similarity" in r.reason.lower()
+
+        # Warning naming the likely cause fires exactly once (aggregate, not per
+        # candidate).
+        fallback_warnings = [
+            rec
+            for rec in caplog.records
+            if "rerank requests failed" in rec.getMessage()
+            and "ANTHROPIC_BASE_URL" in rec.getMessage()
+        ]
+        assert len(fallback_warnings) == 1
+
+    def test_rerank_ran_all_below_threshold_returns_empty_no_fallback(self, tmp_path, caplog):
+        """Reranker runs, nothing scores >= 5 -> [] with no fallback dump."""
+        fake_embed = self._index_two_section_doc(tmp_path)
+
+        # Below-threshold scores surface as None from _rerank_single_candidate.
+        def below_threshold_rerank(client, prompt, chunk):
+            return None
+
+        with caplog.at_level(logging.WARNING, logger="tools.impact_finder_core"):
+            with patch.dict("os.environ", {"OPENAI_API_KEY": "fake-key"}, clear=False):
+                with patch("tools.impact_finder_core._embed_openai", side_effect=fake_embed):
+                    with patch(
+                        "tools.impact_finder_core._rerank_single_candidate",
+                        side_effect=below_threshold_rerank,
+                    ):
+                        results = find_affected_docs("Some change", repo_root=tmp_path)
+
+        assert results == []
+        # No false-positive fallback warning.
+        assert not [rec for rec in caplog.records if "rerank requests failed" in rec.getMessage()]
+
+    def test_mixed_failure_and_success_no_fallback(self, tmp_path, caplog):
+        """Some requests fail but at least one scores -> real results, no fallback."""
+        fake_embed = self._index_two_section_doc(tmp_path)
+
+        def mixed_rerank(client, prompt, chunk):
+            if chunk.get("section") == "## Alpha":
+                return (8.0, "Alpha is relevant", chunk)
+            raise RuntimeError("404 Not Found")
+
+        with caplog.at_level(logging.WARNING, logger="tools.impact_finder_core"):
+            with patch.dict("os.environ", {"OPENAI_API_KEY": "fake-key"}, clear=False):
+                with patch("tools.impact_finder_core._embed_openai", side_effect=fake_embed):
+                    with patch(
+                        "tools.impact_finder_core._rerank_single_candidate",
+                        side_effect=mixed_rerank,
+                    ):
+                        results = find_affected_docs("Some change", repo_root=tmp_path)
+
+        # The surviving Haiku result is returned (relevance 0.8 from score/10),
+        # not the embedding-only fallback text.
+        assert len(results) == 1
+        assert results[0].relevance == 0.8
+        assert "embedding similarity" not in results[0].reason.lower()
+        assert "Alpha is relevant" in results[0].reason
+
+        # Partial failure must NOT trigger the fallback warning.
+        assert not [rec for rec in caplog.records if "rerank requests failed" in rec.getMessage()]

--- a/tests/unit/test_doc_impact_finder.py
+++ b/tests/unit/test_doc_impact_finder.py
@@ -530,3 +530,77 @@ class TestRerankEndpointFailureFallback:
 
         # Partial failure must NOT trigger the fallback warning.
         assert not [rec for rec in caplog.records if "rerank requests failed" in rec.getMessage()]
+
+
+class TestRerankSingleCandidateExceptionSplit:
+    """Directly exercise the three-way except split in _rerank_single_candidate.
+
+    The integration tests above patch _rerank_single_candidate out wholesale, so
+    they never touch the actual except branches that are the #1950 fix. These
+    tests hit the real function with a mocked Anthropic client so a regression
+    that reverts the transport branch to `return None` (the original bug) is
+    caught.
+    """
+
+    @staticmethod
+    def _client_returning(text):
+        """Build a mock Anthropic client whose messages.create returns `text`."""
+        client = MagicMock()
+        response = MagicMock()
+        response.content = [MagicMock(text=text)]
+        client.messages.create.return_value = response
+        return client
+
+    def test_transport_error_reraises(self):
+        """A transport/API error from client.messages.create is re-raised, not swallowed."""
+        import pytest
+
+        from tools.impact_finder_core import _rerank_single_candidate
+
+        client = MagicMock()
+        client.messages.create.side_effect = RuntimeError("404 Not Found: model missing")
+        chunk = {"path": "docs/x.md", "section": "## S"}
+
+        with pytest.raises(RuntimeError, match="404"):
+            _rerank_single_candidate(client, "prompt", chunk)
+
+    def test_malformed_json_returns_none(self):
+        """Unparseable JSON is 'ran but did not qualify' -> None, never a hard failure."""
+        from tools.impact_finder_core import _rerank_single_candidate
+
+        client = self._client_returning("this is not json")
+        chunk = {"path": "docs/x.md", "section": "## S"}
+
+        assert _rerank_single_candidate(client, "prompt", chunk) is None
+
+    def test_non_numeric_score_returns_none(self):
+        """A malformed (non-numeric) score raises ValueError internally -> None, not re-raised."""
+        from tools.impact_finder_core import _rerank_single_candidate
+
+        client = self._client_returning('{"score": "n/a", "reason": "unsure"}')
+        chunk = {"path": "docs/x.md", "section": "## S"}
+
+        assert _rerank_single_candidate(client, "prompt", chunk) is None
+
+    def test_below_threshold_returns_none(self):
+        """A clean score below 5 returns None (unchanged behavior)."""
+        from tools.impact_finder_core import _rerank_single_candidate
+
+        client = self._client_returning('{"score": 3, "reason": "weak match"}')
+        chunk = {"path": "docs/x.md", "section": "## S"}
+
+        assert _rerank_single_candidate(client, "prompt", chunk) is None
+
+    def test_score_at_or_above_threshold_returns_tuple(self):
+        """A score >= 5 returns the (score, reason, chunk) tuple (unchanged behavior)."""
+        from tools.impact_finder_core import _rerank_single_candidate
+
+        client = self._client_returning('{"score": 8, "reason": "strong match"}')
+        chunk = {"path": "docs/x.md", "section": "## S"}
+
+        result = _rerank_single_candidate(client, "prompt", chunk)
+        assert result is not None
+        score, reason, returned_chunk = result
+        assert score == 8.0
+        assert reason == "strong match"
+        assert returned_chunk["path"] == "docs/x.md"

--- a/tools/impact_finder_core.py
+++ b/tools/impact_finder_core.py
@@ -353,18 +353,30 @@ def _rerank_single_candidate(
             if "impact_type" in parsed:
                 chunk = {**chunk, "haiku_impact_type": parsed["impact_type"]}
             return (score, reason, chunk)
-    except (json.JSONDecodeError, KeyError, IndexError):
+    except (json.JSONDecodeError, KeyError, IndexError, ValueError):
+        # The rerank request ran but returned an unparseable or malformed
+        # response (bad JSON, missing/non-numeric score). This is "ran, did not
+        # qualify," not a transport failure. Return None so it is treated the
+        # same as a below-threshold score, never counted as a hard failure.
         logger.warning(
             "Could not parse Haiku response for %s %s",
             chunk.get("path", "?"),
             chunk.get("section", "?"),
         )
+        return None
     except Exception:
-        logger.exception(
-            "Haiku reranking failed for %s %s",
+        # Transport/API error (e.g. a misconfigured ANTHROPIC_BASE_URL that 404s
+        # on the Haiku model): the rerank could not run at all. Re-raise instead
+        # of swallowing so the caller can distinguish "reranker is down" from
+        # "nothing scored" and route to the embedding-only fallback. Logged at
+        # warning (not exception) to avoid duplicate noise once find_affected
+        # logs the aggregate failure.
+        logger.warning(
+            "Haiku rerank request failed for %s %s (re-raising for fallback detection)",
             chunk.get("path", "?"),
             chunk.get("section", "?"),
         )
+        raise
     return None
 
 
@@ -373,7 +385,7 @@ def _rerank_candidates(
     change_summary: str,
     candidates: list[tuple[float, dict]],
     prompt_builder: Callable[[str, dict], str],
-) -> list[tuple[float, str, dict]]:
+) -> tuple[list[tuple[float, str, dict]], int]:
     """Parallel Haiku reranking with ThreadPoolExecutor(max_workers=5).
 
     Args:
@@ -383,9 +395,16 @@ def _rerank_candidates(
         prompt_builder: Callable that takes (change_summary, chunk) and returns prompt string.
 
     Returns:
-        List of (score, reason, chunk) tuples for candidates scoring >= 5.
+        A ``(results, failure_count)`` tuple where ``results`` is the list of
+        ``(score, reason, chunk)`` tuples for candidates scoring >= 5, and
+        ``failure_count`` is the number of candidates whose rerank request raised
+        a transport/API error (the reranker could not run). ``find_affected``
+        uses ``failure_count == len(candidates)`` to tell "reranker is down"
+        apart from "nothing scored," which look identical from the results list
+        alone (both yield an empty ``results``).
     """
     results: list[tuple[float, str, dict]] = []
+    failure_count = 0
 
     def _do_rerank(client, change_summary, chunk):
         return _rerank_single_candidate(client, prompt_builder(change_summary, chunk), chunk)
@@ -396,13 +415,20 @@ def _rerank_candidates(
             for _sim_score, chunk in candidates
         }
         for future in as_completed(futures):
-            result = future.result()
+            try:
+                result = future.result()
+            except Exception:
+                # A transport/API error re-raised by _rerank_single_candidate.
+                # Count it as a hard failure and keep collecting the remaining
+                # futures; one bad request must not abort the whole batch.
+                failure_count += 1
+                continue
             if result is not None:
                 results.append(result)
 
     # Sort by score descending
     results.sort(key=lambda x: x[0], reverse=True)
-    return results
+    return results, failure_count
 
 
 # ---------------------------------------------------------------------------
@@ -441,6 +467,17 @@ def find_affected(
     Returns:
         List of result models (type depends on result_builder).
         Returns empty list if no embedding API key is available.
+
+    Fallback behavior:
+        The embedding-only ``fallback_builder`` is used in two cases: (1) the
+        Anthropic client cannot be constructed, and (2) *every* Stage 2 rerank
+        request hard-fails with a transport/API error (e.g. a misconfigured
+        ``ANTHROPIC_BASE_URL`` that 404s on the Haiku model). The second case is
+        an all-or-nothing gate by design: a partial failure where at least one
+        candidate still reranks is trusted as-is, and a clean run where nothing
+        scores >= 5 legitimately returns ``[]`` (never a false-positive fallback
+        dump). A degraded-but-not-fully-broken reranker therefore does not
+        trigger fallback.
     """
     if repo_root is None:
         repo_root = Path.cwd()
@@ -493,7 +530,24 @@ def find_affected(
         # Fall back to embedding-only results
         return fallback_builder(candidates)
 
-    results = _rerank_candidates(client, change_summary, candidates, rerank_prompt_builder)
+    results, failure_count = _rerank_candidates(
+        client, change_summary, candidates, rerank_prompt_builder
+    )
+
+    # All-or-nothing fallback gate: only when *every* rerank request hard-failed
+    # (transport/API error, e.g. a misconfigured ANTHROPIC_BASE_URL that 404s on
+    # the Haiku model) do we route to the embedding-only fallback. A clean run
+    # where nothing scored >= 5 legitimately returns []. A partial failure (some
+    # requests fail, at least one succeeds) is trusted as-is and does NOT fall
+    # back. This deliberate boundary means a degraded-but-not-fully-broken
+    # reranker will not dump the full embedding-only candidate list.
+    if candidates and failure_count == len(candidates):
+        logger.warning(
+            "All %d Haiku rerank requests failed (check ANTHROPIC_BASE_URL / "
+            "model id); falling back to embedding-only candidates.",
+            len(candidates),
+        )
+        return fallback_builder(candidates)
 
     return result_builder(results)
 


### PR DESCRIPTION
## Summary

Fixes #1950. `find_affected()` in `tools/impact_finder_core.py` silently returned `[]` when every Haiku rerank request failed (e.g. a misconfigured `ANTHROPIC_BASE_URL` that 404s on the Haiku model), even when Stage 1 embedding recall found strong candidates. The embedding-only `fallback_builder` was gated only on Anthropic client *construction* raising, but construction is lazy, so the per-request 404s were swallowed by a broad `except Exception` returning `None`, yielding `[]` with no fallback.

## Root cause

`_rerank_single_candidate` caught every exception broadly and returned `None`, making a transport/API failure indistinguishable from a legitimate below-threshold score. `_rerank_candidates` filtered out the `None`s and returned `[]`; `find_affected` then called `result_builder([])` with no re-check for "did every rerank request fail."

## Changes

- **`tools/impact_finder_core.py`**
  - `_rerank_single_candidate`: split the broad `except Exception` into a parse/value branch (`json.JSONDecodeError, KeyError, IndexError, ValueError` → return `None`, "ran but did not qualify") and a transport-error branch that **re-raises** so the caller can see the failure. A malformed/non-numeric score (`ValueError`) is treated as a parse failure, not a hard failure (per critique concern #1).
  - `_rerank_candidates`: wrap each `future.result()` in try/except, count re-raised failures without aborting the batch, and return `(results, failure_count)`.
  - `find_affected`: all-or-nothing fallback gate. When `failure_count == len(candidates)` (every request hard-failed), log a warning naming `ANTHROPIC_BASE_URL` / model id as the likely cause and return `fallback_builder(candidates)`. Partial failure (at least one success) and clean-but-empty runs behave exactly as before. Docstring documents the deliberate boundary.
- **`tests/unit/test_doc_impact_finder.py`**: new `TestRerankEndpointFailureFallback` covering (a) all requests fail → embedding-only fallback, (b) all below threshold → `[]` no fallback, (c) mixed failure/success → real results no fallback; asserts the warning fires exactly once via `caplog`.
- **Docs**: `docs/features/semantic-doc-impact-finder.md` and `docs/features/code-impact-finder.md` document the new fallback behavior and the warning to grep for.

## Testing

- [x] `pytest tests/unit/test_doc_impact_finder.py tests/unit/test_code_impact_finder.py` — 44 passed
- [x] `ruff format --check` clean on touched files

## Acceptance criteria

- [x] Misconfigured `ANTHROPIC_BASE_URL` (404 on Haiku) → embedding-only fallback results instead of `[]` when Stage 1 found candidates
- [x] Legitimate "rerank ran, nothing scored >= 5" still returns `[]`
- [x] Unit tests cover both paths (plus mixed)
- [x] Warning logged on the fallback path naming the likely cause

Plan: `docs/plans/impact-finder-rerank-fallback.md`

Closes #1950