### PR TITLE
Suppress drafter-fallback re-enqueue on terminal self-draft deferral

### DIFF
--- a/agent/output_handler.py
+++ b/agent/output_handler.py
@@ -17,6 +17,16 @@ import time
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
+# Sender literal stamped on self-draft steering messages pushed by
+# `_inject_self_draft_steering` (see push site below). Also referenced by
+# `agent/session_executor.py`'s leftover-steering re-enqueue partition
+# (issue #1794 / #2197): drafter-fallback steering is dropped there because
+# the terminal delivery flush (`session_health.flush_deferred_self_draft_sync`
+# or the email async `_deliver_deferred_self_draft_fallback`) already owns
+# delivering that content — re-enqueuing it too spawns a redundant,
+# context-blind continuation session.
+DRAFTER_FALLBACK_SENDER = "drafter-fallback"
+
 logger = logging.getLogger(__name__)
 
 # Default directory for worker output logs
@@ -989,7 +999,7 @@ class TelegramRelayOutputHandler:
         try:
             from agent.steering import peek_steering_sender
 
-            if peek_steering_sender(session_id) == "drafter-fallback":
+            if peek_steering_sender(session_id) == DRAFTER_FALLBACK_SENDER:
                 logger.warning(
                     "Self-draft steering already pending for session %s; "
                     "falling through to narration gate",
@@ -1047,7 +1057,7 @@ class TelegramRelayOutputHandler:
             push_steering_message(
                 session_id,
                 instruction,
-                sender="drafter-fallback",
+                sender=DRAFTER_FALLBACK_SENDER,
             )
             logger.info(
                 "Injected self-draft steering for session %s (validator flagged output)",

--- a/agent/session_executor.py
+++ b/agent/session_executor.py
@@ -799,6 +799,99 @@ async def _maybe_send_failure_notice(messenger, session_id: str) -> None:
         logger.warning("[%s] Failure-notice best-effort send failed: %s", session_id, err)
 
 
+async def _reenqueue_leftover_steering(
+    session: AgentSession,
+    agent_session: AgentSession | None,
+    working_dir: Path,
+    leftover: list[dict],
+) -> None:
+    """Partition unconsumed steering messages and re-enqueue only genuine ones.
+
+    Issue #1794 / #2197: on a terminal-turn self-draft deferral, two independent
+    handlers used to fire uncoordinated. The terminal delivery flush
+    (``agent.session_health.flush_deferred_self_draft_sync`` for the telegram
+    sync path, or ``_deliver_deferred_self_draft_fallback`` for the email async
+    path) already owns delivering the held ``drafter-fallback`` steering text
+    exactly once. This re-enqueue block used to pop the *same* still-present
+    ``drafter-fallback`` steering message and re-enqueue it via
+    ``enqueue_agent_session`` (which has no ``claude_session_uuid`` param), so it
+    spawned a brand-new, context-blind Claude session. That session, told to
+    "rewrite it" with no "it" to rewrite, took the ``SELF_DRAFT_INSTRUCTION``
+    escape hatch and emitted a misleading "no substantive results" reply even
+    though the prior turn produced real, correct output.
+
+    ``drafter-fallback`` messages are therefore dropped here — the flush is the
+    sole handler for that content. Everything else (``carry``) re-enqueues
+    exactly as before, unchanged.
+    """
+    from agent.output_handler import DRAFTER_FALLBACK_SENDER
+
+    fallback = [m for m in leftover if m.get("sender") == DRAFTER_FALLBACK_SENDER]
+    carry = [m for m in leftover if m.get("sender") != DRAFTER_FALLBACK_SENDER]
+
+    if fallback:
+        logger.info(
+            f"[{session.project_key}] Suppressing {len(fallback)} drafter-fallback "
+            f"steering message(s) from re-enqueue for session {session.session_id} — "
+            "the terminal delivery flush already owns delivering this content "
+            "(see #1794 / #2197)"
+        )
+
+    if not carry:
+        return
+
+    texts = [f"  [{m.get('sender', '?')}]: {m.get('text', '')[:500]}" for m in carry]
+    logger.warning(
+        f"[{session.project_key}] {len(carry)} unconsumed steering "
+        f"message(s) for session {session.session_id} — re-enqueuing as continuation:\n"
+        + "\n".join(texts)
+    )
+    try:
+        from agent.agent_session_queue import enqueue_agent_session
+
+        combined_text = "\n\n".join(
+            m.get("text", "").strip() for m in carry if m.get("text", "").strip()
+        )
+        _summary = (
+            getattr(agent_session, "context_summary", None)
+            or "This continues a previously completed session."
+        )
+        augmented = f"[Prior session context: {_summary}]\n\n{combined_text}"
+        # Reuse the slug already checked out in working_dir (if it's a
+        # worktree) so the continuation's synthetic-slug fallback
+        # (session_executor.py's `is_synthetic_slug` branch) doesn't
+        # mint a fresh slug from the *new* agent_session_id — that
+        # mismatches the branch already checked out here and trips
+        # the worktree-branch-guard (issue #1377), killing the
+        # continuation instantly instead of resuming it.
+        continuation_slug = working_dir.name if WORKTREES_DIR in str(working_dir) else None
+        await enqueue_agent_session(
+            project_key=session.project_key,
+            session_id=session.session_id,
+            working_dir=str(working_dir),
+            message_text=augmented,
+            sender_name=carry[0].get("sender", session.sender_name or ""),
+            chat_id=session.chat_id,
+            telegram_message_id=session.telegram_message_id,
+            chat_title=session.chat_title,
+            priority=session.priority or "normal",
+            sender_id=session.sender_id,
+            session_type=session.session_type or "eng",
+            project_config=getattr(session, "project_config", None),
+            slug=continuation_slug,
+        )
+        logger.info(
+            f"[{session.project_key}] Re-enqueued {len(carry)} steering "
+            f"message(s) as continuation for session {session.session_id} "
+            f"(session_type={session.session_type})"
+        )
+    except Exception as re_enqueue_err:
+        logger.warning(
+            f"[{session.project_key}] Failed to re-enqueue steering messages "
+            f"for session {session.session_id} (dropping): {re_enqueue_err}"
+        )
+
+
 async def _execute_agent_session(session: AgentSession) -> None:
     """
     Execute a single agent session:
@@ -2250,58 +2343,7 @@ async def _execute_agent_session(session: AgentSession) -> None:
 
             leftover = pop_all_steering_messages(session.session_id)
             if leftover:
-                texts = [f"  [{m.get('sender', '?')}]: {m.get('text', '')[:500]}" for m in leftover]
-                logger.warning(
-                    f"[{session.project_key}] {len(leftover)} unconsumed steering "
-                    f"message(s) for session {session.session_id} — re-enqueuing as continuation:\n"
-                    + "\n".join(texts)
-                )
-                try:
-                    from agent.agent_session_queue import enqueue_agent_session
-
-                    combined_text = "\n\n".join(
-                        m.get("text", "").strip() for m in leftover if m.get("text", "").strip()
-                    )
-                    _summary = (
-                        getattr(agent_session, "context_summary", None)
-                        or "This continues a previously completed session."
-                    )
-                    augmented = f"[Prior session context: {_summary}]\n\n{combined_text}"
-                    # Reuse the slug already checked out in working_dir (if it's a
-                    # worktree) so the continuation's synthetic-slug fallback
-                    # (session_executor.py's `is_synthetic_slug` branch) doesn't
-                    # mint a fresh slug from the *new* agent_session_id — that
-                    # mismatches the branch already checked out here and trips
-                    # the worktree-branch-guard (issue #1377), killing the
-                    # continuation instantly instead of resuming it.
-                    continuation_slug = (
-                        working_dir.name if WORKTREES_DIR in str(working_dir) else None
-                    )
-                    await enqueue_agent_session(
-                        project_key=session.project_key,
-                        session_id=session.session_id,
-                        working_dir=str(working_dir),
-                        message_text=augmented,
-                        sender_name=leftover[0].get("sender", session.sender_name or ""),
-                        chat_id=session.chat_id,
-                        telegram_message_id=session.telegram_message_id,
-                        chat_title=session.chat_title,
-                        priority=session.priority or "normal",
-                        sender_id=session.sender_id,
-                        session_type=session.session_type or "eng",
-                        project_config=getattr(session, "project_config", None),
-                        slug=continuation_slug,
-                    )
-                    logger.info(
-                        f"[{session.project_key}] Re-enqueued {len(leftover)} steering "
-                        f"message(s) as continuation for session {session.session_id} "
-                        f"(session_type={session.session_type})"
-                    )
-                except Exception as re_enqueue_err:
-                    logger.warning(
-                        f"[{session.project_key}] Failed to re-enqueue steering messages "
-                        f"for session {session.session_id} (dropping): {re_enqueue_err}"
-                    )
+                await _reenqueue_leftover_steering(session, agent_session, working_dir, leftover)
         except Exception as e:
             logger.debug(f"Steering queue cleanup failed (non-fatal): {e}")
 

--- a/docs/features/session-steering.md
+++ b/docs/features/session-steering.md
@@ -163,6 +163,42 @@ This is the **primary** flag-handling path — not a fallback. The drafter no lo
 
 See [Message Drafter](message-drafter.md) for the current feature doc covering the drafter module. (The previous pointer to `summarizer-format.md` is gone — content migrated into `message-drafter.md`.)
 
+### Terminal-Path Re-enqueue Suppression (issue #1794 / #2197)
+
+A **terminal-turn** self-draft deferral (the agent's last turn before reaching a
+terminal status defers a raw reply for self-draft, and no clean redraft ever
+lands) is delivered by a **single** handler: the completed-path flush —
+`agent.session_health.flush_deferred_self_draft_sync` on the telegram sync path,
+or `_deliver_deferred_self_draft_fallback` on the email async path — flushes the
+held `deferred_self_draft_text` to the human exactly once (see issue #1794).
+
+A second, independent handler used to fire uncoordinated with the flush:
+`_execute_agent_session`'s steering-queue cleanup block in
+`agent/session_executor.py` re-enqueues any unconsumed steering messages as a
+continuation session via `enqueue_agent_session` (which has no
+`claude_session_uuid` param, so it spawns a brand-new, context-blind session).
+Because the flush does not pop the steering queue, the still-present
+`drafter-fallback` steering message was popped and re-enqueued too — the new
+session, told to "rewrite it" with no "it" to rewrite, took the
+`SELF_DRAFT_INSTRUCTION` escape hatch ("If your work produced no substantive
+results, say so plainly") and emitted a misleading "no substantive results"
+reply, even though the prior turn had produced real, correct output.
+
+**Fix:** the re-enqueue block (extracted into
+`_reenqueue_leftover_steering(session, agent_session, working_dir, leftover)` in
+`agent/session_executor.py`) partitions leftover steering by sender before
+re-enqueueing:
+
+- Messages with `sender == DRAFTER_FALLBACK_SENDER` (`agent/output_handler.py`)
+  are dropped — the terminal delivery flush already owns delivering that
+  content exactly once.
+- Every other sender (including a leftover message with a missing/`None`
+  `sender`) re-enqueues exactly as before.
+
+The suppression is **transport-agnostic**: it applies regardless of whether the
+session originated on telegram or email, since the partition lives in the
+shared re-enqueue path, not in either transport-specific flush.
+
 ## Watchdog-Authored Steering (issue #1128)
 
 The session watchdog (`monitoring/session_watchdog.py`) is now an active

--- a/tests/unit/test_deferred_self_draft_completed.py
+++ b/tests/unit/test_deferred_self_draft_completed.py
@@ -38,9 +38,13 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from agent.output_handler import DRAFTER_FALLBACK_SENDER
+from agent.session_executor import _reenqueue_leftover_steering
 from models.agent_session import AgentSession
 from models.session_lifecycle import finalize_session
 
@@ -566,6 +570,130 @@ def test_no_deferral_writes_zero_outbox(cleanup):
     finalize_session(session, "completed", reason="normal completion")
 
     assert _outbox_count(sid) == 0
+
+
+# ---------------------------------------------------------------------------
+# 10. Terminal-path re-enqueue suppression of drafter-fallback steering (#2197)
+# ---------------------------------------------------------------------------
+#
+# On a terminal-turn self-draft deferral, the completed-path flush above
+# (``flush_deferred_self_draft_sync`` / ``_deliver_deferred_self_draft_fallback``)
+# already delivers the held text exactly once. A SEPARATE handler in
+# ``agent/session_executor.py`` — ``_reenqueue_leftover_steering`` — used to pop
+# the still-present ``drafter-fallback`` steering message and re-enqueue it as a
+# brand-new, context-blind continuation session, which then emitted a misleading
+# "no substantive results" reply. The fix partitions leftover steering by sender:
+# ``drafter-fallback`` is dropped (the flush already owns it); every other sender
+# still re-enqueues exactly as before.
+#
+# These tests exercise ``_reenqueue_leftover_steering`` directly — it is the
+# extracted, testable unit the terminal-path re-enqueue block in
+# ``_execute_agent_session`` now delegates to. Steering messages use the real
+# Redis-backed queue (``push_steering_message`` / real list contents built
+# in-test); ``enqueue_agent_session`` is mocked since it spawns a new session.
+
+
+def _leftover_msg(sender: str | None, text: str) -> dict:
+    return {"sender": sender, "text": text}
+
+
+class TestReenqueueLeftoverSteeringSuppression:
+    @pytest.mark.asyncio
+    async def test_fallback_only_leftover_suppressed_not_reenqueued(self, cleanup, caplog):
+        """Leftover steering containing ONLY a drafter-fallback message must not
+        trigger a re-enqueue, and the suppression must be logged at INFO."""
+        sid = f"{SID_PREFIX}reenqueue-fallback-only"
+        cleanup.append(sid)
+        session = _make_session(sid, pending=False, status="completed")
+
+        leftover = [_leftover_msg(DRAFTER_FALLBACK_SENDER, "rewrite it please")]
+
+        with (
+            patch("agent.agent_session_queue.enqueue_agent_session", new=AsyncMock()) as mock_enq,
+            caplog.at_level("INFO"),
+        ):
+            await _reenqueue_leftover_steering(
+                session, session, Path("/tmp/does-not-matter"), leftover
+            )
+
+        mock_enq.assert_not_called()
+        suppression_logs = [
+            r
+            for r in caplog.records
+            if "Suppressing" in r.message and "drafter-fallback" in r.message
+        ]
+        assert suppression_logs, "expected an INFO-level suppression log line"
+        assert all(r.levelname == "INFO" for r in suppression_logs)
+
+    @pytest.mark.asyncio
+    async def test_mixed_leftover_reenqueues_only_genuine_message(self, cleanup):
+        """Leftover with BOTH a drafter-fallback message and a genuine-sender
+        message: enqueue_agent_session IS called, and the payload derives only
+        from the genuine (carry) message — the drafter-fallback text must not
+        appear in the augmented message_text."""
+        sid = f"{SID_PREFIX}reenqueue-mixed"
+        cleanup.append(sid)
+        session = _make_session(sid, pending=False, status="completed")
+
+        fallback_text = "rewrite it please (fallback text should not carry over)"
+        genuine_text = "please also check the staging deploy"
+        leftover = [
+            _leftover_msg(DRAFTER_FALLBACK_SENDER, fallback_text),
+            _leftover_msg("Tom", genuine_text),
+        ]
+
+        with patch("agent.agent_session_queue.enqueue_agent_session", new=AsyncMock()) as mock_enq:
+            await _reenqueue_leftover_steering(
+                session, session, Path("/tmp/does-not-matter"), leftover
+            )
+
+        mock_enq.assert_called_once()
+        _, kwargs = mock_enq.call_args
+        assert genuine_text in kwargs["message_text"]
+        assert fallback_text not in kwargs["message_text"]
+        assert kwargs["sender_name"] == "Tom"
+
+    @pytest.mark.asyncio
+    async def test_senderless_leftover_still_reenqueues(self, cleanup):
+        """A leftover message with a missing/None ``sender`` key must be treated
+        as NOT drafter-fallback (lands in carry) — matching today's behavior."""
+        sid = f"{SID_PREFIX}reenqueue-senderless"
+        cleanup.append(sid)
+        session = _make_session(sid, pending=False, status="completed")
+
+        leftover = [_leftover_msg(None, "continue please")]
+
+        with patch("agent.agent_session_queue.enqueue_agent_session", new=AsyncMock()) as mock_enq:
+            await _reenqueue_leftover_steering(
+                session, session, Path("/tmp/does-not-matter"), leftover
+            )
+
+        mock_enq.assert_called_once()
+        _, kwargs = mock_enq.call_args
+        assert "continue please" in kwargs["message_text"]
+
+    @pytest.mark.asyncio
+    async def test_email_transport_fallback_only_leftover_also_suppressed(self, cleanup):
+        """Suppression is transport-agnostic: an email-path terminal session with
+        a drafter-fallback-only leftover is likewise suppressed from re-enqueue.
+        The re-enqueue suppression lives in session_executor.py and does not
+        branch on transport — only the delivery-flush routing (session_health.py
+        for telegram sync, `_deliver_deferred_self_draft_fallback` for email
+        async) is transport-specific."""
+        sid = f"{SID_PREFIX}reenqueue-email-fallback-only"
+        cleanup.append(sid)
+        session = _make_session(
+            sid, pending=False, status="completed", transport="email", chat_id="sender@example.com"
+        )
+
+        leftover = [_leftover_msg(DRAFTER_FALLBACK_SENDER, "rewrite it please")]
+
+        with patch("agent.agent_session_queue.enqueue_agent_session", new=AsyncMock()) as mock_enq:
+            await _reenqueue_leftover_steering(
+                session, session, Path("/tmp/does-not-matter"), leftover
+            )
+
+        mock_enq.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes issue #2197: on a terminal-turn self-draft deferral, two independent handlers fired uncoordinated — the completed-path flush (`session_health.py`) delivered the deferred text without popping the steering queue, then the leftover-steering re-enqueue block (`session_executor.py`) popped the still-present `drafter-fallback` message and spawned a brand-new, context-blind Claude session that emitted a misleading "no substantive results" reply despite the prior turn producing real output.
- Extracted the re-enqueue block into `_reenqueue_leftover_steering()` and partitioned leftover steering by sender before re-enqueueing: `drafter-fallback` messages are dropped (the terminal flush already owns delivering them), everything else (including sender-less messages) re-enqueues unchanged.
- Introduced a shared `DRAFTER_FALLBACK_SENDER` constant in `agent/output_handler.py`, referenced at the existing push/peek sites and the new suppression site, closing the "literal drifts silently" risk called out in the plan.
- The suppression is transport-agnostic (lives in the shared re-enqueue path), so it protects both the telegram sync flush and the email async fallback terminal paths.

## Test plan
- [x] `pytest tests/unit/test_deferred_self_draft_completed.py -q` — 23 passed (19 existing + 4 new: fallback-only suppression w/ INFO log assertion, mixed leftover w/ payload-content assertion, sender-less leftover still carries, email-path transport-agnostic suppression)
- [x] `pytest tests/unit/test_steering.py -q` — 9 passed, no regression
- [x] `ruff check` / `ruff format --check` on all touched files — clean
- [x] Independent validator agent confirmed the diff matches the plan's Technical Approach and Success Criteria line-by-line, including that `session_health.py` (the flush) is untouched
- [x] Docs updated: `docs/features/session-steering.md` gained a "Terminal-Path Re-enqueue Suppression (issue #1794 / #2197)" subsection; the plan's Documentation checklist was corrected on `main` to point at this doc instead of a stale reference to an already-migrated/deleted plan file (`docs/plans/deferred_self_draft_completed_path_flush.md`, superseded by #1794)

Closes #2197