### PR TITLE
Email bridge: symmetric launchd teardown + runtime coexistence (#1338)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,8 @@ gws sheets spreadsheets values get --params '{"spreadsheetId": "ID", "range": "S
 | `./scripts/valor-service.sh email-stop` | Stop the email bridge |
 | `./scripts/valor-service.sh email-restart` | Restart the email bridge |
 | `./scripts/valor-service.sh email-status` | Check email bridge status, IMAP last-poll age, and SMTP relay heartbeat |
+| `./scripts/valor-service.sh email-disable` | Stop the email bridge **and** disable launchd auto-respawn (stays down until `email-enable`/`email-start`) |
+| `./scripts/valor-service.sh email-enable` | Re-enable launchd auto-respawn for the email bridge (does NOT start it; pair with `email-start`) |
 | `./scripts/valor-service.sh email-dead-letter list` | List failed SMTP sends in dead-letter queue |
 | `./scripts/valor-service.sh email-dead-letter replay --all` | Replay all dead-lettered emails |
 | `./scripts/install_email_bridge.sh` | Install launchd plist for boot-time email bridge (machine-gated, idempotent; opt-in) |

--- a/docs/features/email-bridge.md
+++ b/docs/features/email-bridge.md
@@ -272,6 +272,19 @@ Key behaviors:
 
 Operators who don't run the installer keep using `valor-service.sh email-start` exactly as before — boot-time auto-start is opt-in.
 
+#### Runtime coexistence: launchd vs. `email-start` (#1338)
+
+Once the launchd plist is installed with `KeepAlive=true`, a bare `valor-service.sh email-start` (which spawns via `nohup`) would create a **second** IMAP poller running alongside the launchd-managed one — duplicate polling and kill-respawn races. `valor-service.sh` therefore mirrors the worker's transient-vs-permanent stop pattern:
+
+| Command | Behavior when the launchd plist is installed |
+|---------|----------------------------------------------|
+| `email-start` | Detects the installed plist and routes the start **through launchd** (`launchctl enable` + `bootstrap`/`kickstart`) instead of spawning a second `nohup` process. Falls back to `nohup` only when no plist is installed. |
+| `email-stop` | Transient: `launchctl bootout` unloads the job, but `KeepAlive=true` means launchd may respawn it. |
+| `email-disable` | Permanent: `launchctl disable` + `bootout` (with a PID-kill fallback). The bridge stays down across the respawn timer until re-enabled. |
+| `email-enable` | Re-enables launchd auto-respawn **without** starting the bridge. Pair with `email-start` to actually start it. |
+
+This matches `worker-stop`/`worker-disable`/`worker-enable` exactly. There is no separate `uninstall_email_bridge.sh`; `email-disable` is the symmetric teardown (the worker sibling has no uninstaller script either).
+
 ## Health Monitoring
 
 After each successful IMAP poll, the bridge writes the current timestamp to:

--- a/scripts/valor-service.sh
+++ b/scripts/valor-service.sh
@@ -57,6 +57,8 @@ WATCHDOG_PLIST_NAME="${SERVICE_LABEL_PREFIX}.bridge-watchdog"
 WATCHDOG_PLIST_PATH="$HOME/Library/LaunchAgents/${WATCHDOG_PLIST_NAME}.plist"
 WORKER_PLIST_NAME="${SERVICE_LABEL_PREFIX}.worker"
 WORKER_PLIST_PATH="$HOME/Library/LaunchAgents/${WORKER_PLIST_NAME}.plist"
+EMAIL_PLIST_NAME="${SERVICE_LABEL_PREFIX}.email-bridge"
+EMAIL_PLIST_PATH="$HOME/Library/LaunchAgents/${EMAIL_PLIST_NAME}.plist"
 LOG_DIR="$PROJECT_DIR/logs"
 PID_FILE="$PROJECT_DIR/data/bridge.pid"
 
@@ -92,6 +94,8 @@ usage() {
     echo "  email-stop      Stop the email bridge"
     echo "  email-restart   Restart the email bridge"
     echo "  email-status    Check email bridge status and last poll age"
+    echo "  email-disable   Stop the email bridge AND disable launchd auto-respawn (stays down)"
+    echo "  email-enable    Re-enable launchd auto-respawn (does NOT start the bridge)"
     echo "  email-dead-letter list    List failed SMTP sends"
     echo "  email-dead-letter replay --all    Replay all dead-lettered emails"
     echo "  email-dead-letter replay --session-id <id>    Replay one email"
@@ -1051,12 +1055,42 @@ is_email_running() {
     [ -n "$pid" ]
 }
 
+is_email_launchd_loaded() {
+    launchctl list "$EMAIL_PLIST_NAME" &>/dev/null
+}
+
 start_email() {
     echo "Starting email bridge..."
 
     if is_email_running; then
         local pid=$(get_email_pid)
         echo "Email bridge is already running (PID: $pid)"
+        return 0
+    fi
+
+    # Runtime coexistence (#1338): when a boot-time launchd plist is installed
+    # (via install_email_bridge.sh), route the start through launchd instead of
+    # spawning a second nohup process. Two owners = duplicate IMAP polling and
+    # kill-respawn races. Mirror worker-start: `launchctl enable` is idempotent
+    # and undoes a prior email-disable, then bootstrap (or kickstart if already
+    # loaded) so the KeepAlive/watchdog recovery chain is registered.
+    if [ -f "$EMAIL_PLIST_PATH" ]; then
+        launchctl enable "gui/$(id -u)/$EMAIL_PLIST_NAME" 2>/dev/null || true
+        if ! is_email_launchd_loaded; then
+            launchctl bootout "gui/$(id -u)/$EMAIL_PLIST_NAME" 2>/dev/null || true
+            launchctl_bootstrap_fail_soft "gui/$(id -u)" "$EMAIL_PLIST_PATH" "$EMAIL_PLIST_NAME" verify-pid \
+                || echo "WARNING: email-start: continuing despite bootstrap failure for $EMAIL_PLIST_NAME" >&2
+        else
+            launchctl kickstart "gui/$(id -u)/$EMAIL_PLIST_NAME"
+        fi
+        sleep 2
+        if is_email_running; then
+            local pid=$(get_email_pid)
+            echo "Email bridge started via launchd (PID: $pid)"
+        else
+            echo "Failed to start email bridge via launchd. Check logs: $LOG_DIR/email_bridge.error.log"
+            return 1
+        fi
         return 0
     fi
 
@@ -1077,6 +1111,19 @@ start_email() {
 }
 
 stop_email() {
+    # Transient stop, mirroring worker-stop: if launchd owns the job, `bootout`
+    # unloads it — but KeepAlive=true means launchd may respawn it. To keep the
+    # email bridge down across the respawn timer, use `email-disable`.
+    if is_email_launchd_loaded; then
+        echo "Stopping email bridge (via launchd)..."
+        launchctl bootout "gui/$(id -u)/$EMAIL_PLIST_NAME" 2>/dev/null || true
+        sleep 2
+        if ! is_email_running; then
+            echo "Email bridge stopped (via launchd; may respawn if KeepAlive — use email-disable to keep it down)"
+            return 0
+        fi
+    fi
+
     local pid=$(get_email_pid)
 
     if [ -z "$pid" ]; then
@@ -1105,6 +1152,43 @@ restart_email() {
     stop_email
     sleep 1
     start_email
+}
+
+disable_email() {
+    # Symmetric teardown for the boot-time installer (#1338), mirroring
+    # disable_worker. `bootout` alone does NOT stick when the plist has
+    # KeepAlive=true; pairing it with `launchctl disable` makes the disabled
+    # state survive the respawn timer until `email-enable` or `email-start`
+    # re-enables it.
+    echo "Disabling email bridge (launchd will not respawn)..."
+    launchctl disable "gui/$(id -u)/$EMAIL_PLIST_NAME" 2>/dev/null || true
+    launchctl bootout "gui/$(id -u)/$EMAIL_PLIST_NAME" 2>/dev/null || true
+    sleep 2
+
+    if is_email_running; then
+        # bootout failed or a foreground (nohup) bridge is running — fall back
+        # to PID kill so the operator's intent is honored.
+        local pid=$(get_email_pid)
+        echo "Email bridge still running after bootout; killing PID $pid..."
+        kill "$pid" 2>/dev/null || true
+        for i in {1..10}; do
+            if ! is_email_running; then break; fi
+            sleep 1
+        done
+        if is_email_running; then
+            kill -9 "$pid" 2>/dev/null || true
+        fi
+    fi
+    echo "Email bridge stopped and launchd auto-respawn disabled. Run email-start or email-enable to re-enable."
+}
+
+enable_email() {
+    # Re-enable launchd auto-respawn without starting the bridge (#1338),
+    # mirroring enable_worker. Pairs with a follow-up `email-start` if you want
+    # the bridge actually running. Idempotent.
+    echo "Re-enabling launchd auto-respawn for email bridge..."
+    launchctl enable "gui/$(id -u)/$EMAIL_PLIST_NAME" 2>/dev/null || true
+    echo "Email bridge launchd entry enabled. Run email-start to actually start the bridge."
 }
 
 status_email() {
@@ -1222,6 +1306,12 @@ case "${1:-}" in
         ;;
     email-status)
         status_email
+        ;;
+    email-disable)
+        disable_email
+        ;;
+    email-enable)
+        enable_email
         ;;
     email-dead-letter)
         shift

--- a/tests/unit/test_valor_service_bootstrap.py
+++ b/tests/unit/test_valor_service_bootstrap.py
@@ -138,6 +138,26 @@ if [ -n "${PGREP_BRIDGE_FOUND:-}" ]; then
         esac
     done
 fi
+# Env-gated (#1338 email-start-via-launchd test): report the email bridge as
+# running ONLY after launchd has bootstrapped it (a prior email-bridge bootstrap
+# is in the call log). This mirrors reality — the bridge is not running before
+# start_email routes through launchd — so start_email's early is_email_running
+# short-circuit does not fire, but its post-bootstrap probe succeeds. Existing
+# tests never set PGREP_EMAIL_FOUND, so their behavior is unchanged.
+_email_booted=""
+if [ -n "${PGREP_EMAIL_FOUND:-}" ]; then
+    grep -q "bootstrap.*email-bridge" "$CALL_LOG" 2>/dev/null && _email_booted=1
+fi
+if [ -n "$_email_booted" ]; then
+    for a in "$@"; do
+        case "$a" in
+            *email_bridge*)
+                echo 77777
+                exit 0
+                ;;
+        esac
+    done
+fi
 for a in "$@"; do
     case "$a" in
         *worker*)
