### PR TITLE
Sweep repo-local skill-rename husks; unify the husk predicate with rule 19

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ This repo is the canonical source for skills that ship to every machine.
 
 **Terminology:** "make this a **global skill**" or "**general-purpose skill**" means *put it in `.claude/skills-global/`*. It does not mean editing a CLAUDE.md note. A skill is known to every machine precisely when it lives there.
 
-Sync wiring is `scripts/update/hardlinks.py`. Adding a directory with a `SKILL.md` under `skills-global/` is the entire registration step. **When you move a skill between the two directories, add a `RENAMED_REMOVALS` entry** so the stale hardlink is cleaned up on every machine.
+Sync wiring is `scripts/update/hardlinks.py`. Adding a directory with a `SKILL.md` under `skills-global/` is the entire registration step. **When you move a skill between the two directories, add a `RENAMED_REMOVALS` entry** so the stale hardlink is cleaned up on every machine — the same entry also sweeps repo-local rename residue (a gitignored `__pycache__` keeping the old skill directory alive in this checkout) from both skill roots.
 
 Global skill bodies stay generic; repo-specific behavior layers in via `.claude/skill-context/{skill}.md` (non-SDLC) or `docs/sdlc/{skill}.md` (SDLC stages). Coupled bodies carry the probe sentence "If <context-path> exists, read it and honor its declarations; otherwise use the generic defaults described below." See [`docs/features/skill-context-convention.md`](docs/features/skill-context-convention.md).
 

--- a/docs/features/skills-global.md
+++ b/docs/features/skills-global.md
@@ -80,8 +80,21 @@ bare `Path.is_dir()` probe reads that leftover as a live skill. Such a directory
 **husk**.
 
 `tests/unit/test_update_hardlinks.py::test_no_husk_directories_in_skill_roots` fails
