### PR TITLE
Sentry triage dedup: exact-match listing, fail closed (#2300)

### DIFF
--- a/docs/features/sentry-triage.md
+++ b/docs/features/sentry-triage.md
@@ -62,6 +62,27 @@ Each tier-A/B/E update is an independent `PUT /api/0/issues/{id}/`. A single fai
 sentry-issue-triage: 244 issues across 3 project(s) (A=58 B=87 C=12 D=78 E=9), auto-actioned: A=58/58 B=86/87 E=9/9 (1 failed)
 ```
 
+## Duplicate-issue dedup (tier C)
+
+Before filing a tier-C GitHub issue, `_issue_already_filed(title, cwd)` checks
+whether an open issue with that exact title already exists. It lists open
+issues via `gh issue list --state open --limit 200 --json title` — a
+strongly-consistent read, not `gh issue list --search`, whose search index can
+lag fresh issues by minutes and would let back-to-back triage runs both see
+"no existing issue" and file duplicates. Titles are compared for full exact
+equality (whitespace-normalized only, no substring matching).
+
+The check **fails closed**: any subprocess error, non-zero `gh` exit, timeout,
+or JSON-parse failure returns `True` ("assume filed," skip creating the
+issue) and logs a warning. A skipped filing self-heals on the next daily
+run; a duplicate does not, so the failure mode defaults to under-filing
+rather than over-filing.
+
+The `--limit 200` listing assumes the repo's open-issue count stays well
+under 200 — `gh` silently truncates beyond that, so a genuinely-filed issue
+past position 200 would be missed and refiled. Raise the limit if the open
+backlog approaches it.
+
 ## Telegram digest
 
 In live mode, the digest gets an explicit `[LIVE — Sentry state changes applied]` footer. In dry-run mode, it gets `[dry run — no Sentry state changes]` (mirroring the existing `[dry run — no GitHub issues filed]` line for tier C). The auto-actioned block sits between the per-tier counts and the C-tier highlight rows, separating "what we already handled" from "what still needs you".

--- a/docs/infra/cowork-sentry-triage.md
+++ b/docs/infra/cowork-sentry-triage.md
@@ -74,7 +74,9 @@ The repo is cloned into each run's sandbox via a `github_repository` session
 resource (`authorization_token` = the operator's `gh` token; `SDLC_AGENT_GH_TOKEN`
 was empty in the vault on this machine). Class-C filing uses `gh issue create`
 with the vault-injected `GH_TOKEN` env credential (egress-scoped to
-`api.github.com`/`github.com`); dedup via `_issue_already_filed`'s title search.
+`api.github.com`/`github.com`); dedup via `_issue_already_filed`'s
+strongly-consistent `gh issue list --state open` exact-title match (fails
+closed — see [`docs/features/sentry-triage.md`](../features/sentry-triage.md#duplicate-issue-dedup-tier-c)).
 
 ## Sentry Auth
 
@@ -145,9 +147,11 @@ path, which is untouched and continues to use them normally.
 
 **Be precise about what actually gates duplicate filing in the cloud:**
 `_issue_already_filed(title, cwd)` — a **separate** code path from the
-seen-ID set above — does a GitHub title-search before every `gh issue
-create` call. It is this function, not the seen-set, that prevents the
-routine from re-filing the same Class-C issue on a subsequent daily run.
+seen-ID set above — lists open issues via strongly-consistent
+`gh issue list --state open --json title` and does an exact-title match
+before every `gh issue create` call (fails closed on any `gh` error). It is
+this function, not the seen-set, that prevents the routine from re-filing
+the same Class-C issue on a subsequent daily run.
 The practical consequence is simple even though the mechanism is not what
 it looks like at a glance: "no new actionable Sentry issue → no new GitHub
 issue → no notification." Do not describe `_issue_already_filed` as

--- a/reflections/sentry_triage.py
+++ b/reflections/sentry_triage.py
@@ -297,20 +297,48 @@ def _classify_issue(issue: dict) -> tuple[str, str]:
 
 
 def _issue_already_filed(title: str, cwd: str) -> bool:
-    """Check if an open GitHub issue with this title already exists."""
-    search_term = title[:50]
+    """Check if an open GitHub issue with this exact title already exists.
+
+    Uses the strongly-consistent listing (``gh issue list --json title``) rather
+    than ``--search``: GitHub's search index lags fresh issues by minutes, so
+    back-to-back triage runs would both see "no existing issue" and file
+    duplicates. Titles are compared for FULL exact equality (whitespace
+    normalized only) — no substring matching.
+
+    Fails CLOSED: on any subprocess error, non-zero exit, timeout, or JSON
+    parse failure, returns True ("assume filed") and logs a warning. Rationale:
+    a skipped filing self-heals on the next daily run; a duplicate does not.
+    """
+
+    def _normalize(s: str) -> str:
+        return " ".join(s.split())
+
+    target = _normalize(title)
     try:
+        # --limit 200 assumes the open-issue count stays well under 200; gh
+        # silently truncates beyond the limit, so a genuinely-filed issue past
+        # position 200 would be missed and refiled. Raise this ceiling if the
+        # repo's open-issue backlog ever approaches it.
         result = subprocess.run(
-            ["gh", "issue", "list", "--state", "open", "--search", search_term],
+            ["gh", "issue", "list", "--state", "open", "--limit", "200", "--json", "title"],
             capture_output=True,
             text=True,
             timeout=settings.timeouts.git_subprocess_s,
             check=False,
             cwd=cwd,
         )
-        return result.returncode == 0 and bool(result.stdout.strip())
-    except Exception:
-        return False
+        if result.returncode != 0:
+            logger.warning(
+                "sentry_triage: dedup check failed (gh exit %s): %s — assuming filed",
+                result.returncode,
+                result.stderr.strip(),
+            )
+            return True
+        existing = json.loads(result.stdout)
+        return any(_normalize(item.get("title", "")) == target for item in existing)
+    except Exception as exc:
+        logger.warning("sentry_triage: dedup check errored (%s) — assuming filed", exc)
+        return True
 
 
 def _file_github_issue(

--- a/tests/unit/test_sentry_triage_apply.py
+++ b/tests/unit/test_sentry_triage_apply.py
@@ -12,6 +12,8 @@ Covers:
 
 from __future__ import annotations
 
+import json
+import subprocess
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
@@ -547,3 +549,82 @@ def test_local_run_without_cowork_routine_still_skips(monkeypatch: pytest.Monkey
     mock_file.assert_not_called()
     findings_text = "\n".join(result["findings"])
     assert "[SKIP] no working directory for project test-proj" in findings_text
+
+
+# ---------------------------------------------------------------------------
+# _issue_already_filed: strongly-consistent, exact-match, fail-closed dedup
+# (issue #2300). The old --search path lagged the GitHub index and failed OPEN,
+# so back-to-back runs filed duplicates.
+# ---------------------------------------------------------------------------
+
+
+def _mock_gh_list(titles: list[str], returncode: int = 0) -> MagicMock:
+    """Fake `gh issue list --json title` completed-process result."""
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = json.dumps([{"title": t} for t in titles])
+    result.stderr = ""
+    return result
+
+
+def test_issue_already_filed_exact_match_hit() -> None:
+    """An exact-title match in the open-issue listing returns True."""
+    title = "[Sentry] NullPointer in checkout flow"
+    with patch.object(sentry_triage.subprocess, "run") as mock_run:
+        mock_run.return_value = _mock_gh_list(
+            ["[Sentry] some other error", title, "[Sentry] yet another"]
+        )
+        assert sentry_triage._issue_already_filed(title, "/repo") is True
+
+
+def test_issue_already_filed_near_miss_is_not_substring() -> None:
+    """A different-but-overlapping title does NOT count as filed (exact match)."""
+    title = "[Sentry] NullPointer in checkout"
+    with patch.object(sentry_triage.subprocess, "run") as mock_run:
+        # Listing contains a longer title that SHARES the candidate as a prefix.
+        mock_run.return_value = _mock_gh_list(["[Sentry] NullPointer in checkout flow after retry"])
+        assert sentry_triage._issue_already_filed(title, "/repo") is False
+
+
+def test_issue_already_filed_normalizes_whitespace() -> None:
+    """Whitespace runs are collapsed before comparison (still exact otherwise)."""
+    with patch.object(sentry_triage.subprocess, "run") as mock_run:
+        mock_run.return_value = _mock_gh_list(["[Sentry] boom   crash"])
+        assert sentry_triage._issue_already_filed("[Sentry]  boom crash ", "/repo") is True
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        {"returncode": 1},  # non-zero exit
+        {"exc": subprocess.TimeoutExpired(cmd="gh", timeout=5)},  # timeout
+        {"exc": OSError("gh not found")},  # subprocess/exec error
+        {"bad_json": True},  # JSON parse failure
+    ],
+)
+def test_issue_already_filed_fails_closed(failure: dict) -> None:
+    """gh failure/timeout/exception/bad-JSON returns True (assume filed)."""
+    with patch.object(sentry_triage.subprocess, "run") as mock_run:
+        if "exc" in failure:
+            mock_run.side_effect = failure["exc"]
+        elif failure.get("bad_json"):
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "not valid json {"
+            result.stderr = ""
+            mock_run.return_value = result
+        else:
+            result = _mock_gh_list([], returncode=failure["returncode"])
+            mock_run.return_value = result
+        assert sentry_triage._issue_already_filed("[Sentry] anything", "/repo") is True
+
+
+def test_issue_already_filed_does_not_use_search() -> None:
+    """Regression guard: the gh command must NOT use the lagging --search index."""
+    with patch.object(sentry_triage.subprocess, "run") as mock_run:
+        mock_run.return_value = _mock_gh_list([])
+        sentry_triage._issue_already_filed("[Sentry] whatever", "/repo")
+    cmd = mock_run.call_args.args[0]
+    assert "--search" not in cmd
+    assert "--json" in cmd
+    assert "title" in cmd


### PR DESCRIPTION
Fixes #2300.

## Problem
`_issue_already_filed` decided "already filed" by running `gh issue list --state open --search <title[:50]>` and treating any non-empty stdout as a hit. Two defects:

1. **Search-index lag → duplicate filings.** `--search` reads GitHub's search index, which lags fresh issues by minutes. Back-to-back triage runs both saw "no existing issue" and both filed. Observed live during the #2067 pilot (2026-07-23): three runs within ~20 min each refiled ~19 exact-title duplicates. The 07-23 (#2219–#2256) and 07-24 (#2306–#2326) batches are the same errors refiled a day apart — the smoking gun.
2. **Fail-open on error.** `except Exception: return False` reported "not filed" on gh/auth/timeout failure, so the caller filed a duplicate on exactly the runs where the check broke. Substring/truncated matching also risked suppressing a legitimate filing whose 50-char term overlapped a different issue.

## Fix
- List open issues via `gh issue list --state open --limit 200 --json title` (strongly consistent), parse JSON, exact-match the **full** title (whitespace-normalized only, no substring).
- **Fail closed:** return `True` ("assume filed") on non-zero exit / timeout / subprocess error / JSON-parse failure, logging a warning. A skipped filing self-heals on the next daily run; a duplicate does not.
- Inline note on the `--limit 200` ceiling (silent-truncation failure mode) for future maintainers.

## Tests
`tests/unit/test_sentry_triage_apply.py` — exact-title hit, prefix near-miss (proves exact not substring), whitespace-normalization, fail-closed (parametrized over non-zero exit / TimeoutExpired / OSError / bad JSON), and a no-`--search` regression guard. 34/34 module tests pass; ruff clean.

## Docs
Updated the dedup description in `docs/features/sentry-triage.md` and fixed two stale `--search` mentions in `docs/infra/cowork-sentry-triage.md`.

## Scope note
This fixes the **dedup** half of the noise generator. A separate defect — the classifier grading test-fixture (`boom`, `corrupt`, `disk full`) and cross-project (podcast-episode / Stripe / ffmpeg) errors as Class-C actionable — is filed separately; those refile once (not thrice) after this lands but still need a classification/scoping filter.