### PR TITLE
fix(#2793): G8 reads the PR's real head ref; bare-#N never supplies a branch slug

### DIFF
--- a/tests/unit/test_sdlc_next_skill.py
+++ b/tests/unit/test_sdlc_next_skill.py
@@ -38,7 +38,7 @@ def test_build_context_sets_current_plan_hash_when_plan_exists(tmp_path, monkeyp
 
     monkeypatch.setattr(
         "tools._sdlc_utils.find_plan_path",
-        lambda issue_number: plan,
+        lambda issue_number, **_kw: plan,
     )
 
     context = sdlc_next_skill._build_context(proposed_skill=None, issue_number=1639)
@@ -51,7 +51,7 @@ def test_build_context_omits_hash_when_no_plan(monkeypatch):
     """No plan file for the issue → current_plan_hash key is left unset (None-safe)."""
     monkeypatch.setattr(
         "tools._sdlc_utils.find_plan_path",
-        lambda issue_number: None,
+        lambda issue_number, **_kw: None,
     )
 
     context = sdlc_next_skill._build_context(proposed_skill=None, issue_number=999999)
@@ -63,7 +63,7 @@ def test_build_context_omits_hash_when_plan_unreadable(monkeypatch):
     """find_plan_path returns a missing path → compute_plan_hash None → key unset."""
     monkeypatch.setattr(
         "tools._sdlc_utils.find_plan_path",
-        lambda issue_number: Path("/nonexistent/does-not-exist-plan.md"),
+        lambda issue_number, **_kw: Path("/nonexistent/does-not-exist-plan.md"),
     )
 
     context = sdlc_next_skill._build_context(proposed_skill=None, issue_number=1639)
@@ -78,7 +78,7 @@ def test_build_context_sets_issue_number_when_plan_exists(tmp_path, monkeypatch)
 
     monkeypatch.setattr(
         "tools._sdlc_utils.find_plan_path",
-        lambda issue_number: plan,
+        lambda issue_number, **_kw: plan,
     )
 
     context = sdlc_next_skill._build_context(proposed_skill=None, issue_number=1761)
@@ -99,13 +99,13 @@ def test_build_context_uses_body_hash_not_full_bytes(tmp_path, monkeypatch):
 
     monkeypatch.setattr(
         "tools._sdlc_utils.find_plan_path",
-        lambda issue_number: plan_before,
+        lambda issue_number, **_kw: plan_before,
     )
     ctx_before = sdlc_next_skill._build_context(proposed_skill=None, issue_number=1761)
 
     monkeypatch.setattr(
         "tools._sdlc_utils.find_plan_path",
-        lambda issue_number: plan_after,
+        lambda issue_number, **_kw: plan_after,
     )
     ctx_after = sdlc_next_skill._build_context(proposed_skill=None, issue_number=1761)
 
@@ -139,7 +139,7 @@ class TestBranchExistsCanonicalShape:
     def test_true_when_canonical_slug_branch_exists(self, tmp_path, monkeypatch):
         plan = tmp_path / "my-feature-slug.md"
         plan.write_text("# Plan\n", encoding="utf-8")
-        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number: plan)
+        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: plan)
         monkeypatch.setattr(
             "subprocess.run",
             self._fake_git("  main\n  session/my-feature-slug\n"),
@@ -153,7 +153,7 @@ class TestBranchExistsCanonicalShape:
         """A `session/sdlc-{N}` branch must NOT count — that shape is never created."""
         plan = tmp_path / "my-feature-slug.md"
         plan.write_text("# Plan\n", encoding="utf-8")
-        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number: plan)
+        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: plan)
         monkeypatch.setattr(
             "subprocess.run",
             self._fake_git("  main\n  session/sdlc-2003\n"),
@@ -165,7 +165,7 @@ class TestBranchExistsCanonicalShape:
 
     def test_false_when_no_plan_resolvable(self, monkeypatch):
         """No plan → no slug → cannot affirm existence → False (never sdlc-{N})."""
-        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number: None)
+        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: None)
         monkeypatch.setattr(
             "subprocess.run",
             self._fake_git("  main\n  session/sdlc-2003\n  session/other-slug\n"),
@@ -178,7 +178,7 @@ class TestBranchExistsCanonicalShape:
     def test_false_when_branch_absent(self, tmp_path, monkeypatch):
         plan = tmp_path / "my-feature-slug.md"
         plan.write_text("# Plan\n", encoding="utf-8")
-        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number: plan)
+        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: plan)
         monkeypatch.setattr("subprocess.run", self._fake_git("  main\n"))
 
         context = sdlc_next_skill._build_context(proposed_skill=None, issue_number=2003)
