### PR TITLE
fix(#2785): router row 8b keys on verdict staleness, not the dispatch latch

### DIFF
--- a/agent/sdlc_router.py
+++ b/agent/sdlc_router.py
@@ -1181,14 +1181,38 @@ def _rule_review_has_findings(stage_states: dict, meta: dict, context: dict) -> 
 
 
 def _rule_patch_applied_after_review(stage_states: dict, meta: dict, context: dict) -> bool:
-    """Patch applied after review findings — re-review is required."""
+    """Patch applied after review findings — re-review is required.
+
+    Two independent ways to recognize "a patch landed after the last verdict":
+
+    1. ``last_dispatched_skill == /do-patch`` — the immediate post-patch turn.
+    2. ``_review_verdict_is_stale()`` — the recorded verdict predates the latest
+       ``/do-patch`` dispatch, regardless of what has been dispatched since.
+
+    Disjunct (2) closes the crashed-re-review dead end: row 8
+    (``_rule_review_has_findings``) steps aside on exactly this staleness by
+    design (#1641) and hands off to this row, but the ``last_dispatched_skill``
+    latch is a single slot — a ``/do-pr-review`` dispatch that crashes without
+    recording a verdict overwrites ``/do-patch`` in it. The state then matched
+    nothing: row 8 stepped aside (stale), 8b missed (latch overwritten), 8c
+    needs ``REVIEW==in_progress``, 8d needs ``REVIEW in (completed, failed)``
+    AND no recorded verdict at all, and 8e/8f/9/10 need ``REVIEW==completed``
+    or an APPROVED verdict — ``Blocked('no matching dispatch rule')``,
+    permanently stranded. Keying on staleness rather than only on the latch
+    makes this row the true complement of row 8's step-aside.
+
+    Loop-bound by G4 (``same_stage_dispatch_count``): the re-review records a
+    fresh verdict (postdating the patch, so no longer stale), which converges.
+    """
     if not meta.get("pr_number"):
         return False
     # PATCH completed after REVIEW failed — need to re-review.
     if stage_states.get("PATCH") != STATUS_COMPLETED:
         return False
     last = meta.get("last_dispatched_skill") or ""
-    return last == SKILL_DO_PATCH
+    if last == SKILL_DO_PATCH:
+        return True
+    return _review_verdict_is_stale(stage_states)
 
 
 def _rule_review_in_progress_no_verdict(stage_states: dict, meta: dict, context: dict) -> bool:

--- a/tests/unit/test_sdlc_router_decision.py
+++ b/tests/unit/test_sdlc_router_decision.py
@@ -615,6 +615,41 @@ class TestReviewVerdictStaleness:
         assert isinstance(result, Dispatch)
         assert result.skill == SKILL_DO_PATCH
 
+    def test_crashed_rereview_after_patch_still_dispatches_review(self):
+        """Stale verdict + crashed re-review dispatch → row 8b, not Blocked.
+
+        The observed dead end (popoto PR #548 / issue #537): a /do-pr-review
+        dispatched after the patch crashed before recording a verdict, so it
+        overwrote the /do-patch latch in last_dispatched_skill while leaving
+        the stale CHANGES REQUESTED verdict and REVIEW=pending in place.
+
+        Row 8 steps aside (verdict stale, #1641), 8c needs REVIEW=in_progress,
+        8d needs REVIEW in (completed, failed) AND no recorded verdict, and
+        8e/8f/9/10 need REVIEW=completed or an APPROVED verdict — every row
+        missed and the pipeline stranded on Blocked('no matching dispatch
+        rule'). Row 8b must own it on staleness alone.
+        """
+        states = self._base_states(
+            verdict_at="2026-08-13T07:02:49",
+            patch_at="2026-08-13T07:17:32",
+        )
+        states["REVIEW"] = "pending"
+        states["_sdlc_dispatches"].append(
+            # Crashed re-review: recorded no verdict, wrote no REVIEW marker.
+            {"skill": SKILL_DO_PR_REVIEW, "at": "2026-08-13T07:17:36"},
+        )
+        meta = {
+            "pr_number": 548,
+            "latest_review_verdict": "CHANGES REQUESTED",
+            "last_dispatched_skill": SKILL_DO_PR_REVIEW,  # latch overwritten
+            "patch_cycle_count": 1,
+            "pr_merge_state": "CLEAN",
+        }
+        result = decide_next_dispatch(states, meta)
+        assert isinstance(result, Dispatch), f"expected Dispatch, got {result!r}"
+        assert result.skill == SKILL_DO_PR_REVIEW
+        assert result.row_id == "8b", f"expected row 8b, got {result.row_id!r}"
+
     def test_fresh_review_verdict_after_patch_still_dispatches_patch(self):
         """patch T1 < verdict T2 → fresh verdict → row 8 wins → /do-patch."""
         states = self._base_states(


### PR DESCRIPTION
Closes #2785

## Problem

`decide_next_dispatch()` returned `Blocked(reason="no matching dispatch rule", guard_id=null)` — a permanent dead end — for this state (observed on popoto PR #548 / issue #537):

- `PATCH=completed`, `REVIEW=pending`
- `latest_review_verdict="CHANGES REQUESTED"` recorded 07:02:49
- dispatch history: `/do-pr-review` (verdict @07:02:49) -> `/do-patch` @07:17:32 -> `/do-pr-review` @07:17:36 (crashed; no verdict, no marker)
- `last_dispatched_skill=/do-pr-review`

## Root cause

Row 8 (`_rule_review_has_findings`) steps aside on *verdict staleness* (#1641) and hands off to row 8b, but row 8b recognized the post-patch state only via `last_dispatched_skill == /do-patch`. That latch is a single slot, and a `/do-pr-review` that crashes before recording a verdict overwrites it. The two rows therefore did not partition the state space they were designed to share, and nothing else covered the remainder: 8c needs `REVIEW==in_progress`, 8d needs `REVIEW in (completed, failed)` **and** no recorded verdict at all (a stale verdict is still recorded — and here the marker is `pending`, so 8d misses on both counts), 8e/8f/9/10 need `REVIEW==completed` or an APPROVED verdict.

Note this is *not* fixable by relaxing row 8d's verdict gate alone; 8d's marker gate excludes the state independently.

## Fix

Add verdict staleness as a second, independent disjunct to row 8b, reusing the existing `_review_verdict_is_stale()` helper:

```python
last = meta.get("last_dispatched_skill") or ""
if last == SKILL_DO_PATCH:
    return True
return _review_verdict_is_stale(stage_states)
```

The latch path is untouched, so every state that already routed through 8b still does. Row 8b is now the true complement of row 8's step-aside — the #1641 handoff keeps working and can no longer be broken by an intervening dispatch. Still loop-bound by G4: the re-review records a fresh verdict that postdates the patch, so staleness clears and the loop converges. `_review_verdict_is_stale()` fails safe to "not stale" on missing/unparseable data, preserving the fail-closed property.

## Tests

`TestReviewVerdictStaleness::test_crashed_rereview_after_patch_still_dispatches_review` reproduces the exact stranded state and asserts row 8b dispatches `/do-pr-review`.

```
scripts/pytest-clean.sh tests/unit/test_sdlc_router_decision.py tests/unit/test_sdlc_router.py \
  tests/unit/test_sdlc_router_oscillation.py tests/unit/test_sdlc_next_skill.py \
  tests/unit/test_sdlc_review_finalize.py tests/unit/test_architectural_constraints.py \
  tests/unit/test_do_plan_critique_barrier.py tests/unit/test_sdlc_verdict.py \
  tests/unit/test_sdlc_skill_md_parity.py tests/unit/test_sdlc_utils_trailer_regex.py \
  tests/unit/test_sdlc_stage_query.py tests/integration/test_sdlc_dispatch.py -p no:randomly -q
# 520 passed in 125.49s
```