### PR TITLE
Trim CLAUDE.md and move the command table to a lazy-loaded skill

### DIFF
--- a/.claude/skill-context/do-docs.md
+++ b/.claude/skill-context/do-docs.md
@@ -57,7 +57,8 @@ This repo's documentation lives in these locations. Scan them in this priority o
 
 | Location | What lives there |
 |----------|-----------------|
-| `CLAUDE.md` | Primary project guidance, architecture, rules, Quick Commands table |
+| `CLAUDE.md` | Primary project guidance, rules, and a short everyday-commands table |
+| `.claude/skills/repo-commands/SKILL.md` | Full command reference (lazy-loaded; new CLI commands go here) |
 | `docs/features/*.md` | Feature documentation |
 | `docs/features/README.md` | Feature index table (canonical feature list — keep entries current) |
 | `site/*.html` | Published docs site pages at valorengels.com (living docs — edit alongside markdown; `site/assets/` is out of scope) |
@@ -154,8 +155,7 @@ Do not re-commit the substrate's changes — it commits them itself.
 
 When a new feature doc is created, add an entry to the `docs/features/README.md` index table.
 Missing entries cause discoverability gaps. When a new CLI command, script, or tool is added,
-add it to the appropriate table in `CLAUDE.md` (the Quick Commands table is the first place
-devs look).
+add it to the table in `.claude/skills/repo-commands/SKILL.md` (the full command reference).
 
 When you **add or remove** a `site/*.html` page during the cascade, update `site/sitemap.xml`
 so the published sitemap matches the page set. Edit affected site pages surgically, exactly

--- a/.claude/skill-context/new-skill.md
+++ b/.claude/skill-context/new-skill.md
@@ -81,9 +81,11 @@ Then run: `uv pip install -e .`
 - For explicit file sending, use: `<<FILE:/path/to/file>>`.
 - For AI models, import from `config/models.py`: `MODEL_FAST`, `MODEL_REASONING`, `MODEL_IMAGE_GEN`, `MODEL_VISION`.
 
-### Document in CLAUDE.md
+### Document in the command reference
 