@@ -546,4 +566,64 @@ def test_restart_webui_cold_start_succeeds(webui_harness):
     assert f"Web UI restarted (PID: {FAKE_NEW_PID})" in result.stdout
     assert "ADVISORY" not in result.stderr, result.stderr
     assert "WARNING: Web UI restart failed" not in result.stderr, result.stderr
+    assert result.returncode == 0
+
+
+# === email runtime coexistence: email-disable/enable + launchd-aware start/stop (#1338) ===
+
+
+def _seed_email_plist(harness: Harness) -> None:
+    (harness.agents_dir / "com.valor.email-bridge.plist").write_text("<plist/>\n")
+
+
+def _email_launchctl_calls(harness: Harness) -> list[str]:
+    """launchctl calls that target the email-bridge label."""
+    return [line for line in harness.launchctl_calls() if "email-bridge" in line]
+
+
+def test_email_disable_disables_and_bootouts(harness):
+    # email-disable is the symmetric teardown: launchctl disable + bootout so the
+    # KeepAlive=true job stays down. pgrep reports the email bridge not running,
+    # so no PID-kill fallback fires.
+    result = harness.run("email-disable")
+    email_calls = _email_launchctl_calls(harness)
+    assert any(line.startswith("LAUNCHCTL disable") for line in email_calls), harness.calls()
+    assert any(line.startswith("LAUNCHCTL bootout") for line in email_calls), harness.calls()
+    assert "auto-respawn disabled" in result.stdout, result.stdout
+    assert result.returncode == 0
+
+
+def test_email_enable_enables_only(harness):
+    # email-enable re-arms launchd auto-respawn WITHOUT starting the bridge: it
+    # calls `launchctl enable` and must NOT bootout/disable/bootstrap.
+    result = harness.run("email-enable")
+    email_calls = _email_launchctl_calls(harness)
+    assert any(line.startswith("LAUNCHCTL enable") for line in email_calls), harness.calls()
+    assert not any(line.startswith("LAUNCHCTL bootout") for line in email_calls), harness.calls()
+    assert not any(line.startswith("LAUNCHCTL disable") for line in email_calls), harness.calls()
+    assert not any("bootstrap" in line for line in email_calls), harness.calls()
+    assert "Run email-start" in result.stdout, result.stdout
+    assert result.returncode == 0
+
+
+def test_email_start_routes_through_launchd_when_plist_installed(harness):
+    # With the boot-time plist installed, email-start must NOT spawn a second
+    # nohup process — it routes through launchd (enable + bootstrap, since the
+    # list probe reports the label not loaded) so there's a single owner.
+    _seed_email_plist(harness)
+    result = harness.run("email-start", extra_env={"PGREP_EMAIL_FOUND": "1"})
+    email_calls = _email_launchctl_calls(harness)
+    assert any(line.startswith("LAUNCHCTL enable") for line in email_calls), harness.calls()
+    assert any("bootstrap " in line for line in email_calls), harness.calls()
+    assert "started via launchd" in result.stdout, result.stdout
+    assert result.returncode == 0
+
+
+def test_email_stop_transient_bootout_when_launchd_loaded(harness):
+    # email-stop is transient: when launchd owns the job it bootouts (KeepAlive
+    # may respawn) and points the operator at email-disable for a durable stop.
+    result = harness.run("email-stop", extra_env={"LAUNCHCTL_LIST_LOADED": "1"})
+    email_calls = _email_launchctl_calls(harness)
+    assert any(line.startswith("LAUNCHCTL bootout") for line in email_calls), harness.calls()
+    assert "use email-disable to keep it down" in result.stdout, result.stdout
     assert result.returncode == 0


