### PR TITLE
Judge only the file the Write named, and stop firing on quoted critique text

### DIFF
--- a/.claude/hooks/validators/validate_no_gos_justification.py
+++ b/.claude/hooks/validators/validate_no_gos_justification.py
@@ -40,8 +40,31 @@ PUNT_PHRASES = [
     # "operator/human will <do something>" is a punt. "operator will SEE the
     # log line change" is a description of observable behavior, which every
     # plan's impact section is made of (#2682). Only the action sense counts.
+    #
+    # The optional adverb slot is load-bearing: impact prose says "will *simply*
+    # see", "will *then* see", "will *now* observe", and without the slot each
+    # of those scores as a punt — a false positive that blocks an unrelated
+    # lane's write. The slot must live INSIDE the negative lookahead. Placed
+    # before it (``will\s+(?:\w+ly\s+)?(?!see\b|...)``) it does nothing: the
+    # group is optional, so when the lookahead fails with the adverb consumed
+    # the engine backtracks, matches the group as empty, re-tests the lookahead
+    # against the adverb itself ("simply" is not "see"), and the pattern matches
+    # anyway. Written as ``(?!<optional adverb><perception verb>)`` the
+    # assertion is what we actually mean: what follows is NOT an optionally
+    # adverb-prefixed perception verb.
+    #
+    # ``no longer`` stays a standalone alternative rather than an adverb,
+    # because it exempts ANY following verb ("will no longer rotate the key" is
+    # not a punt). Demoted into the adverb slot it would only exempt perception
+    # verbs, re-introducing a false positive.
+    #
+    # ``\w+ly`` deliberately over-matches a few verbs ("apply", "supply"), which
+    # is harmless: after "apply" the next token is not a perception verb, and
+    # "apply" is not one either, so the inner pattern fails and the line stays a
+    # punt. Pinned by ``test_action_sense_is_still_a_punt``.
     r"\b(?:operator|human)\s+will\s+"
-    r"(?!see\b|notice\b|observe\b|read\b|find\b|know\b|get\b|receive\b|experience\b|no longer\b)",
+    r"(?!(?:(?:\w+ly|then|now|also|still|already|just|soon|never)\s+)?"
+    r"(?:see|notice|observe|read|find|know|get|receive|experience)\b|no longer\b)",
     r"\bin v2\b",
     r"\bdefer(?:red)? to v\d\b",
     r"\bpunt(?:ed)? to\b",
@@ -149,7 +172,20 @@ def extract_no_gos_section(content: str) -> str | None:
 
 
 def no_gos_line_span(content: str) -> tuple[int, int]:
-    """0-based ``[start, end)`` line indices of the No-Gos section body.
+    """0-based ``[start, end)`` line range covering the No-Gos section.
+
+    Wider than the section *body* on both ends, deliberately. ``start`` is the
+    ``## No-Gos`` heading line itself, and ``end`` is one past the following
+    ``## `` heading (or at/past EOF when No-Gos is the last section). Both
+    headings land inside the range but cost nothing: the caller skips any line
+    beginning with ``#``.
+
+    The ``+ 1`` is what keeps a final *unterminated* line in range. ``end`` is
+    derived from a newline count, so when No-Gos is the last section and the
+    file has no trailing newline, the closing line contributes no newline and
+    would otherwise fall outside the scan — silently disarming the guard on the
+    one section where the quoted-context exemption does not apply. Pinned by
+    ``test_table_row_inside_no_gos_still_fails``'s no-trailing-newline case.
 
     ``(-1, -1)`` when there is no such section.
     """

--- a/.claude/hooks/validators/validate_no_gos_justification.py
+++ b/.claude/hooks/validators/validate_no_gos_justification.py
@@ -113,7 +113,17 @@ def target_from_hook_input(hook_input: dict) -> str | None:
 
 
 NO_GOS_HEADING = re.compile(r"^## No-Gos[^\n]*$(.*?)(?=^## |\Z)", re.MULTILINE | re.DOTALL)
-FENCE = re.compile(r"^\s*(?:```|~~~)")
+# The full run of fence characters is captured, not just its first three,
+# because a fence closes only on a marker of the SAME character at least as
+# long as the one that opened it — CommonMark's rule, and the only way to write
+# a fenced block that itself contains a fence. A bare open/close toggle treats
+# the inner ``` of a ````-wrapped example as a closer and stays inverted for the
+# rest of the document, so the code exemption evaporates and a punt phrase
+# quoted inside that example blocks an unrelated agent's write (#2682). The
+# false-positive direction is the dangerous one, hence the strict rule.
+# The ``^\s*`` allowance (rather than CommonMark's three-space cap) is
+# deliberate: plans nest fences inside list items at arbitrary depth.
+FENCE = re.compile(r"^\s*(?P<marker>`{3,}|~{3,})")
 
 # A leading pipe or angle bracket marks transcribed material rather than the
 # plan's own commitments: critique-findings tables, review verdict logs, and
@@ -153,13 +163,21 @@ def find_punt_lines(content: str) -> list[str]:
     lines = content.splitlines()
     no_gos_start, no_gos_end = no_gos_line_span(content)
     bad: list[str] = []
-    in_fence = False
+    open_marker: str | None = None
 
     for idx, raw_line in enumerate(lines):
-        if FENCE.match(raw_line):
-            in_fence = not in_fence
+        fence = FENCE.match(raw_line)
+        if fence:
+            marker = fence.group("marker")
+            if open_marker is None:
+                open_marker = marker
+                continue
+            # A shorter marker, or one of the other character, is fence
+            # content — an example block being quoted, not a closer.
+            if marker[0] == open_marker[0] and len(marker) >= len(open_marker):
+                open_marker = None
             continue
-        if in_fence:
+        if open_marker is not None:
             continue
 
         line = raw_line.strip()

--- a/.claude/hooks/validators/validate_no_gos_justification.py
+++ b/.claude/hooks/validators/validate_no_gos_justification.py
@@ -37,8 +37,11 @@ VALID_TAGS = ("[EXTERNAL]", "[ORDERED]", "[DESTRUCTIVE]", "[SEPARATE-SLUG")
 PUNT_PHRASES = [
     r"\bdeferred to (?:a )?follow-?up\b",
     r"\bfollow-?up (?:issue|pr|ticket)\b",
-    r"\boperator will\b",
-    r"\bhuman will\b",
+    # "operator/human will <do something>" is a punt. "operator will SEE the
+    # log line change" is a description of observable behavior, which every
+    # plan's impact section is made of (#2682). Only the action sense counts.
+    r"\b(?:operator|human)\s+will\s+"
+    r"(?!see\b|notice\b|observe\b|read\b|find\b|know\b|get\b|receive\b|experience\b|no longer\b)",
     r"\bin v2\b",
     r"\bdefer(?:red)? to v\d\b",
     r"\bpunt(?:ed)? to\b",
@@ -90,47 +93,92 @@ this rule blocks.
 """
 
 
-def find_newest_plan_file(directory: str = "docs/plans") -> str | None:
-    try:
-        result = subprocess.run(
-            ["git", "status", "--porcelain", f"{directory}/"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if result.returncode != 0:
-            return None
-        new_files = []
-        for line in result.stdout.strip().split("\n"):
-            if not line:
-                continue
-            status = line[:2]
-            filepath = line[3:].strip()
-            if status in ("??", "A ", " A", "AM", " M", "M ", "MM") and filepath.endswith(".md"):
-                new_files.append(filepath)
-        if not new_files:
-            return None
-        newest = None
-        newest_mtime = 0.0
-        for filepath in new_files:
-            path = Path(filepath)
-            if path.exists():
-                mtime = path.stat().st_mtime
-                if mtime > newest_mtime:
-                    newest_mtime = mtime
-                    newest = str(path)
-        return newest
-    except (subprocess.TimeoutExpired, subprocess.SubprocessError):
+def target_from_hook_input(hook_input: dict) -> str | None:
+    """The path the triggering Write actually targeted, or None.
+
+    None means "nothing to validate", never "go find something to validate".
+    The predecessor resolved the target by scanning ``git status docs/plans/``
+    and taking the newest dirty file, which gated a lane on a plan it had never
+    touched: a Write to ``docs/features/foo.md`` in one worktree was blocked by
+    another lane's in-progress plan, and the git query ran against whatever
+    checkout the hook process started in (#2682).
+    """
+    tool_input = hook_input.get("tool_input")
+    if not isinstance(tool_input, dict):
         return None
+    # The `or` already collapses an empty string to the next candidate, and
+    # then to None — so an empty path can never reach the caller as a target.
+    path = tool_input.get("file_path") or tool_input.get("notebook_path")
+    return path if isinstance(path, str) else None
+
+
+NO_GOS_HEADING = re.compile(r"^## No-Gos[^\n]*$(.*?)(?=^## |\Z)", re.MULTILINE | re.DOTALL)
+FENCE = re.compile(r"^\s*(?:```|~~~)")
+
+# A leading pipe or angle bracket marks transcribed material rather than the
+# plan's own commitments: critique-findings tables, review verdict logs, and
+# "critic's suggested remedy, kept for the record" blocks all quote deferral
+# phrasing in order to discuss it. Scanning them means a plan gets *more*
+# likely to fail the more carefully it records its own review (#2682).
+QUOTED_CONTEXT_PREFIXES = ("|", ">")
 
 
 def extract_no_gos_section(content: str) -> str | None:
-    match = re.search(
-        r"^## No-Gos[^\n]*$(.*?)(?=^## |\Z)",
-        content,
-        re.MULTILINE | re.DOTALL,
-    )
+    match = NO_GOS_HEADING.search(content)
     return match.group(1).strip() if match else None
+
+
+def no_gos_line_span(content: str) -> tuple[int, int]:
+    """0-based ``[start, end)`` line indices of the No-Gos section body.
+
+    ``(-1, -1)`` when there is no such section.
+    """
+    match = NO_GOS_HEADING.search(content)
+    if not match:
+        return (-1, -1)
+    start = content.count("\n", 0, match.start(1))
+    end = content.count("\n", 0, match.end(1))
+    return (start, end + 1)
+
+
+def find_punt_lines(content: str) -> list[str]:
+    """Unjustified deferrals in the plan's own voice.
+
+    The whole body is scanned, not just No-Gos, because a punt hides in prose
+    anywhere. Two kinds of line are exempt outside the No-Gos section:
+    fenced code, and quoted/tabular context. Inside No-Gos nothing is exempt
+    but code fences — that section is where commitments are made, so a punt
+    written as a table row there must still fail.
+    """
+    lines = content.splitlines()
+    no_gos_start, no_gos_end = no_gos_line_span(content)
+    bad: list[str] = []
+    in_fence = False
+
+    for idx, raw_line in enumerate(lines):
+        if FENCE.match(raw_line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+
+        line = raw_line.strip()
+        if not line or line.startswith("#") or line.startswith("<!--"):
+            continue
+
+        inside_no_gos = no_gos_start <= idx < no_gos_end
+        if not inside_no_gos and line.startswith(QUOTED_CONTEXT_PREFIXES):
+            continue
+
+        if not line_is_punt(line):
+            continue
+        if line_is_justified(line):
+            continue
+        if line_is_explicit_none(line):
+            continue
+        bad.append(f"  {raw_line.rstrip()}")
+
+    return bad
 
 
 def line_is_punt(line: str) -> bool:
@@ -182,21 +230,7 @@ def validate(filepath: str) -> tuple[bool, str]:
     if section is None:
         return False, MISSING_SECTION_ERROR.format(file=filepath)
 
-    # Walk every body line of the entire plan looking for punt phrases —
-    # punts hide outside the No-Gos section too.
-    bad: list[str] = []
-    for raw_line in content.splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#") or line.startswith("<!--"):
-            continue
-        if not line_is_punt(line):
-            continue
-        if line_is_justified(line):
-            continue
-        if line_is_explicit_none(line):
-            continue
-        bad.append(f"  {raw_line.rstrip()}")
-
+    bad = find_punt_lines(content)
     if bad:
         return False, UNJUSTIFIED_PUNT_ERROR.format(file=filepath, lines="\n".join(bad[:10]))
 
@@ -214,21 +248,37 @@ def main():
     parser.add_argument("plan_file", nargs="?", help="Path to plan file")
     args = parser.parse_args()
 
-    try:
-        json.load(sys.stdin)
-    except (json.JSONDecodeError, EOFError):
-        pass
+    # An explicit path (CLI / tests) wins; otherwise take the path the hook's
+    # own tool input names. Never guess.
+    plan_file = args.plan_file
+    if not plan_file:
+        hook_input: dict = {}
+        try:
+            raw = sys.stdin.read()
+            if raw.strip():
+                hook_input = json.loads(raw)
+        except (json.JSONDecodeError, OSError, EOFError):
+            hook_input = {}
+        plan_file = target_from_hook_input(hook_input)
 
-    plan_file = args.plan_file or find_newest_plan_file()
     if not plan_file:
         sys.exit(0)
 
-    if not Path(plan_file).exists():
-        print(f"ERROR: Plan file does not exist: {plan_file}", file=sys.stderr)
-        sys.exit(2)
-
-    # Only enforce on plan docs; pass through anything else
+    # Only enforce on plan docs; pass through anything else. This has to come
+    # before the existence check, or a Write to any non-plan path that the hook
+    # cannot stat (a relative path resolved against a different cwd, a file in
+    # another worktree) exits 2 and blocks a write it has no business judging.
     if "docs/plans" not in plan_file.replace("\\", "/"):
+        sys.exit(0)
+
+    path = Path(plan_file)
+    if not path.exists():
+        # An explicit CLI argument that names nothing is a user error worth
+        # reporting. A hook-derived path we cannot resolve is not: there is no
+        # content to judge, so there is no finding to make.
+        if args.plan_file:
+            print(f"ERROR: Plan file does not exist: {plan_file}", file=sys.stderr)
+            sys.exit(2)
         sys.exit(0)
 
     success, message = validate(plan_file)

--- a/.claude/hooks/validators/validate_no_gos_justification.py
+++ b/.claude/hooks/validators/validate_no_gos_justification.py
@@ -121,6 +121,16 @@ NO_GOS_HEADING = re.compile(r"^## No-Gos[^\n]*$(.*?)(?=^## |\Z)", re.MULTILINE |
 # rest of the document, so the code exemption evaporates and a punt phrase
 # quoted inside that example blocks an unrelated agent's write (#2682). The
 # false-positive direction is the dangerous one, hence the strict rule.
+#
+# Accepted cost: the strict rule widens the fail-open surface from *unterminated*
+# fences to ANY mismatched marker — a ````-opened block "closed" by ``` now
+# exempts everything to EOF, and that reach extends into ``## No-Gos``, the one
+# section where the quoted-context exemption deliberately does not apply. So a
+# typo'd fence anywhere above No-Gos silently disarms the gate for that document.
+# We take that trade knowingly: fail-open can never block a lane, and CommonMark
+# correctness is worth more than catching a malformed document. Pinned by
+# ``test_mismatched_fence_markers_fail_open_into_no_gos``.
+#
 # The ``^\s*`` allowance (rather than CommonMark's three-space cap) is
 # deliberate: plans nest fences inside list items at arbitrary depth.
 FENCE = re.compile(r"^\s*(?P<marker>`{3,}|~{3,})")
@@ -171,10 +181,11 @@ def find_punt_lines(content: str) -> list[str]:
             marker = fence.group("marker")
             if open_marker is None:
                 open_marker = marker
-                continue
             # A shorter marker, or one of the other character, is fence
-            # content — an example block being quoted, not a closer.
-            if marker[0] == open_marker[0] and len(marker) >= len(open_marker):
+            # content — an example block being quoted, not a closer. The
+            # ``elif`` is structural: an opener must never be tested against
+            # itself, or every fence would close on the line that opened it.
+            elif marker[0] == open_marker[0] and len(marker) >= len(open_marker):
                 open_marker = None
             continue
         if open_marker is not None:

--- a/tests/unit/test_validate_no_gos_justification.py
+++ b/tests/unit/test_validate_no_gos_justification.py
@@ -1,13 +1,25 @@
 """Unit tests for validate_no_gos_justification.py hook validator.
 
-Focused on the PUNT_PHRASES post-merge patterns: descriptive uses of the
-hyphenated phrase must pass, deferral constructions must fail (issue #1900
-review flagged the old bare \\bpost-merge\\b pattern as a false-positive on
-every mention).
+Two families here.
+
+The PUNT_PHRASES patterns: descriptive uses of a phrase must pass, deferral
+constructions must fail (issue #1900 flagged the old bare \\bpost-merge\\b
+pattern as a false-positive on every mention; #2682 flagged \\boperator will\\b
+the same way).
+
+Targeting and quoted context (#2682): the validator must judge only the file
+the triggering Write named, and must not fire on deferral language a plan
+*quotes* while recording its own critique.
 """
 
+import json
+import subprocess
 import sys
 from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 # Hook scripts live in .claude/hooks/validators/
 VALIDATORS_DIR = Path(__file__).resolve().parent.parent.parent / ".claude" / "hooks" / "validators"
@@ -122,3 +134,230 @@ class TestOtherPuntPhrasesUnchanged:
         ok, message = mod.validate(str(plan))
         assert not ok
         assert "missing a ## No-Gos section" in message
+
+
+VALIDATOR = VALIDATORS_DIR / "validate_no_gos_justification.py"
+
+
+def run_hook(payload: dict | str | None, cwd: Path) -> int:
+    """Invoke the validator the way the harness does: JSON on stdin, no argv."""
+    stdin = payload if isinstance(payload, str) else json.dumps(payload or {})
+    proc = subprocess.run(
+        [sys.executable, str(VALIDATOR)],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+        timeout=30,
+    )
+    return proc.returncode
+
+
+def write_plan(root: Path, name: str, body: str) -> Path:
+    plans = root / "docs" / "plans"
+    plans.mkdir(parents=True, exist_ok=True)
+    path = plans / name
+    path.write_text(body)
+    return path
+
+
+BAD_PLAN = """\
+# Other lane's plan
+
+## No-Gos (Out of Scope)
+
+- Rate limiting deferred to a follow-up issue.
+"""
+
+
+class TestTargetIsTheFileTheWriteNamed:
+    """#2682: a lane must never be gated on a plan it did not touch."""
+
+    def test_newest_plan_fallback_is_gone(self):
+        mod = import_validator()
+        assert not hasattr(mod, "find_newest_plan_file"), (
+            "the git-status/mtime fallback is the defect; it must not come back"
+        )
+
+    def test_reads_file_path_from_tool_input(self):
+        mod = import_validator()
+        payload = {"tool_input": {"file_path": "docs/plans/x.md"}}
+        assert mod.target_from_hook_input(payload) == "docs/plans/x.md"
+
+    def test_reads_notebook_path(self):
+        mod = import_validator()
+        assert mod.target_from_hook_input({"tool_input": {"notebook_path": "a.ipynb"}}) == "a.ipynb"
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {},
+            {"tool_input": None},
+            {"tool_input": "nope"},
+            {"tool_input": {}},
+            {"tool_input": {"file_path": ""}},
+        ],
+    )
+    def test_unresolvable_target_is_none_not_a_guess(self, payload):
+        mod = import_validator()
+        assert mod.target_from_hook_input(payload) is None
+
+    @pytest.mark.parametrize("bogus", [123, {"a": 1}, ["x"], True])
+    def test_non_string_path_is_rejected(self, bogus):
+        """A malformed payload must not hand a non-path downstream."""
+        mod = import_validator()
+        assert mod.target_from_hook_input({"tool_input": {"file_path": bogus}}) is None
+
+    def test_unrelated_write_passes_while_a_bad_plan_sits_in_docs_plans(self, tmp_path):
+        """The exact shape that blocked Workstream F."""
+        write_plan(tmp_path, "other-lane.md", BAD_PLAN)
+        payload = {"tool_name": "Write", "tool_input": {"file_path": "docs/features/mine.md"}}
+        assert run_hook(payload, cwd=tmp_path) == 0
+
+    def test_non_plan_source_file_passes(self, tmp_path):
+        write_plan(tmp_path, "other-lane.md", BAD_PLAN)
+        payload = {"tool_name": "Write", "tool_input": {"file_path": "tools/foo.py"}}
+        assert run_hook(payload, cwd=tmp_path) == 0
+
+    def test_the_plan_you_actually_wrote_is_still_enforced(self, tmp_path):
+        plan = write_plan(tmp_path, "mine.md", BAD_PLAN)
+        payload = {"tool_name": "Write", "tool_input": {"file_path": str(plan)}}
+        assert run_hook(payload, cwd=tmp_path) == 2
+
+    def test_relative_plan_path_is_enforced(self, tmp_path):
+        write_plan(tmp_path, "mine.md", BAD_PLAN)
+        payload = {"tool_name": "Write", "tool_input": {"file_path": "docs/plans/mine.md"}}
+        assert run_hook(payload, cwd=tmp_path) == 2
+
+    @pytest.mark.parametrize("payload", [None, "", "not json", {"tool_input": {}}])
+    def test_absent_or_malformed_input_passes_through(self, payload, tmp_path):
+        write_plan(tmp_path, "other-lane.md", BAD_PLAN)
+        assert run_hook(payload, cwd=tmp_path) == 0
+
+    def test_unresolvable_plan_path_does_not_block(self, tmp_path):
+        payload = {"tool_input": {"file_path": "docs/plans/never-written.md"}}
+        assert run_hook(payload, cwd=tmp_path) == 0
+
+    def test_non_plan_path_passes_even_when_it_does_not_exist(self, tmp_path):
+        """The plan-path check must precede the existence check.
+
+        Reversed, a Write to any non-plan path the hook cannot stat — a
+        relative path resolved against a different cwd, a file in another
+        worktree — exits 2 on a file the validator would never have judged.
+        """
+        proc = subprocess.run(
+            [sys.executable, str(VALIDATOR), "tools/does-not-exist.py"],
+            capture_output=True,
+            text=True,
+            cwd=str(tmp_path),
+            timeout=30,
+        )
+        assert proc.returncode == 0, proc.stderr
+
+
+class TestQuotedCritiqueContentDoesNotFalsePositive:
+    """A plan that records its own review must not fail for quoting it."""
+
+    def _plan(self, quoted_block: str) -> str:
+        return f"""\
+## Problem
+
+Something.
+
+## Critique Findings
+
+{quoted_block}
+
+## No-Gos (Out of Scope)
+
+Nothing deferred — every relevant item is in scope for this plan.
+"""
+
+    def test_table_row_quoting_a_punt_passes(self, tmp_path):
+        mod = import_validator()
+        plan = tmp_path / "p.md"
+        plan.write_text(
+            self._plan("| CONCERN | The honest fix is a follow-up issue naming the records. |")
+        )
+        ok, message = mod.validate(str(plan))
+        assert ok, message
+
+    def test_blockquote_quoting_a_punt_passes(self, tmp_path):
+        mod = import_validator()
+        plan = tmp_path / "p.md"
+        plan.write_text(self._plan("> Critic noted the work was deferred to a follow-up issue."))
+        ok, message = mod.validate(str(plan))
+        assert ok, message
+
+    def test_fenced_code_quoting_a_punt_passes(self, tmp_path):
+        mod = import_validator()
+        plan = tmp_path / "p.md"
+        plan.write_text(self._plan('```\nerror: "punted to the next sprint"\n```'))
+        ok, message = mod.validate(str(plan))
+        assert ok, message
+
+    def test_table_row_inside_no_gos_still_fails(self, tmp_path):
+        """No-Gos is where commitments live; the exemption must not reach it."""
+        mod = import_validator()
+        plan = tmp_path / "p.md"
+        plan.write_text(
+            "## Problem\n\nThing.\n\n"
+            "## No-Gos (Out of Scope)\n\n"
+            "| Item | Disposition |\n|---|---|\n"
+            "| Rate limiting | Punted to the next sprint. |\n"
+        )
+        ok, message = mod.validate(str(plan))
+        assert not ok
+        assert "unjustified deferrals" in message
+
+    def test_punt_in_ordinary_prose_outside_no_gos_still_fails(self, tmp_path):
+        """The original intent — punts hide outside No-Gos — is preserved."""
+        mod = import_validator()
+        plan = tmp_path / "p.md"
+        plan.write_text(plan_with_body("The retry backoff will be done post-merge."))
+        ok, message = mod.validate(str(plan))
+        assert not ok
+
+    def test_committed_watchdog_plan_validates(self):
+        """The #2682 repro fixture: a real plan whose critique tables tripped it."""
+        candidates = [
+            REPO_ROOT / "docs" / "plans" / "watchdog-import-time-log-handler.md",
+            REPO_ROOT / "docs" / "plans" / "completed" / "watchdog-import-time-log-handler.md",
+        ]
+        plan = next((p for p in candidates if p.exists()), None)
+        if plan is None:
+            pytest.skip("watchdog plan not present in this checkout")
+        mod = import_validator()
+        ok, message = mod.validate(str(plan))
+        assert ok, message
+
+
+class TestOperatorWillIsActionSenseOnly:
+    """#2682: 'operator will see X' describes impact; it defers nothing."""
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "**What an operator will see change**: one log copy instead of two.",
+            "An operator will notice the duplicate lines are gone.",
+            "The operator will observe a single formatted record.",
+            "A human will read the same message in both files.",
+            "The operator will no longer see two copies.",
+        ],
+    )
+    def test_perception_sense_is_not_a_punt(self, line):
+        mod = import_validator()
+        assert not mod.line_is_punt(line)
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "The operator will rotate the signing key.",
+            "The operator will run the migration by hand.",
+            "A human will apply the config change.",
+            "The operator will need to click through the vendor UI.",
+        ],
+    )
+    def test_action_sense_is_still_a_punt(self, line):
+        mod = import_validator()
+        assert mod.line_is_punt(line)

