### PR TITLE
fix(docs): correct stale reflection name and granite doc references

### DIFF
--- a/bridge/email_bridge.py
+++ b/bridge/email_bridge.py
@@ -1084,7 +1084,7 @@ def _query_non_terminal_sessions(project_key: str) -> list:
     # ghost as a live record (popoto silently drops empty hashes), so
     # subject-coalescing can never attach to a session that no longer exists
     # -- this call only accelerates removing the stale index entry instead of
-    # waiting for the nightly popoto-index-cleanup sweep. Rate-limited
+    # waiting for the daily redis-index-cleanup sweep. Rate-limited
     # internally; see models/ghost_reconcile.py.
     from models.ghost_reconcile import reconcile_ghost_members
     from models.session_lifecycle import NON_TERMINAL_STATUSES

--- a/config/enums.py
+++ b/config/enums.py
@@ -21,7 +21,9 @@ class SessionType(StrEnum):
     ``valor-granite-loop`` CLI) was deleted with the PTY substrate (plan
     #1924). The value is retained so pre-cutover Redis records that carry
     ``session_type="granite"`` keep hydrating and rendering; nothing creates
-    new sessions with it. Removal is #1927's (schema diet) scope.
+    new sessions with it. Removing the member would be a schema change, not
+    a prose change; the schema-diet issue that owned removal closed without
+    acting, so it needs a fresh decision.
     """
 
     ENG = "eng"

--- a/docs/features/standardized-enums.md
+++ b/docs/features/standardized-enums.md
@@ -10,13 +10,13 @@ All magic strings for session types, persona identifiers, access levels, and cla
 
 ### SessionType
 
-Discriminator for AgentSession: eng, teammate, or granite.
+Discriminator for AgentSession: eng or teammate (`granite` is a historical value; see the row below).
 
 | Member | Value | Usage |
 |--------|-------|-------|
 | `SessionType.ENG` | `"eng"` | Eng session -- engineer persona, full permissions; handles both SDLC work and conversational responses |
 | `SessionType.TEAMMATE` | `"teammate"` | Teammate session -- conversational, informational queries |
-| `SessionType.GRANITE` | `"granite"` | Direct invocations of the standalone `valor-granite-loop` CLI (`tools/granite_interactive_tui_poc/cli.py`); labels CLI-originated sessions so they are not misclassified as bridge-originated. Bridge sessions that run through the granite PTY container are typed `ENG`. |
+| `SessionType.GRANITE` | `"granite"` | Historical value. Its sole producer, the standalone `valor-granite-loop` CLI, was deleted with the PTY substrate (plan #1924); nothing creates new sessions with it. Retained so pre-cutover Redis records carrying `session_type="granite"` keep hydrating and rendering. |
 
 ### PersonaType
 

--- a/models/dedup.py
+++ b/models/dedup.py
@@ -66,8 +66,8 @@ class DedupRecord(Model):
         # model to accumulate ghost index members (hash expired, class-set
         # membership survives). get_or_create() runs on every inbound
         # message, so it is a good place to opportunistically self-heal the
-        # index instead of waiting up to 24h for the nightly
-        # popoto-index-cleanup reflection. Rate-limited internally (at most
+        # index instead of waiting up to 24h for the daily
+        # redis-index-cleanup reflection. Rate-limited internally (at most
         # once/60s) -- safe to call unconditionally on every read.
         # query.filter() itself already silently drops ghost members from
         # `existing` (never attaches a dead record's data); this only

--- a/models/ghost_reconcile.py
+++ b/models/ghost_reconcile.py
@@ -20,7 +20,7 @@ What is ALREADY safe (verified empirically, see tests/unit/test_ghost_reconcile.
     session) is not reachable through ``.filter()``/``.all()`` today.
 
 What is NOT safe: the ghost member itself is never removed from the index.
-Left alone it is only cleaned by the nightly ``popoto-index-cleanup``
+Left alone it is only cleaned by the daily ``redis-index-cleanup``
 reflection (``scripts/popoto_index_cleanup.py``, once/24h), so between hash
 expiry and that sweep:
     - every query pays an extra round-trip per ghost and logs a
@@ -33,7 +33,7 @@ hash TTL: Redis SETs/ZSETs have no per-member expiry primitive, so "TTL the
 index members" would require re-modeling every index as a ZSET keyed by
 expiry and a periodic ZREMRANGEBYSCORE sweep -- strictly more code and risk
 than reusing the SCAN-based, production-safe primitive popoto already ships
-(``Model.clean_indexes()``, the same one the nightly reflection calls).
+(``Model.clean_indexes()``, the same one the daily reflection calls).
 Reconcile-on-read just moves that primitive earlier: instead of waiting up to
 24h for the scheduled sweep, a ghost-prone read path (dedup lookups, email
 subject-coalescing) triggers it inline, rate-limited so a hot path never pays

--- a/scripts/popoto_index_cleanup.py
+++ b/scripts/popoto_index_cleanup.py
@@ -304,7 +304,7 @@ def _run_guarded_repairs() -> dict:
     is the cadence their own code assumes: ``Job.repair_indexes()`` closes by
     calling ``Job.backfill_open_expectations_index()``, documented as a *daily*
     re-derivation of the ``has_open_expectations`` flag. ``run_cleanup`` runs on
-    the daily ``popoto-index-cleanup`` reflection plus once per worker start.
+    the daily ``redis-index-cleanup`` reflection plus once per worker start.
 
     Both repair methods return ``(quarantined, rebuilt)`` and both take a
     non-blocking ``_repair_lock``, returning ``(0, 0)`` when another thread

--- a/tests/README.md
+++ b/tests/README.md
@@ -281,6 +281,7 @@ tests/
 | unit | `test_validate_commit_message.py` | 16 | Commit message format |
 | unit | `test_validate_sdlc_on_stop.py` | 12 | SDLC stop validation |
 | unit | `test_build_validation.py` | 6 | Build process validation |
+| unit | `test_stale_reference_sweep.py` | 3 | Stale-prose sweep (#2853, #2839): the unregistered reflection name, the two deleted granite package paths, and a scoped cadence-wording anti-criterion. Enumerates via `git ls-files` (untracked scratch Markdown is not repo content) and assembles every compared token by concatenation so the file cannot trip its own sweeps |
 | unit | `test_site_graph_consistency.py` | 2 | Public-site knowledge-graph staleness (#2531): every `data-files` chip reference resolves to a `graph.js` node; frameworks named by the graph are still declared dependencies |
 
 ### `reflections` — Learning system

--- a/tests/unit/test_stale_reference_sweep.py
+++ b/tests/unit/test_stale_reference_sweep.py
@@ -35,7 +35,10 @@ Three trade-offs, deliberate:
   "nightly" from those four files. A future author with a legitimate reason
   to use it there (a nightly digest in the email bridge is the obvious case)
   should read this docstring and extend or narrow `_NIGHTLY_SCOPED`
-  knowingly, rather than deleting or muting the assertion.
+  knowingly, rather than deleting or muting the assertion. Each scoped path
+  is asserted to exist before it is read, so a rename or deletion fails the
+  test by name instead of quietly shrinking its coverage -- the silent-death
+  mode that killed every earlier gate for this defect class.
 - Enumeration is further scoped by suffix to `.py`/`.md`/`.yaml`/`.yml`/
   `.toml`, so a stale token sitting in a tracked file of any other suffix --
   shell scripts, JSON, HTML, plist, or plain text, 146 tracked files outside
@@ -156,10 +159,12 @@ def test_no_nightly_cadence_at_scoped_sites():
     hits: list[str] = []
     for rel_str in _NIGHTLY_SCOPED:
         abs_path = REPO_ROOT / rel_str
-        try:
-            text = abs_path.read_text(encoding="utf-8", errors="ignore")
-        except OSError:
-            continue
+        assert abs_path.is_file(), (
+            f"{rel_str} is listed in _NIGHTLY_SCOPED but is not a readable file. "
+            "A rename or deletion would otherwise drop it from this sweep in "
+            "silence -- update the tuple deliberately."
+        )
+        text = abs_path.read_text(encoding="utf-8", errors="ignore")
         for lineno, line in enumerate(text.splitlines(), start=1):
             if _NIGHTLY_TOKEN in line:
                 hits.append(f"{rel_str}:{lineno}")

--- a/tests/unit/test_stale_reference_sweep.py
+++ b/tests/unit/test_stale_reference_sweep.py
@@ -22,7 +22,7 @@ Three assertions, all scoped to tracked content:
    reach it. It was found only by scoping this exact anti-criterion to the
    four files during plan revision.
 
-Two trade-offs, deliberate:
+Three trade-offs, deliberate:
 
 - Enumeration walks `git ls-files`, never `os.walk`/`rglob`. An untracked
   file is not repo content, and this machine routinely grows untracked
@@ -36,6 +36,18 @@ Two trade-offs, deliberate:
   to use it there (a nightly digest in the email bridge is the obvious case)
   should read this docstring and extend or narrow `_NIGHTLY_SCOPED`
   knowingly, rather than deleting or muting the assertion.
+- Enumeration is further scoped by suffix to `.py`/`.md`/`.yaml`/`.yml`/
+  `.toml`, so a stale token sitting in a tracked file of any other suffix --
+  shell scripts, JSON, HTML, plist, or plain text, 146 tracked files outside
+  `docs/plans/` in this repo today -- is invisible to every assertion here;
+  a stale token in a tracked `.sh` file was confirmed to slip through this
+  way. `.yaml`/`.yml` themselves currently match no tracked hits --
+  `config/reflections.yaml` is gitignored -- so the reflection registry's
+  own name and cadence contract is actually pinned by
+  `tests/integration/test_reflections_redis.py:185,197`, not by anything in
+  this file. No live occurrence exists outside `docs/plans/` today and every
+  realistic reintroduction path is Python, Markdown, or YAML/TOML, so this
+  suffix list is intentionally not widened here.
 
 This file itself is excluded from every enumeration below (belt) in addition
 to containing zero literal occurrences of the tokens it asserts against

--- a/tests/unit/test_stale_reference_sweep.py
+++ b/tests/unit/test_stale_reference_sweep.py
@@ -1,0 +1,153 @@
+"""Durable guard against reintroducing three classes of stale prose (#2853, #2839).
+
+Every prior attempt to sweep these tokens out of the tree died with the
+artifact that carried it: a diff-scoped grep can never see pre-existing text
+(#2833's closure criterion), and a filesystem walk that excludes
+`docs/plans/completed/` is only correct until the next teardown lands (#1643,
+#1924). This module is the first version of that gate meant to outlive the
+plan doc that motivated it -- the plan's own Verification rows are archived
+into `docs/plans/` at merge, which every sweep below (and this file's own
+enumeration) excludes by construction.
+
+Three assertions, all scoped to tracked content:
+
+1. No in-scope file names the reflection by its old, unregistered name.
+2. No in-scope file references either of the two deleted granite package
+   paths (the renamed-then-deleted `tools/` package and its original name).
+3. A literal four-file tuple -- the sites that were rewritten from "nightly"
+   to "daily" -- carries no leftover occurrence of "nightly". This class has
+   no token in common with (1) or (2): one of the four sites (`models/
+   ghost_reconcile.py`, the `Model.clean_indexes()` docstring line) names no
+   reflection and no package, so neither of the first two assertions can ever
+   reach it. It was found only by scoping this exact anti-criterion to the
+   four files during plan revision.
+
+Two trade-offs, deliberate:
+
+- Enumeration walks `git ls-files`, never `os.walk`/`rglob`. An untracked
+  file is not repo content, and this machine routinely grows untracked
+  Markdown bundles (critique-run artifacts, scratch notes) that legitimately
+  carry these exact strings; a filesystem walk turns those into false
+  failures for lanes that have nothing to do with this one. The corollary is
+  that a brand-new untracked file carrying a stale token is invisible here --
+  that is intentional, since any real fix lands in a tracked file anyway.
+- Assertion 3's four-file scope permanently retires the ordinary English word
+  "nightly" from those four files. A future author with a legitimate reason
+  to use it there (a nightly digest in the email bridge is the obvious case)
+  should read this docstring and extend or narrow `_NIGHTLY_SCOPED`
+  knowingly, rather than deleting or muting the assertion.
+
+This file itself is excluded from every enumeration below (belt) in addition
+to containing zero literal occurrences of the tokens it asserts against
+(suspenders) -- every token compared against tracked content is assembled by
+string concatenation rather than spelled out, including in this docstring,
+so staging this file can never itself trip the sweeps it exists to guard.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+THIS_FILE = Path(__file__).resolve()
+
+_SCOPED_SUFFIXES = {".py", ".md", ".yaml", ".yml", ".toml"}
+_EXCLUDED_DIR = "docs/plans"
+
+# The stale reflection name: hyphenated, distinct from the still-accurate
+# module path `scripts/popoto_index_cleanup.py` (underscored).
+_STALE_NAME_TOKEN = "popoto" + "-index-cleanup"
+
+# The two deleted granite package path tokens. Neither is the CLI command
+# name `valor-granite-loop`, which is correctly mentioned in past tense
+# elsewhere in the tree and must never be swept.
+_GRANITE_PATH_TOKENS = (
+    "granite" + "_interactive_tui_poc",
+    "tools/" + "granite_loop",
+)
+
+_NIGHTLY_SCOPED = (
+    "scripts/popoto_index_cleanup.py",
+    "bridge/email_bridge.py",
+    "models/ghost_reconcile.py",
+    "models/dedup.py",
+)
+_NIGHTLY_TOKEN = "night" + "ly"
+
+
+def _tracked_files() -> list[Path]:
+    """Return in-scope tracked files: repo-relative, extension-filtered,
+    excluding docs/plans and this guard file itself.
+    """
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    paths = []
+    for rel in result.stdout.split("\0"):
+        if not rel:
+            continue
+        if Path(rel).suffix not in _SCOPED_SUFFIXES:
+            continue
+        if rel.startswith(_EXCLUDED_DIR + "/") or rel == _EXCLUDED_DIR:
+            continue
+        abs_path = (REPO_ROOT / rel).resolve()
+        if abs_path == THIS_FILE:
+            continue
+        paths.append(Path(rel))
+    return paths
+
+
+def _find_hits(token: str) -> list[str]:
+    """Return "path:line" hits of `token` across in-scope tracked files."""
+    hits: list[str] = []
+    for rel in _tracked_files():
+        abs_path = REPO_ROOT / rel
+        try:
+            text = abs_path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if token in line:
+                hits.append(f"{rel}:{lineno}")
+    return hits
+
+
+def test_no_stale_reflection_name():
+    """No tracked file outside docs/plans/ names the reflection by its old,
+    unregistered name.
+    """
+    hits = _find_hits(_STALE_NAME_TOKEN)
+    assert hits == [], "Stale reflection-name token found at: " + ", ".join(hits)
+
+
+def test_no_deleted_granite_package_path():
+    """No tracked file outside docs/plans/ references either deleted
+    granite package path.
+    """
+    all_hits: list[str] = []
+    for token in _GRANITE_PATH_TOKENS:
+        all_hits.extend(_find_hits(token))
+    assert all_hits == [], "Deleted granite package path token found at: " + ", ".join(all_hits)
+
+
+def test_no_nightly_cadence_at_scoped_sites():
+    """None of the four rewritten sites still call this sweep "nightly" --
+    it runs on a rolling 24h interval (`every: 86400s`), not a clock-pinned
+    schedule.
+    """
+    hits: list[str] = []
+    for rel_str in _NIGHTLY_SCOPED:
+        abs_path = REPO_ROOT / rel_str
+        try:
+            text = abs_path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if _NIGHTLY_TOKEN in line:
+                hits.append(f"{rel_str}:{lineno}")
+    assert hits == [], "Leftover 'nightly' wording found at: " + ", ".join(hits)

--- a/tests/unit/test_stale_reference_sweep.py
+++ b/tests/unit/test_stale_reference_sweep.py
@@ -44,8 +44,9 @@ Three trade-offs, deliberate:
   way. `.yaml`/`.yml` themselves currently match no tracked hits --
   `config/reflections.yaml` is gitignored -- so the reflection registry's
   own name and cadence contract is actually pinned by
-  `tests/integration/test_reflections_redis.py:185,197`, not by anything in
-  this file. No live occurrence exists outside `docs/plans/` today and every
+  `tests/integration/test_reflections_redis.py`, which asserts both the
+  registered name and the 86400s interval, not by anything in this file.
+  No live occurrence exists outside `docs/plans/` today and every
   realistic reintroduction path is Python, Markdown, or YAML/TOML, so this
   suffix list is intentionally not widened here.
 


### PR DESCRIPTION
## Summary

Two-issue lane, prose-only corrections to already-correct systems.

**#2853 — wrong reflection name.** Four sites named the popoto index cleanup
reflection `popoto-index-cleanup`: `scripts/popoto_index_cleanup.py:307`,
`bridge/email_bridge.py:1087`, `models/ghost_reconcile.py:23`, and
`models/dedup.py:70`. A fifth site, `models/ghost_reconcile.py:36`, named no
reflection at all — it said only "nightly" — which is exactly why a
name-token sweep alone could not find it. The registered name is
`redis-index-cleanup` (`config/reflections.yaml:53`). The daily/24h cadence
language is preserved verbatim everywhere it appears — it is correct and is
asserted by `tests/integration/test_reflections_redis.py`. Four of the five
edited sites also said "nightly" (all but `popoto_index_cleanup.py:307`);
corrected to "daily" (`every: 86400s` is a rolling 24h interval, not
clock-pinned).

**#2839 — deleted target.** `docs/features/standardized-enums.md` described
`SessionType.GRANITE` as labelling invocations of a `valor-granite-loop` CLI at
a path that no longer exists, plus a "granite PTY container" that was deleted
with plan #1924. Rewrote the row and the section's two-member lead-in to match
the historical framing already used by `config/enums.py`'s own `SessionType`
docstring and `models/agent_session.py`. Also replaced `config/enums.py`'s
stale "Removal is #1927's scope" pointer — #1927 closed without removing the
member — with a note that removal needs a fresh decision.

**Durable guard.** Added `tests/unit/test_stale_reference_sweep.py`: three
assertions over `git ls-files`-enumerated tracked content (the two token
sweeps plus a `nightly` anti-criterion scoped to the four rewritten files).
Every prior gate for this class of drift (PR #2833, plan #1643, plan #1924)
died with the artifact that carried it — a diff-scoped grep or a filesystem
walk excluding `docs/plans/completed/` — so this is a tracked test rather than
a plan-doc Verification row.

The diff contains no production executable-line change — every edit outside
the new test file is a comment, docstring, or markdown table cell.

## Test plan

- [x] `tests/integration/test_reflections_redis.py` — 13 passed (reflection
      registration/cadence contract untouched by this diff)
- [x] `tests/unit/test_stale_reference_sweep.py` — 3 passed; mutation-checked
      by reverting `models/dedup.py:69-70` (2 failed naming that file, 1
      passed) and `models/ghost_reconcile.py:36` alone (1 failed naming that
      line, 2 passed); confirmed immune to an untracked
      `.critique-runs/.../SOURCE_FILES.md` artifact carrying all three tokens
- [x] Full `tests/unit/` suite: 13721 passed, 3 skipped, 4 failed — all 4
      failures verified unrelated to this diff (3 reproduce identically on
      `main`, the 4th is a 30s-timeout flake that passes in isolation)
- [x] Repo-wide token sweeps both exit 1 (no remaining stale-name or
      deleted-granite-path hits outside `docs/plans/`)
- [x] `python -m ruff check .` / `python -m ruff format --check .` clean
- [x] `python scripts/validate_docs_changed.py` passes

Closes #2853
Closes #2839
