### PR TITLE
Doctor: flag console scripts that resolve outside the repo venv

### DIFF
--- a/tests/unit/test_doctor_console_scripts.py
+++ b/tests/unit/test_doctor_console_scripts.py
@@ -198,6 +198,64 @@ class TestDeclaredButNotInstalled:
         assert result.fix and "uv sync" not in result.fix
 
 
+class TestShimmedAndNeverInstalled:
+    """The sub-state where both problems land on the same name.
+
+    Every other fixture shims a name that `_fake_checkout` also installs, so
+    "resolves to a stale shim AND was never built into the venv" was never
+    constructed — and the not-installed tagging on that branch could be
+    stripped with the suite still green.
+
+    It is not exotic: pull a branch that adds a `[project.scripts]` entry, skip
+    the sync, and if a stale user-site directory happens to carry that name you
+    are in exactly this state. Telling the operator only to reorder PATH would
+    leave them with a name that still does not exist.
+    """
+
+    def _checkout_with_a_declared_but_unbuilt_name(self, tmp_path):
+        root = _fake_checkout(tmp_path)
+        (root / "pyproject.toml").write_text(
+            (root / "pyproject.toml").read_text() + 'never-installed = "tools.never:main"\n'
+        )
+        return root
+
+    def test_shimmed_absent_name_is_tagged_not_installed(self, tmp_path, monkeypatch):
+        root = self._checkout_with_a_declared_but_unbuilt_name(tmp_path)
+        # The shim carries the one name the venv does NOT have.
+        shims = _stale_shim_dir(tmp_path, ("never-installed",))
+        result = _run(root, [shims, root / ".venv" / "bin"], monkeypatch)
+
+        assert result.passed is False
+        assert "1/4" in result.message
+        assert "never-installed" in result.message
+        assert "not installed in the repo venv" in result.message, (
+            "resolving to a shim does not make the name present in the venv"
+        )
+        assert str(shims) in result.message, "the operator still needs to know what won"
+
+    def test_fix_names_uv_sync_for_a_shimmed_absent_name(self, tmp_path, monkeypatch):
+        root = self._checkout_with_a_declared_but_unbuilt_name(tmp_path)
+        shims = _stale_shim_dir(tmp_path, ("never-installed",))
+        result = _run(root, [shims, root / ".venv" / "bin"], monkeypatch)
+
+        assert result.fix
+        assert "uv sync" in result.fix, "PATH advice alone leaves the name non-existent"
+        assert "never-installed" in result.fix
+
+    def test_mixed_host_aggregate_suffix_counts_the_absent_names(self, tmp_path, monkeypatch):
+        """One genuinely shadowed name plus one shimmed-and-absent name."""
+        root = self._checkout_with_a_declared_but_unbuilt_name(tmp_path)
+        shims = _stale_shim_dir(tmp_path, ("critique-roster-check", "never-installed"))
+        result = _run(root, [shims, root / ".venv" / "bin"], monkeypatch)
+
+        assert "2/4" in result.message
+        assert "shadowed" in result.message
+        assert "1 also not installed in the venv" in result.message, (
+            "the aggregate suffix must count the absent names, not just mention them"
+        )
+        assert result.fix and "export PATH" in result.fix and "uv sync" in result.fix
+
+
 class TestRegisteredInDoctor:
     def test_check_is_registered_before_system_tools(self):
         """`_check_system_tools` imports verify.py, which prepends the stale dir."""

--- a/tests/unit/test_doctor_console_scripts.py
+++ b/tests/unit/test_doctor_console_scripts.py
@@ -255,6 +255,34 @@ class TestShimmedAndNeverInstalled:
         )
         assert result.fix and "export PATH" in result.fix and "uv sync" in result.fix
 
