### PR TITLE
Clear PYTEST_XDIST_WORKER in the db-claim tests' reset helper (residual of #2605)

### DIFF
--- a/tests/unit/test_conftest_isolation_guards.py
+++ b/tests/unit/test_conftest_isolation_guards.py
@@ -473,7 +473,13 @@ class TestPerProcessDbClaim:
     def _reset_claim_state(monkeypatch, tmp_path, *, pool_max: int | None = None):
         """Point the claim registry at ``tmp_path`` and start from an unclaimed
         state, tracking test-opened fds so ``finally`` can close only them.
+
+        ``PYTEST_XDIST_WORKER`` is cleared so the claim's legacy fallback is the
+        deterministic master branch (db1) rather than whatever worker this file
+        happens to land on under ``-n auto``. A test that wants a specific
+        worker id sets it back explicitly.
         """
+        monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
         monkeypatch.setattr(_db_claim, "_test_db_claim_dir", lambda: str(tmp_path))
         monkeypatch.setattr(_db_claim, "_CLAIMED_TEST_DB", None, raising=False)
         fresh_fds: list[int] = []


### PR DESCRIPTION
Refs #2605

The residual of #2606. That PR changed the db claim's legacy fallback to read the worker id from the environment (`tests/db_claim.py::_legacy_test_db_num`) instead of a pytest `request` object. The matching test-side adjustment was pushed after the merge landed, so it never made it.

`TestPerProcessDbClaim._reset_claim_state` no longer neutralizes the worker id, so a test exercising the fallback inherits whichever worker it lands on under `-n auto`. `test_dead_holder_slot_is_reclaimed` asserts the master→db1 branch and gets db4 while running as `gw3`.

## Reproduction on current main

```
$ PYTEST_XDIST_WORKER=gw3 scripts/pytest-clean.sh -q -n0 -p no:randomly \
    tests/unit/test_conftest_isolation_guards.py
E   assert 4 == 1
E    +  where 4 = claim_test_db()
WARNING  tests.db_claim: all 1 test-DB slots held by live processes;
         falling back to legacy db=4 (may collide with a concurrent process)
FAILED ...::TestPerProcessDbClaim::test_dead_holder_slot_is_reclaimed
1 failed, 14 passed
```

It also failed in a full randomized `tests/unit/` run on clean `main` and passed when the file ran alone — the exact false-signal shape #2603 and #2605 were about.

## Fix

Clear `PYTEST_XDIST_WORKER` in the shared reset helper, so the fallback is the deterministic master branch. The one test that wants a specific worker id, `test_pool_exhaustion_falls_back_with_warning`, already sets it explicitly afterwards, so its `gw3 → db4` assertion is unaffected.

## Verification

| Condition | Result |
|---|---|
| `PYTEST_XDIST_WORKER=gw3`, the repro condition | **15 passed** |
| real `-n auto` | **15 passed** |

The mutation check is the reproduction itself: the fix is one line, and removing it puts the failure back deterministically under the command above.

Closes #2630
