### PR TITLE
Surface a stale data/catchup-disabled kill switch as a WARN in doctor and dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -505,6 +505,11 @@ REFLECTION_POOL_WORKERS=2
 # auto-expires inactive chats). Uncomment to override.
 # TIMEOUTS__LAST_PROCESSED_TTL_S=2592000
 
+# Grace window (hours) before a present data/catchup-disabled kill switch is
+# surfaced as a WARN by tools.doctor and /dashboard.json (issue #2473).
+# Provisional/tunable. Uncomment to override.
+# TIMEOUTS__CATCHUP_DISABLED_WARN_HOURS=24
+
 # =============================================================================
 # Correctness & delivery-integrity hardening (issue #1817)
 # =============================================================================

--- a/bridge/catchup.py
+++ b/bridge/catchup.py
@@ -72,9 +72,13 @@ def kill_switch_status() -> dict:
     from config.settings import settings
 
     warn_hours = settings.timeouts.catchup_disabled_warn_hours
-    age = catchup_disabled_age_hours()
+    # `disabled` shares catchup_disabled()'s exists() predicate so this surface
+    # can never disagree with the scanners' own gate: a flag whose stat() fails
+    # mid-check still reports disabled=True, just with no age (and not stale).
+    disabled = catchup_disabled()
+    age = catchup_disabled_age_hours() if disabled else None
     return {
-        "disabled": age is not None,
+        "disabled": disabled,
         "age_hours": round(age, 2) if age is not None else None,
         "warn_hours": warn_hours,
         "stale": age is not None and age >= warn_hours,

--- a/bridge/catchup.py
+++ b/bridge/catchup.py
@@ -45,6 +45,42 @@ def catchup_disabled() -> bool:
     return CATCHUP_DISABLED_FLAG.exists()
 
 
+def catchup_disabled_age_hours() -> float | None:
+    """Hours since the kill-switch flag was set, or None when it is absent.
+
+    Uses the flag file's mtime (`touch data/catchup-disabled` sets it), so the
+    age tracks when the operator last (re)armed the switch. Never raises: a
+    flag that vanishes between the exists-check and the stat maps to None.
+    """
+    import time
+
+    try:
+        mtime = CATCHUP_DISABLED_FLAG.stat().st_mtime
+    except OSError:
+        return None
+    return max(0.0, (time.time() - mtime) / 3600.0)
+
+
+def kill_switch_status() -> dict:
+    """Operator-surface status of the recovery kill switch (issue #2473).
+
+    Single source of truth consumed by `tools.doctor` and `/dashboard.json`.
+    A kill switch with no expiry and no alarm silently disabled the entire
+    recovery layer for 7 days; `stale` flips once the flag has been present
+    longer than `settings.timeouts.catchup_disabled_warn_hours`.
+    """
+    from config.settings import settings
+
+    warn_hours = settings.timeouts.catchup_disabled_warn_hours
+    age = catchup_disabled_age_hours()
+    return {
+        "disabled": age is not None,
+        "age_hours": round(age, 2) if age is not None else None,
+        "warn_hours": warn_hours,
+        "stale": age is not None and age >= warn_hours,
+    }
+
+
 async def scan_for_missed_messages(
     client,
     monitored_groups: list[str],

--- a/config/settings.py
+++ b/config/settings.py
@@ -430,6 +430,25 @@ class TimeoutSettings(BaseModel):
             "TIMEOUTS__DEDUP_RECORD_TTL_S."
         ),
     )
