### PR TITLE
Stop resolving /update's merge target through the shared FETCH_HEAD (#2650)

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(cd ~/src/ai && git checkout main && git pull:*), Bash(cd ~/src/ai && .venv/bin/python scripts/update/run.py --full:*)
+allowed-tools: Bash(cd ~/src/ai && git checkout main && git fetch origin main && git merge --ff-only origin/main:*), Bash(cd ~/src/ai && .venv/bin/python scripts/update/run.py --full:*)
 description: Bring this machine to latest main — sync deps, verify environment, restart services. Runs deterministically via inline bash execution, not model discretion.
 ---
 
@@ -7,9 +7,9 @@ description: Bring this machine to latest main — sync deps, verify environment
 
 The commands below already ran as part of expanding this command — you are reading their actual output, not deciding whether to run them.
 
-## git pull
+## Fast-forward main
 
-!`cd ~/src/ai && git checkout main && git pull`
+!`cd ~/src/ai && git checkout main && git fetch origin main && git merge --ff-only origin/main`
 
 ## Update orchestrator (`scripts/update/run.py --full`)
 

--- a/.claude/skills-global/do-deploy-example/SKILL.md
+++ b/.claude/skills-global/do-deploy-example/SKILL.md
@@ -75,8 +75,12 @@ Before deploying, verify the environment is ready:
 # Adapt DEPLOY_TARGET_REPO to your repo's target-path env var (see Cross-Repo Resolution)
 REPO="${DEPLOY_TARGET_REPO:-.}"
 
-# 1. Confirm local repo is on the merge target branch and up to date
-git -C "$REPO" checkout main && git -C "$REPO" pull
+# 1. Confirm local repo is on the merge target branch and up to date.
+# Fetch + ff-merge a named ref rather than `git pull`: `.git/FETCH_HEAD` is
+# shared by every worktree of a repo, so in a multi-worktree checkout a
+# concurrent fetch can retarget a bare pull's merge.
+git -C "$REPO" checkout main && git -C "$REPO" fetch origin main \
+  && git -C "$REPO" merge --ff-only origin/main
 
 # 2. Verify the merge commit exists locally
 git -C "$REPO" log --oneline -1 $MERGE_COMMIT

--- a/.claude/skills-global/do-plan/SKILL.md
+++ b/.claude/skills-global/do-plan/SKILL.md
@@ -390,6 +390,8 @@ Please review the Open Questions section at the end of the plan and provide answ
 
 ### Phase 4: Finalize Plan
 
