### PR TITLE
fix(merge_predicate): resolve SDLC-tracked issue on multi-issue-closure PRs (#2034)

### DIFF
--- a/docs/plans/merge-predicate-tracked-issue-resolution.md
+++ b/docs/plans/merge-predicate-tracked-issue-resolution.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: docs_complete
 type: bug
 appetite: Small
 owner: Valor Engels

--- a/docs/plans/merge-predicate-tracked-issue-resolution.md
+++ b/docs/plans/merge-predicate-tracked-issue-resolution.md
@@ -219,14 +219,14 @@ No agent integration required — `tools/merge_predicate.py` is already reachabl
 
 ## Success Criteria
 
-- [ ] The resolver returns the umbrella `issue_number` for a `session/{slug}` head ref whose single live, same-project `AgentSession` carries it; yields **no signal** for no-slug, no-session, project-unresolved, and cross-project-only cases; yields **ambiguous** for >1 distinct `issue_number` among live same-project sessions.
-- [ ] `evaluate_merge_predicate` keys groups (b)/(c) on the tracked issue when resolved, else the body `Closes #N`; on **ambiguous** it appends an explicit fail-closed gate failure and does not guess; group (a) body-link presence check unchanged.
-- [ ] Regression test reproduces the PR #2033 shape (body `Closes #1871/#1267/#1760`, session slug → #2029) and asserts DOCS/REVIEW checks query #2029, not #1871.
-- [ ] Ambiguity, terminal-session filtering, and cross-project scoping each have a passing unit test (critique concerns #1, #2); no-session vs project-unresolved notes are distinct strings.
-- [ ] Single-issue-PR invariance test passes (tracked == body, and session-absent fallback == body).
-- [ ] Change is confined to `tools/merge_predicate.py` + `tests/unit/test_merge_predicate.py` (git diff touches no other source files).
-- [ ] Tests pass (`/do-test`)
-- [ ] Documentation updated (`/do-docs`)
+- [x] The resolver returns the umbrella `issue_number` for a `session/{slug}` head ref whose single live, same-project `AgentSession` carries it; yields **no signal** for no-slug, no-session, project-unresolved, and cross-project-only cases; yields **ambiguous** for >1 distinct `issue_number` among live same-project sessions.
+- [x] `evaluate_merge_predicate` keys groups (b)/(c) on the tracked issue when resolved, else the body `Closes #N`; on **ambiguous** it appends an explicit fail-closed gate failure and does not guess; group (a) body-link presence check unchanged.
+- [x] Regression test reproduces the PR #2033 shape (body `Closes #1871/#1267/#1760`, session slug → #2029) and asserts DOCS/REVIEW checks query #2029, not #1871.
+- [x] Ambiguity, terminal-session filtering, and cross-project scoping each have a passing unit test (critique concerns #1, #2); no-session vs project-unresolved notes are distinct strings.
+- [x] Single-issue-PR invariance test passes (tracked == body, and session-absent fallback == body).
+- [x] Change is confined to `tools/merge_predicate.py` + `tests/unit/test_merge_predicate.py` (git diff touches no other source files).
+- [x] Tests pass (`/do-test`)
+- [x] Documentation updated (`/do-docs`)
 
 ## Team Orchestration
 

--- a/docs/sdlc/do-merge.md
+++ b/docs/sdlc/do-merge.md
@@ -47,6 +47,20 @@ generic steps as follows:
   verdict legs). Do NOT re-implement any of these checks inline in this file —
   the helper is the single source; the parity test
   (`tests/unit/test_do_merge_docs_gate.py`) breaks on drift.
+  - **Tracked-issue resolution for (b)/(c) (#2034).** Groups (b) and (c) key
+    on the SDLC-tracked issue derived from the PR's branch slug
+    (`session/{slug}` → the live, project-scoped `AgentSession.issue_number`),
+    not the first `Closes #N` in the PR body. A PR that closes several
+    sub-issues under an umbrella tracking issue records its DOCS marker and
+    REVIEW verdict on the umbrella; keying on the first-match body issue
+    false-fails the gate for that shape. When no tracked issue resolves (no
+    session for the slug, project unresolved, or the lookup degrades), groups
+    (b)/(c) fall back to the first-match body issue — single-issue PRs are
+    unaffected. When more than one distinct tracked issue is found for the
+    slug, the predicate **fails closed** with an explicit
+    `tracked-issue lookup ambiguous` entry in `failed_checks` rather than
+    guessing. Group (a)'s body-link presence check always uses the raw
+    first-match body issue, unchanged.
 - **Step 4 merge-authorization guard.** The merge-guard hook
   (`.claude/hooks/validators/validate_merge_guard.py`) evaluates the SAME live
   predicate (`tools.merge_predicate`) when the merge command runs. On the happy

--- a/tests/unit/test_merge_predicate.py
+++ b/tests/unit/test_merge_predicate.py
@@ -1,0 +1,363 @@
+"""Unit tests for tools.merge_predicate tracked-issue resolution (#2034).
+
+Groups (b)/(c) of the merge predicate must key on the SDLC-tracked issue
+derived from the PR's branch slug, not the first ``Closes #N`` in the PR body.
+For a multi-issue-closure PR under an umbrella tracking issue, the first-match
+body issue is a sub-issue with no SDLC substrate — keying on it false-fails the
+gate. These tests exercise the tri-state resolver (``tracked`` / ``no signal`` /
+``ambiguous``) and its wiring into ``evaluate_merge_predicate``.
+
+All session sources are synthetic — the resolver's lazy imports
+(``models.agent_session``, ``models.session_lifecycle``,
+``config.project_key_resolver``) are replaced in ``sys.modules`` so no live
+Redis is required.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tools import merge_predicate as mp
+
+REPO_ROOT = Path("/tmp/fake-repo")
+
+# Mirror of models.session_lifecycle.NON_TERMINAL_STATUSES for the fake module.
+_NON_TERMINAL = frozenset(
+    {
+        "pending",
+        "running",
+        "active",
+        "dormant",
+        "waiting_for_children",
+        "superseded",
+        "paused_circuit",
+        "paused",
+        "paused_budget",
+    }
+)
+
+
+def _session(slug, issue_number, project_key="valor", status="running"):
+    return SimpleNamespace(
+        slug=slug,
+        issue_number=issue_number,
+        project_key=project_key,
+        status=status,
+    )
+
+
+@pytest.fixture
+def install_session_source(monkeypatch):
+    """Install fake ``models``/``config`` modules for the resolver's lazy imports.
+
+    Returns a configurator; call it with the sessions/behaviour a test needs.
+    Using ``sys.modules`` shims keeps the resolver's two-guard structure intact
+    while never touching real Redis.
+    """
+
+    def _install(
+        *,
+        sessions=None,
+        project="valor",
+        query_exc=None,
+        break_import=False,
+    ):
+        models_pkg = types.ModuleType("models")
+        config_pkg = types.ModuleType("config")
+        agent_session_mod = types.ModuleType("models.agent_session")
+        lifecycle_mod = types.ModuleType("models.session_lifecycle")
+        resolver_mod = types.ModuleType("config.project_key_resolver")
+
+        class _Query:
+            def filter(self, **kwargs):
+                if query_exc is not None:
+                    raise query_exc
+                return self
+
+            def all(self):
+                return list(sessions or [])
+
+        class _AgentSession:
+            query = _Query()
+
+        agent_session_mod.AgentSession = _AgentSession
+        lifecycle_mod.NON_TERMINAL_STATUSES = _NON_TERMINAL
+
+        def _resolve_project_key(cwd=None, env=None, **kwargs):
+            # env={} must be passed by the resolver to force cwd-only scoping.
+            assert env == {}, "resolver must pass env={} to force cwd-only scoping"
+            return project
+
+        resolver_mod.resolve_project_key = _resolve_project_key
+
+        monkeypatch.setitem(sys.modules, "models", models_pkg)
+        monkeypatch.setitem(sys.modules, "config", config_pkg)
+        monkeypatch.setitem(sys.modules, "models.agent_session", agent_session_mod)
+        monkeypatch.setitem(sys.modules, "models.session_lifecycle", lifecycle_mod)
+        monkeypatch.setitem(sys.modules, "config.project_key_resolver", resolver_mod)
+
+        if break_import:
+            # A None entry makes ``from models.agent_session import ...`` raise.
+            monkeypatch.setitem(sys.modules, "models.agent_session", None)
+
+    return _install
+
+
+# ---------------------------------------------------------------------------
+# Resolver unit cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("head_ref", ["main", "master", "HEAD", "", "session/", None])
+def test_resolver_no_slug_is_no_signal(head_ref):
+    """Non-substrate head refs yield no signal before any import/query."""
+    result = mp._resolve_tracked_issue(head_ref, REPO_ROOT)
+    assert result.outcome is mp._TrackedOutcome.NO_SIGNAL
+    assert result.issue_number is None
+
+
+def test_resolver_happy_path_returns_tracked(install_session_source):
+    install_session_source(sessions=[_session("dev-abc", 2029)])
+    result = mp._resolve_tracked_issue("session/dev-abc", REPO_ROOT)
+    assert result.outcome is mp._TrackedOutcome.TRACKED
+    assert result.issue_number == 2029
+
+
+def test_resolver_no_session_is_no_signal(install_session_source):
+    install_session_source(sessions=[])
+    result = mp._resolve_tracked_issue("session/dev-abc", REPO_ROOT)
+    assert result.outcome is mp._TrackedOutcome.NO_SIGNAL
+    assert "no session found for slug dev-abc" in result.note
+
+
+def test_resolver_ambiguous_multiple_distinct_issues(install_session_source):
+    install_session_source(sessions=[_session("dev-abc", 2029), _session("dev-abc", 1871)])
+    result = mp._resolve_tracked_issue("session/dev-abc", REPO_ROOT)
+    assert result.outcome is mp._TrackedOutcome.AMBIGUOUS
+    assert result.distinct_count == 2
+    assert result.slug == "dev-abc"
+
+
+def test_resolver_terminal_and_transitional_sessions_filtered(install_session_source):
+    """A live 2029 session plus a completed/superseded divergent session for the
+    same slug resolves to 2029, not ambiguous."""
+    install_session_source(
+        sessions=[
+            _session("dev-abc", 2029, status="running"),
+            _session("dev-abc", 9999, status="completed"),
+            _session("dev-abc", 8888, status="superseded"),
+            _session("dev-abc", 7777, status="paused_budget"),
+        ]
+    )
+    result = mp._resolve_tracked_issue("session/dev-abc", REPO_ROOT)
+    assert result.outcome is mp._TrackedOutcome.TRACKED
+    assert result.issue_number == 2029
+
+
+def test_resolver_cross_project_session_discarded(install_session_source):
+    """A matching-slug session in a different project is ignored → no signal."""
+    install_session_source(
+        sessions=[_session("dev-abc", 1871, project_key="other-project")],
+        project="valor",
+    )
+    result = mp._resolve_tracked_issue("session/dev-abc", REPO_ROOT)
+    assert result.outcome is mp._TrackedOutcome.NO_SIGNAL
+    assert "no session found for slug dev-abc" in result.note
+
+
+def test_resolver_project_unresolved_is_no_signal(install_session_source):
+    install_session_source(sessions=[_session("dev-abc", 2029)], project=None)
+    result = mp._resolve_tracked_issue("session/dev-abc", REPO_ROOT)
+    assert result.outcome is mp._TrackedOutcome.NO_SIGNAL
+    assert "project unresolved" in result.note
+
+
+def test_resolver_import_guard_degrades_to_no_signal(install_session_source):
+    install_session_source(sessions=[_session("dev-abc", 2029)], break_import=True)
+    result = mp._resolve_tracked_issue("session/dev-abc", REPO_ROOT)
+    assert result.outcome is mp._TrackedOutcome.NO_SIGNAL
+    assert "unimportable" in result.note
+
+
+def test_resolver_query_guard_degrades_to_no_signal(install_session_source):
+    install_session_source(query_exc=RuntimeError("redis down"))
+    result = mp._resolve_tracked_issue("session/dev-abc", REPO_ROOT)
+    assert result.outcome is mp._TrackedOutcome.NO_SIGNAL
+    assert "query failed" in result.note
+
+
+def test_no_session_and_project_unresolved_notes_are_distinct(install_session_source):
+    install_session_source(sessions=[])
+    no_session = mp._resolve_tracked_issue("session/dev-abc", REPO_ROOT).note
+    install_session_source(sessions=[_session("dev-abc", 2029)], project=None)
+    unresolved = mp._resolve_tracked_issue("session/dev-abc", REPO_ROOT).note
+    assert no_session != unresolved
+
+
+# ---------------------------------------------------------------------------
+# evaluate_merge_predicate wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def wire_predicate(monkeypatch):
+    """Stub the gh/substrate seams and record which issue groups (b)/(c) see.
+
+    Returns the list that ``_check_docs_stage``/``_check_verdict_freshness``
+    record their ``issue_number`` argument into.
+    """
+
+    def _wire(*, body, head_ref="session/dev-abc", substrate=True):
+        recorded_issues: list[int] = []
+
+        def _fake_pr_view(pr_number, repo_root):
+            return {
+                "state": "OPEN",
+                "mergeable": "MERGEABLE",
+                "mergeStateStatus": "CLEAN",
+                "statusCheckRollup": [],
+                "body": body,
+                "headRefName": head_ref,
+            }
+
+        def _fake_docs(issue_number, head_ref_, repo_root, failed, notes):
+            recorded_issues.append(("docs", issue_number))
+
+        def _fake_verdict(pr_number, issue_number, repo_root, failed, notes):
+            recorded_issues.append(("verdict", issue_number))
+
+        monkeypatch.setattr(mp, "_substrate_present", lambda root: substrate)
+        monkeypatch.setattr(mp, "_gh_pr_view", _fake_pr_view)
+        monkeypatch.setattr(mp, "_check_docs_stage", _fake_docs)
+        monkeypatch.setattr(mp, "_check_verdict_freshness", _fake_verdict)
+        return recorded_issues
+
+    return _wire
+
+
+def test_multi_issue_closure_keys_on_tracked_umbrella(wire_predicate, install_session_source):
+    """PR #2033 shape: body Closes #1871/#1267/#1760, slug → umbrella #2029.
+    Groups (b)/(c) must query 2029, NOT the first-match 1871."""
+    recorded = wire_predicate(body="Closes #1871\nCloses #1267\nCloses #1760")
+    install_session_source(sessions=[_session("dev-abc", 2029)])
+
+    result = mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
+
+    assert ("docs", 2029) in recorded
+    assert ("verdict", 2029) in recorded
+    assert all(issue == 2029 for _, issue in recorded)
+    assert not any(issue == 1871 for _, issue in recorded)
+    # A substitution note is surfaced for observability.
+    assert any("SDLC-tracked issue #2029" in n for n in result.notes)
+
+
+def test_single_issue_invariance_with_matching_session(wire_predicate, install_session_source):
+    recorded = wire_predicate(body="Closes #42")
+    install_session_source(sessions=[_session("dev-abc", 42)])
+
+    mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
+
+    assert ("docs", 42) in recorded
+    assert ("verdict", 42) in recorded
+
+
+def test_single_issue_invariance_session_absent_falls_back_to_body(
+    wire_predicate, install_session_source
+):
+    recorded = wire_predicate(body="Closes #42")
+    install_session_source(sessions=[])
+
+    result = mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
+
+    assert ("docs", 42) in recorded
+    assert ("verdict", 42) in recorded
+    assert any("using body issue" in n for n in result.notes)
+
+
+def test_ambiguous_fails_closed_and_skips_groups_bc(wire_predicate, install_session_source):
+    recorded = wire_predicate(body="Closes #1871")
+    install_session_source(sessions=[_session("dev-abc", 2029), _session("dev-abc", 1871)])
+
+    result = mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
+
+    assert not result.allowed
+    ambiguous_failures = [f for f in result.failed_checks if "tracked-issue lookup ambiguous" in f]
+    assert len(ambiguous_failures) == 1
+    assert "dev-abc" in ambiguous_failures[0]
+    assert "2 distinct" in ambiguous_failures[0]
+    # Groups (b)/(c) were NOT keyed on a guessed issue.
+    assert recorded == []
+
+
+def test_cross_project_collision_falls_back_to_body(wire_predicate, install_session_source):
+    recorded = wire_predicate(body="Closes #42")
+    install_session_source(
+        sessions=[_session("dev-abc", 999, project_key="other-project")],
+        project="valor",
+    )
+
+    mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
+
+    assert ("docs", 42) in recorded
+    assert ("verdict", 42) in recorded
+    assert not any(issue == 999 for _, issue in recorded)
+
+
+def test_project_unresolved_falls_back_to_body_with_note(wire_predicate, install_session_source):
+    recorded = wire_predicate(body="Closes #42")
+    install_session_source(sessions=[_session("dev-abc", 2029)], project=None)
+
+    result = mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
+
+    assert ("docs", 42) in recorded
+    assert any("project unresolved" in n for n in result.notes)
+
+
+def test_query_failure_falls_back_to_body(wire_predicate, install_session_source):
+    recorded = wire_predicate(body="Closes #42")
+    install_session_source(query_exc=RuntimeError("redis down"))
+
+    mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
+
+    assert ("docs", 42) in recorded
+    assert ("verdict", 42) in recorded
+
+
+def test_import_failure_falls_back_to_body(wire_predicate, install_session_source):
+    recorded = wire_predicate(body="Closes #42")
+    install_session_source(sessions=[_session("dev-abc", 2029)], break_import=True)
+
+    mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
+
+    assert ("docs", 42) in recorded
+    assert ("verdict", 42) in recorded
+
+
+def test_group_a_missing_body_link_unchanged(wire_predicate):
+    """Group (a)'s body-link presence check is independent of tracked lookup."""
+    wire_predicate(body="", substrate=False)
+    result = mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
+    assert not result.allowed
+    assert any(
+        "PR body lacks a Closes/Fixes/Resolves #N issue link" in f for f in result.failed_checks
+    )
+
+
+def test_tracked_issue_used_even_when_body_link_missing(wire_predicate, install_session_source):
+    """When the body lacks a link but a session resolves, groups (b)/(c) still
+    run against the tracked issue (group (a) blocks the merge regardless)."""
+    recorded = wire_predicate(body="no issue link here")
+    install_session_source(sessions=[_session("dev-abc", 2029)])
+
+    result = mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
+
+    assert ("docs", 2029) in recorded
+    assert not result.allowed  # group (a) still fails on missing body link
+    assert any(
+        "PR body lacks a Closes/Fixes/Resolves #N issue link" in f for f in result.failed_checks
+    )

--- a/tools/merge_predicate.py
+++ b/tools/merge_predicate.py
@@ -21,6 +21,18 @@ Three check groups:
   latest commit's committer date. A bare ``"APPROVED" in text`` check is
   explicitly insufficient (#2003 critique BLOCKER 2).
 
+Tracked-issue resolution for groups (b)/(c) (#2034): the two SDLC-substrate
+checks key on the **SDLC-tracked issue derived from the PR's branch slug**, not
+the first ``Closes #N`` in the PR body. A PR that closes several sub-issues under
+an umbrella tracking issue records its DOCS marker and REVIEW verdict on the
+umbrella, so keying on the first-match body issue false-fails the gate.
+``_resolve_tracked_issue`` maps ``session/{slug}`` → the live, project-scoped
+``AgentSession`` carrying the tracked ``issue_number``; when exactly one resolves
+groups (b)/(c) use it, when none resolves they fall back to the first ``Closes
+#N`` (single-issue PRs are unchanged), and genuine ambiguity (>1 distinct tracked
+issue for the slug) **fails closed** with a named gate failure rather than
+guessing. Group (a)'s body-link presence check always uses the raw body issue.
+
 Ordered detection (cycle-2 CONCERN 3): the substrate is probed FIRST as a repo
 property — present iff ``docs/sdlc/do-merge.md`` exists under the target repo
 root AND ``sdlc-tool`` (or ``python -m tools.sdlc_stage_query``) is resolvable.
@@ -50,6 +62,7 @@ import subprocess
 import sys
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
+from enum import Enum
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -187,7 +200,12 @@ def _sdlc_tool_cmd(subcommand: list[str], repo_root: Path) -> list[str]:
     """Build the substrate invocation: prefer ``sdlc-tool``, else ``python -m``."""
     if shutil.which("sdlc-tool") is not None:
         return ["sdlc-tool", *subcommand]
-    return [sys.executable, "-m", f"tools.sdlc_{subcommand[0].replace('-', '_')}", *subcommand[1:]]
+    return [
+        sys.executable,
+        "-m",
+        f"tools.sdlc_{subcommand[0].replace('-', '_')}",
+        *subcommand[1:],
+    ]
 
 
 def _run_stage_query(issue_number: int, repo_root: Path) -> dict:
@@ -207,7 +225,8 @@ def _run_stage_query(issue_number: int, repo_root: Path) -> dict:
 def _run_verdict_get(issue_number: int, repo_root: Path) -> dict:
     """Run ``sdlc-tool verdict get --stage REVIEW`` and return the parsed record."""
     cmd = _sdlc_tool_cmd(
-        ["verdict", "get", "--stage", "REVIEW", "--issue-number", str(issue_number)], repo_root
+        ["verdict", "get", "--stage", "REVIEW", "--issue-number", str(issue_number)],
+        repo_root,
     )
     proc = subprocess.run(
         cmd, capture_output=True, text=True, timeout=_SUBPROCESS_TIMEOUT, cwd=repo_root
@@ -264,6 +283,127 @@ def _parse_iso(value: str) -> datetime | None:
 
 
 # ---------------------------------------------------------------------------
+# Tracked-issue resolution (#2034)
+# ---------------------------------------------------------------------------
+
+
+class _TrackedOutcome(Enum):
+    """Outcome of a slug→SDLC-tracked-issue resolution.
+
+    - ``TRACKED``: exactly one live, project-scoped session carries the tracked
+      ``issue_number`` — groups (b)/(c) key on it.
+    - ``NO_SIGNAL``: no usable slug, no matching session, project unresolvable,
+      or a degraded import/query — the caller falls back to the body issue.
+    - ``AMBIGUOUS``: >1 distinct tracked ``issue_number`` for the slug — the
+      caller fails closed rather than guessing.
+    """
+
+    TRACKED = "tracked"
+    NO_SIGNAL = "no_signal"
+    AMBIGUOUS = "ambiguous"
+
+
+@dataclass
+class _TrackedIssue:
+    """Tri-state result of :func:`_resolve_tracked_issue`."""
+
+    outcome: _TrackedOutcome
+    issue_number: int | None = None
+    note: str = ""
+    slug: str = ""
+    distinct_count: int = 0
+
+
+def _resolve_tracked_issue(head_ref: str | None, repo_root: Path) -> _TrackedIssue:
+    """Resolve the SDLC-tracked issue carried by the PR's branch slug (#2034).
+
+    Groups (b)/(c) must key on the umbrella tracking issue where the DOCS marker
+    and REVIEW verdict actually live, not the first ``Closes #N`` in the PR body
+    (which, for a multi-issue-closure PR, points at a sub-issue with no SDLC
+    substrate). This maps the branch slug to the live ``AgentSession`` carrying
+    the tracked ``issue_number``.
+
+    Resolution:
+
+    1. ``slug = _derive_slug(head_ref)``; empty/``main``/``master``/``HEAD``/
+       ``session/`` → **NO_SIGNAL** (single-issue and non-substrate branches
+       behave exactly as before).
+    2. Two broad ``except Exception`` guards (the ``sdlc_progress.py`` shape) —
+       one around the lazy imports, one around the ``AgentSession`` query. The
+       imports can raise *non-*``ImportError`` at import time (Redis/Popoto or
+       settings init); catching only ``ImportError`` would let those escape and
+       crash the merge-guard hook. Any failure degrades to **NO_SIGNAL**.
+    3. Project-scope with ``resolve_project_key(cwd=repo_root, env={})``. The
+       empty ``env`` is load-bearing: it forces cwd-only resolution and
+       neutralizes an ambient ``VALOR_PROJECT_KEY`` that worker/session-runner
+       processes inject (which would otherwise scope to the wrong project — the
+       wrong-allow direction). ``project is None`` → **NO_SIGNAL**.
+    4. Keep only live, non-transitional sessions (``NON_TERMINAL_STATUSES`` minus
+       ``superseded``/``paused_budget``) so a stale transitional session cannot
+       inflate the distinct-issue set into false ambiguity.
+    5. Distinct non-null ``issue_number`` values across the survivors: exactly
+       one → **TRACKED**; zero → **NO_SIGNAL**; more than one → **AMBIGUOUS**.
+    """
+    slug = _derive_slug(head_ref or "")
+    if not slug:
+        return _TrackedIssue(_TrackedOutcome.NO_SIGNAL, note="no usable slug from PR head ref")
+
+    # Guard 1: lazy imports. Broad except — import-time failures include
+    # Redis/Popoto client init and settings validation, not just ImportError.
+    try:
+        from config.project_key_resolver import resolve_project_key
+        from models.agent_session import AgentSession
+        from models.session_lifecycle import NON_TERMINAL_STATUSES
+    except Exception:
+        return _TrackedIssue(
+            _TrackedOutcome.NO_SIGNAL,
+            note="repo models unimportable; body-issue fallback",
+            slug=slug,
+        )
+
+    # Force cwd-only project resolution (env={} neutralizes VALOR_PROJECT_KEY).
+    project = resolve_project_key(cwd=str(repo_root), env={})
+    if project is None:
+        return _TrackedIssue(
+            _TrackedOutcome.NO_SIGNAL,
+            note=f"project unresolved for repo_root {repo_root}",
+            slug=slug,
+        )
+
+    # Guard 2: the Redis-backed query. Broad except — an outage degrades to the
+    # body issue, never crashes the hook.
+    try:
+        sessions = list(AgentSession.query.filter(slug=slug).all())
+    except Exception:
+        return _TrackedIssue(
+            _TrackedOutcome.NO_SIGNAL,
+            note="session query failed; body-issue fallback",
+            slug=slug,
+        )
+
+    live_statuses = NON_TERMINAL_STATUSES - {"superseded", "paused_budget"}
+    distinct: set[int] = set()
+    for session in sessions:
+        if getattr(session, "project_key", None) != project:
+            continue
+        if getattr(session, "status", None) not in live_statuses:
+            continue
+        issue = getattr(session, "issue_number", None)
+        if issue is not None:
+            distinct.add(int(issue))
+
+    if len(distinct) == 1:
+        return _TrackedIssue(_TrackedOutcome.TRACKED, issue_number=next(iter(distinct)), slug=slug)
+    if not distinct:
+        return _TrackedIssue(
+            _TrackedOutcome.NO_SIGNAL,
+            note=f"no session found for slug {slug}",
+            slug=slug,
+        )
+    return _TrackedIssue(_TrackedOutcome.AMBIGUOUS, slug=slug, distinct_count=len(distinct))
+
+
+# ---------------------------------------------------------------------------
 # Check groups
 # ---------------------------------------------------------------------------
 
@@ -302,7 +442,12 @@ def _check_pr_state(
         # CheckRun entries carry `conclusion`; StatusContext entries carry `state`.
         conclusion = (check.get("conclusion") or "").upper()
         status_state = (check.get("state") or "").upper()
-        if conclusion in ("FAILURE", "ERROR", "CANCELLED", "TIMED_OUT") or status_state in (
+        if conclusion in (
+            "FAILURE",
+            "ERROR",
+            "CANCELLED",
+            "TIMED_OUT",
+        ) or status_state in (
             "FAILURE",
             "ERROR",
         ):
@@ -452,14 +597,45 @@ def evaluate_merge_predicate(pr_number: int, repo_root: Path | None = None) -> P
         )
         notes.append(note)
         logger.info("merge_predicate: %s", note)
-    elif issue_number is None:
-        # Group (a) already recorded the missing/unresolvable issue link as a
-        # failed check, so the predicate is blocked regardless; groups (b)/(c)
-        # have no issue number to query.
-        notes.append("substrate checks not evaluated: issue number unresolvable from PR state")
     else:
-        _check_docs_stage(issue_number, head_ref, root, failed, notes)
-        _check_verdict_freshness(pr_number, issue_number, root, failed, notes)
+        # Groups (b)/(c) key on the SDLC-tracked issue derived from the branch
+        # slug (#2034), not the first-match body ``Closes #N``. Group (a)'s
+        # body-link presence check (in _check_pr_state) is unaffected.
+        tracked = _resolve_tracked_issue(head_ref, root)
+        if tracked.outcome is _TrackedOutcome.AMBIGUOUS:
+            # Fail closed: refuse to guess which issue carries the substrate.
+            failed.append(
+                f"tracked-issue lookup ambiguous: {tracked.distinct_count} distinct"
+                f" issues for branch slug {tracked.slug!r}; cannot determine which"
+                " issue carries the SDLC substrate"
+            )
+        else:
+            if tracked.outcome is _TrackedOutcome.TRACKED:
+                effective_issue = tracked.issue_number
+                if issue_number is None:
+                    notes.append(
+                        f"substrate checks keyed on SDLC-tracked issue #{effective_issue}"
+                        " (branch slug)"
+                    )
+                elif effective_issue != issue_number:
+                    notes.append(
+                        f"substrate checks keyed on SDLC-tracked issue #{effective_issue}"
+                        f" (branch slug), not first Closes #{issue_number}"
+                    )
+            else:  # NO_SIGNAL — fall back to the body-parsed issue (today's path).
+                effective_issue = issue_number
+                if tracked.note:
+                    notes.append(f"tracked-issue lookup: {tracked.note}; using body issue")
+
+            if effective_issue is None:
+                # Group (a) already recorded the missing/unresolvable issue link
+                # as a failed check; groups (b)/(c) have no issue number to query.
+                notes.append(
+                    "substrate checks not evaluated: issue number unresolvable from PR state"
+                )
+            else:
+                _check_docs_stage(effective_issue, head_ref, root, failed, notes)
+                _check_verdict_freshness(pr_number, effective_issue, root, failed, notes)
 
     return PredicateResult(
         allowed=not failed,


### PR DESCRIPTION
Closes #2034

## Problem
`tools/merge_predicate.py::_extract_issue_number()` used `.search()` (first match) against `Closes/Fixes/Resolves #N` in the PR body. On a multi-issue-closure PR under an umbrella tracking issue, the merge predicate keyed its DOCS (group b) and REVIEW-verdict (group c) checks on the FIRST closed sub-issue instead of the umbrella issue where the recorded SDLC state lives, producing false merge-gate failures (`no recorded REVIEW verdict`, `DOCS marker not authoritative`) that required a break-glass override on every such PR (observed on PR #2033 / issue #2029).

## Fix
Adds a tri-state tracked-issue resolver `_resolve_tracked_issue(head_ref, repo_root)`:
- Derives the branch slug via the existing `_derive_slug`; empty/`main`/`master`/`HEAD`/`session/` → no signal.
- Two broad `except Exception` guards (lazy imports; then the `AgentSession.query.filter(slug=...)` call) so import/query failure degrades to the body issue and never crashes the in-process merge-guard hook.
- Project-scopes candidates via `resolve_project_key(cwd=str(repo_root), env={})` (the `env={}` forces cwd-only resolution, neutralizing an ambient `VALOR_PROJECT_KEY`); a cross-project slug collision is discarded.
- Filters to live, non-transitional sessions (`NON_TERMINAL_STATUSES - {superseded, paused_budget}`) so a stale session cannot inflate the distinct-issue set.
- Distinct `issue_number` set: one → tracked; zero → no signal (body fallback); more than one → **ambiguous → fail closed** with an explicit `tracked-issue lookup ambiguous` entry rather than guessing.

Wired into `evaluate_merge_predicate`: groups (b)/(c) key on the tracked issue when resolved (with a substitution note), else the body issue (with a distinguishing note); group (a) body-link presence check is unchanged. Single-issue PRs are invariant (tracked == body).

## Scope
Diff touches only `tools/merge_predicate.py` and the new `tests/unit/test_merge_predicate.py` (scope fence per plan). No raw Redis; read-only `AgentSession` lookup.

## Tests
`tests/unit/test_merge_predicate.py` (25 tests): resolver tri-state, the PR #2033 regression (`Closes #1871/#1267/#1760` + session slug → #2029 → checks query 2029), single-issue invariance, project scoping, terminal/transitional filtering, guard degradation, and fail-closed ambiguity. `pytest tests/unit/test_merge_predicate.py tests/unit/test_validate_merge_guard.py -q` → 50 passed.

## Plan
`docs/plans/merge-predicate-tracked-issue-resolution.md` (CRITIQUE: READY TO BUILD, 0 blockers; two critique rounds folded in).