### PR TITLE
Repair the agent module tree by rebinding, not by evicting (#2558)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -286,6 +286,53 @@ def isolate_catchup_kill_switch(_catchup_flag_redirect_dir):
         bridge.catchup.CATCHUP_DISABLED_FLAG = original
 
 
+def repair_agent_module_tree() -> list[str]:
+    """Rebind every cached ``agent.*`` submodule onto its parent package.
+
+    The corruption this repairs: ``sys.modules`` is a flat name->module cache
+    and does not, by itself, keep the attribute tree in sync. CPython binds a
+    submodule as an attribute on its parent package only at the moment that
+    submodule is freshly imported. If something replaces or partially rebuilds
+    ``sys.modules["agent"]`` while ``sys.modules["agent.hooks"]`` survives from
+    an earlier import, the new ``agent`` object never gets ``hooks`` bound onto
+    it, and every dotted-string ``monkeypatch.setattr``/``mock.patch`` that
+    walks through ``agent.hooks`` raises ``AttributeError`` at setup.
+
+    Repairs by REBINDING, not by evicting (#2558). Evicting every ``agent.*``
+    key also self-heals, because the next import rebuilds the whole chain --
+    but it rebuilds it around NEW module objects, and that is a second bug
+    wearing the first one's clothes. A test module that bound a name at
+    collection time (``from agent.sdk_client import load_persona_prompt``, the
+    ordinary idiom, present in ~50 files here) still closes over the OLD
+    module's ``__globals__``. Its ``patch("agent.sdk_client._assemble_segments")``
+    then imports and patches a FRESH module object that nothing under test is
+    looking at. The patch silently applies to nobody: in
+    ``tests/unit/test_persona_substitution.py`` that surfaced as four
+    unexplainable failures, but the same divergence in a test asserting a mock
+    was CALLED would have read green while measuring nothing.
+
+    Rebinding fixes the actual defect -- the severed attribute link -- and
+    leaves module identity alone, so every already-bound reference stays valid
+    and a patch reaches the object the test holds.
+
+    Returns the dotted names rebound, so callers and tests can assert on the
+    repair instead of inferring it.
+    """
+    repaired: list[str] = []
+    for name in sorted(k for k in sys.modules if k == "agent" or k.startswith("agent.")):
+        parent_name, _, attr = name.rpartition(".")
+        if not parent_name:
+            continue
+        parent = sys.modules.get(parent_name)
+        module = sys.modules.get(name)
+        if parent is None or module is None:
+            continue
+        if getattr(parent, attr, None) is not module:
+            setattr(parent, attr, module)
+            repaired.append(name)
+    return repaired
+
+
 @pytest.fixture(autouse=True)
 def agent_hooks_consistency_guard():
     """Detect and repair a corrupt `agent` package/submodule cache state.
@@ -314,28 +361,21 @@ def agent_hooks_consistency_guard():
     guards against (SDK entry swaps specifically), so it needs its own
     independent, always-on check rather than being folded into that fixture.
 
-    Fix: evicting *every* ``agent.*`` key from ``sys.modules`` (not just the
-    two implicated in the check) is what actually self-heals, because the
-    next ``import agent.hooks.pre_tool_use`` then performs a full fresh
-    import: Python imports ``agent``, then imports ``agent.hooks`` and binds
-    it onto the freshly-imported ``agent`` object, then imports
-    ``agent.hooks.pre_tool_use`` and binds it onto the freshly-imported
-    ``agent.hooks`` object. A full eviction guarantees every link in that
-    chain gets rebuilt together and consistently; evicting only some of the
-    keys (or leaving stale ones in place) would just reproduce the same
-    partial-tree problem on the next import.
+    Fix: ``repair_agent_module_tree`` above rebinds every cached ``agent.*``
+    submodule onto its parent, restoring the whole tree in one pass without
+    disturbing module identity. Read that function for why rebinding rather
+    than evicting is load-bearing (#2558).
 
     No-op (untouched) when ``agent`` isn't imported at all, or when it *is*
     imported and its ``hooks`` attribute is intact -- only the corrupt state
-    triggers eviction.
+    triggers a repair.
     """
     if (
         "agent" in sys.modules
         and "agent.hooks" in sys.modules
         and not hasattr(sys.modules["agent"], "hooks")
     ):
-        for name in [key for key in sys.modules if key == "agent" or key.startswith("agent.")]:
-            del sys.modules[name]
+        repair_agent_module_tree()
 
     yield
 

--- a/tests/unit/test_agent_module_tree_repair.py
+++ b/tests/unit/test_agent_module_tree_repair.py
@@ -1,0 +1,109 @@
+"""The ``agent.*`` module-tree repair must not change module identity (#2558).
+
+``tests/conftest.py``'s autouse ``agent_hooks_consistency_guard`` fires when the
+parent-attribute link between ``agent`` and ``agent.hooks`` is severed --
+``sys.modules`` reports both loaded while ``getattr(agent, "hooks")`` raises, so
+every dotted-string ``mock.patch``/``monkeypatch.setattr`` that walks that path
+dies at setup.
+
+It used to repair by evicting every ``agent.*`` key from ``sys.modules``. That
+self-heals the attribute walk and introduces a quieter defect in its place. Test
+modules bind names at collection time (``from agent.sdk_client import
+load_persona_prompt``, the ordinary idiom, in ~50 files here), before any
+eviction. Afterwards the bound function still closes over the OLD module's
+``__globals__`` while ``patch("agent.sdk_client.X")`` imports and patches a
+FRESH module object. The patch lands on a module nothing under test is looking
+at. In ``tests/unit/test_persona_substitution.py`` that surfaced as four
+failures with no explanation in any diff; a test asserting a mock was CALLED
+would instead have read green while measuring nothing.
+
+So the invariant here is narrow and load-bearing: the repair restores the
+attribute tree and leaves ``sys.modules`` entries pointing at the same objects
+they pointed at before.
+
+Both tests below sever the link themselves and restore it in ``finally``, so
+they leave the interpreter exactly as they found it and do not depend on test
+ordering.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import agent
+import agent.hooks  # noqa: F401 -- ensures the key exists so the guard's predicate can fire
+from agent.sdk_client import load_persona_prompt
+from tests.conftest import agent_hooks_consistency_guard, repair_agent_module_tree
+
+
+def _sever_the_link() -> None:
+    """Reproduce the corruption the guard exists to catch."""
+    delattr(sys.modules["agent"], "hooks")
+
+
+def _run_the_guard() -> None:
+    """Drive the real autouse fixture body, predicate included.
+
+    Calling the fixture rather than ``repair_agent_module_tree`` directly is
+    deliberate: it pins the detection condition too, so a repair that stops
+    being reached is a failure here rather than a silent no-op.
+    """
+    generator = agent_hooks_consistency_guard.__wrapped__()
+    next(generator)
+
+
+def test_the_guard_repairs_the_link_without_replacing_the_modules():
+    before = {k: v for k, v in sys.modules.items() if k == "agent" or k.startswith("agent.")}
+    assert "agent.sdk_client" in before, "precondition: the module under test is cached"
+
+    _sever_the_link()
+    try:
+        assert not hasattr(agent, "hooks"), "precondition: the link is actually severed"
+        _run_the_guard()
+
+        for name, module in before.items():
+            assert sys.modules.get(name) is module, (
+                f"{name} was evicted or replaced. Every collection-time "
+                f"`from {name} import ...` in the suite now closes over an orphaned "
+                f'module object, and every `patch("{name}....")` targets a different one'
+            )
+        assert sys.modules["agent"].hooks is before["agent.hooks"], (
+            "the guard did not restore the parent-attribute link"
+        )
+    finally:
+        repair_agent_module_tree()
+
+
+def test_a_collection_time_binding_still_sees_a_patch_after_a_repair(tmp_path):
+    """The symptom, end to end: a patch must reach the object the test holds.
+
+    ``load_persona_prompt`` above is bound at collection time, exactly as
+    ``tests/unit/test_persona_substitution.py`` binds it. If the repair swapped
+    the module out, these patches would apply to a fresh ``agent.sdk_client``
+    and this call would read the real persona tree instead.
+    """
+    overlay = tmp_path / "customer-service.md"
+    overlay.write_text("Hello customer {customer_id}, how can I help?")
+
+    _sever_the_link()
+    try:
+        _run_the_guard()
+
+        with (
+            patch("agent.sdk_client.PERSONAS_OVERLAY_DIR", tmp_path),
+            patch("agent.sdk_client.PERSONAS_BASE_DIR", tmp_path),
+            patch("agent.sdk_client.load_identity", return_value={}),
+            patch("agent.sdk_client._assemble_segments", return_value="base content\n"),
+        ):
+            result = load_persona_prompt(
+                "customer-service", substitutions={"customer_id": "cust-42"}
+            )
+
+        assert "cust-42" in result
+        assert "base content" in result, (
+            "the patched _assemble_segments never ran: the bound function and the patch "
+            "target are different module objects"
+        )
+    finally:
+        repair_agent_module_tree()


### PR DESCRIPTION
Closes #2558

## Problem

`tests/conftest.py`'s autouse `agent_hooks_consistency_guard` fires when the parent-attribute link between `agent` and `agent.hooks` is severed, and repaired it by deleting every `agent.*` key from `sys.modules`.

That self-heals the attribute walk and replaces one isolation defect with a quieter one. Test modules bind names at collection time (`from agent.sdk_client import load_persona_prompt`, the ordinary idiom, in **46 unit files** here), before any eviction. Afterwards the bound function still closes over the OLD module's `__globals__` while `patch("agent.sdk_client.X")` imports and patches a FRESH module object. The patch lands on a module nothing under test is looking at.

## Reproduction

A scratch test that severs the link, run ahead of `tests/unit/test_persona_substitution.py` on unmodified main:

```
FAILED tests/unit/test_persona_substitution.py::test_load_persona_prompt_customer_service_substitution
FAILED tests/unit/test_persona_substitution.py::test_load_persona_prompt_no_substitutions_backward_compat
FAILED tests/unit/test_persona_substitution.py::test_load_persona_prompt_substitutions_none_is_safe
FAILED tests/unit/test_persona_substitution.py::test_load_persona_prompt_unreferenced_braces_preserved
4 failed, 4 passed
```

Every patch in those `with` blocks was a no-op, so the calls read the real persona tree. Here the divergence surfaces as failures. A test asserting a mock was CALLED would instead have read **green while measuring nothing**, which is the reason this is worth fixing rather than routing around.

## Fix

Rebind rather than evict. `repair_agent_module_tree()` walks the cached `agent.*` keys and rebinds each onto its parent, restoring the whole tree in one pass. That repairs the actual corruption (a severed attribute link) and leaves `sys.modules` identity alone, so every already-bound reference stays valid and a patch reaches the object the test holds.

`mock_claude_sdk_cleanup`'s eviction is deliberately left alone: it evicts after an SDK entry swap precisely because it WANTS `agent.*` re-imported against the restored SDK, which rebinding would not accomplish.

## Red / green

`tests/unit/test_agent_module_tree_repair.py` drives the real fixture body (predicate included, via `__wrapped__`) and pins both halves: module identity preserved, and a collection-time-bound function still sees its patch. Both tests sever the link themselves and restore it in `finally`, so they are order-independent and leave the interpreter as they found it.

Restoring the eviction behavior inside `repair_agent_module_tree`:

```
FAILED tests/unit/test_agent_module_tree_repair.py::test_the_guard_repairs_the_link_without_replacing_the_modules
FAILED tests/unit/test_agent_module_tree_repair.py::test_a_collection_time_binding_still_sees_a_patch_after_a_repair
2 failed
```

With the fix in place: 2 passed.

## Verification scope

The issue asked for a full-suite run because conftest touches everything. A full `tests/unit/` run currently wedges at ~99% (#2574, reproduced during this work), so I ran the population that is affected **by construction** instead: every unit test file that both patches `agent.*` and binds a name from `agent.*` at collection time, 46 files, plus the new test and `test_persona_substitution.py`.

| Batch | Result |
|-------|--------|
| chunk 1 (16 files) | 597 passed |
| chunk 2 (16 files) | 329 passed |
| chunk 3, individually + grouped | 364 passed |

One file in chunk 3, `tests/unit/test_session_executor_runner_dispatch.py`, wedges the controller at 0% CPU with no summary. **It wedges identically on baseline with this change stashed**, so it is pre-existing (#2574) and is now a single-file reproducer for that issue.

`python -m ruff check` and `ruff format` clean.

<!-- DOCS: no user-facing behavior change; the rationale lives in the docstrings of `repair_agent_module_tree` and `tests/unit/test_agent_module_tree_repair.py`, which are the only places a reader would look. -->
