### PR TITLE
chore(#2741): delete the docs-auditor rename channel

### DIFF
--- a/.claude/skill-context/do-docs.md
+++ b/.claude/skill-context/do-docs.md
@@ -120,10 +120,9 @@ rg "<retired-term>" --glob 'site/*.html'
 
 ## Auto-fix substrate (Step 2d — run BEFORE manual edits)
 
-Run the unified docs-auditor substrate against the PR-changed files. It auto-handles four
-classes of mechanical fix — renamed markdown links, renamed paths/symbols, README index
-entries pointing at deleted files, and stale-term renames — so manual editing in Step 3 only
-handles cases the substrate can't auto-detect.
+Run the unified docs-auditor substrate against the PR-changed files. It auto-handles one
+class of mechanical fix — stale-term renames — so manual editing in Step 3 only handles
+cases the substrate can't auto-detect.
 
 ```bash
 python -c "

--- a/docs/features/docs-auditor.md
+++ b/docs/features/docs-auditor.md
@@ -51,9 +51,6 @@ writes the SDLC stage marker and updates the plan frontmatter.
 
 | Detector | What it catches | Mechanism |
 |----------|-----------------|-----------|
-| Renamed markdown links | `[label](old/path.md)` after a rename | `git log --follow --diff-filter=R` |
-| Renamed paths/symbols | `` `old/module.py` `` after a rename | `git log --follow --diff-filter=R` |
-| README broken entries | Index entries pointing at deleted files | filesystem check + rename probe |
 | Stale-term dictionary | `SessionLog`, `RedisJob`, `session_log`, `redis_job` | `STALE_TERMS` dict at module top, matched on word boundaries |
 
 The dictionary's current entries are model and field renames: `SessionLog` and
@@ -104,10 +101,10 @@ and `-` are all word boundaries, so a key equal to a whole path segment still
 matches. Gate 3 is what closes that.
 
 Detection and application share one matching semantics: `_detect_stale_term_fixes`
-returns compiled `(pattern, replacement)` pairs on a dedicated `regex_fixes`
-channel, applied by `_apply_fixes_to_file` through `pattern.subn()`. The literal
-`fixes` channel used by the three rename detectors is untouched, so the
-`new == ""` line-delete sentinel keeps its exact-line-equality semantics.
+returns compiled `(pattern, replacement)` pairs on the `regex_fixes` channel,
+applied by `_apply_fixes_to_file` through `pattern.subn()`. It is the **only**
+fix channel `_apply_fixes_to_file` takes — there is no literal `fixes`
+parameter, and no `new == ""` whole-line-delete sentinel.
 
 #### Gate 1: the migration-context hatch is document-scoped
 
@@ -160,14 +157,13 @@ nothing else; the channel contract is unchanged. The suppression callable is
 built inside `_apply_fixes_to_file`'s regex loop by `_make_stale_term_replacer`,
 which wraps that plain string.
 
-That placement is load-bearing, not stylistic. `_apply_fixes_to_file` applies the
-literal `fixes` list **first** (including `_detect_readme_broken_entries`'
-`new == ""` whole-line-delete sentinel) and only then runs the regex fixes over
-the already-mutated text. Any line index computed at detection time is stale the
-moment a line ahead of it disappears, and it fails **silently**: a
-plausible-looking wrong rewrite rather than an error, which is precisely the
-corruption class these gates exist to close. The callable instead re-derives
-context from `match.string` (the text currently being rewritten) and
+That placement is load-bearing, not stylistic. `_apply_fixes_to_file`'s regex
+loop applies its fixes in sequence over the same `new_text`, mutating it after
+each one, so any line index computed once against the pre-loop `content` goes
+stale the moment an earlier fix changes what precedes it — and it fails
+**silently**: a plausible-looking wrong rewrite rather than an error, which is
+precisely the corruption class these gates exist to close. The callable instead
+re-derives context from `match.string` (the text currently being rewritten) and
 `match.start()` (the live offset into it), so there is no index to go stale.
 
 Keeping the callable local also keeps `_reject` receiving the replacement
@@ -234,19 +230,17 @@ symmetrically and pre-existing references are never re-validated. Measured
 self-baselining over `docs/features/*.md` (narrow `+` arm versus shipped `*` arm
 in one run), the widening produces **zero** new withholds.
 
-#### Why the sibling patterns stay narrower
+#### Why the detector pattern stays narrower
 
-`_detect_renamed_symbol_fixes` and `_detect_deleted_target_issues` each carry
-their own `` `((?:[\w.-]+/)+[\w.-]+\.py)` `` pattern that still *requires* a
-directory segment. The asymmetry with `_PATH_REF_RE` is deliberate, and a
-comment at each site records why.
+`_detect_deleted_target_issues` carries its own `` `((?:[\w.-]+/)+[\w.-]+\.py)` ``
+pattern that still *requires* a directory segment. The asymmetry with
+`_PATH_REF_RE` is deliberate, and a comment at the site records why.
 
-Those two are **detector** patterns, governing what the auditor *proposes*.
-`_PATH_REF_RE` is the only one of the three on the write path. Widening the
-detectors enlarges the candidate set and spends the `GIT_LOG_FOLLOW_CAP` per-run
-`git log --follow` budget and the per-run issue cap on bare names that are not
-resolvable to a single path anyway. That is a scope and volume change with its
-own failure modes, not a safety fix.
+`_detect_deleted_target_issues` is a **detector** pattern, governing what the
+auditor *reports*. `_PATH_REF_RE` is the only one of the two on the write path.
+Widening the detector enlarges the candidate set and spends the per-run issue
+cap on bare names that are not resolvable to a single path anyway. That is a
+scope and volume change with its own failure modes, not a safety fix.
 
 - **Attributed per term, not per occurrence.** Only the offending fix is
   dropped; valid sibling fixes in the same file still apply, and the file is
@@ -260,9 +254,11 @@ own failure modes, not a safety fix.
   pre-existing prose that names a long-gone module. The residual hole: if a
   doc already mentions an absent path somewhere, that path is in the original
   reference set, so a fix that rewrites a *valid* path into that same absent
-  one passes the invariant. No live instance is known; the reachable route to
-  it is the rename-target selection defect tracked as **#2725**, and closing it
-  requires span-level (rather than document-level) attribution.
+  one passes the invariant. No live instance is known, and there is no known
+  reachable route to it: the sole detector left on the write path
+  (`_detect_stale_term_fixes`) proposes replacements from a fixed, curated
+  dictionary, not from a query that could ever select an absent path as a
+  rewrite target.
 - **Rejections are reported, not silently discarded.** Each one logs a warning
   naming the offending path and lands in the result contract.
 - **An all-rejected run writes nothing** — no file write, therefore no empty
@@ -275,9 +271,9 @@ Rejected fixes surface on the `audit()` result:
 | `fixes_withheld` | `int` | count of fixes rejected by the existence invariant |
 | `withheld` | `list[dict]` | one entry per rejection: `{"doc", "old", "new", "reason"}`, `reason` = `"target-absent"` |
 
-`old` is whatever the emitting channel matched on: a literal string for the
-three rename detectors, but the **regex source** for a stale-term rejection
-(`\bsession_log\b`, not `session_log`). A caller that echoes `old` verbatim —
+`old` is always the **regex source** of the withheld stale-term fix
+(`\bsession_log\b`, not `session_log`) — there is no other channel left to
+emit a literal string. A caller that echoes `old` verbatim —
 `.claude/skill-context/do-docs.md` does — will show the pattern, which is the
 accurate thing to show, since that is what was withheld.
 
@@ -310,7 +306,7 @@ cascade.
 
 | Detector | What it catches | Action |
 |----------|-----------------|--------|
-| Deleted target | `` `path.py` `` references with no rename in history, after placeholder / fenced-block / deletion-heading filtering | `gh issue create` (deduped) |
+| Deleted target | `` `path.py` `` references to a target absent from the working tree, after placeholder / fenced-block / deletion-heading filtering | `gh issue create` (deduped) |
 | Stub doc | Docs with <5 content lines | `gh issue create` (deduped) |
 | Orphan plan | `docs/plans/*.md` lacking a tracking-issue link | `gh issue create` (deduped) |
 
@@ -541,15 +537,22 @@ asserts `DEFAULT_VAULT_WEIGHT`, `vault_weight`, and `_vault_field` are gone.
 
 The four gates are covered by `TestStaleTermDictionary` (cue tiers across
 backticked, cased, alias, and arrow forms; the channel stays
-`(re.Pattern, str)`), `TestStaleTermWordBoundary` (path-token suppression, and a
-`README.md` fixture where an earlier line is deleted by the `new == ""` sentinel
-before a later stale term is evaluated, the case detection-time indices fail
-silently), `TestExistenceInvariant` (bare-name withhold, doc-relative
-resolution, ambiguous-but-present pass, no re-validation of pre-existing refs),
-and `TestWithheldBlocksAutoMerge` (a bare-name withhold reaching the PR body,
-Telegram, and liveness). `TestWithheldRateNonRegression` self-baselines the
-narrow and widened `_PATH_REF_RE` arms in one run inside a disposable detached
-`git worktree`, asserting the widening adds no withholds.
+`(re.Pattern, str)`), `TestStaleTermWordBoundary` (path-token suppression, and
+`test_suppression_survives_an_earlier_shortening_fix`, a fixture with two regex
+fixes where the first shortens the text ahead of the second's match, proving
+context is derived at match time rather than from a stale detection-time
+index), `TestExistenceInvariant` (bare-name withhold, doc-relative resolution,
+ambiguous-but-present pass, no re-validation of pre-existing refs — every case
+is expressed as a prose-anchored regex fix whose *replacement*, not its match,
+carries the path-shaped string, so gate 3's path-token suppression cannot eat
+the case before the invariant runs), and `TestWithheldBlocksAutoMerge` (a
+bare-name withhold reaching the PR body, Telegram, and liveness).
+`TestWithheldRateNonRegression` self-baselines the narrow and widened
+`_PATH_REF_RE` arms in one run inside a disposable detached `git worktree`,
+asserting the widening adds no withholds. `TestDeletedTargetFiltering::
+test_rename_destination_reference_is_reported` runs on a real git checkout
+(commit, `git mv`, delete) and asserts a reference to a former rename
+destination is now reported rather than suppressed.
 
 ```bash
 pytest tests/unit/test_docs_auditor_substrate.py -v

--- a/docs/features/docs-auditor.md
+++ b/docs/features/docs-auditor.md
@@ -169,9 +169,12 @@ stale.
 The two gates differ in how urgently they need that placement, and the difference
 is worth stating precisely.
 
-**Gate 2 is not currently reachable.** `_is_documented_deletion` consumes a *line
-index*, derived as `text.count("\n", 0, match.start())`, so only a substitution
-that changes the *newline* count can stale it. `_detect_stale_term_fixes` is the
+**Gate 2's placement is not load-bearing today.** The gate itself fires on every
+run — it is what suppresses stale terms inside fenced code blocks — and only its
+apply-time *placement* is currently unexercised, because nothing today can stale
+the position it consumes. `_is_documented_deletion` takes a *line index*, derived
+as `text.count("\n", 0, match.start())`, so only a substitution that changes the
+*newline* count can stale it. `_detect_stale_term_fixes` is the
 sole fix producer and every `STALE_TERMS` replacement is newline-free
 (`SessionLog`->`AgentSession`, `RedisJob`->`AgentSession`,
 `session_log`->`agent_session`, `redis_job`->`agent_session`), so applying one
@@ -179,13 +182,15 @@ shifts byte offsets but never line indices. Gate 2's apply-time placement is
 forward-looking robustness, for `STALE_TERMS` entries an operator may add later
 that shorten text or span newlines.
 
-**Gate 3 has no such reprieve — it is guarding a live corruption today.**
+**Gate 3 has no such reprieve — hoisting it would corrupt docs today.**
 `_match_inside_path_token` consumes raw byte offsets (`match.start()`,
 `match.end()`) rather than a line index, and the apply loop reassigns
 `new_text = candidate` after each fix. Every shipped replacement is strictly
 *longer* than its key, so each applied fix shifts the offsets of every later
-match — precisely *because* of the property that spares gate 2. Concretely: a doc
-containing the prose word `SessionLog` and the path token
+match. Length and newline-freeness are orthogonal properties, not cause and
+effect: newline-freeness is what spares gate 2, strictly-longer is what dooms
+gate 3, and an equal-length newline-free replacement would spare both.
+Concretely: a doc containing the prose word `SessionLog` and the path token
 `models/session_log.py` queues fixes in `STALE_TERMS` order, so the `SessionLog`
 fix lengthens the text ahead of the `session_log` match; a detection-time offset
 map would mis-locate that match, gate 3 would fail to suppress, and

--- a/docs/features/docs-auditor.md
+++ b/docs/features/docs-auditor.md
@@ -157,14 +157,25 @@ nothing else; the channel contract is unchanged. The suppression callable is
 built inside `_apply_fixes_to_file`'s regex loop by `_make_stale_term_replacer`,
 which wraps that plain string.
 
-That placement is load-bearing, not stylistic. `_apply_fixes_to_file`'s regex
-loop applies its fixes in sequence over the same `new_text`, mutating it after
-each one, so any line index computed once against the pre-loop `content` goes
-stale the moment an earlier fix changes what precedes it — and it fails
-**silently**: a plausible-looking wrong rewrite rather than an error, which is
-precisely the corruption class these gates exist to close. The callable instead
-re-derives context from `match.string` (the text currently being rewritten) and
-`match.start()` (the live offset into it), so there is no index to go stale.
+That placement is forward-looking robustness, not stylistic.
+`_apply_fixes_to_file`'s regex loop applies its fixes in sequence over the same
+`new_text`, mutating it after each one, so any line index computed once against
+the pre-loop `content` would go stale the moment an earlier fix changed what
+precedes it — and it would fail **silently**: a plausible-looking wrong rewrite
+rather than an error. The callable instead re-derives context from `match.string`
+(the text currently being rewritten) and `match.start()` (the live offset into
+it), so there is no index to go stale.
+
+No shipped fix can trigger that failure today. `_detect_stale_term_fixes` is the
+sole fix producer, and since `line_idx` is derived as `text.count("\n", 0,
+match.start())`, only a substitution that changes the *newline* count can shift a
+later fix's line index. Every `STALE_TERMS` replacement is newline-free and
+strictly longer than its key (`SessionLog`->`AgentSession`,
+`RedisJob`->`AgentSession`, `session_log`->`agent_session`,
+`redis_job`->`agent_session`), so applying one shifts byte offsets but never line
+indices. The apply-time placement exists for `STALE_TERMS` entries an operator may
+add later, which may shorten text or span newlines; it is not guarding a
+currently-reachable corruption.
 
 Keeping the callable local also keeps `_reject` receiving the replacement
 *string*, so a withheld record stays readable in the PR body, the findings

--- a/docs/features/docs-auditor.md
+++ b/docs/features/docs-auditor.md
@@ -179,8 +179,9 @@ sole fix producer and every `STALE_TERMS` replacement is newline-free
 (`SessionLog`->`AgentSession`, `RedisJob`->`AgentSession`,
 `session_log`->`agent_session`, `redis_job`->`agent_session`), so applying one
 shifts byte offsets but never line indices. Gate 2's apply-time placement is
-forward-looking robustness, for `STALE_TERMS` entries an operator may add later
-that shorten text or span newlines.
+forward-looking robustness, for a `STALE_TERMS` entry an operator may add later
+whose key or replacement spans a newline — the only shape that can change the
+newline count ahead of a later match.
 
 **Gate 3 has no such reprieve — hoisting it would corrupt docs today.**
 `_match_inside_path_token` consumes raw byte offsets (`match.start()`,

--- a/docs/features/docs-auditor.md
+++ b/docs/features/docs-auditor.md
@@ -157,25 +157,41 @@ nothing else; the channel contract is unchanged. The suppression callable is
 built inside `_apply_fixes_to_file`'s regex loop by `_make_stale_term_replacer`,
 which wraps that plain string.
 
-That placement is forward-looking robustness, not stylistic.
-`_apply_fixes_to_file`'s regex loop applies its fixes in sequence over the same
-`new_text`, mutating it after each one, so any line index computed once against
-the pre-loop `content` would go stale the moment an earlier fix changed what
-precedes it — and it would fail **silently**: a plausible-looking wrong rewrite
-rather than an error. The callable instead re-derives context from `match.string`
-(the text currently being rewritten) and `match.start()` (the live offset into
-it), so there is no index to go stale.
+That placement is load-bearing, not stylistic. `_apply_fixes_to_file`'s regex
+loop applies its fixes in sequence over the same `new_text`, mutating it after
+each one, so any position computed once against the pre-loop `content` goes stale
+the moment an earlier fix changes what precedes it — and it fails **silently**: a
+plausible-looking wrong rewrite rather than an error. The callable instead
+re-derives context from `match.string` (the text currently being rewritten) and
+`match.start()` (the live offset into it), so there is no stored position to go
+stale.
 
-No shipped fix can trigger that failure today. `_detect_stale_term_fixes` is the
-sole fix producer, and since `line_idx` is derived as `text.count("\n", 0,
-match.start())`, only a substitution that changes the *newline* count can shift a
-later fix's line index. Every `STALE_TERMS` replacement is newline-free and
-strictly longer than its key (`SessionLog`->`AgentSession`,
-`RedisJob`->`AgentSession`, `session_log`->`agent_session`,
-`redis_job`->`agent_session`), so applying one shifts byte offsets but never line
-indices. The apply-time placement exists for `STALE_TERMS` entries an operator may
-add later, which may shorten text or span newlines; it is not guarding a
-currently-reachable corruption.
+The two gates differ in how urgently they need that placement, and the difference
+is worth stating precisely.
+
+**Gate 2 is not currently reachable.** `_is_documented_deletion` consumes a *line
+index*, derived as `text.count("\n", 0, match.start())`, so only a substitution
+that changes the *newline* count can stale it. `_detect_stale_term_fixes` is the
+sole fix producer and every `STALE_TERMS` replacement is newline-free
+(`SessionLog`->`AgentSession`, `RedisJob`->`AgentSession`,
+`session_log`->`agent_session`, `redis_job`->`agent_session`), so applying one
+shifts byte offsets but never line indices. Gate 2's apply-time placement is
+forward-looking robustness, for `STALE_TERMS` entries an operator may add later
+that shorten text or span newlines.
+
+**Gate 3 has no such reprieve — it is guarding a live corruption today.**
+`_match_inside_path_token` consumes raw byte offsets (`match.start()`,
+`match.end()`) rather than a line index, and the apply loop reassigns
+`new_text = candidate` after each fix. Every shipped replacement is strictly
+*longer* than its key, so each applied fix shifts the offsets of every later
+match — precisely *because* of the property that spares gate 2. Concretely: a doc
+containing the prose word `SessionLog` and the path token
+`models/session_log.py` queues fixes in `STALE_TERMS` order, so the `SessionLog`
+fix lengthens the text ahead of the `session_log` match; a detection-time offset
+map would mis-locate that match, gate 3 would fail to suppress, and
+`models/session_log.py` would be rewritten to `models/agent_session.py` — the
+corruption described below that the existence invariant provably cannot catch,
+because both files exist. Do not hoist the path-token decision to detection time.
 
 Keeping the callable local also keeps `_reject` receiving the replacement
 *string*, so a withheld record stays readable in the PR body, the findings

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -68,7 +68,6 @@ VAULT_SITE_MAPPING: dict[str, tuple[str, str | None]] = {
 # Hard caps and tunables.
 NEIGHBORHOOD_CAP = 20
 VAULT_DRIFT_ISSUE_CAP = 5
-GIT_LOG_FOLLOW_CAP = 10
 LOCK_TTL_SECONDS = 3600
 SWEEPER_LOCK_TTL_SECONDS = 1800
 STUB_DOC_LINE_THRESHOLD = 5
@@ -367,140 +366,6 @@ def _resolve_pr_changed_files(repo_root: Path) -> list[Path]:
 # ---------------------------------------------------------------------------
 
 
-_RENAME_QUERY_COUNT = 0
-
-
-def _git_log_follow_renames(old_path: str, repo_root: Path) -> list[tuple[str, str]]:
-    """Use ``git log --follow`` to find renames. Capped to GIT_LOG_FOLLOW_CAP per run.
-
-    Returns list of (old_name, new_name) tuples.
-    """
-    global _RENAME_QUERY_COUNT
-    if _RENAME_QUERY_COUNT >= GIT_LOG_FOLLOW_CAP:
-        logger.warning(
-            f"docs_auditor: git log --follow cap ({GIT_LOG_FOLLOW_CAP}) reached, "
-            f"skipping rename detection for {old_path}"
-        )
-        return []
-    _RENAME_QUERY_COUNT += 1
-
-    try:
-        result = subprocess.run(
-            [
-                "git",
-                "log",
-                "--follow",
-                "--diff-filter=R",
-                "--name-status",
-                "--format=",
-                "--",
-                old_path,
-            ],
-            capture_output=True,
-            text=True,
-            timeout=settings.timeouts.git_subprocess_s,
-            cwd=str(repo_root),
-        )
-        renames: list[tuple[str, str]] = []
-        for line in result.stdout.splitlines():
-            line = line.strip()
-            if not line.startswith("R"):
-                continue
-            parts = line.split("\t")
-            if len(parts) >= 3:
-                renames.append((parts[1], parts[2]))
-        return renames
-    except Exception as e:
-        logger.warning(f"docs_auditor: git log --follow failed for {old_path}: {e}")
-        return []
-
-
-def _detect_renamed_link_fixes(
-    doc_path: Path, content: str, repo_root: Path
-) -> list[tuple[str, str]]:
-    """Detect markdown link targets whose path was renamed.
-
-    Returns list of (old_text, new_text) replacements.
-    """
-    fixes: list[tuple[str, str]] = []
-    for m in re.finditer(r"\[[^\]]+\]\(([^)]+\.md)\)", content):
-        target = m.group(1).strip()
-        # Resolve target absolute path; skip URLs
-        if target.startswith(("http://", "https://", "#")):
-            continue
-        target_path = (
-            (doc_path.parent / target).resolve() if not target.startswith("/") else Path(target)
-        )
-        try:
-            rel = target_path.relative_to(repo_root.resolve())
-        except ValueError:
-            continue
-        if (repo_root / rel).exists():
-            continue
-        # Try rename detection
-        renames = _git_log_follow_renames(str(rel), repo_root)
-        if renames:
-            new_name = renames[0][1]
-            fixes.append((target, new_name))
-    return fixes
-
-
-def _detect_renamed_symbol_fixes(content: str, repo_root: Path) -> list[tuple[str, str]]:
-    """Detect Python symbol/file references that were renamed.
-
-    Looks for backtick-wrapped paths like ``foo/bar.py``. If the path no
-    longer exists but git history shows a rename, queue a replacement.
-    """
-    fixes: list[tuple[str, str]] = []
-    # Deliberately narrower than `_PATH_REF_RE`, which was widened to `*` for #2759.
-    # This is a *detector* pattern governing what the auditor proposes, not the write
-    # path the existence invariant guards. Widening it to bare names enlarges the
-    # candidate set and spends the GIT_LOG_FOLLOW_CAP per-run `git log --follow`
-    # budget on names that resolve to no single path anyway — a scope and volume
-    # change with its own failure modes, not a safety fix. Ruled unchanged in #2759.
-    for m in re.finditer(r"`((?:[\w.-]+/)+[\w.-]+\.py)`", content):
-        path = m.group(1)
-        if (repo_root / path).exists():
-            continue
-        renames = _git_log_follow_renames(path, repo_root)
-        if renames and renames[0][1] != path:
-            fixes.append((path, renames[0][1]))
-    return fixes
-
-
-def _detect_readme_broken_entries(
-    readme_path: Path, content: str, repo_root: Path
-) -> list[tuple[str, str]]:
-    """Detect README index entries whose target file is gone.
-
-    Returns list of (old_line, replacement_or_empty) tuples. An empty
-    replacement signals deletion of the line.
-    """
-    fixes: list[tuple[str, str]] = []
-    for line in content.splitlines():
-        m = re.search(r"\(([^)]+\.md)\)", line)
-        if not m:
-            continue
-        target = m.group(1).strip()
-        if target.startswith(("http://", "https://", "#")):
-            continue
-        target_path = (readme_path.parent / target).resolve()
-        try:
-            rel = target_path.relative_to(repo_root.resolve())
-        except ValueError:
-            continue
-        if (repo_root / rel).exists():
-            continue
-        # Broken entry — try rename, otherwise delete the line
-        renames = _git_log_follow_renames(str(rel), repo_root)
-        if renames:
-            new_target = renames[0][1]
-            fixes.append((target, new_target))
-        else:
-            fixes.append((line, ""))
-    return fixes
-
-
 def _normalize_prose(text: str | None) -> str:
     """Lowercase, strip backticks, and collapse whitespace — for cue matching only.
 
@@ -627,18 +492,18 @@ def _detect_stale_term_fixes(content: str) -> list[tuple[re.Pattern[str], str]]:
     context in real prose sits in a different sentence from the term it explains.
     Do not "improve" this into a per-occurrence rule.
 
-    Two further gates live at apply time rather than here, because the literal
-    ``fixes`` loop runs first and can delete lines out from under any index
-    computed against ``content``: fence/heading/deletion-prose suppression (via
-    ``_build_line_context`` / ``_is_documented_deletion``) and path-token
-    suppression. See ``_apply_fixes_to_file``.
+    Two further gates live at apply time rather than here, because the apply
+    loop rewrites the text across iterations and can shift or remove content out
+    from under any index computed against ``content``: fence/heading/
+    deletion-prose suppression (via ``_build_line_context`` /
+    ``_is_documented_deletion``) and path-token suppression. See
+    ``_apply_fixes_to_file``.
 
     Returns fixes on the regex channel — ``(compiled_pattern, replacement)`` —
-    so detection and application share one matching semantics. These are passed
-    to ``_apply_fixes_to_file`` as ``regex_fixes``, never mixed into the literal
-    ``fixes`` list (which carries the ``new == ""`` line-delete sentinel). The
-    replacement stays a plain ``str``; the suppression callable is built at the
-    apply site so the withheld record and this channel's contract stay intact.
+    so detection and application share one matching semantics. This is
+    ``_apply_fixes_to_file``'s only fix channel. The replacement stays a plain
+    ``str``; the suppression callable is built at the apply site so the withheld
+    record and this channel's contract stay intact.
     """
     normalized = _normalize_prose(content)
     fixes: list[tuple[re.Pattern[str], str]] = []
@@ -785,11 +650,11 @@ def _make_stale_term_replacer(replacement: str, suppressed: list[int]) -> Callab
 
     Context is re-derived from ``match.string`` — the text *currently being
     rewritten* — and ``match.start()``, the live offset into it. That is the whole
-    point: ``_apply_fixes_to_file`` applies the literal ``fixes`` list first,
-    including ``_detect_readme_broken_entries``' ``new == ""`` whole-line-delete
-    sentinel, so any line index computed at detection time is stale the moment a
-    line ahead of it disappears — and it fails *silently*, producing a plausible
-    wrong rewrite rather than an error. There is no index here to go stale.
+    point: ``_apply_fixes_to_file``'s regex loop mutates ``new_text`` across
+    iterations, so an index computed against the pre-loop ``content`` is already
+    stale for every fix after the first — and it fails *silently*, producing a
+    plausible wrong rewrite rather than an error. There is no index here to go
+    stale.
 
     A suppressed match returns ``match.group(0)`` unchanged, but ``subn`` still
     counts it, so each suppression is recorded in ``suppressed`` for the caller to
@@ -825,23 +690,21 @@ def _make_stale_term_replacer(replacement: str, suppressed: list[int]) -> Callab
 def _apply_fixes_to_file(
     path: Path,
     repo_root: Path,
-    fixes: list[tuple[str, str]],
-    regex_fixes: list[tuple[re.Pattern[str], str]] | None = None,
+    regex_fixes: list[tuple[re.Pattern[str], str]],
 ) -> tuple[int, list[dict]]:
     """Apply text replacements to a file, subject to the existence invariant.
 
-    ``fixes`` are literal ``(old, new)`` pairs; ``new == ""`` deletes the whole
-    line that exactly equals ``old``. ``regex_fixes`` are ``(pattern, replacement)``
-    pairs applied via ``pattern.subn()`` in their own loop.
+    ``regex_fixes`` — ``(pattern, replacement)`` pairs applied via
+    ``pattern.subn()`` — are the auditor's single fix channel.
 
-    **Apply-time suppression (regex fixes only, #2744):** each regex fix's plain
-    ``str`` replacement is wrapped in a locally-built callable
-    (``_make_stale_term_replacer``) that leaves a match untouched when it sits in
-    a fenced code block, under a deletion-recording heading, next to deletion
-    prose, or inside a file-path token. The literal ``fixes`` loop runs *first*
-    and its ``new == ""`` sentinel deletes whole lines, so this context must be —
-    and is — derived from the live, already-mutated text at match time rather
-    than from any index computed at detection time.
+    **Apply-time suppression (#2744):** each fix's plain ``str`` replacement is
+    wrapped in a locally-built callable (``_make_stale_term_replacer``) that
+    leaves a match untouched when it sits in a fenced code block, under a
+    deletion-recording heading, next to deletion prose, or inside a file-path
+    token. The loop rewrites ``new_text`` in place across iterations, so an index
+    computed against the pre-loop text is stale for every fix after the first;
+    this context must be — and is — derived from the live, already-mutated text
+    at match time rather than from any index computed at detection time.
 
     **Existence invariant:** a fix may not introduce a ``file.{py,md}``-shaped
     reference — bare or ``dir/``-prefixed (#2759) — that does not exist under
@@ -852,9 +715,8 @@ def _apply_fixes_to_file(
     Returns ``(applied_count, withheld)`` where ``withheld`` is a list of
     ``{"doc", "old", "new", "reason"}`` dicts.
     """
-    regex_fixes = regex_fixes or []
     full = repo_root / path
-    if not full.exists() or (not fixes and not regex_fixes):
+    if not full.exists() or not regex_fixes:
         return 0, []
     try:
         text = full.read_text(encoding="utf-8", errors="replace")
@@ -876,32 +738,6 @@ def _apply_fixes_to_file(
             ", ".join(absent),
         )
         withheld.append({"doc": str(path), "old": old, "new": new, "reason": "target-absent"})
-
-    for old, new in fixes:
-        if not old:
-            continue
-        if new == "":
-            # Delete the entire line that exactly equals `old` (after stripping trailing newline).
-            # Substring match would risk collateral deletion when `old` happens to appear
-            # inside an unrelated line.
-            lines = new_text.splitlines(keepends=True)
-            kept = [ln for ln in lines if ln.rstrip("\n\r") != old.rstrip("\n\r")]
-            count = len(lines) - len(kept)
-            if count == 0:
-                continue
-            candidate = "".join(kept)
-        else:
-            if old not in new_text:
-                continue
-            count = new_text.count(old)
-            candidate = new_text.replace(old, new)
-
-        absent = _absent_new_path_refs(original_refs, candidate, repo_root, path)
-        if absent:
-            _reject(old, new, absent)
-            continue
-        new_text = candidate
-        applied += count
 
     for pattern, new in regex_fixes:
         suppressed: list[int] = []
@@ -1038,7 +874,7 @@ def _is_documented_deletion(
 
 
 def _detect_deleted_target_issues(doc_path: Path, content: str, repo_root: Path) -> list[dict]:
-    """File issues for references to deleted (non-renamed) targets.
+    """File issues for references to deleted targets.
 
     Suppresses three classes of false positive before emitting a finding:
     placeholder/example paths (``foo/bar.py``), paths inside fenced illustrative
@@ -1048,11 +884,12 @@ def _detect_deleted_target_issues(doc_path: Path, content: str, repo_root: Path)
     findings: list[dict] = []
     lines = content.splitlines()
     in_fence, heading_for_line = _build_line_context(content)
-    # Deliberately narrower than `_PATH_REF_RE` (widened to `*` for #2759), for the
-    # same reason as `_detect_renamed_symbol_fixes`: this is a detector pattern
-    # governing what the auditor *proposes*, not the write path. Widening it would
-    # spend the per-run issue cap on bare names not resolvable to a single path.
-    # Ruled unchanged in #2759.
+    # Deliberately narrower than `_PATH_REF_RE`, which was widened to `*` for #2759.
+    # The asymmetry is intentional: `_PATH_REF_RE` guards the *write* path, where a
+    # bare name that resolves to nothing is a corruption the existence invariant must
+    # catch, while this is a *detector* pattern governing what the auditor proposes to
+    # a human. Widening it would spend the per-run issue cap on bare names not
+    # resolvable to a single path. Ruled unchanged in #2759.
     for m in re.finditer(r"`((?:[\w.-]+/)+[\w.-]+\.py)`", content):
         path = m.group(1)
         if _is_placeholder_path(path):
@@ -1072,9 +909,6 @@ def _detect_deleted_target_issues(doc_path: Path, content: str, repo_root: Path)
             )
             continue
         if (repo_root / path).exists():
-            continue
-        renames = _git_log_follow_renames(path, repo_root)
-        if renames:
             continue
         findings.append(
             {
@@ -1356,8 +1190,6 @@ def audit(
         Dict with ``status``, ``files_touched``, ``fixes_applied``,
         ``issues_filed``, ``pr_url``.
     """
-    global _RENAME_QUERY_COUNT
-    _RENAME_QUERY_COUNT = 0  # reset per-run cap
     # The bare-name existence oracle is a per-*run* snapshot: a long-lived process
     # must not answer from an index built before the last commit (#2759).
     _BASENAME_INDEX_CACHE.clear()
@@ -1408,25 +1240,16 @@ def audit(
         except Exception:
             continue
 
-        # Auto-fix detectors
-        fixes: list[tuple[str, str]] = []
-        if path.name == "README.md":
-            fixes.extend(_detect_readme_broken_entries(path, content, root))
-        else:
-            fixes.extend(_detect_renamed_link_fixes(path, content, root))
-            fixes.extend(_detect_renamed_symbol_fixes(content, root))
-        # Anchored stale terms travel on their own homogeneous channel — a
-        # compiled pattern must never land in the literal `fixes` list.
+        # Auto-fix detectors — anchored stale terms are the only fix channel.
         regex_fixes = _detect_stale_term_fixes(content)
 
-        # Apply-mode writes are markdown-only (#2058). The detectors above are
-        # markdown-regex based (bare-term renames, backtick link/symbol fixes),
-        # so a committed non-.md file that lands in the same PR — e.g. a
-        # site/*.html doc page — must never be auto-rewritten inside tags,
-        # attributes, or inline <script>. Reporting still runs; only the
-        # write-back is guarded.
-        if (fixes or regex_fixes) and apply_mode == "apply" and str(path).endswith(".md"):
-            applied, rejected = _apply_fixes_to_file(path, root, fixes, regex_fixes=regex_fixes)
+        # Apply-mode writes are markdown-only (#2058). The detector above is
+        # markdown-regex based (bare-term renames), so a committed non-.md file
+        # that lands in the same PR — e.g. a site/*.html doc page — must never be
+        # auto-rewritten inside tags, attributes, or inline <script>. Reporting
+        # still runs; only the write-back is guarded.
+        if regex_fixes and apply_mode == "apply" and str(path).endswith(".md"):
+            applied, rejected = _apply_fixes_to_file(path, root, regex_fixes)
             withheld.extend(rejected)
             if applied > 0:
                 total_fixes += applied

--- a/tests/README.md
+++ b/tests/README.md
@@ -269,7 +269,7 @@ tests/
 
 | Level | File | Tests | Description |
 |-------|------|------:|-------------|
-| unit | `test_docs_auditor_substrate.py` | 62 | Documentation reference validation |
+| unit | `test_docs_auditor_substrate.py` | 131 | Documentation reference validation |
 | unit | `test_features_readme_sort.py` | 27 | README table sorting |
 | unit | `test_verification_parser.py` | 20 | Verification section parsing |
 | unit | `test_validate_test_impact.py` | 20 | Test impact section validation |

--- a/tests/README.md
+++ b/tests/README.md
@@ -269,7 +269,7 @@ tests/
 
 | Level | File | Tests | Description |
 |-------|------|------:|-------------|
-| unit | `test_docs_auditor_substrate.py` | 131 | Documentation reference validation |
+| unit | `test_docs_auditor_substrate.py` | 130 | Documentation reference validation |
 | unit | `test_features_readme_sort.py` | 27 | README table sorting |
 | unit | `test_verification_parser.py` | 20 | Verification section parsing |
 | unit | `test_validate_test_impact.py` | 20 | Test impact section validation |

--- a/tests/unit/test_docs_auditor_substrate.py
+++ b/tests/unit/test_docs_auditor_substrate.py
@@ -730,8 +730,8 @@ class TestStaleTermWordBoundary:
         The shortening regex here is a *synthetic* stand-in for a ``STALE_TERMS``
         shape that does not exist today: every current replacement is newline-free
         and strictly longer than its key, so no production fix can shift a later
-        fix's *line index*. This test guards the forward-looking case, for operator
-        entries that shorten text or span newlines.
+        fix's *line index*. This test guards the forward-looking case, for an
+        operator entry whose key or replacement spans a newline.
 
         That reprieve is specific to the line-index gate. The path-token gate
         consumes raw byte offsets, which every shipped replacement already shifts

--- a/tests/unit/test_docs_auditor_substrate.py
+++ b/tests/unit/test_docs_auditor_substrate.py
@@ -726,6 +726,12 @@ class TestStaleTermWordBoundary:
         of the fenced ``SessionLog`` line, conclude "not in a fence", and rewrite
         inside the illustrative block. It would do so silently, never raising —
         hence the assertion is on the resulting file content.
+
+        The shortening regex here is a *synthetic* stand-in for a ``STALE_TERMS``
+        shape that does not exist today: every current replacement is newline-free
+        and strictly longer than its key, so no production fix can shift a later
+        fix's line index. This test guards the forward-looking case, for operator
+        entries that shorten text or span newlines.
         """
         doc = repo / "docs" / "features" / "ctx.md"
         original = (
@@ -949,26 +955,11 @@ class TestExistenceInvariant:
         assert withheld == []
         assert "vanished_module.py" in p.read_text()
 
-    def test_regex_channel_is_also_guarded(self, repo):
-        # The fixture's match must sit in ordinary prose, NOT inside a path token:
-        # path-token suppression (#2744) refuses an in-token rewrite before the
-        # existence invariant ever sees it, so a fixture like ``\breal\b`` over
-        # ``agent/real.py`` would withhold nothing and prove nothing here. Do not
-        # "simplify" this back to rewriting a word inside a path.
-        p = repo / "docs" / "features" / "regex_inv.md"
-        p.write_text("The runtime lives in the real handler.\n")
-        applied, withheld = docs_auditor._apply_fixes_to_file(
-            Path("docs/features/regex_inv.md"),
-            repo,
-            [(re.compile(r"\breal\b"), "agent/ghost.py")],
-        )
-        assert applied == 0
-        assert len(withheld) == 1
-        assert withheld[0]["reason"] == "target-absent"
-
     @pytest.mark.parametrize("body", ["", "   \n\t\n"])
     def test_empty_or_whitespace_doc_with_no_fixes_writes_nothing(self, repo, body):
-        """An empty ``regex_fixes`` list is the sole early-out condition now."""
+        """With the literal channel gone, an empty ``regex_fixes`` list is the only
+        fix-emptiness early-out.
+        """
         p = repo / "docs" / "features" / "empty.md"
         p.write_text(body)
         applied, withheld = docs_auditor._apply_fixes_to_file(

--- a/tests/unit/test_docs_auditor_substrate.py
+++ b/tests/unit/test_docs_auditor_substrate.py
@@ -49,14 +49,6 @@ def git_repo(repo: Path) -> Path:
     return repo
 
 
-@pytest.fixture(autouse=True)
-def reset_global_state():
-    """Reset module-level counters between tests."""
-    docs_auditor._RENAME_QUERY_COUNT = 0
-    yield
-    docs_auditor._RENAME_QUERY_COUNT = 0
-
-
 @pytest.fixture()
 def fake_redis():
     """Stand-in for the Popoto Redis connection."""
@@ -350,58 +342,6 @@ class TestAuthProbeDegradation:
     def test_check_embedding_auth_returns_true_when_set(self):
         with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}, clear=False):
             assert docs_auditor._check_embedding_auth() is True
-
-
-# ---------------------------------------------------------------------------
-# TestGitLogFollowCap
-# ---------------------------------------------------------------------------
-
-
-class TestGitLogFollowCap:
-    def test_cap_enforced_after_n_calls(self, repo: Path):
-        # Force the cap counter near the limit
-        docs_auditor._RENAME_QUERY_COUNT = docs_auditor.GIT_LOG_FOLLOW_CAP
-        result = docs_auditor._git_log_follow_renames("foo/bar.py", repo)
-        assert result == []
-
-    def test_subprocess_failure_returns_empty(self, repo: Path):
-        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("git", 10)):
-            result = docs_auditor._git_log_follow_renames("foo/bar.py", repo)
-        assert result == []
-
-
-# ---------------------------------------------------------------------------
-# TestRenamedSymbolFixesDegenerate — old==new rename hops must not fix
-# ---------------------------------------------------------------------------
-
-
-class TestRenamedSymbolFixesDegenerate:
-    """A rename history that loops back to the original path is a no-op.
-
-    `_apply_fixes_to_file` would otherwise treat a same-text replacement as a
-    real, successful fix and inflate `fixes_applied` on a run that changed
-    nothing.
-    """
-
-    def test_newest_rename_hop_equal_to_original_path_yields_no_fix(self, repo: Path):
-        content = "See `tests/unit/test_summarizer.py` for details.\n"
-        with patch.object(
-            docs_auditor,
-            "_git_log_follow_renames",
-            return_value=[("deadbeef", "tests/unit/test_summarizer.py")],
-        ):
-            fixes = docs_auditor._detect_renamed_symbol_fixes(content, repo)
-        assert fixes == []
-
-    def test_genuine_rename_hop_still_yields_a_fix(self, repo: Path):
-        content = "See `agent/old_name.py` for details.\n"
-        with patch.object(
-            docs_auditor,
-            "_git_log_follow_renames",
-            return_value=[("deadbeef", "agent/new_name.py")],
-        ):
-            fixes = docs_auditor._detect_renamed_symbol_fixes(content, repo)
-        assert fixes == [("agent/old_name.py", "agent/new_name.py")]
 
 
 # ---------------------------------------------------------------------------
@@ -742,7 +682,7 @@ class TestStaleTermWordBoundary:
 
         regex_fixes = docs_auditor._detect_stale_term_fixes(original)
         applied, withheld = docs_auditor._apply_fixes_to_file(
-            Path("docs/features/snap.md"), repo, [], regex_fixes=regex_fixes
+            Path("docs/features/snap.md"), repo, regex_fixes
         )
         assert applied == 0
         assert withheld == []
@@ -769,56 +709,57 @@ class TestStaleTermWordBoundary:
 
         regex_fixes = docs_auditor._detect_stale_term_fixes(original)
         applied, withheld = docs_auditor._apply_fixes_to_file(
-            Path("docs/features/fence.md"), repo, [], regex_fixes=regex_fixes
+            Path("docs/features/fence.md"), repo, regex_fixes
         )
         assert applied == 0
         assert withheld == []
         assert doc.read_text() == original
 
-    def test_suppression_survives_an_earlier_line_deletion(self, repo):
-        """Apply-time suppression must survive the literal loop's line deletes.
+    def test_suppression_survives_an_earlier_shortening_fix(self, repo):
+        """Apply-time suppression must survive an earlier fix shortening the text.
 
-        ``_apply_fixes_to_file`` runs the literal ``fixes`` list first, and
-        ``_detect_readme_broken_entries`` emits a ``new == ""`` whole-line-delete
-        sentinel. Any line index computed against the on-disk content is stale
-        the moment a line ahead of it disappears.
-
-        Here the broken index entry sits on an *earlier* line than the stale
-        term, so a detection-time index would suppress the wrong line and let
-        ``SessionLog`` be rewritten anyway. It would do so silently, never
-        raising — hence the assertion is on the resulting file content.
+        The regex loop rewrites ``new_text`` across iterations, so any line index
+        computed against the pre-loop content is stale for every fix after the
+        first. Here the first fix deletes three lines that sit *ahead* of a
+        fenced code block, shifting the fence up by three: a detection-time index
+        would read line 6 as the ordinary prose line ``Kept prose line.`` instead
+        of the fenced ``SessionLog`` line, conclude "not in a fence", and rewrite
+        inside the illustrative block. It would do so silently, never raising —
+        hence the assertion is on the resulting file content.
         """
-        readme = repo / "docs" / "features" / "README.md"
+        doc = repo / "docs" / "features" / "ctx.md"
         original = (
-            "# Feature Index\n"
+            "# Notes\n"
             "\n"
-            "- [Gone](gone.md)\n"
-            "- [Kept](kept.md)\n"
+            "Filler one.\n"
+            "Filler two.\n"
+            "Filler three.\n"
             "\n"
-            "The `SessionLog` model no longer exists.\n"
-            "It was superseded during the Popoto consolidation.\n"
+            "Kept prose line.\n"
+            "\n"
+            "```python\n"
+            "rows = SessionLog.objects.all()\n"
+            "```\n"
         )
-        readme.write_text(original)
-        (repo / "docs" / "features" / "kept.md").write_text("# Kept\n")
+        doc.write_text(original)
 
-        with patch.object(docs_auditor, "_git_log_follow_renames", return_value=[]):
-            literal_fixes = docs_auditor._detect_readme_broken_entries(readme, original, repo)
-        # The fixture is only meaningful if the delete sentinel really fired.
-        assert ("- [Gone](gone.md)", "") in literal_fixes
+        # Fix 1 shortens the document by exactly three lines...
+        shortening = (re.compile(r"Filler one\.\nFiller two\.\nFiller three\.\n"), "")
+        # ...ahead of fix 2's match, which must stay suppressed inside the fence.
+        stale = docs_auditor._detect_stale_term_fixes(original)
+        assert stale, "fixture must queue a stale-term fix for the fenced line"
 
-        regex_fixes = docs_auditor._detect_stale_term_fixes(original)
-        assert regex_fixes, "fixture must queue a stale-term fix for the later line"
-
-        docs_auditor._apply_fixes_to_file(
-            Path("docs/features/README.md"), repo, literal_fixes, regex_fixes=regex_fixes
+        applied, withheld = docs_auditor._apply_fixes_to_file(
+            Path("docs/features/ctx.md"), repo, [shortening, *stale]
         )
 
-        text = readme.read_text()
-        # The earlier broken entry is gone...
-        assert "- [Gone](gone.md)" not in text
-        assert "- [Kept](kept.md)" in text
+        text = doc.read_text()
+        assert (applied, withheld) == (1, [])
+        # The earlier lines are gone...
+        assert "Filler one." not in text
+        assert "Kept prose line." in text
         # ...and the later stale term is still correctly suppressed.
-        assert "`SessionLog` model no longer exists" in text
+        assert "rows = SessionLog.objects.all()" in text
         assert "AgentSession" not in text
 
 
@@ -831,7 +772,18 @@ class TestExistenceInvariant:
     @pytest.fixture()
     def doc(self, repo):
         p = repo / "docs" / "features" / "inv.md"
-        p.write_text("See `agent/real.py` and `agent/other.py`.\n")
+        # Every match anchor below is an ordinary PROSE word, never a path token.
+        # Path-token suppression (#2744) refuses an in-token rewrite *before* the
+        # existence invariant ever runs, so a fixture matching inside
+        # `agent/real.py` would yield `applied == 0` / `withheld == []` and prove
+        # nothing. The path-shaped string always travels as the *replacement*.
+        # Do not "simplify" these back into path-shaped patterns.
+        p.write_text(
+            "The real handler drives the loop.\n"
+            "The other helper wraps it.\n"
+            "A ghost adapter is planned.\n"
+            "The renamed shim is still referenced.\n"
+        )
         (repo / "agent").mkdir()
         (repo / "agent" / "real.py").write_text("")
         (repo / "agent" / "other.py").write_text("")
@@ -839,13 +791,13 @@ class TestExistenceInvariant:
 
     def test_fix_introducing_absent_path_is_rejected_and_reported(self, repo, doc):
         applied, withheld = docs_auditor._apply_fixes_to_file(
-            doc, repo, [("agent/real.py", "agent/ghost.py")]
+            doc, repo, [(re.compile(r"\breal\b"), "agent/ghost.py")]
         )
         assert applied == 0
         assert len(withheld) == 1
         assert withheld[0] == {
             "doc": str(doc),
-            "old": "agent/real.py",
+            "old": r"\breal\b",
             "new": "agent/ghost.py",
             "reason": "target-absent",
         }
@@ -853,7 +805,9 @@ class TestExistenceInvariant:
 
     def test_rejection_is_logged_with_offending_path(self, repo, doc, caplog):
         with caplog.at_level("WARNING", logger="reflections.docs_auditor"):
-            docs_auditor._apply_fixes_to_file(doc, repo, [("agent/real.py", "agent/ghost.py")])
+            docs_auditor._apply_fixes_to_file(
+                doc, repo, [(re.compile(r"\breal\b"), "agent/ghost.py")]
+            )
         assert any("agent/ghost.py" in r.getMessage() for r in caplog.records)
 
     def test_sibling_valid_fix_still_applies(self, repo, doc):
@@ -861,13 +815,16 @@ class TestExistenceInvariant:
         applied, withheld = docs_auditor._apply_fixes_to_file(
             doc,
             repo,
-            [("agent/real.py", "agent/ghost.py"), ("agent/other.py", "agent/renamed.py")],
+            [
+                (re.compile(r"\breal\b"), "agent/ghost.py"),
+                (re.compile(r"\bother\b"), "agent/renamed.py"),
+            ],
         )
         assert applied == 1
         assert len(withheld) == 1
         text = (repo / doc).read_text()
         assert "agent/renamed.py" in text
-        assert "agent/real.py" in text
+        assert "The real handler" in text
         assert "agent/ghost.py" not in text
 
     def test_all_fixes_rejected_writes_nothing(self, repo, doc):
@@ -876,7 +833,10 @@ class TestExistenceInvariant:
         applied, withheld = docs_auditor._apply_fixes_to_file(
             doc,
             repo,
-            [("agent/real.py", "agent/ghost.py"), ("agent/other.py", "agent/phantom.py")],
+            [
+                (re.compile(r"\breal\b"), "agent/ghost.py"),
+                (re.compile(r"\bother\b"), "agent/phantom.py"),
+            ],
         )
         assert applied == 0
         assert len(withheld) == 2
@@ -885,12 +845,11 @@ class TestExistenceInvariant:
 
     def test_preexisting_absent_path_is_never_revalidated(self, repo):
         p = repo / "docs" / "features" / "pre.md"
-        p.write_text("Legacy `agent/vanished.py` and `agent/real.py`.\n")
+        p.write_text("Legacy `agent/vanished.py` and the real handler.\n")
         (repo / "agent").mkdir()
-        (repo / "agent" / "real.py").write_text("")
         (repo / "agent" / "kept.py").write_text("")
         applied, withheld = docs_auditor._apply_fixes_to_file(
-            Path("docs/features/pre.md"), repo, [("agent/real.py", "agent/kept.py")]
+            Path("docs/features/pre.md"), repo, [(re.compile(r"\breal\b"), "agent/kept.py")]
         )
         assert applied == 1
         assert withheld == []
@@ -902,9 +861,10 @@ class TestExistenceInvariant:
 
     @pytest.fixture()
     def bare_doc(self, repo):
+        # Prose anchor again: ``\brunner\b`` matches the standalone word only —
+        # never inside a ``*.py`` token, where #2744 would suppress it first.
         p = repo / "docs" / "features" / "bare.md"
-        p.write_text("Runtime lives in `session_runner.py`.\n")
-        (repo / "docs" / "features" / "session_runner.py").write_text("")
+        p.write_text("The runtime lives in the runner module.\n")
         return Path("docs/features/bare.md")
 
     def test_fix_introducing_absent_bare_name_is_withheld(self, repo, bare_doc):
@@ -915,13 +875,13 @@ class TestExistenceInvariant:
         unconditionally — exactly the class that shipped as ``d7bf3ad99``.
         """
         applied, withheld = docs_auditor._apply_fixes_to_file(
-            bare_doc, repo, [("session_runner.py", "ghost_module.py")]
+            bare_doc, repo, [(re.compile(r"\brunner\b"), "ghost_module.py")]
         )
         assert applied == 0
         assert withheld == [
             {
                 "doc": str(bare_doc),
-                "old": "session_runner.py",
+                "old": r"\brunner\b",
                 "new": "ghost_module.py",
                 "reason": "target-absent",
             }
@@ -936,7 +896,7 @@ class TestExistenceInvariant:
         """
         (repo / "docs" / "features" / "headless_runner.py").write_text("")
         applied, withheld = docs_auditor._apply_fixes_to_file(
-            bare_doc, repo, [("session_runner.py", "headless_runner.py")]
+            bare_doc, repo, [(re.compile(r"\brunner\b"), "headless_runner.py")]
         )
         assert applied == 1
         assert withheld == []
@@ -951,8 +911,7 @@ class TestExistenceInvariant:
         """
         repo = git_repo
         doc = repo / "docs" / "features" / "amb.md"
-        doc.write_text("Runtime lives in `session_runner.py`.\n")
-        (repo / "docs" / "features" / "session_runner.py").write_text("")
+        doc.write_text("The runtime lives in the runner module.\n")
         for pkg in ("alpha", "beta"):
             (repo / pkg).mkdir()
             (repo / pkg / "shared_helper.py").write_text("")
@@ -961,7 +920,7 @@ class TestExistenceInvariant:
             applied, withheld = docs_auditor._apply_fixes_to_file(
                 Path("docs/features/amb.md"),
                 repo,
-                [("session_runner.py", "shared_helper.py")],
+                [(re.compile(r"\brunner\b"), "shared_helper.py")],
             )
 
         assert applied == 1
@@ -979,13 +938,12 @@ class TestExistenceInvariant:
         symmetrically and the 1557 newly-visible corpus refs cost zero withholds.
         """
         p = repo / "docs" / "features" / "pre_bare.md"
-        p.write_text("Legacy `vanished_module.py` and `session_runner.py`.\n")
-        (repo / "docs" / "features" / "session_runner.py").write_text("")
+        p.write_text("Legacy `vanished_module.py` and the runner module.\n")
         (repo / "docs" / "features" / "kept_module.py").write_text("")
         applied, withheld = docs_auditor._apply_fixes_to_file(
             Path("docs/features/pre_bare.md"),
             repo,
-            [("session_runner.py", "kept_module.py")],
+            [(re.compile(r"\brunner\b"), "kept_module.py")],
         )
         assert applied == 1
         assert withheld == []
@@ -1002,8 +960,7 @@ class TestExistenceInvariant:
         applied, withheld = docs_auditor._apply_fixes_to_file(
             Path("docs/features/regex_inv.md"),
             repo,
-            [],
-            regex_fixes=[(re.compile(r"\breal\b"), "agent/ghost.py")],
+            [(re.compile(r"\breal\b"), "agent/ghost.py")],
         )
         assert applied == 0
         assert len(withheld) == 1
@@ -1011,6 +968,7 @@ class TestExistenceInvariant:
 
     @pytest.mark.parametrize("body", ["", "   \n\t\n"])
     def test_empty_or_whitespace_doc_with_no_fixes_writes_nothing(self, repo, body):
+        """An empty ``regex_fixes`` list is the sole early-out condition now."""
         p = repo / "docs" / "features" / "empty.md"
         p.write_text(body)
         applied, withheld = docs_auditor._apply_fixes_to_file(
@@ -1087,14 +1045,17 @@ class TestExistenceInvariant:
             applied, withheld = docs_auditor._apply_fixes_to_file(
                 doc,
                 repo,
-                [("agent/real.py", "agent/ghost.py"), ("agent/other.py", "agent/renamed.py")],
+                [
+                    (re.compile(r"\bghost\b"), "agent/ghost.py"),
+                    (re.compile(r"\brenamed\b"), "agent/renamed.py"),
+                ],
             )
 
         assert applied == 1
         assert withheld == [
             {
                 "doc": str(doc),
-                "old": "agent/real.py",
+                "old": r"\bghost\b",
                 "new": "agent/ghost.py",
                 "reason": "target-absent",
             }
@@ -1109,18 +1070,18 @@ class TestExistenceInvariant:
         assert res["withheld"] == []
 
     def test_audit_surfaces_withheld_without_writing(self, repo, auth_ok, patch_redis):
+        # The surviving producer is the regex channel, and its match must sit in
+        # prose: a path-token match is suppressed by #2744 before the existence
+        # invariant runs, and this test would then assert nothing.
         p = repo / "docs" / "features" / "aud.md"
-        p.write_text("Reference `agent/real.py` here.\n")
-        (repo / "agent").mkdir()
-        (repo / "agent" / "real.py").write_text("")
+        p.write_text("The SessionRunner drives each turn.\n")
 
         with (
             patch.object(
                 docs_auditor,
-                "_detect_renamed_symbol_fixes",
-                return_value=[("agent/real.py", "agent/ghost.py")],
+                "_detect_stale_term_fixes",
+                return_value=[(re.compile(r"\bSessionRunner\b"), "ghost_module.py")],
             ),
-            patch.object(docs_auditor, "_detect_renamed_link_fixes", return_value=[]),
             patch.object(
                 docs_auditor,
                 "_resolve_pr_changed_files",
@@ -1138,45 +1099,10 @@ class TestExistenceInvariant:
 
         assert result["status"] == "ok"
         assert result["fixes_withheld"] == 1
-        assert result["withheld"][0]["new"] == "agent/ghost.py"
+        assert result["withheld"][0]["new"] == "ghost_module.py"
         assert result["files_touched"] == []
         commit.assert_not_called()
-        assert "agent/ghost.py" not in p.read_text()
-
-
-# ---------------------------------------------------------------------------
-# TestLineDeleteSentinel — `new == ""` deletes only exact-matching lines
-# ---------------------------------------------------------------------------
-
-
-class TestLineDeleteSentinel:
-    """The `new == ""` sentinel used by `_detect_readme_broken_entries`.
-
-    Its semantics are exact line equality, never substring: a line that merely
-    *contains* `old` must survive. This is asserted here because the invariant
-    work restructured the branch's count bookkeeping.
-    """
-
-    @pytest.fixture()
-    def doc(self, repo):
-        p = repo / "docs" / "features" / "del.md"
-        p.write_text("- [Gone](gone.md)\nkeep me\n")
-        return Path("docs/features/del.md")
-
-    def test_exact_line_is_deleted(self, repo, doc):
-        applied, withheld = docs_auditor._apply_fixes_to_file(
-            doc, repo, [("- [Gone](gone.md)", "")]
-        )
-        assert (applied, withheld) == (1, [])
-        assert (repo / doc).read_text() == "keep me\n"
-
-    def test_line_merely_containing_old_survives(self, repo, doc):
-        (repo / doc).write_text("prefix - [Gone](gone.md) suffix\nkeep me\n")
-        applied, withheld = docs_auditor._apply_fixes_to_file(
-            doc, repo, [("- [Gone](gone.md)", "")]
-        )
-        assert (applied, withheld) == (0, [])
-        assert (repo / doc).read_text() == "prefix - [Gone](gone.md) suffix\nkeep me\n"
+        assert "ghost_module.py" not in p.read_text()
 
 
 # ---------------------------------------------------------------------------
@@ -1250,17 +1176,17 @@ class TestWithheldBlocksAutoMerge:
         The withheld record here is produced by a real ``audit()`` run, not
         hand-written, so the first assertion is the one that fails on ``main``.
         """
+        # Prose anchor, not a path token — see the #2744 note on the sibling
+        # ``test_audit_surfaces_withheld_without_writing``.
         p = repo / "docs" / "features" / "foo.md"
-        p.write_text("Reference `session_runner.py` here.\n" + "Padding line.\n" * 6)
-        (repo / "docs" / "features" / "session_runner.py").write_text("")
+        p.write_text("The SessionRunner drives each turn.\n" + "Padding line.\n" * 6)
 
         with (
             patch.object(
                 docs_auditor,
-                "_detect_renamed_symbol_fixes",
-                return_value=[("session_runner.py", "ghost_module.py")],
+                "_detect_stale_term_fixes",
+                return_value=[(re.compile(r"\bSessionRunner\b"), "ghost_module.py")],
             ),
-            patch.object(docs_auditor, "_detect_renamed_link_fixes", return_value=[]),
             patch.object(
                 docs_auditor,
                 "_resolve_pr_changed_files",
@@ -1500,7 +1426,7 @@ class TestWithheldRateNonRegression:
                 if not fixes:
                     continue
                 _, withheld = docs_auditor._apply_fixes_to_file(
-                    full.relative_to(worktree), worktree, [], regex_fixes=fixes
+                    full.relative_to(worktree), worktree, fixes
                 )
                 withheld_total += len(withheld)
         finally:
@@ -1680,8 +1606,7 @@ class TestDeletedTargetFiltering:
             "## Architecture\n\n"
             "The handler lives in `agent/totally_made_up_handler_xyz.py` and runs the loop.\n"
         )
-        with patch.object(docs_auditor, "_git_log_follow_renames", return_value=[]):
-            findings = _mk_finding(content, repo)
+        findings = _mk_finding(content, repo)
         assert len(findings) == 1
         assert "agent/totally_made_up_handler_xyz.py" in findings[0]["title"]
         assert findings[0]["category"] == "deleted-target"
@@ -1700,9 +1625,60 @@ class TestDeletedTargetFiltering:
         # Inline single-backtick code is the normal way real refs are written —
         # it must NOT be suppressed merely for being inline code.
         content = "The module `agent/inline_ref_xyz.py` is referenced inline in prose.\n"
-        with patch.object(docs_auditor, "_git_log_follow_renames", return_value=[]):
-            findings = _mk_finding(content, repo)
+        findings = _mk_finding(content, repo)
         assert len(findings) == 1
+
+    def test_rename_destination_reference_is_reported(self, git_repo: Path):
+        """A deleted rename destination must now reach the human-facing report.
+
+        Before #2741 the reporter called ``git log --follow`` and dropped any
+        reference whose path had a rename anywhere in history. This fixture is
+        exactly that shape — ``pkgdir/old_module.py`` renamed to
+        ``pkgdir/new_module.py``, then deleted — so on the pre-change code the
+        finding was silently suppressed. The ``--follow`` assertion below pins
+        the suppression condition down against a real checkout, which is what
+        keeps this a regression guard rather than a tautology.
+        """
+        repo = git_repo
+        env = ["-c", "user.email=t@e.st", "-c", "user.name=Test"]
+
+        def git(*args: str) -> subprocess.CompletedProcess:
+            return subprocess.run(
+                ["git", *env, *args], cwd=repo, check=True, capture_output=True, text=True
+            )
+
+        (repo / "pkgdir").mkdir()
+        (repo / "pkgdir" / "old_module.py").write_text("x = 1\n")
+        git("add", "pkgdir/old_module.py")
+        git("commit", "-qm", "add old_module")
+        git("mv", "pkgdir/old_module.py", "pkgdir/new_module.py")
+        git("commit", "-qm", "rename to new_module")
+        git("rm", "-q", "pkgdir/new_module.py")
+        git("commit", "-qm", "delete new_module")
+
+        # The pre-change suppression condition, asserted directly: the deleted
+        # path really is a rename destination in this checkout's history.
+        follow = git(
+            "log",
+            "--follow",
+            "--diff-filter=R",
+            "--name-status",
+            "--format=",
+            "--",
+            "pkgdir/new_module.py",
+        )
+        assert "pkgdir/old_module.py" in follow.stdout, (
+            "fixture must reproduce the rename-destination history the old "
+            "`git log --follow` suppression keyed on"
+        )
+
+        content = (
+            "## Architecture\n\nThe handler lives in `pkgdir/new_module.py` and runs the loop.\n"
+        )
+        findings = _mk_finding(content, repo)
+        assert len(findings) == 1
+        assert "pkgdir/new_module.py" in findings[0]["title"]
+        assert findings[0]["category"] == "deleted-target"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_docs_auditor_substrate.py
+++ b/tests/unit/test_docs_auditor_substrate.py
@@ -730,8 +730,13 @@ class TestStaleTermWordBoundary:
         The shortening regex here is a *synthetic* stand-in for a ``STALE_TERMS``
         shape that does not exist today: every current replacement is newline-free
         and strictly longer than its key, so no production fix can shift a later
-        fix's line index. This test guards the forward-looking case, for operator
+        fix's *line index*. This test guards the forward-looking case, for operator
         entries that shorten text or span newlines.
+
+        That reprieve is specific to the line-index gate. The path-token gate
+        consumes raw byte offsets, which every shipped replacement already shifts
+        precisely because it is longer than its key — so its apply-time placement
+        is guarding a live corruption, not a hypothetical one.
         """
         doc = repo / "docs" / "features" / "ctx.md"
         original = (


### PR DESCRIPTION
## Summary

Deletes the docs-auditor rename-detection channel outright. `_git_log_follow_renames` ran `git log --follow`, which answers "what was this path called *before*" — while every consumer needed "what is it called *now*". The query is unsound in one direction, so no rename fix the channel proposed could ever be correct. Two prior fixes (#2725/PR #2728, #2759/PR #2782) hardened the *write* path around that unsound read, converting wrong output into permanently-withheld output. That is safety-shaped but leaves a permanent `fixes_withheld > 0` generator, which makes `fixes_withheld` meaningless as a signal.

With all three literal-fix detectors gone the literal `fixes` channel has **zero producers**, so its parameter, loop, and `new == ""` line-delete sentinel are code no execution path can reach — removed rather than fed `[]`.

Closes #2741

## Changes

- **Deleted** `GIT_LOG_FOLLOW_CAP`, `_RENAME_QUERY_COUNT` (and its per-run reset in `audit()`), `_git_log_follow_renames`, `_detect_renamed_link_fixes`, `_detect_renamed_symbol_fixes`, `_detect_readme_broken_entries`, and the README/else detector branches in the audit loop. `_BASENAME_INDEX_CACHE.clear()` (#2759) survives intact.
- **Un-blinded the reporter.** Removed `_detect_deleted_target_issues`' `if renames: continue` suppression, which silently dropped a broken `.py` reference from the human-facing report precisely when that path had a rename in its history — deferring to a fix channel that could never fix anything. Its `(non-renamed)` docstring qualifier, which encoded that suppression, is gone; its narrow-pattern rationale (ruled unchanged in #2759) is **restated standalone**, not deleted, and the pattern is **not** widened.
- **Collapsed** `_apply_fixes_to_file` to `(path, repo_root, regex_fixes)` — one channel, no literal loop, no `new == ""` sentinel, no `None` default.
- **Restated three docstrings.** The match-time context derivation stays; only its stated reason changes, from "the literal loop runs first" to the regex loop's own cross-iteration mutation of `new_text`. Behavior unchanged.
- **Migrated the test suite** to the single regex channel, plus a new rename-destination regression on a real git checkout.
- **Swept the doc surfaces**: `docs/features/docs-auditor.md` (eight edits), `.claude/skill-context/do-docs.md`, `tests/README.md`.

## ⚠️ Disclosure 1 — broken README `.md` index entries lose BOTH repair and reporting

`_detect_readme_broken_entries`' `else` arm was **not** dead code. When a README index entry linked a genuinely-deleted `.md` file and the rename query returned nothing, it deleted that index line — correctly, and cleanly past the existence invariant. It is deleted here by a deliberate human scope decision (2026-08-17), not as a consequence of the query defect: an auditor that deletes lines from a human's index file on its own judgment is the unreviewed-write class that produced bad commit `d7bf3ad99` and that #2739 exists to gate.

**Un-blinding `_detect_deleted_target_issues` does NOT compensate for this.** The two detectors match disjoint path shapes:

| Detector | Pattern | Matches |
|---|---|---|
| `_detect_readme_broken_entries` (deleted) | `re.search(r"\(([^)]+\.md)\)", line)` | markdown-link `.md` targets |
| `_detect_deleted_target_issues` (survives) | `` re.finditer(r"`((?:[\w.-]+/)+[\w.-]+\.py)`") `` | backticked `.py` paths |

A broken `.md` index entry now matches neither the surviving reporter nor anything else in the module. It goes **fully silent** — neither auto-repaired nor reported. Filed as **#2834**, which records that `.md`-shaped broken references have no reporting path, so a future widening (or #2739's gated rebuild) has somewhere to attach. Widening the reporter to cover `.md` targets is explicitly out of scope here.

## ⚠️ Disclosure 2 — removing the suppression un-blinds an unknown number of findings

`_detect_deleted_target_issues` currently drops any broken `.py` reference whose path has a rename anywhere in its git history. Removing that suppression makes those references visible for the first time. **How many there are is not known, and this PR does not attempt to find out** — it is a property of the whole doc corpus against the whole rename history, and every bounded proxy proposed for it measured either structurally zero or one arbitrary slice. Stated plainly: this may raise `_detect_deleted_target_issues` finding volume, by an amount discovered at run time rather than at build time.

**The only bounds are the existing controls, and they bound rate, not steady-state volume.** Filing is rotation-only, the neighborhood is capped at `NEIGHBORHOOD_CAP = 20` files per run, and the per-run cap allows at most 5 filings per rotation — so there is no single-surge failure mode, but a backlog drains at 5/run indefinitely. `_open_issue_exists` dedupes against **open** issues only, so a finding closed without fixing the doc is re-filed on a later rotation.

**Mitigation is ordinary observation** — watch the next few scheduled rotation runs after this merges. If the trickle turns out to be a standing source rather than a draining backlog, that is a real finding about the doc corpus and belongs on its own issue. No pre-merge measurement, no threshold, no gate.

## Demonstrated-red proof (the only real guard here)

Path-token suppression (#2744) runs **before** the existence invariant, so a naive `re.compile(re.escape(path))` rewrite of the `TestExistenceInvariant` cases would be suppressed before the invariant ever ran — producing green tests that assert nothing, silently destroying the coverage guarding against a repeat of `d7bf3ad99`. **A vacuous pass was the default failure mode of this migration.** Every migrated case therefore uses the `test_regex_channel_is_also_guarded` shape: the *pattern* matches a prose word, the *replacement* carries the path-shaped string the invariant must reject.

The `target-absent > 3` verification row is a **textual presence check, not a liveness check** — it counts a string and cannot tell a live assertion from a tautology. It is kept as a floor only. The proof below is the actual guard.

Procedure per case: neuter `_absent_new_path_refs` to `return []`, run the case, confirm it FAILS, revert.

```diff
--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ def _absent_new_path_refs(
     owners is absent.
     """
+    return []  # NEUTERED FOR RED-STATE PROOF (#2741) — reverted immediately after
     absent: list[str] = []
     for ref in sorted(set(_PATH_REF_RE.findall(candidate)) - original_refs):
```

### The four mandated cases

Scoped by assertion, not class membership: every case that both asserts `target-absent` **and** calls `_apply_fixes_to_file` — on `main` those are `:850`, `:926`, `:1010`, `:1099`. `:1099` is `test_dir_prefixed_decisions_unaffected_by_degraded_index`, the twelfth `TestExistenceInvariant` call site, which falls outside any "the eleven cases" phrasing and is explicitly in scope.

```
FFFFF                                                                    [100%]
=================================== FAILURES ===================================
_ TestExistenceInvariant.test_fix_introducing_absent_path_is_rejected_and_reported _
tests/unit/test_docs_auditor_substrate.py:796: in test_fix_introducing_absent_path_is_rejected_and_reported
    assert applied == 0
E   assert 1 == 0
___ TestExistenceInvariant.test_fix_introducing_absent_bare_name_is_withheld ___
tests/unit/test_docs_auditor_substrate.py:880: in test_fix_introducing_absent_bare_name_is_withheld
    assert applied == 0
E   assert 1 == 0
__________ TestExistenceInvariant.test_regex_channel_is_also_guarded ___________
tests/unit/test_docs_auditor_substrate.py:965: in test_regex_channel_is_also_guarded
    assert applied == 0
E   assert 1 == 0
_ TestExistenceInvariant.test_dir_prefixed_decisions_unaffected_by_degraded_index[nonzero-rc] _
tests/unit/test_docs_auditor_substrate.py:1054: in test_dir_prefixed_decisions_unaffected_by_degraded_index
    assert applied == 1
E   assert 2 == 1
_ TestExistenceInvariant.test_dir_prefixed_decisions_unaffected_by_degraded_index[oserror] _
tests/unit/test_docs_auditor_substrate.py:1054: in test_dir_prefixed_decisions_unaffected_by_degraded_index
    assert applied == 1
E   assert 2 == 1
5 failed in 9.94s
```

Read the failures, not their count: with the invariant neutered the rewrite **applies** (`assert 1 == 0`, and `assert 2 == 1` where a valid sibling fix already applied). A vacuously-green migration would have stayed green here, because path-token suppression would have refused the rewrite before the invariant ran at all.

### Whole-file sweep under the same neutering

Not required by the plan, run as the cheapest evidence that the entire migrated block is live:

```
FAILED ...TestExistenceInvariant::test_fix_introducing_absent_path_is_rejected_and_reported
FAILED ...TestExistenceInvariant::test_rejection_is_logged_with_offending_path
FAILED ...TestExistenceInvariant::test_sibling_valid_fix_still_applies
FAILED ...TestExistenceInvariant::test_all_fixes_rejected_writes_nothing
FAILED ...TestExistenceInvariant::test_fix_introducing_absent_bare_name_is_withheld
FAILED ...TestExistenceInvariant::test_ambiguous_bare_name_passes_and_debug_logs
FAILED ...TestExistenceInvariant::test_regex_channel_is_also_guarded
FAILED ...TestExistenceInvariant::test_dir_prefixed_decisions_unaffected_by_degraded_index[nonzero-rc]
FAILED ...TestExistenceInvariant::test_dir_prefixed_decisions_unaffected_by_degraded_index[oserror]
FAILED ...TestExistenceInvariant::test_audit_surfaces_withheld_without_writing
FAILED ...TestWithheldBlocksAutoMerge::test_bare_name_withhold_propagates_to_pr_body_telegram_and_liveness
11 failed, 120 passed in 28.40s
```

Eleven red, all of them existence-invariant coverage. The two `audit()`-driven tests fail on `fixes_withheld == 1` → `0`, which is exactly what the re-pointing required: a real `audit()` run still produces a withheld fix through the regex channel.

Revert confirmed (`grep -c NEUTERED` → 0); green after revert: `131 passed`.

**Post-review update.** Review tech-debt finding 1 deleted `test_regex_channel_is_also_guarded` — one of the four mandated cases — because with a single fix channel left it drove the *identical* pair as `test_fix_introducing_absent_path_is_rejected_and_reported` and asserted a strict subset of its assertions. The proof was re-run after the deletion: **10 red instead of 11, exactly the deleted case and nothing else**, with the three surviving mandated cases all still red. The deleted case's code path is covered by `test_fix_introducing_absent_path_is_rejected_and_reported`, which asserts the full withheld dict plus file content rather than the reason alone. Transcript appended to the red-state note on `main`.

Full transcripts: `docs/plans/notes/docs-auditor-rename-detection-red-state.md` (on `main`).

## The withheld signal chain was preserved, not deleted

`test_audit_surfaces_withheld_without_writing` and `test_bare_name_withhold_propagates_to_pr_body_telegram_and_liveness` are the **only** end-to-end coverage of `fixes_withheld` → `WITHHELD_PR_MARKER` → auto-merge-ineligibility → Telegram → liveness. Both were driven by the deleted literal channel. They were **re-pointed** at the surviving regex producer (`_detect_stale_term_fixes`, patched with a prose-anchored pattern), not stripped or deleted — losing this chain's coverage while deleting its permanent noise generator would have been strictly worse than not doing the work. Both still drive a real `audit()` and still assert `fixes_withheld == 1`.

## Ordering note — this should land before #2739

`docs/plans/docs-auditor-review-gate.md` (#2739, still `status: Planning`) edits the same file. **#2739's core premise — that a nonzero `fixes_withheld` is a real signal — becomes true only after this merges**, because this PR removes the permanent generator. This diff is a pure deletion; rebasing #2739 onto it is strictly easier than the reverse.

That plan document carries 24 lines referencing the six deleted symbols. Those survive deliberately: `docs/plans/` is out of scope for the symbol-absence scan by design, and refreshing #2739's draft is #2739's own work when it replans onto the post-deletion tree. Nothing in this PR edits it.

## Testing

- [x] `tests/unit/test_docs_auditor_substrate.py` — **130 passed** (131 before the post-review patch deleted one redundant case)
- [x] `tests/unit/test_public_api_contract.py` — 1 passed; zero references to any deleted symbol
- [x] Full `tests/unit/` sweep — 3936 passed, 2 failed, both confirmed **pre-existing on `origin/main`** by running them in the clean main checkout (byte-identical assertion messages): `test_valor_session_resume_release.py::test_transitions_to_pending_and_appends_steering` and `test_reflection_scheduler.py::test_all_entries_have_required_fields`. Neither touches `docs_auditor`.
- [x] All 19 plan `## Verification` rows PASS under `agent/verification_parser.py` (0 malformed)
- [x] `ruff check` / `ruff format --check` clean

## Documentation

- [x] `docs/features/docs-auditor.md` — eight edits. Rationale whose conclusion still holds was **restated, not deleted** (Gates 2/3 match-time derivation; the per-run issue-cap argument for the narrow pattern). The residual existence-invariant hole now has **no known reachable route** — its previous route via #2725 is deleted with the channel. The `withheld` record's `old` field is now *always* the regex source.
- [x] `.claude/skill-context/do-docs.md` — "four classes of mechanical fix" → one. The `python -c` invocation block and its result-key handling are **byte-identical**; the `audit()` return contract is unchanged.
- [x] `docs/features/README.md` — verified, no rename mention.
- [x] `tests/README.md` — case count recounted (62 → 130; the old figure was badly stale).
- [x] `.claude/skills-global/do-docs/SKILL.md` deliberately **not** touched — its text is explicitly hypothetical and asserts nothing about this repo's substrate; global skill bodies stay generic.

## Definition of Done
- [x] Built: rename channel deleted, apply path collapsed to one channel
- [x] Tested: suite green, migration demonstrated red before green
- [x] Reviewed: two validator passes, both PASS with no blockers
- [x] Documented: every surface in the plan's `## Documentation` checklist swept
- [x] Quality: lint and format clean



## Review history — the four rounds converged on one paragraph

Rounds 1-3 each returned CHANGES REQUESTED whose only substantive finding was an inaccuracy in the same paragraph of `docs/features/docs-auditor.md` (the "The two gates differ..." block). The inaccuracy relocated within the paragraph each round rather than being fixed, because each patch treated it as a wording problem. The actual defect was structural: the paragraph conflated *"the gate is unexercised"* with *"the gate's apply-time placement is unexercised"*.

The round-3 patch (`8340532f1`) rewrote the paragraph to state two propositions **separately** for each gate:

| | Does the gate fire today? | Is the corruption its *placement* guards reachable today? |
|---|---|---|
| **Gate 2** (`_is_documented_deletion`, `docs_auditor.py:679`) | **Yes**, unconditionally — it is what suppresses stale terms inside fenced code blocks; deleting the call would re-enable rewriting inside fences | **No** — it consumes a line index, and every `STALE_TERMS` replacement is newline-free |
| **Gate 3** (`_match_inside_path_token`, `docs_auditor.py:682`) | **Yes**, at apply time | **Yes** — it consumes raw byte offsets and every replacement is strictly longer than its key; the counterfactual hoist to detection time rewrites `models/session_log.py` to `models/agent_session.py` |

**Round 4: APPROVED**, 0 blockers / 0 tech debt / 2 nits.

- Nit 1 was in that same paragraph and the reviewer supplied exact replacement wording, adopted **verbatim** in `522cac6f9`: the closing gloss had listed "shorten text" as a shape that would exercise gate 2's placement, but a shorter newline-free replacement shifts byte offsets only and cannot stale a line index — so it exercises gate 3's placement, not gate 2's. The forward-looking shape for gate 2 is an entry whose key or replacement *spans a newline*. The parallel clause in the test docstring (`test_docs_auditor_substrate.py`) was corrected to match; the test's synthetic fixture regex does in fact span newlines, so the narrowed wording describes it accurately.
- Nit 2 (`.claude/skills-global/do-docs/SKILL.md` still enumerating the deleted channel) was raised **for awareness only and explicitly not actionable** — the reviewer agreed with the existing decision recorded above: the text is hypothetical ("typically handles"), global skill bodies stay generic per `CLAUDE.md`, and repo specifics belong in `.claude/skill-context/do-docs.md`, which this PR did update. Accepted as-is, no change.