+> **Never leave `docs/plans/` dirty across an await.** Plan docs commit directly on the shared main checkout, so an uncommitted edit sitting there while you wait on a subagent, a critique, or a human is exposed to every concurrent lane. A peer running `git pull --rebase` autostashes your work-in-progress, and if the pulled commits touch the same file the autostash-apply conflicts — at which point the peer has to quarantine the stash and someone has to prove by content diff which of stash-vs-commit was authoritative. That happened on 2026-08-07 (#2650, shape 1). Commit each revision as soon as it is coherent; a slightly noisy history costs nothing next to a reconciliation.
+
 After receiving answers:
 
 1. **Update plan** - Incorporate feedback, remove Open Questions section

--- a/.claude/skills-global/do-sdlc/SKILL.md
+++ b/.claude/skills-global/do-sdlc/SKILL.md
@@ -132,6 +132,12 @@ sdlc-tool dispatch record --skill {skill} --issue-number {issue_number} --run-id
 
 ### 3c. Spawn the stage subagent
 
+**One writer per artifact — enumerate live children before you dispatch.** Every stage you dispatch is a writer on a shared artifact, and the plan doc in particular is a single file on the shared main checkout that no worktree isolates. Before spawning, account for the children you already have out: if a child is still holding the plan doc, do not dispatch a second one onto it, and do not edit it yourself while it does. Wait for the outstanding child to report, then dispatch.
+
+This is not hypothetical. On 2026-08-07 one plan doc took two concurrent revision children twice over (#2650, shape 3) — a writer watched its line count grow from 62 to 111 between its own reads and had to stop and ask who owned the file — and a supervisor patched a plan task while its own dispatched child held the doc, then had to warn the child mid-flight to re-read before committing (shape 4). Both were recovered only because an agent happened to notice the file moving underneath it.
+
+Since Hard Rule 6 already requires `run_in_background: false`, the ordinary loop has exactly one child out at a time and satisfies this for free. The rule bites when you are tempted to fan out, or to "just fix one line" in a doc a child is revising. Neither is safe; the second is the one that feels harmless.
+
 Use the Agent tool (general-purpose), with `model:` from the Stage→Model table and **`run_in_background: false`** (Hard Rule 6 — this fork cannot be resumed by a background notification). Prompt template:
 
 ```

--- a/.claude/skills-global/weekly-review/SKILL.md
+++ b/.claude/skills-global/weekly-review/SKILL.md
@@ -21,8 +21,12 @@ If the user provides args, parse them as `<days> [categories]`. Otherwise use de
 Run these git commands in parallel from the repo root to collect commit history:
 
 ```bash
-# Verify you're on the correct branch
-git pull && git branch --show-current
+# Refresh from the remote, then verify you're on the correct branch.
+# Fetch + ff-merge the upstream ref rather than `git pull`: `.git/FETCH_HEAD`
+# is shared by every worktree of a repo, so in a multi-worktree checkout a
+# concurrent fetch can retarget a bare pull's merge. The merge is allowed to
+# fail (no upstream, or diverged) — this is a read-only review either way.
+git fetch && git merge --ff-only @{upstream} 2>/dev/null; git branch --show-current
 
 # Get all commits
 git log --since="<DAYS> days ago" --oneline --no-merges

--- a/.claude/skills/do-deploy/SKILL.md
+++ b/.claude/skills/do-deploy/SKILL.md
@@ -57,8 +57,10 @@ Deploy blocked: PR #N is not merged. Run /do-merge first.
 ## Step 2: Confirm Local Machine Is Current
 
 ```bash
-# Pull latest main
-git checkout main && git pull
+# Fast-forward main. Not `git pull` (#2650): FETCH_HEAD is shared by every
+# worktree, so a concurrent lane's fetch can retarget a bare pull's merge --
+# and a deploy runs during exactly those multi-lane conditions.
+git checkout main && git fetch origin main && git merge --ff-only origin/main
 
 # Verify merge commit is present
 git log --oneline -1 $MERGE_COMMIT

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -13,7 +13,7 @@ Configure this machine to run the Valor Telegram bridge. You do everything excep
 **PREREQUISITE: Must be on latest main branch before running.**
 
 ```bash
-cd ~/src/ai && git checkout main && git pull
+cd ~/src/ai && git checkout main && git fetch origin main && git merge --ff-only origin/main
 ```
 
 Before starting, confirm the user has:

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -13,8 +13,10 @@ Bring this machine to latest main: deps synced, environment verified, services r
 **PREREQUISITE: Must be on latest main branch before running.**
 
 ```bash
-cd ~/src/ai && git checkout main && git pull
+cd ~/src/ai && git checkout main && git fetch origin main && git merge --ff-only origin/main
 ```
+
+Fetch-then-merge-a-named-ref rather than `git pull` (#2650): `.git/FETCH_HEAD` is shared by every worktree of the repo, so with concurrent lanes on this machine a peer's fetch can retarget a bare pull's merge.
 
 If there are local changes, stash them first: `git stash`. The update orchestrator also handles this, but being on main is required.
 

--- a/agent/worktree_manager.py
+++ b/agent/worktree_manager.py
@@ -1348,9 +1348,16 @@ def preserve_uncommitted_worktree_changes(repo_root: Path, slug: str, worktree_d
     work as a WIP commit on ``session/{slug}`` plus a durable named ref
     ``refs/session-wip/{slug}`` before any ``git worktree remove --force``.
 
-    Mechanism (WIP commit + named ref, NOT ``git stash``): a plain ``git stash``
-    inside a worktree writes to the *per-worktree* ``refs/stash``, which is
-    destroyed with the worktree — useless as a teardown backstop. Instead:
+    Mechanism (WIP commit + named ref, NOT ``git stash``). The reason is NOT
+    that a worktree's stash is worktree-local: ``refs/stash`` lives in the
+    *common* ref store, so a stash pushed from a worktree is visible as
+    ``stash@{0}`` from the main checkout and survives the worktree's removal
+    (verified on git 2.50.1). That shared stack is precisely the problem —
+    every lane on this machine pushes onto the same one, so an entry's position
+    is meaningless and a teardown backstop keyed on it would race every peer
+    (issue #2650, shape 1). A WIP commit under a slug-scoped named ref is
+    single-owner by construction, and it captures untracked files, which
+    ``git stash`` declines by default. Instead:
 
     1. ``git -C <worktree> status --porcelain`` — if empty, no-op.
     2. ``git -C <worktree> add -A`` — captures untracked + tracked edits.

--- a/docs/features/bridge-self-healing.md
+++ b/docs/features/bridge-self-healing.md
@@ -360,7 +360,7 @@ These mechanical scanners address message **ingestion** gaps (a message that was
 
 **Solution**: The `com.valor.update` launchd plist uses `StartInterval` of 1800 seconds (30 minutes) to poll for updates frequently. Each invocation runs `scripts/remote-update.sh`, which:
 1. Acquires a lock (`data/update.lock`) to prevent concurrent runs
-2. Runs `git pull --ff-only` directly in bash (before invoking Python), so the orchestrator and all update scripts are loaded fresh from disk
+2. Fast-forwards `main` directly in bash (`git fetch origin main` + `git merge --ff-only origin/main`, never a bare `git pull` — see #2650), so the orchestrator and all update scripts are loaded fresh from disk
 3. Invokes `scripts/update/run.py --cron --no-pull` (the `--no-pull` flag skips the redundant internal pull since bash already pulled)
 4. If new commits arrived: syncs dependencies (if dep files changed), writes `data/restart-requested`
 5. The bridge session queue detects the restart flag and triggers a graceful restart after in-flight sessions complete

--- a/docs/features/deployment.md
+++ b/docs/features/deployment.md
@@ -119,7 +119,7 @@ Every machine automatically polls for updates from `origin/main` every 30 minute
 
 **How it works:**
 1. `com.valor.update` fires every 1800 seconds (30 minutes) via `StartInterval`
-2. Runs `scripts/remote-update.sh`, which first does `git pull --ff-only` in bash, then calls the update orchestrator (`scripts/update/run.py --cron --no-pull`)
+2. Runs `scripts/remote-update.sh`, which first fast-forwards `main` in bash (`git fetch origin main` + `git merge --ff-only origin/main`), then calls the update orchestrator (`scripts/update/run.py --cron --no-pull`)
 3. If new commits are detected: pulls changes, syncs dependencies (if dep files changed), writes `data/restart-requested`
 4. The bridge session queue detects the restart flag and triggers a graceful restart after in-flight sessions complete
 

--- a/docs/features/remote-update.md
+++ b/docs/features/remote-update.md
@@ -35,7 +35,7 @@ We update Valor's codebase almost daily, but changes only take effect on the mac
 
 ### Key Elements
 
-- **`scripts/remote-update.sh`**: Single shell script that does the essential update — git pull first (in bash, before Python loads), then delegates to the Python orchestrator. Does NOT restart the bridge itself. Stripped-down version of the Claude Code `/update` skill (no calendar config, no MCP checks, no CLI tool audit — those are setup concerns, not update concerns).
+- **`scripts/remote-update.sh`**: Single shell script that does the essential update — fast-forwards `main` first (in bash, before Python loads), then delegates to the Python orchestrator. Does NOT restart the bridge itself. Stripped-down version of the Claude Code `/update` skill (no calendar config, no MCP checks, no CLI tool audit — those are setup concerns, not update concerns).
 - **Bridge command intercept**: Before any message processing, check if the raw text is `/update`. Run the script, reply with the result. If code changed, queue a restart (don't restart immediately).
 - **Queued restart**: Instead of killing the bridge mid-response, the update writes a restart flag file. The session queue worker checks for this flag between sessions and triggers a graceful restart only when idle.
 - **Launchd cron plist**: A second launchd job that runs `remote-update.sh` every 12 hours. If code changed, it writes the restart flag. Independent of the bridge — runs even if the bridge is down (in that case, launchd's `KeepAlive` will restart the bridge with the new code anyway).
@@ -123,17 +123,18 @@ if ! claim_lock; then
 fi
 trap cleanup_lock EXIT
 
-# ── Git pull FIRST — before invoking any Python ──────────────────────
-# Pull here so the Python orchestrator (run.py) and all update scripts are
-# up to date before they execute. Without this, a Telegram /update or cron
-# run always executes the pre-pull version of the orchestrator; changes to
+# ── Fast-forward FIRST — before invoking any Python ──────────────────
+# Update here so the Python orchestrator (run.py) and all update scripts are
+# current before they execute. Without this, a Telegram /update or cron
+# run always executes the pre-update version of the orchestrator; changes to
 # the update scripts only take effect on the next run.
 # run.py --cron is then called with --no-pull to skip the redundant pull.
 echo "[update] Pulling latest changes..."
-if git -C "$PROJECT_DIR" pull --ff-only 2>&1; then
+if git -C "$PROJECT_DIR" fetch origin main 2>&1 && \
+   git -C "$PROJECT_DIR" merge --ff-only origin/main 2>&1; then
     echo "[update] Pull complete"
 else
-    echo "[update] WARN: git pull failed or had conflicts — continuing with current code"
+    echo "[update] WARN: fetch/fast-forward failed or had conflicts — continuing with current code"
 fi
 
 # ── Run update in cron mode ──────────────────────────────────────────
@@ -327,12 +328,12 @@ Install/uninstall via `valor-service.sh`:
 **Mitigation:** Eliminated by design. The update script no longer restarts the bridge directly. It writes a restart flag file. The session queue worker checks the flag between sessions and only triggers a restart when all projects have no running sessions. The bridge finishes its current work before restarting. Worst case: if the bridge is perpetually busy, the restart is deferred until a quiet moment. A very long-running session (2+ hours) would delay the update — acceptable tradeoff vs losing a response.
 
 ### Risk 2: Cron and manual trigger race
-**Impact:** If someone types `/update` at the same moment the cron fires, two `git pull` + restart sequences run simultaneously.
+**Impact:** If someone types `/update` at the same moment the cron fires, two fast-forward + restart sequences run simultaneously.
 **Mitigation:** Use a lockfile in `remote-update.sh`. `flock` or a simple `mkdir`-based lock. If lock is held, exit 0 with "Update already in progress."
 
-### Risk 3: `git pull --ff-only` fails on dirty working tree
-**Impact:** If the machine has uncommitted local changes (e.g., from a running agent session), `git pull` fails.
-**Mitigation:** The script auto-stashes before pulling and pops after (matching the existing `/update` Claude Code skill behavior). If stash pop has conflicts, the code is still updated but the warning is surfaced. Agent sessions commit and push before completing, so dirty trees should be rare. Worst case: operator sees "stash pop conflict" in the output and resolves manually.
+### Risk 3: the fast-forward fails on a dirty working tree
+**Impact:** If the machine has uncommitted local changes (e.g., from a running agent session), the merge refuses.
+**Mitigation:** The script auto-stashes before updating and restores after. The restore is keyed on the stash's **commit sha**, never `stash@{0}` (#2650): `refs/stash` is a per-repository stack shared by every worktree, so a concurrent lane's stash landing on top would otherwise be restored into this checkout instead of ours. If our entry is gone, nothing is restored rather than a stranger's work. If stash pop has conflicts, the code is still updated but the warning is surfaced. Agent sessions commit and push before completing, so dirty trees should be rare. Worst case: operator sees "stash pop conflict" in the output and resolves manually.
 
 ### Risk 4: `uv` not installed on all machines
 **Impact:** New machines might not have `uv` yet.

--- a/scripts/migrate_completed_plan.py
+++ b/scripts/migrate_completed_plan.py
@@ -324,7 +324,13 @@ def migrate_plan_to_completed(plan_path: Path, *, apply: bool) -> str:
             f"[WARN] git push rejected for {plan_path.name} "
             f"(attempt {attempt}/{max_attempts}): {push_result.stderr.strip()}"
         )
-        pull_result = _run_git(["pull", "--rebase", "origin", "main"], cwd=repo_root, timeout=60)
+        # Fetch, then rebase onto the NAMED ref (#2650). `git pull --rebase`
+        # takes its onto-target from `.git/FETCH_HEAD`, which every worktree of
+        # the repo shares -- and this script runs on the shared main checkout
+        # while concurrent lanes are fetching, which is exactly when a peer's
+        # fetch can retarget the rebase.
+        _run_git(["fetch", "origin", "main"], cwd=repo_root, timeout=60)
+        pull_result = _run_git(["rebase", "origin/main"], cwd=repo_root, timeout=60)
         conflict_text = (pull_result.stdout + pull_result.stderr).lower()
         if pull_result.returncode != 0 and (
             _rebase_in_progress(repo_root) or "conflict" in conflict_text

--- a/scripts/remote-update.sh
+++ b/scripts/remote-update.sh
@@ -128,6 +128,12 @@ BEFORE_SHA=$(git -C "$PROJECT_DIR" rev-parse HEAD)
 # That broke three consecutive /update runs on 2026-08-07. Merging
 # origin/main by name is immune -- a peer fetching the same branch can only
 # advance that ref to the same value.
+#
+# `origin main` is hardcoded rather than resolved via @{upstream} (which is what
+# scripts/update/git.py::pull_ff_only does): this wrapper's whole job is to put
+# the shared checkout on latest main before any Python loads, so main is the
+# intended target even if the checkout was left on a side branch. The ff-only
+# merge simply refuses in that case, which is the safe outcome.
 echo "[update] Pulling latest changes..."
 if git -C "$PROJECT_DIR" fetch origin main 2>&1 && \
    git -C "$PROJECT_DIR" merge --ff-only origin/main 2>&1; then

--- a/scripts/remote-update.sh
+++ b/scripts/remote-update.sh
@@ -120,11 +120,20 @@ trap cleanup_lock EXIT
 # Capture SHA before pull so we can detect whether code actually changed.
 BEFORE_SHA=$(git -C "$PROJECT_DIR" rev-parse HEAD)
 
+# Fetch + merge the NAMED remote-tracking ref, never bare `git pull` (#2650).
+# `git pull`'s merge step resolves its target through .git/FETCH_HEAD, which is
+# shared by every worktree of the repository. With concurrent SDLC lanes on this
+# machine, a peer lane's fetch lands between our fetch and our merge and the
+# merge reads their refs: `fatal: Cannot fast-forward to multiple branches`.
+# That broke three consecutive /update runs on 2026-08-07. Merging
+# origin/main by name is immune -- a peer fetching the same branch can only
+# advance that ref to the same value.
 echo "[update] Pulling latest changes..."
-if git -C "$PROJECT_DIR" pull --ff-only 2>&1; then
+if git -C "$PROJECT_DIR" fetch origin main 2>&1 && \
+   git -C "$PROJECT_DIR" merge --ff-only origin/main 2>&1; then
     echo "[update] Pull complete"
 else
-    echo "[update] WARN: git pull failed or had conflicts — continuing with current code"
+    echo "[update] WARN: fetch/fast-forward failed or had conflicts — continuing with current code"
 fi
 
 AFTER_SHA=$(git -C "$PROJECT_DIR" rev-parse HEAD)

--- a/scripts/update/git.py
+++ b/scripts/update/git.py
@@ -89,28 +89,66 @@ def stash_pop(project_dir: Path) -> bool:
     return result.returncode == 0
 
 
-def pull_ff_only(project_dir: Path) -> tuple[bool, str]:
-    """Pull with --ff-only, falling back to --rebase on divergence.
+def get_upstream_ref(project_dir: Path) -> str | None:
+    """Return the current branch's upstream remote-tracking ref (``origin/main``).
 
-    Returns (success, output).
+    ``None`` when the branch has no upstream configured (detached HEAD, or a
+    local-only branch), which callers treat as "nothing to pull".
     """
     result = run_cmd(
-        ["git", "pull", "--ff-only"],
+        ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
         cwd=project_dir,
         check=False,
     )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def pull_ff_only(project_dir: Path) -> tuple[bool, str]:
+    """Fast-forward the current branch to its upstream, rebasing on divergence.
+
+    Returns (success, output).
+
+    **Never uses bare ``git pull`` (issue #2650, shape 2).** ``git pull``'s
+    merge step resolves its target through ``.git/FETCH_HEAD`` — a file shared
+    by every worktree of a repository, not per-worktree state. This machine
+    runs concurrent SDLC lanes across many worktrees of one repo, so a peer
+    lane's fetch lands between our fetch and our merge, and the merge reads
+    the peer's refs instead of ours::
+
+        fatal: Cannot fast-forward to multiple branches
+
+    That failure hit three consecutive ``/update`` attempts on 2026-08-07 and
+    is pure collateral: nothing is wrong with either lane's work.
+
+    Fetching and then merging the *remote-tracking ref* by name removes the
+    race outright. ``refs/remotes/origin/main`` is a named ref that a peer's
+    fetch of the same branch can only advance to the same value, so a
+    concurrent fetch is at worst a no-op for us and never a wrong target.
+    """
+    upstream = get_upstream_ref(project_dir)
+    if not upstream:
+        return False, "no upstream tracking branch configured for the current branch"
+
+    remote, _, branch = upstream.partition("/")
+    if not remote or not branch:
+        return False, f"could not parse upstream ref: {upstream!r}"
+
+    fetch = run_cmd(["git", "fetch", remote, branch], cwd=project_dir, check=False)
+    if fetch.returncode != 0:
+        return False, (fetch.stdout + fetch.stderr).strip()
+
+    # Merge the named remote-tracking ref, NOT FETCH_HEAD.
+    result = run_cmd(["git", "merge", "--ff-only", upstream], cwd=project_dir, check=False)
     output = result.stdout + result.stderr
 
     if result.returncode == 0:
         return True, output.strip()
 
-    # If ff-only failed due to divergence, try rebase
+    # If ff-only failed due to divergence, rebase onto the same named ref.
     if "diverging" in output.lower() or "not possible to fast-forward" in output.lower():
-        result = run_cmd(
-            ["git", "pull", "--rebase"],
-            cwd=project_dir,
-            check=False,
-        )
+        result = run_cmd(["git", "rebase", upstream], cwd=project_dir, check=False)
         output = result.stdout + result.stderr
         return result.returncode == 0, output.strip()
 

--- a/scripts/update/git.py
+++ b/scripts/update/git.py
@@ -124,35 +124,42 @@ def stash_changes(project_dir: Path) -> StashResult:
     if result.returncode != 0:
         return StashResult(ok=False)
 
-    sha = _find_stash_by_token(project_dir, token)
+    entries = _stash_entries(project_dir)
+    if entries is None:
+        # The listing failed, so we cannot tell whether the push created an
+        # entry. FAIL CLOSED. Reporting "nothing to stash" here would strand
+        # real work in the stack under a token nobody will look up, and let
+        # the pull proceed over the tree it came from.
+        return StashResult(ok=False)
+
+    sha = next((s for s, _ref, subject in entries if token in subject), None)
     if sha is None:
-        # Exit 0 with no matching entry == "No local changes to save". Not a
-        # failure, and emphatically not licence to adopt whatever is on top.
+        # Exit 0, listing read cleanly, no entry carrying our token ==
+        # "No local changes to save". Not a failure, and emphatically not
+        # licence to adopt whatever is on top.
         return StashResult(ok=True, sha=None)
     return StashResult(ok=True, sha=sha)
 
 
-def _stash_entries(project_dir: Path) -> list[tuple[str, str, str]]:
-    """Return ``(sha, stack_ref, subject)`` for every entry, newest first."""
+def _stash_entries(project_dir: Path) -> list[tuple[str, str, str]] | None:
+    """``(sha, stack_ref, subject)`` per entry, newest first. ``None`` on error.
+
+    ``None`` (read failed) is deliberately distinct from ``[]`` (stack is
+    empty). Collapsing the two is how a failed read becomes a confident
+    "nothing is stashed" answer, and this module exists because that class of
+    fail-open guess loses other lanes' work.
+    """
     listing = run_cmd(
         ["git", "stash", "list", "--format=%H%x00%gd%x00%gs"], cwd=project_dir, check=False
     )
     if listing.returncode != 0:
-        return []
+        return None
     entries = []
     for line in listing.stdout.splitlines():
         parts = line.split("\x00")
         if len(parts) == 3 and parts[0]:
             entries.append((parts[0], parts[1], parts[2]))
     return entries
-
-
-def _find_stash_by_token(project_dir: Path, token: str) -> str | None:
-    """The sha of the entry whose message carries ``token``, or ``None``."""
-    for sha, _ref, subject in _stash_entries(project_dir):
-        if token in subject:
-            return sha
-    return None
 
 
 def _resolve_stash_ref(project_dir: Path, stash_sha: str) -> str | None:
@@ -162,7 +169,7 @@ def _resolve_stash_ref(project_dir: Path, stash_sha: str) -> str | None:
     stash, so a position is only valid at the instant it is read. Needed only
     for ``git stash drop``, which has no by-sha form.
     """
-    for sha, ref, _subject in _stash_entries(project_dir):
+    for sha, ref, _subject in _stash_entries(project_dir) or []:
         if sha == stash_sha and ref:
             return ref
     return None

--- a/scripts/update/git.py
+++ b/scripts/update/git.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+from typing import NamedTuple
 
 
 @dataclass
@@ -68,47 +69,128 @@ def get_dirty_files(project_dir: Path, limit: int = 5) -> list[str]:
     return [line.strip() for line in lines[:limit] if line.strip()]
 
 
-def stash_changes(project_dir: Path) -> str | None:
-    """Stash uncommitted changes. Returns the stash commit sha, or ``None``.
+class StashResult(NamedTuple):
+    """Outcome of an auto-stash attempt.
 
-    The sha is the durable handle: ``refs/stash`` is a per-*repository* stack
-    shared by every worktree, so ``stash@{0}`` names whatever was pushed most
-    recently by anyone. Returning the sha lets :func:`stash_pop` restore *our*
-    entry rather than a peer lane's (issue #2650, shape 1).
+    Three states, and the caller must tell them apart: ``ok=False`` is a real
+    failure that must abort the pull; ``ok=True, sha=None`` means there was
+    nothing to stash (an untracked-only tree, which ``git stash push`` declines
+    with exit 0); ``ok=True`` with a sha means our entry is on the stack.
     """
+
+    ok: bool
+    sha: str | None = None
+
+
+def stash_changes(project_dir: Path) -> StashResult:
+    """Stash uncommitted changes, identified by a token WE mint.
+
+    **Never infers identity from the top of the stack (issue #2650, shape 1).**
+    ``refs/stash`` is a per-*repository* stack shared by every worktree, so
+    ``stash@{0}`` -- and ``git rev-parse refs/stash`` -- names whatever was
+    pushed most recently by anyone.
+
+    Reading it after our own push is not enough, for two independent reasons:
+
+    1. ``git stash push`` exits **0** when there is nothing to stash. This tree
+       counts as dirty via ``git status --porcelain`` whenever an untracked
+       file is present, but the push (no ``-u``) declines it with "No local
+       changes to save" -- so the stack top read back is a *peer's* entry, and
+       restoring it writes their uncommitted work into this checkout and drops
+       it from the stack.
+    2. Even after a successful push, a peer pushing before we read leaves their
+       sha on top.
+
+    So the entry is found by a token minted here, before the push, and searched
+    for by message afterwards. A peer's concurrent push cannot match it.
+
+    Untracked files are deliberately NOT stashed (no ``-u``). This runs against
+    the shared checkout, where untracked files routinely belong to other lanes;
+    sweeping them into our stash and restoring them later would be its own
+    cross-lane collision. They do not block a fast-forward unless the merge
+    would overwrite one, in which case git refuses and the caller reports it.
+    """
+    import os
+    import uuid
+
     from bridge.utc import utc_now
 
     timestamp = utc_now().strftime("%Y%m%d-%H%M%S")
-    msg = f"remote-update auto-stash {timestamp}"
+    # pid + random suffix: the token is the identity, so it must not collide
+    # with a peer lane stashing in the same second.
+    token = f"remote-update auto-stash {timestamp}-{os.getpid()}-{uuid.uuid4().hex[:8]}"
 
-    result = run_cmd(
-        ["git", "stash", "push", "-m", msg],
-        cwd=project_dir,
-        check=False,
-    )
+    result = run_cmd(["git", "stash", "push", "-m", token], cwd=project_dir, check=False)
     if result.returncode != 0:
-        return None
+        return StashResult(ok=False)
 
-    sha = run_cmd(["git", "rev-parse", "refs/stash"], cwd=project_dir, check=False)
-    if sha.returncode != 0:
-        return None
-    return sha.stdout.strip() or None
+    sha = _find_stash_by_token(project_dir, token)
+    if sha is None:
+        # Exit 0 with no matching entry == "No local changes to save". Not a
+        # failure, and emphatically not licence to adopt whatever is on top.
+        return StashResult(ok=True, sha=None)
+    return StashResult(ok=True, sha=sha)
+
+
+def _stash_entries(project_dir: Path) -> list[tuple[str, str, str]]:
+    """Return ``(sha, stack_ref, subject)`` for every entry, newest first."""
+    listing = run_cmd(
+        ["git", "stash", "list", "--format=%H%x00%gd%x00%gs"], cwd=project_dir, check=False
+    )
+    if listing.returncode != 0:
+        return []
+    entries = []
+    for line in listing.stdout.splitlines():
+        parts = line.split("\x00")
+        if len(parts) == 3 and parts[0]:
+            entries.append((parts[0], parts[1], parts[2]))
+    return entries
+
+
+def _find_stash_by_token(project_dir: Path, token: str) -> str | None:
+    """The sha of the entry whose message carries ``token``, or ``None``."""
+    for sha, _ref, subject in _stash_entries(project_dir):
+        if token in subject:
+            return sha
+    return None
 
 
 def _resolve_stash_ref(project_dir: Path, stash_sha: str) -> str | None:
     """Find the current ``stash@{N}`` position of a stash commit, by sha.
 
     Positions shift whenever any worktree of the repository pushes or drops a
-    stash, so a position is only valid at the instant it is read.
+    stash, so a position is only valid at the instant it is read. Needed only
+    for ``git stash drop``, which has no by-sha form.
     """
-    listing = run_cmd(["git", "stash", "list", "--format=%H %gd"], cwd=project_dir, check=False)
-    if listing.returncode != 0:
-        return None
-    for line in listing.stdout.splitlines():
-        sha, _, name = line.strip().partition(" ")
-        if sha == stash_sha and name:
-            return name
+    for sha, ref, _subject in _stash_entries(project_dir):
+        if sha == stash_sha and ref:
+            return ref
     return None
+
+
+_NULL_SHA = "0" * 40
+
+
+def _is_applicable_stash_sha(project_dir: Path, stash_sha: str | None) -> bool:
+    """True iff ``stash_sha`` is a real object id safe to hand to ``git stash``.
+
+    Guards the null-sha fallback: ``git stash apply 0000…0`` is treated by git
+    as "no argument" and silently applies ``stash@{0}``, exiting 0. In a shared
+    checkout that means restoring a peer lane's work.
+    """
+    if not stash_sha or not isinstance(stash_sha, str):
+        return False
+    sha = stash_sha.strip().lower()
+    if len(sha) != 40 or sha == _NULL_SHA:
+        return False
+    if any(c not in "0123456789abcdef" for c in sha):
+        return False
+    exists = run_cmd(
+        ["git", "rev-parse", "--verify", "--quiet", f"{sha}^{{commit}}"],
+        cwd=project_dir,
+        check=False,
+    )
+    return exists.returncode == 0
 
 
 def stash_pop(project_dir: Path, stash_sha: str | None = None) -> bool:
@@ -116,31 +198,32 @@ def stash_pop(project_dir: Path, stash_sha: str | None = None) -> bool:
 
     **Never pops ``stash@{0}`` (issue #2650, shape 1).** The stash stack is
     per-repository, not per-worktree, so between our push and our pop a
-    concurrent lane's ``git stash`` becomes ``stash@{0}`` — and popping it
+    concurrent lane's ``git stash`` becomes ``stash@{0}`` -- and popping it
     would restore that lane's uncommitted work into this checkout while
     leaving ours buried. Identity, not position, is what makes the restore
     correct.
 
-    The sha is resolved to its stack position at pop time (positions shift as
-    peers push and pop), then dropped explicitly, because ``git stash pop``
-    only accepts a stack reference.
+    ``git stash apply`` accepts a raw commit sha, so the restore itself needs
+    no position lookup and has no window to race. Only the ``drop`` does: it
+    has no by-sha form, so the position is resolved immediately before it, and
+    a resolve that comes back empty skips the drop rather than guessing.
+
+    **The sha is validated before it is handed to git.** ``git stash apply``
+    treats an all-zeros sha as "no argument" and silently falls back to
+    ``stash@{0}``, exiting 0 -- so a null sha reaching this function would
+    restore a peer lane's work into this checkout, which is the exact harm
+    this function exists to prevent. Anything that is not a non-zero 40-hex
+    object id is refused outright, and the object is confirmed to exist before
+    the apply.
     """
-    if not stash_sha:
+    if not _is_applicable_stash_sha(project_dir, stash_sha):
         return False
 
-    ref = _resolve_stash_ref(project_dir, stash_sha)
-    if ref is None:
-        # Our entry is gone (already restored, or dropped by someone else).
-        # Applying nothing beats applying a stranger's work.
-        return False
-
-    applied = run_cmd(["git", "stash", "apply", ref], cwd=project_dir, check=False)
+    # Apply by sha directly -- no stack position, so nothing to race.
+    applied = run_cmd(["git", "stash", "apply", stash_sha], cwd=project_dir, check=False)
     if applied.returncode != 0:
         return False
 
-    # Re-resolve before dropping. `apply` does not shift the stack, but a peer
-    # lane's push between the two calls does, and dropping a stale position
-    # would discard their entry instead of ours.
     ref = _resolve_stash_ref(project_dir, stash_sha)
     if ref is not None:
         run_cmd(["git", "stash", "drop", ref], cwd=project_dir, check=False)
@@ -264,19 +347,24 @@ def git_pull(project_dir: Path) -> GitPullResult:
 
     # Check for dirty working tree
     if is_dirty(project_dir):
-        stashed = True
-        stash_sha = stash_changes(project_dir)
-        if not stash_sha:
+        stash = stash_changes(project_dir)
+        if not stash.ok:
             return GitPullResult(
                 success=False,
                 before_sha=before_sha,
                 after_sha=before_sha,
                 commit_count=0,
                 commits=[],
-                stashed=True,
+                stashed=False,
                 stash_restored=False,
                 error="Failed to stash changes",
             )
+        # `ok` with no sha means there was nothing to stash -- an untracked-only
+        # tree, which `is_dirty` counts but `git stash push` declines. That is
+        # not a failure, and treating it as one would make /update fail every
+        # time a stray untracked file sits in the shared checkout.
+        stash_sha = stash.sha
+        stashed = stash_sha is not None
 
     # Pull
     success, output = pull_ff_only(project_dir)

--- a/scripts/update/git.py
+++ b/scripts/update/git.py
@@ -68,8 +68,14 @@ def get_dirty_files(project_dir: Path, limit: int = 5) -> list[str]:
     return [line.strip() for line in lines[:limit] if line.strip()]
 
 
-def stash_changes(project_dir: Path) -> bool:
-    """Stash uncommitted changes. Returns True if stash was created."""
+def stash_changes(project_dir: Path) -> str | None:
+    """Stash uncommitted changes. Returns the stash commit sha, or ``None``.
+
+    The sha is the durable handle: ``refs/stash`` is a per-*repository* stack
+    shared by every worktree, so ``stash@{0}`` names whatever was pushed most
+    recently by anyone. Returning the sha lets :func:`stash_pop` restore *our*
+    entry rather than a peer lane's (issue #2650, shape 1).
+    """
     from bridge.utc import utc_now
 
     timestamp = utc_now().strftime("%Y%m%d-%H%M%S")
@@ -80,20 +86,72 @@ def stash_changes(project_dir: Path) -> bool:
         cwd=project_dir,
         check=False,
     )
-    return result.returncode == 0
+    if result.returncode != 0:
+        return None
+
+    sha = run_cmd(["git", "rev-parse", "refs/stash"], cwd=project_dir, check=False)
+    if sha.returncode != 0:
+        return None
+    return sha.stdout.strip() or None
 
 
-def stash_pop(project_dir: Path) -> bool:
-    """Pop stashed changes. Returns True if successful."""
-    result = run_cmd(["git", "stash", "pop"], cwd=project_dir, check=False)
-    return result.returncode == 0
+def _resolve_stash_ref(project_dir: Path, stash_sha: str) -> str | None:
+    """Find the current ``stash@{N}`` position of a stash commit, by sha.
+
+    Positions shift whenever any worktree of the repository pushes or drops a
+    stash, so a position is only valid at the instant it is read.
+    """
+    listing = run_cmd(["git", "stash", "list", "--format=%H %gd"], cwd=project_dir, check=False)
+    if listing.returncode != 0:
+        return None
+    for line in listing.stdout.splitlines():
+        sha, _, name = line.strip().partition(" ")
+        if sha == stash_sha and name:
+            return name
+    return None
+
+
+def stash_pop(project_dir: Path, stash_sha: str | None = None) -> bool:
+    """Restore a stash by commit sha. Returns True if successful.
+
+    **Never pops ``stash@{0}`` (issue #2650, shape 1).** The stash stack is
+    per-repository, not per-worktree, so between our push and our pop a
+    concurrent lane's ``git stash`` becomes ``stash@{0}`` — and popping it
+    would restore that lane's uncommitted work into this checkout while
+    leaving ours buried. Identity, not position, is what makes the restore
+    correct.
+
+    The sha is resolved to its stack position at pop time (positions shift as
+    peers push and pop), then dropped explicitly, because ``git stash pop``
+    only accepts a stack reference.
+    """
+    if not stash_sha:
+        return False
+
+    ref = _resolve_stash_ref(project_dir, stash_sha)
+    if ref is None:
+        # Our entry is gone (already restored, or dropped by someone else).
+        # Applying nothing beats applying a stranger's work.
+        return False
+
+    applied = run_cmd(["git", "stash", "apply", ref], cwd=project_dir, check=False)
+    if applied.returncode != 0:
+        return False
+
+    # Re-resolve before dropping. `apply` does not shift the stack, but a peer
+    # lane's push between the two calls does, and dropping a stale position
+    # would discard their entry instead of ours.
+    ref = _resolve_stash_ref(project_dir, stash_sha)
+    if ref is not None:
+        run_cmd(["git", "stash", "drop", ref], cwd=project_dir, check=False)
+    return True
 
 
 def get_upstream_ref(project_dir: Path) -> str | None:
     """Return the current branch's upstream remote-tracking ref (``origin/main``).
 
     ``None`` when the branch has no upstream configured (detached HEAD, or a
-    local-only branch), which callers treat as "nothing to pull".
+    local-only branch), which callers surface as a pull failure.
     """
     result = run_cmd(
         ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
@@ -199,6 +257,7 @@ def git_pull(project_dir: Path) -> GitPullResult:
     before_sha = get_current_sha(project_dir)
     stashed = False
     stash_restored = False
+    stash_sha: str | None = None
 
     # Ensure pre-commit secret scanning hook is active
     run_cmd(["git", "config", "core.hooksPath", ".githooks"], cwd=project_dir, check=False)
@@ -206,7 +265,8 @@ def git_pull(project_dir: Path) -> GitPullResult:
     # Check for dirty working tree
     if is_dirty(project_dir):
         stashed = True
-        if not stash_changes(project_dir):
+        stash_sha = stash_changes(project_dir)
+        if not stash_sha:
             return GitPullResult(
                 success=False,
                 before_sha=before_sha,
@@ -224,7 +284,7 @@ def git_pull(project_dir: Path) -> GitPullResult:
     if not success:
         # Restore stash if we stashed
         if stashed:
-            stash_restored = stash_pop(project_dir)
+            stash_restored = stash_pop(project_dir, stash_sha)
 
         return GitPullResult(
             success=False,
@@ -234,12 +294,12 @@ def git_pull(project_dir: Path) -> GitPullResult:
             commits=[],
             stashed=stashed,
             stash_restored=stash_restored,
-            error=f"git pull --ff-only failed: {output}",
+            error=f"fast-forward to upstream failed: {output}",
         )
 
     # Restore stash
     if stashed:
-        stash_restored = stash_pop(project_dir)
+        stash_restored = stash_pop(project_dir, stash_sha)
 
     after_sha = get_current_sha(project_dir)
 

--- a/scripts/update/run.py
+++ b/scripts/update/run.py
@@ -1116,8 +1116,17 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
                         # Pull rebase and re-push; if our changes are already present,
                         # reset to origin/main (no warning needed).
                         try:
+                            # Fetch + rebase onto the NAMED ref, not FETCH_HEAD
+                            # (#2650): `git pull --rebase` resolves its onto-
+                            # target through .git/FETCH_HEAD, which every
+                            # worktree of the repo shares, so a peer lane's
+                            # concurrent fetch can retarget our rebase.
                             deps.run_cmd(
-                                ["git", "pull", "--rebase", "origin", "main"],
+                                ["git", "fetch", "origin", "main"],
+                                cwd=project_dir,
+                            )
+                            deps.run_cmd(
+                                ["git", "rebase", "origin/main"],
                                 cwd=project_dir,
                             )
                             # Check if our commit is still ahead of origin

--- a/tests/unit/test_update_pull_fetch_head_race.py
+++ b/tests/unit/test_update_pull_fetch_head_race.py
@@ -41,7 +41,10 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 # is not a pull.
 _EXECUTABLE_ROOTS = (
     REPO_ROOT / "scripts",
+    REPO_ROOT / ".githooks",
     REPO_ROOT / ".claude" / "commands",
+    REPO_ROOT / ".claude" / "hooks",
+    REPO_ROOT / ".claude" / "agents",
     REPO_ROOT / ".claude" / "skills",
     REPO_ROOT / ".claude" / "skills-global",
 )
@@ -65,13 +68,32 @@ _ARGV_PULL = re.compile(r"""["']git["']\s*,\s*["']pull["']""")
 _ARGV_PULL_WRAPPED = re.compile(r"""\[\s*["']pull["']\s*,""")
 
 
+def _has_shell_shebang(path: Path) -> bool:
+    """True for an extensionless file whose first line is a shell shebang.
+
+    `.githooks/` (`commit-msg`, `pre-commit`, `pre-push`) and `scripts/sdlc-tool`
+    are executable shell with no suffix, so a suffix-only filter would let a
+    future `git pull` hide in exactly the kind of file this sweep is about.
+    """
+    try:
+        with path.open("r", errors="ignore") as fh:
+            first = fh.readline()
+    except OSError:
+        return False
+    return first.startswith("#!") and ("sh" in first or "bash" in first or "zsh" in first)
+
+
 def _executable_files() -> list[Path]:
     files: list[Path] = []
     for root in _EXECUTABLE_ROOTS:
         if not root.exists():
             continue
         for path in root.rglob("*"):
-            if path.is_file() and path.suffix in _EXECUTABLE_SUFFIXES:
+            if not path.is_file() or "__pycache__" in path.parts:
+                continue
+            if path.suffix in _EXECUTABLE_SUFFIXES or (
+                not path.suffix and _has_shell_shebang(path)
+            ):
                 files.append(path)
     return sorted(files)
 
@@ -92,7 +114,7 @@ def _executable_regions(path: Path, text: str) -> list[tuple[int, str]]:
     if path.suffix == ".py":
         return [(1, text)]
 
-    if path.suffix == ".sh":
+    if path.suffix == ".sh" or not path.suffix:
         return [(i, line.split("#", 1)[0]) for i, line in enumerate(text.splitlines(), 1)]
 
     regions: list[tuple[int, str]] = []
@@ -327,9 +349,13 @@ class TestFetchHeadRace:
             ".claude/skills/update/SKILL.md",
             ".claude/skills/do-deploy/SKILL.md",
             ".claude/skills-global/weekly-review/SKILL.md",
+            # Extensionless shell -- a suffix-only filter would drop these,
+            # and they are as executable as anything with a .sh on it.
+            "scripts/sdlc-tool",
+            ".githooks/pre-push",
         ):
             assert required in found, f"sweep stopped discovering {required}"
-        assert len(found) > 50, len(found)
+        assert len(found) > 250, len(found)
 
     def test_no_bare_git_pull_survives_on_any_executable_surface(self):
         """A real sweep: every script and every agent-executable command body.
@@ -406,8 +432,9 @@ class TestStashIsRestoredByIdentity:
         from scripts.update.git import stash_changes, stash_pop
 
         (repo / "tracked.txt").write_text("OURS\n")
-        our_sha = stash_changes(repo)
-        assert our_sha, "stash_changes must return the stash commit sha"
+        result = stash_changes(repo)
+        assert result.ok and result.sha, "stash_changes must return our stash commit sha"
+        our_sha = result.sha
 
         # A peer lane in another worktree of the same repo stashes its own work.
         (repo / "tracked.txt").write_text("PEER\n")
@@ -422,30 +449,68 @@ class TestStashIsRestoredByIdentity:
         assert "peer lane auto-stash" in remaining
         assert "remote-update auto-stash" not in remaining  # ours was dropped
 
-    def test_missing_stash_restores_nothing_rather_than_a_strangers_work(self, repo: Path):
-        """If our entry is gone, applying nothing beats applying someone
-        else's — the failure mode that made the original bug destructive."""
+    def test_dropped_entry_still_restores_ours_and_never_a_strangers(self, repo: Path):
+        """Our entry is off the stack, a peer's is on it.
+
+        Applying by raw sha succeeds here — a dropped stash commit stays
+        reachable until gc — so this restores OUR work rather than declining.
+        That is the correct outcome and a deliberate contract change from the
+        position-based version, which returned False. The property that
+        matters is unchanged and asserted directly: a stranger's work never
+        enters this tree, and their entry is never dropped.
+        """
         from scripts.update.git import stash_changes, stash_pop
 
         (repo / "tracked.txt").write_text("OURS\n")
-        our_sha = stash_changes(repo)
+        our_sha = stash_changes(repo).sha
         assert our_sha
 
-        # Ours is dropped (already restored elsewhere), a peer's remains.
+        # Ours is dropped (e.g. already restored elsewhere); a peer's remains.
         ref = _git(repo, "stash", "list", "--format=%H %gd").stdout.split()[1]
         _git(repo, "stash", "drop", ref)
         (repo / "tracked.txt").write_text("PEER\n")
         _git(repo, "stash", "push", "-m", "peer lane auto-stash")
 
-        assert stash_pop(repo, our_sha) is False
-        assert (repo / "tracked.txt").read_text() == "committed\n"  # untouched
+        stash_pop(repo, our_sha)
+
+        assert (repo / "tracked.txt").read_text() == "OURS\n"  # ours, not PEER
+        assert "peer lane auto-stash" in _git(repo, "stash", "list").stdout
+
+    @pytest.mark.parametrize(
+        "bad_sha",
+        [
+            pytest.param("0" * 40, id="null-sha"),
+            pytest.param("deadbeef" * 5, id="nonexistent"),
+            pytest.param("stash@{0}", id="stack-position"),
+            pytest.param("HEAD", id="non-stash-rev"),
+            pytest.param("", id="empty"),
+            pytest.param(None, id="none"),
+        ],
+    )
+    def test_a_sha_that_is_not_ours_restores_nothing(self, repo: Path, bad_sha):
+        """Nothing but a real object id gets through to git.
+
+        The null sha is the dangerous one: `git stash apply 0000...0` is read
+        by git as "no argument" and silently applies `stash@{0}`, exiting 0.
+        In the shared checkout that restores a peer lane's work — the very
+        harm this function exists to prevent, reached through an argument
+        rather than a position. Verified against real git: it returned exit 0
+        with the peer's content in the tree.
+        """
+        from scripts.update.git import stash_pop
+
+        (repo / "tracked.txt").write_text("PEER\n")
+        _git(repo, "stash", "push", "-m", "peer lane auto-stash")
+
+        assert stash_pop(repo, bad_sha) is False
+        assert (repo / "tracked.txt").read_text() == "committed\n"
         assert "peer lane auto-stash" in _git(repo, "stash", "list").stdout
 
     def test_round_trip_with_no_peers(self, repo: Path):
         from scripts.update.git import stash_changes, stash_pop
 
         (repo / "tracked.txt").write_text("OURS\n")
-        our_sha = stash_changes(repo)
+        our_sha = stash_changes(repo).sha
         assert our_sha
         assert (repo / "tracked.txt").read_text() == "committed\n"
         assert stash_pop(repo, our_sha) is True
@@ -461,3 +526,106 @@ class TestStashIsRestoredByIdentity:
 
         assert stash_pop(repo, None) is False
         assert "peer lane auto-stash" in _git(repo, "stash", "list").stdout
+
+
+class TestStashIdentityIsNeverInferredFromTheStackTop:
+    """The identity must be OURS, not whatever sits on the shared stack.
+
+    `refs/stash` is a per-repository stack. Reading its top after our own
+    `git stash push` looks like it identifies our entry, and does not:
+
+    1. `git stash push` exits **0** when there is nothing to stash. A tree
+       whose only dirt is an untracked file is dirty by `git status
+       --porcelain` (what `is_dirty` uses) but declined by the push (no `-u`),
+       so the top read back is a PEER's entry. Restoring it writes their
+       uncommitted work into this checkout and drops it from the stack — the
+       original #2650 shape-1 harm, reached through the code written to
+       prevent it.
+    2. Even after a real push, a peer pushing before we read leaves their sha
+       on top.
+
+    So the entry is found by a token minted before the push. These tests drive
+    the real functions against real git repos.
+    """
+
+    @pytest.fixture
+    def repo(self, tmp_path: Path) -> Path:
+        r = tmp_path / "repo"
+        _git(tmp_path, "init", "-b", "main", str(r))
+        _git(r, "config", "user.email", "t@example.com")
+        _git(r, "config", "user.name", "T")
+        (r / "tracked.txt").write_text("committed\n")
+        _git(r, "add", "tracked.txt")
+        _git(r, "commit", "-m", "base")
+        return r
+
+    def test_untracked_only_tree_never_adopts_a_peers_stash(self, repo: Path):
+        """The blocker, directly. Our tree is dirty only by an untracked file
+        and a peer's stash is on the stack: we must report nothing-to-stash,
+        leave the peer's entry alone, and leave their work out of our tree."""
+        from scripts.update.git import is_dirty, stash_changes
+
+        (repo / "tracked.txt").write_text("PEERWORK\n")
+        _git(repo, "stash", "push", "-m", "peer lane auto-stash")
+        peer_sha = _git(repo, "rev-parse", "refs/stash").stdout.strip()
+
+        (repo / "untracked.txt").write_text("ours, untracked\n")
+        assert is_dirty(repo) is True  # porcelain counts the untracked file
+
+        result = stash_changes(repo)
+
+        assert result.ok is True, "nothing-to-stash is not a failure"
+        assert result.sha is None, f"must not adopt the peer's sha ({peer_sha})"
+        assert result.sha != peer_sha
+        # The peer's stash is untouched and their work stayed out of our tree.
+        assert "peer lane auto-stash" in _git(repo, "stash", "list").stdout
+        assert (repo / "tracked.txt").read_text() == "committed\n"
+
+    def test_a_peer_pushing_right_after_us_does_not_steal_our_identity(self, repo: Path):
+        """Our push lands, then a peer's push tops the stack before anyone
+        reads it. Token search still returns ours."""
+        from scripts.update.git import stash_changes, stash_pop
+
+        (repo / "tracked.txt").write_text("OURS\n")
+        result = stash_changes(repo)
+        assert result.ok and result.sha
+
+        (repo / "tracked.txt").write_text("PEER\n")
+        _git(repo, "stash", "push", "-m", "peer lane auto-stash")
+        assert _git(repo, "rev-parse", "refs/stash").stdout.strip() != result.sha
+
+        assert stash_pop(repo, result.sha) is True
+        assert (repo / "tracked.txt").read_text() == "OURS\n"
+        assert "peer lane auto-stash" in _git(repo, "stash", "list").stdout
+
+    def test_git_pull_treats_nothing_to_stash_as_success_not_failure(
+        self, clone_with_divergent_remote_branches: Path
+    ):
+        """`is_dirty` counts untracked files but the push declines them. If
+        that read as a stash failure, /update would break every time a stray
+        untracked file sat in the shared checkout."""
+        from scripts.update.git import git_pull
+
+        clone = clone_with_divergent_remote_branches
+        (clone / "scratch-note.txt").write_text("someone's scratch file\n")
+
+        result = git_pull(clone)
+
+        assert result.success is True, result.error
+        assert result.stashed is False  # nothing was stashed, so nothing to restore
+        assert _sha(clone, "HEAD") == _sha(clone, "origin/main")
+        assert (clone / "scratch-note.txt").exists()  # left alone
+
+    def test_token_is_unique_per_call(self, repo: Path):
+        """The token IS the identity, so two stashes in the same second must
+        not collide."""
+        from scripts.update.git import stash_changes
+
+        (repo / "tracked.txt").write_text("first\n")
+        first = stash_changes(repo)
+        (repo / "tracked.txt").write_text("second\n")
+        second = stash_changes(repo)
+
+        assert first.sha and second.sha and first.sha != second.sha
+        subjects = _git(repo, "stash", "list", "--format=%gs").stdout
+        assert subjects.count("remote-update auto-stash") == 2

--- a/tests/unit/test_update_pull_fetch_head_race.py
+++ b/tests/unit/test_update_pull_fetch_head_race.py
@@ -26,12 +26,109 @@ phrasing, is what these tests are about.
 
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
 
 import pytest
 
 from scripts.update.git import get_upstream_ref, pull_ff_only
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Roots holding things that actually execute: scripts, and the command/skill
+# bodies an agent runs. Deliberately excludes docs/ — prose describing a pull
+# is not a pull.
+_EXECUTABLE_ROOTS = (
+    REPO_ROOT / "scripts",
+    REPO_ROOT / ".claude" / "commands",
+    REPO_ROOT / ".claude" / "skills",
+    REPO_ROOT / ".claude" / "skills-global",
+)
+_EXECUTABLE_SUFFIXES = (".sh", ".py", ".md")
+
+# `git pull` anywhere in a command chain. The leading alternation is the fix
+# for the miss that this file's first version shipped: the old pattern anchored
+# on `^`, so `cd ~/src/ai && git checkout main && git pull` was invisible.
+#
+# Backtick is deliberately NOT a separator here. It means command substitution
+# in shell but code-span in markdown, and prose saying "never use `git pull`"
+# is everywhere in this codebase — including in the comments explaining this
+# very fix. The inline-bash `` !`…` `` wrapper is stripped in
+# :func:`_executable_regions` instead, so that form is still reached.
+_SHELL_PULL = re.compile(
+    r"(?:^|[;&|(]|&&|\|\||\bif\s+|\bthen\s+|\bdo\s+)\s*git\s+(?:-C\s+\S+\s+)?pull\b"
+)
+# Python argv forms: an explicit ["git", "pull", ...] and the `_run_git`
+# wrapper style that supplies the `git` itself — ["pull", "--rebase", ...].
+_ARGV_PULL = re.compile(r"""["']git["']\s*,\s*["']pull["']""")
+_ARGV_PULL_WRAPPED = re.compile(r"""\[\s*["']pull["']\s*,""")
+
+
+def _executable_files() -> list[Path]:
+    files: list[Path] = []
+    for root in _EXECUTABLE_ROOTS:
+        if not root.exists():
+            continue
+        for path in root.rglob("*"):
+            if path.is_file() and path.suffix in _EXECUTABLE_SUFFIXES:
+                files.append(path)
+    return sorted(files)
+
+
+def _executable_regions(path: Path, text: str) -> list[tuple[int, str]]:
+    """Return (line_number, text) for the parts of a file that actually run.
+
+    Markdown is mostly prose, and prose naming a command is not a command, so
+    only three regions count: fenced shell blocks, Claude Code's inline-bash
+    ``!`…` `` form, and ``allowed-tools:`` permission patterns (which encode a
+    literal command and must track it).
+
+    Comments are stripped everywhere they appear, including inside fenced
+    blocks — a comment explaining why `git pull` is wrong must not read as a
+    `git pull`. Python is returned whole and matched only by the argv
+    patterns, which cannot match English.
+    """
+    if path.suffix == ".py":
+        return [(1, text)]
+
+    if path.suffix == ".sh":
+        return [(i, line.split("#", 1)[0]) for i, line in enumerate(text.splitlines(), 1)]
+
+    regions: list[tuple[int, str]] = []
+    in_shell_fence = False
+    for i, line in enumerate(text.splitlines(), 1):
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            lang = stripped[3:].strip().lower()
+            in_shell_fence = lang in {"bash", "sh", "shell", "zsh", "console"}
+            continue
+        if stripped.startswith("!`"):
+            # Strip the inline-bash wrapper so the command inside is scanned
+            # as a command, without making backtick a shell separator globally.
+            regions.append((i, stripped[2:].rstrip("`")))
+        elif in_shell_fence or stripped.startswith("allowed-tools:"):
+            regions.append((i, line.split("#", 1)[0]))
+    return regions
+
+
+def _bare_pull_hits(path: Path) -> list[tuple[int, str]]:
+    text = path.read_text()
+    # Python invokes git through argv lists, never a shell string, so the
+    # shell pattern would only ever match its prose (docstrings, comments).
+    patterns = (
+        (_ARGV_PULL, _ARGV_PULL_WRAPPED)
+        if path.suffix == ".py"
+        else (_SHELL_PULL, _ARGV_PULL, _ARGV_PULL_WRAPPED)
+    )
+    hits: list[tuple[int, str]] = []
+    for start_line, region in _executable_regions(path, text):
+        for pattern in patterns:
+            for match in pattern.finditer(region):
+                line_no = start_line + region[: match.start()].count("\n")
+                snippet = region.splitlines()[region[: match.start()].count("\n")].strip()
+                hits.append((line_no, snippet[:100]))
+    return hits
 
 
 def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
@@ -215,48 +312,57 @@ class TestFetchHeadRace:
         assert "local work" in log
         assert "two" in log
 
-    def test_no_bare_git_pull_survives_anywhere_in_the_update_path(self):
-        """Sweep, not a checklist: `/update` runs from a shell wrapper and two
-        Python modules, and the incident came from the shell one. Any of them
-        reintroducing `git pull` restores the race, so all are swept.
+    def test_the_sweep_discovers_the_known_execution_surfaces(self):
+        """Guard the guard. The first version of this sweep was a three-entry
+        list that called itself a sweep, and it missed `/update`'s own
+        slash-command — the most-used entry point of the path it was named
+        after. Discovery replaced the list; this asserts discovery works."""
+        found = {p.relative_to(REPO_ROOT).as_posix() for p in _executable_files()}
+        for required in (
+            "scripts/remote-update.sh",
+            "scripts/update/git.py",
+            "scripts/update/run.py",
+            "scripts/migrate_completed_plan.py",
+            ".claude/commands/update.md",
+            ".claude/skills/update/SKILL.md",
+            ".claude/skills/do-deploy/SKILL.md",
+            ".claude/skills-global/weekly-review/SKILL.md",
+        ):
+            assert required in found, f"sweep stopped discovering {required}"
+        assert len(found) > 50, len(found)
+
+    def test_no_bare_git_pull_survives_on_any_executable_surface(self):
+        """A real sweep: every script and every agent-executable command body.
+
+        `git pull` resolves its merge (or rebase) target through
+        `.git/FETCH_HEAD`, which is per-repository. Any of these surfaces
+        reintroducing it restores the race, and they all run against the same
+        shared `~/src/ai` checkout during exactly the multi-lane conditions
+        #2650 describes.
+
+        Caught regardless of shape: a pull chained after `&&` (which the
+        original pattern's line-start anchor missed), an inline-bash
+        `` !`…` `` command body, a `Bash(...)` permission pattern, and both
+        argv forms — `["git", "pull", …]` and a `_run_git(["pull", …])`
+        wrapper that supplies the `git` itself.
 
         `git pull --rebase origin main` is caught too: naming the remote and
         branch does not help, because the rebase still takes its onto-target
         from FETCH_HEAD.
         """
-        import re
-
-        repo_root = Path(__file__).resolve().parents[2]
-        swept = [
-            repo_root / "scripts" / "remote-update.sh",
-            repo_root / "scripts" / "update" / "git.py",
-            repo_root / "scripts" / "update" / "run.py",
-        ]
-
-        # A `git pull` invocation in shell form or argv-list form. Prose
-        # mentions ("used after git pull pulls new code") are not invocations,
-        # so the shell pattern requires the command to start a statement and
-        # the argv pattern requires the quoted-list shape.
-        shell_pull = re.compile(r"^\s*(?:if\s+)?git\s+(?:-C\s+\S+\s+)?pull\b", re.MULTILINE)
-        argv_pull = re.compile(r"""["']git["']\s*,\s*["']pull["']""")
-
         offenders = []
-        for path in swept:
-            assert path.exists(), f"swept file missing -- update the sweep: {path}"
-            text = path.read_text()
-            for pattern in (shell_pull, argv_pull):
-                for match in pattern.finditer(text):
-                    line_no = text[: match.start()].count("\n") + 1
-                    offenders.append(f"{path.relative_to(repo_root)}:{line_no}")
+        for path in _executable_files():
+            for line_no, snippet in _bare_pull_hits(path):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{line_no}  {snippet}")
 
         assert not offenders, (
             "bare `git pull` resolves its merge/rebase target through the "
             "repo-shared .git/FETCH_HEAD and races concurrent lanes (#2650); "
             "use `git fetch <remote> <branch>` + "
-            f"`git merge --ff-only <remote>/<branch>`: {offenders}"
+            "`git merge --ff-only <remote>/<branch>`:\n  " + "\n  ".join(offenders)
         )
 
-    def test_no_upstream_is_reported_not_crashed(self, tmp_path: Path):
+    def test_no_upstream_is_reported_not_crashed_local(self, tmp_path: Path):
         repo = tmp_path / "solo"
         _git(tmp_path, "init", "-b", "main", str(repo))
         _git(repo, "config", "user.email", "t@example.com")
@@ -269,3 +375,89 @@ class TestFetchHeadRace:
         success, output = pull_ff_only(repo)
         assert success is False
         assert "upstream" in output.lower()
+
+
+class TestStashIsRestoredByIdentity:
+    """`refs/stash` is per-repository too (#2650, shape 1).
+
+    `/update` stashes a dirty tree before fast-forwarding and restores it
+    after. It used to restore with a bare `git stash pop`, which means
+    `stash@{0}` — whatever anyone pushed most recently. Between our push and
+    our pop, a concurrent lane's `git stash` becomes `stash@{0}`, so `/update`
+    would restore that lane's uncommitted work into this checkout and leave
+    ours buried. Same family as the autostash collision in #2650, inside the
+    function that PR hardens.
+    """
+
+    @pytest.fixture
+    def repo(self, tmp_path: Path) -> Path:
+        r = tmp_path / "repo"
+        _git(tmp_path, "init", "-b", "main", str(r))
+        _git(r, "config", "user.email", "t@example.com")
+        _git(r, "config", "user.name", "T")
+        (r / "tracked.txt").write_text("committed\n")
+        _git(r, "add", "tracked.txt")
+        _git(r, "commit", "-m", "base")
+        return r
+
+    def test_restores_our_stash_not_a_peer_stash_pushed_after_ours(self, repo: Path):
+        """The bug, directly. Ours goes on the stack first, a peer's lands on
+        top, and the restore must still bring back ours."""
+        from scripts.update.git import stash_changes, stash_pop
+
+        (repo / "tracked.txt").write_text("OURS\n")
+        our_sha = stash_changes(repo)
+        assert our_sha, "stash_changes must return the stash commit sha"
+
+        # A peer lane in another worktree of the same repo stashes its own work.
+        (repo / "tracked.txt").write_text("PEER\n")
+        _git(repo, "stash", "push", "-m", "peer lane auto-stash")
+        assert "PEER" not in (repo / "tracked.txt").read_text()
+
+        assert stash_pop(repo, our_sha) is True
+        assert (repo / "tracked.txt").read_text() == "OURS\n"
+
+        # The peer's stash is untouched and still restorable by them.
+        remaining = _git(repo, "stash", "list").stdout
+        assert "peer lane auto-stash" in remaining
+        assert "remote-update auto-stash" not in remaining  # ours was dropped
+
+    def test_missing_stash_restores_nothing_rather_than_a_strangers_work(self, repo: Path):
+        """If our entry is gone, applying nothing beats applying someone
+        else's — the failure mode that made the original bug destructive."""
+        from scripts.update.git import stash_changes, stash_pop
+
+        (repo / "tracked.txt").write_text("OURS\n")
+        our_sha = stash_changes(repo)
+        assert our_sha
+
+        # Ours is dropped (already restored elsewhere), a peer's remains.
+        ref = _git(repo, "stash", "list", "--format=%H %gd").stdout.split()[1]
+        _git(repo, "stash", "drop", ref)
+        (repo / "tracked.txt").write_text("PEER\n")
+        _git(repo, "stash", "push", "-m", "peer lane auto-stash")
+
+        assert stash_pop(repo, our_sha) is False
+        assert (repo / "tracked.txt").read_text() == "committed\n"  # untouched
+        assert "peer lane auto-stash" in _git(repo, "stash", "list").stdout
+
+    def test_round_trip_with_no_peers(self, repo: Path):
+        from scripts.update.git import stash_changes, stash_pop
+
+        (repo / "tracked.txt").write_text("OURS\n")
+        our_sha = stash_changes(repo)
+        assert our_sha
+        assert (repo / "tracked.txt").read_text() == "committed\n"
+        assert stash_pop(repo, our_sha) is True
+        assert (repo / "tracked.txt").read_text() == "OURS\n"
+        assert _git(repo, "stash", "list").stdout.strip() == ""
+
+    def test_no_sha_is_a_refusal_not_a_bare_pop(self, repo: Path):
+        """Without an identity there is nothing safe to restore."""
+        from scripts.update.git import stash_pop
+
+        (repo / "tracked.txt").write_text("PEER\n")
+        _git(repo, "stash", "push", "-m", "peer lane auto-stash")
+
+        assert stash_pop(repo, None) is False
+        assert "peer lane auto-stash" in _git(repo, "stash", "list").stdout

--- a/tests/unit/test_update_pull_fetch_head_race.py
+++ b/tests/unit/test_update_pull_fetch_head_race.py
@@ -629,3 +629,80 @@ class TestStashIdentityIsNeverInferredFromTheStackTop:
         assert first.sha and second.sha and first.sha != second.sha
         subjects = _git(repo, "stash", "list", "--format=%gs").stdout
         assert subjects.count("remote-update auto-stash") == 2
+
+
+class TestStashListFailureFailsClosed:
+    """A failed `git stash list` must not read as "nothing was stashed".
+
+    `_stash_entries` returning `[]` for both an empty stack and a failed read
+    would run downhill: no token match, `StashResult(ok=True, sha=None)`,
+    `git_pull` sets `stashed=False`, skips the restore, and reports success.
+    If the push *did* create an entry, the user's work is stranded in the stack
+    under a token nobody will look up, and the pull proceeds over the tree it
+    came from.
+
+    This module exists because that class of fail-open guess loses other lanes'
+    work, so the read failure fails closed and `git_pull` aborts through its
+    existing error path.
+    """
+
+    @pytest.fixture
+    def repo(self, tmp_path: Path) -> Path:
+        r = tmp_path / "repo"
+        _git(tmp_path, "init", "-b", "main", str(r))
+        _git(r, "config", "user.email", "t@example.com")
+        _git(r, "config", "user.name", "T")
+        (r / "tracked.txt").write_text("committed\n")
+        _git(r, "add", "tracked.txt")
+        _git(r, "commit", "-m", "base")
+        return r
+
+    @staticmethod
+    def _break_stash_list(monkeypatch):
+        """Fail only `git stash list`; every other git call runs for real."""
+        import scripts.update.git as gitmod
+
+        real = gitmod.run_cmd
+
+        def failing(cmd, cwd=None, check=True):
+            if len(cmd) >= 3 and cmd[:3] == ["git", "stash", "list"]:
+                return subprocess.CompletedProcess(cmd, 128, "", "fatal: cannot read stash\n")
+            return real(cmd, cwd=cwd, check=check)
+
+        monkeypatch.setattr(gitmod, "run_cmd", failing)
+
+    def test_empty_stack_and_failed_read_are_distinguishable(self, repo: Path, monkeypatch):
+        """The distinction the fix rests on, asserted directly."""
+        from scripts.update.git import _stash_entries
+
+        assert _stash_entries(repo) == []  # empty stack: a real answer
+        self._break_stash_list(monkeypatch)
+        assert _stash_entries(repo) is None  # failed read: not an answer
+
+    def test_stash_changes_reports_failure_not_nothing_to_stash(self, repo: Path, monkeypatch):
+        from scripts.update.git import stash_changes
+
+        (repo / "tracked.txt").write_text("OURS\n")
+        self._break_stash_list(monkeypatch)
+
+        result = stash_changes(repo)
+
+        assert result.ok is False, "a failed listing must not read as ok"
+        assert result.sha is None
+
+    def test_git_pull_aborts_rather_than_pulling_over_stranded_work(
+        self, clone_with_divergent_remote_branches: Path, monkeypatch
+    ):
+        """The consequence that matters: the pull must not proceed."""
+        from scripts.update.git import git_pull
+
+        clone = clone_with_divergent_remote_branches
+        (clone / "a.txt").write_text("uncommitted local work\n")
+        before = _sha(clone, "HEAD")
+        self._break_stash_list(monkeypatch)
+
+        result = git_pull(clone)
+
+        assert result.success is False
+        assert result.error and "stash" in result.error.lower()
+        assert _sha(clone, "HEAD") == before  # did not move

--- a/tests/unit/test_update_pull_fetch_head_race.py
+++ b/tests/unit/test_update_pull_fetch_head_race.py
@@ -1,0 +1,271 @@
+"""`/update`'s pull must not resolve its merge target through FETCH_HEAD (#2650).
+
+`.git/FETCH_HEAD` is per-*repository*, not per-worktree. This machine runs
+concurrent SDLC lanes across many worktrees of one repo, so a bare
+``git pull --ff-only`` races: a peer lane's fetch rewrites FETCH_HEAD between
+our fetch and our merge, and the merge resolves the peer's refs instead of
+ours. That killed three consecutive ``/update`` attempts on 2026-08-07 with
+``fatal: Cannot fast-forward to multiple branches``.
+
+These tests build a real remote + clone on disk (no mocks, no network).
+
+**On the control.** ``git pull`` cannot itself be the control: it is fetch +
+merge, and its own fetch overwrites any FETCH_HEAD poison planted beforehand,
+so it passes and proves nothing. (Confirmed the hard way — the first version of
+this file asserted exactly that and the control came back green.) The race
+lands the peer's write *between* those two internal steps, which is not
+reachable from outside the process. So the control targets the merge step
+directly: ``git merge --ff-only FETCH_HEAD`` is what ``git pull --ff-only``
+runs after fetching, and it is where the wrong target is read.
+
+The failure is asserted as a non-zero exit rather than a message match. Git
+words this differently across versions ("Cannot fast-forward to multiple
+branches" vs "Not possible to fast-forward"), and the mechanism, not the
+phrasing, is what these tests are about.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.update.git import get_upstream_ref, pull_ff_only
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=True)
+
+
+def _sha(cwd: Path, ref: str) -> str:
+    return _git(cwd, "rev-parse", ref).stdout.strip()
+
+
+def _poison(clone: Path) -> None:
+    """Write the FETCH_HEAD a peer lane's concurrent fetch leaves behind.
+
+    Two real, mutually divergent heads, each individually fast-forwardable
+    from the clone's HEAD — the shape that has no single ff target.
+    """
+    (clone / ".git" / "FETCH_HEAD").write_text(
+        f"{_sha(clone, 'origin/main')}\t\tbranch 'main' of remote\n"
+        f"{_sha(clone, 'origin/other')}\t\tbranch 'other' of remote\n"
+    )
+
+
+@pytest.fixture
+def clone_with_divergent_remote_branches(tmp_path: Path) -> Path:
+    """A clone one commit behind origin/main, with a divergent origin/other.
+
+    Layout — the clone sits at `one`, and `two` and `other` are siblings, so
+    neither remote head is an ancestor of the other:
+
+        one ── two      (origin/main)
+          └─── other    (origin/other)
+    """
+    remote = tmp_path / "remote.git"
+    seed = tmp_path / "seed"
+    clone = tmp_path / "clone"
+
+    _git(tmp_path, "init", "--bare", "-b", "main", str(remote))
+    _git(tmp_path, "clone", str(remote), str(seed))
+    _git(seed, "config", "user.email", "t@example.com")
+    _git(seed, "config", "user.name", "T")
+    (seed / "a.txt").write_text("one\n")
+    _git(seed, "add", "a.txt")
+    _git(seed, "commit", "-m", "one")
+    _git(seed, "push", "-u", "origin", "main")
+
+    # Clone now, so it stays pinned at `one`.
+    _git(tmp_path, "clone", str(remote), str(clone))
+    _git(clone, "config", "user.email", "t@example.com")
+    _git(clone, "config", "user.name", "T")
+
+    _git(seed, "checkout", "-b", "other")
+    (seed / "b.txt").write_text("other\n")
+    _git(seed, "add", "b.txt")
+    _git(seed, "commit", "-m", "other")
+    _git(seed, "push", "origin", "other")
+
+    _git(seed, "checkout", "main")
+    (seed / "a.txt").write_text("two\n")
+    _git(seed, "add", "a.txt")
+    _git(seed, "commit", "-m", "two")
+    _git(seed, "push", "origin", "main")
+
+    _git(clone, "fetch", "origin", "main")
+    _git(clone, "fetch", "origin", "other")
+    return clone
+
+
+class TestFetchHeadRace:
+    def test_control_merging_fetch_head_fails_under_a_peer_fetch(
+        self, clone_with_divergent_remote_branches: Path
+    ):
+        """The control: resolving the merge target through FETCH_HEAD really
+        does break once a peer has written it. Without this, a green treatment
+        test would only prove the fixture is harmless."""
+        clone = clone_with_divergent_remote_branches
+        _poison(clone)
+
+        result = subprocess.run(
+            ["git", "merge", "--ff-only", "FETCH_HEAD"],
+            cwd=clone,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode != 0, result.stdout + result.stderr
+        assert "fast-forward" in (result.stdout + result.stderr).lower()
+        # And the clone did not move.
+        assert _sha(clone, "HEAD") != _sha(clone, "origin/main")
+
+    def test_treatment_merging_the_named_ref_succeeds_in_the_same_state(
+        self, clone_with_divergent_remote_branches: Path
+    ):
+        """Same poisoned FETCH_HEAD, named remote-tracking ref: immune."""
+        clone = clone_with_divergent_remote_branches
+        _poison(clone)
+
+        result = subprocess.run(
+            ["git", "merge", "--ff-only", "origin/main"],
+            cwd=clone,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert _sha(clone, "HEAD") == _sha(clone, "origin/main")
+
+    def test_pull_ff_only_survives_a_peer_fetch_landing_mid_pull(
+        self, clone_with_divergent_remote_branches: Path, monkeypatch
+    ):
+        """End to end: the peer's write lands right after our fetch, exactly
+        where the real race puts it, and `pull_ff_only` still lands correctly."""
+        import scripts.update.git as gitmod
+
+        clone = clone_with_divergent_remote_branches
+        real_run_cmd = gitmod.run_cmd
+
+        def racing_run_cmd(cmd, cwd=None, check=True):
+            result = real_run_cmd(cmd, cwd=cwd, check=check)
+            if len(cmd) >= 2 and cmd[0] == "git" and cmd[1] == "fetch":
+                _poison(clone)  # the peer lane, in miniature
+            return result
+
+        monkeypatch.setattr(gitmod, "run_cmd", racing_run_cmd)
+
+        before = _sha(clone, "HEAD")
+        success, output = pull_ff_only(clone)
+
+        assert success is True, output
+        assert _sha(clone, "HEAD") != before
+        assert _sha(clone, "HEAD") == _sha(clone, "origin/main")
+
+    def test_pull_ff_only_never_shells_out_to_bare_git_pull(
+        self, clone_with_divergent_remote_branches: Path, monkeypatch
+    ):
+        """The load-bearing property, asserted on the command trail.
+
+        A future edit reintroducing `git pull` would still pass the behavioral
+        test above — its own fetch clears the poison — so the command shape is
+        asserted directly rather than inferred from an outcome.
+        """
+        import scripts.update.git as gitmod
+
+        real_run_cmd = gitmod.run_cmd
+        seen: list[list[str]] = []
+
+        def recording_run_cmd(cmd, cwd=None, check=True):
+            seen.append(list(cmd))
+            return real_run_cmd(cmd, cwd=cwd, check=check)
+
+        monkeypatch.setattr(gitmod, "run_cmd", recording_run_cmd)
+        success, output = pull_ff_only(clone_with_divergent_remote_branches)
+
+        assert success is True, output
+        git_cmds = [c for c in seen if c and c[0] == "git"]
+        assert not any(c[1] == "pull" for c in git_cmds), git_cmds
+        assert ["git", "fetch", "origin", "main"] in git_cmds
+        assert ["git", "merge", "--ff-only", "origin/main"] in git_cmds
+
+    def test_already_up_to_date_is_success(self, clone_with_divergent_remote_branches: Path):
+        clone = clone_with_divergent_remote_branches
+        assert pull_ff_only(clone)[0] is True
+        # Nothing left to do; still a success, not a spurious failure.
+        assert pull_ff_only(clone)[0] is True
+
+    def test_diverged_branch_rebases_onto_the_named_ref(
+        self, clone_with_divergent_remote_branches: Path
+    ):
+        """Divergence falls back to rebase — onto `origin/main`, never
+        onto FETCH_HEAD."""
+        clone = clone_with_divergent_remote_branches
+        (clone / "local.txt").write_text("local\n")
+        _git(clone, "add", "local.txt")
+        _git(clone, "commit", "-m", "local work")
+
+        success, output = pull_ff_only(clone)
+
+        assert success is True, output
+        log = _git(clone, "log", "--oneline", "-3").stdout
+        assert "local work" in log
+        assert "two" in log
+
+    def test_no_bare_git_pull_survives_anywhere_in_the_update_path(self):
+        """Sweep, not a checklist: `/update` runs from a shell wrapper and two
+        Python modules, and the incident came from the shell one. Any of them
+        reintroducing `git pull` restores the race, so all are swept.
+
+        `git pull --rebase origin main` is caught too: naming the remote and
+        branch does not help, because the rebase still takes its onto-target
+        from FETCH_HEAD.
+        """
+        import re
+
+        repo_root = Path(__file__).resolve().parents[2]
+        swept = [
+            repo_root / "scripts" / "remote-update.sh",
+            repo_root / "scripts" / "update" / "git.py",
+            repo_root / "scripts" / "update" / "run.py",
+        ]
+
+        # A `git pull` invocation in shell form or argv-list form. Prose
+        # mentions ("used after git pull pulls new code") are not invocations,
+        # so the shell pattern requires the command to start a statement and
+        # the argv pattern requires the quoted-list shape.
+        shell_pull = re.compile(r"^\s*(?:if\s+)?git\s+(?:-C\s+\S+\s+)?pull\b", re.MULTILINE)
+        argv_pull = re.compile(r"""["']git["']\s*,\s*["']pull["']""")
+
+        offenders = []
+        for path in swept:
+            assert path.exists(), f"swept file missing -- update the sweep: {path}"
+            text = path.read_text()
+            for pattern in (shell_pull, argv_pull):
+                for match in pattern.finditer(text):
+                    line_no = text[: match.start()].count("\n") + 1
+                    offenders.append(f"{path.relative_to(repo_root)}:{line_no}")
+
+        assert not offenders, (
+            "bare `git pull` resolves its merge/rebase target through the "
+            "repo-shared .git/FETCH_HEAD and races concurrent lanes (#2650); "
+            "use `git fetch <remote> <branch>` + "
+            f"`git merge --ff-only <remote>/<branch>`: {offenders}"
+        )
+
+    def test_no_upstream_is_reported_not_crashed(self, tmp_path: Path):
+        repo = tmp_path / "solo"
+        _git(tmp_path, "init", "-b", "main", str(repo))
+        _git(repo, "config", "user.email", "t@example.com")
+        _git(repo, "config", "user.name", "T")
+        (repo / "f.txt").write_text("x\n")
+        _git(repo, "add", "f.txt")
+        _git(repo, "commit", "-m", "c")
+
+        assert get_upstream_ref(repo) is None
+        success, output = pull_ff_only(repo)
+        assert success is False
+        assert "upstream" in output.lower()


### PR DESCRIPTION
Closes #2697. Refs #2650 — closes shape 2 outright, hardens shape 1 inside `/update`, and states the rules behind shapes 3 and 4. Does **not** close the issue; the plan-doc single-writer lease is the remaining acceptance criterion and needs a plan.

## Shape 2: the FETCH_HEAD race

`.git/FETCH_HEAD` is per-*repository*, not per-worktree. With concurrent SDLC lanes across many worktrees of one repo, bare `git pull` races: its merge step resolves the target through FETCH_HEAD, a peer lane's fetch lands between our fetch and our merge, and the merge reads their refs.

```
fatal: Cannot fast-forward to multiple branches
```

Three consecutive `/update` attempts died this way on 2026-08-07. The workaround was to pull only when the machine was quiet.

**The sweep found more than the issue reported.** The issue named `scripts/update/git.py`. The primary offender was `scripts/remote-update.sh` — it pulls *first*, before any Python runs. Widening further found four more, including `scripts/migrate_completed_plan.py`, which rebases on the shared main checkout where plan-doc migrations run.

| Site | Now |
|---|---|
| `scripts/remote-update.sh` | `git fetch origin main` + `git merge --ff-only origin/main` |
| `scripts/update/git.py::pull_ff_only` | fetch + merge/rebase the resolved `@{upstream}` |
| `scripts/update/run.py` | `git fetch origin main` + `git rebase origin/main` |
| `scripts/migrate_completed_plan.py` | same |
| `.claude/commands/update.md` (body + `allowed-tools`) | fetch + ff-merge |
| `.claude/skills/{update,setup,do-deploy}/SKILL.md` | fetch + ff-merge |
| `.claude/skills-global/weekly-review/SKILL.md` | `git fetch && git merge --ff-only @{upstream}` — the branch-portable form, since this skill is global |
| `.claude/skills-global/do-deploy-example/SKILL.md` | `git -C "$REPO" fetch origin main` + `merge --ff-only origin/main` — named ref, matching its deploy-to-main intent |

## Shape 1: the stash, inside `/update` itself

`refs/stash` is a per-repository stack too. `/update` stashes a dirty tree before fast-forwarding and restored it with a bare `git stash pop` — `stash@{0}`, whatever *anyone* pushed last. A peer stashing in between meant `/update` restored their work into the shared checkout and buried ours.

Fixing that turned out to have two more layers, both found by review and by testing rather than by reasoning:

**Identity cannot be read from the stack.** Keying on the sha from `rev-parse refs/stash` after our own push still captures a peer's entry, because `git stash push` **exits 0 when there is nothing to stash**. `is_dirty()` uses `git status --porcelain`, which counts untracked files; the push (no `-u`) does not. An untracked-only tree — ordinary in the shared checkout — prints `No local changes to save`, exits 0, and the follow-up read returns a peer's sha. Identity is now a unique token minted *before* the push and found by searching stash messages, so no shared state is read at any point.

**`git stash apply` has a null-sha fallback.** Writing the test surfaced a second, independent path: `git stash apply 0000…0` is read by git as "no argument" and silently applies `stash@{0}`, exit 0. So does passing `stash@{0}` itself. Verified against real git — it returned exit 0 with the peer's content in the tree. Only a non-zero 40-hex id resolving to a real commit now reaches git.

Two alternatives were considered and rejected:

- **Before/after `refs/stash` comparison** does not close it. Peer pushes after ours, `before != after`, and we adopt theirs anyway.
- **`git stash create` + `store` + reset**, the classic idiom, requires `git reset --hard` on the shared checkout. This repo's own `validate_no_destructive_git_in_shared_checkout` hook forbids that shape — it blocked the scratch test I wrote for it, which settled the question.

`--include-untracked` was also rejected: in a shared checkout it would stash *other lanes'* scratch files and restore them later, which is its own cross-lane collision. Untracked files are left alone, and "nothing to stash" is now a first-class outcome (`StashResult`) so `git_pull` no longer reports it as `Failed to stash changes` — which would have broken `/update` whenever a stray untracked file was present.

**A failed listing is not an answer.** `_stash_entries` returned `[]` for both an empty stack and a failed `git stash list`, so a read failure became a confident "nothing was stashed" — `git_pull` would skip the restore and report success while real work sat in the stack under a token nobody would look up. It now returns `None` on error, distinct from `[]`, and `stash_changes` turns that into `StashResult(ok=False)` so the pull aborts. No one could induce a natural `git stash list` failure, so this is the error convention rather than an observed fault; it still had to change, because a PR about fail-open guesses in shared-checkout git handling cannot ship one in its own error path.

## On the control — the part worth reading

**`git pull` cannot be its own control.** It is fetch + merge, and its own fetch overwrites any FETCH_HEAD poison planted beforehand. The first version of this test file asserted exactly that, and the control came back **green** — a fixture that proved nothing while looking rigorous.

So the control targets the merge step directly, which is where the wrong target is read:

```
CONTROL   git merge --ff-only FETCH_HEAD   -> FAILED exit=128
TREATMENT git merge --ff-only origin/main  -> SUCCEEDED, HEAD == origin/main
```

Failure is asserted as a non-zero exit, not a message match — git words this differently across versions.

## Verification

**Demonstrated red.** Against `origin/main`, the sweep flags all 12 offending lines across 10 files; on the branch, zero.

**Every guard mutation-checked:**

| Mutation | Result |
|---|---|
| merge step back to `git pull` | **2 red of 26** — `test_pull_ff_only_never_shells_out_to_bare_git_pull` and the sweep, which catches the reintroduced argv form. The behavioral test stays green, because the reintroduced pull's own fetch clears the poison — which is why the command-shape assertion earns its place |
| revert `.claude/commands/update.md` | sweep red on both forms (body + `allowed-tools`) |
| stash identity back to the stack top | 2 red |
| drop the sha guard | `null-sha` and `stack-position` cases red |
| `stash_pop` back to bare positional pop | **10 red of 17** across the three stash classes; `test_round_trip_with_no_peers` stays green, which is exactly why the bug survived — a bare pop is correct right up until a peer exists |

```
tests/unit/test_update_pull_fetch_head_race.py                       26 passed
+ test_worktree_manager, test_update_cron_summary,
  test_remote_update_shell, test_migrate_completed_plan             169 passed
ruff check / format, bash -n scripts/remote-update.sh                clean
```

The sweep discovers **300** files across `scripts/`, `.githooks/`, `.claude/{commands,hooks,agents,skills,skills-global}/`, including extensionless shell caught by shebang (`scripts/sdlc-tool`, `.githooks/pre-push`). A `test_the_sweep_discovers_the_known_execution_surfaces` case guards the guard.

## Also corrected

`agent/worktree_manager.py` claimed a worktree's stash is worktree-local and dies with the worktree. It is not — `refs/stash` lives in the common ref store and survives (verified on git 2.50.1), which is the premise this PR rests on. Its conclusion (WIP commit + named ref) still holds, now for the accurate reason: the shared stack is exactly what makes a position-keyed backstop unsafe.

## What remains on #2650

The headline criterion — a plan-doc single-writer lease with staleness semantics covering the supervisor-vs-own-child case — is deliberately not here. The issue leaves the mechanism open, and a wrong lease would wedge every plan doc on the machine, so it wants a plan and a critique round. The "warn on dirty `docs/plans/` at a stage boundary" criterion is also unlanded; its natural home is a hook.

## Merge safety

**Safe to merge during the fan-out.** The git changes only affect `/update`, which no lane runs mid-pipeline, and they strictly reduce cross-lane interference. Skill-body edits are additive prose reaching agents only after merge plus a `/update` sync.

Two things worth knowing. `stash_changes` changed its return type to `StashResult`; its only caller is in the same module and updated in the same commit. And `scripts/remote-update.sh` is the script `/update` runs, so the first `/update` after this merges executes the **old** wrapper and picks up the new one the run after — the normal self-update lag for that file, not a new hazard.

Refs #2448, #2064, #2050, #2628.


