### PR TITLE
Preserve uncommitted worktree work + destructive-git guard (#2137)

### DIFF
--- a/.claude/hooks/validators/validate_no_destructive_git_in_worktree.py
+++ b/.claude/hooks/validators/validate_no_destructive_git_in_worktree.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""
+Guard (issue #2137): block destructive git commands issued from inside a DIRTY
+session worktree (`.worktrees/{slug}/`), where they would silently destroy
+uncommitted work with no recovery path.
+
+Background: a production incident destroyed six uncommitted files in a
+`session/dev-XXXX` worktree — the reflog showed `reset: moving to HEAD`,
+matching an agent-issued `git reset --hard`/`git stash` during a confused
+post-interruption recovery. The unmerged-branch guard (#1646) protects only
+*committed* work; nothing stopped an agent from hard-resetting a dirty tree.
+This PreToolUse hook is the agent-facing half of the #2137 backstop (the other
+half is `preserve_uncommitted_worktree_changes` in `agent/worktree_manager.py`,
+which auto-WIP-commits before teardown).
+
+Blocked signatures (only when the tree is DIRTY and cwd is inside `.worktrees/`):
+  - `git reset --hard [<ref>]`
+  - `git clean -f[dx...]` / `git clean --force`
+  - `git checkout -- .` / `git checkout .`
+  - `git restore .`
+  - bare `git stash` / `git stash push` with NO pathspec
+
+Explicitly ALLOWED (out of scope — see the plan Rabbit Holes):
+  - the same commands on a CLEAN tree (a reset on a clean tree loses nothing)
+  - the same commands OUTSIDE `.worktrees/`
+  - a specific-path variant: `git checkout -- file.py`, `git stash push -- file`
+  - `git reset --soft`, `git stash list/pop/apply`, etc.
+  - any command carrying the inline override token `# allow-destructive-git`
+
+Detection is anchored to the *command position*, not a bare substring search:
+`git commit -m "reset --hard bug"` must NOT be blocked. The command is split on
+shell control operators into simple commands, each tokenized with `shlex`, and
+only a simple command whose first non-env token is `git` and whose subcommand
+matches a destructive signature counts. A `cd <path> && git reset --hard` chain
+resolves the effective directory from the `cd` prefix (mirrors
+`validate_no_uv_sync_in_worktree.py`).
+
+Claude Code hook protocol:
+- Stdin: JSON with tool_name, tool_input, cwd
+- To BLOCK: print {"decision": "block", "reason": "..."} to stdout, exit 0
+- To ALLOW: print nothing, exit 0
+
+Fail-open: any parse error, git error, or unexpected exception results in
+exit 0 (allow) — this guard must never crash a legitimate Bash call.
+
+Direct/manual invocation (also used by tests):
+  python validate_no_destructive_git_in_worktree.py <command> <cwd>
+Exits 1 with a message on stderr if the command would be blocked (dirty tree
+assumed for the CLI path), 0 otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+_CONTROL_SPLIT_RE = re.compile(r"&&|\|\||;|\n|\|")
+_ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+OVERRIDE_TOKEN = "# allow-destructive-git"
+
+
+def _split_simple_commands(command: str) -> list[str]:
+    """Split a shell command on control operators into simple commands.
+
+    Not a full shell parser (see the plan Rabbit Holes) — handles the common
+    `a && b`, `a; b`, `a | b` shapes and otherwise treats the whole string as
+    one simple command.
+    """
+    return [s.strip() for s in _CONTROL_SPLIT_RE.split(command) if s.strip()]
+
+
+def _git_tokens(simple_cmd: str) -> list[str] | None:
+    """Return the token list starting at `git` if `simple_cmd` is a git
+    invocation (command-position match, skipping leading env assignments),
+    else None.
+    """
+    try:
+        tokens = shlex.split(simple_cmd)
+    except ValueError:
+        return None
+    i = 0
+    while i < len(tokens) and _ENV_ASSIGNMENT_RE.match(tokens[i]):
+        i += 1
+    if i >= len(tokens) or tokens[i] != "git":
+        return None
+    return tokens[i:]
+
+
+def _subcommand_and_args(git_tokens: list[str]) -> tuple[str | None, list[str]]:
+    """From tokens starting at `git`, return (subcommand, args_after_it).
+
+    Skips `git`-level flags (e.g. `git -C path reset`). Note: `-C`/`--git-dir`
+    take a value; we skip the value too so it is not mistaken for the
+    subcommand.
+    """
+    i = 1  # skip `git`
+    while i < len(git_tokens):
+        tok = git_tokens[i]
+        if tok in ("-C", "--git-dir", "--work-tree", "-c"):
+            i += 2  # flag + its value
+            continue
+        if tok.startswith("-"):
+            i += 1
+            continue
+        return tok, git_tokens[i + 1 :]
+    return None, []
+
+
+def _is_destructive_git(simple_cmd: str) -> bool:
+    """True if `simple_cmd` is one of the destructive git signatures in scope."""
+    git_tokens = _git_tokens(simple_cmd)
+    if git_tokens is None:
+        return False
+    sub, args = _subcommand_and_args(git_tokens)
+    if sub is None:
+        return False
+
+    if sub == "reset":
+        return "--hard" in args
+
+    if sub == "clean":
+        # A force flag is required for `git clean` to delete anything: `-f`,
+        # `-fd`, `-fdx`, or `--force`.
+        for a in args:
+            if a == "--force":
+                return True
+            if a.startswith("-") and not a.startswith("--") and "f" in a:
+                return True
+        return False
+
+    if sub == "checkout":
+        # Block only the whole-tree discard `checkout -- .` / `checkout .`.
+        # A specific pathspec (`checkout -- file.py`) is allowed.
+        pathspecs = [a for a in args if a != "--" and not a.startswith("-")]
+        return pathspecs == ["."]
+
+    if sub == "restore":
+        pathspecs = [a for a in args if a != "--" and not a.startswith("-")]
+        return "." in pathspecs
+
+    if sub == "stash":
+        # Bare `git stash` (no subcommand) → block.
+        if not args:
+            return True
+        # `git stash push` with NO pathspec → block; with a pathspec → allow.
+        if args[0] == "push":
+            push_args = args[1:]
+            if "--" in push_args:
+                # everything after `--` is a pathspec → scoped, allow
+                return False
+            # A trailing non-flag token that is not an option value is a
+            # pathspec (e.g. `git stash push file`). `-m msg` has no pathspec.
+            has_pathspec = _stash_push_has_pathspec(push_args)
+            return not has_pathspec
+        # Any other stash subcommand (list/show/pop/apply/drop/...) is allowed.
+        return False
+
+    return False
+
+
+def _stash_push_has_pathspec(push_args: list[str]) -> bool:
+    """Heuristic: does `git stash push <push_args>` name a pathspec?
+
+    `-m/--message` takes a value; `-p/--patch`, `-k/--keep-index`,
+    `-u/--include-untracked`, `-a/--all` are boolean flags. Any bare
+    non-flag token that is not the value of `-m/--message` is treated as a
+    pathspec.
+    """
+    i = 0
+    while i < len(push_args):
+        tok = push_args[i]
+        if tok in ("-m", "--message"):
+            i += 2  # consume the message value
+            continue
+        if tok.startswith("-"):
+            i += 1
+            continue
+        return True  # a bare positional token → pathspec
+    return False
+
+
+def _effective_dir(command: str, hook_cwd: str) -> str:
+    """Resolve the effective working directory: `hook_cwd`, unless the first
+    simple command is a `cd <path>` prefix, in which case that path (resolved
+    against `hook_cwd`) wins. Mirrors `validate_no_uv_sync_in_worktree.py`.
+    """
+    simple_cmds = _split_simple_commands(command)
+    if simple_cmds:
+        try:
+            first_tokens = shlex.split(simple_cmds[0])
+        except ValueError:
+            first_tokens = []
+        if len(first_tokens) >= 2 and first_tokens[0] == "cd":
+            path = Path(first_tokens[1])
+            if not path.is_absolute():
+                path = Path(hook_cwd) / path if hook_cwd else path
+            return str(path)
+    return hook_cwd
+
+
+def _is_worktree_path(path: str) -> bool:
+    """Component match against `.worktrees` — never a bare substring match, so
+    `.worktrees-backup` never matches.
+    """
+    return ".worktrees" in Path(path).parts
+
+
+_BLOCK_MESSAGE_TEMPLATE = (
+    "BLOCKED: destructive git command `{command}` in a DIRTY session worktree "
+    "({worktree}). This would permanently destroy uncommitted work (staged, "
+    "unstaged, and untracked) with no recovery path — the exact failure mode "
+    "of the #2137 incident.\n\n"
+    "Do one of the following instead:\n"
+    "  - Commit or WIP-commit first:  git add -A && git commit --no-verify -m 'WIP'\n"
+    "  - Scope to a specific path:     git checkout -- <file>  (not `.`)\n"
+    "  - If you REALLY mean it, append the override token to the command:\n"
+    "        {command}  {override}\n\n"
+    "Uncommitted work is auto-preserved to refs/session-wip/<slug> on session "
+    "teardown, but an in-session destructive reset happens before that backstop."
+)
+
+
+def find_violation(command: str, cwd: str, is_dirty: bool) -> str | None:
+    """Return a block-reason string if `command` is a destructive git command
+    issued from a DIRTY worktree cwd (no override), else None.
+
+    Pure and injectable: `is_dirty` is supplied by the caller (`_run_hook`
+    computes it from `git status --porcelain`; tests inject it directly).
+    Never raises — any internal parse failure is treated as "no violation"
+    (fail open).
+    """
+    if not command or not cwd:
+        return None
+    try:
+        if OVERRIDE_TOKEN in command:
+            return None
+        effective_dir = _effective_dir(command, cwd)
+        if not _is_worktree_path(effective_dir):
+            return None
+        if not is_dirty:
+            # A destructive command on a clean tree loses nothing → allow.
+            return None
+        for simple_cmd in _split_simple_commands(command):
+            if _is_destructive_git(simple_cmd):
+                return _BLOCK_MESSAGE_TEMPLATE.format(
+                    command=command.strip(),
+                    worktree=effective_dir,
+                    override=OVERRIDE_TOKEN,
+                )
+    except Exception:
+        return None
+    return None
+
+
+def _is_tree_dirty(cwd: str) -> bool:
+    """Return True iff `git -C <cwd> status --porcelain` reports changes.
+
+    Fail-closed-to-allow: any git error, timeout, or missing path returns
+    False (treated as "not dirty" → the guard does not block), preserving the
+    fail-open contract.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd, "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return False
+        return bool(result.stdout.strip())
+    except (subprocess.SubprocessError, OSError):
+        return False
+
+
+def read_stdin() -> dict:
+    try:
+        raw = sys.stdin.read()
+        if not raw.strip():
+            return {}
+        return json.loads(raw)
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def block(reason: str) -> None:
+    print(json.dumps({"decision": "block", "reason": reason}))
+    sys.exit(0)
+
+
+def _run_hook() -> None:
+    try:
+        hook_input = read_stdin()
+        if hook_input.get("tool_name") != "Bash":
+            sys.exit(0)
+
+        tool_input = hook_input.get("tool_input", {})
+        command = tool_input.get("command", "") if isinstance(tool_input, dict) else ""
+        hook_cwd = hook_input.get("cwd", "") or ""
+
+        # Cheap pre-check: only pay for `git status` when the command is even
+        # plausibly destructive-git inside a worktree.
+        if not command or OVERRIDE_TOKEN in command:
+            sys.exit(0)
+        effective_dir = _effective_dir(command, hook_cwd)
+        if not _is_worktree_path(effective_dir):
+            sys.exit(0)
+        if not any(_is_destructive_git(sc) for sc in _split_simple_commands(command)):
+            sys.exit(0)
+
+        is_dirty = _is_tree_dirty(effective_dir)
+        reason = find_violation(command, hook_cwd, is_dirty)
+        if reason:
+            block(reason)
+    except Exception:
+        # Fail open: never crash a legitimate Bash call.
+        sys.exit(0)
+
+    sys.exit(0)
+
+
+def _run_cli(command: str, cwd: str) -> None:
+    """Direct-invocation path used by tests/humans: validate a single
+    (command, cwd) pair. The CLI path assumes a dirty tree (worst case) so a
+    human can check whether a command *would* be blocked.
+    """
+    reason = find_violation(command, cwd, is_dirty=True)
+    if reason:
+        print(reason, file=sys.stderr)
+        sys.exit(1)
+    sys.exit(0)
+
+
+def main():
+    argv = sys.argv[1:]
+    if len(argv) == 2:
+        _run_cli(argv[0], argv[1])
+    else:
+        _run_hook()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -59,6 +59,11 @@
           },
           {
             "type": "command",
+            "command": "python \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validators/validate_no_destructive_git_in_worktree.py",
+            "timeout": 15
+          },
+          {
+            "type": "command",
             "command": "python \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validators/validate_design_system_sync.py",
             "timeout": 10
           }

--- a/agent/worktree_manager.py
+++ b/agent/worktree_manager.py
@@ -4,6 +4,7 @@ Creates and manages git worktrees for isolated coding sessions.
 Each work item gets its own worktree under .worktrees/{slug}/.
 """
 
+import datetime
 import logging
 import os
 import re
@@ -829,6 +830,12 @@ def _cleanup_stale_worktree(repo_root: Path, branch_name: str, worktree_path: st
         f"Stale worktree for branch {branch_name} at {worktree_path}. "
         "Force-removing to unblock checkout."
     )
+    # Preserve any uncommitted work before the direct force-remove (#2137).
+    # _cleanup_stale_worktree force-removes directly (not via remove_worktree),
+    # so it needs its own preservation call. The slug is the worktree dir name.
+    stale_slug = wt.name
+    if VALID_SLUG_RE.match(stale_slug):
+        preserve_uncommitted_worktree_changes(repo_root, stale_slug, wt)
     try:
         subprocess.run(
             ["git", "worktree", "remove", "--force", worktree_path],
@@ -1101,6 +1108,144 @@ def get_or_create_worktree(repo_root: Path, slug: str, base_branch: str = "main"
     return create_worktree(repo_root, slug, base_branch)
 
 
+def preserve_uncommitted_worktree_changes(repo_root: Path, slug: str, worktree_dir: Path) -> dict:
+    """Preserve uncommitted work in a session worktree before teardown (#2137).
+
+    Session worktrees under ``.worktrees/{slug}`` are force-removed on session
+    exit (normal, exception, or cancellation). The unmerged-branch guard (#1646)
+    protects only *committed* work; staged, unstaged, and untracked edits are
+    otherwise discarded with no backstop. This helper captures ALL uncommitted
+    work as a WIP commit on ``session/{slug}`` plus a durable named ref
+    ``refs/session-wip/{slug}`` before any ``git worktree remove --force``.
+
+    Mechanism (WIP commit + named ref, NOT ``git stash``): a plain ``git stash``
+    inside a worktree writes to the *per-worktree* ``refs/stash``, which is
+    destroyed with the worktree — useless as a teardown backstop. Instead:
+
+    1. ``git -C <worktree> status --porcelain`` — if empty, no-op.
+    2. ``git -C <worktree> add -A`` — captures untracked + tracked edits.
+    3. ``git -C <worktree> commit --no-verify --no-gpg-sign`` — the WIP commit
+       (``--no-verify`` avoids pre-commit hooks hanging teardown;
+       ``--no-gpg-sign`` avoids signing prompts).
+    4. ``git -C <repo_root> update-ref refs/session-wip/{slug} <sha>`` — writes
+       to the *common* ref store, so the ref survives both worktree removal and
+       the unmerged-branch-guard branch deletion.
+
+    Non-blocking contract: any subprocess failure, timeout, or exception is
+    caught, logged at ERROR with the ``[worktree-wip-preserve-failed]`` tag,
+    and returned in the result dict — this function NEVER raises into the
+    teardown path and must never hang teardown.
+
+    Recovery: ``git checkout refs/session-wip/{slug}`` (or diff/cherry-pick the
+    WIP commit). ``git reset --soft HEAD~1`` on the resumed session unstages the
+    WIP commit to restore the dirty tree. Refs live in ``refs/session-wip/*``
+    and are reclaimed manually (no automated GC — see the plan No-Gos).
+
+    Args:
+        repo_root: Path to the main repository (common ref store owner).
+        slug: Work item slug (validated).
+        worktree_dir: Path to the worktree to preserve.
+
+    Returns:
+        A result dict. On a clean tree: ``{"preserved": False, "was_clean":
+        True}``. On success: ``{"preserved": True, "was_clean": False, "sha":
+        <sha>, "ref": "refs/session-wip/{slug}", "errors": []}``. On failure:
+        ``{"preserved": False, "was_clean": False, "errors": [<msg>, ...]}``.
+    """
+    _validate_slug(slug)
+    ref = f"refs/session-wip/{slug}"
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(worktree_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=settings.timeouts.git_subprocess_s,
+        )
+        if status.returncode != 0:
+            raise RuntimeError(
+                f"git status failed (rc={status.returncode}): {status.stderr.strip()}"
+            )
+        if not status.stdout.strip():
+            # Clean tree — nothing to preserve.
+            return {"preserved": False, "was_clean": True, "ref": ref, "errors": []}
+
+        add = subprocess.run(
+            ["git", "-C", str(worktree_dir), "add", "-A"],
+            capture_output=True,
+            text=True,
+            timeout=settings.timeouts.git_subprocess_s,
+        )
+        if add.returncode != 0:
+            raise RuntimeError(f"git add -A failed: {add.stderr.strip()}")
+
+        ts = datetime.datetime.now(datetime.UTC).isoformat()
+        commit = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(worktree_dir),
+                "commit",
+                "--no-verify",
+                "--no-gpg-sign",
+                "-m",
+                f"WIP: auto-preserved before teardown [{slug}] [{ts}]",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=settings.timeouts.git_subprocess_s,
+        )
+        if commit.returncode != 0:
+            raise RuntimeError(f"git commit failed: {commit.stderr.strip()}")
+
+        rev = subprocess.run(
+            ["git", "-C", str(worktree_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=settings.timeouts.git_subprocess_s,
+        )
+        if rev.returncode != 0:
+            raise RuntimeError(f"git rev-parse HEAD failed: {rev.stderr.strip()}")
+        sha = rev.stdout.strip()
+
+        # Write to the COMMON ref store (repo_root), not the worktree, so the
+        # ref outlives worktree removal and branch deletion.
+        update = subprocess.run(
+            ["git", "-C", str(repo_root), "update-ref", ref, sha],
+            capture_output=True,
+            text=True,
+            timeout=settings.timeouts.git_subprocess_s,
+        )
+        if update.returncode != 0:
+            raise RuntimeError(f"git update-ref failed: {update.stderr.strip()}")
+
+        logger.warning(
+            "[worktree-wip-preserved] slug=%s ref=%s sha=%s — uncommitted work "
+            "preserved before teardown; recover with `git checkout %s`.",
+            slug,
+            ref,
+            sha,
+            ref,
+        )
+        return {
+            "preserved": True,
+            "was_clean": False,
+            "sha": sha,
+            "ref": ref,
+            "errors": [],
+        }
+    except Exception as e:
+        # Non-blocking contract: never raise into teardown. Log loudly and
+        # return an error dict so force-remove can still proceed.
+        logger.error(
+            "[worktree-wip-preserve-failed] slug=%s worktree=%s error=%s — "
+            "uncommitted work could NOT be preserved; teardown proceeds.",
+            slug,
+            worktree_dir,
+            e,
+        )
+        return {"preserved": False, "was_clean": False, "ref": ref, "errors": [str(e)]}
+
+
 def remove_worktree(
     repo_root: Path,
     slug: str,
@@ -1185,6 +1330,10 @@ def remove_worktree(
         # CWD already invalid — move to repo root as recovery
         logger.warning("CWD is already invalid. Changing to repo root.")
         os.chdir(repo_root)
+
+    # Preserve any uncommitted work before the destructive force-remove (#2137).
+    # Non-blocking: failure here degrades to loud logging and teardown proceeds.
+    preserve_uncommitted_worktree_changes(repo_root, slug, worktree_dir)
 
     try:
         subprocess.run(

--- a/docs/features/session-isolation.md
+++ b/docs/features/session-isolation.md
@@ -223,6 +223,41 @@ When the guard fires:
 
 **Layering.** The guard prevents the bad delete (source); the watchdog catches it if it happens anyway via a different path (sink). The two layers are independent and reverting either does not break the other.
 
+### Uncommitted-Work Preservation & Destructive-Git Guard (Issue #2137)
+
+Session worktrees are force-removed on session exit (`git worktree remove --force`). The unmerged-branch guard (#1646) protects only *committed* work; before #2137, staged, unstaged, and untracked edits in a dirty worktree were discarded with no backstop. A production incident destroyed six uncommitted files this way (the reflog showed `reset: moving to HEAD`). Two complementary layers close the gap.
+
+**1. Auto-WIP-commit before teardown.** `preserve_uncommitted_worktree_changes(repo_root, slug, worktree_dir)` (`agent/worktree_manager.py`) runs *before* every force-remove. It is called from `remove_worktree()` and directly from `_cleanup_stale_worktree()` (which force-removes without going through `remove_worktree`). Mechanism:
+
+1. `git -C <worktree> status --porcelain` — if clean, no-op (`{"preserved": False, "was_clean": True}`).
+2. `git -C <worktree> add -A` — captures untracked + tracked edits.
+3. `git -C <worktree> commit --no-verify --no-gpg-sign -m "WIP: auto-preserved before teardown [slug] [ISO-ts]"` — `--no-verify` avoids pre-commit hooks hanging teardown; `--no-gpg-sign` avoids signing prompts.
+4. `git -C <repo_root> update-ref refs/session-wip/{slug} <sha>` — writes to the **common** ref store (not the per-worktree one), so the ref survives both worktree removal and the unmerged-branch-guard branch deletion.
+
+The recovery pointer is logged at WARNING with a greppable tag: `[worktree-wip-preserved] slug=… ref=refs/session-wip/… sha=…`.
+
+**Why a WIP commit + named ref, not `git stash`.** A plain `git stash` inside a worktree writes to the *per-worktree* `refs/stash`, which is destroyed with the worktree — useless as a teardown backstop.
+
+**Non-blocking contract.** Preservation must never block or hang teardown. Any subprocess failure, timeout, or exception is caught, logged at ERROR with `[worktree-wip-preserve-failed]`, and returned in the result dict (`{"preserved": False, "errors": [...]}`) — the force-remove still proceeds.
+
+**Recovery procedure.** The preserved work lives at `refs/session-wip/{slug}` and as a WIP commit on `session/{slug}`:
+
+```bash
+git checkout refs/session-wip/{slug}      # inspect the preserved tree
+git cherry-pick refs/session-wip/{slug}   # or replay onto another branch
+git reset --soft HEAD~1                    # on a resumed session: unstage the WIP to restore the dirty tree
+```
+
+**GC policy.** `refs/session-wip/*` refs are reclaimed **manually** — they are cheap pointers to dangling commits. There is no automated GC/TTL daemon in this feature (out of scope; a scheduled ref-GC reflection is a separate follow-up). Remove a stale ref with `git update-ref -d refs/session-wip/{slug}`.
+
+**2. Destructive-git PreToolUse guard.** `.claude/hooks/validators/validate_no_destructive_git_in_worktree.py` blocks an agent from destroying a dirty worktree in-session (before the teardown backstop can fire). It blocks `git reset --hard`, `git clean -f[dx]`, `git checkout -- .` / `git checkout .`, `git restore .`, and bare `git stash` / `git stash push` (no pathspec) **only when** the cwd resolves inside a `.worktrees/` path **and** the tree is dirty. It mirrors `validate_no_uv_sync_in_worktree.py`: a pure `find_violation(command, cwd, is_dirty)` core, command-position (not substring) detection, `cd … &&` chain resolution, and fail-open on any parse/git error.
+
+- **Clean-tree resets are allowed** — a `git reset --hard` on a clean tree loses nothing.
+- **Override token.** Append `# allow-destructive-git` anywhere in the command to deliberately run a destructive command (greppable, mirrors existing hook-override conventions).
+- Registered in `.claude/settings.json` under the `PreToolUse` `Bash` matcher.
+
+**Layering.** The guard stops in-session destruction (source); the auto-WIP-commit catches whatever survives to teardown (sink). Independent — reverting either leaves the other functional.
+
 ## Key Experiment Findings
 
 Experiments validated the approach before implementation:
@@ -235,7 +270,8 @@ Experiments validated the approach before implementation:
 
 | File | Purpose |
 |------|---------|
-| `agent/worktree_manager.py` | Git worktree create/remove/list/prune/cleanup operations |
+| `agent/worktree_manager.py` | Git worktree create/remove/list/prune/cleanup operations; `preserve_uncommitted_worktree_changes()` auto-WIP-commit backstop (#2137) |
+| `.claude/hooks/validators/validate_no_destructive_git_in_worktree.py` | PreToolUse guard blocking destructive git commands in a dirty worktree (#2137) |
 | `scripts/post_merge_cleanup.py` | CLI script for post-merge worktree and branch cleanup |
 | `agent/hooks/session_registry.py` | Maps Claude Code UUIDs to bridge session IDs for hook-side resolution |
 | `agent/sdk_client.py` | Injects `CLAUDE_CODE_TASK_LIST_ID` into SDK environment; registers/unregisters sessions in the hook registry |

--- a/tests/unit/test_validate_no_destructive_git_in_worktree.py
+++ b/tests/unit/test_validate_no_destructive_git_in_worktree.py
@@ -1,0 +1,210 @@
+"""Tests for the destructive-git-in-worktree PreToolUse guard (issue #2137).
+
+Mirrors the structure of ``test_validate_no_uv_sync_in_worktree.py``: a pure,
+injectable ``find_violation(command, cwd, is_dirty)`` core plus the JSON-stdin
+``_run_hook`` contract exercised via subprocess for fail-open coverage, plus a
+real-worktree dirty-detection integration path.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Import the validator module under test (does not exist yet -> RED).
+VALIDATOR = (
+    Path(__file__).resolve().parents[2]
+    / ".claude"
+    / "hooks"
+    / "validators"
+    / "validate_no_destructive_git_in_worktree.py"
+)
+
+sys.path.insert(0, str(VALIDATOR.parent))
+import validate_no_destructive_git_in_worktree as guard  # noqa: E402
+
+WT = "/repo/.worktrees/sdlc-2137"
+OUTSIDE = "/repo/src"
+
+
+class TestFindViolationBlocks:
+    """Destructive commands in a dirty worktree cwd are blocked."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git reset --hard",
+            "git reset --hard HEAD",
+            "git reset --hard origin/main",
+            "git clean -fd",
+            "git clean -f",
+            "git clean -fdx",
+            "git checkout -- .",
+            "git checkout .",
+            "git restore .",
+            "git stash",
+            "git stash push",
+            "git stash push -m 'wip'",
+        ],
+    )
+    def test_blocks_destructive_in_dirty_worktree(self, command):
+        reason = guard.find_violation(command, WT, is_dirty=True)
+        assert reason is not None, f"expected block for: {command}"
+
+    def test_blocks_in_cd_chain(self):
+        reason = guard.find_violation(f"cd {WT} && git reset --hard", OUTSIDE, is_dirty=True)
+        assert reason is not None
+
+
+class TestFindViolationAllows:
+    """Non-destructive or out-of-scope commands are allowed (None)."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git status",
+            "git reset --soft HEAD~1",
+            "git reset HEAD file.py",
+            "git checkout -- specific_file.py",
+            "git checkout -b new-branch",
+            "git stash push -- specific_file.py",
+            "git stash list",
+            "git stash pop",
+            "git commit -m 'reset --hard in message'",
+            "ls -la",
+        ],
+    )
+    def test_allows_non_destructive(self, command):
+        assert guard.find_violation(command, WT, is_dirty=True) is None
+
+    def test_allows_when_clean_tree(self):
+        # A destructive reset on a CLEAN tree loses nothing -> allowed.
+        assert guard.find_violation("git reset --hard", WT, is_dirty=False) is None
+
+    def test_allows_outside_worktree(self):
+        assert guard.find_violation("git reset --hard", OUTSIDE, is_dirty=True) is None
+
+    def test_allows_with_override_token(self):
+        assert (
+            guard.find_violation("git reset --hard  # allow-destructive-git", WT, is_dirty=True)
+            is None
+        )
+
+    def test_empty_inputs_return_none(self):
+        assert guard.find_violation("", WT, is_dirty=True) is None
+        assert guard.find_violation("git reset --hard", "", is_dirty=True) is None
+
+
+class TestBlockMessage:
+    """The block reason names the command, the worktree path, and the override."""
+
+    def test_reason_mentions_command_path_and_override(self):
+        reason = guard.find_violation("git reset --hard", WT, is_dirty=True)
+        assert reason is not None
+        assert "reset" in reason
+        assert WT in reason
+        assert "# allow-destructive-git" in reason
+
+
+class TestRunHookFailOpen:
+    """The JSON-stdin hook contract must fail open on malformed input/errors."""
+
+    def _run(self, stdin: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(VALIDATOR)],
+            input=stdin,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    def test_malformed_json_exits_zero_no_block(self):
+        res = self._run("this is not json{{{")
+        assert res.returncode == 0
+        assert res.stdout.strip() == ""
+
+    def test_non_bash_tool_is_ignored(self):
+        res = self._run(json.dumps({"tool_name": "Read", "tool_input": {}}))
+        assert res.returncode == 0
+        assert res.stdout.strip() == ""
+
+    def test_nonexistent_cwd_fails_open(self):
+        res = self._run(
+            json.dumps(
+                {
+                    "tool_name": "Bash",
+                    "tool_input": {"command": "git reset --hard"},
+                    "cwd": "/nonexistent/.worktrees/ghost",
+                }
+            )
+        )
+        # cwd not a real dirty worktree -> git status fails -> fail open (allow).
+        assert res.returncode == 0
+        assert res.stdout.strip() == ""
+
+
+class TestRunHookRealWorktree:
+    """End-to-end dirty-detection against a throwaway git worktree."""
+
+    def _init_dirty_worktree(self, tmp_path: Path) -> Path:
+        def g(*args, cwd):
+            subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        g("init", "-q", "-b", "main", cwd=repo)
+        g("config", "user.email", "t@example.com", cwd=repo)
+        g("config", "user.name", "T", cwd=repo)
+        (repo / "seed.txt").write_text("seed\n")
+        g("add", "seed.txt", cwd=repo)
+        g("commit", "-q", "-m", "seed", cwd=repo)
+        wt = repo / ".worktrees" / "sdlc-live"
+        g("worktree", "add", "-q", "-b", "session/sdlc-live", str(wt), cwd=repo)
+        # dirty it
+        (wt / "seed.txt").write_text("seed\nchanged\n")
+        return wt
+
+    def test_blocks_reset_hard_in_real_dirty_worktree(self, tmp_path):
+        wt = self._init_dirty_worktree(tmp_path)
+        res = subprocess.run(
+            [sys.executable, str(VALIDATOR)],
+            input=json.dumps(
+                {
+                    "tool_name": "Bash",
+                    "tool_input": {"command": "git reset --hard"},
+                    "cwd": str(wt),
+                }
+            ),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert res.returncode == 0
+        payload = json.loads(res.stdout)
+        assert payload["decision"] == "block"
+
+    def test_allows_reset_hard_in_real_clean_worktree(self, tmp_path):
+        wt = self._init_dirty_worktree(tmp_path)
+        # make it clean
+        subprocess.run(
+            ["git", "checkout", "--", "seed.txt"], cwd=wt, check=True, capture_output=True
+        )
+        res = subprocess.run(
+            [sys.executable, str(VALIDATOR)],
+            input=json.dumps(
+                {
+                    "tool_name": "Bash",
+                    "tool_input": {"command": "git reset --hard"},
+                    "cwd": str(wt),
+                }
+            ),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert res.returncode == 0
+        assert res.stdout.strip() == ""

--- a/tests/unit/test_worktree_manager.py
+++ b/tests/unit/test_worktree_manager.py
@@ -306,8 +306,13 @@ class TestCleanupStaleWorktree:
 
     @patch("agent.worktree_manager.prune_worktrees")
     @patch("agent.worktree_manager.subprocess.run")
-    def test_force_removes_existing_directory(self, mock_run, mock_prune):
-        """When the worktree directory exists, force-remove it."""
+    @patch("agent.worktree_manager.preserve_uncommitted_worktree_changes")
+    def test_force_removes_existing_directory(self, mock_preserve, mock_run, mock_prune):
+        """When the worktree directory exists, force-remove it.
+
+        Preservation (#2137) is patched to a no-op here so the single
+        ``subprocess.run`` assertion isolates the force-remove call.
+        """
         mock_run.return_value = MagicMock(returncode=0)
         with patch.object(Path, "exists", return_value=True):
             _cleanup_stale_worktree(Path("/repo"), "session/feat", "/repo/.worktrees/old-feat")
@@ -379,8 +384,9 @@ class TestCleanupStaleWorktree:
     @patch("agent.worktree_manager.prune_worktrees")
     @patch("agent.worktree_manager.subprocess.run")
     @patch("agent.worktree_manager.logger")
+    @patch("agent.worktree_manager.preserve_uncommitted_worktree_changes")
     def test_fallback_does_not_pass_ignore_errors(
-        self, mock_logger, mock_run, mock_prune, mock_rmtree
+        self, mock_preserve, mock_logger, mock_run, mock_prune, mock_rmtree
     ):
         """Fallback branch fires logger.critical before rmtree and does not
         swallow errors via ``ignore_errors=True``.

--- a/tests/unit/test_worktree_manager.py
+++ b/tests/unit/test_worktree_manager.py
@@ -1055,3 +1055,151 @@ class TestCreateWorktreeProvisioningWiring:
             result = create_worktree(repo, "my-feature")
         assert result == repo / ".worktrees" / "my-feature"
         mock_prov.assert_called_once_with(repo / ".worktrees" / "my-feature")
+
+
+def _init_git_repo(tmp_path: Path, name: str = "repo") -> Path:
+    """Create a real git repo with an initial commit on ``main``."""
+    import subprocess as _sp
+
+    repo = tmp_path / name
+    repo.mkdir()
+    _sp.run(["git", "init", "-q", "-b", "main", str(repo)], check=True)
+    _sp.run(["git", "-C", str(repo), "config", "user.email", "t@example.com"], check=True)
+    _sp.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
+    (repo / "seed.txt").write_text("seed\n")
+    _sp.run(["git", "-C", str(repo), "add", "seed.txt"], check=True)
+    _sp.run(["git", "-C", str(repo), "commit", "-q", "-m", "seed"], check=True)
+    return repo
+
+
+def _add_linked_worktree(repo: Path, slug: str) -> Path:
+    """Add a linked worktree under ``.worktrees/{slug}`` on ``session/{slug}``."""
+    import subprocess as _sp
+
+    wt = repo / ".worktrees" / slug
+    _sp.run(
+        ["git", "-C", str(repo), "worktree", "add", "-q", "-b", f"session/{slug}", str(wt)],
+        check=True,
+    )
+    return wt
+
+
+def _dirty(wt: Path) -> None:
+    """Introduce staged + unstaged + untracked changes in a worktree."""
+    import subprocess as _sp
+
+    # Modify a tracked file (unstaged), stage a second edit, and add an untracked file.
+    (wt / "seed.txt").write_text("seed\nunstaged change\n")
+    (wt / "staged.txt").write_text("staged content\n")
+    _sp.run(["git", "-C", str(wt), "add", "staged.txt"], check=True)
+    (wt / "untracked.txt").write_text("untracked content\n")
+
+
+def _git(wt: Path, *args: str):
+    import subprocess as _sp
+
+    return _sp.run(["git", "-C", str(wt), *args], capture_output=True, text=True)
+
+
+class TestPreserveUncommittedChanges:
+    """TDD (issue #2137): auto-preserve uncommitted worktree work before teardown."""
+
+    def test_dirty_tree_preserved_in_named_ref_and_wip_commit(self, tmp_path, caplog):
+        from agent.worktree_manager import preserve_uncommitted_worktree_changes
+
+        repo = _init_git_repo(tmp_path)
+        slug = "sdlc-2137t"
+        wt = _add_linked_worktree(repo, slug)
+        head_before = _git(wt, "rev-parse", "HEAD").stdout.strip()
+        _dirty(wt)
+
+        with caplog.at_level(logging.WARNING, logger="agent.worktree_manager"):
+            result = preserve_uncommitted_worktree_changes(repo, slug, wt)
+
+        assert result["preserved"] is True
+        assert result["was_clean"] is False
+        sha = result["sha"]
+        assert sha and sha != head_before
+        assert result["ref"] == f"refs/session-wip/{slug}"
+
+        # Durable named ref resolves in the common ref store to the WIP commit.
+        ref_sha = _git(repo, "rev-parse", f"refs/session-wip/{slug}").stdout.strip()
+        assert ref_sha == sha
+        # HEAD of the worktree advanced to the WIP commit; tree is now clean.
+        assert _git(wt, "rev-parse", "HEAD").stdout.strip() == sha
+        assert _git(wt, "status", "--porcelain").stdout.strip() == ""
+
+        # Recovery pointer logged with slug, ref, and sha.
+        joined = " ".join(r.message for r in caplog.records)
+        assert "worktree-wip-preserved" in joined
+        assert slug in joined
+        assert f"refs/session-wip/{slug}" in joined
+        assert sha[:7] in joined
+
+    def test_clean_tree_is_noop_and_creates_no_ref(self, tmp_path):
+        from agent.worktree_manager import preserve_uncommitted_worktree_changes
+
+        repo = _init_git_repo(tmp_path)
+        slug = "sdlc-clean"
+        wt = _add_linked_worktree(repo, slug)
+
+        result = preserve_uncommitted_worktree_changes(repo, slug, wt)
+
+        assert result["preserved"] is False
+        assert result["was_clean"] is True
+        # No ref created.
+        assert _git(repo, "rev-parse", "--verify", f"refs/session-wip/{slug}").returncode != 0
+
+    def test_untracked_only_is_preserved(self, tmp_path):
+        from agent.worktree_manager import preserve_uncommitted_worktree_changes
+
+        repo = _init_git_repo(tmp_path)
+        slug = "sdlc-untr"
+        wt = _add_linked_worktree(repo, slug)
+        (wt / "brand-new.txt").write_text("only untracked\n")
+
+        result = preserve_uncommitted_worktree_changes(repo, slug, wt)
+
+        assert result["preserved"] is True
+        sha = result["sha"]
+        # The untracked file is captured in the WIP commit tree.
+        listing = _git(repo, "ls-tree", "-r", "--name-only", sha).stdout
+        assert "brand-new.txt" in listing
+
+    def test_git_failure_returns_error_dict_and_never_raises(self, tmp_path, caplog):
+        from agent.worktree_manager import preserve_uncommitted_worktree_changes
+
+        repo = _init_git_repo(tmp_path)
+        slug = "sdlc-fail"
+        wt = _add_linked_worktree(repo, slug)
+        _dirty(wt)
+
+        # Simulate a git plumbing failure: every git call raises.
+        with patch(
+            "agent.worktree_manager.subprocess.run",
+            side_effect=OSError("git exploded"),
+        ):
+            with caplog.at_level(logging.ERROR, logger="agent.worktree_manager"):
+                result = preserve_uncommitted_worktree_changes(repo, slug, wt)
+
+        assert result["preserved"] is False
+        assert result.get("errors")
+        joined = " ".join(r.message for r in caplog.records)
+        assert "worktree-wip-preserve-failed" in joined
+
+    def test_remove_worktree_preserves_dirty_tree_before_force_remove(self, tmp_path):
+        from agent import worktree_manager
+
+        repo = _init_git_repo(tmp_path)
+        slug = "sdlc-remove"
+        wt = _add_linked_worktree(repo, slug)
+        _dirty(wt)
+
+        with patch.object(worktree_manager, "worktree_busy_check", return_value=None):
+            ok = worktree_manager.remove_worktree(repo, slug, delete_branch=False)
+
+        assert ok is True
+        # Worktree directory is gone (force-removed) ...
+        assert not wt.exists()
+        # ... but the uncommitted work survives in the durable ref.
+        assert _git(repo, "rev-parse", "--verify", f"refs/session-wip/{slug}").returncode == 0


### PR DESCRIPTION
## Summary

Closes the backstop gap for uncommitted work in session worktrees (issue #2137). Two complementary layers, both driven TDD (red → green):

1. **Auto-WIP-commit before teardown** — `preserve_uncommitted_worktree_changes(repo_root, slug, worktree_dir)` in `agent/worktree_manager.py`. Before any `git worktree remove --force`, a dirty worktree's staged/unstaged/untracked work is captured as a WIP commit on `session/{slug}` plus a durable `refs/session-wip/{slug}` ref written to the **common** ref store (survives worktree removal and branch deletion). Wired into both `remove_worktree()` and `_cleanup_stale_worktree()` (the latter force-removes directly). Non-blocking contract: any git failure is logged loudly (`[worktree-wip-preserve-failed]`) and teardown still proceeds — it never raises or hangs.

2. **Destructive-git PreToolUse guard** — `.claude/hooks/validators/validate_no_destructive_git_in_worktree.py`. Blocks `git reset --hard`, `git clean -f[dx]`, `git checkout -- .` / `git checkout .`, `git restore .`, and bare `git stash` / `git stash push` (no pathspec) **only when** cwd is inside a `.worktrees/` path **and** the tree is dirty. Clean-tree resets are allowed; `# allow-destructive-git` override token bypasses. Mirrors `validate_no_uv_sync_in_worktree.py` (pure `find_violation`, command-position detection, `cd … &&` resolution, fail-open). Registered in `.claude/settings.json`.

## Testing

- `tests/unit/test_worktree_manager.py::TestPreserveUncommittedChanges` (5 tests) — dirty/clean/untracked-only/git-failure/real-`remove_worktree` against throwaway `git init` repos.
- `tests/unit/test_validate_no_destructive_git_in_worktree.py` (33 tests) — block/allow matrix, override, clean-tree, outside-worktree, fail-open, real dirty-worktree e2e.
- `pytest tests/unit/test_worktree_manager.py tests/unit/test_validate_no_destructive_git_in_worktree.py` → 101 passed. Ruff clean.

## Docs

`docs/features/session-isolation.md` gains an "Uncommitted-Work Preservation & Destructive-Git Guard" section covering the WIP-commit mechanism, `refs/session-wip/*` recovery, override convention, and manual GC policy.

Plan: `docs/plans/sdlc-2137.md`

Closes #2137
