### PR TITLE
Anchor the SDLC lease heartbeat to its supervisor's lifetime

### DIFF
--- a/.claude/skills-global/do-sdlc/SKILL.md
+++ b/.claude/skills-global/do-sdlc/SKILL.md
@@ -248,6 +248,30 @@ On exit (any path), report:
 3. **Artifacts**: issue, plan path, PR number, merge commit
 4. **Anything needing human attention**: unresolved blockers, skipped acknowledgments, follow-ups
 
+## Step 5: Release the run lease
+
+You hold this issue's run lease for as long as this supervision loop lives, and
+nothing reclaims it when you simply stop — there is no terminal transition on a
+HALT. Left held, it makes the *next* run on this issue refuse with a foreign-owner
+block until the lease's ceiling lapses hours later.
+
+So after the Final Report, hand the lease back with the pipeline tool's
+**`session-release`** subcommand, passing this run's issue number and `run_id`
+(see the repo context probe for the exact invocation). It is ownership-checked
+and best-effort: a wrong or already-released `run_id` is a safe no-op, so run it
+whenever in doubt and never let its output change your reported outcome.
+
+Do this on the exits nothing else observes:
+
+- the **3d.4 REVIEW self-check HALT**
+- a **`blocked`** router decision (3a / 3e)
+- the **iteration cap** being reached
+
+The **merged** exit needs no action from you — completing the MERGE stage
+releases the lease in the tool layer, on the marker write itself. Running the
+step there anyway is harmless (it reports no lease held), but it is not what
+makes the merged path correct.
+
 ## Relationship to /sdlc (in this repo)
 
 | | `/sdlc` (in this repo) | `/do-sdlc` |

--- a/agent/supervised_run.py
+++ b/agent/supervised_run.py
@@ -37,8 +37,12 @@ the single source of truth for "is this run still the owner."
 
   All three renewers write only after confirming they still own the lease, so a
   signal is never republished over a successor's. The fourth writer matters