--- a/tests/unit/test_validate_no_gos_justification.py
+++ b/tests/unit/test_validate_no_gos_justification.py
@@ -413,7 +413,13 @@ class TestFenceMarkersFollowCommonMark:
         assert ok, message
 
     def test_inline_backticks_do_not_open_a_fence(self, tmp_path):
-        """Only line-initial markers delimit; inline code spans must not."""
+        """A mid-line code span does not open a fence (the ``^`` anchor).
+
+        Scope note: this pins the mid-line case only. A *line-initial* span
+        (a line beginning ```foo```) does open a fence that never closes,
+        swallowing later punts. That is pre-existing, in the fail-open
+        direction, and out of scope here.
+        """
         mod = import_validator()
         plan = tmp_path / "p.md"
         plan.write_text(
@@ -427,6 +433,53 @@ class TestFenceMarkersFollowCommonMark:
         ok, message = mod.validate(str(plan))
         assert not ok
         assert "will be done post-merge" in message
+
+    def test_longer_closing_marker_still_closes_the_fence(self, tmp_path):
+        """CommonMark: a ``` fence closes on a marker at least as long.
+
+        Pins the ``>=`` in the close comparison. Tightened to ``==``, the
+        fence would never close and the punt below it would be swallowed.
+        """
+        mod = import_validator()
+        plan = tmp_path / "p.md"
+        plan.write_text(
+            "# Plan\n\n"
+            "## Design\n\n"
+            "```\n"
+            "example\n"
+            "````\n\n"
+            "The retry backoff will be done post-merge.\n\n"
+            "## No-Gos (Out of Scope)\n\n"
+            "Nothing deferred — every relevant item is in scope for this plan.\n"
+        )
+        ok, message = mod.validate(str(plan))
+        assert not ok
+        assert "will be done post-merge" in message
+
+    def test_mismatched_fence_markers_fail_open_into_no_gos(self, tmp_path):
+        """Decision on the record: mismatched markers exempt to EOF.
+
+        A ````-opened block "closed" by a shorter ``` marker stays open for
+        the rest of the document, and that reach extends into ``## No-Gos``,
+        where the quoted-context exemption deliberately does not apply — so an
+        unjustified punt there goes uncaught. This is the ACCEPTED fail-open
+        direction, taken knowingly: fail-open can never block a lane, and
+        CommonMark correctness is worth more than catching a malformed
+        document. Asserting PASS documents the trade rather than endorsing it.
+        """
+        mod = import_validator()
+        plan = tmp_path / "p.md"
+        plan.write_text(
+            "# Plan\n\n"
+            "## Design\n\n"
+            "````\n"
+            "example\n"
+            "```\n\n"
+            "## No-Gos (Out of Scope)\n\n"
+            "- Rate limiting deferred to a follow-up issue.\n"
+        )
+        ok, message = mod.validate(str(plan))
+        assert ok, message
 
 
 class TestOperatorWillIsActionSenseOnly:

--- a/tests/unit/test_validate_no_gos_justification.py
+++ b/tests/unit/test_validate_no_gos_justification.py
@@ -332,6 +332,103 @@ Nothing deferred — every relevant item is in scope for this plan.
         assert ok, message
 
 
+class TestFenceMarkersFollowCommonMark:
+    """A fence closes only on a same-type marker at least as long (#2682).
+
+    A bare open/close toggle desyncs on the first nested marker and stays
+    desynced for the rest of the document, in the dangerous direction: the
+    exemption evaporates and an unrelated agent's write gets blocked.
+    """
+
+    def test_four_backtick_wrapper_around_three_backtick_block_passes(self, tmp_path):
+        """Documenting markdown-in-markdown must not leak its content."""
+        mod = import_validator()
+        plan = tmp_path / "p.md"
+        plan.write_text(
+            "# Plan\n\n"
+            "## No-Gos (Out of Scope)\n\n"
+            "Nothing deferred — every relevant item is in scope for this plan.\n\n"
+            "## Notes\n\n"
+            "Documenting how to write a fenced block:\n\n"
+            "````\n"
+            "```\n"
+            "- Rate limiting deferred to a follow-up issue\n"
+            "```\n"
+            "````\n"
+        )
+        ok, message = mod.validate(str(plan))
+        assert ok, message
+
+    def test_backtick_fence_nested_in_tilde_fence_does_not_desync(self, tmp_path):
+        """A different-type marker inside a fence is content, not a delimiter."""
+        mod = import_validator()
+        plan = tmp_path / "p.md"
+        plan.write_text(
+            "# Plan\n\n"
+            "## No-Gos (Out of Scope)\n\n"
+            "Nothing deferred — every relevant item is in scope for this plan.\n\n"
+            "## Notes\n\n"
+            "~~~\n"
+            "```\n"
+            "- Rate limiting deferred to a follow-up issue\n"
+            "```\n"
+            "~~~\n"
+        )
+        ok, message = mod.validate(str(plan))
+        assert ok, message
+
+    def test_ordinary_fence_still_closes_and_later_punts_still_fail(self, tmp_path):
+        """The fix must not turn every fence into an open-ended exemption."""
+        mod = import_validator()
+        plan = tmp_path / "p.md"
+        plan.write_text(
+            "# Plan\n\n"
+            "## Design\n\n"
+            "```\n"
+            "punted to the next sprint\n"
+            "```\n\n"
+            "The retry backoff will be done post-merge.\n\n"
+            "## No-Gos (Out of Scope)\n\n"
+            "Nothing deferred — every relevant item is in scope for this plan.\n"
+        )
+        ok, message = mod.validate(str(plan))
+        assert not ok
+        assert "will be done post-merge" in message
+
+    def test_indented_fence_still_opens(self, tmp_path):
+        """The ``^\\s*`` allowance is deliberate; list-nested fences count."""
+        mod = import_validator()
+        plan = tmp_path / "p.md"
+        plan.write_text(
+            "# Plan\n\n"
+            "## Design\n\n"
+            "- Example:\n\n"
+            "      ```\n"
+            "      punted to the next sprint\n"
+            "      ```\n\n"
+            "## No-Gos (Out of Scope)\n\n"
+            "Nothing deferred — every relevant item is in scope for this plan.\n"
+        )
+        ok, message = mod.validate(str(plan))
+        assert ok, message
+
+    def test_inline_backticks_do_not_open_a_fence(self, tmp_path):
+        """Only line-initial markers delimit; inline code spans must not."""
+        mod = import_validator()
+        plan = tmp_path / "p.md"
+        plan.write_text(
+            "# Plan\n\n"
+            "## Design\n\n"
+            "Call ```foo``` then ```bar```.\n\n"
+            "The retry backoff will be done post-merge.\n\n"
+            "## No-Gos (Out of Scope)\n\n"
+            "Nothing deferred — every relevant item is in scope for this plan.\n"
+        )
+        ok, message = mod.validate(str(plan))
+        assert not ok
+        assert "will be done post-merge" in message
+
+
 class TestOperatorWillIsActionSenseOnly:
     """#2682: 'operator will see X' describes impact; it defers nothing."""
 

--- a/tests/unit/test_validate_no_gos_justification.py
+++ b/tests/unit/test_validate_no_gos_justification.py
@@ -296,16 +296,27 @@ Nothing deferred — every relevant item is in scope for this plan.
         ok, message = mod.validate(str(plan))
         assert ok, message
 
-    def test_table_row_inside_no_gos_still_fails(self, tmp_path):
-        """No-Gos is where commitments live; the exemption must not reach it."""
+    @pytest.mark.parametrize("trailing_newline", [True, False])
+    def test_table_row_inside_no_gos_still_fails(self, tmp_path, trailing_newline):
+        """No-Gos is where commitments live; the exemption must not reach it.
+
+        The no-trailing-newline variant pins the ``+ 1`` in
+        ``no_gos_line_span``. ``end`` is computed by counting newlines, so when
+        No-Gos is the last section and the file does not end in one, the final
+        punt line contributes no newline and falls outside the scanned range
+        without it — the guard silently returns clean on exactly the section it
+        exists to police. Trailing newlines are an editor detail no plan author
+        controls, so both shapes must fail.
+        """
         mod = import_validator()
         plan = tmp_path / "p.md"
-        plan.write_text(
+        content = (
             "## Problem\n\nThing.\n\n"
             "## No-Gos (Out of Scope)\n\n"
             "| Item | Disposition |\n|---|---|\n"
             "| Rate limiting | Punted to the next sprint. |\n"
         )
+        plan.write_text(content if trailing_newline else content.rstrip("\n"))
         ok, message = mod.validate(str(plan))
         assert not ok
         assert "unjustified deferrals" in message
@@ -415,10 +426,12 @@ class TestFenceMarkersFollowCommonMark:
     def test_inline_backticks_do_not_open_a_fence(self, tmp_path):
         """A mid-line code span does not open a fence (the ``^`` anchor).
 
-        Scope note: this pins the mid-line case only. A *line-initial* span
-        (a line beginning ```foo```) does open a fence that never closes,
-        swallowing later punts. That is pre-existing, in the fail-open
-        direction, and out of scope here.
+        Scope note: this pins the mid-line case only. A line-initial span of
+        three or more backticks (a line beginning ```foo```) does open a fence
+        that never closes, swallowing later punts. That is pre-existing, in the
+        fail-open direction, and out of scope here. Line-initial spans *shorter*
+        than a fence are pinned by
+        ``test_line_initial_short_code_span_does_not_open_a_fence``.
         """
         mod = import_validator()
         plan = tmp_path / "p.md"
@@ -426,6 +439,29 @@ class TestFenceMarkersFollowCommonMark:
             "# Plan\n\n"
             "## Design\n\n"
             "Call ```foo``` then ```bar```.\n\n"
+            "The retry backoff will be done post-merge.\n\n"
+            "## No-Gos (Out of Scope)\n\n"
+            "Nothing deferred — every relevant item is in scope for this plan.\n"
+        )
+        ok, message = mod.validate(str(plan))
+        assert not ok
+        assert "will be done post-merge" in message
+
+    @pytest.mark.parametrize("ticks", ["`", "``"])
+    def test_line_initial_short_code_span_does_not_open_a_fence(self, tmp_path, ticks):
+        """A fence needs three markers; one or two are an inline code span.
+
+        Pins the ``{3,}`` floor in ``FENCE``. Relaxed to ``{1,}``, a line that
+        merely *begins* with a code span — ```flag` enables it.``, ordinary
+        plan prose — opens a fence that nothing ever closes, exempting every
+        later line to EOF and disarming the validator for the whole document.
+        """
+        mod = import_validator()
+        plan = tmp_path / "p.md"
+        plan.write_text(
+            "# Plan\n\n"
+            "## Design\n\n"
+            f"{ticks}flag{ticks} enables it.\n\n"
             "The retry backoff will be done post-merge.\n\n"
             "## No-Gos (Out of Scope)\n\n"
             "Nothing deferred — every relevant item is in scope for this plan.\n"
@@ -493,6 +529,16 @@ class TestOperatorWillIsActionSenseOnly:
             "The operator will observe a single formatted record.",
             "A human will read the same message in both files.",
             "The operator will no longer see two copies.",
+            # An adverb between "will" and the perception verb must not defeat
+            # the exemption — impact prose is written this way constantly.
+            "The operator will simply see one log line.",
+            "The operator will then see the change.",
+            "An operator will now observe a single record.",
+            "The human will eventually receive the digest.",
+            "The operator will still find both entries.",
+            "A human will already know the outcome.",
+            # "no longer" exempts any following verb, not just perception ones.
+            "The operator will no longer rotate the key.",
         ],
     )
     def test_perception_sense_is_not_a_punt(self, line):
