### PR TITLE
Fix #1964: recover worker launchctl bootstrap EIO-5 race in /update

### DIFF
--- a/scripts/remote-update.sh
+++ b/scripts/remote-update.sh
@@ -252,10 +252,14 @@ PYEOF
                 WORKER_STATE="worker restarted"
                 VERIFY_SINCE=$RESTART_TS
             else
-                # kickstart failed; fall back to bootout + bootstrap with a brief wait
+                # kickstart failed; fall back to bootout + bootstrap with a brief wait.
+                # Suppress the raw launchctl stderr ("Bootstrap failed: 5: Input/output
+                # error") — the scannable `RESTART FAILED` line below is the signal we
+                # classify on, and leaking launchctl's own error text into the /update
+                # report is noise (issue #1964).
                 launchctl bootout "gui/$(id -u)/$WORKER_LABEL" 2>/dev/null || true
                 sleep 2
-                if launchctl bootstrap "gui/$(id -u)" "$WORKER_DST"; then
+                if launchctl bootstrap "gui/$(id -u)" "$WORKER_DST" 2>/dev/null; then
                     WORKER_STATE="worker restarted"
                     VERIFY_SINCE=$RESTART_TS
                 else
@@ -270,12 +274,25 @@ PYEOF
             echo "[update] No worker-relevant changes detected — skipping restart"
         fi
     else
-        # Service not yet loaded (first install) — always bootstrap.
-        if launchctl bootstrap "gui/$(id -u)" "$WORKER_DST"; then
+        # Service not shown in `launchctl list` — first install, OR a transient
+        # state where the label is still registered with launchd (a plain
+        # `bootstrap` then fails with "Bootstrap failed: 5: Input/output error",
+        # errno 5 = EIO). Try bootstrap first; on failure fall back to
+        # `kickstart -k`, which adopts + restarts an already-registered label
+        # (the same EIO-5 race the NEED_RESTART path above handles). Only when
+        # BOTH fail is the worker genuinely un-startable → RESTART FAILED. The
+        # raw launchctl stderr is suppressed on the bootstrap attempt so error 5
+        # never leaks into the /update report when the kickstart fallback
+        # recovers it (issue #1964).
+        if launchctl bootstrap "gui/$(id -u)" "$WORKER_DST" 2>/dev/null; then
+            WORKER_STATE="worker restarted"
+            VERIFY_SINCE=$RESTART_TS
+        elif launchctl kickstart -k "gui/$(id -u)/$WORKER_LABEL" 2>/dev/null; then
+            # bootstrap hit EIO 5 (label already registered) — kickstart recovers it.
             WORKER_STATE="worker restarted"
             VERIFY_SINCE=$RESTART_TS
         else
-            echo "RESTART FAILED: worker bootstrap failed for $WORKER_LABEL"
+            echo "RESTART FAILED: worker bootstrap+kickstart failed for $WORKER_LABEL"
             WORKER_STATE="worker restart FAILED"
             RESTART_FAILED=1
         fi

--- a/tests/integration/test_remote_update.py
+++ b/tests/integration/test_remote_update.py
@@ -185,6 +185,51 @@ class TestRemoteUpdateScript:
         # lines is acceptable as long as we got *some* output.
         assert len(lines) > 0, "Expected at least one line of output"
 
+    def test_worker_bootstrap_has_kickstart_fallback(self):
+        """The worker-restart region must never run a bare `launchctl bootstrap`
+        (issue #1964).
+
+        A plain ``launchctl bootstrap`` fails with "Bootstrap failed: 5:
+        Input/output error" (errno 5 = EIO) when the worker label is still
+        registered with launchd — a recoverable race, not a genuine failure.
+        Every worker bootstrap in the restart region must therefore (a) suppress
+        the raw launchctl stderr so error 5 never leaks into the /update report,
+        and (b) be backed by a ``kickstart -k`` fallback (the modern idempotent
+        primitive that adopts + restarts an already-registered label). This is a
+        source-level guard so the resilience contract can't silently regress.
+        """
+        source = Path(self.SCRIPT).read_text()
+
+        # Isolate the worker-restart region (between its opening comment and the
+        # bridge-restart decision) so we only assert on worker bootstraps.
+        start = source.index("Reload worker plist if present")
+        end = source.index("Bridge restart decision")
+        region = source[start:end]
+
+        # No worker `launchctl bootstrap "$WORKER_DST"` may leak stderr: every
+        # occurrence must be stderr-suppressed with `2>/dev/null`.
+        for line in region.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            if "launchctl bootstrap" in stripped and "$WORKER_DST" in stripped:
+                assert "2>/dev/null" in stripped, (
+                    "worker `launchctl bootstrap` must suppress raw stderr so "
+                    f'"Bootstrap failed: 5" cannot leak into the report: {stripped!r}'
+                )
+
+        # The not-loaded branch must recover an already-registered label via a
+        # kickstart fallback rather than hard-failing on the bootstrap EIO.
+        assert "kickstart -k" in region, (
+            "worker-restart region must retain a `kickstart -k` fallback for the "
+            "EIO-5 (label already registered) race"
+        )
+        # The legacy hard-fail message (bootstrap with no fallback) must be gone.
+        assert "worker bootstrap failed for" not in region, (
+            "the bare-bootstrap failure path must be replaced by the "
+            "bootstrap+kickstart fallback path"
+        )
+
 
 # =============================================================================
 # Restart Flag Tests


