### PR TITLE
Own the calendar-heartbeat task: registry, done-callback, shutdown drain

### DIFF
--- a/agent/session_executor.py
+++ b/agent/session_executor.py
@@ -482,9 +482,22 @@ def _find_valor_calendar() -> str:
     return "valor-calendar"  # Let it fail with clear error
 
 
+# Bounds the ENTIRE heartbeat body — subprocess spawn included, not just
+# communicate(). The #2574 wedge sat inside BaseSubprocessTransport._connect_pipes,
+# which the old `wait_for(proc.communicate(), timeout=10)` never covered.
+CALENDAR_HEARTBEAT_TIMEOUT = 10.0
+
+
 async def _calendar_heartbeat(slug: str, project: str | None = None) -> None:
-    """Fire-and-forget calendar heartbeat via subprocess."""
-    try:
+    """Calendar heartbeat via subprocess, bounded end-to-end by CALENDAR_HEARTBEAT_TIMEOUT.
+
+    Never call this via a bare ``asyncio.create_task`` — use
+    ``_schedule_calendar_heartbeat`` so the task is owned, its exceptions are
+    logged, and ``drain_pending_calendar_heartbeats`` can cancel it on worker
+    shutdown (issue #2590).
+    """
+
+    async def _run() -> None:
         valor_calendar = _find_valor_calendar()
         cmd = [valor_calendar]
         if project:
@@ -495,13 +508,78 @@ async def _calendar_heartbeat(slug: str, project: str | None = None) -> None:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=10)
+        stdout, stderr = await proc.communicate()
         if proc.returncode == 0:
             logger.info(f"Calendar heartbeat: {stdout.decode().strip()}")
         else:
             logger.warning(f"Calendar heartbeat failed: {stderr.decode().strip()}")
+
+    try:
+        await asyncio.wait_for(_run(), timeout=CALENDAR_HEARTBEAT_TIMEOUT)
+    except asyncio.CancelledError:
+        raise  # preserve cancellation semantics for shutdown drain
     except Exception as e:
         logger.warning(f"Calendar heartbeat failed for '{slug}': {e}")
+
+
+# Registry of in-flight heartbeat tasks (issue #2590). Mirrors the extraction
+# pattern (#1055): tasks are owned here, deregistered by done-callback, and
+# drained by drain_pending_calendar_heartbeats on worker shutdown.
+_pending_calendar_tasks: set[asyncio.Task] = set()
+
+
+def _on_calendar_heartbeat_done(task: asyncio.Task) -> None:
+    """Done-callback: deregister the task and log any escaped exception."""
+    _pending_calendar_tasks.discard(task)
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.warning("Calendar heartbeat task %s failed: %s", task.get_name(), exc)
+
+
+def _schedule_calendar_heartbeat(slug: str, project: str | None = None) -> None:
+    """Schedule an owned calendar-heartbeat task (issue #2590).
+
+    Synchronous fire-and-forget like ``_schedule_post_session_extraction``:
+    keeps a reference in ``_pending_calendar_tasks`` so the task can never be
+    garbage-collected mid-flight or orphaned past loop teardown, and attaches
+    a done-callback that deregisters it and logs exceptions.
+
+    Looks up ``_calendar_heartbeat`` through the module global at call time so
+    test patches of that name (tests/conftest.py) take effect.
+    """
+    task = asyncio.create_task(
+        _calendar_heartbeat(slug, project=project),
+        name=f"calendar_heartbeat:{slug}",
+    )
+    _pending_calendar_tasks.add(task)
+    task.add_done_callback(_on_calendar_heartbeat_done)
+
+
+async def drain_pending_calendar_heartbeats(timeout: float = 5.0) -> None:
+    """Drain in-flight calendar heartbeats on worker shutdown (issue #2590).
+
+    No-op when nothing is pending. Called from ``worker/__main__.py`` shutdown
+    alongside ``drain_pending_extractions`` — same ordering rationale: worker
+    loops have drained, the event loop is still running, so pending heartbeats
+    can complete or be cancelled cleanly instead of being abandoned to
+    ``_cancel_all_tasks`` (the #2574 wedge mechanism).
+    """
+    if not _pending_calendar_tasks:
+        return
+
+    pending = list(_pending_calendar_tasks)
+    logger.info("Draining %d pending calendar heartbeat task(s)", len(pending))
+    done, still_pending = await asyncio.wait(pending, timeout=timeout)
+    for task in still_pending:
+        task.cancel()
+    if still_pending:
+        logger.warning(
+            "Cancelled %d calendar heartbeat task(s) that did not complete within %.1fs",
+            len(still_pending),
+            timeout,
+        )
 
 
 # Interval between calendar heartbeats during long-running sessions
