### PR TITLE
Update flow drains sessions before worker restart; no orphaned harness (#2141)

### DIFF
--- a/docs/features/bridge-worker-architecture.md
+++ b/docs/features/bridge-worker-architecture.md
@@ -476,6 +476,42 @@ A session whose `session_id` starts with `local` was spawned from a local Claude
 | `running` (local `teammate`/historical `granite`/pre-migration) | Finalized as `abandoned`; human CLI may reclaim |
 | `complete` / `failed` / `killed` | Terminal — no action taken |
 
+### Update restart semantics for in-flight sessions (#2141)
+
+The ~30-min update cron (`scripts/remote-update.sh`) restarts the worker
+only when ALL of the following hold:
+
+1. **The release actually changed** (`BEFORE_SHA != AFTER_SHA`) **and the
+   diff touches worker-loaded paths** (`worker/ agent/ mcp_servers/ models/
+   tools/ bridge/ reflections/ pyproject.toml`). Docs-only pushes — notably
+   the plan commits every SDLC pipeline pushes to main — never trigger a
+   restart, which breaks the plan-commit → self-restart livelock.
+2. **The machine is idle**: before the kickstart, the script runs the drain
+   probe `python -m scripts.update.drain --timeout $UPDATE_WORKER_DRAIN_TIMEOUT_S
+   --poll $UPDATE_WORKER_DRAIN_POLL_S` (defaults 300s / 10s), which polls
+   the AgentSession ORM until no non-ledger session is `running`. If the
+   window expires while sessions are still running, the restart is
+   **DEFERRED** to the next update cycle with a loud
+   `[update] Worker restart DEFERRED: …` line — the worker keeps serving on
+   the previously-deployed code. The probe fails OPEN (restart proceeds,
+   stderr warning) so a broken probe can never wedge fleet updates.
+
+A **dead** worker (label unregistered AND no `python -m worker` process —
+the `pgrep` liveness cross-check prevents the historical `launchctl list`
+false-negative from kickstarting a live worker every cycle) is bootstrapped
+unconditionally: that is recovery, not a restart, and nothing is running to
+drain.
+
+On the worker side, the SIGTERM shutdown sequence bounds its active-task
+wait at `WORKER_SHUTDOWN_GRACE_S` (default 3s — sized to launchd's real
+SIGTERM→SIGKILL grace) and then calls
+`worker/shutdown_cleanup.py::terminate_harness_children()`, which SIGTERMs
+(then SIGKILLs) every in-flight `claude -p` harness descendant with a loud
+per-PID log line. Sessions cut off here are recovered by the startup
+recovery above — the cleanup removes the orphaned-harness race (a zombie
+subprocess writing into a recovered session's worktree for a full boot
+cycle), not the recovery itself.
+
 ### Own-progress fields are heartbeat-gated (#1614)
 
 The no-progress detector in `_has_progress` (`agent/session_health.py`) includes a set of "own-progress" fields — `turn_count`, `log_path`, and `claude_session_uuid` — that serve as evidence that a session authenticated with the SDK and began work. These fields are sticky once set and are only evaluated when `sdk_ever_output` is False, i.e. `agent.session_runner.liveness.derive_sdk_ever_output` returns False because none of `last_tool_use_at`, `last_turn_at`, or `last_stdout_at` has ever been written (issue #1935 added `last_stdout_at` as the third OR-input, closing the toolless-streaming false-positive window — see [Headless Session Runner § Liveness signals](headless-session-runner.md#liveness-signals-sdk_ever_output-issue-1935)).

--- a/docs/features/config-timeout-catalog.md
+++ b/docs/features/config-timeout-catalog.md
@@ -123,6 +123,21 @@ tool's own `timeout` parameter (milliseconds, harness cap 600000):
   `TIMEOUTS__*`); promoting them into `TimeoutSettings` remains a separate
   cleanup per the criterion below.
 
+## Update-restart drain knobs (issue #2141)
+
+Raw-env knobs (consumed by `scripts/remote-update.sh` — a bash consumer, so
+`TIMEOUTS__*`/`TimeoutSettings` does not apply — and by
+`scripts/update/drain.py` / `worker/shutdown_cleanup.py` as their defaults):
+
+| Knob | Default | Used by |
+|------|---------|---------|
+| `UPDATE_WORKER_DRAIN_TIMEOUT_S` | 300 | Total window the update flow waits for running sessions to drain before DEFERRING the worker restart to the next cycle. |
+| `UPDATE_WORKER_DRAIN_POLL_S` | 10 | Poll interval of the drain probe. |
+| `WORKER_SHUTDOWN_GRACE_S` | 3 | Worker SIGTERM shutdown: bounded active-task wait before abandoning in-flight turns and terminating `claude -p` harness children (`worker/shutdown_cleanup.py`). Sized to launchd's real kill grace. |
+
+See `docs/features/bridge-worker-architecture.md` § "Update restart
+semantics for in-flight sessions" for the full decision flow.
+
 ## Promote-vs-name-locally criterion
 
 Promote a literal to a `settings.timeouts.*` field if it is:

--- a/scripts/remote-update.sh
+++ b/scripts/remote-update.sh
@@ -241,49 +241,72 @@ PYEOF
         fi
     fi
 
-    # Restart moment — handed to the terminal verify's bounded beacon poll
-    # (Race 1 mitigation, issue #1898). Captured just before the kickstarts.
-    RESTART_TS=$(date +%s)
-    if launchctl list | grep -q "$WORKER_LABEL"; then
+    # Liveness cross-check (#2141): `launchctl list | grep` can false-negative
+    # while the worker is alive and still registered in the domain. The old
+    # fallback branch then hit bootstrap-EIO and kickstart -k'd the LIVE
+    # worker every cycle — bypassing the NEED_RESTART gate entirely (observed
+    # as `[update] Worker restarted` on runs with BEFORE_SHA == AFTER_SHA).
+    # A live worker process means "loaded" regardless of what the grep says.
+    WORKER_ALIVE=false
+    if pgrep -f "python -m worker" >/dev/null 2>&1; then
+        WORKER_ALIVE=true
+    fi
+    if launchctl list | grep -q "$WORKER_LABEL" || $WORKER_ALIVE; then
         if $NEED_RESTART; then
-            # Service is loaded — use kickstart -k to atomically kill+restart without
-            # the bootout/bootstrap race condition (bootstrap error 5: label still registered).
-            if launchctl kickstart -k "gui/$(id -u)/$WORKER_LABEL" 2>/dev/null; then
-                WORKER_STATE="worker restarted"
-                VERIFY_SINCE=$RESTART_TS
-            else
-                # kickstart failed; fall back to bootout + bootstrap with a brief wait
-                launchctl bootout "gui/$(id -u)/$WORKER_LABEL" 2>/dev/null || true
-                sleep 2
-                if launchctl bootstrap "gui/$(id -u)" "$WORKER_DST"; then
+            # Drain before restart (#2141): a PM turn legitimately runs 20+
+            # minutes; killing it mid-turn discards the in-flight work and
+            # orphans the harness. Poll until no sessions are running; on
+            # timeout DEFER the restart to the next update cycle — the worker
+            # keeps serving on the previously-deployed code (same posture the
+            # bridge takes for config-validation failures). Exit 0 = idle or
+            # probe failure (fail-open, warned on stderr); exit 3 = still busy.
+            if "$PYTHON" -m scripts.update.drain \
+                --timeout "${UPDATE_WORKER_DRAIN_TIMEOUT_S:-300}" \
+                --poll "${UPDATE_WORKER_DRAIN_POLL_S:-10}"; then
+                # Restart moment — handed to the terminal verify's bounded
+                # beacon poll (Race 1 mitigation, issue #1898). Captured just
+                # before the kickstart, after the drain window.
+                RESTART_TS=$(date +%s)
+                # Service is loaded — use kickstart -k to atomically kill+restart without
+                # the bootout/bootstrap race condition (bootstrap error 5: label still registered).
+                if launchctl kickstart -k "gui/$(id -u)/$WORKER_LABEL" 2>/dev/null; then
                     WORKER_STATE="worker restarted"
                     VERIFY_SINCE=$RESTART_TS
                 else
-                    # Distinct, scannable failure line + non-zero terminal exit.
-                    # A swallowed `echo ERROR` here is the #1898 root-cause shape.
-                    echo "RESTART FAILED: worker kickstart/bootstrap failed for $WORKER_LABEL"
-                    WORKER_STATE="worker restart FAILED"
-                    RESTART_FAILED=1
+                    # kickstart failed; fall back to bootout + bootstrap with a brief wait
+                    launchctl bootout "gui/$(id -u)/$WORKER_LABEL" 2>/dev/null || true
+                    sleep 2
+                    if launchctl bootstrap "gui/$(id -u)" "$WORKER_DST"; then
+                        WORKER_STATE="worker restarted"
+                        VERIFY_SINCE=$RESTART_TS
+                    else
+                        # Distinct, scannable failure line + non-zero terminal exit.
+                        # A swallowed `echo ERROR` here is the #1898 root-cause shape.
+                        echo "RESTART FAILED: worker kickstart/bootstrap failed for $WORKER_LABEL"
+                        WORKER_STATE="worker restart FAILED"
+                        RESTART_FAILED=1
+                    fi
                 fi
+            else
+                echo "[update] Worker restart DEFERRED: running session(s) did not drain in ${UPDATE_WORKER_DRAIN_TIMEOUT_S:-300}s — retrying next cycle"
             fi
         else
             echo "[update] No worker-relevant changes detected — skipping restart"
         fi
     else
-        # `launchctl list | grep` reported the label absent — treat as a first
-        # install and bootstrap. But that grep can false-negative while the
-        # label is in fact still registered in the domain (e.g. a stale worker
-        # process still holding it): the bare bootstrap then fails with
-        # `Bootstrap failed: 5: Input/output error` (errno 5 = label already
-        # bootstrapped in target domain). EIO here means the service IS loaded,
-        # so kickstart -k is the correct atomic recovery — the same primitive
-        # the loaded branch above prefers. Only declare failure if BOTH the
-        # bootstrap and the kickstart fallback fail. Suppress bootstrap stderr
-        # so a recoverable EIO doesn't leak the raw launchd error into the
-        # update summary (issue: stale-worker bootstrap EIO on "Valor the Bald").
-        # Capture bootstrap stderr so a recoverable EIO stays out of the summary
-        # but the raw launchd error (errno + message) is available to surface if
-        # BOTH the bootstrap and the kickstart fallback fail.
+        # Label absent AND no live worker process (#2141 liveness cross-check
+        # above) — the worker is genuinely down. Bootstrapping here is
+        # RECOVERY of a dead service, not a restart: nothing is running, so
+        # no drain is needed and the NEED_RESTART gate does not apply.
+        # The grep can still false-negative in exotic cases; the bare
+        # bootstrap then fails with `Bootstrap failed: 5: Input/output error`
+        # (errno 5 = label already bootstrapped in target domain). EIO here
+        # means the service IS loaded, so kickstart -k is the correct atomic
+        # recovery. Only declare failure if BOTH the bootstrap and the
+        # kickstart fallback fail. Capture bootstrap stderr so a recoverable
+        # EIO stays out of the summary but the raw launchd error is available
+        # to surface if both fail.
+        RESTART_TS=$(date +%s)
         WORKER_UID=$(id -u)
         # `|| true` keeps a failing bootstrap from tripping `set -e` before we
         # can inspect BOOTSTRAP_RC and attempt the kickstart recovery below.

--- a/scripts/update/drain.py
+++ b/scripts/update/drain.py
@@ -1,0 +1,100 @@
+"""Drain probe for the update flow's worker restart (issue #2141).
+
+The ~30-min update cron restarts the worker after a worker-relevant code
+change. Before #2141 the restart fired unconditionally, killing PM turns
+that legitimately run 20+ minutes and orphaning their `claude -p` harness.
+This module is the bounded busy-check `scripts/remote-update.sh` consults
+before restarting:
+
+    .venv/bin/python -m scripts.update.drain --timeout 300 --poll 10
+
+Exit codes (consumed by the shell):
+    0  — idle (no running sessions) → safe to restart NOW
+    3  — still busy after the whole window → the shell DEFERS the restart
+         to the next update cycle (worker keeps serving on the old code)
+
+Fail-open contract: any import/Redis/ORM error exits 0 with a stderr
+warning. A broken probe must degrade to today's behavior (restart), not
+wedge fleet updates forever — the warning line lands in update.log so the
+degradation is visible. Session counts go through the AgentSession ORM
+(never raw Redis — repo convention).
+
+Env knobs (documented in docs/features/config-timeout-catalog.md):
+    UPDATE_WORKER_DRAIN_TIMEOUT_S  (default 300) — total drain window
+    UPDATE_WORKER_DRAIN_POLL_S     (default 10)  — poll interval
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+EXIT_IDLE = 0
+EXIT_BUSY = 3
+
+DEFAULT_TIMEOUT_S = int(os.environ.get("UPDATE_WORKER_DRAIN_TIMEOUT_S", 300))
+DEFAULT_POLL_S = int(os.environ.get("UPDATE_WORKER_DRAIN_POLL_S", 10))
+
+
+def count_running_sessions() -> int:
+    """Number of AgentSessions currently in status ``running``.
+
+    Non-executable ledger sessions (sdlc-tool run anchors, #2042) hold no
+    in-flight turn — a machine whose only "running" rows are ledgers is
+    idle for restart purposes, so they are excluded. Raises on any ORM /
+    Redis failure; the caller decides the fail-open policy.
+    """
+    from agent.session_pickup import _truthy
+    from models.agent_session import AgentSession
+
+    running = list(AgentSession.query.filter(status="running"))
+    # _truthy: Popoto round-trips Field(default=False) as 'False'/'True'
+    # strings — mirrors session_health._is_ledger's robustness.
+    return sum(1 for s in running if not _truthy(getattr(s, "is_ledger", False)))
+
+
+def wait_for_idle(timeout_s: float, poll_s: float, *, log=print) -> bool:
+    """Poll until no sessions are running or ``timeout_s`` expires.
+
+    Returns True when idle (safe to restart), False when still busy at the
+    end of the window. Polls immediately first, so an already-idle machine
+    returns without sleeping. Propagates probe exceptions to the caller.
+    """
+    deadline = time.monotonic() + timeout_s
+    while True:
+        n = count_running_sessions()
+        if n == 0:
+            return True
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            log(f"[update-drain] still busy: {n} running session(s) at window end")
+            return False
+        log(
+            f"[update-drain] {n} running session(s) — waiting "
+            f"{min(poll_s, remaining):.0f}s (window {remaining:.0f}s left)"
+        )
+        time.sleep(min(poll_s, remaining))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_S)
+    parser.add_argument("--poll", type=float, default=DEFAULT_POLL_S)
+    args = parser.parse_args(argv)
+
+    try:
+        idle = wait_for_idle(args.timeout, args.poll)
+    except Exception as e:
+        # Fail-open: a broken probe must not wedge updates forever.
+        print(
+            f"[update-drain] WARNING: probe failed ({e!r}) — failing open (restart proceeds)",
+            file=sys.stderr,
+        )
+        return EXIT_IDLE
+    return EXIT_IDLE if idle else EXIT_BUSY
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_update_drain.py
+++ b/tests/unit/test_update_drain.py
@@ -1,0 +1,91 @@
+"""Update-flow drain probe (issue #2141).
+
+`scripts.update.drain` is the busy-check `remote-update.sh` consults before
+restarting the worker: exit 0 = idle (restart now), exit 3 = still busy
+(shell DEFERS to the next cycle). Fail-open on probe errors — a broken
+probe must degrade to today's restart behavior, never wedge fleet updates.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from scripts.update import drain
+
+
+def _sessions(*flags):
+    """Fake running-session rows; each flag is the row's is_ledger value."""
+    return [SimpleNamespace(is_ledger=f) for f in flags]
+
+
+# ---------------------------------------------------------------------------
+# count_running_sessions
+# ---------------------------------------------------------------------------
+
+
+def test_count_excludes_ledger_rows():
+    with patch("models.agent_session.AgentSession") as fake:
+        fake.query.filter.return_value = _sessions(False, True, "True", "False")
+        # 'True' string (Popoto round-trip) and bool True are ledgers;
+        # False and 'False' are real sessions.
+        assert drain.count_running_sessions() == 2
+        fake.query.filter.assert_called_once_with(status="running")
+
+
+def test_count_zero_when_only_ledgers():
+    with patch("models.agent_session.AgentSession") as fake:
+        fake.query.filter.return_value = _sessions(True, "True")
+        assert drain.count_running_sessions() == 0
+
+
+# ---------------------------------------------------------------------------
+# wait_for_idle
+# ---------------------------------------------------------------------------
+
+
+def test_wait_returns_true_immediately_when_idle():
+    with patch.object(drain, "count_running_sessions", return_value=0):
+        with patch.object(drain.time, "sleep") as fake_sleep:
+            assert drain.wait_for_idle(60, 5, log=lambda *_: None) is True
+            fake_sleep.assert_not_called()
+
+
+def test_wait_polls_until_idle():
+    counts = iter([2, 1, 0])
+    with patch.object(drain, "count_running_sessions", side_effect=lambda: next(counts)):
+        with patch.object(drain.time, "sleep") as fake_sleep:
+            assert drain.wait_for_idle(60, 5, log=lambda *_: None) is True
+            assert fake_sleep.call_count == 2
+
+
+def test_wait_returns_false_when_busy_past_deadline():
+    clock = iter([0.0, 0.0, 100.0, 100.0])
+    with (
+        patch.object(drain, "count_running_sessions", return_value=1),
+        patch.object(drain.time, "monotonic", side_effect=lambda: next(clock, 200.0)),
+        patch.object(drain.time, "sleep"),
+    ):
+        assert drain.wait_for_idle(50, 5, log=lambda *_: None) is False
+
+
+# ---------------------------------------------------------------------------
+# main / exit codes
+# ---------------------------------------------------------------------------
+
+
+def test_main_exit_idle():
+    with patch.object(drain, "wait_for_idle", return_value=True):
+        assert drain.main(["--timeout", "1", "--poll", "1"]) == drain.EXIT_IDLE
+
+
+def test_main_exit_busy():
+    with patch.object(drain, "wait_for_idle", return_value=False):
+        assert drain.main(["--timeout", "1", "--poll", "1"]) == drain.EXIT_BUSY
+
+
+def test_main_fails_open_on_probe_error(capsys):
+    with patch.object(drain, "wait_for_idle", side_effect=RuntimeError("redis down")):
+        assert drain.main(["--timeout", "1", "--poll", "1"]) == drain.EXIT_IDLE
+    err = capsys.readouterr().err
+    assert "failing open" in err

--- a/tests/unit/test_worker_shutdown_cleanup.py
+++ b/tests/unit/test_worker_shutdown_cleanup.py
@@ -1,0 +1,115 @@
+"""Worker shutdown harness-child cleanup (issue #2141).
+
+`terminate_harness_children` must SIGTERM (then SIGKILL) every `claude`
+harness descendant on worker shutdown instead of orphaning it into the next
+boot's reaper — and must never raise into the shutdown path.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from worker import shutdown_cleanup
+
+# ---------------------------------------------------------------------------
+# _is_claude_harness
+# ---------------------------------------------------------------------------
+
+
+def _proc(name="python", cmdline=None, pid=123):
+    p = MagicMock()
+    p.pid = pid
+    p.name.return_value = name
+    p.cmdline.return_value = cmdline if cmdline is not None else [name]
+    return p
+
+
+def test_matches_claude_by_name():
+    assert shutdown_cleanup._is_claude_harness(_proc(name="claude")) is True
+
+
+def test_matches_claude_by_argv0_basename():
+    p = _proc(name="2.1.205", cmdline=["/Users/x/.local/bin/claude", "-p", "--verbose"])
+    assert shutdown_cleanup._is_claude_harness(p) is True
+
+
+def test_non_claude_process_not_matched():
+    p = _proc(name="python", cmdline=["/usr/bin/python", "-m", "worker"])
+    assert shutdown_cleanup._is_claude_harness(p) is False
+
+
+def test_matcher_never_raises():
+    p = MagicMock()
+    p.name.side_effect = RuntimeError("gone")
+    assert shutdown_cleanup._is_claude_harness(p) is False
+
+
+# ---------------------------------------------------------------------------
+# terminate_harness_children
+# ---------------------------------------------------------------------------
+
+
+def test_terminates_matching_children_and_kills_survivors():
+    harness = _proc(name="claude", pid=101)
+    other = _proc(name="python", cmdline=["python", "-m", "x"], pid=102)
+    me = MagicMock()
+    me.children.return_value = [harness, other]
+
+    fake_psutil = SimpleNamespace(
+        Process=MagicMock(return_value=me),
+        wait_procs=MagicMock(return_value=([], [harness])),  # harness survives TERM
+    )
+    with patch.dict(sys.modules, {"psutil": fake_psutil}):
+        n = shutdown_cleanup.terminate_harness_children(term_grace_s=0.01)
+
+    assert n == 1
+    harness.terminate.assert_called_once()
+    harness.kill.assert_called_once()
+    other.terminate.assert_not_called()
+
+
+def test_no_children_is_noop():
+    me = MagicMock()
+    me.children.return_value = []
+    fake_psutil = SimpleNamespace(Process=MagicMock(return_value=me), wait_procs=MagicMock())
+    with patch.dict(sys.modules, {"psutil": fake_psutil}):
+        assert shutdown_cleanup.terminate_harness_children() == 0
+    fake_psutil.wait_procs.assert_not_called()
+
+
+def test_enumeration_failure_never_raises():
+    fake_psutil = SimpleNamespace(Process=MagicMock(side_effect=RuntimeError("no procfs")))
+    with patch.dict(sys.modules, {"psutil": fake_psutil}):
+        assert shutdown_cleanup.terminate_harness_children() == 0
+
+
+def test_terminate_failure_still_counts_and_continues():
+    bad = _proc(name="claude", pid=201)
+    bad.terminate.side_effect = RuntimeError("gone already")
+    good = _proc(name="claude", pid=202)
+    me = MagicMock()
+    me.children.return_value = [bad, good]
+    fake_psutil = SimpleNamespace(
+        Process=MagicMock(return_value=me),
+        wait_procs=MagicMock(return_value=([bad, good], [])),
+    )
+    with patch.dict(sys.modules, {"psutil": fake_psutil}):
+        assert shutdown_cleanup.terminate_harness_children(term_grace_s=0.01) == 2
+    good.terminate.assert_called_once()
+
+
+def test_real_subprocess_child_is_not_matched():
+    """Sanity: a real non-claude child (sleep) is never touched."""
+    child = subprocess.Popen(["sleep", "5"])
+    try:
+        time.sleep(0.1)
+        n = shutdown_cleanup.terminate_harness_children(term_grace_s=0.1)
+        assert child.poll() is None  # still alive — not collateral damage
+        assert isinstance(n, int)
+    finally:
+        child.terminate()
+        child.wait(timeout=5)

--- a/worker/__main__.py
+++ b/worker/__main__.py
@@ -984,16 +984,36 @@ async def _run_worker(projects: dict, dry_run: bool = False) -> None:
     # Wait for shutdown signal
     await shutdown_event.wait()
 
-    # Wait for active worker loops to finish their current sessions
+    # Wait for active worker loops to finish their current sessions. The
+    # wait is bounded by WORKER_SHUTDOWN_GRACE_S (default 3s — honest about
+    # launchd's real SIGTERM→SIGKILL grace; the previous 60s wait never
+    # completed under kickstart -k and silently orphaned the harness, issue
+    # #2141). Sessions cut off here are recovered by startup recovery.
+    from worker.shutdown_cleanup import WORKER_SHUTDOWN_GRACE_S, terminate_harness_children
+
     active_tasks = [t for t in _active_workers.values() if not t.done()]
     if active_tasks:
-        logger.info(f"Waiting for {len(active_tasks)} active worker(s) to finish...")
-        done, pending = await asyncio.wait(active_tasks, timeout=60)
+        logger.info(
+            f"Waiting up to {WORKER_SHUTDOWN_GRACE_S:.0f}s for {len(active_tasks)} "
+            "active worker(s) to finish..."
+        )
+        done, pending = await asyncio.wait(active_tasks, timeout=WORKER_SHUTDOWN_GRACE_S)
         if pending:
-            logger.warning(f"{len(pending)} worker(s) did not finish in 60s, cancelling...")
+            logger.warning(
+                f"{len(pending)} worker(s) did not finish in "
+                f"{WORKER_SHUTDOWN_GRACE_S:.0f}s, cancelling..."
+            )
             for task in pending:
                 task.cancel()
             await asyncio.gather(*pending, return_exceptions=True)
+
+    # Kill any in-flight `claude -p` harness children instead of orphaning
+    # them into the next boot's reaper (issue #2141) — an orphaned harness
+    # keeps writing into a worktree whose session is about to be recovered.
+    try:
+        terminate_harness_children()
+    except Exception as _thc_err:
+        logger.warning("[shutdown] terminate_harness_children failed: %s", _thc_err)
 
     # Drain in-flight PM final-delivery completion runners (issue #1058).
     # Ordering: before extraction drain because the completion runner may

--- a/worker/shutdown_cleanup.py
+++ b/worker/shutdown_cleanup.py
@@ -1,0 +1,93 @@
+"""Terminate in-flight harness children on worker shutdown (issue #2141).
+
+Before this module, the worker's SIGTERM path waited up to 60s for active
+session tasks — but launchd's real kill grace is ~3-5s, so the wait never
+completed and the session's `claude -p` harness subprocess was ORPHANED,
+surviving into the next boot where the orphan-reap SIGKILLed it a full boot
+cycle later. One boot cycle with a zombie subprocess writing into a
+recovered session's worktree is an avoidable race.
+
+``terminate_harness_children`` is called from the worker shutdown sequence
+after the (now grace-bounded) active-task wait: it enumerates this process's
+descendants, SIGTERMs every `claude` harness among them, waits briefly, and
+SIGKILLs survivors. Loud per-PID logging makes each abandoned turn visible
+in worker.log. Best-effort by design: if launchd SIGKILLs the worker before
+this runs, behavior degrades to exactly the pre-#2141 status quo (next-boot
+reaper). Never raises into the shutdown path.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+# Env knob (documented in docs/features/config-timeout-catalog.md): how long
+# the shutdown sequence waits for active session tasks before abandoning
+# them and cleaning up children. Sized to launchd's observed ~3-5s SIGTERM
+# grace — an honest bound, unlike the previous 60s wait that never completed.
+WORKER_SHUTDOWN_GRACE_S = float(os.environ.get("WORKER_SHUTDOWN_GRACE_S", 3.0))
+
+
+def _is_claude_harness(proc) -> bool:
+    """True if ``proc`` looks like a `claude` harness subprocess.
+
+    Matches on the process name OR argv[0] basename being `claude` (the
+    headless runner spawns the CLI binary directly; versioned installs give
+    it a bare-number basename with `claude` in argv[0]). Never raises.
+    """
+    try:
+        if proc.name() == "claude":
+            return True
+        cmdline = proc.cmdline()
+        if cmdline and os.path.basename(cmdline[0]) == "claude":
+            return True
+    except Exception:
+        return False
+    return False
+
+
+def terminate_harness_children(term_grace_s: float = 1.5) -> int:
+    """SIGTERM (then SIGKILL) all `claude` harness descendants of this process.
+
+    Returns the number of harness processes terminated. Never raises — any
+    psutil/platform failure logs a warning and returns what was done so far.
+    """
+    try:
+        import psutil
+
+        me = psutil.Process()
+        harnesses = [c for c in me.children(recursive=True) if _is_claude_harness(c)]
+    except Exception as e:
+        logger.warning("[shutdown] harness-child enumeration failed: %s", e)
+        return 0
+
+    if not harnesses:
+        return 0
+
+    for proc in harnesses:
+        try:
+            logger.warning(
+                "[shutdown] terminating in-flight harness PID %d (session turn "
+                "abandoned; startup recovery will resume the session)",
+                proc.pid,
+            )
+            proc.terminate()
+        except Exception as e:
+            logger.warning("[shutdown] SIGTERM failed for PID %d: %s", proc.pid, e)
+
+    try:
+        import psutil
+
+        _, alive = psutil.wait_procs(harnesses, timeout=term_grace_s)
+        for proc in alive:
+            try:
+                logger.warning("[shutdown] SIGKILL harness PID %d (survived SIGTERM)", proc.pid)
+                proc.kill()
+            except Exception as e:
+                logger.warning("[shutdown] SIGKILL failed for PID %d: %s", proc.pid, e)
+    except Exception as e:
+        logger.warning("[shutdown] harness-child wait/kill failed: %s", e)
+
+    return len(harnesses)


### PR DESCRIPTION
## Summary

The ~30-min update cron restarted the worker unconditionally — killing PM turns 19 minutes in, orphaning their `claude -p` harness for the next boot's reaper, and livelocking pipelines whose own plan commits armed the next restart (6 restarts observed 2026-07-17).

## Root causes fixed

1. **Ungated fallback restart** — `launchctl list | grep` false-negatives sent the flow into the not-loaded branch, whose bootstrap→EIO→`kickstart -k` chain restarted the LIVE worker every cycle, bypassing the existing `NEED_RESTART` diff gate (this is why unchanged releases still restarted). Fixed with a `pgrep` liveness cross-check: a live worker process is treated as loaded; only a genuinely dead worker (no label AND no process) is bootstrapped unconditionally — recovery, not restart.
2. **No drain** — gated restarts now run `python -m scripts.update.drain --timeout 300 --poll 10` (new, ORM-based, ledger-aware, unit-tested). Still busy at window end → the restart is **DEFERRED** to the next cycle with a loud log; the worker keeps serving the previous release. Probe failure fails OPEN so a broken probe can't wedge fleet updates.
3. **Orphaned harness on SIGTERM** — the worker's 60s active-task wait never completed under launchd's ~3-5s real grace. The wait is now bounded by `WORKER_SHUTDOWN_GRACE_S` (default 3s) and `worker/shutdown_cleanup.py::terminate_harness_children()` SIGTERMs/SIGKILLs in-flight `claude` descendants with loud per-PID logs — no zombie writing into a recovered session's worktree for a boot cycle.

The existing worker-relevant-diff gate (skip-when-unchanged + docs/plans-only exemption) is preserved and — with fix 1 — now actually effective on every path.

## Tests

17 new (-n0 pass): drain count/wait/exit-code matrix incl. Popoto string-bool ledger rows and fail-open; harness matcher (name + argv0-basename), terminate→kill escalation, never-raises contracts, real-subprocess non-collateral sanity. `bash -n` syntax gate on remote-update.sh.

## Docs

- `docs/features/bridge-worker-architecture.md` — 'Update restart semantics for in-flight sessions'
- `docs/features/config-timeout-catalog.md` — drain/grace knob table

Plan: `docs/plans/update-drain-before-worker-restart.md` (on main)

Closes #2141