### PR TITLE
Ownership-based startup-recovery guard — no stranded sessions, no serialization violation (#2148)

### DIFF
--- a/agent/session_health.py
+++ b/agent/session_health.py
@@ -58,6 +58,62 @@ def _is_ledger(entry) -> bool:
     return _truthy(getattr(entry, "is_ledger", False))
 
 
+def _coerce_pid(value) -> int | None:
+    """Best-effort int coercion for a stored PID field. Garbage → None.
+
+    PIDs ≤ 1 are rejected: pid 1 is launchd (always alive — a liveness test
+    against it is meaningless) and no worker/harness can ever legitimately
+    hold it.
+    """
+    try:
+        pid = int(value)
+    except (TypeError, ValueError):
+        return None
+    return pid if pid > 1 else None
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """True if a process with ``pid`` exists (issue #2148 ownership test).
+
+    ``os.kill(pid, 0)`` semantics: ProcessLookupError → dead; PermissionError
+    → a process EXISTS (just not signalable by us) → treated as alive, the
+    conservative direction for a skip-guard. Any other failure → dead.
+    """
+    try:
+        os.kill(pid, 0)
+        return True
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+
+
+def _terminate_detached_harness(entry) -> None:
+    """SIGTERM a recovered session's still-alive harness subprocess (#2148).
+
+    A SIGKILL'd worker leaves its `claude -p` child running detached. If the
+    session is recovered (running→pending) while that harness lives, the
+    re-picked session double-executes against it. Best-effort — never raises.
+    """
+    for attr in ("claude_pid", "pm_pid"):
+        pid = _coerce_pid(getattr(entry, attr, None))
+        if pid is None or not _pid_is_alive(pid):
+            continue
+        try:
+            logger.warning(
+                "[startup-recovery] Terminating detached harness %s=%d of session %s "
+                "before re-queue (#2148)",
+                attr,
+                pid,
+                getattr(entry, "agent_session_id", "?"),
+            )
+            os.kill(pid, signal.SIGTERM)
+        except OSError as e:
+            logger.warning(
+                "[startup-recovery] Failed to SIGTERM detached harness pid=%d: %s", pid, e
+            )
+
+
 # Re-exported for tests/monkeypatching: keeps the symbol resolvable as
 # `agent.session_health.record_metric` even after ruff/F401 lint cycles.
 __all__ = ["record_metric"]
@@ -700,15 +756,37 @@ def _recover_interrupted_agent_sessions_startup() -> int:
     now = time.time()
     cutoff = now - AGENT_SESSION_HEALTH_MIN_RUNNING
 
-    # Filter out recently-started sessions (they are not orphans from a dead process)
+    # Ownership-based guard (issue #2148): skip only sessions owned by a
+    # LIVE worker process (a concurrent worker that started before this
+    # recovery fired — the guard's original purpose, now exact). A session
+    # whose owning worker is dead is interrupted REGARDLESS of age — the old
+    # age-only guard stranded <300s-old sessions as unowned `running` rows,
+    # letting the new worker's queue loop pop a second session for the same
+    # worker_key (serialization violation, observed 2026-07-17). Legacy rows
+    # without a worker_pid stamp fall back to the age guard until they cycle.
     stale_sessions = []
     skipped = 0
     for entry in running_sessions:
+        owner_pid = _coerce_pid(getattr(entry, "worker_pid", None))
+        if owner_pid is not None:
+            if owner_pid != os.getpid() and _pid_is_alive(owner_pid):
+                skipped += 1
+                logger.info(
+                    "[startup-recovery] Skipping session %s — owning worker pid=%d is alive",
+                    entry.agent_session_id,
+                    owner_pid,
+                )
+                continue
+            # Owner dead (or, defensively, this very process) → interrupted.
+            stale_sessions.append(entry)
+            continue
+        # Legacy row (pre-#2148, no ownership stamp): age fallback.
         started_ts = _ts(getattr(entry, "started_at", None))
         if started_ts is not None and started_ts > cutoff:
             skipped += 1
             logger.info(
-                "[startup-recovery] Skipping recent session %s (started %ds ago, guard=%ds)",
+                "[startup-recovery] Skipping recent session %s "
+                "(no worker_pid stamp; started %ds ago, guard=%ds)",
                 entry.agent_session_id,
                 int(now - started_ts),
                 AGENT_SESSION_HEALTH_MIN_RUNNING,
@@ -717,7 +795,7 @@ def _recover_interrupted_agent_sessions_startup() -> int:
             stale_sessions.append(entry)
 
     if skipped:
-        logger.info("[startup-recovery] Skipped %d recently-started session(s)", skipped)
+        logger.info("[startup-recovery] Skipped %d live-owned/recent session(s)", skipped)
 
     if not stale_sessions:
         return 0
@@ -762,6 +840,11 @@ def _recover_interrupted_agent_sessions_startup() -> int:
                 entry.agent_session_id,
             )
             continue
+
+        # A dead owner can leave a live detached harness (SIGKILL'd worker
+        # skips shutdown cleanup). Kill it before re-queue/abandon so the
+        # session's next pickup can't double-execute against it (#2148).
+        _terminate_detached_harness(entry)
 
         wk = entry.worker_key
         is_local = entry.session_id.startswith("local")  # session_id is the reliable discriminator

--- a/agent/session_pickup.py
+++ b/agent/session_pickup.py
@@ -471,6 +471,9 @@ async def _pop_agent_session(
         )
 
         chosen.started_at = datetime.now(tz=UTC)
+        # Ownership stamp (#2148): startup recovery keys its skip-guard on
+        # this PID's liveness. Persisted by transition_status's full save.
+        chosen.worker_pid = os.getpid()
         transition_status(chosen, "running", reason="worker picked up session")
     finally:
         _release_pop_lock(worker_key)
@@ -630,6 +633,8 @@ async def _pop_agent_session_with_fallback(
         )
 
         chosen.started_at = datetime.now(tz=UTC)
+        # Ownership stamp (#2148) — same contract as the primary pickup path.
+        chosen.worker_pid = os.getpid()
         transition_status(chosen, "running", reason="worker picked up session (sync fallback)")
 
         # Inject resume hydration context BEFORE steering messages (#874)

--- a/docs/features/bridge-worker-architecture.md
+++ b/docs/features/bridge-worker-architecture.md
@@ -455,7 +455,7 @@ Worker restarts (SIGTERM, crash, or explicit `verify command exists or correct s
 When the worker process is killed mid-execution, the `asyncio.CancelledError` handler does **not** finalize the session. The session remains in `running` state in Redis. On the next worker startup, two steps handle stale `running` sessions in order:
 
 1. **Step 3a — `_sweep_dead_worker_sessions()`** (issue #1767): checks `claude_pid` liveness via `os.kill(pid, 0)`. Sessions whose subprocess is provably dead are finalized to `killed` and `bridge.agent_catchup` is triggered so the user's unanswered message re-enqueues. This step must run first — otherwise Step 3b would reset all `running` sessions to `pending` before PID liveness can be checked.
-2. **Step 3b — `_recover_interrupted_agent_sessions_startup()`**: handles the remaining `running` sessions (those with a live PID or no PID yet) and transitions them back to `pending` so they are retried by the new worker.
+2. **Step 3b — `_recover_interrupted_agent_sessions_startup()`**: handles the remaining `running` sessions (those with a live PID or no PID yet) and transitions them back to `pending` so they are retried by the new worker. Its skip-guard is **ownership-based** (#2148): sessions whose stamped `worker_pid` belongs to a live concurrent worker are skipped; a dead owner means interrupted regardless of age (legacy rows without the stamp fall back to the 300s age guard), and a still-alive detached harness is SIGTERM'd before re-queue — see [Session Lifecycle § Ownership-Based Startup-Recovery Guard](session-lifecycle.md#ownership-based-startup-recovery-guard-issue-2148).
 
 ### Local session recovery is `session_type`-aware (#1092)
 

--- a/docs/features/session-lifecycle.md
+++ b/docs/features/session-lifecycle.md
@@ -96,6 +96,32 @@ Recovery now confirms subprocess termination before deciding how to transition:
 
 **User-facing notification (issue #1937 — silent-resume inversion):** the requeue-to-`pending` branch above is an auto-resuming interruption and is **silent** — no "I was interrupted" message is sent; the user next hears from the session when it actually finishes or fails. Only the "not confirmed dead" escalation to `failed` is terminal, and that branch delivers a last-resort `INTERRUPT_NO_RESUME` notice (`_deliver_terminal_interrupt_notice` in `agent/session_health.py`) when neither the deferred self-draft fallback nor the tool-timeout degraded notice already spoke for this exit. See [Reason-Aware Interrupt Messaging and Failure Notification](pm-final-delivery.md#reason-aware-interrupt-messaging-and-failure-notification-issue-1877-silent-resume-inversion) for the full send-site design.
 
+### Ownership-Based Startup-Recovery Guard (issue #2148)
+
+Every pending→running pickup stamps `AgentSession.worker_pid = os.getpid()`
+(`agent/session_pickup.py`, both transition sites — persisted by
+`transition_status`'s full save). At boot,
+`_recover_interrupted_agent_sessions_startup` keys its skip-guard on that
+stamp instead of wall-clock age:
+
+- **`worker_pid` alive** (`os.kill(pid, 0)`; `PermissionError` counts as
+  alive; PIDs ≤ 1 rejected as garbage) → the session is owned by a live
+  concurrent worker → **skip** (the guard's original purpose, now exact).
+- **`worker_pid` dead** → the session is interrupted **regardless of age** —
+  a session started 10s before the worker crash is recovered, not stranded.
+  The pre-#2148 age-only guard left such sessions `running` with no owner,
+  letting the new worker's queue loop pop a second session for the same
+  worker_key (per-project serialization violation, observed 2026-07-17).
+- **No stamp** (legacy rows) → the old 300s age guard applies until the row
+  cycles.
+
+Before re-queue/abandon, `_terminate_detached_harness` SIGTERMs any
+still-alive `claude_pid`/`pm_pid` (a SIGKILL'd worker skips the #2141
+shutdown cleanup and leaves its harness detached) so the re-picked session
+cannot double-execute against a zombie. Serialization across restarts then
+holds by boot ordering: recovery runs before the queue loops start popping,
+so previously-stranded sessions are back in `pending` — one session per key.
+
 ## Kill-is-Terminal Invariant
 
 `valor-session kill` is a hard guarantee. Once a session is killed (or in any terminal state), no routine pipeline-progression code path may transition it to a different terminal status. This invariant is enforced symmetrically by both lifecycle entry points:

--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -375,6 +375,17 @@ class AgentSession(Model):
     # turn's subprocess exists.
     pm_pid = IntField(null=True)
 
+    # === Owning worker identity (issue #2148) ===
+    # OS PID of the worker process that owns this session's execution,
+    # stamped at pending->running pickup (agent/session_pickup.py) alongside
+    # ``started_at`` (persisted by transition_status's full save). Startup
+    # recovery keys its skip-guard on THIS pid's liveness — "owned by a live
+    # concurrent worker" — instead of wall-clock age, so a session started
+    # seconds before a worker crash is still recovered rather than stranded
+    # `running` with no owner. Nullable; legacy rows fall back to the age
+    # guard until they cycle.
+    worker_pid = IntField(null=True)
+
     # === Crash-recovery reflection fields (issue #1539) ===
     # crash_signature: write-once stamp set at resume time, recording the
     # crash signature of the session this resume recovers. Used by the

--- a/tests/unit/test_recovery_respawn_safety.py
+++ b/tests/unit/test_recovery_respawn_safety.py
@@ -53,6 +53,12 @@ def _mock_agent_session(**kwargs):
         # truthy child Mock, which would make getattr(entry, "is_ledger", False)
         # in agent/session_health.py's _is_ledger() guard misfire (#2042).
         "is_ledger": False,
+        # Ownership stamp (#2148): None = legacy row → recovery falls back to
+        # the age guard. Same auto-vivification rationale as is_ledger above.
+        "worker_pid": None,
+        # Detached-harness pids: None so _terminate_detached_harness no-ops.
+        "claude_pid": None,
+        "pm_pid": None,
     }
     defaults.update(kwargs)
     session = MagicMock()
@@ -1016,4 +1022,111 @@ class TestMarkSupersededTerminalGuard:
             "must not be reintroduced by any successor (e.g. "
             "_delete_stale_terminal_duplicates(), which deletes stale terminal duplicates "
             "instead of transitioning them)."
+        )
+
+
+class TestStartupRecoveryOwnershipGuard:
+    """#2148: the recent-session guard keys on owning-worker liveness, not age."""
+
+    def _recent_bridge_session(self, **kwargs):
+        import time
+
+        defaults = dict(
+            session_id="0_recent",
+            agent_session_id="agent-recent-001",
+            worker_key="valor",
+            session_type=SessionType.ENG,
+            started_at=time.time() - 30,  # well inside the old 300s guard
+            message_text="in-flight work",
+        )
+        defaults.update(kwargs)
+        return _mock_agent_session(**defaults)
+
+    def _run_recovery(self, sessions):
+        import time
+
+        from agent.agent_session_queue import _recover_interrupted_agent_sessions_startup
+
+        with (
+            patch("agent.session_health.AgentSession") as mock_as,
+            patch("agent.session_health.time") as mock_time,
+            patch("models.session_lifecycle.finalize_session"),
+            patch("models.session_lifecycle.update_session") as mock_update,
+        ):
+            mock_time.time.return_value = time.time()
+            mock_as.query.filter.return_value = sessions
+            count = _recover_interrupted_agent_sessions_startup()
+        return count, mock_update
+
+    def test_recent_session_with_dead_owner_is_recovered(self):
+        """The #2148 incident shape: started 30s before the crash, owner dead
+        → recovered, NOT stranded."""
+        session = self._recent_bridge_session(worker_pid=2**22 + 12345)  # dead pid
+        with patch("agent.session_health._pid_is_alive", return_value=False):
+            count, mock_update = self._run_recovery([session])
+        assert count == 1
+        mock_update.assert_called_once()
+        assert mock_update.call_args[1]["new_status"] == "pending"
+
+    def test_recent_session_with_live_owner_is_skipped(self):
+        """Owned by a live concurrent worker → skip (the guard's real purpose)."""
+        session = self._recent_bridge_session(worker_pid=99999)
+        with patch("agent.session_health._pid_is_alive", return_value=True):
+            count, mock_update = self._run_recovery([session])
+        assert count == 0
+        mock_update.assert_not_called()
+
+    def test_recent_legacy_session_without_stamp_uses_age_fallback(self):
+        """No worker_pid (legacy row) + recent → skipped, exactly as before."""
+        session = self._recent_bridge_session(worker_pid=None)
+        count, mock_update = self._run_recovery([session])
+        assert count == 0
+        mock_update.assert_not_called()
+
+    def test_stale_legacy_session_without_stamp_still_recovered(self):
+        import time
+
+        from agent.agent_session_queue import AGENT_SESSION_HEALTH_MIN_RUNNING
+
+        session = self._recent_bridge_session(
+            worker_pid=None,
+            started_at=time.time() - AGENT_SESSION_HEALTH_MIN_RUNNING - 600,
+        )
+        count, mock_update = self._run_recovery([session])
+        assert count == 1
+        mock_update.assert_called_once()
+
+    def test_garbage_worker_pid_falls_back_to_age_guard(self):
+        """Non-int worker_pid (corrupt row / Mock) → treated as absent."""
+        session = self._recent_bridge_session(worker_pid="not-a-pid")
+        count, mock_update = self._run_recovery([session])
+        assert count == 0  # recent + fallback age guard → skipped
+        mock_update.assert_not_called()
+
+    def test_recovery_terminates_detached_live_harness(self):
+        """A recovered session with a live claude_pid gets its detached
+        harness SIGTERM'd before re-queue."""
+        import signal as _signal
+
+        session = self._recent_bridge_session(worker_pid=424242, claude_pid=55555)
+        with (
+            patch("agent.session_health._pid_is_alive", side_effect=lambda p: p == 55555),
+            patch("agent.session_health.os.kill") as mock_kill,
+        ):
+            count, _ = self._run_recovery([session])
+        assert count == 1
+        mock_kill.assert_any_call(55555, _signal.SIGTERM)
+
+
+class TestPickupStampsWorkerPid:
+    """#2148: pending→running pickup stamps worker_pid = os.getpid()."""
+
+    def test_pickup_source_stamps_worker_pid(self):
+        """Both transition sites in session_pickup.py set worker_pid before
+        transition_status (whose full save persists companion fields)."""
+        from pathlib import Path
+
+        src = (Path(__file__).parent.parent.parent / "agent" / "session_pickup.py").read_text()
+        assert src.count("chosen.worker_pid = os.getpid()") == 2, (
+            "Both pending->running pickup sites must stamp worker_pid (#2148)"
         )


### PR DESCRIPTION
## Summary

The startup-recovery 'recent session' guard (300s wall-clock) stranded sessions started shortly before a worker crash: skipped by recovery but owned by no one, status stuck `running`, harness executing detached — and the new worker's queue loop popped a SECOND session for the same worker_key (two concurrent sessions on worker_key=valor observed live 2026-07-17 14:11).

## Fix

- **`AgentSession.worker_pid`** — stamped `os.getpid()` at both pending→running pickup sites; rides `transition_status`'s full save.
- **Recovery guard keys on ownership, not age**: a live owner (PID alive; `PermissionError` counts as alive; PIDs ≤1 rejected) → skip, exactly the guard's original purpose. A dead owner → interrupted **regardless of age**. Legacy rows without the stamp keep the age fallback until they cycle.
- **Detached-harness termination**: before re-queue/abandon, any still-alive `claude_pid`/`pm_pid` is SIGTERM'd (loud log) — a SIGKILL'd worker skips the #2141 shutdown cleanup, and a zombie harness must not run against a recovered session.
- **Serialization across restarts follows by boot ordering**: recovery runs before queue loops pop, so the previously-stranded session is back in `pending` when popping starts — one session per key. No pop-side blocking added (two racing mechanisms would be worse than one).
- Dead-worker sweep (#1767) untouched — its recency guard protects the pickup→spawn window where `claude_pid` is stale from a prior turn.

## Tests

84 passed (-n0) across recovery + zombie-resurrection suites; 7 new ownership cases including the exact incident shape (session started 30s before the crash, dead owner → recovered not stranded), garbage-PID fallback, live-owner skip, detached-harness SIGTERM, and a source-level assertion that both pickup sites stamp `worker_pid`.

## Docs

- `docs/features/session-lifecycle.md` — 'Ownership-Based Startup-Recovery Guard' section
- `docs/features/bridge-worker-architecture.md` — Step 3b updated

Plan: `docs/plans/recovery-guard-ownership-based.md` (on main)

Closes #2148