### PR TITLE
Fix importtime false-positive on redis-flush-guard .pth shim lookalikes

### DIFF
--- a/tests/unit/test_post_tool_use_fast_path.py
+++ b/tests/unit/test_post_tool_use_fast_path.py
@@ -19,6 +19,37 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 HOOK = REPO_ROOT / ".claude" / "hooks" / "post_tool_use.py"
 
+_HEAVY_MODULES = ("popoto", "redis", "config.settings", "models.memory", "models.agent_session")
+
+_GUARD_SHIM_DUMP = """\
+import time: self [us] | cumulative | imported package
+import time:       120 |        120 |   site
+import time:        45 |         45 |     tools.redis_flush_guard
+import time:        30 |         30 |     _redis_flush_guard_boot
+import time: cached    | cached     | _redis_flush_guard_boot
+import time: truncated output
+import time:  120 |  120
+"""
+
+_REAL_HEAVY_DUMP = """\
+import time: self [us] | cumulative | imported package
+import time:       310 |        310 |   redis
+import time:       220 |        530 |     popoto.models
+import time:       140 |        140 |   config.settings
+"""
+
+
+def _heavy_import_offenders(stderr: str, heavy: tuple[str, ...] = _HEAVY_MODULES) -> list[str]:
+    """Return which ``heavy`` module names are genuinely present in a
+    ``-X importtime`` stderr dump.
+
+    Placeholder body (Task 1 / red-first): the ORIGINAL substring scan,
+    verbatim. It is deliberately kept naive here so the crafted fixtures can
+    demonstrate the false positive before the identity-matching parser
+    replaces this body in Task 2.
+    """
+    return [m for m in heavy if m in stderr]
+
 
 def _sidecar(session_id: str) -> Path:
     return REPO_ROOT / "data" / "sessions" / session_id / "memory_buffer.json"
@@ -74,9 +105,26 @@ def test_counter_only_call_does_not_import_popoto(clean_session):
         capture_output=True,
     )
     assert proc.returncode == 0, proc.stderr
-    heavy = ("popoto", "redis", "config.settings", "models.memory", "models.agent_session")
-    offenders = [m for m in heavy if m in proc.stderr]
+    offenders = _heavy_import_offenders(proc.stderr)
     assert not offenders, f"counter-only path imported heavy modules: {offenders}"
+
+
+def test_heavy_detection_ignores_lookalike_module_names():
+    """``tools.redis_flush_guard`` / ``_redis_flush_guard_boot`` must NOT be
+    mistaken for the ``redis`` package: they merely contain "redis" as a
+    substring. Also covers Risk 2's malformed-row and empty-input guards."""
+    assert _heavy_import_offenders(_GUARD_SHIM_DUMP) == []
+    assert _heavy_import_offenders("") == []
+
+
+def test_heavy_detection_still_catches_real_imports():
+    """A genuine top-level ``redis``, a ``popoto.models`` descendant, and an
+    exact ``config.settings`` must still be flagged (over-loosening guard)."""
+    assert set(_heavy_import_offenders(_REAL_HEAVY_DUMP)) == {
+        "redis",
+        "popoto",
+        "config.settings",
+    }
 
 
 def test_counter_only_call_bumps_sidecar_counter(clean_session):

--- a/tests/unit/test_post_tool_use_fast_path.py
+++ b/tests/unit/test_post_tool_use_fast_path.py
@@ -39,16 +39,50 @@ import time:       140 |        140 |   config.settings
 """
 
 
+def _importtime_module_names(stderr: str) -> list[str]:
+    """Parse module names out of a ``-X importtime`` stderr dump.
+
+    Row contract (stable since Python 3.7, verified on CPython 3.14.5):
+    each import row is ``import time: {self_us} | {cumulative_us} |
+    {indent}{module_name}``, preceded by a header row whose final column is
+    the literal ``imported package`` (the only column with an interior
+    space, which is what lets us skip the header generically). ``-X
+    importtime=2`` additionally emits ``import time: cached | cached |
+    {name}`` rows sharing the same three-column shape. Dotted submodule
+    names appear in full (e.g. ``json.scanner``), not as bare leaves.
+    Malformed rows (fewer than 3 pipe-delimited fields — CPython documents
+    that importtime output "may be broken in multi-threaded applications")
+    are skipped rather than treated as fatal.
+    """
+    names = []
+    for line in stderr.splitlines():
+        if not line.startswith("import time:"):
+            continue
+        parts = line.split("|")
+        if len(parts) < 3:
+            continue
+        name = parts[-1].strip().lstrip("│├└─ \t")
+        if not name or " " in name:
+            continue
+        names.append(name)
+    return names
+
+
 def _heavy_import_offenders(stderr: str, heavy: tuple[str, ...] = _HEAVY_MODULES) -> list[str]:
     """Return which ``heavy`` module names are genuinely present in a
     ``-X importtime`` stderr dump.
 