@@ -257,7 +257,7 @@ class TestTargetRepoCwd:
         monkeypatch.setenv("SDLC_TARGET_REPO", str(target))
         monkeypatch.setattr(
             "tools._sdlc_utils.find_plan_path",
-            lambda issue_number: target / "docs" / "plans" / "sdlc-2078-fixture.md",
+            lambda issue_number, **_kw: target / "docs" / "plans" / "sdlc-2078-fixture.md",
         )
 
         context = sdlc_next_skill._build_context(proposed_skill=None, issue_number=2078)
@@ -496,7 +496,7 @@ class TestStageArtifactVerification:
     def test_no_claimed_artifact_is_a_noop(self, monkeypatch):
         """No stage claims completion → verification never runs a live check
         and leaves stage_artifacts_verified/unverified_stage unset."""
-        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number: None)
+        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: None)
         run_mock = MagicMock()
         monkeypatch.setattr("subprocess.run", run_mock)
 
@@ -521,7 +521,7 @@ class TestStageArtifactVerification:
         """BUILD claims completed but the claimed PR is not OPEN live →
         stage_artifacts_verified=False, unverified_stage='BUILD', and an
         observable warning names the stage and the missing artifact."""
-        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number: None)
+        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: None)
         monkeypatch.setattr("subprocess.run", self._fake_gh_pr_state("CLOSED"))
 
         stage_states = {"BUILD": "completed"}
@@ -544,7 +544,7 @@ class TestStageArtifactVerification:
     def test_true_build_claim_leaves_context_unset(self, monkeypatch):
         """BUILD claims completed and the PR really is OPEN live → no-op
         (advances normally, g8 never fires)."""
-        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number: None)
+        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: None)
         monkeypatch.setattr("subprocess.run", self._fake_gh_pr_state("OPEN"))
 
         stage_states = {"BUILD": "completed"}
@@ -566,7 +566,7 @@ class TestStageArtifactVerification:
         the strongest possible proof the BUILD artifact was real; treating
         it as unverified would re-dispatch /do-build forever on an issue
         that already shipped."""
-        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number: None)
+        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: None)
         monkeypatch.setattr("subprocess.run", self._fake_gh_pr_state("MERGED"))
 
         stage_states = {"BUILD": "completed"}
@@ -589,7 +589,9 @@ class TestStageArtifactVerification:
         even run once the PR's live state proves MERGED."""
         plan_path = tmp_path / "my-slug.md"
         plan_path.write_text("---\nstatus: Ready\n---\n\n# Plan\n")
-        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number: plan_path)
+        monkeypatch.setattr(
+            "tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: plan_path
+        )
 
         ls_remote_calls = []
 
