### PR TITLE
Gate bridge Redis storage to machine-owned chats (cache, not archive)

### DIFF
--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -1076,6 +1076,20 @@ async def check_message_query_request(client: TelegramClient) -> None:
             logger.warning(f"Failed to delete request file: {e}")
 
 
+def should_store_inbound(early_project_key: str | None, sender_id: int | None) -> bool:
+    """Store to Redis only for machine-owned chats, plus registered bots.
+
+    early_project_key is None exactly when this machine owns no project for the
+    chat (every resolution map is built over ACTIVE_PROJECTS). Registered bots
+    resolve via find_project_for_bot, not chat/DM resolution, so their
+    early_project_key is often None — they must still be stored so the
+    valor-telegram --await-reply awaiter can poll recorded history (#1574).
+    """
+    if early_project_key is not None:
+        return True
+    return bool(sender_id and find_project_for_bot(sender_id) is not None)
+
+
 async def main():
     """Main entry point."""
     if not API_ID or not API_HASH:
@@ -1216,46 +1230,52 @@ async def main():
         else:
             project = find_project_for_chat(chat_title) if chat_title else None
 
-        # Store ALL incoming messages for history (regardless of whether we respond).
-        # Conversation history (store_message / register_chat) is preserved for unowned
-        # chats by passing project_key=None — both functions accept str | None. Only the
-        # canonical Memory partition write below is gated on a resolved project, since
-        # that's the actual leak surface (#1173 — the retired "dm" namespace must never
-        # be written to again).
+        # Store inbound messages to Redis only for machine-owned chats, plus
+        # registered bots (needed for the valor-telegram --await-reply E2E flow,
+        # #1574). Unowned chats are never persisted here — they're read-through
+        # from the Telegram API on demand instead (#2020). Conversation history
+        # (store_message / register_chat) is preserved for owned-but-unresolved
+        # cases by passing project_key=None where applicable — both functions
+        # accept str | None. The canonical Memory partition write below remains
+        # separately gated on a resolved project (#1173 — the retired "dm"
+        # namespace must never be written to again).
         _early_project_key = project.get("_key") if project else None
         stored_msg_id = None  # Track for telegram_message_key cross-reference
-        try:
-            # sdlc-1179: persist safe_text so wrapped <private> regions never
-            # land in TelegramMessage.content (and therefore never surface via
-            # `valor-telegram read --search` or the conversation-history prefetch).
-            store_result = store_message(
-                chat_id=str(event.chat_id),
-                content=safe_text,
-                sender=sender_name,
-                message_id=message.id,
-                timestamp=message.date,
-                message_type=("text" if not message.media else get_media_type(message) or "media"),
-                project_key=_early_project_key,
-                has_media=bool(message.media),
-                media_type=get_media_type(message) if message.media else None,
-                reply_to_msg_id=message.reply_to_msg_id,
-            )
-            if store_result.get("stored"):
-                stored_msg_id = store_result.get("id")
-                logger.debug(f"Stored message {message.id} from {sender_name}")
-                # Register chat mapping for CLI lookup
-                if chat_title:
-                    chat_type = "private" if is_dm else "group"
-                    register_chat(
-                        chat_id=str(event.chat_id),
-                        chat_name=chat_title,
-                        chat_type=chat_type,
-                        project_key=_early_project_key,
-                    )
-            elif store_result.get("error"):
-                logger.warning(f"Failed to store message: {store_result['error']}")
-        except Exception as e:
-            logger.error(f"Error storing message: {e}")
+        if should_store_inbound(_early_project_key, sender_id):
+            try:
+                # sdlc-1179: persist safe_text so wrapped <private> regions never
+                # land in TelegramMessage.content (and therefore never surface via
+                # `valor-telegram read --search` or the conversation-history prefetch).
+                store_result = store_message(
+                    chat_id=str(event.chat_id),
+                    content=safe_text,
+                    sender=sender_name,
+                    message_id=message.id,
+                    timestamp=message.date,
+                    message_type=(
+                        "text" if not message.media else get_media_type(message) or "media"
+                    ),
+                    project_key=_early_project_key,
+                    has_media=bool(message.media),
+                    media_type=get_media_type(message) if message.media else None,
+                    reply_to_msg_id=message.reply_to_msg_id,
+                )
+                if store_result.get("stored"):
+                    stored_msg_id = store_result.get("id")
+                    logger.debug(f"Stored message {message.id} from {sender_name}")
+                    # Register chat mapping for CLI lookup
+                    if chat_title:
+                        chat_type = "private" if is_dm else "group"
+                        register_chat(
+                            chat_id=str(event.chat_id),
+                            chat_name=chat_title,
+                            chat_type=chat_type,
+                            project_key=_early_project_key,
+                        )
+                elif store_result.get("error"):
+                    logger.warning(f"Failed to store message: {store_result['error']}")
+            except Exception as e:
+                logger.error(f"Error storing message: {e}")
 
         # Deterministic registered-bot loop-guard (issue #1574). A message from a
         # registered bot peer is recorded to history (above) but MUST NEVER spawn a