-    Placeholder body (Task 1 / red-first): the ORIGINAL substring scan,
-    verbatim. It is deliberately kept naive here so the crafted fixtures can
-    demonstrate the false positive before the identity-matching parser
-    replaces this body in Task 2.
+    Matches on module *identity* (exact name or dotted descendant) rather
+    than substring containment. Substring matching produced a false
+    positive for #2692: ``tools.redis_flush_guard`` and
+    ``_redis_flush_guard_boot`` merely contain "redis" as a substring — they
+    are not the ``redis`` package and not descendants of it — so a plain
+    ``"redis" in stderr`` check blamed the hook for an import it never
+    performed.
     """
-    return [m for m in heavy if m in stderr]
+    names = _importtime_module_names(stderr)
+    offenders = {h for h in heavy for n in names if n == h or n.startswith(h + ".")}
+    return sorted(offenders)
 
 
 def _sidecar(session_id: str) -> Path:


### PR DESCRIPTION
## Summary

`test_counter_only_call_does_not_import_popoto` scanned the whole `-X importtime` stderr dump for heavy-module names as plain **substrings**. `tools.redis_flush_guard` / `_redis_flush_guard_boot` merely contain `"redis"` as a substring — they are not the `redis` package — so once the redis-flush-guard `.pth` shim is installed, the test fails a hook that imported nothing heavy at all.

This PR replaces the substring scan with module-**identity** matching: parse `-X importtime`'s three-column row format into a list of module names, then flag a heavy module only on exact match or dotted-descendant prefix.

Closes #2692

## Red-first paper trail

Task 1 landed the crafted-fixture tests against the **unchanged, verbatim old substring logic** first, to make the false positive observable and reproducible from the repo alone (the real venv no longer has the `.pth` shim installed, so the bug can't be reproduced from environment state):

```
tests/unit/test_post_tool_use_fast_path.py:116: in test_heavy_detection_ignores_lookalike_module_names
    assert _heavy_import_offenders(_GUARD_SHIM_DUMP) == []
E   AssertionError: assert ['redis'] == []
E
E     Left contains one more item: 'redis'
FAILED tests/unit/test_post_tool_use_fast_path.py::test_heavy_detection_ignores_lookalike_module_names
1 failed, 5 passed
```

Task 2 then replaced the body with `_importtime_module_names()` + identity matching in `_heavy_import_offenders()`. `./scripts/pytest-clean.sh tests/unit/test_post_tool_use_fast_path.py -q` now reports **6 passed**.

## Changes

- `tests/unit/test_post_tool_use_fast_path.py` — the only file touched:
  - `_HEAVY_MODULES` lifted to module scope (single shared definition)
  - `_importtime_module_names(stderr)` — parses the documented three-column importtime row format
  - `_heavy_import_offenders(stderr, heavy=_HEAVY_MODULES)` — identity match (`n == h or n.startswith(h + ".")`) instead of substring
  - `test_heavy_detection_ignores_lookalike_module_names` — the red-first case, also exercises Risk 2's malformed-row guard (`truncated output`, a 2-field row) and the empty-input case
  - `test_heavy_detection_still_catches_real_imports` — the over-loosening guard: a genuine top-level `redis`, a `popoto.models` descendant, and an exact `config.settings` are still caught
  - `test_counter_only_call_does_not_import_popoto` now routes through `_heavy_import_offenders(proc.stderr)`

No production code touched. `.claude/hooks/post_tool_use.py` is unmodified.

## Test plan

- [x] `./scripts/pytest-clean.sh tests/unit/test_post_tool_use_fast_path.py -q` — 6 passed
- [x] `python -m ruff check tests/unit/test_post_tool_use_fast_path.py` — clean
- [x] `python -m ruff format --check tests/unit/test_post_tool_use_fast_path.py` — clean
- [x] `git diff --name-only main...HEAD` — exactly one file
- [x] Broader unit-test spot check (`test_post_tool_use_fast_path.py`, `test_reflection_scheduler.py`, `test_session_modal_liveness_render.py`, `test_update_hardlinks.py`) — only the four known pre-existing `main` baseline failures remain, no new failures introduced
- [x] All 13 non-lint Verification-table rows independently re-derived and confirmed true (two rows misreport in the automated `verification_parser`/`validate_build.py` harnesses due to pre-existing table-escaping and `match count == N` idiom-support gaps in those tools, not defects in this change — manually confirmed with `grep -c "^def test_" ...` → 6 and `grep -cE 'startswith\(h \+ "\."\)|startswith\(heavy \+ "\."\)' ...` → 1)