@@ -506,6 +552,13 @@ class TestOperatorWillIsActionSenseOnly:
             "The operator will run the migration by hand.",
             "A human will apply the config change.",
             "The operator will need to click through the vendor UI.",
+            # The adverb slot admits ``\w+ly``, which over-matches verbs ending
+            # in "ly". "apply" must stay a punt: it is not a perception verb,
+            # and neither is the "the" that follows it.
+            "The operator will apply the patch.",
+            "The operator will supply the credentials.",
+            # An adverb in front of a real action is still a punt.
+            "The operator will manually rotate the signing key.",
         ],
     )
     def test_action_sense_is_still_a_punt(self, line):


### PR DESCRIPTION
Closes #2682

Two independent defects, both fixed here.

## 1. Targeting: judge only the file the Write named

The hook read its own tool input and **threw it away**, then resolved a target by scanning `git status --porcelain docs/plans/` for the newest dirty `.md`. Two consequences:

- A lane got gated on a plan it never touched. My Write to `docs/features/scheduled-disk-reclaim.md` was blocked by another workstream's in-progress plan.
- The `git status` ran against whichever checkout the hook process started in, so the collision **crossed worktrees**.

Replaced with `tool_input.file_path`. `find_newest_plan_file` is deleted, and a test asserts it does not come back. When no path is resolvable the validator validates nothing — never "validate whatever looks newest".

