### PR TITLE
Make the SDLC dispatch record unbypassable via a router upsert slot (#2730)

### DIFF
--- a/agent/pipeline_state.py
+++ b/agent/pipeline_state.py
@@ -406,6 +406,9 @@ class PipelineStateMachine:
         # build the instance via __new__) lands with the full attribute set.
         self.stage_skips = {}
         self._skip_precondition_cache: dict[str, tuple[str, str] | None] = {}
+        # (stage, pre-entry status) staged by _activate_stage for _save() to
+        # record as a dispatch entry (#2730).
+        self._pending_stage_entry: tuple[str, str | None] | None = None
 
         def _apply(data: dict) -> None:
             self.states = {k: v for k, v in data.items() if k in ALL_STAGES}
@@ -507,8 +510,10 @@ class PipelineStateMachine:
         key (``_verdicts``, ``_sdlc_dispatches``, or any future ``_*`` key)
         would be silently dropped if we serialized ``self.states`` alone. To
         protect cross-writer invariants — especially the verdict recorder in
-        ``tools.sdlc_verdict`` and the dispatch recorder in
-        ``agent.sdlc_router.record_dispatch`` — we reload the latest raw
+        ``tools.sdlc_verdict`` and the router's dispatch recorder in
+        ``agent.sdlc_router.record_dispatch`` (and, since #2730, ``_save()``
+        itself, which appends the stage-entry record AFTER this merge — see
+        ``_apply_pending_stage_entry``) — we reload the latest raw
         stage-state blob from the active backing store BEFORE writing and
         merge every ``_*`` key we did not manage ourselves. This makes
         ``_save()`` a safe participant in the cross-process stage-state
@@ -583,7 +588,7 @@ class PipelineStateMachine:
         Never raises: a stage must not become unrecordable because its audit
         entry failed.
         """
-        pending = getattr(self, "_pending_stage_entry", None)
+        pending = self._pending_stage_entry
         if not pending:
             return
         self._pending_stage_entry = None
@@ -592,7 +597,7 @@ class PipelineStateMachine:
             from agent.sdlc_router import confirm_or_append_stage_entry
 
             confirm_or_append_stage_entry(data, stage, prior_status=prior_status)
-        except Exception as e:  # pragma: no cover - audit must never block a write
+        except Exception as e:  # audit must never block a write
             logger.debug(f"pipeline_state: stage-entry dispatch record failed for {stage}: {e}")
 
     def _load_preserved_metadata(self) -> dict:

--- a/agent/pipeline_state.py
+++ b/agent/pipeline_state.py
@@ -549,10 +549,50 @@ class PipelineStateMachine:
                 continue
             data[key] = value
 
+        # #2730: record the stage entry AFTER the merge, so it operates on the
+        # freshest `_sdlc_dispatches` just read from the store rather than a
+        # stale in-memory copy, and lands inside this same single write.
+        self._apply_pending_stage_entry(data)
+
         try:
             self._write_raw(data)
         except Exception as e:
             logger.warning(f"Failed to save stage_states for {self._store_label()}: {e}")
+
+    def _apply_pending_stage_entry(self, data: dict) -> None:
+        """Record a pending stage entry into ``data``'s dispatch history (#2730).
+
+        Every branch of ``start_stage`` funnels through ``_activate_stage``, and
+        so does every actor that starts a stage: the skill bodies via
+        ``sdlc-tool stage-marker``, the PreToolUse hook (which never touches
+        ``write_marker`` and is the dominant marker writer on the bridge), and
+        ``/do-sdlc``'s backfills. Recording here is what makes the dispatch
+        history unbypassable. Previously only the router wrote it, so a stage
+        reached by a skill-to-skill chain such as ``/do-build`` → ``/do-patch``
+        left a marker and no ledger entry, and G4 had nothing to count.
+
+        The double-count question is delegated to
+        ``sdlc_router.confirm_or_append_stage_entry``: the router's own
+        pre-invocation record is an *unconfirmed slot* that this upgrades in
+        place, so a router-driven dispatch still yields exactly one record.
+
+        Called from ``_save()`` after the preserved-metadata merge, so it sees
+        the freshest history and rides the same single write -- there is no
+        second read-modify-write to race with.
+
+        Never raises: a stage must not become unrecordable because its audit
+        entry failed.
+        """
+        stage = getattr(self, "_pending_stage_entry", None)
+        if not stage:
+            return
+        self._pending_stage_entry = None
+        try:
+            from agent.sdlc_router import confirm_or_append_stage_entry
+
+            confirm_or_append_stage_entry(data, stage)
+        except Exception as e:  # pragma: no cover - audit must never block a write
+            logger.debug(f"pipeline_state: stage-entry dispatch record failed for {stage}: {e}")
 
     def _load_preserved_metadata(self) -> dict:
         """Return underscore-prefixed metadata keys from the live backing store.
@@ -598,6 +638,11 @@ class PipelineStateMachine:
     def _activate_stage(self, stage: str) -> None:
         """Set stage to in_progress, save, and record analytics."""
         self.states[stage] = "in_progress"
+        # #2730: flag the entry for _save() to record. It cannot be applied
+        # here -- _save() re-reads `_sdlc_dispatches` from the backing store and
+        # merges that copy, so an in-memory mutation made now would be silently
+        # discarded by the very next line.
+        self._pending_stage_entry = stage
         self._save()
         _record_stage_metric("sdlc.stage_started", stage)
 

--- a/agent/pipeline_state.py
+++ b/agent/pipeline_state.py
@@ -583,14 +583,15 @@ class PipelineStateMachine:
         Never raises: a stage must not become unrecordable because its audit
         entry failed.
         """
-        stage = getattr(self, "_pending_stage_entry", None)
-        if not stage:
+        pending = getattr(self, "_pending_stage_entry", None)
+        if not pending:
             return
         self._pending_stage_entry = None
+        stage, prior_status = pending
         try:
             from agent.sdlc_router import confirm_or_append_stage_entry
 
-            confirm_or_append_stage_entry(data, stage)
+            confirm_or_append_stage_entry(data, stage, prior_status=prior_status)
         except Exception as e:  # pragma: no cover - audit must never block a write
             logger.debug(f"pipeline_state: stage-entry dispatch record failed for {stage}: {e}")
 
@@ -637,12 +638,15 @@ class PipelineStateMachine:
 
     def _activate_stage(self, stage: str) -> None:
         """Set stage to in_progress, save, and record analytics."""
+        prior_status = self.states.get(stage)
         self.states[stage] = "in_progress"
         # #2730: flag the entry for _save() to record. It cannot be applied
         # here -- _save() re-reads `_sdlc_dispatches` from the backing store and
         # merges that copy, so an in-memory mutation made now would be silently
-        # discarded by the very next line.
-        self._pending_stage_entry = stage
+        # discarded by the very next line. The pre-entry status rides along
+        # because the record must snapshot the same side of this transition the
+        # router's slot did; see confirm_or_append_stage_entry.
+        self._pending_stage_entry = (stage, prior_status)
         self._save()
         _record_stage_metric("sdlc.stage_started", stage)
 

--- a/agent/sdlc_router.py
+++ b/agent/sdlc_router.py
@@ -1798,11 +1798,15 @@ def stage_for_skill(skill: str | None) -> str | None:
     return None
 
 
+_NO_PRIOR_STATUS = object()
+
+
 def confirm_or_append_stage_entry(
     stage_states: dict,
     stage: str,
     now: datetime | None = None,
     pr_number: int | None = None,
+    prior_status: object = _NO_PRIOR_STATUS,
 ) -> dict:
     """Record that ``stage`` was entered, without double-counting the router.
 
@@ -1829,6 +1833,17 @@ def confirm_or_append_stage_entry(
     ``last_dispatched_skill`` (``history[-1]["skill"]``) consequently becomes
     *true* on the bypass path rather than naming whichever skill the router last
     saw. That is the fix, not a side effect: rows 8b/8d gate on it.
+
+    ``prior_status`` is the entering stage's status **before** it flipped to
+    ``in_progress``, and it is what keeps the two writers comparable. The router
+    records its slot before invoking, so its snapshot sees the pre-entry status;
+    an appended record is written after ``_activate_stage`` has already flipped
+    the stage, so without this it would see ``in_progress`` instead. G4 breaks
+    its walk on the first snapshot mismatch, so mixing the two observation
+    points makes a loop that alternates router-driven and bypass entries count
+    *lower* than it did before this feature existed -- adding the correct record
+    would lower the streak. Callers that know the pre-entry status pass it; the
+    snapshot is then built against that value, matching the router.
     """
     history = stage_states.get("_sdlc_dispatches")
     if not isinstance(history, list):
@@ -1869,7 +1884,28 @@ def confirm_or_append_stage_entry(
                 pr_number = snapshot["pr_number"]
                 break
 
-    return record_dispatch(stage_states, skill=skill, now=now, pr_number=pr_number, confirmed=True)
+    # Build the snapshot against the stage's PRE-entry status, so this record is
+    # comparable with a router slot recorded before the same transition.
+    if prior_status is _NO_PRIOR_STATUS:
+        return record_dispatch(
+            stage_states, skill=skill, now=now, pr_number=pr_number, confirmed=True
+        )
+
+    had_key = stage in stage_states
+    current = stage_states.get(stage)
+    if prior_status is None:
+        stage_states.pop(stage, None)
+    else:
+        stage_states[stage] = prior_status
+    try:
+        return record_dispatch(
+            stage_states, skill=skill, now=now, pr_number=pr_number, confirmed=True
+        )
+    finally:
+        if had_key:
+            stage_states[stage] = current
+        else:
+            stage_states.pop(stage, None)
 
 
 def record_dispatch(

--- a/agent/sdlc_router.py
+++ b/agent/sdlc_router.py
@@ -1256,7 +1256,8 @@ def _rule_patch_applied_after_review(stage_states: dict, meta: dict, context: di
     deliberate: an approval recorded before the latest patch does not describe
     the code that patch produced, and advancing on it would merge code no review
     ever saw. It converges -- the re-review records a verdict newer than the
-    patch dispatch, which row 9 then owns -- and G4 bounds it otherwise. See
+    patch dispatch, which row 9 then owns. If it does not converge, nothing
+    stops it; see the unbounded-loop note at the end of this docstring. See
     ``TestStaleApprovedIsReReviewedNotAdvanced``.
 
     Disjointness from rows 8c/8d/8e (which have no step-aside against disjunct
@@ -1272,9 +1273,16 @@ def _rule_patch_applied_after_review(stage_states: dict, meta: dict, context: di
 
     No defensive step-asides are added on the strength of that proof.
 
-    Loop-bound by G4 (``same_stage_dispatch_count``): a verdict that stays
-    permanently stale escalates to a human rather than spinning on
-    ``/do-pr-review``.
+    NOT loop-bounded, despite what this docstring claimed until #2730. The
+    8 -> 8b loop alternates ``/do-patch`` with ``/do-pr-review``, and
+    ``compute_same_stage_count`` requires consecutive entries to share BOTH the
+    skill and the ``stage_snapshot``. The alternation fails the first test, and
+    ``_patch_cycle_count`` -- which ``build_stage_snapshot`` includes and
+    ``complete_stage("PATCH")`` increments every cycle -- fails the second. G2
+    caps critique cycles only; there is no patch-cycle equivalent. So a verdict
+    that stays permanently stale spins on ``/do-pr-review`` without escalating.
+    Tracked on #2801, which carries the measurements and the reason the obvious
+    one-line fix does not work.
     """
     if not meta.get("pr_number"):
         return False

--- a/agent/sdlc_router.py
+++ b/agent/sdlc_router.py
@@ -1826,23 +1826,40 @@ def confirm_or_append_stage_entry(
     if not isinstance(history, list):
         history = []
 
-    # Newest-first: upgrade the most recent unconfirmed slot for this stage.
-    for entry in reversed(history):
-        if not isinstance(entry, dict) or entry.get("stage") != stage:
-            continue
-        if entry.get("confirmed") is False:
-            entry["confirmed"] = True
-            stage_states["_sdlc_dispatches"] = history
-            return stage_states
-        # The newest record for this stage is already confirmed, so this is a
-        # fresh entry into a stage that ran before. Fall through and append.
-        break
+    # ONLY the newest record can be this entry's router slot. The router records
+    # immediately before invoking the sub-skill, so nothing else can land in
+    # between. Scanning further back would let a stale slot -- a dispatch that
+    # was recorded and then never started -- absorb an unrelated later entry,
+    # dropping that entry's record entirely and leaving `last_dispatched_skill`
+    # naming the wrong skill: exactly the defect this function exists to fix.
+    last = history[-1] if history else None
+    if isinstance(last, dict) and last.get("stage") == stage and last.get("confirmed") is False:
+        last["confirmed"] = True
+        # Re-stamp the time: `_latest_dispatch_at` (rows 8 and 2b) must report
+        # when the stage actually started, not when the router queued it.
+        last["at"] = (now or datetime.now(UTC)).isoformat()
+        stage_states["_sdlc_dispatches"] = history
+        return stage_states
 
     skill = STAGE_TO_SKILL.get(stage)
     if skill is None:
         # An unknown stage has no skill to attribute the entry to. Recording a
         # skill-less record would break every consumer of history[-1]["skill"].
         return stage_states
+
+    # Inherit the PR number from the newest record that carries one. The bypass
+    # path has no `_meta` to read it from, and `pr_number` is IN the snapshot
+    # G4 compares -- so recording None beside a router record's real value
+    # breaks the streak at every router/bypass boundary, making the very records
+    # this function adds uncountable.
+    if pr_number is None:
+        for entry in reversed(history):
+            if not isinstance(entry, dict):
+                continue
+            snapshot = entry.get("stage_snapshot")
+            if isinstance(snapshot, dict) and snapshot.get("pr_number") is not None:
+                pr_number = snapshot["pr_number"]
+                break
 
     return record_dispatch(stage_states, skill=skill, now=now, pr_number=pr_number, confirmed=True)
 

--- a/agent/sdlc_router.py
+++ b/agent/sdlc_router.py
@@ -1777,11 +1777,82 @@ def decide_next_dispatch(
     return primary
 
 
+def stage_for_skill(skill: str | None) -> str | None:
+    """Return the pipeline stage a ``/do-*`` skill executes, or ``None``.
+
+    Inverse of ``agent.pipeline_graph.STAGE_TO_SKILL``, derived from it rather
+    than hand-maintained so the two cannot drift (#2730). ``STAGE_TO_SKILL`` is
+    1:1, so the inversion is unambiguous.
+    """
+    for stage, mapped in STAGE_TO_SKILL.items():
+        if mapped == skill:
+            return stage
+    return None
+
+
+def confirm_or_append_stage_entry(
+    stage_states: dict,
+    stage: str,
+    now: datetime | None = None,
+    pr_number: int | None = None,
+) -> dict:
+    """Record that ``stage`` was entered, without double-counting the router.
+
+    Issue #2730. Two different actors observe a stage starting, and before this
+    only one of them recorded it:
+
+    - the router calls ``record_dispatch`` *before* invoking a sub-skill, which
+      is the only signal available if the skill dies before it starts;
+    - the stage itself transitions to ``in_progress``, which happens on EVERY
+      entry path including the ones that never reach the router (a skill-to-skill
+      chain such as ``/do-build`` → ``/do-patch``, and the PreToolUse hook, which
+      is the dominant marker writer on the bridge).
+
+    Recording in both places naively would double every router-driven dispatch
+    and halve G4's effective threshold. Instead the router's record is an
+    **unconfirmed slot** (``confirmed: False``) and this function upgrades it in
+    place. When no unconfirmed slot exists the stage was reached without the
+    router, and a confirmed record is appended.
+
+    The result is exactly one record per stage entry, from either path, while a
+    genuine second entry still appends a second record -- which is the whole G4
+    signal and must not be deduplicated away.
+
+    ``last_dispatched_skill`` (``history[-1]["skill"]``) consequently becomes
+    *true* on the bypass path rather than naming whichever skill the router last
+    saw. That is the fix, not a side effect: rows 8b/8d gate on it.
+    """
+    history = stage_states.get("_sdlc_dispatches")
+    if not isinstance(history, list):
+        history = []
+
+    # Newest-first: upgrade the most recent unconfirmed slot for this stage.
+    for entry in reversed(history):
+        if not isinstance(entry, dict) or entry.get("stage") != stage:
+            continue
+        if entry.get("confirmed") is False:
+            entry["confirmed"] = True
+            stage_states["_sdlc_dispatches"] = history
+            return stage_states
+        # The newest record for this stage is already confirmed, so this is a
+        # fresh entry into a stage that ran before. Fall through and append.
+        break
+
+    skill = STAGE_TO_SKILL.get(stage)
+    if skill is None:
+        # An unknown stage has no skill to attribute the entry to. Recording a
+        # skill-less record would break every consumer of history[-1]["skill"].
+        return stage_states
+
+    return record_dispatch(stage_states, skill=skill, now=now, pr_number=pr_number, confirmed=True)
+
+
 def record_dispatch(
     stage_states: dict,
     skill: str,
     now: datetime | None = None,
     pr_number: int | None = None,
+    confirmed: bool = True,
 ) -> dict:
     """Append a dispatch record to ``stage_states._sdlc_dispatches``.
 
@@ -1823,6 +1894,15 @@ def record_dispatch(
             "skill": skill,
             "at": timestamp,
             "stage_snapshot": snapshot,
+            # #2730: the stage this dispatch executes, so the stage-entry
+            # upgrade path can find its slot without re-deriving it from the
+            # skill string at read time. NOT in `stage_snapshot` -- G4 compares
+            # snapshots, and a per-dispatch-varying field there kills
+            # oscillation detection outright.
+            "stage": stage_for_skill(skill),
+            # False marks a router slot awaiting confirmation that the stage
+            # actually started. See confirm_or_append_stage_entry.
+            "confirmed": confirmed,
         }
     )
     # FIFO-evict oldest entries to bound the list.

--- a/agent/sdlc_router.py
+++ b/agent/sdlc_router.py
@@ -1849,12 +1849,19 @@ def confirm_or_append_stage_entry(
     if not isinstance(history, list):
         history = []
 
-    # ONLY the newest record can be this entry's router slot. The router records
-    # immediately before invoking the sub-skill, so nothing else can land in
-    # between. Scanning further back would let a stale slot -- a dispatch that
-    # was recorded and then never started -- absorb an unrelated later entry,
-    # dropping that entry's record entirely and leaving `last_dispatched_skill`
-    # naming the wrong skill: exactly the defect this function exists to fix.
+    # ONLY the newest record is eligible as this entry's router slot. Scanning
+    # further back would let a stale slot -- a dispatch recorded and then never
+    # started -- absorb an unrelated later entry, dropping that entry's record
+    # and leaving `last_dispatched_skill` naming the wrong skill: exactly the
+    # defect this function exists to fix.
+    #
+    # This narrows the hole rather than closing it. If the sub-skill dies before
+    # `start_stage`, its slot IS the newest record, and a later entry into the
+    # same stage upgrades that dead slot instead of appending -- collapsing two
+    # dispatch events into one record and under-counting G4 by one. Closing it
+    # needs an age-out against `last["at"]`, which needs a defensible staleness
+    # threshold; the under-count is the safe direction (a missed escalation, not
+    # a false one), so it is left open deliberately rather than guessed at.
     last = history[-1] if history else None
     if isinstance(last, dict) and last.get("stage") == stage and last.get("confirmed") is False:
         last["confirmed"] = True
@@ -1885,27 +1892,26 @@ def confirm_or_append_stage_entry(
                 break
 
     # Build the snapshot against the stage's PRE-entry status, so this record is
-    # comparable with a router slot recorded before the same transition.
-    if prior_status is _NO_PRIOR_STATUS:
-        return record_dispatch(
-            stage_states, skill=skill, now=now, pr_number=pr_number, confirmed=True
-        )
-
-    had_key = stage in stage_states
-    current = stage_states.get(stage)
-    if prior_status is None:
-        stage_states.pop(stage, None)
-    else:
-        stage_states[stage] = prior_status
-    try:
-        return record_dispatch(
-            stage_states, skill=skill, now=now, pr_number=pr_number, confirmed=True
-        )
-    finally:
-        if had_key:
-            stage_states[stage] = current
+    # comparable with a router slot recorded before the same transition. The
+    # override is an explicit view rather than a mutate-and-restore of the
+    # caller's dict, so the invariant stays local to this function instead of
+    # depending on `build_stage_snapshot` copying eagerly two calls away.
+    snapshot_states = None
+    if prior_status is not _NO_PRIOR_STATUS:
+        snapshot_states = dict(stage_states)
+        if prior_status is None:
+            snapshot_states.pop(stage, None)
         else:
-            stage_states.pop(stage, None)
+            snapshot_states[stage] = prior_status
+
+    return record_dispatch(
+        stage_states,
+        skill=skill,
+        now=now,
+        pr_number=pr_number,
+        confirmed=True,
+        snapshot_states=snapshot_states,
+    )
 
 
 def record_dispatch(
@@ -1914,6 +1920,7 @@ def record_dispatch(
     now: datetime | None = None,
     pr_number: int | None = None,
     confirmed: bool = True,
+    snapshot_states: dict | None = None,
 ) -> dict:
     """Append a dispatch record to ``stage_states._sdlc_dispatches``.
 
@@ -1937,14 +1944,27 @@ def record_dispatch(
             ``pr_number`` is ``None`` — the explicit argument is the sole
             provenance (``sdlc_stage_query`` resolves the PR number from the
             ``AgentSession.pr_number`` field into ``_meta.pr_number``).
+        confirmed: ``False`` marks the record a **router slot** — a dispatch the
+            router recorded immediately before invoking a sub-skill, which the
+            stage entry later upgrades in place rather than duplicating. See
+            ``confirm_or_append_stage_entry`` for the protocol. ``True`` (the
+            default) records a dispatch that is already known to have started.
+        snapshot_states: Optional alternative source for the ``stage_snapshot``
+            projection. The record is still appended to ``stage_states``; only
+            the snapshot is built from this. Callers use it to snapshot a stage
+            transition from a specific side without mutating the live dict —
+            see ``confirm_or_append_stage_entry``'s ``prior_status``.
 
     Returns:
-        The mutated stage_states dict.
+        The mutated stage_states dict. The appended record carries ``skill``,
+        ``at``, ``stage_snapshot``, ``stage`` and ``confirmed``; the last two
+        are deliberately outside the snapshot (see below).
     """
     timestamp = (now or datetime.now(UTC)).isoformat()
     # Build a snapshot from a stage_states view that EXCLUDES the history
     # list itself, otherwise the counter would never match across invocations.
-    view = {k: v for k, v in stage_states.items() if k != "_sdlc_dispatches"}
+    source = stage_states if snapshot_states is None else snapshot_states
+    view = {k: v for k, v in source.items() if k != "_sdlc_dispatches"}
     snapshot = build_stage_snapshot(view, meta={"pr_number": pr_number})
 
     history = stage_states.setdefault("_sdlc_dispatches", [])

--- a/docs/features/sdlc-router-oscillation-guard.md
+++ b/docs/features/sdlc-router-oscillation-guard.md
@@ -239,6 +239,21 @@ that actually ran rather than whichever one the router last saw — after a
 that value; G1, G3 and G7 also read it, and rows 8 and 2b read
 `_latest_dispatch_at`.
 
+A sixth consumer reads the history for a different purpose:
+`tools/sdlc_stage_marker.py`'s retroactive-skip check refuses to mark a stage
+`skipped` once a dispatch for it exists. Because every stage entry now records
+one, a `/do-plan` that entered PLAN and then aborted to ask a question is no
+longer retroactively skippable. That is the guard's stated contract — the stage
+*was* reached — and it errs toward refusing a skip rather than granting a false
+one.
+
+Records appended by the stage entry carry no `run_id`. That annotation is
+applied only on the router path (`tools/sdlc_dispatch.py`), because
+`PipelineStateMachine` reaches its store as a bare `PipelineLedger` on the
+`for_issue` path while `active_run_id` is a field of `AgentSession`. A
+hook-driven lane's history is therefore `run_id`-sparse, and a missing `run_id`
+means "not recorded", never "a different run".
+
 The record is applied inside `_save()` **after** the preserved-metadata merge.
 `_save()` re-reads `_sdlc_dispatches` from the backing store and merges that
 copy over anything in memory, so a record written before the merge is silently
@@ -248,6 +263,25 @@ same single write.
 `stage` and `confirmed` live on the record and **never** in `stage_snapshot` —
 G4 compares snapshots, and a per-dispatch-varying field there would stop every
 comparison from ever matching, silently disabling oscillation detection.
+
+**Both writers must snapshot the same side of the stage transition.** The router
+records its slot before invoking, so its snapshot sees the entering stage's
+**pre-entry** status. An appended record is written from `_save()` *after*
+`_activate_stage` has already flipped the stage to `in_progress`, so left alone
+it would snapshot the other side. Since `compute_same_stage_count` breaks its
+walk on the first snapshot mismatch, mixing the two observation points makes a
+loop that alternates router-driven and bypass entries count **lower than it did
+before this feature existed** — adding the correct record would *lower* the
+streak. `_activate_stage` therefore carries the pre-entry status alongside the
+pending stage, and `confirm_or_append_stage_entry` builds the appended record's
+snapshot against that value via `record_dispatch`'s `snapshot_states` override.
+Measured on a three-cycle mixed-path `/do-patch` loop: 1 without the override, 6
+with it. `pr_number` has the same hazard and the same treatment — bypass records
+inherit it from the newest record carrying one.
+
+This invariant is the correctness keystone of the whole feature: a change that
+drops it does not fail loudly, it silently makes G4 count worse than not having
+the records at all.
 
 The `stage_snapshot` projection is deliberately narrow to prevent spurious
 churn:

--- a/docs/features/sdlc-router-oscillation-guard.md
+++ b/docs/features/sdlc-router-oscillation-guard.md
@@ -211,8 +211,43 @@ Both guards now check `meta.get("pr_number")` first and return `None` (step asid
 ### G4 state machine
 
 `stage_states._sdlc_dispatches` is a bounded FIFO list (max 10 entries) of
-`{skill, at, stage_snapshot}` records. The record is written **before** the
-sub-skill launches (so oscillation on crashing skills is still detected).
+`{skill, at, stage_snapshot, stage, confirmed}` records.
+
+**Two writers, one record per stage entry.** The router records **before** the
+sub-skill launches, so oscillation on a skill that crashes before it starts is
+still detected. That record is an *unconfirmed slot* (`confirmed: false`).
+`PipelineStateMachine._activate_stage` — the single point every `start_stage`
+branch funnels through — upgrades that slot in place when the stage actually
+starts, and appends its own confirmed record when no slot exists.
+
+The second writer is what makes the history unbypassable. Only the router used
+to write it, while stage markers were written by the stage itself, so any stage
+reached without the router left a marker and no ledger entry and G4 had nothing
+to count. Two such paths exist: a skill-to-skill chain (`/do-build` routes
+failures straight to `/do-patch`), and the PreToolUse hook, which calls
+`start_stage()` on every `Skill(do-*)` call and never touches `write_marker` —
+on the bridge that hook is how markers get written at all.
+
+The upsert slot is what keeps the two writers from double-counting a single
+dispatch, which would halve G4's effective threshold. A genuine **re-entry**
+still appends a second record: that is the entire G4 signal, and deduplicating
+it would disarm the guard.
+
+`last_dispatched_skill` is `history[-1]["skill"]`, so it now names the skill
+that actually ran rather than whichever one the router last saw — after a
+`/do-build` → `/do-patch` chain it reads `/do-patch`. Rows 8b and 8d gate on
+that value; G1, G3 and G7 also read it, and rows 8 and 2b read
+`_latest_dispatch_at`.
+
+The record is applied inside `_save()` **after** the preserved-metadata merge.
+`_save()` re-reads `_sdlc_dispatches` from the backing store and merges that
+copy over anything in memory, so a record written before the merge is silently
+discarded; applying it after means it sees the freshest history and rides the
+same single write.
+
+`stage` and `confirmed` live on the record and **never** in `stage_snapshot` —
+G4 compares snapshots, and a per-dispatch-varying field there would stop every
+comparison from ever matching, silently disabling oscillation detection.
 
 The `stage_snapshot` projection is deliberately narrow to prevent spurious
 churn:

--- a/docs/features/sdlc-stage-tracking.md
+++ b/docs/features/sdlc-stage-tracking.md
@@ -17,6 +17,21 @@ Both paths share the exact same `StageStates` Pydantic validation and the `_load
 
 **Write authority.** A caller may only write the issue-keyed ledger while it holds the per-issue run_id lease (`models/session_lifecycle.py::touch_issue_lock`, see [`docs/features/sdlc-issue-ownership-lock.md`](sdlc-issue-ownership-lock.md)). The lease also carries the pinned `target_repo` component of the ledger key, resolved once at lease-acquire time — writers never re-resolve it per call. Takeover of an issue is simply acquiring that same lease; the ledger itself never moves, because it never lived on either session.
 
+
+### Stage entry records a dispatch
+
+Starting a stage records an entry in `_sdlc_dispatches`, not just a marker.
+`PipelineStateMachine._activate_stage` is the single point every `start_stage`
+branch and every actor funnels through — the skill bodies via `sdlc-tool
+stage-marker`, the PreToolUse hook (which calls `start_stage()` directly and
+never touches `write_marker`), and `/do-sdlc`'s backfills.
+
+The router still records before invoking a sub-skill, as an *unconfirmed slot*
+that the stage entry upgrades in place; a stage reached without the router
+appends its own confirmed record. One record per stage entry from either path,
+and a genuine re-entry appends another, which is what G4 counts. See
+[SDLC Router Oscillation Guard](sdlc-router-oscillation-guard.md#g4-state-machine).
+
 ## How Stage State Is Written
 
 Two complementary paths write stage markers:

--- a/tests/unit/test_pipeline_state_machine.py
+++ b/tests/unit/test_pipeline_state_machine.py
@@ -1897,3 +1897,116 @@ class TestSkippedIsSettled:
         """StageStates coerces unknown statuses to `pending`; `skipped` is known."""
         validated = StageStates.from_dict({"CRITIQUE": "skipped"}).to_dict()
         assert validated["CRITIQUE"] == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# Issue #2730: starting a stage records a dispatch, through the real _save().
+#
+# These go through PipelineStateMachine rather than calling the router helper
+# directly, because the load-bearing claim is that the record survives _save()'s
+# preserved-metadata merge. _save() re-reads `_sdlc_dispatches` from the backing
+# store and merges that copy over anything in memory, so a record applied before
+# the merge would be silently discarded -- which is precisely why the entry is
+# applied inside _save() after the merge rather than in _activate_stage.
+# ---------------------------------------------------------------------------
+
+
+class TestStageEntryRecordsDispatch:
+    def _history(self, session):
+        return json.loads(session.stage_states).get("_sdlc_dispatches", [])
+
+    def test_start_stage_records_a_dispatch_through_save(self):
+        session = _make_session(
+            {"ISSUE": "completed", "PLAN": "completed", "CRITIQUE": "completed"}
+        )
+        sm = PipelineStateMachine(session)
+        sm.start_stage("BUILD")
+
+        history = self._history(session)
+        assert [e["skill"] for e in history] == ["/do-build"]
+        assert history[0]["stage"] == "BUILD"
+        assert history[0]["confirmed"] is True
+
+    def test_the_record_survives_the_preserved_metadata_merge(self):
+        """The reason this lives inside _save(): a record written before the
+        merge is overwritten by the store's copy of `_sdlc_dispatches`."""
+        session = _make_session(
+            {
+                "ISSUE": "completed",
+                "PLAN": "completed",
+                "CRITIQUE": "completed",
+                "_sdlc_dispatches": [
+                    {"skill": "/do-plan", "at": "2026-01-01T00:00:00+00:00", "stage": "PLAN"}
+                ],
+            }
+        )
+        sm = PipelineStateMachine(session)
+        sm.start_stage("BUILD")
+
+        assert [e["skill"] for e in self._history(session)] == ["/do-plan", "/do-build"]
+
+    def test_a_router_slot_is_upgraded_not_duplicated(self):
+        """The router records `confirmed: False` before invoking; the stage
+        entry must upgrade that slot rather than append beside it."""
+        session = _make_session(
+            {
+                "ISSUE": "completed",
+                "PLAN": "completed",
+                "CRITIQUE": "completed",
+                "_sdlc_dispatches": [
+                    {
+                        "skill": "/do-build",
+                        "at": "2026-01-01T00:00:00+00:00",
+                        "stage": "BUILD",
+                        "confirmed": False,
+                    }
+                ],
+            }
+        )
+        sm = PipelineStateMachine(session)
+        sm.start_stage("BUILD")
+
+        history = self._history(session)
+        assert len(history) == 1, history
+        assert history[0]["confirmed"] is True
+
+    def test_a_failing_dispatch_record_never_blocks_the_marker_write(self):
+        """A stage must not become unrecordable because its audit entry failed."""
+        session = _make_session(
+            {"ISSUE": "completed", "PLAN": "completed", "CRITIQUE": "completed"}
+        )
+        sm = PipelineStateMachine(session)
+        with patch(
+            "agent.sdlc_router.confirm_or_append_stage_entry",
+            side_effect=RuntimeError("ledger exploded"),
+        ):
+            sm.start_stage("BUILD")
+
+        assert json.loads(session.stage_states)["BUILD"] == "in_progress"
+
+    def test_a_genuine_re_entry_appends_a_second_record(self):
+        """The G4 signal: a real re-entry must not be deduplicated away, or the
+        guard this issue exists to re-arm stays disarmed."""
+        session = _make_session(
+            {"ISSUE": "completed", "PLAN": "completed", "CRITIQUE": "completed"}
+        )
+        sm = PipelineStateMachine(session)
+        sm.start_stage("BUILD")
+        sm.fail_stage("BUILD")
+        sm.start_stage("BUILD")
+
+        assert [e["skill"] for e in self._history(session)] == ["/do-build", "/do-build"]
+
+    def test_restarting_an_already_in_progress_stage_records_nothing(self):
+        """`start_stage` no-ops when the stage is already in_progress, so no
+        entry occurred and none must be recorded -- otherwise a repeated marker
+        write would inflate the count and trip G4 on a stage that never
+        re-entered."""
+        session = _make_session(
+            {"ISSUE": "completed", "PLAN": "completed", "CRITIQUE": "completed"}
+        )
+        sm = PipelineStateMachine(session)
+        sm.start_stage("BUILD")
+        sm.start_stage("BUILD")
+
+        assert [e["skill"] for e in self._history(session)] == ["/do-build"]

--- a/tests/unit/test_sdlc_router_oscillation.py
+++ b/tests/unit/test_sdlc_router_oscillation.py
@@ -17,6 +17,7 @@ from agent.sdlc_router import (
     build_stage_snapshot,
     canonical_snapshot,
     compute_same_stage_count,
+    confirm_or_append_stage_entry,
     decide_next_dispatch,
     record_dispatch,
 )
@@ -952,3 +953,130 @@ def test_g4_bounds_permanently_stale_review_verdict_loop():
     assert len(dispatched) <= MAX_SAME_STAGE_DISPATCHES + 1, (
         f"row 8b re-dispatched {len(dispatched)} times before G4 fired"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #2730: the dispatch record must be unbypassable.
+#
+# Only the router used to write `_sdlc_dispatches`, while stage markers were
+# written by the stage itself. Any stage reached without the router -- a
+# skill-to-skill chain like /do-build -> /do-patch, or the PreToolUse hook,
+# which never touches write_marker and is the dominant marker writer on the
+# bridge -- therefore left a marker and no ledger entry, and G4 had nothing to
+# count. Issue #2711's ledger showed six completed stages and zero dispatches.
+#
+# The fix is an upsert slot: the router records `confirmed: False` before
+# invoking, and the stage entry upgrades that slot in place -- or appends its
+# own when the router was bypassed. Exactly one record per stage entry from
+# either path, while a genuine SECOND entry still appends, because that is the
+# whole G4 signal and deduplicating it away would disarm the guard.
+# ---------------------------------------------------------------------------
+
+
+class TestStageEntryUpsert:
+    def _skills(self, states):
+        return [e["skill"] for e in states.get("_sdlc_dispatches", [])]
+
+    def test_router_driven_dispatch_yields_exactly_one_record(self):
+        """The double-count hazard. Two writers observe one dispatch; a naive
+        append would halve G4's effective threshold."""
+        states: dict = {}
+        record_dispatch(states, SKILL_DO_BUILD, confirmed=False)
+        confirm_or_append_stage_entry(states, "BUILD")
+
+        assert self._skills(states) == [SKILL_DO_BUILD]
+        assert states["_sdlc_dispatches"][0]["confirmed"] is True
+
+    def test_bypassed_stage_records_itself(self):
+        """The #2730 defect proper: no router record exists, so the stage entry
+        must append one rather than leaving the ledger silent."""
+        states: dict = {}
+        confirm_or_append_stage_entry(states, "PATCH")
+
+        assert self._skills(states) == [SKILL_DO_PATCH]
+        assert states["_sdlc_dispatches"][0]["confirmed"] is True
+
+    def test_build_to_patch_chain_reports_patch_as_last_dispatched(self):
+        """The named regression fixture. `/do-build` chains to `/do-patch`
+        without the router, so before this fix `last_dispatched_skill` read
+        `/do-build` while `/do-patch` was the skill that actually ran -- and
+        rows 8b and 8d gate on exactly that value."""
+        states: dict = {}
+        record_dispatch(states, SKILL_DO_BUILD, confirmed=False)
+        confirm_or_append_stage_entry(states, "BUILD")
+        confirm_or_append_stage_entry(states, "PATCH")
+
+        assert self._skills(states) == [SKILL_DO_BUILD, SKILL_DO_PATCH]
+        _, last_skill = compute_same_stage_count(states)
+        assert last_skill == SKILL_DO_PATCH
+
+    def test_genuine_repeat_still_appends_so_g4_can_count(self):
+        """Deduplicating a real re-entry would silently disarm the guard this
+        whole issue exists to re-arm."""
+        states: dict = {}
+        for _ in range(3):
+            record_dispatch(states, SKILL_DO_PR_REVIEW, confirmed=False)
+            confirm_or_append_stage_entry(states, "REVIEW")
+
+        assert self._skills(states) == [SKILL_DO_PR_REVIEW] * 3
+        count, skill = compute_same_stage_count(states)
+        assert count == 3
+        assert skill == SKILL_DO_PR_REVIEW
+
+    def test_repeat_on_the_bypass_path_also_appends(self):
+        states: dict = {}
+        confirm_or_append_stage_entry(states, "PATCH")
+        confirm_or_append_stage_entry(states, "PATCH")
+
+        assert self._skills(states) == [SKILL_DO_PATCH] * 2
+
+    def test_only_the_newest_unconfirmed_slot_is_upgraded(self):
+        """A stale unconfirmed slot from a dispatch that never started must not
+        absorb a later entry -- that would merge two entries into one record."""
+        states: dict = {}
+        record_dispatch(states, SKILL_DO_PR_REVIEW, confirmed=False)
+        record_dispatch(states, SKILL_DO_PR_REVIEW, confirmed=False)
+        confirm_or_append_stage_entry(states, "REVIEW")
+
+        flags = [e["confirmed"] for e in states["_sdlc_dispatches"]]
+        assert flags == [False, True], flags
+
+    def test_unknown_stage_records_nothing_and_does_not_raise(self):
+        """A skill-less record would break every consumer of
+        history[-1]["skill"]."""
+        states: dict = {}
+        confirm_or_append_stage_entry(states, "NOT_A_STAGE")
+        assert states.get("_sdlc_dispatches", []) == []
+
+    def test_stage_field_is_recorded_but_never_enters_the_snapshot(self):
+        """G4 compares snapshots. A per-dispatch-varying field inside one kills
+        oscillation detection outright -- the exact failure this issue is
+        about."""
+        states: dict = {}
+        record_dispatch(states, SKILL_DO_BUILD)
+        entry = states["_sdlc_dispatches"][0]
+
+        assert entry["stage"] == "BUILD"
+        assert "stage" not in entry["stage_snapshot"]
+        assert "confirmed" not in entry["stage_snapshot"]
+
+    def test_snapshot_key_set_is_unchanged(self):
+        """Pins the projection: widening it silently disarms G4."""
+        states: dict = {"BUILD": "in_progress"}
+        record_dispatch(states, SKILL_DO_BUILD)
+        assert set(states["_sdlc_dispatches"][0]["stage_snapshot"]) == {
+            "stages",
+            "_verdicts",
+            "_patch_cycle_count",
+            "_critique_cycle_count",
+            "pr_number",
+        }
+
+    def test_stage_for_skill_inverts_the_canonical_map(self):
+        from agent.pipeline_graph import STAGE_TO_SKILL
+        from agent.sdlc_router import stage_for_skill
+
+        for stage, skill in STAGE_TO_SKILL.items():
+            assert stage_for_skill(skill) == stage
+        assert stage_for_skill("/do-nonexistent") is None
+        assert stage_for_skill(None) is None

--- a/tests/unit/test_sdlc_router_oscillation.py
+++ b/tests/unit/test_sdlc_router_oscillation.py
@@ -980,6 +980,52 @@ class TestStageEntryUpsert:
     def _skills(self, states):
         return [e["skill"] for e in states.get("_sdlc_dispatches", [])]
 
+    def _router_driven(self, states):
+        """Router records its slot, THEN the stage flips and the entry lands."""
+        record_dispatch(states, SKILL_DO_PATCH, confirmed=False)
+        prior = states.get("PATCH")
+        states["PATCH"] = "in_progress"
+        confirm_or_append_stage_entry(states, "PATCH", prior_status=prior)
+
+    def _bypass(self, states):
+        """`/do-build` chains straight to `/do-patch` -- no router record."""
+        prior = states.get("PATCH")
+        states["PATCH"] = "in_progress"
+        confirm_or_append_stage_entry(states, "PATCH", prior_status=prior)
+
+    def test_a_bypass_record_snapshots_the_pre_entry_status_like_the_router(self):
+        """The two writers must observe the SAME side of the stage transition.
+
+        The router records its slot before invoking, so its snapshot sees the
+        pre-entry status. An appended record is written after `_activate_stage`
+        already flipped the stage, so if it snapshots the live value it sees
+        `in_progress` instead. G4 breaks its walk on the first snapshot
+        mismatch, so mixing the two observation points makes a loop that
+        alternates router-driven and bypass entries count LOWER than it did
+        before this feature existed -- adding the correct record would lower the
+        streak, which is the opposite of the point.
+
+        Every other fixture here starts from a bare `states = {}`, where the
+        diverging field is empty on both sides and the defect is invisible.
+        This one gives PATCH a real pre-entry status.
+        """
+        states: dict = {"PATCH": "failed", "REVIEW": "completed"}
+        self._router_driven(states)
+        states["PATCH"] = "failed"
+        self._bypass(states)
+        states["PATCH"] = "failed"
+        self._router_driven(states)
+
+        snapshots = [e["stage_snapshot"]["stages"].get("PATCH") for e in states["_sdlc_dispatches"]]
+        assert snapshots == ["failed", "failed", "failed"], (
+            f"a bypass record must snapshot the pre-entry status, got {snapshots}"
+        )
+        count, _ = compute_same_stage_count(states)
+        assert count == 3, (
+            "three /do-patch entries over an unchanged snapshot must count 3; "
+            f"got {count} -- the added record is lowering G4's streak"
+        )
+
     def test_router_driven_dispatch_yields_exactly_one_record(self):
         """The double-count hazard. Two writers observe one dispatch; a naive
         append would halve G4's effective threshold."""

--- a/tests/unit/test_sdlc_router_oscillation.py
+++ b/tests/unit/test_sdlc_router_oscillation.py
@@ -1084,13 +1084,27 @@ class TestStageEntryUpsert:
         `_meta` to read it from, so recording None beside a router record's real
         value breaks the streak at every router/bypass boundary -- making the
         very records this feature adds uncountable, which is worse than the
-        missing records it fixes."""
-        states: dict = {}
-        record_dispatch(states, SKILL_DO_PR_REVIEW, pr_number=42, confirmed=False)
-        confirm_or_append_stage_entry(states, "REVIEW")
-        confirm_or_append_stage_entry(states, "REVIEW")
+        missing records it fixes.
 
-        assert [e["stage_snapshot"]["pr_number"] for e in states["_sdlc_dispatches"]] == [42, 42]
+        Carries real stage statuses so the `count == 2` assertion is load-bearing:
+        on a bare `states = {}` the `stages` field is empty on both sides of the
+        boundary, and the count would hold even with the pre-entry-status
+        comparability bug reintroduced.
+        """
+        states: dict = {"REVIEW": "failed", "BUILD": "completed"}
+        record_dispatch(states, SKILL_DO_PR_REVIEW, pr_number=42, confirmed=False)
+        prior = states.get("REVIEW")
+        states["REVIEW"] = "in_progress"
+        confirm_or_append_stage_entry(states, "REVIEW", prior_status=prior)
+
+        states["REVIEW"] = "failed"
+        prior = states.get("REVIEW")
+        states["REVIEW"] = "in_progress"
+        confirm_or_append_stage_entry(states, "REVIEW", prior_status=prior)
+
+        records = states["_sdlc_dispatches"]
+        assert [e["stage_snapshot"]["pr_number"] for e in records] == [42, 42]
+        assert [e["stage_snapshot"]["stages"]["REVIEW"] for e in records] == ["failed", "failed"]
         count, _ = compute_same_stage_count(states)
         assert count == 2
 

--- a/tests/unit/test_sdlc_router_oscillation.py
+++ b/tests/unit/test_sdlc_router_oscillation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 from agent.pipeline_graph import MAX_CRITIQUE_CYCLES
 from agent.sdlc_router import (
     MAX_SAME_STAGE_DISPATCHES,
@@ -12,6 +14,7 @@ from agent.sdlc_router import (
     SKILL_DO_PLAN,
     SKILL_DO_PLAN_CRITIQUE,
     SKILL_DO_PR_REVIEW,
+    SKILL_DO_TEST,
     Blocked,
     Dispatch,
     build_stage_snapshot,
@@ -1029,6 +1032,53 @@ class TestStageEntryUpsert:
         confirm_or_append_stage_entry(states, "PATCH")
 
         assert self._skills(states) == [SKILL_DO_PATCH] * 2
+
+    def test_a_bypass_record_inherits_the_pr_number_so_g4_can_count_it(self):
+        """`pr_number` is IN the snapshot G4 compares. The bypass path has no
+        `_meta` to read it from, so recording None beside a router record's real
+        value breaks the streak at every router/bypass boundary -- making the
+        very records this feature adds uncountable, which is worse than the
+        missing records it fixes."""
+        states: dict = {}
+        record_dispatch(states, SKILL_DO_PR_REVIEW, pr_number=42, confirmed=False)
+        confirm_or_append_stage_entry(states, "REVIEW")
+        confirm_or_append_stage_entry(states, "REVIEW")
+
+        assert [e["stage_snapshot"]["pr_number"] for e in states["_sdlc_dispatches"]] == [42, 42]
+        count, _ = compute_same_stage_count(states)
+        assert count == 2
+
+    def test_a_stale_slot_for_another_stage_does_not_absorb_this_entry(self):
+        """A dispatch recorded but never started leaves an unconfirmed slot
+        forever. Scanning past intervening records to find it would drop the
+        real entry's record and leave `last_dispatched_skill` naming the wrong
+        skill -- the exact defect this feature exists to fix. Only the NEWEST
+        record can be this entry's slot, since the router records immediately
+        before invoking."""
+        states: dict = {}
+        record_dispatch(states, SKILL_DO_TEST, confirmed=False)  # never started
+        record_dispatch(states, SKILL_DO_PATCH, confirmed=False)
+        confirm_or_append_stage_entry(states, "PATCH")
+        confirm_or_append_stage_entry(states, "TEST")  # /do-patch chains to /do-test
+
+        assert [e["skill"] for e in states["_sdlc_dispatches"]] == [
+            SKILL_DO_TEST,
+            SKILL_DO_PATCH,
+            SKILL_DO_TEST,
+        ]
+        _, last_skill = compute_same_stage_count(states)
+        assert last_skill == SKILL_DO_TEST
+
+    def test_upgrading_a_slot_restamps_the_time(self):
+        """`_latest_dispatch_at` (rows 8 and 2b) must report when the stage
+        actually started, not when the router queued it."""
+        states: dict = {}
+        record_dispatch(
+            states, SKILL_DO_BUILD, now=datetime(2026, 1, 1, tzinfo=UTC), confirmed=False
+        )
+        confirm_or_append_stage_entry(states, "BUILD", now=datetime(2026, 6, 1, tzinfo=UTC))
+
+        assert states["_sdlc_dispatches"][0]["at"].startswith("2026-06-01")
 
     def test_only_the_newest_unconfirmed_slot_is_upgraded(self):
         """A stale unconfirmed slot from a dispatch that never started must not

--- a/tools/sdlc_dispatch.py
+++ b/tools/sdlc_dispatch.py
@@ -28,6 +28,17 @@ router evaluates guards and selects a dispatch target but **before** invoking
 the sub-skill. This ordering preserves the G4 oscillation signal even if the
 sub-skill crashes mid-execution.
 
+**The router is no longer the only writer (issue #2730).** It writes an
+*unconfirmed slot* (``confirmed: False``), and
+``PipelineStateMachine._activate_stage`` upgrades that slot in place when the
+stage actually starts -- or appends its own confirmed record when the stage was
+reached without the router at all. Previously only this module wrote the
+history, so a stage reached by a skill-to-skill chain (``/do-build`` ->
+``/do-patch``) or by the PreToolUse hook left a stage marker and no ledger
+entry, and G4 had nothing to count: issue #2711's ledger showed six completed
+stages against zero dispatch records. The slot protocol is what keeps the two
+writers from double-counting a single dispatch.
+
 The ``get`` subcommand prints the current ``_sdlc_dispatches`` list as JSON.
 It is useful for debugging G4 state in a live session.
 
@@ -103,7 +114,13 @@ def record_dispatch_for_ledger(
     ts = now or datetime.now(UTC)
 
     def _apply(states: dict) -> dict:
-        states = record_dispatch(states, skill=skill, now=ts, pr_number=pr_number)
+        # #2730: the router records BEFORE invoking the sub-skill, so this is a
+        # slot awaiting confirmation that the stage actually started, not a
+        # completed observation. `PipelineStateMachine.start_stage` upgrades it
+        # in place; if the stage is instead reached without the router, that
+        # path appends its own confirmed record. Either way exactly one record
+        # per stage entry.
+        states = record_dispatch(states, skill=skill, now=ts, pr_number=pr_number, confirmed=False)
         # Dispatch records carry the run identity (issue #2003) — annotated
         # here so ``agent.sdlc_router.record_dispatch`` stays run-id-agnostic.
         try:

--- a/tools/sdlc_dispatch.py
+++ b/tools/sdlc_dispatch.py
@@ -123,6 +123,15 @@ def record_dispatch_for_ledger(
         states = record_dispatch(states, skill=skill, now=ts, pr_number=pr_number, confirmed=False)
         # Dispatch records carry the run identity (issue #2003) — annotated
         # here so ``agent.sdlc_router.record_dispatch`` stays run-id-agnostic.
+        #
+        # This annotation is ROUTER-PATH-ONLY. Records appended by the stage
+        # entry (#2730, `confirm_or_append_stage_entry`) carry no `run_id`,
+        # because `PipelineStateMachine` reaches its store as a bare
+        # `PipelineLedger` on the `for_issue` path and `active_run_id` is a
+        # field of `AgentSession`, not of the ledger — there is nothing to read
+        # it from. So a hook-driven lane's history is `run_id`-sparse, and any
+        # future reader must treat a missing `run_id` as "not recorded" rather
+        # than "a different run". No current reader consumes the field.
         try:
             history = states.get("_sdlc_dispatches") or []
             if history and isinstance(history[-1], dict):

--- a/tools/sdlc_stage_marker.py
+++ b/tools/sdlc_stage_marker.py
@@ -387,6 +387,12 @@ def _skip_precondition_error(
             "produced a verdict actually ran and is never retroactively skippable.",
         )
 
+    # #2730 tightened this: every stage entry now records a dispatch, including
+    # the hook-driven and skill-to-skill paths that previously left no trace. So
+    # a `/do-plan` that entered PLAN and then aborted to ask a question is no
+    # longer retroactively skippable. That is the guard's stated contract read
+    # honestly -- the stage WAS reached -- and it errs toward refusing a skip
+    # rather than granting a false one.
     history = raw.get("_sdlc_dispatches")
     skill = _SKIP_STAGE_SKILL.get(stage)
     if skill and isinstance(history, list):


### PR DESCRIPTION
Closes #2730

**#2730's record-completeness half ships here; its counter half is tracked on #2801.**
Closing the issue because the mechanism it was filed about — markers without dispatch records — is fixed, and the second mechanism named in its "defangs the G4 oscillation guard" claim now has its own issue carrying the full evidence and measurements. The record-completeness half ships here. The G4 counter defect — the second mechanism named in the issue's "defangs the G4 oscillation guard" claim — is **not** fixed, and is filed as #2801 with its full evidence. Details in "What is not fixed" below.

## The defect

Only the router wrote `_sdlc_dispatches`, while stage markers were written by the stage itself. Any stage that ran without passing through the router therefore left a marker and no ledger entry. Issue #2711's ledger shows the result: **six completed stages against zero dispatch records**.

Two bypass paths exist today, and the second is the dominant one:

- `/do-build` routes failures straight to `/do-patch` (`do-build/SKILL.md:128`) — a skill-to-skill chain that never reaches the router's record step.
- The **PreToolUse hook** calls `PipelineStateMachine.start_stage()` on every `Skill(do-*)` call and never touches `write_marker`. Per `docs/features/sdlc-local-supervision.md`, on the bridge that hook is how stage markers get written at all.

That second path is why the obvious fix location is wrong: a change in `write_marker` would have been **a no-op exactly where the divergence was observed**. `PipelineStateMachine._activate_stage` is the single point every `start_stage` branch and every actor funnels through, so the record is made there.

## The design: an upsert slot, not a dedup predicate

Two writers observing one dispatch would double every router-driven entry and halve G4's effective threshold. A dedup predicate can't distinguish "the router already recorded this" from "this is a genuine second entry" — and deduplicating the latter would disarm the very guard this re-arms.

So the router records an **unconfirmed slot** (`confirmed: false`) before invoking, and the stage entry upgrades it in place. When no slot exists, the stage was reached without the router and a confirmed record is appended.

| scenario | records |
|---|---|
| router-driven dispatch | 1 (slot upgraded) |
| `/do-build` → `/do-patch` chain | 1 for each — `/do-patch` no longer invisible |
| genuine re-entry into a stage | 2 — the G4 signal, preserved |
| `start_stage` on an already-`in_progress` stage | 0 — no entry occurred |
| unknown stage | 0, and no raise |

## The two placements that matter

**Where in the save.** The record is applied inside `_save()` **after** the preserved-metadata merge, not in `_activate_stage`. `_save()` re-reads `_sdlc_dispatches` from the backing store and merges that copy over anything in memory, so a record written before the merge is **silently discarded**. Applying it after means it sees the freshest history and rides the same single write — no second read-modify-write to race against.

**Which side of the transition.** Both writers must snapshot the *same* side, and originally they did not. The router records its slot before invoking, so it sees the entering stage's pre-entry status; an appended record is written after `_activate_stage` already flipped the stage, so it saw `in_progress`. `compute_same_stage_count` breaks its walk on the first snapshot mismatch, so a loop alternating router-driven and bypass entries counted **lower than before this feature existed** — measured on a three-cycle `/do-patch` loop, `main` scores 2 and the branch scored 1. Adding the correct record was lowering the streak.

`_activate_stage` now carries the pre-entry status alongside the pending stage, and the appended record's snapshot is built against that value. This was found in review; the regression test gives PATCH a real pre-entry status and was verified red before the fix (`['failed', 'in_progress', 'failed']`) and green after. Every pre-existing `TestStageEntryUpsert` fixture started from a bare `states = {}`, where the diverging field is empty on both sides and the defect is invisible.

The same hazard applies to `pr_number`, which bypass records inherit from the newest record carrying one, for the same reason.

## `last_dispatched_skill` changes, and that is the fix

`history[-1]["skill"]` now names the skill that actually ran rather than whichever one the router last saw. After a `/do-build` → `/do-patch` chain it reads `/do-patch`; previously it read `/do-build` while `/do-patch` was doing the work.

This value has five consumers — G1 (`:336`), G3 (`:403`), G7 (`:685`), row 8b (`:1284`), row 8d (`:1380`) — and rows 8/2b read `_latest_dispatch_at`. All were enumerated and all their suites pass unchanged. Rows 8b and 8d gate on exactly this value, so making it true is the point, not a side effect.

A sixth consumer surfaced in review: `tools/sdlc_stage_marker.py`'s retroactive-skip check. Because every stage entry now records a dispatch, a `/do-plan` that entered PLAN and then aborted to ask a question is no longer retroactively skippable. That is the guard's stated contract ("the stage was reached") read honestly, and it errs toward refusing a skip rather than granting a false one. Noted at the call site.

## Guard integrity

`stage` and `confirmed` ride on the record and **never** enter `stage_snapshot`. G4 compares snapshots; a per-dispatch-varying field there would stop every comparison matching and silently disable oscillation detection outright. Pinned by a test on the snapshot's exact key set.

`stage_for_skill` inverts the canonical `STAGE_TO_SKILL` rather than adding a fourth hand-maintained map — the three that already exist are catalogued on #2491.

## The one false claim, swept

`_rule_patch_applied_after_review` (row 8b) asserted in two places that G4 bounds its re-review loop. It does not: the 8↔8b loop alternates `/do-patch` with `/do-pr-review`, failing the skill test, and `_patch_cycle_count` moves every cycle, failing the snapshot test. G2 caps critique cycles only. Both claims now state the loop is unbounded and point at #2801.

All eleven `bound by G4` claims were audited. The other ten name same-skill re-dispatch loops (rows 2c/8c/8d/8e/8f) that G4 genuinely counts, and are left alone.

## What is not fixed, and why

**The G4 counter still scores alternating oscillation at ≤1.** `compute_same_stage_count` breaks its walk on the first differing skill, so an A→B→A→B loop never reaches the threshold. That is filed as **#2801** rather than fixed here, because the obvious fix does not work and I have no evidence of harm:

- Removing the skill break was measured. A *frozen* alternation then counts 4 and escalates, but a **real** 8↔8b loop counts 2 and does not — `build_stage_snapshot` includes `_patch_cycle_count`/`_critique_cycle_count`, and those increment every cycle, so the snapshot conjunct breaks the walk anyway.
- The one history that looked like a defect turned out to be **productive work** G4 correctly declined to escalate.
- The trade-off is real: the snapshot conjunct that correctly protects productive work is the same thing that defeats detection of the stuck version of that loop. #2801 carries both halves so the next reader starts with the full picture.

**#2731 (dispatch liveness gate) is closed as re-scoped-and-deferred**, not built. Under the owner's lease-read-only ruling the remaining inter-run gate is a no-op: `resolve_ledger_lease` already refuses every foreign holder, live or dead, and already surfaces `orphaned_lock`. The intra-run collision it was filed about cannot be gated by the lease at all — forks inherit the supervisor's `run_id`, and under `/do-sdlc` they are subagents of one `claude` process sharing every identity a fence could read. Full analysis and the shape of the eventual fix are on the issue.

## Plan

`docs/plans/ledger-integrity.md` is revised to rev-3 on `main`, recording the lead's fence/scope ruling (fence extended to `agent/pipeline_state.py`; counter change split to #2801; #2731 closed) and rewriting the operative sections to describe what shipped. Round 2's escalation is closed there rather than only in this PR body.

## Verification

**699 tests pass** across `test_sdlc_router{,_oscillation,_decision}.py`, `test_sdlc_dispatch.py` (unit + integration), `test_pipeline_state_machine.py`, `test_sdlc_stage_marker.py`, `test_sdlc_stage_query.py`, `test_pre_tool_use_start_stage.py`, `test_post_tool_use_stage_completion.py`, `test_sdlc_lease_helper_binding.py`, and `test_sdlc_next_skill.py`. `ruff check .` and `ruff format --check` clean.

One failure in that set, `TestDispatchRecordLease::test_lease_lost_between_peek_and_write_refuses`, reproduces identically on current `main` at the same SHA this branch is rebased onto — pre-existing, not from this branch, and unrelated to the changed code (it exercises `_cli_record`'s mocked lease call sequence).

New tests cover both directions rather than presence alone: exact record **counts** per scenario (a naive unconditional append fails them), the pre-entry-status pin (verified red), the `/do-build`→`/do-patch` regression fixture the change is justified by, the snapshot key-set pin, survival of `_save()`'s merge, and that a failing dispatch record never blocks the marker write.