@@ -1317,7 +1395,7 @@ async def _execute_agent_session(session: AgentSession) -> None:
         # The calendar tool skips silently for projects without a mapping.
         cal_slug = session.slug or session.project_key
         if cal_slug:
-            asyncio.create_task(_calendar_heartbeat(cal_slug, project=session.project_key))
+            _schedule_calendar_heartbeat(cal_slug, project=session.project_key)
 
         # Create messenger with bridge callbacks, falling back to file output
         # Find the transport from extra_context to support multiple transports per project
@@ -2111,9 +2189,7 @@ async def _execute_agent_session(session: AgentSession) -> None:
                     # (Telegram-originated) sessions still record calendar activity.
                     cal_slug = session.slug or session.project_key
                     if cal_slug:
-                        asyncio.create_task(
-                            _calendar_heartbeat(cal_slug, project=session.project_key)
-                        )
+                        _schedule_calendar_heartbeat(cal_slug, project=session.project_key)
                     if agent_session:
                         try:
                             agent_session.updated_at = datetime.now(tz=UTC)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -584,8 +584,9 @@ def no_calendar_subprocess_in_tests():
     This is the mechanism behind the #2574 tail wedge, and it is a live
     unit-test hazard on its own.
 
-    `agent/session_executor.py` fires ``asyncio.create_task(_calendar_heartbeat(...))``
-    unawaited at session start, and `_calendar_heartbeat` runs
+    `agent/session_executor.py` fires ``_schedule_calendar_heartbeat(...)`` at
+    session start (owned task with a shutdown drain since #2590, but still
+    fire-and-forget from the test's perspective), and `_calendar_heartbeat` runs
     ``asyncio.create_subprocess_exec`` against the real `valor-calendar` CLI --
     which talks to a real Google Calendar. Ten unit test files call
     `_execute_agent_session`, so ten files could spawn it.

--- a/tests/unit/test_session_executor_calendar_heartbeat.py
+++ b/tests/unit/test_session_executor_calendar_heartbeat.py
@@ -1,0 +1,146 @@
+"""Unit tests for the owned calendar-heartbeat task lifecycle (issue #2590).
+
+``asyncio.create_task(_calendar_heartbeat(...))`` used to be fired with no
+reference kept, no done-callback, and no shutdown drain — the confirmed
+mechanism behind the #2574 tail wedge. These tests verify the replacement
+scheduler mirrors the extraction pattern (#1055):
+
+- ``_schedule_calendar_heartbeat`` registers the task in
+  ``_pending_calendar_tasks`` and the done-callback removes it.
+- Heartbeat failures are logged by the done-callback, never propagated.
+- ``drain_pending_calendar_heartbeats`` is a no-op when nothing is pending,
+  lets fast tasks finish, and cancels stuck ones.
+- The whole heartbeat body — including subprocess spawn — is bounded by
+  ``CALENDAR_HEARTBEAT_TIMEOUT`` (the old code only bounded ``communicate()``).
+"""
+
+import asyncio
+
+import pytest
+
+import agent.session_executor as _se_module
+
+# Captured at collection time, before the autouse ``no_calendar_subprocess_in_tests``
+# fixture swaps in a no-op. Lets the timeout test exercise the real coroutine.
+_REAL_CALENDAR_HEARTBEAT = _se_module._calendar_heartbeat
+
+
+@pytest.fixture(autouse=True)
+def _clear_pending_calendar_tasks():
+    """Reset the module-level _pending_calendar_tasks between tests."""
+    from agent import session_executor as se
+
+    se._pending_calendar_tasks.clear()
+    yield
+    for task in list(se._pending_calendar_tasks):
+        if not task.done():
+            task.cancel()
+    se._pending_calendar_tasks.clear()
+
+
+class TestScheduleCalendarHeartbeat:
+    """Verify the scheduler owns the task it creates."""
+
+    @pytest.mark.asyncio
+    async def test_task_registered_and_removed_on_completion(self, monkeypatch):
+        from agent import session_executor as se
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def _slow_heartbeat(slug, project=None):
+            started.set()
+            await release.wait()
+
+        monkeypatch.setattr(se, "_calendar_heartbeat", _slow_heartbeat)
+
+        se._schedule_calendar_heartbeat("test-slug", project="test-proj")
+        await asyncio.wait_for(started.wait(), timeout=2.0)
+        assert len(se._pending_calendar_tasks) == 1, "task must be registered while running"
+
+        release.set()
+        await asyncio.gather(*se._pending_calendar_tasks)
+        await asyncio.sleep(0)  # let done-callbacks run
+        assert not se._pending_calendar_tasks, "done-callback must deregister the task"
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_exception_logged_not_propagated(self, monkeypatch, caplog):
+        from agent import session_executor as se
+
+        async def _boom(slug, project=None):
+            raise RuntimeError("simulated heartbeat crash")
+
+        monkeypatch.setattr(se, "_calendar_heartbeat", _boom)
+
+        with caplog.at_level("WARNING", logger=se.logger.name):
+            se._schedule_calendar_heartbeat("crash-slug")
+            (task,) = se._pending_calendar_tasks
+            with pytest.raises(RuntimeError):
+                await task
+            await asyncio.sleep(0)  # let done-callback run
+
+        assert not se._pending_calendar_tasks
+        assert any("simulated heartbeat crash" in r.message for r in caplog.records), (
+            "done-callback must log the task exception"
+        )
+
+
+class TestDrainPendingCalendarHeartbeats:
+    """Verify shutdown drain semantics mirror drain_pending_extractions."""
+
+    @pytest.mark.asyncio
+    async def test_noop_when_empty(self):
+        from agent import session_executor as se
+
+        assert not se._pending_calendar_tasks
+        await se.drain_pending_calendar_heartbeats(timeout=0.1)  # must return immediately
+
+    @pytest.mark.asyncio
+    async def test_fast_task_completes_within_drain(self, monkeypatch):
+        from agent import session_executor as se
+
+        async def _fast_heartbeat(slug, project=None):
+            await asyncio.sleep(0)
+
+        monkeypatch.setattr(se, "_calendar_heartbeat", _fast_heartbeat)
+        se._schedule_calendar_heartbeat("fast-slug")
+
+        await se.drain_pending_calendar_heartbeats(timeout=2.0)
+        await asyncio.sleep(0)
+        assert not se._pending_calendar_tasks
+
+    @pytest.mark.asyncio
+    async def test_stuck_task_cancelled_by_drain(self, monkeypatch):
+        from agent import session_executor as se
+
+        async def _stuck_heartbeat(slug, project=None):
+            await asyncio.sleep(600)
+
+        monkeypatch.setattr(se, "_calendar_heartbeat", _stuck_heartbeat)
+        se._schedule_calendar_heartbeat("stuck-slug")
+        (task,) = se._pending_calendar_tasks
+
+        await se.drain_pending_calendar_heartbeats(timeout=0.05)
+        # Cancellation lands on the next loop pass.
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await asyncio.sleep(0)
+        assert task.cancelled()
+        assert not se._pending_calendar_tasks
+
+
+class TestHeartbeatTimeoutBoundsSpawn:
+    """The wait_for must cover subprocess creation, not just communicate()."""
+
+    @pytest.mark.asyncio
+    async def test_hang_during_spawn_is_bounded(self, monkeypatch):
+        from agent import session_executor as se
+
+        async def _hanging_spawn(*cmd, **kwargs):
+            await asyncio.sleep(600)  # simulate a wedge inside _connect_pipes
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _hanging_spawn)
+        monkeypatch.setattr(se, "CALENDAR_HEARTBEAT_TIMEOUT", 0.05)
+
+        # Must return (logging a warning), not hang or raise.
+        await asyncio.wait_for(_REAL_CALENDAR_HEARTBEAT("timeout-slug", project="p"), timeout=2.0)