**Reproduced before the fix** (a Write to an unrelated file, with a bad plan present in `docs/plans/`):

```
$ echo '{"tool_name":"Write","tool_input":{"file_path":"docs/features/my-own-doc.md"}}' | python validate_no_gos_justification.py
VALIDATION FAILED: Plan 'docs/plans/zzz-other-lane.md' has unjustified deferrals.
exit=2   # the Write targeted docs/features/my-own-doc.md
```

After: exit 0, while a Write to the bad plan itself still exits 2.

## 2. Quoted critique content no longer false-positives

The body scan flagged deferral language a plan *quotes while reviewing it*. Critique-findings tables, verdict logs, and "critic's suggested remedy, kept for the record" blocks all reproduce punt phrasing in order to discuss it — so a plan became **more** likely to fail the more carefully it recorded its own critique. That is structurally incompatible with a plan-critique workflow that logs findings verbatim.

Outside the No-Gos section, table rows and blockquotes are exempt. Fenced code is exempt everywhere. **Inside No-Gos nothing is exempt but code** — that section is where commitments are made, so a punt written as a table row there still fails. No plan in the repo puts No-Gos content in a table, so the exemption is conservative even before that carve-out.

## 3. Pattern: `operator will` is the action sense only

`\boperator will\b` matched "an operator **will see** the log line change" — which is what every plan's impact section is made of. Narrowed with a lookahead over perception verbs. "The operator will rotate the key" is still a punt, and the pre-existing test asserting that still passes.

