### PR TITLE
Fix stale stall-advisory test fixture (#2092)

### DIFF
--- a/tests/unit/reflections/test_stall_advisory_reflection.py
+++ b/tests/unit/reflections/test_stall_advisory_reflection.py
@@ -15,11 +15,23 @@ import pytest
 
 # We import the module — not the function — so we can monkeypatch its internals.
 import reflections.stall_advisory as stall_advisory_mod
+from agent.session_stall_classifier import (
+    NEVER_STARTED_CONFIRM_MARGIN_SECS,
+    NEVER_STARTED_GRACE_SECS,
+)
 from reflections.stall_advisory import run_stall_advisory
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+# Age a "never-started" fixture must reach before classify_session_stall() will
+# confirm it as stalled: the grace window plus the cold-start confirmation
+# margin, both imported from the classifier so this fixture tracks the
+# thresholds as they evolve (issue #2092 — a hardcoded 700s literal went stale
+# after the #2069/#2071 grace-widening). The extra buffer keeps the fixture
+# comfortably past the confirm threshold.
+_STALLED_FIXTURE_AGE_SECS = NEVER_STARTED_GRACE_SECS + NEVER_STARTED_CONFIRM_MARGIN_SECS + 300
 
 
 def _fake_session(
@@ -34,7 +46,7 @@ def _fake_session(
         agent_session_id=session_id,
         status=status,
         started_at=started_at,
-        created_at=created_at if created_at is not None else (now - 700),
+        created_at=created_at if created_at is not None else (now - _STALLED_FIXTURE_AGE_SECS),
     )
 
 
@@ -176,7 +188,8 @@ class TestTelegramFlagOff:
 
 class TestTelegramFlagOn:
     def test_enabled_with_stalled_session_sends_alert(self, monkeypatch):
-        # session created 700s ago, status=running, no events → stalled/never_started
+        # session aged past the never-started confirm threshold, status=running,
+        # no events → stalled/never_started
         sess = _fake_session("stalled-enabled", status="running")
 
         with patch.object(stall_advisory_mod, "_send_alert") as mock_alert:


### PR DESCRIPTION
## Summary

Fixes #2092. `tests/unit/reflections/test_stall_advisory_reflection.py` used a hardcoded 700s age in `_fake_session`, but the never-started confirm threshold widened to `NEVER_STARTED_GRACE_SECS` (1200) + `NEVER_STARTED_CONFIRM_MARGIN_SECS` (30) = 1230s after #2069/#2071. A supposedly-stalled fixture therefore classified as healthy and `test_enabled_with_stalled_session_sends_alert` failed (`status 'ok' != 'warn'`).

## Fix

Derive the stalled-fixture age from the classifier constants (imported from `agent.session_stall_classifier`) plus a 300s buffer, so the fixture tracks the thresholds as they evolve rather than going stale on the next grace-widening.

## Testing

- Reproduced the failure first (`status 'ok' != 'warn'`).
- Full file green: 11 passed.
- ruff check + format clean.