### PR TITLE
fix(reflections): worktree-safe registry resolution and a schedule-shape contract (#2734)

### DIFF
--- a/agent/reflection_scheduler.py
+++ b/agent/reflection_scheduler.py
@@ -64,17 +64,107 @@ _reflection_pool = ThreadPoolExecutor(
 )
 
 
+# Candidate sets for which the exhausted-candidates diagnostic has already been
+# emitted. Keyed on the joined candidate tuple, so a *different* exhausted set
+# still logs its own line, while the eight-plus call sites that re-resolve within
+# one process share a single message. Deliberately not an lru_cache on the
+# resolver: load_registry() re-resolves per call and tests mutate REFLECTIONS_YAML,
+# so the resolver itself must stay uncached.
+_exhausted_warned: set[str] = set()
+
+
+def _owning_checkout_root() -> Path | None:
+    """Locate the root of the checkout that owns this one, or None.
+
+    In a linked git worktree, ``<repo_root>/.git`` is a *file* holding a single
+    ``gitdir: <path>`` line pointing at ``<primary>/.git/worktrees/<name>``. That
+    directory usually holds a ``commondir`` file (typically ``../..``) which
+    resolves to the primary ``.git``. In the primary checkout, ``.git`` is a
+    directory and there is no owning checkout, so this returns None.
+
+    The two branches are **asymmetric** and must not be given a uniform
+    ``.parent``: with ``commondir`` present the resolved path is the primary
+    ``.git`` so we take its ``.parent``; with ``commondir`` missing,
+    ``parents[2]`` of the gitdir already *is* the checkout root for git's fixed
+    ``<primary>/.git/worktrees/<name>`` layout, so no ``.parent`` is applied.
+
+    The ``gitdir:`` link is assumed **absolute**. Git writes it that way by
+    default, but ``git worktree add --relative-paths`` and the
+    ``worktree.useRelativePaths`` config write a relative link. Resolving a
+    relative link would silently anchor it to the *process CWD* rather than to
+    the worktree root and yield a wrong root, so a relative link returns None and
+    takes the same unfamiliar-layout path as a malformed one.
+
+    This is resolved from git's on-disk worktree metadata rather than by invoking
+    the git CLI: ``REGISTRY_PATH`` is computed at import time inside a launchd
+    worker, and a blocking child process on that path is precisely the class of
+    hazard the surrounding launchd guards exist to prevent.
+
+    Performs **no** registry ``exists()`` check — it does not know what a
+    registry is. The caller owns that, so the candidate path stays nameable in
+    the exhausted-candidates diagnostic even when it turns out to be absent.
+    """
+    try:
+        repo_root = Path(__file__).parent.parent
+        dot_git = repo_root / ".git"
+        if dot_git.is_dir():
+            return None
+        if not dot_git.is_file():
+            return None
+
+        gitdir_text = ""
+        for line in dot_git.read_text().splitlines():
+            if line.startswith("gitdir:"):
+                gitdir_text = line.split(":", 1)[1].strip()
+                break
+        if not gitdir_text:
+            return None
+        # Guard before any commondir read or parents[] indexing (see docstring).
+        if not Path(gitdir_text).is_absolute():
+            return None
+
+        gitdir = Path(gitdir_text)
+        commondir_file = gitdir / "commondir"
+        if commondir_file.is_file():
+            commondir_text = commondir_file.read_text().strip()
+            if commondir_text:
+                common = (gitdir / Path(commondir_text)).resolve()
+                return common.parent
+
+        # No commondir: rely on git's fixed <primary>/.git/worktrees/<name> layout.
+        # Guard the index explicitly — a short gitdir: would raise IndexError, which
+        # the broad except below would swallow into the silent fallback this guard
+        # exists to keep legible.
+        if len(gitdir.parents) > 2:
+            return gitdir.parents[2]
+        return None
+    except Exception:
+        return None
+
+
 # Path to the reflections registry.
-# Resolution order: REFLECTIONS_YAML env var → ~/Desktop/Valor/reflections.yaml → config/
+# Resolution order: REFLECTIONS_YAML env var → ~/Desktop/Valor/reflections.yaml →
+# this checkout's config/ → the owning checkout's config/
 def _resolve_registry_path() -> Path:
     """Resolve the reflections YAML path using vault-first fallback logic.
 
     Priority:
     1. REFLECTIONS_YAML env var (explicit override, e.g., for testing)
     2. ~/Desktop/Valor/reflections.yaml (iCloud-synced vault, private config)
-    3. config/reflections.yaml (in-repo fallback, always present)
+       — skipped entirely under VALOR_LAUNCHD (macOS TCC hazard, see below)
+    3. config/reflections.yaml in *this* checkout. Gitignored and materialized
+       only at install time, so it is **absent in worktrees**.
+    4. config/reflections.yaml in the checkout that owns this worktree, located
+       via ``_owning_checkout_root()``. This is the level that makes the registry
+       readable from ``.worktrees/{slug}/`` under VALOR_LAUNCHD.
+
+    When every candidate is exhausted, one error naming all four slots is logged
+    (de-duplicated per candidate set) and the level-3 path is returned unchanged,
+    so no new exception escapes at import time.
     """
     import os
+
+    candidates: list[str] = []
 
     env_path = os.environ.get("REFLECTIONS_YAML")
     if env_path:
@@ -82,6 +172,7 @@ def _resolve_registry_path() -> Path:
         if p.exists():
             return p
         logger.warning("REFLECTIONS_YAML env var points to non-existent path: %s", env_path)
+    candidates.append(f"REFLECTIONS_YAML={env_path or '<unset>'}")
 
     # When running under launchd (VALOR_LAUNCHD=1), skip the iCloud-synced Desktop
     # path entirely. macOS TCC blocks stat()/open() on ~/Desktop files from launchd
@@ -89,10 +180,41 @@ def _resolve_registry_path() -> Path:
     # install_worker.sh copies reflections.yaml → config/reflections.yaml at install time.
     if not os.environ.get("VALOR_LAUNCHD"):
         vault_path = Path.home() / "Desktop" / "Valor" / "reflections.yaml"
+        candidates.append(str(vault_path))
         if vault_path.exists():
             return vault_path
+    else:
+        candidates.append("<vault skipped: VALOR_LAUNCHD>")
 
-    return Path(__file__).parent.parent / "config" / "reflections.yaml"
+    local_path = Path(__file__).parent.parent / "config" / "reflections.yaml"
+    candidates.append(str(local_path))
+    if local_path.exists():
+        return local_path
+
+    # Fourth level: the owning checkout's install-time copy. The locator answers
+    # only "which checkout owns this one?"; the existence check is owned here so
+    # the candidate stays nameable in the diagnostic below even when absent.
+    owning_root = _owning_checkout_root()
+    if owning_root is not None:
+        primary_candidate = owning_root / "config" / "reflections.yaml"
+        candidates.append(str(primary_candidate))
+        if primary_candidate.exists():
+            return primary_candidate
+    else:
+        candidates.append("<owning checkout not resolvable>")
+
+    key = "|".join(candidates)
+    if key not in _exhausted_warned:
+        _exhausted_warned.add(key)
+        logger.error(
+            "Reflections registry not found; every candidate exhausted: %s. "
+            "Returning %s, which does not exist. Run /update on this machine to "
+            "materialize the install-time copy.",
+            ", ".join(candidates),
+            local_path,
+        )
+
+    return local_path
 
 
 REGISTRY_PATH = _resolve_registry_path()

--- a/agent/reflection_scheduler.py
+++ b/agent/reflection_scheduler.py
@@ -332,9 +332,11 @@ def load_registry(path: Path | None = None) -> list[ReflectionEntry]:
     """Load and validate the reflections registry from YAML.
 
     Args:
-        path: Path to the YAML file. Defaults to vault-first resolution:
-              REFLECTIONS_YAML env var → ~/Desktop/Valor/reflections.yaml →
-              config/reflections.yaml.
+        path: Path to the YAML file. Defaults to ``_resolve_registry_path()``;
+              see that function's docstring for the authoritative ordering of
+              its resolution levels, including the owning-checkout level that
+              covers worktrees (issue #2734). Deliberately not re-enumerated
+              here — the duplicate went stale once already.
 
     Returns:
         List of validated ReflectionEntry objects. Invalid entries are

--- a/agent/reflection_scheduler.py
+++ b/agent/reflection_scheduler.py
@@ -177,7 +177,8 @@ def _resolve_registry_path() -> Path:
     # When running under launchd (VALOR_LAUNCHD=1), skip the iCloud-synced Desktop
     # path entirely. macOS TCC blocks stat()/open() on ~/Desktop files from launchd
     # agents — even exists() hangs indefinitely and blocks the asyncio event loop.
-    # install_worker.sh copies reflections.yaml → config/reflections.yaml at install time.
+    # install_reflection_worker.sh / install_email_bridge.sh / env_sync.py::sync_reflections_yaml
+    # copy reflections.yaml → config/reflections.yaml at install time.
     if not os.environ.get("VALOR_LAUNCHD"):
         vault_path = Path.home() / "Desktop" / "Valor" / "reflections.yaml"
         candidates.append(str(vault_path))

--- a/docs/features/reflections.md
+++ b/docs/features/reflections.md
@@ -59,7 +59,7 @@ reflections:
 
 ### Code-Registered Reflections
 
-`config/reflections.yaml` is a **gitignored symlink** (`~/Desktop/Valor/reflections.yaml`, vault-synced) — a hand-edit to it, or even to a checked-out machine's local copy, never ships via git history and gets clobbered by the next vault→config sync. A reflection that must ship with a feature's code (rather than be registered by hand on each machine after the fact) instead registers itself through a small idempotent helper in `scripts/update/reflection_register.py`, invoked as a step inside `scripts/update/run.py`.
+`config/reflections.yaml` is a **gitignored real-file copy** of `~/Desktop/Valor/reflections.yaml` (vault-synced) — a hand-edit to it, or even to a checked-out machine's local copy, never ships via git history and gets clobbered by the next vault→config sync. A reflection that must ship with a feature's code (rather than be registered by hand on each machine after the fact) instead registers itself through a small idempotent helper in `scripts/update/reflection_register.py`, invoked as a step inside `scripts/update/run.py`.
 
 Each registration function (`register_crash_recovery`, `register_memory_distill_backfill`, ...) checks whether its entry is already present in the vault's `reflections.yaml`, appends a YAML block matching the file's existing indentation if not, and reports one of `registered` / `noop` / `skipped` via a `RegisterResult`. `scripts/update/run.py` runs every registration step **before** the step that copies the vault file into the per-machine `config/reflections.yaml`, so a freshly-registered entry propagates to the local config on the same `/update` cycle rather than requiring a second run. The reflection scheduler subprocess (`com.valor.reflection-worker`) picks up the change on its next config reload.
 
@@ -91,24 +91,48 @@ The `interval: <int>` field is now `every: <int>s`. The migration is one-shot an
 
 - `scripts/migrate_reflections_yaml.py` rewrites `interval: N` → `every: Ns` in place. Running it on an already-migrated YAML is a no-op.
 - The `/update` skill invokes the migration on every pull (`scripts/update/run.py` Step 3.65) so machines that haven't migrated yet pick up the change automatically. The wrapper lives in `scripts/update/reflections_yaml.py`.
-- The vault copy (`~/Desktop/Valor/reflections.yaml`) is the canonical target; the in-repo `config/reflections.yaml` symlinks to it on live machines.
+- The vault copy (`~/Desktop/Valor/reflections.yaml`) is the canonical target; the in-repo `config/reflections.yaml` is a real-file copy of it, written on every update, on live machines.
 
 ### Registry Location (Vault-First)
 
-The scheduler resolves `config/reflections.yaml` via a three-level fallback:
+The scheduler resolves `config/reflections.yaml` via a four-level fallback
+(`agent/reflection_scheduler.py::_resolve_registry_path()`):
 
 1. `REFLECTIONS_YAML` env var (explicit override, e.g., for testing)
-2. `~/Desktop/Valor/reflections.yaml` (vault copy — iCloud-synced, takes precedence)
-3. `config/reflections.yaml` in-repo (symlink to vault on live machines)
+2. `~/Desktop/Valor/reflections.yaml` (vault copy — iCloud-synced, takes precedence) —
+   skipped entirely under `VALOR_LAUNCHD` (macOS TCC hazard, see below)
+3. `config/reflections.yaml` in *this* checkout
+4. `config/reflections.yaml` in the **owning checkout** — the primary checkout that a
+   linked git worktree belongs to, located via `_owning_checkout_root()` from git's
+   on-disk worktree metadata (the worktree's `.git` file → `gitdir:` → `commondir`),
+   never by invoking the git CLI
 
-On live machines, `config/reflections.yaml` is a symlink to `~/Desktop/Valor/reflections.yaml`.
-The symlink is created by `sync_reflections_yaml()` in `scripts/update/env_sync.py` during
-each update run. This ensures the scheduler always reads the vault version.
+Levels 3 and 4 exist because `config/reflections.yaml` is **gitignored** and is
+materialized only at install time — by `install_reflection_worker.sh`,
+`install_email_bridge.sh`, and `scripts/update/env_sync.py::sync_reflections_yaml` —
+and only in the **primary checkout**. A linked git worktree (`.worktrees/{slug}/`, see
+[Worktree Manager](worktree-manager.md)) never receives its own copy: install-time
+artifacts are not duplicated per worktree, both because per-worktree copies would go
+stale independently and because linking each worktree straight into the vault would
+reintroduce the June 2026 worker wedge (the incident that motivated the real-file form
+noted just below). Level 3 is therefore always
+absent in a worktree, and level 4 — reading the *owning* checkout's real-file copy
+instead — is what makes the registry resolvable from `.worktrees/{slug}/` under
+`VALOR_LAUNCHD=1`. When every level is exhausted, the resolver logs one deduplicated
+error naming all four candidates and still returns the local (level-3) in-repo path,
+unchanged from its legacy behavior, so no new exception type escapes into production.
 
-Under launchd (`VALOR_LAUNCHD=1`), the worker instead reads a **real copy** at
-`config/reflections.yaml` that `install_worker.sh` writes from the vault (macOS TCC blocks
-launchd agents from reading `~/Desktop`). That copy step is where repo-specific ownership is
-applied — see below.
+On live machines, `config/reflections.yaml` in the primary checkout is a **real file** —
+a plain copy of `~/Desktop/Valor/reflections.yaml`, not a symlink into it. The copy is
+written by `sync_reflections_yaml()` in `scripts/update/env_sync.py` during each update
+run. This ensures the scheduler always reads a current snapshot of the vault version.
+The real-file form matters: reading that path directly from `~/Desktop` under launchd
+was the June 2026 worker wedge, and the resolver's worktree-fallback level 4 depends on
+the primary copy staying a real file so it never re-trips that hazard one layer removed.
+
+Under launchd (`VALOR_LAUNCHD=1`), the worker reads that same real copy at
+`config/reflections.yaml` (macOS TCC blocks launchd agents from reading `~/Desktop`
+directly). That copy step is where repo-specific ownership is applied — see below.
 
 ### Repo-Specific Reflections (Single-Machine Ownership)
 
@@ -140,9 +164,10 @@ Ownership semantics (`tools/reflection_machine_filter.py`):
 | `project_key` not in `projects.json` | Fail-open (left as-is) with a warning — a typo never silently disables an audit everywhere |
 
 The filter only **disables**; it never re-enables (so an owned-but-authored-`enabled: false`
-reflection like a paused `docs-auditor` stays off). It refuses to write through a symlink, so a
-manual run against the symlinked `config/reflections.yaml` can never corrupt the shared vault —
-it only ever rewrites the real per-machine copy that `install_worker.sh` produces.
+reflection like a paused `docs-auditor` stays off). It refuses to write through a symlink — a
+defensive check against the pre-June-2026 layout, not a claim that `config/reflections.yaml`
+is one today — so a manual run against `config/reflections.yaml` can never corrupt the shared
+vault: it only ever rewrites the real per-machine copy that `install_worker.sh` produces.
 
 > **Note on `docs-auditor` filing:** issue-filing is **rotation-only**. The `audit()` substrate
 > files advisory issues (deleted-target, stub-doc) only under `scope_mode="rotation"` (Caller A,
@@ -792,7 +817,7 @@ worker-role install gate, cutover ordering, and the `/dashboard.json`
 | Component | Detail |
 |-----------|--------|
 | Scheduler | `agent/reflection_scheduler.py` (run out-of-process by `python -m reflections`) |
-| Registry | `config/reflections.yaml` (symlink → `~/Desktop/Valor/reflections.yaml`) |
+| Registry | `config/reflections.yaml` (real-file copy of `~/Desktop/Valor/reflections.yaml`) |
 | State | Redis via `models/reflection.py` |
 | Tick interval | 60 seconds |
 
@@ -810,7 +835,7 @@ worker-role install gate, cutover ordering, and the `/dashboard.json`
 | File | Purpose |
 |------|---------|
 | `agent/reflection_scheduler.py` | Unified scheduler: registry loader, schedule evaluator, executor |
-| `config/reflections.yaml` | Declarative registry symlink → `~/Desktop/Valor/reflections.yaml` |
+| `config/reflections.yaml` | Declarative registry, real-file copy of `~/Desktop/Valor/reflections.yaml` |
 | `reflections/__init__.py` | Package: all callables return `{"status", "findings", "summary"}` |
 | `reflections/utilities.py` | Shared helpers: `load_local_projects()`, `is_ignored()`, `run_llm_reflection()`, `extract_structured_errors()`, `CORRECTION_PATTERNS` |
 | `reflections/agents/` | 5 agent/session health reflections (one file each): `circuit_health_gate.py`, `session_recovery_drip.py`, `session_count_throttle.py`, `failure_loop_detector.py`, `system_health_digest.py` |
@@ -828,7 +853,7 @@ worker-role install gate, cutover ordering, and the `/dashboard.json`
 | `models/pr_review_audit.py` | PRReviewAudit: PR review finding deduplication |
 | `models/reflections.py` | Re-export shim: `ReflectionIgnore`, `PRReviewAudit` |
 | `scripts/reflections_report.py` | GitHub issue creation module (was used by retired `daily_report`) |
-| `scripts/update/env_sync.py` | `sync_reflections_yaml()`: creates vault symlink on update |
+| `scripts/update/env_sync.py` | `sync_reflections_yaml()`: writes the real-file vault copy on update |
 | `~/Desktop/Valor/projects.json` | Multi-repo project registry |
 | `~/Desktop/Valor/reflections.yaml` | Vault copy of the registry (canonical source) |
 

--- a/docs/features/reflections.md
+++ b/docs/features/reflections.md
@@ -167,7 +167,9 @@ The filter only **disables**; it never re-enables (so an owned-but-authored-`ena
 reflection like a paused `docs-auditor` stays off). It refuses to write through a symlink — a
 defensive check against the pre-June-2026 layout, not a claim that `config/reflections.yaml`
 is one today — so a manual run against `config/reflections.yaml` can never corrupt the shared
-vault: it only ever rewrites the real per-machine copy that `install_worker.sh` produces.
+vault: it only ever rewrites the real per-machine copy produced by
+`install_reflection_worker.sh`, `install_email_bridge.sh`, and
+`scripts/update/env_sync.py::sync_reflections_yaml`.
 
 > **Note on `docs-auditor` filing:** issue-filing is **rotation-only**. The `audit()` substrate
 > files advisory issues (deleted-target, stub-doc) only under `scope_mode="rotation"` (Caller A,

--- a/docs/features/reflections.md
+++ b/docs/features/reflections.md
@@ -42,7 +42,7 @@ reflections:
 | Field | Type | Description |
 |-------|------|-------------|
 | `name` | string | Unique identifier (used as Redis key) |
-| `every` / `cron` / `at` | string | Unified schedule grammar — exactly one is required. See [Schedule Grammar](#schedule-grammar) below. |
+| `schedule` / `every` / `cron` / `at` | string | Unified schedule grammar — exactly one is required. See [Schedule Grammar](#schedule-grammar) below. |
 | `priority` | string | `urgent`, `high`, `normal`, or `low` |
 | `execution_type` | string | `function` (direct callable) or `agent` (PM session) |
 | `callable` | string | Dotted Python path (for function type) |
@@ -75,15 +75,26 @@ A reflection that an operator is expected to add by hand on a per-machine basis 
 
 ### Schedule Grammar
 
-The unified Reflection schema (issue #1273) collapses the prior `interval:` integer-seconds field into one of three string-typed schedule keys. Exactly one must be present per reflection.
+The unified Reflection schema (issue #1273) collapses the prior `interval:` integer-seconds field into a string-typed schedule key. Exactly one must be present per reflection.
 
 | Key | Shape | Example | Semantics |
 |-----|-------|---------|-----------|
 | `every` | duration string | `every: 300s`, `every: 5m`, `every: 1h`, `every: 24h` | Recurring on a fixed interval. Tracked by `ran_at + interval`. |
 | `cron` | five-field cron expression, optional `; tz=<zone>` suffix | `cron: 0 9 * * 1-5; tz=America/New_York` | Recurring on a calendar schedule. Timezone defaults to UTC; explicit zones must be valid IANA names. |
 | `at` | ISO-8601 instant | `at: 2026-05-15T09:00:00+00:00` | One-shot — fires exactly once at the given instant. Pair with `auto_delete_after_run: true` so the record self-cleans on success. |
+| `schedule` | pre-composed grammar string | `schedule: "cron: 0 9 * * 1-5; tz=America/New_York"` | The already-normalized form the other three keys are folded into. Written by machinery that composes a schedule programmatically; prefer `every` / `cron` / `at` when hand-authoring. |
 
 The runtime parser lives in `agent/reflection_schedule.py::compute_next_due()` and depends on `croniter` (declared in `pyproject.toml`).
+
+**Exactly one, enforced by test (#2734).** `load_registry()` resolves a multi-key entry
+deterministically by precedence — `schedule` > `every` > `cron` > `at` — rather than refusing
+it, so an entry declaring two keys would load with one declaration silently discarded.
+`tests/unit/test_reflection_scheduler.py::required_field_violations` is therefore
+**deliberately stricter than the loader**: it rejects zero keys (matching the loader, which
+cannot schedule such an entry at all) *and* two-or-more (a lint the loader does not perform).
+It also counts a key as declared when **present**, while the loader counts it when **truthy**.
+Both divergences are intentional; a future loader change that formalizes multi-key support is
+a decision to re-make there, not a bug in the test.
 
 #### Migration from `interval:` (issue #1273)
 

--- a/docs/features/reflections.md
+++ b/docs/features/reflections.md
@@ -146,7 +146,7 @@ The fix extends [single-machine ownership](single-machine-ownership.md) to refle
 applies it at **update time, not run time**:
 
 1. A reflection declares `project_key: <key>` in the shared registry (e.g. `project_key: valor`).
-2. `install_worker.sh`, right after copying the vault `reflections.yaml` into the launchd-safe
+2. `install_reflection_worker.sh`, right after copying the vault `reflections.yaml` into the launchd-safe
    `config/reflections.yaml`, runs `python -m tools.reflection_machine_filter`. For each entry
    with a `project_key`, if `projects.<key>.machine` (from `projects.json`) is **not** this
    machine, it forces `enabled: false` in the local copy.

--- a/docs/features/worktree-manager.md
+++ b/docs/features/worktree-manager.md
@@ -88,6 +88,30 @@ exception message (including expected branch, actual branch, worktree
 path, and dirty file list). This is a visible failure mode, in contrast to
 the silent `communicated=False` hang it replaces.
 
+## Gitignored install-time artifacts are absent in worktrees
+
+A linked worktree only ever gets what `git worktree add` checks out — it inherits
+none of a machine's gitignored, install-time state. The worked example is
+`config/reflections.yaml` (reflections registry): it's written once, at install/update
+time, into the **primary checkout** by `install_reflection_worker.sh`,
+`install_email_bridge.sh`, and `scripts/update/env_sync.py::sync_reflections_yaml`, and
+is gitignored, so no `.worktrees/{slug}/` ever receives a copy of its own.
+
+The resolution strategy is to **read the owning checkout's copy**, not to duplicate the
+file per worktree. `agent/reflection_scheduler.py::_owning_checkout_root()` walks the
+worktree's `.git` file (`gitdir:` → `commondir`) to find the primary checkout root, purely
+from git's on-disk metadata — no subprocess — and the registry resolver falls back to
+`<primary>/config/reflections.yaml` when the local copy is missing. See
+[Reflections § Registry Location (Vault-First)](reflections.md#registry-location-vault-first)
+for the full four-level resolution order.
+
+Duplicating such an artifact per worktree at creation time was considered and rejected:
+per-worktree copies go stale independently of the primary's, and linking a worktree
+straight at the private vault source defeats the launchd TCC guard the primary checkout's
+copy step exists to satisfy — the exact failure mode behind the June 2026 worker wedge.
+Any future gitignored, install-time file that a worktree process needs to read should
+follow the same pattern: resolve to the owning checkout, don't duplicate.
+
 ## Related
 
 - Issue [#1377](https://github.com/tomcounsell/ai/issues/1377) — bug

--- a/scripts/update/reflection_register.py
+++ b/scripts/update/reflection_register.py
@@ -30,11 +30,16 @@ vault source (``~/Desktop/Valor/reflections.yaml``), refreshed by
 the entry only to the in-repo copy is silently clobbered the next time that copy
 step runs, so registration for real means appending the entry to the *vault*
 file. The target is resolved via
-``agent.reflection_scheduler._resolve_registry_path()`` (critique C6), which
-prioritizes the vault over the config copy -- a builder who hardcoded the config
-copy would reproduce #1539's "looks wired, never lands" failure. This step runs
-BEFORE Step 1.66's vault->config copy (critique NIT) so the appended entry
-propagates into the per-machine ``config/reflections.yaml`` on the same cycle.
+``agent.reflection_scheduler._resolve_registry_path()`` (critique C6), which in
+the primary checkout -- where this module always runs, via the ``/update`` step
+-- picks the vault ahead of the config copy: that resolver's fourth,
+owning-checkout-fallback level (issue #2734) is only reached when the local
+config copy is absent, and in the primary checkout it is present. A builder who
+hardcoded the config copy would reproduce #1539's "looks wired, never lands"
+failure; see ``_resolve_target``'s docstring for the worktree-caller caveat this
+qualification exists to flag. This step runs BEFORE Step 1.66's vault->config
+copy (critique NIT) so the appended entry propagates into the per-machine
+``config/reflections.yaml`` on the same cycle.
 
 Guarded on (mirroring ``reflection_arm.py``):
   - the vault ``reflections.yaml`` existing (fresh machines with no vault copy
@@ -182,10 +187,36 @@ def _resolve_target() -> Path:
     """Resolve the registry file to write, prioritizing the vault (critique C6).
 
     Delegates to ``agent.reflection_scheduler._resolve_registry_path`` -- the
-    same vault-first resolver the scheduler reads at runtime -- so the entry
-    lands where the scheduler will actually look, not in the soon-clobbered
-    config copy. Imported lazily because the scheduler transitively imports
-    heavy models; the update step only needs it at call time.
+    same resolver the scheduler reads at runtime. That resolver gained a
+    fourth fallback level (issue #2734): when *this* checkout's
+    ``config/reflections.yaml`` is absent, it reads the owning checkout's copy
+    instead of the vault. C6 -- "the entry lands where the scheduler will
+    actually look, not in the soon-clobbered config copy" -- still holds for
+    every real caller of this function, but only because of a reachability
+    condition, not because the resolver always prefers the vault: the fourth
+    level is reached only when this checkout's local ``config/reflections.yaml``
+    is absent, which never holds in the **primary checkout**, where ``/update``
+    (and therefore this function) runs. There the vault branch is hit first,
+    exactly as C6 assumed.
+
+    That reachability condition is caller-specific, not resolver-enforced. A
+    hypothetical caller of this function running from a **worktree** under
+    ``VALOR_LAUNCHD=1`` -- where the local config copy is genuinely absent --
+    would have this function resolve to the *primary checkout's* install-time
+    ``config/reflections.yaml`` and write the registration there. That copy is
+    live scheduler input, so the write would silently succeed, but the next
+    ``/update`` overwrites it from the vault and the registration is lost with
+    no error. See Risk 3 in
+    ``docs/plans/reflection-registry-schedule-contract.md`` for why this is a
+    contained CONCERN rather than a blocker: no such caller exists today --
+    ``_this_machine_owns_valor`` fails closed and this module runs only as an
+    ``/update`` step in the primary checkout -- and the containment must not be
+    relaxed without first splitting this shared resolver into distinct read
+    and write functions (the ``[ORDERED]`` No-Go in that plan; a separate,
+    sequenced change, not done here).
+
+    Imported lazily because the scheduler transitively imports heavy models;
+    the update step only needs it at call time.
     """
     from agent.reflection_scheduler import _resolve_registry_path
 

--- a/scripts/update/reflection_register.py
+++ b/scripts/update/reflection_register.py
@@ -208,10 +208,20 @@ def _resolve_target() -> Path:
     ``/update`` overwrites it from the vault and the registration is lost with
     no error. See Risk 3 in
     ``docs/plans/reflection-registry-schedule-contract.md`` for why this is a
-    contained CONCERN rather than a blocker: no such caller exists today --
-    ``_this_machine_owns_valor`` fails closed and this module runs only as an
-    ``/update`` step in the primary checkout -- and the containment must not be
-    relaxed without first splitting this shared resolver into distinct read
+    contained CONCERN rather than a blocker: no such caller exists today,
+    because this module runs only as an ``/update`` step in the primary
+    checkout. That is the whole of the containment, and it is sufficient under
+    every real invocation path.
+
+    ``_this_machine_owns_valor`` is **not** a second, independent leg. It fails
+    closed in a worktree only because ``config/projects.json`` is gitignored and
+    therefore absent there -- and ``scripts/update/run.py`` calls
+    ``env_sync.sync_projects_json(project_dir)`` at Step 1.65, which runs *before*
+    the registration steps, so a ``run.py --project-dir <worktree>`` invocation
+    would materialize that file and arm the ownership guard within the same run.
+    Treat the primary-checkout leg as the containment; do not relax it on the
+    assumption that ownership would catch a worktree caller. The containment must
+    not be relaxed without first splitting this shared resolver into distinct read
     and write functions (the ``[ORDERED]`` No-Go in that plan; a separate,
     sequenced change, not done here).
 

--- a/scripts/update/reflection_register.py
+++ b/scripts/update/reflection_register.py
@@ -30,14 +30,14 @@ vault source (``~/Desktop/Valor/reflections.yaml``), refreshed by
 the entry only to the in-repo copy is silently clobbered the next time that copy
 step runs, so registration for real means appending the entry to the *vault*
 file. The target is resolved via
-``agent.reflection_scheduler._resolve_registry_path()`` (critique C6), which in
-the primary checkout -- where this module always runs, via the ``/update`` step
--- picks the vault ahead of the config copy: that resolver's fourth,
-owning-checkout-fallback level (issue #2734) is only reached when the local
-config copy is absent, and in the primary checkout it is present. A builder who
-hardcoded the config copy would reproduce #1539's "looks wired, never lands"
-failure; see ``_resolve_target``'s docstring for the worktree-caller caveat this
-qualification exists to flag. This step runs BEFORE Step 1.66's vault->config
+``agent.reflection_scheduler._resolve_registry_path()`` (critique C6), which
+picks the vault ahead of the config copy **only when ``VALOR_LAUNCHD`` is
+unset** -- that resolver gates the vault candidate on the environment, not on
+checkout identity. Under ``VALOR_LAUNCHD=1`` it returns the soon-clobbered
+config copy even in the primary checkout, reproducing #1539's "looks wired,
+never lands" failure; a builder who hardcoded the config copy would reproduce it
+unconditionally. See ``_resolve_target``'s docstring for both reachable paths
+and issue #2855 for the fix. This step runs BEFORE Step 1.66's vault->config
 copy (critique NIT) so the appended entry propagates into the per-machine
 ``config/reflections.yaml`` on the same cycle.
 
@@ -191,27 +191,35 @@ def _resolve_target() -> Path:
     fourth fallback level (issue #2734): when *this* checkout's
     ``config/reflections.yaml`` is absent, it reads the owning checkout's copy
     instead of the vault. C6 -- "the entry lands where the scheduler will
-    actually look, not in the soon-clobbered config copy" -- still holds for
-    every real caller of this function, but only because of a reachability
-    condition, not because the resolver always prefers the vault: the fourth
-    level is reached only when this checkout's local ``config/reflections.yaml``
-    is absent, which never holds in the **primary checkout**, where ``/update``
-    (and therefore this function) runs. There the vault branch is hit first,
-    exactly as C6 assumed.
+    actually look, not in the soon-clobbered config copy" -- holds only when
+    ``VALOR_LAUNCHD`` is unset. It is **not** guaranteed by running in the
+    primary checkout, and the resolver does not always prefer the vault.
 
-    That reachability condition is caller-specific, not resolver-enforced. A
-    hypothetical caller of this function running from a **worktree** under
-    ``VALOR_LAUNCHD=1`` -- where the local config copy is genuinely absent --
-    would have this function resolve to the *primary checkout's* install-time
-    ``config/reflections.yaml`` and write the registration there. That copy is
-    live scheduler input, so the write would silently succeed, but the next
-    ``/update`` overwrites it from the vault and the registration is lost with
-    no error. See Risk 3 in
-    ``docs/plans/reflection-registry-schedule-contract.md`` for why this is a
-    contained CONCERN rather than a blocker: no such caller exists today,
-    because this module runs only as an ``/update`` step in the primary
-    checkout. That is the whole of the containment, and it is sufficient under
-    every real invocation path.
+    The vault level is gated on the environment, not on checkout identity:
+    ``agent/reflection_scheduler.py`` appends the vault candidate only ``if not
+    os.environ.get("VALOR_LAUNCHD")`` (macOS TCC blocks ``~/Desktop`` access
+    from launchd agents). So there are two distinct ways to land on a
+    soon-clobbered ``config/reflections.yaml``:
+
+    - **Under ``VALOR_LAUNCHD=1``, even in the primary checkout.** The vault
+      candidate is skipped, control reaches the local-config level, and that
+      file exists in the primary checkout -- so this function returns the
+      config copy. The worker plist sets ``VALOR_LAUNCHD=1`` and a
+      worker-spawned ``claude -p`` session inherits it, so an agent running
+      ``/update`` hits this path. The write succeeds silently and Step 1.66's
+      vault->config copy discards it on the next cycle: #1539's "looks wired,
+      never lands" failure, with no error.
+    - **From a worktree under ``VALOR_LAUNCHD=1``**, where the local copy is
+      absent, the fourth owning-checkout level (issue #2734) resolves to the
+      *primary checkout's* copy, with the same silent-loss outcome.
+
+    Issue #2855 tracks the real fix. It is not attempted here because a
+    write-side caller must not share the scheduler's read-side resolver at all;
+    splitting them into distinct read and write functions is the ``[ORDERED]``
+    No-Go in ``docs/plans/reflection-registry-schedule-contract.md`` (Risk 3),
+    sequenced as a separate change. Until then, treat "unset ``VALOR_LAUNCHD``"
+    as a precondition of correct registration rather than an invariant this
+    module enforces.
 
     ``_this_machine_owns_valor`` is **not** a second, independent leg. It fails
     closed in a worktree only because ``config/projects.json`` is gitignored and

--- a/tests/unit/test_reflection_scheduler.py
+++ b/tests/unit/test_reflection_scheduler.py
@@ -61,8 +61,10 @@ def _entry_interval_seconds(entry: dict) -> int:
     return parse_every_duration(str(entry["every"]).strip())
 
 
-# The four schedule shapes the loader's normalizer accepts
-# (agent/reflection_scheduler.py:266-283), in its own precedence order.
+# The four schedule shapes the loader's normalizer accepts (the schedule
+# normalizer inside agent/reflection_scheduler.py::load_registry), in its own
+# precedence order. Referenced by symbol, not line range: line ranges in this
+# module have already drifted once.
 SCHEDULE_KEYS = ("schedule", "every", "cron", "at")
 
 
@@ -76,12 +78,23 @@ def required_field_violations(entry: dict) -> list[str]:
     The schedule rule is **exactly one of** ``schedule`` / ``every`` / ``cron`` /
     ``at``. Rejecting zero keys matches the loader, which cannot schedule such an
     entry at all. Rejecting two-or-more is **stricter than the loader by policy**:
-    the normalizer at ``agent/reflection_scheduler.py:266-283`` resolves a
-    multi-key entry deterministically by precedence (schedule > every > cron > at)
-    rather than refusing it, so a multi-key entry would load with one of its
-    declarations silently discarded. This lint exists to stop that from reaching
-    the registry. If a future loader change formalizes multi-key support, that is
-    an intended divergence to re-decide here, not a bug in this test.
+    the schedule normalizer in ``agent/reflection_scheduler.py::load_registry``
+    resolves a multi-key entry deterministically by precedence
+    (schedule > every > cron > at) rather than refusing it, so a multi-key entry
+    would load with one of its declarations silently discarded. This lint exists
+    to stop that from reaching the registry. If a future loader change formalizes
+    multi-key support, that is an intended divergence to re-decide here, not a bug
+    in this test.
+
+    Second, narrower divergence: this check counts a key as declared when it is
+    **present**, while the loader counts it when it is **truthy** (it reads
+    ``raw.get("schedule", "") or ""`` and then tests ``if raw.get("every")``). So
+    an entry carrying ``schedule: ""`` alongside ``every: 300s`` loads fine — the
+    loader ignores the empty ``schedule`` — but is flagged here as multi-key. That
+    is the stricter-by-policy posture applied consistently: a falsy schedule key is
+    still a declaration a reader would have to reason about. Zero registry entries
+    look like this today; the filter is left presence-based deliberately rather
+    than relaxed to truthiness.
     """
     violations: list[str] = []
     name = entry.get("name")
@@ -92,13 +105,14 @@ def required_field_violations(entry: dict) -> list[str]:
     if not declared:
         violations.append(
             f"Entry {name} declares no schedule; exactly one of {list(SCHEDULE_KEYS)!r} "
-            f"is required (agent/reflection_scheduler.py:266-283)."
+            f"is required (see the schedule normalizer in "
+            f"agent/reflection_scheduler.py::load_registry)."
         )
     elif len(declared) > 1:
         violations.append(
-            f"Entry {name} declares {declared!r}; the loader "
-            f"(agent/reflection_scheduler.py:266-283) would silently pick by precedence "
-            f"schedule>every>cron>at. Declare exactly one."
+            f"Entry {name} declares {declared!r}; the loader's schedule normalizer "
+            f"(agent/reflection_scheduler.py::load_registry) would silently pick by "
+            f"precedence schedule>every>cron>at. Declare exactly one."
         )
 
     if "cron_tz" in entry and "cron" not in entry:

--- a/tests/unit/test_reflection_scheduler.py
+++ b/tests/unit/test_reflection_scheduler.py
@@ -44,7 +44,9 @@ def _registry_path() -> Path:
     """Resolve the live reflections registry the way the scheduler does.
 
     The in-repo ``config/reflections.yaml`` is only present after install
-    (install_worker.sh copies it from the iCloud-synced vault). Tests must use
+    (``install_reflection_worker.sh``, ``install_email_bridge.sh``, or
+    ``scripts/update/env_sync.py::sync_reflections_yaml`` copies it from the
+    iCloud-synced vault). Tests must use
     the same vault-first resolver the scheduler uses so they read the real file
     regardless of where it currently lives.
     """

--- a/tests/unit/test_reflection_scheduler.py
+++ b/tests/unit/test_reflection_scheduler.py
@@ -12,6 +12,7 @@ Tests cover:
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -19,6 +20,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
+import agent.reflection_scheduler as reflection_scheduler
 from agent.reflection_schedule import parse_every_duration
 from agent.reflection_scheduler import (
     DEFAULT_AGENT_TIMEOUT,
@@ -27,6 +29,7 @@ from agent.reflection_scheduler import (
     ReflectionEntry,
     ReflectionScheduler,
     _get_memory_rss,
+    _owning_checkout_root,
     _resolve_callable,
     _resolve_registry_path,
     execute_function_reflection,
@@ -58,6 +61,59 @@ def _entry_interval_seconds(entry: dict) -> int:
     return parse_every_duration(str(entry["every"]).strip())
 
 
+# The four schedule shapes the loader's normalizer accepts
+# (agent/reflection_scheduler.py:266-283), in its own precedence order.
+SCHEDULE_KEYS = ("schedule", "every", "cron", "at")
+
+
+def required_field_violations(entry: dict) -> list[str]:
+    """Return the registry-contract violations for one raw entry dict.
+
+    Extracted as a module-level predicate so the contract can be exercised
+    against synthetic entries without editing the live, gitignored registry.
+    An empty list means the entry satisfies the contract.
+
+    The schedule rule is **exactly one of** ``schedule`` / ``every`` / ``cron`` /
+    ``at``. Rejecting zero keys matches the loader, which cannot schedule such an
+    entry at all. Rejecting two-or-more is **stricter than the loader by policy**:
+    the normalizer at ``agent/reflection_scheduler.py:266-283`` resolves a
+    multi-key entry deterministically by precedence (schedule > every > cron > at)
+    rather than refusing it, so a multi-key entry would load with one of its
+    declarations silently discarded. This lint exists to stop that from reaching
+    the registry. If a future loader change formalizes multi-key support, that is
+    an intended divergence to re-decide here, not a bug in this test.
+    """
+    violations: list[str] = []
+    name = entry.get("name")
+    if "name" not in entry:
+        violations.append(f"Entry missing name: {entry}")
+
+    declared = [key for key in SCHEDULE_KEYS if key in entry]
+    if not declared:
+        violations.append(
+            f"Entry {name} declares no schedule; exactly one of {list(SCHEDULE_KEYS)!r} "
+            f"is required (agent/reflection_scheduler.py:266-283)."
+        )
+    elif len(declared) > 1:
+        violations.append(
+            f"Entry {name} declares {declared!r}; the loader "
+            f"(agent/reflection_scheduler.py:266-283) would silently pick by precedence "
+            f"schedule>every>cron>at. Declare exactly one."
+        )
+
+    if "cron_tz" in entry and "cron" not in entry:
+        violations.append(
+            f"Entry {name} declares cron_tz without cron; a timezone is meaningless "
+            f"for a non-cron schedule."
+        )
+
+    for required in ("priority", "execution_type"):
+        if required not in entry:
+            violations.append(f"Entry {name} missing {required}")
+
+    return violations
+
+
 # === Registry Loading Tests ===
 
 
@@ -80,6 +136,11 @@ class TestRegistryLoading:
     def test_load_registry_returns_only_enabled(self):
         """load_registry() filters out disabled entries."""
         entries = load_registry()
+        assert entries, (
+            "load_registry() returned no entries — the loop below would assert nothing. "
+            "This means registry resolution broke (see _resolve_registry_path's "
+            "exhausted-candidates error), not that every entry is disabled."
+        )
         for entry in entries:
             assert entry.enabled, f"Disabled entry '{entry.name}' should not be returned"
 
@@ -657,16 +718,24 @@ class TestRegistryIntegrity:
         assert "reflections" in data
 
     def test_all_entries_have_required_fields(self):
-        """All registry entries have name, every, priority, execution_type."""
+        """Every registry entry carries name, priority, execution_type and exactly
+        one schedule key.
+
+        The schedule rule accepts every shape the loader's normalizer accepts
+        (``schedule`` / ``every`` / ``cron`` / ``at``) and additionally rejects
+        multi-key entries — a lint **stricter than the loader by policy**, since
+        the loader resolves those by precedence instead of refusing them. See
+        ``required_field_violations`` for the full rationale.
+        """
         registry_path = _registry_path()
         with open(registry_path) as f:
             data = yaml.safe_load(f)
+        failures: list[str] = []
         for entry in data["reflections"]:
-            assert "name" in entry, f"Entry missing name: {entry}"
-            # Schema uses `every: Ns` (unified grammar), not a bare `interval`.
-            assert "every" in entry, f"Entry {entry.get('name')} missing every"
-            assert "priority" in entry, f"Entry {entry.get('name')} missing priority"
-            assert "execution_type" in entry, f"Entry {entry.get('name')} missing execution_type"
+            failures.extend(required_field_violations(entry))
+        assert not failures, "Registry entries violate the schedule contract:\n" + "\n".join(
+            failures
+        )
 
     def test_all_callables_resolve(self):
         """Every function-type entry's `callable:` dotted path must resolve.
@@ -1099,3 +1168,316 @@ reflections:
 
         assert len(entries) == 1
         assert entries[0].params == {"stall_advisory_telegram_enabled": True}
+
+
+# === Required-fields Predicate Tests ===
+
+
+class TestRequiredFieldsPredicate:
+    """The schedule contract, exercised against synthetic entries.
+
+    These assert against ``required_field_violations`` rather than the live
+    registry: the registry has no invalid entry and must never gain one just to
+    give a test something to fail on.
+    """
+
+    def test_entry_with_no_schedule_key_is_rejected(self):
+        entry = {"name": "no-schedule", "priority": "low", "execution_type": "function"}
+        violations = required_field_violations(entry)
+        assert violations, "an entry with no schedule key must be rejected"
+        assert "declares no schedule" in violations[0]
+
+    def test_entry_with_every_and_cron_is_rejected_as_ambiguous(self):
+        entry = {
+            "name": "ambiguous",
+            "priority": "low",
+            "execution_type": "function",
+            "every": "300s",
+            "cron": "0 9 * * *",
+        }
+        violations = required_field_violations(entry)
+        assert violations, "a multi-key entry must be rejected"
+        # The message must name the loader's precedence so a reader learns what
+        # would otherwise happen silently.
+        assert "schedule>every>cron>at" in violations[0]
+
+    def test_cron_only_entry_with_cron_tz_is_accepted(self):
+        entry = {
+            "name": "sdlc-upvote-pickup",
+            "priority": "normal",
+            "execution_type": "agent",
+            "cron": "0 9 * * *",
+            "cron_tz": "Asia/Bangkok",
+        }
+        assert required_field_violations(entry) == []
+
+    def test_cron_tz_without_cron_is_rejected(self):
+        entry = {
+            "name": "stray-tz",
+            "priority": "low",
+            "execution_type": "function",
+            "every": "300s",
+            "cron_tz": "Asia/Bangkok",
+        }
+        violations = required_field_violations(entry)
+        assert any("cron_tz without cron" in v for v in violations)
+
+
+# === Registry Path Resolution Tests ===
+
+
+@pytest.fixture(autouse=True)
+def _clear_exhausted_warned():
+    """Isolate the module-level exhausted-candidates dedup set.
+
+    ``_exhausted_warned`` is process-global, so without this the dedup test is
+    order-dependent: an earlier test that exhausts the same candidate set primes
+    it and the dedup test sees zero caplog records (or passes vacuously in the
+    reverse order). Cleared on entry *and* exit so this module neither inherits
+    nor leaks the state.
+    """
+    reflection_scheduler._exhausted_warned.clear()
+    yield
+    reflection_scheduler._exhausted_warned.clear()
+
+
+def _fake_module_file(root: Path) -> str:
+    """The path ``agent/reflection_scheduler.py`` would have inside ``root``.
+
+    Both ``_owning_checkout_root()`` and ``_resolve_registry_path()`` derive the
+    repo root as ``Path(__file__).parent.parent``, so patching the module's
+    ``__file__`` to this relocates both at once.
+    """
+    return str(root / "agent" / "reflection_scheduler.py")
+
+
+def _synthesize_worktree(tmp_path: Path, *, commondir: bool = True) -> tuple[Path, Path]:
+    """Build a linked-worktree layout under ``tmp_path``.
+
+    Returns ``(primary_root, worktree_root)``. Only the git metadata is created —
+    no ``config/reflections.yaml`` — because the locator performs no registry
+    existence check of its own.
+    """
+    primary = tmp_path / "primary"
+    admin = primary / ".git" / "worktrees" / "lane"
+    admin.mkdir(parents=True)
+    if commondir:
+        (admin / "commondir").write_text("../..\n")
+    worktree = tmp_path / "lane"
+    worktree.mkdir()
+    (worktree / ".git").write_text(f"gitdir: {admin}\n")
+    return primary, worktree
+
+
+class TestOwningCheckoutRoot:
+    """Unit tests for the pure git-metadata locator."""
+
+    def test_worktree_layout_returns_checkout_root_not_git_dir(self, tmp_path, monkeypatch):
+        """The locator returns the checkout *root* — the directory containing
+        ``.git`` — not the ``.git`` directory itself.
+
+        Anti-regression for the two branches diverging on ``.parent``: applying a
+        uniform ``.parent`` lands one directory above the checkout, whose
+        ``config/reflections.yaml`` does not exist, so the resolver would fall
+        through silently instead of finding the registry.
+        """
+        primary, worktree = _synthesize_worktree(tmp_path)
+        monkeypatch.setattr(reflection_scheduler, "__file__", _fake_module_file(worktree))
+
+        root = _owning_checkout_root()
+
+        assert root == primary
+        assert (root / ".git").exists(), "locator must return the root that contains .git"
+
+    def test_worktree_without_commondir_returns_checkout_root(self, tmp_path, monkeypatch):
+        """With no ``commondir`` file the locator falls back to ``parents[2]``,
+        which already *is* the checkout root for git's fixed layout."""
+        primary, worktree = _synthesize_worktree(tmp_path, commondir=False)
+        monkeypatch.setattr(reflection_scheduler, "__file__", _fake_module_file(worktree))
+
+        assert _owning_checkout_root() == primary
+
+    def test_primary_checkout_returns_none(self, tmp_path, monkeypatch):
+        """In the primary checkout ``.git`` is a directory: no owning checkout."""
+        primary = tmp_path / "primary"
+        (primary / ".git").mkdir(parents=True)
+        monkeypatch.setattr(reflection_scheduler, "__file__", _fake_module_file(primary))
+
+        assert _owning_checkout_root() is None
+
+    def test_malformed_git_file_returns_none(self, tmp_path, monkeypatch):
+        """Garbage with no ``gitdir:`` line degrades to None, never raises."""
+        root = tmp_path / "weird"
+        root.mkdir()
+        (root / ".git").write_text("this is not a gitdir pointer\nnor is this\n")
+        monkeypatch.setattr(reflection_scheduler, "__file__", _fake_module_file(root))
+
+        assert _owning_checkout_root() is None
+
+    def test_empty_git_file_returns_none(self, tmp_path, monkeypatch):
+        root = tmp_path / "empty"
+        root.mkdir()
+        (root / ".git").write_text("")
+        monkeypatch.setattr(reflection_scheduler, "__file__", _fake_module_file(root))
+
+        assert _owning_checkout_root() is None
+
+    def test_short_gitdir_returns_none_instead_of_index_error(self, tmp_path, monkeypatch):
+        """``gitdir: /a`` has fewer than three parents.
+
+        The explicit ``len(parents) > 2`` guard is what keeps this from raising
+        IndexError into the broad except, where it would be indistinguishable
+        from a genuinely unfamiliar layout.
+        """
+        root = tmp_path / "short"
+        root.mkdir()
+        (root / ".git").write_text("gitdir: /a\n")
+        monkeypatch.setattr(reflection_scheduler, "__file__", _fake_module_file(root))
+
+        assert _owning_checkout_root() is None
+
+    def test_relative_gitdir_returns_none(self, tmp_path, monkeypatch):
+        """``git worktree add --relative-paths`` writes a relative link.
+
+        Resolving it would anchor to the *process CWD* rather than the worktree
+        root and yield a silently wrong checkout, so the ``is_absolute()`` guard
+        routes it down the unfamiliar-layout path instead.
+        """
+        root = tmp_path / "relative"
+        root.mkdir()
+        (root / ".git").write_text("gitdir: ../.git/worktrees/x\n")
+        monkeypatch.setattr(reflection_scheduler, "__file__", _fake_module_file(root))
+
+        assert _owning_checkout_root() is None
+
+    def test_dangling_gitdir_still_returns_a_root(self, tmp_path, monkeypatch):
+        """A ``gitdir:`` pointing at a nonexistent directory still yields a root.
+
+        The locator does no ``exists()`` check by design — the resolver owns that,
+        which is what keeps the fourth candidate nameable in the diagnostic. Paired
+        with the resolver-side half in
+        ``test_dangling_gitdir_names_absent_candidate_in_exhausted_message``.
+        """
+        root = tmp_path / "dangling"
+        root.mkdir()
+        missing = tmp_path / "gone" / ".git" / "worktrees" / "lane"
+        (root / ".git").write_text(f"gitdir: {missing}\n")
+        monkeypatch.setattr(reflection_scheduler, "__file__", _fake_module_file(root))
+
+        assert _owning_checkout_root() == tmp_path / "gone"
+
+
+class TestResolverFourthCandidate:
+    """The resolver's owning-checkout level and its exhausted-candidates log."""
+
+    @pytest.fixture(autouse=True)
+    def _isolated_env(self, monkeypatch):
+        """Force the resolver past the env-var and vault levels.
+
+        VALOR_LAUNCHD=1 is the real nightly environment and deterministically
+        skips the ~/Desktop vault, so these tests measure levels 3 and 4 on any
+        machine regardless of whether a vault copy exists.
+        """
+        monkeypatch.delenv("REFLECTIONS_YAML", raising=False)
+        monkeypatch.setenv("VALOR_LAUNCHD", "1")
+
+    def test_worktree_hit_returns_owning_checkout_copy(self, tmp_path, monkeypatch):
+        primary, worktree = _synthesize_worktree(tmp_path)
+        (primary / "config").mkdir()
+        registry = primary / "config" / "reflections.yaml"
+        registry.write_text("reflections: []\n")
+        monkeypatch.setattr(reflection_scheduler, "__file__", _fake_module_file(worktree))
+
+        assert _resolve_registry_path() == registry
+
+    def test_malformed_git_file_falls_back_to_local_path_without_raising(
+        self, tmp_path, monkeypatch
+    ):
+        """The locator's broad ``except`` must show up as a fallback, not a crash."""
+        root = tmp_path / "weird"
+        root.mkdir()
+        (root / ".git").write_text("not a gitdir pointer at all\n")
+        monkeypatch.setattr(reflection_scheduler, "__file__", _fake_module_file(root))
+
+        assert _resolve_registry_path() == root / "config" / "reflections.yaml"
+
+    def test_exhausted_message_names_all_four_candidates(self, tmp_path, monkeypatch, caplog):
+        """An operator must be able to tell 'nothing anywhere' from 'wrong path'."""
+        primary, worktree = _synthesize_worktree(tmp_path)
+        monkeypatch.setattr(reflection_scheduler, "__file__", _fake_module_file(worktree))
+
+        with caplog.at_level(logging.ERROR, logger="agent.reflection_scheduler"):
+            resolved = _resolve_registry_path()
+
+        assert resolved == worktree / "config" / "reflections.yaml"
+        records = [r for r in caplog.records if "every candidate exhausted" in r.getMessage()]
+        assert len(records) == 1
+        message = records[0].getMessage()
+        assert "REFLECTIONS_YAML=<unset>" in message
+        assert "<vault skipped: VALOR_LAUNCHD>" in message
+        assert str(worktree / "config" / "reflections.yaml") in message
+        assert str(primary / "config" / "reflections.yaml") in message
+
+    def test_dangling_gitdir_names_absent_candidate_in_exhausted_message(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """The resolver half of the locator/resolver division of labour.
+
+        The locator hands back a root for a dangling ``gitdir:``; the resolver is
+        what discovers the registry is absent there, falls back, and still names
+        that concrete path.
+        """
+        root = tmp_path / "dangling"
+        root.mkdir()
+        missing_admin = tmp_path / "gone" / ".git" / "worktrees" / "lane"
+        (root / ".git").write_text(f"gitdir: {missing_admin}\n")
+        monkeypatch.setattr(reflection_scheduler, "__file__", _fake_module_file(root))
+
+        with caplog.at_level(logging.ERROR, logger="agent.reflection_scheduler"):
+            resolved = _resolve_registry_path()
+
+        assert resolved == root / "config" / "reflections.yaml"
+        message = next(
+            r.getMessage() for r in caplog.records if "every candidate exhausted" in r.getMessage()
+        )
+        assert str(tmp_path / "gone" / "config" / "reflections.yaml") in message
+
+    def test_primary_checkout_exhausted_message_marks_owner_unresolvable(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """With ``.git`` a directory the locator returns None, and the fourth slot
+        reads the literal placeholder — the contract that keeps the message at
+        four slots rather than three."""
+        primary = tmp_path / "primary"
+        (primary / ".git").mkdir(parents=True)
+        monkeypatch.setattr(reflection_scheduler, "__file__", _fake_module_file(primary))
+
+        with caplog.at_level(logging.ERROR, logger="agent.reflection_scheduler"):
+            resolved = _resolve_registry_path()
+
+        assert resolved == primary / "config" / "reflections.yaml"
+        message = next(
+            r.getMessage() for r in caplog.records if "every candidate exhausted" in r.getMessage()
+        )
+        assert "<owning checkout not resolvable>" in message
+
+    def test_exhausted_diagnostic_logs_once_per_candidate_set(self, tmp_path, monkeypatch, caplog):
+        """Eight call sites re-resolving in one process must not print eight
+        copies — but a *different* exhausted set must still get its own line."""
+        _primary_a, worktree_a = _synthesize_worktree(tmp_path / "a")
+        _primary_b, worktree_b = _synthesize_worktree(tmp_path / "b")
+
+        with caplog.at_level(logging.ERROR, logger="agent.reflection_scheduler"):
+            monkeypatch.setattr(reflection_scheduler, "__file__", _fake_module_file(worktree_a))
+            _resolve_registry_path()
+            _resolve_registry_path()
+            first_pass = [
+                r for r in caplog.records if "every candidate exhausted" in r.getMessage()
+            ]
+            assert len(first_pass) == 1, "same candidate set must log exactly once"
+
+            monkeypatch.setattr(reflection_scheduler, "__file__", _fake_module_file(worktree_b))
+            _resolve_registry_path()
+
+        all_records = [r for r in caplog.records if "every candidate exhausted" in r.getMessage()]
+        assert len(all_records) == 2, "a different exhausted candidate set must log its own line"


### PR DESCRIPTION
## Summary

Two independent defects on the gitignored reflections registry, the second of which hid the first.

**Defect 2 — the registry was unresolvable from a worktree under launchd.** `_resolve_registry_path` skips the `~/Desktop` vault whenever `VALOR_LAUNCHD` is set (the June 2026 macOS TCC hang workaround) and then falls through to an in-repo `config/reflections.yaml` its docstring called "always present". That file is gitignored and materialized only in the primary checkout, so **no worktree ever has it**. Eight registry-reading call sites blew up on a correctly-absent path, and `load_registry()` compounded it by failing open with `[]` — a production process inheriting `VALOR_LAUNCHD=1` from a worktree silently scheduled **zero reflections** behind a single WARNING.

**Defect 1 — the required-fields test encoded a narrower contract than the loader.** The test asserted every registry entry carries an `every` key; the loader accepts `every:` / `cron:` / `at:` / `schedule:` and folds all of them into one `schedule` string. The `sdlc-upvote-pickup` entry (PR #2721) is the first to use `cron:` and the first the stale assertion rejected. The entry is valid; the test was wrong.

## What changed

- **`_owning_checkout_root() -> Path | None`** — a private locator that answers "which checkout owns this one?" purely from git's on-disk worktree metadata (`.git` file → `gitdir:` → `commondir`). No `git` subprocess: `REGISTRY_PATH` is computed at import time inside a launchd worker, and a blocking subprocess there is the exact hazard the surrounding code exists to prevent. Returns `None` on a `.git` directory (primary checkout), a relative `gitdir:` (git can write those via `--relative-paths`; resolving against process CWD gives a silently wrong root), a short `gitdir:`, or any parse failure.
- **A fourth resolution level in `_resolve_registry_path`** — when this checkout's `config/reflections.yaml` is absent, read the owning checkout's copy. The **resolver**, not the locator, builds the candidate and owns the `exists()` check; that split is what keeps the fourth slot nameable in the diagnostic. The `REFLECTIONS_YAML`, vault, and `VALOR_LAUNCHD` branches are untouched in order and semantics, and the `~/Desktop` realpath guard in `load_registry()` is unmodified — the TCC guard is sidestepped, not weakened.
- **An exhausted-candidates diagnostic** — when nothing is reachable anywhere, one legible error names all four slots (the concrete owning-checkout path, or the literal `<owning checkout not resolvable>`), deduplicated per candidate set via a module-level `_exhausted_warned`, then returns the local in-repo path as before so no new exception escapes at import.
- **Exactly-one-of schedule contract** — the required-fields check is extracted into a module-level predicate and now requires exactly one of `every` / `cron` / `at` / `schedule`, plus `cron_tz` only alongside `cron`. Rejecting two-or-more is an intentional lint **stricter than the loader by policy** (the loader resolves multi-key entries by precedence `schedule>every>cron>at`); the failure text names that precedence so a future grammar change reads as intended divergence. The registry was **not** edited — no `every:` bolted onto the cron entry.
- **De-vacuumed `test_load_registry_returns_only_enabled`** — it asserts a non-empty registry before iterating, so it can never again pass while asserting nothing.
- **Docs** — the four-level fallback documented, all ten stale "symlink" claims in `docs/features/reflections.md` corrected to the real-file-copy invariant `sync_reflections_yaml()` actually maintains, a worktree-manager note on gitignored install-time artifacts, and the two `reflection_register.py` docstrings whose C6 claim this change would otherwise falsify.

## Demonstrated red → green

Measured from this lane's own build worktree, in place, before any of this code existed:

| Block | Environment | Pre-build | Post-build |
|---|---|---|---|
| `SC1` `TestRegistryIntegrity` | build worktree + `VALOR_LAUNCHD=1` | **5 failed** | **5 passed** |
| `SC2` `TestRegistryIntegrity` | build worktree, `VALOR_LAUNCHD` unset | 1 failed, 4 passed | **5 passed** |
| `SC3` `TestRegistryLoading` | build worktree + `VALOR_LAUNCHD=1` | 2 failed, 5 passed | **7 passed** |
| `SC4` `test_plan_migration_invariant.py` | build worktree + `VALOR_LAUNCHD=1` | 1 failed, 4 passed | **5 passed** |
| `SC0` `TestRegistryIntegrity` | primary checkout | 1 failed, 4 passed | — |
| `MOD` whole module | — | 1 failed, 56 passed | **75 passed** |
| `EXH` `-k exhausted` | — | 57 deselected (no such test) | **4 passed** |

Every SC block was confirmed to have run in a linked worktree (`grep -c "not a linked worktree"` = 0 on each captured output), so none of the greens is the false positive a primary-checkout paste would produce.

Other Verification rows, all green: `CALL` 1 passed, `FNF` 0, `LOAD` 7 passed, `MIG` 5 passed, `grep -c "always present"` 0, `VALOR_LAUNCHD` count 7 (>2), both `subprocess` import forms 0, `grep -ci symlink docs/features/reflections.md` 2 (was 10), C6 claim 0 (was 1), registry-copies projection `MATCH`, ruff check and format clean.

**Both registry copies are byte-identical to the pre-build baseline** (`shasum -a 256 -c` → two `OK` lines). A `git diff` cannot prove this — the file is gitignored and untracked — which is why the baseline was captured with absolute paths in task 1.

## Notes for review

- `scripts/validate_build.py` reports FAILs on this plan that are **parser artifacts, not findings**: it cannot execute the plan's `block \`SC1\`` label indirection (exit 127 on every block row), and it treats `grep -c` returning `0` with exit status 1 as a failure even when `0` is the expected result. Every row was run by hand; results are tabulated above.
- `scripts/validate_docs_changed.py` exits 2 (non-blocking stale-marker warning), not 1 or 3.
- **Risk 3 is documented, not fixed.** `scripts/update/reflection_register.py::_resolve_target` reuses this resolver as a *write* target. After this change a worktree caller under `VALOR_LAUNCHD=1` would write to the primary checkout's install-time copy and lose the registration at the next `/update` — quieter than today's loud "registry not found; will retry". No worktree caller reaches it (`_this_machine_owns_valor` fails closed, and `reflection_register` runs only inside `/update` in the primary checkout), which is why this is contained rather than blocking. That containment is load-bearing and must not be relaxed without first splitting the resolver into separate read and write functions — the plan's `[ORDERED]` No-Go, now cross-referenced from the rewritten docstring.

## Greens a long-standing failure other lanes keep footnoting

`tests/unit/test_reflection_scheduler.py::TestRegistryIntegrity::test_all_entries_have_required_fields` has been red on `main` and is routinely written off as "pre-existing". It is Defect 1 of this issue, and this PR fixes it.

Verified by running `main`'s own copy of the test file against the live registry:

```
tests/unit/test_zz_main_baseline_tmp.py:667: in test_all_entries_have_required_fields
    assert "every" in entry, f"Entry {entry.get('name')} missing every"
E   AssertionError: Entry sdlc-upvote-pickup missing every
1 failed in 7.92s
```

The `sdlc-upvote-pickup` entry (added by #2721) is the first to use `cron:` instead of `every:`. The entry is valid and the reflection runs correctly; `main`'s assertion is simply wrong about the schedule grammar. Replacing it with the exactly-one-of contract takes the module to **75 passed**.

## Follow-up filed

Round-3 review found that both docstrings in `scripts/update/reflection_register.py` asserted a containment that does not hold: they claimed running in the primary checkout is what keeps critique C6 true. The resolver actually gates its vault level on `VALOR_LAUNCHD`, not on checkout identity, so under `VALOR_LAUNCHD=1` the primary checkout resolves to the soon-clobbered config copy:

```
VALOR_LAUNCHD=1     -> <repo>/config/reflections.yaml     (clobbered copy)
VALOR_LAUNCHD unset -> ~/Desktop/Valor/reflections.yaml   (correct)
```

`43c165bd7` corrects both docstrings and the plan's Risk 3. The underlying behavior is **not** changed here: the real fix needs the read/write resolver split this plan records as an `[ORDERED]` No-Go, now tracked as **#2855**.

Plan: `docs/plans/reflection-registry-schedule-contract.md`

Closes #2734

