### PR TITLE
Clear worker-down (⚠) reaction on worker recovery (#2178)

### DIFF
--- a/agent/session_pickup.py
+++ b/agent/session_pickup.py
@@ -17,6 +17,24 @@ _PRIORITY_RANK = {"urgent": 0, "high": 1, "normal": 2, "low": 3}
 _POP_LOCK_TTL_SECONDS = 5  # Long enough to cover transition_status write; short enough to self-heal
 
 
+def _clear_worker_down_reactions(session: AgentSession) -> None:
+    """Replace any lingering worker-down (⚠) reactions for a picked-up session.
+
+    Best-effort reach-back (#2178): the worker has no Telethon client, so it
+    queues replacement reactions on the outbox for the bridge relay to apply.
+    Never raises — reaction cleanup must not block session pickup.
+    """
+    session_id = getattr(session, "session_id", None)
+    if not session_id:
+        return
+    try:
+        from agent.worker_down_reactions import clear_worker_down_reactions  # noqa: PLC0415
+
+        clear_worker_down_reactions(session_id)
+    except Exception as e:  # noqa: BLE001 — cleanup must never crash pickup
+        logger.debug("worker-down reaction cleanup failed (non-fatal): %s", e)
+
+
 def is_scheduled_eligible(session: AgentSession, now: datetime | None = None) -> bool:
     """True when a session's ``scheduled_at`` (if any) is due (<= now).
 
@@ -488,6 +506,11 @@ async def _pop_agent_session(
     finally:
         _release_pop_lock(worker_key)
 
+    # Worker recovered and is now draining this session: replace any lingering
+    # worker-down (⚠) reaction on the originating message(s) with the normal
+    # processing reaction, via the outbox reach-back (#2178). Fail-silent.
+    _clear_worker_down_reactions(chosen)
+
     # Inject resume hydration context BEFORE steering messages so the agent
     # orients itself on prior work before processing new instructions (#874).
     await _maybe_inject_resume_hydration(chosen, worker_key)
@@ -634,6 +657,10 @@ async def _pop_agent_session_with_fallback(
         # Ownership stamp (#2148) — same contract as the primary pickup path.
         chosen.worker_pid = os.getpid()
         transition_status(chosen, "running", reason="worker picked up session (sync fallback)")
+
+        # Replace any lingering worker-down (⚠) reaction now the worker is
+        # draining this session (#2178). Fail-silent.
+        _clear_worker_down_reactions(chosen)
 
         # Inject resume hydration context BEFORE steering messages (#874)
         await _maybe_inject_resume_hydration(chosen, worker_key)

--- a/agent/worker_down_reactions.py
+++ b/agent/worker_down_reactions.py
@@ -1,0 +1,155 @@
+"""Track and clear the worker-down (⚠) reaction across the worker→bridge boundary.
+
+When the bridge reacts with the worker-down warning (⚠) on a message that arrived
+while no worker was alive (issue #1312), that reaction must not linger forever.
+Once the recovering worker drains the enqueued session it should reach back to the
+bridge and replace the stale ⚠ with the normal "processing" reaction, so the user
+sees the request move from *paused* to *being worked on*.
+
+Two facts shape the design (issue #2178):
+
+- The bridge process owns the Telethon client; the worker process does not. Only
+  the bridge can mutate a Telegram reaction. The worker therefore reaches back via
+  the same ``telegram:outbox:{session_id}`` relay it already uses for output
+  delivery and RTR-suppress reactions (``agent/output_handler.py``, drained by
+  ``bridge/telegram_relay.py``). No new IPC channel or listener is introduced.
+
+- The relay's ``_send_queued_reaction`` drops payloads whose ``emoji`` field is
+  falsy, so an empty-reaction "clear" cannot traverse it. Issue #2178 sanctions
+  *replacing* the warning with a normal processing reaction; a single reaction
+  from the bot account overwrites the prior one on the same message, so writing
+  the processing emoji makes the ⚠ disappear.
+
+The tracking store lives in ephemeral, non-Popoto Redis keys
+(``bridge:worker_down_reactions:{session_id}``), the same precedent as
+``worker:registered_pid:*`` and ``telegram:outbox:*`` — so the shared Redis client
+is used directly rather than an ORM record.
+
+All operations are fail-silent: neither recording a warning nor clearing one may
+crash the bridge ingestion path or the worker session-pickup path.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Redis key prefix for the per-session list of warned messages. Ephemeral bridge
+# infra key (not Popoto-managed) — direct shared-client access, same as
+# ``worker:registered_pid:*``.
+WORKER_DOWN_REACTIONS_KEY_PREFIX = "bridge:worker_down_reactions:"
+
+# TTL (seconds) on the tracking list. Provisional/tunable: a warned message that
+# is never drained (worker stays dead) should not accumulate a Redis key
+# indefinitely. One hour matches ``TelegramRelayOutputHandler.OUTBOX_TTL`` so the
+# tracking record and the outbox it feeds age out on the same clock.
+WORKER_DOWN_REACTIONS_TTL_S = 3600
+
+# Outbox key the bridge relay drains — same format the worker uses for output.
+_OUTBOX_KEY_PREFIX = "telegram:outbox:"
+
+
+def _redis():
+    """Return the shared popoto Redis connection (same client as the rest of agent/)."""
+    from popoto.redis_db import POPOTO_REDIS_DB  # noqa: PLC0415
+
+    return POPOTO_REDIS_DB
+
+
+def _recovered_emoji() -> str:
+    """The reaction that replaces the stale ⚠ on worker recovery.
+
+    ``REACTION_PROCESSING`` (✍, "actively composing a reply") is accurate to the
+    state the message enters the instant the worker picks it up. Imported lazily
+    to avoid pulling ``bridge.response`` into every ``agent`` import.
+    """
+    from bridge.response import REACTION_PROCESSING  # noqa: PLC0415
+
+    return REACTION_PROCESSING
+
+
+def _tracking_key(session_id: str) -> str:
+    return f"{WORKER_DOWN_REACTIONS_KEY_PREFIX}{session_id}"
+
+
+def record_worker_down_reaction(session_id: str, chat_id: int | str, message_id: int) -> bool:
+    """Record that ``message_id`` in ``chat_id`` got a worker-down (⚠) reaction.
+
+    Called by the bridge at ⚠-set time (issue #1312 ingestion path), keyed by the
+    session id the message was enqueued under, so the worker can later clear it.
+
+    Returns ``True`` on a successful write, ``False`` if anything went wrong
+    (Redis down, bad inputs) — recording is best-effort and never raises.
+    """
+    if not session_id or chat_id in (None, "") or message_id is None:
+        return False
+    try:
+        r = _redis()
+        key = _tracking_key(session_id)
+        r.rpush(key, json.dumps({"chat_id": str(chat_id), "message_id": int(message_id)}))
+        r.expire(key, WORKER_DOWN_REACTIONS_TTL_S)
+        return True
+    except Exception as e:  # noqa: BLE001 — recording must never crash ingestion
+        logger.debug("record_worker_down_reaction failed (non-fatal): %s", e)
+        return False
+
+
+def clear_worker_down_reactions(session_id: str) -> int:
+    """Replace any tracked worker-down (⚠) reactions for ``session_id``.
+
+    Called by the worker the moment it drains the session (pending→running). For
+    each warned message it queues a replacement reaction (the processing emoji) on
+    ``telegram:outbox:{session_id}`` — which the bridge relay drains and applies,
+    overwriting the ⚠ — then deletes the tracking key.
+
+    Returns the number of replacement reactions queued. Fail-silent: returns 0 on
+    any error and never raises, so session pickup is never blocked.
+    """
+    if not session_id:
+        return 0
+    try:
+        r = _redis()
+        key = _tracking_key(session_id)
+        raw_entries = r.lrange(key, 0, -1)
+    except Exception as e:  # noqa: BLE001
+        logger.debug("clear_worker_down_reactions read failed (non-fatal): %s", e)
+        return 0
+
+    if not raw_entries:
+        return 0
+
+    try:
+        from agent.output_handler import TelegramRelayOutputHandler  # noqa: PLC0415
+
+        emoji = _recovered_emoji()
+        outbox_key = f"{_OUTBOX_KEY_PREFIX}{session_id}"
+        queued = 0
+        for raw in raw_entries:
+            try:
+                entry = json.loads(raw)
+                chat_id = entry["chat_id"]
+                message_id = int(entry["message_id"])
+            except (ValueError, TypeError, KeyError) as parse_err:
+                logger.debug("skipping malformed worker-down entry %r: %s", raw, parse_err)
+                continue
+            payload = TelegramRelayOutputHandler._build_reaction_payload(
+                str(chat_id), message_id, emoji, session_id
+            )
+            r.rpush(outbox_key, json.dumps(payload))
+            queued += 1
+
+        if queued:
+            r.expire(outbox_key, WORKER_DOWN_REACTIONS_TTL_S)
+        r.delete(key)
+        if queued:
+            logger.info(
+                "Queued %d worker-recovered reaction(s) for session %s (replacing ⚠)",
+                queued,
+                session_id,
+            )
+        return queued
+    except Exception as e:  # noqa: BLE001 — must never crash session pickup
+        logger.debug("clear_worker_down_reactions write failed (non-fatal): %s", e)
+        return 0

--- a/docs/features/bridge-worker-architecture.md
+++ b/docs/features/bridge-worker-architecture.md
@@ -100,6 +100,20 @@ When a project does have an explicit `EmailOutputHandler` registered (via `regis
 - **Fallback**: If Redis is down, the output is still captured on disk (though not delivered to Telegram).
 - **Dev environments**: On machines without a bridge, the file log is the only record.
 
+### Worker-Down Reaction Lifecycle (issue #2178)
+
+The same `telegram:outbox:{session_id}` reach-back also clears the worker-down
+warning reaction. When a message arrives while no worker is alive, the bridge
+reacts with ⚠ (issue #1312) and records the warned `(chat_id, message_id)` under
+`bridge:worker_down_reactions:{session_id}` via
+`agent.worker_down_reactions.record_worker_down_reaction`. When the recovering
+worker drains the session (pending→running in `agent/session_pickup.py`),
+`clear_worker_down_reactions` reads those entries and queues a **replacement**
+reaction (the normal processing emoji ✍) on `telegram:outbox:{session_id}` for
+each, then deletes the tracking key. The bridge relay applies the replacement,
+so the stale ⚠ disappears. Replacement (not empty-clear) is used because the
+relay drops reaction payloads with a falsy `emoji`; both writes are fail-silent.
+
 ## Bridge Responsibilities (only)
 
 1. Authenticate with Telegram and receive messages

--- a/docs/plans/bridge-worker-liveness-reaction.md
+++ b/docs/plans/bridge-worker-liveness-reaction.md
@@ -351,7 +351,10 @@ none exists today), so no deletions or rewrites of unrelated suites are required
   stretch goal. It requires the worker (or watchdog) to track which messages got a
   warning and reach back to un-react. Out of scope for v1 — a follow-up message from
   the user gets a normal reaction once the worker is back. Do NOT build reaction
-  reconciliation here.
+  reconciliation here. (Shipped separately: see
+  `docs/plans/clear-worker-down-reaction.md` / issue #2178, which owns the
+  record→clear lifecycle — the ⚠-set site here calls
+  `agent.worker_down_reactions.record_worker_down_reaction`.)
 - **Per-project liveness.** Tempting to mirror the issue's `project_key` framing,
   but spike-1 proved liveness is per-process. Do not introduce a per-project loop
   registry — it does not exist and would be a fabricated signal.

--- a/docs/plans/clear-worker-down-reaction.md
+++ b/docs/plans/clear-worker-down-reaction.md
@@ -1,0 +1,120 @@
+---
+status: Ready
+type: bug
+appetite: Small
+owner: Valor Engels
+created: 2026-07-20
+tracking: https://github.com/tomcounsell/ai/issues/2178
+---
+
+# Clear the Worker-Down (⚠) Reaction When the Worker Recovers
+
+## Problem
+
+Stretch follow-up to #1312. When the bridge reacts with the worker-down warning
+(⚠) on a message that arrived while no worker was alive, that reaction lingers
+forever — even after the worker recovers and drains the session. The user is
+left staring at a stale ⚠ on a request that is now actually being processed.
+
+Clearing the reaction requires two capabilities #1312 deliberately deferred:
+
+1. **Per-message tracking** — the bridge must remember which (chat_id, message_id)
+   pairs got a ⚠ so they can be un-reacted later.
+2. **A worker→bridge reach-back** — the recovering worker has no Telethon client;
+   only the bridge can mutate a Telegram reaction. The worker must signal the
+   bridge to replace the stale ⚠.
+
+## Root Cause
+
+The reaction is applied by the bridge process at message-ingestion time, but the
+recovery event (worker draining the session) happens in a *separate* worker
+process. There is no shared record of which messages were warned, and no path
+for the worker to reach back into the bridge's Telethon client.
+
+## Approach
+
+Reuse the existing `telegram:outbox:{session_id}` relay — the same Redis-mediated
+reach-back the worker already uses to deliver text and RTR-suppress reactions
+(`agent/output_handler.py`, drained by `bridge/telegram_relay.py`). No new
+listener or IPC channel is introduced.
+
+New module `agent/worker_down_reactions.py`:
+
+- `record_worker_down_reaction(session_id, chat_id, message_id)` — the bridge (via
+  #1312's ⚠-set site) records the warned message under the enqueued session's id
+  in a short-TTL Redis list `bridge:worker_down_reactions:{session_id}`. These are
+  ephemeral bridge-infra keys, not Popoto-managed records (same precedent as
+  `worker:registered_pid:*` and `telegram:outbox:*`), so the shared Redis client
+  is used directly.
+- `clear_worker_down_reactions(session_id)` — when the worker drains the session
+  (pending→running in `agent/session_pickup.py`), it reads the tracked messages
+  and writes a **replacement** reaction (the normal "processing" emoji ✍) to
+  `telegram:outbox:{session_id}` for each, then deletes the tracking key. The
+  bridge relay picks these up and replaces the ⚠, making it disappear.
+
+**Why replace, not clear-to-empty:** the relay's `_send_queued_reaction` drops
+payloads with a falsy `emoji` field (`if not chat_id or not reply_to or not emoji`),
+so an empty-reaction payload can't traverse the existing relay. The issue
+sanctions "clear (or replace with a normal processing reaction)"; replacing with
+✍ (REACTION_PROCESSING — "actively composing") is both accurate to the new state
+and compatible with the relay unchanged. A single reaction from the bot account
+replaces the prior one on the same message, so ✍ overwrites ⚠.
+
+Wire `clear_worker_down_reactions(chosen.session_id)` into both pickup paths in
+`agent/session_pickup.py` (`_pop_agent_session` and its sync fallback), right
+after the `transition_status(..., "running")` call. Fail-silent — a reaction
+cleanup must never crash session pickup.
+
+## Success Criteria
+
+- `record_worker_down_reaction` persists a warned (chat_id, message_id) under
+  `bridge:worker_down_reactions:{session_id}` with a TTL.
+- On worker pickup (pending→running), `clear_worker_down_reactions` writes one
+  replacement-reaction payload per warned message to `telegram:outbox:{session_id}`
+  and deletes the tracking key.
+- Clearing an unknown/empty session is a no-op that returns 0 and never raises.
+- Session pickup never crashes on a reaction-cleanup failure (fail-silent).
+- Scoped unit tests pass; `ruff check`/`format` clean on touched files.
+
+## No-Gos
+
+- No new bridge listener, pub/sub channel, or watchdog hook — the outbox relay is
+  the sole reach-back.
+- No relay schema change — replacement reaction rides the existing payload shape.
+- No Popoto model for the tracking store — ephemeral infra keys only.
+- Do not implement #1312's ⚠-set path here; this PR provides the `record_` hook
+  #1312 will call and owns the clear/replace lifecycle.
+
+## Update System
+No update system changes required — this feature is purely internal (Redis keys +
+worker pickup wiring); no new dependencies, config, or migration steps.
+
+## Agent Integration
+No agent integration required — this is a bridge/worker-internal reach-back. No
+new CLI entry point and no new bridge import surface; the worker calls the clear
+function during its existing session-pickup path.
+
+## Failure Path Test Strategy
+Unit test the record→clear round-trip against Redis: record two warned messages,
+call clear, assert the tracking key is gone and two replacement-reaction payloads
+land on `telegram:outbox:{session_id}` with the processing emoji. Also assert
+clear on an unknown session is a no-op returning 0.
+
+## Test Impact
+No existing tests affected — this is greenfield behavior (a new module and two
+additive call sites in the pickup path); no prior test asserts reaction-clearing
+on worker recovery.
+
+## Rabbit Holes
+- Do not try to make the relay support empty-reaction clears — replacement is the
+  chosen, relay-compatible outcome.
+- Do not attempt to un-react from the worker directly — the worker has no Telethon
+  client; the outbox reach-back is the only sanctioned path.
+
+## Documentation
+- [ ] Add a "Worker-down reaction lifecycle" note to
+      `docs/features/bridge-worker-architecture.md` describing the record→clear
+      reach-back (bridge records the ⚠, worker replaces it via the outbox relay on
+      pickup).
+- [ ] Reference this plan from `docs/plans/bridge-worker-liveness-reaction.md`'s
+      stretch note so the #1312 plan points at the shipped clear path.

--- a/tests/unit/test_worker_down_reactions.py
+++ b/tests/unit/test_worker_down_reactions.py
@@ -1,0 +1,107 @@
+"""Unit tests for the worker-down (⚠) reaction record→clear lifecycle (issue #2178).
+
+The bridge records which messages got a worker-down warning; when the worker
+recovers and drains the session it replaces the ⚠ with the normal processing
+reaction via the ``telegram:outbox:{session_id}`` relay reach-back.
+"""
+
+import json
+
+import pytest
+
+import agent.worker_down_reactions as wdr
+from agent.worker_down_reactions import (
+    WORKER_DOWN_REACTIONS_KEY_PREFIX,
+    clear_worker_down_reactions,
+    record_worker_down_reaction,
+)
+
+
+class _FakeRedis:
+    """Minimal in-memory Redis stand-in for list ops used by the module."""
+
+    def __init__(self):
+        self.lists: dict[str, list[str]] = {}
+        self.expires: dict[str, int] = {}
+
+    def rpush(self, key, value):
+        self.lists.setdefault(key, []).append(value)
+        return len(self.lists[key])
+
+    def lrange(self, key, start, end):
+        items = self.lists.get(key, [])
+        if end == -1:
+            return items[start:]
+        return items[start : end + 1]
+
+    def expire(self, key, ttl):
+        self.expires[key] = ttl
+        return True
+
+    def delete(self, key):
+        existed = key in self.lists
+        self.lists.pop(key, None)
+        self.expires.pop(key, None)
+        return 1 if existed else 0
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    fake = _FakeRedis()
+    monkeypatch.setattr(wdr, "_redis", lambda: fake)
+    # Pin the recovery emoji so the test does not depend on bridge.response import.
+    monkeypatch.setattr(wdr, "_recovered_emoji", lambda: "✍")
+    return fake
+
+
+def test_record_then_clear_round_trip(fake_redis):
+    session_id = "tg_test_-100_42"
+    tracking_key = f"{WORKER_DOWN_REACTIONS_KEY_PREFIX}{session_id}"
+
+    assert record_worker_down_reaction(session_id, chat_id=-100, message_id=11) is True
+    assert record_worker_down_reaction(session_id, chat_id=-100, message_id=22) is True
+
+    # Tracking list holds both warned messages with a TTL.
+    assert len(fake_redis.lists[tracking_key]) == 2
+    assert tracking_key in fake_redis.expires
+
+    queued = clear_worker_down_reactions(session_id)
+    assert queued == 2
+
+    # Tracking key is gone; two replacement reactions landed on the outbox.
+    assert tracking_key not in fake_redis.lists
+    outbox_key = f"telegram:outbox:{session_id}"
+    payloads = [json.loads(p) for p in fake_redis.lists[outbox_key]]
+    assert len(payloads) == 2
+    for payload, msg_id in zip(payloads, (11, 22), strict=True):
+        assert payload["type"] == "reaction"
+        assert payload["chat_id"] == "-100"
+        assert payload["reply_to"] == msg_id
+        assert payload["emoji"] == "✍"
+        assert payload["session_id"] == session_id
+
+
+def test_clear_unknown_session_is_noop(fake_redis):
+    assert clear_worker_down_reactions("tg_never_recorded") == 0
+    assert fake_redis.lists == {}
+
+
+def test_clear_empty_session_id_is_noop(fake_redis):
+    assert clear_worker_down_reactions("") == 0
+
+
+def test_record_rejects_bad_inputs(fake_redis):
+    assert record_worker_down_reaction("", chat_id=1, message_id=1) is False
+    assert record_worker_down_reaction("sid", chat_id=None, message_id=1) is False
+    assert record_worker_down_reaction("sid", chat_id=1, message_id=None) is False
+    assert fake_redis.lists == {}
+
+
+def test_replacement_emoji_is_non_falsy_for_relay(fake_redis):
+    """The relay drops reaction payloads with a falsy emoji; the replacement
+    must always be a non-empty glyph so the ⚠ actually gets overwritten."""
+    session_id = "tg_relay_guard_1"
+    record_worker_down_reaction(session_id, chat_id=5, message_id=7)
+    clear_worker_down_reactions(session_id)
+    payload = json.loads(fake_redis.lists[f"telegram:outbox:{session_id}"][0])
+    assert payload["emoji"]  # non-empty — passes the relay's `not emoji` guard


### PR DESCRIPTION
Closes #2178.

## Problem
Stretch follow-up to #1312. Once the bridge applies a ⚠ warning on messages that arrive while the worker is dead, the warning lingered forever — even after the worker recovered and drained the session.

## Approach
Reuses the existing `telegram:outbox:{session_id}` relay (the worker→bridge reach-back already used for output delivery) — no new listener or IPC.

- **New module `agent/worker_down_reactions.py`:**
  - `record_worker_down_reaction(session_id, chat_id, message_id)` — the bridge (#1312 ⚠-set site) records the warned message under `bridge:worker_down_reactions:{session_id}` (ephemeral non-Popoto key, shared Redis client, 1h TTL).
  - `clear_worker_down_reactions(session_id)` — on worker pickup, reads the tracked messages, writes a **replacement** reaction (processing emoji ✍) to the outbox for each, then deletes the tracking key.
- **`agent/session_pickup.py`:** both pickup paths call the clear right after `transition_status(..., "running")`.

**Why replace, not clear-to-empty:** the relay's `_send_queued_reaction` drops payloads with a falsy `emoji`, so an empty-clear can't traverse it. The issue sanctions "clear (or replace with a normal processing reaction)"; a single bot reaction overwrites the prior ⚠. Both writes are fail-silent so neither ingestion nor pickup can crash.

This PR owns the clear/replace lifecycle and provides the `record_` hook #1312 will call; it does not implement #1312's ⚠-set path.

## Tests
`tests/unit/test_worker_down_reactions.py` — record→clear round-trip (tracking key deleted, replacement payloads on outbox), unknown/empty-session no-ops, bad-input rejection, relay non-falsy-emoji guard. 5 passed.

## Docs
- `docs/plans/clear-worker-down-reaction.md` (plan)
- `docs/features/bridge-worker-architecture.md` (lifecycle note)
- cross-reference from `docs/plans/bridge-worker-liveness-reaction.md` (#1312)