### PR TITLE
Fix run_email_bridge un-awaited-coroutine teardown leak wedging full-suite gates (#2118)

### DIFF
--- a/docs/plans/fix-email-bridge-teardown-hang.md
+++ b/docs/plans/fix-email-bridge-teardown-hang.md
@@ -38,6 +38,24 @@ This is **purely test-side** — in production `asyncio.run` really awaits the c
 It is distinct from #2064 (machine-global lock) and #2060 (per-process Redis-db isolation),
 both merged.
 
+**Broader finding (verification-driven):** running the full suite after the `run_email_bridge`
+fix confirmed the specific warning is gone (0 occurrences), but the suite then advances past
+the old ~99% wedge point and hangs on **other** un-awaited-coroutine leaks of the identical
+class. Full inventory of leaked coroutines across the suite:
+
+| Coroutine | Where | Mechanism | Status |
+|-----------|-------|-----------|--------|
+| `run_email_bridge` | `test_email_bridge.py` (2 tests) | `asyncio.run` mock drops coro | FIXED (this PR) |
+| `download_media` | `test_telegram_bridge_media_timeout.py` (3 tests) | `asyncio.wait_for` mock drops the `download_media(...)` arg | FIXED (this PR) |
+| `_ingest_attachments` | `test_bridge_ack_steering_routed.py` (1 test) | `asyncio.create_task` mocked to raise drops the real coro | FIXED (this PR) |
+| `_worker_loop` | integration (`test_slow_redis_no_loop_freeze`, `test_progress_deadline_cancel`, others) | worker-loop `create_task` not cancel-awaited on some path | RESIDUAL → follow-up |
+| `_evaluate_promise_async` | integration (promise-gate path via `_run_async_safely`) | sync wrapper drops coro when a loop is already running | RESIDUAL → follow-up |
+
+The three test-mock leaks (top three) are fixed at their source in this PR. The two residual
+integration leaks are async task-lifecycle / sync-wrapper issues that need a quiesced machine
+to verify a fix and are tracked as a follow-up (they are broader than #2118's named
+`run_email_bridge` scope). This PR reduces the teardown-wedge sources from five to two.
+
 **Deterministic repro:**
 ```
 python -W error::RuntimeWarning -m pytest \
@@ -93,8 +111,10 @@ under `-W error::RuntimeWarning` and asserting zero `never awaited` warnings —
 repro command that currently fails now passes clean.
 
 ## Test Impact
-- [ ] `tests/unit/test_email_bridge.py::TestMainEnvLoading::test_main_calls_load_dotenv_with_correct_paths` — UPDATE: change the `asyncio.run` patch to close the received coroutine (`side_effect=lambda coro: coro.close()`). Assertions unchanged.
-- [ ] `tests/unit/test_email_bridge.py::TestMainEnvLoading::test_main_skips_dotenv_under_launchd` — UPDATE: same patch change. Assertions unchanged.
+- [x] `tests/unit/test_email_bridge.py::TestMainEnvLoading::test_main_calls_load_dotenv_with_correct_paths` — UPDATE: change the `asyncio.run` patch to close the received coroutine (`side_effect=lambda coro: coro.close()`). Assertions unchanged.
+- [x] `tests/unit/test_email_bridge.py::TestMainEnvLoading::test_main_skips_dotenv_under_launchd` — UPDATE: same patch change. Assertions unchanged.
+- [x] `tests/unit/test_telegram_bridge_media_timeout.py` (3 async retry tests) — UPDATE: replace the `asyncio.wait_for` `AsyncMock` stubs with async fakes that `coro.close()` the received `download_media(...)` coroutine before applying behavior. Assertions unchanged; dropped now-unused `AsyncMock` import.
+- [x] `tests/unit/test_bridge_ack_steering_routed.py::...::test_ingest_task_exception_does_not_block_push` — UPDATE: mock `asyncio.create_task` via a `_raise_after_closing(...)` helper so the real `_ingest_attachments(...)` coroutine is closed before the mock raises. Assertions unchanged.
 
 ## Rabbit Holes
 

--- a/docs/plans/fix-email-bridge-teardown-hang.md
+++ b/docs/plans/fix-email-bridge-teardown-hang.md
@@ -62,10 +62,10 @@ source rather than suppressing the warning via filterwarnings.
 
 ## Success Criteria
 
-- [ ] The two `TestMainEnvLoading` tests patch `asyncio.run` so the received coroutine is closed, not dropped.
-- [ ] `python -W error::RuntimeWarning -m pytest tests/unit/test_email_bridge.py::TestMainEnvLoading -p no:cacheprovider -n0 -q` passes with zero `coroutine 'run_email_bridge' was never awaited` warnings.
-- [ ] The full `tests/unit/test_email_bridge.py` module passes clean.
-- [ ] No production code in `bridge/email_bridge.py` changed.
+- [x] The two `TestMainEnvLoading` tests patch `asyncio.run` so the received coroutine is closed, not dropped.
+- [x] `python -W error::RuntimeWarning -m pytest tests/unit/test_email_bridge.py::TestMainEnvLoading -p no:cacheprovider -n0 -q` passes with zero `coroutine 'run_email_bridge' was never awaited` warnings.
+- [x] The full `tests/unit/test_email_bridge.py` module passes clean.
+- [x] No production code in `bridge/email_bridge.py` changed.
 
 ## No-Gos
 

--- a/docs/plans/fix-email-bridge-teardown-hang.md
+++ b/docs/plans/fix-email-bridge-teardown-hang.md
@@ -1,0 +1,111 @@
+---
+status: Ready
+type: bug
+appetite: Small
+owner: Valor Engels
+created: 2026-07-16
+revised: 2026-07-16
+tracking: https://github.com/tomcounsell/ai/issues/2118
+last_comment_id:
+revision_applied: true
+---
+
+# Fix run_email_bridge async-teardown hang (un-awaited coroutine leak)
+
+## Problem
+
+During the 2026-07-16 reliability batch, 6 of 8 parallel SDLC merge gates wedged: the
+full pytest suite reached ~99% and then hung in async teardown, emitting
+`coroutine 'run_email_bridge' was never awaited` followed by `gc.collect()`, and never
+wrote junitxml. The merge-guard had no suite evidence, forcing every lane onto the
+documented targeted-test bypass. This silently degrades every future full-suite gate.
+
+**Root cause (confirmed):** `bridge/email_bridge.py::main()` ends with
+`asyncio.run(run_email_bridge())`. Two unit tests in
+`tests/unit/test_email_bridge.py::TestMainEnvLoading`
+(`test_main_calls_load_dotenv_with_correct_paths` and
+`test_main_skips_dotenv_under_launchd`) patch `bridge.email_bridge.asyncio.run` with a
+bare `MagicMock`. Python evaluates the argument `run_email_bridge()` **before** the call,
+creating a coroutine object, and hands it to the mock — which never awaits it. The
+coroutine object is retained on the mock's `call_args` and is only finalized later during
+garbage collection / interpreter teardown, at which point CPython emits
+`RuntimeWarning: coroutine 'run_email_bridge' was never awaited`. Under pytest this
+surfaces as a `PytestUnraisableExceptionWarning` during loop/interpreter teardown and,
+combined with the full suite's teardown ordering on a contended machine, wedges the run
+before junit is written.
+
+This is **purely test-side** — in production `asyncio.run` really awaits the coroutine.
+It is distinct from #2064 (machine-global lock) and #2060 (per-process Redis-db isolation),
+both merged.
+
+**Deterministic repro:**
+```
+python -W error::RuntimeWarning -m pytest \
+  tests/unit/test_email_bridge.py::TestMainEnvLoading -p no:cacheprovider -n0 -q
+```
+emits two `coroutine 'run_email_bridge' was never awaited` warnings (one per test).
+
+## Solution
+
+Make the patched `asyncio.run` consume the coroutine instead of dropping it. Replace the
+bare `patch("bridge.email_bridge.asyncio.run")` in both tests with a patch whose
+`side_effect` closes the coroutine it receives:
+
+```python
+with patch("bridge.email_bridge.asyncio.run", side_effect=lambda coro: coro.close()):
+```
+
+`coro.close()` finalizes the coroutine immediately and deterministically, so no
+"never awaited" warning is ever emitted. The tests still exercise the real `main()` code
+path (dotenv gating) without actually running the async loop. This fixes the leak at its
+source rather than suppressing the warning via filterwarnings.
+
+## Success Criteria
+
+- [ ] The two `TestMainEnvLoading` tests patch `asyncio.run` so the received coroutine is closed, not dropped.
+- [ ] `python -W error::RuntimeWarning -m pytest tests/unit/test_email_bridge.py::TestMainEnvLoading -p no:cacheprovider -n0 -q` passes with zero `coroutine 'run_email_bridge' was never awaited` warnings.
+- [ ] The full `tests/unit/test_email_bridge.py` module passes clean.
+- [ ] No production code in `bridge/email_bridge.py` changed.
+
+## No-Gos
+
+- Do NOT suppress the warning via `filterwarnings` / `pytest.ini` — that hides the leak
+  instead of fixing it, and would mask genuinely un-awaited coroutines elsewhere.
+- Do NOT change `bridge/email_bridge.py::main()` production behavior — the leak is entirely
+  in the test's mock, not in production code.
+- Do NOT re-solve #2064 (lock) or #2060 (db isolation).
+
+## Update System
+
+No update system changes required — this is a test-only fix. No new dependencies, config
+files, or migration steps; nothing propagates to other machines beyond the normal git pull.
+
+## Agent Integration
+
+No agent integration required — this is a test-only fix. No new CLI entry point, no bridge
+import changes. The agent's ability to invoke the email bridge is unchanged.
+
+## Failure Path Test Strategy
+
+The fix is itself a test-correctness fix. The failure path is "the coroutine leaks a
+RuntimeWarning." We prove the failure path is closed by running the two affected tests
+under `-W error::RuntimeWarning` and asserting zero `never awaited` warnings — the same
+repro command that currently fails now passes clean.
+
+## Test Impact
+- [ ] `tests/unit/test_email_bridge.py::TestMainEnvLoading::test_main_calls_load_dotenv_with_correct_paths` — UPDATE: change the `asyncio.run` patch to close the received coroutine (`side_effect=lambda coro: coro.close()`). Assertions unchanged.
+- [ ] `tests/unit/test_email_bridge.py::TestMainEnvLoading::test_main_skips_dotenv_under_launchd` — UPDATE: same patch change. Assertions unchanged.
+
+## Rabbit Holes
+
+- Chasing a production-side fix in `main()` — there is none; production awaits correctly.
+- Auditing every `patch(..., "asyncio.run")` in the suite. A sibling instance exists in
+  `tests/unit/test_memory_bridge.py`, but it is out of scope for #2118 (different coroutine,
+  not implicated in the gate wedge). Note it in the PR for a possible follow-up; do not
+  expand this fix to cover it.
+
+## Documentation
+No documentation changes needed — this is a test-internal correctness fix with no
+user-facing surface, no new feature, and no behavior change to any documented component.
+`tests/README.md` already documents `bridge/email_bridge.py` `main()` coverage and remains
+accurate.

--- a/tests/unit/test_bridge_ack_steering_routed.py
+++ b/tests/unit/test_bridge_ack_steering_routed.py
@@ -18,6 +18,23 @@ import pytest
 from bridge.telegram_bridge import _ack_steering_routed
 
 
+def _raise_after_closing(exc):
+    """Build an ``asyncio.create_task`` side_effect that closes the coroutine
+    it is handed before raising ``exc``.
+
+    When ``create_task`` is mocked to fail, the coroutine passed to it (here the
+    real ``_ingest_attachments(...)``) would otherwise be dropped un-awaited and
+    surface a "coroutine ... was never awaited" RuntimeWarning at pytest
+    teardown — one of the leaks that wedged full-suite gates (#2118).
+    """
+
+    def _side_effect(coro, *args, **kwargs):
+        coro.close()
+        raise exc
+
+    return _side_effect
+
+
 def _make_event_message(
     chat_id: int = 12345,
     msg_id: int = 67890,
@@ -319,7 +336,10 @@ class TestMediaEnrichment:
             ),
             patch(
                 "bridge.telegram_bridge.asyncio.create_task",
-                side_effect=RuntimeError("loop closed"),
+                # Close the real _ingest_attachments(...) coroutine handed to
+                # create_task before raising, so it isn't dropped and leaked as
+                # a "coroutine ... was never awaited" RuntimeWarning (#2118).
+                side_effect=_raise_after_closing(RuntimeError("loop closed")),
             ),
             patch("bridge.telegram_bridge.push_steering_message") as push,
             patch("bridge.telegram_bridge.set_reaction", new_callable=AsyncMock),

--- a/tests/unit/test_email_bridge.py
+++ b/tests/unit/test_email_bridge.py
@@ -824,7 +824,13 @@ class TestMainEnvLoading:
         monkeypatch.delenv("VALOR_LAUNCHD", raising=False)
 
         with patch("dotenv.load_dotenv") as mock_load:
-            with patch("bridge.email_bridge.asyncio.run"):
+            # Close the coroutine main() passes to asyncio.run so it is finalized
+            # deterministically here rather than leaking a "coroutine ... was never
+            # awaited" RuntimeWarning into pytest's interpreter/loop teardown (#2118).
+            with patch(
+                "bridge.email_bridge.asyncio.run",
+                side_effect=lambda coro: coro.close(),
+            ):
                 from bridge.email_bridge import main
 
                 main()
@@ -852,7 +858,13 @@ class TestMainEnvLoading:
         monkeypatch.setenv("VALOR_LAUNCHD", "1")
 
         with patch("dotenv.load_dotenv") as mock_load:
-            with patch("bridge.email_bridge.asyncio.run"):
+            # Close the coroutine main() passes to asyncio.run so it is finalized
+            # deterministically here rather than leaking a "coroutine ... was never
+            # awaited" RuntimeWarning into pytest's interpreter/loop teardown (#2118).
+            with patch(
+                "bridge.email_bridge.asyncio.run",
+                side_effect=lambda coro: coro.close(),
+            ):
                 from bridge.email_bridge import main
 
                 main()

--- a/tests/unit/test_telegram_bridge_media_timeout.py
+++ b/tests/unit/test_telegram_bridge_media_timeout.py
@@ -12,7 +12,7 @@ import asyncio
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -93,8 +93,16 @@ async def test_retry_emits_retried_suffix_on_terminal_timeout():
     fake_client = MagicMock()
 
     # Patch wait_for to time out on every attempt — that's the only seam
-    # the retry helper relies on.
-    with patch.object(asyncio, "wait_for", new=AsyncMock(side_effect=TimeoutError())):
+    # the retry helper relies on. The fake must close the coroutine it is
+    # handed (the eagerly-created download_media(...) arg); otherwise it leaks
+    # a "coroutine 'download_media' was never awaited" RuntimeWarning into
+    # pytest's teardown, one of the un-awaited-coroutine leaks that wedged the
+    # full suite (#2118).
+    async def _always_timeout(coro, *args, **kwargs):
+        coro.close()
+        raise TimeoutError()
+
+    with patch.object(asyncio, "wait_for", new=_always_timeout):
         local_path, error = await telegram_bridge._download_media_with_retry(
             fake_client,
             fake_message,
@@ -123,13 +131,14 @@ async def test_retry_succeeds_on_second_attempt():
 
     call_count = {"n": 0}
 
-    async def flaky(*_args, **_kwargs):
+    async def flaky(coro, *_args, **_kwargs):
+        coro.close()  # dispose the download_media(...) coroutine (#2118)
         call_count["n"] += 1
         if call_count["n"] == 1:
             raise TimeoutError()
         return success_path
 
-    with patch.object(asyncio, "wait_for", new=AsyncMock(side_effect=flaky)):
+    with patch.object(asyncio, "wait_for", new=flaky):
         local_path, error = await telegram_bridge._download_media_with_retry(
             fake_client,
             fake_message,
@@ -194,11 +203,12 @@ async def test_first_attempt_success_no_retry():
 
     call_count = {"n": 0}
 
-    async def succeed(*_args, **_kwargs):
+    async def succeed(coro, *_args, **_kwargs):
+        coro.close()  # dispose the download_media(...) coroutine (#2118)
         call_count["n"] += 1
         return success_path
 
-    with patch.object(asyncio, "wait_for", new=AsyncMock(side_effect=succeed)):
+    with patch.object(asyncio, "wait_for", new=succeed):
         local_path, error = await telegram_bridge._download_media_with_retry(
             fake_client,
             fake_message,


### PR DESCRIPTION
## Problem

Closes #2118. During the 2026-07-16 reliability batch, 6/8 parallel SDLC merge gates wedged: the full pytest suite reached ~99%, then hung in async teardown emitting `coroutine 'run_email_bridge' was never awaited` and never wrote junitxml.

## Root cause (a class of leaks)

The wedge is caused by tests handing a real coroutine to a mocked async seam that drops it (never awaited / never closed); at GC/interpreter teardown CPython emits the `never awaited` RuntimeWarning, and the mass-finalization at session teardown wedges pytest before junit is written. `run_email_bridge` was the first-surfaced instance. Verification revealed **five** leaked-coroutine families; this PR fixes the three test-mock leaks at their source:

| Coroutine | Test | Mechanism | Fix |
|-----------|------|-----------|-----|
| `run_email_bridge` | `test_email_bridge.py` (2) | `asyncio.run` mock drops coro | `side_effect=lambda coro: coro.close()` |
| `download_media` | `test_telegram_bridge_media_timeout.py` (3) | `asyncio.wait_for` mock drops the `download_media(...)` arg | async fakes that `coro.close()` the arg |
| `_ingest_attachments` | `test_bridge_ack_steering_routed.py` (1) | mocked `create_task` raises, dropping the real coro | `_raise_after_closing()` closes coro before raising |

No production code changed — all three are test-side.

## Verification

- Targeted repros under `-W error::RuntimeWarning` for each fixed family: **0** `never awaited` warnings.
- A full-suite run confirmed `run_email_bridge` leaks dropped to **0** and the suite advanced past the old ~99% wedge point.
- `tests/unit/test_email_bridge.py` (81), the media-timeout file, and the ack-steering file all pass clean; ruff clean.

## Residual (follow-up #2120)

The full suite still has **two** integration leaks of the same class — `_worker_loop` and `_evaluate_promise_async` — that are async task-lifecycle / sync-wrapper issues (not trivial mock-drops) and need a quiesced machine to verify a fix. They are broader than #2118's named scope and are tracked in #2120. This PR reduces teardown-wedge sources from five to two. A fully-green full-suite run is not achievable on the current non-quiesced dev box regardless (parallel-contention failures).

## Plan
`docs/plans/fix-email-bridge-teardown-hang.md` (in this PR; lands on main at merge). Contains the full leak inventory.