### PR TITLE
do-sdlc SKILL.md: strip stale TTL number + attribute owned-run_ids set (#2466)

### DIFF
--- a/.claude/skills-global/do-sdlc/SKILL.md
+++ b/.claude/skills-global/do-sdlc/SKILL.md
@@ -99,8 +99,8 @@ the payload shape looks like a hand-off. `owner_session_id == sdlc-local-{issue_
 concurrent `/do-sdlc` on the same issue emits a byte-identical `owner_session_id`. Compare `owner_run_id`
 explicitly; do not substitute `run_id` (the sibling field the tool also returns) for it. A match on
 `owner_run_id` is this run's own ghost (inherit-and-continue); a mismatch is a rival even when
-`owner_session_id` matches (stop-and-report).
-- **Recovery after run_id loss** (context compaction, restarted supervisor): re-run the `session-ensure` above. While the old lock is live it returns `ISSUE_LOCKED` (bounded by the ≤300s lock TTL, since nothing renews the orphaned run's lock); after the TTL lapses a fresh contest mints a new run_id. **If you still have the run_id**, add `--reuse-run-id {run_id}` to recover immediately under the same identity — the tool verifies the claim against the live lock (or, on a free lock, the session record) and never adopts an unverified one.
+`owner_session_id` matches (stop-and-report). (see #2446, #2451)
+- **Recovery after run_id loss** (context compaction, restarted supervisor): re-run the `session-ensure` above. While the old lock is live it returns `ISSUE_LOCKED`; the lock frees within its TTL and a fresh contest then mints a new run_id (duration and renewal semantics are #2446's — do not restate a number here). **If you still have the run_id**, add `--reuse-run-id {run_id}` to recover immediately under the same identity — the tool verifies the claim against the live lock (or, on a free lock, the session record) and never adopts an unverified one.
 - **Ledger-anchor rule:** `sdlc-local-{N}` is a non-executable ledger anchor (`is_ledger`, #2042), not
   a live executable session. It permanently shows `status=running` and carries the run's `_meta` stage
   state — it must **not** be killed, and a running-looking anchor is not evidence of a rogue pipeline.


### PR DESCRIPTION
Closes #2466

## What

Two prose-only edits to `.claude/skills-global/do-sdlc/SKILL.md` (hardlink-synced to `~/.claude/skills/` on every machine, so stale prose actively misleads live supervisors). No source-code, tool-contract, or `sdlc_router.py` changes.

## Edit 1 — Line 103 (Recovery after run_id loss): strip stale `≤300s` TTL

The real lease is `ISSUE_LOCK_TTL_SECONDS = 1800` (`models/session_lifecycle.py:848`), not 300s. Per the plan, the number is stripped entirely (not swapped to 1800) so it never re-goes-stale when #2446 lands; timing is deferred to the #2446 cross-reference, matching the already-shipped line 90 phrasing.

**Before:**
> While the old lock is live it returns `ISSUE_LOCKED` (bounded by the ≤300s lock TTL, since nothing renews the orphaned run's lock); after the TTL lapses a fresh contest mints a new run_id.

**After:**
> While the old lock is live it returns `ISSUE_LOCKED`; the lock frees within its TTL and a fresh contest then mints a new run_id (duration and renewal semantics are #2446's — do not restate a number here).

No numeric TTL (`300`, `≤300s`, `1800`) remains on the recovery bullet.

## Edit 2 — Lines 95-101 (owned-run_ids discriminator): add bare attribution cross-reference

The decisive refusal discriminator (`owner_run_id ∈ {run_ids this run has held}`) had no pointer to the work that records that set. A **bare** `(see #2446, #2451)` pointer is appended to the end of the paragraph — no verb phrase, no mechanism description (that is #2446/#2451's scope; describing it here would re-create the duplicate-build failure class #2451 exists to describe).

Current lines 95-101 region (the discriminator paragraph), with the appended pointer on the final sentence:

> The **decisive** term is `owner_run_id ∈ {run_ids this run has held}`: a live signal carrying a run_id this run never held is a genuine concurrent rival — **stop and report**, even though the payload shape looks like a hand-off. `owner_session_id == sdlc-local-{issue_number}` is *necessary-but-not-sufficient* — ledger anchors are keyed by issue number, not by run, so a second concurrent `/do-sdlc` on the same issue emits a byte-identical `owner_session_id`. Compare `owner_run_id` explicitly; do not substitute `run_id` (the sibling field the tool also returns) for it. A match on `owner_run_id` is this run's own ghost (inherit-and-continue); a mismatch is a rival even when `owner_session_id` matches (stop-and-report). **(see #2446, #2451)**

## Verification

- `git diff` confined to `.claude/skills-global/do-sdlc/SKILL.md` (1 file, +2/-2)
- `audit_skills.py --skill do-sdlc` → PASS (16/16 rules, rule_13/rule_21 probe coverage intact)
- No numeric TTL remains on the recovery bullet; the added cross-reference is a bare pointer with no verb phrase