--- a/docs/features/single-machine-ownership.md
+++ b/docs/features/single-machine-ownership.md
@@ -89,7 +89,7 @@ A bad config never reaches a bridge restart, so the rule cannot be violated at r
 
 The single-machine-ownership rule applies to memory persistence as well as response routing. Following PR #1173 (the bridge `dm`-namespace writer leak), the Telegram bridge now treats an incoming message in three layers:
 
-1. **Conversation history** (`store_message`, `register_chat`): always recorded, even when the chat doesn't resolve to any declared project. Pass `project_key=None` — both functions accept it. This is what `valor-telegram read` reads from.
+1. **Conversation history** (`store_message`, `register_chat`): gated on ownership (issue #2020) — recorded only when the chat resolves to a project on this machine, or the sender is a registered bot (`should_store_inbound`, preserving the `--await-reply` carve-out from #1574). Unowned chats are no longer written to Redis at all; `valor-telegram read` falls back live to the Telegram/Telethon API for them. See [Telegram History — Cache-not-archive model](telegram-history.md#cache-not-archive-model).
 2. **Canonical Memory partition write** (`Memory.safe_save`): gated on a resolved project. If no project resolves (sender not whitelisted, group title not declared on this machine), the canonical memory write is skipped entirely. Unowned messages no longer pollute any partition.
 3. **Session creation**: hard early-return if no project resolves. The `:1003` guard in `bridge/telegram_bridge.py` makes this explicit and prevents the latent NameError class problem from the previous `else "dm"` fallback.
 

--- a/docs/features/telegram-history.md
+++ b/docs/features/telegram-history.md
@@ -4,6 +4,7 @@
 **Created**: 2026-01-19
 **Implemented**: 2026-01-20
 **Backend migrated to Redis**: 2026-02-24
+**Storage gated to owned chats**: 2026-07 (issue #2020)
 
 ---
 
@@ -11,9 +12,23 @@
 
 The Telegram History & Link Collection feature provides:
 
-1. **Full message history** - All incoming Telegram messages are stored in Redis via Popoto
+1. **Message history (cache, not archive)** - Incoming messages **from machine-owned chats** (plus registered-bot messages) are stored in Redis via Popoto; unowned chats are read-through from the Telegram API on demand
 2. **Link collection** - URLs from whitelisted users are automatically extracted and stored with metadata
 3. **Chat registry** - Chat ID to name mappings maintained in Redis
+
+### Cache-not-archive model
+
+Redis is a **working-set cache** for machine-owned chats, not a durable archive of every Telegram message this machine ever sees. Telegram itself remains the complete, durable source of truth for chats this machine doesn't own.
+
+- **Machine-owned chats** (any chat resolving to a project this machine serves, per [Single-Machine Ownership](single-machine-ownership.md)) have every inbound message written to `TelegramMessage` as before.
+- **Registered bots** (`projects.<key>.telegram.bots[]`) are also stored even when they resolve no owned project, because `valor-telegram send --await-reply` polls recorded history to detect a bot's settled reply (issue #1574).
+- **Unowned chats** — large group chats with no project configured on this machine — are no longer written to Redis at all. `valor-telegram read` falls back live to the Telegram/Telethon API for these chats, so history is still available, just not cached locally.
+
+The gating predicate is `should_store_inbound(early_project_key, sender_id)` in `bridge/telegram_bridge.py`: it returns `True` if the chat already resolved to an owned project (`early_project_key is not None`), or if the sender is a registered bot (`find_project_for_bot(sender_id) is not None`). Otherwise the message is processed (responses, reactions, etc. still work) but never persisted to `TelegramMessage`. See issue #2020 for the gating rationale and #1574 for the bot carve-out.
+
+### Retention unchanged
+
+Gating storage collapses the volume of stored messages to just the machine's owned chats, which is what makes the existing 90-day TTL and the daily `redis-ttl-cleanup` sweep sensible again — TTL sweep cost and memory footprint now scale with owned-chat volume, not with every chat this machine happens to observe. The TTL value itself was **not** changed by this work; see Data Retention below.
 
 ## Architecture
 
@@ -55,7 +70,7 @@ All data is stored in **Redis** via Popoto ORM models. SQLite was removed as of 
 
 ### Data Retention
 
-- Redis models: 90-day TTL, cleaned by the `redis-ttl-cleanup` reflection (`reflections.maintenance.run_redis_ttl_cleanup`)
+- Redis models: 90-day TTL, cleaned by the `redis-ttl-cleanup` reflection (`reflections.maintenance.run_redis_ttl_cleanup`) — **unchanged** by the storage-gating work in #2020; only the volume of chats eligible for storage changed
 - No SQLite backup after 2026-02-24 migration
 
 ## Configuration
@@ -228,9 +243,9 @@ link = get_link_by_url("https://example.com", max_age_hours=24)
 
 The Telegram bridge (`bridge/telegram_bridge.py`) automatically:
 
-1. **Stores all incoming messages** - Every message the bridge receives is stored directly in Redis
+1. **Stores messages from owned chats (plus registered bots)** - Gated by `should_store_inbound()`; unowned chats are read-through from the Telegram API instead of stored (see Cache-not-archive model above)
 2. **Extracts and stores links** - URLs from users in `TELEGRAM_LINK_COLLECTORS` are automatically saved
-3. **Registers chats** - `register_chat()` called on each message to maintain the chat registry
+3. **Registers chats** - `register_chat()` called on each stored message to maintain the chat registry
 4. **Stores full responses** - Valor's responses stored with no character cap
 
 ## Testing

--- a/tests/unit/test_should_store_inbound.py
+++ b/tests/unit/test_should_store_inbound.py
@@ -1,0 +1,38 @@
+"""Unit tests for bridge.telegram_bridge.should_store_inbound (issue #2020).
+
+should_store_inbound gates Redis persistence of inbound Telegram messages to
+machine-owned chats, plus a carve-out for registered bots (needed for the
+valor-telegram --await-reply E2E flow, issue #1574).
+"""
+
+from bridge.telegram_bridge import should_store_inbound
+
+
+def test_owned_project_key_stores_regardless_of_sender(monkeypatch):
+    """A resolved (non-None) early_project_key always means store."""
+    monkeypatch.setattr("bridge.telegram_bridge.find_project_for_bot", lambda sender_id: None)
+    assert should_store_inbound("psyoptimal", None) is True
+    assert should_store_inbound("psyoptimal", 12345) is True
+
+
+def test_unowned_chat_with_no_sender_does_not_store(monkeypatch):
+    monkeypatch.setattr("bridge.telegram_bridge.find_project_for_bot", lambda sender_id: None)
+    assert should_store_inbound(None, None) is False
+
+
+def test_unowned_chat_with_unregistered_sender_does_not_store(monkeypatch):
+    monkeypatch.setattr("bridge.telegram_bridge.find_project_for_bot", lambda sender_id: None)
+    assert should_store_inbound(None, 99999) is False
+
+
+def test_unowned_chat_with_registered_bot_sender_stores(monkeypatch):
+    monkeypatch.setattr(
+        "bridge.telegram_bridge.find_project_for_bot",
+        lambda sender_id: {"_key": "some-project"} if sender_id == 8837490628 else None,
+    )
+    assert should_store_inbound(None, 8837490628) is True
+
+
+def test_never_raises_on_none_none(monkeypatch):
+    monkeypatch.setattr("bridge.telegram_bridge.find_project_for_bot", lambda sender_id: None)
+    assert should_store_inbound(None, None) is False


### PR DESCRIPTION
## Summary
- Add `should_store_inbound(early_project_key, sender_id)` predicate in `bridge/telegram_bridge.py` that returns `True` for machine-owned chats or registered-bot senders, `False` otherwise.
- Gate the inbound `store_message` + `register_chat` pair in the `NewMessage` handler on this predicate. Unowned chats (large group chats no project on this machine serves) no longer get written to Redis; they become read-through via the Telegram/Telethon API (`valor-telegram read` already falls back there for cache misses).
- The `stored_msg_id = None` init stays unconditional, outside the new guard, so downstream `None`-safe consumers are unaffected.
- Retention decision: keep the existing 90-day TTL on `TelegramMessage` (no change to `models/telegram.py` or `config/reflections.yaml`) — gating storage removes the volume that made the daily `cleanup_expired` sweep slow, so the existing TTL sweep remains adequate.
- Preserves the registered-bot carve-out from #1574 so `valor-telegram send --await-reply` continues to work (bot messages are still stored so the awaiter can poll recorded history).
- Docs: `docs/features/telegram-history.md` now states the cache-not-archive model explicitly.

Closes #2020

## Test plan
- [x] `pytest tests/unit/test_should_store_inbound.py -q` — 5/5 pass, covers all four predicate branches (owned / unowned+no-sender / unowned+unregistered-bot / unowned+registered-bot) plus a never-raises assertion on `(None, None)`.
- [x] `pytest tests/integration/test_bot_loop_guard.py -q` — passes unchanged.
- [x] `pytest tests/integration/test_bot_await_reply.py -q` — flaky live-E2E test (polls a real bot over Telegram with a 15s window); confirmed the same timeout failure reproduces identically on unmodified `main` HEAD, so it's a pre-existing environmental flake, not a regression from this change.
- [x] Verification table from the plan: predicate exists, gate call site exists, `stored_msg_id` init precedes the guard, stale "Store ALL incoming messages" comment removed, `models/telegram.py`/`config/reflections.yaml`/`bridge/routing.py` untouched, outbound reply-store call site untouched, `ruff check`/`ruff format --check` clean, docs mention "cache".

🤖 Generated with [Claude Code](https://claude.com/claude-code)