### PR TITLE
Register Job in the guarded index-repair sweep (#2640)

### DIFF
--- a/docs/features/durability-model.md
+++ b/docs/features/durability-model.md
@@ -112,15 +112,18 @@ seemingly-closed conversation can pick up where it left off weeks later.
 
 ## Index safety (#2207 discipline)
 
-Both `Room` and `Job` ship with their own guarded `repair_indexes()` and a
-`_GUARDED_ELSEWHERE` entry in `scripts/popoto_index_cleanup.py`, so the
-generic `rebuild_indexes()` sweep never touches them; both register a
+Both `Room` and `Job` ship with their own guarded `repair_indexes()`, are
+registered in `_run_guarded_repairs()` so that repair path actually runs, and
+carry a `_GUARDED_ELSEWHERE` entry in `scripts/popoto_index_cleanup.py` so the
+generic `rebuild_indexes()` sweep skips them instead; both register a
 `ModelDriftSpec` in `agent/index_drift.py` (drift detection never silently
-narrows). `Job` carries two IndexedFields, both low-cardinality: `status`
-(active/at-rest) and the derived boolean `has_open_promises` (Schema Gate
-Amendment 1, PR #2646); no index holds a pid, uuid, or timestamp. The reply index
-is a plain string KV — no hash, no class set, no secondary index — so the
-identity-less-hash flood mechanism structurally cannot occur for it.
+narrows). Listing a model in `_GUARDED_ELSEWHERE` without registering it in
+`_run_guarded_repairs()` leaves it with no index hygiene at all — the gap
+that produced #2640. `Job` carries two IndexedFields, both low-cardinality:
+`status` (active/at-rest) and the derived boolean `has_open_promises` (Schema
+Gate Amendment 1, PR #2646); no index holds a pid, uuid, or timestamp. The
+reply index is a plain string KV — no hash, no class set, no secondary index —
+so the identity-less-hash flood mechanism structurally cannot occur for it.
 
 The daily `has_open_promises` backfill (`Job.backfill_open_promises_index()`,
 run from `repair_indexes()` while the bridge and workers are live) writes

--- a/docs/features/popoto-index-hygiene.md
+++ b/docs/features/popoto-index-hygiene.md
@@ -37,19 +37,28 @@ Note the scope of that statement: since issue #2536, `Model.rebuild_indexes()` *
 ### How `run_cleanup()` Works
 
 1. Iterates all Popoto models from `models/__init__.__all__`, deduped and filtered by class `__name__` (not the `__all__` export string -- an alias like `AgentSession` for `AgentSession` cannot smuggle a guarded model past the exclusion checks)
-2. Skips models in `_SCHEDULER_STATE_MODELS` (live `get_or_create`-per-tick models, see Concurrency Safety) and `_GUARDED_ELSEWHERE` (models whose index hygiene is handled by their own guarded rebuild path -- currently just `AgentSession`)
+2. Skips models in `_SCHEDULER_STATE_MODELS` (live `get_or_create`-per-tick models, see Concurrency Safety) and `_GUARDED_ELSEWHERE` (`AgentSession`, `Room`, `Job` -- models whose index hygiene is handled by their own guarded `repair_indexes()` path)
 3. For each remaining model, counts orphaned index entries (dry-run scan) and captures a `keyspace_before` SCARD snapshot of the model's class-set index
 4. Runs `Model.rebuild_indexes()` in a daemon thread with a wall-clock timeout (see [Step 1 Un-Wedge](#step-1-un-wedge-daemon-thread--join-timeout) below), then captures `keyspace_after` and computes `keyspace_delta = keyspace_after - keyspace_before`
 5. Logs per-model orphan counts found/cleaned and the keyspace delta
+6. Finally runs `_run_guarded_repairs()`, which invokes the guarded `repair_indexes()` of each `_GUARDED_ELSEWHERE` model that has no other caller -- `Room` and `Job`. Results land under the summary's `guarded_repairs` key.
 
 Each model is processed independently -- one model failure does not abort the sweep. The SCAN-based `rebuild_indexes()` is safe to run concurrently with normal operations for every model still in scope.
+
+### The two-part `_GUARDED_ELSEWHERE` contract
+
+Listing a model in `_GUARDED_ELSEWHERE` is only half of registering it. The frozenset removes the model from the generic sweep; `_run_guarded_repairs()`'s `guarded_repairs` registry is what puts its own repair path back on the schedule. A model in the first and absent from the second receives **no index hygiene at all**.
+
+That is precisely what happened to `Job` (issue #2640): it was excluded from the sweep when it shipped and never registered, so its identity-less-hash quarantine, its `$IndexF:Job:*` clear, its `$SortF:Job:last_active_at:*` partition rebuild, and the daily `Job.backfill_open_promises_index()` re-derivation all went unrun in production while the docstrings claimed a daily cadence.
+
+`AgentSession` is the one deliberate absence from the registry, and it is safe because it has two other production callers (worker Step 2 and the hourly `agent-session-cleanup` reflection). Any new entry in the frozenset needs either a registry entry here or a named caller elsewhere.
 
 ### Cleanup Paths
 
 | Path | Trigger | Scope |
 |------|---------|-------|
-| Worker startup | `python -m worker` | All models except `AgentSession` via `run_cleanup()` |
-| ReflectionScheduler | Reflection subprocess tick (daily, `python -m reflections`) | All models except `AgentSession` via `run_cleanup()` |
+| Worker startup | `python -m worker` | All models except `_GUARDED_ELSEWHERE` via `run_cleanup()`, plus `Room` and `Job` via `_run_guarded_repairs()` |
+| ReflectionScheduler | Reflection subprocess tick (daily, `python -m reflections`) | All models except `_GUARDED_ELSEWHERE` via `run_cleanup()`, plus `Room` and `Job` via `_run_guarded_repairs()` |
 | Worker Step 2 | `python -m worker` (post-Step-1) | `AgentSession` only, via the guarded `AgentSession.repair_indexes()` |
 | Hourly `agent-session-cleanup` reflection | Worker-internal hourly tick (`agent/session_health.py`) | `AgentSession` only, via the guarded `AgentSession.repair_indexes()` |
 
@@ -181,7 +190,7 @@ The exposed case is a machine holding un-migrated legacy records. If that stops 
 | `models/agent_session.py` | AgentSession with Meta.ttl, the A1 rebuild guard (`repair_indexes()`), and the persisted quarantine-count Redis key |
 | `agent/agent_session_queue.py` | Refactored diagnostic fallback |
 | `worker/__main__.py` | Worker startup using `run_cleanup()` for all-model rebuild (Step 1, excludes `AgentSession`) and the guarded `AgentSession.repair_indexes()` (Step 2) |
-| `scripts/popoto_index_cleanup.py` | Cleanup function (`run_cleanup()`), model discovery (`_get_all_models()`), `_GUARDED_ELSEWHERE` exclusion set, and the daemon-thread rebuild timeout (`_run_rebuild_with_timeout()`) |
+| `scripts/popoto_index_cleanup.py` | Cleanup function (`run_cleanup()`), model discovery (`_get_all_models()`), `_GUARDED_ELSEWHERE` exclusion set, the `_run_guarded_repairs()` registry that schedules `Room.repair_indexes()` and `Job.repair_indexes()`, and the daemon-thread rebuild timeout (`_run_rebuild_with_timeout()`) |
 | `tools/doctor.py` | `agentsession-index-drift` check, `_recent_quarantine_suffix()` |
 | `config/reflections.yaml` | Reflection registry entry for `ReflectionScheduler` |
 | `monitoring/sentry_config.py` | `drop_orphan_noise()` Sentry `before_send` filter (see Sentry Orphan-Noise Filter) |

--- a/models/job.py
+++ b/models/job.py
@@ -347,8 +347,11 @@ class Job(Model):
         """Guarded repair path — the ONLY sanctioned index rebuild for Job.
 
         Job is listed in ``scripts/popoto_index_cleanup._GUARDED_ELSEWHERE``
-        so the generic raw ``rebuild_indexes()`` sweep never touches it; this
-        method is what the daily cleanup reflection invokes instead.
+        so the generic raw ``rebuild_indexes()`` sweep never touches it, and
+        registered in that module's ``_run_guarded_repairs()`` so this method
+        is what the daily cleanup reflection invokes instead. Both halves are
+        required: the exclusion alone left Job with no index hygiene at all
+        between the model shipping and issue #2640.
 
         Guard, two legs:
 

--- a/scripts/popoto_index_cleanup.py
+++ b/scripts/popoto_index_cleanup.py
@@ -45,13 +45,18 @@ _SCHEDULER_STATE_MODELS = frozenset({"Reflection"})
 # ``agent-session-cleanup`` reflection. Excluding it here is the primary fix
 # for #2207 — do not remove without an equivalent guard in this sweep.
 #
-# Room is likewise excluded from the raw sweep: its guarded
-# ``Room.repair_indexes()`` (quarantines identity-less hashes before any
-# rebuild — see models/room.py) is invoked by this module's own
-# ``_run_guarded_repairs()`` pass below instead. Every new durable Popoto
-# model MUST either appear here with its own guarded repair path or carry a
-# written proof it cannot produce an identity-less hash (Risk 2 of
-# docs/plans/durability-room-job-agentrun.md).
+# Room and Job are likewise excluded from the raw sweep: their guarded
+# ``repair_indexes()`` methods (which quarantine identity-less hashes before
+# any rebuild — see models/room.py and models/job.py) are invoked by this
+# module's own ``_run_guarded_repairs()`` pass below instead. Every new
+# durable Popoto model MUST either appear here with its own guarded repair
+# path or carry a written proof it cannot produce an identity-less hash
+# (Risk 2 of docs/plans/durability-room-job-agentrun.md).
+#
+# Listing a model here is only HALF the contract: it removes the model from
+# the generic sweep, so the guarded path must also be registered in
+# ``_run_guarded_repairs()`` below or the model gets no hygiene at all. Job
+# was listed here and never registered there, which is issue #2640.
 _GUARDED_ELSEWHERE = frozenset({"AgentSession", "Room", "Job"})
 
 
@@ -285,10 +290,27 @@ def _run_rebuild_with_timeout(model_class):
 def _run_guarded_repairs() -> dict:
     """Invoke each guarded model's OWN repair path (never the raw rebuild).
 
+    Every name in ``_GUARDED_ELSEWHERE`` must appear either here or in the
+    docstring below with a stated reason — an entry that is excluded from the
+    generic sweep AND unregistered here receives no index hygiene at all
+    (issue #2640, which is exactly what happened to ``Job``).
+
     AgentSession is deliberately absent: its A1-guarded ``repair_indexes()``
     already runs unconditionally from worker Step 2 and the hourly
     ``agent-session-cleanup`` reflection — a third invocation here would add
-    nothing. Room has no other caller, so this daily sweep is its cadence.
+    nothing.
+
+    Room and Job have no other caller, so this sweep is their cadence, and it
+    is the cadence their own code assumes: ``Job.repair_indexes()`` closes by
+    calling ``Job.backfill_open_promises_index()``, documented as a *daily*
+    re-derivation of the ``has_open_promises`` flag. ``run_cleanup`` runs on
+    the daily ``popoto-index-cleanup`` reflection plus once per worker start.
+
+    Both repair methods return ``(quarantined, rebuilt)`` and both take a
+    non-blocking ``_repair_lock``, returning ``(0, 0)`` when another thread
+    already holds it. A skipped invocation is therefore recorded as a clean
+    pass here; the models log a WARNING in that case, which is where the
+    distinction lives.
 
     Failures are contained per model, mirroring the generic sweep.
     """
@@ -299,7 +321,12 @@ def _run_guarded_repairs() -> dict:
 
         return Room.repair_indexes()
 
-    guarded_repairs = {"Room": _room_repair}
+    def _job_repair():
+        from models.job import Job
+
+        return Job.repair_indexes()
+
+    guarded_repairs = {"Room": _room_repair, "Job": _job_repair}
 
     for model_name, repair_fn in guarded_repairs.items():
         try:

--- a/tests/unit/test_popoto_cleanup_reflection.py
+++ b/tests/unit/test_popoto_cleanup_reflection.py
@@ -62,6 +62,85 @@ class TestGuardedElsewhereExclusion:
         assert "AgentSession" not in model_names
 
 
+class TestJobGuardedRepairIsScheduled:
+    """Issue #2640: `_GUARDED_ELSEWHERE` membership is only half the contract.
+
+    It removes a model from the generic `rebuild_indexes()` sweep; the
+    `_run_guarded_repairs()` registry is what puts that model's own guarded
+    path back on the schedule. `Job` was listed in the first and absent from
+    the second, so it received no index hygiene of any kind in production --
+    no identity-less-hash quarantine, no `$IndexF:Job:*` clear, no
+    `$SortF:Job:last_active_at:*` partition rebuild, no daily
+    `backfill_open_promises_index()`.
+
+    The load-bearing assertions below are behavioural: a `run_cleanup()` pass
+    must actually reap a manufactured `$SortF` orphan and delete a planted
+    identity-less `Job:*` hash. Deleting the `"Job"` entry from
+    `_run_guarded_repairs()` turns them red.
+    """
+
+    def test_job_excluded_from_generic_sweep(self):
+        assert "Job" not in {m.__name__ for m in _get_all_models()}
+
+    def test_run_cleanup_reaps_job_sortf_orphan_and_identity_less_hash(self):
+        import uuid
+
+        from popoto import SortedField
+        from popoto.redis_db import POPOTO_REDIS_DB
+
+        from models.job import Job
+
+        room_id = f"test-cleanupsweep-{uuid.uuid4().hex[:8]}|telegram:1"
+        sorted_key = SortedField.get_sortedset_db_key(Job, "last_active_at", room_id).redis_key
+        phantom_key = f"Job:test-phantom-{uuid.uuid4().hex[:8]}"
+
+        # A single stub keeps the generic sweep trivial. It cannot be an empty
+        # list: run_cleanup() returns "no_models" and short-circuits before
+        # _run_guarded_repairs() ever runs.
+        stub = MagicMock()
+        stub.__name__ = "StubModel"
+        stub.rebuild_indexes.return_value = 0
+
+        try:
+            # (a) A textbook $SortF partition orphan. Mint alone so the
+            # partition holds exactly one member, capture it, then delete the
+            # backing hash raw -- the same bypass of on_delete's ZREM that
+            # repair leg 1's quarantine performs.
+            Job.mint(room_id, "orphan probe")
+            members = POPOTO_REDIS_DB.zrange(sorted_key, 0, -1)
+            assert len(members) == 1, "unique room should hold exactly one member"
+            orphan = members[0].decode() if isinstance(members[0], bytes) else members[0]
+            survivor = Job.mint(room_id, "survivor")
+            POPOTO_REDIS_DB.delete(orphan)
+            assert POPOTO_REDIS_DB.zscore(sorted_key, orphan) is not None, (
+                "harness suspect: the orphan was not manufactured"
+            )
+
+            # (b) An identity-less Job hash -- repair leg 1's quarantine target.
+            POPOTO_REDIS_DB.hset(phantom_key, mapping={"status": "active"})
+
+            with (
+                patch("scripts.popoto_index_cleanup._get_all_models", return_value=[stub]),
+                patch("scripts.popoto_index_cleanup._count_orphans", return_value=0),
+            ):
+                result = run_cleanup()
+
+            assert POPOTO_REDIS_DB.zscore(sorted_key, orphan) is None, (
+                "run_cleanup() must reap the $SortF partition orphan -- it does not "
+                "unless Job is registered in _run_guarded_repairs()"
+            )
+            assert POPOTO_REDIS_DB.exists(phantom_key) == 0, (
+                "run_cleanup() must quarantine the identity-less Job hash"
+            )
+            # The healthy record survives the rebuild and stays queryable.
+            assert any(j.job_id == survivor.job_id for j in Job.query.filter(room_id=room_id))
+            assert result["guarded_repairs"]["Job"]["status"] == "ok"
+        finally:
+            POPOTO_REDIS_DB.delete(phantom_key)
+            for job in Job.query.filter(room_id=room_id):
+                job.delete()
+
+
 class TestRebuildTimeoutAbandonment:
     """Un-wedge fix: a per-model rebuild that overruns
     POPOTO_INDEX_CLEANUP_REBUILD_TIMEOUT_SECONDS must be abandoned (daemon


### PR DESCRIPTION
Closes #2640

## What was actually wrong

The issue's conclusion holds. Its mechanism does not, and the real cause is simpler.

`Job.repair_indexes()` **has no production caller.** Wide probe over every file in the repo, all extensions, excluding `.venv/` and `.worktrees/`, grouped by receiver:

```
92  AgentSession.repair_indexes(
 4  Room.repair_indexes(
 6  Job.repair_indexes(
```

Of the six `Job` hits, two are the production-shaped call sites — `tests/unit/test_job_model.py:410` and `:456` — and the other four are prose in a single completed plan doc, `docs/plans/completed/job-open-promise-backfill-clobber.md`, not a caller. No dynamic dispatch reaches it either.

Two exclusions met in the middle:

1. `scripts/popoto_index_cleanup.py` — `_GUARDED_ELSEWHERE = {"AgentSession", "Room", "Job"}`. `_get_all_models()` skips every name in it, so Job never enters the generic `rebuild_indexes()` sweep.
2. `_run_guarded_repairs()` — the registry that puts an excluded model's own repair path back on the schedule was literally `{"Room": _room_repair}`. Job was absent.

`run_cleanup()` calls `_run_guarded_repairs()` and is itself scheduled twice: worker startup (`worker/__main__.py:749`) and the daily `popoto-index-cleanup` reflection. That schedule lives in `config/reflections.yaml`, which is gitignored (`.gitignore:8`), machine-generated by the `/update` migration, and absent from a fresh checkout — so it isn't independently checkable from the repo. In-repo corroboration of the same nightly/24h cadence: `models/ghost_reconcile.py:23-24`, `models/dedup.py:70`, `bridge/email_bridge.py:1087`.

Net: Job received no index hygiene of any kind in production. Wider than `$SortF` orphans. Leg 1's identity-less-hash quarantine, leg 2's `$IndexF:Job:*` clear, and the daily `Job.backfill_open_promises_index()` re-derivation had all never run outside tests.

## Why the filed mechanism is false

The issue claims `rebuild_indexes()` "does not enumerate `$SortF:*` at all". It does. popoto 1.8.0, `Model.rebuild_indexes()` Step 1:

```python
for field_name in cls._meta.sorted_field_names:
    field = cls._meta.fields[field_name]
    base_key = field.get_special_use_field_db_key(cls, field_name)
    pattern = base_key.redis_key + "*"
    # Use SCAN to find all keys matching this pattern (handles partitioned fields)
    for key in POPOTO_REDIS_DB.scan_iter(match=pattern, count=1000):
        POPOTO_REDIS_DB.delete(key)
```

Measured on an isolated Redis against the pinned 1.8.0: manufacture a textbook orphan by raw-deleting one Job hash, then run *only* `rebuild_indexes()`.

```
1. seeded 5 jobs                          members=5  ORPHANS=0
2. deleted the Job hash directly (bypasses on_delete SREM/ZREM)
3. orphan manufactured?                   members=5  ORPHANS=1
4. Job.rebuild_indexes() -> 4
5. after rebuild_indexes() ONLY           members=4  ORPHANS=0
6. deleted the entire $SortF key; zcard 0
7. after rebuild_indexes(): zcard=4
```

So no per-member removal mechanism is needed: no raw sorted-set `ZREM`, no `DB_key.from_redis_key` round trip. The earlier correction comment on the issue, that `DB_key` round-trips cleanly, is right on its own terms and now moot. Full evidence is in the [issue thread](https://github.com/tomcounsell/ai/issues/2640#issuecomment-5219928042).

## The change

Register Job alongside Room in `_run_guarded_repairs()`, following the existing `_room_repair` closure.

**Arity and locking.** `Job.repair_indexes()` returns `(quarantined, rebuilt)`, the same shape Room returns, so the existing `stale, rebuilt = repair_fn()` unpacking is unchanged. Both take a non-blocking `_repair_lock` and return `(0, 0)` when another thread holds it, so a skipped invocation is recorded as a clean pass here; both models log a WARNING in that case, which is where the distinction lives. `Job.repair_indexes()` also calls `assert_popoto_floor()` at entry, and a below-floor raise is caught by the loop's per-model `try/except` and recorded as `status: error` without aborting the sweep. That is the correct posture: it mirrors the generic sweep and fails the one model rather than the whole pass.

**Cadence.** Daily is not just acceptable, it is the cadence Job's own code was written to assume. `backfill_open_promises_index()` documents itself as a daily re-derivation of `has_open_promises`, and its only caller is `repair_indexes()`. `run_cleanup()` runs on the daily reflection plus once per worker start, which is exactly what those docstrings describe. Registering Job restores intended behaviour rather than introducing a new load.

## Docs

- `models/job.py` — the `repair_indexes` docstring claimed "this method is what the daily cleanup reflection invokes instead". True only of the exclusion half. Now states both halves and names why both are required.
- `docs/features/popoto-index-hygiene.md` — described `_GUARDED_ELSEWHERE` as "currently just `AgentSession`" (Room had been added and never documented) and never mentioned `_run_guarded_repairs()` at all. Adds the guarded pass to the `run_cleanup()` steps and the Cleanup Paths table, plus a section stating the two-part contract explicitly.
- `scripts/popoto_index_cleanup.py` — the `_GUARDED_ELSEWHERE` comment and the `_run_guarded_repairs` docstring now both say that listing a model is half the contract.
- `docs/features/durability-model.md:115` — this line ("Both `Room` and `Job` ship with their own guarded `repair_indexes()` and a `_GUARDED_ELSEWHERE` entry") was **already true before this PR**; Job shipped both halves pre-PR, so this change does not make it true. The paragraph did, however, state only the exclusion half of the guard contract and omit the registry half (`_run_guarded_repairs()`) — the exact omission that produced #2640 — so it now names both halves explicitly.

Completed plan docs under `docs/plans/completed/` are left as archived records.

## Test

`tests/unit/test_popoto_cleanup_reflection.py::TestJobGuardedRepairIsScheduled`. Behavioural, not structural: a `run_cleanup()` pass must reap a manufactured `$SortF:Job:last_active_at:<room>` partition orphan and delete a planted identity-less `Job:*` hash, while the healthy record stays queryable.

Mutation-checked. With `"Job": _job_repair` removed from the registry:

```
FAILED tests/unit/test_popoto_cleanup_reflection.py::TestJobGuardedRepairIsScheduled::
       test_run_cleanup_reaps_job_sortf_orphan_and_identity_less_hash
E   AssertionError: run_cleanup() must reap the $SortF partition orphan -- it does not
    unless Job is registered in _run_guarded_repairs()
E   assert 1786122989.65125 is None
```

It fails on the orphan assertion, not on a dict-key existence check.

```
tests/unit/test_popoto_cleanup_reflection.py
tests/unit/test_job_model.py
tests/unit/test_room_resolution.py                     73 passed
tests/integration/test_session_archive_cold_boot.py
tests/unit/test_worker_entry.py                        41 passed
```

`ruff check` and `ruff format --check` clean.

## Follow-up worth a look, deliberately not bundled

`_run_guarded_repairs()` has no wall-clock budget, unlike the generic sweep's `_run_rebuild_with_timeout()` daemon-thread abandonment (added for the 8-hour zero-heartbeat worker wedge, #2207). Both guarded repairs run synchronously on worker startup. Room's is small; Job's carries three cost centres Room's does not: leg 2 issues a blocking, O(total-keyspace) `POPOTO_REDIS_DB.keys("$IndexF:Job:*")` (`models/job.py:430`) that stalls the Redis server for every client, not just the calling worker thread; and the closing `backfill_open_promises_index()` hydrates and re-fetches every Job row, so its cost scales with the Job count. At today's volume that is seconds, and this PR restores a path the model was designed for rather than adding an unvetted one, so the budget is a separate concern about the guarded path generally rather than about registering Job. Tracked as #2699, which scopes the missing wall-clock budget and the full-hydration cost; the blocking `KEYS` server-wide stall at `models/job.py:430` is a distinct failure mode a timeout wrapper would not contain, flagged separately in a comment on that issue.


