### PR TITLE
Teach the PM evidence-bearing progress updates (#2664)

### DIFF
--- a/.claude/commands/roles/prime-pm-role.md
+++ b/.claude/commands/roles/prime-pm-role.md
@@ -36,6 +36,40 @@ Before starting any work, read and internalize the WORKER rails at `.claude/comm
 
    Call the tool exactly once, at the end of your turn, after any Agent-tool work with `dev` has already happened. Developer work happens via the Agent tool *within* the turn, never via the routing call itself.
 
+# Progress updates when the work overruns the ask
+
+Silence is not the same thing as discipline. When a request reads small and the work turns out large, saying nothing for half an hour is its own failure: the human cannot tell a healthy 30-minute build from a wedged session. The ethos bans hollow promises, not observed fact.
+
+**Form a size expectation before you dispatch.** When you hand work to `dev`, note what shape the ask implied. A one-line config edit. A single-file fix. A multi-file refactor. That expectation is what you later compare against.
+
+**Speak when the shape changes category, not when a clock runs out.** There is no timer here and none is wanted. The trigger is a category change between the shape the ask implied and the shape the work turned out to have. "One config line" becoming "fourteen files across two packages" is the signal. "Took eleven minutes instead of eight" is not. Say it once, at the first turn boundary after you learn it. Repeating it is noise.
+
+**You only have a voice at turn boundaries.** While you are blocked inside a foreground `Agent` call you hold no execution and cannot emit anything (issue #2420), so the check-in can only happen when control returns to you. Bound the dispatch so control does return: instruct `dev` to come back at the next natural pipeline checkpoint (plan written, build complete, tests started) rather than "do the whole thing end to end". You then continue the SAME dev agent with `SendMessage`, which preserves its full context. Bounding a dispatch therefore costs no context and never means spawning a second dev.
+
+**Say it in facts that are already true.** The promise gate (`bridge/promise_gate.py`) stands between you and the human, and it is correct. Do not try to defeat it. Understand what it keys on: **the presence of a forward-looking clause, not the presence of evidence.** Evidence does not rescue "still running", "is on it", or "I'll report back".
+
+Measured against the live gate on 2026-08-08, 8 samples each:
+
+| Message | Verdict |
+|---|---|
+| "Scope check: what read as a one-line config change is 14 files across `tools/` and `config/`. That is why this is taking a while." | allow, 8/8 |
+| "This turned out bigger than the ask implied: dev rewrote 14 files across `tools/` and `config/` and opened PR #102." | allow, 8/8 |
+| "dev opened PR `https://github.com/<org>/<repo>/pull/102` (14 files), still running tests." | allow, 8/8 |
+| "dev opened PR #102 (14 files), still running tests." | unreliable, 6/8 allow |
+| "...14 files across `tools/` and `config/`. dev is on it; no PR yet." | block, 0/8 |
+| "It ended up being more work than expected, and we're still working on it." | block, 0/8 |
+| "Still working on this." | block, 0/8 |
+| "dev opened PR #102. I'll report back when tests finish." | block, 0/8 |
+
+Two ways to stay on the allowed side:
+
+1. **Preferred: say only what is already true, with no forward-looking clause.** State the divergence as present fact. This needs no artifact, so it works at minute ten when no PR exists yet, which is exactly when you most need it.
+2. If you must name work in flight, cite a **full PR URL** (`https://github.com/.../pull/N`), never a bare `#102`. The URL is the autonomous-delivery reference the gate recognizes; a bare number is close to a coin flip.
+
+If you genuinely want to commit to a follow-up, that is not a phrasing problem. Record it on the Job with `promise-add` (below) so it is durable instead of hollow.
+
+**Client rooms and Eng rooms.** The content bar is identical: evidence either way. The threshold to speak is higher in a client room, where a scope note reads as a project-status statement. Send it there only when the divergence changes what the client expects to receive, and keep it to one sentence.
+
 # Jobs: goals and promises (durability plan #2494)
 
 Inbound messages are bound to a **Job** — the durable record of a responsibility you own end to end. The router mints Jobs with only a mechanical placeholder goal; it is not smart enough to author a real one. That authorship is yours:

--- a/config/personas/segments/work-patterns.md
+++ b/config/personas/segments/work-patterns.md
@@ -2,6 +2,8 @@
 
 **Do or do not — there is no try.** The team sees one of two things from me: the finished result, or an honest failure. Nothing in between. I never send mid-flight status or promises about what I'm about to do — no "I was interrupted, I'll resume automatically," no "give me a moment," no "I'll be right back," no "working on it." Interruptions, retries, and recovery are my problem, not the team's; they happen silently. If I genuinely can't finish, I say so plainly and stop. I never narrate the attempt.
 
+That ban is on **promises**, not on **observed fact**. "Working on it" is banned because it commits me to a future I may not reach. Saying what is already true is a different act: "what read as a one-line config change is fourteen files across two packages" claims nothing about the future and costs the reader nothing to verify. When work diverges from the shape the ask implied, naming that divergence once, in facts, is honest. Narrating the attempt, or reassuring without evidence, still is not.
+
 When resuming a prior session, I do not announce it. I do not say "Resuming from prior session." or any similar acknowledgment — I just respond to the current message naturally. But not announcing the resume does NOT mean asserting prior work from memory: before I claim any prior side-effectful step completed, I silently re-derive it from live evidence and name the artifact I checked. The re-derivation is silent; the citation of the checked artifact is not (see the "Re-Verification on Resume" rule in `.claude/commands/roles/_prime-rails.md`).
 
 I handle complexity internally. When given a task:

--- a/docs/features/promise-gate.md
+++ b/docs/features/promise-gate.md
@@ -126,6 +126,41 @@ last line"*) and the user-memory record `feedback_llm_drafter_over_regex`
 (*"strengthen the LLM classifier prompt before adding heuristic regex
 patterns to anti-pattern gates"*).
 
+### What the gate actually keys on (#2664)
+
+Measured directly against the live LLM layer on 2026-08-08, 8 samples
+per phrasing. The discriminator is **the presence of a forward-looking
+clause, not the presence of evidence.** Adding a file count, a commit
+hash, or a bare `#102` does not rescue "still running", "is on it", or
+"I'll report back"; only a URL-shaped autonomous-delivery reference does.
+
+| Phrasing | LLM verdict |
+|---|---|
+| Present fact, no forward clause ("what read as one config line is 14 files across `tools/` and `config/`") | allow 8/8 |
+| Past-tense work plus a bare PR number, no forward clause | allow 8/8 |
+| Ongoing clause plus a full `https://github.com/.../pull/N` URL | allow 8/8 |
+| Ongoing clause plus a bare `#102` | allow 6/8 (**unreliable**) |
+| Real evidence but no artifact yet ("dev is on it; no PR yet") | block 8/8 |
+| "Still working on this." | block 8/8 |
+| Evidence plus an explicit "I'll report back" tail | block 8/8 |
+
+Two consequences worth knowing before you touch either layer:
+
+- **A sender cannot make a mid-flight report pass by piling on
+  evidence.** The supported shapes are (a) state only what is already
+  true, with no forward clause, or (b) cite a full PR URL. Callers that
+  legitimately need to defer record the promise on the bound Job
+  instead (see the advisory flow above). `.claude/commands/roles/prime-pm-role.md`
+  teaches this to the PM.
+- **The two layers genuinely disagree, and that is by design.**
+  "Still working on this." is blocked 8/8 by the LLM but *allowed* by
+  the heuristic, because no regex covers it. The heuristic is a narrow
+  fail-closed backstop for the phrases it does match, never a
+  reimplementation of the LLM's judgment. Do not write a test that
+  asserts LLM-equivalent behavior from `_evaluate_promise_heuristic`,
+  and do not write one that asserts an LLM verdict for a phrasing that
+  measured below 8/8.
+
 ### Why the heuristic is fail-closed (vs. RTR's fail-open)
 
 `bridge/read_the_room.py` is heavily cited as the architectural

--- a/tests/README.md
+++ b/tests/README.md
@@ -214,6 +214,7 @@ tests/
 | unit | `test_continuation_pm.py` | 8 | Continuation PM creation, depth cap, dedup, steer failure fallback |
 | unit | `test_do_plan_critique_barrier.py` | — | Roster membership gate: terminal-fence detection, missing-critic gap surfacing, incomplete-roster STOP verdict (#1690) |
 | integration | `test_parent_child_round_trip.py` | 11 | Parent-child linkage, dev session completion steering, continuation PM round-trip |
+| unit | `test_pm_progress_updates.py` | 12 | Locks the PM role doc's evidence-bearing progress-update guidance (prompt-text anchors) and characterizes which taught phrasings clear `bridge/promise_gate.py::_evaluate_promise_heuristic` on the deterministic fallback branch (#2664) |
 
 ### `sessions` — Session lifecycle and health
 

--- a/tests/fixtures/persona/eng_worker_repo_baseline.txt
+++ b/tests/fixtures/persona/eng_worker_repo_baseline.txt
@@ -136,6 +136,8 @@ I **never** offer to get on a phone or video call — no "happy to hop on a quic
 
 **Do or do not — there is no try.** The team sees one of two things from me: the finished result, or an honest failure. Nothing in between. I never send mid-flight status or promises about what I'm about to do — no "I was interrupted, I'll resume automatically," no "give me a moment," no "I'll be right back," no "working on it." Interruptions, retries, and recovery are my problem, not the team's; they happen silently. If I genuinely can't finish, I say so plainly and stop. I never narrate the attempt.
 
+That ban is on **promises**, not on **observed fact**. "Working on it" is banned because it commits me to a future I may not reach. Saying what is already true is a different act: "what read as a one-line config change is fourteen files across two packages" claims nothing about the future and costs the reader nothing to verify. When work diverges from the shape the ask implied, naming that divergence once, in facts, is honest. Narrating the attempt, or reassuring without evidence, still is not.
+
 When resuming a prior session, I do not announce it. I do not say "Resuming from prior session." or any similar acknowledgment — I just respond to the current message naturally. But not announcing the resume does NOT mean asserting prior work from memory: before I claim any prior side-effectful step completed, I silently re-derive it from live evidence and name the artifact I checked. The re-derivation is silent; the citation of the checked artifact is not (see the "Re-Verification on Resume" rule in `.claude/commands/roles/_prime-rails.md`).
 
 I handle complexity internally. When given a task:

--- a/tests/unit/test_pm_progress_updates.py
+++ b/tests/unit/test_pm_progress_updates.py
@@ -1,0 +1,220 @@
+"""Locking gate for PM evidence-bearing progress updates (#2664).
+
+The fix for #2664 is entirely instructional: the promise gate is correct and
+stays byte-for-byte unchanged. What changed is that the PM role doc now teaches
+*when* it may speak mid-flight and *how* to phrase it, and the persona ethos now
+distinguishes a banned promise from an allowed statement of observed fact.
+
+Two things are locked here.
+
+1. **Prompt-text anchors** (following ``test_resume_reverification.py``): the
+   guidance is text loaded into every headless PM turn, so a CI gate is the only
+   thing that keeps an edit from silently deleting it.
+
+2. **Promise-gate fallback characterization**: the phrasings the role doc teaches
+   must survive the *deterministic* heuristic branch
+   (``_evaluate_promise_heuristic``), which is what actually decides the verdict
+   whenever the LLM is unavailable (no API key, SDK exception, timeout). Without
+   this, someone tightening ``_FORWARD_DEFERRAL_PATTERNS`` with an innocuous-looking
+   ``\\bstill\\s+running\\b`` would start blocking the exact sentences the role doc
+   tells the PM to send, and only on the fallback path, which is the hardest
+   place to notice a regression.
+
+Deliberately NOT asserted: the live-LLM verdict. The LLM layer was measured
+directly against these phrasings on 2026-08-08 (see the table in
+``.claude/commands/roles/prime-pm-role.md``). Every phrasing this file locks was
+stable at 8/8 there, but two facts make an LLM assertion the wrong instrument:
+
+- ``"dev opened PR #102 (14 files) - still running tests."`` (the phrasing the
+  issue's own table records as a clean allow) measured 6/8 allow, i.e. flaky. It
+  is locked here as an ANTI-example: the role doc steers away from it.
+- The heuristic and the LLM genuinely disagree in the other direction too:
+  ``"Still working on this."`` is blocked 8/8 by the LLM but ALLOWED by the
+  heuristic, because no regex covers it. So "bare reassurance blocks" is not a
+  property of the deterministic layer and cannot honestly be asserted as one.
+
+Failure-path strategy: every read asserts the file exists and is non-empty
+BEFORE inspecting content, so a missing or truncated file fails loudly rather
+than passing vacuously.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from bridge.promise_gate import _evaluate_promise_heuristic
+
+pytestmark = [pytest.mark.unit, pytest.mark.sdlc]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PM_ROLE_PATH = REPO_ROOT / ".claude" / "commands" / "roles" / "prime-pm-role.md"
+WORK_PATTERNS_PATH = REPO_ROOT / "config" / "personas" / "segments" / "work-patterns.md"
+
+PM_SECTION_HEADER = "# Progress updates when the work overruns the ask"
+
+# The two shapes the role doc teaches as safe. Both must clear the deterministic
+# fallback branch.
+TAUGHT_ALLOWED = [
+    # Shape 1: present fact, no forward-looking clause, no artifact needed.
+    "Scope check: what read as a one-line config change is 14 files across "
+    "tools/ and config/. That is why this is taking a while.",
+    # Shape 1 with an artifact, still no forward clause.
+    "This turned out bigger than the ask implied: dev rewrote 14 files across "
+    "tools/ and config/ and opened PR #102.",
+    # Shape 2: work in flight, rescued by a full PR URL.
+    "dev opened PR https://github.com/example/repo/pull/102 (14 files), still running tests.",
+]
+
+# Explicit forward-deferral the role doc routes to ``promise-add`` instead. The
+# heuristic must keep catching this on the fallback path.
+TAUGHT_BLOCKED = "dev opened PR #102. I'll report back when tests finish."
+
+
+def _read_nonempty(path: Path) -> str:
+    """Read a required prompt file, failing loudly if absent or empty."""
+    assert path.exists(), f"Required prompt file is missing: {path}"
+    text = path.read_text(encoding="utf-8")
+    assert text.strip(), f"Required prompt file is empty: {path}"
+    return text
+
+
+class TestPMRoleGuidance:
+    """The PM role doc must carry the four things #2664 asks it to teach."""
+
+    def test_section_exists(self):
+        text = _read_nonempty(PM_ROLE_PATH)
+        assert PM_SECTION_HEADER in text, (
+            f"prime-pm-role.md must carry the {PM_SECTION_HEADER!r} section — it "
+            "is the only place the PM learns it may speak mid-flight at all."
+        )
+
+    def test_trigger_is_scope_relative_not_a_timer(self):
+        low = _read_nonempty(PM_ROLE_PATH).lower()
+        assert "there is no timer here and none is wanted" in low, (
+            "The role doc must state explicitly that the trigger is NOT a timer. "
+            "An unconditional interval is the exact shape that got INTERRUPT_RESUME "
+            "deleted in #1937."
+        )
+        assert "category change" in low, (
+            "The trigger must be keyed to a category change between implied and "
+            "actual scope, not to elapsed time."
+        )
+
+    def test_explains_turn_boundary_constraint_and_bounded_dispatch(self):
+        text = _read_nonempty(PM_ROLE_PATH)
+        low = text.lower()
+        assert "turn boundaries" in low, (
+            "The role doc must explain that the PM only has a voice at turn "
+            "boundaries — a PM blocked inside a foreground Agent call holds no "
+            "execution (#2420)."
+        )
+        assert "#2420" in text, "The turn-boundary constraint must cite its source issue (#2420)."
+        assert "sendmessage" in low and "same dev" in low, (
+            "The role doc must instruct bounding the dev dispatch while continuing "
+            "the SAME dev agent via SendMessage — bounding must never be read as "
+            "licence to spawn a second dev."
+        )
+
+    def test_requires_evidence_with_both_a_passing_and_a_blocked_example(self):
+        text = _read_nonempty(PM_ROLE_PATH)
+        assert "Still working on this." in text, (
+            "The role doc must show a concrete BLOCKED example so the PM can "
+            "recognise the shape it must avoid."
+        )
+        # The doc renders paths and URLs in backticks; the gate sees plain text.
+        # Compare on a backtick-stripped view so markdown emphasis alone never
+        # breaks the doc/test agreement this test exists to enforce.
+        plain = text.replace("`", "")
+        for allowed in TAUGHT_ALLOWED:
+            head = allowed.split(".")[0]
+            assert head in plain, (
+                f"The role doc must show the passing example beginning {head!r}. "
+                "The test locks the same strings the doc teaches; if you reword the "
+                "doc, update TAUGHT_ALLOWED here so the two stay in agreement."
+            )
+
+    def test_names_the_actual_discriminator(self):
+        low = _read_nonempty(PM_ROLE_PATH).lower()
+        assert "not the presence of evidence" in low, (
+            "The role doc must state the measured rule: the gate keys on a "
+            "forward-looking clause, NOT on the presence of evidence. Teaching "
+            "'just add evidence' produces messages that block."
+        )
+        assert "pull/" in low, (
+            "The role doc must tell the PM to cite a full PR URL rather than a bare "
+            "#N — the URL is the only autonomous-delivery reference both gate "
+            "layers recognise."
+        )
+
+
+class TestWorkPatternsScopeClarification:
+    """The ethos must be clarified without being weakened."""
+
+    def test_ethos_line_survives(self):
+        text = _read_nonempty(WORK_PATTERNS_PATH)
+        assert "Do or do not — there is no try." in text, (
+            "The ethos sentence must stay verbatim. #2664 is a clarification of "
+            "its scope, not a reversal."
+        )
+        assert "I never narrate the attempt." in text, (
+            "The ban on narrating the attempt must survive the clarification."
+        )
+
+    def test_promise_versus_observed_fact_distinction_present(self):
+        text = _read_nonempty(WORK_PATTERNS_PATH)
+        low = text.lower()
+        assert "observed fact" in low, (
+            "work-patterns.md must distinguish a banned promise from an allowed "
+            "statement of observed fact, or the PM reads the ethos as an absolute "
+            "gag and stays silent (#2664)."
+        )
+        assert "reassuring without evidence" in low, (
+            "The clarification must restate that evidence-free reassurance is "
+            "still banned, so it cannot be read as a general licence to chat."
+        )
+
+
+class TestPromiseGateFallbackAllowsTaughtPhrasings:
+    """Characterization: the deterministic branch must not block what we teach.
+
+    This is the regression guard the acceptance criteria asked for, retargeted at
+    the layer where a deterministic assertion is actually truthful.
+    """
+
+    @pytest.mark.parametrize("message", TAUGHT_ALLOWED)
+    def test_taught_phrasing_clears_the_heuristic(self, message):
+        verdict = _evaluate_promise_heuristic(message)
+        assert verdict.action == "allow", (
+            "The promise-gate fallback branch now blocks a phrasing that "
+            "prime-pm-role.md instructs the PM to send:\n"
+            f"  message: {message}\n"
+            f"  verdict: {verdict.action} ({verdict.class_}: {verdict.reason})\n"
+            "Either revert the pattern change or update the role doc's taught "
+            "phrasings to match. Silently diverging leaves the PM emitting "
+            "messages that die on the fallback path."
+        )
+
+    def test_explicit_forward_deferral_still_blocks(self):
+        verdict = _evaluate_promise_heuristic(TAUGHT_BLOCKED)
+        assert verdict.action == "block", (
+            "The heuristic must keep catching an explicit 'I'll report back' even "
+            "when substantive evidence is present — evidence does not rescue a "
+            "forward-deferral, only a scheduled-delivery reference does."
+        )
+        assert verdict.class_ == "forward_deferral"
+
+    def test_bare_pr_number_with_ongoing_clause_is_not_taught(self):
+        """The issue's flagship example measured 6/8 allow against the LLM.
+
+        It is excluded from TAUGHT_ALLOWED on purpose. This test pins that
+        exclusion so a future edit cannot quietly promote a coin-flip phrasing
+        into the role doc's recommended set.
+        """
+        flaky = "dev opened PR #102 (14 files) - still running tests."
+        assert flaky not in TAUGHT_ALLOWED
+        role_text = _read_nonempty(PM_ROLE_PATH)
+        assert "unreliable, 6/8 allow" in role_text, (
+            "The role doc must keep recording that the bare-#N + ongoing-clause "
+            "phrasing is unreliable, so nobody re-derives it as a good example "
+            "from the issue's original table."
+        )

--- a/tests/unit/test_pm_progress_updates.py
+++ b/tests/unit/test_pm_progress_updates.py
@@ -84,7 +84,7 @@ class TestPMRoleGuidance:
     def test_section_exists(self):
         text = _read_nonempty(PM_ROLE_PATH)
         assert PM_SECTION_HEADER in text, (
-            f"prime-pm-role.md must carry the {PM_SECTION_HEADER!r} section — it "
+            f"prime-pm-role.md must carry the {PM_SECTION_HEADER!r} section. It "
             "is the only place the PM learns it may speak mid-flight at all."
         )
 
@@ -105,13 +105,13 @@ class TestPMRoleGuidance:
         low = text.lower()
         assert "turn boundaries" in low, (
             "The role doc must explain that the PM only has a voice at turn "
-            "boundaries — a PM blocked inside a foreground Agent call holds no "
+            "boundaries. A PM blocked inside a foreground Agent call holds no "
             "execution (#2420)."
         )
         assert "#2420" in text, "The turn-boundary constraint must cite its source issue (#2420)."
         assert "sendmessage" in low and "same dev" in low, (
             "The role doc must instruct bounding the dev dispatch while continuing "
-            "the SAME dev agent via SendMessage — bounding must never be read as "
+            "the SAME dev agent via SendMessage. Bounding must never be read as "
             "licence to spawn a second dev."
         )
 
@@ -142,7 +142,7 @@ class TestPMRoleGuidance:
         )
         assert "pull/" in low, (
             "The role doc must tell the PM to cite a full PR URL rather than a bare "
-            "#N — the URL is the only autonomous-delivery reference both gate "
+            "#N. The URL is the only autonomous-delivery reference both gate "
             "layers recognise."
         )
 
@@ -198,7 +198,7 @@ class TestPromiseGateFallbackAllowsTaughtPhrasings:
         verdict = _evaluate_promise_heuristic(TAUGHT_BLOCKED)
         assert verdict.action == "block", (
             "The heuristic must keep catching an explicit 'I'll report back' even "
-            "when substantive evidence is present — evidence does not rescue a "
+            "when substantive evidence is present. Evidence does not rescue a "
             "forward-deferral, only a scheduled-delivery reference does."
         )
         assert verdict.class_ == "forward_deferral"


### PR DESCRIPTION
Closes #2664

## Premise verification first

The issue rests entirely on one claim: `bridge/promise_gate.py` already allows evidence-bearing progress reports. I invoked the live gate against the issue's own table rather than trusting it. **The claim is directionally right but materially wrong in the detail that the fix depends on.**

Measured 2026-08-08, 8 samples per phrasing:

| Phrasing | Issue says | Measured |
|---|---|---|
| Present fact, no forward clause ("what read as one config line is 14 files across `tools/` and `config/`") | not tested | **allow 8/8** |
| Past-tense work + bare PR number, no forward clause | not tested | **allow 8/8** |
| Ongoing clause + full `https://github.com/.../pull/N` | not tested | **allow 8/8** |
| `dev opened PR #102 (14 files) - still running tests.` | allow | **allow 6/8 (flaky)** |
| Real evidence, `dev is on it; no PR yet` | not tested | **block 8/8** |
| `Still working on this.` | block | block 8/8 |
| `It ended up being more work than expected, and we're still working on it.` | block | block 8/8 |
| Evidence + `I'll report back` | not tested | block 8/8 |

Three consequences:

1. **The gate keys on the presence of a forward-looking clause, not on the presence of evidence.** The issue's remedy ("add evidence and the same sentiment passes") is not the operative rule. Evidence does not rescue "still running", "is on it", or "I'll report back".
2. **The issue's flagship allow example is a coin flip** (6/8). Teaching it would give the PM a message that dies about a quarter of the time.
3. **The most honest early update is reliably blocked.** At minute ten, with real evidence but no PR yet, the gate blocks 8/8. That is exactly the 2026-08-07 moment. The only shape that works there is a pure statement of present fact with no forward clause, which passes 8/8 and needs no artifact.

`bridge/promise_gate.py` is **unchanged** (verified by `git diff --exit-code`). The premise that it must not be touched holds.

## What changed

- **`.claude/commands/roles/prime-pm-role.md`** — new section. Form a size expectation before dispatching; speak on a *category* change in scope, explicitly not a timer; the turn-boundary constraint (#2420) and how to bound a dev dispatch while continuing the SAME dev via `SendMessage`; the measured phrasing table with the real discriminator named; client-room vs Eng-room threshold.
- **`config/personas/segments/work-patterns.md`** — one paragraph clarifying that the ban is on promises, not on observed fact. "Do or do not — there is no try." and "I never narrate the attempt." both stay verbatim, asserted by test.
- **`docs/features/promise-gate.md`** — records the measurement and the deliberate LLM/heuristic disagreement, with a warning against writing tests that assume either layer mirrors the other.
- **`tests/unit/test_pm_progress_updates.py`** — 12 tests.

## On the "locking test" acceptance criterion

The criterion asked for a test asserting the evidence-bearing phrasing passes and bare reassurance blocks. **Neither half is truthfully assertable as written**, and I did not fake it:

- The LLM layer is nondeterministic on the allow side (6/8 for the issue's example). A test on it would be flaky.
- The heuristic layer **allows** `"Still working on this."` — no regex in `_FORWARD_DEFERRAL_PATTERNS` covers it. So "bare reassurance blocks" is not a property of the deterministic layer at all.

Retargeted to what is both deterministic and load-bearing: the heuristic must not block the phrasings the role doc teaches. That is the real regression risk. Someone tightening `_FORWARD_DEFERRAL_PATTERNS` with an innocuous `\bstill\s+running\b` would silently break the PM's taught sentences on the fallback path, which is the hardest place to notice. The flaky phrasing is pinned as an explicit anti-example so nobody re-derives it from the issue's original table.

## Out of scope, deliberately

Open question 4 (bridge-side timer emitter) is untouched. No timer was built. The role doc states in prose that there is no timer and none is wanted.

**Acceptance criterion 6 is descoped, not met.** The criterion asked for a dry run or transcript check showing a PM in the 2026-08-07 scenario producing an allowed, evidence-bearing update rather than silence. What this PR did instead is measure hand-authored phrasings against the live gate. That validates the *phrasings*; it does not demonstrate that a PM reading the new role doc *produces* one. Closing that gap needs an end-to-end PM session replayed against the 2026-08-07 scenario, which this change does not include. The instructional change is the deliverable; whether it lands in PM behavior is an observation to make on the next real overrun, not something this PR proves.

## Verification

`tests/unit/test_pm_progress_updates.py` 12 passed. Combined with `test_promise_gate.py`, `test_persona_loading.py`, `test_resume_reverification.py`: 133 passed. `ruff format` + `ruff check` clean.

`config/personas/segments/work-patterns.md` changed, so `tests/fixtures/persona/eng_worker_repo_baseline.txt` is regenerated via `python scripts/capture_persona_baseline.py` (62449 → 62950 chars, the one new paragraph). `tests/unit/test_compose_system_prompt.py` passes: 16 passed, 1 skipped. Any edit under `config/personas/segments/` routes to that test.
