### PR TITLE
fix(#2396): break bridge watchdog level-5 livelock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -383,7 +383,7 @@ The bridge includes automatic crash recovery (see `docs/features/bridge-self-hea
 - **Session lock cleanup**: Kills stale processes holding session-related files on startup
 - **Bridge watchdog**: Separate launchd service (`com.valor.bridge-watchdog`) monitors health every 60s
 - **Crash tracker**: Logs start/crash events to Redis via `monitoring/crash_tracker.py` with git commit correlation
-- **5-level escalation**: restart → kill stale → clear locks → revert commit → alert human
+- **4-level escalation, plus a decoupled human-alert signal** (#2396): restart → kill stale → clear locks → revert commit; a crash-storm alert (`human_alert_needed`) and a reason-aware restart throttle (`restart_circuit_open`) fire independently of `recovery_level` so a recurring wedge's capped restart is never silently overridden
 - **Update-loop wedged detector** (#1712): detects when the bridge is process-alive but Telethon's `NewMessage` handler has silently stopped firing — auto-restarts with `catch_up=True` for lossless backfill
 
 **Check watchdog**: `python monitoring/bridge_watchdog.py --check-only`

--- a/docs/features/bridge-self-healing.md
+++ b/docs/features/bridge-self-healing.md
@@ -75,15 +75,19 @@ Claude Code CLI subprocesses can become orphaned when their parent session ends 
 
 The `--check-only` output includes zombie count, PIDs, memory usage, and active instance count.
 
-**5-Level Recovery Escalation**:
+**4-Level Recovery Escalation, plus a decoupled human-alert signal** (issue #2396):
 
 | Level | Condition | Action |
 |-------|-----------|--------|
 | 1 | Process not running | Log crash event via `crash_tracker.log_crash("bridge_dead_on_watchdog_check")` + simple restart (launchd) |
 | 2 | Process running but logs stale — or update loop wedged | Kill stale + kill zombies + restart (the bridge always catches up missed messages on startup — see below) |
 | 3 | Lock files present | Kill stale + kill zombies + clear locks + restart |
-| 4 | Crash pattern detected | Kill stale + kill zombies + revert HEAD + restart (if enabled) |
-| 5 | Recovery exhausted | Alert human via Telegram |
+| 4 | Crash pattern detected | Kill stale + kill zombies + revert HEAD + restart (if enabled); if auto-revert is disabled or the revert fails, falls through to "Recovery exhausted" below |
+
+`recovery_level` never reaches 5 — level 5 ("alert human") used to be a silent no-op action level that permanently overrode any lower level once a crash-count threshold was crossed, which livelocked the ladder (the wedge detector's own capped, known-safe restart never got to run). It has been replaced by two independent signals computed alongside `recovery_level`, both on `HealthStatus`:
+
+- **`human_alert_needed`** — set when `get_recent_crashes(1800)` (30 min window) returns `>= CRASH_STORM_THRESHOLD` (default 5, env-overridable) crashes. When true, `_alert_human_of_crash_storm()` enqueues a deduplicated Telegram alert (same `AgentSession`-enqueue pattern as `send_hibernation_notification()`), gated by a 30-minute file-sentinel cooldown (`WATCHDOG_ALERT_COOLDOWN_SECONDS`, env-overridable) so a sustained storm alerts once per window, not once per 60s tick. The same alert fires from the level-4 "recovery exhausted" fallback (`_recovery_exhausted()`), so that previously-silent path now also surfaces a human-visible alert.
+- **`restart_circuit_open`** — a reason-aware restart throttle for *non-wedge* storms. `CrashEvent.reason` classifies each crash; when the storm is not wedge-dominated (`wedge_count < len(recent_crashes) * WEDGE_DOMINANCE_FRACTION`, default fraction `0.9` — a bare `0.5` majority would let a 50/50 wedge+real-bug storm through), `restart_circuit_open` is set and `run_health_check()` skips `execute_recovery()` for that tick entirely (still alerting). A **wedge-dominated** storm always leaves this False, so the wedge detector's already-capped restart (level 2, `launchctl kickstart` with `catch_up=True`) keeps running every tick with no attempt ceiling — restarting is cheap and idempotent, and throttling it would recreate the exact livelock this fix removes.
 
 Zombie cleanup is integrated into recovery levels 2+ to free memory before restarting.
 
@@ -118,7 +122,7 @@ A SECONDARY accelerator fires at `UPDATE_STALENESS_WARN` (before the ceiling) to
 - **Startup grace window**: `bridge:last_update_received` is absent on cold start (bridge has not received any messages yet). The grace window prevents false wedge verdicts during startup before Telegram delivers the first event.
 - **`None` process-start = fail-safe**: if `get_bridge_process_start_ts()` returns `None` (process info unavailable), the detector treats the verdict as inconclusive and suppresses the restart. This avoids a restart based on incomplete information.
 
-**Recovery**: when `update_flow_live=False`, the watchdog sets `recovery_level = max(recovery_level, 2)` and calls the standard `restart_bridge()` (a `launchctl kickstart` — it takes no arguments). The level cap of 2 is hard — the wedge detector never escalates to level 4 (auto-revert), regardless of how many consecutive wedge ticks occur. Lossless backfill is inherent to bridge startup, not a flag the watchdog passes: the bridge unconditionally initializes Telethon with `catch_up=True` and runs a missed-message catchup scan on every connect, so any restart recovers the messages that arrived during the wedge window.
+**Recovery**: when `update_flow_live=False`, the watchdog sets `recovery_level = max(recovery_level, 2)` and calls the standard `restart_bridge()` (a `launchctl kickstart` — it takes no arguments). The level cap of 2 is hard — the wedge detector never escalates to level 4 (auto-revert), regardless of how many consecutive wedge ticks occur. Lossless backfill is inherent to bridge startup, not a flag the watchdog passes: the bridge unconditionally initializes Telethon with `catch_up=True` and runs a missed-message catchup scan on every connect, so any restart recovers the messages that arrived during the wedge window. This level-2 cap is now honored end to end: previously, a wedge that recurred faster than the crash-count window could re-cross while the crash-count check was still active, silently overriding this capped restart with the level-5 no-op (issue #2396). Because that override no longer exists, a recurring wedge always gets its capped restart on every tick — the crash-count storm this produces (all `bridge_update_loop_wedged`-reason crashes) is wedge-dominated, so `restart_circuit_open` stays False and the restart is never throttled.
 
 **Log signals**:
 ```

--- a/monitoring/bridge_watchdog.py
+++ b/monitoring/bridge_watchdog.py
@@ -2,14 +2,22 @@
 """Bridge watchdog - external health monitor for the Telegram bridge.
 
 This runs as a SEPARATE process from the bridge (via launchd) so it can
-detect and recover from bridge crashes. It implements a 5-level recovery
-escalation chain:
+detect and recover from bridge crashes. It implements a 4-level recovery
+escalation chain for corrective *action*, plus a decoupled human-alert
+signal layered on top (issue #2396):
 
 1. Simple restart (launchd handles this automatically)
 2. Kill stale processes + restart
 3. Clear lock files + restart
 4. Revert recent commit + restart (if enabled)
-5. Alert human with diagnostics
+
+A crash-count storm (>= CRASH_STORM_THRESHOLD crashes in 30 min) no longer
+overrides the action level to a silent no-op "level 5". Instead it sets
+HealthStatus.human_alert_needed (a deduplicated Telegram alert fires) and,
+for storms that are NOT wedge-dominated, HealthStatus.restart_circuit_open
+(suppresses that tick's restart to avoid thrashing a genuinely broken
+bridge). A wedge-dominated storm always gets its already-capped, known-safe
+restart -- see docs/features/bridge-self-healing.md.
 
 Usage:
     python monitoring/bridge_watchdog.py        # Run once (for launchd)
@@ -79,6 +87,11 @@ ERROR_LOG = PROJECT_DIR / "logs" / "bridge.error.log"
 DATA_DIR = PROJECT_DIR / "data"
 RECOVERY_LOCK = DATA_DIR / "recovery-in-progress"
 AUTO_REVERT_ENABLED_FILE = DATA_DIR / "auto-revert-enabled"
+# Human-alert dedup cooldown sentinel (issue #2396). mtime-based, create-or-refresh
+# via touch() -- deliberately not an exclusive-create primitive, since exclusive
+# create cannot refresh an existing sentinel's mtime and this cooldown needs to
+# persist across windows and be reused.
+COOLDOWN_FILE = DATA_DIR / "bridge-watchdog-alert-cooldown"
 
 # Update release-verify signals (issue #1898):
 # - UPDATE_RESTART_MARKER: written by remote-update.sh just before its
@@ -104,6 +117,18 @@ STARTUP_GRACE_SECONDS = 5 * 60  # 5 minutes — grace window after bridge start
 # How recent last_probe_ok must be to count as "API layer healthy"
 PROBE_FRESHNESS_SECONDS = 3 * 3600  # 3 hours
 
+# Crash-storm / human-alert thresholds (issue #2396). Env-overridable, provisional/
+# tunable -- adjust if real-world storm sizes or alert cadence prove wrong.
+CRASH_STORM_THRESHOLD = int(os.environ.get("CRASH_STORM_THRESHOLD", "5"))
+# Fraction of a crash storm that must be wedge-reason for the storm to be treated
+# as "wedge-dominated" (restart always runs, no circuit breaker). Deliberately a
+# high bar (0.9, not a bare 0.5 majority) so a meaningfully mixed storm (e.g. a
+# 50/50 wedge + real-bug split) still opens the circuit rather than restart-looping
+# a genuinely broken bridge. See docs/plans/bridge_watchdog_level_5_livelock.md.
+WEDGE_DOMINANCE_FRACTION = float(os.environ.get("WEDGE_DOMINANCE_FRACTION", "0.9"))
+# Minimum spacing between deduplicated human alerts during a sustained crash storm.
+WATCHDOG_ALERT_COOLDOWN_SECONDS = int(os.environ.get("WATCHDOG_ALERT_COOLDOWN_SECONDS", "1800"))
+
 # Process name patterns to scan for zombies.
 # ZOMBIE_PROCESS_EXCLUDES filters out Claude Desktop app helper processes.
 ZOMBIE_PROCESS_PATTERNS = ("claude ", "pyright")
@@ -121,13 +146,20 @@ class HealthStatus:
     logs_fresh: bool
     no_crash_pattern: bool
     issues: list[str]
-    recovery_level: int  # 0 = healthy, 1-5 = escalation level needed
+    # 0 = healthy, 1-4 = escalation action level (5/alert is a separate
+    # signal — see human_alert_needed)
+    recovery_level: int
     zombie_count: int = 0
     zombie_pids: list[int] | None = None
     zombie_memory_mb: float = 0.0
     active_claude_count: int = 0
     update_flow_live: bool = True  # default True preserves existing tests
     update_flow_issue: str = ""
+    # issue #2396: crash-count signal split from the action level. A storm no
+    # longer overrides recovery_level to a silent no-op 5 -- it sets these two
+    # independent flags instead (see module docstring).
+    human_alert_needed: bool = False
+    restart_circuit_open: bool = False
 
     def __post_init__(self):
         if self.zombie_pids is None:
@@ -506,11 +538,23 @@ def check_bridge_health() -> HealthStatus:
         else:
             recovery_level = max(recovery_level, 3)
 
-    # Check recent crash count
+    # Check recent crash count (issue #2396: reason-aware, decoupled from the
+    # action level). A storm no longer forces recovery_level to a silent
+    # no-op 5 -- it sets human_alert_needed, and (for non-wedge-dominated
+    # storms only) restart_circuit_open to suppress that tick's restart.
     recent_crashes = get_recent_crashes(1800)  # 30 min
-    if len(recent_crashes) >= 5:
+    human_alert_needed = False
+    restart_circuit_open = False
+    if len(recent_crashes) >= CRASH_STORM_THRESHOLD:
         issues.append(f"{len(recent_crashes)} crashes in last 30 minutes")
-        recovery_level = max(recovery_level, 5)  # Alert human
+        human_alert_needed = True
+        wedge_count = sum(1 for c in recent_crashes if c.reason == "bridge_update_loop_wedged")
+        if wedge_count < len(recent_crashes) * WEDGE_DOMINANCE_FRACTION:
+            # Not wedge-dominated -- open the circuit so a genuinely broken
+            # bridge doesn't restart-loop every tick (Risk 1). A wedge-
+            # dominated storm leaves this False so the capped, known-safe
+            # restart keeps running every tick with no attempt ceiling.
+            restart_circuit_open = True
 
     # Check 4: Zombie process detection
     all_processes = _enumerate_claude_processes()
@@ -577,6 +621,8 @@ def check_bridge_health() -> HealthStatus:
         active_claude_count=active_claude_count,
         update_flow_live=update_flow_live,
         update_flow_issue=update_flow_issue,
+        human_alert_needed=human_alert_needed,
+        restart_circuit_open=restart_circuit_open,
     )
 
 
@@ -673,6 +719,105 @@ def _kill_detected_zombies() -> int:
     return 0
 
 
+def _alert_cooldown_open() -> bool:
+    """Return True and stamp the cooldown sentinel if the alert window is open.
+
+    Read-mtime-then-touch() create-or-refresh primitive (issue #2396, C1).
+    Deliberately not an exclusive-create flag: exclusive-create fails on an
+    existing file and so cannot refresh a persistent expiry sentinel's mtime,
+    which is exactly what this cooldown needs (the sentinel must be reusable
+    across windows, not a one-shot marker). Single-writer-per-tick model (see
+    Race Conditions in the plan) makes a cross-process atomic CAS unnecessary
+    here.
+    """
+    try:
+        age = time.time() - COOLDOWN_FILE.stat().st_mtime
+    except FileNotFoundError:
+        age = None
+
+    if age is not None and age < WATCHDOG_ALERT_COOLDOWN_SECONDS:
+        return False
+
+    try:
+        COOLDOWN_FILE.parent.mkdir(parents=True, exist_ok=True)
+        COOLDOWN_FILE.touch()
+    except Exception as e:
+        logger.debug("Failed to stamp alert cooldown sentinel: %s", e)
+    return True
+
+
+def _alert_cooldown_remaining() -> bool:
+    """Read-only variant of the cooldown check -- never stamps the sentinel.
+
+    Used by ``--check-only`` so a diagnostic run can never consume the
+    dedup window. Returns True if currently on cooldown (i.e. an alert would
+    NOT fire right now).
+    """
+    try:
+        age = time.time() - COOLDOWN_FILE.stat().st_mtime
+    except FileNotFoundError:
+        return False
+    return age < WATCHDOG_ALERT_COOLDOWN_SECONDS
+
+
+def _alert_human_of_crash_storm(issues: list[str]) -> None:
+    """Enqueue a deduplicated Telegram alert for a sustained crash storm.
+
+    Modeled on ``send_hibernation_notification()`` in agent/sustainability.py
+    -- enqueues a lightweight AgentSession with a pre-composed "send this
+    exact Telegram message" instruction rather than building a new outbound
+    send path. Fail-quiet: never raises, matching every other recovery
+    helper in this module.
+
+    The cooldown gate lives here so every caller (the human_alert_needed
+    path in run_health_check(), and _recovery_exhausted() below) shares one
+    dedup window -- whichever fires first in a tick stamps the sentinel and
+    the other finds it closed.
+    """
+    try:
+        if not _alert_cooldown_open():
+            logger.debug("Human alert on cooldown, skipping")
+            return
+
+        from models.agent_session import AgentSession
+
+        command = (
+            "Send a Telegram message to the 'Eng: Valor' chat with this exact text:\n"
+            f"[{_hostname()}] Bridge watchdog: sustained crash storm detected. "
+            f"Issues: {', '.join(issues)}. Manual investigation may be required."
+        )
+        notification_session = AgentSession(
+            session_type="teammate",
+            project_key=os.environ.get("VALOR_PROJECT_KEY", "valor").strip() or "valor",
+            command=command,
+        )
+        notification_session.save()
+        logger.info(
+            "Enqueued crash-storm alert notification session %s",
+            getattr(notification_session, "agent_session_id", "?"),
+        )
+    except Exception as e:
+        logger.error("Failed to enqueue crash-storm alert notification: %s", e)
+
+
+def _recovery_exhausted(issues: list[str]) -> bool:
+    """Log critical failure and fire the deduplicated human alert.
+
+    Replaces the former level-5 dispatch branch. Reached from the level-4
+    branch when auto-revert is disabled or the revert itself fails (issue
+    #2396, B1) -- level 5 is no longer a valid ``execute_recovery`` level.
+    """
+    logger.critical(
+        "[%s] Bridge recovery failed — levels 1-4 exhausted."
+        " Issues: %s. Manual intervention required.",
+        _hostname(),
+        ", ".join(issues),
+    )
+    log_crash(f"[{_hostname()}] Recovery exhausted")
+    _alert_human_of_crash_storm(issues)
+    return False
+
+
 def execute_recovery(level: int, issues: list[str]) -> bool:
     """Execute recovery at the specified escalation level."""
     if level == 0:
@@ -716,8 +861,8 @@ def execute_recovery(level: int, issues: list[str]) -> bool:
         elif level == 4:
             # Revert commit + restart
             if not AUTO_REVERT_ENABLED_FILE.exists():
-                logger.warning("Auto-revert not enabled, escalating to level 5")
-                return execute_recovery(5, issues)
+                logger.warning("Auto-revert not enabled, recovery exhausted")
+                return _recovery_exhausted(issues)
 
             kill_stale_processes()
             _kill_detected_zombies()
@@ -732,18 +877,7 @@ def execute_recovery(level: int, issues: list[str]) -> bool:
                 time.sleep(2)
                 return restart_bridge()
             else:
-                return execute_recovery(5, issues)
-
-        elif level == 5:
-            # Log critical failure with hostname for multi-machine debugging
-            logger.critical(
-                "[%s] Bridge recovery failed — levels 1-4 exhausted."
-                " Issues: %s. Manual intervention required.",
-                _hostname(),
-                ", ".join(issues),
-            )
-            log_crash(f"[{_hostname()}] Recovery exhausted")
-            return False
+                return _recovery_exhausted(issues)
 
     finally:
         # Remove recovery lock
@@ -882,6 +1016,20 @@ def run_health_check() -> bool:
         except Exception as e:
             logger.debug("Failed to log wedge crash event: %s", e)
 
+    # Fire the deduplicated human alert independent of which action level (if
+    # any) ends up executing this tick (issue #2396).
+    if status.human_alert_needed:
+        _alert_human_of_crash_storm(status.issues)
+
+    # Non-wedge-dominated crash storm: suppress the restart entirely for this
+    # tick to avoid thrashing a genuinely broken bridge (C2). A wedge-
+    # dominated storm leaves this False so the capped restart always runs.
+    if status.restart_circuit_open:
+        logger.critical(
+            "Non-wedge crash storm — restart circuit open, skipping restart to avoid thrash"
+        )
+        return False
+
     # Execute recovery
     success = execute_recovery(status.recovery_level, status.issues)
 
@@ -943,6 +1091,9 @@ def main():
         print(f"Update flow live: {status.update_flow_live}")
         if not status.update_flow_live:
             print(f"Update flow issue: {status.update_flow_issue}")
+        print(f"Human alert needed: {status.human_alert_needed}")
+        print(f"Alert on cooldown: {_alert_cooldown_remaining()}")
+        print(f"Restart circuit open: {status.restart_circuit_open}")
         return 0 if status.healthy else 1
 
     if args.loop:

--- a/tests/unit/test_bridge_watchdog.py
+++ b/tests/unit/test_bridge_watchdog.py
@@ -15,6 +15,7 @@ from monitoring.bridge_watchdog import (
     classify_zombies,
     kill_zombie_processes,
 )
+from monitoring.crash_tracker import CrashEvent
 
 # --- _parse_elapsed_time tests ---
 
@@ -349,6 +350,25 @@ class TestHealthStatus:
         assert status.zombie_pids == []
         assert status.zombie_memory_mb == 0.0
         assert status.active_claude_count == 0
+        assert status.human_alert_needed is False
+        assert status.restart_circuit_open is False
+
+    def test_alert_signal_fields_settable(self):
+        """issue #2396: human_alert_needed / restart_circuit_open are independent
+        of recovery_level -- a level-2 action can coexist with an alert signal."""
+        status = HealthStatus(
+            healthy=False,
+            process_running=True,
+            logs_fresh=True,
+            no_crash_pattern=True,
+            issues=["5 crashes in last 30 minutes"],
+            recovery_level=2,
+            human_alert_needed=True,
+            restart_circuit_open=True,
+        )
+        assert status.recovery_level == 2
+        assert status.human_alert_needed is True
+        assert status.restart_circuit_open is True
 
     def test_zombie_fields_populated(self):
         status = HealthStatus(
@@ -440,8 +460,8 @@ class TestCheckOnlyOutput:
     """Tests for --check-only output format including zombie data."""
 
     @patch("monitoring.bridge_watchdog.check_bridge_health")
-    def test_check_only_includes_zombie_section(self, mock_health, capsys):
-        from monitoring.bridge_watchdog import main
+    def test_check_only_includes_zombie_section(self, mock_health, capsys, tmp_path):
+        from monitoring import bridge_watchdog as bw
 
         mock_health.return_value = HealthStatus(
             healthy=True,
@@ -456,12 +476,18 @@ class TestCheckOnlyOutput:
             active_claude_count=2,
         )
 
-        with patch("sys.argv", ["bridge_watchdog.py", "--check-only"]):
-            result = main()
+        with (
+            patch.object(bw, "COOLDOWN_FILE", tmp_path / "no-cooldown"),
+            patch("sys.argv", ["bridge_watchdog.py", "--check-only"]),
+        ):
+            result = bw.main()
 
         output = capsys.readouterr().out
         assert "Zombie processes: 0" in output
         assert "Active claude instances: 2" in output
+        assert "Human alert needed: False" in output
+        assert "Alert on cooldown: False" in output
+        assert "Restart circuit open: False" in output
         assert result == 0
 
     @patch("monitoring.bridge_watchdog.check_bridge_health")
@@ -874,3 +900,386 @@ class TestUpdateReleaseSignals:
             bw.run_health_check()
 
         assert any("[update-release]" in r.message for r in caplog.records)
+
+
+# --- issue #2396: crash-count signal split from action level ---
+
+
+def _wedge_crash(ts: float) -> CrashEvent:
+    return CrashEvent(
+        timestamp=ts,
+        event_type="crash",
+        commit_sha="abc123",
+        commit_age_seconds=100.0,
+        reason="bridge_update_loop_wedged",
+    )
+
+
+def _other_crash(ts: float, reason: str = "some_other_crash") -> CrashEvent:
+    return CrashEvent(
+        timestamp=ts,
+        event_type="crash",
+        commit_sha="abc123",
+        commit_age_seconds=100.0,
+        reason=reason,
+    )
+
+
+class TestCrashStormActionAlertSplit:
+    """check_bridge_health(): crash-count storm no longer overrides
+    recovery_level to a no-op 5 -- it sets human_alert_needed and
+    (reason-aware) restart_circuit_open instead."""
+
+    @patch("monitoring.bridge_watchdog._enumerate_claude_processes")
+    @patch("monitoring.bridge_watchdog.get_recent_crashes")
+    @patch("monitoring.bridge_watchdog.detect_crash_pattern")
+    @patch("monitoring.bridge_watchdog.are_logs_fresh")
+    @patch("monitoring.bridge_watchdog.is_bridge_running")
+    def test_wedge_dominated_crash_storm_livelock_regression(
+        self, mock_running, mock_logs, mock_crash, mock_crashes, mock_enumerate
+    ):
+        """SC1: a large all-wedge storm (12 crashes, well above the threshold)
+        never opens the circuit and never suppresses the action level -- there
+        is no attempt ceiling on the wedge restart."""
+        import time as _time
+
+        mock_running.return_value = (True, 1234)
+        mock_logs.return_value = True
+        mock_crash.return_value = (False, None)
+        now = _time.time()
+        mock_crashes.return_value = [_wedge_crash(now - i) for i in range(12)]
+        mock_enumerate.return_value = []
+
+        status = check_bridge_health()
+
+        assert status.human_alert_needed is True
+        assert status.restart_circuit_open is False
+        # recovery_level never escalated to a former "5" -- it stays whatever
+        # the other checks computed (0 here, since nothing else fired).
+        assert status.recovery_level in (0, 1, 2, 3, 4)
+
+    @patch("monitoring.bridge_watchdog._enumerate_claude_processes")
+    @patch("monitoring.bridge_watchdog.get_recent_crashes")
+    @patch("monitoring.bridge_watchdog.detect_crash_pattern")
+    @patch("monitoring.bridge_watchdog.are_logs_fresh")
+    @patch("monitoring.bridge_watchdog.is_bridge_running")
+    def test_non_wedge_storm_opens_circuit(
+        self, mock_running, mock_logs, mock_crash, mock_crashes, mock_enumerate
+    ):
+        """C2: a storm of non-wedge crashes opens restart_circuit_open while
+        still requesting a human alert (today's throttle is preserved)."""
+        import time as _time
+
+        mock_running.return_value = (True, 1234)
+        mock_logs.return_value = True
+        mock_crash.return_value = (False, None)
+        now = _time.time()
+        mock_crashes.return_value = [_other_crash(now - i) for i in range(5)]
+        mock_enumerate.return_value = []
+
+        status = check_bridge_health()
+
+        assert status.human_alert_needed is True
+        assert status.restart_circuit_open is True
+
+    @patch("monitoring.bridge_watchdog._enumerate_claude_processes")
+    @patch("monitoring.bridge_watchdog.get_recent_crashes")
+    @patch("monitoring.bridge_watchdog.detect_crash_pattern")
+    @patch("monitoring.bridge_watchdog.are_logs_fresh")
+    @patch("monitoring.bridge_watchdog.is_bridge_running")
+    def test_mixed_50_50_storm_opens_circuit(
+        self, mock_running, mock_logs, mock_crash, mock_crashes, mock_enumerate
+    ):
+        """Re-critique blocker: WEDGE_DOMINANCE_FRACTION = 0.9 means a bare
+        50/50 mixed storm (3 wedge + 3 non-wedge) is NOT wedge-dominated and
+        must open the circuit -- a 0.5 bar would incorrectly let it through."""
+        import time as _time
+
+        mock_running.return_value = (True, 1234)
+        mock_logs.return_value = True
+        mock_crash.return_value = (False, None)
+        now = _time.time()
+        mock_crashes.return_value = [_wedge_crash(now - i) for i in range(3)] + [
+            _other_crash(now - i) for i in range(3)
+        ]
+        mock_enumerate.return_value = []
+
+        status = check_bridge_health()
+
+        assert status.human_alert_needed is True
+        assert status.restart_circuit_open is True
+
+    @patch("monitoring.bridge_watchdog._enumerate_claude_processes")
+    @patch("monitoring.bridge_watchdog.get_recent_crashes")
+    @patch("monitoring.bridge_watchdog.detect_crash_pattern")
+    @patch("monitoring.bridge_watchdog.are_logs_fresh")
+    @patch("monitoring.bridge_watchdog.is_bridge_running")
+    def test_below_threshold_no_alert_no_circuit(
+        self, mock_running, mock_logs, mock_crash, mock_crashes, mock_enumerate
+    ):
+        """Fewer than CRASH_STORM_THRESHOLD crashes: neither signal fires."""
+        import time as _time
+
+        mock_running.return_value = (True, 1234)
+        mock_logs.return_value = True
+        mock_crash.return_value = (False, None)
+        now = _time.time()
+        mock_crashes.return_value = [_other_crash(now)]
+        mock_enumerate.return_value = []
+
+        status = check_bridge_health()
+
+        assert status.human_alert_needed is False
+        assert status.restart_circuit_open is False
+
+    def test_safety_constants_env_overridable(self, monkeypatch):
+        """Re-critique Concern 3: the three safety-critical constants are read
+        via os.environ.get, not hard-coded -- verified by re-importing the
+        module with overridden env vars."""
+        import importlib
+
+        monkeypatch.setenv("CRASH_STORM_THRESHOLD", "9")
+        monkeypatch.setenv("WEDGE_DOMINANCE_FRACTION", "0.75")
+        monkeypatch.setenv("WATCHDOG_ALERT_COOLDOWN_SECONDS", "42")
+
+        from monitoring import bridge_watchdog as bw
+
+        reloaded = importlib.reload(bw)
+        try:
+            assert reloaded.CRASH_STORM_THRESHOLD == 9
+            assert reloaded.WEDGE_DOMINANCE_FRACTION == 0.75
+            assert reloaded.WATCHDOG_ALERT_COOLDOWN_SECONDS == 42
+        finally:
+            # Restore module state for subsequent tests in the same process.
+            monkeypatch.delenv("CRASH_STORM_THRESHOLD", raising=False)
+            monkeypatch.delenv("WEDGE_DOMINANCE_FRACTION", raising=False)
+            monkeypatch.delenv("WATCHDOG_ALERT_COOLDOWN_SECONDS", raising=False)
+            importlib.reload(bw)
+
+
+class TestAlertCooldown:
+    """_alert_cooldown_open() / _alert_cooldown_remaining(): file-sentinel
+    create-or-refresh cooldown gate (issue #2396, C1)."""
+
+    def test_window_open_when_no_sentinel(self, tmp_path):
+        from monitoring import bridge_watchdog as bw
+
+        with patch.object(bw, "COOLDOWN_FILE", tmp_path / "cooldown"):
+            assert bw._alert_cooldown_open() is True
+            # Stamped as a side effect -- immediately re-checking is closed.
+            assert bw._alert_cooldown_open() is False
+
+    def test_cooldown_expired_refires_and_restamps(self, tmp_path):
+        import os as _os
+        import time as _time
+
+        from monitoring import bridge_watchdog as bw
+
+        sentinel = tmp_path / "cooldown"
+        sentinel.write_text("x")
+        aged = _time.time() - (bw.WATCHDOG_ALERT_COOLDOWN_SECONDS + 10)
+        _os.utime(sentinel, (aged, aged))
+
+        with patch.object(bw, "COOLDOWN_FILE", sentinel):
+            assert bw._alert_cooldown_open() is True
+            mtime_after = sentinel.stat().st_mtime
+
+        assert _time.time() - mtime_after < 5  # freshly re-stamped
+
+    def test_check_only_variant_never_stamps(self, tmp_path):
+        """--check-only must never consume the cooldown window."""
+        from monitoring import bridge_watchdog as bw
+
+        sentinel = tmp_path / "cooldown"
+        with patch.object(bw, "COOLDOWN_FILE", sentinel):
+            assert bw._alert_cooldown_remaining() is False
+            assert not sentinel.exists()  # read-only variant creates nothing
+
+    def test_check_only_variant_reports_within_window(self, tmp_path):
+        from monitoring import bridge_watchdog as bw
+
+        sentinel = tmp_path / "cooldown"
+        sentinel.write_text("x")
+        with patch.object(bw, "COOLDOWN_FILE", sentinel):
+            assert bw._alert_cooldown_remaining() is True
+
+
+class TestAlertHumanOfCrashStorm:
+    """_alert_human_of_crash_storm(): fail-quiet, deduplicated Telegram alert."""
+
+    def test_enqueues_agent_session_when_cooldown_open(self, tmp_path):
+        from monitoring import bridge_watchdog as bw
+
+        with (
+            patch.object(bw, "COOLDOWN_FILE", tmp_path / "cooldown"),
+            patch("models.agent_session.AgentSession") as mock_session_cls,
+        ):
+            mock_instance = MagicMock()
+            mock_session_cls.return_value = mock_instance
+
+            bw._alert_human_of_crash_storm(["5 crashes in last 30 minutes"])
+
+            mock_session_cls.assert_called_once()
+            mock_instance.save.assert_called_once()
+
+    def test_second_call_within_cooldown_is_noop(self, tmp_path):
+        from monitoring import bridge_watchdog as bw
+
+        with (
+            patch.object(bw, "COOLDOWN_FILE", tmp_path / "cooldown"),
+            patch("models.agent_session.AgentSession") as mock_session_cls,
+        ):
+            mock_instance = MagicMock()
+            mock_session_cls.return_value = mock_instance
+
+            bw._alert_human_of_crash_storm(["issue 1"])
+            bw._alert_human_of_crash_storm(["issue 2"])
+
+            mock_session_cls.assert_called_once()
+
+    def test_exception_in_agent_session_does_not_raise(self, tmp_path):
+        """Fail-quiet contract: an exception building/saving the notification
+        session must not propagate."""
+        from monitoring import bridge_watchdog as bw
+
+        with (
+            patch.object(bw, "COOLDOWN_FILE", tmp_path / "cooldown"),
+            patch("models.agent_session.AgentSession", side_effect=Exception("boom")),
+        ):
+            # Should not raise.
+            bw._alert_human_of_crash_storm(["issue"])
+
+
+class TestRecoveryExhaustedFallback:
+    """execute_recovery(): level 5 is no longer a valid dispatch target;
+    both former level-4 fallback paths route through _recovery_exhausted()
+    (issue #2396, B1)."""
+
+    def test_level_5_no_longer_dispatched(self, tmp_path):
+        from monitoring import bridge_watchdog as bw
+
+        with patch.object(bw, "RECOVERY_LOCK", tmp_path / "recovery-lock"):
+            # level 5 falls through every elif and returns the bare False at
+            # the bottom of execute_recovery -- it is not a valid level.
+            assert bw.execute_recovery(5, ["issues"]) is False
+
+    @patch("monitoring.bridge_watchdog._alert_human_of_crash_storm")
+    @patch("monitoring.bridge_watchdog.log_crash")
+    def test_auto_revert_disabled_routes_to_recovery_exhausted(
+        self, mock_log_crash, mock_alert, tmp_path
+    ):
+        from monitoring import bridge_watchdog as bw
+
+        with (
+            patch.object(bw, "RECOVERY_LOCK", tmp_path / "recovery-lock"),
+            patch.object(bw, "AUTO_REVERT_ENABLED_FILE", tmp_path / "not-enabled"),
+        ):
+            result = bw.execute_recovery(4, ["crash pattern detected"])
+
+        assert result is False
+        mock_log_crash.assert_called_once()
+        assert "Recovery exhausted" in mock_log_crash.call_args[0][0]
+        mock_alert.assert_called_once()
+
+    @patch("monitoring.bridge_watchdog._alert_human_of_crash_storm")
+    @patch("monitoring.bridge_watchdog.log_crash")
+    @patch("monitoring.bridge_watchdog.revert_last_commit")
+    @patch("monitoring.bridge_watchdog.restart_bridge")
+    @patch("monitoring.bridge_watchdog.kill_stale_processes")
+    @patch("monitoring.bridge_watchdog._kill_detected_zombies")
+    @patch("monitoring.bridge_watchdog.clear_lock_files")
+    def test_revert_failure_routes_to_recovery_exhausted(
+        self,
+        mock_clear_locks,
+        mock_kill_zombies,
+        mock_kill_stale,
+        mock_restart,
+        mock_revert,
+        mock_log_crash,
+        mock_alert,
+        tmp_path,
+    ):
+        from monitoring import bridge_watchdog as bw
+
+        mock_revert.return_value = False
+        auto_revert_file = tmp_path / "auto-revert-enabled"
+        auto_revert_file.touch()
+
+        with (
+            patch.object(bw, "RECOVERY_LOCK", tmp_path / "recovery-lock"),
+            patch.object(bw, "AUTO_REVERT_ENABLED_FILE", auto_revert_file),
+        ):
+            result = bw.execute_recovery(4, ["crash pattern detected"])
+
+        assert result is False
+        mock_restart.assert_not_called()
+        mock_log_crash.assert_called_once()
+        mock_alert.assert_called_once()
+
+
+class TestRunHealthCheckAlertAndCircuitWiring:
+    """run_health_check(): fires the alert independent of the action level
+    and skips execute_recovery() entirely when the circuit is open."""
+
+    @patch("monitoring.bridge_watchdog.execute_recovery")
+    @patch("monitoring.bridge_watchdog._alert_human_of_crash_storm")
+    @patch("monitoring.bridge_watchdog.check_bridge_health")
+    def test_circuit_open_skips_execute_recovery_but_still_alerts(
+        self, mock_health, mock_alert, mock_recovery, tmp_path
+    ):
+        from monitoring import bridge_watchdog as bw
+
+        mock_health.return_value = HealthStatus(
+            healthy=False,
+            process_running=True,
+            logs_fresh=True,
+            no_crash_pattern=True,
+            issues=["5 crashes in last 30 minutes"],
+            recovery_level=0,
+            human_alert_needed=True,
+            restart_circuit_open=True,
+        )
+
+        with (
+            patch("bridge.hibernation.AUTH_REQUIRED_FLAG", tmp_path / "no-hibernation"),
+            patch.object(bw, "RECOVERY_LOCK", tmp_path / "no-recovery-lock"),
+            patch.object(bw, "UPDATE_RESTART_MARKER", tmp_path / "no-marker"),
+        ):
+            result = bw.run_health_check()
+
+        assert result is False
+        mock_alert.assert_called_once()
+        mock_recovery.assert_not_called()
+
+    @patch("monitoring.bridge_watchdog.execute_recovery")
+    @patch("monitoring.bridge_watchdog._alert_human_of_crash_storm")
+    @patch("monitoring.bridge_watchdog.check_bridge_health")
+    def test_wedge_dominated_storm_alerts_and_still_executes_recovery(
+        self, mock_health, mock_alert, mock_recovery, tmp_path
+    ):
+        """A wedge-dominated storm: human_alert_needed True, circuit closed
+        -- execute_recovery() still runs with the real action level."""
+        from monitoring import bridge_watchdog as bw
+
+        mock_health.return_value = HealthStatus(
+            healthy=False,
+            process_running=True,
+            logs_fresh=True,
+            no_crash_pattern=True,
+            issues=["update loop wedged", "12 crashes in last 30 minutes"],
+            recovery_level=2,
+            human_alert_needed=True,
+            restart_circuit_open=False,
+        )
+        mock_recovery.return_value = True
+
+        with (
+            patch("bridge.hibernation.AUTH_REQUIRED_FLAG", tmp_path / "no-hibernation"),
+            patch.object(bw, "RECOVERY_LOCK", tmp_path / "no-recovery-lock"),
+            patch.object(bw, "UPDATE_RESTART_MARKER", tmp_path / "no-marker"),
+        ):
+            result = bw.run_health_check()
+
+        assert result is True
+        mock_alert.assert_called_once()
+        mock_recovery.assert_called_once_with(2, mock_health.return_value.issues)


### PR DESCRIPTION
## Summary

- The bridge watchdog's 5-level recovery escalation permanently pinned at level 5 ("alert human," which took no action and sent no alert) once a 30-minute crash-count threshold was crossed — this livelocked recovery for a recurring Telethon update-loop wedge, since the same threshold re-crossed every tick and silently overrode the level-2 restart the wedge detector had already judged safe.
- Splits the crash-count signal into two independent `HealthStatus` fields instead of overriding `recovery_level`: `human_alert_needed` (deduplicated Telegram alert, 30-min cooldown, also now fires from the previously-silent level-4 "recovery exhausted" fallback) and `restart_circuit_open` (reason-aware throttle — a non-wedge-dominated storm suppresses that tick's restart; a wedge-dominated storm always restarts, every tick, no cap).
- `recovery_level` now only ever reaches 1-4. Level 5 is deleted as a dispatch target; former call sites route through a new `_recovery_exhausted()` helper. Three safety constants (`CRASH_STORM_THRESHOLD`, `WEDGE_DOMINANCE_FRACTION`, `WATCHDOG_ALERT_COOLDOWN_SECONDS`) are env-overridable. `--check-only` output gains the three new signal lines.
- Updated `docs/features/bridge-self-healing.md` (escalation table + wedge-detector recovery paragraph) and the stale `1-5` field comment.

Plan: `docs/plans/bridge_watchdog_level_5_livelock.md`

## Test plan

- [x] `scripts/pytest-clean.sh tests/unit/test_bridge_watchdog.py tests/integration/test_update_loop_wedge_recovery.py -q` — 87 passed
- [x] `python -m ruff check` / `ruff format --check` on changed files — clean
- [x] Verification grep table from the plan (level-5 dispatch removed, `_recovery_exhausted` present, `restart_circuit_open` present, `WEDGE_DOMINANCE_FRACTION` default `0.9`, no backoff mechanism, env-overridable constants, stale comment fixed, no `O_EXCL`, docs updated) — all pass
- [ ] Live post-deploy check (C4, plan Success Criteria): after merge and `/update` on the bridge machine, run `python monitoring/bridge_watchdog.py --check-only` and confirm `Recovery level:` is 0-4 (never 5) plus the new alert/circuit lines; tail `logs/watchdog.log` and confirm no pinned "Executing recovery level 5" loop

Closes #2396
