### PR TITLE
Fix VALOR_SESSION_ID doc misattribution to sdk_client.py

### DIFF
--- a/docs/features/agent-session-model.md
+++ b/docs/features/agent-session-model.md
@@ -127,7 +127,7 @@ session = AgentSession.get_by_id(agent_session_id)
 
 | Priority | Source | Description |
 |----------|--------|-------------|
-| 1 | `VALOR_SESSION_ID` env var | Bridge session_id, set by `sdk_client.py` |
+| 1 | `VALOR_SESSION_ID` env var | Bridge session_id, set by `session_executor.py`'s `_harness_env` |
 | 2 | Direct `session_id` match | Works when caller has the bridge session_id |
 | 3 | `task_list_id` match | Fallback for hook contexts with Claude Code UUID |
 
@@ -135,15 +135,14 @@ session = AgentSession.get_by_id(agent_session_id)
 
 ### VALOR_SESSION_ID Environment Variable
 
-Set by `agent/sdk_client.py` in `_create_options()` alongside `CLAUDE_CODE_TASK_LIST_ID`. Propagated to all Claude Code subprocesses.
+Set by `agent/session_executor.py`'s `_harness_env` alongside `CLAUDE_CODE_TASK_LIST_ID`. Propagated to all Claude Code subprocesses.
 
 ```python
-# In sdk_client.py _create_options():
-if session_id:
-    env["VALOR_SESSION_ID"] = session_id
+# In session_executor.py _harness_env:
+env["VALOR_SESSION_ID"] = session.session_id or ""
 ```
 
-The env var is only set when `session_id` is non-None (i.e., when the SDK is invoked from the bridge with a real session). Local Claude Code sessions without bridge context will not have this env var set, and `_find_session()` falls back to the other lookup paths.
+The key is **always** set in `_harness_env` — there is no conditional `if session_id:` guard. Its *value* is `session.session_id` when truthy, or an empty string when `session.session_id` is falsy. Local Claude Code sessions without bridge context will see this env var present but empty, and `_find_session()` falls back to the other lookup paths. For the full list of keys `_harness_env` sets, see [Harness Abstraction: env-contract table](harness-abstraction.md).
 
 **Important**: This env var is available inside the Claude Code subprocess (for shell scripts, Python tools via Bash) but is **not** available to hooks. Hooks execute in the parent bridge process, not the subprocess. For hook-side session resolution, use the session registry (`agent/hooks/session_registry.py`) which maps Claude Code UUIDs to bridge session IDs via `resolve(claude_uuid)`. See [Session Isolation: Hook Session Registry](session-isolation.md#hook-session-registry-issue-597) for details.
 

--- a/docs/features/session-steering.md
+++ b/docs/features/session-steering.md
@@ -342,7 +342,7 @@ python scripts/steer_child.py --session-id <child_id> --message "stop" --parent-
 python scripts/steer_child.py --list --parent-id <parent_id>
 ```
 
-The `--parent-id` can also be read from the `VALOR_SESSION_ID` environment variable, which is set by `sdk_client.py` for running sessions.
+The `--parent-id` can also be read from the `VALOR_SESSION_ID` environment variable, which `agent/session_executor.py`'s `_harness_env` sets for running sessions.
 
 ### Validation
 

--- a/docs/plans/valor_session_id_doc_source_fix.md
+++ b/docs/plans/valor_session_id_doc_source_fix.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: docs_complete
 type: bug
 appetite: Small
 owner: Valor Engels

--- a/docs/plans/valor_session_id_doc_source_fix.md
+++ b/docs/plans/valor_session_id_doc_source_fix.md
@@ -195,12 +195,12 @@ or bridge wiring is affected.
 ## Documentation
 
 ### Feature Documentation
-- [ ] Correct `docs/features/agent-session-model.md` line 130 (Session Lookup Chain table)
+- [x] Correct `docs/features/agent-session-model.md` line 130 (Session Lookup Chain table)
       to attribute `VALOR_SESSION_ID` to `agent/session_executor.py`'s `_harness_env`.
-- [ ] Rewrite the "VALOR_SESSION_ID Environment Variable" section (lines 136-148) with the
+- [x] Rewrite the "VALOR_SESSION_ID Environment Variable" section (lines 136-148) with the
       correct source, code snippet, and "always set / empty string when absent" behavior;
       preserve the hook-invisibility paragraph.
-- [ ] Add a cross-link to `docs/features/harness-abstraction.md` as the canonical `_harness_env`
+- [x] Add a cross-link to `docs/features/harness-abstraction.md` as the canonical `_harness_env`
       env-contract reference.
 
 ### External Documentation Site
@@ -211,11 +211,11 @@ or bridge wiring is affected.
 
 ## Success Criteria
 
-- [ ] `docs/features/agent-session-model.md` no longer references `sdk_client.py` or
+- [x] `docs/features/agent-session-model.md` no longer references `sdk_client.py` or
       `_create_options()` as the source of `VALOR_SESSION_ID`.
-- [ ] The doc correctly names `agent/session_executor.py` / `_harness_env` as the source.
-- [ ] The three-tier lookup and hook-invisibility guidance is preserved and still reads coherently.
-- [ ] Documentation updated (`/do-docs` cascade check passes).
+- [x] The doc correctly names `agent/session_executor.py` / `_harness_env` as the source.
+- [x] The three-tier lookup and hook-invisibility guidance is preserved and still reads coherently.
+- [x] Documentation updated (`/do-docs` cascade check passes).
 
 ## Team Orchestration
 


### PR DESCRIPTION
## Summary
- `docs/features/agent-session-model.md` misattributed the `VALOR_SESSION_ID` env var to `agent/sdk_client.py`'s `_create_options()`, a method that doesn't exist (deleted in the harness migration, #2000).
- Corrects both spots (Session Lookup Chain table + the VALOR_SESSION_ID section) to name `agent/session_executor.py`'s `_harness_env` as the real source, matching the current code (`env["VALOR_SESSION_ID"] = session.session_id or ""`).
- Fixes a secondary inaccuracy: the doc claimed the var is "only set when session_id is non-None"; the real behavior is the key is always set, empty string when falsy. This is now stated directly in the doc (not deferred to `harness-abstraction.md`, whose env-contract cell omits the `or ""` nuance).
- Adds a cross-link to `docs/features/harness-abstraction.md` as the canonical reference for the full `_harness_env` key list.
- Preserves the hook-invisibility paragraph and session-registry cross-reference verbatim (still accurate).

Documentation-only change, no code touched.

Closes #2208

## Test plan
- [x] `grep -c "set by \`sdk_client.py\`" docs/features/agent-session-model.md` → 0
- [x] `grep -c "_create_options" docs/features/agent-session-model.md` → 0
- [x] `grep -c "session_executor" docs/features/agent-session-model.md` → 5 (> 0)
- [x] `python -m ruff check docs/features/agent-session-model.md` → All checks passed
- [x] `python scripts/validate_docs_changed.py docs/plans/valor_session_id_doc_source_fix.md` → passed