## 4. An ordering bug the targeting fix exposed

The existence check ran *before* the is-this-a-plan check, so any Write to a non-plan path the hook could not stat exited 2. Plan-path gate now comes first; a hook-derived path that does not resolve passes through, because there is no content to judge and so no finding to make. An explicit CLI argument naming a missing file still errors.

## Demonstrated red, both directions

Before, the committed `docs/plans/watchdog-import-time-log-handler.md` failed on two lines — both the `operator will see` pattern, one of them inside a critique table. After:

| Case | Result |
|---|---|
| Committed watchdog plan (the fixture) | **passes** |
| Descriptive prose + critique table + blockquote | **passes** |
| Unjustified punt in No-Gos prose | still fails |
| Unjustified punt in body prose outside No-Gos | still fails |
| Unjustified punt as a **table row inside No-Gos** | still fails |
| "The operator will rotate the signing key" | still fails |

## Mutation results

14 mutations across every guard — targeting, stdin handling, gate ordering, the table/blockquote exemption, the No-Gos carve-out, code fences, both directions of the `operator will` pattern, the No-Gos span, the justification tag, and the missing-section check. **13 caught.**

The one survivor is an **equivalent mutant** (`tool_input = {}` versus `return None` for non-dict input), confirmed by differential evaluation over seven payload shapes rather than by argument.

