### PR TITLE
Fix stale happy-path router merge-termination fixture (#2091)

### DIFF
--- a/docs/plans/fix-sdlc-router-merge-termination.md
+++ b/docs/plans/fix-sdlc-router-merge-termination.md
@@ -85,6 +85,11 @@ not weaken the verdict gate.
   states — it reintroduces the #1897 misroute (#2062 WS3a/b/c).
 - Do NOT relax Row 8e or the Row 10 verdict gate.
 - Do NOT touch head_sha staleness (WS3d) logic — out of scope.
+- The no-verdict `REVIEW == completed` re-review behavior (Row 8e) is
+  deliberate #2062 behavior and is loop-bound by G4 (`guard_g4_oscillation`
+  escalates to `Blocked` after `MAX_SAME_STAGE_DISPATCHES`). Whether the WS3c
+  stage-marker write-refusal is fully enforced at every write-site is a
+  separate #2062 concern, out of scope for this fixture correction.
 
 ## No-Gos (Out of Scope)
 

--- a/docs/plans/fix-sdlc-router-merge-termination.md
+++ b/docs/plans/fix-sdlc-router-merge-termination.md
@@ -1,0 +1,125 @@
+---
+status: Ready
+type: bug
+appetite: Small
+owner: Valor Engels
+created: 2026-07-15
+tracking: https://github.com/tomcounsell/ai/issues/2091
+last_comment_id:
+revision_applied: true
+revision_applied_at: 2026-07-15T00:00:00Z
+---
+
+# Fix SDLC Router Happy-Path Merge Termination (#2091)
+
+## Problem
+
+`test_1036_replay_terminates` (Scenario 4, "happy-path termination") in
+`tests/unit/test_sdlc_router_oscillation.py` fails at line 464:
+
+```python
+happy = {"ISSUE":"completed","PLAN":"completed","CRITIQUE":"completed",
+         "BUILD":"completed","TEST":"completed","REVIEW":"completed","DOCS":"completed"}
+r4 = decide_next_dispatch(happy, {"pr_number": 1039})
+assert r4.skill == SKILL_DO_MERGE   # gets "/do-pr-review"
+```
+
+The issue was filed as a suspected router regression. Investigation shows the
+**router is correct**; the **test fixture is stale**.
+
+## Root Cause
+
+Scenario 4 seeds all stages `completed` and a PR open, but supplies **no
+recorded REVIEW verdict** (`meta = {"pr_number": 1039}` only). Walking
+`decide_next_dispatch`:
+
+- No guard trips (G3 only redirects when `last`/`proposed` is a plan-stage
+  skill; G6 needs `pr_merge_state == "CLEAN"`).
+- Row 8e (`_rule_review_completed_no_verdict`, added by #2062 WS3b) matches:
+  `REVIEW == completed` with **no recorded verdict** is treated as an unearned
+  marker and re-dispatched to `/do-pr-review`.
+- Row 10 (`_rule_ready_to_merge`) would not fire either — since #2062 WS3a it
+  requires a recorded `APPROVED` verdict, which the fixture omits.
+
+Under the #2062 **WS3c invariant** a `REVIEW == completed` marker is unwritable
+without a readable verdict, so an all-completed state with no verdict is an
+*impossible* production state (or a crash), and the router deliberately routes
+it to re-review. This exact behavior is pinned by
+`tests/unit/test_sdlc_router.py::TestRow10VerdictGate::test_review_completed_no_verdict_routes_to_review`
+(the #1897 replay) and `TestRow8eNoVerdictRecovery::test_dispatches_pr_review_row_8e`.
+
+The Scenario 4 fixture predates #2062 and omits the verdict. Notably, the
+**12-turn replay in the same test** already passes `latest_review_verdict:
+"APPROVED"` on its final `happy` turn and reaches `/do-merge` correctly — only
+the standalone Scenario 4 assertion forgot the verdict.
+
+## Solution
+
+Update the stale Scenario 4 fixture to supply the recorded `APPROVED` verdict —
+matching the real happy-path terminal state, the #2062 WS3c invariant, and the
+replay's own final turn. With the verdict present, Row 8e steps aside and Row 10
+routes to `/do-merge`. Strengthen the assertion to pin `row_id == "10"` so the
+happy-path terminal is anchored to the merge row, not merely the merge skill.
+
+The router source (`agent/sdlc_router.py`) is **not** changed: any router
+short-circuit that merged a no-verdict all-completed state would regress the
+shipped #2062 behavior (`test_review_completed_no_verdict_routes_to_review`,
+`test_rule_ready_to_merge_false_without_verdict`).
+
+## Failure Path Test Strategy
+
+The corrected fixture IS the failure-path assertion: it drives the happy-path
+terminal state (all stages completed + PR open + recorded APPROVED verdict) and
+pins the terminal dispatch to `/do-merge` via Row 10. The negative side is
+already covered by the shipped #2062 tests, which pin the no-verdict variant to
+`/do-pr-review` — those must continue to pass unchanged, proving the fix does
+not weaken the verdict gate.
+
+## Test Impact
+- [ ] `tests/unit/test_sdlc_router_oscillation.py::test_1036_replay_terminates` — UPDATE: add `latest_review_verdict: "APPROVED"` to the Scenario 4 meta and assert `r4.row_id == "10"`, aligning the standalone assertion with the replay's final turn and the #2062 WS3c invariant.
+- [ ] No other test changes: the #2062 row-8e/row-10 tests in `tests/unit/test_sdlc_router.py` must pass **unchanged**, confirming the no-verdict re-review gate is preserved.
+
+## Rabbit Holes
+
+- Do NOT add a router terminal short-circuit for no-verdict all-completed
+  states — it reintroduces the #1897 misroute (#2062 WS3a/b/c).
+- Do NOT relax Row 8e or the Row 10 verdict gate.
+- Do NOT touch head_sha staleness (WS3d) logic — out of scope.
+
+## No-Gos (Out of Scope)
+
+- No changes to `agent/sdlc_router.py` dispatch logic or guards.
+- No changes to `agent/pipeline_graph.py`.
+- No changes to the stage-marker write path (WS3c invariant enforcement).
+
+## Update System
+
+No update-system changes required — this is a test-only fixture correction with
+no new dependencies, config, or migration steps.
+
+## Agent Integration
+
+No agent integration required — this change touches only a unit-test fixture. No
+new CLI entry point, no bridge import, no runtime surface.
+
+## Documentation
+- [ ] Update the `test_1036_replay_terminates` docstring in `tests/unit/test_sdlc_router_oscillation.py` to record that the happy-path terminal fixture must carry a recorded APPROVED verdict, per the #2062 WS3c invariant (`REVIEW == completed` is unwritable without a readable verdict), so this stale-fixture failure class does not recur.
+- [ ] Add a one-line note to `docs/sdlc/do-test.md` cross-referencing the #2062 verdict-gate invariant, so future router-test authors seed the recorded verdict when asserting `/do-merge` termination.
+
+## Verification
+
+| Check | Command | Expected |
+|-------|---------|----------|
+| Repro test passes | `pytest tests/unit/test_sdlc_router_oscillation.py::test_1036_replay_terminates -n0` | PASS, `r4.skill == /do-merge`, `r4.row_id == 10` |
+| No #2062 regression | `pytest tests/unit/test_sdlc_router.py -k "Row10VerdictGate or Row8eNoVerdictRecovery" -n0` | all PASS unchanged |
+| Full oscillation file green | `pytest tests/unit/test_sdlc_router_oscillation.py -n0` | all PASS |
+| Format clean | `python -m ruff format tests/unit/test_sdlc_router_oscillation.py` | no reformatting needed |
+
+## Success Criteria
+
+- `test_1036_replay_terminates` passes: all-completed + PR-open + APPROVED
+  verdict → `/do-merge` (Row 10).
+- No other `test_sdlc_router_oscillation.py` scenario regresses.
+- The #2062 row-8e/row-10 gate tests pass unchanged.
+- The happy-path termination is pinned by an assertion on both `skill` and
+  `row_id`.

--- a/docs/sdlc/do-test.md
+++ b/docs/sdlc/do-test.md
@@ -114,3 +114,15 @@ diagnosable instead of mysterious. See
 
 The OUTCOME contract this skill emits is parsed by `classify_outcome()` in
 `agent/pipeline_state.py` (Tier 0) before any text pattern matching.
+
+## Router-Test Fixtures: Seed a Recorded Verdict for Merge-Termination Asserts
+
+When a `tests/unit/test_sdlc_router*.py` fixture asserts the happy-path terminal
+dispatches `/do-merge`, it MUST seed a recorded `APPROVED` review verdict (via
+`meta["latest_review_verdict"]` or `_verdicts["REVIEW"]`) alongside the
+all-`completed` stage states. A `REVIEW == completed` marker is unwritable
+without a readable verdict (#2062 WS3c invariant), so an all-completed state with
+no verdict is not the terminal state — Row 8e (no-verdict recovery) correctly
+re-dispatches `/do-pr-review`, and Row 10 (ready-to-merge) requires the recorded
+verdict (#2062 WS3a). A fixture that omits the verdict but asserts `/do-merge` is
+stale, not a router bug (see #2091).

--- a/tests/unit/test_sdlc_router_oscillation.py
+++ b/tests/unit/test_sdlc_router_oscillation.py
@@ -415,6 +415,14 @@ def test_1036_replay_terminates():
     asserts the router never cycles indefinitely — it either terminates in a
     legitimate merge dispatch or in a Blocked escalation, never in a
     repeated /do-plan-critique on NEEDS REVISION.
+
+    Happy-path terminal fixture invariant (#2091): Scenario 4 seeds every stage
+    ``completed`` with a PR open AND a recorded ``APPROVED`` review verdict. The
+    verdict is load-bearing, not decoration — a ``REVIEW == completed`` marker is
+    unwritable without a readable verdict (#2062 WS3c), so the real terminal state
+    always carries one. Omitting it makes Row 8e (no-verdict recovery) correctly
+    re-dispatch ``/do-pr-review`` instead of ``/do-merge``. Any future edit here
+    must keep the verdict so the terminal resolves via Row 10 (ready-to-merge).
     """
     # Scenario 1: NEEDS REVISION loop — second invocation should route to
     # /do-plan, not re-critique.
@@ -459,9 +467,15 @@ def test_1036_replay_terminates():
         "REVIEW": "completed",
         "DOCS": "completed",
     }
-    r4 = decide_next_dispatch(happy, {"pr_number": 1039})
+    # A REVIEW==completed marker is unwritable without a recorded verdict
+    # (#2062 WS3c invariant), so the real happy-path terminal always carries an
+    # APPROVED review verdict — mirror the replay's final turn below. Without it,
+    # Row 8e (no-verdict recovery) correctly re-dispatches /do-pr-review, which is
+    # pinned by tests/unit/test_sdlc_router.py::TestRow8eNoVerdictRecovery.
+    r4 = decide_next_dispatch(happy, {"pr_number": 1039, "latest_review_verdict": "APPROVED"})
     assert isinstance(r4, Dispatch)
     assert r4.skill == SKILL_DO_MERGE
+    assert r4.row_id == "10", "happy-path terminal must resolve via Row 10 (ready-to-merge)"
 
     # Combined 12-turn replay: drive turns and assert no single skill is
     # dispatched > MAX_SAME_STAGE_DISPATCHES consecutively. The synthetic


### PR DESCRIPTION
Closes #2091.

## Root cause

`test_1036_replay_terminates` Scenario 4 (the "happy-path termination" case) asserted that an all-`completed` + PR-open state routes to `/do-merge`, but the fixture seeded **no recorded REVIEW verdict** (`meta = {"pr_number": 1039}`).

Tracing `decide_next_dispatch` for that state:
- No guard trips (G3 only redirects plan-stage dispatches; G6 needs `pr_merge_state == "CLEAN"`).
- Row 8e (`_rule_review_completed_no_verdict`, #2062 WS3b) matches: `REVIEW == completed` with no recorded verdict is an unearned marker → `/do-pr-review`.
- Row 10 (`_rule_ready_to_merge`) would not fire anyway — since #2062 WS3a it requires a recorded `APPROVED` verdict.

Under the #2062 **WS3c invariant** a `REVIEW == completed` marker is unwritable without a readable verdict, so a no-verdict all-completed state is not the terminal state. The router is **correct**; the fixture was **stale** — it predates #2062 and diverged from the *same test's* 12-turn replay, whose final `happy` turn already passes `latest_review_verdict: "APPROVED"` and reaches `/do-merge`.

## Fix

Test-only. Add the recorded `APPROVED` verdict to the Scenario 4 meta (matching the replay's final turn and the WS3c invariant) and pin `r4.row_id == "10"` so the happy-path terminal is anchored to the ready-to-merge row.

**No router source change.** A short-circuit routing no-verdict all-completed → `/do-merge` would regress shipped #2062 behavior pinned by `test_review_completed_no_verdict_routes_to_review` (the #1897 replay) and `test_rule_ready_to_merge_false_without_verdict`.

## Tests

- `test_1036_replay_terminates` — PASS (`r4.skill == /do-merge`, `r4.row_id == "10"`).
- `tests/unit/test_sdlc_router.py -k "Row10VerdictGate or Row8eNoVerdictRecovery"` — 9 passed, no regression.
- `tests/unit/test_sdlc_router_oscillation.py` — 47 passed.
- `tests/unit/test_sdlc_router.py` — 63 passed.
- `ruff format` — clean.

## Docs

- Plan: `docs/plans/fix-sdlc-router-merge-termination.md`.
- `docs/sdlc/do-test.md`: new section requiring router-test merge-termination fixtures to seed a recorded verdict.
- `test_1036_replay_terminates` docstring records the fixture invariant.