### PR TITLE
Fix duplicate Telegram delivery on null message_id (#2179)

### DIFF
--- a/bridge/telegram_relay.py
+++ b/bridge/telegram_relay.py
@@ -55,6 +55,33 @@ RELAY_FLOOD_WAIT_MAX = int(os.environ.get("RELAY_FLOOD_WAIT_MAX", "10"))
 # Known message types accepted by the relay dispatcher
 KNOWN_MESSAGE_TYPES = {None, "reaction", "custom_emoji_message"}
 
+
+class _DeliveredNoId:
+    """Sentinel: a send reached Telegram but no ``message_id`` was captured.
+
+    ``_send_queued_message`` returns ``int | None`` where ``None`` historically
+    meant *both* "send failed/dropped" and "delivered but Telethon returned no
+    id". That conflation let a delivered-but-idless ``pm_direct`` reply be
+    treated as a failure, which skipped the ``#1205-style`` dedup registration
+    (so the executor's ``response`` copy shipped too) and re-queued the message
+    (#2179). This sentinel disambiguates the delivered-without-id case so the
+    relay records the dedup draft and does not retry.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid only
+        return "DELIVERED_NO_ID"
+
+
+DELIVERED_NO_ID = _DeliveredNoId()
+
+
+def _delivered(msg_id: int | None):
+    """Wrap a delivered send's result: the id, or the delivered-no-id sentinel."""
+    return msg_id if msg_id is not None else DELIVERED_NO_ID
+
+
 # Maximum characters per chat_message_log entry (prevents Path A's multi-paragraph
 # drafter output from inflating Redis storage to ~200KB per session).
 MAX_CHAT_LOG_ENTRY_CHARS = 500
@@ -309,7 +336,7 @@ async def _maybe_send_oversized_text_as_file(
 async def _send_queued_message(
     telegram_client,
     message: dict,
-) -> int | None:
+) -> "int | None | _DeliveredNoId":
     """Send a single queued message via Telethon.
 
     Supports single files, multi-file albums (via ``file_paths`` list),
@@ -321,8 +348,11 @@ async def _send_queued_message(
             optional file_paths (list) or file_path (string), and session_id.
 
     Returns:
-        The Telegram message ID on success, None on failure.
-        For albums, returns the ID of the first message in the album.
+        The Telegram message ID when the send delivered and an id was captured;
+        ``DELIVERED_NO_ID`` when the send delivered but Telethon returned no id
+        (so callers can dedup/record without re-queuing, #2179); ``None`` when
+        the message was dropped (malformed) or the send failed with an
+        exception. For albums, returns the ID of the first message in the album.
 
     Note: this function may mutate ``message`` in-place with ``_file_sent`` and
     ``_file_msg_id`` idempotency keys after a successful file send, and with
@@ -419,7 +449,7 @@ async def _send_queued_message(
                         )
                         if message.get("cleanup_file"):
                             _safe_unlink(voice_path)
-                        return msg_id
+                        return _delivered(msg_id)
                     except FloodWaitError:
                         raise
                     except Exception as voice_err:
@@ -486,7 +516,7 @@ async def _send_queued_message(
                         reply_to=reply_to_id,
                     )
                     logger.info(f"Relay: sent follow-up text to chat {chat_id} ({len(text)} chars)")
-                return msg_id
+                return _delivered(msg_id)
             else:
                 # All files missing -- fall back to text-only
                 logger.warning(
@@ -524,7 +554,7 @@ async def _send_queued_message(
             f"Relay: sent PM message to chat {chat_id} "
             f"(reply_to={reply_to}, {len(text)} chars, msg_id={msg_id})"
         )
-        return msg_id
+        return _delivered(msg_id)
     except FloodWaitError:
         raise
     except Exception as e:
@@ -803,8 +833,17 @@ async def process_outbox(telegram_client) -> int:
                         msg_id = await _send_custom_emoji_message(telegram_client, message)
                         success = msg_id is not None
                     else:
-                        msg_id = await _send_queued_message(telegram_client, message)
-                        success = msg_id is not None
+                        send_result = await _send_queued_message(telegram_client, message)
+                        # A send that reached Telegram but returned no message id
+                        # (DELIVERED_NO_ID) is still a success: it must record the
+                        # dedup draft and must NOT be re-queued. Only a plain None
+                        # (drop/failure) is treated as failure (#2179).
+                        if send_result is DELIVERED_NO_ID:
+                            success = True
+                            msg_id = None
+                        else:
+                            msg_id = send_result
+                            success = msg_id is not None
                 except FloodWaitError as flood_err:
                     # Borrows only blocking-sleep shape from telegram_bridge.py connect-loop
                     # handler; NOT a connect-path handler; intentionally omits

--- a/docs/features/bridge-worker-architecture.md
+++ b/docs/features/bridge-worker-architecture.md
@@ -57,6 +57,16 @@ Redis outbox  → polled by the matching bridge relay
                     ↓ after successful send: appends outbound entry to
                       AgentSession.chat_message_log (three-tier session resolution:
                       owner_agent_session_id → real session_id → chat_id lookup)
+                    ↓ after successful send: registers the sent text in
+                      AgentSession.recent_sent_drafts (the #1205-style dedup guard,
+                      _record_relay_sent_draft) so the executor's follow-up
+                      "response" copy is suppressed by redundancy_filter. This
+                      fires on delivery success and is INDEPENDENT of whether a
+                      Telegram message_id was captured: _send_queued_message
+                      returns a DELIVERED_NO_ID sentinel for delivered-but-idless
+                      sends, so a null message_id no longer defeats
+                      response/pm_direct reconciliation nor re-queues the already
+                      delivered message (issue #2179).
                   bridge/email_relay.py     for email:outbox:*
                 ↓ delivers via Telethon (Telegram) or SMTP (email)
 ```

--- a/docs/plans/issue-2179-null-msgid-dedup.md
+++ b/docs/plans/issue-2179-null-msgid-dedup.md
@@ -1,0 +1,89 @@
+# Plan: Fix duplicate Telegram delivery when message_id is null (#2179)
+
+## Root cause
+
+A single logical reply reaches the "Eng: Valor" chat through two emit paths:
+the relay's `pm_direct` send (sender `system`) and the executor's `response`
+send (sender "Valor"). The relay is supposed to collapse these: after it ships
+the `pm_direct` copy it records that text in `AgentSession.recent_sent_drafts`
+via `_record_relay_sent_draft`, so `bridge.redundancy_filter` suppresses the
+executor's follow-up `send_cb`.
+
+That reconciliation is gated inside `if success:` in
+`bridge/telegram_relay.py::process_outbox`, where
+`success = (msg_id is not None)`. The send helper `_send_queued_message`
+returns `int | None`, and **`None` is overloaded to mean both "send failed" and
+"send delivered but Telegram/Telethon returned no message id"** (e.g.
+`send_markdown` returns a message object whose `.id` is `None`). When a
+`pm_direct` send delivers with a null `msg_id`:
+
+1. `success` is `False`, so `_record_relay_sent_draft` never runs — the
+   executor's `response` copy is not suppressed and ships ~2s later (the
+   observed double post).
+2. `success` is `False`, so the already-delivered message is re-queued for
+   retry, risking a second `pm_direct` copy too.
+
+Both 07-18 copies carried a null `message_id`, matching this path exactly.
+
+## Approach
+
+Decouple "delivery reached Telegram" from "message_id captured." Introduce a
+module sentinel `DELIVERED_NO_ID` returned by `_send_queued_message` on its
+delivered-but-no-id branches (voice-note, file+text, text-only). `process_outbox`
+treats the sentinel as `success=True` with `msg_id=None`, so:
+
+- `_record_relay_sent_draft` fires (dedup registered) even with a null id —
+  the executor `response` path is now suppressed → exactly one delivery.
+- The delivered message is not re-queued.
+- `_record_sent_message` and the Redis history store still correctly require a
+  real `msg_id` (they gate on `msg_id is not None`).
+
+Failure (exception) and drop (malformed / no chat_id) branches keep returning
+plain `None`, so genuine failures still retry/dead-letter unchanged.
+
+## Success Criteria
+- [ ] Root cause documented: `success = (msg_id is not None)` conflates delivery
+  failure with delivered-but-null-id.
+- [ ] A `pm_direct` reply delivered with a null `message_id` records the dedup
+  draft, so the executor `response` copy is suppressed — exactly one delivery.
+- [ ] A delivered-but-null-id message is not re-queued.
+- [ ] Genuine send failure still skips dedup and re-queues (unchanged).
+- [ ] Regression test in `tests/unit/test_bridge_relay.py` covers the null-id
+  double-send path.
+
+## No-Gos
+
+- No change to `_send_queued_message`'s failure/drop semantics (still `None`).
+- No message splitting; no LLM calls added to the relay path.
+- No change to `redundancy_filter` scoring.
+
+## Update System
+No update system changes required — this is a purely internal bridge relay fix;
+no new deps, config, or migration.
+
+## Agent Integration
+No agent integration required — bridge-internal change to an existing relay path.
+No new CLI entry point or bridge import.
+
+## Failure Path Test Strategy
+Regression test drives `process_outbox` with a `pm_direct` text message whose
+send delivers a null `message_id`, asserting the dedup draft is recorded and the
+message is not re-queued. A second case asserts a genuine send failure still
+skips dedup and re-queues.
+
+## Test Impact
+- [ ] `tests/unit/test_bridge_relay.py` — ADD: null-msg_id dedup regression cases
+  (no existing case exercises the delivered-but-null-id branch).
+
+## Rabbit Holes
+- Do not refactor `_send_queued_message`'s multi-branch return structure beyond
+  the sentinel; the drop/failure returns are intentionally `None`.
+
+## Documentation
+- [ ] Add a note to `docs/features/bridge-worker-architecture.md` in the relay
+  section stating that the `#1205-style` dedup registration
+  (`_record_relay_sent_draft`) fires on delivery success and is independent of
+  whether a Telegram `message_id` was captured, so a null `message_id` no longer
+  defeats response/pm_direct reconciliation.
+</content>
+</invoke>

--- a/tests/unit/test_bridge_relay.py
+++ b/tests/unit/test_bridge_relay.py
@@ -13,6 +13,7 @@ import pytest
 from telethon.errors import FloodWaitError
 
 from bridge.telegram_relay import (
+    DELIVERED_NO_ID,
     KNOWN_MESSAGE_TYPES,
     MAX_RELAY_RETRIES,
     OUTBOX_KEY_PATTERN,
@@ -1107,3 +1108,95 @@ class TestFloodWait:
             assert mock_client.send_message.call_count == 2
         finally:
             os.unlink(tmp_path)
+
+
+class TestNullMsgIdDedup:
+    """Regression tests for #2179: a delivered reply with a null message_id.
+
+    A ``pm_direct`` send can reach Telegram while Telethon returns no message
+    id. The relay must still (a) register the dedup draft so the executor's
+    ``response`` copy is suppressed and (b) not re-queue the already-delivered
+    message. Both 07-18 duplicate copies carried a null ``message_id``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_delivered_without_id_records_dedup_draft(self):
+        """DELIVERED_NO_ID must register recent_sent_drafts and count as sent."""
+        mock_redis = MagicMock()
+        message = json.dumps(
+            {
+                "chat_id": "12345",
+                "text": "one logical reply",
+                "session_id": "test-session",
+            }
+        )
+        mock_redis.keys.return_value = ["telegram:outbox:test-session"]
+        mock_redis.lpop.side_effect = [message, None]
+
+        with (
+            patch("bridge.telegram_relay._get_redis_connection", return_value=mock_redis),
+            patch(
+                "bridge.telegram_relay._send_queued_message", new_callable=AsyncMock
+            ) as mock_send,
+            patch("bridge.telegram_relay._record_relay_sent_draft") as mock_dedup,
+            patch("bridge.telegram_relay._record_sent_message") as mock_record,
+        ):
+            # Send delivered but Telegram returned no message id.
+            mock_send.return_value = DELIVERED_NO_ID
+            sent = await process_outbox(MagicMock())
+
+        assert sent == 1
+        # The #1205-style dedup guard MUST fire even with a null message_id so
+        # the executor's response copy is suppressed.
+        mock_dedup.assert_called_once()
+        assert mock_dedup.call_args[0][0] == "test-session"
+        assert mock_dedup.call_args[0][1] == "one logical reply"
+        # No real message id, so per-session id recording is skipped.
+        mock_record.assert_not_called()
+        # Delivered message must NOT be re-queued.
+        mock_redis.rpush.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_failure_still_skips_dedup_and_requeues(self):
+        """A genuine failure (None) must skip dedup and re-queue, unchanged."""
+        mock_redis = MagicMock()
+        message = json.dumps(
+            {
+                "chat_id": "12345",
+                "text": "failed reply",
+                "session_id": "test-session",
+            }
+        )
+        mock_redis.keys.return_value = ["telegram:outbox:test-session"]
+        mock_redis.lpop.side_effect = [message, None]
+
+        with (
+            patch("bridge.telegram_relay._get_redis_connection", return_value=mock_redis),
+            patch(
+                "bridge.telegram_relay._send_queued_message", new_callable=AsyncMock
+            ) as mock_send,
+            patch("bridge.telegram_relay._record_relay_sent_draft") as mock_dedup,
+        ):
+            mock_send.return_value = None  # Send failed / dropped.
+            sent = await process_outbox(MagicMock())
+
+        assert sent == 0
+        mock_dedup.assert_not_called()
+        mock_redis.rpush.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_send_returns_sentinel_when_telethon_gives_no_id(self):
+        """_send_queued_message returns DELIVERED_NO_ID on a null-id delivery."""
+        mock_client = MagicMock()
+        # send_markdown path returns a message object whose .id is None.
+        sent_obj = MagicMock()
+        sent_obj.id = None
+        mock_client.send_message = AsyncMock(return_value=sent_obj)
+
+        message = {
+            "chat_id": "12345",
+            "text": "reply with no id",
+            "session_id": "test-session",
+        }
+        result = await _send_queued_message(mock_client, message)
+        assert result is DELIVERED_NO_ID


### PR DESCRIPTION
Closes #2179.

## Root cause

`bridge/telegram_relay.py::process_outbox` set `success = (msg_id is not None)`,
conflating two distinct outcomes of `_send_queued_message` (`int | None`):

- **send failed / dropped** → `None`
- **send delivered but Telethon returned no id** → also `None`

When a `pm_direct` reply delivered with a null `message_id`, `success` was
`False`, so:

1. The `#1205-style` dedup registration (`_record_relay_sent_draft`) was
   skipped — the executor's `response` copy was never suppressed by
   `redundancy_filter` and shipped ~2s later (the observed double post).
2. The already-delivered message was re-queued for retry.

Both 07-18 duplicate copies carried a null `message_id`, matching this path.

## Fix

Decouple "delivery reached Telegram" from "message_id captured." A
`DELIVERED_NO_ID` sentinel is returned by `_send_queued_message` on its
delivered-but-no-id branches (voice-note, file+text, text-only). `process_outbox`
treats the sentinel as `success=True` with `msg_id=None`, so:

- `_record_relay_sent_draft` fires even with a null id → executor `response`
  copy is suppressed → exactly one delivery.
- The delivered message is not re-queued.
- `_record_sent_message` and the Redis history store still require a real
  `message_id` (unchanged).

Failure (exception) and drop (malformed / no chat_id) paths keep returning plain
`None`, so genuine failures still retry / dead-letter unchanged.

## Tests

`tests/unit/test_bridge_relay.py::TestNullMsgIdDedup`:
- `test_delivered_without_id_records_dedup_draft` — DELIVERED_NO_ID registers
  the dedup draft, counts as sent, and does not re-queue.
- `test_send_failure_still_skips_dedup_and_requeues` — genuine `None` still
  skips dedup and re-queues.
- `test_send_returns_sentinel_when_telethon_gives_no_id` — `_send_queued_message`
  returns the sentinel when the sent message has no `.id`.

Scoped run: `tests/unit/test_bridge_relay.py` (51 passed) plus adjacent relay
suites (voice-note, length-guard, chat-log — 19 passed).

## Docs

Updated `docs/features/bridge-worker-architecture.md` relay flow to note dedup
registration is keyed on delivery success, independent of message_id capture.