### PR TITLE
Let skills that mandate subagent dispatch actually dispatch (#2679)

### DIFF
--- a/.claude/skills-global/do-issue/SKILL.md
+++ b/.claude/skills-global/do-issue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: do-issue
 description: "Create a self-contained GitHub issue ready for planning. Triggered by 'create an issue', 'file an issue', 'track this', or by /sdlc at Step 1."
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent
 argument-hint: "<title or description>"
 ---
 

--- a/.claude/skills-global/do-plan/SKILL.md
+++ b/.claude/skills-global/do-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: do-plan
 description: "Use when creating or updating a feature plan document. Triggered by 'make a plan', 'plan this', 'flesh out the idea', or any request to scope and plan work before implementation."
-allowed-tools: Read, Write, Edit, Glob, Bash, AskUserQuestion, ToolSearch, WebSearch
+allowed-tools: Read, Write, Edit, Glob, Bash, AskUserQuestion, ToolSearch, WebSearch, Agent
 ---
 
 # Make a Plan (Shape Up Methodology)

--- a/.claude/skills-global/do-pr-review/SKILL.md
+++ b/.claude/skills-global/do-pr-review/SKILL.md
@@ -3,7 +3,7 @@ name: do-pr-review
 description: "Review a pull request against its plan. Triggered by 'review this PR', 'check the pull request', 'do a PR review', or a PR URL."
 argument-hint: "<pr-number>"
 context: fork
-allowed-tools: mcp__byob__*, Bash(gh:*), Bash(git:*), Bash(python:*), Bash(jq:*), Bash(sdlc-tool:*), Read, Write, Edit, Grep, Glob
+allowed-tools: mcp__byob__*, Bash(gh:*), Bash(git:*), Bash(python:*), Bash(jq:*), Bash(sdlc-tool:*), Read, Write, Edit, Grep, Glob, Agent
 ---
 
 # PR Review

--- a/tests/unit/test_skill_agent_tool_consistency.py
+++ b/tests/unit/test_skill_agent_tool_consistency.py
@@ -1,0 +1,92 @@
+"""A skill that dispatches subagents must be allowed to (#2649).
+
+`allowed-tools` in a SKILL.md frontmatter is a restriction: per
+`.claude/skills-global/new-skill/SKILL.md`, "Restricts which tools the skill
+can use. Omit to allow all." So a skill whose body instructs the driver to
+dispatch subagents, while its own `allowed-tools` omits `Agent`, asks for
+something it has forbidden itself.
+
+`do-pr-review` was in exactly that state: `context: fork`, an `allowed-tools`
+list without `Agent`, and a body mandating judge subagents — with this repo
+opting into multi-judge consensus by default
+(`SDLC_REVIEW_JUDGES=code-quality,risk`, `docs/sdlc/do-pr-review.md`). The
+failure is silent: the driver inlines the judges instead, so reviews still post
+and no gate trips, they just lose the independent-context property that makes a
+second judge worth having.
+
+This is a consistency check between two declarations in the same file, not a
+claim about harness behavior. Whether a `context: fork` context also strips
+`Agent` is a separate question this test does not speak to.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_ROOTS = (REPO_ROOT / ".claude" / "skills-global", REPO_ROOT / ".claude" / "skills")
+
+# Body phrasings that mean "spawn a subagent". Kept to unambiguous forms: a
+# skill merely mentioning the word "agent" is not dispatching one.
+DISPATCH_PATTERNS = (
+    re.compile(r"\bAgent tool\b"),
+    re.compile(r"\b(?:Agent|Task)\(\{"),
+    re.compile(r"\bdispatch(?:es|ing)? (?:the )?(?:critics|judges|subagents?)\b", re.I),
+    re.compile(r"\bjudge subagents?\b", re.I),
+    re.compile(r"\bspawn(?:s|ing)? .{0,20}subagents?\b", re.I),
+)
+
+
+def _skill_files() -> list[Path]:
+    files: list[Path] = []
+    for root in SKILL_ROOTS:
+        if root.exists():
+            files.extend(sorted(root.glob("*/SKILL.md")))
+    return files
+
+
+def _split_frontmatter(text: str) -> tuple[str, str]:
+    """Return (frontmatter, body). Empty frontmatter when there is none."""
+    if not text.startswith("---"):
+        return "", text
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return "", text
+    return parts[1], parts[2]
+
+
+def _allowed_tools(frontmatter: str) -> list[str] | None:
+    """The declared tool list, or None when the key is absent (= allow all)."""
+    match = re.search(r"^allowed-tools:(.*)$", frontmatter, re.MULTILINE)
+    if not match:
+        return None
+    return [t.strip() for t in match.group(1).split(",") if t.strip()]
+
+
+def test_skill_inventory_is_non_empty():
+    """Guard the guard: a glob that stops finding skills must fail loudly
+    rather than silently vacuously pass."""
+    assert len(_skill_files()) > 20, _skill_files()
+
+
+@pytest.mark.parametrize("skill_path", _skill_files(), ids=lambda p: p.parent.name)
+def test_skill_that_dispatches_subagents_is_allowed_the_agent_tool(skill_path: Path):
+    text = skill_path.read_text()
+    frontmatter, body = _split_frontmatter(text)
+
+    allowed = _allowed_tools(frontmatter)
+    if allowed is None:
+        return  # no restriction declared: the full tool set, including Agent
+
+    dispatch_hits = [p.pattern for p in DISPATCH_PATTERNS if p.search(body)]
+    if not dispatch_hits:
+        return
+
+    assert any(t in ("Agent", "Task") for t in allowed), (
+        f"{skill_path.relative_to(REPO_ROOT)} instructs subagent dispatch "
+        f"(matched {dispatch_hits}) but its allowed-tools omits Agent, so the "
+        f"dispatch it mandates is forbidden to it: {allowed}"
+    )

--- a/tests/unit/test_skill_agent_tool_consistency.py
+++ b/tests/unit/test_skill_agent_tool_consistency.py
@@ -29,15 +29,40 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SKILL_ROOTS = (REPO_ROOT / ".claude" / "skills-global", REPO_ROOT / ".claude" / "skills")
 
-# Body phrasings that mean "spawn a subagent". Kept to unambiguous forms: a
-# skill merely mentioning the word "agent" is not dispatching one.
+# Body phrasings that mean "spawn a subagent". A skill merely mentioning the
+# word "agent" is not dispatching one, so a dispatch VERB is always required.
+#
+# The first version of this set was derived from `do-pr-review`'s own wording
+# and therefore found `do-pr-review` and nothing else, while two skills sat in
+# the identical broken state and passed green. Three near-misses caused it: the
+# literal token "subagent" (so "Spawn an Explore agent" slipped past), no
+# hyphenated "sub-agents", and three hardcoded nouns (so "Dispatch spikes …
+# parallel Agent sub-agents" slipped past). Hence verb + agent-noun proximity
+# rather than an enumeration of phrasings.
+_AGENT_NOUN = r"(?:sub-?agents?|agents?|critics|judges)"
+# "launch" is deliberately absent. This repo also uses "agent" for a Claude
+# Managed Agent -- a hosted product you launch, not a subagent you spawn -- and
+# `build-agent` ("launch the agent -> run a graded outcome -> schedule it on
+# cron") is a false positive under it. No skill in either root writes
+# "launch ... subagent", so excluding the verb costs no coverage.
+_DISPATCH_VERB = r"(?:spawn|dispatch|fan[-\s]?out)"
+
 DISPATCH_PATTERNS = (
     re.compile(r"\bAgent tool\b"),
     re.compile(r"\b(?:Agent|Task)\(\{"),
-    re.compile(r"\bdispatch(?:es|ing)? (?:the )?(?:critics|judges|subagents?)\b", re.I),
-    re.compile(r"\bjudge subagents?\b", re.I),
-    re.compile(r"\bspawn(?:s|ing)? .{0,20}subagents?\b", re.I),
+    re.compile(r"\bExplore agents?\b", re.I),
+    re.compile(r"\bAgent sub-?agents?\b", re.I),
+    # A dispatch verb and an agent noun in the same clause. Bounded to 60
+    # characters and stopped at a sentence end so the two words have to be
+    # talking about each other.
+    re.compile(rf"\b{_DISPATCH_VERB}\w*\b[^.\n]{{0,60}}?\b{_AGENT_NOUN}\b", re.I),
 )
+
+# A dispatch phrase inside a prohibition is the opposite of an instruction to
+# dispatch. `do-design-system` says "do NOT delegate to a subagent" and
+# `authenticity-pass` returns a draft *to* a drafter subagent rather than
+# spawning one; both must stay green while the patterns widen.
+_NEGATION = re.compile(r"(?:do\s+not|don't|never|avoid|without|rather than|instead of)\s*$", re.I)
 
 
 def _skill_files() -> list[Path]:
@@ -59,7 +84,38 @@ def _split_frontmatter(text: str) -> tuple[str, str]:
 
 
 def _allowed_tools(frontmatter: str) -> list[str] | None:
-    """The declared tool list, or None when the key is absent (= allow all)."""
+    """The declared tool list, or None when the key is absent (= allow all).
+
+    Both YAML forms count. An inline `allowed-tools: A, B` and a block
+    sequence (`allowed-tools:` followed by `  - A`) mean the same thing, but a
+    regex reading only the inline form parses the block form as `[]` — which is
+    indistinguishable from "declared, restricted to nothing" and is *not* the
+    `None` that means unrestricted. `calendar-sync` uses the block form today,
+    so the next list-form skill to legitimately declare `Agent` would get a
+    failure whose message contradicts the file it describes.
+    """
+    try:
+        import yaml
+
+        data = yaml.safe_load(frontmatter)
+    except Exception:
+        data = None
+
+    if isinstance(data, dict) and "allowed-tools" in data:
+        value = data["allowed-tools"]
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [t.strip() for t in value.split(",") if t.strip()]
+        if isinstance(value, list):
+            return [str(t).strip() for t in value if str(t).strip()]
+        return []
+
+    if isinstance(data, dict):
+        return None  # parsed cleanly, key genuinely absent
+
+    # Frontmatter that YAML cannot parse: fall back to the inline form rather
+    # than silently reporting "unrestricted".
     match = re.search(r"^allowed-tools:(.*)$", frontmatter, re.MULTILINE)
     if not match:
         return None
@@ -72,6 +128,23 @@ def test_skill_inventory_is_non_empty():
     assert len(_skill_files()) > 20, _skill_files()
 
 
+def _dispatch_hits(body: str) -> list[str]:
+    """Patterns whose match is a genuine instruction to dispatch.
+
+    A match sitting inside a prohibition is skipped: a skill saying "do NOT
+    delegate to a subagent" is asserting the opposite of a dispatch.
+    """
+    hits = []
+    for pattern in DISPATCH_PATTERNS:
+        for match in pattern.finditer(body):
+            line_start = body.rfind("\n", 0, match.start()) + 1
+            if _NEGATION.search(body[line_start : match.start()]):
+                continue
+            hits.append(pattern.pattern)
+            break
+    return hits
+
+
 @pytest.mark.parametrize("skill_path", _skill_files(), ids=lambda p: p.parent.name)
 def test_skill_that_dispatches_subagents_is_allowed_the_agent_tool(skill_path: Path):
     text = skill_path.read_text()
@@ -81,7 +154,7 @@ def test_skill_that_dispatches_subagents_is_allowed_the_agent_tool(skill_path: P
     if allowed is None:
         return  # no restriction declared: the full tool set, including Agent
 
-    dispatch_hits = [p.pattern for p in DISPATCH_PATTERNS if p.search(body)]
+    dispatch_hits = _dispatch_hits(body)
     if not dispatch_hits:
         return
 


### PR DESCRIPTION
Closes #2679. Refs #2649.

Three SDLC pipeline stages instruct the driver to dispatch subagents while their own `allowed-tools` omits `Agent` — which is a restriction, per `new-skill/SKILL.md:68` ("Restricts which tools the skill can use. Omit to allow all"). They ask for a dispatch they have forbidden themselves.

| Skill | Body mandates | Was |
|---|---|---|
| `do-pr-review` | step 9: *"dispatch the judges and BLOCK on each returning IN THE SAME TURN"* | no `Agent` |
| `do-issue` | *"Spawn an Explore agent"*, *"Fan-out — Spawn one Explore agent per concern"* (mandatory: *"Skip only for trivially simple issues"*) | no `Agent` |
| `do-plan` | *"Dispatch spikes in parallel - Use the P-Thread pattern (parallel Agent sub-agents)"* | no `Agent` |

**The failure is silent, which is why it survived.** The driver inlines the work instead of spawning it; stages complete, verdicts post, no gate trips. What is lost is the independence that makes fan-out worth doing: subagents each reason in a fresh context, while inlined lenses share the driver's history and can be anchored by whatever ran before them. A second judge that has already read the first judge's reasoning is not a second opinion.

## Why #2679 and not #2649

#2649 reported that *forked* skill contexts lack the Agent tool, serializing `do-plan-critique`'s roster lenses. That does not reproduce: `do-plan-critique` declares no `allowed-tools` at all, so it inherits the full set, and it asks for foreground same-message dispatch, which works. Its framing stays wrong, so it is the wrong `Closes` target. #2679 states the real defect; #2649 should be closed on the refutation evidence already posted there.

## The sweep — and why the first one was not one

The first version of this guard derived `DISPATCH_PATTERNS` from `do-pr-review`'s own wording. It therefore found `do-pr-review` and nothing else, while `do-issue` and `do-plan` sat in the identical state and passed green. Three independent near-misses: the literal token `subagent` (so "Spawn an Explore agent" slipped past), no hyphenated `sub-agents`, and three hardcoded nouns (so "Dispatch spikes" slipped past).

Patterns are now **verb + agent-noun proximity**, bounded to one clause, rather than an enumeration of phrasings.

Two false-positive traps, both found by measuring rather than reasoning:

**`launch` is deliberately not a dispatch verb.** The review suggested including it. On the first widened run it flagged `build-agent` — *"launch the agent → run a graded outcome → schedule it on cron"* — because this repo also uses "agent" for a **Claude Managed Agent**, a hosted product you launch rather than a subagent you spawn. Grepping both roots confirms no skill writes "launch … subagent", so excluding the verb costs no coverage. Reported back rather than applied as given.

**A negation guard** skips a dispatch phrase inside a prohibition, so `do-design-system` (*"do NOT delegate to a subagent"*) and `authenticity-pass` (which returns a draft *to* a drafter subagent rather than spawning one) stay green, as the review required.

## Frontmatter parsing

`_allowed_tools` read only the inline comma form, so a YAML block sequence parsed to `[]` — indistinguishable from "declared, restricted to nothing", and not the `None` that means unrestricted. `calendar-sync` uses that form today, and the review mutation-proved the consequence: a block-form skill legitimately declaring `Agent` got a failure whose message contradicted the file it described. Now `yaml.safe_load` with both forms normalized, falling back to the regex only when frontmatter will not parse. **The reviewer's exact mutation now passes.**

Not taken: moving the check into `audit_skills.py` as rule 22. It would inherit `--fix` and a better parser, but it edits a globally-synced skill script and its own test suite mid-fan-out — more blast radius than the parse fix needs. Recorded on #2679 as follow-up.

## Verification

**Demonstrated red in the order the review asked for.** Widening the patterns *before* the frontmatter fixes names exactly the two skills the review identified:

```
FAILED ...test_skill_that_dispatches_subagents_is_allowed_the_agent_tool[do-issue]
FAILED ...test_skill_that_dispatches_subagents_is_allowed_the_agent_tool[do-plan]
2 failed, 56 passed
```

Each of the three fixes is then independently mutation-checked — reverting any one turns exactly one of 58 cases red:

```
revert do-issue     -> 1 failed, 57 passed
revert do-plan      -> 1 failed, 57 passed
revert do-pr-review -> 1 failed, 57 passed
```

Negation controls and the parse fix, measured directly:

```
calendar-sync allowed-tools parses to 13 tools (was [])
do-design-system   dispatch hits = 0
authenticity-pass  dispatch hits = 0
do-issue / do-plan / do-pr-review: dispatch detected, Agent present
```

Suites and tooling:

```
test_skill_agent_tool_consistency + test_skills_audit + test_cma_skills_well_formed
+ test_sdlc_fork_no_background + test_sdlc_skill_md_parity + test_relink_global_skills
                                                              206 passed
audit_skills.py: do-issue / do-plan / do-pr-review     all fully aligned
ruff check + format                                            clean
```

## Scope note

This is a consistency check between two declarations in the same file. Whether a `context: fork` context *also* strips `Agent` at the harness level is a separate question, unverifiable from inside the repo, that this test deliberately does not speak to. The test's docstring carries the same limit so it travels with the code.

## Merge safety

**Safe to merge during the fan-out, and worth merging early.** Three one-word frontmatter additions plus one test file; no code path, gate, or hook behavior changes. Reaches running agents only after merge plus a `/update` hardlink sync.

For the coordinator: `do-pr-review` is the REVIEW stage every PR in this batch passes through, and `do-issue`/`do-plan` are the ISSUE and PLAN stages. Until this lands, all three run their fan-out inlined rather than independently.

**Merge-order note:** this branch edits `do-plan/SKILL.md` frontmatter (line 4) while PR #2669 edits the same file's body (Phase 4, ~line 393). Different regions, so git merges them cleanly in either order — flagging it only so the overlap is not a surprise.

Refs #2124, #2112.