Worth noting for the reviewer: the first pass surfaced two malformed mutants of my own — one anchor was ambiguous so its mutation never ran, and one "order reversal" never actually reversed the order. Both were corrected and re-run rather than counted as passes. A third survivor was a real gap and is now covered by a test.

52 tests passed at that commit (the file's original 20 plus 32 new). `ruff check` and `ruff format` clean. `manifest.toml` is unchanged, so no hook re-registration is needed. The file has grown since; the authoritative current count is in section 7.

## 5. Fences close by CommonMark's rule, not a bare toggle

Added after review. The fence tracker flipped a boolean on every line-initial marker, ignoring marker length and type, so an odd number of fence-looking lines desynced it for the rest of the document. The harmful direction is the false positive: a plan documenting markdown with a four-backtick wrapper around a three-backtick block had its code content scanned once the inner marker flipped the toggle, so a punt phrase quoted inside that example **blocked the write** — the same class of harm this PR set out to remove.

A fence now closes only on a marker of the same character at least as long as the one that opened it. A shorter or other-type marker while a fence is open is content. Unterminated fences still exempt to EOF, which is CommonMark's own rule and deliberately unchanged. That sentence understated the cost, though, and section 6 records the part it left out.

Reachability was low and stays low: **the four-backtick shape occurs in zero of the 550 committed plans.** A corpus sweep of `validate()` across all 550, comparing the pre-fence-fix commit against this one, gives 87 failing before and 87 after — zero regressions, zero newly passing. This is a latent edge in gate machinery, closed on purpose rather than left for someone to trip over.

5 tests added, 2 of them red before the change. **57 tests passed** in the file at that commit.

## 6. The fail-open cost, named rather than implied

Added after the second review. Section 5's "unterminated fences still exempt to EOF" understated the trade. The strict CommonMark rule widens the fail-open surface from *unterminated* fences to **any mismatched marker**: a four-backtick block "closed" by a three-backtick marker now exempts everything to EOF, and that reach extends into `## No-Gos`, the one section where the quoted-context exemption deliberately does not apply. So a one-character typo in a fence marker anywhere above No-Gos silently disarms the punt gate for the rest of that document.

The trade is taken knowingly: fail-open can never block a lane, which is the harm this PR exists to remove, and CommonMark correctness is worth more than catching a malformed document. What changed is that the cost is now written down in the code instead of left for the next reader to discover, and pinned by a test that asserts the behavior rather than describing it (`test_mismatched_fence_markers_fail_open_into_no_gos`).

Two smaller items in the same commit. The opener and closer branches became an `elif`, so an opener can never be compared against itself; correctness previously depended on a `continue` that read like a mere short-circuit. And the `>=` in the close comparison gained a test, a three-backtick fence closed by a four-backtick line, so tightening it to `==` now fails exactly that test instead of landing green.

## 7. Adverbs no longer defeat the `operator will` exemption

Added after the third review. The section 3 lookahead sits immediately after `will\s+`, so any intervening adverb defeated it: "the operator will **simply** see one log line", "will **then** see the change", "will **now** observe a single record", "will **eventually** receive the digest" all scored as punts again. That is ordinary impact prose, and it is the exact false-positive class this PR exists to remove, on a hook that gates every agent's plan Write across worktrees.

The adverb slot had to go **inside** the negative lookahead. Placed before it the fix is a no-op: the group is optional, so when the lookahead fails with the adverb consumed, the engine backtracks, matches the group as empty, re-tests the lookahead against the adverb itself, and the pattern matches anyway. I confirmed the naive form leaves all four false positives intact before writing the real one. `no longer` stays a standalone alternative, so "will no longer rotate the key" remains exempt for any following verb rather than only perception ones. `\w+ly` over-matches a few verbs; "apply" and "supply" both stay punts, because what follows them is not a perception verb either, and both are now pinned.

The three mutants that survived the third review's battery are closed:

| Surviving mutant | Now killed by |
|---|---|
| `no_gos_line_span` returning `(start, end)` instead of `(start, end + 1)` | `test_table_row_inside_no_gos_still_fails[False]` — No-Gos last section, no trailing newline |
| `FENCE` relaxed from a three-marker floor to a one-marker floor | `test_line_initial_short_code_span_does_not_open_a_fence`, parametrized over one and two backticks |
| `no_gos_line_span` docstring describing a *body* span it never returned | rewritten to state the real range: heading line through one past the following `## ` heading |

**Verification at head `1425bb778`:** **72 tests pass** in the file, up from 59. Both mutants above were applied, confirmed to fail exactly those tests and nothing else, then reverted and the file checked byte-identical. `ruff check` and `ruff format --check` clean on both changed files. `manifest.toml` untouched, so no hook re-registration.

Corpus sweep over all **550** committed plans, `ea06177e` against this head: **87 failing before, 87 after. Zero regressions, zero newly passing.** Line-level, the old and new patterns disagree on **zero** lines in the entire corpus. The adverb shape appears in no committed plan, which is what survivorship predicts: a plan that tripped this false positive could not be committed in the first place, because the hook blocked the Write. The fix closes a latent false-positive class rather than releasing a real punt.

## Not in this PR — correction

The earlier revision of this section claimed I had no evidence that `validate_documentation_section.py`, `validate_test_impact_section.py`, and `validate_verification_section.py` reproduce the lane collision. **That claim was wrong, and the reviewer falsified it.** They do reproduce it, and I have now reproduced it myself.

My original probe false-cleared on a detail that is easy to miss: `docs/plans/` must be a **tracked** directory. If nothing in it is tracked, `git status --porcelain docs/plans/` collapses the whole directory to the single line `?? docs/plans/`, whose path does not end in `.md`, so `find_newest_plan_file` filters it out and the validator exits 0 looking innocent.

With `docs/plans/` tracked and one untracked bad plan inside it, a Write naming `docs/features/mine.md`:

```
validate_no_gos_justification      exit=0
validate_documentation_section     exit=2   <-- blocks a write it never targeted
validate_test_impact_section       exit=2   <-- blocks a write it never targeted
validate_verification_section      exit=2   <-- blocks a write it never targeted
```

Each of the three names `docs/plans/zzz-other-lane.md`, a file the Write never touched. Re-running the same probe with `docs/plans/` untracked reproduces the original false clear (all three exit 0), which is exactly how I talked myself out of it the first time.

This PR's validator is the only one of the four that now behaves. The scope decision to fix one validator here stands; the evidentiary claim attached to it did not, and this section is the correction. Follow-up: **#2689**, updated to carry the reproducer. It is the urgent part — those three hooks gate every agent's Write while a fan-out is running.

The separate `json.load(sys.stdin)` defect noted there is real too: given an argv path with stdin open, all three block, and all three exit 2 on a non-plan path — the same ordering bug fixed here in section 4.

