### PR TITLE
Make test subprocesses inherit the parent's claimed test DB (#2763)

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -474,3 +474,53 @@ Source modules with no test coverage. Priority targets for new tests.
 
 **Partially covered** (operational layer added in #936):
 - `bridge/email_bridge.py` — parsing, SMTP output, routing, and thread continuation have full coverage. Operational layer (`main()`, `_poll_imap()` batch cap, `_email_inbox_loop()` health timestamp) now covered via unit and integration tests.
+
+## Subprocess Test-DB Inheritance (issue #2763)
+
+Any test that shells out to a subprocess which can reach Popoto — a Python
+interpreter running a repo module, the sdlc-tool `WRAPPER`, or an inline `-c`
+script against a repo checkout — must pass `env=subprocess_env(...)` from
+`tests.db_claim`.
+
+**Why**: Popoto resolves `REDIS_URL` at *import time* and falls back to
+`redis://localhost:6379` — db0, production — when the variable is unset. The
+parent pytest process claims a test db from the pool `[1..15]` via
+`tests/db_claim.py`'s `fcntl.flock`, but that claim lives only in the parent's
+in-process Popoto client objects; `os.environ` is never mutated. The
+environment is therefore the only channel to a child, and `subprocess_env` is
+the bridge. A child launched without it silently reads and writes production
+db0.
+
+**How to use it**: `subprocess_env(*, project_root=None, **extra)`. Thread
+extra variables as keyword arguments (`subprocess_env(AI_REPO_ROOT=...)`)
+rather than hand-building a dict. If a site also needs keys removed, the
+accepted shape is `env = subprocess_env(); env.pop("NAME", None)` — assign,
+then mutate with `.pop(<literal>, None)` / `.update(...)`, never rebind.
+
+`project_root=` is **opt-in, not a default**. It prepends the path to the
+child's `PYTHONPATH`. Pass it when the child must resolve repo modules from
+this checkout; omit it when the test asserts something about import order or
+module resolution. `tests/unit/test_sdlc_tool_wrapper.py::test_dispatch_from_foreign_cwd_with_own_tools_succeeds`
+is the worked example of a deliberate omission — it pins the wrapper's own
+module-resolution order against a decoy `tools/` package, so prepending
+`REPO_ROOT` to `PYTHONPATH` would resolve the import for reasons other than
+the wrapper's doing.
+
+Never re-derive a db number by hand. Reading
+`POPOTO_REDIS_DB.connection_pool.connection_kwargs` to rebuild a `REDIS_URL`
+is the anti-pattern this work removed; `claim_test_db()` via `subprocess_env`
+is the only source.
+
+The enforcing guard is `tests/unit/test_subprocess_test_db_isolation.py`, an
+AST scan of `tests/**/*.py`. It matches in-scope call sites on **argv**
+(`sys.executable`, a `PYTHON`-containing identifier, a `"-m"` element,
+`WRAPPER`, or a `scripts/` string); `cwd=` is deliberately not part of the
+predicate, since what determines whether a child can import popoto is what is
+executed, not where it is executed from. Exemptions exist only as
+`SKIP_ARGV0 = {"git"}` (a `git` child never imports Python) and a commented
+`ALLOWLIST` of `path:line` entries, each carrying one of exactly two reasons:
+`[#2628]` (the file is owned by open PR #2683 — fix it there when it lands)
+or `[standalone-script]` (the child imports no repo package). **When
+reachability is unclear, convert the site — do not allowlist it.**
+
+When #2683 lands, this section folds into `docs/features/test-db-ownership.md`.

--- a/tests/_worker_guard.py
+++ b/tests/_worker_guard.py
@@ -66,6 +66,10 @@ def _pgrep_worker_pids() -> set[int]:
             capture_output=True,
             text=True,
             timeout=5,
+            # `pgrep` cannot import popoto and does not need REDIS_URL. The env
+            # is here because the isolation guard's argv heuristic matches the
+            # word "python" inside the *pattern* string; passing it is cheaper
+            # and less brittle than an allowlist entry.
             env=subprocess_env(),
         )
         return {int(tok) for tok in out.stdout.split() if tok.strip().isdigit()}

--- a/tests/_worker_guard.py
+++ b/tests/_worker_guard.py
@@ -64,6 +64,7 @@ def _pgrep_worker_pids() -> set[int]:
             capture_output=True,
             text=True,
             timeout=5,
+            env=subprocess_env(),
         )
         return {int(tok) for tok in out.stdout.split() if tok.strip().isdigit()}
     except Exception:

--- a/tests/_worker_guard.py
+++ b/tests/_worker_guard.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 import re
 import subprocess
 
+from tests.db_claim import subprocess_env
+
 # A command line for the launchd worker joins to `<python> -m worker`. Require
 # BOTH a python-ish executable AND the `-m worker` token so an unrelated
 # process that merely mentions "worker" never trips the guard. `python -m

--- a/tests/e2e/test_telegram_flow.py
+++ b/tests/e2e/test_telegram_flow.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.db_claim import subprocess_env
+
 
 @dataclass
 class TestMessage:

--- a/tests/e2e/test_telegram_flow.py
+++ b/tests/e2e/test_telegram_flow.py
@@ -40,6 +40,7 @@ class TestTelegramE2EFlow:
             capture_output=True,
             text=True,
             cwd=Path(__file__).parent.parent.parent,
+            env=subprocess_env(),
         )
         return "RUNNING" in result.stdout
 

--- a/tests/integration/test_design_system_pipeline.py
+++ b/tests/integration/test_design_system_pipeline.py
@@ -25,6 +25,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.db_claim import subprocess_env
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 FIXTURE_DIR = REPO_ROOT / "tests/fixtures/design_system"
 
@@ -88,6 +90,7 @@ def test_all_pipeline_produces_committed_artifacts(worktree_fixture: Path):
         capture_output=True,
         text=True,
         cwd=str(REPO_ROOT),
+        env=subprocess_env(project_root=str(REPO_ROOT)),
     )
     assert result.returncode == 0, result.stderr
     assert (worktree_fixture / "design-system.md").is_file()
@@ -102,6 +105,7 @@ def test_all_pipeline_produces_committed_artifacts(worktree_fixture: Path):
         capture_output=True,
         text=True,
         cwd=str(REPO_ROOT),
+        env=subprocess_env(project_root=str(REPO_ROOT)),
     )
     assert check.returncode == 0, check.stderr
 
@@ -114,6 +118,7 @@ def test_check_detects_mutation(worktree_fixture: Path):
         [sys.executable, "-m", "tools.design_system_sync", "--all", "--pen", str(pen)],
         check=True,
         cwd=str(REPO_ROOT),
+        env=subprocess_env(project_root=str(REPO_ROOT)),
     )
     brand = worktree_fixture / "css/brand.css"
     brand.write_text(brand.read_text() + "\n/* drift */\n", encoding="utf-8")
@@ -122,6 +127,7 @@ def test_check_detects_mutation(worktree_fixture: Path):
         capture_output=True,
         text=True,
         cwd=str(REPO_ROOT),
+        env=subprocess_env(project_root=str(REPO_ROOT)),
     )
     assert result.returncode == 1
     assert "differs from generated output" in result.stderr

--- a/tests/integration/test_doc_impact_finder_sdk.py
+++ b/tests/integration/test_doc_impact_finder_sdk.py
@@ -21,6 +21,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.db_claim import subprocess_env
+
 REPO_ROOT = Path(__file__).parent.parent.parent
 PYTHON = sys.executable
 

--- a/tests/integration/test_doc_impact_finder_sdk.py
+++ b/tests/integration/test_doc_impact_finder_sdk.py
@@ -27,7 +27,7 @@ PYTHON = sys.executable
 
 def run_tool_subprocess(code: str, env_override: dict | None = None) -> subprocess.CompletedProcess:
     """Run a python -c command the same way the agent does in /do-docs Agent C."""