-  most for long runs: the heartbeat self-exits at 4h, after which the ledger
-  gate is the only renewer left.
+  most for long runs, because the heartbeat's exit is no longer a single 4h
+  backstop (issue #2714): it exits within ~2 checks of its supervising
+  ``claude`` process dying (releasing the lease and clearing this signal), at
+  90 minutes when no supervisor identity resolved (leaving both to their own
+  TTL), and otherwise still at the unchanged 4h ceiling. After any of those the
+  ledger gate is the only renewer left.
 
   Issue #2659: the renew half was missing for the first two years of this key's
   life, so the signal expired 1800s into every pipeline while the lease was

--- a/docs/features/sdlc-issue-ownership-lock.md
+++ b/docs/features/sdlc-issue-ownership-lock.md
@@ -313,11 +313,11 @@ Three paths extend the lease, and all three refresh the signal, each only after 
 
 | Renewer | Ownership proof before the signal write |
 |---|---|
-| `tools/sdlc_lease_heartbeat.py` (local supervisor, not in the table above) | its peek-confirmed `owner_run_id == run_id` match |
+| `tools/sdlc_lease_heartbeat.py` (local supervisor, not in the table above) | its peek-confirmed `owner_run_id == run_id` match, then a `renew_only=True` extend |
 | `agent/session_executor.py::_tick_issue_lock_renewal` (worker, 60s) | an `acquired` result |
 | `tools/_sdlc_utils.py::revalidate_ledger_lease` (every ledger-write gate — see below) | an `acquired` result |
 
-The third matters more than it looks, and it reaches further than the two tools first associated with it. `revalidate_ledger_lease` is non-peek, so **all five of its callers** renew the lease on their own: `tools/sdlc_stage_marker.py` (three sites), `tools/sdlc_dispatch.py`, `tools/sdlc_verdict.py`, `tools/sdlc_meta_set.py`, and `tools/sdlc_review_finalize.py`. The local heartbeat self-exits at `MAX_LIFETIME_SECONDS` (4h), after which those gates are the only renewer left. Without the refresh there, a pipeline past ~4.5h would lose its signal under a lease those writes were holding up, reproducing the #2659 wedge exactly. The observed incidents were at roughly 3.5h, so that window is reachable rather than theoretical.
+The third matters more than it looks, and it reaches further than the two tools first associated with it. `revalidate_ledger_lease` is non-peek, so **all five of its callers** renew the lease on their own: `tools/sdlc_stage_marker.py` (three sites), `tools/sdlc_dispatch.py`, `tools/sdlc_verdict.py`, `tools/sdlc_meta_set.py`, and `tools/sdlc_review_finalize.py`. The local heartbeat's own renew loop stops at `MAX_LIFETIME_SECONDS` (4h, on a resolved supervisor) or `UNSUPERVISED_MAX_LIFETIME_SECONDS` (90 min, unresolved) -- see [Heartbeat exit conditions and release paths](#heartbeat-exit-conditions-and-release-paths-issue-2714) below -- after which those gates are the only renewer left. Without the refresh there, a pipeline past ~4.5h would lose its signal under a lease those writes were holding up, reproducing the #2659 wedge exactly. The observed incidents were at roughly 3.5h, so that window is reachable rather than theoretical.
 
 Ownership-first ordering is the safety property. Writing the signal before the ownership check would republish a non-owner's `run_id` over a live successor's, which **denies the successor's forks their inheritance signal and re-creates the #2659 wedge**. It does not hand anyone the wrong `run_id`: `supervised_run_status` reports `live=True` only when the signal's `run_id` equals the lock peek's `owner_run_id`, so a mis-owned signal reads not-live and is never inherited. That liveness anchor is what bounds the damage to a stand-down rather than a takeover.
 
@@ -326,6 +326,24 @@ Ownership-first ordering is the safety property. Writing the signal before the o
 Before #2659 the signal was written only on acquire, so it expired 1800s into every pipeline while the lease was renewed indefinitely. From minute 30 onward every stage fork the supervisor dispatched got a bare `ISSUE_LOCKED` from its own supervisor's lock and stood down -- correctly, per the substrate-probe rule, since only `SUPERVISED_RUN_ACTIVE` means inherit-and-continue. The pipeline wedged with a live lock, a live heartbeat, and no error anywhere. Both carriers now share the renewers' lifetime: the signal cannot outlive the lease, and the lease cannot outlive the signal by more than one renewal interval.
 
 The worktree `.sdlc-run` file carrier is deliberately not refreshed on renew -- it has no TTL, and is cleared by `clear_supervised_run_signal` on the run's terminal transition.
+
+### Heartbeat exit conditions and release paths (issue #2714)
+
+**A renewer never mints.** `touch_issue_lock(..., renew_only=True)` is the mode the heartbeat's extend uses: it skips both minting branches (`SET NX` on an absent key, and the since-expired-key-reads-as-free branch) and writes through a compare-and-set Lua script that only lands if the stored value is still byte-identical to the one this call just read. A release landing between the peek and the extend makes the write a no-op instead of recreating the key -- structurally, not by convention, so a zombie heartbeat can never re-acquire a lease its supervisor already gave up. A `renew_only` call also fails **closed** on a Redis error (`acquired=False`), the one exception to `touch_issue_lock`'s default fail-open behavior: reporting ownership it cannot verify is exactly the shape the mode exists to eliminate.
+
+The heartbeat's own exits:
+
+| Exit reason | Trigger | Releases the lease? |
+|---|---|---|
+| `lease_lost` / `foreign_owner` | The peek finds the lease absent, or owned by a different `run_id` | No -- nothing to release, or a successor already owns it |
+| `supervisor_dead` | Two consecutive positive-death observations of the recorded `(pid, create_time)` | Yes -- releases the lease and clears the supervised-run signal, then exits (~120s bound from a kill) |
+| `max_lifetime` | `MAX_LIFETIME_SECONDS` (4h) reached with a resolved supervisor | No -- the supervisor watch is the real death detector; this is only a backstop |
+| `unsupervised_max_lifetime` | `UNSUPERVISED_MAX_LIFETIME_SECONDS` (90 min) reached with no resolvable supervisor | No -- an unresolvable supervisor is not proof of death; the lease is left to lapse on its own TTL |
+
+**Explicit release, alongside `finalize_session`.** Two additional paths hand the lease back deliberately, independent of the heartbeat:
+
+- **`tools/sdlc_stage_marker.py`'s stage-marker MERGE leg.** A successful, non-idempotent `MERGE`/`completed` marker write calls `release_run` (below) in the tool layer itself -- path-agnostic, firing for `/do-sdlc`, the `/sdlc` router, and worker-driven pipelines with zero skill cooperation.
+- **`sdlc-tool session-release`** (`tools/sdlc_session_release.py`). The `/do-sdlc` skill body's Step 5 calls this on the exits the tool-layer leg cannot observe: the REVIEW self-check HALT, a `blocked` router decision, and the iteration cap. It wraps `release_issue_lock` (compare-and-delete) followed by `clear_supervised_run_signal`, both already keyed on `run_id`, so a wrong or stale `run_id` is a safe no-op rather than a foreign-run's lease being dropped.
 
 ### Every ledger-write gate renews
 
@@ -381,12 +399,14 @@ The deploy runbook pairs the merge with an immediate worker restart: `./scripts/
 | `models/session_lifecycle.py` | `touch_issue_lock()`, `release_issue_lock()`, `_lock_owner_is_live()`, `IssueLockResult`, `ISSUE_LOCK_TTL_SECONDS` |
 | `tools/sdlc_session_ensure.py` | `_iter_orphan_sessions()`, `_issue_lock_payload_for_session()`, `_last_activity_at()` (idle-window fallback only) |
 | `models/agent_session.py` | `issue_number` mirror field; `active_run_id` field; `owned_run_ids` accumulated self-recognition set (issue #2446/#2451, see [SDLC Run Self-Recognition](sdlc-run-self-recognition.md)) |
-| `tools/sdlc_lease_heartbeat.py` | Peek-first renew-only detached lease-heartbeat for the local `/do-sdlc` supervisor (issue #2446/#2451) |
+| `tools/sdlc_lease_heartbeat.py` | Peek-first, `renew_only=True`-extending detached lease-heartbeat for the local `/do-sdlc` supervisor; polls the recorded supervisor identity and releases on confirmed death (issue #2446/#2451/#2714) |
+| `tools/sdlc_supervisor_identity.py` | `resolve_supervisor_identity_detailed()` -- resolves the supervising `claude` process's `(pid, create_time)` via `CLAUDE_PID` env then a `psutil` ancestry walk (issue #2714) |
+| `tools/sdlc_session_release.py` | `release_run()` / `sdlc-tool session-release` -- releases the issue lease + supervised-run signal for a run_id, ownership-checked (issue #2714) |
 | `tools/sdlc_session_ensure.py` | `ensure_session()`'s return-point wiring; `_acquire_run_lock_and_bind()` (exclusive run_id mint site) |
 | `tools/_sdlc_utils.py` | `find_session_by_issue(include_terminal=...)`, `renew_issue_lock_for_session()`, `check_run_ownership()`, `resolve_ledger_lease()`/`revalidate_ledger_lease()` (writer lease checks, issue #2012), `resolve_target_repo_for_read()` (reader lease-first repo resolution, issue #2012) |
 | `agent/pipeline_ledger.py` | `PipelineLedger` -- the durable, issue-keyed record this lock's `target_repo` field authorizes writes to (issue #2012; see [`docs/features/sdlc-issue-keyed-stage-ledger.md`](sdlc-issue-keyed-stage-ledger.md)) |
 | `tools/sdlc_dispatch.py` | `record_dispatch_for_session()`'s direct lock call; `_peek_issue_lock_conflict()` + `_cli_record()`'s post-failure disambiguation; `--run-id` CLI flag |
-| `tools/sdlc_stage_marker.py` | `--run-id` CLI flag; ownership guard + renewal call |
+| `tools/sdlc_stage_marker.py` | `--run-id` CLI flag; ownership guard + renewal call; `_release_run_best_effort()` on the MERGE-completed transition (issue #2714) |
 | `tools/sdlc_verdict.py` | `--run-id` CLI flag on `verdict record`; ownership guard (no renewal) |
 | `tools/sdlc_meta_set.py` | `--run-id` CLI flag on state-mutating keys (e.g. `pr_number`); ownership guard (no renewal) |
 | `tools/sdlc_next_skill.py` | `decide()`'s peek pre-check |

--- a/docs/features/sdlc-local-supervision.md
+++ b/docs/features/sdlc-local-supervision.md
@@ -16,9 +16,24 @@ The supervisor never decides dispatch itself — `sdlc-tool next-skill` (→ `ag
 
 The `sdlc-local-{N}` anchor created by `session-ensure` in step 1 is a bookkeeping record, not a job for a worker to run: it is created with `is_ledger=True`, and every worker recovery/pickup guard skips past it rather than requeuing or executing it. This keeps a live standalone `python -m worker` process from mistaking the anchor for orphaned work and driving the same issue a second time in parallel with this local supervisor. See [Eng Session Architecture](eng-session-architecture.md#sdlc-local-session-is_ledger-non-executable-flag-issue-2042) for the full guard-site catalogue.
 
-### Lease Heartbeat (issue #2446/#2451)
+### Lease Heartbeat (issue #2446/#2451/#2714)
 
-Unlike the worker, which keeps its issue lock alive via the in-process 60s `_tick_issue_lock_renewal` tick, this supervisor is a per-turn `claude -p` subprocess blocked inside a synchronous stage call -- it has no equivalent in-process renewer. `session-ensure` closes that gap on a fresh local mint by launching `tools/sdlc_lease_heartbeat.py` as a **detached** subprocess: a peek-first, renew-only loop that extends the lease every `ISSUE_LOCK_TTL_SECONDS // 3` and self-terminates once the lease is no longer owned by its `run_id` or after a bounded max lifetime. The wiring lives entirely in `tools/sdlc_session_ensure.py` -- no edit to this skill body was required. If the lease still lapses (e.g. a Redis hiccup outlasting the heartbeat), the `AgentSession.owned_run_ids` accumulated set lets a stage fork carrying the prior `run_id` be recognized as self and inherit the re-minted identity instead of aborting. See [SDLC Run Self-Recognition](sdlc-run-self-recognition.md) for the full mechanism.
+Unlike the worker, which keeps its issue lock alive via the in-process 60s `_tick_issue_lock_renewal` tick, this supervisor is a per-turn `claude -p` subprocess blocked inside a synchronous stage call -- it has no equivalent in-process renewer. `session-ensure` closes that gap on a fresh local mint by launching `tools/sdlc_lease_heartbeat.py` as a **detached** subprocess: a peek-first loop that extends the lease every `ISSUE_LOCK_TTL_SECONDS // 3` through a `renew_only=True` compare-and-set write (`touch_issue_lock`'s two minting branches are structurally skipped, so this renewer can never mint a lease nobody holds) and exits once the lease is no longer owned by its `run_id`.
+
+The heartbeat's lifetime is anchored to evidence about its supervisor, not a fixed clock. `session-ensure` resolves the supervising `claude` process's identity -- `CLAUDE_PID` env var, then a `psutil` ancestry walk, then unresolved -- at mint time (the only moment the detached child is still inside that process tree) and hands `(pid, create_time)` to the heartbeat on its argv. The heartbeat polls that identity every `SDLC_SUPERVISOR_CHECK_INTERVAL_SECONDS` (default 60s), decoupled from the renew cadence, and on two consecutive positively-established death observations (`SDLC_SUPERVISOR_DEATH_CONFIRMATIONS`) it releases the lease and the supervised-run signal and exits -- a killed supervisor's lease is gone in roughly two minutes rather than waiting on a multi-hour ceiling. Every decision (start, each exit) is logged at INFO to `logs/sdlc_lease_heartbeat.log`.
+
+When the supervisor resolves, the unchanged 4h `MAX_LIFETIME_SECONDS` backstop still applies -- the supervisor watch is the real death detector, so a live long-running BUILD stage is never cut off by the ceiling. When no supervisor identity can be resolved, a tighter 90-minute `UNSUPERVISED_MAX_LIFETIME_SECONDS` ceiling applies instead, and that exit stops renewing **without releasing** -- an unresolvable supervisor is not proof of death, so the lease is left to lapse on its own 1800s TTL (total exposure ≤2h on that path only).
+
+If the lease still lapses (e.g. a Redis hiccup outlasting the heartbeat), the `AgentSession.owned_run_ids` accumulated set lets a stage fork carrying the prior `run_id` be recognized as self and inherit the re-minted identity instead of aborting. See [SDLC Run Self-Recognition](sdlc-run-self-recognition.md) for the full mechanism.
+
+### Lease release on exit (issue #2714)
+
+Nothing reclaims the lease when the supervisor loop simply stops -- there is no terminal transition on a HALT. Two release paths close that:
+
+- **Tool-layer, path-agnostic.** A successful, non-idempotent `MERGE`/`completed` stage-marker write releases the lease and clears the supervised-run signal in `tools/sdlc_stage_marker.py` itself, so it fires for `/do-sdlc`, the `/sdlc` router, and worker-driven pipelines alike with zero skill cooperation.
+- **`/do-sdlc` Step 5.** On the exits the tool layer cannot observe -- the REVIEW self-check HALT, a `blocked` router decision, or the iteration cap -- Step 5 invokes `sdlc-tool session-release --issue-number {n} --run-id {run_id}` after the Final Report. It is ownership-checked and best-effort: a wrong or already-released `run_id` is a safe no-op. See `docs/sdlc/do-sdlc.md` for the concrete invocation and reason-code table.
+
+See [SDLC Issue Ownership Lock](sdlc-issue-ownership-lock.md) for the full renewer/release call-site catalogue.
 
 ## Refusal discrimination (issue #2452)
 

--- a/docs/features/sdlc-pipeline.md
+++ b/docs/features/sdlc-pipeline.md
@@ -209,9 +209,23 @@ session-ensure`, owns the per-issue lock for the WHOLE run:
   still renews it at stage boundaries.
 - **Explicit release.** `finalize_session` (`models/session_lifecycle.py`)
   releases the lease (`release_issue_lock`, compare-and-delete) and clears
-  the signal on EVERY terminal transition — completion and graceful failure —
-  so the happy path frees immediately and the TTL is only the crash backstop
-  (the existing `orphaned_lock` self-heal covers a hard crash).
+  the signal on EVERY terminal transition it runs on. A `/do-sdlc`
+  supervisor exit never calls it, though — its HALT/blocked/cap exits have
+  no terminal transition at all — so two further paths release explicitly
+  (issue #2714): the `MERGE`/`completed` stage-marker write releases in the
+  tool layer itself (`tools/sdlc_stage_marker.py`, path-agnostic — fires for
+  `/do-sdlc`, the `/sdlc` router, and worker-driven pipelines alike), and
+  `/do-sdlc`'s own Step 5 calls `sdlc-tool session-release` on the REVIEW
+  self-check HALT, a `blocked` router decision, and the iteration cap — the
+  exits neither of the other two paths observes. The detached local lease
+  heartbeat (`tools/sdlc_lease_heartbeat.py`) also releases on its own,
+  independent of all three, once it confirms its supervisor is dead. The
+  `orphaned_lock` self-heal is not a crash backstop for any of this: its
+  freshness is re-stamped by the heartbeat's own renewal ticks, so a lease
+  the heartbeat is still renewing never reads as orphaned regardless of
+  whether the supervisor behind it is still alive. See
+  [SDLC Issue Ownership Lock](sdlc-issue-ownership-lock.md#heartbeat-exit-conditions-and-release-paths-issue-2714)
+  for the full release-path catalogue.
 - **Single-owner MERGE.** `tools/merge_predicate.py` gains check group (d):
   when `--run-id` is supplied (the `/do-merge` skill always passes it), the
   merge actor's `run_id` must hold the current issue lease. A fork that never

--- a/docs/features/sdlc-run-self-recognition.md
+++ b/docs/features/sdlc-run-self-recognition.md
@@ -103,17 +103,18 @@ standalone worker's in-process 60s tick
 (`agent/session_executor.py::_tick_issue_lock_renewal`), so its lease could
 lapse mid-stage. `tools/sdlc_lease_heartbeat.py` is the missing renewer:
 
-- **Peek-first, renew-only (the load-bearing safety property).**
-  `touch_issue_lock` has no renew-only mode -- passing a `run_id` against an
-  *absent* key does `SET NX EX` and makes the caller the owner. A naive renew
-  loop would therefore let a zombie heartbeat *re-acquire* a lapsed lease
-  under its stale id and block a legitimate successor with `ISSUE_LOCKED`.
-  So every tick peeks first (`touch_issue_lock(issue, run_id, peek=True)` --
-  a peek never mutates, whatever run_id it carries) and:
+- **Peek-first, renew-only (the load-bearing safety property).** Every tick
+  peeks first (`touch_issue_lock(issue, run_id, peek=True)` -- a peek never
+  mutates, whatever run_id it carries) and:
   - `peek.owner_run_id is None` (lease absent/lapsed) -> exit 0 immediately.
   - `peek.owner_run_id != run_id` (a successor owns it) -> exit 0 immediately.
-  - `peek.owner_run_id == run_id` -> only then calls the mutating
-    `touch_issue_lock(issue, run_id, ...)` to extend the TTL.
+  - `peek.owner_run_id == run_id` -> only then calls
+    `touch_issue_lock(issue, run_id, ..., renew_only=True)` to extend the
+    TTL. `renew_only=True` (issue #2714) makes the "never mint" guarantee
+    structural rather than conventional: it skips both of
+    `touch_issue_lock`'s minting branches and writes through a
+    compare-and-set Lua script, so a release landing between the peek and
+    the extend is a no-op rather than something the extend could undo.
 
   The exit conditions are deliberately **ownership checks, never pid-liveness
   inference** (issue #2537 review): the lease payload's `pid` is stamped by
@@ -121,25 +122,47 @@ lapse mid-stage. `tools/sdlc_lease_heartbeat.py` is the missing renewer:
   before the detached heartbeat's first tick, so the peek's pid-keyed
   `orphaned_lock` signal reads every locally-minted lease as orphaned and
   must not gate the renew -- gating on it would lapse the lease mid-stage,
-  the exact failure this heartbeat exists to prevent. Run-liveness is the
-  heartbeat's own existence; its bounded max-lifetime is the death backstop.
-  Issue #2620 then fixed the signal itself at its source: each renewal below
-  re-stamps `renewed_at` on the payload, and `_lock_owner_is_live` treats a
-  fresh stamp as proof of life, so *this loop's own ticking* is what now keeps
-  the lease reading live to every other consumer. The exit conditions here
-  stay pure ownership checks regardless -- see
+  the exact failure this heartbeat exists to prevent. Issue #2620 then fixed
+  the signal itself at its source: each renewal re-stamps `renewed_at` on
+  the payload, and `_lock_owner_is_live` treats a fresh stamp as proof of
+  life, so *this loop's own ticking* is what keeps the lease reading live to
+  every other consumer -- `orphaned_lock` freshness is therefore
+  manufactured by the heartbeat itself, not an independent crash signal. The
+  exit conditions here stay pure ownership checks regardless -- see
   [SDLC Issue Ownership Lock](sdlc-issue-ownership-lock.md).
   This mirrors `touch_issue_lock`'s own "no run_id supplied: never mutates"
   special case at the caller layer: the heartbeat can only ever *extend* a
   lease it already owns, never mint on a free key nor steal one from a
   successor.
+- **Run liveness is the supervisor's liveness (issue #2714).** The
+  heartbeat's own existence proves nothing about whether a supervisor is
+  still driving the run, so `session-ensure` resolves the supervising
+  `claude` process's `(pid, create_time)` at mint time and hands it to the
+  heartbeat, which polls it every `SDLC_SUPERVISOR_CHECK_INTERVAL_SECONDS`
+  (default 60s). Two consecutive positive-death observations release the
+  lease and the supervised-run signal and exit -- a killed supervisor's
+  lease is gone in roughly two minutes. When a supervisor identity resolves,
+  the unchanged 4h `MAX_LIFETIME_SECONDS` remains a backstop, not the
+  primary detector. When no identity resolves, a tighter 90-minute
+  `UNSUPERVISED_MAX_LIFETIME_SECONDS` ceiling applies and that exit stops
+  renewing **without** releasing (an unresolvable supervisor is not proof of
+  death), leaving the lease to lapse on its own TTL.
 - Renews every `ISSUE_LOCK_TTL_SECONDS // 3` by default (so ~3 renews per TTL
-  window), overridable via `--interval`. Self-terminates after a bounded
-  `--max-lifetime` (default 4h, env-overridable via
-  `SDLC_LEASE_HEARTBEAT_MAX_LIFETIME_SECONDS`) regardless of ownership state,
-  so a crashed supervisor's heartbeat can never outlive an unbounded window.
+  window), overridable via `--interval`, decoupled from the supervisor-check
+  cadence above.
 - Best-effort throughout: every tick is wrapped in try/except; a Redis hiccup
   is swallowed and retried next tick.
+
+**Self-recognition is now a narrower fallback.** Before issue #2714 the
+heartbeat had no way to detect a dead supervisor directly, so a lapsed lease
+under a live pipeline was the case `owned_run_ids` self-recognition existed
+to recover from. The heartbeat now has an external liveness input -- the
+polled supervisor identity -- so most crash scenarios are caught and released
+by the heartbeat itself well before the lease lapses. Self-recognition
+remains the recovery path for what the supervisor watch cannot see: a Redis
+hiccup that drops the lease despite a live supervisor and a healthy
+heartbeat, or any lapse on the unsupervised path where the ceiling
+deliberately declines to release.
 
 **Why a detached subprocess, not an in-turn thread.** An LLM turn (a `claude
 -p` subprocess) cannot reliably host a background thread across its own
@@ -225,7 +248,8 @@ completes -> at run end, `run-health` reports "0 never-landed writes" ->
 |---|---|
 | `models/agent_session.py` | `owned_run_ids` field |
 | `tools/sdlc_session_ensure.py` | `_read_owned_run_ids`, `_append_owned_run_id`, `_validated_reuse_candidate` (widened), `_acquire_run_lock_and_bind` (accumulation + supervised-self check + heartbeat launch), `_maybe_launch_lease_heartbeat` |
-| `tools/sdlc_lease_heartbeat.py` | Peek-first renew-only detached lease-heartbeat CLI/loop (`run_heartbeat`) |
+| `tools/sdlc_lease_heartbeat.py` | Peek-first, `renew_only=True`-extending detached lease-heartbeat CLI/loop (`run_heartbeat`); polls the supervisor identity and releases on confirmed death (issue #2714) |
+| `tools/sdlc_supervisor_identity.py` | `resolve_supervisor_identity_detailed()` -- the supervisor `(pid, create_time)` resolver handed to the heartbeat at mint time (issue #2714) |
 | `tools/_sdlc_marker_telemetry.py` | Per-run ok/fail marker-write counters (`record_marker_write`, `read_marker_counters`, `marker_ok_write_count`) |
 | `tools/sdlc_stage_marker.py` | `write_marker` -- calls `record_marker_write` on every write outcome |
 | `tools/sdlc_run_health.py` | Read-only `run-health` disposition report (`clean` / `transient_recovered` / `never_landed`) |

--- a/docs/sdlc/do-sdlc.md
+++ b/docs/sdlc/do-sdlc.md
@@ -41,3 +41,29 @@ sdlc-tool session-ensure --issue-number {issue_number} --reuse-run-id {run_id}
 `SDLC_TARGET_REPO` (set once in Step 2) must stay exported for the lifetime of the loop — `sdlc-tool`
 forces its own cwd to `~/src/ai` and relies on this env var to locate the target repo's plans and
 worktree when the target repo is not `ai` itself.
+
+## `session-release` invocation, this repo's path (Step 5)
+
+Step 5's release runs through the same `sdlc-tool` entry point as `session-ensure` (installed to
+`~/.local/bin` by `/update`; cwd-independent per `docs/features/sdlc-tool-resolver.md`):
+
+```bash
+sdlc-tool session-release --issue-number {issue_number} --run-id {run_id}
+```
+
+`{run_id}` is the value this run is carrying — the one Step 3d.6 passes as `--reuse-run-id`, rebound
+if any refusal in the Step 2 table made you re-ensure. Pass the *current* value; a stale one is
+refused as a foreign release and leaves the lease held.
+
+Output is typed JSON, exit code always 0:
+
+| `reason` | Meaning |
+|---|---|
+| `released` | The lease and the supervised-run signal are both gone. |
+| `no_lease` | Nothing to release — already released (the merged path's tool-layer leg got there first) or the lease lapsed. Not an error. |
+| `not_owner` | A live lease is held by a *different* run; nothing was touched. Report this — it means the `run_id` you carried is not the one that owns this issue. |
+| `missing_args` | You passed an empty/absent issue number or `run_id`. |
+| `error` | The Redis substrate raised; the lease may still be held and will lapse on its own TTL. |
+
+Never let any of these change the outcome you reported in Step 4. The release is a courtesy that
+shortens the *next* run's wait, not part of this run's result.

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -483,6 +483,16 @@ sdlc-tool session-ensure --issue-number 941 --issue-url "https://github.com/tomc
 
 Returns JSON: `{"session_id": "sdlc-local-941", "created": true}` (or `"created": false` if reused).
 
+### SDLC Session Release (`sdlc-tool session-release`)
+
+Release the per-issue run lease and its companion supervised-run signal, ownership-checked against `--run-id`. The counterpart to `session-ensure`: hands both back instead of taking them. Used by `/do-sdlc` Step 5 on exits a stage-marker `MERGE` write never observes (the REVIEW self-check HALT, a `blocked` router decision, the iteration cap); see `docs/sdlc/do-sdlc.md`. Best-effort and always exits 0.
+
+```bash
+sdlc-tool session-release --issue-number 2714 --run-id <hex>
+```
+
+Returns typed JSON, always all four keys: `{"released": bool, "reason": "released"|"not_owner"|"no_lease"|"missing_args"|"error", "issue_number": N, "run_id": "..."}`. A wrong or already-released `run_id` is a safe no-op (`not_owner` / `no_lease`), never a foreign run's lease being dropped.
+
 ### SDLC Stage Query (`sdlc-tool stage-query`)
 
 Query SDLC pipeline `stage_states` from a PM session. Used by the SDLC router skill as the primary signal for routing decisions (which sub-skill to dispatch next). Returns JSON mapping stage names to statuses.

--- a/models/session_lifecycle.py
+++ b/models/session_lifecycle.py
@@ -869,6 +869,19 @@ _RELEASE_IF_VALUE_MATCHES_LUA = (
     "return redis.call('del', KEYS[1]) else return 0 end"
 )
 
+# Compare-and-set renewal (issue #2714, L0): rewrite the lock payload with a
+# fresh TTL only if the stored value is still byte-identical to the one this
+# call just read (ARGV[1]). ARGV[2] is the self-healed payload, ARGV[3] the
+# TTL. A plain read-then-SET renewal has a real TOCTOU window: a release
+# landing between the GET and the SET is UNDONE by the SET, which recreates
+# the key -- a renewer minting a lease its owner already gave up. A `GET` on
+# an absent key returns `false`, never equal to ARGV[1], so this script is
+# structurally incapable of minting.
+_RENEW_IF_VALUE_MATCHES_LUA = (
+    "if redis.call('GET', KEYS[1]) == ARGV[1] then "
+    "redis.call('SET', KEYS[1], ARGV[2], 'EX', ARGV[3]) return 1 end return 0"
+)
+
 
 class IssueLockResult(NamedTuple):
     """Result of touch_issue_lock().
@@ -1068,6 +1081,44 @@ def _current_process_create_time() -> float | None:
         return None
 
 
+def _healed_renewal_payload(payload: dict, target_repo: str | None) -> dict:
+    """Build the payload a same-owner renewal writes back.
+
+    Self-healing renewal (BLOCKER round-2, issue #2012): a bare
+    ``_R.expire(key, ttl)`` would renew the TTL without ever rewriting the
+    payload -- a lock acquired before ``target_repo`` pinning existed (or
+    whose payload otherwise lacks it) would then renew FOREVER without ever
+    gaining the field, hard-failing every issue-keyed ledger write across
+    cutover. So renewal re-writes the FULL payload: spread the EXISTING
+    payload (never reconstruct a subset -- that would silently drop
+    ``pid``/``hostname`` even though nothing asked it to) and override only
+    the fields below.
+
+    - ``target_repo``: re-pinned from the caller's freshly-resolved value
+      when given, else whatever the payload already carried.
+    - ``machine_id`` (issue #2537, same self-heal pattern): a pre-#2537
+      payload gains the stable identity on its next same-owner renewal.
+      Renewal requires a run_id match and run_ids are minted on exactly one
+      machine, so the renewer IS on the owner's machine. Identity is
+      immutable once stamped: an existing machine_id is never overwritten,
+      and an unresolvable local id ("") is never written over the legacy
+      hostname signal.
+    - ``renewed_at`` (issue #2620): unlike the identity fields above, this
+      one is deliberately OVERWRITTEN on every renewal -- the re-stamp IS
+      the liveness signal, since the payload's pid (the ephemeral
+      ``session-ensure`` CLI) is dead by the first tick. This also
+      self-heals a pre-#2620 payload.
+    """
+    healed_target_repo = target_repo if target_repo is not None else payload.get("target_repo")
+    new_payload = {**payload, "target_repo": healed_target_repo}
+    if not new_payload.get("machine_id"):
+        local_machine_id = _local_machine_id()
+        if local_machine_id:
+            new_payload["machine_id"] = local_machine_id
+    new_payload["renewed_at"] = time.time()
+    return new_payload
+
+
 def touch_issue_lock(
     issue_number: int | None,
     run_id: str | None,
@@ -1075,6 +1126,8 @@ def touch_issue_lock(
     ttl: int = ISSUE_LOCK_TTL_SECONDS,
     peek: bool = False,
     target_repo: str | None = None,
+    *,
+    renew_only: bool = False,
 ) -> IssueLockResult:
     """Acquire, renew, or peek the per-issue SDLC ownership lock.
 
@@ -1094,15 +1147,22 @@ def touch_issue_lock(
       SET NX its way into ownership. Reports the current holder
       (``acquired=False`` when a lock exists, ``True`` when free).
     - No existing key: ``SET NX EX`` claims it carrying ``run_id``.
-      Returns ``acquired=True``.
-    - Existing key, same run_id: renews via ``EXPIRE``. ``acquired=True``.
+      Returns ``acquired=True``. **Except under ``renew_only=True``**, which
+      never mints: an absent key returns ``acquired=False`` with
+      ``owner_run_id=None`` (issue #2714 L0).
+    - Existing key, same run_id: renews the full payload with a fresh TTL.
+      ``acquired=True``. Under ``renew_only=True`` the write is a
+      compare-and-set that only lands if the value is still the one this call
+      read.
     - Existing key, different run_id: a foreign run owns it. Returns
       ``acquired=False`` with the owner's run_id + session_id surfaced.
     - Malformed/legacy (non-JSON) value: treated as a foreign, non-matching
       holder -- fails toward "not acquired". Never raises on ``json.loads``.
     - Race: the ``SET NX`` fails because the key existed, but by the time
       of the follow-up ``GET`` the key has since expired -- treated as
-      free; this attempt succeeds (``acquired=True``).
+      free; this attempt succeeds (``acquired=True``). This branch is also
+      skipped under ``renew_only=True``: it is a second minting path, and a
+      renewer must have none.
 
     Stale-owner takeover keeps TTL semantics: an expired lock is claimable
     by the next fresh candidate; no takeover reads ``active_run_id`` as
@@ -1134,13 +1194,27 @@ def touch_issue_lock(
             acquire or a re-acquire-after-expiry, ``target_repo`` is
             written into the payload verbatim (including ``None`` -- a
             caller that could not resolve it is not this function's
-            problem to paper over). On a same-owner renewal, see the
-            self-healing behavior documented at that branch below.
+            problem to paper over). On a same-owner renewal, see
+            ``_healed_renewal_payload``.
+        renew_only: Keyword-only. True marks this call a RENEWAL of a lease
+            the caller believes it already holds (the detached lease
+            heartbeat, ``tools/sdlc_lease_heartbeat.py``). A renewer must
+            never mint, so both minting branches above are skipped and the
+            renewal write goes through a compare-and-set (issue #2714 L0).
+            The failure mode this closes: the heartbeat's extend landing a
+            millisecond after its supervisor released the lease used to
+            ``SET NX`` its way back into ownership of a lease nobody held,
+            then renew it to the max-lifetime ceiling with no supervisor
+            behind it.
 
     Fails OPEN (returns ``acquired=True``) on any Redis exception -- mirrors
     ``claim_pending_run()``'s existing fail-open behavior: a Redis hiccup
     degrades to no cross-process protection rather than wedging the SDLC
     pipeline. Each fail-open logs the swallowed error CLASS explicitly.
+    A ``renew_only`` call is the ONE exception and fails CLOSED
+    (``acquired=False``): reporting ownership it cannot verify is exactly
+    the "renew a lease you do not hold" shape the mode exists to eliminate,
+    and the caller's own next peek is a cheap recovery.
     """
     if not issue_number:
         return IssueLockResult(acquired=True, owner_session_id=None)
@@ -1191,6 +1265,48 @@ def touch_issue_lock(
                 owner_session_id=payload.get("session_id"),
                 owner_run_id=payload.get("run_id"),
                 target_repo=payload.get("target_repo"),
+            )
+
+        if renew_only:
+            # Renewal, never minting (issue #2714 L0). Deliberately reached
+            # BEFORE the `SET NX` below: that statement acquires on an absent
+            # key, and the `raw is None` follow-up after it treats a
+            # since-expired key as acquired too. Both are minting paths, and a
+            # renewer whose lease was just released must have neither -- it
+            # must report the loss so its caller can stand down.
+            raw = _R.get(key)
+            if raw is None:
+                return IssueLockResult(acquired=False, owner_session_id=None, owner_run_id=None)
+            try:
+                payload = json.loads(raw)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "[session-lifecycle] issue-lock value for issue=%s is not valid JSON "
+                    "(malformed or legacy) -- refusing to renew",
+                    issue_number,
+                )
+                return IssueLockResult(acquired=False, owner_session_id=None)
+            if payload.get("run_id") != run_id:
+                return IssueLockResult(
+                    acquired=False,
+                    owner_session_id=payload.get("session_id"),
+                    owner_run_id=payload.get("run_id"),
+                    target_repo=payload.get("target_repo"),
+                )
+            new_payload = _healed_renewal_payload(payload, target_repo)
+            # Compare-and-set against the exact bytes just read. A release
+            # landing inside this window makes the script a no-op rather than
+            # recreating the key.
+            renewed = _R.eval(
+                _RENEW_IF_VALUE_MATCHES_LUA, 1, key, raw, json.dumps(new_payload), ttl
+            )
+            if not renewed:
+                return IssueLockResult(acquired=False, owner_session_id=None, owner_run_id=None)
+            return IssueLockResult(
+                acquired=True,
+                owner_session_id=payload.get("session_id"),
+                owner_run_id=run_id,
+                target_repo=new_payload.get("target_repo"),
             )
 
         value = json.dumps(
@@ -1251,48 +1367,15 @@ def touch_issue_lock(
             return IssueLockResult(acquired=False, owner_session_id=None)
 
         if payload.get("run_id") == run_id:
-            # Self-healing renewal (BLOCKER round-2, issue #2012): a bare
-            # `_R.expire(key, ttl)` here would renew the TTL without ever
-            # rewriting the payload -- a lock acquired before target_repo
-            # pinning existed (or whose payload otherwise lacks it) would
-            # then renew FOREVER without ever gaining the field, hard-
-            # failing every issue-keyed ledger write across cutover. Instead
-            # we re-SET the full payload: spread the EXISTING payload
-            # (never reconstruct a subset -- that would silently drop
-            # `pid`/`hostname` even though nothing asked it to) and override
-            # only `target_repo`, re-pinning it from the caller's
-            # freshly-resolved value when given, else falling back to
-            # whatever the payload already carried. Re-validated against
-            # the payload just fetched by THIS call (not a cached peek from
-            # earlier) -- the caller (writers/readers of the issue-keyed
-            # ledger) must call this non-peek method immediately before its
-            # own ledger write, not trust an earlier peek. The single
-            # read-compare-write happens within one function invocation
-            # with no intervening peek, so this already closes the
-            # stale-peek TOCTOU race without any additional locking
-            # machinery.
-            healed_target_repo = (
-                target_repo if target_repo is not None else payload.get("target_repo")
-            )
-            new_payload = {**payload, "target_repo": healed_target_repo}
-            # machine_id self-heal (issue #2537, same pattern as target_repo
-            # above): a pre-#2537 payload gains the stable identity on its
-            # next same-owner renewal. Renewal requires a run_id match and
-            # run_ids are minted on exactly one machine, so the renewer IS on
-            # the owner's machine. Identity is immutable once stamped: an
-            # existing machine_id is never overwritten, and an unresolvable
-            # local id ("") is never written over the legacy hostname signal.
-            if not new_payload.get("machine_id"):
-                local_machine_id = _local_machine_id()
-                if local_machine_id:
-                    new_payload["machine_id"] = local_machine_id
-            # renewed_at re-stamp (issue #2620): unlike the identity fields
-            # above, this one is deliberately OVERWRITTEN on every renewal --
-            # the re-stamp IS the liveness signal, since the payload's pid
-            # (the ephemeral `session-ensure` CLI) is dead by the first tick.
-            # This also self-heals a pre-#2620 payload, which gains the field
-            # on its next same-owner renewal.
-            new_payload["renewed_at"] = time.time()
+            # Self-healing renewal (see `_healed_renewal_payload`), re-validated
+            # against the payload just fetched by THIS call (not a cached peek
+            # from earlier) -- the caller (writers/readers of the issue-keyed
+            # ledger) must call this non-peek method immediately before its own
+            # ledger write, not trust an earlier peek. The single
+            # read-compare-write happens within one function invocation with no
+            # intervening peek, so this closes the stale-peek TOCTOU race
+            # without any additional locking machinery.
+            new_payload = _healed_renewal_payload(payload, target_repo)
             _R.set(key, json.dumps(new_payload), ex=ttl)
             return IssueLockResult(
                 acquired=True,
@@ -1308,6 +1391,24 @@ def touch_issue_lock(
             target_repo=payload.get("target_repo"),
         )
     except Exception as e:
+        if renew_only:
+            # A renewer fails CLOSED (issue #2714 L0). This handler wraps the
+            # ENTIRE function, including the CAS EVAL above, so the default
+            # fail-open below would hand a renewer `acquired=True` on a
+            # transient Redis error -- the exact "report ownership without
+            # holding the key" shape the CAS exists to eliminate, letting a
+            # heartbeat keep renewing (and keep publishing a supervised-run
+            # signal for) a lease its supervisor already released. Reporting
+            # the loss costs the caller one cheap re-peek; claiming ownership
+            # it cannot verify costs a wedged issue.
+            logger.warning(
+                "[session-lifecycle] issue-lock renewal failed for issue=%s "
+                "(failing closed; error class %s): %s",
+                issue_number,
+                type(e).__name__,
+                e,
+            )
+            return IssueLockResult(acquired=False, owner_session_id=None, owner_run_id=None)
         logger.warning(
             "[session-lifecycle] issue-lock acquisition failed for issue=%s "
             "(failing open; error class %s): %s",

--- a/scripts/sdlc-tool
+++ b/scripts/sdlc-tool
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-ALLOWED_SUBCOMMANDS=(verdict dispatch stage-marker stage-query session-ensure next-skill meta-set run-health)
+ALLOWED_SUBCOMMANDS=(verdict dispatch stage-marker stage-query session-ensure session-release next-skill meta-set run-health)
 
 usage() {
     cat <<EOF >&2
@@ -28,6 +28,7 @@ Subcommands:
   stage-marker     Mark current SDLC stage (best-effort)
   stage-query      Query current SDLC pipeline state (best-effort)
   session-ensure   Ensure an AgentSession exists for the issue (best-effort)
+  session-release  Release the issue lease + supervised-run signal (best-effort)
   next-skill       Compute the next dispatch decision (production routing)
   meta-set         Set a whitelisted _meta key on the PM session (best-effort)
   run-health       Report per-run marker-write health + disposition (read-only)

--- a/tests/unit/test_sdlc_lease_heartbeat.py
+++ b/tests/unit/test_sdlc_lease_heartbeat.py
@@ -426,3 +426,540 @@ class TestReleaseRaceIsClosed:
         assert calls["n"] == 2  # tick 1 renewed nothing; tick 2 saw it gone
         # The extend did NOT recreate the released key.
         assert _R.get(self.KEY) is None
+
+
+class TestSupervisorIdentityResolution:
+    """Issue #2714 L2: three-tier supervisor identity (env -> ancestry -> none).
+
+    spike-1 measured ``CLAUDE_PID`` exported into every Claude Code Bash tool
+    call, matching the ``claude`` ancestor exactly -- even from a subagent.
+    spike-2 proved ``ppid``-based inference is unsound (a HEALTHY heartbeat is
+    reparented to pid 1 within seconds of spawn), so the resolver must never
+    consult it.
+    """
+
+    def test_env_var_resolves_pid_and_create_time(self, monkeypatch):
+        from tools import sdlc_supervisor_identity as si
+
+        monkeypatch.setenv("CLAUDE_PID", "32886")
+        proc = MagicMock()
+        proc.create_time.return_value = 111.5
+
+        with patch("agent.session_health._psutil_process_for_pid", return_value=proc):
+            detailed = si.resolve_supervisor_identity_detailed()
+            # The 2-tuple form is the same resolution minus the source label.
+            assert si.resolve_supervisor_identity() == (32886, 111.5)
+
+        assert detailed == (si.SOURCE_ENV, 32886, 111.5)
+
+    def test_env_var_that_does_not_resolve_falls_through_to_ancestry(self, monkeypatch):
+        """A stale/garbage CLAUDE_PID must degrade to the walk, not to nothing."""
+        from tools import sdlc_supervisor_identity as si
+
+        monkeypatch.setenv("CLAUDE_PID", "not-a-number")
+
+        ancestor = MagicMock()
+        ancestor.pid = 999
+        ancestor.exe.return_value = "/opt/homebrew/bin/claude"
+        ancestor.create_time.return_value = 222.5
+        me = MagicMock()
+        me.parents.return_value = [MagicMock(pid=1, **{"exe.return_value": "/bin/zsh"}), ancestor]
+
+        with patch.object(si, "_self_process", return_value=me):
+            assert si.resolve_supervisor_identity_detailed() == (si.SOURCE_ANCESTRY, 999, 222.5)
+
+    def test_ancestry_matches_node_process_whose_cmdline_mentions_claude(self, monkeypatch):
+        from tools import sdlc_supervisor_identity as si
+
+        monkeypatch.delenv("CLAUDE_PID", raising=False)
+        ancestor = MagicMock()
+        ancestor.pid = 777
+        ancestor.exe.return_value = "/usr/local/bin/node"
+        ancestor.cmdline.return_value = ["node", "/x/@anthropic-ai/claude-code/cli.js"]
+        ancestor.create_time.return_value = 333.0
+        me = MagicMock()
+        me.parents.return_value = [ancestor]
+
+        with patch.object(si, "_self_process", return_value=me):
+            assert si.resolve_supervisor_identity_detailed() == (si.SOURCE_ANCESTRY, 777, 333.0)
+
+    def test_no_env_and_no_claude_ancestor_is_unresolved(self, monkeypatch):
+        from tools import sdlc_supervisor_identity as si
+
+        monkeypatch.delenv("CLAUDE_PID", raising=False)
+        other = MagicMock()
+        other.pid = 5
+        other.exe.return_value = "/bin/zsh"
+        other.cmdline.return_value = ["zsh"]
+        me = MagicMock()
+        me.parents.return_value = [other]
+
+        with patch.object(si, "_self_process", return_value=me):
+            assert si.resolve_supervisor_identity_detailed() == (si.SOURCE_UNRESOLVED, None, None)
+            assert si.resolve_supervisor_identity() == (None, None)
+
+    def test_any_exception_resolves_to_none_never_raises(self, monkeypatch):
+        from tools import sdlc_supervisor_identity as si
+
+        monkeypatch.delenv("CLAUDE_PID", raising=False)
+        with patch.object(si, "_self_process", side_effect=RuntimeError("psutil exploded")):
+            assert si.resolve_supervisor_identity_detailed() == (si.SOURCE_UNRESOLVED, None, None)
+
+    def test_module_never_consults_the_parent_pid_syscall(self):
+        """spike-2 anti-criterion: ``ppid``/``getppid`` is not a death signal."""
+        import inspect
+
+        from tools import sdlc_supervisor_identity as si
+
+        src = inspect.getsource(si)
+        assert "getppid" not in src
+
+
+def _alive_proc(create_time):
+    p = MagicMock()
+    p.create_time.return_value = create_time
+    return p
+
+
+def _self_owned_touch():
+    """A touch_issue_lock double that always reports self-ownership."""
+
+    def fake_touch(issue, run_id, session_id="", ttl=None, peek=False, renew_only=False):
+        if peek:
+            return _peek_result(run_id)
+        return MagicMock()
+
+    return fake_touch
+
+
+class TestSupervisorLiveness:
+    """Issue #2714 L2: a positively-dead supervisor drops the lease.
+
+    The evidence bar is deliberately high (Risk 5 + #2446): a pid that psutil
+    cannot find, or one whose ``create_time`` no longer matches, counts as
+    dead -- but only after ``SDLC_SUPERVISOR_DEATH_CONFIRMATIONS`` consecutive
+    such observations, and ANY exception counts as NOT dead so a psutil flake
+    can never lapse a live run's lease.
+    """
+
+    def test_dead_supervisor_releases_the_lease_and_exits(self, caplog):
+        import logging
+
+        from tools.sdlc_lease_heartbeat import run_heartbeat
+
+        caplog.set_level(logging.INFO, logger="tools.sdlc_lease_heartbeat")
+        ticks = iter([0.0, 1.0, 2.0, 3.0, 4.0])
+
+        with (
+            patch("models.session_lifecycle.touch_issue_lock", side_effect=_self_owned_touch()),
+            patch("agent.supervised_run.write_supervised_run_signal"),
+            patch("agent.session_health._psutil_process_for_pid", return_value=None),
+            patch("models.session_lifecycle.release_issue_lock") as release,
+            patch("agent.supervised_run.clear_supervised_run_signal") as clear,
+        ):
+            rc = run_heartbeat(
+                issue_number=2714,
+                run_id="mine",
+                interval=1,
+                max_lifetime=100,
+                supervisor_pid=4242,
+                supervisor_create_time=99.0,
+                supervisor_check_interval=1,
+                _sleep=lambda s: None,
+                _monotonic=lambda: next(ticks),
+            )
+
+        assert rc == 0
+        release.assert_called_once()
+        clear.assert_called_once()
+        assert any("supervisor_dead" in r.getMessage() for r in caplog.records if r.levelno >= 20)
+
+    def test_live_supervisor_keeps_renewing(self):
+        from tools.sdlc_lease_heartbeat import run_heartbeat
+
+        renews = []
+
+        def fake_touch(issue, run_id, session_id="", ttl=None, peek=False, renew_only=False):
+            if peek:
+                return _peek_result("mine")
+            renews.append(run_id)
+            return MagicMock()
+
+        ticks = iter([0.0, 1.0, 2.0, 999.0])
+        with (
+            patch("models.session_lifecycle.touch_issue_lock", side_effect=fake_touch),
+            patch("agent.supervised_run.write_supervised_run_signal"),
+            patch("agent.session_health._psutil_process_for_pid", return_value=_alive_proc(99.0)),
+            patch("models.session_lifecycle.release_issue_lock") as release,
+        ):
+            rc = run_heartbeat(
+                issue_number=2714,
+                run_id="mine",
+                interval=1,
+                max_lifetime=10,
+                supervisor_pid=4242,
+                supervisor_create_time=99.0,
+                supervisor_check_interval=1,
+                _sleep=lambda s: None,
+                _monotonic=lambda: next(ticks),
+            )
+
+        assert rc == 0
+        assert len(renews) >= 2
+        release.assert_not_called()
+
+    def test_unresolved_supervisor_never_consults_psutil(self):
+        """No recorded identity -> the watch is inert; nothing is probed."""
+        from tools.sdlc_lease_heartbeat import run_heartbeat
+
+        ticks = iter([0.0, 1.0, 2.0, 999.0])
+        with (
+            patch("models.session_lifecycle.touch_issue_lock", side_effect=_self_owned_touch()),
+            patch("agent.supervised_run.write_supervised_run_signal"),
+            patch("agent.session_health._psutil_process_for_pid") as probe,
+            patch("models.session_lifecycle.release_issue_lock") as release,
+        ):
+            rc = run_heartbeat(
+                issue_number=2714,
+                run_id="mine",
+                interval=1,
+                max_lifetime=10,
+                _sleep=lambda s: None,
+                _monotonic=lambda: next(ticks),
+            )
+
+        assert rc == 0
+        assert probe.call_count == 0
+        release.assert_not_called()
+
+    def test_partial_or_invalid_identity_is_unresolved_never_dead(self):
+        """pid 0/negative/non-numeric, or one half missing -> unresolved."""
+        from tools.sdlc_lease_heartbeat import run_heartbeat
+
+        for pid, create_time in [
+            (0, 99.0),
+            (-5, 99.0),
+            ("not-a-pid", 99.0),
+            (4242, None),
+            (None, 99.0),
+            (4242, "not-a-time"),
+        ]:
+            ticks = iter([0.0, 1.0, 999.0])
+            with (
+                patch("models.session_lifecycle.touch_issue_lock", side_effect=_self_owned_touch()),
+                patch("agent.supervised_run.write_supervised_run_signal"),
+                patch("agent.session_health._psutil_process_for_pid") as probe,
+                patch("models.session_lifecycle.release_issue_lock") as release,
+            ):
+                rc = run_heartbeat(
+                    issue_number=2714,
+                    run_id="mine",
+                    interval=1,
+                    max_lifetime=10,
+                    supervisor_pid=pid,
+                    supervisor_create_time=create_time,
+                    supervisor_check_interval=1,
+                    _sleep=lambda s: None,
+                    _monotonic=lambda: next(ticks),
+                )
+            assert rc == 0, (pid, create_time)
+            assert probe.call_count == 0, (pid, create_time)
+            release.assert_not_called()
+
+    def test_create_time_mismatch_counts_as_dead(self, caplog):
+        """Risk 5: the OS recycled the pid -- alive, but not our supervisor."""
+        import logging
+
+        from tools.sdlc_lease_heartbeat import run_heartbeat
+
+        caplog.set_level(logging.INFO, logger="tools.sdlc_lease_heartbeat")
+        ticks = iter([0.0, 1.0, 2.0, 3.0, 4.0])
+        with (
+            patch("models.session_lifecycle.touch_issue_lock", side_effect=_self_owned_touch()),
+            patch("agent.supervised_run.write_supervised_run_signal"),
+            patch(
+                "agent.session_health._psutil_process_for_pid",
+                return_value=_alive_proc(123.456),  # recorded was 99.0
+            ),
+            patch("models.session_lifecycle.release_issue_lock") as release,
+            patch("agent.supervised_run.clear_supervised_run_signal"),
+        ):
+            rc = run_heartbeat(
+                issue_number=2714,
+                run_id="mine",
+                interval=1,
+                max_lifetime=100,
+                supervisor_pid=4242,
+                supervisor_create_time=99.0,
+                supervisor_check_interval=1,
+                _sleep=lambda s: None,
+                _monotonic=lambda: next(ticks),
+            )
+
+        assert rc == 0
+        release.assert_called_once()
+        assert any("supervisor_dead" in r.getMessage() for r in caplog.records)
+
+    def test_single_flake_does_not_trip_the_confirmation_gate(self):
+        """One dead observation followed by a live one must NOT release."""
+        from tools.sdlc_lease_heartbeat import run_heartbeat
+
+        seq = [None, _alive_proc(99.0), _alive_proc(99.0), _alive_proc(99.0)]
+
+        def probe(_pid):
+            return seq.pop(0) if seq else _alive_proc(99.0)
+
+        ticks = iter([0.0, 1.0, 2.0, 3.0, 999.0])
+        with (
+            patch("models.session_lifecycle.touch_issue_lock", side_effect=_self_owned_touch()),
+            patch("agent.supervised_run.write_supervised_run_signal"),
+            patch("agent.session_health._psutil_process_for_pid", side_effect=probe),
+            patch("models.session_lifecycle.release_issue_lock") as release,
+        ):
+            rc = run_heartbeat(
+                issue_number=2714,
+                run_id="mine",
+                interval=1,
+                max_lifetime=100,
+                supervisor_pid=4242,
+                supervisor_create_time=99.0,
+                supervisor_check_interval=1,
+                _sleep=lambda s: None,
+                _monotonic=lambda: next(ticks),
+            )
+
+        assert rc == 0
+        release.assert_not_called()
+
+    def test_psutil_exception_keeps_renewing_never_releases(self):
+        """#2446: an unverifiable probe fails TOWARD holding the lease, and the
+        tick's renew still fires -- the watch must never break the renewer."""
+        from tools.sdlc_lease_heartbeat import run_heartbeat
+
+        renews = []
+
+        def fake_touch(issue, run_id, session_id="", ttl=None, peek=False, renew_only=False):
+            if peek:
+                return _peek_result("mine")
+            renews.append(run_id)
+            return MagicMock()
+
+        ticks = iter([0.0, 1.0, 2.0, 3.0, 999.0])
+        with (
+            patch("models.session_lifecycle.touch_issue_lock", side_effect=fake_touch),
+            patch("agent.supervised_run.write_supervised_run_signal"),
+            patch(
+                "agent.session_health._psutil_process_for_pid",
+                side_effect=RuntimeError("psutil exploded"),
+            ),
+            patch("models.session_lifecycle.release_issue_lock") as release,
+        ):
+            rc = run_heartbeat(
+                issue_number=2714,
+                run_id="mine",
+                interval=1,
+                max_lifetime=100,
+                supervisor_pid=4242,
+                supervisor_create_time=99.0,
+                supervisor_check_interval=1,
+                _sleep=lambda s: None,
+                _monotonic=lambda: next(ticks),
+            )
+
+        assert rc == 0
+        release.assert_not_called()
+        assert len(renews) >= 3  # the raising probe never stopped the renewer
+
+
+class TestUnsupervisedCeiling:
+    """Issue #2714 L3: an unresolvable supervisor gets a 90-minute bound.
+
+    Risk 1: the shortened bound applies ONLY on the unresolvable path, and it
+    only STOPS RENEWING -- it never releases, because failing to resolve a
+    supervisor is not positive proof the run is dead. The lease's own 1800s
+    TTL is the correct disposition there.
+    """
+
+    def _run(self, ticks, **kwargs):
+        from tools.sdlc_lease_heartbeat import run_heartbeat
+
+        it = iter(ticks)
+        with (
+            patch("models.session_lifecycle.touch_issue_lock", side_effect=_self_owned_touch()),
+            patch("agent.supervised_run.write_supervised_run_signal"),
+            patch("agent.session_health._psutil_process_for_pid", return_value=_alive_proc(99.0)),
+            patch("models.session_lifecycle.release_issue_lock") as release,
+            patch("agent.supervised_run.clear_supervised_run_signal") as clear,
+        ):
+            rc = run_heartbeat(
+                issue_number=2714,
+                run_id="mine",
+                interval=1,
+                _sleep=lambda s: None,
+                _monotonic=lambda: next(it),
+                **kwargs,
+            )
+        return rc, release, clear
+
+    def test_unresolved_supervisor_selects_the_ninety_minute_bound(self, caplog):
+        import logging
+
+        from tools.sdlc_lease_heartbeat import UNSUPERVISED_MAX_LIFETIME_SECONDS
+
+        assert UNSUPERVISED_MAX_LIFETIME_SECONDS == 90 * 60
+
+        caplog.set_level(logging.INFO, logger="tools.sdlc_lease_heartbeat")
+        # Inside the 5400s bound, then past it.
+        rc, release, clear = self._run([0.0, 5399.0, 5401.0])
+
+        assert rc == 0
+        assert any("unsupervised_max_lifetime" in r.getMessage() for r in caplog.records)
+        # Risk 1: stop renewing, but NEVER release -- the TTL is the backstop.
+        release.assert_not_called()
+        clear.assert_not_called()
+
+    def test_resolvable_supervisor_keeps_the_unchanged_four_hour_bound(self, caplog):
+        """The invariant the round-1 plan asserted and never tested.
+
+        A tick at 5401s -- past the unsupervised ceiling -- must still renew,
+        proving the 4h bound is the one selected whenever a supervisor pid is
+        present. Lowering MAX_LIFETIME_SECONDS uniformly would lapse a live
+        supervisor's long BUILD stage and reintroduce #2446.
+        """
+        import logging
+
+        from tools.sdlc_lease_heartbeat import MAX_LIFETIME_SECONDS
+
+        assert MAX_LIFETIME_SECONDS == 4 * 60 * 60
+
+        caplog.set_level(logging.INFO, logger="tools.sdlc_lease_heartbeat")
+        rc, release, _clear = self._run(
+            [0.0, 5401.0, 14401.0],
+            supervisor_pid=4242,
+            supervisor_create_time=99.0,
+            supervisor_check_interval=1,
+        )
+
+        assert rc == 0
+        assert not any("unsupervised_max_lifetime" in r.getMessage() for r in caplog.records)
+        assert any("max_lifetime" in r.getMessage() for r in caplog.records)
+        release.assert_not_called()
+
+    def test_explicit_max_lifetime_overrides_both_defaults(self):
+        """The sentinel: an explicitly-passed bound is never silently replaced."""
+        rc, _release, _clear = self._run([0.0, 3.0], max_lifetime=2)
+        assert rc == 0  # exited at the caller's bound, not at 5400
+
+    def test_invalid_env_override_falls_back_to_the_default(self, monkeypatch):
+        import importlib
+
+        for bad in ("not-a-number", "-1", "0", ""):
+            monkeypatch.setenv("SDLC_HEARTBEAT_UNSUPERVISED_MAX_SECONDS", bad)
+            import tools.sdlc_lease_heartbeat as hb
+
+            hb = importlib.reload(hb)
+            assert hb.UNSUPERVISED_MAX_LIFETIME_SECONDS == 90 * 60, bad
+
+        monkeypatch.delenv("SDLC_HEARTBEAT_UNSUPERVISED_MAX_SECONDS", raising=False)
+        import tools.sdlc_lease_heartbeat as hb
+
+        importlib.reload(hb)
+
+
+class TestHeartbeatObservability:
+    """Issue #2714 L4 / spike-4: the log file has been 0 bytes since 2026-08-04.
+
+    ``main()`` only configured logging under ``--verbose`` and every call site
+    was ``logger.debug``, so the six observed zombie heartbeats produced zero
+    diagnostics. Every decision now emits an assertable INFO record.
+    """
+
+    def test_startup_line_names_the_supervisor_source_and_intervals(self, caplog):
+        import logging
+
+        from tools.sdlc_lease_heartbeat import run_heartbeat
+
+        caplog.set_level(logging.INFO, logger="tools.sdlc_lease_heartbeat")
+        with patch(
+            "models.session_lifecycle.touch_issue_lock",
+            side_effect=lambda *a, **k: _peek_result(None),
+        ):
+            run_heartbeat(
+                issue_number=2714,
+                run_id="mine",
+                interval=1,
+                max_lifetime=10,
+                supervisor_source="env",
+                supervisor_pid=4242,
+                supervisor_create_time=99.0,
+                _sleep=lambda s: None,
+            )
+
+        startup = [r.getMessage() for r in caplog.records if "starting" in r.getMessage()]
+        assert startup, [r.getMessage() for r in caplog.records]
+        assert "env" in startup[0]
+        assert "4242" in startup[0]
+
+    def test_lease_lost_and_foreign_owner_exits_are_named(self, caplog):
+        import logging
+
+        from tools.sdlc_lease_heartbeat import run_heartbeat
+
+        for owner, reason in [(None, "lease_lost"), ("successor", "foreign_owner")]:
+            caplog.clear()
+            caplog.set_level(logging.INFO, logger="tools.sdlc_lease_heartbeat")
+            with patch(
+                "models.session_lifecycle.touch_issue_lock",
+                side_effect=lambda *a, _o=owner, **k: _peek_result(_o),
+            ):
+                rc = run_heartbeat(
+                    issue_number=2714,
+                    run_id="mine",
+                    interval=1,
+                    max_lifetime=10,
+                    _sleep=lambda s: None,
+                )
+            assert rc == 0
+            assert any(
+                reason in r.getMessage() for r in caplog.records if r.levelno >= logging.INFO
+            ), reason
+
+    def test_main_configures_info_logging_without_verbose(self):
+        """spike-4's root cause: basicConfig ran only under --verbose."""
+        import sys
+
+        from tools import sdlc_lease_heartbeat as hb
+
+        argv = ["sdlc_lease_heartbeat", "--issue-number", "2714", "--run-id", "mine"]
+        with (
+            patch.object(sys, "argv", argv),
+            patch.object(hb, "run_heartbeat", return_value=0),
+            patch.object(hb.logging, "basicConfig") as basic_config,
+            patch.object(hb.sys, "exit"),
+        ):
+            hb.main()
+
+        basic_config.assert_called_once()
+        assert basic_config.call_args.kwargs["level"] == hb.logging.INFO
+
+    def test_cli_passes_none_max_lifetime_so_the_sentinel_is_live(self):
+        """Round-2 CONCERN: --max-lifetime must default to None at BOTH ends."""
+        import sys
+
+        from tools import sdlc_lease_heartbeat as hb
+
+        argv = ["sdlc_lease_heartbeat", "--issue-number", "2714", "--run-id", "mine"]
+        with (
+            patch.object(sys, "argv", argv),
+            patch.object(hb, "run_heartbeat", return_value=0) as run,
+            patch.object(hb.logging, "basicConfig"),
+            patch.object(hb.sys, "exit"),
+        ):
+            hb.main()
+
+        assert run.call_args.kwargs["max_lifetime"] is None
+
+    def test_docstring_no_longer_claims_max_lifetime_is_the_death_backstop(self):
+        from tools import sdlc_lease_heartbeat as hb
+
+        assert "max-lifetime is the death backstop" not in (hb.__doc__ or "")

--- a/tests/unit/test_sdlc_lease_heartbeat.py
+++ b/tests/unit/test_sdlc_lease_heartbeat.py
@@ -592,9 +592,68 @@ class TestReleaseRaceIsClosed:
             )
 
         assert rc == 0
-        assert calls["n"] == 2  # tick 1 renewed nothing; tick 2 saw it gone
+        # The extend's compare-and-set loses on the released key, and the
+        # heartbeat consumes that result: it exits on THIS tick rather than
+        # falling through to the signal write and discovering the loss on a
+        # later peek. One peek total.
+        assert calls["n"] == 1
         # The extend did NOT recreate the released key.
         assert _R.get(self.KEY) is None
+        # And it never republished the companion supervised-run signal with a
+        # fresh TTL for a lease it no longer holds. Without this assertion the
+        # fail-closed renewal result could be discarded and the suite would
+        # still pass.
+        assert signals == []
+
+    def test_fail_closed_renewal_also_stops_the_signal_write(self):
+        """The other way the extend reports not-acquired: `renew_only`'s
+        fail-CLOSED exception handler. It must reach the same exit, or a
+        transient Redis blip would keep republishing the supervised-run
+        signal for a lease whose ownership could not be verified.
+        """
+        from models.session_lifecycle import IssueLockResult
+        from tools.sdlc_lease_heartbeat import run_heartbeat
+
+        def peek_ok_extend_fails_closed(*args, **kwargs):
+            if kwargs.get("peek"):
+                return IssueLockResult(
+                    acquired=False, owner_session_id="sdlc-local-2714", owner_run_id="mine"
+                )
+            # What touch_issue_lock returns for renew_only=True on any error.
+            return IssueLockResult(acquired=False, owner_session_id=None, owner_run_id=None)
+
+        # Bounded clock: the deadline is reachable, so a regression that stops
+        # consuming the fail-closed result fails this test on `signals` rather
+        # than spinning until the suite-wide timeout.
+        clock = {"n": 0}
+
+        def monotonic():
+            clock["n"] += 1
+            return 0.0 if clock["n"] <= 20 else 999.0
+
+        signals = []
+        with (
+            patch(
+                "models.session_lifecycle.touch_issue_lock",
+                side_effect=peek_ok_extend_fails_closed,
+            ),
+            patch(
+                "agent.supervised_run.write_supervised_run_signal",
+                side_effect=lambda *a, **kw: signals.append(a),
+            ),
+        ):
+            rc = run_heartbeat(
+                issue_number=self.ISSUE,
+                run_id="mine",
+                session_id="sdlc-local-2714",
+                interval=1,
+                max_lifetime=100,
+                _sleep=lambda s: None,
+                _monotonic=monotonic,
+            )
+
+        assert rc == 0
+        assert signals == []
 
 
 class TestSupervisorIdentityResolution:

--- a/tests/unit/test_sdlc_lease_heartbeat.py
+++ b/tests/unit/test_sdlc_lease_heartbeat.py
@@ -175,6 +175,135 @@ class TestPeekFirstRenewOnly:
         assert renewed["run_id"] == "mine"
         assert int(eval_args[5]) > 0  # ARGV[3]: the TTL
 
+    def test_no_supervisor_args_is_the_unchanged_pre_2714_behavior(self):
+        """Default-off proof (#2714 Test Impact): every branch this issue added
+        is inert unless an identity was explicitly recorded.
+
+        Called exactly as the pre-#2714 callers call it -- no supervisor args --
+        the loop peeks, renews, and exits at the caller's own bound: no process
+        is probed, no lease is released, no signal is cleared, and the exit
+        reason is the plain ``max_lifetime`` one, not the new unsupervised
+        ceiling. A regression here means the supervisor watch acquired a
+        default-on foothold.
+        """
+        import logging
+
+        from tools.sdlc_lease_heartbeat import run_heartbeat
+
+        calls = []
+
+        def fake_touch(issue, run_id, session_id="", ttl=None, peek=False, renew_only=False):
+            calls.append((run_id, peek, renew_only))
+            return _peek_result("mine") if peek else MagicMock()
+
+        ticks = iter([0.0, 1.0, 2.0, 999.0])
+        with (
+            patch("models.session_lifecycle.touch_issue_lock", side_effect=fake_touch),
+            patch("agent.supervised_run.write_supervised_run_signal") as write_signal,
+            patch("agent.session_health._psutil_process_for_pid") as probe,
+            patch("models.session_lifecycle.release_issue_lock") as release,
+            patch("agent.supervised_run.clear_supervised_run_signal") as clear,
+            patch.object(logging.getLogger("tools.sdlc_lease_heartbeat"), "info") as info,
+        ):
+            rc = run_heartbeat(
+                issue_number=2446,
+                run_id="mine",
+                interval=1,
+                max_lifetime=5,
+                _sleep=lambda s: None,
+                _monotonic=lambda: next(ticks),
+            )
+
+        assert rc == 0
+        assert probe.call_count == 0  # the supervisor watch never engaged
+        release.assert_not_called()
+        clear.assert_not_called()
+        renews = [c for c in calls if c[1] is False]
+        assert len(renews) >= 1
+        assert write_signal.call_count >= 1
+        logged = " ".join(str(c.args) for c in info.call_args_list)
+        assert "max_lifetime" in logged
+        assert "unsupervised_max_lifetime" not in logged
+
+    def test_dead_payload_pid_with_a_live_supervisor_still_renews(self):
+        """#2714 must never confuse the PAYLOAD pid with the SUPERVISOR pid.
+
+        Two different pids are in play on every local run: the lease payload's,
+        stamped by the ephemeral ``session-ensure`` CLI and dead by tick one,
+        and the supervising ``claude`` process's, handed over on the argv. Only
+        the latter may end the loop. Here the payload pid is dead and the
+        supervisor is alive: the renew must still fire (#2446/#2451) and the
+        lease must not be released.
+
+        Runs the REAL ``touch_issue_lock`` against the per-worker test Redis so
+        the payload-pid path is genuinely exercised, and keys the psutil double
+        on the pid so a mixed-up lookup shows up as an assertion failure rather
+        than a coincidence.
+        """
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+        from tools.sdlc_lease_heartbeat import run_heartbeat
+
+        issue = 271402
+        key = f"session:issuelock:{issue}"
+        payload_pid, supervisor_pid = 4242, 777
+        _R.delete(key)
+        _R.set(
+            key,
+            json.dumps(
+                {
+                    "run_id": "mine",
+                    "session_id": "sdlc-local-2714",
+                    "pid": payload_pid,  # the session-ensure CLI -- long dead
+                    "machine_id": "hw-uuid-1",
+                    "hostname": "this-host",
+                    "create_time": 1.0,
+                }
+            ),
+            ex=1800,
+        )
+
+        probed = []
+
+        def probe(pid):
+            probed.append(pid)
+            return None if pid == payload_pid else _alive_proc(99.0)
+
+        ticks = iter([0.0, 1.0, 2.0, 999.0])
+        try:
+            with (
+                patch("models.session_lifecycle._local_machine_id", return_value="hw-uuid-1"),
+                patch("agent.session_health._psutil_process_for_pid", side_effect=probe),
+                patch("agent.supervised_run.write_supervised_run_signal"),
+                patch("models.session_lifecycle.release_issue_lock") as release,
+            ):
+                rc = run_heartbeat(
+                    issue_number=issue,
+                    run_id="mine",
+                    session_id="sdlc-local-2714",
+                    interval=1,
+                    max_lifetime=5,
+                    supervisor_pid=supervisor_pid,
+                    supervisor_create_time=99.0,
+                    supervisor_check_interval=1,
+                    _sleep=lambda s: None,
+                    _monotonic=lambda: next(ticks),
+                )
+
+            assert rc == 0
+            # The dead payload pid never became a death signal ...
+            release.assert_not_called()
+            # ... and the supervisor pid is the one the watch actually probed.
+            assert supervisor_pid in probed
+            # The lease survived, renewed under our own identity.
+            stored = _R.get(key)
+            assert stored is not None
+            renewed = json.loads(stored)
+            assert renewed["run_id"] == "mine"
+            assert renewed["renewed_at"] > 0
+        finally:
+            _R.delete(key)
+
     def test_missing_identifiers_exit_clean_never_touch(self):
         from tools.sdlc_lease_heartbeat import run_heartbeat
 
@@ -344,6 +473,46 @@ class TestSupervisedRunSignalRenewal:
         assert rc == 0
         assert len(renews) >= 2  # the raising write did not end the loop
 
+    def test_signal_is_cleared_on_the_supervisor_dead_exit(self):
+        """#2714: a dead supervisor's signal is dropped, not left to expire.
+
+        #2659 coupled the signal's lifetime to the lease's, which is exactly
+        why a zombie heartbeat kept BOTH keys fresh. The coupling has to hold
+        in the other direction too: when the watch releases the lease it must
+        clear the companion signal under the same identity in the same breath,
+        or a stale ``session:supervisedrun:{N}`` outlives the lock it was
+        supposed to shadow for up to a full TTL and a successor's forks read a
+        dead run's ``run_id``.
+        """
+        from tools.sdlc_lease_heartbeat import run_heartbeat
+
+        ticks = iter([0.0, 1.0, 2.0, 3.0, 4.0])
+        with (
+            patch("models.session_lifecycle.touch_issue_lock", side_effect=_self_owned_touch()),
+            patch("agent.supervised_run.write_supervised_run_signal"),
+            patch("agent.session_health._psutil_process_for_pid", return_value=None),
+            patch("models.session_lifecycle.release_issue_lock") as release,
+            patch("agent.supervised_run.clear_supervised_run_signal") as clear,
+        ):
+            rc = run_heartbeat(
+                issue_number=2659,
+                run_id="mine",
+                session_id="sdlc-local-2659",
+                interval=1,
+                max_lifetime=100,
+                supervisor_pid=4242,
+                supervisor_create_time=99.0,
+                supervisor_check_interval=1,
+                _sleep=lambda s: None,
+                _monotonic=lambda: next(ticks),
+            )
+
+        assert rc == 0
+        # Compare-and-delete keyed on OUR run_id: a successor that already took
+        # over is never harmed by this clear.
+        clear.assert_called_once_with(2659, "mine")
+        release.assert_called_once_with(2659, "mine")
+
 
 class TestReleaseRaceIsClosed:
     """Race 1 (issue #2714): the supervisor releases the lease in the window
@@ -504,6 +673,32 @@ class TestSupervisorIdentityResolution:
         monkeypatch.delenv("CLAUDE_PID", raising=False)
         with patch.object(si, "_self_process", side_effect=RuntimeError("psutil exploded")):
             assert si.resolve_supervisor_identity_detailed() == (si.SOURCE_UNRESOLVED, None, None)
+            # The best-effort contract asserted through its OBSERVABLE fallback,
+            # not through a `pass`: the caller gets (None, None) and no
+            # exception crosses the boundary into the ensure that spawns the
+            # heartbeat.
+            assert si.resolve_supervisor_identity() == (None, None)
+
+    def test_env_tier_raising_degrades_to_the_ancestry_tier(self, monkeypatch):
+        """A failing tier degrades to the next one, never to unresolved."""
+        from tools import sdlc_supervisor_identity as si
+
+        monkeypatch.setenv("CLAUDE_PID", "32886")
+        ancestor = MagicMock()
+        ancestor.pid = 999
+        ancestor.exe.return_value = "/opt/homebrew/bin/claude"
+        ancestor.create_time.return_value = 222.5
+        me = MagicMock()
+        me.parents.return_value = [ancestor]
+
+        with (
+            patch(
+                "agent.session_health._psutil_process_for_pid",
+                side_effect=RuntimeError("psutil exploded"),
+            ),
+            patch.object(si, "_self_process", return_value=me),
+        ):
+            assert si.resolve_supervisor_identity_detailed() == (si.SOURCE_ANCESTRY, 999, 222.5)
 
     def test_module_never_consults_the_parent_pid_syscall(self):
         """spike-2 anti-criterion: ``ppid``/``getppid`` is not a death signal."""
@@ -769,6 +964,43 @@ class TestSupervisorLiveness:
         assert rc == 0
         release.assert_not_called()
         assert len(renews) >= 3  # the raising probe never stopped the renewer
+
+    def test_malformed_supervisor_argv_never_aborts_the_cli(self):
+        """The CLI boundary half of "malformed means unresolved, not dead".
+
+        ``--supervisor-pid`` / ``--supervisor-create-time`` are deliberately
+        parsed as strings. With ``type=int`` / ``type=float`` a garbage value
+        would abort argparse with exit code 2 and leave the lease with NO
+        renewer at all -- strictly worse than the unresolved fallback. The
+        values must reach ``run_heartbeat`` verbatim, where
+        ``_resolved_supervisor`` classifies them as unresolved.
+        """
+        import sys
+
+        from tools import sdlc_lease_heartbeat as hb
+
+        for pid, create_time in [("not-a-pid", "99.0"), ("0", "99.0"), ("-5", "not-a-time")]:
+            argv = [
+                "sdlc_lease_heartbeat",
+                "--issue-number",
+                "2714",
+                "--run-id",
+                "mine",
+                "--supervisor-pid",
+                pid,
+                "--supervisor-create-time",
+                create_time,
+            ]
+            with (
+                patch.object(sys, "argv", argv),
+                patch.object(hb, "run_heartbeat", return_value=0) as run,
+                patch.object(hb.logging, "basicConfig"),
+                patch.object(hb.sys, "exit"),
+            ):
+                hb.main()  # no SystemExit(2) from argparse
+
+            assert run.call_args.kwargs["supervisor_pid"] == pid
+            assert hb._resolved_supervisor(pid, create_time) == (None, None)
 
 
 class TestUnsupervisedCeiling:

--- a/tests/unit/test_sdlc_lease_heartbeat.py
+++ b/tests/unit/test_sdlc_lease_heartbeat.py
@@ -34,7 +34,7 @@ class TestPeekFirstRenewOnly:
 
         calls = []
 
-        def fake_touch(issue, run_id, session_id="", ttl=None, peek=False):
+        def fake_touch(issue, run_id, session_id="", ttl=None, peek=False, renew_only=False):
             calls.append((run_id, peek))
             # Peek on an absent key reports no owner.
             return _peek_result(None)
@@ -62,7 +62,7 @@ class TestPeekFirstRenewOnly:
 
         calls = []
 
-        def fake_touch(issue, run_id, session_id="", ttl=None, peek=False):
+        def fake_touch(issue, run_id, session_id="", ttl=None, peek=False, renew_only=False):
             calls.append((run_id, peek))
             return _peek_result("successor-run")
 
@@ -86,8 +86,8 @@ class TestPeekFirstRenewOnly:
 
         calls = []
 
-        def fake_touch(issue, run_id, session_id="", ttl=None, peek=False):
-            calls.append((run_id, peek))
+        def fake_touch(issue, run_id, session_id="", ttl=None, peek=False, renew_only=False):
+            calls.append((run_id, peek, renew_only))
             if peek:
                 return _peek_result("mine")  # self still owns
             return MagicMock()  # renew result (unused)
@@ -106,12 +106,14 @@ class TestPeekFirstRenewOnly:
             )
 
         assert rc == 0
-        # Each iteration: one peek (run_id=None) then one mutating renew (run_id="mine").
+        # Each iteration: one peek then one mutating renew (run_id="mine").
         peeks = [c for c in calls if c[1] is True]
         renews = [c for c in calls if c[1] is False]
         assert len(peeks) >= 1
         assert len(renews) >= 1
-        assert all(run_id == "mine" for run_id, peek in renews)  # renew under self only
+        assert all(run_id == "mine" for run_id, _peek, _renew_only in renews)
+        # Issue #2714 L0: the extend is renew-only -- it can never mint.
+        assert all(renew_only is True for _run_id, _peek, renew_only in renews)
 
     def test_renews_when_self_owned_payload_pid_is_dead(self):
         """#2537 review regression (PR #2615): the lease payload's pid is
@@ -146,7 +148,7 @@ class TestPeekFirstRenewOnly:
             patch("popoto.redis_db.POPOTO_REDIS_DB") as mock_redis,
         ):
             mock_redis.get.return_value = stored
-            mock_redis.set.return_value = False  # renew path: NX fails, re-SET follows
+            mock_redis.eval.return_value = 1  # CAS renewal wins
             rc = run_heartbeat(
                 issue_number=2537,
                 run_id="mine",
@@ -157,13 +159,21 @@ class TestPeekFirstRenewOnly:
             )
 
         assert rc == 0
-        # The mutating renew fired despite the dead payload pid: the renewal
-        # branch re-SETs the full payload with a fresh TTL.
-        assert mock_redis.set.call_count >= 1
-        _args, kwargs = mock_redis.set.call_args
-        assert kwargs.get("ex") is not None  # TTL-bearing renewal re-SET
-        renewed = json.loads(_args[1])
+        lock_key = "session:issuelock:2537"
+        # The mutating renew fired despite the dead payload pid. Under
+        # renew_only (issue #2714 L0) the renewal is a compare-and-set Lua
+        # EVAL carrying the full self-healed payload and a fresh TTL -- never
+        # a SET (which could mint).
+        lock_sets = [c for c in mock_redis.set.call_args_list if c.args[0] == lock_key]
+        assert lock_sets == []  # only the supervised-run signal used SET
+        assert mock_redis.eval.call_count >= 1
+        eval_args = mock_redis.eval.call_args.args
+        assert eval_args[1] == 1
+        assert eval_args[2] == lock_key
+        assert eval_args[3] == stored  # ARGV[1]: the exact raw value just read
+        renewed = json.loads(eval_args[4])  # ARGV[2]: the self-healed payload
         assert renewed["run_id"] == "mine"
+        assert int(eval_args[5]) > 0  # ARGV[3]: the TTL
 
     def test_missing_identifiers_exit_clean_never_touch(self):
         from tools.sdlc_lease_heartbeat import run_heartbeat
@@ -179,7 +189,7 @@ class TestPeekFirstRenewOnly:
 
         state = {"n": 0}
 
-        def flaky_touch(issue, run_id, session_id="", ttl=None, peek=False):
+        def flaky_touch(issue, run_id, session_id="", ttl=None, peek=False, renew_only=False):
             state["n"] += 1
             if state["n"] == 1 and peek:
                 raise RuntimeError("redis down")
@@ -216,7 +226,7 @@ class TestSupervisedRunSignalRenewal:
         """The renewing tick refreshes the signal under the same identity."""
         from tools.sdlc_lease_heartbeat import run_heartbeat
 
-        def fake_touch(issue, run_id, session_id="", ttl=None, peek=False):
+        def fake_touch(issue, run_id, session_id="", ttl=None, peek=False, renew_only=False):
             if peek:
                 return _peek_result("mine")  # self still owns
             return MagicMock()
@@ -260,7 +270,7 @@ class TestSupervisedRunSignalRenewal:
         """
         from tools.sdlc_lease_heartbeat import run_heartbeat
 
-        def fake_touch(issue, run_id, session_id="", ttl=None, peek=False):
+        def fake_touch(issue, run_id, session_id="", ttl=None, peek=False, renew_only=False):
             return _peek_result("successor-run")
 
         with (
@@ -283,7 +293,7 @@ class TestSupervisedRunSignalRenewal:
         lease we no longer hold (the signal must never outlive the lock)."""
         from tools.sdlc_lease_heartbeat import run_heartbeat
 
-        def fake_touch(issue, run_id, session_id="", ttl=None, peek=False):
+        def fake_touch(issue, run_id, session_id="", ttl=None, peek=False, renew_only=False):
             return _peek_result(None)
 
         with (
@@ -308,7 +318,7 @@ class TestSupervisedRunSignalRenewal:
 
         renews = []
 
-        def fake_touch(issue, run_id, session_id="", ttl=None, peek=False):
+        def fake_touch(issue, run_id, session_id="", ttl=None, peek=False, renew_only=False):
             if peek:
                 return _peek_result("mine")
             renews.append(run_id)
@@ -333,3 +343,86 @@ class TestSupervisedRunSignalRenewal:
 
         assert rc == 0
         assert len(renews) >= 2  # the raising write did not end the loop
+
+
+class TestReleaseRaceIsClosed:
+    """Race 1 (issue #2714): the supervisor releases the lease in the window
+    between the heartbeat's peek and its extend.
+
+    Before the L0 renew-only mode, the extend's ``SET NX`` succeeded on the
+    now-absent key and the heartbeat RE-MINTED the lease it had just lost --
+    then renewed it to the 4h ceiling with no supervisor behind it, which is
+    #2714's exact bug. Runs the REAL ``touch_issue_lock`` against the
+    per-worker test Redis db: only the release is injected.
+    """
+
+    ISSUE = 271401
+    KEY = f"session:issuelock:{ISSUE}"
+
+    def teardown_method(self):
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+        _R.delete(self.KEY)
+
+    def test_release_between_peek_and_extend_leaves_key_absent(self):
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+        from models.session_lifecycle import touch_issue_lock
+        from tools.sdlc_lease_heartbeat import run_heartbeat
+
+        _R.set(
+            self.KEY,
+            json.dumps(
+                {
+                    "run_id": "mine",
+                    "session_id": "sdlc-local-2714",
+                    "pid": 1,
+                    "hostname": "h",
+                }
+            ),
+            ex=1800,
+        )
+
+        calls = {"n": 0}
+
+        def touch_then_release(*args, **kwargs):
+            result = touch_issue_lock(*args, **kwargs)
+            if kwargs.get("peek"):
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    # The supervisor releases the lease right after our peek
+                    # reported self-ownership, before the extend lands.
+                    _R.delete(self.KEY)
+            return result
+
+        # Deterministic clock with a generous budget: the loop is free to run
+        # many ticks, so ending after exactly two proves it took the
+        # lease-lost exit rather than the deadline.
+        clock = {"n": 0}
+
+        def monotonic():
+            clock["n"] += 1
+            return 0.0 if clock["n"] <= 20 else 999.0
+
+        signals = []
+        with (
+            patch("models.session_lifecycle.touch_issue_lock", side_effect=touch_then_release),
+            patch(
+                "agent.supervised_run.write_supervised_run_signal",
+                side_effect=lambda *a, **kw: signals.append(a),
+            ),
+        ):
+            rc = run_heartbeat(
+                issue_number=self.ISSUE,
+                run_id="mine",
+                session_id="sdlc-local-2714",
+                interval=1,
+                max_lifetime=100,
+                _sleep=lambda s: None,
+                _monotonic=monotonic,
+            )
+
+        assert rc == 0
+        assert calls["n"] == 2  # tick 1 renewed nothing; tick 2 saw it gone
+        # The extend did NOT recreate the released key.
+        assert _R.get(self.KEY) is None

--- a/tests/unit/test_sdlc_session_ensure.py
+++ b/tests/unit/test_sdlc_session_ensure.py
@@ -2707,3 +2707,67 @@ class TestOwnedRunIdsSelfRecognition:
 
         assert result["blocked"] is True
         assert result["reason"] == "SUPERVISED_RUN_ACTIVE"
+
+
+class TestLeaseHeartbeatSpawnIdentity:
+    """Issue #2714 L2: the spawner hands the heartbeat its supervisor identity.
+
+    The heartbeat is detached (``start_new_session=True``) and reparented to
+    pid 1 within seconds, so it can only ever watch an EXPLICITLY RECORDED
+    supervisor ``(pid, create_time)`` -- spike-2 proved the parent-pid shortcut
+    is unsound because it reads a HEALTHY heartbeat as orphaned.
+    """
+
+    def _spawn(self, monkeypatch, detailed):
+        from tools import sdlc_session_ensure as se
+        from tools import sdlc_supervisor_identity as si
+
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        monkeypatch.delenv("VALOR_WORKER_MODE", raising=False)
+        with (
+            patch.object(si, "resolve_supervisor_identity_detailed", detailed),
+            patch("subprocess.Popen") as popen,
+        ):
+            se._maybe_launch_lease_heartbeat(2714, "run-abc", "sdlc-local-2714")
+        return popen
+
+    def test_argv_carries_identity_when_both_halves_resolve(self, monkeypatch):
+        from tools import sdlc_supervisor_identity as si
+
+        popen = self._spawn(monkeypatch, MagicMock(return_value=(si.SOURCE_ENV, 32886, 111.5)))
+
+        popen.assert_called_once()
+        argv = popen.call_args.args[0]
+        assert "--supervisor-pid" in argv
+        assert argv[argv.index("--supervisor-pid") + 1] == "32886"
+        assert argv[argv.index("--supervisor-create-time") + 1] == "111.5"
+        assert argv[argv.index("--supervisor-source") + 1] == si.SOURCE_ENV
+
+    def test_argv_omits_identity_when_unresolved(self, monkeypatch):
+        from tools import sdlc_supervisor_identity as si
+
+        popen = self._spawn(monkeypatch, MagicMock(return_value=(si.SOURCE_UNRESOLVED, None, None)))
+
+        popen.assert_called_once()
+        argv = popen.call_args.args[0]
+        assert "--supervisor-pid" not in argv
+        assert "--supervisor-create-time" not in argv
+
+    def test_resolver_raising_still_spawns_the_heartbeat(self, monkeypatch):
+        """The renewer is the load-bearing part; identity is an enhancement."""
+        popen = self._spawn(monkeypatch, MagicMock(side_effect=RuntimeError("psutil exploded")))
+
+        popen.assert_called_once()
+        argv = popen.call_args.args[0]
+        assert "--supervisor-pid" not in argv
+        assert "--issue-number" in argv
+
+    def test_pytest_guard_still_blocks_every_spawn(self, monkeypatch):
+        """The guard at sdlc_session_ensure.py:164 must stay intact -- a real
+        detached process must never outlive the test suite."""
+        from tools import sdlc_session_ensure as se
+
+        monkeypatch.setenv("PYTEST_CURRENT_TEST", "test_x (call)")
+        with patch("subprocess.Popen") as popen:
+            se._maybe_launch_lease_heartbeat(2714, "run-abc", "sdlc-local-2714")
+        popen.assert_not_called()

--- a/tests/unit/test_sdlc_session_release.py
+++ b/tests/unit/test_sdlc_session_release.py
@@ -1,0 +1,226 @@
+"""Unit tests for ``tools.sdlc_session_release`` (issue #2714, L1).
+
+``release_run`` is a THIN wrapper over two already-ownership-checked
+compare-and-delete primitives (``release_issue_lock`` and
+``clear_supervised_run_signal``). These tests therefore assert two things:
+
+1. The reason taxonomy is exactly ``released`` / ``not_owner`` / ``no_lease`` /
+   ``missing_args`` / ``error`` and maps onto real Redis lease states. The
+   lease/signal keys are plain (non-Popoto-managed) Redis keys, so the raw
+   client is the correct read path for assertions here.
+2. The subcommand is reachable **through the ``sdlc-tool`` dispatcher**, not
+   merely importable — without the ``ALLOWED_SUBCOMMANDS`` entry the skill step
+   is a silent no-op (issue #2714 Agent Integration).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ISSUE = 992714
+
+
+def _redis():
+    from popoto.redis_db import POPOTO_REDIS_DB
+
+    return POPOTO_REDIS_DB
+
+
+def _lock_key(issue_number: int) -> str:
+    return f"session:issuelock:{issue_number}"
+
+
+def _signal_key(issue_number: int) -> str:
+    return f"session:supervisedrun:{issue_number}"
+
+
+@pytest.fixture
+def clean_keys():
+    """Drop the (non-Popoto) lease + signal keys before and after each test."""
+    r = _redis()
+    for key in (_lock_key(ISSUE), _signal_key(ISSUE)):
+        r.delete(key)
+    yield
+    for key in (_lock_key(ISSUE), _signal_key(ISSUE)):
+        r.delete(key)
+
+
+def _acquire(run_id: str) -> None:
+    """Take the real issue lease + publish the supervised-run signal."""
+    from agent.supervised_run import write_supervised_run_signal
+    from models.session_lifecycle import touch_issue_lock
+
+    result = touch_issue_lock(ISSUE, run_id, session_id="sess-1", target_repo="ai")
+    assert result.acquired, "test setup failed to acquire the issue lease"
+    write_supervised_run_signal(ISSUE, run_id, session_id="sess-1")
+    assert _redis().get(_signal_key(ISSUE)) is not None
+
+
+class TestReleaseRun:
+    """The reason taxonomy, exercised against real Redis lease state."""
+
+    def test_releases_when_owner(self, clean_keys):
+        from tools.sdlc_session_release import release_run
+
+        _acquire("run-owner")
+        result = release_run(ISSUE, "run-owner")
+
+        assert result == {
+            "released": True,
+            "reason": "released",
+            "issue_number": ISSUE,
+            "run_id": "run-owner",
+        }
+        assert _redis().get(_lock_key(ISSUE)) is None
+
+    def test_clears_the_supervised_run_signal(self, clean_keys):
+        from tools.sdlc_session_release import release_run
+
+        _acquire("run-owner")
+        release_run(ISSUE, "run-owner")
+
+        assert _redis().get(_signal_key(ISSUE)) is None
+
+    def test_foreign_run_id_is_a_no_op(self, clean_keys):
+        """A wrong run_id must neither release the lease nor clear the signal."""
+        from tools.sdlc_session_release import release_run
+
+        _acquire("run-owner")
+        result = release_run(ISSUE, "run-intruder")
+
+        assert result["released"] is False
+        assert result["reason"] == "not_owner"
+        assert _redis().get(_lock_key(ISSUE)) is not None
+        assert _redis().get(_signal_key(ISSUE)) is not None
+
+    def test_absent_lease_reports_no_lease(self, clean_keys):
+        from tools.sdlc_session_release import release_run
+
+        result = release_run(ISSUE, "run-nobody")
+
+        assert result["released"] is False
+        assert result["reason"] == "no_lease"
+
+    @pytest.mark.parametrize(
+        "issue_number,run_id",
+        [
+            (None, "run-1"),
+            (0, "run-1"),
+            (ISSUE, None),
+            (ISSUE, ""),
+            (ISSUE, "   "),
+            (None, None),
+        ],
+    )
+    def test_missing_args_never_reaches_the_primitives(self, issue_number, run_id):
+        """Empty/whitespace input short-circuits BEFORE any Redis primitive."""
+        from tools.sdlc_session_release import release_run
+
+        release_mock = MagicMock()
+        clear_mock = MagicMock()
+        with (
+            patch("models.session_lifecycle.release_issue_lock", release_mock),
+            patch("agent.supervised_run.clear_supervised_run_signal", clear_mock),
+        ):
+            result = release_run(issue_number, run_id)
+
+        assert result["released"] is False
+        assert result["reason"] == "missing_args"
+        release_mock.assert_not_called()
+        clear_mock.assert_not_called()
+
+    def test_redis_error_is_swallowed_into_a_named_reason(self, clean_keys):
+        """A raising primitive yields a printable reason, never an empty dict."""
+        from tools.sdlc_session_release import release_run
+
+        boom = MagicMock(side_effect=RuntimeError("redis down"))
+        with patch("models.session_lifecycle.release_issue_lock", boom):
+            result = release_run(ISSUE, "run-owner")
+
+        assert result == {
+            "released": False,
+            "reason": "error",
+            "issue_number": ISSUE,
+            "run_id": "run-owner",
+        }
+
+
+class TestNoRawDelete:
+    """Anti-criterion: the tool must delegate, never delete on its own."""
+
+    def test_module_source_contains_no_raw_delete_path(self):
+        import tools.sdlc_session_release as mod
+
+        with open(mod.__file__) as fh:
+            source = fh.read()
+
+        assert ".delete(" not in source
+        assert "DEL " not in source
+
+
+class TestDispatcherIntegration:
+    """The agent reaches this via ``sdlc-tool``; importing it is not enough."""
+
+    def test_subcommand_is_allowlisted_in_the_dispatcher(self):
+        with open(os.path.join(REPO_ROOT, "scripts", "sdlc-tool")) as fh:
+            source = fh.read()
+
+        allowlist_line = next(
+            line for line in source.splitlines() if line.startswith("ALLOWED_SUBCOMMANDS=")
+        )
+        assert "session-release" in allowlist_line
+        assert "session-release" in source  # also described in usage()
+
+    def test_help_is_reachable_through_the_dispatcher(self):
+        proc = subprocess.run(
+            [os.path.join(REPO_ROOT, "scripts", "sdlc-tool"), "session-release", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=90,
+            env={**os.environ, "AI_REPO_ROOT": REPO_ROOT},
+        )
+
+        assert proc.returncode == 0, proc.stderr
+        assert "--issue-number" in proc.stdout
+        assert "--run-id" in proc.stdout
+
+
+class TestCLI:
+    def test_main_emits_typed_json_and_exits_zero(self, clean_keys, capsys):
+        from tools.sdlc_session_release import main
+
+        _acquire("run-cli")
+        with patch.object(
+            sys,
+            "argv",
+            ["sdlc_session_release", "--issue-number", str(ISSUE), "--run-id", "run-cli"],
+        ):
+            code = main()
+
+        payload = json.loads(capsys.readouterr().out)
+        assert code == 0
+        assert payload == {
+            "released": True,
+            "reason": "released",
+            "issue_number": ISSUE,
+            "run_id": "run-cli",
+        }
+
+    def test_main_without_args_is_missing_args_exit_zero(self, capsys):
+        from tools.sdlc_session_release import main
+
+        with patch.object(sys, "argv", ["sdlc_session_release"]):
+            code = main()
+
+        payload = json.loads(capsys.readouterr().out)
+        assert code == 0
+        assert payload["released"] is False
+        assert payload["reason"] == "missing_args"

--- a/tests/unit/test_sdlc_stage_marker.py
+++ b/tests/unit/test_sdlc_stage_marker.py
@@ -1547,3 +1547,85 @@ class TestSkipMarkerWrite:
         assert code == 1
         assert result["reason"] == "STAGE_RAN_NOT_SKIPPABLE"
         assert "STAGE_RAN_NOT_SKIPPABLE" in capsys.readouterr().err
+
+
+class TestMergeCompletedReleasesLease:
+    """The tool-layer release leg (issue #2714 L1, round-1 History CONCERN).
+
+    A skill-body prose step cannot be the only release mechanism -- #1654
+    failed for exactly that reason. The happy path therefore releases from the
+    tool layer, on the MERGE/completed marker write itself, so it fires for
+    ``/do-sdlc``, the ``/sdlc`` router, and worker-driven pipelines alike with
+    zero skill cooperation.
+    """
+
+    @staticmethod
+    def _live_lock():
+        from models.session_lifecycle import IssueLockResult
+
+        return MagicMock(
+            return_value=IssueLockResult(
+                acquired=True, owner_session_id="s", owner_run_id="run-m", target_repo="o/r"
+            )
+        )
+
+    def _write(self, states, release_mock, stage="MERGE", status="completed"):
+        from tools.sdlc_stage_marker import SUBSTRATE_PRESENT, write_marker
+
+        mock_sm = MagicMock()
+        mock_sm.states = states
+
+        with (
+            patch("tools.sdlc_stage_marker.probe_substrate", return_value=SUBSTRATE_PRESENT),
+            patch("models.session_lifecycle.touch_issue_lock", self._live_lock()),
+            patch("agent.pipeline_state.PipelineStateMachine.for_issue", return_value=mock_sm),
+            patch("tools._sdlc_utils.revalidate_ledger_lease", return_value=True),
+            patch("tools.sdlc_session_release.release_run", release_mock),
+        ):
+            return write_marker(stage=stage, status=status, issue_number=2714, run_id="run-m")
+
+    def test_successful_merge_completion_releases_the_run(self):
+        release_mock = MagicMock(return_value={"released": True, "reason": "released"})
+
+        result, code = self._write({"MERGE": "in_progress"}, release_mock)
+
+        assert code == 0
+        assert result == {"stage": "MERGE", "status": "completed"}
+        release_mock.assert_called_once_with(2714, "run-m")
+
+    def test_idempotent_merge_completion_does_not_release(self):
+        """Race 3: the already-completed branch does not own the transition,
+        so releasing there could free a SUCCESSOR run's lease."""
+        release_mock = MagicMock()
+
+        result, code = self._write({"MERGE": "completed"}, release_mock)
+
+        assert code == 0
+        assert result == {"stage": "MERGE", "status": "completed"}
+        release_mock.assert_not_called()
+
+    def test_non_merge_completion_does_not_release(self):
+        release_mock = MagicMock()
+
+        _, code = self._write({"DOCS": "in_progress"}, release_mock, stage="DOCS")
+
+        assert code == 0
+        release_mock.assert_not_called()
+
+    def test_merge_in_progress_does_not_release(self):
+        release_mock = MagicMock()
+
+        _, code = self._write({"MERGE": "pending"}, release_mock, status="in_progress")
+
+        assert code == 0
+        release_mock.assert_not_called()
+
+    def test_release_failure_never_fails_the_marker_write(self):
+        """Best-effort: a raising release must not turn a good write into an error."""
+        release_mock = MagicMock(side_effect=RuntimeError("redis down"))
+
+        result, code = self._write({"MERGE": "in_progress"}, release_mock)
+
+        assert code == 0
+        assert result == {"stage": "MERGE", "status": "completed"}
+        release_mock.assert_called_once_with(2714, "run-m")

--- a/tests/unit/test_session_lifecycle.py
+++ b/tests/unit/test_session_lifecycle.py
@@ -1508,6 +1508,179 @@ class TestTouchIssueLockTargetRepoPinning:
         assert renewed_payload["target_repo"] == "tomcounsell/ai"
 
 
+class TestRenewOnly:
+    """Tests for touch_issue_lock(..., renew_only=True) -- issue #2714 L0.
+
+    A renewer must NEVER mint. The default (``renew_only=False``) path has two
+    independent minting branches (the ``SET NX`` and the follow-up
+    ``raw is None`` "treat as acquired" race window); under ``renew_only``
+    both are skipped and the renewal write goes through a compare-and-set Lua
+    script, so re-minting a lease the supervisor just released is structurally
+    impossible rather than argued down.
+
+    The state assertions run against the real (per-worker test db) Redis so
+    "leaves the key absent" is a claim about Redis, not about a mock.
+    """
+
+    ISSUE = 271400
+    KEY = f"session:issuelock:{ISSUE}"
+
+    def teardown_method(self):
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+        _R.delete(self.KEY)
+
+    def _seed(self, payload, ttl=1800):
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+        _R.set(self.KEY, json.dumps(payload), ex=ttl)
+
+    def _stored(self):
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+        raw = _R.get(self.KEY)
+        return None if raw is None else json.loads(raw)
+
+    def test_absent_key_is_not_minted(self):
+        """BLOCKER regression (#2714): the heartbeat's extend landing one
+        millisecond after the supervisor released the lease must report
+        not-acquired AND leave the key absent -- never re-mint it."""
+        from models.session_lifecycle import touch_issue_lock
+
+        result = touch_issue_lock(
+            self.ISSUE, "run-a", session_id="sdlc-local-2714", renew_only=True
+        )
+
+        assert result.acquired is False
+        assert result.owner_run_id is None
+        assert result.owner_session_id is None
+        assert self._stored() is None  # the key is still absent
+
+    def test_self_owned_key_renews_and_self_heals(self):
+        """A self-owned lease still renews under renew_only, and still gains
+        target_repo / machine_id / renewed_at on a legacy payload."""
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+        from models.session_lifecycle import ISSUE_LOCK_TTL_SECONDS, touch_issue_lock
+
+        self._seed(
+            {
+                "run_id": "run-a",
+                "session_id": "sdlc-local-2714",
+                "pid": 1,
+                "hostname": "h",
+                "create_time": 1000.0,
+            },
+            ttl=30,
+        )
+
+        with patch("models.session_lifecycle._local_machine_id", return_value="hw-uuid-1"):
+            result = touch_issue_lock(
+                self.ISSUE,
+                "run-a",
+                session_id="sdlc-local-2714",
+                target_repo="tomcounsell/ai",
+                renew_only=True,
+            )
+
+        assert result.acquired is True
+        assert result.owner_run_id == "run-a"
+        assert result.owner_session_id == "sdlc-local-2714"
+        assert result.target_repo == "tomcounsell/ai"
+
+        renewed = self._stored()
+        assert renewed["target_repo"] == "tomcounsell/ai"
+        assert renewed["machine_id"] == "hw-uuid-1"
+        assert renewed["renewed_at"] > 0
+        # Untouched identity fields survive the renewal verbatim.
+        assert renewed["pid"] == 1
+        assert renewed["hostname"] == "h"
+        assert renewed["create_time"] == 1000.0
+        # The CAS re-applies the full lease TTL, not the 30s the seed carried.
+        assert _R.ttl(self.KEY) > 30
+        assert _R.ttl(self.KEY) <= ISSUE_LOCK_TTL_SECONDS
+
+    def test_foreign_key_reports_owner_and_does_not_write(self):
+        from models.session_lifecycle import touch_issue_lock
+
+        self._seed(
+            {
+                "run_id": "successor-run",
+                "session_id": "sdlc-local-2714",
+                "pid": 999,
+                "hostname": "other",
+            }
+        )
+        before = self._stored()
+
+        result = touch_issue_lock(
+            self.ISSUE, "run-a", session_id="sdlc-local-2714", renew_only=True
+        )
+
+        assert result.acquired is False
+        assert result.owner_run_id == "successor-run"
+        assert self._stored() == before  # nothing written
+
+    def test_cas_loses_when_value_changed_between_read_and_write(self):
+        """A release landing inside the read->write window makes the CAS a
+        no-op: report not-acquired, and never recreate the key."""
+        from popoto.redis_db import POPOTO_REDIS_DB as _R
+
+        from models.session_lifecycle import touch_issue_lock
+
+        self._seed({"run_id": "run-a", "session_id": "sdlc-local-2714", "pid": 1})
+
+        real_get = _R.get
+
+        def get_then_release(key, *a, **kw):
+            raw = real_get(key, *a, **kw)
+            if key == self.KEY:
+                _R.delete(self.KEY)  # supervisor releases mid-call
+            return raw
+
+        with patch.object(_R, "get", side_effect=get_then_release):
+            result = touch_issue_lock(
+                self.ISSUE, "run-a", session_id="sdlc-local-2714", renew_only=True
+            )
+
+        assert result.acquired is False
+        assert result.owner_run_id is None
+        assert self._stored() is None
+
+    def test_default_still_mints_via_set_nx(self):
+        """renew_only=False (the default) is unchanged for every existing
+        caller, including the SET NX acquire."""
+        from models.session_lifecycle import touch_issue_lock
+
+        with patch("popoto.redis_db.POPOTO_REDIS_DB") as mock_redis:
+            mock_redis.set.return_value = True
+            result = touch_issue_lock(1954, "run-a", session_id="sdlc-local-1954")
+
+        assert result.acquired is True
+        assert result.owner_run_id == "run-a"
+        _args, kwargs = mock_redis.set.call_args
+        assert kwargs.get("nx") is True
+        mock_redis.eval.assert_not_called()
+
+    def test_redis_error_fails_closed_for_renewer_open_for_default(self):
+        """A renewer must fail CLOSED: a transient Redis error on the extend
+        must never report ownership of a lease it may not hold. The
+        non-renew_only default keeps #2446's fail-open behavior."""
+        from models.session_lifecycle import touch_issue_lock
+
+        with patch("popoto.redis_db.POPOTO_REDIS_DB") as mock_redis:
+            mock_redis.get.side_effect = RuntimeError("redis down")
+            mock_redis.set.side_effect = RuntimeError("redis down")
+            renewer = touch_issue_lock(1954, "run-a", renew_only=True)
+            default = touch_issue_lock(1954, "run-a")
+
+        assert renewer.acquired is False
+        assert renewer.owner_run_id is None
+        assert renewer.owner_session_id is None
+        assert default.acquired is True  # #2446 fail-open preserved
+        assert default.owner_run_id == "run-a"
+
+
 class TestReleaseIssueLock:
     """Tests for release_issue_lock() -- the COMPARE-AND-DELETE release
     (issue #2003, cycle-2 CONCERN 2). Never a raw DEL."""

--- a/tools/_sdlc_run_identity.py
+++ b/tools/_sdlc_run_identity.py
@@ -199,9 +199,15 @@ def reestablish_run_id(
         # the just-acquired lease so it does not linger.
         if new_run_id != candidate and _pipeline_is_terminal(issue_number):
             try:
-                from models.session_lifecycle import release_issue_lock
+                # Routed through release_run (issue #2714) so this site also
+                # clears the supervised-run signal, not just the lease --
+                # otherwise a bare `session-ensure` could still inherit the
+                # dead run's identity from a signal nobody dropped. Local
+                # import: tools.sdlc_session_release is only needed on this
+                # narrow terminal-guard path.
+                from tools.sdlc_session_release import release_run
 
-                release_issue_lock(issue_number, new_run_id)
+                release_run(issue_number, new_run_id)
             except Exception as e:  # pragma: no cover - fail-open
                 logger.debug("reestablish_run_id: terminal-guard release failed: %s", e)
             return None

--- a/tools/sdlc_lease_heartbeat.py
+++ b/tools/sdlc_lease_heartbeat.py
@@ -10,19 +10,26 @@ module is that missing renewer, launched detached by
 ``tools/sdlc_session_ensure._acquire_run_lock_and_bind`` on a fresh local mint.
 
 **Peek-first, renew-only (BLOCKER 1 -- the load-bearing safety property).**
-``touch_issue_lock`` has NO renew-only mode: passing a ``run_id`` against an
-*absent* key in a non-peek call does ``SET NX EX`` and makes the caller the
-owner (``models/session_lifecycle.py`` ~lines 1100-1123). A naive renew loop
+A DEFAULT ``touch_issue_lock`` call passing a ``run_id`` against an *absent*
+key does ``SET NX EX`` and makes the caller the owner. A naive renew loop
 would therefore let a zombie heartbeat *re-acquire* a lapsed lease under its
 stale id and block a legitimate successor with ``ISSUE_LOCKED`` -- the exact
-lease-theft Risk 2 forbids. So every tick PEEKS first
+lease-theft Risk 2 forbids. Two independent guards close that:
+
+**The extend is ``renew_only=True``** (issue #2714), which skips both of
+``touch_issue_lock``'s minting branches and writes through a compare-and-set
+Lua script. This is the structural half: minting is impossible for this
+caller, not merely avoided by convention, so even a release landing between
+the peek and the extend cannot be undone by the extend.
+
+**Every tick PEEKS first**
 (``touch_issue_lock(issue, run_id, peek=True)`` -- a peek never mutates,
 whatever run_id it carries) and:
 
 - ``peek.owner_run_id is None`` (lease absent/lapsed) -> EXIT 0 immediately.
 - ``peek.owner_run_id != run_id`` (a successor owns it) -> EXIT 0 immediately.
 - ``peek.owner_run_id == run_id`` -> ONLY THEN call the mutating
-  ``touch_issue_lock(issue, run_id, ...)`` to extend the TTL.
+  ``touch_issue_lock(issue, run_id, ..., renew_only=True)`` to extend the TTL.
 
 This is deliberately an OWNERSHIP check, never a pid-liveness one (issue
 #2537 review): the payload's ``pid`` is stamped by the short-lived
@@ -150,11 +157,19 @@ def run_heartbeat(
                 )
                 return 0
             # Self-owned: extend the TTL under our own identity only.
+            # `renew_only=True` (issue #2714) makes that structural rather
+            # than conventional: the extend skips both of `touch_issue_lock`'s
+            # minting branches and writes through a compare-and-set, so a
+            # release landing between the peek above and this call cannot be
+            # undone by it. Without it the extend re-minted the lease the
+            # supervisor had just given up and renewed it to the max-lifetime
+            # ceiling with nothing behind it.
             touch_issue_lock(
                 issue_number,
                 run_id,
                 session_id=session_id,
                 ttl=ISSUE_LOCK_TTL_SECONDS,
+                renew_only=True,
             )
             # Refresh the companion supervised-run signal on the same tick
             # (issue #2659). The signal carries the lock's TTL but was written

--- a/tools/sdlc_lease_heartbeat.py
+++ b/tools/sdlc_lease_heartbeat.py
@@ -426,13 +426,29 @@ def run_heartbeat(
                 # undone by it. Without it the extend re-minted the lease the
                 # supervisor had just given up and renewed it to the max-lifetime
                 # ceiling with nothing behind it.
-                touch_issue_lock(
+                extended = touch_issue_lock(
                     issue_number,
                     run_id,
                     session_id=session_id,
                     ttl=ISSUE_LOCK_TTL_SECONDS,
                     renew_only=True,
                 )
+                if not extended.acquired:
+                    # The CAS lost (a release landed inside the peek/extend
+                    # window) or `renew_only`'s fail-closed handler fired. Either
+                    # way we no longer hold the lease, so stop here rather than
+                    # falling through: the signal write below would otherwise
+                    # republish `session:supervisedrun:{N}` with a fresh TTL for
+                    # a lease we do not hold, which is the exact shape
+                    # `renew_only` fails closed to prevent. Exiting instead of
+                    # retrying is correct -- an absent or foreign lease is
+                    # terminal for this heartbeat, never re-acquirable (Risk 2).
+                    return _log_exit(
+                        EXIT_LEASE_LOST,
+                        issue_number,
+                        run_id,
+                        "renewal lost the lease between peek and extend",
+                    )
                 # Refresh the companion supervised-run signal on the same tick
                 # (issue #2659). The signal carries the lock's TTL but was written
                 # only at acquire, so before this it expired 1800s into every run

--- a/tools/sdlc_lease_heartbeat.py
+++ b/tools/sdlc_lease_heartbeat.py
@@ -9,7 +9,7 @@ no equivalent renewer, so its lease can lapse mid-run and force a re-mint. This
 module is that missing renewer, launched detached by
 ``tools/sdlc_session_ensure._acquire_run_lock_and_bind`` on a fresh local mint.
 
-**Peek-first, renew-only (BLOCKER 1 -- the load-bearing safety property).**
+**Peek-first, renew-only (the load-bearing safety property).**
 A DEFAULT ``touch_issue_lock`` call passing a ``run_id`` against an *absent*
 key does ``SET NX EX`` and makes the caller the owner. A naive renew loop
 would therefore let a zombie heartbeat *re-acquire* a lapsed lease under its
@@ -36,11 +36,38 @@ This is deliberately an OWNERSHIP check, never a pid-liveness one (issue
 ``sdlc-tool session-ensure`` CLI at acquire time and is dead before this
 detached heartbeat's first tick, so the peek's pid-keyed ``orphaned_lock``
 signal reads every locally-minted lease as orphaned and must not gate the
-renew. Run-liveness is this heartbeat's own existence; its bounded
-max-lifetime is the death backstop. The shape mirrors ``touch_issue_lock``'s
-own "no run_id supplied: never mutates" special case at the caller layer: the
-heartbeat can only ever EXTEND a lease it already owns, never mint on a free
-key nor steal one from a successor.
+renew. The shape mirrors ``touch_issue_lock``'s own "no run_id supplied:
+never mutates" special case at the caller layer: the heartbeat can only ever
+EXTEND a lease it already owns, never mint on a free key nor steal one from a
+successor.
+
+**Run liveness is the SUPERVISOR's liveness (issue #2714).** The heartbeat's
+own existence proves nothing about the run: a supervisor killed mid-stage
+leaves this loop renewing a lease for a pipeline nobody is driving, and every
+subsequent attempt on that issue reads ``ISSUE_LOCKED``. So the supervising
+``claude`` process's identity -- ``(pid, create_time)``, resolved by
+``tools/sdlc_supervisor_identity.py`` at mint time and handed over on the
+argv -- is polled every ``SDLC_SUPERVISOR_CHECK_INTERVAL_SECONDS``. On
+``SDLC_SUPERVISOR_DEATH_CONFIRMATIONS`` CONSECUTIVE positive-death
+observations the lease is released, the supervised-run signal cleared, and
+the loop exits. The evidence bar is deliberately asymmetric: a pid psutil
+cannot find, or one whose ``create_time`` no longer matches within ``1e-3``
+(pid recycling), counts as dead -- but ANY exception counts as NOT dead, so
+an unverifiable probe fails toward HOLDING the lease (#2446).
+
+The parent pid is never consulted. ``start_new_session=True`` detaches this
+process at spawn and its spawner (the ephemeral ``session-ensure`` CLI) exits
+seconds later, so a HEALTHY heartbeat is reparented to pid 1 almost at once;
+reading that as death would drop a live run's lease on tick one.
+
+**Two bounds, chosen by evidence quality.** When a supervisor identity was
+recorded, the loop's ceiling is the unchanged 4h ``MAX_LIFETIME_SECONDS`` --
+the supervisor watch is the real death detector and a long BUILD stage must
+not lapse its own lease. When no identity could be resolved, the ceiling
+drops to the 90-minute ``UNSUPERVISED_MAX_LIFETIME_SECONDS`` and the loop
+stops renewing WITHOUT releasing: a failure to resolve a supervisor is not
+positive proof the run is dead, so the lease's own 1800s TTL is the correct
+disposition. The two are mutually exclusive, never stacked.
 
 **The supervised-run signal renews with the lease (issue #2659).** A renewed
 tick also refreshes ``session:supervisedrun:{N}``
@@ -53,18 +80,30 @@ stood down. The two keys now share this loop's lifetime, so the signal can
 never outlive the lease and the lease can never outlive the signal by more
 than one renewal interval.
 
+**Cadence is split.** The loop wakes every
+``SDLC_SUPERVISOR_CHECK_INTERVAL_SECONDS`` to poll the supervisor but only
+peeks and renews once ``--interval`` seconds of sleep have accumulated. Crash
+detection tightens to ~2 minutes without changing Redis renew load.
+
+**Observability.** ``main()`` configures INFO logging unconditionally and
+every decision is an INFO record in ``logs/sdlc_lease_heartbeat.log``: one
+startup line naming the supervisor source, pid and both cadences, and one
+exit line naming the reason (``supervisor_dead``,
+``unsupervised_max_lifetime``, ``lease_lost``, ``foreign_owner``,
+``max_lifetime``).
+
 Best-effort throughout: every tick is wrapped in try/except; a Redis hiccup is
-swallowed and retried next tick. The loop self-terminates after
-``--max-lifetime`` regardless, so a crashed supervisor's heartbeat can never
-outlive a bounded window.
+swallowed and retried next tick.
 
 Usage::
 
     python -m tools.sdlc_lease_heartbeat --issue-number 2446 --run-id <hex> \
-        --session-id sdlc-local-2446
+        --session-id sdlc-local-2446 \
+        --supervisor-pid 32886 --supervisor-create-time 1755069402.5
 
 Exit codes:
-    0 -- always (lost ownership, max-lifetime reached, or clean shutdown).
+    0 -- always (lost ownership, supervisor died, ceiling reached, or clean
+    shutdown).
 """
 
 from __future__ import annotations
@@ -77,15 +116,65 @@ import time
 
 logger = logging.getLogger(__name__)
 
-# Upper bound on how long a single heartbeat process runs before self-exiting
-# (issue #2446/#2451). A crashed supervisor's heartbeat must not outlive a
-# bounded window even though the peek-first guard already prevents lease-theft.
+
+def _env_int(name: str, default: int) -> int:
+    """A positive int from the environment, falling back to ``default``.
+
+    A missing, non-numeric, zero, or negative value yields ``default`` rather
+    than raising or selecting a degenerate zero-length bound -- a typo in an
+    override must never be the thing that lapses a live run's lease.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+# Upper bound on how long a SUPERVISED heartbeat runs before self-exiting
+# (issue #2446/#2451). With a resolvable supervisor the process watch is the
+# real death detector, so this is only a backstop -- and it is deliberately
+# NOT lowered (issue #2714): a live supervisor's BUILD stage can exceed two
+# hours, and lapsing its lease mid-stage would reintroduce #2446 to buy
+# tidiness.
 # GRAIN OF SALT: 4h (14400s) is PROVISIONAL/TUNABLE -- generously above the
 # longest observed end-to-end local run, low enough to bound a zombie. Override
 # via the SDLC_LEASE_HEARTBEAT_MAX_LIFETIME_SECONDS env var.
-MAX_LIFETIME_SECONDS = int(
-    os.environ.get("SDLC_LEASE_HEARTBEAT_MAX_LIFETIME_SECONDS", str(4 * 60 * 60))
-)
+MAX_LIFETIME_SECONDS = _env_int("SDLC_LEASE_HEARTBEAT_MAX_LIFETIME_SECONDS", 4 * 60 * 60)
+
+# Upper bound when NO supervisor identity could be resolved (issue #2714 L3).
+# Applies only on that path: unresolvable means the heartbeat has no death
+# detector at all, so a tighter ceiling is the whole safety story. It stops
+# renewing but never releases, so the worst case is this bound plus the lock's
+# own 1800s TTL.
+# GRAIN OF SALT: 90 minutes (5400s) is PROVISIONAL/TUNABLE -- above a typical
+# end-to-end local pipeline, far below the 4h supervised ceiling. Override via
+# the SDLC_HEARTBEAT_UNSUPERVISED_MAX_SECONDS env var.
+UNSUPERVISED_MAX_LIFETIME_SECONDS = _env_int("SDLC_HEARTBEAT_UNSUPERVISED_MAX_SECONDS", 90 * 60)
+
+# How often the loop wakes to poll the supervising process. Decoupled from the
+# renew cadence so crash detection is ~2 minutes (two confirmations) instead of
+# one full renew interval, at no extra Redis cost.
+# GRAIN OF SALT: 60s is PROVISIONAL/TUNABLE -- matches the worker's own
+# in-process renewal tick. Override via SDLC_SUPERVISOR_CHECK_INTERVAL_SECONDS.
+SUPERVISOR_CHECK_INTERVAL_SECONDS = _env_int("SDLC_SUPERVISOR_CHECK_INTERVAL_SECONDS", 60)
+
+# Consecutive positive-death observations required before the lease is
+# released. One psutil flake must never drop a live run's lease; a genuinely
+# dead supervisor stays dead, so the only cost of >1 is detection latency.
+# GRAIN OF SALT: 2 is PROVISIONAL/TUNABLE. Override via
+# SDLC_SUPERVISOR_DEATH_CONFIRMATIONS.
+SUPERVISOR_DEATH_CONFIRMATIONS = _env_int("SDLC_SUPERVISOR_DEATH_CONFIRMATIONS", 2)
+
+# Exit reasons, each emitted verbatim on the single INFO exit line.
+EXIT_SUPERVISOR_DEAD = "supervisor_dead"
+EXIT_UNSUPERVISED_MAX_LIFETIME = "unsupervised_max_lifetime"
+EXIT_LEASE_LOST = "lease_lost"
+EXIT_FOREIGN_OWNER = "foreign_owner"
+EXIT_MAX_LIFETIME = "max_lifetime"
 
 
 def _default_interval() -> int:
@@ -99,14 +188,84 @@ def _default_interval() -> int:
     return max(1, ISSUE_LOCK_TTL_SECONDS // 3)
 
 
+def _resolved_supervisor(pid, create_time) -> tuple[int | None, float | None]:
+    """Normalize a recorded supervisor identity, or ``(None, None)``.
+
+    Both halves are required: a pid without a ``create_time`` cannot be
+    distinguished from a recycled pid, so a partial identity is no identity.
+    A zero, negative, or non-numeric value is likewise UNRESOLVED -- never
+    "dead". Nothing about a malformed argv is evidence that a supervisor died.
+    """
+    if pid is None or create_time is None:
+        return (None, None)
+    try:
+        pid_int = int(str(pid).strip())
+        create_time_float = float(str(create_time).strip())
+    except (TypeError, ValueError):
+        return (None, None)
+    if pid_int <= 0:
+        return (None, None)
+    return (pid_int, create_time_float)
+
+
+def _supervisor_is_dead(pid: int, create_time: float) -> bool:
+    """True only on POSITIVE evidence that the supervising process is gone.
+
+    Mirrors ``models/session_lifecycle.py::_lock_owner_is_live``'s proven
+    shape:
+
+    - psutil cannot find the pid -> dead.
+    - psutil finds it but its ``create_time`` differs by more than ``1e-3``
+      -> the OS recycled the pid onto an unrelated process -> dead (Risk 5;
+      the guard fails toward detection here, which is the safe direction).
+    - Any exception -> NOT dead. An unverifiable probe must fail toward
+      HOLDING the lease (#2446): a lapsed lease under a live supervisor is
+      the worse failure, and the caller's confirmation gate plus the lifetime
+      ceiling both remain as backstops.
+    """
+    try:
+        from agent.session_health import _psutil_process_for_pid
+
+        proc = _psutil_process_for_pid(pid)
+        if proc is None:
+            return True
+        return abs(float(proc.create_time()) - float(create_time)) > 1e-3
+    except Exception as e:  # noqa: BLE001 - unverifiable means "not dead", never "dead"
+        logger.debug(
+            "sdlc_lease_heartbeat: supervisor liveness probe for pid=%s failed "
+            "(%s: %s) -- treating as alive",
+            pid,
+            type(e).__name__,
+            e,
+        )
+        return False
+
+
+def _log_exit(reason: str, issue_number: int, run_id: str, detail: str = "") -> int:
+    """Emit the single INFO exit line naming ``reason``. Always returns 0."""
+    logger.info(
+        "sdlc_lease_heartbeat: exiting issue #%s run_id=%s reason=%s%s",
+        issue_number,
+        run_id,
+        reason,
+        f" ({detail})" if detail else "",
+    )
+    return 0
+
+
 def run_heartbeat(
     issue_number: int,
     run_id: str,
     session_id: str = "",
     interval: int | None = None,
-    max_lifetime: int = MAX_LIFETIME_SECONDS,
+    max_lifetime: int | None = None,
     _sleep=time.sleep,
     _monotonic=time.monotonic,
+    *,
+    supervisor_pid=None,
+    supervisor_create_time=None,
+    supervisor_check_interval: int | None = None,
+    supervisor_source: str | None = None,
 ) -> int:
     """Peek-first renew-only heartbeat loop. Returns an exit code (always 0).
 
@@ -114,9 +273,24 @@ def run_heartbeat(
         issue_number: The issue whose lease this heartbeat renews.
         run_id: The run identity that must own the lease for a renew to fire.
         session_id: Stored in the lock payload for display only.
-        interval: Seconds between ticks (default: ``ISSUE_LOCK_TTL_SECONDS//3``).
+        interval: Seconds between renews (default: ``ISSUE_LOCK_TTL_SECONDS//3``).
         max_lifetime: Hard upper bound on total run time before self-exit.
+            ``None`` (the default) selects it from whether a supervisor
+            resolved -- see below. An explicit value is always honored as-is.
+        supervisor_pid / supervisor_create_time: the supervising ``claude``
+            process's identity, recorded at mint time. Both are required;
+            either missing, or a non-numeric/non-positive pid, means
+            UNRESOLVED (never "dead").
+        supervisor_check_interval: Seconds between supervisor liveness polls
+            (default: :data:`SUPERVISOR_CHECK_INTERVAL_SECONDS`).
+        supervisor_source: Which tier resolved the identity, for the startup
+            log line only.
         _sleep / _monotonic: Injectable clocks for deterministic tests.
+
+    The ``max_lifetime`` sentinel is load-bearing. Resolving the bound
+    unconditionally from ``supervisor_pid`` would silently override a caller's
+    explicit value on the unsupervised path, which is exactly the path every
+    small-bound caller takes.
     """
     if not issue_number or not run_id:
         # Nothing to renew without both identifiers -- exit cleanly, never mint.
@@ -126,70 +300,159 @@ def run_heartbeat(
         interval = _default_interval()
     interval = max(1, interval)
 
+    sup_pid, sup_create_time = _resolved_supervisor(supervisor_pid, supervisor_create_time)
+    source = supervisor_source or "unresolved"
+    if sup_pid is None:
+        source = "unresolved"
+
+    # Bound selection, ONLY when the caller left max_lifetime unset (the same
+    # explicit-vs-default sentinel `interval` uses just above).
+    unsupervised_bound = False
+    if max_lifetime is None:
+        if sup_pid is None:
+            max_lifetime = UNSUPERVISED_MAX_LIFETIME_SECONDS
+            unsupervised_bound = True
+        else:
+            max_lifetime = MAX_LIFETIME_SECONDS
+
+    check_interval = max(1, int(supervisor_check_interval or SUPERVISOR_CHECK_INTERVAL_SECONDS))
+    # Wake often enough to poll the supervisor, but never more often than the
+    # renew cadence itself when that is the tighter of the two.
+    sleep_seconds = max(1, min(check_interval, interval))
+    confirmations_required = max(1, SUPERVISOR_DEATH_CONFIRMATIONS)
+
     from agent.supervised_run import write_supervised_run_signal
     from models.session_lifecycle import ISSUE_LOCK_TTL_SECONDS, touch_issue_lock
 
+    logger.info(
+        "sdlc_lease_heartbeat: starting issue #%s run_id=%s session_id=%s "
+        "supervisor=%s pid=%s create_time=%s renew_interval=%ss check_interval=%ss "
+        "lifetime_bound=%ss",
+        issue_number,
+        run_id,
+        session_id or "-",
+        source,
+        sup_pid if sup_pid is not None else "-",
+        sup_create_time if sup_create_time is not None else "-",
+        interval,
+        check_interval,
+        max_lifetime,
+    )
+
     deadline = _monotonic() + max_lifetime
-    while _monotonic() < deadline:
-        try:
-            # PEEK FIRST, carrying the guarded run_id (issue #2537 review):
-            # peek=True never mutates regardless of run_id, and passing the
-            # run_id makes this an OWNERSHIP check, not a pid-liveness
-            # inference. The payload's pid is stamped by the short-lived
-            # `sdlc-tool session-ensure` CLI and is dead by the time this
-            # detached heartbeat first ticks, so any pid-keyed signal
-            # (`orphaned_lock`) reads every locally-minted lease as orphaned
-            # on tick one and would lapse it mid-stage -- the exact
-            # #2446/#2451 failure this heartbeat exists to prevent. Liveness
-            # of the RUN is this heartbeat's own job: its bounded
-            # max-lifetime is the death backstop.
-            peek = touch_issue_lock(issue_number, run_id, session_id=session_id, peek=True)
-            owner = peek.owner_run_id
-            if owner is None or owner != run_id:
-                # Lease absent/lapsed, or a successor owns it -> stop. Never
-                # re-acquire (that would be lease-theft, Risk 2).
-                logger.debug(
-                    "sdlc_lease_heartbeat: issue #%s lease no longer owned by run_id=%s "
-                    "(current owner=%s) -- exiting",
+    consecutive_deaths = 0
+    # Seconds of accumulated sleep since the last renew. Seeded at `interval`
+    # so tick one always renews. Accumulated from the sleep amount rather than
+    # read off the clock so an injected/frozen test clock cannot starve the
+    # renew cadence.
+    since_renew = interval
+
+    while True:
+        if _monotonic() >= deadline:
+            if unsupervised_bound:
+                # Risk 1: this shortened bound applies ONLY when the supervisor
+                # was unresolvable. Deliberately NO release -- failing to
+                # resolve a supervisor is not positive proof the run is dead,
+                # so the lease's own 1800s TTL is the correct disposition. A
+                # live-but-unresolvable run therefore loses at most one TTL
+                # window, and #2446's owned_run_ids self-recognition re-binds it.
+                return _log_exit(
+                    EXIT_UNSUPERVISED_MAX_LIFETIME,
                     issue_number,
                     run_id,
-                    owner,
+                    "no supervisor identity; lease left to expire on its own TTL",
                 )
-                return 0
-            # Self-owned: extend the TTL under our own identity only.
-            # `renew_only=True` (issue #2714) makes that structural rather
-            # than conventional: the extend skips both of `touch_issue_lock`'s
-            # minting branches and writes through a compare-and-set, so a
-            # release landing between the peek above and this call cannot be
-            # undone by it. Without it the extend re-minted the lease the
-            # supervisor had just given up and renewed it to the max-lifetime
-            # ceiling with nothing behind it.
-            touch_issue_lock(
-                issue_number,
-                run_id,
-                session_id=session_id,
-                ttl=ISSUE_LOCK_TTL_SECONDS,
-                renew_only=True,
-            )
-            # Refresh the companion supervised-run signal on the same tick
-            # (issue #2659). The signal carries the lock's TTL but was written
-            # only at acquire, so before this it expired 1800s into every run
-            # while the lock was renewed forever -- and from that moment on
-            # every stage fork got a bare ISSUE_LOCKED from its own
-            # supervisor's lock and correctly stood down. Renewing both
-            # together is what makes the module docstring's "refreshed on
-            # every acquire/renew" true. working_dir is deliberately omitted:
-            # the worktree file carrier has no TTL and never needs refreshing.
-            write_supervised_run_signal(issue_number, run_id, session_id=session_id)
-        except Exception as e:  # noqa: BLE001 - best-effort; never crash the loop
-            logger.debug(
-                "sdlc_lease_heartbeat: tick failed for issue #%s (%s: %s) -- retrying",
-                issue_number,
-                type(e).__name__,
-                e,
-            )
-        _sleep(interval)
-    return 0
+            return _log_exit(EXIT_MAX_LIFETIME, issue_number, run_id)
+
+        if sup_pid is not None:
+            if _supervisor_is_dead(sup_pid, sup_create_time):
+                consecutive_deaths += 1
+            else:
+                consecutive_deaths = 0
+            if consecutive_deaths >= confirmations_required:
+                # Positively dead: the run has no driver, so holding its lease
+                # only blocks a successor. Release both keys under our own
+                # identity (both are compare-and-delete, so a successor that
+                # already took over is never harmed).
+                try:
+                    from agent.supervised_run import clear_supervised_run_signal
+                    from models.session_lifecycle import release_issue_lock
+
+                    release_issue_lock(issue_number, run_id)
+                    clear_supervised_run_signal(issue_number, run_id)
+                except Exception as e:  # noqa: BLE001 - best-effort; TTL is the backstop
+                    logger.info(
+                        "sdlc_lease_heartbeat: release after supervisor death failed "
+                        "for issue #%s (%s: %s) -- lease TTL is the backstop",
+                        issue_number,
+                        type(e).__name__,
+                        e,
+                    )
+                return _log_exit(
+                    EXIT_SUPERVISOR_DEAD,
+                    issue_number,
+                    run_id,
+                    f"pid={sup_pid} gone on {consecutive_deaths} consecutive "
+                    "checks; lease released",
+                )
+
+        if since_renew >= interval:
+            since_renew = 0
+            try:
+                # PEEK FIRST, carrying the guarded run_id (issue #2537 review):
+                # peek=True never mutates regardless of run_id, and passing the
+                # run_id makes this an OWNERSHIP check, not a pid-liveness
+                # inference. The payload's pid is stamped by the short-lived
+                # `sdlc-tool session-ensure` CLI and is dead by the time this
+                # detached heartbeat first ticks, so any pid-keyed signal
+                # (`orphaned_lock`) reads every locally-minted lease as orphaned
+                # on tick one and would lapse it mid-stage -- the exact
+                # #2446/#2451 failure this heartbeat exists to prevent.
+                peek = touch_issue_lock(issue_number, run_id, session_id=session_id, peek=True)
+                owner = peek.owner_run_id
+                if owner is None:
+                    # Lease absent/lapsed -> stop. Never re-acquire (that would
+                    # be lease-theft, Risk 2).
+                    return _log_exit(EXIT_LEASE_LOST, issue_number, run_id)
+                if owner != run_id:
+                    return _log_exit(
+                        EXIT_FOREIGN_OWNER, issue_number, run_id, f"current owner={owner}"
+                    )
+                # Self-owned: extend the TTL under our own identity only.
+                # `renew_only=True` (issue #2714) makes that structural rather
+                # than conventional: the extend skips both of `touch_issue_lock`'s
+                # minting branches and writes through a compare-and-set, so a
+                # release landing between the peek above and this call cannot be
+                # undone by it. Without it the extend re-minted the lease the
+                # supervisor had just given up and renewed it to the max-lifetime
+                # ceiling with nothing behind it.
+                touch_issue_lock(
+                    issue_number,
+                    run_id,
+                    session_id=session_id,
+                    ttl=ISSUE_LOCK_TTL_SECONDS,
+                    renew_only=True,
+                )
+                # Refresh the companion supervised-run signal on the same tick
+                # (issue #2659). The signal carries the lock's TTL but was written
+                # only at acquire, so before this it expired 1800s into every run
+                # while the lock was renewed forever -- and from that moment on
+                # every stage fork got a bare ISSUE_LOCKED from its own
+                # supervisor's lock and correctly stood down. Renewing both
+                # together is what makes the module docstring's "refreshed on
+                # every acquire/renew" true. working_dir is deliberately omitted:
+                # the worktree file carrier has no TTL and never needs refreshing.
+                write_supervised_run_signal(issue_number, run_id, session_id=session_id)
+            except Exception as e:  # noqa: BLE001 - best-effort; never crash the loop
+                logger.debug(
+                    "sdlc_lease_heartbeat: tick failed for issue #%s (%s: %s) -- retrying",
+                    issue_number,
+                    type(e).__name__,
+                    e,
+                )
+
+        _sleep(sleep_seconds)
+        since_renew += sleep_seconds
 
 
 def main() -> None:
@@ -211,14 +474,30 @@ def main() -> None:
         "--max-lifetime",
         dest="max_lifetime",
         type=int,
-        default=MAX_LIFETIME_SECONDS,
-        help="Hard upper bound on total run time before self-exit",
+        default=None,
+        help=(
+            "Hard upper bound on total run time before self-exit. Unset selects "
+            "MAX_LIFETIME_SECONDS when a supervisor is recorded, else "
+            "UNSUPERVISED_MAX_LIFETIME_SECONDS."
+        ),
     )
+    # Deliberately parsed as strings, not `type=int` / `type=float`: a
+    # malformed value must degrade to UNRESOLVED, not abort the heartbeat with
+    # argparse's exit code 2 and leave the lease with no renewer at all.
+    parser.add_argument("--supervisor-pid", dest="supervisor_pid", default=None)
+    parser.add_argument("--supervisor-create-time", dest="supervisor_create_time", default=None)
+    parser.add_argument("--supervisor-source", dest="supervisor_source", default=None)
     parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
 
     args = parser.parse_args()
-    if args.verbose:
-        logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
+    # INFO unconditionally: this log file is the only diagnostic a detached
+    # heartbeat can leave behind, and configuring it only under --verbose is
+    # why it stayed 0 bytes across every zombie heartbeat ever spawned.
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        stream=sys.stderr,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
 
     exit_code = run_heartbeat(
         issue_number=args.issue_number,
@@ -226,6 +505,9 @@ def main() -> None:
         session_id=args.session_id or "",
         interval=args.interval,
         max_lifetime=args.max_lifetime,
+        supervisor_pid=args.supervisor_pid,
+        supervisor_create_time=args.supervisor_create_time,
+        supervisor_source=args.supervisor_source,
     )
     sys.exit(exit_code)
 

--- a/tools/sdlc_session_ensure.py
+++ b/tools/sdlc_session_ensure.py
@@ -140,6 +140,38 @@ def _append_owned_run_id(session, run_id: str) -> None:
         )
 
 
+def _supervisor_identity_argv() -> list[str]:
+    """Heartbeat flags naming the supervising ``claude`` process, or ``[]``.
+
+    Issue #2714. Returns ``--supervisor-pid`` / ``--supervisor-create-time`` /
+    ``--supervisor-source`` only when the identity resolves in full. Any
+    failure returns ``[]``, which the heartbeat reads as "unresolved" -- never
+    as "dead", and never as a reason not to spawn at all.
+    """
+    try:
+        from tools.sdlc_supervisor_identity import resolve_supervisor_identity_detailed
+
+        source, pid, create_time = resolve_supervisor_identity_detailed()
+        if pid is None or create_time is None:
+            return []
+        return [
+            "--supervisor-pid",
+            str(pid),
+            "--supervisor-create-time",
+            repr(float(create_time)),
+            "--supervisor-source",
+            str(source),
+        ]
+    except Exception as e:  # noqa: BLE001 - identity is an enhancement, not a precondition
+        logger.debug(
+            "sdlc_session_ensure: supervisor identity resolution failed (%s: %s) "
+            "-- spawning the heartbeat unsupervised",
+            type(e).__name__,
+            e,
+        )
+        return []
+
+
 def _maybe_launch_lease_heartbeat(issue_number: int, run_id: str, session_id: str) -> None:
     """Spawn the detached lease-heartbeat renewer for a fresh LOCAL mint.
 
@@ -155,6 +187,16 @@ def _maybe_launch_lease_heartbeat(issue_number: int, run_id: str, session_id: st
       redundant (though harmless -- both are same-owner idempotent extends).
     - under pytest (``PYTEST_CURRENT_TEST`` set): never spawn a lingering
       detached process during the test suite.
+
+    The supervisor's ``(pid, create_time)`` is resolved HERE, not in the child
+    (issue #2714). This process is still inside the supervising ``claude``
+    process's tree; the detached child is not, and is reparented away within
+    seconds of spawn, so this is the only moment the identity is observable.
+    The flags are appended only when both halves resolve -- a partial identity
+    is no identity, and the heartbeat treats it as unresolved. Resolution is
+    strictly an enhancement: if it fails or raises, the heartbeat still spawns
+    (renewing the lease is the load-bearing job) and simply falls back to its
+    shortened unsupervised lifetime ceiling.
 
     Best-effort: any spawn failure is swallowed (the lease TTL is the backstop);
     never raises, never fails the ensure.
@@ -177,18 +219,21 @@ def _maybe_launch_lease_heartbeat(issue_number: int, run_id: str, session_id: st
         except Exception:
             logf = subprocess.DEVNULL
 
+        argv = [
+            sys.executable,
+            "-m",
+            "tools.sdlc_lease_heartbeat",
+            "--issue-number",
+            str(issue_number),
+            "--run-id",
+            run_id,
+            "--session-id",
+            session_id or "",
+        ]
+        argv.extend(_supervisor_identity_argv())
+
         subprocess.Popen(
-            [
-                sys.executable,
-                "-m",
-                "tools.sdlc_lease_heartbeat",
-                "--issue-number",
-                str(issue_number),
-                "--run-id",
-                run_id,
-                "--session-id",
-                session_id or "",
-            ],
+            argv,
             stdout=logf,
             stderr=logf,
             stdin=subprocess.DEVNULL,

--- a/tools/sdlc_session_release.py
+++ b/tools/sdlc_session_release.py
@@ -1,0 +1,125 @@
+"""CLI tool for releasing an SDLC run's issue lease and supervised-run signal.
+
+The counterpart to ``sdlc-tool session-ensure``: where that tool mints a
+``run_id`` and takes the per-issue lease, this one hands both back. It exists
+because a ``/do-sdlc`` supervisor exiting (HALT, blocked, cap reached) never
+goes through ``finalize_session``, so before this the lease sat until its TTL
+or the heartbeat's max-lifetime ceiling lapsed, and the next run on the same
+issue saw ``ISSUE_LOCKED`` behind a dead run (issue #2714).
+
+Usage:
+    sdlc-tool session-release --issue-number 2714 --run-id <hex>
+
+Exit codes:
+    0 -- always (best-effort; errors report a named reason and never crash the
+         calling skill)
+
+Output (typed JSON, always all four keys):
+    {"released": true,  "reason": "released",     "issue_number": N, "run_id": "..."}
+    {"released": false, "reason": "not_owner",    ...}  -- a live lease is held
+        by a DIFFERENT run; nothing was touched
+    {"released": false, "reason": "no_lease",     ...}  -- no lease to release
+    {"released": false, "reason": "missing_args", ...}  -- absent/blank input;
+        no Redis primitive was called at all
+    {"released": false, "reason": "error",        ...}  -- the substrate raised;
+        swallowed, but always with a printable reason (never an empty object)
+
+Ownership: this module deliberately contains NO ownership logic and no key
+mutation of its own. Both primitives it calls -- ``release_issue_lock`` and
+``clear_supervised_run_signal`` -- are already Lua compare-and-drop operations
+keyed on ``run_id``, so passing a wrong ``run_id`` is a safe no-op and a
+delayed release can never free a *successor* run's lease. The only read this
+module performs itself is a non-mutating ``peek``, used solely to tell
+``not_owner`` apart from ``no_lease`` for the operator-facing reason string.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+def release_run(issue_number: int | None, run_id: str | None) -> dict:
+    """Release the issue lease and supervised-run signal owned by ``run_id``.
+
+    A thin, ownership-checked wrapper: it calls
+    :func:`models.session_lifecycle.release_issue_lock` followed by
+    :func:`agent.supervised_run.clear_supervised_run_signal`, both of which
+    compare against the stored ``run_id`` before dropping anything. The signal
+    clear runs even when the lease release reports ``False`` (the two keys can
+    legitimately expire independently), and is itself a no-op for a foreign or
+    absent signal.
+
+    Args:
+        issue_number: The GitHub issue this run owns. Falsy input is refused.
+        run_id: The run identity minted by ``session-ensure``. Absent, empty,
+            or whitespace-only input is refused -- the primitives are never
+            called with ``None``, which would be an unkeyed release attempt.
+
+    Returns:
+        A dict with exactly ``released`` (bool), ``reason`` (one of
+        ``released`` / ``not_owner`` / ``no_lease`` / ``missing_args`` /
+        ``error``), ``issue_number``, and ``run_id``. Never raises.
+    """
+    normalized_run_id = run_id.strip() if isinstance(run_id, str) else run_id
+    result = {
+        "released": False,
+        "reason": "missing_args",
+        "issue_number": issue_number,
+        "run_id": normalized_run_id,
+    }
+
+    if not issue_number or not normalized_run_id:
+        return result
+
+    try:
+        from agent.supervised_run import clear_supervised_run_signal
+        from models.session_lifecycle import release_issue_lock, touch_issue_lock
+
+        released = bool(release_issue_lock(issue_number, normalized_run_id))
+        clear_supervised_run_signal(issue_number, normalized_run_id)
+
+        if released:
+            reason = "released"
+        else:
+            # Not a second ownership decision -- the drop already happened (or
+            # did not) above. This peek only labels WHY for the operator: a
+            # lease still standing means someone else holds it.
+            peek = touch_issue_lock(issue_number, None, peek=True)
+            reason = "not_owner" if getattr(peek, "owner_run_id", None) else "no_lease"
+
+        result["released"] = released
+        result["reason"] = reason
+    except Exception as e:
+        logger.warning(
+            "[session-release] release failed for issue #%s run_id=%s (%s: %s)",
+            issue_number,
+            normalized_run_id,
+            type(e).__name__,
+            e,
+        )
+        result["released"] = False
+        result["reason"] = "error"
+
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Release the SDLC issue lease and supervised-run signal for a run."
+    )
+    parser.add_argument("--issue-number", type=int, default=None, help="GitHub issue number")
+    parser.add_argument("--run-id", type=str, default=None, help="Run identity to release")
+    args = parser.parse_args()
+
+    result = release_run(args.issue_number, args.run_id)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/sdlc_stage_marker.py
+++ b/tools/sdlc_stage_marker.py
@@ -491,6 +491,24 @@ def write_marker(
     return result, exit_code
 
 
+def _release_run_best_effort(issue_number: int | None, run_id: str | None) -> None:
+    """Hand back the issue lease + supervised-run signal. Never raises.
+
+    Fully exception-isolated on purpose: this sits inside the marker write's
+    body, so an un-swallowed failure here would be caught by the outer
+    STATE_MACHINE_RAISED handler and turn a persisted, successful MERGE
+    completion into a reported exit 1. Releasing is a courtesy that shortens a
+    lease's life; the marker write is the load-bearing operation.
+    """
+    try:
+        from tools.sdlc_session_release import release_run
+
+        result = release_run(issue_number, run_id)
+        logger.debug("sdlc_stage_marker: MERGE-completed lease release -> %s", result)
+    except Exception as e:
+        logger.debug("sdlc_stage_marker: MERGE-completed lease release failed: %s", e)
+
+
 def _write_marker_impl(
     stage: str,
     status: str,
@@ -725,6 +743,21 @@ def _write_marker_impl(
                     }, 1
                 sm.states[stage] = "in_progress"
             sm.complete_stage(stage)
+
+            if stage == "MERGE":
+                # Tool-layer release leg (issue #2714 L1). This transition --
+                # not a skill-body prose step -- is the happy-path release: it
+                # fires for /do-sdlc, the /sdlc router, and worker-driven
+                # pipelines alike, with zero skill cooperation. It is
+                # ordering-consistent with what already exists: once MERGE is
+                # completed, `_pipeline_is_terminal` makes `reestablish_run_id`
+                # decline to re-mint, so nothing downstream expects to still
+                # hold the lease.
+                #
+                # Deliberately NOT in the already-completed idempotent branch
+                # above: that branch does not own the transition, and releasing
+                # there could free a SUCCESSOR run's lease (Race 3).
+                _release_run_best_effort(issue_number, run_id)
 
         return {"stage": stage, "status": status}, 0
 

--- a/tools/sdlc_supervisor_identity.py
+++ b/tools/sdlc_supervisor_identity.py
@@ -1,0 +1,176 @@
+"""Resolve the identity of the ``claude`` process supervising a local SDLC run.
+
+Issue #2714. The detached lease heartbeat
+(``tools/sdlc_lease_heartbeat.py``) renews a per-issue lease on behalf of a
+``/do-sdlc`` supervisor it cannot see: ``start_new_session=True`` detaches it
+from its spawner immediately, and its spawner -- the ephemeral ``sdlc-tool
+session-ensure`` CLI -- exits within seconds anyway. The only way the heartbeat
+can ever tell that its supervisor died is to be handed that supervisor's
+identity *explicitly*, at mint time, by a process that is still inside the
+supervisor's own process tree. That handoff is what this module produces.
+
+An identity is the pair ``(pid, create_time)``. The ``create_time`` half is
+not optional: a bare pid is recyclable, and a recycled pid would read as a
+live supervisor forever (Risk 5). Matching ``create_time`` within ``1e-3`` is
+the same guard ``models/session_lifecycle.py::_lock_owner_is_live`` uses, and
+it fails toward *detecting* death rather than away from it.
+
+Three tiers, in order:
+
+1. ``CLAUDE_PID`` -- Claude Code exports it into every Bash tool call's
+   environment, and it names the TOP-LEVEL ``claude`` process even when the
+   call originates from a subagent. That is exactly the right supervisor
+   identity for ``/do-sdlc``, whose supervisor loop and every stage subagent
+   live inside that one process. Accepted only when psutil can actually
+   resolve the pid, so a stale or garbage value degrades rather than lies.
+2. **Ancestry walk** -- ``psutil.Process().parents()``, taking the first
+   ancestor whose executable basename is ``claude`` (or a ``node`` process
+   whose cmdline mentions ``claude``, for the bundled-CLI shape). Keeps the
+   feature working if the undocumented env var ever disappears.
+3. ``(None, None)`` -- unresolved. The caller spawns the heartbeat without an
+   identity and the heartbeat falls back to its shortened unsupervised
+   lifetime ceiling.
+
+**The parent pid is never consulted.** A heartbeat's literal parent exits
+seconds after spawn, so a healthy heartbeat is reparented to pid 1 almost
+immediately; treating that as a death signal would drop a live run's lease on
+tick one. This module resolves identity only from the environment and from an
+ancestry walk performed while the supervisor is still an ancestor.
+
+Best-effort throughout: every tier is wrapped, and any failure degrades to the
+next tier or to ``(None, None)``. Nothing here ever raises.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+#: Identity came from the ``CLAUDE_PID`` environment variable.
+SOURCE_ENV = "env"
+#: Identity came from the psutil ancestry walk.
+SOURCE_ANCESTRY = "ancestry"
+#: No supervisor could be identified.
+SOURCE_UNRESOLVED = "unresolved"
+
+# How far up the ancestor chain to look for a `claude` process. A Claude Code
+# Bash tool call sits 1-3 hops below its `claude` process; the cap only bounds
+# a pathological chain.
+# GRAIN OF SALT: 12 is PROVISIONAL/TUNABLE -- generously above the observed
+# depth, small enough that the walk stays cheap.
+_MAX_ANCESTOR_DEPTH = 12
+
+
+def _self_process():
+    """This process as a ``psutil.Process``. Module seam so tests can patch it."""
+    import psutil
+
+    return psutil.Process()
+
+
+def _create_time_for_pid(pid: int) -> float | None:
+    """``create_time()`` for a live pid, or ``None`` when it cannot be resolved."""
+    from agent.session_health import _psutil_process_for_pid
+
+    proc = _psutil_process_for_pid(pid)
+    if proc is None:
+        return None
+    return float(proc.create_time())
+
+
+def _executable_basename(proc) -> str:
+    """Basename of a process's executable, preferring ``exe()`` over ``name()``.
+
+    ``exe()`` is the precise answer but raises ``AccessDenied`` for processes
+    owned by another user; ``name()`` is always readable and is what matches
+    for the bare-``claude`` shape. Returns ``""`` when neither is available.
+    """
+    for getter in ("exe", "name"):
+        try:
+            value = getattr(proc, getter)()
+        except Exception:
+            continue
+        if value:
+            return os.path.basename(str(value).strip())
+    return ""
+
+
+def _is_claude_process(proc) -> bool:
+    """True for a ``claude`` executable, or a ``node`` running the bundled CLI.
+
+    Deliberately narrow. The ``node`` arm requires ``claude`` to appear in the
+    cmdline, so an unrelated node process in the ancestry never matches.
+    """
+    base = _executable_basename(proc)
+    if base == "claude":
+        return True
+    if base.startswith("node"):
+        try:
+            cmdline = proc.cmdline() or []
+        except Exception:
+            return False
+        return any("claude" in str(part) for part in cmdline)
+    return False
+
+
+def _from_env() -> tuple[int | None, float | None]:
+    """Tier 1: ``CLAUDE_PID``, accepted only when psutil resolves the pid."""
+    raw = os.environ.get("CLAUDE_PID", "").strip()
+    if not raw:
+        return (None, None)
+    try:
+        pid = int(raw)
+    except (TypeError, ValueError):
+        return (None, None)
+    if pid <= 0:
+        return (None, None)
+    create_time = _create_time_for_pid(pid)
+    if create_time is None:
+        return (None, None)
+    return (pid, create_time)
+
+
+def _from_ancestry() -> tuple[int | None, float | None]:
+    """Tier 2: the nearest ``claude`` ancestor of this process."""
+    for proc in (_self_process().parents() or [])[:_MAX_ANCESTOR_DEPTH]:
+        if _is_claude_process(proc):
+            return (int(proc.pid), float(proc.create_time()))
+    return (None, None)
+
+
+def resolve_supervisor_identity_detailed() -> tuple[str, int | None, float | None]:
+    """``(source, pid, create_time)`` for the supervising ``claude`` process.
+
+    ``source`` is one of :data:`SOURCE_ENV`, :data:`SOURCE_ANCESTRY`, or
+    :data:`SOURCE_UNRESOLVED`, and is carried into the heartbeat's startup log
+    line so a silent loss of ``CLAUDE_PID`` (an undocumented harness variable)
+    shows up as a visible tier downgrade rather than as an unexplained drop to
+    the shortened unsupervised lifetime.
+
+    Never raises: any failure in any tier degrades to the next one.
+    """
+    for source, tier in ((SOURCE_ENV, _from_env), (SOURCE_ANCESTRY, _from_ancestry)):
+        try:
+            pid, create_time = tier()
+        except Exception as e:  # noqa: BLE001 - best-effort; degrade to the next tier
+            logger.debug(
+                "sdlc_supervisor_identity: %s tier failed (%s: %s) -- degrading",
+                source,
+                type(e).__name__,
+                e,
+            )
+            continue
+        if pid is not None and create_time is not None:
+            return (source, pid, create_time)
+    return (SOURCE_UNRESOLVED, None, None)
+
+
+def resolve_supervisor_identity() -> tuple[int | None, float | None]:
+    """``(pid, create_time)`` for the supervising ``claude`` process, or ``(None, None)``.
+
+    Source-agnostic form of :func:`resolve_supervisor_identity_detailed`.
+    """
+    _source, pid, create_time = resolve_supervisor_identity_detailed()
+    return (pid, create_time)


### PR DESCRIPTION
## Problem

`tools/sdlc_lease_heartbeat.py` renewed the per-issue lease with no connection to the process that *uses* it. Its only death signal was a 4-hour wall-clock backstop measured from its own start. A supervisor that halted on a guard, stopped at a gate FAIL, or was killed left its heartbeat renewing — and because the heartbeat kept stamping `renewed_at`, `orphaned_lock` read `false`, so every resume on that issue correctly stood down against a run that no longer existed.

Confirmed live on 2026-08-13: the 4h backstop processes died on schedule, but **the leases did not release**. Expiry-by-timeout was never a release path.

## Solution

Six layers, each defaulting to today's behavior when its new inputs are absent:

- **Renew-only lease extension** (`touch_issue_lock(..., renew_only=True)`) — skips both minting branches and writes through a Lua compare-and-set, so a renewer can never mint on a free key nor undo a release that lands between the peek and the extend. The outer exception handler is threaded too: a renewer fails **closed**, while the non-`renew_only` default keeps #2446's fail-open behavior.
- **Supervisor identity resolution** at mint time — `CLAUDE_PID` env, then a `psutil` ancestry walk for a `claude` ancestor, then unresolved. Never `os.getppid()`, never `ppid == 1`.
- **Supervisor watch** — on `SDLC_SUPERVISOR_DEATH_CONFIRMATIONS` (default 2) consecutive `(pid, create_time)` mismatches the heartbeat **actively releases** the lease and the supervised-run signal, then exits. This is the fix for the finding above: release, not merely stop renewing.
- **Unsupervised ceiling** — 90 minutes when no supervisor resolves, and deliberately **no** release there (failure to resolve is not proof of death, so the lease's own TTL is the right disposition). With a supervisor present the unchanged 4h bound is selected.
- **`sdlc-tool session-release`** plus a tool-layer leg in `sdlc_stage_marker.py` firing on the non-idempotent `MERGE`/`completed` transition, so the merged exit releases without depending on skill prose.
- **Observability** — `logs/sdlc_lease_heartbeat.log` has been 0 bytes since 2026-08-04; INFO logging is now unconditional, with a named startup line and a named exit reason.

## Verification

All Verification and anti-criteria rows pass. Targeted suites, `POPOTO_TEST_DB=11`:

- `test_sdlc_lease_heartbeat.py`, `test_sdlc_session_release.py`, `test_sdlc_session_ensure.py`, `test_sdlc_stage_marker.py` — 245 passed
- `test_session_lifecycle.py`, `test_session_executor_issue_lock_renewal.py` — 103 passed
- `ruff check` / `ruff format --check` clean

Guarantees held: #2446/#2451 (a dead payload pid never stops renewal; a live supervisor renews indefinitely), #2537 (peek-before-renew intact, foreign owner exits, never mints on a free key), and the 90-minute ceiling is unreachable whenever a supervisor pid is present.

The spawn-side observation (six heartbeats on March-closed issues, a different root cause) is split out as #2781.

Closes #2714