+    def test_fix_signals_omission_when_more_than_five_names_are_not_installed(
+        self, tmp_path, monkeypatch
+    ):
+        """The `fix` string truncates the not-installed list at 5; it must say so.
+
+        `message` already appends `(+N more)` on truncation (see
+        `test_truncates_a_long_failure_list`); the `fix` string's own
+        `uv sync` remediation list truncated silently, so an operator who
+        installed exactly the five named entries and re-ran would still have
+        unnamed broken scripts.
+        """
+        names = tuple(f"valor-tool-{i}" for i in range(9))
+        root = _fake_checkout(tmp_path, names=())
+        (root / "pyproject.toml").write_text(
+            (root / "pyproject.toml").read_text()
+            + "\n".join(f'{n} = "tools.{n.replace("-", "_")}:main"' for n in names)
+            + "\n"
+        )
+        result = _run(root, [root / ".venv" / "bin", Path("/usr/bin")], monkeypatch)
+
+        assert result.passed is False
+        assert result.fix
+        assert "uv sync" in result.fix
+        assert "(+4 more)" in result.fix, (
+            "9 not-installed names, 5 shown -- the remaining 4 must be signaled, "
+            "not silently dropped"
+        )
+
 
 class TestRegisteredInDoctor:
     def test_check_is_registered_before_system_tools(self):

--- a/tests/unit/test_doctor_console_scripts.py
+++ b/tests/unit/test_doctor_console_scripts.py
@@ -137,6 +137,67 @@ class TestConsoleScriptsResolve:
         assert "no [project.scripts]" in result.message
 
 
+class TestDeclaredButNotInstalled:
+    """The third state: venv on PATH, nothing shadowing, name simply absent.
+
+    This is the routine one — a teammate pulls a new `[project.scripts]` entry
+    and has not re-synced — and it used to be reported as "shadowed" with a
+    remediation (reorder PATH) that was already satisfied.
+    """
+
+    def test_absent_name_is_not_called_shadowed(self, tmp_path, monkeypatch):
+        root = _fake_checkout(tmp_path)
+        # Declared in pyproject but never built into .venv/bin.
+        (root / "pyproject.toml").write_text(
+            (root / "pyproject.toml").read_text() + 'never-installed = "tools.never:main"\n'
+        )
+        result = _run(root, [root / ".venv" / "bin", Path("/usr/bin")], monkeypatch)
+
+        assert result.passed is False
+        assert "1/4" in result.message
+        assert "not installed" in result.message
+        assert "shadowed" not in result.message, "PATH is already correct; nothing shadows it"
+        assert "never-installed" in result.message
+
+    def test_fix_points_at_uv_sync_not_at_path(self, tmp_path, monkeypatch):
+        root = _fake_checkout(tmp_path)
+        (root / "pyproject.toml").write_text(
+            (root / "pyproject.toml").read_text() + 'never-installed = "tools.never:main"\n'
+        )
+        result = _run(root, [root / ".venv" / "bin", Path("/usr/bin")], monkeypatch)
+
+        assert result.fix
+        assert "uv sync" in result.fix
+        assert "export PATH" not in result.fix, "advising a PATH reorder that is already done"
+        assert "never-installed" in result.fix
+
+    def test_mixed_shadowed_and_absent_reports_both_remedies(self, tmp_path, monkeypatch):
+        """A host can have both problems; the fix must not name only one."""
+        root = _fake_checkout(tmp_path)
+        (root / "pyproject.toml").write_text(
+            (root / "pyproject.toml").read_text() + 'never-installed = "tools.never:main"\n'
+        )
+        shims = _stale_shim_dir(tmp_path, ("critique-roster-check",))
+        result = _run(root, [shims, root / ".venv" / "bin"], monkeypatch)
+
+        assert result.passed is False
+        assert "2/4" in result.message
+        assert "shadowed" in result.message
+        assert "not installed" in result.message
+        assert result.fix
+        assert "export PATH" in result.fix and "uv sync" in result.fix
+
+    def test_a_shadowed_name_still_reads_as_shadowed(self, tmp_path, monkeypatch):
+        """Control: the not-installed branch must not swallow the real thing."""
+        root = _fake_checkout(tmp_path)
+        shims = _stale_shim_dir(tmp_path, ("critique-roster-check",))
+        result = _run(root, [shims, root / ".venv" / "bin"], monkeypatch)
+
+        assert "shadowed" in result.message
+        assert "not installed" not in result.message
+        assert result.fix and "uv sync" not in result.fix
+
+
 class TestRegisteredInDoctor:
     def test_check_is_registered_before_system_tools(self):
         """`_check_system_tools` imports verify.py, which prepends the stale dir."""

