### PR TITLE
tool-budget: emit per-deny denied_calls counter for denial-distribution observability (#1886)

### DIFF
--- a/agent/tool_budget.py
+++ b/agent/tool_budget.py
@@ -177,7 +177,12 @@ def record_resolution_error(project_key: str, err: object, *, surface: str = "ho
 def record_budget_trip(session, verdict: BudgetVerdict) -> None:
     """Fail-quiet deny surfacing — the caller's inline block proceeds regardless.
 
-    On EVERY deny (default included), once per session (dedup ``SET NX``):
+    On EVERY deny (default included), unconditionally increment
+    ``{project_key}:tool-budget:denied_calls`` (issue #1886 — observability for
+    the deferred deny-but-don't-halt decision; counts every wasted round-trip,
+    NOT deduped per session).
+
+    Then, once per session (dedup ``SET NX``):
     increment ``{project_key}:tool-budget:tripped``, log a WARNING, and set the
     race-free hook-owned ``budget_tripped`` + ``budget_tripped_reason`` fields
     (a FIELD write, NEVER a ``status`` write — a hook-driven status write would
@@ -195,6 +200,23 @@ def record_budget_trip(session, verdict: BudgetVerdict) -> None:
     try:
         project_key = _project_key(session)
         from popoto.redis_db import POPOTO_REDIS_DB
+
+        # #1886 (from #1873 item 4): count EVERY deny — BEFORE the per-session
+        # dedup gate below — so the round-trips-per-denied-session distribution
+        # becomes observable. With ``TOOL_BUDGET_AUTO_PAUSE`` off (the shipped
+        # default) a denied session keeps metering one harness round-trip per
+        # denied tool call until max-turns; ``denied_calls`` counts those wasted
+        # round-trips while ``:tripped`` (post-dedup, below) counts DISTINCT
+        # denied sessions, so ``denied_calls / tripped`` is the mean burned
+        # round-trips per denied session — the number the deferred
+        # deny-but-don't-halt decision hinges on. Its own isolated try/except
+        # (mirroring the ``:tripped`` INCR) keeps a Redis blip on this counter
+        # from swallowing the dedup-key write, the WARNING log, the
+        # ``budget_tripped`` flag, or the auto-pause side effects.
+        try:
+            POPOTO_REDIS_DB.incr(f"{project_key}:tool-budget:denied_calls")
+        except Exception as e:
+            logger.warning("[tool-budget] failed to increment denied_calls counter: %s", e)
 
         # Dedup the SIDE EFFECTS (not the block) to once per session.
         # #1873 item 3: an id-less session (no session_id AND no agent_session_id)

--- a/tests/unit/test_tool_budget.py
+++ b/tests/unit/test_tool_budget.py
@@ -69,3 +69,96 @@ def test_verdict_dataclass_shape():
     v = BudgetVerdict(allow=False, reason="x")
     assert (v.allow, v.reason) == (False, "x")
     assert BudgetVerdict(allow=True).reason is None
+
+
+class _FakeRedis:
+    """Minimal Redis double for ``record_budget_trip`` side effects.
+
+    Records ``incr`` totals per key and implements ``set(nx=...)`` dedup
+    semantics (returns truthy only the first time a key is set) so the
+    per-session dedup gate behaves as in production.
+    """
+
+    def __init__(self):
+        self.counters: dict[str, int] = {}
+        self._keys: set[str] = set()
+
+    def incr(self, key):
+        self.counters[key] = self.counters.get(key, 0) + 1
+        return self.counters[key]
+
+    def set(self, key, value, nx=False, ex=None):
+        if nx and key in self._keys:
+            return None
+        self._keys.add(key)
+        return True
+
+    # never reached in these tests, but keep the surface honest
+    def rpush(self, *a, **k):  # pragma: no cover
+        return 1
+
+    def expire(self, *a, **k):  # pragma: no cover
+        return True
+
+
+class _FakeSession:
+    def __init__(self, session_id):
+        self.session_id = session_id
+        self.project_key = "testproj"
+        self.tool_call_count = 999
+
+    def save(self, **kwargs):  # budget_tripped flag write; no-op here
+        return None
+
+
+@pytest.fixture
+def _fake_redis(monkeypatch):
+    fake = _FakeRedis()
+    import popoto.redis_db as redis_db
+
+    monkeypatch.setattr(redis_db, "POPOTO_REDIS_DB", fake)
+    return fake
+
+
+def test_denied_calls_counts_every_deny_tripped_dedups_per_session(_fake_redis):
+    """#1886: ``denied_calls`` increments on EVERY deny (before the per-session
+    dedup gate); ``tripped`` increments once per session.
+
+    Two denies for the same session ⇒ denied_calls == 2 but tripped == 1 — the
+    exact ratio (mean wasted round-trips per denied session) the deferred
+    deny-but-don't-halt decision depends on.
+    """
+    session = _FakeSession("sess-A")
+    verdict = BudgetVerdict(allow=False, reason="per-session tool-call budget reached (999/1000)")
+
+    tool_budget.record_budget_trip(session, verdict)
+    tool_budget.record_budget_trip(session, verdict)
+
+    assert _fake_redis.counters.get("testproj:tool-budget:denied_calls") == 2
+    assert _fake_redis.counters.get("testproj:tool-budget:tripped") == 1
+
+
+def test_denied_calls_counts_across_distinct_sessions(_fake_redis):
+    """Distinct sessions each count once toward both counters."""
+    verdict = BudgetVerdict(allow=False, reason="per-session cost cap reached ($50.00/$50.00)")
+
+    tool_budget.record_budget_trip(_FakeSession("sess-A"), verdict)
+    tool_budget.record_budget_trip(_FakeSession("sess-B"), verdict)
+
+    assert _fake_redis.counters.get("testproj:tool-budget:denied_calls") == 2
+    assert _fake_redis.counters.get("testproj:tool-budget:tripped") == 2
+
+
+def test_denied_calls_counts_id_less_sessions_without_dedup_key(_fake_redis):
+    """An id-less session bypasses the NX dedup gate (issue #1873 item 3) — its
+    denies must still be counted on every call, never collapsed into a shared
+    ``:None`` slot."""
+    verdict = BudgetVerdict(allow=False, reason="per-session tool-call budget reached (999/1000)")
+    idless = SimpleNamespace(project_key="testproj", tool_call_count=999, save=lambda **k: None)
+
+    tool_budget.record_budget_trip(idless, verdict)
+    tool_budget.record_budget_trip(idless, verdict)
+
+    assert _fake_redis.counters.get("testproj:tool-budget:denied_calls") == 2
+    # id-less path bypasses the dedup gate, so tripped counts every deny too
+    assert _fake_redis.counters.get("testproj:tool-budget:tripped") == 2

--- a/ui/app.py
+++ b/ui/app.py
@@ -396,7 +396,8 @@ def create_app() -> FastAPI:
         occupancy (``permits_free``/``held`` from ``worker:slot:leases:{host}``), the
         recovery counters (``bridge_reclaims``, ``loop_wedged_detected``,
         ``bridge_contract_stale``), the Fix #6 budget counters
-        (``tool_budget_tripped``, ``tool_budget_resolution_errors``), and the last few
+        (``tool_budget_tripped``, the #1886 per-deny ``tool_budget_denied_calls``,
+        ``tool_budget_resolution_errors``), and the last few
         ``worker:watchdog:actions`` entries. Fail-quiet — never blocks the health
         payload; every field defaults to a safe zero/None on any Redis error.
         """
@@ -407,6 +408,7 @@ def create_app() -> FastAPI:
             "loop_wedged_detected": 0,
             "bridge_contract_stale": 0,
             "tool_budget_tripped": 0,
+            "tool_budget_denied_calls": 0,
             "tool_budget_resolution_errors": 0,
             "recent_actions": [],
         }
@@ -441,6 +443,7 @@ def create_app() -> FastAPI:
 
             result["bridge_reclaims"] = _sum_project_counter("session-health:bridge_reclaims")
             result["tool_budget_tripped"] = _sum_project_counter("tool-budget:tripped")
+            result["tool_budget_denied_calls"] = _sum_project_counter("tool-budget:denied_calls")
             result["tool_budget_resolution_errors"] = _sum_project_counter(
                 "tool-budget:resolution_errors"
             )
@@ -821,6 +824,7 @@ def create_app() -> FastAPI:
                     "worker_loop_wedged_detected": worker.get("loop_wedged_detected"),
                     "worker_bridge_contract_stale": worker.get("bridge_contract_stale"),
                     "worker_tool_budget_tripped": worker.get("tool_budget_tripped"),
+                    "worker_tool_budget_denied_calls": worker.get("tool_budget_denied_calls"),
                     "worker_tool_budget_resolution_errors": worker.get(
                         "tool_budget_resolution_errors"
                     ),
@@ -888,6 +892,7 @@ def create_app() -> FastAPI:
                 "worker_loop_wedged_detected": worker.get("loop_wedged_detected"),
                 "worker_bridge_contract_stale": worker.get("bridge_contract_stale"),
                 "worker_tool_budget_tripped": worker.get("tool_budget_tripped"),
+                "worker_tool_budget_denied_calls": worker.get("tool_budget_denied_calls"),
                 "worker_tool_budget_resolution_errors": worker.get("tool_budget_resolution_errors"),
                 # Additive-only (issue #1828): out-of-process reflection scheduler.
                 "reflection_scheduler": reflection_scheduler["status"],


### PR DESCRIPTION
## What & why

Closes the actionable half of #1886.

#1886 asks someone to revisit the `TOOL_BUDGET_AUTO_PAUSE` deny-but-don't-halt default **"after observing live denial distributions."** But the instrumentation to observe those distributions did not exist. The existing `{project_key}:tool-budget:tripped` INCR fires **once per session** (post-dedup): it answers *"did any denial happen"* but not *"how many round-trips did a denied session burn before max-turns."* So the issue as written was unactionable — nobody could make the decision it requests.

This PR **inverts the issue**: build the observability now, leave the decision (and the default) untouched until data exists.

## Changes

- **`agent/tool_budget.py`** — increment `{project_key}:tool-budget:denied_calls` on **every** deny, **before** the per-session dedup gate, so it counts every wasted round-trip. `denied_calls / tripped` (tripped = distinct denied sessions) is the mean burned round-trips per denied session — the number the deferred decision hinges on. The INCR carries its **own isolated inner `try/except`** (mirroring the `:tripped` INCR) so a Redis blip on it cannot swallow the dedup-key write, WARNING log, `budget_tripped` flag, or the auto-pause side effects.
- **`ui/app.py`** — surface `tool_budget_denied_calls` on the dashboard `worker` block + `/health` payload, alongside the existing `tripped` / `resolution_errors` counters (the established operator surface for these metrics — no new surface invented).
- **`tests/unit/test_tool_budget.py`** — assert `denied_calls` counts every deny while `tripped` dedups per session (2 denies same session → `denied_calls==2`, `tripped==1`), across distinct sessions, and for id-less sessions that bypass the dedup gate.

## Deliberately NOT changed

The `TOOL_BUDGET_AUTO_PAUSE` deny-but-don't-halt **default is unchanged**. Flipping it now would be guessing while claiming to be evidence-driven — the exact thing #1886 defers until data exists. That decision stays blocked on the data this counter now produces.

## Observability, no behavior change

Additive counter + dashboard field only. No change to allow/deny verdicts, dedup, or auto-pause side effects.

## Test
`scripts/pytest-clean.sh tests/unit/test_tool_budget.py -n0` → 14 passed. ruff format + check clean.

---

Closes #1886 (the instrumentation half).

Step 2 — the actual deny-but-don't-halt **decision**, now data-gated on the counter this PR ships — is tracked in **#2410** (do not action before the read window: ~1 week or `tripped >= 10`).