-Add to the Quick Commands table or appropriate tools section:
+Add to the table in `.claude/skills/repo-commands/SKILL.md` (the full command reference).
+Only add to `CLAUDE.md`'s short "Everyday commands" table if the command is one an agent
+needs on nearly every session:
 
 ```markdown
 | `valor-tool-name arg1` | Brief description |

--- a/.claude/skills/repo-commands/SKILL.md
+++ b/.claude/skills/repo-commands/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: repo-commands
+description: Exact invocations for this repo's scripts and CLIs — valor-service (bridge/worker/email), valor-session and the agent-session scheduler, sdlc-tool, the pytest wrappers, memory search, doctor, reflections, analytics, TTS/video/ingest, and computer-use. Use when you need the precise command, flag, or subcommand for a repo tool rather than guessing.
+---
+
+# Repo Command Reference
+
+Full command table for this repository. Extracted from `CLAUDE.md` so it loads on demand
+instead of sitting in context every session.
+
+
+| Command | Description |
+|---------|-------------|
+| `./scripts/start_bridge.sh` | Start Telegram bridge |
+| `./scripts/valor-service.sh status` | Check bridge status |
+| `./scripts/valor-service.sh restart` | Restart bridge, watchdog, and worker after code changes |
+| `./scripts/valor-service.sh worker-start` | Start standalone worker service (also re-enables launchd auto-respawn) |
+| `./scripts/valor-service.sh worker-stop` | Transient stop — `bootout` only; launchd's `KeepAlive=true` may relaunch |
+| `./scripts/valor-service.sh worker-restart` | Restart standalone worker |
+| `./scripts/valor-service.sh worker-status` | Check worker service status |
+| `./scripts/valor-service.sh worker-disable` | Stop the worker **and** disable launchd auto-respawn (stays down until `worker-enable`/`worker-start`) |
+| `./scripts/valor-service.sh worker-enable` | Re-enable launchd auto-respawn (does NOT start the worker; pair with `worker-start`) |
+| `./scripts/valor-service.sh email-start` | Start the email bridge (IMAP polling) |
+| `./scripts/valor-service.sh email-stop` | Stop the email bridge |
+| `./scripts/valor-service.sh email-restart` | Restart the email bridge |
+| `./scripts/valor-service.sh email-status` | Check email bridge status, IMAP last-poll age, and SMTP relay heartbeat |
+| `./scripts/valor-service.sh email-disable` | Stop the email bridge **and** disable launchd auto-respawn (stays down until `email-enable`/`email-start`) |
+| `./scripts/valor-service.sh email-enable` | Re-enable launchd auto-respawn for the email bridge (does NOT start it; pair with `email-start`) |
+| `./scripts/valor-service.sh email-dead-letter list` | List failed SMTP sends in dead-letter queue |
+| `./scripts/valor-service.sh email-dead-letter replay --all` | Replay all dead-lettered emails |
+| `./scripts/install_email_bridge.sh` | Install launchd plist for boot-time email bridge (machine-gated, idempotent; opt-in) |
+| `tail -f logs/bridge.log` | Stream bridge logs |
+| `pytest tests/` | Run all tests (parallel by default — `-n auto --dist=loadfile` from `pyproject.toml`). **Prefer `scripts/pytest-clean.sh` over bare `pytest`** — the wrapper reaps xdist workers on exit; without it, interrupted runs leave orphan workers consuming memory (see xdist reaper note in `pyproject.toml`). |
+| `pytest tests/unit/` | Run unit tests only (~40s parallel) |
+| `pytest tests/unit/ -n0` | Force serial unit run (e.g. for debugging) |
+| `pytest tests/integration/` | Run integration tests only (~125s parallel) |
+| `scripts/pytest-clean.sh <pytest-args>` | Run pytest with automatic xdist worker reaping (drop-in for `pytest`). Full-suite runs also take a machine-global advisory lock (a `/tmp` path keyed to the repo's git common dir, shared across all worktrees) so a second concurrent full-suite run — including one from another worktree — waits instead of oversubscribing cores — see `docs/features/full-suite-pytest-lock.md`. Disable with `PYTEST_SUITE_LOCK=0`. |
+| `scripts/reap-xdist.sh` | Kill any orphan xdist workers on the system (one-shot reaper, idempotent) |
+| `pytest -m sdlc` | Run tests for a specific feature (see `tests/README.md`) |
+| `python -m ruff format . && python -m ruff check .` | Format and lint |
+| `python -m ui.app` | Start web UI server on localhost:8500 |
+| `curl -s localhost:8500/dashboard.json` | Check the dashboard — full system state as JSON (sessions, health, reflections, machine) |
+| `curl -s localhost:8500/memories/metrics.json` | Corpus-wide memory ingest-quality metrics as JSON (act rate, junk rate, ingest volume, histograms); optional `?project_key=`/`?min_evidence=`. See `docs/features/memory-telemetry.md`. |
+| `python -m tools.memory_eval.snapshot` | Snapshot current memory-corpus telemetry to `docs/baselines/memory-telemetry-baseline.{json,md}`; refuses to overwrite existing artifacts unless `--force` is passed |
+| `tail -f logs/worker.log` | Stream worker logs |
+| `python -m reflections --dry-run` | Load the reflection registry, print status, exit 0 (validates the out-of-process scheduler entry) |
+| `./scripts/install_reflection_worker.sh` | Install/reload the reflection-scheduler subprocess (`com.valor.reflection-worker`; worker-role gated, self-skips + removes stale plist elsewhere) |
+| `tail -f logs/reflection_worker.log` | Stream reflection-scheduler subprocess logs (`python -m reflections`) |
+| `sdlc-tool stage-query --issue-number {N}` | Query SDLC pipeline state for an issue (cwd-independent — see `docs/features/sdlc-tool-resolver.md`) |
+| `sdlc-tool verdict get --stage CRITIQUE --issue-number {N}` | Read the recorded critique verdict for an issue (also: `--stage REVIEW`) |
+| `sdlc-tool verdict finalize --pr {N} --issue-number {N} --verdict APPROVED --blockers 0 --tech-debt 0 --run-id {ID}` | Atomically record the REVIEW verdict + `REVIEW_CONTEXT head_sha=` trailer + `completed` stage marker with fail-closed named-error readback (see `docs/features/sdlc-verdict-fail-closed-persistence.md`) |
+| `sdlc-tool verdict selfcheck --pr {N} --issue-number {N}` | Read-only probe: verdict present, trailer matches PR head, marker completed — the `/do-sdlc` supervisor gates advance-past-REVIEW on `ok:true` |
+| `python scripts/sdlc_reflection.py` | Run SDLC reflection manually |
+| `python scripts/sdlc_reflection.py --dry-run` | Preview SDLC reflection without writing |
+| `python scripts/sdlc_reflection.py --days 14` | Run with larger lookback window |
+| `./scripts/install_sdlc_reflection.sh` | Install SDLC reflection launchd schedule |
+| `tail -f logs/sdlc_reflection.log` | Stream SDLC reflection logs |
+| `python scripts/autoexperiment.py --target observer --iterations 50` | Run autoexperiment on observer prompt |
+| `python scripts/autoexperiment.py --target summarizer --dry-run` | Dry-run autoexperiment on the message drafter (target name is historical) |
+| `python scripts/autoexperiment.py --list-targets` | List autoexperiment targets |
+| `./scripts/install_autoexperiment.sh` | Install autoexperiment nightly schedule |
+| `./scripts/install_nightly_tests.sh` | Install nightly regression test launchd schedule (bridge-role gated; auto-installed by `/update` on bridge machines, self-skips + removes stale plist elsewhere) |
+| `python scripts/nightly_regression_tests.py --dry-run` | Preview nightly test run without Telegram |
+| `tail -f logs/nightly_tests.log` | Stream nightly test logs |
+| `tail -f logs/nightly_tests_error.log` | Stream nightly test error log (startup crashes) |
+| `python -m tools.analytics export --days 30` | Export analytics metrics as JSON |
+| `python -m tools.analytics summary` | Print human-readable analytics summary |
+| `python -m tools.analytics rollup` | Run analytics daily rollup manually |
+| `python -m tools.agent_session_scheduler status` | Show queue status (pending, running, killed counts) |
+| `python -m tools.agent_session_scheduler list --status killed,abandoned` | List sessions filtered by status |
+| `python -m tools.agent_session_scheduler kill --agent-session-id <ID>` | Kill a running or pending session by ID |
+| `python -m tools.agent_session_scheduler kill --session-id <ID>` | Kill a session by session ID |
+| `python -m tools.agent_session_scheduler kill --all` | Kill all running and pending sessions |
+| `python -m tools.agent_session_scheduler cleanup --age 30 --dry-run` | Preview stale session cleanup |
+| `python -m tools.agent_session_scheduler cleanup --age 30` | Delete stale killed/abandoned/failed sessions |
+| `python -m tools.valor_session list` | List all sessions |
+| `python -m tools.valor_session status --id <ID>` | Show session status and pending steering messages |
+| `python -m tools.valor_session status --full-message --id <ID>` | Show full initial prompt (no 100-char truncation) |
+| `python -m tools.valor_session inspect --id <ID>` | Dump all raw Popoto fields for a session (debugging) |
+| `python -m tools.valor_session children --id <ID>` | List all child sessions spawned by a parent session |
+| `python -m tools.valor_session steer --id <ID> --message "..."` | Inject a steering message into a running session |
+| `python -m tools.valor_session kill --id <ID>` | Kill a session |
+| `python -m tools.valor_session kill --all` | Kill all running sessions |
+| `python -m tools.valor_session create --role eng --message "..."` | Create and enqueue a new Eng session. `project_key` determines the repo via `projects.json`; there is no working-directory override flag. Precedence: `--project-key` > `--parent` inheritance > cwd match (raises on no match). Warns to stderr if no worker is running. |
+| `python -m tools.valor_session resume --id <ID> --message "..."` | Resume a completed, killed, or failed session (hard-PATCH path; accepts session_id or agent_session_id) |
+| `python -m tools.valor_session release --pr <N>` | Clear retain_for_resume after PR merge/close |
+| `python -m tools.valor_session telemetry --id <ID>` | Show session telemetry timeline (turn events, token usage, status transitions) |
+| `valor-session crash-signatures` | Show crash signatures in the library (project-scoped) |
+| `valor-session crash-policy list` | Show derived auto-resume policy entries |
+| `valor-session-archive status` | Show the SQLite secondary-store (`data/session_archive.db`) freshness: row count, last export age, health |
+| `valor-session-archive restore --dry-run` | Report the empty-Redis restore guard decision (would it restore/skip/resume, and how many rows) without writing anything — read-only; export and live restore run automatically via the worker |
+| `python -m tools.memory_search search "query"` | Search memories by query |
+| `python -m tools.memory_search search "query" --category correction` | Search filtered by category |
+| `python -m tools.memory_search search "query" --tag redis` | Search filtered by tag |
+| `python -m tools.memory_search save "content"` | Save a new memory |
+| `python -m tools.memory_search inspect --id <ID>` | Inspect a specific memory |
+| `python -m tools.memory_search inspect --stats` | Show memory statistics |
+| `python -m tools.memory_search forget --id <ID> --confirm` | Delete a memory |
+| `python -m tools.memory_search status` | Check memory system health (Redis, counts, superseded ratio) |
+| `python -m tools.memory_search status --json` | Memory health as machine-readable JSON |
+| `python -m tools.memory_search status --deep` | Memory health with Redis-side `orphan_index_count`, disk-side `disk_orphan_count`, and per-category confidence |
+| `python -m tools.doctor` | Run all environment and health checks |
+| `python -m tools.doctor --quick` | Skip slow checks (Telegram session, model verification) |
+| `python -m tools.doctor --quality` | Include code quality checks (ruff, pytest) |
+| `python -m tools.doctor --json` | Output health check results as JSON |
+| `python -m tools.doctor --install-hook` | Install git pre-push hook running doctor --quick |
+| `valor-youtube-search "query"` | Search YouTube for videos by query |
+| `valor-youtube-search --limit N "query"` | Search YouTube with limited results |
+| `valor-youtube-transcribe <url>` | Transcribe a YouTube video (captions-first, Whisper fallback). Prefer this over `WebFetch` for YouTube URLs — YouTube serves anti-bot HTML to non-browser fetchers. |
+| `valor-youtube-transcribe --json <url>` | Same as above, emit raw `process_youtube_url` dict as JSON |
+| `valor-youtube-transcribe --summary-only <url>` | Emit only the GPT-4o-mini summary (or full transcript with a note if none) |
+| `valor-video-watch <url> ["question"]` | Visual grounding for a YouTube or X/Twitter video: yt-dlp download, ffmpeg scene-change frame extraction (deduped), Whisper transcript, and Grok X-native context/fallback for X. Prints frame JPEG paths (`t=MM:SS`) to `Read` image-by-image. Use when the answer is on-screen, not in the audio. See `docs/features/video-watch-visual-grounding.md`. |
+| `valor-video-watch --json <url>` | Same, emitting the raw `watch_video` result dict as JSON |
+| `valor-tts --text "Hello." --output /tmp/out.ogg` | Synthesize text to OGG/Opus (Kokoro local primary, OpenAI tts-1 fallback). See `docs/features/tts.md`. |
+| `valor-tts --text "Hello." --output /tmp/out.ogg --voice af_bella` | Synthesize with a specific voice (catalog in `tools/tts/README.md`) |
+| `valor-tts --text "Hello." --output /tmp/out.ogg --force-cloud` | Force the cloud (OpenAI tts-1) backend even if Kokoro is available |
+| `valor-deck-video deck.md` | Render a narrated MP4 of a Marp deck (per-slide `<!-- narration: ... -->`, voiceover via valor-tts, slides held for each clip's duration). See `docs/features/narrated-deck-video.md`. |
+| `valor-ingest <path-or-url>` | Convert a PDF/DOCX/PPTX/XLSX/HTML/image/YouTube URL into a `.md` sidecar the knowledge indexer picks up (see `docs/features/markitdown-ingestion.md`) |
+| `valor-ingest --scan ~/work-vault/` | Backfill every convertible binary file in the vault recursively (audio formats deliberately excluded) |
+| `valor-computer bootstrap` | Readiness preflight (`GET /v1/bootstrap`); run once per session before the first action. Exit 0 when ready, 78 when permissions ungranted (`instructions.ready == false`) or bcu unavailable — relay `instructions.user` and stop |
+| `valor-computer list_apps` | List all visible macOS apps (requires bcu opt-in via `/setup`; macOS-only — exits 78 on other OSes) |
+| `valor-computer list_windows <app>` | List open windows for an app (name, bundle ID, or query); window IDs are strings |
+| `valor-computer click <window> --x N --y N` | Click coordinates in a native window without moving the user's cursor |
+| `valor-computer type_text <window> "text"` | Type text into a native app window via Accessibility API |
+| `valor-computer screenshot <window> --output /tmp/out.png` | Capture a native window screenshot via get_window_state imageMode (see `docs/features/computer-use.md`) |
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,146 +8,25 @@ Guidance for Claude Code when working with this repository.
 
 On PATH after `npm install -g @googleworkspace/cli` (installed automatically on every machine by `/update`). **Not pre-authenticated** — first use requires a one-time human OAuth step: `gws auth setup` then `gws auth login`. If `gws` is present but unauthenticated, fall through to the next tool in the ladder (Gmail/Calendar/Drive MCP, then BYOB) rather than stalling.
 
-Usage: `gws <service> <resource> [sub-resource] <method> [flags]`
-
-**Services:** drive, sheets, gmail, calendar, docs, slides, people, chat, forms, keep, meet
-
-**Key flags:**
-- `--params '<JSON>'` — URL/query parameters
-- `--json '<JSON>'` — request body (POST/PATCH/PUT)
-- `--format table|csv|yaml` — output format (default: json)
-- `--page-all` — auto-paginate (NDJSON, max 10 pages)
-- `--upload <PATH>` — upload file
-- `--output <PATH>` — save binary response to file
-- `gws schema <service.resource.method>` — discover params for any method
-
-**Common patterns:**
-```
-gws gmail users messages list --params '{"userId": "me", "maxResults": 5}'
-gws gmail users messages get --params '{"userId": "me", "id": "MSG_ID"}'
-gws drive files list --params '{"q": "name contains '\''report'\''", "pageSize": 10}'
-gws calendar events list --params '{"calendarId": "primary", "timeMin": "2026-03-06T00:00:00Z"}'
-gws sheets spreadsheets values get --params '{"spreadsheetId": "ID", "range": "Sheet1!A1:D10"}'
-```
-
-**Workflows:** `gws workflow +standup-report`, `+meeting-prep`, `+email-to-task`, `+weekly-digest`
+Command reference: `gws --help`, and `gws schema <service.resource.method>` to discover params for any method. The full usage/flags/patterns reference lives in `~/.claude/CLAUDE.md`, which loads on every machine and in every project.
 
 ## Quick Commands
 
+Everyday commands:
+
 | Command | Description |
 |---------|-------------|
-| `./scripts/start_bridge.sh` | Start Telegram bridge |
-| `./scripts/valor-service.sh status` | Check bridge status |
 | `./scripts/valor-service.sh restart` | Restart bridge, watchdog, and worker after code changes |
-| `./scripts/valor-service.sh worker-start` | Start standalone worker service (also re-enables launchd auto-respawn) |
-| `./scripts/valor-service.sh worker-stop` | Transient stop — `bootout` only; launchd's `KeepAlive=true` may relaunch |
-| `./scripts/valor-service.sh worker-restart` | Restart standalone worker |
-| `./scripts/valor-service.sh worker-status` | Check worker service status |
-| `./scripts/valor-service.sh worker-disable` | Stop the worker **and** disable launchd auto-respawn (stays down until `worker-enable`/`worker-start`) |
-| `./scripts/valor-service.sh worker-enable` | Re-enable launchd auto-respawn (does NOT start the worker; pair with `worker-start`) |
-| `./scripts/valor-service.sh email-start` | Start the email bridge (IMAP polling) |
-| `./scripts/valor-service.sh email-stop` | Stop the email bridge |
-| `./scripts/valor-service.sh email-restart` | Restart the email bridge |
-| `./scripts/valor-service.sh email-status` | Check email bridge status, IMAP last-poll age, and SMTP relay heartbeat |
-| `./scripts/valor-service.sh email-disable` | Stop the email bridge **and** disable launchd auto-respawn (stays down until `email-enable`/`email-start`) |
-| `./scripts/valor-service.sh email-enable` | Re-enable launchd auto-respawn for the email bridge (does NOT start it; pair with `email-start`) |
-| `./scripts/valor-service.sh email-dead-letter list` | List failed SMTP sends in dead-letter queue |
-| `./scripts/valor-service.sh email-dead-letter replay --all` | Replay all dead-lettered emails |
-| `./scripts/install_email_bridge.sh` | Install launchd plist for boot-time email bridge (machine-gated, idempotent; opt-in) |
-| `tail -f logs/bridge.log` | Stream bridge logs |
-| `pytest tests/` | Run all tests (parallel by default — `-n auto --dist=loadfile` from `pyproject.toml`). **Prefer `scripts/pytest-clean.sh` over bare `pytest`** — the wrapper reaps xdist workers on exit; without it, interrupted runs leave orphan workers consuming memory (see xdist reaper note in `pyproject.toml`). |
-| `pytest tests/unit/` | Run unit tests only (~40s parallel) |
-| `pytest tests/unit/ -n0` | Force serial unit run (e.g. for debugging) |
-| `pytest tests/integration/` | Run integration tests only (~125s parallel) |
-| `scripts/pytest-clean.sh <pytest-args>` | Run pytest with automatic xdist worker reaping (drop-in for `pytest`). Full-suite runs also take a machine-global advisory lock (a `/tmp` path keyed to the repo's git common dir, shared across all worktrees) so a second concurrent full-suite run — including one from another worktree — waits instead of oversubscribing cores — see `docs/features/full-suite-pytest-lock.md`. Disable with `PYTEST_SUITE_LOCK=0`. |
-| `scripts/reap-xdist.sh` | Kill any orphan xdist workers on the system (one-shot reaper, idempotent) |
-| `pytest -m sdlc` | Run tests for a specific feature (see `tests/README.md`) |
+| `./scripts/valor-service.sh status` | Check bridge status |
+| `scripts/pytest-clean.sh tests/unit/` | Run tests via the wrapper that reaps xdist workers (prefer over bare `pytest`) |
 | `python -m ruff format . && python -m ruff check .` | Format and lint |
-| `python -m ui.app` | Start web UI server on localhost:8500 |
-| `curl -s localhost:8500/dashboard.json` | Check the dashboard — full system state as JSON (sessions, health, reflections, machine) |
-| `curl -s localhost:8500/memories/metrics.json` | Corpus-wide memory ingest-quality metrics as JSON (act rate, junk rate, ingest volume, histograms); optional `?project_key=`/`?min_evidence=`. See `docs/features/memory-telemetry.md`. |
-| `python -m tools.memory_eval.snapshot` | Snapshot current memory-corpus telemetry to `docs/baselines/memory-telemetry-baseline.{json,md}`; refuses to overwrite existing artifacts unless `--force` is passed |
-| `tail -f logs/worker.log` | Stream worker logs |
-| `python -m reflections --dry-run` | Load the reflection registry, print status, exit 0 (validates the out-of-process scheduler entry) |
-| `./scripts/install_reflection_worker.sh` | Install/reload the reflection-scheduler subprocess (`com.valor.reflection-worker`; worker-role gated, self-skips + removes stale plist elsewhere) |
-| `tail -f logs/reflection_worker.log` | Stream reflection-scheduler subprocess logs (`python -m reflections`) |
-| `sdlc-tool stage-query --issue-number {N}` | Query SDLC pipeline state for an issue (cwd-independent — see `docs/features/sdlc-tool-resolver.md`) |
-| `sdlc-tool verdict get --stage CRITIQUE --issue-number {N}` | Read the recorded critique verdict for an issue (also: `--stage REVIEW`) |
-| `sdlc-tool verdict finalize --pr {N} --issue-number {N} --verdict APPROVED --blockers 0 --tech-debt 0 --run-id {ID}` | Atomically record the REVIEW verdict + `REVIEW_CONTEXT head_sha=` trailer + `completed` stage marker with fail-closed named-error readback (see `docs/features/sdlc-verdict-fail-closed-persistence.md`) |
-| `sdlc-tool verdict selfcheck --pr {N} --issue-number {N}` | Read-only probe: verdict present, trailer matches PR head, marker completed — the `/do-sdlc` supervisor gates advance-past-REVIEW on `ok:true` |
-| `python scripts/sdlc_reflection.py` | Run SDLC reflection manually |
-| `python scripts/sdlc_reflection.py --dry-run` | Preview SDLC reflection without writing |
-| `python scripts/sdlc_reflection.py --days 14` | Run with larger lookback window |
-| `./scripts/install_sdlc_reflection.sh` | Install SDLC reflection launchd schedule |
-| `tail -f logs/sdlc_reflection.log` | Stream SDLC reflection logs |
-| `python scripts/autoexperiment.py --target observer --iterations 50` | Run autoexperiment on observer prompt |
-| `python scripts/autoexperiment.py --target summarizer --dry-run` | Dry-run autoexperiment on the message drafter (target name is historical) |
-| `python scripts/autoexperiment.py --list-targets` | List autoexperiment targets |
-| `./scripts/install_autoexperiment.sh` | Install autoexperiment nightly schedule |
-| `./scripts/install_nightly_tests.sh` | Install nightly regression test launchd schedule (bridge-role gated; auto-installed by `/update` on bridge machines, self-skips + removes stale plist elsewhere) |
-| `python scripts/nightly_regression_tests.py --dry-run` | Preview nightly test run without Telegram |
-| `tail -f logs/nightly_tests.log` | Stream nightly test logs |
-| `tail -f logs/nightly_tests_error.log` | Stream nightly test error log (startup crashes) |
-| `python -m tools.analytics export --days 30` | Export analytics metrics as JSON |
-| `python -m tools.analytics summary` | Print human-readable analytics summary |
-| `python -m tools.analytics rollup` | Run analytics daily rollup manually |
-| `python -m tools.agent_session_scheduler status` | Show queue status (pending, running, killed counts) |
-| `python -m tools.agent_session_scheduler list --status killed,abandoned` | List sessions filtered by status |
-| `python -m tools.agent_session_scheduler kill --agent-session-id <ID>` | Kill a running or pending session by ID |
-| `python -m tools.agent_session_scheduler kill --session-id <ID>` | Kill a session by session ID |
-| `python -m tools.agent_session_scheduler kill --all` | Kill all running and pending sessions |
-| `python -m tools.agent_session_scheduler cleanup --age 30 --dry-run` | Preview stale session cleanup |
-| `python -m tools.agent_session_scheduler cleanup --age 30` | Delete stale killed/abandoned/failed sessions |
-| `python -m tools.valor_session list` | List all sessions |
-| `python -m tools.valor_session status --id <ID>` | Show session status and pending steering messages |
-| `python -m tools.valor_session status --full-message --id <ID>` | Show full initial prompt (no 100-char truncation) |
-| `python -m tools.valor_session inspect --id <ID>` | Dump all raw Popoto fields for a session (debugging) |
-| `python -m tools.valor_session children --id <ID>` | List all child sessions spawned by a parent session |
-| `python -m tools.valor_session steer --id <ID> --message "..."` | Inject a steering message into a running session |
-| `python -m tools.valor_session kill --id <ID>` | Kill a session |
-| `python -m tools.valor_session kill --all` | Kill all running sessions |
-| `python -m tools.valor_session create --role eng --message "..."` | Create and enqueue a new Eng session. `project_key` determines the repo via `projects.json`; there is no working-directory override flag. Precedence: `--project-key` > `--parent` inheritance > cwd match (raises on no match). Warns to stderr if no worker is running. |
-| `python -m tools.valor_session resume --id <ID> --message "..."` | Resume a completed, killed, or failed session (hard-PATCH path; accepts session_id or agent_session_id) |
-| `python -m tools.valor_session release --pr <N>` | Clear retain_for_resume after PR merge/close |
-| `python -m tools.valor_session telemetry --id <ID>` | Show session telemetry timeline (turn events, token usage, status transitions) |
-| `valor-session crash-signatures` | Show crash signatures in the library (project-scoped) |
-| `valor-session crash-policy list` | Show derived auto-resume policy entries |
-| `valor-session-archive status` | Show the SQLite secondary-store (`data/session_archive.db`) freshness: row count, last export age, health |
-| `valor-session-archive restore --dry-run` | Report the empty-Redis restore guard decision (would it restore/skip/resume, and how many rows) without writing anything — read-only; export and live restore run automatically via the worker |
-| `python -m tools.memory_search search "query"` | Search memories by query |
-| `python -m tools.memory_search search "query" --category correction` | Search filtered by category |
-| `python -m tools.memory_search search "query" --tag redis` | Search filtered by tag |
-| `python -m tools.memory_search save "content"` | Save a new memory |
-| `python -m tools.memory_search inspect --id <ID>` | Inspect a specific memory |
-| `python -m tools.memory_search inspect --stats` | Show memory statistics |
-| `python -m tools.memory_search forget --id <ID> --confirm` | Delete a memory |
-| `python -m tools.memory_search status` | Check memory system health (Redis, counts, superseded ratio) |
-| `python -m tools.memory_search status --json` | Memory health as machine-readable JSON |
-| `python -m tools.memory_search status --deep` | Memory health with Redis-side `orphan_index_count`, disk-side `disk_orphan_count`, and per-category confidence |
-| `python -m tools.doctor` | Run all environment and health checks |
-| `python -m tools.doctor --quick` | Skip slow checks (Telegram session, model verification) |
-| `python -m tools.doctor --quality` | Include code quality checks (ruff, pytest) |
-| `python -m tools.doctor --json` | Output health check results as JSON |
-| `python -m tools.doctor --install-hook` | Install git pre-push hook running doctor --quick |
-| `valor-youtube-search "query"` | Search YouTube for videos by query |
-| `valor-youtube-search --limit N "query"` | Search YouTube with limited results |
-| `valor-youtube-transcribe <url>` | Transcribe a YouTube video (captions-first, Whisper fallback). Prefer this over `WebFetch` for YouTube URLs — YouTube serves anti-bot HTML to non-browser fetchers. |
-| `valor-youtube-transcribe --json <url>` | Same as above, emit raw `process_youtube_url` dict as JSON |
-| `valor-youtube-transcribe --summary-only <url>` | Emit only the GPT-4o-mini summary (or full transcript with a note if none) |
-| `valor-video-watch <url> ["question"]` | Visual grounding for a YouTube or X/Twitter video: yt-dlp download, ffmpeg scene-change frame extraction (deduped), Whisper transcript, and Grok X-native context/fallback for X. Prints frame JPEG paths (`t=MM:SS`) to `Read` image-by-image. Use when the answer is on-screen, not in the audio. See `docs/features/video-watch-visual-grounding.md`. |
-| `valor-video-watch --json <url>` | Same, emitting the raw `watch_video` result dict as JSON |
-| `valor-tts --text "Hello." --output /tmp/out.ogg` | Synthesize text to OGG/Opus (Kokoro local primary, OpenAI tts-1 fallback). See `docs/features/tts.md`. |
-| `valor-tts --text "Hello." --output /tmp/out.ogg --voice af_bella` | Synthesize with a specific voice (catalog in `tools/tts/README.md`) |
-| `valor-tts --text "Hello." --output /tmp/out.ogg --force-cloud` | Force the cloud (OpenAI tts-1) backend even if Kokoro is available |
-| `valor-deck-video deck.md` | Render a narrated MP4 of a Marp deck (per-slide `<!-- narration: ... -->`, voiceover via valor-tts, slides held for each clip's duration). See `docs/features/narrated-deck-video.md`. |
-| `valor-ingest <path-or-url>` | Convert a PDF/DOCX/PPTX/XLSX/HTML/image/YouTube URL into a `.md` sidecar the knowledge indexer picks up (see `docs/features/markitdown-ingestion.md`) |
-| `valor-ingest --scan ~/work-vault/` | Backfill every convertible binary file in the vault recursively (audio formats deliberately excluded) |
-| `valor-computer bootstrap` | Readiness preflight (`GET /v1/bootstrap`); run once per session before the first action. Exit 0 when ready, 78 when permissions ungranted (`instructions.ready == false`) or bcu unavailable — relay `instructions.user` and stop |
-| `valor-computer list_apps` | List all visible macOS apps (requires bcu opt-in via `/setup`; macOS-only — exits 78 on other OSes) |
-| `valor-computer list_windows <app>` | List open windows for an app (name, bundle ID, or query); window IDs are strings |
-| `valor-computer click <window> --x N --y N` | Click coordinates in a native window without moving the user's cursor |
-| `valor-computer type_text <window> "text"` | Type text into a native app window via Accessibility API |
-| `valor-computer screenshot <window> --output /tmp/out.png` | Capture a native window screenshot via get_window_state imageMode (see `docs/features/computer-use.md`) |
+| `curl -s localhost:8500/dashboard.json` | Full system state as JSON |
+| `python -m tools.doctor --quick` | Environment and health checks |
+| `tail -f logs/bridge.log` | Stream bridge logs |
+
+**The full command table** (valor-session, sdlc-tool, memory, reflections, analytics,
+TTS/video/ingest, computer-use, email bridge, and every flag) lives in the `repo-commands`
+skill. Invoke it when you need an exact invocation instead of guessing.
 
 ## Manual Testing Hygiene
 
@@ -253,22 +132,13 @@ The standard flow from conversation to shipped feature:
 
 ## System Architecture
 
-```
-Telegram → Python Bridge (Telethon) → Enqueues AgentSession to Redis (I/O only)
-              (bridge/telegram_bridge.py)     → Nudge loop (bridge has no SDLC awareness)
-                                              → Registers output callbacks for delivery
+Telegram → bridge (I/O only, no SDLC awareness) → AgentSession in Redis → standalone
+worker → Eng session via the headless session runner (one `claude -p` per turn).
 
