### PR TITLE
Reject ledger steers; make TelegramMessage.direction writer-determined

### DIFF
--- a/agent/session_executor.py
+++ b/agent/session_executor.py
@@ -727,6 +727,23 @@ def steer_session(session_id: str, message: str) -> dict:
                 "error": f"Session is in terminal status {current_status!r} — steering rejected",
             }
 
+        # Ledger rows (sdlc-local-{N}) record SDLC pipeline state and are
+        # never executed: every pickup/drain path skips is_ledger sessions,
+        # and steering:{session_id} has no TTL. Accepting the steer would
+        # persist a message no consumer ever reads — silent loss behind a
+        # success return (#2495).
+        from agent.session_pickup import _truthy
+
+        if _truthy(getattr(session, "is_ledger", False)):
+            return {
+                "success": False,
+                "session_id": session_id,
+                "error": (
+                    "Session is a non-executable SDLC ledger row (is_ledger) — "
+                    "no worker ever drains its steering queue; steering rejected"
+                ),
+            }
+
         from agent.steering import push_steering_message as _push_steering_message
 
         _push_steering_message(session.session_id, message, "pm")

--- a/bridge/read_the_room.py
+++ b/bridge/read_the_room.py
@@ -14,8 +14,8 @@ Design notes
 * **Snapshot includes the agent's own prior turns (Risk 3):** Path A messages
   flow into ``TelegramMessage`` via two recording sites and end up under two
   different ``sender`` values: the bridge handler writes ``sender="Valor"``
-  (``direction="out"``) and the relay's PM-direct path writes
-  ``sender="system"`` (``direction="in"``). The snapshot is passed through
+  and the relay's PM-direct path writes ``sender="system"`` (both
+  ``direction="out"`` — writer-determined since #2496). The snapshot is passed through
   *unfiltered* -- the system prompt below tells the model to treat any entry
   with ``sender`` in ``{valor, system}`` as agent-authored context, not as a
   competing input.

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -1317,6 +1317,7 @@ async def main():
                     has_media=bool(message.media),
                     media_type=get_media_type(message) if message.media else None,
                     reply_to_msg_id=message.reply_to_msg_id,
+                    direction="in",
                 )
                 if store_result.get("stored"):
                     stored_msg_id = store_result.get("id")
@@ -3061,6 +3062,7 @@ async def main():
                             message_type="response",
                             message_id=None,
                             reply_to_msg_id=reply_to_msg_id,
+                            direction="out",
                         )
                     except Exception as store_err:
                         logger.warning(

--- a/bridge/telegram_relay.py
+++ b/bridge/telegram_relay.py
@@ -917,6 +917,7 @@ async def process_outbox(telegram_client) -> int:
                                 sender="system",
                                 timestamp=utc_now(),
                                 message_type="pm_direct",
+                                direction="out",
                             )
                         except Exception as e:
                             # Non-fatal: history storage is best-effort.

--- a/docs/features/session-steering.md
+++ b/docs/features/session-steering.md
@@ -55,7 +55,7 @@ The `send_to_chat()` callback in the executor calls `route_session_output()` and
 
 `agent/session_executor.py` exports:
 
