### PR TITLE
Unify memory write-path quality gates + remove line-splitting fallback

### DIFF
--- a/agent/memory_extraction.py
+++ b/agent/memory_extraction.py
@@ -881,10 +881,10 @@ def _parse_categorized_observations(raw_text: str) -> list[tuple[str, float, dic
         return []
 
     # Tolerant JSON path: strip code fences / preamble, then strict json.loads.
-    # If extraction yields a JSON-shaped substring but parsing fails, fall
-    # through to the line-based parser (worst case: same behavior as before
-    # the fix). If extraction yields no JSON-shaped substring, also fall
-    # through.
+    # If extraction yields a JSON-shaped substring but parsing fails, or if
+    # no JSON-shaped substring is found at all, both cases converge on the
+    # unconditional `return []` at the bottom of this function -- no
+    # fallback parser is invoked (there isn't one; issue #2201 removed it).
     payload = extract_json_payload(raw_text)
     if payload is not None:
         try:
@@ -904,11 +904,14 @@ def _parse_categorized_observations(raw_text: str) -> list[tuple[str, float, dic
                     # would otherwise raise AttributeError that the surrounding
                     # except (json.JSONDecodeError, TypeError) does NOT catch,
                     # aborting the whole batch. This closes the whole-text-vs-
-                    # per-record asymmetry: the line-based fallback below already
-                    # filters each line through _looks_like_refusal, but this JSON
-                    # branch previously let shrapnel-shaped observation values
-                    # through untouched, causing the same anomaly cluster to be
-                    # re-filed repeatedly by the audit (#1497/#1786/#1931).
+                    # per-record asymmetry: the whole-payload short-circuit at
+                    # the top of this function already runs raw_text through
+                    # _looks_like_refusal, but before this fix the per-record
+                    # JSON branch did not apply the same filter to each
+                    # individual observation value, letting shrapnel-shaped
+                    # values through untouched, causing the same anomaly
+                    # cluster to be re-filed repeatedly by the audit
+                    # (#1497/#1786/#1931).
                     category_raw = item.get("category", "")
                     if not isinstance(category_raw, str):
                         continue

--- a/agent/memory_extraction.py
+++ b/agent/memory_extraction.py
@@ -680,8 +680,7 @@ async def extract_observations_async(
         # Post-LLM refusal-pattern filter (issue #1212 PRIMARY defense).
         # Even when input passed all three pre-LLM guards, Haiku can still
         # return refusal prose ("There is no agent session response to
-        # analyze…"). Drop those before parsing — they'd otherwise explode
-        # into multiple Memory rows via the line-based fallback.
+        # analyze…"). Drop those before parsing.
         if _looks_like_refusal(raw_text):
             logger.debug(
                 "[memory_extraction] Post-LLM refusal text — skipping save for session_id=%s",
@@ -719,12 +718,9 @@ async def extract_observations_async(
         # Parse observations with category-aware importance
         parsed = _parse_categorized_observations(raw_text)
 
-        if not parsed:
-            return []
-
-        # Save each observation as Memory
-        from models.memory import SOURCE_AGENT, Memory
-
+        # Resolve project_key BEFORE the not-parsed short-circuit so the
+        # fallback_dropped counter below always has a key to increment
+        # (issue #2201). Keeps its own None early-return unchanged.
         if not project_key:
             from config.project_key_resolver import resolve_project_key
 
@@ -736,6 +732,15 @@ async def extract_observations_async(
                     os.environ.get("VALOR_PROJECT_KEY"),
                 )
                 return []
+
+        if not parsed:
+            from models.memory_gate import _increment_gate_counter
+
+            _increment_gate_counter(project_key, "fallback_dropped")
+            return []
+
+        # Save each observation as Memory
+        from models.memory import SOURCE_AGENT, Memory
 
         # Per-batch clamp (issue #2040) — the load-bearing half of the
         # per-session cap. per_call_cap is the pre-existing per-response
@@ -851,13 +856,20 @@ def _parse_categorized_observations(raw_text: str) -> list[tuple[str, float, dic
     Tries tolerant JSON parsing first (strips markdown code fences and slices
     to outermost brackets via ``extract_json_payload``, then ``json.loads``).
     On a successful JSON parse with ≥1 valid observation, short-circuits and
-    returns — the line-based fallback NEVER runs in that case (issue #1212).
+    returns (issue #1212).
 
-    Falls back to a line-based ``CATEGORY: text`` parser only when
-    ``extract_json_payload`` finds no JSON-shaped substring AND the input
-    is not a refusal. Each fallback line is filtered through
-    ``_looks_like_refusal`` so refusal prose and JSON-syntax fragments
-    (``"tags": [...]``) never reach the Memory store.
+    Any other outcome -- no JSON-shaped substring found, ``json.loads``
+    raising, or the payload parsing but yielding zero valid observations --
+    returns an empty list. Issue #2201 removed the line-splitting fallback
+    that used to run in these cases: it exploded a single unparseable
+    payload into one Memory record per line ("shrapnel"). Unparseable
+    output is now dropped and counted (`fallback_dropped`, incremented by
+    the caller `extract_observations_async` once `project_key` is
+    resolved) rather than saved in any form. No retry is attempted -- JSON
+    is the sanctioned contract since #1212/#2016.
+
+    This function takes no `project_key` parameter and must never
+    reference one -- see the caller for where the drop is counted.
 
     Returns list of (content_string, importance_float, metadata_dict) tuples.
     """
@@ -940,42 +952,16 @@ def _parse_categorized_observations(raw_text: str) -> list[tuple[str, float, dic
                     # one observation into 4-5 shrapnel rows.
                     return results
         except (json.JSONDecodeError, TypeError):
-            pass  # Fall through to line-based parser
+            pass  # Fall through to the unconditional drop below
 
-    # Fallback: line-based parser (returns empty metadata). Each line filtered
-    # through _looks_like_refusal so we never persist single-line JSON
-    # syntax fragments or refusal sentences as Memory records.
-    lines = [
-        line.strip()
-        for line in raw_text.split("\n")
-        if line.strip()
-        and len(line.strip()) > 10
-        and not _looks_like_refusal(line)
-        and not _is_scoping_boilerplate(line)  # Fix 3 (#1822)
-    ]
-    if not lines:
-        return []
-
-    categorized: list[tuple[str, float, dict]] = []
-    uncategorized: list[str] = []
-
-    for line in lines:
-        matched = False
-        for category in CATEGORY_IMPORTANCE:
-            prefix = f"{category}:"
-            if line.lower().startswith(prefix):
-                content = line[len(prefix) :].strip()
-                if content and len(content) > 10:
-                    categorized.append((content, CATEGORY_IMPORTANCE[category], {}))
-                matched = True
-                break
-        if not matched:
-            uncategorized.append(line)
-
-    if categorized:
-        return categorized
-
-    return [(line, DEFAULT_CATEGORY_IMPORTANCE, {}) for line in uncategorized]
+    # Unparseable payloads are dropped+counted (issue #2201) — do not
+    # re-add a line-splitting fallback here. This single unconditional
+    # return converges all three non-JSON-success cases: (1) no JSON-shaped
+    # substring found above, (2) json.loads raised (caught above), and
+    # (3) the payload parsed but `results` was empty (fell through the `if
+    # results:` short-circuit). Any of these previously exploded raw_text
+    # into one Memory record per line.
+    return []
 
 
 async def extract_post_merge_learning(

--- a/agent/memory_quality.py
+++ b/agent/memory_quality.py
@@ -188,3 +188,63 @@ def classify_content(content: str | None) -> str:
     if is_fragment(stripped):
         return "fragment"
     return "durable"
+
+
+# Phase-2 (issue #2201) write-gate-only length floor. This is DELIBERATELY
+# NOT part of `classify_content` -- that function's three-bucket output
+# (durable/ack_only/fragment) drives the frozen `junk_rate` baseline
+# (docs/baselines/memory-telemetry-baseline.json), and folding a length
+# check into it would silently redefine what "junk" means, breaking the
+# apples-to-apples baseline comparison (Decision 1 in the plan).
+#
+# The floor exists because `classify_content` cannot see length at all: a
+# concrete anchor from production is "1. Concurrency" (14 chars) -- the
+# bare-list-marker regex (`^([-*•]|\d+[.)])\s*$`) requires NO body text, so
+# a marker *with* a trailing word is not a fragment, and 14 characters of
+# real words is not an ack. `classify_content` calls it "durable". It is
+# nonetheless production junk (shrapnel from a since-removed line-splitting
+# extraction fallback -- see issue #2201 Task 2). The length floor is the
+# only mechanism that catches this shape; `gate_reason` below is where it
+# is enforced, and it is enforced ONLY at write time (a write-gate
+# concern), never at classification time (a measurement concern).
+#
+# 15 is a conservative provisional value, not a tuned one: it sits below
+# the Claude Code hook's MIN_PROMPT_LENGTH=50 and aligns with extraction's
+# pre-existing `len(observation) < 10` per-observation drop. Ship it, wire
+# `gate_rejected_short` (see `models/memory.py`) so the true rejection
+# volume is observable, and only tighten the value after that telemetry is
+# read (or by anchoring to the shortest-durable-record length in the
+# committed baseline).
+MIN_CONTENT_LENGTH = 15
+
+
+def gate_reason(content: str | None) -> str | None:
+    """Return the write-gate rejection reason for ``content``, or ``None`` to persist.
+
+    Composes the frozen `classify_content` three-bucket classification with
+    the write-gate-only length floor (`MIN_CONTENT_LENGTH`). This is the
+    single predicate `Memory.save()` (models/memory.py) calls before
+    persisting a new record -- every one of the five Memory writer paths
+    inherits it for free because they all funnel through `Memory.save()`
+    (issue #2201).
+
+    Returns exactly one of `{"ack", "fragment", "short", None}` -- three
+    distinct non-None reasons, each with its own `gate_rejected_*` Redis
+    counter (models/memory.py). `"fragment"` (dangling colon, bare list
+    marker, unbalanced brackets, or None/empty/whitespace input) is never
+    folded into `"short"`: they are different junk shapes and conflating
+    them would make `gate_rejected_fragment` a permanent-zero dead counter
+    while hiding the fragment volume inside `gate_rejected_short`.
+
+    `None`/`""`/whitespace-only input is classified `"fragment"` by
+    `classify_content` and so returns `"fragment"` here too (checked before
+    the length floor, since a fragment is always also short).
+    """
+    classification = classify_content(content)
+    if classification == "ack_only":
+        return "ack"
+    if classification == "fragment":
+        return "fragment"
+    if len((content or "").strip()) < MIN_CONTENT_LENGTH:
+        return "short"
+    return None

--- a/docs/features/memory-telemetry.md
+++ b/docs/features/memory-telemetry.md
@@ -1,6 +1,6 @@
 # Memory Telemetry
 
-> **Phase 1 (Layer A: Measure)** of a multi-phase memory-optimization effort (issue #2200). This phase is read-only: it measures corpus-level memory quality and establishes a pre-intervention baseline. It does not gate writes, prune records, or mutate any Memory record. Downstream phases — write-gate unification (#2201), ingest distillation (#2202), and outcome-loop + pruning (#2203) — are separate future issues that will consume the module documented here.
+> **Phase 1 (Layer A: Measure)** of a multi-phase memory-optimization effort (issue #2200). This phase is read-only: it measures corpus-level memory quality and establishes a pre-intervention baseline. It does not gate writes, prune records, or mutate any Memory record. **Phase 2 (write-gate unification, #2201) has since shipped** — see [Write-Path Quality Gates](subconscious-memory.md#write-path-quality-gates) in the subconscious-memory doc for how it consumes `classify_content()` from this module to gate all five writer paths at `Memory.save()`. Ingest distillation (#2202) and outcome-loop + pruning (#2203) remain separate, not-yet-built issues.
 
 Before this feature, there was no machine-readable, corpus-level view of memory quality. `python -m tools.memory_search status` reports per-record counts and a superseded ratio, and the `/memories` dashboard inspects individual records, but nothing aggregated act rates, junk rates, or ingest volume across the whole corpus into a single exportable snapshot. That made it impossible to answer "is the memory system getting noisier or cleaner over time?" without an ad hoc script, and impossible to know whether a future write-gate change actually improved anything, because there was no "before" number to compare against.
 
@@ -22,7 +22,7 @@ ui/data/memories.py::get_corpus_metrics   <- the ONE function that touches Redis
         +---> python -m tools.memory_eval.snapshot   (CLI, writes docs/baselines/*)
 ```
 
-`agent/memory_quality.py` is deliberately dependency-light — no imports of `redis`, `popoto`, or `models` — so it can be imported both from the pure-aggregation CLI/tool path documented here and from a future `models/` write gate (Phase 2, #2201) without pulling Redis clients or creating circular imports.
+`agent/memory_quality.py` is deliberately dependency-light — no imports of `redis`, `popoto`, or `models` — so it can be imported both from the pure-aggregation CLI/tool path documented here and from `models/memory.py`'s write gate (Phase 2, #2201, shipped) without pulling Redis clients or creating circular imports. The write gate imports `classify_content()` via a deferred (in-`save()`) import specifically to avoid a real circular-import cycle through `agent/__init__.py` — see [Write-Path Quality Gates](subconscious-memory.md#write-path-quality-gates).
 
 ## Junk / Fragment Heuristics
 
@@ -134,7 +134,7 @@ curl -s "localhost:8500/memories/metrics.json?project_key=valor&min_evidence=3"
 
 `docs/baselines/memory-telemetry-baseline.json` and `.md` are the committed pre-intervention snapshot, generated via the CLI above and checked into git. Numbers as of the snapshot: 1991 total records, aggregate act rate 0.990, junk rate 0.030, 138 never-injected records.
 
-This baseline is the "before" side of the comparison that later phases (write-gate unification, ingest distillation, outcome-loop pruning) will need to demonstrate they actually improved corpus quality rather than just believing they did.
+This baseline is the "before" side of the comparison that later phases need to demonstrate they actually improved corpus quality rather than just believing they did. Write-gate unification (#2201) has shipped and reports its own immediate `gate_rejected_*`/`gate_fallback_dropped` counters as evidence of junk *prevented* (see [Write-Path Quality Gates](subconscious-memory.md#write-path-quality-gates)); the `junk_rate` trend against this baseline is a slower, post-deploy signal since existing junk records are not pruned until outcome-loop pruning (#2203) ships. Ingest distillation (#2202) also remains pending.
 
 **`.gitignore` note.** The repo has a broad `*.json` ignore rule. Committing the baseline JSON required a scoped negation:
 

--- a/docs/features/subconscious-memory.md
+++ b/docs/features/subconscious-memory.md
@@ -591,6 +591,52 @@ The memory system MUST work equally across all agent session types — SDK/Teleg
 |-----------|-------------|-----------|--------|
 | Prompt ingestion (auto-save user input) | Yes (UserPromptSubmit hook) | No (Telegram messages only) | Add ingestion hook or equivalent to SDK path |
 
+## Write-Path Quality Gates
+
+Human Telegram messages, post-session Haiku extraction, post-merge learning, the Claude Code hook ingest, and the intentional CLI save are the five writer paths in the system (Flows 1, 3, 5, 7, and the Claude Code integration above). Before issue #2201, only the hook ingest path (`MIN_PROMPT_LENGTH=50` + `TRIVIAL_PATTERNS`) filtered content before persistence — the other four called `Memory.safe_save()` / `Memory(...).save()` with no content inspection at all, because `compute_filter_score()` (the `WriteFilterMixin` choke point every path already passes through) filters on `importance` only and never looks at `content`.
+
+### Single choke point, zero per-path edits
+
+`Memory.save()` (`models/memory.py`) is overridden to run a content gate before delegating to `super().save()`. Because every one of the five writer paths already calls `save()` (directly or via `safe_save()`), all five inherited the gate the moment the override shipped — no writer-path code changed. This mirrors the same "one shared module, two consumers" design as [Memory Telemetry](memory-telemetry.md): the gate composes `classify_content()` from `agent/memory_quality.py`, the identical function the Phase 1 `junk_rate` metric uses, so "what counts as junk" cannot drift between what is measured and what is prevented.
+
+### What the gate catches — and what it deliberately does not
+
+`gate_reason(content)` (`agent/memory_quality.py`) returns one of three rejection reasons, or `None` to persist:
+
+| Reason | Trigger |
+|--------|---------|
+| `"ack"` | `classify_content` returns `ack_only` — a bare acknowledgement/filler utterance ("Yup", "thanks", "Ahhh") |
+| `"fragment"` | `classify_content` returns `fragment` — dangling syntax: unbalanced brackets, a trailing colon with no body (`"includes:"`), a bare list marker with no content (`"1."`), or `None`/empty/whitespace input |
+| `"short"` | Content classifies `durable` but is below `MIN_CONTENT_LENGTH = 15` characters — e.g. `"1. Concurrency"` (14 chars): a list marker *with* a trailing word is not a bare marker, so `classify_content` calls it `durable`, and only the length floor catches it |
+
+**What it does not catch:** multi-word shrapnel like `"runs on a schedule"` (18 chars, classifies `durable`, at/above the floor) sails straight through the content gate — nothing about that string looks like junk in isolation. That shape was never a content-quality problem; it was a structural one. It only entered the corpus because the (now-removed) line-splitting extraction fallback exploded one multi-line Haiku response into one Memory record per line, so a fragment of a sentence became its own "record." The content gate and the fallback removal below are complementary, not overlapping: the gate stops bad *content*, fallback-removal stops bad *segmentation*. Do not expect `MIN_CONTENT_LENGTH` tuning to catch multi-word shrapnel — it structurally can't, by design (a higher floor would just as easily reject real short facts like `"Deploy on Fridays"`).
+
+### INSERT-only: updates are never gated
+
+The gate runs only when `self.db_key` does not already exist in Redis (`_key_exists`, `models/memory.py`) — i.e., only on a genuine new record. Every update path, including the outcome-metadata re-save in `agent/memory_extraction.py`'s outcome-detection loop (`dismissal_count`, `last_outcome`, `outcome_history`), calls a bare `m.save()` on an already-persisted record and always bypasses the gate. This is a structural guarantee, not a "durable content stays durable" assumption: it holds even when the record being updated is a legacy fragment that predates the gate and would fail `gate_reason` today. Without this guard, an outcome-loop re-save on any of the pre-existing junk records would return `False` and silently drop the outcome write — the content gate would end up breaking the very outcome tracking that dismissal decay depends on.
+
+### Fallback removal: extraction drops instead of shrapnel-izing
+
+`agent/memory_extraction.py::_parse_categorized_observations()` used to fall back to splitting unparseable LLM output on newlines and emitting one Memory tuple per line whenever the tolerant JSON parse didn't produce ≥1 valid observation. That fallback fired in three cases — no JSON-shaped substring found, `json.loads` raising, or the JSON parsing to zero valid observations — and all three are now unified: the function ends with a single unconditional `return []`. Nothing is saved when extraction can't get valid structured output; there is no retry (Decision 2 in the plan — JSON has been the sanctioned contract since #1212/#2016, and a retry only adds latency for unproven gain). The caller, `extract_observations_async`, increments the `fallback_dropped` counter after `project_key` has been resolved (moved above the `if not parsed:` short-circuit so the counter always has a key to write to).
+
+### Counters: `gate_rejected_ack`, `gate_rejected_fragment`, `gate_rejected_short`, `gate_fallback_dropped`
+
+Each rejection increments a best-effort Redis counter (`models/memory_gate.py::_increment_gate_counter`, atomic `INCR` on `{project_key}:memory-gate:{reason}`, never raises). `ui/data/memories.py::get_corpus_metrics` sums these across the resolved project keys via `_sum_gate_counter` and attaches four fields to its return dict, which `GET /memories/metrics.json` already serves (no new route — see [Memory Telemetry](memory-telemetry.md#get-memoriesmetricsjson)):
+
+```bash
+curl -s localhost:8500/memories/metrics.json | python3 -c "
+import json, sys
+m = json.load(sys.stdin)
+print({k: m[k] for k in ('gate_rejected_ack', 'gate_rejected_fragment', 'gate_rejected_short', 'gate_fallback_dropped')})
+"
+```
+
+### How this relates to the Phase 1 `junk_rate` baseline
+
+[Memory Telemetry](memory-telemetry.md) (Phase 1, #2200) measures `junk_rate` against a frozen, committed baseline (`docs/baselines/memory-telemetry-baseline.json`) — a corpus-wide ratio of `ack_only` + `fragment` records over non-superseded records. This feature (Phase 2, #2201) does not change that measurement or its definition: `classify_content`'s three-bucket output stays frozen so the baseline comparison stays apples-to-apples. What Phase 2 adds is prevention at write time, and the `gate_*` counters are its own, faster signal — direct, immediate evidence of junk stopped before it ever reached the store.
+
+The two signals move on different timescales. Write gates prevent *new* junk; they cannot remove the fragments already in the corpus at baseline time (Phase 4, #2203, is where existing junk gets pruned). `junk_rate` can therefore only trend downward as new durable records accumulate around the existing junk denominator — it will not visibly move on the day of deploy. Read `gate_rejected_*` and `gate_fallback_dropped` as the pre-merge, executable proof that the gate works; read the `junk_rate` trend on `/memories/metrics.json` as a non-blocking, post-deploy signal worth checking a week or two out, not an instant-drop expectation.
+
 ## Memory Consolidation
 
 The nightly `memory-dedup` reflection runs LLM-based semantic consolidation to prevent the memory store from accumulating near-duplicate entries and contradictions over time.

--- a/docs/plans/memory-write-gate-unification.md
+++ b/docs/plans/memory-write-gate-unification.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: docs_complete
 type: bug
 appetite: Medium
 owner: Valor Engels

--- a/models/memory.py
+++ b/models/memory.py
@@ -39,6 +39,7 @@ from popoto import (  # noqa: E402
 from popoto.fields.existence_filter import ExistenceFilter  # noqa: E402
 
 from models.graceful_embedding_field import GracefulEmbeddingField  # noqa: E402
+from models.memory_gate import _increment_gate_counter  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +48,26 @@ SOURCE_HUMAN = "human"
 SOURCE_AGENT = "agent"
 SOURCE_SYSTEM = "system"
 SOURCE_KNOWLEDGE = "knowledge"
+
+
+def _key_exists(db_key) -> bool:
+    """Best-effort existence check distinguishing INSERT from UPDATE.
+
+    Returns False on any error (including Redis being unreachable), which
+    defaults the caller to treating the write as an INSERT -- the safer
+    choice, since it preserves the content gate's junk-blocking guarantee
+    on the common insert path. An `exists()` failure while the write itself
+    succeeds is nearly impossible (both use the same Redis handle); the
+    only exposure is a rare junk-content UPDATE whose existence check
+    errored, and Phase 4 (#2203, existing-fragment pruning) removes that
+    class of record anyway.
+    """
+    try:
+        from popoto.redis_db import POPOTO_REDIS_DB
+
+        return bool(POPOTO_REDIS_DB.exists(str(db_key)))
+    except Exception:
+        return False
 
 
 def _warn_if_legacy_namespace(project_key: "str | None") -> None:
@@ -178,6 +199,57 @@ class Memory(WriteFilterMixin, AccessTrackerMixin, Model):
         are silently dropped on save().
         """
         return self.importance or 0.0
+
+    def save(self, *args, **kwargs):
+        """Content-gate new records before persisting (issue #2201).
+
+        Runs on INSERT only -- an existing key means this is an UPDATE
+        (e.g. the outcome/metadata re-save in
+        `agent/memory_extraction.py`'s outcome-detection loop, which calls
+        a bare `m.save()` on an already-persisted record). Gating that
+        re-save would return `False` and silently lose the
+        outcome/`dismissal_count`/`last_outcome` write on any record whose
+        content happens to be below-floor or a legacy fragment already in
+        the store. So the gate is skipped whenever `self.db_key` already
+        exists in Redis.
+
+        On a genuine INSERT, `gate_reason` (agent/memory_quality.py)
+        classifies `self.content`; a non-None reason increments its
+        `{project_key}:memory-gate:{reason}` counter and returns `False`
+        without ever calling `super().save()` -- this mirrors
+        `WriteFilterMixin`'s own drop contract (`save()` returning `False`
+        on rejection), so `safe_save()`'s existing `result is False ->
+        None` mapping and logging need no changes.
+
+        This counts each rejected write exactly once: `save()` is called
+        once per persist attempt (verified against `Model.save()` in the
+        vendored popoto package, which calls `_check_write_filter()`
+        exactly once per invocation), so placing the counter here --
+        rather than inside `compute_filter_score()`, which
+        `WriteFilterMixin` could in principle call more than once per
+        `save()` -- avoids any double-count hazard.
+
+        `compute_filter_score()` above is left completely unchanged: it
+        still filters on raw `importance` only. The content gate is a
+        distinct concern living entirely in this override.
+
+        `gate_reason` is imported locally (not at module level) because
+        `agent.memory_quality` is dependency-light on its own, but Python
+        still executes `agent/__init__.py` on any `agent.*` submodule
+        import, and that package `__init__` pulls in `agent.session_health`
+        -> `models.memory` -> a circular partial-init `ImportError` at
+        module load time. Deferring the import into the method body avoids
+        the cycle entirely: by the time any `save()` call happens,
+        `models.memory` has already finished loading.
+        """
+        from agent.memory_quality import gate_reason
+
+        if not _key_exists(self.db_key):
+            reason = gate_reason(self.content)
+            if reason:
+                _increment_gate_counter(self.project_key, reason)
+                return False
+        return super().save(*args, **kwargs)
 
     @classmethod
     def safe_save(cls, **kwargs) -> "Memory | None":

--- a/models/memory_gate.py
+++ b/models/memory_gate.py
@@ -1,0 +1,42 @@
+"""Redis counters for the Memory write-gate (issue #2201).
+
+Small, isolated module so `models/memory.py` doesn't need to inline Redis
+plumbing directly. NOT Popoto-managed keys -- these are plain `INCR`/`GET`
+counters shaped `{project_key}:memory-gate:{reason}`, one per rejection
+reason (`ack`, `fragment`, `short`, `fallback_dropped`). The raw-Redis ban
+enforced by `.claude/hooks/validators/validate_no_raw_redis_delete.py`
+targets `delete`/`srem`/`sadd`/`zrem` on Popoto *model* keys only --
+`INCR`/`GET` on this counter namespace is exactly the pattern
+`_sum_project_counter` (`ui/app.py:434`) already uses for other
+non-Popoto-managed operational counters.
+
+Uses the same Redis handle the rest of the repo already uses for this
+purpose (`monitoring/worker_watchdog.py:409`) -- there is no
+`tools.redis_client` module.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _increment_gate_counter(project_key: str | None, reason: str) -> None:
+    """Best-effort atomic increment of `{project_key}:memory-gate:{reason}`.
+
+    Never raises -- a Redis hiccup must never crash a write. `INCR` is
+    atomic, so concurrent increments from the bridge/worker/hooks racing on
+    the same `project_key` are safe by construction (no read-modify-write).
+    """
+    try:
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+        _R.incr(f"{project_key}:memory-gate:{reason}")
+    except Exception as e:
+        logger.debug(
+            "[memory_gate] Could not increment gate counter project_key=%r reason=%r: %s",
+            project_key,
+            reason,
+            e,
+        )

--- a/tests/integration/test_dashboard_memories.py
+++ b/tests/integration/test_dashboard_memories.py
@@ -209,10 +209,20 @@ class TestMemoriesMetricsJson:
             "confidence_histogram",
             "decay_imminent_count",
             "never_injected_count",
+            # Issue #2201 write-gate counters.
+            "gate_rejected_ack",
+            "gate_rejected_fragment",
+            "gate_rejected_short",
+            "gate_fallback_dropped",
         ):
             assert key in body
         assert body["total_records"] == 0
         assert body["aggregate_act_rate"] is None
+        # Zero-filled on an empty corpus (no gate rejections have occurred).
+        assert body["gate_rejected_ack"] == 0
+        assert body["gate_rejected_fragment"] == 0
+        assert body["gate_rejected_short"] == 0
+        assert body["gate_fallback_dropped"] == 0
 
     def test_get_reflects_records(self):
         from ui.app import create_app
@@ -248,6 +258,29 @@ class TestMemoriesMetricsJson:
             resp = client.get("/memories/metrics.json")
         assert resp.status_code == 200
         assert resp.json()["total_records"] == 0
+
+    def test_gate_counters_zero_fill_and_never_500_when_redis_down(self, client):
+        """`_sum_gate_counter` (issue #2201) is best-effort: a raising Redis
+        GET must never surface as a 500, and the four gate_* fields must
+        still be present, zero-filled."""
+
+        class _RaisingRedis:
+            def get(self, *_args, **_kwargs):
+                raise ConnectionError("redis unreachable")
+
+        with (
+            patch("models.memory.Memory.query.filter") as mock_filter,
+            patch("popoto.redis_db.POPOTO_REDIS_DB", _RaisingRedis()),
+        ):
+            mock_filter.return_value.no_track.return_value.all.return_value = []
+            resp = client.get("/memories/metrics.json")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["gate_rejected_ack"] == 0
+        assert body["gate_rejected_fragment"] == 0
+        assert body["gate_rejected_short"] == 0
+        assert body["gate_fallback_dropped"] == 0
 
     def test_min_evidence_zero_is_rejected_not_500(self, client):
         # min_evidence=0 previously reached compute_corpus_metrics and raised

--- a/tests/integration/test_memory_write_gate.py
+++ b/tests/integration/test_memory_write_gate.py
@@ -1,0 +1,346 @@
+"""Integration tests: the Memory.save() content gate across every writer path (#2201).
+
+Valor's subconscious memory system has five distinct code paths that
+construct and save a Memory record. Before this issue, only one of them
+(Claude Code hook ingest) applied any content-quality filtering; the other
+four saved whatever they were given, relying only on WriteFilterMixin's
+importance threshold. Issue #2201 moved the content gate into
+`Memory.save()` itself so every path inherits it for free.
+
+This module proves that claim empirically, one test per path, against the
+real `Memory` model and real Redis (no mocks on the model/gate itself) --
+per this repo's "no mocks, use actual APIs" testing philosophy. Each path
+gets a junk-content case (asserting the write is dropped) and a
+durable-content case (asserting it persists).
+
+The five paths (see docs/plans/memory-write-gate-unification.md):
+    1. Hook ingest              -- .claude/hooks/hook_utils/memory_bridge.py::ingest()
+    2. Post-session extraction  -- agent/memory_extraction.py::extract_observations_async()
+    3. Post-merge learning      -- agent/memory_extraction.py::extract_post_merge_learning()
+    4. Telegram bridge          -- bridge/telegram_bridge.py (Memory.safe_save call site)
+    5. Intentional CLI save     -- tools/memory_search/__init__.py::save()
+
+Uses the autouse ``redis_test_db`` fixture (tests/conftest.py) for
+per-worker Redis isolation; all test records are additionally scoped
+under a ``test-gate-`` project_key prefix and cleaned up via the Popoto
+ORM (never raw Redis) in a module-level teardown.
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytestmark = [pytest.mark.integration]
+
+# Hook code lives outside the `agent`/`models` package tree under
+# .claude/hooks -- add it to sys.path the same way tests/unit/test_memory_bridge.py
+# does, so `hook_utils.memory_bridge` is importable.
+_HOOKS_DIR = Path(__file__).resolve().parent.parent.parent / ".claude" / "hooks"
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+_PROJECT_KEY_PREFIX = "test-gate-"
+
+
+def _unique_project_key(suffix: str) -> str:
+    return f"{_PROJECT_KEY_PREFIX}{suffix}-{uuid.uuid4().hex[:8]}"
+
+
+def _cleanup(project_key: str) -> None:
+    """Delete every Memory record under project_key via the Popoto ORM.
+
+    Never raw Redis (`delete`/`srem`/`sadd`/`zrem`) on Popoto-managed keys
+    -- per-instance `.delete()` only, per repo convention.
+    """
+    from models.memory import Memory
+
+    for record in Memory.query.filter(project_key=project_key):
+        record.delete()
+
+
+class TestHookIngestWriterPath:
+    """Writer path #1: .claude/hooks/hook_utils/memory_bridge.py::ingest()."""
+
+    def test_fragment_junk_is_dropped(self):
+        from hook_utils.memory_bridge import ingest
+
+        project_key = _unique_project_key("hook-fragment")
+        try:
+            # Dangling colon (fragment under classify_content), >= the hook's
+            # own MIN_PROMPT_LENGTH=50 so it clears the hook's pre-filter and
+            # reaches the model gate itself.
+            junk = (
+                "Here is a description of the deployment process that "
+                "we still need to write up in full detail:"
+            )
+            assert len(junk.strip()) >= 50
+
+            with patch("hook_utils.memory_bridge._get_project_key", return_value=project_key):
+                result = ingest(junk)
+
+            assert result is False
+
+            from models.memory import Memory
+
+            assert list(Memory.query.filter(project_key=project_key)) == []
+        finally:
+            _cleanup(project_key)
+
+    def test_durable_content_persists(self):
+        from hook_utils.memory_bridge import ingest
+
+        project_key = _unique_project_key("hook-durable")
+        try:
+            durable = (
+                f"Durable fact {uuid.uuid4().hex[:8]}: deploys run every Friday "
+                "afternoon after the smoke suite is green."
+            )
+            assert len(durable.strip()) >= 50
+
+            with patch("hook_utils.memory_bridge._get_project_key", return_value=project_key):
+                result = ingest(durable)
+
+            assert result is True
+
+            from models.memory import Memory
+
+            records = Memory.query.filter(project_key=project_key)
+            assert len(records) == 1
+            assert records[0].content == durable
+        finally:
+            _cleanup(project_key)
+
+
+class TestPostSessionExtractionWriterPath:
+    """Writer path #2: agent/memory_extraction.py::extract_observations_async()."""
+
+    @pytest.mark.asyncio
+    async def test_below_floor_observation_is_dropped(self):
+        """A JSON observation between 10 (extraction's own floor) and 15
+        (the model gate's MIN_CONTENT_LENGTH) chars passes extraction's own
+        per-item filter but is still gated by Memory.save() -- proving the
+        model-layer gate, not extraction's pre-existing length check, is
+        what catches it.
+        """
+        import json
+
+        from agent.memory_extraction import extract_observations_async
+
+        project_key = _unique_project_key("extraction-short")
+        try:
+            # "Fixed at noon" == 13 chars: >= extraction's len(observation) < 10
+            # drop, but < the model gate's MIN_CONTENT_LENGTH (15).
+            raw = json.dumps([{"category": "decision", "observation": "Fixed at noon"}])
+            assert 10 <= len("Fixed at noon") < 15
+
+            mock_llm = AsyncMock(return_value=raw)
+            with (
+                patch("agent.memory_extraction._llm_call", mock_llm),
+                patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
+            ):
+                result = await extract_observations_async(
+                    "sess-gate-extraction-short", raw, project_key=project_key
+                )
+
+            assert result == []
+
+            from models.memory import Memory
+
+            assert list(Memory.query.filter(project_key=project_key)) == []
+        finally:
+            _cleanup(project_key)
+
+    @pytest.mark.asyncio
+    async def test_durable_observation_persists(self):
+        import json
+
+        from agent.memory_extraction import extract_observations_async
+
+        project_key = _unique_project_key("extraction-durable")
+        try:
+            observation = (
+                f"Chose blue-green deployment {uuid.uuid4().hex[:8]} over rolling "
+                "updates for zero-downtime releases"
+            )
+            raw = json.dumps([{"category": "decision", "observation": observation}])
+
+            mock_llm = AsyncMock(return_value=raw)
+            with (
+                patch("agent.memory_extraction._llm_call", mock_llm),
+                patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
+            ):
+                result = await extract_observations_async(
+                    "sess-gate-extraction-durable", raw, project_key=project_key
+                )
+
+            assert result != []
+
+            from models.memory import Memory
+
+            records = Memory.query.filter(project_key=project_key)
+            assert len(records) == 1
+            assert records[0].content == observation
+        finally:
+            _cleanup(project_key)
+
+
+class TestPostMergeLearningWriterPath:
+    """Writer path #3: agent/memory_extraction.py::extract_post_merge_learning()."""
+
+    @pytest.mark.asyncio
+    async def test_fragment_learning_is_dropped(self):
+        from agent.memory_extraction import extract_post_merge_learning
+
+        project_key = _unique_project_key("postmerge-fragment")
+        try:
+            # Dangling colon (fragment), >= post-merge's own 20-char floor.
+            raw = "Includes a helper function we still need to write:"
+            assert len(raw) >= 20
+
+            mock_llm = AsyncMock(return_value=raw)
+            with (
+                patch("agent.memory_extraction._llm_call", mock_llm),
+                patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
+            ):
+                result = await extract_post_merge_learning(
+                    "Fix flaky test", "body", "diff", project_key=project_key
+                )
+
+            assert result is None
+
+            from models.memory import Memory
+
+            assert list(Memory.query.filter(project_key=project_key)) == []
+        finally:
+            _cleanup(project_key)
+
+    @pytest.mark.asyncio
+    async def test_durable_learning_persists(self):
+        from agent.memory_extraction import extract_post_merge_learning
+
+        project_key = _unique_project_key("postmerge-durable")
+        try:
+            raw = (
+                f"Chose blue-green deployment {uuid.uuid4().hex[:8]} for "
+                "zero-downtime release cycles across all services."
+            )
+
+            mock_llm = AsyncMock(return_value=raw)
+            with (
+                patch("agent.memory_extraction._llm_call", mock_llm),
+                patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
+            ):
+                result = await extract_post_merge_learning(
+                    "Adopt blue-green deploys", "body", "diff", project_key=project_key
+                )
+
+            assert result is not None
+
+            from models.memory import Memory
+
+            records = Memory.query.filter(project_key=project_key)
+            assert len(records) == 1
+            assert records[0].content == raw
+        finally:
+            _cleanup(project_key)
+
+
+class TestTelegramBridgeWriterPath:
+    """Writer path #4: bridge/telegram_bridge.py's Memory.safe_save call site.
+
+    The save call itself (bridge/telegram_bridge.py:1335) is a plain
+    `Memory.safe_save(agent_id=..., project_key=..., content=..., importance=
+    InteractionWeight.HUMAN, source="human")` inside a full Telethon event
+    handler. Reconstructing that handler (event objects, sender resolution,
+    project routing) is out of scope for a write-gate test -- what this
+    test proves is the exact call shape at that site funnels through the
+    same gated Memory.save(), which is the property #2201 established.
+    """
+
+    def test_ack_only_message_is_dropped(self):
+        from popoto import InteractionWeight
+
+        from models.memory import Memory
+
+        project_key = _unique_project_key("telegram-ack")
+        try:
+            result = Memory.safe_save(
+                agent_id="test-sender",
+                project_key=project_key,
+                content="Yup",
+                importance=InteractionWeight.HUMAN,
+                source="human",
+            )
+
+            assert result is None
+            assert list(Memory.query.filter(project_key=project_key)) == []
+        finally:
+            _cleanup(project_key)
+
+    def test_durable_message_persists(self):
+        from popoto import InteractionWeight
+
+        from models.memory import Memory
+
+        project_key = _unique_project_key("telegram-durable")
+        try:
+            content = f"Deploy on Fridays only {uuid.uuid4().hex[:8]}, after the smoke suite."
+
+            result = Memory.safe_save(
+                agent_id="test-sender",
+                project_key=project_key,
+                content=content,
+                importance=InteractionWeight.HUMAN,
+                source="human",
+            )
+
+            assert result is not None
+
+            records = Memory.query.filter(project_key=project_key)
+            assert len(records) == 1
+            assert records[0].content == content
+        finally:
+            _cleanup(project_key)
+
+
+class TestIntentionalCliSaveWriterPath:
+    """Writer path #5: tools/memory_search/__init__.py::save()."""
+
+    def test_fragment_content_is_dropped(self):
+        from tools.memory_search import save
+
+        project_key = _unique_project_key("cli-fragment")
+        try:
+            result = save("includes:", project_key=project_key)
+
+            assert result is None
+
+            from models.memory import Memory
+
+            assert list(Memory.query.filter(project_key=project_key)) == []
+        finally:
+            _cleanup(project_key)
+
+    def test_durable_content_persists(self):
+        from tools.memory_search import save
+
+        project_key = _unique_project_key("cli-durable")
+        try:
+            content = f"Deploy on Fridays {uuid.uuid4().hex[:8]} after the smoke suite is green."
+
+            result = save(content, project_key=project_key)
+
+            assert result is not None
+
+            from models.memory import Memory
+
+            records = Memory.query.filter(project_key=project_key)
+            assert len(records) == 1
+            assert records[0].content == content
+        finally:
+            _cleanup(project_key)

--- a/tests/unit/test_memory_extraction.py
+++ b/tests/unit/test_memory_extraction.py
@@ -150,6 +150,49 @@ class TestRunPostSessionExtraction:
         # Should not raise even with bad session
         await run_post_session_extraction("nonexistent", "some text")
 
+    # --- Issue #2201: unparseable extraction output is dropped+counted,
+    # never exploded into per-line records (the removed fallback). ---
+
+    @pytest.mark.asyncio
+    async def test_unparseable_llm_output_returns_empty_and_increments_fallback_counter(self):
+        """Non-JSON, non-refusal Haiku output is dropped and counted.
+
+        Guards issue #2201 end-to-end at the caller: `_parse_categorized_
+        observations` returns [] for prose with no JSON-shaped substring,
+        and `extract_observations_async` must resolve `project_key` BEFORE
+        the not-parsed short-circuit so `fallback_dropped` always has a key
+        to increment (the plan's Blocker 2 fix -- project_key resolution
+        must not happen after the early return).
+        """
+        from unittest.mock import AsyncMock, patch
+
+        from popoto.redis_db import POPOTO_REDIS_DB
+
+        from agent.memory_extraction import extract_observations_async
+
+        project_key = "test-fallback-dropped-project"
+        counter_key = f"{project_key}:memory-gate:fallback_dropped"
+        before = int(POPOTO_REDIS_DB.get(counter_key) or 0)
+
+        # Plain prose, no JSON substring, not a refusal, long enough to pass
+        # every pre-LLM guard -- reaches the parser and falls through to
+        # the unconditional `return []`.
+        unparseable = (
+            "Worker finished session in 12.4s and migrated three tables "
+            "across the new API server without any structured takeaway."
+        )
+        mock_llm = AsyncMock(return_value=unparseable)
+        with (
+            patch("agent.memory_extraction._llm_call", mock_llm),
+            patch("utils.api_keys.get_anthropic_api_key", return_value="fake-key"),
+        ):
+            result = await extract_observations_async(
+                "sess-fallback-dropped", unparseable, project_key=project_key
+            )
+
+        assert result == []
+        assert int(POPOTO_REDIS_DB.get(counter_key) or 0) == before + 1
+
     # --- Issue #1212: pre-LLM and post-LLM refusal/whitespace guards ---
 
     @pytest.mark.asyncio
@@ -648,11 +691,18 @@ class TestRefusalLLMComplement:
 
     # A genuine-looking primary-extraction payload that passes the closed-vocab
     # refusal check and the "NONE" short-circuit, so extraction reaches the
-    # point where the complement would fire if the flag is enabled. Mirrors
-    # the DECISION: line-format idiom used throughout
-    # TestParseCategorizedObservations.
-    _PRIMARY_OUTPUT = (
-        "DECISION: chose blue-green deployment over rolling updates for zero-downtime releases"
+    # point where the complement would fire if the flag is enabled. JSON-
+    # shaped (issue #2201 removed the DECISION:-line-based fallback this
+    # used to rely on) so `_parse_categorized_observations` yields ≥1
+    # observation via the sanctioned JSON path.
+    _PRIMARY_OUTPUT = json.dumps(
+        [
+            {
+                "category": "decision",
+                "observation": "chose blue-green deployment over rolling updates "
+                "for zero-downtime releases",
+            }
+        ]
     )
 
     # Real-looking input passes all three pre-LLM guards (length, refusal
@@ -818,49 +868,46 @@ class TestRefusalLLMComplement:
 class TestParseCategorizedObservations:
     """Test agent/memory_extraction.py _parse_categorized_observations()."""
 
-    def test_parses_correction_category(self):
+    @pytest.mark.parametrize("category", ["correction", "decision", "pattern", "surprise"])
+    def test_json_category_maps_to_correct_importance(self, category):
+        """Category -> importance mapping, exercised via the sanctioned JSON
+        path. Issue #2201 removed the line-based `CATEGORY: text` fallback
+        that used to be the only place these mappings were tested -- the
+        mapping itself (CATEGORY_IMPORTANCE) is unchanged, only how an
+        LLM's raw text reaches it (JSON only, now).
+        """
         from agent.memory_extraction import CATEGORY_IMPORTANCE, _parse_categorized_observations
 
-        raw = "CORRECTION: Redis SCAN is preferred over KEYS in production for large keyspaces"
+        raw = json.dumps(
+            [
+                {
+                    "category": category,
+                    "observation": f"a durable {category} observation about the deploy pipeline",
+                }
+            ]
+        )
         result = _parse_categorized_observations(raw)
         assert len(result) == 1
-        content, importance, metadata = result[0]
-        assert "Redis SCAN" in content
-        assert importance == CATEGORY_IMPORTANCE["correction"]
-        assert isinstance(metadata, dict)
+        assert result[0][1] == CATEGORY_IMPORTANCE[category]
 
-    def test_parses_decision_category(self):
+    def test_json_array_parses_multiple_items_in_order(self):
         from agent.memory_extraction import CATEGORY_IMPORTANCE, _parse_categorized_observations
 
-        raw = "DECISION: chose blue-green deployment over rolling updates for zero-downtime"
-        result = _parse_categorized_observations(raw)
-        assert len(result) == 1
-        assert result[0][1] == CATEGORY_IMPORTANCE["decision"]
-        assert isinstance(result[0][2], dict)
-
-    def test_parses_pattern_category(self):
-        from agent.memory_extraction import CATEGORY_IMPORTANCE, _parse_categorized_observations
-
-        raw = "PATTERN: all Popoto models use safe_save as the primary entry point for creation"
-        result = _parse_categorized_observations(raw)
-        assert len(result) == 1
-        assert result[0][1] == CATEGORY_IMPORTANCE["pattern"]
-
-    def test_parses_surprise_category(self):
-        from agent.memory_extraction import CATEGORY_IMPORTANCE, _parse_categorized_observations
-
-        raw = "SURPRISE: the bloom filter returns false positives more often than expected"
-        result = _parse_categorized_observations(raw)
-        assert len(result) == 1
-        assert result[0][1] == CATEGORY_IMPORTANCE["surprise"]
-
-    def test_parses_multiple_categories(self):
-        from agent.memory_extraction import CATEGORY_IMPORTANCE, _parse_categorized_observations
-
-        raw = (
-            "CORRECTION: Redis SCAN is preferred over KEYS in production\n"
-            "DECISION: chose ContextAssembler for memory search over raw queries\n"
-            "PATTERN: all models use safe_save as their primary entry point"
+        raw = json.dumps(
+            [
+                {
+                    "category": "correction",
+                    "observation": "Redis SCAN is preferred over KEYS in production",
+                },
+                {
+                    "category": "decision",
+                    "observation": "chose ContextAssembler for memory search over raw queries",
+                },
+                {
+                    "category": "pattern",
+                    "observation": "all models use safe_save as their primary entry point",
+                },
+            ]
         )
         result = _parse_categorized_observations(raw)
         assert len(result) == 3
@@ -868,10 +915,18 @@ class TestParseCategorizedObservations:
         assert result[1][1] == CATEGORY_IMPORTANCE["decision"]
         assert result[2][1] == CATEGORY_IMPORTANCE["pattern"]
 
-    def test_case_insensitive_category(self):
+    def test_json_category_matching_is_case_insensitive(self):
         from agent.memory_extraction import CATEGORY_IMPORTANCE, _parse_categorized_observations
 
-        raw = "correction: Redis SCAN is preferred over KEYS in production for large keyspaces"
+        raw = json.dumps(
+            [
+                {
+                    "category": "CORRECTION",
+                    "observation": "Redis SCAN is preferred over KEYS in production "
+                    "for large keyspaces",
+                }
+            ]
+        )
         result = _parse_categorized_observations(raw)
         assert len(result) == 1
         assert result[0][1] == CATEGORY_IMPORTANCE["correction"]
@@ -901,45 +956,55 @@ class TestParseCategorizedObservations:
         assert any("blue-green" in c for c in contents)
         assert len(result) == 1
 
-    def test_scoping_boilerplate_dropped_line_path(self):
-        """An observation echoing session-scoping boilerplate is dropped (line-based path)."""
+    # --- Issue #2201: the line-splitting fallback is removed entirely.
+    # Every one of the three fall-through cases (no JSON-shaped substring
+    # found, json.loads raising, or a valid-JSON-parse with zero valid
+    # observations) now returns [] and is counted as `fallback_dropped` by
+    # the caller (extract_observations_async), never exploded into
+    # per-line Memory records. ---
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            pytest.param(
+                "The deployment uses blue-green strategy for zero downtime",
+                id="plain_prose_no_json_substring",
+            ),
+            pytest.param(
+                "CORRECTION: Redis SCAN is preferred over KEYS in production\n"
+                "DECISION: chose ContextAssembler for memory search over raw queries",
+                id="category_prefixed_lines_no_json_substring",
+            ),
+            pytest.param(
+                "CORRECTION: Redis SCAN is preferred over KEYS in production\n"
+                "Some uncategorized observation that should be dropped",
+                id="mixed_categorized_and_uncategorized_lines",
+            ),
+            pytest.param("CORRECTION: short", id="short_content_after_category_prefix"),
+        ],
+    )
+    def test_no_json_substring_returns_empty(self, raw):
+        """Case (1): extract_json_payload finds no JSON-shaped substring."""
         from agent.memory_extraction import _parse_categorized_observations
 
-        raw = (
-            "PATTERN: this session is scoped to isolated session contexts; do not "
-            "include work from other sessions\n"
-            "PATTERN: all Popoto models use safe_save as the primary entry point"
-        )
-        result = _parse_categorized_observations(raw)
-        contents = [c for c, _, _ in result]
-        assert all("scoped to isolated session" not in c.lower() for c in contents)
-        assert any("safe_save" in c for c in contents)
+        assert _parse_categorized_observations(raw) == []
 
-    def test_fallback_uncategorized(self):
-        from agent.memory_extraction import (
-            DEFAULT_CATEGORY_IMPORTANCE,
-            _parse_categorized_observations,
-        )
-
-        raw = "The deployment uses blue-green strategy for zero downtime"
-        result = _parse_categorized_observations(raw)
-        assert len(result) == 1
-        assert result[0][1] == DEFAULT_CATEGORY_IMPORTANCE
-        # Line-based fallback returns empty metadata
-        assert result[0][2] == {}
-
-    def test_mixed_categorized_and_uncategorized(self):
-        """When some lines are categorized, uncategorized lines are dropped."""
+    def test_json_loads_raises_returns_empty(self):
+        """Case (2): a JSON-shaped substring is found but json.loads raises."""
         from agent.memory_extraction import _parse_categorized_observations
 
-        raw = (
-            "CORRECTION: Redis SCAN is preferred over KEYS in production\n"
-            "Some uncategorized observation that should be dropped"
-        )
-        result = _parse_categorized_observations(raw)
-        # Only the categorized line should be returned
-        assert len(result) == 1
-        assert "Redis SCAN" in result[0][0]
+        raw = '[{"category": "correction", broken json'
+        assert _parse_categorized_observations(raw) == []
+
+    def test_json_valid_but_zero_observations_returns_empty(self):
+        """Case (3): valid JSON parses but yields zero valid observations."""
+        from agent.memory_extraction import _parse_categorized_observations
+
+        # "short" is < 10 chars, so the per-item length filter drops it,
+        # leaving `results` empty -- this must NOT fall through to any
+        # line-based parsing of raw_text.
+        raw = json.dumps([{"category": "correction", "observation": "short"}])
+        assert _parse_categorized_observations(raw) == []
 
     def test_empty_input(self):
         from agent.memory_extraction import _parse_categorized_observations
@@ -950,14 +1015,6 @@ class TestParseCategorizedObservations:
         from agent.memory_extraction import _parse_categorized_observations
 
         assert _parse_categorized_observations("NONE") == []
-
-    def test_short_content_after_category_filtered(self):
-        from agent.memory_extraction import _parse_categorized_observations
-
-        # Content after category prefix is too short (< 10 chars)
-        raw = "CORRECTION: short"
-        result = _parse_categorized_observations(raw)
-        assert len(result) == 0
 
     def test_json_array_parsing(self):
         """JSON array input is parsed with full metadata."""
@@ -1002,20 +1059,19 @@ class TestParseCategorizedObservations:
         assert len(result) == 1
         assert result[0][2]["category"] == "decision"
 
-    def test_json_malformed_falls_back_to_line_parser(self):
-        """Malformed JSON falls back to line-based parser."""
-        from agent.memory_extraction import _parse_categorized_observations
-
-        raw = '[{"category": "correction", broken json'
-        # Should not raise, falls back to line-based
-        result = _parse_categorized_observations(raw)
-        assert isinstance(result, list)
-
     def test_returns_three_tuples(self):
         """All results are (content, importance, metadata) 3-tuples."""
         from agent.memory_extraction import _parse_categorized_observations
 
-        raw = "CORRECTION: Redis SCAN is preferred over KEYS in production for large keyspaces"
+        raw = json.dumps(
+            [
+                {
+                    "category": "correction",
+                    "observation": "Redis SCAN is preferred over KEYS in production "
+                    "for large keyspaces",
+                }
+            ]
+        )
         result = _parse_categorized_observations(raw)
         assert len(result) == 1
         assert len(result[0]) == 3

--- a/tests/unit/test_memory_quality.py
+++ b/tests/unit/test_memory_quality.py
@@ -3,17 +3,27 @@
 Covers the Phase-1 (issue #2200) success criteria for
 `docs/plans/memory-telemetry-baseline.md`: ack-only detection, fragment
 detection, durable full-fact classification, and the deterministic
-None/empty/whitespace disposition. Pure-function tests -- no Redis, no
-popoto, no network.
+None/empty/whitespace disposition. Also covers the Phase-2 (issue #2201)
+write-gate predicate `gate_reason` / `MIN_CONTENT_LENGTH` and the
+best-effort `_increment_gate_counter` helper. Pure-function tests -- no
+Redis, no popoto, no network (the counter test mocks the Redis handle).
 
-Marker: sdlc (feature tests for issue #2200).
+Marker: sdlc (feature tests for issue #2200 / #2201).
 """
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
-from agent.memory_quality import classify_content, is_ack_only, is_fragment
+from agent.memory_quality import (
+    MIN_CONTENT_LENGTH,
+    classify_content,
+    gate_reason,
+    is_ack_only,
+    is_fragment,
+)
 
 pytestmark = pytest.mark.sdlc
 
@@ -94,3 +104,192 @@ class TestClassifyContentEdgeCases:
         source = open(mq.__file__).read()
         for banned in ("import redis", "import popoto", "from redis", "from popoto", "from models"):
             assert banned not in source
+
+
+class TestGateReasonTaxonomy:
+    """Phase-2 (issue #2201) write-gate predicate.
+
+    Oracle values verified directly against the frozen `classify_content`
+    (see that function's docstring/tests above) -- `gate_reason` composes
+    it and must never alter its three-bucket output.
+    """
+
+    def test_ack_only_maps_to_ack(self):
+        assert gate_reason("Yup") == "ack"
+
+    def test_dangling_colon_maps_to_fragment(self):
+        # "includes:" has no trailing body -- classify_content says fragment.
+        assert gate_reason("includes:") == "fragment"
+
+    def test_bare_list_marker_no_body_maps_to_fragment(self):
+        # "1." alone (no body) is a bare list marker -- fragment, not short.
+        assert gate_reason("1.") == "fragment"
+
+    def test_list_marker_with_body_below_floor_maps_to_short(self):
+        # "1. Concurrency" (14 chars) has a body, so the bare-marker regex
+        # does NOT match -- classify_content calls it "durable". Only the
+        # length floor (15) catches it, so it must be "short", not "fragment".
+        assert len("1. Concurrency") == 14
+        assert classify_content("1. Concurrency") == "durable"
+        assert gate_reason("1. Concurrency") == "short"
+
+    def test_below_floor_durable_content_maps_to_short(self):
+        assert len("deploy fri") == 10
+        assert gate_reason("deploy fri") == "short"
+
+    @pytest.mark.parametrize("content", [None, "", "   "])
+    def test_none_empty_whitespace_maps_to_fragment(self, content):
+        assert gate_reason(content) == "fragment"
+
+    def test_at_floor_durable_content_persists(self):
+        # 17 chars, >= MIN_CONTENT_LENGTH (15) -- persists (None = no gate reason).
+        assert len("Deploy on Fridays") == 17
+        assert gate_reason("Deploy on Fridays") is None
+
+    def test_taxonomy_is_exactly_three_reasons(self):
+        """fragment must never be folded into short -- three distinct counters."""
+        reasons = {
+            gate_reason("Yup"),
+            gate_reason("includes:"),
+            gate_reason("deploy fri"),
+        }
+        assert reasons == {"ack", "fragment", "short"}
+
+
+class TestMinContentLength:
+    def test_min_content_length_is_fifteen(self):
+        assert MIN_CONTENT_LENGTH == 15
+
+    def test_classify_content_has_no_length_awareness(self):
+        """classify_content stays frozen -- the length floor is write-gate-only."""
+        # "1. Concurrency" is short (14 chars) yet classify_content still
+        # reports "durable" -- proves the length floor lives only in
+        # gate_reason, never inside classify_content (baseline integrity).
+        assert classify_content("1. Concurrency") == "durable"
+
+
+class TestIncrementGateCounterNeverRaises:
+    def test_raising_redis_client_does_not_propagate(self):
+        from models.memory_gate import _increment_gate_counter
+
+        class _RaisingRedis:
+            def incr(self, *_args, **_kwargs):
+                raise ConnectionError("redis unreachable")
+
+        with patch("popoto.redis_db.POPOTO_REDIS_DB", _RaisingRedis()):
+            # Must not raise -- best-effort telemetry only.
+            _increment_gate_counter("test-project", "ack")
+
+
+class TestMemorySaveContentGate:
+    """Memory.save() content gate (issue #2201) -- exercised against real
+    Redis via the Memory model, not mocked, per this repo's testing
+    philosophy. Each test uses a unique project_key so counter deltas are
+    unambiguous even when the suite runs repeatedly against a shared Redis.
+    """
+
+    def test_insert_rejects_ack_only_and_increments_ack_counter(self):
+        from popoto.redis_db import POPOTO_REDIS_DB
+
+        from models.memory import Memory
+
+        project_key = "test-gate-ack-project"
+        counter_key = f"{project_key}:memory-gate:ack"
+        before = int(POPOTO_REDIS_DB.get(counter_key) or 0)
+
+        m = Memory(
+            agent_id="test-gate-agent", project_key=project_key, content="Yup", importance=5.0
+        )
+        result = m.save()
+
+        assert result is False
+        assert int(POPOTO_REDIS_DB.get(counter_key) or 0) == before + 1
+
+    def test_insert_rejects_fragment_and_increments_fragment_counter(self):
+        from popoto.redis_db import POPOTO_REDIS_DB
+
+        from models.memory import Memory
+
+        project_key = "test-gate-fragment-project"
+        counter_key = f"{project_key}:memory-gate:fragment"
+        before = int(POPOTO_REDIS_DB.get(counter_key) or 0)
+
+        m = Memory(
+            agent_id="test-gate-agent",
+            project_key=project_key,
+            content="includes:",
+            importance=5.0,
+        )
+        result = m.save()
+
+        assert result is False
+        assert int(POPOTO_REDIS_DB.get(counter_key) or 0) == before + 1
+
+    def test_insert_rejects_below_floor_and_increments_short_counter(self):
+        from popoto.redis_db import POPOTO_REDIS_DB
+
+        from models.memory import Memory
+
+        project_key = "test-gate-short-project"
+        counter_key = f"{project_key}:memory-gate:short"
+        before = int(POPOTO_REDIS_DB.get(counter_key) or 0)
+
+        m = Memory(
+            agent_id="test-gate-agent",
+            project_key=project_key,
+            content="1. Concurrency",  # 14 chars, durable under classify_content
+            importance=5.0,
+        )
+        result = m.save()
+
+        assert result is False
+        assert int(POPOTO_REDIS_DB.get(counter_key) or 0) == before + 1
+
+    def test_insert_persists_durable_content_above_floor(self):
+        from models.memory import Memory
+
+        project_key = "test-gate-durable-project"
+        m = Memory(
+            agent_id="test-gate-agent",
+            project_key=project_key,
+            content="Deploy on Fridays only after the smoke suite is green",
+            importance=5.0,
+        )
+        result = m.save()
+
+        assert result is not False
+        reloaded = Memory.query.filter(memory_id=m.memory_id)
+        assert len(reloaded) == 1
+
+    def test_update_resave_of_junk_content_is_never_gated(self):
+        """Guards the outcome/metadata re-save at memory_extraction.py:1343.
+
+        A record that is already persisted (an UPDATE, not an INSERT) must
+        never be dropped by the content gate, even if its content has
+        degraded to (or always was) below-floor/ack-only junk -- otherwise
+        the outcome/dismissal_count/last_outcome write is silently lost.
+        """
+        from models.memory import Memory
+
+        project_key = "test-gate-update-project"
+        m = Memory(
+            agent_id="test-gate-agent",
+            project_key=project_key,
+            content="Durable content for the update re-save gating test",
+            importance=2.0,
+            source="agent",
+        )
+        insert_result = m.save()
+        assert insert_result is not False
+
+        # Simulate the record degrading to legacy junk and an outcome-loop
+        # metadata re-save on the SAME already-persisted key.
+        m.content = "no"  # ack-only -- would gate a fresh INSERT
+        m.metadata = {"last_outcome": "acted"}
+        update_result = m.save()
+
+        assert update_result is not False, "Update re-save must never be content-gated"
+        reloaded = Memory.query.filter(memory_id=m.memory_id)
+        assert len(reloaded) == 1
+        assert reloaded[0].content == "no"
+        assert reloaded[0].metadata.get("last_outcome") == "acted"

--- a/ui/data/memories.py
+++ b/ui/data/memories.py
@@ -237,6 +237,47 @@ def get_memories(
     }
 
 
+_GATE_COUNTER_FIELDS: tuple[tuple[str, str], ...] = (
+    ("ack", "gate_rejected_ack"),
+    ("fragment", "gate_rejected_fragment"),
+    ("short", "gate_rejected_short"),
+    ("fallback_dropped", "gate_fallback_dropped"),
+)
+
+
+def _sum_gate_counter(reason: str, pks: list[str]) -> int:
+    """Best-effort sum of the `{project_key}:memory-gate:{reason}` counter across `pks`.
+
+    Issue #2201's write-gate counters live on plain `INCR`/`GET` Redis keys
+    (not Popoto-managed), written by `models/memory.py`'s `Memory.save()`
+    override and `agent/memory_extraction.py`'s fallback-drop path. This
+    reuses `_sum_project_counter`'s `{project_key}:{suffix}` key layout
+    (`ui/app.py:434`) but is DELIBERATELY driven by the `pks` this call's
+    `get_corpus_metrics` already resolved (`_resolve_project_keys`), not
+    `get_machine_project_keys()` -- the counters must match the exact
+    corpus scope this metrics call reports on, not every project this
+    machine owns.
+
+    Never raises: any Redis error (including the whole handle being
+    unreachable) yields 0 so the metrics payload stays well-formed and the
+    dashboard never crashes.
+    """
+    try:
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+    except Exception:
+        return 0
+
+    total = 0
+    for pk in pks:
+        try:
+            val = _R.get(f"{pk}:memory-gate:{reason}")
+            if val:
+                total += int(val)
+        except Exception:
+            continue
+    return total
+
+
 def get_corpus_metrics(project_key: str | None = None, min_evidence: int = 2) -> dict:
     """Corpus-wide ingest-quality metrics for the memory-telemetry surface.
 
@@ -287,6 +328,8 @@ def get_corpus_metrics(project_key: str | None = None, min_evidence: int = 2) ->
         )
         metrics = compute_corpus_metrics([], min_evidence=min_evidence)
         metrics["project_key"] = ", ".join(pks)
+        for reason, field in _GATE_COUNTER_FIELDS:
+            metrics[field] = _sum_gate_counter(reason, pks)
         return metrics
 
     decorated = [_decorate_record(r) for r in all_records]
@@ -301,6 +344,13 @@ def get_corpus_metrics(project_key: str | None = None, min_evidence: int = 2) ->
     # Redis) -- there is no matching "read current value" accessor to
     # attach without inventing new analytics surface, so it is
     # intentionally skipped (per plan: skip rather than invent).
+    #
+    # The issue #2201 write-gate counters ARE attached below: unlike the
+    # analytics metrics above, they live on plain readable `INCR`/`GET`
+    # Redis keys (`_sum_gate_counter`), not analytics.collector's
+    # write-only store, so there is a real "read current value" accessor.
+    for reason, field in _GATE_COUNTER_FIELDS:
+        metrics[field] = _sum_gate_counter(reason, pks)
 
     return metrics
 


### PR DESCRIPTION
## Summary
- All five Memory writer paths (hook ingest, post-session extraction, post-merge learning, Telegram bridge, intentional CLI save) funnel through `Memory.save()`, but only the hook path had content-quality gating. This unifies gating at that single choke point so all five paths are covered with zero per-path edits.
- A separate line-splitting fallback in `agent/memory_extraction.py::_parse_categorized_observations()` exploded unparseable LLM output into one junk Memory record per line. That fallback is deleted outright.

## Changes
- `agent/memory_quality.py`: new `MIN_CONTENT_LENGTH` + `gate_reason(content)`, composing the existing frozen `classify_content` classifier (`ack` / `fragment` / `short` / `None`). `classify_content`'s three buckets are unchanged (baseline `junk_rate` integrity preserved).
- `models/memory.py`: `Memory.save()` overridden to gate on INSERT only — an existence check on the record's Redis key skips gating on updates (protects the outcome-metadata re-save in `memory_extraction.py` from losing writes on legacy-junk records).
- `models/memory_gate.py` (new): `_increment_gate_counter(project_key, reason)`, a try/except-wrapped Redis `INCR` on `{project_key}:memory-gate:{reason}`.
- `agent/memory_extraction.py`: the newline-splitting fallback is deleted; `_parse_categorized_observations` always returns `[]` on unparseable input (all three fall-through cases: no JSON substring, `json.loads` failure, zero valid observations). The caller increments a `fallback_dropped` counter. No retry before dropping.
- `ui/data/memories.py`: `_sum_gate_counter` + four new fields (`gate_rejected_ack`, `gate_rejected_fragment`, `gate_rejected_short`, `gate_fallback_dropped`) in `get_corpus_metrics`, surfaced via the existing `/memories/metrics.json` endpoint.
- `docs/features/subconscious-memory.md`: new "Write-Path Quality Gates" section.

## Testing
- [x] Unit tests passing (`tests/unit/test_memory_quality.py`, `tests/unit/test_memory_extraction.py`)
- [x] Integration tests passing (`tests/integration/test_memory_write_gate.py` — one test per writer path; `tests/integration/test_dashboard_memories.py`)
- [x] Lint/format checks passing (`ruff check` / `ruff format --check` — no new findings)
- [x] Broader `tests/unit/` suite run; the 18 failures observed are pre-existing/environmental (missing worktree symlink, shared-machine live state, xdist ordering) and independently reproduced on `main` — none touch the changed files

## Documentation
- [x] Docs created per plan requirements (`docs/features/subconscious-memory.md` write-gate subsection)
- [x] `docs/features/README.md` index confirmed to need no change (no new file)

## Definition of Done
- [x] Built: Code implemented and working
- [x] Tested: All tests passing
- [x] Reviewed: Code review completed, zero blocking issues (verdict: APPROVE)
- [x] Documented: Docs created/updated
- [x] Quality: Lint and format checks pass

Closes #2201