### PR TITLE
SDLC Fork WS-F: adopt ownerless bridge PM session, no duplicate sdlc-local mint (#2026)

### DIFF
--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -21,7 +21,7 @@ You are the **developer (Dev)** for this session. The project manager (PM) spawn
 
 # What you DO
 
-1. **Own the SDLC pipeline.** When the PM routes work to you, drive it through the full pipeline: intake → plan → critique → build → test → review → patch → docs → merge. You invoke `/do-*` skills directly. You are the single executor for all SDLC stages.
+1. **Own the SDLC pipeline.** When the PM routes work to you, drive it through the full pipeline: intake → plan → critique → build → test → review → patch → docs → merge. Drive the pipeline via `/sdlc` (the single-stage router) or the individual stage `/do-*` skills, which you invoke directly. You are the single executor and the supervision loop itself, so **never invoke `/do-sdlc`** — it is the local-only stand-in for the bridge PM session, and running it here nests a whole supervision loop inside your own.
 2. **Run CRITIQUE and REVIEW gates before merging.** Before opening a PR, run `/do-plan-critique` on the plan. Before merging, run `/do-pr-review` on the PR. Do NOT merge unless the review passes. Gate exceptions require explicit PM instruction.
 3. **MERGE is mandatory.** After review passes, dispatch `/do-merge` to merge the PR. Do NOT self-merge via git.
 4. **Fan out to Sonnet subagents for parallel work.** Use builder/code-reviewer subagents liberally for independent subtasks — one builder per worktree, one reviewer per PR. Your session owns exactly one worktree, `.worktrees/{slug}` on `session/{slug}` (slug identity always wins) — do not expect or allocate separate `.worktrees/sdlc-{N}` lanes; fan builders into the single slug worktree with disjoint file sets so their commits never interleave.

--- a/.claude/skills-global/do-sdlc/SKILL.md
+++ b/.claude/skills-global/do-sdlc/SKILL.md
@@ -10,6 +10,8 @@ This skill is the **local stand-in for the bridge PM session**. `/sdlc` is a sin
 
 You are the supervisor, not the worker. You assess, dispatch, and track. The stage subagents do all the work.
 
+**Redundant-context check (issue #2026, WS-F):** if a bridge PM/dev context already owns this issue — a live eng session (e.g. a bridge PM session) or a live supervised-run signal for the issue number — then `/do-sdlc` is redundant: that context IS the supervision loop. Do not run it; drive via `/sdlc` (the single-stage router) instead. Running `/do-sdlc` inside an already-owned run nests a second supervision loop and wastes turns.
+
 ## Repo Context Probe
 
 If `docs/sdlc/do-sdlc.md` exists, read it and honor its declarations; otherwise use the generic defaults described below. The defaults drive the pipeline through `sdlc-tool` (synced to every machine via `~/.local/bin`), `gh`, and `git`.

--- a/docs/features/sdlc-issue-ownership-lock.md
+++ b/docs/features/sdlc-issue-ownership-lock.md
@@ -157,6 +157,22 @@ No backfill was performed on existing historical `AgentSession` records (out of 
 
 All three resolution passes (`issue_url` ownership, deterministic-id `sdlc-local-{N}`, `message_text` fallback) now exclude sessions whose `status` is in `{"failed", "completed", "killed"}` by default. Callers that want live-ownership resolution -- the common case: `ensure_session`, routing -- get only non-terminal sessions. Callers that explicitly want history (audit/debug tooling) opt in with `include_terminal=True`.
 
+## Bridge-owned run adoption (issue #2026, WS-F)
+
+`ensure_session`'s env short-circuit (`VALOR_SESSION_ID` / `AGENT_SESSION_ID`) resolves the live bridge PM eng session that spawned the dev subagent driving the pipeline. The #1147 dedup contract keeps that env session "without creating anything" **only when it already owns the issue** by `issue_url` (`.endswith("/issues/{N}")`). But a bridge PM session built from raw message text -- e.g. Tom's `"SDLC 1312"` -- never gets `issue_url` stamped, so the ownership check missed, and `find_session_by_issue`'s `message_text` fallback regex (`\bissue\s*#?\s*{N}\b`) also missed because the bare form carries no literal word "issue". `ensure_session` then fell through and minted a **second, unlinked `sdlc-local-{N}`** for an issue the PM session already owned -- the split-brain that manufactures the very gate/verdict/lease races WS1–WS-E exist to survive.
+
+**The fix:** when the resolved env session is a live, non-terminal eng session whose `issue_url` is **ownerless** (empty, `None`, or whitespace-only -- tested with `.strip()`), `ensure_session` **adopts** it as the run owner instead of minting a competitor:
+
+1. `_acquire_run_lock_and_bind(issue_number, resolved, reuse_run_id=...)` acquires the issue lock, binds the fresh `run_id` to `resolved.active_run_id` (with the post-save readback), and writes the supervised-run signal -- all the normal ownership machinery.
+2. **Only on the bind's success**, `resolved.issue_url` is stamped (from the passed `--issue-url`, or built as `https://github.com/{repo}/issues/{N}` from the resolved target-repo slug) and `save()`d as the **last** write.
+3. Returns `{"session_id": <env_session>, "created": false, "run_id": ...}` -- no `sdlc-local-{N}` is minted.
+
+**Bind-first, stamp-last** is load-bearing: a bind failure (`RUN_BIND_FAILED`, or a *foreign* `ISSUE_LOCKED`) leaves `issue_url` untouched and returns the error dict verbatim -- it never falls through to `create_local`, because under a held foreign lock that would mint the exact orphan WS-F prevents (then fail `ISSUE_LOCKED` anyway). A stamp failure *after* a successful bind is benign: the run is already correctly owned, so the adopted session is returned and a later ensure re-stamps idempotently via the self-owned `ISSUE_LOCKED` + `--reuse-run-id` recovery path (the `issue_url` stamp is a best-effort findability optimization, not the ownership record -- the lock is).
+
+**Divergent-owner protection preserved (#1671/#1672):** adoption fires *only* for an ownerless session. An env session that already owns a **different** issue (`issue_url` set to `/issues/{M}`, M != N) keeps the existing fall-through to `find_session_by_issue`, so a forked subagent inheriting a parent's `VALOR_SESSION_ID` never has its issue reassigned.
+
+`sdlc-local-{N}` is still minted in the #1558 case it was built for -- when no live eng session owns the issue at all.
+
 ## Renewal Call Sites
 
 Every mutation-adjacent checkpoint in the SDLC pipeline touches the lock. This is deliberately broader than "just where the lock is first acquired" -- a single stage (e.g. BUILD) can run far longer than the gap between dispatch-time touches, so the lock must be kept alive by whichever mechanism is already firing regularly on that path.

--- a/tests/integration/test_sdlc_session_ensure_integration.py
+++ b/tests/integration/test_sdlc_session_ensure_integration.py
@@ -128,6 +128,93 @@ def test_bridge_short_circuit_produces_no_duplicate(monkeypatch, cleanup_test_se
     assert eng_sessions[0].session_id == bridge_session_id
 
 
+def test_ownerless_bridge_session_adopted_no_duplicate(monkeypatch, cleanup_test_sessions):
+    """WS-F (#2026) live trigger: a bridge PM eng session built from the BARE
+    "SDLC N" form (no literal word "issue", so the message_text regex misses)
+    with issue_url=None + AGENT_SESSION_ID set is ADOPTED — no sdlc-local-N is
+    minted, and the PM session ends up holding the issue lock + supervised-run
+    signal under the returned run_id.
+
+    This reproduces the observed "SDLC 1312" case end-to-end through real Redis,
+    closing the gap the synthetic unit tests miss (critique concern #5).
+    """
+    from agent.supervised_run import (
+        clear_supervised_run_signal,
+        read_supervised_run_signal,
+    )
+    from models.session_lifecycle import release_issue_lock, touch_issue_lock
+    from tools.sdlc_session_ensure import ensure_session
+
+    issue_number = 700200
+    bridge_session_id = "tg_valor_test_wsf_700200"
+
+    bridge_session = AgentSession.create_eng(
+        session_id=bridge_session_id,
+        project_key=TEST_PROJECT_KEY,
+        working_dir="/tmp",
+        chat_id="test_chat_wsf",
+        telegram_message_id=1,
+        # BARE form — NO literal "issue", so find_session_by_issue's message_text
+        # regex would miss; only adoption prevents the duplicate mint.
+        message_text=f"SDLC {issue_number}",
+        sender_name="IntegrationTest",
+    )
+    # issue_url stays None — the ownerless bridge case.
+    assert getattr(bridge_session, "issue_url", None) in (None, "")
+
+    try:
+        from models.session_lifecycle import transition_status
+
+        transition_status(bridge_session, "running", "integration test setup")
+    except Exception:
+        pass
+
+    monkeypatch.setenv("AGENT_SESSION_ID", bridge_session_id)
+    monkeypatch.delenv("VALOR_SESSION_ID", raising=False)
+
+    result = ensure_session(
+        issue_number=issue_number,
+        issue_url=f"https://github.com/tomcounsell/ai/issues/{issue_number}",
+    )
+    run_id = result.get("run_id")
+
+    try:
+        # Adopted, not minted.
+        assert result["session_id"] == bridge_session_id
+        assert result["created"] is False
+        assert run_id
+
+        # No competing sdlc-local-N record.
+        zombie = list(AgentSession.query.filter(session_id=f"sdlc-local-{issue_number}"))
+        assert zombie == [], "adoption must not mint sdlc-local-N for an ownerless bridge session"
+
+        # Exactly one eng session in the test project.
+        eng_sessions = [
+            s
+            for s in AgentSession.query.all()
+            if getattr(s, "project_key", None) == TEST_PROJECT_KEY
+            and getattr(s, "session_type", None) == "eng"
+        ]
+        assert len(eng_sessions) == 1
+        assert eng_sessions[0].session_id == bridge_session_id
+
+        # issue_url stamped on the adopted PM session (best-effort findability).
+        persisted = list(AgentSession.query.filter(session_id=bridge_session_id))[0]
+        assert persisted.issue_url == f"https://github.com/tomcounsell/ai/issues/{issue_number}"
+
+        # PM session holds the issue lock under the returned run_id.
+        peek = touch_issue_lock(issue_number, None, peek=True)
+        assert peek.owner_run_id == run_id
+
+        # Supervised-run signal was published against the run_id.
+        signal = read_supervised_run_signal(issue_number, working_dir="/tmp")
+        assert signal and signal.get("run_id") == run_id
+    finally:
+        # Free the issue lock + signal so the test leaves no live-lease residue.
+        release_issue_lock(issue_number, run_id)
+        clear_supervised_run_signal(issue_number, run_id, working_dir="/tmp")
+
+
 def test_new_anchor_session_created_with_is_ledger_true(monkeypatch, cleanup_test_sessions):
     """Non-executable ledger flag (#2042), real Popoto Redis, end-to-end.
 

--- a/tests/unit/test_sdlc_session_ensure.py
+++ b/tests/unit/test_sdlc_session_ensure.py
@@ -537,6 +537,242 @@ class TestBridgeShortCircuit:
         assert result["run_id"]
 
 
+class TestOwnerlessAdoption:
+    """WS-F (#2026): adopt an ownerless bridge PM eng session instead of minting
+    a competing ``sdlc-local-{N}``.
+
+    A bridge PM session built from raw message text (``"SDLC 1312"``) never gets
+    ``issue_url`` stamped, so #1147's ownership check missed and a duplicate
+    top-level session was minted. The env short-circuit now adopts the ownerless
+    env session (bind run_id + write signal, then stamp ``issue_url`` last).
+    """
+
+    def test_ownerless_env_session_is_adopted(self, monkeypatch):
+        """Env eng session with issue_url=None → adopt (created False), stamp
+        issue_url from the explicit arg, mint nothing, no issue-lookup detour."""
+        from tools.sdlc_session_ensure import ensure_session
+
+        monkeypatch.setenv("AGENT_SESSION_ID", "tg_valor_-1003449100931_1192")
+        monkeypatch.delenv("VALOR_SESSION_ID", raising=False)
+
+        pm_session = MagicMock()
+        pm_session.session_id = "tg_valor_-1003449100931_1192"
+        pm_session.session_type = "eng"
+        pm_session.status = "running"
+        pm_session.issue_url = None  # the observed ownerless bridge case
+
+        fsbi = MagicMock()  # divergent-owner detour must NOT run
+        mock_as = MagicMock()
+
+        with (
+            patch("tools._sdlc_utils.find_session", return_value=pm_session),
+            patch("tools._sdlc_utils.find_session_by_issue", fsbi),
+            patch("models.agent_session.AgentSession", mock_as),
+            patch(
+                "tools.sdlc_session_ensure._acquire_run_lock_and_bind",
+                return_value=("run_abc123", None),
+            ),
+        ):
+            result = ensure_session(
+                issue_number=1312,
+                issue_url="https://github.com/tomcounsell/ai/issues/1312",
+            )
+
+        assert result["session_id"] == "tg_valor_-1003449100931_1192"
+        assert result["created"] is False
+        assert result["run_id"] == "run_abc123"
+        # issue_url stamped LAST (after a successful bind) and persisted.
+        assert pm_session.issue_url == "https://github.com/tomcounsell/ai/issues/1312"
+        pm_session.save.assert_called_once()
+        # No competitor minted; no divergent-owner detour.
+        mock_as.create_local.assert_not_called()
+        fsbi.assert_not_called()
+
+    def test_ownerless_variants_none_empty_whitespace_all_adopted(self, monkeypatch):
+        """None, "", and whitespace-only issue_url are ALL ownerless → adopt."""
+        from tools.sdlc_session_ensure import ensure_session
+
+        monkeypatch.delenv("VALOR_SESSION_ID", raising=False)
+
+        for offset, ownerless in enumerate((None, "", "   ")):
+            issue_number = 13120 + offset
+            monkeypatch.setenv("AGENT_SESSION_ID", f"pm-{issue_number}")
+
+            pm_session = MagicMock()
+            pm_session.session_id = f"pm-{issue_number}"
+            pm_session.session_type = "eng"
+            pm_session.status = "running"
+            pm_session.issue_url = ownerless
+
+            mock_as = MagicMock()
+
+            with (
+                patch("tools._sdlc_utils.find_session", return_value=pm_session),
+                patch("tools._sdlc_utils.find_session_by_issue", MagicMock()),
+                patch("models.agent_session.AgentSession", mock_as),
+                patch(
+                    "tools.sdlc_session_ensure._acquire_run_lock_and_bind",
+                    return_value=(f"run-{issue_number}", None),
+                ),
+            ):
+                result = ensure_session(
+                    issue_number=issue_number,
+                    issue_url=f"https://github.com/tomcounsell/ai/issues/{issue_number}",
+                )
+
+            assert result["session_id"] == f"pm-{issue_number}", (
+                f"failed to adopt for ownerless issue_url={ownerless!r}"
+            )
+            assert result["created"] is False
+            mock_as.create_local.assert_not_called()
+
+    def test_ownerless_adoption_builds_issue_url_when_arg_absent(self, monkeypatch):
+        """No --issue-url arg → stamp is built from the resolved repo slug."""
+        from tools.sdlc_session_ensure import ensure_session
+
+        monkeypatch.setenv("AGENT_SESSION_ID", "pm-13199")
+        monkeypatch.delenv("VALOR_SESSION_ID", raising=False)
+
+        pm_session = MagicMock()
+        pm_session.session_id = "pm-13199"
+        pm_session.session_type = "eng"
+        pm_session.status = "running"
+        pm_session.issue_url = None
+
+        mock_as = MagicMock()
+
+        with (
+            patch("tools._sdlc_utils.find_session", return_value=pm_session),
+            patch("tools._sdlc_utils.find_session_by_issue", MagicMock()),
+            patch("models.agent_session.AgentSession", mock_as),
+            patch("tools._sdlc_utils._resolve_target_repo", return_value="tomcounsell/ai"),
+            patch(
+                "tools.sdlc_session_ensure._acquire_run_lock_and_bind",
+                return_value=("run-13199", None),
+            ),
+        ):
+            result = ensure_session(issue_number=13199)  # no issue_url
+
+        assert result["created"] is False
+        assert pm_session.issue_url == "https://github.com/tomcounsell/ai/issues/13199"
+
+    def test_ownerless_adoption_bind_failure_returns_error_no_mint(self, monkeypatch):
+        """Bind fails (foreign ISSUE_LOCKED) → return the error dict verbatim,
+        NEVER fall through to a mint, and leave issue_url untouched (no stamp).
+
+        Falling through under a held foreign lock would mint the exact
+        ``sdlc-local-{N}`` orphan WS-F prevents (critique blocker #2)."""
+        from tools.sdlc_session_ensure import ensure_session
+
+        monkeypatch.setenv("AGENT_SESSION_ID", "pm-1313")
+        monkeypatch.delenv("VALOR_SESSION_ID", raising=False)
+
+        pm_session = MagicMock()
+        pm_session.session_id = "pm-1313"
+        pm_session.session_type = "eng"
+        pm_session.status = "running"
+        pm_session.issue_url = None
+
+        error_dict = {
+            "blocked": True,
+            "reason": "ISSUE_LOCKED",
+            "owner_run_id": "foreign_run",
+            "owner_session_id": "foreign_sess",
+            "orphaned_lock": False,
+        }
+
+        mock_as = MagicMock()
+
+        with (
+            patch("tools._sdlc_utils.find_session", return_value=pm_session),
+            patch("tools._sdlc_utils.find_session_by_issue", MagicMock()),
+            patch("models.agent_session.AgentSession", mock_as),
+            patch(
+                "tools.sdlc_session_ensure._acquire_run_lock_and_bind",
+                return_value=(None, error_dict),
+            ),
+        ):
+            result = ensure_session(issue_number=1313)
+
+        assert result == error_dict
+        # No stamp on a bind failure (catches a stamp-first regression).
+        assert pm_session.issue_url is None
+        pm_session.save.assert_not_called()
+        # No competitor minted.
+        mock_as.create_local.assert_not_called()
+
+    def test_ownerless_adoption_stamp_failure_returns_adopted_no_mint(self, monkeypatch):
+        """Bind succeeds but the issue_url save raises → return the adopted
+        session (run already owned); NEVER fall through to a mint."""
+        from tools.sdlc_session_ensure import ensure_session
+
+        monkeypatch.setenv("AGENT_SESSION_ID", "pm-1314")
+        monkeypatch.delenv("VALOR_SESSION_ID", raising=False)
+
+        pm_session = MagicMock()
+        pm_session.session_id = "pm-1314"
+        pm_session.session_type = "eng"
+        pm_session.status = "running"
+        pm_session.issue_url = None
+        pm_session.save.side_effect = ConnectionError("Redis down during stamp")
+
+        mock_as = MagicMock()
+
+        with (
+            patch("tools._sdlc_utils.find_session", return_value=pm_session),
+            patch("tools._sdlc_utils.find_session_by_issue", MagicMock()),
+            patch("models.agent_session.AgentSession", mock_as),
+            patch(
+                "tools.sdlc_session_ensure._acquire_run_lock_and_bind",
+                return_value=("run-1314", None),
+            ),
+        ):
+            result = ensure_session(
+                issue_number=1314,
+                issue_url="https://github.com/tomcounsell/ai/issues/1314",
+            )
+
+        assert result["session_id"] == "pm-1314"
+        assert result["created"] is False
+        assert result["run_id"] == "run-1314"
+        # Stamp failure did not fall through to a mint under a held lock.
+        mock_as.create_local.assert_not_called()
+
+    def test_divergent_owner_not_adopted(self, monkeypatch):
+        """Env session owning a DIFFERENT issue is NOT adopted (its issue_url is
+        untouched) → existing divergent-owner fall-through preserved (#1671)."""
+        from tools.sdlc_session_ensure import ensure_session
+
+        monkeypatch.setenv("AGENT_SESSION_ID", "pm-other")
+        monkeypatch.delenv("VALOR_SESSION_ID", raising=False)
+
+        env_session = MagicMock()
+        env_session.session_id = "pm-other"
+        env_session.session_type = "eng"
+        env_session.status = "running"
+        env_session.issue_url = "https://github.com/tomcounsell/ai/issues/9999"
+
+        issue_session = MagicMock()
+        issue_session.session_id = "sdlc-local-1315"
+
+        mock_as = MagicMock()
+        mock_as.query.filter.return_value = [issue_session]  # post-save readback
+
+        with (
+            patch("tools._sdlc_utils.find_session", return_value=env_session),
+            patch("tools._sdlc_utils.find_session_by_issue", return_value=issue_session),
+            patch("models.agent_session.AgentSession", mock_as),
+        ):
+            result = ensure_session(issue_number=1315)
+
+        # Divergent env session preferred the issue-scoped session; not adopted.
+        assert result["session_id"] == "sdlc-local-1315"
+        assert result["created"] is False
+        # The divergent env session's issue_url was NOT overwritten.
+        assert env_session.issue_url == "https://github.com/tomcounsell/ai/issues/9999"
+        env_session.save.assert_not_called()
+
+
 def _make_orphan_session(
     session_id,
     age_seconds,

--- a/tools/sdlc_session_ensure.py
+++ b/tools/sdlc_session_ensure.py
@@ -79,6 +79,32 @@ logger = logging.getLogger(__name__)
 ORPHAN_AGE_SECONDS = 600
 
 
+def _issue_url_for(issue_number: int) -> str | None:
+    """Build a canonical GitHub issue URL from the resolved target repo slug.
+
+    Used to stamp ``issue_url`` when adopting an ownerless bridge PM session
+    (issue #2026, WS-F) and the caller passed no explicit ``--issue-url``.
+    Returns ``None`` when the repo slug cannot be resolved -- the stamp is
+    best-effort findability, so adoption's correctness rests on the lock +
+    run_id bind (and the supervised-run signal), never on this URL.
+    """
+    try:
+        from tools._sdlc_utils import _resolve_target_repo
+
+        repo = _resolve_target_repo()
+    except Exception as e:
+        logger.debug(
+            "sdlc_session_ensure: issue_url repo resolution failed for #%s (%s: %s)",
+            issue_number,
+            type(e).__name__,
+            e,
+        )
+        return None
+    if not repo:
+        return None
+    return f"https://github.com/{repo}/issues/{issue_number}"
+
+
 def _validated_reuse_candidate(issue_number: int, session, reuse_run_id: str) -> str | None:
     """Return ``reuse_run_id`` when the caller proves it is the same top-level
     invocation; ``None`` otherwise (caller falls back to a fresh mint contest).
@@ -374,7 +400,15 @@ def ensure_session(
            endswith ``/issues/{issue_number}``), return it without creating
            anything — this is the legitimate bridge case (#1147 dedup), a true
            no-op, no ``find_session_by_issue`` detour.
-         - If the env session exists but does **not** own the issue, consult
+         - If the env session exists and is **ownerless** (empty/None/
+           whitespace ``issue_url``), ADOPT it as the run owner for this issue
+           (issue #2026, WS-F): bind the run_id + write the supervised-run
+           signal, then stamp ``issue_url`` last, and mint nothing. This closes
+           the bridge PM→dev duplicate-mint gap — a PM session built from raw
+           message text ("SDLC 1312") never advertises ``issue_url``, so #1147's
+           ownership check missed and a competing ``sdlc-local-{N}`` was minted.
+         - If the env session owns a **different** issue (a set ``issue_url``
+           ending in ``/issues/{M}``, M != N), consult
            :func:`find_session_by_issue` and prefer an existing issue-scoped
            session (e.g. ``sdlc-local-{N}``) over the divergent env session.
            This is the #1671 case: a forked subagent inherited a parent's
@@ -449,7 +483,63 @@ def ensure_session(
                                     "created": False,
                                     "run_id": run_id,
                                 }
-                            # Env session is live but does NOT own this issue.
+                            # Ownerless bridge PM session (issue #2026, WS-F):
+                            # a bridge PM eng session built from raw message
+                            # text ("SDLC 1312") never gets issue_url stamped,
+                            # so the owning-issue check above misses and this
+                            # issue looks unowned. Rather than minting a
+                            # competing sdlc-local-{N}, ADOPT the ownerless env
+                            # session as the single run owner. Ownerless =
+                            # empty/None/whitespace issue_url (.strip() so a
+                            # whitespace-only value is adopted, not mistaken for
+                            # a divergent owner). A DIVERGENT owner (issue_url
+                            # set to a different /issues/M) keeps the existing
+                            # fall-through below, preserving the #1671/#1672
+                            # divergent-owner protection.
+                            #
+                            # BIND-FIRST, STAMP-LAST: _acquire_run_lock_and_bind
+                            # acquires the issue lock, binds run_id, and writes
+                            # the supervised-run signal; only on its success do
+                            # we stamp issue_url as the LAST write. A bind
+                            # failure leaves issue_url untouched and propagates
+                            # the error dict verbatim -- NEVER a mint. Falling
+                            # through to create_local under a held foreign
+                            # ISSUE_LOCKED would mint the exact orphan WS-F
+                            # prevents. Extends the #1147 dedup contract to
+                            # bridge sessions that never advertised issue_url.
+                            if not env_issue_url.strip():
+                                run_id, err = _acquire_run_lock_and_bind(
+                                    issue_number, resolved, reuse_run_id=reuse_run_id
+                                )
+                                if err is not None:
+                                    return err
+                                try:
+                                    resolved.issue_url = issue_url or _issue_url_for(issue_number)
+                                    resolved.save()
+                                except Exception as save_err:
+                                    # Bind already succeeded -- the run is
+                                    # correctly owned (lock held, signal
+                                    # written). issue_url is a best-effort
+                                    # findability stamp; its failure must NOT
+                                    # fall through to the mint while the lock is
+                                    # held. Return the adopted session; a later
+                                    # ensure re-stamps via the self-owned
+                                    # ISSUE_LOCKED + --reuse-run-id path.
+                                    logger.debug(
+                                        "sdlc_session_ensure: issue_url stamp failed for "
+                                        "adopted session %s (%s: %s) -- run already owned, "
+                                        "returning adopted session",
+                                        env_session_id,
+                                        type(save_err).__name__,
+                                        save_err,
+                                    )
+                                return {
+                                    "session_id": env_session_id,
+                                    "created": False,
+                                    "run_id": run_id,
+                                }
+
+                            # Env session is live but owns a DIFFERENT issue.
                             # Prefer an existing issue-scoped session if one
                             # exists; otherwise fall through to the issue
                             # lookup / create path below.


### PR DESCRIPTION
## Summary

WS-F of the #2026 fork/supervisor hardening umbrella. Closes the last split-brain path: a bridge PM eng session that already owns an issue was getting a **second, unlinked `sdlc-local-{N}`** minted underneath it.

**Root cause (fully traced in the plan):** when a bridge PM session routes SDLC work to its `dev` subagent, the dev runs `sdlc-tool session-ensure`. The env short-circuit resolves the PM session via `AGENT_SESSION_ID`, but adoption failed because the PM session carries **no `issue_url`** (it was built from raw text like `"SDLC 1312"`). The `#1147` ownership check (`issue_url.endswith("/issues/N")`) missed, and `find_session_by_issue`'s message_text regex requires the literal word "issue" — which `"SDLC 1312"` lacks — so `ensure_session` fell through and minted `sdlc-local-1312`. Two independent Eng sessions then raced to own one issue.

## Fix

In `ensure_session`'s env short-circuit, when the resolved live eng session is **ownerless** (`issue_url` empty/None/whitespace, tested with `.strip()`), **adopt** it as the run owner instead of minting a competitor:

- **Bind-first, stamp-last:** `_acquire_run_lock_and_bind` acquires the issue lock, binds `run_id`, and writes the supervised-run signal; only on its success is `issue_url` stamped (from `--issue-url` or built from the resolved repo slug) as the **last** write.
- **Bind failure** (`RUN_BIND_FAILED` / foreign `ISSUE_LOCKED`) returns the error dict verbatim and **never** falls through to `create_local` — under a held foreign lock that would mint the exact orphan WS-F prevents.
- **Stamp failure after a good bind** returns the adopted session (run already owned); a later ensure re-stamps idempotently via the self-owned `ISSUE_LOCKED` + `--reuse-run-id` path.
- **Divergent-owner protection preserved (#1671/#1672):** an env session owning a *different* issue keeps the existing fall-through.

Instruction edits (defense-in-depth hygiene): `dev.md` drives via `/sdlc` or stage `/do-*` skills and never `/do-sdlc`; `do-sdlc/SKILL.md` carries the reciprocal redundant-context note.

## Tests

- **Unit** (`tests/unit/test_sdlc_session_ensure.py`, new `TestOwnerlessAdoption`): ownerless adopt; None/empty/whitespace variants; issue_url built from repo slug when the arg is absent; bind-fail returns error + no stamp + no mint; stamp-fail returns adopted + no mint; divergent-owner not adopted.
- **Integration** (`tests/integration/test_sdlc_session_ensure_integration.py`): real-Redis reproduction of the live `"SDLC N"` bare-form trigger — asserts no `sdlc-local-N` minted, exactly one eng session, PM session holds the lock + supervised-run signal under the returned run_id. Project-scoped cleanup.

Scoped run: 72 unit + 2 integration cases green. (One pre-existing, unrelated router test `test_terminal_merged_pipeline_routes_to_merge_not_build` fails on the base branch too — Redis-state pollution, not touched by this change.)

## Docs

`docs/features/sdlc-issue-ownership-lock.md` gains a "Bridge-owned run adoption (issue #2026, WS-F)" section.

Plan: `docs/plans/sdlc-fork-redundant-owner-mint.md`

Closes #2026