### PR TITLE
Wire /v1/bootstrap readiness gating into valor-computer (#2130)

### DIFF
--- a/.claude/skill-context/computer-use.md
+++ b/.claude/skill-context/computer-use.md
@@ -21,6 +21,35 @@ The `valor-computer` CLI enforces macOS-only at its entry point: on non-macOS ho
   containing the loopback `baseURL`. The CLI reads that manifest on every call. If absent, the
   CLI returns `{"error": "computer_use_unavailable", ...}` and exits 78.
 
+## Readiness gating (run once per session, before the first action)
+
+Before issuing the first action in a session, run the preflight check:
+
+```bash
+valor-computer bootstrap
+```
+
+This calls `GET /v1/bootstrap` and reports whether bcu is ready. Gate on the exit
+code:
+
+- **exit 0** (`instructions.ready == true`) — permissions granted; proceed with
+  `list_apps` / `click` / `type_text` / etc.
+- **exit 78** with `instructions.ready == false` in the payload — bcu is running but
+  macOS **Accessibility** / **Screen Recording** permission is not granted. Do **not**
+  issue actions (they will fail). Relay the payload's `instructions.user` text to the
+  user and stop.
+- **exit 78** with `{"error": "computer_use_unavailable", ...}` — bcu not installed,
+  not opted in, or not running. Tell the user to run `/setup` and answer "yes" to the
+  computer-use opt-in.
+- **exit 1** — some other error (e.g. bcu returned HTTP 500); surface it.
+
+You only need this once per session — bcu readiness does not change between actions
+within a session. Chain it to gate the first action:
+
+```bash
+valor-computer bootstrap && valor-computer list_windows Notes
+```
+
 ## Quick start
 
 Window IDs are **strings** returned by `list_windows`.
@@ -46,6 +75,7 @@ valor-computer press_key <window> return
 ## Core workflow
 
 ```
+0. bootstrap                        # once per session: gate on instructions.ready
 1. list_apps                        # find the app
 2. list_windows <app>               # pick the string window ID
 3. get_window_state <window>        # AX tree + stateToken + screenshot (optional)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,7 @@ valor-email threads
 | `valor-deck-video deck.md` | Render a narrated MP4 of a Marp deck (per-slide `<!-- narration: ... -->`, voiceover via valor-tts, slides held for each clip's duration). See `docs/features/narrated-deck-video.md`. |
 | `valor-ingest <path-or-url>` | Convert a PDF/DOCX/PPTX/XLSX/HTML/image/YouTube URL into a `.md` sidecar the knowledge indexer picks up (see `docs/features/markitdown-ingestion.md`) |
 | `valor-ingest --scan ~/work-vault/` | Backfill every convertible binary file in the vault recursively (audio formats deliberately excluded) |
+| `valor-computer bootstrap` | Readiness preflight (`GET /v1/bootstrap`); run once per session before the first action. Exit 0 when ready, 78 when permissions ungranted (`instructions.ready == false`) or bcu unavailable — relay `instructions.user` and stop |
 | `valor-computer list_apps` | List all visible macOS apps (requires bcu opt-in via `/setup`; macOS-only — exits 78 on other OSes) |
 | `valor-computer list_windows <app>` | List open windows for an app (name, bundle ID, or query); window IDs are strings |
 | `valor-computer click <window> --x N --y N` | Click coordinates in a native window without moving the user's cursor |

--- a/config/personas/segments/tools.md
+++ b/config/personas/segments/tools.md
@@ -59,6 +59,7 @@ Full reference: `docs/features/byob-browser-control.md`.
 For native macOS app control -- driving Slack, Notes, Telegram Desktop, VS Code, etc. **without moving the user's cursor or stealing focus** -- I use the `computer-use` skill via the `valor-computer` CLI:
 
 ```bash
+valor-computer bootstrap                       # once per session: gate on readiness (exit 78 if not ready)
 valor-computer list_apps                       # all visible apps
 valor-computer list_windows Notes              # windows for an app (string window IDs)
 valor-computer click <window> --x 400 --y 300

--- a/docs/features/computer-use.md
+++ b/docs/features/computer-use.md
@@ -50,7 +50,7 @@ and exits **78** (`EX_CONFIG`). This is distinct from the generic exit-1 path us
 
 | Path | Purpose |
 |------|---------|
-| `tools/computer/__init__.py` | HTTP wrapper for the bcu v0.1.0 loopback API. Functions: `list_apps`, `list_windows`, `get_window_state`, `screenshot`, `click`, `scroll`, `type_text`, `press_key`, `set_value`, `perform_secondary_action`, `drag`, `resize`, `set_window_frame`. Stdlib-only (`urllib.request`). Reads base URL from `$TMPDIR/background-computer-use/runtime-manifest.json`. Raises `ComputerUseUnavailableError` when manifest absent or bcu not running. |
+| `tools/computer/__init__.py` | HTTP wrapper for the bcu v0.1.0 loopback API. Functions: `bootstrap`, `is_ready`, `list_apps`, `list_windows`, `get_window_state`, `screenshot`, `click`, `scroll`, `type_text`, `press_key`, `set_value`, `perform_secondary_action`, `drag`, `resize`, `set_window_frame`. Stdlib-only (`urllib.request`); `bootstrap()` is the only GET wrapper. Reads base URL from `$TMPDIR/background-computer-use/runtime-manifest.json`. Raises `ComputerUseUnavailableError` when manifest absent or bcu not running. |
 | `tools/computer/cli.py` | argparse CLI. OS gate enforced at entry. `--target` JSON parsing, `--state-token` pass-through. |
 | `.claude/skill-context/computer-use.md` | Repo-specific skill context. Documents `valor-computer` invocation patterns, target/stateToken usage, error semantics. |
 | `config/bcu_pin.json` | Pinned bcu release tag (`v0.1.0`) consumed by /setup's opt-in installer. |
@@ -86,6 +86,32 @@ bcu requires two macOS permissions, granted by the operator in System Settings:
 - **Privacy & Security -> Screen Recording** -> add `BackgroundComputerUse.app`
 
 These cannot be granted programmatically. The `/setup` skill (Step 8.5) prompts the operator before installing bcu and surfaces the permission requirement.
+
+## Readiness gating (`bootstrap`)
+
+`GET /v1/bootstrap` reports whether bcu is ready to run action routes. Its
+`instructions.ready` boolean is the gate: `true` means click/type/screenshot will
+succeed; `false` means bcu is running but the two macOS permissions above are not
+granted yet. The response also carries `instructions.summary`, `instructions.agent`
+(agent-facing recovery steps), `instructions.user` (user-facing recovery text), and
+`permissions` (per-permission `granted`/`promptable`).
+
+`valor-computer bootstrap` exposes this as a preflight check the agent runs **once
+per session before the first action**:
+
+- **exit 0** — `instructions.ready == true`; proceed with actions.
+- **exit 78** (`EX_CONFIG`) — bcu is reachable but `instructions.ready == false`
+  (permissions ungranted). The printed payload carries `instructions.user`; relay
+  it to the user and stop rather than issuing blind actions.
+- **exit 78** — bcu unavailable (`computer_use_unavailable`; manifest absent or app
+  not running), same as every other command.
+- **exit 1** — any other error (e.g. an HTTP 500 from bcu), not a readiness signal.
+
+The exit code lets a script gate the first action: `valor-computer bootstrap &&
+valor-computer click ...`. The gate is a single explicit call — it is deliberately
+**not** injected into every action wrapper (that would double every request). The
+`is_ready(bootstrap_result)` module predicate centralizes the "no error and
+`instructions.ready` truthy" decision so the CLI and any future caller agree.
 
 ## Install + opt-in
 

--- a/docs/features/tools-reference.md
+++ b/docs/features/tools-reference.md
@@ -278,6 +278,9 @@ Always exits 0 and returns `{}` on any error (missing session, Redis down, malfo
 macOS-only desktop control via background-computer-use (bcu, pinned to v0.1.0). Wraps the bcu loopback HTTP API (all routes POST + JSON body; window IDs are strings) so the agent can drive native macOS apps -- click, type, screenshot windows -- without moving the user's cursor.
 
 ```bash
+# Preflight: once per session, gate on readiness (exit 78 if permissions ungranted)
+valor-computer bootstrap
+
 # Discover
 valor-computer list_apps                       # all visible apps
 valor-computer list_windows Notes              # windows for an app (name, bundle ID, or query)

--- a/docs/plans/bcu_bootstrap_readiness_gating.md
+++ b/docs/plans/bcu_bootstrap_readiness_gating.md
@@ -1,0 +1,154 @@
+---
+status: planned
+type: feature
+appetite: Small
+owner: Valor Engels
+created: 2026-07-20
+tracking: https://github.com/tomcounsell/ai/issues/2130
+last_comment_id: none
+---
+
+# Wire /v1/bootstrap readiness gating into valor-computer
+
+## Problem
+
+bcu v0.1.0 exposes `GET /v1/bootstrap`, whose `instructions.ready` field gates
+whether action routes (click/type/screenshot/etc.) will succeed. When
+Accessibility or Screen Recording permission is missing, bcu returns
+`instructions.ready == false` plus user-facing recovery text, and action routes
+fail. The v0.1.0 contract migration (#2114 / PR #2132) deliberately dropped a
+`bootstrap()` wrapper because it had no consumer at the time. This follow-up adds
+the wrapper, a `valor-computer bootstrap` subcommand, and skill-context guidance
+so callers check readiness once per session before the first action — turning a
+silent, confusing action failure into an actionable "grant permissions" message.
+
+## Freshness Check
+
+- `tools/computer/__init__.py` is on the v0.1.0 contract (merged PR #2132): all
+  routes are POST with JSON bodies except `/health`, `/v1/bootstrap`, `/v1/routes`
+  which are GET. There is currently **no** `_get` helper and no `bootstrap()`.
+- `config/bcu_pin.json` pins `release_tag: v0.1.0`.
+- `.claude/skill-context/computer-use.md` documents the CLI commands and error
+  handling but has no readiness-gating step.
+- Contract source (pinned tag v0.1.0, `Sources/BackgroundComputerUse/Contracts/BootstrapContracts.swift`):
+  `BootstrapResponse` = `{ contractVersion, baseURL?, startedAt?, permissions,
+  instructions, guide, routes }`; `BootstrapInstructionsDTO` = `{ ready: Bool,
+  summary: String, agent: [String], user: [String] }`; `RuntimePermissionsDTO` =
+  `{ accessibility: {granted, promptable}, screenRecording: {granted, promptable},
+  checkedAt, checkMs }`. Upstream `runtime.md`: "Always trust the GET /v1/bootstrap
+  response: `instructions.ready == true` → action routes available;
+  `instructions.ready == false` → report `instructions.user` and recovery guidance."
+
+## Prior Art
+
+- The v0.1.0 migration plan (`docs/plans/completed/bcu_v010_contract_migration.md`)
+  explicitly deferred readiness-gating via `/v1/bootstrap` `instructions.ready` to
+  this issue (#2130), which this plan now resolves in full.
+- Contract-level test harness already exists in
+  `tools/computer/tests/test_computer_use.py` (a real loopback `http.server` fake
+  bcu that records method/path/body). The fake handler already implements `do_GET`.
+
+## Solution
+
+**Module (`tools/computer/__init__.py`):**
+- Add a `_get(path, *, timeout)` helper mirroring `_post` (same error-dict and
+  `ComputerUseUnavailableError` semantics) but issuing an HTTP GET with no body.
+- Add `bootstrap() -> dict` → `_get("/v1/bootstrap")`. Returns the parsed
+  `BootstrapResponse` dict, or an error dict / raises `ComputerUseUnavailableError`
+  exactly like the other wrappers.
+- Add `is_ready(bootstrap_result: dict) -> bool` — a pure helper that returns
+  `True` only when the payload has no `error` key and `instructions.ready` is
+  truthy. Centralizes the gating predicate so the CLI and any future caller agree.
+
+**CLI (`tools/computer/cli.py`):**
+- Add a `bootstrap` subcommand (no positional args) that calls `bootstrap()` and
+  prints the JSON payload like every other command.
+- Exit-code semantics encode the gate so a script can do
+  `valor-computer bootstrap && valor-computer click ...`:
+  - bcu unavailable (`computer_use_unavailable`) → exit 78 (existing path).
+  - other error dict → exit 1 (existing path).
+  - HTTP-200 payload with `instructions.ready == false` → exit 78 (`EX_CONFIG`):
+    bcu is running but not ready (permissions ungranted). This is the new gate.
+  - `instructions.ready == true` → exit 0.
+
+**Skill-context (`.claude/skill-context/computer-use.md`):**
+- Add a "Readiness gating" section: run `valor-computer bootstrap` **once per
+  session before the first action**; on exit 78 with `instructions.ready == false`,
+  surface `instructions.user` to the user and stop rather than issuing blind
+  actions.
+
+No auto-gating is injected into every action wrapper — that would double every
+request and duplicate the skill-level check. The gate is one explicit, cheap,
+once-per-session call, exactly as the issue scopes it.
+
+## Step by Step Tasks
+
+1. Add `_get` + `bootstrap()` + `is_ready()` to `tools/computer/__init__.py`.
+2. Add the `bootstrap` subcommand and readiness exit-code logic to
+   `tools/computer/cli.py`.
+3. Add contract + CLI tests to `tools/computer/tests/test_computer_use.py`.
+4. Update `.claude/skill-context/computer-use.md` with the readiness-gating step.
+5. Update `docs/features/computer-use.md` with the bootstrap command + gating flow.
+6. `ruff format` + `ruff check`, run the targeted test module, commit, open PR.
+
+## Success Criteria
+
+- `valor-computer bootstrap` issues `GET /v1/bootstrap` (asserted against the fake
+  bcu), prints the payload, and exits 0 when ready, 78 when `ready == false`, 78
+  when bcu is unavailable, 1 on other errors.
+- `bootstrap()` and `is_ready()` are importable and unit-tested.
+- Skill-context and feature doc describe the once-per-session gate.
+- macOS-only OS gate and all existing behavior unchanged.
+
+## Failure Path Test Strategy
+
+- `ready == false` payload → CLI exits 78 and prints the payload (test asserts exit
+  code + `instructions.ready == false` in output).
+- bcu unavailable (no manifest) → `bootstrap()` raises `ComputerUseUnavailableError`;
+  CLI exits 78 with `computer_use_unavailable` (reuse existing assertions pattern).
+- HTTP 500 from `/v1/bootstrap` → `bootstrap()` returns `http_500` error dict; CLI
+  exits 1.
+- `is_ready()` returns `False` for error dicts and missing/false `instructions.ready`.
+
+## Test Impact
+
+- [ ] `tools/computer/tests/test_computer_use.py` — UPDATE: add `bootstrap` contract
+  test (GET method + `/v1/bootstrap` path + empty body), `is_ready` unit tests, and
+  CLI exit-code tests (ready=0, not-ready=78, unavailable=78, http-500=1). No existing
+  cases change behavior; this is purely additive.
+
+## Rabbit Holes
+
+- Do **not** add auto-gating inside every action wrapper (doubles requests, couples
+  the module to session state). One explicit subcommand + skill-context step only.
+- Do **not** parse/normalize the `guide`/`routes` sub-objects — pass the payload
+  through verbatim; only `instructions.ready` drives the exit code.
+- Do **not** cache bootstrap results in the module — "once per session" is the
+  caller's (skill's) responsibility, not the CLI's.
+
+## No-Gos
+
+- No live bcu on this host (macOS opt-in, installed only on Tom's MacBook Air).
+  All tests are contract-level against the loopback fake server; live verification
+  deferred to the opted-in machine.
+- No new dependencies.
+
+## Update System
+
+No update-system changes required. `config/bcu_pin.json` is unchanged (still
+v0.1.0), no new config files or dependencies, and the `/update` flow is unaffected.
+
+## Agent Integration
+
+The `bootstrap` subcommand is reached through the existing `valor-computer` CLI
+entry point (`pyproject.toml [project.scripts] → tools.computer.cli:main`), which
+the agent already invokes via Bash — no new entry point needed. The skill-context
+update wires the agent's behavior (check readiness once before acting). CLI dispatch
+tests verify the agent-visible surface (exit codes + JSON payload).
+
+## Documentation
+
+- [ ] Update `docs/features/computer-use.md` with the `valor-computer bootstrap`
+  command and the once-per-session readiness-gating flow.
+- [ ] Update `.claude/skill-context/computer-use.md` with the readiness-gating step
+  and exit-code contract.

--- a/tools/computer/__init__.py
+++ b/tools/computer/__init__.py
@@ -175,6 +175,51 @@ def _post(path: str, body: dict[str, Any], *, timeout: float = _DEFAULT_TIMEOUT_
         return {"error": "timeout", "message": str(exc), "path": path, "timeout_s": timeout}
 
 
+def _get(path: str, *, timeout: float = _DEFAULT_TIMEOUT_S) -> dict:
+    """GET a bcu loopback route (no request body) and return the parsed dict.
+
+    Mirrors :func:`_post`'s error-dict and ``ComputerUseUnavailableError``
+    semantics, but issues an HTTP GET. Only the GET system routes
+    (``/health``, ``/v1/bootstrap``, ``/v1/routes``) use this in v0.1.0.
+    """
+    base_url = _read_base_url()
+    url = f"{base_url}{path}"
+
+    headers = {"Accept": "application/json"}
+    req = urllib.request.Request(url, headers=headers, method="GET")
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+            try:
+                return json.loads(raw)
+            except json.JSONDecodeError:
+                return {"error": "invalid_json_response", "raw": raw[:200]}
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return {"error": "not_found", "path": path}
+        try:
+            err_body = exc.read().decode("utf-8", errors="replace")
+        except Exception:  # noqa: BLE001
+            err_body = ""
+        return {
+            "error": f"http_{exc.code}",
+            "message": err_body[:500],
+            "path": path,
+        }
+    except urllib.error.URLError as exc:
+        # Connection refused == bcu not running; treat as unavailable.
+        reason = getattr(exc, "reason", exc)
+        msg = str(reason)
+        if "Connection refused" in msg or isinstance(reason, ConnectionRefusedError):
+            raise ComputerUseUnavailableError(
+                f"bcu loopback API at {base_url} not reachable (is the bcu app running?)"
+            ) from exc
+        return {"error": "transport_error", "message": msg, "path": path}
+    except TimeoutError as exc:
+        return {"error": "timeout", "message": str(exc), "path": path, "timeout_s": timeout}
+
+
 def _merge_optional(body: dict[str, Any], **fields: Any) -> dict[str, Any]:
     """Add each field to ``body`` only when its value is not None."""
     for key, value in fields.items():
@@ -186,6 +231,43 @@ def _merge_optional(body: dict[str, Any], **fields: Any) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 # Public API -- bcu v0.1.0 endpoint wrappers
 # ---------------------------------------------------------------------------
+
+
+def bootstrap() -> dict:
+    """Return bcu's connection/permission/route-discovery payload.
+
+    Maps to ``GET /v1/bootstrap``. The response (``BootstrapResponse`` in the
+    v0.1.0 contract) carries ``contractVersion``, ``baseURL``, ``startedAt``,
+    ``permissions`` (accessibility + screenRecording grant status),
+    ``instructions`` (``{ready, summary, agent, user}``), ``guide``, and
+    ``routes``.
+
+    ``instructions.ready`` is the readiness gate: when ``true`` the action
+    routes (click/type/screenshot/...) are available; when ``false`` the user
+    must grant macOS Accessibility / Screen Recording permission (relay
+    ``instructions.user``) before any action will succeed. Callers should check
+    this once per session before the first action -- see :func:`is_ready`.
+
+    Returns the parsed dict, an error dict, or raises
+    ``ComputerUseUnavailableError`` exactly like the other wrappers.
+    """
+    return _get("/v1/bootstrap")
+
+
+def is_ready(bootstrap_result: dict) -> bool:
+    """Return ``True`` only when a :func:`bootstrap` payload signals readiness.
+
+    The gate is truthy only when the payload carries no ``error`` key and
+    ``instructions.ready`` is truthy. Error dicts, missing ``instructions``, and
+    ``ready == false`` all return ``False``. This is the single predicate the
+    CLI and any future caller share so the gating decision stays consistent.
+    """
+    if not isinstance(bootstrap_result, dict) or "error" in bootstrap_result:
+        return False
+    instructions = bootstrap_result.get("instructions")
+    if not isinstance(instructions, dict):
+        return False
+    return bool(instructions.get("ready"))
 
 
 def list_apps() -> dict:

--- a/tools/computer/cli.py
+++ b/tools/computer/cli.py
@@ -78,7 +78,8 @@ def _build_parser() -> argparse.ArgumentParser:
         help=(
             "Check bcu readiness (GET /v1/bootstrap). Exit 0 when ready, "
             "78 when bcu is running but permissions are ungranted "
-            "(instructions.ready == false), 78 when bcu is unavailable."
+            "(instructions.ready == false) or bcu is unavailable, "
+            "1 on any other error."
         ),
     )
 

--- a/tools/computer/cli.py
+++ b/tools/computer/cli.py
@@ -73,6 +73,15 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     sub = parser.add_subparsers(dest="command", required=True)
 
+    sub.add_parser(
+        "bootstrap",
+        help=(
+            "Check bcu readiness (GET /v1/bootstrap). Exit 0 when ready, "
+            "78 when bcu is running but permissions are ungranted "
+            "(instructions.ready == false), 78 when bcu is unavailable."
+        ),
+    )
+
     sub.add_parser("list_apps", help="List visible apps.")
 
     p_list_windows = sub.add_parser("list_windows", help="List open windows for an app.")
@@ -197,6 +206,7 @@ def _dispatch(args: argparse.Namespace) -> dict:
     # import).
     from tools.computer import (
         ComputerUseUnavailableError,
+        bootstrap,
         click,
         drag,
         get_window_state,
@@ -215,6 +225,8 @@ def _dispatch(args: argparse.Namespace) -> dict:
     cmd = args.command
 
     try:
+        if cmd == "bootstrap":
+            return bootstrap()
         if cmd == "list_apps":
             return list_apps()
         if cmd == "list_windows":
@@ -306,6 +318,17 @@ def main(argv: list[str] | None = None) -> int:
         return EX_CONFIG
     if isinstance(result, dict) and "error" in result:
         return 1
+
+    # Readiness gate: a successful GET /v1/bootstrap that reports
+    # instructions.ready == false means bcu is running but permissions are
+    # ungranted. Exit 78 (EX_CONFIG) so `valor-computer bootstrap && ...` gates
+    # the first action; the printed payload carries instructions.user recovery
+    # text for the caller to relay.
+    if args.command == "bootstrap":
+        from tools.computer import is_ready
+
+        if not is_ready(result):
+            return EX_CONFIG
     return 0
 
 

--- a/tools/computer/tests/test_computer_use.py
+++ b/tools/computer/tests/test_computer_use.py
@@ -150,6 +150,26 @@ def _call(bcu, fn, *args, **kwargs):
     return result, bcu.requests[0]
 
 
+def test_bootstrap_contract(bcu):
+    """GET /v1/bootstrap with no request body."""
+    from tools.computer import bootstrap
+
+    _, req = _call(bcu, bootstrap)
+    assert req == {"method": "GET", "path": "/v1/bootstrap", "body": None}
+
+
+def test_bootstrap_returns_payload(bcu):
+    from tools.computer import bootstrap
+
+    payload = {
+        "contractVersion": "0.1.0",
+        "instructions": {"ready": True, "summary": "ok", "agent": [], "user": []},
+    }
+    bcu.respond("/v1/bootstrap", payload)
+    result = bootstrap()
+    assert result == payload
+
+
 def test_list_apps_contract(bcu):
     from tools.computer import list_apps
 
@@ -491,6 +511,45 @@ def test_connection_refused_raises_unavailable(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# bootstrap readiness gate (module-level)
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_http_500_returns_structured_error(bcu):
+    from tools.computer import bootstrap
+
+    bcu.respond("/v1/bootstrap", {"detail": "boom"}, status=500)
+    result = bootstrap()
+    assert result["error"] == "http_500"
+    assert "boom" in result["message"]
+
+
+def test_bootstrap_missing_manifest_raises_unavailable(no_manifest):
+    from tools.computer import ComputerUseUnavailableError, bootstrap
+
+    with pytest.raises(ComputerUseUnavailableError):
+        bootstrap()
+
+
+@pytest.mark.parametrize(
+    "payload,expected",
+    [
+        ({"instructions": {"ready": True}}, True),
+        ({"instructions": {"ready": False}}, False),
+        ({"instructions": {}}, False),
+        ({}, False),
+        ({"error": "http_500", "instructions": {"ready": True}}, False),
+        ("not a dict", False),
+    ],
+    ids=["ready", "not-ready", "no-ready-key", "no-instructions", "error-dict", "non-dict"],
+)
+def test_is_ready_predicate(payload, expected):
+    from tools.computer import is_ready
+
+    assert is_ready(payload) is expected
+
+
+# ---------------------------------------------------------------------------
 # CLI: OS gate, exit codes, dispatch
 # ---------------------------------------------------------------------------
 
@@ -570,6 +629,68 @@ def test_cli_list_windows_dispatch(bcu, monkeypatch, capsys):
     assert bcu.requests[0]["body"] == {"app": "Notes"}
     payload = json.loads(capsys.readouterr().out)
     assert payload["windows"][0]["id"] == "w-1"
+
+
+def test_cli_bootstrap_ready_exits_0(bcu, monkeypatch, capsys):
+    """A ready payload exits 0 and prints the bootstrap JSON."""
+    from tools.computer.cli import main
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+    bcu.respond(
+        "/v1/bootstrap",
+        {"contractVersion": "0.1.0", "instructions": {"ready": True, "user": []}},
+    )
+    rc = main(["bootstrap"])
+    assert rc == 0
+    assert bcu.requests[0] == {"method": "GET", "path": "/v1/bootstrap", "body": None}
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["instructions"]["ready"] is True
+
+
+def test_cli_bootstrap_not_ready_exits_78(bcu, monkeypatch, capsys):
+    """ready == false gates action: exit 78 with instructions.user surfaced."""
+    from tools.computer.cli import EX_CONFIG, main
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+    bcu.respond(
+        "/v1/bootstrap",
+        {
+            "contractVersion": "0.1.0",
+            "instructions": {
+                "ready": False,
+                "summary": "Grant permissions",
+                "user": ["Enable Accessibility in System Settings, then relaunch."],
+            },
+        },
+    )
+    rc = main(["bootstrap"])
+    assert rc == EX_CONFIG
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["instructions"]["ready"] is False
+    assert payload["instructions"]["user"]
+
+
+def test_cli_bootstrap_unavailable_exits_78(monkeypatch, no_manifest, capsys):
+    """No bcu manifest: bootstrap surfaces unavailable and exits 78."""
+    from tools.computer.cli import EX_CONFIG, main
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+    rc = main(["bootstrap"])
+    assert rc == EX_CONFIG
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"] == "computer_use_unavailable"
+
+
+def test_cli_bootstrap_http_500_exits_1(bcu, monkeypatch, capsys):
+    """A server error (not a readiness signal) exits 1, not 78."""
+    from tools.computer.cli import main
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+    bcu.respond("/v1/bootstrap", {"detail": "boom"}, status=500)
+    rc = main(["bootstrap"])
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"] == "http_500"
 
 
 def test_cli_screenshot_output_writes_file(bcu, monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
Closes #2130.

## What

Follow-up to the bcu v0.1.0 contract migration (#2114 / PR #2132). Adds `/v1/bootstrap` readiness gating to `valor-computer` so callers verify bcu is ready (permissions granted) once per session before the first action, turning a silent action failure into an actionable "grant permissions" message.

## Changes

- **`tools/computer/__init__.py`**: new `_get()` helper (GET, no body; same error-dict / `ComputerUseUnavailableError` semantics as `_post`), `bootstrap()` → `GET /v1/bootstrap`, and `is_ready(payload)` predicate (truthy only when no `error` and `instructions.ready` is truthy).
- **`tools/computer/cli.py`**: `bootstrap` subcommand. Exit codes: **0** when `instructions.ready == true`; **78** (`EX_CONFIG`) when bcu is running but `instructions.ready == false` (permissions ungranted) or bcu is unavailable; **1** on other errors. Lets a script gate: `valor-computer bootstrap && valor-computer click ...`.
- **`.claude/skill-context/computer-use.md`**: readiness-gating step (run `bootstrap` once per session before the first action; on exit 78 with `ready == false`, relay `instructions.user` and stop).
- **Docs**: `docs/features/computer-use.md` (new Readiness gating section), `docs/features/tools-reference.md`, `config/personas/segments/tools.md`, `CLAUDE.md` quick-command row.

## Contract source

`BootstrapInstructionsDTO` = `{ ready: Bool, summary, agent: [String], user: [String] }` from the pinned v0.1.0 `Sources/BackgroundComputerUse/Contracts/BootstrapContracts.swift`. Upstream `runtime.md`: `instructions.ready == true` → action routes available; `false` → report `instructions.user`.

## Tests

`tools/computer/tests/test_computer_use.py` — bootstrap GET contract (method/path/empty body), `is_ready` predicate matrix, CLI exit codes (ready=0, not-ready=78, unavailable=78, http-500=1). **52 passed**; integration module auto-skips (no live bcu on this host — macOS opt-in only).

## Plan

`docs/plans/bcu_bootstrap_readiness_gating.md` (migrated to `completed/` post-merge).

No update-system changes; `config/bcu_pin.json` unchanged (still v0.1.0).