-the build whenever a husk exists under `.claude/skills-global/` or `.claude/skills/`.
-All liveness checks in that file (`_skill_exists_in_any_root`, `test_renamed_removals_entries_are_not_stale`)
+the build whenever an *actionable* husk exists under `.claude/skills-global/` or
+`.claude/skills/` — one a commit can do something about. A husk whose only contents
+are build artifacts (`__pycache__`, `.DS_Store`, the gitignored
+`references/metadata.json` sync cache — the same artifact predicate
+`rule_19_husk_directories` in `audit_skills.py` uses, pinned equivalent by
+`test_husk_artifact_predicate_matches_audit_skills`) *and* whose name carries a
+`("skills", name)` `RENAMED_REMOVALS` entry is excluded from the assertion: git can
+never remove ignored residue, so `/update`'s `cleanup_repo_skill_husks` sweep in
+`scripts/update/hardlinks.py` clears it on the machine that has it instead
+(issues #2597, #2598). An artifact-only husk *without* a removal entry still fails —
+committing the entry is the fix — and a husk holding real files always fails, needing
+a human delete-or-restore decision (or
+`python .claude/skills-global/audit-skills/scripts/audit_skills.py --fix --no-sync`
+for the prunable ones). All liveness checks in that file
+(`_skill_exists_in_any_root`, `test_renamed_removals_entries_are_not_stale`)
 route through the same `_skill_is_live` helper, so a directory-existence check cannot
 silently reappear at a second call site.
 

--- a/scripts/update/hardlinks.py
+++ b/scripts/update/hardlinks.py
@@ -174,6 +174,87 @@ RENAMED_REMOVALS: list[tuple[str, str]] = [
     ("hooks", "sdlc/validate_commit_message.py"),
 ]
 
+# The repo's own skill roots, relative to the project dir. RENAMED_REMOVALS
+# targets the user tree (~/.claude/), but a rename also leaves residue HERE:
+# git moves the tracked files and leaves the old directory standing whenever
+# gitignored artifacts (__pycache__, the references/metadata.json sync cache)
+# keep it alive. That residue is invisible to git status and to every fresh
+# clone, so no commit can clear it — only this sweep on the machine that has
+# it (issues #2597, #2598).
+REPO_SKILL_ROOTS: tuple[str, ...] = (".claude/skills-global", ".claude/skills")
+
+
+def _is_husk_artifact(file_path: Path, husk_root: Path) -> bool:
+    """True when ``file_path`` (inside ``husk_root``) is a build artifact that
+    doesn't count as "real content" for husk-emptiness purposes.
+
+    Mirrors ``_is_husk_artifact`` in
+    ``.claude/skills-global/audit-skills/scripts/audit_skills.py`` (rule 19's
+    artifact predicate) — that script must stay standalone because it is
+    hardlinked to ``~/.claude/skills/`` and runs outside this repo, so the two
+    copies are pinned equivalent by test
+    (``test_husk_artifact_predicate_matches_audit_skills``) rather than by
+    import. The set:
+      - ``__pycache__`` anywhere in the path
+      - ``.DS_Store``
+      - ``references/metadata.json``, anchored to that EXACT husk-relative
+        path (the git-ignored sync cache ``sync_best_practices.py`` writes,
+        exempted by #2441) — not a bare filename match.
+    """
+    if "__pycache__" in file_path.parts:
+        return True
+    if file_path.name == ".DS_Store":
+        return True
+    if file_path.relative_to(husk_root) == Path("references/metadata.json"):
+        return True
+    return False
+
+
+def _is_empty_skill_husk(d: Path) -> bool:
+    """True when ``d`` holds no files besides husk artifacts — the only class
+    the repo-local sweep is allowed to delete. A husk still holding real files
+    is a human delete-or-restore decision, never an automatic rmtree.
+    """
+    return not any(p.is_file() and not _is_husk_artifact(p, d) for p in d.rglob("*"))
+
+
+def cleanup_repo_skill_husks(project_dir: Path, result: HardlinkSyncResult) -> None:
+    """Remove repo-local artifact-only husks of RENAMED_REMOVALS skill names.
+
+    For every ``("skills", old_name)`` entry, checks both repo skill roots for
+    a surviving ``old_name`` directory. It is removed only when BOTH hold:
+
+    - no ``SKILL.md`` — a live skill sharing a swept name (e.g. one moved from
+      skills-global to project-only) is never touched;
+    - artifact-only contents per ``_is_empty_skill_husk`` — ``/update`` runs
+      against a checkout that may carry uncommitted work, so anything holding
+      a real file is left in place (rule 19 keeps reporting it).
+
+    A clean checkout is a strict no-op: nothing is removed, nothing recorded.
+    """
+    removal_names = sorted({old for kind, old in RENAMED_REMOVALS if kind == "skills"})
+    for root_rel in REPO_SKILL_ROOTS:
+        root = project_dir / root_rel
+        if not root.is_dir():
+            continue
+        for name in removal_names:
+            target = root / name
+            if not target.is_dir():
+                continue
+            if (target / "SKILL.md").is_file():
+                continue
+            if not _is_empty_skill_husk(target):
+                continue
+            rel = str(Path(root_rel) / name)
+            try:
+                shutil.rmtree(target)
+                result.actions.append(LinkAction("", rel, "removed", "repo-local rename husk"))
+                result.removed += 1
+            except OSError as e:
+                result.actions.append(LinkAction("", rel, "error", str(e)))
+                result.errors += 1
+
+
 # Standalone executable scripts hardlinked into ~/.local/bin so they're available
 # anywhere on PATH (not just from the repo). Each tuple is (src_relpath, dst_name).
 # Adding an entry here propagates to every machine on the next /update run.
@@ -360,6 +441,12 @@ def sync_claude_dirs(project_dir: Path) -> HardlinkSyncResult:
     # Remove explicitly renamed commands/skills (inode-guarded: a target still
     # hardlinked to a live project source is preserved; only genuine orphans go)
     _cleanup_renamed(user_claude, project_dir, result)
+
+    # Sweep repo-local rename residue in the project's own skill roots —
+    # gitignored artifacts keep a renamed skill's old directory alive in the
+    # checkout that performed the rename, and git can never remove it
+    # (issues #2597, #2598).
+    cleanup_repo_skill_husks(project_dir, result)
 
     # Clean up stale hardlinks that no longer have a source
     _cleanup_stale_commands(project_dir / ".claude" / "commands", user_claude / "commands", result)

--- a/tests/unit/test_update_hardlinks.py
+++ b/tests/unit/test_update_hardlinks.py
@@ -457,19 +457,51 @@ def _find_husk_dirs(root: Path) -> list[Path]:
     )
 
 
