### PR TITLE
Prune orphaned pre-manifest hook files under ~/.claude/hooks/ (#2521)

### DIFF
--- a/docs/features/hook-manifest.md
+++ b/docs/features/hook-manifest.md
@@ -185,7 +185,31 @@ Exactly one such entry was found deployed: `validators/validate_no_raw_redis_del
 
 Condition 3 is an **explicit precise-match allowlist**, deliberately not a `validators/` or `~/.claude/hooks/` prefix test. A prefix gate would silently deregister a hand-added user hook that happens to live under `~/.claude/hooks/`; only the exact scripts named in the tuple are ever removed. Blocks and events emptied by the sweep are pruned.
 
-The migration is **registration-only: it deletes no files.** Once the registration is gone the orphaned pre-manifest files under `~/.claude/hooks/` are inert; pruning them is deferred to issue #2521, which must use a static keep-by-default allowlist rather than a negative reference test. Like its sibling it writes a timestamped `.bak` snapshot first, asserts JSON validity before touching disk, and is idempotent — an absent file, an empty `{}`, a missing `hooks` key, or nothing left to sweep are all no-ops that write nothing.
+The migration is **registration-only: it deletes no files.** Once the registration is gone the orphaned pre-manifest files under `~/.claude/hooks/` are inert; removing them from disk is the separate sibling migration described in [User-tree Hygiene](#user-tree-hygiene-claudehooks) below. Like its sibling it writes a timestamped `.bak` snapshot first, asserts JSON validity before touching disk, and is idempotent — an absent file, an empty `{}`, a missing `hooks` key, or nothing left to sweep are all no-ops that write nothing.
+
+## User-tree Hygiene (`~/.claude/hooks/`)
+
+The user generator owns a **narrow slice** of `~/.claude/hooks/`: it hardlinks exactly the manifest's `scope = "global"` declarations (today three scripts, all under `sdlc/`) and it registers exactly those in `~/.claude/settings.json`. It does **not** own, enumerate, or clean anything else in that directory. Everything the pre-manifest hardcoded `_SDLC_HOOK_DEFS` path put there — `validators/`, `dispatch/`, `hook_utils/`, `__pycache__/`, nine top-level scripts, and a stale copy of `manifest.toml` — was therefore permanent residue on every fleet machine, inert after the registration sweep above but never removed.
+
+`scripts/update/migrations.py::_migrate_prune_orphaned_premanifest_hook_files()` (issue #2521) is the one-time self-heal. A path is removed only when **all three** gates permit it:
+
+1. it is named in `_PREMANIFEST_HOOK_ORPHANS`, the static hand-maintained inventory of the pre-manifest layout;
+2. it is not in `_USER_HOOK_KEEP_PATHS`; and
+3. it is not referenced by any command string in `~/.claude/settings.json`.
+
+Gate 1 makes **unrecognized ⇒ kept** the default: a hand-added user hook, a foreign repo's artifact, or any path the inventory has never heard of is never touched. Naming a *tree* in the inventory does not license deleting its whole contents — each contained file is recognized individually (it must have a counterpart under this repo's `.claude/hooks/`, or be regenerable `.pyc` bytecode) and still passes gates 2 and 3, so a tree holding a hand-added file survives, holding just that file. Every gate compares the path **relative to `~/.claude/hooks/`**, never a bare basename: top-level `sdlc_reminder.py` is removable residue while `sdlc/sdlc_reminder.py` is a live manifest-declared global script, and the two share a basename.
+
+Gate 3 is deliberately **permissive** on an absent, unreadable, or malformed `settings.json` — one shared code path that logs a WARNING and proceeds with no registration guard. It is defense in depth, not the primary gate; a machine with a hand-broken settings.json must still get its residue pruned rather than being wedged forever on a file this migration does not own.
+
+`sdlc/sdlc_context.py` is in the keep-set and is the reason the keep-set exists as an explicit constant rather than being derived from command strings. **It carries no manifest declaration of its own** and appears in no hook command anywhere — it is a pure runtime import sibling, imported by all three global fork scripts (`sdlc/validate_commit_message_sdlc.py:35`, `sdlc/validate_sdlc_on_stop.py:34`, `sdlc/sdlc_reminder.py:29`). Any future keep-set, sweep, or generator change touching this directory must account for it explicitly; a command-string-derived keep-set deletes it and breaks all three global hooks in every foreign repo. (`sync_user_hooks()` likewise does not hardlink import siblings, so a genuinely fresh machine has a latent import failure — tracked separately as #2561.)
+
+A full-tree `shutil.copytree` snapshot to `~/.claude/hooks.bak.{UTC timestamp}` is taken **only** when the removal set is non-empty and **before** any unlink; if the snapshot cannot be written the migration aborts before touching anything. Idempotency comes from disk state rather than the migration ledger — the removal set is recomputed from what is actually present, so a second run finds nothing, writes nothing, and takes no second `.bak`. The prune is **not** routed through `RENAMED_REMOVALS`: `_cleanup_renamed` (`scripts/update/hardlinks.py:547-585`) is inode-guarded and preserves any target still hardlinked to a live project source, which describes every file in scope here.
+
+### The legacy dir-symlink layout
+
+On machines set up before the manifest generator, `~/.claude/hooks` can be a **symlink to `<project>/.claude/hooks`** — the same legacy layout `hardlinks.py` migrates away from for `~/.claude/skills`. There the "user tree" and this repo's own git-tracked source tree are the *same directory*, so every path in the orphan inventory resolves to a live repo file and an unguarded prune deletes the repo's real hooks. This is not hypothetical: it was observed on a live machine during the #2521 build, where an unguarded run removed 36 tracked files plus their bytecode.
+
+The migration therefore returns immediately (logging a WARNING, writing nothing, taking no `.bak`) when `~/.claude/hooks` is a symlink or resolves to `<project_dir>/.claude/hooks`. A machine in this layout has no separate user tree to prune. Any future sweep of this directory must carry the same guard.
 
 ## Both-Scope Audit
 
@@ -200,7 +224,7 @@ The migration is **registration-only: it deletes no files.** Once the registrati
 | `.claude/hooks/dispatch/pre_tool_use_bash.py` | In-process PreToolUse/Bash dispatcher. |
 | `scripts/update/hardlinks.py` | `generate_project_hooks()`, `sync_project_hooks()`, `sync_user_hooks()`, `_merge_hook_settings()`, `RENAMED_REMOVALS` `"hooks"` kind, and the interpreter contract (`PROJECT_HOOK_INTERPRETER`, `GLOBAL_INTERPRETER_CANDIDATES`, `MIN_GLOBAL_PYTHON`, `resolve_global_interpreter()`). |
 | `.claude/hooks/hook_python` | The project-scope interpreter shim (POSIX `sh`, extensionless, mode 755) — resolves the main checkout's venv, fails open with an auditable record. |
-| `scripts/update/migrations.py` | `_migrate_hook_registration_manifest_ids()` — the one-time legacy-entry rewrite. `_migrate_sweep_legacy_unmarked_global_hooks()` — the one-time unmarked-global-entry sweep. |
+| `scripts/update/migrations.py` | `_migrate_hook_registration_manifest_ids()` — the one-time legacy-entry rewrite. `_migrate_sweep_legacy_unmarked_global_hooks()` — the one-time unmarked-global-entry sweep. `_migrate_prune_orphaned_premanifest_hook_files()` + `_PREMANIFEST_HOOK_ORPHANS` / `_USER_HOOK_KEEP_PATHS` — the one-time user-tree file prune. |
 | `.claude/hooks/stop.py` | Detached-extraction spawn point; genuine bare-except swallows replaced with logged handlers. |
 | `.claude/hooks/hook_utils/detach_lock.py` | Absolute log path, absolute state dir, deadline/max-inflight env readers, slot reservation. |
 | `.claude/hooks/hook_utils/stop_detach_worker.py` | The detached worker: self-deadline via `SIGALRM`, releases its slot in `finally`. |

--- a/scripts/update/migrations.py
+++ b/scripts/update/migrations.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import logging
+import shutil
 import subprocess
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -700,6 +701,275 @@ def _migrate_sweep_legacy_unmarked_global_hooks(project_dir: Path) -> str | None
     return None
 
 
+# Pre-manifest residue under ~/.claude/hooks/ (issue #2521).
+#
+# POSTURE: delete-by-inventory, keep-by-default. This is an EXPLICIT, static,
+# hand-maintained inventory of exactly the paths the old hardcoded
+# `_SDLC_HOOK_DEFS` / pre-manifest sync path put in the user tree. Anything under
+# ~/.claude/hooks/ that is NOT named here is left alone, forever -- a hand-added
+# user hook, a foreign repo's artifact, or a path this list has never heard of is
+# never touched. Deliberately NOT a prefix test and NOT a diff of the user tree
+# against the manifest: both invert the default to delete-by-default, which is
+# exactly the unsoundness #2503's plan critique rejected.
+#
+# The list names historical artifacts, so it cannot grow stale in a dangerous
+# direction: a machine whose tree has drifted simply keeps its extra debris,
+# inert. Entries are relative to ~/.claude/hooks/. Trailing-slash entries are
+# whole trees; naming a tree does NOT license deleting its whole contents --
+# each file inside one is still recognized individually (see
+# ``_is_premanifest_artifact``) and still passes gates (b) and (c), and the
+# directory itself is removed only once it is empty.
+#
+# `sdlc/__pycache__/` is deliberately ABSENT: it belongs to the kept sdlc/ tree.
+_PREMANIFEST_HOOK_ORPHANS: tuple[str, ...] = (
+    # Whole trees.
+    "validators/",
+    "dispatch/",
+    "hook_utils/",
+    "__pycache__/",
+    # Top-level files.
+    "format_file.py",
+    "hook_python",
+    "manifest.toml",
+    "post_compact.py",
+    "post_tool_use.py",
+    "pre_tool_use.py",
+    "sdlc_reminder.py",
+    "stop.py",
+    "subagent_stop.py",
+    "user_prompt_submit.py",
+)
+
+# Paths under ~/.claude/hooks/ that must NEVER be removed, whatever else says so.
+#
+# The first three are the manifest's `scope = "global"` declarations. The fourth,
+# `sdlc/sdlc_context.py`, CARRIES NO MANIFEST DECLARATION OF ITS OWN and appears
+# in no hook command string anywhere -- it is a pure runtime import sibling,
+# imported by all three global fork scripts:
+#   sdlc/validate_commit_message_sdlc.py:35
+#   sdlc/validate_sdlc_on_stop.py:34
+#   sdlc/sdlc_reminder.py:29
+# Any keep-set or sweep derived from command strings alone would delete it and
+# break all three global hooks in every foreign repo. Future edits here must
+# account for it explicitly.
+#
+# Intersecting the orphan inventory against this set is belt-and-braces (the two
+# are already disjoint); it means a future edit that mistakenly adds a live path
+# to the orphan list still cannot delete it.
+_USER_HOOK_KEEP_PATHS: frozenset[str] = frozenset(
+    {
+        "sdlc/validate_commit_message_sdlc.py",
+        "sdlc/sdlc_reminder.py",
+        "sdlc/validate_sdlc_on_stop.py",
+        "sdlc/sdlc_context.py",
+    }
+)
+
+
+def _registered_hook_commands() -> str:
+    """Return all ~/.claude/settings.json hook command strings joined for substring tests.
+
+    PERMISSIVE on absent, unreadable, AND malformed settings.json -- one shared
+    code path returning ``""`` (i.e. "no registrations"). Gates (a) and (b) are
+    the load-bearing ones; gate (c) is defense in depth, and a machine with a
+    hand-broken settings.json must still get its pre-manifest residue pruned
+    rather than being wedged forever on a file this migration does not own.
+    A read/parse failure is logged at WARNING; it never aborts.
+    """
+    settings_path = Path.home() / ".claude" / "settings.json"
+    if not settings_path.exists():
+        return ""
+
+    try:
+        settings = json.loads(settings_path.read_text())
+    except (OSError, ValueError) as e:
+        logger.warning(
+            "[migration:prune_orphaned_premanifest_hook_files] "
+            "could not read/parse %s (%s); proceeding with no registration guard",
+            settings_path,
+            e,
+        )
+        return ""
+
+    if not isinstance(settings, dict):
+        logger.warning(
+            "[migration:prune_orphaned_premanifest_hook_files] "
+            "%s is not a JSON object; proceeding with no registration guard",
+            settings_path,
+        )
+        return ""
+
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict):
+        return ""
+
+    commands: list[str] = []
+    for block in _iter_hook_blocks(hooks):
+        entries = block.get("hooks")
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if isinstance(entry, dict):
+                command = entry.get("command")
+                if isinstance(command, str):
+                    commands.append(command)
+    return "\n".join(commands)
+
+
+def _migrate_prune_orphaned_premanifest_hook_files(project_dir: Path) -> str | None:
+    """Prune orphaned pre-manifest script files under ~/.claude/hooks/ (#2521).
+
+    Sibling migration ``_migrate_sweep_legacy_unmarked_global_hooks`` (#2503)
+    removed the last orphaned *registration*, which made these files inert but
+    deliberately deleted nothing. The manifest-driven generator hardlinks only
+    the manifest's ``scope = "global"`` declarations, so it is structurally
+    unable to remove anything the old hardcoded path put in the user tree. This
+    migration is the one-time self-heal.
+
+    A path is removed only when ALL THREE gates permit it:
+      (a) it is named in ``_PREMANIFEST_HOOK_ORPHANS``,
+      (b) it is not in ``_USER_HOOK_KEEP_PATHS``, and
+      (c) it is not referenced by any command string in ~/.claude/settings.json.
+
+    Gate (a) makes "unrecognized => kept" the default. Every gate compares the
+    path RELATIVE TO ~/.claude/hooks/ -- never a bare basename: top-level
+    ``sdlc_reminder.py`` is removable residue while ``sdlc/sdlc_reminder.py`` is
+    a live manifest-declared global script, and the two share a basename.
+
+    A full-tree ``shutil.copytree`` snapshot to ``~/.claude/hooks.bak.{ts}`` is
+    taken ONLY when the removal set is non-empty, and BEFORE any unlink. If the
+    snapshot cannot be written the migration aborts before touching anything and
+    returns the OS error, so the tree is never left half-pruned with no backup.
+
+    Idempotency comes from disk state, not the ledger: the removal set is
+    recomputed from what is actually present, so a second run finds nothing,
+    writes nothing, takes no second ``.bak``, and returns ``None``.
+
+    Not routed through ``RENAMED_REMOVALS``: ``_cleanup_renamed``
+    (scripts/update/hardlinks.py:547-585) is inode-guarded and preserves any
+    target still hardlinked to a live project source, which describes every
+    file in scope here.
+
+    Returns None on success (including "nothing to prune"), an error string on
+    failure. Never raises.
+    """
+    try:
+        hooks_root = Path.home() / ".claude" / "hooks"
+        if not hooks_root.is_dir():
+            return None
+
+        repo_hooks_root = project_dir / ".claude" / "hooks"
+
+        # LEGACY DIR-SYMLINK GUARD -- do not remove.
+        #
+        # On machines set up before the manifest generator, ~/.claude/hooks can
+        # be a SYMLINK to <project>/.claude/hooks (the same legacy layout
+        # hardlinks.py:219-227 migrates away from for ~/.claude/skills). There
+        # the "user tree" and the repo's own tracked source tree are the SAME
+        # directory, so every path in the orphan inventory resolves to a live,
+        # git-tracked repo file. Pruning would delete this repo's real hooks --
+        # observed on a live machine during the #2521 build, where an unguarded
+        # run removed 36 tracked files plus their bytecode.
+        #
+        # This also corrects the plan's spike-1: the "shared inode" it measured
+        # between the user path and the repo path was this symlink, not a
+        # hardlink, so its "unlinking loses nothing" conclusion does not hold
+        # on such a machine.
+        #
+        # A machine in this layout has no separate user tree to prune, so the
+        # correct action is to do nothing at all.
+        if hooks_root.is_symlink() or hooks_root.resolve() == repo_hooks_root.resolve():
+            logger.warning(
+                "[migration:prune_orphaned_premanifest_hook_files] "
+                "%s is a legacy directory symlink into the repo (-> %s); "
+                "skipping the prune -- there is no separate user tree to clean",
+                hooks_root,
+                hooks_root.resolve(),
+            )
+            return None
+
+        registered = _registered_hook_commands()
+
+        def _permitted(rel: str) -> bool:
+            """Gates (b) and (c), evaluated on the hooks-root-relative path."""
+            if rel in _USER_HOOK_KEEP_PATHS:
+                return False
+            return f"{hooks_root}/{rel}" not in registered
+
+        def _is_premanifest_artifact(rel: str) -> bool:
+            """Gate (a) for a file found INSIDE an enumerated orphan tree.
+
+            Naming a tree in the inventory does not license deleting whatever
+            happens to be sitting in it: "unrecognized => kept" applies file by
+            file. A file inside one of these trees is pre-manifest residue
+            exactly when this repo still supplies the same relative path (per
+            spike-1 every such user-tree file is a HARDLINK to that repo source,
+            which is why unlinking it loses nothing), or when it is regenerable
+            ``.pyc`` bytecode for a source being removed. A hand-added user file
+            has no repo counterpart, so it survives -- and keeps its directory
+            alive with it.
+            """
+            if rel.endswith(".pyc"):
+                return True
+            return (repo_hooks_root / rel).exists()
+
+        removable_files: list[Path] = []
+        tree_roots: list[Path] = []
+
+        for entry in _PREMANIFEST_HOOK_ORPHANS:
+            target = hooks_root / entry.rstrip("/")
+            if entry.endswith("/"):
+                if not target.is_dir():
+                    continue
+                tree_roots.append(target)
+                for path in sorted(target.rglob("*")):
+                    if not path.is_file():
+                        continue
+                    rel = str(path.relative_to(hooks_root))
+                    if _is_premanifest_artifact(rel) and _permitted(rel):
+                        removable_files.append(path)
+            else:
+                if not target.is_file():
+                    continue
+                rel = str(target.relative_to(hooks_root))
+                if _permitted(rel):
+                    removable_files.append(target)
+
+        if not removable_files:
+            return None
+
+        backup_path = hooks_root.parent / (
+            f"{hooks_root.name}.bak.{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}"
+        )
+        try:
+            shutil.copytree(hooks_root, backup_path)
+        except OSError as e:
+            return f"failed to write backup {backup_path}, aborting prune: {e}"
+
+        for path in removable_files:
+            try:
+                path.unlink()
+            except OSError as e:
+                return f"failed to remove {path}: {e}"
+
+        # Remove each enumerated tree only once it is empty -- an unrecognized
+        # user file inside one keeps its directory alive.
+        for root in tree_roots:
+            for directory in sorted(
+                (p for p in root.rglob("*") if p.is_dir()),
+                key=lambda p: len(p.parts),
+                reverse=True,
+            ):
+                if not any(directory.iterdir()):
+                    directory.rmdir()
+            if root.is_dir() and not any(root.iterdir()):
+                root.rmdir()
+
+        return None
+    except Exception as e:  # swallow-ok: error returned as string to caller for logging
+        return f"failed to prune orphaned pre-manifest hook files: {e}"
+
+
 def _migrate_hook_registration_manifest_ids(project_dir: Path) -> str | None:
     """Rewrite the 3 deployed legacy SDLC-fork hook entries in place (Bug 1).
 
@@ -1078,6 +1348,11 @@ MIGRATIONS: dict[str, tuple[callable, str]] = {
         _migrate_sweep_legacy_unmarked_global_hooks,
         "Remove the stale unmarked pre-manifest validate_no_raw_redis_delete.py "
         "global registration from ~/.claude/settings.json (issue #2503)",
+    ),
+    "prune_orphaned_premanifest_hook_files": (
+        _migrate_prune_orphaned_premanifest_hook_files,
+        "Prune orphaned pre-manifest script files under ~/.claude/hooks/ that no "
+        "manifest declaration or live registration references (issue #2521)",
     ),
 }
 

--- a/tests/unit/test_hook_migration.py
+++ b/tests/unit/test_hook_migration.py
@@ -599,3 +599,241 @@ def test_sweep_registered_in_migrations_dict():
     fn, description = migrations.MIGRATIONS["sweep_legacy_unmarked_global_hooks"]
     assert fn is migrations._migrate_sweep_legacy_unmarked_global_hooks
     assert description
+
+
+# ---------------------------------------------------------------------------
+# Issue #2521: _migrate_prune_orphaned_premanifest_hook_files
+#
+# The FILE prune that #2503 deliberately carved out. Delete-by-inventory,
+# keep-by-default: only paths named in _PREMANIFEST_HOOK_ORPHANS may go, and
+# only if they are not in _USER_HOOK_KEEP_PATHS and not named by a surviving
+# settings.json command. Every gate compares the path RELATIVE to
+# ~/.claude/hooks/ -- top-level sdlc_reminder.py (residue) and
+# sdlc/sdlc_reminder.py (live global script) share a basename.
+# ---------------------------------------------------------------------------
+
+# Files the migration must remove, relative to ~/.claude/hooks/.
+_EXPECTED_REMOVED = (
+    "validators/validate_no_raw_redis_delete.py",
+    "validators/validate_merge_guard.py",
+    "validators/__pycache__/validate_no_raw_redis_delete.cpython-313.pyc",
+    "dispatch/pre_tool_use_bash.py",
+    "hook_utils/constants.py",
+    "__pycache__/stop.cpython-313.pyc",
+    "format_file.py",
+    "hook_python",
+    "manifest.toml",
+    "post_compact.py",
+    "post_tool_use.py",
+    "pre_tool_use.py",
+    "sdlc_reminder.py",
+    "stop.py",
+    "subagent_stop.py",
+    "user_prompt_submit.py",
+)
+
+# Files the migration must never touch.
+_EXPECTED_KEPT = (
+    "sdlc/validate_commit_message_sdlc.py",
+    "sdlc/sdlc_reminder.py",
+    "sdlc/validate_sdlc_on_stop.py",
+    "sdlc/sdlc_context.py",
+    "sdlc/__pycache__/sdlc_context.cpython-313.pyc",
+)
+
+# Files not on the inventory at all -- kept by default, and they keep their
+# containing directory alive with them.
+_UNRECOGNIZED = (
+    "validators/my_own_validator.py",
+    "my_notes.md",
+)
+
+
+def _seed_premanifest_tree(home: Path) -> Path:
+    """Build a synthetic pre-manifest ~/.claude/hooks/ tree. Returns hooks_root."""
+    hooks_root = home / ".claude" / "hooks"
+    for rel in _EXPECTED_REMOVED + _EXPECTED_KEPT + _UNRECOGNIZED:
+        path = hooks_root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"# {rel}\n")
+    return hooks_root
+
+
+def _backups(home: Path) -> list[Path]:
+    return list((home / ".claude").glob("hooks.bak.*"))
+
+
+def _prune(project_dir: Path = _REPO_ROOT) -> str | None:
+    return migrations._migrate_prune_orphaned_premanifest_hook_files(project_dir)
+
+
+class TestPruneOrphanedPremanifestHookFiles:
+    def test_removes_inventory_and_keeps_keep_set(self, fake_home):
+        hooks_root = _seed_premanifest_tree(fake_home)
+
+        assert _prune() is None
+
+        for rel in _EXPECTED_REMOVED:
+            assert not (hooks_root / rel).exists(), f"{rel} should have been removed"
+        for rel in _EXPECTED_KEPT:
+            assert (hooks_root / rel).exists(), f"{rel} must survive"
+
+    def test_top_level_sdlc_reminder_removed_but_sdlc_subdir_one_survives(self, fake_home):
+        """Highest-value assertion: the gates key on the relative path, not the basename."""
+        hooks_root = _seed_premanifest_tree(fake_home)
+        assert (hooks_root / "sdlc_reminder.py").exists()
+        assert (hooks_root / "sdlc" / "sdlc_reminder.py").exists()
+
+        assert _prune() is None
+
+        assert not (hooks_root / "sdlc_reminder.py").exists()
+        assert (hooks_root / "sdlc" / "sdlc_reminder.py").exists()
+
+    def test_unrecognized_files_and_their_directory_survive(self, fake_home):
+        hooks_root = _seed_premanifest_tree(fake_home)
+
+        assert _prune() is None
+
+        for rel in _UNRECOGNIZED:
+            assert (hooks_root / rel).exists(), f"unrecognized {rel} must be kept"
+        assert (hooks_root / "validators").is_dir(), (
+            "a tree holding an unrecognized user file must survive"
+        )
+        # Fully-emptied trees are gone.
+        assert not (hooks_root / "dispatch").exists()
+        assert not (hooks_root / "hook_utils").exists()
+        assert not (hooks_root / "__pycache__").exists()
+
+    def test_takes_full_tree_backup_containing_removed_files(self, fake_home):
+        hooks_root = _seed_premanifest_tree(fake_home)
+
+        assert _prune() is None
+
+        backups = _backups(fake_home)
+        assert len(backups) == 1, f"expected exactly one .bak snapshot, found {backups}"
+        for rel in _EXPECTED_REMOVED:
+            snapshot = backups[0] / rel
+            assert snapshot.exists(), f"{rel} missing from snapshot"
+            assert snapshot.read_text() == f"# {rel}\n"
+        assert (hooks_root / "sdlc" / "sdlc_context.py").exists()
+
+    def test_second_run_is_a_no_op(self, fake_home):
+        hooks_root = _seed_premanifest_tree(fake_home)
+
+        assert _prune() is None
+        first_state = sorted(p.relative_to(hooks_root) for p in hooks_root.rglob("*"))
+
+        assert _prune() is None
+        assert sorted(p.relative_to(hooks_root) for p in hooks_root.rglob("*")) == first_state
+        assert len(_backups(fake_home)) == 1, "idempotent re-run must not write a 2nd .bak"
+
+    def test_absent_hooks_dir_is_a_clean_no_op(self, fake_home):
+        assert not (fake_home / ".claude" / "hooks").exists()
+
+        assert _prune() is None
+
+        assert not (fake_home / ".claude" / "hooks").exists()
+        assert _backups(fake_home) == []
+
+    @pytest.mark.parametrize("settings_body", [None, "{ this is not json"])
+    def test_absent_and_malformed_settings_yield_the_same_removal_set(
+        self, fake_home, tmp_path, settings_body
+    ):
+        """Gate (c) is PERMISSIVE on absent, unreadable, and malformed alike."""
+        hooks_root = _seed_premanifest_tree(fake_home)
+        settings_path = fake_home / ".claude" / "settings.json"
+        if settings_body is None:
+            settings_path.unlink(missing_ok=True)
+        else:
+            settings_path.write_text(settings_body)
+
+        assert _prune() is None
+
+        survivors = sorted(
+            str(p.relative_to(hooks_root)) for p in hooks_root.rglob("*") if p.is_file()
+        )
+        assert survivors == sorted(_EXPECTED_KEPT + _UNRECOGNIZED)
+
+    def test_path_named_by_surviving_settings_command_is_not_removed(self, fake_home):
+        hooks_root = _seed_premanifest_tree(fake_home)
+        settings_path = fake_home / ".claude" / "settings.json"
+        settings_path.write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "PreToolUse": [
+                            {
+                                "matcher": "Bash",
+                                "hooks": [
+                                    {
+                                        "type": "command",
+                                        "command": f"python {hooks_root}/pre_tool_use.py",
+                                        "timeout": 5,
+                                    },
+                                    {
+                                        "type": "command",
+                                        "command": "python /opt/my-own-tool/guard.py",
+                                        "timeout": 5,
+                                    },
+                                ],
+                            }
+                        ]
+                    }
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+
+        assert _prune() is None
+
+        assert (hooks_root / "pre_tool_use.py").exists(), (
+            "gate (c) must veto removal of a still-registered path"
+        )
+        assert not (hooks_root / "post_tool_use.py").exists()
+
+    def test_registered_in_migrations_dict(self):
+        assert "prune_orphaned_premanifest_hook_files" in migrations.MIGRATIONS
+        fn, description = migrations.MIGRATIONS["prune_orphaned_premanifest_hook_files"]
+        assert fn is migrations._migrate_prune_orphaned_premanifest_hook_files
+        assert "#2521" in description
+
+    def test_unwritable_backup_aborts_before_any_unlink(self, fake_home, monkeypatch):
+        hooks_root = _seed_premanifest_tree(fake_home)
+        before = sorted(str(p.relative_to(hooks_root)) for p in hooks_root.rglob("*"))
+
+        def _boom(src, dst, **kwargs):
+            raise OSError("read-only file system")
+
+        monkeypatch.setattr(migrations.shutil, "copytree", _boom)
+
+        error = _prune()
+        assert error is not None
+        assert "read-only file system" in error
+        assert sorted(str(p.relative_to(hooks_root)) for p in hooks_root.rglob("*")) == before
+
+    def test_legacy_dir_symlink_into_repo_is_never_pruned(self, fake_home, tmp_path):
+        """~/.claude/hooks may be a legacy SYMLINK to <repo>/.claude/hooks.
+
+        On such a machine the "user tree" and the repo's own git-tracked source
+        tree are the same directory, so every inventory path resolves to a live
+        repo file. An unguarded run deletes this repo's real hooks -- observed
+        on a live machine during the #2521 build. The migration must no-op.
+        """
+        repo = tmp_path / "repo"
+        repo_hooks = repo / ".claude" / "hooks"
+        repo_hooks.mkdir(parents=True)
+        seeded = _seed_premanifest_tree(fake_home)
+        # Re-home the seeded tree inside the fake repo, then symlink the user
+        # path at it -- the exact legacy layout.
+        for child in sorted(seeded.iterdir()):
+            child.rename(repo_hooks / child.name)
+        seeded.rmdir()
+        (fake_home / ".claude" / "hooks").symlink_to(repo_hooks)
+
+        before = sorted(str(p.relative_to(repo_hooks)) for p in repo_hooks.rglob("*"))
+
+        assert _prune(project_dir=repo) is None
+
+        assert sorted(str(p.relative_to(repo_hooks)) for p in repo_hooks.rglob("*")) == before
+        assert _backups(fake_home) == [], "a symlinked user tree must not produce a .bak"


### PR DESCRIPTION
Closes #2521

Plan: `docs/plans/prune-orphaned-hook-files.md`

## What

Adds `_migrate_prune_orphaned_premanifest_hook_files()` to `scripts/update/migrations.py`, registered in `MIGRATIONS` as `prune_orphaned_premanifest_hook_files`. `/update` Step 3.6 runs it automatically; no operator action.

The manifest generator hardlinks only the manifest's `scope = "global"` declarations, so it is structurally unable to remove anything the old hardcoded `_SDLC_HOOK_DEFS` path left in `~/.claude/hooks/`. #2503 (PR #2522) removed the last orphaned *registration*, making those files inert but deleting nothing. This removes the files.

**Three gates, all of which must permit a removal:**
1. named in `_PREMANIFEST_HOOK_ORPHANS` — a static, hand-maintained inventory. Unrecognized ⇒ kept, always.
2. not in `_USER_HOOK_KEEP_PATHS`.
3. not referenced by any command string in `~/.claude/settings.json` (permissive on absent/unreadable/malformed, one shared code path, WARNING logged, never aborts).

Every gate keys on `str(path.relative_to(hooks_root))`, never `path.name`: top-level `sdlc_reminder.py` is residue while `sdlc/sdlc_reminder.py` is a live global script, and the two share a basename. `sdlc/sdlc_context.py` is in the keep-set explicitly — it carries no manifest declaration and appears in no command string, but all three global fork hooks import it at runtime.

A full-tree `.bak` snapshot is taken only when the removal set is non-empty and before any unlink. Idempotency comes from disk state, not the ledger.

## Deviation from the plan — a blocking safety finding

**`~/.claude/hooks` on this machine is a SYMLINK to `<repo>/.claude/hooks`** (created Feb 3 2026, the legacy dir-symlink layout `hardlinks.py:219-227` migrates away from for `~/.claude/skills`). `/update` does not create it, but it exists.

On such a machine the "user tree" and this repo's git-tracked source tree are the *same directory*, so every inventory path resolves to a live repo file. An unguarded run during this build deleted 36 tracked repo files plus their bytecode (restored from git + the migration's own `.bak`).

This invalidates the plan's **spike-1**: the "shared inode 5917700" it measured between the user path and the repo path was this symlink, not a hardlink, so its "unlinking leaves the repo source intact" conclusion does not hold on this layout.

The migration now returns immediately (WARNING logged, no writes, no `.bak`) when `~/.claude/hooks` is a symlink or resolves to `<project_dir>/.claude/hooks`. Verified against the real machine: `result: None`, tree byte-identical, no `.bak`. Covered by `test_legacy_dir_symlink_into_repo_is_never_pruned`.

**Consequence for reviewers:** on a machine in this layout the prune is a permanent no-op, so the issue's stated outcome is not achieved there. Whether that layout should itself be migrated (as `~/.claude/skills` was) is a separate question worth filing.

## Verification

| Check | Result |
|---|---|
| `scripts/pytest-clean.sh tests/unit/test_hook_migration.py -n0 -q` | 36 passed |
| `tests/unit/test_migrations.py` | 10 passed |
| `ruff check` | All checks passed |
| `ruff format --check` | 2 files already formatted |
| Migration registered in `MIGRATIONS` | True |
| `sdlc/sdlc_context.py` in keep-set | 2 hits |
| Foreign `/opt/my-own-tool/guard.py` fixture intact | 4 hits, untouched |
| No AST import walk | pass |
| Not routed through `RENAMED_REMOVALS` | pass |
| No basename comparison in the prune | pass (2 hits are pre-existing `settings_path.name` backup-filename construction in older migrations, verified identical on `main`) |
| Live-tree cross-check | inventory covers the real tree exactly; 74 files removed, 6 `sdlc/` survivors, no live path caught |

## Docs

`docs/features/hook-manifest.md` gains a **User-tree Hygiene** section covering what the generator does and does not own, the three gates, the `sdlc/sdlc_context.py` import edge, and a **legacy dir-symlink** subsection. Docs gate: exit 2 (non-blocking stale-marker warning on the word "legacy" in the new prose).