### PR TITLE
Repoint dangling command-table references; de-stale the pypdf comments

### DIFF
--- a/.claude/skill-context/do-docs.md
+++ b/.claude/skill-context/do-docs.md
@@ -57,7 +57,8 @@ This repo's documentation lives in these locations. Scan them in this priority o
 
 | Location | What lives there |
 |----------|-----------------|
-| `CLAUDE.md` | Primary project guidance, architecture, rules, Quick Commands table |
+| `CLAUDE.md` | Primary project guidance, architecture, rules |
+| `docs/tools-reference.md` | Full command/tool catalog (new CLI commands go here) |
 | `docs/features/*.md` | Feature documentation |
 | `docs/features/README.md` | Feature index table (canonical feature list — keep entries current) |
 | `site/*.html` | Published docs site pages at valorengels.com (living docs — edit alongside markdown; `site/assets/` is out of scope) |
@@ -154,8 +155,7 @@ Do not re-commit the substrate's changes — it commits them itself.
 
 When a new feature doc is created, add an entry to the `docs/features/README.md` index table.
 Missing entries cause discoverability gaps. When a new CLI command, script, or tool is added,
-add it to the appropriate table in `CLAUDE.md` (the Quick Commands table is the first place
-devs look).
+add it to `docs/tools-reference.md` (the full command catalog, and the first place devs look).
 
 When you **add or remove** a `site/*.html` page during the cascade, update `site/sitemap.xml`
 so the published sitemap matches the page set. Edit affected site pages surgically, exactly

--- a/.claude/skill-context/do-docs.md
+++ b/.claude/skill-context/do-docs.md
@@ -70,7 +70,7 @@ This repo's documentation lives in these locations. Scan them in this priority o
 | `.claude/commands/*.md` | Slash commands |
 | `config/identity.json` | Structured identity data |
 | `config/personas/segments/*.md` | Composable persona segments |
-| `docs/*.md` (top-level) | Deployment, tools-reference, etc. |
+| `docs/*.md` (other top-level) | Deployment guides, etc. |
 
 Sort by importance: `CLAUDE.md` first, then features, then commands, then plans, then the rest.
 

--- a/.claude/skill-context/new-skill.md
+++ b/.claude/skill-context/new-skill.md
@@ -81,9 +81,9 @@ Then run: `uv pip install -e .`
 - For explicit file sending, use: `<<FILE:/path/to/file>>`.
 - For AI models, import from `config/models.py`: `MODEL_FAST`, `MODEL_REASONING`, `MODEL_IMAGE_GEN`, `MODEL_VISION`.
 
-### Document in CLAUDE.md
+### Document in the command reference
 
-Add to the Quick Commands table or appropriate tools section:
+Add to the appropriate table in `docs/tools-reference.md` (the full command catalog):
 
 ```markdown
 | `valor-tool-name arg1` | Brief description |

--- a/.claude/skill-context/new-skill.md
+++ b/.claude/skill-context/new-skill.md
@@ -83,18 +83,27 @@ Then run: `uv pip install -e .`
 
 ### Document in the command reference
 
-Add to the appropriate table in `docs/tools-reference.md` (the full command catalog):
+Add a section to `docs/tools-reference.md` (the full command catalog). That file
+documents each CLI as an H3 naming the tool and its module, followed by a short
+description and a fenced bash block of example invocations:
 
-```markdown
-| `valor-tool-name arg1` | Brief description |
+````markdown
+### Tool Name (`tools.tool_name`)
+
+One or two sentences on what it does and when to reach for it.
+
+```bash
+valor-tool-name arg1              # what this invocation does
+valor-tool-name arg1 --flag       # what the flag changes
 ```
+````
 
 ### Checklist
 
 - [ ] `tools/<name>/` created with `__init__.py` and `README.md`
 - [ ] Main function returns `{"result": ...}` or `{"error": ...}`
 - [ ] CLI entry point added to `pyproject.toml`, ran `uv pip install -e .`
