### PR TITLE
Fix 11 nightly unit failures: carry queue-notify + sdlc self-heal tests to current source contracts (#2399)

### DIFF
--- a/tests/unit/test_agent_session_queue_async.py
+++ b/tests/unit/test_agent_session_queue_async.py
@@ -133,7 +133,13 @@ class TestPushAgentSessionPublish:
             )
             mock_redis.publish.assert_called_once()
             args = mock_redis.publish.call_args
-            assert args[0][0] == "valor:sessions:new"
+            # The publish channel is db-derived (issue #2147): db=0 → the
+            # canonical channel, any test db → a db-scoped suffix. Assert against
+            # notify_channel_for(...) rather than a bare literal so the test
+            # tracks the same derivation the source uses.
+            from agent.agent_session_queue import notify_channel_for
+
+            assert args[0][0] == notify_channel_for(mock_redis)
             import json
 
             payload = json.loads(args[0][1])
@@ -486,13 +492,21 @@ class TestNotifyHealthcheckWatchdog:
             "db": 0,
         }
 
+        from agent.agent_session_queue import notify_channel_for
+
+        # The watchdog now takes the db-derived channel the listener subscribed
+        # to as a required arg (issue #2147) rather than re-deriving a literal.
+        # mock_popoto is pinned to db=0, so this resolves to the canonical
+        # channel the numsub_side_effect fixtures return.
+        channel = notify_channel_for(mock_popoto)
+
         async def run():
             with (
                 patch("agent.agent_session_queue.NOTIFY_HEALTHCHECK_INTERVAL", interval),
                 patch("popoto.redis_db.POPOTO_REDIS_DB", mock_popoto),
                 patch.object(_redis_module, "Redis", return_value=mock_probe_conn),
             ):
-                task = asyncio.create_task(_notify_healthcheck_watchdog(handle))
+                task = asyncio.create_task(_notify_healthcheck_watchdog(handle, channel))
                 await asyncio.sleep(interval * (ticks + 2))
                 task.cancel()
                 try:

--- a/tests/unit/test_sdlc_dispatch.py
+++ b/tests/unit/test_sdlc_dispatch.py
@@ -275,6 +275,12 @@ def _isolated_subprocess_env():
     The autouse redis_test_db fixture patches the IN-PROCESS popoto client;
     a subprocess re-resolves REDIS_URL at import, so point it explicitly at
     the same test db -- unit tests must never touch production Redis.
