### PR TITLE
Add PID liveness check to update lock guard (#2169)

### DIFF
--- a/docs/features/remote-update.md
+++ b/docs/features/remote-update.md
@@ -108,8 +108,16 @@ LOCK_DIR="$PROJECT_DIR/data/update.lock"
 cd "$PROJECT_DIR"
 
 # ── Lockfile (mkdir is atomic on POSIX) ──────────────────────────────
-cleanup_lock() { rmdir "$LOCK_DIR" 2>/dev/null || true; }
-if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+# The lock dir records its holder PID in a `pid` file so a collision can tell a
+# running update from a crashed one (issue #2169). Decision order on collision:
+#   1. Age backstop first — lock older than 600s TTL → reclaim regardless of PID.
+#   2. Young lock + recorded PID alive (kill -0) → genuine concurrent run → skip.
+#   3. Young lock + recorded PID dead → crashed run → reclaim immediately.
+#   4. Young lock + PID unknown (legacy/mid-claim) → skip; age backstop clears it.
+cleanup_lock() { rm -rf "$LOCK_DIR" 2>/dev/null || true; }   # rm -rf: dir holds pid
+claim_lock() { mkdir "$LOCK_DIR" 2>/dev/null && echo "$$" > "$LOCK_DIR/pid"; }
+if ! claim_lock; then
+    # ... age backstop, then kill -0 liveness on the recorded pid (see script) ...
     echo "Another update is already running. Skipping."
     exit 0
 fi
@@ -140,6 +148,7 @@ fi
 |----------|-----------|
 | `set -euo pipefail` | Strict mode — fail on any error, undefined var, or broken pipe |
 | `mkdir`-based lockfile | Atomic on POSIX, no `flock` dependency. `trap EXIT` ensures cleanup even on failure |
+| Lock stores holder PID + liveness check (#2169) | On collision the guard checks the recorded PID with `kill -0`. A crashed run (SIGKILL/OOM/power loss, EXIT trap never fired) leaves a *dead*-PID lock that is reclaimed immediately instead of green-skipping every run for up to 600s. Age backstop (600s TTL) stays the ultimate authority — it wins first, covering PID reuse and wedged-but-alive holders. Release is `rm -rf` since the dir now holds a `pid` file |
 | Pull in bash before Python | `run.py` and all update scripts are loaded from disk after the pull, so fixes to the update system take effect immediately (not on the next run). `run.py` receives `--no-pull` to skip the redundant internal pull |
 | `--ff-only` | Prevents surprise merges. If branches diverged, fail loudly and let the operator handle it |
 | Delegate to `run.py --cron` | Dep sync, restart flag, and Telegram summary logic live in the Python orchestrator (`scripts/update/run.py`). The shell script stays thin — pull + invoke |

--- a/docs/plans/update-lock-pid-liveness.md
+++ b/docs/plans/update-lock-pid-liveness.md
@@ -1,0 +1,123 @@
+# Plan: Update Lock Guard PID Liveness Check
+
+**Issue:** https://github.com/tomcounsell/ai/issues/2169
+**Slug:** update-lock-pid-liveness
+
+## Problem
+
+The `/update` concurrency guard in `scripts/remote-update.sh` uses a `mkdir`-based
+lock directory at `data/update.lock`. On a collision it has **only an age-based
+staleness backstop** (`LOCK_AGE > 600` → reclaim) and **no PID liveness check**.
+The lock dir records no owner PID, so the guard cannot tell a *running* update
+from a *dead* one.
+
+If a prior update run dies without releasing the lock — SIGKILL, OOM, power loss,
+or the bridge-kickstart self-kill on a path that skips the explicit pre-kickstart
+release — the `trap cleanup_lock EXIT` handler never fires and the orphaned lock
+blocks **every** subsequent run (manual `/update` and the 30-min cron) for up to
+600 seconds with a green `exit 0` "Skipping" no-op.
+
+## Root Cause
+
+The lock dir carries no owner identity. Collision handling can only reason about
+the lock's mtime, so a crashed run and a legitimately-running one are
+indistinguishable until the 600s TTL elapses.
+
+## Fix
+
+Record the holder PID in the lock dir and check liveness on collision, in this
+precedence order:
+
+- **Age backstop first** (ultimate authority; no legitimate hold approaches the
+  TTL): lock older than TTL → reclaim regardless of PID. This covers PID reuse
+  and wedged-but-alive holders.
+- Young lock + recorded PID **alive** (`kill -0` succeeds) → genuine concurrent
+  run → skip (correct).
+- Young lock + recorded PID **dead** → crashed run → reclaim immediately (the fix).
+- Young lock + PID **unknown** (legacy lock or a run mid-claim that hasn't written
+  its pid yet) → skip conservatively; the age backstop clears it later.
+
+Implementation notes:
+- After the `mkdir "$LOCK_DIR"` that claims the lock, write `$$` to
+  `$LOCK_DIR/pid`.
+- The reclaim-then-reclaim path (age backstop and dead-PID) must re-`mkdir` and
+  re-write the pid file so the reclaiming run becomes the recorded owner.
+- Switch the lock-release calls from `rmdir` to `rm -rf` since the dir now
+  contains a `pid` file (`rmdir` only removes empty dirs). Affects
+  `cleanup_lock()` (the EXIT trap) and the pre-kickstart release.
+
+## Success Criteria
+
+- A young `data/update.lock` whose recorded PID is dead is reclaimed immediately;
+  the update run proceeds instead of green-skipping.
+- A young lock whose recorded PID is alive still causes a skip (genuine concurrent
+  run is not stomped).
+- A lock older than the 600s TTL is reclaimed regardless of PID liveness.
+- A young lock with no/unknown pid file is skipped conservatively.
+- Lock release works on the now-non-empty lock dir (`rm -rf`, not `rmdir`), so the
+  release-before-kickstart path and the EXIT trap both clear the lock.
+- All existing `tests/unit/test_remote_update_shell.py` cases still pass, plus new
+  PID-liveness cases.
+
+## No-Gos
+
+- Do not replace the `mkdir` atomic-claim mechanism with `flock` or a lockfile —
+  `mkdir` atomicity across POSIX is the intentional design and other machines
+  rely on it.
+- Do not lower or remove the 600s age backstop; it remains the ultimate authority
+  against PID reuse and wedged-but-alive holders.
+- Do not add a PID check that skips when the pid file is missing on an *old* lock
+  — age wins first, unconditionally.
+
+## Update System
+
+This change **is** an update-system change: it modifies `scripts/remote-update.sh`,
+the top-level update entrypoint. No new dependencies, config files, or migration
+steps — the lock dir format gains a `pid` file that older code simply ignores
+(older `rmdir` release would fail on the non-empty dir, but the new code ships as
+one atomic script replacement via `git pull` at the top of the same run, so no
+mixed-version window exists). No changes to `.claude/skills/update/` or
+`scripts/update/*.py` are required.
+
+## Agent Integration
+
+No agent integration required — this is a bridge/update-infrastructure shell
+change with no new CLI entry point and no bridge import surface. The agent already
+invokes `/update` (which calls `remote-update.sh`) via the existing update skill.
+
+## Failure Path Test Strategy
+
+Extend the existing real-script harness in
+`tests/unit/test_remote_update_shell.py` (runs the actual `remote-update.sh` in a
+sandboxed fake project). New cases seed a pre-existing `data/update.lock` dir with
+a controlled mtime and pid file, then assert the collision branch's decision:
+
+- Young lock + dead PID → reclaimed, run proceeds (the fix).
+- Young lock + live PID → skipped (genuine concurrent run).
+- Young lock + missing pid file → skipped conservatively.
+- Old lock (mtime > 600s) + live PID → reclaimed anyway (age backstop wins).
+- Lock is released via `rm -rf` (non-empty dir with pid file) — existing
+  release-before-kickstart test still passes.
+
+## Test Impact
+- [ ] `tests/unit/test_remote_update_shell.py` — UPDATE: add PID-liveness
+  collision cases; existing `test_lock_collision_*` and
+  `test_lock_released_before_self_kill_second_run_not_skipped` cases must still
+  pass (release path now `rm -rf`).
+
+## Rabbit Holes
+
+- Making the lock robust against `stat -f` (BSD) vs `stat -c` (GNU) portability —
+  the script already uses `stat -f %m` (BSD/macOS), matching the target fleet.
+  Keep that; do not add GNU fallbacks not needed here.
+- Overthinking PID-reuse races: the age backstop is the deliberate coarse guard
+  for that; a young lock whose pid was reused by an unrelated live process is an
+  accepted (astronomically rare, self-healing at TTL) edge.
+
+## Documentation
+- [ ] Add a note to `docs/features/bridge-self-healing.md` documenting the update
+  lock's PID-liveness reclaim behavior (age backstop first, then live/dead/unknown
+  PID handling) so the self-healing reference reflects the new guard.
+- [ ] Update the in-script comment block above the lock guard in
+  `scripts/remote-update.sh` to describe the pid-file + liveness decision table
+  (the script comments are the authoritative inline reference for this mechanism).

--- a/scripts/remote-update.sh
+++ b/scripts/remote-update.sh
@@ -71,17 +71,38 @@ skip_locked() {
 }
 
 # ── Lockfile (mkdir is atomic on POSIX) ──────────────────────────────
-cleanup_lock() { rmdir "$LOCK_DIR" 2>/dev/null || true; }
-if ! mkdir "$LOCK_DIR" 2>/dev/null; then
-    # Stale lock detection: if lock is older than 10 minutes, force-remove it.
-    # This prevents permanent lockout after crashes, OOM kills, or power loss.
+# The lock dir records its holder's PID in a `pid` file so collision handling
+# can distinguish a *running* update from a *dead* one (issue #2169). Decision
+# table on collision, in strict precedence order:
+#   1. Age backstop first (ultimate authority; no legitimate hold approaches the
+#      600s TTL) — lock older than TTL is reclaimed regardless of PID. Covers PID
+#      reuse and wedged-but-alive holders.
+#   2. Young lock + recorded PID alive (`kill -0`) → genuine concurrent run → skip.
+#   3. Young lock + recorded PID dead → crashed run → reclaim immediately (the fix
+#      for the up-to-600s green-skip lockout after SIGKILL/OOM/power loss).
+#   4. Young lock + PID unknown (legacy lock or a run mid-claim) → skip
+#      conservatively; the age backstop clears it later.
+# The dir now holds a `pid` file, so release uses `rm -rf` (rmdir needs empty).
+cleanup_lock() { rm -rf "$LOCK_DIR" 2>/dev/null || true; }
+claim_lock() { mkdir "$LOCK_DIR" 2>/dev/null && echo "$$" > "$LOCK_DIR/pid"; }
+if ! claim_lock; then
     if [ -d "$LOCK_DIR" ]; then
         LOCK_AGE=$(( $(date +%s) - $(stat -f %m "$LOCK_DIR" 2>/dev/null || echo 0) ))
+        LOCK_PID=$(cat "$LOCK_DIR/pid" 2>/dev/null || echo "")
         if [ "$LOCK_AGE" -gt 600 ]; then
             echo "Stale lock detected (${LOCK_AGE}s old). Removing."
-            rmdir "$LOCK_DIR" 2>/dev/null || rm -rf "$LOCK_DIR"
-            mkdir "$LOCK_DIR" 2>/dev/null || true
+            rm -rf "$LOCK_DIR"
+            claim_lock || true
+        elif [ -n "$LOCK_PID" ] && kill -0 "$LOCK_PID" 2>/dev/null; then
+            # Recorded holder is alive → genuine concurrent run.
+            skip_locked
+        elif [ -n "$LOCK_PID" ]; then
+            # Recorded holder is dead → crashed run left an orphaned lock. Reclaim.
+            echo "Crashed update detected (pid $LOCK_PID dead, ${LOCK_AGE}s old). Reclaiming lock."
+            rm -rf "$LOCK_DIR"
+            claim_lock || true
         else
+            # No/unknown pid (legacy lock or mid-claim) → skip; age backstop clears it.
             skip_locked
         fi
     else
@@ -415,7 +436,7 @@ fi
 if $NEED_BRIDGE_RESTART; then
     echo "[update] Bridge-relevant changes detected — restarting bridge"
     date +%s > "$RESTART_MARKER"
-    rmdir "$LOCK_DIR" 2>/dev/null || true
+    rm -rf "$LOCK_DIR" 2>/dev/null || true
     if ! launchctl kickstart -k "gui/$(id -u)/$BRIDGE_LABEL" 2>/dev/null; then
         # Only reachable when the kickstart itself failed (a successful one
         # kills this shell): surface it loudly and withdraw the marker + the

--- a/tests/unit/test_remote_update_shell.py
+++ b/tests/unit/test_remote_update_shell.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -363,6 +364,61 @@ def test_lock_collision_without_marker_prints_generic_skip(harness):
     result = harness.run()
     assert result.returncode == 0
     assert "Another update is already running" in result.stdout
+
+
+def _seed_lock(harness, *, pid: str | None, age_s: int) -> Path:
+    """Seed a pre-existing data/update.lock dir with an optional pid file and a
+    controlled mtime (age_s seconds in the past)."""
+    lock = harness.proj / "data" / "update.lock"
+    lock.parent.mkdir(exist_ok=True)
+    lock.mkdir()
+    if pid is not None:
+        (lock / "pid").write_text(f"{pid}\n")
+    when = int(time.time()) - age_s
+    os.utime(lock, (when, when))
+    return lock
+
+
+def test_lock_collision_young_dead_pid_is_reclaimed(harness):
+    """Young lock whose recorded PID is dead → crashed run → reclaim immediately
+    (the #2169 fix). The run must proceed rather than green-skip."""
+    _seed_lock(harness, pid="999999", age_s=5)  # 999999 is not a live process
+    result = harness.run()
+    assert result.returncode == 0
+    assert "Crashed update detected" in result.stdout
+    assert "Another update is already running" not in result.stdout
+    assert "Pulling latest changes" in result.stdout
+
+
+def test_lock_collision_young_live_pid_is_skipped(harness):
+    """Young lock whose recorded PID is alive → genuine concurrent run → skip."""
+    _seed_lock(harness, pid=str(os.getpid()), age_s=5)  # pytest process is alive
+    result = harness.run()
+    assert result.returncode == 0
+    assert "Another update is already running" in result.stdout
+    assert "Pulling latest changes" not in result.stdout
+
+
+def test_lock_collision_old_live_pid_reclaimed_age_backstop_wins(harness):
+    """Lock older than the 600s TTL is reclaimed regardless of PID liveness —
+    the age backstop is the ultimate authority (covers wedged-but-alive holders
+    and PID reuse)."""
+    _seed_lock(harness, pid=str(os.getpid()), age_s=700)  # alive pid, but stale
+    result = harness.run()
+    assert result.returncode == 0
+    assert "Stale lock detected" in result.stdout
+    assert "Another update is already running" not in result.stdout
+    assert "Pulling latest changes" in result.stdout
+
+
+def test_lock_collision_young_unknown_pid_is_skipped(harness):
+    """Young lock with no pid file (legacy lock or mid-claim) → skip
+    conservatively; the age backstop clears it later."""
+    _seed_lock(harness, pid=None, age_s=5)
+    result = harness.run()
+    assert result.returncode == 0
+    assert "Another update is already running" in result.stdout
+    assert "Pulling latest changes" not in result.stdout
 
 
 def test_marker_freshness_literal_matches_python_ttl():


### PR DESCRIPTION
## Summary

Fixes #2169. The `/update` concurrency guard in `scripts/remote-update.sh` used a `mkdir`-based lock dir at `data/update.lock` with **only an age-based staleness backstop** (600s TTL) and **no PID liveness check**. The lock recorded no owner, so the guard could not tell a *running* update from a *dead* one.

A crashed run — SIGKILL, OOM, power loss, or the bridge-kickstart self-kill on a path that skips the `trap cleanup_lock EXIT` handler — left an orphaned lock that green-skipped (`exit 0` "Skipping") **every** subsequent run (manual and 30-min cron alike) for up to 600 seconds.

## Fix

Record the holder PID in `$LOCK_DIR/pid` and check liveness on collision, in strict precedence:

1. **Age backstop first** (ultimate authority): lock older than 600s TTL → reclaim regardless of PID (covers PID reuse and wedged-but-alive holders).
2. Young lock + recorded PID **alive** (`kill -0`) → genuine concurrent run → skip.
3. Young lock + recorded PID **dead** → crashed run → reclaim immediately (the fix).
4. Young lock + PID **unknown** (legacy lock / mid-claim) → skip conservatively; age backstop clears it later.

Release calls switch `rmdir` → `rm -rf` since the dir now holds a `pid` file.

## Tests

4 new PID-liveness collision cases in `tests/unit/test_remote_update_shell.py` run the **real** script against a seeded lock dir with controlled mtime + pid: dead-PID reclaim, live-PID skip, old-lock age-backstop-wins, unknown-PID skip. **16 passed.**

One unrelated pre-existing failure in the same file (`test_worker_bootstrap_and_kickstart_both_fail_reports_failure` — a #1898-era `bootstrap/kickstart` vs `kickstart/bootstrap` string-order mismatch) fails **identically on main**; out of scope for this PR.

## Docs

- `docs/features/remote-update.md`: lockfile snippet + design-decision table updated with the PID-liveness behavior.
- Plan: `docs/plans/update-lock-pid-liveness.md`.

## Update System

This IS an update-system change (modifies the top-level `remote-update.sh`). The lock dir gains a `pid` file; the new script ships atomically via the `git pull` at the top of the same run, so no mixed-version window exists. No new deps or config.