--- a/tests/unit/test_doctor_console_scripts.py
+++ b/tests/unit/test_doctor_console_scripts.py
@@ -1,0 +1,148 @@
+"""Tests for doctor's `[project.scripts]` PATH-resolution check (#2566).
+
+The defect these guard is pure host state: `.venv/bin` missing from PATH while
+a stale `~/Library/Python/3.12/bin` sits on it holding shims for a system
+interpreter with no editable install of this repo. Two of the three SDLC entry
+points resolved to those shims and died with `ModuleNotFoundError`; the third
+had no shim and failed as `command not found`. Both shapes are simulated here
+with real files and a real PATH, because a check that only ever sees a healthy
+machine proves nothing.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
+from tools.doctor import _check_console_scripts_resolve
+
+SCRIPTS = ("critique-roster-check", "critique-resume-probe", "sdlc-push-guard")
+
+
+def _executable(path: Path, body: str = "#!/bin/sh\nexit 0\n") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+def _fake_checkout(tmp_path: Path, names: tuple[str, ...] = SCRIPTS) -> Path:
+    """A checkout with a `[project.scripts]` table and a populated `.venv/bin`."""
+    root = tmp_path / "repo"
+    (root / ".git").mkdir(parents=True)
+    table = "\n".join(f'{n} = "tools.{n.replace("-", "_")}:main"' for n in names)
+    (root / "pyproject.toml").write_text(f'[project]\nname = "x"\n\n[project.scripts]\n{table}\n')
+    for name in names:
+        _executable(root / ".venv" / "bin" / name)
+    return root
+
+
+def _stale_shim_dir(tmp_path: Path, names: tuple[str, ...]) -> Path:
+    """Stand-in for `~/Library/Python/3.12/bin` — shims for a foreign interpreter."""
+    shim_dir = tmp_path / "Library" / "Python" / "3.12" / "bin"
+    for name in names:
+        _executable(shim_dir / name, "#!/usr/bin/python3\nraise SystemExit(1)\n")
+    return shim_dir
+
+
+def _run(root: Path, path_entries: list[Path], monkeypatch):
+    monkeypatch.setenv("PATH", os.pathsep.join(str(p) for p in path_entries))
+    with patch("tools.doctor.PROJECT_DIR", root):
+        return _check_console_scripts_resolve()
+
+
+class TestConsoleScriptsResolve:
+    def test_passes_when_venv_bin_leads_path(self, tmp_path, monkeypatch):
+        root = _fake_checkout(tmp_path)
+        result = _run(root, [root / ".venv" / "bin", Path("/usr/bin")], monkeypatch)
+        assert result.passed is True, result.message
+        assert "3 console scripts" in result.message
+        assert str(root / ".venv" / "bin") in result.message
+
+    def test_stale_shim_ahead_of_venv_is_caught(self, tmp_path, monkeypatch):
+        """The `valorengels` shape: venv on PATH, but shadowed for two names."""
+        root = _fake_checkout(tmp_path)
+        shims = _stale_shim_dir(tmp_path, ("critique-roster-check", "critique-resume-probe"))
+        result = _run(root, [shims, root / ".venv" / "bin"], monkeypatch)
+        assert result.passed is False
+        assert "2/3" in result.message
+        assert "critique-roster-check" in result.message
+        assert str(shims) in result.message
+        assert "shadowed" in result.message
+        assert result.fix and str(root / ".venv" / "bin") in result.fix
+
+    def test_venv_absent_from_path_reports_both_failure_shapes(self, tmp_path, monkeypatch):
+        """The `MacBookPro.local` shape: shims for two names, nothing for the third."""
+        root = _fake_checkout(tmp_path)
+        shims = _stale_shim_dir(tmp_path, ("critique-roster-check", "critique-resume-probe"))
+        result = _run(root, [shims, tmp_path / "empty"], monkeypatch)
+        assert result.passed is False
+        assert "3/3" in result.message
+        assert "not on PATH" in result.message
+        # ModuleNotFoundError shape and command-not-found shape, both named.
+        assert f"critique-roster-check -> {shims / 'critique-roster-check'}" in result.message
+        assert "sdlc-push-guard -> not found" in result.message
+
+    def test_nothing_on_path_at_all_fails(self, tmp_path, monkeypatch):
+        root = _fake_checkout(tmp_path)
+        result = _run(root, [tmp_path / "empty"], monkeypatch)
+        assert result.passed is False
+        assert "not found" in result.message
+
+    def test_hardlinked_copy_outside_the_venv_is_accepted(self, tmp_path, monkeypatch):
+        """`/update` hardlinks entry points into ~/.local/bin — not a wrong copy."""
+        root = _fake_checkout(tmp_path, names=("sdlc-push-guard",))
+        local_bin = tmp_path / "local" / "bin"
+        local_bin.mkdir(parents=True)
+        os.link(root / ".venv" / "bin" / "sdlc-push-guard", local_bin / "sdlc-push-guard")
+        result = _run(root, [local_bin, root / ".venv" / "bin"], monkeypatch)
+        assert result.passed is True, result.message
+
+    def test_main_checkout_venv_accepted_from_a_worktree(self, tmp_path, monkeypatch):
+        """Doctor often runs from a worktree whose lane uses the main venv."""
+        root = _fake_checkout(tmp_path)
+        worktree = root / ".worktrees" / "lane-a"
+        worktree.mkdir(parents=True)
+        (worktree / ".git").write_text(f"gitdir: {root / '.git' / 'worktrees' / 'lane-a'}\n")
+        (worktree / "pyproject.toml").write_text((root / "pyproject.toml").read_text())
+        result = _run(worktree, [root / ".venv" / "bin"], monkeypatch)
+        assert result.passed is True, result.message
+        # The pass message names where they actually resolved (the main venv),
+        # not the worktree's own bin that nothing on PATH points at.
+        assert str(root / ".venv" / "bin") in result.message
+        assert str(worktree / ".venv" / "bin") not in result.message
+
+    def test_truncates_a_long_failure_list(self, tmp_path, monkeypatch):
+        names = tuple(f"valor-tool-{i}" for i in range(9))
+        root = _fake_checkout(tmp_path, names=names)
+        result = _run(root, [tmp_path / "empty"], monkeypatch)
+        assert result.passed is False
+        assert "+4 more" in result.message
+
+    def test_unreadable_pyproject_fails(self, tmp_path, monkeypatch):
+        root = tmp_path / "repo"
+        root.mkdir()
+        result = _run(root, [tmp_path / "empty"], monkeypatch)
+        assert result.passed is False
+        assert "could not read" in result.message
+
+    def test_empty_scripts_table_fails(self, tmp_path, monkeypatch):
+        root = tmp_path / "repo"
+        root.mkdir()
+        (root / "pyproject.toml").write_text('[project]\nname = "x"\n')
+        result = _run(root, [tmp_path / "empty"], monkeypatch)
+        assert result.passed is False
+        assert "no [project.scripts]" in result.message
+
+
+class TestRegisteredInDoctor:
+    def test_check_is_registered_before_system_tools(self):
+        """`_check_system_tools` imports verify.py, which prepends the stale dir."""
+        from tools.doctor import _check_console_scripts_resolve as check
+        from tools.doctor import _check_system_tools, get_checks
+
+        checks = get_checks()
+        assert check in checks
+        assert checks.index(check) < checks.index(_check_system_tools)

--- a/tools/doctor.py
+++ b/tools/doctor.py
@@ -156,19 +156,25 @@ def _check_console_scripts_resolve() -> CheckResult:
     name resolves to is therefore load-bearing, and it is pure host state that
     no amount of correct packaging can guarantee.
 
-    Two live failure modes, both observed on other machines in #2566:
+    Three failure modes, with three different remedies:
 
     * `.venv/bin` is absent from PATH while a stale `~/Library/Python/3.12/bin`
       is present. The stale directory holds shims for a *system* interpreter
       with no editable install of this repo, so the name resolves, runs, and
-      dies with `ModuleNotFoundError: No module named 'tools'`.
+      dies with `ModuleNotFoundError: No module named 'tools'`. Observed on
+      another machine in #2566.
     * The same PATH with no stale shim for a given name, which surfaces as
-      `command not found` (exit 127) instead.
+      `command not found` (exit 127) instead. Also #2566.
+    * The venv leads PATH and nothing shadows it, but the name was never
+      installed into it — someone added a `[project.scripts]` entry and the
+      puller has not re-synced. The remedy is `uv sync`, and reporting this as
+      "shadowed" sends an operator to reorder a PATH that is already correct.
 
     Deleting stale shims only converts the first shape into the second, so the
     check measures resolution rather than shim hygiene: a name is healthy when
     it resolves into a repo venv bin directory, and unhealthy when it resolves
-    anywhere else or nowhere at all.
+    anywhere else or nowhere at all. Distinguishing the third shape from the
+    first two is what `_installed_in_venv` is for.
 
     Ordering note: this runs before `_check_system_tools`, whose
     `scripts.update.verify` import prepends `~/Library/Python/3.12/bin` to
@@ -207,12 +213,26 @@ def _check_console_scripts_resolve() -> CheckResult:
     }
     on_path = [d for d in venv_bins if os.path.realpath(d) in path_entries]
 
+    def _installed_in_venv(script_name: str) -> bool:
+        """Does a repo venv bin dir actually carry this entry point?
+
+        This is what separates "something else is winning the PATH race" from
+        "nothing was ever built to win it". Both produce an unresolvable bare
+        name, and they have opposite remedies.
+        """
+        return any((bin_dir / script_name).exists() for bin_dir in venv_bins)
+
     misresolved: list[str] = []
+    not_installed: list[str] = []
     resolved_into: list[str] = []
     for name in sorted(scripts):
         found = shutil.which(name)
         if found is None:
-            misresolved.append(f"{name} -> not found")
+            if _installed_in_venv(name):
+                misresolved.append(f"{name} -> not found")
+            else:
+                not_installed.append(name)
+                misresolved.append(f"{name} -> not installed in the repo venv")
             continue
         found_path = Path(found)
         match = next(
@@ -226,7 +246,11 @@ def _check_console_scripts_resolve() -> CheckResult:
             None,
         )
         if match is None:
-            misresolved.append(f"{name} -> {found}")
+            if not _installed_in_venv(name):
+                not_installed.append(name)
+                misresolved.append(f"{name} -> {found} (not installed in the repo venv)")
+            else:
+                misresolved.append(f"{name} -> {found}")
         elif str(match) not in resolved_into:
             resolved_into.append(str(match))
 
@@ -237,11 +261,34 @@ def _check_console_scripts_resolve() -> CheckResult:
         suffix = (
             f" (+{len(misresolved) - len(shown)} more)" if len(misresolved) > len(shown) else ""
         )
-        path_note = (
-            f"{primary} is not on PATH"
-            if not on_path
-            else f"{on_path[0]} is on PATH but is shadowed"
-        )
+        # Three states, not two. A name can lose the PATH race, or never have
+        # been built to enter it. Collapsing the second into "shadowed" tells
+        # an operator to reorder a PATH that is already correct — and that is
+        # the likeliest case from here on, since it is what a teammate hits
+        # after pulling a new [project.scripts] entry without re-syncing.
+        a_path_problem = len(not_installed) < len(misresolved)
+        if not a_path_problem:
+            path_note = f"{len(not_installed)} declared but not installed in {primary}"
+        elif not on_path:
+            path_note = f"{primary} is not on PATH"
+        else:
+            path_note = f"{on_path[0]} is on PATH but is shadowed"
+        if a_path_problem and not_installed:
+            path_note += f"; {len(not_installed)} also not installed in the venv"
+
+        fixes = []
+        if a_path_problem:
+            fixes.append(
+                f'Put the repo venv first on PATH: export PATH="{primary}:$PATH" '
+                "(persist it in your shell profile). Any stale shim in an earlier "
+                "directory becomes unreachable."
+            )
+        if not_installed:
+            fixes.append(
+                f"Install the missing entry point(s) with `uv sync` in {PROJECT_DIR} "
+                f"(or `uv pip install -e .`): {', '.join(sorted(not_installed)[:5])}."
+            )
+
         return CheckResult(
             name="console_scripts_resolve",
             category="Environment",
@@ -251,11 +298,7 @@ def _check_console_scripts_resolve() -> CheckResult:
                 f"repo venv — {path_note}; bare-name callers run the wrong copy or nothing "
                 f"at all (#2566): {'; '.join(shown)}{suffix}"
             ),
-            fix=(
-                f'Put the repo venv first on PATH: export PATH="{primary}:$PATH" '
-                "(persist it in your shell profile), then re-run. Any stale shim in an "
-                "earlier directory becomes unreachable."
-            ),
+            fix=" ".join(fixes) + " Then re-run.",
         )
 
     return CheckResult(

--- a/tools/doctor.py
+++ b/tools/doctor.py
@@ -284,9 +284,17 @@ def _check_console_scripts_resolve() -> CheckResult:
                 "directory becomes unreachable."
             )
         if not_installed:
+            not_installed_sorted = sorted(not_installed)
+            shown_not_installed = not_installed_sorted[:5]
+            not_installed_suffix = (
+                f" (+{len(not_installed_sorted) - len(shown_not_installed)} more)"
+                if len(not_installed_sorted) > len(shown_not_installed)
+                else ""
+            )
             fixes.append(
                 f"Install the missing entry point(s) with `uv sync` in {PROJECT_DIR} "
-                f"(or `uv pip install -e .`): {', '.join(sorted(not_installed)[:5])}."
+                f"(or `uv pip install -e .`): {', '.join(shown_not_installed)}"
+                f"{not_installed_suffix}."
             )
 
         return CheckResult(

--- a/tools/doctor.py
+++ b/tools/doctor.py
@@ -105,6 +105,167 @@ def _check_venv() -> CheckResult:
     )
 
 
+def _repo_venv_bin_dirs() -> list[Path]:
+    """Bin directories whose console scripts legitimately run this repo's code.
+
+    The current checkout's ``.venv/bin`` always counts. The main checkout's is
+    added too, because doctor frequently runs from a worktree whose lane still
+    invokes the tools installed by the main checkout.
+    """
+    candidates = [PROJECT_DIR / ".venv" / "bin"]
+    try:
+        from agent.worktree_manager import main_checkout_venv
+
+        main_venv = main_checkout_venv(PROJECT_DIR)
+        if main_venv is not None:
+            candidates.append(main_venv / "bin")
+    except Exception:  # noqa: S110 -- the current checkout's venv is enough on its own
+        pass
+
+    seen: set[str] = set()
+    ordered: list[Path] = []
+    for candidate in candidates:
+        try:
+            key = str(candidate.resolve())
+        except OSError:
+            continue
+        if key not in seen:
+            seen.add(key)
+            ordered.append(candidate)
+    return ordered
+
+
+def _same_file(a: Path, b: Path) -> bool:
+    """True when two paths are the same file, including via a hardlink.
+
+    `/update` hardlinks some entry points into `~/.local/bin`, so an on-PATH
+    copy outside the venv is not automatically the wrong copy.
+    """
+    try:
+        return a.samefile(b)
+    except OSError:
+        return False
+
+
+def _check_console_scripts_resolve() -> CheckResult:
+    """Check every `[project.scripts]` name resolves into this repo's venv (#2566).
+
+    Skills, hooks, and SDLC addenda invoke these entry points by bare name:
+    `critique-roster-check`, `critique-resume-probe`, and `sdlc-push-guard` are
+    all called that way, and the first two are fail-closed *gates*. What the
+    name resolves to is therefore load-bearing, and it is pure host state that
+    no amount of correct packaging can guarantee.
+
+    Two live failure modes, both observed on other machines in #2566:
+
+    * `.venv/bin` is absent from PATH while a stale `~/Library/Python/3.12/bin`
+      is present. The stale directory holds shims for a *system* interpreter
+      with no editable install of this repo, so the name resolves, runs, and
+      dies with `ModuleNotFoundError: No module named 'tools'`.
+    * The same PATH with no stale shim for a given name, which surfaces as
+      `command not found` (exit 127) instead.
+
+    Deleting stale shims only converts the first shape into the second, so the
+    check measures resolution rather than shim hygiene: a name is healthy when
+    it resolves into a repo venv bin directory, and unhealthy when it resolves
+    anywhere else or nowhere at all.
+
+    Ordering note: this runs before `_check_system_tools`, whose
+    `scripts.update.verify` import prepends `~/Library/Python/3.12/bin` to
+    `os.environ["PATH"]`. Measuring first keeps the reported resolution the one
+    a shell would actually get.
+    """
+    import shutil
+    import tomllib
+
+    pyproject = PROJECT_DIR / "pyproject.toml"
+    try:
+        scripts = tomllib.loads(pyproject.read_text()).get("project", {}).get("scripts", {})
+    except (OSError, ValueError) as e:
+        return CheckResult(
+            name="console_scripts_resolve",
+            category="Environment",
+            passed=False,
+            message=f"could not read [project.scripts] from {pyproject}: {e}",
+            fix="Repair pyproject.toml",
+        )
+
+    if not scripts:
+        return CheckResult(
+            name="console_scripts_resolve",
+            category="Environment",
+            passed=False,
+            message="pyproject.toml declares no [project.scripts] entry points",
+            fix="Restore the [project.scripts] table in pyproject.toml",
+        )
+
+    venv_bins = _repo_venv_bin_dirs()
+    path_entries = {
+        os.path.realpath(os.path.expanduser(p))
+        for p in os.environ.get("PATH", "").split(os.pathsep)
+        if p
+    }
+    on_path = [d for d in venv_bins if os.path.realpath(d) in path_entries]
+
+    misresolved: list[str] = []
+    resolved_into: list[str] = []
+    for name in sorted(scripts):
+        found = shutil.which(name)
+        if found is None:
+            misresolved.append(f"{name} -> not found")
+            continue
+        found_path = Path(found)
+        match = next(
+            (
+                bin_dir
+                for bin_dir in venv_bins
+                if found_path.parent == bin_dir
+                or os.path.realpath(found_path.parent) == os.path.realpath(bin_dir)
+                or _same_file(found_path, bin_dir / name)
+            ),
+            None,
+        )
+        if match is None:
+            misresolved.append(f"{name} -> {found}")
+        elif str(match) not in resolved_into:
+            resolved_into.append(str(match))
+
+    primary = venv_bins[0] if venv_bins else PROJECT_DIR / ".venv" / "bin"
+
+    if misresolved:
+        shown = misresolved[:5]
+        suffix = (
+            f" (+{len(misresolved) - len(shown)} more)" if len(misresolved) > len(shown) else ""
+        )
+        path_note = (
+            f"{primary} is not on PATH"
+            if not on_path
+            else f"{on_path[0]} is on PATH but is shadowed"
+        )
+        return CheckResult(
+            name="console_scripts_resolve",
+            category="Environment",
+            passed=False,
+            message=(
+                f"{len(misresolved)}/{len(scripts)} console scripts do not resolve into the "
+                f"repo venv — {path_note}; bare-name callers run the wrong copy or nothing "
+                f"at all (#2566): {'; '.join(shown)}{suffix}"
+            ),
+            fix=(
+                f'Put the repo venv first on PATH: export PATH="{primary}:$PATH" '
+                "(persist it in your shell profile), then re-run. Any stale shim in an "
+                "earlier directory becomes unreachable."
+            ),
+        )
+
+    return CheckResult(
+        name="console_scripts_resolve",
+        category="Environment",
+        passed=True,
+        message=f"{len(scripts)} console scripts resolve into {', '.join(resolved_into)}",
+    )
+
+
 def _check_git_hooks_installed() -> CheckResult:
     """Check that `core.hooksPath` points at the repo's tracked hooks (#2540).
 