-Standalone Worker (python -m worker) → Sole session execution engine
-              (worker/__main__.py)         → Startup: index rebuild → corrupted+orphan cleanup → dead-worker sweep (Step 3a, issue #1767) → recovery (Step 3b) → register_worker_pid (self-suicide guard)
-                                           → Hourly `agent-session-cleanup` reflection: corrupted records + cross-process orphan reap (claude/MCP, PPID==1, heartbeat-gated; issue #1271)
-                                           → Executes Eng session (AgentSession session_type=eng)
-                                               → Eng session handles SDLC work via the headless session runner (one `claude -p` subprocess per turn; PM spawns/continues a resumable `dev` subagent inline)
-                                                 (agent/session_runner/; bridge-originated sessions; see docs/features/headless-session-runner.md)
-                                           → Uses OutputHandler protocol (agent/output_handler.py)
-                                           → TelegramRelayOutputHandler writes to Redis outbox
-                                           → FileOutputHandler fallback for non-Telegram / dev environments
-```
-See `docs/features/bridge-worker-architecture.md` for the full bridge/worker separation design.
+Read these before changing anything in `bridge/`, `worker/`, or `agent/`:
+- `docs/features/bridge-worker-architecture.md` — bridge/worker separation, startup and recovery order
+- `docs/features/headless-session-runner.md` — the `claude -p` per-turn model, PM/dev subagent continuation
+- `docs/features/eng-session-architecture.md` — session types and permissions
 
 **Session Types** (see `docs/features/eng-session-architecture.md`):
 - **Eng Session** (`session_type="eng"`) - Handles both SDLC work and conversational responses, full permissions, engineer persona
@@ -287,17 +157,6 @@ See `docs/features/bridge-worker-architecture.md` for the full bridge/worker sep
 - **Claude Code hooks** extend memory to CLI sessions via `.claude/hooks/hook_utils/memory_bridge.py` (see `docs/features/claude-code-memory.md`): UserPromptSubmit ingests prompts, PostToolUse recalls with file-based sliding window, Stop extracts observations
 - All memory operations fail silently -- memory system never crashes the agent or hooks
 - **Memory consolidation** (`memory-dedup` nightly reflection): Haiku-based semantic dedup merges near-duplicate records, sets `superseded_by` on originals (never deleted), filters superseded records from recall. Dry-run default — see `docs/features/subconscious-memory.md#memory-consolidation`
-
-**Key Directories:**
-- `.claude/skills-global/` - **Global skills** — synced to every machine (see below)
-- `.claude/skills/` - **Project-only skills** — work only in this repo's context, NOT synced
-- `.claude/commands/` - Slash command skills
-- `.claude/agents/` - Subagent definitions (builder, validator, code-reviewer; eng sessions created via valor_session CLI)
-- `bridge/` - Telegram integration, nudge loop
-- `worker/` - Standalone worker service (`python -m worker`)
-- `agent/` - Session queue, SDK client, output router (`output_router.py`), output handler protocol, constants
-- `tools/` - Local Python tools
-- `config/` - Configuration files
 
 ## Global vs. Project-Only Skills
 
@@ -326,14 +185,6 @@ Example: `/do-debrief` (the TTS composite that wraps `valor-tts`) lives in `.cla
 - **Real integration testing** - No mocks, use actual APIs
 - **Intelligence validation** - Use AI judges, not keyword matching
 - **Quality gates**: Unit 100%, Integration 95%, E2E 90%
-
-## Work Completion Criteria
-
-Work is DONE when:
-1. ✅ Deliverable exists and works
-2. ✅ Code quality standards met (`python -m ruff check`, `python -m ruff format`)
-3. ✅ Changes committed and pushed to git
-4. ✅ Original request fulfilled
 
 ## Session Management
 

--- a/docs/features/session-lifecycle.md
+++ b/docs/features/session-lifecycle.md
@@ -151,7 +151,7 @@ The `agent/agent_session_queue.py:cancel_agent_session` site does **not** need a
 **Operator semantics**:
 
 - `valor-session kill <id>` — writes `status=killed` via `finalize_session(reject_from_terminal=True)` (its own pre-condition guarantees no terminal-flip).
-- `./scripts/valor-service.sh worker-disable` — pairs `launchctl disable` with `bootout`. Use this when killing all sessions and you do **not** want the worker to come back via launchd's `KeepAlive=true` respawn. Re-enable with `worker-enable` (or `worker-start`, which calls `launchctl enable` idempotently before `bootstrap`). See `./scripts/valor-service.sh` help and CLAUDE.md "Quick Commands" for the full table.
+- `./scripts/valor-service.sh worker-disable` — pairs `launchctl disable` with `bootout`. Use this when killing all sessions and you do **not** want the worker to come back via launchd's `KeepAlive=true` respawn. Re-enable with `worker-enable` (or `worker-start`, which calls `launchctl enable` idempotently before `bootstrap`). See `./scripts/valor-service.sh` help and the `repo-commands` skill for the full table.
 
 ## Completion Flow
 


### PR DESCRIPTION
## What

Trims `CLAUDE.md` from **40,152 → 24,460 chars** (~10,038 → ~6,115 est. tokens loaded into every session) by cutting derivable content and moving the rest to lazy loading.

The file had just crossed Claude Code's large-memory-file warning threshold (~5% of the context window, floor ~40,000 chars). It is now comfortably under.

Came out of a `/doctor` pass on the Claude Code setup.

## Moved to lazy loading

| From | To | Saved |
|---|---|---|
| Quick Commands table (13.9k chars, 116 rows) | `.claude/skills/repo-commands/SKILL.md` | ~3,470 est. tokens |
| System Architecture diagram + Key Directories | pointers to the three `docs/features/` files that already hold it | ~1,249 est. tokens |

The command table is now a skill: only its one-line description stays resident, and the body loads when invoked. A 7-row "everyday commands" table stays inline (`valor-service restart`, `pytest-clean.sh`, ruff, `dashboard.json`, doctor, bridge logs).

## Cut as derivable

- **gws command reference** (services, flags, common patterns) — reconstructable from `gws --help` and `gws schema`, and duplicated verbatim in `~/.claude/CLAUDE.md`, which loads on every machine. Kept the auth-ladder paragraph (not pre-authenticated, fall through to MCP then BYOB) since that is a real gotcha and not derivable.
- **Work Completion Criteria** — restated Principle 4 (commit and push) and Principle 7 (definition of done); the ruff commands were already in the command table.

## Deliberately not cut

Principles 2 and 6 looked like generic best practice, but removing them forces a renumber, and `docs/audits/skills-architecture-audit-2026-07.md` plus two plan docs cite "Principle 3" and "Principle 8" **by number**. Not worth breaking cross-references for ~86 tokens.

## Anti-regrowth

Three places instructed future agents to add new commands to the table that moved. Updated so it does not silently regrow:

- `.claude/skill-context/do-docs.md` — doc-location table and the "new CLI command" cascade rule
- `.claude/skill-context/new-skill.md` — the "Document in CLAUDE.md" step
- `docs/features/session-lifecycle.md` — a cross-reference to the old table

## Verification

- All three `docs/features/` pointers resolve to existing files.
- Extracted skill is intact: 114 table rows, no bleed into the following section.
- The skill registers correctly — it appeared in the available-skills list immediately after creation.
- Diff is docs/markdown only; no source changes.

## Related

Filed #2435 out of the same pass, on hook registration and the project→user propagation seam. Independent of this PR.