### PR TITLE
Ownership gate for stale one-shot reapers — never kill a live PM-turn harness (#2149)

### DIFF
--- a/agent/session_health.py
+++ b/agent/session_health.py
@@ -12,6 +12,7 @@ See ``docs/features/pm-session-liveness.md`` for the full model.
 """
 
 import asyncio
+import concurrent.futures
 import functools
 import json
 import logging
@@ -101,11 +102,33 @@ ORPHAN_PROCESS_HEARTBEAT_GRACE_SECONDS = 1800
 #
 # Observed 2026-06-11: rogue orphan subagents spawned bare `claude ... --print`
 # one-shots (~250 MB each) that never exited; 21 accumulated at PPID==1. The
-# bundled-path regex above missed them (argv[0] was bare `claude` on PATH) and
-# the heartbeat gate is irrelevant — no legitimate `--print` one-shot lives
-# longer than a few minutes. Any PPID==1 `claude` process in `--print`/`-p`
-# mode older than this threshold is ALWAYS reapable. Conservative 10 minutes.
+# bundled-path regex above missed them (argv[0] was bare `claude` on PATH).
+#
+# Age alone is NO LONGER decisive (issue #2149): the premise that "no legitimate
+# `--print` one-shot lives this long" is false. A single PM turn driven by the
+# headless session runner legitimately runs 14-19 minutes as one live
+# `claude -p` harness process. Killing purely on age SIGTERM/SIGKILL'd a
+# genuinely running session on 2026-07-17. Both reapers now gate the age match
+# behind an ownership check (the fast reaper's ownership-gate helper below, the
+# existing ``_session_is_alive`` fall-through gate in the hourly reaper): a
+# stale-by-age one-shot is only reaped when its PID is NOT the harness of a live
+# session. The threshold remains the minimum age before a one-shot is even a
+# reap candidate. Conservative 10 minutes.
 ORPHAN_PRINT_ONESHOT_MAX_AGE_SECONDS = 600
+
+# Upper bound on the ownership `find_by_claude_pid` Redis lookup performed by
+# the fast reaper's ownership-gate helper in its hot loop. The fast reaper is
+# deliberately Redis-free elsewhere so it stays responsive during a memory
+# cascade; this bounded lookup must never stall the loop if Redis is slow or
+# wedged, so it runs in a worker thread with this timeout and fails toward
+# reapable (see the ownership-gate helper below).
+ORPHAN_OWNER_LOOKUP_TIMEOUT_SECONDS = 2.0
+
+# Single-worker executor backing the bounded ownership lookup above. Module-level
+# so the thread is created once and reused across reap passes rather than
+# per-call. Never resized; the lookup is strictly serialized behind the 2s
+# timeout.
+_owner_lookup_executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
 # Shell executables whose `-c` invocations count as transient wrappers for
 # dead-chain detection (issue #1632 mode 1b): a wrapper that is itself
@@ -4892,6 +4915,40 @@ def _session_is_alive(session) -> bool:
     return age < ORPHAN_PROCESS_HEARTBEAT_GRACE_SECONDS
 
 
+def _oneshot_owner_is_live(pid: int | None) -> bool:
+    """True if ``pid`` is the harness of a currently-live session (issue #2149).
+
+    The fast reaper (``_fast_reap_stale_print_oneshots``) uses this as its
+    ownership gate before killing a stale-by-age `claude --print` one-shot: a PM
+    turn legitimately runs 14-19 minutes as one live `claude -p` harness, so age
+    alone is not enough to declare the PID an orphan.
+
+    Bounded-lookup contract: the fast reaper is deliberately Redis-free in its
+    hot loop so it stays responsive during a memory cascade. The owning-session
+    resolution here (``AgentSession.find_by_claude_pid``) is the one Redis touch,
+    so it is dispatched to a module-level single-worker thread and awaited with
+    ``ORPHAN_OWNER_LOOKUP_TIMEOUT_SECONDS`` — it can never stall the loop longer
+    than that even if Redis is slow or wedged.
+
+    Fail-toward-reapable contract: ``pid is None``, a lookup timeout, or ANY
+    other exception returns False (the PID is treated as unowned → reapable).
+    This mirrors ``_session_is_alive``'s conservative-False bias: when liveness
+    cannot be positively confirmed, prefer cleanup. This function never raises.
+    """
+    if pid is None:
+        return False
+    try:
+        future = _owner_lookup_executor.submit(AgentSession.find_by_claude_pid, pid)
+        session = future.result(timeout=ORPHAN_OWNER_LOOKUP_TIMEOUT_SECONDS)
+    except concurrent.futures.TimeoutError:
+        logger.debug("[fast-oneshot-reap] owner lookup timed out for PID %s — reapable", pid)
+        return False
+    except Exception as e:
+        logger.debug("[fast-oneshot-reap] owner lookup failed for PID %s: %s — reapable", pid, e)
+        return False
+    return bool(session is not None and _session_is_alive(session))
+
+
 def _increment_orphan_process_counter(session) -> None:
     """Increment the appropriate orphan-reap counter (issue #1271).
 
@@ -5056,18 +5113,15 @@ def _reap_orphan_session_processes() -> int:
                         e,
                     )
 
-            if is_stale_oneshot:
-                # Fast-kill signature (issue #1632 mode 1a): no legitimate
-                # `--print` one-shot lives this long. The heartbeat gate is
-                # intentionally bypassed — an alive owning session does not
-                # legitimize a stuck one-shot child.
-                logger.info(
-                    "[orphan-reap] Stale --print one-shot PID %d (age > %ds) — fast-kill",
-                    pid,
-                    ORPHAN_PRINT_ONESHOT_MAX_AGE_SECONDS,
+            if session is not None and _session_is_alive(session):
+                # Issue #2149: a stale-by-age one-shot whose PID belongs to a
+                # live session is a legitimate long PM turn (14-19 min), not an
+                # orphan. The heartbeat gate is the sole protection here — the
+                # former age-only fast-kill branch that bypassed it was removed
+                # because it SIGTERM/SIGKILL'd a running session.
+                logger.debug(
+                    "[orphan-reap] protected live harness PID %d — owning session alive", pid
                 )
-            elif session is not None and _session_is_alive(session):
-                logger.debug("[orphan-reap] Skip PID %d — owning session is alive", pid)
                 continue
 
             # === Capture descendants BEFORE killing the parent ===
@@ -5137,9 +5191,17 @@ def _fast_reap_stale_print_oneshots() -> int:
     multiple-spawns-per-minute orphan cascade (observed: ~4/min, ~250 MB each).
 
     Deliberately minimal surface:
-      - No heartbeat gate, no Redis skip-set scan, no descendant walk — the
-        signature alone is decisive, and a `--print` one-shot has no useful
-        descendants. ``os.getpid()`` is still skipped, and the signature
+      - Ownership gate only (issue #2149): once a process matches the age
+        signature, the ownership-gate helper decides whether the PID is a live
+        PM-turn harness (14-19 min turns are legitimate) or a true orphan. That
+        gate performs a single ``find_by_claude_pid`` Redis lookup, but it is
+        BOUNDED — dispatched to a worker thread with
+        ``ORPHAN_OWNER_LOOKUP_TIMEOUT_SECONDS`` — precisely because this hot
+        loop must stay responsive during a memory cascade and must not stall on
+        a slow/wedged Redis. On timeout or error the gate fails toward reapable,
+        so conservative cleanup is preserved even when Redis is unavailable.
+      - No Redis skip-set scan, no descendant walk — a `--print` one-shot has no
+        useful descendants. ``os.getpid()`` is still skipped, and the signature
         cannot match `python -m worker` (argv[0] basename must be `claude`).
       - Escalation: first sighting → SIGTERM + stage ``(pid, create_time)``
         into ``_pending_sigkill_orphans``; if the same tuple is sighted again
@@ -5181,6 +5243,13 @@ def _fast_reap_stale_print_oneshots() -> int:
                     continue
 
                 staged = (pid, create_time)
+                if _oneshot_owner_is_live(pid):
+                    # Issue #2149: this PID is a live session's `claude -p`
+                    # harness (a legitimate multi-minute PM turn), not an
+                    # orphan. Never leak a recycled/live PID into the staging
+                    # ledger — discard any prior TERM stage for this tuple.
+                    _pending_sigkill_orphans.discard(staged)
+                    continue
                 if staged in _pending_sigkill_orphans:
                     proc.kill()
                     _pending_sigkill_orphans.discard(staged)

--- a/agent/session_health.py
+++ b/agent/session_health.py
@@ -104,10 +104,11 @@ ORPHAN_PROCESS_HEARTBEAT_GRACE_SECONDS = 1800
 # one-shots (~250 MB each) that never exited; 21 accumulated at PPID==1. The
 # bundled-path regex above missed them (argv[0] was bare `claude` on PATH).
 #
-# Age alone is NO LONGER decisive (issue #2149): the premise that "no legitimate
-# `--print` one-shot lives this long" is false. A single PM turn driven by the
-# headless session runner legitimately runs 14-19 minutes as one live
-# `claude -p` harness process. Killing purely on age SIGTERM/SIGKILL'd a
+# Age alone is NO LONGER decisive (issue #2149): the #1632 premise that a
+# legitimate `--print` one-shot never survives past this threshold is false. A
+# single PM turn driven by the headless session runner legitimately runs 14-19
+# minutes as one live `claude -p` harness process. Killing purely on age
+# SIGTERM/SIGKILL'd a
 # genuinely running session on 2026-07-17. Both reapers now gate the age match
 # behind an ownership check (the fast reaper's ownership-gate helper below, the
 # existing ``_session_is_alive`` fall-through gate in the hourly reaper): a
@@ -5249,6 +5250,10 @@ def _fast_reap_stale_print_oneshots() -> int:
                     # orphan. Never leak a recycled/live PID into the staging
                     # ledger — discard any prior TERM stage for this tuple.
                     _pending_sigkill_orphans.discard(staged)
+                    logger.info(
+                        "[fast-oneshot-reap] protected live harness PID %d — owning session alive",
+                        pid,
+                    )
                     continue
                 if staged in _pending_sigkill_orphans:
                     proc.kill()

--- a/docs/features/pm-session-liveness.md
+++ b/docs/features/pm-session-liveness.md
@@ -307,6 +307,50 @@ process unreachable at its creation sites, so a reaper leg here would be a clean
 path that should never fire while carrying a live-kill risk. The existing PPID==1
 reaper still covers genuinely-orphaned (worker-dead) processes.
 
+## One-shot reaper verifies orphanhood before killing (issue #2149)
+
+The two `claude --print` one-shot reapers in `agent/session_health.py` — the
+fast-cadence `_fast_reap_stale_print_oneshots()` (every health-loop tick) and
+the hourly `_reap_orphan_session_processes()` — no longer treat age alone as
+proof of orphanhood. The #1632 premise ("no legitimate `--print` one-shot
+survives past 600s") was invalidated by the headless-runner cutover: a single
+PM turn IS a `claude -p` process and legitimately runs 14–19 minutes. On
+2026-07-17 the age-only rule SIGTERM'd the live harness of a running session
+(PID 74819), which the next dead-worker sweep then finalized to `killed`.
+
+**The ownership gate.** Age > `ORPHAN_PRINT_ONESHOT_MAX_AGE_SECONDS` (600s) is
+now only a trigger to *investigate ownership*, never to kill:
+
+- **Fast reaper** calls `_oneshot_owner_is_live(pid)`: resolves
+  `AgentSession.find_by_claude_pid(pid)` inside a **bounded lookup** (a
+  module-level single-worker executor awaited with
+  `ORPHAN_OWNER_LOOKUP_TIMEOUT_SECONDS = 2.0`), then requires
+  `_session_is_alive(session)` (non-terminal + heartbeat fresher than 30 min).
+  Live owner → the PID is protected: any prior SIGTERM stage for its
+  `(pid, create_time)` tuple is discarded from `_pending_sigkill_orphans` (no
+  staging-ledger leak on PID recycling) and an INFO
+  `[fast-oneshot-reap] protected live harness PID N — owning session alive`
+  line is emitted. Timeout, lookup exception, or `pid=None` all **fail toward
+  reapable** — a wedged Redis degrades to the pre-fix cleanup, never a stalled
+  health loop, matching `_session_is_alive`'s conservative-False contract.
+- **Hourly reaper**: the former `is_stale_oneshot` fast-kill branch (which
+  deliberately bypassed the heartbeat gate) is deleted. A stale one-shot now
+  falls through to the same `session is not None and _session_is_alive(session)`
+  gate every other signature uses — one `find_by_claude_pid` lookup, already
+  resolved, no redundant second call.
+
+**Cleanup power preserved.** The #1632 rogue-subagent one-shots have no owning
+session (`find_by_claude_pid` → None), so they are still reaped on the same
+fast cadence — as are one-shots whose owner is terminal or whose owner's
+heartbeat is stale (dead worker).
+
+**Write-side dependency.** The gate reads `claude_pid`, written on PM-turn
+spawn by `agent/session_runner/runner.py` inside a fail-silent `try/except`
+and never backfilled afterward (the heartbeat writer refreshes only
+`last_heartbeat_at`). A spawn-time Redis blip that loses the write would make a
+live harness look unowned again; hardening that write is a tracked follow-up
+(plan Open Question 3), not part of this fix.
+
 ## See Also
 
 - [`docs/features/agent-session-health-monitor.md`](agent-session-health-monitor.md) — the simplified `_has_progress` + `_tier2_reprieve_signal` detector.

--- a/tests/unit/test_session_health_orphan_process_reap.py
+++ b/tests/unit/test_session_health_orphan_process_reap.py
@@ -412,28 +412,93 @@ def _young_ct() -> float:
     return time.time() - 60
 
 
-class TestStalePrintOneshotFastKill:
-    def test_stale_bare_print_oneshot_reaped_despite_fresh_heartbeat(self, clean_state):
-        """PPID==1 `claude --print` older than threshold is ALWAYS reapable.
+def _session(
+    *, status: str = "running", hb_age_seconds: float = 10, pid=None, project_key="proj-own"
+):
+    """Build a fake owning AgentSession-like object.
 
-        Two gaps closed at once: the legacy regex only matched the bundled
-        path (bare `claude` slipped through), and the heartbeat gate shielded
-        anything an alive-looking session claimed. Neither protects a stale
-        one-shot — no legitimate `--print` invocation lives that long.
+    ``hb_age_seconds`` sets how far in the past ``last_heartbeat_at`` is:
+    <1800s + non-terminal status => ``_session_is_alive`` True.
+    """
+    return SimpleNamespace(
+        project_key=project_key,
+        status=status,
+        last_heartbeat_at=datetime.now(UTC) - timedelta(seconds=hb_age_seconds),
+        claude_pid=pid,
+    )
+
+
+class TestStalePrintOneshotFastKill:
+    def test_stale_oneshot_live_owner_survives(self, clean_state):
+        """A stale `--print` one-shot owned by a live session is NOT reaped.
+
+        This is the 2026-07-17 regression fix: the old fast-kill branch killed
+        any stale one-shot on age alone, ignoring whether the PID belonged to a
+        genuinely running PM-turn harness. Under the ownership gate the stale
+        one-shot now falls through to the pre-existing
+        ``elif session is not None and _session_is_alive(session): continue``
+        gate and is protected.
         """
         proc = _fake_proc(pid=2100, ppid=1, cmdline=_BARE_ONESHOT_CMD, create_time=_stale_ct())
-        live_session = SimpleNamespace(
-            project_key="proj-fast",
-            status="running",
-            last_heartbeat_at=datetime.now(UTC) - timedelta(seconds=10),
-            claude_pid=2100,
-        )
+        live_session = _session(status="running", hb_age_seconds=10, pid=2100)
 
         with patch.object(psutil, "process_iter", return_value=[proc]):
             with patch.object(
                 session_health.AgentSession, "find_by_claude_pid", return_value=live_session
             ):
                 killed = session_health._reap_orphan_session_processes()
+
+        assert killed == 0
+        proc.terminate.assert_not_called()
+        proc.kill.assert_not_called()
+
+    def test_stale_oneshot_orphan_still_reaped(self, clean_state):
+        """A stale `--print` one-shot with NO owning session is still reaped.
+
+        The ownership gate only protects live-owned PIDs — a genuine orphan
+        (``find_by_claude_pid`` returns None) still gets terminated + staged.
+        """
+        proc = _fake_proc(pid=2110, ppid=1, cmdline=_BARE_ONESHOT_CMD, create_time=_stale_ct())
+
+        with patch.object(psutil, "process_iter", return_value=[proc]):
+            with patch.object(session_health.AgentSession, "find_by_claude_pid", return_value=None):
+                with patch.object(session_health, "_psutil_process_for_pid", return_value=proc):
+                    killed = session_health._reap_orphan_session_processes()
+
+        assert killed == 1
+        proc.terminate.assert_called_once()
+
+    def test_stale_oneshot_terminal_owner_still_reaped(self, clean_state):
+        """A stale one-shot whose owning session is terminal (killed) is reaped.
+
+        ``_session_is_alive`` returns False for terminal status, so the
+        ``elif ... _session_is_alive`` gate does not continue and the process
+        falls through to termination.
+        """
+        proc = _fake_proc(pid=2111, ppid=1, cmdline=_BARE_ONESHOT_CMD, create_time=_stale_ct())
+        dead_owner = _session(status="killed", hb_age_seconds=10, pid=2111)
+
+        with patch.object(psutil, "process_iter", return_value=[proc]):
+            with patch.object(
+                session_health.AgentSession, "find_by_claude_pid", return_value=dead_owner
+            ):
+                with patch.object(session_health, "_psutil_process_for_pid", return_value=proc):
+                    killed = session_health._reap_orphan_session_processes()
+
+        assert killed == 1
+        proc.terminate.assert_called_once()
+
+    def test_stale_oneshot_stale_heartbeat_owner_still_reaped(self, clean_state):
+        """A stale one-shot whose owning session has a >30min heartbeat is reaped."""
+        proc = _fake_proc(pid=2112, ppid=1, cmdline=_BARE_ONESHOT_CMD, create_time=_stale_ct())
+        stale_owner = _session(status="running", hb_age_seconds=2 * 3600, pid=2112)
+
+        with patch.object(psutil, "process_iter", return_value=[proc]):
+            with patch.object(
+                session_health.AgentSession, "find_by_claude_pid", return_value=stale_owner
+            ):
+                with patch.object(session_health, "_psutil_process_for_pid", return_value=proc):
+                    killed = session_health._reap_orphan_session_processes()
 
         assert killed == 1
         proc.terminate.assert_called_once()
@@ -604,10 +669,13 @@ class TestFastReapStalePrintOneshots:
             pid=2303, ppid=4242, cmdline=_BARE_ONESHOT_CMD, create_time=_stale_ct()
         )
 
+        # Under the ownership gate the fast reaper resolves each candidate PID
+        # via find_by_claude_pid; None keeps `stale` on the orphan path.
         with patch.object(
             psutil, "process_iter", return_value=[stale, young, interactive, attached]
         ):
-            reaped = session_health._fast_reap_stale_print_oneshots()
+            with patch.object(session_health.AgentSession, "find_by_claude_pid", return_value=None):
+                reaped = session_health._fast_reap_stale_print_oneshots()
 
         assert reaped == 1
         stale.terminate.assert_called_once()
@@ -618,13 +686,18 @@ class TestFastReapStalePrintOneshots:
         assert 2300 in staged_pids
 
     def test_escalates_to_sigkill_on_second_pass(self, clean_state):
-        """A survivor staged on a previous pass gets SIGKILL, tuple-verified."""
+        """A survivor staged on a previous pass gets SIGKILL, tuple-verified.
+
+        The survivor is an orphan (``find_by_claude_pid`` -> None), so the
+        ownership gate does not protect it and the staged tuple escalates.
+        """
         ct = _stale_ct()
         survivor = _fake_proc(pid=2304, ppid=1, cmdline=_BARE_ONESHOT_CMD, create_time=ct)
         session_health._pending_sigkill_orphans.add((2304, ct))
 
         with patch.object(psutil, "process_iter", return_value=[survivor]):
-            reaped = session_health._fast_reap_stale_print_oneshots()
+            with patch.object(session_health.AgentSession, "find_by_claude_pid", return_value=None):
+                reaped = session_health._fast_reap_stale_print_oneshots()
 
         assert reaped == 1
         survivor.kill.assert_called_once()
@@ -634,8 +707,11 @@ class TestFastReapStalePrintOneshots:
     def test_self_pid_never_reaped(self, clean_state):
         me = _fake_proc(pid=os.getpid(), ppid=1, cmdline=_BARE_ONESHOT_CMD, create_time=_stale_ct())
 
+        # The self-PID skip precedes the ownership lookup; patch anyway so the
+        # test is robust to any reordering of the guard checks.
         with patch.object(psutil, "process_iter", return_value=[me]):
-            reaped = session_health._fast_reap_stale_print_oneshots()
+            with patch.object(session_health.AgentSession, "find_by_claude_pid", return_value=None):
+                reaped = session_health._fast_reap_stale_print_oneshots()
 
         assert reaped == 0
         me.terminate.assert_not_called()
@@ -672,3 +748,214 @@ class TestFastReapStalePrintOneshots:
                 await session_health._agent_session_health_loop()
 
         fr.assert_called_once()
+
+
+# -----------------------------------------------------------------------------
+# Fast-reaper ownership gate (issue #2149): don't SIGTERM/SIGKILL a stale
+# one-shot whose PID is a genuinely live PM-turn harness.
+# -----------------------------------------------------------------------------
+
+
+class TestFastReapOwnershipGate:
+    def test_live_owned_stale_oneshot_survives(self, clean_state):
+        """A stale one-shot owned by a live session is neither TERM'd nor staged.
+
+        This is the direct regression for the 2026-07-17 incident: the fast
+        reaper killed a running session's `claude -p` on age alone. With the
+        ownership gate, ``_oneshot_owner_is_live`` returns True and the reaper
+        discards the candidate before any signal.
+        """
+        proc = _fake_proc(pid=2400, ppid=1, cmdline=_BARE_ONESHOT_CMD, create_time=_stale_ct())
+        live_owner = _session(status="running", hb_age_seconds=10, pid=2400)
+
+        with patch.object(psutil, "process_iter", return_value=[proc]):
+            with patch.object(
+                session_health.AgentSession, "find_by_claude_pid", return_value=live_owner
+            ):
+                reaped = session_health._fast_reap_stale_print_oneshots()
+
+        assert reaped == 0
+        proc.terminate.assert_not_called()
+        proc.kill.assert_not_called()
+        staged_pids = {p for p, _ in session_health._pending_sigkill_orphans}
+        assert 2400 not in staged_pids
+
+    def test_orphaned_stale_oneshot_reaped(self, clean_state):
+        """No owning session (find_by_claude_pid -> None) -> still reaped."""
+        proc = _fake_proc(pid=2401, ppid=1, cmdline=_BARE_ONESHOT_CMD, create_time=_stale_ct())
+
+        with patch.object(psutil, "process_iter", return_value=[proc]):
+            with patch.object(session_health.AgentSession, "find_by_claude_pid", return_value=None):
+                reaped = session_health._fast_reap_stale_print_oneshots()
+
+        assert reaped == 1
+        proc.terminate.assert_called_once()
+        staged_pids = {p for p, _ in session_health._pending_sigkill_orphans}
+        assert 2401 in staged_pids
+
+    def test_terminal_owner_stale_oneshot_reaped(self, clean_state):
+        """Owner exists but is terminal (killed) -> not live -> reaped."""
+        proc = _fake_proc(pid=2402, ppid=1, cmdline=_BARE_ONESHOT_CMD, create_time=_stale_ct())
+        dead_owner = _session(status="killed", hb_age_seconds=10, pid=2402)
+
+        with patch.object(psutil, "process_iter", return_value=[proc]):
+            with patch.object(
+                session_health.AgentSession, "find_by_claude_pid", return_value=dead_owner
+            ):
+                reaped = session_health._fast_reap_stale_print_oneshots()
+
+        assert reaped == 1
+        proc.terminate.assert_called_once()
+
+    def test_stale_heartbeat_owner_stale_oneshot_reaped(self, clean_state):
+        """Owner is running but heartbeat is >30min old -> not live -> reaped."""
+        proc = _fake_proc(pid=2403, ppid=1, cmdline=_BARE_ONESHOT_CMD, create_time=_stale_ct())
+        stale_owner = _session(status="running", hb_age_seconds=2 * 3600, pid=2403)
+
+        with patch.object(psutil, "process_iter", return_value=[proc]):
+            with patch.object(
+                session_health.AgentSession, "find_by_claude_pid", return_value=stale_owner
+            ):
+                reaped = session_health._fast_reap_stale_print_oneshots()
+
+        assert reaped == 1
+        proc.terminate.assert_called_once()
+
+    def test_staging_leak_discarded_when_owner_becomes_live(self, clean_state):
+        """Concern-2 regression: a PID staged for SIGKILL that now resolves to a
+        live owner must be discarded from ``_pending_sigkill_orphans`` and NOT
+        killed.
+
+        Scenario: a prior pass SIGTERM'd the PID and staged ``(pid, ct)``. On
+        this pass ``find_by_claude_pid`` now resolves the PID to a genuinely
+        running session (e.g. a recycled/handed-off harness). The ownership
+        gate must fire before the staged-SIGKILL branch — no TERM, no KILL —
+        and the leaked tuple must be dropped so it can't escalate later.
+        """
+        ct = _stale_ct()
+        proc = _fake_proc(pid=2404, ppid=1, cmdline=_BARE_ONESHOT_CMD, create_time=ct)
+        session_health._pending_sigkill_orphans.add((2404, ct))
+        live_owner = _session(status="running", hb_age_seconds=5, pid=2404)
+
+        with patch.object(psutil, "process_iter", return_value=[proc]):
+            with patch.object(
+                session_health.AgentSession, "find_by_claude_pid", return_value=live_owner
+            ):
+                reaped = session_health._fast_reap_stale_print_oneshots()
+
+        assert reaped == 0
+        proc.terminate.assert_not_called()
+        proc.kill.assert_not_called()
+        assert (2404, ct) not in session_health._pending_sigkill_orphans
+
+    def test_raising_lookup_does_not_abort_pass(self, clean_state):
+        """A find_by_claude_pid that raises for one PID must not abort the pass.
+
+        ``_oneshot_owner_is_live`` swallows the exception and returns False, so
+        the raising PID is treated as an orphan and reaped, and the *other*
+        stale one-shot in the same pass is still reaped too.
+        """
+        raising = _fake_proc(pid=2405, ppid=1, cmdline=_BARE_ONESHOT_CMD, create_time=_stale_ct())
+        normal = _fake_proc(pid=2406, ppid=1, cmdline=_BARE_ONESHOT_CMD, create_time=_stale_ct())
+
+        def lookup(pid):
+            if pid == 2405:
+                raise RuntimeError("redis lookup blew up")
+            return None
+
+        with patch.object(psutil, "process_iter", return_value=[raising, normal]):
+            with patch.object(
+                session_health.AgentSession, "find_by_claude_pid", side_effect=lookup
+            ):
+                reaped = session_health._fast_reap_stale_print_oneshots()
+
+        assert reaped == 2
+        raising.terminate.assert_called_once()
+        normal.terminate.assert_called_once()
+
+    def test_protect_path_logs_decision(self, clean_state, caplog):
+        """The protect path emits an auditable log line so operators can see
+        why a stale one-shot was spared.
+
+        The exact wording is owned by the companion fix; this assertion is
+        intentionally resilient — it only requires a distinguishing substring
+        ("protect"/"live"/"owner") to appear in the captured logs at DEBUG.
+        """
+        proc = _fake_proc(pid=2407, ppid=1, cmdline=_BARE_ONESHOT_CMD, create_time=_stale_ct())
+        live_owner = _session(status="running", hb_age_seconds=10, pid=2407)
+
+        with caplog.at_level(logging.DEBUG, logger="agent.session_health"):
+            with patch.object(psutil, "process_iter", return_value=[proc]):
+                with patch.object(
+                    session_health.AgentSession, "find_by_claude_pid", return_value=live_owner
+                ):
+                    session_health._fast_reap_stale_print_oneshots()
+
+        text = caplog.text.lower()
+        assert any(token in text for token in ("protect", "live", "owner"))
+
+
+# -----------------------------------------------------------------------------
+# _oneshot_owner_is_live direct unit tests (issue #2149)
+# -----------------------------------------------------------------------------
+
+
+class TestOneshotOwnerIsLive:
+    def test_pid_none_returns_false(self):
+        assert session_health._oneshot_owner_is_live(None) is False
+
+    def test_live_owner_returns_true(self):
+        live_owner = _session(status="running", hb_age_seconds=10, pid=3100)
+        with patch.object(
+            session_health.AgentSession, "find_by_claude_pid", return_value=live_owner
+        ):
+            assert session_health._oneshot_owner_is_live(3100) is True
+
+    def test_orphan_returns_false(self):
+        with patch.object(session_health.AgentSession, "find_by_claude_pid", return_value=None):
+            assert session_health._oneshot_owner_is_live(3101) is False
+
+    def test_terminal_owner_returns_false(self):
+        dead_owner = _session(status="killed", hb_age_seconds=10, pid=3102)
+        with patch.object(
+            session_health.AgentSession, "find_by_claude_pid", return_value=dead_owner
+        ):
+            assert session_health._oneshot_owner_is_live(3102) is False
+
+    def test_stale_heartbeat_owner_returns_false(self):
+        stale_owner = _session(status="running", hb_age_seconds=2 * 3600, pid=3103)
+        with patch.object(
+            session_health.AgentSession, "find_by_claude_pid", return_value=stale_owner
+        ):
+            assert session_health._oneshot_owner_is_live(3103) is False
+
+    def test_lookup_exception_returns_false(self):
+        with patch.object(
+            session_health.AgentSession,
+            "find_by_claude_pid",
+            side_effect=RuntimeError("redis down"),
+        ):
+            assert session_health._oneshot_owner_is_live(3104) is False
+
+    def test_lookup_timeout_returns_false_within_bound(self, monkeypatch):
+        """A find_by_claude_pid slower than the bound returns False, not a hang.
+
+        The timeout constant is shrunk for the test; the fake lookup sleeps far
+        longer, so a correct bounded implementation must return within the
+        shortened budget rather than blocking on the full sleep.
+        """
+        monkeypatch.setattr(session_health, "ORPHAN_OWNER_LOOKUP_TIMEOUT_SECONDS", 0.1)
+
+        def slow_lookup(pid):
+            time.sleep(0.6)
+            return _session(status="running", hb_age_seconds=5, pid=pid)
+
+        with patch.object(
+            session_health.AgentSession, "find_by_claude_pid", side_effect=slow_lookup
+        ):
+            start = time.monotonic()
+            result = session_health._oneshot_owner_is_live(3105)
+            elapsed = time.monotonic() - start
+
+        assert result is False
+        assert elapsed < 1.5

--- a/tests/unit/test_session_health_orphan_process_reap.py
+++ b/tests/unit/test_session_health_orphan_process_reap.py
@@ -874,12 +874,13 @@ class TestFastReapOwnershipGate:
         normal.terminate.assert_called_once()
 
     def test_protect_path_logs_decision(self, clean_state, caplog):
-        """The protect path emits an auditable log line so operators can see
-        why a stale one-shot was spared.
+        """The protect path emits an auditable "protected live harness" log line
+        so operators can distinguish protection from a kill in logs/worker.log.
 
-        The exact wording is owned by the companion fix; this assertion is
-        intentionally resilient — it only requires a distinguishing substring
-        ("protect"/"live"/"owner") to appear in the captured logs at DEBUG.
+        The exact substring is load-bearing: the post-deploy observability
+        criterion (plan Success Criteria, issue #2149) greps worker.log for
+        "protected live harness" as the counter-assertion to the 2026-07-17
+        SIGTERM incident, and asserts NO SIGTERM line for the protected PID.
         """
         proc = _fake_proc(pid=2407, ppid=1, cmdline=_BARE_ONESHOT_CMD, create_time=_stale_ct())
         live_owner = _session(status="running", hb_age_seconds=10, pid=2407)
@@ -891,8 +892,10 @@ class TestFastReapOwnershipGate:
                 ):
                     session_health._fast_reap_stale_print_oneshots()
 
-        text = caplog.text.lower()
-        assert any(token in text for token in ("protect", "live", "owner"))
+        assert "protected live harness" in caplog.text
+        assert "SIGTERM" not in caplog.text
+        proc.terminate.assert_not_called()
+        proc.kill.assert_not_called()
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Both age-gated `claude --print` one-shot reapers (`_fast_reap_stale_print_oneshots` and the hourly `_reap_orphan_session_processes`) killed purely on the 600s age signature. The #1632 premise — that no legitimate one-shot lives that long — is false: a headless-session-runner PM turn legitimately runs 14–19 minutes as one live `claude -p` harness. Observed 2026-07-17 14:33 UTC: the fast reaper SIGTERM'd the live harness of running session `0_1784286827622`, and the dead-worker sweep then swept the session to `killed`.

## Fix

- New `_oneshot_owner_is_live(pid)` ownership gate: resolves the PID via `AgentSession.find_by_claude_pid` in a module-level single-worker thread bounded by `ORPHAN_OWNER_LOOKUP_TIMEOUT_SECONDS` (2s), so the deliberately Redis-free fast-reap hot loop can never stall on a slow/wedged Redis. Fails toward reapable (pid None / timeout / any exception → False) and never raises.
- Fast reaper: an age-matched PID whose owning session is alive is protected (INFO log) and any prior staged SIGTERM tuple is discarded so a live/recycled PID never leaks into the SIGKILL escalation ledger.
- Hourly reaper: the age-only fast-kill branch that bypassed the heartbeat gate is removed; `_session_is_alive` is now the sole gate, with a parallel protect-path debug log.
- Genuine orphans (no owning session, terminal session, stale heartbeat) are still reaped — the rule's cleanup purpose is preserved.

## Tests

`tests/unit/test_session_health_orphan_process_reap.py`: 48 passed (-n0). Covers: live-owned harness survives both reapers; orphaned/terminal/stale-heartbeat still reaped; staging-set discard regression; raising lookup doesn't abort the pass; bounded-timeout behavior; protect-path log assertion. Sibling session_health suites: 111 passed.

## Docs

`docs/features/pm-session-liveness.md`: ownership-gate section added.

Plan: `docs/plans/fast-oneshot-reap-verify-orphanhood.md` (critique folded on main).

Closes #2149