+def _actionable_husks(husks: list[Path]) -> list[Path]:
+    """Husks a commit can actually do something about (#2597, #2598).
+
+    An *artifact-only* husk (nothing but ``__pycache__`` / ``.DS_Store`` /
+    the ``references/metadata.json`` sync cache, per the shared
+    ``hardlinks._is_husk_artifact`` predicate — the same set
+    ``rule_19_husk_directories`` uses) whose name carries a
+    ``("skills", name)`` entry in ``RENAMED_REMOVALS`` already has a
+    remediation owner: ``/update``'s repo-local sweep removes it on the
+    machine that has it, and a fresh checkout never had it. Failing the unit
+    suite on that class trains people to ignore a red no commit can clear
+    (#2597). Everything else stays actionable: an artifact-only husk with NO
+    removal entry is fixed by committing one, and a husk holding real files
+    needs a delete-or-restore decision.
+    """
+    return [
+        h
+        for h in husks
+        if not (
+            hardlinks._is_empty_skill_husk(h) and ("skills", h.name) in hardlinks.RENAMED_REMOVALS
+        )
+    ]
+
+
 def test_no_husk_directories_in_skill_roots():
-    """No skill root holds a husk — a directory with no ``SKILL.md`` (#2557, #2523).
+    """No skill root holds an actionable husk — a directory with no ``SKILL.md``
+    (#2557, #2523, #2597, #2598).
 
     A husk is what a half-completed skill rename leaves behind: the ``SKILL.md``
     is deleted but ``__pycache__`` or a stray reference file keeps the directory
-    alive on disk. Nothing observed that class before, because the only probe
-    that could have caught it was itself a directory-existence check.
+    alive on disk. Artifact-only husks already covered by ``RENAMED_REMOVALS``
+    are excluded — ``/update`` sweeps those (see ``_actionable_husks``) — so the
+    verdict here is one a commit can control.
     """
-    husks = [h for root in _SKILL_ROOTS for h in _find_husk_dirs(_REPO_ROOT / root)]
+    husks = _actionable_husks(
+        [h for root in _SKILL_ROOTS for h in _find_husk_dirs(_REPO_ROOT / root)]
+    )
     assert not husks, (
-        "husk directories found in the skill roots (a directory with no SKILL.md "
-        "is a leftover from an incomplete skill rename/deletion — delete it, or "
-        f"add it to HUSK_GUARD_ALLOWLIST if it is an intentional shared resource): "
+        "husk directories found in the skill roots (a directory with no SKILL.md is "
+        "the leftover of an incomplete skill rename/deletion). Remediation: run "
+        "`python .claude/skills-global/audit-skills/scripts/audit_skills.py --fix "
+        "--no-sync` to prune artifact-only husks now, and for a renamed skill add a "
+        "('skills', <old-name>) entry to RENAMED_REMOVALS in "
+        "scripts/update/hardlinks.py so /update sweeps it on every machine. A husk "
+        "still holding real files needs a delete-or-restore decision: "
         f"{[str(h.relative_to(_REPO_ROOT)) for h in husks]}"
     )
 
@@ -495,6 +527,143 @@ def test_find_husk_dirs_edge_cases(tmp_path):
     (root / "loose-file.md").write_text("not a directory")
 
     assert [d.name for d in _find_husk_dirs(root)] == ["husk"]
+
+
+# ---------------------------------------------------------------------------
+# Repo-local husk sweep + shared artifact predicate (#2597, #2598)
+# ---------------------------------------------------------------------------
+
+
+def _make_artifact_only_husk(root: Path, name: str) -> Path:
+    """Build a husk holding only gitignored artifacts — the #2597 class."""
+    husk = root / name
+    (husk / "scripts" / "__pycache__").mkdir(parents=True)
+    (husk / "scripts" / "__pycache__" / "audit.cpython-312.pyc").write_bytes(b"\x00")
+    (husk / "references").mkdir()
+    (husk / "references" / "metadata.json").write_text("{}")
+    return husk
+
+
+def test_pycache_only_husk_is_still_detected(tmp_path):
+    """The #2557 motivating case: a ``__pycache__``-only husk IS a husk.
+
+    Detection must never be blinded by "it's all gitignored" — that residue is
+    exactly what fooled the hardlinks staleness probe. Verified hermetically,
+    and the husk stays *actionable* when no RENAMED_REMOVALS entry covers it.
+    """
+    root = tmp_path / "skills"
+    root.mkdir()
+    (root / "ghost" / "__pycache__").mkdir(parents=True)
+    (root / "ghost" / "__pycache__" / "m.cpython-312.pyc").write_bytes(b"\x00")
+
+    husks = _find_husk_dirs(root)
+    assert [d.name for d in husks] == ["ghost"]
+    # No ("skills", "ghost") removal entry exists, so a commit adding one is
+    # the fix — the guard must keep failing until then.
+    assert _actionable_husks(husks) == husks
+
+
+def test_actionable_husks_excludes_swept_artifact_only_husks(tmp_path):
+    """An artifact-only husk covered by RENAMED_REMOVALS is /update's job, not
+    a unit-suite red (#2597, #2598). A same-named husk holding a real file
+    stays actionable — the sweep refuses it, so a human must decide.
+    """
+    root = tmp_path / "skills"
+    root.mkdir()
+    covered = _make_artifact_only_husk(root, "do-skills-audit")
+    assert ("skills", "do-skills-audit") in hardlinks.RENAMED_REMOVALS
+
+    assert _actionable_husks([covered]) == []
+
+    (covered / "notes.md").write_text("real orphaned content")
+    assert _actionable_husks([covered]) == [covered]
+
+
+def test_husk_artifact_predicate_matches_audit_skills():
+    """The pytest guard and ``rule_19_husk_directories`` share one artifact
+    predicate (#2598). ``audit_skills.py`` must stay standalone (it hardlinks
+    to ``~/.claude/skills/`` and runs outside this repo), so the agreement is
+    pinned by behavior over a case matrix instead of by import.
+    """
+    import importlib.util
+    import sys
+
+    spec = importlib.util.spec_from_file_location(
+        "audit_skills",
+        _REPO_ROOT / ".claude" / "skills-global" / "audit-skills" / "scripts" / "audit_skills.py",
+    )
+    audit_skills = importlib.util.module_from_spec(spec)
+    # Registered before exec: the module defines dataclasses, whose field
+    # resolution looks the module up in sys.modules.
+    sys.modules[spec.name] = audit_skills
+    try:
+        spec.loader.exec_module(audit_skills)
+    finally:
+        sys.modules.pop(spec.name, None)
+
+    husk_root = Path("/x/skills/husk")
+    cases = [
+        husk_root / "scripts" / "__pycache__" / "m.cpython-312.pyc",
+        husk_root / ".DS_Store",
+        husk_root / "references" / "metadata.json",  # #2441 exemption
+        husk_root / "metadata.json",  # NOT the anchored path — real content
+        husk_root / "scripts" / "helper.py",
+        husk_root / "notes.md",
+    ]
+    for case in cases:
+        assert hardlinks._is_husk_artifact(case, husk_root) == audit_skills._is_husk_artifact(
+            case, husk_root
+        ), f"predicates disagree on {case}"
+
+
+def test_cleanup_repo_skill_husks_removes_ignored_residue(fake_project):
+    """A RENAMED_REMOVALS skill name surviving as artifact-only residue in a
+    repo-local skill root is removed by the sweep (#2597 regression test).
+    """
+    global_root = fake_project / ".claude" / "skills-global"
+    global_root.mkdir(parents=True, exist_ok=True)
+    project_root = fake_project / ".claude" / "skills"
+    husk_global = _make_artifact_only_husk(global_root, "do-skills-audit")
+    husk_project = _make_artifact_only_husk(project_root, "do-skills-audit")
+
+    result = hardlinks.HardlinkSyncResult()
+    hardlinks.cleanup_repo_skill_husks(fake_project, result)
+
+    assert not husk_global.exists()
+    assert not husk_project.exists()
+    assert result.removed == 2
+    assert all(a.action == "removed" for a in result.actions)
+
+
+def test_cleanup_repo_skill_husks_clean_checkout_is_noop(fake_project):
+    """On a checkout with no residue the sweep does nothing and records nothing."""
+    (fake_project / ".claude" / "skills-global").mkdir(parents=True, exist_ok=True)
+    result = hardlinks.HardlinkSyncResult()
+    hardlinks.cleanup_repo_skill_husks(fake_project, result)
+    assert result.removed == 0
+    assert result.actions == []
+
+
+def test_cleanup_repo_skill_husks_preserves_live_and_content(fake_project):
+    """The sweep never touches a live skill sharing a swept name (a skill moved
+    between roots, e.g. ``linkedin``) nor a husk holding real files — those
+    need a human delete-or-restore decision.
+    """
+    project_root = fake_project / ".claude" / "skills"
+    live = project_root / "linkedin"
+    live.mkdir()
+    (live / "SKILL.md").write_text("# linkedin\n")
+    assert ("skills", "linkedin") in hardlinks.RENAMED_REMOVALS
+
+    content_husk = _make_artifact_only_husk(project_root, "do-skills-audit")
+    (content_husk / "orphan.md").write_text("real content")
+
+    result = hardlinks.HardlinkSyncResult()
+    hardlinks.cleanup_repo_skill_husks(fake_project, result)
+
+    assert (live / "SKILL.md").is_file()
+    assert (content_husk / "orphan.md").is_file()
+    assert result.removed == 0
 
 
 def test_renamed_removals_covers_deleted_skills():


### PR DESCRIPTION
Closes #2597
Closes #2598

## What

The husk guard `test_no_husk_directories_in_skill_roots` was red in the primary checkout on gitignored residue no commit could clear, and disagreed with `rule_19_husk_directories` about the same directory. This PR gives ignored residue a remediation owner and makes the guard's verdict commit-controllable.

**Repo-local sweep** (`scripts/update/hardlinks.py`): new `cleanup_repo_skill_husks`, wired into `sync_claude_dirs` so `/update` runs it. For every `("skills", old_name)` in `RENAMED_REMOVALS` it checks both repo skill roots (`.claude/skills-global/`, `.claude/skills/`) and removes the directory only when it has no `SKILL.md` **and** holds nothing but husk artifacts. Live skills sharing a swept name (moved-between-roots skills like `linkedin`) and husks with real files are never touched — `/update` can run against a checkout with uncommitted work, so the sweep is deliberately conservative. Clean checkout is a strict no-op (tested).

**Predicate unification**: `hardlinks._is_husk_artifact` mirrors rule 19's artifact predicate (`__pycache__` anywhere, `.DS_Store`, `references/metadata.json` anchored to that exact husk-relative path — the #2441 exemption). `audit_skills.py` must stay standalone (hardlinked to `~/.claude/skills/`, runs outside this repo), so the two copies are pinned equivalent by `test_husk_artifact_predicate_matches_audit_skills` over a case matrix rather than by a runtime import. The pytest guard now routes through this shared predicate instead of a bare `SKILL.md` check.

**Guard determinism**: the live assertion now fails only on *actionable* husks. An artifact-only husk already covered by a `RENAMED_REMOVALS` entry is `/update`'s job (a fresh checkout never had it; git can never clear it) and is excluded. An artifact-only husk **without** an entry still fails — committing the entry is the fix, so any red is commit-fixable. A husk holding real files always fails. The failure message names the remediation commands (`audit_skills.py --fix --no-sync`; add a `RENAMED_REMOVALS` entry) and no longer offers allowlisting as a co-equal option.

**#2557 preserved**: a `__pycache__`-only husk IS still detected — verified hermetically (`test_pycache_only_husk_is_still_detected`), and it stays actionable when uncovered.

**#2441 preserved**: `references/metadata.json` remains an artifact in both predicates; a metadata.json-only husk is still auto-prunable under `--fix` (audit_skills.py untouched).

**Read-only boundary preserved**: no background job deletes anything. The sweep runs only inside `/update` (operator-invoked); the nightly reflection stays read-only.

## Machine state (main checkout)

The three husks (`.claude/skills-global/do-skills-audit`, `.claude/skills/do-skills-audit`, `.claude/skills-global/logs`) were already gone from `/Users/valorengels/src/ai` when this task ran — cleared before this PR. The sanctioned `audit_skills.py --fix --no-sync` was run there anyway: exit 0, zero rule-19 findings. The guard node now passes in the main checkout (1 passed).

**Stale `.worktrees/` copies: out of scope.** Worktrees are ephemeral and GC'd; `/update` never runs from them; and with this PR the guard no longer reds on covered artifact-only residue there either, so old worktrees stop producing false nightly findings without being touched.

## Verification

- `./scripts/pytest-clean.sh tests/unit/test_update_hardlinks.py` — 83 passed
- `./scripts/pytest-clean.sh tests/unit/test_skills_audit.py tests/unit/test_relink_global_skills.py tests/unit/test_skills_exist.py` — 128 passed
- Guard node in main checkout — 1 passed
- `ruff check` / `ruff format --check` — clean

Not folded in: #2595 (different cause, separately owned).