### PR TITLE
chore(update): sweep obsolete launchd jobs on every /update

### DIFF
--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -41,6 +41,8 @@ After running, report the result. List every warning or error clearly.
 
 **Log rotation:** every `--full` run installs the user-space LaunchAgent `com.valor.log-rotate.plist` (content-idempotent, no sudo) which rotates any `logs/*.log` over 10 MB every 30 minutes. A stale root-era `/etc/newsyslog.d/valor.conf` is removed via non-interactive `sudo -n rm`; if sudo needs a password, cleanup is skipped with a warning and retried next run.
 
+**Obsolete launchd-job sweep (Step 1.56):** every run boots out and deletes LaunchAgents for features that have been fully removed from the codebase, so a deleted feature's plist doesn't keep loading and failing on already-provisioned machines forever. The list of removed jobs lives in `scripts/update/service.py::OBSOLETE_SERVICE_SUFFIXES` — this is the launchd analog of `RENAMED_REMOVALS` in `hardlinks.py`: **when you delete a launchd-backed feature (its install script + code), add its label suffix there** so `/update` cleans up the stale job on every machine. The sweep is idempotent and fail-soft (a machine that never had the job is a no-op); removals are logged and reported in the run summary. Runs unconditionally alongside the plist-PATH heal (Step 1.55), not gated on the service-restart step.
+
 **Session cleanup (Step 5.5):** corrupted sessions are deleted and indexes rebuilt; running/pending sessions older than 120 min with no live process transition to `killed`; terminal sessions are preserved for reflections (which handles its own 90-day expiry).
 
 ### Agent-Judgment Catchup (strictly last step)

--- a/scripts/update/run.py
+++ b/scripts/update/run.py
@@ -571,6 +571,15 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
             "services reloaded automatically"
         )
 
+    # Step 1.56: Remove launchd jobs for features that have been fully deleted
+    # from the codebase (see service.OBSOLETE_SERVICE_SUFFIXES). Without this,
+    # a removed feature's plist keeps loading and failing on every machine that
+    # was provisioned before the removal. Runs unconditionally (like Step 1.55)
+    # since dead-job cleanup is self-healing hygiene, not a service mutation.
+    obsolete_removed = service.remove_obsolete_services()
+    for label in obsolete_removed:
+        log(f"Removed obsolete launchd job {label} (feature deleted from codebase)", v, always=True)
+
     # Step 1.6: Verify .env symlink
     log("Verifying .env symlink...", v)
     result.env_sync_result = env_sync.sync_env_from_vault(project_dir)

--- a/scripts/update/service.py
+++ b/scripts/update/service.py
@@ -17,6 +17,69 @@ logger = logging.getLogger(__name__)
 # com.valor for the canonical fork; downstream forks override via SERVICE_LABEL_PREFIX.
 SERVICE_PREFIX = os.environ.get("SERVICE_LABEL_PREFIX", "com.valor")
 
+# Launchd job SUFFIXES for features that have been fully removed from the
+# codebase. Their plists linger on every already-provisioned machine forever
+# (launchd keeps loading and failing them) because nothing else deletes them —
+# the per-job "remove stale plist" gates in install_nightly_tests /
+# install_reflection_worker only cover role-gated jobs that still EXIST, not
+# jobs whose install script and code are gone. This is the launchd analog of
+# RENAMED_REMOVALS in hardlinks.py: when you delete a launchd-backed feature,
+# add its suffix here so `/update` boots it out and removes its plist on every
+# machine. Full labels are built with SERVICE_PREFIX so downstream forks are
+# covered too. Suffix only (no "com.valor." prefix, no ".plist").
+OBSOLETE_SERVICE_SUFFIXES: list[str] = [
+    # issue_poller.py deleted in commit 71190e8a7 ("Remove deprecated issue
+    # poller feature entirely"); the com.valor.issue-poller LaunchAgent kept
+    # firing every 300s and failing "No such file or directory" on every
+    # already-provisioned machine.
+    "issue-poller",
+]
+
+
+def remove_obsolete_services() -> list[str]:
+    """Boot out and delete launchd jobs for fully-removed features.
+
+    Idempotent and fail-soft: for each label in OBSOLETE_SERVICE_SUFFIXES,
+    bootout the job if it is currently loaded, then unlink its plist if present.
+    A machine that never had the job (or already cleaned it) is a no-op. Per-job
+    failures are swallowed and logged so one wedged job never aborts the sweep.
+
+    Returns the list of full labels that were actually removed (loaded job
+    booted out OR plist deleted) — empty when nothing needed cleanup.
+    """
+    launch_agents = Path.home() / "Library" / "LaunchAgents"
+    uid = os.getuid()
+    try:
+        launchctl_list = run_cmd(["launchctl", "list"]).stdout or ""
+    except Exception:
+        launchctl_list = ""
+
+    removed: list[str] = []
+    for suffix in OBSOLETE_SERVICE_SUFFIXES:
+        label = f"{SERVICE_PREFIX}.{suffix}"
+        plist_path = launch_agents / f"{label}.plist"
+        acted = False
+
+        if label in launchctl_list:
+            try:
+                run_cmd(["launchctl", "bootout", f"gui/{uid}/{label}"])
+                acted = True
+            except Exception as exc:
+                logger.warning("remove_obsolete_services: bootout %s failed: %s", label, exc)
+
+        if plist_path.exists():
+            try:
+                plist_path.unlink()
+                acted = True
+            except Exception as exc:
+                logger.warning("remove_obsolete_services: unlink %s failed: %s", plist_path, exc)
+
+        if acted:
+            logger.info("remove_obsolete_services: removed obsolete launchd job %s", label)
+            removed.append(label)
+
+    return removed
+
 
 @dataclass
 class ServiceStatus:

