### PR TITLE
Read-the-room: react instead of late-reply on stale group mentions (#2199)

### DIFF
--- a/agent/output_handler.py
+++ b/agent/output_handler.py
@@ -777,21 +777,22 @@ class TelegramRelayOutputHandler:
                         if self._file_handler is not None:
                             await self._file_handler.send(chat_id, text, 0, session)
                         return DeliveryOutcome.suppressed_redundant
-                    if reply_to_msg_id is not None:
-                        self._rtr_queue_reaction(
-                            chat_id, reply_to_msg_id, _REDUND_EMOJI, session_id
-                        )
+                    # React on the reply anchor if present, else on the
+                    # triggering message (#2199) — same no-anchor contract as
+                    # the RTR suppress branch below, kept uniform.
+                    _redund_target = reply_to_msg_id or self._trigger_reaction_target(session)
+                    if _redund_target is not None:
+                        self._rtr_queue_reaction(chat_id, _redund_target, _REDUND_EMOJI, session_id)
                         if self._file_handler is not None:
-                            await self._file_handler.send(chat_id, text, reply_to_msg_id, session)
+                            await self._file_handler.send(chat_id, text, _redund_target, session)
                         return DeliveryOutcome.suppressed_redundant
-                    # No anchor for the reaction — fall through and send.
-                    # Mirrors RTR's no-anchor contract (lines 437-443 below).
+                    # No reaction target at all — fall through and send.
                     self._rtr_emit_event(
                         session,
                         "drafter.suppress_fallthrough",
                         chat_id=chat_id,
                         draft_text=delivery_text,
-                        reason="no_reply_anchor",
+                        reason="no_reaction_target",
                     )
         except Exception as _redund_err:
             logger.warning(
@@ -836,14 +837,19 @@ class TelegramRelayOutputHandler:
                         if self._file_handler is not None:
                             await self._file_handler.send(chat_id, text, 0, session)
                         return DeliveryOutcome.suppressed_rtr
-                    if reply_to_msg_id is not None:
+                    # #2199: react on the reply anchor if present, else on the
+                    # triggering message id. An offhand mid-chit-chat mention is
+                    # rarely a threaded reply, so the trigger id is what lets the
+                    # 👀 land at all.
+                    _react_target = reply_to_msg_id or self._trigger_reaction_target(session)
+                    if _react_target is not None:
                         self._rtr_queue_reaction(
-                            chat_id, reply_to_msg_id, RTR_SUPPRESS_EMOJI, session_id
+                            chat_id, _react_target, RTR_SUPPRESS_EMOJI, session_id
                         )
                         if self._file_handler is not None:
-                            await self._file_handler.send(chat_id, text, reply_to_msg_id, session)
+                            await self._file_handler.send(chat_id, text, _react_target, session)
                         return DeliveryOutcome.suppressed_rtr
-                    # No anchor: fall through to send original.
+                    # No reaction target at all: fall through to send original.
                     # F4: silent suppression breaks the I-heard-you contract --
                     # fall-through preserves the audit signal
                     self._rtr_emit_event(
@@ -851,7 +857,7 @@ class TelegramRelayOutputHandler:
                         "rtr.suppress_fallthrough",
                         chat_id=chat_id,
                         draft_text=delivery_text,
-                        reason="no_reply_anchor",
+                        reason="no_reaction_target",
                     )
                 else:
                     # Long-form trim: substitute the revised text.
@@ -878,22 +884,24 @@ class TelegramRelayOutputHandler:
                     if self._file_handler is not None:
                         await self._file_handler.send(chat_id, text, 0, session)
                     return DeliveryOutcome.suppressed_rtr
-                if reply_to_msg_id is not None:
-                    self._rtr_queue_reaction(
-                        chat_id, reply_to_msg_id, RTR_SUPPRESS_EMOJI, session_id
-                    )
+                # #2199: react on the reply anchor if present, else on the
+                # triggering message id (the stale offhand mention). This is the
+                # case the reaction fallback was built for and previously missed.
+                _react_target = reply_to_msg_id or self._trigger_reaction_target(session)
+                if _react_target is not None:
+                    self._rtr_queue_reaction(chat_id, _react_target, RTR_SUPPRESS_EMOJI, session_id)
                     if self._file_handler is not None:
-                        await self._file_handler.send(chat_id, text, reply_to_msg_id, session)
+                        await self._file_handler.send(chat_id, text, _react_target, session)
                     return DeliveryOutcome.suppressed_rtr
-                # No anchor for the 👀 reaction. F4: silent suppression breaks
-                # the I-heard-you contract -- fall-through preserves the audit
-                # signal by sending the original draft text and logging.
+                # No reaction target at all. F4: silent suppression breaks the
+                # I-heard-you contract -- fall-through preserves the audit signal
+                # by sending the original draft text and logging.
                 self._rtr_emit_event(
                     session,
                     "rtr.suppress_fallthrough",
                     chat_id=chat_id,
                     draft_text=delivery_text,
-                    reason="no_reply_anchor",
+                    reason="no_reaction_target",
                 )
             # else: send (or trim with no revised_text) -- fall through to
             # the existing outbox write path with delivery_text unchanged.
@@ -1193,6 +1201,25 @@ class TelegramRelayOutputHandler:
                 session.save()
         except Exception as e:  # pragma: no cover - defensive
             logger.debug("RTR event append failed (non-fatal): %s", e)
+
+    @staticmethod
+    def _trigger_reaction_target(session: Any) -> int | None:
+        """Return the triggering message id to react on, or ``None``.
+
+        #2199: when an RTR ``suppress`` verdict has no reply anchor, the 👀
+        reaction lands on the message that spawned this turn (the offhand
+        "Valor" mention) instead of falling through and posting an interrupting
+        late reply. Sourced from ``session.telegram_message_id``. Best-effort:
+        any missing/unparseable value returns ``None`` and the caller falls
+        back to the send-and-log path.
+        """
+        if session is None:
+            return None
+        try:
+            val = getattr(session, "telegram_message_id", None)
+            return int(val) if val else None
+        except (TypeError, ValueError):
+            return None
 
     def _rtr_queue_reaction(
         self,

--- a/bridge/read_the_room.py
+++ b/bridge/read_the_room.py
@@ -34,6 +34,11 @@ Public surface
 * ``read_the_room(draft_text, chat_id, session) -> RoomVerdict`` -- the
   async entry point.
 * ``READ_THE_ROOM_ENABLED`` -- module-level env-var gate (default ``False``).
+  The master kill switch. When enabled, RTR runs for GROUP chats only; DMs are
+  always excluded (issue #2199). Default is off pending a group-chat canary; the
+  flip criterion is a low false-suppression rate observed in ``rtr.suppressed``
+  session_events against human reports of missed replies.
+* ``RTR_STALE_TRIGGER_SECONDS`` -- deterministic staleness floor (#2199).
 * ``RTR_SUPPRESS_EMOJI`` -- the reaction emoji emitted on suppress.
 """
 
@@ -89,6 +94,20 @@ TRIM_TOO_SHORT_THRESHOLD = 20
 # Trim duration for "draft preview" snippets stored in session_events.
 PREVIEW_LENGTH = 200
 
+# Staleness threshold (issue #2199). When the triggering message is older than
+# this, the conversation has almost certainly moved on: a late text reply would
+# interrupt whatever is being discussed now, so RTR suppresses the text
+# deterministically (no Haiku call) and the call site reacts 👀 on the trigger
+# instead. This is a judgment call, not a derived constant -- 1 hour is a
+# conservative floor chosen so a genuinely-in-flight back-and-forth (replies
+# within minutes) is never caught, while a mention the room has clearly left
+# behind is. Provisional/tunable: override with RTR_STALE_TRIGGER_SECONDS in the
+# environment. Named locally (#1968 promote-vs-name-locally) -- a single-file
+# RTR knob, not promoted to config.settings. To tune, watch the age
+# distribution on `rtr.suppressed` events with reason ``stale_trigger`` against
+# any human report of a missed reply.
+RTR_STALE_TRIGGER_SECONDS = int(os.environ.get("RTR_STALE_TRIGGER_SECONDS", "3600"))
+
 
 def _read_enabled() -> bool:
     """Read ``READ_THE_ROOM_ENABLED`` env var fresh on each call.
@@ -102,6 +121,92 @@ def _read_enabled() -> bool:
         "yes",
         "on",
     )
+
+
+def _is_group_chat(chat_id: str | int | None) -> bool:
+    """Return True when ``chat_id`` is a Telegram group/supergroup/channel.
+
+    RTR only ever room-reads GROUP chats (issue #2199): a DM always deserves a
+    reply, and suppressing one to leave a silent reaction would read as the bot
+    ignoring the person. Telegram/Telethon assign negative ids to
+    groups/supergroups/channels and positive ids to user (DM) peers, so the sign
+    is the discriminator.
+
+    Conservative on ambiguity: an unparseable / ``None`` id returns False (treat
+    as non-group -> RTR short-circuits to ``send``), because false suppression
+    is the costly failure and we never want it in a chat we can't classify.
+    """
+    if chat_id is None:
+        return False
+    try:
+        return int(chat_id) < 0
+    except (TypeError, ValueError):
+        return False
+
+
+def _trigger_message_id(session: Any) -> int | None:
+    """Best-effort read of the triggering Telegram message id from ``session``.
+
+    This is the message that spawned the turn (the offhand "Valor" mention). It
+    is the reaction target when the outgoing draft has no reply anchor, and the
+    row whose age determines staleness.
+    """
+    if session is None:
+        return None
+    try:
+        val = getattr(session, "telegram_message_id", None)
+        return int(val) if val is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _fetch_trigger_age_sync(chat_id: str | int, message_id: int) -> float | None:
+    """Synchronously look up the triggering message's age in seconds.
+
+    Queries ``TelegramMessage`` by ``chat_id`` + ``message_id`` and returns
+    ``time.time() - message_timestamp``. The stored timestamp is the message's
+    *original* Telegram ``.date`` (bridge records ``timestamp=message.date``), so
+    a day-old catch_up replay reports a day-old age -- exactly the staleness we
+    want to detect. Deliberately NOT window-bounded: unlike the snapshot, the
+    trigger may legitimately sit outside the 5-minute freshness window.
+
+    Returns ``None`` on any miss or error (caller treats absent age as "no
+    temporal signal" and proceeds to the Haiku pass).
+    """
+    try:
+        from models.telegram import TelegramMessage
+
+        matches = list(
+            TelegramMessage.query.filter(chat_id=str(chat_id), message_id=int(message_id))
+        )
+        if not matches:
+            return None
+        ts = float(matches[0].timestamp or 0)
+        if ts <= 0:
+            return None
+        return max(0.0, time.time() - ts)
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug("RTR trigger-age lookup failed (chat=%s msg=%s): %s", chat_id, message_id, e)
+        return None
+
+
+async def _fetch_trigger_age(chat_id: str | int, message_id: int) -> float | None:
+    """Async wrapper around the synchronous trigger-age lookup."""
+    return await asyncio.to_thread(_fetch_trigger_age_sync, chat_id, message_id)
+
+
+def _humanize_age(age_seconds: float) -> str:
+    """Render an age in seconds as a compact human phrase for the prompt."""
+    secs = int(age_seconds)
+    if secs < 90:
+        return f"{secs} seconds ago"
+    minutes = secs // 60
+    if minutes < 90:
+        return f"{minutes} minutes ago"
+    hours = minutes // 60
+    if hours < 48:
+        return f"{hours} hours ago"
+    return f"{hours // 24} days ago"
 
 
 # === Verdict dataclass ===
@@ -131,11 +236,18 @@ You are a pre-send guard for an AI assistant that posts messages into a shared \
 Telegram chat. The assistant has just produced a draft. Your job is to decide \
 whether the draft should be sent as-is, trimmed to a shorter form, or suppressed.
 
-You will receive two inputs:
+You will receive up to three inputs:
 
 1. A snapshot of the last few messages in the chat (newest last). Each entry has \
 a `sender` and a `content` field.
 2. The draft the assistant is about to send.
+3. Optionally, how long ago the message that prompted this draft arrived (the \
+"trigger age"). Use it as hard evidence of staleness: the older the trigger, the \
+more likely the room has moved on and a late text reply would interrupt the \
+current topic rather than answer the original one. When the trigger is old AND \
+the snapshot shows the conversation has since moved elsewhere, prefer `suppress` \
+— a quiet reaction is left in place of the interrupting text. A fresh trigger \
+(seconds/low minutes) that is still on-topic should `send` as normal.
 
 Important attribution rules:
 - Snapshot entries with `sender` in {Valor, valor, system} ARE this assistant's \
@@ -369,11 +481,18 @@ async def read_the_room(
         * ``READ_THE_ROOM_ENABLED`` env var is falsey.
         * ``draft_text`` is empty / whitespace-only.
         * ``chat_id`` is ``None`` (no room to read).
+        * ``chat_id`` is a DM (positive id) -- RTR only room-reads group chats
+          (#2199); a DM always deserves a reply.
         * ``len(draft_text) < SHORT_OUTPUT_THRESHOLD`` -- aligns with the
           drafter's own bypass band so we don't pay RTR latency for short
           messages the drafter already skipped.
         * ``session.sdlc_slug`` is set -- emits a ``rtr.bypassed`` event.
         * Snapshot is empty -- nothing to compare against.
+
+    Deterministic staleness (#2199): before the Haiku pass, if the triggering
+    message is older than ``RTR_STALE_TRIGGER_SECONDS`` the room has provably
+    moved on, so this returns ``suppress`` (reason ``stale_trigger``) WITHOUT a
+    Haiku call. The call site reacts 👀 on the trigger instead of interrupting.
 
     Args:
         draft_text: The string that will hit the outbox after upstream
@@ -404,6 +523,10 @@ async def read_the_room(
     if chat_id is None:
         return RoomVerdict(action="send", reason="no_chat_id")
 
+    if not _is_group_chat(chat_id):
+        # DMs (and unclassifiable ids) always get a reply — never room-read.
+        return RoomVerdict(action="send", reason="dm_excluded")
+
     if len(draft_text) < SHORT_OUTPUT_THRESHOLD:
         return RoomVerdict(action="send", reason="short_output")
 
@@ -419,6 +542,30 @@ async def read_the_room(
         )
         return RoomVerdict(action="send", reason="sdlc_session")
 
+    # ── Trigger age (temporal signal, #2199) ──
+    # The triggering message's true age drives both a deterministic stale
+    # short-circuit and a hint threaded into the Haiku prompt. Absent (no
+    # trigger id, or the row isn't in TelegramMessage) means "no temporal
+    # signal" -> fall through to the Haiku pass with snapshot-only context.
+    trigger_id = _trigger_message_id(session)
+    trigger_age: float | None = None
+    if trigger_id is not None:
+        trigger_age = await _fetch_trigger_age(chat_id, trigger_id)
+
+    if trigger_age is not None and trigger_age >= RTR_STALE_TRIGGER_SECONDS:
+        # Provably stale: the room has moved on. Suppress the text without a
+        # Haiku call; the call site reacts 👀 on the trigger instead.
+        _append_event(
+            session,
+            _make_event(
+                "rtr.suppressed",
+                chat_id=chat_id,
+                draft_text=draft_text,
+                reason="stale_trigger",
+            ),
+        )
+        return RoomVerdict(action="suppress", reason="stale_trigger")
+
     # ── Snapshot ──
     snapshot = await _fetch_snapshot(chat_id, k=k, max_age_seconds=max_age_seconds)
     if not snapshot:
@@ -426,9 +573,16 @@ async def read_the_room(
 
     # ── Haiku call (post-#1055 pattern: semaphore_slot + inner async with
     #    AsyncAnthropic(timeout=RTR_SDK_TIMEOUT); NO asyncio.wait_for). ──
+    trigger_age_block = (
+        f"## Trigger age\nThe message that prompted this draft arrived "
+        f"{_humanize_age(trigger_age)}.\n\n"
+        if trigger_age is not None
+        else ""
+    )
     user_payload = (
         "## Recent chat snapshot (oldest first, newest last)\n"
         f"{_format_snapshot_for_prompt(snapshot)}\n\n"
+        f"{trigger_age_block}"
         "## Draft about to be sent\n"
         f"{draft_text}\n\n"
         "Decide via the room_verdict tool."
@@ -534,6 +688,7 @@ __all__ = [
     "RoomVerdict",
     "RTR_SUPPRESS_EMOJI",
     "TRIM_TOO_SHORT_THRESHOLD",
+    "RTR_STALE_TRIGGER_SECONDS",
     "READ_THE_ROOM_SYSTEM_PROMPT",
     "DEFAULT_K",
     "DEFAULT_MAX_AGE_SECONDS",

--- a/docs/features/drafter-redundancy-suppression.md
+++ b/docs/features/drafter-redundancy-suppression.md
@@ -68,7 +68,7 @@ Two `session_events` entries are emitted:
 | Event type | When |
 |------------|------|
 | `drafter.suppressed_redundant` | Suppression fired; reaction queued. |
-| `drafter.suppress_fallthrough` | Suppression would have fired but no `reply_to_msg_id` anchor existed; text sent. |
+| `drafter.suppress_fallthrough` | Suppression would have fired but no reaction target existed at all — no `reply_to_msg_id` anchor **and** no triggering message id (`reason="no_reaction_target"`); text sent. |
 
 Both entries carry `{type, ts, chat_id, reason, draft_preview}` — compatible with
 the RTR event schema. Dashboard tooling that reads `session.session_events` can
@@ -93,7 +93,7 @@ when any of the following are true:
 | `_extract_bigrams` raises | `filter_error` → deliver text. |
 | `extract_artifacts` raises | `_draft_artifacts = {}` → may suppress if Jaccard alone qualifies, but no false-positive on artifact-diff. |
 | `session.record_recent_sent_draft` save fails | Logged as `WARNING`; the `rpush` already completed, so delivery is not reversed. |
-| No `reply_to_msg_id` anchor | `suppress_fallthrough` event; text delivered (mirrors RTR's no-anchor contract). |
+| No `reply_to_msg_id` anchor | React on the triggering message id if known (`session.telegram_message_id`, #2199); only if there is no reaction target at all does the `suppress_fallthrough` event fire and text is delivered (mirrors RTR's no-anchor contract). |
 
 ## Configuration
 

--- a/docs/features/read-the-room.md
+++ b/docs/features/read-the-room.md
@@ -13,6 +13,10 @@ that the drafter alone cannot see:
 2. **Crossing-streams** — while the agent was drafting, a participant has
    shifted topic. The agent's reply would land as a non-sequitur into a
    personal exchange.
+3. **Stale offhand mention** — someone dropped a "Valor" mention mid-chit-chat,
+   the room moved on, and the socially-correct response is a quiet 👀 reaction
+   on the original message, not a late text reply that interrupts the current
+   topic (issue [#2199](https://github.com/tomcounsell/ai/issues/2199)).
 
 The drafter has no view of the *room state* at send time; the drafter only
 sees the agent's tool outputs. Read-the-Room (RTR) is the explicit catch-all.
@@ -21,6 +25,8 @@ Sources:
 - Path A — issue [#1193](https://github.com/tomcounsell/ai/issues/1193), implementation in
   PR [#1204](https://github.com/tomcounsell/ai/pull/1204) at commit `531e8f4e`.
 - Path B (`valor-telegram send`) — issue [#1203](https://github.com/tomcounsell/ai/issues/1203).
+- Stale-mention staleness signal + no-anchor reaction target + group-only
+  gate — issue [#2199](https://github.com/tomcounsell/ai/issues/2199).
 
 ## Where it lives
 
@@ -43,8 +49,8 @@ Sources:
 | `send` | Write the original `delivery_text` to the outbox unchanged. |
 | `trim` (`len(revised_text) >= 20`) | Substitute `verdict.revised_text` for `delivery_text` and write that. |
 | `trim` (`len(revised_text) < 20`) | **Coerced to suppress** — too-short trims are exactly the failure mode the feature exists to prevent (a one-emoji message landing in a personal exchange). |
-| `suppress` (with `reply_to_msg_id`) | Skip the text write. Queue a 👀 reaction (`RTR_SUPPRESS_EMOJI`) on the message we were replying to so the human still gets a "received" signal. |
-| `suppress` (no `reply_to_msg_id`) | **Fall through to send the original text.** Without an anchor we cannot emit the reaction, and silent suppression breaks the I-heard-you contract — fall-through preserves the audit signal. |
+| `suppress` (reply anchor OR triggering message id available) | Skip the text write. Queue a 👀 reaction (`RTR_SUPPRESS_EMOJI`) on the reply anchor if present, else on the **triggering message** (`session.telegram_message_id`, #2199) so the human still gets a "received" signal. An offhand mid-chit-chat mention is rarely a threaded reply, so the trigger id is what lets the reaction land at all. |
+| `suppress` (no reply anchor AND no triggering message id) | **Fall through to send the original text.** With no reaction target at all, silent suppression breaks the I-heard-you contract — fall-through preserves the audit signal (`reason="no_reaction_target"`). |
 
 ## Snapshot defaults
 
@@ -59,20 +65,68 @@ Sources:
 
 Tune via the `DEFAULT_K` and `DEFAULT_MAX_AGE_SECONDS` module constants.
 
+## Staleness signal (issue #2199)
+
+Detecting "the room moved on" from topic drift in message *content* alone is
+unreliable, so RTR threads the triggering message's **true age** into the
+decision:
+
+* **Source.** The bridge records each inbound message into `TelegramMessage`
+  with `timestamp=message.date` (the message's *original* Telegram date). RTR
+  looks up the triggering message by `session.telegram_message_id` and computes
+  `age = now - timestamp`. This is deliberately *not* window-bounded (unlike the
+  5-minute snapshot): a day-old catch_up replay reports a day-old age, which is
+  exactly the staleness we want to catch.
+* **Deterministic short-circuit.** If the trigger is older than
+  `RTR_STALE_TRIGGER_SECONDS` (default **3600s = 1 hour**, env-overridable), RTR
+  returns `suppress` (reason `stale_trigger`) **without calling Haiku** — the
+  room has provably moved on. This is a judgment-call threshold, not a derived
+  constant; 1 hour is a conservative floor chosen so a genuinely-in-flight
+  back-and-forth (replies within minutes) is never caught. Tune by watching the
+  age distribution on `rtr.suppressed`/`stale_trigger` events against any human
+  report of a missed reply.
+* **Prompt hint.** For triggers younger than the deterministic floor, the age is
+  rendered as a relative phrase ("N minutes ago") in a `## Trigger age` block so
+  the Haiku pass can weigh staleness alongside topic drift. When no trigger id
+  is available (age unknown) the block is omitted and the pass runs
+  snapshot-only.
+
+## Enablement decision (issue #2199)
+
+RTR is a **group-chat** feature. A DM always deserves a reply — suppressing one
+to leave a silent reaction would read as the bot ignoring the person — so RTR
+**never** room-reads DMs. Group vs. DM is discriminated by the Telegram id sign
+(`_is_group_chat`: groups/supergroups/channels are negative, user DMs positive;
+an unclassifiable id is treated as non-group and short-circuits to `send`).
+
+The master `READ_THE_ROOM_ENABLED` flag remains **off by default**. The decision
+for this issue is: ship the full mechanism (staleness signal + no-anchor
+reaction target) group-scoped behind the existing kill switch, then flip the
+flag for groups once a canary shows a low false-suppression rate. **Flip
+criterion:** sample `rtr.suppressed` `session_events` in a low-stakes group for a
+day; if genuinely on-topic mentions are not being suppressed (false-suppression
+rate is low) and no human reports a missed reply, flip `READ_THE_ROOM_ENABLED`
+in production. The kill switch is the same flag set back to `false`.
+
 ## Bypass conditions (no Haiku call)
 
 RTR short-circuits to `send` without calling Haiku in any of:
 
-* `READ_THE_ROOM_ENABLED` env var is unset/false (default for first
-  rollout — opt in per machine).
+* `READ_THE_ROOM_ENABLED` env var is unset/false (default — see enablement
+  decision above).
 * `draft_text` is empty / whitespace-only.
 * `chat_id` is `None` (file-only delivery, etc.).
+* `chat_id` is a DM (positive id) or unclassifiable — RTR only room-reads group
+  chats (#2199).
 * `len(draft_text) < SHORT_OUTPUT_THRESHOLD` — aligns with the drafter's
   bypass band (200 chars) so we don't pay RTR latency in the same range
   the drafter already skipped.
 * `session.sdlc_slug` is set — emits a `rtr.bypassed` event so SDLC
   pipeline status messages are observable but never blocked.
 * The fetched snapshot is empty — no room to read.
+
+The deterministic stale short-circuit (above) is the one case that returns
+`suppress` rather than `send` without a Haiku call.
 
 ## Failure modes
 
@@ -111,8 +165,8 @@ Event types:
 
 | Type | When |
 |------|------|
-| `rtr.suppressed` | Suppress verdict applied (with reaction emitted, OR coerced-from-short-trim). |
-| `rtr.suppress_fallthrough` | Suppress verdict but no `reply_to_msg_id` anchor — original text was sent and this event records why. |
+| `rtr.suppressed` | Suppress verdict applied (with reaction emitted, coerced-from-short-trim, or the deterministic `stale_trigger` short-circuit of #2199). |
+| `rtr.suppress_fallthrough` | Suppress verdict but no reaction target at all (no reply anchor AND no triggering message id, `reason="no_reaction_target"`) — original text was sent and this event records why. |
 | `rtr.trimmed` | Long-form trim verdict applied. |
 | `rtr.bypassed` | RTR short-circuited (currently emitted only for SDLC sessions). |
 | `rtr.failed` | RTR raised an exception; fell open to `send`. |
@@ -190,12 +244,15 @@ observable; if RTR is firing on >90% of sends, the heuristic is wrong.
 
 ## Rollout
 
-1. Land the code with `READ_THE_ROOM_ENABLED=false` (default).
+1. Land the code with `READ_THE_ROOM_ENABLED=false` (default). DMs are excluded
+   unconditionally; only group chats are ever room-read.
 2. Flip the flag in `~/Desktop/Valor/.env` on the dev/test machine first.
-3. Watch a low-stakes chat for one day; sample `session_events` for
-   suppressed messages and judge the false-positive rate.
-4. If false-positive rate > 10%, tighten the system prompt or raise the
-   suppression bar. Otherwise flip the flag in production.
+3. Watch a low-stakes **group** chat for one day; sample `session_events` for
+   `rtr.suppressed` messages (including `stale_trigger`) and judge the
+   false-suppression rate.
+4. If false-suppression rate > 10%, tighten the system prompt, raise the
+   suppression bar, or raise `RTR_STALE_TRIGGER_SECONDS`. Otherwise flip the
+   flag in production. The kill switch is the same flag set back to `false`.
 
 ## Adjacent layers
 

--- a/tests/unit/test_output_handler.py
+++ b/tests/unit/test_output_handler.py
@@ -1055,6 +1055,7 @@ class TestReadTheRoomWiring:
         s.get_parent_session = MagicMock(return_value=None)
         s.is_sdlc = False
         s.session_events = None
+        s.telegram_message_id = kwargs.get("telegram_message_id", None)
         return s
 
     def test_send_verdict_writes_text_payload(self):
@@ -1230,14 +1231,15 @@ class TestReadTheRoomWiring:
         assert from_send == from_react
 
     def test_suppress_with_no_anchor_falls_through_to_send(self):
-        """suppress + reply_to_msg_id is None falls through to send the
-        original text and emits rtr.suppress_fallthrough (Implementation Note SI1).
+        """suppress + no reply anchor AND no triggering message id falls through
+        to send the original text and emits rtr.suppress_fallthrough
+        (Implementation Note SI1; #2199 reason ``no_reaction_target``).
         """
         from bridge.read_the_room import RoomVerdict
 
         mock_r = self._mock_redis()
         handler = self._make_handler(mock_r)
-        session = self._make_session()
+        session = self._make_session(telegram_message_id=None)
 
         with (
             patch(
@@ -1263,12 +1265,52 @@ class TestReadTheRoomWiring:
         payload = json.loads(mock_r.rpush.call_args[0][1])
         assert payload["text"] == "x" * 250
 
-        # And we logged the fallthrough event with reason no_reply_anchor.
+        # And we logged the fallthrough event with reason no_reaction_target.
         events = session.session_events or []
         types_ = [e["type"] for e in events]
         assert "rtr.suppress_fallthrough" in types_
         ev = next(e for e in events if e["type"] == "rtr.suppress_fallthrough")
-        assert ev["reason"] == "no_reply_anchor"
+        assert ev["reason"] == "no_reaction_target"
+
+    def test_suppress_no_anchor_reacts_on_trigger_message(self):
+        """#2199: suppress + no reply anchor but a known triggering message id
+        reacts 👀 on the trigger instead of falling through to a late text
+        reply. This is the stale-offhand-mention case the fallback was built
+        for and previously missed.
+        """
+        from bridge.read_the_room import RTR_SUPPRESS_EMOJI, RoomVerdict
+
+        mock_r = self._mock_redis()
+        handler = self._make_handler(mock_r)
+        session = self._make_session(session_id="sess-xyz", telegram_message_id=555)
+
+        with (
+            patch(
+                "bridge.message_drafter.draft_message", AsyncMock(side_effect=self._bypass_drafter)
+            ),
+            patch(
+                "bridge.read_the_room.read_the_room",
+                AsyncMock(return_value=RoomVerdict(action="suppress", reason="stale_trigger")),
+            ),
+        ):
+            asyncio.run(
+                handler.send(
+                    chat_id="-100123",
+                    text="x" * 250,
+                    reply_to_msg_id=None,  # No reply anchor.
+                    session=session,
+                )
+            )
+
+        # Exactly one rpush -- the reaction on the triggering message. No text.
+        assert mock_r.rpush.call_count == 1
+        key = mock_r.rpush.call_args[0][0]
+        assert key == "telegram:outbox:sess-xyz"
+        payload = json.loads(mock_r.rpush.call_args[0][1])
+        assert payload["type"] == "reaction"
+        assert payload["emoji"] == RTR_SUPPRESS_EMOJI
+        assert payload["reply_to"] == 555
+        assert "text" not in payload
 
     def test_steering_deferred_path_skips_rtr(self):
         """RTR must not run when delivery is deferred to self-draft steering
@@ -1659,7 +1701,7 @@ class TestRedundancyFilterWiring:
 
         return MessageDraft(text=_input, artifacts={})
 
-    def _make_sdlc_session(self, *, recent_drafts=None, status="active"):
+    def _make_sdlc_session(self, *, recent_drafts=None, status="active", telegram_message_id=None):
         s = MagicMock()
         s.session_id = "sdlc-sess-001"
         s.is_sdlc = True
@@ -1668,6 +1710,9 @@ class TestRedundancyFilterWiring:
         s.session_events = None
         s.record_recent_sent_draft = MagicMock()
         s.extra_context = {}
+        # Explicit None so a bare MagicMock's __int__ (defaults to 1) never
+        # masquerades as a triggering message id in the no-anchor fallthrough.
+        s.telegram_message_id = telegram_message_id
         return s
 
     def _make_non_sdlc_session(self):
@@ -1919,12 +1964,57 @@ class TestRedundancyFilterWiring:
                 )
             )
 
-        # Text must have been sent (no anchor → fallthrough).
+        # Text must have been sent (no anchor, no trigger id → fallthrough).
         mock_r.rpush.assert_called()
         text_calls = [
             c for c in mock_r.rpush.call_args_list if json.loads(c[0][1]).get("type") != "reaction"
         ]
         assert len(text_calls) >= 1
+
+    def test_suppress_no_anchor_reacts_on_trigger_message(self):
+        """#2199: redundancy suppress + no reply anchor but a known triggering
+        message id reacts on the trigger instead of falling through — the same
+        no-anchor contract as the RTR suppress branch, kept uniform."""
+        import time
+
+        from bridge.redundancy_filter import SuppressionVerdict
+
+        mock_r = self._mock_redis()
+        handler = self._make_handler(mock_r)
+        session = self._make_sdlc_session(
+            recent_drafts=[{"ts": time.time(), "text": "status", "artifacts": {}}],
+            telegram_message_id=909,
+        )
+
+        suppress_verdict = SuppressionVerdict(
+            action="suppress", reason="jaccard=0.90>=threshold=0.65", jaccard=0.90, matched_index=0
+        )
+
+        with (
+            patch(
+                "bridge.message_drafter.draft_message",
+                AsyncMock(side_effect=self._bypass_drafter),
+            ),
+            patch(
+                "bridge.redundancy_filter.should_suppress",
+                return_value=suppress_verdict,
+            ),
+        ):
+            asyncio.run(
+                handler.send(
+                    chat_id="-100123",
+                    text="status",
+                    reply_to_msg_id=None,  # No anchor.
+                    session=session,
+                )
+            )
+
+        # Exactly one rpush -- the reaction on the triggering message. No text.
+        assert mock_r.rpush.call_count == 1
+        payload = json.loads(mock_r.rpush.call_args[0][1])
+        assert payload["type"] == "reaction"
+        assert payload["reply_to"] == 909
+        assert "text" not in payload
 
     # ── Session event includes jaccard and matched_prior_preview ─────────────
 

--- a/tests/unit/test_read_the_room.py
+++ b/tests/unit/test_read_the_room.py
@@ -32,22 +32,36 @@ from bridge.read_the_room import (
     DEFAULT_K,
     DEFAULT_MAX_AGE_SECONDS,
     READ_THE_ROOM_SYSTEM_PROMPT,
+    RTR_STALE_TRIGGER_SECONDS,
     RTR_SUPPRESS_EMOJI,
     TRIM_TOO_SHORT_THRESHOLD,
     _format_snapshot_for_prompt,
+    _humanize_age,
+    _is_group_chat,
     _parse_verdict_block,
     read_the_room,
 )
 
 # === Fixtures ===================================================================
 
+# Telegram assigns negative ids to groups/supergroups/channels. RTR only ever
+# room-reads group chats (#2199), so the shared test chat_id is a supergroup id.
+GROUP_CHAT_ID = "-1001234567890"
+
 
 class FakeSession:
     """Minimal stand-in for ``AgentSession`` used in unit tests."""
 
-    def __init__(self, *, session_id: str = "sess-test", sdlc_slug: str | None = None):
+    def __init__(
+        self,
+        *,
+        session_id: str = "sess-test",
+        sdlc_slug: str | None = None,
+        telegram_message_id: int | None = None,
+    ):
         self.session_id = session_id
         self.sdlc_slug = sdlc_slug
+        self.telegram_message_id = telegram_message_id
         self.session_events: list[dict] | None = None
         self._save_calls = 0
 
@@ -110,13 +124,117 @@ def _patch_snapshot(monkeypatch, snapshot):
     monkeypatch.setattr(rtr_module, "_fetch_snapshot", fake_fetch)
 
 
+def _patch_trigger_age(monkeypatch, age_seconds):
+    """Patch the async trigger-age lookup so tests never touch Redis."""
+
+    async def fake_age(chat_id, message_id):
+        return age_seconds
+
+    monkeypatch.setattr(rtr_module, "_fetch_trigger_age", fake_age)
+
+
+# === Group / DM gate (#2199) ====================================================
+
+
+@pytest.mark.parametrize(
+    "chat_id, expected",
+    [
+        ("-1001234567890", True),
+        (-1001234567890, True),
+        ("-42", True),
+        ("12345", False),
+        (12345, False),
+        ("0", False),
+        (None, False),
+        ("not-an-int", False),
+    ],
+)
+def test_is_group_chat(chat_id, expected):
+    assert _is_group_chat(chat_id) is expected
+
+
+def test_dm_excluded_returns_send(monkeypatch):
+    """A positive (DM) chat_id short-circuits to send without a Haiku call."""
+    _enable_rtr(monkeypatch)
+    create_mock = _patch_anthropic(monkeypatch, _make_tool_use_msg("suppress"))
+
+    verdict = asyncio.run(read_the_room(_long_draft(), "12345", FakeSession()))
+    assert verdict.action == "send"
+    assert verdict.reason == "dm_excluded"
+    create_mock.assert_not_awaited()
+
+
+# === Deterministic staleness (#2199) ============================================
+
+
+def test_stale_trigger_deterministic_suppress(monkeypatch):
+    """A trigger older than the threshold suppresses without calling Haiku."""
+    _enable_rtr(monkeypatch)
+    create_mock = _patch_anthropic(monkeypatch, _make_tool_use_msg("send"))
+    _patch_trigger_age(monkeypatch, RTR_STALE_TRIGGER_SECONDS + 60)
+
+    session = FakeSession(telegram_message_id=777)
+    verdict = asyncio.run(read_the_room(_long_draft(), GROUP_CHAT_ID, session))
+    assert verdict.action == "suppress"
+    assert verdict.reason == "stale_trigger"
+    create_mock.assert_not_awaited()
+    assert session.session_events and session.session_events[0]["type"] == "rtr.suppressed"
+    assert session.session_events[0]["reason"] == "stale_trigger"
+
+
+def test_fresh_trigger_threads_age_into_prompt(monkeypatch):
+    """A fresh trigger does not deterministically suppress; its age is passed
+    to the Haiku prompt as a temporal signal."""
+    _enable_rtr(monkeypatch)
+    create_mock = _patch_anthropic(monkeypatch, _make_tool_use_msg("send", reason="clean"))
+    _patch_snapshot(monkeypatch, [{"sender": "Tom", "content": "hi"}])
+    _patch_trigger_age(monkeypatch, 42)
+
+    session = FakeSession(telegram_message_id=777)
+    verdict = asyncio.run(read_the_room(_long_draft(), GROUP_CHAT_ID, session))
+    assert verdict.action == "send"
+    create_mock.assert_awaited_once()
+    payload = create_mock.await_args.kwargs["messages"][0]["content"]
+    assert "## Trigger age" in payload
+    assert "ago" in payload
+
+
+def test_absent_trigger_age_omits_age_block(monkeypatch):
+    """With no trigger id (age None) the prompt carries no trigger-age block."""
+    _enable_rtr(monkeypatch)
+    create_mock = _patch_anthropic(monkeypatch, _make_tool_use_msg("send", reason="clean"))
+    _patch_snapshot(monkeypatch, [{"sender": "Tom", "content": "hi"}])
+
+    verdict = asyncio.run(read_the_room(_long_draft(), GROUP_CHAT_ID, FakeSession()))
+    assert verdict.action == "send"
+    create_mock.assert_awaited_once()
+    payload = create_mock.await_args.kwargs["messages"][0]["content"]
+    assert "## Trigger age" not in payload
+
+
+@pytest.mark.parametrize(
+    "age_seconds, expected",
+    [
+        (5, "5 seconds ago"),
+        (89, "89 seconds ago"),
+        (120, "2 minutes ago"),
+        (3600, "60 minutes ago"),
+        (5340, "89 minutes ago"),
+        (7200, "2 hours ago"),
+        (172800, "2 days ago"),
+    ],
+)
+def test_humanize_age(age_seconds, expected):
+    assert _humanize_age(age_seconds) == expected
+
+
 # === Short-circuit tests ========================================================
 
 
 def test_disabled_flag_returns_send(monkeypatch):
     _disable_rtr(monkeypatch)
     session = FakeSession()
-    verdict = asyncio.run(read_the_room("anything", "12345", session))
+    verdict = asyncio.run(read_the_room("anything", GROUP_CHAT_ID, session))
     assert verdict.action == "send"
     assert verdict.reason == "rtr_disabled"
     assert session.session_events in (None, [])
@@ -124,14 +242,14 @@ def test_disabled_flag_returns_send(monkeypatch):
 
 def test_empty_draft_returns_send(monkeypatch):
     _enable_rtr(monkeypatch)
-    verdict = asyncio.run(read_the_room("", "12345", FakeSession()))
+    verdict = asyncio.run(read_the_room("", GROUP_CHAT_ID, FakeSession()))
     assert verdict.action == "send"
     assert verdict.reason == "empty_draft"
 
 
 def test_whitespace_only_draft_returns_send(monkeypatch):
     _enable_rtr(monkeypatch)
-    verdict = asyncio.run(read_the_room("   \n  \t", "12345", FakeSession()))
+    verdict = asyncio.run(read_the_room("   \n  \t", GROUP_CHAT_ID, FakeSession()))
     assert verdict.action == "send"
     assert verdict.reason == "empty_draft"
 
@@ -149,7 +267,7 @@ def test_short_output_short_circuits(monkeypatch):
     create_mock = _patch_anthropic(monkeypatch, _make_tool_use_msg("send"))
 
     short_draft = "Tiny ack."
-    verdict = asyncio.run(read_the_room(short_draft, "12345", FakeSession()))
+    verdict = asyncio.run(read_the_room(short_draft, GROUP_CHAT_ID, FakeSession()))
     assert verdict.action == "send"
     assert verdict.reason == "short_output"
     create_mock.assert_not_awaited()
@@ -161,7 +279,7 @@ def test_sdlc_session_short_circuits_with_event(monkeypatch):
     create_mock = _patch_anthropic(monkeypatch, _make_tool_use_msg("send"))
 
     session = FakeSession(sdlc_slug="sdlc-1193")
-    verdict = asyncio.run(read_the_room(_long_draft(), "12345", session))
+    verdict = asyncio.run(read_the_room(_long_draft(), GROUP_CHAT_ID, session))
     assert verdict.action == "send"
     assert verdict.reason == "sdlc_session"
     create_mock.assert_not_awaited()
@@ -175,7 +293,7 @@ def test_empty_snapshot_returns_send(monkeypatch):
     create_mock = _patch_anthropic(monkeypatch, _make_tool_use_msg("send"))
     _patch_snapshot(monkeypatch, [])
 
-    verdict = asyncio.run(read_the_room(_long_draft(), "12345", FakeSession()))
+    verdict = asyncio.run(read_the_room(_long_draft(), GROUP_CHAT_ID, FakeSession()))
     assert verdict.action == "send"
     assert verdict.reason == "empty_snapshot"
     create_mock.assert_not_awaited()
@@ -189,7 +307,7 @@ def test_send_verdict(monkeypatch):
     _patch_snapshot(monkeypatch, [{"sender": "Tom", "content": "hi"}])
     create_mock = _patch_anthropic(monkeypatch, _make_tool_use_msg("send", reason="clean"))
 
-    verdict = asyncio.run(read_the_room(_long_draft(), "12345", FakeSession()))
+    verdict = asyncio.run(read_the_room(_long_draft(), GROUP_CHAT_ID, FakeSession()))
     assert verdict.action == "send"
     assert verdict.reason == "clean"
     create_mock.assert_awaited_once()
@@ -204,7 +322,7 @@ def test_trim_long_verdict_preserves_revised_text(monkeypatch):
         _make_tool_use_msg("trim", revised_text=revised, reason="partial_redundant"),
     )
 
-    verdict = asyncio.run(read_the_room(_long_draft(), "12345", FakeSession()))
+    verdict = asyncio.run(read_the_room(_long_draft(), GROUP_CHAT_ID, FakeSession()))
     assert verdict.action == "trim"
     assert verdict.revised_text == revised
 
@@ -220,7 +338,7 @@ def test_trim_short_verdict_preserves_text(monkeypatch):
         _make_tool_use_msg("trim", revised_text="ok", reason="redundant"),
     )
 
-    verdict = asyncio.run(read_the_room(_long_draft(), "12345", FakeSession()))
+    verdict = asyncio.run(read_the_room(_long_draft(), GROUP_CHAT_ID, FakeSession()))
     assert verdict.action == "trim"
     assert verdict.revised_text == "ok"
     assert len(verdict.revised_text) < TRIM_TOO_SHORT_THRESHOLD
@@ -234,7 +352,7 @@ def test_trim_with_no_revised_text_falls_back_to_send(monkeypatch):
         _make_tool_use_msg("trim", revised_text=None, reason="redundant"),
     )
 
-    verdict = asyncio.run(read_the_room(_long_draft(), "12345", FakeSession()))
+    verdict = asyncio.run(read_the_room(_long_draft(), GROUP_CHAT_ID, FakeSession()))
     assert verdict.action == "send"
     assert verdict.reason == "trim_missing_revised_text"
 
@@ -247,7 +365,7 @@ def test_suppress_verdict(monkeypatch):
         _make_tool_use_msg("suppress", reason="duplicate_answer"),
     )
 
-    verdict = asyncio.run(read_the_room(_long_draft(), "12345", FakeSession()))
+    verdict = asyncio.run(read_the_room(_long_draft(), GROUP_CHAT_ID, FakeSession()))
     assert verdict.action == "suppress"
     assert verdict.reason == "duplicate_answer"
 
@@ -262,7 +380,7 @@ def test_api_timeout_returns_send_and_logs_event(monkeypatch):
     _patch_anthropic(monkeypatch, raises=err)
 
     session = FakeSession()
-    verdict = asyncio.run(read_the_room(_long_draft(), "12345", session))
+    verdict = asyncio.run(read_the_room(_long_draft(), GROUP_CHAT_ID, session))
     assert verdict.action == "send"
     assert verdict.reason == "rtr_error"
 
@@ -277,7 +395,7 @@ def test_api_connection_error_returns_send(monkeypatch):
     _patch_anthropic(monkeypatch, raises=err)
 
     session = FakeSession()
-    verdict = asyncio.run(read_the_room(_long_draft(), "12345", session))
+    verdict = asyncio.run(read_the_room(_long_draft(), GROUP_CHAT_ID, session))
     assert verdict.action == "send"
     assert verdict.reason == "rtr_error"
     assert session.session_events[0]["error"] == "APIConnectionError"
@@ -294,7 +412,7 @@ def test_value_error_on_bad_tool_use_returns_send(monkeypatch):
     _patch_anthropic(monkeypatch, bad_msg)
 
     session = FakeSession()
-    verdict = asyncio.run(read_the_room(_long_draft(), "12345", session))
+    verdict = asyncio.run(read_the_room(_long_draft(), GROUP_CHAT_ID, session))
     assert verdict.action == "send"
     assert verdict.reason == "rtr_error"
     assert session.session_events[0]["error"] == "ValueError"
@@ -306,7 +424,7 @@ def test_unexpected_exception_caught_last_resort(monkeypatch):
     _patch_anthropic(monkeypatch, raises=RuntimeError("boom"))
 
     session = FakeSession()
-    verdict = asyncio.run(read_the_room(_long_draft(), "12345", session))
+    verdict = asyncio.run(read_the_room(_long_draft(), GROUP_CHAT_ID, session))
     assert verdict.action == "send"
     assert verdict.reason == "rtr_error"
     assert session.session_events[0]["error"] == "RuntimeError"
@@ -337,7 +455,7 @@ def test_snapshot_k_cap(monkeypatch):
 
     with patch.dict("sys.modules", {"models.telegram": fake_module}):
         out = rtr_module._fetch_snapshot_sync(
-            "12345", k=DEFAULT_K, max_age_seconds=DEFAULT_MAX_AGE_SECONDS
+            GROUP_CHAT_ID, k=DEFAULT_K, max_age_seconds=DEFAULT_MAX_AGE_SECONDS
         )
 
     assert len(out) == DEFAULT_K
@@ -368,7 +486,7 @@ def test_snapshot_time_window_drops_old(monkeypatch):
     fake_module.TelegramMessage = fake_model
 
     with patch.dict("sys.modules", {"models.telegram": fake_module}):
-        out = rtr_module._fetch_snapshot_sync("12345", k=DEFAULT_K, max_age_seconds=300)
+        out = rtr_module._fetch_snapshot_sync(GROUP_CHAT_ID, k=DEFAULT_K, max_age_seconds=300)
 
     senders = [m["sender"] for m in out]
     assert "ancient" not in senders
@@ -410,7 +528,7 @@ def test_snapshot_mixed_attribution_passes_through(monkeypatch):
     fake_module.TelegramMessage = fake_model
 
     with patch.dict("sys.modules", {"models.telegram": fake_module}):
-        out = rtr_module._fetch_snapshot_sync("12345", k=DEFAULT_K, max_age_seconds=300)
+        out = rtr_module._fetch_snapshot_sync(GROUP_CHAT_ID, k=DEFAULT_K, max_age_seconds=300)
 
     senders = [m["sender"] for m in out]
     assert senders == ["Valor", "system", "Tom"]
@@ -424,7 +542,7 @@ def test_snapshot_query_failure_returns_empty(monkeypatch):
     fake_module.TelegramMessage = fake_model
 
     with patch.dict("sys.modules", {"models.telegram": fake_module}):
-        out = rtr_module._fetch_snapshot_sync("12345", k=DEFAULT_K, max_age_seconds=300)
+        out = rtr_module._fetch_snapshot_sync(GROUP_CHAT_ID, k=DEFAULT_K, max_age_seconds=300)
 
     assert out == []
 

--- a/tools/valor_telegram.py
+++ b/tools/valor_telegram.py
@@ -966,27 +966,31 @@ def cmd_send(args: argparse.Namespace) -> int:
                         revised_text=verdict.revised_text,
                         reason="trim_too_short",
                     )
-                    if anchor_reply_to is not None:
-                        # Suppress with reply anchor: queue the 👀 reaction.
-                        from agent.output_handler import TelegramRelayOutputHandler
+                    from agent.output_handler import TelegramRelayOutputHandler
 
+                    # React on the reply anchor if present, else on the
+                    # triggering message id (#2199); same contract as Path A.
+                    _react_target = anchor_reply_to or (
+                        TelegramRelayOutputHandler._trigger_reaction_target(session)
+                    )
+                    if _react_target is not None:
                         rtr_suppress_reaction = TelegramRelayOutputHandler._build_reaction_payload(
                             chat_id,
-                            anchor_reply_to,
+                            _react_target,
                             RTR_SUPPRESS_EMOJI,
                             session_id,
                         )
                         rtr_should_send = False
                         rtr_suppressed_reason = "trim_too_short"
                     else:
-                        # No anchor: F4 fall-through preserves the I-heard-you
-                        # contract by sending the original text + audit event.
+                        # No reaction target: F4 fall-through preserves the
+                        # I-heard-you contract by sending the original text.
                         _rtr_emit_event(
                             session,
                             "rtr.suppress_fallthrough",
                             chat_id=chat_id,
                             draft_text=text,
-                            reason="no_reply_anchor",
+                            reason="no_reaction_target",
                         )
                 else:
                     # Long-form trim: substitute the revised text.
@@ -1007,25 +1011,30 @@ def cmd_send(args: argparse.Namespace) -> int:
                     draft_text=text,
                     reason=verdict.reason or "suppress",
                 )
-                if anchor_reply_to is not None:
-                    from agent.output_handler import TelegramRelayOutputHandler
+                from agent.output_handler import TelegramRelayOutputHandler
 
+                # React on the reply anchor if present, else on the triggering
+                # message id (#2199) — the stale offhand mention.
+                _react_target = anchor_reply_to or (
+                    TelegramRelayOutputHandler._trigger_reaction_target(session)
+                )
+                if _react_target is not None:
                     rtr_suppress_reaction = TelegramRelayOutputHandler._build_reaction_payload(
                         chat_id,
-                        anchor_reply_to,
+                        _react_target,
                         RTR_SUPPRESS_EMOJI,
                         session_id,
                     )
                     rtr_should_send = False
                     rtr_suppressed_reason = verdict.reason or "suppress"
                 else:
-                    # No anchor: F4 fall-through (send original + log).
+                    # No reaction target: F4 fall-through (send original + log).
                     _rtr_emit_event(
                         session,
                         "rtr.suppress_fallthrough",
                         chat_id=chat_id,
                         draft_text=text,
-                        reason="no_reply_anchor",
+                        reason="no_reaction_target",
                     )
             # else: action == "send" (or "trim" with no revised_text) —
             # fall through with text unchanged.


### PR DESCRIPTION
Closes #2199.

Makes read-the-room (RTR) actually capable of the behavior it was designed for: a stale, offhand group mention where the room has moved on now gets a quiet 👀 reaction on the triggering message instead of an interrupting late text reply.

## The three gaps, closed

**Gap 1 — RTR was off by default / no DM exclusion.** RTR now short-circuits to `send` for DMs (positive Telegram ids) and unclassifiable ids (`_is_group_chat`); it only ever room-reads group chats. A DM always deserves a reply. `READ_THE_ROOM_ENABLED` remains the default-off master kill switch.

**Gap 2 — no staleness signal reached the model.** The triggering message's true age is looked up from `TelegramMessage` by `session.telegram_message_id` (the stored `timestamp` is the message's original `.date`, so a `catch_up` replay reports its real age — no bridge plumbing or new session field needed). It drives:
- a **deterministic** stale short-circuit: `suppress` without a Haiku call when `age >= RTR_STALE_TRIGGER_SECONDS`;
- a `## Trigger age` hint threaded into the Haiku prompt for younger triggers.

**Gap 3 — the reaction fallback was anchor-gated.** On a `suppress` verdict with no reply anchor, the 👀 now lands on the triggering message id (the offhand mention — exactly the case least likely to be a threaded reply). Fall-through to send only when there is no reaction target at all (`reason=no_reaction_target`).

## Enablement decision (issue asked us to settle it)

RTR is a **group-chat** feature; DMs are permanently excluded. The full mechanism ships **group-scoped behind the existing `READ_THE_ROOM_ENABLED` flag, default off**. Flip criterion: sample `rtr.suppressed` `session_events` in a low-stakes group for a day; if genuinely on-topic mentions are not being suppressed and no human reports a missed reply, flip the flag in production. Kill switch = the same flag set back to `false`. What I'd want to observe to tune `RTR_STALE_TRIGGER_SECONDS`: the age distribution of `stale_trigger` suppressions against any human report of a missed reply.

## The staleness threshold

`RTR_STALE_TRIGGER_SECONDS` defaults to **3600s (1 hour)** — a judgment call, not a derived constant. Named, env-overridable, commented provisional/tunable (single-file RTR knob, not promoted to `config.settings` per #1968). 1 hour is a conservative floor so a genuinely in-flight back-and-forth (replies within minutes) is never caught.

## No half-migration

The no-anchor "I heard you" contract is now identical across every suppress site: both RTR suppress branches (Path A), the redundancy-filter suppress branch (Path A), and both Path B (`valor-telegram send`) suppress branches all react on `reply_anchor or trigger_message_id`, falling through only when neither exists. No divergent capability left between paths.

## Persona safety

An offhand stale mention gets a first-person 👀 (`RTR_SUPPRESS_EMOJI`), never a raw error or interrupting narration — same standard as the wrap-up guard.

## Transport / email + #2160/#2159

Telegram-only by design: the staleness+reaction behavior is a group-chat social-grace feature and email has no reaction concept (the email suppress branches already drop the payload). The change is output-side and does not touch the intake decision function, so it neither helps nor hinders the #2160/#2159 intake convergence.

## Tests (unit, targeted)

`test_read_the_room.py`: `_is_group_chat` matrix, DM-excluded, deterministic stale suppress, fresh-trigger age-threaded-into-prompt, absent-age-omits-block, `_humanize_age` matrix. `test_output_handler.py`: suppress-no-anchor-reacts-on-trigger (RTR **and** redundancy), no-target fallthrough reason updated. `test_valor_telegram.py`: Path B unaffected (mocks RTR). 228 passed across the three files; ruff clean.