### PR TITLE
fix(docs-auditor): word-anchor stale terms and enforce a path-existence invariant

### DIFF
--- a/.claude/skill-context/do-docs.md
+++ b/.claude/skill-context/do-docs.md
@@ -144,12 +144,29 @@ The substrate applies fixes to the working tree, commits them to the **current b
 a new branch), fires the memory-refresh hook after the commit, and files deduped GitHub
 issues for cases needing human judgment (deleted targets, stub docs, orphan plans).
 
-Parse the JSON output:
-- `status: "ok"` — proceed to Step 3 for any remaining manual edits.
+Parse the JSON output. `status` alone does **not** mean the output is correct — check
+`fixes_withheld` too:
+
+- `status: "ok"` and `fixes_withheld == 0` — proceed to Step 3 for any remaining manual edits.
+- `fixes_withheld > 0` (with any `status`) — the existence invariant rejected one or more
+  fixes because they would have introduced a path that does not exist on disk. Before
+  trusting the substrate's self-committed output:
+  1. **Echo every `withheld` entry into your transcript output** — one line per entry giving
+     `doc`, `old`, `new`, and `reason` — so the rejection is visible in the stage record and
+     not buried in a log file.
+  2. Re-check each named `doc` by hand in Step 3. The withheld fix means the doc has a stale
+     reference the substrate declined to guess at; either correct it manually or leave it and
+     say so.
+  3. Only then continue. Do not treat `status: "ok"` as a pass on those docs.
 - `status: "error"` — abort and report; do NOT write the completion stage marker.
 - `status: "disabled"` — auth probe failed; proceed in skill-only mode (no auto-fixes).
 
-Do not re-commit the substrate's changes — it commits them itself.
+Result keys that carry the withheld set: `fixes_withheld` (int) and `withheld`
+(list of `{"doc", "old", "new", "reason"}`, `reason` = `"target-absent"`).
+
+Do not re-commit the substrate's changes — it commits them itself. Withheld fixes were never
+written, so there is nothing of theirs to commit; any correction you make in Step 3 is your
+own commit.
 
 ## Index-table maintenance (Step 3)
 

--- a/docs/features/docs-auditor.md
+++ b/docs/features/docs-auditor.md
@@ -89,8 +89,14 @@ fix for that term.
 #### The existence invariant
 
 Every auto-fix, regardless of detector, is subject to one post-condition before
-anything is written: **the auditor may not introduce a repo-path reference that
-is absent from the working tree.**
+anything is written: **the auditor may not introduce a slash-shaped `.py`/`.md`
+repo-path reference that is absent from the working tree.**
+
+That is the exact shape `_PATH_REF_RE` matches, and it is narrower than "any
+reference to a file". Two forms are deliberately **not** covered: paths with
+other extensions (`.sh`, `.ts`, `.json`), and the dotted module form
+(`bridge.session_log`) — the same class as the #2711 incident. A fix that
+introduces only those forms passes the invariant with `withheld=0`.
 
 `_apply_fixes_to_file` simulates each fix, collects the `dir/file.{py,md}`-shaped
 references the candidate text would newly introduce, and resolves each against

