### PR TITLE
Gate Sentry environment to dev-vs-prod by machine ownership + fix VALOR-BX KeyError (#1834)

### DIFF
--- a/docs/features/sentry-triage.md
+++ b/docs/features/sentry-triage.md
@@ -57,9 +57,28 @@ sentry-issue-triage: 244 issues across 3 project(s) (A=58 B=87 C=12 D=78 E=9), a
 
 In live mode, the digest gets an explicit `[LIVE — Sentry state changes applied]` footer. In dry-run mode, it gets `[dry run — no Sentry state changes]` (mirroring the existing `[dry run — no GitHub issues filed]` line for tier C). The auto-actioned block sits between the per-tier counts and the C-tier highlight rows, separating "what we already handled" from "what still needs you".
 
+## Environment gating (init side)
+
+Triage is the read/dismiss side. The **init** side — deciding whether an event is even captured, and under which `environment` tag — lives in `monitoring/sentry_config.py::configure_sentry()`, called once at startup by both the bridge (`bridge/telegram_bridge.py`) and the worker (`worker/__main__.py`). Two gates run in order:
+
+1. **Test/CI suppression (#1948).** `configure_sentry()` returns early (no `sentry_sdk.init`) whenever `PYTEST_CURRENT_TEST` or `CI` is set. A local `pytest` run therefore never reports to Sentry at all — synthetic test errors can't leak into the production project.
+
+2. **Dev-vs-prod environment resolution (#1834).** When init does proceed, `_resolve_environment()` picks the `environment` tag with this precedence:
+   - An explicit `SENTRY_ENVIRONMENT` env var always wins (escape hatch; can force e.g. `staging`).
+   - Otherwise, a **designated bridge machine** — one that owns ≥1 project in `~/Desktop/Valor/projects.json` (a `projects.<key>.machine` field matching the local `scutil --get ComputerName`, case-insensitive) — reports as `production`.
+   - Every other machine reports as `development`.
+
+   The ownership predicate is a self-contained copy of the one in `ui/data/machine.py::get_machine_project_keys` and enforced by `bridge/config_validation.py::validate_projects_config`; `monitoring/` deliberately does not import `ui/` (layer direction). See [`single-machine-ownership.md`](single-machine-ownership.md) for the ownership model.
+
+   **Fail-to-development is deliberate.** Any failure (unreadable `projects.json`, `scutil` error, or an empty/unresolved ComputerName) resolves to `development`. An empty ComputerName is explicitly short-circuited to "not owned" so it can never accidentally match a config entry with an empty `machine` field (`"" == ""`). A real production bridge machine always resolves a non-empty name and a readable config (it cannot route messages otherwise), so only dev/misconfigured hosts hit the fallback — exactly the ones that should not report as `production`.
+
+`configure_sentry()` logs the resolved environment plus its inputs (ComputerName, matched project key) at INFO on init, so a wrong tag is diagnosable from `logs/bridge.log` / `logs/worker.log` without needing Sentry itself.
+
 ## Related files
 
 - `reflections/sentry_triage.py` — the reflection (apply gate, tier map, update helper)
+- `monitoring/sentry_config.py` — init-side gating: test/CI suppression + dev-vs-prod `environment` resolution
 - `tests/unit/test_sentry_triage_apply.py` — coverage for the apply gate, tier mapping, dry-run no-op, failure isolation, and digest rendering
+- `tests/unit/test_worker_sentry_init.py` — coverage for the init guards and environment resolution
 - `config/reflections.yaml` — daily schedule entry (`sentry-issue-triage`, 86400s)
-- `~/Desktop/Valor/.env` — `SENTRY_AUTH_TOKEN` (read+write) and the optional `SENTRY_TRIAGE_APPLY=1` flag
+- `~/Desktop/Valor/.env` — `SENTRY_AUTH_TOKEN` (read+write) and the optional `SENTRY_TRIAGE_APPLY=1` flag; `SENTRY_ENVIRONMENT` (optional) overrides the resolved environment

--- a/docs/plans/sentry-gate-dev-test-init.md
+++ b/docs/plans/sentry-gate-dev-test-init.md
@@ -192,14 +192,14 @@ No agent integration required — this is a bridge/worker-internal initializatio
 
 ## Success Criteria
 
-- [ ] On a machine that owns no project (no `projects.<key>.machine` match), with `SENTRY_DSN` set and no `SENTRY_ENVIRONMENT`, `configure_sentry()` calls `sentry_sdk.init` with `environment="development"`.
-- [ ] On a designated bridge machine, `environment="production"` (unchanged behavior).
-- [ ] Explicit `SENTRY_ENVIRONMENT` always wins.
-- [ ] `dashboard_json` and `health` return successfully with `claude_auth_subscription_type: null` when `claude auth status` fails (no `KeyError`).
-- [ ] `monitoring/sentry_config.py` does not import `ui.data.machine`.
-- [ ] Operational (Nit #5): `configure_sentry()` logs the resolved environment + inputs at INFO so a non-bridge dev machine's real bridge/worker run is confirmable to carry `environment=development` from its process log.
-- [ ] Tests pass (`/do-test`).
-- [ ] Documentation updated (`/do-docs`).
+- [x] On a machine that owns no project (no `projects.<key>.machine` match), with `SENTRY_DSN` set and no `SENTRY_ENVIRONMENT`, `configure_sentry()` calls `sentry_sdk.init` with `environment="development"`.
+- [x] On a designated bridge machine, `environment="production"` (unchanged behavior).
+- [x] Explicit `SENTRY_ENVIRONMENT` always wins.
+- [x] `dashboard_json` and `health` return successfully with `claude_auth_subscription_type: null` when `claude auth status` fails (no `KeyError`).
+- [x] `monitoring/sentry_config.py` does not import `ui.data.machine`.
+- [x] Operational (Nit #5): `configure_sentry()` logs the resolved environment + inputs at INFO so a non-bridge dev machine's real bridge/worker run is confirmable to carry `environment=development` from its process log.
+- [x] Tests pass (`/do-test`).
+- [x] Documentation updated (`/do-docs`).
 
 ## Team Orchestration
 

--- a/monitoring/sentry_config.py
+++ b/monitoring/sentry_config.py
@@ -152,18 +152,23 @@ def _is_designated_bridge_machine() -> bool:
     return _owned_project_key(_get_machine_name()) is not None
 
 
-def _resolve_environment() -> str:
+def _resolve_environment(owned_project_key: str | None) -> str:
     """Resolve the Sentry ``environment`` tag for this process (issue #1834).
+
+    Pure function of the ownership result so the caller can compute the
+    ``projects.json`` + ``scutil`` inputs exactly once and reuse them for both
+    the tag and the init log line.
 
     Precedence: an explicit ``SENTRY_ENVIRONMENT`` always wins (preserves the
     existing escape hatch and lets a designated machine be forced to e.g.
-    ``staging``); otherwise a designated bridge machine reports as
-    ``"production"`` and every other machine reports as ``"development"``.
+    ``staging``); otherwise a machine that owns a project
+    (``owned_project_key is not None``) reports as ``"production"`` and every
+    other machine reports as ``"development"``.
     """
     explicit = os.getenv("SENTRY_ENVIRONMENT")
     if explicit:
         return explicit
-    return "production" if _is_designated_bridge_machine() else "development"
+    return "production" if owned_project_key is not None else "development"
 
 
 def configure_sentry(component: str, before_send=None) -> bool:
@@ -192,16 +197,19 @@ def configure_sentry(component: str, before_send=None) -> bool:
 
     import sentry_sdk  # noqa: PLC0415
 
-    environment = _resolve_environment()
+    # Resolve the ownership inputs exactly once and reuse them for both the
+    # environment tag and the observability log line (no double scutil/file read).
+    machine = _get_machine_name()
+    owned_key = _owned_project_key(machine)
+    environment = _resolve_environment(owned_key)
     # Observability (issue #1834, critique concern #2): make a wrong environment
     # tag diagnosable from the process log without needing Sentry itself.
-    machine = _get_machine_name()
     logger.info(
         "[%s] Sentry init: environment=%s (ComputerName=%r, owned_project=%s)",
         component,
         environment,
         machine,
-        _owned_project_key(machine) or "none",
+        owned_key or "none",
     )
     sentry_sdk.init(
         dsn=dsn,

--- a/monitoring/sentry_config.py
+++ b/monitoring/sentry_config.py
@@ -17,18 +17,27 @@ Design notes:
     orphan-index diagnostic it emits in a tight poll loop never floods Sentry. The
     worker deliberately does NOT get the bridge-hibernation filter — this helper
     never imports ``bridge.hibernation``.
-  * **Minimal test/CI guard only.** ``configure_sentry`` returns early under
+  * **Test/CI guard.** ``configure_sentry`` returns early under
     ``PYTEST_CURRENT_TEST`` or ``CI`` so a ``SENTRY_DSN``-present test run never
-    mis-tags ``production``. It deliberately does NOT add a machine/platform gate
-    and does NOT own the richer dev-vs-prod environment gating (that is #1834's
-    scope, layered on top of this helper later).
+    reports at all (and never mis-tags ``production``).
+  * **Dev-vs-prod environment gating (#1834).** When init does proceed,
+    :func:`_resolve_environment` decides the ``environment`` tag: an explicit
+    ``SENTRY_ENVIRONMENT`` always wins; otherwise a *designated bridge machine*
+    (one that owns >=1 project in ``projects.json``) reports as ``production`` and
+    every other machine reports as ``development``. This keeps the production
+    Sentry project clean of events from dev/misconfigured machines that start a
+    real bridge/worker outside pytest. The machine-ownership check is a
+    self-contained copy of the ``projects.json`` + ``scutil`` predicate (it does
+    NOT import the ui-layer machine helper — that would invert the layer direction).
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import subprocess
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +96,76 @@ def drop_orphan_noise(event, hint):
     return event
 
 
+def _get_machine_name() -> str:
+    """Return the local ComputerName via ``scutil``; ``""`` on any failure.
+
+    Self-contained copy of the ui-layer ``get_machine_name`` — ``monitoring``
+    must not import that layer (wrong direction). ``""`` on failure is the
+    fail-to-development signal consumed by :func:`_owned_project_key`.
+    """
+    try:
+        result = subprocess.run(["scutil", "--get", "ComputerName"], capture_output=True, text=True)
+        return result.stdout.strip()
+    except Exception:
+        return ""
+
+
+def _owned_project_key(machine: str) -> str | None:
+    """Return the first ``projects.json`` key whose ``machine`` field matches
+    ``machine`` (case-insensitive), or ``None`` if this host owns no project.
+
+    Mirrors the ui-layer ``get_machine_project_keys`` and the predicate
+    ``bridge.config_validation.validate_projects_config`` enforces
+    (``proj_cfg.get("machine")``), kept as a self-contained copy to avoid the
+    ``monitoring``->``ui`` import inversion. Any failure (missing/unreadable
+    file, malformed JSON) returns ``None`` — fail-to-development.
+    """
+    # Fail-to-development guard (issue #1834, critique concern #1): an unresolved
+    # ComputerName must never match a project. Without this, an empty machine
+    # name would match any projects.json entry that has an empty `machine` field
+    # (`"" == ""`), mis-tagging a dev/misconfigured host as `production` — the
+    # exact bug this gate exists to eliminate. A real production bridge machine
+    # always resolves a non-empty ComputerName and a readable projects.json (it
+    # cannot route messages otherwise), so only dev/misconfigured hosts hit this.
+    if not machine:
+        return None
+    config_path = Path("~/Desktop/Valor/projects.json").expanduser()
+    if not config_path.exists():
+        return None
+    try:
+        config = json.loads(config_path.read_text())
+    except Exception:
+        return None
+    machine_lower = machine.lower()
+    for project_key, project in config.get("projects", {}).items():
+        if project.get("machine", "").lower() == machine_lower:
+            return project_key
+    return None
+
+
+def _is_designated_bridge_machine() -> bool:
+    """``True`` iff this machine owns >=1 project in ``projects.json``.
+
+    Any failure resolves to ``False`` (fail-to-development) — see
+    :func:`_owned_project_key`.
+    """
+    return _owned_project_key(_get_machine_name()) is not None
+
+
+def _resolve_environment() -> str:
+    """Resolve the Sentry ``environment`` tag for this process (issue #1834).
+
+    Precedence: an explicit ``SENTRY_ENVIRONMENT`` always wins (preserves the
+    existing escape hatch and lets a designated machine be forced to e.g.
+    ``staging``); otherwise a designated bridge machine reports as
+    ``"production"`` and every other machine reports as ``"development"``.
+    """
+    explicit = os.getenv("SENTRY_ENVIRONMENT")
+    if explicit:
+        return explicit
+    return "production" if _is_designated_bridge_machine() else "development"
+
+
 def configure_sentry(component: str, before_send=None) -> bool:
     """Initialize Sentry for a process ``component`` (e.g. ``"bridge"`` / ``"worker"``).
 
@@ -100,9 +179,9 @@ def configure_sentry(component: str, before_send=None) -> bool:
         ``True`` if ``sentry_sdk.init`` was invoked, ``False`` otherwise (no DSN,
         or the pytest/CI guard tripped).
     """
-    # Minimal guard: never initialize (and never mis-tag `production`) under a
-    # test run or CI. This is intentionally the ONLY environment gate here —
-    # #1834's dev-vs-prod gating layers on top later.
+    # Guard: never initialize (and never mis-tag `production`) under a test run
+    # or CI. Runs upstream of environment resolution so `_resolve_environment`
+    # never fires under a normal test (issue #1834).
     if os.environ.get("PYTEST_CURRENT_TEST") or os.environ.get("CI"):
         logger.debug("[%s] Sentry init skipped (pytest/CI guard)", component)
         return False
@@ -113,11 +192,22 @@ def configure_sentry(component: str, before_send=None) -> bool:
 
     import sentry_sdk  # noqa: PLC0415
 
+    environment = _resolve_environment()
+    # Observability (issue #1834, critique concern #2): make a wrong environment
+    # tag diagnosable from the process log without needing Sentry itself.
+    machine = _get_machine_name()
+    logger.info(
+        "[%s] Sentry init: environment=%s (ComputerName=%r, owned_project=%s)",
+        component,
+        environment,
+        machine,
+        _owned_project_key(machine) or "none",
+    )
     sentry_sdk.init(
         dsn=dsn,
         release=subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
         traces_sample_rate=0.1,
-        environment=os.getenv("SENTRY_ENVIRONMENT", "production"),
+        environment=environment,
         before_send=before_send,
     )
     logger.info("[%s] Sentry initialized", component)

--- a/tests/unit/test_ui_app.py
+++ b/tests/unit/test_ui_app.py
@@ -400,3 +400,47 @@ class TestLocalhostBinding:
             content = f.read()
         assert "127.0.0.1" in content
         assert "0.0.0.0" not in content
+
+
+class TestClaudeAuthHealthUnavailable:
+    """VALOR-BX (#1834): when `claude auth status` fails, `_get_claude_auth_health`
+    returns an error dict WITHOUT a `subscription_type` key. `dashboard_json` and
+    `health` must read it with `.get()` and surface `null`, never raise a KeyError
+    (which would 500 the endpoint and itself be captured to Sentry)."""
+
+    def _failing_auth_run(self):
+        """A subprocess.run stub whose `claude auth status` returns non-zero.
+
+        The error branch of `_get_claude_auth_health` returns a dict lacking the
+        `subscription_type` key. Other `subprocess.run` callers in the request
+        path (e.g. scutil for machine name) see an empty, non-crashing result.
+        """
+        from unittest.mock import MagicMock
+
+        result = MagicMock()
+        result.returncode = 1
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+    def test_dashboard_json_no_keyerror_when_auth_unavailable(self, client):
+        from unittest.mock import patch
+
+        with patch("subprocess.run", return_value=self._failing_auth_run()):
+            response = client.get("/dashboard.json")
+
+        assert response.status_code == 200
+        health = response.json()["health"]
+        assert health["claude_auth"] == "error"
+        assert health["claude_auth_subscription_type"] is None
+
+    def test_health_no_keyerror_when_auth_unavailable(self, client):
+        from unittest.mock import patch
+
+        with patch("subprocess.run", return_value=self._failing_auth_run()):
+            response = client.get("/health")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["claude_auth"] == "error"
+        assert data["claude_auth_subscription_type"] is None

--- a/tests/unit/test_worker_sentry_init.py
+++ b/tests/unit/test_worker_sentry_init.py
@@ -43,7 +43,7 @@ def test_configure_sentry_inits_when_dsn_set_and_no_guard(monkeypatch):
             return_value="abc123\n",
         ),
         # Pin ownership so the assertion does not depend on the host's projects.json.
-        patch("monitoring.sentry_config._is_designated_bridge_machine", return_value=True),
+        patch("monitoring.sentry_config._owned_project_key", return_value="valor"),
     ):
         result = configure_sentry("worker", before_send=None)
 
@@ -99,7 +99,7 @@ def test_configure_sentry_passes_before_send_for_bridge(monkeypatch):
             "monitoring.sentry_config.subprocess.check_output",
             return_value="abc123\n",
         ),
-        patch("monitoring.sentry_config._is_designated_bridge_machine", return_value=True),
+        patch("monitoring.sentry_config._owned_project_key", return_value="valor"),
     ):
         result = configure_sentry("bridge", before_send=_before_send)
 
@@ -122,7 +122,7 @@ def test_configure_sentry_passes_before_send_for_worker(monkeypatch):
             "monitoring.sentry_config.subprocess.check_output",
             return_value="abc123\n",
         ),
-        patch("monitoring.sentry_config._is_designated_bridge_machine", return_value=True),
+        patch("monitoring.sentry_config._owned_project_key", return_value="valor"),
     ):
         result = configure_sentry("worker", before_send=drop_orphan_noise)
 
@@ -136,24 +136,21 @@ def test_configure_sentry_passes_before_send_for_worker(monkeypatch):
 
 
 def test_environment_development_when_not_bridge_machine(monkeypatch):
-    """No explicit override + not a designated bridge machine → development."""
+    """No explicit override + owns no project (owned_key is None) → development."""
     monkeypatch.delenv("SENTRY_ENVIRONMENT", raising=False)
-    with patch("monitoring.sentry_config._is_designated_bridge_machine", return_value=False):
-        assert _resolve_environment() == "development"
+    assert _resolve_environment(None) == "development"
 
 
 def test_environment_production_when_bridge_machine(monkeypatch):
-    """No explicit override + designated bridge machine → production."""
+    """No explicit override + owns a project → production."""
     monkeypatch.delenv("SENTRY_ENVIRONMENT", raising=False)
-    with patch("monitoring.sentry_config._is_designated_bridge_machine", return_value=True):
-        assert _resolve_environment() == "production"
+    assert _resolve_environment("valor") == "production"
 
 
 def test_explicit_sentry_environment_overrides(monkeypatch):
     """Explicit SENTRY_ENVIRONMENT wins over machine ownership (even a bridge machine)."""
     monkeypatch.setenv("SENTRY_ENVIRONMENT", "staging")
-    with patch("monitoring.sentry_config._is_designated_bridge_machine", return_value=True):
-        assert _resolve_environment() == "staging"
+    assert _resolve_environment("valor") == "staging"
 
 
 def test_owned_project_key_empty_machine_returns_none():

--- a/tests/unit/test_worker_sentry_init.py
+++ b/tests/unit/test_worker_sentry_init.py
@@ -1,24 +1,39 @@
-"""Unit tests for the shared Sentry init helper (#1877 defect #3).
+"""Unit tests for the shared Sentry init helper (#1877 defect #3, #1834).
 
 `configure_sentry` must:
   (a) call `sentry_sdk.init` when `SENTRY_DSN` is set and no guard trips;
   (b) return WITHOUT calling `sentry_sdk.init` under `PYTEST_CURRENT_TEST`
-      even when `SENTRY_DSN` is present (no `production` mis-tag).
+      even when `SENTRY_DSN` is present (no `production` mis-tag);
+  (c) resolve the `environment` tag via machine ownership (#1834): a designated
+      bridge machine reports `production`, every other machine reports
+      `development`, and an explicit `SENTRY_ENVIRONMENT` always wins.
+
+The init-path tests below pin `_is_designated_bridge_machine` so they do not
+depend on whether the test host owns a project in the real `projects.json`.
 """
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock, patch
 
-from monitoring.sentry_config import configure_sentry, drop_orphan_noise
+from monitoring.sentry_config import (
+    _is_designated_bridge_machine,
+    _owned_project_key,
+    _resolve_environment,
+    configure_sentry,
+    drop_orphan_noise,
+)
 
 
 def test_configure_sentry_inits_when_dsn_set_and_no_guard(monkeypatch):
-    """DSN present + guards cleared → sentry_sdk.init is invoked."""
+    """DSN present + guards cleared + designated bridge machine → init with production."""
     monkeypatch.setenv("SENTRY_DSN", "https://example@sentry.io/123")
     # Clear the test/CI guard so the init path is exercised.
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
     monkeypatch.delenv("CI", raising=False)
+    # No explicit override — environment must resolve via machine ownership.
+    monkeypatch.delenv("SENTRY_ENVIRONMENT", raising=False)
 
     fake_sentry = MagicMock()
     with (
@@ -27,6 +42,8 @@ def test_configure_sentry_inits_when_dsn_set_and_no_guard(monkeypatch):
             "monitoring.sentry_config.subprocess.check_output",
             return_value="abc123\n",
         ),
+        # Pin ownership so the assertion does not depend on the host's projects.json.
+        patch("monitoring.sentry_config._is_designated_bridge_machine", return_value=True),
     ):
         result = configure_sentry("worker", before_send=None)
 
@@ -70,6 +87,7 @@ def test_configure_sentry_passes_before_send_for_bridge(monkeypatch):
     monkeypatch.setenv("SENTRY_DSN", "https://example@sentry.io/123")
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
     monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("SENTRY_ENVIRONMENT", raising=False)
 
     def _before_send(event, hint):
         return event
@@ -81,6 +99,7 @@ def test_configure_sentry_passes_before_send_for_bridge(monkeypatch):
             "monitoring.sentry_config.subprocess.check_output",
             return_value="abc123\n",
         ),
+        patch("monitoring.sentry_config._is_designated_bridge_machine", return_value=True),
     ):
         result = configure_sentry("bridge", before_send=_before_send)
 
@@ -94,6 +113,7 @@ def test_configure_sentry_passes_before_send_for_worker(monkeypatch):
     monkeypatch.setenv("SENTRY_DSN", "https://example@sentry.io/123")
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
     monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("SENTRY_ENVIRONMENT", raising=False)
 
     fake_sentry = MagicMock()
     with (
@@ -102,6 +122,7 @@ def test_configure_sentry_passes_before_send_for_worker(monkeypatch):
             "monitoring.sentry_config.subprocess.check_output",
             return_value="abc123\n",
         ),
+        patch("monitoring.sentry_config._is_designated_bridge_machine", return_value=True),
     ):
         result = configure_sentry("worker", before_send=drop_orphan_noise)
 
@@ -109,3 +130,77 @@ def test_configure_sentry_passes_before_send_for_worker(monkeypatch):
     fake_sentry.init.assert_called_once()
     _, kwargs = fake_sentry.init.call_args
     assert kwargs["before_send"] is drop_orphan_noise
+
+
+# --- Environment resolution (#1834) -----------------------------------------
+
+
+def test_environment_development_when_not_bridge_machine(monkeypatch):
+    """No explicit override + not a designated bridge machine → development."""
+    monkeypatch.delenv("SENTRY_ENVIRONMENT", raising=False)
+    with patch("monitoring.sentry_config._is_designated_bridge_machine", return_value=False):
+        assert _resolve_environment() == "development"
+
+
+def test_environment_production_when_bridge_machine(monkeypatch):
+    """No explicit override + designated bridge machine → production."""
+    monkeypatch.delenv("SENTRY_ENVIRONMENT", raising=False)
+    with patch("monitoring.sentry_config._is_designated_bridge_machine", return_value=True):
+        assert _resolve_environment() == "production"
+
+
+def test_explicit_sentry_environment_overrides(monkeypatch):
+    """Explicit SENTRY_ENVIRONMENT wins over machine ownership (even a bridge machine)."""
+    monkeypatch.setenv("SENTRY_ENVIRONMENT", "staging")
+    with patch("monitoring.sentry_config._is_designated_bridge_machine", return_value=True):
+        assert _resolve_environment() == "staging"
+
+
+def test_owned_project_key_empty_machine_returns_none():
+    """Load-bearing guard (critique concern #1): an empty ComputerName must NOT
+    match a projects.json entry whose `machine` field is also empty (`"" == ""`)."""
+    fake_config = json.dumps({"projects": {"p1": {"machine": ""}, "p2": {"machine": "Prod-Box"}}})
+    with patch("monitoring.sentry_config.Path") as mock_path:
+        instance = mock_path.return_value.expanduser.return_value
+        instance.exists.return_value = True
+        instance.read_text.return_value = fake_config
+        # Empty machine short-circuits to None despite the empty-`machine` entry.
+        assert _owned_project_key("") is None
+
+
+def test_owned_project_key_matches_case_insensitive():
+    """A machine that owns a project resolves to that project key (case-insensitive)."""
+    fake_config = json.dumps({"projects": {"p1": {"machine": "Prod-Box"}}})
+    with patch("monitoring.sentry_config.Path") as mock_path:
+        instance = mock_path.return_value.expanduser.return_value
+        instance.exists.return_value = True
+        instance.read_text.return_value = fake_config
+        assert _owned_project_key("prod-box") == "p1"
+        assert _owned_project_key("Unowned-Laptop") is None
+
+
+def test_owned_project_key_read_failure_returns_none():
+    """A projects.json read error resolves to None (fail-to-development)."""
+    with patch("monitoring.sentry_config.Path") as mock_path:
+        instance = mock_path.return_value.expanduser.return_value
+        instance.exists.return_value = True
+        instance.read_text.side_effect = OSError("boom")
+        assert _owned_project_key("Prod-Box") is None
+
+
+def test_is_designated_bridge_machine_false_on_empty_computer_name():
+    """Fail-to-development: an unresolved ComputerName is never a bridge machine."""
+    with patch("monitoring.sentry_config._get_machine_name", return_value=""):
+        assert _is_designated_bridge_machine() is False
+
+
+def test_is_designated_bridge_machine_false_on_read_failure():
+    """Fail-to-development: an unreadable projects.json is never a bridge machine."""
+    with (
+        patch("monitoring.sentry_config._get_machine_name", return_value="Dev-Laptop"),
+        patch("monitoring.sentry_config.Path") as mock_path,
+    ):
+        instance = mock_path.return_value.expanduser.return_value
+        instance.exists.return_value = True
+        instance.read_text.side_effect = OSError("boom")
+        assert _is_designated_bridge_machine() is False

--- a/ui/app.py
+++ b/ui/app.py
@@ -819,7 +819,7 @@ def create_app() -> FastAPI:
                     "claude_auth": claude_auth["status"],
                     "claude_auth_logged_in": claude_auth["logged_in"],
                     "claude_auth_method": claude_auth["auth_method"],
-                    "claude_auth_subscription_type": claude_auth["subscription_type"],
+                    "claude_auth_subscription_type": claude_auth.get("subscription_type"),
                     "redis_offload": {
                         "label": "drain-loop idle-check latency",
                         "p95_latency_s": get_redis_latency_p95(),
@@ -879,7 +879,7 @@ def create_app() -> FastAPI:
                 "claude_auth": claude_auth["status"],
                 "claude_auth_logged_in": claude_auth["logged_in"],
                 "claude_auth_method": claude_auth["auth_method"],
-                "claude_auth_subscription_type": claude_auth["subscription_type"],
+                "claude_auth_subscription_type": claude_auth.get("subscription_type"),
                 # Additive-only (issue #1825): AgentSession SQLite secondary
                 # store freshness -- see docs/plans/session-archive-sqlite.md.
                 "archive": archive["status"],


### PR DESCRIPTION
Closes #1834.

**Plan:** `docs/plans/sentry-gate-dev-test-init.md` (critique: READY TO BUILD, 0 blockers)

## Problem
A dev machine running the real bridge/worker *outside* pytest still reported Sentry events as `environment=production`, because `configure_sentry()` defaulted `environment=os.getenv("SENTRY_ENVIRONMENT", "production")` with no machine awareness. The pytest/CI suppression (AC#1) and its assertion test (AC#3) were already delivered by #1948 — this PR closes the remaining AC#2 plus the VALOR-BX cleanup.

## What shipped

### Sentry environment gating (`monitoring/sentry_config.py`)
- New `_resolve_environment()`: explicit `SENTRY_ENVIRONMENT` always wins; otherwise a **designated bridge machine** (owns ≥1 project in `projects.json`, matching `scutil --get ComputerName` case-insensitively) reports as `production`; every other machine reports as `development`.
- New `_is_designated_bridge_machine()` / `_owned_project_key()` / `_get_machine_name()`: a self-contained copy of the `projects.json` + `scutil` ownership predicate (mirrors `ui/data/machine.py::get_machine_project_keys`, enforced by `bridge/config_validation.py`). `monitoring/` does **not** import `ui/` — layer direction preserved.
- **Load-bearing fail-to-development guard** (critique concern #1): an empty/unresolved ComputerName short-circuits to "not owned" so it can never match a config entry with an empty `machine` field (`"" == ""`). Any read failure resolves to `development`.
- INFO log on init records the resolved environment + inputs (ComputerName, matched project key) so a wrong tag is diagnosable from `logs/bridge.log` / `logs/worker.log` without Sentry itself (critique concern #2).

### VALOR-BX KeyError (`ui/app.py`)
- `dashboard_json` and `health` hard-indexed `claude_auth["subscription_type"]`, which the error paths of `_get_claude_auth_health()` omit → `KeyError` (itself captured to Sentry) whenever `claude auth status` fails. Both call sites now use `.get("subscription_type")`.

### Tests
- Pinned `_is_designated_bridge_machine` in the three init-path tests so they no longer depend on the host `projects.json`.
- Added: environment-resolution (dev-default / prod-on-bridge / explicit-override), empty-ComputerName guard, case-insensitive match, and read-failure (→ development) tests.
- Added `dashboard_json`/`health` error-branch tests asserting no `KeyError` and a null subscription type.

### Docs
- `docs/features/sentry-triage.md` gains an "Environment gating" section (test/CI suppression + dev-vs-prod resolution), cross-referencing `single-machine-ownership.md`.

## Verification
| Check | Result |
|-------|--------|
| `test_worker_sentry_init.py` | 13 passed |
| `test_ui_app.py` | 34 passed |
| `grep -c "ui.data.machine\|from ui" monitoring/sentry_config.py` | 0 |
| `grep -c 'claude_auth\["subscription_type"\]' ui/app.py` | 0 |
| `grep -c "_resolve_environment" monitoring/sentry_config.py` | >0 |
| ruff check / format | clean |

## Scope notes
- Centralizing the four duplicated machine-name helpers is out of scope (filed separately as #1997).
- `before_send` / orphan-noise filtering (#1835/#1948) left untouched.