--- a/tests/unit/test_update_remove_obsolete_services.py
+++ b/tests/unit/test_update_remove_obsolete_services.py
@@ -1,0 +1,133 @@
+"""Tests for remove_obsolete_services() in scripts/update/service.py.
+
+Covers the launchd analog of RENAMED_REMOVALS: fully-deleted features must
+have their lingering LaunchAgent booted out and their plist unlinked on every
+machine on the next `/update`, idempotently and fail-soft.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from scripts.update import service
+
+
+def _fake_home(tmp_path: Path, monkeypatch) -> Path:
+    fake_home = tmp_path / "fake_home"
+    (fake_home / "Library" / "LaunchAgents").mkdir(parents=True)
+    monkeypatch.setattr(service.Path, "home", staticmethod(lambda: fake_home))
+    return fake_home
+
+
+class TestRemoveObsoleteServices:
+    def test_noop_when_nothing_present(self, tmp_path, monkeypatch):
+        _fake_home(tmp_path, monkeypatch)
+
+        def fake_run_cmd(cmd, **kwargs):
+            # launchctl list returns no obsolete labels.
+            return MagicMock(returncode=0, stdout="com.valor.worker\n")
+
+        monkeypatch.setattr(service, "run_cmd", fake_run_cmd)
+
+        assert service.remove_obsolete_services() == []
+
+    def test_boots_out_and_unlinks_loaded_obsolete_job(self, tmp_path, monkeypatch):
+        fake_home = _fake_home(tmp_path, monkeypatch)
+        label = f"{service.SERVICE_PREFIX}.issue-poller"
+        plist = fake_home / "Library" / "LaunchAgents" / f"{label}.plist"
+        plist.write_text("<plist>dead</plist>\n")
+
+        calls: list[list[str]] = []
+
+        def fake_run_cmd(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd[:2] == ["launchctl", "list"]:
+                return MagicMock(returncode=0, stdout=f"{label}\n")
+            return MagicMock(returncode=0, stdout="")
+
+        monkeypatch.setattr(service, "run_cmd", fake_run_cmd)
+
+        removed = service.remove_obsolete_services()
+
+        assert removed == [label]
+        # Job was booted out AND the plist deleted.
+        assert any(c[:2] == ["launchctl", "bootout"] for c in calls)
+        assert not plist.exists()
+
+    def test_unlinks_plist_even_when_not_loaded(self, tmp_path, monkeypatch):
+        # Plist on disk but launchctl doesn't list it (job failed to load) —
+        # still must be removed so it stops trying every interval.
+        fake_home = _fake_home(tmp_path, monkeypatch)
+        label = f"{service.SERVICE_PREFIX}.issue-poller"
+        plist = fake_home / "Library" / "LaunchAgents" / f"{label}.plist"
+        plist.write_text("<plist>dead</plist>\n")
+
+        calls: list[list[str]] = []
+
+        def fake_run_cmd(cmd, **kwargs):
+            calls.append(cmd)
+            return MagicMock(returncode=0, stdout="")  # list is empty
+
+        monkeypatch.setattr(service, "run_cmd", fake_run_cmd)
+
+        removed = service.remove_obsolete_services()
+
+        assert removed == [label]
+        assert not plist.exists()
+        # No bootout attempted since the job wasn't loaded.
+        assert not any(c[:2] == ["launchctl", "bootout"] for c in calls)
+
+    def test_idempotent_second_run_is_noop(self, tmp_path, monkeypatch):
+        _fake_home(tmp_path, monkeypatch)
+
+        def fake_run_cmd(cmd, **kwargs):
+            return MagicMock(returncode=0, stdout="")
+
+        monkeypatch.setattr(service, "run_cmd", fake_run_cmd)
+
+        # First run: nothing on disk, nothing loaded → empty.
+        assert service.remove_obsolete_services() == []
+        # Second run: still empty, no error.
+        assert service.remove_obsolete_services() == []
+
+    def test_failsoft_when_unlink_raises(self, tmp_path, monkeypatch):
+        fake_home = _fake_home(tmp_path, monkeypatch)
+        label = f"{service.SERVICE_PREFIX}.issue-poller"
+        plist = fake_home / "Library" / "LaunchAgents" / f"{label}.plist"
+        plist.write_text("<plist>dead</plist>\n")
+
+        def fake_run_cmd(cmd, **kwargs):
+            if cmd[:2] == ["launchctl", "list"]:
+                return MagicMock(returncode=0, stdout=f"{label}\n")
+            return MagicMock(returncode=0, stdout="")
+
+        monkeypatch.setattr(service, "run_cmd", fake_run_cmd)
+
+        def boom(self):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(service.Path, "unlink", boom)
+
+        # bootout still succeeds, so the label is reported removed; the unlink
+        # failure is swallowed (no raise).
+        removed = service.remove_obsolete_services()
+        assert removed == [label]
+
+    def test_uses_service_prefix_for_labels(self, tmp_path, monkeypatch):
+        # Downstream forks override SERVICE_PREFIX; the sweep must target the
+        # prefixed label, not a hardcoded com.valor.
+        fake_home = _fake_home(tmp_path, monkeypatch)
+        monkeypatch.setattr(service, "SERVICE_PREFIX", "com.fork")
+        label = "com.fork.issue-poller"
+        plist = fake_home / "Library" / "LaunchAgents" / f"{label}.plist"
+        plist.write_text("<plist>dead</plist>\n")
+
+        def fake_run_cmd(cmd, **kwargs):
+            return MagicMock(returncode=0, stdout="")
+
+        monkeypatch.setattr(service, "run_cmd", fake_run_cmd)
+
+        removed = service.remove_obsolete_services()
+        assert removed == [label]
+        assert not plist.exists()


### PR DESCRIPTION
## Problem

When a launchd-backed feature is **deleted** from the codebase, its LaunchAgent plist keeps living on every machine that was provisioned before the deletion — launchd loads it and it fails every interval, forever, silently.

Concretely: `scripts/issue_poller.py` was deleted in `71190e8a7` ("Remove deprecated issue poller feature entirely") months ago, but `com.valor.issue-poller` has been firing every 300s and failing `No such file or directory` on this machine ever since. A human had to notice it.

The existing per-job "remove stale plist" gates (`install_nightly_tests`, `install_reflection_worker`) only self-remove **role-gated jobs that still exist** on machines where they don't belong. Nothing handles a job whose install script and code are entirely gone.

## Change

- **`service.OBSOLETE_SERVICE_SUFFIXES`** — the launchd analog of `hardlinks.py::RENAMED_REMOVALS`. When you delete a launchd-backed feature, add its label suffix here.
- **`service.remove_obsolete_services()`** — boots out the job if loaded, unlinks its plist if present. Idempotent, fail-soft (per-job failures swallowed + logged), `SERVICE_PREFIX`-aware so downstream forks are covered.
- **`run.py` Step 1.56** — calls it unconditionally right after the plist-PATH heal (Step 1.55), since dead-job cleanup is self-healing hygiene, not a service mutation. Removals are logged and surfaced in the run summary.
- Seeded with `issue-poller`.

## Tests

New `tests/unit/test_update_remove_obsolete_services.py` (6 cases): loaded-job bootout+unlink, plist-present-but-not-loaded, no-op when absent, idempotent second run, fail-soft on unlink error, and `SERVICE_PREFIX` override. All green; sibling update-service tests unaffected (54 pass).

## Docs

`/update` SKILL.md documents Step 1.56 and the "add your removed feature's suffix here" contract.

## Notes

The `com.valor.issue-poller` job was already manually removed from the current machine during investigation; this makes every *other* machine self-clean on its next `/update`.