+
+    Also strips the run-identity env vars the #2144 self-heal path consults
+    (``VALOR_SESSION_ID`` / ``AGENT_SESSION_ID`` — read by
+    ``tools.sdlc_session_ensure``). A CLI subprocess test must never inherit a
+    LIVE run identity from the parent process, or the healable/unhealable
+    boundary these tests assert would depend on the ambient environment.
     """
     import popoto.redis_db as rdb
 
@@ -282,14 +288,41 @@ def _isolated_subprocess_env():
     host = kwargs.get("host") or "localhost"
     port = kwargs.get("port") or 6379
     db = kwargs.get("db", 1)
-    return {**os.environ, "REDIS_URL": f"redis://{host}:{port}/{db}"}
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in ("VALOR_SESSION_ID", "AGENT_SESSION_ID", "active_run_id")
+    }
+    env["REDIS_URL"] = f"redis://{host}:{port}/{db}"
+    return env
 
 
 class TestRunIdRequiredFlag:
-    """Issue #2003: every state-MUTATING sdlc-tool subcommand exits non-zero
-    with the NAMED error RUN_ID_REQUIRED when --run-id is missing -- no mint,
-    no adopt, no session resolution. Read-only subcommands take no run-id.
-    One subprocess test per mutating subcommand."""
+    """Run-identity self-heal contract for state-MUTATING sdlc-tool subcommands.
+
+    Issue #2003 originally hard-refused RUN_ID_REQUIRED whenever ``--run-id``
+    was missing -- "no mint, no adopt, no session resolution". Issue #2144
+    (``tools/_sdlc_run_identity.heal_missing_run_id``) DELIBERATELY replaced
+    that unconditional refusal with a self-heal: a resumed pipeline turn that
+    lost its ``run_id`` from context re-establishes identity from the
+    environment (a live supervisor / ``.sdlc-run`` / ``active_run_id``) or, on
+    a genuinely FREE issue lock, fresh-mints one and proceeds. The refusal
+    only stands when the heal has nothing to key on.
+
+    These tests encode that healable/unhealable boundary:
+
+    * With a resolvable ``--issue-number`` on a free lock (no session, no
+      foreign lease), a missing ``--run-id`` is self-healed -- the tool does
+      NOT emit RUN_ID_REQUIRED and proceeds (exit 0).
+    * With NO ``--issue-number`` there is nothing to key the heal on, so the
+      original RUN_ID_REQUIRED refusal stands (exit 2).
+
+    The two real hazards the heal never crosses -- adopting a foreign LIVE
+    lease (ISSUE_LOCKED) and resurrecting a MERGE-completed pipeline -- are
+    guarded in ``reestablish_run_id`` and covered by that module's own tests.
+    Read-only subcommands take no run-id. One subprocess case per mutating
+    subcommand.
+    """
 
     @pytest.mark.parametrize(
         ("module", "argv"),
@@ -321,7 +354,14 @@ class TestRunIdRequiredFlag:
         ],
         ids=["dispatch-record", "verdict-record", "stage-marker", "meta-set"],
     )
-    def test_missing_run_id_is_named_nonzero_error(self, module, argv):
+    def test_missing_run_id_self_heals_on_free_lock(self, module, argv):
+        """Missing --run-id + resolvable free-lock issue -> self-heal, no refusal.
+
+        Issue 999999 has no session and a free lock in the fresh test db, so
+        ``heal_missing_run_id`` fresh-mints an identity and the write proceeds.
+        This is the #2144 contract: the ledger no longer freezes when a resumed
+        turn lost its run_id.
+        """
         proc = subprocess.run(
             [sys.executable, "-m", module, *argv],
             capture_output=True,
@@ -330,7 +370,45 @@ class TestRunIdRequiredFlag:
             env=_isolated_subprocess_env(),
             timeout=60,
         )
-        assert proc.returncode != 0, f"{module} must exit non-zero without --run-id"
+        combined = proc.stdout + proc.stderr
+        assert "RUN_ID_REQUIRED" not in combined, (
+            f"{module} must self-heal a missing --run-id on a free-lock issue "
+            f"(issue #2144), not refuse RUN_ID_REQUIRED; got: {combined!r}"
+        )
+        assert proc.returncode == 0, (
+            f"{module} should proceed (exit 0) after self-healing; "
+            f"rc={proc.returncode}, out={combined!r}"
+        )
+
+    @pytest.mark.parametrize(
+        ("module", "argv"),
+        [
+            ("tools.sdlc_dispatch", ["record", "--skill", "/do-build"]),
+            (
+                "tools.sdlc_verdict",
+                ["record", "--stage", "CRITIQUE", "--verdict", "READY TO BUILD"],
+            ),
+            ("tools.sdlc_stage_marker", ["--stage", "DOCS", "--status", "completed"]),
+            ("tools.sdlc_meta_set", ["--key", "plan_revising", "--value", "true"]),
+        ],
+        ids=["dispatch-record", "verdict-record", "stage-marker", "meta-set"],
+    )
+    def test_missing_run_id_without_issue_number_still_refuses(self, module, argv):
+        """No --run-id AND no --issue-number -> the heal cannot key on anything,
+        so the RUN_ID_REQUIRED refusal stands (exit 2). This is the stable
+        unhealable boundary of the #2144 self-heal."""
+        proc = subprocess.run(
+            [sys.executable, "-m", module, *argv],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+            env=_isolated_subprocess_env(),
+            timeout=60,
+        )
+        assert proc.returncode == 2, (
+            f"{module} must refuse (exit 2) with no run-id and no issue-number; "
+            f"rc={proc.returncode}"
+        )
         combined = proc.stdout + proc.stderr
         assert "RUN_ID_REQUIRED" in combined, (
             f"{module} must name the error RUN_ID_REQUIRED; got: {combined!r}"

--- a/tests/unit/test_sdlc_stage_marker.py
+++ b/tests/unit/test_sdlc_stage_marker.py
@@ -1124,11 +1124,17 @@ class TestCLI:
             env=clean_env,
         )
         output = json.loads(result.stdout.strip())
