### PR TITLE
Fix the two test defects 7123245c1 left behind (#2595)

### DIFF
--- a/agent/pipeline_ledger.py
+++ b/agent/pipeline_ledger.py
@@ -43,8 +43,8 @@ logger = logging.getLogger(__name__)
 # Writer budget: bounds the get_or_create() retry loop that guards the
 # "genuine miss vs. racing concurrent create" window (see get_or_create's
 # docstring for why this is NOT the #1720 class-set-index window). Mirrors
-# tools/sdlc_stage_query.py's _CLASS_SET_RETRY_ATTEMPTS / _BACKOFF_S in shape
-# but is a distinct budget for a distinct race -- provisional/tunable.
+# the class-set retry loop in tools/class_set_retry.py in shape but is a
+# distinct budget for a distinct race -- provisional/tunable.
 _CREATE_RACE_RETRY_ATTEMPTS = 5
 _CREATE_RACE_RETRY_BACKOFF_S = 0.20  # seconds between attempts; provisional/tunable
 

--- a/tests/unit/test_class_set_retry.py
+++ b/tests/unit/test_class_set_retry.py
@@ -15,6 +15,21 @@ import time
 from tools.class_set_retry import class_set_retry_attempts, log_class_set_exhaustion
 
 
+class _FakeTime:
+    """Deterministic clock/sleep pair for injecting into the retry loop."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.sleeps: list[float] = []
+
+    def clock(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+
 class TestClassSetRetryAttempts:
     def test_first_attempt_always_yields(self):
         """Retry is an addition to the read, never a precondition for it."""
@@ -26,11 +41,26 @@ class TestClassSetRetryAttempts:
         assert len(attempts) > 1
 
     def test_stops_within_the_budget(self):
-        """The bound is wall-clock, so a bigger keyspace is a config change."""
-        start = time.monotonic()
-        list(class_set_retry_attempts(budget_s=0.3, backoff_s=0.05))
-        elapsed = time.monotonic() - start
-        assert elapsed <= 0.3 + 0.05
+        """Hard ceiling: requested sleep never extends past the budget (#2595).
+
+        The final sleep is clamped to the remaining budget and one last attempt
+        yields right at the deadline. Asserted against an injected clock/sleep,
+        not wall-clock: macOS timer coalescing stretches a nominal 50ms sleep to
+        ~190ms on an idle host, so a wall-clock assertion here measures the OS
+        scheduler, not this module's contract.
+        """
+        fake = _FakeTime()
+        attempts = list(
+            class_set_retry_attempts(
+                budget_s=8.0, backoff_s=3.0, clock=fake.clock, sleep=fake.sleep
+            )
+        )
+        # Sleeps of 3, 3, then clamped to the 2 remaining — never a full
+        # nominal backoff past the deadline.
+        assert fake.sleeps == [3.0, 3.0, 2.0]
+        assert fake.now <= 8.0
+        # The clamped sleep buys one final attempt exactly at the deadline.
+        assert attempts == [1, 2, 3, 4]
 
     def test_a_larger_budget_buys_more_attempts(self):
         """The #2550 sizing fix: the cap scales without touching code."""

--- a/tests/unit/test_valor_session_resume_release.py
+++ b/tests/unit/test_valor_session_resume_release.py
@@ -750,8 +750,11 @@ class TestFindSessionFallbackToAgentSessionId:
                 "sys.modules",
                 {"models.agent_session": MagicMock(AgentSession=mock_cls)},
             ),
-            patch("tools.valor_session.time.sleep"),
-        ):  # skip retry backoff
+            # The backoff sleep lives in tools/class_set_retry.py (#2583), so
+            # patching valor_session's time.sleep no longer suppresses it.
+            # Stub the generator itself: one attempt, no sleep.
+            patch("tools.valor_session.class_set_retry_attempts", return_value=[1]),
+        ):
             result = _find_session("nonexistent-id")
 
         assert result is None
@@ -767,8 +770,9 @@ class TestFindSessionFallbackToAgentSessionId:
                 "sys.modules",
                 {"models.agent_session": MagicMock(AgentSession=mock_cls)},
             ),
-            patch("tools.valor_session.time.sleep"),
-        ):  # skip retry backoff
+            # Same generator stub as above: skip the real retry budget.
+            patch("tools.valor_session.class_set_retry_attempts", return_value=[1]),
+        ):
             result = _find_session("")
 
         assert result is None

--- a/tools/class_set_retry.py
+++ b/tools/class_set_retry.py
@@ -16,6 +16,15 @@ would go stale exactly the same way. A budget in
 :class:`config.settings.TimeoutSettings` can be raised per host without a code
 change.
 