+    catchup_disabled_warn_hours: float = Field(
+        default=24.0,
+        ge=0.1,
+        le=336.0,
+        description=(
+            "Grace window (hours) before a present `data/catchup-disabled` "
+            "operator kill switch is surfaced as a WARN by `tools.doctor` and "
+            "`/dashboard.json` (issue #2473). The flag pauses ALL message-"
+            "recovery scans (startup catchup, periodic reconciler, agent "
+            "sweep); in the #2473 incident it sat forgotten for 7 days with "
+            "no alarm while a crash storm dropped recovery entirely. Within "
+            "the window a set flag is reported as a deliberate pause; beyond "
+            "it, doctor fails the `catchup_kill_switch` check and the "
+            "dashboard sets `catchup_disabled_stale`. GRAIN OF SALT: 24h is "
+            "provisional/tunable -- long enough for a deliberate overnight "
+            "pause, short enough that a forgotten flag is loud within a day. "
+            "Env: TIMEOUTS__CATCHUP_DISABLED_WARN_HOURS."
+        ),
+    )
 
 
 class HybridEvalSettings(BaseModel):

--- a/docs/features/agent-judgment-catchup.md
+++ b/docs/features/agent-judgment-catchup.md
@@ -266,6 +266,17 @@ duplicate replies reappear after re-enabling recovery:
    investigating — only the kill switch needs to be re-touched. Check the
    offending chat's `[dedup-seed]` log line before re-removing the flag.
 
+The kill switch is no longer silent (issue #2473: it once sat forgotten for
+7 days with all recovery disabled). Once the flag has been present longer
+than `settings.timeouts.catchup_disabled_warn_hours` (default 24h, env
+`TIMEOUTS__CATCHUP_DISABLED_WARN_HOURS`), the full `python -m tools.doctor`
+run fails its `catchup_kill_switch` check with a WARN, and `/dashboard.json`
+/ `/health` set `catchup_disabled_stale: true` alongside
+`catchup_disabled_age_hours`. `doctor --quick` (the opt-in pre-push hook)
+deliberately omits the check so a stale flag alarms without gating git
+pushes. Re-`touch` the flag to reset its age if the pause is still
+deliberate; nothing ever removes the flag automatically.
+
 ## Error Handling
 
 All errors are narrowly scoped:
@@ -328,6 +339,7 @@ valor-catchup (CLI) or run_catchup_step (/update final step)
 | `seed_dedup_for_chat` | `bridge/dedup_seed.py` | Seed one chat's dedup set from a live Telethon read; writes that chat's marker only on full success |
 | `is_chat_seeded` | `bridge/dedup_seed.py` | Check a chat's `data/dedup-seeded.{chat_id}` marker |
 | `catchup_disabled` | `bridge/catchup.py` | Operator kill switch check (`data/catchup-disabled`) |