### PR DESCRIPTION
## Problem

A `/update` run failed on the machine "Valor the Pirate" with:

```
Bootstrap failed: 5: Input/output error
Try re-running the command...
```

and the run reported as **failed** (non-zero exit), even though the two ⚠️ warnings in the same output (stale `GRANITE_*` env keys, `sms_reader` traceback) are pre-existing non-fatal warnings the pipeline already tolerates.

## Root cause

Traced through the pipeline:

- `handle_update_command` / cron → `scripts/remote-update.sh` → `run.py --cron --no-pull`.
- In cron mode `do_service_restart=False`, and `--no-pull` leaves `result.git_result = None` (hence the `up to date at unknown` summary). So `run.py` never reaches its Step 5 launchctl block and returns 0 with only warnings. **The bootstrap failure does not originate in `run.py`.**
- The git pull was "Already up to date" (`BEFORE_SHA == AFTER_SHA`), so no code-change-gated restart fired.

The only `launchctl bootstrap` that runs **unconditionally** (independent of code changes) is the worker-restart "service not loaded" branch in `remote-update.sh`. When the worker plist is installed but the label isn't shown in `launchctl list` — yet is still registered with launchd (a recoverable transient state, e.g. after a crash/bootout) — a plain `launchctl bootstrap` fails with `Bootstrap failed: 5: Input/output error` (errno 5 = EIO). Two defects followed:

1. The bare `launchctl bootstrap` had no `2>/dev/null`, so launchctl's raw error text leaked straight into the `/update` report.
2. The branch unconditionally set `RESTART_FAILED=1`, so the terminal `exit $(( RESTART_FAILED || VERIFY_FAILED ))` failed the entire `/update` — recurring every 30-minute cron cycle on that machine.

This is a **code-resilience defect** with a machine-local trigger. The `NEED_RESTART` path already learned this exact lesson and uses `kickstart -k` to avoid "bootstrap error 5: label still registered"; the not-loaded branch never got the same treatment.

## Fix

- Not-loaded branch: on `bootstrap` failure, fall back to `launchctl kickstart -k`, which adopts + restarts an already-registered label. Only declare `RESTART FAILED` when **both** fail.
- Suppress the raw launchctl stderr on both the not-loaded bootstrap and the `NEED_RESTART` fallback bootstrap so error 5 can never leak into the report when the fallback recovers it.
- Adds a source-level regression guard (`test_worker_bootstrap_has_kickstart_fallback`) asserting every worker `launchctl bootstrap` suppresses stderr and the region retains a `kickstart -k` fallback.

## Scope notes

- The `GRANITE_*` stale-key warning and the `sms_reader` traceback are **independent, non-fatal warnings** surfaced by `run.py --cron` into `result.warnings`; neither touches the shell exit code or the launchctl path. Confirmed **not connected** to the bootstrap failure — left out of scope.
- Machine remediation for "Valor the Pirate" (why the worker wasn't loaded in the first place) is orthogonal: check `logs/worker.log`, `launchctl print gui/$(id -u)/com.valor.worker`, and `./scripts/valor-service.sh worker-restart`. This PR makes `/update` recover gracefully regardless.

## Test

```
pytest tests/integration/test_remote_update.py::TestRemoteUpdateScript::test_worker_bootstrap_has_kickstart_fallback
```

`bash -n scripts/remote-update.sh` clean.