### PR TITLE
fix(update): use npm ci --omit=dev instead of deprecated --only=prod

### DIFF
--- a/scripts/remote-update.sh
+++ b/scripts/remote-update.sh
@@ -122,7 +122,7 @@ fi
 # non-pipefail subshell so a missing npm or a transient install failure
 # cannot abort the parent update script.
 if [ -f "$PROJECT_DIR/package.json" ] && command -v npm >/dev/null 2>&1; then
-    ( set +o pipefail; cd "$PROJECT_DIR" && npm ci --only=prod ) || echo "[update] npm ci failed (non-fatal); continuing"
+    ( set +o pipefail; cd "$PROJECT_DIR" && npm ci --omit=dev ) || echo "[update] npm ci failed (non-fatal); continuing"
 fi
 
 # ── Run update in cron mode ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

On "Valor the Bald", `/update` completed successfully but reported an npm config warning on the design-system Node toolchain sync step:

```
npm warn config only Use `--omit=dev` to omit dev dependencies from the install.
```

Root cause: `scripts/remote-update.sh:125` ran `npm ci --only=prod`. npm deprecated the `--only` flag in favor of `--omit`. Switch to `npm ci --omit=dev` — same effect (install prod deps only), no warning.

## Scope note

This PR fixes only the one actionable npm warning. Two other warnings from the same run are intentionally NOT addressed because they are benign:

- **`npm warn deprecated mdast@3.0.0`** — transitive dependency of `@google/design.md@0.1.1` (a pinned third-party package). Not fixable in our config; mdast still works (just renamed to remark upstream).
- **gws auth not authenticated** — working as designed (`scripts/update/gws_auth.py` returns `success=True, action="needs_auth"`). Human-gated one-time OAuth step; a human runs `gws auth setup --login` on the machine.

The fourth warning (`[cyndra] README missing '## Running' section`) is fixed in a separate repo: Cyndra-AI/cyndra-consulting#58.

## Test

Shell one-liner change to a deploy script; no unit tests cover `remote-update.sh` directly. Verified `--omit=dev` is the current npm-supported replacement via `npm help ci`. The npm invocation is already wrapped in a non-pipefail subshell with a non-fatal fallback, so behavior on failure is unchanged.