-    env = os.environ.copy()
+    env = subprocess_env(project_root=str(REPO_ROOT))
     if env_override:
         env.update(env_override)
     return subprocess.run(

--- a/tests/integration/test_memory_mcp_server.py
+++ b/tests/integration/test_memory_mcp_server.py
@@ -153,6 +153,13 @@ def test_fresh_shell_import_resolution():
     resolve modules through the activated venv and the test would pass for
     the wrong reason. ``subprocess_env`` still supplies REDIS_URL so the
     child's Popoto lands on this process's claimed test db, not db0 (#2763).
+
+    Every other interpreter-steering variable is stripped too. Building the env
+    from ``subprocess_env`` means the child inherits the parent's environment
+    rather than the three-key whitelist this test used before #2763, so the
+    strips are what keep the assertion's subject intact: with any of these left
+    in place the child could resolve modules through a channel other than
+    ``PYTHONPATH`` and the test would pass without proving anything.
     """
     import subprocess
 
@@ -160,8 +167,14 @@ def test_fresh_shell_import_resolution():
         PATH="/opt/homebrew/bin:/usr/bin:/bin",
         PYTHONPATH=_project_root(),
     )
-    env.pop("VIRTUAL_ENV", None)
-    env.pop("PYTHONHOME", None)
+    for steering_var in (
+        "VIRTUAL_ENV",
+        "PYTHONHOME",
+        "PYTHONUSERBASE",
+        "PYTHONNOUSERSITE",
+        "PYTHONSAFEPATH",
+    ):
+        env.pop(steering_var, None)
     result = subprocess.run(
         ["python3", "-m", "mcp_servers.memory_server", "--help"],
         capture_output=True,

--- a/tests/integration/test_memory_mcp_server.py
+++ b/tests/integration/test_memory_mcp_server.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.db_claim import subprocess_env
+
 
 def _project_root() -> str:
     return str(Path(__file__).resolve().parent.parent.parent)
@@ -142,14 +144,24 @@ def test_fresh_shell_import_resolution():
     ``python3`` resolves to a Python that has the ``mcp`` SDK
     installed. ``/usr/bin/python3`` does not (it is the system Python
     on Darwin).
+
+    ``PYTHONPATH`` is passed as an explicit override rather than through
+    ``subprocess_env(project_root=...)``: this test's subject IS module
+    resolution from ``PYTHONPATH`` alone, so the value must replace the
+    parent's rather than be prepended to it. The venv-steering variables
+    are stripped for the same reason — inheriting them would let the child
+    resolve modules through the activated venv and the test would pass for
+    the wrong reason. ``subprocess_env`` still supplies REDIS_URL so the
+    child's Popoto lands on this process's claimed test db, not db0 (#2763).
     """
     import subprocess
 
-    env = {
-        "HOME": os.environ.get("HOME", ""),
-        "PATH": "/opt/homebrew/bin:/usr/bin:/bin",
-        "PYTHONPATH": _project_root(),
-    }
+    env = subprocess_env(
+        PATH="/opt/homebrew/bin:/usr/bin:/bin",
+        PYTHONPATH=_project_root(),
+    )
+    env.pop("VIRTUAL_ENV", None)
+    env.pop("PYTHONHOME", None)
     result = subprocess.run(
         ["python3", "-m", "mcp_servers.memory_server", "--help"],
         capture_output=True,

--- a/tests/integration/test_memory_prefetch.py
+++ b/tests/integration/test_memory_prefetch.py
@@ -18,7 +18,6 @@ so concurrent tests do not interfere with production data.
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 import sys
 import time
@@ -26,6 +25,8 @@ import uuid
 from pathlib import Path
 
 import pytest
+
+from tests.db_claim import subprocess_env
 
 pytestmark = [pytest.mark.integration]
 
@@ -72,17 +73,15 @@ def _run_user_prompt_submit_hook(
     prompt: str,
     session_id: str,
     project_key: str,
-    redis_url: str,
     cwd: str | None = None,
 ) -> dict | None:
     """Invoke .claude/hooks/user_prompt_submit.py as a subprocess.
 
     Returns the parsed hookSpecificOutput JSON dict (or None if the hook
     produced no output). Forces VALOR_PROJECT_KEY so the prefetch path
-    queries the test-isolated project partition. Forces REDIS_URL to the
-    same per-worker test db that the autouse `redis_test_db` fixture
-    points popoto at -- without this the subprocess would query
-    production Redis and find no seeded records.
+    queries the test-isolated project partition. ``subprocess_env`` points
+    the child's REDIS_URL at this process's claimed test db -- without it
+    the subprocess would query production Redis and find no seeded records.
     """
     payload = {
         "prompt": prompt,
@@ -90,9 +89,7 @@ def _run_user_prompt_submit_hook(
         "cwd": cwd or str(REPO_ROOT),
     }
 
-    env = os.environ.copy()
-    env["VALOR_PROJECT_KEY"] = project_key
-    env["REDIS_URL"] = redis_url
+    env = subprocess_env(VALOR_PROJECT_KEY=project_key)
     # Suppress AgentSession side-effects: no SESSION_TYPE / parent.
     env.pop("SESSION_TYPE", None)
     env.pop("VALOR_PARENT_SESSION_ID", None)
@@ -155,9 +152,7 @@ def isolated_session_id():
 class TestPrefetchEndToEnd:
     """Verify the UserPromptSubmit hook produces prefetched thoughts."""
 
-    def test_prefetch_emits_hookspecific_output(
-        self, isolated_project_key, isolated_session_id, redis_test_url
-    ):
+    def test_prefetch_emits_hookspecific_output(self, isolated_project_key, isolated_session_id):
         """A non-trivial prompt against seeded memories yields <thought> blocks."""
         # Seed a memory matching the prompt content.
         seeded = _seed_memory(
@@ -171,7 +166,6 @@ class TestPrefetchEndToEnd:
             prompt=("investigate auth flow refactor that broke after PR 800 deployment"),
             session_id=isolated_session_id,
             project_key=isolated_project_key,
-            redis_url=redis_test_url,
         )
 
         hso = hook_output["hookSpecificOutput"]
@@ -180,9 +174,7 @@ class TestPrefetchEndToEnd:
         # Both empty-title (no async title-gen yet) and title-present cases include `id="`.
         assert '<thought id="' in hso["additionalContext"]
 
-    def test_prefetch_writes_sidecar_injected_ids(
-        self, isolated_project_key, isolated_session_id, redis_test_url
-    ):
+    def test_prefetch_writes_sidecar_injected_ids(self, isolated_project_key, isolated_session_id):
         """After prefetch, sidecar.injected[] contains the surfaced memory_ids."""
         seeded = _seed_memory(
             "deployment rollback playbook for auth service migration",
@@ -195,7 +187,6 @@ class TestPrefetchEndToEnd:
             prompt=("investigate deployment rollback for auth service migration plan"),
             session_id=isolated_session_id,
             project_key=isolated_project_key,
-            redis_url=redis_test_url,
         )
 
         sidecar_path = REPO_ROOT / "data" / "sessions" / isolated_session_id / "memory_buffer.json"
@@ -213,9 +204,7 @@ class TestPrefetchEndToEnd:
 class TestPrefetchStripsBoilerplate:
     """PM-shaped prompts must query against the MESSAGE: payload only."""
 
-    def test_pm_boilerplate_stripped_before_query(
-        self, isolated_project_key, isolated_session_id, redis_test_url
-    ):
+    def test_pm_boilerplate_stripped_before_query(self, isolated_project_key, isolated_session_id):
         """Worker-shaped FROM:/SCOPE:/MESSAGE: prompt surfaces MESSAGE-matched memory."""
         # Two memories: one matches MESSAGE: payload, one matches FROM:/SCOPE: terms.
         msg_memory = _seed_memory(
@@ -239,7 +228,6 @@ class TestPrefetchStripsBoilerplate:
             prompt=prompt,
             session_id=isolated_session_id,
             project_key=isolated_project_key,
-            redis_url=redis_test_url,
         )
         assert hook_output is not None, "Expected hookSpecificOutput JSON on stdout"
         body = hook_output["hookSpecificOutput"]["additionalContext"]
@@ -259,9 +247,7 @@ class TestPrefetchStripsBoilerplate:
 class TestPrefetchLatencyBudget:
     """A single prefetch must complete well under PREFETCH_LATENCY_WARN_MS."""
 
-    def test_prefetch_completes_under_budget(
-        self, isolated_project_key, isolated_session_id, redis_test_url
-    ):
+    def test_prefetch_completes_under_budget(self, isolated_project_key, isolated_session_id):
         """End-to-end subprocess call returns inside the latency budget on a small fixture."""
         from config.memory_defaults import PREFETCH_LATENCY_WARN_MS
 
@@ -292,7 +278,6 @@ class TestPrefetchLatencyBudget:
             prompt=("test memory verification for latency budget on small fixture set"),
             session_id=isolated_session_id,
             project_key=isolated_project_key,
-            redis_url=redis_test_url,
         )
         elapsed = time.monotonic() - start
 

--- a/tests/integration/test_sdlc_cross_repo_resolution.py
+++ b/tests/integration/test_sdlc_cross_repo_resolution.py
@@ -11,13 +11,14 @@ It runs the resolver in a real subprocess whose cwd is the temp repo, so the
 
 from __future__ import annotations
 
-import os
 import subprocess
 import sys
 import textwrap
 from pathlib import Path
 
 import pytest
+
+from tests.db_claim import subprocess_env
 
 pytestmark = pytest.mark.sdlc
 
@@ -39,7 +40,8 @@ def _make_temp_repo(tmp_path: Path) -> Path:
 
 def _resolve_plan_in(repo: Path, issue_number: int) -> str:
     """Run find_plan_path in a subprocess with cwd=repo and no SDLC_TARGET_REPO."""
-    env = {k: v for k, v in os.environ.items() if k != "SDLC_TARGET_REPO"}
+    env = subprocess_env(project_root=str(REPO_ROOT))
+    env.pop("SDLC_TARGET_REPO", None)
     code = textwrap.dedent(
         f"""
         from tools._sdlc_utils import find_plan_path
@@ -52,7 +54,7 @@ def _resolve_plan_in(repo: Path, issue_number: int) -> str:
         cwd=str(repo),
         capture_output=True,
         text=True,
-        env={**env, "PYTHONPATH": str(REPO_ROOT)},
+        env=env,
     )
     assert result.returncode == 0, result.stderr
     return result.stdout.strip()
@@ -95,7 +97,6 @@ def test_boundary_longer_issue_number_does_not_match(tmp_path):
 
 def _resolve_plan_with_env(env_repo: Path, issue_number: int) -> str:
     """Run find_plan_path with SDLC_TARGET_REPO set, cwd forced to REPO_ROOT (ai-repo)."""
-    env = {k: v for k, v in os.environ.items() if k != "SDLC_TARGET_REPO"}
     code = textwrap.dedent(
         f"""
         from tools._sdlc_utils import find_plan_path
@@ -108,11 +109,7 @@ def _resolve_plan_with_env(env_repo: Path, issue_number: int) -> str:
         cwd=str(REPO_ROOT),  # force cwd to ai-repo (simulates sdlc-tool behaviour)
         capture_output=True,
         text=True,
-        env={
-            **env,
-            "PYTHONPATH": str(REPO_ROOT),
-            "SDLC_TARGET_REPO": str(env_repo),
-        },
+        env=subprocess_env(project_root=str(REPO_ROOT), SDLC_TARGET_REPO=str(env_repo)),
     )
     assert result.returncode == 0, result.stderr
     return result.stdout.strip()
@@ -149,7 +146,8 @@ def test_file_fallback_bare_mention_suppressed(tmp_path):
     non_git_dir = tmp_path / "not-a-repo"
     non_git_dir.mkdir()
 
-    env = {k: v for k, v in os.environ.items() if k != "SDLC_TARGET_REPO"}
+    env = subprocess_env(project_root=str(REPO_ROOT))
+    env.pop("SDLC_TARGET_REPO", None)
     code = textwrap.dedent(
         """
         from tools._sdlc_utils import find_plan_path
@@ -163,7 +161,7 @@ def test_file_fallback_bare_mention_suppressed(tmp_path):
         cwd=str(non_git_dir),  # not a git repo — forces __file__ fallback
         capture_output=True,
         text=True,
-        env={**env, "PYTHONPATH": str(REPO_ROOT)},
+        env=env,
     )
     assert result.returncode == 0, result.stderr
     # When __file__ fallback is used and no tracking: match exists, bare-#N

--- a/tests/integration/test_sdlc_dispatch.py
+++ b/tests/integration/test_sdlc_dispatch.py
@@ -24,6 +24,7 @@ from agent.sdlc_router import (
     Dispatch,
     decide_next_dispatch,
 )
+from tests.db_claim import subprocess_env
 from tools.sdlc_next_skill import decide
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -323,6 +324,7 @@ class TestNextSkillCLISubprocess:
             capture_output=True,
             text=True,
             cwd=str(REPO_ROOT),
+            env=subprocess_env(project_root=str(REPO_ROOT)),
             timeout=15,
         )
         try:
@@ -354,6 +356,7 @@ class TestNextSkillCLISubprocess:
             capture_output=True,
             text=True,
             cwd=str(REPO_ROOT),
+            env=subprocess_env(project_root=str(REPO_ROOT)),
             timeout=15,
         )
         # The tool should exit 0 even when session is not found (empty states → Row 1)

--- a/tests/integration/test_session_telemetry_e2e.py
+++ b/tests/integration/test_session_telemetry_e2e.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from agent.session_telemetry import _get_telemetry_dir
+from tests.db_claim import subprocess_env
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/integration/test_session_telemetry_e2e.py
+++ b/tests/integration/test_session_telemetry_e2e.py
@@ -23,6 +23,7 @@ def _run_cli(*args: str) -> subprocess.CompletedProcess:
         capture_output=True,
         text=True,
         cwd=str(WORKTREE),
+        env=subprocess_env(project_root=str(WORKTREE)),
     )
 
 

--- a/tests/integration/test_tool_budget_enforcement.py
+++ b/tests/integration/test_tool_budget_enforcement.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 import subprocess
 import sys
 import uuid
@@ -30,6 +29,7 @@ import pytest
 
 from agent import tool_budget
 from models.agent_session import AgentSession, SessionType
+from tests.db_claim import subprocess_env
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
@@ -205,18 +205,15 @@ def _write_sidecar(cli_session_id: str, agent_session_id: str) -> Path:
 def _run_cli_hook(cli_session_id: str, *, max_calls: str = "5"):
     """Run the CLI PreToolUse hook as a real subprocess; return the exit code.
 
-    Point the subprocess's Popoto at the SAME per-worker test DB the in-process
-    ``redis_test_db`` fixture swapped to (the fixture rebinds the client object
-    at runtime; a fresh subprocess would otherwise import against db=0 and see
-    no sessions → a false silent-allow).
+    ``subprocess_env`` points the child's Popoto at the SAME test DB this
+    process claimed (the ``redis_test_db`` fixture rebinds the client object
+    in memory, which cannot cross a fork; a fresh subprocess would otherwise
+    import against db=0 and see no sessions → a false silent-allow).
     """
-    from popoto.redis_db import POPOTO_REDIS_DB
-
-    test_db = POPOTO_REDIS_DB.connection_pool.connection_kwargs.get("db", 0)
-    env = {**os.environ}
-    env["REDIS_URL"] = f"redis://127.0.0.1:6379/{test_db}"
-    env["MAX_TOOL_CALLS_PER_SESSION"] = max_calls
-    env["PYTHONPATH"] = str(REPO_ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+    env = subprocess_env(
+        MAX_TOOL_CALLS_PER_SESSION=max_calls,
+        project_root=str(REPO_ROOT),
+    )
     payload = json.dumps(
         {"session_id": cli_session_id, "tool_name": "Read", "tool_input": {"file_path": "/x"}}
     )

--- a/tests/integration/test_watchdog_recovery.py
+++ b/tests/integration/test_watchdog_recovery.py
@@ -65,6 +65,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from monitoring.worker_watchdog import HEARTBEAT_THRESHOLD, _handle_missing_worker, check, recover
+from tests.db_claim import subprocess_env
 
 pytestmark = [pytest.mark.integration, pytest.mark.macos_only]
 

--- a/tests/integration/test_watchdog_recovery.py
+++ b/tests/integration/test_watchdog_recovery.py
@@ -94,6 +94,7 @@ def _spawn_fake_worker() -> subprocess.Popen:
         ],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
+        env=subprocess_env(),
     )
 
 

--- a/tests/unit/hooks/test_validate_design_system_sync.py
+++ b/tests/unit/hooks/test_validate_design_system_sync.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import importlib.util
 import json
-import os
 import subprocess
 import sys
 from pathlib import Path
+
+from tests.db_claim import subprocess_env
 
 HOOK = (
     Path(__file__).resolve().parents[3] / ".claude/hooks/validators/validate_design_system_sync.py"
@@ -25,8 +26,7 @@ def _load_hook_module():
 
 
 def _run_hook(payload: dict, env_extra: dict | None = None) -> tuple[int, str, str]:
-    env = os.environ.copy()
-    env.setdefault("PYTHONPATH", str(REPO_ROOT))
+    env = subprocess_env(project_root=str(REPO_ROOT))
     if env_extra:
         env.update(env_extra)
     proc = subprocess.run(
@@ -151,8 +151,10 @@ def test_crashed_checker_fails_open(tmp_path: Path):
     real_pen = REPO_ROOT / "tests/fixtures/design_system/design-system.pen"
     (pen_dir / "design-system.pen").write_bytes(real_pen.read_bytes())
 
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(REPO_ROOT)
+    # project_root only PREPENDS REPO_ROOT to PYTHONPATH; the hook's own
+    # `-m tools.design_system_sync` grandchild still puts its cwd (tmp_path)
+    # ahead of it, so the fake package planted above keeps winning.
+    env = subprocess_env(project_root=str(REPO_ROOT))
     proc = subprocess.run(
         [sys.executable, str(HOOK)],
         input=json.dumps(
@@ -209,8 +211,7 @@ def test_log_path_anchored_to_repo_root_not_cwd(tmp_path: Path):
     log_path = REPO_ROOT / "logs/validate_design_system_sync.jsonl"
     before = log_path.read_text(encoding="utf-8").splitlines() if log_path.is_file() else []
 
-    env = os.environ.copy()
-    env.setdefault("PYTHONPATH", str(REPO_ROOT))
+    env = subprocess_env(project_root=str(REPO_ROOT))
     proc = subprocess.run(
         [sys.executable, str(HOOK)],
         input=json.dumps({"tool_name": "Bash", "tool_input": {"command": "git add README.md"}}),

--- a/tests/unit/session_runner/test_tool_activity_liveness.py
+++ b/tests/unit/session_runner/test_tool_activity_liveness.py
@@ -34,6 +34,7 @@ from agent.session_runner.hook_edge import (
     tool_activity_path,
 )
 from agent.session_runner.liveness import tool_activity_ts
+from tests.db_claim import subprocess_env
 
 pytestmark = pytest.mark.unit
 
@@ -57,6 +58,9 @@ def _run_hook(*args: str) -> subprocess.CompletedProcess:
         capture_output=True,
         text=True,
         timeout=30,
+        # No project_root: this repo's importability is precisely what the hook
+        # must NOT depend on. subprocess_env only pins REDIS_URL (#2763).
+        env=subprocess_env(),
     )
 
 
@@ -281,5 +285,7 @@ def test_hook_module_imports_only_stdlib():
         capture_output=True,
         text=True,
         timeout=30,
+        # No project_root: the child strips this repo off sys.path on purpose.
+        env=subprocess_env(),
     )
     assert proc.returncode == 0, proc.stderr

--- a/tests/unit/test_critique_resume.py
+++ b/tests/unit/test_critique_resume.py
@@ -22,7 +22,10 @@ from unittest.mock import patch
 
 import pytest
 
+from tests.db_claim import subprocess_env
 from tools.critique_resume import find_reusable_run, main
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 # ---------------------------------------------------------------------------
 # Fence constants (mirror critique_roster_check)
@@ -477,6 +480,7 @@ class TestCLIHelp:
             [sys.executable, "-m", "tools.critique_resume", "--help"],
             capture_output=True,
             text=True,
+            env=subprocess_env(project_root=str(REPO_ROOT)),
         )
         assert result.returncode == 0
         assert "critique-resume-probe" in result.stdout

--- a/tests/unit/test_evaluate_build.py
+++ b/tests/unit/test_evaluate_build.py
@@ -10,6 +10,8 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+from tests.db_claim import subprocess_env
+
 # Add scripts to path for direct imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
@@ -138,6 +140,7 @@ class TestExitCodes:
             capture_output=True,
             text=True,
             cwd=cwd or str(Path(__file__).parent.parent.parent),
+            env=subprocess_env(project_root=str(Path(__file__).parent.parent.parent)),
         )
         return result
 
@@ -152,12 +155,7 @@ class TestExitCodes:
         plan_file = tmp_path / "no_ac_plan.md"
         plan_file.write_text(PLAN_WITHOUT_AC)
 
-        result = subprocess.run(
-            [sys.executable, "scripts/evaluate_build.py", str(plan_file)],
-            capture_output=True,
-            text=True,
-            cwd=str(Path(__file__).parent.parent.parent),
-        )
+        result = self._run_script([str(plan_file)])
         assert result.returncode == 3, (
             f"Expected exit 3, got {result.returncode}. stderr: {result.stderr}"
         )
@@ -168,12 +166,7 @@ class TestExitCodes:
         plan_file = tmp_path / "empty_ac_plan.md"
         plan_file.write_text(PLAN_WITH_EMPTY_AC)
 
-        result = subprocess.run(
-            [sys.executable, "scripts/evaluate_build.py", str(plan_file)],
-            capture_output=True,
-            text=True,
-            cwd=str(Path(__file__).parent.parent.parent),
-        )
+        result = self._run_script([str(plan_file)])
         assert result.returncode == 3, (
             f"Expected exit 3, got {result.returncode}. stderr: {result.stderr}"
         )

--- a/tests/unit/test_fence_census.py
+++ b/tests/unit/test_fence_census.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 import pytest
 
+from tests.db_claim import subprocess_env
 from tools.check_fence_census import EXEMPTION_MARKER, check_file
 
 #: tests/unit/test_fence_census.py -> repo root. Resolved from this file rather
@@ -42,6 +43,7 @@ def _run_checker(root: Path, *extra: str, cwd: Path | None = None):
         capture_output=True,
         text=True,
         cwd=str(cwd) if cwd is not None else str(Path(__file__).parent),
+        env=subprocess_env(),
         timeout=120,
     )
 

--- a/tests/unit/test_memory_search_cli.py
+++ b/tests/unit/test_memory_search_cli.py
@@ -12,6 +12,8 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from tests.db_claim import subprocess_env
+
 _REPO_ROOT = str(Path(__file__).parents[2])
 
 
@@ -365,6 +367,7 @@ class TestStatusSubcommandE2E:
             capture_output=True,
             text=True,
             cwd=_REPO_ROOT,
+            env=subprocess_env(project_root=_REPO_ROOT),
         )
         assert result.returncode == 0
         assert "status" in result.stdout
@@ -378,6 +381,7 @@ class TestStatusSubcommandE2E:
             capture_output=True,
             text=True,
             cwd=_REPO_ROOT,
+            env=subprocess_env(project_root=_REPO_ROOT),
         )
         # Exit 0 when Redis is up; exit 1 when down — both are valid in this test environment
         output = result.stdout.strip()

--- a/tests/unit/test_memory_timeline.py
+++ b/tests/unit/test_memory_timeline.py
@@ -10,10 +10,14 @@ import subprocess
 import sys
 import uuid
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 import pytest
 
+from tests.db_claim import subprocess_env
 from tools.memory_search import forget, save, timeline
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 # Unique project key for test isolation
 TEST_PROJECT_KEY = f"test-timeline-{uuid.uuid4().hex[:8]}"
@@ -230,6 +234,7 @@ class TestTimelineCLI:
             [sys.executable, "-m", "tools.memory_search", "timeline", "--help"],
             capture_output=True,
             text=True,
+            env=subprocess_env(project_root=str(REPO_ROOT)),
         )
         assert result.returncode == 0
         assert "timeline" in result.stdout.lower()
@@ -250,6 +255,7 @@ class TestTimelineCLI:
             ],
             capture_output=True,
             text=True,
+            env=subprocess_env(project_root=str(REPO_ROOT)),
         )
         assert result.returncode == 0
         parsed = json.loads(result.stdout)

--- a/tests/unit/test_migrate_strip_pid_fields.py
+++ b/tests/unit/test_migrate_strip_pid_fields.py
@@ -48,6 +48,7 @@ import pytest
 import scripts._strip_migration as shared
 import scripts.migrate_strip_pid_fields as strip
 from models.agent_session import AgentSession
+from tests.db_claim import subprocess_env
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -348,6 +349,7 @@ class TestLogsGoToStdout:
             capture_output=True,
             text=True,
             timeout=300,
+            env=subprocess_env(project_root=str(REPO_ROOT)),
         )
 
         assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"

--- a/tests/unit/test_pipeline_integrity.py
+++ b/tests/unit/test_pipeline_integrity.py
@@ -11,7 +11,10 @@ import os
 import subprocess
 import sys
 
+from tests.db_claim import subprocess_env
 from utils.github_patterns import construct_canonical_url as _construct_canonical_url
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 class TestCanonicalUrlConstruction:
@@ -91,7 +94,8 @@ class TestMergeGuardHook:
             input=hook_input,
             capture_output=True,
             text=True,
-            cwd=os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+            cwd=REPO_ROOT,
+            env=subprocess_env(project_root=REPO_ROOT),
         )
         assert result.returncode == 0, f"Hook failed: {result.stderr}"
         if result.stdout.strip():

--- a/tests/unit/test_post_tool_use_fast_path.py
+++ b/tests/unit/test_post_tool_use_fast_path.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.db_claim import subprocess_env
+
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 HOOK = REPO_ROOT / ".claude" / "hooks" / "post_tool_use.py"
 
@@ -95,6 +97,7 @@ def _run_hook(event: dict) -> subprocess.CompletedProcess:
         input=json.dumps(event),
         text=True,
         capture_output=True,
+        env=subprocess_env(project_root=str(REPO_ROOT)),
     )
 
 
@@ -137,6 +140,7 @@ def test_counter_only_call_does_not_import_popoto(clean_session):
         input=json.dumps(event),
         text=True,
         capture_output=True,
+        env=subprocess_env(project_root=str(REPO_ROOT)),
     )
     assert proc.returncode == 0, proc.stderr
     offenders = _heavy_import_offenders(proc.stderr)

--- a/tests/unit/test_reflections_main.py
+++ b/tests/unit/test_reflections_main.py
@@ -27,6 +27,7 @@ import pytest
 
 import reflections.__main__ as reflections_main
 from agent.reflection_scheduler import ReflectionScheduler
+from tests.db_claim import subprocess_env
 
 
 @pytest.fixture
@@ -73,8 +74,10 @@ class TestDryRun:
 
     def test_dry_run_subprocess_exits_zero(self, empty_registry_env):
         """Smoke test: `python -m reflections --dry-run` exits 0 as a real subprocess."""
-        env = dict(os.environ)
-        env["REFLECTIONS_YAML"] = str(empty_registry_env)
+        env = subprocess_env(
+            REFLECTIONS_YAML=str(empty_registry_env),
+            project_root=str(Path(__file__).parent.parent.parent),
+        )
         result = subprocess.run(
             [sys.executable, "-m", "reflections", "--dry-run"],
             cwd=Path(__file__).parent.parent.parent,

--- a/tests/unit/test_room_resolution.py
+++ b/tests/unit/test_room_resolution.py
@@ -10,6 +10,7 @@ prefix and delete every record via the ORM afterward.
 
 import json
 import uuid
+from pathlib import Path
 
 import pytest
 
@@ -22,6 +23,9 @@ from models.room import (
     room_id_for_session,
     telegram_addressee,
 )
+from tests.db_claim import subprocess_env
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 @pytest.fixture
@@ -256,6 +260,7 @@ class TestPeerParseSingleHome:
             text=True,
             timeout=30,
             check=True,
+            env=subprocess_env(project_root=str(REPO_ROOT)),
         )
         payload = json.loads(result.stdout.strip().splitlines()[-1])
         assert payload["popoto_loaded"] is False, (

--- a/tests/unit/test_sdlc_dispatch.py
+++ b/tests/unit/test_sdlc_dispatch.py
@@ -17,6 +17,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.db_claim import subprocess_env
+
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
@@ -270,30 +272,23 @@ class TestDispatchGetResetReader:
 
 
 def _isolated_subprocess_env():
-    """Env for CLI subprocesses: Redis isolated to the per-worker test db.
+    """Env for CLI subprocesses: Redis isolated to this process's claimed test db.
 
     The autouse redis_test_db fixture patches the IN-PROCESS popoto client;
-    a subprocess re-resolves REDIS_URL at import, so point it explicitly at
-    the same test db -- unit tests must never touch production Redis.
+    a subprocess re-resolves REDIS_URL at import, so ``subprocess_env()``
+    hands it the same claimed db -- unit tests must never touch production
+    Redis.
 
-    Also strips the run-identity env vars the #2144 self-heal path consults
+    Strips the run-identity env vars the #2144 self-heal path consults
     (``VALOR_SESSION_ID`` / ``AGENT_SESSION_ID`` — read by
     ``tools.sdlc_session_ensure``). A CLI subprocess test must never inherit a
     LIVE run identity from the parent process, or the healable/unhealable
     boundary these tests assert would depend on the ambient environment.
     """
-    import popoto.redis_db as rdb
-
-    kwargs = rdb.POPOTO_REDIS_DB.connection_pool.connection_kwargs
-    host = kwargs.get("host") or "localhost"
-    port = kwargs.get("port") or 6379
-    db = kwargs.get("db", 1)
-    env = {
-        k: v
-        for k, v in os.environ.items()
-        if k not in ("VALOR_SESSION_ID", "AGENT_SESSION_ID", "active_run_id")
-    }
-    env["REDIS_URL"] = f"redis://{host}:{port}/{db}"
+    env = subprocess_env()
+    env.pop("VALOR_SESSION_ID", None)
+    env.pop("AGENT_SESSION_ID", None)
+    env.pop("active_run_id", None)
     return env
 
 

--- a/tests/unit/test_sdlc_fork_issue_number.py
+++ b/tests/unit/test_sdlc_fork_issue_number.py
@@ -28,6 +28,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.db_claim import subprocess_env
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
 # ---------------------------------------------------------------------------
 # Skill-file resolution helpers
 # ---------------------------------------------------------------------------
@@ -506,6 +510,7 @@ class TestIssueNumberArgparseBoundary:
             ],
             capture_output=True,
             text=True,
+            env=subprocess_env(project_root=str(REPO_ROOT)),
         )
         assert result.returncode == 2, (
             f"Expected argparse exit code 2 for empty --issue-number, got {result.returncode}.\n"
@@ -532,6 +537,7 @@ class TestIssueNumberArgparseBoundary:
             ],
             capture_output=True,
             text=True,
+            env=subprocess_env(project_root=str(REPO_ROOT)),
         )
         assert result.returncode == 2, (
             f"Expected argparse exit code 2 for empty --issue-number stage-marker, "

--- a/tests/unit/test_sdlc_meta_set.py
+++ b/tests/unit/test_sdlc_meta_set.py
@@ -18,6 +18,8 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from tests.db_claim import subprocess_env
+
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 
@@ -359,6 +361,7 @@ class TestMetaSetCLI:
             capture_output=True,
             text=True,
             cwd=str(REPO_ROOT),
+            env=subprocess_env(project_root=str(REPO_ROOT)),
         )
         assert proc.returncode == 2
 
@@ -369,6 +372,7 @@ class TestMetaSetCLI:
             capture_output=True,
             text=True,
             cwd=str(REPO_ROOT),
+            env=subprocess_env(project_root=str(REPO_ROOT)),
         )
         assert proc.returncode != 0
 
