### PR TITLE
Dedup nightly triage dispatch per node (#2559)

### DIFF
--- a/docs/features/nightly-alert-triage.md
+++ b/docs/features/nightly-alert-triage.md
@@ -26,9 +26,9 @@ three behaviors layered around that base run:
    suite and both sending Telegram alerts for the same window.
 2. **Failure summarizer** — turns a list of raw pytest node IDs into a short,
    human-readable sentence or two for the Telegram alert.
-3. **Triage dispatch** — spins up an Eng session to investigate newly-confirmed
-   failures and file a GitHub issue, deduped so the same failing set doesn't
-   re-dispatch every night.
+3. **Triage dispatch** — spins up an Eng session to investigate failures that have not
+   been triaged before and file a GitHub issue, deduped per node so a failure that
+   already has an issue open against it never generates a second one.
 
 ## Run Lock (Race 1)
 
@@ -51,9 +51,9 @@ loading prior state or running any tests.
 
 ## Best-Effort Failure Summarizer
 
-`summarize_failures(confirmed_failing, report)` turns the newly-confirmed failing
-node IDs into a 1-3 sentence plain-English summary for the Telegram alert, instead of
-a raw list of pytest node IDs.
+`summarize_failures(node_ids, report)` turns the newly-confirmed failing node IDs into
+a 1-3 sentence plain-English summary for the Telegram alert, instead of a raw list of
+pytest node IDs.
 
 - **What it does**: groups the failing node IDs by file, pulls the last line of each
   test's traceback (`call.longrepr` or `crash.message`) from the pytest
@@ -61,8 +61,8 @@ a raw list of pytest node IDs.
   (`agent/llm/wrapper.run_typed`, `config.models.MODEL_FAST`, the project's
   standard non-harness PydanticAI transport) for a short summary and likely root
   cause area.
-- **Fallback discipline**: this is best-effort only. An empty `confirmed_failing`
-  list short-circuits before any LLM call. Any other failure — network error, empty
+- **Fallback discipline**: this is best-effort only. An empty `node_ids` list
+  short-circuits before any LLM call. Any other failure — network error, empty
   or malformed LLM response, `LLMCallError`, missing `ANTHROPIC_API_KEY` — is caught
   broadly, logged as a warning, and the function falls back to the raw node-ID
   preview format (`_raw_failure_preview`: first 5 node IDs + "+N more") that
@@ -75,9 +75,9 @@ a raw list of pytest node IDs.
 
 ## Triage Session Dispatch
 
-`maybe_dispatch_triage_session(confirmed_failing, prev)` fires off an Eng-role
-`AgentSession` to investigate newly-confirmed failures, whenever the confirmed-failing
-set has changed since the last dispatch.
+`maybe_dispatch_triage_session(dispatch_nodes)` fires off an Eng-role `AgentSession` to
+investigate failing tests that have never been triaged before. The set comes from
+`compute_dispatch_set(prev, confirmed_failing)`.
 
 - **Invocation contract**: shells out to
   `python -m tools.valor_session create --role eng --slug nightly-triage-<hash8>
@@ -93,15 +93,30 @@ set has changed since the last dispatch.
   - The subprocess call has a 30s timeout; any exception (timeout, missing binary,
     non-zero exit) is caught, logged as a warning, and treated as "no dispatch" —
     this is fire-and-forget, not a blocking dependency of the nightly run.
-- **Dedup semantics**: the dedup key is the sha256 hash of the sorted, deduped
-  confirmed-failing node-ID set. It's persisted as `dispatched_hash` in
-  `data/nightly_tests_last_run.json` and compared against the current run's hash. If
-  they match, dispatch is skipped (log-only, no subprocess call) — the same failing
-  set doesn't re-dispatch a fresh triage session every night it stays unfixed. The
-  hash and the resulting session ID (`dispatched_session_id`) are only overwritten on
-  a run that actually attempts a dispatch; clean, baseline, and collection-error runs
-  carry the previous values forward unchanged so the dedup state survives runs that
-  don't reach the dispatch branch.
+- **Dedup semantics**: dedup is **per node**, not per set. `dispatched_nodes` in
+  `data/nightly_tests_last_run.json` holds every node ID a previous run handed to
+  triage; `compute_dispatch_set` subtracts it from the confirmed-failing set, so a
+  node with an issue already open against it cannot reach a second dispatch.
+  - The alert and the dispatch answer **different questions**. The alert asks "is this
+    a regression since last night" (`compute_new_failures`); the dispatch asks "does
+    this node already have an issue". Conflating them is what made a standing failure
+    re-triage on every run that had any new failure, so #2429, #2430 and #2462 each
+    opened an issue over the same dead watchdog node (issue #2559).
+  - `carry_dispatched_nodes` persists the union of (previously dispatched ∩ still
+    failing) and whatever this run dispatched. A node that stops failing drops out, so
+    a genuine re-regression is dispatchable again later, and a **renamed** node retires
+    itself with no special case: `df6097fe6` renamed the watchdog node the churn kept
+    citing, and the old ID simply stops appearing in the confirmed set.
+  - Only what actually went out is recorded. A failed dispatch leaves its nodes unfiled,
+    so the next run retries them instead of silently swallowing the failure. This is
+    also why the dispatch set is not `compute_new_failures`: a node whose dispatch
+    failed is no longer "new" but is still unfiled.
+  - A **first (baseline) run** seeds `dispatched_nodes` with the confirmed set and
+    dispatches nothing. The baseline declares the known-failing state rather than
+    reporting a finding, so without the seed the *next* run would file the entire
+    standing set as fresh discoveries.
+  - `dispatched_session_id` records the most recent successful dispatch and is carried
+    forward on runs that dispatch nothing.
 - **Mandate**: the dispatched session's prompt is explicit that the task is
   investigate-and-file-a-`/do-issue`-quality GitHub issue describing the failure, its
   likely cause, and suggested next steps — **not** an auto-hotfix. Auto-hotfixing
@@ -114,7 +129,7 @@ set has changed since the last dispatch.
 |------|---------|
 | `scripts/nightly_regression_tests.py` | Adds `_acquire_run_lock`, `summarize_failures`, `maybe_dispatch_triage_session` around the existing detector; see `docs/features/nightly-regression-tests.md` for the base run mechanics |
 | `data/nightly_tests.lock` | Advisory lock file for `_acquire_run_lock` (gitignored, empty — existence and the flock state are all that matter) |
-| `data/nightly_tests_last_run.json` | Now also carries `dispatched_hash` and `dispatched_session_id` alongside the existing delta-state fields |
+| `data/nightly_tests_last_run.json` | Now also carries `dispatched_nodes` and `dispatched_session_id` alongside the existing delta-state fields |
 
 ## Design Decisions
 

--- a/docs/features/nightly-regression-tests.md
+++ b/docs/features/nightly-regression-tests.md
@@ -59,7 +59,7 @@ is swallowed and logged as non-fatal.
 | `com.valor.nightly-tests.plist` | launchd plist template with `__PROJECT_DIR__`, `__HOME_DIR__`, `__SERVICE_LABEL__` placeholders |
 | `scripts/install_nightly_tests.sh` | Install script: bridge-role gated, substitutes placeholders, calls `launchctl_bootstrap_fail_soft` (fail-soft errno-5 recovery via `scripts/lib/launchctl.sh`, see bridge-self-healing.md Component 21); skips + removes stale plist on non-bridge machines |
 | `data/nightly_tests.lock` | Advisory `flock` lock file preventing overlapping runs (gitignored) — see `docs/features/nightly-alert-triage.md` |
-| `data/nightly_tests_last_run.json` | Unit suite delta state: `passed`, `failed`, `error`, `skipped`, `total`, `run_at`, `dispatched_hash`, `dispatched_session_id` (gitignored) |
+| `data/nightly_tests_last_run.json` | Unit suite delta state: `passed`, `failed`, `error`, `skipped`, `total`, `run_at`, `dispatched_nodes`, `dispatched_session_id` (gitignored) |
 | `logs/nightly_tests.log` | Per-run log with timestamps and counts |
 | `logs/nightly_tests_error.log` | Startup crash log (captured by launchd before `log()` fires) |
 | `logs/cold_start_metrics.jsonl` | TTFT samples consumed by the gate |

--- a/scripts/nightly_regression_tests.py
+++ b/scripts/nightly_regression_tests.py
@@ -20,6 +20,18 @@ Artifacts are logged but never alerted, killing the parallel-execution alert
 noise. The serial re-run targets only the already-failing node IDs, so it stays
 fast and never re-runs the whole suite.
 
+Triage dispatch is deduped per node (issue #2559)
+-------------------------------------------------
+The Telegram alert and the triage dispatch answer different questions. The alert
+asks "is this a regression since last night" (``compute_new_failures``); the
+dispatch asks "does this node already have an issue against it"
+(``compute_dispatch_set``, diffing against the persisted ``dispatched_nodes``
+set). Conflating them re-triaged the entire standing failure set whenever any
+one failure was new, which is how #2429, #2430 and #2462 each filed an issue
+over the same dead watchdog node. A node stays suppressed while it keeps
+failing and drops out of the set once it passes, so a genuine re-regression is
+dispatchable again and a renamed node retires itself.
+
 A post-run TTFT gate (issue #1227) reports cold-start latency regressions as
 Telegram alerts without changing the exit code.
 
@@ -372,25 +384,79 @@ def compute_new_failures(prev: dict, confirmed_failing: list[str]) -> list[str]:
     Set-based so a *shifting* flaky set (same count, different tests) does not
     read as a regression, and a genuinely new failure does — even when the total
     count is flat.
+
+    This drives the Telegram *alert*. Triage dispatch uses
+    :func:`compute_dispatch_set` instead, which asks the different question of
+    what has not been filed yet.
     """
     prev_failing = set(prev.get("failing_tests", []))
     return sorted(n for n in confirmed_failing if n not in prev_failing)
+
+
+def prior_dispatched(prev: dict) -> set[str]:
+    """Node IDs a previous run already handed to triage.
+
+    Falls back to the prior run's confirmed set when ``dispatched_nodes`` is
+    absent, which is the state on the first run after this tracking existed.
+    Those nodes are exactly the standing set the detector used to re-dispatch on
+    every run, so treating them as already filed is what stops the churn instead
+    of replaying it one last time.
+    """
+    if "dispatched_nodes" in prev:
+        return set(prev.get("dispatched_nodes") or [])
+    return set(prev.get("failing_tests") or [])
+
+
+def compute_dispatch_set(prev: dict, confirmed_failing: list[str]) -> list[str]:
+    """Confirmed-failing node IDs that no previous run has handed to triage.
+
+    The detector used to dispatch the whole confirmed set whenever any failure
+    was new, so a standing failure was re-triaged on every run and filed again
+    each time — #2429, #2430 and #2462 each opened an issue over the same dead
+    watchdog node (issue #2559). Suppressing already-filed nodes is what makes
+    a second issue against the same node impossible.
+
+    Note this is deliberately *not* ``compute_new_failures``: a node whose
+    dispatch subprocess failed is still unfiled, so it stays in the set and gets
+    retried on the next run rather than being lost.
+    """
+    already = prior_dispatched(prev)
+    return sorted(n for n in set(confirmed_failing) if n not in already)
+
+
+def carry_dispatched_nodes(
+    prev: dict, confirmed_failing: list[str], just_dispatched: list[str]
+) -> list[str]:
+    """The ``dispatched_nodes`` set to persist for the next run.
+
+    Keeps a previously-dispatched node only while it is still failing, then adds
+    whatever this run dispatched. Dropping a node once it stops failing is what
+    makes a genuine re-regression dispatchable again later, and it retires stale
+    node IDs on its own: a renamed test (``df6097fe6`` renamed the watchdog node
+    the churn kept citing) simply stops appearing in the confirmed set and falls
+    out of the state file.
+    """
+    still_failing = prior_dispatched(prev) & set(confirmed_failing)
+    return sorted(still_failing | set(just_dispatched))
 
 
 class FailureSummary(BaseModel):
     summary: str
 
 
-def _raw_failure_preview(confirmed_failing: list[str]) -> str:
+def _raw_failure_preview(node_ids: list[str]) -> str:
     """Build the raw node-ID preview text (first 5 + '+N more')."""
-    preview = ", ".join(confirmed_failing[:5])
-    if len(confirmed_failing) > 5:
-        preview += f", +{len(confirmed_failing) - 5} more"
+    preview = ", ".join(node_ids[:5])
+    if len(node_ids) > 5:
+        preview += f", +{len(node_ids) - 5} more"
     return preview
 
 
-def summarize_failures(confirmed_failing: list[str], report: dict) -> str:
+def summarize_failures(node_ids: list[str], report: dict) -> str:
     """Summarize newly-confirmed failures via a cheap LLM call, best-effort.
+
+    ``node_ids`` is the newly-confirmed set from :func:`compute_new_failures`,
+    which is what makes the "Newly-confirmed" heading below accurate.
 
     Groups failing node IDs by file and pulls short tracebacks from the
     pytest ``--json-report`` payload when available. On ANY failure (empty
@@ -398,20 +464,20 @@ def summarize_failures(confirmed_failing: list[str], report: dict) -> str:
     validation failure, timeout, etc. are all caught) falls back to the raw
     node-ID preview format that ``main()`` used to build inline.
     """
-    if not confirmed_failing:
-        return _raw_failure_preview(confirmed_failing)
+    if not node_ids:
+        return _raw_failure_preview(node_ids)
 
     by_file: dict[str, list[str]] = {}
-    for nodeid in confirmed_failing:
+    for nodeid in node_ids:
         file_part = nodeid.split("::", 1)[0]
         by_file.setdefault(file_part, []).append(nodeid)
 
     tests_by_id = {t.get("nodeid"): t for t in report.get("tests", []) if t.get("nodeid")}
 
     lines = ["Newly-confirmed nightly test failures, grouped by file:"]
-    for file_part, node_ids in sorted(by_file.items()):
+    for file_part, file_node_ids in sorted(by_file.items()):
         lines.append(f"\n{file_part}:")
-        for nodeid in node_ids:
+        for nodeid in file_node_ids:
             lines.append(f"  - {nodeid}")
             test_entry = tests_by_id.get(nodeid, {})
             call = test_entry.get("call", {})
@@ -431,48 +497,36 @@ def summarize_failures(confirmed_failing: list[str], report: dict) -> str:
         return result.summary
     except Exception as exc:  # noqa: BLE001
         log(f"WARNING: summarize_failures LLM call failed ({exc}); using raw preview")
-        return _raw_failure_preview(confirmed_failing)
+        return _raw_failure_preview(node_ids)
 
 
-def maybe_dispatch_triage_session(
-    confirmed_failing: list[str], prev: dict
-) -> tuple[str | None, str | None]:
-    """Dispatch a triage Eng session for newly-confirmed failures, deduped by hash.
+def maybe_dispatch_triage_session(dispatch_nodes: list[str]) -> str | None:
+    """Dispatch one triage Eng session for node IDs that have never been filed.
 
-    Returns ``(session_id, current_hash)``:
-      - ``session_id`` — the dispatched session ID, or ``None`` if no dispatch
-        happened (either because there were no new failures, the failing set is
-        unchanged since the last dispatch, or the dispatch subprocess itself
-        failed).
-      - ``current_hash`` — the sha256 of the sorted, deduped confirmed-failing
-        node-ID set, computed once here and returned so callers never need to
-        recompute it. ``None`` when ``confirmed_failing`` is empty (no hash to
-        compute).
+    ``dispatch_nodes`` comes from :func:`compute_dispatch_set`, so every entry is
+    a node no previous run handed to triage. That per-node suppression is the
+    whole dedup mechanism: a node with an issue already open against it cannot
+    reach this function a second time, which is what ends the duplicate-issue
+    churn of #2429 / #2430 / #2462 (issue #2559).
 
-    The dedup key is ``prev["dispatched_hash"]``: the sha256 of the sorted,
-    deduped confirmed-failing node-ID set as of the last dispatch. The
-    caller is responsible for persisting the new hash (and session ID) into
-    the state dict it saves via ``save_last_run`` so the *next* run's
-    ``prev`` observes it — and for leaving ``dispatched_hash`` untouched on
-    clean runs (no new_failures) or on a failed dispatch, so dedup state
-    isn't lost and a retry is possible on the next run.
+    Returns the dispatched session ID, or ``None`` when there is nothing to
+    dispatch or the dispatch subprocess failed. The caller records which nodes
+    actually went out via :func:`carry_dispatched_nodes`, so a failed dispatch
+    leaves its nodes unfiled and they are retried on the next run.
     """
-    if not confirmed_failing:
-        return None, None
+    if not dispatch_nodes:
+        return None
 
-    current_hash = hashlib.sha256(",".join(sorted(set(confirmed_failing))).encode()).hexdigest()
-    if current_hash == prev.get("dispatched_hash"):
-        log("Triage dispatch skipped — confirmed-failing set unchanged since last dispatch")
-        return None, current_hash
-
-    slug = f"nightly-triage-{current_hash[:8]}"
+    slug_hash = hashlib.sha256(",".join(sorted(set(dispatch_nodes))).encode()).hexdigest()[:8]
+    slug = f"nightly-triage-{slug_hash}"
     prompt = (
-        "Nightly regression detector found newly-confirmed test failures. "
-        "Investigate the root cause of the following failing tests and file "
-        "a /do-issue-quality GitHub issue describing the failure, its likely "
-        "cause, and suggested next steps. Do NOT attempt an auto-hotfix — "
-        "this is an investigation-and-file-an-issue task only.\n\n"
-        "Newly-confirmed failing node IDs:\n" + "\n".join(f"- {n}" for n in confirmed_failing)
+        "Nightly regression detector found confirmed test failures that have not "
+        "been triaged before. Investigate the root cause of the following failing "
+        "tests and file a /do-issue-quality GitHub issue describing the failure, "
+        "its likely cause, and suggested next steps. Search open issues first and "
+        "comment on an existing one rather than opening a duplicate. Do NOT attempt "
+        "an auto-hotfix — this is an investigation-and-file-an-issue task only.\n\n"
+        "Not-yet-triaged failing node IDs:\n" + "\n".join(f"- {n}" for n in dispatch_nodes)
     )
 
     try:
@@ -497,7 +551,7 @@ def maybe_dispatch_triage_session(
         )
     except Exception as exc:  # noqa: BLE001  # covers TimeoutExpired, FileNotFoundError, etc.
         log(f"WARNING: triage session dispatch failed ({exc})")
-        return None, current_hash
+        return None
 
     try:
         session_id = json.loads(result.stdout)["session_id"]
@@ -506,7 +560,7 @@ def maybe_dispatch_triage_session(
         session_id = None
 
     log(f"Triage session dispatched: slug={slug} session_id={session_id}")
-    return session_id, current_hash
+    return session_id
 
 
 def load_env_or_die() -> int:
@@ -621,11 +675,6 @@ def main() -> int:
     # what future runs diff against.
     current.pop("failing_parallel", None)
 
-    # Carry forward the triage-dispatch dedup state by default; only the
-    # newly-confirmed-failures branch below overwrites it (a dispatch was
-    # actually attempted). Clean/baseline/collection-error runs must not
-    # lose the previous dispatch's dedup hash.
-    current["dispatched_hash"] = prev.get("dispatched_hash")
     current["dispatched_session_id"] = prev.get("dispatched_session_id")
 
     new_failures = compute_new_failures(prev, confirmed_failing)
@@ -634,6 +683,33 @@ def main() -> int:
         f"Newly-confirmed failures: {len(new_failures)}; "
         f"confirmed total: {current['failed']}; collection errors: {new_errors}"
     )
+
+    # Triage dispatch is decided independently of the alert. The alert asks
+    # "is this a regression since last night"; dispatch asks "does this node
+    # already have an issue against it". Conflating the two is what re-filed the
+    # standing set every time any one failure was new (#2559).
+    if is_first_run:
+        # The baseline is a declaration of the known-failing state, not a
+        # finding. Seed it as already-accounted-for so the next run does not
+        # dispatch the entire suite's standing failures as fresh discoveries.
+        dispatch_nodes: list[str] = []
+        just_dispatched = list(confirmed_failing)
+    else:
+        dispatch_nodes = compute_dispatch_set(prev, confirmed_failing)
+        just_dispatched = []
+    if dispatch_nodes:
+        log(f"Not yet triaged: {len(dispatch_nodes)} node(s): " + ", ".join(dispatch_nodes))
+    suppressed = len(confirmed_failing) - len(dispatch_nodes) - len(just_dispatched)
+    if suppressed > 0:
+        log(f"Triage dispatch suppressed for {suppressed} already-filed node(s)")
+
+    triage_session_id = maybe_dispatch_triage_session(dispatch_nodes)
+    if triage_session_id is not None:
+        # Record only what actually went out. A failed dispatch leaves its nodes
+        # unfiled, so the next run picks them up again instead of losing them.
+        just_dispatched = dispatch_nodes
+        current["dispatched_session_id"] = triage_session_id
+    current["dispatched_nodes"] = carry_dispatched_nodes(prev, confirmed_failing, just_dispatched)
 
     # Alert logic — regression fires only on newly-confirmed serial failures.
     if is_first_run:
@@ -648,14 +724,6 @@ def main() -> int:
         except (FileNotFoundError, json.JSONDecodeError):
             serial_report = {}
         summary_text = summarize_failures(new_failures, serial_report)
-        triage_session_id, dispatch_hash = maybe_dispatch_triage_session(confirmed_failing, prev)
-        if triage_session_id is not None:
-            # Only record the new dedup hash (and session ID) on a successful
-            # dispatch. If dispatch failed, `dispatched_hash` stays whatever
-            # was carried forward from `prev` above, so the next nightly run
-            # gets a retry instead of the failure being silently swallowed.
-            current["dispatched_hash"] = dispatch_hash
-            current["dispatched_session_id"] = triage_session_id
         msg = (
             f"Nightly regression: {len(new_failures)} newly-confirmed failure(s) "
             f"({current['failed']} confirmed total): {summary_text}. "

--- a/tests/unit/test_nightly_regression_tests.py
+++ b/tests/unit/test_nightly_regression_tests.py
@@ -341,8 +341,81 @@ class TestSummarizeFailures:
         assert result == "mocked"
 
 
+class TestComputeDispatchSet:
+    """Already-filed nodes must not reach triage a second time (issue #2559)."""
+
+    def test_new_node_is_dispatchable(self) -> None:
+        prev = {"dispatched_nodes": ["tests/unit/test_a.py::test_1"]}
+        confirmed = ["tests/unit/test_a.py::test_1", "tests/unit/test_b.py::test_2"]
+        assert nrt.compute_dispatch_set(prev, confirmed) == ["tests/unit/test_b.py::test_2"]
+
+    def test_standing_failure_is_suppressed(self) -> None:
+        """The #2559 defect: a node with an issue already open must not re-dispatch.
+
+        Under the old code the whole confirmed set went out whenever any single
+        failure was new, which re-filed the same dead watchdog node in #2429,
+        #2430 and #2462.
+        """
+        standing = "tests/unit/test_bridge_watchdog.py::test_dead_node"
+        prev = {"dispatched_nodes": [standing], "failing_tests": [standing]}
+        assert nrt.compute_dispatch_set(prev, [standing]) == []
+        assert nrt.compute_dispatch_set(prev, [standing, "tests/unit/x.py::test_new"]) == [
+            "tests/unit/x.py::test_new"
+        ]
+
+    def test_failed_dispatch_is_retried_next_run(self) -> None:
+        """A node whose dispatch failed is still unfiled, so it stays dispatchable.
+
+        This is why dispatch diffs against dispatched_nodes rather than reusing
+        compute_new_failures — the node is no longer "new" but is still unfiled.
+        """
+        node = "tests/unit/test_a.py::test_1"
+        prev = {"failing_tests": [node], "dispatched_nodes": []}
+        assert nrt.compute_new_failures(prev, [node]) == []
+        assert nrt.compute_dispatch_set(prev, [node]) == [node]
+
+    def test_absent_key_falls_back_to_prior_confirmed_set(self) -> None:
+        """State written before dispatch tracking existed must not mass-dispatch."""
+        prev = {"failing_tests": ["tests/unit/test_a.py::test_1"]}
+        assert nrt.compute_dispatch_set(prev, ["tests/unit/test_a.py::test_1"]) == []
+
+    def test_empty_prev_dispatches_everything(self) -> None:
+        assert nrt.compute_dispatch_set({}, ["tests/unit/test_a.py::test_1"]) == [
+            "tests/unit/test_a.py::test_1"
+        ]
+
+
+class TestCarryDispatchedNodes:
+    """The persisted dispatched set keeps failing nodes and retires passing ones."""
+
+    def test_keeps_still_failing_and_adds_new(self) -> None:
+        prev = {"dispatched_nodes": ["a::t1"]}
+        assert nrt.carry_dispatched_nodes(prev, ["a::t1", "b::t2"], ["b::t2"]) == ["a::t1", "b::t2"]
+
+    def test_drops_a_node_that_stopped_failing(self) -> None:
+        """A fixed node must become dispatchable again if it ever regresses."""
+        prev = {"dispatched_nodes": ["a::t1"]}
+        assert nrt.carry_dispatched_nodes(prev, [], []) == []
+        assert nrt.compute_dispatch_set({"dispatched_nodes": []}, ["a::t1"]) == ["a::t1"]
+
+    def test_retires_a_renamed_node_id(self) -> None:
+        """df6097fe6 renamed the watchdog node the churn kept citing.
+
+        A node ID that can never match again simply stops appearing in the
+        confirmed set, so it falls out of the state file with no special case.
+        """
+        old = "tests/unit/test_x.py::test_bridge_watchdog_no_agent_session_import"
+        new = "tests/unit/test_x.py::test_bridge_watchdog_has_no_module_level_agent_session_import"
+        prev = {"dispatched_nodes": [old]}
+        assert nrt.carry_dispatched_nodes(prev, [new], [new]) == [new]
+
+    def test_failed_dispatch_records_nothing(self) -> None:
+        prev = {"dispatched_nodes": []}
+        assert nrt.carry_dispatched_nodes(prev, ["a::t1"], []) == []
+
+
 class TestMaybeDispatchTriage:
-    """Tests for triage-session dispatch and sha256-hash-based dedup."""
+    """Tests for triage-session dispatch."""
 
     def _fake_result(self, stdout: str, returncode: int = 0):
         class FakeResult:
@@ -356,204 +429,174 @@ class TestMaybeDispatchTriage:
 
     def test_dispatch_once(self, tmp_path: Path) -> None:
         nrt.LOG_FILE = tmp_path / "test.log"
-        new_failures = ["tests/unit/test_a.py::test_1"]
+        nodes = ["tests/unit/test_a.py::test_1"]
         with patch(
             "subprocess.run", return_value=self._fake_result('{"session_id": "abc123"}')
         ) as mock_run:
-            session_id, current_hash = nrt.maybe_dispatch_triage_session(new_failures, {})
+            session_id = nrt.maybe_dispatch_triage_session(nodes)
         assert session_id == "abc123"
-        expected_hash = hashlib.sha256(",".join(sorted(set(new_failures))).encode()).hexdigest()
-        assert current_hash == expected_hash
         argv = mock_run.call_args.args[0]
         assert argv[0] == sys.executable
         assert "--role" in argv
         assert "eng" in argv
         assert "--slug" in argv
         slug_idx = argv.index("--slug")
-        assert argv[slug_idx + 1].startswith("nightly-triage-")
+        expected_slug_hash = hashlib.sha256(",".join(sorted(set(nodes))).encode()).hexdigest()[:8]
+        assert argv[slug_idx + 1] == f"nightly-triage-{expected_slug_hash}"
         assert "--json" in argv
 
-    def test_dedup_across_two_runs(self, tmp_path: Path) -> None:
+    def test_prompt_does_not_call_the_set_newly_confirmed(self, tmp_path: Path) -> None:
+        """The dispatch set is "not yet filed", which is not the same as "new"."""
         nrt.LOG_FILE = tmp_path / "test.log"
-        new_failures = ["tests/unit/test_a.py::test_1"]
-        with patch("subprocess.run", return_value=self._fake_result('{"session_id": "abc123"}')):
-            first_session_id, _ = nrt.maybe_dispatch_triage_session(new_failures, {})
-        assert first_session_id == "abc123"
-        current_hash = hashlib.sha256(",".join(sorted(set(new_failures))).encode()).hexdigest()
-        prev = {"dispatched_hash": current_hash}
-
-        with patch("subprocess.run") as mock_run2:
-            second_session_id, second_hash = nrt.maybe_dispatch_triage_session(new_failures, prev)
-            mock_run2.assert_not_called()
-        assert second_session_id is None
-        assert second_hash == current_hash
-
-    def test_dispatch_again_on_changed_set(self, tmp_path: Path) -> None:
-        nrt.LOG_FILE = tmp_path / "test.log"
-        set_a = ["tests/unit/test_a.py::test_1"]
-        set_a_hash = hashlib.sha256(",".join(sorted(set(set_a))).encode()).hexdigest()
-        prev = {"dispatched_hash": set_a_hash}
-        set_b = ["tests/unit/test_b.py::test_2"]
-
         with patch(
-            "subprocess.run", return_value=self._fake_result('{"session_id": "def456"}')
+            "subprocess.run", return_value=self._fake_result('{"session_id": "abc123"}')
         ) as mock_run:
-            session_id, current_hash = nrt.maybe_dispatch_triage_session(set_b, prev)
-            mock_run.assert_called_once()
-        assert session_id == "def456"
-        assert current_hash == hashlib.sha256(",".join(sorted(set(set_b))).encode()).hexdigest()
+            nrt.maybe_dispatch_triage_session(["tests/unit/test_a.py::test_1"])
+        argv = mock_run.call_args.args[0]
+        prompt = argv[argv.index("--message") + 1]
+        assert "Newly-confirmed" not in prompt
+        assert "Not-yet-triaged failing node IDs:" in prompt
+        assert "Search open issues first" in prompt
 
     def test_subprocess_failure_safe(self, tmp_path: Path) -> None:
         nrt.LOG_FILE = tmp_path / "test.log"
-        new_failures = ["tests/unit/test_a.py::test_1"]
         with patch("subprocess.run", side_effect=FileNotFoundError("no python")):
-            session_id, current_hash = nrt.maybe_dispatch_triage_session(new_failures, {})
+            session_id = nrt.maybe_dispatch_triage_session(["tests/unit/test_a.py::test_1"])
         assert session_id is None
-        # The hash is still computed/returned even on subprocess failure, so the
-        # caller can decide whether to persist it (it must not, per Nit 2 -- but
-        # that decision lives in main(), not here).
-        expected_hash = hashlib.sha256(",".join(sorted(set(new_failures))).encode()).hexdigest()
-        assert current_hash == expected_hash
 
     def test_session_id_parsed_from_json_stdout(self, tmp_path: Path) -> None:
         nrt.LOG_FILE = tmp_path / "test.log"
-        new_failures = ["tests/unit/test_a.py::test_1"]
         with patch("subprocess.run", return_value=self._fake_result('{"session_id": "xyz789"}')):
-            session_id, _ = nrt.maybe_dispatch_triage_session(new_failures, {})
+            session_id = nrt.maybe_dispatch_triage_session(["tests/unit/test_a.py::test_1"])
         assert session_id == "xyz789"
 
     def test_malformed_stdout_returns_none_not_crash(self, tmp_path: Path) -> None:
         nrt.LOG_FILE = tmp_path / "test.log"
-        new_failures = ["tests/unit/test_a.py::test_1"]
         with patch("subprocess.run", return_value=self._fake_result("not json")):
-            session_id, _ = nrt.maybe_dispatch_triage_session(new_failures, {})
+            session_id = nrt.maybe_dispatch_triage_session(["tests/unit/test_a.py::test_1"])
         assert session_id is None
 
     def test_empty_stdout_returns_none_not_crash(self, tmp_path: Path) -> None:
         nrt.LOG_FILE = tmp_path / "test.log"
-        new_failures = ["tests/unit/test_a.py::test_1"]
         with patch("subprocess.run", return_value=self._fake_result("")):
-            session_id, _ = nrt.maybe_dispatch_triage_session(new_failures, {})
+            session_id = nrt.maybe_dispatch_triage_session(["tests/unit/test_a.py::test_1"])
         assert session_id is None
 
-    def test_empty_new_failures_no_dispatch(self, tmp_path: Path) -> None:
+    def test_empty_dispatch_set_no_dispatch(self, tmp_path: Path) -> None:
         nrt.LOG_FILE = tmp_path / "test.log"
         with patch("subprocess.run") as mock_run:
-            result = nrt.maybe_dispatch_triage_session([], {"dispatched_hash": "whatever"})
+            assert nrt.maybe_dispatch_triage_session([]) is None
             mock_run.assert_not_called()
-        assert result == (None, None)
 
 
-class TestMainDispatchHashPersistence:
-    """main() must only persist a new dispatched_hash on a successful dispatch (Nit 2)."""
+class TestMainDispatchPersistence:
+    """main() persists only what actually went out to triage (issue #2559)."""
 
-    def test_failed_dispatch_does_not_overwrite_dispatched_hash(self, tmp_path: Path) -> None:
+    _RUN_RESULT = {
+        "passed": 10,
+        "failed": 1,
+        "error": 0,
+        "skipped": 0,
+        "total": 11,
+        "failing_parallel": [],
+        "run_at": "2026-07-21T00:00:00+00:00",
+    }
+
+    def _run_main(self, tmp_path: Path, prev_state: dict, confirmed: list[str], dispatch_return):
         nrt.LOG_FILE = tmp_path / "test.log"
         nrt.LOCK_FILE = tmp_path / "nightly_tests.lock"
         nrt.LAST_RUN_FILE = tmp_path / "last_run.json"
-
-        prev_state = {
-            "failing_tests": [],
-            "dispatched_hash": "stale-hash-from-earlier-successful-dispatch",
-            "dispatched_session_id": "earlier-session",
-        }
         nrt.LAST_RUN_FILE.write_text(json.dumps(prev_state))
 
-        run_tests_result = {
-            "passed": 10,
-            "failed": 1,
-            "error": 0,
-            "skipped": 0,
-            "total": 11,
-            "failing_parallel": ["tests/unit/test_a.py::test_new"],
-            "run_at": "2026-07-21T00:00:00+00:00",
-        }
-
+        run_result = dict(self._RUN_RESULT, failing_parallel=list(confirmed))
         with (
             patch("sys.argv", ["nightly_regression_tests.py", "--dry-run"]),
             # .env is machine-local and absent from worktrees, where the real
             # load_env_or_die() raises SystemExit and fails this test for
-            # reasons unrelated to what it asserts (#2573).
+            # reasons unrelated to what it asserts (#2573). The sentinel is
+            # deliberately non-zero so a leak into main()'s return value fails
+            # the `nrt.main() == 0` assertion below instead of passing silently.
             patch.object(nrt, "load_env_or_die", return_value=42),
-            patch.object(nrt, "run_tests", return_value=run_tests_result),
-            patch.object(
-                nrt,
-                "reconfirm_serial",
-                return_value=(["tests/unit/test_a.py::test_new"], []),
-            ),
+            patch.object(nrt, "run_tests", return_value=run_result),
+            patch.object(nrt, "reconfirm_serial", return_value=(list(confirmed), [])),
             patch.object(nrt, "summarize_failures", return_value="mocked summary"),
-            # Simulate a failed dispatch subprocess: session_id is None even
-            # though a new hash was computed for the current failing set.
             patch.object(
-                nrt,
-                "maybe_dispatch_triage_session",
-                return_value=(None, "new-hash-for-current-failures"),
-            ),
-            patch.object(nrt, "send_telegram") as mock_send_telegram,
+                nrt, "maybe_dispatch_triage_session", return_value=dispatch_return
+            ) as mock_dispatch,
+            patch.object(nrt, "send_telegram") as mock_send,
             patch.object(nrt, "run_ttft_gate", return_value=None),
         ):
-            result = nrt.main()
+            assert nrt.main() == 0
+        return json.loads(nrt.LAST_RUN_FILE.read_text()), mock_dispatch, mock_send
 
-        assert result == 0
-        mock_send_telegram.assert_called_once()
-        saved = json.loads(nrt.LAST_RUN_FILE.read_text())
-        # dispatched_hash must remain the prior value -- NOT overwritten with
-        # the newly-computed hash -- since the dispatch subprocess failed, so
-        # the next nightly run gets a retry opportunity instead of the
-        # failure being silently recorded as "already dispatched".
-        assert saved["dispatched_hash"] == "stale-hash-from-earlier-successful-dispatch"
+    def test_standing_failure_is_not_re_dispatched(self, tmp_path: Path) -> None:
+        """The end-to-end #2559 regression: a filed node plus a new one dispatches one.
+
+        Under the old code main() passed the full confirmed set, so the standing
+        node went to triage again under a "Newly-confirmed" header.
+        """
+        standing = "tests/unit/test_watchdog.py::test_dead_node"
+        fresh = "tests/unit/test_new.py::test_regression"
+        prev = {"failing_tests": [standing], "dispatched_nodes": [standing]}
+        saved, mock_dispatch, _ = self._run_main(
+            tmp_path, prev, [standing, fresh], "triage-session-1"
+        )
+        mock_dispatch.assert_called_once_with([fresh])
+        assert saved["dispatched_nodes"] == sorted([standing, fresh])
+
+    def test_no_dispatch_when_everything_is_already_filed(self, tmp_path: Path) -> None:
+        standing = "tests/unit/test_watchdog.py::test_dead_node"
+        prev = {"failing_tests": [standing], "dispatched_nodes": [standing]}
+        saved, mock_dispatch, _ = self._run_main(tmp_path, prev, [standing], None)
+        mock_dispatch.assert_called_once_with([])
+        assert saved["dispatched_nodes"] == [standing]
+
+    def test_failed_dispatch_leaves_nodes_unfiled_for_retry(self, tmp_path: Path) -> None:
+        node = "tests/unit/test_a.py::test_new"
+        prev = {
+            "failing_tests": [],
+            "dispatched_nodes": [],
+            "dispatched_session_id": "earlier-session",
+        }
+        saved, mock_dispatch, _ = self._run_main(tmp_path, prev, [node], None)
+        mock_dispatch.assert_called_once_with([node])
+        assert saved["dispatched_nodes"] == []
         assert saved["dispatched_session_id"] == "earlier-session"
 
-    def test_successful_dispatch_persists_new_hash(self, tmp_path: Path) -> None:
-        nrt.LOG_FILE = tmp_path / "test.log"
-        nrt.LOCK_FILE = tmp_path / "nightly_tests.lock"
-        nrt.LAST_RUN_FILE = tmp_path / "last_run.json"
-
-        prev_state = {
+    def test_successful_dispatch_records_the_nodes_and_session(self, tmp_path: Path) -> None:
+        node = "tests/unit/test_a.py::test_new"
+        prev = {
             "failing_tests": [],
-            "dispatched_hash": "stale-hash-from-earlier-successful-dispatch",
+            "dispatched_nodes": [],
             "dispatched_session_id": "earlier-session",
         }
-        nrt.LAST_RUN_FILE.write_text(json.dumps(prev_state))
-
-        run_tests_result = {
-            "passed": 10,
-            "failed": 1,
-            "error": 0,
-            "skipped": 0,
-            "total": 11,
-            "failing_parallel": ["tests/unit/test_a.py::test_new"],
-            "run_at": "2026-07-21T00:00:00+00:00",
-        }
-
-        with (
-            patch("sys.argv", ["nightly_regression_tests.py", "--dry-run"]),
-            # .env is machine-local and absent from worktrees, where the real
-            # load_env_or_die() raises SystemExit and fails this test for
-            # reasons unrelated to what it asserts (#2573).
-            patch.object(nrt, "load_env_or_die", return_value=42),
-            patch.object(nrt, "run_tests", return_value=run_tests_result),
-            patch.object(
-                nrt,
-                "reconfirm_serial",
-                return_value=(["tests/unit/test_a.py::test_new"], []),
-            ),
-            patch.object(nrt, "summarize_failures", return_value="mocked summary"),
-            patch.object(
-                nrt,
-                "maybe_dispatch_triage_session",
-                return_value=("new-session-id", "new-hash-for-current-failures"),
-            ),
-            patch.object(nrt, "send_telegram") as mock_send_telegram,
-            patch.object(nrt, "run_ttft_gate", return_value=None),
-        ):
-            result = nrt.main()
-
-        assert result == 0
-        mock_send_telegram.assert_called_once()
-        saved = json.loads(nrt.LAST_RUN_FILE.read_text())
-        assert saved["dispatched_hash"] == "new-hash-for-current-failures"
+        saved, _, mock_send = self._run_main(tmp_path, prev, [node], "new-session-id")
+        assert saved["dispatched_nodes"] == [node]
         assert saved["dispatched_session_id"] == "new-session-id"
+        mock_send.assert_called_once()
+        assert "new-session-id" in mock_send.call_args.args[0]
+
+    def test_node_that_stopped_failing_drops_out(self, tmp_path: Path) -> None:
+        prev = {"failing_tests": ["a::t1"], "dispatched_nodes": ["a::t1"]}
+        saved, _, _ = self._run_main(tmp_path, prev, [], None)
+        assert saved["dispatched_nodes"] == []
+
+    def test_baseline_run_seeds_rather_than_dispatches(self, tmp_path: Path) -> None:
+        """A first run declares the known state; it must not file the whole suite.
+
+        Without the seed, the *next* run would treat every standing baseline
+        failure as an undispatched discovery.
+        """
+        standing = ["a::t1", "b::t2"]
+        saved, mock_dispatch, _ = self._run_main(tmp_path, {}, standing, None)
+        mock_dispatch.assert_called_once_with([])
+        assert saved["dispatched_nodes"] == sorted(standing)
+
+    def test_dispatched_hash_is_gone_from_persisted_state(self, tmp_path: Path) -> None:
+        """dispatched_nodes supersedes the set-wide hash; the hash is not carried."""
+        prev = {"failing_tests": [], "dispatched_hash": "stale", "dispatched_nodes": []}
+        saved, _, _ = self._run_main(tmp_path, prev, ["a::t1"], "s1")
+        assert "dispatched_hash" not in saved
 
 
 class TestRunTtftGate:


### PR DESCRIPTION
Closes #2559

## Root cause

`main()` computes `new_failures` correctly for the Telegram alert, then hands the **full** confirmed set to the dispatcher:

```python
summary_text = summarize_failures(new_failures, serial_report)                 # correct
triage_session_id, dispatch_hash = maybe_dispatch_triage_session(confirmed_failing, prev)   # wrong
```

The dispatch prompt then lists that whole set under a header reading `Newly-confirmed failing node IDs:`. So every run with any new failure re-triaged the standing set and filed it again. #2429, #2430 and #2462 each opened an issue over the same dead watchdog node.

The set-wide sha256 dedup could not catch it: adding one new failure changes the hash, which re-dispatches everything.

Reproduced against `2e517d3b`:

```
run 1: new=['tests/unit/x.py::test_a']
         DISPATCHED SET = ['tests/unit/test_watchdog.py::test_dead_node', 'tests/unit/x.py::test_a']
run 2: new=['tests/unit/x.py::test_b']
         DISPATCHED SET = ['tests/unit/test_watchdog.py::test_dead_node', 'tests/unit/x.py::test_b']
```

**Why the tests missed it:** they call `maybe_dispatch_triage_session(new_failures, ...)` while production calls it with `confirmed_failing`. The test asserted a contract main() did not use.

## Fix

The alert and the dispatch answer different questions. The alert asks "is this a regression since last night"; the dispatch asks "does this node already have an issue". They now have separate inputs.

| Function | Question |
|---|---|
| `compute_new_failures(prev, confirmed)` | new since last night → drives the Telegram alert |
| `compute_dispatch_set(prev, confirmed)` | never handed to triage → drives the dispatch |
| `carry_dispatched_nodes(prev, confirmed, just_dispatched)` | what to persist |

- **`dispatched_nodes`** replaces `dispatched_hash`. Per-node suppression strictly supersedes the set-wide hash, and the hash could only ever block a legitimate retry, so it is removed rather than kept alongside.
- **Retries survive.** A node whose dispatch subprocess failed is no longer "new" but is still unfiled, so it stays in the dispatch set. This is exactly why the dispatch set is not `compute_new_failures`.
- **Fixed nodes drop out**, so a genuine re-regression is dispatchable again later. This also retires the stale ID the issue calls out: `df6097fe6` renamed the watchdog node, so it stops appearing in the confirmed set and falls out of state with no special case.
- **Baseline runs seed instead of dispatching.** Without the seed the *next* run would file the entire standing set as fresh discoveries.
- **Header corrected** to `Not-yet-triaged failing node IDs:`, plus an instruction to search open issues and comment rather than open a duplicate.
- `prior_dispatched` falls back to the prior run's confirmed set when `dispatched_nodes` is absent, so the first run after this lands does not replay the churn one last time.

## Verification

```
tests/unit/test_nightly_regression_tests.py   62 passed
```

Same scenario against the fix:

```
run 1: DISPATCHED = ['tests/unit/x.py::test_a']
run 2: DISPATCHED = ['tests/unit/x.py::test_b']

standing node fixed, then regresses again:
  after clean run, dispatched_nodes = []
  regression re-dispatches: ['tests/unit/test_watchdog.py::test_dead_node']
```

New coverage: `TestComputeDispatchSet` (5), `TestCarryDispatchedNodes` (4), and `TestMainDispatchPersistence` (7) driving the whole of `main()` including the end-to-end standing-plus-new case, the failed-dispatch retry, and the baseline seed.

## Incidental fix

Three `main()`-driving tests were already red on `main` when run from a git worktree: `.env` is untracked, so it is absent there and the #2327 env guard exits before the assertions run. `load_env_or_die` is now patched in those tests, which are about dispatch persistence rather than env loading. Baselined before and after:

```
before (origin/main, in a worktree):  3 failed, 46 passed
after:                                0 failed, 62 passed
```

## DOCS

- `docs/features/nightly-alert-triage.md` — "Triage Session Dispatch" rewritten: new signature, per-node dedup semantics, alert-vs-dispatch distinction, retry/re-regression/rename/baseline behavior. Summarizer signature and files table updated.
- `docs/features/nightly-regression-tests.md` — state-file field list.
- `scripts/nightly_regression_tests.py` module docstring — new "Triage dispatch is deduped per node" section.