--- a/worker/__main__.py
+++ b/worker/__main__.py
@@ -1067,6 +1067,17 @@ async def _run_worker(projects: dict, dry_run: bool = False) -> None:
     except Exception as e:
         logger.warning(f"Extraction drain failed: {e}")
 
+    # Drain in-flight calendar heartbeats (issue #2590). Same ordering rationale
+    # as the extraction drain above: the loop is still running, so a heartbeat
+    # mid-subprocess-spawn is cancelled cleanly here instead of being abandoned
+    # to _cancel_all_tasks at loop teardown (the #2574 wedge mechanism).
+    try:
+        from agent.session_executor import drain_pending_calendar_heartbeats
+
+        await drain_pending_calendar_heartbeats(timeout=5.0)
+    except Exception as e:
+        logger.warning(f"Calendar heartbeat drain failed: {e}")
+
     # Stop the dedicated heartbeat thread (issue #1767).
     # Setting the event causes _heartbeat_thread_main's wait() to return
     # immediately; the thread exits its loop and the join() completes quickly.


### PR DESCRIPTION
Closes #2590

## Problem

`agent/session_executor.py` fired `asyncio.create_task(_calendar_heartbeat(...))` with no reference kept, no done-callback, and nothing cancelling it on shutdown. A task stuck inside `BaseSubprocessTransport._connect_pipes` never answers loop-teardown cancellation — the confirmed mechanism behind the #2574 tail wedge. The `wait_for(proc.communicate(), timeout=10)` also never bounded subprocess spawn, which is exactly where the observed hang sat.

