### PR TITLE
Fix sms_reader CLI leaking a traceback instead of an actionable error

### DIFF
--- a/docs/plans/sms-reader-clean-error.md
+++ b/docs/plans/sms-reader-clean-error.md
@@ -1,0 +1,150 @@
+# sms_reader CLI: clean error instead of raw traceback
+
+Issue: #2073
+Branch: session/dev-6434747e
+Labels: bug, skills
+
+## Problem
+
+On a machine without Full Disk Access to the Messages DB (or without a Messages
+DB at all), `/update`'s verifier runs `python -m tools.sms_reader.cli recent
+--limit 1`. The CLI's `main()` does not catch `SMSReaderError`, so the process
+dies with an unhandled traceback on stderr. The `/update` verifier surfaces
+stderr verbatim as the failure reason, producing the warning:
+
+```
+⚠️ sms_reader: Traceback (most recent call last)
+```
+
+This is useless (names no cause, no fix) and — being multi-line — buries the
+warnings printed after it in the update summary (the reason "Valor the Pirate"'s
+3-warning run only showed 2 lines when pasted).
+
+## Freshness Check
+
+- `tools/sms_reader/cli.py` — current `main()` dispatches directly, no error trap.
+- `scripts/update/verify.py::check_valor_tools` (lines ~283-307) — runs the CLI,
+  stores `result.stderr.strip()` as the ToolCheck error.
+- `scripts/update/run.py` (lines ~1805-1808) — appends `{name}: {error}` per
+  unavailable valor tool to `result.warnings`.
+- `tools/sms_reader/__init__.py::SMSReaderError` — already carries a clean,
+  actionable `.message` (e.g. "Grant Full Disk Access…").
+
+## Prior Art
+
+`SMSReaderError` is raised throughout `tools/sms_reader/__init__.py` with
+category-tagged, human-readable messages. The fix simply surfaces that existing
+message cleanly instead of letting it escape as a traceback.
+
+## Data Flow
+
+`/update` → `verify.check_valor_tools` → subprocess `sms_reader.cli recent` →
+`get_recent_messages` → `_get_db_connection` raises `SMSReaderError` → (today)
+unhandled traceback on stderr → verifier stores it → run.py appends it as a
+warning. The fix inserts a `try/except SMSReaderError` at the `main()` boundary
+that converts the exception into `sms: <message>` + exit 1.
+
+## Appetite
+
+Small — a single-file bug fix plus regression tests. Under an hour.
+
+## Solution
+
+### Key Elements
+
+- Split `main()` into `_build_parser()` / `_dispatch(args)` / `main()`.
+- `main()` wraps `_dispatch()` in `try/except SMSReaderError`, printing
+  `sms: {exc.message}` to stderr and exiting 1.
+
+### Technical Approach
+
+No behavior change on the success path (JSON still printed, exit 0). On any
+`SMSReaderError` from any subcommand, stderr becomes a single actionable line and
+the exit code stays 1, so the `/update` warning reads the message verbatim.
+
+## Failure Path Test Strategy
+
+### Exception Handling Coverage
+- `SMSReaderError` from `get_recent_messages` → clean `sms: …` stderr, exit 1,
+  no traceback, no stdout.
+- `SMSReaderError` from `list_senders` → same wrapper covers all subcommands.
+
+### Empty/Invalid Input Handling
+- Success path with empty result list still prints `[]` and does not exit
+  non-zero (wrapper does not swallow normal output).
+
+### Error State Rendering
+- Assert `captured.err` equals the exact `sms: <message>` string and contains no
+  "Traceback".
+
+## Test Impact
+No existing tests affected — `tools/sms_reader/cli.py` had no prior test module;
+this adds `tests/unit/test_sms_reader_cli.py` as greenfield coverage.
+
+## Rabbit Holes
+
+- Do NOT add a DB-path env override or attempt to auto-grant Full Disk Access —
+  granting FDA is a per-machine GUI action, out of scope for this code fix.
+- Do NOT rework the `/update` verifier's multi-line handling; a clean one-line
+  error from the CLI resolves the burying symptom at the source.
+
+## No-Gos (Out of Scope)
+
+- The stale `GRANITE_DELIVERY_TIMEOUT_S` process-env warning (separate,
+  machine-local; self-heals on the next worker restart — config already correct).
+- The `env-completeness: 20 missing` warning (pre-existing; those keys are
+  optional/defaulted knobs plus an intentionally-absent `ANTHROPIC_API_KEY`).
+
+## Update System
+
+No update-script or update-skill changes required. This fix improves the text of
+an existing `/update` verifier warning; the verifier wiring is unchanged.
+
+## Agent Integration
+
+No new CLI entry point or bridge import required — `sms_reader.cli` is already an
+existing entrypoint invoked via the agent's Bash tool and by the `/update`
+verifier. This only changes its stderr on the error path.
+
+## Documentation
+- [ ] No new feature doc required — update the inline module docstring/comment in
+  `tools/sms_reader/cli.py` explaining why the error is trapped (done in the fix).
+  The `reading-sms-messages` skill and existing behavior are otherwise unchanged;
+  no `docs/features/*.md` covers the CLI's error text, so no external doc drifts.
+
+## Success Criteria
+
+- `python -m tools.sms_reader.cli recent --limit 1` on an FDA-less machine prints
+  a single `sms: …` line to stderr, exit 1, no traceback.
+- `tests/unit/test_sms_reader_cli.py` passes.
+- Success path unchanged (JSON + exit 0).
+
+## Step by Step Tasks
+
+### 1. Trap SMSReaderError in the CLI
+Refactor `main()` into `_build_parser` / `_dispatch` / `main`, wrap dispatch in
+`try/except SMSReaderError`.
+
+### 2. Add regression tests
+`tests/unit/test_sms_reader_cli.py`: error-path (recent, senders) and success
+path, asserting no traceback and exact stderr.
+
+### 3. Final Validation
+Ruff clean; new tests green; manual CLI run shows clean error.
+
+## Verification
+
+- [ ] `python -m ruff check tools/sms_reader/cli.py tests/unit/test_sms_reader_cli.py` passes.
+- [ ] `pytest tests/unit/test_sms_reader_cli.py -q -n0` passes (3 tests).
+- [ ] Manual: `python -m tools.sms_reader.cli recent --limit 1` emits `sms: …`
+      (no `Traceback`) on a machine without Full Disk Access.
+
+## Knowledge Base
+
+- Memory (project `valor`): no prior memory on sms_reader CLI error handling;
+  this plan is the record.
+- Vault: no vault entry touches sms_reader; none needed.
+
+## Open Questions
+
+None.

--- a/tests/unit/test_sms_reader_cli.py
+++ b/tests/unit/test_sms_reader_cli.py
@@ -1,0 +1,67 @@
+"""Unit tests for the sms_reader CLI error handling.
+
+Regression coverage for the `/update` verifier warning that surfaced a raw
+`Traceback (most recent call last)` instead of the actionable SMSReaderError
+message when Full Disk Access is not granted (or the Messages DB is absent).
+"""
+
+from unittest import mock
+
+import pytest
+
+from tools.sms_reader import SMSReaderError
+from tools.sms_reader import cli as sms_cli
+
+pytestmark = pytest.mark.sdlc
+
+
+def test_dispatch_smsreadererror_becomes_clean_stderr(capsys):
+    """A raised SMSReaderError exits 1 with a clean `sms: <message>` line and no traceback."""
+    with mock.patch.object(
+        sms_cli,
+        "get_recent_messages",
+        side_effect=SMSReaderError(
+            "Cannot open Messages database. Grant Full Disk Access to your terminal.",
+            category="permission",
+        ),
+    ):
+        with mock.patch.object(sms_cli.sys, "argv", ["sms", "recent", "--limit", "1"]):
+            with pytest.raises(SystemExit) as excinfo:
+                sms_cli.main()
+
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Traceback" not in captured.err
+    assert captured.err.strip() == (
+        "sms: Cannot open Messages database. Grant Full Disk Access to your terminal."
+    )
+
+
+def test_dispatch_wraps_all_subcommands(capsys):
+    """The error wrapper covers every subcommand, not just `recent`."""
+    with mock.patch.object(
+        sms_cli,
+        "list_senders",
+        side_effect=SMSReaderError("Database error: locked", category="database"),
+    ):
+        with mock.patch.object(sms_cli.sys, "argv", ["sms", "senders"]):
+            with pytest.raises(SystemExit) as excinfo:
+                sms_cli.main()
+
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert "Traceback" not in captured.err
+    assert captured.err.strip() == "sms: Database error: locked"
+
+
+def test_dispatch_success_path_not_swallowed(capsys):
+    """A normal (non-error) invocation still prints JSON and does not exit non-zero."""
+    with mock.patch.object(sms_cli, "get_recent_messages", return_value=[]):
+        with mock.patch.object(sms_cli.sys, "argv", ["sms", "recent", "--limit", "1"]):
+            # No SystemExit expected on the success path.
+            sms_cli.main()
+
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "[]"
+    assert captured.err == ""

--- a/tools/sms_reader/cli.py
+++ b/tools/sms_reader/cli.py
@@ -6,6 +6,7 @@ import json
 import sys
 
 from tools.sms_reader import (
+    SMSReaderError,
     get_2fa,
     get_latest_2fa_code,
     get_recent_messages,
@@ -14,7 +15,7 @@ from tools.sms_reader import (
 )
 
 
-def main():
+def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="sms", description="Read macOS Messages")
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -40,8 +41,10 @@ def main():
     p.add_argument("--limit", type=int, default=50)
     p.add_argument("--since-days", type=int, default=30)
 
-    args = parser.parse_args()
+    return parser
 
+
+def _dispatch(args) -> None:
     if args.command == "2fa":
         if args.detailed:
             result = get_latest_2fa_code(minutes=args.minutes, sender=args.sender)
@@ -73,6 +76,19 @@ def main():
     elif args.command == "senders":
         senders = list_senders(limit=args.limit, since_days=args.since_days)
         print(json.dumps(senders, indent=2))
+
+
+def main():
+    args = _build_parser().parse_args()
+    try:
+        _dispatch(args)
+    except SMSReaderError as exc:
+        # Emit a clean, actionable one-line error instead of leaking a raw
+        # traceback. Callers (e.g. the /update verifier) surface stderr as the
+        # failure reason; a traceback there is useless noise, whereas the
+        # SMSReaderError message names the fix (e.g. "Grant Full Disk Access").
+        print(f"sms: {exc.message}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #2073. On a machine without Full Disk Access to the Messages DB, `/update`'s verifier runs `python -m tools.sms_reader.cli recent --limit 1` and surfaces the subprocess stderr as the failure reason. `main()` did not catch `SMSReaderError`, so the CLI died with an unhandled traceback — producing the useless update warning `⚠️ sms_reader: Traceback (most recent call last)` (which, being multi-line, also buried subsequent warnings in the update summary).

## Change

- Split `main()` into `_build_parser()` / `_dispatch(args)` / `main()`.
- `main()` traps `SMSReaderError` and prints a clean `sms: <message>` to stderr with exit 1. The `/update` warning now reads the actionable message verbatim (e.g. "Grant Full Disk Access…").
- Success path unchanged (JSON + exit 0).
- Adds `tests/unit/test_sms_reader_cli.py` (error-path for two subcommands + success path; asserts no traceback leak).

## Verification

- `ruff check` / `ruff format --check`: clean.
- `pytest tests/unit/test_sms_reader_cli.py -q -n0`: 3 passed.
- Manual: `python -m tools.sms_reader.cli recent --limit 1` on this FDA-less machine now prints `sms: Cannot open Messages database. Grant Full Disk Access…` (no traceback), exit 1.

## Plan

`docs/plans/sms-reader-clean-error.md` — critique verdict: READY TO BUILD (0 blockers, 0 concerns).

## Out of scope (reported separately to the PM)

- Stale `GRANITE_DELIVERY_TIMEOUT_S` process-env warning: machine-local, self-heals on next worker restart (vault `.env` and worker plist already use `SESSION_RUNNER_DELIVERY_TIMEOUT_S`).
- `env-completeness: 20 missing`: pre-existing; optional/defaulted knobs plus intentionally-absent `ANTHROPIC_API_KEY`.