### PR TITLE
Split the delete-and-recreate helper along its two contracts (#2563)

### DIFF
--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -163,62 +163,113 @@ _SESSION_TYPE_UNSET = object()
 PRIORITY_RANK = {"urgent": 0, "high": 1, "normal": 2, "low": 3}
 
 
-# Fields to extract from AgentSession for delete-and-recreate pattern.
-# Used by callers that legitimately need a fresh AutoKeyField-generated ID:
-# retry, orphan fix, and the continuation fallback in _enqueue_nudge. The pop
-# path (_pop_agent_session) does NOT use this — it mutates in place via
-# transition_status() because status is an IndexedField, not a KeyField, and
-# the secondary index is updated correctly on save().
-_AGENT_SESSION_FIELDS = [
-    "project_key",
-    "status",
-    "priority",
-    "scheduled_at",
-    "created_at",
-    "session_id",
-    "working_dir",
-    "initial_telegram_message",
-    "chat_id",
-    "extra_context",
-    "task_list_id",
-    "auto_continue_count",
-    "started_at",
-    "telegram_message_key",
-    "updated_at",
-    "completed_at",
-    "turn_count",
-    "tool_call_count",
-    "log_path",
-    "branch_name",
-    "tags",
-    "session_events",
-    "issue_url",
-    "plan_url",
-    "pr_url",
-    "context_summary",
-    "correlation_id",
-    "claude_session_uuid",
-    "parent_agent_session_id",
-    "session_type",
-    "slug",
-    "pm_sent_message_ids",
-    "recent_sent_drafts",
-    "last_heartbeat_at",
-    "last_sdk_heartbeat_at",
-    "last_stdout_at",
-    "recovery_attempts",
-    "reprieve_count",
-]
+# ---------------------------------------------------------------------------
+# Delete-and-recreate field sets (issue #2563)
+# ---------------------------------------------------------------------------
+# Four call sites delete an AgentSession row and create a replacement, because
+# KeyFields cannot be mutated in place without corrupting their index. They
+# split into two contracts that no single field list can serve at once:
+#
+#   CLONE — the recreated row IS the same session. Orphan repair
+#   (agent/session_health.py) clears a KeyField; the scheduler's priority bump
+#   (tools/agent_session_scheduler.py) changes one value. Both describe the same
+#   live process, so anything not copied is destroyed.
+#
+#   CONTINUATION — the recreated row is a NEW execution of the same session_id.
+#   retry_agent_session below and the auto-continue fallback in
+#   agent/session_executor.py both produce a `pending` row that no process has
+#   ever run. History carries; the execution fence must not.
+#
+# A hand-maintained list served both and was wrong for both: it had drifted 50
+# fields behind the model, silently destroying issue_number, pr_number, model,
+# the token/cost accounting and the thread counters on every clone, while its
+# omission of the fence fields was load-bearing-by-accident for continuation.
+# Deriving the copy set from the model removes that drift class permanently.
+#
+# The pop path (_pop_agent_session) uses neither — it mutates in place via
+# transition_status(), since status is an IndexedField and save() maintains the
+# secondary index correctly.
+
+# Fields cleared on the CONTINUATION path. Each describes ONE execution, so
+# copying it onto a row that has never run forges a record of a process that
+# never ran for it — the exact forged-liveness failure the #2518 durability
+# fence exists to prevent, since a `pending` row is non-terminal and therefore
+# visible to find_live_session_by_pid's ownership scan.
+#
+# This set is deliberately the execution fence and run identity, NOT a general
+# freshness reset. The heartbeat and liveness timestamps carry, as they always
+# have; changing those has watchdog blast radius and is a separate decision.
+_EXECUTION_FENCE_RESET_FIELDS = frozenset(
+    {
+        # The fenced execution record (docs/features/agent-session-fenced-execution-record.md).
+        "exec_pid",  # OS pid of a harness subprocess this row never spawned.
+        "pid_create_time",  # The PID-reuse fence for that pid; meaningless without it.
+        "exec_cwd",  # Working dir that spawn ran in; resume is cwd-scoped.
+        "exec_harness",  # Which harness ran it; the new run picks its own.
+        "spawn_history",  # Append-only spawn timeline of the previous run.
+        # Run identity.
+        "active_run_id",  # Names the run that just ended, not the one being queued.
+        "owned_run_ids",  # Runs the previous execution owned.
+        "worker_pid",  # Worker process that owned the previous execution.
+    }
+)
 
 
-def _extract_agent_session_fields(redis_session: AgentSession) -> dict:
-    """Extract all non-auto fields from an AgentSession instance.
+def _agent_session_model_fields() -> dict:
+    """The real ``AgentSession._meta.fields``, independent of module-level patching.
 
-    Returns a dict suitable for AgentSession.create(**fields) or
-    AgentSession.async_create(**fields). Excludes agent_session_id since that is
-    an AutoKeyField and will be auto-generated on create.
+    Schema derivation is a different concern from row construction. Several tests
+    patch this module's ``AgentSession`` name with a mock to intercept ``create``;
+    reading the schema off that mock would yield an empty field set and silently
+    produce empty payloads. Importing the model here keeps the derivation reading
+    the actual schema in every context.
     """
-    return {field: getattr(redis_session, field) for field in _AGENT_SESSION_FIELDS}
+    from models.agent_session import AgentSession as _AgentSessionModel
+
+    return _AgentSessionModel._meta.fields
+
+
+def _copyable_agent_session_fields() -> list[str]:
+    """Every AgentSession field a create() call may set, derived from the model.
+
+    Excludes AutoKeyFields (``id``), which are generated on create. Derived at
+    runtime rather than listed, so a new model field is covered the moment it is
+    added instead of waiting for someone to remember the list.
+    """
+    from popoto import AutoKeyField
+
+    return [
+        name
+        for name, field in _agent_session_model_fields().items()
+        if not isinstance(field, AutoKeyField)
+    ]
+
+
+def clone_agent_session_fields(redis_session: AgentSession) -> dict:
+    """Field payload for recreating the SAME session under a new AutoKey.
+
+    Copies everything, including the execution fence, because the recreated row
+    describes the same live process. Use this wherever the delete-and-recreate
+    exists only to change a KeyField; anything omitted here is destroyed.
+    """
+    return {field: getattr(redis_session, field) for field in _copyable_agent_session_fields()}
+
+
+def continuation_agent_session_fields(redis_session: AgentSession) -> dict:
+    """Field payload for a NEW execution of the same ``session_id``.
+
+    Starts from :func:`clone_agent_session_fields` and resets
+    :data:`_EXECUTION_FENCE_RESET_FIELDS` to each field's declared default, so
+    the new row carries the session's history without claiming a process that
+    never ran for it. Reading the default off the model rather than hardcoding
+    ``None`` keeps this correct if a field's unset state ever stops being null.
+    """
+    fields = clone_agent_session_fields(redis_session)
+    model_fields = _agent_session_model_fields()
+    for name in _EXECUTION_FENCE_RESET_FIELDS:
+        if name in fields:
+            fields[name] = getattr(model_fields[name], "default", None)
+    return fields
 
 
 async def _push_agent_session(
@@ -781,7 +832,9 @@ def retry_agent_session(agent_session_id: str) -> AgentSession | None:
         )
         return None
 
-    fields = _extract_agent_session_fields(session)
+    # CONTINUATION: a new execution of the same session_id. The failed run's
+    # fence must not follow it onto a row no process has run (#2563).
+    fields = continuation_agent_session_fields(session)
     fields["status"] = "pending"
     fields["priority"] = "high"
     fields["started_at"] = None

--- a/agent/session_executor.py
+++ b/agent/session_executor.py
@@ -583,9 +583,14 @@ async def _enqueue_nudge(
         # underlying AgentSession that was loaded when the session was popped.
         # This prevents loss of context_summary, issue_url,
         # pr_url, history, correlation_id, and other session-phase fields.
-        from agent.agent_session_queue import _extract_agent_session_fields as _eaf  # noqa: PLC0415
+        # CONTINUATION: a new execution of the same session_id. Copying the
+        # finished run's execution fence here would forge liveness for a process
+        # that never ran this row (#2563).
+        from agent.agent_session_queue import (  # noqa: PLC0415
+            continuation_agent_session_fields,
+        )
 
-        fields = _eaf(session)
+        fields = continuation_agent_session_fields(session)
         # Override fields that change for continuation
         fields["status"] = "pending"
         # Update initial_telegram_message directly (message_text/sender_name

--- a/agent/session_health.py
+++ b/agent/session_health.py
@@ -4579,11 +4579,13 @@ async def _agent_session_hierarchy_health_check() -> None:
                     )
                     # Delete-and-recreate required: parent_agent_session_id is a KeyField,
                     # so mutating it directly would corrupt the index.
+                    # CLONE: same session, same live process — copy everything
+                    # (#2563). Anything omitted here is destroyed.
                     from agent.agent_session_queue import (
-                        _extract_agent_session_fields,  # noqa: PLC0415
+                        clone_agent_session_fields,  # noqa: PLC0415
                     )
 
-                    fields = _extract_agent_session_fields(child)
+                    fields = clone_agent_session_fields(child)
                     child.delete()
                     fields["parent_agent_session_id"] = None
                     AgentSession.create(**fields)

--- a/docs/features/agent-session-model.md
+++ b/docs/features/agent-session-model.md
@@ -180,7 +180,7 @@ Each `session_id` has exactly one `AgentSession` at any time. The `AgentSession`
 - `issue_url`, `plan_url`, `pr_url` (link accumulation)
 - `context_summary` (semantic routing)
 
-Only four fields change during continuation: `status` (reset to "pending"), `initial_telegram_message.message_text` (nudge feedback), `auto_continue_count` (incremented), and `priority` (set to "high").
+Four fields change during continuation: `status` (reset to "pending"), `initial_telegram_message.message_text` (nudge feedback), `auto_continue_count` (incremented), and `priority` (set to "high"). The execution fence is additionally cleared, since the new row is a new execution that no process has run yet -- see [Two contracts, two field payloads](agent-session-queue.md#two-contracts-two-field-payloads-2563).
 
 **Fresh reads in routing:** The `send_to_chat` closure in `_execute_agent_session()` re-reads the `AgentSession` from Redis before making routing decisions. This ensures `is_sdlc` and `stage_states` data are current, not the stale in-memory copy captured at session start.
 

--- a/docs/features/agent-session-queue.md
+++ b/docs/features/agent-session-queue.md
@@ -55,13 +55,26 @@ Popoto's `KeyField.on_save()` only adds the object key to the new status index s
 The original delete-and-recreate pattern was:
 
 ```python
-fields = _extract_agent_session_fields(job)
+fields = clone_agent_session_fields(job)
 await job.async_delete()        # removes from old index via on_delete
 fields["status"] = "running"
 new_job = await AgentSession.async_create(**fields)  # adds to new index via on_save
 ```
 
-The `_extract_agent_session_fields()` helper reads all non-auto fields (56+) from an AgentSession instance for recreation. The `status` field is included for defense-in-depth: any remaining delete-and-recreate path (e.g., health check orphan-fixing that reparents sessions) preserves the original status instead of defaulting to `"pending"`. Callers that intentionally override status (retry, nudge fallback) set `fields["status"]` explicitly after extraction.
+### Two contracts, two field payloads (#2563)
+
+The surviving delete-and-recreate sites split into two groups that no single field payload can serve:
+
+| Helper | Contract | Call sites |
+|---|---|---|
+| `clone_agent_session_fields` | The recreated row **is** the same session; copy everything, fence included | `agent/session_health.py` orphan repair, `tools/agent_session_scheduler.py` priority bump |
+| `continuation_agent_session_fields` | The recreated row is a **new execution** of the same `session_id`; copy history, reset the fence | `retry_agent_session`, `agent/session_executor.py` auto-continue fallback |
+
+Both derive their field set from `AgentSession._meta` at runtime via `_copyable_agent_session_fields()`. The hand-maintained 38-entry list they replace had drifted 50 fields behind the model, silently destroying `issue_number`, `pr_number`, `model`, `retain_for_resume`, the token/cost accounting and the thread counters on every clone. Deriving retires that drift class rather than re-freezing it.
+
+`continuation_agent_session_fields` additionally resets `_EXECUTION_FENCE_RESET_FIELDS` — `exec_pid`, `pid_create_time`, `exec_cwd`, `exec_harness`, `spawn_history`, `active_run_id`, `owned_run_ids`, `worker_pid` — to each field's declared default. A continuation row is `pending` and therefore non-terminal, so it is visible to `find_live_session_by_pid`'s ownership scan; copying a fence onto it would make it claim a process that never ran for it, the forged-liveness failure the [execution fence](agent-session-fenced-execution-record.md) exists to prevent. That set is deliberately the fence and run identity, not a general freshness reset: the heartbeat and liveness timestamps carry, as they always have.
+
+The `status` field is copied by both for defense-in-depth, so orphan repair preserves the original status instead of defaulting to `"pending"`. Callers that intentionally override status (retry, nudge fallback) set `fields["status"]` explicitly afterward.
 
 ## Worker Drain Guard (Event-Based)
 
@@ -206,7 +219,7 @@ Parent finalization mutates the parent's status in place via `transition_status(
 
 The periodic health check (`_agent_session_hierarchy_health_check()`, called from `_agent_session_health_loop()` every 5 minutes) detects and self-heals:
 
-- **Orphaned children**: `parent_agent_session_id` points to non-existent session -- cleared (status preserved via `_extract_agent_session_fields()` to prevent zombie loops)
+- **Orphaned children**: `parent_agent_session_id` points to non-existent session -- cleared (status preserved via `clone_agent_session_fields()` to prevent zombie loops)
 - **Stuck parents**: `waiting_for_children` with all children terminal -- auto-finalized
 
 See [Agent Session Scheduling](agent-session-scheduling.md) for usage details and CLI commands.

--- a/docs/features/bridge-self-healing.md
+++ b/docs/features/bridge-self-healing.md
@@ -930,8 +930,10 @@ Redis counters keyed by `<project_key>:session-health:`:
 
 Pillar B's `self_report_sent_at` frequency-cap field was deleted by the schema diet (#1927) — the PM mid-work self-report it gated (`_emit_pm_self_report`) was retired 2026-05-06 and had no live writer.
 
-All fields are included in `_AGENT_SESSION_FIELDS` so they round-trip
-through delete-and-recreate paths (retry, orphan-fix, continuation fallback).
+Every model field round-trips through the delete-and-recreate paths (retry,
+orphan-fix, continuation fallback): both payloads derive their field set from
+`AgentSession._meta` at runtime, so a field added to the model is covered
+immediately. See [Two contracts, two field payloads](agent-session-queue.md#two-contracts-two-field-payloads-2563).
 
 ### Messenger callbacks (ORM-free)
 

--- a/tests/integration/test_agent_session_health_monitor.py
+++ b/tests/integration/test_agent_session_health_monitor.py
@@ -76,11 +76,11 @@ class TestStartedAtField:
         assert before <= started <= after
 
     def test_started_at_in_extract_fields(self):
-        """started_at should be included in _extract_agent_session_fields."""
-        from agent.agent_session_queue import _extract_agent_session_fields
+        """started_at should be included in the clone payload."""
+        from agent.agent_session_queue import clone_agent_session_fields
 
         session = _create_test_session(started_at=datetime.now(tz=UTC))
-        fields = _extract_agent_session_fields(session)
+        fields = clone_agent_session_fields(session)
         assert "started_at" in fields
         assert fields["started_at"] is not None
 

--- a/tests/integration/test_agent_session_queue_race.py
+++ b/tests/integration/test_agent_session_queue_race.py
@@ -18,11 +18,11 @@ from agent.agent_session_queue import (
     DRAIN_TIMEOUT,
     _active_workers,
     _ensure_worker,
-    _extract_agent_session_fields,
     _pop_agent_session,
     _pop_agent_session_with_fallback,
     _recover_interrupted_agent_sessions_startup,
     _starting_workers,
+    clone_agent_session_fields,
 )
 from models.agent_session import AgentSession
 
@@ -46,7 +46,7 @@ def _create_test_session(**overrides) -> AgentSession:
 
 
 class TestExtractJobFields:
-    """Tests for the _extract_agent_session_fields helper."""
+    """Tests for the clone_agent_session_fields helper."""
 
     def test_returns_complete_field_set(self):
         """All non-auto fields should be present in the extracted dict."""
@@ -60,7 +60,7 @@ class TestExtractJobFields:
             auto_continue_count=2,
         )
 
-        fields = _extract_agent_session_fields(session)
+        fields = clone_agent_session_fields(session)
 
         # agent_session_id should NOT be in extracted fields (it's AutoKeyField)
         assert "agent_session_id" not in fields
@@ -78,7 +78,7 @@ class TestExtractJobFields:
         assert fields["auto_continue_count"] == 2
 
         # message_text/sender_name/etc are packed into initial_telegram_message.
-        # _extract_agent_session_fields preserves the dict wholesale, so these
+        # clone_agent_session_fields preserves the dict wholesale, so these
         # user-facing values round-trip transitively.
         itm = fields["initial_telegram_message"]
         assert isinstance(itm, dict)
@@ -97,7 +97,7 @@ class TestExtractJobFields:
     def test_extracted_fields_can_recreate_job(self):
         """Extracted fields should be usable for AgentSession.create()."""
         original = _create_test_session()
-        fields = _extract_agent_session_fields(original)
+        fields = clone_agent_session_fields(original)
 
         # Should create successfully without errors
         new_job = AgentSession.create(**fields)

--- a/tests/integration/test_agent_session_scheduler.py
+++ b/tests/integration/test_agent_session_scheduler.py
@@ -12,8 +12,8 @@ import pytest
 
 from agent.agent_session_queue import (
     PRIORITY_RANK,
-    _extract_agent_session_fields,
     _pop_agent_session,
+    clone_agent_session_fields,
 )
 from models.agent_session import AgentSession
 
@@ -202,13 +202,13 @@ class TestAgentSessionFields:
         session = _create_pending()
         assert session.priority == "normal"
 
-    def test_extract_agent_session_fields_includes_new_fields(self):
-        """_extract_agent_session_fields preserves scheduled_at."""
+    def test_clone_fields_includes_new_fields(self):
+        """clone_agent_session_fields preserves scheduled_at."""
         from datetime import timedelta
 
         future = datetime.now(tz=UTC) + timedelta(hours=1)
         session = _create_pending(scheduled_at=future)
-        fields = _extract_agent_session_fields(session)
+        fields = clone_agent_session_fields(session)
         assert "scheduled_at" in fields
         assert fields["scheduled_at"] is not None
 
@@ -369,7 +369,7 @@ class TestSelfSchedulingProtection:
 
     scheduling_depth is a derived property on AgentSession that walks the
     parent_agent_session_id chain (see models/agent_session.py::scheduling_depth).
-    It is not stored and not included in _AGENT_SESSION_FIELDS. Tests that
+    It is not stored and not in the derived copy set. Tests that
     assert scheduling_depth appears in push JSON output or that exercise the
     derivation walker are skipped here -- they belong alongside tests for the
     derivation itself, not the scheduler CLI.

--- a/tests/integration/test_lifecycle_transition.py
+++ b/tests/integration/test_lifecycle_transition.py
@@ -291,12 +291,12 @@ class TestJobQueueLifecycleLogging:
         assert any("running" in entry for entry in lifecycle_entries)
 
     def test_session_fields_includes_session_events(self):
-        """_AGENT_SESSION_FIELDS includes session_events for lifecycle entry preservation.
+        """The derived copy set includes session_events for lifecycle entry preservation.
 
         The legacy 'history' field was replaced by the structured session_events
         ListField. Delete-and-recreate callers preserve lifecycle entries by
         copying session_events.
         """
-        from agent.agent_session_queue import _AGENT_SESSION_FIELDS
+        from agent.agent_session_queue import _copyable_agent_session_fields
 
-        assert "session_events" in _AGENT_SESSION_FIELDS
+        assert "session_events" in _copyable_agent_session_fields()

--- a/tests/integration/test_session_zombie_health_check.py
+++ b/tests/integration/test_session_zombie_health_check.py
@@ -21,7 +21,7 @@ def completed_child_with_orphaned_parent(redis_test_db):
 
     This is the exact scenario that caused the zombie loop: the health check
     detects the orphaned parent reference, deletes the child, and recreates
-    it. Without the status field in _AGENT_SESSION_FIELDS, the recreated
+    it. Without the status field in the copy set, the recreated
     session would default to status='pending' and be re-executed.
     """
     return AgentSession.create(

--- a/tests/integration/test_silent_failures.py
+++ b/tests/integration/test_silent_failures.py
@@ -138,7 +138,7 @@ class TestEnqueueContinuationSessionLookupLogging:
         and the function falls back to enqueue_agent_session."""
 
         # Use a real AgentSession instance (not persisted) so the fallback
-        # _extract_agent_session_fields call sees real field values instead
+        # clone_agent_session_fields call sees real field values instead
         # of MagicMock placeholders that crash AgentSession construction.
         from models.agent_session import AgentSession as AgentSessionModel
 

--- a/tests/unit/test_agent_session.py
+++ b/tests/unit/test_agent_session.py
@@ -582,9 +582,9 @@ class TestRecentSentDraftsField:
         assert hasattr(AgentSession, "recent_sent_drafts")
 
     def test_field_in_agent_session_fields_allow_list(self):
-        from agent.agent_session_queue import _AGENT_SESSION_FIELDS
+        from agent.agent_session_queue import _copyable_agent_session_fields
 
-        assert "recent_sent_drafts" in _AGENT_SESSION_FIELDS
+        assert "recent_sent_drafts" in _copyable_agent_session_fields()
 
     # ── record_recent_sent_draft: basic append ────────────────────────────────
 

--- a/tests/unit/test_agent_session_hierarchy.py
+++ b/tests/unit/test_agent_session_hierarchy.py
@@ -409,7 +409,7 @@ class TestSchedulerParentSession:
 
 
 # ===================================================================
-# _AGENT_SESSION_FIELDS includes parent_agent_session_id
+# the derived copy set includes parent_agent_session_id
 # ===================================================================
 
 
@@ -417,9 +417,9 @@ class TestSessionFieldsIncludesParentSessionId:
     """Verify parent_agent_session_id is in the extract list."""
 
     def test_parent_agent_session_id_in_session_fields(self):
-        from agent.agent_session_queue import _AGENT_SESSION_FIELDS
+        from agent.agent_session_queue import _copyable_agent_session_fields
 
-        assert "parent_agent_session_id" in _AGENT_SESSION_FIELDS
+        assert "parent_agent_session_id" in _copyable_agent_session_fields()
 
 
 # ===================================================================

--- a/tests/unit/test_agent_session_queue.py
+++ b/tests/unit/test_agent_session_queue.py
@@ -3,7 +3,7 @@
 Focused on field-extraction semantics used by delete-and-recreate callers
 (retry, orphan fix, continuation fallback). _pop_agent_session itself uses
 in-place mutation via transition_status() and does NOT go through
-_extract_agent_session_fields.
+the delete-and-recreate field payloads.
 
 Also tests Redis pop lock acquisition and contention behavior.
 Also tests sustainability throttle guards in _pop_agent_session.
@@ -20,14 +20,14 @@ import pytest
 
 import agent.agent_session_queue as asq
 from agent.agent_session_queue import (
-    _AGENT_SESSION_FIELDS,
     _acquire_pop_lock,
     _complete_agent_session,
-    _extract_agent_session_fields,
+    _copyable_agent_session_fields,
     _pop_agent_session,
     _push_agent_session,
     _release_pop_lock,
     _worker_loop,
+    clone_agent_session_fields,
 )
 from models.agent_session import AgentSession
 from models.session_lifecycle import StatusConflictError
@@ -52,11 +52,11 @@ def _make_session(**overrides) -> AgentSession:
 
 
 class TestExtractFieldsMessageTextRoundTrip:
-    """_extract_agent_session_fields must preserve message_text across
+    """clone_agent_session_fields must preserve message_text across
     delete-and-recreate via the initial_telegram_message dict.
 
     message_text is a virtual @property on AgentSession that reads from
-    initial_telegram_message["message_text"]. _AGENT_SESSION_FIELDS does not
+    initial_telegram_message["message_text"]. The copy set does not
     include message_text directly -- it includes initial_telegram_message,
     so the value is preserved transitively when the dict is copied.
     """
@@ -66,7 +66,7 @@ class TestExtractFieldsMessageTextRoundTrip:
         original = _make_session(message_text="the-original-message")
         assert original.message_text == "the-original-message"
 
-        fields = _extract_agent_session_fields(original)
+        fields = clone_agent_session_fields(original)
 
         # message_text is NOT a top-level key in the extracted dict; it lives
         # inside initial_telegram_message.
@@ -85,29 +85,29 @@ class TestExtractFieldsMessageTextRoundTrip:
         # Clear the text explicitly
         original.initial_telegram_message = None
 
-        fields = _extract_agent_session_fields(original)
+        fields = clone_agent_session_fields(original)
         # initial_telegram_message may be None; recreation should still work
         recreated = AgentSession(**fields)
         # No crash; .message_text returns None for empty dict
         assert recreated.message_text in (None, "")
 
     def test_scheduling_depth_intentionally_omitted(self):
-        """_AGENT_SESSION_FIELDS must NOT include scheduling_depth.
+        """The derived copy set must NOT include scheduling_depth.
 
         scheduling_depth is a derived @property that walks the
         parent_agent_session_id chain at read time. Including it in the
         extracted dict would attempt to set a read-only property on recreate.
         """
-        assert "scheduling_depth" not in _AGENT_SESSION_FIELDS
+        assert "scheduling_depth" not in _copyable_agent_session_fields()
 
     def test_agent_session_id_intentionally_omitted(self):
-        """_AGENT_SESSION_FIELDS must NOT include agent_session_id / id.
+        """The derived copy set must NOT include agent_session_id / id.
 
         agent_session_id is the AutoKeyField; delete-and-recreate callers
         rely on a fresh auto-generated ID for the new record.
         """
-        assert "agent_session_id" not in _AGENT_SESSION_FIELDS
-        assert "id" not in _AGENT_SESSION_FIELDS
+        assert "agent_session_id" not in _copyable_agent_session_fields()
+        assert "id" not in _copyable_agent_session_fields()
 
 
 class TestPopLock:

--- a/tests/unit/test_health_check_recovery_finalization.py
+++ b/tests/unit/test_health_check_recovery_finalization.py
@@ -958,11 +958,11 @@ class TestDisableProgressKill:
 
 
 class TestAgentSessionFieldsRoundTrip:
-    """Tests for _AGENT_SESSION_FIELDS round-trip (B2 from plan critique)."""
+    """Tests for delete-and-recreate field round-trip (B2 from plan critique)."""
 
     def test_new_fields_in_agent_session_fields_list(self):
         """All five new fields must round-trip through save/load."""
-        from agent.agent_session_queue import _AGENT_SESSION_FIELDS
+        from agent.agent_session_queue import _copyable_agent_session_fields
 
         required = {
             "last_heartbeat_at",
@@ -971,8 +971,8 @@ class TestAgentSessionFieldsRoundTrip:
             "recovery_attempts",
             "reprieve_count",
         }
-        missing = required - set(_AGENT_SESSION_FIELDS)
-        assert not missing, f"Missing from _AGENT_SESSION_FIELDS: {missing}"
+        missing = required - set(_copyable_agent_session_fields())
+        assert not missing, f"Missing from the derived copy set: {missing}"
 
     def test_datetime_fields_registered(self):
         """All three new DatetimeField names registered for coercion."""

--- a/tests/unit/test_nudge_loop.py
+++ b/tests/unit/test_nudge_loop.py
@@ -238,10 +238,10 @@ class TestPmSentMessageIds:
     """Tests for pm_sent_message_ids field preserved in session queue (issue #497)."""
 
     def test_pm_sent_message_ids_in_job_fields(self):
-        """pm_sent_message_ids should be in the _AGENT_SESSION_FIELDS list for preservation."""
-        from agent.agent_session_queue import _AGENT_SESSION_FIELDS
+        """pm_sent_message_ids must be in the derived copy set for preservation."""
+        from agent.agent_session_queue import _copyable_agent_session_fields
 
-        assert "pm_sent_message_ids" in _AGENT_SESSION_FIELDS
+        assert "pm_sent_message_ids" in _copyable_agent_session_fields()
 
     def test_outbox_drain_import(self):
         """bridge.telegram_relay.get_outbox_length should be importable."""

--- a/tests/unit/test_pipeline_integrity.py
+++ b/tests/unit/test_pipeline_integrity.py
@@ -167,9 +167,9 @@ class TestMergeGuardHook:
 class TestEnqueueContinuationFallback:
     """Test that the fallback path preserves session metadata."""
 
-    def test_extract_agent_session_fields_includes_metadata(self):
-        """Verify _AGENT_SESSION_FIELDS includes all critical session metadata."""
-        from agent.agent_session_queue import _AGENT_SESSION_FIELDS
+    def test_continuation_payload_includes_metadata(self):
+        """The continuation payload carries all critical session metadata."""
+        from agent.agent_session_queue import _copyable_agent_session_fields
 
         critical_fields = [
             "context_summary",
@@ -179,10 +179,9 @@ class TestEnqueueContinuationFallback:
             "correlation_id",
             "slug",
         ]
+        copyable = set(_copyable_agent_session_fields())
         for field in critical_fields:
-            assert field in _AGENT_SESSION_FIELDS, (
-                f"Critical field {field!r} missing from _AGENT_SESSION_FIELDS"
-            )
+            assert field in copyable, f"Critical field {field!r} missing from the copy set"
 
     def test_diagnose_missing_session_returns_dict(self):
         """Verify _diagnose_missing_session returns diagnostic info."""
@@ -215,117 +214,157 @@ def _non_autokey_model_fields() -> set[str]:
     }
 
 
-# AgentSession fields deliberately NOT copied by `_extract_agent_session_fields`
-# as of today. This is an honest record of an existing gap, not an approval of
-# it: the helper serves two incompatible contracts (delete-and-recreate of the
-# SAME session, where dropping a field is data loss, vs. creation of a NEW
-# session, where the #2518 execution fence must be reset), and resolving that
-# conflict is tracked in issue #2563.
-#
-# TERMINATION CONDITION: when #2563 ships, entries leave this set and it empties.
-# An empty KNOWN_GAP is a valid, meaningful state — the guard below asserts set
-# EQUALITY, so it becomes a plain completeness assertion at that point and a
-# newly added model field can never be silently absorbed into the excuse list.
-#
-# The left-hand side of the comparison excludes auto-key fields; see
-# `_non_autokey_model_fields` for why and how.
-KNOWN_GAP = frozenset(
-    {
-        "active_run_id",
-        "auto_resume_attempts",
-        "budget_tripped",
-        "budget_tripped_reason",
-        "chat_message_log",
-        "claude_version",
-        "continuation_depth",
-        "crash_outcome_attributed",
-        "crash_signature",
-        "current_tool_name",
-        "current_tool_timeout_s",
-        "dev_agent_id",
-        "exec_cwd",
-        "exec_harness",
-        "exec_pid",
-        "exit_reason",
-        "exit_returncode",
-        "is_ledger",
-        "issue_number",
-        "last_authored_at",
-        "last_compaction_ts",
-        "last_tool_use_at",
-        "last_turn_at",
-        "model",
-        "owned_run_ids",
-        "pid_create_time",
-        "pr_number",
-        "project_config",
-        "recent_thinking_excerpt",
-        "requires_real_chrome",
-        "response_delivered_at",
-        "retain_for_resume",
-        "rework_triggered",
-        "runner_cwd",
-        "spawn_history",
-        "task_type",
-        "thread_first_created_at",
-        "thread_run_count",
-        "thread_tool_call_count",
-        "thread_turn_count",
-        "tool_timeout_count_default",
-        "tool_timeout_count_internal",
-        "tool_timeout_count_mcp",
-        "total_cache_read_tokens",
-        "total_cost_usd",
-        "total_input_tokens",
-        "total_output_tokens",
-        "unhealthy_reason",
-        "user_facing_routed",
-        "worker_pid",
-    }
-)
+class TestAgentSessionCloneContract:
+    """`clone_agent_session_fields` copies the whole model, by derivation (#2563).
 
-
-class TestAgentSessionFieldContractDrift:
-    """Guard `_AGENT_SESSION_FIELDS` against drift in both directions.
-
-    `df6097fe6` deleted the `expectations` field and nothing detected that the
-    list guarding it had drifted; these two tests are what would have caught it.
-    Five other modules assert *membership* in `_AGENT_SESSION_FIELDS`
-    (`test_health_check_recovery_finalization.py`, `test_agent_session_hierarchy.py`,
-    `test_agent_session.py`, `test_nudge_loop.py`, `test_session_completion_zombie.py`);
-    these are the completeness counterparts.
+    The hand-maintained `_AGENT_SESSION_FIELDS` list this replaces had drifted 50
+    fields behind the model, silently destroying `issue_number`, `pr_number`,
+    `model`, `retain_for_resume`, the token/cost accounting and the thread
+    counters on every orphan repair and every priority bump. Deriving the set
+    from `AgentSession._meta` retires that drift class rather than re-freezing
+    it, which is why the KNOWN_GAP constant that recorded the 50-field gap is
+    gone instead of emptied.
     """
 
-    def test_no_phantom_names_in_field_list(self):
-        """Every name in `_AGENT_SESSION_FIELDS` still exists on the model.
+    def test_copy_set_covers_every_non_autokey_model_field(self):
+        from agent.agent_session_queue import _copyable_agent_session_fields
 
-        A phantom name makes `_extract_agent_session_fields` raise
-        AttributeError at runtime on the delete-and-recreate path.
-        """
-        from agent.agent_session_queue import _AGENT_SESSION_FIELDS
+        assert set(_copyable_agent_session_fields()) == _non_autokey_model_fields()
 
-        phantoms = sorted(set(_AGENT_SESSION_FIELDS) - _non_autokey_model_fields())
-        assert not phantoms, (
-            f"_AGENT_SESSION_FIELDS names field(s) that no longer exist on "
-            f"AgentSession: {phantoms}. Remove them from the list in "
-            f"agent/agent_session_queue.py, or restore the model field."
+    def test_copy_set_excludes_autokey_fields(self):
+        """A generated key in a create() payload is an error, not drift."""
+        from agent.agent_session_queue import _copyable_agent_session_fields
+
+        copyable = set(_copyable_agent_session_fields())
+        assert "id" not in copyable
+        assert "agent_session_id" not in copyable
+
+    def test_previously_lost_fields_are_now_copied(self):
+        """Named regression: the fields the 38-entry list destroyed on every clone."""
+        from agent.agent_session_queue import _copyable_agent_session_fields
+
+        copyable = set(_copyable_agent_session_fields())
+        for field in (
+            "issue_number",
+            "pr_number",
+            "model",
+            "task_type",
+            "project_config",
+            "retain_for_resume",
+            "budget_tripped",
+            "budget_tripped_reason",
+            "crash_signature",
+            "total_cost_usd",
+            "total_input_tokens",
+            "total_output_tokens",
+            "total_cache_read_tokens",
+            "thread_turn_count",
+            "thread_run_count",
+            "thread_tool_call_count",
+            "thread_first_created_at",
+        ):
+            assert field in copyable, f"{field!r} would still be destroyed on clone"
+
+
+class TestAgentSessionContinuationContract:
+    """`continuation_agent_session_fields` resets the execution fence (#2563).
+
+    A continuation row is `pending` and therefore non-terminal, so it is visible
+    to `find_live_session_by_pid`'s ownership scan. Copying `exec_pid` and its
+    `pid_create_time` onto it would make it claim a process that never ran for
+    it — the forged-liveness failure the #2518 durability fence exists to
+    prevent.
+    """
+
+    def test_reset_set_names_only_real_model_fields(self):
+        """A phantom name in the reset set would silently reset nothing."""
+        from agent.agent_session_queue import _EXECUTION_FENCE_RESET_FIELDS
+
+        phantoms = sorted(_EXECUTION_FENCE_RESET_FIELDS - _non_autokey_model_fields())
+        assert not phantoms, f"reset set names non-existent field(s): {phantoms}"
+
+    def test_reset_set_is_the_fence_and_run_identity(self):
+        """Pinned explicitly: widening this set is a decision, not a refactor."""
+        from agent.agent_session_queue import _EXECUTION_FENCE_RESET_FIELDS
+
+        assert set(_EXECUTION_FENCE_RESET_FIELDS) == {
+            "exec_pid",
+            "pid_create_time",
+            "exec_cwd",
+            "exec_harness",
+            "spawn_history",
+            "active_run_id",
+            "owned_run_ids",
+            "worker_pid",
+        }
+
+    def test_continuation_covers_the_same_fields_as_clone(self):
+        """Same derived set; the two paths differ only in the reset, never in coverage."""
+        from agent.agent_session_queue import (
+            clone_agent_session_fields,
+            continuation_agent_session_fields,
         )
 
-    def test_unlisted_model_fields_match_known_gap(self):
-        """Model fields absent from the list equal the frozen KNOWN_GAP exactly."""
-        from agent.agent_session_queue import _AGENT_SESSION_FIELDS
-
-        actual_gap = _non_autokey_model_fields() - set(_AGENT_SESSION_FIELDS)
-        unclassified = sorted(actual_gap - KNOWN_GAP)
-        newly_classified = sorted(KNOWN_GAP - actual_gap)
-        assert actual_gap == KNOWN_GAP, (
-            f"AgentSession field coverage drifted. Unclassified field(s) missing "
-            f"from _AGENT_SESSION_FIELDS and from KNOWN_GAP: {unclassified}. "
-            f"KNOWN_GAP entries no longer in the gap: {newly_classified}. "
-            f"Decide explicitly whether each field should be copied by "
-            f"_extract_agent_session_fields (see issue #2563) and update the "
-            f"list or KNOWN_GAP accordingly."
+        session = _FakeSession()
+        assert set(continuation_agent_session_fields(session)) == set(
+            clone_agent_session_fields(session)
         )
+
+    def test_clone_preserves_exec_pid(self):
+        """The clone direction of the assertion pair the issue asks for."""
+        from agent.agent_session_queue import clone_agent_session_fields
+
+        fields = clone_agent_session_fields(_FakeSession())
+        assert fields["exec_pid"] == 424242
+        assert fields["pid_create_time"] == 1234.5
+        assert fields["spawn_history"] == [{"pid": 424242}]
+
+    def test_continuation_clears_exec_pid(self):
+        """The continuation direction of the same pair."""
+        from agent.agent_session_queue import (
+            _EXECUTION_FENCE_RESET_FIELDS,
+            continuation_agent_session_fields,
+        )
+
+        fields = continuation_agent_session_fields(_FakeSession())
+        for name in _EXECUTION_FENCE_RESET_FIELDS:
+            assert not fields[name], f"{name!r} survived onto a continuation row"
+
+    def test_continuation_preserves_history(self):
+        """Only the fence resets; accounting and identifiers carry."""
+        from agent.agent_session_queue import continuation_agent_session_fields
+
+        fields = continuation_agent_session_fields(_FakeSession())
+        assert fields["issue_number"] == 2563
+        assert fields["total_cost_usd"] == 1.25
+        assert fields["session_id"] == "fake-session"
+
+
+class _FakeSession:
+    """Stands in for an AgentSession with a live fence, no Redis required.
+
+    Returns a per-field sentinel for anything not set explicitly, so it satisfies
+    the derived copy set whatever fields the model grows.
+    """
+
+    _EXPLICIT = {
+        "exec_pid": 424242,
+        "pid_create_time": 1234.5,
+        "exec_cwd": "/tmp/wt",
+        "exec_harness": "claude",
+        "spawn_history": [{"pid": 424242}],
+        "active_run_id": "run-abc",
+        "owned_run_ids": "run-abc",
+        "worker_pid": 999,
+        "issue_number": 2563,
+        "total_cost_usd": 1.25,
+        "session_id": "fake-session",
+    }
+
+    def __getattr__(self, name: str):
+        if name in self._EXPLICIT:
+            return self._EXPLICIT[name]
+        return f"<{name}>"
 
 
 class TestMergeStageTracking:

--- a/tests/unit/test_recovery_respawn_safety.py
+++ b/tests/unit/test_recovery_respawn_safety.py
@@ -141,7 +141,10 @@ class TestEnqueueNudgeTerminalGuard:
         with (
             patch("agent.agent_session_queue.AgentSession") as mock_as,
             patch("agent.agent_session_queue._diagnose_missing_session", return_value="diag"),
-            patch("agent.agent_session_queue._extract_agent_session_fields", return_value={}),
+            patch(
+                "agent.agent_session_queue.continuation_agent_session_fields",
+                return_value={},
+            ),
         ):
             # The entry guard catches this before we even get to the fallback,
             # so async_create should never be called.

--- a/tests/unit/test_session_completion_zombie.py
+++ b/tests/unit/test_session_completion_zombie.py
@@ -1,7 +1,7 @@
 """Tests for session completion zombie fix.
 
 Covers:
-- Bug 1: _extract_agent_session_fields preserves status field
+- Bug 1: the delete-and-recreate field payload preserves the status field
 - Bug 2: Worker finally block skips completion when nudge was enqueued
 - Health check orphan-fixing preserves original session status
 """
@@ -9,61 +9,61 @@ Covers:
 from unittest.mock import MagicMock, patch
 
 from agent.agent_session_queue import (
-    _AGENT_SESSION_FIELDS,
-    _extract_agent_session_fields,
+    _copyable_agent_session_fields,
+    clone_agent_session_fields,
 )
 
 
 class TestExtractAgentSessionFieldsStatus:
-    """Bug 1: status must be included in _AGENT_SESSION_FIELDS."""
+    """Bug 1: status must be included in the derived copy set."""
 
     def test_status_in_field_list(self):
-        """The _AGENT_SESSION_FIELDS list must include 'status'."""
-        assert "status" in _AGENT_SESSION_FIELDS
+        """The derived copy set must include 'status'."""
+        assert "status" in _copyable_agent_session_fields()
 
     def test_extract_preserves_completed_status(self):
         """Extracting fields from a completed session must preserve status."""
         mock_session = MagicMock()
         mock_session.status = "completed"
         # Set all fields to avoid AttributeError
-        for field in _AGENT_SESSION_FIELDS:
+        for field in _copyable_agent_session_fields():
             if field != "status":
                 setattr(mock_session, field, f"test_{field}")
 
-        fields = _extract_agent_session_fields(mock_session)
+        fields = clone_agent_session_fields(mock_session)
         assert fields["status"] == "completed"
 
     def test_extract_preserves_pending_status(self):
         """Extracting fields from a pending session must preserve status."""
         mock_session = MagicMock()
         mock_session.status = "pending"
-        for field in _AGENT_SESSION_FIELDS:
+        for field in _copyable_agent_session_fields():
             if field != "status":
                 setattr(mock_session, field, f"test_{field}")
 
-        fields = _extract_agent_session_fields(mock_session)
+        fields = clone_agent_session_fields(mock_session)
         assert fields["status"] == "pending"
 
     def test_extract_preserves_failed_status(self):
         """Extracting fields from a failed session must preserve status."""
         mock_session = MagicMock()
         mock_session.status = "failed"
-        for field in _AGENT_SESSION_FIELDS:
+        for field in _copyable_agent_session_fields():
             if field != "status":
                 setattr(mock_session, field, f"test_{field}")
 
-        fields = _extract_agent_session_fields(mock_session)
+        fields = clone_agent_session_fields(mock_session)
         assert fields["status"] == "failed"
 
     def test_extract_preserves_none_status(self):
         """Extracting fields from a session with None status must preserve None."""
         mock_session = MagicMock()
         mock_session.status = None
-        for field in _AGENT_SESSION_FIELDS:
+        for field in _copyable_agent_session_fields():
             if field != "status":
                 setattr(mock_session, field, f"test_{field}")
 
-        fields = _extract_agent_session_fields(mock_session)
+        fields = clone_agent_session_fields(mock_session)
         assert fields["status"] is None
 
 
@@ -74,11 +74,11 @@ class TestRetryPreservesStatusOverride:
         """Retry path must override status to 'pending' after extraction."""
         mock_session = MagicMock()
         mock_session.status = "failed"
-        for field in _AGENT_SESSION_FIELDS:
+        for field in _copyable_agent_session_fields():
             if field != "status":
                 setattr(mock_session, field, f"test_{field}")
 
-        fields = _extract_agent_session_fields(mock_session)
+        fields = clone_agent_session_fields(mock_session)
         # Simulate what retry does (line ~810)
         fields["status"] = "pending"
         assert fields["status"] == "pending"
@@ -96,11 +96,11 @@ class TestHealthCheckOrphanFix:
         child.agent_session_id = "child-1"
         child.parent_agent_session_id = "missing-parent"
         child.status = "completed"
-        for field in _AGENT_SESSION_FIELDS:
+        for field in _copyable_agent_session_fields():
             if field not in ("status", "parent_agent_session_id"):
                 setattr(child, field, f"test_{field}")
 
-        fields = _extract_agent_session_fields(child)
+        fields = clone_agent_session_fields(child)
         # The health check clears the parent but should preserve status
         fields["parent_agent_session_id"] = None
 
@@ -115,11 +115,11 @@ class TestHealthCheckOrphanFix:
         child.agent_session_id = "child-2"
         child.parent_agent_session_id = "missing-parent"
         child.status = "failed"
-        for field in _AGENT_SESSION_FIELDS:
+        for field in _copyable_agent_session_fields():
             if field not in ("status", "parent_agent_session_id"):
                 setattr(child, field, f"test_{field}")
 
-        fields = _extract_agent_session_fields(child)
+        fields = clone_agent_session_fields(child)
         fields["parent_agent_session_id"] = None
 
         assert fields["status"] == "failed", "Health check orphan-fix must preserve failed status"

--- a/tools/agent_session_scheduler.py
+++ b/tools/agent_session_scheduler.py
@@ -880,10 +880,11 @@ def cmd_bump(args: argparse.Namespace) -> int:
             )
             return 1
 
-        # Use delete-and-recreate pattern for KeyField safety
-        from agent.agent_session_queue import _extract_agent_session_fields
+        # Use delete-and-recreate pattern for KeyField safety.
+        # CLONE: same session, only the priority changes (#2563).
+        from agent.agent_session_queue import clone_agent_session_fields
 
-        fields = _extract_agent_session_fields(target)
+        fields = clone_agent_session_fields(target)
         target.delete()
         fields["priority"] = new_priority
         fields["created_at"] = datetime.now(tz=UTC)


### PR DESCRIPTION
Closes #2563

## Verified before fixing

The 50-field drift is exact. Against `2e517d3b`:

```
total model fields: 89   (auto: ['id'])
listed in _AGENT_SESSION_FIELDS: 38
MISSING: 50 — issue_number, pr_number, model, task_type, project_config,
  retain_for_resume, budget_tripped, budget_tripped_reason, crash_signature,
  total_cost_usd, total_input_tokens, total_output_tokens, total_cache_read_tokens,
  thread_turn_count, thread_run_count, thread_tool_call_count, thread_first_created_at,
  exec_pid, pid_create_time, exec_cwd, exec_harness, spawn_history, active_run_id,
  owned_run_ids, worker_pid, ...
```

All four call sites confirmed, and they split exactly as the issue describes.

## Why this cannot be a list edit

Group 1 (`agent/session_health.py` orphan repair, `tools/agent_session_scheduler.py` priority bump) recreates the **same** session, so every field absent from the list is destroyed. Group 2 (`retry_agent_session`, `agent/session_executor.py` auto-continue fallback) creates a **new execution** of the same `session_id`, where the list's omission of the fence fields was accidentally protective.

Adding the missing 50 would close the Group 1 loss and simultaneously forge fences in Group 2. A continuation row is `pending` and therefore non-terminal, so it is visible to `find_live_session_by_pid`'s ownership scan; a copied `exec_pid` makes it claim a process that never ran for it.

## The split

| Helper | Contract | Call sites |
|---|---|---|
| `clone_agent_session_fields` | Same session, same live process. Copy everything. | orphan repair, priority bump |
| `continuation_agent_session_fields` | New execution of the same `session_id`. Copy history, reset the fence. | `retry_agent_session`, auto-continue fallback |

Both derive from `AgentSession._meta` at runtime via `_copyable_agent_session_fields()`, which retires the drift class rather than re-freezing it.

`_EXECUTION_FENCE_RESET_FIELDS` carries a one-line rationale per entry:

```python
"exec_pid",         # OS pid of a harness subprocess this row never spawned.
"pid_create_time",  # The PID-reuse fence for that pid; meaningless without it.
"exec_cwd",         # Working dir that spawn ran in; resume is cwd-scoped.
"exec_harness",     # Which harness ran it; the new run picks its own.
"spawn_history",    # Append-only spawn timeline of the previous run.
"active_run_id",    # Names the run that just ended, not the one being queued.
"owned_run_ids",    # Runs the previous execution owned.
"worker_pid",       # Worker process that owned the previous execution.
```

**Scope call worth flagging:** this set is deliberately the fence and run identity, **not** a general freshness reset. `last_heartbeat_at`, `last_sdk_heartbeat_at` and `last_stdout_at` are in today's 38-entry list and therefore already carry onto continuations; they keep doing so. Clearing them is arguably also right, but it changes watchdog inputs and belongs to a separate decision rather than riding in here. `test_reset_set_is_the_fence_and_run_identity` pins the set explicitly so widening it is a decision, not a refactor.

Fields reset to each field's **declared default** rather than a hardcoded `None`, so this stays correct if a field's unset state ever stops being null.

## Bug found while wiring this up

Several tests patch `agent.agent_session_queue.AgentSession` with a mock to intercept `create`. Deriving the schema off that name would read the mock's `_meta` and silently produce an **empty** payload. `_agent_session_model_fields()` imports the model directly, so schema derivation is independent of module-level patching. This surfaced as two real red tests, not a hypothetical.

## Relationship to #2553

`KNOWN_GAP` is **removed, not emptied**. The issue anticipated it dropping to empty, but that assumed the hand-maintained list survived. It does not, so the drift class the constant recorded cannot recur and a frozen-empty set would guard nothing. Its guard is replaced by assertions on the two new contracts.

## Verification

Round trip against real Redis (`dbg-2563` project key, ORM-scoped, cleaned up):

```
derived copy-set size: 88            (was 38)
CLONE keeps history: 2563 99 claude-opus-5 1.25 7
CLONE keeps fence:   424242 [{'pid': 424242}]
CONT keeps history:  2563 1.25 7
CONT clears fence:   all 8 -> None
CLONE create OK -> issue_number=2563 exec_pid=424242
CONT  create OK -> issue_number=2563 exec_pid=None
remaining rows: 0
```

```
8 affected unit test files    357 passed
4 affected integration files   89 passed
```

Baselined against `origin/main` on the same 8-file set (350 passed) before and after.

New coverage includes the assertion pair the issue asks for: `test_clone_preserves_exec_pid` and `test_continuation_clears_exec_pid`, plus `test_previously_lost_fields_are_now_copied` naming the fields the 38-entry list destroyed.

## DOCS

- `docs/features/agent-session-queue.md` — new "Two contracts, two field payloads (#2563)" section with the call-site table, the reset set and its rationale; code sample and orphan-children bullet updated.
- `docs/features/agent-session-model.md` — continuation now notes the fence clear.
- `docs/features/bridge-self-healing.md` — the "all fields are in `_AGENT_SESSION_FIELDS`" claim replaced with the derivation, cross-linked.