## Fix (mirrors the extraction pattern, #1055)

- `_schedule_calendar_heartbeat` — creates a named task, registers it in module-level `_pending_calendar_tasks`, attaches a done-callback that deregisters and logs exceptions. Both call sites (session start, 25-min heartbeat loop) now go through it.
- `drain_pending_calendar_heartbeats(timeout=5.0)` — wired into `worker/__main__.py` shutdown directly after `drain_pending_extractions`, same ordering rationale: the loop is still running, so an in-flight heartbeat completes or cancels cleanly instead of being abandoned to `_cancel_all_tasks`.
- `CALENDAR_HEARTBEAT_TIMEOUT = 10.0` now wraps the **entire** heartbeat body (spawn + communicate), closing the unbounded-spawn gap. `CancelledError` is re-raised so the drain can cooperate.
- Updated the stale `no_calendar_subprocess_in_tests` conftest docstring; the patch itself is unchanged and still takes effect (the scheduler resolves `_calendar_heartbeat` through the module global at call time).

## Tests

New `tests/unit/test_session_executor_calendar_heartbeat.py` (6 tests, modeled on `test_session_executor_extraction_decoupling.py`): registration + done-callback removal, exception logging, drain no-op/fast-complete/stuck-cancel, and spawn-phase hang bounded by the timeout (tested against the real coroutine captured before the conftest no-op patch).

```
tests/unit/test_session_executor_calendar_heartbeat.py — 6 passed
tests/unit/test_session_executor_extraction_decoupling.py + #2590 repro test — 14 passed
ruff check / ruff format --check — clean
```