### PR TITLE
sdlc-tool: validate PR body issue-reference before trusting fuzzy search match

### DIFF
--- a/tests/unit/test_sdlc_stage_query.py
+++ b/tests/unit/test_sdlc_stage_query.py
@@ -269,28 +269,40 @@ class TestLookupPrNumber:
     def test_issue_search_primary_path(self):
         from tools.sdlc_stage_query import _lookup_pr_number
 
-        with patch("tools.sdlc_stage_query._gh_pr_list", return_value=55) as gh:
+        # The validated issue-search helper returns a PR whose body references
+        # the issue; the branch-head fallback must not be consulted.
+        with (
+            patch("tools.sdlc_stage_query._gh_pr_search_issue_ref", return_value=55) as search,
+            patch("tools.sdlc_stage_query._gh_pr_list") as gh,
+        ):
             assert _lookup_pr_number(145, slug="some_slug") == 55
-        # First call is the issue-number search.
-        first_args = gh.call_args_list[0].args[0]
-        assert "--search" in first_args and "#145" in first_args
+        search.assert_called_once()
+        assert search.call_args.args[0] == 145
+        gh.assert_not_called()
 
     def test_branch_head_fallback_when_issue_search_empty(self):
         from tools.sdlc_stage_query import _lookup_pr_number
 
-        # Issue search returns None, branch-head returns 88.
-        with patch("tools.sdlc_stage_query._gh_pr_list", side_effect=[None, 88]) as gh:
+        # Validated issue search returns None; branch-head returns 88.
+        with (
+            patch("tools.sdlc_stage_query._gh_pr_search_issue_ref", return_value=None),
+            patch("tools.sdlc_stage_query._gh_pr_list", return_value=88) as gh,
+        ):
             assert _lookup_pr_number(145, slug="my_slug") == 88
-        branch_args = gh.call_args_list[1].args[0]
+        branch_args = gh.call_args_list[0].args[0]
         assert "--head" in branch_args and "session/my_slug" in branch_args
 
     def test_no_slug_no_branch_fallback(self):
         from tools.sdlc_stage_query import _lookup_pr_number
 
-        # Only the issue search runs (returns None); no branch-head attempt.
-        with patch("tools.sdlc_stage_query._gh_pr_list", side_effect=[None]) as gh:
+        # Only the validated issue search runs (returns None); no branch-head attempt.
+        with (
+            patch("tools.sdlc_stage_query._gh_pr_search_issue_ref", return_value=None) as search,
+            patch("tools.sdlc_stage_query._gh_pr_list") as gh,
+        ):
             assert _lookup_pr_number(145, slug=None) is None
-        assert gh.call_count == 1
+        search.assert_called_once()
+        gh.assert_not_called()
 
     def test_gh_failure_returns_none(self):
         from tools.sdlc_stage_query import _gh_pr_list
@@ -298,6 +310,91 @@ class TestLookupPrNumber:
         # subprocess raises -> None, never propagates.
         with patch("tools.sdlc_stage_query.subprocess.run", side_effect=OSError("boom")):
             assert _gh_pr_list(["--head", "session/x"]) is None