### PR DESCRIPTION
Closes #1338.

## Audit result

Audited all six required components against `main`. Five were already shipped (PR #1339 + hardening #2021, #2104/#2109); only component 3 was a genuine gap. Full evidence table posted as an [issue comment](https://github.com/tomcounsell/ai/issues/1338#issuecomment-5087016148).

| # | Component | Status |
|---|-----------|--------|
| 1 | `com.valor.email-bridge.plist` (KeepAlive/RunAtLoad/VALOR_LAUNCHD) | shipped |
| 2 | `scripts/install_email_bridge.sh` (machine-gate, config copy, dotenv inject, plutil, set -euo) | shipped |
| 3 | Symmetric teardown (`email-disable`/`email-enable` + launchd-aware start/stop) | **this PR** |
| 4 | `email_bridge.py::main` VALOR_LAUNCHD gate on `load_dotenv` | shipped |
| 5 | `test_main_skips_dotenv_under_launchd` | shipped |
| 6 | Docs subsection + CLAUDE.md row | shipped |

## What this PR adds

Closes the component-3 gap in `scripts/valor-service.sh`, mirroring the worker's transient-vs-permanent stop pattern:

- **`email-disable`** — `launchctl disable` + `bootout` (PID-kill fallback) so the `KeepAlive=true` job stays down until re-enabled.
- **`email-enable`** — re-arm launchd auto-respawn without starting the bridge.
- **`email-start`** — when the boot-time plist is installed, route through launchd (enable + bootstrap/kickstart) instead of spawning a second `nohup` process. This is the fix for the runtime-coexistence risk the issue flagged: two owners = duplicate IMAP polling and kill-respawn races.
- **`email-stop`** — transient `bootout` when launchd owns the job; points the operator at `email-disable` for a durable stop.

No separate `uninstall_email_bridge.sh`: `email-disable` is the symmetric teardown, matching the worker sibling (no uninstaller script there either).

## Testing

4 shell-level tests added to `tests/unit/test_valor_service_bootstrap.py`, running the real script against the sandboxed `launchctl`/`pgrep` stubs. Full file (98 tests incl. `test_email_bridge.py`) passes. The five shipped components were not touched.