### PR TITLE
Durability M2: Room model, DM recovery coverage, steering dual-read, shadow inbox (Tasks 10-12)

### DIFF
--- a/.claude/hooks/validators/validate_no_raw_redis_delete.py
+++ b/.claude/hooks/validators/validate_no_raw_redis_delete.py
@@ -97,6 +97,7 @@ _POPOTO_CONTEXT = [
     "PRReviewAudit",
     "Reflection",
     "ReflectionIgnore",
+    "Room",
     "SessionEvent",
     "TaskTypeProfile",
     "TelegramMessage",

--- a/agent/health_check.py
+++ b/agent/health_check.py
@@ -487,7 +487,7 @@ def _repush_messages(session_id: str, messages: list[dict]) -> None:
     logger.info(f"[steering] Re-pushed {len(messages)} message(s) to {session_id}")
 
 
-async def _handle_steering(session_id: str) -> dict[str, Any] | None:
+async def _handle_steering(session_id: str, room_id: str | None = None) -> dict[str, Any] | None:
     """Check the steering queue and handle any pending messages.
 
     Returns a hook result dict if steering action was taken, None otherwise.
@@ -508,7 +508,10 @@ async def _handle_steering(session_id: str) -> dict[str, Any] | None:
     """
     from agent.steering import pop_all_steering_messages
 
-    messages = pop_all_steering_messages(session_id)
+    # Dual-read (Task 11 phase 1, issue #2494): drain the legacy session key
+    # first, then the Room key when the caller resolved one. Writers are
+    # unchanged — the re-pushes below always target the legacy list.
+    messages = pop_all_steering_messages(session_id, room_id=room_id)
     if not messages:
         return None
 
@@ -517,6 +520,20 @@ async def _handle_steering(session_id: str) -> dict[str, Any] | None:
         if msg.get("is_abort"):
             sender = msg.get("sender", "supervisor")
             logger.warning(f"[steering] ABORT from {sender} for session {session_id}")
+            # An abort must not destroy the instructions queued alongside it
+            # (issue #2494: this drain used to `return` here and drop every
+            # sibling). Re-push the non-abort siblings so the next turn — or
+            # a follow-up session — still receives them.
+            siblings = [m for m in messages if not m.get("is_abort")]
+            if siblings:
+                try:
+                    _repush_messages(session_id, siblings)
+                except Exception as e:
+                    logger.error(
+                        f"[steering] Failed to re-push {len(siblings)} sibling "
+                        f"message(s) alongside abort: {e} — retrying once"
+                    )
+                    _repush_messages(session_id, siblings)
             # PostToolUse can't enforce continue_: False, but inject a strong
             # stop directive via additionalContext so Claude sees it.
             return {
@@ -591,11 +608,15 @@ async def watchdog_hook(
     key_args = _summarize_input(tool_name, tool_input) if isinstance(tool_input, dict) else ""
     _write_activity_stream(session_id, tool_name, key_args, count)
 
-    # Update session tracking in Redis (best-effort, every call)
+    # Update session tracking in Redis (best-effort, every call). The loaded
+    # session also resolves the Room for the steering dual-read below —
+    # tracking failure degrades to a legacy-only drain, never breaks the hook.
+    steering_room_id: str | None = None
     try:
         import time
 
         from models.agent_session import AgentSession
+        from models.room import room_id_for_session
 
         sessions = AgentSession.query.filter(session_id=session_id)
         if sessions:
@@ -603,6 +624,7 @@ async def watchdog_hook(
             s.tool_call_count = count
             s.updated_at = time.time()
             s.save()
+            steering_room_id = room_id_for_session(s)
     except Exception as e:
         # Non-fatal: don't let tracking break the agent.
         logger.debug("session tracking update failed for %s: %s", session_id, e)
@@ -628,7 +650,7 @@ async def watchdog_hook(
 
     # === STEERING CHECK (every tool call) ===
     try:
-        steering_result = await _handle_steering(session_id)
+        steering_result = await _handle_steering(session_id, room_id=steering_room_id)
         if steering_result is not None:
             # Combine memory_context with steering result if both exist
             if memory_context and steering_result.get("continue_"):

--- a/agent/index_drift.py
+++ b/agent/index_drift.py
@@ -364,8 +364,8 @@ def reconcile_all_indexes() -> dict[str, tuple[int, int, bool, bool]]:
 
 # ── Registry population ──────────────────────────────────────────────
 #
-# AgentSession is covered today. Room and Job register their own specs in
-# Milestones 2/3 of docs/plans/durability-room-job-agentrun.md (they do not
+# AgentSession and Room are covered today. Job registers its own spec in
+# Milestone 3 of docs/plans/durability-room-job-agentrun.md (it does not
 # exist yet). Each new durable Popoto model MUST add a register_drift_model
 # call so drift detection never silently narrows (Risk 3).
 
@@ -376,12 +376,27 @@ def _load_agent_session() -> type:
     return AgentSession
 
 
+def _load_room() -> type:
+    from models.room import Room
+
+    return Room
+
+
 register_drift_model(
     ModelDriftSpec(
         name="AgentSession",
         model_loader=_load_agent_session,
         counter_attr="_count_agentsession_hashes",
         tolerance_env="AGENTSESSION_INDEX_DRIFT_TOLERANCE",
+        default_tolerance=0,
+    )
+)
+
+register_drift_model(
+    ModelDriftSpec(
+        name="Room",
+        model_loader=_load_room,
+        tolerance_env="ROOM_INDEX_DRIFT_TOLERANCE",
         default_tolerance=0,
     )
 )

--- a/agent/session_executor.py
+++ b/agent/session_executor.py
@@ -1903,8 +1903,11 @@ async def _execute_agent_session(session: AgentSession) -> None:
         if agent_session:
             try:
                 from agent.steering import pop_all_steering_messages as _pop_all_steering
+                from models.room import room_id_for_session as _room_id_for_session
 
-                steering_msgs = _pop_all_steering(session.session_id)
+                steering_msgs = _pop_all_steering(
+                    session.session_id, room_id=_room_id_for_session(agent_session)
+                )
                 if steering_msgs:
                     # #2458 D3: if this session has never run a turn (no prior
                     # claude session UUID), its own message_text has not been
@@ -2460,8 +2463,12 @@ async def _execute_agent_session(session: AgentSession) -> None:
         # Clean up steering queue — re-enqueue unconsumed messages as a continuation
         try:
             from agent.steering import pop_all_steering_messages
+            from models.room import room_id_for_session
 
-            leftover = pop_all_steering_messages(session.session_id)
+            leftover = pop_all_steering_messages(
+                session.session_id,
+                room_id=room_id_for_session(agent_session) if agent_session else None,
+            )
             if leftover:
                 await _reenqueue_leftover_steering(session, agent_session, working_dir, leftover)
         except Exception as e:

--- a/agent/session_pickup.py
+++ b/agent/session_pickup.py
@@ -219,7 +219,11 @@ async def _drain_startup_steering(session: AgentSession, *, worker_key: str = ""
     Function body: pop → prepend → async_save when extra_texts is non-empty.
     """
     try:
-        steering_msgs = _steering.pop_all_steering_messages(session.session_id)
+        from models.room import room_id_for_session
+
+        steering_msgs = _steering.pop_all_steering_messages(
+            session.session_id, room_id=room_id_for_session(session)
+        )
         if steering_msgs:
             extra_texts = [m["text"] for m in steering_msgs if m.get("text", "").strip()]
             if extra_texts:

--- a/agent/session_runner/runner.py
+++ b/agent/session_runner/runner.py
@@ -585,13 +585,20 @@ class SessionRunner:
             logger.debug("[runner] stdout liveness stamp failed: %s", e)
 
     def _default_steering_pop(self) -> list[dict]:
-        """Pop all pending steering messages for this session (Redis list)."""
+        """Pop all pending steering messages for this session (Redis list).
+
+        Dual-read (issue #2494): drains the legacy session key first, then
+        the session's Room key. Writers are unchanged in this release.
+        """
         from agent.steering import pop_all_steering_messages  # noqa: PLC0415
+        from models.room import room_id_for_session  # noqa: PLC0415
 
         session_id = str(getattr(self._agent_session, "session_id", "") or "")
         if not session_id:
             return []
-        return pop_all_steering_messages(session_id)
+        return pop_all_steering_messages(
+            session_id, room_id=room_id_for_session(self._agent_session)
+        )
 
     def _default_steering_push(self, msg: dict) -> None:
         """Push one steering message back onto this session's Redis list."""

--- a/agent/steering.py
+++ b/agent/steering.py
@@ -5,10 +5,21 @@ by pushing to a per-session Redis list. The watchdog hook (PostToolUse)
 checks this queue on every tool call and injects messages via the SDK.
 
 Queue design:
-- Key:    steering:{session_id}
+- Key:    steering:{session_id}  (legacy, session-scoped — writers target this)
+- Key:    steering:room:{room_id}  (Room-scoped, ``room_id`` =
+          ``{project_key}|{addressee}``; see models/room.py)
 - Type:   Redis List (RPUSH to add, LPOP to consume)
 - Values: JSON strings with text, sender, timestamp, is_abort, target_agent (optional)
 - TTL:    None (persist until consumed or session completion)
+
+Room dual-read (durability plan Task 11 phase 1, issue #2494): every drain
+consumer reads the legacy session key FIRST, then the Room key when a
+``room_id`` is provided. Writers still push to the legacy key only — the
+writer flip to the Room key is a SEPARATE release, deployable only after the
+dual-read consumer has reached every machine (Race 1 two-phase deploy). The
+Room inbox makes a steer addressed to a dead session impossible by
+construction once writers flip: the Room is immortal, so the message waits
+for whichever session next drains the Room.
 """
 
 from __future__ import annotations
@@ -30,8 +41,45 @@ def _get_redis():
 
 
 def _queue_key(session_id: str) -> str:
-    """Redis key for a session's steering queue."""
+    """Redis key for a session's steering queue (legacy leg)."""
     return f"steering:{session_id}"
+
+
+def _room_queue_key(room_id: str) -> str:
+    """Redis key for a Room's steering queue (dual-read leg).
+
+    ``room_id`` is the ``{project_key}|{addressee}`` composite from
+    ``models.room.room_id_for_session``. No writer targets this key yet —
+    the writer flip is a separate release (Race 1).
+    """
+    return f"steering:room:{room_id}"
+
+
+def _drain_list(key: str) -> list[dict]:
+    """Destructively drain one steering list via sequential LPOPs (FIFO)."""
+    r = _get_redis()
+    messages: list[dict] = []
+    while True:
+        raw = r.lpop(key)
+        if raw is None:
+            break
+        try:
+            messages.append(json.loads(raw))
+        except json.JSONDecodeError:
+            logger.warning(f"[steering] Invalid JSON in queue {key}: {raw!r}")
+    return messages
+
+
+def _peek_list(key: str) -> list[dict]:
+    """Non-destructive FIFO read of one steering list."""
+    r = _get_redis()
+    messages: list[dict] = []
+    for raw in r.lrange(key, 0, -1):
+        try:
+            messages.append(json.loads(raw))
+        except json.JSONDecodeError:
+            logger.warning(f"[steering] Invalid JSON in queue {key}: {raw!r}")
+    return messages
 
 
 def push_steering_message(
@@ -87,12 +135,17 @@ def push_steering_message(
     )
 
 
-def pop_all_steering_messages(session_id: str) -> list[dict]:
-    """Pop ALL pending steering messages (FIFO order).
+def pop_all_steering_messages(session_id: str, room_id: str | None = None) -> list[dict]:
+    """Pop ALL pending steering messages (FIFO order), legacy leg first.
 
     Drains the queue via sequential LPOPs. Not strictly atomic, but safe
     because only one consumer exists per session (the watchdog hook).
     Returns empty list if no messages.
+
+    Dual-read (Task 11 phase 1): when ``room_id`` is provided, the Room key
+    is drained AFTER the legacy session key. During the transition writers
+    only push to the legacy key, so old workers keep working; once every
+    consumer runs this code, the writer flip to the Room key is safe.
 
     Each returned dict contains:
         - text (str): The message body
@@ -102,75 +155,68 @@ def pop_all_steering_messages(session_id: str) -> list[dict]:
         - target_agent (str | None): Optional agent name this message
           is addressed to. Present only when the pusher specified one.
     """
-    r = _get_redis()
-    key = _queue_key(session_id)
-    messages = []
-
-    while True:
-        raw = r.lpop(key)
-        if raw is None:
-            break
-        try:
-            msg = json.loads(raw)
-            messages.append(msg)
-        except json.JSONDecodeError:
-            logger.warning(f"[steering] Invalid JSON in queue {key}: {raw!r}")
-
+    messages = _drain_list(_queue_key(session_id))
+    if room_id:
+        messages.extend(_drain_list(_room_queue_key(room_id)))
     return messages
 
 
-def pop_steering_message(session_id: str) -> dict | None:
-    """Pop the next steering message (FIFO). Returns None if empty."""
+def pop_steering_message(session_id: str, room_id: str | None = None) -> dict | None:
+    """Pop the next steering message (FIFO, legacy leg first). None if empty."""
     r = _get_redis()
-    key = _queue_key(session_id)
+    keys = [_queue_key(session_id)]
+    if room_id:
+        keys.append(_room_queue_key(room_id))
 
-    raw = r.lpop(key)
-    if raw is None:
-        return None
+    for key in keys:
+        raw = r.lpop(key)
+        if raw is None:
+            continue
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            logger.warning(f"[steering] Invalid JSON in queue {key}: {raw!r}")
+            return None
+    return None
 
-    try:
-        return json.loads(raw)
-    except json.JSONDecodeError:
-        logger.warning(f"[steering] Invalid JSON in queue {key}: {raw!r}")
-        return None
 
-
-def clear_steering_queue(session_id: str) -> int:
-    """Clear all pending steering messages. Returns count cleared."""
+def clear_steering_queue(session_id: str, room_id: str | None = None) -> int:
+    """Clear all pending steering messages (both legs). Returns count cleared."""
     r = _get_redis()
-    key = _queue_key(session_id)
+    keys = [_queue_key(session_id)]
+    if room_id:
+        keys.append(_room_queue_key(room_id))
 
-    count = r.llen(key)
-    if count > 0:
-        r.delete(key)
-        logger.info(f"[steering] Cleared {count} message(s) from {key}")
-    return count
+    cleared = 0
+    for key in keys:
+        count = r.llen(key)
+        if count > 0:
+            r.delete(key)
+            logger.info(f"[steering] Cleared {count} message(s) from {key}")
+            cleared += count
+    return cleared
 
 
-def has_steering_messages(session_id: str) -> bool:
-    """Check if there are pending steering messages without consuming them."""
+def has_steering_messages(session_id: str, room_id: str | None = None) -> bool:
+    """Check if there are pending steering messages (either leg)."""
     r = _get_redis()
-    key = _queue_key(session_id)
-    return r.llen(key) > 0
+    if r.llen(_queue_key(session_id)) > 0:
+        return True
+    return bool(room_id) and r.llen(_room_queue_key(room_id)) > 0
 
 
-def peek_steering_messages(session_id: str) -> list[dict]:
+def peek_steering_messages(session_id: str, room_id: str | None = None) -> list[dict]:
     """Peek at all pending steering messages without consuming them.
 
     Uses LRANGE (non-destructive) so callers -- status dumps, CLI inspection --
     can inspect the queue without racing the turn-boundary consumer. Returns
     messages in the same FIFO order pop_all_steering_messages would return
-    them. Returns an empty list if the queue is empty or unreadable.
+    them (legacy leg first, then the Room leg when ``room_id`` is provided).
+    Returns an empty list if the queue is empty or unreadable.
     """
-    r = _get_redis()
-    key = _queue_key(session_id)
-    raw_messages = r.lrange(key, 0, -1)
-    messages = []
-    for raw in raw_messages:
-        try:
-            messages.append(json.loads(raw))
-        except json.JSONDecodeError:
-            logger.warning(f"[steering] Invalid JSON in queue {key}: {raw!r}")
+    messages = _peek_list(_queue_key(session_id))
+    if room_id:
+        messages.extend(_peek_list(_room_queue_key(room_id)))
     return messages
 
 

--- a/bridge/agent_catchup.py
+++ b/bridge/agent_catchup.py
@@ -57,7 +57,12 @@ from typing import Literal
 from pydantic import BaseModel
 
 from agent.llm import run_typed
-from bridge.routing import persona_to_session_type, resolve_persona
+from bridge.dedup import get_dm_coverage_epoch, get_or_init_dm_coverage_epoch
+from bridge.routing import (
+    find_project_for_dm_dialog,
+    persona_to_session_type,
+    resolve_persona,
+)
 from config.enums import SessionType
 from config.models import MODEL_FAST
 
@@ -109,12 +114,23 @@ class ThreadMessage:
 
 @dataclass
 class OwnedChat:
-    """An owned chat to sweep: the Telethon entity plus its project config."""
+    """An owned chat to sweep: the Telethon entity plus its project config.
+
+    ``chat_title`` is ``None`` for DM Rooms (a Telegram private chat is a
+    ``User`` entity with no title — parity with the live handler, which also
+    has no title for DMs). Use :func:`_chat_label` for log/summary rendering.
+    """
 
     chat_id: int
-    chat_title: str
+    chat_title: str | None
     project: dict
     entity: object  # Telethon entity (opaque here)
+    is_dm: bool = False
+
+
+def _chat_label(chat: OwnedChat) -> str:
+    """Human-readable label for logs and summaries (DMs have no title)."""
+    return chat.chat_title or f"DM:{chat.chat_id}"
 
 
 @dataclass
@@ -241,26 +257,49 @@ async def resolve_owned_chats(
     dialogs = await client.get_dialogs()
     for dialog in dialogs:
         chat_title = getattr(dialog.entity, "title", None)
-        if not chat_title:
-            continue
-        # monitored_groups holds lowercase names; titles may have capitals.
-        if chat_title.lower() not in monitored_groups:
-            continue
-        # Telethon can return the same supergroup twice (channel + linked group).
-        if dialog.id in seen_chat_ids:
-            logger.warning(
-                "%s skipping duplicate dialog for %s (id=%s)",
-                LOG_PREFIX,
-                chat_title,
-                dialog.id,
-            )
-            continue
-        seen_chat_ids.add(dialog.id)
+        is_dm = False
+        if chat_title:
+            # monitored_groups holds lowercase names; titles may have capitals.
+            if chat_title.lower() not in monitored_groups:
+                continue
+            # Telethon can return the same supergroup twice (channel + linked group).
+            if dialog.id in seen_chat_ids:
+                logger.warning(
+                    "%s skipping duplicate dialog for %s (id=%s)",
+                    LOG_PREFIX,
+                    chat_title,
+                    dialog.id,
+                )
+                continue
+            seen_chat_ids.add(dialog.id)
 
-        project = find_project_fn(chat_title)
-        if not project:
-            logger.warning("%s no project config for %s", LOG_PREFIX, chat_title)
-            continue
+            project = find_project_fn(chat_title)
+            if not project:
+                logger.warning("%s no project config for %s", LOG_PREFIX, chat_title)
+                continue
+        else:
+            # DM Rooms (durability plan Task 10, issue #2494): a private chat
+            # is a User entity with no title. Covered iff whitelisted; bots
+            # and self never scan (see find_project_for_dm_dialog).
+            project = find_project_for_dm_dialog(dialog.entity)
+            if project is None:
+                continue
+            if dialog.id in seen_chat_ids:
+                continue
+            seen_chat_ids.add(dialog.id)
+            is_dm = True
+
+            # Newly-covered DM Rooms initialize their cursor at "now" — never
+            # sweep pre-coverage history (Task 10 cursor-init constraint).
+            epoch_dt, newly_initialized = await get_or_init_dm_coverage_epoch(dialog.id)
+            if newly_initialized:
+                logger.info(
+                    "%s DM:%s coverage epoch initialized at %s — skipping this sweep",
+                    LOG_PREFIX,
+                    dialog.id,
+                    epoch_dt.isoformat(),
+                )
+                continue
 
         owned.append(
             OwnedChat(
@@ -268,6 +307,7 @@ async def resolve_owned_chats(
                 chat_title=chat_title,
                 project=project,
                 entity=dialog.entity,
+                is_dm=is_dm,
             )
         )
     return owned
@@ -491,7 +531,16 @@ async def sweep_chat(
         record_processed_fn = record_processed_fn or record_message_processed
         record_last_fn = record_last_fn or record_last_processed
 
-    result = ChatResult(chat_title=chat.chat_title, chat_id=chat.chat_id)
+    result = ChatResult(chat_title=_chat_label(chat), chat_id=chat.chat_id)
+
+    if chat.is_dm:
+        # Clamp the DM sweep to the coverage epoch: recovery reaches back to
+        # the configured lookback, but never before coverage began (Task 10 —
+        # pre-coverage DM history must never be swept as "unanswered").
+        epoch = await get_dm_coverage_epoch(chat.chat_id)
+        if epoch is not None:
+            base = lookback if lookback is not None else timedelta(hours=LOOKBACK_HOURS)
+            lookback = min(base, datetime.now(UTC) - epoch)
 
     thread = await read_thread(client, chat.entity, lookback=lookback)
     result.messages_scanned = len(thread)
@@ -609,14 +658,14 @@ async def _enqueue_recovery(
     session_id = f"tg_{project_key}_{chat.chat_id}_{inbound.message_id}"
 
     try:
-        persona = resolve_persona(project, chat.chat_title, is_dm=False)
+        persona = resolve_persona(project, chat.chat_title, is_dm=chat.is_dm)
         session_type = persona_to_session_type(persona)
     except Exception as e:
         logger.warning(
             "%s persona resolution failed for chat %s (%s); defaulting to eng: %s",
             LOG_PREFIX,
             chat.chat_id,
-            chat.chat_title,
+            _chat_label(chat),
             e,
         )
         session_type = SessionType.ENG
@@ -624,7 +673,7 @@ async def _enqueue_recovery(
     logger.warning(
         "%s recovering unanswered message in %s: msg %d from %s: '%s'",
         LOG_PREFIX,
-        chat.chat_title,
+        _chat_label(chat),
         inbound.message_id,
         inbound.sender_name,
         inbound.text[:80],
@@ -691,11 +740,11 @@ async def run_sweep(
                 "%s sweep failed for chat=%s (%s); continuing: %s",
                 LOG_PREFIX,
                 chat.chat_id,
-                chat.chat_title,
+                _chat_label(chat),
                 e,
             )
             result = ChatResult(
-                chat_title=chat.chat_title,
+                chat_title=_chat_label(chat),
                 chat_id=chat.chat_id,
                 errored=True,
                 error=str(e),

--- a/bridge/agent_catchup.py
+++ b/bridge/agent_catchup.py
@@ -57,7 +57,7 @@ from typing import Literal
 from pydantic import BaseModel
 
 from agent.llm import run_typed
-from bridge.dedup import get_dm_coverage_epoch, get_or_init_dm_coverage_epoch
+from bridge.dedup import get_or_init_dm_coverage_epoch
 from bridge.routing import (
     find_project_for_dm_dialog,
     persona_to_session_type,
@@ -537,10 +537,12 @@ async def sweep_chat(
         # Clamp the DM sweep to the coverage epoch: recovery reaches back to
         # the configured lookback, but never before coverage began (Task 10 —
         # pre-coverage DM history must never be swept as "unanswered").
-        epoch = await get_dm_coverage_epoch(chat.chat_id)
-        if epoch is not None:
-            base = lookback if lookback is not None else timedelta(hours=LOOKBACK_HOURS)
-            lookback = min(base, datetime.now(UTC) - epoch)
+        # Fail-closed (PR #2622 review): get_or_init never returns None — on a
+        # Redis blip it returns (now, newly_initialized=True), clamping this
+        # sweep to ~zero instead of falling open to the full LOOKBACK_HOURS.
+        epoch, _newly_initialized = await get_or_init_dm_coverage_epoch(chat.chat_id)
+        base = lookback if lookback is not None else timedelta(hours=LOOKBACK_HOURS)
+        lookback = min(base, datetime.now(UTC) - epoch)
 
     thread = await read_thread(client, chat.entity, lookback=lookback)
     result.messages_scanned = len(thread)

--- a/bridge/catchup.py
+++ b/bridge/catchup.py
@@ -13,8 +13,13 @@ from pathlib import Path
 
 from telethon.errors import FloodWaitError
 
+from bridge.dedup import get_or_init_dm_coverage_epoch
 from bridge.history_fetch import fetch_messages_back_to
-from bridge.routing import persona_to_session_type, resolve_persona
+from bridge.routing import (
+    find_project_for_dm_dialog,
+    persona_to_session_type,
+    resolve_persona,
+)
 from config.enums import SessionType
 
 logger = logging.getLogger(__name__)
@@ -165,29 +170,43 @@ async def scan_for_missed_messages(
     seen_chat_ids: set[int] = set()
     for dialog in dialogs:
         chat_title = getattr(dialog.entity, "title", None)
-        if not chat_title:
-            continue
+        is_dm = False
+        if chat_title:
+            # Note: monitored_groups contains lowercase group names, but Telegram
+            # group titles may have capitals. Compare case-insensitively.
+            if chat_title.lower() not in monitored_groups:
+                logger.debug(f"[catchup] Skipping non-monitored group: {chat_title}")
+                continue
 
-        # Note: monitored_groups contains lowercase group names, but Telegram
-        # group titles may have capitals. Compare case-insensitively.
-        if chat_title.lower() not in monitored_groups:
-            logger.debug(f"[catchup] Skipping non-monitored group: {chat_title}")
-            continue
+            # Deduplicate by dialog ID — Telethon may return the same supergroup
+            # twice (once as a channel, once as a linked discussion group).
+            if dialog.id in seen_chat_ids:
+                logger.warning(
+                    f"[catchup] Skipping duplicate dialog for {chat_title} (id={dialog.id})"
+                )
+                continue
+            seen_chat_ids.add(dialog.id)
 
-        # Deduplicate by dialog ID — Telethon may return the same supergroup
-        # twice (once as a channel, once as a linked discussion group).
-        if dialog.id in seen_chat_ids:
-            logger.warning(f"[catchup] Skipping duplicate dialog for {chat_title} (id={dialog.id})")
-            continue
-        seen_chat_ids.add(dialog.id)
+            logger.info(f"[catchup] Found monitored group: {chat_title}")
+            matched_groups.append(chat_title)
 
-        logger.info(f"[catchup] Found monitored group: {chat_title}")
-        matched_groups.append(chat_title)
+            project = find_project_fn(chat_title)
+            if not project:
+                logger.warning(f"[catchup] No project config for {chat_title}")
+                continue
+        else:
+            # DM Rooms (durability plan Task 10, issue #2494): a private chat
+            # is a User entity with no title. A whitelisted DM is a covered
+            # Room and is scanned identically to a group.
+            project = find_project_for_dm_dialog(dialog.entity)
+            if project is None:
+                continue
+            if dialog.id in seen_chat_ids:
+                continue
+            seen_chat_ids.add(dialog.id)
+            is_dm = True
 
-        project = find_project_fn(chat_title)
-        if not project:
-            logger.warning(f"[catchup] No project config for {chat_title}")
-            continue
+        chat_label = chat_title or f"DM:{dialog.id}"
 
         project_key = project.get("_key", "unknown")
         working_dir = project.get("working_directory", "")
@@ -221,18 +240,31 @@ async def scan_for_missed_messages(
                 per_chat_cutoff = min(cutoff, candidate)
                 if per_chat_cutoff < cutoff:
                     logger.info(
-                        f"[catchup] {chat_title}: per-chat cutoff {per_chat_cutoff.isoformat()} "
+                        f"[catchup] {chat_label}: per-chat cutoff {per_chat_cutoff.isoformat()} "
                         f"predates global cutoff {cutoff.isoformat()} "
                         f"(last dispatched {last_proc_dt.isoformat()}) — extending lookback"
                     )
         except Exception as e:
             # Defensive: a cursor read failure must not break the per-group scan.
             logger.warning(
-                f"[catchup] {chat_title}: get_last_processed failed ({e}); "
+                f"[catchup] {chat_label}: get_last_processed failed ({e}); "
                 f"falling back to global cutoff"
             )
 
-        logger.info(f"[catchup] Scanning {chat_title} for missed messages...")
+        if is_dm:
+            # Newly-covered DM Rooms initialize their cursor at "now" — never
+            # replay pre-coverage history as "recovered" messages (durability
+            # plan Task 10). Once covered, the epoch clamps every lookback.
+            epoch_dt, newly_initialized = await get_or_init_dm_coverage_epoch(chat_id)
+            if newly_initialized:
+                logger.info(
+                    f"[catchup] {chat_label}: DM coverage epoch initialized at "
+                    f"{epoch_dt.isoformat()} — skipping scan this pass"
+                )
+                continue
+            per_chat_cutoff = max(per_chat_cutoff, epoch_dt)
+
+        logger.info(f"[catchup] Scanning {chat_label} for missed messages...")
 
         try:
             # Fetch recent messages via the paged, bounded, loud fetch shared
@@ -252,7 +284,7 @@ async def scan_for_missed_messages(
                         client,
                         dialog.entity,
                         per_chat_cutoff,
-                        chat_title,
+                        chat_label,
                         page_size=CATCHUP_MESSAGE_LIMIT,
                         max_messages=CATCHUP_MAX_MESSAGES_PER_CHAT,
                         scanner="catchup",
@@ -263,7 +295,7 @@ async def scan_for_missed_messages(
                         logger.warning(
                             "[catchup] %s: FloodWait %ds exceeds cap %ds — skipping "
                             "this chat's scan (Telegram backpressure, not an error)",
-                            chat_title,
+                            chat_label,
                             flood.seconds,
                             CATCHUP_FLOODWAIT_MAX_SLEEP_S,
                         )
@@ -271,7 +303,7 @@ async def scan_for_missed_messages(
                     logger.warning(
                         "[catchup] %s: FloodWait %ds (Telegram backpressure, not an "
                         "error) — honoring wait, retrying",
-                        chat_title,
+                        chat_label,
                         flood.seconds,
                     )
                     await asyncio.sleep(flood.seconds + CATCHUP_FLOODWAIT_SLEEP_BUFFER_S)
@@ -280,7 +312,7 @@ async def scan_for_missed_messages(
                 continue
 
             logger.info(
-                f"[catchup] {chat_title}: Fetched {len(messages)} messages, "
+                f"[catchup] {chat_label}: Fetched {len(messages)} messages, "
                 f"scanning for messages after {per_chat_cutoff.isoformat()}"
             )
 
@@ -288,20 +320,20 @@ async def scan_for_missed_messages(
                 # Skip if too old
                 if message.date < per_chat_cutoff:
                     logger.debug(
-                        f"[catchup] {chat_title}: msg {message.id} too old "
+                        f"[catchup] {chat_label}: msg {message.id} too old "
                         f"({message.date.isoformat()}) - stopping scan"
                     )
                     break
 
                 # Skip outgoing messages (our own)
                 if message.out:
-                    logger.debug(f"[catchup] {chat_title}: msg {message.id} is outgoing - skip")
+                    logger.debug(f"[catchup] {chat_label}: msg {message.id} is outgoing - skip")
                     continue
 
                 # Skip messages without text
                 text = message.text or ""
                 if not text.strip():
-                    logger.debug(f"[catchup] {chat_title}: msg {message.id} has no text - skip")
+                    logger.debug(f"[catchup] {chat_label}: msg {message.id} has no text - skip")
                     continue
 
                 # Skip messages already processed (Redis dedup)
@@ -310,7 +342,7 @@ async def scan_for_missed_messages(
                 if await is_duplicate_message(chat_id, message.id):
                     skipped_duplicate += 1
                     logger.info(
-                        f"[catchup] {chat_title}: msg {message.id} "
+                        f"[catchup] {chat_label}: msg {message.id} "
                         f"already processed (Redis dedup) - skip"
                     )
                     continue
@@ -322,7 +354,7 @@ async def scan_for_missed_messages(
                 sender_id = getattr(sender, "id", None)
 
                 logger.info(
-                    f"[catchup] {chat_title}: msg {message.id} from {sender_name} "
+                    f"[catchup] {chat_label}: msg {message.id} from {sender_name} "
                     f"at {message.date.isoformat()}: '{text[:50]}...'"
                 )
 
@@ -337,18 +369,18 @@ async def scan_for_missed_messages(
                 # Check if we should respond to this message
                 # Create a minimal event-like object for should_respond_fn
                 class MinimalEvent:
-                    def __init__(self, msg, chat_id):
+                    def __init__(self, msg, chat_id, is_private):
                         self.message = msg
                         self.chat_id = chat_id
-                        self.is_private = False
+                        self.is_private = is_private
 
-                minimal_event = MinimalEvent(message, chat_id)
+                minimal_event = MinimalEvent(message, chat_id, is_dm)
 
                 should_respond, is_reply_to_valor = await should_respond_fn(
                     client,
                     minimal_event,
                     text,
-                    False,  # is_dm
+                    is_dm,
                     chat_title,
                     project,
                     sender_name,
@@ -358,14 +390,14 @@ async def scan_for_missed_messages(
 
                 if not should_respond:
                     logger.info(
-                        f"[catchup] {chat_title}: msg {message.id} - "
+                        f"[catchup] {chat_label}: msg {message.id} - "
                         f"should_respond=False (reply_to_valor={is_reply_to_valor}) - skip"
                     )
                     continue
 
                 # Queue this message for processing
                 logger.info(
-                    f"[catchup] Found missed message in {chat_title}: "
+                    f"[catchup] Found missed message in {chat_label}: "
                     f"'{text[:50]}...' from {sender_name}"
                 )
 
@@ -379,14 +411,14 @@ async def scan_for_missed_messages(
                 # NARROW (per-message): a persona failure falls back to the eng
                 # default and continues the scan rather than aborting the chat.
                 try:
-                    persona = resolve_persona(project, chat_title, is_dm=False)
+                    persona = resolve_persona(project, chat_title, is_dm=is_dm)
                     session_type = persona_to_session_type(persona)
                 except Exception as e:
                     logger.warning(
                         "[catchup] persona resolution failed for chat %s (%s); "
                         "defaulting to eng: %s",
                         chat_id,
-                        chat_title,
+                        chat_label,
                         e,
                     )
                     session_type = SessionType.ENG
@@ -453,12 +485,12 @@ async def scan_for_missed_messages(
             logger.warning(
                 "[catchup] %s: FloodWait %ds (Telegram backpressure, not an error) — "
                 "skipping this chat's scan",
-                chat_title,
+                chat_label,
                 flood.seconds,
             )
             continue
         except Exception as e:
-            logger.error(f"[catchup] Error scanning {chat_title}: {e}")
+            logger.error(f"[catchup] Error scanning {chat_label}: {e}")
             continue
 
     logger.info(

--- a/bridge/dedup.py
+++ b/bridge/dedup.py
@@ -251,3 +251,56 @@ async def get_last_event_ts(chat_id) -> float | None:
     except Exception as e:
         logger.warning("last-event read failed for chat=%s: %s", chat_id, e)
         return None
+
+
+# --- DM Room coverage epoch (durability plan Task 10, issue #2494) -----------
+#
+# `bridge:dm_coverage_epoch:{chat_id}` records WHEN recovery-scanner coverage
+# began for a DM Room. The three scanners historically skipped every title-less
+# dialog, so the first deploy that covers DMs must initialize each DM Room's
+# cursor at "now", never at history-zero: without this epoch, a long-lookback
+# scan (catchup's 24h override) would replay old, already-answered DM history
+# as "recovered" messages. Freeform (not Popoto-managed) string key, SET NX,
+# no TTL — coverage, once begun, never lapses back to uncovered.
+
+
+_DM_COVERAGE_EPOCH_KEY_PREFIX = "bridge:dm_coverage_epoch:"
+
+
+async def get_or_init_dm_coverage_epoch(chat_id) -> tuple[datetime, bool]:
+    """Return ``(epoch_dt, newly_initialized)`` for a DM Room, initializing at now.
+
+    ``newly_initialized=True`` means coverage began THIS call — the caller must
+    skip scanning this pass (nothing can have been missed before coverage).
+    On any failure the safe direction is the same: return ``(now, True)`` so
+    the scan skips rather than replaying unbounded history. Never raises.
+    """
+    now = datetime.now(UTC)
+    try:
+        r = _get_redis()
+        key = f"{_DM_COVERAGE_EPOCH_KEY_PREFIX}{chat_id}"
+        if r.set(key, str(now.timestamp()), nx=True):
+            return (now, True)
+        raw = r.get(key)
+        if raw is None:  # expired/deleted between SET NX failure and GET
+            return (now, True)
+        return (datetime.fromtimestamp(float(raw), tz=UTC), False)
+    except Exception as e:
+        logger.warning("dm coverage-epoch read/init failed for chat=%s: %s", chat_id, e)
+        return (now, True)
+
+
+async def get_dm_coverage_epoch(chat_id) -> datetime | None:
+    """Return the coverage epoch for a DM Room, or ``None`` if uncovered.
+
+    Read-only (never initializes). Returns ``None`` on any failure.
+    """
+    try:
+        r = _get_redis()
+        raw = r.get(f"{_DM_COVERAGE_EPOCH_KEY_PREFIX}{chat_id}")
+        if raw is None:
+            return None
+        return datetime.fromtimestamp(float(raw), tz=UTC)
+    except Exception as e:
+        logger.warning("dm coverage-epoch read failed for chat=%s: %s", chat_id, e)
+        return None

--- a/bridge/dedup_seed.py
+++ b/bridge/dedup_seed.py
@@ -132,21 +132,37 @@ async def seed_dedup_for_chats(
     seen_chat_ids: set[int] = set()
     for dialog in dialogs:
         chat_title = getattr(dialog.entity, "title", None)
-        if not chat_title:
-            continue
-        if chat_title.lower() not in monitored_groups:
-            continue
-        if dialog.id in seen_chat_ids:
-            continue
-        seen_chat_ids.add(dialog.id)
+        if chat_title:
+            if chat_title.lower() not in monitored_groups:
+                continue
+            if dialog.id in seen_chat_ids:
+                continue
+            seen_chat_ids.add(dialog.id)
 
-        try:
-            project = find_project_fn(chat_title)
-        except Exception as e:
-            logger.warning("[dedup-seed] find_project_fn failed for %s: %s", chat_title, e)
-            continue
-        if not project:
-            continue
+            try:
+                project = find_project_fn(chat_title)
+            except Exception as e:
+                logger.warning("[dedup-seed] find_project_fn failed for %s: %s", chat_title, e)
+                continue
+            if not project:
+                continue
+        else:
+            # DM Rooms (durability plan Task 10, issue #2494): the scanners now
+            # cover whitelisted DMs, so the seed covers them too — "the seed
+            # covers exactly the chats the scanners cover".
+            from bridge.routing import find_project_for_dm_dialog
+
+            try:
+                project = find_project_for_dm_dialog(dialog.entity)
+            except Exception as e:
+                logger.warning("[dedup-seed] DM project resolution failed for %s: %s", dialog.id, e)
+                continue
+            if project is None:
+                continue
+            if dialog.id in seen_chat_ids:
+                continue
+            seen_chat_ids.add(dialog.id)
+            chat_title = f"DM:{dialog.id}"
 
         chat_id = dialog.id
         if is_chat_seeded(chat_id):

--- a/bridge/reconciler.py
+++ b/bridge/reconciler.py
@@ -15,13 +15,18 @@ from datetime import UTC, datetime, timedelta
 
 from bridge.dedup import (
     claim_message,
+    get_or_init_dm_coverage_epoch,
     is_duplicate_message,
     record_last_processed,
     record_message_processed,
     release_message_claim,
 )
 from bridge.history_fetch import fetch_messages_back_to
-from bridge.routing import persona_to_session_type, resolve_persona
+from bridge.routing import (
+    find_project_for_dm_dialog,
+    persona_to_session_type,
+    resolve_persona,
+)
 from bridge.silent_stream import SilentStreamState, check_silent_chat
 from config.enums import SessionType
 
@@ -145,34 +150,45 @@ async def reconcile_once(
 
     for dialog in dialogs:
         chat_title = getattr(dialog.entity, "title", None)
-        if not chat_title:
-            continue
+        is_dm = False
+        if chat_title:
+            if chat_title.lower() not in monitored_groups:
+                continue
 
-        if chat_title.lower() not in monitored_groups:
-            continue
+            project = find_project_fn(chat_title)
 
-        project = find_project_fn(chat_title)
+            # Silent-gap observability (issue #1408): ride this dialog pass
+            # instead of a separate loop. Best-effort — a failure here must
+            # never break the recovery scan. Runs even when the chat has no
+            # project config (the per-chat check applies its own
+            # respond_to_unaddressed gate). Groups only — the DM branch below
+            # has no unaddressed-traffic stream to watch.
+            if silent_stream_state is not None:
+                try:
+                    await check_silent_chat(
+                        chat_id=dialog.id,
+                        chat_title=chat_title,
+                        project=project,
+                        state=silent_stream_state,
+                    )
+                except Exception as e:
+                    logger.error(
+                        "[silent-stream] check failed for %s: %s", chat_title, e, exc_info=True
+                    )
 
-        # Silent-gap observability (issue #1408): ride this dialog pass instead
-        # of a separate loop. Best-effort — a failure here must never break the
-        # recovery scan. Runs even when the chat has no project config (the
-        # per-chat check applies its own respond_to_unaddressed gate).
-        if silent_stream_state is not None:
-            try:
-                await check_silent_chat(
-                    chat_id=dialog.id,
-                    chat_title=chat_title,
-                    project=project,
-                    state=silent_stream_state,
-                )
-            except Exception as e:
-                logger.error(
-                    "[silent-stream] check failed for %s: %s", chat_title, e, exc_info=True
-                )
+            if not project:
+                logger.debug("[reconciler] No project config for %s, skipping", chat_title)
+                continue
+        else:
+            # DM Rooms (durability plan Task 10, issue #2494): a private chat
+            # is a User entity with no title. Scanners iterate Rooms, not just
+            # titled group dialogs — a whitelisted DM is covered identically.
+            project = find_project_for_dm_dialog(dialog.entity)
+            if project is None:
+                continue
+            is_dm = True
 
-        if not project:
-            logger.debug("[reconciler] No project config for %s, skipping", chat_title)
-            continue
+        chat_label = chat_title or f"DM:{dialog.id}"
 
         project_key = project.get("_key", "unknown")
         working_dir = project.get("working_directory", "")
@@ -216,9 +232,26 @@ async def reconcile_once(
             # Defensive: a cursor read failure must not break the per-group scan.
             logger.warning(
                 "[reconciler] %s: get_last_processed failed (%s); falling back to global cutoff",
-                chat_title,
+                chat_label,
                 e,
             )
+
+        if is_dm:
+            # Newly-covered DM Rooms initialize their cursor at "now" — the
+            # first covered scan must never replay pre-coverage history as
+            # "recovered" messages (durability plan Task 10). Once covered,
+            # the epoch clamps every lookback: recovery reaches back to the
+            # global/cursor cutoff, but never before coverage began.
+            epoch_dt, newly_initialized = await get_or_init_dm_coverage_epoch(chat_id)
+            if newly_initialized:
+                logger.info(
+                    "[reconciler] %s: DM coverage epoch initialized at %s — "
+                    "skipping scan this pass",
+                    chat_label,
+                    epoch_dt.isoformat(),
+                )
+                continue
+            per_chat_cutoff = max(per_chat_cutoff, epoch_dt)
 
         try:
             # Paged, bounded, loud fetch shared with bridge/catchup.py
@@ -227,7 +260,7 @@ async def reconcile_once(
                 client,
                 dialog.entity,
                 per_chat_cutoff,
-                chat_title,
+                chat_label,
                 page_size=RECONCILE_MESSAGE_LIMIT,
                 max_messages=RECONCILE_MAX_MESSAGES_PER_CHAT,
                 scanner="reconciler",
@@ -258,20 +291,22 @@ async def reconcile_once(
                 sender_username = getattr(sender, "username", None)
                 sender_id = getattr(sender, "id", None)
 
-                # Check if we should respond via routing logic
+                # Check if we should respond via routing logic. Parity with
+                # the live handler: DMs carry is_private=True, is_dm=True,
+                # and chat_title=None (a User entity has no title).
                 class MinimalEvent:
-                    def __init__(self, msg, ev_chat_id):
+                    def __init__(self, msg, ev_chat_id, is_private):
                         self.message = msg
                         self.chat_id = ev_chat_id
-                        self.is_private = False
+                        self.is_private = is_private
 
-                minimal_event = MinimalEvent(message, chat_id)
+                minimal_event = MinimalEvent(message, chat_id, is_dm)
 
                 should_respond, _is_reply_to_valor = await should_respond_fn(
                     client,
                     minimal_event,
                     text,
-                    False,  # is_dm
+                    is_dm,
                     chat_title,
                     project,
                     sender_name,
@@ -287,7 +322,7 @@ async def reconcile_once(
 
                 logger.warning(
                     "[reconciler] Recovered missed message in %s: msg %d from %s: '%s'",
-                    chat_title,
+                    chat_label,
                     message.id,
                     sender_name,
                     text[:80],
@@ -300,14 +335,14 @@ async def reconcile_once(
                 # NARROW (per-message): a persona failure falls back to the eng
                 # default and continues the scan rather than aborting the chat.
                 try:
-                    persona = resolve_persona(project, chat_title, is_dm=False)
+                    persona = resolve_persona(project, chat_title, is_dm=is_dm)
                     session_type = persona_to_session_type(persona)
                 except Exception as e:
                     logger.warning(
                         "[reconciler] persona resolution failed for chat %s (%s); "
                         "defaulting to eng: %s",
                         chat_id,
-                        chat_title,
+                        chat_label,
                         e,
                     )
                     session_type = SessionType.ENG
@@ -366,7 +401,7 @@ async def reconcile_once(
                 )
 
         except Exception as e:
-            logger.error("[reconciler] Error scanning %s: %s", chat_title, e, exc_info=True)
+            logger.error("[reconciler] Error scanning %s: %s", chat_label, e, exc_info=True)
             continue
 
     logger.debug(

--- a/bridge/room_inbox.py
+++ b/bridge/room_inbox.py
@@ -1,0 +1,73 @@
+"""Shadow-mode durable Room-inbox append (Task 11 phase 1, issue #2494).
+
+The target inbound flow of ``docs/plans/durability-room-job-agentrun.md`` is
+👀 → **durable Room-inbox append** → route → bind: one Redis write collapses
+the multi-step intake loss window to a single operation. Cutover is 3-phase
+(spike-4 checklist) and this module is **phase 1 — shadow**: the durable
+append is written ALONGSIDE the untouched dispatch flow so parity can be
+verified in production. Nothing reads this inbox for dispatch yet; the
+authoritative flip ships in a separate release, and the inbox is cap-bounded
+(``models.room.ROOM_INBOX_MAX_ENTRIES``) precisely because nothing drains it
+during the shadow phase.
+
+Contract: never raises into the live intake path. A failed append returns
+``False`` and logs at ERROR (loud, but the untouched dispatch flow still
+handles the message — shadow mode has no durability responsibility yet).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+def shadow_append_inbox(
+    project: dict | None,
+    *,
+    chat_id,
+    message_id: int,
+    sender_id,
+    sender_name: str | None,
+    text: str,
+    date: datetime | None,
+) -> bool:
+    """Durably append one inbound Telegram message to its Room's inbox.
+
+    The Room resolves from the project (``projects.json`` stays the source of
+    truth) and the chat id — DMs and groups identically
+    (``telegram:{chat_id}``). The entry carries a stable message identity
+    (``chat_id`` + ``message_id``) so the future authoritative phase can
+    route/bind idempotently from it.
+
+    Returns ``True`` on a durable write, ``False`` otherwise. Never raises.
+    """
+    try:
+        from models.room import Room, telegram_addressee
+
+        project_key = (project or {}).get("_key")
+        if not project_key:
+            logger.error(
+                "[room-inbox] shadow append skipped: no project key (chat=%s msg=%s)",
+                chat_id,
+                message_id,
+            )
+            return False
+
+        room = Room.resolve(project_key, telegram_addressee(chat_id))
+        return room.append_inbox(
+            {
+                "chat_id": str(chat_id),
+                "message_id": message_id,
+                "sender_id": sender_id,
+                "sender_name": sender_name,
+                "text": text,
+                "ts": date.isoformat() if date is not None else None,
+            }
+        )
+    except Exception as e:  # noqa: BLE001 — intake must survive an inbox outage
+        logger.error(
+            "[room-inbox] shadow append failed for chat=%s msg=%s: %s", chat_id, message_id, e
+        )
+        return False

--- a/bridge/routing.py
+++ b/bridge/routing.py
@@ -381,7 +381,7 @@ def ensure_email_routing_loaded() -> bool:
 
 def find_project_for_chat(chat_title: str | None) -> dict | None:
     """Find which project a chat belongs to."""
-    if not chat_title:
+    if chat_title is None or chat_title == "":
         return None
 
     chat_lower = chat_title.lower()
@@ -403,6 +403,30 @@ def find_project_for_dm(sender_id: int | None) -> dict | None:
     if not sender_id:
         return None
     return DM_USER_TO_PROJECT.get(sender_id)
+
+
+def find_project_for_dm_dialog(entity) -> dict | None:
+    """Project for a title-less (DM) dialog in a recovery scanner, or ``None``.
+
+    A Telegram private chat is a ``User`` entity with no ``title`` — the shape
+    the recovery scanners historically skipped, making DMs permanently lost on
+    a pre-enqueue bridge crash (the DM loss class of issue #2494). A DM dialog
+    is a covered Room iff its user maps to a project via the DM whitelist.
+
+    Returns ``None`` (never scan) for:
+    - bot peers (``entity.bot`` or a ``find_project_for_bot`` hit — the
+      deterministic loop-guard: known bots never spawn sessions),
+    - our own account (``entity.is_self`` — Saved Messages),
+    - users with no DM whitelist project mapping.
+    """
+    if getattr(entity, "bot", False) or getattr(entity, "is_self", False):
+        return None
+    sender_id = getattr(entity, "id", None)
+    if not sender_id:
+        return None
+    if find_project_for_bot(sender_id) is not None:
+        return None
+    return find_project_for_dm(sender_id)
 
 
 def find_project_for_bot(sender_id: int | None) -> dict | None:
@@ -473,7 +497,7 @@ def find_project_for_email(sender_email: str | None) -> dict | None:
 
 def is_team_chat(chat_title: str | None) -> bool:
     """Team chats (no Eng: prefix) are mention-only."""
-    if not chat_title:
+    if chat_title is None or chat_title == "":
         return False
     return not chat_title.startswith(("Eng:",))
 

--- a/bridge/silent_stream.py
+++ b/bridge/silent_stream.py
@@ -149,7 +149,9 @@ async def check_silent_streams(
     warnings_emitted = 0
     for dialog in dialogs:
         chat_title = getattr(dialog.entity, "title", None)
-        if not chat_title or chat_title.lower() not in monitored_groups:
+        # Group-scoped by design: the silent-stream heuristic watches
+        # unaddressed group traffic; DM Rooms have no such stream to compare.
+        if chat_title is None or chat_title.lower() not in monitored_groups:
             continue
 
         project = find_project_fn(chat_title)

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -130,6 +130,7 @@ from bridge.response import (  # noqa: E402
     react_if_worker_down,
     set_reaction,
 )
+from bridge.room_inbox import shadow_append_inbox  # noqa: E402
 from bridge.routing import (  # noqa: E402
     build_group_to_project_map,
     classify_needs_response,  # noqa: F401
@@ -1272,6 +1273,23 @@ async def main():
             project = find_project_for_dm(sender_id) or find_project_for_chat(chat_title)
         else:
             project = find_project_for_chat(chat_title) if chat_title else None
+
+        # Durable Room-inbox shadow append (durability plan Task 11 phase 1,
+        # issue #2494): written alongside the untouched dispatch flow below.
+        # NOT authoritative — dispatch still routes from the live event; this
+        # write exists so production parity can be verified before the
+        # authoritative 👀→append→route→bind cutover ships in a separate
+        # release. shadow_append_inbox never raises into intake.
+        if project:
+            shadow_append_inbox(
+                project,
+                chat_id=event.chat_id,
+                message_id=message.id,
+                sender_id=sender_id,
+                sender_name=sender_name,
+                text=safe_text,
+                date=getattr(message, "date", None),
+            )
 
         # #1630: pre-execution prompt-injection screen on untrusted inbound text.
         # Runs at the raw-intake seam -- strictly BEFORE the steer/resume/new

--- a/docs/features/session-steering.md
+++ b/docs/features/session-steering.md
@@ -306,6 +306,13 @@ steering via `valor-session steer` needs no special-casing for mid-turn vs.
 turn-boundary delivery — the runner's preempt watcher makes turn-boundary
 delivery the only shape steering ever needs to reason about.
 
+Transitional note (durability plan #2494, Milestone 2): consumers additionally
+drain a Room-scoped key (`steering:room:{room_id}`, `room_id` =
+`{project_key}|{addressee}`) after the legacy session key. This is a
+**drain-only dual-read leg — no writer targets it yet**; the writer flip to
+the Room key ships as a separate release once every machine runs the
+dual-read consumer.
+
 ## Parent-Child Steering (parent Eng session to child Eng session)
 
 In addition to Telegram reply-thread steering (user to agent), the steering queue supports **parent-child steering**. Parent and child sessions are both Eng sessions (`session_type="eng"`); a parent created its child via `AgentSession.create_child()` for parallel work, and steers it while it runs.

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -39,6 +39,7 @@ from models.memory import Memory  # noqa: E402
 from models.pr_review_audit import PRReviewAudit  # noqa: E402
 from models.reflection import Reflection  # noqa: E402
 from models.reflection_ignore import ReflectionIgnore  # noqa: E402
+from models.room import Room  # noqa: E402
 from models.teammate_metrics import TeammateMetrics  # noqa: E402
 from models.telegram import TelegramMessage  # noqa: E402
 
@@ -56,6 +57,7 @@ __all__ = [
     "PRReviewAudit",
     "Reflection",
     "ReflectionIgnore",
+    "Room",
     "TeammateMetrics",
     "TelegramMessage",
     "Chat",

--- a/models/room.py
+++ b/models/room.py
@@ -1,0 +1,252 @@
+"""Room — the environment a conversation happens in.
+
+``Room = (project_key, addressee)`` where ``addressee`` is one of
+``telegram:{chat_id}`` | ``email:{address}`` | ``system``. Resolved from
+``projects.json`` (which stays the source of truth — Room caches the resolved
+binding, it does not replace the config). Owns addressing and the durable
+inbox. Immortal: no ``Meta.ttl``.
+
+Schema (ratified one-shot by the Task 5 schema-gate ruling of
+``docs/plans/durability-room-job-agentrun.md``):
+
+- KeyField set = ``{project_key, addressee}`` — every Room resolution is a
+  direct composite-primary-key lookup.
+- **No IndexedField.** This is load-bearing for Risk 2 (#2207): the phantom
+  index flood mechanism is an ``IndexedField.on_save`` re-SADDing values
+  decoded off identity-less hashes during ``rebuild_indexes()``. With zero
+  IndexedFields Room has no ``$IndexF`` surface at all; the guarded
+  :meth:`Room.repair_indexes` below closes the remaining class-set/KeyField
+  leg by quarantining identity-less hashes before any rebuild.
+- The inbox is a Redis list under the Room's primary key (a ``::inbox``
+  companion key — the ``::`` suffix keeps it out of index-drift hash counts),
+  drained by pattern-scanning consumers, never ``.filter()``ed.
+
+Every session belongs to a Room (spike-1): chatless sessions get the
+per-project ``system`` Room, unifying the three prior synthetic addressees
+(``chat_id="0"``, ``chat_id = session_id``, default-DM inheritance).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+
+from popoto import Field, KeyField, Model
+
+logger = logging.getLogger(__name__)
+
+SYSTEM_ADDRESSEE = "system"
+
+# Cap on retained Room-inbox entries during the shadow phase (Task 11 phase 1:
+# the durable append is written alongside the untouched dispatch flow and
+# nothing drains it yet, so an uncapped list would grow without bound).
+# GRAIN OF SALT: provisional/tunable via env; sized to hold days of traffic in
+# the busiest room while staying trivially small for Redis.
+ROOM_INBOX_MAX_ENTRIES = int(os.environ.get("ROOM_INBOX_MAX_ENTRIES", "1000"))
+
+
+def telegram_addressee(chat_id) -> str:
+    """Addressee for a Telegram chat — DMs and groups identically."""
+    return f"telegram:{chat_id}"
+
+
+def email_addressee(address: str) -> str:
+    """Addressee for an email correspondent (case-insensitive address)."""
+    return f"email:{address.strip().lower()}"
+
+
+def room_id(project_key: str, addressee: str) -> str:
+    """Composite room id ``{project_key}|{addressee}`` (Job.room_id shape)."""
+    return f"{project_key}|{addressee}"
+
+
+def addressee_for_session(session) -> str:
+    """Map an AgentSession onto its Room addressee.
+
+    - Numeric ``chat_id`` (Telegram DM, group, or supergroup) → ``telegram:``.
+    - ``chat_id`` containing ``@`` (the email bridge stores the sender address
+      as ``chat_id``) → ``email:``.
+    - Anything else (no chat, ``chat_id = session_id`` synthetics, reflection
+      sessions) → the per-project ``system`` Room.
+    """
+    chat_id = getattr(session, "chat_id", None)
+    if chat_id:
+        raw = str(chat_id).strip()
+        if raw.lstrip("-").isdigit():
+            return telegram_addressee(raw)
+        if "@" in raw:
+            return email_addressee(raw)
+    return SYSTEM_ADDRESSEE
+
+
+def room_id_for_session(session) -> str | None:
+    """Composite room id for a session, or ``None`` without a project_key."""
+    project_key = getattr(session, "project_key", None)
+    if not project_key:
+        return None
+    return room_id(str(project_key), addressee_for_session(session))
+
+
+class Room(Model):
+    """The environment a conversation happens in. Immortal."""
+
+    project_key = KeyField()
+    addressee = KeyField()
+    # Plain metadata (not queryable — read off a fetched Room only).
+    display_name = Field(null=True)
+
+    # -- Resolution ---------------------------------------------------------
+
+    @classmethod
+    def resolve(
+        cls,
+        project_key: str,
+        addressee: str,
+        display_name: str | None = None,
+    ) -> Room:
+        """Get or create the Room for ``(project_key, addressee)``.
+
+        Idempotent: the KeyField pair is the primary key, so a concurrent
+        double-create converges on the same record. ``display_name`` is
+        refreshed opportunistically when provided.
+        """
+        existing = cls.query.filter(project_key=project_key, addressee=addressee)
+        if existing:
+            room = existing[0]
+            if display_name and room.display_name != display_name:
+                room.display_name = display_name
+                room.save()
+            return room
+        room = cls(project_key=project_key, addressee=addressee, display_name=display_name)
+        room.save()
+        return room
+
+    # -- Identity -----------------------------------------------------------
+
+    @property
+    def room_id(self) -> str:
+        return room_id(self.project_key, self.addressee)
+
+    # -- Inbox (durable, Room-owned) ----------------------------------------
+
+    @property
+    def inbox_key(self) -> str:
+        """Companion list key under the Room's primary key.
+
+        The ``::`` suffix follows the repo's companion-key convention, so
+        index-drift hash counting (``agent/index_drift.py``) excludes it.
+        """
+        return f"{self.db_key.redis_key}::inbox"
+
+    def append_inbox(self, entry: dict) -> bool:
+        """Durably append one inbox entry (RPUSH + cap trim). Never raises.
+
+        This is the single-operation loss window of the target inbound flow
+        (👀 → durable append → route → bind). A failure returns ``False`` and
+        logs at ERROR — loud, but it must never take down the live intake
+        path it shadows.
+        """
+        from popoto.redis_db import POPOTO_REDIS_DB
+
+        try:
+            payload = json.dumps(entry)
+            key = self.inbox_key
+            POPOTO_REDIS_DB.rpush(key, payload)
+            POPOTO_REDIS_DB.ltrim(key, -ROOM_INBOX_MAX_ENTRIES, -1)
+            return True
+        except Exception as e:  # noqa: BLE001 — intake must survive an inbox outage
+            logger.error("[room] inbox append failed for %s: %s", self.room_id, e)
+            return False
+
+    def peek_inbox(self, limit: int | None = None) -> list[dict]:
+        """Non-destructive FIFO read of inbox entries (newest last)."""
+        from popoto.redis_db import POPOTO_REDIS_DB
+
+        start = -limit if limit else 0
+        entries: list[dict] = []
+        try:
+            for raw in POPOTO_REDIS_DB.lrange(self.inbox_key, start, -1):
+                try:
+                    entries.append(json.loads(raw))
+                except (json.JSONDecodeError, TypeError):
+                    logger.warning("[room] invalid inbox JSON in %s: %r", self.inbox_key, raw)
+        except Exception as e:  # noqa: BLE001
+            logger.error("[room] inbox peek failed for %s: %s", self.room_id, e)
+        return entries
+
+    def inbox_len(self) -> int:
+        from popoto.redis_db import POPOTO_REDIS_DB
+
+        try:
+            return int(POPOTO_REDIS_DB.llen(self.inbox_key))
+        except Exception:  # noqa: BLE001
+            return 0
+
+    def clear_inbox(self) -> None:
+        from popoto.redis_db import POPOTO_REDIS_DB
+
+        POPOTO_REDIS_DB.delete(self.inbox_key)
+
+    # -- Guarded index repair (Risk 2 / #2207) ------------------------------
+
+    _repair_lock = threading.Lock()
+
+    @classmethod
+    def repair_indexes(cls) -> tuple[int, int]:
+        """Guarded repair path — the ONLY sanctioned index rebuild for Room.
+
+        Room is listed in ``scripts/popoto_index_cleanup._GUARDED_ELSEWHERE``
+        so the generic raw ``rebuild_indexes()`` sweep never touches it; this
+        method is what the daily cleanup reflection invokes instead.
+
+        Guard: quarantine (delete) identity-less ``Room:*`` hashes — records
+        missing either KeyField — BEFORE calling ``rebuild_indexes()``, so a
+        phantom hash can never be re-indexed into the class set on every
+        rebuild (the #2207 flood mechanism, adapted to a model with zero
+        IndexedFields: Room has no ``$IndexF`` surface, the class-set/KeyField
+        leg is the only one to guard).
+
+        Returns ``(quarantined_count, rebuilt_count)`` — same arity as
+        ``AgentSession.repair_indexes()``.
+        """
+        from popoto.redis_db import POPOTO_REDIS_DB
+
+        from config.popoto_floor import assert_popoto_floor
+
+        # Below-floor popoto must never reach the destructive rebuild
+        # (see config/popoto_floor.py / issue #2536).
+        assert_popoto_floor()
+
+        if not cls._repair_lock.acquire(blocking=False):
+            logger.warning("[room] repair_indexes already running; skipping this invocation")
+            return (0, 0)
+        try:
+            quarantined = 0
+            cursor = 0
+            while True:
+                cursor, keys = POPOTO_REDIS_DB.scan(cursor=cursor, match="Room:*", count=500)
+                for key in keys:
+                    key_str = key.decode() if isinstance(key, bytes) else str(key)
+                    if "::" in key_str:
+                        continue  # companion key (inbox), not a record hash
+                    if POPOTO_REDIS_DB.type(key) != b"hash":
+                        continue
+                    fields = POPOTO_REDIS_DB.hgetall(key)
+                    decoded = {(k.decode() if isinstance(k, bytes) else k) for k in fields}
+                    if "project_key" not in decoded or "addressee" not in decoded:
+                        POPOTO_REDIS_DB.delete(key)
+                        quarantined += 1
+                        logger.warning(
+                            "[room] quarantined identity-less Room hash %s "
+                            "(missing KeyField data — would re-index as a phantom)",
+                            key_str,
+                        )
+                if cursor == 0:
+                    break
+
+            rebuilt = cls.rebuild_indexes()
+            return (quarantined, rebuilt if isinstance(rebuilt, int) else 0)
+        finally:
+            cls._repair_lock.release()

--- a/models/room.py
+++ b/models/room.py
@@ -201,12 +201,18 @@ class Room(Model):
         so the generic raw ``rebuild_indexes()`` sweep never touches it; this
         method is what the daily cleanup reflection invokes instead.
 
-        Guard: quarantine (delete) identity-less ``Room:*`` hashes — records
-        missing either KeyField — BEFORE calling ``rebuild_indexes()``, so a
-        phantom hash can never be re-indexed into the class set on every
-        rebuild (the #2207 flood mechanism, adapted to a model with zero
-        IndexedFields: Room has no ``$IndexF`` surface, the class-set/KeyField
-        leg is the only one to guard).
+        Guard: **DELETES** identity-less ``Room:*`` hashes — records missing
+        either KeyField — BEFORE calling ``rebuild_indexes()``, so a phantom
+        hash can never be re-indexed into the class set on every rebuild (the
+        #2207 flood mechanism, adapted to a model with zero IndexedFields:
+        Room has no ``$IndexF`` surface, the class-set/KeyField leg is the
+        only one to guard). Note the blast-radius difference from
+        ``AgentSession.repair_indexes()``: that guard merely *skips* the
+        re-SADD for identity-less records and leaves the hash in place; this
+        one removes the hash itself. Safe here because a Room hash without
+        both KeyFields is unreachable through the ORM by construction (the
+        KeyField pair IS the primary key) and Room carries no other payload
+        worth preserving forensically.
 
         Returns ``(quarantined_count, rebuilt_count)`` — same arity as
         ``AgentSession.repair_indexes()``.

--- a/scripts/popoto_index_cleanup.py
+++ b/scripts/popoto_index_cleanup.py
@@ -44,7 +44,15 @@ _SCHEDULER_STATE_MODELS = frozenset({"Reflection"})
 # (``session_health.cleanup_corrupted_agent_sessions``) and by the hourly
 # ``agent-session-cleanup`` reflection. Excluding it here is the primary fix
 # for #2207 — do not remove without an equivalent guard in this sweep.
-_GUARDED_ELSEWHERE = frozenset({"AgentSession"})
+#
+# Room is likewise excluded from the raw sweep: its guarded
+# ``Room.repair_indexes()`` (quarantines identity-less hashes before any
+# rebuild — see models/room.py) is invoked by this module's own
+# ``_run_guarded_repairs()`` pass below instead. Every new durable Popoto
+# model MUST either appear here with its own guarded repair path or carry a
+# written proof it cannot produce an identity-less hash (Risk 2 of
+# docs/plans/durability-room-job-agentrun.md).
+_GUARDED_ELSEWHERE = frozenset({"AgentSession", "Room"})
 
 
 def _has_embedding_field(model_class) -> bool:
@@ -274,6 +282,48 @@ def _run_rebuild_with_timeout(model_class):
     return outcome.get("count"), False, None
 
 
+def _run_guarded_repairs() -> dict:
+    """Invoke each guarded model's OWN repair path (never the raw rebuild).
+
+    AgentSession is deliberately absent: its A1-guarded ``repair_indexes()``
+    already runs unconditionally from worker Step 2 and the hourly
+    ``agent-session-cleanup`` reflection — a third invocation here would add
+    nothing. Room has no other caller, so this daily sweep is its cadence.
+
+    Failures are contained per model, mirroring the generic sweep.
+    """
+    results: dict = {}
+
+    def _room_repair():
+        from models.room import Room
+
+        return Room.repair_indexes()
+
+    guarded_repairs = {"Room": _room_repair}
+
+    for model_name, repair_fn in guarded_repairs.items():
+        try:
+            stale, rebuilt = repair_fn()
+            results[model_name] = {
+                "status": "ok",
+                "quarantined": stale,
+                "records_rebuilt": rebuilt,
+            }
+            if stale:
+                logger.warning(
+                    f"[popoto-cleanup] {model_name}: guarded repair quarantined "
+                    f"{stale} identity-less hash(es), {rebuilt} records reindexed"
+                )
+            else:
+                logger.debug(
+                    f"[popoto-cleanup] {model_name}: guarded repair clean ({rebuilt} records)"
+                )
+        except Exception as e:
+            results[model_name] = {"status": "error", "error": str(e)}
+            logger.error(f"[popoto-cleanup] Guarded repair failed for {model_name}: {e}")
+    return results
+
+
 def run_cleanup() -> dict:
     """Run cleanup across all Popoto models.
 
@@ -359,6 +409,10 @@ def run_cleanup() -> dict:
             results[model_name] = {"status": "error", "error": str(e)}
             logger.error(f"[popoto-cleanup] Error processing {model_name}: {e}")
 
+    # Guarded models (``_GUARDED_ELSEWHERE``) with a caller in this sweep run
+    # their OWN guarded repair paths — never the raw rebuild above.
+    guarded_results = _run_guarded_repairs()
+
     summary = {
         "status": "completed",
         "models_processed": len(model_classes),
@@ -366,6 +420,7 @@ def run_cleanup() -> dict:
         "total_records_rebuilt": total_rebuilt,
         "errors": errors,
         "per_model": results,
+        "guarded_repairs": guarded_results,
     }
 
     logger.info(

--- a/tests/integration/test_dm_recovery.py
+++ b/tests/integration/test_dm_recovery.py
@@ -1,0 +1,352 @@
+"""DM recovery coverage for the three scanners (Task 10, issue #2494).
+
+The DM loss class: all three recovery scanners used to open with
+``if not chat_title: continue`` — a Telegram private chat is a ``User`` entity
+with no ``title``, so DMs were permanently lost if the bridge crashed before
+enqueue. These tests pin the new behavior: scanners iterate Rooms (groups AND
+DMs), DMs resolve via the whitelist (``find_project_for_dm``), bots/self never
+scan, and a newly-covered DM Room's cursor initializes at "now" — the first
+deploy must never replay old DM history as "recovered" messages.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import bridge.routing as routing
+from bridge.reconciler import reconcile_once
+
+
+def _make_message(msg_id, text=None, out=False, minutes_ago=2, sender_id=42):
+    msg = MagicMock()
+    msg.id = msg_id
+    msg.text = f"Message {msg_id}" if text is None else text
+    msg.out = out
+    msg.date = datetime.now(UTC) - timedelta(minutes=minutes_ago)
+
+    sender = MagicMock()
+    sender.first_name = "Tom"
+    sender.username = "tom"
+    sender.id = sender_id
+    msg.get_sender = AsyncMock(return_value=sender)
+    return msg
+
+
+def _make_dm_dialog(user_id, first_name="Tom", bot=False, is_self=False):
+    """A Telethon DM dialog: a User entity with NO title attribute."""
+    dialog = MagicMock()
+    dialog.entity = MagicMock()
+    dialog.entity.title = None  # User entities have no title
+    dialog.entity.id = user_id
+    dialog.entity.first_name = first_name
+    dialog.entity.bot = bot
+    dialog.entity.is_self = is_self
+    dialog.id = user_id  # DM chat_id == user id (no -100 prefix)
+    return dialog
+
+
+@pytest.fixture
+def dm_project():
+    return {"_key": "test-dmrec", "working_directory": "/tmp/test-dmrec"}
+
+
+@pytest.fixture
+def fresh_user_id():
+    """Unique user id per test so coverage-epoch keys never collide."""
+    uid = int(uuid.uuid4().int % 10**9) + 10**9
+    yield uid
+    from bridge.dedup import _get_redis
+
+    _get_redis().delete(f"bridge:dm_coverage_epoch:{uid}")
+
+
+def _reconcile_patches():
+    return (
+        patch("bridge.catchup.catchup_disabled", return_value=False),
+        patch("bridge.reconciler.is_duplicate_message", new=AsyncMock(return_value=False)),
+        patch("bridge.reconciler.record_message_processed", new_callable=AsyncMock),
+        patch("bridge.reconciler.record_last_processed", new_callable=AsyncMock),
+    )
+
+
+async def _run_reconcile(client, should_respond_fn=None, enqueue=None):
+    return await reconcile_once(
+        client=client,
+        monitored_groups=["some group"],
+        should_respond_fn=should_respond_fn or AsyncMock(return_value=(True, False)),
+        enqueue_agent_session_fn=enqueue or AsyncMock(),
+        find_project_fn=MagicMock(return_value=None),
+    )
+
+
+class TestReconcilerDMCoverage:
+    @pytest.mark.asyncio
+    async def test_first_dm_scan_initializes_epoch_and_skips(
+        self, dm_project, fresh_user_id, monkeypatch
+    ):
+        """Newly-covered DM Room: cursor initializes at now, no history replay."""
+        monkeypatch.setitem(routing.DM_USER_TO_PROJECT, fresh_user_id, dm_project)
+        dialog = _make_dm_dialog(fresh_user_id)
+        client = AsyncMock()
+        client.get_dialogs = AsyncMock(return_value=[dialog])
+
+        enqueue = AsyncMock()
+        p1, p2, p3, p4 = _reconcile_patches()
+        with p1, p2, p3, p4:
+            recovered = await _run_reconcile(client, enqueue=enqueue)
+
+        assert recovered == 0
+        enqueue.assert_not_called()
+
+        from bridge.dedup import get_dm_coverage_epoch
+
+        epoch = await get_dm_coverage_epoch(fresh_user_id)
+        assert epoch is not None
+        assert abs((datetime.now(UTC) - epoch).total_seconds()) < 60
+
+    @pytest.mark.asyncio
+    async def test_second_dm_scan_recovers_missed_message(
+        self, dm_project, fresh_user_id, monkeypatch
+    ):
+        """After the epoch exists, a missed DM inside the window is recovered."""
+        monkeypatch.setitem(routing.DM_USER_TO_PROJECT, fresh_user_id, dm_project)
+        dialog = _make_dm_dialog(fresh_user_id)
+        missed = _make_message(7, minutes_ago=5, sender_id=fresh_user_id)
+        client = AsyncMock()
+        client.get_dialogs = AsyncMock(return_value=[dialog])
+
+        # Epoch predates the missed message (coverage began before it arrived).
+        epoch = datetime.now(UTC) - timedelta(minutes=10)
+        enqueue = AsyncMock()
+        should_respond = AsyncMock(return_value=(True, False))
+
+        p1, p2, p3, p4 = _reconcile_patches()
+        with (
+            p1,
+            p2,
+            p3,
+            p4,
+            patch(
+                "bridge.reconciler.get_or_init_dm_coverage_epoch",
+                new=AsyncMock(return_value=(epoch, False)),
+            ),
+            patch(
+                "bridge.reconciler.fetch_messages_back_to",
+                new=AsyncMock(return_value=[missed]),
+            ),
+        ):
+            recovered = await _run_reconcile(client, should_respond, enqueue)
+
+        assert recovered == 1
+        kwargs = enqueue.call_args.kwargs
+        assert kwargs["project_key"] == "test-dmrec"
+        assert kwargs["chat_id"] == str(fresh_user_id)
+        assert kwargs["chat_title"] is None, "DM parity: live handler has no chat_title"
+        assert kwargs["telegram_message_id"] == 7
+
+        # should_respond saw a DM: is_dm=True, chat_title=None, private event.
+        sr_args = should_respond.call_args.args
+        minimal_event = sr_args[1]
+        assert minimal_event.is_private is True
+        assert sr_args[3] is True  # is_dm
+        assert sr_args[4] is None  # chat_title
+
+    @pytest.mark.asyncio
+    async def test_dm_message_before_epoch_is_never_replayed(
+        self, dm_project, fresh_user_id, monkeypatch
+    ):
+        """Pre-coverage history stays untouched even inside the global window."""
+        monkeypatch.setitem(routing.DM_USER_TO_PROJECT, fresh_user_id, dm_project)
+        dialog = _make_dm_dialog(fresh_user_id)
+        # In the 30-min global window, but BEFORE the coverage epoch.
+        old = _make_message(3, minutes_ago=20, sender_id=fresh_user_id)
+        client = AsyncMock()
+        client.get_dialogs = AsyncMock(return_value=[dialog])
+
+        epoch = datetime.now(UTC) - timedelta(minutes=10)
+        enqueue = AsyncMock()
+
+        p1, p2, p3, p4 = _reconcile_patches()
+        with (
+            p1,
+            p2,
+            p3,
+            p4,
+            patch(
+                "bridge.reconciler.get_or_init_dm_coverage_epoch",
+                new=AsyncMock(return_value=(epoch, False)),
+            ),
+            patch(
+                "bridge.reconciler.fetch_messages_back_to",
+                new=AsyncMock(return_value=[old]),
+            ),
+        ):
+            recovered = await _run_reconcile(client, enqueue=enqueue)
+
+        assert recovered == 0
+        enqueue.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bot_and_self_dm_dialogs_never_scan(self, dm_project, monkeypatch):
+        bot_id, self_id = 111000111, 222000222
+        monkeypatch.setitem(routing.DM_USER_TO_PROJECT, bot_id, dm_project)
+        monkeypatch.setitem(routing.DM_USER_TO_PROJECT, self_id, dm_project)
+        dialogs = [
+            _make_dm_dialog(bot_id, bot=True),
+            _make_dm_dialog(self_id, is_self=True),
+        ]
+        client = AsyncMock()
+        client.get_dialogs = AsyncMock(return_value=dialogs)
+
+        enqueue = AsyncMock()
+        p1, p2, p3, p4 = _reconcile_patches()
+        with p1, p2, p3, p4:
+            recovered = await _run_reconcile(client, enqueue=enqueue)
+
+        assert recovered == 0
+        enqueue.assert_not_called()
+        from bridge.dedup import get_dm_coverage_epoch
+
+        # No epoch was initialized for either — they are not covered Rooms.
+        assert await get_dm_coverage_epoch(bot_id) is None
+        assert await get_dm_coverage_epoch(self_id) is None
+
+    @pytest.mark.asyncio
+    async def test_non_whitelisted_dm_skipped(self):
+        dialog = _make_dm_dialog(333000333)
+        client = AsyncMock()
+        client.get_dialogs = AsyncMock(return_value=[dialog])
+
+        enqueue = AsyncMock()
+        p1, p2, p3, p4 = _reconcile_patches()
+        with p1, p2, p3, p4:
+            recovered = await _run_reconcile(client, enqueue=enqueue)
+
+        assert recovered == 0
+        enqueue.assert_not_called()
+
+
+class TestCatchupDMCoverage:
+    @pytest.mark.asyncio
+    async def test_startup_catchup_recovers_dm(self, dm_project, fresh_user_id, monkeypatch):
+        from bridge.catchup import scan_for_missed_messages
+
+        monkeypatch.setitem(routing.DM_USER_TO_PROJECT, fresh_user_id, dm_project)
+        dialog = _make_dm_dialog(fresh_user_id)
+        missed = _make_message(9, minutes_ago=5, sender_id=fresh_user_id)
+        client = AsyncMock()
+        client.get_dialogs = AsyncMock(return_value=[dialog])
+
+        epoch = datetime.now(UTC) - timedelta(minutes=30)
+        enqueue = AsyncMock()
+        should_respond = AsyncMock(return_value=(True, False))
+
+        with (
+            patch("bridge.catchup.catchup_disabled", return_value=False),
+            patch("bridge.dedup.is_duplicate_message", new=AsyncMock(return_value=False)),
+            patch("bridge.dedup.record_message_processed", new_callable=AsyncMock),
+            patch("bridge.dedup.record_last_processed", new_callable=AsyncMock),
+            patch(
+                "bridge.catchup.get_or_init_dm_coverage_epoch",
+                new=AsyncMock(return_value=(epoch, False)),
+            ),
+            patch(
+                "bridge.catchup.fetch_messages_back_to",
+                new=AsyncMock(return_value=[missed]),
+            ),
+        ):
+            queued = await scan_for_missed_messages(
+                client=client,
+                monitored_groups=["some group"],
+                projects_config={},
+                should_respond_fn=should_respond,
+                enqueue_agent_session_fn=enqueue,
+                find_project_fn=MagicMock(return_value=None),
+            )
+
+        assert queued == 1
+        kwargs = enqueue.call_args.kwargs
+        assert kwargs["chat_id"] == str(fresh_user_id)
+        assert kwargs["chat_title"] is None
+
+    @pytest.mark.asyncio
+    async def test_startup_catchup_first_dm_scan_skips(
+        self, dm_project, fresh_user_id, monkeypatch
+    ):
+        from bridge.catchup import scan_for_missed_messages
+
+        monkeypatch.setitem(routing.DM_USER_TO_PROJECT, fresh_user_id, dm_project)
+        dialog = _make_dm_dialog(fresh_user_id)
+        client = AsyncMock()
+        client.get_dialogs = AsyncMock(return_value=[dialog])
+        enqueue = AsyncMock()
+
+        with patch("bridge.catchup.catchup_disabled", return_value=False):
+            queued = await scan_for_missed_messages(
+                client=client,
+                monitored_groups=[],
+                projects_config={},
+                should_respond_fn=AsyncMock(return_value=(True, False)),
+                enqueue_agent_session_fn=enqueue,
+                find_project_fn=MagicMock(return_value=None),
+            )
+
+        assert queued == 0
+        enqueue.assert_not_called()
+
+
+class TestAgentCatchupDMCoverage:
+    @pytest.mark.asyncio
+    async def test_resolve_owned_chats_includes_covered_dm(
+        self, dm_project, fresh_user_id, monkeypatch
+    ):
+        from bridge.agent_catchup import resolve_owned_chats
+
+        monkeypatch.setitem(routing.DM_USER_TO_PROJECT, fresh_user_id, dm_project)
+        dialog = _make_dm_dialog(fresh_user_id)
+        client = AsyncMock()
+        client.get_dialogs = AsyncMock(return_value=[dialog])
+
+        epoch = datetime.now(UTC) - timedelta(minutes=30)
+        with patch(
+            "bridge.agent_catchup.get_or_init_dm_coverage_epoch",
+            new=AsyncMock(return_value=(epoch, False)),
+        ):
+            owned = await resolve_owned_chats(client, [], MagicMock(return_value=None))
+
+        assert len(owned) == 1
+        chat = owned[0]
+        assert chat.chat_id == fresh_user_id
+        assert chat.is_dm is True
+        assert chat.chat_title is None
+        assert chat.project["_key"] == "test-dmrec"
+
+    @pytest.mark.asyncio
+    async def test_resolve_owned_chats_skips_dm_on_epoch_init(
+        self, dm_project, fresh_user_id, monkeypatch
+    ):
+        from bridge.agent_catchup import resolve_owned_chats
+
+        monkeypatch.setitem(routing.DM_USER_TO_PROJECT, fresh_user_id, dm_project)
+        dialog = _make_dm_dialog(fresh_user_id)
+        client = AsyncMock()
+        client.get_dialogs = AsyncMock(return_value=[dialog])
+
+        owned = await resolve_owned_chats(client, [], MagicMock(return_value=None))
+        assert owned == []  # first pass: epoch just initialized, nothing to sweep
+
+
+class TestNoChatTitleFilterRemains:
+    def test_scanners_do_not_skip_titleless_dialogs(self):
+        """Verification row: `grep 'if not chat_title' bridge/` must be 0."""
+        import pathlib
+
+        bridge_dir = pathlib.Path(__file__).resolve().parents[2] / "bridge"
+        offenders = [
+            str(p)
+            for p in bridge_dir.glob("*.py")
+            if "if not chat_title" in p.read_text(encoding="utf-8")
+        ]
+        assert offenders == []

--- a/tests/integration/test_dm_recovery.py
+++ b/tests/integration/test_dm_recovery.py
@@ -272,6 +272,50 @@ class TestCatchupDMCoverage:
         assert kwargs["chat_title"] is None
 
     @pytest.mark.asyncio
+    async def test_24h_override_never_reaches_before_epoch(
+        self, dm_project, fresh_user_id, monkeypatch
+    ):
+        """Catchup's 24h lookback_override is clamped to the DM coverage epoch:
+        a pre-coverage message inside the 24h window is never replayed."""
+        from bridge.catchup import scan_for_missed_messages
+
+        monkeypatch.setitem(routing.DM_USER_TO_PROJECT, fresh_user_id, dm_project)
+        dialog = _make_dm_dialog(fresh_user_id)
+        # Inside the 24h override window, but BEFORE the coverage epoch.
+        pre_coverage = _make_message(5, minutes_ago=60, sender_id=fresh_user_id)
+        client = AsyncMock()
+        client.get_dialogs = AsyncMock(return_value=[dialog])
+
+        epoch = datetime.now(UTC) - timedelta(minutes=10)
+        enqueue = AsyncMock()
+        fetch = AsyncMock(return_value=[pre_coverage])
+
+        with (
+            patch("bridge.catchup.catchup_disabled", return_value=False),
+            patch("bridge.dedup.is_duplicate_message", new=AsyncMock(return_value=False)),
+            patch(
+                "bridge.catchup.get_or_init_dm_coverage_epoch",
+                new=AsyncMock(return_value=(epoch, False)),
+            ),
+            patch("bridge.catchup.fetch_messages_back_to", new=fetch),
+        ):
+            queued = await scan_for_missed_messages(
+                client=client,
+                monitored_groups=[],
+                projects_config={},
+                should_respond_fn=AsyncMock(return_value=(True, False)),
+                enqueue_agent_session_fn=enqueue,
+                find_project_fn=MagicMock(return_value=None),
+                lookback_override=timedelta(hours=24),
+            )
+
+        assert queued == 0
+        enqueue.assert_not_called()
+        # The paged fetch was asked to reach back only to the epoch, not 24h.
+        fetch_cutoff = fetch.call_args.args[2]
+        assert fetch_cutoff >= epoch
+
+    @pytest.mark.asyncio
     async def test_startup_catchup_first_dm_scan_skips(
         self, dm_project, fresh_user_id, monkeypatch
     ):
@@ -336,6 +380,39 @@ class TestAgentCatchupDMCoverage:
 
         owned = await resolve_owned_chats(client, [], MagicMock(return_value=None))
         assert owned == []  # first pass: epoch just initialized, nothing to sweep
+
+    @pytest.mark.asyncio
+    async def test_sweep_clamps_fail_closed_on_epoch_read_blip(self, dm_project, fresh_user_id):
+        """A Redis blip during the sweep's epoch read must clamp the DM sweep
+        to ~zero lookback (get_or_init's fail-safe (now, True) shape) — never
+        fall open to the full LOOKBACK_HOURS (PR #2622 review note)."""
+        from bridge.agent_catchup import OwnedChat, sweep_chat
+
+        chat = OwnedChat(
+            chat_id=fresh_user_id,
+            chat_title=None,
+            project=dm_project,
+            entity=MagicMock(),
+            is_dm=True,
+        )
+        captured = {}
+
+        async def fake_read_thread(client, entity, lookback=None):
+            captured["lookback"] = lookback
+            return []
+
+        with (
+            patch("bridge.agent_catchup.read_thread", new=fake_read_thread),
+            patch(
+                "bridge.agent_catchup.get_or_init_dm_coverage_epoch",
+                new=AsyncMock(return_value=(datetime.now(UTC), True)),
+            ),
+        ):
+            result = await sweep_chat(AsyncMock(), chat, enqueue_fn=AsyncMock())
+
+        assert result.enqueued == 0
+        assert captured["lookback"] is not None
+        assert captured["lookback"] <= timedelta(seconds=5)
 
 
 class TestNoChatTitleFilterRemains:

--- a/tests/integration/test_steering.py
+++ b/tests/integration/test_steering.py
@@ -1546,3 +1546,126 @@ class TestSteerChildDelivery:
         assert exit_code == 1
         captured = capsys.readouterr()
         assert "mock failure" in captured.err
+
+
+class TestRoomDualRead:
+    """Room-scoped steering dual-read (Task 11 phase 1, issue #2494).
+
+    The drain consumer reads the LEGACY session key first, then the Room key.
+    Writers are UNCHANGED in this release — the Room leg exists so the writer
+    flip can ship later without any consumer change (Race 1 two-phase deploy:
+    dual-read consumer everywhere BEFORE any writer flips).
+    """
+
+    ROOM_ID = "test-proj|telegram:4242"
+
+    def _push_room(self, room_id, text, sender="Tom", is_abort=False):
+        """Simulate a future room-key writer (the flip is a separate release)."""
+        import json
+        import time as _time
+
+        from agent.steering import _get_redis, _room_queue_key
+
+        _get_redis().rpush(
+            _room_queue_key(room_id),
+            json.dumps(
+                {"text": text, "sender": sender, "timestamp": _time.time(), "is_abort": is_abort}
+            ),
+        )
+
+    def test_pop_all_drains_legacy_then_room(self):
+        session_id = "test_dualread_order"
+        push_steering_message(session_id, "legacy-1", "Tom")
+        self._push_room(self.ROOM_ID, "room-1")
+
+        msgs = pop_all_steering_messages(session_id, room_id=self.ROOM_ID)
+        assert [m["text"] for m in msgs] == ["legacy-1", "room-1"]
+        assert pop_all_steering_messages(session_id, room_id=self.ROOM_ID) == []
+
+    def test_pop_all_without_room_id_is_legacy_only(self):
+        session_id = "test_dualread_legacy_only"
+        push_steering_message(session_id, "legacy-only", "Tom")
+        self._push_room(self.ROOM_ID + "-b", "room-untouched")
+
+        msgs = pop_all_steering_messages(session_id)
+        assert [m["text"] for m in msgs] == ["legacy-only"]
+        # The room key was NOT drained by a room-less pop.
+        msgs = pop_all_steering_messages(session_id, room_id=self.ROOM_ID + "-b")
+        assert [m["text"] for m in msgs] == ["room-untouched"]
+
+    def test_has_and_peek_see_the_room_leg(self):
+        session_id = "test_dualread_haspeek"
+        assert has_steering_messages(session_id, room_id=self.ROOM_ID + "-c") is False
+        self._push_room(self.ROOM_ID + "-c", "room-only")
+        assert has_steering_messages(session_id) is False  # legacy leg empty
+        assert has_steering_messages(session_id, room_id=self.ROOM_ID + "-c") is True
+
+        from agent.steering import peek_steering_messages
+
+        push_steering_message(session_id, "legacy-first", "Tom")
+        peeked = peek_steering_messages(session_id, room_id=self.ROOM_ID + "-c")
+        assert [m["text"] for m in peeked] == ["legacy-first", "room-only"]
+        # Peek is non-destructive on both legs.
+        assert has_steering_messages(session_id, room_id=self.ROOM_ID + "-c") is True
+        clear_steering_queue(session_id, room_id=self.ROOM_ID + "-c")
+
+    def test_clear_clears_both_legs(self):
+        session_id = "test_dualread_clear"
+        push_steering_message(session_id, "legacy", "Tom")
+        self._push_room(self.ROOM_ID + "-d", "room")
+        cleared = clear_steering_queue(session_id, room_id=self.ROOM_ID + "-d")
+        assert cleared == 2
+        assert pop_all_steering_messages(session_id, room_id=self.ROOM_ID + "-d") == []
+
+    @pytest.mark.asyncio
+    async def test_handle_steering_drains_room_leg(self):
+        """The watchdog-hook path participates in the dual-read: a message on
+        the Room key is seen and re-pushed to the legacy list for the worker's
+        turn-boundary drain (writers unchanged — the re-push targets legacy)."""
+        from agent.health_check import _handle_steering
+
+        session_id = "test_dualread_hook"
+        self._push_room(self.ROOM_ID + "-e", "room-steer")
+
+        result = await _handle_steering(session_id, room_id=self.ROOM_ID + "-e")
+        assert result is not None
+        assert result["continue_"] is True
+
+        msgs = pop_all_steering_messages(session_id)
+        assert [m["text"] for m in msgs] == ["room-steer"]
+
+
+class TestAbortSiblingPreservation:
+    """agent/health_check.py abort drain must re-push the abort's siblings
+    (Task 11, issue #2494): a 'stop' message must not destroy the
+    instructions queued alongside it."""
+
+    @pytest.mark.asyncio
+    async def test_abort_repushes_non_abort_siblings(self):
+        from agent.health_check import _handle_steering
+
+        session_id = "test_abort_siblings"
+        push_steering_message(session_id, "do X first", "Tom")
+        push_steering_message(session_id, "stop", "Tom")  # auto-detected abort
+        push_steering_message(session_id, "then do Y", "Tom")
+
+        result = await _handle_steering(session_id)
+        assert result is not None
+        assert "ABORT" in result["hookSpecificOutput"]["additionalContext"]
+
+        remaining = pop_all_steering_messages(session_id)
+        assert {m["text"] for m in remaining} == {"do X first", "then do Y"}, (
+            "abort must not destroy the instructions queued alongside it"
+        )
+
+    @pytest.mark.asyncio
+    async def test_abort_alone_leaves_queue_empty(self):
+        from agent.health_check import _handle_steering
+
+        session_id = "test_abort_alone"
+        push_steering_message(session_id, "stop", "Tom")
+
+        result = await _handle_steering(session_id)
+        assert result is not None
+        assert "ABORT" in result["hookSpecificOutput"]["additionalContext"]
+        assert pop_all_steering_messages(session_id) == []

--- a/tests/unit/test_public_api_contract.py
+++ b/tests/unit/test_public_api_contract.py
@@ -32,7 +32,12 @@ PUBLIC_API_SIGNATURES: dict[tuple[str, str], str] = {
         "(session_id: 'str', text: 'str', sender: 'str', is_abort: 'bool' = False, "
         "target_agent: 'str | None' = None, front: 'bool' = False) -> 'None'"
     ),
-    ("agent.steering", "pop_all_steering_messages"): "(session_id: 'str') -> 'list[dict]'",
+    # room_id added DELIBERATELY (issue #2494 Task 11 phase 1): the steering
+    # dual-read consumer drains the legacy session key first, then the Room
+    # key. Default None preserves every legacy call site.
+    ("agent.steering", "pop_all_steering_messages"): (
+        "(session_id: 'str', room_id: 'str | None' = None) -> 'list[dict]'"
+    ),
     ("tools.doc_impact_finder", "find_affected_docs"): (
         "(change_summary: 'str', top_n: 'int' = 15, repo_root: 'Path | None' = None) "
         "-> 'tuple[list[AffectedDoc], ImpactFinderMeta]'"

--- a/tests/unit/test_room_inbox_shadow.py
+++ b/tests/unit/test_room_inbox_shadow.py
@@ -1,0 +1,128 @@
+"""Shadow-mode durable Room-inbox append (Task 11 phase 1, issue #2494).
+
+Spike-4 cutover checklist phase 1: the durable append is written ALONGSIDE
+the untouched dispatch flow (not authoritative), so production parity can be
+verified before the authoritative cutover ships in a separate release. The
+append must never raise into the live intake path.
+"""
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+from bridge.room_inbox import shadow_append_inbox
+from models.room import Room, telegram_addressee
+
+
+@pytest.fixture
+def scratch_project():
+    key = f"test-inbox-{uuid.uuid4().hex[:8]}"
+    project = {"_key": key, "working_directory": "/tmp/x"}
+    yield project
+    for room in Room.query.filter(project_key=key):
+        room.clear_inbox()
+        room.delete()
+
+
+class TestShadowAppend:
+    def test_appends_message_identity_to_room_inbox(self, scratch_project):
+        chat_id = -100777
+        ok = shadow_append_inbox(
+            scratch_project,
+            chat_id=chat_id,
+            message_id=42,
+            sender_id=7,
+            sender_name="Tom",
+            text="hello room",
+            date=datetime(2026, 8, 7, 12, 0, 0, tzinfo=UTC),
+        )
+        assert ok is True
+
+        room = Room.resolve(scratch_project["_key"], telegram_addressee(chat_id))
+        entries = room.peek_inbox()
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["chat_id"] == str(chat_id)
+        assert entry["message_id"] == 42
+        assert entry["sender_id"] == 7
+        assert entry["sender_name"] == "Tom"
+        assert entry["text"] == "hello room"
+        assert entry["ts"].startswith("2026-08-07T12:00:00")
+
+    def test_dm_and_group_share_the_same_code_path(self, scratch_project):
+        assert shadow_append_inbox(
+            scratch_project,
+            chat_id=4242,
+            message_id=1,
+            sender_id=4242,
+            sender_name="Tom",
+            text="dm",
+            date=datetime.now(UTC),
+        )
+        assert shadow_append_inbox(
+            scratch_project,
+            chat_id=-1004242,
+            message_id=2,
+            sender_id=7,
+            sender_name="Tom",
+            text="group",
+            date=datetime.now(UTC),
+        )
+        rooms = Room.query.filter(project_key=scratch_project["_key"])
+        assert len(rooms) == 2
+
+    def test_never_raises_on_bad_project(self):
+        assert (
+            shadow_append_inbox(
+                None,
+                chat_id=1,
+                message_id=1,
+                sender_id=1,
+                sender_name="x",
+                text="x",
+                date=datetime.now(UTC),
+            )
+            is False
+        )
+        assert (
+            shadow_append_inbox(
+                {},
+                chat_id=1,
+                message_id=1,
+                sender_id=1,
+                sender_name="x",
+                text="x",
+                date=datetime.now(UTC),
+            )
+            is False
+        )
+
+    def test_never_raises_on_resolve_failure(self, scratch_project, monkeypatch):
+        def _boom(*a, **k):
+            raise RuntimeError("redis down")
+
+        monkeypatch.setattr(Room, "resolve", classmethod(lambda cls, *a, **k: _boom()))
+        ok = shadow_append_inbox(
+            scratch_project,
+            chat_id=1,
+            message_id=1,
+            sender_id=1,
+            sender_name="x",
+            text="x",
+            date=datetime.now(UTC),
+        )
+        assert ok is False
+
+
+class TestIntakeWiring:
+    def test_live_intake_calls_the_shadow_append(self):
+        """No correct-logic-dead-caller: the bridge intake actually invokes
+        the shadow append (the notify_sdk_started failure shape this plan
+        exists to prevent)."""
+        import pathlib
+
+        src = (
+            pathlib.Path(__file__).resolve().parents[2] / "bridge" / "telegram_bridge.py"
+        ).read_text(encoding="utf-8")
+        assert "shadow_append_inbox(" in src

--- a/tests/unit/test_room_resolution.py
+++ b/tests/unit/test_room_resolution.py
@@ -1,0 +1,193 @@
+"""Room model + resolution (Task 10, docs/plans/durability-room-job-agentrun.md).
+
+Room = (project_key, addressee), addressee in ``telegram:{chat_id}`` |
+``email:{address}`` | ``system``. KeyField set {project_key, addressee} was
+ratified one-shot by the schema gate; no IndexedField on Room.
+
+These tests hit real Redis (repo convention) under a ``test-`` project-key
+prefix and delete every record via the ORM afterward.
+"""
+
+import json
+import uuid
+
+import pytest
+
+from models.room import (
+    SYSTEM_ADDRESSEE,
+    Room,
+    addressee_for_session,
+    email_addressee,
+    room_id,
+    room_id_for_session,
+    telegram_addressee,
+)
+
+
+@pytest.fixture
+def scratch_project_key():
+    """Unique test- prefixed project key; ORM-scoped cleanup afterward."""
+    key = f"test-room-{uuid.uuid4().hex[:8]}"
+    yield key
+    for room in Room.query.filter(project_key=key):
+        room.delete()
+
+
+class TestAddressees:
+    def test_telegram_addressee_includes_chat_id(self):
+        assert telegram_addressee(-1001234) == "telegram:-1001234"
+        assert telegram_addressee("42") == "telegram:42"
+
+    def test_email_addressee_normalizes_case(self):
+        assert email_addressee("Tom@Yuda.me") == "email:tom@yuda.me"
+
+    def test_system_addressee_constant(self):
+        assert SYSTEM_ADDRESSEE == "system"
+
+    def test_room_id_is_pipe_composite(self):
+        assert room_id("valor", "telegram:42") == "valor|telegram:42"
+
+
+class TestAddresseeForSession:
+    """Sessions map onto a Room via project_key + chat_id shape."""
+
+    class _FakeSession:
+        def __init__(self, project_key=None, chat_id=None):
+            self.project_key = project_key
+            self.chat_id = chat_id
+
+    def test_numeric_chat_id_is_telegram(self):
+        s = self._FakeSession("valor", "-100123")
+        assert addressee_for_session(s) == "telegram:-100123"
+        assert room_id_for_session(s) == "valor|telegram:-100123"
+
+    def test_email_chat_id_is_email(self):
+        s = self._FakeSession("valor", "Tom@Yuda.me")
+        assert addressee_for_session(s) == "email:tom@yuda.me"
+
+    def test_chatless_session_is_system_room(self):
+        # spike-1: every session belongs to a Room; chatless sessions get the
+        # per-project system Room (unifies chat_id="0" / chat_id=session_id /
+        # default-DM inheritance).
+        assert addressee_for_session(self._FakeSession("valor", None)) == SYSTEM_ADDRESSEE
+        # Non-numeric, non-email chat_id (e.g. chat_id=session_id) is system too.
+        assert addressee_for_session(self._FakeSession("valor", "sdlc-local-42")) == (
+            SYSTEM_ADDRESSEE
+        )
+
+    def test_no_project_key_yields_no_room(self):
+        assert room_id_for_session(self._FakeSession(None, "42")) is None
+
+
+class TestRoomResolve:
+    def test_resolve_round_trips_and_is_idempotent(self, scratch_project_key):
+        addressee = telegram_addressee(-100999)
+        room = Room.resolve(scratch_project_key, addressee, display_name="Test Chat")
+        assert room.project_key == scratch_project_key
+        assert room.addressee == addressee
+        assert room.room_id == room_id(scratch_project_key, addressee)
+
+        again = Room.resolve(scratch_project_key, addressee)
+        assert again.room_id == room.room_id
+        assert len(Room.query.filter(project_key=scratch_project_key)) == 1
+
+    def test_dm_and_group_resolve_identically(self, scratch_project_key):
+        """The DM-loss class closer: a private chat is just another Room."""
+        dm = Room.resolve(scratch_project_key, telegram_addressee(4242))
+        group = Room.resolve(scratch_project_key, telegram_addressee(-1004242))
+        assert dm.room_id != group.room_id
+        assert len(Room.query.filter(project_key=scratch_project_key)) == 2
+
+
+class TestRoomInbox:
+    def test_append_and_peek_round_trip(self, scratch_project_key):
+        room = Room.resolve(scratch_project_key, SYSTEM_ADDRESSEE)
+        entry = {"chat_id": "-100999", "message_id": 7, "text": "hello"}
+        room.append_inbox(entry)
+        peeked = room.peek_inbox()
+        assert peeked[-1]["message_id"] == 7
+        assert peeked[-1]["text"] == "hello"
+        room.clear_inbox()
+        assert room.peek_inbox() == []
+
+    def test_inbox_is_capped(self, scratch_project_key, monkeypatch):
+        import models.room as room_mod
+
+        monkeypatch.setattr(room_mod, "ROOM_INBOX_MAX_ENTRIES", 5)
+        room = Room.resolve(scratch_project_key, SYSTEM_ADDRESSEE)
+        for i in range(9):
+            room.append_inbox({"message_id": i})
+        peeked = room.peek_inbox()
+        assert len(peeked) == 5
+        # Newest survive the trim.
+        assert [e["message_id"] for e in peeked] == [4, 5, 6, 7, 8]
+        room.clear_inbox()
+
+    def test_inbox_key_is_companion_of_primary_key(self, scratch_project_key):
+        # "::" companion suffix keeps the inbox out of index-drift hash counts.
+        room = Room.resolve(scratch_project_key, SYSTEM_ADDRESSEE)
+        assert room.inbox_key.endswith("::inbox")
+        room.clear_inbox()
+
+    def test_append_never_raises(self, scratch_project_key, monkeypatch):
+        """Durable-append failures must be loud in logs but never crash intake."""
+        room = Room.resolve(scratch_project_key, SYSTEM_ADDRESSEE)
+        entry_that_cannot_serialize = {"bad": object()}
+        assert room.append_inbox(entry_that_cannot_serialize) is False
+        assert room.append_inbox({"ok": 1}) is True
+        room.clear_inbox()
+
+
+class TestGuardedRepair:
+    """Risk 2: a new model must not re-trigger the #2207 phantom index flood."""
+
+    def test_room_is_guarded_elsewhere(self):
+        from scripts.popoto_index_cleanup import _GUARDED_ELSEWHERE
+
+        assert "Room" in _GUARDED_ELSEWHERE
+
+    def test_generic_sweep_excludes_room(self):
+        from scripts.popoto_index_cleanup import _get_all_models
+
+        names = {m.__name__ for m in _get_all_models()}
+        assert "Room" not in names
+
+    def test_repair_indexes_quarantines_identity_less_hash(self, scratch_project_key):
+        from popoto.redis_db import POPOTO_REDIS_DB
+
+        # Plant an identity-less Room hash (no project_key/addressee) — the
+        # exact shape that, unguarded, gets re-indexed on every rebuild.
+        phantom_key = "Room:None:test-phantom"
+        POPOTO_REDIS_DB.hset(phantom_key, mapping={"display_name": json.dumps("ghost")})
+        try:
+            healthy = Room.resolve(scratch_project_key, SYSTEM_ADDRESSEE)
+            stale, rebuilt = Room.repair_indexes()
+            assert POPOTO_REDIS_DB.exists(phantom_key) == 0, (
+                "identity-less hash must be quarantined, not re-indexed"
+            )
+            # The healthy record survives the rebuild and stays queryable.
+            assert any(
+                r.room_id == healthy.room_id
+                for r in Room.query.filter(project_key=scratch_project_key)
+            )
+            assert isinstance(stale, int) and isinstance(rebuilt, int)
+        finally:
+            POPOTO_REDIS_DB.delete(phantom_key)
+
+
+class TestDriftCoverage:
+    def test_room_registered_in_index_drift(self):
+        from agent.index_drift import covered_model_names
+
+        assert "Room" in covered_model_names()
+
+    def test_room_drift_reconciles_clean(self, scratch_project_key):
+        from agent.index_drift import DRIFT_COVERED_MODELS, reconcile_model_index
+
+        Room.resolve(scratch_project_key, SYSTEM_ADDRESSEE)
+        hash_count, queryable, drifted, truncated = reconcile_model_index(
+            DRIFT_COVERED_MODELS["Room"]
+        )
+        if not truncated:
+            assert drifted is False
+            assert hash_count == queryable

--- a/tools/valor_session.py
+++ b/tools/valor_session.py
@@ -1026,8 +1026,11 @@ def cmd_status(args: argparse.Namespace) -> int:
         full_message = getattr(args, "full_message", False)
 
         from agent.steering import peek_steering_messages
+        from models.room import room_id_for_session
 
-        pending_steering = peek_steering_messages(session.session_id)
+        pending_steering = peek_steering_messages(
+            session.session_id, room_id=room_id_for_session(session)
+        )
 
         # Check worker health when session is pending (compute gate avoids the
         # git subprocess on every status call; non-pending emits null fields)


### PR DESCRIPTION
Milestone 2 of the durability plan (`docs/plans/durability-room-job-agentrun.md`): Tasks 10-12. The issue stays open for Milestone 3.

Refs #2494

## Milestone summary

**Task 10 — Room model + resolution + DM recovery coverage**
- New `models/room.py`: `Room = (project_key, addressee)`, addressee in `telegram:{chat_id}` | `email:{address}` | `system`, per the ratified schema-gate KeyField set. Zero IndexedFields (load-bearing for Risk 2). Durable cap-bounded `::inbox` companion list, `addressee_for_session` / `room_id_for_session` helpers (chatless sessions map to the per-project `system` Room; email `chat_id` maps to `email:`).
- Guarded repair path: `Room.repair_indexes()` quarantines identity-less hashes before any rebuild; `Room` added to `_GUARDED_ELSEWHERE` in `scripts/popoto_index_cleanup.py` (the #2207 flood-prevention mechanism) and the daily cleanup sweep invokes the guarded path via `_run_guarded_repairs()`. Registered in `agent/index_drift.py` coverage (Risk 3).
- The DM loss class is closed: all three recovery scanners (`bridge/reconciler.py`, `bridge/catchup.py`, `bridge/agent_catchup.py`) plus the dedup seed pass now iterate Rooms, not just titled dialogs. `if not chat_title: continue` is removed from `bridge/` entirely (verification row green). Title-less dialogs resolve via `bridge/routing.py::find_project_for_dm_dialog` (DM-whitelist-gated; bots and self never scan). Dispatch parity with the live handler: `is_dm=True`, `is_private=True`, `chat_title=None`.
- Newly-covered DM Rooms initialize their scanner cursor at "now" (`bridge:dm_coverage_epoch:{chat_id}`, SET NX, no TTL): the first covered pass skips, and every later lookback is clamped to the epoch, so pre-coverage DM history is never replayed as "recovered" messages — including under catchup's 24h lookback override.

**Task 11 — Room-owned inbox, phase 1 (dual-read + shadow append)**
- `agent/steering.py`: Room-scoped key `steering:room:{room_id}` added as a **drain-only dual-read leg** — every consumer (runner turn-boundary pop, pickup startup drain, executor turn-input + leftover re-enqueue, watchdog hook, `valor-session status` peek) drains the legacy session key first, then the Room key. **No writer targets the Room key in this PR.** Public-API snapshot updated deliberately.
- Abort-sibling fix (`agent/health_check.py`): a "stop" message no longer destroys the instructions queued alongside it — non-abort siblings are re-pushed before the abort directive returns.
- Shadow-mode durable Room-inbox append (`bridge/room_inbox.py`, wired into the intake handler after project resolution): written alongside the untouched dispatch flow, **not authoritative**, never raises into intake, cap-bounded (`ROOM_INBOX_MAX_ENTRIES`, provisional 1000, env-overridable) because nothing drains it during shadow. This is phase 1 of the spike-4 3-phase cutover checklist.

**Task 12 — Validation**
- 382 targeted tests passed via `scripts/pytest-clean.sh` across every touched suite (Room resolution 19, shadow inbox 5, DM recovery 10, steering 66, scanners/dedup/routing/watchdog/index the rest). Ruff check + format clean repo-wide.
- Verification rows green: `_GUARDED_ELSEWHERE` contains literal `Room`; `agent/index_drift.py` covers `Room`; `grep 'if not chat_title' bridge/` = 0; no `Relationship(` in models; no IndexedField declared on `Room`.

## Ordering constraint honored (plan line ~358)

The steering **writer flip is deliberately NOT in this PR**. The plan mandates the dual-read consumer reach every machine before any writer flips, and that the two never ship in the same release. The flip, when its release comes, is a single change in `agent/steering.py::push_steering_message`: resolve the target session's `room_id` (via `models.room.room_id_for_session`) and `RPUSH` to `_room_queue_key(room_id)` instead of `_queue_key(session_id)` (mid-turn injection delivery via the watchdog hook already dual-reads). Same applies to `_repush_messages` in `agent/health_check.py` and the runner's `_default_steering_push`.

## Catchup re-enable (operator step — NOT performed by this PR)

`data/catchup-disabled` has been set since 2026-07-22 (pending #2204). Everything needed for DM recovery validation is now in place; the flip itself belongs to the operator:

1. Confirm `/update` has run on the owning machine so the bridge/worker run this branch's merge commit (the dual-read consumer and DM epoch code must be live BEFORE recovery scans resume).
2. Re-enable: `rm data/catchup-disabled` on the owning machine (coordinate with #2204's scoping first).
3. What to watch:
   - `logs/bridge.log` for `DM coverage epoch initialized at ... skipping scan this pass` — expected exactly once per whitelisted DM chat on the first scan; **no** `catchup.re_enqueue` lines for historical DM message ids should follow.
   - `catchup.re_enqueue` / `[reconciler] Recovered` counters — a spike in `re_enqueued` with large `age_s` values indicates history replay; re-set the flag (`touch data/catchup-disabled`) if seen.
   - `python -m tools.doctor` — the stale-kill-switch WARN (#2611, merged today) clears once the flag is removed; while the flag exists past 24h it alarms, which is the desired pressure.
   - Catchup now uses the shared paged/bounded fetch (#2613), so deep scans are capped by `CATCHUP_MAX_MESSAGES_PER_CHAT` and WARN on truncation.

## Deviations from the plan (with reasons)

- **Phantom-guard / pending-index-leak test extension**: the plan's Test Impact list says those two suites "extend to Room and Job". Both suites pin AgentSession's IndexedField-shim mechanics; Room declares zero IndexedFields, so the equivalent Room guarantees are pinned in `tests/unit/test_room_resolution.py` (`TestGuardedRepair`: identity-less hash quarantined, healthy record survives, generic sweep excludes Room; `TestDriftCoverage`) instead of duplicating AgentSession-specific scaffolding. Job's extension lands with Job in M3.
- **Three null-guard `if not chat_title` occurrences** outside the scanners (`routing.py` x2, `silent_stream.py`) were reworded to explicit `is None` forms with unchanged semantics so the plan's literal verification grep proves the *loss filter* is gone; `bridge/dedup_seed.py` got a real DM branch (it documents "the seed covers exactly the chats the scanners cover").
- **`dedup_seed` DM coverage** was not named by Task 10 but is required by that module's own contract once scanners cover DMs.

## Pre-existing failures on main (not this PR)

`tests/integration/test_steering.py::TestResolveRootSessionId::{test_fresh_session_non_valor_reply_timeout_falls_back, test_reply_chain_fetch_failure_falls_back[fresh_session_non_valor-FRESH_REPLY_CHAIN_FAIL]}` assert source literals (`timeout=3.0`, `extra_overrides: dict | None = None`) that are absent from `bridge/telegram_bridge.py` on **origin/main** as of `02dfc3a39` (verified via `git show origin/main:...`). Likely broken by today's #2610/#2613 landings; needs its own fix.

## Do not merge

Per the milestone instructions this PR is left open for review; M2 is independently shippable and gated on PM review before M3 (Task 13+).

Closes #2626