### PR TITLE
fix(#1916): opt-in predecessor backfill fixes fresh-pipeline stage-marker rejection

### DIFF
--- a/agent/pipeline_state.py
+++ b/agent/pipeline_state.py
@@ -433,7 +433,64 @@ class PipelineStateMachine:
         self._save()
         _record_stage_metric("sdlc.stage_started", stage)
 
-    def start_stage(self, stage: str) -> None:
+    def _reaches_issue(self, stage: str) -> bool:
+        """True iff `stage` sits on the ISSUE-rooted success spine — its transitive
+        success-predecessor set contains ISSUE (or it IS ISSUE). PATCH is off-spine
+        (`_get_predecessors("PATCH") == []`), so this returns False for it — that is
+        what stops a backfill reaching TEST (predecessors [BUILD, PATCH]) from
+        pulling the off-happy-path PATCH into the promotion set.
+        """
+        if stage == "ISSUE":
+            return True
+        seen: set[str] = set()
+        frontier = list(self._get_predecessors(stage))
+        while frontier:
+            p = frontier.pop()
+            if p in seen:
+                continue
+            seen.add(p)
+            if p == "ISSUE":
+                return True
+            frontier.extend(self._get_predecessors(p))
+        return False
+
+    def _backfill_predecessors(self, stage: str) -> list[str]:
+        """Promote the ISSUE-rooted success spine behind `stage` to completed.
+
+        Scan-then-mutate: collect every transitive ON-SPINE predecessor currently in
+        {pending, ready, in_progress}; if ANY collected member is `failed`, raise
+        ValueError BEFORE mutating (a failed predecessor is a real inconsistency,
+        never silently erased, and no partial state is persisted). Then promote all
+        collected members in one pass, persist with a single _save(), and emit
+        sdlc.stage_backfilled per synthetic promotion. Off-spine predecessors (PATCH,
+        reached via TEST's second success in-edge) are never walked or promoted.
+        Returns the promoted stages.
+        """
+        to_promote: list[str] = []
+        seen: set[str] = set()
+        # Seed and extend the frontier with ON-SPINE predecessors only — PATCH,
+        # being off-spine, is excluded here and never force-completed.
+        frontier = [p for p in self._get_predecessors(stage) if self._reaches_issue(p)]
+        while frontier:  # SCAN — no mutation in this loop
+            pred = frontier.pop()
+            if pred in seen:
+                continue
+            seen.add(pred)
+            st = self.states.get(pred, "pending")
+            if st == "failed":
+                raise ValueError(f"Cannot backfill predecessors of {stage}: {pred} is failed")
+            if st != "completed":
+                to_promote.append(pred)
+            frontier.extend(p for p in self._get_predecessors(pred) if self._reaches_issue(p))
+        for pred in to_promote:  # MUTATE — only after a clean scan
+            self.states[pred] = "completed"
+        if to_promote:
+            self._save()  # single persist for the whole chain
+            for pred in to_promote:
+                _record_stage_metric("sdlc.stage_backfilled", pred)
+        return to_promote
+
+    def start_stage(self, stage: str, backfill_predecessors: bool = False) -> None:
         """Mark a stage as in_progress.
 
         Validates that at least one predecessor is completed (via success
@@ -442,9 +499,16 @@ class PipelineStateMachine:
 
         Args:
             stage: Stage name to start.
+            backfill_predecessors: When True, if the predecessor check would
+                otherwise fail, promote the ISSUE-rooted spine of predecessors
+                to completed (see `_backfill_predecessors`) and activate the
+                stage instead of raising. Defaults to False so existing
+                strict callers (router, pre_tool_use hook) are unaffected.
 
         Raises:
-            ValueError: If stage is invalid or predecessor not completed.
+            ValueError: If stage is invalid or predecessor not completed
+                (and backfill_predecessors is False, or a predecessor is
+                `failed`).
         """
         if stage not in ALL_STAGES:
             raise ValueError(f"Invalid stage: {stage!r}. Valid stages: {ALL_STAGES}")
@@ -495,6 +559,11 @@ class PipelineStateMachine:
             if self.states.get(pred) == "completed":
                 self._activate_stage(stage)
                 return
+
+        if backfill_predecessors:
+            self._backfill_predecessors(stage)
+            self._activate_stage(stage)
+            return
 
         pred_statuses = {p: self.states.get(p, "pending") for p in predecessors}
         raise ValueError(

--- a/docs/features/pipeline-state-machine.md
+++ b/docs/features/pipeline-state-machine.md
@@ -80,6 +80,29 @@ The state machine validates transitions using `PIPELINE_EDGES` from `agent/pipel
 - PATCH can start when TEST or REVIEW has failed/completed
 - TEST can restart after PATCH completes (cycle support)
 
+## Predecessor Backfill (Opt-In)
+
+`start_stage()` takes an optional `backfill_predecessors: bool = False` parameter (issue #1916). When the predecessor check would otherwise raise `ValueError`, passing `backfill_predecessors=True` promotes the missing predecessors to `completed` instead of raising, then activates the target stage.
+
+- **Default `False`** preserves strict ordering for callers that enforce forward-transition decisions: the SDLC router and the PreToolUse hook (`agent/hooks/pre_tool_use.py`) both call `start_stage()` without the flag, so a genuinely out-of-order dispatch still raises.
+- **`tools/sdlc_stage_marker.py` opts in** (`backfill_predecessors=True` on its `in_progress` path) because it records reality rather than deciding what should happen next. Reaching a stage as the first marker write of a pipeline — e.g. PLAN on a freshly auto-ensured session, where ISSUE is only `ready` — implies ISSUE was in fact reached, even though nothing ever wrote its marker.
+
+### `_backfill_predecessors(stage)`
+
+Promotes the ISSUE-rooted success spine behind `stage` to `completed`, using `_reaches_issue(stage)` to test spine membership:
+
+- **Spine-only walk**: only predecessors whose transitive success-predecessor set contains ISSUE are considered. PATCH is excluded — it has no success in-edge (it's reached only via TEST's fail/partial edges), so a backfill never force-completes it.
+- **Scan-then-mutate**: the walk first collects every not-yet-`completed` on-spine predecessor without mutating any state. If any collected predecessor is `failed`, it raises `ValueError` before touching state, so a genuine failure is never silently erased and no partial promotion is left behind.
+- **Single save**: all promotions from one call are persisted with one `_save()`, not one write per stage.
+- **Distinct metric**: each promoted stage emits `sdlc.stage_backfilled` (not `sdlc.stage_started`), so synthetic promotions are observable and distinguishable from real stage-start events.
+
+### Marker vs. Router Semantics
+
+The marker tool (`tools/sdlc_stage_marker.py`) and the router (`.claude/skills/sdlc/SKILL.md`) both operate on the same `PipelineStateMachine`, but with different intent:
+
+- **The marker tool records reality.** A marker write means "we reached this stage" — an unrecorded predecessor is evidence it happened, not an ordering violation, so the tool opts into backfill.
+- **The router enforces ordering.** It decides which stage to dispatch next, so a missing predecessor there is a genuine misorder signal, and it keeps the strict default so it still raises.
+
 ## Artifact-Based Inference
 
 Artifact inference was **deleted in PR #733** (issue #729). `get_display_progress()` no longer accepts a `slug=` parameter and does not check plan files, PRs, or GitHub review state. Stored `stage_states` is the single source of truth.

--- a/docs/features/sdlc-stage-tracking.md
+++ b/docs/features/sdlc-stage-tracking.md
@@ -52,6 +52,14 @@ Exit code is always 0. Returns `{}` on error, `{"stage": "DOCS", "status": "comp
 
 The bare module form (`python -m tools.sdlc_stage_marker`) is the underlying entry point — runtime callers should always use the `sdlc-tool stage-marker` wrapper so the call is cwd-independent.
 
+### Predecessor Backfill on the First Write (issue #1916)
+
+A fresh pipeline entering at PLAN — the first marker write of the whole pipeline, with ISSUE still at `ready` — now backfills ISSUE to `completed` automatically on the `in_progress` write, rather than failing with the old `PRESENT_WRITE_FAILED` diagnostic (`sdlc_stage_marker: FAILED to write PLAN=in_progress ... State NOT persisted.`).
+
+A `completed`-status write also backfills unrecorded predecessors, not just `in_progress` writes. This closes the asymmetry where a stage could be marked `completed` while its predecessors were never recorded, leaving ISSUE stuck at `ready` behind a completed later stage.
+
+See "Predecessor Backfill (Opt-In)" in `docs/features/pipeline-state-machine.md` for the backfill mechanics (`start_stage(..., backfill_predecessors=True)`, `_backfill_predecessors()`, and the marker-vs-router semantics distinction).
+
 ## `get_display_progress()` — Stored State Only
 
 `PipelineStateMachine.get_display_progress()` returns stored stage states only. It does NOT:

--- a/docs/plans/stage-marker-in-progress-plan-rejection.md
+++ b/docs/plans/stage-marker-in-progress-plan-rejection.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: docs_complete
 type: bug
 appetite: Small
 owner: Valor Engels

--- a/docs/plans/stage-marker-in-progress-plan-rejection.md
+++ b/docs/plans/stage-marker-in-progress-plan-rejection.md
@@ -487,16 +487,16 @@ behavior only; no new MCP surface, `.mcp.json`, or bridge import is involved.
 ## Documentation
 
 ### Feature Documentation
-- [ ] Update `docs/features/pipeline-state-machine.md` to document the
+- [x] Update `docs/features/pipeline-state-machine.md` to document the
   `backfill_predecessors` parameter on `start_stage` and the marker-vs-router
   semantics distinction (marker records reality; router enforces ordering).
-- [ ] Update `docs/features/sdlc-stage-tracking.md` to note that a fresh pipeline
+- [x] Update `docs/features/sdlc-stage-tracking.md` to note that a fresh pipeline
   entering at PLAN backfills ISSUE to completed on the first `in_progress` write.
 
 ### Inline Documentation
-- [ ] Docstring on `start_stage` explaining `backfill_predecessors` and the
+- [x] Docstring on `start_stage` explaining `backfill_predecessors` and the
   never-backfill-over-`failed` guard.
-- [ ] Update the D7 degradation-contract docstring in `sdlc_stage_marker.py` to
+- [x] Update the D7 degradation-contract docstring in `sdlc_stage_marker.py` to
   reflect that first-write-at-a-forward-stage now persists rather than failing.
 
 ## Success Criteria

--- a/docs/plans/stage-marker-in-progress-plan-rejection.md
+++ b/docs/plans/stage-marker-in-progress-plan-rejection.md
@@ -501,26 +501,26 @@ behavior only; no new MCP surface, `.mcp.json`, or bridge import is involved.
 
 ## Success Criteria
 
-- [ ] `sdlc-tool stage-marker --stage PLAN --status in_progress --issue-number N`
+- [x] `sdlc-tool stage-marker --stage PLAN --status in_progress --issue-number N`
   on a fresh issue exits 0 and persists `ISSUE → completed`, `PLAN → in_progress`
   (verified by re-running the reproduction from the Freshness Check).
-- [ ] `sdlc-tool stage-marker --stage PLAN --status completed --issue-number N` on
+- [x] `sdlc-tool stage-marker --stage PLAN --status completed --issue-number N` on
   a fresh issue (`ISSUE=ready`) exits 0 and persists `ISSUE → completed`,
   `PLAN → completed` — no stage left stuck at `ready` behind a completed stage
   (this is the "ISSUE stuck at ready" half of the defect, now in scope).
-- [ ] `start_stage(stage, backfill_predecessors=True)` and
+- [x] `start_stage(stage, backfill_predecessors=True)` and
   `_backfill_predecessors(stage)` with a `failed` predecessor still raise
   `ValueError` (loud path preserved) and mutate no state.
-- [ ] Strict-default `start_stage` behavior is unchanged for router/hook callers
+- [x] Strict-default `start_stage` behavior is unchanged for router/hook callers
   (existing tests pass).
-- [ ] A marker write at a **multi-predecessor stage** (TEST — predecessors
+- [x] A marker write at a **multi-predecessor stage** (TEST — predecessors
   `[BUILD, PATCH]`) or any stage downstream of it (REVIEW/DOCS/MERGE) that
   triggers backfill promotes the spine (ISSUE/PLAN/CRITIQUE/BUILD) to `completed`
   but leaves **PATCH un-promoted** (still `pending`), and `patch_cycle_count`
   stays `0` (round-2 BLOCKER regression guard).
-- [ ] A test covers the first-write-at-PLAN path (acceptance criterion from #1916).
-- [ ] Tests pass (`/do-test`)
-- [ ] Documentation updated (`/do-docs`)
+- [x] A test covers the first-write-at-PLAN path (acceptance criterion from #1916).
+- [x] Tests pass (`/do-test`)
+- [x] Documentation updated (`/do-docs`)
 
 ## Verification
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -131,7 +131,8 @@ tests/
 | unit | `test_pipeline_graph.py` | 29 | Pipeline graph visualization |
 | unit | `test_observer_early_return.py` | 18 | Early return optimization |
 | unit | `test_pipeline_state.py` | 15 | Pipeline state transitions |
-| unit | `test_sdlc_stage_marker.py` | 12 | Stage marker writes via CLI (session resolution, issue-number fallback) |
+| unit | `test_pipeline_state_machine.py` | 137 | `PipelineStateMachine` transitions, outcome classification, opt-in predecessor backfill (`_backfill_predecessors`, `_reaches_issue`) |
+| unit | `test_sdlc_stage_marker.py` | 25 | Stage marker writes via CLI (session resolution, issue-number fallback, opt-in predecessor backfill on `in_progress`/`completed`) |
 | unit | `test_sdlc_stage_query.py` | 17 | Stage query CLI (session-id and issue-number resolution) |
 | unit | `test_sdlc_session_ensure.py` | 8 | Local session creation/reuse for SDLC pipeline state |
 | unit | `test_sdlc_utils.py` | 6 | Shared `find_session_by_issue()` helper |

--- a/tests/unit/test_pipeline_state_machine.py
+++ b/tests/unit/test_pipeline_state_machine.py
@@ -235,6 +235,174 @@ class TestStartStage:
         assert sm.states["PLAN"] == "in_progress"
 
 
+class TestStartStageBackfill:
+    """Test PipelineStateMachine.start_stage(backfill_predecessors=True)."""
+
+    def test_strict_default_unchanged(self):
+        """Default (no kwarg) still raises on a fresh session — no behavior shift
+        for existing strict callers (router, pre_tool_use hook)."""
+        session = _make_session()
+        sm = PipelineStateMachine(session)
+        with pytest.raises(ValueError, match="Cannot start PLAN"):
+            sm.start_stage("PLAN")
+
+    def test_explicit_false_unchanged(self):
+        """backfill_predecessors=False behaves identically to the default."""
+        session = _make_session()
+        sm = PipelineStateMachine(session)
+        with pytest.raises(ValueError, match="Cannot start PLAN"):
+            sm.start_stage("PLAN", backfill_predecessors=False)
+
+    def test_backfill_true_activates_plan_on_fresh_session(self):
+        """First-write-at-PLAN acceptance: a fresh session (ISSUE=ready) backfills
+        ISSUE to completed and activates PLAN instead of raising."""
+        session = _make_session()
+        sm = PipelineStateMachine(session)
+        sm.start_stage("PLAN", backfill_predecessors=True)
+        assert sm.states["ISSUE"] == "completed"
+        assert sm.states["PLAN"] == "in_progress"
+
+    def test_backfill_true_raises_on_failed_predecessor(self):
+        """A failed predecessor is never silently backfilled — still raises."""
+        states = {"ISSUE": "failed"}
+        session = _make_session(stage_states=json.dumps(states))
+        sm = PipelineStateMachine(session)
+        with pytest.raises(ValueError, match="failed"):
+            sm.start_stage("PLAN", backfill_predecessors=True)
+        assert sm.states["PLAN"] == "pending"
+
+
+class TestReachesIssue:
+    """Test PipelineStateMachine._reaches_issue()."""
+
+    @pytest.mark.parametrize(
+        "stage,expected",
+        [
+            ("ISSUE", True),
+            ("PLAN", True),
+            ("CRITIQUE", True),
+            ("BUILD", True),
+            ("TEST", True),
+            ("REVIEW", True),
+            ("DOCS", True),
+            ("MERGE", True),
+            ("PATCH", False),
+        ],
+    )
+    def test_reaches_issue_truth_table(self, stage, expected):
+        session = _make_session()
+        sm = PipelineStateMachine(session)
+        assert sm._reaches_issue(stage) is expected
+
+
+class TestBackfillPredecessors:
+    """Test PipelineStateMachine._backfill_predecessors()."""
+
+    def test_backfills_fresh_chain_to_plan(self):
+        """Fresh session: backfilling PLAN's predecessors completes ISSUE only."""
+        session = _make_session()
+        sm = PipelineStateMachine(session)
+        promoted = sm._backfill_predecessors("PLAN")
+        assert promoted == ["ISSUE"]
+        assert sm.states["ISSUE"] == "completed"
+
+    def test_backfills_deep_chain_to_build(self):
+        """A backfill at BUILD promotes ISSUE, PLAN, CRITIQUE."""
+        session = _make_session()
+        sm = PipelineStateMachine(session)
+        promoted = sm._backfill_predecessors("BUILD")
+        assert set(promoted) == {"ISSUE", "PLAN", "CRITIQUE"}
+        assert sm.states["ISSUE"] == "completed"
+        assert sm.states["PLAN"] == "completed"
+        assert sm.states["CRITIQUE"] == "completed"
+
+    def test_no_promotion_when_already_completed(self):
+        """Nothing to promote when the whole chain is already completed."""
+        states = {"ISSUE": "completed"}
+        session = _make_session(stage_states=json.dumps(states))
+        sm = PipelineStateMachine(session)
+        promoted = sm._backfill_predecessors("PLAN")
+        assert promoted == []
+
+    def test_partial_state_guard_raises_before_mutating(self):
+        """CONCERN 1: a deeper `failed` predecessor with a nearer `pending` one
+        raises ValueError AND leaves state unmutated (scan-then-mutate ordering)."""
+        states = {"ISSUE": "failed", "PLAN": "pending", "CRITIQUE": "pending"}
+        session = _make_session(stage_states=json.dumps(states))
+        sm = PipelineStateMachine(session)
+        with pytest.raises(ValueError, match="ISSUE is failed"):
+            sm._backfill_predecessors("BUILD")
+        # No partial state was persisted — nearer predecessor unchanged.
+        assert sm.states["PLAN"] == "pending"
+        assert sm.states["ISSUE"] == "failed"
+        session.save.assert_not_called()
+
+    def test_single_save_regardless_of_chain_length(self):
+        """_save() (and therefore session.save()) is invoked at most once per
+        _backfill_predecessors call, regardless of chain length."""
+        session = _make_session()
+        sm = PipelineStateMachine(session)
+        sm._backfill_predecessors("BUILD")
+        assert session.save.call_count == 1
+
+    def test_no_save_when_nothing_to_promote(self):
+        states = {"ISSUE": "completed"}
+        session = _make_session(stage_states=json.dumps(states))
+        sm = PipelineStateMachine(session)
+        sm._backfill_predecessors("PLAN")
+        session.save.assert_not_called()
+
+    def test_distinct_metric_emitted_per_promotion(self):
+        """CONCERN 2: _record_stage_metric is called with sdlc.stage_backfilled
+        (not sdlc.stage_started) once per promoted predecessor."""
+        session = _make_session()
+        sm = PipelineStateMachine(session)
+        with patch("agent.pipeline_state._record_stage_metric") as mock_metric:
+            sm._backfill_predecessors("BUILD")
+        calls = [c.args for c in mock_metric.call_args_list]
+        assert ("sdlc.stage_backfilled", "ISSUE") in calls
+        assert ("sdlc.stage_backfilled", "PLAN") in calls
+        assert ("sdlc.stage_backfilled", "CRITIQUE") in calls
+        assert all(c[0] == "sdlc.stage_backfilled" for c in calls)
+
+    def test_no_metric_when_already_completed(self):
+        states = {"ISSUE": "completed"}
+        session = _make_session(stage_states=json.dumps(states))
+        sm = PipelineStateMachine(session)
+        with patch("agent.pipeline_state._record_stage_metric") as mock_metric:
+            sm._backfill_predecessors("PLAN")
+        mock_metric.assert_not_called()
+
+    def test_patch_not_backfilled_at_test(self):
+        """Round-2 BLOCKER regression: backfilling TEST's predecessors
+        ([BUILD, PATCH]) promotes only the ISSUE spine and leaves PATCH pending
+        with patch_cycle_count unchanged at 0."""
+        session = _make_session()
+        sm = PipelineStateMachine(session)
+        promoted = sm._backfill_predecessors("TEST")
+        assert "PATCH" not in promoted
+        assert set(promoted) == {"ISSUE", "PLAN", "CRITIQUE", "BUILD"}
+        assert sm.states["PATCH"] == "pending"
+        assert sm.patch_cycle_count == 0
+
+    def test_patch_not_backfilled_at_review(self):
+        session = _make_session()
+        sm = PipelineStateMachine(session)
+        promoted = sm._backfill_predecessors("REVIEW")
+        assert "PATCH" not in promoted
+        assert sm.states["PATCH"] == "pending"
+        assert sm.patch_cycle_count == 0
+
+    def test_patch_not_backfilled_at_merge(self):
+        session = _make_session()
+        sm = PipelineStateMachine(session)
+        promoted = sm._backfill_predecessors("MERGE")
+        assert "PATCH" not in promoted
+        assert set(promoted) == {"ISSUE", "PLAN", "CRITIQUE", "BUILD", "TEST", "REVIEW", "DOCS"}
+        assert sm.states["PATCH"] == "pending"
+        assert sm.patch_cycle_count == 0
+
+
 class TestCompleteStage:
     """Test PipelineStateMachine.complete_stage()."""
 

--- a/tests/unit/test_sdlc_stage_marker.py
+++ b/tests/unit/test_sdlc_stage_marker.py
@@ -108,6 +108,97 @@ class TestWriteMarker:
         assert code == 1
         assert result == {}
 
+    def test_fresh_plan_in_progress_backfills_and_persists(self):
+        """First-write-at-PLAN acceptance (#1916): a fresh session (ISSUE=ready)
+        must NOT be rejected — start_stage is called with
+        backfill_predecessors=True, and a real PipelineStateMachine persists
+        ISSUE -> completed, PLAN -> in_progress."""
+        from agent.pipeline_state import PipelineStateMachine
+        from tools.sdlc_stage_marker import SUBSTRATE_PRESENT, write_marker
+
+        mock_session = MagicMock()
+        mock_session.stage_states = None
+        mock_session.save = MagicMock()
+
+        with (
+            patch("tools.sdlc_stage_marker.probe_substrate", return_value=SUBSTRATE_PRESENT),
+            patch("tools.sdlc_stage_marker.find_session", return_value=mock_session),
+        ):
+            result, code = write_marker(stage="PLAN", status="in_progress")
+
+        assert code == 0
+        assert result == {"stage": "PLAN", "status": "in_progress"}
+        sm = PipelineStateMachine(mock_session)
+        assert sm.states["ISSUE"] == "completed"
+        assert sm.states["PLAN"] == "in_progress"
+
+    def test_plan_in_progress_with_failed_issue_still_exits_1(self):
+        """Companion failure case: a genuinely `failed` predecessor is never
+        backfilled — in_progress at PLAN still exits 1 loudly."""
+        import json
+
+        from tools.sdlc_stage_marker import SUBSTRATE_PRESENT, write_marker
+
+        mock_session = MagicMock()
+        mock_session.stage_states = json.dumps({"ISSUE": "failed"})
+        mock_session.save = MagicMock()
+
+        with (
+            patch("tools.sdlc_stage_marker.probe_substrate", return_value=SUBSTRATE_PRESENT),
+            patch("tools.sdlc_stage_marker.find_session", return_value=mock_session),
+        ):
+            result, code = write_marker(stage="PLAN", status="in_progress")
+
+        assert code == 1
+        assert result == {}
+
+    def test_fresh_plan_completed_backfills_issue_too(self):
+        """Completed-path backfill (BLOCKER regression, #1916): on a fresh
+        session (ISSUE=ready, PLAN=pending), a --status completed write for
+        PLAN must persist ISSUE -> completed AND PLAN -> completed. Proves the
+        standalone _backfill_predecessors helper is reached directly and the
+        start_stage `current == "in_progress"` no-op does not gate it."""
+        from agent.pipeline_state import PipelineStateMachine
+        from tools.sdlc_stage_marker import SUBSTRATE_PRESENT, write_marker
+
+        mock_session = MagicMock()
+        mock_session.stage_states = None
+        mock_session.save = MagicMock()
+
+        with (
+            patch("tools.sdlc_stage_marker.probe_substrate", return_value=SUBSTRATE_PRESENT),
+            patch("tools.sdlc_stage_marker.find_session", return_value=mock_session),
+        ):
+            result, code = write_marker(stage="PLAN", status="completed")
+
+        assert code == 0
+        assert result == {"stage": "PLAN", "status": "completed"}
+        sm = PipelineStateMachine(mock_session)
+        assert sm.states["ISSUE"] == "completed"
+        assert sm.states["PLAN"] == "completed"
+
+    def test_plan_completed_with_failed_issue_exits_1_unmutated(self):
+        """Companion failure case: a `failed` predecessor on the completed
+        path exits 1 and leaves state unmutated (PLAN never force-set to
+        in_progress, ISSUE stays failed)."""
+        import json
+
+        from tools.sdlc_stage_marker import SUBSTRATE_PRESENT, write_marker
+
+        mock_session = MagicMock()
+        mock_session.stage_states = json.dumps({"ISSUE": "failed", "PLAN": "pending"})
+        mock_session.save = MagicMock()
+
+        with (
+            patch("tools.sdlc_stage_marker.probe_substrate", return_value=SUBSTRATE_PRESENT),
+            patch("tools.sdlc_stage_marker.find_session", return_value=mock_session),
+        ):
+            result, code = write_marker(stage="PLAN", status="completed")
+
+        assert code == 1
+        assert result == {}
+        mock_session.save.assert_not_called()
+
     def test_idempotent_already_completed_exit_0(self):
         """Idempotent already-completed path stays exit 0 (not loud)."""
         from tools.sdlc_stage_marker import SUBSTRATE_PRESENT, write_marker

--- a/tools/sdlc_stage_marker.py
+++ b/tools/sdlc_stage_marker.py
@@ -38,6 +38,17 @@ Degradation contract (D7 — loud failure, quiet absence):
       Loud is reserved ONLY for this case. The idempotent already-completed
       path stays exit 0.
 
+Predecessor backfill (issue #1916): both the `in_progress` and `completed`
+write paths opt into `PipelineStateMachine`'s predecessor backfill
+(`start_stage(..., backfill_predecessors=True)` / `_backfill_predecessors()`)
+because a marker write records reality, not an ordering decision — reaching a
+stage implies its ISSUE-rooted spine of predecessors was reached too, even if
+nothing ever wrote their markers. A fresh pipeline's first write (e.g. PLAN
+`in_progress` while ISSUE is still `ready`) now persists instead of hitting
+PRESENT_WRITE_FAILED. PRESENT_WRITE_FAILED still fires for a genuine misorder
+or a `failed` predecessor — backfill never promotes over a `failed` state.
+See "Predecessor Backfill (Opt-In)" in `docs/features/pipeline-state-machine.md`.
+
 Ownership gate (issue #1735): when ``--issue-number N`` is explicitly provided,
 the resolved session is verified to own issue N via ``session_owns_issue()`` in
 ``tools._sdlc_utils``. If the check fails (the resolved session belongs to a

--- a/tools/sdlc_stage_marker.py
+++ b/tools/sdlc_stage_marker.py
@@ -185,7 +185,7 @@ def write_marker(
 
         if status == "in_progress":
             try:
-                sm.start_stage(stage)
+                sm.start_stage(stage, backfill_predecessors=True)
             except ValueError as e:
                 # Predecessor not completed — inconsistent pipeline state, not a
                 # substrate failure. Loud so the operator notices the misorder.
@@ -198,7 +198,13 @@ def write_marker(
                 # Already completed — idempotent no-op (exit 0)
                 return {"stage": stage, "status": status}, 0
             if current not in ("in_progress", "ready"):
-                # Force to in_progress first so complete_stage() accepts it
+                # Reaching this stage implies the ISSUE-rooted spine of
+                # predecessors was reached too — backfill them directly
+                # (NOT via start_stage, whose `current == "in_progress"`
+                # no-op would otherwise skip backfill once we pre-set the
+                # target stage) before forcing the target to in_progress so
+                # complete_stage() accepts it.
+                sm._backfill_predecessors(stage)
                 sm.states[stage] = "in_progress"
             sm.complete_stage(stage)
 


### PR DESCRIPTION
## Summary
- On a fresh SDLC pipeline session, the first marker write (`sdlc-tool stage-marker --stage PLAN --status in_progress`) was rejected because `start_stage("PLAN")` enforces that predecessor `ISSUE` be `completed`, but a freshly auto-ensured session has `ISSUE = ready`. A related asymmetry in the `completed` path force-set the target stage to `in_progress` before completing, bypassing the predecessor check entirely and leaving `ISSUE` stuck at `ready` forever behind a completed later stage.
- Adds a new standalone `PipelineStateMachine._backfill_predecessors(stage)` helper (spine-restricted via `_reaches_issue`, so the off-happy-path `PATCH` stage is never force-completed), and an opt-in `backfill_predecessors=False` kwarg on `start_stage()`. The router and `pre_tool_use` hook keep today's strict default unchanged.
- `write_marker`'s `in_progress` path opts into backfill via `start_stage`; the `completed` path calls `_backfill_predecessors` directly (before setting the target `in_progress`) to sidestep `start_stage`'s early no-op.
- Documents the marker-records-reality vs. router-enforces-ordering distinction in `docs/features/pipeline-state-machine.md` and `docs/features/sdlc-stage-tracking.md`.

Closes #1916

## Test plan
- [x] `pytest tests/unit/test_sdlc_stage_marker.py tests/unit/test_pipeline_state.py tests/unit/test_pipeline_state_machine.py -q` — 179 passed
- [x] Full `tests/unit/` suite run clean (two initially-failing tests were a pre-existing worktree-only gap — missing gitignored `config/reflections.yaml` symlink — confirmed unrelated to this change and resolved for the worktree)
- [x] Plan's Verification table checks all pass (backfill param present, marker opts in, standalone helper present, `sdlc.stage_backfilled` metric present, spine predicate present, `patch_not_backfilled` regression tests pass)
- [x] `ruff format --check` / `ruff check` clean on changed files
- [x] Code review pass: no blocking or non-blocking issues found
- [x] Docs-changed gate passed (`scripts/validate_docs_changed.py`)