### PR TITLE
do-sdlc supervisor: discriminate session-ensure refusals instead of aborting (#2452)

### DIFF
--- a/.claude/skills-global/do-sdlc/SKILL.md
+++ b/.claude/skills-global/do-sdlc/SKILL.md
@@ -10,7 +10,7 @@ This skill is the **local stand-in for the bridge PM session**. `/sdlc` (in this
 
 You are the supervisor, not the worker. You assess, dispatch, and track. The stage subagents do all the work.
 
-**Redundant-context check (issue #2026, WS-F):** if a bridge PM/dev context already owns this issue — a live eng session (e.g. a bridge PM session) or a live supervised-run signal for the issue number — then `/do-sdlc` is redundant: that context IS the supervision loop. Do not run it; drive via `/sdlc` (in this repo, the single-stage router) instead. Running `/do-sdlc` inside an already-owned run nests a second supervision loop and wastes turns.
+**Redundant-context check (issue #2026, WS-F):** if a bridge PM/dev context already owns this issue — a live eng session (e.g. a bridge PM session) — then `/do-sdlc` is redundant: that context IS the supervision loop. Do not run it; drive via `/sdlc` (in this repo, the single-stage router) instead. A live *supervised-run signal* for the issue number is a different case — see the refusal decision table in Step 2: if the signal's `owner_run_id` is one this run already holds, it is this run's own hand-off, not another owner, and must be inherited rather than treated as redundant-context grounds to stand down.
 
 ## Repo Context Probe
 
@@ -78,8 +78,32 @@ sdlc-tool session-ensure --issue-number {issue_number} --issue-url "https://gith
 Read the JSON from the tool result and **record the `run_id`** (`{"session_id": ..., "created": ..., "run_id": "<hex>"}`) — carry it through every iteration of the Step 3 loop. Reuses the existing `sdlc-local-{N}` session on re-runs. The ownership contract:
 
 - **Every state-mutating `sdlc-tool` call** (`dispatch record`, `stage-marker`, `verdict record`, `meta-set`) **MUST pass `--run-id {run_id}` explicitly.** A missing flag is a named non-zero error (`RUN_ID_REQUIRED`) — the call never mints or adopts an identity.
-- A foreign run_id (another live run owns the issue lock) yields `ISSUE_LOCKED` with the owning `run_id`/`session_id` — treat it like a router block: stop and report.
+
+### Three-way refusal decision table
+
+`session-ensure` (and any subsequent re-ensure — see Step 3's between-stage continuity check) can
+refuse with exactly three payload shapes. Discriminate them; do not collapse all three to "stop":
+
+| Refusal | Shape | Action |
+|---|---|---|
+| **Hand-off** | `{"blocked": true, "reason": "SUPERVISED_RUN_ACTIVE", "run_id", "owner_run_id", "owner_session_id"}` | This is a **designed hand-off**, not a block. It mints nothing — the supervisor already owns the run. **Pass the self-identity check below first.** If it confirms your own signal: **inherit** `owner_run_id` (carry it forward as `run_id`, pass it back via `--run-id`/`--reuse-run-id`), and **continue** — never stop for a confirmed-own signal. |
+| **Orphaned lock** | `{"blocked": true, "reason": "ISSUE_LOCKED", "owner_run_id", "owner_session_id", "orphaned_lock": true}` | The prior owner died before renewing; the lock frees within its TTL (duration and renewal semantics are #2446's — cross-reference it, do not reimplement). Wait, re-ensure, then **rebind `run_id` to whatever the re-ensure returns** before continuing — a post-TTL fresh contest mints a NEW run_id, and every downstream `--run-id` call must use the rebound value or it silently orphans. |
+| **Foreign holder** | `{"blocked": true, "reason": "ISSUE_LOCKED", "owner_run_id", "owner_session_id", "orphaned_lock": false}` | The **only unconditional stop condition of the three.** A genuine live foreign run owns the issue. Stop and report. |
+
+**Self-identity check before standing down** (applies to the hand-off row above): `SUPERVISED_RUN_ACTIVE`
+fires only on a LIVE signal — a stale/expired one falls through to the orphaned-lock/foreign-holder
+rows instead. The **decisive** term is `owner_run_id ∈ {run_ids this run has held}`: a live signal
+carrying a run_id this run never held is a genuine concurrent rival — **stop and report**, even though
+the payload shape looks like a hand-off. `owner_session_id == sdlc-local-{issue_number}` is
+*necessary-but-not-sufficient* — ledger anchors are keyed by issue number, not by run, so a second
+concurrent `/do-sdlc` on the same issue emits a byte-identical `owner_session_id`. Compare `owner_run_id`
+explicitly; do not substitute `run_id` (the sibling field the tool also returns) for it. A match on
+`owner_run_id` is this run's own ghost (inherit-and-continue); a mismatch is a rival even when
+`owner_session_id` matches (stop-and-report).
 - **Recovery after run_id loss** (context compaction, restarted supervisor): re-run the `session-ensure` above. While the old lock is live it returns `ISSUE_LOCKED` (bounded by the ≤300s lock TTL, since nothing renews the orphaned run's lock); after the TTL lapses a fresh contest mints a new run_id. **If you still have the run_id**, add `--reuse-run-id {run_id}` to recover immediately under the same identity — the tool verifies the claim against the live lock (or, on a free lock, the session record) and never adopts an unverified one.
+- **Ledger-anchor rule:** `sdlc-local-{N}` is a non-executable ledger anchor (`is_ledger`, #2042), not
+  a live executable session. It permanently shows `status=running` and carries the run's `_meta` stage
+  state — it must **not** be killed, and a running-looking anchor is not evidence of a rogue pipeline.
 
 ## Step 3: Supervision Loop
 
@@ -125,6 +149,7 @@ Context:
 - Plan: {docs/plans/{slug}.md or "none yet"}
 - Prior stage outcome: {one-line summary, or "None — first stage"}
 - Run identity: {run_id} — pass --run-id {run_id} on every state-mutating sdlc-tool call (stage-marker, verdict record, meta-set, dispatch record); read-only calls take none.
+- Commit early: commit to session/{slug} as work lands (small logical checkpoints), not only at the end — a preempt or lease lapse mid-stage must never lose work.
 
 When done, report back (this is data for the supervisor, not prose for a human):
 - outcome: success | failure
@@ -187,6 +212,22 @@ Inspect every stage subagent's final report before acting on it. If the final me
 1. Log it: "TOOL-AVAILABILITY MISMATCH: stage={skill}, final message is a bare shell command with zero tool calls"
 2. Re-dispatch the same stage once on a Bash-capable agent type (`general-purpose`)
 3. If the re-dispatch shows the same signature, stop and surface the mismatch to the human — do not loop
+
+### 3d.6. Between-stage continuity re-ensure (issue #2452)
+
+After the stage subagent returns (3c/3d/3d.4/3d.5) and before asking the router again (3a), re-ensure
+this run's identity:
+
+```bash
+sdlc-tool session-ensure --issue-number {issue_number} --reuse-run-id {run_id} 2>/dev/null || true
+```
+
+This is a **continuity proof** — the tool verifies the held `run_id` against the live lock/session
+record — not a lease keepalive; it does not renew or extend the TTL. (Lease renewal/heartbeat is
+owned by #2446; revisit this step once that lands, since a heartbeat may make it redundant.) The
+re-ensure can itself return a refusal — route its payload through the **same** three-way table and
+`owner_run_id` self-identity check from Step 2, so the own-ghost abandonment bug does not simply
+relocate from the top of the loop to this stage seam.
 
 ### 3e. Check exit conditions
 

--- a/docs/features/sdlc-local-supervision.md
+++ b/docs/features/sdlc-local-supervision.md
@@ -6,7 +6,7 @@
 
 ## Solution
 
-`/do-sdlc {issue|PR|description}` (`.claude/skills/do-sdlc/SKILL.md`) is the local stand-in for the bridge eng loop. It supervises the full pipeline in one invocation:
+`/do-sdlc {issue|PR|description}` (`.claude/skills-global/do-sdlc/SKILL.md`) is the local stand-in for the bridge eng loop. It supervises the full pipeline in one invocation:
 
 1. Resolves the issue (creates one via a `/do-issue` subagent if given a bare description) and runs `sdlc-tool session-ensure`.
 2. Loops: `sdlc-tool next-skill` → `sdlc-tool dispatch record` → spawn a stage subagent that invokes the stage's `/do-*` skill → read its structured report → repeat.
@@ -15,6 +15,10 @@
 The supervisor never decides dispatch itself — `sdlc-tool next-skill` (→ `agent.sdlc_router.decide_next_dispatch()`) remains the single source of dispatch truth, so all guards (G1–G8, including G4 oscillation) apply identically to local runs.
 
 The `sdlc-local-{N}` anchor created by `session-ensure` in step 1 is a bookkeeping record, not a job for a worker to run: it is created with `is_ledger=True`, and every worker recovery/pickup guard skips past it rather than requeuing or executing it. This keeps a live standalone `python -m worker` process from mistaking the anchor for orphaned work and driving the same issue a second time in parallel with this local supervisor. See [Eng Session Architecture](eng-session-architecture.md#sdlc-local-session-is_ledger-non-executable-flag-issue-2042) for the full guard-site catalogue.
+
+## Refusal discrimination (issue #2452)
+
+`session-ensure` returns three distinguishable refusals, and the supervisor must not collapse them all to "stop." The skill body (Step 2) encodes the three-way decision: `SUPERVISED_RUN_ACTIVE` is a **hand-off** — inherit the returned `owner_run_id` and continue (this fires on the supervisor's own live signal, the own-ghost case behind the 2026-07-29 `#2420`/`#2421`/`#2422` zero-PR incident); `ISSUE_LOCKED` + `orphaned_lock: true` is wait-then-re-ensure-and-rebind; only `ISSUE_LOCKED` + `orphaned_lock: false` is a genuine foreign owner and a stop. The decisive self-vs-rival term is `owner_run_id` membership in the run's held run_ids, not the issue-keyed `owner_session_id`. The lease can still lapse under a multi-minute stage — inheritance makes the run *recoverable*, not immune; the code-level TTL/heartbeat fix is tracked in #2446. The generic body carries this contract; the ai-repo-specific ledger-anchor diagnostics (why a running-looking `sdlc-local-*` on `dashboard.json` is expected, and that killing one destroys its `_meta` stage state) live in `docs/sdlc/do-sdlc.md` behind the skill-context probe.
 
 ## Stage→Model Parity
 

--- a/docs/sdlc/do-sdlc.md
+++ b/docs/sdlc/do-sdlc.md
@@ -1,0 +1,43 @@
+# do-sdlc addendum — this repo only
+<!-- Do not duplicate content from the global do-sdlc skill (.claude/skills-global/do-sdlc/SKILL.md). Only include what is unique to this repo. Max 300 lines. -->
+
+## Ledger-anchor diagnostic tooling (issue #2452)
+
+The generic body names `sdlc-local-{N}` as a non-executable ledger anchor (`is_ledger`, #2042) that
+carries the run's `_meta` stage state and must not be killed. This repo's own diagnostic tooling
+disagrees on whether that anchor is even visible, and that disagreement is exactly what caused two
+anchors to be killed on 2026-07-29 (#2420/#2421/#2422 incident):
+
+- **`python -m tools.valor_session list`** (or the `valor-session list` CLI) **filters ledger anchors
+  out of its default view.** A `sdlc-local-{N}` row will NOT appear there even while it is the live,
+  correct anchor for an in-progress run.
+- **`curl -s localhost:8500/dashboard.json`** (the web UI dashboard state) **does display them.** A
+  `sdlc-local-{N}` session showing `status=running` on the dashboard is the **expected**, permanent
+  steady state of a ledger anchor — not evidence of a stuck or rogue pipeline, and not grounds to kill
+  it. If a `sdlc-local-{N}` row looks "stuck" on the dashboard, cross-check `sdlc-tool stage-query
+  --issue-number {N}` for real progress (stage markers, `_meta`) before concluding anything is wrong;
+  do not act on the dashboard's `status=running` alone.
+
+**Consequence of killing it anyway:** a `sdlc-local-{N}` anchor is an `AgentSession` record. Killing it
+deletes that record, and the `_meta` stage state (dispatch history, recorded verdicts, PR number) it
+carries is deleted with it — there is no separate persistence layer for that state. A killed anchor
+cannot be un-killed; a fresh `session-ensure` for the same issue mints a new session and starts the
+stage-tracking history over.
+
+## `session-ensure` re-ensure invocations, this repo's paths
+
+Both the Step 2 initial ensure and the Step 3d.6 between-stage continuity re-ensure run the same
+`sdlc-tool` entry point (installed to `~/.local/bin` by `/update`, so no repo-relative path is
+needed) and are cwd-independent per `docs/features/sdlc-tool-resolver.md`:
+
+```bash
+# Initial (Step 2)
+sdlc-tool session-ensure --issue-number {issue_number} --issue-url "https://github.com/$SDLC_REPO/issues/{issue_number}"
+
+# Between-stage continuity re-ensure (Step 3d.6) — always includes --reuse-run-id
+sdlc-tool session-ensure --issue-number {issue_number} --reuse-run-id {run_id}
+```
+
+`SDLC_TARGET_REPO` (set once in Step 2) must stay exported for the lifetime of the loop — `sdlc-tool`
+forces its own cwd to `~/src/ai` and relies on this env var to locate the target repo's plans and
+worktree when the target repo is not `ai` itself.


### PR DESCRIPTION
## Summary

Prose-only fix to the `/do-sdlc` supervisor skill so it **discriminates** the three `sdlc-tool session-ensure` refusals instead of collapsing them all to "stop." The tool contract (#2026 fork-inheritance hardening) is correct; only the skill body's interpretation was wrong — a supervisor (or stage fork) receiving the designed hand-off signal `SUPERVISED_RUN_ACTIVE` was pattern-matching on `blocked: true` and abandoning a lease it should inherit, including its own ledger anchor.

Confirmed live on 2026-07-29: #2420/#2421/#2422 each reached CRITIQUE and produced zero PRs; #2421's fork received `SUPERVISED_RUN_ACTIVE` with `owner_session_id: sdlc-local-2421` (its own anchor) and stood down. Two `sdlc-local-{N}` ledger anchors were killed, destroying their `_meta` stage state.

Closes #2452

## Changes

**`.claude/skills-global/do-sdlc/SKILL.md`** (generic global body):
- Three-way refusal decision table replacing the "foreign run_id → stop" rule and fixing the redundant-context check:
  - `SUPERVISED_RUN_ACTIVE` → inherit `owner_run_id`, continue (never stop for a confirmed-own signal)
  - `ISSUE_LOCKED` + `orphaned_lock: true` → wait within TTL, re-ensure, rebind run_id
  - `ISSUE_LOCKED` + `orphaned_lock: false` → the only unconditional stop
- Self-identity check: `owner_run_id ∈ {run_ids this run held}` is decisive; `owner_session_id == sdlc-local-{issue}` is necessary-but-not-sufficient (anchors are keyed by issue, not run). Traces the #2421 own-ghost case and its adversarial rival twin.
- Between-stage continuity re-ensure (`--reuse-run-id`) in the Step 3 loop, framed as a continuity proof (not a lease keepalive), routing its own refusals through the same table.
- Ledger-anchor rule: `sdlc-local-{N}` is a non-executable `is_ledger` anchor (#2042), permanently `status=running`, carries `_meta`, must not be killed.
- Commit-early instruction in the stage-subagent prompt template.
- TTL known-limit note cross-referencing #2446 (no duplication of its heartbeat/TTL code work).

**`docs/sdlc/do-sdlc.md`** (new, repo-specific addendum behind the existing probe):
- `valor_session list` hides ledger anchors while `dashboard.json` displays them — a running-looking `sdlc-local-*` on the dashboard is expected, not a rogue pipeline (the exact confusion behind the 2026-07-29 incident).
- Killing an anchor destroys its `_meta` stage state.
- Concrete re-ensure invocation specifics for this repo.

## Scope / No-Gos honored

No changes to `agent/sdlc_router.py` dispatch rows or the `tools/sdlc_session_ensure.py` tool contract. No lease-TTL/heartbeat code (owned by #2446 — cross-referenced only). No repo-specific executables in the generic body (verified: 0 hits).

## Verification

- `grep -c` over SKILL.md: `SUPERVISED_RUN_ACTIVE`=2, `orphaned_lock`=2, `is_ledger`=1, `owner_run_id`=8 (all ≥1).
- `audit-skills --skill do-sdlc`: 16/16 rules PASS (rule_13/rule_21 probe coverage intact).
- `validate_build.py`: 3 PASS / 0 FAIL. Docs gate: pass.
- No executable test surface (prose skill body + probed addendum); plan Test Impact confirms no existing tests affected.
