### PR TITLE
Fix SDLC hooks failing to launch in every foreign repo

### DIFF
--- a/.claude/hooks/sdlc/sdlc_context.py
+++ b/.claude/hooks/sdlc/sdlc_context.py
@@ -10,6 +10,8 @@ system. The AgentSession import is optional — it falls back gracefully to
 branch-only detection when Redis or the AI repo isn't available.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import subprocess

--- a/.claude/hooks/sdlc/sdlc_reminder.py
+++ b/.claude/hooks/sdlc/sdlc_reminder.py
@@ -18,6 +18,8 @@ Claude Code hook protocol:
   Advisory: print message to stdout, exit 0
 """
 
+from __future__ import annotations
+
 import hashlib
 import os
 import sys

--- a/.claude/hooks/sdlc/validate_commit_message.py
+++ b/.claude/hooks/sdlc/validate_commit_message.py
@@ -19,6 +19,8 @@ Claude Code hook protocol:
   To ALLOW: print nothing, exit 0
 """
 
+from __future__ import annotations
+
 import os
 import subprocess
 import sys

--- a/.claude/hooks/sdlc/validate_sdlc_on_stop.py
+++ b/.claude/hooks/sdlc/validate_sdlc_on_stop.py
@@ -22,6 +22,8 @@ Claude Code hook protocol:
   Stdin: JSON with session_id, transcript_path (JSONL file), cwd, etc.
 """
 
+from __future__ import annotations
+
 import os
 import re
 import subprocess

--- a/scripts/update/hardlinks.py
+++ b/scripts/update/hardlinks.py
@@ -686,6 +686,13 @@ def sync_user_hooks(project_dir: Path) -> HardlinkSyncResult:
     return result
 
 
+# Claude Code runs hook commands via /bin/sh, which is non-interactive and never
+# sources ~/.zshenv -- so the `python -> python3` shell alias does not apply and a
+# bare `python` resolves only when a virtualenv happens to be on PATH. These hooks
+# are registered at *user* scope and fire inside every repo on the machine, most of
+# which have no such venv. Must stay an interpreter name that resolves bare.
+_HOOK_INTERPRETER = "python3"
+
 # SDLC hook definitions for ~/.claude/settings.json.
 # Each tuple: (hook_event, matcher, script_name, timeout)
 _SDLC_HOOK_DEFS: list[tuple[str, str, str, int]] = [
@@ -722,7 +729,8 @@ def _merge_hook_settings(settings_path: Path, hooks_dir: Path, result: HardlinkS
     updated = 0
 
     for hook_event, matcher, script_name, timeout in _SDLC_HOOK_DEFS:
-        command = f"python {hooks_dir / script_name}"
+        command = f"{_HOOK_INTERPRETER} {hooks_dir / script_name}"
+        legacy_command = f"python {hooks_dir / script_name}"
         hook_entry = {
             "type": "command",
             "command": command,
@@ -735,12 +743,19 @@ def _merge_hook_settings(settings_path: Path, hooks_dir: Path, result: HardlinkS
 
         event_hooks = hooks.setdefault(hook_event, [])
 
-        # Check if a hook with the same command already exists
+        # Check if a hook with the same command already exists. A legacy
+        # bare-`python` command counts as a match and is rewritten in place --
+        # dedup is by exact command string, so treating it as absent would
+        # append a second block and leave the broken original firing too.
         already_exists = False
         for existing_block in event_hooks:
             for existing_hook in existing_block.get("hooks", []):
-                if existing_hook.get("command", "") == command:
+                existing_command = existing_hook.get("command", "")
+                if existing_command in (command, legacy_command):
                     already_exists = True
+                    if existing_command != command:
+                        existing_hook["command"] = command
+                        updated += 1
                     # Update matcher if it changed
                     if existing_block.get("matcher", "") != matcher:
                         existing_block["matcher"] = matcher

--- a/tests/unit/test_hardlinks_hook_merge.py
+++ b/tests/unit/test_hardlinks_hook_merge.py
@@ -1,0 +1,143 @@
+"""Tests for _merge_hook_settings in scripts/update/hardlinks.py.
+
+The SDLC hooks are registered in the *user-scope* ~/.claude/settings.json and
+therefore fire inside every repo on the machine, not just this one. Claude Code
+executes hook commands via /bin/sh, which is non-interactive and never sources
+~/.zshenv -- so a bare `python` resolves only when a virtualenv happens to be on
+PATH. On a machine whose only interpreter is `python3`, a bare `python` command
+dies with `command not found` in every foreign repo, silently disabling the
+guardrails (including the block-code-commits-to-main check).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from update.hardlinks import (  # noqa: E402
+    _SDLC_HOOK_DEFS,
+    HardlinkSyncResult,
+    _merge_hook_settings,
+)
+
+HOOKS_DIR = Path("/Users/test/.claude/hooks/sdlc")
+
+
+def _all_commands(settings: dict) -> list[str]:
+    """Flatten every hook command across every event in a settings dict."""
+    return [
+        hook.get("command", "")
+        for event_blocks in settings.get("hooks", {}).values()
+        for block in event_blocks
+        for hook in block.get("hooks", [])
+    ]
+
+
+def test_hook_commands_use_python3(tmp_path: Path) -> None:
+    """Registered commands must invoke python3, never a bare python."""
+    settings_path = tmp_path / "settings.json"
+    _merge_hook_settings(settings_path, HOOKS_DIR, HardlinkSyncResult())
+
+    settings = json.loads(settings_path.read_text())
+    commands = _all_commands(settings)
+
+    assert commands, "expected SDLC hook commands to be registered"
+    for command in commands:
+        assert command.startswith("python3 "), f"bare interpreter in: {command}"
+
+
+def test_legacy_bare_python_entry_is_rewritten_not_duplicated(tmp_path: Path) -> None:
+    """A deployed `python ...` entry is upgraded in place, not shadowed by a twin.
+
+    Dedup is by exact command string, so switching the interpreter would
+    otherwise append a second block and leave the broken original firing
+    alongside it -- every hook running twice, once failing.
+    """
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": f"python {HOOKS_DIR / 'validate_commit_message.py'}",
+                                    "timeout": 10,
+                                }
+                            ],
+                        }
+                    ]
+                }
+            }
+        )
+    )
+
+    _merge_hook_settings(settings_path, HOOKS_DIR, HardlinkSyncResult())
+    settings = json.loads(settings_path.read_text())
+
+    commands = _all_commands(settings)
+    legacy = f"python {HOOKS_DIR / 'validate_commit_message.py'}"
+    assert legacy not in commands, "stale bare-python entry survived the merge"
+    assert commands.count(f"python3 {HOOKS_DIR / 'validate_commit_message.py'}") == 1
+
+
+def test_non_sdlc_user_hooks_survive(tmp_path: Path) -> None:
+    """Merging never clobbers hooks the user registered themselves."""
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [{"type": "command", "command": "bash /some/user/hook.sh"}],
+                        }
+                    ]
+                }
+            }
+        )
+    )
+
+    _merge_hook_settings(settings_path, HOOKS_DIR, HardlinkSyncResult())
+    settings = json.loads(settings_path.read_text())
+
+    assert "bash /some/user/hook.sh" in _all_commands(settings)
+
+
+def test_hook_scripts_tolerate_system_python() -> None:
+    """Every SDLC hook script must parse and evaluate under macOS system Python.
+
+    `python3` on PATH is whichever interpreter comes first -- under a stripped
+    environment (launchd, cron, a minimal PATH) that is /usr/bin/python3, which
+    is 3.9 on macOS. These scripts annotate with PEP 604 unions (`str | None`),
+    which 3.9 evaluates at runtime and rejects with a TypeError at import time.
+    The __future__ import makes annotations lazy, so they parse as strings.
+    """
+    scripts = sorted((REPO_ROOT / ".claude" / "hooks" / "sdlc").glob("*.py"))
+    assert scripts, "expected SDLC hook scripts to exist"
+
+    for script in scripts:
+        source = script.read_text()
+        assert "from __future__ import annotations" in source, (
+            f"{script.name} lacks the __future__ import and will crash on Python 3.9"
+        )
+
+
+def test_merge_is_idempotent(tmp_path: Path) -> None:
+    """Running the sync twice leaves exactly one entry per hook definition."""
+    settings_path = tmp_path / "settings.json"
+    _merge_hook_settings(settings_path, HOOKS_DIR, HardlinkSyncResult())
+    _merge_hook_settings(settings_path, HOOKS_DIR, HardlinkSyncResult())
+
+    settings = json.loads(settings_path.read_text())
+    commands = _all_commands(settings)
+
+    for _event, _matcher, script_name, _timeout in _SDLC_HOOK_DEFS:
+        expected = f"python3 {HOOKS_DIR / script_name}"
+        assert commands.count(expected) == 1, f"duplicate registration for {script_name}"


