### PR TITLE
Repair the test suite's measuring instrument: four false-signal defects (#2552, #2553, #2556, #2557, #2523)

### DIFF
--- a/docs/features/skills-global.md
+++ b/docs/features/skills-global.md
@@ -71,6 +71,32 @@ stat -f %i .claude/skills-global/<name>/SKILL.md ~/.claude/skills/<name>/SKILL.m
 
 Differing inodes mean the live copy is stale; `/update` re-establishes every link.
 
+## Skill Liveness and Husks
+
+A skill is *live* if and only if its directory holds a `SKILL.md` file. Directory
+existence alone is not liveness — a directory can survive on disk after its `SKILL.md`
+is deleted (a `__pycache__` dir, a stray reference file, an incomplete rename), and a
+bare `Path.is_dir()` probe reads that leftover as a live skill. Such a directory is a
+**husk**.
+
+`tests/unit/test_update_hardlinks.py::test_no_husk_directories_in_skill_roots` fails
+the build whenever a husk exists under `.claude/skills-global/` or `.claude/skills/`.
+All liveness checks in that file (`_skill_exists_in_any_root`, `test_renamed_removals_entries_are_not_stale`)
+route through the same `_skill_is_live` helper, so a directory-existence check cannot
+silently reappear at a second call site.
+
+The one directory allowed to lack a `SKILL.md` is `.claude/skills/_shared/` — an
+intentional shared-resource directory (it tracks `test-quality.md`, consumed by other
+skills rather than being one itself). It is permitted via an explicit
+`HUSK_GUARD_ALLOWLIST` frozenset in `test_update_hardlinks.py`, not an underscore-prefix
+convention: an allowlist of one names exactly what's exempt and fails loudly the moment
+a second non-skill directory shows up, instead of a naming convention silently absorbing
+anything that happens to start with `_`.
+
+When a skill is renamed or removed, delete its directory entirely (not just `SKILL.md`)
+and add a `RENAMED_REMOVALS` entry — see "Global vs. Project-Only Skills" in the root
+`CLAUDE.md`. Leaving the emptied directory behind is exactly what creates a husk.
+
 ## Invocation Types
 
 - **User + Model**: Both user and agent can trigger via `/skill-name`

--- a/docs/plans/wave2-test-instrument.md
+++ b/docs/plans/wave2-test-instrument.md
@@ -250,9 +250,9 @@ No agent integration required. Every change is in test code, test fixtures, or a
 
 ## Documentation
 
-- [ ] Update `tests/README.md` — add the catchup kill-switch isolation fixture to the fixture/blind-spot notes, recording that operator flag files are neutralized suite-wide and why (a test reading a gitignored production flag is a contamination class, not a one-off).
-- [ ] Update `docs/features/skill-context-convention.md` or the nearest skills-infrastructure doc — record that skill liveness is defined by `SKILL.md` presence, not directory existence, and that `_`-prefixed directories under the skill roots are shared resources rather than skills.
-- [ ] No new feature doc. This plan repairs existing behavior rather than adding capability; a `docs/features/` entry would describe a test fixture, which belongs in `tests/README.md`.
+- [x] Update `tests/README.md` — added the `isolate_catchup_kill_switch` fixture to the Fixtures table and a new "Operator control-state isolation (issue #2552)" subsection recording the neutralization, the `CATCHUP_FLAG_ISOLATION=0` escape hatch, and the contamination-class lesson.
+- [x] Update `docs/features/skills-global.md` (nearest skills-infrastructure doc, not `skill-context-convention.md` — that doc covers repo-specific skill behavior layering, not liveness) — added a "Skill Liveness and Husks" section recording that liveness is `SKILL.md` presence, that `.claude/skills/_shared/` is exempted via the explicit `HUSK_GUARD_ALLOWLIST` frozenset rather than an underscore-prefix convention, and the husk-guard test that enforces it.
+- [x] No new feature doc. This plan repairs existing behavior rather than adding capability; a `docs/features/` entry would describe a test fixture, which belongs in `tests/README.md`.
 
 ## Success Criteria
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -73,6 +73,32 @@ Fix at source, not by suppression: the three #2118 leaks (`run_email_bridge`,
 via `bridge/promise_gate.py::_run_async_safely`, `_worker_loop` in
 `test_slow_redis_no_loop_freeze.py`) were each closed where the coroutine was dropped.
 
+### Operator control-state isolation (issue #2552)
+
+`bridge/catchup.py` anchors `CATCHUP_DISABLED_FLAG` to its own source tree (not to a
+fixture-controlled path), which is correct for production but means the suite reads
+live operator control state by default. On a host where an operator has paused message
+recovery via `data/catchup-disabled`, 17 unit tests with no relation to catchup went red
+purely because the file existed on that machine and not on another — a false red with no
+explanation anywhere in the diff.
+
+The autouse `isolate_catchup_kill_switch` fixture (`tests/conftest.py`) repoints
+`bridge.catchup.CATCHUP_DISABLED_FLAG` at a per-test tmp path for the duration of every
+test, covering all three production readers (`bridge/catchup.py`, `bridge/reconciler.py`,
+`bridge/agent_catchup.py`) since they all import the symbol from `bridge.catchup` rather
+than re-deriving the path. The flag is *repointed*, not stubbed — `catchup_disabled()`
+still runs a real `Path.exists()` against a real filesystem path, so a test that wants
+genuine disabled behavior can `touch` the redirected path.
+
+- **Escape hatch:** set `CATCHUP_FLAG_ISOLATION=0` to skip the redirect. This exists so
+  the negative control for #2552 stays permanently reproducible — running the suite with
+  it set must reproduce the same 17 flag-caused failures on a host where the real
+  `data/catchup-disabled` exists.
+- **The general lesson:** a test reading a gitignored production flag file is a
+  contamination *class*, not a one-off. Any future operator-toggled flag under `data/`
+  needs the same treatment before it can silently flip unrelated tests red depending on
+  which machine or checkout ran them.
+
 ### Known-failing clusters resolved on `main` (issue #1578)
 
 The previously known-bad clusters on `main` were driven to green in #1578. The fixes were **test-only** — assertions were re-pointed to current source/templates, never weakened, and no test was deleted:
