### PR TITLE
Runner init-hang: first-output deadline + circuit breaker + diagnostics (#2181)

### DIFF
--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -1658,10 +1658,62 @@ def _ensure_worker(worker_key: str, is_project_keyed: bool = False) -> None:
 # for a tool-in-flight wedge — this watcher only catches the residual (no
 # tool in flight / model-inference stall / wedged between tool calls).
 SESSION_PROGRESS_DEADLINE_S = int(os.environ.get("SESSION_PROGRESS_DEADLINE_S", 1800))
+# First-output deadline anchor (issue #2181): reuse the stall classifier's
+# never-started ceiling so the two never drift.
+from agent.session_stall_classifier import (  # noqa: E402
+    NEVER_STARTED_CONFIRM_MARGIN_SECS,
+    NEVER_STARTED_GRACE_SECS,
+)
+
 # Poll interval for the owned-task progress watcher in `_worker_loop` below.
 # Provisional — keeps the worker loop's liveness beacon ticking while
 # watching progress without busy-waiting.
 PROGRESS_POLL_S = float(os.environ.get("PROGRESS_POLL_S", 30))
+
+# First-output deadline (issue #2181). A running session whose subprocess is
+# alive but has NEVER produced any SDK output (communicated=False —
+# ``derive_sdk_ever_output`` False) is recovered on THIS deadline, INDEPENDENT
+# of the flat-CPU hang probe. This closes the init-hang blind spot: a wedged
+# ``claude -p`` that holds an established API socket (model connect) or
+# MCP-server children reads ``"progressing"`` to ``subprocess_hang_verdict``
+# forever — so the flat-CPU probe never fires — yet emits zero output, and would
+# otherwise burn the full ``SESSION_PROGRESS_DEADLINE_S`` (1800s) catch-all,
+# then re-spawn into the identical hang.
+#
+# Anchored to the stall classifier's never-started ceiling
+# (``NEVER_STARTED_GRACE_SECS + NEVER_STARTED_CONFIRM_MARGIN_SECS`` ≈ 1230s): a
+# genuinely-slow Opus cold start emits its ``system/init`` stdout event (which
+# stamps ``last_stdout_at`` → ``derive_sdk_ever_output`` True) well before that
+# ceiling, so this deadline never false-kills a healthy cold start, while still
+# firing meaningfully sooner than the 1800s catch-all. Env-overridable; grain of
+# salt — provisional, tune freely, but keep it ≥ the documented cold-start
+# ceiling.
+FIRST_OUTPUT_DEADLINE_S = int(
+    os.environ.get(
+        "FIRST_OUTPUT_DEADLINE_S",
+        NEVER_STARTED_GRACE_SECS + NEVER_STARTED_CONFIRM_MARGIN_SECS,
+    )
+)
+
+
+def _first_output_deadline_exceeded(session: AgentSession, acquired_at: float) -> bool:
+    """Whether ``session`` has never produced SDK output past the first-output deadline.
+
+    Returns True iff BOTH hold (issue #2181):
+
+      * ``derive_sdk_ever_output(session)`` is False — the subprocess has NEVER
+        emitted a recognized SDK output event (no ``system/init``, no tool
+        boundary, no turn boundary), i.e. ``communicated=False``.
+      * ``now - acquired_at > FIRST_OUTPUT_DEADLINE_S`` — the session has been
+        bound to its worker slot longer than the first-output deadline.
+
+    Independent of the flat-CPU hang probe by design: this is the leg that
+    catches a never-communicated init hang holding an API socket / MCP children
+    (which the probe classifies ``"progressing"``). Never raises.
+    """
+    if derive_sdk_ever_output(session):
+        return False
+    return (time.time() - acquired_at) > FIRST_OUTPUT_DEADLINE_S
 
 
 def _session_progress_ts(session: AgentSession, acquired_at: float) -> float:
@@ -2276,7 +2328,20 @@ async def _worker_loop(
                         current, _active_sessions, session.agent_session_id
                     )
 
-                    if not deadline_exceeded and not hang_detected:
+                    # First-output deadline (issue #2181), INDEPENDENT of the
+                    # flat-CPU probe. A session that has produced ZERO SDK output
+                    # (communicated=False) past FIRST_OUTPUT_DEADLINE_S is a hung
+                    # runner init — this is the leg that catches the probe blind
+                    # spot (an init hang holding an API socket / MCP children,
+                    # which the probe classifies "progressing" forever). Anchored
+                    # to the never-started ceiling, so a healthy cold start — which
+                    # stamps last_stdout_at on its `system/init` event well before
+                    # the ceiling — is never false-killed here.
+                    first_output_exceeded = _first_output_deadline_exceeded(
+                        current, _session_acquired_at
+                    )
+
+                    if not deadline_exceeded and not hang_detected and not first_output_exceeded:
                         continue  # progress observed / probe inconclusive — keep watching
                     if os.environ.get("DISABLE_PROGRESS_KILL") == "1":
                         break  # kill-switch: let it run
@@ -2300,17 +2365,52 @@ async def _worker_loop(
                     # otherwise look for, so re-consulting it would be redundant
                     # (it would return the same "hung"→no-reprieve). The deadline
                     # path still consults reprieves for active children /
-                    # compaction.
-                    if not hang_detected and not _should_kill_no_progress(
-                        current, handle, emit_telemetry=emit
+                    # compaction. The first-output deadline ALSO bypasses the
+                    # reprieve gate (issue #2181): the reprieve reprieves on
+                    # "active children" / compaction, but a never-communicated
+                    # init hang holding a hung MCP child is exactly the false
+                    # reprieve this leg exists to defeat.
+                    if (
+                        not hang_detected
+                        and not first_output_exceeded
+                        and not _should_kill_no_progress(current, handle, emit_telemetry=emit)
                     ):
                         continue  # active children / compaction — reprieve, keep watching
                     deadline_cancelled = True
-                    _recovery_reason = (
-                        f"subprocess hang probe ({hang_gate})"
-                        if hang_detected
-                        else "progress deadline exceeded"
-                    )
+                    # Circuit breaker (issue #2181): a kill on a session that has
+                    # NEVER produced SDK output is an init hang. Both the
+                    # flat-CPU probe (`_owned_task_hang_check` returns hung only
+                    # when derive_sdk_ever_output is False) and the first-output
+                    # deadline imply never-communicated. Re-spawning the identical
+                    # zero-output input reproduces the identical hang, so route it
+                    # through the terminal-finalizing `init_hang` reason_kind
+                    # rather than the requeue path. Only a kill on a session that
+                    # HAS communicated (a genuine post-output stall) stays
+                    # `progress_deadline`.
+                    _never_communicated = not derive_sdk_ever_output(current)
+                    if _never_communicated:
+                        _recovery_reason_kind = "init_hang"
+                        if first_output_exceeded:
+                            _recovery_reason = (
+                                "first-output deadline exceeded "
+                                "(init hang — runner produced no output)"
+                            )
+                        elif hang_detected:
+                            _recovery_reason = (
+                                f"subprocess hang probe ({hang_gate}) "
+                                "— init hang, runner produced no output"
+                            )
+                        else:
+                            _recovery_reason = (
+                                "progress deadline exceeded (runner produced no output)"
+                            )
+                    else:
+                        _recovery_reason_kind = "progress_deadline"
+                        _recovery_reason = (
+                            f"subprocess hang probe ({hang_gate})"
+                            if hang_detected
+                            else "progress deadline exceeded"
+                        )
                     # FINALIZE FIRST — at the watcher scope, before cancel
                     # reaches the CancelledError handler below. Subprocess
                     # teardown rides exec_task.cancel() below (the harness
@@ -2321,7 +2421,7 @@ async def _worker_loop(
                     did_finalize = await _apply_recovery_transition(
                         current,
                         reason=_recovery_reason,
-                        reason_kind="progress_deadline",
+                        reason_kind=_recovery_reason_kind,
                         # handle=None (NIT): Fix #3 OWNS the cancel scope — it
                         # calls exec_task.cancel() itself below. Passing the
                         # registry handle would make _apply_recovery_transition

--- a/agent/session_health.py
+++ b/agent/session_health.py
@@ -2369,6 +2369,12 @@ async def _apply_recovery_transition(
         call this function — evaluating it a second time here would be a
         redundant, stale re-check (the caller's decision already stands).
         Always called with ``handle=None`` (Fix #3 owns its own cancel).
+      * ``"init_hang"`` — skip Tier 2 reprieve AND never requeue (issue #2181's
+        circuit breaker). The session hung at runner init having produced ZERO
+        SDK output (communicated=False); re-spawning the identical input
+        reproduces the identical hang. Always finalize terminal on the FIRST
+        occurrence (``failed`` remote / ``abandoned`` local) rather than
+        requeuing to ``pending``. Also caller-driven with ``handle=None``.
 
     Project-scoped Redis counter
     ``{project_key}:session-health:recoveries:{reason_kind}`` is incremented
@@ -2508,6 +2514,10 @@ async def _apply_recovery_transition(
         return False
 
     is_local = worker_key.startswith("local")
+    # Init-hang circuit breaker (issue #2181): a never-communicated init hang is
+    # always terminal — never requeued — so re-spawning the identical zero-output
+    # input cannot reproduce the identical hang.
+    _init_hang = reason_kind == "init_hang"
     # Capture tool_name once for use in advisory injection and degraded notice.
     tool_name = getattr(entry, "current_tool_name", None)
     logger.warning(
@@ -2539,7 +2549,7 @@ async def _apply_recovery_transition(
         from agent.cancel_reason import set_cancel_reason
 
         _predicted_terminal = (
-            is_local or ((entry.recovery_attempts or 0) + 1) >= MAX_RECOVERY_ATTEMPTS
+            _init_hang or is_local or ((entry.recovery_attempts or 0) + 1) >= MAX_RECOVERY_ATTEMPTS
         )
         if _predicted_terminal:
             set_cancel_reason(entry.session_id, "no_resume")
@@ -2631,7 +2641,8 @@ async def _apply_recovery_transition(
             if is_local
             else (
                 "failed"
-                if entry.recovery_attempts >= MAX_RECOVERY_ATTEMPTS
+                if _init_hang
+                or entry.recovery_attempts >= MAX_RECOVERY_ATTEMPTS
                 or not _subprocess_confirmed_dead
                 else "pending"
             )
@@ -2723,6 +2734,48 @@ async def _apply_recovery_transition(
             logger.warning(
                 "[session-health] Finalized session %s as failed after %s recovery attempts",
                 entry.agent_session_id,
+                entry.recovery_attempts,
+            )
+        elif _init_hang:
+            # Init-hang circuit breaker (issue #2181). The session hung at runner
+            # init having produced ZERO SDK output (communicated=False). Re-spawning
+            # the identical input reproduces the identical hang — the incident that
+            # burned ~70 min re-spawning the same input 3x. Fail on the FIRST init
+            # hang instead of requeuing, so the input is surfaced rather than
+            # silently retried into the same wedge. Deliver a terminal notice that
+            # names the cause (runner never started / no output).
+            from agent.cancel_reason import set_cancel_reason
+
+            set_cancel_reason(entry.session_id, "no_resume")
+            _has_deferred = (getattr(entry, "extra_context", None) or {}).get(
+                "deferred_self_draft_pending"
+            )
+            await _deliver_deferred_self_draft_fallback(entry)
+            if not _has_deferred:
+                await _deliver_terminal_interrupt_notice(entry)
+            finalize_session(
+                entry,
+                "failed",
+                reason=(
+                    f"health check: init hang — runner started but produced no output "
+                    f"(communicated=False); not re-spawning identical input "
+                    f"(chat={worker_key}, attempt {entry.recovery_attempts}, "
+                    f"kind={reason_kind})"
+                ),
+                emit_telemetry=False,
+            )
+            _reclaim_slot_lease()  # row is now terminal (failed, init hang circuit break)
+            try:
+                from popoto.redis_db import POPOTO_REDIS_DB as _IHR  # noqa: PLC0415
+
+                _IHR.incr(f"{entry.project_key}:session-health:init_hang_circuit_break")
+            except Exception:  # noqa: S110 -- optional telemetry counter
+                pass
+            logger.warning(
+                "[session-health] Init-hang circuit breaker: failed session %s "
+                "without re-spawn (chat=%s, attempt %s)",
+                entry.agent_session_id,
+                worker_key,
                 entry.recovery_attempts,
             )
         elif not _subprocess_confirmed_dead:

--- a/agent/session_runner/harness/claude.py
+++ b/agent/session_runner/harness/claude.py
@@ -838,6 +838,54 @@ async def get_response_via_harness(
     return ""
 
 
+# Bounds for the init-hang stderr diagnostic (issue #2181). Env-tunable; grain
+# of salt — provisional. The read is guarded by a short timeout so a wedged pipe
+# can never stall the teardown, and the logged tail is bounded to keep the log
+# line small.
+INIT_HANG_STDERR_TIMEOUT_S: float = float(os.environ.get("INIT_HANG_STDERR_TIMEOUT_S", "2.0"))
+INIT_HANG_STDERR_MAX_CHARS: int = int(os.environ.get("INIT_HANG_STDERR_MAX_CHARS", "4000"))
+
+
+async def _log_init_hang_stderr(proc: Any, session_id: str | None) -> None:
+    """Drain and log a killed subprocess's buffered stderr for issue #2181.
+
+    Best-effort diagnostic for the ``communicated=False`` init hang: the
+    subprocess held its process (heartbeats fired) but never emitted a stdout
+    event, so the real init blocker (MCP-server load / oauth / model connect)
+    would otherwise be lost with the killed pipe. The caller SIGKILLs first, so
+    the stderr pipe is at EOF and the read returns promptly; a short
+    ``wait_for`` guards against any residual block.
+
+    Never raises and never masks the cancellation propagating through the
+    caller's ``finally`` — a re-delivered ``CancelledError`` from the inner
+    ``await`` is caught here; the ORIGINAL exception that triggered the
+    ``finally`` still re-raises on ``finally`` exit.
+    """
+    stderr_reader = getattr(proc, "stderr", None)
+    if stderr_reader is None:
+        return
+    try:
+        data = await asyncio.wait_for(
+            stderr_reader.read(INIT_HANG_STDERR_MAX_CHARS),
+            timeout=INIT_HANG_STDERR_TIMEOUT_S,
+        )
+        text = data.decode("utf-8", errors="replace").strip() if data else ""
+        logger.warning(
+            "[harness] init-hang diagnostics session_id=%s communicated=False stderr_tail=%r",
+            session_id,
+            (text[:INIT_HANG_STDERR_MAX_CHARS] if text else "<empty>"),
+        )
+    except (TimeoutError, asyncio.CancelledError) as _diag_timeout:
+        logger.warning(
+            "[harness] init-hang diagnostics session_id=%s communicated=False "
+            "stderr unavailable (%s)",
+            session_id,
+            type(_diag_timeout).__name__,
+        )
+    except Exception as _diag_err:  # noqa: BLE001 — diagnostic must never raise
+        logger.debug("[harness] init-hang stderr drain failed (non-fatal): %s", _diag_err)
+
+
 async def _run_harness_subprocess(
     cmd: list[str],
     working_dir: str,
@@ -1193,6 +1241,16 @@ async def _run_harness_subprocess(
                 pass
             except Exception as _reap_err:  # noqa: BLE001
                 logger.warning("[harness] cancellation reap failed (non-fatal): %s", _reap_err)
+            # Init-hang diagnostics (issue #2181). When this subprocess is torn
+            # down before it EVER emitted a stdout event (``not _first_stdout_seen``
+            # — the communicated=False init-hang shape: no ``system/init``, no
+            # ``result``), the real init blocker (MCP-server load, oauth, model
+            # connect) is otherwise lost with the killed pipe. Drain and log the
+            # buffered stderr now that the SIGKILL above has closed the pipes so
+            # the read returns promptly at EOF. Best-effort and bounded; never
+            # masks the cancellation being propagated by this ``finally``.
+            if not _first_stdout_seen:
+                await _log_init_hang_stderr(proc, true_session_id)
 
     # Fire SDK-finished callback once the subprocess has exited (#1269).
     # Paired with on_sdk_started — together they bracket the subprocess

--- a/docs/features/bridge-worker-architecture.md
+++ b/docs/features/bridge-worker-architecture.md
@@ -442,6 +442,43 @@ The fast path covers normal operation. The health check catches edge cases: miss
 
 **`VALOR_WORKER_MODE=standalone` in worker plist**: `com.valor.worker.plist` now sets `VALOR_WORKER_MODE=standalone` in `EnvironmentVariables`. The runtime behavior was already standalone (via `os.environ.setdefault("VALOR_WORKER_MODE", "standalone")` in `worker/__main__.py:main()` before the worker loop), but the explicit plist entry makes `ps eww` inspection unambiguous — the variable is visible in the launchd launch environment, not just the mutated runtime environment.
 
+## Runner Init-Hang: First-Output Deadline + Circuit Breaker (issue #2181)
+
+A `claude -p` runner can hang at **init**: the subprocess starts and holds its
+process (heartbeats fire) but never emits a single SDK message
+(`communicated=False` — `derive_sdk_ever_output` False, i.e. no `system/init`,
+no tool boundary, no turn boundary). Zero turns, tokens, or tool calls. Three
+nets now cover this shape:
+
+- **First-output deadline** (`agent/agent_session_queue.py`,
+  `_first_output_deadline_exceeded` / `FIRST_OUTPUT_DEADLINE_S`): the owned-task
+  progress watcher recovers a never-communicated session past
+  `FIRST_OUTPUT_DEADLINE_S` (default `NEVER_STARTED_GRACE_SECS +
+  NEVER_STARTED_CONFIRM_MARGIN_SECS` ≈ 1230s), **independent of the flat-CPU hang
+  probe**. This closes the probe blind spot: an init hang that holds an
+  established API socket (model connect) or MCP-server children reads
+  `"progressing"` to `subprocess_hang_verdict` forever, so the flat-CPU probe
+  never fires — but it emits zero output, so the first-output deadline catches it.
+  The deadline sits above the documented slow Opus cold-start ceiling (a healthy
+  cold start stamps `last_stdout_at` on its `system/init` event well before then)
+  and below the 1800s `SESSION_PROGRESS_DEADLINE_S` catch-all it front-runs.
+- **Init-hang circuit breaker** (`agent/session_health.py`,
+  `_apply_recovery_transition`): a kill on a never-communicated session uses
+  `reason_kind="init_hang"`, which finalizes the session terminal (`failed`
+  remote / `abandoned` local) on the **first** occurrence and never requeues to
+  `pending`. Re-spawning the identical zero-output input reproduces the identical
+  hang, so the input is surfaced rather than silently retried. A
+  `{project}:session-health:init_hang_circuit_break` Redis counter tracks these.
+- **Diagnostics** (`agent/session_runner/harness/claude.py`,
+  `_log_init_hang_stderr`): on a teardown that kills the subprocess before it ever
+  emitted a stdout event (`not _first_stdout_seen`), the harness drains and logs
+  the buffered stderr (bounded, best-effort, after the SIGKILL closes the pipe) so
+  the real init blocker (MCP load / oauth / model connect) is knowable instead of
+  lost with the killed pipe.
+
+All three are env-tunable (`FIRST_OUTPUT_DEADLINE_S`,
+`INIT_HANG_STDERR_TIMEOUT_S`, `INIT_HANG_STDERR_MAX_CHARS`).
+
 ## Worker Restart Recovery
 
 Worker restarts (SIGTERM, crash, or explicit `verify command exists or correct syntax`) are non-destructive. Sessions in `pending` or `running` state at restart time are both preserved and will be executed by the new worker process.

--- a/docs/plans/issue-2181-init-hang-first-output-deadline.md
+++ b/docs/plans/issue-2181-init-hang-first-output-deadline.md
@@ -1,0 +1,108 @@
+# Runner init-hang: first-output deadline + init-hang circuit breaker (#2181)
+
+## Root cause
+
+An Eng session hung at runner init: the `claude -p` subprocess started and held
+its process (heartbeats fired) but never emitted a single SDK message
+(`communicated=False` — `derive_sdk_ever_output` False). Zero turns, tokens, or
+tool calls. Every safety net missed it and recovery re-spawned the identical
+input into the identical hang three times over ~70 min.
+
+Why each net failed:
+
+1. **No first-output deadline.** `communicated=False` is logged every 60s but
+   never acted on. The only backstop was the 1800s `SESSION_PROGRESS_DEADLINE_S`
+   catch-all in the owned-task progress watcher (`agent/agent_session_queue.py`).
+2. **Hang-probe blind spot.** `_owned_task_hang_check` → `subprocess_hang_verdict`
+   only returns `"hung"` on flat CPU + no children + no established API socket. An
+   init hang that holds an API socket (model connect) or MCP-server children reads
+   `"progressing"` forever and falls through to the 1800s deadline.
+3. **No circuit breaker.** Recovery requeued the identical zero-output input to
+   `pending`, re-spawning the identical hang instead of failing after the first.
+4. **No diagnostics.** The runner's stderr/stdout was not captured on a
+   `communicated=False` kill, so the real blocker (MCP load / oauth / model
+   connect) was not knowable.
+
+## Approach
+
+Scoped to the four named deliverables:
+
+1. **First-output deadline** (`agent/agent_session_queue.py`): in the owned-task
+   progress watcher, recover a session that has never produced SDK output past
+   `FIRST_OUTPUT_DEADLINE_S` (anchored to the classifier's never-started ceiling
+   `NEVER_STARTED_GRACE_SECS + NEVER_STARTED_CONFIRM_MARGIN_SECS ≈ 1230s`, well
+   below the 1800s catch-all, above the documented ~20-min slow-cold-start
+   ceiling), INDEPENDENT of the flat-CPU probe. This closes the blind spot: a
+   socket-/child-holding init hang is caught by the first-output deadline even
+   when the flat-CPU probe never fires.
+2. **Circuit breaker** (`agent/session_health.py`): a kill on a never-communicated
+   session uses `reason_kind="init_hang"`, which `_apply_recovery_transition`
+   finalizes `failed` (or `abandoned` for local) on the FIRST occurrence instead
+   of requeuing — re-spawning identical input reproduces the identical hang. Cap
+   is inherently 1.
+3. **Diagnostics** (`agent/session_runner/harness/claude.py`): on a teardown that
+   kills the subprocess before it ever emitted a stdout event
+   (`not _first_stdout_seen` — the `communicated=False` shape), drain and log the
+   buffered stderr so the real init blocker is knowable. Best-effort, bounded,
+   never masks the cancellation.
+
+## Success Criteria
+
+- A running session with a live subprocess that has never produced SDK output
+  (`derive_sdk_ever_output` False) is recovered on `FIRST_OUTPUT_DEADLINE_S`
+  (~1230s), independent of the flat-CPU hang probe.
+- A never-communicated init hang holding an API socket / MCP children (flat-CPU
+  probe returns `"progressing"`) is still caught by the first-output deadline.
+- The first zero-output init hang finalizes the session terminal
+  (`failed`/`abandoned`) and is NOT requeued to `pending`.
+- The runner's buffered stderr is captured and logged on a `communicated=False`
+  kill.
+- Scoped unit tests pass; no regression in existing `no_progress` recovery tests.
+
+## No-Gos
+
+- Do not shorten the never-started grace for sessions that legitimately cold-start
+  slowly (Opus + MCP fleet); the first-output deadline sits at the documented
+  ceiling, not below it.
+- Do not requeue a zero-output init hang.
+
+## Update System
+
+No update system changes required — this is purely internal worker/runner logic;
+no new dependencies, config files, or migration steps.
+
+## Agent Integration
+
+No agent integration required — no new CLI entry point or bridge import. The
+change is internal to the worker's session-recovery path.
+
+## Failure Path Test Strategy
+
+Unit tests drive `_apply_recovery_transition` with `reason_kind="init_hang"` and
+assert it finalizes terminal (never requeues to pending), plus the pure
+first-output-deadline predicate and the `init_hang` reason-kind selection in the
+watcher.
+
+## Test Impact
+- [ ] `tests/unit/test_never_started_recovery.py` — no change; existing
+  `reason_kind="no_progress"` assertions are unaffected.
+- New: `tests/unit/test_init_hang_circuit_breaker.py` — covers the first-output
+  deadline predicate, the `init_hang` circuit-breaker terminal finalize, and the
+  diagnostics capture.
+
+## Rabbit Holes
+
+- User-facing messaging coalescing and the `killed`-vs-`failed` finalize
+  reconciliation (issue's remaining acceptance bullets) are out of this focused
+  lane; the circuit breaker removes the re-spawn that produced the duplicate
+  notice in the first place.
+
+## Documentation
+- [ ] Add a "First-output deadline + init-hang circuit breaker (#2181)" subsection
+  to `docs/features/bridge-worker-architecture.md` describing: the
+  `FIRST_OUTPUT_DEADLINE_S` recovery path in the owned-task progress watcher, the
+  `init_hang` reason-kind that finalizes terminal instead of requeuing, and the
+  harness stderr-capture diagnostic on a `communicated=False` kill.
+- [ ] Note the `FIRST_OUTPUT_DEADLINE_S` and `init_hang` telemetry counter
+  (`{project}:session-health:init_hang_circuit_break`) so operators can find them.
+</content>

--- a/tests/integration/test_progress_deadline_cancel.py
+++ b/tests/integration/test_progress_deadline_cancel.py
@@ -258,7 +258,12 @@ async def test_no_progress_session_cancelled_reclaimed_not_requeued(
                     break
 
         assert recovery_calls, "Expected _apply_recovery_transition to fire on the deadline path"
-        assert recovery_calls[0]["reason_kind"] == "progress_deadline"
+        # This session NEVER produced SDK output (last_tool_use_at/last_turn_at
+        # both None, _hang_forever emits nothing) — the issue #2181 init-hang
+        # shape. The deadline kill on a never-communicated session now routes
+        # through the terminal-finalizing `init_hang` reason_kind (circuit
+        # breaker), not the requeue-eligible `progress_deadline`.
+        assert recovery_calls[0]["reason_kind"] == "init_hang"
         assert recovery_calls[0]["handle"] is None
 
         fresh = _fresh(session)

--- a/tests/unit/test_init_hang_circuit_breaker.py
+++ b/tests/unit/test_init_hang_circuit_breaker.py
@@ -1,0 +1,250 @@
+"""Tests for the runner init-hang first-output deadline + circuit breaker (#2181).
+
+Covers the three focused deliverables:
+
+  1. First-output deadline predicate ``_first_output_deadline_exceeded`` — a
+     never-communicated (``communicated=False``) session past
+     ``FIRST_OUTPUT_DEADLINE_S`` is flagged, INDEPENDENT of the flat-CPU hang
+     probe; a session that has produced output, or one still inside the
+     deadline, is not.
+  2. Circuit breaker — ``_apply_recovery_transition`` with
+     ``reason_kind="init_hang"`` finalizes the session terminal (``failed``
+     remote / ``abandoned`` local) on the FIRST occurrence and NEVER requeues to
+     ``pending``.
+  3. Diagnostics — ``_log_init_hang_stderr`` drains and logs a killed
+     subprocess's buffered stderr, and never raises.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import agent.session_health as session_health
+
+# ---------------------------------------------------------------------------
+# Deliverable 1 — first-output deadline predicate
+# ---------------------------------------------------------------------------
+
+
+class TestFirstOutputDeadlinePredicate:
+    """``_first_output_deadline_exceeded`` — the never-communicated leg."""
+
+    @staticmethod
+    def _entry(**overrides):
+        defaults = dict(last_tool_use_at=None, last_turn_at=None, last_stdout_at=None)
+        defaults.update(overrides)
+        return SimpleNamespace(**defaults)
+
+    def test_never_communicated_past_deadline_flagged(self):
+        from agent import agent_session_queue as q
+
+        entry = self._entry()  # derive_sdk_ever_output False
+        acquired_at = 0.0  # long ago
+        with patch(
+            "agent.agent_session_queue.time.time", return_value=q.FIRST_OUTPUT_DEADLINE_S + 5
+        ):
+            assert q._first_output_deadline_exceeded(entry, acquired_at) is True
+
+    def test_never_communicated_inside_deadline_not_flagged(self):
+        from agent import agent_session_queue as q
+
+        entry = self._entry()
+        acquired_at = 0.0
+        with patch(
+            "agent.agent_session_queue.time.time",
+            return_value=q.FIRST_OUTPUT_DEADLINE_S - 60,
+        ):
+            assert q._first_output_deadline_exceeded(entry, acquired_at) is False
+
+    def test_communicated_session_never_flagged(self):
+        """A session that emitted a stdout event (last_stdout_at) is never flagged,
+        no matter how old — the blind spot leg only targets communicated=False."""
+        from agent import agent_session_queue as q
+
+        entry = self._entry(last_stdout_at=datetime.now(UTC))
+        acquired_at = 0.0
+        with patch(
+            "agent.agent_session_queue.time.time",
+            return_value=q.FIRST_OUTPUT_DEADLINE_S * 10,
+        ):
+            assert q._first_output_deadline_exceeded(entry, acquired_at) is False
+
+    def test_deadline_below_progress_catch_all(self):
+        """The first-output deadline must fire meaningfully sooner than the 1800s
+        SESSION_PROGRESS_DEADLINE_S catch-all it front-runs."""
+        from agent import agent_session_queue as q
+
+        assert q.FIRST_OUTPUT_DEADLINE_S < q.SESSION_PROGRESS_DEADLINE_S
+
+
+# ---------------------------------------------------------------------------
+# Deliverable 2 — init-hang circuit breaker in _apply_recovery_transition
+# ---------------------------------------------------------------------------
+
+
+def _recovery_entry(**overrides):
+    """A running remote session on its first recovery attempt, never-communicated."""
+    now = datetime.now(UTC)
+    saves: list[list[str]] = []
+
+    def _save(update_fields=None, **_kw):
+        saves.append(list(update_fields) if update_fields else [])
+
+    defaults = dict(
+        agent_session_id="ih-sess-1",
+        id="ih-sess-1",
+        session_id="sid-ih-1",
+        status="running",
+        project_key="test-init-hang",
+        current_tool_name=None,
+        last_tool_use_at=None,
+        last_turn_at=None,
+        last_stdout_at=None,
+        last_heartbeat_at=now,
+        created_at=now - timedelta(seconds=1400),
+        started_at=None,
+        response_delivered_at=None,
+        claude_pid=None,
+        claude_session_uuid=None,
+        extra_context={},
+        worker_key="telegram-cyndra",
+        recovery_attempts=0,
+        reprieve_count=0,
+        is_project_keyed=True,
+        get_children=MagicMock(return_value=[]),
+        save=_save,
+        delete=lambda **_kw: None,
+        _saves=saves,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+async def _drive_recovery(entry, worker_key, reason_kind):
+    """Drive ``_apply_recovery_transition`` with the confirm-dead + terminal seams
+    stubbed, returning the finalize/transition calls it made."""
+    finalize_calls: list[tuple] = []
+    transition_calls: list[tuple] = []
+
+    def _fake_finalize(e, status, **kw):
+        finalize_calls.append((status, kw.get("reason")))
+
+    def _fake_transition(e, status, **kw):
+        transition_calls.append((status, kw.get("reason")))
+
+    kill_result = SimpleNamespace(confirmed_dead=True, signal_sent=False)
+
+    with (
+        patch.object(session_health, "_delivery_belongs_to_current_run", lambda e: False),
+        patch.object(
+            session_health,
+            "_confirm_subprocess_dead",
+            lambda *a, **k: kill_result,
+        ),
+        patch.object(session_health, "_deliver_deferred_self_draft_fallback", AsyncMock()),
+        patch.object(session_health, "_deliver_terminal_interrupt_notice", AsyncMock()),
+        patch.dict(
+            "sys.modules",
+            {
+                "popoto.redis_db": SimpleNamespace(POPOTO_REDIS_DB=MagicMock()),
+                "models.session_lifecycle": SimpleNamespace(
+                    StatusConflictError=type("StatusConflictError", (Exception,), {}),
+                    finalize_session=_fake_finalize,
+                    transition_status=_fake_transition,
+                ),
+            },
+        ),
+        patch("agent.cancel_reason.set_cancel_reason", lambda *a, **k: None),
+    ):
+        await session_health._apply_recovery_transition(
+            entry,
+            reason="init hang — runner produced no output",
+            reason_kind=reason_kind,
+            handle=None,
+            worker_key=worker_key,
+        )
+    return finalize_calls, transition_calls
+
+
+class TestInitHangCircuitBreaker:
+    async def test_init_hang_finalizes_failed_never_requeues(self):
+        """A remote init_hang on the FIRST attempt finalizes ``failed`` and never
+        transitions to ``pending`` (the circuit breaker)."""
+        entry = _recovery_entry(recovery_attempts=0)
+        finalize_calls, transition_calls = await _drive_recovery(
+            entry, "telegram-cyndra", "init_hang"
+        )
+        assert any(status == "failed" for status, _ in finalize_calls)
+        assert all(status != "pending" for status, _ in transition_calls)
+        assert transition_calls == []  # never requeued
+
+    async def test_progress_deadline_first_attempt_requeues(self):
+        """Control: the SAME first-attempt session under ``progress_deadline``
+        (a communicated session's genuine stall) DOES requeue to ``pending`` —
+        proving init_hang's terminal behavior is the distinguishing change."""
+        entry = _recovery_entry(recovery_attempts=0)
+        finalize_calls, transition_calls = await _drive_recovery(
+            entry, "telegram-cyndra", "progress_deadline"
+        )
+        assert any(status == "pending" for status, _ in transition_calls)
+        assert all(status != "failed" for status, _ in finalize_calls)
+
+    async def test_init_hang_local_abandons(self):
+        """A local init_hang finalizes ``abandoned`` (terminal), still no requeue."""
+        entry = _recovery_entry(recovery_attempts=0)
+        finalize_calls, transition_calls = await _drive_recovery(entry, "local-dev", "init_hang")
+        assert any(status == "abandoned" for status, _ in finalize_calls)
+        assert transition_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Deliverable 3 — diagnostics
+# ---------------------------------------------------------------------------
+
+
+class _FakeStderr:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    async def read(self, n: int = -1) -> bytes:
+        return self._data
+
+
+class TestInitHangStderrDiagnostics:
+    async def test_logs_buffered_stderr(self):
+        from agent.session_runner.harness import claude
+
+        proc = SimpleNamespace(stderr=_FakeStderr(b"MCP server 'x' failed to connect"))
+        with patch.object(claude.logger, "warning") as warn:
+            await claude._log_init_hang_stderr(proc, "sid-123")
+        assert warn.called
+        logged = " ".join(str(a) for a in warn.call_args[0])
+        assert "sid-123" in logged or "sid-123" in str(warn.call_args)
+
+    async def test_empty_stderr_does_not_raise(self):
+        from agent.session_runner.harness import claude
+
+        proc = SimpleNamespace(stderr=_FakeStderr(b""))
+        await claude._log_init_hang_stderr(proc, "sid-empty")  # must not raise
+
+    async def test_missing_stderr_is_noop(self):
+        from agent.session_runner.harness import claude
+
+        proc = SimpleNamespace(stderr=None)
+        await claude._log_init_hang_stderr(proc, "sid-none")  # must not raise
+
+    async def test_read_timeout_is_swallowed(self, monkeypatch):
+        from agent.session_runner.harness import claude
+
+        class _HangStderr:
+            async def read(self, n: int = -1) -> bytes:
+                import asyncio
+
+                await asyncio.sleep(10)
+                return b""
+
+        monkeypatch.setattr(claude, "INIT_HANG_STDERR_TIMEOUT_S", 0.01)
+        proc = SimpleNamespace(stderr=_HangStderr())
+        await claude._log_init_hang_stderr(proc, "sid-hang")  # must return, not hang


### PR DESCRIPTION
Closes #2181.

## Problem

An Eng session hung at runner **init**: the `claude -p` subprocess started and held its process (heartbeats fired) but never emitted a single SDK message (`communicated=False` — zero turns, tokens, tool calls). Every safety net was too slow or missed it, and recovery re-spawned the identical zero-output input into the identical hang three times over ~70 min, posting two duplicate "I was stopped…" messages and doing no work.

Why each net failed:
1. **No first-output deadline** — `communicated=False` was logged every 60s but never acted on; the only backstop was the 1800s `SESSION_PROGRESS_DEADLINE_S` catch-all.
2. **Hang-probe blind spot** — an init hang holding an established API socket / MCP-server children reads `"progressing"` to `subprocess_hang_verdict` forever, so the flat-CPU probe never fires.
3. **No circuit breaker** — recovery requeued the identical zero-output input to `pending`, re-spawning the identical hang.
4. **No diagnostics** — the runner's stderr/stdout was not captured on a `communicated=False` kill, so the real blocker (MCP load / oauth / model connect) was not knowable.

## Changes

- **First-output deadline** (`agent/agent_session_queue.py`): `_first_output_deadline_exceeded` / `FIRST_OUTPUT_DEADLINE_S` (default ≈1230s, anchored to the never-started ceiling `NEVER_STARTED_GRACE_SECS + NEVER_STARTED_CONFIRM_MARGIN_SECS`, below the 1800s catch-all, above the documented slow-cold-start ceiling). The owned-task watcher recovers a never-communicated session on this deadline **independent of the flat-CPU probe** — closing the blind spot.
- **Init-hang circuit breaker** (`agent/session_health.py`): a kill on a never-communicated session uses `reason_kind="init_hang"`, which `_apply_recovery_transition` finalizes terminal (`failed` remote / `abandoned` local) on the FIRST occurrence and **never requeues**. Tracked via `{project}:session-health:init_hang_circuit_break`.
- **Diagnostics** (`agent/session_runner/harness/claude.py`): `_log_init_hang_stderr` drains and logs the killed subprocess's buffered stderr when it never emitted a stdout event — bounded, best-effort, never masks the cancellation.

## Tests

- New `tests/unit/test_init_hang_circuit_breaker.py` (11 tests): first-output-deadline predicate, `init_hang` terminal-finalize vs `progress_deadline` requeue control, local-abandon, and diagnostics (logs stderr / empty / missing / timeout, never raises).
- Updated the never-communicated deadline assertion in `tests/integration/test_progress_deadline_cancel.py` (now correctly classified `init_hang`).
- Scoped run: `test_init_hang_circuit_breaker.py`, `test_progress_deadline_cancel.py`, `test_never_started_recovery.py`, `test_hang_probe.py`, `test_health_check_recovery_finalization.py` all green.

## Scope note

The issue's remaining acceptance bullets (user-facing message coalescing, `killed`-vs-`failed` finalize reconciliation) are out of this focused lane; the circuit breaker removes the re-spawn that produced the duplicate notice in the first place.