### PR DESCRIPTION
## Problem

Every Bash/Edit tool call in any repo other than this one emitted:

```
PreToolUse:Bash hook error
Failed with non-blocking status code: /bin/sh: python: command not found
```

The user-scope SDLC hooks in `~/.claude/settings.json` were registered with a bare `python`. Claude Code runs hook commands via `/bin/sh` — non-interactive, never sources `~/.zshenv` — so the `python → python3` alias doesn't apply. This machine has no `python` binary; `python3` only. It resolved inside `~/src/ai` purely because `.venv/bin` is on PATH.

Net effect: the hooks have been dead in every foreign repo, silently.

## Two independent bugs

**1. Bare interpreter** — `scripts/update/hardlinks.py` now emits `python3`. Because dedup is by exact command string, a deployed legacy `python ...` entry is matched and **rewritten in place**; without that, the next `/update` would append a second block and leave the broken original firing alongside it.

**2. PEP 604 annotations under system Python** — surfaced only after fixing #1. `python3` on a stripped PATH is `/usr/bin/python3` = **3.9** on macOS, which evaluates `str | None` at runtime and raises `TypeError` at import. Swapping one failure mode for another. All four scripts are 3.9-syntax-clean, so `from __future__ import annotations` fully resolves it.

## Verification

All hooks exit 0 under the worst case (`env -i`, `/bin/sh`, PATH forced to Python 3.9):