--- a/docs/features/docs-auditor.md
+++ b/docs/features/docs-auditor.md
@@ -145,7 +145,8 @@ reaches the sweeper's stale-close at `STALE_PR_AGE_DAYS` and is closed with
 `--delete-branch`, discarding the fixes that did pass the invariant; the next
 rotation onto that slug re-proposes and re-opens the same PR. This is strictly
 safer than auto-merging suspect output, and the escalation (exempt from
-stale-close, or notify before closing) is an open gap, not a shipped behavior.
+stale-close, or notify before closing) is an open gap tracked by
+[#2729](https://github.com/tomcounsell/ai/issues/2729), not a shipped behavior.
 
 `status` stays `"ok"` — a withheld fix is not an error. That is precisely why a
 caller must branch on `fixes_withheld > 0` rather than treat `"ok"` as "output

--- a/docs/features/docs-auditor.md
+++ b/docs/features/docs-auditor.md
@@ -133,7 +133,19 @@ it opens a PR the branch sweeper can auto-merge — so it threads the withheld s
 into its `findings`, its `summary`, and its Telegram message, and stamps
 `WITHHELD_PR_MARKER` plus the rejection list into the PR body.
 `_pr_is_auto_merge_eligible` refuses any PR carrying that marker, so a run that
-withheld a fix always requires a human merge.
+withheld a fix always requires a human merge. It also passes the count to
+`_write_liveness` as a keyword `fixes_withheld`, emitted into the Redis summary
+only when non-zero. That last surface is the load-bearing one: the reflection
+scheduler consumes only `projects` from a function reflection's return, so
+`findings` and `summary` reach no human, and without the liveness field a
+withheld run would be byte-identical to a clean one in Redis.
+
+Because the marker disqualification is permanent, a withheld PR nobody reviews
+reaches the sweeper's stale-close at `STALE_PR_AGE_DAYS` and is closed with
+`--delete-branch`, discarding the fixes that did pass the invariant; the next
+rotation onto that slug re-proposes and re-opens the same PR. This is strictly
+safer than auto-merging suspect output, and the escalation (exempt from
+stale-close, or notify before closing) is an open gap, not a shipped behavior.
 
 `status` stays `"ok"` — a withheld fix is not an error. That is precisely why a
 caller must branch on `fixes_withheld > 0` rather than treat `"ok"` as "output
@@ -369,7 +381,8 @@ hook, and the `/do-docs` thin-caller contract. `TestIsSecretsPath` and
 `TestVaultSiteDrift` cover the vault↔site/docs drift detector (mixed-case,
 near-miss, symlink-into-secrets, out-of-vault exclusion; compared-count
 correctness; issue-cap enforcement); `TestWriteLivenessVaultParam` covers
-the `_write_liveness` 4-arg/5-arg contract; `TestVaultDeadCodeRemoved`
+the `_write_liveness` 4-arg/5-arg positional contract (`fixes_withheld` is a
+trailing keyword param, so that contract is unchanged); `TestVaultDeadCodeRemoved`
 asserts `DEFAULT_VAULT_WEIGHT`, `vault_weight`, and `_vault_field` are gone.
 
 ```bash

--- a/docs/features/docs-auditor.md
+++ b/docs/features/docs-auditor.md
@@ -54,7 +54,61 @@ writes the SDLC stage marker and updates the plan frontmatter.
 | Renamed markdown links | `[label](old/path.md)` after a rename | `git log --follow --diff-filter=R` |
 | Renamed paths/symbols | `` `old/module.py` `` after a rename | `git log --follow --diff-filter=R` |
 | README broken entries | Index entries pointing at deleted files | filesystem check + rename probe |
-| Stale-term dictionary | `SessionLog`, `RedisJob`, `session_log`, `redis_job` | `STALE_TERMS` dict at module top |
+| Stale-term dictionary | `SessionLog`, `RedisJob`, `session_log`, `redis_job` | `STALE_TERMS` dict at module top, matched on word boundaries |
+
+The dictionary's current entries are model and field renames: `SessionLog` and
+`RedisJob` were renamed to AgentSession; the `session_log` and `redis_job`
+fields were renamed to agent_session. Stating the mapping in that form is also
+what keeps this page immune to its own detector — see the `migration_context`
+escape hatch below.
+
+#### Stale terms are word-anchored
+
+A `STALE_TERMS` key matches a **whole word only**, never a fragment of a longer
+identifier or path segment. `session_log` does not match inside
+`agent/session_logs.py`, and `SessionLog` does not match inside `SessionLogs`.
+
+Detection and application share one matching semantics: `_detect_stale_term_fixes`
+returns compiled `(pattern, replacement)` pairs on a dedicated `regex_fixes`
+channel, applied by `_apply_fixes_to_file` through `pattern.subn()`. The literal
+`fixes` channel used by the three rename detectors is untouched, so the
+`new == ""` line-delete sentinel keeps its exact-line-equality semantics.
+
+The `migration_context` escape hatch is unchanged: a doc that already says
+"renamed to X", "replaced by X", "now X", "formerly Y", or "replaces Y" gets no
+fix for that term.
+
+#### The existence invariant
+
+Every auto-fix, regardless of detector, is subject to one post-condition before
+anything is written: **the auditor may not introduce a repo-path reference that
+is absent from the working tree.**
+
+`_apply_fixes_to_file` simulates each fix, collects the `dir/file.{py,md}`-shaped
+references the candidate text would newly introduce, and resolves each against
+`repo_root`. If any is absent, that fix is rejected.
+
+- **Attributed per fix.** Only the offending fix is dropped; valid sibling fixes
+  in the same file still apply. The file is never abandoned wholesale.
+- **References already present in the document are never re-validated.** The
+  invariant constrains what the auditor *adds*, so it cannot reject a fix over
+  pre-existing prose that names a long-gone module.
+- **Rejections are reported, not silently discarded.** Each one logs a warning
+  naming the offending path and lands in the result contract.
+- **An all-rejected run writes nothing** — no file write, therefore no empty
+  commit.
+
+Rejected fixes surface on the `audit()` result:
+
+| Result key | Type | Meaning |
+|---|---|---|
+| `fixes_withheld` | `int` | count of fixes rejected by the existence invariant |
+| `withheld` | `list[dict]` | one entry per rejection: `{"doc", "old", "new", "reason"}`, `reason` = `"target-absent"` |
+
+`status` stays `"ok"` — a withheld fix is not an error. That is precisely why a
+caller must branch on `fixes_withheld > 0` rather than treat `"ok"` as "output
+is correct"; `.claude/skill-context/do-docs.md` wires that branch for the
+cascade.
 
 ### File-as-issue (judgment required)
 

--- a/docs/features/docs-auditor.md
+++ b/docs/features/docs-auditor.md
@@ -64,9 +64,17 @@ escape hatch below.
 
 #### Stale terms are word-anchored
 
-A `STALE_TERMS` key matches a **whole word only**, never a fragment of a longer
-identifier or path segment. `session_log` does not match inside
-`agent/session_logs.py`, and `SessionLog` does not match inside `SessionLogs`.
+A `STALE_TERMS` key is matched with `\b` anchors, so it never matches inside a
+longer run of word characters: `session_log` does not match inside
+`agent/session_logs.py` or `session_log_writer`, and `SessionLog` does not match
+inside `SessionLogs`.
+
+That is the whole guarantee, and it stops short of "never rewrites a path".
+`/`, `.`, and `-` are all word boundaries, so a key that *equals* an entire path
+segment still matches and is still rewritten — `models/session_log.py` becomes
+`models/agent_session.py`. The existence invariant below is the only thing that
+catches such a rewrite, and only when the rewritten path is absent from the
+working tree; if both paths happen to exist, the rewrite is accepted.
 
 Detection and application share one matching semantics: `_detect_stale_term_fixes`
 returns compiled `(pattern, replacement)` pairs on a dedicated `regex_fixes`
@@ -88,11 +96,20 @@ is absent from the working tree.**
 references the candidate text would newly introduce, and resolves each against
 `repo_root`. If any is absent, that fix is rejected.
 
-- **Attributed per fix.** Only the offending fix is dropped; valid sibling fixes
-  in the same file still apply. The file is never abandoned wholesale.
+- **Attributed per term, not per occurrence.** Only the offending fix is
+  dropped; valid sibling fixes in the same file still apply, and the file is
+  never abandoned wholesale. But a fix is one `(old, new)` pair applied to the
+  whole document — `str.replace` and `pattern.subn()` both rewrite *every*
+  occurrence — so a single path-shaped hit withholds that term's legitimate
+  prose hits in the same file too.
 - **References already present in the document are never re-validated.** The
   invariant constrains what the auditor *adds*, so it cannot reject a fix over
-  pre-existing prose that names a long-gone module.
+  pre-existing prose that names a long-gone module. The residual hole: if a
+  doc already mentions an absent path somewhere, that path is in the original
+  reference set, so a fix that rewrites a *valid* path into that same absent
+  one passes the invariant. No live instance is known; the reachable route to
+  it is the rename-target selection defect tracked as **#2725**, and closing it
+  requires span-level (rather than document-level) attribution.
 - **Rejections are reported, not silently discarded.** Each one logs a warning
   naming the offending path and lands in the result contract.
 - **An all-rejected run writes nothing** — no file write, therefore no empty
@@ -104,6 +121,19 @@ Rejected fixes surface on the `audit()` result:
 |---|---|---|
 | `fixes_withheld` | `int` | count of fixes rejected by the existence invariant |
 | `withheld` | `list[dict]` | one entry per rejection: `{"doc", "old", "new", "reason"}`, `reason` = `"target-absent"` |
+
+`old` is whatever the emitting channel matched on: a literal string for the
+three rename detectors, but the **regex source** for a stale-term rejection
+(`\bsession_log\b`, not `session_log`). A caller that echoes `old` verbatim —
+`.claude/skill-context/do-docs.md` does — will show the pattern, which is the
+accurate thing to show, since that is what was withheld.
+
+The rotation caller (`run_docs_auditor`) is the one path with no human review —
+it opens a PR the branch sweeper can auto-merge — so it threads the withheld set
+into its `findings`, its `summary`, and its Telegram message, and stamps
+`WITHHELD_PR_MARKER` plus the rejection list into the PR body.
+`_pr_is_auto_merge_eligible` refuses any PR carrying that marker, so a run that
+withheld a fix always requires a human merge.
 
 `status` stays `"ok"` — a withheld fix is not an error. That is precisely why a
 caller must branch on `fixes_withheld > 0` rather than treat `"ok"` as "output

--- a/docs/features/durability-model.md
+++ b/docs/features/durability-model.md
@@ -27,9 +27,9 @@ flip ships as its own release.
 ## Job routing (`bridge/job_router.py`)
 
 The **single routing authority** for inbound messages — it replaced the
-expectations-based semantic session router (`bridge/session_router.py`,
-deleted). Session-level routing is now purely mechanical: reply-to resumes a
-session, everything else is a fresh session.
+expectations-based semantic session router, now deleted. Session-level routing
+is now purely mechanical: reply-to resumes a session, everything else is a
+fresh session.
 
 - **Reply-to** routes through the **permanent reply index** —
   `reply:{chat_id}:{message_id}` → `{job_id, room_id}`, a standalone

--- a/docs/features/message-drafter.md
+++ b/docs/features/message-drafter.md
@@ -165,7 +165,7 @@ To prevent infinite steering loops (the agent's self-draft also fails validation
 
 ### `_derive_context_summary(raw_text) -> str | None`
 
-Derives a coarse one-sentence routing hint from the narration-stripped text. This is deliberately simple — first non-blank, non-heading line, capped at 140 characters at a word boundary. No NLP, no LLM. Purpose: give `session_router.py` and other routing readers a coarse topic hint. Not a quality deliverable, not user-facing prose. Returns `None` for empty or whitespace-only input.
+Derives a coarse one-sentence routing hint from the narration-stripped text. This is deliberately simple — first non-blank, non-heading line, capped at 140 characters at a word boundary. No NLP, no LLM. Purpose: give `bridge/job_router.py` — the single routing authority — and other routing readers a coarse topic hint. Not a quality deliverable, not user-facing prose. Returns `None` for empty or whitespace-only input.
 
 ### `_extract_open_questions(text) -> list[str]`
 

--- a/docs/features/nonharness-llm-wrapper.md
+++ b/docs/features/nonharness-llm-wrapper.md
@@ -72,7 +72,7 @@ Every site below moved from a hand-rolled client (or `ollama.chat()`) to `run_ty
 |------|--------------|-----|-----|
 | `agent/intent_classifier.py` | `IntentClassification` | sync `anthropic.Anthropic` (Haiku), hand-rolled text parse | `run_typed`; `parsed.model_dump()` replaces `dataclasses.asdict(parsed)` to keep the function's dict-returning cached contract |
 | `agent/memory_extraction.py` (`_llm_call`) | `ExtractionResult` | `AsyncAnthropic` (Haiku), hand-rolled `json.loads`-shape repair | `run_typed`, shared by four call sites in the module; the merged LLM refusal-detector stays in place |
-| `bridge/session_router.py` | `SessionRouteDecision` | `anthropic_slot()` (Haiku), fence-strip + `json.loads` | `run_typed` |
+| `bridge/job_router.py` | `JobRouteDecision` | the superseded semantic session router's `anthropic_slot()` (Haiku), fence-strip + `json.loads` | `run_typed_local` (granite) |
 | `bridge/routing.py` (`classify_needs_response`) | `NeedsResponseDecision` | `ollama.chat()` + Haiku fallback | `run_typed` |
 | `bridge/routing.py` (`classify_conversation_terminus`) | `TerminusDecision` | `ollama.chat()` + Haiku fallback | `run_typed` |
 | `bridge/routing.py` (`classify_work_request`) | `RoutingDecision` | `ollama.chat()` + Haiku fallback | `run_typed` |

--- a/docs/features/nonharness-llm-wrapper.md
+++ b/docs/features/nonharness-llm-wrapper.md
@@ -72,7 +72,6 @@ Every site below moved from a hand-rolled client (or `ollama.chat()`) to `run_ty
 |------|--------------|-----|-----|
 | `agent/intent_classifier.py` | `IntentClassification` | sync `anthropic.Anthropic` (Haiku), hand-rolled text parse | `run_typed`; `parsed.model_dump()` replaces `dataclasses.asdict(parsed)` to keep the function's dict-returning cached contract |
 | `agent/memory_extraction.py` (`_llm_call`) | `ExtractionResult` | `AsyncAnthropic` (Haiku), hand-rolled `json.loads`-shape repair | `run_typed`, shared by four call sites in the module; the merged LLM refusal-detector stays in place |
-| `bridge/job_router.py` | `JobRouteDecision` | the superseded semantic session router's `anthropic_slot()` (Haiku), fence-strip + `json.loads` | `run_typed_local` (granite) |
 | `bridge/routing.py` (`classify_needs_response`) | `NeedsResponseDecision` | `ollama.chat()` + Haiku fallback | `run_typed` |
 | `bridge/routing.py` (`classify_conversation_terminus`) | `TerminusDecision` | `ollama.chat()` + Haiku fallback | `run_typed` |
 | `bridge/routing.py` (`classify_work_request`) | `RoutingDecision` | `ollama.chat()` + Haiku fallback | `run_typed` |

--- a/docs/features/worker-service.md
+++ b/docs/features/worker-service.md
@@ -186,7 +186,7 @@ The session execution engine (`agent/agent_session_queue.py`) has zero module-le
 | What | Canonical Location | Re-export Location |
 |------|-------------------|-------------------|
 | `REACTION_SUCCESS/COMPLETE/ERROR` | `agent/constants.py` | `bridge/response.py` |
-| `save_session_snapshot()` | `agent/session_logs.py` | (none) |
+| `save_session_snapshot()` | `agent/session_logs.py` | `bridge/session_logs.py` |
 
 All 7 lazy `bridge/` imports inside functions are guarded with `try/except` for graceful degradation when running without Telegram.
 

--- a/docs/features/worker-service.md
+++ b/docs/features/worker-service.md
@@ -186,7 +186,7 @@ The session execution engine (`agent/agent_session_queue.py`) has zero module-le
 | What | Canonical Location | Re-export Location |
 |------|-------------------|-------------------|
 | `REACTION_SUCCESS/COMPLETE/ERROR` | `agent/constants.py` | `bridge/response.py` |
-| `save_session_snapshot()` | `agent/agent_sessions.py` | (none) |
+| `save_session_snapshot()` | `agent/session_logs.py` | (none) |
 
 All 7 lazy `bridge/` imports inside functions are guarded with `try/except` for graceful degradation when running without Telegram.
 

--- a/docs/guides/valor-name-references.md
+++ b/docs/guides/valor-name-references.md
@@ -175,7 +175,7 @@ References in prose, test fixtures, and examples. Low runtime impact — these f
 | `~/Desktop/Valor/projects.json` | Mention triggers (private, iCloud-synced) |
 | `bridge/telegram_bridge.py` | 322: `"valor"` default for `ACTIVE_PROJECTS` |
 | `bridge/session_transcript.py` | 57: `"valor"` in docstring example |
-| `bridge/agent_sessions.py` | 81: `"valor"` in docstring example |
+| `bridge/session_logs.py` | 81: `"valor"` in docstring example |
 | `tools/job_scheduler.py` | 37: `DEFAULT_PROJECT_KEY = "valor"` |
 
 **Total Category C: ~150+ references across ~145 files**

--- a/docs/guides/valor-name-references.md
+++ b/docs/guides/valor-name-references.md
@@ -175,7 +175,7 @@ References in prose, test fixtures, and examples. Low runtime impact — these f
 | `~/Desktop/Valor/projects.json` | Mention triggers (private, iCloud-synced) |
 | `bridge/telegram_bridge.py` | 322: `"valor"` default for `ACTIVE_PROJECTS` |
 | `bridge/session_transcript.py` | 57: `"valor"` in docstring example |
-| `bridge/session_logs.py` | 81: `"valor"` in docstring example |
+| `agent/session_logs.py` | 92: `"valor"` in docstring example |
 | `tools/job_scheduler.py` | 37: `DEFAULT_PROJECT_KEY = "valor"` |
 
 **Total Category C: ~150+ references across ~145 files**

--- a/docs/plans/docs-auditor-rename-guard.md
+++ b/docs/plans/docs-auditor-rename-guard.md
@@ -406,22 +406,22 @@ are needed.
 
 ## Success Criteria
 
-- [ ] `_detect_stale_term_fixes` does not emit a fix for `agent/session_logs.py` or
+- [x] `_detect_stale_term_fixes` does not emit a fix for `agent/session_logs.py` or
       `bridge/session_logs.py` (the #2711 regression, as a hard assertion).
-- [ ] `_apply_fixes_to_file` rejects and reports any fix introducing a path absent from the
+- [x] `_apply_fixes_to_file` rejects and reports any fix introducing a path absent from the
       working tree, while still applying valid sibling fixes in the same file.
-- [ ] `audit()` reports a `fixes_withheld` count and a `withheld` list; an all-rejected run
+- [x] `audit()` reports a `fixes_withheld` count and a `withheld` list; an all-rejected run
       writes nothing and still surfaces the withheld count.
-- [ ] Zero live references to `agent/agent_sessions.py` or `bridge/agent_sessions.py` in
+- [x] Zero live references to `agent/agent_sessions.py` or `bridge/agent_sessions.py` in
       `docs/features/` and `docs/guides/` (the plan doc and `docs/plans/` legitimately name them).
-- [ ] Zero references to `bridge/session_router.py` in `docs/features/`, with `docs/plans/`,
+- [x] Zero references to `bridge/session_router.py` in `docs/features/`, with `docs/plans/`,
       `docs/research/`, and `site/` untouched.
-- [ ] The auditor's own detectors report zero findings over every doc this PR touches (the
+- [x] The auditor's own detectors report zero findings over every doc this PR touches (the
       PR #2528 verification method).
-- [ ] Tests pass (`/do-test`) — `scripts/pytest-clean.sh`, scoped to
+- [x] Tests pass (`/do-test`) — `scripts/pytest-clean.sh`, scoped to
       `tests/unit/test_docs_auditor_substrate.py`.
-- [ ] Documentation updated (`/do-docs`).
-- [ ] Both #2711 and #2713 closed from the PR.
+- [x] Documentation updated (`/do-docs`).
+- [x] Both #2711 and #2713 closed from the PR.
 
 ## Team Orchestration
 

--- a/docs/plans/docs-auditor-rename-guard.md
+++ b/docs/plans/docs-auditor-rename-guard.md
@@ -416,8 +416,10 @@ are needed.
       `docs/features/` and `docs/guides/` (the plan doc and `docs/plans/` legitimately name them).
 - [x] Zero references to `bridge/session_router.py` in `docs/features/`, with `docs/plans/`,
       `docs/research/`, and `site/` untouched.
-- [x] The auditor's own detectors report zero findings over every doc this PR touches (the
-      PR #2528 verification method).
+- [x] The auditor's own detectors report zero findings over every doc this PR touches in
+      `docs/features/` and `docs/guides/` (the plan doc and `docs/plans/` legitimately name
+      the dictionary in prose, same as the criterion above) — the PR #2528 verification
+      method, applied at its own stated width.
 - [x] Tests pass (`/do-test`) — `scripts/pytest-clean.sh`, scoped to
       `tests/unit/test_docs_auditor_substrate.py`.
 - [x] Documentation updated (`/do-docs`).

--- a/docs/plans/docs-auditor-rename-guard.md
+++ b/docs/plans/docs-auditor-rename-guard.md
@@ -296,17 +296,17 @@ result. A rejected fix must never be silently absorbed into `fixes_applied`.
 
 ## Test Impact
 
-- [ ] `tests/unit/test_docs_auditor_substrate.py::TestStaleTermDictionary` — UPDATE: existing
+- [x] `tests/unit/test_docs_auditor_substrate.py::TestStaleTermDictionary` — UPDATE: existing
       cases assert unanchored substring behavior; re-assert against word-anchored semantics.
-- [ ] `tests/unit/test_docs_auditor_substrate.py` — ADD `TestStaleTermWordBoundary`: the
+- [x] `tests/unit/test_docs_auditor_substrate.py` — ADD `TestStaleTermWordBoundary`: the
       `agent/session_logs.py` regression as a hard assertion (currently reproduces in 3 lines,
       untested).
-- [ ] `tests/unit/test_docs_auditor_substrate.py` — ADD `TestExistenceInvariant`: a fix
+- [x] `tests/unit/test_docs_auditor_substrate.py` — ADD `TestExistenceInvariant`: a fix
       introducing an absent path is rejected, reported, and not written; sibling valid fixes in
       the same file still apply.
-- [ ] `tests/unit/test_docs_auditor_substrate.py` — ADD `TestRenamedSymbolFixesDegenerate`: a
+- [x] `tests/unit/test_docs_auditor_substrate.py` — ADD `TestRenamedSymbolFixesDegenerate`: a
       rename hop that loops back to the original path yields no fix; a genuine hop still does.
-- [ ] `tests/unit/test_docs_auditor_substrate.py::TestGitLogFollowCap` — UNCHANGED: tests the
+- [x] `tests/unit/test_docs_auditor_substrate.py::TestGitLogFollowCap` — UNCHANGED: tests the
       query cap only, unaffected.
 
 The three rename detectors had **zero** direct coverage before this work;

--- a/docs/plans/docs-auditor-rename-guard.md
+++ b/docs/plans/docs-auditor-rename-guard.md
@@ -391,19 +391,19 @@ are needed.
 
 ## Documentation
 
-- [ ] Update `docs/features/docs-auditor.md` to document the existence invariant and the
+- [x] Update `docs/features/docs-auditor.md` to document the existence invariant and the
       word-anchored stale-term semantics, including that rejected fixes are reported rather than
       applied.
-- [ ] Correct `docs/features/worker-service.md:189` — `agent/agent_sessions.py` →
+- [x] Correct `docs/features/worker-service.md:189` — `agent/agent_sessions.py` →
       `agent/session_logs.py`.
-- [ ] Correct `docs/guides/valor-name-references.md:178` — `bridge/agent_sessions.py` →
-      `bridge/session_logs.py`.
-- [ ] Repoint the two `bridge/session_router.py` **path** references (#2713):
+- [x] Correct `docs/guides/valor-name-references.md:178` — `bridge/agent_sessions.py` →
+      `agent/session_logs.py`.
+- [x] Repoint the two `bridge/session_router.py` **path** references (#2713):
       `docs/features/nonharness-llm-wrapper.md:75`, `docs/features/durability-model.md:30`.
-- [ ] Rewrite the `bridge/session_router.py` **claim** at `docs/features/message-drafter.md:168` —
+- [x] Rewrite the `bridge/session_router.py` **claim** at `docs/features/message-drafter.md:168` —
       prose about who consumes the routing hint, so it names the successor authority
       (`bridge/job_router.py`), not a substituted filename.
-- [ ] Update `.claude/skill-context/do-docs.md` so the cascade no longer treats `status: "ok"`
+- [x] Update `.claude/skill-context/do-docs.md` so the cascade no longer treats `status: "ok"`
       as "output is correct": it must branch on `fixes_withheld > 0` and re-check before trusting
       the substrate's self-committed output.
 

--- a/docs/plans/docs-auditor-rename-guard.md
+++ b/docs/plans/docs-auditor-rename-guard.md
@@ -304,11 +304,14 @@ result. A rejected fix must never be silently absorbed into `fixes_applied`.
 - [ ] `tests/unit/test_docs_auditor_substrate.py` — ADD `TestExistenceInvariant`: a fix
       introducing an absent path is rejected, reported, and not written; sibling valid fixes in
       the same file still apply.
+- [ ] `tests/unit/test_docs_auditor_substrate.py` — ADD `TestRenamedSymbolFixesDegenerate`: a
+      rename hop that loops back to the original path yields no fix; a genuine hop still does.
 - [ ] `tests/unit/test_docs_auditor_substrate.py::TestGitLogFollowCap` — UNCHANGED: tests the
       query cap only, unaffected.
 
-The three rename detectors have **zero** direct coverage today; the existence-invariant tests
-give them their first behavioral test through the shared apply path.
+The three rename detectors had **zero** direct coverage before this work;
+`_detect_renamed_symbol_fixes` now has direct cases, and the existence-invariant tests exercise
+all three through the shared apply path.
 
 ## Rabbit Holes
 

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -83,7 +83,8 @@ STALE_PR_AGE_DAYS = 14
 # This is a *conditional* instance of the "review requirement" option that #2726
 # defers — it applies only on the withheld path, leaves clean-run commit/staging
 # behavior untouched, and becomes a no-op if #2726 later adopts a wholesale
-# stage-and-report or explicit-path-list policy.
+# stage-and-report or explicit-path-list policy. Recorded on #2726 itself so the
+# owner rules with the shipped partial gate in view, not against a blank slate.
 #
 # NOTE: [cycle-2 nit — marker lives in a mutable PR body with no cross-check, so
 # a human `gh pr edit` that rewrites the body silently re-enables auto-merge]
@@ -1902,7 +1903,7 @@ def _pr_is_auto_merge_eligible(pr_number: int) -> bool:
         # Withheld fixes disqualify: the run that opened this PR proposed at least
         # one rewrite to a nonexistent path, so its surviving output is suspect.
         #
-        # KNOWN ESCALATION GAP (#2728 cycle-2 review, follow-up issue pending):
+        # KNOWN ESCALATION GAP — tracked by #2729:
         # this disqualification is permanent, so a withheld PR nobody reviews
         # falls through to the sweeper's stale-close at STALE_PR_AGE_DAYS —
         # closed with --delete-branch, discarding the fixes that *did* pass the
@@ -1911,7 +1912,8 @@ def _pr_is_auto_merge_eligible(pr_number: int) -> bool:
         # record is a `findings` entry, and the scheduler reads only `projects`
         # from a function reflection. Still strictly safer than auto-merging
         # suspect output. Ownership of the escalation (exempt from stale-close,
-        # or notify before closing) is deliberately out of scope here.
+        # or notify before closing) is deliberately out of scope here and needs
+        # an owner ruling; see #2729.
         if WITHHELD_PR_MARKER in (meta.get("body") or ""):
             logger.info(
                 "docs_auditor: PR #%d not auto-merge eligible — run withheld fixes", pr_number

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -1774,6 +1774,10 @@ def run_docs_auditor() -> dict:
         # count must reach every surface this function produces, not just a log
         # line: findings, summary, Telegram, the PR body (auto-merge gate) and
         # the Redis liveness summary, which is the only durable queryable one.
+        # Telegram has two mutually exclusive senders: step 9 below (files were
+        # touched) and the zero-diff early return (nothing was touched, which is
+        # where an all-withheld run lands — the loudest case, and one step 9 can
+        # never reach). Exactly one of the two fires per run.
         withheld: list[dict] = result.get("withheld", [])
         fixes_withheld: int = result.get("fixes_withheld", 0)
         withheld_note = (
@@ -1784,6 +1788,12 @@ def run_docs_auditor() -> dict:
         if not files_touched or _git_diff_quiet(PROJECT_ROOT):
             _update_rotation_hash(project_key, [str(primary)])
             _write_liveness(slug, "skipped", None, 0, fixes_withheld=fixes_withheld)
+            if fixes_withheld:
+                _send_telegram_notification(
+                    f"docs-auditor pass for {slug}: zero-diff, no PR"
+                    f"\n⚠️ {fixes_withheld} fix(es) withheld — target path absent; "
+                    "nothing was written and no PR was opened to review them"
+                )
             return {
                 "status": "ok",
                 "findings": [f"docs-auditor: zero-diff for {primary}{withheld_note}"],

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -79,6 +79,19 @@ STALE_PR_AGE_DAYS = 14
 # human review — it opens the PR and the branch sweeper can auto-merge it — so
 # `_pr_is_auto_merge_eligible` refuses any PR carrying this marker. A withheld
 # fix means the auditor wanted to write something wrong; that needs a human read.
+#
+# This is a *conditional* instance of the "review requirement" option that #2726
+# defers — it applies only on the withheld path, leaves clean-run commit/staging
+# behavior untouched, and becomes a no-op if #2726 later adopts a wholesale
+# stage-and-report or explicit-path-list policy.
+#
+# NOTE: [cycle-2 nit — marker lives in a mutable PR body with no cross-check, so
+# a human `gh pr edit` that rewrites the body silently re-enables auto-merge]
+# left as-is because the sturdier carrier (a `do-not-auto-merge` label) does not
+# exist in this repo, and creating one plus wiring `gh pr create --label` risks
+# failing PR creation outright on any checkout where the label is missing — a
+# strictly worse failure than the human-only body-rewrite path this guards. No
+# automation in this repo runs `gh pr edit`.
 WITHHELD_PR_MARKER = "<!-- docs-auditor:fixes-withheld -->"
 
 # Redis key namespace for state/locks/liveness.
@@ -484,9 +497,15 @@ def _detect_readme_broken_entries(
 def _detect_stale_term_fixes(content: str) -> list[tuple[re.Pattern[str], str]]:
     """Detect stale terms from STALE_TERMS dict that lack migration context.
 
-    Matching is **word-anchored**: a key matches a whole word only, never a
-    fragment of a longer identifier or path segment. ``session_log`` therefore
-    does not match inside ``agent/session_logs.py`` (#2711).
+    Matching is **word-anchored** with ``\\b``: a key never matches inside a
+    longer run of word characters, so ``session_log`` does not match inside
+    ``agent/session_logs.py`` or ``session_log_writer`` (#2711). That is the
+    whole guarantee — it stops short of "never rewrites a path". ``/``, ``.``
+    and ``-`` are all word boundaries, so a key that *equals* an entire path
+    segment still matches and is still rewritten (``models/session_log.py`` →
+    ``models/agent_session.py``). Only the existence invariant in
+    ``_apply_fixes_to_file`` catches that, and only when the rewritten path is
+    absent from the working tree.
 
     Returns fixes on the regex channel — ``(compiled_pattern, replacement)`` —
     so detection and application share one matching semantics. These are passed
@@ -1430,6 +1449,7 @@ def _write_liveness(
     pr_url: str | None,
     files_touched: int,
     vault_narratives_compared: int | None = None,
+    fixes_withheld: int = 0,
 ) -> None:
     """Persist liveness signals for PM monitoring (Phase 2).
 
@@ -1437,6 +1457,13 @@ def _write_liveness(
     (i.e. only from the rotation call site that actually ran the vault drift
     comparison), so "detector ran, found zero drift" is distinguishable from
     "narrative→page mapping is silently empty/broken".
+
+    ``fixes_withheld`` is emitted only when non-zero, mirroring the same pattern.
+    This is the only durable, queryable surface the rotation produces — the
+    scheduler consumes just ``projects`` from a function reflection's return, so
+    without this a withheld run would be byte-identical to a clean one in Redis.
+    Both extras are keyword params with defaults, so the positional 4-arg/5-arg
+    call contract asserted by ``TestWriteLivenessVaultParam`` is unchanged.
     """
     try:
         r = _get_redis()
@@ -1450,6 +1477,8 @@ def _write_liveness(
         }
         if vault_narratives_compared is not None:
             summary["vault_narratives_compared"] = vault_narratives_compared
+        if fixes_withheld:
+            summary["fixes_withheld"] = fixes_withheld
         r.set(REDIS_LAST_COMPLETED_SUMMARY_KEY, json.dumps(summary))
     except Exception as e:
         logger.warning(f"docs_auditor: liveness write failed: {e}")
@@ -1742,7 +1771,9 @@ def run_docs_auditor() -> dict:
         files_touched: list[str] = result.get("files_touched", [])
         # Existence-invariant rejections. This is the one caller with no human in
         # the loop — it opens a PR the sweeper may auto-merge — so the withheld
-        # count must reach every surface this function produces, not just a log line.
+        # count must reach every surface this function produces, not just a log
+        # line: findings, summary, Telegram, the PR body (auto-merge gate) and
+        # the Redis liveness summary, which is the only durable queryable one.
         withheld: list[dict] = result.get("withheld", [])
         fixes_withheld: int = result.get("fixes_withheld", 0)
         withheld_note = (
@@ -1752,7 +1783,7 @@ def run_docs_auditor() -> dict:
         # 6. Zero-diff gate
         if not files_touched or _git_diff_quiet(PROJECT_ROOT):
             _update_rotation_hash(project_key, [str(primary)])
-            _write_liveness(slug, "skipped", None, 0)
+            _write_liveness(slug, "skipped", None, 0, fixes_withheld=fixes_withheld)
             return {
                 "status": "ok",
                 "findings": [f"docs-auditor: zero-diff for {primary}{withheld_note}"],
@@ -1786,8 +1817,16 @@ def run_docs_auditor() -> dict:
         _update_rotation_hash(project_key, files_touched)
 
         # 11. Liveness signal (threads the vault-drift compared count — the only
-        # call site that ran the vault comparison; the other 4 stay 4-arg).
-        _write_liveness(slug, "ok", pr_url, len(files_touched), vault_narratives_compared)
+        # call site that ran the vault comparison; the other 3 stay 4-arg — plus
+        # the withheld count, so Redis distinguishes a withheld run from a clean one).
+        _write_liveness(
+            slug,
+            "ok",
+            pr_url,
+            len(files_touched),
+            vault_narratives_compared,
+            fixes_withheld=fixes_withheld,
+        )
 
         findings.append(
             f"Touched {len(files_touched)} files; {result.get('fixes_applied', 0)} fixes applied"
@@ -1862,6 +1901,17 @@ def _pr_is_auto_merge_eligible(pr_number: int) -> bool:
 
         # Withheld fixes disqualify: the run that opened this PR proposed at least
         # one rewrite to a nonexistent path, so its surviving output is suspect.
+        #
+        # KNOWN ESCALATION GAP (#2728 cycle-2 review, follow-up issue pending):
+        # this disqualification is permanent, so a withheld PR nobody reviews
+        # falls through to the sweeper's stale-close at STALE_PR_AGE_DAYS —
+        # closed with --delete-branch, discarding the fixes that *did* pass the
+        # invariant, and the next rotation onto the same slug re-proposes,
+        # re-opens and re-closes it forever. Nothing pages a human: the only
+        # record is a `findings` entry, and the scheduler reads only `projects`
+        # from a function reflection. Still strictly safer than auto-merging
+        # suspect output. Ownership of the escalation (exempt from stale-close,
+        # or notify before closing) is deliberately out of scope here.
         if WITHHELD_PR_MARKER in (meta.get("body") or ""):
             logger.info(
                 "docs_auditor: PR #%d not auto-merge eligible — run withheld fixes", pr_number

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -74,6 +74,13 @@ STUB_DOC_LINE_THRESHOLD = 5
 STALE_BRANCH_AGE_DAYS = 7
 STALE_PR_AGE_DAYS = 14
 
+# Marker stamped into a docs-audit PR body when the existence invariant withheld
+# any fix on the run that opened it. The rotation path is the one path with no
+# human review — it opens the PR and the branch sweeper can auto-merge it — so
+# `_pr_is_auto_merge_eligible` refuses any PR carrying this marker. A withheld
+# fix means the auditor wanted to write something wrong; that needs a human read.
+WITHHELD_PR_MARKER = "<!-- docs-auditor:fixes-withheld -->"
+
 # Redis key namespace for state/locks/liveness.
 REDIS_LAST_RUN_HASH = "docs_audit:last_run"
 REDIS_RUNNING_KEY = "docs_audit:running:global"
@@ -1309,12 +1316,18 @@ def _record_daily_pr(repo_root: Path) -> None:
         logger.warning(f"docs_auditor: daily PR cap record failed: {e}")
 
 
-def _push_branch_and_pr(slug: str, repo_root: Path) -> str | None:
+def _push_branch_and_pr(
+    slug: str, repo_root: Path, withheld: list[dict] | None = None
+) -> str | None:
     """Create timestamped branch, push, open PR. Returns PR URL or None on failure.
 
     Always returns the repo to the main branch afterward, even on error.
     Skips PR creation if an open PR for the same slug already exists or if
     the daily cap (1 PR per calendar day) has been reached.
+
+    ``withheld`` is the run's existence-invariant rejections. When non-empty the
+    PR body lists them and carries ``WITHHELD_PR_MARKER``, which disqualifies the
+    PR from the sweeper's auto-merge path.
     """
     ts = datetime.now(UTC).strftime("%Y%m%d-%H%M")
     branch = f"docs-audit/{slug}-{ts}"
@@ -1360,6 +1373,20 @@ def _push_branch_and_pr(slug: str, repo_root: Path) -> str | None:
             cwd=str(repo_root),
             check=True,
         )
+        body = "Automated docs auditor pass."
+        if withheld:
+            rejected = "\n".join(
+                f"- `{w.get('doc')}`: `{w.get('old')}` → `{w.get('new')}` "
+                f"({w.get('reason', 'unknown')})"
+                for w in withheld
+            )
+            body += (
+                f"\n\n{WITHHELD_PR_MARKER}\n"
+                f"⚠️ **{len(withheld)} fix(es) withheld** by the existence invariant — "
+                "the auditor tried to introduce a path that is absent from the working "
+                "tree. Not eligible for auto-merge; review the surviving fixes before "
+                f"merging.\n\n{rejected}"
+            )
         pr_result = subprocess.run(
             [
                 "gh",
@@ -1368,7 +1395,7 @@ def _push_branch_and_pr(slug: str, repo_root: Path) -> str | None:
                 "--title",
                 f"Docs auditor: {slug}",
                 "--body",
-                "Automated docs auditor pass.",
+                body,
             ],
             capture_output=True,
             text=True,
@@ -1713,6 +1740,14 @@ def run_docs_auditor() -> dict:
         )
 
         files_touched: list[str] = result.get("files_touched", [])
+        # Existence-invariant rejections. This is the one caller with no human in
+        # the loop — it opens a PR the sweeper may auto-merge — so the withheld
+        # count must reach every surface this function produces, not just a log line.
+        withheld: list[dict] = result.get("withheld", [])
+        fixes_withheld: int = result.get("fixes_withheld", 0)
+        withheld_note = (
+            f"; {fixes_withheld} fix(es) withheld (target-absent)" if fixes_withheld else ""
+        )
 
         # 6. Zero-diff gate
         if not files_touched or _git_diff_quiet(PROJECT_ROOT):
@@ -1720,13 +1755,13 @@ def run_docs_auditor() -> dict:
             _write_liveness(slug, "skipped", None, 0)
             return {
                 "status": "ok",
-                "findings": [f"docs-auditor: zero-diff for {primary}"],
-                "summary": f"docs-auditor: zero-diff ({slug})",
+                "findings": [f"docs-auditor: zero-diff for {primary}{withheld_note}"],
+                "summary": f"docs-auditor: zero-diff ({slug}){withheld_note}",
             }
 
         # 7. Memory refresh hook (fire-and-forget) — fired after commit
         # 8. Push branch + PR
-        pr_url = _push_branch_and_pr(slug, PROJECT_ROOT)
+        pr_url = _push_branch_and_pr(slug, PROJECT_ROOT, withheld=withheld)
 
         try:
             refresh_docs_in_memory(files_touched)
@@ -1737,6 +1772,12 @@ def run_docs_auditor() -> dict:
         msg = (
             f"docs-auditor pass for {slug}: "
             f"{len(files_touched)} files, {result.get('fixes_applied', 0)} fixes"
+            + (
+                f"\n⚠️ {fixes_withheld} fix(es) withheld — target path absent; "
+                "PR is not auto-merge eligible"
+                if fixes_withheld
+                else ""
+            )
             + (f"\nPR: {pr_url}" if pr_url else "")
         )
         _send_telegram_notification(msg)
@@ -1751,6 +1792,14 @@ def run_docs_auditor() -> dict:
         findings.append(
             f"Touched {len(files_touched)} files; {result.get('fixes_applied', 0)} fixes applied"
         )
+        if fixes_withheld:
+            findings.append(
+                f"{fixes_withheld} fix(es) withheld by the existence invariant "
+                "(target-absent); PR is not auto-merge eligible"
+            )
+            findings.extend(
+                f"withheld: {w.get('doc')} {w.get('old')!r} -> {w.get('new')!r}" for w in withheld
+            )
         if pr_url:
             findings.append(f"PR: {pr_url}")
 
@@ -1759,7 +1808,8 @@ def run_docs_auditor() -> dict:
             "findings": findings,
             "summary": (
                 f"docs-auditor: {len(files_touched)} files touched, "
-                f"{result.get('fixes_applied', 0)} fixes, PR={pr_url or 'none'}"
+                f"{result.get('fixes_applied', 0)} fixes{withheld_note}, "
+                f"PR={pr_url or 'none'}"
             ),
         }
 
@@ -1789,6 +1839,7 @@ def _pr_is_auto_merge_eligible(pr_number: int) -> bool:
     - ≤ 50 net lines changed (additions + deletions)
     - No reviews, review requests, or comments
     - PR is between 1 and 7 days old (not brand-new, not stale)
+    - The opening run withheld no fixes (no ``WITHHELD_PR_MARKER`` in the body)
     """
     try:
         meta_res = subprocess.run(
@@ -1798,7 +1849,7 @@ def _pr_is_auto_merge_eligible(pr_number: int) -> bool:
                 "view",
                 str(pr_number),
                 "--json",
-                "files,reviews,reviewRequests,comments,createdAt,additions,deletions",
+                "files,reviews,reviewRequests,comments,createdAt,additions,deletions,body",
             ],
             capture_output=True,
             text=True,
@@ -1808,6 +1859,14 @@ def _pr_is_auto_merge_eligible(pr_number: int) -> bool:
         if meta_res.returncode != 0:
             return False
         meta = json.loads(meta_res.stdout or "{}")
+
+        # Withheld fixes disqualify: the run that opened this PR proposed at least
+        # one rewrite to a nonexistent path, so its surviving output is suspect.
+        if WITHHELD_PR_MARKER in (meta.get("body") or ""):
+            logger.info(
+                "docs_auditor: PR #%d not auto-merge eligible — run withheld fixes", pr_number
+            )
+            return False
 
         # No reviewer activity
         if meta.get("reviews") or meta.get("reviewRequests") or meta.get("comments"):

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -1774,10 +1774,12 @@ def run_docs_auditor() -> dict:
         # count must reach every surface this function produces, not just a log
         # line: findings, summary, Telegram, the PR body (auto-merge gate) and
         # the Redis liveness summary, which is the only durable queryable one.
-        # Telegram has two mutually exclusive senders: step 9 below (files were
-        # touched) and the zero-diff early return (nothing was touched, which is
-        # where an all-withheld run lands — the loudest case, and one step 9 can
-        # never reach). Exactly one of the two fires per run.
+        # Telegram has two mutually exclusive senders, and a run can also reach
+        # neither. Three cases: files were touched — step 9 sends the pass
+        # summary; nothing was touched but fixes were withheld — the zero-diff
+        # early return sends the withheld alert, the loudest case and one step 9
+        # can never reach; nothing was touched and nothing was withheld — a clean
+        # zero-diff run, which stays silent.
         withheld: list[dict] = result.get("withheld", [])
         fixes_withheld: int = result.get("fixes_withheld", 0)
         withheld_note = (

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -95,15 +95,25 @@ def _ok_result(
     fixes_applied: int = 0,
     issues_filed: int = 0,
     pr_url: str | None = None,
+    fixes_withheld: int = 0,
+    withheld: list[dict] | None = None,
     extras: dict | None = None,
 ) -> dict:
-    """Build the standard substrate return value."""
+    """Build the standard substrate return value.
+
+    ``fixes_withheld`` / ``withheld`` carry fixes the existence invariant rejected.
+    ``status`` stays ``"ok"`` for a withheld fix — it is not an error — which is
+    exactly why callers must branch on ``fixes_withheld > 0`` rather than trust
+    ``status`` alone.
+    """
     res: dict = {
         "status": status,
         "files_touched": files_touched or [],
         "fixes_applied": fixes_applied,
         "issues_filed": issues_filed,
         "pr_url": pr_url,
+        "fixes_withheld": fixes_withheld,
+        "withheld": withheld or [],
     }
     if extras:
         res.update(extras)
@@ -464,11 +474,22 @@ def _detect_readme_broken_entries(
     return fixes
 
 
-def _detect_stale_term_fixes(content: str) -> list[tuple[str, str]]:
-    """Detect stale terms from STALE_TERMS dict that lack migration context."""
-    fixes: list[tuple[str, str]] = []
+def _detect_stale_term_fixes(content: str) -> list[tuple[re.Pattern[str], str]]:
+    """Detect stale terms from STALE_TERMS dict that lack migration context.
+
+    Matching is **word-anchored**: a key matches a whole word only, never a
+    fragment of a longer identifier or path segment. ``session_log`` therefore
+    does not match inside ``agent/session_logs.py`` (#2711).
+
+    Returns fixes on the regex channel — ``(compiled_pattern, replacement)`` —
+    so detection and application share one matching semantics. These are passed
+    to ``_apply_fixes_to_file`` as ``regex_fixes``, never mixed into the literal
+    ``fixes`` list (which carries the ``new == ""`` line-delete sentinel).
+    """
+    fixes: list[tuple[re.Pattern[str], str]] = []
     for old_term, new_term in STALE_TERMS.items():
-        if old_term not in content:
+        pattern = re.compile(rf"\b{re.escape(old_term)}\b")
+        if not pattern.search(content):
             continue
         migration_context = (
             f"renamed to {new_term}" in content
@@ -479,23 +500,72 @@ def _detect_stale_term_fixes(content: str) -> list[tuple[str, str]]:
             or f"replaces {old_term}" in content
         )
         if not migration_context:
-            fixes.append((old_term, new_term))
+            fixes.append((pattern, new_term))
     return fixes
 
 
-def _apply_fixes_to_file(path: Path, repo_root: Path, fixes: list[tuple[str, str]]) -> int:
-    """Apply (old, new) text replacements to a file. Returns count of fixes applied."""
+# Path-shaped reference: ``dir/file.py`` or ``dir/file.md``, one or more segments.
+_PATH_REF_RE = re.compile(r"(?:[\w.-]+/)+[\w.-]+\.(?:py|md)")
+
+
+def _absent_new_path_refs(original_refs: set[str], candidate: str, repo_root: Path) -> list[str]:
+    """Path refs a candidate rewrite would newly introduce that are absent from disk.
+
+    References already present in the original document are never re-validated —
+    the invariant constrains only what the auditor *adds*.
+    """
+    return sorted(
+        ref
+        for ref in set(_PATH_REF_RE.findall(candidate)) - original_refs
+        if not (repo_root / ref).exists()
+    )
+
+
+def _apply_fixes_to_file(
+    path: Path,
+    repo_root: Path,
+    fixes: list[tuple[str, str]],
+    regex_fixes: list[tuple[re.Pattern[str], str]] | None = None,
+) -> tuple[int, list[dict]]:
+    """Apply text replacements to a file, subject to the existence invariant.
+
+    ``fixes`` are literal ``(old, new)`` pairs; ``new == ""`` deletes the whole
+    line that exactly equals ``old``. ``regex_fixes`` are ``(pattern, replacement)``
+    pairs applied via ``pattern.subn()`` in their own loop.
+
+    **Existence invariant:** a fix may not introduce a ``dir/file.{py,md}``-shaped
+    reference that does not exist under ``repo_root``. Violating fixes are rejected
+    individually — valid sibling fixes in the same file still apply — logged at
+    warning level, and returned for the caller to surface.
+
+    Returns ``(applied_count, withheld)`` where ``withheld`` is a list of
+    ``{"doc", "old", "new", "reason"}`` dicts.
+    """
+    regex_fixes = regex_fixes or []
     full = repo_root / path
-    if not full.exists() or not fixes:
-        return 0
+    if not full.exists() or (not fixes and not regex_fixes):
+        return 0, []
     try:
         text = full.read_text(encoding="utf-8", errors="replace")
     except Exception as e:
         logger.warning(f"docs_auditor: cannot read {path}: {e}")
-        return 0
+        return 0, []
 
+    original_refs = set(_PATH_REF_RE.findall(text))
     new_text = text
     applied = 0
+    withheld: list[dict] = []
+
+    def _reject(old: str, new: str, absent: list[str]) -> None:
+        logger.warning(
+            "docs_auditor: withheld fix in %s (%r -> %r) — introduces absent path(s): %s",
+            path,
+            old,
+            new,
+            ", ".join(absent),
+        )
+        withheld.append({"doc": str(path), "old": old, "new": new, "reason": "target-absent"})
+
     for old, new in fixes:
         if not old:
             continue
@@ -505,23 +575,41 @@ def _apply_fixes_to_file(path: Path, repo_root: Path, fixes: list[tuple[str, str
             # inside an unrelated line.
             lines = new_text.splitlines(keepends=True)
             kept = [ln for ln in lines if ln.rstrip("\n\r") != old.rstrip("\n\r")]
-            removed = len(lines) - len(kept)
-            if removed > 0:
-                new_text = "".join(kept)
-                applied += removed
+            count = len(lines) - len(kept)
+            if count == 0:
+                continue
+            candidate = "".join(kept)
         else:
-            if old in new_text:
-                count = new_text.count(old)
-                new_text = new_text.replace(old, new)
-                applied += count
+            if old not in new_text:
+                continue
+            count = new_text.count(old)
+            candidate = new_text.replace(old, new)
+
+        absent = _absent_new_path_refs(original_refs, candidate, repo_root)
+        if absent:
+            _reject(old, new, absent)
+            continue
+        new_text = candidate
+        applied += count
+
+    for pattern, new in regex_fixes:
+        candidate, count = pattern.subn(new, new_text)
+        if count == 0:
+            continue
+        absent = _absent_new_path_refs(original_refs, candidate, repo_root)
+        if absent:
+            _reject(pattern.pattern, new, absent)
+            continue
+        new_text = candidate
+        applied += count
 
     if new_text != text:
         try:
             full.write_text(new_text, encoding="utf-8")
         except Exception as e:
             logger.warning(f"docs_auditor: cannot write {path}: {e}")
-            return 0
-    return applied
+            return 0, withheld
+    return applied, withheld
 
 
 # ---------------------------------------------------------------------------
@@ -985,6 +1073,7 @@ def audit(
     total_fixes = 0
     issues_filed = 0
     issue_findings: list[dict] = []
+    withheld: list[dict] = []
 
     for path in files:
         full = root / path
@@ -1002,7 +1091,9 @@ def audit(
         else:
             fixes.extend(_detect_renamed_link_fixes(path, content, root))
             fixes.extend(_detect_renamed_symbol_fixes(content, root))
-        fixes.extend(_detect_stale_term_fixes(content))
+        # Anchored stale terms travel on their own homogeneous channel — a
+        # compiled pattern must never land in the literal `fixes` list.
+        regex_fixes = _detect_stale_term_fixes(content)
 
         # Apply-mode writes are markdown-only (#2058). The detectors above are
         # markdown-regex based (bare-term renames, backtick link/symbol fixes),
@@ -1010,8 +1101,9 @@ def audit(
         # site/*.html doc page — must never be auto-rewritten inside tags,
         # attributes, or inline <script>. Reporting still runs; only the
         # write-back is guarded.
-        if fixes and apply_mode == "apply" and str(path).endswith(".md"):
-            applied = _apply_fixes_to_file(path, root, fixes)
+        if (fixes or regex_fixes) and apply_mode == "apply" and str(path).endswith(".md"):
+            applied, rejected = _apply_fixes_to_file(path, root, fixes, regex_fixes=regex_fixes)
+            withheld.extend(rejected)
             if applied > 0:
                 total_fixes += applied
                 touched.append(str(path))
@@ -1066,6 +1158,8 @@ def audit(
         files_touched=touched,
         fixes_applied=total_fixes,
         issues_filed=issues_filed,
+        fixes_withheld=len(withheld),
+        withheld=withheld,
     )
 
 

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -86,13 +86,12 @@ STALE_PR_AGE_DAYS = 14
 # stage-and-report or explicit-path-list policy. Recorded on #2726 itself so the
 # owner rules with the shipped partial gate in view, not against a blank slate.
 #
-# NOTE: [cycle-2 nit — marker lives in a mutable PR body with no cross-check, so
-# a human `gh pr edit` that rewrites the body silently re-enables auto-merge]
-# left as-is because the sturdier carrier (a `do-not-auto-merge` label) does not
-# exist in this repo, and creating one plus wiring `gh pr create --label` risks
-# failing PR creation outright on any checkout where the label is missing — a
-# strictly worse failure than the human-only body-rewrite path this guards. No
-# automation in this repo runs `gh pr edit`.
+# NOTE: The marker lives in the PR body with no cross-check, so a human
+# `gh pr edit` that rewrites the body re-enables auto-merge. A
+# `do-not-auto-merge` label would be sturdier, but the label does not exist in
+# this repo and `gh pr create --label` fails outright when it is missing — a
+# worse failure than the human-only path this guards. No automation here runs
+# `gh pr edit`.
 WITHHELD_PR_MARKER = "<!-- docs-auditor:fixes-withheld -->"
 
 # Redis key namespace for state/locks/liveness.
@@ -457,7 +456,7 @@ def _detect_renamed_symbol_fixes(content: str, repo_root: Path) -> list[tuple[st
         if (repo_root / path).exists():
             continue
         renames = _git_log_follow_renames(path, repo_root)
-        if renames:
+        if renames and renames[0][1] != path:
             fixes.append((path, renames[0][1]))
     return fixes
 

--- a/tests/unit/test_docs_auditor_substrate.py
+++ b/tests/unit/test_docs_auditor_substrate.py
@@ -1344,6 +1344,32 @@ class TestWriteLivenessVaultParam:
         summary = self._summary(fake_redis)
         assert summary["vault_narratives_compared"] == 0
 
+    def test_withheld_count_absent_when_zero(self, fake_redis, patch_redis):
+        # A clean run must not carry the key at all — same shape as before.
+        docs_auditor._write_liveness("slug", "ok", None, 3)
+        assert "fixes_withheld" not in self._summary(fake_redis)
+
+    def test_withheld_count_emitted_when_nonzero(self, fake_redis, patch_redis):
+        # Redis is the only durable, queryable surface; a withheld run must not
+        # be byte-identical to a clean one there.
+        docs_auditor._write_liveness("slug", "ok", None, 3, fixes_withheld=2)
+        assert self._summary(fake_redis)["fixes_withheld"] == 2
+
+    def test_withheld_is_keyword_only_and_preserves_positional_contract(self):
+        import inspect
+
+        params = list(inspect.signature(docs_auditor._write_liveness).parameters)
+        # fixes_withheld must come last so existing 4-arg and 5-arg positional
+        # call sites keep their meaning.
+        assert params[-1] == "fixes_withheld"
+        assert params[:5] == [
+            "slug",
+            "status",
+            "pr_url",
+            "files_touched",
+            "vault_narratives_compared",
+        ]
+
 
 class TestVaultDeadCodeRemoved:
     def test_default_vault_weight_gone(self):

--- a/tests/unit/test_docs_auditor_substrate.py
+++ b/tests/unit/test_docs_auditor_substrate.py
@@ -922,6 +922,61 @@ class TestWithheldBlocksAutoMerge:
         assert push.call_args.kwargs["withheld"] == audit_result["withheld"]
         assert "withheld" in notify.call_args.args[0]
 
+    def test_all_withheld_zero_diff_run_still_notifies(self, repo, auth_ok, patch_redis):
+        """Every fix rejected => no files touched => the step-9 notify is unreachable.
+
+        That is the loudest case (the auditor tried to invent paths), so the
+        zero-diff early return must send its own Telegram alert.
+        """
+        primary = repo / "docs" / "features" / "foo.md"
+        primary.write_text("# Foo\n" + "Padding line.\n" * 6)
+        audit_result = docs_auditor._ok_result(
+            "ok",
+            files_touched=[],
+            fixes_applied=0,
+            fixes_withheld=2,
+            withheld=[
+                {"doc": "docs/features/foo.md", "old": "a/b.py", "new": "a/c.py", "reason": "x"},
+                {"doc": "docs/features/foo.md", "old": "a/d.py", "new": "a/e.py", "reason": "x"},
+            ],
+        )
+        with (
+            patch("reflections.docs_auditor.PROJECT_ROOT", repo),
+            patch("reflections.docs_auditor._git_dirty", return_value=False),
+            patch("reflections.docs_auditor._run_vault_drift_detection", return_value=0),
+            patch("reflections.docs_auditor.audit", return_value=audit_result),
+            patch("reflections.docs_auditor._send_telegram_notification") as notify,
+            patch("reflections.docs_auditor._update_rotation_hash"),
+            patch("reflections.docs_auditor._write_liveness") as liveness,
+        ):
+            result = docs_auditor.run_docs_auditor()
+
+        assert result["status"] == "ok"
+        assert "zero-diff" in result["summary"]
+        assert notify.call_count == 1
+        msg = notify.call_args.args[0]
+        assert "2 fix(es) withheld" in msg
+        assert "docs_features_foo_md" in msg  # the rotation slug
+        assert liveness.call_args.kwargs["fixes_withheld"] == 2
+
+    def test_clean_zero_diff_run_does_not_notify(self, repo, auth_ok, patch_redis):
+        """No withholding => a zero-diff pass stays silent, as before."""
+        primary = repo / "docs" / "features" / "foo.md"
+        primary.write_text("# Foo\n" + "Padding line.\n" * 6)
+        audit_result = docs_auditor._ok_result("ok", files_touched=[], fixes_applied=0)
+        with (
+            patch("reflections.docs_auditor.PROJECT_ROOT", repo),
+            patch("reflections.docs_auditor._git_dirty", return_value=False),
+            patch("reflections.docs_auditor._run_vault_drift_detection", return_value=0),
+            patch("reflections.docs_auditor.audit", return_value=audit_result),
+            patch("reflections.docs_auditor._send_telegram_notification") as notify,
+            patch("reflections.docs_auditor._update_rotation_hash"),
+            patch("reflections.docs_auditor._write_liveness"),
+        ):
+            docs_auditor.run_docs_auditor()
+
+        assert notify.call_count == 0
+
 
 # ---------------------------------------------------------------------------
 # TestDirtyTreeGuard

--- a/tests/unit/test_docs_auditor_substrate.py
+++ b/tests/unit/test_docs_auditor_substrate.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import re
 import subprocess
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -757,6 +758,135 @@ class TestExistenceInvariant:
         assert result["files_touched"] == []
         commit.assert_not_called()
         assert "agent/ghost.py" not in p.read_text()
+
+
+# ---------------------------------------------------------------------------
+# TestLineDeleteSentinel — `new == ""` deletes only exact-matching lines
+# ---------------------------------------------------------------------------
+
+
+class TestLineDeleteSentinel:
+    """The `new == ""` sentinel used by `_detect_readme_broken_entries`.
+
+    Its semantics are exact line equality, never substring: a line that merely
+    *contains* `old` must survive. This is asserted here because the invariant
+    work restructured the branch's count bookkeeping.
+    """
+
+    @pytest.fixture()
+    def doc(self, repo):
+        p = repo / "docs" / "features" / "del.md"
+        p.write_text("- [Gone](gone.md)\nkeep me\n")
+        return Path("docs/features/del.md")
+
+    def test_exact_line_is_deleted(self, repo, doc):
+        applied, withheld = docs_auditor._apply_fixes_to_file(
+            doc, repo, [("- [Gone](gone.md)", "")]
+        )
+        assert (applied, withheld) == (1, [])
+        assert (repo / doc).read_text() == "keep me\n"
+
+    def test_line_merely_containing_old_survives(self, repo, doc):
+        (repo / doc).write_text("prefix - [Gone](gone.md) suffix\nkeep me\n")
+        applied, withheld = docs_auditor._apply_fixes_to_file(
+            doc, repo, [("- [Gone](gone.md)", "")]
+        )
+        assert (applied, withheld) == (0, [])
+        assert (repo / doc).read_text() == "prefix - [Gone](gone.md) suffix\nkeep me\n"
+
+
+# ---------------------------------------------------------------------------
+# TestWithheldBlocksAutoMerge — the rotation path's only review gate
+# ---------------------------------------------------------------------------
+
+
+class TestWithheldBlocksAutoMerge:
+    """A run that withheld a fix must not produce an auto-mergeable PR."""
+
+    @staticmethod
+    def _meta(body: str) -> dict:
+        return {
+            "files": [{"path": "docs/features/foo.md"}],
+            "reviews": [],
+            "reviewRequests": [],
+            "comments": [],
+            "additions": 1,
+            "deletions": 1,
+            "createdAt": (datetime.now(UTC) - timedelta(days=3)).isoformat().replace("+00:00", "Z"),
+            "body": body,
+        }
+
+    def _eligible(self, body: str) -> bool:
+        with patch("reflections.docs_auditor.subprocess.run") as run:
+            run.return_value = MagicMock(returncode=0, stdout=json.dumps(self._meta(body)))
+            return docs_auditor._pr_is_auto_merge_eligible(123)
+
+    def test_clean_pr_is_eligible(self):
+        assert self._eligible("Automated docs auditor pass.") is True
+
+    def test_withheld_marker_disqualifies(self):
+        body = f"Automated docs auditor pass.\n\n{docs_auditor.WITHHELD_PR_MARKER}\n1 withheld"
+        assert self._eligible(body) is False
+
+    def test_pr_body_carries_marker_when_fixes_withheld(self, repo):
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, *a, **kw):
+            calls.append(cmd)
+            return MagicMock(returncode=0, stdout="https://github.com/o/r/pull/1", stderr="")
+
+        withheld = [
+            {
+                "doc": "docs/features/x.md",
+                "old": "a/b.py",
+                "new": "a/c.py",
+                "reason": "target-absent",
+            }
+        ]
+        with (
+            patch("reflections.docs_auditor.subprocess.run", side_effect=fake_run),
+            patch("reflections.docs_auditor._daily_pr_cap_reached", return_value=False),
+            patch("reflections.docs_auditor._has_open_pr_for_slug", return_value=False),
+            patch("reflections.docs_auditor._record_daily_pr"),
+        ):
+            docs_auditor._push_branch_and_pr("slug", repo, withheld=withheld)
+
+        create = next(c for c in calls if c[:3] == ["gh", "pr", "create"])
+        body = create[create.index("--body") + 1]
+        assert docs_auditor.WITHHELD_PR_MARKER in body
+        assert "a/c.py" in body
+
+    def test_rotation_result_surfaces_withheld_count(self, repo, auth_ok, patch_redis):
+        primary = repo / "docs" / "features" / "foo.md"
+        primary.write_text("# Foo\n" + "Padding line.\n" * 6)
+        audit_result = docs_auditor._ok_result(
+            "ok",
+            files_touched=["docs/features/foo.md"],
+            fixes_applied=1,
+            fixes_withheld=2,
+            withheld=[
+                {"doc": "docs/features/foo.md", "old": "a/b.py", "new": "a/c.py", "reason": "x"},
+                {"doc": "docs/features/foo.md", "old": "a/d.py", "new": "a/e.py", "reason": "x"},
+            ],
+        )
+        with (
+            patch("reflections.docs_auditor.PROJECT_ROOT", repo),
+            patch("reflections.docs_auditor._git_dirty", return_value=False),
+            patch("reflections.docs_auditor._git_diff_quiet", return_value=False),
+            patch("reflections.docs_auditor._run_vault_drift_detection", return_value=0),
+            patch("reflections.docs_auditor.audit", return_value=audit_result),
+            patch("reflections.docs_auditor._push_branch_and_pr", return_value=None) as push,
+            patch("reflections.docs_auditor._send_telegram_notification") as notify,
+            patch("reflections.docs_auditor._update_rotation_hash"),
+            patch("reflections.docs_auditor._write_liveness"),
+        ):
+            result = docs_auditor.run_docs_auditor()
+
+        assert result["status"] == "ok"
+        assert any("2 fix(es) withheld" in f for f in result["findings"])
+        assert "withheld" in result["summary"]
+        assert push.call_args.kwargs["withheld"] == audit_result["withheld"]
+        assert "withheld" in notify.call_args.args[0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_docs_auditor_substrate.py
+++ b/tests/unit/test_docs_auditor_substrate.py
@@ -355,6 +355,40 @@ class TestGitLogFollowCap:
 
 
 # ---------------------------------------------------------------------------
+# TestRenamedSymbolFixesDegenerate — old==new rename hops must not fix
+# ---------------------------------------------------------------------------
+
+
+class TestRenamedSymbolFixesDegenerate:
+    """A rename history that loops back to the original path is a no-op.
+
+    `_apply_fixes_to_file` would otherwise treat a same-text replacement as a
+    real, successful fix and inflate `fixes_applied` on a run that changed
+    nothing.
+    """
+
+    def test_newest_rename_hop_equal_to_original_path_yields_no_fix(self, repo: Path):
+        content = "See `tests/unit/test_summarizer.py` for details.\n"
+        with patch.object(
+            docs_auditor,
+            "_git_log_follow_renames",
+            return_value=[("deadbeef", "tests/unit/test_summarizer.py")],
+        ):
+            fixes = docs_auditor._detect_renamed_symbol_fixes(content, repo)
+        assert fixes == []
+
+    def test_genuine_rename_hop_still_yields_a_fix(self, repo: Path):
+        content = "See `agent/old_name.py` for details.\n"
+        with patch.object(
+            docs_auditor,
+            "_git_log_follow_renames",
+            return_value=[("deadbeef", "agent/new_name.py")],
+        ):
+            fixes = docs_auditor._detect_renamed_symbol_fixes(content, repo)
+        assert fixes == [("agent/old_name.py", "agent/new_name.py")]
+
+
+# ---------------------------------------------------------------------------
 # TestDoDocsContract — pr-changed-files mode contract for /do-docs
 # ---------------------------------------------------------------------------
 
@@ -1355,7 +1389,7 @@ class TestWriteLivenessVaultParam:
         docs_auditor._write_liveness("slug", "ok", None, 3, fixes_withheld=2)
         assert self._summary(fake_redis)["fixes_withheld"] == 2
 
-    def test_withheld_is_keyword_only_and_preserves_positional_contract(self):
+    def test_withheld_is_trailing_and_preserves_positional_contract(self):
         import inspect
 
         params = list(inspect.signature(docs_auditor._write_liveness).parameters)

--- a/tests/unit/test_docs_auditor_substrate.py
+++ b/tests/unit/test_docs_auditor_substrate.py
@@ -9,6 +9,7 @@ contract (pr-changed-files mode).
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -551,6 +552,13 @@ class TestRotationKeyExplosion:
 # ---------------------------------------------------------------------------
 
 
+def _stale_pairs(content: str) -> list[tuple[str, str]]:
+    """Flatten the regex fix channel to (pattern_source, replacement) pairs."""
+    return [
+        (pattern.pattern, new) for pattern, new in docs_auditor._detect_stale_term_fixes(content)
+    ]
+
+
 class TestStaleTermDictionary:
     def test_stale_term_dict_seeded(self):
         assert "SessionLog" in docs_auditor.STALE_TERMS
@@ -561,12 +569,194 @@ class TestStaleTermDictionary:
         content = "The SessionLog has been renamed to AgentSession."
         fixes = docs_auditor._detect_stale_term_fixes(content)
         # Migration context recognized -> no fix queued
-        assert ("SessionLog", "AgentSession") not in fixes
+        assert fixes == []
 
     def test_no_migration_context_queues_fix(self):
         content = "The SessionLog has methods to track session state."
-        fixes = docs_auditor._detect_stale_term_fixes(content)
-        assert ("SessionLog", "AgentSession") in fixes
+        assert (r"\bSessionLog\b", "AgentSession") in _stale_pairs(content)
+
+    def test_fixes_travel_on_the_regex_channel(self):
+        fixes = docs_auditor._detect_stale_term_fixes("The SessionLog tracks state.")
+        assert fixes
+        for pattern, new in fixes:
+            assert isinstance(pattern, re.Pattern)
+            assert isinstance(new, str)
+
+    def test_absent_key_emits_no_fix(self):
+        assert docs_auditor._detect_stale_term_fixes("Nothing stale here at all.") == []
+
+
+# ---------------------------------------------------------------------------
+# TestStaleTermWordBoundary — the #2711 regression
+# ---------------------------------------------------------------------------
+
+
+class TestStaleTermWordBoundary:
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "| `save_session_snapshot()` | `agent/session_logs.py` | (none) |",
+            "See `bridge/session_logs.py` for the re-export shim.",
+            "The SessionLogs collection is plural.",
+            "A `_RedisJob` wrapper carries the payload.",
+        ],
+    )
+    def test_compound_identifiers_are_not_rewritten(self, content):
+        """`session_log` must not match inside `session_logs` (issue #2711)."""
+        assert docs_auditor._detect_stale_term_fixes(content) == []
+
+    def test_standalone_term_still_matches(self):
+        assert _stale_pairs("The session_log field is written on exit.") == [
+            (r"\bsession_log\b", "agent_session")
+        ]
+
+    def test_apply_leaves_session_logs_path_untouched(self, repo):
+        doc = repo / "docs" / "features" / "snap.md"
+        original = "Snapshots live in `agent/session_logs.py`.\n"
+        doc.write_text(original)
+        (repo / "agent").mkdir()
+        (repo / "agent" / "session_logs.py").write_text("")
+
+        regex_fixes = docs_auditor._detect_stale_term_fixes(original)
+        applied, withheld = docs_auditor._apply_fixes_to_file(
+            Path("docs/features/snap.md"), repo, [], regex_fixes=regex_fixes
+        )
+        assert applied == 0
+        assert withheld == []
+        assert doc.read_text() == original
+
+
+# ---------------------------------------------------------------------------
+# TestExistenceInvariant — no fix may introduce an absent repo path
+# ---------------------------------------------------------------------------
+
+
+class TestExistenceInvariant:
+    @pytest.fixture()
+    def doc(self, repo):
+        p = repo / "docs" / "features" / "inv.md"
+        p.write_text("See `agent/real.py` and `agent/other.py`.\n")
+        (repo / "agent").mkdir()
+        (repo / "agent" / "real.py").write_text("")
+        (repo / "agent" / "other.py").write_text("")
+        return Path("docs/features/inv.md")
+
+    def test_fix_introducing_absent_path_is_rejected_and_reported(self, repo, doc):
+        applied, withheld = docs_auditor._apply_fixes_to_file(
+            doc, repo, [("agent/real.py", "agent/ghost.py")]
+        )
+        assert applied == 0
+        assert len(withheld) == 1
+        assert withheld[0] == {
+            "doc": str(doc),
+            "old": "agent/real.py",
+            "new": "agent/ghost.py",
+            "reason": "target-absent",
+        }
+        assert "agent/ghost.py" not in (repo / doc).read_text()
+
+    def test_rejection_is_logged_with_offending_path(self, repo, doc, caplog):
+        with caplog.at_level("WARNING", logger="reflections.docs_auditor"):
+            docs_auditor._apply_fixes_to_file(doc, repo, [("agent/real.py", "agent/ghost.py")])
+        assert any("agent/ghost.py" in r.getMessage() for r in caplog.records)
+
+    def test_sibling_valid_fix_still_applies(self, repo, doc):
+        (repo / "agent" / "renamed.py").write_text("")
+        applied, withheld = docs_auditor._apply_fixes_to_file(
+            doc,
+            repo,
+            [("agent/real.py", "agent/ghost.py"), ("agent/other.py", "agent/renamed.py")],
+        )
+        assert applied == 1
+        assert len(withheld) == 1
+        text = (repo / doc).read_text()
+        assert "agent/renamed.py" in text
+        assert "agent/real.py" in text
+        assert "agent/ghost.py" not in text
+
+    def test_all_fixes_rejected_writes_nothing(self, repo, doc):
+        original = (repo / doc).read_text()
+        mtime = (repo / doc).stat().st_mtime_ns
+        applied, withheld = docs_auditor._apply_fixes_to_file(
+            doc,
+            repo,
+            [("agent/real.py", "agent/ghost.py"), ("agent/other.py", "agent/phantom.py")],
+        )
+        assert applied == 0
+        assert len(withheld) == 2
+        assert (repo / doc).read_text() == original
+        assert (repo / doc).stat().st_mtime_ns == mtime
+
+    def test_preexisting_absent_path_is_never_revalidated(self, repo):
+        p = repo / "docs" / "features" / "pre.md"
+        p.write_text("Legacy `agent/vanished.py` and `agent/real.py`.\n")
+        (repo / "agent").mkdir()
+        (repo / "agent" / "real.py").write_text("")
+        (repo / "agent" / "kept.py").write_text("")
+        applied, withheld = docs_auditor._apply_fixes_to_file(
+            Path("docs/features/pre.md"), repo, [("agent/real.py", "agent/kept.py")]
+        )
+        assert applied == 1
+        assert withheld == []
+        assert "agent/vanished.py" in p.read_text()
+
+    def test_regex_channel_is_also_guarded(self, repo, doc):
+        applied, withheld = docs_auditor._apply_fixes_to_file(
+            doc, repo, [], regex_fixes=[(re.compile(r"\breal\b"), "ghost")]
+        )
+        assert applied == 0
+        assert len(withheld) == 1
+        assert withheld[0]["reason"] == "target-absent"
+
+    @pytest.mark.parametrize("body", ["", "   \n\t\n"])
+    def test_empty_or_whitespace_doc_with_no_fixes_writes_nothing(self, repo, body):
+        p = repo / "docs" / "features" / "empty.md"
+        p.write_text(body)
+        applied, withheld = docs_auditor._apply_fixes_to_file(
+            Path("docs/features/empty.md"), repo, []
+        )
+        assert (applied, withheld) == (0, [])
+        assert p.read_text() == body
+
+    def test_ok_result_carries_withheld_keys(self):
+        res = docs_auditor._ok_result("ok")
+        assert res["fixes_withheld"] == 0
+        assert res["withheld"] == []
+
+    def test_audit_surfaces_withheld_without_writing(self, repo, auth_ok, patch_redis):
+        p = repo / "docs" / "features" / "aud.md"
+        p.write_text("Reference `agent/real.py` here.\n")
+        (repo / "agent").mkdir()
+        (repo / "agent" / "real.py").write_text("")
+
+        with (
+            patch.object(
+                docs_auditor,
+                "_detect_renamed_symbol_fixes",
+                return_value=[("agent/real.py", "agent/ghost.py")],
+            ),
+            patch.object(docs_auditor, "_detect_renamed_link_fixes", return_value=[]),
+            patch.object(
+                docs_auditor,
+                "_resolve_pr_changed_files",
+                return_value=[Path("docs/features/aud.md")],
+            ),
+            patch.object(docs_auditor, "_commit_current_branch") as commit,
+        ):
+            result = docs_auditor.audit(
+                primary_path=None,
+                scope_mode="pr-changed-files",
+                apply_mode="apply",
+                project_key="test",
+                repo_root=repo,
+            )
+
+        assert result["status"] == "ok"
+        assert result["fixes_withheld"] == 1
+        assert result["withheld"][0]["new"] == "agent/ghost.py"
+        assert result["files_touched"] == []
+        commit.assert_not_called()
+        assert "agent/ghost.py" not in p.read_text()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The docs auditor's auto-fixer invented references to a module that has never existed and self-committed them (`d7bf3ad99`). Root cause: `STALE_TERMS` contains `"session_log": "agent_session"`, detection is a bare `in` substring test, and application is an unanchored global `str.replace` — so `session_log` matched inside `session_logs` and rewrote `agent/session_logs.py` into `agent/agent_sessions.py`.

This fixes the generator and sweeps the damage.

## Changes

**1. Word-anchored stale terms** (`_detect_stale_term_fixes`) — `STALE_TERMS` keys now match on word boundaries, so no key can fire inside a longer identifier or path segment. Detection and application share one matching semantics.

Anchored replacements travel on a **separate homogeneous channel**: `_apply_fixes_to_file(path, repo_root, fixes, regex_fixes=None)` where `regex_fixes: list[tuple[re.Pattern[str], str]]` is applied in its own `pattern.subn()` loop. The existing `fixes: list[tuple[str, str]]` parameter keeps its type and its `new == ""` line-delete sentinel semantics **unchanged**, so the three rename detectors and the line-delete path are untouched.

**2. The existence invariant** (`_apply_fixes_to_file`) — a fix-class-agnostic post-condition on every write: the auditor may not introduce a `dir/file.{py,md}`-shaped reference that is absent under `repo_root`. Rejection is attributed **per fix**, so valid sibling fixes in the same file still apply, and references already present in the document are never re-validated. Rejections are logged at warning level naming the offending path.

This also independently covers three latent defects #2711 did not name: `renames[0][1]` on a rename-then-delete chain, `_detect_renamed_link_fixes` emitting a repo-root-relative replacement for a doc-relative link, and any future `STALE_TERMS` value forming a plausible-but-absent path.

**3. Withheld fixes are a first-class part of the result contract** — `_ok_result` gains `fixes_withheld` (int) and `withheld` (list of `{"doc","old","new","reason"}`). `status` stays `"ok"` (a withheld fix is not an error), which is exactly why the count must be separately checkable. `.claude/skill-context/do-docs.md` now branches **behaviorally** on `fixes_withheld > 0` rather than treating `status: "ok"` as "output verified".

**4. Damage swept** (grep-based, not from an enumerated list):
- `agent/agent_sessions.py` / `bridge/agent_sessions.py` → `agent/session_logs.py` / `bridge/session_logs.py` in `docs/features/worker-service.md` and `docs/guides/valor-name-references.md` (#2711 residue live on `main` from earlier cascades).
- Retired `bridge/session_router.py` references in `docs/features/` repointed to `bridge/job_router.py` (#2713). `docs/features/message-drafter.md` is a prose **claim** about who consumes the routing hint, so the sentence was rewritten to name the successor authority rather than mechanically substituting a filename — the failure mode PR #2528 hit on 4 of its 22 findings.
- `docs/plans/`, `docs/plans/completed/`, `docs/research/` deliberately untouched: they are the historical records that specify the deletion. `site/` untouched — `site/assets/graph.js` is a generated code-graph artifact; tracked as #2727.

**5. Degenerate rename hop guarded** (`_detect_renamed_symbol_fixes:459`) — `if renames:` becomes `if renames and renames[0][1] != path:`. A rename history whose newest hop loops back to the original path is not a rename, but the detector still emitted an `old == new` replacement that changed no bytes while incrementing `fixes_applied`. This is the identity case only; newest-hop chain selection is unchanged and stays deferred to #2725.

**6. Cycle-4 review debt closed** (commit `0b724229f`) — three tech-debt items from the two-judge consensus review, all of which were documentation or alerting accuracy rather than behavior the plan specified:

- **A fabricated table row deleted** (`docs/features/nonharness-llm-wrapper.md`). The `bridge/job_router.py` row in *Migrated Call Sites* claimed the site moved off "the superseded semantic session router's `anthropic_slot()`". That migration never happened: `git log --follow -- bridge/job_router.py` returns exactly one commit (the module was born in durability M3 `f08ab6d3d` already calling `run_typed_local`) and `git log -S"anthropic_slot" -- bridge/job_router.py` is empty. The row also contradicted its own section's framing sentence ("moved ... to `run_typed`" — the row said `run_typed_local`) and duplicated accurate coverage already in the `run_typed_local` section. This is the same mechanical-substitution failure mode this PR avoided for `message-drafter.md`; the row is deleted rather than repointed.
- **All-withheld runs now alert** (`reflections/docs_auditor.py`). The loudest case was the quietest: when *every* proposed fix is rejected by the existence invariant, `files_touched` is empty, so the zero-diff gate returned before the step-9 Telegram notification ever ran. The comment above `withheld` claimed the count reaches Telegram; for that case it did not. The zero-diff early return now sends its own alert when `fixes_withheld > 0`, and the comment now enumerates the **three cases** rather than making a blanket claim: files touched → step 9 sends the pass summary; nothing touched but fixes withheld → the early return sends the withheld alert; nothing touched and nothing withheld → a clean zero-diff run, which stays silent (asserted by `test_clean_zero_diff_run_does_not_notify`). Placing the send inside the early-return branch — rather than unconditionally before the gate — is what keeps it at exactly one Telegram message per run.
- **The existence-invariant sentence no longer overclaims** (`docs/features/docs-auditor.md`). The bolded invariant promised no absent "repo-path reference"; `_PATH_REF_RE` only matches slash-shaped `.py`/`.md`. The sentence is now qualified to that shape and explicitly names the two uncovered forms — other extensions (`.sh`, `.ts`, `.json`) and the **dotted module form** (`bridge.session_log`), which is the same class as the #2711 incident and therefore worth stating plainly. Both pass with `withheld=0`. The regex is deliberately **not** widened: that is a behavior change outside this PR's scope.

Plan hygiene from the same review: the six completed `## Documentation` checkboxes are ticked, and the plan's line naming `bridge/session_logs.py` as a correction target is corrected to `agent/session_logs.py` (see *Named deviation*).

### Named deviation

`docs/features/durability-model.md:30` was slated for a repoint to `bridge/job_router.py`, but the sentence's subject already *is* `job_router` ("it replaced the expectations-based semantic session router (`bridge/session_router.py`, deleted)"). Substituting would have produced "job_router replaced job_router, deleted". The dead parenthetical was dropped instead.

The plan's `## Documentation` section named `bridge/session_logs.py` as the correction target for `docs/guides/valor-name-references.md:178`; the implementation used `agent/session_logs.py:92`. The **implementation is correct** (the `bridge` shim has zero occurrences of the term), so the plan line was corrected to match reality rather than the code changed to match the plan.

### Risk 1 evidence — matches lost to anchoring

Unanchored vs `\b`-anchored grep of all four `STALE_TERMS` keys over every `.md` under `docs/`:

| Key | Lines lost | What was lost |
|---|---|---|
| `session_log` | 68 | All `session_logs` (`agent/session_logs.py`, `bridge/session_logs.py`, `bridge.session_logs`, `~/.claude/session_logs/`) — i.e. exactly the #2711 corruption |
| `SessionLog` | 1 | `SessionLogs` (plural) in the plan's own prose |
| `RedisJob` | 1 | `_RedisJob`, a real Python class name in `docs/plans/completed/` |
| `redis_job` | 0 | none |

**Zero legitimate stale-term renames were lost.** Every dropped match was a compound identifier the dictionary should never have rewritten.

## Testing

- [x] `POPOTO_TEST_DB=13 scripts/pytest-clean.sh tests/unit/test_docs_auditor_substrate.py -q` — **112 passed** (110 before the cycle-4 patch, +2 new)
- [x] `TestStaleTermWordBoundary` — the `agent/session_logs.py` / `bridge/session_logs.py` regressions as hard assertions
- [x] `TestExistenceInvariant` — rejection, reporting, sibling-fix survival, all-rejected writing nothing and creating no commit, and pre-existing absent paths never re-validated
- [x] `TestStaleTermDictionary` re-asserted against word-anchored semantics
- [x] `TestRenamedSymbolFixesDegenerate` — a hop looping back to the original path yields no fix; a genuine hop still does
- [x] `test_all_withheld_zero_diff_run_still_notifies` — an all-withheld, zero-diff run sends exactly one Telegram alert naming the withheld count and the rotation slug, and still writes liveness with `fixes_withheld=2`. **Mutation-checked**: reverting the guard to `if False:` fails this test and only this test (`assert 0 == 1`), so it is load-bearing rather than green-by-accident.
- [x] `test_clean_zero_diff_run_does_not_notify` — the paired negative case: a zero-diff run with `fixes_withheld=0` stays silent, guarding against the naive "notify unconditionally before the gate" fix that would double-alert the normal path.
- [x] Lint/format checks passing
- [x] All 10 `## Verification` rows pass, both anti-criteria clean (`site/` untouched, no rename-chain rewrite in the diff)
- [x] PR #2528 verification method, applied at its own stated width: the auditor's own detectors report zero findings over every doc this PR touches in `docs/features/` and `docs/guides/` (the plan doc and `docs/plans/` legitimately name the dictionary in prose)

The three rename detectors had **zero** direct coverage before this work; `_detect_renamed_symbol_fixes` now has direct cases, and the existence-invariant tests exercise all three through the shared apply path.

Also fixed opportunistically: `docs/features/docs-auditor.md` on `main` triggered all four stale-term detectors on itself (it documents the dictionary keys in prose), so a cascade auditing that page would corrupt its own documentation. The mappings are now stated in `migration_context` form, making the page self-immune.

## Documentation

- [x] `docs/features/docs-auditor.md` — the existence invariant and word-anchored semantics
- [x] `.claude/skill-context/do-docs.md` — behavioral `fixes_withheld > 0` branch

## Deferred (filed, not in this PR)

- **#2725** — rename-target selection. The **degenerate identity case** (`renames[0][1] == path`) is fixed here, in `_detect_renamed_symbol_fixes` only. Still deferred: newest-hop selection (`renames[0][1]` takes the newest rename *commit* rather than the final hop, in all three detectors) and `_detect_renamed_link_fixes` resolving a doc-relative link against the repo root. The invariant added here demotes both remaining defects from "writes a wrong reference" to "declines to write".
- **#2726** — the auditor is its own committer. The structural reason a generator bug reaches `main`, but the fix is a decision about the `/do-docs` contract, not a bug with one correct answer.
- **#2727** — `site/` stale references (generated artifact).
- **#2744** — the `migration_context` escape hatch tests **bare substrings** while the corpus writes the terms **backticked**, so the hatch never fires on the dominant form. Three live docs (`docs/features/popoto-redis-expansion.md`, `docs/guides/agent-session-migration-audit.md`, `docs/guides/summarizer-output-audit.md`) are still rewritten into false statements with `withheld=0`, hence auto-merge eligible. **Pre-existing** — a control run against `main`'s detector produces an identical fix set — and a distinct defect class from this PR's subject: the existence invariant constrains *invented paths*, whereas this is *prose falsity between two names that both exist*, which the invariant cannot catch by design. This PR hand-fixed one instance of the class (`docs/features/docs-auditor.md` self-immunity, above) without fixing the generator; the issue records that explicitly.
- **#2729** — withheld PRs are auto-merge-ineligible forever, so the sweeper stale-closes them at day 14 with no escalation.
- **#2739** (defect 4) — the daily-cap and open-PR guards in `_push_branch_and_pr` (`reflections/docs_auditor.py:1355-1362`) return **after** `audit(apply_mode="apply")` has already written to the working tree and **before** `git checkout -b`, leaving the shared checkout dirty while the run reports success — which then trips the auditor's own dirty-tree guard, self-muting every subsequent rotation. **Pre-existing** (both guards predate this PR) and out of scope here: the fix is a write-ordering change in the commit path, not a detector guard. Scoped for the follow-on lane on #2739, the consolidated tracking issue for this bug class.

## Definition of Done
- [x] Built: Code implemented and working
- [x] Tested: All tests passing
- [x] Documented: Docs created/updated
- [x] Quality: Lint and format checks pass

Closes #2711
Closes #2713




