### PR TITLE
Fix residual un-awaited-coroutine leaks: _worker_loop and _evaluate_promise_async (#2120)

### DIFF
--- a/bridge/promise_gate.py
+++ b/bridge/promise_gate.py
@@ -736,8 +736,20 @@ def _run_async_safely(coro):
     except RuntimeError as e:
         # asyncio.run() refuses to run inside a running loop.
         if "running event loop" in str(e):
+            # asyncio.run raises BEFORE it ever touches `coro`, so the
+            # eagerly-created coroutine is neither awaited nor closed. Close it
+            # deterministically here — otherwise it leaks and CPython emits
+            # `coroutine '_evaluate_promise_async' was never awaited` at
+            # GC/teardown, which wedges the full pytest suite (#2120, follow-up
+            # to #2118). This branch is only reachable under a test harness /
+            # async caller; production reaches _run_async_safely from a sync CLI
+            # context with no running loop, so asyncio.run succeeds and the
+            # coroutine is really awaited.
+            coro.close()
             logger.warning("promise_gate: asyncio.run inside running loop, falling through")
             return None
+        # Any other RuntimeError means asyncio.run started the coroutine and it
+        # raised from inside; the coroutine is already finalized. Re-raise.
         raise
 
 

--- a/docs/features/promise-gate.md
+++ b/docs/features/promise-gate.md
@@ -245,6 +245,19 @@ and writes the audit entry with `source="promise_gate_timeout"`.
 | Kill switch on | Audit + skip | Audit JSONL written first; ALLOW returned; `promise_gate.disabled` session_event on real-session |
 | Audit log write fails | Silent log warning | Gate continues; gate's verdict not affected |
 | `cli_check_or_exit` swallows unexpected raise | Fail-open (infrastructure branch) | Logs warning; writes audit `source="promise_gate_cli_exception"`; CLI proceeds to outbox write |
+| LLM path reached while an event loop is already running | Heuristic fallthrough | `_run_async_safely` cannot use `asyncio.run` inside a running loop; it **closes** the coroutine and returns `None` (heuristic takes over). Only reachable under a test harness / async caller — production reaches the sync API from a CLI context with no running loop. |
+
+### The `_run_async_safely` running-loop guard (#2120)
+
+`evaluate_promise` is a sync API; on the CLI Haiku path it runs
+`_run_async_safely(_evaluate_promise_async(text))`. `_run_async_safely` calls
+`asyncio.run(coro)`, which raises `RuntimeError` if an event loop is already running —
+**before** it ever touches the coroutine. Because the `_evaluate_promise_async(text)`
+argument was eagerly created, it would be neither awaited nor closed, leaking
+`coroutine '_evaluate_promise_async' was never awaited` at GC/teardown (the full-suite
+teardown wedge, #2118/#2120). The running-loop branch therefore calls `coro.close()` before
+returning `None`. Behavior is unchanged: in production there is no running loop so
+`asyncio.run` really awaits the coroutine; the close-branch is only exercised under tests.
 
 ## Tests
 

--- a/docs/plans/fix-residual-coroutine-leaks-2120.md
+++ b/docs/plans/fix-residual-coroutine-leaks-2120.md
@@ -1,0 +1,172 @@
+---
+status: Ready
+type: bug
+appetite: Small
+owner: Valor Engels
+created: 2026-07-16
+revised: 2026-07-16
+tracking: https://github.com/tomcounsell/ai/issues/2120
+last_comment_id:
+revision_applied: true
+---
+
+# Fix residual un-awaited-coroutine leaks: `_worker_loop` and `_evaluate_promise_async`
+
+## Problem
+
+Second half of the #2118 teardown-hang fix (PR #2119 merged). The full-suite ~99%
+teardown wedge is a **class** of un-awaited-coroutine leaks: a test hands an eagerly-created
+real coroutine to a seam that drops it (never awaited, never closed). At GC / session
+teardown CPython finalizes the coroutine and emits `coroutine '…' was never awaited`; on a
+contended machine the mass-finalization wedges the run before junitxml is written. #2118
+fixed 3 of 5 leak families (`run_email_bridge`, `download_media`, `_ingest_attachments`),
+cutting the sources 5 → 2. The two RESIDUAL leaks:
+
+### 1. `_evaluate_promise_async` / `_run_async_safely` (production seam)
+`bridge/promise_gate.py::_run_async_safely(coro)` calls `asyncio.run(coro)`. When an event
+loop is **already running** (pytest-asyncio, or any async caller), `asyncio.run` raises
+`RuntimeError("asyncio.run() cannot be called from a running event loop")` **before touching
+the coroutine** — so the eagerly-created `_evaluate_promise_async(text)` coroutine at
+`promise_gate.py:654` is neither awaited nor closed. The `except RuntimeError` branch logs and
+returns `None` (heuristic fallthrough) but leaves the coroutine open → finalized later at
+GC/teardown → `coroutine '_evaluate_promise_async' was never awaited`.
+
+**Confirmed by deterministic repro** (`_run_async_safely(_evaluate_promise_async(text))` from
+inside a running loop): emits `coroutine '_evaluate_promise_async' was never awaited` at
+finalization.
+
+### 2. `_worker_loop` (test task-lifecycle)
+`agent/agent_session_queue.py:1720 async def _worker_loop(...)` is spawned in integration tests
+via `asyncio.create_task(_worker_loop(...))`. On a failure/timeout path where the created task
+is **not cancel-awaited to completion**, the task's underlying coroutine is finalized at GC and
+emits `coroutine '_worker_loop' was never awaited`. Audit of all `create_task(_worker_loop)`
+sites:
+
+| Test | Teardown today | Verdict |
+|------|----------------|---------|
+| `test_slow_redis_no_loop_freeze.py:154` | `finally` gathers ticker/unrelated tasks but **NOT** `worker_task`; only awaited on the happy path via `wait_for` at L209 | **LEAKS** on any early failure/timeout |
+| `test_worker_wedge_pending.py:245` | `finally` cancels + `wait_for(shield(...), 1.0)` | OK (reference pattern) |
+| `test_progress_deadline_cancel.py:122` | `_teardown_loop` cancels + `wait_for(shield(...), 1.0)` | OK (reference pattern) |
+| `test_worker_drain.py` (140/170/199/249) | `await _worker_loop(...)` directly (no create_task) or awaits the helper task | OK |
+| `test_agent_session_queue_async.py` (672/713/759/852) | `await` / `await wait_for(_worker_loop(...))` directly | OK (wait_for cancel-awaits on timeout) |
+| `test_remote_update.py` (343/374) | `await _worker_loop(...)` directly | OK |
+
+The single clear leaker is `test_slow_redis_no_loop_freeze.py`.
+
+### Why these are hard to see
+Neither reproduces deterministically per-file; they only surface in a full integration run
+because the leaked coroutine is held alive inside an event-loop / task **reference cycle**
+until session-level `gc.collect()`, at which point the whole batch finalizes at once and wedges
+teardown. The immediate-refcount-drop case (which fires mid-test and is attributable) is not
+the problem; the cycle-held case (silent until teardown) is.
+
+## Solution
+
+Three changes — fix each source, then add a durable class-level guardrail.
+
+1. **`_run_async_safely` (production):** in the `except RuntimeError` "running event loop"
+   branch, `coro.close()` before returning `None`. `close()` finalizes the coroutine
+   immediately and deterministically, so no "never awaited" warning is ever emitted. Behavior
+   is unchanged: in production `_run_async_safely` is only reached from a **sync** CLI context
+   with no running loop, so `asyncio.run` succeeds and the branch is never taken; the branch
+   fires only under a test harness / async caller, where returning `None` (heuristic
+   fallthrough) is already the contract. We close the coroutine we were handed rather than
+   dropping it.
+
+2. **`_worker_loop` test (`test_slow_redis_no_loop_freeze.py`):** add `worker_task` to the
+   `finally` teardown so it is **cancelled and awaited to completion** on every exit path,
+   matching the established `_teardown_loop` pattern (cancel → `await wait_for(shield(task),
+   timeout)` swallowing `TimeoutError`/`CancelledError`). No production change.
+
+3. **Class-level guardrail (`tests/conftest.py`):** add a non-suppressing
+   `pytest_runtest_teardown(item, nextitem)` hook that runs `gc.collect()` inside
+   `warnings.catch_warnings(record=True)` and, for any captured `coroutine '…' was never
+   awaited` RuntimeWarning, **re-emits it as a loud per-test `RuntimeWarning`** attributed to
+   the finishing test. Under `-W error::RuntimeWarning` this converts a silent ~99%
+   session-teardown wedge into an attributable per-test teardown failure. Validated: cycle-held
+   leaked coroutines (exactly the wedge case) ARE captured by `catch_warnings` around
+   `gc.collect()`. The hook must be xdist-safe (runs in every worker), cheap (one `gc.collect()`
+   per test — acceptable; teardown already does cleanup), and must never itself raise other than
+   the intended re-emitted warning.
+
+## Success Criteria
+
+- [ ] `_run_async_safely` closes the coroutine on the running-loop branch; deterministic repro
+  (call from inside a running loop) emits **zero** `_evaluate_promise_async` "never awaited"
+  warnings under `-W error::RuntimeWarning`.
+- [ ] `test_slow_redis_no_loop_freeze.py` cancel-awaits `worker_task` in `finally`; forcing an
+  early failure no longer leaks `_worker_loop`.
+- [ ] `pytest_runtest_teardown` guardrail present in `tests/conftest.py`; a deliberate
+  cycle-held leaked coroutine surfaces as a loud, test-attributed RuntimeWarning (fail-fast
+  under `-W error`), proven by a dedicated meta-test.
+- [ ] Affected areas run clean under `-W error::RuntimeWarning`: promise-gate unit + the two
+  worker-loop integration files, zero `never awaited` for these two coroutines.
+- [ ] Existing promise-gate and worker-loop tests still pass unchanged in behavior.
+
+## No-Gos
+
+- Do NOT suppress via `filterwarnings` / `pytest.ini` — that hides the whole class. The
+  guardrail must SURFACE, not silence.
+- Do NOT change `_run_async_safely`'s return-`None` contract or the heuristic fallthrough; only
+  stop leaking the coroutine.
+- Do NOT re-solve #2064 (machine-global lock), #2060 (per-process db isolation), or the three
+  already-fixed #2118 leaks.
+- Do NOT make the guardrail hook itself flaky or expensive enough to slow the suite materially.
+
+## Update System
+
+No update-system changes required — this is a test-correctness fix plus one narrow production
+guard (`coro.close()`), both purely internal. No new dependencies, config files, or migration
+steps; nothing propagates to other machines beyond the normal git pull.
+
+## Agent Integration
+
+No agent integration required — no new CLI entry point and no bridge import changes. The
+`promise_gate.evaluate_promise` sync API and its CLI (`cli_check_or_exit`) behave identically;
+the only change is that a coroutine dropped on the never-taken-in-production running-loop branch
+is now closed instead of leaked.
+
+## Documentation
+
+- [ ] Update `tests/README.md` to note the `pytest_runtest_teardown` un-awaited-coroutine
+  guardrail (what it catches, how to read a failure, `-W error::RuntimeWarning` fail-fast).
+- [ ] Add a short note to `docs/features/promise-gate.md` (if the loop-guard behavior is
+  documented there) that `_run_async_safely` closes the coroutine on the running-loop
+  fallthrough. If no such doc section exists, state so — no doc change beyond `tests/README.md`.
+
+## Failure Path Test Strategy
+
+The failure path is "a coroutine leaks a `never awaited` RuntimeWarning." We prove it is closed
+three ways: (a) a promise-gate meta-test that calls `_run_async_safely` from inside a running
+loop under `-W error::RuntimeWarning` and asserts no warning; (b) forcing an early exception in
+the slow-redis test path and asserting `worker_task` is cancel-awaited (no leak); (c) a
+guardrail meta-test that deliberately creates a cycle-held un-awaited coroutine and asserts the
+`pytest_runtest_teardown` hook re-emits an attributable RuntimeWarning.
+
+## Test Impact
+
+- [ ] `tests/integration/test_slow_redis_no_loop_freeze.py` — UPDATE: add `worker_task`
+  cancel-await to the `finally` block. Assertions unchanged.
+- [ ] `tests/unit/test_promise_gate.py` (or a new focused case) — ADD: a meta-test asserting
+  `_run_async_safely` closes the coroutine on the running-loop branch (no `never awaited` under
+  `-W error::RuntimeWarning`). No existing case deleted.
+- [ ] `tests/conftest.py` — UPDATE: add `pytest_runtest_teardown` guardrail hook (new hook, no
+  existing hook removed).
+- [ ] New meta-test for the guardrail (e.g. `tests/unit/test_coroutine_leak_guardrail.py`) —
+  ADD: prove the hook re-emits an attributable warning for a cycle-held leaked coroutine.
+- No other existing tests are affected — the production `_run_async_safely` change is a no-op on
+  the branch every non-test caller takes (no running loop → `asyncio.run` succeeds).
+
+## Rabbit Holes
+
+- Do NOT try to make `_run_async_safely` actually RUN the coroutine on a running loop (dedicated
+  thread + `asyncio.run`): that would make real Haiku API calls under the test harness and
+  change behavior. Closing the coroutine preserves the exact current heuristic-fallthrough
+  contract.
+- Do NOT rewrite the two OK worker-loop teardowns (`test_worker_wedge_pending`,
+  `test_progress_deadline_cancel`) — they already cancel-await.
+- Do NOT chase immediate-refcount-drop leaks — those fire mid-test and are already attributable;
+  the guardrail targets the cycle-held teardown-wedge class.
+- Full-suite green on this non-quiesced box is NOT a success gate — environmental
+  parallel-contention failures are expected and separate. Prove the two specific leaks are gone
+  via targeted repro + the guardrail firing, and document the environmental limitation honestly.

--- a/tests/README.md
+++ b/tests/README.md
@@ -45,6 +45,33 @@ A third, **cross-process** instance (#2060) is not xdist-ordering at all: two se
 
 New instances of this class get filed under the umbrella issue [#1897](https://github.com/tomcounsell/ai/issues/1897) as they're observed and root-caused. `tests/unit/test_conftest_isolation_guards.py` is the deterministic regression suite locking in the fixes (Test A: agent-hooks guard repair; Test B: falsifiable len-vs-identity binding gate for the popoto cache; Test C: #2037 create-then-`filter` round trip; `TestPerProcessDbClaim`: #2060 per-process db claim) — start there when investigating a new phantom failure. See [`docs/features/test-isolation-hardening.md`](../docs/features/test-isolation-hardening.md) for a write-up distinguishing this single-run isolation work from the separate cross-run concurrency coordination in [`docs/features/full-suite-pytest-lock.md`](../docs/features/full-suite-pytest-lock.md).
 
+### Un-awaited-coroutine leak guardrail (issue #2120)
+
+A `pytest_runtest_teardown` hook in `tests/conftest.py` runs one `gc.collect()` at each
+test's teardown inside a warning recorder and **re-emits** any captured `coroutine '...'
+was never awaited` RuntimeWarning as a loud, test-attributed warning. This targets the
+class of full-suite teardown wedge (#2118/#2120): a test hands an eagerly-created coroutine
+to a seam that drops it (never awaited, never closed); when that coroutine is held alive in
+an event-loop / task reference cycle, its finalization is deferred to a session-level
+`gc.collect()` where the whole batch finalizes at once and — on a contended machine —
+hangs the run before junitxml is written.
+
+- **Normal runs:** the leak surfaces as a per-test warning in the summary (non-fatal) —
+  `un-awaited coroutine leak surfaced at teardown of <nodeid>: coroutine '...' was never awaited`.
+- **Fail-fast:** under `python -W error::RuntimeWarning -m pytest ...` the re-emitted warning
+  becomes a per-test teardown **error**, converting a silent session-teardown wedge into an
+  attributable failure at the offending test.
+- **Attribution is best-effort:** a coroutine created in test A but not collected until B's
+  teardown is attributed to B — the goal is to make the class loud and locatable, not
+  forensically perfect.
+- **Escape hatch:** set `COROUTINE_LEAK_GUARD=0` to disable the hook (e.g. to isolate its own
+  cost). Regression suite: `tests/unit/test_coroutine_leak_guardrail.py`.
+
+Fix at source, not by suppression: the three #2118 leaks (`run_email_bridge`,
+`download_media`, `_ingest_attachments`) and the two #2120 residuals (`_evaluate_promise_async`
+via `bridge/promise_gate.py::_run_async_safely`, `_worker_loop` in
+`test_slow_redis_no_loop_freeze.py`) were each closed where the coroutine was dropped.
+
 ### Known-failing clusters resolved on `main` (issue #1578)
 
 The previously known-bad clusters on `main` were driven to green in #1578. The fixes were **test-only** — assertions were re-pointed to current source/templates, never weakened, and no test was deleted:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,14 +4,68 @@ Shared test fixtures for Valor AI tests.
 
 import atexit
 import fcntl
+import gc
 import logging
 import os
 import subprocess
 import sys
 import time
+import warnings
 from unittest.mock import MagicMock
 
 import pytest
+
+# --- Un-awaited-coroutine leak guardrail (#2120) --------------------------
+# A test that hands an eagerly-created coroutine to a seam that drops it (never
+# awaited, never closed) leaks it: CPython finalizes it later and emits
+# `coroutine '...' was never awaited`. When the coroutine is held alive inside
+# an event-loop / task reference cycle, that finalization is deferred to a
+# session-level gc.collect(), where the whole batch finalizes at once and — on a
+# contended machine — wedges teardown before junitxml is written (the ~99%
+# full-suite hang, #2118/#2120).
+#
+# This guardrail runs one gc.collect() at each test's teardown inside a warning
+# recorder. Any captured "never awaited" RuntimeWarning is RE-EMITTED as a loud,
+# test-attributed RuntimeWarning, so a silent session-teardown wedge becomes an
+# attributable per-test signal — and, under `-W error::RuntimeWarning`, a
+# per-test teardown failure (fail-fast). It SURFACES leaks; it never silences
+# them. Set COROUTINE_LEAK_GUARD=0 to disable (e.g. to isolate its own cost).
+_COROUTINE_LEAK_GUARD_ENABLED = os.environ.get("COROUTINE_LEAK_GUARD", "1") != "0"
+
+
+def pytest_runtest_teardown(item, nextitem):
+    """Surface un-awaited-coroutine leaks as a loud, test-attributed warning.
+
+    Cycle-held leaked coroutines are only finalized by gc.collect(); running one
+    here inside a warning recorder attributes the leak to the finishing test
+    instead of letting it accumulate into a silent session-teardown wedge. The
+    re-emitted RuntimeWarning is fatal under `-W error::RuntimeWarning`.
+
+    Attribution is best-effort: a coroutine created in test A but not collected
+    until B's teardown is attributed to B. That is acceptable — the goal is to
+    make the *class* of leak loud and locatable, not forensically perfect.
+    """
+    if not _COROUTINE_LEAK_GUARD_ENABLED:
+        return
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            gc.collect()
+    except Exception:
+        # The guardrail must never itself break a teardown.
+        return
+    leaks = [
+        str(w.message)
+        for w in caught
+        if issubclass(w.category, RuntimeWarning) and "never awaited" in str(w.message)
+    ]
+    for msg in leaks:
+        warnings.warn(
+            f"un-awaited coroutine leak surfaced at teardown of {item.nodeid}: {msg}",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
 
 _logger = logging.getLogger("tests.conftest")
 

--- a/tests/integration/test_slow_redis_no_loop_freeze.py
+++ b/tests/integration/test_slow_redis_no_loop_freeze.py
@@ -143,6 +143,11 @@ async def test_slow_redis_does_not_freeze_loop_or_park_drain(monkeypatch):
     _active_events[chat_id] = event
     asq._session_state._shutdown_requested = False
 
+    # Initialized before the try so the finally can always cancel-await it,
+    # even if the body raises before the task is created (#2120: an orphaned
+    # worker_task leaks `coroutine '_worker_loop' was never awaited`).
+    worker_task = None
+
     try:
         with (
             patch("agent.agent_session_queue._execute_agent_session", side_effect=fake_execute),
@@ -213,6 +218,17 @@ async def test_slow_redis_does_not_freeze_loop_or_park_drain(monkeypatch):
     finally:
         ticker_stop.set()
         await asyncio.gather(ticker_task, unrelated_task, return_exceptions=True)
+        # Cancel AND await the worker loop task to completion on every exit
+        # path (#2120). On the happy path it already completed via the wait_for
+        # above; on any early failure/timeout it is still running, and dropping
+        # it here would leak `coroutine '_worker_loop' was never awaited` at GC,
+        # wedging full-suite teardown. Mirrors the _teardown_loop pattern.
+        if worker_task is not None and not worker_task.done():
+            worker_task.cancel()
+            try:
+                await asyncio.wait_for(asyncio.shield(worker_task), timeout=1.0)
+            except (TimeoutError, asyncio.CancelledError):
+                pass
         asq._session_state._shutdown_requested = False
         _active_events.pop(chat_id, None)
         _active_workers.pop(chat_id, None)

--- a/tests/unit/test_coroutine_leak_guardrail.py
+++ b/tests/unit/test_coroutine_leak_guardrail.py
@@ -1,0 +1,110 @@
+"""Meta-tests for the un-awaited-coroutine leak guardrail (#2120).
+
+The guardrail is a ``pytest_runtest_teardown`` hook in ``tests/conftest.py`` that
+runs one ``gc.collect()`` inside a warning recorder and re-emits any captured
+``coroutine '...' was never awaited`` RuntimeWarning as a loud, test-attributed
+warning (fatal under ``-W error::RuntimeWarning``).
+
+These tests call the hook directly with a fake ``item`` so we assert the
+mechanism without needing a nested pytest run.
+"""
+
+import gc
+import types
+import warnings
+
+import tests.conftest as ct
+
+
+def _make_cycle_held_leak():
+    """Create a cycle-held, un-awaited coroutine and drop the local name.
+
+    The holder dict references itself, so the whole cycle (and the coroutine it
+    carries) is unreachable but survives ordinary refcount collection — it is
+    only finalized by an explicit ``gc.collect()``. That is exactly the
+    teardown-wedge shape the guardrail targets.
+    """
+
+    async def leaky_meta_coro():
+        return 1
+
+    holder = {}
+    holder["self"] = holder
+    holder["coro"] = leaky_meta_coro()
+    # Return without awaiting/closing; `holder` goes out of scope but the
+    # self-reference keeps the cycle alive until gc.collect().
+
+
+def test_guardrail_surfaces_cycle_held_leak():
+    """A cycle-held leaked coroutine is re-emitted, attributed to the node."""
+    fake_item = types.SimpleNamespace(nodeid="meta::cycle_held_leak")
+    gc.disable()
+    try:
+        _make_cycle_held_leak()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ct.pytest_runtest_teardown(fake_item, None)
+    finally:
+        gc.enable()
+
+    surfaced = [
+        w
+        for w in caught
+        if issubclass(w.category, RuntimeWarning)
+        and "never awaited" in str(w.message)
+        and "meta::cycle_held_leak" in str(w.message)
+    ]
+    assert surfaced, (
+        "guardrail did not re-emit a test-attributed RuntimeWarning for a "
+        f"cycle-held un-awaited coroutine; captured: {[str(w.message) for w in caught]}"
+    )
+
+
+def test_guardrail_silent_when_no_leak():
+    """No leak → the guardrail emits nothing (no false positives)."""
+    fake_item = types.SimpleNamespace(nodeid="meta::no_leak")
+    # Collect first so any unrelated cycle-held coroutines from earlier work are
+    # cleared and cannot be misattributed to this call.
+    gc.collect()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        ct.pytest_runtest_teardown(fake_item, None)
+    surfaced = [
+        w
+        for w in caught
+        if issubclass(w.category, RuntimeWarning)
+        and "never awaited" in str(w.message)
+        and "meta::no_leak" in str(w.message)
+    ]
+    assert not surfaced, (
+        f"guardrail emitted a spurious leak warning with no leak present: "
+        f"{[str(w.message) for w in surfaced]}"
+    )
+
+
+def test_guardrail_disabled_via_env(monkeypatch):
+    """COROUTINE_LEAK_GUARD=0 short-circuits the hook (no gc, no warning)."""
+    monkeypatch.setattr(ct, "_COROUTINE_LEAK_GUARD_ENABLED", False)
+    fake_item = types.SimpleNamespace(nodeid="meta::disabled")
+    gc.disable()
+    try:
+        _make_cycle_held_leak()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ct.pytest_runtest_teardown(fake_item, None)
+        # With the guard disabled the hook does not gc.collect, so the leaked
+        # coroutine is NOT surfaced by this call.
+        surfaced = [
+            w
+            for w in caught
+            if issubclass(w.category, RuntimeWarning) and "meta::disabled" in str(w.message)
+        ]
+        assert not surfaced
+    finally:
+        # Clean up the deliberate leak so it does not misattribute elsewhere.
+        # Swallow its own "never awaited" warning inside a recorder — it is a
+        # test artifact of the disabled-guard path, not a real product leak.
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            gc.collect()
+        gc.enable()

--- a/tests/unit/test_promise_gate.py
+++ b/tests/unit/test_promise_gate.py
@@ -585,3 +585,68 @@ class TestAuditOrdering:
         evaluate_promise("   ", transport="telegram", session_id="cli-123")
         evaluate_promise(None, transport="telegram", session_id="cli-123")
         assert not log_path.exists()
+
+
+class TestRunAsyncSafelyNoLeak:
+    """`_run_async_safely` must not leak the coroutine when a loop is running.
+
+    Regression guard for #2120: on the running-event-loop branch,
+    ``asyncio.run`` raises before touching the coroutine, so the eagerly-created
+    ``_evaluate_promise_async(text)`` coroutine must be explicitly closed —
+    otherwise it leaks ``coroutine '_evaluate_promise_async' was never awaited``
+    at GC/teardown and wedges the full suite.
+    """
+
+    def test_closes_coro_on_running_loop_no_warning(self):
+        import asyncio
+        import warnings
+
+        from bridge.promise_gate import _evaluate_promise_async, _run_async_safely
+
+        async def _drive():
+            # A loop IS running here (mirrors pytest-asyncio / any async caller).
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", RuntimeWarning)
+                result = _run_async_safely(_evaluate_promise_async("I will do this later."))
+                # Fallthrough contract: returns None (LLM unavailable), heuristic
+                # takes over in the caller.
+                assert result is None
+                # The coroutine we handed in must already be closed, not merely
+                # dropped — closed coroutines cannot be awaited.
+                # (If it had leaked, the -W error filter would not have caught it
+                # here since finalization is deferred; the explicit close below is
+                # the real assertion.)
+
+        asyncio.run(_drive())
+
+        # Force a collection under an error filter: a leaked coroutine would be
+        # finalized here and raise. A properly closed one produces nothing.
+        import gc
+        import warnings as _w
+
+        with _w.catch_warnings():
+            _w.simplefilter("error", RuntimeWarning)
+            gc.collect()
+
+    def test_running_loop_branch_actually_closes(self):
+        """Directly assert the coroutine object is closed (state check)."""
+        import asyncio
+
+        from bridge.promise_gate import _run_async_safely
+
+        closed = {"seen": False}
+
+        async def _sentinel():
+            return 1
+
+        async def _drive():
+            coro = _sentinel()
+            result = _run_async_safely(coro)
+            assert result is None
+            # A closed coroutine raises RuntimeError when awaited; use getcoroutinestate.
+            import inspect
+
+            closed["seen"] = inspect.getcoroutinestate(coro) == inspect.CORO_CLOSED
+
+        asyncio.run(_drive())
+        assert closed["seen"], "coroutine was not closed on the running-loop branch"


### PR DESCRIPTION
Closes #2120. Second half of the #2118 teardown-hang fix (PR #2119 merged). Eliminates the two RESIDUAL un-awaited-coroutine leak families that wedge the full-suite ~99% teardown, and adds a durable class-level guardrail.

## Root causes and fixes

### 1. `_evaluate_promise_async` / `_run_async_safely` (production seam)
`bridge/promise_gate.py::_run_async_safely(coro)` calls `asyncio.run(coro)`. When an event loop is already running (pytest-asyncio / any async caller), `asyncio.run` raises `RuntimeError` **before touching the coroutine**, so the eagerly-created `_evaluate_promise_async(text)` coroutine was neither awaited nor closed → leaked `coroutine '_evaluate_promise_async' was never awaited` at GC/teardown.

**Fix:** `coro.close()` on the running-loop branch before returning `None`. Behavior unchanged — production reaches this from a sync CLI context with no running loop, so `asyncio.run` really awaits; the close-branch is test-harness only. Verified by deterministic repro (call from inside a running loop): zero warnings under `-W error::RuntimeWarning`.

### 2. `_worker_loop` (test task-lifecycle)
`tests/integration/test_slow_redis_no_loop_freeze.py` created `worker_task = asyncio.create_task(_worker_loop(...))` but its `finally` gathered only the ticker/unrelated tasks — any early failure/timeout orphaned `worker_task` and leaked its coroutine at GC.

**Fix:** cancel AND await `worker_task` on every exit path (mirrors the proven `_teardown_loop` pattern: cancel → `await wait_for(shield(task), 1.0)` swallowing `TimeoutError`/`CancelledError`). Audited all other `create_task(_worker_loop)` sites (`test_worker_wedge_pending`, `test_progress_deadline_cancel`, `test_worker_drain`, `test_agent_session_queue_async`, `test_remote_update`) — they already cancel-await or await directly.

### 3. Class-level guardrail (durable, prevents regressions of the whole class)
New `pytest_runtest_teardown` hook in `tests/conftest.py`: one `gc.collect()` per test inside a warning recorder, re-emitting any `never awaited` RuntimeWarning as a loud, test-attributed warning. Cycle-held leaked coroutines (the teardown-wedge shape) ARE captured by `catch_warnings` around `gc.collect()` (validated). Non-fatal in normal runs; under `-W error::RuntimeWarning` it converts a silent ~99% session-teardown wedge into an attributable per-test failure. `COROUTINE_LEAK_GUARD=0` disables it.

## Verification
- `python -W error::RuntimeWarning -m pytest tests/unit/test_coroutine_leak_guardrail.py tests/unit/test_promise_gate.py::TestRunAsyncSafelyNoLeak -n0 -q` → **5 passed, 0 warnings**.
- `python -W error::RuntimeWarning -m pytest tests/integration/test_slow_redis_no_loop_freeze.py -n0 -q` → **1 passed**.
- `pytest tests/unit/test_promise_gate.py tests/integration/test_worker_wedge_pending.py tests/integration/test_progress_deadline_cancel.py tests/integration/test_worker_drain.py -n0 -q` → **96 passed** (only pre-existing `datetime.utcnow` DeprecationWarnings; no `_worker_loop` leaks, no guardrail false positives).
- Repo has no global `filterwarnings` escalation, so the guardrail is non-fatal by default and cannot break the existing suite.

## Environmental note
Per the issue, a fully-green full suite is not achievable on a non-quiesced dev box (parallel-contention failures are environmental and separate). The two specific leaks are proven gone via targeted repro + the new guardrail firing correctly, rather than by a clean full-suite claim.

## Tests
- `tests/unit/test_coroutine_leak_guardrail.py` — guardrail meta-tests (surfaces cycle-held leak, silent when no leak, env-disable).
- `TestRunAsyncSafelyNoLeak` in `tests/unit/test_promise_gate.py` — asserts the coroutine is closed on the running-loop branch.

## Docs
- `tests/README.md` — new "Un-awaited-coroutine leak guardrail" subsection.
- `docs/features/promise-gate.md` — `_run_async_safely` running-loop guard + failure-mode row.

Plan: `docs/plans/fix-residual-coroutine-leaks-2120.md`.