### PR TITLE
Fix sms_reader /update check: degrade Full Disk Access failure to a clean warning

### DIFF
--- a/scripts/update/verify.py
+++ b/scripts/update/verify.py
@@ -276,6 +276,53 @@ def check_dev_tools(project_dir: Path) -> list[ToolCheck]:
     return [check_venv_tool(project_dir, tool) for tool in tools]
 
 
+# Substrings that mark the sms_reader CLI failing because of an environment
+# condition the operator resolves once (macOS TCC), NOT a code regression:
+#   - Full Disk Access not granted to the process running /update
+#   - Messages app never used, so ~/Library/Messages/chat.db is absent
+# Both are surfaced by SMSReaderError as a single clean line via cli.py.
+_SMS_READER_ENV_MARKERS = (
+    "full disk access",
+    "messages database not found",
+)
+
+
+def _classify_sms_reader(result: subprocess.CompletedProcess) -> ToolCheck:
+    """Turn an ``sms_reader.cli recent`` run into a ToolCheck.
+
+    macOS gates the Messages database behind Full Disk Access (a per-machine,
+    one-time human grant — like the ``gws auth`` OAuth step). On a machine
+    without it, the CLI exits non-zero with a clean one-line SMSReaderError
+    message. Treat that as a clean, actionable one-line WARNING (mirroring the
+    ``gws auth`` line) instead of dumping a raw Python traceback into the
+    /update output.
+
+    Any other non-zero exit is a genuine failure: also reported as
+    ``available=False`` but with the first stderr line only (never the full
+    multi-line traceback).
+    """
+    if result.returncode == 0:
+        return ToolCheck(name="sms_reader", available=True)
+
+    stderr = (result.stderr or "").strip()
+    first_line = stderr.splitlines()[0] if stderr else "no error output"
+    lowered = stderr.lower()
+
+    if any(marker in lowered for marker in _SMS_READER_ENV_MARKERS):
+        # Environment condition, not a bug — collapse to one actionable line.
+        return ToolCheck(
+            name="sms_reader",
+            available=False,
+            error=(
+                "Full Disk Access not granted (macOS Messages DB unreadable) — "
+                "grant it in System Settings > Privacy & Security > Full Disk "
+                "Access, then re-run /update"
+            ),
+        )
+
+    return ToolCheck(name="sms_reader", available=False, error=first_line)
+
+
 def check_valor_tools(project_dir: Path) -> list[ToolCheck]:
     """Check Valor-specific CLI tools."""
     results = []
@@ -296,15 +343,25 @@ def check_valor_tools(project_dir: Path) -> list[ToolCheck]:
                 cwd=project_dir,
                 timeout=10,
             )
+            results.append(_classify_sms_reader(result))
+        except subprocess.TimeoutExpired:
             results.append(
                 ToolCheck(
                     name="sms_reader",
-                    available=result.returncode == 0,
-                    error=result.stderr.strip() if result.returncode != 0 else None,
+                    available=False,
+                    error="timed out reading Messages DB (>10s)",
                 )
             )
         except Exception as e:
-            results.append(ToolCheck(name="sms_reader", available=False, error=str(e)))
+            # Never let an unexpected error dump a multi-line traceback into
+            # the /update warning line — keep it to the first line.
+            results.append(
+                ToolCheck(
+                    name="sms_reader",
+                    available=False,
+                    error=str(e).splitlines()[0] if str(e) else "unknown error",
+                )
+            )
 
     # valor-calendar - check multiple locations
     calendar_found = False

