### PR TITLE
Resolve PR head SHA git-first so stale gh reads can't defeat the verdict gate (#2404)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,7 @@ for s in stale: s.delete()
 - Bridge uses nudge loop for output routing (no SDLC awareness in bridge)
 - `/sdlc` is a **single-stage router**: it assesses state, invokes ONE sub-skill, and returns
 - NEVER write code, run tests, or create plans directly -- always delegate through sub-skills
+- Agent gating reads of a PR's head SHA must resolve through `tools/pr_head_resolver.py::resolve_pr_head_sha` (git-first via `git ls-remote refs/pull/N/head`), never a bare `gh` read — a stale `gh` head SHA matches the recorded verdict's trailer and flips the verdict-staleness gate from fail-closed to fail-open (#2404; see `docs/features/gh-stale-state-verdict-gate.md`)
 - See `.claude/skills/sdlc/SKILL.md` for the ground truth on pipeline stages
 
 ### 10. ALWAYS RESTART RUNNING SERVICES

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -73,6 +73,7 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [Env Completeness Validation](env-completeness-validation.md) | Detects missing environment variables during `--verify` runs by diffing `.env` against `.env.example`; surfaces `WARN: env-completeness:` lines listing missing keys with descriptions | Shipped |
 | [Features README Sort Check](features-readme-sort-check.md) | PostToolUse hook enforcing alphabetical sort order in the feature index table with auto-fix | Shipped |
 | [Full-suite pytest lock](full-suite-pytest-lock.md) | Advisory lock serializing concurrent full-suite `-n auto` runs so overlapping invocations wait instead of oversubscribing CPU cores | Shipped |
+| [gh Stale-State Verdict Gate](gh-stale-state-verdict-gate.md) | PR head SHA for the #2062 verdict-staleness gate is resolved git-first via `tools/pr_head_resolver.py` (`git ls-remote refs/pull/N/head`, no shared cache with `gh`) so a stale `gh` head SHA can't match the recorded trailer and flip the gate fail-closed→fail-open; empirical gh-2.89.0 cache root-cause, enumerated decision sites, regression test (#2404) | Shipped |
 | [Git State Guard](git-state-guard.md) | Detects and resolves dirty git state (merges, rebases, cherry-picks) before SDLC branch operations | Shipped |
 | [Goal Gates](goal-gates.md) | Deterministic enforcement gates preventing SDLC pipeline from silently skipping stages | Shipped |
 | [Google Calendar Integration](google-calendar-integration.md) | Work session logging as Google Calendar events with segment rounding | Shipped |

--- a/docs/features/gh-stale-state-verdict-gate.md
+++ b/docs/features/gh-stale-state-verdict-gate.md
@@ -1,0 +1,107 @@
+# Cache-immune PR head resolution for the verdict-staleness gate (#2404)
+
+## The hole
+
+The SDLC verdict-staleness gate (#2062) decides whether a recorded REVIEW
+approval still applies to the code in front of it by comparing the verdict's
+`REVIEW_CONTEXT head_sha=<40-hex>` trailer against the PR's **current** head
+commit. If the current-head read is stale in the fail-open direction — it
+returns the *pre-push* value, which is exactly the value the trailer already
+carries — the gate sees a match and passes a verdict that predates newly pushed
+code. A path deliberately designed fail-closed
+([`sdlc-verdict-fail-closed-persistence.md`](sdlc-verdict-fail-closed-persistence.md))
+silently becomes fail-open.
+
+## Root cause (established empirically, gh 2.89.0)
+
+The issue hypothesized a local `gh` disk-cache hit. Direct measurement
+contradicts that as the mechanism for the gating helpers:
+
+- `~/.cache/gh` is written **only** by `gh api --cache <ttl>`. Bare `gh api`,
+  `gh pr view --json`, `gh pr list`, `gh issue list`, `gh pr status`, and
+  `gh pr checks` each produced zero new cache files and read none (a control
+  `gh api --cache 60s` wrote exactly one).
+- The repo passes `--cache` **nowhere** (`grep -rn -- --cache` over all
+  `*.py`/`*.sh`/`*.md`). Every SDLC gating read already bypasses the disk cache
+  by construction.
+
+So the observed ~20h-stale `gh issue list` was **not** a local-disk-cache hit;
+it is consistent with GitHub's server-side eventual consistency (list/search
+index lag), which self-corrects on its own. A local cache flag cannot address
+that. The residual fail-open risk to the verdict gate is GitHub API
+read-staleness in the seconds-to-minutes window after a push.
+
+## The fix: resolve the head SHA from git, not gh
+
+`git ls-remote origin refs/pull/{N}/head` returns the PR's head commit over the
+**git** transport — a different transport from `gh`'s HTTP layer, sharing no
+response cache, and authoritative for the ref. Verified: for PR #2412 it returns
+the identical SHA as both `gh api …/pulls/2412 --jq .head.sha` and
+`gh pr view --json headRefOid`. This is the same "reconcile against observable
+git ground truth" direction #2395's recovery path took, and it is correct
+**without per-machine configuration** — no `GH_*` env var to drift out of place
+across bridge / worker / launchd / local / subagent contexts.
+
+`tools/pr_head_resolver.py::resolve_pr_head_sha(pr, repo=, repo_root=)` is the
+single source of truth:
+
+1. **Primary (authoritative):** `git ls-remote origin refs/pull/{pr}/head`,
+   guarded by `_origin_matches_repo` so a cross-repo cwd (e.g. `sdlc-tool`
+   forcing cwd to `~/src/ai`) never resolves the wrong repo's head.
+2. **Fallback:** `gh pr view --json headRefOid` when the git read yields
+   nothing (no `origin`, or a cross-repo checkout). `gh pr view` does not
+   disk-cache on gh 2.89.0.
+3. **cross_check** (default on): when both resolve and disagree, the git value
+   wins and a WARNING logs both SHAs — the fail-open event is surfaced, not
+   hidden.
+
+Stdlib-only, so `tools/merge_predicate.py` (stdlib-only for the merge-guard
+hook) can consume it.
+
+### Wired decision sites (the fail-open-critical head-SHA reads)
+
+| Site | Role | Change |
+|------|------|--------|
+| `tools/merge_predicate.py::_gh_latest_commit` | merge gate `_check_verdict_freshness` | SHA resolved via `resolve_pr_head_sha`; gh still supplies the committer date |
+| `tools/sdlc_next_skill.py::_fetch_pr_head_sha` | router `context["pr_head_sha"]` signal | delegates to `resolve_pr_head_sha` |
+| `tools/sdlc_review_finalize.py::_fetch_pr_head_sha` | records the trailer | delegates to `resolve_pr_head_sha` (record and check now agree) |
+
+### Enumerated but intentionally left as bare `gh` reads
+
+These drive control flow but are **not** fail-open against the verdict gate and
+do not disk-cache on gh 2.89.0, so they need no git cross-check (adding one
+would be speculative complexity the issue warns against):
+
+- `tools/sdlc_next_skill.py::_fetch_pr_state`, `tools/merge_predicate.py::_gh_pr_view`,
+  `tools/sdlc_stage_query.py` (`gh pr list`/`gh pr view`), `agent/pipeline_state.py`
+  (`statusCheckRollup`, `gh pr diff`), `agent/pipeline_complete.py` / `agent/goal_gates.py`
+  (`gh pr list`).
+- Rationale: a stale `state`/list read is fail-safe (a momentarily-stale OPEN
+  re-runs a stage rather than skipping a gate) and self-correcting; only a stale
+  head SHA flips the verdict gate from fail-closed to fail-open.
+
+## Interaction with #2305
+
+#2305 closes a *second, independent* hole in the same gate:
+`pipeline_state.py::_backfill_predecessors()` force-setting `REVIEW="completed"`
+with no verdict check (defeats verdict *presence*; this fix defeats verdict
+*staleness*). The current backfill reads no head SHA, so there is no code
+collision. If #2305's verdict-aware backfill starts validating a `head_sha`
+trailer, it must resolve the current head through `resolve_pr_head_sha` or it
+re-opens the freshness hole.
+
+## Durable rule
+
+Agent gating reads of a PR's head state must resolve through
+`resolve_pr_head_sha` (git-first), never a bare `gh` read. Recorded in
+`CLAUDE.md` so it lives where agents encounter it.
+
+## Tests
+
+- `tests/unit/test_pr_head_resolver.py` — git-primary wins over a stale gh read
+  (the acceptance-bar case), gh fallback, both-empty → None, cross-check
+  warning, and the `_origin_matches_repo` cross-repo guard.
+- `tests/unit/test_merge_predicate.py` — `_gh_latest_commit` returns the
+  git-authoritative SHA when gh serves a stale one; `_check_verdict_freshness`
+  **blocks** when the trailer predates the authoritative head (regression), and
+  passes when they match.

--- a/docs/plans/gh-stale-verdict-gate.md
+++ b/docs/plans/gh-stale-verdict-gate.md
@@ -1,0 +1,130 @@
+# Plan: gh stale-state cannot defeat the verdict-staleness gate (#2404)
+
+## Root cause (established empirically, gh 2.89.0)
+
+The issue hypothesized a local `gh` disk-cache hit. Direct measurement on this
+machine contradicts that as the mechanism for the gating helpers:
+
+- `~/.cache/gh` is written **only** by `gh api --cache <ttl>`. Bare `gh api`,
+  `gh pr view --json`, `gh pr list`, `gh issue list`, `gh pr status`, and
+  `gh pr checks` each produced **zero** new cache files and read none
+  (before/after file counts identical; a control `gh api --cache 60s` wrote
+  exactly one).
+- The repo passes `--cache` **nowhere** (`grep -rn -- --cache` over all
+  `*.py`/`*.sh`/`*.md`). So every SDLC gating read already bypasses the disk
+  cache by construction. The `_fetch_pr_head_sha` / `_fetch_pr_state`
+  "live" docstrings are therefore mechanically accurate for the disk-cache
+  dimension — they never touch it.
+- The pre-existing `merge-info-preview` cache files were written by some other
+  path (interactive `gh pr merge`, older gh behavior), not by the gating
+  helpers.
+
+So the observed ~20h-stale `gh issue list` was **not** a local-disk-cache hit.
+It is consistent with GitHub's server-side eventual consistency (list/search
+index lag), which self-corrected minutes later exactly as reported. This is a
+transient, TTL-bounded staleness in GitHub's own edge, not something a local
+cache flag can address.
+
+**Why the issue is still valid.** The fail-open risk is real for *any*
+staleness vector, including the seconds-to-minutes window of GitHub API
+read-staleness right after a push. The `pr_head_sha` verdict-staleness gate
+(#2062) compares the recorded REVIEW verdict's `head_sha` trailer against the
+PR's *current* head. If the current-head read returns the pre-push value (the
+same value the trailer carries), the gate sees a match and passes a stale
+approval — a fail-closed design silently becomes fail-open. The remedy must be
+robust to the staleness vector regardless of which layer produced it.
+
+## Fix: resolve the gating head SHA from git, which shares no cache with gh
+
+`git ls-remote origin refs/pull/{N}/head` returns the PR's head commit over the
+git transport — a different transport from `gh`'s HTTP layer, with no shared
+response cache, and authoritative for the ref. Verified: for PR #2412 it
+returns `61c2f57b…`, identical to both `gh api …/pulls/2412 --jq .head.sha`
+and `gh pr view --json headRefOid`. This is the same "reconcile against
+observable git ground truth" direction #2395's recovery path took, and it is
+correct **without per-machine configuration** — no `GH_*` env var to drift out
+of place across bridge / worker / launchd / local / subagent contexts.
+
+### New shared resolver — `tools/pr_head_resolver.py` (stdlib-only)
+
+```
+resolve_pr_head_sha(pr, repo=None, repo_root=None, *, cross_check=True) -> str | None
+```
+
+- **Primary (authoritative):** `git ls-remote origin refs/pull/{pr}/head` run
+  in `repo_root`; parse the leading 40-hex token. Immune to gh's HTTP cache and
+  authoritative for the PR head.
+- **Fallback:** `gh pr view {pr} [--repo R] --json headRefOid` when ls-remote
+  yields nothing (no `origin`, or cross-repo `GH_REPO` checkout where `origin`
+  is a different repo). No worse than today, and gh does not disk-cache this
+  read anyway.
+- **cross_check:** when both sources resolve and disagree, return the git value
+  (authoritative) and log a WARNING naming both SHAs — this is the fail-open
+  signal made visible.
+
+Stdlib-only so `tools/merge_predicate.py` (deliberately stdlib-only for the
+merge-guard hook — it must load under any interpreter and avoids
+`tools._sdlc_utils` because that pulls in `models`) can import it at module
+level.
+
+### Wiring (the three fail-open-critical head-SHA sites)
+
+1. `tools/merge_predicate.py::_gh_latest_commit` — the merge gate
+   (`_check_verdict_freshness`). Resolve head via `resolve_pr_head_sha`; keep
+   the committer-date fallback for the no-trailer branch.
+2. `tools/sdlc_next_skill.py::_fetch_pr_head_sha` — the router's
+   `context["pr_head_sha"]` signal.
+3. `tools/sdlc_review_finalize.py::_fetch_pr_head_sha` — records the trailer;
+   use the same authoritative source so record and check agree.
+
+Docstrings updated to state the authoritative git-first resolution instead of
+claiming a bare `gh pr view` is "live".
+
+### Left as-is, with justification (no over-engineering)
+
+Other gh state reads (`gh pr view --json state`, `gh pr list`,
+`gh issue view`, `statusCheckRollup`, `gh pr diff`) drive control flow but:
+they do not disk-cache on gh 2.89.0 (already cache-proof), and their
+staleness is either fail-safe (a stale-OPEN read re-runs a stage rather than
+skipping a gate) or self-correcting. Adding git cross-checks there would be
+speculative complexity the issue explicitly warns against. They are enumerated
+in the docs as "cache-proof, no git cross-check required" so the sweep is on
+record.
+
+## Interaction with #2305
+
+#2305 closes a *second, independent* hole in the same gate:
+`pipeline_state.py::_backfill_predecessors()` force-sets `REVIEW="completed"`
+with no verdict check (defeats verdict *presence*; mine defeats verdict
+*freshness*). Current `_backfill_predecessors` does **not** read a head SHA
+(confirmed by grep), so there is no code collision today. If #2305's
+verdict-aware backfill starts validating a `head_sha` trailer, it must resolve
+the current head through `resolve_pr_head_sha` — the single source of truth this
+plan introduces — or it will re-open the freshness hole. The PR body will state
+this explicitly.
+
+## Durable guidance (acceptance criterion)
+
+Record in `CLAUDE.md` (and the sdlc skill-context) the rule: **agent gating
+reads of PR head state must resolve through `resolve_pr_head_sha` (git-first),
+never a bare `gh` read**, so the guidance lives where agents encounter it, not
+only in this issue.
+
+## Tests (targeted, via scripts/pytest-clean.sh)
+
+- `resolve_pr_head_sha`: git-primary success; gh fallback when git empty;
+  cross-check disagreement returns git value + warns; both empty → None.
+- **Regression (the acceptance bar):** `_check_verdict_freshness` with a
+  trailer carrying the OLD sha while the authoritative git head is the NEW sha
+  → gate **blocks** (`failed` gains "predates PR head"). Proves a stale gh read
+  cannot make the gate pass, because the authoritative git head wins.
+- Docstring/enumeration assertions kept light.
+
+## Acceptance criteria mapping
+
+- [x] Root cause documented (this doc + PR body).
+- [x] Gating gh reads enumerated; head-SHA gate made git-authoritative, rest
+      justified as cache-proof.
+- [x] Regression test: stale SHA → gate blocks.
+- [x] `sdlc_next_skill` docstrings accurate.
+- [x] Durable guidance in `CLAUDE.md` + skill-context.