-- [ ] CLAUDE.md updated
+- [ ] `docs/tools-reference.md` updated with the new tool's section
 - [ ] Tests written and passing
 - [ ] `black` and `ruff` pass
 - [ ] Committed and pushed

--- a/docs/features/sdlc-repo-addenda.md
+++ b/docs/features/sdlc-repo-addenda.md
@@ -18,7 +18,7 @@ docs/sdlc/
 ├── do-test.md           # Test tiers, Redis isolation, AI judge pattern, quality gates
 ├── do-patch.md          # Worktree context, ruff auto-fix, test isolation regression
 ├── do-pr-review.md      # Documentation gate, plan section compliance, UI screenshots
-├── do-docs.md           # docs/features/ index, CLAUDE.md quick reference, commit rules
+├── do-docs.md           # docs/features/ index, command reference, commit rules
 └── do-merge.md          # Documentation gate, plan migration, post-merge cleanup
 ```
 
@@ -85,7 +85,7 @@ State is stored in `data/sdlc_reflection_last_run.json`.
 | `docs/sdlc/do-test.md` | Test tiers, Redis isolation, AI judges, quality gates |
 | `docs/sdlc/do-patch.md` | Worktree context, auto-fix, Redis safety |
 | `docs/sdlc/do-pr-review.md` | Docs gate, section compliance, UI screenshots |
-| `docs/sdlc/do-docs.md` | Index, CLAUDE.md, commit rules |
+| `docs/sdlc/do-docs.md` | Index, command reference, commit rules |
 | `docs/sdlc/do-merge.md` | Docs gate, plan migration, post-merge cleanup |
 | `scripts/sdlc_reflection.py` | Reflection agent (3-day cron) |
 | `com.valor.sdlc-reflection.plist` | launchd schedule definition |

--- a/docs/features/session-lifecycle.md
+++ b/docs/features/session-lifecycle.md
@@ -152,7 +152,7 @@ The `agent/agent_session_queue.py:cancel_agent_session` site does **not** need a
 **Operator semantics**:
 
 - `valor-session kill <id>` — writes `status=killed` via `finalize_session(reject_from_terminal=True)` (its own pre-condition guarantees no terminal-flip).
-- `./scripts/valor-service.sh worker-disable` — pairs `launchctl disable` with `bootout`. Use this when killing all sessions and you do **not** want the worker to come back via launchd's `KeepAlive=true` respawn. Re-enable with `worker-enable` (or `worker-start`, which calls `launchctl enable` idempotently before `bootstrap`). See `./scripts/valor-service.sh` help and [`docs/tools-reference.md`](../tools-reference.md) for the full table.
+- `./scripts/valor-service.sh worker-disable` — pairs `launchctl disable` with `bootout`. Use this when killing all sessions and you do **not** want the worker to come back via launchd's `KeepAlive=true` respawn. Re-enable with `worker-enable` (or `worker-start`, which calls `launchctl enable` idempotently before `bootstrap`). See `./scripts/valor-service.sh` help and [Bridge/Worker Architecture § Service commands](bridge-worker-architecture.md) for the full table.
 
 ## Completion Flow
 

--- a/docs/features/session-lifecycle.md
+++ b/docs/features/session-lifecycle.md
@@ -152,7 +152,7 @@ The `agent/agent_session_queue.py:cancel_agent_session` site does **not** need a
 **Operator semantics**:
 
 - `valor-session kill <id>` — writes `status=killed` via `finalize_session(reject_from_terminal=True)` (its own pre-condition guarantees no terminal-flip).
-- `./scripts/valor-service.sh worker-disable` — pairs `launchctl disable` with `bootout`. Use this when killing all sessions and you do **not** want the worker to come back via launchd's `KeepAlive=true` respawn. Re-enable with `worker-enable` (or `worker-start`, which calls `launchctl enable` idempotently before `bootstrap`). See `./scripts/valor-service.sh` help and [Bridge/Worker Architecture § Service commands](bridge-worker-architecture.md) for the full table.
+- `./scripts/valor-service.sh worker-disable` — pairs `launchctl disable` with `bootout`. Use this when killing all sessions and you do **not** want the worker to come back via launchd's `KeepAlive=true` respawn. Re-enable with `worker-enable` (or `worker-start`, which calls `launchctl enable` idempotently before `bootstrap`). See `./scripts/valor-service.sh` help and [Bridge/Worker Architecture § Service Management](bridge-worker-architecture.md#service-management) for the full table.
 
 ## Completion Flow
 

--- a/docs/features/session-lifecycle.md
+++ b/docs/features/session-lifecycle.md
@@ -152,7 +152,7 @@ The `agent/agent_session_queue.py:cancel_agent_session` site does **not** need a
 **Operator semantics**:
 
 - `valor-session kill <id>` — writes `status=killed` via `finalize_session(reject_from_terminal=True)` (its own pre-condition guarantees no terminal-flip).
-- `./scripts/valor-service.sh worker-disable` — pairs `launchctl disable` with `bootout`. Use this when killing all sessions and you do **not** want the worker to come back via launchd's `KeepAlive=true` respawn. Re-enable with `worker-enable` (or `worker-start`, which calls `launchctl enable` idempotently before `bootstrap`). See `./scripts/valor-service.sh` help and CLAUDE.md "Quick Commands" for the full table.
+- `./scripts/valor-service.sh worker-disable` — pairs `launchctl disable` with `bootout`. Use this when killing all sessions and you do **not** want the worker to come back via launchd's `KeepAlive=true` respawn. Re-enable with `worker-enable` (or `worker-start`, which calls `launchctl enable` idempotently before `bootstrap`). See `./scripts/valor-service.sh` help and [`docs/tools-reference.md`](../tools-reference.md) for the full table.
 
 ## Completion Flow
 

--- a/docs/infra/markitdown-ingestion.md
+++ b/docs/infra/markitdown-ingestion.md
@@ -6,7 +6,7 @@
 - **Supported formats:** only `.md`, `.txt`, `.markdown`, `.text` (hardcoded at `bridge/knowledge_watcher.py:21` and `tools/knowledge/indexer.py:28`).
 - **Embedding provider:** OpenAI `text-embedding-3-small` (existing dependency).
 - **Summarization LLM:** Anthropic Haiku via the canonical `HAIKU` constant in `config.models` (used by `tools/knowledge/indexer.py:20`).
-- **pypdf** is installed at `>=6.10.2` but only used in `bridge/media.py` for Telegram attachment handling — not wired into the indexer.
+- **pypdf** is pinned in `pyproject.toml` (see the `[project].dependencies` entry for the current floor) but only used in `bridge/media.py` for Telegram attachment handling — not wired into the indexer.
 
 ## New Requirements
 

--- a/docs/sdlc/do-docs.md
+++ b/docs/sdlc/do-docs.md
@@ -5,9 +5,9 @@
 
 All feature documentation lives in `docs/features/`. When creating a new feature doc, also add an entry to `docs/features/README.md` index table. The index is the canonical list of features; missing entries cause discoverability gaps.
 
-## CLAUDE.md Quick Reference
+## Command Reference
 
-If the feature adds a new CLI command, script, or tool, add it to the appropriate table in `CLAUDE.md`. The quick reference table is the first place devs look — keep it current.
+If the feature adds a new CLI command, script, or tool, document it in `docs/tools-reference.md`. That file is the full catalog and the first place devs look; `CLAUDE.md` carries only a short everyday-commands list and a pointer to it.
 
 ## docs/plans/ Commit-on-Main
 

--- a/docs/sdlc/do-docs.md
+++ b/docs/sdlc/do-docs.md
@@ -7,7 +7,7 @@ All feature documentation lives in `docs/features/`. When creating a new feature
 
 ## Command Reference
 
-If the feature adds a new CLI command, script, or tool, document it in `docs/tools-reference.md`. That file is the full catalog and the first place devs look; `CLAUDE.md` carries only a short everyday-commands list and a pointer to it.
+If the feature adds a new CLI command, script, or tool, document it in `docs/tools-reference.md`. That file is the full catalog and the first place devs look; `CLAUDE.md` carries only a pointer to it plus a short list of non-obvious behaviors that `--help` does not cover.
 
 ## docs/plans/ Commit-on-Main
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "google-auth-httplib2>=0.2.0", # Google Auth HTTP transport
     "google-api-python-client>=2.100.0", # Google API client
     "psutil>=5.9.0", # System resource monitoring for SDK diagnostics
-    "pypdf>=6.14.2",  # 6.10.0 patches CVE: XMP metadata RAM exhaustion
+    "pypdf>=6.14.2",  # floor tracks upstream SEC/ROB fixes; 6.10.0 patched the XMP metadata RAM-exhaustion CVE
     "html2text>=2024.2.26", # HTML to markdown conversion for web fetch
     "numpy>=1.26.0", # Vector math for semantic doc impact finder
     "openai>=1.0.0", # Embedding API for semantic doc impact finder
@@ -55,7 +55,7 @@ dev = [
 # PDF backend resolution (Task 1a result, 2026-04-24 uv lock on Python 3.14):
 #   - pdfminer-six 20251230 (primary extractor for markitdown[pdf])
 #   - pypdfium2 5.7.1 (transitive via pdfplumber)
-#   - pypdf 6.10.2 (our direct CVE-safe pin, line 22 — no conflict)
+#   - pypdf (our direct pin in [project].dependencies above — no conflict)
 # onnxruntime>=1.25.0 is required because magika (transitive) pulls older
 # onnxruntime that lacks cp314 wheels; 1.25.0 ships Python 3.14 wheels.
 knowledge = [


### PR DESCRIPTION
## What

Cleans up two independent bits of documentation rot surfaced while reviewing the open-PR backlog. Neither was caused by the PRs that exposed them.

## 1. Dangling `Quick Commands` references (4 sites, 3 files)

Commit `a2964a98` trimmed `CLAUDE.md` and removed the Quick Commands table. Four live references to it survived:

| File | What it said |
|---|---|
| `.claude/skill-context/do-docs.md:60` | docs-location table lists CLAUDE.md as holding the "Quick Commands table" |
| `.claude/skill-context/do-docs.md:157` | "when a new CLI command is added, add it to the appropriate table in `CLAUDE.md`" |
| `.claude/skill-context/new-skill.md:86` | "Add to the Quick Commands table" |
| `docs/features/session-lifecycle.md:155` | "See ... CLAUDE.md 'Quick Commands' for the full table" |

Two of those are **standing instructions to agents** to write into a table that no longer exists, so a new CLI command documented by `/do-docs` or `/new-skill` had nowhere correct to land. All four now point at `docs/tools-reference.md`, where the catalog actually lives.

Credit to closed PR #2437, which found these. Its fix pointed at a `.claude/skills/repo-commands/SKILL.md` that main never created, so it could not be cherry-picked.

## 2. Stale pypdf references (3 sites)

Drifting since `ddc33e49` (#1167), and widened by every dependabot bump since:

- `pyproject.toml:23` — the comment explained a **6.10.0** CVE as the rationale for a floor that is now **6.14.2**
- `pyproject.toml:58` — named "pypdf **6.10.2** ... **line 22**"; both the version and the line number were wrong
- `docs/infra/markitdown-ingestion.md:9` — claimed pypdf "is installed at `>=6.10.2`"

Rewritten as **version-free pointers to the pin itself**, so a future bump cannot re-stale them. Surfaced during the #2332 review.

## Scope

Comments and docs only. The `pypdf>=6.14.2` pin value is unchanged; `pyproject.toml` still parses and resolves identically. No behavior change, no test impact.

## Verification

- `rg "Quick Commands"` across live files returns only `docs/features/reflections.md:797`, which is that doc's own local section heading with its own table, not a cross-reference.
- `rg "6\.10\.2"` across live files returns nothing.
- `tomllib` parses `pyproject.toml`; pypdf pin reads `pypdf>=6.14.2`.

Closes #2575
