### PR TITLE
Single Jinja filter registrar for the dashboard

### DIFF
--- a/docs/features/dashboard.md
+++ b/docs/features/dashboard.md
@@ -237,6 +237,28 @@ into exactly the context an operator is watching. `_last_divergence_check_at` st
 `None` rather than `0.0` because `time.monotonic()` counts from boot: a zero would swallow
 the first check of every process opened within 5 minutes of the machine coming up.
 
+## Template Filters
+
+`ui.app.register_template_filters(env)` is the single registration seam for
+the six dashboard Jinja2 filters: `format_timestamp`, `format_duration`,
+`format_interval_filter`, `format_relative`, `freshness_age` (see [Freshness
+chip](#row-level-signals-non-terminal-only) above), and `usd` (ceil-to-cent
+USD formatting, shipped by `96b0f65dd` — a sub-cent cost reads as `$0.01`,
+never `$0.00`). It takes any `jinja2.Environment`, registers filters and
+nothing else (never loader, autoescape, or globals), and `create_app` calls
+it against `templates.env`.
+
+A new filter is added **only** in `register_template_filters` — never as a
+one-off `env.filters["name"] = ...` in a template render fixture. Both
+render-test fixtures (`tests/unit/test_session_modal_liveness_render.py`,
+`tests/unit/test_per_project_modal.py`) call the same registrar, so a new
+production filter is automatically available in every test env with no
+hand-copying. `tests/unit/test_template_filter_registry.py` is the CI
+enforcement of this rule: a filter-demand guard fails a template that
+references a filter the registrar does not provide, and a no-hand-copy guard
+fails any test file that assigns into `.filters[...]` instead of calling the
+registrar.
+
 ## PipelineProgress Model
 
 The `PipelineProgress` Pydantic model is the serialization layer between Redis data and the UI/JSON API.

--- a/tests/README.md
+++ b/tests/README.md
@@ -413,7 +413,19 @@ here.
 | Level | File | Tests | Description |
 |-------|------|------:|-------------|
 | unit | `test_nightly_regression_tests.py` | 28 | Nightly regression runner: suite invocation, JSON report parsing, Telegram alerting, version-pinned `claude` canary |
+| unit | `test_template_filter_registry.py` | 4 | Dashboard Jinja filter guards (#2719): every template's filter demand resolves against `ui.app.register_template_filters`; filter-key equality against a `Jinja2Templates`-shaped env; registrar-completeness; no test file hand-copies a `.filters[...]` registration |
+| unit | `test_analytics_stats_render.py` | 3 | Render coverage for `_partials/analytics_stats.html`'s two `\| usd` cost cards, including the sub-cent-renders-as-$0.01 case |
 | e2e | `test_telegram_flow.py` | — | Live Telegram flow stubs |
+
+Dashboard render-test fixtures (`test_session_modal_liveness_render.py`,
+`test_per_project_modal.py`, `test_analytics_stats_render.py`) build a bare
+`jinja2.Environment` and must obtain filters by calling
+`ui.app.register_template_filters(env)` — never by hand-copying individual
+`env.filters["name"] = ...` assignments. Three independent hand-rolled filter
+lists (production, plus two divergent test stand-ins) is exactly what
+shipped `TemplateRuntimeError: No filter named 'usd' found` past all three
+call sites (#2719); `test_template_filter_registry.py`'s no-hand-copy guard
+enforces this in CI, not just in this note.
 
 ## Fixtures
 

--- a/tests/unit/test_analytics_stats_render.py
+++ b/tests/unit/test_analytics_stats_render.py
@@ -1,0 +1,78 @@
+"""Render coverage for `_partials/analytics_stats.html` (#2719).
+
+This is the last of the three `| usd` call sites (alongside jobs_table.html
+and session_modal_content.html) and previously had zero render coverage
+anywhere under tests/ — a gap called out explicitly by the plan. It renders
+through a registrar-configured env exactly like the other render tests, so
+the ceil-to-cent `usd` filter behavior shipped by `96b0f65dd` is protected
+here too.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from jinja2 import Environment, FileSystemLoader
+
+from ui.app import register_template_filters
+
+pytestmark = [pytest.mark.unit, pytest.mark.webui]
+
+
+@pytest.fixture
+def env() -> Environment:
+    template_dir = Path(__file__).resolve().parent.parent.parent / "ui" / "templates"
+    e = Environment(loader=FileSystemLoader(str(template_dir)))
+    register_template_filters(e)
+    return e
+
+
+def _minimal_analytics(**overrides) -> dict:
+    base = dict(
+        sessions_started_today=3,
+        sessions_started_7d=12,
+        sessions_completed_today=2,
+        sessions_completed_7d=10,
+        cost_today_usd=1.2345,
+        cost_7d_usd=9.001,
+        turns_today=42,
+        turns_7d=280,
+        turns_avg_today=6.0,
+        turns_avg_7d=5.5,
+        memory_recalls_today=4,
+        memory_recalls_7d=20,
+        memory_extractions_today=1,
+        memory_extractions_7d=6,
+    )
+    base.update(overrides)
+    return base
+
+
+def test_both_cost_cards_render_ceil_to_cent(env):
+    tmpl = env.get_template("_partials/analytics_stats.html")
+    html = tmpl.render(analytics=_minimal_analytics(cost_today_usd=1.2345, cost_7d_usd=9.001))
+    assert "stats-grid" in html
+    # Ceil-to-cent: 1.2345 -> $1.24, 9.001 -> $9.01 (never truncated down).
+    assert "$1.24" in html
+    assert "$9.01" in html
+
+
+def test_sub_cent_cost_renders_as_one_cent_not_zero(env):
+    """The behavior 96b0f65dd exists to protect: a sub-cent cost must never
+    display as $0.00."""
+    tmpl = env.get_template("_partials/analytics_stats.html")
+    html = tmpl.render(analytics=_minimal_analytics(cost_today_usd=0.001, cost_7d_usd=0.0001))
+    assert "$0.01" in html
+    assert "$0.00" not in html
+
+
+def test_no_analytics_renders_empty_state():
+    """Falsy `analytics` renders the empty-state message, not a KeyError."""
+    template_dir = Path(__file__).resolve().parent.parent.parent / "ui" / "templates"
+    e = Environment(loader=FileSystemLoader(str(template_dir)))
+    register_template_filters(e)
+    tmpl = e.get_template("_partials/analytics_stats.html")
+    html = tmpl.render(analytics=None)
+    assert "No analytics data yet." in html
+    assert "stats-grid" not in html

--- a/tests/unit/test_analytics_stats_render.py
+++ b/tests/unit/test_analytics_stats_render.py
@@ -10,20 +10,17 @@ here too.
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 from jinja2 import Environment, FileSystemLoader
 
-from ui.app import register_template_filters
+from ui.app import TEMPLATES_DIR, register_template_filters
 
 pytestmark = [pytest.mark.unit, pytest.mark.webui]
 
 
 @pytest.fixture
 def env() -> Environment:
-    template_dir = Path(__file__).resolve().parent.parent.parent / "ui" / "templates"
-    e = Environment(loader=FileSystemLoader(str(template_dir)))
+    e = Environment(loader=FileSystemLoader(str(TEMPLATES_DIR)))
     register_template_filters(e)
     return e
 
@@ -67,12 +64,9 @@ def test_sub_cent_cost_renders_as_one_cent_not_zero(env):
     assert "$0.00" not in html
 
 
-def test_no_analytics_renders_empty_state():
+def test_no_analytics_renders_empty_state(env):
     """Falsy `analytics` renders the empty-state message, not a KeyError."""
-    template_dir = Path(__file__).resolve().parent.parent.parent / "ui" / "templates"
-    e = Environment(loader=FileSystemLoader(str(template_dir)))
-    register_template_filters(e)
-    tmpl = e.get_template("_partials/analytics_stats.html")
+    tmpl = env.get_template("_partials/analytics_stats.html")
     html = tmpl.render(analytics=None)
     assert "No analytics data yet." in html
     assert "stats-grid" not in html

--- a/tests/unit/test_per_project_modal.py
+++ b/tests/unit/test_per_project_modal.py
@@ -22,6 +22,8 @@ from pathlib import Path
 import pytest
 from jinja2 import Environment, FileSystemLoader
 
+from ui.app import register_template_filters
+
 UI_TEMPLATES = Path(__file__).resolve().parents[2] / "ui" / "templates"
 
 
@@ -29,13 +31,7 @@ UI_TEMPLATES = Path(__file__).resolve().parents[2] / "ui" / "templates"
 def env() -> Environment:
     """Jinja2 environment configured exactly like ``ui/app.py`` does."""
     e = Environment(loader=FileSystemLoader(str(UI_TEMPLATES)), autoescape=True)
-    # The modal template expects these filters to exist; provide minimal
-    # implementations so rendering does not crash. Output formatting is not
-    # what we are asserting on — presence/absence of rows and class names is.
-    e.filters["format_timestamp"] = lambda ts: str(ts) if ts is not None else "-"
-    e.filters["format_duration"] = lambda s: f"{s}s" if s is not None else "-"
-    e.filters["format_interval_filter"] = lambda s: f"{s}s" if s else "-"
-    e.filters["format_relative"] = lambda s: f"{s}s" if s is not None else "-"
+    register_template_filters(e)
     return e
 
 

--- a/tests/unit/test_session_modal_liveness_render.py
+++ b/tests/unit/test_session_modal_liveness_render.py
@@ -229,7 +229,7 @@ class TestModalMetadataSections:
         )
         assert "token-strip" in html
         # Ceil-to-cent per 96b0f65dd: production _filter_usd(1.2345) == "$1.24",
-        # not the retired 4-decimal "$1.2345".
+        # not the retired 4-decimal-places rendering.
         assert "$1.24" in html
         assert "12,000" in html
 

--- a/tests/unit/test_session_modal_liveness_render.py
+++ b/tests/unit/test_session_modal_liveness_render.py
@@ -14,13 +14,14 @@ assert HTML substrings without spinning up the full app.
 
 from __future__ import annotations
 
-import datetime
 import time
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 from jinja2 import Environment, FileSystemLoader
+
+from ui.app import _filter_format_timestamp, register_template_filters
 
 pytestmark = [pytest.mark.unit, pytest.mark.webui]
 
@@ -30,27 +31,7 @@ def env():
     """Isolated Jinja env with the production filters registered."""
     template_dir = Path(__file__).resolve().parent.parent.parent / "ui" / "templates"
     env = Environment(loader=FileSystemLoader(str(template_dir)))
-
-    # Mirror the filters registered in ui/app.py::create_app
-    def _format_timestamp(ts):
-        if ts is None:
-            return "-"
-        return datetime.datetime.fromtimestamp(ts, tz=datetime.UTC).strftime("%H:%M")
-
-    def _format_duration(seconds):
-        if seconds is None:
-            return "-"
-        return f"{int(seconds)}s"
-
-    def _freshness_age(ts):
-        if ts is None:
-            return None
-        age = time.time() - float(ts)
-        return age if age >= 0 else None
-
-    env.filters["format_timestamp"] = _format_timestamp
-    env.filters["format_duration"] = _format_duration
-    env.filters["freshness_age"] = _freshness_age
+    register_template_filters(env)
     return env
 
 
@@ -185,7 +166,9 @@ class TestModalLivenessSection:
 
     def test_renders_timestamps_via_format_filter(self, env):
         """Evidence + heartbeat are merged into a single "Last active" row
-        (max of the two), rendered through the format_timestamp filter."""
+        (max of the two), rendered through the production format_timestamp
+        filter. `ts = now - 60` is always >= 60s old, so the filter's
+        `< 60 -> "just now"` boundary never applies here."""
         tmpl = env.get_template("_partials/session_modal_content.html")
         ts = time.time() - 60
         pipeline = _make_pipeline(
@@ -194,9 +177,17 @@ class TestModalLivenessSection:
         )
         html = tmpl.render(pipeline=pipeline)
         assert "Last active" in html
-        # The merged value renders via the format_timestamp filter (HH:MM).
-        expected = datetime.datetime.fromtimestamp(ts, tz=datetime.UTC).strftime("%H:%M")
+        # Compute the expectation by calling the production filter directly
+        # (agreement with production, not a re-encoded format that can drift
+        # again) rather than hardcoding "1m ago" — several _filter_format_timestamp
+        # branches return a local-timezone-dependent strftime("%H:%M").
+        expected = _filter_format_timestamp(ts)
         assert expected in html
+        # Discriminating checks: the "1m ago"-shaped expected value is a short
+        # substring that could incidentally appear in a large HTML blob, so
+        # also assert the raw unfiltered timestamp is absent and the row
+        # structure is present.
+        assert str(int(ts)) not in html
 
 
 class TestModalPersonaBadge:
@@ -237,7 +228,9 @@ class TestModalMetadataSections:
             )
         )
         assert "token-strip" in html
-        assert "$1.2345" in html
+        # Ceil-to-cent per 96b0f65dd: production _filter_usd(1.2345) == "$1.24",
+        # not the retired 4-decimal "$1.2345".
+        assert "$1.24" in html
         assert "12,000" in html
 
     def test_token_strip_omitted_when_all_zero(self, env):

--- a/tests/unit/test_template_filter_registry.py
+++ b/tests/unit/test_template_filter_registry.py
@@ -1,0 +1,135 @@
+"""Guards over dashboard Jinja2 filter registration (#2719).
+
+Two symmetric guards keep `ui.app.register_template_filters` the single
+source of truth for dashboard template filters:
+
+1. **Filter-demand guard**: every `| filter` and `{% filter %}` token used
+   across `ui/templates/**/*.html` must resolve against the registrar's
+   output. Catches a template using a filter nobody registered — the class
+   of bug that shipped `TemplateRuntimeError: No filter named 'usd' found`.
+2. **No-hand-copy guard**: no file under `tests/` may hand-roll a filter
+   dict (`env.filters["x"] = ...` / `env.filters["x"] = lambda: ...`)
+   instead of calling the registrar. Catches a future fixture re-opening the
+   hand-copy hole that caused this bug in the first place.
+
+Known blind spot (documented, not solved): dynamic filter application via
+`|attr('name')` or `map('name')` passes the filter name as a runtime string
+and is invisible to AST scanning. No dashboard template currently uses
+either idiom, so the guard is complete for the current template set.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from fastapi.templating import Jinja2Templates
+from jinja2 import Environment, FileSystemLoader, nodes
+
+from ui.app import TEMPLATES_DIR, register_template_filters
+
+pytestmark = [pytest.mark.unit, pytest.mark.webui]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TESTS_DIR = Path(__file__).resolve().parent.parent
+HAND_COPY_PATTERN = re.compile(r"\.filters\s*\[")
+
+
+def _registrar_env() -> Environment:
+    """A bare Environment with only the registrar applied (the guard env)."""
+    env = Environment(loader=FileSystemLoader(str(TEMPLATES_DIR)))
+    register_template_filters(env)
+    return env
+
+
+def _production_shaped_env() -> Jinja2Templates:
+    """A Jinja2Templates instance with the registrar applied — the shape
+    production actually renders through. Deliberately NOT create_app(), which
+    mounts StaticFiles and builds every router for no benefit here."""
+    templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
+    register_template_filters(templates.env)
+    return templates
+
+
+def test_registrar_covers_all_six_dashboard_filters():
+    """`register_template_filters` adds exactly the six dashboard filters
+    beyond Jinja's built-ins — proof that "add a filter, tests inherit it"
+    is mechanical, not aspirational."""
+    baseline = set(Environment().filters)
+    env = Environment()
+    register_template_filters(env)
+    added = set(env.filters) - baseline
+    assert added == {
+        "format_timestamp",
+        "format_duration",
+        "format_interval_filter",
+        "format_relative",
+        "freshness_age",
+        "usd",
+    }
+
+
+def test_guard_env_matches_production_shaped_filter_keys():
+    """The guard env is a bare Environment; production renders through
+    Jinja2Templates (ui/app.py, imported from fastapi.templating). Assert
+    filter-KEY equality between the two so a future production-only filter
+    added by any mechanism other than the registrar (filters.update(...),
+    Jinja2Templates(env=...), a Jinja extension in create_app) trips this
+    guard instead of silently re-diverging one level up. The two envs
+    legitimately differ in autoescape and a url_for global — keys only."""
+    guard_env = _registrar_env()
+    prod = _production_shaped_env()
+    assert set(guard_env.filters) == set(prod.env.filters)
+
+
+def test_every_template_filter_reference_resolves():
+    """Parse every ui/templates/**/*.html and assert every `nodes.Filter`
+    and `nodes.FilterBlock` name resolves against the registrar's output.
+    `nodes.FilterBlock` (the `{% filter %}` tag) is a distinct AST node from
+    `nodes.Filter` (the `| name` token) and must be scanned alongside it."""
+    env = _registrar_env()
+    templates = sorted(TEMPLATES_DIR.rglob("*.html"))
+
+    missing: list[tuple[str, str, int]] = []
+    demanded: set[str] = set()
+
+    for template_path in templates:
+        source = template_path.read_text()
+        ast = env.parse(source, filename=str(template_path))
+        for node in ast.find_all((nodes.Filter, nodes.FilterBlock)):
+            demanded.add(node.name)
+            if node.name not in env.filters:
+                missing.append((str(template_path), node.name, node.lineno))
+
+    # An empty sweep would pass vacuously and prove nothing (#2719 Risk 2) —
+    # assert the scan actually visited templates and collected filter demand.
+    assert len(templates) > 0, "No templates found under ui/templates/ — guard scanned nothing"
+    assert len(demanded) > 0, "No filter usage found across templates — guard scanned nothing"
+
+    if missing:
+        lines = "\n".join(f"  {path}:{lineno} uses unregistered filter '{name}'" for path, name, lineno in missing)
+        pytest.fail(f"Template(s) reference unregistered Jinja filters:\n{lines}")
+
+
+def test_no_hand_copied_filter_registration_in_tests():
+    """No file under tests/ may assign into a Jinja `.filters[...]` dict —
+    that is exactly the hand-copy hole that caused #2719: three independent
+    filter lists with nothing keeping them in sync. Anchored on the
+    attribute-access form (`\\.filters\\s*\\[`), not a bare `filters[`, so a
+    local variable named `filters` cannot false-positive. This file itself
+    is exempted because it legitimately reads `env.filters`."""
+    self_path = Path(__file__).resolve()
+    offenders: list[str] = []
+
+    for py_file in sorted(TESTS_DIR.rglob("*.py")):
+        if py_file.resolve() == self_path:
+            continue
+        text = py_file.read_text()
+        if HAND_COPY_PATTERN.search(text):
+            offenders.append(str(py_file.relative_to(REPO_ROOT)))
+
+    assert not offenders, (
+        "Test file(s) hand-copy Jinja filter registration instead of calling "
+        f"ui.app.register_template_filters: {offenders}"
+    )

--- a/tests/unit/test_template_filter_registry.py
+++ b/tests/unit/test_template_filter_registry.py
@@ -108,7 +108,9 @@ def test_every_template_filter_reference_resolves():
     assert len(demanded) > 0, "No filter usage found across templates — guard scanned nothing"
 
     if missing:
-        lines = "\n".join(f"  {path}:{lineno} uses unregistered filter '{name}'" for path, name, lineno in missing)
+        lines = "\n".join(
+            f"  {path}:{lineno} uses unregistered filter '{name}'" for path, name, lineno in missing
+        )
         pytest.fail(f"Template(s) reference unregistered Jinja filters:\n{lines}")
 
 

--- a/tests/unit/test_template_filter_registry.py
+++ b/tests/unit/test_template_filter_registry.py
@@ -73,11 +73,15 @@ def test_registrar_covers_all_six_dashboard_filters():
 def test_guard_env_matches_production_shaped_filter_keys():
     """The guard env is a bare Environment; production renders through
     Jinja2Templates (ui/app.py, imported from fastapi.templating). Assert
-    filter-KEY equality between the two so a future production-only filter
-    added by any mechanism other than the registrar (filters.update(...),
-    Jinja2Templates(env=...), a Jinja extension in create_app) trips this
-    guard instead of silently re-diverging one level up. The two envs
-    legitimately differ in autoescape and a url_for global — keys only."""
+    filter-KEY equality between the two so a filter that Jinja2Templates
+    itself contributes — e.g. a FastAPI/Starlette upgrade shipping a new
+    default — cannot diverge from the guard unnoticed. The two envs
+    legitimately differ in autoescape and a url_for global — keys only.
+
+    Scope: this builds its own Jinja2Templates and never calls create_app
+    (which would mount StaticFiles and every router), so a filter registered
+    inside create_app by some route other than the registrar is invisible
+    here; that case is covered by the anti-criterion grep over ui/app.py."""
     guard_env = _registrar_env()
     prod = _production_shaped_env()
     assert set(guard_env.filters) == set(prod.env.filters)

--- a/ui/app.py
+++ b/ui/app.py
@@ -19,6 +19,7 @@ from fastapi import FastAPI, Query, Request
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from jinja2 import Environment
 
 from agent.constants import HEARTBEAT_STALENESS_THRESHOLD_S, WORKER_DOWN_THRESHOLD_S
 from agent.session_pickup import _truthy  # canonical untyped-Popoto-bool coercion (#2439)
@@ -127,6 +128,24 @@ def _filter_usd(amount: float | None) -> str:
     return f"${cents / 100:.2f}"
 
 
+def register_template_filters(env: Environment) -> None:
+    """Single source of truth for dashboard Jinja2 filter registration.
+
+    Registers the six dashboard filters (`format_timestamp`, `format_duration`,
+    `format_interval_filter`, `format_relative`, `freshness_age`, `usd`) on any
+    `jinja2.Environment`. Registers filters and nothing else — callers own their
+    own loader, autoescape, and globals. Production (`create_app`) and every test
+    fixture call this so a new filter added here is picked up everywhere
+    automatically, instead of being hand-copied per env.
+    """
+    env.filters["format_timestamp"] = _filter_format_timestamp
+    env.filters["format_duration"] = _filter_format_duration
+    env.filters["format_interval_filter"] = _filter_format_interval
+    env.filters["format_relative"] = _filter_format_relative
+    env.filters["freshness_age"] = _filter_freshness_age
+    env.filters["usd"] = _filter_usd
+
+
 def create_app() -> FastAPI:
     """Create and configure the FastAPI application.
 
@@ -146,12 +165,7 @@ def create_app() -> FastAPI:
     templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
     # Register Jinja2 filters for template use
-    templates.env.filters["format_timestamp"] = _filter_format_timestamp
-    templates.env.filters["format_duration"] = _filter_format_duration
-    templates.env.filters["format_interval_filter"] = _filter_format_interval
-    templates.env.filters["format_relative"] = _filter_format_relative
-    templates.env.filters["freshness_age"] = _filter_freshness_age
-    templates.env.filters["usd"] = _filter_usd
+    register_template_filters(templates.env)
 
     # Store templates in app state for access by routers
     app.state.templates = templates


### PR DESCRIPTION
## Summary
- Extracts `ui.app.register_template_filters(env)` as the single source of truth for the six dashboard Jinja2 filters, replacing the three independently-drifting lists (production + two hand-rolled test stand-ins) that let `usd` ship (`96b0f65dd`) without the render-test fixtures picking it up.
- Rewires both existing render-test fixtures (`test_session_modal_liveness_render.py`, `test_per_project_modal.py`) onto the shared registrar and re-baselines the two assertions that encoded the old stand-in output shapes rather than shipped production semantics.
- Adds two CI guard tests (`test_template_filter_registry.py`) that make the *class* of bug impossible: a filter-demand guard (every template's filter usage must resolve against the registrar) and a no-hand-copy guard (no test file may hand-roll `.filters[...]` again).
- Adds render coverage for the third, previously-uncovered `| usd` site (`analytics_stats.html`).

## Changes
- `ui/app.py`: new `register_template_filters(env)`; `create_app` now delegates to it instead of six imperative assignments.
- `tests/unit/test_session_modal_liveness_render.py`: fixture calls the registrar; `test_token_cost_strip_renders_when_present` re-baselined to `$1.24` (ceil-to-cent); `test_renders_timestamps_via_format_filter` re-baselined to compute its expectation from `_filter_format_timestamp` directly, with a discriminating raw-value-absent check.
- `tests/unit/test_per_project_modal.py`: fixture calls the registrar (no assertion changes — confirmed safe by the plan's spike-3).
- `tests/unit/test_template_filter_registry.py` (new): filter-demand guard, production-shape (`Jinja2Templates`) filter-key equality assertion, registrar-completeness test, no-hand-copy guard.
- `tests/unit/test_analytics_stats_render.py` (new): render coverage for `analytics_stats.html`'s two `| usd` cost cards, including the sub-cent -> `$0.01` (never `$0.00`) case.
- `docs/features/dashboard.md`, `tests/README.md`: document the registrar seam and the no-hand-copy rule.

## Demonstrated-Red Proof (both guards)

**(a) Filter-demand guard** — injected `{{ 1 | notafilter }}` into `analytics_stats.html`:
```
E   Failed: Template(s) reference unregistered Jinja filters:
E     .../ui/templates/_partials/analytics_stats.html:84 uses unregistered filter 'notafilter'
```
Removed the injection → 1 passed.

**(b) No-hand-copy guard** — added a scratch test file with `env.filters["x"] = lambda v: v`:
```
E   AssertionError: Test file(s) hand-copy Jinja filter registration instead of calling ui.app.register_template_filters: ['tests/unit/_scratch_hand_copy_probe.py']
```
Removed the scratch file → 1 passed.

## Testing
- [x] `tests/unit/test_session_modal_liveness_render.py`, `tests/unit/test_per_project_modal.py`, `tests/unit/test_template_filter_registry.py`, `tests/unit/test_analytics_stats_render.py` — 47/47 passing
- [x] Full `-m webui` marker suite (334 items) — 333 passed, 1 skipped, 1 pre-existing xdist-flaky failure (`test_dashboard_json_carries_both_halves_of_the_fence`) confirmed passing in isolation on both `main` and this branch — not a regression
- [x] Verification table (via `agent.verification_parser.run_checks`): all 10 in-scope checks PASS. The lone `ruff check .` row fails on 2 pre-existing `N802` violations in `tests/db_derivation_guard.py`, verified present on `main` before this build and outside this PR's file set — not caused by this change.
- [x] Lint/format on touched files clean (`ruff check`/`ruff format --check` pass with zero findings in every file this PR modifies)

## Documentation
- [x] `docs/features/dashboard.md` — new "Template Filters" subsection
- [x] `tests/README.md` — new test files indexed, no-hand-copy rule documented as CI-enforced

## Definition of Done
- [x] Built: `register_template_filters` extracted, `create_app` delegates, both fixtures rewired
- [x] Tested: 47/47 targeted tests passing, both guards demonstrated red then green
- [x] Documented: `docs/features/dashboard.md` and `tests/README.md` updated
- [x] Quality: lint/format clean on every file this PR touches
- [x] No production render output changed: `_filter_usd` still uses `math.ceil`; `git diff --name-only main...HEAD -- ui/templates/` is empty

Closes #2719