### PR TITLE
Tail batch: merge-guard cd blind spot (#2422), impact-finder silent degrade (#2499), stale graph.js (#2531)

### DIFF
--- a/.claude/hooks/validators/validate_merge_guard.py
+++ b/.claude/hooks/validators/validate_merge_guard.py
@@ -88,6 +88,11 @@ _REPO_FLAG_RE = re.compile(r"(?:^|\s)(?:-R|--repo)(?:=|\s+)(\S+)")
 # blocking, protecting legitimate local merges.
 _DIR_CHANGE_RE = re.compile(r"^\s*(?:cd|pushd)\s+([^\s]+)")
 
+# `popd` rewinds the directory stack to a location this parser does not
+# model; it poisons the chain (unknown endpoint → fall through) rather than
+# leaving a stale pushd target that would false-block a local merge.
+_POPD_RE = re.compile(r"^\s*popd\b")
+
 
 def _normalize_repo_slug(value: str) -> str | None:
     """Reduce a -R/--repo value (or git remote URL) to lowercase OWNER/REPO.
@@ -164,6 +169,15 @@ def _effective_merge_dir(command: str) -> str | None:
             segment = command[start:end]
             if _MERGE_CMD_RE.search(segment):
                 return None if unresolvable else current
+            if _POPD_RE.match(segment):
+                # `popd` rewinds to a directory this parser does not track
+                # (no pushd-stack modelling — see Rabbit Holes in the plan).
+                # After `pushd /foreign && make && popd && <merge>` the merge
+                # runs back in the ORIGINAL directory; keeping the pushd
+                # target would false-block a legitimate local merge. Poison
+                # the chain instead: unknown endpoint → fall through.
+                unresolvable = True
+                continue
             m = _DIR_CHANGE_RE.match(segment)
             if not m:
                 continue

--- a/.claude/hooks/validators/validate_merge_guard.py
+++ b/.claude/hooks/validators/validate_merge_guard.py
@@ -65,13 +65,28 @@ _DATA_DIR = _REPO_ROOT / "data"
 # treated as absent.
 _OVERRIDE_LINE_RE = re.compile(r"override:\s*(\S[^\n]*)")
 
-# Cross-repo flag on the merge command (#2003 cycle-3 TD1). `gh` accepts
-# `-R/--repo OWNER/REPO` (also `HOST/OWNER/REPO` and full URLs), in which
-# case the PR number in the command belongs to a DIFFERENT repository —
-# evaluating the predicate here would judge the LOCAL repo's PR of the same
-# number. Foreign repos are never evaluable from this checkout: block with a
-# named message instead of mis-evaluating.
+# Cross-repo detection (#2003 cycle-3 TD1, extended by #2422). A command can
+# target a DIFFERENT repository two ways this hook recognises:
+#
+# 1. An explicit `-R/--repo OWNER/REPO` flag (also `HOST/OWNER/REPO` and full
+#    URLs) on the merge command.
+# 2. A directory change (`cd`/`pushd`) whose effective working directory
+#    resolves to a checkout with a different origin slug — `gh` resolves its
+#    base repo from the process cwd.
+#
+# In either case the PR number belongs to ANOTHER repository — evaluating the
+# predicate here would judge the LOCAL repo's PR of the same number. Foreign
+# repos are never evaluable from this checkout: block with a named message
+# instead of mis-evaluating. (`git -C <dir>` is deliberately NOT a cross-repo
+# signal: it does not change the process cwd, so it does not retarget gh.)
 _REPO_FLAG_RE = re.compile(r"(?:^|\s)(?:-R|--repo)(?:=|\s+)(\S+)")
+
+# Literal `cd <dir>` / `pushd <dir>` at the start of a command segment.
+# Quoted or variable targets are intentionally NOT matched here (the span
+# tokenizer strips quoted regions; `$`/backtick targets are rejected below):
+# an unresolvable directory falls through to the predicate rather than
+# blocking, protecting legitimate local merges.
+_DIR_CHANGE_RE = re.compile(r"^\s*(?:cd|pushd)\s+([^\s]+)")
 
 
 def _normalize_repo_slug(value: str) -> str | None:
@@ -92,13 +107,18 @@ def _normalize_repo_slug(value: str) -> str | None:
     return f"{parts[-2]}/{parts[-1]}".lower()
 
 
-def _local_repo_slug() -> str | None:
-    """OWNER/REPO of this checkout's origin remote, or None when unresolvable."""
+def _slug_for_dir(path: str) -> str | None:
+    """OWNER/REPO of the checkout at ``path``, or None when unresolvable.
+
+    Returns None for any failure — not a directory, not a git repo, no
+    origin remote, subprocess timeout. Callers treat None as "cannot
+    classify" and fall through rather than blocking.
+    """
     try:
         import subprocess
 
         proc = subprocess.run(
-            ["git", "-C", str(_REPO_ROOT), "remote", "get-url", "origin"],
+            ["git", "-C", str(path), "remote", "get-url", "origin"],
             capture_output=True,
             text=True,
             timeout=10,
@@ -106,6 +126,65 @@ def _local_repo_slug() -> str | None:
         if proc.returncode != 0 or not proc.stdout.strip():
             return None
         return _normalize_repo_slug(proc.stdout.strip())
+    except Exception:
+        return None
+
+
+def _local_repo_slug() -> str | None:
+    """OWNER/REPO of this checkout's origin remote, or None when unresolvable."""
+    return _slug_for_dir(str(_REPO_ROOT))
+
+
+def _effective_merge_dir(command: str) -> str | None:
+    """Working directory in effect when the merge command runs, or None.
+
+    Walks the tokenizer's ordered command segments up to the one containing
+    the merge invocation, tracking literal ``cd <dir>`` / ``pushd <dir>``
+    changes (chained changes accumulate; relative targets resolve against
+    the previous one, or the hook's cwd — a known approximation of the Bash
+    tool's cwd, which they share in practice).
+
+    Returns None when no directory change precedes the merge, or when any
+    target in the chain is unresolvable (shell variable, substitution,
+    quoted path stripped by the tokenizer, ``cd`` with no literal target).
+    Unresolvable means fall-through: a bare ``cd`` is far more likely benign
+    local navigation than foreign intent, so ambiguity must never block a
+    legitimate local merge (contrast the `-R` flag path, where an explicit
+    flag is an explicit foreign signal and fails closed).
+
+    Never raises — any tokenizer failure yields None (fall-through).
+    """
+    import os
+
+    try:
+        spans = _extract_executed_commands(command)
+        current: str | None = None
+        unresolvable = False
+        for start, end in spans:
+            segment = command[start:end]
+            if _MERGE_CMD_RE.search(segment):
+                return None if unresolvable else current
+            m = _DIR_CHANGE_RE.match(segment)
+            if not m:
+                continue
+            target = m.group(1)
+            if target.startswith("-") or "$" in target or "`" in target:
+                # Flags (`cd -`, `pushd -n`), variables, substitutions:
+                # the chain's endpoint is unknowable — poison it.
+                unresolvable = True
+                continue
+            target = os.path.expanduser(target)
+            if os.path.isabs(target):
+                # An absolute target re-anchors the chain regardless of any
+                # earlier unresolvable hop.
+                current = os.path.normpath(target)
+                unresolvable = False
+                continue
+            if unresolvable:
+                continue  # relative hop from an unknown base stays unknown
+            base = current if current is not None else os.getcwd()
+            current = os.path.normpath(os.path.join(base, target))
+        return None
     except Exception:
         return None
 
@@ -589,9 +668,29 @@ def find_violation(command: str) -> str | None:
     if _command_has_help_flag(command):
         return None
 
-    # Cross-repo guard (#2003 cycle-3 TD1): a -R/--repo flag means the PR
-    # number belongs to ANOTHER repository — the predicate below would judge
-    # this repo's PR of the same number. Never evaluate foreign repos here.
+    # Cross-repo guard, directory form (#2422): a `cd`/`pushd` that lands the
+    # merge in a checkout with a DIFFERENT origin slug retargets gh — the
+    # predicate below would judge this repo's PR of the same number. Only a
+    # positively-resolved foreign slug blocks; same-slug or unresolvable
+    # directories fall through (never false-block a local merge).
+    effective_dir = _effective_merge_dir(command)
+    if effective_dir is not None:
+        dir_slug = _slug_for_dir(effective_dir)
+        local = _local_repo_slug()
+        if dir_slug is not None and local is not None and dir_slug != local:
+            return (
+                "Cross-repo merge not evaluable here: this command changes"
+                f" directory to '{effective_dir}' (repository '{dir_slug}'),"
+                " but the merge-guard hook evaluates the live merge predicate"
+                f" against THIS repository only ({local})."
+                " Run the merge from a session rooted in the target repository"
+                " so its own merge gate applies."
+            )
+
+    # Cross-repo guard, flag form (#2003 cycle-3 TD1): a -R/--repo flag means
+    # the PR number belongs to ANOTHER repository — the predicate below would
+    # judge this repo's PR of the same number. Never evaluate foreign repos
+    # here.
     repo_flag = _REPO_FLAG_RE.search(command)
     if repo_flag:
         target = _normalize_repo_slug(repo_flag.group(1))

--- a/docs/features/code-impact-finder.md
+++ b/docs/features/code-impact-finder.md
@@ -57,8 +57,12 @@ for r in results:
 `ImpactFinderMeta` degraded-result contract as `find_affected_docs`; see
 [Semantic Doc Impact Finder → Degraded-Result Contract](semantic-doc-impact-finder.md#degraded-result-contract-impactfindermeta-issue-2004)
 for the full field reference and reason values (issue #2004 T1.4). The CLI
-(below) already prints a `WARNING: impact finder degraded (...)` line when
-`meta.degraded` is true.
+(below) prints a `WARNING: impact finder degraded (...)` line when
+`meta.degraded` is true and **exits 1 on any degraded run** (#2499), so a
+caller — the `/do-plan` blast-radius step in particular — can never mistake
+"the finder is broken" for "nothing is affected". A whitespace-only change
+summary is itself a degraded run (`empty_query`): it would otherwise embed
+to nothing and score every chunk 0.0.
 
 ### Output Model
 

--- a/docs/features/sdlc-enforcement.md
+++ b/docs/features/sdlc-enforcement.md
@@ -271,6 +271,8 @@ A PreToolUse hook (`.claude/hooks/validators/validate_merge_guard.py`) blocks `g
 
 MERGE is a formal pipeline stage routed after DOCS completes. See [SDLC Pipeline Integrity](sdlc-pipeline-integrity.md) for full details.
 
+**Cross-repo detection** (#2003, extended by #2422): the merge predicate is inherently local, so the guard refuses to judge a PR belonging to a different repository. It recognizes both an explicit `-R`/`--repo` flag and a directory change — a literal `cd`/`pushd` chain preceding the merge is resolved to an effective working directory whose origin slug is compared against the local one. A positively-foreign slug blocks with the cross-repo message (which never offers the `data/merge_authorized_{pr}` break-glass, since that file cannot authorize a foreign PR). Same-slug and unresolvable directories (shell variables, quoted or substituted targets, non-checkout paths) fall through to the normal predicate path, so ambiguity never false-blocks a local merge. `git -C` is deliberately not a cross-repo signal: it does not change the process cwd that `gh` resolves its base repo from.
+
 ## Related
 
 - [Hook Manifest](hook-manifest.md) — the manifest declaration, generators, both-scope audit, and legacy-entry migration referenced throughout this doc

--- a/docs/features/valorengels-site.md
+++ b/docs/features/valorengels-site.md
@@ -42,3 +42,13 @@ deployment versions).
 `site/assets/graph.js` and any `data-meta="commit"` reference are a machine-generated
 snapshot of a past commit and do NOT auto-refresh with cascades. Regenerating them is
 tracked separately in #2059; this feature integrates the hand-written page copy only.
+
+Two staleness invariants are pinned by `tests/unit/test_site_graph_consistency.py`
+(#2531): every `data-files` chip reference across `site/*.html` must resolve to a
+graph node (a missing node silently drops the file from the chip's rendered count),
+and every framework named in the graph's project section must still be a declared
+dependency in `pyproject.toml` (the check that would have caught the stale Flask
+claims the day the FastAPI migration landed). Known deferred drift: seven phantom
+file nodes for since-deleted files remain in the graph; pruning them and their
+layer/tour references is a separate cleanup, so an every-file-node-exists invariant
+is deliberately not asserted.

--- a/site/assets/graph.js
+++ b/site/assets/graph.js
@@ -13,7 +13,6 @@ window.VALOR_GRAPH = {
   ],
   "frameworks": [
    "FastAPI",
-   "Flask",
    "Uvicorn",
    "pytest"
   ],
@@ -3485,6 +3484,20 @@ window.VALOR_GRAPH = {
     "scheduler"
    ],
    "complexity": "moderate"
+  },
+  {
+   "id": "file:agent/pid_fence.py",
+   "type": "file",
+   "name": "pid_fence.py",
+   "filePath": "agent/pid_fence.py",
+   "summary": "Best-effort (pid, create_time) process-identity fence: verifies a recorded pid still names the process it was captured for before signalling it, detecting pid recycling rather than guaranteeing against it.",
+   "tags": [
+    "self-healing",
+    "process-management",
+    "recovery"
+   ],
+   "complexity": "simple",
+   "languageNotes": "macOS has no pidfd, so psutil create_time() comparison is the ceiling available; the module documents the irreducible TOCTOU window explicitly."
   },
   {
    "id": "file:agent/session_health.py",
@@ -10799,7 +10812,7 @@ window.VALOR_GRAPH = {
    "type": "file",
    "name": "app.py",
    "filePath": "ui/app.py",
-   "summary": "Flask web UI application factory exposing the system dashboard, session views, and JSON endpoints, plus Jinja template filters for timestamps and durations.",
+   "summary": "FastAPI web UI application factory exposing the system dashboard, session views, and JSON endpoints, plus Jinja2 template filters for timestamps and durations.",
    "tags": [
     "entry-point",
     "web-ui",
@@ -10807,7 +10820,7 @@ window.VALOR_GRAPH = {
     "api-handler"
    ],
    "complexity": "complex",
-   "languageNotes": "Single large create_app factory registers routes and template filters inline rather than using Flask blueprints."
+   "languageNotes": "Single large create_app factory registers routes and template filters inline rather than splitting them across FastAPI APIRouter modules."
   },
   {
    "id": "function:ui/app.py:create_app",
@@ -10818,7 +10831,7 @@ window.VALOR_GRAPH = {
     115,
     976
    ],
-   "summary": "Application factory that builds the Flask app, registers template filters, and defines all dashboard and JSON routes.",
+   "summary": "Application factory that builds the FastAPI app, registers template filters, and defines all dashboard and JSON routes.",
    "tags": [
     "web-ui",
     "factory",
@@ -36446,7 +36459,7 @@ window.VALOR_GRAPH = {
   {
    "id": "layer:ui",
    "name": "Web Dashboard",
-   "description": "Flask dashboard application factory, Jinja2 + HTMX templates, and static CSS that render live system state (sessions, health, reflections).",
+   "description": "FastAPI dashboard application factory, Jinja2 + HTMX templates, and static CSS that render live system state (sessions, health, reflections).",
    "nodeIds": [
     "file:ui/app.py",
     "file:ui/templates/_partials/analytics_stats.html",
@@ -36626,7 +36639,7 @@ window.VALOR_GRAPH = {
   {
    "order": 13,
    "title": "The Web Dashboard",
-   "description": "Finally, the Flask dashboard makes all of this observable. The application factory in ui/app.py exposes the system dashboard, session views, and JSON endpoints (including /dashboard.json, the full system state). The base template defines the HTML shell and pulls in HTMX for live updates, while style.css covers the session cards, reflection grids, and SDLC pipeline visuals. This is the human window into the sessions, health, and pipeline state that every prior step produces.",
+   "description": "Finally, the FastAPI dashboard makes all of this observable. The application factory in ui/app.py exposes the system dashboard, session views, and JSON endpoints (including /dashboard.json, the full system state). The base template defines the HTML shell and pulls in HTMX for live updates, while style.css covers the session cards, reflection grids, and SDLC pipeline visuals. This is the human window into the sessions, health, and pipeline state that every prior step produces.",
    "nodeIds": [
     "file:ui/app.py",
     "file:ui/templates/base.html",

--- a/tests/README.md
+++ b/tests/README.md
@@ -272,6 +272,7 @@ tests/
 | unit | `test_validate_sdlc_on_stop.py` | 12 | SDLC stop validation |
 | unit | `test_validate_verification_section.py` | 9 | Verification validation |
 | unit | `test_build_validation.py` | 6 | Build process validation |
+| unit | `test_site_graph_consistency.py` | 2 | Public-site knowledge-graph staleness (#2531): every `data-files` chip reference resolves to a `graph.js` node; frameworks named by the graph are still declared dependencies |
 
 ### `reflections` — Learning system
 
@@ -348,7 +349,7 @@ tests/
 | Level | File | Tests | Description |
 |-------|------|------:|-------------|
 | unit | `test_doc_impact_finder.py` | 21 | Documentation impact analysis |
-| unit | `test_code_impact_finder.py` | 19 | Code file impact analysis |
+| unit | `test_code_impact_finder.py` | 24 | Code file impact analysis, empty-chunk filtering, degraded-run CLI exit (#2499) |
 | unit | `test_cross_repo_gh_resolution.py` | 11 | Cross-repo GitHub resolution |
 | unit | `test_cross_wire_fixes.py` | 7 | Cross-wire fix application |
 | integration | `test_doc_impact_finder_sdk.py` | 13 | Doc impact with SDK |

--- a/tests/unit/test_code_impact_finder.py
+++ b/tests/unit/test_code_impact_finder.py
@@ -409,6 +409,82 @@ class TestEmbedOpenAITruncation:
         assert len(encoding.encode(captured_inputs[0])) <= 8000
 
 
+class TestEmbedOpenAIEmptyInputs:
+    def test_embed_openai_skips_empty_inputs(self):
+        """Empty/whitespace-only texts are never sent to the API (one empty
+        string fails the whole batch, #2499); their slots come back as empty
+        embeddings and non-empty texts keep their positions."""
+        from tools.impact_finder_core import _embed_openai
+
+        captured_inputs = []
+
+        class _FakeEmbeddingItem:
+            def __init__(self):
+                self.embedding = [0.1, 0.2]
+
+        class _FakeEmbeddingResponse:
+            def __init__(self, n):
+                self.data = [_FakeEmbeddingItem() for _ in range(n)]
+
+        class _FakeEmbeddings:
+            def create(self, model, input):
+                assert all(t.strip() for t in input), "empty input reached the API"
+                captured_inputs.extend(input)
+                return _FakeEmbeddingResponse(len(input))
+
+        class _FakeOpenAIClient:
+            def __init__(self, *args, **kwargs):
+                self.embeddings = _FakeEmbeddings()
+
+        with patch("openai.OpenAI", _FakeOpenAIClient):
+            result = _embed_openai(["first chunk", "", "   \n\t", "last chunk"])
+
+        assert captured_inputs == ["first chunk", "last chunk"]
+        assert len(result) == 4
+        assert result[0] == [0.1, 0.2]
+        assert result[1] == []
+        assert result[2] == []
+        assert result[3] == [0.1, 0.2]
+
+
+class TestCliDegradedExit:
+    """#2499: a degraded finder run must exit non-zero so callers cannot
+    mistake "the tool is broken" for "nothing is affected"."""
+
+    def _run_cli(self, monkeypatch, results, meta):
+        import tools.code_impact_finder as cif
+
+        monkeypatch.setattr("sys.argv", ["code_impact_finder", "some change"])
+        monkeypatch.setattr(
+            cif,
+            "_core_get_index_status",
+            lambda name: {"exists": True, "chunk_count": 1, "model": "m", "index_path": "p"},
+        )
+        monkeypatch.setattr(cif, "find_affected_code", lambda summary, top_n: (results, meta))
+        return cif._cli()
+
+    def test_degraded_empty_run_exits_nonzero(self, monkeypatch, capsys):
+        import pytest
+
+        from tools.impact_finder_core import ImpactFinderMeta
+
+        meta = ImpactFinderMeta(
+            degraded=True, reason="empty_index", rerank_failures=0, candidates=0
+        )
+        with pytest.raises(SystemExit) as excinfo:
+            self._run_cli(monkeypatch, [], meta)
+        assert excinfo.value.code == 1
+        out = capsys.readouterr().out
+        assert "degraded" in out
+
+    def test_clean_empty_run_exits_zero(self, monkeypatch, capsys):
+        from tools.impact_finder_core import ImpactFinderMeta
+
+        meta = ImpactFinderMeta(degraded=False, reason=None, rerank_failures=0, candidates=5)
+        assert self._run_cli(monkeypatch, [], meta) is None  # no SystemExit
+        assert "No affected code found." in capsys.readouterr().out
+
+
 # ---------------------------------------------------------------------------
 # TestChunkCodeFile — routing by extension
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_code_impact_finder.py
+++ b/tests/unit/test_code_impact_finder.py
@@ -447,6 +447,19 @@ class TestEmbedOpenAIEmptyInputs:
         assert result[3] == [0.1, 0.2]
 
 
+class TestEmptyQueryGuard:
+    def test_whitespace_only_query_is_degraded(self):
+        """A whitespace-only change summary must come back degraded, not as a
+        clean empty result — it would otherwise embed to nothing, score every
+        chunk 0.0, and exit 0 (#2499 hardening)."""
+        from tools.code_impact_finder import find_affected_code
+
+        results, meta = find_affected_code("   \n\t")
+        assert results == []
+        assert meta.degraded is True
+        assert meta.reason == "empty_query"
+
+
 class TestCliDegradedExit:
     """#2499: a degraded finder run must exit non-zero so callers cannot
     mistake "the tool is broken" for "nothing is affected"."""

--- a/tests/unit/test_site_graph_consistency.py
+++ b/tests/unit/test_site_graph_consistency.py
@@ -1,0 +1,77 @@
+"""Staleness checks for the generated site knowledge graph (#2531).
+
+``site/assets/graph.js`` is a generated artifact with no in-repo generator,
+so it drifts silently as the codebase moves. Two drift modes have shipped to
+visitors already:
+
+- Stale claims: the graph described ``ui/app.py`` as Flask long after the
+  dashboard migrated to FastAPI.
+- Missing nodes: a ``data-files`` chip on the public site referenced
+  ``agent/pid_fence.py``, which had no graph node, so the chip silently
+  dropped it from its file count.
+
+These tests pin the cheap invariants that catch both modes at PR time:
+every file the site's chips reference must resolve to a graph node, and
+every framework the graph names must still be a declared dependency.
+(A stricter invariant — every file node points at an existing file — is
+already violated by seven phantom nodes for since-deleted files; pruning
+them and their layer/tour references is a separate cleanup, so that check
+is deliberately not asserted here.)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GRAPH_PATH = REPO_ROOT / "site" / "assets" / "graph.js"
+SITE_DIR = REPO_ROOT / "site"
+
+
+@pytest.fixture(scope="module")
+def graph() -> dict:
+    """Parse window.VALOR_GRAPH out of the generated graph.js."""
+    raw = GRAPH_PATH.read_text(encoding="utf-8")
+    _, _, payload = raw.partition("=")
+    return json.loads(payload.strip().rstrip(";"))
+
+
+def _chip_file_refs() -> set[str]:
+    """Every ``file:...`` reference in a data-files chip across site/*.html."""
+    refs: set[str] = set()
+    for page in SITE_DIR.glob("*.html"):
+        for match in re.finditer(r'data-files="([^"]*)"', page.read_text(encoding="utf-8")):
+            for item in match.group(1).split(","):
+                item = item.strip()
+                if item.startswith("file:"):
+                    refs.add(item[len("file:") :])
+    return refs
+
+
+def test_every_chip_reference_resolves_to_a_graph_node(graph):
+    """A file the site links via a chip must have a node in the graph —
+    otherwise the chip silently drops it from its rendered file count."""
+    node_ids = {node["id"] for node in graph["nodes"]}
+    refs = _chip_file_refs()
+    assert refs, "no data-files chips found — extraction regex is broken"
+    missing = sorted(ref for ref in refs if f"file:{ref}" not in node_ids)
+    assert not missing, (
+        f"data-files chips reference files with no graph node: {missing}. "
+        "Add nodes to site/assets/graph.js (or regenerate it) so the chips render."
+    )
+
+
+def test_graph_frameworks_are_declared_dependencies(graph):
+    """Every framework the graph claims must appear in pyproject.toml.
+    Catches the class of drift where the graph kept describing the
+    dashboard as Flask after the FastAPI migration."""
+    pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8").lower()
+    stale = [fw for fw in graph["project"]["frameworks"] if fw.lower() not in pyproject]
+    assert not stale, (
+        f"graph.js names frameworks absent from pyproject.toml: {stale}. "
+        "The graph has drifted from the codebase."
+    )

--- a/tests/unit/test_validate_merge_guard.py
+++ b/tests/unit/test_validate_merge_guard.py
@@ -318,6 +318,110 @@ def test_cross_repo_unresolvable_local_fails_closed(enforcement, monkeypatch, ca
     assert "Cross-repo merge not evaluable here" in decision["reason"]
 
 
+def _install_dir_slugs(enforcement, monkeypatch, mapping: dict[str, str]):
+    """Route _slug_for_dir through a path→slug mapping (no real git calls)."""
+    monkeypatch.setattr(enforcement, "_local_repo_slug", lambda: "tomcounsell/ai")
+    monkeypatch.setattr(
+        enforcement,
+        "_slug_for_dir",
+        lambda path: mapping.get(str(path)),
+    )
+
+
+def test_cross_repo_cd_blocks_without_evaluating(enforcement, monkeypatch, capsys):
+    """#2422: `cd /foreign && <merge> N` retargets gh via the process cwd.
+    The guard must classify it cross-repo and never evaluate the local
+    predicate — and the block must not offer the break-glass override,
+    which is namespaced to THIS repo's PR numbers."""
+
+    def must_not_run(pr):  # pragma: no cover - guard against regression
+        raise AssertionError("predicate must not be evaluated for a foreign repo")
+
+    monkeypatch.setattr(enforcement, "_evaluate_predicate", must_not_run)
+    _install_dir_slugs(enforcement, monkeypatch, {"/tmp/psyoptimal": "tomcounsell/psyoptimal"})
+    decision = _run_main(
+        enforcement, monkeypatch, capsys, f"cd /tmp/psyoptimal && {MERGE} 670 --squash"
+    )
+    assert decision is not None and decision["decision"] == "block"
+    assert "Cross-repo merge not evaluable here" in decision["reason"]
+    assert "tomcounsell/psyoptimal" in decision["reason"]
+    assert "merge_authorized" not in decision["reason"]
+    assert "override:" not in decision["reason"]
+
+
+def test_cross_repo_pushd_blocks_without_evaluating(enforcement, monkeypatch, capsys):
+    """`pushd /foreign && <merge> N` behaves identically to the cd form."""
+
+    def must_not_run(pr):  # pragma: no cover
+        raise AssertionError("predicate must not be evaluated for a foreign repo")
+
+    monkeypatch.setattr(enforcement, "_evaluate_predicate", must_not_run)
+    _install_dir_slugs(enforcement, monkeypatch, {"/tmp/psyoptimal": "tomcounsell/psyoptimal"})
+    decision = _run_main(enforcement, monkeypatch, capsys, f"pushd /tmp/psyoptimal && {MERGE} 670")
+    assert decision is not None and decision["decision"] == "block"
+    assert "Cross-repo merge not evaluable here" in decision["reason"]
+
+
+def test_chained_cd_resolves_final_directory(enforcement, monkeypatch, capsys):
+    """`cd /a && cd sub && <merge>` accumulates: the FINAL directory decides."""
+
+    def must_not_run(pr):  # pragma: no cover
+        raise AssertionError("predicate must not be evaluated for a foreign repo")
+
+    monkeypatch.setattr(enforcement, "_evaluate_predicate", must_not_run)
+    _install_dir_slugs(enforcement, monkeypatch, {"/tmp/checkouts/foreign": "otherorg/otherrepo"})
+    decision = _run_main(
+        enforcement, monkeypatch, capsys, f"cd /tmp/checkouts && cd foreign && {MERGE} 42"
+    )
+    assert decision is not None and decision["decision"] == "block"
+    assert "otherorg/otherrepo" in decision["reason"]
+
+
+def test_same_repo_cd_evaluates_normally(enforcement, monkeypatch, capsys):
+    """A cd that resolves to THIS repo's slug is not cross-repo (AC4)."""
+    _install_dir_slugs(enforcement, monkeypatch, {"/tmp/ai-checkout": "tomcounsell/ai"})
+    decision = _run_main(enforcement, monkeypatch, capsys, f"cd /tmp/ai-checkout && {MERGE} 42")
+    assert decision is None  # green predicate seam from the fixture
+
+
+def test_unresolvable_cd_falls_through_to_predicate(enforcement, monkeypatch, capsys):
+    """A shell-variable cd target is unresolvable → fall through, not block."""
+    _install_dir_slugs(enforcement, monkeypatch, {})
+    decision = _run_main(enforcement, monkeypatch, capsys, f'cd "$WORKDIR" && {MERGE} 42')
+    assert decision is None
+
+
+def test_non_repo_cd_target_falls_through(enforcement, monkeypatch, capsys):
+    """A cd to a directory that is not a git checkout (slug None) falls
+    through to the predicate rather than blocking."""
+    _install_dir_slugs(enforcement, monkeypatch, {})  # every dir resolves to None
+    decision = _run_main(enforcement, monkeypatch, capsys, f"cd /tmp/scratch && {MERGE} 42")
+    assert decision is None
+
+
+def test_git_dash_c_is_not_a_cross_repo_signal(enforcement, monkeypatch, capsys):
+    """`git -C /foreign` does NOT change gh's process cwd, so it must not
+    trigger the cross-repo block (Open Question 1: cd/pushd-only scope)."""
+    _install_dir_slugs(enforcement, monkeypatch, {"/tmp/psyoptimal": "tomcounsell/psyoptimal"})
+    decision = _run_main(
+        enforcement, monkeypatch, capsys, f"git -C /tmp/psyoptimal status && {MERGE} 42"
+    )
+    assert decision is None
+
+
+def test_effective_dir_tokenizer_failure_falls_through(enforcement, monkeypatch, capsys):
+    """If the tokenizer raises inside _effective_merge_dir, the helper returns
+    None and the command still reaches the predicate (no crash, no block)."""
+
+    def boom(_cmd):
+        raise RuntimeError("synthetic tokenizer failure")
+
+    monkeypatch.setattr(enforcement, "_extract_executed_commands", boom)
+    assert enforcement._effective_merge_dir(f"cd /tmp/x && {MERGE} 42") is None
+    decision = _run_main(enforcement, monkeypatch, capsys, f"cd /tmp/x && {MERGE} 42")
+    assert decision is None  # green predicate seam — fell through, evaluated
+
+
 def test_merge_guard_override_valid_file_allows_logs_and_emits_metric(
     enforcement, monkeypatch, capsys, tmp_path, caplog
 ):

--- a/tests/unit/test_validate_merge_guard.py
+++ b/tests/unit/test_validate_merge_guard.py
@@ -399,6 +399,18 @@ def test_non_repo_cd_target_falls_through(enforcement, monkeypatch, capsys):
     assert decision is None
 
 
+def test_popd_after_pushd_falls_through(enforcement, monkeypatch, capsys):
+    """`pushd /foreign && make && popd && <merge> N` runs the merge back in
+    the ORIGINAL directory — keeping the pushd target would false-block a
+    legitimate local merge (the plan's Risk 1 / AC4 direction). popd poisons
+    the chain: unknown endpoint, fall through to the predicate."""
+    _install_dir_slugs(enforcement, monkeypatch, {"/tmp/psyoptimal": "tomcounsell/psyoptimal"})
+    decision = _run_main(
+        enforcement, monkeypatch, capsys, f"pushd /tmp/psyoptimal && make && popd && {MERGE} 5"
+    )
+    assert decision is None  # green predicate seam — evaluated locally, no block
+
+
 def test_git_dash_c_is_not_a_cross_repo_signal(enforcement, monkeypatch, capsys):
     """`git -C /foreign` does NOT change gh's process cwd, so it must not
     trigger the cross-repo block (Open Question 1: cd/pushd-only scope)."""

--- a/tools/code_impact_finder.py
+++ b/tools/code_impact_finder.py
@@ -537,12 +537,16 @@ def _cli():
 
     if not results:
         print("No affected code found." if not meta.degraded else "No results (finder degraded).")
-        return
+    else:
+        for r in results:
+            print(f"\n  {r.path} :: {r.section}")
+            print(f"    Relevance: {r.relevance:.2f}  Type: {r.impact_type}")
+            print(f"    Reason: {r.reason}")
 
-    for r in results:
-        print(f"\n  {r.path} :: {r.section}")
-        print(f"    Relevance: {r.relevance:.2f}  Type: {r.impact_type}")
-        print(f"    Reason: {r.reason}")
+    # A degraded run must not exit 0: callers (the /do-plan blast-radius step)
+    # would mistake "the finder is broken" for "nothing is affected" (#2499).
+    if meta.degraded:
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/tools/code_impact_finder.py
+++ b/tools/code_impact_finder.py
@@ -453,6 +453,14 @@ def find_affected_code(
     ``([], degraded=True)`` means the finder itself could not run cleanly
     (``meta.reason`` names the branch).
     """
+    # #2499 hardening: a whitespace-only query would get an empty embedding
+    # from the provider (empty inputs are filtered before the API call),
+    # score every chunk 0.0, and come back as a clean-looking empty/garbage
+    # result. That is a broken run, not "nothing affected" — flag it.
+    if not change_summary.strip():
+        return [], ImpactFinderMeta(
+            degraded=True, reason="empty_query", rerank_failures=0, candidates=0
+        )
     return _core_find_affected(
         change_summary=change_summary,
         discover_files=_discover_code_files,

--- a/tools/impact_finder_core.py
+++ b/tools/impact_finder_core.py
@@ -157,49 +157,70 @@ def get_embedding_provider() -> tuple | None:
     return None
 
 
+def _partition_embeddable(texts: list[str]) -> tuple[list[int], list[str]]:
+    """Split texts into (embeddable_indices, embeddable_texts).
+
+    Empty and whitespace-only texts are excluded — the OpenAI embeddings API
+    rejects the whole batch when any single input is empty (#2499), and an
+    empty chunk carries no signal worth embedding anyway. The dropped count
+    is logged so silent chunker/truncation regressions stay visible.
+    """
+    indices = [i for i, t in enumerate(texts) if t.strip()]
+    dropped = len(texts) - len(indices)
+    if dropped:
+        logger.warning(
+            "Skipping %d empty/whitespace-only chunk(s) of %d before embedding "
+            "(empty inputs are rejected by the embeddings API).",
+            dropped,
+            len(texts),
+        )
+    return indices, [texts[i] for i in indices]
+
+
 def _embed_openai(texts: list[str]) -> list[list[float]]:
     """Embed texts using OpenAI's text-embedding-3-small model.
 
     Handles batching internally -- splits into chunks of EMBEDDING_BATCH_SIZE.
+    Empty/whitespace-only inputs are never sent to the API (one empty string
+    fails the whole batch, #2499); their slots in the returned list hold an
+    empty embedding ``[]``, which downstream scoring already skips.
     """
     import openai
 
     client = openai.OpenAI()
 
     texts = [truncate_to_tokens(t, 8000) for t in texts]
+    indices, payload = _partition_embeddable(texts)
 
-    if len(texts) <= EMBEDDING_BATCH_SIZE:
-        response = client.embeddings.create(model="text-embedding-3-small", input=texts)
-        return [item.embedding for item in response.data]
-
-    # Batch large requests
-    all_embeddings: list[list[float]] = []
-    for i in range(0, len(texts), EMBEDDING_BATCH_SIZE):
-        batch = texts[i : i + EMBEDDING_BATCH_SIZE]
+    embeddings: list[list[float]] = [[] for _ in texts]
+    for start in range(0, len(payload), EMBEDDING_BATCH_SIZE):
+        batch = payload[start : start + EMBEDDING_BATCH_SIZE]
         response = client.embeddings.create(model="text-embedding-3-small", input=batch)
-        all_embeddings.extend(item.embedding for item in response.data)
-    return all_embeddings
+        for offset, item in enumerate(response.data):
+            embeddings[indices[start + offset]] = item.embedding
+    return embeddings
 
 
 def _embed_voyage(texts: list[str]) -> list[list[float]]:
     """Embed texts using Voyage AI.
 
     Handles batching internally -- splits into chunks of EMBEDDING_BATCH_SIZE.
+    Empty/whitespace-only inputs are skipped the same way as ``_embed_openai``
+    (slots filled with ``[]``) so both providers share one contract.
     """
     import voyageai
 
     client = voyageai.Client()
 
-    if len(texts) <= EMBEDDING_BATCH_SIZE:
-        result = client.embed(texts, model="voyage-3-lite")
-        return result.embeddings
+    indices, payload = _partition_embeddable(texts)
 
-    all_embeddings: list[list[float]] = []
-    for i in range(0, len(texts), EMBEDDING_BATCH_SIZE):
-        batch = texts[i : i + EMBEDDING_BATCH_SIZE]
+    embeddings: list[list[float]] = [[] for _ in texts]
+    for start in range(0, len(payload), EMBEDDING_BATCH_SIZE):
+        batch = payload[start : start + EMBEDDING_BATCH_SIZE]
         result = client.embed(batch, model="voyage-3-lite")
-        all_embeddings.extend(result.embeddings)
-    return all_embeddings
+        for offset, emb in enumerate(result.embeddings):
+            embeddings[indices[start + offset]] = emb
+    return embeddings
 
 
 # ---------------------------------------------------------------------------

--- a/tools/impact_finder_core.py
+++ b/tools/impact_finder_core.py
@@ -57,7 +57,9 @@ class ImpactFinderMeta:
             clean run. One of: ``no_embedding_provider``, ``empty_index``,
             ``query_embedding_failed``, ``no_scorable_candidates``,
             ``rerank_client_init_failed``, ``rerank_all_failed``,
-            ``rerank_partial_failure``.
+            ``rerank_partial_failure`` — plus ``empty_query`` emitted by
+            wrappers that reject a whitespace-only change summary before the
+            pipeline runs.
         rerank_failures: Number of Stage-2 rerank requests that hard-failed
             with a transport/API error (0 when Stage 2 never ran).
         candidates: Number of Stage-1 candidates selected for reranking


### PR DESCRIPTION
Tail batch of three small, independently mergeable fixes (one commit each). #2500 was assessed and deliberately skipped — see below.

## #2422 — merge-guard cross-repo `cd` blind spot

The cross-repo guard only recognized the `-R/--repo` flag; `cd /foreign && <merge> N` slipped past it and evaluated the local predicate against the wrong repo, producing a misleading "PR state unavailable" block that pointed operators at a mis-scoped `data/merge_authorized_{pr}` override.

Implements the resolve-don't-enumerate approach from `docs/plans/merge-guard-cross-repo-cwd-blind-spot.md`: `_effective_merge_dir()` walks the existing tokenizer segments accumulating literal `cd`/`pushd` targets (chained hops compose; absolute targets re-anchor), and `_slug_for_dir()` resolves the endpoint to an origin slug. Only a positively-foreign slug blocks, with a cross-repo message that names the target and never mentions the override file. Same-slug, shell-variable, quoted, substituted, and non-checkout targets all fall through to the normal predicate path (AC4: no false blocks on local merges). `git -C` is deliberately not a signal — it does not move gh's process cwd (plan Open Question 1, resolved as recommended). Eight new regression tests alongside the existing flag-form cases.

## #2499 — code_impact_finder silently degrades to empty and exits 0

Two defects: `_embed_openai` sent empty strings to the embeddings API (one empty chunk 400s the whole batch and aborts index construction), and a degraded run printed a WARNING but exited 0, so `/do-plan`'s blast-radius step proceeded as though nothing were affected.

Empty/whitespace-only chunks are now partitioned out before the API call (shared helper, both providers, dropped count logged); their slots return `[]`, which downstream scoring already skips, preserving index alignment. The CLI exits 1 on any degraded run after printing whatever partial results exist.

## #2531 — graph.js describes ui/ as Flask; pid_fence node missing

`graph.js` is generated with no in-repo generator (analyzedAt 2026-07-10, wiring unrecorded), so targeted correction is the available fix: all six Flask claims about `ui/app.py` now say FastAPI, Flask is dropped from the frameworks list, and `agent/pid_fence.py` gets a node so the runtime page's execution-record chip renders "3 files" instead of silently dropping the file that implements the mechanism it describes.

New `tests/unit/test_site_graph_consistency.py` pins both drift modes: every `data-files` chip reference across `site/*.html` must resolve to a graph node, and every framework the graph names must be a declared dependency. A stricter every-file-node-exists check surfaced **seven phantom nodes for since-deleted files** (`worker/idle_sweeper.py`, `tools/send_telegram.py`, etc.); pruning those plus their layer/tour references is a separate cleanup, documented in the test docstring rather than asserted.

## #2500 — skipped (investigation, not a mergeable fix)

Re-ran the hardlink experiment in this session's harness: Edit deterministically re-inodes the source and strands the `~/.claude/` copy at links=1 (observed `ino 11782281 → 11782741`, dst unchanged content). That confirms the established half, but the issue's open question — why only 3 of 7 links broke in the historical batch — requires a controlled multi-factor study of harness behaviors (read-first vs grep-first, possible in-place fast paths, `/update` interleaving) with no small mergeable artifact at the end. Left untouched.

## Verification

- `scripts/pytest-clean.sh tests/unit/test_validate_merge_guard.py -q` — 33 passed
- `scripts/pytest-clean.sh tests/unit/test_code_impact_finder.py -q` — 23 passed
- `scripts/pytest-clean.sh tests/unit/test_doc_impact_finder.py -q` — 38 passed (shared core untouched behavior)
- `scripts/pytest-clean.sh tests/unit/test_site_graph_consistency.py -q` — 2 passed
- ruff check / format clean on all changed files; graph.js still parses as JSON (1312 nodes), zero Flask references remain

Closes #2422
Closes #2499
Closes #2531