```
sdlc_reminder                exit=0
validate_commit_message      exit=0
validate_sdlc_on_stop        exit=0
```

And functionally, not just non-crashing — staged `.py` commit to `main`:

```json
{"decision": "block", "reason": "Cannot commit code files to main: mod.py. ..."}
```

Applied to this machine's live `~/.claude/settings.json` (backup at `~/.claude/settings.json.bak-hotfix-python3`); diff was exactly 3 command rewrites, no duplicates, no non-SDLC hooks touched.

## Tests

New `tests/unit/test_hardlinks_hook_merge.py` (5 tests) — `_merge_hook_settings` had **zero** coverage before. Covers python3 registration, in-place legacy rewrite without duplication, non-SDLC hook survival, idempotency, and the `__future__` guard.

`tests/unit/test_update_hardlinks.py::test_renamed_removals_entries_are_not_stale` fails on this branch — verified pre-existing on a clean tree (stale `do-skills-audit` entry), unrelated.

## Follow-ups (not in this hotfix)

- **`track_quality_runs.py` was vestigial — removed, not adopted.** It was registered in the deployed settings but absent from `_SDLC_HOOK_DEFS` and from `.claude/hooks/sdlc/` (no repo source, file link count 1). I initially assumed it fed the Stop gate. It does not: `validate_sdlc_on_stop.py` scans the session **transcript**, and the only references to its `/tmp/sdlc_quality_<session_id>` marker are inside the file itself. It wrote a file nobody read, on every Bash call — and was the PostToolUse half of the reported log spam. Deregistered and deleted on this machine; `/update` never managed it, so removal is durable. The `_SDLC_HOOK_DEFS` baseline in `docs/plans/hook-registration-manifest-dispatcher.md` lists three deployed entries and not this one, indicating it was local to this machine.
- **`validate_commit_message.py` gates on `repo_name != "popoto"`** (line 74) — its module docstring claims general "block code commits to main" behavior it does not implement.
- **`docs/plans/hook-registration-manifest-dispatcher.md`** rewrites these same command strings via a migration. That plan should absorb the `python3` literal, or the two will fight.
- `.opencode/SYNC_MANIFEST.json` hashes for the four scripts are now stale; the next sync advances them. Deliberately left out to keep this diff minimal — running the sync also pulled in unrelated pre-existing drift.