@@ -379,6 +383,7 @@ class TestMetaSetCLI:
             capture_output=True,
             text=True,
             cwd=str(REPO_ROOT),
+            env=subprocess_env(project_root=str(REPO_ROOT)),
         )
         assert proc.returncode != 0
 
@@ -403,6 +408,7 @@ class TestMetaSetCLI:
             capture_output=True,
             text=True,
             cwd=str(REPO_ROOT),
+            env=subprocess_env(project_root=str(REPO_ROOT)),
         )
         assert proc.returncode == 1
         assert "LEASE_ABSENT" in proc.stderr
@@ -425,6 +431,7 @@ class TestMetaSetCLI:
                 capture_output=True,
                 text=True,
                 cwd=str(REPO_ROOT),
+                env=subprocess_env(project_root=str(REPO_ROOT)),
             )
             assert proc.returncode == 2, f"value {bad!r} should exit 2, got {proc.returncode}"
 
@@ -435,5 +442,6 @@ class TestMetaSetCLI:
             capture_output=True,
             text=True,
             cwd=str(REPO_ROOT),
+            env=subprocess_env(project_root=str(REPO_ROOT)),
         )
         assert proc.returncode == 0

--- a/tests/unit/test_sdlc_session_ensure.py
+++ b/tests/unit/test_sdlc_session_ensure.py
@@ -23,6 +23,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.db_claim import subprocess_env
+
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
@@ -235,6 +237,7 @@ class TestCLI:
             capture_output=True,
             text=True,
             cwd=REPO_ROOT,
