### PR TITLE
Fix validate_docs_changed exit-code and diff-scoped stale scan (#2133)

### DIFF
--- a/docs/features/documentation-lifecycle.md
+++ b/docs/features/documentation-lifecycle.md
@@ -38,9 +38,9 @@ After the build agent creates a PR, a validation script checks that promised doc
 - **Script**: `scripts/validate_docs_changed.py`
 - **Invoked by**: Build skill (Step 7.5 in `.claude/skills/do-build/SKILL.md`)
 - **Phase 1 — Diff Check**: Parses the plan's `## Documentation` section, extracts expected doc paths, and verifies they appear in `git diff` against the base branch
-- **Phase 2 — Stale Marker Scan**: Scans all changed `.md` files for stale markers (`DEPRECATED`, `LEGACY`, `OBSOLETE`, `TODO: remove`, `FIXME: update`)
+- **Phase 2 — Stale Marker Scan**: Scans the changed `.md` files for stale markers (`DEPRECATED`, `LEGACY`, `OBSOLETE`, `TODO: remove`, `FIXME: update`). The scan is **diff-scoped** — it examines only the lines this branch ADDED (`git diff {base}...HEAD -U0` `+` lines), never pre-existing file content, so a plan that targets a large pre-existing doc (e.g. `CLAUDE.md`) never trips on unchanged text.
 - **Flags**: `--dry-run` (report only), `--base-branch` (compare target, defaults to `main`)
-- **Exit codes**: 0 = pass, 1 = missing docs (hard fail), 2 = stale markers found (warning)
+- **Exit codes**: `0` = pass; `1` = missing docs (hard fail, **BLOCKS PR**); `2` = stale markers found in added lines (**non-blocking warning** — the only non-blocking code, PR proceeds); `3` = internal/usage error such as plan file not found or unreadable (**BLOCKS PR**)
 
 ### Gate 3: Plan Migration (at Merge)
 
@@ -112,8 +112,9 @@ python scripts/migrate_completed_plan.py docs/plans/my-feature.md --skip-issue
 | Problem | Cause | Solution |
 |---------|-------|----------|
 | Plan validation blocks write | Missing or empty `## Documentation` section | Add checklist items with doc paths OR explicit exemption with 50+ char justification |
-| Build validation fails (exit 1) | Expected docs not created/modified | Create/modify the docs listed in plan's Documentation section |
-| Build validation warns (exit 2) | Stale markers found in changed docs | Remove `DEPRECATED`/`LEGACY`/`OBSOLETE` markers from documentation |
+| Build validation fails (exit 1, BLOCKS PR) | Expected docs not created/modified | Create/modify the docs listed in plan's Documentation section |
+| Build validation warns (exit 2, non-blocking) | Stale markers found in **added** doc lines | Remove `DEPRECATED`/`LEGACY`/`OBSOLETE` markers from the lines this branch added (pre-existing content is never flagged); PR still proceeds |
+| Build validation errors (exit 3, BLOCKS PR) | Plan file not found or unreadable | Pass a valid plan path; a real error is never silently treated as a warning |
 | Migration fails - doc not found | Feature doc path doesn't match plan | Ensure `docs/features/` path in plan matches created doc |
 | Migration fails - not indexed | Feature missing from README.md | Add entry to `docs/features/README.md` table |
 | Migration fails - can't close issue | `gh` CLI issue | Verify `tracking:` URL in plan frontmatter is valid |

--- a/docs/plans/validate-docs-exit-scope.md
+++ b/docs/plans/validate-docs-exit-scope.md
@@ -271,16 +271,16 @@ by the `do-build` skill via Bash, not an agent-facing tool. No MCP surface, no
 
 ## Success Criteria
 
-- [ ] Stale marker in an added line → validator exits `2` (not `1`).
-- [ ] Missing expected docs → validator exits `1`.
-- [ ] Missing plan file → validator exits `3` (not `2`).
-- [ ] A trigger word that exists only in PRE-EXISTING (unchanged) file content is
+- [x] Stale marker in an added line → validator exits `2` (not `1`).
+- [x] Missing expected docs → validator exits `1`.
+- [x] Missing plan file → validator exits `3` (not `2`).
+- [x] A trigger word that exists only in PRE-EXISTING (unchanged) file content is
   NOT flagged — validator exits `0`.
-- [ ] A trigger word in a brand-new untracked doc IS flagged (exit `2`).
-- [ ] New test file `tests/unit/test_validate_docs_changed.py` passes.
-- [ ] Tests pass (`/do-test`)
-- [ ] Documentation updated (`/do-docs`)
-- [ ] `python -m ruff check scripts/validate_docs_changed.py tests/unit/test_validate_docs_changed.py` clean
+- [x] A trigger word in a brand-new untracked doc IS flagged (exit `2`).
+- [x] New test file `tests/unit/test_validate_docs_changed.py` passes.
+- [x] Tests pass (`/do-test`)
+- [x] Documentation updated (`/do-docs`)
+- [x] `python -m ruff check scripts/validate_docs_changed.py tests/unit/test_validate_docs_changed.py` clean
 
 ## Team Orchestration
 

--- a/docs/plans/validate-docs-exit-scope.md
+++ b/docs/plans/validate-docs-exit-scope.md
@@ -1,11 +1,13 @@
 ---
-status: Planning
+status: Ready
 type: bug
 appetite: Small
 owner: Valor Engels
 created: 2026-07-17
 tracking: https://github.com/tomcounsell/ai/issues/2133
 last_comment_id:
+revision_applied: true
+revision_applied_at: 2026-07-17T11:32:08Z
 ---
 
 # validate_docs_changed.py stale-marker scan: exit-code and scope fix
@@ -43,6 +45,10 @@ false-positive PR blocks.
 - Missing docs → exit `1` (hard fail, blocks PR), reserved for this case only.
 - Internal/usage errors (plan not found, read failure) → exit `3` (distinct from
   the warning code) so a real error is never confused with a stale-marker warning.
+  Exit `3` **extends** the documented 0/1/2 contract by splitting the previously
+  overloaded exit `2` (which the old docstring used for BOTH "file/command error"
+  AND — per `documentation-lifecycle.md` — "stale markers"); exit `2` now means
+  ONLY the non-blocking stale warning.
 - The stale-marker scan examines ONLY lines ADDED by this branch
   (`git diff {base}...HEAD -U0` `+` lines), never pre-existing file content.
 - Docs (`documentation-lifecycle.md`, `do-build.md`) reflect the reconciled
@@ -144,10 +150,19 @@ surfaces in the build report.
   - Run `git diff --unified=0 {base}...HEAD -- {doc_path}` (three-dot: changes on
     HEAD since branch point — matches the "added by this PR" intent and the
     `do-build` `main...HEAD` convention on line 105).
-  - Parse hunk headers `@@ -a,b +c,d @@` to track new-file line numbers; collect
-    lines starting with `+` (excluding the `+++` file header).
-  - If the diff is empty AND the file is untracked (`git ls-files --error-unmatch`
-    fails), treat every line of the file as added (brand-new doc).
+  - Parse hunk headers with `@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@` — git OMITS
+    the `,d` count when it equals 1, so single-line additions emit `@@ -a +c @@`
+    and a brand-new single-line doc emits `@@ -0,0 +1 @@`. When the count group is
+    None, default `d = 1`. Track new-file line numbers from `c`; collect `+`-body
+    lines (excluding the `+++` file header). **(concern #2)**
+  - If the diff is empty, before concluding "no added lines" check whether the doc
+    is a NEW file that this branch is adding but that three-dot diff misses:
+    - Untracked (`git ls-files --error-unmatch <doc>` fails) → treat every line as
+      added (brand-new doc).
+    - Staged-but-uncommitted addition (`git diff --cached --name-only -- <doc>`
+      lists it) → also treat every line as added, so a staged new doc is scanned.
+      **(concern #3 — bounded in the normal do-build flow where docs are committed
+      before Gate 2, but handled for correctness.)**
 - `check_deprecated_markers(matched, base_branch)` iterates matched docs, pulls
   added lines via the helper, and applies the existing skip rules (code fences,
   headings, inline-code stripping) to those lines only. Line numbers reported are
@@ -239,12 +254,18 @@ by the `do-build` skill via Bash, not an agent-facing tool. No MCP surface, no
 
 - [ ] Update `docs/features/documentation-lifecycle.md` — Gate 2 description
   (line 41-43) and the Troubleshooting table (lines 115-116) to state the
-  reconciled contract: exit `1` = missing docs (hard fail), exit `2` = stale
-  markers (non-blocking warning, diff-scoped), exit `3` = file/command error; and
-  that the stale scan examines only diff-added lines.
-- [ ] Update `docs/sdlc/do-build.md:104` — change "exit 1 BLOCKS PR" to reflect
-  that exit `1` blocks (missing docs), exit `2` is a non-blocking stale-marker
-  warning, and exit `3` is an error.
+  reconciled contract: exit `1` = missing docs (hard fail, BLOCKS), exit `2` =
+  stale markers (non-blocking warning, diff-scoped — the ONLY non-blocking code),
+  exit `3` = file/command error (BLOCKS); and that the stale scan examines only
+  diff-added lines. Mirror the same blocking/non-blocking annotation used in
+  do-build.md so all surfaces agree exit 2 is the sole non-blocking code.
+  **(concern #1)**
+- [ ] Update `docs/sdlc/do-build.md:104` — change "exit 1 BLOCKS PR" to spell out
+  the per-code blocking semantics explicitly, e.g. `exit 1 (missing docs) or
+  exit 3 (file/command error) BLOCKS PR; exit 2 (stale markers) = non-blocking
+  warning, proceed`. The comment is LLM-read (no shell branches on `$?`), so it
+  MUST state that exit 3 blocks — otherwise a genuine error reads as
+  non-blocking, strictly worse than today. **(concern #1)**
 - [ ] Update the module docstring in `scripts/validate_docs_changed.py` exit-code
   table to match.
 
@@ -280,6 +301,14 @@ for a single-file fix plus its test module.
 - Assert the DOCUMENTED contract: exit `2` for stale markers, exit `1` for missing
   docs, exit `3` for missing plan file, exit `0` when trigger words exist only in
   pre-existing content, exit `2` for a stale marker in a new untracked doc.
+- **(concern #4)** Add a real-world regression case: a doc whose pre-existing
+  (non-added) content contains a real flagged phrase from the issue (e.g.
+  CLAUDE.md's "NO LEGACY CODE TOLERANCE") plus one unrelated ADDED line → assert
+  exit `0`. Reference `docs/plans/completed/merge-gate-baseline-refresh.md:364` as
+  the workaround this removes.
+- **(concern #2)** Add a single-line-addition case whose diff hunk header is
+  `@@ -0,0 +1 @@` (omitted `,d` count) to prove the parser catches single-line
+  additions.
 - Run and confirm they FAIL against current code (red).
 
 ### 2. Fix the validator (TDD green)
@@ -332,3 +361,9 @@ for a single-file fix plus its test module.
 <!-- Populated by /do-plan-critique (war room). Leave empty until critique is run. -->
 | Severity | Critic | Finding | Addressed By | Implementation Note |
 |----------|--------|---------|--------------|---------------------|
+| CONCERN | Risk/History/Scope | do-build.md:104 must encode per-exit-code blocking semantics (exit 3 also blocks) | Documentation tasks reworded | Comment is LLM-read; state exit 1 & 3 block, exit 2 is the only non-blocking warning; mirror in documentation-lifecycle.md |
+| CONCERN | Risk & Robustness | Hunk-header parser must handle omitted `,d` count (single-line adds `@@ -a +c @@`) | Technical Approach + test | Regex `@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@`, default d=1; test `@@ -0,0 +1 @@` |
+| CONCERN | Risk & Robustness | Staged-but-uncommitted new doc → three-dot diff misses it, Phase 2 scans nothing | Technical Approach untracked/staged fallback | On empty diff, also check `git diff --cached --name-only`; bounded since do-build commits docs before Gate 2 |
+| CONCERN | Scope & Value | Success Criteria lack a real PR #2132 regression test | build-tests task | Stage a doc with pre-existing "NO LEGACY CODE TOLERANCE" + unrelated added line → assert exit 0 |
+| NIT | Scope & Value | Discriminated outcome enum vs. exit int | Accepted as-is | String/enum kept for test readability |
+| NIT | History & Consistency | "documented contract" framing vs. new exit 3 | Problem section clarified | Exit 3 extends the contract by splitting overloaded exit 2 |

--- a/docs/plans/validate-docs-exit-scope.md
+++ b/docs/plans/validate-docs-exit-scope.md
@@ -1,0 +1,334 @@
+---
+status: Planning
+type: bug
+appetite: Small
+owner: Valor Engels
+created: 2026-07-17
+tracking: https://github.com/tomcounsell/ai/issues/2133
+last_comment_id:
+---
+
+# validate_docs_changed.py stale-marker scan: exit-code and scope fix
+
+## Problem
+
+`scripts/validate_docs_changed.py` is Gate 2 of the documentation lifecycle
+(invoked at build completion, `do-build.md` Step 6). Its Phase 2 "stale marker
+scan" diverges from its own documented contract in two ways that produce
+false-positive PR blocks.
+
+**Current behavior:**
+1. **Exit-code mismatch.** `main()` returns exit `1` for BOTH "no expected docs
+   changed" (missing docs) AND "deprecated markers found" (stale markers). The
+   documented contract (`docs/features/documentation-lifecycle.md:43`) says:
+   `0` = pass, `1` = missing docs (hard fail), `2` = stale markers (warning).
+   Stale markers should be a non-blocking exit `2`, not a hard exit `1`.
+2. **Scan-scope mismatch.** `check_deprecated_markers()` reads the ENTIRE content
+   of every matched doc file and flags any line containing a trigger word. When a
+   plan lists a large, pre-existing doc as a target (e.g. `CLAUDE.md`,
+   `docs/features/tools-reference.md`), the scan sweeps thousands of pre-existing
+   lines the PR never touched. Issue #2133 documented four concrete false
+   positives — all four lines exist verbatim on `main` and none were added by the
+   PR (verified by diff-scoped grep):
+   - `CLAUDE.md:262-263` — the "NO LEGACY CODE TOLERANCE" principle text
+   - `CLAUDE.md:612` — "Do NOT use a `feature` label"
+   - `docs/features/tools-reference.md:371` — historical "legacy … retired in #1256" note
+3. **Exit-code collision.** The current `main()` uses exit `2` for "file/command
+   error" (plan file not found) — which collides with the documented meaning of
+   exit `2` (stale-marker warning). A missing plan file must NOT be silently
+   treated as a mere warning.
+
+**Desired outcome:**
+- Stale markers → exit `2` (non-blocking warning), per the documented contract.
+- Missing docs → exit `1` (hard fail, blocks PR), reserved for this case only.
+- Internal/usage errors (plan not found, read failure) → exit `3` (distinct from
+  the warning code) so a real error is never confused with a stale-marker warning.
+- The stale-marker scan examines ONLY lines ADDED by this branch
+  (`git diff {base}...HEAD -U0` `+` lines), never pre-existing file content.
+- Docs (`documentation-lifecycle.md`, `do-build.md`) reflect the reconciled
+  contract, including the new error code.
+
+## Freshness Check
+
+**Baseline commit:** 85d5f0432f2f6029677a986b8bbb3b8009cdd24e
+**Issue filed at:** 2026-07-17T06:06:16Z
+**Disposition:** Unchanged
+
+**File:line references re-verified:**
+- `scripts/validate_docs_changed.py` — `main()` returns `1` for missing docs AND
+  deprecated markers (lines 268-290 return `False` → `main` returns 1 at 342);
+  `check_deprecated_markers()` scans full file content (lines 183-217); exit `2`
+  used for plan-not-found (line 328) — all still hold.
+- `docs/features/documentation-lifecycle.md:43` — "0 = pass, 1 = missing docs
+  (hard fail), 2 = stale markers found (warning)" — still present, verbatim.
+- `docs/sdlc/do-build.md:104` — "exit 1 BLOCKS PR" — still present, verbatim.
+
+**Cited sibling issues/PRs re-checked:** Issue references #2114/PR #2132 (the
+build during which this was found) — merged; not a blocker for this fix.
+
+**Commits on main since issue was filed (touching referenced files):** None. The
+three affected files have no commits since `2026-07-17T06:06:16Z`.
+
+**Active plans in `docs/plans/` overlapping this area:** None.
+
+**Notes:** Recon Summary section absent from the issue body, but every claim is
+backed by a concrete file:line pointer that was re-verified by hand against the
+current code — evidence requirement satisfied manually.
+
+## Prior Art
+
+No prior issues or PRs attempted to fix this validator's exit-code or scan-scope
+behavior. Related context only:
+- **PR #2132** (#2114 build) — surfaced the false positives; a doc note in
+  `docs/plans/completed/merge-gate-baseline-refresh.md:364` already documents the
+  full-file-scan false-positive as a known workaround ("applied outside the
+  plan's Documentation contract"). This fix removes the need for that workaround.
+
+## Data Flow
+
+1. **Entry point**: `do-build` Step 6 runs `python scripts/validate_docs_changed.py {PLAN_PATH}`.
+2. **`extract_doc_paths(plan_text)`**: parses the plan's `## Documentation`
+   section → list of expected `.md` paths.
+3. **`get_changed_files(base)`** → `changed_docs` (the `.md` subset).
+4. **Phase 1** matches expected vs. changed. No match → missing docs → exit `1`.
+5. **Phase 2** `check_deprecated_markers(matched)` — TODAY reads full file
+   content; AFTER this fix reads only diff-added lines from
+   `git diff {base}...HEAD -U0 -- <file>`. Violations → exit `2` (warning).
+6. **Output**: `main()` maps the outcome to the reconciled exit code and prints
+   pass/warning/fail messaging.
+
+## Appetite
+
+**Size:** Small
+
+**Team:** Solo dev
+
+**Interactions:**
+- PM check-ins: 0
+- Review rounds: 1
+
+## Prerequisites
+
+No prerequisites — this work uses only `git`, the stdlib, and pytest already present.
+
+## Solution
+
+### Key Elements
+
+- **Exit-code reconciliation** (`main()`): distinguish three outcomes —
+  pass (`0`), missing-docs hard fail (`1`), stale-marker warning (`2`) — and move
+  internal/usage errors to a distinct code (`3`).
+- **Diff-scoped stale scan** (`check_deprecated_markers` + new helper): a helper
+  `get_added_lines(doc_path, base_branch)` returns the `+` lines introduced by
+  `git diff {base}...HEAD -U0 -- <doc_path>` with their new-file line numbers.
+  For untracked/brand-new docs (not in the diff), all lines count as added.
+  The marker scan runs over ONLY those added lines, preserving the existing
+  code-fence / heading / inline-code skip logic.
+- **Structured result** (`validate_docs_changed`): return an outcome the caller
+  can map to the right exit code (e.g. a small enum/string:
+  `"pass" | "missing_docs" | "stale_markers"`), instead of a bare
+  `(success, message)` that erases the missing-vs-stale distinction.
+
+### Flow
+
+`do-build` Step 6 → run validator → validator scans only added lines of matched
+docs → outcome maps to exit code (0 pass / 1 missing / 2 stale-warning / 3 error)
+→ do-build treats exit 1 as a PR blocker, exit 2 as a non-blocking warning it
+surfaces in the build report.
+
+### Technical Approach
+
+- Introduce an outcome discriminator so `main()` can pick the exit code. Keep the
+  human-readable message.
+- Add `get_added_lines(doc_path, base_branch) -> list[tuple[int, str]]`:
+  - Run `git diff --unified=0 {base}...HEAD -- {doc_path}` (three-dot: changes on
+    HEAD since branch point — matches the "added by this PR" intent and the
+    `do-build` `main...HEAD` convention on line 105).
+  - Parse hunk headers `@@ -a,b +c,d @@` to track new-file line numbers; collect
+    lines starting with `+` (excluding the `+++` file header).
+  - If the diff is empty AND the file is untracked (`git ls-files --error-unmatch`
+    fails), treat every line of the file as added (brand-new doc).
+- `check_deprecated_markers(matched, base_branch)` iterates matched docs, pulls
+  added lines via the helper, and applies the existing skip rules (code fences,
+  headings, inline-code stripping) to those lines only. Line numbers reported are
+  the true new-file line numbers.
+- `main()`:
+  - plan not found / read error → exit `3` (was `2`/`1`).
+  - missing docs → exit `1`.
+  - stale markers → print warning to stderr, exit `2`.
+  - pass → exit `0`.
+- Update the module docstring exit-code table to match.
+
+## Failure Path Test Strategy
+
+### Exception Handling Coverage
+- [ ] `get_changed_files` already swallows `subprocess` errors returning `[]`; the
+  new `get_added_lines` helper follows the same pattern (git failure → treat as no
+  added lines / fall back). Test asserts a git failure does not crash and yields a
+  defined result.
+- [ ] No new bare `except Exception: pass` blocks introduced.
+
+### Empty/Invalid Input Handling
+- [ ] Doc with zero added lines (only deletions or unchanged) → scan finds no
+  violations even if the file body contains trigger words. Covered by a test.
+- [ ] Untracked brand-new doc → all lines treated as added; a stale marker in it
+  IS flagged. Covered by a test.
+
+### Error State Rendering
+- [ ] Missing plan file → exit `3` with an error message on stderr (test asserts
+  exit code and message channel).
+- [ ] Stale marker → warning message on stderr, exit `2` (non-blocking). Test
+  asserts the message makes the "warning, not hard fail" distinction visible.
+
+## Test Impact
+
+No existing tests affected — a repo search (`find tests -name '*validate_docs*'`,
+`grep -rn validate_docs_changed tests/`) returns no test file for this script, so
+this is net-new test coverage. New tests will live in
+`tests/unit/test_validate_docs_changed.py`.
+
+## Rabbit Holes
+
+- Do NOT rework `extract_doc_paths` parsing or Phase 1 matching — the issue is
+  scoped to the Phase 2 scan and exit-code mapping only.
+- Do NOT try to semantically classify stale markers (the Limitations section of
+  the feature doc already accepts "simple string matching"). Scope stays: which
+  LINES are scanned, and which EXIT CODE results.
+- Do NOT change how `do-build` orchestrates the call beyond the doc note; the
+  build skill already tolerates non-1 exit codes for other validators.
+
+## Risks
+
+### Risk 1: Three-dot vs two-dot diff base semantics
+**Impact:** `get_changed_files` uses two-dot (`git diff {base} HEAD`) while the new
+helper uses three-dot (`{base}...HEAD`). A file could appear in Phase 1's matched
+set but have no three-dot added lines (e.g. base advanced past the change).
+**Mitigation:** Empty added-lines → zero violations (correct: nothing this branch
+added is stale). The untracked-file fallback covers brand-new docs. Both paths are
+explicitly tested.
+
+### Risk 2: do-build consumers assuming exit 2 == error
+**Impact:** If any caller currently treats exit `2` as a fatal error, the new
+warning semantics could change behavior.
+**Mitigation:** Only `docs/sdlc/do-build.md:104` references this script's exit
+codes, and it only calls out "exit 1 BLOCKS PR". No code path branches on exit `2`
+today. Doc is updated to state 1 = block, 2 = warning, 3 = error.
+
+## Race Conditions
+
+No race conditions identified — the validator is a synchronous, single-threaded
+CLI that reads git state and files once per invocation.
+
+## No-Gos (Out of Scope)
+
+Nothing deferred — every relevant item is in scope for this plan.
+
+## Update System
+
+No update system changes required — `scripts/validate_docs_changed.py` is invoked
+directly by the `do-build` skill; it is not propagated by `/update` and has no new
+dependencies or config.
+
+## Agent Integration
+
+No agent integration required — this script is a build-pipeline validator invoked
+by the `do-build` skill via Bash, not an agent-facing tool. No MCP surface, no
+`.mcp.json` change, no bridge import.
+
+## Documentation
+
+- [ ] Update `docs/features/documentation-lifecycle.md` — Gate 2 description
+  (line 41-43) and the Troubleshooting table (lines 115-116) to state the
+  reconciled contract: exit `1` = missing docs (hard fail), exit `2` = stale
+  markers (non-blocking warning, diff-scoped), exit `3` = file/command error; and
+  that the stale scan examines only diff-added lines.
+- [ ] Update `docs/sdlc/do-build.md:104` — change "exit 1 BLOCKS PR" to reflect
+  that exit `1` blocks (missing docs), exit `2` is a non-blocking stale-marker
+  warning, and exit `3` is an error.
+- [ ] Update the module docstring in `scripts/validate_docs_changed.py` exit-code
+  table to match.
+
+## Success Criteria
+
+- [ ] Stale marker in an added line → validator exits `2` (not `1`).
+- [ ] Missing expected docs → validator exits `1`.
+- [ ] Missing plan file → validator exits `3` (not `2`).
+- [ ] A trigger word that exists only in PRE-EXISTING (unchanged) file content is
+  NOT flagged — validator exits `0`.
+- [ ] A trigger word in a brand-new untracked doc IS flagged (exit `2`).
+- [ ] New test file `tests/unit/test_validate_docs_changed.py` passes.
+- [ ] Tests pass (`/do-test`)
+- [ ] Documentation updated (`/do-docs`)
+- [ ] `python -m ruff check scripts/validate_docs_changed.py tests/unit/test_validate_docs_changed.py` clean
+
+## Team Orchestration
+
+Solo dev executes directly in the session worktree. No multi-agent fan-out needed
+for a single-file fix plus its test module.
+
+## Step by Step Tasks
+
+### 1. Write failing tests (TDD red)
+- **Task ID**: build-tests
+- **Depends On**: none
+- **Validates**: tests/unit/test_validate_docs_changed.py (create)
+- **Assigned To**: solo dev
+- **Agent Type**: builder
+- **Parallel**: false
+- Create `tests/unit/test_validate_docs_changed.py` with a git-repo fixture
+  (tmp_path init, commit a base doc, branch, add lines).
+- Assert the DOCUMENTED contract: exit `2` for stale markers, exit `1` for missing
+  docs, exit `3` for missing plan file, exit `0` when trigger words exist only in
+  pre-existing content, exit `2` for a stale marker in a new untracked doc.
+- Run and confirm they FAIL against current code (red).
+
+### 2. Fix the validator (TDD green)
+- **Task ID**: build-fix
+- **Depends On**: build-tests
+- **Validates**: tests/unit/test_validate_docs_changed.py
+- **Assigned To**: solo dev
+- **Agent Type**: builder
+- **Parallel**: false
+- Add `get_added_lines(doc_path, base_branch)` helper (diff parse + untracked
+  fallback).
+- Rework `check_deprecated_markers` to scan added lines only.
+- Rework `validate_docs_changed` to return a discriminated outcome and `main()` to
+  map outcomes to exit codes 0/1/2/3.
+- Update the module docstring exit-code table.
+- Run tests → green.
+
+### 3. Documentation
+- **Task ID**: document-feature
+- **Depends On**: build-fix
+- **Assigned To**: solo dev
+- **Agent Type**: documentarian
+- **Parallel**: false
+- Update `docs/features/documentation-lifecycle.md` (Gate 2 + Troubleshooting).
+- Update `docs/sdlc/do-build.md:104`.
+
+### 4. Final Validation
+- **Task ID**: validate-all
+- **Depends On**: build-fix, document-feature
+- **Assigned To**: solo dev
+- **Agent Type**: validator
+- **Parallel**: false
+- Run `pytest tests/unit/test_validate_docs_changed.py -q`.
+- Run `python -m ruff check` + `python -m ruff format --check` on touched files.
+- Verify all success criteria met.
+
+## Verification
+
+| Check | Command | Expected |
+|-------|---------|----------|
+| New tests pass | `pytest tests/unit/test_validate_docs_changed.py -q` | exit code 0 |
+| Lint clean | `python -m ruff check scripts/validate_docs_changed.py tests/unit/test_validate_docs_changed.py` | exit code 0 |
+| Format clean | `python -m ruff format --check scripts/validate_docs_changed.py tests/unit/test_validate_docs_changed.py` | exit code 0 |
+| Stale scan is diff-scoped | `grep -c 'get_added_lines' scripts/validate_docs_changed.py` | output > 0 |
+| Exit 2 documented for stale | `grep -c 'exit .*2.*stale\|stale.*exit .*2\|2 = stale' docs/features/documentation-lifecycle.md` | output > 0 |
+| Stale scan uses three-dot diff | `grep -c 'base_branch}...HEAD\|\.\.\.HEAD' scripts/validate_docs_changed.py` | output > 0 |
+
+## Critique Results
+
+<!-- Populated by /do-plan-critique (war room). Leave empty until critique is run. -->
+| Severity | Critic | Finding | Addressed By | Implementation Note |
+|----------|--------|---------|--------------|---------------------|

--- a/docs/sdlc/do-build.md
+++ b/docs/sdlc/do-build.md
@@ -101,7 +101,7 @@ python -c "from agent.verification_parser import parse_verification_table, run_c
 **Documentation gate scripts (Step 6):**
 
 ```bash
-(cd $TARGET_REPO/.worktrees/{slug} && python scripts/validate_docs_changed.py {PLAN_PATH})   # exit 1 BLOCKS PR
+(cd $TARGET_REPO/.worktrees/{slug} && python scripts/validate_docs_changed.py {PLAN_PATH})   # exit 1 (missing docs) or exit 3 (file/command error) BLOCKS PR; exit 2 (stale markers, diff-scoped) = non-blocking warning, proceed
 (cd $TARGET_REPO/.worktrees/{slug} && CHANGED_FILES=$(git diff --name-only main...HEAD | tr '\n' ' ') && python scripts/scan_related_docs.py --json $CHANGED_FILES > /tmp/related_docs.json)
 cat /tmp/related_docs.json | python scripts/create_doc_review_issue.py
 ```

--- a/scripts/validate_docs_changed.py
+++ b/scripts/validate_docs_changed.py
@@ -5,10 +5,16 @@ Extracts expected doc paths from plan's ## Documentation section and verifies
 that those documents were actually created, modified, or removed in git.
 Also checks for deprecated/legacy markers in documentation files.
 
+The stale-marker scan is diff-scoped: it examines ONLY the lines this branch
+ADDED (`git diff {base}...HEAD -U0` `+` lines), never pre-existing file content,
+so a plan that targets a large pre-existing doc never trips on unchanged text.
+
 Exit codes:
-    0 - Validation passed (docs changed as planned, no deprecated markers)
-    1 - Validation failed (docs not changed, plan unclear, or deprecated markers found)
-    2 - File or command error
+    0 - Validation passed (expected docs changed, no stale markers in added lines)
+    1 - Missing docs (expected docs not changed) — hard fail, BLOCKS the PR
+    2 - Stale markers found in added lines — non-blocking WARNING (the only
+        non-blocking code); the PR proceeds
+    3 - Internal/usage error (plan file not found or unreadable) — BLOCKS the PR
 
 Usage:
     python scripts/validate_docs_changed.py docs/plans/my-feature.md
@@ -169,29 +175,134 @@ def get_changed_files(base_branch: str = "main") -> list[str]:
     return sorted(changed)
 
 
-def check_deprecated_markers(doc_paths: list[str]) -> list[tuple[str, int, str]]:
-    """Scan documentation files for deprecated/legacy language.
+# Hunk header: `@@ -a,b +c,d @@` — git OMITS the `,d` count when it equals 1,
+# so single-line additions emit `@@ -a +c @@` and a brand-new single-line file
+# emits `@@ -0,0 +1 @@`. Capture the new-file start line (c); count group is optional.
+_HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
 
-    Skips:
+
+def _parse_diff_added(diff_text: str) -> list[tuple[int, str]]:
+    """Parse `git diff -U0` output → list of (new_file_line_number, added_text).
+
+    With --unified=0 there are no context lines, so a hunk is a run of `-` then
+    `+` bodies. Deletions do not advance the new-file counter; additions start at
+    the hunk's `+c` line number.
+    """
+    added: list[tuple[int, str]] = []
+    new_lineno = 0
+    for line in diff_text.split("\n"):
+        m = _HUNK_RE.match(line)
+        if m:
+            new_lineno = int(m.group(1))
+            continue
+        # Skip the file-header lines (`+++ b/path`, `--- a/path`); they always
+        # have a trailing space, whereas an added body line never does after
+        # its single leading `+`.
+        if line.startswith("+++ ") or line.startswith("--- "):
+            continue
+        if line.startswith("+"):
+            added.append((new_lineno, line[1:]))
+            new_lineno += 1
+        elif line.startswith("-"):
+            continue
+        elif line:
+            # Defensive: any context line advances the new-file counter.
+            new_lineno += 1
+    return added
+
+
+def _is_new_branch_file(doc_path: str, base_branch: str) -> bool:
+    """True if doc_path is a brand-new file this branch introduces (absent in base).
+
+    Used only when the three-dot diff is empty — covers untracked new docs and
+    staged-but-uncommitted new docs that `{base}...HEAD` misses. Fail-safe: any
+    git error (including "not a repo") returns False.
+    """
+    try:
+        tracked = subprocess.run(
+            ["git", "ls-files", "--error-unmatch", "--", doc_path],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError):
+        return False
+    # 128 == fatal (not a git repository); do not guess.
+    if tracked.returncode == 128:
+        return False
+
+    try:
+        in_base = subprocess.run(
+            ["git", "cat-file", "-e", f"{base_branch}:{doc_path}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError):
+        return False
+    # Present in base → not brand-new (a modification, already covered by the
+    # three-dot diff); absent → brand-new on this branch.
+    return in_base.returncode != 0
+
+
+def get_added_lines(doc_path: str, base_branch: str = "main") -> list[tuple[int, str]]:
+    """Return (line_number, text) for lines this branch ADDED to doc_path.
+
+    Uses a three-dot diff (`git diff -U0 {base}...HEAD -- {doc}`) so only changes
+    made on HEAD since the branch point count — matching the "added by this PR"
+    intent. For brand-new docs the three-dot diff misses (untracked, or
+    staged-but-uncommitted additions), every current line is treated as added.
+
+    Fail-safe: on any git failure returns [] (nothing to scan) rather than raising.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--unified=0", f"{base_branch}...HEAD", "--", doc_path],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError):
+        return []
+
+    if result.returncode == 0 and result.stdout.strip():
+        added = _parse_diff_added(result.stdout)
+        if added:
+            return added
+
+    # Empty diff: a brand-new file the branch adds won't appear in {base}...HEAD.
+    if _is_new_branch_file(doc_path, base_branch):
+        try:
+            content = Path(doc_path).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return []
+        return list(enumerate(content.split("\n"), start=1))
+
+    return []
+
+
+def check_deprecated_markers(
+    doc_paths: list[str], base_branch: str = "main"
+) -> list[tuple[str, int, str]]:
+    """Scan the ADDED lines of documentation files for deprecated/legacy language.
+
+    Only lines this branch added (per `get_added_lines`) are examined, so
+    pre-existing file content is never flagged. Skips:
     - Markdown headings (lines starting with #)
     - Code blocks (lines between ``` fences)
+    - Inline code (backtick-wrapped text)
 
     Returns list of (filepath, line_number, line_content) for each violation.
     """
     violations = []
 
     for doc_path in doc_paths:
-        path = Path(doc_path)
-        if not path.exists():
-            continue
-
-        try:
-            content = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+        added_lines = get_added_lines(doc_path, base_branch)
+        if not added_lines:
             continue
 
         in_code_block = False
-        for line_num, line in enumerate(content.split("\n"), start=1):
+        for line_num, line in added_lines:
             stripped = line.strip()
 
             # Toggle code block state
@@ -221,37 +332,43 @@ def validate_docs_changed(
     plan_path: Path,
     dry_run: bool = False,
     base_branch: str = "main",
-) -> tuple[bool, str]:
+) -> tuple[str, str]:
     """Validate that docs were changed according to plan.
 
     Two-phase validation:
     1. Check that expected doc files appear in the git diff
-    2. Check that no deprecated/legacy markers exist in those docs
+    2. Check that no deprecated/legacy markers exist in the ADDED lines of those docs
 
-    In dry-run mode, prints expected paths and returns True immediately
+    In dry-run mode, prints expected paths and returns "pass" immediately
     without running actual git validation.
 
-    Returns (success, message).
+    Returns (outcome, message), where outcome is one of:
+        "pass"          — validation succeeded
+        "missing_docs"  — expected docs were not changed (hard fail)
+        "stale_markers" — stale markers found in added lines (non-blocking warning)
+        "error"         — internal/usage error (plan unreadable)
     """
     # Read plan
     try:
         plan_text = plan_path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as e:
-        return False, f"Failed to read plan file: {e}"
+        return "error", f"Failed to read plan file: {e}"
 
     # Extract expected doc paths (this function handles missing section via sys.exit)
     expected_paths = extract_doc_paths(plan_text)
 
     # If explicitly "no docs needed", pass validation
     if not expected_paths:
-        return True, ("Plan explicitly states no documentation changes needed. Validation passed.")
+        return "pass", (
+            "Plan explicitly states no documentation changes needed. Validation passed."
+        )
 
     # Dry-run: print expected paths and return early
     if dry_run:
         print("[DRY-RUN] Expected documentation paths:")
         for p in expected_paths:
             print(f"  - {p}")
-        return True, "[DRY-RUN] Would validate the above paths against git diff."
+        return "pass", "[DRY-RUN] Would validate the above paths against git diff."
 
     # Phase 1: Check expected docs appear in git diff
     changed_files = get_changed_files(base_branch)
@@ -266,7 +383,7 @@ def validate_docs_changed(
             missing.append(expected)
 
     if not matched:
-        return False, (
+        return "missing_docs", (
             f"Validation failed: No expected docs were changed.\n\n"
             f"Expected paths: {expected_paths}\n"
             f"Changed docs: {changed_docs if changed_docs else '(none)'}\n\n"
@@ -276,17 +393,18 @@ def validate_docs_changed(
             f"if this is intentional"
         )
 
-    # Phase 2: Check for deprecated markers in changed doc files
-    deprecated_violations = check_deprecated_markers(matched)
+    # Phase 2: Check for deprecated markers in the ADDED lines of changed docs
+    deprecated_violations = check_deprecated_markers(matched, base_branch)
     if deprecated_violations:
         violation_lines = []
         for filepath, line_num, line_content in deprecated_violations:
             violation_lines.append(f"  {filepath}:{line_num}: {line_content}")
         violation_report = "\n".join(violation_lines)
-        return False, (
-            f"Validation failed: Deprecated/legacy markers found in docs.\n\n"
+        return "stale_markers", (
+            f"Warning (non-blocking): stale/deprecated markers found in added doc lines.\n\n"
             f"Violations:\n{violation_report}\n\n"
-            f"Remove or rewrite deprecated language before merging."
+            f"Consider removing or rewriting the deprecated language, but this does "
+            f"NOT block the PR."
         )
 
     # Success
@@ -296,7 +414,7 @@ def validate_docs_changed(
     ]
     if missing:
         msg_parts.append(f"Note: {len(missing)} expected doc(s) not yet changed: {missing}")
-    return True, " ".join(msg_parts)
+    return "pass", " ".join(msg_parts)
 
 
 def main() -> int:
@@ -322,24 +440,31 @@ def main() -> int:
 
     args = parser.parse_args()
 
-    # Validate plan exists
+    # Validate plan exists — internal/usage error (exit 3, BLOCKS the PR).
     if not args.plan_path.exists():
         print(f"Error: Plan file not found: {args.plan_path}", file=sys.stderr)
-        return 2
+        return 3
 
     # Run validation
-    success, message = validate_docs_changed(
+    outcome, message = validate_docs_changed(
         args.plan_path,
         dry_run=args.dry_run,
         base_branch=args.base_branch,
     )
 
-    if success:
+    if outcome == "pass":
         print(message)
         return 0
-    else:
+    if outcome == "missing_docs":
         print(message, file=sys.stderr)
         return 1
+    if outcome == "stale_markers":
+        # Non-blocking warning — the only non-blocking exit code.
+        print(message, file=sys.stderr)
+        return 2
+    # outcome == "error": internal/usage error, BLOCKS the PR.
+    print(message, file=sys.stderr)
+    return 3
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_validate_docs_changed.py
+++ b/tests/unit/test_validate_docs_changed.py
@@ -1,0 +1,239 @@
+"""Tests for scripts/validate_docs_changed.py exit-code and scan-scope contract.
+
+Covers issue #2133: the stale-marker scan must be diff-scoped (only lines ADDED
+by the branch, never pre-existing file content) and the exit codes must follow
+the documented contract:
+
+    0 = pass
+    1 = missing docs (hard fail, blocks PR)
+    2 = stale markers found (non-blocking warning)
+    3 = internal/usage error (plan not found, read failure) — blocks PR
+
+These tests drive the validator as a subprocess against a purpose-built temp git
+repo so the git-diff plumbing is exercised for real (no mocks).
+"""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "validate_docs_changed.py"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _run_validator(
+    repo: Path,
+    plan_path: str,
+    base_branch: str = "main",
+    extra: list[str] | None = None,
+) -> subprocess.CompletedProcess:
+    """Invoke the validator with cwd inside the temp repo so its git calls resolve there."""
+    cmd = [sys.executable, str(SCRIPT), plan_path, "--base-branch", base_branch]
+    if extra:
+        cmd += extra
+    return subprocess.run(cmd, cwd=repo, capture_output=True, text=True)
+
+
+def _write_plan(repo: Path, doc_paths: list[str], name: str = "plan.md") -> str:
+    """Write a minimal plan file with a ## Documentation section listing doc_paths.
+
+    Returns the plan path relative to the repo root (as passed on the CLI).
+    """
+    lines = ["# Plan", "", "## Documentation", ""]
+    for p in doc_paths:
+        lines.append(f"- [ ] Update `{p}` for the feature")
+    plan = repo / name
+    plan.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return name
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    # Seed an unrelated base commit so `main` exists as a ref.
+    (repo / "README.md").write_text("# Seed\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "seed")
+    return repo
+
+
+def _commit_doc_on_main(git_repo: Path, rel: str, content: str) -> None:
+    doc = git_repo / rel
+    doc.parent.mkdir(parents=True, exist_ok=True)
+    doc.write_text(content, encoding="utf-8")
+    _git(git_repo, "add", rel)
+    _git(git_repo, "commit", "-m", f"add {rel}")
+
+
+def _new_branch(git_repo: Path, name: str = "session/test") -> None:
+    _git(git_repo, "checkout", "-b", name)
+
+
+# ---------------------------------------------------------------------------
+# Exit-code contract
+# ---------------------------------------------------------------------------
+
+
+def test_stale_marker_in_added_line_exits_2(git_repo: Path):
+    """A stale marker on a line ADDED by the branch → non-blocking warning, exit 2."""
+    rel = "docs/features/foo.md"
+    _commit_doc_on_main(git_repo, rel, "# Foo\n\nOriginal clean content.\n")
+    _new_branch(git_repo)
+    doc = git_repo / rel
+    doc.write_text(
+        "# Foo\n\nOriginal clean content.\nThis behaviour is deprecated now.\n",
+        encoding="utf-8",
+    )
+    _git(git_repo, "add", rel)
+    _git(git_repo, "commit", "-m", "add stale line")
+
+    plan = _write_plan(git_repo, [rel])
+    result = _run_validator(git_repo, plan)
+    assert result.returncode == 2, (result.returncode, result.stdout, result.stderr)
+
+
+def test_missing_docs_exits_1(git_repo: Path):
+    """Expected docs never changed → hard fail, exit 1."""
+    _new_branch(git_repo)
+    plan = _write_plan(git_repo, ["docs/features/never-touched.md"])
+    result = _run_validator(git_repo, plan)
+    assert result.returncode == 1, (result.returncode, result.stdout, result.stderr)
+
+
+def test_missing_plan_file_exits_3(git_repo: Path):
+    """Plan file not found → internal/usage error, exit 3 (not 2, which is a warning)."""
+    result = _run_validator(git_repo, "docs/plans/does-not-exist.md")
+    assert result.returncode == 3, (result.returncode, result.stdout, result.stderr)
+
+
+def test_trigger_word_only_in_preexisting_content_exits_0(git_repo: Path):
+    """A trigger word that exists ONLY in pre-existing (unchanged) lines is not flagged.
+
+    Regression for issue #2133 / PR #2132 false positives (e.g. the
+    "NO LEGACY CODE TOLERANCE" principle text living verbatim on main). Replaces
+    the manual workaround noted in
+    docs/plans/completed/merge-gate-baseline-refresh.md:364.
+    """
+    rel = "docs/features/principles.md"
+    _commit_doc_on_main(
+        git_repo,
+        rel,
+        "# Principles\n\nNO LEGACY CODE TOLERANCE: never leave traces of legacy code.\n",
+    )
+    _new_branch(git_repo)
+    doc = git_repo / rel
+    # Add an unrelated, clean line only.
+    doc.write_text(
+        "# Principles\n\nNO LEGACY CODE TOLERANCE: never leave traces of legacy code.\n"
+        "A brand new capability was added here.\n",
+        encoding="utf-8",
+    )
+    _git(git_repo, "add", rel)
+    _git(git_repo, "commit", "-m", "add unrelated clean line")
+
+    plan = _write_plan(git_repo, [rel])
+    result = _run_validator(git_repo, plan)
+    assert result.returncode == 0, (result.returncode, result.stdout, result.stderr)
+
+
+def test_stale_marker_in_new_untracked_doc_exits_2(git_repo: Path):
+    """A brand-new untracked doc → all lines count as added; a stale marker IS flagged."""
+    _new_branch(git_repo)
+    rel = "docs/features/brand-new.md"
+    doc = git_repo / rel
+    doc.parent.mkdir(parents=True, exist_ok=True)
+    # Untracked (never git-added) doc containing a trigger word.
+    doc.write_text("# New\n\nThis path is deprecated already.\n", encoding="utf-8")
+
+    plan = _write_plan(git_repo, [rel])
+    result = _run_validator(git_repo, plan)
+    assert result.returncode == 2, (result.returncode, result.stdout, result.stderr)
+
+
+def test_single_line_addition_hunk_header_is_parsed(git_repo: Path):
+    """Concern #2: a brand-new single-line doc emits `@@ -0,0 +1 @@` (omitted ,d count).
+
+    The hunk parser must still detect the added line and flag its stale marker.
+    """
+    _new_branch(git_repo)
+    rel = "docs/features/oneline.md"
+    doc = git_repo / rel
+    doc.parent.mkdir(parents=True, exist_ok=True)
+    doc.write_text("This single line is obsolete.\n", encoding="utf-8")
+    _git(git_repo, "add", rel)
+    _git(git_repo, "commit", "-m", "add one-line doc")
+
+    plan = _write_plan(git_repo, [rel])
+    result = _run_validator(git_repo, plan)
+    assert result.returncode == 2, (result.returncode, result.stdout, result.stderr)
+
+
+def test_clean_added_doc_exits_0(git_repo: Path):
+    """A changed doc with no stale markers in added lines → pass, exit 0."""
+    rel = "docs/features/clean.md"
+    _commit_doc_on_main(git_repo, rel, "# Clean\n\nOriginal.\n")
+    _new_branch(git_repo)
+    doc = git_repo / rel
+    doc.write_text("# Clean\n\nOriginal.\nA fresh, tidy sentence.\n", encoding="utf-8")
+    _git(git_repo, "add", rel)
+    _git(git_repo, "commit", "-m", "add clean line")
+
+    plan = _write_plan(git_repo, [rel])
+    result = _run_validator(git_repo, plan)
+    assert result.returncode == 0, (result.returncode, result.stdout, result.stderr)
+
+
+# ---------------------------------------------------------------------------
+# get_added_lines helper (unit level)
+# ---------------------------------------------------------------------------
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("validate_docs_changed", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_get_added_lines_git_failure_returns_empty(tmp_path: Path, monkeypatch):
+    """Concern: git failure (not a repo) must not crash; helper returns no added lines."""
+    mod = _load_module()
+    monkeypatch.chdir(tmp_path)  # not a git repo
+    result = mod.get_added_lines("docs/features/whatever.md", "main")
+    assert result == []
+
+
+def test_get_added_lines_reports_added_line_numbers(git_repo: Path, monkeypatch):
+    """Added lines are returned with their true new-file line numbers."""
+    mod = _load_module()
+    rel = "docs/features/nums.md"
+    _commit_doc_on_main(git_repo, rel, "# Nums\n\nline a\nline b\n")
+    _new_branch(git_repo)
+    doc = git_repo / rel
+    doc.write_text("# Nums\n\nline a\nline b\nline c added\n", encoding="utf-8")
+    _git(git_repo, "add", rel)
+    _git(git_repo, "commit", "-m", "add line c")
+
+    monkeypatch.chdir(git_repo)
+    added = mod.get_added_lines(rel, "main")
+    # Only the newly added line body should be present.
+    bodies = [text for _, text in added]
+    assert any("line c added" in b for b in bodies)
+    assert all("line a" not in b and "line b" not in b for b in bodies)


### PR DESCRIPTION
## Summary

Reconciles `scripts/validate_docs_changed.py` (Gate 2 of the docs lifecycle) with its documented contract. Closes #2133.

Two contract mismatches were producing false-positive PR blocks:

1. **Exit-code mismatch.** `main()` returned exit `1` for BOTH "no expected docs changed" AND "stale markers found", and used exit `2` for "plan file not found" — colliding with the documented meaning of exit `2` (non-blocking stale warning). A real error could read as a mere warning.
2. **Scan-scope mismatch.** `check_deprecated_markers()` read the ENTIRE content of every matched doc and flagged any trigger word, so targeting a large pre-existing doc (e.g. `CLAUDE.md`) swept thousands of unchanged lines. PR #2132 documented four false positives, all verbatim on `main`.

## Changes

- **Exit codes** now follow the documented contract: `0` pass, `1` missing docs (blocks), `2` stale markers in added lines (non-blocking warning — the only non-blocking code), `3` internal/usage error (blocks). Exit `3` extends the 0/1/2 contract by splitting the previously overloaded exit `2`.
- **Diff-scoped stale scan.** New `get_added_lines(doc_path, base_branch)` parses `git diff -U0 {base}...HEAD` and returns only the lines this branch ADDED (with a fallback that treats untracked / staged-but-uncommitted new docs as all-added). The marker scan runs over those lines only, preserving code-fence / heading / inline-code skip logic. Pre-existing content is never flagged.
- `validate_docs_changed()` returns a discriminated outcome (`pass` / `missing_docs` / `stale_markers` / `error`) so `main()` maps to the right exit code.
- Module docstring exit-code table updated.

## Tests (TDD)

Net-new `tests/unit/test_validate_docs_changed.py` (no prior coverage existed). Written red-first against the documented contract, then made green:

- stale marker in an added line → exit 2
- missing docs → exit 1
- missing plan file → exit 3
- trigger word only in **pre-existing** content → exit 0 (PR #2132 regression, uses the real "NO LEGACY CODE TOLERANCE" phrase)
- stale marker in a brand-new untracked doc → exit 2
- single-line addition (`@@ -0,0 +1 @@`, omitted `,d` count) hunk-header parse
- clean added doc → exit 0
- `get_added_lines` git-failure fail-safe + line-number reporting

All 9 pass; `ruff check` and `ruff format --check` clean.

## Docs

- `docs/features/documentation-lifecycle.md` — Gate 2 description + Troubleshooting table now spell out the 0/1/2/3 blocking semantics and the diff-scoped scan.
- `docs/sdlc/do-build.md` — the LLM-read exit-code comment now states exit 1 & 3 block, exit 2 is the sole non-blocking warning.

## Plan

`docs/plans/validate-docs-exit-scope.md`