+**The budget is a hard ceiling on requested sleep, not a soft target.** The
+loop never *asks* the OS for sleep that would extend past the deadline: the
+final backoff is clamped to the remaining budget, and the attempt after it
+lands right at the deadline. Actual wall-clock elapsed can still exceed the
+budget by the oversleep of a single ``time.sleep`` call — macOS timer
+coalescing has been measured stretching a nominal 50ms sleep to ~190ms for an
+idle process (#2595) — which is OS scheduler slop, not budget spend, and is
+why the contract is stated (and tested) in terms of requested sleep.
+
 **Exhaustion is never silent.** A cap-exhausted read returns the same ``None`` as
 a genuine miss, so the caller reports "session not found" for a live session and
 nothing anywhere says a retry loop gave up. :func:`log_class_set_exhaustion` is
@@ -26,7 +35,7 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 
 from config.settings import settings
 
@@ -34,13 +43,25 @@ logger = logging.getLogger(__name__)
 
 
 def class_set_retry_attempts(
-    budget_s: float | None = None, backoff_s: float | None = None
+    budget_s: float | None = None,
+    backoff_s: float | None = None,
+    *,
+    clock: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
 ) -> Iterator[int]:
     """Yield 1-based attempt numbers, sleeping between them, until the budget is spent.
 
     The first attempt always yields, even with a zero budget: the retry is an
     addition to the read, never a precondition for it. Sleeps happen between
     attempts only, so a hit on the first read costs nothing.
+
+    The budget is a hard ceiling on requested sleep (see the module docstring):
+    the final backoff is clamped to ``deadline - clock()``, and that clamped
+    sleep buys one last attempt right at the deadline — the read most likely to
+    land after a rebuild finishes.
+
+    ``clock`` and ``sleep`` exist for deterministic tests; production callers
+    never pass them.
 
     Usage::
 
@@ -56,15 +77,16 @@ def class_set_retry_attempts(
     if backoff_s is None:
         backoff_s = settings.timeouts.class_set_retry_backoff_s
 
-    deadline = time.monotonic() + budget_s
+    deadline = clock() + budget_s
     attempt = 0
     while True:
         attempt += 1
         yield attempt
-        # Only sleep if another attempt would still land inside the budget.
-        if time.monotonic() + backoff_s >= deadline:
+        remaining = deadline - clock()
+        if remaining <= 0:
             return
-        time.sleep(backoff_s)
+        # Clamp so the requested sleep never extends past the deadline.
+        sleep(min(backoff_s, remaining))
 
 
 def log_class_set_exhaustion(


### PR DESCRIPTION
Closes #2595

Two independent defects left by 7123245c1 (#2583), fixed as two commits per the issue's instruction not to fold them.

## Commit 1 — Defect 1 residuals (test patch target + stale comment)

The core rewrite (AttributeError on the deleted `_CLASS_SET_RETRY_ATTEMPTS`, pinning the UUID short-circuit with `filter.call_count == 0`) already landed on main in c4253a306. This commit closes out the residuals the acceptance criteria name:

- `test_returns_none_when_neither_lookup_finds` and `test_empty_string_returns_none` still patched `tools.valor_session.time.sleep`, which no longer suppresses the class-set backoff (it moved to `tools/class_set_retry.py`), so both paid the real 3s default budget. They now stub `class_set_retry_attempts` directly (one attempt, no sleep).
- `agent/pipeline_ledger.py:46` no longer references the deleted `tools/sdlc_stage_query.py::_CLASS_SET_RETRY_ATTEMPTS`; the shape comparison points at the budget loop in `tools/class_set_retry.py`.
- `grep -rn "_CLASS_SET_RETRY_ATTEMPTS" tests/ tools/ agent/` now returns nothing.

## Commit 2 — Defect 2 contract decision: hard ceiling on *requested* sleep

**Decision:** the budget is a hard ceiling on requested sleep, not a soft target. The final backoff is clamped to `deadline - clock()`, which also buys one last attempt right at the deadline — the read most likely to land after a rebuild finishes. Wall-clock elapsed may still exceed the budget by a single `time.sleep` call's OS oversleep (macOS coalescing stretches a nominal 50ms sleep to ~190ms when idle); that is scheduler slop, not budget spend, and the module docstring states the contract explicitly.

**Why hard ceiling:** callers use the budget as an upper bound on latency added to session-lookup paths; clamping keeps that bound honest without shrinking coverage (it strictly *adds* one attempt at the deadline). And the suite treats wall-clock assertions as the odd ones out (`--timeout` is the only sanctioned timing bound), so the test now asserts the stated contract deterministically via an injectable `clock`/`sleep` pair instead of measuring the scheduler — which is what made the old zero-tolerance assertion an idle-machine nightly flake while loaded PR runs passed.

## Verification

- RED confirmed: new deterministic test failed (`TypeError: unexpected keyword argument 'clock'`) before the clamp landed.
- `scripts/pytest-clean.sh "tests/unit/test_valor_session_resume_release.py::TestFindSessionFallbackToAgentSessionId" "tests/unit/test_class_set_retry.py"` → **14 passed** (whole retry test file run because the loop semantics changed).
- `ruff check` / `ruff format --check` clean on all four touched files.