@@ -629,7 +631,9 @@ class TestStageArtifactVerification:
         strictly to state == "MERGED", not to "PR exists"."""
         plan_path = tmp_path / "my-slug.md"
         plan_path.write_text("---\nstatus: Ready\n---\n\n# Plan\n")
-        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number: plan_path)
+        monkeypatch.setattr(
+            "tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: plan_path
+        )
 
         def _fake_run(cmd, **kwargs):
             proc = MagicMock()
@@ -662,7 +666,7 @@ class TestStageArtifactVerification:
     def test_fails_open_on_infra_error(self, monkeypatch, caplog):
         """subprocess.TimeoutExpired/OSError from the gh/git call → advances
         (stage_artifacts_verified stays unset/True) with a warning logged."""
-        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number: None)
+        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: None)
 
         def _raise_timeout(cmd, **kwargs):
             raise subprocess.TimeoutExpired(cmd=cmd, timeout=10)
@@ -685,7 +689,7 @@ class TestStageArtifactVerification:
 
     def test_fails_open_on_os_error(self, monkeypatch, caplog):
         """OSError (e.g. gh binary missing) also fails open with a warning."""
-        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number: None)
+        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: None)
 
         def _raise_os_error(cmd, **kwargs):
             raise OSError("gh: command not found")
@@ -710,7 +714,7 @@ class TestStageArtifactVerification:
         """A logic bug (TypeError from a malformed artifact spec) must NOT be
         swallowed by the narrowed fail-open catch -- it surfaces (raises)
         and is logged at error level, never silently advancing."""
-        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number: None)
+        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: None)
 
         def _raise_type_error(cmd, **kwargs):
             raise TypeError("malformed artifact spec")
@@ -734,7 +738,7 @@ class TestStageArtifactVerification:
     def test_missing_stage_states_or_meta_skips_verification(self, monkeypatch):
         """Legacy callers that only pass proposed_skill/issue_number (no
         stage_states/meta) must not trigger verification at all."""
-        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number: None)
+        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: None)
         run_mock = MagicMock()
         monkeypatch.setattr("subprocess.run", run_mock)
 
@@ -742,6 +746,204 @@ class TestStageArtifactVerification:
 
         assert "stage_artifacts_verified" not in context
         run_mock.assert_not_called()
+
+
+class TestG8BranchResolution:
+    """Issue #2793: G8 falsely reported a pushed branch as missing.
+
+    Observed on popoto issue #530 / PR #553: G8 emitted "branch
+    session/docs_repositioning is not pushed" while the real, pushed branch
+    was ``bench/530-post-correction-refresh``. Two independent defects:
+
+    (a) the slug came from a bare-``#N`` textual match against a DIFFERENT
+        issue's plan that merely cross-references #530, and
+    (b) the branch name was reconstructed as ``session/{slug}`` rather than
+        read from the PR.
+
+    Fixing either alone leaves the state wedged, so both legs are covered
+    here plus the combination.
+    """
+
+    @staticmethod
+    def _fake_gh(*, state: str = "OPEN", head_ref: str | None = None, pushed: str = ""):
+        """Fake ``subprocess.run`` answering gh pr view (state + headRefName).
+
+        ``pushed`` is the branch name ``git ls-remote`` will report as
+        existing; anything else comes back empty (not pushed).
+        """
+
+        def _run(cmd, **kwargs):
+            proc = MagicMock()
+            if cmd[:3] == ["gh", "pr", "view"]:
+                payload: dict = {}
+                if "state" in cmd:
+                    payload["state"] = state
+                if "headRefName" in cmd and head_ref is not None:
+                    payload["headRefName"] = head_ref
+                proc.returncode = 0
+                proc.stdout = json.dumps(payload)
+            elif cmd[:2] == ["git", "ls-remote"]:
+                proc.returncode = 0
+                proc.stdout = (
+                    f"abc123\trefs/heads/{pushed}\n" if pushed and cmd[-1] == pushed else ""
+                )
+            else:
+                proc.returncode = 1
+                proc.stdout = ""
+            return proc
+
+        return _run
+
+    def test_bench_branch_with_no_tracking_plan_passes_g8(self, monkeypatch):
+        """THE #2793 BUG: a pushed `bench/`-prefixed branch on an issue that no
+        plan tracks must verify clean, not report "branch not pushed".
+
+        This is the popoto #530 shape end to end: no tracking plan (so no
+        slug), and a real branch that does not follow the `session/` convention.
+        """
+        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: None)
+        monkeypatch.setattr(
+            "subprocess.run",
+            self._fake_gh(
+                head_ref="bench/530-post-correction-refresh",
+                pushed="bench/530-post-correction-refresh",
+            ),
+        )
+
+        context = sdlc_next_skill._build_context(
+            proposed_skill=None,
+            issue_number=530,
+            stage_states={"PATCH": "completed"},
+            meta={"pr_number": 553},
+        )
+
+        assert "stage_artifacts_verified" not in context
+        assert "unverified_stage" not in context
+
+    def test_branch_check_uses_pr_head_ref_not_reconstructed_name(self, monkeypatch, tmp_path):
+        """Leg (b) alone: even with a CORRECTLY-resolved slug, a PR whose head
+        branch is not `session/{slug}` must verify against the real head ref."""
+        plan = tmp_path / "my-slug.md"
+        plan.write_text("---\ntracking: #530\n---\n\n# Plan\n", encoding="utf-8")
+        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: plan)
+
+        ls_remote_args: list[str] = []
+        inner = self._fake_gh(
+            head_ref="bench/530-post-correction-refresh", pushed="bench/530-post-correction-refresh"
+        )
+
+        def _run(cmd, **kwargs):
+            if cmd[:2] == ["git", "ls-remote"]:
+                ls_remote_args.append(cmd[-1])
+            return inner(cmd, **kwargs)
+
+        monkeypatch.setattr("subprocess.run", _run)
+
+        context = sdlc_next_skill._build_context(
+            proposed_skill=None,
+            issue_number=530,
+            stage_states={"PATCH": "completed"},
+            meta={"pr_number": 553},
+        )
+
+        assert "stage_artifacts_verified" not in context
+        assert ls_remote_args == ["bench/530-post-correction-refresh"], (
+            "branch check must query the PR's head ref, never a reconstructed session/{slug}"
+        )
+
+    def test_cross_reference_plan_does_not_supply_a_slug(self, tmp_path, monkeypatch):
+        """Leg (a) at its source: a plan that merely mentions `#530` (while
+        tracking #511) must not resolve as #530's plan when the caller needs
+        an identity. The unqualified call still finds it (unchanged)."""
+        from tools import _sdlc_utils
+
+        plans = tmp_path / "docs" / "plans"
+        plans.mkdir(parents=True)
+        (plans / "docs_repositioning.md").write_text(
+            "---\ntracking: #511\n---\n\n# Plan\n\nSee also #530 for the bench refresh.\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("SDLC_TARGET_REPO", str(tmp_path))
+
+        # Unqualified: the bare-#N fallback still matches (behavior preserved).
+        assert _sdlc_utils.find_plan_path(530) == plans / "docs_repositioning.md"
+        # Identity-deriving caller: no authoritative tracking: match → None.
+        assert _sdlc_utils.find_plan_path(530, tracking_only=True) is None
+        # The plan that genuinely tracks #511 resolves either way.
+        assert (
+            _sdlc_utils.find_plan_path(511, tracking_only=True) == plans / "docs_repositioning.md"
+        )
+
+    def test_tracking_only_suppression_applies_with_target_repo_set(self, tmp_path, monkeypatch):
+        """The pre-existing CONCERN-3 suppression only fired on the step-3
+        __file__ path. With SDLC_TARGET_REPO set (step 1) it never ran — which
+        is exactly how #530 got a foreign slug. tracking_only must suppress on
+        this path too."""
+        from tools import _sdlc_utils
+
+        plans = tmp_path / "docs" / "plans"
+        plans.mkdir(parents=True)
+        (plans / "other.md").write_text("# Plan\n\nRefs #530.\n", encoding="utf-8")
+        monkeypatch.setenv("SDLC_TARGET_REPO", str(tmp_path))
+
+        assert _sdlc_utils.find_plan_path(530) == plans / "other.md"
+        assert _sdlc_utils.find_plan_path(530, tracking_only=True) is None
+
+    def test_genuinely_missing_branch_still_fails_closed(self, monkeypatch):
+        """The fix must not trade a false positive for a false negative: a PR
+        whose head branch really is absent from origin still fails G8."""
+        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: None)
+        monkeypatch.setattr(
+            "subprocess.run",
+            self._fake_gh(head_ref="bench/530-post-correction-refresh", pushed=""),
+        )
+
+        context = sdlc_next_skill._build_context(
+            proposed_skill=None,
+            issue_number=530,
+            stage_states={"PATCH": "completed"},
+            meta={"pr_number": 553},
+        )
+
+        assert context["stage_artifacts_verified"] is False
+        assert context["unverified_stage"] == "PATCH"
+
+    def test_unresolvable_head_ref_fails_closed(self, monkeypatch, caplog):
+        """A PR whose head ref cannot be read (gh returns no headRefName) is
+        "could not determine" — and must NOT fall back to session/{slug}, nor
+        silently pass. It fails closed, mirroring the BUILD check's treatment
+        of an unresolvable state."""
+        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: None)
+        monkeypatch.setattr("subprocess.run", self._fake_gh(head_ref=None))
+
+        with caplog.at_level(logging.WARNING):
+            context = sdlc_next_skill._build_context(
+                proposed_skill=None,
+                issue_number=530,
+                stage_states={"PATCH": "completed"},
+                meta={"pr_number": 553},
+            )
+
+        assert context["stage_artifacts_verified"] is False
+        assert context["unverified_stage"] == "PATCH"
+        assert any("could not be resolved" in record.message for record in caplog.records)
+
+    def test_pr_less_patch_claim_still_uses_session_convention(self, tmp_path, monkeypatch):
+        """With no PR there is no head ref to read, so the `session/{slug}`
+        convention remains the fallback — unchanged behavior."""
+        plan = tmp_path / "my-slug.md"
+        plan.write_text("---\ntracking: #530\n---\n", encoding="utf-8")
+        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: plan)
+        monkeypatch.setattr("subprocess.run", self._fake_gh(pushed="session/my-slug"))
+
+        context = sdlc_next_skill._build_context(
+            proposed_skill=None,
+            issue_number=530,
+            stage_states={"PATCH": "completed"},
+            meta={},
+        )
+
+        assert "stage_artifacts_verified" not in context
 
 
 class TestPrHeadShaContext:
@@ -759,7 +961,7 @@ class TestPrHeadShaContext:
         }
 
     def test_head_sha_set_on_successful_lookup(self, monkeypatch):
-        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number: None)
+        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: None)
         monkeypatch.setattr(
             sdlc_next_skill, "_fetch_pr_head_sha", lambda pr_number, repo=None: self._SHA
         )
@@ -778,7 +980,7 @@ class TestPrHeadShaContext:
         def _boom(pr_number, repo=None):
             raise RuntimeError("gh exploded")
 
-        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number: None)
+        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: None)
         monkeypatch.setattr(sdlc_next_skill, "_fetch_pr_head_sha", _boom)
         context = sdlc_next_skill._build_context(
             proposed_skill=None,
@@ -790,7 +992,7 @@ class TestPrHeadShaContext:
         assert context["pr_head_sha_lookup_failed"] is True
 
     def test_lookup_returning_none_fails_closed(self, monkeypatch):
-        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number: None)
+        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: None)
         monkeypatch.setattr(
             sdlc_next_skill, "_fetch_pr_head_sha", lambda pr_number, repo=None: None
         )
@@ -805,7 +1007,7 @@ class TestPrHeadShaContext:
 
     def test_no_pr_number_skips_lookup_and_omits_key(self, monkeypatch):
         called = []
-        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number: None)
+        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: None)
         monkeypatch.setattr(
             sdlc_next_skill,
             "_fetch_pr_head_sha",
@@ -824,7 +1026,7 @@ class TestPrHeadShaContext:
         """No recorded verdict → no live call, key omitted (the router's
         no-verdict recovery rows own that state; the signal stays inert)."""
         called = []
-        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number: None)
+        monkeypatch.setattr("tools._sdlc_utils.find_plan_path", lambda issue_number, **_kw: None)
         monkeypatch.setattr(
             sdlc_next_skill,
             "_fetch_pr_head_sha",
@@ -861,7 +1063,7 @@ class TestLedgerDurabilityRecovery:
         from models.session_lifecycle import IssueLockResult
 
         monkeypatch.setattr(
-            "tools._sdlc_utils.find_session_by_issue", lambda issue_number: issue_session
+            "tools._sdlc_utils.find_session_by_issue", lambda issue_number, **_kw: issue_session
         )
         monkeypatch.setattr(
             "models.session_lifecycle.touch_issue_lock",
@@ -956,7 +1158,7 @@ class TestLedgerDurabilityRecovery:
 
         monkeypatch.setattr(
             "tools._sdlc_utils.find_session_by_issue",
-            lambda issue_number: (_ for _ in ()).throw(RuntimeError("boom")),
+            lambda issue_number, **_kw: (_ for _ in ()).throw(RuntimeError("boom")),
         )
         monkeypatch.setattr(
             "models.session_lifecycle.touch_issue_lock",
@@ -976,7 +1178,9 @@ class TestLedgerDurabilityRecovery:
     def test_recover_helper_returns_empty_when_no_session_found(self, monkeypatch):
         """Direct unit coverage of the helper: no issue session resolvable ->
         returns {} without raising."""
-        monkeypatch.setattr("tools._sdlc_utils.find_session_by_issue", lambda issue_number: None)
+        monkeypatch.setattr(
+            "tools._sdlc_utils.find_session_by_issue", lambda issue_number, **_kw: None
+        )
 
         result = sdlc_next_skill._recover_stage_states_from_durable_signals(9999)
 
@@ -986,7 +1190,7 @@ class TestLedgerDurabilityRecovery:
         """Direct unit coverage: derive_from_durable_signals raising is
         swallowed and {} is returned."""
         monkeypatch.setattr(
-            "tools._sdlc_utils.find_session_by_issue", lambda issue_number: MagicMock()
+            "tools._sdlc_utils.find_session_by_issue", lambda issue_number, **_kw: MagicMock()
         )
         monkeypatch.setattr(
             "agent.pipeline_state.PipelineStateMachine.derive_from_durable_signals",

--- a/tests/unit/test_sdlc_next_skill.py
+++ b/tests/unit/test_sdlc_next_skill.py
@@ -905,8 +905,15 @@ class TestG8BranchResolution:
             meta={"pr_number": 553},
         )
 
-        assert context["stage_artifacts_verified"] is False
-        assert context["unverified_stage"] == "PATCH"
+        # .get() rather than [] so an ABSENT key fails as a legible assertion
+        # instead of a bare KeyError. This is not a relaxation: None is not
+        # False, so a missing key still fails. Absence would itself be the bug
+        # (the verifier advancing a claim it could not verify), and the router
+        # reads this with `.get(...) is not False`, so it must be present.
+        assert context.get("stage_artifacts_verified") is False, (
+            f"missing branch must fail closed; got context={context!r}"
+        )
+        assert context.get("unverified_stage") == "PATCH", f"context={context!r}"
 
     def test_unresolvable_head_ref_fails_closed(self, monkeypatch, caplog):
         """A PR whose head ref cannot be read (gh returns no headRefName) is
@@ -924,8 +931,10 @@ class TestG8BranchResolution:
                 meta={"pr_number": 553},
             )
 
