### PR TITLE
Dashboard thread-level timing/turn aggregation across resumes

### DIFF
--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -335,43 +335,46 @@ async def _push_agent_session(
     # pop-loop caller (_cancel_stuck_pending_on_conflict escalation) are
     # left completely unchanged by this feature.
     #
-    # A capture failure must never block record creation, so the existence
-    # check and the capture itself are each wrapped in their own
-    # try/except. The existence check lets us distinguish a genuine
-    # first-run enqueue (no prior record at all -> no degrade, no metric)
-    # from a resume where a prior record existed but capture came back
-    # None or raised (a real degrade, worth counting).
+    # A capture failure must never block record creation, so the capture
+    # itself is wrapped in its own try/except. The existence check (used to
+    # distinguish a genuine first-run enqueue -- no prior record at all, no
+    # degrade, no metric -- from a resume where a prior record existed but
+    # capture came back None or raised, a real degrade worth counting) is
+    # only needed when thread_rollup ends up None, so it runs lazily inside
+    # that branch below instead of unconditionally on every call -- avoiding
+    # a second Redis round-trip on the common path where capture succeeds.
     thread_rollup: dict | None = None
-    try:
-        prior_existed = await asyncio.to_thread(
-            lambda: AgentSession.query.filter(session_id=session_id).count() > 0
-        )
-    except Exception as e:
-        logger.warning(f"Failed to check prior record existence for {session_id}: {e}")
-        prior_existed = False
-
     try:
         thread_rollup = await asyncio.to_thread(_capture_thread_rollup, session_id)
     except Exception as e:
         logger.warning(f"Failed to capture thread rollup for {session_id}: {e}")
         thread_rollup = None
 
-    if thread_rollup is None and prior_existed:
-        logger.info(
-            "Thread rollup capture degraded to null for session_id=%s "
-            "(a prior record existed but capture returned None or failed)",
-            session_id,
-        )
+    if thread_rollup is None:
         try:
-            from analytics.collector import record_metric
-
-            record_metric("thread_rollup_capture_null", 1.0, {"session_id": session_id})
-        except Exception as metric_exc:
-            logger.debug(
-                "record_metric(thread_rollup_capture_null) failed for %s: %s",
-                session_id,
-                metric_exc,
+            prior_existed = await asyncio.to_thread(
+                lambda: AgentSession.query.filter(session_id=session_id).count() > 0
             )
+        except Exception as e:
+            logger.warning(f"Failed to check prior record existence for {session_id}: {e}")
+            prior_existed = False
+
+        if prior_existed:
+            logger.info(
+                "Thread rollup capture degraded to null for session_id=%s "
+                "(a prior record existed but capture returned None or failed)",
+                session_id,
+            )
+            try:
+                from analytics.collector import record_metric
+
+                record_metric("thread_rollup_capture_null", 1.0, {"session_id": session_id})
+            except Exception as metric_exc:
+                logger.debug(
+                    "record_metric(thread_rollup_capture_null) failed for %s: %s",
+                    session_id,
+                    metric_exc,
+                )
 
     try:
         deleted_count = await asyncio.to_thread(_delete_stale_terminal_duplicates, session_id)

--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -322,6 +322,57 @@ async def _push_agent_session(
     # ORM-only, never raw Redis. Kept inside this try/except so a
     # reconciliation failure (Race 2: a concurrent reconciler already
     # deleted the record) never blocks the new record's creation below.
+    # Thread-level rollup capture (issue: dashboard-thread-timing-aggregation).
+    # This is a SEPARATE pre-read, not a modification of
+    # _delete_stale_terminal_duplicates(). The rollup is snapshotted into a
+    # detached plain dict below, before any delete runs, so atomicity
+    # between this read and the delete that follows is not required — a
+    # later delete (this path's own _delete_stale_terminal_duplicates call
+    # right below, or a racing pop-loop escalation delete at the
+    # StatusConflictError handler further down in this module) cannot
+    # invalidate an already-detached dict. That is exactly why
+    # _delete_stale_terminal_duplicates's `-> int` return contract and its
+    # pop-loop caller (_cancel_stuck_pending_on_conflict escalation) are
+    # left completely unchanged by this feature.
+    #
+    # A capture failure must never block record creation, so the existence
+    # check and the capture itself are each wrapped in their own
+    # try/except. The existence check lets us distinguish a genuine
+    # first-run enqueue (no prior record at all -> no degrade, no metric)
+    # from a resume where a prior record existed but capture came back
+    # None or raised (a real degrade, worth counting).
+    thread_rollup: dict | None = None
+    try:
+        prior_existed = await asyncio.to_thread(
+            lambda: AgentSession.query.filter(session_id=session_id).count() > 0
+        )
+    except Exception as e:
+        logger.warning(f"Failed to check prior record existence for {session_id}: {e}")
+        prior_existed = False
+
+    try:
+        thread_rollup = await asyncio.to_thread(_capture_thread_rollup, session_id)
+    except Exception as e:
+        logger.warning(f"Failed to capture thread rollup for {session_id}: {e}")
+        thread_rollup = None
+
+    if thread_rollup is None and prior_existed:
+        logger.info(
+            "Thread rollup capture degraded to null for session_id=%s "
+            "(a prior record existed but capture returned None or failed)",
+            session_id,
+        )
+        try:
+            from analytics.collector import record_metric
+
+            record_metric("thread_rollup_capture_null", 1.0, {"session_id": session_id})
+        except Exception as metric_exc:
+            logger.debug(
+                "record_metric(thread_rollup_capture_null) failed for %s: %s",
+                session_id,
+                metric_exc,
+            )
+
     try:
         deleted_count = await asyncio.to_thread(_delete_stale_terminal_duplicates, session_id)
         if deleted_count:
@@ -355,6 +406,10 @@ async def _push_agent_session(
         project_config=project_config or None,
         model=model or None,
         requires_real_chrome=requires_real_chrome,
+        thread_first_created_at=(thread_rollup or {}).get("thread_first_created_at"),
+        thread_turn_count=(thread_rollup or {}).get("thread_turn_count", 0),
+        thread_tool_call_count=(thread_rollup or {}).get("thread_tool_call_count", 0),
+        thread_run_count=(thread_rollup or {}).get("thread_run_count", 0),
     )
 
     # Initialize stage_states for SDLC sessions so the dashboard shows
@@ -1337,6 +1392,78 @@ def _resolve_callbacks(
         send_cb = _send_callbacks.get(project_key)
         react_cb = _reaction_callbacks.get(project_key)
     return send_cb, react_cb
+
+
+def _capture_thread_rollup(session_id: str) -> dict | None:
+    """Capture the prior terminal record's thread-level rollup counters for
+    ``session_id`` into a detached plain dict (issue:
+    dashboard-thread-timing-aggregation).
+
+    Called by ``_push_agent_session`` immediately BEFORE
+    ``_delete_stale_terminal_duplicates`` runs, so the resumed record's
+    ``thread_*`` fields can be seeded with the prior run's history instead of
+    losing it on every reply-to-resume. This function only reads; it never
+    deletes and is never itself a delete-authorizing check.
+
+    Base selection: among all ``AgentSession`` records sharing ``session_id``
+    whose ``status`` is in ``TERMINAL_STATUSES``, the single record with the
+    maximum ``created_at`` is the "base" this capture folds forward. If no
+    terminal record exists for ``session_id`` (e.g. a genuine first-run
+    enqueue, or a resume racing a concurrent deleter), returns ``None``.
+
+    Deliberately unconditional / no child-guard (divergence from
+    ``_delete_stale_terminal_duplicates``): that function's
+    ``get_child_sessions()`` guard exists only to protect *deletes* from
+    orphaning children, and does not apply to *reading* counters — a
+    child-guarded terminal base (one that ``_delete_stale_terminal_duplicates``
+    would skip deleting) must still be folded here, or its counters would be
+    silently dropped forever since the guard keeps that record alive but this
+    capture is the only path that ever reads it forward.
+
+    Bootstrap semantics for a base whose own ``thread_*`` fields are unset
+    (created before this feature, or itself a genuine first run):
+      - ``thread_first_created_at``: ``prior.thread_first_created_at or
+        prior.created_at`` — falls back to the base's own creation time.
+      - ``thread_run_count``: ``(prior.thread_run_count or 1) + 1`` — an
+        unset/zero prior run count is treated as "1 run so far" (the base
+        run itself), so the returned count for the new resume is 2.
+      - ``thread_turn_count`` / ``thread_tool_call_count``: ``(prior.thread_*
+        or 0) + (prior.turn_count or 0 / prior.tool_call_count or 0)`` — an
+        unset prior rollup contributes 0, and the base's own per-run counters
+        (which may also be unset/None) contribute 0 rather than raising on
+        ``None + int``.
+
+    Forward-accumulation / no-double-count invariant: every resume folds
+    exactly ONE base (the max-created_at terminal record), and that base's
+    own ``thread_*`` fields already carry all earlier runs forward (because
+    it was itself seeded the same way when it was created). A child-guarded
+    record that survives the delete pass has a strictly older ``created_at``
+    than any later completed run for the same ``session_id`` — once a newer
+    run exists and completes, that newer run becomes the max-created_at base
+    and the older child-guarded record is never selected again. So each
+    historical run's counters are folded exactly once, at the resume
+    immediately following its own completion, and are never re-summed on
+    subsequent resumes.
+
+    Returns:
+        A detached dict with keys ``thread_first_created_at``,
+        ``thread_run_count``, ``thread_turn_count``, ``thread_tool_call_count``,
+        or ``None`` if no terminal record exists for ``session_id``.
+    """
+    duplicates = [
+        s for s in AgentSession.query.filter(session_id=session_id) if s.status in TERMINAL_STATUSES
+    ]
+    if not duplicates:
+        return None
+
+    prior = max(duplicates, key=lambda s: s.created_at)
+    return {
+        "thread_first_created_at": prior.thread_first_created_at or prior.created_at,
+        "thread_run_count": (prior.thread_run_count or 1) + 1,
+        "thread_turn_count": (prior.thread_turn_count or 0) + (prior.turn_count or 0),
+        "thread_tool_call_count": (prior.thread_tool_call_count or 0)
+        + (prior.tool_call_count or 0),
+    }
 
 
 def _delete_stale_terminal_duplicates(session_id: str) -> int:

--- a/docs/features/agent-session-model.md
+++ b/docs/features/agent-session-model.md
@@ -22,6 +22,8 @@ See [Session Lifecycle](session-lifecycle.md) for the full 14-state reference (9
 
 **Session-phase:** `turn_count`, `tool_call_count`, `log_path`, `branch_name`, `tags`, `context_summary`, `expectations`
 
+**Thread-level rollup (across reply-resumes):** `thread_first_created_at` (`DatetimeField`, null), `thread_turn_count`, `thread_tool_call_count`, `thread_run_count` (all `IntField`, default 0) — nullable/additive fields that carry a resumed thread's history forward, since each reply-to-resume creates a fresh record with `turn_count=0`/`tool_call_count=0` and the prior terminal record gets deleted. Seeded by `_capture_thread_rollup` (`agent/agent_session_queue.py`) from the prior terminal record immediately before that record's delete runs. The dashboard folds these with the current run's per-run counters into `thread_display_*` values at read time. See [Session Lifecycle § Thread-Level Timing/Turn Rollup Across Resumes](session-lifecycle.md#thread-level-timingturn-rollup-across-resumes) for the full accumulation/no-double-count design.
+
 **Extra context (consolidated):** `extra_context` (DictField) — contains `revival_context`, `classification_type`, `classification_confidence`, and other ad-hoc context. Property accessors expose individual fields.
 
 **Lifecycle:** `session_events` (ListField of `SessionEvent` dicts), `issue_url`, `plan_url`, `pr_url`
@@ -425,3 +427,4 @@ python scripts/migrate_datetime_fields.py
 - [Session Watchdog](session-watchdog.md) - Reader of `unhealthy_reason`
 - [Compaction Hardening](compaction-hardening.md) - The compaction counters cut by the schema diet
 - [Removed Defenses Ledger](../removed-defenses.md) - `startup_failure_kind` plumbing removal record
+- [Session Lifecycle § Thread-Level Timing/Turn Rollup Across Resumes](session-lifecycle.md#thread-level-timingturn-rollup-across-resumes) - `thread_*` field capture, accumulation semantics, and dashboard render-time fold

--- a/docs/features/dashboard.md
+++ b/docs/features/dashboard.md
@@ -22,6 +22,16 @@ The sessions table is the primary view, auto-refreshing every 5 seconds via HTMX
 | Duration | Computed from start to completion or now | Formatted duration |
 | Links/Activity | `turn_count`/`tool_call_count`, issue/PR URLs | Activity badge shows turns/tool-calls; issue and PR links (captured via PostToolUse hook or backfilled from session history) |
 
+Per-run counts (`turn_count`/`tool_call_count`, `started_at`) reflect only the current
+resume, not the whole Telegram thread. Reply-resumes carry the prior run's history forward
+via `thread_first_created_at`/`thread_turn_count`/`thread_tool_call_count`/`thread_run_count`
+on the `AgentSession` record; `dashboard.json` also emits the render-time fold
+(`thread_display_started_at`, `thread_display_turn_count`, `thread_display_tool_call_count`,
+`thread_display_run_count`), which sums the rollup with the in-flight run and falls back to
+the per-run values for a never-resumed thread. See
+[Thread-Level Timing/Turn Rollup Across Resumes](session-lifecycle.md#thread-level-timingturn-rollup-across-resumes)
+for the accumulation semantics.
+
 ### Parent/Child Hierarchy
 
 Sessions spawned by a parent (e.g., PM spawning Dev) are grouped visually:

--- a/docs/features/session-lifecycle.md
+++ b/docs/features/session-lifecycle.md
@@ -230,6 +230,58 @@ The skip deliberately does **not** block legitimate recovery paths — `_complet
 
 The `_AGENT_SESSION_FIELDS` list defines which fields are preserved during delete-and-recreate operations. The `status` field is included for defense-in-depth: any delete-and-recreate path preserves the original status instead of defaulting to `"pending"`.
 
+## Thread-Level Timing/Turn Rollup Across Resumes
+
+### Problem
+
+Each Telegram reply-to-resume creates a fresh `AgentSession` record: `created_at=now`, `turn_count=0`, `tool_call_count=0`. The prior terminal record is then deleted by `_delete_stale_terminal_duplicates` (see [Duplicate-Session Dedup](#duplicate-session-dedup-only-completed-counts-as-handled-issue-1877)). Per-run fields are correct for a single run, but a dashboard reading only the latest record misreports a resumed thread's history as if the conversation started at the most recent resume — prior turns, tool calls, and the thread's actual start time are invisible.
+
+### Fix — four additive fields carry history forward
+
+`AgentSession` gained four nullable/additive fields (`models/agent_session.py`, alongside `turn_count`/`tool_call_count`):
+
+- `thread_first_created_at` (`DatetimeField`, null) — the thread's earliest `created_at`, carried forward across resumes.
+- `thread_turn_count` (`IntField`, default 0) — cumulative turn count from prior completed runs in this thread.
+- `thread_tool_call_count` (`IntField`, default 0) — cumulative tool call count from prior completed runs in this thread.
+- `thread_run_count` (`IntField`, default 0) — number of runs (resumes) this thread has had, including the current one.
+
+`_capture_thread_rollup(session_id)` in `agent/agent_session_queue.py` is a pure read helper: it selects the terminal record (status in `TERMINAL_STATUSES`) with the max `created_at` for `session_id` as the "base," and snapshots its rollup into a detached plain dict. `_push_agent_session` calls this **immediately before** `_delete_stale_terminal_duplicates` runs, so the read can never race the delete — the dict is fully detached from Redis state before any deletion happens, and the delete's own contract and pop-loop-escalation caller are untouched by this feature.
+
+### Accumulation semantics
+
+Given the selected base (`prior`), the new record is seeded with:
+
+- `thread_first_created_at = prior.thread_first_created_at or prior.created_at` — falls back to the base's own creation time if the base predates this feature or is itself a genuine first run.
+- `thread_run_count = (prior.thread_run_count or 1) + 1` — an unset/zero prior count is treated as "1 run so far" (the base run itself), so the new record's count is 2 on the first resume.
+- `thread_turn_count = (prior.thread_turn_count or 0) + (prior.turn_count or 0)`, and equivalently for `thread_tool_call_count` — the base's own accumulated rollup plus its per-run counters, both `None`-safe.
+
+### Child-guard does not apply to capture
+
+`_delete_stale_terminal_duplicates` skips deleting a terminal record that has child sessions (the child-guard exists to avoid orphaning children). `_capture_thread_rollup` is unconditional and ignores that guard entirely, because it only reads — a child-guarded terminal record still has its counters folded into the next resume. If capture respected the guard, a child-guarded parent's turn/tool history would be permanently invisible to the dashboard even though the record itself survives.
+
+### No-double-count invariant
+
+Each resume folds exactly one base: the single max-`created_at` terminal record. That base's own `thread_*` fields already carry all earlier runs forward, because it was seeded the same way when it was created. A child-guarded record that survives a delete pass always has a strictly older `created_at` than any later-completing run for the same `session_id`, so once a newer run exists and completes, that newer run becomes the max-`created_at` base and the older record is never selected again. Every historical run's counters are folded exactly once — at the resume immediately following its own completion — and never re-summed on subsequent resumes, even across a survives-delete → resumed → resumed chain.
+
+### Render-time fold, not a second write
+
+The dashboard (`ui/data/sdlc.py::PipelineProgress`, surfaced via `ui/app.py`) computes four `thread_display_*` fields at read time, never via an additional write on run completion:
+
+- `thread_display_turn_count = (thread_turn_count or 0) + (turn_count or 0)`
+- `thread_display_tool_call_count = (thread_tool_call_count or 0) + (tool_call_count or 0)`
+- `thread_display_started_at = thread_first_created_at or created_at`
+- `thread_display_run_count = thread_run_count or 1`
+
+Null `thread_*` fields — a never-resumed thread, or a pre-existing record from before this feature shipped — fall back to the per-run values, so old and first-run threads render identically to before this feature.
+
+### No Popoto migration
+
+The four fields are nullable/additive/non-indexed, so no schema migration is required — existing records simply read back with `None`/default values and get seeded correctly on their next resume.
+
+### Observability — `thread_rollup_capture_null`
+
+`_push_agent_session` records the `thread_rollup_capture_null` analytics counter (`analytics/collector.py::record_metric`) only when a prior record existed for `session_id` but capture returned `None` (a race or failure degrade) — never on a genuine first-run enqueue, which is distinguished by a separate existence check before capture runs. Operators can use this counter to see how often the rollup silently falls back to per-run-only display.
+
 ## Zombie Loop Prevention
 
 ### Health Check Orphan-Fixing
@@ -626,3 +678,4 @@ why it deliberately does not call `repair_indexes()` itself.
 - [Session Lifecycle Diagnostics](session-lifecycle-diagnostics.md) -- Structured LIFECYCLE logging at every state transition
 - [Agent Session Hierarchy](agent-session-scheduling.md#parent-child-session-hierarchy) -- Parent-child relationships and orphan handling
 - [Popoto Index Hygiene](popoto-index-hygiene.md) -- Full index-cleanup pipeline and model exclusion list
+- [AgentSession Model](agent-session-model.md) -- Full field reference, including the `thread_*` rollup fields documented above

--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -178,6 +178,16 @@ class AgentSession(Model):
     # === Session fields ===
     turn_count = IntField(default=0)
     tool_call_count = IntField(default=0)
+
+    # === Thread-level rollup (issue: dashboard-thread-timing-aggregation) ===
+    # Carries history forward across reply-resumes so the dashboard doesn't
+    # misreport a resumed thread as if it started at the most recent resume.
+    # Nullable/additive -- no backfill needed, Popoto's descriptor self-heal
+    # path covers new fields on existing records.
+    thread_first_created_at = DatetimeField(null=True)
+    thread_turn_count = IntField(default=0)
+    thread_tool_call_count = IntField(default=0)
+    thread_run_count = IntField(default=0)
     log_path = Field(null=True)
     branch_name = Field(null=True)
     tags = ListField(null=True)

--- a/tests/unit/test_agent_session_queue.py
+++ b/tests/unit/test_agent_session_queue.py
@@ -10,6 +10,7 @@ Also tests sustainability throttle guards in _pop_agent_session.
 """
 
 import asyncio
+import inspect
 import logging
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -1160,6 +1161,331 @@ class TestReconcileStaleTerminalDuplicatesFailureIsolation:
         # The reconciler blew up before deleting anything, but the new
         # pending record must still have been created.
         assert statuses == ["failed", "pending"]
+
+
+# ---------------------------------------------------------------------------
+# dashboard-thread-timing-aggregation (issue: build-enqueue task): thread-level
+# rollup capture (_capture_thread_rollup) and its enqueue-time wiring into
+# _push_agent_session.
+# ---------------------------------------------------------------------------
+
+
+def _make_terminal_session(session_id, **overrides):
+    """Create-and-save a terminal AgentSession for rollup-capture tests."""
+    defaults = {
+        "session_id": session_id,
+        "session_type": "teammate",
+        "project_key": "rollup-test",
+        "working_dir": "/tmp",
+        "status": "completed",
+        "chat_id": f"chat-{session_id}",
+        "message_text": "prior run",
+        "sender_name": "tester",
+        "created_at": datetime.now(tz=UTC),
+        "turn_count": 3,
+        "tool_call_count": 5,
+    }
+    defaults.update(overrides)
+    return AgentSession.create(**defaults)
+
+
+class TestCaptureThreadRollup:
+    """Unit coverage for asq._capture_thread_rollup's pure read/fold logic."""
+
+    def test_first_run_no_prior_record_returns_none(self, redis_test_db):
+        sid = f"rollup-first-{uuid.uuid4().hex[:10]}"
+        assert asq._capture_thread_rollup(sid) is None
+
+    def test_bootstrap_unset_thread_run_count_becomes_two(self, redis_test_db):
+        sid = f"rollup-bootstrap-runs-{uuid.uuid4().hex[:10]}"
+        _make_terminal_session(sid, thread_run_count=0)
+
+        rollup = asq._capture_thread_rollup(sid)
+
+        assert rollup is not None
+        assert rollup["thread_run_count"] == 2
+
+    def test_null_per_run_counters_treated_as_zero(self, redis_test_db):
+        sid = f"rollup-null-perrun-{uuid.uuid4().hex[:10]}"
+        _make_terminal_session(sid, turn_count=None, tool_call_count=None)
+
+        rollup = asq._capture_thread_rollup(sid)
+
+        assert rollup is not None
+        assert rollup["thread_turn_count"] == 0
+        assert rollup["thread_tool_call_count"] == 0
+
+    def test_null_preexisting_thread_fields_bootstrap(self, redis_test_db):
+        """A base created before this feature has unset thread_* fields;
+        capture must bootstrap from its own created_at / per-run counters."""
+        sid = f"rollup-bootstrap-all-{uuid.uuid4().hex[:10]}"
+        created = datetime.now(tz=UTC)
+        _make_terminal_session(
+            sid,
+            created_at=created,
+            turn_count=4,
+            tool_call_count=2,
+            thread_first_created_at=None,
+            thread_run_count=0,
+            thread_turn_count=0,
+            thread_tool_call_count=0,
+        )
+
+        rollup = asq._capture_thread_rollup(sid)
+
+        assert rollup is not None
+        # Popoto round-trips DatetimeField as naive UTC; compare by value.
+        assert rollup["thread_first_created_at"].replace(tzinfo=UTC) == created
+        assert rollup["thread_run_count"] == 2
+        assert rollup["thread_turn_count"] == 4
+        assert rollup["thread_tool_call_count"] == 2
+
+    def test_most_recent_base_selected_among_duplicates(self, redis_test_db):
+        sid = f"rollup-most-recent-{uuid.uuid4().hex[:10]}"
+        older = datetime.now(tz=UTC) - timedelta(hours=2)
+        newer = datetime.now(tz=UTC)
+        _make_terminal_session(sid, created_at=older, turn_count=1, tool_call_count=1)
+        _make_terminal_session(sid, created_at=newer, turn_count=9, tool_call_count=9)
+
+        rollup = asq._capture_thread_rollup(sid)
+
+        assert rollup is not None
+        # The newer record (turn_count=9) must be the folded base, not the
+        # older one (turn_count=1).
+        assert rollup["thread_turn_count"] == 9 + 0
+        assert rollup["thread_tool_call_count"] == 9 + 0
+
+    def test_child_guarded_base_is_still_folded(self, redis_test_db):
+        """_delete_stale_terminal_duplicates skips deleting a terminal record
+        with children, but _capture_thread_rollup has no such guard — the
+        child-guard protects deletes only, not reads."""
+        sid = f"rollup-child-guard-{uuid.uuid4().hex[:10]}"
+        base = _make_terminal_session(sid, turn_count=7, tool_call_count=2)
+        AgentSession.create(
+            session_id=f"{sid}-child",
+            session_type="teammate",
+            project_key="rollup-test",
+            working_dir="/tmp",
+            status="completed",
+            chat_id="chat-child",
+            message_text="child",
+            sender_name="tester",
+            created_at=datetime.now(tz=UTC),
+            parent_agent_session_id=base.id,
+        )
+
+        # Sanity: the child-guard would indeed skip deleting `base`.
+        assert base.get_child_sessions(), "expected base to have a child session"
+
+        rollup = asq._capture_thread_rollup(sid)
+
+        assert rollup is not None
+        assert rollup["thread_turn_count"] == 7
+        assert rollup["thread_tool_call_count"] == 2
+
+    def test_forward_accumulation_no_double_count(self, redis_test_db):
+        """Simulate run A (terminal, child-guarded so it survives delete) ->
+        resume B folds A's counters -> B becomes terminal -> resume C folds B
+        (not A again). A's per-run counters must appear exactly once in C's
+        thread_* totals."""
+        sid = f"rollup-forward-{uuid.uuid4().hex[:10]}"
+        t0 = datetime.now(tz=UTC) - timedelta(hours=3)
+
+        # Run A: terminal, has a child so it is never deleted.
+        run_a = _make_terminal_session(
+            sid, created_at=t0, turn_count=10, tool_call_count=4, status="completed"
+        )
+        AgentSession.create(
+            session_id=f"{sid}-child-of-a",
+            session_type="teammate",
+            project_key="rollup-test",
+            working_dir="/tmp",
+            status="completed",
+            chat_id="chat-child-a",
+            message_text="child of A",
+            sender_name="tester",
+            created_at=datetime.now(tz=UTC),
+            parent_agent_session_id=run_a.id,
+        )
+
+        # Resume folds A -> Run B is created with A's counters folded in, then
+        # itself becomes terminal (run B does 2 more turns / 1 more tool call).
+        rollup_for_b = asq._capture_thread_rollup(sid)
+        assert rollup_for_b["thread_turn_count"] == 10
+        assert rollup_for_b["thread_tool_call_count"] == 4
+        assert rollup_for_b["thread_run_count"] == 2
+
+        t1 = datetime.now(tz=UTC) - timedelta(hours=1)
+        run_b = AgentSession.create(
+            session_id=sid,
+            session_type="teammate",
+            project_key="rollup-test",
+            working_dir="/tmp",
+            status="completed",
+            chat_id="chat-b",
+            message_text="run B",
+            sender_name="tester",
+            created_at=t1,
+            turn_count=2,
+            tool_call_count=1,
+            thread_first_created_at=rollup_for_b["thread_first_created_at"],
+            thread_turn_count=rollup_for_b["thread_turn_count"],
+            thread_tool_call_count=rollup_for_b["thread_tool_call_count"],
+            thread_run_count=rollup_for_b["thread_run_count"],
+        )
+        assert run_b.created_at > run_a.created_at
+
+        # Resume folds B (the now-max-created_at base) -> must select B, not A.
+        rollup_for_c = asq._capture_thread_rollup(sid)
+
+        # A's 10 turns / 4 tool calls must appear exactly once (via B's
+        # already-folded thread_* fields), plus B's own 2 turns / 1 tool call.
+        assert rollup_for_c["thread_turn_count"] == 10 + 2
+        assert rollup_for_c["thread_tool_call_count"] == 4 + 1
+        assert rollup_for_c["thread_run_count"] == 3
+
+
+class TestPushAgentSessionThreadRollupWiring:
+    """Integration coverage for _capture_thread_rollup's wiring into
+    _push_agent_session: null-degrade metric and capture-failure isolation."""
+
+    @pytest.mark.asyncio
+    async def test_first_run_enqueue_no_degrade_metric(self, redis_test_db):
+        sid = f"rollup-wire-first-{uuid.uuid4().hex[:10]}"
+
+        with patch("analytics.collector.record_metric") as mock_metric:
+            await _push_agent_session(
+                project_key="rollup-test",
+                session_id=sid,
+                working_dir="/tmp",
+                message_text="fresh enqueue",
+                sender_name="tester",
+                chat_id="chat-fresh",
+                telegram_message_id=1,
+                session_type="teammate",
+            )
+
+        mock_metric.assert_not_called()
+        record = AgentSession.query.filter(session_id=sid)[0]
+        assert record.thread_run_count == 0
+        assert record.thread_turn_count == 0
+        assert record.thread_tool_call_count == 0
+        assert record.thread_first_created_at is None
+
+    @pytest.mark.asyncio
+    async def test_resume_seeds_new_record_with_prior_rollup(self, redis_test_db):
+        sid = f"rollup-wire-resume-{uuid.uuid4().hex[:10]}"
+        _make_terminal_session(sid, turn_count=6, tool_call_count=3)
+
+        await _push_agent_session(
+            project_key="rollup-test",
+            session_id=sid,
+            working_dir="/tmp",
+            message_text="resume",
+            sender_name="tester",
+            chat_id="chat-resume",
+            telegram_message_id=1,
+            session_type="teammate",
+        )
+
+        pending = [s for s in AgentSession.query.filter(session_id=sid) if s.status == "pending"]
+        assert len(pending) == 1
+        assert pending[0].thread_turn_count == 6
+        assert pending[0].thread_tool_call_count == 3
+        assert pending[0].thread_run_count == 2
+
+    @pytest.mark.asyncio
+    async def test_capture_failure_degrades_null_but_still_creates_record_and_counts(
+        self, redis_test_db, caplog
+    ):
+        sid = f"rollup-wire-fail-{uuid.uuid4().hex[:10]}"
+        _make_terminal_session(sid, turn_count=1, tool_call_count=1)
+
+        caplog.set_level(logging.WARNING, logger="agent.agent_session_queue")
+        with (
+            patch(
+                "agent.agent_session_queue._capture_thread_rollup",
+                side_effect=RuntimeError("simulated capture failure"),
+            ),
+            patch("analytics.collector.record_metric") as mock_metric,
+        ):
+            await _push_agent_session(
+                project_key="rollup-test",
+                session_id=sid,
+                working_dir="/tmp",
+                message_text="resume during capture failure",
+                sender_name="tester",
+                chat_id="chat-fail",
+                telegram_message_id=1,
+                session_type="teammate",
+            )
+
+        warning_logs = [
+            r.getMessage()
+            for r in caplog.records
+            if "Failed to capture thread rollup" in r.getMessage()
+        ]
+        assert warning_logs, "expected a WARNING when capture raises"
+
+        pending = [s for s in AgentSession.query.filter(session_id=sid) if s.status == "pending"]
+        assert len(pending) == 1, "new pending record must still be created"
+        assert pending[0].thread_run_count == 0
+        assert pending[0].thread_turn_count == 0
+
+        mock_metric.assert_called_once()
+        assert mock_metric.call_args.args[0] == "thread_rollup_capture_null"
+
+    @pytest.mark.asyncio
+    async def test_null_degrade_counter_increments_when_prior_existed_but_capture_none(
+        self, redis_test_db
+    ):
+        sid = f"rollup-wire-degrade-{uuid.uuid4().hex[:10]}"
+        # A prior record exists but is NOT terminal (e.g. still pending from
+        # a race) -> _capture_thread_rollup returns None even though a prior
+        # record genuinely existed for this session_id.
+        AgentSession.create(
+            session_id=sid,
+            session_type="teammate",
+            project_key="rollup-test",
+            working_dir="/tmp",
+            status="pending",
+            chat_id="chat-degrade",
+            message_text="stuck pending",
+            sender_name="tester",
+            created_at=datetime.now(tz=UTC),
+        )
+
+        with patch("analytics.collector.record_metric") as mock_metric:
+            await _push_agent_session(
+                project_key="rollup-test",
+                session_id=sid,
+                working_dir="/tmp",
+                message_text="resume while prior is stuck pending",
+                sender_name="tester",
+                chat_id="chat-degrade",
+                telegram_message_id=1,
+                session_type="teammate",
+            )
+
+        mock_metric.assert_called_once()
+        assert mock_metric.call_args.args[0] == "thread_rollup_capture_null"
+
+
+class TestDeleteStaleTerminalDuplicatesUntouched:
+    """Regression guard (dashboard-thread-timing-aggregation): the shared
+    _delete_stale_terminal_duplicates helper and its pop-loop escalation
+    caller must be untouched by the thread-rollup capture feature."""
+
+    def test_signature_unchanged(self):
+        sig = inspect.signature(asq._delete_stale_terminal_duplicates)
+        assert list(sig.parameters) == ["session_id"]
+        assert sig.parameters["session_id"].annotation is str
+        assert sig.return_annotation is int
+
+    def test_pop_loop_caller_still_uses_only_int_return(self):
+        source = inspect.getsource(asq)
+        assert "_deleted = await offload_redis(" in source
+        assert "_delete_stale_terminal_duplicates, _conflict_sid" in source
 
 
 class TestPopLoopConflictCounterDegenerateSessionId:

--- a/tests/unit/test_agent_session_thread_rollup_fields.py
+++ b/tests/unit/test_agent_session_thread_rollup_fields.py
@@ -1,0 +1,80 @@
+"""Field guards for the thread-level rollup fields (dashboard-thread-timing-aggregation).
+
+Each reply-resume of a Telegram thread creates a fresh AgentSession record
+with created_at=now and turn_count=0/tool_call_count=0, and the prior
+terminal record is deleted before the new one is created. That made the
+dashboard misreport a resumed thread's history as if the whole conversation
+were only the most recent resume.
+
+These four fields carry thread-level history forward across resumes:
+
+- ``thread_first_created_at`` (DatetimeField, null=True) — timestamp of the
+  very first session in the thread's resume chain.
+- ``thread_turn_count`` (IntField, default=0) — cumulative turn count across
+  all resumes in the thread.
+- ``thread_tool_call_count`` (IntField, default=0) — cumulative tool call
+  count across all resumes in the thread.
+- ``thread_run_count`` (IntField, default=0) — number of resumes/runs in the
+  thread's chain.
+
+All four are nullable/additive — no backfill needed, Popoto's descriptor
+self-heal path covers new fields on existing records. This module only
+covers the model fields; capture/aggregation wiring lands in follow-up tasks.
+"""
+
+from __future__ import annotations
+
+from models.agent_session import AgentSession, SessionType
+
+
+def _make_session(suffix: str) -> AgentSession:
+    return AgentSession(
+        project_key=f"test-thread-rollup-fields-{suffix}",
+        chat_id="x",
+        session_type=SessionType.ENG,
+        message_text="x",
+        sender_name="x",
+        agent_session_id=f"thread-rollup-fields-{suffix}",
+    )
+
+
+def test_thread_rollup_fields_default_without_crashing():
+    """A fresh session must construct fine with thread_first_created_at left None."""
+    s = _make_session("defaults")
+    try:
+        assert s.thread_first_created_at is None
+        assert s.thread_turn_count == 0
+        assert s.thread_tool_call_count == 0
+        assert s.thread_run_count == 0
+    finally:
+        try:
+            s.delete()
+        except Exception:
+            pass
+
+
+def test_thread_rollup_fields_persist_after_save_and_reload():
+    """Writing then reloading must roundtrip without losing the new fields."""
+    from datetime import UTC, datetime
+
+    s = _make_session("roundtrip")
+    sid = s.agent_session_id
+    try:
+        first_created = datetime.now(tz=UTC)
+        s.thread_first_created_at = first_created
+        s.thread_turn_count = 7
+        s.thread_tool_call_count = 12
+        s.thread_run_count = 3
+        s.save()
+
+        loaded = AgentSession.get_by_id(sid)
+        assert loaded is not None
+        assert loaded.thread_first_created_at is not None
+        assert loaded.thread_turn_count == 7
+        assert loaded.thread_tool_call_count == 12
+        assert loaded.thread_run_count == 3
+    finally:
+        try:
+            s.delete()
+        except Exception:
+            pass

--- a/tests/unit/test_ui_app.py
+++ b/tests/unit/test_ui_app.py
@@ -259,6 +259,103 @@ class TestDashboardSessionSerialization:
         assert session["claude_version"] is None
 
 
+class TestDashboardSessionThreadRollup:
+    """dashboard.json session objects carry both per-run and per-thread
+    timing/turn/tool stats (issue: dashboard-thread-timing-aggregation), so
+    a resumed Telegram thread shows its full history instead of just the
+    latest resume's numbers."""
+
+    def test_thread_raw_keys_present_in_payload(self, client):
+        from unittest.mock import patch
+
+        from ui.data.sdlc import PipelineProgress
+
+        progress = PipelineProgress(
+            agent_session_id="thread-rollup-1",
+            thread_first_created_at=1000.0,
+            thread_turn_count=5,
+            thread_tool_call_count=3,
+            thread_run_count=2,
+        )
+        with patch("ui.data.sdlc.get_all_sessions", return_value=[progress]):
+            response = client.get("/dashboard.json")
+
+        assert response.status_code == 200
+        (session,) = [
+            s for s in response.json()["sessions"] if s["agent_session_id"] == "thread-rollup-1"
+        ]
+        assert session["thread_first_created_at"] == 1000.0
+        assert session["thread_turn_count"] == 5
+        assert session["thread_tool_call_count"] == 3
+        assert session["thread_run_count"] == 2
+
+    def test_display_values_fall_back_to_per_run_when_never_resumed(self, client):
+        """Never-resumed thread: _session_to_pipeline computes the folded
+        display values equal to the per-run values (see
+        TestThreadRollupFold in test_ui_sdlc_data.py); this asserts the JSON
+        layer passes them through as always-present (never None/missing)
+        keys -- no crash, no blank dashboard tile."""
+        from unittest.mock import patch
+
+        from ui.data.sdlc import PipelineProgress
+
+        progress = PipelineProgress(
+            agent_session_id="thread-rollup-2",
+            created_at=500.0,
+            turn_count=3,
+            tool_call_count=2,
+            thread_display_turn_count=3,
+            thread_display_tool_call_count=2,
+            thread_display_started_at=500.0,
+            thread_display_run_count=1,
+        )
+        with patch("ui.data.sdlc.get_all_sessions", return_value=[progress]):
+            response = client.get("/dashboard.json")
+
+        assert response.status_code == 200
+        (session,) = [
+            s for s in response.json()["sessions"] if s["agent_session_id"] == "thread-rollup-2"
+        ]
+        assert session["thread_display_turn_count"] == session["turn_count"] == 3
+        assert session["thread_display_tool_call_count"] == session["tool_call_count"] == 2
+        assert session["thread_display_started_at"] == session["created_at"] == 500.0
+        assert session["thread_display_run_count"] == 1
+
+    def test_display_values_sum_rollup_and_current_run(self, client):
+        """Resumed thread: JSON layer surfaces the folded totals computed
+        by _session_to_pipeline (prior-run rollup + this run's in-flight
+        counters)."""
+        from unittest.mock import patch
+
+        from ui.data.sdlc import PipelineProgress
+
+        progress = PipelineProgress(
+            agent_session_id="thread-rollup-3",
+            created_at=1800.0,
+            turn_count=3,
+            tool_call_count=2,
+            thread_first_created_at=0.0,
+            thread_turn_count=5,
+            thread_tool_call_count=3,
+            thread_run_count=2,
+            thread_display_turn_count=8,
+            thread_display_tool_call_count=5,
+            thread_display_started_at=0.0,
+            thread_display_run_count=2,
+        )
+        with patch("ui.data.sdlc.get_all_sessions", return_value=[progress]):
+            response = client.get("/dashboard.json")
+
+        assert response.status_code == 200
+        (session,) = [
+            s for s in response.json()["sessions"] if s["agent_session_id"] == "thread-rollup-3"
+        ]
+        assert session["thread_display_turn_count"] == 8
+        assert session["thread_display_tool_call_count"] == 5
+        assert session["thread_display_started_at"] == 0.0
+        assert session["thread_display_run_count"] == 2
+
+
 class TestArchiveHealth:
     """The dashboard's ``archive`` health block surfaces
     ``agent.session_archive.get_archive_status()`` -- issue #1825,

--- a/tests/unit/test_ui_sdlc_data.py
+++ b/tests/unit/test_ui_sdlc_data.py
@@ -42,6 +42,10 @@ def _make_mock_session(**overrides):
         "unhealthy_reason": None,
         "priority": "normal",
         "extra_context": None,
+        "thread_first_created_at": None,
+        "thread_turn_count": None,
+        "thread_tool_call_count": None,
+        "thread_run_count": None,
     }
     defaults.update(overrides)
     mock = MagicMock()
@@ -653,6 +657,96 @@ class TestSessionToPipeline:
         assert pipeline.dev_agent_id is None
         assert pipeline.runner_cwd is None
         assert pipeline.claude_version is None
+
+
+class TestThreadRollupFold:
+    """Tests for the per-thread rollup + fold logic
+    (issue: dashboard-thread-timing-aggregation). The thread_* raw fields
+    are carried forward from prior completed runs by a separate write-path
+    task; this covers the read/render side: raw passthrough plus the
+    fold that computes per-thread display totals with a per-run fallback."""
+
+    def test_raw_thread_fields_pass_through(self):
+        """The four raw thread_* ORM fields flow through unchanged."""
+        from ui.data.sdlc import _session_to_pipeline
+
+        earlier = time.time() - 1800
+        mock_session = _make_mock_session(
+            thread_first_created_at=earlier,
+            thread_turn_count=5,
+            thread_tool_call_count=3,
+            thread_run_count=2,
+        )
+        pipeline = _session_to_pipeline(mock_session)
+        assert pipeline.thread_first_created_at == earlier
+        assert pipeline.thread_turn_count == 5
+        assert pipeline.thread_tool_call_count == 3
+        assert pipeline.thread_run_count == 2
+
+    def test_fold_falls_back_to_per_run_values_when_never_resumed(self):
+        """A never-resumed / pre-migration thread (all thread_* fields null)
+        must render identically to before this feature: the folded display
+        values equal the per-run values exactly."""
+        from ui.data.sdlc import _session_to_pipeline
+
+        created = time.time() - 60
+        mock_session = _make_mock_session(
+            created_at=created,
+            turn_count=3,
+            tool_call_count=2,
+            thread_first_created_at=None,
+            thread_turn_count=None,
+            thread_tool_call_count=None,
+            thread_run_count=None,
+        )
+        pipeline = _session_to_pipeline(mock_session)
+        assert pipeline.thread_display_turn_count == pipeline.turn_count == 3
+        assert pipeline.thread_display_tool_call_count == pipeline.tool_call_count == 2
+        assert pipeline.thread_display_started_at == pipeline.created_at
+        assert pipeline.thread_display_run_count == 1
+
+    def test_fold_sums_rollup_and_current_run_when_resumed(self):
+        """A resumed thread folds prior-run rollup with this run's in-flight
+        counters, and the thread start time is the earliest run's creation."""
+        from ui.data.sdlc import _session_to_pipeline
+
+        thread_start = time.time() - 1800  # thread actually started 30 min ago
+        this_run_created = time.time() - 180  # this resume started 3 min ago
+        mock_session = _make_mock_session(
+            created_at=this_run_created,
+            turn_count=3,
+            tool_call_count=2,
+            thread_first_created_at=thread_start,
+            thread_turn_count=5,
+            thread_tool_call_count=3,
+            thread_run_count=2,
+        )
+        pipeline = _session_to_pipeline(mock_session)
+        assert pipeline.thread_display_turn_count == 8
+        assert pipeline.thread_display_tool_call_count == 5
+        assert pipeline.thread_display_started_at == thread_start
+        assert pipeline.thread_display_run_count == 2
+
+    def test_missing_thread_fields_handled_gracefully(self):
+        """Records predating this migration (no thread_* attrs at all) must
+        not raise -- graceful degradation, not an exception path."""
+        from ui.data.sdlc import _session_to_pipeline
+
+        mock_session = _make_mock_session(turn_count=4, tool_call_count=1)
+        del mock_session.thread_first_created_at
+        del mock_session.thread_turn_count
+        del mock_session.thread_tool_call_count
+        del mock_session.thread_run_count
+
+        pipeline = _session_to_pipeline(mock_session)
+        assert pipeline.thread_first_created_at is None
+        assert pipeline.thread_turn_count is None
+        assert pipeline.thread_tool_call_count is None
+        assert pipeline.thread_run_count is None
+        assert pipeline.thread_display_turn_count == 4
+        assert pipeline.thread_display_tool_call_count == 1
+        assert pipeline.thread_display_started_at == pipeline.created_at
+        assert pipeline.thread_display_run_count == 1
 
 
 class TestParentChildGrouping:

--- a/ui/app.py
+++ b/ui/app.py
@@ -706,6 +706,19 @@ def create_app() -> FastAPI:
             "expectations": s.expectations,
             "turn_count": s.turn_count,
             "tool_call_count": s.tool_call_count,
+            # === Thread-level rollup (issue: dashboard-thread-timing-aggregation) ===
+            # Raw carried-forward fields (None on never-resumed / pre-migration
+            # records) plus folded display values that always resolve — falling
+            # back to the per-run values when no rollup exists yet, so a
+            # never-resumed thread renders identically to before this feature.
+            "thread_first_created_at": s.thread_first_created_at,
+            "thread_turn_count": s.thread_turn_count,
+            "thread_tool_call_count": s.thread_tool_call_count,
+            "thread_run_count": s.thread_run_count,
+            "thread_display_turn_count": s.thread_display_turn_count,
+            "thread_display_tool_call_count": s.thread_display_tool_call_count,
+            "thread_display_started_at": s.thread_display_started_at,
+            "thread_display_run_count": s.thread_display_run_count,
             "unhealthy_reason": s.unhealthy_reason,
             "priority": s.priority,
             "classification_type": s.classification_type,

--- a/ui/data/sdlc.py
+++ b/ui/data/sdlc.py
@@ -253,6 +253,11 @@ class PipelineProgress(BaseModel):
         expectations: What the agent needs from the human (for dormant sessions).
         turn_count: Number of conversation turns.
         tool_call_count: Number of tool calls made.
+        thread_first_created_at: Timestamp the thread's first (earliest) run was created, carried
+            forward across resumes. None on never-resumed / pre-migration records.
+        thread_turn_count: Cumulative turn count from prior completed runs in this thread.
+        thread_tool_call_count: Cumulative tool call count from prior completed runs in this thread.
+        thread_run_count: Number of runs (resumes) this thread has had, including the current one.
         unhealthy_reason: Reason string when flagged unhealthy, None when healthy.
         priority: Session priority (urgent, high, normal, low).
         classification_type: Session classification (sdlc, qa, etc.).
@@ -284,6 +289,25 @@ class PipelineProgress(BaseModel):
     expectations: str | None = None
     turn_count: int | None = None
     tool_call_count: int | None = None
+
+    # === Thread-level rollup (issue: dashboard-thread-timing-aggregation) ===
+    # Raw fields carried forward from prior completed runs in the same thread.
+    thread_first_created_at: float | None = None
+    thread_turn_count: int | None = None
+    thread_tool_call_count: int | None = None
+    thread_run_count: int | None = None
+
+    # Folded display values: per-thread totals (prior runs' rollup + this
+    # run's in-flight counters), computed once in
+    # _pipeline_progress_from_session so JSON consumers never have to
+    # re-derive the fold. Always populated (never None) — on a
+    # never-resumed / pre-migration record these equal the per-run values
+    # exactly, so the dashboard renders identically to before this feature.
+    thread_display_turn_count: int = 0
+    thread_display_tool_call_count: int = 0
+    thread_display_started_at: float | None = None
+    thread_display_run_count: int = 1
+
     unhealthy_reason: str | None = None
     priority: str | None = None
     classification_type: str | None = None
@@ -947,6 +971,40 @@ def _session_to_pipeline(session) -> PipelineProgress:
         except (ValueError, TypeError):
             tool_call_count = None
 
+    # === Thread-level rollup (issue: dashboard-thread-timing-aggregation) ===
+    # Raw ORM fields may be None/unset on pre-migration records or the very
+    # first run of a thread — coerce safely, no crash.
+    thread_first_created_at = _safe_float(getattr(session, "thread_first_created_at", None))
+
+    thread_turn_count = getattr(session, "thread_turn_count", None)
+    if thread_turn_count is not None:
+        try:
+            thread_turn_count = int(thread_turn_count)
+        except (ValueError, TypeError):
+            thread_turn_count = None
+
+    thread_tool_call_count = getattr(session, "thread_tool_call_count", None)
+    if thread_tool_call_count is not None:
+        try:
+            thread_tool_call_count = int(thread_tool_call_count)
+        except (ValueError, TypeError):
+            thread_tool_call_count = None
+
+    thread_run_count = getattr(session, "thread_run_count", None)
+    if thread_run_count is not None:
+        try:
+            thread_run_count = int(thread_run_count)
+        except (ValueError, TypeError):
+            thread_run_count = None
+
+    # Fold per-thread rollup + this run's in-flight counters into display
+    # values. When all thread_* fields are null (never-resumed thread /
+    # pre-migration record), these equal the per-run values exactly.
+    thread_display_turn_count = (thread_turn_count or 0) + (turn_count or 0)
+    thread_display_tool_call_count = (thread_tool_call_count or 0) + (tool_call_count or 0)
+    thread_display_started_at = thread_first_created_at or _safe_float(session.created_at)
+    thread_display_run_count = thread_run_count or 1
+
     # Per-session token + cost fields (issue #1128). Always coerced to
     # numeric (0 / 0.0) so `/dashboard.json` never returns None here.
     def _to_int(val, default: int = 0) -> int:
@@ -1074,6 +1132,14 @@ def _session_to_pipeline(session) -> PipelineProgress:
         expectations=_safe_str(getattr(session, "expectations", None)),
         turn_count=turn_count,
         tool_call_count=tool_call_count,
+        thread_first_created_at=thread_first_created_at,
+        thread_turn_count=thread_turn_count,
+        thread_tool_call_count=thread_tool_call_count,
+        thread_run_count=thread_run_count,
+        thread_display_turn_count=thread_display_turn_count,
+        thread_display_tool_call_count=thread_display_tool_call_count,
+        thread_display_started_at=thread_display_started_at,
+        thread_display_run_count=thread_display_run_count,
         unhealthy_reason=_safe_str(getattr(session, "unhealthy_reason", None)),
         priority=_safe_str(getattr(session, "priority", None)),
         classification_type=classification_type,

--- a/ui/data/sdlc.py
+++ b/ui/data/sdlc.py
@@ -299,7 +299,7 @@ class PipelineProgress(BaseModel):
 
     # Folded display values: per-thread totals (prior runs' rollup + this
     # run's in-flight counters), computed once in
-    # _pipeline_progress_from_session so JSON consumers never have to
+    # _session_to_pipeline so JSON consumers never have to
     # re-derive the fold. Always populated (never None) — on a
     # never-resumed / pre-migration record these equal the per-run values
     # exactly, so the dashboard renders identically to before this feature.


### PR DESCRIPTION
## Summary
- Adds four nullable/additive AgentSession fields (`thread_first_created_at`, `thread_turn_count`, `thread_tool_call_count`, `thread_run_count`) that carry a Telegram thread's history forward across reply-resumes.
- Adds `_capture_thread_rollup()` in `agent/agent_session_queue.py`: a pure pre-read that snapshots the most-recent terminal record's rollup into a detached dict *before* `_delete_stale_terminal_duplicates` runs, so the delete can never race away the data it needs. Capture failures degrade to null rollup and never block new-record creation; a `thread_rollup_capture_null` analytics counter tracks genuine prior-existed-but-gone degrades (not first-run enqueues).
- Adds render-time per-thread fold (`thread_display_*`) to `PipelineProgress` (`ui/data/sdlc.py`) and `_session_to_json` (`ui/app.py`) — per-thread turns/tools/start/run-count fold in the current in-flight run, with graceful fallback to per-run values when thread fields are null (never-resumed thread renders identically to before).
- No Popoto migration — fields are nullable/default=0/non-indexed and self-heal via the existing descriptor self-heal path (#1099/#1172).

Closes #2212

## Test plan
- [x] `pytest tests/unit/test_agent_session_thread_rollup_fields.py -x -q` — model field tests
- [x] `pytest tests/unit/test_agent_session_queue.py -x -q` — 72 passed (capture helper: bootstrap, null counters, most-recent-base selection, child-guarded-base still folded, forward-accumulation no-double-count, first-run, capture-failure degrade, null-degrade counter, `_delete_stale_terminal_duplicates` signature/caller regression guard)
- [x] `pytest tests/unit/test_ui_app.py tests/unit/test_ui_sdlc_data.py -x -q` — dashboard JSON payload + fold logic
- [x] Full plan Verification table (lint, format, field/grep checks) — all pass
- [x] `python -m ruff check .` / `python -m ruff format --check .` — clean (one unrelated pre-existing lint issue on main, not touched by this PR)