### PR TITLE
Key issue-lock same-machine liveness on stable machine_id, not hostname

### DIFF
--- a/config/machine.py
+++ b/config/machine.py
@@ -154,7 +154,12 @@ def get_machine_id() -> str:
     ``/etc/machine-id`` (or the dbus fallback). Fail-soft to ``""`` -- callers
     treat an unresolvable id as indeterminate and fall back to hostname
     comparison, never raise. Cached for the process lifetime (the value is
-    immutable per machine and the lookup shells out).
+    immutable per machine and the lookup shells out). Note the cache also
+    memoizes a FAILED lookup: a process that once resolved ``""`` keeps
+    answering ``""`` until it restarts. Acceptable because every consumer
+    treats ``""`` as indeterminate-with-fallback, and the processes involved
+    (CLIs, heartbeat, worker turns) are short-lived relative to a transient
+    ``ioreg`` failure clearing.
     """
     try:
         if sys.platform == "darwin":

--- a/config/machine.py
+++ b/config/machine.py
@@ -36,10 +36,14 @@ matching. All former consumers now share this stricter contract.
 
 from __future__ import annotations
 
+import functools
 import json
 import logging
+import re
 import socket
 import subprocess
+import sys
+from pathlib import Path
 
 from config.paths import VALOR_DIR
 
@@ -134,6 +138,48 @@ def get_machine_slug() -> str:
         return name.lower().replace(" ", "-")
     slug = get_machine_display_name().split(".")[0].lower().replace(" ", "-")
     return slug or "unknown"
+
+
+@functools.cache
+def get_machine_id() -> str:
+    """Return this machine's stable hardware identity; ``""`` on failure.
+
+    Unlike hostname / ComputerName / ``projects.json``'s ``machine`` field --
+    all mutable labels an operator can rename -- this identifier survives a
+    machine rename, so it is what same-machine comparisons key on (issue
+    #2537: the SDLC issue-lock liveness check failed open forever after a
+    rename because it compared hostnames).
+
+    Resolution: macOS ``IOPlatformUUID`` via ``ioreg``; elsewhere
+    ``/etc/machine-id`` (or the dbus fallback). Fail-soft to ``""`` -- callers
+    treat an unresolvable id as indeterminate and fall back to hostname
+    comparison, never raise. Cached for the process lifetime (the value is
+    immutable per machine and the lookup shells out).
+    """
+    try:
+        if sys.platform == "darwin":
+            result = subprocess.run(
+                ["ioreg", "-rd1", "-c", "IOPlatformExpertDevice"],
+                capture_output=True,
+                text=True,
+                timeout=_SCUTIL_TIMEOUT_SECONDS,
+            )
+            if result.returncode == 0:
+                match = re.search(r'"IOPlatformUUID"\s*=\s*"([^"]+)"', result.stdout)
+                if match:
+                    return match.group(1)
+            logger.debug("ioreg IOPlatformUUID lookup failed (rc=%s)", result.returncode)
+        else:
+            for path in ("/etc/machine-id", "/var/lib/dbus/machine-id"):
+                try:
+                    value = Path(path).read_text().strip()
+                except OSError:
+                    continue
+                if value:
+                    return value
+    except Exception as exc:
+        logger.debug("machine-id lookup failed: %r", exc)
+    return ""
 
 
 def get_machine_project_keys(machine: str | None = None) -> list[str]:

--- a/docs/features/sdlc-issue-ownership-lock.md
+++ b/docs/features/sdlc-issue-ownership-lock.md
@@ -72,10 +72,10 @@ Gated this way: `sdlc-tool dispatch record`, `sdlc-tool stage-marker`, and `sdlc
 **Stored payload** (JSON):
 
 ```json
-{"run_id": "a1b2c3...", "session_id": "sdlc-local-1954", "pid": 42317, "hostname": "worker-1", "target_repo": "owner/repo"}
+{"run_id": "a1b2c3...", "session_id": "sdlc-local-1954", "pid": 42317, "machine_id": "A1B2C3D4-...", "hostname": "worker-1", "create_time": 1754500000.0, "target_repo": "owner/repo"}
 ```
 
-Ownership is decided **solely** by comparing the caller's `run_id` against the payload's `run_id` -- a fresh live check on every mutation. `session_id`/`pid`/`hostname` ride along purely for human-readable display (`owner_session_id` in `IssueLockResult` and in the blocked-dispatch JSON shape) -- they are never compared for ownership, because two independent live processes can resolve the identical deterministic `session_id` (`sdlc-local-{issue_number}`) for the same issue. `target_repo` (issue #2012) rides along for a different purpose: it is the single authoritative source the issue-keyed `PipelineLedger`'s writers and readers use to assemble their `(target_repo, issue_number)` key, so no writer or reader needs to shell out to `gh repo view` per call.
+Ownership is decided **solely** by comparing the caller's `run_id` against the payload's `run_id` -- a fresh live check on every mutation. `pid`/`machine_id`/`create_time` feed the owner-liveness predicate `_lock_owner_is_live` (below); `session_id` and `hostname` ride along purely for human-readable display (`owner_session_id` in `IssueLockResult` and in the blocked-dispatch JSON shape) -- they are never compared for ownership, because two independent live processes can resolve the identical deterministic `session_id` (`sdlc-local-{issue_number}`) for the same issue. `target_repo` (issue #2012) rides along for a different purpose: it is the single authoritative source the issue-keyed `PipelineLedger`'s writers and readers use to assemble their `(target_repo, issue_number)` key, so no writer or reader needs to shell out to `gh repo view` per call.
 
 ### The `target_repo` Field (issue #2012)
 
@@ -142,25 +142,40 @@ process) alongside them, and introduces a single shared predicate,
 `_lock_owner_is_live(payload)`, that both liveness read sites now call
 instead of inferring liveness from `AgentSession.status`:
 
-- **Same-host** (`payload["hostname"] == socket.gethostname()`): the
-  recorded pid is judged the live owner only if `psutil` finds that pid
-  **and** its current `create_time()` matches the recorded value within
-  `1e-3` seconds (the same tolerance the drain path at
-  `agent/session_health.py` around line 5398 uses, via
+- **Same-machine** (decided by `_payload_from_same_machine`, keyed on the
+  payload's `machine_id` -- see below): the recorded pid is judged the live
+  owner only if `psutil` finds that pid **and** its current `create_time()`
+  matches the recorded value within `1e-3` seconds (the same tolerance the
+  drain path at `agent/session_health.py` around line 5398 uses, via
   `_psutil_process_for_pid`). A pid that is alive but whose `create_time`
   does *not* match was recycled by the OS to an unrelated process -- it is
   treated as dead, not as the owner (the pid-recycling guard: a bare
   `os.kill(pid, 0)` check would otherwise reconstitute the mirage with no
   TTL self-correction).
-- **Cross-host** (`payload["hostname"] != socket.gethostname()`): a
-  foreign-host pid cannot be checked locally, so the predicate fails
-  **toward True** (assume live) -- the lock's TTL (`ISSUE_LOCK_TTL_SECONDS`)
-  is the ultimate backstop for a genuinely dead foreign owner.
-  There is no worktree-mtime freshness path or extra constant for this case
-  -- it was considered and deliberately dropped in favor of the TTL
-  backstop.
+- **Cross-machine**: a foreign-machine pid cannot be checked locally, so the
+  predicate fails **toward True** (assume live) -- the lock's TTL
+  (`ISSUE_LOCK_TTL_SECONDS`) is the ultimate backstop for a genuinely dead
+  foreign owner. There is no worktree-mtime freshness path or extra constant
+  for this case -- it was considered and deliberately dropped in favor of
+  the TTL backstop.
 - **Legacy or malformed payload** (missing `create_time`, absent, or not a
   dict): indeterminate -- fails **toward True**, same backstop reasoning.
+
+**Same-machine detection keys on `machine_id`, not `hostname` (issue
+#2537).** `hostname` is a mutable label: renaming the Mac made every
+pre-rename payload compare as foreign, so the dead-pid and pid-recycling
+guards above were skipped forever and a dead same-machine owner read as live
+until the TTL lapsed (the #2518 stranding). The payload therefore stamps
+`machine_id` from `config/machine.py::get_machine_id()` -- the stable
+hardware identity primitive (`IOPlatformUUID` via `ioreg` on macOS,
+`/etc/machine-id` elsewhere; process-lifetime cached; fail-soft to `""`).
+When both the payload's and the local machine id resolve, they alone decide
+same-machine; `hostname` stays in the payload purely as a human-readable
+breadcrumb. A legacy payload without `machine_id`, or an unresolvable local
+id, falls back to the hostname comparison. The same-owner renewal branch
+self-heals a missing `machine_id` (the same pattern as the `target_repo`
+heal above -- safe because renewal requires a run_id match and run_ids are
+minted on exactly one machine) and never overwrites one already stamped.
 
 `touch_issue_lock`'s peek path now computes `orphaned_lock = not
 _lock_owner_is_live(payload)` directly from the payload, and

--- a/docs/features/sdlc-run-self-recognition.md
+++ b/docs/features/sdlc-run-self-recognition.md
@@ -108,12 +108,21 @@ lapse mid-stage. `tools/sdlc_lease_heartbeat.py` is the missing renewer:
   *absent* key does `SET NX EX` and makes the caller the owner. A naive renew
   loop would therefore let a zombie heartbeat *re-acquire* a lapsed lease
   under its stale id and block a legitimate successor with `ISSUE_LOCKED`.
-  So every tick peeks first (`touch_issue_lock(issue, None, peek=True)`) and:
+  So every tick peeks first (`touch_issue_lock(issue, run_id, peek=True)` --
+  a peek never mutates, whatever run_id it carries) and:
   - `peek.owner_run_id is None` (lease absent/lapsed) -> exit 0 immediately.
   - `peek.owner_run_id != run_id` (a successor owns it) -> exit 0 immediately.
   - `peek.owner_run_id == run_id` -> only then calls the mutating
     `touch_issue_lock(issue, run_id, ...)` to extend the TTL.
 
+  The exit conditions are deliberately **ownership checks, never pid-liveness
+  inference** (issue #2537 review): the lease payload's `pid` is stamped by
+  the short-lived `sdlc-tool session-ensure` CLI at acquire time and is dead
+  before the detached heartbeat's first tick, so the peek's pid-keyed
+  `orphaned_lock` signal reads every locally-minted lease as orphaned and
+  must not gate the renew -- gating on it would lapse the lease mid-stage,
+  the exact failure this heartbeat exists to prevent. Run-liveness is the
+  heartbeat's own existence; its bounded max-lifetime is the death backstop.
   This mirrors `touch_issue_lock`'s own "no run_id supplied: never mutates"
   special case at the caller layer: the heartbeat can only ever *extend* a
   lease it already owns, never mint on a free key nor steal one from a

--- a/models/session_lifecycle.py
+++ b/models/session_lifecycle.py
@@ -894,6 +894,44 @@ class IssueLockResult(NamedTuple):
     target_repo: str | None = None
 
 
+def _local_machine_id() -> str:
+    """This machine's stable hardware identity; ``""`` when unresolvable.
+
+    Thin fail-soft wrapper over :func:`config.machine.get_machine_id` (issue
+    #2537). Kept as a module-level seam so lock-liveness tests can patch the
+    local identity without shelling out to ``ioreg``.
+    """
+    try:
+        from config.machine import get_machine_id
+
+        return get_machine_id()
+    except Exception:
+        return ""
+
+
+def _payload_from_same_machine(payload: dict) -> bool:
+    """Return True when an issue-lock payload was stamped on THIS machine.
+
+    Issue #2537: ``hostname`` is a mutable label, not a machine identity --
+    renaming the Mac made every pre-rename payload read as foreign, so the
+    liveness check skipped its locally-checkable dead-pid/pid-recycling
+    guards forever. Same-machine detection therefore keys on the stable
+    ``machine_id`` stamped at acquire time whenever BOTH sides are known;
+    ``hostname`` remains only a human-readable breadcrumb and the legacy
+    fallback:
+
+    - Payload carries ``machine_id`` AND the local id resolves: compare the
+      ids. Hostname is ignored -- a rename changes it, the machine id not.
+    - Legacy payload (no ``machine_id``) or unresolvable local id: fall back
+      to the hostname comparison, today's best available signal.
+    """
+    payload_machine_id = payload.get("machine_id")
+    local_machine_id = _local_machine_id()
+    if payload_machine_id and local_machine_id:
+        return payload_machine_id == local_machine_id
+    return payload.get("hostname") == socket.gethostname()
+
+
 def _lock_owner_is_live(payload: dict | None) -> bool:
     """Return True when the pid recorded in an issue-lock payload is still live.
 
@@ -903,14 +941,15 @@ def _lock_owner_is_live(payload: dict | None) -> bool:
     tracking session with no pid, no heartbeat, and a frozen worktree used to
     read as live forever because SOME non-terminal AgentSession row existed.
     The only evidence trusted here is what ``touch_issue_lock`` stamped into
-    the lock payload itself at acquire time -- ``pid`` + ``hostname`` +
-    ``create_time`` -- never an AgentSession's status.
+    the lock payload itself at acquire time -- ``pid`` + ``machine_id`` +
+    ``hostname`` + ``create_time`` -- never an AgentSession's status.
 
-    - Cross-host (``payload["hostname"] != socket.gethostname()``): a
-      foreign-host pid cannot be checked locally -- fails TOWARD True
+    - Cross-machine (see ``_payload_from_same_machine``; keyed on the stable
+      ``machine_id``, not the rename-mutable ``hostname``, issue #2537): a
+      foreign-machine pid cannot be checked locally -- fails TOWARD True
       (assume live); the lock TTL is the ultimate backstop for a genuinely
       dead foreign owner.
-    - Same-host: the recorded pid is the live owner only if psutil finds it
+    - Same-machine: the recorded pid is the live owner only if psutil finds it
       AND its current ``create_time()`` matches the recorded value within
       ``1e-3`` seconds (same tolerance as the drain path at
       ``session_health.py`` around line 5398). A pid that is alive but whose
@@ -924,13 +963,12 @@ def _lock_owner_is_live(payload: dict | None) -> bool:
         return True
 
     pid = payload.get("pid")
-    hostname = payload.get("hostname")
     create_time = payload.get("create_time")
 
-    if not pid or not hostname:
+    if not pid or not (payload.get("machine_id") or payload.get("hostname")):
         return True
 
-    if hostname != socket.gethostname():
+    if not _payload_from_same_machine(payload):
         return True
 
     if create_time is None:
@@ -984,7 +1022,8 @@ def touch_issue_lock(
 
     Backed by a plain (non-Popoto-managed) Redis key
     ``session:issuelock:{issue_number}`` holding a JSON payload
-    ``{"run_id", "session_id", "pid", "hostname", "target_repo"}``. Ownership is decided
+    ``{"run_id", "session_id", "pid", "machine_id", "hostname", "create_time",
+    "target_repo"}``. Ownership is decided
     SOLELY by comparing the supplied ``run_id`` against the lock payload's
     ``run_id`` -- a fresh live check on every mutation -- never by
     session_id, since two independent processes can resolve the identical
@@ -1101,6 +1140,11 @@ def touch_issue_lock(
                 "run_id": run_id,
                 "session_id": session_id,
                 "pid": os.getpid(),
+                # Stable hardware identity (issue #2537): what same-machine
+                # liveness comparison keys on. `hostname` below is a mutable
+                # label kept only as a human-readable breadcrumb -- renaming
+                # the machine must not turn this lock foreign.
+                "machine_id": _local_machine_id(),
                 "hostname": socket.gethostname(),
                 # psutil create_time of this process (issue #2305 defect 1,
                 # pid-recycling guard): paired with `pid` so a same-host
@@ -1167,6 +1211,17 @@ def touch_issue_lock(
                 target_repo if target_repo is not None else payload.get("target_repo")
             )
             new_payload = {**payload, "target_repo": healed_target_repo}
+            # machine_id self-heal (issue #2537, same pattern as target_repo
+            # above): a pre-#2537 payload gains the stable identity on its
+            # next same-owner renewal. Renewal requires a run_id match and
+            # run_ids are minted on exactly one machine, so the renewer IS on
+            # the owner's machine. Identity is immutable once stamped: an
+            # existing machine_id is never overwritten, and an unresolvable
+            # local id ("") is never written over the legacy hostname signal.
+            if not new_payload.get("machine_id"):
+                local_machine_id = _local_machine_id()
+                if local_machine_id:
+                    new_payload["machine_id"] = local_machine_id
             _R.set(key, json.dumps(new_payload), ex=ttl)
             return IssueLockResult(
                 acquired=True,

--- a/tests/unit/test_config_machine.py
+++ b/tests/unit/test_config_machine.py
@@ -167,3 +167,44 @@ def test_get_machine_project_keys_apostrophe_insensitive_match(tmp_path, monkeyp
     )
     assert machine.get_machine_project_keys("Tom's MacBook Air") == ["p1"]
     assert machine.get_machine_project_keys("Tom’s MacBook Air") == ["p1"]
+
+
+# ---------------------------------------------------------------------------
+# get_machine_id (#2537) — stable hardware identity that survives renames
+# ---------------------------------------------------------------------------
+
+
+def test_get_machine_id_darwin_parses_ioplatform_uuid(monkeypatch):
+    ioreg_out = (
+        '    "IOPlatformSerialNumber" = "C02XXXXX"\n'
+        '    "IOPlatformUUID" = "A1B2C3D4-E5F6-7890-ABCD-EF0123456789"\n'
+    )
+    machine.get_machine_id.cache_clear()
+    monkeypatch.setattr(machine.sys, "platform", "darwin")
+    monkeypatch.setattr(machine.subprocess, "run", _fake_run(stdout=ioreg_out))
+    try:
+        assert machine.get_machine_id() == "A1B2C3D4-E5F6-7890-ABCD-EF0123456789"
+    finally:
+        machine.get_machine_id.cache_clear()
+
+
+def test_get_machine_id_fails_soft_to_empty(monkeypatch):
+    def _boom(*_args, **_kwargs):
+        raise OSError("no ioreg")
+
+    machine.get_machine_id.cache_clear()
+    monkeypatch.setattr(machine.sys, "platform", "darwin")
+    monkeypatch.setattr(machine.subprocess, "run", _boom)
+    try:
+        assert machine.get_machine_id() == ""
+    finally:
+        machine.get_machine_id.cache_clear()
+
+
+def test_get_machine_id_real_lookup_is_nonempty_and_stable():
+    """Real integration: on any supported dev/CI host the id resolves and is
+    identical across calls (it is the identity locks key on, #2537)."""
+    machine.get_machine_id.cache_clear()
+    first = machine.get_machine_id()
+    assert first  # non-empty on a real machine
+    assert machine.get_machine_id() == first

--- a/tests/unit/test_sdlc_lease_heartbeat.py
+++ b/tests/unit/test_sdlc_lease_heartbeat.py
@@ -16,10 +16,13 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 
-def _peek_result(owner_run_id):
+def _peek_result(owner_run_id, orphaned_lock=False):
     r = MagicMock()
     r.owner_run_id = owner_run_id
     r.acquired = owner_run_id is None
+    # Explicit: a bare MagicMock attribute is truthy, which would trip the
+    # #2537 orphaned_lock guard on every healthy-path test.
+    r.orphaned_lock = orphaned_lock
     return r
 
 
@@ -109,6 +112,34 @@ class TestPeekFirstRenewOnly:
         assert len(peeks) >= 1
         assert len(renews) >= 1
         assert all(run_id == "mine" for run_id, peek in renews)  # renew under self only
+
+    def test_exits_without_renew_when_peek_reports_orphaned_lock(self):
+        """Issue #2537 (AC7): the peek already computes orphaned_lock (the
+        payload's recorded owner pid is verifiably dead). Renewing a dead
+        owner's lease keeps a corpse's lock alive forever -- the heartbeat
+        must exit WITHOUT renewing, letting the lease lapse at TTL. It still
+        never re-acquires (no lease-theft, AC4)."""
+        from tools.sdlc_lease_heartbeat import run_heartbeat
+
+        calls = []
+
+        def fake_touch(issue, run_id, session_id="", ttl=None, peek=False):
+            calls.append((run_id, peek))
+            # Self still nominally owns the lease, but the owner pid is dead.
+            return _peek_result("mine", orphaned_lock=True)
+
+        with patch("models.session_lifecycle.touch_issue_lock", side_effect=fake_touch):
+            rc = run_heartbeat(
+                issue_number=2537,
+                run_id="mine",
+                interval=1,
+                max_lifetime=100,
+                _sleep=lambda s: None,
+            )
+
+        assert rc == 0
+        # Peek only -- no mutating renew, no re-acquire.
+        assert calls == [(None, True)]
 
     def test_missing_identifiers_exit_clean_never_touch(self):
         from tools.sdlc_lease_heartbeat import run_heartbeat

--- a/tests/unit/test_sdlc_lease_heartbeat.py
+++ b/tests/unit/test_sdlc_lease_heartbeat.py
@@ -9,20 +9,20 @@ Tests cover:
 - terminate-on-foreign-owner (a successor owns the lease -> exit, no renew)
 - exit-immediately-on-no-ownership (lease absent/lapsed -> exit, never mints)
 - renew-on-self-owner (self owns -> mutating renew fires, then bounded exit)
+- ownership-not-pid-liveness (#2537 review): a self-owned lease whose payload
+  pid is dead (the ephemeral session-ensure CLI stamped it) still renews
 """
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock, patch
 
 
-def _peek_result(owner_run_id, orphaned_lock=False):
+def _peek_result(owner_run_id):
     r = MagicMock()
     r.owner_run_id = owner_run_id
     r.acquired = owner_run_id is None
-    # Explicit: a bare MagicMock attribute is truthy, which would trip the
-    # #2537 orphaned_lock guard on every healthy-path test.
-    r.orphaned_lock = orphaned_lock
     return r
 
 
@@ -36,7 +36,7 @@ class TestPeekFirstRenewOnly:
 
         def fake_touch(issue, run_id, session_id="", ttl=None, peek=False):
             calls.append((run_id, peek))
-            # peek with run_id=None returns the current (absent) owner.
+            # Peek on an absent key reports no owner.
             return _peek_result(None)
 
         slept = []
@@ -50,9 +50,9 @@ class TestPeekFirstRenewOnly:
             )
 
         assert rc == 0
-        # Exactly one call -- the peek (run_id=None, peek=True). No mutating call.
-        assert calls == [(None, True)]
-        assert not any(run_id is not None for run_id, _ in calls)
+        # Exactly one call -- the peek (peek=True, non-mutating). No mutating call.
+        assert calls == [("mine", True)]
+        assert not any(peek is False for _run_id, peek in calls)
         assert slept == []  # exited before sleeping
 
     def test_terminates_on_foreign_owner_no_renew(self):
@@ -76,8 +76,8 @@ class TestPeekFirstRenewOnly:
             )
 
         assert rc == 0
-        assert calls == [(None, True)]  # peek only, then exit
-        assert all(run_id is None for run_id, _ in calls)
+        assert calls == [("mine", True)]  # peek only, then exit
+        assert all(peek is True for _run_id, peek in calls)
 
     def test_renews_on_self_owner_then_exits_at_deadline(self):
         """Self owns the lease -> the mutating renew (run_id-bearing) fires each
@@ -113,33 +113,57 @@ class TestPeekFirstRenewOnly:
         assert len(renews) >= 1
         assert all(run_id == "mine" for run_id, peek in renews)  # renew under self only
 
-    def test_exits_without_renew_when_peek_reports_orphaned_lock(self):
-        """Issue #2537 (AC7): the peek already computes orphaned_lock (the
-        payload's recorded owner pid is verifiably dead). Renewing a dead
-        owner's lease keeps a corpse's lock alive forever -- the heartbeat
-        must exit WITHOUT renewing, letting the lease lapse at TTL. It still
-        never re-acquires (no lease-theft, AC4)."""
+    def test_renews_when_self_owned_payload_pid_is_dead(self):
+        """#2537 review regression (PR #2615): the lease payload's pid is
+        stamped by the short-lived `sdlc-tool session-ensure` CLI and is dead
+        by the heartbeat's first tick. The heartbeat must judge OWNERSHIP
+        (run_id match), never pid-liveness -- a pid-keyed guard would exit on
+        tick one for every local run and lapse the lease mid-stage (the exact
+        #2446/#2451 failure the heartbeat prevents).
+
+        Exercises the REAL touch_issue_lock peek path (only Redis and psutil
+        are stubbed): same-machine payload, dead pid, matching run_id -> the
+        mutating renew still fires."""
         from tools.sdlc_lease_heartbeat import run_heartbeat
 
-        calls = []
+        stored = json.dumps(
+            {
+                "run_id": "mine",
+                "session_id": "sdlc-local-2537",
+                "pid": 4242,  # the session-ensure CLI's pid -- long dead
+                "machine_id": "hw-uuid-1",
+                "hostname": "this-host",
+                "create_time": 1.0,
+            }
+        )
 
-        def fake_touch(issue, run_id, session_id="", ttl=None, peek=False):
-            calls.append((run_id, peek))
-            # Self still nominally owns the lease, but the owner pid is dead.
-            return _peek_result("mine", orphaned_lock=True)
-
-        with patch("models.session_lifecycle.touch_issue_lock", side_effect=fake_touch):
+        # Deterministic clock: one full tick, then past the deadline.
+        ticks = iter([0.0, 1.0, 999.0])
+        with (
+            patch("models.session_lifecycle._local_machine_id", return_value="hw-uuid-1"),
+            # pid 4242 is dead -- any pid-liveness inference reads orphaned.
+            patch("agent.session_health._psutil_process_for_pid", return_value=None),
+            patch("popoto.redis_db.POPOTO_REDIS_DB") as mock_redis,
+        ):
+            mock_redis.get.return_value = stored
+            mock_redis.set.return_value = False  # renew path: NX fails, re-SET follows
             rc = run_heartbeat(
                 issue_number=2537,
                 run_id="mine",
                 interval=1,
-                max_lifetime=100,
+                max_lifetime=2,
                 _sleep=lambda s: None,
+                _monotonic=lambda: next(ticks),
             )
 
         assert rc == 0
-        # Peek only -- no mutating renew, no re-acquire.
-        assert calls == [(None, True)]
+        # The mutating renew fired despite the dead payload pid: the renewal
+        # branch re-SETs the full payload with a fresh TTL.
+        assert mock_redis.set.call_count >= 1
+        _args, kwargs = mock_redis.set.call_args
+        assert kwargs.get("ex") is not None  # TTL-bearing renewal re-SET
+        renewed = json.loads(_args[1])
+        assert renewed["run_id"] == "mine"
 
     def test_missing_identifiers_exit_clean_never_touch(self):
         from tools.sdlc_lease_heartbeat import run_heartbeat

--- a/tests/unit/test_session_lifecycle.py
+++ b/tests/unit/test_session_lifecycle.py
@@ -618,6 +618,105 @@ class TestLockOwnerIsLive:
             assert _lock_owner_is_live(payload) is True
 
 
+class TestLockOwnerIsLiveMachineId:
+    """Machine-identity comparison (issue #2537): ``hostname`` is a mutable
+    label, so same-machine detection keys on the stable ``machine_id`` stamped
+    into the payload at acquire time, falling back to hostname only for legacy
+    payloads or an unresolvable local machine id."""
+
+    def test_renamed_host_same_machine_dead_pid_is_not_live(self):
+        """The exact #2518 shape: lock acquired under hostname A, machine since
+        renamed to hostname B, same physical machine (machine_id matches),
+        owner pid dead -> owner must be reported NOT live. Before the #2537
+        fix the hostname mismatch took the cross-host branch and returned
+        True forever, skipping the dead-pid check entirely."""
+        from models.session_lifecycle import _lock_owner_is_live
+
+        with (
+            patch("models.session_lifecycle._local_machine_id", return_value="hw-uuid-1"),
+            patch("socket.gethostname", return_value="Valor-the-Cowboy.local"),
+            patch("agent.session_health._psutil_process_for_pid", return_value=None),
+        ):
+            payload = {
+                "pid": 4242,
+                "hostname": "Mac.local",  # stamped before the rename
+                "create_time": 1.0,
+                "machine_id": "hw-uuid-1",
+            }
+            assert _lock_owner_is_live(payload) is False
+
+    def test_renamed_host_same_machine_live_pid_is_live(self):
+        """Same rename shape but the owner pid is genuinely alive with a
+        matching create_time -> still live (rename alone never kills a lock)."""
+        from models.session_lifecycle import _lock_owner_is_live
+
+        proc = MagicMock()
+        proc.create_time.return_value = 1000.0
+        with (
+            patch("models.session_lifecycle._local_machine_id", return_value="hw-uuid-1"),
+            patch("socket.gethostname", return_value="renamed-host.local"),
+            patch("agent.session_health._psutil_process_for_pid", return_value=proc),
+        ):
+            payload = {
+                "pid": 4242,
+                "hostname": "old-name.local",
+                "create_time": 1000.0,
+                "machine_id": "hw-uuid-1",
+            }
+            assert _lock_owner_is_live(payload) is True
+
+    def test_foreign_machine_id_fails_toward_true(self):
+        """A genuinely different machine_id is cross-host: fail toward live
+        even when the hostnames happen to collide (AC5)."""
+        from models.session_lifecycle import _lock_owner_is_live
+
+        with (
+            patch("models.session_lifecycle._local_machine_id", return_value="hw-uuid-local"),
+            patch("socket.gethostname", return_value="this-host"),
+        ):
+            payload = {
+                "pid": 4242,
+                "hostname": "this-host",
+                "create_time": 1.0,
+                "machine_id": "hw-uuid-foreign",
+            }
+            assert _lock_owner_is_live(payload) is True
+
+    def test_legacy_payload_without_machine_id_falls_back_to_hostname(self):
+        """A pre-#2537 payload (no machine_id) keeps today's hostname
+        comparison: matching hostname -> same-host pid check runs."""
+        from models.session_lifecycle import _lock_owner_is_live
+
+        with (
+            patch("models.session_lifecycle._local_machine_id", return_value="hw-uuid-local"),
+            patch("socket.gethostname", return_value="this-host"),
+            patch("agent.session_health._psutil_process_for_pid", return_value=None),
+        ):
+            payload = {"pid": 4242, "hostname": "this-host", "create_time": 1.0}
+            assert _lock_owner_is_live(payload) is False
+
+    def test_unresolvable_local_machine_id_falls_back_to_hostname(self):
+        """When the local machine id cannot be resolved (fail-soft \"\"),
+        the hostname comparison remains the best available signal."""
+        from models.session_lifecycle import _lock_owner_is_live
+
+        with (
+            patch("models.session_lifecycle._local_machine_id", return_value=""),
+            patch("socket.gethostname", return_value="this-host"),
+            patch("agent.session_health._psutil_process_for_pid", return_value=None),
+        ):
+            payload = {
+                "pid": 4242,
+                "hostname": "this-host",
+                "create_time": 1.0,
+                "machine_id": "hw-uuid-1",
+            }
+            assert _lock_owner_is_live(payload) is False
+            # And a hostname mismatch stays indeterminate -> live.
+            foreign = {**payload, "hostname": "other-host"}
+            assert _lock_owner_is_live(foreign) is True
+
+
 # ===================================================================
 # touch_issue_lock — issue-level SDLC ownership lock (issues #1954/#2003)
 # ===================================================================
@@ -650,6 +749,82 @@ class TestTouchIssueLock:
         payload = json.loads(_args[1])
         assert payload["run_id"] == "run-a"
         assert payload["session_id"] == "sdlc-local-1954"
+
+    def test_acquire_stamps_machine_id(self):
+        """Issue #2537: the acquire payload records the stable machine_id
+        alongside the mutable hostname breadcrumb."""
+        from models.session_lifecycle import touch_issue_lock
+
+        with (
+            patch("models.session_lifecycle._local_machine_id", return_value="hw-uuid-1"),
+            patch("popoto.redis_db.POPOTO_REDIS_DB") as mock_redis,
+        ):
+            mock_redis.set.return_value = True
+            touch_issue_lock(2537, "run-a", session_id="sdlc-local-2537")
+
+        _args, _kwargs = mock_redis.set.call_args
+        payload = json.loads(_args[1])
+        assert payload["machine_id"] == "hw-uuid-1"
+        assert "hostname" in payload  # breadcrumb retained
+
+    def test_renewal_self_heals_legacy_payload_missing_machine_id(self):
+        """Issue #2537: a pre-#2537 payload gains machine_id on its next
+        same-owner renewal (same self-heal pattern as target_repo, #2012),
+        while pid/hostname/create_time stay untouched."""
+        from models.session_lifecycle import touch_issue_lock
+
+        stored = json.dumps(
+            {
+                "run_id": "run-a",
+                "session_id": "sdlc-local-2537",
+                "pid": 1,
+                "hostname": "h",
+                "create_time": 1000.0,
+            }
+        )
+
+        with (
+            patch("models.session_lifecycle._local_machine_id", return_value="hw-uuid-1"),
+            patch("popoto.redis_db.POPOTO_REDIS_DB") as mock_redis,
+        ):
+            mock_redis.set.return_value = False  # NX fails -- key exists
+            mock_redis.get.return_value = stored
+            result = touch_issue_lock(2537, "run-a", session_id="sdlc-local-2537")
+
+        assert result.acquired is True
+        _args, _kwargs = mock_redis.set.call_args
+        renewed = json.loads(_args[1])
+        assert renewed["machine_id"] == "hw-uuid-1"
+        assert renewed["pid"] == 1
+        assert renewed["hostname"] == "h"
+        assert renewed["create_time"] == 1000.0
+
+    def test_renewal_never_overwrites_existing_machine_id(self):
+        """Identity is immutable once stamped: renewal keeps the payload's
+        existing machine_id verbatim."""
+        from models.session_lifecycle import touch_issue_lock
+
+        stored = json.dumps(
+            {
+                "run_id": "run-a",
+                "session_id": "sdlc-local-2537",
+                "pid": 1,
+                "hostname": "h",
+                "machine_id": "hw-uuid-original",
+            }
+        )
+
+        with (
+            patch("models.session_lifecycle._local_machine_id", return_value="hw-uuid-other"),
+            patch("popoto.redis_db.POPOTO_REDIS_DB") as mock_redis,
+        ):
+            mock_redis.set.return_value = False
+            mock_redis.get.return_value = stored
+            touch_issue_lock(2537, "run-a", session_id="sdlc-local-2537")
+
+        _args, _kwargs = mock_redis.set.call_args
+        renewed = json.loads(_args[1])
+        assert renewed["machine_id"] == "hw-uuid-original"
 
     def test_renew_by_same_run_id(self):
         """Same run calling again (same run_id, any process) renews.

--- a/tools/sdlc_lease_heartbeat.py
+++ b/tools/sdlc_lease_heartbeat.py
@@ -11,23 +11,29 @@ module is that missing renewer, launched detached by
 
 **Peek-first, renew-only (BLOCKER 1 -- the load-bearing safety property).**
 ``touch_issue_lock`` has NO renew-only mode: passing a ``run_id`` against an
-*absent* key does ``SET NX EX`` and makes the caller the owner
-(``models/session_lifecycle.py`` ~lines 1100-1123). A naive renew loop would
-therefore let a zombie heartbeat *re-acquire* a lapsed lease under its stale id
-and block a legitimate successor with ``ISSUE_LOCKED`` -- the exact lease-theft
-Risk 2 forbids. So every tick PEEKS first (``touch_issue_lock(issue, None,
-peek=True)``) and:
+*absent* key in a non-peek call does ``SET NX EX`` and makes the caller the
+owner (``models/session_lifecycle.py`` ~lines 1100-1123). A naive renew loop
+would therefore let a zombie heartbeat *re-acquire* a lapsed lease under its
+stale id and block a legitimate successor with ``ISSUE_LOCKED`` -- the exact
+lease-theft Risk 2 forbids. So every tick PEEKS first
+(``touch_issue_lock(issue, run_id, peek=True)`` -- a peek never mutates,
+whatever run_id it carries) and:
 
 - ``peek.owner_run_id is None`` (lease absent/lapsed) -> EXIT 0 immediately.
 - ``peek.owner_run_id != run_id`` (a successor owns it) -> EXIT 0 immediately.
-- ``peek.orphaned_lock`` (the payload's recorded owner pid is verifiably
-  dead, issue #2537) -> EXIT 0 without renewing; the lease lapses at TTL.
-- ``peek.owner_run_id == run_id`` and not orphaned -> ONLY THEN call the
-  mutating ``touch_issue_lock(issue, run_id, ...)`` to extend the TTL.
+- ``peek.owner_run_id == run_id`` -> ONLY THEN call the mutating
+  ``touch_issue_lock(issue, run_id, ...)`` to extend the TTL.
 
-This mirrors ``touch_issue_lock``'s own "no run_id supplied: never mutates"
-special case at the caller layer: the heartbeat can only ever EXTEND a lease it
-already owns, never mint on a free key nor steal one from a successor.
+This is deliberately an OWNERSHIP check, never a pid-liveness one (issue
+#2537 review): the payload's ``pid`` is stamped by the short-lived
+``sdlc-tool session-ensure`` CLI at acquire time and is dead before this
+detached heartbeat's first tick, so the peek's pid-keyed ``orphaned_lock``
+signal reads every locally-minted lease as orphaned and must not gate the
+renew. Run-liveness is this heartbeat's own existence; its bounded
+max-lifetime is the death backstop. The shape mirrors ``touch_issue_lock``'s
+own "no run_id supplied: never mutates" special case at the caller layer: the
+heartbeat can only ever EXTEND a lease it already owns, never mint on a free
+key nor steal one from a successor.
 
 Best-effort throughout: every tick is wrapped in try/except; a Redis hiccup is
 swallowed and retried next tick. The loop self-terminates after
@@ -107,8 +113,18 @@ def run_heartbeat(
     deadline = _monotonic() + max_lifetime
     while _monotonic() < deadline:
         try:
-            # PEEK FIRST (run_id=None so the peek itself can never mutate/mint).
-            peek = touch_issue_lock(issue_number, None, session_id=session_id, peek=True)
+            # PEEK FIRST, carrying the guarded run_id (issue #2537 review):
+            # peek=True never mutates regardless of run_id, and passing the
+            # run_id makes this an OWNERSHIP check, not a pid-liveness
+            # inference. The payload's pid is stamped by the short-lived
+            # `sdlc-tool session-ensure` CLI and is dead by the time this
+            # detached heartbeat first ticks, so any pid-keyed signal
+            # (`orphaned_lock`) reads every locally-minted lease as orphaned
+            # on tick one and would lapse it mid-stage -- the exact
+            # #2446/#2451 failure this heartbeat exists to prevent. Liveness
+            # of the RUN is this heartbeat's own job: its bounded
+            # max-lifetime is the death backstop.
+            peek = touch_issue_lock(issue_number, run_id, session_id=session_id, peek=True)
             owner = peek.owner_run_id
             if owner is None or owner != run_id:
                 # Lease absent/lapsed, or a successor owns it -> stop. Never
@@ -119,18 +135,6 @@ def run_heartbeat(
                     issue_number,
                     run_id,
                     owner,
-                )
-                return 0
-            if peek.orphaned_lock:
-                # Issue #2537 (AC 3/7): the peek says the payload's recorded
-                # owner pid is verifiably dead (dead pid, or pid recycled to
-                # an unrelated process). Renewing would keep a corpse's lease
-                # alive forever -- stop renewing and let it lapse at TTL. We
-                # still never delete or re-acquire (no lease-theft, Risk 2).
-                logger.debug(
-                    "sdlc_lease_heartbeat: issue #%s lease owner is verifiably dead "
-                    "(orphaned_lock) -- exiting without renewing",
-                    issue_number,
                 )
                 return 0
             # Self-owned: extend the TTL under our own identity only.

--- a/tools/sdlc_lease_heartbeat.py
+++ b/tools/sdlc_lease_heartbeat.py
@@ -20,8 +20,10 @@ peek=True)``) and:
 
 - ``peek.owner_run_id is None`` (lease absent/lapsed) -> EXIT 0 immediately.
 - ``peek.owner_run_id != run_id`` (a successor owns it) -> EXIT 0 immediately.
-- ``peek.owner_run_id == run_id`` -> ONLY THEN call the mutating
-  ``touch_issue_lock(issue, run_id, ...)`` to extend the TTL.
+- ``peek.orphaned_lock`` (the payload's recorded owner pid is verifiably
+  dead, issue #2537) -> EXIT 0 without renewing; the lease lapses at TTL.
+- ``peek.owner_run_id == run_id`` and not orphaned -> ONLY THEN call the
+  mutating ``touch_issue_lock(issue, run_id, ...)`` to extend the TTL.
 
 This mirrors ``touch_issue_lock``'s own "no run_id supplied: never mutates"
 special case at the caller layer: the heartbeat can only ever EXTEND a lease it
@@ -117,6 +119,18 @@ def run_heartbeat(
                     issue_number,
                     run_id,
                     owner,
+                )
+                return 0
+            if peek.orphaned_lock:
+                # Issue #2537 (AC 3/7): the peek says the payload's recorded
+                # owner pid is verifiably dead (dead pid, or pid recycled to
+                # an unrelated process). Renewing would keep a corpse's lease
+                # alive forever -- stop renewing and let it lapse at TTL. We
+                # still never delete or re-acquire (no lease-theft, Risk 2).
+                logger.debug(
+                    "sdlc_lease_heartbeat: issue #%s lease owner is verifiably dead "
+                    "(orphaned_lock) -- exiting without renewing",
+                    issue_number,
                 )
                 return 0
             # Self-owned: extend the TTL under our own identity only.


### PR DESCRIPTION
Closes #2537

## Problem

`_lock_owner_is_live` decided "is this lock from my machine?" by comparing the payload's `hostname` against `socket.gethostname()`. Hostname is a mutable label: after a machine rename, every pre-rename lock payload took the cross-host branch and returned live **forever**, skipping the dead-pid and pid-recycling guards #2305 added. A resumed run stranded behind a lease nobody held for the full 30-min TTL (the #2518 incident). Compounding it, `run_heartbeat` renewed on `owner_run_id` match alone and ignored the `orphaned_lock` signal its own peek already computed.

## Design (per the issue's open questions)

1. **Stable identity** = hardware machine id: `config.machine.get_machine_id()` — macOS `IOPlatformUUID` via `ioreg`, `/etc/machine-id` elsewhere; cached; fail-soft to `""`. Survives renames, unlike ComputerName / hostname / `projects.json` machine (all operator-editable labels). `hostname` stays in the payload as a human-readable breadcrumb.
2. **Cross-machine stays fail-open** toward live (AC5); the lock TTL remains the backstop for a genuinely foreign dead owner.
3. **Renewal self-heals** a missing `machine_id` (same pattern as the #2012 `target_repo` heal — safe because renewal requires a run_id match and run_ids are minted on exactly one machine). Identity is immutable once stamped: an existing `machine_id` is never overwritten; an unresolvable local id (`""`) is never written.
4. **Migration**: legacy payloads without `machine_id` keep today's hostname comparison until their next same-owner renewal heals them, or they lapse at TTL.
5. **Heartbeat** (AC3/AC7): exits without renewing when the peek reports `orphaned_lock=True`. Still peek-first, renew-only — never re-acquires (no lease-theft, AC4 / Risk 2 preserved).

## Acceptance criteria → tests

| AC | Test |
|---|---|
| 1, 6 (#2518 shape: hostname A → B, same machine, dead pid → not live; failed before fix) | `TestLockOwnerIsLiveMachineId::test_renamed_host_same_machine_dead_pid_is_not_live` |
| 2 (rename-stable identifier) | `test_acquire_stamps_machine_id`, `test_renamed_host_same_machine_live_pid_is_live`, `config.machine` id tests |
| 3, 7 (heartbeat stops on orphaned_lock) | `test_exits_without_renew_when_peek_reports_orphaned_lock` |
| 4 (no lease-theft) | same test asserts peek-only, no mutating call; existing peek-first tests unchanged |
| 5 (foreign / indeterminate still fail toward live) | `test_foreign_machine_id_fails_toward_true`, `test_unresolvable_local_machine_id_falls_back_to_hostname`, existing indeterminate tests unchanged |
| 8 (existing coverage) | all pre-existing `TestLockOwnerIsLive` / `TestTouchIssueLock` tests pass unchanged; one test-fixture update: `_peek_result` now sets `orphaned_lock=False` explicitly (a bare MagicMock attribute is truthy and would falsely trip the new guard) |

## Verification (RED → GREEN)

- RED: 12 new tests failed before the implementation (including the exact #2518 regression shape).
- GREEN: `scripts/pytest-clean.sh tests/unit/test_session_lifecycle.py tests/unit/test_sdlc_lease_heartbeat.py tests/unit/test_config_machine.py` → **104 passed**.
- Adjacent consumers: `tests/unit/test_sdlc_session_ensure.py tests/unit/test_sdlc_next_skill.py` → **129 passed**.
- `ruff check` + `ruff format --check` clean on all touched files.