### PR TITLE
Classify signal-killed harness exits as SIGNAL_KILLED (#2341)

### DIFF
--- a/agent/session_runner/harness/claude.py
+++ b/agent/session_runner/harness/claude.py
@@ -1357,10 +1357,21 @@ async def _run_harness_subprocess(
         stderr_snippet,
     )
     if log_level == logging.WARNING:
-        logger.warning(
-            "Harness exited cleanly (rc=0) with no result event and no streamed text; "
-            "treating as empty turn"
-        )
+        if exit_class == HarnessExitClass.SIGNAL_KILLED:
+            # Signal death (128 + n, e.g. rc=143 SIGTERM): the child was killed
+            # mid-turn — worker restart/deploy or an external reaper — not a
+            # harness fault. Below Sentry's error threshold; the runner already
+            # degrades gracefully (empty turn → wrap-up guard).
+            logger.warning(
+                "Harness was signal-killed (rc=%s) with no result event and no "
+                "streamed text; treating as empty turn (worker restart / reaper)",
+                returncode,
+            )
+        else:
+            logger.warning(
+                "Harness exited cleanly (rc=0) with no result event and no streamed text; "
+                "treating as empty turn"
+            )
     else:
         try:
             import sentry_sdk  # noqa: PLC0415 — local import mirrors agent/index_drift.py

--- a/agent/session_runner/harness/claude_diagnostics.py
+++ b/agent/session_runner/harness/claude_diagnostics.py
@@ -44,6 +44,20 @@ from enum import StrEnum
 # config.settings.
 HARNESS_TLS_CONSECUTIVE_SUPPRESS = int(os.environ.get("HARNESS_TLS_CONSECUTIVE_SUPPRESS", "2"))
 
+# Exit-code floor above which a nonzero return is a SIGNAL death, not an
+# application crash. POSIX shells report a signal-killed child as ``128 + n``
+# (SIGTERM → 143, SIGKILL → 137, SIGINT → 130, SIGQUIT → 131), so any
+# ``returncode > 128`` means the harness subprocess was *killed*, not that the
+# CLI itself exited with an error status. This is the signature of a worker
+# restart/deploy (launchd SIGTERMs the whole process group mid-turn) or an
+# external reaper — an operationally EXPECTED event, not a harness failure.
+#
+# Provisional/tunable: 128 is the POSIX convention and the grain-of-salt
+# default; override with HARNESS_SIGNAL_EXIT_FLOOR in the environment. Named
+# locally (#1968 promote-vs-name-locally) — single-file knob, not promoted to
+# config.settings.
+HARNESS_SIGNAL_EXIT_FLOOR = int(os.environ.get("HARNESS_SIGNAL_EXIT_FLOOR", "128"))
+
 
 # Bare-version basename shape, e.g. "2.1.202". When the resolved claude binary's
 # basename matches this, macOS logs/dialogs show it as the process name and we
@@ -176,6 +190,7 @@ class HarnessExitClass(StrEnum):
     TLS_TRUST = "tls_trust"
     STALE_UUID = "stale_uuid"
     CLEAN_NO_OUTPUT = "clean_no_output"
+    SIGNAL_KILLED = "signal_killed"
     GENERIC_NONZERO = "generic_nonzero"
 
 
@@ -223,17 +238,29 @@ def classify_harness_early_exit(
     * ``AUTH_UNAVAILABLE`` — stderr matches any auth token **and not** a TLS
       token. **TLS wins over auth** (it is the destructive-dialog class) — this
       precedence is load-bearing.
-    * ``STALE_UUID`` — ``init_seen`` False on an exit with no TLS/auth match
-      (retained for parity with the existing stale-UUID fallback). Its condition
-      is returncode-independent, so it keeps first claim on every
+    * ``SIGNAL_KILLED`` — ``returncode > HARNESS_SIGNAL_EXIT_FLOOR`` (128) with
+      no TLS/auth match: the subprocess was *killed by a signal*
+      (128 + n: SIGTERM → 143, SIGKILL → 137), not crashed. The dominant
+      cause is a worker restart/deploy SIGTERMing the process group mid-turn,
+      or an external reaper — operationally expected, not a harness fault. The
+      returncode is direct evidence of a signal, so this wins over the
+      init-based inferences (``STALE_UUID``/``GENERIC_NONZERO``) below. It
+      cannot collide with ``CLEAN_NO_OUTPUT`` (returncode 0) since 0 is never
+      ``> 128``.
+    * ``STALE_UUID`` — ``init_seen`` False on an exit with no TLS/auth/signal
+      match (retained for parity with the existing stale-UUID fallback). For a
+      non-signal exit (``returncode <= 128``) its condition is
+      returncode-independent, so it keeps first claim on every
       ``init_seen=False`` exit — including a returncode-0 one — ahead of
-      ``CLEAN_NO_OUTPUT``.
+      ``CLEAN_NO_OUTPUT``. A signal-killed exit (``> 128``) is claimed by
+      ``SIGNAL_KILLED`` above regardless of ``init_seen``.
     * ``CLEAN_NO_OUTPUT`` — ``returncode == 0`` with ``init_seen`` True and no
       TLS/auth match: a benign exit-0 empty turn (returncode 0 stops
       masquerading as ``GENERIC_NONZERO``). This guard runs *after* the
       ``STALE_UUID`` check so an ``init_seen=False`` exit-0 stays error-level
       ``STALE_UUID``, not warning-level ``CLEAN_NO_OUTPUT`` (issue #2219).
-    * ``GENERIC_NONZERO`` — nonzero exit, none of the above.
+    * ``GENERIC_NONZERO`` — nonzero exit at or below the signal floor
+      (``1 <= returncode <= 128``), none of the above: a genuine CLI crash.
     """
     if result_event_fired:
         return None
@@ -249,6 +276,15 @@ def classify_harness_early_exit(
     # TLS WINS: only reachable here when there is NO TLS match.
     if any(tok in stderr_lc for tok in _AUTH_TOKENS):
         return HarnessExitClass.AUTH_UNAVAILABLE
+
+    # SIGNAL death wins over the init-based inferences below: a returncode
+    # above the signal floor (128 + n) is direct evidence the child was KILLED
+    # (worker restart/deploy, external reaper), not that it crashed or resumed
+    # a stale UUID. Placed before the STALE_UUID (init_seen) check so a
+    # signal-killed pre-init turn is attributed to the kill, not misread as a
+    # bad resume pointer (#2341).
+    if returncode > HARNESS_SIGNAL_EXIT_FLOOR:
+        return HarnessExitClass.SIGNAL_KILLED
 
     if not init_seen:
         return HarnessExitClass.STALE_UUID
@@ -275,9 +311,11 @@ def describe_harness_exit_for_sentry(
     BRANCH-C Sentry wiring (``agent/session_runner/harness/claude.py``) is
     unit-testable without driving the whole subprocess (issue #2219).
 
-    ``log_level`` is ``logging.WARNING`` for ``CLEAN_NO_OUTPUT`` (a benign
-    exit-0 empty turn — drops below Sentry's error threshold so it stops paging)
-    and ``logging.ERROR`` for every other class.
+    ``log_level`` is ``logging.WARNING`` for the operationally-expected classes
+    — ``CLEAN_NO_OUTPUT`` (a benign exit-0 empty turn) and ``SIGNAL_KILLED`` (a
+    worker restart/deploy or external reaper SIGTERMing the child mid-turn) —
+    which drop below Sentry's error threshold so they stop paging, and
+    ``logging.ERROR`` for every other class.
 
     ``sentry_payload`` is ``{"tags", "context", "fingerprint"}``:
 
@@ -289,7 +327,11 @@ def describe_harness_exit_for_sentry(
     * ``fingerprint`` — ``["harness-exit-no-result", str(exit_class)]`` so the
       single VALOR-2M bucket splits into one Sentry issue per exit class.
     """
-    log_level = logging.WARNING if exit_class == HarnessExitClass.CLEAN_NO_OUTPUT else logging.ERROR
+    log_level = (
+        logging.WARNING
+        if exit_class in (HarnessExitClass.CLEAN_NO_OUTPUT, HarnessExitClass.SIGNAL_KILLED)
+        else logging.ERROR
+    )
     sentry_payload = {
         "tags": {
             "harness_exit_class": str(exit_class),

--- a/docs/features/claude-child-keychain-tls-diagnostics.md
+++ b/docs/features/claude-child-keychain-tls-diagnostics.md
@@ -75,7 +75,7 @@ grep '\[harness-spawn\]' logs/worker.log | tail -1
 
 When a harness subprocess exits early (before a normal result event), the exit
 is classified by
-`claude_diagnostics.py::classify_harness_early_exit` into one of six classes,
+`claude_diagnostics.py::classify_harness_early_exit` into one of seven classes,
 checked in this order:
 
 | Class | Trigger |
@@ -83,9 +83,10 @@ checked in this order:
 | `BINARY_MISSING` | `returncode is None` (FileNotFoundError path — `claude` not on PATH). |
 | `TLS_TRUST` | stderr matches a TLS/trust token (`MissingIntermediate`, `AnchorTrusted`, `unable to get local issuer`, `self-signed certificate`, `certificate verify failed`, `tls`, …). This is the **destructive-dialog class**. |
 | `AUTH_UNAVAILABLE` | stderr matches an auth token (`invalid api key`, `authentication`, `oauth`, `401`, `unauthorized`, `credit balance`) **and not** a TLS token. |
-| `STALE_UUID` | no `system/init` seen and no TLS/auth match (a stale resume UUID) — returncode-independent, so this claims a `returncode=0` exit too. |
+| `SIGNAL_KILLED` | `returncode > HARNESS_SIGNAL_EXIT_FLOOR` (128) with no TLS/auth match (issue #2341) — the child was *killed by a signal* (POSIX `128 + n`: SIGTERM → 143, SIGKILL → 137), not crashed. Dominant cause is a worker restart/deploy SIGTERMing the process group mid-turn, or an external reaper. Checked **before** `STALE_UUID` so a signal-killed pre-init turn is attributed to the kill, not misread as a bad resume pointer; cannot collide with `CLEAN_NO_OUTPUT` (rc 0 is never `> 128`). |
+| `STALE_UUID` | no `system/init` seen and no TLS/auth/signal match (a stale resume UUID) — returncode-independent for non-signal exits, so this claims a `returncode=0` exit too. |
 | `CLEAN_NO_OUTPUT` | `returncode == 0`, `init` was seen, no TLS/auth match (issue #2219) — a benign exit-0 empty turn, not a failure. Checked **after** `STALE_UUID` so an `init_seen=False` exit-0 still classifies as the error-level `STALE_UUID`, never gets silently downgraded. |
-| `GENERIC_NONZERO` | nonzero exit, none of the above. |
+| `GENERIC_NONZERO` | nonzero exit (`1 ≤ rc ≤ 128`), none of the above — a genuine CLI crash. |
 
 ### TLS wins over auth (load-bearing precedence)
 
@@ -118,6 +119,16 @@ returncode, init_seen, stderr_snippet)` is a pure helper that returns
   removing the dominant noise source from the bucket. The caller still
   returns `text=None` and handles the empty turn exactly as before; only the
   log level and Sentry visibility change.
+- **`SIGNAL_KILLED` → `logging.WARNING` (issue #2341).** A signal death
+  (`rc > 128`) mid-turn is an operationally *expected* event — the worker
+  process group is SIGTERMed on every `/update` and `valor-service.sh restart`
+  that lands while a turn is in flight, and external reapers kill orphans.
+  Paging on it would recreate the VALOR-2M noise problem one class down, so it
+  drops below Sentry's error threshold like `CLEAN_NO_OUTPUT`. The runner
+  already degrades gracefully: `text=None` → empty turn → wrap-up guard →
+  persona-safe user message, so the human never sees a raw error. This is the
+  one real post-#2219 event (Sentry VALOR-F5, `rc=143` SIGTERM) that was
+  previously misfiled as `GENERIC_NONZERO`.
 - **Every other class → `logging.ERROR`**, emitted inside an isolated
   `sentry_sdk.new_scope()` carrying:
   - tags `harness_exit_class` (the class value) and `harness_returncode`;

--- a/tests/unit/test_claude_diagnostics.py
+++ b/tests/unit/test_claude_diagnostics.py
@@ -9,10 +9,11 @@ Covers ``agent/session_runner/harness/claude_diagnostics.py``:
 - ``trust_env_presence`` — present-with-value vs absent.
 - ``build_spawn_diagnostic`` — never leaks the prompt or any secret value.
 - ``classify_harness_early_exit`` — the full precedence ladder, including the
-  load-bearing TLS-wins-over-auth contract and the ``CLEAN_NO_OUTPUT`` exit-0
-  empty-turn branch (issue #2219).
+  load-bearing TLS-wins-over-auth contract, the ``CLEAN_NO_OUTPUT`` exit-0
+  empty-turn branch (issue #2219), and the ``SIGNAL_KILLED`` rc>128 branch for
+  worker-restart/reaper kills (issue #2341).
 - ``describe_harness_exit_for_sentry`` — per-class log level + Sentry-scope
-  payload (tags/context/fingerprint) used by BRANCH C (issue #2219).
+  payload (tags/context/fingerprint) used by BRANCH C (issues #2219, #2341).
 - ``HARNESS_TLS_CONSECUTIVE_SUPPRESS`` — int default 2.
 
 All classification is synthetic — no live TLS failure, no network, no Keychain.
@@ -25,6 +26,7 @@ import json
 import logging
 
 from agent.session_runner.harness.claude_diagnostics import (
+    HARNESS_SIGNAL_EXIT_FLOOR,
     HARNESS_TLS_CONSECUTIVE_SUPPRESS,
     HarnessExitClass,
     build_spawn_diagnostic,
@@ -333,6 +335,78 @@ class TestClassifyHarnessEarlyExit:
             == HarnessExitClass.STALE_UUID
         )
 
+    def test_sigterm_rc143_is_signal_killed(self):
+        """rc=143 (128+SIGTERM) with init seen → SIGNAL_KILLED, not GENERIC (#2341).
+
+        This is the observed post-#2219 case (Sentry VALOR-F5): a worker
+        restart/deploy SIGTERMs the process group mid-turn.
+        """
+        assert (
+            classify_harness_early_exit(
+                returncode=143,
+                stderr_snippet="",
+                init_seen=True,
+                result_event_fired=False,
+            )
+            == HarnessExitClass.SIGNAL_KILLED
+        )
+
+    def test_sigkill_rc137_is_signal_killed(self):
+        """rc=137 (128+SIGKILL) → SIGNAL_KILLED (OOM / teardown reap) (#2341)."""
+        assert (
+            classify_harness_early_exit(
+                returncode=137,
+                stderr_snippet=None,
+                init_seen=True,
+                result_event_fired=False,
+            )
+            == HarnessExitClass.SIGNAL_KILLED
+        )
+
+    def test_signal_killed_wins_over_stale_uuid_before_init(self):
+        """rc>128 with init NOT seen is a kill, not a stale UUID (#2341).
+
+        The returncode is direct evidence of a signal, so SIGNAL_KILLED is
+        checked before the init-based STALE_UUID inference.
+        """
+        assert (
+            classify_harness_early_exit(
+                returncode=143,
+                stderr_snippet="",
+                init_seen=False,
+                result_event_fired=False,
+            )
+            == HarnessExitClass.SIGNAL_KILLED
+        )
+
+    def test_tls_wins_over_signal_kill(self):
+        """A TLS token in stderr keeps first claim even on a signal exit (#2341).
+
+        TLS-wins is load-bearing (destructive-dialog class): if the child hit a
+        TLS failure and was then killed, the TLS cause is the one to surface.
+        """
+        assert (
+            classify_harness_early_exit(
+                returncode=143,
+                stderr_snippet="certificate verify failed",
+                init_seen=True,
+                result_event_fired=False,
+            )
+            == HarnessExitClass.TLS_TRUST
+        )
+
+    def test_low_nonzero_stays_generic_not_signal(self):
+        """rc=2 (a genuine crash, not > 128) stays GENERIC_NONZERO (#2341)."""
+        assert (
+            classify_harness_early_exit(
+                returncode=2,
+                stderr_snippet="some unrelated crash",
+                init_seen=True,
+                result_event_fired=False,
+            )
+            == HarnessExitClass.GENERIC_NONZERO
+        )
+
 
 # --- module constant ----------------------------------------------------------
 
@@ -340,6 +414,11 @@ class TestClassifyHarnessEarlyExit:
 def test_tls_consecutive_suppress_default_is_int_2():
     assert isinstance(HARNESS_TLS_CONSECUTIVE_SUPPRESS, int)
     assert HARNESS_TLS_CONSECUTIVE_SUPPRESS == 2
+
+
+def test_signal_exit_floor_default_is_int_128():
+    assert isinstance(HARNESS_SIGNAL_EXIT_FLOOR, int)
+    assert HARNESS_SIGNAL_EXIT_FLOOR == 128
 
 
 # --- stripped_harness_env (env-strip lives with the harness, asserted here too)
@@ -366,13 +445,18 @@ def test_stripped_harness_env_pops_all_three_anthropic_vars():
 
 # --- describe_harness_exit_for_sentry -----------------------------------------
 
-# Every non-CLEAN class BRANCH C can carry into the helper (all stay error-level).
+# Classes BRANCH C carries into the helper that stay error-level. CLEAN_NO_OUTPUT
+# and SIGNAL_KILLED are the operationally-expected WARNING-level classes.
 _ERROR_LEVEL_CLASSES = [
     HarnessExitClass.BINARY_MISSING,
     HarnessExitClass.AUTH_UNAVAILABLE,
     HarnessExitClass.TLS_TRUST,
     HarnessExitClass.STALE_UUID,
     HarnessExitClass.GENERIC_NONZERO,
+]
+_WARNING_LEVEL_CLASSES = [
+    HarnessExitClass.CLEAN_NO_OUTPUT,
+    HarnessExitClass.SIGNAL_KILLED,
 ]
 
 
@@ -383,6 +467,16 @@ class TestDescribeHarnessExitForSentry:
             returncode=0,
             init_seen=True,
             stderr_snippet=None,
+        )
+        assert level == logging.WARNING
+
+    def test_signal_killed_is_warning_level(self):
+        """SIGNAL_KILLED (worker restart / reaper) drops below Sentry error (#2341)."""
+        level, _payload = describe_harness_exit_for_sentry(
+            HarnessExitClass.SIGNAL_KILLED,
+            returncode=143,
+            init_seen=True,
+            stderr_snippet="",
         )
         assert level == logging.WARNING
 
@@ -415,7 +509,7 @@ class TestDescribeHarnessExitForSentry:
     def test_fingerprint_is_per_class(self):
         """Each class fingerprints distinctly so the bucket splits per cause."""
         seen = set()
-        for exit_class in [*_ERROR_LEVEL_CLASSES, HarnessExitClass.CLEAN_NO_OUTPUT]:
+        for exit_class in [*_ERROR_LEVEL_CLASSES, *_WARNING_LEVEL_CLASSES]:
             _level, payload = describe_harness_exit_for_sentry(
                 exit_class, returncode=1, init_seen=True, stderr_snippet=None
             )


### PR DESCRIPTION
Closes #2341.

## What VALOR-2M actually was
The over-broad Sentry bucket "Harness exited without a result event and no accumulated text" (685 events) was already split by exit class in **#2219 / PR #2338** (merged 2026-07-24 11:45Z). Verified live:

- **VALOR-2M is frozen.** `count` still 685, `lastSeen` still `2026-07-24T11:22:41Z` — 23 min *before* the split merged, and zero new events in the 3 days since. Status is already `ignored / archived_forever`. The dominant benign contributor (`CLEAN_NO_OUTPUT`) now logs at WARNING, below Sentry's error threshold.

## The residual bug this PR fixes
The one real post-fix event — **Sentry VALOR-F5** — routed to the new per-class fingerprint but with the **wrong class**: `harness_exit_class=generic_nonzero`, `returncode=143`, `init_seen=true`, empty stderr.

`rc=143` is `128 + 15` = **SIGTERM**. The subprocess was *killed*, not crashed. This is exactly the team's "subprocess was killed (OOM, timeout, external reaper)" case — the dominant cause being a **worker restart/deploy** (`/update`, `valor-service.sh restart`) SIGTERMing the process group while a turn is in flight. `GENERIC_NONZERO` is meant for genuine CLI crashes, so this was both inaccurate and paging at ERROR for an operationally expected event.

## Fix — ours vs external
This is an **external** (or self-inflicted-restart) kill, not a harness fault. Per the "graceful degradation + accurate message" posture:

- New `SIGNAL_KILLED` `HarnessExitClass` for `returncode > HARNESS_SIGNAL_EXIT_FLOOR` (128; POSIX `128+n`), checked **before** the init-based `STALE_UUID`/`GENERIC_NONZERO` inferences (the returncode is direct evidence of a signal) but **after** TLS/auth (TLS-wins precedence stays load-bearing).
- Maps to `logging.WARNING` (below Sentry's error threshold, like `CLEAN_NO_OUTPUT`) with its own per-class fingerprint `["harness-exit-no-result", "signal_killed"]`.
- `HARNESS_SIGNAL_EXIT_FLOOR`: named, env-overridable, provisional (default 128).
- BRANCH-C WARNING log line is now class-aware.

**No session-finalization behavior changes.** The runner still returns `text=None`; the empty turn flows `EMPTY_OUTPUT → PM_EMPTY_TURN → wrap-up guard`, which delivers a persona-safe message ("I wasn't able to produce a response to this. Please rephrase or follow up.") — the human never sees a raw error.

## What the human sees when it happens
Unchanged and in-persona: the wrap-up guard's persona-safe message. This PR only changes Sentry attribution/level (accurate class, no false ERROR page).

## Tests
`tests/unit/test_claude_diagnostics.py` — new cases for rc=143/137 SIGNAL_KILLED, precedence (signal wins over STALE_UUID; TLS wins over signal; rc≤128 stays GENERIC_NONZERO), WARNING level, and the floor constant. 39 passed.

## Not done
No blanket retry added (explicitly avoided). This is precise attribution, not a retry.