+
+    def test_issue_1987_false_match_returns_none(self):
+        """Regression #1987: a fuzzy hit whose body references a *different*
+        issue must not be trusted; with no slug fallback the result is None."""
+        from tools.sdlc_stage_query import _lookup_pr_number
+
+        # Search surfaces PR #1984 (body: "Closes #1967") for issue 1950.
+        proc = MagicMock(
+            returncode=0, stdout=json.dumps([{"number": 1984, "body": "Closes #1967"}])
+        )
+        with patch("tools.sdlc_stage_query.subprocess.run", return_value=proc):
+            assert _lookup_pr_number(1950, slug=None) is None
+
+    def test_issue_search_validated_hit_returned(self):
+        from tools.sdlc_stage_query import _gh_pr_search_issue_ref
+
+        proc = MagicMock(returncode=0, stdout=json.dumps([{"number": 77, "body": "Closes #1950"}]))
+        with patch("tools.sdlc_stage_query.subprocess.run", return_value=proc):
+            assert _gh_pr_search_issue_ref(1950) == 77
+
+    def test_issue_search_returns_first_validating_candidate(self):
+        from tools.sdlc_stage_query import _gh_pr_search_issue_ref
+
+        # Only the second candidate's body references the issue.
+        proc = MagicMock(
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    {"number": 10, "body": "Closes #1967"},
+                    {"number": 20, "body": "Fixes #1950"},
+                ]
+            ),
+        )
+        with patch("tools.sdlc_stage_query.subprocess.run", return_value=proc):
+            assert _gh_pr_search_issue_ref(1950) == 20
+
+    def test_issue_search_empty_or_malformed_returns_none(self):
+        from tools.sdlc_stage_query import _gh_pr_search_issue_ref
+
+        # Empty list, non-list, and missing/None body all resolve to None.
+        for stdout in ("[]", json.dumps({"not": "a list"}), json.dumps([{"number": 5}])):
+            proc = MagicMock(returncode=0, stdout=stdout)
+            with patch("tools.sdlc_stage_query.subprocess.run", return_value=proc):
+                assert _gh_pr_search_issue_ref(1950) is None
+
+    def test_issue_search_subprocess_error_returns_none(self):
+        from tools.sdlc_stage_query import _gh_pr_search_issue_ref
+
+        with patch("tools.sdlc_stage_query.subprocess.run", side_effect=OSError("boom")):
+            assert _gh_pr_search_issue_ref(1950) is None
+
+
+class TestBodyReferencesIssue:
+    """#1987: closing-keyword body validation with word-boundary matching."""
+
+    def test_word_boundary_prevents_prefix_match(self):
+        from tools.sdlc_stage_query import _body_references_issue
+
+        # #195 must NOT match a body that says "Closes #1950".
+        assert _body_references_issue("Closes #1950", 195) is False
+
+    def test_closing_keyword_variants_match(self):
+        from tools.sdlc_stage_query import _body_references_issue
+
+        for body in (
+            "Closes #1950",
+            "closes #1950",
+            "Closed #1950",
+            "Fixes #1950",
+            "Fix #1950",
+            "Fixed #1950",
+            "Resolves #1950",
+            "Resolve #1950",
+            "Resolved #1950",
+            "Closed: #1950",
+            "This PR fixes #1950 finally.",
+        ):
+            assert _body_references_issue(body, 1950) is True, body
+
+    def test_bare_mention_and_empty_do_not_match(self):
+        from tools.sdlc_stage_query import _body_references_issue
+
+        assert _body_references_issue("See #1950 for context", 1950) is False
+        assert _body_references_issue("", 1950) is False
+        assert _body_references_issue(None, 1950) is False
 
 
 class TestCLIOutput:

--- a/tools/sdlc_stage_query.py
+++ b/tools/sdlc_stage_query.py
@@ -257,6 +257,74 @@ def _gh_pr_list(args: list[str], repo: str | None = None) -> int | None:
     return None
 
 
+def _body_references_issue(body: str | None, issue_number: int) -> bool:
+    """Return True iff ``body`` contains a closing-keyword reference to the issue.
+
+    Matches a word-boundary GitHub closing keyword (``close``/``closes``/``closed``,
+    ``fix``/``fixes``/``fixed``, ``resolve``/``resolves``/``resolved``, case-insensitive)
+    immediately followed by ``#{issue_number}`` with no trailing digit. The trailing
+    ``(?!\\d)`` negative lookahead is the numeric boundary that prevents ``#195`` from
+    matching a body that says ``Closes #1950``. Empty/None body → False.
+
+    A bare ``#N`` mention with no closing keyword is intentionally NOT a match: fuzzy
+    ``gh pr list --search "#N"`` tokenizes the digits and can surface an unrelated PR,
+    so a literal closing-keyword reference is required to trust the match.
+    """
+    if not body:
+        return False
+    pattern = re.compile(
+        rf"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[:\s]+#{issue_number}(?!\d)",
+        re.IGNORECASE,
+    )
+    return pattern.search(body) is not None
+
+
+def _gh_pr_search_issue_ref(issue_number: int, repo: str | None = None) -> int | None:
+    """Search open PRs for ``#{issue_number}`` and return the first whose body validates.
+
+    Runs ``gh pr list --search "#{issue_number}" --state open --json number,body`` and
+    iterates the returned candidates in order, returning the ``number`` of the first PR
+    whose ``body`` passes :func:`_body_references_issue`. Fuzzy search alone is untrusted:
+    it can return an unrelated PR whose text merely contains the digits, so the body must
+    carry a literal ``Closes/Fixes/Resolves #{issue_number}`` reference to be trusted.
+
+    Returns the validated PR number, or None on any failure or when no candidate validates.
+    Never raises.
+    """
+    try:
+        cmd = ["gh", "pr", "list", "--search", f"#{issue_number}", "--state", "open"]
+        if repo:
+            cmd = [
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                repo,
+                "--search",
+                f"#{issue_number}",
+                "--state",
+                "open",
+            ]
+        cmd += ["--json", "number,body"]
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+        if proc.returncode != 0:
+            return None
+        prs = json.loads(proc.stdout or "[]")
+        if not isinstance(prs, list):
+            return None
+        for pr in prs:
+            if not isinstance(pr, dict):
+                continue
+            number = pr.get("number")
+            if not isinstance(number, int):
+                continue
+            if _body_references_issue(pr.get("body"), issue_number):
+                return number
+    except Exception as e:
+        logger.debug(f"_gh_pr_search_issue_ref failed: {e}")
+    return None
+
+
 def _lookup_pr_number(
     issue_number: int | None, slug: str | None = None, repo: str | None = None
 ) -> int | None:
