### PR TITLE
Document owned_run_ids growth characteristic (#2446/#2451)

### DIFF
--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -252,13 +252,22 @@ class AgentSession(Model):
     # foreign) because its id is in this session's own recorded history. Written
     # ONLY by _acquire_run_lock_and_bind on a bind THIS session won -- never
     # populated from a foreign lock/record, so a membership test can never wave a
-    # genuine foreign run through (Risk 1). Growth: unbounded by design. One id
-    # is appended per re-mint (bind-win only), so the practical ceiling is a
-    # single pipeline's re-mint count -- a handful even for a long run. There is
-    # deliberately NO cap or eviction: a bounded set that evicted would relocate
-    # the forgetting bug this field exists to fix to the Nth re-mint (a long run
-    # would evict an early self id, then read its own fork's hand-off as foreign
-    # -- the #2451 duplicate-BUILD class, reproducible only after N re-mints).
+    # genuine foreign run through (Risk 1). Growth is BOUNDED: one id is
+    # appended per re-mint (bind-win only, deduped so a same-id re-bind is a
+    # no-op), and the list is capped to the most recent OWNED_RUN_IDS_CAP
+    # entries -- default 32, env-overridable -- with the oldest evicted past
+    # the cap. Write path and cap both live in
+    # tools/sdlc_session_ensure.py::_append_owned_run_id.
+    # The accepted tradeoff: eviction is what re-opens the forgetting bug this
+    # field closes, because self-recognition reads the set as a pure membership
+    # test, so an evicted self id reads as foreign (the #2451 duplicate-BUILD
+    # class). That needs a run exceeding the cap in re-mints AND a fork holding
+    # an id older than that, judged acceptable because a fork carries the id it
+    # was handed seconds ago, not one from hours back. If you raise or remove
+    # the cap, update tools/sdlc_session_ensure.py, the bound assertion in
+    # tests/unit/test_sdlc_session_ensure.py::
+    # test_append_dedups_preserves_order_and_caps, and
+    # docs/features/sdlc-run-self-recognition.md together.
     # Additive nullable; Popoto lazy-load descriptor healing default-fills
     # absent rows (no backfill, #1099/#1172).
     owned_run_ids = Field(null=True)

--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -252,8 +252,15 @@ class AgentSession(Model):
     # foreign) because its id is in this session's own recorded history. Written
     # ONLY by _acquire_run_lock_and_bind on a bind THIS session won -- never
     # populated from a foreign lock/record, so a membership test can never wave a
-    # genuine foreign run through (Risk 1). Additive nullable; Popoto lazy-load
-    # descriptor healing default-fills absent rows (no backfill, #1099/#1172).
+    # genuine foreign run through (Risk 1). Growth: unbounded by design. One id
+    # is appended per re-mint (bind-win only), so the practical ceiling is a
+    # single pipeline's re-mint count -- a handful even for a long run. There is
+    # deliberately NO cap or eviction: a bounded set that evicted would relocate
+    # the forgetting bug this field exists to fix to the Nth re-mint (a long run
+    # would evict an early self id, then read its own fork's hand-off as foreign
+    # -- the #2451 duplicate-BUILD class, reproducible only after N re-mints).
+    # Additive nullable; Popoto lazy-load descriptor healing default-fills
+    # absent rows (no backfill, #1099/#1172).
     owned_run_ids = Field(null=True)
     pr_number = IntField(null=True)
 


### PR DESCRIPTION
## What

Comment-only change to `models/agent_session.py` recording the growth characteristic of `owned_run_ids`.

## Correction from review

The original version of this PR claimed growth was "unbounded by design" with "deliberately NO cap or eviction." **Both halves were false.** The field has been capped since the commit that introduced it (`95eeba84`, PR #2468):

```python
# tools/sdlc_session_ensure.py:88
OWNED_RUN_IDS_CAP = int(os.environ.get("OWNED_RUN_IDS_CAP", "32"))
# :130-131
if len(owned) > OWNED_RUN_IDS_CAP:
    owned = owned[-OWNED_RUN_IDS_CAP:]
```

The claim also contradicted `docs/features/sdlc-run-self-recognition.md:46-47`, which already documents the cap and its env var, and a passing test, `test_append_dedups_preserves_order_and_caps`, which asserts both the bound and the oldest-dropped behavior. Merging the original would have installed a false claim on the field definition itself, in the one place a reader is least likely to cross-check.

The PR's stated premise was also backwards. It said a reviewer could not tell whether unbounded was deliberate or an oversight. **Bounded was the deliberate choice**, argued in place at `sdlc_session_ensure.py:81-87` and resolved as an explicit open question in `docs/plans/completed/sdlc-run-self-recognition.md:566`.

## What the rewrite keeps

Two things the original got right:

- **Append-per-winning-bind semantics.** Verified: `_append_owned_run_id` has exactly one production caller, after the lock-acquisition success path, with dedup making a same-id re-bind a no-op.
- **The eviction risk is real.** Self-recognition reads the set as a pure membership test, so an evicted self id does read as foreign. It is now recorded as an accepted tradeoff with its preconditions (a run exceeding the cap in re-mints AND a fork holding an id older than that), rather than as a description of a system without a cap.

Adds a three-file consistency note so a future cap change updates code, test, and doc together.

## Scope

Comment-only, zero behavior change. No test impact.