### PR TITLE
SDLC ledger durability: index-independent existence check, non-mutating reads, durable-signal recovery (#2395)

### DIFF
--- a/agent/pipeline_ledger.py
+++ b/agent/pipeline_ledger.py
@@ -24,7 +24,36 @@ every AgentSession that ever worked it is deleted -- see
 
 from __future__ import annotations
 
+import logging
+import time
+
 from popoto import Field, IntField, KeyField, Model
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Retry budgets (issue #2395)
+# ---------------------------------------------------------------------------
+# These constants live in this module (the lower layer) rather than in
+# tools/sdlc_stage_query.py, which imports them UPWARD -- the existing
+# dependency edge is tools/ -> agent/ (sdlc_stage_query.py already imports
+# PipelineLedger), so defining them here and importing up preserves that
+# layering instead of inverting it into a circular import.
+#
+# Writer budget: bounds the get_or_create() retry loop that guards the
+# "genuine miss vs. racing concurrent create" window (see get_or_create's
+# docstring for why this is NOT the #1720 class-set-index window). Mirrors
+# tools/sdlc_stage_query.py's _CLASS_SET_RETRY_ATTEMPTS / _BACKOFF_S in shape
+# but is a distinct budget for a distinct race -- provisional/tunable.
+_CREATE_RACE_RETRY_ATTEMPTS = 5
+_CREATE_RACE_RETRY_BACKOFF_S = 0.20  # seconds between attempts; provisional/tunable
+
+# Reader budget: PipelineLedger.get() never creates on a miss, so it cannot
+# amortize a retry sleep the way get_or_create() can (a never-written issue
+# would pay the sleep on every single router poll, forever). One attempt,
+# no sleep -- provisional/tunable, but must stay small by design (see
+# get()'s docstring and Risk 2 in docs/plans/sdlc_ledger_durability.md).
+_READER_RETRY_ATTEMPTS = 1
 
 
 def _build_key(target_repo: str, issue_number: int) -> str:
@@ -93,6 +122,40 @@ class PipelineLedger(Model):
         behavior of ``PipelineStateMachine.__init__`` on a session with no
         prior ``stage_states``).
 
+        Existence check (issue #2395): this uses a direct-key ``cls.load(ledger_key=key)``
+        -- an ``HGETALL`` on the specific record -- instead of
+        ``cls.query.filter(ledger_key=key)``, which reads popoto's class-set
+        index. That index is exactly what popoto's ``rebuild_indexes()``
+        transiently empties (the #1720 hazard), and a false-miss there used
+        to fall through to ``cls.create(...)``, which unconditionally
+        overwrites ``stage_states_json`` back to ``"{}"`` -- wiping a live,
+        populated ledger. ``load()`` resolves to a direct key GET
+        (``query.get(db_key=...)``) and is already index-independent --
+        ``agent/pipeline_state.py``'s ``_refresh_ledger`` relies on exactly
+        this property today.
+
+        The bounded retry below (``_CREATE_RACE_RETRY_ATTEMPTS`` x
+        ``_CREATE_RACE_RETRY_BACKOFF_S``) does **not** exist to wait out the
+        #1720 index window -- ``load()`` is immune to that window by
+        construction. It exists to bridge a *different*, narrower window:
+        genuine miss vs. a concurrent caller's ``create()`` landing between
+        this call's ``load()`` and its own ``create()``. Do not "simplify"
+        this retry away as redundant with the index-independent load -- it
+        guards a distinct TOCTOU race, not #1720.
+
+        On a hit at any attempt, the record is returned immediately -- no
+        retry budget is spent past a hit. On a cap-exhausted miss, one final
+        ``load()`` is issued immediately before ``create()`` ("re-load-before-
+        create") so a racing concurrent create is very unlikely to be
+        clobbered. This *narrows*, but does not fully *close*, the
+        create-race: two callers can still both observe ``None`` on that
+        final re-load and both call ``create()``, each unconditionally
+        overwriting ``stage_states_json``. That residual window is accepted
+        here as a much-lower-probability risk than the index-window clobber
+        it replaces (which reproduced 2/2 for in-flight pipelines -- see
+        issue #2395); a follow-up issue tracks closing it with a
+        SETNX-style atomic guard.
+
         Args:
             target_repo: Already-resolved ``owner/name`` GitHub slug. Callers
                 are responsible for never passing ``None``/empty here (see
@@ -104,12 +167,73 @@ class PipelineLedger(Model):
             The existing or newly created ``PipelineLedger`` record.
         """
         key = _build_key(target_repo, issue_number)
-        existing = cls.query.filter(ledger_key=key)
-        if existing:
-            return existing[0]
+
+        for attempt in range(_CREATE_RACE_RETRY_ATTEMPTS):
+            existing = cls.load(ledger_key=key)
+            if existing is not None:
+                return existing
+            if attempt < _CREATE_RACE_RETRY_ATTEMPTS - 1:
+                time.sleep(_CREATE_RACE_RETRY_BACKOFF_S)
+
+        # Re-load-before-create: one final direct-key check immediately
+        # before create() narrows (does not close) the concurrent-create
+        # race described above. If a concurrent caller's create() landed in
+        # between our retry loop and here, we pick up its record instead of
+        # clobbering it -- this is also the observability point (issue #2395,
+        # Nit 1): a hit here on an already-populated record means a
+        # create()-clobber was narrowly averted, which is the residual-race
+        # signal worth logging so post-deploy we can confirm the SETNX
+        # follow-up is (or isn't) needed. A hit is expected to be
+        # exceedingly rare -- if this ever fires, someone else's create()
+        # raced ours within a few-ms window.
+        existing = cls.load(ledger_key=key)
+        if existing is not None:
+            if existing.stage_states_json not in ("{}", "", None):
+                logger.warning(
+                    "PipelineLedger.get_or_create: averted a create()-clobber on "
+                    "an already-populated ledger_key=%r (residual create-race "
+                    "window, issue #2395) -- stage_states_json was %r",
+                    key,
+                    existing.stage_states_json,
+                )
+            return existing
+
         return cls.create(
             ledger_key=key,
             target_repo=target_repo,
             issue_number=issue_number,
             stage_states_json="{}",
         )
+
+    @classmethod
+    def get(cls, target_repo: str, issue_number: int) -> PipelineLedger | None:
+        """Non-mutating read: return the ledger for ``(target_repo, issue_number)``, or ``None``.
+
+        Unlike :meth:`get_or_create`, this method never creates a record --
+        callers that only want to observe current state (e.g. the router's
+        ``stage-query`` poll) must use this instead of ``get_or_create``, so
+        read-only polling never has the side effect of littering empty
+        ledgers or racing a concurrent writer's create.
+
+        Uses a single-attempt budget (``_READER_RETRY_ATTEMPTS = 1``, no
+        sleep) rather than the writer's 5x200ms budget. The writer can
+        amortize its retry sleep because a miss is followed by a create --
+        the record exists on every subsequent call. This method never
+        creates, so a never-written issue would miss on *every* call; if it
+        inherited the writer's budget, the router's hottest path (constant
+        polling) would pay up to 1000ms of retry latency per poll, forever,
+        with no amortization. One attempt, return ``None`` on absence, done.
+
+        Args:
+            target_repo: Already-resolved ``owner/name`` GitHub slug.
+            issue_number: The GitHub issue number.
+
+        Returns:
+            The existing ``PipelineLedger`` record, or ``None`` if absent.
+        """
+        key = _build_key(target_repo, issue_number)
+        for _attempt in range(_READER_RETRY_ATTEMPTS):
+            existing = cls.load(ledger_key=key)
+            if existing is not None:
+                return existing
+        return None

--- a/docs/features/sdlc-issue-keyed-stage-ledger.md
+++ b/docs/features/sdlc-issue-keyed-stage-ledger.md
@@ -312,6 +312,121 @@ entirely — an explicit human decision, not a substitute for the ledger fix.
 left in place would silently authorize a *future* merge of the same PR
 number that the operator never reviewed.
 
+## Hardening the existence check (issue #2395)
+
+The original `get_or_create()` had a second, independent hazard beyond the
+ones documented above: its existence check read popoto's class-set index
+(`cls.query.filter(ledger_key=key)`), the exact structure `rebuild_indexes()`
+transiently empties (the same #1720 hazard `find_session_by_issue()` guards
+against on the session side — see [Popoto Index
+Hygiene](popoto-index-hygiene.md)). A false-miss during that window fell
+through to `cls.create(...)`, which unconditionally overwrites
+`stage_states_json` back to `"{}"` — silently wiping a live, populated
+ledger. This reproduced 2/2 for in-flight pipelines observed against issue
+#2395.
+
+**The fix is a direct-key existence check, not a retry on the old one.**
+`get_or_create()` now checks existence with `cls.load(ledger_key=key)` — an
+`HGETALL` on the specific record, resolving to `query.get(db_key=...)` —
+instead of the class-set-index `query.filter(...)`. `load()` is
+index-independent by construction; `agent/pipeline_state.py`'s
+`_refresh_ledger()` already relied on exactly this property before #2395.
+Because the existence check no longer touches the index, the #1720 window
+cannot cause a false-miss here at all — this is a structural fix, not a
+retry-shaped mitigation of the same race #1720 has.
+
+**The retry that *is* present guards a different, narrower race.**
+`get_or_create()` retries the `load()` up to `_CREATE_RACE_RETRY_ATTEMPTS`
+(5) times, `_CREATE_RACE_RETRY_BACKOFF_S` (0.20s) apart — both in
+`agent/pipeline_ledger.py`. This bounds a genuine-miss-vs-concurrent-create
+TOCTOU: two callers can both reach `get_or_create()` for the same
+never-before-seen `(target_repo, issue_number)` at nearly the same time, and
+without this retry, both would independently miss and both would call
+`create()`, with the second clobbering the first. On any `load()` hit, the
+retry loop returns immediately — the budget is only spent when the record
+genuinely doesn't exist yet.
+
+**Re-load-before-create narrows, but does not close, the residual race.**
+If every retry attempt misses, `get_or_create()` issues one final `load()`
+immediately before calling `create()`. A hit there means a concurrent
+caller's `create()` landed in the gap between this call's retry loop and its
+own `create()` — the pre-existing record is returned instead of clobbered,
+and (since #2395) this is logged as a WARNING when the recovered record's
+`stage_states_json` is non-empty: a clobber-averted event, and the
+observability signal for confirming post-deploy whether the residual window
+ever fires in practice. This narrows the create-race to a few-millisecond
+gap but does not fully close it — two callers can still both observe `None`
+on that final re-load and both call `create()`. **Follow-up issue
+[#2397](https://github.com/tomcounsell/ai/issues/2397)** tracks closing this
+residual window with a SETNX-style atomic guard.
+
+**Retry-constant pattern precedent.** The shared shape of these budgets
+(bounded attempts, fixed backoff, provisional/tunable) mirrors the
+`_CLASS_SET_RETRY_ATTEMPTS`/`_BACKOFF_S` pair `tools/sdlc_stage_query.py`
+already uses for the #1720 session-lookup race — see [Popoto Index
+Hygiene § AgentSession operator/dispatch read-path
+retry](popoto-index-hygiene.md) for that race's root-cause analysis and
+measured index-empty window (p99=651ms). The #2395 constants guard a
+distinct race (create-vs-create, not read-during-rebuild) and live in
+`agent/pipeline_ledger.py` rather than `tools/`, deliberately — see that
+module's top-of-file comment for the import-direction rationale.
+
+## The non-mutating read path: `PipelineLedger.get()`
+
+`PipelineLedger.get(target_repo, issue_number)` (issue #2395) is a
+read-only sibling of `get_or_create()`: same direct-key `load()`, but it
+never calls `create()` and never writes anything. It uses a single-attempt
+budget (`_READER_RETRY_ATTEMPTS = 1`, no sleep) rather than the writer's
+5×200ms budget — a never-written issue misses on *every* call, and without
+this distinction the router's hottest path (constant `stage-query` polling)
+would pay up to 1000ms of retry latency per poll, forever, with no
+amortization the way the writer's create-then-hit-forever pattern gets.
+
+`tools/sdlc_stage_query.py::_resolve_issue_record()` now calls
+`PipelineLedger.get()` instead of `get_or_create()` for its issue-keyed
+lookup. This makes the reader path fully non-mutating: a router poll of a
+never-seen issue used to write an empty ledger as a side effect (and, worse,
+could false-miss into a create-clobber of a live ledger during a
+#1720-style window before the direct-key fix above); it now returns `None`
+and leaves nothing behind. Resolution order is otherwise unchanged — a
+resolved `target_repo` with an empty/absent ledger still falls through to
+the retained cold-path session fallback (`find_session_by_issue()`) for
+pre-cutover records, and an unresolved `target_repo` still returns `None`
+immediately without ever touching a phantom `PipelineLedger[(None, issue)]`
+key (Risk 5, unchanged).
+
+## Router recovery from durable signals on a fully-empty ledger
+
+A fully-empty `PipelineLedger` is ambiguous: it could mean a genuinely fresh
+issue that has never been worked, or an issue whose durable state (a
+committed plan, an open or merged PR, review comments) exists but whose
+ledger lost track of it (cold Redis, an eviction, a cleared session). Before
+#2395, `tools/sdlc_next_skill.py::decide()` treated both cases identically —
+routing to `/do-plan` as if the issue were brand new, discarding real
+progress.
+
+`decide()` now calls `_recover_stage_states_from_durable_signals()`, which
+delegates to `PipelineStateMachine.derive_from_durable_signals()`
+(`agent/pipeline_state.py`, plan/PR/review inspection), immediately before
+calling `decide_next_dispatch()`. The gate is exact-empty, not falsy:
+`stage_states == {}` — a partially-populated ledger (even just an `ISSUE`
+stage marker) is left completely untouched, because partial state is
+legitimately-recorded progress, not a loss to recover from. Recovery only
+ever *supplements* a fully-empty ledger, never overrides a non-empty one.
+The recovery call is best-effort and read-only: any failure inside it
+(a lookup error, a subprocess error, a missing session) is swallowed and
+falls back to `{}`, leaving pre-#2395 behavior — a fresh issue routes to
+`/do-plan` — completely intact.
+
+**This call lives in the CLI wrapper (`tools/sdlc_next_skill.py::decide()`),
+not inside `decide_next_dispatch()`.** `agent/sdlc_router.py`'s
+`decide_next_dispatch()` is a pure G1-G7 guard table and stays that way —
+it does not import or call `derive_from_durable_signals` itself, preserving
+the #1954 purity boundary the router has maintained since the issue-lock
+pre-check was added. Confirmed by inspection: `agent/sdlc_router.py` has no
+import of `derive_from_durable_signals` and no reference to it anywhere in
+the module.
+
 ## Source Files
 
 | File | Role |
@@ -322,7 +437,8 @@ number that the operator never reviewed.
 | `tools/sdlc_session_ensure.py` | `_acquire_run_lock_and_bind()` — the one place `target_repo` is resolved and pinned |
 | `tools/_sdlc_utils.py` | `resolve_ledger_lease()`, `revalidate_ledger_lease()`, `resolve_target_repo_for_read()`, `is_pipeline_ledger()`, demoted `find_session_by_issue()` |
 | `tools/sdlc_stage_marker.py`, `tools/sdlc_verdict.py`, `tools/sdlc_meta_set.py`, `tools/sdlc_dispatch.py` | The four writer CLIs, re-pointed at the ledger with hard-fail semantics |
-| `tools/sdlc_stage_query.py` | `_resolve_issue_record()` — the reader resolution path |
+| `tools/sdlc_stage_query.py` | `_resolve_issue_record()` — the reader resolution path (non-mutating `PipelineLedger.get()` since #2395) |
+| `tools/sdlc_next_skill.py` | `decide()`, `_recover_stage_states_from_durable_signals()` — router recovery from durable signals on a fully-empty ledger (#2395) |
 | `ui/data/sdlc.py` | Dashboard re-point (`_resolve_issue_ledger()`, `_resolve_display_stages()`, `_session_has_stage_data()`) |
 | `scripts/update/migrations.py` | `_migrate_backfill_pipeline_ledger()` |
 | `tests/unit/test_sdlc_takeover_regression.py` | Driver→takeover regression + empty-ledger merge-gate behavior tests |
@@ -331,4 +447,7 @@ number that the operator never reviewed.
 
 - [`docs/features/sdlc-stage-tracking.md`](sdlc-stage-tracking.md) — how stage markers get written day to day
 - [`docs/features/sdlc-issue-ownership-lock.md`](sdlc-issue-ownership-lock.md) — the run_id lease this feature reuses as its write authority
-- `docs/plans/sdlc-issue-keyed-stage-ledger.md` — the originating plan, with full risk/race-condition analysis
+- [`docs/features/popoto-index-hygiene.md`](popoto-index-hygiene.md) — the #1720 class-set-index race and its retry pattern, the shared shape the #2395 create-race retry constants mirror (a distinct race, not the same one)
+- `docs/plans/sdlc_ledger_durability.md` — the plan for issue #2395's existence-check hardening, non-mutating reader, and router recovery
+- `docs/plans/sdlc-issue-keyed-stage-ledger.md` — the originating plan for this feature (issue #2012), with full risk/race-condition analysis
+- [issue #2397](https://github.com/tomcounsell/ai/issues/2397) — follow-up tracking a SETNX-style atomic guard to fully close the residual `get_or_create()` create-race window

--- a/tests/unit/test_pipeline_ledger.py
+++ b/tests/unit/test_pipeline_ledger.py
@@ -91,3 +91,80 @@ class TestPersistenceSurvivesIndependentOfSession:
         indefinitely -- it has to outlive every AgentSession lifecycle
         event (crash, completion, takeover)."""
         assert PipelineLedger._meta.ttl is None
+
+
+class TestGetOrCreateSurvivesIndexEmptyWindow:
+    """Issue #2395: get_or_create's existence check must be index-independent
+    so a live ledger survives a #1720-style rebuild_indexes() window where
+    the class-set index (what query.filter reads) is transiently empty."""
+
+    def setup_method(self):
+        _cleanup(100010)
+
+    def teardown_method(self):
+        _cleanup(100010)
+
+    def test_existence_check_no_longer_uses_query_filter(self, monkeypatch):
+        """Populate a ledger, then make query.filter() lie and report the
+        class-set index as empty (simulating the #1720 window). get_or_create
+        must still find the live record, because its existence check goes
+        through the index-independent cls.load(), not query.filter()."""
+        live = PipelineLedger.get_or_create(_TEST_REPO, 100010)
+        live.stage_states_json = '{"ISSUE": "completed", "PLAN": "in_progress"}'
+        live.save()
+
+        original_filter = PipelineLedger.query.filter
+
+        def _lying_filter(*args, **kwargs):
+            if kwargs.get("ledger_key") == f"{_TEST_REPO}:100010":
+                return []
+            return original_filter(*args, **kwargs)
+
+        monkeypatch.setattr(PipelineLedger.query, "filter", _lying_filter)
+
+        found = PipelineLedger.get_or_create(_TEST_REPO, 100010)
+        assert found.stage_states_json == '{"ISSUE": "completed", "PLAN": "in_progress"}'
+
+    def test_create_clobber_on_existing_key_is_unreachable(self):
+        """A populated ledger must never be reset to "{}" by a subsequent
+        get_or_create call for the same key -- the create()-clobber path
+        (query.filter false-miss -> create()) is no longer reachable from
+        get_or_create's normal resolution flow."""
+        ledger = PipelineLedger.get_or_create(_TEST_REPO, 100010)
+        ledger.stage_states_json = '{"ISSUE": "completed"}'
+        ledger.pr_number = 999
+        ledger.save()
+
+        for _ in range(3):
+            resolved = PipelineLedger.get_or_create(_TEST_REPO, 100010)
+            assert resolved.stage_states_json == '{"ISSUE": "completed"}'
+            assert resolved.pr_number == 999
+
+
+class TestGet:
+    """Issue #2395: PipelineLedger.get() is a non-mutating, read-only lookup
+    used by the router's stage-query poll path."""
+
+    def setup_method(self):
+        _cleanup(100011)
+
+    def teardown_method(self):
+        _cleanup(100011)
+
+    def test_returns_none_for_absent_key(self):
+        """A never-seen (repo, issue) pair returns None -- and, critically,
+        leaves no record behind (get() must never create)."""
+        assert PipelineLedger.get(_TEST_REPO, 100011) is None
+        assert PipelineLedger.query.filter(ledger_key=f"{_TEST_REPO}:100011") == []
+
+    def test_returns_existing_record_for_present_key(self):
+        """get() returns the live record when one already exists, without
+        needing get_or_create."""
+        created = PipelineLedger.get_or_create(_TEST_REPO, 100011)
+        created.stage_states_json = '{"ISSUE": "completed"}'
+        created.save()
+
+        found = PipelineLedger.get(_TEST_REPO, 100011)
+        assert found is not None
+        assert found.ledger_key == created.ledger_key
+        assert found.stage_states_json == '{"ISSUE": "completed"}'

--- a/tests/unit/test_sdlc_next_skill.py
+++ b/tests/unit/test_sdlc_next_skill.py
@@ -838,3 +838,161 @@ class TestPrHeadShaContext:
         )
         assert "pr_head_sha" not in context
         assert called == []
+
+
+class TestLedgerDurabilityRecovery:
+    """Issue #2395: an empty PipelineLedger for an issue that actually has
+    durable state (committed plan, open PR, review) must not be silently
+    treated as "pipeline never started" and routed to /do-plan. decide()
+    reconstructs stage_states from PipelineStateMachine.derive_from_durable_signals
+    when -- and only when -- stage_states is EXACTLY the empty dict.
+
+    Decision 1 (settled): the reconstruction hook lives in
+    tools/sdlc_next_skill.decide(), never inside agent/sdlc_router's pure
+    guard table.
+    Decision 2 (settled): gated on ``stage_states == {}`` exactly, not a
+    falsy check -- any partially-populated ledger must pass through
+    untouched.
+    """
+
+    @staticmethod
+    def _patch_common(monkeypatch, issue_session=MagicMock()):
+        """Bypass the issue-lock pre-check so decide() reaches _resolve_enriched."""
+        from models.session_lifecycle import IssueLockResult
+
+        monkeypatch.setattr(
+            "tools._sdlc_utils.find_session_by_issue", lambda issue_number: issue_session
+        )
+        monkeypatch.setattr(
+            "models.session_lifecycle.touch_issue_lock",
+            lambda *a, **k: IssueLockResult(acquired=True, owner_session_id=None),
+        )
+
+    def test_empty_ledger_with_durable_signals_skips_do_plan(self, monkeypatch):
+        """Empty ledger + durable signals showing an open PR and committed
+        plan -> reconstruction fires, decide_next_dispatch receives the
+        reconstructed non-empty stage_states, and the router does NOT
+        dispatch /do-plan."""
+        self._patch_common(monkeypatch)
+        monkeypatch.setattr(
+            sdlc_next_skill,
+            "_resolve_enriched",
+            lambda issue_number, session_id: {"stages": {}, "_meta": {"pr_number": 4242}},
+        )
+        reconstructed = {
+            "ISSUE": STATUS_COMPLETED,
+            "PLAN": STATUS_COMPLETED,
+            "CRITIQUE": STATUS_COMPLETED,
+            "BUILD": STATUS_COMPLETED,
+            "TEST": "pending",
+            "REVIEW": "pending",
+            "DOCS": "pending",
+            "MERGE": "pending",
+        }
+        monkeypatch.setattr(
+            "agent.pipeline_state.PipelineStateMachine.derive_from_durable_signals",
+            lambda session: reconstructed,
+        )
+
+        result = sdlc_next_skill.decide(issue_number=4242)
+
+        assert result["dispatched"] is True
+        assert result["skill"] != SKILL_DO_PLAN
+
+    def test_empty_ledger_no_durable_signals_still_dispatches_do_plan(self, monkeypatch):
+        """Empty ledger + a genuinely fresh issue (derive_from_durable_signals
+        finds nothing) -> reconstruction yields nothing meaningful, router
+        still dispatches /do-plan. Critical: don't mask a genuinely fresh
+        issue."""
+        self._patch_common(monkeypatch)
+        monkeypatch.setattr(
+            sdlc_next_skill,
+            "_resolve_enriched",
+            lambda issue_number, session_id: {"stages": {}, "_meta": {}},
+        )
+        monkeypatch.setattr(
+            "agent.pipeline_state.PipelineStateMachine.derive_from_durable_signals",
+            lambda session: {},
+        )
+
+        result = sdlc_next_skill.decide(issue_number=4243)
+
+        assert result["dispatched"] is True
+        assert result["skill"] == SKILL_DO_PLAN
+
+    def test_partial_ledger_passes_through_unchanged(self, monkeypatch):
+        """A partially-populated stage_states (e.g. only ISSUE completed) must
+        pass through UNCHANGED -- reconstruction must not fire at all when
+        stage_states != {}, even if it's mostly-empty."""
+        self._patch_common(monkeypatch)
+        monkeypatch.setattr(
+            sdlc_next_skill,
+            "_resolve_enriched",
+            lambda issue_number, session_id: {
+                "stages": {"ISSUE": STATUS_COMPLETED},
+                "_meta": {},
+            },
+        )
+        recover_mock = MagicMock()
+        monkeypatch.setattr(
+            sdlc_next_skill, "_recover_stage_states_from_durable_signals", recover_mock
+        )
+
+        result = sdlc_next_skill.decide(issue_number=4244)
+
+        recover_mock.assert_not_called()
+        # Partial ledger (only ISSUE completed, no PLAN) still routes to /do-plan
+        # via the normal guard table -- but the point under test is that the
+        # reconstruction path was never invoked.
+        assert result["dispatched"] is True
+        assert result["skill"] == SKILL_DO_PLAN
+
+    def test_reconstruction_failure_does_not_propagate(self, monkeypatch):
+        """A failure inside the reconstruction path (derive_from_durable_signals
+        raising, or find_session_by_issue raising) does not propagate --
+        decide() still returns a normal result routing to /do-plan for the
+        empty-ledger case."""
+        from models.session_lifecycle import IssueLockResult
+
+        monkeypatch.setattr(
+            "tools._sdlc_utils.find_session_by_issue",
+            lambda issue_number: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        monkeypatch.setattr(
+            "models.session_lifecycle.touch_issue_lock",
+            lambda *a, **k: IssueLockResult(acquired=True, owner_session_id=None),
+        )
+        monkeypatch.setattr(
+            sdlc_next_skill,
+            "_resolve_enriched",
+            lambda issue_number, session_id: {"stages": {}, "_meta": {}},
+        )
+
+        result = sdlc_next_skill.decide(issue_number=4245)
+
+        assert result["dispatched"] is True
+        assert result["skill"] == SKILL_DO_PLAN
+
+    def test_recover_helper_returns_empty_when_no_session_found(self, monkeypatch):
+        """Direct unit coverage of the helper: no issue session resolvable ->
+        returns {} without raising."""
+        monkeypatch.setattr("tools._sdlc_utils.find_session_by_issue", lambda issue_number: None)
+
+        result = sdlc_next_skill._recover_stage_states_from_durable_signals(9999)
+
+        assert result == {}
+
+    def test_recover_helper_swallows_derive_exception(self, monkeypatch):
+        """Direct unit coverage: derive_from_durable_signals raising is
+        swallowed and {} is returned."""
+        monkeypatch.setattr(
+            "tools._sdlc_utils.find_session_by_issue", lambda issue_number: MagicMock()
+        )
+        monkeypatch.setattr(
+            "agent.pipeline_state.PipelineStateMachine.derive_from_durable_signals",
+            lambda session: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+
+        result = sdlc_next_skill._recover_stage_states_from_durable_signals(9999)
+
+        assert result == {}

--- a/tests/unit/test_sdlc_stage_query.py
+++ b/tests/unit/test_sdlc_stage_query.py
@@ -1111,12 +1111,40 @@ class TestResolveIssueRecord:
 
         with (
             patch("tools.sdlc_stage_query._resolve_target_repo_for_read", return_value=None),
-            patch("agent.pipeline_ledger.PipelineLedger.get_or_create") as mock_get_or_create,
+            patch("agent.pipeline_ledger.PipelineLedger.get") as mock_get,
         ):
             result = _resolve_issue_record(999888)
 
         assert result is None
-        mock_get_or_create.assert_not_called()
+        mock_get.assert_not_called()
+
+    def test_never_creates_a_ledger_as_a_side_effect(self):
+        """Issue #2395: the reader must never write. Querying a never-seen
+        issue with a resolvable target_repo must not persist a
+        PipelineLedger record -- the old get_or_create-based read path used
+        to litter an empty ledger on every poll; the new get()-based path
+        must leave no trace."""
+        from agent.pipeline_ledger import PipelineLedger
+        from tools.sdlc_stage_query import _resolve_issue_record
+
+        target_repo = "owner/never-seen-repo"
+        issue_number = 700599
+
+        # Sanity: no record exists yet.
+        assert PipelineLedger.get(target_repo, issue_number) is None
+
+        with (
+            patch(
+                "tools.sdlc_stage_query._resolve_target_repo_for_read",
+                return_value=target_repo,
+            ),
+            patch("tools.sdlc_stage_query._find_session_by_issue", return_value=None),
+        ):
+            result = _resolve_issue_record(issue_number)
+
+        assert result is None
+        # No side-effect record was written by the read path.
+        assert PipelineLedger.get(target_repo, issue_number) is None
 
     def test_query_stage_states_returns_empty_dict_when_target_repo_unresolved(self):
         """CLI contract: stage-query on an unresolvable repo context stays

--- a/tools/sdlc_next_skill.py
+++ b/tools/sdlc_next_skill.py
@@ -402,6 +402,35 @@ def _build_context(
     return context
 
 
+def _recover_stage_states_from_durable_signals(issue_number: int) -> dict:
+    """Best-effort, read-only fallback: reconstruct stage_states from durable
+    artifacts (committed plan, open/merged PR, review comments) when the
+    ``PipelineLedger`` is empty for an issue that actually has durable state
+    (issue #2395).
+
+    Delegates to ``PipelineStateMachine.derive_from_durable_signals`` in
+    ``agent/pipeline_state.py``, which already implements the plan/PR/review
+    inspection. This wrapper only resolves the ``session`` argument that
+    function requires (via ``find_session_by_issue``) and swallows every
+    failure -- a lookup error, a subprocess error inside the derive call, or
+    a missing session all fall back to "nothing recovered" (``{}``), which
+    leaves today's behavior (empty stage_states flows through unchanged to
+    ``decide_next_dispatch``, which routes fresh issues to ``/do-plan``)
+    completely intact. Never raises.
+    """
+    try:
+        from agent.pipeline_state import PipelineStateMachine
+        from tools._sdlc_utils import find_session_by_issue
+
+        issue_session = find_session_by_issue(issue_number)
+        if issue_session is None:
+            return {}
+        return PipelineStateMachine.derive_from_durable_signals(issue_session) or {}
+    except Exception as e:
+        logger.debug(f"_recover_stage_states_from_durable_signals failed: {e}")
+        return {}
+
+
 def decide(
     issue_number: int | None = None,
     session_id: str | None = None,
@@ -469,6 +498,30 @@ def decide(
         enriched = _resolve_enriched(issue_number, session_id)
         stage_states = enriched.get("stages") or {}
         meta = enriched.get("_meta") or {}
+
+        # Ledger-durability recovery (issue #2395): a fully-empty ledger
+        # ("pipeline never started") is ambiguous -- it could be a genuinely
+        # fresh issue, or an issue whose durable state (committed plan, open
+        # PR, review) exists but the PipelineLedger lost track of it (cold
+        # Redis, eviction, cleared session). Gate on ``stage_states == {}``
+        # EXACTLY, not a falsy check: a partially-populated ledger (any stage
+        # marker present, even just ISSUE) is legitimately-recorded partial
+        # state and must be left completely untouched -- reconstruction only
+        # ever supplements a fully-empty ledger, never overrides it. This
+        # reconstruction call is deliberately placed HERE, in the CLI wrapper,
+        # rather than inside ``decide_next_dispatch`` -- that function is a
+        # pure guard table (G1-G7) and must never import/call
+        # ``derive_from_durable_signals`` itself, preserving the #1954
+        # purity boundary (see the comment block above on the issue-lock
+        # pre-check). Best-effort and read-only: any failure inside
+        # ``_recover_stage_states_from_durable_signals`` leaves stage_states
+        # empty, and the empty dict flows through to decide_next_dispatch
+        # exactly as before (routing a fresh issue to /do-plan).
+        if stage_states == {} and issue_number:
+            recovered = _recover_stage_states_from_durable_signals(issue_number)
+            if recovered:
+                stage_states = recovered
+
         context = _build_context(proposed_skill, issue_number, stage_states, meta)
 
         result = decide_next_dispatch(stage_states, meta, context)

--- a/tools/sdlc_stage_query.py
+++ b/tools/sdlc_stage_query.py
@@ -587,16 +587,22 @@ def _resolve_issue_record(issue_number: int):
        key, and never fall back to a session either (a caller who genuinely
        cannot resolve a repo has no coherent issue-keyed context to read).
     2. If a ``target_repo`` DOES resolve: load
-       ``PipelineLedger.get_or_create(target_repo, issue_number)``. If it
-       carries any recorded stage state, return it.
-    3. Ledger resolved but empty (never written, or pre-cutover) -- retained
-       cold-path session fallback via ``find_session_by_issue()``: the belt
-       for issues whose work started before this migration and whose
-       ``AgentSession`` still carries the old data, or a session created
-       between a migration backfill run and this deploy.
+       ``PipelineLedger.get(target_repo, issue_number)`` -- a non-mutating,
+       read-only lookup (issue #2395). A never-seen issue returns ``None``
+       and leaves no record behind: the router polls this path constantly,
+       and the prior create-on-miss reader call this replaced used to write
+       an empty ledger as a side effect on every one of those polls (and,
+       worse, could false-miss into a wipe of a live ledger during a
+       #1720-style index-rebuild window). ``get()`` never creates and never
+       clobbers. If it carries any recorded stage state, return it.
+    3. Ledger resolved but empty/absent (never written, or pre-cutover) --
+       retained cold-path session fallback via ``find_session_by_issue()``:
+       the belt for issues whose work started before this migration and
+       whose ``AgentSession`` still carries the old data, or a session
+       created between a migration backfill run and this deploy.
 
     Returns the ``PipelineLedger``, the fallback ``AgentSession``, or
-    ``None`` if nothing resolves. Never raises.
+    ``None`` if nothing resolves. Never raises, never writes.
     """
     target_repo = _resolve_target_repo_for_read(issue_number)
     if not target_repo:
@@ -606,7 +612,7 @@ def _resolve_issue_record(issue_number: int):
     try:
         from agent.pipeline_ledger import PipelineLedger
 
-        ledger = PipelineLedger.get_or_create(target_repo, issue_number)
+        ledger = PipelineLedger.get(target_repo, issue_number)
     except Exception as e:
         logger.debug(f"_resolve_issue_record: ledger load failed for issue #{issue_number}: {e}")
 


### PR DESCRIPTION
## Summary

Fixes #2395: a live `PipelineLedger` (issue-keyed SDLC pipeline ledger) was
silently wiped mid-run because `get_or_create`'s existence check was a
class-set index read (`cls.query.filter(ledger_key=key)`), which popoto's
`rebuild_indexes()` transiently empties (the #1720 hazard). A false-miss
during that window triggered `create()`, which unconditionally overwrites
`stage_states_json` back to `"{}"` — a full clobber, not a merge. Reproduced
2/2 for in-flight pipelines (#2376, #2337).

- **`agent/pipeline_ledger.py`**: `get_or_create` now uses a bounded-retry,
  index-independent direct-key `load()` for its existence check, with a
  final re-load immediately before `create()` (narrows, does not fully
  close, the residual create-race — tracked as a follow-up: #2397). Adds a
  new read-only `PipelineLedger.get()` with its own single-attempt reader
  budget (distinct from the writer's 5×200ms budget, so router polling of a
  never-written issue pays no retry latency). Logs a clobber-averted warning
  when the re-load-before-create step catches an already-populated key.
- **`tools/sdlc_stage_query.py`**: `_resolve_issue_record` now calls the
  new non-mutating `PipelineLedger.get()` instead of `get_or_create` — stage
  queries (which the router polls constantly) never write a ledger record
  as a side effect.
- **`tools/sdlc_next_skill.py`**: `decide()` reconstructs stage state via
  the existing `PipelineStateMachine.derive_from_durable_signals()` when
  (and only when) the ledger is fully empty (`stage_states == {}` exactly —
  never a partially-populated ledger), immediately before dispatching. The
  pure guard table `agent/sdlc_router.py::decide_next_dispatch` stays
  untouched (#1954 purity preserved).
- **Docs**: `docs/features/sdlc-issue-keyed-stage-ledger.md` updated with
  the hardening details and the #2397 follow-up.

Follow-up filed: #2397 (SETNX-style atomic guard to fully close the residual
create-race window; explicitly deferred per this plan's appetite).

## Test plan

- [x] `pytest tests/unit/test_pipeline_ledger.py -q` — 10 passed
- [x] `pytest tests/unit/test_sdlc_stage_query.py -q` — 71 passed
- [x] `pytest tests/unit/test_pipeline_state_machine.py tests/unit/test_pipeline_state.py -q` — 159 passed
- [x] `pytest tests/unit/test_sdlc_next_skill.py -q` — 40 passed
- [x] `pytest tests/unit/test_sdlc_router.py -q` — 63 passed (confirms `agent/sdlc_router.py` stays pure)
- [x] `python -m ruff check` / `format --check` clean on all touched files
- [x] `grep -n "get_or_create" tools/sdlc_stage_query.py` — 0 matches
- [x] `docs/features/sdlc-issue-keyed-stage-ledger.md` updated; `validate_docs_changed.py` passes

Closes #2395