### PR TITLE
fix(docs-auditor): migration-context hatch and bare-path existence invariant

### DIFF
--- a/docs/features/docs-auditor.md
+++ b/docs/features/docs-auditor.md
@@ -83,10 +83,12 @@ Gates 1 to 3 govern stale-term rewrites. Gate 4 governs every auto-fix from
 every detector.
 
 Over the three docs the auditor previously corrupted, false rewrites went from
-**18 occurrences to zero**. Across all of `docs/**/*.md` outside `docs/plans/`,
-surviving stale-term proposals are zero; the four docs that still contain a
-`STALE_TERMS` key are all genuine migration or audit prose where any rewrite
-would produce a false sentence. The detector is quiet, not dead: a synthetic
+**18 occurrences to 1**. Across all of `docs/**/*.md` outside `docs/plans/`,
+exactly one stale-term proposal survives — the accepted quoted-transcript
+residual at `docs/guides/summarizer-output-audit.md:68`, which the plan predicted
+and accepted; the four docs that still contain a `STALE_TERMS` key are all
+genuine migration or audit prose where any rewrite would produce a false
+sentence. The detector is quiet, not dead: a synthetic
 sentence carrying a stale term and no migration context still queues a fix, and
 a test pins that.
 

--- a/docs/features/docs-auditor.md
+++ b/docs/features/docs-auditor.md
@@ -59,8 +59,36 @@ writes the SDLC stage marker and updates the plan frontmatter.
 The dictionary's current entries are model and field renames: `SessionLog` and
 `RedisJob` were renamed to AgentSession; the `session_log` and `redis_job`
 fields were renamed to agent_session. Stating the mapping in that form is also
-what keeps this page immune to its own detector — see the `migration_context`
-escape hatch below.
+what keeps this page immune to its own detector — see the migration-context
+hatch (gate 1) below.
+
+### Four gates guard every rewrite
+
+The auditor is an unreviewed autonomous committer: the rotation caller opens a
+PR the branch sweeper can auto-merge with nobody in between. That makes its two
+failure modes asymmetric. A stale term that survives is a cosmetic miss. A
+sentence the auditor falsifies is a corruption a human later trusts. Every gate
+below therefore errs toward **not** rewriting.
+
+Four fail-closed gates sit between a proposed rewrite and the disk, in order:
+
+| # | Gate | Where it runs |
+|---|------|---------------|
+| 1 | Migration-context hatch | `_detect_stale_term_fixes` (detection) |
+| 2 | Fence / heading / deletion-prose suppression | `_apply_fixes_to_file` (apply) |
+| 3 | Path-token suppression | `_apply_fixes_to_file` (apply) |
+| 4 | Existence invariant | `_apply_fixes_to_file` (apply) |
+
+Gates 1 to 3 govern stale-term rewrites. Gate 4 governs every auto-fix from
+every detector.
+
+Over the three docs the auditor previously corrupted, false rewrites went from
+**18 occurrences to zero**. Across all of `docs/**/*.md` outside `docs/plans/`,
+surviving stale-term proposals are zero; the four docs that still contain a
+`STALE_TERMS` key are all genuine migration or audit prose where any rewrite
+would produce a false sentence. The detector is quiet, not dead: a synthetic
+sentence carrying a stale term and no migration context still queues a fix, and
+a test pins that.
 
 #### Stale terms are word-anchored
 
@@ -69,12 +97,9 @@ longer run of word characters: `session_log` does not match inside
 `agent/session_logs.py` or `session_log_writer`, and `SessionLog` does not match
 inside `SessionLogs`.
 
-That is the whole guarantee, and it stops short of "never rewrites a path".
-`/`, `.`, and `-` are all word boundaries, so a key that *equals* an entire path
-segment still matches and is still rewritten — `models/session_log.py` becomes
-`models/agent_session.py`. The existence invariant below is the only thing that
-catches such a rewrite, and only when the rewritten path is absent from the
-working tree; if both paths happen to exist, the rewrite is accepted.
+Word-anchoring on its own does not deliver "never rewrites a path". `/`, `.`,
+and `-` are all word boundaries, so a key equal to a whole path segment still
+matches. Gate 3 is what closes that.
 
 Detection and application share one matching semantics: `_detect_stale_term_fixes`
 returns compiled `(pattern, replacement)` pairs on a dedicated `regex_fixes`
@@ -82,32 +107,141 @@ channel, applied by `_apply_fixes_to_file` through `pattern.subn()`. The literal
 `fixes` channel used by the three rename detectors is untouched, so the
 `new == ""` line-delete sentinel keeps its exact-line-equality semantics.
 
-The `migration_context` escape hatch is unchanged: a doc that already says
-"renamed to X", "replaced by X", "now X", "formerly Y", or "replaces Y" gets no
-fix for that term.
+#### Gate 1: the migration-context hatch is document-scoped
 
-#### The existence invariant
+`_has_migration_context` asks whether the **whole document** records the
+`old_term` → `new_term` migration, over text run through `_normalize_prose`
+(backticks stripped, whitespace collapsed, lowercased). That normalization is
+used for cue matching only and never to produce output; it is lossy by design.
+It is also the point: the corpus writes every identifier backticked, so a bare
+substring test for `formerly RedisJob` never sees the prose humans actually
+wrote.
+
+Two tiers of cue:
+
+1. **Directed cues**, generated per `(old_term, new_term)` pair by
+   `_migration_cues`: `renamed to X`, `replaced by X`, `now X`, `formerly Y`,
+   `replaces Y`, `replacing Y`, `earlier Y`, `old Y`, `alias`, `Y = X`,
+   `Y -> X`, `Y → X`. Each names both (or the specific) terms, so it is
+   conclusive alone. Generating them from the pair means adding a `STALE_TERMS`
+   entry costs no edit here.
+2. **Generic cue words** (`_MIGRATION_CUE_WORDS`: `renamed`, `replaced`,
+   `replacing`, `formerly`, `earlier`, `old`, `alias`, `superseded`, …) that
+   fire **only when the new term also appears somewhere in the document**. That
+   second condition is the anti-over-exemption guard: prose mentioning a stale
+   name without ever naming its successor is not a migration record and still
+   queues a fix. Tier 2 is what catches real corpus phrasing whose cue and term
+   sit in different clauses, such as *"replacing both the earlier `SessionLog`
+   and `RedisJob` models"* for `RedisJob`, which no directed cue names.
+
+**The scope is the document, deliberately.** Line-scoping (one exemption
+decision per occurrence) was measured and is strictly worse: it re-exposes 8
+occurrences the document scope correctly exempts, because in real prose the
+migration context sits in a *different* sentence from the term it explains. Do
+not "improve" this into a per-occurrence rule.
+
+#### Gates 2 and 3 are computed at apply time, never at detection time
+
+`_detect_stale_term_fixes` returns `(compiled pattern, replacement string)` and
+nothing else; the channel contract is unchanged. The suppression callable is
+built inside `_apply_fixes_to_file`'s regex loop by `_make_stale_term_replacer`,
+which wraps that plain string.
+
+That placement is load-bearing, not stylistic. `_apply_fixes_to_file` applies the
+literal `fixes` list **first** (including `_detect_readme_broken_entries`'
+`new == ""` whole-line-delete sentinel) and only then runs the regex fixes over
+the already-mutated text. Any line index computed at detection time is stale the
+moment a line ahead of it disappears, and it fails **silently**: a
+plausible-looking wrong rewrite rather than an error, which is precisely the
+corruption class these gates exist to close. The callable instead re-derives
+context from `match.string` (the text currently being rewritten) and
+`match.start()` (the live offset into it), so there is no index to go stale.
+
+Keeping the callable local also keeps `_reject` receiving the replacement
+*string*, so a withheld record stays readable in the PR body, the findings
+summary, and the warning log instead of rendering as `<function ... at 0x...>`.
+
+**Gate 2** reuses `_build_line_context` / `_is_documented_deletion`, the same
+machinery the deleted-target detector uses (described below): fenced code
+blocks, deletion or migration headings, and deletion prose on an adjacent line.
+
+**Gate 3** suppresses any match lying wholly inside a `_PATH_TOKEN_RE` token
+(`(?:[\w.-]+/)*[\w.-]+\.(?:py|md)`), scanned within the match's own line so the
+cost is independent of document size. This is the gate that stops
+`models/session_log.py` from becoming `models/agent_session.py`, a corruption
+the existence invariant provably cannot catch, because both files exist.
+
+A suppressed match returns unchanged, but `subn` still counts it as a
+substitution. Suppressions are therefore tallied in a closure cell and
+subtracted from the reported `applied` count, and an all-suppressed fix is
+skipped outright rather than booked as a no-op write.
+
+#### Gate 4: the existence invariant
 
 Every auto-fix, regardless of detector, is subject to one post-condition before
-anything is written: **the auditor may not introduce a slash-shaped `.py`/`.md`
-repo-path reference that is absent from the working tree.**
+anything is written: **the auditor may not introduce a `.py`/`.md` reference
+that is absent from the working tree.**
 
-That is the exact shape `_PATH_REF_RE` matches, and it is narrower than "any
-reference to a file". Two forms are deliberately **not** covered: paths with
-other extensions (`.sh`, `.ts`, `.json`), and the dotted module form
-(`bridge.session_log`) — the same class as the #2711 incident. A fix that
-introduces only those forms passes the invariant with `withheld=0`.
+`_PATH_REF_RE` is `(?:[\w.-]+/)*[\w.-]+\.(?:py|md)`. The directory segment is
+optional, so bare filenames (`agent_session.py`, `README.md`) are visible to the
+invariant alongside `dir/file.md` forms. A bare name existing nowhere is the
+#2711 corruption shape minus its directory prefix. Two forms are still
+deliberately **not** covered: other extensions (`.sh`, `.ts`, `.json`), and the
+dotted module form (`bridge.session_log`). A fix that introduces only those
+passes the invariant with `withheld=0`.
 
