### PR TITLE
Fix merge-predicate tracked-issue resolution: key on PipelineLedger.pr_number

### DIFF
--- a/tests/unit/test_merge_predicate.py
+++ b/tests/unit/test_merge_predicate.py
@@ -4,8 +4,9 @@ Groups (b)/(c) of the merge predicate must key on the SDLC-tracked issue
 resolved from the durable ``PipelineLedger`` by PR number, not the first
 ``Closes #N`` in the PR body. For a multi-issue-closure PR under an umbrella
 tracking issue, the first-match body issue is a sub-issue with no SDLC
-substrate -- keying on it false-fails the gate (repro: PR #2033, body closes
-#1871/#1267/#1760, umbrella tracking issue #2029).
+substrate -- keying on it false-fails the gate (repro shape: an umbrella
+tracking issue whose PR body closes several sub-issues with no ledgers of
+their own).
 
 An earlier mechanism (PR #2035, superseded by this fix) resolved the tracked
 issue via ``AgentSession.query.filter(slug=..., issue_number=...)``. That
@@ -17,6 +18,16 @@ records (via ``get_or_create``, under the autouse ``redis_test_db`` fixture --
 see ``tests/unit/test_pipeline_ledger.py``) and never construct any
 AgentSession-shaped fixture, so the suite provably fails if the resolver ever
 reverts to the inert slug-keyed mechanism.
+
+Identifiers below are dedicated synthetic values (990000+ range), never real
+GitHub issue/PR numbers in this repo. An earlier revision of this file used
+the REAL repo string and REAL production identifiers (this repo's own
+umbrella issue/PR/sub-issues); when ``redis_test_db`` isolation was
+imperfect under ``pytest -n auto``, ``get_or_create`` on those real
+identifiers could collide with -- and ``ledger_factory``'s teardown could
+*delete* -- the actual production ``PipelineLedger`` record. Synthetic
+identifiers make that class of collision structurally impossible: nothing in
+production ever creates a ledger keyed on ``test-owner/...``.
 """
 
 from __future__ import annotations
@@ -30,8 +41,59 @@ from agent.pipeline_ledger import PipelineLedger
 from tools import merge_predicate as mp
 
 REPO_ROOT = Path("/tmp/fake-repo")
-TARGET_REPO = "tomcounsell/ai"
-OTHER_REPO = "tomcounsell/other-repo"
+TARGET_REPO = "test-owner/merge-predicate-test-repo"
+OTHER_REPO = "test-owner/merge-predicate-other-repo"
+
+# Dedicated synthetic issue/PR numbers -- see module docstring. The
+# multi-issue-closure shape is preserved: UMBRELLA_ISSUE's ledger carries
+# TRACKED_PR, while the PR body's first ``Closes #N`` points at a sub-issue
+# (SUB_ISSUE_A) that has no ledger of its own for that PR.
+UMBRELLA_ISSUE = 990029
+TRACKED_PR = 990033
+SUB_ISSUE_A = 991871
+SUB_ISSUE_B = 991267
+SUB_ISSUE_C = 991760
+SINGLE_ISSUE = 990042
+SIMPLE_PR = 990001
+OTHER_REPO_ISSUE = 990999
+NO_LEDGER_PR = 990999999
+
+_SYNTHETIC_LEDGER_KEYS: list[tuple[str, int]] = [
+    (TARGET_REPO, UMBRELLA_ISSUE),
+    (TARGET_REPO, SUB_ISSUE_A),
+    (TARGET_REPO, SUB_ISSUE_B),
+    (TARGET_REPO, SUB_ISSUE_C),
+    (TARGET_REPO, SINGLE_ISSUE),
+    (OTHER_REPO, UMBRELLA_ISSUE),
+    (OTHER_REPO, OTHER_REPO_ISSUE),
+]
+
+
+def _cleanup_ledger(target_repo: str, issue_number: int) -> None:
+    """Delete any PipelineLedger record for a synthetic test identifier.
+
+    Mirrors ``tests/unit/test_pipeline_ledger.py``'s ``_cleanup`` helper:
+    explicit deletion by ``ledger_key``, not reliant on Redis flushdb
+    isolation holding under parallel workers.
+    """
+    for record in PipelineLedger.query.filter(ledger_key=f"{target_repo}:{issue_number}"):
+        record.delete()
+
+
+@pytest.fixture(autouse=True)
+def _clean_synthetic_ledgers():
+    """Belt-and-suspenders cleanup before AND after every test.
+
+    Guards against a leaked record from a prior aborted run poisoning this
+    run, independent of whether ``redis_test_db`` isolation held -- same
+    defensive posture as ``test_pipeline_ledger.py``'s
+    ``setup_method``/``teardown_method`` pattern.
+    """
+    for target_repo, issue_number in _SYNTHETIC_LEDGER_KEYS:
+        _cleanup_ledger(target_repo, issue_number)
+    yield
+    for target_repo, issue_number in _SYNTHETIC_LEDGER_KEYS:
+        _cleanup_ledger(target_repo, issue_number)
 
 
 @pytest.fixture
@@ -69,64 +131,64 @@ def stub_repo_name(monkeypatch):
 
 
 def test_resolver_happy_path_returns_tracked(ledger_factory):
-    """PR #2033 shape: umbrella issue #2029's ledger carries pr_number=2033."""
-    ledger_factory(TARGET_REPO, 2029, pr_number=2033)
-    result = mp._resolve_tracked_issue(2033, REPO_ROOT)
+    """Umbrella-issue shape: UMBRELLA_ISSUE's ledger carries pr_number=TRACKED_PR."""
+    ledger_factory(TARGET_REPO, UMBRELLA_ISSUE, pr_number=TRACKED_PR)
+    result = mp._resolve_tracked_issue(TRACKED_PR, REPO_ROOT)
     assert result.outcome is mp._TrackedOutcome.TRACKED
-    assert result.issue_number == 2029
+    assert result.issue_number == UMBRELLA_ISSUE
 
 
 def test_resolver_no_ledger_is_no_signal():
     """No PipelineLedger carries this pr_number -> NO_SIGNAL, not a crash."""
-    result = mp._resolve_tracked_issue(999999, REPO_ROOT)
+    result = mp._resolve_tracked_issue(NO_LEDGER_PR, REPO_ROOT)
     assert result.outcome is mp._TrackedOutcome.NO_SIGNAL
-    assert "no PipelineLedger found for pr_number 999999" in result.note
+    assert f"no PipelineLedger found for pr_number {NO_LEDGER_PR}" in result.note
 
 
 def test_resolver_ambiguous_multiple_distinct_issues(ledger_factory):
-    ledger_factory(TARGET_REPO, 2029, pr_number=2033)
-    ledger_factory(TARGET_REPO, 1871, pr_number=2033)
-    result = mp._resolve_tracked_issue(2033, REPO_ROOT)
+    ledger_factory(TARGET_REPO, UMBRELLA_ISSUE, pr_number=TRACKED_PR)
+    ledger_factory(TARGET_REPO, SUB_ISSUE_A, pr_number=TRACKED_PR)
+    result = mp._resolve_tracked_issue(TRACKED_PR, REPO_ROOT)
     assert result.outcome is mp._TrackedOutcome.AMBIGUOUS
     assert result.distinct_count == 2
 
 
 def test_resolver_cross_repo_ledger_discarded(ledger_factory):
     """A ledger for this pr_number under a different target_repo is ignored."""
-    ledger_factory(OTHER_REPO, 2029, pr_number=2033)
-    result = mp._resolve_tracked_issue(2033, REPO_ROOT)
+    ledger_factory(OTHER_REPO, UMBRELLA_ISSUE, pr_number=TRACKED_PR)
+    result = mp._resolve_tracked_issue(TRACKED_PR, REPO_ROOT)
     assert result.outcome is mp._TrackedOutcome.NO_SIGNAL
-    assert "no PipelineLedger found for pr_number 2033" in result.note
+    assert f"no PipelineLedger found for pr_number {TRACKED_PR}" in result.note
 
 
 def test_resolver_repo_unresolvable_is_no_signal(ledger_factory, monkeypatch):
-    ledger_factory(TARGET_REPO, 2029, pr_number=2033)
+    ledger_factory(TARGET_REPO, UMBRELLA_ISSUE, pr_number=TRACKED_PR)
 
     def _raise(root):
         raise RuntimeError("gh repo view failed")
 
     monkeypatch.setattr(mp, "_gh_repo_name_with_owner", _raise)
-    result = mp._resolve_tracked_issue(2033, REPO_ROOT)
+    result = mp._resolve_tracked_issue(TRACKED_PR, REPO_ROOT)
     assert result.outcome is mp._TrackedOutcome.NO_SIGNAL
     assert "target repo unresolvable" in result.note
 
 
 def test_resolver_import_guard_degrades_to_no_signal(ledger_factory, monkeypatch):
-    ledger_factory(TARGET_REPO, 2029, pr_number=2033)
+    ledger_factory(TARGET_REPO, UMBRELLA_ISSUE, pr_number=TRACKED_PR)
     monkeypatch.setitem(sys.modules, "agent.pipeline_ledger", None)
-    result = mp._resolve_tracked_issue(2033, REPO_ROOT)
+    result = mp._resolve_tracked_issue(TRACKED_PR, REPO_ROOT)
     assert result.outcome is mp._TrackedOutcome.NO_SIGNAL
     assert "unimportable" in result.note
 
 
 def test_resolver_query_guard_degrades_to_no_signal(ledger_factory, monkeypatch):
-    ledger_factory(TARGET_REPO, 2029, pr_number=2033)
+    ledger_factory(TARGET_REPO, UMBRELLA_ISSUE, pr_number=TRACKED_PR)
 
     def _raise(**kwargs):
         raise RuntimeError("redis down")
 
     monkeypatch.setattr(PipelineLedger.query, "filter", _raise)
-    result = mp._resolve_tracked_issue(2033, REPO_ROOT)
+    result = mp._resolve_tracked_issue(TRACKED_PR, REPO_ROOT)
     assert result.outcome is mp._TrackedOutcome.NO_SIGNAL
     assert "query failed" in result.note
 
@@ -174,30 +236,33 @@ def wire_predicate(monkeypatch):
 
 
 def test_multi_issue_closure_keys_on_tracked_umbrella(wire_predicate, ledger_factory):
-    """PR #2033 shape: body Closes #1871/#1267/#1760, PipelineLedger for #2029
-    carries pr_number=2033. Groups (b)/(c) must query 2029, NOT the
-    first-match 1871 -- the exact false merge-gate failure #2034 reports."""
-    recorded = wire_predicate(body="Closes #1871\nCloses #1267\nCloses #1760")
-    ledger_factory(TARGET_REPO, 2029, pr_number=2033)
+    """Umbrella shape: body Closes #SUB_ISSUE_A/#SUB_ISSUE_B/#SUB_ISSUE_C,
+    PipelineLedger for UMBRELLA_ISSUE carries pr_number=TRACKED_PR. Groups
+    (b)/(c) must query UMBRELLA_ISSUE, NOT the first-match SUB_ISSUE_A -- the
+    exact false merge-gate failure #2034 reports."""
+    recorded = wire_predicate(
+        body=f"Closes #{SUB_ISSUE_A}\nCloses #{SUB_ISSUE_B}\nCloses #{SUB_ISSUE_C}"
+    )
+    ledger_factory(TARGET_REPO, UMBRELLA_ISSUE, pr_number=TRACKED_PR)
 
-    result = mp.evaluate_merge_predicate(2033, repo_root=REPO_ROOT)
+    result = mp.evaluate_merge_predicate(TRACKED_PR, repo_root=REPO_ROOT)
 
-    assert ("docs", 2029) in recorded
-    assert ("verdict", 2029) in recorded
-    assert all(issue == 2029 for _, issue in recorded)
-    assert not any(issue == 1871 for _, issue in recorded)
+    assert ("docs", UMBRELLA_ISSUE) in recorded
+    assert ("verdict", UMBRELLA_ISSUE) in recorded
+    assert all(issue == UMBRELLA_ISSUE for _, issue in recorded)
+    assert not any(issue == SUB_ISSUE_A for _, issue in recorded)
     # A substitution note is surfaced for observability.
-    assert any("SDLC-tracked issue #2029" in n for n in result.notes)
+    assert any(f"SDLC-tracked issue #{UMBRELLA_ISSUE}" in n for n in result.notes)
 
 
 def test_single_issue_invariance_with_matching_ledger(wire_predicate, ledger_factory):
-    recorded = wire_predicate(body="Closes #42")
-    ledger_factory(TARGET_REPO, 42, pr_number=1)
+    recorded = wire_predicate(body=f"Closes #{SINGLE_ISSUE}")
+    ledger_factory(TARGET_REPO, SINGLE_ISSUE, pr_number=SIMPLE_PR)
 
-    mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
+    mp.evaluate_merge_predicate(SIMPLE_PR, repo_root=REPO_ROOT)
 
-    assert ("docs", 42) in recorded
-    assert ("verdict", 42) in recorded
+    assert ("docs", SINGLE_ISSUE) in recorded
+    assert ("verdict", SINGLE_ISSUE) in recorded
 
 
 def test_noop_resolver_falls_back_to_first_closes_issue(wire_predicate):
@@ -207,87 +272,88 @@ def test_noop_resolver_falls_back_to_first_closes_issue(wire_predicate):
     distinguishes a working resolver from an inert one: an inert resolver
     that never resolves TRACKED would make every call take this same path,
     so ``test_multi_issue_closure_keys_on_tracked_umbrella`` (which requires
-    2029, not 1871) is what actually catches an inert resolver -- this test
-    documents that the fallback path itself still behaves correctly."""
-    recorded = wire_predicate(body="Closes #42")
+    UMBRELLA_ISSUE, not SUB_ISSUE_A) is what actually catches an inert
+    resolver -- this test documents that the fallback path itself still
+    behaves correctly."""
+    recorded = wire_predicate(body=f"Closes #{SINGLE_ISSUE}")
 
-    result = mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
+    result = mp.evaluate_merge_predicate(SIMPLE_PR, repo_root=REPO_ROOT)
 
-    assert ("docs", 42) in recorded
-    assert ("verdict", 42) in recorded
+    assert ("docs", SINGLE_ISSUE) in recorded
+    assert ("verdict", SINGLE_ISSUE) in recorded
     assert any("using body issue" in n for n in result.notes)
 
 
 def test_ambiguous_fails_closed_and_skips_groups_bc(wire_predicate, ledger_factory):
-    recorded = wire_predicate(body="Closes #1871")
-    ledger_factory(TARGET_REPO, 2029, pr_number=1)
-    ledger_factory(TARGET_REPO, 1871, pr_number=1)
+    recorded = wire_predicate(body=f"Closes #{SUB_ISSUE_A}")
+    ledger_factory(TARGET_REPO, UMBRELLA_ISSUE, pr_number=SIMPLE_PR)
+    ledger_factory(TARGET_REPO, SUB_ISSUE_A, pr_number=SIMPLE_PR)
 
-    result = mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
+    result = mp.evaluate_merge_predicate(SIMPLE_PR, repo_root=REPO_ROOT)
 
     assert not result.allowed
     ambiguous_failures = [f for f in result.failed_checks if "tracked-issue lookup ambiguous" in f]
     assert len(ambiguous_failures) == 1
-    assert "PR #1" in ambiguous_failures[0]
+    assert f"PR #{SIMPLE_PR}" in ambiguous_failures[0]
     assert "2 distinct" in ambiguous_failures[0]
     # Groups (b)/(c) were NOT keyed on a guessed issue.
     assert recorded == []
 
 
 def test_cross_repo_collision_falls_back_to_body(wire_predicate, ledger_factory):
-    recorded = wire_predicate(body="Closes #42")
-    ledger_factory(OTHER_REPO, 999, pr_number=1)
+    recorded = wire_predicate(body=f"Closes #{SINGLE_ISSUE}")
+    ledger_factory(OTHER_REPO, OTHER_REPO_ISSUE, pr_number=SIMPLE_PR)
 
-    mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
+    mp.evaluate_merge_predicate(SIMPLE_PR, repo_root=REPO_ROOT)
 
-    assert ("docs", 42) in recorded
-    assert ("verdict", 42) in recorded
-    assert not any(issue == 999 for _, issue in recorded)
+    assert ("docs", SINGLE_ISSUE) in recorded
+    assert ("verdict", SINGLE_ISSUE) in recorded
+    assert not any(issue == OTHER_REPO_ISSUE for _, issue in recorded)
 
 
 def test_repo_unresolvable_falls_back_to_body_with_note(wire_predicate, monkeypatch):
-    recorded = wire_predicate(body="Closes #42")
+    recorded = wire_predicate(body=f"Closes #{SINGLE_ISSUE}")
 
     def _raise(root):
         raise RuntimeError("gh repo view failed")
 
     monkeypatch.setattr(mp, "_gh_repo_name_with_owner", _raise)
 
-    result = mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
+    result = mp.evaluate_merge_predicate(SIMPLE_PR, repo_root=REPO_ROOT)
 
-    assert ("docs", 42) in recorded
+    assert ("docs", SINGLE_ISSUE) in recorded
     assert any("target repo unresolvable" in n for n in result.notes)
 
 
 def test_query_failure_falls_back_to_body(wire_predicate, monkeypatch):
-    recorded = wire_predicate(body="Closes #42")
+    recorded = wire_predicate(body=f"Closes #{SINGLE_ISSUE}")
 
     def _raise(**kwargs):
         raise RuntimeError("redis down")
 
     monkeypatch.setattr(PipelineLedger.query, "filter", _raise)
 
-    mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
+    mp.evaluate_merge_predicate(SIMPLE_PR, repo_root=REPO_ROOT)
 
-    assert ("docs", 42) in recorded
-    assert ("verdict", 42) in recorded
+    assert ("docs", SINGLE_ISSUE) in recorded
+    assert ("verdict", SINGLE_ISSUE) in recorded
 
 
 def test_import_failure_falls_back_to_body(wire_predicate, monkeypatch, ledger_factory):
-    recorded = wire_predicate(body="Closes #42")
-    ledger_factory(TARGET_REPO, 2029, pr_number=1)
+    recorded = wire_predicate(body=f"Closes #{SINGLE_ISSUE}")
+    ledger_factory(TARGET_REPO, UMBRELLA_ISSUE, pr_number=SIMPLE_PR)
     monkeypatch.setitem(sys.modules, "agent.pipeline_ledger", None)
 
-    mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
+    mp.evaluate_merge_predicate(SIMPLE_PR, repo_root=REPO_ROOT)
 
-    assert ("docs", 42) in recorded
-    assert ("verdict", 42) in recorded
+    assert ("docs", SINGLE_ISSUE) in recorded
+    assert ("verdict", SINGLE_ISSUE) in recorded
 
 
 def test_group_a_missing_body_link_unchanged(wire_predicate):
     """Group (a)'s body-link presence check is independent of tracked lookup."""
     wire_predicate(body="", substrate=False)
-    result = mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
+    result = mp.evaluate_merge_predicate(SIMPLE_PR, repo_root=REPO_ROOT)
     assert not result.allowed
     assert any(
         "PR body lacks a Closes/Fixes/Resolves #N issue link" in f for f in result.failed_checks
@@ -298,11 +364,11 @@ def test_tracked_issue_used_even_when_body_link_missing(wire_predicate, ledger_f
     """When the body lacks a link but a ledger resolves, groups (b)/(c) still
     run against the tracked issue (group (a) blocks the merge regardless)."""
     recorded = wire_predicate(body="no issue link here")
-    ledger_factory(TARGET_REPO, 2029, pr_number=1)
+    ledger_factory(TARGET_REPO, UMBRELLA_ISSUE, pr_number=SIMPLE_PR)
 
-    result = mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
+    result = mp.evaluate_merge_predicate(SIMPLE_PR, repo_root=REPO_ROOT)
 
-    assert ("docs", 2029) in recorded
+    assert ("docs", UMBRELLA_ISSUE) in recorded
     assert not result.allowed  # group (a) still fails on missing body link
     assert any(
         "PR body lacks a Closes/Fixes/Resolves #N issue link" in f for f in result.failed_checks

--- a/tests/unit/test_merge_predicate.py
+++ b/tests/unit/test_merge_predicate.py
@@ -1,111 +1,66 @@
 """Unit tests for tools.merge_predicate tracked-issue resolution (#2034).
 
 Groups (b)/(c) of the merge predicate must key on the SDLC-tracked issue
-derived from the PR's branch slug, not the first ``Closes #N`` in the PR body.
-For a multi-issue-closure PR under an umbrella tracking issue, the first-match
-body issue is a sub-issue with no SDLC substrate — keying on it false-fails the
-gate. These tests exercise the tri-state resolver (``tracked`` / ``no signal`` /
-``ambiguous``) and its wiring into ``evaluate_merge_predicate``.
+resolved from the durable ``PipelineLedger`` by PR number, not the first
+``Closes #N`` in the PR body. For a multi-issue-closure PR under an umbrella
+tracking issue, the first-match body issue is a sub-issue with no SDLC
+substrate -- keying on it false-fails the gate (repro: PR #2033, body closes
+#1871/#1267/#1760, umbrella tracking issue #2029).
 
-All session sources are synthetic — the resolver's lazy imports
-(``models.agent_session``, ``models.session_lifecycle``,
-``config.project_key_resolver``) are replaced in ``sys.modules`` so no live
-Redis is required.
+An earlier mechanism (PR #2035, superseded by this fix) resolved the tracked
+issue via ``AgentSession.query.filter(slug=..., issue_number=...)``. That
+mechanism is empirically inert in production: ``slug`` and ``issue_number``
+are populated by disjoint AgentSession creation paths, so 0 of the live
+sessions co-populate both fields, and the resolver always degraded to
+NO_SIGNAL. These tests build REAL, production-shaped ``PipelineLedger``
+records (via ``get_or_create``, under the autouse ``redis_test_db`` fixture --
+see ``tests/unit/test_pipeline_ledger.py``) and never construct any
+AgentSession-shaped fixture, so the suite provably fails if the resolver ever
+reverts to the inert slug-keyed mechanism.
 """
 
 from __future__ import annotations
 
 import sys
-import types
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
+from agent.pipeline_ledger import PipelineLedger
 from tools import merge_predicate as mp
 
 REPO_ROOT = Path("/tmp/fake-repo")
-
-# Mirror of models.session_lifecycle.NON_TERMINAL_STATUSES for the fake module.
-_NON_TERMINAL = frozenset(
-    {
-        "pending",
-        "running",
-        "active",
-        "dormant",
-        "waiting_for_children",
-        "superseded",
-        "paused_circuit",
-        "paused",
-        "paused_budget",
-    }
-)
-
-
-def _session(slug, issue_number, project_key="valor", status="running"):
-    return SimpleNamespace(
-        slug=slug,
-        issue_number=issue_number,
-        project_key=project_key,
-        status=status,
-    )
+TARGET_REPO = "tomcounsell/ai"
+OTHER_REPO = "tomcounsell/other-repo"
 
 
 @pytest.fixture
-def install_session_source(monkeypatch):
-    """Install fake ``models``/``config`` modules for the resolver's lazy imports.
+def ledger_factory():
+    """Create real PipelineLedger records and clean them up on teardown."""
+    created: list[PipelineLedger] = []
 
-    Returns a configurator; call it with the sessions/behaviour a test needs.
-    Using ``sys.modules`` shims keeps the resolver's two-guard structure intact
-    while never touching real Redis.
+    def _factory(target_repo: str, issue_number: int, pr_number: int | None = None):
+        ledger = PipelineLedger.get_or_create(target_repo, issue_number)
+        if pr_number is not None:
+            ledger.pr_number = pr_number
+            ledger.save()
+        created.append(ledger)
+        return ledger
+
+    yield _factory
+
+    for ledger in created:
+        ledger.delete()
+
+
+@pytest.fixture(autouse=True)
+def stub_repo_name(monkeypatch):
+    """Default target-repo resolution for direct resolver calls.
+
+    Individual tests override this via ``monkeypatch.setattr`` when they need
+    a different repo or a failure.
     """
-
-    def _install(
-        *,
-        sessions=None,
-        project="valor",
-        query_exc=None,
-        break_import=False,
-    ):
-        models_pkg = types.ModuleType("models")
-        config_pkg = types.ModuleType("config")
-        agent_session_mod = types.ModuleType("models.agent_session")
-        lifecycle_mod = types.ModuleType("models.session_lifecycle")
-        resolver_mod = types.ModuleType("config.project_key_resolver")
-
-        class _Query:
-            def filter(self, **kwargs):
-                if query_exc is not None:
-                    raise query_exc
-                return self
-
-            def all(self):
-                return list(sessions or [])
-
-        class _AgentSession:
-            query = _Query()
-
-        agent_session_mod.AgentSession = _AgentSession
-        lifecycle_mod.NON_TERMINAL_STATUSES = _NON_TERMINAL
-
-        def _resolve_project_key(cwd=None, env=None, **kwargs):
-            # env={} must be passed by the resolver to force cwd-only scoping.
-            assert env == {}, "resolver must pass env={} to force cwd-only scoping"
-            return project
-
-        resolver_mod.resolve_project_key = _resolve_project_key
-
-        monkeypatch.setitem(sys.modules, "models", models_pkg)
-        monkeypatch.setitem(sys.modules, "config", config_pkg)
-        monkeypatch.setitem(sys.modules, "models.agent_session", agent_session_mod)
-        monkeypatch.setitem(sys.modules, "models.session_lifecycle", lifecycle_mod)
-        monkeypatch.setitem(sys.modules, "config.project_key_resolver", resolver_mod)
-
-        if break_import:
-            # A None entry makes ``from models.agent_session import ...`` raise.
-            monkeypatch.setitem(sys.modules, "models.agent_session", None)
-
-    return _install
+    monkeypatch.setattr(mp, "_gh_repo_name_with_owner", lambda root: TARGET_REPO)
 
 
 # ---------------------------------------------------------------------------
@@ -113,90 +68,67 @@ def install_session_source(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("head_ref", ["main", "master", "HEAD", "", "session/", None])
-def test_resolver_no_slug_is_no_signal(head_ref):
-    """Non-substrate head refs yield no signal before any import/query."""
-    result = mp._resolve_tracked_issue(head_ref, REPO_ROOT)
-    assert result.outcome is mp._TrackedOutcome.NO_SIGNAL
-    assert result.issue_number is None
-
-
-def test_resolver_happy_path_returns_tracked(install_session_source):
-    install_session_source(sessions=[_session("dev-abc", 2029)])
-    result = mp._resolve_tracked_issue("session/dev-abc", REPO_ROOT)
+def test_resolver_happy_path_returns_tracked(ledger_factory):
+    """PR #2033 shape: umbrella issue #2029's ledger carries pr_number=2033."""
+    ledger_factory(TARGET_REPO, 2029, pr_number=2033)
+    result = mp._resolve_tracked_issue(2033, REPO_ROOT)
     assert result.outcome is mp._TrackedOutcome.TRACKED
     assert result.issue_number == 2029
 
 
-def test_resolver_no_session_is_no_signal(install_session_source):
-    install_session_source(sessions=[])
-    result = mp._resolve_tracked_issue("session/dev-abc", REPO_ROOT)
+def test_resolver_no_ledger_is_no_signal():
+    """No PipelineLedger carries this pr_number -> NO_SIGNAL, not a crash."""
+    result = mp._resolve_tracked_issue(999999, REPO_ROOT)
     assert result.outcome is mp._TrackedOutcome.NO_SIGNAL
-    assert "no session found for slug dev-abc" in result.note
+    assert "no PipelineLedger found for pr_number 999999" in result.note
 
 
-def test_resolver_ambiguous_multiple_distinct_issues(install_session_source):
-    install_session_source(sessions=[_session("dev-abc", 2029), _session("dev-abc", 1871)])
-    result = mp._resolve_tracked_issue("session/dev-abc", REPO_ROOT)
+def test_resolver_ambiguous_multiple_distinct_issues(ledger_factory):
+    ledger_factory(TARGET_REPO, 2029, pr_number=2033)
+    ledger_factory(TARGET_REPO, 1871, pr_number=2033)
+    result = mp._resolve_tracked_issue(2033, REPO_ROOT)
     assert result.outcome is mp._TrackedOutcome.AMBIGUOUS
     assert result.distinct_count == 2
-    assert result.slug == "dev-abc"
 
 
-def test_resolver_terminal_and_transitional_sessions_filtered(install_session_source):
-    """A live 2029 session plus a completed/superseded divergent session for the
-    same slug resolves to 2029, not ambiguous."""
-    install_session_source(
-        sessions=[
-            _session("dev-abc", 2029, status="running"),
-            _session("dev-abc", 9999, status="completed"),
-            _session("dev-abc", 8888, status="superseded"),
-            _session("dev-abc", 7777, status="paused_budget"),
-        ]
-    )
-    result = mp._resolve_tracked_issue("session/dev-abc", REPO_ROOT)
-    assert result.outcome is mp._TrackedOutcome.TRACKED
-    assert result.issue_number == 2029
-
-
-def test_resolver_cross_project_session_discarded(install_session_source):
-    """A matching-slug session in a different project is ignored → no signal."""
-    install_session_source(
-        sessions=[_session("dev-abc", 1871, project_key="other-project")],
-        project="valor",
-    )
-    result = mp._resolve_tracked_issue("session/dev-abc", REPO_ROOT)
+def test_resolver_cross_repo_ledger_discarded(ledger_factory):
+    """A ledger for this pr_number under a different target_repo is ignored."""
+    ledger_factory(OTHER_REPO, 2029, pr_number=2033)
+    result = mp._resolve_tracked_issue(2033, REPO_ROOT)
     assert result.outcome is mp._TrackedOutcome.NO_SIGNAL
-    assert "no session found for slug dev-abc" in result.note
+    assert "no PipelineLedger found for pr_number 2033" in result.note
 
 
-def test_resolver_project_unresolved_is_no_signal(install_session_source):
-    install_session_source(sessions=[_session("dev-abc", 2029)], project=None)
-    result = mp._resolve_tracked_issue("session/dev-abc", REPO_ROOT)
+def test_resolver_repo_unresolvable_is_no_signal(ledger_factory, monkeypatch):
+    ledger_factory(TARGET_REPO, 2029, pr_number=2033)
+
+    def _raise(root):
+        raise RuntimeError("gh repo view failed")
+
+    monkeypatch.setattr(mp, "_gh_repo_name_with_owner", _raise)
+    result = mp._resolve_tracked_issue(2033, REPO_ROOT)
     assert result.outcome is mp._TrackedOutcome.NO_SIGNAL
-    assert "project unresolved" in result.note
+    assert "target repo unresolvable" in result.note
 
 
-def test_resolver_import_guard_degrades_to_no_signal(install_session_source):
-    install_session_source(sessions=[_session("dev-abc", 2029)], break_import=True)
-    result = mp._resolve_tracked_issue("session/dev-abc", REPO_ROOT)
+def test_resolver_import_guard_degrades_to_no_signal(ledger_factory, monkeypatch):
+    ledger_factory(TARGET_REPO, 2029, pr_number=2033)
+    monkeypatch.setitem(sys.modules, "agent.pipeline_ledger", None)
+    result = mp._resolve_tracked_issue(2033, REPO_ROOT)
     assert result.outcome is mp._TrackedOutcome.NO_SIGNAL
     assert "unimportable" in result.note
 
 
-def test_resolver_query_guard_degrades_to_no_signal(install_session_source):
-    install_session_source(query_exc=RuntimeError("redis down"))
-    result = mp._resolve_tracked_issue("session/dev-abc", REPO_ROOT)
+def test_resolver_query_guard_degrades_to_no_signal(ledger_factory, monkeypatch):
+    ledger_factory(TARGET_REPO, 2029, pr_number=2033)
+
+    def _raise(**kwargs):
+        raise RuntimeError("redis down")
+
+    monkeypatch.setattr(PipelineLedger.query, "filter", _raise)
+    result = mp._resolve_tracked_issue(2033, REPO_ROOT)
     assert result.outcome is mp._TrackedOutcome.NO_SIGNAL
     assert "query failed" in result.note
-
-
-def test_no_session_and_project_unresolved_notes_are_distinct(install_session_source):
-    install_session_source(sessions=[])
-    no_session = mp._resolve_tracked_issue("session/dev-abc", REPO_ROOT).note
-    install_session_source(sessions=[_session("dev-abc", 2029)], project=None)
-    unresolved = mp._resolve_tracked_issue("session/dev-abc", REPO_ROOT).note
-    assert no_session != unresolved
 
 
 # ---------------------------------------------------------------------------
@@ -212,8 +144,8 @@ def wire_predicate(monkeypatch):
     record their ``issue_number`` argument into.
     """
 
-    def _wire(*, body, head_ref="session/dev-abc", substrate=True):
-        recorded_issues: list[int] = []
+    def _wire(*, body, head_ref="session/dev-abc", substrate=True, target_repo=TARGET_REPO):
+        recorded_issues: list[tuple[str, int]] = []
 
         def _fake_pr_view(pr_number, repo_root):
             return {
@@ -233,6 +165,7 @@ def wire_predicate(monkeypatch):
 
         monkeypatch.setattr(mp, "_substrate_present", lambda root: substrate)
         monkeypatch.setattr(mp, "_gh_pr_view", _fake_pr_view)
+        monkeypatch.setattr(mp, "_gh_repo_name_with_owner", lambda root: target_repo)
         monkeypatch.setattr(mp, "_check_docs_stage", _fake_docs)
         monkeypatch.setattr(mp, "_check_verdict_freshness", _fake_verdict)
         return recorded_issues
@@ -240,13 +173,14 @@ def wire_predicate(monkeypatch):
     return _wire
 
 
-def test_multi_issue_closure_keys_on_tracked_umbrella(wire_predicate, install_session_source):
-    """PR #2033 shape: body Closes #1871/#1267/#1760, slug → umbrella #2029.
-    Groups (b)/(c) must query 2029, NOT the first-match 1871."""
+def test_multi_issue_closure_keys_on_tracked_umbrella(wire_predicate, ledger_factory):
+    """PR #2033 shape: body Closes #1871/#1267/#1760, PipelineLedger for #2029
+    carries pr_number=2033. Groups (b)/(c) must query 2029, NOT the
+    first-match 1871 -- the exact false merge-gate failure #2034 reports."""
     recorded = wire_predicate(body="Closes #1871\nCloses #1267\nCloses #1760")
-    install_session_source(sessions=[_session("dev-abc", 2029)])
+    ledger_factory(TARGET_REPO, 2029, pr_number=2033)
 
-    result = mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
+    result = mp.evaluate_merge_predicate(2033, repo_root=REPO_ROOT)
 
     assert ("docs", 2029) in recorded
     assert ("verdict", 2029) in recorded
@@ -256,9 +190,9 @@ def test_multi_issue_closure_keys_on_tracked_umbrella(wire_predicate, install_se
     assert any("SDLC-tracked issue #2029" in n for n in result.notes)
 
 
-def test_single_issue_invariance_with_matching_session(wire_predicate, install_session_source):
+def test_single_issue_invariance_with_matching_ledger(wire_predicate, ledger_factory):
     recorded = wire_predicate(body="Closes #42")
-    install_session_source(sessions=[_session("dev-abc", 42)])
+    ledger_factory(TARGET_REPO, 42, pr_number=1)
 
     mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
 
@@ -266,11 +200,16 @@ def test_single_issue_invariance_with_matching_session(wire_predicate, install_s
     assert ("verdict", 42) in recorded
 
 
-def test_single_issue_invariance_session_absent_falls_back_to_body(
-    wire_predicate, install_session_source
-):
+def test_noop_resolver_falls_back_to_first_closes_issue(wire_predicate):
+    """NO-OP-FAILS case: no PipelineLedger exists for this PR number, so the
+    resolver returns NO_SIGNAL and the predicate must key groups (b)/(c) on
+    the first Closes #N in the body. This is the load-bearing assertion that
+    distinguishes a working resolver from an inert one: an inert resolver
+    that never resolves TRACKED would make every call take this same path,
+    so ``test_multi_issue_closure_keys_on_tracked_umbrella`` (which requires
+    2029, not 1871) is what actually catches an inert resolver -- this test
+    documents that the fallback path itself still behaves correctly."""
     recorded = wire_predicate(body="Closes #42")
-    install_session_source(sessions=[])
 
     result = mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
 
@@ -279,27 +218,25 @@ def test_single_issue_invariance_session_absent_falls_back_to_body(
     assert any("using body issue" in n for n in result.notes)
 
 
-def test_ambiguous_fails_closed_and_skips_groups_bc(wire_predicate, install_session_source):
+def test_ambiguous_fails_closed_and_skips_groups_bc(wire_predicate, ledger_factory):
     recorded = wire_predicate(body="Closes #1871")
-    install_session_source(sessions=[_session("dev-abc", 2029), _session("dev-abc", 1871)])
+    ledger_factory(TARGET_REPO, 2029, pr_number=1)
+    ledger_factory(TARGET_REPO, 1871, pr_number=1)
 
     result = mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
 
     assert not result.allowed
     ambiguous_failures = [f for f in result.failed_checks if "tracked-issue lookup ambiguous" in f]
     assert len(ambiguous_failures) == 1
-    assert "dev-abc" in ambiguous_failures[0]
+    assert "PR #1" in ambiguous_failures[0]
     assert "2 distinct" in ambiguous_failures[0]
     # Groups (b)/(c) were NOT keyed on a guessed issue.
     assert recorded == []
 
 
-def test_cross_project_collision_falls_back_to_body(wire_predicate, install_session_source):
+def test_cross_repo_collision_falls_back_to_body(wire_predicate, ledger_factory):
     recorded = wire_predicate(body="Closes #42")
-    install_session_source(
-        sessions=[_session("dev-abc", 999, project_key="other-project")],
-        project="valor",
-    )
+    ledger_factory(OTHER_REPO, 999, pr_number=1)
 
     mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
 
@@ -308,19 +245,27 @@ def test_cross_project_collision_falls_back_to_body(wire_predicate, install_sess
     assert not any(issue == 999 for _, issue in recorded)
 
 
-def test_project_unresolved_falls_back_to_body_with_note(wire_predicate, install_session_source):
+def test_repo_unresolvable_falls_back_to_body_with_note(wire_predicate, monkeypatch):
     recorded = wire_predicate(body="Closes #42")
-    install_session_source(sessions=[_session("dev-abc", 2029)], project=None)
+
+    def _raise(root):
+        raise RuntimeError("gh repo view failed")
+
+    monkeypatch.setattr(mp, "_gh_repo_name_with_owner", _raise)
 
     result = mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
 
     assert ("docs", 42) in recorded
-    assert any("project unresolved" in n for n in result.notes)
+    assert any("target repo unresolvable" in n for n in result.notes)
 
 
-def test_query_failure_falls_back_to_body(wire_predicate, install_session_source):
+def test_query_failure_falls_back_to_body(wire_predicate, monkeypatch):
     recorded = wire_predicate(body="Closes #42")
-    install_session_source(query_exc=RuntimeError("redis down"))
+
+    def _raise(**kwargs):
+        raise RuntimeError("redis down")
+
+    monkeypatch.setattr(PipelineLedger.query, "filter", _raise)
 
     mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
 
@@ -328,9 +273,10 @@ def test_query_failure_falls_back_to_body(wire_predicate, install_session_source
     assert ("verdict", 42) in recorded
 
 
-def test_import_failure_falls_back_to_body(wire_predicate, install_session_source):
+def test_import_failure_falls_back_to_body(wire_predicate, monkeypatch, ledger_factory):
     recorded = wire_predicate(body="Closes #42")
-    install_session_source(sessions=[_session("dev-abc", 2029)], break_import=True)
+    ledger_factory(TARGET_REPO, 2029, pr_number=1)
+    monkeypatch.setitem(sys.modules, "agent.pipeline_ledger", None)
 
     mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
 
@@ -348,11 +294,11 @@ def test_group_a_missing_body_link_unchanged(wire_predicate):
     )
 
 
-def test_tracked_issue_used_even_when_body_link_missing(wire_predicate, install_session_source):
-    """When the body lacks a link but a session resolves, groups (b)/(c) still
+def test_tracked_issue_used_even_when_body_link_missing(wire_predicate, ledger_factory):
+    """When the body lacks a link but a ledger resolves, groups (b)/(c) still
     run against the tracked issue (group (a) blocks the merge regardless)."""
     recorded = wire_predicate(body="no issue link here")
-    install_session_source(sessions=[_session("dev-abc", 2029)])
+    ledger_factory(TARGET_REPO, 2029, pr_number=1)
 
     result = mp.evaluate_merge_predicate(1, repo_root=REPO_ROOT)
 

--- a/tools/merge_predicate.py
+++ b/tools/merge_predicate.py
@@ -21,17 +21,26 @@ Three check groups:
   latest commit's committer date. A bare ``"APPROVED" in text`` check is
   explicitly insufficient (#2003 critique BLOCKER 2).
 
-Tracked-issue resolution for groups (b)/(c) (#2034): the two SDLC-substrate
-checks key on the **SDLC-tracked issue derived from the PR's branch slug**, not
-the first ``Closes #N`` in the PR body. A PR that closes several sub-issues under
-an umbrella tracking issue records its DOCS marker and REVIEW verdict on the
-umbrella, so keying on the first-match body issue false-fails the gate.
-``_resolve_tracked_issue`` maps ``session/{slug}`` → the live, project-scoped
-``AgentSession`` carrying the tracked ``issue_number``; when exactly one resolves
-groups (b)/(c) use it, when none resolves they fall back to the first ``Closes
-#N`` (single-issue PRs are unchanged), and genuine ambiguity (>1 distinct tracked
-issue for the slug) **fails closed** with a named gate failure rather than
-guessing. Group (a)'s body-link presence check always uses the raw body issue.
+Tracked-issue resolution for groups (b)/(c) (#2034, corrected mechanism): the
+two SDLC-substrate checks key on the **SDLC-tracked issue looked up from the
+durable ``PipelineLedger`` by PR number**, not the first ``Closes #N`` in the PR
+body. A PR that closes several sub-issues under an umbrella tracking issue
+records its DOCS marker and REVIEW verdict on the umbrella, so keying on the
+first-match body issue false-fails the gate.
+
+An earlier mechanism (PR #2035) attempted this via ``AgentSession.query.filter(
+slug=..., issue_number=...)``, but that shape is empirically inert: ``slug`` and
+``issue_number`` are populated by disjoint creation paths and 0 live sessions
+co-populate both, so the resolver always degraded to NO_SIGNAL in production.
+``_resolve_tracked_issue`` now maps the PR number → ``PipelineLedger.query.filter(
+pr_number=...)``, scoped to the current ``target_repo`` (``gh repo view``); when
+exactly one distinct ``issue_number`` resolves, groups (b)/(c) use it; when none
+resolves they fall back to the first ``Closes #N`` (single-issue PRs are
+unchanged); and genuine ambiguity (>1 distinct tracked issue for the PR number)
+**fails closed** with a named gate failure rather than guessing. Group (a)'s
+body-link presence check always uses the raw body issue. ``pr_number`` is
+written by ``sdlc-tool meta-set --key pr_number`` at PR creation time (``/do-build``),
+so it is populated before the merge gate ever runs.
 
 Ordered detection (cycle-2 CONCERN 3): the substrate is probed FIRST as a repo
 property — present iff ``docs/sdlc/do-merge.md`` exists under the target repo
@@ -162,11 +171,12 @@ def _gh_pr_view(pr_number: int, repo_root: Path) -> dict:
     return data
 
 
-def _gh_latest_commit(pr_number: int, repo_root: Path) -> dict:
-    """Return ``{"sha": ..., "date": ...}`` for the PR's latest commit.
+def _gh_repo_name_with_owner(repo_root: Path) -> str:
+    """Resolve the target repo's ``owner/name`` slug via ``gh repo view``.
 
-    Raises on any failure — with the substrate present, missing latest-commit
-    data must fail the predicate closed, never silently pass.
+    Raises on any failure. Shared by the latest-commit lookup and the
+    PipelineLedger tracked-issue resolution (#2034), both of which need the
+    same repo-scoping value.
     """
     repo_proc = subprocess.run(
         ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
@@ -177,7 +187,16 @@ def _gh_latest_commit(pr_number: int, repo_root: Path) -> dict:
     )
     if repo_proc.returncode != 0 or not repo_proc.stdout.strip():
         raise RuntimeError("gh repo view failed while resolving repo name")
-    repo = repo_proc.stdout.strip()
+    return repo_proc.stdout.strip()
+
+
+def _gh_latest_commit(pr_number: int, repo_root: Path) -> dict:
+    """Return ``{"sha": ..., "date": ...}`` for the PR's latest commit.
+
+    Raises on any failure — with the substrate present, missing latest-commit
+    data must fail the predicate closed, never silently pass.
+    """
+    repo = _gh_repo_name_with_owner(repo_root)
     proc = subprocess.run(
         ["gh", "api", f"repos/{repo}/pulls/{pr_number}/commits", "--jq", ".[-1]"],
         capture_output=True,
@@ -288,14 +307,15 @@ def _parse_iso(value: str) -> datetime | None:
 
 
 class _TrackedOutcome(Enum):
-    """Outcome of a slug→SDLC-tracked-issue resolution.
+    """Outcome of a PR-number→SDLC-tracked-issue resolution.
 
-    - ``TRACKED``: exactly one live, project-scoped session carries the tracked
-      ``issue_number`` — groups (b)/(c) key on it.
-    - ``NO_SIGNAL``: no usable slug, no matching session, project unresolvable,
-      or a degraded import/query — the caller falls back to the body issue.
-    - ``AMBIGUOUS``: >1 distinct tracked ``issue_number`` for the slug — the
-      caller fails closed rather than guessing.
+    - ``TRACKED``: exactly one ``PipelineLedger`` record for this PR number
+      (scoped to ``target_repo``) carries the tracked ``issue_number`` —
+      groups (b)/(c) key on it.
+    - ``NO_SIGNAL``: no matching ledger, repo unresolvable, or a degraded
+      import/query — the caller falls back to the body issue.
+    - ``AMBIGUOUS``: >1 distinct tracked ``issue_number`` for the PR number —
+      the caller fails closed rather than guessing.
     """
 
     TRACKED = "tracked"
@@ -310,97 +330,91 @@ class _TrackedIssue:
     outcome: _TrackedOutcome
     issue_number: int | None = None
     note: str = ""
-    slug: str = ""
     distinct_count: int = 0
 
 
-def _resolve_tracked_issue(head_ref: str | None, repo_root: Path) -> _TrackedIssue:
-    """Resolve the SDLC-tracked issue carried by the PR's branch slug (#2034).
+def _resolve_tracked_issue(pr_number: int, repo_root: Path) -> _TrackedIssue:
+    """Resolve the SDLC-tracked issue carried by the PR's PipelineLedger record (#2034).
 
     Groups (b)/(c) must key on the umbrella tracking issue where the DOCS marker
     and REVIEW verdict actually live, not the first ``Closes #N`` in the PR body
     (which, for a multi-issue-closure PR, points at a sub-issue with no SDLC
-    substrate). This maps the branch slug to the live ``AgentSession`` carrying
-    the tracked ``issue_number``.
+    substrate). This looks up the PR number in the durable ``PipelineLedger``,
+    which is keyed by ``(target_repo, issue_number)`` and carries a unique
+    ``pr_number`` field written by ``sdlc-tool meta-set --key pr_number`` at PR
+    creation time (``/do-build``) — long before the merge gate ever runs.
+
+    An earlier mechanism (PR #2035) resolved this via
+    ``AgentSession.query.filter(slug=..., issue_number=...)``, keyed on the PR's
+    branch slug. That mechanism is empirically inert: ``slug`` and
+    ``issue_number`` are populated by disjoint AgentSession creation paths, so
+    0 of the live sessions in production co-populate both fields, and the
+    resolver always degraded to NO_SIGNAL. ``PipelineLedger.pr_number`` is a
+    single-writer, unique-per-PR field with no such gap.
 
     Resolution:
 
-    1. ``slug = _derive_slug(head_ref)``; empty/``main``/``master``/``HEAD``/
-       ``session/`` → **NO_SIGNAL** (single-issue and non-substrate branches
-       behave exactly as before).
-    2. Two broad ``except Exception`` guards (the ``sdlc_progress.py`` shape) —
-       one around the lazy imports, one around the ``AgentSession`` query. The
-       imports can raise *non-*``ImportError`` at import time (Redis/Popoto or
-       settings init); catching only ``ImportError`` would let those escape and
-       crash the merge-guard hook. Any failure degrades to **NO_SIGNAL**.
-    3. Project-scope with ``resolve_project_key(cwd=repo_root, env={})``. The
-       empty ``env`` is load-bearing: it forces cwd-only resolution and
-       neutralizes an ambient ``VALOR_PROJECT_KEY`` that worker/session-runner
-       processes inject (which would otherwise scope to the wrong project — the
-       wrong-allow direction). ``project is None`` → **NO_SIGNAL**.
-    4. Keep only live, non-transitional sessions (``NON_TERMINAL_STATUSES`` minus
-       ``superseded``/``paused_budget``) so a stale transitional session cannot
-       inflate the distinct-issue set into false ambiguity.
+    1. Lazy import of ``agent.pipeline_ledger.PipelineLedger``, guarded by a
+       broad ``except Exception`` — import-time failures include Redis/Popoto
+       client init, not just ``ImportError``. Any failure degrades to
+       **NO_SIGNAL**.
+    2. Resolve ``target_repo`` via ``_gh_repo_name_with_owner(repo_root)``,
+       guarded the same way — a ``gh`` failure degrades to **NO_SIGNAL**.
+    3. Query ``PipelineLedger.query.filter(pr_number=pr_number)``, guarded the
+       same way — a Redis outage degrades to **NO_SIGNAL**, never crashes the
+       merge-guard hook.
+    4. Keep only ledgers whose ``target_repo`` matches the resolved repo (a
+       ``pr_number`` could in principle collide across repos in a shared test
+       Redis; this keeps resolution repo-scoped in production too).
     5. Distinct non-null ``issue_number`` values across the survivors: exactly
        one → **TRACKED**; zero → **NO_SIGNAL**; more than one → **AMBIGUOUS**.
     """
-    slug = _derive_slug(head_ref or "")
-    if not slug:
-        return _TrackedIssue(_TrackedOutcome.NO_SIGNAL, note="no usable slug from PR head ref")
-
-    # Guard 1: lazy imports. Broad except — import-time failures include
-    # Redis/Popoto client init and settings validation, not just ImportError.
+    # Guard 1: lazy import. Broad except — import-time failures include
+    # Redis/Popoto client init, not just ImportError.
     try:
-        from config.project_key_resolver import resolve_project_key
-        from models.agent_session import AgentSession
-        from models.session_lifecycle import NON_TERMINAL_STATUSES
+        from agent.pipeline_ledger import PipelineLedger
     except Exception:
         return _TrackedIssue(
             _TrackedOutcome.NO_SIGNAL,
-            note="repo models unimportable; body-issue fallback",
-            slug=slug,
+            note="PipelineLedger unimportable; body-issue fallback",
         )
 
-    # Force cwd-only project resolution (env={} neutralizes VALOR_PROJECT_KEY).
-    project = resolve_project_key(cwd=str(repo_root), env={})
-    if project is None:
-        return _TrackedIssue(
-            _TrackedOutcome.NO_SIGNAL,
-            note=f"project unresolved for repo_root {repo_root}",
-            slug=slug,
-        )
-
-    # Guard 2: the Redis-backed query. Broad except — an outage degrades to the
-    # body issue, never crashes the hook.
+    # Guard 2: repo-name resolution via gh. Broad except — any gh failure
+    # degrades to the body issue, never crashes the hook.
     try:
-        sessions = list(AgentSession.query.filter(slug=slug).all())
+        target_repo = _gh_repo_name_with_owner(repo_root)
     except Exception:
         return _TrackedIssue(
             _TrackedOutcome.NO_SIGNAL,
-            note="session query failed; body-issue fallback",
-            slug=slug,
+            note="target repo unresolvable; body-issue fallback",
         )
 
-    live_statuses = NON_TERMINAL_STATUSES - {"superseded", "paused_budget"}
+    # Guard 3: the Redis-backed query. Broad except — an outage degrades to
+    # the body issue, never crashes the hook.
+    try:
+        ledgers = list(PipelineLedger.query.filter(pr_number=pr_number).all())
+    except Exception:
+        return _TrackedIssue(
+            _TrackedOutcome.NO_SIGNAL,
+            note="ledger query failed; body-issue fallback",
+        )
+
     distinct: set[int] = set()
-    for session in sessions:
-        if getattr(session, "project_key", None) != project:
+    for ledger in ledgers:
+        if getattr(ledger, "target_repo", None) != target_repo:
             continue
-        if getattr(session, "status", None) not in live_statuses:
-            continue
-        issue = getattr(session, "issue_number", None)
+        issue = getattr(ledger, "issue_number", None)
         if issue is not None:
             distinct.add(int(issue))
 
     if len(distinct) == 1:
-        return _TrackedIssue(_TrackedOutcome.TRACKED, issue_number=next(iter(distinct)), slug=slug)
+        return _TrackedIssue(_TrackedOutcome.TRACKED, issue_number=next(iter(distinct)))
     if not distinct:
         return _TrackedIssue(
             _TrackedOutcome.NO_SIGNAL,
-            note=f"no session found for slug {slug}",
-            slug=slug,
+            note=f"no PipelineLedger found for pr_number {pr_number}",
         )
-    return _TrackedIssue(_TrackedOutcome.AMBIGUOUS, slug=slug, distinct_count=len(distinct))
+    return _TrackedIssue(_TrackedOutcome.AMBIGUOUS, distinct_count=len(distinct))
 
 
 # ---------------------------------------------------------------------------
@@ -598,16 +612,17 @@ def evaluate_merge_predicate(pr_number: int, repo_root: Path | None = None) -> P
         notes.append(note)
         logger.info("merge_predicate: %s", note)
     else:
-        # Groups (b)/(c) key on the SDLC-tracked issue derived from the branch
-        # slug (#2034), not the first-match body ``Closes #N``. Group (a)'s
-        # body-link presence check (in _check_pr_state) is unaffected.
-        tracked = _resolve_tracked_issue(head_ref, root)
+        # Groups (b)/(c) key on the SDLC-tracked issue resolved from the
+        # PipelineLedger by PR number (#2034), not the first-match body
+        # ``Closes #N``. Group (a)'s body-link presence check (in
+        # _check_pr_state) is unaffected.
+        tracked = _resolve_tracked_issue(pr_number, root)
         if tracked.outcome is _TrackedOutcome.AMBIGUOUS:
             # Fail closed: refuse to guess which issue carries the substrate.
             failed.append(
                 f"tracked-issue lookup ambiguous: {tracked.distinct_count} distinct"
-                f" issues for branch slug {tracked.slug!r}; cannot determine which"
-                " issue carries the SDLC substrate"
+                f" issues for PR #{pr_number}; cannot determine which issue"
+                " carries the SDLC substrate"
             )
         else:
             if tracked.outcome is _TrackedOutcome.TRACKED:
@@ -615,12 +630,12 @@ def evaluate_merge_predicate(pr_number: int, repo_root: Path | None = None) -> P
                 if issue_number is None:
                     notes.append(
                         f"substrate checks keyed on SDLC-tracked issue #{effective_issue}"
-                        " (branch slug)"
+                        " (PipelineLedger pr_number lookup)"
                     )
                 elif effective_issue != issue_number:
                     notes.append(
                         f"substrate checks keyed on SDLC-tracked issue #{effective_issue}"
-                        f" (branch slug), not first Closes #{issue_number}"
+                        f" (PipelineLedger pr_number lookup), not first Closes #{issue_number}"
                     )
             else:  # NO_SIGNAL — fall back to the body-parsed issue (today's path).
                 effective_issue = issue_number


### PR DESCRIPTION
Closes #2034

Supersedes the inert PR #2035 slug-based mechanism with a PipelineLedger-by-pr_number lookup.

## Background

PR #2035 shipped a fix for #2034 that resolves the SDLC-tracked umbrella issue via `AgentSession.query.filter(slug=..., issue_number=...)`. That mechanism is **empirically inert** in production: `slug` and `issue_number` are populated by disjoint AgentSession creation paths, and 0 of 267 live sessions co-populate both fields. On the repro case (multi-issue PR #2033, branch `session/sdlc-router-convergence-redesign`, umbrella issue #2029), `filter(slug=...)` returns 0 rows, so the resolver always degrades to NO_SIGNAL and the predicate falls back to the first `Closes #N` (#1871) — reproducing the exact false merge-gate failure #2034 reports (`no recorded REVIEW verdict`, `DOCS marker not authoritative`).

## The fix

Key `_resolve_tracked_issue` on the **PR number** via the durable `PipelineLedger` instead of the branch slug:

```python
from agent.pipeline_ledger import PipelineLedger
PipelineLedger.query.filter(pr_number=pr_number)  # scoped to target_repo
```

Verified live on the repro:
- `PipelineLedger.query.filter(pr_number=2033)` returns **exactly one row** with `issue_number=2029`, `target_repo='tomcounsell/ai'` — the umbrella issue where PR #2033's REVIEW verdict and DOCS marker actually live.
- `pr_number` is **unique across all 187 ledgers** (no collisions).
- `pr_number` is written by `sdlc-tool meta-set --key pr_number` at PR creation time (`/do-build`), so it's populated well before the merge gate ever runs.

The tri-state resolution semantics (TRACKED / NO_SIGNAL / AMBIGUOUS) and fail-safe fallback/fail-closed behavior from #2034's design are preserved exactly — only the resolution key changed from branch-slug→AgentSession to PR-number→PipelineLedger. The `_resolve_tracked_issue` signature changed from `(head_ref, repo_root)` to `(pr_number, repo_root)`; the dead slug-derivation call site and the `AgentSession`/`resolve_project_key`/`NON_TERMINAL_STATUSES` imports inside the resolver were removed (the `_derive_slug` helper itself is kept — it's still used by the unrelated DOCS-stage `docs/features/{slug}.md` fallback).

## Tests

Rebuilt `tests/unit/test_merge_predicate.py` around **real, production-shaped `PipelineLedger` records** (via `get_or_create`, under the autouse `redis_test_db` fixture — mirrors `tests/unit/test_pipeline_ledger.py`), replacing the old monkeypatched `AgentSession` slug+issue_number shape that occurs 0x in production. The suite never constructs an `AgentSession` fixture at all now, so it structurally cannot pass if the resolver reverts to the inert mechanism.

- Core regression case reproduces PR #2033 exactly: a `PipelineLedger` for umbrella issue 2029 with `pr_number=2033`, body `Closes #1871\nCloses #1267\nCloses #1760` — asserts groups (b)/(c) key on 2029, not the first-match 1871.
- Explicit NO-OP-FAILS case: no ledger for the PR number → resolver returns NO_SIGNAL → predicate falls back to the first `Closes #N`.
- Tri-state, single-issue-invariance, cross-repo-collision, guard-degradation (import/query/repo-unresolvable), and fail-closed-ambiguity cases carried forward and adapted to the new key.

```
tools/merge_predicate.py + tests/unit/test_merge_predicate.py:
17 passed (test_merge_predicate.py alone)
42 passed (test_merge_predicate.py + test_validate_merge_guard.py)
```

`python -m black tools/merge_predicate.py tests/unit/test_merge_predicate.py` — clean, no further diffs.

## Scope

Touches only `tools/merge_predicate.py` and `tests/unit/test_merge_predicate.py`, per the corrective-bugfix scope fence. `agent/pipeline_ledger.py` is read-only (imported, not modified).

## Test plan
- [x] `pytest tests/unit/test_merge_predicate.py tests/unit/test_validate_merge_guard.py -q` — 42 passed
- [x] `python -m black tools/merge_predicate.py tests/unit/test_merge_predicate.py` — clean