### PR TITLE
Worker hang forensics + watchdog latency + resume-notify pickup (#2143, #2165)

### DIFF
--- a/monitoring/worker_watchdog.py
+++ b/monitoring/worker_watchdog.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python3
 """Worker watchdog — external health monitor for the standalone worker.
 
-Runs as a separate launchd service (StartInterval: 120s) so it can detect
-and recover from a hung worker (process alive but event loop frozen) AND
-from a missing worker (process gone, launchd KeepAlive failed to restart).
+Runs as a separate launchd service (StartInterval: 90s — kept at or below half
+the 180s HEARTBEAT_THRESHOLD so worst-case hang detection is bounded to roughly
+2× the threshold rather than the old ~300-480s) so it can detect and recover
+from a hung worker (process alive but event loop frozen) AND from a missing
+worker (process gone, launchd KeepAlive failed to restart).
+
+Every check tick logs a line to logs/worker_watchdog.log (healthy ticks
+included, at INFO), so a silent window in that log unambiguously means the
+watchdog itself is not running — not "the watchdog ran and saw a healthy
+worker."
 
 Two recovery paths:
 
@@ -109,7 +116,7 @@ DOWN_TICKS_KEY_TTL = 3600
 # critical key. Break-glass recovery: `launchctl enable` + `worker-start`, then
 # delete `worker:watchdog:critical:breaker:{host}`.
 #
-# Provisional/tunable: 5 starts in 120s is a grain-of-salt default chosen high
+# Provisional/tunable: 5 starts in 120 seconds is a grain-of-salt default chosen high
 # enough that only a genuine tight crash-loop trips it (a scripted restart is one
 # start and is additionally guarded by the restart-suppression marker). Override
 # via WORKER_RESPAWN_CIRCUIT_THRESHOLD / WORKER_RESPAWN_CIRCUIT_WINDOW_S. Named
@@ -842,7 +849,10 @@ def main() -> None:
         sys.exit(0 if status["status"] in ("ok", "starting") else 1)
 
     if status["status"] == "ok":
-        logger.debug("Worker healthy (heartbeat %ss ago)", f"{status['heartbeat_age']:.0f}")
+        # Log every healthy tick at INFO (not debug) so each watchdog invocation
+        # writes an observable line to logs/worker_watchdog.log — a silent window
+        # then unambiguously means "watchdog not running" rather than "saw healthy".
+        logger.info("Worker healthy (heartbeat %ss ago)", f"{status['heartbeat_age']:.0f}")
         # Reset down-tick counter on any healthy tick.
         _clear_down_ticks()
         return

--- a/scripts/install_worker.sh
+++ b/scripts/install_worker.sh
@@ -211,7 +211,9 @@ echo "Loading $LABEL..."
 # "abort a batch" concern).
 launchctl_bootstrap_fail_soft "gui/$(id -u)" "$PLIST_DST" "$LABEL" verify-pid || exit 1
 
-# Install worker watchdog (checks heartbeat every 300s, kills hung worker so launchd restarts it)
+# Install worker watchdog (checks heartbeat every 90s, kills hung worker so launchd restarts it).
+# StartInterval is kept at or below half the 180s HEARTBEAT_THRESHOLD in
+# monitoring/worker_watchdog.py so worst-case hang detection stays bounded to ~2x threshold.
 WATCHDOG_LABEL="${SERVICE_LABEL_PREFIX}.worker-watchdog"
 WATCHDOG_PLIST="$HOME/Library/LaunchAgents/${WATCHDOG_LABEL}.plist"
 
@@ -237,7 +239,7 @@ cat > "$WATCHDOG_PLIST" << WATCHDOGEOF
         <string>${HOME}</string>
     </dict>
     <key>StartInterval</key>
-    <integer>300</integer>
+    <integer>90</integer>
     <key>StandardOutPath</key>
     <string>${PROJECT_DIR}/logs/worker_watchdog.log</string>
     <key>StandardErrorPath</key>
@@ -248,7 +250,7 @@ WATCHDOGEOF
 
 launchctl bootout "gui/$(id -u)/$WATCHDOG_LABEL" 2>/dev/null || true
 launchctl_bootstrap_fail_soft "gui/$(id -u)" "$WATCHDOG_PLIST" "$WATCHDOG_LABEL" || exit 1
-echo "Worker watchdog installed (checks heartbeat every 300s)"
+echo "Worker watchdog installed (checks heartbeat every 90s)"
 
 echo ""
 echo "Worker service installed successfully."

--- a/scripts/lib/launchctl.sh
+++ b/scripts/lib/launchctl.sh
@@ -39,7 +39,7 @@
 # e.g. worker, reflection-worker, email-bridge, bridge, and worker-start which reuses
 # the worker label) pass `verify-pid`. SCHEDULED services (StartCalendarInterval /
 # StartInterval, e.g. nightly-tests, sdlc-reflection, update-cron, and BOTH watchdogs —
-# worker-watchdog at StartInterval 300 and bridge-watchdog at StartInterval 60) have no
+# worker-watchdog at StartInterval 90 and bridge-watchdog at StartInterval 60) have no
 # persistent PID between runs and must NOT pass it — a blanket PID check would falsely
 # fail every scheduled service (aborting a real install at a `|| exit 1` site).
 #

--- a/tests/unit/test_resume_notify.py
+++ b/tests/unit/test_resume_notify.py
@@ -1,0 +1,243 @@
+"""Regression tests for resume-to-pending notify publish (#2165, plan sdlc-2143).
+
+A terminal->pending resume used to sit unpicked for 8-16 minutes: `resume_session`
+transitioned to pending but — unlike the create path (`_push_agent_session`) —
+never published the session-notify, so the worker's `_session_notify_listener`
+never woke a popper. Pickup then depended on the queue loop's 1.5s drain re-poll
+or the 5-min health scan (whose liveness test treats a parked/busy loop as alive).
+
+These tests pin the fix's contract:
+- `resume_session` publishes the SAME payload/channel as the create path.
+- The publish is a PLAIN SYNCHRONOUS `POPOTO_REDIS_DB.publish` (NOT
+  `asyncio.to_thread`) — `resume_session` is a sync `def` whose CLI/reflection
+  callers have no running event loop.
+- It is NOTIFY-ONLY: it never calls `_ensure_worker` / `asyncio.create_task`
+  (the worker's notify listener is the sole owner of the spawn, so all three
+  callers — CLI, out-of-process auto-resume reflection, in-worker — stay
+  single-worker-ownership-safe; B2/C1 blocker).
+- The publish is fail-quiet: a Redis publish error must not fail the resume,
+  because the transition already succeeded.
+"""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Bootstrap: ensure repo root is on sys.path
+_repo_root = Path(__file__).parent.parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from tools.valor_session import resume_session  # noqa: E402
+
+_RESUMABLE_STATUSES = frozenset({"completed", "killed", "failed", "abandoned"})
+_TEST_CHANNEL = "valor:sessions:new:db-test"
+
+
+def _make_session(
+    *,
+    session_id="notify-sess",
+    status="completed",
+    claude_session_uuid="uuid-notify",
+    worker_key="notify-sess",
+    project_key="proj-key",
+    chat_id="chat-123",
+):
+    """Build a session whose notify-relevant attrs are REAL strings.
+
+    `worker_key` on the real model is a computed property; here we set it as a
+    plain string attribute so the JSON payload is serializable (a raw MagicMock
+    child would make json.dumps raise and be swallowed by the fail-quiet guard).
+    """
+    s = MagicMock()
+    s.session_id = session_id
+    s.status = status
+    s.claude_session_uuid = claude_session_uuid
+    s.worker_key = worker_key
+    s.project_key = project_key
+    s.chat_id = chat_id
+    s.model = None
+    # Goal fields left as MagicMock children — the isinstance(str) guard skips them.
+    return s
+
+
+def _run_resume(session, *, redis_mock, source="cli", message="continue", publish_side_effect=None):
+    """Drive resume_session with the notify surface patched. Returns ResumeResult."""
+    if publish_side_effect is not None:
+        redis_mock.publish.side_effect = publish_side_effect
+
+    with (
+        patch("tools.valor_session._load_env"),
+        patch("agent.steering.push_steering_message"),
+        patch("popoto.redis_db.POPOTO_REDIS_DB", redis_mock),
+        patch("agent.agent_session_queue.notify_channel_for", return_value=_TEST_CHANNEL),
+        patch.dict(
+            "sys.modules",
+            {
+                "models.session_lifecycle": MagicMock(
+                    transition_status=MagicMock(),
+                    RESUMABLE_STATUSES=_RESUMABLE_STATUSES,
+                ),
+            },
+        ),
+    ):
+        return resume_session(session, message, source=source)
+
+
+class TestResumePublishesNotify:
+    def test_publishes_notify_with_correct_payload_and_channel(self):
+        """A terminal->pending resume publishes the create-path notify (#2165 AC)."""
+        session = _make_session(worker_key="my-slug", project_key="proj-key", chat_id="chat-9")
+        redis_mock = MagicMock()
+
+        result = _run_resume(session, redis_mock=redis_mock)
+
+        assert result.success is True
+        redis_mock.publish.assert_called_once()
+        channel, payload_json = redis_mock.publish.call_args[0]
+        assert channel == _TEST_CHANNEL
+        payload = json.loads(payload_json)
+        assert payload == {
+            "chat_id": "chat-9",
+            "session_id": "notify-sess",
+            "worker_key": "my-slug",
+            "is_project_keyed": False,
+        }
+
+    def test_is_project_keyed_true_when_worker_key_equals_project_key(self):
+        """is_project_keyed mirrors the create path: worker_key == project_key."""
+        session = _make_session(worker_key="proj-key", project_key="proj-key")
+        redis_mock = MagicMock()
+
+        result = _run_resume(session, redis_mock=redis_mock)
+
+        assert result.success is True
+        payload = json.loads(redis_mock.publish.call_args[0][1])
+        assert payload["worker_key"] == "proj-key"
+        assert payload["is_project_keyed"] is True
+
+    def test_publish_is_synchronous_not_to_thread(self):
+        """The publish must be a plain sync call — resume callers have no event loop."""
+        session = _make_session()
+        redis_mock = MagicMock()
+
+        with patch.object(asyncio, "to_thread") as mock_to_thread:
+            result = _run_resume(session, redis_mock=redis_mock)
+
+        assert result.success is True
+        redis_mock.publish.assert_called_once()
+        mock_to_thread.assert_not_called()
+
+    def test_publish_happens_after_successful_transition(self):
+        """Notify is published only AFTER transition_status returns (Race 1)."""
+        call_order: list[str] = []
+        session = _make_session()
+        redis_mock = MagicMock()
+        redis_mock.publish.side_effect = lambda *a, **k: call_order.append("publish")
+
+        def _record_transition(*_a, **_kw):
+            call_order.append("transition")
+
+        with (
+            patch("tools.valor_session._load_env"),
+            patch("agent.steering.push_steering_message"),
+            patch("popoto.redis_db.POPOTO_REDIS_DB", redis_mock),
+            patch("agent.agent_session_queue.notify_channel_for", return_value=_TEST_CHANNEL),
+            patch.dict(
+                "sys.modules",
+                {
+                    "models.session_lifecycle": MagicMock(
+                        transition_status=MagicMock(side_effect=_record_transition),
+                        RESUMABLE_STATUSES=_RESUMABLE_STATUSES,
+                    ),
+                },
+            ),
+        ):
+            result = resume_session(session, "continue", source="cli")
+
+        assert result.success is True
+        assert call_order == ["transition", "publish"], (
+            "notify must publish only after the pending transition is index-visible"
+        )
+
+
+class TestResumeIsNotifyOnly:
+    """The resume path must NEVER spawn a worker loop locally (B2/C1)."""
+
+    def test_never_calls_ensure_worker_cli(self):
+        session = _make_session()
+        redis_mock = MagicMock()
+        ensure_worker = MagicMock()
+
+        with patch("agent.agent_session_queue._ensure_worker", ensure_worker):
+            result = _run_resume(session, redis_mock=redis_mock, source="cli")
+
+        assert result.success is True
+        ensure_worker.assert_not_called()
+
+    def test_never_calls_ensure_worker_reflection(self):
+        """The auto-resume reflection caller must also stay notify-only."""
+        session = _make_session()
+        redis_mock = MagicMock()
+        ensure_worker = MagicMock()
+
+        with patch("agent.agent_session_queue._ensure_worker", ensure_worker):
+            result = _run_resume(session, redis_mock=redis_mock, source="auto-resume")
+
+        assert result.success is True
+        ensure_worker.assert_not_called()
+
+    def test_never_calls_asyncio_create_task(self):
+        session = _make_session()
+        redis_mock = MagicMock()
+
+        with patch.object(asyncio, "create_task") as mock_create_task:
+            result = _run_resume(session, redis_mock=redis_mock)
+
+        assert result.success is True
+        mock_create_task.assert_not_called()
+
+
+class TestResumeNotifyFailQuiet:
+    def test_publish_failure_does_not_fail_resume(self):
+        """A Redis publish error must not fail the resume (transition already succeeded)."""
+        session = _make_session()
+        redis_mock = MagicMock()
+
+        result = _run_resume(
+            session,
+            redis_mock=redis_mock,
+            publish_side_effect=RuntimeError("redis down"),
+        )
+
+        assert result.success is True
+        assert result.error is None
+
+    def test_publish_failure_logs_warning(self, caplog):
+        session = _make_session()
+        redis_mock = MagicMock()
+
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="tools.valor_session"):
+            result = _run_resume(
+                session,
+                redis_mock=redis_mock,
+                publish_side_effect=RuntimeError("redis down"),
+            )
+
+        assert result.success is True
+        assert any("resume notification" in r.message.lower() for r in caplog.records)
+
+    def test_none_worker_key_does_not_crash(self):
+        """A session with a None worker_key/chat_id resumes without crashing (fail-quiet)."""
+        session = _make_session(worker_key=None, project_key=None, chat_id=None)
+        redis_mock = MagicMock()
+
+        result = _run_resume(session, redis_mock=redis_mock)
+
+        # Publish still succeeds with a null-worker_key payload (json handles None);
+        # is_project_keyed is None == None -> True. The point is: no crash.
+        assert result.success is True

--- a/tests/unit/test_worker_entry.py
+++ b/tests/unit/test_worker_entry.py
@@ -611,6 +611,123 @@ class TestIndexDriftStartupGuard:
         )
 
 
+class TestFaulthandlerSigtermRegistration:
+    """Cement the load-bearing SIGTERM faulthandler registration (#2143 B1).
+
+    When the external worker-watchdog SIGTERMs a wedged worker, the worker must
+    leave an all-threads stack dump in stderr -> logs/worker_error.log so the
+    next native freeze is diagnosable. For that dump to fire, faulthandler must
+    register its C-level SIGTERM handler *after* `_run_worker` installs the
+    graceful Python `_signal_handler` via `signal.signal(SIGTERM, ...)` — a
+    later `signal.signal` would otherwise clobber the C handler and the dump
+    would never fire (the B1 blocker). These tests parse the AST of `_run_worker`
+    so they assert the real source order rather than a fragile string match.
+    """
+
+    @staticmethod
+    def _run_worker_ast():
+        import ast
+
+        source = (Path(__file__).parent.parent.parent / "worker" / "__main__.py").read_text()
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == "_run_worker":
+                return node
+        raise AssertionError("async def _run_worker not found in worker/__main__.py")
+
+    @staticmethod
+    def _call_name(call):
+        """Return the dotted name of a Call's func, e.g. 'signal.signal'."""
+        import ast
+
+        func = call.func
+        parts = []
+        while isinstance(func, ast.Attribute):
+            parts.append(func.attr)
+            func = func.value
+        if isinstance(func, ast.Name):
+            parts.append(func.id)
+        return ".".join(reversed(parts))
+
+    def _find_calls(self, dotted: str):
+        import ast
+
+        run_worker = self._run_worker_ast()
+        return [
+            node
+            for node in ast.walk(run_worker)
+            if isinstance(node, ast.Call) and self._call_name(node) == dotted
+        ]
+
+    def test_faulthandler_register_after_signal_handler_install(self):
+        """faulthandler.register(SIGTERM) must come AFTER both signal.signal() calls."""
+        signal_calls = self._find_calls("signal.signal")
+        register_calls = self._find_calls("faulthandler.register")
+
+        # The two graceful-handler installs (SIGTERM + SIGINT).
+        assert len(signal_calls) >= 2, (
+            "_run_worker must install the graceful signal handler via signal.signal(SIGTERM/SIGINT)"
+        )
+        assert len(register_calls) == 1, (
+            "_run_worker must register faulthandler for SIGTERM exactly once"
+        )
+
+        last_signal_line = max(c.lineno for c in signal_calls)
+        register_line = register_calls[0].lineno
+        assert register_line > last_signal_line, (
+            f"faulthandler.register (line {register_line}) MUST come after the last "
+            f"signal.signal install (line {last_signal_line}) — otherwise the later "
+            "signal.signal clobbers faulthandler's C-level SIGTERM handler (B1)."
+        )
+
+    def test_faulthandler_register_has_correct_args(self):
+        """The register call must target SIGTERM with all_threads=True, chain=True."""
+        import ast
+
+        register = self._find_calls("faulthandler.register")[0]
+
+        # Positional arg 0 must be signal.SIGTERM.
+        assert register.args, "faulthandler.register must be called with signal.SIGTERM"
+        first = register.args[0]
+        assert isinstance(first, ast.Attribute) and first.attr == "SIGTERM", (
+            "faulthandler.register's first arg must be signal.SIGTERM"
+        )
+
+        kwargs = {kw.arg: kw.value for kw in register.keywords}
+        assert "all_threads" in kwargs and getattr(kwargs["all_threads"], "value", None) is True, (
+            "faulthandler.register must pass all_threads=True (dump every thread's stack)"
+        )
+        assert "chain" in kwargs and getattr(kwargs["chain"], "value", None) is True, (
+            "faulthandler.register must pass chain=True so the graceful _signal_handler still runs"
+        )
+
+    def test_faulthandler_register_is_best_effort(self):
+        """The register/enable must be wrapped in try/except so startup survives a failure."""
+        import ast
+
+        run_worker = self._run_worker_ast()
+        register_line = self._find_calls("faulthandler.register")[0].lineno
+
+        # Find a Try node whose body contains the faulthandler.register call and
+        # whose handlers are non-empty (best-effort — a raise must not crash startup).
+        wrapped = False
+        for node in ast.walk(run_worker):
+            if not isinstance(node, ast.Try):
+                continue
+            body_lines = {
+                c.lineno
+                for c in ast.walk(node)
+                if isinstance(c, ast.Call) and self._call_name(c) == "faulthandler.register"
+            }
+            if register_line in body_lines and node.handlers:
+                wrapped = True
+                break
+        assert wrapped, (
+            "faulthandler.enable()/register() must be wrapped in try/except so a "
+            "non-real-fd stderr (test/launchd redirection) cannot crash worker startup"
+        )
+
+
 class TestSigtermExitCode:
     """Test that SIGTERM sets _shutdown_via_signal and SIGINT does not.
 

--- a/tests/unit/test_worker_watchdog.py
+++ b/tests/unit/test_worker_watchdog.py
@@ -261,6 +261,38 @@ class TestHealthyTickResetsCounter:
         key_used = mock_r.delete.call_args[0][0]
         assert "worker:watchdog:down_ticks:" in key_used
 
+    def test_healthy_tick_logs_info_line(self, isolated_state, caplog):
+        """Every healthy tick emits an observable INFO line (not debug/silent).
+
+        Regression guard for #2143: a silent healthy tick makes "watchdog not
+        running" indistinguishable from "watchdog ran and saw a healthy worker".
+        The healthy log must be INFO and carry the heartbeat age.
+        """
+        ok_status = {"status": "ok", "pid": 1, "heartbeat_age": 5.0, "message": "ok"}
+        mock_r = MagicMock()
+
+        # Watchdog logger is non-propagating; attach caplog handler directly.
+        wwd.logger.addHandler(caplog.handler)
+        try:
+            with patch("popoto.redis_db.POPOTO_REDIS_DB", mock_r):
+                with (
+                    patch.object(wwd, "check", return_value=ok_status),
+                    patch.object(wwd, "_is_operator_disabled", return_value=False),
+                ):
+                    with caplog.at_level(logging.INFO, logger=wwd.logger.name):
+                        with patch("sys.argv", ["worker_watchdog.py"]):
+                            wwd.main()
+        finally:
+            wwd.logger.removeHandler(caplog.handler)
+
+        healthy_records = [
+            r for r in caplog.records if "Worker healthy" in r.message and "heartbeat" in r.message
+        ]
+        assert healthy_records, "healthy tick must emit an observable log line"
+        assert all(r.levelno == logging.INFO for r in healthy_records), (
+            "healthy tick must log at INFO, not debug (a debug line is silent in the log file)"
+        )
+
 
 # --- Operator disable via launchctl print-disabled ---------------------------
 

--- a/tools/valor_session.py
+++ b/tools/valor_session.py
@@ -759,6 +759,59 @@ def _resolve_resume_goal(session) -> str | None:
     return None
 
 
+def _publish_resume_notify(session) -> None:
+    """Publish the create-path session-notify for a resumed-to-pending session (#2165).
+
+    A terminal->pending resume otherwise sat unpicked for 8-16 minutes: the
+    per-key queue loop only re-polls on its 1.5s drain timeout or the 5-min
+    health scan (whose liveness test treats a parked/busy loop as alive), so no
+    fresh popper started. `create` never has this problem — `_push_agent_session`
+    publishes a session-notify and the worker's `_session_notify_listener` spawns
+    the worker loop on receipt. This helper publishes the SAME payload/channel
+    so a resume wakes a popper within one notify hop, restart-free.
+
+    Notify-only by design (B2/C1): it does NOT spawn a worker loop locally (no
+    local worker-ensure / task creation).
+    The worker's notify listener is the SOLE owner of the spawn, exactly like the
+    create path. That keeps all three `resume_session` callers ownership-safe —
+    the CLI (no event loop), the auto-resume reflection subprocess (its own
+    out-of-process `asyncio.run` loop with an empty process-local `_active_workers`),
+    and any future in-worker caller. A variant that spawned a `_worker_loop`
+    locally (gated only on `asyncio.get_running_loop()`) would run a rogue worker
+    inside the reflection subprocess — a single-worker-ownership violation. The
+    cross-process Redis notify is the one universal, ownership-safe wake mechanism.
+
+    Uses a PLAIN synchronous `POPOTO_REDIS_DB.publish` (NOT `asyncio.to_thread`)
+    because `resume_session` is a sync `def` whose CLI/reflection callers have no
+    running event loop. Fail-quiet: the transition already succeeded, so a publish
+    failure must never fail the resume (the 5-min health scan remains the net).
+    """
+    try:
+        from popoto.redis_db import POPOTO_REDIS_DB
+
+        from agent.agent_session_queue import notify_channel_for
+
+        worker_key = session.worker_key
+        project_key = getattr(session, "project_key", None)
+        payload = json.dumps(
+            {
+                "chat_id": getattr(session, "chat_id", None),
+                "session_id": getattr(session, "session_id", None),
+                "worker_key": worker_key,
+                "is_project_keyed": worker_key == project_key,
+            }
+        )
+        channel = notify_channel_for(POPOTO_REDIS_DB)
+        POPOTO_REDIS_DB.publish(channel, payload)
+        logger.debug("Published resume notification for worker_key=%s", worker_key)
+    except Exception as e:
+        logger.warning(
+            "Failed to publish resume notification for %s: %s",
+            getattr(session, "session_id", "?"),
+            e,
+        )
+
+
 def resume_session(session, message: str, *, source: str = "cli") -> "ResumeResult":
     """Programmatic core for resuming a terminal session.
 
@@ -843,6 +896,13 @@ def resume_session(session, message: str, *, source: str = "cli") -> "ResumeResu
             session_id=session_id,
             error=f"Could not transition to pending: {e}",
         )
+
+    # Publish the create-path session-notify so the worker's notify listener
+    # picks up the resumed session within ~1s (one notify hop), restart-free
+    # (#2165). Notify-only + fail-quiet — see _publish_resume_notify. Published
+    # strictly AFTER the transition returns so the pending record is already
+    # index-visible when the woken loop polls (Race 1).
+    _publish_resume_notify(session)
 
     return ResumeResult(
         success=True,

--- a/worker/__main__.py
+++ b/worker/__main__.py
@@ -981,6 +981,30 @@ async def _run_worker(projects: dict, dry_run: bool = False) -> None:
     signal.signal(signal.SIGTERM, _signal_handler)
     signal.signal(signal.SIGINT, _signal_handler)
 
+    # SIGTERM forensics (#2143 B1 — ordering is load-bearing): register the
+    # faulthandler for SIGTERM *after* the two `signal.signal(..., _signal_handler)`
+    # calls above so its C-level sigaction is the active SIGTERM disposition. This
+    # matters because:
+    #   (a) the C-level handler fires even when a native/syscall block is holding
+    #       the GIL — a case the pure-Python `_signal_handler` above can never
+    #       service (it only runs at the next bytecode boundary). When the external
+    #       worker-watchdog SIGTERMs a wedged worker, this leaves an all-threads
+    #       stack dump in stderr → logs/worker_error.log so the next #2143 freeze
+    #       is diagnosable instead of silent.
+    #   (b) chain=True stores the previously-registered Python SIGTERM handler
+    #       (`_signal_handler`) as the chained handler, so a healthy worker still
+    #       runs the graceful asyncio shutdown after the dump.
+    # Registering this in main() before asyncio.run would be a defect: the
+    # `signal.signal(SIGTERM, _signal_handler)` above would then clobber the
+    # faulthandler C handler and the dump would never fire. Best-effort — a
+    # non-real-fd stderr (e.g. under some test/launchd redirections) must not
+    # crash worker startup.
+    try:
+        faulthandler.enable()
+        faulthandler.register(signal.SIGTERM, all_threads=True, chain=True)
+    except (ValueError, OSError, RuntimeError) as exc:
+        logger.warning("Could not register faulthandler for SIGTERM (%s) — continuing", exc)
+
     # Wait for shutdown signal
     await shutdown_event.wait()
 


### PR DESCRIPTION
## Summary

Investigation-first outcome for #2143 (full findings on the issue): the 2026-07-17/18/19 worker freezes require BOTH the event-loop thread and the off-loop heartbeat thread frozen simultaneously (deadman never fired + stale heartbeat + live PID) — a GIL-holding native block whose exact site needs a stack dump that the system could not produce. This PR makes the next freeze self-diagnosing, halves detection latency, and fixes the reproducible #2165 pickup stall.

## Changes

1. **SIGTERM forensics** (`worker/__main__.py`): `faulthandler.register(SIGTERM, all_threads=True, chain=True)` registered AFTER the Python signal handlers so the C-level handler is the active disposition — it dumps all thread stacks even under a GIL-holding block (the case the Python handler can never service), then chains to the graceful shutdown. The watchdog's own SIGTERM now leaves a full dump in worker_error.log.
2. **Watchdog latency + observability** (`monitoring/worker_watchdog.py`, install scripts): StartInterval 300s → 90s (≤ half the 180s heartbeat threshold; worst-case detection ~2× threshold instead of ~5-8 min pre-sleep-coalescing), and EVERY tick logs at INFO — a silent watchdog log now unambiguously means the watchdog isn't running (yesterday's 17:05–20:34 blind window was undiagnosable).
3. **Resume-notify pickup** (`tools/valor_session.py`) — **Closes #2165**: `resume_session` publishes the same session-notify payload/channel as the create path (via `notify_channel_for`, honoring #2147's db-scoping), so a terminal→pending resume wakes a popper within one notify hop instead of stalling 8-16 min behind a parked loop. Notify-only by design: the worker's listener remains the sole spawn owner (a local spawn would run a rogue worker inside the auto-resume reflection subprocess). Fail-quiet — the 5-min health scan stays as the net.

## Tests

118 passed (-n0): resume-notify payload/channel/fail-quiet matrix (10 new), worker-entry faulthandler registration + ordering guard, watchdog tick-logging and cadence assertions, plus existing suites unchanged.

## Evidence trail

Three freezes (2026-07-17 20:34, 2026-07-19 13:25 local-log timestamps) and three pickup stalls documented across #2143/#2165 comments; the 2026-07-19 13:25 freeze produced no dump precisely because this PR wasn't deployed yet.

Plan: `docs/plans/sdlc-2143.md` (on main, revised d58ee1c2)

Built by worker session 0_1784413982594 (commits 72e5958b, 0ee37411, 9279efd0); close-out completed by the supervising operator after progress-deadline attrition through machine-sleep windows.

Closes #2143
Closes #2165