### PR TITLE
fix(#2180): serial re-confirmation gate for nightly regression detector

### DIFF
--- a/docs/plans/nightly-serial-reconfirm.md
+++ b/docs/plans/nightly-serial-reconfirm.md
@@ -1,0 +1,91 @@
+# Nightly detector: serial re-confirmation gate (#2180)
+
+## Root cause
+
+`scripts/nightly_regression_tests.py` runs `pytest tests/unit/ -n auto --json-report`
+and alerts whenever the **failure count** rises above the prior run's baseline. `-n auto`
+is pytest-xdist parallel execution. The classic xdist failure mode — tests that pass
+serially but collide under parallel workers on shared state (Redis keys, temp files,
+fixture ordering) — produces a **shifting set** of failures that the count-based detector
+cannot distinguish from a genuine regression.
+
+The 07-19 +15/21 spike re-appeared right after a 07-17 "false alarm" fix precisely because
+the detector had no way to tell a parallelism artifact from a real regression: it only ever
+looked at a scalar count. A count comparison is structurally blind to *which* tests fail, so
+a fix that suppressed one symptom left the underlying ambiguity in place.
+
+## Success Criteria
+
+- The nightly detector classifies each parallel failure as a confirmed regression or an
+  xdist-parallelism artifact via a serial `-n0` re-run of the failing node IDs.
+- Regression alerts fire only for newly-confirmed serial failures; parallel-only artifacts
+  are logged, never alerted.
+- The state file persists the confirmed failing set so future runs diff sets, not counts.
+- New unit tests cover node-ID extraction, serial classification, and set-based new-failure
+  detection; scoped tests pass.
+
+## Approach
+
+Add a **serial re-confirmation gate** and make the baseline **set-based** instead of
+count-based:
+
+1. Run `pytest tests/unit/ -n auto` as before, but capture the **set of failing node IDs**
+   (not just the count) from the JSON report.
+2. If any tests failed, re-run **only those node IDs** serially (`-n0`). Tests that fail in
+   parallel but pass serially are classified as **xdist-parallelism artifacts** (shared-state
+   collisions); tests that fail in both are **confirmed regressions**.
+3. Persist the confirmed failing set in the state file. A regression alert fires only for
+   **newly-confirmed** failures (confirmed set minus the prior confirmed set) — a shifting
+   flaky set no longer trips the alert.
+4. Artifacts are logged (with their node IDs) but never sent as a regression alert, so
+   parallel-execution noise stops generating spurious pages.
+
+The serial re-run targets only the already-failing node IDs, so it is fast and respects the
+narrow-scope test rule — it never re-runs the whole suite.
+
+## No-Gos
+
+- Do not remove `-n auto` from the primary run — parallel execution is the point of the
+  nightly gate (speed + catching real parallel-safety regressions).
+- Do not run the full suite serially as the re-confirmation step; only re-run the failing
+  node IDs.
+- Do not touch issue #2173's `test_remote_update_shell.py` assertion (separate lane).
+
+## Update System
+
+No update system changes required — `scripts/nightly_regression_tests.py` is invoked by an
+already-installed launchd schedule (`install_nightly_tests.sh`); its CLI surface and state
+file location are unchanged.
+
+## Agent Integration
+
+No agent integration required — this is a standalone maintenance script run by launchd, not a
+bridge-reachable capability. No new CLI entry point in `pyproject.toml`.
+
+## Failure Path Test Strategy
+
+- Re-confirmation subprocess failure (serial re-run itself errors / can't collect): fail
+  safe by treating all parallel failures as confirmed, so a genuine regression is never
+  silently hidden.
+- Missing/old-format state file (no `failing_tests` key): fall back to count-delta so first
+  run after deploy still behaves sanely.
+
+## Test Impact
+- [ ] `tests/unit/test_nightly_regression_tests.py` — UPDATE: add coverage for
+  `extract_failing_node_ids`, serial classification (confirmed vs artifact), and set-based
+  new-failure detection. Existing `TestDeltaLogic`/`TestRunTtftGate` cases remain valid.
+
+## Rabbit Holes
+
+- Do not attempt to reproduce the exact 07-19 environment; the durable fix is making the
+  detector self-classify regardless of which tests happen to collide on a given night.
+- Do not try to individually fix every parallel-unsafe unit test in this issue; the gate
+  neutralizes their alert-noise. Specific collisions can be filed separately.
+
+## Documentation
+- [ ] Update the module docstring in `scripts/nightly_regression_tests.py` to describe the
+  serial re-confirmation gate, the confirmed/artifact classification, and why the state file
+  now stores a failing-test set instead of a scalar count.
+- [ ] Update the `python scripts/nightly_regression_tests.py` row context in `CLAUDE.md` /
+  the nightly-tests feature note is not required; the docstring is the canonical reference
+  for this internal script. No other docs are affected.

--- a/scripts/nightly_regression_tests.py
+++ b/scripts/nightly_regression_tests.py
@@ -4,6 +4,22 @@
 Runs pytest tests/unit/ -n auto with JSON report, compares against prior run,
 and sends a Telegram alert only when new failures appear. Clean runs are silent.
 
+Serial re-confirmation gate (issue #2180)
+-----------------------------------------
+`-n auto` is pytest-xdist parallel execution. The classic xdist failure mode —
+tests that pass serially but collide under parallel workers on shared state
+(Redis keys, temp files, fixture ordering) — produces a *shifting set* of
+failures a count-based detector cannot distinguish from a real regression.
+
+To disambiguate, after the parallel run we re-run **only the failing node IDs**
+serially (`-n0`). Tests that fail in parallel but pass serially are classified as
+xdist-parallelism *artifacts*; tests that fail in both are *confirmed*
+regressions. The state file persists the confirmed failing **set** (not a scalar
+count), so a regression alert fires only for *newly-confirmed* serial failures.
+Artifacts are logged but never alerted, killing the parallel-execution alert
+noise. The serial re-run targets only the already-failing node IDs, so it stays
+fast and never re-runs the whole suite.
+
 A post-run TTFT gate (issue #1227) reports cold-start latency regressions as
 Telegram alerts without changing the exit code.
 
@@ -28,8 +44,13 @@ LOG_FILE = PROJECT_DIR / "logs" / "nightly_tests.log"
 TELEGRAM_CHAT = "Eng: Valor"
 TELEGRAM_BIN = PROJECT_DIR / ".venv" / "bin" / "valor-telegram"
 PYTEST_JSON_TMP = "/tmp/nightly_pytest_report.json"
+PYTEST_SERIAL_JSON_TMP = "/tmp/nightly_pytest_serial_report.json"
 
 PYTEST_TIMEOUT_SECONDS = 1800  # 30 minutes max
+# Serial re-confirmation only re-runs the already-failing node IDs, so it is far
+# cheaper than the full parallel run. Grain-of-salt: provisional, env-tunable if
+# the confirmed failing set ever grows large enough to matter.
+PYTEST_RECONFIRM_TIMEOUT_SECONDS = 900  # 15 minutes max
 
 # TTFT regression gate (issue #1227).
 # Plan target: production 90s, nightly CI 120s (allowing slack for run-to-run noise).
@@ -70,8 +91,27 @@ def save_last_run(state: dict, run_file: Path | None = None) -> None:
     target.write_text(json.dumps(state, indent=2) + "\n")
 
 
+def extract_failing_node_ids(report: dict) -> list[str]:
+    """Return the node IDs of tests that failed or errored in a JSON report.
+
+    De-duplicated and stably sorted so downstream set math and alert text are
+    deterministic.
+    """
+    failing: set[str] = set()
+    for test in report.get("tests", []):
+        if test.get("outcome") in ("failed", "error"):
+            nodeid = test.get("nodeid")
+            if nodeid:
+                failing.add(nodeid)
+    return sorted(failing)
+
+
 def run_tests() -> dict:
-    """Run pytest tests/unit/ with --json-report. Returns summary dict."""
+    """Run pytest tests/unit/ -n auto with --json-report.
+
+    Returns a summary dict including ``failing_parallel`` — the list of node IDs
+    that failed under parallel execution — which the caller re-confirms serially.
+    """
     log("Starting pytest tests/unit/ -n auto --json-report ...")
     try:
         result = subprocess.run(
@@ -111,8 +151,56 @@ def run_tests() -> dict:
         "error": summary.get("error", 0),
         "skipped": summary.get("skipped", 0),
         "total": summary.get("total", 0),
+        "failing_parallel": extract_failing_node_ids(report),
         "run_at": datetime.now(UTC).isoformat(),
     }
+
+
+def reconfirm_serial(node_ids: list[str]) -> tuple[list[str], list[str]]:
+    """Re-run the given node IDs serially (`-n0`) to disambiguate xdist noise.
+
+    Returns ``(confirmed, artifacts)``:
+      - ``confirmed`` — node IDs that failed again serially (real regressions).
+      - ``artifacts`` — node IDs that passed serially (xdist-parallelism
+        collisions on shared state).
+
+    Fail-safe: if the serial re-run cannot be executed or parsed, every input
+    node ID is treated as *confirmed* so a genuine regression is never silently
+    hidden behind an infrastructure hiccup.
+    """
+    if not node_ids:
+        return [], []
+
+    ordered = sorted(set(node_ids))
+    log(f"Serial re-confirmation of {len(ordered)} failing node ID(s) with -n0 ...")
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                *ordered,
+                "-n0",
+                "--tb=no",
+                "-q",
+                "--json-report",
+                f"--json-report-file={PYTEST_SERIAL_JSON_TMP}",
+            ],
+            cwd=PROJECT_DIR,
+            capture_output=True,
+            text=True,
+            timeout=PYTEST_RECONFIRM_TIMEOUT_SECONDS,
+        )
+        log(f"serial re-confirmation exit code: {result.returncode}")
+        report = json.loads(Path(PYTEST_SERIAL_JSON_TMP).read_text())
+    except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        log(f"WARNING: serial re-confirmation failed ({exc}); treating all as confirmed")
+        return ordered, []
+
+    serial_failing = set(extract_failing_node_ids(report))
+    confirmed = [n for n in ordered if n in serial_failing]
+    artifacts = [n for n in ordered if n not in serial_failing]
+    return confirmed, artifacts
 
 
 def send_telegram(msg: str, dry_run: bool = False) -> None:
@@ -225,6 +313,17 @@ def run_ttft_gate(
     )
 
 
+def compute_new_failures(prev: dict, confirmed_failing: list[str]) -> list[str]:
+    """Node IDs newly confirmed as failing vs. the prior run's confirmed set.
+
+    Set-based so a *shifting* flaky set (same count, different tests) does not
+    read as a regression, and a genuinely new failure does — even when the total
+    count is flat.
+    """
+    prev_failing = set(prev.get("failing_tests", []))
+    return sorted(n for n in confirmed_failing if n not in prev_failing)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Nightly regression test runner")
     parser.add_argument("--dry-run", action="store_true", help="Preview without sending Telegram")
@@ -250,27 +349,60 @@ def main() -> int:
         log(f"FATAL: Could not parse test results: {exc}")
         return 1
 
+    parallel_failing = current.get("failing_parallel", [])
     log(
-        f"Results: passed={current['passed']}, failed={current['failed']}, "
-        f"error={current['error']}, total={current['total']}"
+        f"Results (parallel -n auto): passed={current['passed']}, "
+        f"failed={current['failed']}, error={current['error']}, total={current['total']}"
     )
 
-    # Compute delta
-    delta = current["failed"] - prev.get("failed", 0)
-    new_errors = current.get("error", 0)
-    log(f"Delta: {delta:+d} new failures, {new_errors} collection errors")
+    # Serial re-confirmation gate (issue #2180): re-run only the failing node IDs
+    # serially to separate real regressions from xdist-parallelism artifacts.
+    confirmed_failing, artifacts = reconfirm_serial(parallel_failing)
+    if parallel_failing:
+        log(
+            f"Re-confirmation: {len(confirmed_failing)} confirmed, "
+            f"{len(artifacts)} xdist artifact(s)"
+        )
+        if artifacts:
+            log(
+                "xdist-parallelism artifacts (passed serially, not alerted): "
+                + ", ".join(artifacts)
+            )
+        if confirmed_failing:
+            log("Confirmed serial failures: " + ", ".join(confirmed_failing))
 
-    # Alert logic
+    # The confirmed set is the authoritative failure signal; keep the raw parallel
+    # count for observability.
+    current["failed_parallel"] = current["failed"]
+    current["failed"] = len(confirmed_failing)
+    current["failing_tests"] = confirmed_failing
+    current["artifact_tests"] = artifacts
+    # Drop the transient parallel list from persisted state — the confirmed set is
+    # what future runs diff against.
+    current.pop("failing_parallel", None)
+
+    new_failures = compute_new_failures(prev, confirmed_failing)
+    new_errors = current.get("error", 0)
+    log(
+        f"Newly-confirmed failures: {len(new_failures)}; "
+        f"confirmed total: {current['failed']}; collection errors: {new_errors}"
+    )
+
+    # Alert logic — regression fires only on newly-confirmed serial failures.
     if is_first_run:
         msg = (
             f"Nightly regression baseline established: "
-            f"{current['total']} tests, {current['failed']} failures."
+            f"{current['total']} tests, {current['failed']} confirmed failures."
         )
         send_telegram(msg, dry_run=args.dry_run)
-    elif delta > 0:
+    elif new_failures:
+        preview = ", ".join(new_failures[:5])
+        if len(new_failures) > 5:
+            preview += f", +{len(new_failures) - 5} more"
         msg = (
-            f"Nightly regression: +{delta} new failures "
-            f"({current['failed']} total). Run: pytest tests/unit/ -n auto"
+            f"Nightly regression: {len(new_failures)} newly-confirmed failure(s) "
+            f"({current['failed']} confirmed total): {preview}. "
+            f"Run: pytest tests/unit/ -n0"
         )
         send_telegram(msg, dry_run=args.dry_run)
     elif new_errors > 0:
@@ -280,7 +412,7 @@ def main() -> int:
         )
         send_telegram(msg, dry_run=args.dry_run)
     else:
-        log("Clean run — no Telegram alert sent")
+        log("Clean run (no newly-confirmed failures) — no Telegram alert sent")
 
     # Save state
     save_last_run(current)

--- a/tests/unit/test_nightly_regression_tests.py
+++ b/tests/unit/test_nightly_regression_tests.py
@@ -122,6 +122,103 @@ class TestDeltaLogic:
         assert result is None
 
 
+class TestExtractFailingNodeIds:
+    def test_extracts_failed_and_error_outcomes(self) -> None:
+        report = {
+            "tests": [
+                {"nodeid": "tests/unit/test_a.py::test_pass", "outcome": "passed"},
+                {"nodeid": "tests/unit/test_a.py::test_fail", "outcome": "failed"},
+                {"nodeid": "tests/unit/test_b.py::test_err", "outcome": "error"},
+                {"nodeid": "tests/unit/test_c.py::test_skip", "outcome": "skipped"},
+            ]
+        }
+        result = nrt.extract_failing_node_ids(report)
+        assert result == [
+            "tests/unit/test_a.py::test_fail",
+            "tests/unit/test_b.py::test_err",
+        ]
+
+    def test_empty_report_returns_empty(self) -> None:
+        assert nrt.extract_failing_node_ids({}) == []
+        assert nrt.extract_failing_node_ids({"tests": []}) == []
+
+    def test_dedupes_and_sorts(self) -> None:
+        report = {
+            "tests": [
+                {"nodeid": "z::t", "outcome": "failed"},
+                {"nodeid": "a::t", "outcome": "failed"},
+                {"nodeid": "a::t", "outcome": "failed"},
+            ]
+        }
+        assert nrt.extract_failing_node_ids(report) == ["a::t", "z::t"]
+
+    def test_skips_entries_without_nodeid(self) -> None:
+        report = {"tests": [{"outcome": "failed"}]}
+        assert nrt.extract_failing_node_ids(report) == []
+
+
+class TestReconfirmSerial:
+    def test_empty_input_short_circuits(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            confirmed, artifacts = nrt.reconfirm_serial([])
+            mock_run.assert_not_called()
+        assert confirmed == []
+        assert artifacts == []
+
+    def test_classifies_confirmed_vs_artifact(self, tmp_path: Path) -> None:
+        nrt.LOG_FILE = tmp_path / "test.log"
+        # test_x still fails serially (confirmed); test_y passes serially (artifact).
+        serial_report = {
+            "tests": [
+                {"nodeid": "tests/unit/test_x.py::test_a", "outcome": "failed"},
+                {"nodeid": "tests/unit/test_y.py::test_b", "outcome": "passed"},
+            ]
+        }
+        report_path = Path(nrt.PYTEST_SERIAL_JSON_TMP)
+        report_path.write_text(json.dumps(serial_report))
+
+        class FakeResult:
+            returncode = 1
+
+        with patch("subprocess.run", return_value=FakeResult()):
+            confirmed, artifacts = nrt.reconfirm_serial(
+                ["tests/unit/test_y.py::test_b", "tests/unit/test_x.py::test_a"]
+            )
+        assert confirmed == ["tests/unit/test_x.py::test_a"]
+        assert artifacts == ["tests/unit/test_y.py::test_b"]
+
+    def test_fail_safe_treats_all_confirmed_on_error(self, tmp_path: Path) -> None:
+        nrt.LOG_FILE = tmp_path / "test.log"
+        node_ids = ["tests/unit/test_x.py::test_a", "tests/unit/test_y.py::test_b"]
+        with patch("subprocess.run", side_effect=FileNotFoundError("no pytest")):
+            confirmed, artifacts = nrt.reconfirm_serial(node_ids)
+        assert confirmed == sorted(node_ids)
+        assert artifacts == []
+
+
+class TestComputeNewFailures:
+    def test_new_confirmed_failure_detected(self) -> None:
+        prev = {"failing_tests": ["tests/unit/test_a.py::test_1"]}
+        confirmed = ["tests/unit/test_a.py::test_1", "tests/unit/test_b.py::test_2"]
+        assert nrt.compute_new_failures(prev, confirmed) == ["tests/unit/test_b.py::test_2"]
+
+    def test_shifting_set_same_count_is_not_new(self) -> None:
+        # Same count as prev, but the failing test is one previously seen — a
+        # stable failure, not a new regression.
+        prev = {"failing_tests": ["tests/unit/test_a.py::test_1"]}
+        confirmed = ["tests/unit/test_a.py::test_1"]
+        assert nrt.compute_new_failures(prev, confirmed) == []
+
+    def test_missing_prev_key_treats_all_as_new(self) -> None:
+        prev: dict = {}
+        confirmed = ["tests/unit/test_a.py::test_1"]
+        assert nrt.compute_new_failures(prev, confirmed) == ["tests/unit/test_a.py::test_1"]
+
+    def test_healed_failure_is_not_new(self) -> None:
+        prev = {"failing_tests": ["tests/unit/test_a.py::test_1"]}
+        assert nrt.compute_new_failures(prev, []) == []
+
+
 class TestSendTelegram:
     def test_dry_run_does_not_call_subprocess(
         self, tmp_path: Path, capsys: pytest.CaptureFixture


### PR DESCRIPTION
Closes #2180.

## Root cause

`scripts/nightly_regression_tests.py` ran `pytest tests/unit/ -n auto` and alerted whenever the scalar failure **count** rose above the prior run's baseline. `-n auto` is pytest-xdist parallel execution. The classic xdist failure mode — tests that pass serially but collide under parallel workers on shared state (Redis keys, temp files, fixture ordering) — produces a **shifting set** of failures a count comparison cannot distinguish from a genuine regression. That is why the 07-19 +15/21 spike re-appeared right after the 07-17 "false alarm" fix: the detector only ever looked at a scalar, so it was structurally blind to *which* tests failed.

## Fix

Add a **serial re-confirmation gate** and make the baseline **set-based**:

1. Capture the **set of failing node IDs** from the parallel run's JSON report (not just the count).
2. Re-run **only those node IDs** serially (`-n0`). Fail in parallel but pass serially → **xdist-parallelism artifact** (logged, never alerted). Fail in both → **confirmed regression**.
3. Persist the confirmed failing set. A regression alert fires only for **newly-confirmed** failures (confirmed set minus prior confirmed set) — a shifting flaky set no longer trips the alert, and a genuinely new failure does even when the total count is flat.
4. Fail-safe: if the serial re-run can't execute/parse, all parallel failures are treated as confirmed so a real regression is never silently hidden.

The serial re-run targets only the already-failing node IDs, so it stays fast and never re-runs the whole suite.

## New functions
- `extract_failing_node_ids(report)` — failing/errored node IDs, deduped + sorted.
- `reconfirm_serial(node_ids)` → `(confirmed, artifacts)`.
- `compute_new_failures(prev, confirmed)` — set-based new-failure detection.

## Acceptance criteria
- [x] Detector classifies parallel failures as real regression vs xdist artifact via serial re-run.
- [x] Regression alerts fire only on newly-confirmed serial failures; artifacts logged not alerted.
- [x] Serial re-confirmation gate added to the detector.

## Tests
`scripts/pytest-clean.sh tests/unit/test_nightly_regression_tests.py -n0 -q` → 28 passed. Added coverage for extraction, confirmed-vs-artifact classification, fail-safe, and set-based new-failure detection.

Note: issue #2173 (`test_remote_update_shell.py`) is a separate lane and untouched here.

Plan: `docs/plans/nightly-serial-reconfirm.md`.