-- `steer_session(session_id, message)` — pushes to the Redis steering list via `agent.steering.push_steering_message()`, validates non-terminal status, wakes worker
+- `steer_session(session_id, message)` — pushes to the Redis steering list via `agent.steering.push_steering_message()`, validates non-terminal status, wakes worker. Also rejects `is_ledger` sessions (SDLC ledger rows like `sdlc-local-{N}`): no worker ever drains their steering queue, so accepting would be silent loss (#2495)
 - `re_enqueue_session(session, ...)` — public wrapper for `_enqueue_nudge`, encapsulates re-enqueue logic
 
 ## Data Flow

--- a/docs/features/telegram-history.md
+++ b/docs/features/telegram-history.md
@@ -42,7 +42,7 @@ All data is stored in **Redis** via Popoto ORM models. SQLite was removed as of 
 - `msg_id` - Auto-generated key
 - `chat_id` - Telegram chat ID (KeyField, used for filtering)
 - `message_id` - Telegram message ID (KeyField(null=True), enables O(1) indexed filter for reverse lookup)
-- `direction` - "in" or "out" (KeyField)
+- `direction` - "in" or "out" (KeyField). Writer-determined: each `store_message` call site passes it explicitly; it is never inferred from the sender string (#2496)
 - `sender` - Message sender name (KeyField)
 - `content` - Full message content (up to 50,000 chars, no truncation)
 - `timestamp` - Unix timestamp (SortedField, partitioned by chat_id)

--- a/docs/guides/valor-name-references.md
+++ b/docs/guides/valor-name-references.md
@@ -29,7 +29,7 @@ References where "Valor" is the **persona** that users interact with — the nam
 | `bridge/context.py` | 287-406 | `sender == "Valor"` (6 occurrences) | Identifies our outbound messages |
 | `bridge/catchup.py` | 214 | `"reply from us (Valor)"` | Comment |
 | `bridge/telegram_bridge.py` | 1339, 1482 | `sender="Valor"` | Message attribution |
-| `tools/telegram_history/__init__.py` | 150 | `sender.lower() == "valor"` | Direction detection |
+| ~~`tools/telegram_history/__init__.py`~~ | -- | *(removed)* | Direction is writer-determined via an explicit `direction` param, no longer derived from the sender string (#2496) |
 | ~~`scripts/migrate_sqlite_to_redis.py`~~ | -- | *(removed)* | Legacy migration deleted |
 | `agent/branch_manager.py` | 548 | `"Reply to any Valor message"` | User-facing help text |
 

--- a/tests/integration/test_redis_models.py
+++ b/tests/integration/test_redis_models.py
@@ -611,19 +611,66 @@ class TestStoreMessageMirror:
         assert found[0].sender == "TestUser"
 
     def test_store_message_outgoing_direction(self, redis_test_db):
+        """Explicit direction is stored as given, regardless of sender (#2496).
+
+        Direction is determined by the writer, never inferred from the sender
+        string. ``sender="system"`` is the relay's spelling — before #2496 it
+        fell through to ``direction="in"``.
+        """
         from models.telegram import TelegramMessage
         from tools.telegram_history import store_message
 
         store_message(
             chat_id="out_chat",
             content="response text",
-            sender="Valor",
-            message_type="response",
+            sender="system",
+            message_type="pm_direct",
+            direction="out",
         )
 
         found = TelegramMessage.query.filter(chat_id="out_chat")
         assert len(found) == 1
         assert found[0].direction == "out"
+
+    def test_store_message_no_sender_derivation(self, redis_test_db):
+        """Without explicit direction, default is "in" even for sender="Valor" (#2496)."""
+        from models.telegram import TelegramMessage
+        from tools.telegram_history import store_message
+
+        store_message(
+            chat_id="derive_chat",
+            content="response text",
+            sender="Valor",
+            message_type="response",
+        )
+
+        found = TelegramMessage.query.filter(chat_id="derive_chat")
+        assert len(found) == 1
+        assert found[0].direction == "in"
+
+    def test_outbound_call_sites_pass_explicit_direction(self):
+        """Both outbound store_message call sites declare direction="out" (#2496)."""
+        import re
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[2]
+        for rel in ("bridge/telegram_relay.py", "bridge/telegram_bridge.py"):
+            source = (repo_root / rel).read_text()
+            # A "call site window" is the ~600 chars following each
+            # store_message token (covers both direct calls and the relay's
+            # asyncio.to_thread(store_message, ...) form). Outbound windows
+            # are the ones spelling a literal outbound sender.
+            windows = [
+                source[m.start() : m.start() + 600]
+                for m in re.finditer(r"store_message[,(]", source)
+            ]
+            outbound = [w for w in windows if 'sender="Valor"' in w or 'sender="system"' in w]
+            assert outbound, f"no outbound store_message call found in {rel}"
+            for window in outbound:
+                assert 'direction="out"' in window, (
+                    f'outbound store_message in {rel} must pass direction="out" '
+                    f"explicitly: {window[:200]}"
+                )
 
 
 # ── Test isolation verification ──────────────────────────────────────────────

--- a/tests/unit/test_steering_mechanism.py
+++ b/tests/unit/test_steering_mechanism.py
@@ -106,6 +106,44 @@ class TestSteerSessionGuards:
         assert result["error"] is not None
 
 
+class TestSteerSessionLedgerGuard:
+    """steer_session must reject ledger rows — no consumer ever drains them (#2495).
+
+    ``sdlc-local-{N}`` sessions are SDLC ledger rows (``is_ledger=True``).
+    They record pipeline state and are never executed, so every pickup/drain
+    path skips them. Accepting a steer would persist the message to a
+    ``steering:{session_id}`` list with no TTL and no reader — silent loss
+    behind a success return.
+    """
+
+    @pytest.fixture()
+    def ledger_session(self):
+        from models.agent_session import AgentSession
+
+        session = AgentSession(
+            session_id="sdlc-local-999999",
+            status="running",
+            is_ledger=True,
+        )
+        session.save()
+        yield session
+        session.delete()
+
+    def test_ledger_session_rejected(self, ledger_session):
+        from agent.agent_session_queue import steer_session
+
+        result = steer_session(ledger_session.session_id, "hello ledger")
+        assert result["success"] is False
+        assert "ledger" in result["error"].lower()
+
+    def test_ledger_rejection_pushes_nothing(self, ledger_session):
+        from agent.agent_session_queue import steer_session
+        from agent.steering import has_steering_messages
+
+        steer_session(ledger_session.session_id, "hello ledger")
+        assert has_steering_messages(ledger_session.session_id) is False
+
+
 class TestRouteSessionOutput:
     """Tests for route_session_output() persona-aware cap selection."""
 

--- a/tools/telegram_history/__init__.py
+++ b/tools/telegram_history/__init__.py
@@ -359,6 +359,7 @@ def store_message(
     classification_type: str | None = None,
     classification_confidence: float | None = None,
     db_path=None,  # Ignored — kept for API compatibility
+    direction: str = "in",
 ) -> dict:
     """Store a message in Redis via TelegramMessage.
 
@@ -366,6 +367,9 @@ def store_message(
         chat_id: Telegram chat ID.
         content: Message content (stored in full, no truncation).
         sender: Message sender.
+        direction: "in" (received) or "out" (sent by the agent). Determined
+            by the writer — never inferred from the sender string, whose
+            spelling varies across call sites (#2496).
         message_id: Telegram message ID.
         timestamp: Message timestamp (defaults to now).
         message_type: Type of message (text, photo, etc.).
@@ -386,7 +390,6 @@ def store_message(
     from tools.field_utils import log_large_field
 
     ts = _parse_ts(timestamp)
-    direction = "out" if sender and sender.lower() == "valor" else "in"
     log_large_field("TelegramMessage.content", content)
 
     try:


### PR DESCRIPTION
## Summary

Two small message-loss-cluster fixes, each following the exact shape prescribed in the audit rulings on the issues.

### #2495 — steer_session accepted writes to sdlc-local ledger rows

`steer_session` (`agent/session_executor.py`) rejected only empty messages, missing sessions, and terminal statuses. A ledger row (`is_ledger=True`, e.g. `sdlc-local-{N}`) is `running`/`pending`, so the steer was accepted and RPUSHed to a TTL-less `steering:{session_id}` list that no consumer ever drains — silent loss behind a success return.

**Fix:** reject on `is_ledger` (via the canonical `_truthy` helper, since Popoto round-trips bools as strings). The `valor-session steer` CLI reaches `steer_session` with no additional check, so the single guard covers that surface too.

### #2496 — TelegramMessage.direction derived from a sender string

`store_message` derived `direction = "out" if sender.lower() == "valor" else "in"`; the relay passes `sender="system"`, so relay-sent PM messages were recorded as inbound. Per the rescoped issue this is a correctness-of-record repair, not a behavior repair.

**Fix:** `store_message` takes an explicit `direction` parameter (default `"in"`), the sender derivation is deleted, and all three call sites declare direction explicitly — bridge outbound and relay pass `direction="out"`, bridge inbound passes `direction="in"`.

Review surfaced one real behavior defect this also closes: `tools/valor_telegram_await.py:146` filters candidate replies on `direction == "in"`, so relay-written PM-direct messages stored as `"in"` could previously be picked up as if they were the peer's reply.

## Tests

- `tests/unit/test_steering_mechanism.py::TestSteerSessionLedgerGuard` — steering a saved `is_ledger=True` session returns `success=False` with a ledger error and pushes nothing to the steering list.
- `tests/integration/test_redis_models.py` — explicit `direction="out"` with `sender="system"` (the relay's spelling) is stored as `out`; `sender="Valor"` without explicit direction now stores `in` (derivation removed); a call-site test asserts both outbound `store_message` sites in `bridge/telegram_relay.py` and `bridge/telegram_bridge.py` pass `direction="out"`.

All 5 new tests were confirmed failing before the fix. Targeted run: 167 passed (steering, redis models, and all telegram-history suites). Ruff check and format clean.

Closes #2495
Closes #2496