-        assert context["stage_artifacts_verified"] is False
-        assert context["unverified_stage"] == "PATCH"
+        assert context.get("stage_artifacts_verified") is False, (
+            f"unresolvable head ref must fail closed; got context={context!r}"
+        )
+        assert context.get("unverified_stage") == "PATCH", f"context={context!r}"
         assert any("could not be resolved" in record.message for record in caplog.records)
 
     def test_pr_less_patch_claim_still_uses_session_convention(self, tmp_path, monkeypatch):

--- a/tools/_sdlc_utils.py
+++ b/tools/_sdlc_utils.py
@@ -859,7 +859,7 @@ def session_owns_issue(session, issue_number) -> bool:
         return False
 
 
-def find_plan_path(issue_number: int) -> Path | None:
+def find_plan_path(issue_number: int, *, tracking_only: bool = False) -> Path | None:
     """Locate the plan file tracking this issue.
 
     Walks ``docs/plans/`` and returns the first ``.md`` file referencing the
@@ -885,6 +885,22 @@ def find_plan_path(issue_number: int) -> Path | None:
     cross-reference or No-Gos entry referencing a foreign (target-repo) issue,
     not the plan that actually owns it.  The ``tracking:`` match is always
     authoritative and is returned immediately regardless of resolution path.
+
+    **``tracking_only`` (#2793):** when True, the bare-``#N`` textual fallback
+    is suppressed on EVERY resolution path, not just the step-3 ``__file__``
+    one — only an authoritative ``tracking:`` match resolves. Callers that
+    derive an *identity* from the plan filename (a branch slug, a
+    ``docs/plans/{slug}.md`` ownership check) must pass this: a plan that
+    merely cross-references ``#N`` yields some other issue's slug, and a slug
+    that belongs to another issue is worse than no slug at all — it sends a
+    live check off to verify an artifact nobody claimed. The default (False)
+    preserves the historical behavior for callers that only need *a* plausible
+    plan document (e.g. the G5 plan-hash probe), where a near-miss is
+    harmless.
+
+    Note the CONCERN-3 suppression above is NOT sufficient for those callers:
+    it only fires when resolution reached step 3, so with ``SDLC_TARGET_REPO``
+    set (step 1) a bare-``#N`` cross-reference still won.
     """
     if not issue_number:
         return None