@@ -264,17 +332,22 @@ def _lookup_pr_number(
 
     Resolution order (D4):
     1. Issue-number search (``gh pr list --search "#{issue_number}"``) —
-       primary path; resolves PRs whose body references the issue.
+       primary path; returns a PR only when its body carries a literal
+       word-boundary closing-keyword reference (``Closes/Fixes/Resolves
+       #{issue_number}``) to the exact issue. Fuzzy search matches alone are
+       NOT trusted (they can surface an unrelated PR whose text merely contains
+       the digits); validation runs in :func:`_gh_pr_search_issue_ref`.
     2. Branch-head fallback (``gh pr list --head session/{slug}``) — recovers
        out-of-band PRs whose body never referenced the issue. Uses the
        canonical SDLC branch shape ``session/{slug}`` (NOT a fabricated
-       ``session/sdlc-{issue_number}`` form this repo never creates); only
-       runs when a slug is available.
+       ``session/sdlc-{issue_number}`` form this repo never creates); an exact
+       head-ref match needs no body validation. Only runs when a slug is
+       available.
 
     Returns the PR number or None. Never raises.
     """
     if issue_number:
-        pr = _gh_pr_list(["--search", f"#{issue_number}", "--state", "open"], repo=repo)
+        pr = _gh_pr_search_issue_ref(issue_number, repo=repo)
         if pr is not None:
             return pr
 


### PR DESCRIPTION
Closes #1987

## Problem
`_lookup_pr_number` trusted the first `gh pr list --search "#N"` result unconditionally. GitHub's fuzzy search tokenizes `#N` and can return an unrelated PR whose title/body merely contains those digits — no literal `Closes #N` required. Observed: `/do-sdlc` for #1950 resolved to PR #1984 (body `Closes #1967`), misrouting the whole downstream pipeline.

## Fix
- `_body_references_issue(body, issue_number)` — word-boundary closing-keyword regex (`close[sd]?`/`fix(e[sd])?`/`resolve[sd]?`, case-insensitive) followed by `#{issue_number}` with a trailing `(?!\d)` numeric boundary so `#195` never matches `#1950`. None/empty → False.
- `_gh_pr_search_issue_ref(issue_number, repo)` — runs `gh pr list --search "#N" --state open --json number,body`, iterates candidates in order, returns the first whose body validates. Never raises.
- `_lookup_pr_number` primary branch now calls the validated helper. The exact branch-head fallback (`--head session/{slug}`) is unchanged — an exact head-ref match needs no body validation.

## Tests
- REPLACE/UPDATE the three helper-patching cases in `TestLookupPrNumber` to patch `_gh_pr_search_issue_ref`.
- ADD the #1987 false-match regression (body `Closes #1967` for issue 1950, no slug → None), positive-match, multi-candidate (returns first validating), empty/malformed, and subprocess-error cases.
- ADD `TestBodyReferencesIssue`: word-boundary rejection, all nine closing-keyword variants, bare-mention/empty/None rejection.
- `pytest tests/unit/test_sdlc_stage_query.py` — 57 passed. Ruff check + format clean.

## Plan
docs/plans/pr-lookup-issue-ref-validation.md (critique passed, revision_applied: true). Docs: inline docstrings only (no feature-doc changes).