-`_apply_fixes_to_file` simulates each fix, collects the `dir/file.{py,md}`-shaped
-references the candidate text would newly introduce, and resolves each against
-`repo_root`. If any is absent, that fix is rejected.
+`_apply_fixes_to_file` simulates each fix, collects the references the candidate
+text would newly introduce, and hands them to `_absent_new_path_refs` together
+with the doc's own path. If any is absent, that fix is rejected.
+
+**Resolution order.** A ref containing `/` resolves against `repo_root` and
+nothing about it changed. A **bare** ref resolves first against the doc's own
+directory (`repo_root / doc_path.parent / ref`), because a bare name in prose is
+most often a sibling, and then against a basename index built from
+`git ls-files --cached --others --exclude-standard`. That is one subprocess, it
+respects `.gitignore` for free, and it counts files added but not yet committed,
+which matters because a doc may reference a file added in the same change. The
+index is memoized per resolved repo root and cleared at the top of every
+`audit()` run, so a long-lived process never answers from a pre-commit snapshot.
+On subprocess failure it logs a warning and degrades to doc-relative resolution
+alone.
+
+**Ambiguity is not a withhold.** `>=1` owner means the name denotes something
+real and the fix passes; `>1` owners is DEBUG-logged and allowed through; only
+`0` owners is absent. The invariant's question is "does this name denote
+something real", not "is it unambiguous". Ambiguity never produced the #2711
+corruption. A name existing *nowhere* did. The corpus carries 218 ambiguous
+refs across 108 multi-owner basenames, so withholding on ambiguity would fire
+constantly for no safety gain.
+
+Making the directory segment optional costs nothing on already-written prose.
+`_absent_new_path_refs` validates only `findall(candidate) - original_refs`, and
+`original_refs` is computed with the same pattern, so both sides widen
+symmetrically and pre-existing references are never re-validated. Measured
+self-baselining over `docs/features/*.md` (narrow `+` arm versus shipped `*` arm
+in one run), the widening produces **zero** new withholds.
+
+#### Why the sibling patterns stay narrower
+
+`_detect_renamed_symbol_fixes` and `_detect_deleted_target_issues` each carry
+their own `` `((?:[\w.-]+/)+[\w.-]+\.py)` `` pattern that still *requires* a
+directory segment. The asymmetry with `_PATH_REF_RE` is deliberate, and a
+comment at each site records why.
+
+Those two are **detector** patterns, governing what the auditor *proposes*.
+`_PATH_REF_RE` is the only one of the three on the write path. Widening the
+detectors enlarges the candidate set and spends the `GIT_LOG_FOLLOW_CAP` per-run
+`git log --follow` budget and the per-run issue cap on bare names that are not
+resolvable to a single path anyway. That is a scope and volume change with its
+own failure modes, not a safety fix.
 
 - **Attributed per term, not per occurrence.** Only the offending fix is
   dropped; valid sibling fixes in the same file still apply, and the file is
   never abandoned wholesale. But a fix is one `(old, new)` pair applied to the
   whole document — `str.replace` and `pattern.subn()` both rewrite *every*
-  occurrence — so a single path-shaped hit withholds that term's legitimate
-  prose hits in the same file too.
+  occurrence — so a single absent-target hit withholds that term's legitimate
+  prose hits in the same file too. Path-shaped occurrences no longer reach this
+  gate at all: gate 3 suppresses them first.
 - **References already present in the document are never re-validated.** The
   invariant constrains what the auditor *adds*, so it cannot reject a fix over
   pre-existing prose that names a long-gone module. The residual hole: if a
@@ -392,6 +526,18 @@ the `_write_liveness` 4-arg/5-arg positional contract (`fixes_withheld` is a
 trailing keyword param, so that contract is unchanged); `TestVaultDeadCodeRemoved`
 asserts `DEFAULT_VAULT_WEIGHT`, `vault_weight`, and `_vault_field` are gone.
 
+The four gates are covered by `TestStaleTermDictionary` (cue tiers across
+backticked, cased, alias, and arrow forms; the channel stays
+`(re.Pattern, str)`), `TestStaleTermWordBoundary` (path-token suppression, and a
+`README.md` fixture where an earlier line is deleted by the `new == ""` sentinel
+before a later stale term is evaluated, the case detection-time indices fail
+silently), `TestExistenceInvariant` (bare-name withhold, doc-relative
+resolution, ambiguous-but-present pass, no re-validation of pre-existing refs),
+and `TestWithheldBlocksAutoMerge` (a bare-name withhold reaching the PR body,
+Telegram, and liveness). `TestWithheldRateNonRegression` self-baselines the
+narrow and widened `_PATH_REF_RE` arms in one run inside a disposable detached
+`git worktree`, asserting the widening adds no withholds.
+
 ```bash
 pytest tests/unit/test_docs_auditor_substrate.py -v
 ```
@@ -406,3 +552,5 @@ pytest tests/unit/test_docs_auditor_substrate.py -v
 - Issue #1247 — design and rollout plan
 - Issue #1249 — memory refresh hook (forward-compat target)
 - Issue #2084 — vault↔site/docs drift detector, reflection enable, xref-orphan sweep
+- Issues #2744 / #2759 — the migration-context hatch, apply-time suppression, and
+  the bare-name existence invariant (`docs/plans/docs-auditor-migration-context-and-bare-paths.md`)

--- a/docs/features/docs-auditor.md
+++ b/docs/features/docs-auditor.md
@@ -126,13 +126,24 @@ Two tiers of cue:
    conclusive alone. Generating them from the pair means adding a `STALE_TERMS`
    entry costs no edit here.
 2. **Generic cue words** (`_MIGRATION_CUE_WORDS`: `renamed`, `replaced`,
-   `replacing`, `formerly`, `earlier`, `old`, `alias`, `superseded`, …) that
-   fire **only when the new term also appears somewhere in the document**. That
-   second condition is the anti-over-exemption guard: prose mentioning a stale
-   name without ever naming its successor is not a migration record and still
-   queues a fix. Tier 2 is what catches real corpus phrasing whose cue and term
-   sit in different clauses, such as *"replacing both the earlier `SessionLog`
-   and `RedisJob` models"* for `RedisJob`, which no directed cue names.
+   `replacing`, `formerly`, `earlier`, `old`, `alias`, `superseded`, …), matched
+   **word-anchored** through the precompiled `_MIGRATION_CUE_WORD_RE`
+   alternation, that fire **only when the new term also appears somewhere in the
+   document**. Tier 2 is what catches real corpus phrasing whose cue and term sit
+   in different clauses, such as *"replacing both the earlier `SessionLog` and
+   `RedisJob` models"* for `RedisJob`, which no directed cue names.
+
+   **Both halves of tier 2 are the anti-over-exemption guard, and both are
+   load-bearing.** Requiring the new term means prose that mentions a stale name
+   without ever naming its successor is not a migration record and still queues a
+   fix. Word-anchoring the cue words means a cue cannot fire from inside an
+   unrelated word: `old` is a substring of *threshold*, *holds*, *placeholder*,
+   *bold* and *household*, all common in this corpus, and with a bare substring
+   test tier 2 collapses into "the document mentions the new term somewhere".
+   That was not hypothetical — `docs/guides/summarizer-output-audit.md` was
+   exempted for `RedisJob` solely because it contains `summarize_threshold`.
+   `TestStaleTermDictionary::test_cue_word_inside_a_larger_word_does_not_exempt`
+   pins it.
 
 **The scope is the document, deliberately.** Line-scoping (one exemption
 decision per occurrence) was measured and is strictly worse: it re-exposes 8

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -535,6 +535,15 @@ _MIGRATION_CUE_WORDS = (
     "supersedes",
 )
 
+# Word-anchored alternation over the cue words. Anchoring is load-bearing, not
+# cosmetic: an unanchored substring test fires inside unrelated words ("old" is a
+# substring of threshold, holds, placeholder, bold, household), which collapses
+# tier 2 of ``_has_migration_context`` into "the document mentions the new term"
+# and exempts whole documents by accident.
+_MIGRATION_CUE_WORD_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(w) for w in _MIGRATION_CUE_WORDS) + r")\b"
+)
+
 
 def _migration_cues(old_term: str, new_term: str) -> tuple[str, ...]:
     """Directed migration cues for one ``(old_term, new_term)`` pair, normalized.
@@ -569,21 +578,30 @@ def _has_migration_context(normalized: str, old_term: str, new_term: str) -> boo
 
     1. A *directed* cue naming both (or the specific) terms — ``renamed to X``,
        ``formerly Y``, ``Y = X``, ``Y -> X``, ``Y → X``, ``alias Y`` …
-    2. A generic migration cue word (``replacing``, ``earlier``, ``old`` …)
-       **plus** the new term appearing somewhere in the document. Tier 2 is what
-       catches real corpus prose whose cue and term sit in different clauses, e.g.
+    2. A generic migration cue word (``replacing``, ``earlier``, ``old`` …),
+       matched **word-anchored** via ``_MIGRATION_CUE_WORD_RE``, **plus** the new
+       term appearing somewhere in the document. Tier 2 is what catches real
+       corpus prose whose cue and term sit in different clauses, e.g.
        *"`AgentSession` lands, replacing both the earlier `SessionLog` and
        `RedisJob` models"* — where no directed cue names ``RedisJob`` at all.
 
-    Requiring the new term for tier 2 is the guard against over-exemption: prose
-    that merely mentions a stale name without ever naming its successor is not a
-    migration record and still queues a fix.
+    Two things make tier 2 a guard rather than a rubber stamp, and both are
+    load-bearing:
+
+    - **The new term must appear.** Prose that merely mentions a stale name
+      without ever naming its successor is not a migration record.
+    - **The cue words are word-anchored.** A bare ``in`` substring test fires
+      inside unrelated words — ``old`` sits inside *threshold*, *holds*,
+      *placeholder*, *bold*, *household* — and with that, tier 2 degenerates into
+      "the document mentions the new term somewhere". Measured on the live corpus:
+      ``docs/guides/summarizer-output-audit.md`` was exempted for ``RedisJob``
+      solely because it contains ``summarize_threshold``.
     """
     if any(cue in normalized for cue in _migration_cues(old_term, new_term)):
         return True
     new = _normalize_prose(new_term)
     if new and new in normalized:
-        return any(word in normalized for word in _MIGRATION_CUE_WORDS)
+        return bool(_MIGRATION_CUE_WORD_RE.search(normalized))
     return False
 
 
