### PR TITLE
Fix RESTART FAILED worker word order + isolate pgrep in update-shell test (#2173)

### DIFF
--- a/docs/plans/issue-2173-restart-fail-word-order.md
+++ b/docs/plans/issue-2173-restart-fail-word-order.md
@@ -1,0 +1,43 @@
+# Plan: Align RESTART FAILED worker word order (#2173)
+
+## Root Cause
+`tests/unit/test_remote_update_shell.py::test_worker_bootstrap_and_kickstart_both_fail_reports_failure`
+asserts the substring `RESTART FAILED: worker bootstrap/kickstart failed`, but the loaded-branch
+failure line in `scripts/remote-update.sh` emitted `worker kickstart/bootstrap failed` — the two
+words transposed. The not-loaded branch (line 354) already emits `bootstrap/kickstart`, so the two
+failure lines in the same script were also inconsistent with each other. Order-independent
+semantically; the mismatch is a stale/inconsistent string, not a behavior regression.
+
+## Approach
+Standardize on the canonical order `bootstrap/kickstart` (already used by the not-loaded branch and
+the test). Change the single loaded-branch `echo` line from `kickstart/bootstrap` to
+`bootstrap/kickstart`. Both script sites and the test assertion now agree.
+
+## Success Criteria
+- The loaded-branch failure line in `scripts/remote-update.sh` reads `worker bootstrap/kickstart failed`.
+- `test_worker_bootstrap_and_kickstart_both_fail_reports_failure` passes.
+- Both worker RESTART FAILED lines use the same canonical word order.
+
+## No-Gos (Out of Scope)
+
+Nothing deferred — every relevant item is in scope for this plan.
+
+## Update System
+Changes `scripts/remote-update.sh`, which the update system runs. Only a log string is altered; no
+new dependencies, config files, or migration steps. Behavior is unchanged.
+
+## Agent Integration
+No agent integration required — this is a string alignment in a deploy shell script with no CLI or
+bridge surface.
+
+## Test Impact
+- [x] `tests/unit/test_remote_update_shell.py::test_worker_bootstrap_and_kickstart_both_fail_reports_failure`
+  — the word-order fix satisfies the RESTART FAILED assertion.
+- [x] `tests/unit/test_remote_update_shell.py` (harness) — UPDATE: add a `pgrep` stub so the #2141
+  liveness cross-check no longer leaks the host's real `python -m worker` process into the sandbox,
+  which was forcing the loaded branch and making the not-loaded worker tests non-deterministic on
+  bridge/worker machines.
+
+## Documentation
+No documentation changes needed — this is a one-word string alignment in a shell script with no
+user-facing or behavioral surface.

--- a/scripts/remote-update.sh
+++ b/scripts/remote-update.sh
@@ -309,7 +309,7 @@ PYEOF
                     else
                         # Distinct, scannable failure line + non-zero terminal exit.
                         # A swallowed `echo ERROR` here is the #1898 root-cause shape.
-                        echo "RESTART FAILED: worker kickstart/bootstrap failed for $WORKER_LABEL"
+                        echo "RESTART FAILED: worker bootstrap/kickstart failed for $WORKER_LABEL"
                         WORKER_STATE="worker restart FAILED"
                         RESTART_FAILED=1
                     fi

--- a/tests/unit/test_remote_update_shell.py
+++ b/tests/unit/test_remote_update_shell.py
@@ -73,6 +73,18 @@ fi
 exit 0
 """
 
+# The #2141 liveness cross-check shells out to `pgrep` against the real host
+# process table. On a bridge/worker machine a genuine `python -m worker` is
+# running, so the unstubbed pgrep reports WORKER_ALIVE=true and forces the
+# loaded branch regardless of the `launchctl list` stub — contaminating the
+# not-loaded worker tests. This stub shadows pgrep so the sandbox models worker
+# liveness solely through the launchctl list stub (WORKER_NOT_LISTED). Set
+# WORKER_PGREP_ALIVE to simulate a live worker the launchctl grep misses.
+PGREP_STUB = """#!/bin/bash
+if [ -n "${WORKER_PGREP_ALIVE:-}" ]; then exit 0; fi
+exit 1
+"""
+
 PYTHON_STUB = """#!/bin/bash
 echo "PY $*" >> "$CALL_LOG"
 if [ "${1:-}" = "-" ]; then cat > /dev/null; exit 0; fi
@@ -139,6 +151,9 @@ class Harness:
         launchctl = self.stub_bin / "launchctl"
         launchctl.write_text(LAUNCHCTL_STUB)
         launchctl.chmod(0o755)
+        pgrep = self.stub_bin / "pgrep"
+        pgrep.write_text(PGREP_STUB)
+        pgrep.chmod(0o755)
 
         # Worker plist template + installed copy; bridge plist optional.
         (self.proj / "com.valor.worker.plist").write_text("<plist>__PROJECT_DIR__</plist>")


### PR DESCRIPTION
Closes #2173.

## Root cause
`test_worker_bootstrap_and_kickstart_both_fail_reports_failure` asserts `RESTART FAILED: worker bootstrap/kickstart failed`, but the loaded-branch failure line in `scripts/remote-update.sh` emitted `worker kickstart/bootstrap failed` — the words transposed. The not-loaded branch (and the test) already use `bootstrap/kickstart`, so the two failure lines in the same script were also inconsistent with each other.

Additionally, the test is designed for the **not-loaded** branch, but the #2141 `pgrep` liveness cross-check shells out to the real host process table. On a bridge/worker machine a live `python -m worker` set `WORKER_ALIVE=true` and forced the **loaded** branch, so the test hit the wrong failure line (no launchd errno surfaced) and failed non-deterministically.

## Fix
- Standardize both worker `RESTART FAILED` sites in `scripts/remote-update.sh` on the canonical `bootstrap/kickstart` order.
- Add a `pgrep` stub to the test harness so worker liveness is modeled solely through the `launchctl list` stub (`WORKER_NOT_LISTED`), isolating the sandbox from the host. `WORKER_PGREP_ALIVE` remains available to simulate a live worker the grep misses.

## Tests
`scripts/pytest-clean.sh tests/unit/test_remote_update_shell.py -n0 -q` → 17 passed.