@@ -935,6 +951,11 @@ def find_plan_path(issue_number: int) -> Path | None:
                 fallback = entry
     except Exception as e:
         logger.debug(f"find_plan_path walk failed: {e}")
+
+    # tracking_only (#2793): an identity-deriving caller accepts ONLY an
+    # authoritative tracking: match, on every resolution path.
+    if tracking_only:
+        return None
 
     # When plan resolution fell back to the ai-repo __file__ path
     # (SDLC_TARGET_REPO unset, not in a git repo), a bare-#N textual match is

--- a/tools/sdlc_next_skill.py
+++ b/tools/sdlc_next_skill.py
@@ -148,15 +148,49 @@ def _fetch_pr_head_sha(pr_number: int, repo: str | None = None) -> str | None:
     return resolve_pr_head_sha(pr_number, repo=repo, repo_root=_target_repo_cwd())
 
 
-def _check_branch_pushed(slug: str) -> bool:
-    """Live-check (``git ls-remote``) that ``session/{slug}`` exists on origin.
+def _fetch_pr_head_ref(pr_number: int, repo: str | None = None) -> str | None:
+    """Read the PR's actual head BRANCH NAME via ``gh pr view --json headRefName``.
+
+    #2793: the branch-pushed check used to reconstruct ``session/{slug}`` from
+    a plan filename. That convention is real but not universal — a bench chore
+    or hotfix lands on ``bench/…``, ``fix/…``, etc. — so a correctly-slugged
+    issue on a non-``session/`` branch was reported as "not pushed" even though
+    ``git ls-remote`` would find the real branch instantly. The PR itself knows
+    its head ref; ask it rather than reconstructing a name.
+
+    Returns ``None`` when the call fails, the response is unparseable, or
+    ``headRefName`` is absent / not a non-empty string. As with
+    :func:`_fetch_pr_state`, callers must treat ``None`` as "could not
+    determine" and never as evidence of a false claim. May raise
+    ``subprocess.TimeoutExpired``/``SubprocessError``/``OSError`` — the caller
+    applies the narrowed fail-open catch; this helper swallows nothing itself.
+    """
+    cmd = ["gh", "pr", "view", str(pr_number), "--json", "headRefName"]
+    if repo:
+        cmd = ["gh", "pr", "view", str(pr_number), "--repo", repo, "--json", "headRefName"]
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+    if proc.returncode != 0:
+        return None
+    data = json.loads(proc.stdout or "{}")
+    head_ref = data.get("headRefName")
+    if not isinstance(head_ref, str) or not head_ref.strip():
+        return None
+    return head_ref.strip()
+
+
+def _check_branch_pushed(branch: str) -> bool:
+    """Live-check (``git ls-remote``) that ``branch`` exists on origin.
+
+    Takes a FULL branch name (#2793), not a slug to be expanded into
+    ``session/{slug}`` — see :func:`_fetch_pr_head_ref` for why the
+    reconstruction was wrong.
 
     Unlike the local ``git branch -a`` check elsewhere in this module (which
     can be satisfied by a stale remote-tracking ref), this queries the
     remote directly so a claimed "branch pushed" artifact is verified
     against the live world, not local ref cache staleness.
     """
-    cmd = ["git", "ls-remote", "--heads", "origin", f"session/{slug}"]
+    cmd = ["git", "ls-remote", "--heads", "origin", branch]
     proc = subprocess.run(cmd, cwd=_target_repo_cwd(), capture_output=True, text=True, timeout=10)
     if proc.returncode != 0:
         return False
@@ -199,8 +233,12 @@ def _verify_stage_artifacts_live(stage_states: dict, meta: dict, issue_number: i
     """
     from tools._sdlc_utils import find_plan_path
 
+    # tracking_only (#2793): the slug is an IDENTITY here (it names both the
+    # plan file this issue owns and, absent a PR, its branch). A plan that
+    # merely cross-references `#N` must never supply it — that borrowed slug
+    # sends both checks below off to verify some other issue's artifacts.
     slug: str | None = None
-    plan_path = find_plan_path(issue_number)
+    plan_path = find_plan_path(issue_number, tracking_only=True)
     if plan_path is not None:
         slug = Path(plan_path).stem
 
@@ -215,7 +253,10 @@ def _verify_stage_artifacts_live(stage_states: dict, meta: dict, issue_number: i
     pr_number = meta.get("pr_number")
     repo = meta.get("_resolved_target_repo")
     build_claimed = stage_states.get("BUILD") == "completed"
-    patch_claimed = stage_states.get("PATCH") == "completed" and bool(slug)
+    # #2793: no longer gated on a resolvable slug — when a PR exists its head
+    # ref names the branch directly, so a plan-less issue (bench chore, hotfix)
+    # is now genuinely checkable instead of silently skipped.
+    patch_claimed = stage_states.get("PATCH") == "completed"
 
     # Resolve the live PR state at most once (used by both checks below) --
     # only when a claim that needs it is actually present, so an unclaimed
@@ -232,11 +273,34 @@ def _verify_stage_artifacts_live(stage_states: dict, meta: dict, issue_number: i
             )
             return {"stage_artifacts_verified": False, "unverified_stage": "BUILD"}
 
-    if patch_claimed:
-        if pr_state != "MERGED" and not _check_branch_pushed(slug):
+    if patch_claimed and pr_state != "MERGED":
+        # Branch resolution (#2793), most authoritative first:
+        #   1. the PR's own head ref — the branch that actually exists
+        #   2. session/{slug} — the convention, for a PR-less PATCH claim
+        # Never fall back from (1) to (2): the reconstructed name is wrong
+        # precisely in the case that motivated this fix, and a `session/…`
+        # guess that misses would re-report a pushed `bench/…` branch as
+        # missing. An unresolvable head ref on an existing PR is instead
+        # FAIL-CLOSED (unverified), matching how the BUILD check above already
+        # treats an unresolvable `gh` read — a gh outage must not let an
+        # unverifiable claim advance. Genuine infra faults (timeout, OSError)
+        # still fail open one level up in _verify_stage_artifacts.
+        branch: str | None = None
+        if pr_number:
+            branch = _fetch_pr_head_ref(pr_number, repo=repo)
+            if branch is None:
+                logger.warning(
+                    f"stage-artifact-verify: issue #{issue_number} PATCH claims completed "
+                    f"but PR #{pr_number}'s head branch could not be resolved"
+                )
+                return {"stage_artifacts_verified": False, "unverified_stage": "PATCH"}
+        elif slug:
+            branch = f"session/{slug}"
+
+        if branch and not _check_branch_pushed(branch):
             logger.warning(
                 f"stage-artifact-verify: issue #{issue_number} PATCH claims completed "
-                f"but branch session/{slug} is not pushed"
+                f"but branch {branch} is not pushed"
             )
             return {"stage_artifacts_verified": False, "unverified_stage": "PATCH"}
 
@@ -347,12 +411,15 @@ def _build_context(
     # filename stem (#1915 slug-wins ownership; an issue-number-derived branch
     # form is fabricated — this repo never creates one). Without a resolvable
     # plan/slug we cannot affirm existence, so branch_exists stays False (#2003).
+    # tracking_only (#2793): the slug names a branch, so only an authoritative
+    # tracking: plan may supply it — a bare-#N cross-reference would probe some
+    # other issue's branch and report ITS existence as this issue's.
     if issue_number:
         context["branch_exists"] = False
         try:
             from tools._sdlc_utils import find_plan_path
 
-            plan_path = find_plan_path(issue_number)
+            plan_path = find_plan_path(issue_number, tracking_only=True)
             if plan_path is not None:
                 slug = Path(plan_path).stem
 


### PR DESCRIPTION
Closes #2793

Fixes G8 falsely reporting a pushed branch as missing. Observed on popoto issue #530 / PR #553:

```
stage-artifact-verify: issue #530 PATCH claims completed
but branch session/docs_repositioning is not pushed
```

The real branch is `bench/530-post-correction-refresh`, pushed. Two independent defects; fixing either alone leaves the lane wedged.

## (a) Foreign slug from a bare-`#N` match

No plan `tracking:`s #530 (plan-less bench chore), so `find_plan_path`'s bare-`#N` fallback matched `docs/plans/docs_repositioning.md` — issue #511's plan, which merely cross-references #530. The existing CONCERN-3 suppression does not cover this: it only fires when resolution reached the step-3 `__file__` fallback, and with `SDLC_TARGET_REPO` set resolution stops at step 1.

Fix: an opt-in `find_plan_path(..., tracking_only=True)` that suppresses the fallback on every resolution path. Callers deriving an *identity* (a branch slug, a `docs/plans/{slug}.md` ownership check) pass it. Default unchanged, so the G5 plan-hash probe and every other caller keep their behavior.

## (b) Reconstructed branch name

The branch-pushed check hardcoded `session/{slug}`. That convention is real but not universal. Fix: read the PR's actual head ref via `gh pr view --json headRefName`, falling back to `session/{slug}` only for a PR-less PATCH claim — never *from* the head ref to the reconstruction, since the guess is wrong precisely when the real name is unavailable to contradict it.

Because the head ref names the branch directly, the PATCH check no longer requires a resolvable slug: a plan-less issue with a PR is now genuinely checkable instead of silently skipped.

## Fail-closed preserved

An unresolvable head ref on an existing PR marks PATCH **unverified**, mirroring how the BUILD check already treats an unresolvable `gh` read — not skipped, not guessed. A genuinely absent branch still fails. Infra faults (timeout, OSError) still fail open one level up in `_verify_stage_artifacts`.

My first attempt skipped the check on an unresolvable head ref; the existing `test_patch_claim_still_checks_branch_when_pr_open` caught that as a false negative, and the fail-closed version passes it untouched. No existing assertion was weakened.

## Before / after on the real case

```
PRE-FIX  (main):   → {'stage_artifacts_verified': False, 'unverified_stage': 'PATCH'}
POST-FIX (branch): CLEAN (no unverified stage)
```

## Tests

7 new in `TestG8BranchResolution`, including `test_bench_branch_with_no_tracking_plan_passes_g8` (the #530 shape end to end), each leg in isolation, the `SDLC_TARGET_REPO`-path suppression CONCERN-3 missed, and two fail-closed guards (`test_genuinely_missing_branch_still_fails_closed`, `test_unresolvable_head_ref_fails_closed`). 30 `lambda issue_number:` test doubles updated to accept the new kwarg.

```
scripts/pytest-clean.sh tests/unit/test_sdlc_next_skill.py tests/unit/test_sdlc_utils.py \
  tests/unit/test_sdlc_stage_marker.py tests/unit/test_sdlc_env_vars.py tests/unit/test_sdlc_verdict.py \
  tests/unit/test_sdlc_stage_query.py tests/unit/test_sdlc_router.py tests/unit/test_sdlc_router_oscillation.py \
  tests/unit/test_sdlc_router_decision.py tests/integration/test_off_pipeline_merge_path.py \
  tests/integration/test_sdlc_cross_repo_resolution.py tests/integration/test_sdlc_session_ensure_integration.py \
  tests/integration/test_sdlc_dispatch.py -p no:randomly -q

2 failed, 662 passed, 4 warnings in 60.00s
```

Both failures are pre-existing, verified not mine: `test_terminal_merged_pipeline_routes_to_merge_not_build` fails identically on baseline `main`; `test_with_issue_number_outputs_json` (`LEASE_ABSENT`) still fails with my entire diff stashed in the same worktree.

Related: #2718 is the same convention assumption at a different call site.