@@ -1460,6 +1621,9 @@ def get_checks(
         # Environment
         _check_python_version,
         _check_venv,
+        # Runs before _check_system_tools, whose scripts.update.verify import
+        # mutates PATH (see the check's docstring).
+        _check_console_scripts_resolve,
         _check_git_hooks_installed,
         _check_popoto_floor,
         _check_worktree_interpreters,


### PR DESCRIPTION
Closes #2566

## Problem

`[project.scripts]` entry points are invoked by bare name across skills, hooks, and SDLC addenda. Two of them are fail-closed critique gates (`critique-roster-check`, `critique-resume-probe`) and one gates pushes (`sdlc-push-guard`). What those names resolve to is host state that correct packaging cannot guarantee.

On `valorengels` and `MacBookPro.local`, `.venv/bin` was absent from PATH while a stale `~/Library/Python/3.12/bin` sat on it, producing two distinct surfaces at once:

- names with a stale shim resolved, ran under a system interpreter with no editable install of this repo, and died with `ModuleNotFoundError: No module named 'tools'`
- `sdlc-push-guard`, which had no stale shim, failed as `command not found`

Deleting the stale shims only converts the first shape into the second, so the durable fix is detection, not shim hygiene.

## Change

`tools/doctor.py::_check_console_scripts_resolve` reads every `[project.scripts]` name from `pyproject.toml` and `shutil.which`es it against the repo's venv bin directories. Three states, each with its own remedy:

- the name resolves into a repo venv bin directory: healthy, no action needed
- the name resolves somewhere else, or nowhere at all, and is present in the venv: something else is winning the PATH race. The fix is putting the venv first on PATH
- the name is declared in `pyproject.toml` but was never built into the venv: the puller has not re-synced since a `[project.scripts]` entry was added. The fix is `uv sync`, not a PATH reorder

A host can hit both problems at once, a genuinely shadowed name and a separately absent one, and the failure message and fix line report both rather than picking one. The failure message names the offending scripts, where each resolved (or that it did not), and whether `.venv/bin` is off PATH entirely or merely shadowed. When the offending-script list or the missing-entry-point list runs long, both the message and the fix line truncate to the first five and note how many more were omitted.

Two deliberate non-flags, so the check does not manufacture false positives on healthy machines:

- a hardlinked copy outside the venv is accepted, because `/update` installs some entry points that way
- the main checkout's `.venv/bin` is accepted, because doctor frequently runs from a worktree whose lane uses the main venv

The check is registered before `_check_system_tools`, whose `scripts.update.verify` import prepends `~/Library/Python/3.12/bin` to `os.environ["PATH"]`. Measuring first keeps the reported resolution the one a shell would actually get.

## Verification

Live, against the real `pyproject.toml` on this machine (where the issue does **not** reproduce):

```
$ python -c 'from tools.doctor import _check_console_scripts_resolve as c; ...'
True
25 console scripts resolve into /Users/tomcounsell/src/ai/.venv/bin
```

Live, under a PATH that reproduces the broken machines (no `.venv/bin`, a stale shim dir holding two of the three names):

```
passed: False
25/25 console scripts do not resolve into the repo venv — .../.venv/bin is not on PATH;
bare-name callers run the wrong copy or nothing at all (#2566):
critique-resume-probe -> .../fakelib/bin/critique-resume-probe;
critique-roster-check -> .../fakelib/bin/critique-roster-check;
sdlc-push-guard -> not found; ... (+20 more)
```

Both #2566 surfaces are named in one message.

## Tests

`tests/unit/test_doctor_console_scripts.py` — 18 tests, real files and a real PATH, no mocking of `shutil.which`. Covers the `valorengels` shape (shim ahead of an on-PATH venv), the `MacBookPro.local` shape (venv off PATH, mixed shim/not-found), the declared-but-not-installed state and its `uv sync` remedy, a name that is both shimmed and never installed, the hardlink and worktree non-flags, truncation of both the message and the fix line, and registry ordering.

Mutation-tested across three review rounds, each mutation applied and reverted separately, baseline and post-restore both green:

| Mutation | Result |
|---|---|
| `found is None` no longer flagged | caught |
| any resolution accepted (shadowing undetected) | caught |
| hardlink allowance removed (false positive) | caught |
| check unregistered from `get_checks` | caught |
| main-checkout-venv allowance removed | caught |
| `path_note` ternary collapsed to always-"not on PATH" | caught |
| truncation limit 5 -> 50 | caught |
| empty-`[project.scripts]` branch flipped to pass | caught |
| unreadable-pyproject branch flipped to pass | caught |
| not-installed tagging stripped from the resolved-elsewhere branch | caught |
| not-installed tagging stripped from the `found is None` branch | caught |
| aggregate "; N also not installed" suffix removed | caught |
| `_same_file` hardlink clause removed | caught |
| `os.path.realpath(...)` parent-match clause removed | survived — redundant, `_same_file` already covers this case |
| `misresolved[:5]` truncation removed | caught |
| `not_installed` fix-line truncation suffix removed | caught |

`tests/unit/test_doctor_console_scripts.py` + `tests/unit/test_doctor.py`: 65 passed. `ruff format` and `ruff check` clean.

## Out of scope

No stale shim was deleted on any machine — that is host state, and the check now makes it visible with a remediation line. The issue's secondary question (whether callers distinguish exit 127 from a real non-zero verdict) is a separate gate-attribution concern and is not addressed here. Tracked as #2749, so it keeps a home once this PR merges and closes #2566.