+            env=subprocess_env(project_root=REPO_ROOT),
         )
         assert result.returncode == 0
         assert "--issue-number" in result.stdout
@@ -246,6 +249,7 @@ class TestCLI:
             capture_output=True,
             text=True,
             cwd=REPO_ROOT,
+            env=subprocess_env(project_root=REPO_ROOT),
         )
         assert result.returncode != 0
 
@@ -1448,7 +1452,6 @@ class TestKillOrphans:
         assert result["orphans"] == []
 
     def test_cli_dry_run_exits_zero_with_valid_json(self):
-        env = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
         result = subprocess.run(
             [
                 sys.executable,
@@ -1460,7 +1463,7 @@ class TestKillOrphans:
             capture_output=True,
             text=True,
             cwd=REPO_ROOT,
-            env=env,
+            env=subprocess_env(project_root=REPO_ROOT, PYTHONDONTWRITEBYTECODE="1"),
         )
         assert result.returncode == 0
         # stdout must be parseable JSON
@@ -1481,6 +1484,7 @@ class TestKillOrphans:
             capture_output=True,
             text=True,
             cwd=REPO_ROOT,
+            env=subprocess_env(project_root=REPO_ROOT),
         )
         # argparse .error() exits 2
         assert result.returncode != 0

--- a/tests/unit/test_sdlc_stage_marker.py
+++ b/tests/unit/test_sdlc_stage_marker.py
@@ -28,6 +28,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.db_claim import subprocess_env
+
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
@@ -1158,6 +1160,7 @@ class TestCLI:
             capture_output=True,
             text=True,
             cwd=REPO_ROOT,
+            env=subprocess_env(project_root=REPO_ROOT),
         )
         assert result.returncode == 0
         assert "--issue-number" in result.stdout
@@ -1168,22 +1171,18 @@ class TestCLI:
             capture_output=True,
             text=True,
             cwd=REPO_ROOT,
+            env=subprocess_env(project_root=REPO_ROOT),
         )
         # Missing required --stage and --status
         assert result.returncode != 0
 
     def test_with_issue_number_outputs_json(self):
