### PR TITLE
fix(tests): update stale steering/expectations assertions (#2846, #2822)

### DIFF
--- a/docs/features/drafter-redundancy-suppression.md
+++ b/docs/features/drafter-redundancy-suppression.md
@@ -44,7 +44,7 @@ Evaluated in order; the first matching condition returns `"send"` immediately:
 
 1. **Empty draft** — `draft_text` is empty or whitespace-only.
 2. **No baseline** — `recent_sent_drafts` is `None` or empty (cannot be redundant).
-3. **Has expectations** — `MessageDraft.expectations` is non-empty (drafter detected
+3. **Has open questions** — `MessageDraft.open_questions` is non-empty (drafter detected
    a question for the human; this send is intentional).
 4. **Terminal status** — `session.status` is `"completed"`, `"failed"`, or `"blocked"`.
 5. **New artifact** — The new draft contains an artifact (PR URL, commit hash, error
@@ -122,7 +122,7 @@ contract:
 - `session_status=None` — intentionally bypasses the `_TERMINAL_STATUSES`
   exemption (which is correct for the in-session drafter but wrong for the
   completion runner, where dedupe IS desired even on terminal sessions).
-- `expectations=None` — Pass 2 of the runner returns plain text, not a
+- `open_questions=None` — Pass 2 of the runner returns plain text, not a
   `MessageDraft`.
 
 Baseline source is `chat_message_log` outbound entries (Path A + Path B

--- a/docs/features/message-drafter.md
+++ b/docs/features/message-drafter.md
@@ -61,7 +61,7 @@ class MessageDraft:
     needs_self_draft: bool = False            # True when a blocking flag fired (violation or empty promise)
     artifacts: dict[str, list[str]] = {}      # commit hashes, URLs, PRs
     context_summary: str | None = None        # deterministic one-sentence routing hint
-    expectations: str | None = None           # open questions (None when absent, never "")
+    open_questions: str | None = None         # open questions (None when absent, never "")
     violations: list[Violation] = []          # wire-format violations for agent review
     context_recall_advisory: str | None = None  # history-read command when the PM asked the human
                                                 # to re-identify a referent (#2694)
@@ -79,8 +79,8 @@ Note: `was_drafted` has been removed. The drafter no longer calls any LLM — th
 4. If over `FILE_ATTACH_THRESHOLD`, write a full-output `.txt` file (delivery still proceeds).
 5. If `_evaluate_drafter_promise` fires (agent made a promise without substance — "will do", "I'll follow up" etc.) **or** `_validate_for_medium` returns any non-empty `violations` list (markdown table, local file-path reference, etc.): return `MessageDraft(text="", needs_self_draft=True, violations=[...])` — caller injects a self-draft steering nudge. **Both** promotions happen on **both** return points — the short-output early return (see below) and this main-path return — so neither a wire-format violation (issue #1955) nor an empty promise (issue #2421) ever ships silently regardless of message length. Every gate decision writes a `source="promise_gate_drafter"` audit entry to `logs/classification_audit.jsonl`. All promoted drafts route through the self-draft steering path (`agent/output_handler.py:429-441`), the mechanism actually live for eng/session_runner sessions; `agent/hooks/stop.py`'s stop-hook "delivery review gate" is dead code on that path and is **not** a violation-surfacing mechanism today — see [Agent-Controlled Message Delivery](agent-message-delivery.md#stop-hook-review-gate-agenthooksstoppy). Steering is not always consumable, though: on a session's **final** turn there is no next turn left to receive the nudge, so a `local_file_path_reference` violation there falls to a second remedy — the terminal flush's `convert_local_paths_to_attachments` conversion (see [Agent-Controlled Message Delivery §Validator-aware terminal flush](agent-message-delivery.md#validator-aware-terminal-flush-local-path--attachment-conversion-2211)).
 6. Populate `context_summary` from `_derive_context_summary(stripped_raw_text)`.
-7. Populate `expectations` from `_extract_open_questions(stripped_raw_text)` — `None` when no questions, never `""`.
-8. Return `MessageDraft(text=<composed>, context_summary=..., expectations=..., violations=[...])`.
+7. Populate `open_questions` from `_extract_open_questions(stripped_raw_text)` — `None` when no questions, never `""`.
+8. Return `MessageDraft(text=<composed>, context_summary=..., open_questions=..., violations=[...])`.
 
 ### Short-output early return (D5a)
 
@@ -181,9 +181,9 @@ Derives a coarse one-sentence routing hint from the narration-stripped text. Thi
 
 ### `_extract_open_questions(text) -> list[str]`
 
-The sole source of the `expectations` field. Scans the text for a `## Open Questions` heading and extracts substantive list items below it. Returns empty list if no section is found, the section is empty, or it contains only placeholders.
+The sole source of the `open_questions` field. Scans the text for a `## Open Questions` heading and extracts substantive list items below it. Returns empty list if no section is found, the section is empty, or it contains only placeholders.
 
-**None-vs-empty contract**: `expectations` on `MessageDraft` is `None` when no questions are found, never `""`. `_persist_routing_fields` in `output_handler.py` only writes `expectations` when it is not `None`, preserving any prior persisted value when no new questions are present.
+**None-vs-empty contract**: `open_questions` on `MessageDraft` is `None` when no questions are found, never `""`. `_persist_routing_fields` in `output_handler.py` persists only `context_summary`; the drafter's `open_questions` is a transient concept and is never written to the session row (Job expectations, #2708, are the durable obligation record).
 
 ## Drafter-at-the-handler (the critical fix)
 

--- a/docs/features/pm-final-delivery.md
+++ b/docs/features/pm-final-delivery.md
@@ -335,7 +335,7 @@ existing `send_cb` call:
      `_TERMINAL_STATUSES` exemption — that exemption is correct for the
      in-session drafter path but the completion runner is a different
      surface where dedupe IS desired)
-   - `expectations=None` (Pass 2 returns plain text, not a `MessageDraft`)
+   - `open_questions=None` (Pass 2 returns plain text, not a `MessageDraft`)
 
    The caller then enforces the high-confidence cutoff
    (`DRAFTER_COMPLETION_REDUNDANCY_THRESHOLD`, default `0.75`):

--- a/docs/plans/fix-stale-tests-2846-2822.md
+++ b/docs/plans/fix-stale-tests-2846-2822.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: docs_complete
 type: bug
 appetite: Small
 owner: dev

--- a/tests/unit/test_bridge_ack_steering_routed.py
+++ b/tests/unit/test_bridge_ack_steering_routed.py
@@ -11,7 +11,7 @@ branch added for issue #1215.
 """
 
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -73,9 +73,25 @@ class TestSteerBranch:
                 sender_name="Alice",
                 text="please update the readme",
                 log_context="[test] steer log",
+                room_id="test|system",
+                context_advisory="advisory text",
             )
 
-        push.assert_called_once_with("sess-1", "please update the readme", "Alice", is_abort=False)
+        # Human message + context-recall advisory both ride the Room leg
+        # (same room_id) — #2694. The advisory is a second steering message,
+        # never appended to the human's text.
+        assert len(push.call_args_list) == 2
+        assert push.call_args_list[0] == call(
+            "sess-1", "please update the readme", "Alice", is_abort=False, room_id="test|system"
+        )
+        assert push.call_args_list[1] == call(
+            "sess-1",
+            "advisory text",
+            "intake-classifier",
+            is_abort=False,
+            room_id="test|system",
+            front=False,
+        )
         react.assert_awaited_once()
         # Steer reaction is the standard "received" eyes
         args, _ = react.await_args
@@ -108,7 +124,9 @@ class TestAbortBranch:
                 log_context="[test] abort log",
             )
 
-        push.assert_called_once_with("sess-1", "stop", "Alice", is_abort=True)
+        # An abort is demoted to the legacy leg regardless of room_id, so
+        # the None default (no room_id passed) pins the legacy leg.
+        push.assert_called_once_with("sess-1", "stop", "Alice", is_abort=True, room_id=None)
         react.assert_awaited_once()
         args, _ = react.await_args
         assert args[3] == "\U0001fae1"  # 🫡
@@ -135,8 +153,9 @@ class TestAbortBranch:
                 text="  STOP  ",
                 log_context="[test]",
             )
-        # is_abort should still be detected after strip + lower
-        push.assert_called_once_with("sess-1", "  STOP  ", "Alice", is_abort=True)
+        # is_abort should still be detected after strip + lower; abort lands
+        # on the legacy leg (room_id=None), never a Room leg.
+        push.assert_called_once_with("sess-1", "  STOP  ", "Alice", is_abort=True, room_id=None)
 
 
 class TestDefensiveReaction:
@@ -217,10 +236,15 @@ class TestMediaEnrichment:
                 sender_name="Alice",
                 text="--file attachment only--",
                 log_context="[test]",
+                room_id="test|system",
             )
 
         push.assert_called_once_with(
-            "sess-1", "[Document content: hello world]", "Alice", is_abort=False
+            "sess-1",
+            "[Document content: hello world]",
+            "Alice",
+            is_abort=False,
+            room_id="test|system",
         )
 
     @pytest.mark.asyncio
@@ -249,10 +273,13 @@ class TestMediaEnrichment:
                 sender_name="Alice",
                 text="check this out",
                 log_context="[test]",
+                room_id="test|system",
             )
 
         expected = "[User sent an image]\nImage description: cat\n\ncheck this out"
-        push.assert_called_once_with("sess-1", expected, "Alice", is_abort=False)
+        push.assert_called_once_with(
+            "sess-1", expected, "Alice", is_abort=False, room_id="test|system"
+        )
 
     @pytest.mark.asyncio
     async def test_text_only_path_skips_process_incoming_media(self):
@@ -279,10 +306,13 @@ class TestMediaEnrichment:
                 sender_name="Alice",
                 text="hello",
                 log_context="[test]",
+                room_id="test|system",
             )
 
         proc.assert_not_awaited()
-        push.assert_called_once_with("sess-1", "hello", "Alice", is_abort=False)
+        push.assert_called_once_with(
+            "sess-1", "hello", "Alice", is_abort=False, room_id="test|system"
+        )
 
     @pytest.mark.asyncio
     async def test_process_incoming_media_failure_leaves_sentinel_intact(self):
@@ -311,10 +341,13 @@ class TestMediaEnrichment:
                 sender_name="Alice",
                 text="--file attachment only--",
                 log_context="[test]",
+                room_id="test|system",
             )
 
         # Push still happens with the sentinel (defensive fallback).
-        push.assert_called_once_with("sess-1", "--file attachment only--", "Alice", is_abort=False)
+        push.assert_called_once_with(
+            "sess-1", "--file attachment only--", "Alice", is_abort=False, room_id="test|system"
+        )
         rec.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -357,9 +390,12 @@ class TestMediaEnrichment:
                 sender_name="Alice",
                 text="--file attachment only--",
                 log_context="[test]",
+                room_id="test|system",
             )
 
-        push.assert_called_once_with("sess-1", "[Document content: hi]", "Alice", is_abort=False)
+        push.assert_called_once_with(
+            "sess-1", "[Document content: hi]", "Alice", is_abort=False, room_id="test|system"
+        )
         rec.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/tests/unit/test_context_recall_wiring.py
+++ b/tests/unit/test_context_recall_wiring.py
@@ -53,7 +53,6 @@ def _clean_draft(text="Which PR do you mean?"):
         needs_self_draft=False,
         artifacts={},
         context_summary="asked which PR",
-        expectations=None,
     )
 
 
@@ -188,7 +187,6 @@ class TestOutboundBounce:
             needs_self_draft=True,
             artifacts={},
             context_summary="c",
-            expectations=None,
         )
 
         with (
@@ -228,7 +226,6 @@ class TestOutboundBounce:
             needs_self_draft=True,
             artifacts={},
             context_summary="c",
-            expectations=None,
         )
         bump = MagicMock(return_value=1)
 
@@ -291,7 +288,6 @@ class TestBudgetExhaustionKeepsTheDraft:
             needs_self_draft=True,
             artifacts={},
             context_summary="c",
-            expectations=None,
         )
         raw = "Let me investigate. Which PR do you mean?"
 
@@ -319,7 +315,6 @@ class TestAdvisoriesCoexist:
             needs_self_draft=True,
             artifacts={},
             context_summary="c",
-            expectations=None,
         )
         draft.promise_advisory = "PROMISE-ADVISORY-TEXT"
         pushed = []

--- a/tests/unit/test_reaction_never_hostile.py
+++ b/tests/unit/test_reaction_never_hostile.py
@@ -143,7 +143,6 @@ class TestFindBestEmojiNeverHostile:
         }
         with (
             patch("tools.emoji_embedding._embedding_cache", fake_cache),
-            patch("tools.emoji_embedding._custom_embedding_cache", {}),
             patch.dict("os.environ", {"OPENROUTER_API_KEY": "test-key"}),
             patch(
                 "tools.emoji_embedding._compute_embedding",

--- a/tests/unit/test_steer_child.py
+++ b/tests/unit/test_steer_child.py
@@ -91,6 +91,9 @@ class TestSteerChild:
             text="stop everything",
             sender="pm",
             is_abort=True,
+            # Load-bearing literal: an abort is destructive and non-idempotent,
+            # so it must die with the session it was aimed at (legacy key).
+            room_id=None,
         )
 
     @patch(_AGENT_SESSION)

--- a/tests/unit/test_valor_session_resume_release.py
+++ b/tests/unit/test_valor_session_resume_release.py
@@ -57,6 +57,11 @@ def _make_session(
     s.retain_for_resume = retain
     s.pr_url = pr_url
     s.slug = slug
+    # A real project_key string so the resume path's derived room id
+    # (room_id_for_session → "test|system") is assertable rather than a
+    # MagicMock repr. Shared by ~30 call sites; no test asserts on
+    # project_key being absent.
+    s.project_key = "test"
     # Default to a non-null UUID so existing happy-path tests continue to
     # exercise the status-guard path without tripping the null-UUID guard
     # added in issue #1061. Tests that want to exercise the null-UUID path
@@ -179,7 +184,9 @@ class TestCmdResumeHappyPath:
 
         assert result == 0
         # Steering message must be pushed to Redis before transition_status is called
-        mock_push.assert_called_once_with("sess-ok", "Do the patch.", "resume:valor-session resume")
+        mock_push.assert_called_once_with(
+            "sess-ok", "Do the patch.", "resume:valor-session resume", room_id="test|system"
+        )
         mock_transition.assert_called_once_with(
             session, "pending", reason="resume (valor-session resume)", reject_from_terminal=False
         )
@@ -290,7 +297,10 @@ class TestCmdResumeKilledFailedSupport:
         )
         assert result == 0
         mock_push.assert_called_once_with(
-            "sess-k", "Pick up where we left off.", "resume:valor-session resume"
+            "sess-k",
+            "Pick up where we left off.",
+            "resume:valor-session resume",
+            room_id="test|system",
         )
         mock_transition.assert_called_once_with(
             session, "pending", reason="resume (valor-session resume)", reject_from_terminal=False
@@ -300,7 +310,9 @@ class TestCmdResumeKilledFailedSupport:
         session = _make_session("sess-f", status="failed", claude_session_uuid="uuid-failed")
         result, mock_transition, mock_push = self._run_resume(session, message="Recover.")
         assert result == 0
-        mock_push.assert_called_once_with("sess-f", "Recover.", "resume:valor-session resume")
+        mock_push.assert_called_once_with(
+            "sess-f", "Recover.", "resume:valor-session resume", room_id="test|system"
+        )
         mock_transition.assert_called_once_with(
             session, "pending", reason="resume (valor-session resume)", reject_from_terminal=False
         )
@@ -456,7 +468,10 @@ class TestCmdResumeAbandonedSupport:
         )
         assert result == 0
         mock_push.assert_called_once_with(
-            "sess-a", "Pick up where we left off.", "resume:valor-session resume"
+            "sess-a",
+            "Pick up where we left off.",
+            "resume:valor-session resume",
+            room_id="test|system",
         )
         mock_transition.assert_called_once()
         _, kwargs = mock_transition.call_args
@@ -508,6 +523,8 @@ class TestResumeSessionCore:
         s.status = status
         s.claude_session_uuid = uuid
         s.model = "claude-opus-4-5"
+        # Real project_key so the derived room id is assertable ("test|system").
+        s.project_key = "test"
         return s
 
     def _patch_lifecycle(self, mock_transition=None, resumable=None):
@@ -619,7 +636,9 @@ class TestResumeSessionCore:
 
         assert result.success is True
         assert call_order.index("push") < call_order.index("transition")
-        mock_push.assert_called_once_with("core-sess", "continue", "resume:cli")
+        mock_push.assert_called_once_with(
+            "core-sess", "continue", "resume:cli", room_id="test|system"
+        )
 
     def test_transition_error_returns_failure(self):
         session = self._make_mock_session(status="failed")


### PR DESCRIPTION
## Summary

`main` is red at ~30 unit-test nodes. This lane clears 26 of them across two
issues of the same root class: a merged rename/deletion that missed its test
seams. Production code is correct in every case; the tests are stale.

**No production-source change.** Only 5 test files are edited.

## Changes

- **Cluster A1 — `test_bridge_ack_steering_routed.py` (8 tests):** the 6
  steer/media tests pass an explicit `room_id="test|system"` into
  `_ack_steering_routed` and assert it arrives unchanged at
  `push_steering_message` (pinning the live Room-leg pass-through); the 2
  abort tests keep the `None` default and assert `room_id=None` (the legacy
  leg an abort always lands on). Also asserts the `context_advisory` push
  rides the same leg as the human message.
- **Cluster A2 — `test_steer_child.py::test_abort_flag`:** add `room_id=None`
  to the assertion (load-bearing literal — an abort must die with its session).
- **Cluster A3 — `test_valor_session_resume_release.py` (5 tests):** set
  `project_key="test"` in both session helpers so the derived room id is
  assertable; add `room_id="test|system"` to the 5 resume assertions.
- **Cluster B — `test_reaction_never_hostile.py`:** delete the
  `_custom_embedding_cache` patch line (module global removed by #2835);
  confirmed demonstrated-red (test fails when the block filter is removed).
- **Cluster C — `test_context_recall_wiring.py` (11 tests):** remove the
  `expectations=None` kwarg from 5 `MessageDraft(...)` constructions (field
  renamed to `open_questions` by #2814).

## Verification

- #2846 reproduction command: 69 passed
- #2822 reproduction command: 28 passed
- Caller-sweep grep clean (no `push_steering_message` assertion lacks the
  intended `room_id`; no `expectations=` remains)
- `ruff check` / `ruff format` clean
- No `Co-Authored-By` trailers

Closes #2846
Closes #2822