### PR TITLE
Validate that a project's owning machine exists (#2541)

### DIFF
--- a/bridge/config_validation.py
+++ b/bridge/config_validation.py
@@ -13,6 +13,8 @@ by the update script as a green-light gate before service restart.
 
 from __future__ import annotations
 
+from config.machine import normalize_machine_name
+
 
 class ConfigValidationError(RuntimeError):
     """Raised when projects.json fails validation. Update script blocks restart."""
@@ -390,6 +392,138 @@ async def validate_bot_live_flags(config: dict, resolver) -> tuple[set[int], str
     return (quarantine_ids, detail)
 
 
+def declared_machines(config: dict) -> dict[str, str]:
+    """Return the declared fleet roster as ``{normalized_name: as_written}``.
+
+    The roster is the top-level ``machines`` block of ``projects.json``. It
+    accepts either a list of ComputerNames or a dict keyed by ComputerName
+    (values are free-form operator notes), so an operator can annotate a host
+    without changing the shape the validator reads.
+
+    An absent or malformed block yields ``{}``, which
+    :func:`validate_machine_roster` reads as "no roster declared".
+    """
+    raw = config.get("machines")
+    if isinstance(raw, dict):
+        names = list(raw.keys())
+    elif isinstance(raw, list):
+        names = [n for n in raw if isinstance(n, str)]
+    else:
+        return {}
+    return {normalize_machine_name(n): n for n in names if normalize_machine_name(n)}
+
+
+def project_owners(config: dict) -> dict[str, list[str]]:
+    """Return ``{normalized_owner_name: [project_key, ...]}`` for every owned project.
+
+    Projects with a missing or blank ``machine`` are omitted; the per-shape
+    validators already fail those when they declare any bridge identifier.
+    """
+    owners: dict[str, list[str]] = {}
+    for proj_key, proj_cfg in config.get("projects", {}).items():
+        if not isinstance(proj_cfg, dict):
+            continue
+        normalized = normalize_machine_name(proj_cfg.get("machine"))
+        if normalized:
+            owners.setdefault(normalized, []).append(proj_key)
+    return owners
+
+
+def validate_machine_roster(config: dict) -> None:
+    """Enforce that every project owner names a machine the fleet actually has.
+
+    The per-shape validators prove each identifier has *exactly one* owner. They
+    never prove that owner **exists**, so a project can name a host that was
+    decommissioned, renamed, or typo'd and validation passes — leaving the
+    project unowned, its traffic picked up by nobody, and no error anywhere
+    (issue #2541).
+
+    "Exists" is answered by the config itself: the top-level ``machines`` roster
+    lists the fleet's ComputerNames. Ownership is checked against that roster
+    under :func:`config.machine.normalize_machine_name`, so a curly-vs-straight
+    apostrophe cannot unown a live host.
+
+    When no roster is declared the check is skipped rather than guessed at: a
+    single host cannot see the fleet, and inventing a roster from the config's
+    own owner set would only ever confirm itself. The operator learns the roster
+    is missing from the ownership summary that ``/update`` prints on every run
+    (:func:`summarize_ownership`).
+
+    Raises:
+        ConfigValidationError: if any project names a machine outside the roster.
+    """
+    roster = declared_machines(config)
+    if not roster:
+        return
+
+    errors: list[str] = []
+    for normalized, proj_keys in sorted(project_owners(config).items()):
+        if normalized in roster:
+            continue
+        as_written = next(
+            (
+                config["projects"][k].get("machine")
+                for k in proj_keys
+                if isinstance(config["projects"].get(k), dict)
+            ),
+            normalized,
+        )
+        errors.append(
+            f"projects {sorted(proj_keys)} are owned by '{as_written}', which is not in "
+            f"the machines roster {sorted(roster.values())} — those projects are unowned "
+            f"and no bridge will answer their traffic"
+        )
+
+    if errors:
+        raise ConfigValidationError(
+            "projects.json machine ownership failed validation:\n  - " + "\n  - ".join(errors)
+        )
+
+
+def summarize_ownership(config: dict, this_machine: str) -> str:
+    """Render the human-facing ownership report ``/update`` prints on every run.
+
+    Names this host, the projects it claims, the other owners in the config, and
+    whether a roster is declared. Silence is what let a three-week-stale config
+    route twenty projects at a sold laptop; this is the line that makes the
+    current ownership state visible without anyone going looking for it.
+    """
+    roster = declared_machines(config)
+    owners = project_owners(config)
+    me = normalize_machine_name(this_machine)
+
+    lines: list[str] = []
+    mine = sorted(owners.get(me, []))
+    label = this_machine or "unresolved ComputerName"
+    if mine:
+        lines.append(f"this host ({label}) claims {len(mine)} project(s): {', '.join(mine)}")
+    else:
+        lines.append(
+            f"this host ({label}) claims NO projects — every incoming message for "
+            f"this machine's contacts will be handled by some other host, or by nobody"
+        )
+
+    others = {k: v for k, v in owners.items() if k != me}
+    if others:
+        rendered = ", ".join(
+            f"{name} ({len(keys)})" for name, keys in sorted((k, v) for k, v in others.items())
+        )
+        lines.append(f"other owners in config: {rendered}")
+
+    if roster:
+        idle = sorted(roster[n] for n in roster if n not in owners)
+        lines.append(f"machines roster: {', '.join(sorted(roster.values()))}")
+        if idle:
+            lines.append(f"roster hosts owning nothing: {', '.join(idle)}")
+    else:
+        lines.append(
+            "no 'machines' roster declared — owner names are unverifiable; add a "
+            'top-level "machines" list to projects.json to make a decommissioned '
+            "or typo'd owner a hard validation failure (#2541)"
+        )
+    return "\n".join(lines)
+
+
 # NOTE (plan #1924): the per-project ``transport`` block is no longer
 # validated — there is one execution transport (headless ``claude -p``) and
 # no seam. Stale ``transport`` keys still present in a not-yet-migrated
@@ -401,9 +535,9 @@ def validate_projects_config(config: dict) -> None:
     """Run the full bridge-contact ownership validation suite.
 
     Aggregates errors from every shape (DM whitelist, Telegram groups,
-    email routing, bot registry) into a single ConfigValidationError so the
-    operator sees every problem at once instead of fixing them one round-trip
-    at a time.
+    email routing, bot registry, machine roster) into a single
+    ConfigValidationError so the operator sees every problem at once instead of
+    fixing them one round-trip at a time.
     """
     errors: list[str] = []
     for fn in (
@@ -411,6 +545,7 @@ def validate_projects_config(config: dict) -> None:
         validate_telegram_groups,
         validate_email_routing,
         validate_telegram_bots,
+        validate_machine_roster,
     ):
         try:
             fn(config)

--- a/config/machine.py
+++ b/config/machine.py
@@ -49,6 +49,30 @@ logger = logging.getLogger(__name__)
 # tight budget (e.g. the calendar hook). Provisional/tunable — grain of salt.
 _SCUTIL_TIMEOUT_SECONDS = 5
 
+# Apostrophe variants that macOS and hand-edited JSON disagree about. A default
+# macOS ComputerName like "Tom’s MacBook Air" carries U+2019 (RIGHT SINGLE
+# QUOTATION MARK); someone typing the same name into projects.json produces
+# U+0027. Both spell the same machine, so ownership matching folds them to one
+# form before comparing (issue #2541).
+_APOSTROPHE_VARIANTS = "’‘ʼ´`"
+
+
+def normalize_machine_name(name: str | None) -> str:
+    """Fold a machine name to its comparison form: casefolded, apostrophes unified.
+
+    Ownership matching compares a ``projects.<key>.machine`` string against a
+    macOS ComputerName. Those two values are authored in different places and
+    routinely disagree on apostrophe encoding, which silently unowns a project
+    on a machine that is very much alive. Normalizing both sides makes an
+    encoding difference stop being a routing decision.
+    """
+    if not name:
+        return ""
+    folded = name.strip().casefold()
+    for variant in _APOSTROPHE_VARIANTS:
+        folded = folded.replace(variant, "'")
+    return folded
+
 
 def get_machine_name() -> str:
     """Return this machine's macOS ComputerName via ``scutil``; ``""`` on failure.
@@ -116,7 +140,8 @@ def get_machine_project_keys(machine: str | None = None) -> list[str]:
     """Return the ``project_key``s this machine owns in ``projects.json``.
 
     Reads ``VALOR_DIR / "projects.json"`` and returns every key whose
-    ``projects.<key>.machine`` field matches ``machine`` (case-insensitive).
+    ``projects.<key>.machine`` field matches ``machine`` under
+    :func:`normalize_machine_name` (case-insensitive, apostrophe-insensitive).
     When ``machine`` is ``None`` it resolves via :func:`get_machine_name`; a
     caller that already resolved the name can pass it to avoid a second
     ``scutil`` call.
@@ -134,9 +159,9 @@ def get_machine_project_keys(machine: str | None = None) -> list[str]:
         config = json.loads((VALOR_DIR / "projects.json").read_text())
     except Exception:
         return []
-    machine_lower = machine.lower()
+    target = normalize_machine_name(machine)
     return [
         project_key
         for project_key, project in config.get("projects", {}).items()
-        if project.get("machine", "").lower() == machine_lower
+        if normalize_machine_name(project.get("machine", "")) == target
     ]

--- a/config/projects.example.json
+++ b/config/projects.example.json
@@ -14,7 +14,7 @@
 
   "machines": {
     "Machine Name": "Primary bridge host",
-    "Valor the Cowboy": "Second bridge host"
+    "Another Machine Name": "Second bridge host"
   },
 
   "personas": {

--- a/config/projects.example.json
+++ b/config/projects.example.json
@@ -3,12 +3,18 @@
   "_doc": {
     "overview": "Shared config for all Valor machines (iCloud-synced via ~/Desktop/Valor/). Each machine reads this file and filters projects by the 'machine' field matched against its ComputerName (scutil --get ComputerName).",
     "personas": "Define overlay file paths and permissions for each role. The bridge loads composable segments + persona overlay as the system prompt.",
-    "projects.machine": "Must match the machine's ComputerName exactly (case-insensitive). This is how each machine knows which projects to handle.",
+    "machines": "The fleet roster: every ComputerName that runs a bridge, optionally with an operator note. Validation rejects any projects.<key>.machine outside this roster, so a decommissioned or typo'd owner becomes a hard failure instead of a silently unowned project (#2541). Omit the block to skip the check; /update then reports on every run that owner names are unverifiable.",
+    "projects.machine": "Must match the machine's ComputerName (case-insensitive, apostrophe-insensitive — macOS writes U+2019 in a default name like \"Tom's MacBook Air\"). This is how each machine knows which projects to handle.",
     "projects.telegram.groups": "Dict mapping group name to persona. Eng: prefix = engineer (full permissions, SDLC work + conversational), no prefix = teammate (mention-only).",
     "projects.telegram.groups.chat_id": "Optional Telegram chat ID. Speeds up group resolution but not required.",
     "projects.telegram.bots": "Optional (issue #1574). Registry of bot peers for E2E testing via 'valor-telegram send --await-reply'. A registered bot's inbound messages are recorded to history but NEVER spawn a session (deterministic loop-guard). Each id must NOT also appear in dms.whitelist (config validation rejects the overlap). settle_profile tunes the awaiter's debounce.",
     "dms": "Global DM config. All DMs use the specified persona regardless of project.",
     "defaults": "Fallback values for projects that don't specify a field."
+  },
+
+  "machines": {
+    "Machine Name": "Primary bridge host",
+    "Valor the Cowboy": "Second bridge host"
   },
 
   "personas": {

--- a/docs/features/single-machine-ownership.md
+++ b/docs/features/single-machine-ownership.md
@@ -20,6 +20,33 @@ Registered bot ids carry an extra rule on top of single-machine ownership: a bot
 
 For each shape, the validator verifies the identifier resolves to exactly one machine across the *entire* config — not just the per-machine subset. Misconfiguration is caught the same way on every machine, even if the conflicting projects are owned by different machines.
 
+## The fleet roster
+
+`projects.<key>.machine` says *who* owns a project. The top-level `machines` block says *which owners exist*:
+
+```json
+"machines": {
+  "Valor the Cowboy": "Primary bridge host",
+  "Valor the Captain": "Second bridge host"
+}
+```
+
+A list of names works too; the dict form just lets an operator annotate a host. Every project's `machine` must resolve to a roster entry or validation fails, naming the projects that would be left unowned. Without the roster, "exactly one owner" is provable but "that owner exists" is not, and a project can point at a decommissioned, renamed, or typo'd host while validation passes and nobody answers its traffic (issue #2541).
+
+When the block is absent the existence check is skipped rather than guessed at. A single host cannot see the fleet, and deriving a roster from the config's own owner set would only ever confirm itself. `/update` reports the missing roster on every run so the gap stays visible.
+
+## Ownership reporting
+
+`/update` prints the ownership state on every run, pass or fail, before the Step 4.6 verdict:
+
+```
+  ownership: this host (Valor the Cowboy) claims 12 project(s): ai-skills, popoto, valor, ...
+  ownership: other owners in config: valor the captain (8)
+  ownership: machines roster: Valor the Captain, Valor the Cowboy
+```
+
+A host that owns nothing gets an explicit line saying so, as do roster hosts that own nothing. Silence is what let twenty projects stay pointed at a laptop that had been wiped and sold for three weeks.
+
 ## How ownership is derived
 
 `projects.<key>.machine` is the single source of truth. Every other ownership decision inherits from it:
@@ -45,9 +72,10 @@ Adding a new machine costs zero edits to existing whitelist entries, group decla
 
 Four functions, each fail-soft (never raises on a read failure):
 
+- **`normalize_machine_name(name) -> str`** — the comparison form: stripped, casefolded, and with every apostrophe variant (`’ ‘ ʼ ´ \``) folded to `'`. macOS returns `Tom’s MacBook Air` (U+2019) from `scutil`, while the same name hand-typed into `projects.json` carries U+0027; both spell one machine, so every ownership comparison folds both sides first. An encoding difference is not a routing decision (issue #2541).
 - **`get_machine_name() -> str`** — stripped `scutil --get ComputerName`, `""` on any failure. It deliberately has **no** `platform.node()` fallback: the `""` is the "unknown host → do not match / skip" signal the ownership and README-check consumers depend on. A fallback here would let an unresolved host silently match a `"machine": ""` entry.
 - **`get_machine_slug() -> str`** — filesystem-safe, guaranteed **non-empty** variant (lowercased, spaces→hyphens, with a `platform.node()` fallback) used for per-machine token filenames (`tools/google_workspace/auth.py`), where an empty slug would collapse every host's token onto one path.
-- **`get_machine_project_keys(machine=None) -> list[str]`** — case-insensitive match of each `projects.<key>.machine`, `[]` on any read failure. Applies the **empty-machine fail-to-development guard** (#1834): an unresolved `machine` (`""`) returns `[]` before any file read, so it can never mis-tag a dev/misconfigured host as an owner. `monitoring/sentry_config.py::_owned_project_key` is a thin first-or-`None` adapter over it.
+- **`get_machine_project_keys(machine=None) -> list[str]`** — `normalize_machine_name` match of each `projects.<key>.machine`, `[]` on any read failure. Applies the **empty-machine fail-to-development guard** (#1834): an unresolved `machine` (`""`) returns `[]` before any file read, so it can never mis-tag a dev/misconfigured host as an owner. `monitoring/sentry_config.py::_owned_project_key` is a thin first-or-`None` adapter over it.
 - **`get_machine_display_name() -> str`** — human-facing label with a ComputerName → OS hostname → `"unknown"` fallback chain, for triage stamps, issue bodies, and `/update` replies (e.g. `reflections/docs_auditor.py`, `bridge/update.py`). Never use it for ownership matching — the hostname fallback is a different identifier than the `machine` field. `get_machine_slug()` slugifies this chain when the ComputerName is unresolved, which is what makes its non-empty guarantee real.
 
 Note: `scripts/update/readme_check.py` reads the **repo-local** `config/projects.json` (different shape, with `working_directory`), so it borrows only `get_machine_name()`, not the project-key logic.
@@ -62,6 +90,7 @@ Note: `scripts/update/readme_check.py` reads the **repo-local** `config/projects
 4. **Email domain conflicts** — same domain on two machines (case-insensitive; `*.foo.com`, `@foo.com`, and `foo.com` collapse to the same key)
 5. **Cross-shape email conflicts** — an explicit contact `alice@psy.com` on machine A while machine B owns the `psy.com` domain wildcard (the wildcard would steal the message)
 6. **Project missing `machine`** — a project that declares any bridge contact but no `machine` field
+7. **Owner outside the roster** — a project whose `machine` names a host absent from the top-level `machines` block (skipped when no roster is declared)
 
 Plus structural checks: every whitelist entry must declare a `project`, every referenced project must exist, and every machine field must be non-empty.
 
@@ -102,7 +131,7 @@ See [Subconscious Memory — Project Key Partitioning](subconscious-memory.md#pr
 ## Adding a new machine
 
 1. On the new machine, set `ComputerName` (System Settings → Sharing) to a name like `Valor the {Animal}`.
-2. In `<vault>/projects.json` (where `<vault>` is your configured vault directory — see `VALOR_VAULT_DIR`; default `~/Desktop/Valor/`), set `projects.<key>.machine = "Valor the {Animal}"` for each project this machine should own. Propagate the change to every other machine using whatever sync mechanism your vault uses (iCloud for Desktop/Documents vaults, manual copy for `~/.valor/`, etc.).
+2. Add that name to the top-level `machines` roster in `<vault>/projects.json`. In the same file (where `<vault>` is your configured vault directory — see `VALOR_VAULT_DIR`; default `~/Desktop/Valor/`), set `projects.<key>.machine = "Valor the {Animal}"` for each project this machine should own. Propagate the change to every other machine using whatever sync mechanism your vault uses (iCloud for Desktop/Documents vaults, manual copy for `~/.valor/`, etc.).
 3. Run `/update` (or wait for the launchd cron). The update script validates `projects.json` before bouncing the bridge. On the new machine, the bridge starts owning the moved projects; on the old machine, the next update cycle drops them from `ACTIVE_PROJECTS` and the bridge stops responding to those groups/contacts.
 4. There is nothing to edit in `dms.whitelist`, `telegram.groups`, `email.contacts`, or `email.domains` — they all inherit from `projects.<key>.machine`.
 
@@ -114,12 +143,14 @@ See [Subconscious Memory — Project Key Partitioning](subconscious-memory.md#pr
 | Same group on two projects on different machines | `/update` logs `telegram group 'name' is declared on multiple machines [...]` | Move the group to a single project, or change one project's `machine` field |
 | Email contact + overlapping domain wildcard on different machines | `/update` logs `email contact 'x@y.com' (machines [...]) overlaps with domain 'y.com' wildcard (machines [...])` | Move the explicit contact onto the domain owner's project, or split the domain |
 | Project declares bridge contacts but no `machine` | `/update` logs `project 'X' declares ... but has no 'machine' field` | Set the `machine` field on the project |
+| Project owned by a host that no longer exists | `/update` logs `projects [...] are owned by 'X', which is not in the machines roster [...]`; restart is skipped | Reassign those projects to a live host, or add the host to `machines` |
+| This host owns nothing | `/update` logs `this host (X) claims NO projects` | Confirm the host's ComputerName matches what `projects.json` says, then reassign |
 
 In every case, the running bridge keeps serving until the operator fixes the config and re-runs the update.
 
 ## Test coverage
 
-`tests/unit/test_dm_whitelist_validation.py` covers all four identifier shapes, case-insensitivity, the cross-shape email-vs-domain check, the aggregated `validate_projects_config` report, and the live-config validation against `~/Desktop/Valor/projects.json`. 25 cases, run on every CI cycle.
+`tests/unit/test_dm_whitelist_validation.py` covers all four identifier shapes, case-insensitivity, the cross-shape email-vs-domain check, the roster existence check (unknown owner, apostrophe-split owner, and a valid config as negative control), the ownership summary, the aggregated `validate_projects_config` report, and the live-config validation against `~/Desktop/Valor/projects.json`. `tests/unit/test_config_machine.py` covers `normalize_machine_name` and apostrophe-insensitive project-key matching.
 
 ## Related
 

--- a/scripts/update/run.py
+++ b/scripts/update/run.py
@@ -1401,6 +1401,11 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
     if config.do_service_restart and machine_check.get("projects"):
         log("Validating projects.json...", v)
         result.projects_json_check = verify.check_projects_json(project_dir)
+        # Ownership is reported on every run, pass or fail (#2541). Three weeks
+        # of silence is what let twenty projects stay pointed at a sold laptop.
+        if result.projects_json_check.detail:
+            for line in result.projects_json_check.detail.splitlines():
+                log(f"  ownership: {line}", v, always=True)
         if result.projects_json_check.available:
             log(f"  projects.json: {result.projects_json_check.version}", v)
         else:

--- a/scripts/update/verify.py
+++ b/scripts/update/verify.py
@@ -39,6 +39,9 @@ class ToolCheck:
     available: bool
     version: str | None = None
     error: str | None = None
+    # Multi-line operator-facing context printed even on a passing check.
+    # Used by check_projects_json to report machine ownership every run (#2541).
+    detail: str | None = None
 
 
 @dataclass
@@ -1183,8 +1186,10 @@ def check_projects_json(project_dir: Path) -> ToolCheck:
     try:
         from bridge.config_validation import (
             ConfigValidationError,
+            summarize_ownership,
             validate_projects_config,
         )
+        from config.machine import get_machine_name
     except ImportError as e:
         return ToolCheck(
             name="projects.json",
@@ -1192,10 +1197,12 @@ def check_projects_json(project_dir: Path) -> ToolCheck:
             error=f"Could not import validator: {e}",
         )
 
+    ownership = summarize_ownership(cfg, get_machine_name())
+
     try:
         validate_projects_config(cfg)
     except ConfigValidationError as e:
-        return ToolCheck(name="projects.json", available=False, error=str(e))
+        return ToolCheck(name="projects.json", available=False, error=str(e), detail=ownership)
 
     projects = cfg.get("projects", {})
     whitelist_count = len(cfg.get("dms", {}).get("whitelist", []))
@@ -1217,6 +1224,7 @@ def check_projects_json(project_dir: Path) -> ToolCheck:
             f"valid ({whitelist_count} DM contacts, "
             f"{group_count} groups, {email_count} email patterns)"
         ),
+        detail=ownership,
     )
 
 

--- a/tests/unit/test_config_machine.py
+++ b/tests/unit/test_config_machine.py
@@ -137,3 +137,33 @@ def test_get_machine_project_keys_malformed_json_returns_empty(tmp_path, monkeyp
     (tmp_path / "projects.json").write_text("{not valid json")
     monkeypatch.setattr(machine, "VALOR_DIR", tmp_path)
     assert machine.get_machine_project_keys("Prod-Box") == []
+
+
+# --- normalize_machine_name (issue #2541) ------------------------------------
+
+
+def test_normalize_machine_name_folds_apostrophe_variants():
+    """macOS writes U+2019; a hand-typed projects.json writes U+0027."""
+    curly = machine.normalize_machine_name("Tom’s MacBook Air")
+    straight = machine.normalize_machine_name("Tom's MacBook Air")
+    assert curly == straight == "tom's macbook air"
+
+
+def test_normalize_machine_name_strips_and_casefolds():
+    assert machine.normalize_machine_name("  Valor the Cowboy  ") == "valor the cowboy"
+
+
+def test_normalize_machine_name_empty_inputs():
+    assert machine.normalize_machine_name("") == ""
+    assert machine.normalize_machine_name(None) == ""
+
+
+def test_get_machine_project_keys_apostrophe_insensitive_match(tmp_path, monkeypatch):
+    """A live host must match its own name across apostrophe encodings (#2541)."""
+    _write_projects(
+        tmp_path,
+        monkeypatch,
+        {"projects": {"p1": {"machine": "Tom’s MacBook Air"}}},
+    )
+    assert machine.get_machine_project_keys("Tom's MacBook Air") == ["p1"]
+    assert machine.get_machine_project_keys("Tom’s MacBook Air") == ["p1"]

--- a/tests/unit/test_dm_whitelist_validation.py
+++ b/tests/unit/test_dm_whitelist_validation.py
@@ -1,4 +1,4 @@
-"""Tests for bridge.config_validation: dm whitelist + groups + email routing."""
+"""Tests for bridge.config_validation: dm whitelist, groups, email, bots, roster."""
 
 from __future__ import annotations
 
@@ -8,13 +8,16 @@ import pytest
 
 from bridge.config_validation import (
     ConfigValidationError,
+    summarize_ownership,
     validate_bot_live_flags,
     validate_dm_whitelist,
     validate_email_routing,
+    validate_machine_roster,
     validate_projects_config,
     validate_telegram_bots,
     validate_telegram_groups,
 )
+from config.machine import normalize_machine_name
 
 
 def _make_config(whitelist: list, projects: dict | None = None) -> dict:
@@ -597,3 +600,127 @@ async def test_live_flag_probe_failure_not_quarantined():
     assert detail is not None
     assert str(failing_id) in detail
     assert "could not probe" in detail
+
+
+# ---------------------------------------------------------------------------
+# validate_machine_roster — owner existence (issue #2541)
+# ---------------------------------------------------------------------------
+
+
+def test_no_roster_skips_the_existence_check():
+    """Without a declared roster the check is skipped, not guessed at.
+
+    One host cannot see the fleet, and deriving a roster from the config's own
+    owner set would only ever confirm itself. The operator learns the roster is
+    missing from the ownership summary instead.
+    """
+    cfg = {"projects": {"ghost": {"machine": "A Machine That Never Existed"}}}
+    validate_machine_roster(cfg)
+    assert "no 'machines' roster declared" in summarize_ownership(cfg, "Valor the Cowboy")
+
+
+def test_owner_not_in_roster_fails():
+    """The #2541 defect: a project naming a decommissioned host must not pass."""
+    cfg = {
+        "machines": ["Valor the Cowboy", "Valor the Captain"],
+        "projects": {
+            "valor": {"machine": "Valor the Cowboy"},
+            "psyoptimal": {"machine": "Tom's MacBook Pro"},
+        },
+    }
+    with pytest.raises(ConfigValidationError) as exc:
+        validate_machine_roster(cfg)
+    msg = str(exc.value)
+    assert "psyoptimal" in msg
+    assert "Tom's MacBook Pro" in msg
+    assert "unowned" in msg
+    assert "valor" not in msg.split("owned by")[0]
+
+
+def test_owner_in_roster_passes():
+    """Negative control: a roster-resolvable owner is accepted."""
+    cfg = {
+        "machines": {"Valor the Cowboy": "primary bridge host"},
+        "projects": {"valor": {"machine": "Valor the Cowboy"}},
+    }
+    validate_machine_roster(cfg)
+
+
+def test_roster_match_is_apostrophe_insensitive():
+    """A curly-vs-straight apostrophe must not unown a live host.
+
+    macOS returns U+2019 from ``scutil --get ComputerName`` for a default name;
+    the same name hand-typed into projects.json carries U+0027.
+    """
+    cfg = {
+        "machines": ["Tom’s MacBook Air"],
+        "projects": {"valor": {"machine": "Tom's MacBook Air"}},
+    }
+    validate_machine_roster(cfg)
+    assert normalize_machine_name("Tom’s MacBook Air") == normalize_machine_name(
+        "Tom's MacBook Air"
+    )
+
+
+def test_blank_machine_is_not_a_roster_violation():
+    """A missing ``machine`` is the per-shape validators' error, not the roster's."""
+    cfg = {
+        "machines": ["Valor the Cowboy"],
+        "projects": {"orphan": {"machine": ""}, "none": {}},
+    }
+    validate_machine_roster(cfg)
+
+
+def test_validate_projects_config_runs_the_roster_check():
+    """The aggregated suite includes the roster validator."""
+    cfg = {
+        "machines": ["Valor the Cowboy"],
+        "projects": {"ghost": {"machine": "Nobody's Laptop"}},
+        "dms": {"whitelist": []},
+    }
+    with pytest.raises(ConfigValidationError) as exc:
+        validate_projects_config(cfg)
+    assert "Nobody's Laptop" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# summarize_ownership — the report /update prints every run (issue #2541)
+# ---------------------------------------------------------------------------
+
+
+def test_summary_names_this_hosts_projects():
+    cfg = {
+        "machines": ["Valor the Cowboy", "Valor the Captain"],
+        "projects": {
+            "valor": {"machine": "Valor the Cowboy"},
+            "popoto": {"machine": "Valor the Cowboy"},
+            "psyoptimal": {"machine": "Valor the Captain"},
+        },
+    }
+    summary = summarize_ownership(cfg, "Valor the Cowboy")
+    assert "claims 2 project(s): popoto, valor" in summary
+    assert "other owners in config" in summary
+    assert "machines roster" in summary
+
+
+def test_summary_calls_out_a_host_that_claims_nothing():
+    cfg = {"projects": {"valor": {"machine": "Valor the Captain"}}}
+    summary = summarize_ownership(cfg, "Valor the Cowboy")
+    assert "claims NO projects" in summary
+
+
+def test_summary_calls_out_roster_hosts_owning_nothing():
+    cfg = {
+        "machines": ["Valor the Cowboy", "Valor the Bald"],
+        "projects": {"valor": {"machine": "Valor the Cowboy"}},
+    }
+    summary = summarize_ownership(cfg, "Valor the Cowboy")
+    assert "roster hosts owning nothing: Valor the Bald" in summary
+
+
+def test_summary_handles_unresolved_computer_name():
+    """``get_machine_name()`` returns "" on failure; the report must still render."""
+    cfg = {"projects": {"valor": {"machine": "Valor the Cowboy"}}}
+    summary = summarize_ownership(cfg, "")
+    assert "unresolved ComputerName" in summary
+    assert "claims NO projects" in summary

--- a/ui/data/machine.py
+++ b/ui/data/machine.py
@@ -9,7 +9,7 @@ from there.
 import json
 from pathlib import Path
 
-from config.machine import get_machine_name
+from config.machine import get_machine_name, normalize_machine_name
 
 
 def get_machine_projects() -> list[dict]:
@@ -26,10 +26,10 @@ def get_machine_projects() -> list[dict]:
     except Exception:
         return []
 
-    machine = get_machine_name().lower()
+    machine = normalize_machine_name(get_machine_name())
     rows = []
     for project_key, project in config.get("projects", {}).items():
-        if project.get("machine", "").lower() != machine:
+        if normalize_machine_name(project.get("machine", "")) != machine:
             continue
 
         github = project.get("github", {})

--- a/ui/data/memories.py
+++ b/ui/data/memories.py
@@ -45,7 +45,7 @@ def _resolve_project_keys(project_key: str | None = None) -> list[str]:
         return [env_key]
 
     # No env var — resolve from machine config (same source as the dashboard).
-    from config.machine import get_machine_name
+    from config.machine import get_machine_project_keys
     from ui.data.machine import get_machine_projects
 
     projects = get_machine_projects()
@@ -57,12 +57,7 @@ def _resolve_project_keys(project_key: str | None = None) -> list[str]:
         try:
             config = json.loads(config_path.read_text())
             keys = list(config.get("projects", {}).keys())
-            machine = get_machine_name().lower()
-            return [
-                k
-                for k, v in config.get("projects", {}).items()
-                if v.get("machine", "").lower() == machine
-            ] or keys
+            return get_machine_project_keys() or keys
         except Exception:
             pass
 


### PR DESCRIPTION
Closes #2541

## Problem

`validate_projects_config` checks that each bridge identifier has **exactly one** owner. It never checks that the owner **exists**. A project can name a machine that was decommissioned, renamed, or never existed, and validation passes, so `scripts/update/run.py` Step 4.6 greenlights the bridge restart on a config that routes real traffic to nobody.

Reproduced against `2e517d3b`:

```python
cfg = {"projects": {"ghost": {"machine": "A Machine That Never Existed",
                              "telegram": {"groups": {"Eng: Ghost": {}}},
                              "email": {"contacts": ["a@b.com"]}}},
       "dms": {"whitelist": [{"id": 1, "name": "x", "project": "ghost"}]}}
validate_projects_config(cfg)   # returns cleanly
```

And the apostrophe split, against the live config on this host:

```python
get_machine_project_keys(machine="Tom's MacBook Air")   # []      (U+0027)
get_machine_project_keys(machine="Tom’s MacBook Air")   # 20 keys (U+2019)
```

`scutil --get ComputerName` returns the U+2019 form, so a straight-apostrophe owner string cannot match its own machine even when that machine is alive.

## The design decision

The issue named three candidate meanings for "exists" and asked for a decision before implementing. This PR takes the **closed set**, declared in the config:

```json
"machines": {
  "Valor the Cowboy": "Primary bridge host",
  "Valor the Captain": "Second bridge host"
}
```

- **Self-check only** was rejected because one host cannot see the fleet, and deriving a roster from the config's own owner set would only ever confirm itself.
- **Liveness-derived** was rejected because it couples config validation to runtime state and would flag a host that is merely powered off.
- The roster's maintenance cost is one line per machine, in the file the operator already edits when adding a machine, and `/update` reports it every run so it cannot drift unnoticed.

**When no roster is declared the check is skipped.** That keeps this from hard-failing every machine in the fleet the moment it lands; `/update` instead prints, on every run, that owner names are unverifiable and how to fix it. Declaring the roster is the operator's opt-in to strictness.

## Changes

| File | Change |
|---|---|
| `config/machine.py` | `normalize_machine_name()`: strip, casefold, fold `’ ‘ ʼ ´ \`` to `'`. `get_machine_project_keys` routes through it. The #1834 empty-machine guard is unchanged. |
| `bridge/config_validation.py` | `validate_machine_roster`, `declared_machines`, `project_owners`, `summarize_ownership`. Roster check joins the aggregated suite. |
| `ui/data/machine.py`, `ui/data/memories.py` | The two drifted raw-`.lower()` ownership comparisons #1997 missed; `memories.py` now just calls `get_machine_project_keys()`. |
| `scripts/update/verify.py` | `ToolCheck.detail`; `check_projects_json` returns the ownership summary on pass **and** fail. |
| `scripts/update/run.py` | Step 4.6 logs the summary with `always=True`. |
| `config/projects.example.json` | Roster block plus `_doc` entry. |
| `docs/features/single-machine-ownership.md` | Roster, reporting, normalization, two new failure-mode rows, adding-a-machine step. |

## Acceptance criteria

- [x] A project naming a nonexistent machine no longer passes validation silently — hard error with a roster, reported line without one.
- [x] Apostrophe encoding cannot cause a live host to fail to match its own name.
- [x] `/update` reports this host's claimed projects and the config's other owners.
- [x] Test coverage for nonexistent owner, straight-vs-curly mismatch, and a valid config (negative control).

## Verification

```
tests/unit/test_dm_whitelist_validation.py  49 passed
tests/unit/test_config_machine.py           18 passed
tests/unit/test_ui_data_memories.py + test_reflection_machine_filter.py + above: 117 passed
```

End-to-end against the live config on this host:

```
available: True
version: valid (0 DM contacts, 0 groups, 0 email patterns)
ownership: this host (Tom’s MacBook Air) claims 20 project(s): ai-skills, cuttlefish, ...
ownership: no 'machines' roster declared — owner names are unverifiable; ...
```

## Note on the reported data drift

The issue observed 19 projects owned by `Tom's MacBook Pro`. The live config has since been reconciled by the operator: all 20 projects now name `Tom’s MacBook Air`, and `_doc.machine_this` reads "sole remaining Mac; MacBook Pro was wiped and sold 2026-08". The data symptom is gone; the validator defect this PR fixes is not, and reproduces on current main.

## DOCS

`docs/features/single-machine-ownership.md` updated: new "The fleet roster" and "Ownership reporting" sections, `normalize_machine_name` added to the machine-identity function list, roster check added to "What the validator catches", two rows added to failure modes, roster step added to "Adding a new machine", test-coverage paragraph rewritten.