@@ -389,6 +415,7 @@ here.
 |---------|-------|--------|---------|
 | `mock_claude_sdk_cleanup` | autouse | `conftest.py` | SDK mock cleanup between tests |
 | `redis_test_db` | autouse | `conftest.py` | Per-worker Redis db isolation |
+| `isolate_catchup_kill_switch` | autouse | `conftest.py` | Repoints the operator catchup kill-switch flag at a per-test tmp path (issue #2552) |
 | `sample_config` | function | `conftest.py` | 3-project sample configuration |
 | `valor_project` | function | `conftest.py` | Single project config |
 | `mock_telegram_client` | function | `tests/e2e/conftest.py` | AsyncMock Telethon client |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,6 +219,53 @@ def mock_claude_sdk_cleanup():
             del sys.modules[mod_key]
 
 
+# ---------------------------------------------------------------------------
+# Operator kill-switch isolation (#2552)
+# ---------------------------------------------------------------------------
+# `bridge/catchup.py` anchors CATCHUP_DISABLED_FLAG to its own source tree
+# (`Path(__file__).parent.parent / "data" / "catchup-disabled"`), which is
+# correct for production — the bridge runs under launchd with an unpredictable
+# cwd — but means the test suite reads live operator control state. On a host
+# where an operator has paused message recovery, ~17 unit tests that have
+# nothing to do with the kill switch go red, and the same nodes pass from a
+# worktree. That is a false red with no explanation anywhere in the diff.
+#
+# All three production readers (`bridge/catchup.py`, `bridge/reconciler.py`,
+# `bridge/agent_catchup.py`) import the symbol FROM `bridge.catchup` rather than
+# re-deriving the path, so patching this one module attribute covers every
+# reader. The fixture imports `bridge.catchup` itself rather than relying on the
+# test having imported it.
+#
+# The flag is REPOINTED at a per-test temp path, not stubbed: `catchup_disabled()`
+# still runs its real `Path.exists()` against a real filesystem path. A test that
+# wants genuine disabled behavior can `touch` the redirected path.
+_CATCHUP_FLAG_ISOLATION_DISABLED = os.environ.get("CATCHUP_FLAG_ISOLATION", "1") == "0"
+
+
+@pytest.fixture(autouse=True)
+def isolate_catchup_kill_switch(tmp_path_factory):
+    """Repoint the catchup operator kill-switch flag at a per-test temp path.
+
+    Escape hatch: set ``CATCHUP_FLAG_ISOLATION=0`` to skip the redirect. That
+    exists so the negative control for #2552 stays permanently reproducible —
+    running the suite with it set must reproduce the flag-caused failures on a
+    host where the real ``data/catchup-disabled`` exists.
+    """
+    if _CATCHUP_FLAG_ISOLATION_DISABLED:
+        yield
+        return
+
+    import bridge.catchup
+
+    redirect_dir = tmp_path_factory.mktemp("catchup-flag")
+    original = bridge.catchup.CATCHUP_DISABLED_FLAG
+    bridge.catchup.CATCHUP_DISABLED_FLAG = redirect_dir / "catchup-disabled"
+    try:
+        yield
+    finally:
+        bridge.catchup.CATCHUP_DISABLED_FLAG = original
+
+
 @pytest.fixture(autouse=True)
 def agent_hooks_consistency_guard():
     """Detect and repair a corrupt `agent` package/submodule cache state.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ import sys
 import time
 import warnings
 from unittest.mock import MagicMock
+from uuid import uuid4
 
 import pytest
 
@@ -242,9 +243,27 @@ def mock_claude_sdk_cleanup():
 _CATCHUP_FLAG_ISOLATION_DISABLED = os.environ.get("CATCHUP_FLAG_ISOLATION", "1") == "0"
 
 
+@pytest.fixture(scope="session")
+def _catchup_flag_redirect_dir(tmp_path_factory):
+    """One directory for the whole session to hold per-test kill-switch paths.
+
+    Session-scoped on purpose. ``tmp_path_factory.mktemp`` is numbered, so it
+    scans the basetemp for the next free suffix and its cost grows with the
+    number of directories already there. Calling it once per test from an
+    autouse fixture makes that aggregate quadratic and leaves one empty
+    directory per test; the per-test fixture below instead varies only the
+    filename inside this single directory, which costs a string format and no
+    filesystem write at all.
+    """
+    return tmp_path_factory.mktemp("catchup-flag")
+
+
 @pytest.fixture(autouse=True)
-def isolate_catchup_kill_switch(tmp_path_factory):
+def isolate_catchup_kill_switch(_catchup_flag_redirect_dir):
     """Repoint the catchup operator kill-switch flag at a per-test temp path.
+
+    Each test gets a unique path no other test can touch, so a test that wants
+    genuine disabled behavior can create it without leaking into its neighbors.
 
     Escape hatch: set ``CATCHUP_FLAG_ISOLATION=0`` to skip the redirect. That
     exists so the negative control for #2552 stays permanently reproducible —
@@ -257,9 +276,10 @@ def isolate_catchup_kill_switch(tmp_path_factory):
 
     import bridge.catchup
 
-    redirect_dir = tmp_path_factory.mktemp("catchup-flag")
     original = bridge.catchup.CATCHUP_DISABLED_FLAG
-    bridge.catchup.CATCHUP_DISABLED_FLAG = redirect_dir / "catchup-disabled"
+    bridge.catchup.CATCHUP_DISABLED_FLAG = (
+        _catchup_flag_redirect_dir / f"catchup-disabled-{uuid4().hex}"
+    )
     try:
         yield
     finally:

--- a/tests/unit/test_pipeline_integrity.py
+++ b/tests/unit/test_pipeline_integrity.py
@@ -173,7 +173,6 @@ class TestEnqueueContinuationFallback:
 
         critical_fields = [
             "context_summary",
-            "expectations",
             "issue_url",
             "pr_url",
             "session_events",
@@ -193,6 +192,140 @@ class TestEnqueueContinuationFallback:
         assert isinstance(result, dict)
         # Should have hash_exists, popoto_query_matches, or error (if Redis not available)
         assert "hash_exists" in result or "error" in result
+
+
+def _non_autokey_model_fields() -> set[str]:
+    """AgentSession field names eligible to appear in a `create(**fields)` payload.
+
+    AutoKeyFields are excluded because Popoto generates them; passing one into
+    a create payload is an error, so their absence from `_AGENT_SESSION_FIELDS`
+    is correct rather than drift. The exclusion is derived by ``isinstance``
+    against ``AutoKeyField`` and NOT by subtracting a literal ``{"id"}``, so a
+    second auto-key field added later cannot silently reopen the same
+    off-by-one.
+    """
+    from popoto import AutoKeyField
+
+    from models.agent_session import AgentSession
+
+    return {
+        name
+        for name, field in AgentSession._meta.fields.items()
+        if not isinstance(field, AutoKeyField)
+    }
+
+
+# AgentSession fields deliberately NOT copied by `_extract_agent_session_fields`
+# as of today. This is an honest record of an existing gap, not an approval of
+# it: the helper serves two incompatible contracts (delete-and-recreate of the
+# SAME session, where dropping a field is data loss, vs. creation of a NEW
+# session, where the #2518 execution fence must be reset), and resolving that
+# conflict is tracked in issue #2563.
+#
+# TERMINATION CONDITION: when #2563 ships, entries leave this set and it empties.
+# An empty KNOWN_GAP is a valid, meaningful state — the guard below asserts set
+# EQUALITY, so it becomes a plain completeness assertion at that point and a
+# newly added model field can never be silently absorbed into the excuse list.
+#
+# The left-hand side of the comparison excludes auto-key fields; see
+# `_non_autokey_model_fields` for why and how.
+KNOWN_GAP = frozenset(
+    {
+        "active_run_id",
+        "auto_resume_attempts",
+        "budget_tripped",
+        "budget_tripped_reason",
+        "chat_message_log",
+        "claude_version",
+        "continuation_depth",
+        "crash_outcome_attributed",
+        "crash_signature",
+        "current_tool_name",
+        "current_tool_timeout_s",
+        "dev_agent_id",
+        "exec_cwd",
+        "exec_harness",
+        "exec_pid",
+        "exit_reason",
+        "exit_returncode",
+        "is_ledger",
+        "issue_number",
+        "last_authored_at",
+        "last_compaction_ts",
+        "last_tool_use_at",
+        "last_turn_at",
+        "model",
+        "owned_run_ids",
+        "pid_create_time",
+        "pr_number",
+        "project_config",
+        "recent_thinking_excerpt",
+        "requires_real_chrome",
+        "response_delivered_at",
+        "retain_for_resume",
+        "rework_triggered",
+        "runner_cwd",
+        "spawn_history",
+        "task_type",
+        "thread_first_created_at",
+        "thread_run_count",
+        "thread_tool_call_count",
+        "thread_turn_count",
+        "tool_timeout_count_default",
+        "tool_timeout_count_internal",
+        "tool_timeout_count_mcp",
+        "total_cache_read_tokens",
+        "total_cost_usd",
+        "total_input_tokens",
+        "total_output_tokens",
+        "unhealthy_reason",
+        "user_facing_routed",
+        "worker_pid",
+    }
+)
+
+
+class TestAgentSessionFieldContractDrift:
+    """Guard `_AGENT_SESSION_FIELDS` against drift in both directions.
+
+    `df6097fe6` deleted the `expectations` field and nothing detected that the
+    list guarding it had drifted; these two tests are what would have caught it.
+    Five other modules assert *membership* in `_AGENT_SESSION_FIELDS`
+    (`test_health_check_recovery_finalization.py`, `test_agent_session_hierarchy.py`,
+    `test_agent_session.py`, `test_nudge_loop.py`, `test_session_completion_zombie.py`);
+    these are the completeness counterparts.
+    """
+
+    def test_no_phantom_names_in_field_list(self):
+        """Every name in `_AGENT_SESSION_FIELDS` still exists on the model.
+
+        A phantom name makes `_extract_agent_session_fields` raise
+        AttributeError at runtime on the delete-and-recreate path.
+        """
+        from agent.agent_session_queue import _AGENT_SESSION_FIELDS
+
+        phantoms = sorted(set(_AGENT_SESSION_FIELDS) - _non_autokey_model_fields())
+        assert not phantoms, (
+            f"_AGENT_SESSION_FIELDS names field(s) that no longer exist on "
+            f"AgentSession: {phantoms}. Remove them from the list in "
+            f"agent/agent_session_queue.py, or restore the model field."
+        )
+
+    def test_unlisted_model_fields_match_known_gap(self):
+        """Model fields absent from the list equal the frozen KNOWN_GAP exactly."""
+        from agent.agent_session_queue import _AGENT_SESSION_FIELDS
+
+        actual_gap = _non_autokey_model_fields() - set(_AGENT_SESSION_FIELDS)
+        unclassified = sorted(actual_gap - KNOWN_GAP)
+        newly_classified = sorted(KNOWN_GAP - actual_gap)
+        assert actual_gap == KNOWN_GAP, (
+            f"AgentSession field coverage drifted. Unclassified field(s) missing "
+            f"from _AGENT_SESSION_FIELDS and from KNOWN_GAP: {unclassified}. "
+            f"KNOWN_GAP entries no longer in the gap: {newly_classified}. "
+            f"Decide explicitly whether each field should be copied by "
+            f"_extract_agent_session_fields (see issue #2563) and update the "
+            f"list or KNOWN_GAP accordingly."
+        )
 
 
 class TestMergeStageTracking:

--- a/tests/unit/test_reflections_yaml_migration.py
+++ b/tests/unit/test_reflections_yaml_migration.py
@@ -220,12 +220,19 @@ class TestSentryTriageCutover:
         repo_root = Path(__file__).resolve().parent.parent.parent
         registry_path = repo_root / "config" / "reflections.yaml"
 
+        # The contract under guard is *absence of the reflection entry from the
+        # registry*, asserted against parsed YAML — the only signal that survives
+        # tools/reflection_machine_filter.py's safe_load/safe_dump round-trip.
+        # (A comment-substring assertion was deliberately removed here: comments
+        # are destroyed by that round-trip. See TestFilterRoundTripSignalDurability.)
         data = yaml.safe_load(registry_path.read_text())
         names = [r["name"] for r in data["reflections"]]
-        assert "sentry-issue-triage" not in names
-
-        # The pointer comment documenting the migration is still present.
-        assert "sentry-issue-triage migrated to a Claude Code Routine" in registry_path.read_text()
+        assert "sentry-issue-triage" not in names, (
+            "sentry-issue-triage was reintroduced into the local reflections "
+            f"registry at {registry_path}; it has migrated to a Claude Code "
+            "Routine (cloud) and a local entry would double-run the triage. "
+            f"Registry entries: {sorted(names)}"
+        )
 
 
 def _pr_review_audit_cutover_pending() -> bool:
@@ -286,12 +293,111 @@ class TestPrReviewAuditCutover:
         repo_root = Path(__file__).resolve().parent.parent.parent
         registry_path = repo_root / "config" / "reflections.yaml"
 
+        # The contract under guard is *absence of the reflection entry from the
+        # registry*, asserted against parsed YAML — the only signal that survives
+        # tools/reflection_machine_filter.py's safe_load/safe_dump round-trip.
+        # (A comment-substring assertion was deliberately removed here: comments
+        # are destroyed by that round-trip. See TestFilterRoundTripSignalDurability.)
         data = yaml.safe_load(registry_path.read_text())
         names = [r["name"] for r in data["reflections"]]
-        assert "pr-review-audit" not in names
+        assert "pr-review-audit" not in names, (
+            "pr-review-audit was reintroduced into the local reflections registry "
+            f"at {registry_path}; it has been cut over to a Claude Code Routine "
+            "(cloud) and a local entry would double-run the audit. "
+            f"Registry entries: {sorted(names)}"
+        )
 
-        # The pointer comment documenting the cutover is still present.
-        assert "pr-review-audit removed from local scheduling" in registry_path.read_text()
+
+class TestFilterRoundTripSignalDurability:
+    """Why the cutover guards above assert on parsed YAML and never on comments.
+
+    ``tools/reflection_machine_filter.py`` rewrites ``config/reflections.yaml``
+    in place with ``yaml.safe_load`` → ``yaml.safe_dump`` (``:110`` / ``:146``).
+    That round-trip discards comments by construction, so a comment-substring
+    assertion is a latent red: it passes only until the next ``install_worker.sh``
+    run and then fails for a reason unrelated to any live contract.
+
+    This test demonstrates the destruction rather than citing it, and proves the
+    replacement assertion style survives the same round-trip. It operates
+    entirely on ``tmp_path`` and never reads or writes the real machine-local
+    ``config/reflections.yaml``.
+    """
+
+    def test_filter_destroys_comments_but_preserves_structure(self, tmp_path: Path):
+        registry = tmp_path / "reflections.yaml"
+        projects = tmp_path / "projects.json"
+
+        pointer_comment = "# sentry-issue-triage migrated to a Claude Code Routine (cloud)"
+
+        # The synthetic registry carries three things:
+        #   (a) a pointer comment, the substrate the deleted assertions relied on;
+        #   (b) the structural state the cutover tests assert on — a live entry
+        #       list from which "sentry-issue-triage" is absent;
+        #   (c) a reflection whose project_key maps to a machine OTHER than the
+        #       one we pass in. (c) is mandatory: filter_reflections_for_machine
+        #       only writes the file back when disabled_names is non-empty
+        #       (tools/reflection_machine_filter.py:145-146), so without it the
+        #       round-trip silently no-ops and this control would prove nothing.
+        _write(
+            registry,
+            f"""
+            {pointer_comment}
+            reflections:
+              - name: cutover-marker
+                every: 60s
+                priority: low
+                execution_type: function
+                callable: x.y
+                enabled: true
+              - name: other-machine-audit
+                every: 3600s
+                priority: high
+                execution_type: function
+                callable: x.z
+                project_key: otherproj
+                enabled: true
+            """,
+        )
+        projects.write_text('{"projects": {"otherproj": {"machine": "Some Other Machine"}}}')
+
+        assert pointer_comment in _read(registry)  # substrate present before the filter
+
+        from tools.reflection_machine_filter import filter_reflections_for_machine
+
+        count, disabled_names = filter_reflections_for_machine(
+            registry, projects, machine_name="This Machine"
+        )
+
+        # Success Criterion 7a — the round-trip actually wrote. Guards against a
+        # silent no-op control, which would make the two assertions below vacuous.
+        assert disabled_names, (
+            "filter_reflections_for_machine disabled nothing, so it never wrote the "
+            "file and the round-trip below is vacuous; the synthetic registry must "
+            "contain a reflection whose project_key maps to another machine"
+        )
+        assert count == len(disabled_names) == 1
+        assert disabled_names == ["other-machine-audit"]
+
+        round_tripped = _read(registry)
+
+        # Success Criterion 6 — negative control for the DELETED assertion style.
+        # A comment-substring assertion placed here would fail.
+        assert pointer_comment not in round_tripped, (
+            "the safe_load/safe_dump round-trip was expected to destroy the pointer "
+            "comment; if it now survives, the comment-based assertions removed from "
+            "the cutover tests could be restored"
+        )
+        assert "#" not in round_tripped  # no comment of any kind survives
+
+        # Success Criterion 7 — positive control for the REPLACEMENT style, against
+        # the SAME round-tripped artifact: parsed structure survives intact.
+        data = yaml.safe_load(round_tripped)
+        names = [r["name"] for r in data["reflections"]]
+        assert names == ["cutover-marker", "other-machine-audit"]
+        assert "sentry-issue-triage" not in names
+        by_name = {r["name"]: r for r in data["reflections"]}
+        assert by_name["cutover-marker"]["enabled"] is True
+        assert by_name["other-machine-audit"]["enabled"] is False
 
 
 class TestNoTempFileLeak:

--- a/tests/unit/test_update_hardlinks.py
+++ b/tests/unit/test_update_hardlinks.py
@@ -20,9 +20,28 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SKILL_ROOTS = (".claude/skills-global", ".claude/skills")
 
 
+# Directories under a skill root that are legitimately not skills. An explicit
+# named allowlist, not a ``_``-prefix rule: an allowlist of one is honest about
+# how thin the evidence for a convention is, and it fails loudly when a second
+# non-skill directory appears instead of silently absorbing it.
+HUSK_GUARD_ALLOWLIST = frozenset({"_shared"})
+
+
+def _skill_is_live(path: Path) -> bool:
+    """True if ``path`` is a live skill, i.e. it holds a ``SKILL.md``.
+
+    Skill liveness is defined by ``SKILL.md`` presence, never by directory
+    existence. A directory whose ``SKILL.md`` was deleted but which still holds
+    a ``__pycache__`` or a stray reference file is a *husk*: the skill is gone,
+    but a bare ``Path.is_dir`` probe still reads True. That blind spot is what let the
+    ``do-skills-audit`` husk survive its own rename (#2557, #2523).
+    """
+    return (path / "SKILL.md").is_file()
+
+
 def _skill_exists_in_any_root(name: str) -> bool:
-    """True if a skill dir ``name`` currently exists under either skill root."""
-    return any((_REPO_ROOT / root / name).is_dir() for root in _SKILL_ROOTS)
+    """True if a live skill ``name`` currently exists under either skill root."""
+    return any(_skill_is_live(_REPO_ROOT / root / name) for root in _SKILL_ROOTS)
 
 
 @pytest.fixture
@@ -410,12 +429,71 @@ def test_renamed_removals_entries_are_not_stale():
     for kind, name in hardlinks.RENAMED_REMOVALS:
         if kind != "skills":
             continue
-        in_global = (_REPO_ROOT / ".claude" / "skills-global" / name).is_dir()
-        in_project = (_REPO_ROOT / ".claude" / "skills" / name).is_dir()
+        in_global = _skill_is_live(_REPO_ROOT / ".claude" / "skills-global" / name)
+        in_project = _skill_is_live(_REPO_ROOT / ".claude" / "skills" / name)
         assert not (in_global and in_project), (
             f"RENAMED_REMOVALS entry ('skills', {name!r}) is stale: the skill is "
             f"live in both .claude/skills-global/ and .claude/skills/ at once"
         )
+
+
+def _find_husk_dirs(root: Path) -> list[Path]:
+    """Directories directly under ``root`` that are husks: not live skills, not allowlisted.
+
+    A missing root yields no husks. ``os.path.isdir`` rather than ``Path.is_dir``
+    is deliberate: it keeps this file free of the ``Path.is_dir`` call spelling, so
+    a whole-file grep for it stays a durable guard that no future directory-existence
+    skill-liveness probe can slip past.
+    """
+    if not os.path.isdir(root):
+        return []
+    return sorted(
+        entry
+        for entry in root.iterdir()
+        if os.path.isdir(entry)
+        and entry.name not in HUSK_GUARD_ALLOWLIST
+        and not _skill_is_live(entry)
+    )
+
+
+def test_no_husk_directories_in_skill_roots():
+    """No skill root holds a husk — a directory with no ``SKILL.md`` (#2557, #2523).
+
+    A husk is what a half-completed skill rename leaves behind: the ``SKILL.md``
+    is deleted but ``__pycache__`` or a stray reference file keeps the directory
+    alive on disk. Nothing observed that class before, because the only probe
+    that could have caught it was itself a directory-existence check.
+    """
+    husks = [h for root in _SKILL_ROOTS for h in _find_husk_dirs(_REPO_ROOT / root)]
+    assert not husks, (
+        "husk directories found in the skill roots (a directory with no SKILL.md "
+        "is a leftover from an incomplete skill rename/deletion — delete it, or "
+        f"add it to HUSK_GUARD_ALLOWLIST if it is an intentional shared resource): "
+        f"{[str(h.relative_to(_REPO_ROOT)) for h in husks]}"
+    )
+
+
+def test_find_husk_dirs_edge_cases(tmp_path):
+    """Empty root, empty ``SKILL.md``, allowlisted dir, and a real husk."""
+    empty_root = tmp_path / "empty"
+    empty_root.mkdir()
+    assert _find_husk_dirs(empty_root) == []
+    assert _find_husk_dirs(tmp_path / "does-not-exist") == []
+
+    root = tmp_path / "skills"
+    # An EMPTY SKILL.md counts as PRESENT: file existence is the contract here,
+    # content validation belongs to the skills audit, not to this guard.
+    (root / "empty-skill-md").mkdir(parents=True)
+    (root / "empty-skill-md" / "SKILL.md").write_text("")
+    (root / "live").mkdir()
+    (root / "live" / "SKILL.md").write_text("# live\n")
+    (root / "_shared").mkdir()  # allowlisted, no SKILL.md
+    (root / "_shared" / "test-quality.md").write_text("x")
+    (root / "husk").mkdir()
+    (root / "husk" / "leftover.txt").write_text("x")
+    (root / "loose-file.md").write_text("not a directory")
+
+    assert [d.name for d in _find_husk_dirs(root)] == ["husk"]
 
 
 def test_renamed_removals_covers_deleted_skills():

--- a/tests/unit/test_update_hardlinks.py
+++ b/tests/unit/test_update_hardlinks.py
@@ -440,19 +440,15 @@ def test_renamed_removals_entries_are_not_stale():
 def _find_husk_dirs(root: Path) -> list[Path]:
     """Directories directly under ``root`` that are husks: not live skills, not allowlisted.
 
-    A missing root yields no husks. ``os.path.isdir`` rather than ``Path.is_dir``
-    is deliberate: it keeps this file free of the ``Path.is_dir`` call spelling, so
-    a whole-file grep for it stays a durable guard that no future directory-existence
-    skill-liveness probe can slip past.
+    A missing root yields no husks. The ``is_dir`` calls here filter directory
+    entries; skill *liveness* is decided solely by ``_skill_is_live`` (#2557).
     """
-    if not os.path.isdir(root):
+    if not root.is_dir():
         return []
     return sorted(
         entry
         for entry in root.iterdir()
-        if os.path.isdir(entry)
-        and entry.name not in HUSK_GUARD_ALLOWLIST
-        and not _skill_is_live(entry)
+        if entry.is_dir() and entry.name not in HUSK_GUARD_ALLOWLIST and not _skill_is_live(entry)
     )
 
 


### PR DESCRIPTION
## Summary

Repairs four independent defects that break the relationship between "the suite is green" and "the code is correct". Two produced false reds, two produced false greens. Every guard added here ships with a negative control proving it can fail.

Plan: `docs/plans/wave2-test-instrument.md`

## What changed

**#2552 — catchup kill-switch isolation.** An autouse `isolate_catchup_kill_switch` fixture in `tests/conftest.py` repoints `bridge.catchup.CATCHUP_DISABLED_FLAG` at a per-test tmp path. All three production readers import that one symbol, so patching it covers every reader. The flag is *repointed, not stubbed* — `catchup_disabled()` still runs its real `Path.exists()`, so a test that wants disabled behavior can `touch` the redirected path. `CATCHUP_FLAG_ISOLATION=0` is a documented escape hatch that keeps the negative control permanently reproducible.

No file under `bridge/` was changed. The source-tree anchor is correct for production (the bridge runs under launchd with an unpredictable cwd); the defect is that tests read operator control state, and the fix belongs in the tests.

**#2553 — field-contract drift guard.** Deleted the stale `"expectations"` assertion (`df6097fe6` removed that field). Added `TestAgentSessionFieldContractDrift` with two guards: a phantom-name guard (every name in `_AGENT_SESSION_FIELDS` exists on the model) and a `KNOWN_GAP` set-*equality* guard recording the 50 model fields the list does not carry, with a pointer to #2563 as its termination condition. `_AGENT_SESSION_FIELDS` itself is untouched — the guard is added, the list is not edited.

The left-hand set excludes `AutoKeyField`s programmatically (`isinstance(f, AutoKeyField)`), never by subtracting a literal `{"id"}`, so a second auto-key field added later cannot silently reopen the same off-by-one. The 50 names were generated at build time from the exclusion-filtered diff, not transcribed.

**#2556 — durable cutover signal.** Both comment-substring assertions are gone; `tools/reflection_machine_filter.py`'s `safe_load`/`safe_dump` round-trip destroys YAML comments, so those tests were a latent red masquerading as a stable green. The structural assertions (against parsed YAML) remain and now name the contract they protect. A new `TestFilterRoundTripSignalDurability` regression test runs the filter over a synthetic `tmp_path` registry seeded with an other-machine `project_key` (required, or `filter_reflections_for_machine` no-ops and the control proves nothing) and asserts, against the same round-tripped artifact: the write happened, the comment is gone, the structural signal survived. The real `config/reflections.yaml` is never read or written.

**#2557 / #2523 — skill liveness probe.** All three `.is_dir()` liveness probes become `SKILL.md` presence. The uncited one at `:25` is the consequential one: it let `test_renamed_removals_covers_deleted_skills` excuse a deleted skill from needing a `RENAMED_REMOVALS` entry whenever a husk kept the directory readable — a false *pass*. A new `test_no_husk_directories_in_skill_roots` fails while any directory in either skill root lacks `SKILL.md`, gated by an explicit `HUSK_GUARD_ALLOWLIST = frozenset({"_shared"})` rather than an underscore-prefix rule.

## Acceptance evidence

Baseline (main checkout, serial, 7 focused files): **18 failed / 120 passed**. Post-fix: **141 passed, 2 skipped, 0 failed**.

| # | Criterion | Result |
|---|---|---|
| 1 | 17 flag-caused failures green | 141 passed, 2 skipped, 0 failed |
| 2 | **Negative control #2552** — fixture disabled, flag present | 17 failed, distribution 2/13/2 across `test_agent_catchup`/`test_reconciler`/`test_catchup_claim`, matching the baseline node list exactly. Reproduced independently by the orchestrator. |
| 3 | `grep -c '"expectations"' tests/unit/test_pipeline_integrity.py` | 0 |
| 4 | **Negative control** — bogus name appended in-memory | `AssertionError: _AGENT_SESSION_FIELDS names field(s) that no longer exist on AgentSession: ['bogus_phantom_field_xyz']` |
| 5 | **Negative control** — one name removed from `KNOWN_GAP` | `AssertionError: AgentSession field coverage drifted. Unclassified field(s) ...: ['worker_pid']` |
| 6, 7, 7a | **Negative + positive control #2556** — comment destroyed, structure survives, write confirmed | `TestFilterRoundTripSignalDurability` passes; all three assertions against the same round-tripped artifact |
| 8 | **Negative control** — temp husk dir | `AssertionError: husk directories found in the skill roots ...: ['.claude/skills/zz-orchestrator-husk-check']`. Reproduced independently by the orchestrator. |
| 9 | Husk swept | `.claude/skills-global/do-skills-audit` absent in both checkouts |
| 10 | `_shared` not swept | `.claude/skills/_shared/test-quality.md` present |
| 11 | All three former `.is_dir()` liveness sites route through `_skill_is_live` (a `SKILL.md` file check) | 3/3; no liveness decision reads directory existence |
| 12 | **Anti-criterion** — `git diff --name-only origin/main -- bridge/` | empty |
| 13 | **Anti-criterion** — `git diff origin/main -- agent/agent_session_queue.py` | empty |
| 14 | **Anti-criterion** — `data/catchup-disabled` | present, 0 bytes, mtime unchanged (Jul 22 13:45) |
| 15 | `ruff check` / `ruff format --check` | clean |

Measurement confirming the plan's arithmetic: `AgentSession._meta.fields` = 89 entries, 88 non-`AutoKeyField`, `_AGENT_SESSION_FIELDS` = 38, phantom names = 0, `KNOWN_GAP` = 50.

## Reviewer notes

- **The husk sweep produces no diff.** `.claude/skills-global/do-skills-audit/` is fully untracked, so its deletion is invisible here. It was a host-local operation on the main checkout (it never materialized in the worktree). The reviewable, durable artifact is the husk guard, which fails on any machine still carrying a husk. Verify with `test -e .claude/skills-global/do-skills-audit`.
- **Success Criterion 11 was corrected rather than satisfied.** The first build spelled `_find_husk_dirs` with `os.path.isdir` purely so a whole-file `grep -c 'is_dir()'` would keep returning zero. That is code bending to a bad measurement, in a PR about measurements that lie. Those calls filter directory entries and are not liveness probes at all, so the criterion was wrong, not the code. `e90a554d7` restored the natural `Path.is_dir` spelling and the criterion was amended on `main` (`6cd27be71`) to assert what matters: that all three former liveness sites route through a single `_skill_is_live` helper. The file now contains no `os.path` call at all.
- **Two skips in the focused run** are the existing cutover tests, which skip in a worktree because `config/reflections.yaml` is machine-local and gitignored. Their strengthened structural assertions are therefore not exercised from a worktree; the new `tmp_path` test is what carries real coverage, which is why it was added.
- Full-suite verification of the autouse fixture's blast radius is deliberately deferred — this host's full-suite slot is occupied by a diagnostic run. No test in the tree references `CATCHUP_DISABLED_FLAG` or `catchup_disabled` (verified by grep), so the fixture has no test that wants the flag set.

## Out of scope

- **#2563** — the `_extract_agent_session_fields` two-contract conflict and closing the 50-field gap. Production semantics change inside the #2518 fence blast radius; five of the six fields the original issue named are fenced-execution-record fields, and copying them into a newly created session would forge a fence describing a process that never ran.
- **#2473** — the fate of the production `data/catchup-disabled` flag. Operator-gated state.

Closes #2552
Closes #2553
Closes #2556
Closes #2557
Closes #2523


## Post-review patch (both review findings addressed)

Review verdict was Changes Requested — Tech Debt, no blockers. Both items are fixed.

**1. PR body accuracy.** Acceptance row 11 and the `os.path.isdir` reviewer note described code that `e90a554d7` had already removed. Both are corrected above.

**2. Quadratic cost in the autouse fixture** (`7f663d646`). The reviewer measured that `tmp_path_factory.mktemp` is numbered, so it scans the basetemp for the next free suffix and its cost grows with the directory count — 0.15s at 500 directories, 3.34s at 3000. Calling it once per test from a suite-wide autouse fixture made the aggregate quadratic and left one empty directory per test. The directory is now created once at session scope and only the *filename* varies per test, which costs a string format and no filesystem write.

Isolation is unchanged and re-verified after the refactor: each test still gets a path no other test can touch, `catchup_disabled()` still runs a real `Path.exists()`, the focused acceptance run is still **141 passed / 2 skipped / 0 failed**, and the `CATCHUP_FLAG_ISOLATION=0` negative control still reproduces exactly **17 failed / 40 passed** in the 2/13/2 distribution. Ruff clean. The production `data/catchup-disabled` remains 0 bytes at its original Jul 22 13:45 mtime.


### Exact commands behind every number in this PR

Listed so a reviewer reproduces the same thing rather than inferring it. All run from the worktree `.worktrees/wave2-test-instrument` at head `7f663d646`.

Focused acceptance (**141 passed, 2 skipped, 0 failed**):

```
./scripts/pytest-clean.sh -n0 -q --no-header -p no:randomly \
  tests/unit/test_agent_catchup.py tests/unit/test_reconciler.py \
  tests/unit/test_catchup_claim.py tests/unit/test_dedup.py \
  tests/unit/test_pipeline_integrity.py tests/unit/test_reflections_yaml_migration.py \
  tests/unit/test_update_hardlinks.py
```

#2552 negative control (**17 failed, 40 passed**, distribution 2 / 13 / 2). Requires the kill-switch flag to exist in the checkout the run starts from; `data/catchup-disabled` is gitignored, so create it in the worktree and remove it afterwards. Do **not** touch the main checkout's copy — it is operator state tracked in #2473.

```
touch data/catchup-disabled
CATCHUP_FLAG_ISOLATION=0 ./scripts/pytest-clean.sh -n0 -q --no-header -p no:randomly \
  tests/unit/test_agent_catchup.py tests/unit/test_reconciler.py tests/unit/test_catchup_claim.py
rm -f data/catchup-disabled
```

Field-drift arithmetic (89 total / 88 non-auto / 38 listed / `KNOWN_GAP` 50 / 0 phantoms):

```
.venv/bin/python -c "
from popoto import AutoKeyField
from models.agent_session import AgentSession
import agent.agent_session_queue as q
m = AgentSession._meta
nonauto = {n for n, f in m.fields.items() if not isinstance(f, AutoKeyField)}
print(len(m.fields), len(nonauto), len(q._AGENT_SESSION_FIELDS),
      len(nonauto - set(q._AGENT_SESSION_FIELDS)),
      sorted(set(q._AGENT_SESSION_FIELDS) - set(m.fields)))
"
```

Lint: `.venv/bin/python -m ruff check .` and `.venv/bin/python -m ruff format --check .`

### Full-suite status: attempted, wedged, NOT claimed as evidence

A full `tests/unit/` run at this head was ordered and attempted. It reached 99%, printed `[gw5] node down: Not properly terminated`, and stalled with the controller alive at 0% CPU and all xdist workers gone. It never reached the `-rf` summary, so there is no node list and no comparison against the canonical 35-failure baseline in `/tmp/unit-main-baseline.log`.

Recording it here as an open item rather than omitting it: **this PR does not currently carry full-suite evidence.** Memory was 91% free and no crash report was produced, so the worker did not die of resource exhaustion, but the diff ships a suite-wide autouse fixture and that is exactly the blast radius a full run exists to probe — so the wedge is not being attributed to anything until a second run says so.
