### PR TITLE
Fix progress deadline becoming a hard 30-min cap on foreign-repo sessions

### DIFF
--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -130,6 +130,7 @@ from agent.session_runner.liveness import (
     clear_hang_state,
     derive_sdk_ever_output,
     subprocess_hang_verdict,
+    tool_activity_ts,
 )
 from agent.session_state import (  # noqa: F401
     ReactionCallback,
@@ -1918,17 +1919,42 @@ def _session_progress_ts(session: AgentSession, acquired_at: float) -> float:
     The max over every signal that happens to be populated:
 
       * ``last_tool_use_at`` — bumped by the PreToolUse/PostToolUse hooks.
-      * ``last_turn_at`` — bumped on the stream-json ``result`` event.
+        **Repo-scoped**: stamped by ``.claude/hooks/pre_tool_use.py``, which
+        only exists in THIS repo's project settings, so it is structurally
+        absent for a session running against any other repo.
+      * ``last_turn_at`` — bumped on the stream-json ``result`` event. A
+        turn-END signal: it cannot tick mid-turn, so it never rescues a
+        long turn from the deadline.
+      * ``last_stdout_at`` — the headless stream produced output
+        (``SessionRunner._stamp_stdout_liveness``, #1935). This is the
+        headless replacement for the PTY-era ``last_pty_activity_at`` that
+        the #1930 cutover deleted from this list; restoring it here closes a
+        toolless-but-streaming turn's gap.
+      * tool-activity marker — ``liveness.tool_activity_ts`` (2026-07-30),
+        written by the runner's own ``matcher: ""`` PreToolUse hook. The ONLY
+        signal that ticks while the PM is blocked in a long ``Agent`` call in
+        a foreign repo, because a subagent's tool calls fire the parent's
+        hooks.
       * ``acquired_at`` — the slot lease's bind timestamp, captured by the
         caller at the same moment ``registry.bind()`` records it (issue
         #1820 "lease-at-bind-only") — the fallback baseline present for
         EVERY session regardless of registry availability, so the deadline
         is always well-defined even for a never-started session with no
         other signal.
+
+    Regression this list guards (root-caused 2026-07-30): between #1930
+    (PTY signal deleted) and this fix, the first four bullets left a foreign-
+    repo session with NO signal that ticks mid-turn — ``last_tool_use_at``
+    and ``last_turn_at`` both stayed ``None`` for the row's whole life — so
+    the max collapsed to ``acquired_at`` and the deadline degenerated into a
+    hard 30-minute cap on every turn. Observed as three kills in 24h on one
+    Cyndra thread at 1799.99–1800.4s, twice mid-deploy.
     """
     candidates = [
         _ts(getattr(session, "last_tool_use_at", None)),
         _ts(getattr(session, "last_turn_at", None)),
+        _ts(getattr(session, "last_stdout_at", None)),
+        tool_activity_ts(getattr(session, "session_id", None)),
         acquired_at,
     ]
     return max(c for c in candidates if c is not None)

--- a/agent/session_runner/hook_edge.py
+++ b/agent/session_runner/hook_edge.py
@@ -79,6 +79,22 @@ HEADLESS_ENV_OVERRIDES: dict[str, str] = {"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"
 # ``claude`` runs it regardless of its cwd.
 _FORWARDER_PATH = str(pathlib.Path(__file__).resolve().parent / "hook_forwarder.py")
 
+# Absolute path to the stdlib-only PreToolUse liveness stamp (2026-07-30).
+# Same resolve-once rationale as the forwarder above.
+_LIVENESS_HOOK_PATH = str(pathlib.Path(__file__).resolve().parent / "liveness_hook.py")
+
+# Suffix of the per-session tool-activity marker the liveness hook writes,
+# sited alongside the edge file so both share the per-session directory the
+# adapter already provisions. Read back by
+# ``agent.session_runner.liveness.tool_activity_ts``.
+TOOL_ACTIVITY_SUFFIX = ".toolactivity"
+
+
+def tool_activity_path(edge_file: str | os.PathLike[str]) -> pathlib.Path:
+    """Marker path for ``edge_file``'s session/role (``<role>_hook_edges`` → ``.toolactivity``)."""
+    return pathlib.Path(edge_file).with_suffix(TOOL_ACTIVITY_SUFFIX)
+
+
 # The hooks the per-session settings file registers, keyed by Claude Code's
 # ``hook_event_name``. Every one routes to the same forwarder; the consumer
 # classifies by event name downstream.
@@ -216,14 +232,31 @@ def generate_hook_settings(
     # PreToolUse entry narrows to the AskUserQuestion tool so ordinary tool
     # calls do not flood the edge file.
     all_events_entry = [{"matcher": "", "hooks": [{"type": "command", "command": command}]}]
-    ask_user_entry = [
-        {"matcher": _ASK_USER_MATCHER, "hooks": [{"type": "command", "command": command}]}
-    ]
+    ask_user_entry = {
+        "matcher": _ASK_USER_MATCHER,
+        "hooks": [{"type": "command", "command": command}],
+    }
+    # Second PreToolUse entry, matcher "" — the stdlib-only liveness stamp
+    # (2026-07-30). It fires on EVERY tool call, including a subagent's, which
+    # is the only signal that ticks while the PM is blocked in a long ``Agent``
+    # call. It does NOT route through the forwarder: ordinary tool calls must
+    # not flood the edge file, and the marker file is ~40x cheaper to write
+    # than an ORM round-trip. See ``liveness_hook`` for the full rationale.
+    activity_path = tool_activity_path(edge_path)
+    liveness_entry = {
+        "matcher": "",
+        "hooks": [
+            {
+                "type": "command",
+                "command": f'python3 "{_LIVENESS_HOOK_PATH}" "{activity_path}"',
+            }
+        ],
+    }
     hooks: dict[str, list] = {
         _TURN_END_EVENT: all_events_entry,
         _SUBAGENT_EVENT: all_events_entry,
         "Notification": all_events_entry,
-        "PreToolUse": ask_user_entry,
+        "PreToolUse": [ask_user_entry, liveness_entry],
         "PreCompact": all_events_entry,
         "SessionStart": all_events_entry,
     }

--- a/agent/session_runner/liveness.py
+++ b/agent/session_runner/liveness.py
@@ -90,6 +90,49 @@ def _as_unix_ts(val: Any) -> float | None:
     return None
 
 
+def tool_activity_ts(session_id: str | None) -> float | None:
+    """Freshest tool-boundary timestamp from the runner's marker files, or None.
+
+    The read side of :mod:`agent.session_runner.liveness_hook` (2026-07-30).
+    That hook is registered on a ``matcher: ""`` ``PreToolUse`` entry in every
+    headless spawn's generated settings and rewrites the marker file
+    ``<hook-edge-dir>/<session_id>/<role>_hook_edges.toolactivity`` on every
+    tool call, including tool calls made from inside an in-process subagent.
+
+    Globs the per-session directory rather than taking a role argument: one
+    AgentSession can provision more than one hook channel (``pm``, and a
+    ``dev`` channel if one is ever added), and *any* of them ticking is proof
+    the subprocess is doing work. Takes the max.
+
+    This is the signal that replaces what the #1930 headless cutover dropped
+    (``last_pty_activity_at``) for repos that do not carry this repo's
+    ``.claude/hooks`` — see
+    ``agent_session_queue._session_progress_ts``, its only production consumer.
+
+    Never raises: a missing directory, unreadable file, or malformed payload
+    reads as ``None`` (no signal), which leaves the deadline exactly as
+    conservative as it was before this signal existed.
+    """
+    if not session_id:
+        return None
+    try:
+        import pathlib  # noqa: PLC0415 — stdlib, kept local to the cold path
+
+        from agent.session_runner.adapter import _hook_edge_base_dir  # noqa: PLC0415
+        from agent.session_runner.hook_edge import TOOL_ACTIVITY_SUFFIX  # noqa: PLC0415
+
+        session_dir = pathlib.Path(_hook_edge_base_dir()) / str(session_id)
+        stamps: list[float] = []
+        for marker in session_dir.glob(f"*{TOOL_ACTIVITY_SUFFIX}"):
+            try:
+                stamps.append(float(marker.read_text().strip()))
+            except (OSError, ValueError):
+                continue
+        return max(stamps) if stamps else None
+    except Exception:
+        return None
+
+
 def has_demonstrable_activity(entry: Any, *, freshness_window: float | None = None) -> bool:
     """Return True iff the entry's own fields prove it has taken a turn or used a tool.
 

--- a/agent/session_runner/liveness_hook.py
+++ b/agent/session_runner/liveness_hook.py
@@ -1,0 +1,80 @@
+"""Stdlib-only ``PreToolUse`` liveness stamp for headless runner sessions.
+
+Registered by :func:`agent.session_runner.hook_edge.generate_hook_settings` on
+a ``matcher: ""`` ``PreToolUse`` entry, so it fires for EVERY tool call the
+spawned ``claude -p`` makes — including tool calls made inside an in-process
+subagent, which carry the parent session's hook settings (verified empirically
+2026-07-30: a ``Bash`` call issued by an ``Agent`` subagent fires the parent's
+``PreToolUse`` hook with the parent ``session_id``).
+
+Why this exists (the #1930 regression, root-caused 2026-07-30)
+--------------------------------------------------------------
+``agent_session_queue._session_progress_ts`` — the progress-deadline
+watchdog's freshness clock — reads ``last_tool_use_at`` / ``last_turn_at`` /
+``acquired_at``. ``last_tool_use_at`` is stamped ONLY by this repo's own
+``.claude/hooks/pre_tool_use.py``, which exists in *this* repo's project
+settings and nowhere else. A PM session running against any other repo
+(cyndra-consulting, client repos) therefore has NO signal that ticks
+mid-turn: the clock degenerates to ``acquired_at`` and every turn longer than
+``SESSION_PROGRESS_DEADLINE_S`` (1800s) is killed regardless of how much work
+is happening. Observed three times in 24h on one Cyndra thread, each at
+1799.99–1800.4s, twice mid-``/deploy``.
+
+Why stdlib-only (and not a call into ``liveness_writers``)
+----------------------------------------------------------
+A ``PreToolUse`` hook runs as a fresh subprocess on EVERY tool call. Importing
+the ORM to write the field directly costs ~2.0s per tool call measured on this
+machine (``agent.hooks.liveness_writers`` → popoto → redis), against ~0.07s
+for a stdlib-only interpreter start — a ~30x tax on every tool call in every
+session. So this hook does the cheapest possible thing: write the current Unix
+timestamp to a per-session marker file. The worker reads it through
+:func:`agent.session_runner.liveness.tool_activity_ts`, which already runs on
+the watchdog's own 30s poll — no extra process, no Redis write on the hot path.
+
+Deliberately does NOT stamp ``current_tool_name``. That field arms the
+per-tool timeout sub-loop (``session_health._check_tool_timeout``, 300s default
+tier), and arming a killer for sessions that have never had one is a behavior
+change this fix does not need: the wedge clock only needs *freshness*.
+
+Contract: ALWAYS exits 0 and never writes to stderr. A ``PreToolUse`` hook that
+exits 2 BLOCKS the tool call — a liveness stamp must never be able to stop a
+turn.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+
+
+def stamp(path: str, now: float | None = None) -> bool:
+    """Write ``now`` (Unix seconds) to ``path``. Returns False on any failure.
+
+    Whole-file overwrite of a ~18-byte payload — the last writer wins, which is
+    exactly the semantics wanted (freshest tool boundary). Never raises.
+    """
+    try:
+        with open(path, "w") as f:
+            f.write(f"{now if now is not None else time.time():.6f}")
+        return True
+    except Exception:
+        return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Always returns 0 — see the module docstring's blocking-exit contract."""
+    args = sys.argv[1:] if argv is None else argv
+    try:
+        # Drain stdin so Claude Code's hook writer never sees EPIPE. The
+        # payload is unused: this hook stamps time, it does not classify.
+        if not sys.stdin.isatty():
+            sys.stdin.read()
+    except Exception:  # noqa: S110 — nothing to log to; stderr must stay clean
+        pass
+    if args:
+        stamp(args[0])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/features/headless-session-runner.md
+++ b/docs/features/headless-session-runner.md
@@ -320,6 +320,48 @@ last_stdout_at)`:
   `stdout_liveness_stamped` log line so `grep stdout_liveness_stamped
   logs/worker.log` post-deploy positively confirms the write path is firing.
 
+### Mid-turn tool activity (the `.toolactivity` marker, 2026-07-30)
+
+`derive_sdk_ever_output` answers *has it ever spoken*. The progress-deadline
+watchdog needs the different question *has it spoken recently*, and for a
+session running against a repo other than this one it had no way to answer:
+`last_tool_use_at` is written by `.claude/hooks/pre_tool_use.py`, which lives
+in **this repo's** project settings and nowhere else, and `last_turn_at` is a
+turn-END signal that cannot tick mid-turn. So a Cyndra/client-repo PM row
+carried `None` in both fields for its entire life, the freshness clock in
+`agent_session_queue._session_progress_ts` collapsed to `acquired_at`, and
+`SESSION_PROGRESS_DEADLINE_S` became a hard 30-minute cap on every turn —
+three kills in 24h on one thread, at 1799.99–1800.4s, twice mid-deploy.
+
+The runner now carries its own repo-independent signal:
+
+- `agent/session_runner/liveness_hook.py` is registered by
+  `generate_hook_settings` on a **`matcher: ""` PreToolUse** entry, so it runs
+  on every tool call — including calls made from inside an in-process
+  subagent, which fire the parent's hooks (verified empirically against the
+  real CLI: a subagent `Bash` call fires the parent's `PreToolUse` with the
+  parent `session_id`). This is what keeps the clock alive across the long
+  `Agent` tool call a PM spends most of a turn inside.
+- It writes one Unix timestamp to
+  `<hook-edge-dir>/<session_id>/<role>_hook_edges.toolactivity` and is
+  **stdlib-only** by hard requirement: a `PreToolUse` hook is a fresh process
+  per tool call, and importing the ORM to write the field directly measured
+  ~2.0s versus ~0.07s stdlib-only — a ~30x tax on every tool call in every
+  session. The worker reads the marker on its existing 30s watchdog poll via
+  `liveness.tool_activity_ts`, so the Redis write never lands on the hot path.
+- It does **not** stamp `current_tool_name`. That field arms the per-tool
+  timeout sub-loop (`session_health._check_tool_timeout`, 300s default tier);
+  the deadline clock only needs freshness, so this fix does not arm a killer
+  for sessions that never had one.
+- It always exits 0 and prints nothing. A `PreToolUse` hook exiting 2 *blocks
+  the tool call* — a liveness stamp must never be able to stop a turn.
+
+Residual, accepted: an orphaned `claude -p` from a prior turn that is still
+making tool calls would keep stamping the same session's marker and mask the
+deadline for the current turn. The flat-CPU hang probe, the first-output
+deadline, and the worker-startup orphan sweep all remain independent of this
+signal and still fire.
+
 This is a **presence** check, not a freshness check — it does not by itself
 detect a mid-turn hang. A subprocess that streams `init` and then genuinely
 hangs is caught by the whole-turn deadline (the preempt watcher's

--- a/docs/features/pm-session-liveness.md
+++ b/docs/features/pm-session-liveness.md
@@ -141,6 +141,18 @@ can read what's happening live, no inference required.
 | `last_turn_at` | `agent/sdk_client.py` `result` event | Most recent SDK turn boundary. |
 | `recent_thinking_excerpt` | `agent/sdk_client.py` `thinking_delta` | Last 280 chars of extended-thinking content (tweet length). |
 
+> **These writers are repo-scoped — do not treat them as universal.** All
+> three hooks above live in **this repo's** `.claude/settings.json`, so they
+> only fire for a session whose cwd is this repo. A session running against
+> any other repo (cyndra-consulting, a client repo) carries `None` in
+> `current_tool_name` / `last_tool_use_at` / `last_turn_at` for its entire
+> life. Any consumer that reads these fields as a *freshness* signal must
+> therefore also consume a repo-independent one — see the deadline clock in
+> [Headless Session Runner § Mid-turn tool activity](headless-session-runner.md#mid-turn-tool-activity-the-toolactivity-marker-2026-07-30),
+> which is the bug this warning exists to prevent recurring: between #1930
+> and 2026-07-30, `_session_progress_ts` read only these fields and silently
+> became a hard 30-minute cap on every foreign-repo turn.
+
 All writes go through `agent/hooks/liveness_writers.py`, which enforces:
 
 - **Per-session 5s in-memory cooldown** to bound Redis write rate under

--- a/tests/unit/session_runner/test_tool_activity_liveness.py
+++ b/tests/unit/session_runner/test_tool_activity_liveness.py
@@ -1,0 +1,285 @@
+"""Mid-turn liveness for headless sessions running against a foreign repo.
+
+Regression cover for the 2026-07-30 root cause: ``_session_progress_ts`` (the
+progress-deadline watchdog's clock) read only ``last_tool_use_at`` /
+``last_turn_at`` / ``acquired_at``. ``last_tool_use_at`` is stamped solely by
+THIS repo's ``.claude/hooks/pre_tool_use.py``, so a session whose cwd is any
+other repo had no signal that ticks mid-turn — the clock collapsed to
+``acquired_at`` and the deadline became a hard 30-minute cap on every turn
+(three kills in 24h on one Cyndra thread, at 1799.99–1800.4s, twice
+mid-deploy).
+
+The fix has two halves, both covered here:
+
+1. The runner registers its own stdlib-only ``matcher: ""`` PreToolUse stamp
+   (``agent/session_runner/liveness_hook.py``) which writes a marker file on
+   every tool call — including a subagent's, since subagent tool calls fire
+   the parent's hooks (verified empirically against the real CLI).
+2. ``_session_progress_ts`` consumes that marker plus ``last_stdout_at``, the
+   headless replacement for the ``last_pty_activity_at`` signal that the
+   #1930 cutover deleted from the list without a substitute.
+"""
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from agent.session_runner.hook_edge import (
+    TOOL_ACTIVITY_SUFFIX,
+    generate_hook_settings,
+    tool_activity_path,
+)
+from agent.session_runner.liveness import tool_activity_ts
+
+pytestmark = pytest.mark.unit
+
+_HOOK = str(Path(__file__).resolve().parents[3] / "agent" / "session_runner" / "liveness_hook.py")
+
+_HOOK_PAYLOAD = json.dumps(
+    {"hook_event_name": "PreToolUse", "tool_name": "Bash", "session_id": "abc"}
+)
+
+
+def _run_hook(*args: str) -> subprocess.CompletedProcess:
+    """Run the hook the way Claude Code does: bare ``python3``, JSON on stdin.
+
+    ``python3`` (NOT ``sys.executable``) is load-bearing — the hook fires
+    inside the spawned ``claude`` process with no access to this repo's venv,
+    so a stdlib-only import surface is a hard requirement, not a preference.
+    """
+    return subprocess.run(
+        ["python3", _HOOK, *args],
+        input=_HOOK_PAYLOAD,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The hook itself — stdlib-only, always exit 0
+# ---------------------------------------------------------------------------
+
+
+def test_hook_stamps_marker_under_bare_python3(tmp_path):
+    marker = tmp_path / "pm_hook_edges.toolactivity"
+    before = time.time()
+    proc = _run_hook(str(marker))
+
+    assert proc.returncode == 0, proc.stderr
+    stamped = float(marker.read_text())
+    assert before <= stamped <= time.time() + 1
+
+
+def test_hook_never_blocks_a_tool_call_on_failure(tmp_path):
+    """A PreToolUse hook exiting 2 BLOCKS the tool. Every failure path exits 0."""
+    unwritable = tmp_path / "no-such-dir" / "marker.toolactivity"
+
+    assert _run_hook(str(unwritable)).returncode == 0  # unwritable path
+    assert _run_hook().returncode == 0  # no argv
+    assert _run_hook("").returncode == 0  # empty path
+    assert not unwritable.exists()
+
+
+def test_hook_emits_nothing_on_stderr(tmp_path):
+    """Hook stderr surfaces in the transcript — the stamp must stay silent."""
+    proc = _run_hook(str(tmp_path / "m.toolactivity"))
+    assert proc.stderr == ""
+    assert proc.stdout == ""
+
+
+# ---------------------------------------------------------------------------
+# Registration — fires on EVERY tool, without flooding the edge file
+# ---------------------------------------------------------------------------
+
+
+def test_generated_settings_stamp_liveness_on_every_tool(tmp_path):
+    settings_path, edge = generate_hook_settings(tmp_path / "pm", tmp_path / "pm_hook_edges.ndjson")
+    pre_tool_use = json.loads(Path(settings_path).read_text())["hooks"]["PreToolUse"]
+
+    all_tools = [e for e in pre_tool_use if e["matcher"] == ""]
+    assert len(all_tools) == 1, "the liveness stamp must fire for every tool call"
+    command = all_tools[0]["hooks"][0]["command"]
+    assert "liveness_hook.py" in command
+    assert str(tool_activity_path(edge)) in command
+    # The whole reason for a separate marker file: ordinary tool calls must
+    # not flood the NDJSON edge file the consumer cursors through.
+    assert "hook_forwarder.py" not in command
+
+
+def test_ask_user_question_edge_survives(tmp_path):
+    """The needs-human edge (#1919) shares PreToolUse — it must not be displaced."""
+    settings_path, edge = generate_hook_settings(tmp_path / "pm", tmp_path / "pm_hook_edges.ndjson")
+    pre_tool_use = json.loads(Path(settings_path).read_text())["hooks"]["PreToolUse"]
+
+    ask = [e for e in pre_tool_use if e["matcher"] == "AskUserQuestion"]
+    assert len(ask) == 1
+    assert "hook_forwarder.py" in ask[0]["hooks"][0]["command"]
+    assert str(edge) in ask[0]["hooks"][0]["command"]
+
+
+# ---------------------------------------------------------------------------
+# Read side
+# ---------------------------------------------------------------------------
+
+
+def _point_base_dir_at(monkeypatch, path: Path) -> None:
+    import agent.session_runner.adapter as adapter
+
+    monkeypatch.setattr(adapter, "_hook_edge_base_dir", lambda: str(path))
+
+
+def test_tool_activity_ts_takes_max_across_role_channels(monkeypatch, tmp_path):
+    """One AgentSession can provision several hook channels — any tick counts."""
+    _point_base_dir_at(monkeypatch, tmp_path)
+    session_dir = tmp_path / "tg_cyndra_-100_292"
+    session_dir.mkdir()
+    (session_dir / f"pm_hook_edges{TOOL_ACTIVITY_SUFFIX}").write_text("1000.5")
+    (session_dir / f"dev_hook_edges{TOOL_ACTIVITY_SUFFIX}").write_text("2000.25")
+
+    assert tool_activity_ts("tg_cyndra_-100_292") == 2000.25
+
+
+@pytest.mark.parametrize(
+    "session_id, marker_body",
+    [
+        ("missing-session", None),  # no directory at all
+        ("malformed", "not-a-float"),  # truncated / garbage payload
+        ("empty", ""),  # created but never written
+        (None, None),  # no session_id
+        ("", None),  # empty session_id
+    ],
+)
+def test_tool_activity_ts_degrades_to_no_signal(monkeypatch, tmp_path, session_id, marker_body):
+    """Any read failure must read as 'no signal', never raise, never fabricate."""
+    _point_base_dir_at(monkeypatch, tmp_path)
+    if marker_body is not None:
+        d = tmp_path / str(session_id)
+        d.mkdir()
+        (d / f"pm_hook_edges{TOOL_ACTIVITY_SUFFIX}").write_text(marker_body)
+
+    assert tool_activity_ts(session_id) is None
+
+
+# ---------------------------------------------------------------------------
+# The deadline clock — the actual regression
+# ---------------------------------------------------------------------------
+
+
+class _Row:
+    """Minimal AgentSession stand-in — ``_session_progress_ts`` is all getattr."""
+
+    def __init__(self, **fields):
+        self.session_id = fields.pop("session_id", "sess-1")
+        for name in ("last_tool_use_at", "last_turn_at", "last_stdout_at"):
+            setattr(self, name, fields.pop(name, None))
+        assert not fields, fields
+
+
+def test_foreign_repo_session_is_not_capped_at_the_deadline(monkeypatch, tmp_path):
+    """THE regression: no CLI hooks in the target repo, so both SDK fields stay
+    None for the row's whole life. Before the fix the clock collapsed to
+    ``acquired_at`` and any turn past 1800s was killed regardless of activity.
+    """
+    from agent.agent_session_queue import SESSION_PROGRESS_DEADLINE_S, _session_progress_ts
+
+    _point_base_dir_at(monkeypatch, tmp_path)
+    session_dir = tmp_path / "sess-1"
+    session_dir.mkdir()
+    now = time.time()
+    # A subagent tool call 10s ago — real work, mid-turn.
+    (session_dir / f"pm_hook_edges{TOOL_ACTIVITY_SUFFIX}").write_text(str(now - 10))
+
+    acquired_at = now - (SESSION_PROGRESS_DEADLINE_S + 600)  # 40 min into the turn
+    progress = _session_progress_ts(_Row(), acquired_at)
+
+    assert progress == pytest.approx(now - 10, abs=1)
+    assert (now - progress) < SESSION_PROGRESS_DEADLINE_S, "would have been killed mid-work"
+
+
+def test_stdout_liveness_counts_as_progress(monkeypatch, tmp_path):
+    """#1930 deleted ``last_pty_activity_at`` from the candidates; its headless
+    replacement ``last_stdout_at`` (#1935) was never added in its place.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    from agent.agent_session_queue import SESSION_PROGRESS_DEADLINE_S, _session_progress_ts
+
+    _point_base_dir_at(monkeypatch, tmp_path)  # no marker files — stdout only
+    now = time.time()
+    row = _Row(last_stdout_at=datetime.now(tz=UTC) - timedelta(seconds=30))
+
+    progress = _session_progress_ts(row, now - (SESSION_PROGRESS_DEADLINE_S + 600))
+
+    assert progress == pytest.approx(now - 30, abs=2)
+
+
+def test_acquired_at_remains_the_floor(monkeypatch, tmp_path):
+    """A session with no signal at all must still get a well-defined clock —
+    the never-started/init-hang legs depend on the deadline still firing.
+    """
+    from agent.agent_session_queue import _session_progress_ts
+
+    _point_base_dir_at(monkeypatch, tmp_path)
+    acquired_at = time.time() - 4000
+
+    assert _session_progress_ts(_Row(), acquired_at) == acquired_at
+
+
+def test_progress_ts_never_raises_when_marker_dir_is_hostile(monkeypatch, tmp_path):
+    """The watchdog polls this every 30s per running session — an exception
+    here would tear down the worker loop, not just the read.
+    """
+    import agent.session_runner.adapter as adapter
+    from agent.agent_session_queue import _session_progress_ts
+
+    def _boom():
+        raise OSError("data dir unavailable")
+
+    monkeypatch.setattr(adapter, "_hook_edge_base_dir", _boom)
+    acquired_at = time.time() - 100
+
+    assert _session_progress_ts(_Row(), acquired_at) == acquired_at
+
+
+def test_hook_and_reader_agree_on_the_path(monkeypatch, tmp_path):
+    """Writer and reader are wired through different modules — pin the contract
+    that the path the settings file hands the hook is the path the worker globs.
+    """
+    from agent.agent_session_queue import _session_progress_ts
+
+    _point_base_dir_at(monkeypatch, tmp_path)
+    session_dir = tmp_path / "sess-1"
+    session_dir.mkdir()
+    _settings, edge = generate_hook_settings(
+        session_dir / "pm", session_dir / "pm_hook_edges.ndjson"
+    )
+
+    assert _run_hook(str(tool_activity_path(edge))).returncode == 0
+
+    progress = _session_progress_ts(_Row(), time.time() - 4000)
+    assert progress == pytest.approx(time.time(), abs=5), "worker did not see the hook's stamp"
+
+
+def test_hook_module_imports_only_stdlib():
+    """Enforced structurally: the hook pays ~0.07s per tool call stdlib-only vs
+    ~2.0s if it ever imports the ORM (measured 2026-07-30). It fires on EVERY
+    tool call in every session, so that delta is the whole design constraint.
+    """
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; sys.path=[p for p in sys.path if 'src/ai' not in p];"
+            f" exec(open({_HOOK!r}).read())",
+        ],
+        input=_HOOK_PAYLOAD,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr


### PR DESCRIPTION
## What happened

Three Cyndra PM turns were SIGKILLed in 24h at `idle_gap` 1799.99s / 1800.15s / 1800.4s — twice mid-`/deploy`, once ~2 minutes before the deploy step, while the dev subagent was actively committing work (`1176a9c` at 10:27, `98e17e8` "pre-#87-deploy" at 10:45, killed 10:47:50). Each one surfaced in chat only as *"I was stopped and won't resume automatically."*

Not a hang. The watchdog's clock had no signal that could tick.

## Root cause

`_session_progress_ts` (`agent/agent_session_queue.py`) read three candidates:

| Signal | Writer | Ticks mid-turn? |
|---|---|---|
| `last_tool_use_at` | `.claude/hooks/pre_tool_use.py` — **this repo's project settings only** | Only in this repo |
| `last_turn_at` | stream-json `result` event | No — turn-END signal |
| `acquired_at` | slot-lease bind | No — fixed at pickup |

A session whose cwd is any other repo (`cyndra-consulting` has no `.claude/settings.json` at all) carries `None` in both live fields for its entire life — confirmed on the live row: `last_tool_use_at=None`, `last_turn_at=None`, `turn_count=0`. The max collapses to `acquired_at`, so `SESSION_PROGRESS_DEADLINE_S` (1800) becomes a hard wall-clock cap on every turn regardless of activity. This repo's own sessions never trip it, which is why it went unnoticed for three weeks.

**Regression window:** #1930 (headless runner cutover, 2026-07-07) deleted `last_pty_activity_at` from the candidate list. Its headless replacement `last_stdout_at` (#1935) was wired into `derive_sdk_ever_output` (presence) and `session_health`'s Tier-1 killer — but never into `_session_progress_ts` (freshness). Two killers, two different signal sets: `session_health` saw the session as alive while the queue watchdog killed it.

## Fix

**1. A repo-independent mid-turn signal.** The runner registers its own `matcher: ""` PreToolUse hook (`agent/session_runner/liveness_hook.py`) writing a timestamp to a per-session `.toolactivity` marker; the worker reads it on its existing 30s poll.

This works across the long `Agent` tool call because **subagent tool calls fire the parent's hooks** — verified empirically against the real CLI (a subagent's `Bash` fired the parent `PreToolUse` with the parent `session_id`). That mattered: the parent transcript is silent for 29 minutes during a dev subagent run, so `last_stdout_at` alone would have bought only ~40 seconds.

Constraints the hook is built to:
- **stdlib-only** — a PreToolUse hook is a fresh process per tool call; importing the ORM measured **~2.0s vs ~0.07s** (~30x tax on every tool call in every session), so the Redis write stays off the hot path.
- **does not stamp `current_tool_name`** — that arms the 300s per-tool timeout sub-loop; the deadline needs freshness only, and this fix should not arm a killer for sessions that never had one.
- **always exits 0, prints nothing** — a PreToolUse hook exiting 2 *blocks the tool call*.
- **does not route through the forwarder** — ordinary tool calls must not flood the NDJSON edge file.

**2. `last_stdout_at` added to the candidates**, restoring what #1930 dropped and covering toolless-but-streaming turns.

## Residual (accepted, documented)

An orphaned `claude -p` still making tool calls would keep stamping its session's marker and mask the deadline for the current turn. The flat-CPU hang probe, the first-output deadline, and the worker-startup orphan sweep are independent of this signal and still fire.

## Testing

- 17 new cases in `tests/unit/session_runner/test_tool_activity_liveness.py`. Three of them — the foreign-repo cap, the `last_stdout_at` gap, and the writer/reader path contract — **fail on the pre-fix tree and pass after**, verified by reverting the queue hunk.
- The hook is exercised under bare `python3`, so the stdlib-only constraint is enforced structurally rather than by convention.
- End-to-end smoke against a real `claude -p` spawning a real subagent through the production settings generator: marker written, edge file not flooded (3 lines).
- `tests/unit/session_runner/` (289) and `tests/integration/test_progress_deadline_cancel.py` + `test_init_hang_circuit_breaker.py` (19) pass.
- Full unit suite: 10998 passed, 5 failed — all 5 reproduce on a clean tree (the known #2429 cluster), none related.


Closes #2502
