### PR TITLE
stall-advisory: skip is_ledger sessions (#2105)

### DIFF
--- a/docs/features/stall-recovery.md
+++ b/docs/features/stall-recovery.md
@@ -29,6 +29,16 @@ the granite PTY substrate — a `claude -p` turn has no persistent screen to
 stall in a turn-0 loop on. See [Headless Session
 Runner](headless-session-runner.md#liveness) for the current liveness model.
 
+## Probe-Set Exclusion: Non-Executable Ledgers
+
+Before any classification, `run_stall_advisory` excludes `is_ledger=True` sessions
+from the probe set (the same `not _is_ledger(s)` filter applied alongside the
+terminal-status skip). `sdlc-local-{N}` SDLC pipeline anchors are ledgers that by
+design never spawn an SDK subprocess, so they would classify `never_started`
+(an actionable reason) and be killed — orphaning the issue lease and deadlocking
+the SDLC router (`ISSUE_LOCKED / orphaned_lock`). This mirrors the health loop's
+`#2042` ledger skip; see issue #2105 (residual of the #2026 umbrella).
+
 ## Action Mode: Gate Ladder
 
 For every `stalled` finding, `_maybe_recover()` in `stall_advisory.py` runs the following checks in order:

--- a/reflections/stall_advisory.py
+++ b/reflections/stall_advisory.py
@@ -104,6 +104,7 @@ def run_stall_advisory(params: dict | None = None) -> dict:
     findings: list[dict] = []
 
     try:
+        from agent.session_health import _is_ledger
         from agent.session_stall_classifier import (
             _RUNNING_PROBE_STATUSES,
             classify_session_stall,
@@ -126,8 +127,16 @@ def run_stall_advisory(params: dict | None = None) -> dict:
             "summary": f"stall-advisory query error: {e}",
         }
 
-    # Skip any sessions that have transitioned to terminal status concurrently
-    active_sessions = [s for s in probe_sessions if s.status not in TERMINAL_STATUSES]
+    # Skip terminal-status sessions (concurrent transition) AND non-executable
+    # ledgers. `sdlc-local-{N}` pipeline anchors are `is_ledger=True` and by
+    # design never spawn an SDK subprocess, so `classify_session_stall` returns
+    # `never_started` for them — an actionable reason that would kill the ledger
+    # and orphan its issue lock, deadlocking the SDLC router
+    # (`ISSUE_LOCKED / orphaned_lock`). Mirror the ledger skip the health loop
+    # already performs (#2042); this is the stall-path half of that guard.
+    active_sessions = [
+        s for s in probe_sessions if s.status not in TERMINAL_STATUSES and not _is_ledger(s)
+    ]
 
     # Best-effort recovery context. If Redis or the project key is unavailable
     # we skip recovery entirely and preserve advisory-only behaviour.

--- a/tests/unit/test_stall_advisory_ledger_skip.py
+++ b/tests/unit/test_stall_advisory_ledger_skip.py
@@ -1,0 +1,81 @@
+"""Regression: stall-advisory must skip `is_ledger` sessions.
+
+`sdlc-local-{N}` SDLC pipeline anchors are created with `is_ledger=True` and by
+design never spawn an SDK subprocess, so they never emit a start/turn event. The
+stall classifier therefore returns ``never_started`` for them — an *actionable*
+reason. Before this guard, `run_stall_advisory` classified (and could kill) those
+ledgers, orphaning the issue lock and deadlocking the SDLC router
+(`ISSUE_LOCKED / orphaned_lock`). This was hit live on 2026-07-15 for
+`sdlc-local-2101` and `sdlc-local-2086`.
+
+The health loop already skips ledgers (#2042); this pins the stall-path half of
+that guard: a ledger must never reach `classify_session_stall`.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from reflections.stall_advisory import run_stall_advisory
+
+
+def _mk_session(session_id: str, *, is_ledger: bool):
+    return SimpleNamespace(
+        session_id=session_id,
+        agent_session_id=session_id,
+        status="running",
+        is_ledger=is_ledger,
+    )
+
+
+def test_ledger_session_excluded_from_stall_classification():
+    ledger = _mk_session("sdlc-local-9999", is_ledger=True)
+    normal = _mk_session("0_normalsession", is_ledger=False)
+
+    classified: list[str] = []
+
+    def _spy_classify(events, session=None):
+        classified.append(getattr(session, "session_id", "?"))
+        # Healthy verdict — no finding, no recovery side effects.
+        return SimpleNamespace(level="ok", reason="healthy_recent_turn", signals={})
+
+    mock_query = MagicMock()
+    mock_query.filter.return_value = [ledger, normal]
+
+    with (
+        patch("models.agent_session.AgentSession.query", mock_query),
+        patch("agent.session_stall_classifier.classify_session_stall", _spy_classify),
+        patch("agent.session_telemetry.read_session_timeline", lambda sid: []),
+        # Force recovery context unavailable so the test never touches prod Redis.
+        patch("reflections.stall_advisory._get_redis", side_effect=RuntimeError("no redis")),
+    ):
+        result = run_stall_advisory()
+
+    # The ledger must never be classified; the normal session must be.
+    assert "sdlc-local-9999" not in classified, "ledger was classified — guard missing"
+    assert "0_normalsession" in classified
+    # Only the non-ledger session is counted as a running session.
+    assert result["summary"].startswith("1 running session(s)")
+
+
+def test_all_ledgers_yields_no_classification():
+    ledgers = [_mk_session(f"sdlc-local-{n}", is_ledger=True) for n in (1, 2, 3)]
+    classified: list[str] = []
+
+    def _spy_classify(events, session=None):
+        classified.append(getattr(session, "session_id", "?"))
+        return SimpleNamespace(level="ok", reason="healthy", signals={})
+
+    mock_query = MagicMock()
+    mock_query.filter.return_value = ledgers
+
+    with (
+        patch("models.agent_session.AgentSession.query", mock_query),
+        patch("agent.session_stall_classifier.classify_session_stall", _spy_classify),
+        patch("agent.session_telemetry.read_session_timeline", lambda sid: []),
+        patch("reflections.stall_advisory._get_redis", side_effect=RuntimeError("no redis")),
+    ):
+        result = run_stall_advisory()
+
+    assert classified == [], "no ledger should ever be classified"
+    assert result["summary"].startswith("0 running session(s)")
+    assert result["status"] == "ok"


### PR DESCRIPTION
Closes #2105

## Problem
`run_stall_advisory` queried all running sessions with no `is_ledger` guard. `sdlc-local-{N}` ledger anchors never emit a start event (no SDK subprocess by design), so the stall classifier returned `never_started` (an actionable reason) and the reflection killed them after the 1200s grace — orphaning the SDLC issue lease and deadlocking the router (`ISSUE_LOCKED / orphaned_lock`). Hit live on `sdlc-local-2101` and `sdlc-local-2086` (2026-07-15).

## Fix
One guard in `reflections/stall_advisory.py`: exclude `is_ledger` from the probe set via the canonical `_is_ledger` helper (`agent/session_health.py:46`), mirroring the `#2042` health-loop ledger skip. This is the stall-path half of that guard.

## Test
`tests/unit/test_stall_advisory_ledger_skip.py` — asserts a ledger never reaches `classify_session_stall` (and an all-ledger probe set yields `0 running session(s)`). Verified the test fails without the guard and passes with it.

## Relation
Residual of the **#2026** umbrella (core shipped via #2076); related to **#2028** (worker executing ledgers as PM sessions). Root-caused live while driving the #2101 and #2086 pipelines to merge.