### PR TITLE
Fix #2458 D2 and D3: datetime age coercion + steering no longer drops the pending session's own message

### DIFF
--- a/agent/session_executor.py
+++ b/agent/session_executor.py
@@ -34,6 +34,32 @@ from models.session_lifecycle import TERMINAL_STATUSES as _TERMINAL_STATUSES
 logger = logging.getLogger(__name__)
 
 
+def merge_steering_turn_input(
+    own_text: str | None,
+    steering_text: str,
+    own_message_consumed: bool,
+) -> str:
+    """Resolve the turn input when steering messages are queued (#2458 D3).
+
+    A steering message that lands before the session's first turn (e.g. the
+    reply-to path steering into a still-pending session) must not REPLACE the
+    session's own ``message_text`` — that silently drops the first message.
+
+    - Own message not yet consumed (no prior claude session UUID) and
+      non-empty: combine — own text first (it arrived first), then the
+      steering text.
+    - Own message already consumed by a prior turn, or empty/"None" sentinel:
+      the steering text alone is the turn input (replaying consumed text
+      would duplicate it into the resumed conversation).
+    """
+    if own_message_consumed:
+        return steering_text
+    own = ("" if own_text is None else str(own_text)).strip()
+    if not own or own == "None":
+        return steering_text
+    return f"{own}\n\n{steering_text}"
+
+
 def _is_non_clean_runner_exit(agent_session) -> bool:
     """Return True when the session has a runner exit_reason that signals a real failure.
 
@@ -1785,11 +1811,21 @@ async def _execute_agent_session(session: AgentSession) -> None:
 
                 steering_msgs = _pop_all_steering(session.session_id)
                 if steering_msgs:
-                    _turn_input = steering_msgs[0].get("text", "")
+                    # #2458 D3: if this session has never run a turn (no prior
+                    # claude session UUID), its own message_text has not been
+                    # consumed yet — combine it with the steering text instead
+                    # of replacing it, or the first message is silently lost.
+                    _own_consumed = bool(getattr(agent_session, "claude_session_uuid", None))
+                    _turn_input = merge_steering_turn_input(
+                        enriched_text,
+                        steering_msgs[0].get("text", ""),
+                        own_message_consumed=_own_consumed,
+                    )
                     logger.info(
                         f"[{session.project_key}] Injecting steering message for session "
                         f"{session.session_id}: {_turn_input[:80]!r} "
-                        f"({len(steering_msgs)} queued, used first)"
+                        f"({len(steering_msgs)} queued, used first"
+                        f"{', combined with unconsumed own message' if not _own_consumed else ''})"
                     )
                     if len(steering_msgs) > 1:
                         # Re-queue remaining messages for future turns

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -29,7 +29,7 @@ import uuid
 from datetime import UTC, datetime
 from pathlib import Path
 
-from bridge.utc import utc_iso, utc_now
+from bridge.utc import to_unix_ts, utc_iso, utc_now
 from config.machine import get_machine_name
 from config.settings import settings
 
@@ -151,6 +151,22 @@ from config.enums import PersonaType, SessionType  # noqa: E402
 # Messages arriving within this window attach to the pending session via the
 # steering queue instead of spawning a competing session. See issue #619.
 PENDING_MERGE_WINDOW_SECONDS = 8
+
+
+def _pending_session_age_seconds(created_at, now_ts: float) -> float:
+    """Age in seconds of a session's created_at relative to now_ts.
+
+    ``AgentSession.created_at`` is a datetime (Popoto SortedField, naive on
+    read); raw ``now_ts - created_at`` raises TypeError (#2458 D2). Coerce
+    through ``bridge.utc.to_unix_ts`` (naive treated as UTC). A missing or
+    uncoercible created_at returns +inf so the session falls outside any
+    merge window instead of crashing the intake classifier.
+    """
+    ts = to_unix_ts(created_at)
+    if ts is None:
+        return float("inf")
+    return now_ts - ts
+
 
 # Guard timeout (seconds) for fetch_reply_chain() reply-chain hydration —
 # a Telethon API walk, not a subprocess/HTTP/Redis client call, so it stays
@@ -1857,14 +1873,7 @@ async def main():
                     )
                     if pending_sessions:
                         pending_session = pending_sessions[0]
-                        _ct = pending_session.created_at
-                        if isinstance(_ct, datetime):
-                            _ct = (
-                                _ct.timestamp()
-                                if _ct.tzinfo
-                                else _ct.replace(tzinfo=UTC).timestamp()
-                            )
-                        age = time.time() - (_ct or 0)
+                        age = _pending_session_age_seconds(pending_session.created_at, time.time())
                         await _ack_steering_routed(
                             client,
                             event,
@@ -2144,22 +2153,32 @@ async def main():
                     if sessions:
                         active_sessions.extend(sessions)
 
-                # Also include recent pending sessions within the merge window (#619)
-                pending_sessions = AgentSession.query.filter(
-                    chat_id=telegram_chat_id, status="pending"
-                )
-                if pending_sessions:
-                    now_ts = time.time()
-                    for ps in pending_sessions:
-                        age = now_ts - (ps.created_at or 0)
-                        if age <= PENDING_MERGE_WINDOW_SECONDS:
-                            active_sessions.append(ps)
+                # Also include recent pending sessions within the merge window (#619).
+                # Narrow try: a failure in the pending-coalescing arm must never
+                # suppress the running/dormant interjection arm below (#2458 D2).
+                try:
+                    pending_sessions = AgentSession.query.filter(
+                        chat_id=telegram_chat_id, status="pending"
+                    )
+                    if pending_sessions:
+                        now_ts = time.time()
+                        for ps in pending_sessions:
+                            age = _pending_session_age_seconds(ps.created_at, now_ts)
+                            if age <= PENDING_MERGE_WINDOW_SECONDS:
+                                active_sessions.append(ps)
+                except Exception as _pend_err:
+                    logger.warning(
+                        f"[{project_name}] Pending-session merge-window check "
+                        f"failed (non-fatal): {_pend_err}"
+                    )
 
                 if active_sessions:
-                    # Pick the most recent session (by updated_at or created_at)
+                    # Pick the most recent session (by updated_at or created_at).
+                    # Coerce to unix floats: mixing datetimes with the 0 fallback
+                    # in max() raises TypeError (#2458 D2).
                     target_session = max(
                         active_sessions,
-                        key=lambda s: s.updated_at or s.created_at or 0,
+                        key=lambda s: to_unix_ts(s.updated_at) or to_unix_ts(s.created_at) or 0,
                     )
 
                     # Classify message intent with Haiku

--- a/docs/features/steering-implementation-spec.md
+++ b/docs/features/steering-implementation-spec.md
@@ -57,7 +57,7 @@ User sends new mention (not a reply) → Bridge sees active session for project 
 
 **Pending session merge (#619):**
 
-User sends two messages in quick succession (< 8s) → First message enqueues as pending job → Second message arrives before worker pops the first → Bridge detects pending session within `PENDING_MERGE_WINDOW_SECONDS` (8s) → Push to `steering:{session_id}` Redis list → Ack: 👀 emoji reaction on the user's message → When worker pops the job, drain-on-start logic calls `pop_all_steering_messages()` and prepends follow-up text to `message_text` → Agent sees the combined message on first run
+User sends two messages in quick succession (< 8s) → First message enqueues as pending job → Second message arrives before worker pops the first → Bridge detects pending session within `PENDING_MERGE_WINDOW_SECONDS` (8s) → Push to `steering:{session_id}` Redis list → Ack: 👀 emoji reaction on the user's message → When worker pops the job, drain-on-start logic calls `pop_all_steering_messages()` and combines the session's own (not-yet-consumed) `message_text` with the follow-up text — own message first, follow-up appended (`merge_steering_turn_input`, #2458 D3) → Agent sees the combined message on first run
 
 For messages arriving within ~200ms (before the first session is written to Redis), an in-memory coalescing guard (`_recent_session_by_chat`) bridges the Redis visibility gap. See `docs/features/semantic-session-routing.md` for details on the coalescing guard.
 

--- a/tests/unit/test_pending_merge_window_age.py
+++ b/tests/unit/test_pending_merge_window_age.py
@@ -1,0 +1,50 @@
+"""D2 (#2458): pending-session age math must coerce datetime created_at.
+
+``AgentSession.created_at`` is a datetime (Popoto SortedField); the intake
+classifier's pending-window check previously computed
+``now_ts - (ps.created_at or 0)`` which raised ``TypeError`` on every
+invocation, and — because it sat inside the classifier's broad
+``except Exception`` — suppressed the whole intake classifier (including the
+load-bearing running/dormant interjection arm) for any chat with a pending
+session.
+
+These tests call the extracted production helper
+``bridge.telegram_bridge._pending_session_age_seconds`` directly.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from bridge.telegram_bridge import _pending_session_age_seconds
+
+NOW_TS = 1_700_000_000.0
+NOW_DT = datetime.fromtimestamp(NOW_TS, tz=UTC)
+
+
+@pytest.mark.parametrize(
+    ("created_at", "expected_age"),
+    [
+        # Naive datetime — Popoto strips tzinfo on save; must be read as UTC.
+        (NOW_DT.replace(tzinfo=None) - timedelta(seconds=5), 5.0),
+        # Aware UTC datetime.
+        (NOW_DT - timedelta(seconds=3), 3.0),
+        # Float unix timestamp passthrough.
+        (NOW_TS - 7.0, 7.0),
+    ],
+)
+def test_age_coerces_datetime_and_float(created_at, expected_age):
+    assert _pending_session_age_seconds(created_at, NOW_TS) == pytest.approx(
+        expected_age, abs=0.001
+    )
+
+
+def test_missing_created_at_is_infinitely_old():
+    """None created_at must exclude the session (age > any window), not crash."""
+    assert _pending_session_age_seconds(None, NOW_TS) == float("inf")
+
+
+def test_datetime_input_does_not_raise_typeerror():
+    """The original defect: raw ``now_ts - datetime`` raised TypeError."""
+    age = _pending_session_age_seconds(NOW_DT, NOW_TS)
+    assert age == pytest.approx(0.0, abs=0.001)

--- a/tests/unit/test_steering_turn_input_merge.py
+++ b/tests/unit/test_steering_turn_input_merge.py
@@ -1,0 +1,48 @@
+"""D3 (#2458): steering drain must not drop the session's own unconsumed message.
+
+When a steering message lands on a session BEFORE its first turn (e.g. the
+reply-to path steers into a still-``pending`` session), the turn-boundary
+drain previously replaced ``enriched_text`` with ``steering_msgs[0]`` — the
+session's own ``message_text`` was silently lost.
+
+``agent.session_executor.merge_steering_turn_input`` is the production
+predicate: it combines the session's own text with the steering text when the
+own message has not yet been consumed (no prior claude session UUID), and
+keeps the replace behavior once the own message has already run a turn.
+"""
+
+import pytest
+
+from agent.session_executor import merge_steering_turn_input
+
+
+def test_first_turn_combines_own_message_with_steering():
+    result = merge_steering_turn_input(
+        own_text="screenshot: this needs to be clearer about what's missing",
+        steering_text="this is for the new 360 report when it can't generate",
+        own_message_consumed=False,
+    )
+    # Both messages survive, own message first (it arrived first).
+    assert "clearer about what's missing" in result
+    assert "360 report" in result
+    assert result.index("clearer") < result.index("360 report")
+
+
+def test_consumed_own_message_is_not_replayed():
+    """After the first turn, own_text is stale — steering alone is the turn input."""
+    result = merge_steering_turn_input(
+        own_text="original already-consumed message",
+        steering_text="follow-up steer",
+        own_message_consumed=True,
+    )
+    assert result == "follow-up steer"
+
+
+@pytest.mark.parametrize("own_text", [None, "", "   ", "None"])
+def test_empty_or_sentinel_own_text_yields_steering_only(own_text):
+    result = merge_steering_turn_input(
+        own_text=own_text,
+        steering_text="follow-up steer",
+        own_message_consumed=False,
+    )
+    assert result == "follow-up steer"


### PR DESCRIPTION
Refs #2458 (NOT closing — D1 remains open; the guard self-overwrite is deliberately untouched and will be re-checked after the Room-model milestone of #2494 lands, per the audit comment's sequencing).

## D2 — pending-window datetime TypeError

`age = now_ts - (ps.created_at or 0)` raised `TypeError` on every invocation (`created_at` is a datetime), and the classifier's broad `except` turned that into a full intake-classifier blackout — including the unrelated, load-bearing `running`/`dormant` interjection arm — for any chat with a pending session.

Fix shape (`bridge/telegram_bridge.py`):
- New module-level `_pending_session_age_seconds(created_at, now_ts)` coercing via `bridge.utc.to_unix_ts` (naive datetimes treated as UTC, per repo naive-datetime history); `None`/uncoercible → `+inf` so the session falls outside any window instead of crashing.
- The reply-to path's inline `isinstance` coercion copy is folded into the same helper.
- The `max()` recency key coerces both `updated_at`/`created_at` to unix floats (mixing datetimes with the `0` fallback was the same defect class one line down).
- The pending-inclusion arm now sits under its own narrow `try`, so a failure there can never again suppress the `running`/`dormant` arm.

## D3 — steering drain dropped the pending session's own message

`agent/session_executor.py` set `_turn_input = enriched_text` then unconditionally replaced it with `steering_msgs[0]`, re-queueing only `steering_msgs[1:]` — so a steer landing before the session's first turn (reachable today via the reply-to → pending merge) silently destroyed the session's own `message_text`.

Fix shape: new `merge_steering_turn_input(own_text, steering_text, own_message_consumed)`. When the session has never run a turn (no `claude_session_uuid`), the own message and the steering text are **combined** (own first — it arrived first); once a prior turn consumed the own message, replace behavior is kept so consumed text is not replayed into a resumed conversation. `docs/features/steering-implementation-spec.md` updated to describe the shipped combine behavior.

## Tests

Targeted, TDD (both files failed with `ImportError` before implementation):
- `tests/unit/test_pending_merge_window_age.py` — naive/aware datetime, float passthrough, `None` → `+inf`, and the original raw-datetime TypeError shape, all through the production helper.
- `tests/unit/test_steering_turn_input_merge.py` — first-turn combine (both texts survive, own first), consumed → steering-only, empty/`"None"` sentinel → steering-only.

`scripts/pytest-clean.sh` on the two new files: **11 passed**. Adjacent regression run (`test_steering.py`, `test_steering_mechanism.py`, `test_coalescing_guard.py`, `test_bridge_ack_steering_routed.py`, `test_session_executor_guards.py`): **66 passed**. `ruff check` + `ruff format --check`: clean.

Do not merge without review; bridge/worker changes need `./scripts/valor-service.sh restart` after landing.

Closes #2618