--- a/docs/sdlc/do-merge.md
+++ b/docs/sdlc/do-merge.md
@@ -42,7 +42,11 @@ generic steps as follows:
     exist, contain `APPROVED` (case-insensitive), and be fresh against the PR's
     latest commit — via the `REVIEW_CONTEXT head_sha=` trailer when present,
     else recorded-at timestamp vs latest-commit committer date. A stale
-    APPROVED verdict FAILS with `REVIEW verdict predates PR head commit`.
+    APPROVED verdict FAILS with `REVIEW verdict predates PR head commit`. The
+    PR's current head SHA is resolved git-first via
+    `tools/pr_head_resolver.py::resolve_pr_head_sha` (`git ls-remote
+    refs/pull/N/head`, no shared cache with `gh`), so a stale `gh` head read
+    cannot match the trailer and pass a stale approval (#2404).
   - **(d) Single-owner MERGE lease** (issue #2026, WS1): the merge actor's
     `run_id` must hold the current per-issue SDLC lease. This refuses a
     parallel fork/lineage that never held the lease from merging past a

--- a/tests/unit/test_merge_predicate.py
+++ b/tests/unit/test_merge_predicate.py
@@ -437,3 +437,82 @@ class TestLeaseOwnershipGate:
         mp._check_lease_ownership(2026, "owner-run", failed, notes)
         assert failed == []
         assert any("holds the issue lease" in n for n in notes)
+
+
+# === #2404: verdict-freshness gate cannot pass on a stale head-SHA read ======
+#
+# The gate compares the recorded REVIEW verdict's `head_sha` trailer against the
+# PR's *current* head. A stale read (gh serving the pre-push SHA) equals the
+# trailer, so the gate would pass a verdict predating newly pushed code -- a
+# fail-closed design silently going fail-open. `_gh_latest_commit` now resolves
+# the SHA authoritatively via `git ls-remote` (tools.pr_head_resolver), so even
+# when gh serves the stale value the gate blocks.
+
+_OLD = "a" * 40  # stale/pre-push SHA gh would serve; also the trailer value
+_NEW = "b" * 40  # true current head, resolved from git ls-remote
+_DATE = "2026-07-27T00:00:00Z"
+
+
+def _fake_commits_proc(*_a, **_k):
+    class _P:
+        returncode = 0
+        stderr = ""
+        stdout = f'{{"sha": "{_OLD}", "commit": {{"committer": {{"date": "{_DATE}"}}}}}}'
+
+    return _P()
+
+
+def test_gh_latest_commit_overrides_stale_gh_sha_with_git(monkeypatch):
+    """gh's `.../commits` serves the STALE _OLD sha; git ls-remote serves the
+    true _NEW head. `_gh_latest_commit` returns _NEW (authoritative) and keeps
+    gh's committer date."""
+    from tools import pr_head_resolver as phr
+
+    monkeypatch.setattr(mp, "_gh_repo_name_with_owner", lambda root: "o/n")
+    monkeypatch.setattr(mp.subprocess, "run", _fake_commits_proc)
+    monkeypatch.setattr(phr, "_git_ls_remote_pr_head", lambda pr, repo, root: _NEW)
+    monkeypatch.setattr(phr, "_gh_pr_head", lambda pr, repo: _OLD)
+
+    commit = mp._gh_latest_commit(990033, REPO_ROOT)
+    assert commit["sha"] == _NEW
+    assert commit["date"] == _DATE
+
+
+def test_verdict_freshness_blocks_when_stale_trailer_predates_git_head(monkeypatch):
+    """Regression (acceptance bar): trailer carries the OLD sha; the
+    authoritative current head is NEW -> the gate BLOCKS. A stale read cannot
+    make the approval look fresh."""
+    monkeypatch.setattr(
+        mp,
+        "_run_verdict_get",
+        lambda issue, root: {
+            "verdict": f"APPROVED REVIEW_CONTEXT head_sha={_OLD}",
+            "recorded_at": _DATE,
+        },
+    )
+    monkeypatch.setattr(mp, "_gh_latest_commit", lambda pr, root: {"sha": _NEW, "date": _DATE})
+
+    failed: list[str] = []
+    notes: list[str] = []
+    mp._check_verdict_freshness(990033, 990029, REPO_ROOT, failed, notes)
+    assert any("predates PR head commit" in f for f in failed)
+    assert notes == []
+
+
+def test_verdict_freshness_passes_when_trailer_matches_authoritative_head(monkeypatch):
+    """Control: trailer == authoritative current head -> verdict is fresh."""
+    monkeypatch.setattr(
+        mp,
+        "_run_verdict_get",
+        lambda issue, root: {
+            "verdict": f"APPROVED REVIEW_CONTEXT head_sha={_NEW}",
+            "recorded_at": _DATE,
+        },
+    )
+    monkeypatch.setattr(mp, "_gh_latest_commit", lambda pr, root: {"sha": _NEW, "date": _DATE})
+
+    failed: list[str] = []
+    notes: list[str] = []
+    mp._check_verdict_freshness(990033, 990029, REPO_ROOT, failed, notes)
+    assert failed == []
+    assert any("head_sha trailer matches PR head commit" in n for n in notes)

--- a/tests/unit/test_pr_head_resolver.py
+++ b/tests/unit/test_pr_head_resolver.py
@@ -1,0 +1,106 @@
+"""Unit tests for tools.pr_head_resolver (#2404).
+
+The verdict-staleness gate (#2062) compares a recorded REVIEW verdict's
+``head_sha`` trailer against the PR's current head. A stale current-head read
+in the fail-open direction returns the pre-push value -- the same value the
+trailer carries -- so the gate sees a match and passes a verdict that predates
+newly pushed code. These tests pin the guarantee that the authoritative git
+read wins over a stale ``gh`` read, so a stale read can never make the gate
+pass.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from tools import pr_head_resolver as r
+
+OLD = "a" * 40  # the stale, pre-push SHA a cached/eventually-consistent gh serves
+NEW = "b" * 40  # the true current head SHA (authoritative git ls-remote)
+
+
+def test_git_primary_wins_over_stale_gh(monkeypatch):
+    """The acceptance-bar case: gh serves the STALE sha, git serves the true
+    head -- the resolver returns the git (authoritative) value, never gh's."""
+    monkeypatch.setattr(r, "_git_ls_remote_pr_head", lambda pr, repo, root: NEW)
+    monkeypatch.setattr(r, "_gh_pr_head", lambda pr, repo: OLD)
+    assert r.resolve_pr_head_sha(42, repo="o/n", repo_root="/x") == NEW
+
+
+def test_cross_check_disagreement_logs_warning(monkeypatch, caplog):
+    monkeypatch.setattr(r, "_git_ls_remote_pr_head", lambda pr, repo, root: NEW)
+    monkeypatch.setattr(r, "_gh_pr_head", lambda pr, repo: OLD)
+    with caplog.at_level(logging.WARNING):
+        assert r.resolve_pr_head_sha(42) == NEW
+    assert any("head-SHA disagreement" in rec.message for rec in caplog.records)
+
+
+def test_cross_check_false_skips_gh(monkeypatch):
+    """With git resolved and cross_check off, gh is not consulted at all."""
+    monkeypatch.setattr(r, "_git_ls_remote_pr_head", lambda pr, repo, root: NEW)
+
+    def _boom(pr, repo):
+        raise AssertionError("gh must not be called when git resolves and cross_check=False")
+
+    monkeypatch.setattr(r, "_gh_pr_head", _boom)
+    assert r.resolve_pr_head_sha(42, cross_check=False) == NEW
+
+
+def test_gh_fallback_when_git_empty(monkeypatch):
+    monkeypatch.setattr(r, "_git_ls_remote_pr_head", lambda pr, repo, root: None)
+    monkeypatch.setattr(r, "_gh_pr_head", lambda pr, repo: NEW)
+    assert r.resolve_pr_head_sha(42) == NEW
+
+
+def test_both_unresolvable_returns_none(monkeypatch):
+    monkeypatch.setattr(r, "_git_ls_remote_pr_head", lambda pr, repo, root: None)
+    monkeypatch.setattr(r, "_gh_pr_head", lambda pr, repo: None)
+    assert r.resolve_pr_head_sha(42) is None
+
+
+def test_no_agreement_needed_when_only_git(monkeypatch):
+    """git resolves, gh returns None -- git value is used, no warning, no error."""
+    monkeypatch.setattr(r, "_git_ls_remote_pr_head", lambda pr, repo, root: NEW)
+    monkeypatch.setattr(r, "_gh_pr_head", lambda pr, repo: None)
+    assert r.resolve_pr_head_sha(42) == NEW
+
+
+# --- _origin_matches_repo: the cross-repo cwd guard -------------------------
+
+
+class _FakeProc:
+    def __init__(self, returncode=0, stdout=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = ""
+
+
+@pytest.mark.parametrize(
+    "repo,url,expected",
+    [
+        ("owner/name", "https://github.com/owner/name.git", True),
+        ("owner/name", "https://github.com/owner/name", True),
+        ("owner/name", "git@github.com:owner/name.git", True),
+        ("owner/name", "https://github.com/other/repo.git", False),
+        ("owner/name", "https://github.com/owner/name-suffix.git", False),
+        (None, "https://github.com/anything/here.git", True),  # repo=None trusts local origin
+    ],
+)
+def test_origin_matches_repo(monkeypatch, repo, url, expected):
+    monkeypatch.setattr(r.subprocess, "run", lambda *a, **k: _FakeProc(0, url + "\n"))
+    assert r._origin_matches_repo(repo, "/x") is expected
+
+
+def test_git_read_skipped_on_origin_mismatch(monkeypatch):
+    """When origin points at a different repo, the git read is skipped entirely
+    (returns None) so the caller falls back to gh --repo -- the #2377 cross-repo
+    cwd hazard cannot resolve the wrong repo's head."""
+    monkeypatch.setattr(r, "_origin_matches_repo", lambda repo, root: False)
+
+    def _must_not_run(*a, **k):
+        raise AssertionError("git ls-remote must not run when origin does not match repo")
+
+    monkeypatch.setattr(r.subprocess, "run", _must_not_run)
+    assert r._git_ls_remote_pr_head(42, "owner/name", "/x") is None

--- a/tests/unit/test_sdlc_review_finalize.py
+++ b/tests/unit/test_sdlc_review_finalize.py
@@ -228,20 +228,25 @@ class TestFetchPrHeadSha:
             with pytest.raises(HeadShaResolutionError, match="head SHA"):
                 _fetch_pr_head_sha(1)
 
-    def test_gh_nonzero_exit_raises_named_error_with_stderr(self):
+    def test_all_sources_nonzero_exit_raises_named_error(self):
+        """#2404: with resolution git-first + gh fallback, a nonzero exit on
+        every source leaves the head SHA unresolvable -> fail LOUD (raises),
+        never a falsy return."""
         from tools.sdlc_review_finalize import _fetch_pr_head_sha
 
         mock_proc = MagicMock(returncode=1, stdout="", stderr="could not resolve to a PR")
         with patch("subprocess.run", return_value=mock_proc):
-            with pytest.raises(HeadShaResolutionError, match="could not resolve to a PR"):
+            with pytest.raises(HeadShaResolutionError, match="head SHA"):
                 _fetch_pr_head_sha(1)
 
-    def test_gh_empty_output_raises_named_error(self):
+    def test_all_sources_empty_output_raises_named_error(self):
+        """#2404: both git ls-remote and gh return zero-exit-but-no-SHA -> the
+        head SHA is unresolvable -> fail LOUD."""
         from tools.sdlc_review_finalize import _fetch_pr_head_sha
 
         mock_proc = MagicMock(returncode=0, stdout="   \n", stderr="")
         with patch("subprocess.run", return_value=mock_proc):
-            with pytest.raises(HeadShaResolutionError, match="empty head SHA"):
+            with pytest.raises(HeadShaResolutionError, match="head SHA"):
                 _fetch_pr_head_sha(1)
 
     def test_gh_success_strips_and_returns_sha(self):

--- a/tools/merge_predicate.py
+++ b/tools/merge_predicate.py
@@ -189,11 +189,26 @@ def _gh_repo_name_with_owner(repo_root: Path) -> str:
 
 
 def _gh_latest_commit(pr_number: int, repo_root: Path) -> dict:
-    """Return ``{"sha": ..., "date": ...}`` for the PR's latest commit.
+    """Return ``{"sha": ..., "date": ...}`` for the PR's latest (head) commit.
 
     Raises on any failure — with the substrate present, missing latest-commit
     data must fail the predicate closed, never silently pass.
+
+    #2404: the ``sha`` is resolved authoritatively via
+    ``tools.pr_head_resolver.resolve_pr_head_sha`` (``git ls-remote origin
+    refs/pull/N/head``, which shares no response cache with ``gh`` and cannot be
+    served stale in the fail-open direction). The ``gh api …/commits`` read
+    still provides the committer ``date`` (used only by the no-trailer freshness
+    branch, where a stale date fails *closed*), and is the fallback SHA source
+    when the git read yields nothing (foreign/cross-repo checkout). Without the
+    git-authoritative SHA, a stale current-head read matches the verdict's
+    trailer and makes a stale approval look fresh — the fail-open hole #2404
+    closes.
     """
+    # Lazy import to preserve this module's stdlib-only load posture for the
+    # merge-guard hook (see module docstring); pr_head_resolver is stdlib-only.
+    from tools.pr_head_resolver import resolve_pr_head_sha
+
     repo = _gh_repo_name_with_owner(repo_root)
     proc = subprocess.run(
         ["gh", "api", f"repos/{repo}/pulls/{pr_number}/commits", "--jq", ".[-1]"],
@@ -207,8 +222,10 @@ def _gh_latest_commit(pr_number: int, repo_root: Path) -> dict:
     commit = json.loads(proc.stdout)
     if not isinstance(commit, dict):
         raise RuntimeError("latest-commit lookup returned non-object JSON")
+    gh_sha = commit.get("sha") or ""
+    authoritative_sha = resolve_pr_head_sha(pr_number, repo=repo, repo_root=str(repo_root))
     return {
-        "sha": commit.get("sha") or "",
+        "sha": authoritative_sha or gh_sha,
         "date": ((commit.get("commit") or {}).get("committer") or {}).get("date") or "",
     }
 

--- a/tools/pr_head_resolver.py
+++ b/tools/pr_head_resolver.py
@@ -1,0 +1,178 @@
+"""Authoritative, cache-immune resolution of a PR's head commit SHA (#2404).
+
+The SDLC verdict-staleness gate (#2062) compares a recorded REVIEW verdict's
+``REVIEW_CONTEXT head_sha=`` trailer against the PR's *current* head commit to
+decide whether an approval still applies to the code in front of it. If the
+current-head read is stale in the fail-open direction -- returning the pre-push
+value, which is exactly the value the trailer already carries -- the gate sees a
+match and passes a verdict that predates newly pushed code. A path deliberately
+designed fail-closed becomes fail-open, silently.
+
+The robust fix is to resolve the current head over the **git** transport
+(``git ls-remote origin refs/pull/{N}/head``), which shares no response cache
+with ``gh``'s HTTP layer and is authoritative for the ref. This is the same
+"reconcile against observable git ground truth" direction #2395's recovery path
+took, and it needs no per-machine configuration (no ``GH_*`` env var to drift
+out of place across bridge / worker / launchd / local / subagent contexts).
+
+Empirical note (gh 2.89.0): the on-disk ``gh`` cache (``~/.cache/gh``) is
+written only by ``gh api --cache <ttl>``; bare ``gh pr view --json`` /
+``gh api`` do not touch it, and this repo passes ``--cache`` nowhere. So the
+gating reads never hit the disk cache. The residual staleness this module
+guards against is GitHub's server-side eventual consistency in the
+seconds-to-minutes window after a push -- which a local cache flag cannot fix
+but an authoritative git read sidesteps.
+
+Stdlib-only on purpose: ``tools/merge_predicate.py`` is stdlib-only (it must
+load under any interpreter for the merge-guard hook and avoids
+``tools._sdlc_utils`` because that pulls in ``models``), so it can import this
+module at module level.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+_SHA_RE = re.compile(r"\b([0-9a-fA-F]{40})\b")
+# Provisional/tunable: a git ls-remote or gh subprocess for a single ref is
+# fast; 10s is a generous ceiling that fails a wedged network call closed rather
+# than hanging the gate. No env override -- this is a fixed infra guard, not a
+# behavior knob (matches the 10s used by the callers being consolidated here).
+_SUBPROCESS_TIMEOUT = 10
+
+
+def _origin_matches_repo(repo: str | None, repo_root: str | None) -> bool:
+    """Whether the local ``origin`` remote points at ``repo`` (``owner/name``).
+
+    Guards the git-authoritative read against a cross-repo cwd hazard: callers
+    like ``sdlc_review_finalize`` run with cwd forced to ``~/src/ai``, so a bare
+    ``git ls-remote origin`` there would target the ai repo even when the PR
+    lives in another repo. When ``repo`` is ``None`` the caller is responsible
+    for pointing ``repo_root`` at the correct checkout (the same contract the
+    old code had), so we trust the local origin.
+    """
+    if not repo:
+        return True
+    try:
+        proc = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+            cwd=repo_root,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return False
+    if proc.returncode != 0:
+        return False
+    url = (proc.stdout or "").strip().removesuffix(".git")
+    # Match "owner/name" as a path component of the origin URL (ssh or https).
+    return url.endswith(f"/{repo}") or url.endswith(f":{repo}")
+
+
+def _git_ls_remote_pr_head(pr: int, repo: str | None, repo_root: str | None) -> str | None:
+    """Authoritative head SHA via ``git ls-remote origin refs/pull/{pr}/head``.
+
+    Queries the remote directly over the git transport (no dependence on local
+    fetch refspec, no shared cache with ``gh``). Returns the 40-hex SHA, or
+    ``None`` when the local ``origin`` does not point at ``repo``, there is no
+    ``origin`` remote, the ref is absent, or the call fails.
+    """
+    if not _origin_matches_repo(repo, repo_root):
+        return None
+    try:
+        proc = subprocess.run(
+            ["git", "ls-remote", "origin", f"refs/pull/{int(pr)}/head"],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+            cwd=repo_root,
+        )
+    except (subprocess.SubprocessError, OSError) as e:
+        logger.debug("git ls-remote for PR #%s failed: %s", pr, e)
+        return None
+    if proc.returncode != 0:
+        return None
+    match = _SHA_RE.search(proc.stdout or "")
+    return match.group(1) if match else None
+
+
+def _gh_pr_head(pr: int, repo: str | None) -> str | None:
+    """Fallback head SHA via ``gh pr view --json headRefOid``.
+
+    Used when the authoritative git read yields nothing (no ``origin`` remote,
+    or a cross-repo ``GH_REPO`` checkout where ``origin`` is a different repo).
+    ``gh pr view --json`` does not touch gh's disk cache on gh 2.89.0.
+    """
+    cmd = ["gh", "pr", "view", str(pr), "--json", "headRefOid", "-q", ".headRefOid"]
+    if repo:
+        cmd = [
+            "gh",
+            "pr",
+            "view",
+            str(pr),
+            "--repo",
+            repo,
+            "--json",
+            "headRefOid",
+            "-q",
+            ".headRefOid",
+        ]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=_SUBPROCESS_TIMEOUT)
+    except (subprocess.SubprocessError, OSError) as e:
+        logger.debug("gh pr view headRefOid for PR #%s failed: %s", pr, e)
+        return None
+    if proc.returncode != 0:
+        return None
+    match = _SHA_RE.search(proc.stdout or "")
+    return match.group(1) if match else None
+
+
+def resolve_pr_head_sha(
+    pr: int,
+    repo: str | None = None,
+    repo_root: str | None = None,
+    *,
+    cross_check: bool = True,
+) -> str | None:
+    """Resolve a PR's head commit SHA, git-first and cache-immune (#2404).
+
+    Order:
+      1. ``git ls-remote origin refs/pull/{pr}/head`` -- authoritative, shares
+         no cache with ``gh``. Used whenever it resolves.
+      2. ``gh pr view --json headRefOid`` -- fallback when (1) yields nothing.
+
+    ``cross_check`` (default on): when both sources resolve and **disagree**,
+    the git value wins (authoritative) and a WARNING is logged naming both SHAs
+    -- this surfaces a fail-open staleness event rather than hiding it. Set
+    ``cross_check=False`` to skip the extra gh call once git has answered (the
+    gate does not need the second read to be correct; the cross-check is
+    observability).
+
+    Returns the 40-hex SHA, or ``None`` when neither source resolves one --
+    callers must treat ``None`` as "could not determine" and fail closed, never
+    invent a SHA.
+    """
+    git_sha = _git_ls_remote_pr_head(pr, repo, repo_root)
+    if git_sha and not cross_check:
+        return git_sha
+
+    gh_sha = _gh_pr_head(pr, repo)
+
+    if git_sha:
+        if gh_sha and gh_sha.lower() != git_sha.lower():
+            logger.warning(
+                "PR #%s head-SHA disagreement: git ls-remote=%s vs gh=%s -- "
+                "using authoritative git value (possible gh read-staleness)",
+                pr,
+                git_sha,
+                gh_sha,
+            )
+        return git_sha
+
+    return gh_sha

--- a/tools/sdlc_next_skill.py
+++ b/tools/sdlc_next_skill.py
@@ -98,10 +98,17 @@ def _resolve_enriched(issue_number: int | None, session_id: str | None) -> dict:
 
 
 def _fetch_pr_state(pr_number: int, repo: str | None = None) -> str | None:
-    """Live-check (``gh pr view``) and return the PR's raw state string.
+    """Read the PR's raw state string via ``gh pr view``.
 
     Reuses the same ``gh pr view --json`` shape as
-    ``tools.sdlc_stage_query._fetch_pr_merge_state``. Returns ``None`` when
+    ``tools.sdlc_stage_query._fetch_pr_merge_state``. This read is live with
+    respect to gh's on-disk cache (gh 2.89.0 writes that cache only for
+    ``gh api --cache``, which this repo never uses) but is NOT git-cross-checked
+    -- unlike the head-SHA read in :func:`_fetch_pr_head_sha` (#2404). That is
+    deliberate: a stale ``state`` read is fail-safe here (a momentarily-stale
+    OPEN re-runs a stage rather than skipping a gate), whereas a stale head SHA
+    is fail-OPEN against the verdict gate, so only the latter earns the
+    authoritative git resolver. Returns ``None`` when
     the call fails, the response is unparseable, or ``state`` is absent /
     not a string -- callers must treat ``None`` as "could not determine",
     never as evidence of a false claim. May raise
@@ -121,24 +128,24 @@ def _fetch_pr_state(pr_number: int, repo: str | None = None) -> str | None:
 
 
 def _fetch_pr_head_sha(pr_number: int, repo: str | None = None) -> str | None:
-    """Live-fetch the PR's current head commit SHA via ``gh``.
+    """Authoritatively resolve the PR's current head commit SHA (#2404).
 
     WS3d (issue #2062): feeds the router's head_sha verdict-staleness signal
     (``context["pr_head_sha"]``), mirroring the fail-closed shape of
-    ``tools.merge_predicate._gh_latest_commit``. Returns ``None`` on any
-    non-exceptional failure — the CALLER (``_build_context``) converts both
-    ``None`` and a raised error into the empty fail-closed sentinel; this
-    helper never invents a SHA.
+    ``tools.merge_predicate._gh_latest_commit``. Resolution is git-first via
+    ``tools.pr_head_resolver.resolve_pr_head_sha`` (``git ls-remote origin
+    refs/pull/N/head``, which shares no response cache with ``gh`` and is
+    authoritative for the ref), falling back to ``gh pr view --json
+    headRefOid`` only when git yields nothing. This closes the fail-open path
+    where a stale current-head read matches the verdict's trailer and makes a
+    stale approval look fresh (#2404). Returns ``None`` on any non-exceptional
+    failure — the CALLER (``_build_context``) converts both ``None`` and a
+    raised error into the empty fail-closed sentinel; this helper never invents
+    a SHA.
     """
-    cmd = ["gh", "pr", "view", str(pr_number), "--json", "headRefOid"]
-    if repo:
-        cmd = ["gh", "pr", "view", str(pr_number), "--repo", repo, "--json", "headRefOid"]
-    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-    if proc.returncode != 0:
-        return None
-    data = json.loads(proc.stdout or "{}")
-    sha = data.get("headRefOid")
-    return sha if isinstance(sha, str) and sha else None
+    from tools.pr_head_resolver import resolve_pr_head_sha
+
+    return resolve_pr_head_sha(pr_number, repo=repo, repo_root=_target_repo_cwd())
 
 
 def _check_branch_pushed(slug: str) -> bool:

--- a/tools/sdlc_review_finalize.py
+++ b/tools/sdlc_review_finalize.py
@@ -58,7 +58,6 @@ APPROVED-only scope of the completion-marker gate extension in
 from __future__ import annotations
 
 import logging
-import subprocess
 
 from tools._sdlc_utils import (
     _HEAD_SHA_TRAILER_RE,
@@ -96,76 +95,52 @@ class HeadShaResolutionError(Exception):
 
 
 def _fetch_pr_head_sha(pr: int, repo: str | None = None) -> str:
-    """Resolve the PR's current head commit SHA via ``gh pr view``.
+    """Authoritatively resolve the PR's current head commit SHA (#2404).
 
-    When ``repo`` (an ``owner/name`` slug) is provided it is threaded as
-    ``--repo <slug>`` so the lookup targets the correct repository regardless
-    of the tool's process cwd (#2377 Mode 1): ``sdlc-tool`` forces cwd to
-    ``~/src/ai``, so an unscoped ``gh pr view`` resolves the wrong repo (or a
-    real-but-wrong same-numbered PR) on a cross-repo local ``/do-sdlc`` run.
-    Mirrors the ``--repo`` threading already correct in
-    ``tools/sdlc_next_skill.py::_fetch_pr_head_sha``.
+    Resolution is git-first via ``tools.pr_head_resolver.resolve_pr_head_sha``
+    (``git ls-remote origin refs/pull/N/head``, which shares no response cache
+    with ``gh`` and cannot be served stale in the fail-open direction), falling
+    back to ``gh pr view --json headRefOid`` when the git read yields nothing.
+    Recording the trailer from the same authoritative source the merge/router
+    checks read (#2404) means record and check agree, so a fresh approval is
+    never spuriously fail-closed by a record/check SHA-source mismatch.
 
-    Raises :class:`HeadShaResolutionError` on ANY failure (missing ``gh``,
-    non-zero exit, timeout, empty output) -- it never returns a falsy value.
-    Callers fail closed (Risk 2: never record a trailer-less verdict when the
-    head SHA cannot be confirmed).
+    When ``repo`` (an ``owner/name`` slug) is provided it is threaded through so
+    the lookup targets the correct repository regardless of the tool's process
+    cwd (#2377 Mode 1): ``sdlc-tool`` forces cwd to ``~/src/ai``, so an
+    unscoped read resolves the wrong repo on a cross-repo local ``/do-sdlc``
+    run. The resolver's git step self-guards against this — it only trusts the
+    local ``origin`` when it points at ``repo`` — and the gh fallback carries
+    ``--repo``.
+
+    Raises :class:`HeadShaResolutionError` on ANY failure (both sources
+    unresolvable) -- it never returns a falsy value. Callers fail closed
+    (Risk 2: never record a trailer-less verdict when the head SHA cannot be
+    confirmed).
     """
-    try:
-        from config.settings import settings
-
-        timeout = settings.timeouts.git_subprocess_s
-    except Exception:
-        timeout = 10
-
-    cmd = ["gh", "pr", "view", str(pr), "--json", "headRefOid", "-q", ".headRefOid"]
-    if repo:
-        cmd = [
-            "gh",
-            "pr",
-            "view",
-            str(pr),
-            "--repo",
-            repo,
-            "--json",
-            "headRefOid",
-            "-q",
-            ".headRefOid",
-        ]
+    from tools.pr_head_resolver import resolve_pr_head_sha
 
     try:
-        proc = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=timeout,  # timeout-guard: allow
-        )
+        sha = resolve_pr_head_sha(pr, repo=repo)
     except Exception as e:
         logger.error(
-            f"sdlc_review_finalize: gh pr view failed for PR #{pr} (repo={repo or '<cwd>'}): {e}"
+            "sdlc_review_finalize: head SHA resolution raised for PR #%s (repo=%s): %s",
+            pr,
+            repo or "<cwd>",
+            e,
         )
         raise HeadShaResolutionError(
-            f"could not resolve PR #{pr}'s head SHA via `gh pr view` (repo={repo or '<cwd>'}): {e}"
+            f"could not resolve PR #{pr}'s head SHA (repo={repo or '<cwd>'}): {e}"
         ) from e
 
-    if proc.returncode != 0:
-        stderr = (proc.stderr or "").strip()
-        logger.error(
-            f"sdlc_review_finalize: gh pr view rc={proc.returncode} for PR #{pr} "
-            f"(repo={repo or '<cwd>'}): {stderr}"
-        )
-        raise HeadShaResolutionError(
-            f"`gh pr view` exited {proc.returncode} for PR #{pr} (repo={repo or '<cwd>'}): {stderr}"
-        )
-
-    sha = (proc.stdout or "").strip()
     if not sha:
         logger.error(
-            f"sdlc_review_finalize: gh pr view returned an empty head SHA for PR #{pr} "
-            f"(repo={repo or '<cwd>'})"
+            f"sdlc_review_finalize: head SHA unresolvable for PR #{pr} "
+            f"(repo={repo or '<cwd>'}) via git ls-remote or gh pr view"
         )
         raise HeadShaResolutionError(
-            f"`gh pr view` returned an empty head SHA for PR #{pr} (repo={repo or '<cwd>'})"
+            f"could not resolve PR #{pr}'s head SHA (repo={repo or '<cwd>'}): "
+            f"neither `git ls-remote refs/pull/{pr}/head` nor `gh pr view` returned a SHA"
         )
     return sha
 


### PR DESCRIPTION
Closes #2404.

## Root cause (established empirically, gh 2.89.0) — not what the issue assumed

The issue hypothesized a local `gh` disk-cache hit. Direct measurement contradicts that as the mechanism for the gating helpers:

- `~/.cache/gh` is written **only** by `gh api --cache <ttl>`. Bare `gh api`, `gh pr view --json`, `gh pr list`, `gh issue list`, `gh pr status`, `gh pr checks` each produced **zero** new cache files and read none (a control `gh api --cache 60s` wrote exactly one).
- The repo passes `--cache` **nowhere** (grepped all `*.py`/`*.sh`/`*.md`). Every SDLC gating read already bypasses the disk cache by construction — the `_fetch_pr_*` "live" docstrings were mechanically accurate for the disk-cache dimension.

**GraphQL vs REST:** the `merge-info-preview` cache files present on disk are `github.v4` (GraphQL) responses, so GraphQL *can* populate the same on-disk store — but only via the explicit `--cache` path, which nothing here uses. So the observed ~20h-stale `gh issue list` was **not** a local-disk-cache hit; it is GitHub server-side eventual consistency (list/search index lag), which self-corrected on its own. A local cache flag cannot fix that.

**Why the issue is still valid:** the fail-open risk is real for the seconds-to-minutes GitHub API read-staleness window right after a push. The `pr_head_sha` gate (#2062) compares the recorded verdict's trailer against the PR's current head; a stale current-head read equals the trailer, so a stale approval looks fresh and a fail-closed path goes fail-open.

## The lever I chose and why it survives config drift

Resolve the head SHA over the **git** transport: `git ls-remote origin refs/pull/{N}/head`. Different transport from `gh`'s HTTP layer, no shared response cache, authoritative for the ref (verified: identical SHA to both `gh api .head.sha` and `gh pr view headRefOid` for PR #2412). This is #2395's "reconcile against git ground truth" direction and needs **no per-machine configuration** — no `GH_*` env var to drift across bridge/worker/launchd/local/subagent contexts (the stale-plist class of bug the issue warned against). A blanket `--cache 0` was explicitly rejected: it is a `gh api` flag and the subcommands don't take it.

New stdlib-only `tools/pr_head_resolver.py::resolve_pr_head_sha` is the single source of truth: git-first, gh fallback (cross-repo / no-origin), a cross-check that warns on git-vs-gh disagreement, and an `_origin_matches_repo` guard so a cross-repo forced cwd (`sdlc-tool` → `~/src/ai`) never resolves the wrong repo's head.

### Wired (fail-open-critical head-SHA reads)
- `tools/merge_predicate.py::_gh_latest_commit` — merge gate `_check_verdict_freshness` (SHA authoritative; gh still supplies the committer date).
- `tools/sdlc_next_skill.py::_fetch_pr_head_sha` — router `pr_head_sha` signal.
- `tools/sdlc_review_finalize.py::_fetch_pr_head_sha` — records the trailer (record and check now agree).

### Enumerated, left as bare `gh` (cache-proof + fail-safe)
`_fetch_pr_state`, `_gh_pr_view`, `sdlc_stage_query` list/view, `pipeline_state` rollup/diff, `pipeline_complete`/`goal_gates` list. A stale state/list read re-runs a stage rather than skipping a gate (self-correcting); only a stale head SHA flips the verdict gate. Adding git cross-checks there is the speculative complexity the issue warns against. Docstrings updated to stop over-claiming.

## Interaction with #2305

#2305 closes a **second, independent** hole in the same gate: `pipeline_state.py::_backfill_predecessors()` force-sets `REVIEW="completed"` with no verdict check (defeats verdict *presence*; this PR defeats verdict *staleness*). The current backfill reads **no** head SHA (grep-confirmed), so there is no code collision today. If #2305's verdict-aware backfill starts validating a `head_sha` trailer, it must resolve the current head through `resolve_pr_head_sha` — the single source of truth this PR adds — or it re-opens the freshness hole. Fixing either hole alone leaves the gate defeatable; both are needed.

## Tests (acceptance bar)
- `tests/unit/test_pr_head_resolver.py` — git-primary wins over a **stale gh read** (the acceptance-bar case), gh fallback, both-empty → None, cross-check warning, `_origin_matches_repo` cross-repo guard.
- `tests/unit/test_merge_predicate.py` — `_gh_latest_commit` returns the git-authoritative SHA when gh serves a stale one; **regression:** `_check_verdict_freshness` **blocks** when the trailer predates the authoritative head; control passes when they match.
- Updated two `test_sdlc_review_finalize.py` tests to the new git-first fail-loud contract.

118 targeted tests pass; ruff check + format clean.

## Acceptance criteria
- [x] Root cause documented (gh cache written only by `--cache`; GraphQL shares the store but only via that path; list-staleness is server-side).
- [x] Gating gh reads enumerated; head-SHA gate made git-authoritative, rest justified as cache-proof/fail-safe.
- [x] Regression test: stale SHA → gate blocks.
- [x] `sdlc_next_skill` docstrings accurate.
- [x] Durable guidance in `CLAUDE.md` + `docs/sdlc/do-merge.md` + `docs/features/gh-stale-state-verdict-gate.md`.

Note: I found `GITHUB_PAT` printed unredacted in my own investigation transcript (redaction pattern matched "TOKEN" not "PAT"); flagged to the operator to rotate as a precaution. No code in this PR touches secrets.