-        # No lease was ever established for issue 99999 under run-cli-test in
-        # this fresh test Redis db, so this always hard-fails LEASE_ABSENT
-        # (exit 1) unless Redis itself is unreachable (exit 0, degraded).
-        if result.returncode == 0:
-            assert output.get("status") == "degraded"
-        else:
-            assert result.returncode == 1
-            assert output.get("reason") == "LEASE_ABSENT"
+        # No lease was ever established for issue 99999 under run-cli-test, but
+        # the lock is FREE in this fresh test db. The #2144 self-heal
+        # (maybe_heal_after_write) re-acquires the lease under the supplied
+        # --run-id on a free lock -- the documented "stale --run-id + lapsed
+        # lease resume" -- so the marker completes rather than hard-failing
+        # LEASE_ABSENT. A "degraded" exit-0 is the acceptable fallback when
+        # Redis itself is unreachable.
+        assert result.returncode == 0, (
+            f"stage-marker should self-heal on a free lock and complete; "
+            f"rc={result.returncode}, output={output!r}"
+        )
+        assert output.get("status") in ("completed", "degraded"), (
+            f"expected a healed 'completed' (or 'degraded' if Redis is down); got {output!r}"
+        )


### PR DESCRIPTION
Closes #2399.

Triage of the 11 nightly-flagged unit failures across three independent groups. **All three are test-stale — no source regression.** Per-group determination with evidence below.

## Group 1 — queue notify/pubsub watchdog (5 tests) · test-stale
`tests/unit/test_agent_session_queue_async.py`

Commit `8e019ab7` (#2147/#2163) changed two source contracts the tests weren't carried to:
- `_notify_healthcheck_watchdog(handle)` → `_notify_healthcheck_watchdog(handle, channel)` (required 2nd positional).
- Publish channel is now db-derived via `notify_channel_for(POPOTO_REDIS_DB)` — canonical `valor:sessions:new` at db=0, db-scoped `valor:sessions:new:db{N}` otherwise.

**Fix:** the four watchdog tests pass the db-derived `channel`; the publish test asserts against `notify_channel_for(...)` instead of a hardcoded literal so it tracks future db changes. (The observed `db1` came from `MagicMock.__int__` defaulting to 1 — a test artifact, not a source bug.)

## Group 2 — sdlc-tool run-id/lease self-heal (5 tests) · test-stale · **design fork resolved → option (a)**
`tests/unit/test_sdlc_dispatch.py`, `tests/unit/test_sdlc_stage_marker.py`

The issue flagged a genuine fork: (a) the self-heal is intended and the tests are stale, or (b) fresh-minting identity for a call with no `--run-id` is a safety hole.

**Resolved: (a).** Evidence: #2144 (`tools/_sdlc_run_identity.py`), reinforced by #2193/#2213 and the ledger-durability work, *deliberately* replaced the unconditional `RUN_ID_REQUIRED`/`LEASE_ABSENT` hard-refusal with `heal_missing_run_id` / `maybe_heal_after_write`. The design consciously allows fresh-mint on a **free** lock (the terminal guard only declines fresh-mint on `MERGE==completed` pipelines — implying non-terminal fresh-mint is intended) and re-acquires a lapsed lease under a supplied `--run-id`. The two real hazards — adopting a foreign **live** lease (`ISSUE_LOCKED`) and resurrecting a completed pipeline — remain guarded in `reestablish_run_id`. Re-refusing would reintroduce the exact #2133 ledger-freeze bug #2144 fixed. The tests encoded the pre-#2144 "no mint, no adopt" contract.

**Fix:** rewrote `TestRunIdRequiredFlag` to encode the healable/unhealable boundary — a free-lock issue self-heals (no `RUN_ID_REQUIRED`, exit 0); no `--issue-number` still refuses `RUN_ID_REQUIRED` (exit 2). Updated the stage-marker CLI test to expect a healed `completed`. Independently hardened `_isolated_subprocess_env()` to strip `VALOR_SESSION_ID`/`AGENT_SESSION_ID` so a subprocess CLI test never inherits a live run identity (issue acceptance criterion).

## Group 3 — update-hardlinks RENAMED_REMOVALS staleness (1 test) · already resolved
`tests/unit/test_update_hardlinks.py::test_renamed_removals_entries_are_not_stale` **passes at HEAD**. The nightly captured it mid-churn during the #2339 skills-global prune; `ad4e95c8` reconciled `RENAMED_REMOVALS` with the filesystem. No change needed.

## Verification
`scripts/pytest-clean.sh -o addopts="" -n0` over all four affected modules: **137 passed**. `ruff format` + `ruff check` clean.