### PR TITLE
do-merge: gate on DOCS-stage completion (Step 2b) (#1944)

### DIFF
--- a/.claude/skills-global/do-merge/SKILL.md
+++ b/.claude/skills-global/do-merge/SKILL.md
@@ -117,6 +117,16 @@ other value or no verdict FAILS.
 Whichever source is used: if review approval cannot be confirmed, FAIL closed —
 never merge an unconfirmed-review PR.
 
+If the repo-context file declares a DOCS stage-completion substrate, treat
+DOCS-stage completion as a first-class precondition here alongside the REVIEW
+verdict, following its exact invocation (the deterministic gate lives in that
+substrate addendum, not this global skill). When no such substrate exists, DOCS
+completion cannot be verified at merge time, so emit this announced non-gate
+advisory line to the merge log (an auditable advisory, NOT a silent pass) and
+proceed on supervisor sequencing:
+
+`"DOCS-completion gate: NOT ENFORCED — no substrate; DOCS completion cannot be verified here, merge relies on supervisor sequencing (see #1915)."`
+
 ## Step 3: Verify Issue Link
 
 The PR body (from Step 1's `body`) must contain a `Closes #{issue_number}` (or

--- a/docs/features/enforce-review-docs-stages.md
+++ b/docs/features/enforce-review-docs-stages.md
@@ -24,6 +24,43 @@ The `PipelineStateMachine.has_remaining_stages()` method walks the pipeline grap
 
 The `/do-docs` skill writes `status: docs_complete` to the plan document's frontmatter after documentation is created/updated. This signals DOCS stage completion to `do-merge`, which verifies all checklist items and then executes the final plan deletion via `scripts/migrate_completed_plan.py`.
 
+## Merge-Gate DOCS Precondition
+
+`/do-merge` treats DOCS-stage completion as a first-class merge precondition,
+mirroring the Step 2 REVIEW-verdict gate. The check lives as Step 2b in the
+repo addendum `docs/sdlc/do-merge.md`. It reads `stages.DOCS` from
+`sdlc-tool stage-query` and decides as follows:
+
+- `stages.DOCS == completed` is the authoritative PASS. A DOCS skip records the
+  same `completed` status (the "skipped" nuance lives in the router reason string,
+  and `sdlc-tool stage-marker` writes only `in_progress` or `completed`), so the
+  gate admits a legitimate skip with the same `== completed` check. It needs no
+  special skip-branch.
+- `in_progress` is the only hard fail. It fails closed, creates no
+  `data/merge_authorized_{PR}` file, and routes back to `/do-docs`. This is the
+  sole affirmative "DOCS unfinished" signal, reachable only via a real
+  `start_stage` call (the cuttlefish #577 incident shape).
+- `pending` (DOCS never started) and an empty `stages` map (the session was
+  reaped or orphan-cleaned, so the marker is unreadable) both degrade to the
+  file-existence check: `docs/features/{slug}.md` present gives PASS (degraded);
+  absent gives FAIL. Neither case can affirm "unfinished", so degrading to the
+  previous behavior keeps the gate a monotonic improvement over the old
+  file-existence-only check.
+
+The slug for the file-existence fallback comes from the PR head-ref
+(`gh pr view {PR} --json headRefName`), because bypass-path operators
+(raw `gh pr merge`, cross-machine) commonly run from `main` or a detached HEAD.
+A head-ref of `main`/`master`/`HEAD`/empty normalizes to "no usable slug" and
+fails closed with a `<no-slug>` message rather than looking up an always-absent
+`docs/features/main.md`.
+
+The deterministic gate is scoped to substrate repos (those shipping
+`docs/sdlc/do-merge.md` with `sdlc-tool` markers). In a repo with no substrate
+the marker cannot be read, so the global `do-merge` skill emits an announced
+non-gate advisory line (containing `NOT ENFORCED`) to the merge log. That advisory
+is auditable, out of deterministic reach, and relies on supervisor sequencing plus
+the now-closed #1915 fork-strand fix.
+
 ## Related
 
 - [Pipeline Graph](pipeline-graph.md) — defines the stage transition edges

--- a/docs/plans/do-merge-docs-stage-gate.md
+++ b/docs/plans/do-merge-docs-stage-gate.md
@@ -210,7 +210,15 @@ exercises the extracted snippet against the real JSON shapes below).
 swallowed; only stdout is parsed for the status.
 
 ```bash
-SLUG=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | sed 's|^session/||')
+# Derive the slug from the PR's head ref (authoritative on every path), NOT the
+# current branch — a raw `gh pr merge`/cross-machine operator commonly runs from
+# `main` or a detached HEAD, where `git rev-parse --abbrev-ref HEAD` yields
+# `main`/`HEAD` and would false-FAIL a `docs/features/main.md` lookup. Fall back to
+# the current branch only if the PR head-ref lookup is unavailable, and treat
+# main/master/HEAD/empty as "no usable slug".
+SLUG=$(gh pr view {PR} --json headRefName -q .headRefName 2>/dev/null | sed 's|^session/||')
+[ -z "$SLUG" ] && SLUG=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | sed 's|^session/||')
+case "$SLUG" in main|master|HEAD|"") SLUG="" ;; esac
 DOCS_STATUS=$(sdlc-tool stage-query --issue-number {issue_number} \
   | python3 -c "import sys,json; print(json.load(sys.stdin).get('stages',{}).get('DOCS',''))")
 case "$DOCS_STATUS" in
@@ -240,6 +248,15 @@ case "$DOCS_STATUS" in
 esac
 ```
 
+- **Why the slug comes from the PR head-ref, not the current branch (resolves re-critique concern 1):**
+  the degraded fallback needs the slug to locate `docs/features/{slug}.md`, but the
+  bypass paths this plan hardens (raw `gh pr merge`, cross-machine) commonly run
+  from `main` or a detached HEAD, where `git rev-parse --abbrev-ref HEAD` yields
+  `main`/`HEAD` — a non-empty but wrong value that would test the always-absent
+  `docs/features/main.md` and false-FAIL a legitimate merge. `gh pr view {PR}
+  --json headRefName` is authoritative on every path; the current-branch read is a
+  fallback only, and `main`/`master`/`HEAD`/empty normalize to "no usable slug"
+  (fail-closed with a `<no-slug>` message, never a bogus file lookup).
 - **Why `.get('stages',{}).get('DOCS','')` and not the issue's sketch:** the
   enriched query returns bare status strings under `stages`, not
   `{"DOCS": {"status": ...}}`. Verified live and in `query_enriched` (spike-2).
@@ -311,6 +328,7 @@ esac
 - [ ] `DOCS_STATUS == pending` (never-started, indistinguishable from a skip) **with** `docs/features/{slug}.md` present → gate PASSES degraded. Test feeds `{"stages": {"DOCS": "pending"}}` on a branch whose slug's feature doc exists, asserts `PASS (degraded)` and NO `GATES_FAILED`. **without** the feature doc → gate FAILS (`GATES_FAILED`).
 - [ ] `DOCS_STATUS == ""` (empty `stages`, session reaped) **with** `docs/features/{slug}.md` present → gate PASSES degraded. Test feeds `{"stages": {}}` on a branch whose slug's feature doc exists, asserts `PASS (degraded)` and NO `GATES_FAILED`.
 - [ ] `DOCS_STATUS == ""` **without** the feature doc → gate FAILS. Test feeds `{"stages": {}}` with no matching feature doc, asserts `GATES_FAILED`.
+- [ ] **No usable slug** (invoked from `main`/detached HEAD, PR head-ref also resolves to `main`) with `DOCS_STATUS == pending`/`""` → gate FAILS with a `<no-slug>` message, NOT a `docs/features/main.md` lookup. Test stubs `gh pr view` to return `main` (or unavailable) and asserts the FAIL names `<no-slug>`, confirming no bogus file lookup.
 - [ ] The malformed-JSON case is **intentionally not tested:** `sdlc-tool stage-query` is contractually guaranteed to emit valid JSON — every error path in `sdlc_stage_query.py::main` prints `{"stages": {}, "_meta": {...}}` (never non-JSON). A malformed-stdin test would exercise an input the substrate cannot produce; and even if it could, an empty `DOCS_STATUS` now routes to the file-existence fallback, not a distinct branch. State "no reachable malformed-JSON path" rather than testing a synthetic one.
 
 ### Error State Rendering
@@ -318,7 +336,7 @@ esac
 
 ## Test Impact
 
-- [ ] `tests/unit/test_do_merge_docs_gate.py` — CREATE: new test file mirroring `test_do_merge_review_filter.py`; extracts the Step 2b snippet from `docs/sdlc/do-merge.md` and asserts the decision across `completed` (PASS), `in_progress` (hard FAIL), skip-as-`completed` (PASS), `pending`-with-feature-doc (PASS degraded), `pending`-without-feature-doc (FAIL), empty-stages-with-feature-doc (PASS degraded), and empty-stages-without-feature-doc (FAIL). The `pending`/empty-stages cases set up a temp branch/slug + `docs/features/{slug}.md` fixture so the `test -f` fallback is exercised.
+- [ ] `tests/unit/test_do_merge_docs_gate.py` — CREATE: new test file mirroring `test_do_merge_review_filter.py`; extracts the Step 2b snippet from `docs/sdlc/do-merge.md` and asserts the decision across `completed` (PASS), `in_progress` (hard FAIL), skip-as-`completed` (PASS), `pending`-with-feature-doc (PASS degraded), `pending`-without-feature-doc (FAIL), empty-stages-with-feature-doc (PASS degraded), empty-stages-without-feature-doc (FAIL), and **no-usable-slug** (invoked from `main`, `pending`/empty status → FAIL with `<no-slug>`, no `docs/features/main.md` lookup). The snippet calls `gh pr view {PR}` and `sdlc-tool stage-query` — the test stubs both (e.g. a temp `PATH` shim or command substitution) so it controls the head-ref (slug) and the `stages.DOCS` value without a live PR. The `pending`/empty-stages cases set up a temp slug + `docs/features/{slug}.md` fixture so the `test -f` fallback is exercised.
 - [ ] `tests/unit/test_do_merge_baseline.py` — UPDATE (only if it asserts the exact set of gate sections/steps): add the Step 2b / extended Documentation Gate to any section-presence assertion. Verify before editing; leave untouched if it does not enumerate steps.
 - [ ] `tests/unit/test_do_merge_review_filter.py` — no change expected (independent snippet); confirm it still passes after the `docs/sdlc/do-merge.md` edit.
 
@@ -342,9 +360,9 @@ No other existing tests are affected — the change adds one gate step to a mark
 **Impact:** doc-free trivial PRs can't merge — a regression the acceptance criteria forbid.
 **Mitigation:** the gate passes on `completed`; #1799 records a skip *as* `completed`. A dedicated test case ("DOCS recorded completed via skip") asserts PASS. If #1799 ever changes its recorded value, the test is where that contract is caught.
 
-### Risk 3: Degraded substrate blocks an otherwise-valid merge
-**Impact:** a transient Redis outage at merge time fails the DOCS gate, stalling a good PR.
-**Mitigation:** fail-closed is the intended posture (mirrors Step 2 REVIEW). The refusal names the substrate fault explicitly so the operator can retry once the substrate recovers. This is a deliberate safety tradeoff, documented in the gate text.
+### Risk 3: A degraded/unreadable substrate read mis-gates a merge
+**Impact:** a transient Redis outage or reaped session at merge time returns `{"stages": {}}` (`tools/sdlc_stage_query.py:488-489`), so the gate cannot read `stages.DOCS`.
+**Mitigation:** the empty read routes to the `*)` degraded branch — file-existence PASS when `docs/features/{slug}.md` is present, FAIL only when it is absent. This is NOT a blanket fail-closed: `in_progress` is the sole hard fail and it only fires when `stages` is readable. So a substrate outage on a PR whose feature doc is already on disk still merges (degraded PASS, advisory logged); only a truly missing feature doc blocks. The advisory line names the degraded read so the operator can re-run `stage-query` once the substrate recovers if a stricter check is wanted. This is the deliberate monotonic-improvement tradeoff (never worse than today's file-existence gate), documented in the gate text.
 
 ## Race Conditions
 
@@ -460,7 +478,7 @@ the agent already invokes at the MERGE stage. No new CLI entry point, no
 - **Assigned To**: gate-builder
 - **Agent Type**: builder
 - **Parallel**: false
-- Create `tests/unit/test_do_merge_docs_gate.py` mirroring `test_do_merge_review_filter.py`: extract the Step 2b snippet from `docs/sdlc/do-merge.md`, run against synthetic `{"stages": {"DOCS": ...}}` JSON. Assert: PASS for `completed`, PASS for skip-as-`completed`, hard FAIL (`GATES_FAILED`) for `in_progress` only, PASS (degraded) for `pending`-with-feature-doc-fixture, FAIL for `pending`-without-doc, PASS (degraded) for empty-stages-with-feature-doc-fixture, FAIL for empty-stages-without-doc. Do NOT add a malformed-JSON case (unreachable — see Failure Path Test Strategy).
+- Create `tests/unit/test_do_merge_docs_gate.py` mirroring `test_do_merge_review_filter.py`: extract the Step 2b snippet from `docs/sdlc/do-merge.md`, run against synthetic `{"stages": {"DOCS": ...}}` JSON. Stub `gh pr view` and `sdlc-tool stage-query` (PATH shim) so the test controls both the head-ref slug and the DOCS status. Assert: PASS for `completed`, PASS for skip-as-`completed`, hard FAIL (`GATES_FAILED`) for `in_progress` only, PASS (degraded) for `pending`-with-feature-doc-fixture, FAIL for `pending`-without-doc, PASS (degraded) for empty-stages-with-feature-doc-fixture, FAIL for empty-stages-without-doc, and FAIL-with-`<no-slug>` for the no-usable-slug case (head-ref resolves to `main`). Do NOT add a malformed-JSON case (unreachable — see Failure Path Test Strategy).
 
 ### 4. Documentation
 - **Task ID**: document-feature
@@ -492,6 +510,7 @@ the agent already invokes at the MERGE stage. No new CLI entry point, no
 | Step 2b present | `grep -c "Step 2b" docs/sdlc/do-merge.md` | output > 0 |
 | Correct extraction shape | `grep -c "get('stages'" docs/sdlc/do-merge.md` | output > 0 |
 | No wrong extraction shape | `grep -c "get('DOCS',{}).get('status'" docs/sdlc/do-merge.md` | match count == 0 |
+| Slug from PR head-ref | `grep -c "gh pr view.*headRefName" docs/sdlc/do-merge.md` | output > 0 |
 | Announced skip in global skill | `grep -c "NOT ENFORCED" .claude/skills-global/do-merge/SKILL.md` | output > 0 |
 | Router untouched (anti-criterion) | `git diff --name-only origin/main -- agent/sdlc_router.py \| wc -l` | match count == 0 |
 
@@ -502,14 +521,20 @@ the agent already invokes at the MERGE stage. No new CLI entry point, no
 |----------|--------|---------|--------------|---------------------|
 | BLOCKER | Risk & Robustness | Step 2b `case` groups bare `pending` with `in_progress` and hard-fails it, but `pending` is the default unrun status (indistinguishable from stalled). On a live-session trivial docs-free PR reaching the gate via a bypass path (target scope), DOCS reads `pending` because #1799 (skip→`completed`) is unshipped, so the gate hard-refuses a legitimate merge — contradicting Risk 2's own "regression the acceptance criteria forbid." | Technical Approach (line 207), Data Flow step 4, Failure Path Test Strategy, Test Impact | Split `in_progress\|pending)` into two branches: `in_progress)` keeps the hard `GATES_FAILED` (only reachable via an actual `start_stage` call = genuine stalled signal); `pending)` falls through to the same file-existence fallback as the `*)` empty-stages branch. Update `test_do_merge_docs_gate.py` so the `pending` fixture asserts degraded PASS/FAIL by feature-doc presence, not unconditional hard FAIL; adjust the `in_progress\|pending` grouping wording in Failure Path Test Strategy and Test Impact. |
 | CONCERN | Scope & Value + History & Consistency | The Problem "Scope of the fix" subsection overstates the substrate-repo win in two ways that bias the Open Question 1 ratification: (a) the unsupported frequency claim "the far more common case, since this repo is a substrate repo" (no incident/volume data), and (b) the determinism claim that the bypass path "*is* now caught by the new Step 2b check," which spike-2 undercuts because the session is likely reaped on exactly those bypass paths, degrading to the file-existence check the Problem elsewhere calls insufficient. | Problem > "Scope of the fix: substrate repos" | Pure prose edit, no code/test/task change. (a) Replace "the far more common case, since this repo is a substrate repo" with an explicitly-flagged, unmeasured assumption or drop the frequency claim. (b) Qualify "is now caught" to "is now caught when the substrate session is still live; when it has been reaped the gate degrades to today's file-existence check, per spike-2." No other artifact depends on this wording. |
+| CONCERN (re-critique) | Risk & Robustness | Verdict READY TO BUILD. `SLUG=$(git rev-parse --abbrev-ref HEAD)` is brittle on the bypass paths the plan targets: a raw `gh pr merge`/cross-machine operator runs from `main`/detached HEAD, yielding `SLUG=main` (non-empty), so the degraded fallback tests always-absent `docs/features/main.md` → false FAIL of a legitimate merge. | Technical Approach (SLUG derivation), Failure Path, Test Impact, Step 3 | RESOLVED: derive slug from `gh pr view {PR} --json headRefName` (authoritative on every path), current-branch read as fallback only, normalize `main`/`master`/`HEAD`/empty to "no usable slug" (fail-closed with `<no-slug>` message, never a bogus file lookup). Added on-`main` test fixture + `gh pr view` stub guidance. |
+| CONCERN (re-critique) | Risk & Robustness | Risk 3 still described the pre-revision fail-closed posture ("substrate outage fails the gate, stalling a good PR"), contradicting the revised degraded behavior (empty read → file-existence PASS when doc present). | Risks > Risk 3 | RESOLVED: rewrote Risk 3 to describe the actual monotonic-improvement posture — empty/degraded read degrades to file-existence PASS, `in_progress` is the only hard fail and only when `stages` is readable. |
+| CONCERN (re-critique) | Scope & Value + History & Consistency | Open Questions #1 and #2 retained the unqualified determinism overclaim the revision removed from the Problem body ("closes the substrate-repo bypass paths deterministically"). | Open Questions #1, #2 | RESOLVED: propagated the live-session qualifier into OQ#1 and OQ#2 (deterministic only when the substrate session is live at merge time; reaped session degrades to file-existence, per spike-2). |
 
 ---
 
 ## Open Questions
 
 1. **Ratify the reclassified scope + generic-path decision.** After critique, the
-   deterministic DOCS gate is scoped to **substrate repos** (where a stage marker
-   exists to read), which is where this repo's real bypass paths live; the
+   deterministic DOCS gate is scoped to **substrate repos with a live session at
+   merge time** (where a readable stage marker exists) — it hard-blocks an
+   `in_progress` DOCS there; when the substrate session has been reaped (likely on
+   precisely these bypass paths, per spike-2) it degrades to today's file-existence
+   check, not a deterministic block. The
    no-substrate path emits an *announced non-gate* advisory rather than pretending
    to gate DOCS deterministically (that path's real fix is the now-CLOSED #1915 +
    supervisor sequencing). Confirm this reclassification is acceptable — i.e. that
@@ -523,6 +548,8 @@ the agent already invokes at the MERGE stage. No new CLI entry point, no
    migration into `docs/plans/completed/` — not DOCS-stage completion. **No existing
    reflection covers DOCS completion on bypass paths.** A DOCS-completion reflection
    would therefore be genuinely new work, not an extension of the migration
-   backstop. It is separable from this gate (which already closes the substrate-repo
-   bypass paths deterministically) and, if wanted, should be filed as its own issue.
+   backstop. It is separable from this gate (which closes the substrate-repo bypass
+   paths deterministically **only when the substrate session is live at merge time;
+   a reaped session degrades to the file-existence check, per spike-2**) and, if
+   wanted, should be filed as its own issue.
    Confirm OUT-of-scope, or file the separate issue.

--- a/docs/plans/do-merge-docs-stage-gate.md
+++ b/docs/plans/do-merge-docs-stage-gate.md
@@ -52,14 +52,24 @@ deterministic prevention for it is the now-CLOSED **#1915** fork-strand fix plus
 supervisor sequencing. What this plan adds for the no-substrate path is an
 **announced non-gate** (an auditable advisory line in the merge log, not a silent
 pass). The same forked-`/do-sdlc`/raw-merge bypass occurring **in a substrate
-repo** — the far more common case, since this repo is a substrate repo — *is* now
-caught by the new Step 2b check.
+repo** is caught by the new Step 2b check **when the substrate session is still
+live at merge time** (Step 2b reads `stages.DOCS == in_progress` and hard-fails);
+**when that session has been reaped** (spike-2 notes this is likely on precisely
+these bypass paths), Step 2b degrades to today's file-existence check rather than a
+deterministic block. So the honest tradeoff being ratified is: a deterministic
+gate on the live-session substrate path, and an advisory/file-existence posture
+where the session is gone or no substrate exists (the latter being where the
+original incident occurred). No incident-frequency data supports one bypass shape
+being more common than another; the substrate-repo win is scoped to the live-session
+case, not claimed as the dominant path.
 
 **Desired outcome:** in a substrate repo, `/do-merge` treats DOCS-stage
 completion as a first-class precondition, analogous to the Step 2 REVIEW-verdict
-gate, and **fails closed** when DOCS is required but not `completed` — without
-creating the merge-authorization file. A legitimate DOCS-skip PR (#1799) still
-merges. In a no-substrate repo, the gate emits an explicit advisory that DOCS
+gate, and **fails closed** when DOCS is affirmatively unfinished (`in_progress`) —
+without creating the merge-authorization file. A never-started (`pending`) or
+unreadable (session-reaped) DOCS marker degrades to the pre-existing
+file-existence check rather than a false block. A legitimate DOCS-skip PR (#1799)
+still merges. In a no-substrate repo, the gate emits an explicit advisory that DOCS
 cannot be deterministically verified (not a silent pass).
 
 ## Freshness Check
@@ -127,8 +137,8 @@ exercises the extracted snippet against the real JSON shapes below).
 3. **Step 1-2:** verify PR state + recorded REVIEW verdict via `sdlc-tool`.
 4. **Step 2b (NEW):** `sdlc-tool stage-query --issue-number N` → parse `stages.DOCS`.
    - `completed` → PASS.
-   - `in_progress` / `pending` (affirmative "DOCS unfinished" signal) → FAIL closed, route to `/do-docs`.
-   - `""` / empty `stages` (session reaped — can't read the marker, spike-2) → **degraded fallback** to the pre-existing file-existence check `test -f docs/features/{slug}.md`: present ⇒ PASS (degraded, advisory logged); absent ⇒ FAIL.
+   - `in_progress` (affirmative "DOCS unfinished" signal — only reachable via a real `start_stage` call) → FAIL closed, route to `/do-docs`.
+   - `pending` (DOCS never started — the default status, indistinguishable from a legitimate skip while #1799 is unshipped) OR `""` / empty `stages` (session reaped — can't read the marker, spike-2) → **degraded fallback** to the pre-existing file-existence check `test -f docs/features/{slug}.md`: present ⇒ PASS (degraded, advisory logged); absent ⇒ FAIL.
 5. **Step 4:** only on all-pass, `touch data/merge_authorized_{PR}` → `gh pr merge` → `rm`.
 6. **Output:** merged PR, or a gate refusal naming the DOCS blocker; no auth file created on refusal.
 
@@ -164,9 +174,10 @@ exercises the extracted snippet against the real JSON shapes below).
 - **Step 2b — Verify DOCS Stage Completed** (`docs/sdlc/do-merge.md`): a new
   substrate-mapping step placed immediately after the Step 2 REVIEW-verdict
   mapping. Reads `stages.DOCS` from `sdlc-tool stage-query`; PASS on `completed`;
-  FAIL closed on `in_progress`/`pending` (affirmative "DOCS unfinished") and route
-  back to `/do-docs`; on empty `stages` (session reaped) **degrade to the
-  file-existence check** — PASS if `docs/features/{slug}.md` exists, else FAIL.
+  FAIL closed on `in_progress` (the only affirmative "DOCS unfinished" signal) and
+  route back to `/do-docs`; on `pending` (never-started, indistinguishable from a
+  skip) OR empty `stages` (session reaped) **degrade to the file-existence check** —
+  PASS if `docs/features/{slug}.md` exists, else FAIL.
 - **Extended "Documentation Gate"** (`docs/sdlc/do-merge.md`): now checks DOCS
   *stage completion* (via Step 2b) as the authoritative signal, with the existing
   `docs/features/{slug}.md` existence check retained as the degraded fallback for
@@ -178,16 +189,17 @@ exercises the extracted snippet against the real JSON shapes below).
   case. The deterministic gate lives in the substrate addendum, not the global skill.
 - **Gate test** (`tests/unit/test_do_merge_docs_gate.py`): extracts the Step 2b
   snippet from `docs/sdlc/do-merge.md` and asserts the decision across
-  `completed` (PASS), `in_progress`/`pending` (hard FAIL), skip-as-`completed`
-  (PASS), empty-stages-with-doc (PASS degraded), and empty-stages-without-doc (FAIL).
+  `completed` (PASS), `in_progress` (hard FAIL), skip-as-`completed`
+  (PASS), `pending`-with-doc (PASS degraded), `pending`-without-doc (FAIL),
+  empty-stages-with-doc (PASS degraded), and empty-stages-without-doc (FAIL).
 
 ### Flow
 
 `/do-merge {PR}` → Step 1 PR-state PASS → Step 2 REVIEW verdict APPROVED →
 **Step 2b query `stages.DOCS`** → `completed` ⇒ continue to Step 4 merge;
-`in_progress`/`pending` ⇒ **refuse, no auth file, route to `/do-docs`**;
-`""` (empty stages, session reaped) ⇒ fall back to `docs/features/{slug}.md`
-existence: present ⇒ continue; absent ⇒ **refuse, no auth file**.
+`in_progress` ⇒ **refuse, no auth file, route to `/do-docs`**;
+`pending` (never-started) or `""` (empty stages, session reaped) ⇒ fall back to
+`docs/features/{slug}.md` existence: present ⇒ continue; absent ⇒ **refuse, no auth file**.
 
 ### Technical Approach
 
@@ -204,19 +216,25 @@ DOCS_STATUS=$(sdlc-tool stage-query --issue-number {issue_number} \
 case "$DOCS_STATUS" in
   completed)
     echo "DOCS_GATE: PASS — DOCS stage completed" ;;
-  in_progress|pending)
-    # Affirmative "DOCS unfinished" signal — the incident case. Fail closed.
-    echo "DOCS_GATE: FAIL — DOCS stage is '$DOCS_STATUS', not completed"
+  in_progress)
+    # Affirmative "DOCS unfinished" signal — only reachable via an actual
+    # start_stage call, so a genuinely started-but-stalled DOCS stage (the
+    # cuttlefish #577 incident shape). Fail closed.
+    echo "DOCS_GATE: FAIL — DOCS stage is 'in_progress', not completed"
     echo "GATES_FAILED" ;;   # route back to /do-docs; do NOT create the auth file
   *)
-    # Empty stages: the session was reaped/orphan-cleaned (spike-2), so the
-    # marker is unreadable — we cannot AFFIRM 'unfinished'. Degrade to the
-    # pre-existing file-existence Documentation Gate rather than false-refuse a
-    # merge whose DOCS truly completed.
+    # pending (DOCS never started — the DEFAULT status for a stage with no marker,
+    # e.g. a docs-free trivial PR before #1799's skip-as-completed ships) OR empty
+    # stages (session reaped/orphan-cleaned, spike-2, so the marker is unreadable).
+    # In NEITHER case can we AFFIRM 'unfinished': a never-started DOCS is
+    # indistinguishable from a legitimate skip, and a reaped session hides a
+    # possibly-completed run. Degrade to the pre-existing file-existence
+    # Documentation Gate rather than false-refuse a merge whose DOCS truly
+    # completed or was legitimately skipped.
     if [ -n "$SLUG" ] && [ -f "docs/features/${SLUG}.md" ]; then
-      echo "DOCS_GATE: PASS (degraded) — DOCS marker unreadable (empty stages); docs/features/${SLUG}.md present"
+      echo "DOCS_GATE: PASS (degraded) — DOCS marker not authoritative (status='${DOCS_STATUS:-<empty>}'); docs/features/${SLUG}.md present"
     else
-      echo "DOCS_GATE: FAIL — DOCS marker unreadable AND docs/features/${SLUG:-<no-slug>}.md absent"
+      echo "DOCS_GATE: FAIL — DOCS marker not authoritative (status='${DOCS_STATUS:-<empty>}') AND docs/features/${SLUG:-<no-slug>}.md absent"
       echo "GATES_FAILED"
     fi ;;
 esac
@@ -231,22 +249,25 @@ esac
   DOCS as `completed` (the "skipped" nuance lives in the router `reason` string,
   not the status). So a single `== completed` check admits both a real completion
   and a legitimate skip. The gate never needs to distinguish them.
-- **Why empty-`stages` degrades instead of failing closed (resolves blocker 1):**
+- **Why `pending` and empty-`stages` degrade instead of failing closed (resolves blocker 1):**
   `query_enriched` returns `{"stages": {}}` whenever the session is gone
-  (spike-2), which is precisely the router-bypass path this plan hardens. A blanket
-  fail-closed there would REFUSE merges whose DOCS genuinely completed — a false
-  block the critique flagged. Instead the empty case degrades to the **status-quo
-  Documentation Gate** (`test -f docs/features/{slug}.md`). This makes Step 2b a
-  strict, monotonic improvement: when the marker is readable it is authoritative
-  (and can affirmatively *block* an `in_progress` DOCS); when it is not, behavior
-  is exactly today's file-existence gate. An explicit `in_progress`/`pending`
-  status is the ONLY affirmative-unfinished signal and is the only hard fail.
-  - **Residual (accepted):** a docs-free trivial PR whose session was ALSO reaped
-    (double degradation: empty stages AND no feature doc) falls to FAIL. This is
+  (spike-2), and `pending` is the DEFAULT status for a DOCS stage that was never
+  started (confirmed live: an unrun DOCS reads `pending`) — indistinguishable from
+  a legitimate skip, especially since #1799's skip-as-`completed` is UNSHIPPED. Both
+  are precisely the router-bypass paths this plan hardens. A blanket fail-closed on
+  either would REFUSE merges whose DOCS genuinely completed or was legitimately
+  skipped — the regression Risk 2 forbids. Instead both cases degrade to the
+  **status-quo Documentation Gate** (`test -f docs/features/{slug}.md`). This makes
+  Step 2b a strict, monotonic improvement: when the marker reads `completed` it is
+  authoritative PASS; when it reads `in_progress` it can affirmatively *block*
+  (the only affirmative-unfinished signal, reachable only via a real `start_stage`
+  call); in every other case behavior is exactly today's file-existence gate. `in_progress`
+  is therefore the ONLY hard fail.
+  - **Residual (accepted):** a docs-free trivial PR whose DOCS is `pending`/empty
+    AND whose feature doc is absent (double degradation) falls to FAIL. This is
     the same fail-closed posture the status-quo gate takes when a plan-declared doc
-    is missing; it is rare (requires both a bypass path and a reaped session) and
-    recoverable (re-run `/do-docs` or re-authorize). Chosen over admitting an
-    unverifiable merge.
+    is missing; it is rare and recoverable (re-run `/do-docs` or re-authorize).
+    Chosen over admitting an unverifiable merge.
 
 **Generic/no-substrate path (resolves open question #1; aligned with the blocker-2 reclassification):**
 - Per the Problem reclassification, the no-substrate path is **out of deterministic
@@ -286,17 +307,18 @@ esac
 - [ ] No new `except Exception: pass` blocks — the change is shell-in-markdown plus a test. State "No exception handlers in scope" for the gate snippet; the test itself asserts observable decision strings.
 
 ### Empty/Invalid Input Handling
-- [ ] `DOCS_STATUS in {in_progress, pending}` → gate FAILS closed (affirmative "DOCS unfinished"). Test feeds `{"stages": {"DOCS": "in_progress"}}` and asserts `GATES_FAILED`.
+- [ ] `DOCS_STATUS == in_progress` → gate FAILS closed (the only affirmative "DOCS unfinished" signal). Test feeds `{"stages": {"DOCS": "in_progress"}}` and asserts `GATES_FAILED`.
+- [ ] `DOCS_STATUS == pending` (never-started, indistinguishable from a skip) **with** `docs/features/{slug}.md` present → gate PASSES degraded. Test feeds `{"stages": {"DOCS": "pending"}}` on a branch whose slug's feature doc exists, asserts `PASS (degraded)` and NO `GATES_FAILED`. **without** the feature doc → gate FAILS (`GATES_FAILED`).
 - [ ] `DOCS_STATUS == ""` (empty `stages`, session reaped) **with** `docs/features/{slug}.md` present → gate PASSES degraded. Test feeds `{"stages": {}}` on a branch whose slug's feature doc exists, asserts `PASS (degraded)` and NO `GATES_FAILED`.
 - [ ] `DOCS_STATUS == ""` **without** the feature doc → gate FAILS. Test feeds `{"stages": {}}` with no matching feature doc, asserts `GATES_FAILED`.
 - [ ] The malformed-JSON case is **intentionally not tested:** `sdlc-tool stage-query` is contractually guaranteed to emit valid JSON — every error path in `sdlc_stage_query.py::main` prints `{"stages": {}, "_meta": {...}}` (never non-JSON). A malformed-stdin test would exercise an input the substrate cannot produce; and even if it could, an empty `DOCS_STATUS` now routes to the file-existence fallback, not a distinct branch. State "no reachable malformed-JSON path" rather than testing a synthetic one.
 
 ### Error State Rendering
-- [ ] The hard-fail path prints `DOCS_GATE: FAIL — DOCS stage is '<status>', not completed` and `GATES_FAILED`; the degraded-fail path prints `DOCS_GATE: FAIL — DOCS marker unreadable AND docs/features/<slug>.md absent`. The merge report surfaces the specific blocker. Test asserts the FAIL message names the observed condition.
+- [ ] The hard-fail path (`in_progress`) prints `DOCS_GATE: FAIL — DOCS stage is 'in_progress', not completed` and `GATES_FAILED`; the degraded-fail path prints `DOCS_GATE: FAIL — DOCS marker not authoritative (status='<status>') AND docs/features/<slug>.md absent`. The merge report surfaces the specific blocker. Test asserts the FAIL message names the observed condition.
 
 ## Test Impact
 
-- [ ] `tests/unit/test_do_merge_docs_gate.py` — CREATE: new test file mirroring `test_do_merge_review_filter.py`; extracts the Step 2b snippet from `docs/sdlc/do-merge.md` and asserts the decision across `completed` (PASS), `in_progress`/`pending` (hard FAIL), skip-as-`completed` (PASS), empty-stages-with-feature-doc (PASS degraded), and empty-stages-without-feature-doc (FAIL). The empty-stages cases set up a temp branch/slug + `docs/features/{slug}.md` fixture so the `test -f` fallback is exercised.
+- [ ] `tests/unit/test_do_merge_docs_gate.py` — CREATE: new test file mirroring `test_do_merge_review_filter.py`; extracts the Step 2b snippet from `docs/sdlc/do-merge.md` and asserts the decision across `completed` (PASS), `in_progress` (hard FAIL), skip-as-`completed` (PASS), `pending`-with-feature-doc (PASS degraded), `pending`-without-feature-doc (FAIL), empty-stages-with-feature-doc (PASS degraded), and empty-stages-without-feature-doc (FAIL). The `pending`/empty-stages cases set up a temp branch/slug + `docs/features/{slug}.md` fixture so the `test -f` fallback is exercised.
 - [ ] `tests/unit/test_do_merge_baseline.py` — UPDATE (only if it asserts the exact set of gate sections/steps): add the Step 2b / extended Documentation Gate to any section-presence assertion. Verify before editing; leave untouched if it does not enumerate steps.
 - [ ] `tests/unit/test_do_merge_review_filter.py` — no change expected (independent snippet); confirm it still passes after the `docs/sdlc/do-merge.md` edit.
 
@@ -385,8 +407,8 @@ the agent already invokes at the MERGE stage. No new CLI entry point, no
 
 ## Success Criteria
 
-- [ ] `/do-merge` fails closed (prints `GATES_FAILED`, creates no `data/merge_authorized_{PR}` file) when `stages.DOCS` is `in_progress` or `pending`.
-- [ ] On empty `stages` (session reaped), the gate degrades to `docs/features/{slug}.md` existence: PASS when the doc is present, FAIL when absent — it does NOT blanket-refuse a truly-completed merge.
+- [ ] `/do-merge` fails closed (prints `GATES_FAILED`, creates no `data/merge_authorized_{PR}` file) when `stages.DOCS` is `in_progress` (the only affirmative "DOCS unfinished" signal).
+- [ ] On `pending` (never-started, indistinguishable from a legitimate skip) OR empty `stages` (session reaped), the gate degrades to `docs/features/{slug}.md` existence: PASS when the doc is present, FAIL when absent — it does NOT blanket-refuse a truly-completed-or-skipped merge.
 - [ ] A DOCS-skip PR whose DOCS status is `completed` still passes the gate (test asserts PASS).
 - [ ] The "Documentation Gate" section verifies DOCS *stage completion* as authoritative, with file existence retained as the degraded fallback.
 - [ ] The generic/no-substrate path emits an explicit announced non-gate advisory line (not a silent pass); documented in the global SKILL.md and scoped as out of deterministic reach.
@@ -420,7 +442,7 @@ the agent already invokes at the MERGE stage. No new CLI entry point, no
 - **Assigned To**: gate-builder
 - **Agent Type**: builder
 - **Parallel**: true
-- In `docs/sdlc/do-merge.md`, add a "Step 2b: Verify DOCS Stage Completed" mapping in the Stage/Verdict Substrate section, immediately after the Step 2 REVIEW-verdict bullet, using the exact extraction + `case` decision from Technical Approach: PASS on `completed`; hard FAIL on `in_progress`/`pending`; empty-stages ⇒ file-existence fallback (`docs/features/${SLUG}.md`). Do NOT re-add `2>/dev/null` to the `sdlc-tool stage-query` call.
+- In `docs/sdlc/do-merge.md`, add a "Step 2b: Verify DOCS Stage Completed" mapping in the Stage/Verdict Substrate section, immediately after the Step 2 REVIEW-verdict bullet, using the exact extraction + `case` decision from Technical Approach: PASS on `completed`; hard FAIL on `in_progress` only; `pending`/empty-stages ⇒ file-existence fallback (`docs/features/${SLUG}.md`). Do NOT re-add `2>/dev/null` to the `sdlc-tool stage-query` call.
 - Extend the "Documentation Gate" section so it states the authoritative check is DOCS *stage completion* (Step 2b), with `docs/features/{slug}.md` existence retained as the degraded fallback for the unreadable-marker case.
 
 ### 2. Add generic-path precondition + announced skip to the global skill
@@ -438,7 +460,7 @@ the agent already invokes at the MERGE stage. No new CLI entry point, no
 - **Assigned To**: gate-builder
 - **Agent Type**: builder
 - **Parallel**: false
-- Create `tests/unit/test_do_merge_docs_gate.py` mirroring `test_do_merge_review_filter.py`: extract the Step 2b snippet from `docs/sdlc/do-merge.md`, run against synthetic `{"stages": {"DOCS": ...}}` JSON. Assert: PASS for `completed`, PASS for skip-as-`completed`, hard FAIL (`GATES_FAILED`) for `in_progress`/`pending`, PASS (degraded) for empty-stages-with-feature-doc-fixture, FAIL for empty-stages-without-doc. Do NOT add a malformed-JSON case (unreachable — see Failure Path Test Strategy).
+- Create `tests/unit/test_do_merge_docs_gate.py` mirroring `test_do_merge_review_filter.py`: extract the Step 2b snippet from `docs/sdlc/do-merge.md`, run against synthetic `{"stages": {"DOCS": ...}}` JSON. Assert: PASS for `completed`, PASS for skip-as-`completed`, hard FAIL (`GATES_FAILED`) for `in_progress` only, PASS (degraded) for `pending`-with-feature-doc-fixture, FAIL for `pending`-without-doc, PASS (degraded) for empty-stages-with-feature-doc-fixture, FAIL for empty-stages-without-doc. Do NOT add a malformed-JSON case (unreachable — see Failure Path Test Strategy).
 
 ### 4. Documentation
 - **Task ID**: document-feature
@@ -475,9 +497,11 @@ the agent already invokes at the MERGE stage. No new CLI entry point, no
 
 ## Critique Results
 
-<!-- Populated by /do-plan-critique (war room). Leave empty until critique is run. -->
+<!-- Populated by /do-plan-critique (war room). Re-critique of revised plan; verdict NEEDS REVISION (1 blocker). -->
 | Severity | Critic | Finding | Addressed By | Implementation Note |
 |----------|--------|---------|--------------|---------------------|
+| BLOCKER | Risk & Robustness | Step 2b `case` groups bare `pending` with `in_progress` and hard-fails it, but `pending` is the default unrun status (indistinguishable from stalled). On a live-session trivial docs-free PR reaching the gate via a bypass path (target scope), DOCS reads `pending` because #1799 (skip→`completed`) is unshipped, so the gate hard-refuses a legitimate merge — contradicting Risk 2's own "regression the acceptance criteria forbid." | Technical Approach (line 207), Data Flow step 4, Failure Path Test Strategy, Test Impact | Split `in_progress\|pending)` into two branches: `in_progress)` keeps the hard `GATES_FAILED` (only reachable via an actual `start_stage` call = genuine stalled signal); `pending)` falls through to the same file-existence fallback as the `*)` empty-stages branch. Update `test_do_merge_docs_gate.py` so the `pending` fixture asserts degraded PASS/FAIL by feature-doc presence, not unconditional hard FAIL; adjust the `in_progress\|pending` grouping wording in Failure Path Test Strategy and Test Impact. |
+| CONCERN | Scope & Value + History & Consistency | The Problem "Scope of the fix" subsection overstates the substrate-repo win in two ways that bias the Open Question 1 ratification: (a) the unsupported frequency claim "the far more common case, since this repo is a substrate repo" (no incident/volume data), and (b) the determinism claim that the bypass path "*is* now caught by the new Step 2b check," which spike-2 undercuts because the session is likely reaped on exactly those bypass paths, degrading to the file-existence check the Problem elsewhere calls insufficient. | Problem > "Scope of the fix: substrate repos" | Pure prose edit, no code/test/task change. (a) Replace "the far more common case, since this repo is a substrate repo" with an explicitly-flagged, unmeasured assumption or drop the frequency claim. (b) Qualify "is now caught" to "is now caught when the substrate session is still live; when it has been reaped the gate degrades to today's file-existence check, per spike-2." No other artifact depends on this wording. |
 
 ---
 

--- a/docs/sdlc/do-merge.md
+++ b/docs/sdlc/do-merge.md
@@ -25,6 +25,58 @@ generic steps as follows:
   `CHANGES REQUESTED` / `NEEDS REVISION` verdict, or no verdict at all, FAILS —
   route back to `/do-pr-review` or `/do-patch`. In degraded mode the tool may
   return no data; if approval cannot be confirmed, FAIL closed.
+- **Step 2b — Verify DOCS Stage Completed.** Step 2b mirrors the Step 2
+  REVIEW-verdict gate, applied to the DOCS stage. It reads `stages.DOCS` from
+  `sdlc-tool stage-query` and PASSes on `completed`. It hard-FAILs closed on
+  `in_progress` only, because that is the sole affirmative "DOCS unfinished"
+  signal (reachable only via a real `start_stage` call, the cuttlefish #577
+  incident shape), and routes back to `/do-docs` without creating the
+  authorization file. A `pending` status (DOCS never started, indistinguishable
+  from a legitimate skip) and an empty `stages` map (session reaped/orphan-cleaned,
+  per spike-2) both degrade to the pre-existing file-existence check rather than a
+  false refusal. The slug is derived from the PR head-ref because bypass-path
+  operators (raw `gh pr merge`, cross-machine) commonly run from `main` or a
+  detached HEAD, where the current branch is a wrong value. `2>/dev/null` is
+  deliberately omitted from the `stage-query` call so a substrate fault surfaces in
+  the merge log; only stdout is parsed for the status.
+  ```bash
+  # Derive the slug from the PR's head ref (authoritative on every path), NOT the
+  # current branch — a raw `gh pr merge`/cross-machine operator commonly runs from
+  # `main` or a detached HEAD, where `git rev-parse --abbrev-ref HEAD` yields
+  # `main`/`HEAD` and would false-FAIL a `docs/features/main.md` lookup. Fall back to
+  # the current branch only if the PR head-ref lookup is unavailable, and treat
+  # main/master/HEAD/empty as "no usable slug".
+  SLUG=$(gh pr view {PR} --json headRefName -q .headRefName 2>/dev/null | sed 's|^session/||')
+  [ -z "$SLUG" ] && SLUG=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | sed 's|^session/||')
+  case "$SLUG" in main|master|HEAD|"") SLUG="" ;; esac
+  DOCS_STATUS=$(sdlc-tool stage-query --issue-number {issue_number} \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('stages',{}).get('DOCS',''))")
+  case "$DOCS_STATUS" in
+    completed)
+      echo "DOCS_GATE: PASS — DOCS stage completed" ;;
+    in_progress)
+      # Affirmative "DOCS unfinished" signal — only reachable via an actual
+      # start_stage call, so a genuinely started-but-stalled DOCS stage (the
+      # cuttlefish #577 incident shape). Fail closed.
+      echo "DOCS_GATE: FAIL — DOCS stage is 'in_progress', not completed"
+      echo "GATES_FAILED" ;;   # route back to /do-docs; do NOT create the auth file
+    *)
+      # pending (DOCS never started — the DEFAULT status for a stage with no marker,
+      # e.g. a docs-free trivial PR before #1799's skip-as-completed ships) OR empty
+      # stages (session reaped/orphan-cleaned, spike-2, so the marker is unreadable).
+      # In NEITHER case can we AFFIRM 'unfinished': a never-started DOCS is
+      # indistinguishable from a legitimate skip, and a reaped session hides a
+      # possibly-completed run. Degrade to the pre-existing file-existence
+      # Documentation Gate rather than false-refuse a merge whose DOCS truly
+      # completed or was legitimately skipped.
+      if [ -n "$SLUG" ] && [ -f "docs/features/${SLUG}.md" ]; then
+        echo "DOCS_GATE: PASS (degraded) — DOCS marker not authoritative (status='${DOCS_STATUS:-<empty>}'); docs/features/${SLUG}.md present"
+      else
+        echo "DOCS_GATE: FAIL — DOCS marker not authoritative (status='${DOCS_STATUS:-<empty>}') AND docs/features/${SLUG:-<no-slug>}.md absent"
+        echo "GATES_FAILED"
+      fi ;;
+  esac
+  ```
 - **Step 4 merge-authorization guard.** `gh pr merge` is blocked by the
   merge-guard hook (`.claude/hooks/validators/validate_merge_guard.py`) unless an
   authorization file exists. Create it immediately before the merge and delete it
@@ -42,7 +94,13 @@ generic steps as follows:
 
 ## Documentation Gate
 
-Before merging, verify `docs/features/{slug}.md` exists if the plan specified one. This is a hard gate — missing feature docs block the merge.
+The authoritative check is now DOCS *stage completion* via Step 2b above: PASS
+when `stages.DOCS == completed`, hard-FAIL closed when it is `in_progress`. When
+the marker is unreadable (session reaped, empty `stages`) or the stage never
+started (`pending`), the gate degrades to verifying `docs/features/{slug}.md`
+exists (the previous behavior), now retained as the degraded fallback rather than
+a separate, weaker check. Present ⇒ PASS (degraded); absent ⇒ FAIL, missing
+feature docs block the merge.
 
 ## Ruff Gates
 

--- a/tests/unit/test_do_merge_docs_gate.py
+++ b/tests/unit/test_do_merge_docs_gate.py
@@ -1,0 +1,244 @@
+"""Tests for the Step 2b DOCS-stage merge gate (issue #1944).
+
+The Step 2b gate logic lives as a shell snippet inside this repo's merge-gate
+addendum ``docs/sdlc/do-merge.md`` (the portable ``/do-merge`` skill defers
+repo-specific gates to it). We can't execute the full gate here without a live
+PR and a populated Redis session, so these tests exercise the extracted snippet
+directly: we parse the markdown, pull out the fenced ``bash`` block that contains
+``DOCS_GATE:``, substitute the ``{PR}`` / ``{issue_number}`` placeholders, and run
+it under ``bash`` with a temporary PATH shim that provides fake ``gh``,
+``sdlc-tool``, and ``git`` executables the test controls.
+
+Extracting the *live* snippet (rather than hardcoding a copy) is what pins the
+test to the markdown: any drift in the gate's decision logic breaks the test.
+
+The shim lets each test control:
+
+- the PR head-ref (``gh pr view ... headRefName``) — hence the derived slug,
+- the ``stages.DOCS`` value (``sdlc-tool stage-query`` JSON), and
+- the current-branch fallback (``git rev-parse --abbrev-ref HEAD``).
+
+Bash runs from a temp working directory where ``docs/features/{slug}.md`` fixture
+files are created as needed, so the ``test -f`` degraded fallback is exercised
+against a real filesystem. ``python3`` is expected on PATH (not shimmed).
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DO_MERGE_MD = REPO_ROOT / "docs" / "sdlc" / "do-merge.md"
+
+
+def _extract_docs_gate_snippet() -> str:
+    """Pull the fenced ``bash`` block containing ``DOCS_GATE:`` from do-merge.md.
+
+    The block is embedded (indented) under a markdown list item, so we dedent it
+    after extraction. Returns the raw shell source.
+    """
+    md = DO_MERGE_MD.read_text()
+    # Match every ```bash ... ``` fenced block (fence may be indented under a
+    # list item, so allow leading whitespace on the fence lines).
+    pattern = re.compile(
+        r"^[ \t]*```bash[ \t]*\n(.*?)^[ \t]*```[ \t]*$",
+        re.DOTALL | re.MULTILINE,
+    )
+    for match in pattern.finditer(md):
+        body = match.group(1)
+        if "DOCS_GATE:" in body:
+            return textwrap.dedent(body)
+    raise AssertionError("No ```bash block containing DOCS_GATE: found in do-merge.md")
+
+
+def _write_shim(shim_dir: Path, name: str, body: str) -> None:
+    path = shim_dir / name
+    path.write_text("#!/usr/bin/env bash\n" + body)
+    path.chmod(0o755)
+
+
+def _run_gate(
+    tmp_path: Path,
+    *,
+    head_ref: str,
+    stages_json: str,
+    git_branch: str = "main",
+) -> str:
+    """Run the extracted Step 2b snippet under a controlled PATH shim.
+
+    Args:
+        head_ref: what ``gh pr view ... headRefName`` echoes (empty = unavailable).
+        stages_json: what ``sdlc-tool stage-query`` echoes on stdout.
+        git_branch: what ``git rev-parse --abbrev-ref HEAD`` echoes (fallback path).
+
+    Returns combined stdout+stderr of the snippet run.
+    """
+    if shutil.which("bash") is None:
+        pytest.skip("bash not installed")
+
+    snippet = _extract_docs_gate_snippet()
+    snippet = snippet.replace("{PR}", "999").replace("{issue_number}", "1944")
+
+    shim_dir = tmp_path / "bin"
+    shim_dir.mkdir()
+
+    # Fake `gh`: only handle `pr view ... headRefName`. Echo the controlled
+    # head-ref (or nothing, to simulate an unavailable lookup).
+    _write_shim(
+        shim_dir,
+        "gh",
+        f'if [[ "$*" == *headRefName* ]]; then printf %s {head_ref!r}; fi\n',
+    )
+    # Fake `sdlc-tool`: emit the controlled stage-query JSON on stdout.
+    _write_shim(
+        shim_dir,
+        "sdlc-tool",
+        f"cat <<'EOF'\n{stages_json}\nEOF\n",
+    )
+    # Fake `git`: answer rev-parse --abbrev-ref HEAD with the controlled branch.
+    _write_shim(
+        shim_dir,
+        "git",
+        f'if [[ "$*" == *"rev-parse --abbrev-ref HEAD"* ]]; then echo {git_branch!r}; fi\n',
+    )
+
+    workdir = tmp_path / "work"
+    (workdir / "docs" / "features").mkdir(parents=True, exist_ok=True)
+
+    env = {
+        "PATH": f"{shim_dir}:/usr/bin:/bin:/usr/local/bin",
+    }
+    result = subprocess.run(
+        ["bash", "-c", snippet],
+        cwd=workdir,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout + result.stderr
+
+
+def _make_feature_doc(tmp_path: Path, slug: str) -> None:
+    features_dir = tmp_path / "work" / "docs" / "features"
+    features_dir.mkdir(parents=True, exist_ok=True)
+    (features_dir / f"{slug}.md").write_text("# feature\n")
+
+
+# ---------------------------------------------------------------------------
+# completed → authoritative PASS
+# ---------------------------------------------------------------------------
+
+
+def test_completed_passes(tmp_path):
+    out = _run_gate(
+        tmp_path,
+        head_ref="session/my-slug",
+        stages_json='{"stages": {"DOCS": "completed"}, "_meta": {}}',
+    )
+    assert "DOCS_GATE: PASS" in out
+    assert "GATES_FAILED" not in out
+
+
+def test_skip_recorded_as_completed_passes(tmp_path):
+    """A DOCS-skip (#1799) records the ``completed`` status, so it is admitted
+    with no special skip-branch — identical to a real completion."""
+    out = _run_gate(
+        tmp_path,
+        head_ref="session/trivial-docs-skip",
+        stages_json='{"stages": {"DOCS": "completed"}, "_meta": {}}',
+    )
+    assert "DOCS_GATE: PASS" in out
+    assert "GATES_FAILED" not in out
+
+
+# ---------------------------------------------------------------------------
+# in_progress → the only HARD fail
+# ---------------------------------------------------------------------------
+
+
+def test_in_progress_hard_fails(tmp_path):
+    out = _run_gate(
+        tmp_path,
+        head_ref="session/my-slug",
+        stages_json='{"stages": {"DOCS": "in_progress"}, "_meta": {}}',
+    )
+    assert "GATES_FAILED" in out
+    assert "DOCS_GATE: FAIL" in out
+    assert "in_progress" in out
+
+
+# ---------------------------------------------------------------------------
+# pending → degraded fallback to docs/features/{slug}.md existence
+# ---------------------------------------------------------------------------
+
+
+def test_pending_with_feature_doc_passes_degraded(tmp_path):
+    _make_feature_doc(tmp_path, "my-slug")
+    out = _run_gate(
+        tmp_path,
+        head_ref="session/my-slug",
+        stages_json='{"stages": {"DOCS": "pending"}, "_meta": {}}',
+    )
+    assert "PASS (degraded)" in out
+    assert "GATES_FAILED" not in out
+
+
+def test_pending_without_feature_doc_fails(tmp_path):
+    out = _run_gate(
+        tmp_path,
+        head_ref="session/my-slug",
+        stages_json='{"stages": {"DOCS": "pending"}, "_meta": {}}',
+    )
+    assert "GATES_FAILED" in out
+
+
+# ---------------------------------------------------------------------------
+# empty stages (session reaped) → degraded fallback
+# ---------------------------------------------------------------------------
+
+
+def test_empty_stages_with_feature_doc_passes_degraded(tmp_path):
+    _make_feature_doc(tmp_path, "my-slug")
+    out = _run_gate(
+        tmp_path,
+        head_ref="session/my-slug",
+        stages_json='{"stages": {}, "_meta": {}}',
+    )
+    assert "PASS (degraded)" in out
+    assert "GATES_FAILED" not in out
+
+
+def test_empty_stages_without_feature_doc_fails(tmp_path):
+    out = _run_gate(
+        tmp_path,
+        head_ref="session/my-slug",
+        stages_json='{"stages": {}, "_meta": {}}',
+    )
+    assert "GATES_FAILED" in out
+
+
+# ---------------------------------------------------------------------------
+# no usable slug (invoked from main / detached HEAD) → FAIL with <no-slug>
+# ---------------------------------------------------------------------------
+
+
+def test_no_usable_slug_fails_without_main_lookup(tmp_path):
+    """When the PR head-ref resolves to ``main`` (and the git fallback is also
+    ``main``), the slug normalizes to empty: the gate must FAIL naming
+    ``<no-slug>`` and must NOT do a ``docs/features/main.md`` lookup."""
+    out = _run_gate(
+        tmp_path,
+        head_ref="main",
+        stages_json='{"stages": {"DOCS": "pending"}, "_meta": {}}',
+        git_branch="main",
+    )
+    assert "GATES_FAILED" in out
+    assert "<no-slug>" in out
+    assert "docs/features/main.md" not in out


### PR DESCRIPTION
Closes #1944

## Summary

Adds a DOCS-stage-completion gate (Step 2b) to `/do-merge` so a PR cannot merge with its DOCS stage still `in_progress` on the router-bypass paths (forked `/do-sdlc`, raw `gh pr merge`) in a substrate repo.

- **`docs/sdlc/do-merge.md`** — new "Step 2b — Verify DOCS Stage Completed" bullet after the Step 2 REVIEW-verdict mapping. Reads `stages.DOCS` from `sdlc-tool stage-query`: PASS on `completed`; hard-FAIL closed on `in_progress` only (no auth file, routes back to `/do-docs`); `pending`/empty-`stages` degrade to the pre-existing `docs/features/{slug}.md` file-existence check. Slug derives from the PR head-ref (`gh pr view --json headRefName`), normalizing `main`/`master`/`HEAD`/empty to a fail-closed `<no-slug>`. The "Documentation Gate" section now names stage completion as authoritative, with file existence retained as the degraded fallback.
- **`.claude/skills-global/do-merge/SKILL.md`** — Step-2-adjacent note naming DOCS-stage completion as a substrate-supplied precondition, plus the announced non-gate advisory line (`NOT ENFORCED — no substrate ...`) for the no-substrate case. An auditable advisory, not a silent pass.
- **`tests/unit/test_do_merge_docs_gate.py`** — extracts the live Step 2b snippet from the markdown and runs it under `bash` with a PATH shim (fake `gh`, `sdlc-tool`, `git`), asserting all 8 decision cases.
- **`docs/features/enforce-review-docs-stages.md`** — new "Merge-Gate DOCS Precondition" section.

## Verification

- `pytest tests/unit/test_do_merge_docs_gate.py tests/unit/test_do_merge_review_filter.py -q` → 23 passed (8 new gate cases + 15 existing filter tests).
- `ruff format --check` clean.
- `agent/sdlc_router.py` untouched (anti-criterion).
- Snippet uses `.get('stages',{}).get('DOCS')`, not the issue's wrong `.get('DOCS',{}).get('status')` shape.

## Test cases

`completed`→PASS, skip-as-`completed`→PASS, `in_progress`→hard FAIL, `pending`+doc→PASS(degraded), `pending`-no-doc→FAIL, empty-stages+doc→PASS(degraded), empty-stages-no-doc→FAIL, no-usable-slug(`main`)→FAIL with `<no-slug>` and no `docs/features/main.md` lookup.