### PR TITLE
Fix the Verification-table pipe split; reject unreadable rows instead of truncating (#2570)

### DIFF
--- a/agent/verification_parser.py
+++ b/agent/verification_parser.py
@@ -11,6 +11,39 @@ Plan documents contain a ``## Verification`` section with a markdown table:
 
 This module extracts those rows into ``VerificationCheck`` objects and provides
 ``evaluate_expectation`` to decide pass/fail based on command results.
+
+Pipes in commands (#2570)
+-------------------------
+Rows are split on **unescaped** ``|`` only, and ``\\|`` is unescaped to a
+literal ``|`` afterwards. That is standard GitHub-flavored Markdown, and it
+makes the Markdown-safe way to write a pipe also the correct way:
+
+    | Anti-criterion | `grep -rc 'a\\|b' src/ \\| wc -l` | match count == 0 |
+
+runs ``grep -rc 'a|b' src/ | wc -l``. Before this, every row was split on every
+``|``, so a pipe-bearing command was truncated at the pipe, the ``Expected``
+cell received the fragment *after* it, and the real expectation was discarded.
+The check then ran a command its author never wrote, failed for an unrelated
+reason (usually a shell syntax error), and reported that failure against the
+code under test. Escaping did not help: both ``\\|`` and a bare ``|``
+truncated, so there was no working form and regex alternation, shell
+pipelines, and ``re.S|re.M`` were all unwritable.
+
+A row that still does not yield the header's column count -- an author wrote a
+bare ``|`` and meant it as part of the command -- is now reported as a
+:class:`MalformedRow` rather than executed as something else. Silently running
+a different command than the one on the page is the failure this module exists
+not to have.
+
+The escape composes, which matters for basic-regex ``grep``: in a BRE,
+alternation is spelled ``\\|``, and to get that through the table you double
+the backslash. What lands in the shell is one level of unescaping::
+
+    table cell        reaches the shell as     grep -E / grep -c meaning
+    ---------------   ----------------------   -------------------------
+    a\\|b              a|b                      -E: alternation. -c: literal "a|b"
+    a\\\\|b             a\\|b                     -c (BRE): alternation
+    a|b               (rejected: malformed)    --
 """
 
 from __future__ import annotations
@@ -18,6 +51,25 @@ from __future__ import annotations
 import re
 import subprocess
 from dataclasses import dataclass
+
+# Split on a `|` that is not backslash-escaped. A row's cells are the pieces
+# between these; `\|` inside a cell survives the split and is unescaped after.
+_UNESCAPED_PIPE_RE = re.compile(r"(?<!\\)\|")
+
+
+def split_row_cells(row: str) -> list[str]:
+    """Split one markdown table row into its cells, honoring ``\\|`` escapes.
+
+    Leading/trailing empties from the row's border pipes are dropped; interior
+    empties are preserved, because an empty cell is a real (if unusable) cell
+    and collapsing it would shift every column after it.
+    """
+    parts = _UNESCAPED_PIPE_RE.split(row)
+    if parts and not parts[0].strip():
+        parts = parts[1:]
+    if parts and not parts[-1].strip():
+        parts = parts[:-1]
+    return [p.replace("\\|", "|").strip() for p in parts]
 
 
 @dataclass(frozen=True)
@@ -27,6 +79,26 @@ class VerificationCheck:
     name: str
     command: str
     expected: str
+
+
+@dataclass(frozen=True)
+class MalformedRow:
+    """A table row that could not be read as the author wrote it.
+
+    Reported separately from a failed check: this is a plan-authoring error,
+    not evidence about the code under test.
+    """
+
+    line: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ParsedTable:
+    """Everything a ``## Verification`` table yielded, including its rejects."""
+
+    checks: list[VerificationCheck]
+    malformed: list[MalformedRow]
 
 
 @dataclass
@@ -40,48 +112,73 @@ class CheckResult:
     error: str = ""
 
 
-def parse_verification_table(markdown: str) -> list[VerificationCheck]:
+def parse_verification_table(markdown: str) -> ParsedTable:
     """Extract verification checks from a ``## Verification`` markdown table.
 
-    Returns an empty list when no ``## Verification`` section is found or the
-    table has no data rows.
+    Returns an empty :class:`ParsedTable` when no ``## Verification`` section is
+    found or the table has no data rows.
+
+    The expected column count comes from the header rather than being hardcoded
+    to 3, so a table that carries an extra annotation column is read correctly
+    instead of having every row rejected. Only the first three columns are used:
+    Check, Command, Expected.
+
+    A row that does not yield that many cells lands in ``malformed`` with a
+    reason. It is never executed on a guess (#2570).
     """
-    # Find the ## Verification section
     section_match = re.search(
         r"^## Verification\s*$(.*?)(?=^## |\Z)",
         markdown,
         re.MULTILINE | re.DOTALL,
     )
     if not section_match:
-        return []
+        return ParsedTable(checks=[], malformed=[])
 
     section = section_match.group(1)
 
-    # Find table rows (lines starting with |)
     rows = [line.strip() for line in section.splitlines() if line.strip().startswith("|")]
-
     if len(rows) < 2:
         # Need at least header + separator (no data rows)
-        return []
+        return ParsedTable(checks=[], malformed=[])
+
+    expected_columns = max(len(split_row_cells(rows[0])), 3)
 
     checks: list[VerificationCheck] = []
+    malformed: list[MalformedRow] = []
+
     for row in rows[2:]:  # Skip header and separator
-        cells = [c.strip() for c in row.split("|")]
-        # Split produces empty strings at boundaries: ['', 'Check', 'Command', 'Expected', '']
-        cells = [c for c in cells if c]
-        if len(cells) < 3:
+        cells = split_row_cells(row)
+
+        if len(cells) != expected_columns:
+            malformed.append(
+                MalformedRow(
+                    line=row,
+                    reason=(
+                        f"expected {expected_columns} columns, got {len(cells)}. "
+                        "An unescaped `|` inside a cell splits the row. Write it "
+                        "as `\\|` (Markdown escape) and it reaches the shell as a "
+                        "literal pipe."
+                    ),
+                )
+            )
             continue
 
-        name = cells[0].strip()
-        command = cells[1].strip().strip("`")
-        expected = cells[2].strip()
+        name = cells[0]
+        command = cells[1].strip("`")
+        expected = cells[2]
 
         if not name or not command or not expected:
+            malformed.append(
+                MalformedRow(
+                    line=row,
+                    reason="Check, Command, and Expected must all be non-empty.",
+                )
+            )
             continue
 
         checks.append(VerificationCheck(name=name, command=command, expected=expected))
 
-    return checks
+    return ParsedTable(checks=checks, malformed=malformed)
 
 
 def evaluate_expectation(expected: str, *, exit_code: int, output: str) -> bool:
@@ -102,10 +199,11 @@ def evaluate_expectation(expected: str, *, exit_code: int, output: str) -> bool:
       ends with ":0" (the ``grep -c``/``grep -rc`` shapes) AND stdout is non-empty
       (empty-stdout gate: a command that errored or wrote only to stderr yields empty
       stdout; without the gate ``all(...)`` over an empty list is vacuously True).
-      Canonical idioms:
+      Canonical idioms (write the pipe as ``\\|`` in the plan's table -- see the
+      module docstring; it reaches the shell as a literal ``|``):
         - ``grep -c PATTERN file``      → emits literal "0", exit 1 → passes
         - ``grep -rc PATTERN dir``      → emits "path:0" per file, exit 1 → passes
-        - ``grep -r PATTERN dir | wc -l`` → emits whitespace "       0", exit 0 → passes
+        - ``grep -r PATTERN dir \\| wc -l`` → emits whitespace "       0", exit 0 → passes
         - truly-empty stdout (errored)  → rejected by empty-stdout gate → fails
 
     The inverse ``exit code != N`` branch is checked BEFORE the positive ``exit code N``
@@ -226,10 +324,30 @@ def run_checks(
     return results
 
 
-def format_results(results: list[CheckResult]) -> str:
-    """Format check results as a human-readable report."""
+def format_results(
+    results: list[CheckResult],
+    malformed: list[MalformedRow] | None = None,
+) -> str:
+    """Format check results as a human-readable report.
+
+    Malformed rows are reported in their own section, above the checks and
+    named as plan-authoring errors, so a row that could not be read is never
+    mistaken for evidence about the code under test (#2570). They also make the
+    run fail: a row nobody can execute is not a passing check.
+    """
+    malformed = malformed or []
     lines: list[str] = ["## Verification Results", ""]
-    all_passed = all(r.passed for r in results)
+    all_passed = all(r.passed for r in results) and not malformed
+
+    if malformed:
+        lines.append(f"### Plan authoring errors ({len(malformed)})")
+        lines.append("")
+        lines.append("These rows were NOT executed. Fix the plan, not the code.")
+        lines.append("")
+        for m in malformed:
+            lines.append(f"- [MALFORMED] {m.line}")
+            lines.append(f"  Reason: {m.reason}")
+        lines.append("")
 
     for r in results:
         status = "PASS" if r.passed else "FAIL"
@@ -244,7 +362,10 @@ def format_results(results: list[CheckResult]) -> str:
                 lines.append(f"  Error: {r.error[:200]}")
 
     lines.append("")
-    summary = "All checks passed." if all_passed else "Some checks failed."
+    if malformed and all(r.passed for r in results):
+        summary = f"{len(malformed)} row(s) could not be parsed and were not run."
+    else:
+        summary = "All checks passed." if all_passed else "Some checks failed."
     lines.append(f"**{summary}**")
 
     return "\n".join(lines)

--- a/docs/features/machine-readable-dod.md
+++ b/docs/features/machine-readable-dod.md
@@ -83,8 +83,35 @@ These assertable No-Gos (typically `[DESTRUCTIVE]` and `[SEPARATE-SLUG]` tagged 
        | (opt-in derivation — only for assertable No-Gos)
        v
 ## Verification (machine-executable assertion)
-  | No raw Redis deletes | grep -c "r\.delete\|r\.srem" agent/verification_parser.py | match count == 0 |
+  | No raw Redis deletes | grep -c "r\.delete\\|r\.srem" agent/verification_parser.py | match count == 0 |
 ```
+
+### Authoring Rule: Pipes Must Be Escaped
+
+A `|` is the table's own column separator, so a command containing one has to
+be escaped as `\|` — standard GitHub-flavored Markdown. The parser unescapes it
+after splitting, so `\|` reaches the shell as a literal pipe. A bare `|` is
+rejected as a plan-authoring error rather than executed truncated (#2570).
+
+The escape composes, which is the part worth reading twice:
+
+| In the table cell | Reaches the shell as | Under `grep -E` | Under `grep -c` (BRE) |
+|---|---|---|---|
+| `a\|b` | `a\|b` | alternation | literal `a\|b` |
+| `a\\\|b` | `a\\|b` | literal `a\\|b` | alternation |
+| `a\|b` (unescaped) | rejected as malformed | — | — |
+
+So an anti-criterion using basic-regex `grep -c` alternation — the shape most
+anti-criteria take — writes a **doubled** backslash in the table. The worked
+example below does exactly that.
+
+Before this rule existed, both the escaped and unescaped forms truncated at the
+pipe, and the `Expected` cell silently received the fragment after it. A scan of
+`docs/plans/` found 544 rows carrying that signature. The checks failed rather
+than false-passed, but they failed for a parsing reason while looking like a
+finding about the code, which is why several reached `completed/` with the
+broken row still in place. Anti-criteria were the most affected class, because
+they are the ones that need alternation.
 
 ### Authoring Rule: Red-State Proof (Posture: Paper-Trail PR Checklist)
 
@@ -106,7 +133,7 @@ This project has a `[DESTRUCTIVE]` No-Go: "never use raw Redis on Popoto-managed
 **The Verification row:**
 
 ```markdown
-| No raw Redis deletes | `grep -c "r\.delete\|r\.srem" agent/verification_parser.py` | match count == 0 |
+| No raw Redis deletes | `grep -c "r\.delete\\|r\.srem" agent/verification_parser.py` | match count == 0 |
 ```
 
 **Green-state run (clean code — no violations):**

--- a/docs/sdlc/do-build.md
+++ b/docs/sdlc/do-build.md
@@ -95,7 +95,9 @@ live in `stage-query` and never write.
 (cd $TARGET_REPO/.worktrees/{slug} && python scripts/validate_build.py $PLAN_PATH)   # exit 1 → /do-patch, ≤3 iters
 (cd $TARGET_REPO/.worktrees/{slug} && python scripts/evaluate_build.py $PLAN_PATH)   # exit 2 → bundle FAILs to /do-patch, ≤2 iters; 3 = no criteria; 1 = non-blocking
 # Verification table runner:
-python -c "from agent.verification_parser import parse_verification_table, run_checks, format_results; ..."
+python -c "import sys; from agent.verification_parser import parse_verification_table, run_checks, format_results; t = parse_verification_table(open(PLAN_PATH).read()); r = run_checks(t.checks); print(format_results(r, t.malformed)); sys.exit(1 if t.malformed or not all(x.passed for x in r) else 0)"
+# A row in `t.malformed` is a PLAN-AUTHORING error (an unescaped `|` split it), not a
+# finding about the code. Write pipes in the table as `\|`. See #2570.
 ```
 
 **Documentation gate scripts (Step 6):**

--- a/docs/sdlc/do-pr-review.md
+++ b/docs/sdlc/do-pr-review.md
@@ -58,7 +58,9 @@ inheritance, not a block: use the returned `run_id` and continue; only a foreign
 **Verification-table runner (§ 4.5):**
 
 ```bash
-python -c "from agent.verification_parser import parse_verification_table, run_checks, format_results; ..."
+python -c "import sys; from agent.verification_parser import parse_verification_table, run_checks, format_results; t = parse_verification_table(open(PLAN_PATH).read()); r = run_checks(t.checks); print(format_results(r, t.malformed)); sys.exit(1 if t.malformed or not all(x.passed for x in r) else 0)"
+# A row in `t.malformed` is a PLAN-AUTHORING error (an unescaped `|` split it), not a
+# finding about the code. Write pipes in the table as `\|`. See #2570.
 ```
 
 **Plan-checkbox updater (post-review § 2.5).** Sync each rubric-judged criterion with:

--- a/scripts/validate_build.py
+++ b/scripts/validate_build.py
@@ -20,6 +20,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from agent.verification_parser import split_row_cells  # noqa: E402
+
 
 def extract_section(plan_text: str, heading: str) -> str:
     """Extract content of a markdown section by heading name.
@@ -80,6 +84,14 @@ def parse_verification_table(plan_text: str) -> list[dict[str, str]]:
     | Check | Command | Expected |
     |-------|---------|----------|
     | name  | `cmd`   | result   |
+
+    Rows split on **unescaped** ``|`` only, with ``\\|`` unescaped to a literal
+    pipe afterwards, sharing ``agent.verification_parser.split_row_cells`` so
+    this validator and the verification runner cannot disagree about what a row
+    says (#2570). A row that does not yield the header's column count is
+    returned with ``malformed`` set: it is reported as a plan-authoring error
+    rather than executed truncated, which used to run a command the author
+    never wrote and blame the failure on the code under test.
     """
     section = extract_section(plan_text, "Verification")
     if not section:
@@ -92,6 +104,7 @@ def parse_verification_table(plan_text: str) -> list[dict[str, str]]:
         stripped = lines[i].strip()
         # Look for table header with Command column
         if stripped.startswith("|") and "command" in stripped.lower():
+            expected_columns = max(len(split_row_cells(stripped)), 3)
             # Skip separator row
             i += 1
             if i < len(lines) and re.match(r"^\s*\|[\s\-:]+\|", lines[i]):
@@ -101,17 +114,29 @@ def parse_verification_table(plan_text: str) -> list[dict[str, str]]:
                 row = lines[i].strip()
                 if not row.startswith("|"):
                     break
-                cells = [c.strip() for c in row.strip("|").split("|")]
-                if len(cells) >= 3:
+                cells = split_row_cells(row)
+                if len(cells) == expected_columns:
                     cmd_cell = cells[1]
                     cmd_match = re.search(r"`(.+?)`", cmd_cell)
                     command = cmd_match.group(1) if cmd_match else cmd_cell.strip()
-                    expected_cell = cells[2].strip()
                     checks.append(
                         {
-                            "name": cells[0].strip(),
+                            "name": cells[0],
                             "command": command,
-                            "expected": expected_cell,
+                            "expected": cells[2],
+                        }
+                    )
+                else:
+                    checks.append(
+                        {
+                            "name": row,
+                            "command": "",
+                            "expected": "",
+                            "malformed": (
+                                f"expected {expected_columns} columns, got {len(cells)}. "
+                                "An unescaped `|` inside a cell splits the row; "
+                                "write it as `\\|`."
+                            ),
                         }
                     )
                 i += 1
@@ -237,6 +262,21 @@ def check_verification_table(checks: list[dict[str, str]]) -> list[dict]:
     """Run verification table commands and compare output."""
     results = []
     for check in checks:
+        if check.get("malformed"):
+            # Plan-authoring error, not evidence about the code (#2570). Fails
+            # the run -- a row nobody can execute is not a passing check -- but
+            # says plainly that the plan is what needs fixing.
+            results.append(
+                {
+                    "status": "FAIL",
+                    "message": (
+                        f"MALFORMED VERIFICATION ROW (fix the plan, not the code): "
+                        f"{check['malformed']} Row: {check['name']}"
+                    ),
+                }
+            )
+            continue
+
         cmd = check["command"]
         expected = check["expected"]
         name = check["name"]

--- a/tests/unit/test_validate_build.py
+++ b/tests/unit/test_validate_build.py
@@ -299,7 +299,13 @@ class TestMainEdgeCases:
         with patch("sys.argv", ["validate_build.py", str(f)]):
             assert validate_build.main() == 0
 
-    def test_malformed_verification_table(self, tmp_path):
+    def test_malformed_verification_table(self, tmp_path, capsys):
+        """A row that cannot be read must FAIL, not be silently skipped (#2570).
+
+        This previously asserted exit 0 -- "nothing parseable, so nothing to
+        say". That silence is the defect: an unrunnable row and a passing check
+        were indistinguishable in the exit code.
+        """
         f = tmp_path / "malformed.md"
         f.write_text(
             textwrap.dedent("""\
@@ -311,5 +317,28 @@ class TestMainEdgeCases:
         """)
         )
         with patch("sys.argv", ["validate_build.py", str(f)]):
-            # Malformed table -> nothing parseable -> exit 0
+            assert validate_build.main() == 1
+        out = capsys.readouterr().out
+        assert "MALFORMED VERIFICATION ROW" in out
+        assert "fix the plan, not the code" in out
+
+    def test_pipe_bearing_command_runs_intact(self, tmp_path):
+        """The command class this parser could not express at all (#2570):
+        a shell pipeline. `\\|` in the table reaches the shell as a real pipe,
+        so `printf 'a\\nb\\n' | wc -l` emits 2 rather than truncating."""
+        f = tmp_path / "piped.md"
+        f.write_text(
+            textwrap.dedent("""\
+            ## Verification
+
+            | Check | Command | Expected |
+            |-------|---------|----------|
+            | Pipeline runs | `printf 'a\\nb\\n' \\| wc -l` | output contains 2 |
+        """)
+        )
+        checks = validate_build.parse_verification_table(f.read_text())
+        assert len(checks) == 1
+        assert checks[0]["command"] == "printf 'a\\nb\\n' | wc -l"
+        assert checks[0]["expected"] == "output contains 2"
+        with patch("sys.argv", ["validate_build.py", str(f)]):
             assert validate_build.main() == 0

--- a/tests/unit/test_verification_parser.py
+++ b/tests/unit/test_verification_parser.py
@@ -1,9 +1,13 @@
 """Unit tests for agent/verification_parser.py -- machine-readable verification checks."""
 
 from agent.verification_parser import (
+    CheckResult,
+    MalformedRow,
     VerificationCheck,
     evaluate_expectation,
+    format_results,
     parse_verification_table,
+    split_row_cells,
 )
 
 # ---------------------------------------------------------------------------
@@ -23,7 +27,7 @@ class TestParseVerificationTable:
 | Tests pass | `pytest tests/ -x -q` | exit code 0 |
 | Lint clean | `python -m ruff check .` | exit code 0 |
 """
-        checks = parse_verification_table(md)
+        checks = parse_verification_table(md).checks
         assert len(checks) == 2
         assert checks[0] == VerificationCheck(
             name="Tests pass",
@@ -44,7 +48,7 @@ class TestParseVerificationTable:
 |-------|---------|----------|
 | PR opened | `gh pr list --head session/slug --json number --jq length` | output > 0 |
 """
-        checks = parse_verification_table(md)
+        checks = parse_verification_table(md).checks
         assert len(checks) == 1
         assert checks[0].expected == "output > 0"
 
@@ -56,7 +60,7 @@ class TestParseVerificationTable:
 |-------|---------|----------|
 | Module loads | `python -c "import foo; print(foo.__version__)"` | output contains foo |
 """
-        checks = parse_verification_table(md)
+        checks = parse_verification_table(md).checks
         assert len(checks) == 1
         assert checks[0].expected == "output contains foo"
 
@@ -66,7 +70,7 @@ class TestParseVerificationTable:
 
 - [ ] Something
 """
-        checks = parse_verification_table(md)
+        checks = parse_verification_table(md).checks
         assert checks == []
 
     def test_empty_table(self):
@@ -76,7 +80,7 @@ class TestParseVerificationTable:
 | Check | Command | Expected |
 |-------|---------|----------|
 """
-        checks = parse_verification_table(md)
+        checks = parse_verification_table(md).checks
         assert checks == []
 
     def test_ignores_separator_row(self):
@@ -87,7 +91,7 @@ class TestParseVerificationTable:
 |-------|---------|----------|
 | Test | `echo hi` | exit code 0 |
 """
-        checks = parse_verification_table(md)
+        checks = parse_verification_table(md).checks
         assert len(checks) == 1
 
     def test_strips_backticks_from_command(self):
@@ -98,7 +102,7 @@ class TestParseVerificationTable:
 |-------|---------|----------|
 | Test | `echo hello` | exit code 0 |
 """
-        checks = parse_verification_table(md)
+        checks = parse_verification_table(md).checks
         assert checks[0].command == "echo hello"
 
     def test_command_without_backticks(self):
@@ -109,7 +113,7 @@ class TestParseVerificationTable:
 |-------|---------|----------|
 | Test | echo hello | exit code 0 |
 """
-        checks = parse_verification_table(md)
+        checks = parse_verification_table(md).checks
         assert checks[0].command == "echo hello"
 
     def test_table_after_other_content(self):
@@ -131,7 +135,7 @@ Something is broken.
 
 None.
 """
-        checks = parse_verification_table(md)
+        checks = parse_verification_table(md).checks
         assert len(checks) == 1
         assert checks[0].name == "Fix works"
 
@@ -148,7 +152,7 @@ None.
 | Feature doc exists | `test -f docs/features/foo.md` | exit code 0 |
 | PR opened | `gh pr list --head session/foo --json number --jq length` | output > 0 |
 """
-        checks = parse_verification_table(md)
+        checks = parse_verification_table(md).checks
         assert len(checks) == 6
 
 
@@ -377,3 +381,120 @@ class TestEvaluateExpectationInverse:
     def test_positive_output_gt_still_works(self):
         assert evaluate_expectation("output > 0", exit_code=0, output="3") is True
         assert evaluate_expectation("output > 0", exit_code=0, output="0") is False
+
+
+# ---------------------------------------------------------------------------
+# Pipe handling in commands (#2570)
+# ---------------------------------------------------------------------------
+
+
+class TestPipesInCommands:
+    """Rows split on unescaped `|` only; `\\|` is a literal pipe.
+
+    Before this, every row split on every `|`: a pipe-bearing command was
+    truncated at the pipe, the Expected cell received the fragment after it,
+    and the real expectation was discarded. The check then ran a command its
+    author never wrote and failed for an unrelated reason -- attributing a
+    parse error to the code under test. Both `\\|` and a bare `|` truncated, so
+    there was no working form at all.
+
+    A scan of docs/plans/ found 544 rows across 251 plans with the truncation
+    signature. Escape-aware splitting recovers 502 of them; the remaining 42
+    carry a genuinely bare `|` and are now rejected loudly instead of executed
+    as something else.
+    """
+
+    def _table(self, row: str) -> str:
+        return f"## Verification\n\n| Check | Command | Expected |\n|--|--|--|\n{row}\n"
+
+    def test_shell_pipeline_is_expressible(self):
+        table = self._table("| Count | `grep -r X dir \\| wc -l` | match count == 0 |")
+        parsed = parse_verification_table(table)
+        assert parsed.malformed == []
+        assert parsed.checks[0].command == "grep -r X dir | wc -l"
+        assert parsed.checks[0].expected == "match count == 0"
+
+    def test_regex_alternation_is_expressible(self):
+        table = self._table("| Anti | `grep -cE 'a\\|b' src.py` | match count == 0 |")
+        parsed = parse_verification_table(table)
+        assert parsed.malformed == []
+        assert parsed.checks[0].command == "grep -cE 'a|b' src.py"
+
+    def test_python_bitwise_or_is_expressible(self):
+        table = self._table('| Flags | `python -c "import re; print(re.S\\|re.M)"` | exit code 0 |')
+        parsed = parse_verification_table(table)
+        assert parsed.malformed == []
+        assert "re.S|re.M" in parsed.checks[0].command
+
+    def test_the_issue_2570_worked_example(self):
+        """The exact row from the issue, which parsed to a broken command and a
+        garbage expectation, then failed with a shell syntax error."""
+        table = self._table(
+            "| Anti-criterion: sdlc not hardcoded | "
+            '`! grep -nE \'"sdlc/"\\|/ "sdlc"\' scripts/update/hardlinks.py` | exit code 0 |'
+        )
+        parsed = parse_verification_table(table)
+        assert parsed.malformed == []
+        assert (
+            parsed.checks[0].command
+            == '! grep -nE \'"sdlc/"|/ "sdlc"\' scripts/update/hardlinks.py'
+        )
+        assert parsed.checks[0].expected == "exit code 0"
+
+    def test_bare_pipe_is_rejected_not_truncated(self):
+        """The unescaped form has no unambiguous reading, so it must be
+        reported as an authoring error rather than executed as a guess."""
+        table = self._table("| Anti | `grep -cE 'a|b' src.py` | match count == 0 |")
+        parsed = parse_verification_table(table)
+        assert parsed.checks == []
+        assert len(parsed.malformed) == 1
+        assert "unescaped `|`" in parsed.malformed[0].reason
+        assert "\\|" in parsed.malformed[0].reason  # names the remedy
+
+    def test_pipe_free_control_still_parses(self):
+        """The currently-passing control from the issue's table."""
+        table = self._table("| Tests pass | `pytest -q` | exit code 0 |")
+        parsed = parse_verification_table(table)
+        assert parsed.malformed == []
+        assert parsed.checks[0].command == "pytest -q"
+
+    def test_empty_cell_is_rejected_not_silently_dropped(self):
+        table = self._table("| Named check | | exit code 0 |")
+        parsed = parse_verification_table(table)
+        assert parsed.checks == []
+        assert len(parsed.malformed) == 1
+
+    def test_column_count_comes_from_the_header(self):
+        """One plan in docs/plans/ carries a 4-column Verification table.
+        Hardcoding 3 would reject every one of its rows."""
+        table = (
+            "## Verification\n\n"
+            "| Check | Command | Expected | Notes |\n|--|--|--|--|\n"
+            "| Tests pass | `pytest -q` | exit code 0 | nightly |\n"
+        )
+        parsed = parse_verification_table(table)
+        assert parsed.malformed == []
+        assert parsed.checks[0].name == "Tests pass"
+        assert parsed.checks[0].expected == "exit code 0"
+
+    def test_split_row_cells_unescapes_and_preserves_interior_empties(self):
+        assert split_row_cells("| a | b\\|c | d |") == ["a", "b|c", "d"]
+        assert split_row_cells("| a |  | c |") == ["a", "", "c"]
+
+
+class TestMalformedRowReporting:
+    def test_format_results_names_authoring_errors_separately(self):
+        rows = [MalformedRow(line="| bad | row |", reason="expected 3 columns, got 2.")]
+        report = format_results([], rows)
+        assert "Plan authoring errors (1)" in report
+        assert "fix the plan, not the code" in report.lower()
+        assert "| bad | row |" in report
+
+    def test_a_malformed_row_fails_the_run(self):
+        """A row nobody can execute is not a passing check."""
+        check = VerificationCheck(name="ok", command="true", expected="exit code 0")
+        results = [CheckResult(check=check, passed=True, exit_code=0, output="")]
+        assert "All checks passed." in format_results(results, [])
+        report = format_results(results, [MalformedRow(line="| x |", reason="r")])
+        assert "All checks passed." not in report
+        assert "could not be parsed" in report


### PR DESCRIPTION
Closes #2570

## Problem

`agent/verification_parser.py:69` split every table row on every `|`. A pipe-bearing command was truncated at the pipe, the `Expected` cell received the fragment *after* it, and the real expectation was discarded. The check then ran a command its author never wrote, failed for an unrelated reason (usually a shell syntax error), and reported that failure **against the code under test**.

Escaping did not help. `\|` and a bare `|` truncated identically, so there was no working form at all — regex alternation, shell pipelines, and `re.S|re.M` were all unwritable. The failure was misattributed rather than fail-open, which is why it survived: a persistently red check that looks broken gets ignored or deleted.

## Fix

Rows split on **unescaped** `|` only, and `\|` is unescaped to a literal pipe afterwards. That is standard GitHub-flavored Markdown, so the Markdown-safe way to write a pipe is also the correct way.

The escape composes, which matters because most anti-criteria use basic-regex `grep -c` alternation:

| In the table cell | Reaches the shell as | `grep -E` | `grep -c` (BRE) |
|---|---|---|---|
| `a\|b` | `a\|b` | alternation | literal |
| `a\\\|b` | `a\\|b` | literal | alternation |
| `a\|b` unescaped | rejected as malformed | — | — |

A row that still does not yield the header's column count is reported as a `MalformedRow` and **never executed**. `parse_verification_table` returns `ParsedTable(checks, malformed)`; `format_results` reports authoring errors in their own section headed "fix the plan, not the code" and fails the run, because a row nobody can execute is not a passing check. The column count comes from the header rather than a hardcoded 3, so the one 4-column table in `docs/plans/` parses instead of having every row rejected.

## Two corrections to the issue as filed

1. **The same defect was in a second parser.** `scripts/validate_build.py` has its own `parse_verification_table`, and `do-build` Step 14 runs it as a *blocking* gate (exit 1 routes to `/do-patch`). It now shares `split_row_cells` with the runner, so the validator and the runner cannot disagree about what a row says.
2. **The `| wc -l` idiom lives in the parser docstring**, not `docs/features/machine-readable-dod.md` (the issue comment already caught this). Both are corrected: the docstring shows the escaped form, and that feature doc's two canonical anti-criterion rows are corrected to `\\|` — verified to round-trip through the parser and pass.

## Measurement

| Measure | Count |
|---|---|
| Rows with the truncation signature under the old split | 544 (reproduces the issue's 545) |
| Recovered by escape-aware splitting | 508 |
| Still malformed (genuinely bare `\|`), now rejected loudly | 36 across 28 plans |

Of the 31 recovered rows in **active** plans, 10 fail — all in plans whose work is not yet merged, where red is the expected state. None revealed a hidden violation in merged code.

## Tests

`tests/unit/test_verification_parser.py` and `tests/unit/test_validate_build.py`, 88 passing including `test_architectural_constraints`. Covers all three forms from the issue's table (backslash-escaped, unescaped, pipe-free control), the issue's verbatim worked example, each previously-ruled-out command class (alternation, pipeline, `re.S|re.M`), and header-driven column counts.

`test_malformed_verification_table` previously asserted exit 0 — "nothing parseable, so nothing to say". That silence was the defect; it now asserts the loud failure.