### PR TITLE
Hotfix: cold ISSUE stage-marker writes sessionlessly, no phantom pipeline spawn

### DIFF
--- a/docs/features/sdlc-run-identity-self-heal.md
+++ b/docs/features/sdlc-run-identity-self-heal.md
@@ -49,6 +49,34 @@ write proceeds under it (exit 0, so `|| true` is a no-op and the write lands).
 Only a genuinely unhealable state (foreign live lease, or no issue-number to
 key on) still emits `RUN_ID_REQUIRED`.
 
+### Cold ISSUE-stage carve-out (sessionless marker write)
+
+The front-gate heal is **not** used for a cold `--stage ISSUE` marker (no
+`--run-id`). The `ISSUE` marker is issue-creation ledger metadata written by
+`/do-issue` (Steps 6/7) at the very start of the pipeline — there is no
+in-flight run to re-establish. Routing it through the heal was actively
+harmful: `reestablish_run_id` finds no supervised run, no `.sdlc-run`, no
+`active_run_id`, and no existing session, so `ensure_session` fell through to
+its **fresh-mint create branch** and fabricated a runnable-looking
+`sdlc-local-{N}` eng anchor (status `running`, seeded with "Run the full SDLC
+pipeline for issue #N") the instant an issue was filed — before any human
+decided to plan it. The anchor is inert to the worker (`is_ledger=True`, #2042)
+but pollutes the dashboard as a phantom running pipeline and holds the issue
+lease.
+
+Instead, `sdlc_stage_marker.main()` routes a cold `ISSUE` marker to
+`write_issue_marker_cold(status, issue_number)`, which records the marker
+**sessionlessly**: it contends the issue lease with a fresh run identity (no
+`AgentSession` row), writes via `write_marker`, and releases the lease. The
+ledger key `(target_repo, issue_number)` is written exactly as the healed path
+would have — `sdlc-tool stage-query` still shows `ISSUE: completed` — but no
+session is created. If a live run already owns the lease (a supervised
+`/do-sdlc`, or a pipeline that lost its `run_id`), the idempotent marker is
+written under **that** owner's `run_id` without stealing or releasing its
+lease. The carve-out is scoped strictly to the `ISSUE` stage: every later stage
+implies a pipeline already ran (a session exists), so a cold write there is
+pathological and still routes through the normal self-heal.
+
 ### Post-write heal (stale `--run-id` → `LEASE_ABSENT`)
 
 When a write refuses for a run-identity reason (`LEASE_ABSENT`, or a stale
@@ -150,7 +178,8 @@ stored state" — is load-bearing (`.claude/skills/sdlc/SKILL.md`). Instead:
   `_log_path`), and the terminal guard (`_pipeline_is_terminal`).
 - `tools/sdlc_stage_marker.py`, `tools/sdlc_verdict.py`,
   `tools/sdlc_meta_set.py`, `tools/sdlc_dispatch.py` — the front-gate +
-  post-write wiring.
+  post-write wiring. `sdlc_stage_marker.write_issue_marker_cold` is the cold
+  ISSUE-stage sessionless carve-out (no fresh-mint anchor).
 - `tests/unit/test_sdlc_run_identity.py` — helper + CLI-level self-heal unit
   coverage.
 - `tests/integration/test_sdlc_run_identity_resume.py` — end-to-end resume:

--- a/tests/unit/test_sdlc_stage_marker.py
+++ b/tests/unit/test_sdlc_stage_marker.py
@@ -492,6 +492,40 @@ class TestColdIssueMarkerSessionless:
         mock_cold.assert_called_once_with("completed", 970005)
         mock_heal.assert_not_called()
 
+    def test_main_issue_with_run_id_skips_sessionless_path(self):
+        """An ISSUE marker that carries --run-id is NOT cold: it bypasses the
+        sessionless writer and uses the normal write_marker path unchanged."""
+        from tools import sdlc_stage_marker
+
+        mock_cold = MagicMock()
+        mock_heal = MagicMock()
+        mock_write = MagicMock(return_value=({"stage": "ISSUE", "status": "completed"}, 0))
+        argv = [
+            "sdlc_stage_marker",
+            "--stage",
+            "ISSUE",
+            "--status",
+            "completed",
+            "--issue-number",
+            "970007",
+            "--run-id",
+            "run-970007",
+        ]
+        with (
+            patch.object(sdlc_stage_marker, "write_issue_marker_cold", mock_cold),
+            patch.object(sdlc_stage_marker, "heal_missing_run_id", mock_heal),
+            patch.object(sdlc_stage_marker, "write_marker", mock_write),
+            patch.object(sys, "argv", argv),
+        ):
+            try:
+                sdlc_stage_marker.main()
+            except SystemExit:
+                pass
+        # run_id present → neither the cold sessionless writer nor the heal fire.
+        mock_cold.assert_not_called()
+        mock_heal.assert_not_called()
+        assert mock_write.call_args.kwargs["run_id"] == "run-970007"
+
     def test_main_cold_non_issue_stage_still_heals(self):
         """A cold non-ISSUE marker (e.g. DOCS) keeps the normal self-heal path —
         the sessionless writer is scoped to the ISSUE stage only."""

--- a/tests/unit/test_sdlc_stage_marker.py
+++ b/tests/unit/test_sdlc_stage_marker.py
@@ -344,6 +344,184 @@ class TestWriteMarker:
         assert "ISSUE_LOCKED" in capsys.readouterr().err
 
 
+class TestColdIssueMarkerSessionless:
+    """A cold ``--stage ISSUE`` marker (no --run-id) must be written
+    sessionlessly — never by fresh-minting a runnable ``sdlc-local-{N}``
+    pipeline anchor from nothing.
+
+    Regression for the incident where ``/do-issue`` filing an issue spawned a
+    live-looking eng SDLC session (status=running, seeded with "Run the full
+    SDLC pipeline") the instant the ISSUE completion marker was written, before
+    any human decided to plan it. ``write_issue_marker_cold`` records the ledger
+    marker via the issue lease directly, creating no AgentSession.
+    """
+
+    def _no_session_for(self, issue_number: int) -> bool:
+        from models.agent_session import AgentSession
+
+        rows = list(AgentSession.query.filter(session_id=f"sdlc-local-{issue_number}"))
+        return len(rows) == 0
+
+    def test_cold_issue_completed_writes_ledger_without_spawning_session(self):
+        """The core acceptance: cold ISSUE completed persists ISSUE=completed to
+        the ledger, creates NO sdlc-local session, and leaves the lease free."""
+        from agent.pipeline_state import PipelineStateMachine
+        from models.session_lifecycle import touch_issue_lock
+        from tools.sdlc_stage_marker import write_issue_marker_cold
+
+        issue = 970001
+        assert self._no_session_for(issue)
+
+        with (
+            patch("tools._sdlc_utils._resolve_target_repo", return_value="o/r"),
+        ):
+            result, code = write_issue_marker_cold("completed", issue)
+
+        assert code == 0
+        assert result == {"stage": "ISSUE", "status": "completed"}
+        # Ledger marker landed — sdlc-tool stage-query would show it.
+        sm = PipelineStateMachine.for_issue("o/r", issue)
+        assert sm.states["ISSUE"] == "completed"
+        # No phantom pipeline anchor was spawned.
+        assert self._no_session_for(issue)
+        # Lease released — a later /do-plan session-ensure acquires cleanly.
+        assert touch_issue_lock(issue, "probe", peek=True).acquired is True
+
+    def test_cold_issue_in_progress_also_sessionless(self):
+        """The in_progress marker (/do-issue Step 6) is likewise sessionless."""
+        from agent.pipeline_state import PipelineStateMachine
+        from tools.sdlc_stage_marker import write_issue_marker_cold
+
+        issue = 970002
+        with patch("tools._sdlc_utils._resolve_target_repo", return_value="o/r"):
+            result, code = write_issue_marker_cold("in_progress", issue)
+
+        assert code == 0
+        assert result == {"stage": "ISSUE", "status": "in_progress"}
+        sm = PipelineStateMachine.for_issue("o/r", issue)
+        assert sm.states["ISSUE"] == "in_progress"
+        assert self._no_session_for(issue)
+
+    def test_cold_issue_writes_under_foreign_owner_when_lease_held(self):
+        """When a live run already owns the lease, write under ITS run_id (the
+        idempotent ISSUE marker still lands) and never release its lease."""
+        from models.session_lifecycle import IssueLockResult
+        from tools import sdlc_stage_marker
+
+        held = IssueLockResult(
+            acquired=False,
+            owner_session_id="live-sess",
+            owner_run_id="live-run",
+            target_repo="o/r",
+        )
+        mock_write = MagicMock(return_value=({"stage": "ISSUE", "status": "completed"}, 0))
+        mock_release = MagicMock()
+
+        with (
+            patch("tools._sdlc_utils._resolve_target_repo", return_value="o/r"),
+            patch("models.session_lifecycle.touch_issue_lock", return_value=held),
+            patch("models.session_lifecycle.release_issue_lock", mock_release),
+            patch.object(sdlc_stage_marker, "write_marker", mock_write),
+        ):
+            result, code = sdlc_stage_marker.write_issue_marker_cold("completed", 970003)
+
+        assert code == 0
+        assert result == {"stage": "ISSUE", "status": "completed"}
+        # Wrote under the live owner's identity, not a fresh mint.
+        assert mock_write.call_args.kwargs["run_id"] == "live-run"
+        # The foreign lease is not ours — never release it.
+        mock_release.assert_not_called()
+
+    def test_cold_issue_releases_own_lease_after_write(self):
+        """When we acquire the free lease, we release it after writing so it
+        never lingers to block the next run."""
+        from models.session_lifecycle import IssueLockResult
+        from tools import sdlc_stage_marker
+
+        acquired = IssueLockResult(
+            acquired=True, owner_session_id="s", owner_run_id="mine", target_repo="o/r"
+        )
+        mock_write = MagicMock(return_value=({"stage": "ISSUE", "status": "completed"}, 0))
+        mock_release = MagicMock()
+
+        with (
+            patch("tools._sdlc_utils._resolve_target_repo", return_value="o/r"),
+            patch("models.session_lifecycle.touch_issue_lock", return_value=acquired),
+            patch("models.session_lifecycle.release_issue_lock", mock_release),
+            patch.object(sdlc_stage_marker, "write_marker", mock_write),
+        ):
+            sdlc_stage_marker.write_issue_marker_cold("completed", 970004)
+
+        # Released under the fresh run_id we acquired with.
+        assert mock_release.call_count == 1
+        assert mock_release.call_args.args[0] == 970004
+
+    def test_cold_issue_no_issue_number_refuses(self):
+        """No issue number → nothing to key the ledger on → RUN_ID_REQUIRED."""
+        from tools.sdlc_stage_marker import write_issue_marker_cold
+
+        result, code = write_issue_marker_cold("completed", None)
+        assert code == 2
+        assert result["error"] == "RUN_ID_REQUIRED"
+
+    def test_main_routes_cold_issue_to_sessionless_not_heal(self):
+        """main() sends a cold ISSUE marker to the sessionless writer and NEVER
+        the self-heal (which would fresh-mint a session)."""
+        from tools import sdlc_stage_marker
+
+        mock_cold = MagicMock(return_value=({"stage": "ISSUE", "status": "completed"}, 0))
+        mock_heal = MagicMock()
+        argv = [
+            "sdlc_stage_marker",
+            "--stage",
+            "ISSUE",
+            "--status",
+            "completed",
+            "--issue-number",
+            "970005",
+        ]
+        with (
+            patch.object(sdlc_stage_marker, "write_issue_marker_cold", mock_cold),
+            patch.object(sdlc_stage_marker, "heal_missing_run_id", mock_heal),
+            patch.object(sys, "argv", argv),
+        ):
+            try:
+                sdlc_stage_marker.main()
+            except SystemExit as e:
+                assert e.code == 0
+        mock_cold.assert_called_once_with("completed", 970005)
+        mock_heal.assert_not_called()
+
+    def test_main_cold_non_issue_stage_still_heals(self):
+        """A cold non-ISSUE marker (e.g. DOCS) keeps the normal self-heal path —
+        the sessionless writer is scoped to the ISSUE stage only."""
+        from tools import sdlc_stage_marker
+
+        mock_cold = MagicMock()
+        # Heal fails → RUN_ID_REQUIRED exit 2 (we only assert routing, not mint).
+        mock_heal = MagicMock(return_value=None)
+        argv = [
+            "sdlc_stage_marker",
+            "--stage",
+            "DOCS",
+            "--status",
+            "completed",
+            "--issue-number",
+            "970006",
+        ]
+        with (
+            patch.object(sdlc_stage_marker, "write_issue_marker_cold", mock_cold),
+            patch.object(sdlc_stage_marker, "heal_missing_run_id", mock_heal),
+            patch.object(sys, "argv", argv),
+        ):
+            try:
+                sdlc_stage_marker.main()
+            except SystemExit:
+                pass
+        mock_cold.assert_not_called()
+        mock_heal.assert_called_once()
+
+
 class TestReviewCompletedVerdictGate:
     """WS3c (#2062): the REVIEW ``completed`` marker is unwritable without a
     readable substrate verdict. A fork that posts a GitHub APPROVED but skips

--- a/tools/sdlc_stage_marker.py
+++ b/tools/sdlc_stage_marker.py
@@ -80,6 +80,7 @@ import argparse
 import json
 import logging
 import sys
+import uuid
 
 from tools._sdlc_run_identity import heal_missing_run_id, maybe_heal_after_write
 from tools._sdlc_utils import resolve_ledger_lease, revalidate_ledger_lease
@@ -450,6 +451,95 @@ def write_marker(
         return {}, 1
 
 
+def write_issue_marker_cold(status: str, issue_number: int | None) -> tuple[dict, int]:
+    """Write a cold ISSUE-stage marker **sessionlessly**, without spawning a session.
+
+    A ``--stage ISSUE`` marker with no ``--run-id`` is issue-creation ledger
+    metadata (``/do-issue`` Steps 6/7): there is no legitimate in-flight
+    pipeline run to heal. The old path routed it through the #2144 self-heal,
+    whose ``ensure_session`` fresh-mint fabricated a runnable-looking
+    ``sdlc-local-{N}`` eng anchor (status=running, seeded with "Run the full
+    SDLC pipeline") from nothing — the moment ``/do-issue`` filed an issue,
+    before any human decided to plan it. That anchor is inert to the worker
+    (``is_ledger=True``, #2042) but pollutes the dashboard as a phantom running
+    pipeline and holds the issue lease.
+
+    Instead we record the ISSUE marker directly against the issue-keyed ledger:
+    contend the issue lease with a fresh run identity (no ``AgentSession`` row),
+    write via :func:`write_marker`, and release. The ledger key
+    ``(target_repo, issue_number)`` is written exactly as the healed path would
+    have, so ``sdlc-tool stage-query`` still shows the marker — but no session
+    is created.
+
+    Concurrency: the lease is acquired NX. If a live run already owns it (a
+    supervised ``/do-sdlc`` or an in-flight pipeline that lost its ``run_id``
+    from context), we do NOT steal or release it — we write the idempotent
+    ISSUE marker under that owner's ``run_id`` so the marker still lands without
+    disturbing the live run. Only a genuinely unkeyed call (no issue number)
+    falls back to the caller's ``RUN_ID_REQUIRED`` refusal.
+
+    This path is deliberately scoped to the ISSUE stage: every later stage
+    implies a pipeline already ran (a session exists), so a cold write there is
+    pathological and correctly still routes through the normal self-heal.
+
+    Returns:
+        A ``(result, exit_code)`` tuple with the same shape as
+        :func:`write_marker`.
+    """
+    if not issue_number:
+        return {"error": "RUN_ID_REQUIRED"}, 2
+
+    from models.session_lifecycle import (
+        ISSUE_LOCK_TTL_SECONDS,
+        release_issue_lock,
+        touch_issue_lock,
+    )
+    from tools._sdlc_utils import _resolve_target_repo
+
+    run_id = uuid.uuid4().hex
+    synthetic_session_id = f"sdlc-cold-issue-marker-{issue_number}"
+    target_repo = _resolve_target_repo()
+
+    try:
+        lock = touch_issue_lock(
+            issue_number,
+            run_id,
+            session_id=synthetic_session_id,
+            ttl=ISSUE_LOCK_TTL_SECONDS,
+            target_repo=target_repo,
+        )
+    except Exception as e:
+        logger.debug(f"write_issue_marker_cold: lease acquire failed: {e}")
+        return {"error": "RUN_ID_REQUIRED"}, 2
+
+    if lock.acquired:
+        # Sole owner: write under our fresh identity, then release so the lease
+        # never lingers to block a later /do-plan session-ensure for this issue.
+        try:
+            return write_marker(
+                stage="ISSUE", status=status, issue_number=issue_number, run_id=run_id
+            )
+        finally:
+            try:
+                release_issue_lock(issue_number, run_id)
+            except Exception as e:
+                logger.debug(f"write_issue_marker_cold: lease release failed: {e}")
+
+    # A live run already owns the lease. Write the idempotent ISSUE marker under
+    # its identity (no release — the lease is not ours) so the marker still lands.
+    if lock.owner_run_id:
+        return write_marker(
+            stage="ISSUE",
+            status=status,
+            issue_number=issue_number,
+            run_id=lock.owner_run_id,
+        )
+
+    # No owner and not acquired (malformed/racing lease): defer to the caller's
+    # RUN_ID_REQUIRED refusal rather than fabricating anything.
+    return {"error": "RUN_ID_REQUIRED"}, 2
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Write SDLC stage markers to the issue-keyed PipelineLedger",
@@ -509,6 +599,21 @@ def main() -> None:
     # state (foreign live lease, no issue-number) still refuses.
     run_id = args.run_id
     healed_at_gate = False
+    if not run_id and stage == "ISSUE":
+        # Cold ISSUE marker (no --run-id): issue-creation ledger metadata with no
+        # in-flight run to heal. Write it sessionlessly instead of self-healing —
+        # the old path fresh-minted a phantom runnable sdlc-local-{N} pipeline
+        # anchor from nothing (see write_issue_marker_cold / this hotfix).
+        result, exit_code = write_issue_marker_cold(args.status, args.issue_number)
+        stdout_result = {k: v for k, v in result.items() if k != "error"}
+        print(json.dumps(stdout_result))
+        if exit_code == 2:
+            print(
+                "sdlc_stage_marker: RUN_ID_REQUIRED — cold ISSUE marker could not "
+                "resolve an issue number to key the ledger write.",
+                file=sys.stderr,
+            )
+        sys.exit(exit_code)
     if not run_id:
         run_id = heal_missing_run_id(args.issue_number, "stage_marker")
         if not run_id:

--- a/tools/sdlc_stage_marker.py
+++ b/tools/sdlc_stage_marker.py
@@ -608,9 +608,14 @@ def main() -> None:
         stdout_result = {k: v for k, v in result.items() if k != "error"}
         print(json.dumps(stdout_result))
         if exit_code == 2:
+            # exit 2 covers all three cold-write refusals: no issue number, a
+            # touch_issue_lock error, or an unacquired-and-ownerless lease. Keep
+            # the message accurate for every one rather than misattributing them
+            # all to a missing issue number.
             print(
                 "sdlc_stage_marker: RUN_ID_REQUIRED — cold ISSUE marker could not "
-                "resolve an issue number to key the ledger write.",
+                "establish a run identity to write the ledger (no issue number, or "
+                "the issue lease was unavailable).",
                 file=sys.stderr,
             )
         sys.exit(exit_code)


### PR DESCRIPTION
## Problem

Filing an issue via \`/do-issue\` wrote the ISSUE completion marker with **no \`--run-id\`** (\`sdlc-tool stage-marker --stage ISSUE --status completed --issue-number N\`). The #2144 front-gate self-heal (\`heal_missing_run_id\`) then fell through \`ensure_session\`'s **fresh-mint create branch** and fabricated a runnable-looking \`sdlc-local-{N}\` eng anchor (status \`running\`, seeded with "Run the full SDLC pipeline for issue #N") the instant the issue was filed — before any human decided to plan it.

Observed live 2026-07-20: filing #2179/#2180 spawned \`sdlc-local-2179/2180\` as running eng SDLC sessions; both were unverified-anomaly triage issues, killed manually.

The anchor is inert to the worker (\`is_ledger=True\`, #2042) but pollutes the dashboard as a phantom running pipeline and holds the issue lease.

## Root cause

The ISSUE stage is the pipeline root — a cold marker there has no in-flight run to heal, so the self-heal's only recourse was a fresh mint of a brand-new session.

## Fix

\`sdlc_stage_marker.main()\` routes a cold \`--stage ISSUE\` marker to a new \`write_issue_marker_cold()\` that records the ledger marker **sessionlessly**: it contends the issue lease with a fresh run identity (no \`AgentSession\` row), writes via \`write_marker\`, and releases. \`sdlc-tool stage-query\` still shows \`ISSUE: completed\`, but no session is created. If a live run already owns the lease (a supervised \`/do-sdlc\`, or a pipeline that lost its \`run_id\`), the idempotent marker is written under **that** owner's \`run_id\` without stealing or releasing its lease.

Scoped strictly to the ISSUE stage: every later stage implies a pipeline already ran (a session exists), so their cold writes still route through the normal #2144 self-heal — **unchanged**.

## Acceptance (verified live)

- ✅ Cold \`stage-marker --stage ISSUE --status completed\` (no \`--run-id\`, no pre-existing session) creates no runnable eng session and starts no pipeline (\`valor-session list\` shows nothing).
- ✅ ISSUE-stage ledger state still readable — \`stage-query\` shows \`ISSUE=completed\`; lease left free.
- ✅ #2144 self-heal reuse path unchanged (later-stage / corroborated-identity writes untouched).

## Tests

New \`TestColdIssueMarkerSessionless\` (7 cases): sessionless no-spawn write, in_progress variant, write-under-foreign-owner, own-lease release, no-issue-number refusal, and main()-routing (cold ISSUE → sessionless; cold non-ISSUE → normal heal). \`test_sdlc_stage_marker.py\`, \`test_sdlc_session_ensure.py\`, \`test_sdlc_utils.py\`, \`test_sdlc_run_identity.py\` pass.

> Note: \`TestCLI::test_with_issue_number_outputs_json\` (a pre-existing, order/state-dependent CLI test on the PLAN-with-run-id path) fails identically on \`main\` with this change stashed — not introduced here, out of scope for this hotfix.

## Docs

\`docs/features/sdlc-run-identity-self-heal.md\` — new "Cold ISSUE-stage carve-out" section.


Closes #2191
