### PR TITLE
Bridge ⚠ reaction when no worker is alive (#1312)

### DIFF
--- a/agent/session_health.py
+++ b/agent/session_health.py
@@ -4348,6 +4348,57 @@ def _publish_loop_beacon() -> None:
         logger.debug("[session-health] loop-beacon publish failed (non-fatal): %s", e)
 
 
+def worker_loop_beacon_fresh(host: str | None = None) -> bool:
+    """Return ``True`` iff this host's worker loop beacon is fresh (worker alive).
+
+    Reads ``worker:loop_beacon:{host}`` (default ``host`` = the hostname
+    ``_publish_loop_beacon`` writes under, ``_ORPHAN_REAP_HOSTNAME``), parses the
+    JSON payload, and returns ``True`` iff the beacon exists and its wall-clock
+    ``wall_ts`` is within ``BRIDGE_WORKER_BEACON_STALE_S`` seconds of now.
+
+    Freshness is keyed ONLY on the wall-clock ``wall_ts`` (Risk 1) — never the
+    advisory monotonic ``loop_beacon_age_s``, which is meaningless across
+    processes.
+
+    ``armed`` handling: an unarmed-but-FRESH beacon (worker process up, loop not
+    yet ticked) returns ``True`` — a startup grace so a just-launched worker is
+    never reported down. Only a missing or stale beacon returns ``False``.
+
+    Fail-CLOSED: returns ``False`` on a missing/expired key, a missing or
+    non-numeric ``wall_ts``, malformed JSON, or ANY Redis error. A bridge that
+    cannot positively confirm a live worker treats the worker as down — warning
+    the user is strictly safer than a silent false "all good."
+
+    This is the single freshness definition shared by the bridge ingestion-time
+    ⚠ signal (``bridge.response.react_if_worker_down``) and the watchdog's
+    ``check_worker_liveness_and_slots`` freshness read.
+    """
+    target_host = host if host is not None else _ORPHAN_REAP_HOSTNAME
+    try:
+        from popoto.redis_db import POPOTO_REDIS_DB as _R  # noqa: PLC0415
+
+        raw = _R.get(f"{WORKER_LOOP_BEACON_KEY_PREFIX}{target_host}")
+    except Exception as e:
+        logger.debug("[session-health] loop-beacon read failed (fail-closed): %s", e)
+        return False
+
+    if raw is None:
+        return False
+
+    try:
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8", "replace")
+        beacon = json.loads(raw)
+        wall_ts = float(beacon["wall_ts"])
+    except Exception:
+        # Malformed JSON / missing / non-numeric wall_ts → fail-closed.
+        return False
+
+    # wall_ts-only freshness (Risk 1). An unarmed-but-fresh beacon still returns
+    # True (startup grace) — freshness never consults the advisory monotonic age.
+    return (time.time() - wall_ts) <= BRIDGE_WORKER_BEACON_STALE_S
+
+
 async def _agent_session_health_loop() -> None:
     """Periodically check running sessions for liveness and timeout."""
     # #2098: this loop runs ONLY in the owning worker process, so mark it as the

--- a/bridge/response.py
+++ b/bridge/response.py
@@ -115,6 +115,10 @@ REACTION_PROCESSING = "✍"  # Actively composing a reply (distinct from REACTIO
 # standing down") instead of the standard "noted" eyes. Selected inside
 # _ack_steering_routed() in bridge/telegram_bridge.py — never at call sites.
 REACTION_ABORT = "🫡"  # Steering abort acknowledged
+# Applied at ingestion when this machine's worker is NOT alive (#1312): the
+# message still enqueues, but ⚠ signals "paused, not lost" instead of a normal
+# 👀 that would imply work is in progress.
+REACTION_WORKER_DOWN = "⚠"  # Worker not alive — enqueued but not being processed
 
 # REACTION_COMPLETE, REACTION_ERROR, REACTION_SUCCESS are re-exported from
 # agent.constants (canonical location) — imported at top of file for
@@ -133,6 +137,7 @@ def _reaction_constants() -> dict[str, str]:
         "REACTION_RECEIVED": REACTION_RECEIVED,
         "REACTION_PROCESSING": REACTION_PROCESSING,
         "REACTION_ABORT": REACTION_ABORT,
+        "REACTION_WORKER_DOWN": REACTION_WORKER_DOWN,
         "REACTION_SUCCESS": str(REACTION_SUCCESS),
         "REACTION_COMPLETE": str(REACTION_COMPLETE),
         "REACTION_ERROR": str(REACTION_ERROR),
@@ -376,3 +381,38 @@ async def set_reaction(
     except Exception as e:
         logger.debug(f"Could not set reaction '{standard_emoji}': {e}")
         return False
+
+
+async def react_if_worker_down(client, chat_id, message_id, session_id) -> None:
+    """Apply the ⚠ worker-down reaction when this machine's worker is not alive.
+
+    Ingestion-time liveness signal (#1312). Called immediately before each
+    ``dispatch_telegram_session`` enqueue: if the worker loop beacon is not fresh
+    (worker process down/wedged, or Redis unreadable → fail-closed), overwrite
+    the message reaction with ``REACTION_WORKER_DOWN`` so the user sees "paused,
+    not lost." The enqueue still proceeds unconditionally at the call site — no
+    work is dropped; this helper only signals.
+
+    When ⚠ is set, ``record_worker_down_reaction`` records the (session, chat,
+    message) tuple so the already-merged worker-recovery path (#2178) can later
+    clear the reaction once the worker is back. That is why ``session_id`` is
+    required here — this helper only RECORDS; it never clears.
+
+    Fully fail-quiet: never raises into the handler. A fresh beacon is a no-op
+    (happy path byte-identical — no extra reaction).
+    """
+    try:
+        from agent.session_health import worker_loop_beacon_fresh
+
+        if worker_loop_beacon_fresh():
+            return
+
+        # Worker not alive: signal ⚠ (swallow set_reaction failures — non-fatal,
+        # matching the existing "set_reaction failed (non-fatal)" pattern) and
+        # record for the #2178 recovery-time clear.
+        await set_reaction(client, chat_id, message_id, REACTION_WORKER_DOWN)
+        from agent.worker_down_reactions import record_worker_down_reaction
+
+        record_worker_down_reaction(session_id, chat_id, message_id)
+    except Exception as e:
+        logger.debug(f"react_if_worker_down failed (non-fatal): {e}")

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -124,6 +124,7 @@ from bridge.response import (  # noqa: E402
     clean_message,
     extract_files_from_response,
     filter_tool_logs,
+    react_if_worker_down,
     set_reaction,
 )
 from bridge.routing import (  # noqa: E402
@@ -1951,6 +1952,10 @@ async def main():
                         _completed_extra_overrides: dict | None = None
                         if reply_chain_context:
                             _completed_extra_overrides = {"reply_chain_hydrated": True}
+                        # #1312: signal ⚠ if this machine's worker is not alive.
+                        # The wrap precedes enqueue; the enqueue below is
+                        # unconditional (no work is dropped when the worker is down).
+                        await react_if_worker_down(client, event.chat_id, message.id, session_id)
                         await dispatch_telegram_session(
                             project_key=project_key,
                             session_id=session_id,
@@ -2472,6 +2477,9 @@ async def main():
         # Pass full project config so the session carries it through the pipeline.
         # dispatch_telegram_session wraps enqueue_agent_session + dedup record so
         # every live-handler enqueue site has dedup recorded atomically.
+        # #1312: signal ⚠ if this machine's worker is not alive. The wrap precedes
+        # enqueue; the enqueue below is unconditional (no work is dropped).
+        await react_if_worker_down(client, event.chat_id, message.id, session_id)
         depth = await dispatch_telegram_session(
             project_key=project_key,
             session_id=session_id,
@@ -2645,6 +2653,9 @@ async def main():
                 )
                 await set_reaction(client, event.chat_id, message.id, REACTION_RECEIVED)
             else:
+                # #1312: signal ⚠ if this machine's worker is not alive. The wrap
+                # precedes enqueue; the enqueue below is unconditional.
+                await react_if_worker_down(client, event.chat_id, message.id, new_session_id)
                 depth = await dispatch_telegram_session(
                     project_key=project_key,
                     session_id=new_session_id,

--- a/docs/features/bridge-resilience.md
+++ b/docs/features/bridge-resilience.md
@@ -85,8 +85,50 @@ Shows all sessions grouped by worker_key with worker status, session IDs, correl
 
 `ReflectionRunner._preflight_check()` validates prerequisites (Redis, gh CLI) before each reflection step, logging a single warning line on failure instead of crashing with a traceback.
 
+## Worker-liveness Ingestion Signal
+
+When a Telegram message arrives, the bridge enqueues an `AgentSession` for the
+worker to drain. If this machine's worker process is dead, that session sits in
+`pending` forever — yet the user still sees the normal "seen" reaction (👀), so
+the outage looks like work-in-progress. On 2026-05-06 this silent-failure mode
+turned a 30-second worker outage into a 7-hour one (issue #1312).
+
+To make a paused pipeline visible, the bridge checks worker liveness at
+ingestion time and applies a distinct **⚠ reaction** (`REACTION_WORKER_DOWN`)
+when the worker is not alive:
+
+- **Signal source.** `agent.session_health.worker_loop_beacon_fresh(host=None)`
+  reads the worker's wall-clock loop beacon `worker:loop_beacon:{host}` (published
+  every 30s by `_publish_loop_beacon`). It returns `True` iff the beacon exists
+  and its `wall_ts` is within `BRIDGE_WORKER_BEACON_STALE_S` (default **90s**,
+  env-overridable) of now. This is the single freshness definition shared with the
+  session watchdog (`monitoring/session_watchdog.py` delegates its fresh/stale read
+  to it — no duplicate beacon read or threshold constant).
+- **wall_ts-only (Risk 1).** Freshness keys ONLY on the wall-clock `wall_ts`,
+  never the advisory monotonic `loop_beacon_age_s` (a per-process value that is
+  meaningless cross-process). An unarmed-but-fresh beacon (worker up, loop not yet
+  ticked) counts as alive — a startup grace that avoids false warnings.
+- **Fail-closed.** A missing/expired key, malformed JSON, a missing/non-numeric
+  `wall_ts`, or ANY Redis error returns `False` (worker treated as down). A bridge
+  that cannot positively confirm a live worker warns the user; a spurious ⚠ during
+  a Redis blip is strictly safer than a silent false "all good."
+- **Never drops work.** `bridge.response.react_if_worker_down(client, chat_id,
+  message_id, session_id)` runs immediately BEFORE each `dispatch_telegram_session`
+  call site in `bridge/telegram_bridge.py`; the enqueue proceeds
+  **unconditionally** afterward. The reaction is purely additive signalling. When
+  the worker is alive, nothing changes — the happy path is byte-identical.
+- **Detection window.** The beacon refreshes every 30s and reads fresh for up to
+  90s, so a message in the ~90s immediately after the worker dies may still get 👀
+  rather than ⚠. For the multi-hour outages this targets, 90s is negligible.
+- **Recovery-time clear (#2178).** When ⚠ is set, the helper calls
+  `agent.worker_down_reactions.record_worker_down_reaction(...)` so the
+  already-merged worker-recovery path can clear the ⚠ once the worker returns. This
+  ingestion-time signal is the companion to the recovery machinery documented in
+  [Worker Liveness Recovery](worker-liveness-recovery.md).
+
 ## Related
 
+- [Worker Liveness Recovery](worker-liveness-recovery.md) - Dead-man's-switch heartbeat + loop beacon this ingestion signal reads
 - [Bridge Self-Healing](bridge-self-healing.md) - Crash recovery and watchdog
 - [Session Watchdog](session-watchdog.md) - Session health monitoring
 - [Agent Session Health Monitor](agent-session-health-monitor.md) - Session liveness checking

--- a/docs/features/worker-liveness-recovery.md
+++ b/docs/features/worker-liveness-recovery.md
@@ -271,6 +271,10 @@ Both deferred follow-ups have since shipped:
 - [Out-of-Domain Recovery + Per-Tool Budget Backstop](out-of-domain-recovery.md) —
   the bridge-domain reclaim trigger built on top of this beacon, plus the
   synchronous per-tool budget (#1821)
+- [Bridge Resilience: Worker-liveness Ingestion Signal](bridge-resilience.md#worker-liveness-ingestion-signal) —
+  the ingestion-time companion to this recovery machinery: the bridge reads the
+  same loop beacon via `worker_loop_beacon_fresh` and applies a ⚠ reaction when
+  the worker is not alive, so a paused pipeline is visible to the user (#1312)
 - [Redis Durability: Off-Loop Redis Access](redis-durability.md#off-loop-redis-access-fix-4):
   moves the drain loop's hot-path Redis query off the event loop so a slow Redis
   cannot starve this beacon's tick task (#1826)

--- a/docs/plans/bridge-worker-liveness-reaction.md
+++ b/docs/plans/bridge-worker-liveness-reaction.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: docs_complete
 type: bug
 appetite: Small
 owner: Valor Engels

--- a/monitoring/session_watchdog.py
+++ b/monitoring/session_watchdog.py
@@ -140,7 +140,14 @@ WORKER_WATCHDOG_ACTIONS_KEY_PREFIX = "worker:watchdog:actions:"
 # Beacon-freshness threshold: a beacon whose wall_ts is older than this (or a
 # missing beacon) reads as loop_wedged. Wall-clock ONLY — never the advisory
 # monotonic loop_beacon_age_s (Risk 1). Default 90s (matches the #1815 deadman).
-BRIDGE_WORKER_BEACON_STALE_S = int(os.environ.get("BRIDGE_WORKER_BEACON_STALE_S", "90"))
+# Single-sourced in agent/session_health.py alongside the beacon publisher and
+# the shared worker_loop_beacon_fresh() reader — imported here, never re-read
+# from the environment in two places (#1312 extraction).
+from agent.session_health import (  # noqa: E402
+    BRIDGE_WORKER_BEACON_STALE_S,
+    worker_loop_beacon_fresh,
+)
+
 # Master gate for the reclaim-request TRIGGER. Default ON — detection/logging
 # always runs; only the reclaim-request push is gated. Falsy → detect/log only.
 # (Uses the _env_flag_enabled helper below at call time.)
@@ -751,8 +758,12 @@ def check_worker_liveness_and_slots() -> None:
         _record_loop_wedged(POPOTO_REDIS_DB, host, now, "beacon JSON malformed")
         return
 
-    # Freshness keyed ONLY on wall_ts (Risk 1 — never the monotonic advisory age).
-    if (now - wall_ts) > BRIDGE_WORKER_BEACON_STALE_S:
+    # Freshness keyed ONLY on wall_ts (Risk 1 — never the monotonic advisory
+    # age). The boolean fresh/stale decision is delegated to the shared
+    # worker_loop_beacon_fresh() reader (#1312) so there is exactly one freshness
+    # definition; the missing/malformed branches above stay local because they
+    # need distinct loop_wedged detail strings + the parsed `armed` field below.
+    if not worker_loop_beacon_fresh(host):
         _record_loop_wedged(
             POPOTO_REDIS_DB,
             host,

--- a/tests/integration/test_worker_liveness_ingestion.py
+++ b/tests/integration/test_worker_liveness_ingestion.py
@@ -1,0 +1,98 @@
+"""Integration coverage for the #1312 worker-liveness ingestion signal.
+
+Composes the two real units the bridge call sites wire together —
+``bridge.response.react_if_worker_down`` and ``bridge.dispatch.dispatch_telegram_session``
+— in the exact order the live handler runs them (react FIRST, then enqueue),
+and asserts the load-bearing contract:
+
+- The message ENQUEUES on BOTH the worker-alive and worker-down paths (the ⚠
+  signal never drops work).
+- ⚠ is applied ONLY on the worker-down path (happy path adds no reaction).
+
+Only the leaf side-effects (Redis beacon read, Telegram reaction send, the
+dispatch claim/enqueue/dedup writes) are mocked; the react→dispatch wiring and
+the freshness decision run for real.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bridge.dispatch import dispatch_telegram_session
+from bridge.response import REACTION_WORKER_DOWN, react_if_worker_down
+
+
+def _beacon_get(fresh: bool):
+    """Return a Redis-.get() replacement yielding a fresh or stale loop beacon."""
+    wall_ts = time.time() if fresh else time.time() - 100_000
+    payload = json.dumps({"wall_ts": wall_ts, "loop_beacon_age_s": 1.0, "armed": True})
+
+    def _get(key, *a, **k):
+        if isinstance(key, str) and key.startswith("worker:loop_beacon:"):
+            return payload
+        return None
+
+    return _get
+
+
+async def _ingest(worker_fresh: bool):
+    """Run the call-site sequence: react_if_worker_down THEN dispatch.
+
+    Returns ``(enqueue_called, worker_down_reaction_applied)``.
+    """
+    client = MagicMock()
+    redis = MagicMock()
+    redis.get.side_effect = _beacon_get(worker_fresh)
+
+    applied: list[str] = []
+
+    async def _fake_set_reaction(_client, _chat, _msg, emoji):
+        applied.append(str(emoji))
+        return True
+
+    with (
+        patch("popoto.redis_db.POPOTO_REDIS_DB", redis),
+        patch("bridge.response.set_reaction", new=_fake_set_reaction),
+        patch("agent.worker_down_reactions.record_worker_down_reaction"),
+        # Dispatch leaf side-effects (mirrors tests/unit/bridge/test_dispatch.py).
+        patch("bridge.dispatch.claim_message", new=AsyncMock(return_value=True)),
+        patch(
+            "bridge.dispatch.enqueue_agent_session", new=AsyncMock(return_value=1)
+        ) as mock_enqueue,
+        patch("bridge.dispatch.record_message_processed", new=AsyncMock()),
+        patch("bridge.dispatch.record_last_processed", new=AsyncMock()),
+        patch("bridge.dispatch._append_inbound_chat_log"),
+    ):
+        # Exactly the call-site order: signal first, enqueue unconditionally after.
+        await react_if_worker_down(client, "chat-1", 101, "sess-1")
+        await dispatch_telegram_session(
+            project_key="test-project",
+            session_id="sess-1",
+            working_dir="/tmp/test",
+            message_text="hello",
+            sender_name="Tom",
+            chat_id="chat-1",
+            telegram_message_id=101,
+        )
+
+    enqueue_called = mock_enqueue.await_count > 0
+    worker_down_applied = REACTION_WORKER_DOWN in applied
+    return enqueue_called, worker_down_applied
+
+
+@pytest.mark.asyncio
+async def test_worker_alive_enqueues_without_warning():
+    enqueue_called, warned = await _ingest(worker_fresh=True)
+    assert enqueue_called is True  # no dropped work on the happy path
+    assert warned is False  # happy path adds no reaction
+
+
+@pytest.mark.asyncio
+async def test_worker_down_enqueues_and_warns():
+    enqueue_called, warned = await _ingest(worker_fresh=False)
+    assert enqueue_called is True  # worker-down must NEVER drop work
+    assert warned is True  # ⚠ applied on the down path

--- a/tests/unit/test_bridge_worker_liveness_reaction.py
+++ b/tests/unit/test_bridge_worker_liveness_reaction.py
@@ -1,0 +1,154 @@
+"""Unit tests for the #1312 worker-liveness ingestion signal.
+
+Two units under test:
+
+- ``agent.session_health.worker_loop_beacon_fresh`` — the single, fail-closed
+  freshness definition. Freshness is keyed ONLY on the wall-clock ``wall_ts``
+  (Risk 1); an unarmed-but-fresh beacon is still alive (startup grace); a
+  missing/malformed/expired key or ANY Redis error returns ``False``.
+- ``bridge.response.react_if_worker_down`` — applies ⚠ + records for the #2178
+  clear path when the worker is down, is a no-op when the worker is alive, and
+  is fully fail-quiet (a raising ``set_reaction`` never propagates).
+
+All tests patch the Redis client / helpers — no production Redis is touched.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import agent.session_health as sh
+from bridge.response import REACTION_WORKER_DOWN, react_if_worker_down
+
+# ---------------------------------------------------------------------------
+# worker_loop_beacon_fresh — freshness matrix
+# ---------------------------------------------------------------------------
+
+
+def _fake_redis(raw):
+    """A Redis stub whose .get() returns ``raw`` (or raises if ``raw`` is an Exception)."""
+    r = MagicMock()
+    if isinstance(raw, Exception):
+        r.get.side_effect = raw
+    else:
+        r.get.return_value = raw
+    return r
+
+
+def _patch_redis(raw):
+    return patch("popoto.redis_db.POPOTO_REDIS_DB", _fake_redis(raw))
+
+
+def _beacon(wall_ts, *, armed=True, age=0.0):
+    return json.dumps({"wall_ts": wall_ts, "loop_beacon_age_s": age, "armed": armed})
+
+
+def test_fresh_beacon_is_alive():
+    with _patch_redis(_beacon(time.time())):
+        assert sh.worker_loop_beacon_fresh() is True
+
+
+def test_stale_wall_ts_is_down():
+    old = time.time() - (sh.BRIDGE_WORKER_BEACON_STALE_S + 30)
+    with _patch_redis(_beacon(old)):
+        assert sh.worker_loop_beacon_fresh() is False
+
+
+def test_missing_key_is_down():
+    with _patch_redis(None):
+        assert sh.worker_loop_beacon_fresh() is False
+
+
+def test_malformed_json_is_down():
+    with _patch_redis("not-json{"):
+        assert sh.worker_loop_beacon_fresh() is False
+
+
+def test_non_numeric_wall_ts_is_down():
+    with _patch_redis(json.dumps({"wall_ts": "abc", "armed": True})):
+        assert sh.worker_loop_beacon_fresh() is False
+
+
+def test_missing_wall_ts_field_is_down():
+    with _patch_redis(json.dumps({"armed": True})):
+        assert sh.worker_loop_beacon_fresh() is False
+
+
+def test_redis_error_is_down_fail_closed():
+    with _patch_redis(RuntimeError("redis down")):
+        assert sh.worker_loop_beacon_fresh() is False
+
+
+def test_unarmed_but_fresh_is_alive_startup_grace():
+    """Worker process up, loop not yet ticked → alive (freshness ignores armed)."""
+    with _patch_redis(_beacon(time.time(), armed=False, age=None)):
+        assert sh.worker_loop_beacon_fresh() is True
+
+
+def test_bytes_payload_is_decoded():
+    with _patch_redis(_beacon(time.time()).encode("utf-8")):
+        assert sh.worker_loop_beacon_fresh() is True
+
+
+def test_host_override_is_used():
+    r = _fake_redis(_beacon(time.time()))
+    with patch("popoto.redis_db.POPOTO_REDIS_DB", r):
+        sh.worker_loop_beacon_fresh(host="other-host")
+    r.get.assert_called_once_with("worker:loop_beacon:other-host")
+
+
+# ---------------------------------------------------------------------------
+# react_if_worker_down — reaction behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reacts_and_records_when_worker_down():
+    client = MagicMock()
+    with (
+        patch("agent.session_health.worker_loop_beacon_fresh", return_value=False),
+        patch("bridge.response.set_reaction", new=AsyncMock(return_value=True)) as set_rx,
+        patch("agent.worker_down_reactions.record_worker_down_reaction") as record,
+    ):
+        await react_if_worker_down(client, 123, 456, "sess-abc")
+
+    set_rx.assert_awaited_once_with(client, 123, 456, REACTION_WORKER_DOWN)
+    record.assert_called_once_with("sess-abc", 123, 456)
+
+
+@pytest.mark.asyncio
+async def test_no_reaction_when_worker_alive():
+    client = MagicMock()
+    with (
+        patch("agent.session_health.worker_loop_beacon_fresh", return_value=True),
+        patch("bridge.response.set_reaction", new=AsyncMock()) as set_rx,
+        patch("agent.worker_down_reactions.record_worker_down_reaction") as record,
+    ):
+        await react_if_worker_down(client, 123, 456, "sess-abc")
+
+    set_rx.assert_not_awaited()
+    record.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fail_quiet_when_set_reaction_raises():
+    """A raising set_reaction must NOT propagate into the handler (enqueue must proceed)."""
+    client = MagicMock()
+    with (
+        patch("agent.session_health.worker_loop_beacon_fresh", return_value=False),
+        patch(
+            "bridge.response.set_reaction",
+            new=AsyncMock(side_effect=RuntimeError("telegram boom")),
+        ),
+        patch("agent.worker_down_reactions.record_worker_down_reaction") as record,
+    ):
+        # Must not raise.
+        await react_if_worker_down(client, 123, 456, "sess-abc")
+
+    # set_reaction raised before the record call — recording never happened, but
+    # the handler survived (no exception propagated).
+    record.assert_not_called()

--- a/tests/unit/test_session_watchdog.py
+++ b/tests/unit/test_session_watchdog.py
@@ -6,6 +6,7 @@ import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 from popoto.exceptions import ModelException
@@ -606,3 +607,49 @@ class TestCheckWorkerLivenessAndSlots:
         src = inspect.getsource(sw.check_worker_liveness_and_slots)
         for token in ("os.kill", "launchctl", "SIGKILL", "SIGABRT", "watchdog:critical"):
             assert token not in src, f"no-second-killer violation: {token!r} present"
+
+    def test_stale_beacon_records_loop_wedged(self):
+        """A parseable-but-stale beacon records loop_wedged (delegated freshness read)."""
+        import monitoring.session_watchdog as sw
+
+        host = self._host()
+        r = self._redis()
+        r.delete(f"{host}:worker-watchdog:loop_wedged_detected")
+        stale = time.time() - (sw.BRIDGE_WORKER_BEACON_STALE_S + 30)
+        r.set(
+            f"worker:loop_beacon:{host}",
+            json.dumps({"wall_ts": stale, "loop_beacon_age_s": 5.0, "armed": True}),
+            ex=90,
+        )
+
+        sw.check_worker_liveness_and_slots()
+
+        val = r.get(f"{host}:worker-watchdog:loop_wedged_detected")
+        assert val is not None and int(val) >= 1
+
+    def test_freshness_read_delegates_to_shared_helper(self):
+        """The watchdog's fresh/stale decision goes through worker_loop_beacon_fresh.
+
+        Behaviour-preservation guard for the #1312 extraction: a fresh, armed
+        beacon must NOT record loop_wedged, and the shared helper must be the
+        function that produced the fresh verdict.
+        """
+        import monitoring.session_watchdog as sw
+
+        host = self._host()
+        r = self._redis()
+        r.delete(f"{host}:worker-watchdog:loop_wedged_detected")
+        r.set(
+            f"worker:loop_beacon:{host}",
+            json.dumps({"wall_ts": time.time(), "loop_beacon_age_s": 1.0, "armed": True}),
+            ex=90,
+        )
+
+        with patch.object(
+            sw, "worker_loop_beacon_fresh", wraps=sw.worker_loop_beacon_fresh
+        ) as fresh:
+            sw.check_worker_liveness_and_slots()
+
+        fresh.assert_called_once_with(host)
+        # Fresh + armed → never wedged (behaviour unchanged across the refactor).
+        assert r.get(f"{host}:worker-watchdog:loop_wedged_detected") is None


### PR DESCRIPTION
## Summary

Bridge now applies a distinct ⚠ reaction at message ingestion when this machine's worker process is not alive, so a paused pipeline is visible instead of masquerading as work-in-progress (the silent-rot that turned a 30s outage into 7h on 2026-05-06).

Closes #1312

## What changed

- **`agent/session_health.py`**: new `worker_loop_beacon_fresh(host=None) -> bool` — the single, fail-closed freshness reader of the `worker:loop_beacon:{host}` wall-clock beacon (`wall_ts`-only, unarmed-but-fresh = alive, 90s window via relocated `BRIDGE_WORKER_BEACON_STALE_S`).
- **`monitoring/session_watchdog.py`**: delegates its inlined beacon read to the new helper (DRY — one freshness definition, one threshold constant; no duplicate `os.environ.get`).
- **`bridge/response.py`**: new `REACTION_WORKER_DOWN = "⚠"` constant + `react_if_worker_down(client, chat_id, message_id, session_id)` — fully fail-quiet; records via `record_worker_down_reaction` for the #2178 recovery-time clear.
- **`bridge/telegram_bridge.py`**: three call sites now call `react_if_worker_down(...)` immediately before `dispatch_telegram_session(...)`; enqueue proceeds unconditionally (no work dropped).
- **Docs**: `docs/features/bridge-resilience.md` (new "Worker-liveness Ingestion Signal" section) + cross-reference from `docs/features/worker-liveness-recovery.md`.

## Verification

- Unit: `tests/unit/test_bridge_worker_liveness_reaction.py` + updated `test_session_watchdog.py` — 53 passed
- Integration: `tests/integration/test_worker_liveness_ingestion.py` — 2 passed (enqueue on both paths; ⚠ only on down)
- No circular import (`import monitoring.session_watchdog, agent.session_health` OK)
- ruff check + format clean on all changed files (2 pre-existing UP038 in session_health.py are outside this diff)
- All plan `## Verification` table greps pass

## Notes

- Detection window is up to ~90s after worker death (beacon staleness) — accepted for v1; the multi-hour outage case is covered.
- Fail-closed on Redis errors (spurious ⚠ safer than silent false "all good").
- Out of scope (separate slugs): reaction reconciliation/clear lifecycle is #2178; graceful-shutdown beacon-clear is a follow-up.