-        import popoto.redis_db as rdb
-
-        strip = ("VALOR_SESSION_ID", "AGENT_SESSION_ID")
-        clean_env = {k: v for k, v in os.environ.items() if k not in strip}
-        # Isolate the subprocess to the per-worker test Redis db -- unit tests
-        # must never touch production Redis.
-        kwargs = rdb.POPOTO_REDIS_DB.connection_pool.connection_kwargs
-        clean_env["REDIS_URL"] = (
-            f"redis://{kwargs.get('host') or 'localhost'}:"
-            f"{kwargs.get('port') or 6379}/{kwargs.get('db', 1)}"
-        )
+        # subprocess_env() points the child at this pytest process's claimed
+        # test db. The strips keep the child from inheriting a live bridge run
+        # identity, which is what the assertions below turn on.
+        clean_env = subprocess_env(project_root=REPO_ROOT)
+        clean_env.pop("VALOR_SESSION_ID", None)
+        clean_env.pop("AGENT_SESSION_ID", None)
         result = subprocess.run(
             [
                 sys.executable,

--- a/tests/unit/test_sdlc_stage_query.py
+++ b/tests/unit/test_sdlc_stage_query.py
@@ -17,6 +17,8 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch  # noqa: F401 - patch used in tests below
 
+from tests.db_claim import subprocess_env
+
 # Resolve the repo root for subprocess cwd
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -440,8 +442,9 @@ class TestCLIOutput:
         # AGENT_SESSION_ID when no args are given, so inheriting the parent
         # env would cause a real Redis query and a non-empty result when
         # this test runs inside an SDLC session.
-        strip = ("VALOR_SESSION_ID", "AGENT_SESSION_ID")
-        clean_env = {k: v for k, v in os.environ.items() if k not in strip}
+        clean_env = subprocess_env(project_root=REPO_ROOT)
+        clean_env.pop("VALOR_SESSION_ID", None)
+        clean_env.pop("AGENT_SESSION_ID", None)
         result = subprocess.run(
             [sys.executable, "-m", "tools.sdlc_stage_query", "--format", "legacy"],
             capture_output=True,
@@ -458,6 +461,7 @@ class TestCLIOutput:
             capture_output=True,
             text=True,
             cwd=REPO_ROOT,
+            env=subprocess_env(project_root=REPO_ROOT),
         )
         assert result.returncode == 0
         assert "--session-id" in result.stdout
@@ -599,8 +603,9 @@ class TestEnrichedPayload:
 
     def test_legacy_flat_shape_preserved(self):
         """--format legacy returns the old flat shape."""
-        strip = ("VALOR_SESSION_ID", "AGENT_SESSION_ID")
-        clean_env = {k: v for k, v in os.environ.items() if k not in strip}
+        clean_env = subprocess_env(project_root=REPO_ROOT)
+        clean_env.pop("VALOR_SESSION_ID", None)
+        clean_env.pop("AGENT_SESSION_ID", None)
         result = subprocess.run(
             [
                 sys.executable,
@@ -620,8 +625,9 @@ class TestEnrichedPayload:
 
     def test_default_json_shape_includes_stages_and_meta(self):
         """Default (no --format flag) returns the enriched shape."""
-        strip = ("VALOR_SESSION_ID", "AGENT_SESSION_ID")
-        clean_env = {k: v for k, v in os.environ.items() if k not in strip}
+        clean_env = subprocess_env(project_root=REPO_ROOT)
+        clean_env.pop("VALOR_SESSION_ID", None)
+        clean_env.pop("AGENT_SESSION_ID", None)
         result = subprocess.run(
             [sys.executable, "-m", "tools.sdlc_stage_query"],
             capture_output=True,

--- a/tests/unit/test_sdlc_tool_wrapper.py
+++ b/tests/unit/test_sdlc_tool_wrapper.py
@@ -22,6 +22,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from tests.db_claim import subprocess_env
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WRAPPER = REPO_ROOT / "scripts" / "sdlc-tool"
 
@@ -66,29 +68,33 @@ class TestWrapperShellSemantics:
         assert os.access(WRAPPER, os.X_OK), f"wrapper not executable: {WRAPPER}"
 
     def test_wrapper_no_args_exits_2(self):
-        result = subprocess.run([str(WRAPPER)], capture_output=True, text=True)
+        result = subprocess.run(
+            [str(WRAPPER)], capture_output=True, text=True, env=subprocess_env()
+        )
         assert result.returncode == 2
         assert "Usage" in result.stderr
         assert "stage-query" in result.stderr  # subcommand list visible
 
     def test_wrapper_unknown_subcommand_exits_2(self):
-        result = subprocess.run([str(WRAPPER), "make-coffee"], capture_output=True, text=True)
+        result = subprocess.run(
+            [str(WRAPPER), "make-coffee"], capture_output=True, text=True, env=subprocess_env()
+        )
         assert result.returncode == 2
         assert "unknown subcommand" in result.stderr
         assert "make-coffee" in result.stderr
 
     def test_wrapper_help_flag_exits_0(self):
-        result = subprocess.run([str(WRAPPER), "--help"], capture_output=True, text=True)
+        result = subprocess.run(
+            [str(WRAPPER), "--help"], capture_output=True, text=True, env=subprocess_env()
+        )
         assert result.returncode == 0
 
     def test_wrapper_missing_ai_repo_root_exits_2(self, tmp_path):
-        env = os.environ.copy()
-        env["AI_REPO_ROOT"] = str(tmp_path / "does-not-exist")
         result = subprocess.run(
             [str(WRAPPER), "stage-query", "--issue-number", "0"],
             capture_output=True,
             text=True,
-            env=env,
+            env=subprocess_env(AI_REPO_ROOT=str(tmp_path / "does-not-exist")),
         )
         assert result.returncode == 2
         assert "AI_REPO_ROOT" in result.stderr
@@ -96,13 +102,11 @@ class TestWrapperShellSemantics:
 
     def test_wrapper_ai_repo_root_without_tools_exits_2(self, tmp_path):
         # Directory exists but has no tools/ subdir
-        env = os.environ.copy()
-        env["AI_REPO_ROOT"] = str(tmp_path)
         result = subprocess.run(
             [str(WRAPPER), "stage-query", "--issue-number", "0"],
             capture_output=True,
             text=True,
-            env=env,
+            env=subprocess_env(AI_REPO_ROOT=str(tmp_path)),
         )
         assert result.returncode == 2
         assert "tools/" in result.stderr
@@ -124,14 +128,16 @@ class TestWrapperDispatch:
         (fake_tools / "__init__.py").write_text("")
         # Deliberately do NOT create sdlc_stage_query.py here.
 
-        env = os.environ.copy()
-        env["AI_REPO_ROOT"] = str(REPO_ROOT)
+        # No project_root=: this test pins the wrapper's own module-resolution
+        # order against a decoy tools/ package, and prepending REPO_ROOT to
+        # PYTHONPATH would resolve the import for reasons other than the
+        # wrapper's doing. Only subprocess_env's REDIS_URL half is wanted here.
         result = subprocess.run(
             [str(WRAPPER), "stage-query", "--issue-number", "999999"],
             cwd=str(tmp_path),
             capture_output=True,
             text=True,
-            env=env,
+            env=subprocess_env(AI_REPO_ROOT=str(REPO_ROOT)),
             timeout=60,
         )
         assert result.returncode == 0, (
@@ -174,6 +180,7 @@ class TestVerdictAndDispatchLoudExit:
             cwd=str(REPO_ROOT),
             capture_output=True,
             text=True,
+            env=subprocess_env(project_root=str(REPO_ROOT)),
         )
         assert result.returncode == 1, (
             f"sdlc_verdict.main() should exit 1 on inner raise, got "
@@ -200,6 +207,7 @@ class TestVerdictAndDispatchLoudExit:
             cwd=str(REPO_ROOT),
             capture_output=True,
             text=True,
+            env=subprocess_env(project_root=str(REPO_ROOT)),
         )
         assert result.returncode == 0
         assert json.loads(result.stdout.strip()) == {}
@@ -232,6 +240,7 @@ class TestVerdictAndDispatchLoudExit:
             cwd=str(REPO_ROOT),
             capture_output=True,
             text=True,
+            env=subprocess_env(project_root=str(REPO_ROOT)),
         )
         assert result.returncode == 1, (
             f"sdlc_dispatch.main() should exit 1 on inner raise, got "

--- a/tests/unit/test_session_lifecycle.py
+++ b/tests/unit/test_session_lifecycle.py
@@ -25,6 +25,7 @@ from models.session_lifecycle import (
     finalize_session,
     transition_status,
 )
+from tests.db_claim import subprocess_env
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -1600,13 +1601,7 @@ class TestRunIdentityAcrossProcesses:
 
     @staticmethod
     def _subprocess_env():
-        import popoto.redis_db as rdb
-
-        kwargs = rdb.POPOTO_REDIS_DB.connection_pool.connection_kwargs
-        host = kwargs.get("host") or "localhost"
-        port = kwargs.get("port") or 6379
-        db = kwargs.get("db", 1)
-        env = {**os.environ, "REDIS_URL": f"redis://{host}:{port}/{db}"}
+        env = subprocess_env()
         env.pop("SDLC_HOLDER_TOKEN", None)  # the env seam is GONE -- prove it
         return env
 

--- a/tests/unit/test_session_lifecycle_consolidation.py
+++ b/tests/unit/test_session_lifecycle_consolidation.py
@@ -10,7 +10,6 @@ Covers:
 - Parent finalization via _finalize_parent_sync()
 """
 
-import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -25,6 +24,7 @@ from models.session_lifecycle import (
     transition_status,
     update_session,
 )
+from tests.db_claim import subprocess_env
 
 
 @pytest.fixture
@@ -469,7 +469,7 @@ class TestImportSafety:
             capture_output=True,
             text=True,
             cwd=project_root,
-            env={**os.environ, "PYTHONPATH": project_root},
+            env=subprocess_env(project_root=project_root),
         )
         assert result.returncode == 0, (
             f"models.session_lifecycle failed to import standalone: {result.stderr}"

--- a/tests/unit/test_session_progress.py
+++ b/tests/unit/test_session_progress.py
@@ -24,6 +24,7 @@ from types import SimpleNamespace
 import pytest
 
 import agent.session_runner.adapter as adapter
+from tests.db_claim import subprocess_env
 from tools.session_progress import (
     VERDICT_NO_RECENT_ACTIVITY,
     VERDICT_PROGRESSING,
@@ -77,7 +78,7 @@ def _unused_pid() -> int:
     gone rather than a zombie -- a zombie still answers `kill(pid, 0)` and
     would make the test assert the opposite of what it means to.
     """
-    proc = subprocess.Popen([sys.executable, "-c", ""])
+    proc = subprocess.Popen([sys.executable, "-c", ""], env=subprocess_env())
     proc.wait()
     return proc.pid
 

--- a/tests/unit/test_session_telemetry.py
+++ b/tests/unit/test_session_telemetry.py
@@ -12,6 +12,7 @@ from agent.session_telemetry import (
     read_session_timeline,
     record_telemetry_event,
 )
+from tests.db_claim import subprocess_env
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -470,6 +471,7 @@ class TestStatusTransitionTextRenderer:
                 capture_output=True,
                 text=True,
                 cwd=str(repo_root),
+                env=subprocess_env(project_root=str(repo_root)),
             )
             assert result.returncode == 0, f"stderr: {result.stderr}"
             assert "running" in result.stdout, f"Got: {result.stdout!r}"

--- a/tests/unit/test_steering_mechanism.py
+++ b/tests/unit/test_steering_mechanism.py
@@ -7,7 +7,13 @@ Covers:
 4. valor-session CLI — help output and basic argument parsing
 """
 
+from pathlib import Path
+
 import pytest
+
+from tests.db_claim import subprocess_env
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 class TestOutputRouterExports:
@@ -337,6 +343,7 @@ class TestValorSessionCLI:
             [sys.executable, "-m", "tools.valor_session", "--help"],
             capture_output=True,
             text=True,
+            env=subprocess_env(project_root=str(REPO_ROOT)),
         )
         assert result.returncode == 0
         assert "valor-session" in result.stdout
@@ -350,6 +357,7 @@ class TestValorSessionCLI:
             [sys.executable, "-m", "tools.valor_session", "--help"],
             capture_output=True,
             text=True,
+            env=subprocess_env(project_root=str(REPO_ROOT)),
         )
         for cmd in ("create", "steer", "status", "list", "kill"):
             assert cmd in result.stdout, f"Subcommand '{cmd}' missing from help output"
@@ -364,6 +372,7 @@ class TestValorSessionCLI:
             [sys.executable, "-m", "tools.valor_session", "steer", "--id", "abc"],
             capture_output=True,
             text=True,
+            env=subprocess_env(project_root=str(REPO_ROOT)),
         )
         assert result.returncode != 0
         assert "message" in result.stderr.lower() or "required" in result.stderr.lower()

--- a/tests/unit/test_stop_detach.py
+++ b/tests/unit/test_stop_detach.py
@@ -27,6 +27,8 @@ from unittest.mock import patch
 
 import pytest
 
+from tests.db_claim import subprocess_env
+
 HOOKS_DIR = Path(__file__).parent.parent.parent / ".claude" / "hooks"
 
 for _p in (str(HOOKS_DIR),):
@@ -162,7 +164,7 @@ class TestStaleLockReaping:
         # A definitely-dead PID: spawn a trivial subprocess and wait for it
         # to exit. Avoids os.fork() in a (possibly multi-threaded) test
         # process, which Python warns can deadlock.
-        proc = subprocess.Popen([sys.executable, "-c", "pass"])
+        proc = subprocess.Popen([sys.executable, "-c", "pass"], env=subprocess_env())
         proc.wait()
         dead_pid = proc.pid
 

--- a/tests/unit/test_subprocess_test_db_isolation.py
+++ b/tests/unit/test_subprocess_test_db_isolation.py
@@ -131,6 +131,44 @@ ALLOWLIST: frozenset[str] = frozenset(
         "tests/unit/test_youtube_search.py:219",
         # [standalone-script] starred argv0 (*env_git) SKIP_ARGV0 cannot resolve; child is git
         "tests/unit/test_sdlc_next_skill.py:209",
+        #
+        # [standalone-script] validate_design_system_readonly.py: json/os/re/sys only,
+        # no subprocess. (Its sibling validate_design_system_sync.py IS converted —
+        # that one spawns `-m tools.design_system_sync`, a repo module.)
+        "tests/unit/hooks/test_validate_design_system_readonly.py:23",
+        # [standalone-script] validate_features_readme_sort.py: stdlib only, no subprocess
+        "tests/unit/test_features_readme_sort.py:255",
+        "tests/unit/test_features_readme_sort.py:277",
+        "tests/unit/test_features_readme_sort.py:304",
+        "tests/unit/test_features_readme_sort.py:334",
+        "tests/unit/test_features_readme_sort.py:346",
+        "tests/unit/test_features_readme_sort.py:360",
+        "tests/unit/test_features_readme_sort.py:386",
+        # [standalone-script] relink_global_skills.py: json/os/select/sys/pathlib, no subprocess
+        "tests/unit/test_relink_global_skills.py:27",
+        # [standalone-script] validate_commit_message.py: json/re/sys only, no subprocess
+        "tests/unit/test_sync_claude_to_opencode.py:421",
+        "tests/unit/test_sync_claude_to_opencode.py:436",
+        "tests/unit/test_validate_commit_message.py:26",
+        "tests/unit/test_validate_commit_message.py:76",
+        # [standalone-script] validate_no_destructive_git_in_*.py: stdlib plus
+        # hook_utils.destructive_git_shapes, itself stdlib-only; shells out to git only
+        "tests/unit/test_validate_no_destructive_git_in_shared_checkout.py:341",
+        "tests/unit/test_validate_no_destructive_git_in_worktree.py:129",
+        "tests/unit/test_validate_no_destructive_git_in_worktree.py:185",
+        "tests/unit/test_validate_no_destructive_git_in_worktree.py:208",
+        # [standalone-script] validate_no_gos_justification.py: stdlib only; shells to `gh`
+        "tests/unit/test_validate_no_gos_justification.py:145",
+        "tests/unit/test_validate_no_gos_justification.py:248",
+        # [standalone-script] validate_no_uv_sync_in_worktree.py: json/re/shlex/sys/pathlib
+        "tests/unit/test_validate_no_uv_sync_in_worktree.py:133",
+        "tests/unit/test_validate_no_uv_sync_in_worktree.py:188",
+        "tests/unit/test_validate_no_uv_sync_in_worktree.py:199",
+        "tests/unit/test_validate_no_uv_sync_in_worktree.py:487",
+        "tests/unit/test_validate_no_uv_sync_in_worktree.py:501",
+        # [standalone-script] validate_sdlc_on_stop.py: stdlib plus hook_utils.constants
+        # (stdlib-only); its subprocess use is `git` invocations exclusively
+        "tests/unit/test_validate_sdlc_on_stop.py:265",
     }
 )
 

--- a/tests/unit/test_subprocess_test_db_isolation.py
+++ b/tests/unit/test_subprocess_test_db_isolation.py
@@ -1,0 +1,539 @@
+"""Guard: every test subprocess that can reach Popoto must inherit the parent's claimed test db.
+
+Issue #2763. ``tests/conftest.py``'s autouse ``redis_test_db`` fixture isolates
+the *parent* pytest process by rebinding Popoto's client objects in memory. That
+state cannot cross a ``fork``: the only channel to a child process is the
+environment, and popoto resolves ``REDIS_URL`` at import time, falling back to
+``redis://localhost:6379`` — **db0, production** — when the variable is unset.
+So a test that shells out to a Python child without an explicit env silently
+reads and writes production Redis.
+
+``tests.db_claim.subprocess_env()`` is the bridge: it writes
+``REDIS_URL=redis://127.0.0.1:<port>/<claimed db>`` into the child's env. This
+guard fails the suite when a call site reintroduces the un-bridged shape.
+
+The predicate
+-------------
+A ``subprocess.{run,Popen,check_output,check_call,call}`` call is IN SCOPE when
+its **first positional argument** mentions a Python interpreter or a repo entry
+point: ``sys.executable``, an identifier containing ``PYTHON``, a ``"-m"``
+element, the ``WRAPPER`` constant, or a string naming a ``scripts/`` path or a
+``python*`` binary.
+
+``cwd=`` is deliberately **not** part of the predicate. Matching on the spelling
+of a ``cwd`` variable is what let an earlier draft of this guard go green
+without the sweep: converted files spell the repo root a dozen different ways
+(``REPO_ROOT``, ``repo_root``, an inline ``Path(__file__).parent.parent.parent``),
+and ``tests/unit/test_sdlc_tool_wrapper.py`` reaches Python against the repo
+from ``cwd=str(tmp_path)`` — plausibly the very shape that wrote the stray db0
+row this issue was filed against. What determines whether a child can import
+popoto is *what is executed*, not where it is executed from.
+
+Why ``git``-in-``tmp_path`` calls are excluded
+----------------------------------------------
+A large share of the suite's subprocess calls run ``git`` inside a scratch
+repository under ``tmp_path``. A ``git`` child never imports Python, never
+imports popoto, and therefore cannot reach Redis at all; converting those sites
+would add an import and churn to dozens of files for zero isolation gain.
+``SKIP_ARGV0`` names that exclusion explicitly, as one reviewable line, rather
+than hiding it inside the predicate.
+
+How to satisfy the guard
+------------------------
+Pass ``env=subprocess_env(...)``::
+
+    from tests.db_claim import subprocess_env
+
+    subprocess.run([sys.executable, "-m", "tools.thing"], env=subprocess_env())
+
+Four shapes are accepted, because the fixes this guard exists to drive produce
+all four:
+
+1. a direct call — ``env=subprocess_env(project_root=str(REPO_ROOT))``;
+2. a local variable assigned exactly once from ``subprocess_env(...)`` and
+   thereafter only stripped — ``env = subprocess_env(); env.pop("X", None)``
+   (the strips are load-bearing in several tests, so a rule that accepted only
+   the direct call would reject this plan's own remedy);
+3. a module-level delegator resolved **one** hop — ``def _w(**k): return
+   subprocess_env(**k)`` used as ``env=_w()``, or the assign-mutate-return form
+   of (2) ending ``return env``;
+4. the same delegator reached as a method — ``env=self._w()`` / ``cls._w()``,
+   resolved against the nearest enclosing class.
+
+A helper that derives its db from anything other than ``subprocess_env`` — for
+instance by reading it back out of
+``POPOTO_REDIS_DB.connection_pool.connection_kwargs`` — is a violation, however
+correct it happens to be today. The check resolves the ``env=`` value to an AST
+node, never to source text: a substring test on ``"subprocess_env"`` would pass
+``_isolated_subprocess_env()`` and ``_subprocess_env()``, which are precisely
+the helpers this guard exists to kill.
+
+Exemptions are entries in ``ALLOWLIST``, each carrying a written reason. Only
+two reasons are permitted; see that constant. **When reachability is unclear,
+convert the site — do not allowlist it.** A parametrized argv such as
+``[sys.executable, "-m", module, *argv]`` reaches repo code even though a static
+scan cannot name the module.
+
+Self-tests
+----------
+This module lives inside its own scan root, so its fixtures are Python **source
+strings** handed to :func:`scan_source`, never live importable code — a fixture
+written as real code would report itself on the first green run, and the obvious
+"fix" would be to allowlist it, quietly destroying the predicate's only proof.
+The guard's own file is additionally excluded from the walk.
+"""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TESTS_ROOT = REPO_ROOT / "tests"
+GUARD_PATH = Path(__file__).resolve()
+
+# subprocess entry points that fork a child.
+SUBPROCESS_FUNCS = frozenset({"run", "Popen", "check_output", "check_call", "call"})
+
+# Programs that cannot import popoto and so cannot reach Redis, keyed by argv[0]
+# basename. Resolved statically: a non-literal argv[0] is never skipped.
+SKIP_ARGV0 = frozenset({"git"})
+
+# Per-site exemptions, keyed "<repo-relative path>:<subprocess.<fn>( call-start line>".
+#
+# Exactly two reasons are permitted, and the reason is written on the line:
+#   [#2628]             the file is owned by / collides with open PR #2683, so
+#                       this PR must not touch it. Allowlisting here edits no
+#                       forbidden file, which is what makes "guard green" and
+#                       "no #2683-owned file in the diff" simultaneously
+#                       satisfiable. Remove the entry and convert the site when
+#                       #2628 lands.
+#   [standalone-script] the child is a single-file .claude/hooks/ validator or
+#                       scripts/ utility that imports no repo package.
+ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # [#2628] owned by open PR #2683 — No-Go here, fix there; convert when #2628 lands
+        "tests/unit/test_redis_flush_guard_prod.py:54",
+        # [#2628] same file, same owner; helper sets PYTHONPATH but not REDIS_URL
+        "tests/unit/test_redis_flush_guard_prod.py:555",
+        # [#2628] same file, same owner
+        "tests/unit/test_redis_flush_guard_prod.py:579",
+        # [#2628] same file, same owner
+        "tests/unit/test_redis_flush_guard_prod.py:648",
+        # [#2628] same file, same owner. Beyond the five sites the plan enumerated:
+        # env={**_subprocess_env(), "VIRTUAL_ENV": ...} is a Dict literal, so it
+        # resolves to no helper at all. Same disposition — #2683 owns the fix.
+        "tests/unit/test_redis_flush_guard_prod.py:666",
+        # [#2628] owned by open PR #2683 — No-Go here, fix there
+        "tests/unit/test_conftest_isolation_guards.py:463",
+        # [#2628] PR #2683 deletes an adjacent class at :226; both edits land in one hunk
+        "tests/unit/test_youtube_search.py:219",
+        # [standalone-script] starred argv0 (*env_git) SKIP_ARGV0 cannot resolve; child is git
+        "tests/unit/test_sdlc_next_skill.py:209",
+    }
+)
+
+# Methods that would rebuild or re-point an env dict after it was built by
+# subprocess_env(). `.pop(<literal>, None)` and `.update(...)` are the two the
+# plan's remedies use; pure reads (`.get`, `.copy`, `.items`, …) are harmless
+# and are not rejected, so this is written as a denylist of mutators rather than
+# an allowlist of two names.
+_DISALLOWED_MUTATORS = frozenset({"setdefault", "clear", "popitem", "__setitem__"})
+
+
+# --------------------------------------------------------------------------
+# argv predicate
+# --------------------------------------------------------------------------
+
+
+def _string_constants(node: ast.AST) -> list[str]:
+    out: list[str] = []
+    for n in ast.walk(node):
+        if isinstance(n, ast.Constant) and isinstance(n.value, str):
+            out.append(n.value)
+    return out
+
+
+def _identifiers(node: ast.AST) -> list[str]:
+    out: list[str] = []
+    for n in ast.walk(node):
+        if isinstance(n, ast.Name):
+            out.append(n.id)
+        elif isinstance(n, ast.Attribute):
+            out.append(n.attr)
+    return out
+
+
+def _argv0_is_skipped(argv: ast.AST) -> bool:
+    """True when argv[0] is a literal program named in SKIP_ARGV0."""
+    first: ast.AST | None = None
+    if isinstance(argv, (ast.List, ast.Tuple)):
+        if not argv.elts:
+            return False
+        first = argv.elts[0]
+    elif isinstance(argv, ast.Constant) and isinstance(argv.value, str):
+        # shell=True form: "git status --porcelain"
+        parts = argv.value.split()
+        return bool(parts) and Path(parts[0]).name in SKIP_ARGV0
+    if isinstance(first, ast.Constant) and isinstance(first.value, str):
+        return Path(first.value).name in SKIP_ARGV0
+    return False
+
+
+def _argv_reaches_python(argv: ast.AST) -> bool:
+    """True when the first positional arg names a Python interpreter or repo entry point."""
+    for ident in _identifiers(argv):
+        upper = ident.upper()
+        if ident == "executable" or "PYTHON" in upper or "WRAPPER" in upper:
+            return True
+    for s in _string_constants(argv):
+        if s == "-m" or " -m " in s:
+            return True
+        if "scripts/" in s:
+            return True
+        if Path(s).name.lower().startswith("python"):
+            return True
+    return False
+
+
+def _is_subprocess_call(node: ast.Call, ctx: _ScanContext) -> bool:
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        if func.attr not in SUBPROCESS_FUNCS:
+            return False
+        root = func.value
+        while isinstance(root, ast.Attribute):
+            root = root.value
+        return isinstance(root, ast.Name) and root.id == "subprocess"
+    if isinstance(func, ast.Name):
+        return func.id in ctx.subprocess_names
+    return False
+
+
+# --------------------------------------------------------------------------
+# env= resolution
+# --------------------------------------------------------------------------
+
+
+class _ScanContext:
+    """Module-level facts the env= check needs: imports, helpers, parent links."""
+
+    def __init__(self, tree: ast.Module, path: str) -> None:
+        self.tree = tree
+        self.path = path
+        self.imports_db_claim = False
+        self.subprocess_names: set[str] = set()
+        self.module_funcs: dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
+        self.parents: dict[ast.AST, ast.AST] = {}
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                mod = node.module or ""
+                if mod.split(".")[-1] == "db_claim":
+                    self.imports_db_claim = True
+                if mod == "subprocess":
+                    self.subprocess_names.update(
+                        a.asname or a.name for a in node.names if a.name in SUBPROCESS_FUNCS
+                    )
+            elif isinstance(node, ast.Import):
+                for a in node.names:
+                    if a.name.split(".")[-1] == "db_claim":
+                        self.imports_db_claim = True
+            for child in ast.iter_child_nodes(node):
+                self.parents[child] = node
+
+        for node in tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                self.module_funcs[node.name] = node
+
+    def enclosing(self, node: ast.AST, kinds: tuple[type, ...]) -> ast.AST | None:
+        cur = self.parents.get(node)
+        while cur is not None:
+            if isinstance(cur, kinds):
+                return cur
+            cur = self.parents.get(cur)
+        return None
+
+
+def _is_direct_subprocess_env(func: ast.AST) -> bool:
+    """`subprocess_env` or `<mod>.subprocess_env` — exact, never a substring match."""
+    if isinstance(func, ast.Name):
+        return func.id == "subprocess_env"
+    if isinstance(func, ast.Attribute):
+        return func.attr == "subprocess_env"
+    return False
+
+
+def _name_is_clean(name: str, scope: ast.AST | None, ctx: _ScanContext) -> bool:
+    """`name` is bound exactly once from subprocess_env(...) and only stripped after."""
+    if scope is None:
+        return False
+    assigns: list[ast.Assign] = []
+    for node in ast.walk(scope):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == name:
+                    assigns.append(node)
+                elif isinstance(target, ast.Subscript):
+                    if isinstance(target.value, ast.Name) and target.value.id == name:
+                        return False  # env["REDIS_URL"] = ... — hand-derived db
+                elif isinstance(target, (ast.Tuple, ast.List)):
+                    if any(isinstance(e, ast.Name) and e.id == name for e in target.elts):
+                        return False
+        elif isinstance(node, (ast.AugAssign, ast.AnnAssign)):
+            target = node.target
+            if isinstance(target, ast.Name) and target.id == name:
+                return False
+            if isinstance(target, ast.Subscript):
+                if isinstance(target.value, ast.Name) and target.value.id == name:
+                    return False
+        elif isinstance(node, (ast.For, ast.AsyncFor)):
+            if isinstance(node.target, ast.Name) and node.target.id == name:
+                return False
+        elif isinstance(node, ast.withitem):
+            if isinstance(node.optional_vars, ast.Name) and node.optional_vars.id == name:
+                return False
+        elif isinstance(node, ast.Call):
+            func = node.func
+            if (
+                isinstance(func, ast.Attribute)
+                and isinstance(func.value, ast.Name)
+                and func.value.id == name
+                and func.attr in _DISALLOWED_MUTATORS
+            ):
+                return False
+    if len(assigns) != 1:
+        return False
+    value = assigns[0].value
+    return (
+        isinstance(value, ast.Call)
+        and _is_direct_subprocess_env(value.func)
+        and ctx.imports_db_claim
+    )
+
+
+def _body_statements(func: ast.FunctionDef | ast.AsyncFunctionDef) -> list[ast.stmt]:
+    body = list(func.body)
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(body[0].value, ast.Constant)
+        and isinstance(body[0].value.value, str)
+    ):
+        body = body[1:]
+    return body
+
+
+def _delegator_is_clean(func: ast.FunctionDef | ast.AsyncFunctionDef, ctx: _ScanContext) -> bool:
+    """One hop, never recursive: single `return subprocess_env(...)`, or assign-mutate-return."""
+    body = _body_statements(func)
+    if not body:
+        return False
+    last = body[-1]
+    if not isinstance(last, ast.Return) or last.value is None:
+        return False
+    if len(body) == 1:
+        value = last.value
+        return (
+            isinstance(value, ast.Call)
+            and _is_direct_subprocess_env(value.func)
+            and ctx.imports_db_claim
+        )
+    if isinstance(last.value, ast.Name):
+        return _name_is_clean(last.value.id, func, ctx)
+    return False
+
+
+def _env_value_is_clean(value: ast.expr, call: ast.Call, ctx: _ScanContext) -> bool:
+    if isinstance(value, ast.Call):
+        func = value.func
+        if _is_direct_subprocess_env(func):
+            return ctx.imports_db_claim
+        if isinstance(func, ast.Name):
+            helper = ctx.module_funcs.get(func.id)
+            return _delegator_is_clean(helper, ctx) if helper is not None else False
+        if isinstance(func, ast.Attribute):
+            owner = func.value
+            if isinstance(owner, ast.Name) and owner.id in {"self", "cls"}:
+                klass = ctx.enclosing(call, (ast.ClassDef,))
+                if klass is None:
+                    return False
+                for stmt in klass.body:
+                    if (
+                        isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef))
+                        and stmt.name == func.attr
+                    ):
+                        # @staticmethod / @classmethod wrapping is irrelevant to
+                        # the body check, so no unwrapping is needed beyond
+                        # locating the FunctionDef itself.
+                        return _delegator_is_clean(stmt, ctx)
+                return False  # not found in the enclosing class — a violation, not a pass
+        return False
+    if isinstance(value, ast.Name):
+        scope = ctx.enclosing(call, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Module))
+        return _name_is_clean(value.id, scope, ctx)
+    return False
+
+
+# --------------------------------------------------------------------------
+# scanner
+# --------------------------------------------------------------------------
+
+
+def scan_source(src: str, path: str = "<source>") -> list[str]:
+    """Return ``"path:line — reason"`` for every in-scope call lacking a clean env=."""
+    tree = ast.parse(src)
+    ctx = _ScanContext(tree, path)
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not _is_subprocess_call(node, ctx):
+            continue
+        if not node.args:
+            continue
+        argv = node.args[0]
+        if _argv0_is_skipped(argv):
+            continue
+        if not _argv_reaches_python(argv):
+            continue
+        if f"{path}:{node.lineno}" in ALLOWLIST:
+            continue
+        env_kw = next((k for k in node.keywords if k.arg == "env"), None)
+        if env_kw is None:
+            violations.append(f"{path}:{node.lineno} — no env= (child inherits ambient REDIS_URL)")
+        elif not _env_value_is_clean(env_kw.value, node, ctx):
+            expr = ast.unparse(env_kw.value)
+            violations.append(
+                f"{path}:{node.lineno} — env={expr} does not resolve to subprocess_env()"
+            )
+    return violations
+
+
+def scan_tests_tree() -> tuple[list[str], int]:
+    """Walk ``tests/**/*.py`` (excluding this guard). Returns (violations, files_scanned)."""
+    violations: list[str] = []
+    scanned = 0
+    for path in sorted(TESTS_ROOT.rglob("*.py")):
+        if path.resolve() == GUARD_PATH:
+            continue
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        scanned += 1
+        violations.extend(scan_source(path.read_text(encoding="utf-8"), rel))
+    return violations, scanned
+
+
+REMEDY = (
+    "Remedy: pass env=subprocess_env(...) "
+    "(from tests.db_claim import subprocess_env). Extra variables go through "
+    "subprocess_env(**extra); never hand-build a dict or re-derive the db number. "
+    "See this module's docstring for the four accepted shapes and the two "
+    "permitted ALLOWLIST reasons."
+)
+
+
+def test_every_test_subprocess_inherits_the_claimed_test_db():
+    violations, scanned = scan_tests_tree()
+    # An empty scan must never read as success (#2763): if a future refactor
+    # moves the tests tree, the guard would silently become a no-op.
+    assert scanned > 0, f"no Python files found under {TESTS_ROOT} — the guard scanned nothing"
+    assert not violations, (
+        f"{len(violations)} test subprocess call site(s) launch Python or a repo "
+        f"entry point without inheriting this pytest process's claimed Redis test "
+        f"db, so the child resolves REDIS_URL to production db0 (#2763):\n\n"
+        + "\n".join(violations)
+        + f"\n\n{REMEDY}"
+    )
+
+
+# --------------------------------------------------------------------------
+# self-tests — fixtures are SOURCE STRINGS, never live code in the scan root
+# --------------------------------------------------------------------------
+
+_REJECTED_REDERIVED_HELPER = """
+import subprocess
+import sys
+from popoto import redis_db as rdb
+
+
+def _my_subprocess_env():
+    env = os.environ.copy()
+    kwargs = rdb.POPOTO_REDIS_DB.connection_pool.connection_kwargs
+    env["REDIS_URL"] = f"redis://127.0.0.1:6379/{kwargs['db']}"
+    return env
+
+
+def test_thing():
+    subprocess.run([sys.executable, "-m", "tools.thing"], env=_my_subprocess_env())
+"""
+
+_ACCEPTED_THIN_DELEGATOR = """
+import subprocess
+import sys
+
+from tests.db_claim import subprocess_env
+
+
+def _w(**k):
+    return subprocess_env(**k)
+
+
+def test_thing():
+    subprocess.run([sys.executable, "-m", "tools.thing"], env=_w())
+"""
+
+_ACCEPTED_ASSIGN_MUTATE_RETURN = """
+import subprocess
+import sys
+
+from tests.db_claim import subprocess_env
+
+
+def _w():
+    e = subprocess_env()
+    e.pop("X", None)
+    return e
+
+
+def test_thing():
+    subprocess.run([sys.executable, "-m", "tools.thing"], env=_w())
+"""
+
+_ACCEPTED_STATICMETHOD_DELEGATOR = """
+import subprocess
+import sys
+
+from tests.db_claim import subprocess_env
+
+
+class TestThing:
+    @staticmethod
+    def _w():
+        e = subprocess_env()
+        e.pop("X", None)
+        return e
+
+    def test_thing(self):
+        subprocess.run([sys.executable, "-m", "tools.thing"], env=self._w())
+"""
+
+
+def test_self_test_rederived_helper_is_reported():
+    """A helper that reads the db back out of the live client is NOT subprocess_env."""
+    violations = scan_source(textwrap.dedent(_REJECTED_REDERIVED_HELPER), "fixture.py")
+    assert len(violations) == 1, violations
+    assert "fixture.py:" in violations[0]
+
+
+def test_self_test_thin_delegator_is_accepted():
+    """`def _w(**k): return subprocess_env(**k)` is a correct helper, not a violation."""
+    assert scan_source(textwrap.dedent(_ACCEPTED_THIN_DELEGATOR), "fixture.py") == []
+
+
+def test_self_test_assign_mutate_return_delegator_is_accepted():
+    """The strips are load-bearing in several tests; the guard must accept them."""
+    assert scan_source(textwrap.dedent(_ACCEPTED_ASSIGN_MUTATE_RETURN), "fixture.py") == []
+
+
+def test_self_test_staticmethod_delegator_is_accepted():
+    """`env=self._w()` resolves through the enclosing class, one hop."""
+    assert scan_source(textwrap.dedent(_ACCEPTED_STATICMETHOD_DELEGATOR), "fixture.py") == []

--- a/tests/unit/test_subprocess_test_db_isolation.py
+++ b/tests/unit/test_subprocess_test_db_isolation.py
@@ -87,6 +87,8 @@ from __future__ import annotations
 
 import ast
 import textwrap
+import tomllib
+from functools import lru_cache
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -179,6 +181,14 @@ ALLOWLIST: frozenset[str] = frozenset(
 # an allowlist of two names.
 _DISALLOWED_MUTATORS = frozenset({"setdefault", "clear", "popitem", "__setitem__"})
 
+# `.pop` and `.update` are permitted in general, but not when they touch the one
+# key this whole guard exists to protect. `env["REDIS_URL"] = ...` is already
+# rejected as a Subscript store; without this, `env.pop("REDIS_URL", None)` and
+# `env.update({"REDIS_URL": ...})` are the same write in quieter spelling and
+# would sail through, leaving the child on db0 under a green check.
+_PROTECTED_KEY = "REDIS_URL"
+_KEYED_MUTATORS = frozenset({"pop", "update"})
+
 
 # --------------------------------------------------------------------------
 # argv predicate
@@ -219,18 +229,37 @@ def _argv0_is_skipped(argv: ast.AST) -> bool:
     return False
 
 
+@lru_cache(maxsize=1)
+def _console_scripts() -> frozenset[str]:
+    """Repo console-script names from ``[project.scripts]``.
+
+    A bare ``["valor-session", "list"]`` argv names no interpreter and no
+    ``-m``, but the entry point imports repo packages and therefore popoto.
+    Reading pyproject keeps the predicate correct as entry points are added,
+    which a hardcoded list would not.
+    """
+    try:
+        data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    except (OSError, tomllib.TOMLDecodeError):
+        return frozenset()
+    return frozenset(data.get("project", {}).get("scripts", {}))
+
+
 def _argv_reaches_python(argv: ast.AST) -> bool:
     """True when the first positional arg names a Python interpreter or repo entry point."""
     for ident in _identifiers(argv):
         upper = ident.upper()
         if ident == "executable" or "PYTHON" in upper or "WRAPPER" in upper:
             return True
+    scripts = _console_scripts()
     for s in _string_constants(argv):
         if s == "-m" or " -m " in s:
             return True
         if "scripts/" in s:
             return True
         if Path(s).name.lower().startswith("python"):
+            return True
+        if Path(s).name in scripts or s.split()[:1] and s.split()[0] in scripts:
             return True
     return False
 
@@ -243,7 +272,7 @@ def _is_subprocess_call(node: ast.Call, ctx: _ScanContext) -> bool:
         root = func.value
         while isinstance(root, ast.Attribute):
             root = root.value
-        return isinstance(root, ast.Name) and root.id == "subprocess"
+        return isinstance(root, ast.Name) and root.id in ctx.subprocess_modules
     if isinstance(func, ast.Name):
         return func.id in ctx.subprocess_names
     return False
@@ -262,6 +291,8 @@ class _ScanContext:
         self.path = path
         self.imports_db_claim = False
         self.subprocess_names: set[str] = set()
+        # `import subprocess as _sp` must not make a file invisible to the scan.
+        self.subprocess_modules: set[str] = {"subprocess"}
         self.module_funcs: dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
         self.parents: dict[ast.AST, ast.AST] = {}
 
@@ -278,6 +309,8 @@ class _ScanContext:
                 for a in node.names:
                     if a.name.split(".")[-1] == "db_claim":
                         self.imports_db_claim = True
+                    if a.name == "subprocess":
+                        self.subprocess_modules.add(a.asname or a.name)
             for child in ast.iter_child_nodes(node):
                 self.parents[child] = node
 
@@ -332,15 +365,18 @@ def _name_is_clean(name: str, scope: ast.AST | None, ctx: _ScanContext) -> bool:
         elif isinstance(node, ast.withitem):
             if isinstance(node.optional_vars, ast.Name) and node.optional_vars.id == name:
                 return False
+        elif isinstance(node, ast.NamedExpr):
+            if isinstance(node.target, ast.Name) and node.target.id == name:
+                return False  # walrus rebind — "bound exactly once" no longer holds
         elif isinstance(node, ast.Call):
             func = node.func
-            if (
-                isinstance(func, ast.Attribute)
-                and isinstance(func.value, ast.Name)
-                and func.value.id == name
-                and func.attr in _DISALLOWED_MUTATORS
-            ):
-                return False
+            if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+                if func.value.id != name:
+                    continue
+                if func.attr in _DISALLOWED_MUTATORS:
+                    return False
+                if func.attr in _KEYED_MUTATORS and _PROTECTED_KEY in _string_constants(node):
+                    return False
     if len(assigns) != 1:
         return False
     value = assigns[0].value
@@ -427,9 +463,15 @@ def scan_source(src: str, path: str = "<source>") -> list[str]:
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call) or not _is_subprocess_call(node, ctx):
             continue
-        if not node.args:
+        # `subprocess.run(args=[...])` is valid and carries no positional args;
+        # skipping on `not node.args` alone would make it invisible.
+        argv = (
+            node.args[0]
+            if node.args
+            else next((k.value for k in node.keywords if k.arg == "args"), None)
+        )
+        if argv is None:
             continue
-        argv = node.args[0]
         if _argv0_is_skipped(argv):
             continue
         if not _argv_reaches_python(argv):
@@ -555,6 +597,51 @@ class TestThing:
 """
 
 
+_REJECTED_POPS_REDIS_URL = """
+import subprocess
+import sys
+
+from tests.db_claim import subprocess_env
+
+
+def test_thing():
+    env = subprocess_env()
+    env.pop("REDIS_URL", None)
+    subprocess.run([sys.executable, "-m", "tools.thing"], env=env)
+"""
+
+_REJECTED_UPDATES_REDIS_URL = """
+import subprocess
+import sys
+
+from tests.db_claim import subprocess_env
+
+
+def test_thing():
+    env = subprocess_env()
+    env.update({"REDIS_URL": "redis://localhost:6379/0"})
+    subprocess.run([sys.executable, "-m", "tools.thing"], env=env)
+"""
+
+_REJECTED_ALIASED_SUBPROCESS_IMPORT = """
+import subprocess as _sp
+import sys
+
+
+def test_thing():
+    _sp.run([sys.executable, "-m", "tools.thing"])
+"""
+
+_REJECTED_ARGS_KEYWORD = """
+import subprocess
+import sys
+
+
+def test_thing():
+    subprocess.run(args=[sys.executable, "-m", "tools.thing"])
+"""
+
+
 def test_self_test_rederived_helper_is_reported():
     """A helper that reads the db back out of the live client is NOT subprocess_env."""
     violations = scan_source(textwrap.dedent(_REJECTED_REDERIVED_HELPER), "fixture.py")
@@ -575,3 +662,27 @@ def test_self_test_assign_mutate_return_delegator_is_accepted():
 def test_self_test_staticmethod_delegator_is_accepted():
     """`env=self._w()` resolves through the enclosing class, one hop."""
     assert scan_source(textwrap.dedent(_ACCEPTED_STATICMETHOD_DELEGATOR), "fixture.py") == []
+
+
+def test_self_test_popping_redis_url_is_reported():
+    """Stripping the one key that carries the claim puts the child back on db0."""
+    violations = scan_source(textwrap.dedent(_REJECTED_POPS_REDIS_URL), "fixture.py")
+    assert len(violations) == 1, violations
+
+
+def test_self_test_updating_redis_url_is_reported():
+    """`.update({"REDIS_URL": ...})` is `env["REDIS_URL"] = ...` in quieter spelling."""
+    violations = scan_source(textwrap.dedent(_REJECTED_UPDATES_REDIS_URL), "fixture.py")
+    assert len(violations) == 1, violations
+
+
+def test_self_test_aliased_subprocess_import_is_reported():
+    """`import subprocess as _sp` must not make a file invisible to the scan."""
+    violations = scan_source(textwrap.dedent(_REJECTED_ALIASED_SUBPROCESS_IMPORT), "fixture.py")
+    assert len(violations) == 1, violations
+
+
+def test_self_test_args_keyword_is_reported():
+    """`subprocess.run(args=[...])` carries no positional argv and must still be seen."""
+    violations = scan_source(textwrap.dedent(_REJECTED_ARGS_KEYWORD), "fixture.py")
+    assert len(violations) == 1, violations

--- a/tests/unit/test_validate_no_raw_redis_delete.py
+++ b/tests/unit/test_validate_no_raw_redis_delete.py
@@ -22,6 +22,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.db_claim import subprocess_env
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 VALIDATORS_DIR = REPO_ROOT / ".claude" / "hooks" / "validators"
 DISPATCH_SCRIPT = REPO_ROOT / ".claude" / "hooks" / "dispatch" / "pre_tool_use_bash.py"
@@ -267,6 +269,7 @@ class TestDispatcherIntegration:
             input=json.dumps(payload),
             capture_output=True,
             text=True,
+            env=subprocess_env(project_root=str(REPO_ROOT)),
             timeout=30,
         )
         for line in (proc.stdout or "").splitlines():

--- a/tests/unit/test_venv_health.py
+++ b/tests/unit/test_venv_health.py
@@ -2,8 +2,12 @@
 
 import subprocess
 import sys
+from pathlib import Path
 
+from tests.db_claim import subprocess_env
 from tools import venv_health
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 class TestCheckModules:
@@ -68,6 +72,7 @@ class TestCliInvocation:
             capture_output=True,
             text=True,
             timeout=15,
+            env=subprocess_env(project_root=str(REPO_ROOT)),
         )
         assert result.returncode == 0
         assert "OK" in result.stdout

--- a/tests/unit/test_worker_entry.py
+++ b/tests/unit/test_worker_entry.py
@@ -11,6 +11,8 @@ from unittest.mock import patch
 
 import pytest
 
+from tests.db_claim import subprocess_env
+
 
 class TestWorkerImport:
     """Test that the worker module can be imported."""
@@ -71,6 +73,7 @@ class TestWorkerDryRun:
             capture_output=True,
             text=True,
             timeout=30,
+            env=subprocess_env(project_root=str(Path(__file__).parent.parent.parent)),
         )
         # May exit 0 (config valid) or 1 (no Redis / no config)
         # The important thing is it doesn't crash with an unhandled exception
@@ -89,6 +92,7 @@ class TestWorkerDryRun:
             capture_output=True,
             text=True,
             timeout=30,
+            env=subprocess_env(project_root=str(Path(__file__).parent.parent.parent)),
         )
         assert result.returncode != 0
 

--- a/tests/unit/test_worker_guard.py
+++ b/tests/unit/test_worker_guard.py
@@ -19,6 +19,7 @@ from tests._worker_guard import (
     _looks_like_worker_cmdline,
     assert_not_live_worker,
 )
+from tests.db_claim import subprocess_env
 
 
 class TestLooksLikeWorkerCmdline:
@@ -50,7 +51,8 @@ class TestAssertNotLiveWorker:
         line that ``ps`` reports, so the guard treats the pid as a worker.
         """
         proc = subprocess.Popen(
-            [sys.executable, "-c", "import time; time.sleep(30)", "-m", "worker"]
+            [sys.executable, "-c", "import time; time.sleep(30)", "-m", "worker"],
+            env=subprocess_env(),
         )
         try:
             time.sleep(0.3)  # let ps observe the process

--- a/tests/unit/test_worker_supervisor.py
+++ b/tests/unit/test_worker_supervisor.py
@@ -19,6 +19,7 @@ from unittest.mock import patch
 
 import pytest
 
+from tests.db_claim import subprocess_env
 from worker.__main__ import (
     WORKER_SUPERVISOR_BASE_BACKOFF_S,
     WORKER_SUPERVISOR_MAX_RESTARTS,
@@ -276,6 +277,7 @@ def test_storm_cap_kills_process():
         cwd=repo_root,
         capture_output=True,
         timeout=30,
+        env=subprocess_env(project_root=repo_root),
     )
 
     os.unlink(script_path)


### PR DESCRIPTION
Closes #2763.

Plan: `docs/plans/subprocess-harness-test-db-inheritance.md`

## Problem

Test subprocesses inherit no `REDIS_URL`. Popoto resolves it at import time and falls back to `redis://localhost:6379` — db0, **production** — so a child spawned from a test writes to prod while its parent is correctly isolated on a claimed db from the `[1..15]` pool. The parent's claim lives in in-process Popoto client objects, never in the environment, so nothing reaches the child.

The filed defect (`tests/unit/test_sdlc_tool_wrapper.py`) is latent today only because an injected `boom` raises before the ledger write fires. A stray `PipelineLedger` row for fake issue `999999` is sitting in prod db0 as evidence that it has fired before.

## What this does

Routes every reachable test subprocess through the existing `tests.db_claim.subprocess_env()` helper, which sets `REDIS_URL` from `claim_test_db()` — the same per-process claim the autouse `redis_test_db` fixture uses, so parent and child share one db by construction.

Adds a mechanical AST guard, `tests/unit/test_subprocess_test_db_isolation.py`, that fails the suite when a new call site reintroduces the shape. It resolves one hop through module-local delegators, `self`/`cls` method delegators, and the `env = subprocess_env(); env.pop(...)` assign-mutate pattern, so legitimate wrappers are accepted rather than allowlisted into noise. Four self-tests pin the predicate using source *strings* rather than live code, so the guard cannot quietly exempt itself.

Scope: 766 files scanned, 0 violations remaining. Of the 30 sites adjudicated in the final sweep, 5 were converted and 25 allowlisted with a written reason.

## Allowlist

Exactly two reasons are permitted, and each entry carries its reason on the line:

- `[#2628]` — 7 sites in files owned by open PR #2683. Touching them here would collide, so they are allowlisted with a note to remove the entry and convert the site once #2683 lands. Flagged on #2628 ([comment](https://github.com/tomcounsell/ai/issues/2628#issuecomment-5279899837)) because one of the seven, `test_redis_flush_guard_prod.py:666`, is a dict literal (`env={**_subprocess_env(), ...}`) that a helper-keyed sweep resolves to no helper and skips.
- `[standalone-script]` — the child is a single-file hook or script that cannot import popoto and so cannot reach Redis.

## Verification

| Check | Result |
|---|---|
| Isolation guard, 766 files | 0 violations |
| `test_sdlc_tool_wrapper.py` (filed defect) | passes |
| No bare `os.environ.copy()` in target file | 0 occurrences |
| Subprocesses with repo `cwd` and no `env` in target file | 0 |
| Anti-criterion: no #2683-owned file in the diff | 0 files |
| `ruff check` / `ruff format --check` | exit 0 / exit 0 |
| All 31 converted unit-test files, `POPOTO_TEST_DB=10` | 955 passed, 3 pre-existing failures |

### On those 3 failures

They are #2628's rotating-failure signature, not regressions. Evidence:

- The set rotates between identical runs (`test_memory_timeline` in one, `test_sdlc_stage_marker::TestWriteMarker` in the next).
- Every failure is shaped "a row written moments ago is gone" (`LEASE_ABSENT`, `0 >= 2`) — the exact symptom `db_claim.subprocess_env`'s own docstring describes for concurrent pytest processes sharing the claim pool.
- **A baseline run of the same file set on `main` reproduces `test_sdlc_stage_marker::TestCLI::test_with_issue_number_outputs_json` with the pre-conversion code**, and rotates a different second failure. Pre-existing.
- One of them, `test_memory_timeline::TestTimeline::test_timeline_with_records`, uses no subprocess at all and is untouched by this diff.

The one converted site among them, `test_with_issue_number_outputs_json`, previously hand-derived its db from `POPOTO_REDIS_DB.connection_pool.connection_kwargs`. `redis_test_db` (`tests/conftest.py:608`) patches that client from `claim_test_db()`, which is precisely what `subprocess_env()` reads, so the conversion is behavior-preserving.

## Follow-up

The prod `PipelineLedger:tomcounsell//ai{:}999999` row is deleted via the ORM once this merges.