@@ -741,6 +759,9 @@ def _absent_new_path_refs(
 
 # A file-path-shaped token. Generalizes the single-segment shape to any number of
 # directory segments so a stale term matching the *first* segment is suppressed too.
+# Byte-identical to ``_PATH_REF_RE`` today, and deliberately kept separate: it answers
+# a different question (apply-time "is this match inside a path token?" suppression vs.
+# that one's write-path existence oracle) and either may diverge without the other.
 _PATH_TOKEN_RE = re.compile(r"(?:[\w.-]+/)*[\w.-]+\.(?:py|md)")
 
 

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -452,6 +452,12 @@ def _detect_renamed_symbol_fixes(content: str, repo_root: Path) -> list[tuple[st
     longer exists but git history shows a rename, queue a replacement.
     """
     fixes: list[tuple[str, str]] = []
+    # Deliberately narrower than `_PATH_REF_RE`, which was widened to `*` for #2759.
+    # This is a *detector* pattern governing what the auditor proposes, not the write
+    # path the existence invariant guards. Widening it to bare names enlarges the
+    # candidate set and spends the GIT_LOG_FOLLOW_CAP per-run `git log --follow`
+    # budget on names that resolve to no single path anyway — a scope and volume
+    # change with its own failure modes, not a safety fix. Ruled unchanged in #2759.
     for m in re.finditer(r"`((?:[\w.-]+/)+[\w.-]+\.py)`", content):
         path = m.group(1)
         if (repo_root / path).exists():
@@ -627,21 +633,110 @@ def _detect_stale_term_fixes(content: str) -> list[tuple[re.Pattern[str], str]]:
     return fixes
 
 
-# Path-shaped reference: ``dir/file.py`` or ``dir/file.md``, one or more segments.
-_PATH_REF_RE = re.compile(r"(?:[\w.-]+/)+[\w.-]+\.(?:py|md)")
+# Path-shaped reference: ``dir/file.{py,md}`` *or* a bare ``file.{py,md}``. The
+# directory segment is optional (`*`, not `+`) so bare filenames enter the existence
+# invariant (#2759) — the #2711 corruption shape minus its directory prefix.
+_PATH_REF_RE = re.compile(r"(?:[\w.-]+/)*[\w.-]+\.(?:py|md)")
+
+# Basename -> number of owning paths, built once per repo root from the git index.
+# Keyed on the resolved ``repo_root`` so distinct checkouts (and distinct test
+# ``tmp_path`` roots) never share an index. Cleared at the top of every ``audit()``
+# run so a long-lived process does not answer from a stale snapshot.
+_BASENAME_INDEX_CACHE: dict[Path, dict[str, int]] = {}
 
 
-def _absent_new_path_refs(original_refs: set[str], candidate: str, repo_root: Path) -> list[str]:
+def _repo_basename_index(repo_root: Path) -> dict[str, int]:
+    """Map every tracked-or-untracked file's basename to how many paths own it.
+
+    Built from ``git ls-files --cached --others --exclude-standard``: one
+    subprocess, ``.gitignore`` respected for free, and files added but not yet
+    committed still counted (a doc may reference a file added in the same change).
+
+    On any subprocess failure the index degrades to empty and a warning is logged;
+    bare-name resolution then falls back to the doc-relative check alone.
+    """
+    key = repo_root.resolve()
+    cached = _BASENAME_INDEX_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    index: dict[str, int] = {}
+    try:
+        proc = subprocess.run(
+            ["git", "ls-files", "--cached", "--others", "--exclude-standard"],
+            cwd=key,
+            capture_output=True,
+            text=True,
+            timeout=settings.timeouts.git_subprocess_s,
+        )
+        if proc.returncode != 0:
+            logger.warning(
+                "docs_auditor: git ls-files failed in %s (rc=%s): %s — bare-name "
+                "existence falls back to doc-relative resolution only",
+                key,
+                proc.returncode,
+                (proc.stderr or "").strip(),
+            )
+        else:
+            for line in proc.stdout.splitlines():
+                name = line.rsplit("/", 1)[-1]
+                if name:
+                    index[name] = index.get(name, 0) + 1
+    except (OSError, subprocess.SubprocessError) as e:
+        logger.warning(
+            "docs_auditor: git ls-files errored in %s: %s — bare-name existence "
+            "falls back to doc-relative resolution only",
+            key,
+            e,
+        )
+
+    _BASENAME_INDEX_CACHE[key] = index
+    return index
+
+
+def _absent_new_path_refs(
+    original_refs: set[str], candidate: str, repo_root: Path, doc_path: Path
+) -> list[str]:
     """Path refs a candidate rewrite would newly introduce that are absent from disk.
 
     References already present in the original document are never re-validated —
-    the invariant constrains only what the auditor *adds*.
+    the invariant constrains only what the auditor *adds*. Because ``original_refs``
+    is computed with the same pattern, widening that pattern widens both sides
+    symmetrically and costs no new withholds on already-written prose.
+
+    Resolution order:
+
+    - A ref containing ``/`` resolves against ``repo_root`` alone, exactly as before.
+    - A **bare** ref (no ``/``, #2759) resolves first against the doc's own directory
+      (``repo_root / doc_path.parent / ref``), because a bare name in prose is most
+      often a sibling; then against the ``git ls-files`` basename index.
+
+    **Ambiguity is not a withhold.** ``>=1`` owner means the name exists and the fix
+    passes; ``>1`` owners is logged at DEBUG and allowed through. The invariant asks
+    "does this name denote something real", not "is it unambiguous" — ambiguity never
+    produced the #2711 corruption, which was a name existing nowhere. Only ``0``
+    owners is absent.
     """
-    return sorted(
-        ref
-        for ref in set(_PATH_REF_RE.findall(candidate)) - original_refs
-        if not (repo_root / ref).exists()
-    )
+    absent: list[str] = []
+    for ref in sorted(set(_PATH_REF_RE.findall(candidate)) - original_refs):
+        if "/" in ref:
+            if not (repo_root / ref).exists():
+                absent.append(ref)
+            continue
+        if (repo_root / doc_path.parent / ref).exists():
+            continue
+        owners = _repo_basename_index(repo_root).get(ref, 0)
+        if owners == 0:
+            absent.append(ref)
+        elif owners > 1:
+            logger.debug(
+                "docs_auditor: bare ref %r in %s resolves to %d paths — ambiguous "
+                "but present, allowed through",
+                ref,
+                doc_path,
+                owners,
+            )
+    return absent
 
 
 # A file-path-shaped token. Generalizes the single-segment shape to any number of
@@ -727,8 +822,9 @@ def _apply_fixes_to_file(
     and is — derived from the live, already-mutated text at match time rather
     than from any index computed at detection time.
 
-    **Existence invariant:** a fix may not introduce a ``dir/file.{py,md}``-shaped
-    reference that does not exist under ``repo_root``. Violating fixes are rejected
+    **Existence invariant:** a fix may not introduce a ``file.{py,md}``-shaped
+    reference — bare or ``dir/``-prefixed (#2759) — that does not exist under
+    ``repo_root``; see ``_absent_new_path_refs``. Violating fixes are rejected
     individually — valid sibling fixes in the same file still apply — logged at
     warning level, and returned for the caller to surface.
 
@@ -779,7 +875,7 @@ def _apply_fixes_to_file(
             count = new_text.count(old)
             candidate = new_text.replace(old, new)
 
-        absent = _absent_new_path_refs(original_refs, candidate, repo_root)
+        absent = _absent_new_path_refs(original_refs, candidate, repo_root, path)
         if absent:
             _reject(old, new, absent)
             continue
@@ -795,7 +891,7 @@ def _apply_fixes_to_file(
         # and avoids a pointless existence-invariant pass over unchanged text.
         if count <= 0 or candidate == new_text:
             continue
-        absent = _absent_new_path_refs(original_refs, candidate, repo_root)
+        absent = _absent_new_path_refs(original_refs, candidate, repo_root, path)
         if absent:
             _reject(pattern.pattern, new, absent)
             continue
@@ -931,6 +1027,11 @@ def _detect_deleted_target_issues(doc_path: Path, content: str, repo_root: Path)
     findings: list[dict] = []
     lines = content.splitlines()
     in_fence, heading_for_line = _build_line_context(content)
+    # Deliberately narrower than `_PATH_REF_RE` (widened to `*` for #2759), for the
+    # same reason as `_detect_renamed_symbol_fixes`: this is a detector pattern
+    # governing what the auditor *proposes*, not the write path. Widening it would
+    # spend the per-run issue cap on bare names not resolvable to a single path.
+    # Ruled unchanged in #2759.
     for m in re.finditer(r"`((?:[\w.-]+/)+[\w.-]+\.py)`", content):
         path = m.group(1)
         if _is_placeholder_path(path):
@@ -1236,6 +1337,9 @@ def audit(
     """
     global _RENAME_QUERY_COUNT
     _RENAME_QUERY_COUNT = 0  # reset per-run cap
+    # The bare-name existence oracle is a per-*run* snapshot: a long-lived process
+    # must not answer from an index built before the last commit (#2759).
+    _BASENAME_INDEX_CACHE.clear()
 
     root = (repo_root or PROJECT_ROOT).resolve()
 

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -26,6 +26,7 @@ import os
 import re
 import subprocess
 import time
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -494,38 +495,134 @@ def _detect_readme_broken_entries(
     return fixes
 
 
+def _normalize_prose(text: str | None) -> str:
+    """Lowercase, strip backticks, and collapse whitespace — for cue matching only.
+
+    The corpus writes every identifier backticked (``formerly `RedisJob```), which
+    is why the pre-#2744 hatch's bare substring tests (``f"formerly {old_term}"``)
+    never matched a single live document. Normalizing both the haystack and the
+    generated cues makes the hatch see the prose humans actually wrote.
+
+    **Never** use the result to produce output — it is lossy by design. It exists
+    solely to answer "does this document record a migration?".
+    """
+    if not text:
+        return ""
+    return re.sub(r"\s+", " ", text.replace("`", "").lower())
+
+
+# Verbs/adjectives that mark a sentence as recording a completed rename. Each fires
+# only in combination with the *new* term appearing somewhere in the same document
+# (see ``_has_migration_context``), which is what keeps them from exempting prose
+# that merely mentions a stale name.
+_MIGRATION_CUE_WORDS = (
+    "renamed",
+    "rename",
+    "replaced",
+    "replaces",
+    "replacing",
+    "formerly",
+    "earlier",
+    "old",
+    "alias",
+    "superseded",
+    "supersedes",
+)
+
+
+def _migration_cues(old_term: str, new_term: str) -> tuple[str, ...]:
+    """Directed migration cues for one ``(old_term, new_term)`` pair, normalized.
+
+    These name *both* terms, so they are conclusive on their own and do not need
+    the new term to appear separately. Generated from the pair rather than
+    hard-coded, so adding a ``STALE_TERMS`` entry needs no edit here.
+    """
+    old = _normalize_prose(old_term)
+    new = _normalize_prose(new_term)
+    return (
+        f"renamed to {new}",
+        f"replaced by {new}",
+        f"now {new}",
+        f"formerly {old}",
+        f"replaces {old}",
+        f"replacing {old}",
+        f"earlier {old}",
+        f"old {old}",
+        f"alias {old}",
+        f"alias {new}",
+        f"{old} = {new}",
+        f"{old} -> {new}",
+        f"{old} → {new}",
+    )
+
+
+def _has_migration_context(normalized: str, old_term: str, new_term: str) -> bool:
+    """Whether a **whole document** records the ``old_term`` → ``new_term`` migration.
+
+    Two tiers, both evaluated over ``_normalize_prose``'d text:
+
+    1. A *directed* cue naming both (or the specific) terms — ``renamed to X``,
+       ``formerly Y``, ``Y = X``, ``Y -> X``, ``Y → X``, ``alias Y`` …
+    2. A generic migration cue word (``replacing``, ``earlier``, ``old`` …)
+       **plus** the new term appearing somewhere in the document. Tier 2 is what
+       catches real corpus prose whose cue and term sit in different clauses, e.g.
+       *"`AgentSession` lands, replacing both the earlier `SessionLog` and
+       `RedisJob` models"* — where no directed cue names ``RedisJob`` at all.
+
+    Requiring the new term for tier 2 is the guard against over-exemption: prose
+    that merely mentions a stale name without ever naming its successor is not a
+    migration record and still queues a fix.
+    """
+    if any(cue in normalized for cue in _migration_cues(old_term, new_term)):
+        return True
+    new = _normalize_prose(new_term)
+    if new and new in normalized:
+        return any(word in normalized for word in _MIGRATION_CUE_WORDS)
+    return False
+
+
 def _detect_stale_term_fixes(content: str) -> list[tuple[re.Pattern[str], str]]:
     """Detect stale terms from STALE_TERMS dict that lack migration context.
 
     Matching is **word-anchored** with ``\\b``: a key never matches inside a
     longer run of word characters, so ``session_log`` does not match inside
-    ``agent/session_logs.py`` or ``session_log_writer`` (#2711). That is the
-    whole guarantee — it stops short of "never rewrites a path". ``/``, ``.``
-    and ``-`` are all word boundaries, so a key that *equals* an entire path
-    segment still matches and is still rewritten (``models/session_log.py`` →
-    ``models/agent_session.py``). Only the existence invariant in
-    ``_apply_fixes_to_file`` catches that, and only when the rewritten path is
-    absent from the working tree.
+    ``agent/session_logs.py`` or ``session_log_writer`` (#2711).
+
+    **Paths are never rewritten** (#2744). Word-anchoring alone did not deliver
+    that — ``/``, ``.`` and ``-`` are word boundaries, so a key equal to a whole
+    path segment used to be rewritten (``models/session_log.py`` →
+    ``models/agent_session.py``), a corruption the existence invariant provably
+    cannot catch because *both* files exist. Path-token suppression in
+    ``_apply_fixes_to_file`` now closes it: a match lying inside a
+    ``dir/file.{py,md}``-shaped token is left alone unconditionally.
+
+    **The migration-context hatch is DOCUMENT-scoped, deliberately.** Spike-2 of
+    ``docs/plans/docs-auditor-migration-context-and-bare-paths.md`` measured a
+    line-scoped (occurrence-scoped) hatch as *strictly worse*: it re-exposed 8
+    occurrences that the document scope correctly exempts, because migration
+    context in real prose sits in a different sentence from the term it explains.
+    Do not "improve" this into a per-occurrence rule.
+
+    Two further gates live at apply time rather than here, because the literal
+    ``fixes`` loop runs first and can delete lines out from under any index
+    computed against ``content``: fence/heading/deletion-prose suppression (via
+    ``_build_line_context`` / ``_is_documented_deletion``) and path-token
+    suppression. See ``_apply_fixes_to_file``.
 
     Returns fixes on the regex channel — ``(compiled_pattern, replacement)`` —
     so detection and application share one matching semantics. These are passed
     to ``_apply_fixes_to_file`` as ``regex_fixes``, never mixed into the literal
-    ``fixes`` list (which carries the ``new == ""`` line-delete sentinel).
+    ``fixes`` list (which carries the ``new == ""`` line-delete sentinel). The
+    replacement stays a plain ``str``; the suppression callable is built at the
+    apply site so the withheld record and this channel's contract stay intact.
     """
+    normalized = _normalize_prose(content)
     fixes: list[tuple[re.Pattern[str], str]] = []
     for old_term, new_term in STALE_TERMS.items():
         pattern = re.compile(rf"\b{re.escape(old_term)}\b")
         if not pattern.search(content):
             continue
-        migration_context = (
-            f"renamed to {new_term}" in content
-            or f"replaced by {new_term}" in content
-            or f"now {new_term}" in content
-            or f"formerly {old_term}" in content
-            or f"Replaces {old_term}" in content
-            or f"replaces {old_term}" in content
-        )
-        if not migration_context:
+        if not _has_migration_context(normalized, old_term, new_term):
             fixes.append((pattern, new_term))
     return fixes
 
@@ -547,6 +644,68 @@ def _absent_new_path_refs(original_refs: set[str], candidate: str, repo_root: Pa
     )
 
 
+# A file-path-shaped token. Generalizes the single-segment shape to any number of
+# directory segments so a stale term matching the *first* segment is suppressed too.
+_PATH_TOKEN_RE = re.compile(r"(?:[\w.-]+/)*[\w.-]+\.(?:py|md)")
+
+
+def _match_inside_path_token(text: str, start: int, end: int) -> bool:
+    """Whether ``text[start:end]`` lies wholly inside a ``dir/file.{py,md}`` token.
+
+    Scanning is confined to the match's own line, which bounds the cost and makes
+    the answer independent of how large the document is.
+    """
+    line_start = text.rfind("\n", 0, start) + 1
+    line_end = text.find("\n", end)
+    if line_end == -1:
+        line_end = len(text)
+    line = text[line_start:line_end]
+    rel_start, rel_end = start - line_start, end - line_start
+    return any(m.start() <= rel_start and rel_end <= m.end() for m in _PATH_TOKEN_RE.finditer(line))
+
+
+def _make_stale_term_replacer(replacement: str, suppressed: list[int]) -> Callable[[re.Match], str]:
+    """Build the apply-time suppression callable for one stale-term regex fix.
+
+    Context is re-derived from ``match.string`` — the text *currently being
+    rewritten* — and ``match.start()``, the live offset into it. That is the whole
+    point: ``_apply_fixes_to_file`` applies the literal ``fixes`` list first,
+    including ``_detect_readme_broken_entries``' ``new == ""`` whole-line-delete
+    sentinel, so any line index computed at detection time is stale the moment a
+    line ahead of it disappears — and it fails *silently*, producing a plausible
+    wrong rewrite rather than an error. There is no index here to go stale.
+
+    A suppressed match returns ``match.group(0)`` unchanged, but ``subn`` still
+    counts it, so each suppression is recorded in ``suppressed`` for the caller to
+    subtract from the reported ``applied`` count.
+
+    The callable is local to the apply loop and never travels on the regex channel:
+    ``_detect_stale_term_fixes`` keeps returning ``(re.Pattern, str)``, and
+    ``_reject`` keeps receiving the replacement *string* so the withheld record
+    stays human-readable in the PR body, findings summary, and warning log.
+    """
+    context_cache: dict[str, tuple[list[str], list[bool], list[str]]] = {}
+
+    def _replace(match: re.Match) -> str:
+        text = match.string
+        context = context_cache.get(text)
+        if context is None:
+            in_fence, heading_for_line = _build_line_context(text)
+            context = (text.splitlines(), in_fence, heading_for_line)
+            context_cache[text] = context
+        lines, in_fence, heading_for_line = context
+        line_idx = text.count("\n", 0, match.start())
+        if _is_documented_deletion(line_idx, lines, in_fence, heading_for_line):
+            suppressed.append(1)
+            return match.group(0)
+        if _match_inside_path_token(text, match.start(), match.end()):
+            suppressed.append(1)
+            return match.group(0)
+        return replacement
+
+    return _replace
+
+
 def _apply_fixes_to_file(
     path: Path,
     repo_root: Path,
@@ -558,6 +717,15 @@ def _apply_fixes_to_file(
     ``fixes`` are literal ``(old, new)`` pairs; ``new == ""`` deletes the whole
     line that exactly equals ``old``. ``regex_fixes`` are ``(pattern, replacement)``
     pairs applied via ``pattern.subn()`` in their own loop.
+
+    **Apply-time suppression (regex fixes only, #2744):** each regex fix's plain
+    ``str`` replacement is wrapped in a locally-built callable
+    (``_make_stale_term_replacer``) that leaves a match untouched when it sits in
+    a fenced code block, under a deletion-recording heading, next to deletion
+    prose, or inside a file-path token. The literal ``fixes`` loop runs *first*
+    and its ``new == ""`` sentinel deletes whole lines, so this context must be —
+    and is — derived from the live, already-mutated text at match time rather
+    than from any index computed at detection time.
 
     **Existence invariant:** a fix may not introduce a ``dir/file.{py,md}``-shaped
     reference that does not exist under ``repo_root``. Violating fixes are rejected
@@ -619,8 +787,13 @@ def _apply_fixes_to_file(
         applied += count
 
     for pattern, new in regex_fixes:
-        candidate, count = pattern.subn(new, new_text)
-        if count == 0:
+        suppressed: list[int] = []
+        candidate, count = pattern.subn(_make_stale_term_replacer(new, suppressed), new_text)
+        count -= len(suppressed)
+        # An all-suppressed fix leaves the text byte-identical while ``subn``
+        # still reports a nonzero raw count. Skipping it keeps ``applied`` honest
+        # and avoids a pointless existence-invariant pass over unchanged text.
+        if count <= 0 or candidate == new_text:
             continue
         absent = _absent_new_path_refs(original_refs, candidate, repo_root)
         if absent:

--- a/tests/unit/test_docs_auditor_substrate.py
+++ b/tests/unit/test_docs_auditor_substrate.py
@@ -33,6 +33,20 @@ def repo(tmp_path: Path) -> Path:
     return tmp_path
 
 
+@pytest.fixture()
+def git_repo(repo: Path) -> Path:
+    """A ``repo`` that is also a real git checkout.
+
+    The bare-name existence oracle (#2759) resolves a filename with no ``/``
+    against a ``git ls-files --cached --others --exclude-standard`` basename
+    index. That index only exists inside a git checkout, so ambiguity and
+    index-backed resolution have to be exercised here rather than on the plain
+    ``tmp_path`` ``repo`` fixture.
+    """
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    return repo
+
+
 @pytest.fixture(autouse=True)
 def reset_global_state():
     """Reset module-level counters between tests."""
@@ -600,15 +614,51 @@ class TestStaleTermDictionary:
         assert docs_auditor.STALE_TERMS["SessionLog"] == "AgentSession"
         assert "RedisJob" in docs_auditor.STALE_TERMS
 
-    def test_migration_context_skips_fix(self):
-        content = "The SessionLog has been renamed to AgentSession."
-        fixes = docs_auditor._detect_stale_term_fixes(content)
-        # Migration context recognized -> no fix queued
-        assert fixes == []
+    @pytest.mark.parametrize(
+        "content",
+        [
+            # Bare form — the only shape the pre-#2744 hatch could ever see.
+            "The SessionLog has been renamed to AgentSession.",
+            # Backticked: the corpus writes every identifier this way, which is
+            # why `formerly SessionLog` never matched a single live document.
+            "The `SessionLog` has been renamed to `AgentSession`.",
+            "`RedisJob` was replaced by `AgentSession` in the same pass.",
+            # Mixed case at the start of a sentence.
+            "Formerly `RedisJob`, this model is now `AgentSession`.",
+            # Alias form — agent-session-migration-audit.md's actual prose.
+            "The compat shim declares `SessionLog = AgentSession` for old imports.",
+            # Arrow forms — summarizer-output-audit.md's actual prose.
+            "Rename map: `SessionLog` -> `AgentSession` across all call sites.",
+            "Rename map: `SessionLog` → `AgentSession` across all call sites.",
+            # "replacing both the earlier ..." — popoto-redis-expansion.md:7.
+            "`AgentSession` lands, replacing both the earlier `SessionLog` and `RedisJob` models.",
+        ],
+    )
+    def test_migration_context_skips_fix(self, content):
+        """The hatch must fire on the phrasings the corpus actually uses (#2744).
 
-    def test_no_migration_context_queues_fix(self):
-        content = "The SessionLog has methods to track session state."
-        assert (r"\bSessionLog\b", "AgentSession") in _stale_pairs(content)
+        Every case here is a document that *correctly* records a completed
+        rename. Rewriting any occurrence in it produces a sentence saying the
+        new name was formerly itself — a false statement that ships with
+        ``fixes_withheld == 0`` and auto-merges unread.
+        """
+        assert docs_auditor._detect_stale_term_fixes(content) == []
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "The SessionLog has methods to track session state.",
+            "The SessionLog holds per-turn state and is queried directly.",
+            "Worker turns append to the session_log field on exit.",
+        ],
+    )
+    def test_no_migration_context_queues_fix(self, content):
+        """The widened hatch must not over-exempt (plan Risk 1).
+
+        Prose that merely *mentions* a stale term without recording a migration
+        still has to queue a fix, or the detector becomes decorative.
+        """
+        assert docs_auditor._detect_stale_term_fixes(content) != []
 
     def test_fixes_travel_on_the_regex_channel(self):
         fixes = docs_auditor._detect_stale_term_fixes("The SessionLog tracks state.")
@@ -646,11 +696,28 @@ class TestStaleTermWordBoundary:
         ]
 
     def test_apply_leaves_session_logs_path_untouched(self, repo):
+        """Path tokens are never rewritten, whether or not the target exists.
+
+        ``agent/session_logs.py`` is saved by word-anchoring (#2711).
+        ``models/session_log.py`` is not: ``/`` and ``.`` are word boundaries, so
+        ``\\bsession_log\\b`` matches the whole path segment and rewrites it to
+        ``models/agent_session.py``. Both files exist on disk here on purpose —
+        that is the point. The #2728 existence invariant cannot catch a rewrite
+        whose target exists, so only path-token suppression stands between a
+        correct doc and a silently false one (#2744).
+        """
         doc = repo / "docs" / "features" / "snap.md"
-        original = "Snapshots live in `agent/session_logs.py`.\n"
+        original = (
+            "Snapshots live in `agent/session_logs.py`.\n"
+            "The backward-compat shim lives in `models/session_log.py`.\n"
+        )
         doc.write_text(original)
         (repo / "agent").mkdir()
         (repo / "agent" / "session_logs.py").write_text("")
+        (repo / "models").mkdir()
+        (repo / "models" / "session_log.py").write_text("")
+        # The rewrite target exists too — the existence invariant will pass it.
+        (repo / "models" / "agent_session.py").write_text("")
 
         regex_fixes = docs_auditor._detect_stale_term_fixes(original)
         applied, withheld = docs_auditor._apply_fixes_to_file(
@@ -659,6 +726,79 @@ class TestStaleTermWordBoundary:
         assert applied == 0
         assert withheld == []
         assert doc.read_text() == original
+
+    def test_stale_term_inside_fenced_block_is_not_rewritten(self, repo):
+        """A fenced code block is illustrative, not prose to modernize.
+
+        Suppression is an *apply-time* property (the detector keeps returning
+        ``(re.Pattern, str)``), so the assertion is on the resulting file
+        content, not on the detector's return value.
+        """
+        doc = repo / "docs" / "features" / "fence.md"
+        original = (
+            "# Notes\n"
+            "\n"
+            "Historical example, kept verbatim:\n"
+            "\n"
+            "```python\n"
+            "rows = SessionLog.objects.all()\n"
+            "```\n"
+        )
+        doc.write_text(original)
+
+        regex_fixes = docs_auditor._detect_stale_term_fixes(original)
+        applied, withheld = docs_auditor._apply_fixes_to_file(
+            Path("docs/features/fence.md"), repo, [], regex_fixes=regex_fixes
+        )
+        assert applied == 0
+        assert withheld == []
+        assert doc.read_text() == original
+
+    def test_suppression_survives_an_earlier_line_deletion(self, repo):
+        """Apply-time suppression must survive the literal loop's line deletes.
+
+        ``_apply_fixes_to_file`` runs the literal ``fixes`` list first, and
+        ``_detect_readme_broken_entries`` emits a ``new == ""`` whole-line-delete
+        sentinel. Any line index computed against the on-disk content is stale
+        the moment a line ahead of it disappears.
+
+        Here the broken index entry sits on an *earlier* line than the stale
+        term, so a detection-time index would suppress the wrong line and let
+        ``SessionLog`` be rewritten anyway. It would do so silently, never
+        raising — hence the assertion is on the resulting file content.
+        """
+        readme = repo / "docs" / "features" / "README.md"
+        original = (
+            "# Feature Index\n"
+            "\n"
+            "- [Gone](gone.md)\n"
+            "- [Kept](kept.md)\n"
+            "\n"
+            "The `SessionLog` model no longer exists.\n"
+            "It was superseded during the Popoto consolidation.\n"
+        )
+        readme.write_text(original)
+        (repo / "docs" / "features" / "kept.md").write_text("# Kept\n")
+
+        with patch.object(docs_auditor, "_git_log_follow_renames", return_value=[]):
+            literal_fixes = docs_auditor._detect_readme_broken_entries(readme, original, repo)
+        # The fixture is only meaningful if the delete sentinel really fired.
+        assert ("- [Gone](gone.md)", "") in literal_fixes
+
+        regex_fixes = docs_auditor._detect_stale_term_fixes(original)
+        assert regex_fixes, "fixture must queue a stale-term fix for the later line"
+
+        docs_auditor._apply_fixes_to_file(
+            Path("docs/features/README.md"), repo, literal_fixes, regex_fixes=regex_fixes
+        )
+
+        text = readme.read_text()
+        # The earlier broken entry is gone...
+        assert "- [Gone](gone.md)" not in text
+        assert "- [Kept](kept.md)" in text
+        # ...and the later stale term is still correctly suppressed.
+        assert "`SessionLog` model no longer exists" in text
+        assert "AgentSession" not in text
 
 
 # ---------------------------------------------------------------------------
@@ -734,6 +874,101 @@ class TestExistenceInvariant:
         assert applied == 1
         assert withheld == []
         assert "agent/vanished.py" in p.read_text()
+
+    # -- bare (unprefixed) filename refs, #2759 ------------------------------
+    # These sit ALONGSIDE the dir-prefixed cases above, which stay untouched:
+    # widening `_PATH_REF_RE` from `+` to `*` must not change any of them.
+
+    @pytest.fixture()
+    def bare_doc(self, repo):
+        p = repo / "docs" / "features" / "bare.md"
+        p.write_text("Runtime lives in `session_runner.py`.\n")
+        (repo / "docs" / "features" / "session_runner.py").write_text("")
+        return Path("docs/features/bare.md")
+
+    def test_fix_introducing_absent_bare_name_is_withheld(self, repo, bare_doc):
+        """The #2711 corruption shape, minus the directory prefix (#2759 AC1).
+
+        ``_PATH_REF_RE`` requires at least one ``dir/`` segment, so a bare
+        filename is invisible to the existence invariant and passes
+        unconditionally — exactly the class that shipped as ``d7bf3ad99``.
+        """
+        applied, withheld = docs_auditor._apply_fixes_to_file(
+            bare_doc, repo, [("session_runner.py", "ghost_module.py")]
+        )
+        assert applied == 0
+        assert withheld == [
+            {
+                "doc": str(bare_doc),
+                "old": "session_runner.py",
+                "new": "ghost_module.py",
+                "reason": "target-absent",
+            }
+        ]
+        assert "ghost_module.py" not in (repo / bare_doc).read_text()
+
+    def test_bare_name_resolvable_in_doc_directory_passes(self, repo, bare_doc):
+        """Resolution order step 1: the doc's own directory.
+
+        A bare ref in a doc is most often a sibling. Resolving it against the
+        repo root instead would read as absent and over-withhold.
+        """
+        (repo / "docs" / "features" / "headless_runner.py").write_text("")
+        applied, withheld = docs_auditor._apply_fixes_to_file(
+            bare_doc, repo, [("session_runner.py", "headless_runner.py")]
+        )
+        assert applied == 1
+        assert withheld == []
+        assert "headless_runner.py" in (repo / bare_doc).read_text()
+
+    def test_ambiguous_bare_name_passes_and_debug_logs(self, git_repo, caplog):
+        """Resolution order step 2, ambiguity ruling: >=1 match passes (#2759 AC2).
+
+        The invariant asks "does this name denote something real", not "is it
+        unambiguous". Ambiguity never produced the #2711 corruption, so it is
+        logged at DEBUG and allowed through rather than withheld.
+        """
+        repo = git_repo
+        doc = repo / "docs" / "features" / "amb.md"
+        doc.write_text("Runtime lives in `session_runner.py`.\n")
+        (repo / "docs" / "features" / "session_runner.py").write_text("")
+        for pkg in ("alpha", "beta"):
+            (repo / pkg).mkdir()
+            (repo / pkg / "shared_helper.py").write_text("")
+
+        with caplog.at_level("DEBUG", logger="reflections.docs_auditor"):
+            applied, withheld = docs_auditor._apply_fixes_to_file(
+                Path("docs/features/amb.md"),
+                repo,
+                [("session_runner.py", "shared_helper.py")],
+            )
+
+        assert applied == 1
+        assert withheld == []
+        assert "shared_helper.py" in doc.read_text()
+        assert any(
+            r.levelname == "DEBUG" and "shared_helper.py" in r.getMessage() for r in caplog.records
+        ), "ambiguous bare-name resolution must be DEBUG-logged"
+
+    def test_preexisting_absent_bare_name_is_never_revalidated(self, repo):
+        """Additive-only twin of ``test_preexisting_absent_path_is_never_revalidated``.
+
+        This property is what makes the widening free (spike-4): ``original_refs``
+        is computed with the same pattern, so widening widens both sides
+        symmetrically and the 1557 newly-visible corpus refs cost zero withholds.
+        """
+        p = repo / "docs" / "features" / "pre_bare.md"
+        p.write_text("Legacy `vanished_module.py` and `session_runner.py`.\n")
+        (repo / "docs" / "features" / "session_runner.py").write_text("")
+        (repo / "docs" / "features" / "kept_module.py").write_text("")
+        applied, withheld = docs_auditor._apply_fixes_to_file(
+            Path("docs/features/pre_bare.md"),
+            repo,
+            [("session_runner.py", "kept_module.py")],
+        )
+        assert applied == 1
+        assert withheld == []
+        assert "vanished_module.py" in p.read_text()
 
     def test_regex_channel_is_also_guarded(self, repo, doc):
         applied, withheld = docs_auditor._apply_fixes_to_file(
@@ -889,6 +1124,84 @@ class TestWithheldBlocksAutoMerge:
         body = create[create.index("--body") + 1]
         assert docs_auditor.WITHHELD_PR_MARKER in body
         assert "a/c.py" in body
+
+    def test_bare_name_withhold_propagates_to_pr_body_telegram_and_liveness(
+        self, repo, auth_ok, patch_redis
+    ):
+        """The new bare-name withhold class must reach every operator surface.
+
+        Computing the withhold is not enough — #2759's whole value is that the
+        rotation PR becomes auto-merge-ineligible and a human hears about it.
+        The withheld record here is produced by a real ``audit()`` run, not
+        hand-written, so the first assertion is the one that fails on ``main``.
+        """
+        p = repo / "docs" / "features" / "foo.md"
+        p.write_text("Reference `session_runner.py` here.\n" + "Padding line.\n" * 6)
+        (repo / "docs" / "features" / "session_runner.py").write_text("")
+
+        with (
+            patch.object(
+                docs_auditor,
+                "_detect_renamed_symbol_fixes",
+                return_value=[("session_runner.py", "ghost_module.py")],
+            ),
+            patch.object(docs_auditor, "_detect_renamed_link_fixes", return_value=[]),
+            patch.object(
+                docs_auditor,
+                "_resolve_pr_changed_files",
+                return_value=[Path("docs/features/foo.md")],
+            ),
+            patch.object(docs_auditor, "_commit_current_branch"),
+        ):
+            audit_result = docs_auditor.audit(
+                primary_path=None,
+                scope_mode="pr-changed-files",
+                apply_mode="apply",
+                project_key="test",
+                repo_root=repo,
+            )
+
+        assert audit_result["fixes_withheld"] == 1
+        assert audit_result["withheld"][0]["new"] == "ghost_module.py"
+        assert "ghost_module.py" not in p.read_text()
+
+        # Surface 1 — the PR body carries the marker and the offending name.
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, *a, **kw):
+            calls.append(cmd)
+            return MagicMock(returncode=0, stdout="https://github.com/o/r/pull/1", stderr="")
+
+        with (
+            patch("reflections.docs_auditor.subprocess.run", side_effect=fake_run),
+            patch("reflections.docs_auditor._daily_pr_cap_reached", return_value=False),
+            patch("reflections.docs_auditor._has_open_pr_for_slug", return_value=False),
+            patch("reflections.docs_auditor._record_daily_pr"),
+        ):
+            docs_auditor._push_branch_and_pr("slug", repo, withheld=audit_result["withheld"])
+
+        create = next(c for c in calls if c[:3] == ["gh", "pr", "create"])
+        body = create[create.index("--body") + 1]
+        assert docs_auditor.WITHHELD_PR_MARKER in body
+        assert "ghost_module.py" in body
+        # ...and that marker is what makes the PR auto-merge-ineligible.
+        assert self._eligible(body) is False
+
+        # Surfaces 2 and 3 — the Telegram notification and Redis liveness.
+        with (
+            patch("reflections.docs_auditor.PROJECT_ROOT", repo),
+            patch("reflections.docs_auditor._git_dirty", return_value=False),
+            patch("reflections.docs_auditor._run_vault_drift_detection", return_value=0),
+            patch("reflections.docs_auditor.audit", return_value=audit_result),
+            patch("reflections.docs_auditor._send_telegram_notification") as notify,
+            patch("reflections.docs_auditor._update_rotation_hash"),
+            patch("reflections.docs_auditor._write_liveness") as liveness,
+        ):
+            result = docs_auditor.run_docs_auditor()
+
+        assert result["status"] == "ok"
+        assert "1 fix(es) withheld" in notify.call_args.args[0]
+        assert liveness.call_args.kwargs["fixes_withheld"] == 1
 
     def test_rotation_result_surfaces_withheld_count(self, repo, auth_ok, patch_redis):
         primary = repo / "docs" / "features" / "foo.md"

--- a/tests/unit/test_docs_auditor_substrate.py
+++ b/tests/unit/test_docs_auditor_substrate.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
 import subprocess
+import tempfile
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -1299,6 +1301,161 @@ class TestWithheldBlocksAutoMerge:
             docs_auditor.run_docs_auditor()
 
         assert notify.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# TestWithheldRateNonRegression — #2759 AC4
+# ---------------------------------------------------------------------------
+
+
+# The pre-#2759 pattern: `+` requires at least one `dir/` segment, so bare
+# filenames were invisible to the existence invariant. This is the "before" arm.
+_NARROW_PATH_REF_RE = re.compile(r"(?:[\w.-]+/)+[\w.-]+\.(?:py|md)")
+
+
+class TestWithheldRateNonRegression:
+    """Widening ``_PATH_REF_RE`` adds no withholds on the real corpus (#2759 AC4).
+
+    This is the mechanical proof behind the plan's ruling that #2759 does **not**
+    block on #2729 (withheld PRs are auto-merge-ineligible forever and stale-close
+    at day 14). Two measurement paths report a reassuring zero regardless of the
+    change's real effect and are therefore not used:
+
+    1. ``_detect_stale_term_fixes`` alone never reaches ``_absent_new_path_refs``;
+       ``fixes_withheld`` is populated only by ``_apply_fixes_to_file``.
+    2. ``audit(apply_mode="dry-run")`` is *also* wrong — ``_apply_fixes_to_file``
+       is gated on ``apply_mode == "apply"``, so dry-run leaves ``withheld`` empty
+       unconditionally.
+
+    So ``_apply_fixes_to_file`` is driven directly, against a **real git checkout**
+    (both the existence oracle and the ``git ls-files`` basename index need one; a
+    ``tmp_path`` mirror makes every reference read as absent and turns the
+    measurement into noise) — specifically a **disposable detached worktree**, torn
+    down in a ``finally``. Never the live checkout: ``_apply_fixes_to_file`` writes
+    with ``full.write_text``, several agents test on this machine concurrently, and
+    ``pytest-clean.sh`` runs under ``--timeout=420 --timeout-method=thread``, so a
+    restore that does not run is a realistic outcome with another lane's checkout as
+    its blast radius.
+
+    **Self-baselining, no pinned constant.** Both arms are measured in the same run
+    over the same corpus snapshot — narrow ``+`` vs. the shipped widened ``*`` —
+    asserting ``after <= before``. A hard-coded baseline would rot against a corpus
+    the auditor rewrites daily.
+
+    **The fix set deliberately bypasses the migration-context hatch.** After #2744
+    the hatch exempts every doc in the live corpus that mentions a ``STALE_TERMS``
+    key, so ``_detect_stale_term_fixes`` proposes nothing there and a hatch-filtered
+    measurement would be ``0 == 0`` with the invariant never invoked — the third way
+    to report a vacuous zero. Building the fix set straight from ``STALE_TERMS``
+    keeps real corpus text flowing through ``_absent_new_path_refs``, which is the
+    guard AC4 is actually about. The non-vacuity assertions below fail loudly if a
+    future corpus or detector change ever hollows this out.
+    """
+
+    CORPUS_GLOB = "docs/features/*.md"
+
+    @staticmethod
+    def _stale_term_fixes(content: str) -> list[tuple[re.Pattern[str], str]]:
+        """Every ``STALE_TERMS`` rewrite the corpus text could possibly attract."""
+        fixes = []
+        for old_term, new_term in docs_auditor.STALE_TERMS.items():
+            pattern = re.compile(rf"\b{re.escape(old_term)}\b")
+            if pattern.search(content):
+                fixes.append((pattern, new_term))
+        return fixes
+
+    @classmethod
+    def _measure(cls, worktree: Path, *, narrow: bool) -> dict[str, int]:
+        """Run the corpus through ``_apply_fixes_to_file`` under one regex arm.
+
+        Restores the worktree afterwards so the second arm sees the identical
+        snapshot, and clears the basename-index cache (memoized on
+        ``repo_root.resolve()``, i.e. shared by both arms) so neither measurement
+        answers from the other's snapshot.
+        """
+        saved_re = docs_auditor._PATH_REF_RE
+        saved_invariant = docs_auditor._absent_new_path_refs
+        invariant_calls = 0
+
+        def _spy(*args, **kwargs):
+            nonlocal invariant_calls
+            invariant_calls += 1
+            return saved_invariant(*args, **kwargs)
+
+        docs_auditor._absent_new_path_refs = _spy
+        if narrow:
+            docs_auditor._PATH_REF_RE = _NARROW_PATH_REF_RE
+        docs_auditor._BASENAME_INDEX_CACHE.clear()
+
+        withheld_total = 0
+        visible_refs: set[str] = set()
+        try:
+            for full in sorted(worktree.glob(cls.CORPUS_GLOB)):
+                content = full.read_text(encoding="utf-8", errors="replace")
+                visible_refs |= set(docs_auditor._PATH_REF_RE.findall(content))
+                fixes = cls._stale_term_fixes(content)
+                if not fixes:
+                    continue
+                _, withheld = docs_auditor._apply_fixes_to_file(
+                    full.relative_to(worktree), worktree, [], regex_fixes=fixes
+                )
+                withheld_total += len(withheld)
+        finally:
+            docs_auditor._PATH_REF_RE = saved_re
+            docs_auditor._absent_new_path_refs = saved_invariant
+            docs_auditor._BASENAME_INDEX_CACHE.clear()
+            subprocess.run(
+                ["git", "checkout", "--", "."], cwd=worktree, check=True, capture_output=True
+            )
+
+        return {
+            "withheld": withheld_total,
+            "invariant_calls": invariant_calls,
+            "visible_refs": len(visible_refs),
+        }
+
+    def test_widening_path_ref_re_adds_no_withholds(self):
+        repo_root = Path(docs_auditor.__file__).resolve().parents[1]
+        if not (repo_root / ".git").exists():
+            pytest.skip("not a git checkout — the existence oracle needs a real index")
+
+        holder = Path(tempfile.mkdtemp(prefix="docs-auditor-withheld-rate-"))
+        worktree = holder / "corpus"
+        subprocess.run(
+            ["git", "worktree", "add", "--detach", str(worktree), "HEAD"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+        )
+        try:
+            before = self._measure(worktree, narrow=True)
+            after = self._measure(worktree, narrow=False)
+        finally:
+            subprocess.run(
+                ["git", "worktree", "remove", "--force", str(worktree)],
+                cwd=repo_root,
+                check=False,
+                capture_output=True,
+            )
+            shutil.rmtree(holder, ignore_errors=True)
+            docs_auditor._BASENAME_INDEX_CACHE.clear()
+
+        # The two arms must genuinely differ, or "after <= before" is a tautology
+        # over one pattern measured twice.
+        assert after["visible_refs"] > before["visible_refs"], (
+            f"widening made no new refs visible ({after} vs {before}) — "
+            "the narrow arm is not being applied"
+        )
+        # ...and the guard being measured must actually have run.
+        assert before["invariant_calls"] > 0 and after["invariant_calls"] > 0, (
+            f"the existence invariant was never invoked ({before}, {after}) — "
+            "the measurement is vacuous, not clean"
+        )
+        # #2759 AC4: widening `original_refs` and the candidate scan symmetrically
+        # costs no new withholds, because `_absent_new_path_refs` is additive-only.
+        assert after["withheld"] <= before["withheld"], (
+            f"widening _PATH_REF_RE raised the withheld count: {before} -> {after}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_docs_auditor_substrate.py
+++ b/tests/unit/test_docs_auditor_substrate.py
@@ -669,8 +669,27 @@ class TestStaleTermDictionary:
             assert isinstance(pattern, re.Pattern)
             assert isinstance(new, str)
 
-    def test_absent_key_emits_no_fix(self):
-        assert docs_auditor._detect_stale_term_fixes("Nothing stale here at all.") == []
+    def test_cue_word_inside_a_larger_word_does_not_exempt(self):
+        """Tier-2 cue words are word-anchored, not substring tests (plan Risk 1).
+
+        ``old`` is a substring of ``threshold``, ``placeholder``, ``holds``,
+        ``bold`` — all common in this corpus. With an unanchored test, tier 2
+        degenerates into "the document mentions the new term somewhere", which is
+        exactly the over-exemption the anti-over-exemption guard claims to
+        prevent. Measured live: ``docs/guides/summarizer-output-audit.md`` was
+        exempted for ``RedisJob`` solely because it contains ``threshold``.
+        """
+        content = (
+            "The summarize_threshold controls how many turns are batched.\n"
+            "`AgentSession` rows are written once per turn.\n"
+            "The SessionLog is queried directly by the dashboard.\n"
+        )
+        assert docs_auditor._detect_stale_term_fixes(content) != []
+
+    @pytest.mark.parametrize("content", ["", "   \n\n  ", "Nothing stale here at all."])
+    def test_absent_key_emits_no_fix(self, content):
+        """Empty, whitespace-only, and stale-term-free content all yield no fix."""
+        assert docs_auditor._detect_stale_term_fixes(content) == []
 
 
 # ---------------------------------------------------------------------------
@@ -999,6 +1018,90 @@ class TestExistenceInvariant:
         )
         assert (applied, withheld) == (0, [])
         assert p.read_text() == body
+
+    # -- degraded `git ls-files`, the only new failure surface ---------------
+
+    @pytest.fixture()
+    def clear_basename_cache(self):
+        """The index is memoized per repo root; assert against a live call, not a hit."""
+        docs_auditor._BASENAME_INDEX_CACHE.clear()
+        yield
+        docs_auditor._BASENAME_INDEX_CACHE.clear()
+
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            pytest.param(
+                lambda: MagicMock(returncode=1, stdout="", stderr="fatal: not a git repository"),
+                id="nonzero-rc",
+            ),
+            pytest.param(
+                lambda: (_ for _ in ()).throw(OSError("git: command not found")),
+                id="oserror",
+            ),
+        ],
+    )
+    def test_ls_files_failure_warns_and_yields_empty_index(
+        self, repo, caplog, clear_basename_cache, failure
+    ):
+        """Plan Risk 3 / Failure Path Test Strategy: the forced-failure case.
+
+        A failed index must be loud (``logger.warning``) and empty, never a
+        partially-populated dict that silently answers "absent" for real names.
+        """
+        with (
+            patch.object(docs_auditor.subprocess, "run", side_effect=lambda *a, **k: failure()),
+            caplog.at_level("WARNING", logger="reflections.docs_auditor"),
+        ):
+            index = docs_auditor._repo_basename_index(repo)
+
+        assert index == {}
+        assert any(
+            r.levelname == "WARNING" and "git ls-files" in r.getMessage() for r in caplog.records
+        ), "a degraded basename index must warn"
+
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            pytest.param(
+                lambda: MagicMock(returncode=1, stdout="", stderr="fatal: not a git repository"),
+                id="nonzero-rc",
+            ),
+            pytest.param(
+                lambda: (_ for _ in ()).throw(OSError("git: command not found")),
+                id="oserror",
+            ),
+        ],
+    )
+    def test_dir_prefixed_decisions_unaffected_by_degraded_index(
+        self, repo, doc, clear_basename_cache, failure
+    ):
+        """Degradation is scoped to bare names; ``dir/file.py`` never consults the index.
+
+        The fallback must not leak into the path class that already worked, in
+        either direction: an absent dir-prefixed target still withholds and a
+        present one still applies.
+        """
+        (repo / "agent" / "renamed.py").write_text("")
+        with patch.object(docs_auditor.subprocess, "run", side_effect=lambda *a, **k: failure()):
+            applied, withheld = docs_auditor._apply_fixes_to_file(
+                doc,
+                repo,
+                [("agent/real.py", "agent/ghost.py"), ("agent/other.py", "agent/renamed.py")],
+            )
+
+        assert applied == 1
+        assert withheld == [
+            {
+                "doc": str(doc),
+                "old": "agent/real.py",
+                "new": "agent/ghost.py",
+                "reason": "target-absent",
+            }
+        ]
+        text = (repo / doc).read_text()
+        assert "agent/renamed.py" in text
+        assert "agent/ghost.py" not in text
 
     def test_ok_result_carries_withheld_keys(self):
         res = docs_auditor._ok_result("ok")

--- a/tests/unit/test_docs_auditor_substrate.py
+++ b/tests/unit/test_docs_auditor_substrate.py
@@ -970,9 +970,19 @@ class TestExistenceInvariant:
         assert withheld == []
         assert "vanished_module.py" in p.read_text()
 
-    def test_regex_channel_is_also_guarded(self, repo, doc):
+    def test_regex_channel_is_also_guarded(self, repo):
+        # The fixture's match must sit in ordinary prose, NOT inside a path token:
+        # path-token suppression (#2744) refuses an in-token rewrite before the
+        # existence invariant ever sees it, so a fixture like ``\breal\b`` over
+        # ``agent/real.py`` would withhold nothing and prove nothing here. Do not
+        # "simplify" this back to rewriting a word inside a path.
+        p = repo / "docs" / "features" / "regex_inv.md"
+        p.write_text("The runtime lives in the real handler.\n")
         applied, withheld = docs_auditor._apply_fixes_to_file(
-            doc, repo, [], regex_fixes=[(re.compile(r"\breal\b"), "ghost")]
+            Path("docs/features/regex_inv.md"),
+            repo,
+            [],
+            regex_fixes=[(re.compile(r"\breal\b"), "agent/ghost.py")],
         )
         assert applied == 0
         assert len(withheld) == 1


### PR DESCRIPTION
## Summary

Closes two holes in `reflections/docs_auditor.py` that let an unreviewed autonomous committer write false statements into `main`. Both live in the same ~50 lines, both are the "autonomous writer makes a doc false" class, and fixing one without the other leaves the PR half-safe.

- **#2744** — the `migration_context` escape hatch never fired on the corpus's dominant phrasing (the six bare substring tests could not see `` formerly `RedisJob` `` because the corpus backticks its terms). Three live docs queued rewrites turning correct migration prose into sentences saying the new name was formerly itself, all with `fixes_withheld = 0` so auto-merge cleared them unread.
- **#2759** — `_PATH_REF_RE` required at least one directory segment, so bare filenames (`README.md`, `agent_session.py`) were invisible to the existence invariant. That is the #2711 corruption shape minus a directory prefix, and #2711 was a real committed corruption (`d7bf3ad99`).

## Four fail-closed gates now guard every rewrite

1. **Migration-context hatch** — `_normalize_prose` (strips backticks, collapses whitespace, lowercases; cue matching only, never output) plus a generated two-tier cue set. Directed cues per `(old, new)` pair, plus `_MIGRATION_CUE_WORDS` that fire only when the new term also appears in the document (the anti-over-exemption guard). Deliberately **document-scoped**: spike-2 measured line-scoping as strictly worse, re-exposing 8 occurrences real prose correctly exempts, because migration context sits in a different sentence from the term.
2. **Context suppression** — `_build_line_context` / `_is_documented_deletion` (fenced blocks, deletion headings, adjacent deletion prose) wired into stale terms.
3. **Path-token suppression** — a match inside a `(?:[\w.-]+/)*[\w.-]+\.(?:py|md)` token is never rewritten. This closes `models/session_log.py` -> `models/agent_session.py`, which the existence invariant provably cannot catch because both files exist.
4. **Existence invariant** — `_PATH_REF_RE` widened `+` -> `*`; `_absent_new_path_refs` gained `doc_path` and resolves bare refs doc-relative first, then via a per-run `git ls-files --cached --others --exclude-standard` basename index.

**Gates 2 and 3 are computed at APPLY time, never at detection time.** `_apply_fixes_to_file` applies the literal `fixes` list first, including `_detect_readme_broken_entries`' `new == ""` whole-line-delete sentinel, and only then runs the regex fixes over the already-mutated text. A detection-time line index is stale the moment a line is deleted ahead of it, and it fails *silently* (a plausible wrong rewrite, not an error) which is exactly the corruption class this PR exists to close. The replacement callable is built inside `_apply_fixes_to_file`'s regex loop and re-derives context from `match.string` / `match.start()`. `_detect_stale_term_fixes` still returns `(re.Pattern, str)`; the channel contract is unchanged and `test_fixes_travel_on_the_regex_channel` passes byte-for-byte unmodified.

Suppressed matches still increment `subn`'s counter, so suppressions are tallied in a closure cell and `applied` is reported as `subn_count - suppressed_count`, with an `if candidate == new_text: continue` guard for the all-suppressed case. `_reject` still receives the replacement *string*, so withheld records stay readable in the PR body, findings summary, and warning log.

## Rulings recorded (with evidence, in code and in the feature doc)

- **Ambiguity is not a withhold.** `>=1 match => passes` (DEBUG-logged when `>1`); `0 matches => withhold`. The invariant asks "does this name denote something real", not "is it unambiguous". 218 ambiguous refs over 108 multi-owner basenames; ambiguity never produced #2711, a name existing nowhere did.
- **The sibling patterns in `_detect_renamed_symbol_fixes` and `_detect_deleted_target_issues` stay narrower**, with the reason in a code comment naming #2759. They are detector-side, not write-path; widening them spends the `GIT_LOG_FOLLOW_CAP` and per-run issue-cap budgets on names not resolvable to a single path.
- **This lane did not need to wait on #2729**, because the widening's measured new-withhold count is zero.

## Measured outcome

| Doc | Before | After |
|---|---|---|
| `docs/features/popoto-redis-expansion.md` | 3 occurrences rewritten | **0** |
| `docs/guides/agent-session-migration-audit.md` | 8 occurrences rewritten | **0** |
| `docs/guides/summarizer-output-audit.md` | 7 occurrences rewritten | **1** (the accepted residual) |
| **total** | **18** | **1** |

**Corrected after review (this table previously read `0` and `18 -> 0`).** The plan predicted and accepted exactly one residual: the quoted-transcript line at `summarizer-output-audit.md:68`, *"**Example 3** (10:52, fixing RedisJob refs):"*. An earlier revision of this PR reported that residual as not firing and attributed the zero to the document-scoped hatch's second cue tier working as designed. That attribution was wrong. The tier-2 cue-word test was an unanchored substring match, so `old` fired from inside `summarize_threshold` and exempted the whole document by accident. Anchoring the cue words (commit `7a9b1e89e`) restores the designed behavior and returns the residual to 1, which is what the plan's success criterion specifies: *"at most **one** changed occurrence (the accepted `:68` residual), down from five."*

The `:68` residual is filed as a follow-up comment on #2744 per the plan's No-Gos section.

**The detector is quiet, not dead.** Across all `docs/**/*.md` outside `docs/plans/`, exactly one stale-term proposal survives — the accepted `summarizer-output-audit.md:68` residual, re-measured after the cue-word anchoring fix — and the four docs still carrying a `STALE_TERMS` key are all genuine migration/audit prose where any rewrite would produce a false sentence (alias lines would become `AgentSession = AgentSession`; the shim-location line would point at a file that is not the shim). A synthetic no-migration-context sentence still queues a fix, so the drop is attributable to suppression working rather than detection breaking.

`TestWithheldRateNonRegression` proves #2759 AC4 mechanically: it drives `_apply_fixes_to_file` directly inside a disposable `git worktree add --detach` (never the live checkout, which it would rewrite), and is self-baselining — both arms measured in one run over one corpus snapshot, `_PATH_REF_RE` monkeypatched to the narrow `+` form vs the shipped widened `*` form. Result: narrow 1025 visible refs / 0 withheld, widened 1569 visible refs / 0 withheld. `after <= before` holds, with explicit non-vacuity assertions so a future corpus change that hollows the measurement out fails loudly instead of passing green.

## Demonstrated-red paper trail

Every behavioral fix landed with a test proven **failing first**, before any production edit (commit `739fc03af`, tests only). Verbatim red output:

**Run 1** — `POPOTO_TEST_DB=9 ./scripts/pytest-clean.sh tests/unit/test_docs_auditor_substrate.py -k "StaleTerm" -q` -> **10 failed, 12 passed**

```
FAILED ...::TestStaleTermDictionary::test_migration_context_skips_fix[The `SessionLog` has been renamed to `AgentSession`.]
FAILED ...::TestStaleTermDictionary::test_migration_context_skips_fix[`RedisJob` was replaced by `AgentSession` in the same pass.]
FAILED ...::TestStaleTermDictionary::test_migration_context_skips_fix[Formerly `RedisJob`, this model is now `AgentSession`.]
FAILED ...::TestStaleTermDictionary::test_migration_context_skips_fix[The compat shim declares `SessionLog = AgentSession` for old imports.]
FAILED ...::TestStaleTermDictionary::test_migration_context_skips_fix[Rename map: `SessionLog` -> `AgentSession` across all call sites.]
FAILED ...::TestStaleTermDictionary::test_migration_context_skips_fix[Rename map: `SessionLog` → `AgentSession` across all call sites.]
FAILED ...::TestStaleTermDictionary::test_migration_context_skips_fix[`AgentSession` lands, replacing both the earlier `SessionLog` and `RedisJob` models.]
FAILED ...::TestStaleTermWordBoundary::test_apply_leaves_session_logs_path_untouched
FAILED ...::TestStaleTermWordBoundary::test_stale_term_inside_fenced_block_is_not_rewritten
FAILED ...::TestStaleTermWordBoundary::test_suppression_survives_an_earlier_line_deletion
```

The line-shift fixture is the most informative failure and confirms the apply-time design ruling empirically:

```
tests/unit/test_docs_auditor_substrate.py:801: in test_suppression_survives_an_earlier_line_deletion
    assert "`SessionLog` model no longer exists" in text
E   AssertionError: assert '`SessionLog` model no longer exists' in
    '# Feature Index\n\n- [Kept](kept.md)\n\nThe `AgentSession` model no longer exists.\n
     It was superseded during the Popoto consolidation.\n'
```

The earlier `- [Gone](gone.md)` line was deleted by the `new == ""` sentinel *and* the later stale term was rewritten in the same apply, so the fixture genuinely exercises the index-shift window. The assertion is on file content, not on an exception, because detection-time index suppression fails silently.

**Run 2** — `POPOTO_TEST_DB=9 ./scripts/pytest-clean.sh tests/unit/test_docs_auditor_substrate.py -k "Existence or Withheld" -q` -> **3 failed, 21 passed**

```
FAILED ...::TestExistenceInvariant::test_fix_introducing_absent_bare_name_is_withheld
    assert applied == 0   /   E   assert 1 == 0
FAILED ...::TestExistenceInvariant::test_ambiguous_bare_name_passes_and_debug_logs
    E   AssertionError: ambiguous bare-name resolution must be DEBUG-logged
FAILED ...::TestWithheldBlocksAutoMerge::test_bare_name_withhold_propagates_to_pr_body_telegram_and_liveness
    assert audit_result["fixes_withheld"] == 1   /   E   assert 0 == 1
```

All 13 are green after the fixes. Two further new tests (`test_bare_name_resolvable_in_doc_directory_passes`, `test_preexisting_absent_bare_name_is_never_revalidated`) are green against `main` by construction: they assert the *absence* of a withhold, and `main` withholds nothing for bare names. They are the over-withholding guard and go red if bare refs resolve against the repo root instead of the doc's directory, or if the `original_refs` subtraction that makes the widening additive-only is dropped.

One pre-existing test, `TestExistenceInvariant::test_regex_channel_is_also_guarded`, needed a fixture repair: its `\breal\b` match landed inside the path token `agent/real.py`, so gate 3 now pre-empts gate 4 and there was nothing left to withhold. The fixture was changed so the match sits in prose while the replacement still introduces an absent path ref. Name, intent, and assertions are unchanged, and a comment records why it cannot be simplified back.

## Testing

- [x] `POPOTO_TEST_DB=9 ./scripts/pytest-clean.sh tests/unit/test_docs_auditor_substrate.py -q` -> **136 passed**
- [x] All 14 rows of the plan's Verification table pass
- [x] Lint/format clean (`ruff check`, `ruff format --check`)
- [x] No `xfail` markers, no `except Exception: pass` introduced

## Documentation

- [x] `docs/features/docs-auditor.md` rewritten around the four gates, with the document-scope ruling, the apply-time-suppression rationale, the bare-name resolution order, the ambiguity ruling, and the sibling-pattern reason
- [x] `_detect_stale_term_fixes` docstring rewritten (its old "stops short of *never rewrites a path*" sentence is now false and is gone)
- [x] `_absent_new_path_refs` docstring carries the resolution order and ambiguity ruling
- [x] `docs/features/README.md` index line verified accurate, no change needed

## Scope

The diff touches exactly `reflections/docs_auditor.py`, `tests/unit/test_docs_auditor_substrate.py`, and `docs/features/docs-auditor.md`. `_pr_is_auto_merge_eligible`, `_push_branch_and_pr`, `_commit_current_branch`, and `run_docs_branch_sweeper` are untouched (#2739's region, verified by an anti-criterion grep).

## Definition of Done
- [x] Built: four gates implemented and working
- [x] Tested: 136 passing, every fix demonstrated red first
- [x] Documented: feature doc and inline docstrings updated
- [x] Quality: lint and format clean

Closes #2744
Closes #2759