+| `kill_switch_status` | `bridge/catchup.py` | Kill-switch staleness surface (#2473): presence, mtime age, `stale` past the warn threshold; consumed by `tools.doctor` and `/dashboard.json` |
 
 ## See Also
 

--- a/tests/unit/test_catchup_kill_switch_staleness.py
+++ b/tests/unit/test_catchup_kill_switch_staleness.py
@@ -66,9 +66,26 @@ class TestKillSwitchStatus:
         assert status["disabled"] is True
         assert status["stale"] is False
 
-    def test_never_raises_when_flag_vanishes_mid_check(self):
-        # stat() on a missing path must map to the absent shape, not an exception.
-        assert catchup_mod.catchup_disabled_age_hours() is None
+    def test_stat_failure_mid_check_reports_disabled_without_age(self, monkeypatch):
+        """A flag whose stat() fails after exists() succeeded stays disabled=True.
+
+        `disabled` shares `catchup_disabled()`'s exists() predicate, so this
+        surface can never disagree with the scanners' own gate; the failed
+        stat only costs the age (and therefore staleness), never an exception.
+        """
+
+        class _VanishingFlag:
+            def exists(self) -> bool:
+                return True
+
+            def stat(self):
+                raise OSError("vanished mid-check")
+
+        monkeypatch.setattr(catchup_mod, "CATCHUP_DISABLED_FLAG", _VanishingFlag())
+        status = kill_switch_status()
+        assert status["disabled"] is True
+        assert status["age_hours"] is None
+        assert status["stale"] is False
 
 
 class TestDoctorCheck:
@@ -99,10 +116,13 @@ class TestDoctorCheck:
         assert result.fix is not None
         assert "rm data/catchup-disabled" in result.fix
 
-    def test_registered_in_get_checks(self):
+    def test_registered_in_full_run_but_not_quick(self):
+        """--quick backs the opt-in pre-push hook; a stale kill switch must
+        WARN in full runs without gating git pushes (#2473 review)."""
         from tools.doctor import _check_catchup_kill_switch, get_checks
 
         assert _check_catchup_kill_switch in get_checks()
+        assert _check_catchup_kill_switch not in get_checks(quick=True)
 
 
 class TestDashboardSurface:

--- a/tests/unit/test_catchup_kill_switch_staleness.py
+++ b/tests/unit/test_catchup_kill_switch_staleness.py
@@ -1,0 +1,130 @@
+"""Stale ``data/catchup-disabled`` kill switch surfaces as a WARN (issue #2473).
+
+The operator kill switch pauses ALL message-recovery scans and, before this
+feature, could sit forgotten for days (7 days in the #2473 incident) with no
+alarm anywhere. `bridge.catchup.kill_switch_status()` is the single source of
+truth; `tools.doctor` and `/dashboard.json` both surface it once the flag has
+been set longer than `settings.timeouts.catchup_disabled_warn_hours`.
+
+The autouse ``isolate_catchup_kill_switch`` fixture (conftest, #2552) repoints
+``bridge.catchup.CATCHUP_DISABLED_FLAG`` at a per-test temp path, so touching
+the flag here never leaks into live operator state.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+import bridge.catchup as catchup_mod
+from bridge.catchup import kill_switch_status
+from config.settings import settings
+
+pytestmark = pytest.mark.unit
+
+
+def _touch_flag(age_hours: float = 0.0) -> None:
+    """Create the (redirected) flag file with an mtime ``age_hours`` in the past."""
+    flag = catchup_mod.CATCHUP_DISABLED_FLAG
+    flag.touch()
+    if age_hours:
+        past = time.time() - age_hours * 3600
+        os.utime(flag, (past, past))
+
+
+class TestKillSwitchStatus:
+    def test_absent_flag(self):
+        status = kill_switch_status()
+        assert status["disabled"] is False
+        assert status["age_hours"] is None
+        assert status["stale"] is False
+        assert status["warn_hours"] == settings.timeouts.catchup_disabled_warn_hours
+
+    def test_fresh_flag_is_disabled_but_not_stale(self):
+        _touch_flag()
+        status = kill_switch_status()
+        assert status["disabled"] is True
+        assert status["age_hours"] is not None
+        assert status["age_hours"] < 1.0
+        assert status["stale"] is False
+
+    def test_flag_older_than_threshold_is_stale(self, monkeypatch):
+        monkeypatch.setattr(settings.timeouts, "catchup_disabled_warn_hours", 2.0)
+        _touch_flag(age_hours=3.0)
+        status = kill_switch_status()
+        assert status["disabled"] is True
+        assert status["stale"] is True
+        assert status["age_hours"] >= 2.0
+        assert status["warn_hours"] == 2.0
+
+    def test_flag_within_threshold_is_not_stale(self, monkeypatch):
+        monkeypatch.setattr(settings.timeouts, "catchup_disabled_warn_hours", 48.0)
+        _touch_flag(age_hours=3.0)
+        status = kill_switch_status()
+        assert status["disabled"] is True
+        assert status["stale"] is False
+
+    def test_never_raises_when_flag_vanishes_mid_check(self):
+        # stat() on a missing path must map to the absent shape, not an exception.
+        assert catchup_mod.catchup_disabled_age_hours() is None
+
+
+class TestDoctorCheck:
+    def test_absent_flag_passes(self):
+        from tools.doctor import _check_catchup_kill_switch
+
+        result = _check_catchup_kill_switch()
+        assert result.passed is True
+        assert result.category == "Services"
+        assert "not set" in result.message
+
+    def test_fresh_flag_passes_with_paused_note(self):
+        from tools.doctor import _check_catchup_kill_switch
+
+        _touch_flag()
+        result = _check_catchup_kill_switch()
+        assert result.passed is True
+        assert "paused" in result.message
+
+    def test_stale_flag_warns(self, monkeypatch):
+        from tools.doctor import _check_catchup_kill_switch
+
+        monkeypatch.setattr(settings.timeouts, "catchup_disabled_warn_hours", 1.0)
+        _touch_flag(age_hours=2.0)
+        result = _check_catchup_kill_switch()
+        assert result.passed is False
+        assert "WARN" in result.message
+        assert result.fix is not None
+        assert "rm data/catchup-disabled" in result.fix
+
+    def test_registered_in_get_checks(self):
+        from tools.doctor import _check_catchup_kill_switch, get_checks
+
+        assert _check_catchup_kill_switch in get_checks()
+
+
+class TestDashboardSurface:
+    @pytest.fixture
+    def client(self):
+        from fastapi.testclient import TestClient
+
+        from ui.app import create_app
+
+        return TestClient(create_app())
+
+    def test_health_block_carries_catchup_fields(self, client, monkeypatch):
+        monkeypatch.setattr(settings.timeouts, "catchup_disabled_warn_hours", 1.0)
+        _touch_flag(age_hours=2.0)
+        health = client.get("/dashboard.json").json()["health"]
+        assert health["catchup_disabled"] is True
+        assert health["catchup_disabled_stale"] is True
+        assert health["catchup_disabled_age_hours"] >= 1.0
+        assert health["catchup_disabled_warn_hours"] == 1.0
+
+    def test_health_block_absent_flag_defaults(self, client):
+        health = client.get("/dashboard.json").json()["health"]
+        assert health["catchup_disabled"] is False
+        assert health["catchup_disabled_stale"] is False
+        assert health["catchup_disabled_age_hours"] is None

--- a/tools/doctor.py
+++ b/tools/doctor.py
@@ -938,13 +938,15 @@ def _check_catchup_kill_switch() -> CheckResult:
             )
         age = status["age_hours"]
         if not status["stale"]:
+            # age can be None if the flag's stat() failed mid-check even
+            # though it exists; still a legitimate paused state.
+            age_note = f"set {age:.1f}h ago" if age is not None else "set (age unknown)"
             return CheckResult(
                 name="catchup_kill_switch",
                 category="Services",
                 passed=True,
                 message=(
-                    f"set {age:.1f}h ago — recovery scans paused "
-                    f"(within {warn_hours:.0f}h grace window)"
+                    f"{age_note} — recovery scans paused (within {warn_hours:.0f}h grace window)"
                 ),
             )
         return CheckResult(
@@ -1448,7 +1450,6 @@ def get_checks(
         _check_knowledge_zero_chunk_documents,
         _check_bridge,
         _check_worker,
-        _check_catchup_kill_switch,
         # Auth
         lambda: _check_telegram_session(quick=quick),
         _check_api_keys,
@@ -1460,6 +1461,14 @@ def get_checks(
         _check_memory,
         _check_cpu,
     ]
+
+    if not quick:
+        # #2473 review: the stale-kill-switch check must WARN without gating
+        # git pushes. `--quick` backs the opt-in pre-push hook, and a
+        # deliberate >warn-window pause failing that hook would block every
+        # push -- stronger than #2473's WARN intent. Full runs (including
+        # --json) keep the check, slotted with the other Services checks.
+        checks.insert(checks.index(_check_worker) + 1, _check_catchup_kill_switch)
 
     if quality:
         checks.extend(

--- a/tools/doctor.py
+++ b/tools/doctor.py
@@ -914,6 +914,62 @@ def _check_worker() -> CheckResult:
         )
 
 
+def _check_catchup_kill_switch() -> CheckResult:
+    """WARN when `data/catchup-disabled` has been set past its grace window (#2473).
+
+    The flag pauses ALL message-recovery scans (startup catchup, periodic
+    reconciler, `valor-catchup`) and is a deliberate operator control -- a
+    freshly set flag passes with a note. But a kill switch with no expiry and
+    no alarm once silently disabled the entire recovery layer for 7 days, so
+    beyond `settings.timeouts.catchup_disabled_warn_hours` this check fails
+    loudly. It never removes the flag itself; that stays an operator decision.
+    """
+    try:
+        from bridge.catchup import kill_switch_status
+
+        status = kill_switch_status()
+        warn_hours = status["warn_hours"]
+        if not status["disabled"]:
+            return CheckResult(
+                name="catchup_kill_switch",
+                category="Services",
+                passed=True,
+                message="not set — recovery scans enabled",
+            )
+        age = status["age_hours"]
+        if not status["stale"]:
+            return CheckResult(
+                name="catchup_kill_switch",
+                category="Services",
+                passed=True,
+                message=(
+                    f"set {age:.1f}h ago — recovery scans paused "
+                    f"(within {warn_hours:.0f}h grace window)"
+                ),
+            )
+        return CheckResult(
+            name="catchup_kill_switch",
+            category="Services",
+            passed=False,
+            message=(
+                f"WARN: data/catchup-disabled set {age:.1f}h ago "
+                f"(> {warn_hours:.0f}h) — ALL message-recovery scans are disabled"
+            ),
+            fix=(
+                "Re-enable recovery with `rm data/catchup-disabled` once the issue "
+                "it was set for is resolved, or re-`touch` it / raise "
+                "TIMEOUTS__CATCHUP_DISABLED_WARN_HOURS if the pause is still deliberate."
+            ),
+        )
+    except Exception as e:
+        return CheckResult(
+            name="catchup_kill_switch",
+            category="Services",
+            passed=False,
+            message=f"Could not check catchup kill switch: {e}",
+        )
+
+
 def _check_telegram_session(*, quick: bool = False) -> CheckResult:
     """Check Telegram session auth."""
     if quick:
@@ -1392,6 +1448,7 @@ def get_checks(
         _check_knowledge_zero_chunk_documents,
         _check_bridge,
         _check_worker,
+        _check_catchup_kill_switch,
         # Auth
         lambda: _check_telegram_session(quick=quick),
         _check_api_keys,

--- a/ui/app.py
+++ b/ui/app.py
@@ -690,6 +690,23 @@ def create_app() -> FastAPI:
             "kind": status["kind"],
         }
 
+    def _get_catchup_health() -> dict:
+        """Status of the `data/catchup-disabled` recovery kill switch (#2473).
+
+        Delegates to `bridge.catchup.kill_switch_status` (the single source of
+        truth, shared with `tools.doctor`). `stale` flips once the flag has
+        been present longer than `settings.timeouts.catchup_disabled_warn_hours`
+        — a kill switch with no alarm once silently disabled the entire
+        recovery layer for 7 days. Fail-quiet — never blocks the health
+        payload.
+        """
+        try:
+            from bridge.catchup import kill_switch_status
+
+            return kill_switch_status()
+        except Exception:
+            return {"disabled": False, "age_hours": None, "warn_hours": None, "stale": False}
+
     def _session_to_json(s, include_children: bool = True) -> dict:
         """Serialize a PipelineProgress to JSON dict for the dashboard API.
 
@@ -865,6 +882,7 @@ def create_app() -> FastAPI:
         email = _get_email_health()
         claude_auth = _get_claude_auth_health()
         archive = _get_archive_health()
+        catchup = _get_catchup_health()
         # One scan feeds both views. Jobs group first because
         # `assemble_session_tree` nests children onto the same objects, and a
         # Job already lists every run it owns.
@@ -927,6 +945,14 @@ def create_app() -> FastAPI:
                     # Additive-only (issue #1825): AgentSession SQLite secondary
                     # store freshness -- see docs/plans/session-archive-sqlite.md.
                     "archive": archive,
+                    # Additive-only (issue #2473): recovery kill-switch WARN.
+                    # `catchup_disabled_stale` is the operator alarm: the flag
+                    # has outlived its grace window and ALL message-recovery
+                    # scans are still disabled.
+                    "catchup_disabled": catchup["disabled"],
+                    "catchup_disabled_age_hours": catchup["age_hours"],
+                    "catchup_disabled_warn_hours": catchup["warn_hours"],
+                    "catchup_disabled_stale": catchup["stale"],
                 },
                 "sessions": [_session_to_json(s) for s in sessions],
                 # Additive (issue #2519): the Job view. `sessions` keeps its
@@ -952,6 +978,7 @@ def create_app() -> FastAPI:
         email = _get_email_health()
         claude_auth = _get_claude_auth_health()
         archive = _get_archive_health()
+        catchup = _get_catchup_health()
         return JSONResponse(
             {
                 "webserver": "ok",
@@ -990,6 +1017,11 @@ def create_app() -> FastAPI:
                 "archive_healthy": archive["healthy"],
                 "archive_row_count": archive["row_count"],
                 "archive_last_export_age_s": archive["last_export_age_s"],
+                # Additive-only (issue #2473): recovery kill-switch WARN.
+                "catchup_disabled": catchup["disabled"],
+                "catchup_disabled_age_hours": catchup["age_hours"],
+                "catchup_disabled_warn_hours": catchup["warn_hours"],
+                "catchup_disabled_stale": catchup["stale"],
             }
         )
 


### PR DESCRIPTION
Closes #2473

## What

The `data/catchup-disabled` operator kill switch pauses ALL message-recovery scans (startup catchup, periodic reconciler, `valor-catchup`) and, in the #2473 incident, sat forgotten for 7 days with no alarm while a crash storm ran with recovery disabled. This PR makes a stale flag loud without touching the flag mechanism itself (re-enabling stays an operator decision).

## How

- **`bridge/catchup.py`** — `kill_switch_status()` is the single source of truth: flag presence, mtime-based age in hours, and `stale` once the age exceeds the grace window. Never raises.
- **`config/settings.py`** — `TimeoutSettings.catchup_disabled_warn_hours` (default 24h, provisional/tunable per the config-timeout-catalog criterion; env `TIMEOUTS__CATCHUP_DISABLED_WARN_HOURS`, documented in `.env.example`).
- **`tools/doctor.py`** — new `catchup_kill_switch` check in Services: absent → PASS; set within the grace window → PASS with a "recovery scans paused" note; set beyond it → FAIL with a `WARN:` message and a fix hint (`rm data/catchup-disabled` or raise the threshold if deliberate).
- **`ui/app.py`** — additive `catchup_disabled`, `catchup_disabled_age_hours`, `catchup_disabled_warn_hours`, `catchup_disabled_stale` fields on both `/dashboard.json` `health` and `/health`.

## Tests

`tests/unit/test_catchup_kill_switch_staleness.py` (11 tests, TDD red→green): status helper states, mtime-vanish safety, doctor check three states + registration, and both dashboard field shapes via TestClient. Uses the #2552 autouse flag-redirect fixture so no live operator state is touched.

- new file: 11 passed
- neighbors: `test_doctor.py` + `test_ui_app.py` + `test_agent_catchup.py` → 115 passed; `test_settings.py` → 33 passed; `test_env_completeness.py` + `test_update_catchup_step.py` green
- `python -m ruff check` / `format` clean on changed files
- live `python -m tools.doctor --quick`: `[PASS] catchup_kill_switch: not set — recovery scans enabled`