--- a/tests/unit/test_update_sms_reader_check.py
+++ b/tests/unit/test_update_sms_reader_check.py
@@ -1,0 +1,120 @@
+"""Tests for the sms_reader health check in scripts/update/verify.py.
+
+Context: on a machine without macOS Full Disk Access, the process running
+/update cannot open ~/Library/Messages/chat.db. The sms_reader package raises
+a clean SMSReaderError, but historically the CLI let it propagate as a raw
+multi-line Python traceback, and verify.py captured that whole traceback into
+the /update warning line (which then got truncated in the report).
+
+The fix keeps the check honest but tidy:
+- tools/sms_reader/cli.py catches SMSReaderError and prints ONE actionable line.
+- verify._classify_sms_reader() turns the CLI result into a ToolCheck, degrading
+  the known Full-Disk-Access / DB-not-found environment condition to a clean,
+  single-line WARNING (like the `gws auth` line) and never surfacing a raw
+  traceback for any other failure either.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from scripts.update.verify import _classify_sms_reader
+
+
+def _completed(returncode: int, stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=["python", "-m", "tools.sms_reader.cli", "recent", "--limit", "1"],
+        returncode=returncode,
+        stdout="",
+        stderr=stderr,
+    )
+
+
+class TestClassifySmsReader:
+    def test_success_is_available(self) -> None:
+        """A zero exit means the Messages DB was read — tool is available."""
+        check = _classify_sms_reader(_completed(0, stderr=""))
+        assert check.name == "sms_reader"
+        assert check.available is True
+        assert check.error is None
+
+    def test_full_disk_access_degrades_to_clean_one_liner(self) -> None:
+        """Full Disk Access condition → single actionable line, no traceback."""
+        stderr = (
+            "sms_reader unavailable: Cannot open Messages database. Grant Full "
+            "Disk Access to your terminal. System Preferences > Security & "
+            "Privacy > Privacy > Full Disk Access"
+        )
+        check = _classify_sms_reader(_completed(1, stderr=stderr))
+        assert check.available is False
+        assert check.error is not None
+        # Exactly one line — never a multi-line traceback dump.
+        assert "\n" not in check.error
+        assert "Full Disk Access" in check.error
+        assert "Traceback" not in check.error
+
+    def test_db_not_found_degrades_to_clean_one_liner(self) -> None:
+        """Missing chat.db (Messages never used) → clean single-line warning."""
+        stderr = (
+            "sms_reader unavailable: Messages database not found at "
+            "/Users/x/Library/Messages/chat.db. Make sure Messages app has "
+            "been used."
+        )
+        check = _classify_sms_reader(_completed(1, stderr=stderr))
+        assert check.available is False
+        assert check.error is not None
+        assert "\n" not in check.error
+        assert "Full Disk Access" in check.error
+
+    def test_raw_traceback_is_collapsed_to_first_line(self) -> None:
+        """Even an unexpected multi-line stderr must never dump a traceback."""
+        stderr = (
+            "Traceback (most recent call last):\n"
+            '  File "/Users/x/tools/sms_reader/__init__.py", line 107\n'
+            "    conn = sqlite3.connect(...)\n"
+            "sqlite3.OperationalError: something unexpected"
+        )
+        check = _classify_sms_reader(_completed(1, stderr=stderr))
+        assert check.available is False
+        assert check.error is not None
+        assert "\n" not in check.error
+        # Genuine failures keep only the first stderr line for triage.
+        assert check.error == "Traceback (most recent call last):"
+
+    def test_empty_stderr_failure_has_placeholder(self) -> None:
+        """A non-zero exit with no stderr still yields a usable one-liner."""
+        check = _classify_sms_reader(_completed(1, stderr=""))
+        assert check.available is False
+        assert check.error == "no error output"
+
+
+class TestCliCleanError:
+    """The CLI itself must emit one clean line for SMSReaderError, not a trace."""
+
+    def test_cli_prints_single_line_for_sms_reader_error(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import tools.sms_reader.cli as cli
+
+        def _boom(*args, **kwargs):
+            raise cli.SMSReaderError(
+                "Cannot open Messages database. Grant Full Disk Access.",
+                category="permission_denied",
+            )
+
+        monkeypatch.setattr(cli, "get_recent_messages", _boom)
+        monkeypatch.setattr(sys, "argv", ["sms", "recent", "--limit", "1"])
+
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+
+        assert exc.value.code == 1
+        captured = capsys.readouterr()
+        assert "Traceback" not in captured.err
+        # Single actionable line on stderr.
+        assert captured.err.strip().count("\n") == 0
+        assert "sms_reader unavailable" in captured.err
+        assert "Full Disk Access" in captured.err

--- a/tools/sms_reader/cli.py
+++ b/tools/sms_reader/cli.py
@@ -6,6 +6,7 @@ import json
 import sys
 
 from tools.sms_reader import (
+    SMSReaderError,
     get_2fa,
     get_latest_2fa_code,
     get_recent_messages,
@@ -42,6 +43,18 @@ def main():
 
     args = parser.parse_args()
 
+    try:
+        _dispatch(args)
+    except SMSReaderError as e:
+        # Emit a single clean, actionable line instead of a raw traceback.
+        # SMSReaderError already carries a human-readable, category-tagged
+        # message (e.g. Full Disk Access not granted, or DB not found), so
+        # callers like scripts/update/verify.py can surface a tidy warning.
+        print(f"sms_reader unavailable: {e.message}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _dispatch(args) -> None:
     if args.command == "2fa":
         if args.detailed:
             result = get_latest_2fa_code(minutes=args.minutes, sender=args.sender)

--- a/tools/sms_reader/tests/test_sms_reader.py
+++ b/tools/sms_reader/tests/test_sms_reader.py
@@ -18,6 +18,8 @@ get_recent_messages = sms_reader.get_recent_messages
 list_senders = sms_reader.list_senders
 get_latest_2fa_code = sms_reader.get_latest_2fa_code
 MESSAGES_DB_PATH = sms_reader.MESSAGES_DB_PATH
+SMSReaderError = sms_reader.SMSReaderError
+_get_db_connection = sms_reader._get_db_connection
 
 
 class TestCodeExtraction:
@@ -99,9 +101,11 @@ class TestAppleTimeConversion:
 
     def test_roundtrip_conversion(self):
         """Test that conversion roundtrips correctly."""
-        from datetime import datetime
+        from datetime import UTC, datetime
 
-        original = datetime(2024, 6, 15, 12, 30, 45)
+        # _apple_time_to_datetime returns a tz-aware UTC datetime, so the
+        # original must also be tz-aware or the subtraction raises TypeError.
+        original = datetime(2024, 6, 15, 12, 30, 45, tzinfo=UTC)
         apple_time = _datetime_to_apple_time(original)
         recovered = _apple_time_to_datetime(apple_time)
         assert recovered is not None
@@ -119,9 +123,22 @@ class TestDatabaseAccess:
 
     @pytest.fixture
     def db_available(self):
-        """Check if Messages database is available."""
+        """Skip unless the Messages database can actually be opened.
+
+        Checking ``MESSAGES_DB_PATH.exists()`` is not enough: on a machine
+        without Full Disk Access the file's metadata is visible (``exists()``
+        is True) but macOS TCC blocks opening it, so a real query raises
+        SMSReaderError. Probe an actual read-only connection and skip on any
+        SMSReaderError so these integration tests don't fail on CI or on
+        developer machines that never granted Full Disk Access.
+        """
         if not MESSAGES_DB_PATH.exists():
             pytest.skip("Messages database not found")
+        try:
+            conn = _get_db_connection()
+            conn.close()
+        except SMSReaderError as e:
+            pytest.skip(f"Messages database not accessible: {e}")
         return True
 
     def test_get_recent_messages(self, db_available):


### PR DESCRIPTION
## Problem

On the *Valor the Bald* machine, running `/update` dumped a raw, truncated Python traceback into the report:

```
⚠️ sms_reader: Traceback (most recent call last):
  File "/Users/valorengels
```

The `/update` health check runs `python -m tools.sms_reader.cli recent --limit 1`. On a machine without macOS **Full Disk Access**, that CLI cannot open `~/Library/Messages/chat.db`, and the raw traceback propagated all the way into `verify.py`, which captured the whole multi-line stderr into the single-line `/update` warning (then truncated).

## Root cause

**Environment condition, not a code bug.** macOS TCC gates the Messages DB behind Full Disk Access — a one-time human grant, exactly like the `gws auth` OAuth step. The file's metadata is visible (`path.exists()` is `True`) but the process cannot *open* it, so `_get_db_connection` correctly raises a clean, category-tagged `SMSReaderError`. The defect was purely in how that error was **surfaced**:

1. `cli.py main()` did not catch `SMSReaderError`, so Python printed the full raw traceback.
2. `verify.check_valor_tools` captured `result.stderr` verbatim, so the whole traceback became the warning string.

Full captured traceback ends in:
```
tools.sms_reader.SMSReaderError: Cannot open Messages database. Grant Full Disk Access to your terminal. ...
```

## Fix

- **`tools/sms_reader/cli.py`** — catch `SMSReaderError` in `main()` and print ONE actionable line to stderr (exit 1) instead of a traceback. Defense in depth for every caller, not just `/update`.
- **`scripts/update/verify.py`** — new `_classify_sms_reader()` turns the CLI result into a `ToolCheck`: the known Full-Disk-Access / DB-not-found environment condition degrades to a clean, single-line warning (mirroring the `gws auth` line); any other failure keeps only the first stderr line, so a traceback can never be dumped again. Timeouts get a dedicated message.
- **`tools/sms_reader/tests/test_sms_reader.py`** — the `db_available` fixture now probes a real read-only connection and *skips* on `SMSReaderError`, so integration tests skip (not fail) when Full Disk Access is absent. Also fixes `test_roundtrip_conversion`, which was failing with `TypeError: can't subtract offset-naive and offset-aware datetimes` (the converter returns tz-aware UTC; the test's original datetime was naive).
- **`tests/unit/test_update_sms_reader_check.py`** — new unit tests for `_classify_sms_reader` (success / FDA / DB-not-found / raw-traceback / empty-stderr) and the CLI's clean single-line handling.

## Verification

- `tests/unit/test_update_sms_reader_check.py` + `tools/sms_reader/tests/test_sms_reader.py`: **22 passed, 3 skipped** (DB-access tests cleanly skip on this FDA-less machine).
- End-to-end `check_valor_tools()` against the live FDA-less environment now yields a single clean line (0 embedded newlines):
  > `Full Disk Access not granted (macOS Messages DB unreadable) — grant it in System Settings > Privacy & Security > Full Disk Access, then re-run /update`
- `ruff format --check`: all files clean.

The `gws auth` warning in the same `/update` run is expected (one-time human OAuth) and is intentionally left untouched.

Closes #2074
