### PR TITLE
install_worker: injection-aware plist idempotency + drain before bootout (#2161)

### DIFF
--- a/docs/features/bridge-worker-architecture.md
+++ b/docs/features/bridge-worker-architecture.md
@@ -502,6 +502,16 @@ false-negative from kickstarting a live worker every cycle) is bootstrapped
 unconditionally: that is recovery, not a restart, and nothing is running to
 drain.
 
+Both restart paths are gated (#2161 closed the second): the shell path
+above, AND the Python pipeline's `service.install_worker()` — whose plist
+idempotency check is injection-aware (it compares the on-disk plist against
+the EXPECTED final plist: rendered template + the same only-add-missing-keys
+`.env` injection applied in-memory) and which runs the same drain probe
+before any `bootout`, deferring with a loud
+`install_worker: restart DEFERRED` log on busy-timeout. A healthy loaded
+worker with an unchanged template and unchanged `.env` is never cycled by
+either path.
+
 On the worker side, the SIGTERM shutdown sequence bounds its active-task
 wait at `WORKER_SHUTDOWN_GRACE_S` (default 3s — sized to launchd's real
 SIGTERM→SIGKILL grace) and then calls

--- a/docs/features/config-timeout-catalog.md
+++ b/docs/features/config-timeout-catalog.md
@@ -131,7 +131,7 @@ Raw-env knobs (consumed by `scripts/remote-update.sh` — a bash consumer, so
 
 | Knob | Default | Used by |
 |------|---------|---------|
-| `UPDATE_WORKER_DRAIN_TIMEOUT_S` | 300 | Total window the update flow waits for running sessions to drain before DEFERRING the worker restart to the next cycle. |
+| `UPDATE_WORKER_DRAIN_TIMEOUT_S` | 300 | Total window the update flow waits for running sessions to drain before DEFERRING the worker restart to the next cycle. Consumed by `remote-update.sh` AND `scripts/update/service.py::install_worker` (#2161). |
 | `UPDATE_WORKER_DRAIN_POLL_S` | 10 | Poll interval of the drain probe. |
 | `WORKER_SHUTDOWN_GRACE_S` | 3 | Worker SIGTERM shutdown: bounded active-task wait before abandoning in-flight turns and terminating `claude -p` harness children (`worker/shutdown_cleanup.py`). Sized to launchd's real kill grace. |
 

--- a/scripts/update/service.py
+++ b/scripts/update/service.py
@@ -347,6 +347,47 @@ def _inject_env_into_plist(plist_path: Path, env_file: Path) -> int:
     return injected
 
 
+def _plist_matches_expected(plist_dst: Path, rendered_text: str, env_file: Path) -> bool:
+    """True iff the on-disk plist equals the EXPECTED final plist (issue #2161).
+
+    The expected plist is the rendered template with
+    :func:`_inject_env_into_plist`'s exact semantics applied in-memory:
+    ``.env`` keys are added to ``EnvironmentVariables`` only when absent
+    (template placeholders win) and ``None`` values are skipped. Missing
+    ``.env`` / dotenv import failure leaves the template dict unchanged —
+    matching what the file-mutating injection would have done. Dict equality
+    via ``plistlib`` is key-order-independent by construction.
+
+    Returns False on ANY parse/read failure so the caller falls through to
+    the rebuild path (fail-open to a restart, never to a wedged update).
+    """
+    try:
+        if not plist_dst.exists():
+            return False
+        with open(plist_dst, "rb") as f:
+            existing = plistlib.load(f)
+        expected = plistlib.loads(rendered_text.encode())
+        env_section = expected.setdefault("EnvironmentVariables", {})
+        if env_file.exists():
+            try:
+                from dotenv import dotenv_values
+
+                for key, value in dotenv_values(env_file).items():
+                    if key in env_section or value is None:
+                        continue
+                    env_section[key] = value
+            except Exception as e:
+                logger.warning(
+                    "install_worker: expected-plist env application failed (%s) — "
+                    "comparing template-only",
+                    e,
+                )
+        return existing == expected
+    except Exception as e:
+        logger.warning("install_worker: idempotency compare failed (%s) — rebuilding", e)
+        return False
+
+
 def _launchctl_label_running(label: str) -> bool:
     """Return True if ``label`` appears in ``launchctl list`` with a live PID.
 
@@ -395,35 +436,51 @@ def install_worker(project_dir: Path) -> bool:
     plist_text = plist_text.replace("__HOME_DIR__", str(Path.home()))
     plist_text = plist_text.replace("__SERVICE_LABEL__", label)
 
-    # Idempotency check is done against the rendered template. The post-write
-    # env injection mutates the destination plist (added EnvironmentVariables
-    # keys) so a byte-for-byte compare against ``plist_text`` would fail on
-    # every subsequent run if we read existing_text after injection. We avoid
-    # that by comparing the rendered template against the on-disk template
-    # BEFORE injection — but the on-disk plist on disk has already been
-    # mutated. Solution: re-render the template then compare against a
-    # template-only round-trip of the existing plist (i.e. strip the injected
-    # keys before compare). For simplicity we keep the prior behavior — the
-    # idempotency check may produce a false-negative on a healthy worker
-    # where env injection is the only difference, triggering an extra
-    # bootout/bootstrap cycle. That is harmless (worker restarts cleanly).
-    try:
-        existing_text = plist_dst.read_text() if plist_dst.exists() else None
-    except OSError:
-        existing_text = None
-
+    # Injection-aware idempotency (issue #2161): the on-disk plist carries
+    # .env-injected EnvironmentVariables the rendered template lacks, so a
+    # raw text compare false-negatives on EVERY run — which used to trigger
+    # an unconditional bootout/bootstrap (an undrained worker restart every
+    # update cycle, the surviving half of #2141). Compare the on-disk plist
+    # against the EXPECTED final plist instead: the rendered template with
+    # the same only-add-missing-keys injection semantics applied in-memory.
+    # Any parse failure falls through to the rebuild path (fail-open to a
+    # restart, never to a wedged update).
     already_loaded = False
     try:
         already_loaded = label in run_cmd(["launchctl", "list"]).stdout
     except Exception:
         pass
 
-    if existing_text == plist_text and already_loaded:
+    if already_loaded and _plist_matches_expected(plist_dst, plist_text, project_dir / ".env"):
         return True
 
     try:
         uid = os.getuid()
         if already_loaded:
+            # Drain before the restart (parity with remote-update.sh's #2141
+            # gate): a PM turn legitimately runs 20+ minutes; killing it
+            # mid-turn discards in-flight work. On busy-timeout DEFER — the
+            # worker keeps serving on the old plist/code and the next update
+            # cycle retries. Drain errors fail open (restart proceeds).
+            try:
+                from scripts.update.drain import (
+                    DEFAULT_POLL_S,
+                    DEFAULT_TIMEOUT_S,
+                    wait_for_idle,
+                )
+
+                if not wait_for_idle(DEFAULT_TIMEOUT_S, DEFAULT_POLL_S, log=logger.info):
+                    logger.warning(
+                        "install_worker: restart DEFERRED (running sessions did not "
+                        "drain in %ss) — retrying next update cycle",
+                        DEFAULT_TIMEOUT_S,
+                    )
+                    return True
+            except Exception as _drain_err:
+                logger.warning(
+                    "install_worker: drain probe failed (%s) — proceeding with restart",
+                    _drain_err,
+                )
             run_cmd(["launchctl", "bootout", f"gui/{uid}/{label}"])
 
         plist_dst.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/test_update_install_worker.py
+++ b/tests/unit/test_update_install_worker.py
@@ -434,3 +434,140 @@ class TestWorktreeInstallGuard:
         # The guard let it through — the refusal message never appears. (The
         # script then fails later on the absent lib/launchctl.sh, which is fine.)
         assert self._GUARD_MSG not in result.stderr
+
+
+class TestInstallWorkerIdempotency:
+    """#2161: injection-aware idempotency + drain-before-bootout.
+
+    The old text compare (on-disk WITH injected env vs template WITHOUT)
+    false-negatived every run and bootout/bootstrapped a healthy worker each
+    update cycle, bypassing the #2141 drain entirely.
+    """
+
+    def _recording_run_cmd(self, calls: list, list_pid: str | None = "12345"):
+        inner = _fake_run_cmd(list_pid=list_pid)
+
+        def _run(cmd, *args, **kwargs):
+            calls.append(list(cmd))
+            return inner(cmd, *args, **kwargs)
+
+        return _run
+
+    def _project(self, tmp_path: Path, monkeypatch) -> Path:
+        project_dir = _make_worker_project(tmp_path, monkeypatch)
+        (project_dir / ".env").write_text("VALOR_PROJECT_KEY=valor\n")
+        return project_dir
+
+    def test_unchanged_second_run_skips_bootout(self, tmp_path: Path, monkeypatch) -> None:
+        """Same template + same .env + loaded worker → no restart commands."""
+        project_dir = self._project(tmp_path, monkeypatch)
+
+        first_calls: list = []
+        with patch(
+            "scripts.update.service.run_cmd",
+            side_effect=self._recording_run_cmd(first_calls),
+        ):
+            assert install_worker(project_dir) is True
+
+        second_calls: list = []
+        with patch(
+            "scripts.update.service.run_cmd",
+            side_effect=self._recording_run_cmd(second_calls),
+        ):
+            assert install_worker(project_dir) is True
+
+        joined = [" ".join(c) for c in second_calls]
+        assert not any("bootout" in c or "bootstrap" in c or "kickstart" in c for c in joined), (
+            f"#2161 regression: unchanged second run issued restart commands: {joined}"
+        )
+
+    def test_env_change_triggers_rebuild(self, tmp_path: Path, monkeypatch) -> None:
+        """A NEW .env key makes the expected plist differ → rebuild path runs."""
+        project_dir = self._project(tmp_path, monkeypatch)
+
+        with patch("scripts.update.service.run_cmd", side_effect=_fake_run_cmd(list_pid="12345")):
+            assert install_worker(project_dir) is True
+
+        (project_dir / ".env").write_text("VALOR_PROJECT_KEY=valor\nNEW_KEY=added\n")
+        calls: list = []
+        with (
+            patch(
+                "scripts.update.service.run_cmd",
+                side_effect=self._recording_run_cmd(calls),
+            ),
+            patch("scripts.update.drain.wait_for_idle", return_value=True),
+        ):
+            assert install_worker(project_dir) is True
+
+        joined = [" ".join(c) for c in calls]
+        assert any("bootout" in c for c in joined), "env change must trigger the rebuild path"
+
+    def test_busy_drain_defers_restart(self, tmp_path: Path, monkeypatch) -> None:
+        """Genuine change + sessions still running → DEFER: True, no bootout."""
+        project_dir = self._project(tmp_path, monkeypatch)
+
+        with patch("scripts.update.service.run_cmd", side_effect=_fake_run_cmd(list_pid="12345")):
+            assert install_worker(project_dir) is True
+
+        (project_dir / ".env").write_text("VALOR_PROJECT_KEY=valor\nNEW_KEY=added\n")
+        calls: list = []
+        with (
+            patch(
+                "scripts.update.service.run_cmd",
+                side_effect=self._recording_run_cmd(calls),
+            ),
+            patch("scripts.update.drain.wait_for_idle", return_value=False),
+        ):
+            assert install_worker(project_dir) is True  # deferred, not failed
+
+        joined = [" ".join(c) for c in calls]
+        assert not any("bootout" in c for c in joined), "busy drain must defer the bootout"
+
+    def test_drain_error_fails_open_to_restart(self, tmp_path: Path, monkeypatch) -> None:
+        project_dir = self._project(tmp_path, monkeypatch)
+
+        with patch("scripts.update.service.run_cmd", side_effect=_fake_run_cmd(list_pid="12345")):
+            assert install_worker(project_dir) is True
+
+        (project_dir / ".env").write_text("VALOR_PROJECT_KEY=valor\nNEW_KEY=added\n")
+        calls: list = []
+        with (
+            patch(
+                "scripts.update.service.run_cmd",
+                side_effect=self._recording_run_cmd(calls),
+            ),
+            patch(
+                "scripts.update.drain.wait_for_idle",
+                side_effect=RuntimeError("redis down"),
+            ),
+        ):
+            assert install_worker(project_dir) is True
+
+        joined = [" ".join(c) for c in calls]
+        assert any("bootout" in c for c in joined), "drain error must fail open to restart"
+
+    def test_first_install_unaffected(self, tmp_path: Path, monkeypatch) -> None:
+        """No existing plist + label absent → bootstrap proceeds, no bootout.
+
+        The fake launchctl is stateful: `list` reports the label absent until
+        a `bootstrap` call is seen, then reports a live PID so the #2089
+        post-bootstrap verify passes (mirrors real launchd behavior).
+        """
+        project_dir = self._project(tmp_path, monkeypatch)
+        calls: list = []
+        bootstrapped = {"done": False}
+        absent = _fake_run_cmd(list_pid=None)
+        loaded = _fake_run_cmd(list_pid="12345")
+
+        def _run(cmd, *args, **kwargs):
+            calls.append(list(cmd))
+            if "bootstrap" in cmd:
+                bootstrapped["done"] = True
+            inner = loaded if bootstrapped["done"] else absent
+            return inner(cmd, *args, **kwargs)
+
+        with patch("scripts.update.service.run_cmd", side_effect=_run):
+            assert install_worker(project_dir) is True
+        joined = [" ".join(c) for c in calls]
+        assert any("bootstrap" in c for c in joined)
+        assert not any("bootout" in c for c in joined)


### PR DESCRIPTION
## Summary

`scripts/update/run.py` calls `service.install_worker()` every cron cycle. Its idempotency check compared the on-disk plist (WITH `.env`-injected EnvironmentVariables) against the raw rendered template (WITHOUT) — never equal, so it bootout/bootstrapped the worker **every run**, bypassing the #2141 drain entirely. Three same-day undrained restarts (10:13, 11:31, 15:23 UTC) killed in-flight PM turns; 15:23 killed the #2147 pipeline's TEST turn and orphaned two pytest runs.

## Fix

- **`_plist_matches_expected()`**: computes the EXPECTED final plist — rendered template + `_inject_env_into_plist`'s exact only-add-missing-keys/skip-None semantics applied in-memory — and dict-compares against the on-disk plist. Equal + already-loaded → return True, no restart commands at all. Parse failures fail open to the rebuild path (never to a wedged update).
- **Drain parity with the shell path**: a genuine rebuild on a loaded worker runs `scripts.update.drain.wait_for_idle` (same #2141 knobs) before `bootout`; busy-timeout → loud `install_worker: restart DEFERRED` and return True (defer to next cycle). Drain errors fail open.
- First-install (no plist, label absent) unchanged: bootstrap without bootout, no drain.
- The `service.py:395-409` "harmless" comment — the incorrect assumption itself — is replaced with the real semantics.

## Tests

31 passed (-n0) across the install_worker + drain suites. New: unchanged-second-run issues ZERO bootout/bootstrap/kickstart commands (the core regression); env-change triggers rebuild; busy-drain defers (no bootout); drain-error fails open; first-install via a stateful fake launchctl (label appears after bootstrap so the #2089 verify passes). All #1171 env-injection and #2089/#2013 bootstrap-ladder tests unchanged and passing.

## Docs

- `docs/features/bridge-worker-architecture.md` — both restart paths now documented as gated
- `docs/features/config-timeout-catalog.md` — drain-knob consumers updated

Plan: `docs/plans/install-worker-idempotency-drain.md` (on main)

Closes #2161