### PR TITLE
Fix ollama_client wrapper: Client is not a context manager (0.6.1)

### DIFF
--- a/tests/unit/test_ollama_client.py
+++ b/tests/unit/test_ollama_client.py
@@ -1,6 +1,12 @@
 """Unit tests for tools.ollama_client.
 
 No live Ollama server required — all tests stub ollama.Client via unittest.mock.
+
+The stub (_FakeClient) is deliberately NOT a context manager, matching the real
+ollama>=0.4 Client (which has no __enter__/__exit__). This guards against
+regressing to the old `with ollama.Client(...)` pattern, which raised TypeError
+at runtime against the pinned client and silently no-op'd generate() (issue: the
+16GB-machine cloud-generation hotfix).
 """
 
 from __future__ import annotations
@@ -8,6 +14,22 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+
+class _FakeClient:
+    """Stand-in for ollama.Client — a plain object, NOT a context manager.
+
+    Using this in a `with` block raises TypeError (no __enter__), so any
+    reintroduction of the old context-manager pattern fails the suite. Exposes
+    `_client` (the httpx pool) so tests can assert _close_client() closed it.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.init_args = args
+        self.init_kwargs = kwargs
+        self.generate = MagicMock()
+        self.chat = MagicMock()
+        self._client = MagicMock()  # httpx pool; _close_client() calls .close()
 
 
 class TestResolveConfig:
@@ -42,14 +64,10 @@ class TestGenerate:
         """Strips whitespace from the response text and returns it."""
         from tools.ollama_client import generate
 
-        stub_response = self._make_response("  hello  ")
+        fake = _FakeClient()
+        fake.generate.return_value = self._make_response("  hello  ")
 
-        mock_client = MagicMock()
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=False)
-        mock_client.generate.return_value = stub_response
-
-        with patch("ollama.Client", return_value=mock_client):
+        with patch("ollama.Client", return_value=fake):
             result = generate("my prompt", model="m", timeout_s=5.0, base_url="http://localhost")
 
         assert result == "hello"
@@ -58,14 +76,10 @@ class TestGenerate:
         """Returns None when the Ollama response text is empty/whitespace."""
         from tools.ollama_client import generate
 
-        stub_response = self._make_response("")
+        fake = _FakeClient()
+        fake.generate.return_value = self._make_response("")
 
-        mock_client = MagicMock()
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=False)
-        mock_client.generate.return_value = stub_response
-
-        with patch("ollama.Client", return_value=mock_client):
+        with patch("ollama.Client", return_value=fake):
             result = generate("prompt", model="m", timeout_s=5.0, base_url="http://localhost")
 
         assert result is None
@@ -74,43 +88,46 @@ class TestGenerate:
         """Returns None when the client raises (fail-silent contract)."""
         from tools.ollama_client import generate
 
-        mock_client = MagicMock()
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=False)
-        mock_client.generate.side_effect = ConnectionRefusedError("ollama down")
+        fake = _FakeClient()
+        fake.generate.side_effect = ConnectionRefusedError("ollama down")
 
-        with patch("ollama.Client", return_value=mock_client):
+        with patch("ollama.Client", return_value=fake):
             result = generate("prompt", model="m", timeout_s=5.0, base_url="http://localhost")
 
         assert result is None
 
-    def test_client_context_managed_on_generate(self):
-        """Client is used as a context manager (__exit__ is called)."""
+    def test_generate_closes_httpx_pool(self):
+        """The httpx socket pool is closed after generate() (even on the happy path)."""
         from tools.ollama_client import generate
 
-        stub_response = self._make_response("ok")
+        fake = _FakeClient()
+        fake.generate.return_value = self._make_response("ok")
 
-        mock_client = MagicMock()
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=False)
-        mock_client.generate.return_value = stub_response
-
-        with patch("ollama.Client", return_value=mock_client):
+        with patch("ollama.Client", return_value=fake):
             generate("prompt", model="m", timeout_s=5.0, base_url="http://localhost")
 
-        mock_client.__exit__.assert_called_once()
+        fake._client.close.assert_called_once()
+
+    def test_generate_closes_httpx_pool_on_exception(self):
+        """The httpx pool is closed even when the request raises (finally block)."""
+        from tools.ollama_client import generate
+
+        fake = _FakeClient()
+        fake.generate.side_effect = ConnectionRefusedError("ollama down")
+
+        with patch("ollama.Client", return_value=fake):
+            generate("prompt", model="m", timeout_s=5.0, base_url="http://localhost")
+
+        fake._client.close.assert_called_once()
 
     def test_generate_uses_provided_base_url(self):
         """The base_url argument is forwarded to ollama.Client(host=...)."""
         from tools.ollama_client import generate
 
-        stub_response = self._make_response("text")
-        mock_client = MagicMock()
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=False)
-        mock_client.generate.return_value = stub_response
+        fake = _FakeClient()
+        fake.generate.return_value = self._make_response("text")
 
-        with patch("ollama.Client", return_value=mock_client) as mock_cls:
+        with patch("ollama.Client", return_value=fake) as mock_cls:
             generate("prompt", model="my-model", timeout_s=3.0, base_url="http://custom:9999")
 
         mock_cls.assert_called_once_with(host="http://custom:9999", timeout=3.0)
@@ -129,14 +146,10 @@ class TestChat:
         """Returns the assistant message content string."""
         from tools.ollama_client import chat
 
-        stub_response = self._make_chat_response("spam")
+        fake = _FakeClient()
+        fake.chat.return_value = self._make_chat_response("spam")
 
-        mock_client = MagicMock()
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=False)
-        mock_client.chat.return_value = stub_response
-
-        with patch("ollama.Client", return_value=mock_client):
+        with patch("ollama.Client", return_value=fake):
             result = chat(
                 [{"role": "user", "content": "hello"}],
                 model="m",
@@ -149,12 +162,10 @@ class TestChat:
         """chat() propagates exceptions — callers rely on raise-to-escalate."""
         from tools.ollama_client import chat
 
-        mock_client = MagicMock()
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=False)
-        mock_client.chat.side_effect = RuntimeError("ollama down")
+        fake = _FakeClient()
+        fake.chat.side_effect = RuntimeError("ollama down")
 
-        with patch("ollama.Client", return_value=mock_client):
+        with patch("ollama.Client", return_value=fake):
             with pytest.raises(RuntimeError, match="ollama down"):
                 chat(
                     [{"role": "user", "content": "hi"}],
@@ -162,32 +173,39 @@ class TestChat:
                     base_url="http://localhost",
                 )
 
-    def test_client_context_managed_on_chat(self):
-        """Client is used as a context manager (__exit__ is called)."""
+    def test_chat_closes_httpx_pool(self):
+        """The httpx socket pool is closed after chat()."""
         from tools.ollama_client import chat
 
-        stub_response = self._make_chat_response("ok")
-        mock_client = MagicMock()
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=False)
-        mock_client.chat.return_value = stub_response
+        fake = _FakeClient()
+        fake.chat.return_value = self._make_chat_response("ok")
 
-        with patch("ollama.Client", return_value=mock_client):
+        with patch("ollama.Client", return_value=fake):
             chat([{"role": "user", "content": "hi"}], model="m", base_url="http://localhost")
 
-        mock_client.__exit__.assert_called_once()
+        fake._client.close.assert_called_once()
+
+    def test_chat_closes_httpx_pool_on_exception(self):
+        """The httpx pool is closed even when chat() raises (finally block)."""
+        from tools.ollama_client import chat
+
+        fake = _FakeClient()
+        fake.chat.side_effect = RuntimeError("ollama down")
+
+        with patch("ollama.Client", return_value=fake):
+            with pytest.raises(RuntimeError):
+                chat([{"role": "user", "content": "hi"}], model="m", base_url="http://localhost")
+
+        fake._client.close.assert_called_once()
 
     def test_chat_passes_options(self):
         """options dict is forwarded to client.chat() when provided."""
         from tools.ollama_client import chat
 
-        stub_response = self._make_chat_response("reply")
-        mock_client = MagicMock()
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=False)
-        mock_client.chat.return_value = stub_response
+        fake = _FakeClient()
+        fake.chat.return_value = self._make_chat_response("reply")
 
-        with patch("ollama.Client", return_value=mock_client):
+        with patch("ollama.Client", return_value=fake):
             chat(
                 [{"role": "user", "content": "hi"}],
                 model="m",
@@ -195,20 +213,17 @@ class TestChat:
                 options={"temperature": 0},
             )
 
-        call_kwargs = mock_client.chat.call_args
+        call_kwargs = fake.chat.call_args
         assert call_kwargs.kwargs.get("options") == {"temperature": 0}
 
     def test_chat_no_timeout_by_default(self):
         """Without timeout_s, Client is not passed a timeout (preserves prior behavior)."""
         from tools.ollama_client import chat
 
-        stub_response = self._make_chat_response("ok")
-        mock_client = MagicMock()
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=False)
-        mock_client.chat.return_value = stub_response
+        fake = _FakeClient()
+        fake.chat.return_value = self._make_chat_response("ok")
 
-        with patch("ollama.Client", return_value=mock_client) as mock_cls:
+        with patch("ollama.Client", return_value=fake) as mock_cls:
             chat([{"role": "user", "content": "hi"}], model="m", base_url="http://localhost")
 
         # timeout should NOT be in the Client constructor kwargs

--- a/tools/ollama_client.py
+++ b/tools/ollama_client.py
@@ -42,6 +42,22 @@ def resolve_config() -> tuple[str, str, float]:
     return m.ollama_host, m.ollama_generation_model, m.memory_title_timeout_s
 
 
+def _close_client(client) -> None:
+    """Eagerly close an ollama.Client's underlying httpx socket pool.
+
+    ollama>=0.4 Client is NOT a context manager (no __enter__/__exit__), so we
+    close the httpx connection pool by hand (it has no __del__). Best-effort:
+    swallow any close error so it never masks the caller's result/exception.
+    """
+    inner = getattr(client, "_client", None)
+    close = getattr(inner, "close", None)
+    if close is not None:
+        try:
+            close()
+        except Exception:  # noqa: BLE001, S110 — close is best-effort cleanup
+            pass
+
+
 def generate(
     prompt: str,
     *,
@@ -56,8 +72,9 @@ def generate(
     output (so callers' None-on-failure fallback chains fire correctly — e.g. the
     knowledge indexer's Haiku fallback triggers when Ollama returns an empty string).
 
-    Constructs ollama.Client inside a `with` block for deterministic socket close
-    (httpx connection pool has no __del__; the with block closes sockets eagerly).
+    Constructs ollama.Client and closes its httpx socket pool via _close_client()
+    in a finally block (the pool has no __del__; ollama>=0.4 Client is not a
+    context manager, so we close sockets eagerly by hand).
 
     Args:
         prompt: The text prompt to send.
@@ -73,8 +90,11 @@ def generate(
 
     label = caller or "ollama_client"
     try:
-        with ollama.Client(host=base_url, timeout=timeout_s) as client:
+        client = ollama.Client(host=base_url, timeout=timeout_s)
+        try:
             response = client.generate(model=model, prompt=prompt, stream=False)
+        finally:
+            _close_client(client)
         text = response.response
         return text.strip() or None
     except Exception as e:  # noqa: BLE001 — fail-silent by contract
@@ -96,7 +116,8 @@ def chat(
     Does NOT return None; a transport/model error propagates to the caller's
     try/except block.
 
-    Constructs ollama.Client inside a `with` block for deterministic socket close.
+    Constructs ollama.Client and closes its httpx socket pool via _close_client()
+    in a finally block (ollama>=0.4 Client is not a context manager).
 
     No timeout is passed when timeout_s is None (httpx default = no timeout),
     preserving the pre-existing behavior of the module-level ollama.chat() call
@@ -118,10 +139,13 @@ def chat(
     if timeout_s is not None:
         client_kwargs["timeout"] = timeout_s
 
-    with ollama.Client(**client_kwargs) as client:
+    client = ollama.Client(**client_kwargs)
+    try:
         chat_kwargs: dict = {"model": model, "messages": messages}
         if options is not None:
             chat_kwargs["options"] = options
         response = client.chat(**chat_kwargs)
+    finally:
+        _close_client(client)
 
     return response.message.content


### PR DESCRIPTION
## Problem
While fixing a 16GB-machine crash (a 19GB local `gemma4:31b` was being loaded), testing the reconfigured cloud generation revealed a second, pre-existing bug: **`tools/ollama_client.py` was broken against the pinned `ollama==0.6.1`**.

The wrapper used `with ollama.Client(...) as client:`, but 0.6.1's `Client` has no `__enter__`/`__exit__`, so **every call raised `TypeError`**:
- `generate()` caught it and returned `None` (fail-soft) → memory-title generation and knowledge-doc summarization have been silently no-op'ing
- `chat()` re-raised

The existing unit tests hid this by mocking `Client` *with* fake `__enter__`/`__exit__`, so the mock's API didn't match the real library.

## Fix
- Replace the unsupported context manager in `generate()` and `chat()` with explicit construction plus a `_close_client()` `finally` block that closes the httpx socket pool by hand (the pool has no `__del__`; deterministic close was the original intent of the `with`).
- Rewrite the unit tests to stub a **plain, non-context-manager** `_FakeClient`, so reintroducing `with ollama.Client(...)` fails immediately. Added coverage that the pool is closed on both success and error paths.

## Verification
- End-to-end through the app wrapper: `generate()` and `chat()` now return real output against `gemma4:31b-cloud` (zero local RAM).
- `31 passed` in `tests/unit/test_ollama_client.py` + `test_ollama_consolidation.py`; ruff clean.

## Note / follow-up
Separate from this PR: the RAM guard in `config/models.py:247` only fires for tags containing `"mlx"`, so any large non-mlx local tag (like plain `gemma4:31b`) bypasses it — that's what caused the original crash. Worth a follow-up issue to gate all local (non-cloud) tags by actual model size.

Closes #2128