### PR TITLE
fix(docs-auditor): review-gate every write, report broken .md links (#2739, #2834)

### DIFF
--- a/.claude/skill-context/do-docs.md
+++ b/.claude/skill-context/do-docs.md
@@ -139,9 +139,11 @@ sys.exit(0 if result['status'] != 'error' else 1)
 "
 ```
 
-The substrate applies fixes to the working tree, commits them to the **current branch** (not
-a new branch), fires the memory-refresh hook after the commit, and files deduped GitHub
-issues for cases needing human judgment (deleted targets, stub docs, orphan plans).
+The substrate applies fixes to the working tree, fires the memory-refresh hook on the applied
+set, and files deduped GitHub issues for cases needing human judgment (deleted targets, stub
+docs, orphan plans). It runs **no git at all** and leaves the tree dirty: you own the commit,
+and its diff passes through your Step 4 review first. Carry the `files_touched` list from the
+JSON output into Step 4 — those paths are expected there, alongside the Step 2 task list.
 
 Parse the JSON output. `status` alone does **not** mean the output is correct — check
 `fixes_withheld` too:
@@ -149,7 +151,7 @@ Parse the JSON output. `status` alone does **not** mean the output is correct �
 - `status: "ok"` and `fixes_withheld == 0` — proceed to Step 3 for any remaining manual edits.
 - `fixes_withheld > 0` (with any `status`) — the existence invariant rejected one or more
   fixes because they would have introduced a path that does not exist on disk. Before
-  trusting the substrate's self-committed output:
+  trusting the substrate's applied-but-uncommitted output:
   1. **Echo every `withheld` entry into your transcript output** — one line per entry giving
      `doc`, `old`, `new`, and `reason` — so the rejection is visible in the stage record and
      not buried in a log file.
@@ -163,9 +165,8 @@ Parse the JSON output. `status` alone does **not** mean the output is correct �
 Result keys that carry the withheld set: `fixes_withheld` (int) and `withheld`
 (list of `{"doc", "old", "new", "reason"}`, `reason` = `"target-absent"`).
 
-Do not re-commit the substrate's changes — it commits them itself. Withheld fixes were never
-written, so there is nothing of theirs to commit; any correction you make in Step 3 is your
-own commit.
+Withheld fixes were never written, so there is nothing of theirs in the diff; any correction
+you make for them in Step 3 rides in the same commit you make in Step 4.
 
 ## Index-table maintenance (Step 3)
 

--- a/.claude/skills-global/do-docs/SKILL.md
+++ b/.claude/skills-global/do-docs/SKILL.md
@@ -217,8 +217,13 @@ If the repo-context file declares an auto-fix substrate, run it against the chan
 **before** doing manual edits. Such a substrate typically handles mechanical fixes —
 renamed markdown links, renamed paths/symbols, index entries pointing at deleted files, and
 stale-term renames — so Step 3 only handles cases requiring human judgment. Follow the
-context file's invocation and output-handling instructions exactly, and do not re-commit
-changes the substrate commits itself.
+context file's invocation and output-handling instructions exactly.
+
+The substrate applies its fixes to the working tree and does **not** commit them — you own
+the commit, and the diff it produced has to pass your review in Step 4 before it becomes a
+permanent record. Record the set of files it reports touching (the `files_touched` key of its
+output, if it reports one) and carry that list into Step 4, where it joins the Step 2 task
+list as an expected file.
 
 If no substrate is declared (the generic case), skip this step — all edits are made manually in Step 3.
 
@@ -249,7 +254,10 @@ After all edits are complete:
    ```bash
    git diff --name-only
    ```
-   Every file in this list should appear in the Step 2 task list. If there are unexpected files, revert them.
+   Every file in this list should appear in the expected set: the Step 2 task list **plus**
+   the `files_touched` the Step 2d substrate reported. If there are unexpected files, revert
+   them. Substrate-touched files are expected, but they are not exempt from review — read
+   their diffs in the next sub-step like any other, and revert any change you cannot justify.
 
 2. **Review each diff is minimal and correct:**
    ```bash

--- a/.claude/skills-global/do-docs/SKILL.md
+++ b/.claude/skills-global/do-docs/SKILL.md
@@ -300,6 +300,12 @@ After all edits are complete:
    ```
    Documentation changes must be persisted. If this fails (e.g., nothing to commit), that's fine — report "no changes needed." Push if the workflow expects it (`git push`).
 
+   <!-- NOTE (#2739 review): this `git add -A` stages the whole tree, mirroring
+   the whole-tree stage this issue removed from `reflections/docs_auditor.py`
+   itself. Left as-is here because this cascade runs inside a worktree-isolated
+   lane behind the plan's Step 4 review gate, unlike the rotation path's shared
+   main checkout — revisit if `/do-docs` ever runs outside a dedicated worktree. -->
+
    **Push-ancestry guard (this repo — #2026).** Before any `git push` to `main`
    from a cascade, run the push-ancestry guard so a worktree HEAD left detached at
    a PR branch head cannot register the open PR's ancestry as its merge:

--- a/.claude/skills-global/new-audit-skill/BEST_PRACTICES.md
+++ b/.claude/skills-global/new-audit-skill/BEST_PRACTICES.md
@@ -29,7 +29,7 @@ Every audit skill answers five questions:
 |-------------|-------------|---------|
 | **Report only** | Domain expert (human) must decide. Audit surfaces info they can't easily see themselves. | `audit-models` — pauses for architect review |
 | **Auto-fix trivial** | Some findings have obvious mechanical fixes (rename, add field). Complex ones need human. | `audit-skills --fix` — fixes missing name fields |
-| **Full apply** | All corrections are safe and reversible. Skill commits results. | `docs-auditor` (substrate) — applies UPDATE/DELETE verdicts, commits |
+| **Full apply, gated** | All corrections are safe and reversible, but the write still needs a review gate in front of it before it becomes a permanent record — no skill in this repo commits its own applied output unreviewed. | `docs-auditor` (substrate) — applies fixes to the working tree and leaves it dirty; the caller (a human merge on the rotation PR, or the `/do-docs` skill's own commit step) owns the commit |
 
 **Rule of thumb**: Auto-fix only when the fix is unambiguous and the blast radius is contained to the audited files.
 

--- a/agent/reflection_scheduler.py
+++ b/agent/reflection_scheduler.py
@@ -637,7 +637,12 @@ async def run_reflection(entry: ReflectionEntry, state: Reflection) -> None:
         # return None (or non-dict). Guard with isinstance to keep legacy
         # callables fully backward-compatible.
         projects_list = result.get("projects") if isinstance(result, dict) else None
-        state.mark_completed(duration, projects=projects_list)
+        summary_str = result.get("summary") if isinstance(result, dict) else None
+        state.mark_completed(
+            duration,
+            projects=projects_list,
+            output_summary=str(summary_str)[:500] if summary_str else None,
+        )
         logger.info(
             "[reflection] Completed: %s (%.1fs)",
             entry.name,

--- a/docs/features/docs-auditor.md
+++ b/docs/features/docs-auditor.md
@@ -349,7 +349,12 @@ PR body. The branch sweeper reads that marker from its own `gh pr list` query
 and never closes or deletes the branch of a PR carrying it — instead it files
 a **separate**, PR-scoped escalation issue (`docs-auditor: withheld PR #{n}
 still unreviewed`), distinct from the per-defect titles above so the two
-filings never collide on the same dedup key. It also passes the withheld
+filings never collide on the same dedup key. The exemption from stale-close
+applies at any age; the escalation issue waits for the same
+`STALE_PR_AGE_DAYS` threshold that would have closed a plain PR, so the
+title's "still unreviewed" claim is true when it is made. Because the dedup
+key fires once ever, a filing made on sight would make the wrong wording the
+permanent record. It also passes the withheld
 count to `_write_liveness` as a keyword `fixes_withheld`, emitted into the
 Redis summary only when non-zero — a secondary signal now that the durable
 operator surface is the GitHub issue plus the reflection dashboard's rendered

--- a/docs/features/docs-auditor.md
+++ b/docs/features/docs-auditor.md
@@ -349,7 +349,7 @@ PR body. The branch sweeper reads that marker from its own `gh pr list` query
 and never closes or deletes the branch of a PR carrying it — instead it files
 a **separate**, PR-scoped escalation issue (`docs-auditor: withheld PR #{n}
 still unreviewed`), distinct from the per-defect titles above so the two
-filings never collide on the same dedup key. It also passes the touched-file
+filings never collide on the same dedup key. It also passes the withheld
 count to `_write_liveness` as a keyword `fixes_withheld`, emitted into the
 Redis summary only when non-zero — a secondary signal now that the durable
 operator surface is the GitHub issue plus the reflection dashboard's rendered

--- a/docs/features/docs-auditor.md
+++ b/docs/features/docs-auditor.md
@@ -19,31 +19,50 @@ Unified documentation hygiene substrate that consolidates five disjointed pieces
                           reflections/docs_auditor.py
                           ┌────────────────────────────┐
 docs-auditor (daily) ────►│ run_docs_auditor()         │──► docs-audit/{slug}-{ts} branch + PR
-                          │   ↓                        │
+                          │   ↓                        │   (requires a human merge)
                           │ audit(scope_mode='rotation')│
                           └────────────────────────────┘
 
                           ┌────────────────────────────┐
-/do-docs (SDLC stage) ───►│ audit(scope_mode=          │──► commit on current branch
-                          │   'pr-changed-files')      │
+/do-docs (SDLC stage) ───►│ audit(scope_mode=          │──► working tree written, left dirty
+                          │   'pr-changed-files')      │   (the skill owns the commit)
                           └────────────────────────────┘
 ```
+
+`audit()` **never commits.** It writes fixes to the working tree, fires the
+memory-refresh hook on what it wrote, and returns `files_touched`; every write
+it makes passes a named review gate before it becomes a permanent record. For
+Caller A that gate is the pull request `run_docs_auditor` opens, which a human
+merges via `/do-merge`. For Caller B that gate is the `/do-docs` skill's own
+Step 4 review of the diff before it commits.
 
 ### Caller A — `docs-auditor` daily rotation reflection
 
 Picks the least-recently-audited primary doc from a Redis hash, expands its
 neighborhood (≤20 files via outbound links + inbound refs), runs auto-fix
-detectors, applies them, opens a `docs-audit/{slug}-{ts}` branch, posts a
-non-draft PR, and notifies the `Dev: Valor` Telegram chat. Errors are
-swallowed; the auditor never crashes the worker.
+detectors, applies them, stages exactly `files_touched` (never a whole-tree
+`git add -A`), opens a `docs-audit/{slug}-{ts}` branch, posts a non-draft PR,
+and notifies the `Eng: Valor` Telegram chat that review is required. Errors
+are swallowed; the auditor never crashes the worker.
+
+A guard-skipped run (daily PR cap reached, or an open PR already exists for
+the picked doc's slug) performs no working-tree write and no git operation,
+but it still stamps the rotation hash for the doc it picked — exactly as a
+zero-diff pass does — so `_select_primary_doc` advances to a different doc on
+the next run instead of re-picking the same blocked one forever. Without that
+stamp, one long-lived withheld PR (which the sweeper never closes — see
+[Branch Sweeper](#branch-sweeper)) would pin the whole rotation on a single
+document indefinitely.
 
 ### Caller B — `/do-docs` SDLC stage
 
-The `/do-docs` skill (`.claude/skills/do-docs/SKILL.md`) calls the substrate
-with `scope_mode="pr-changed-files"` after sub-agents A–D finish discovery.
-The substrate applies auto-fixes to the working tree, commits to the **current
-branch** (no new branch), and fires the memory-refresh hook. The skill then
-writes the SDLC stage marker and updates the plan frontmatter.
+The `/do-docs` skill (`.claude/skills-global/do-docs/SKILL.md`) calls the
+substrate with `scope_mode="pr-changed-files"` after sub-agents A–D finish
+discovery. The substrate applies auto-fixes to the working tree and fires the
+memory-refresh hook on the applied set — it does **not** commit. The skill's
+own Step 4 reviews the diff (the `files_touched` return value merged with its
+own Step 2 task list) and commits it itself, then writes the SDLC stage
+marker and updates the plan frontmatter.
 
 ## Detectors
 
@@ -61,11 +80,14 @@ hatch (gate 1) below.
 
 ### Four gates guard every rewrite
 
-The auditor is an unreviewed autonomous committer: the rotation caller opens a
-PR the branch sweeper can auto-merge with nobody in between. That makes its two
-failure modes asymmetric. A stale term that survives is a cosmetic miss. A
-sentence the auditor falsifies is a corruption a human later trusts. Every gate
-below therefore errs toward **not** rewriting.
+Even with a human merge required on every rotation PR (see
+[Two Callers](#two-callers)), the auditor's proposed rewrites still need to be
+trustworthy before a reviewer ever sees them: an unreviewed writer that floods
+a human with plausible-looking wrong rewrites is only marginally safer than
+one that ships them outright. That makes its two failure modes asymmetric. A
+stale term that survives is a cosmetic miss. A sentence the auditor falsifies
+is a corruption a human later trusts. Every gate below therefore errs toward
+**not** rewriting.
 
 Four fail-closed gates sit between a proposed rewrite and the disk, in order:
 
@@ -304,84 +326,197 @@ Rejected fixes surface on the `audit()` result:
 | `fixes_withheld` | `int` | count of fixes rejected by the existence invariant |
 | `withheld` | `list[dict]` | one entry per rejection: `{"doc", "old", "new", "reason"}`, `reason` = `"target-absent"` |
 
-`old` is always the **regex source** of the withheld stale-term fix
-(`\bsession_log\b`, not `session_log`) — there is no other channel left to
-emit a literal string. A caller that echoes `old` verbatim —
+`old` in the `withheld` list is always the **regex source** of the withheld
+stale-term fix (`\bsession_log\b`, not `session_log`) — there is no other
+channel left to emit a literal string. A caller that echoes `old` verbatim —
 `.claude/skill-context/do-docs.md` does — will show the pattern, which is the
-accurate thing to show, since that is what was withheld.
+accurate thing to show, since that is what was withheld. The per-defect
+GitHub issue title (below) is the one place that does **not** echo the raw
+pattern: it unwraps the `\b...\b` anchors before formatting, because the
+title is also the cross-machine dedup key passed to `gh issue list --search`.
 
-The rotation caller (`run_docs_auditor`) is the one path with no human review —
-it opens a PR the branch sweeper can auto-merge — so it threads the withheld set
-into its `findings`, its `summary`, and its Telegram message, and stamps
-`WITHHELD_PR_MARKER` plus the rejection list into the PR body.
-`_pr_is_auto_merge_eligible` refuses any PR carrying that marker, so a run that
-withheld a fix always requires a human merge. It also passes the count to
-`_write_liveness` as a keyword `fixes_withheld`, emitted into the Redis summary
-only when non-zero. That last surface is the load-bearing one: the reflection
-scheduler consumes only `projects` from a function reflection's return, so
-`findings` and `summary` reach no human, and without the liveness field a
-withheld run would be byte-identical to a clean one in Redis.
+The rotation caller (`run_docs_auditor`) files **one issue per withheld
+entry**, titled `docs-auditor: withheld fix in {doc} ({old} -> {new})` with
+`{old}` unwrapped to the plain term — a per-defect title, so distinct
+withholds dedup independently rather than sharing one key. Filing is bounded
+by the module's shared per-run cap (`ISSUE_FILING_PER_RUN_CAP`, see
+[Two-tier dedup](#two-tier-dedup)); entries past the cap are logged and
+suppressed, not filed. It also threads the withheld set into its `findings`,
+`summary`, and Telegram message — which states plainly that review is
+required and that the PR is closed unmerged after `STALE_PR_AGE_DAYS` if
+nobody acts — and stamps `WITHHELD_PR_MARKER` plus the rejection list into the
+PR body. The branch sweeper reads that marker from its own `gh pr list` query
+and never closes or deletes the branch of a PR carrying it — instead it files
+a **separate**, PR-scoped escalation issue (`docs-auditor: withheld PR #{n}
+still unreviewed`), distinct from the per-defect titles above so the two
+filings never collide on the same dedup key. It also passes the touched-file
+count to `_write_liveness` as a keyword `fixes_withheld`, emitted into the
+Redis summary only when non-zero — a secondary signal now that the durable
+operator surface is the GitHub issue plus the reflection dashboard's rendered
+`output_summary` (see [Configuration](#configuration)), not a manual
+`redis-cli` read.
 
-Because the marker disqualification is permanent, a withheld PR nobody reviews
-reaches the sweeper's stale-close at `STALE_PR_AGE_DAYS` and is closed with
-`--delete-branch`, discarding the fixes that did pass the invariant; the next
-rotation onto that slug re-proposes and re-opens the same PR. This is strictly
-safer than auto-merging suspect output, and the escalation (exempt from
-stale-close, or notify before closing) is an open gap tracked by
-[#2729](https://github.com/tomcounsell/ai/issues/2729), not a shipped behavior.
+A rotation run that writes to the working tree and then fails to produce a PR
+— a `git`/`gh` step failing, or the scoped restore itself failing — files its
+own escalation issue, `docs-auditor: rotation failed to produce a PR for
+{slug}`, category `operational-failure`, **before** returning `status="error"`
+(`agent/reflection_scheduler.py` reads only `projects` from a function
+reflection's return, so the status field alone reaches nobody). The body
+names the slug, the `files_touched` paths, and the cleanup command
+(`git -C "${AI_REPO_ROOT:-$HOME/src/ai}" status --porcelain -- docs .claude`);
+it deliberately does not name the failing step or assert whether the restore
+succeeded, since neither fact reaches that call site. The dirty-tree guard
+that can precede such a failure returns `status="skipped"` and stays silent —
+it tests the whole shared main checkout, where concurrent lanes routinely
+hold uncommitted work as a matter of routine, so a filing guard there would
+mint issues blaming the auditor for a peer's dirt. Its silence is safe only
+because the `operational-failure` filing above stays open until a human acts
+and re-files if the failure recurs (see
+[Two-tier dedup](#two-tier-dedup)) — if that gate is ever widened to match
+closed issues too, the dirty-tree guard's silence becomes a real blind spot.
 
-`status` stays `"ok"` — a withheld fix is not an error. That is precisely why a
-caller must branch on `fixes_withheld > 0` rather than treat `"ok"` as "output
-is correct"; `.claude/skill-context/do-docs.md` wires that branch for the
-cascade.
+`audit()`'s own `status` stays `"ok"` — a withheld fix is not an error. That
+is precisely why a caller must branch on `fixes_withheld > 0` rather than
+treat `"ok"` as "output is correct"; `.claude/skill-context/do-docs.md` wires
+that branch for the cascade.
+
+`run_docs_auditor`'s outcome vocabulary is separate and stricter: `"ok"`
+survives on exactly the one return that created a PR. Every other return that
+reached the lock — the lock-held return, the dirty-tree guard, no candidates
+found, and a zero-diff pass — reports `"skipped"`, matching each one's own
+`_write_liveness(..., "skipped", ...)` call, so the field means "a PR was
+opened" and nothing weaker. (`"disabled"`, returned when the auth probe fails
+before the lock is even acquired, is a pre-flight bail rather than a run
+outcome and sits outside this vocabulary.)
 
 ### File-as-issue (judgment required)
 
 | Detector | What it catches | Action |
 |----------|-----------------|--------|
-| Deleted target | `` `path.py` `` references to a target absent from the working tree, after placeholder / fenced-block / deletion-heading filtering | `gh issue create` (deduped) |
+| Deleted target (`.py`) | `` `path.py` `` references to a target absent from the working tree, after placeholder / fenced-block / deletion-heading filtering | `gh issue create` (deduped) |
+| Broken link target (`.md`) | `[label](target.md)` links whose target is absent, doc-relative, after the same filtering | `gh issue create` (deduped), **report only, never repaired** |
 | Stub doc | Docs with <5 content lines | `gh issue create` (deduped) |
 | Orphan plan | `docs/plans/*.md` lacking a tracking-issue link | `gh issue create` (deduped) |
 
-#### Deleted-target false-positive filtering
+`_detect_deleted_target_issues` covers both reference shapes, scoped
+differently: the `.py` branch runs over whatever neighborhood the caller
+already resolved, repo-wide; the `.md` branch is scoped to `docs/` minus
+`docs/plans/completed/` and `docs/plans/done/` (archived plans deliberately
+record history and are not a live surface a human reviews for broken links).
 
-The deleted-target detector runs three suppression passes before emitting a
-finding, so it never floods the tracker with illustrative or
+**The frame rule (#2725 / #2741).** `.md` link targets resolve **relative to
+the containing document's directory** — the frame markdown renderers actually
+use — not the repo root. A target that exists at the repo root but not
+doc-relative is still a real break and is reported as one. Anchors and
+queries are stripped before the target becomes the title (and the dedup key):
+`[x](./gone.md#section)` reports `gone.md`, not `gone.md#section`.
+
+**The inline-code asymmetry is deliberate.** A bare backticked `.py` path
+*is* a reference — that is how the `.py` branch's genuine matches are always
+written. A markdown link inside a code span is *not* a reference — it is a
+literal illustration of syntax. Do not "harmonize" the two branches; the
+asymmetry is the correct reading of each shape.
+
+**`.md` links are reported, never repaired.** No write path exists for this
+branch — the only effect of a finding is a GitHub issue. An auto-repairing
+predecessor existed at one point and was deleted (#2741): an auditor deleting
+lines from a human's index file on its own judgment is exactly the
+unreviewed-write class this module exists to gate, and it is not coming back.
+
+#### Deleted-target and broken-link false-positive filtering
+
+Both branches run the same three suppression passes before emitting a
+finding, so neither floods the tracker with illustrative or
 intentionally-documented paths:
 
 - **Placeholder / example paths** (`_is_placeholder_path`): a path is skipped if
-  any component (or the final file's stem) is a well-known stand-in — `foo`,
-  `bar`, `baz`, `qux`, `quux`, `example`, `your-module`, `mymodule`, `sample` —
-  or a single-letter directory. This suppresses paths like `foo/bar.py` and
-  `agent/docs_handler/foo.py`.
+  any component (or the final file's stem, `.py` or `.md`) is a well-known
+  stand-in — `foo`, `bar`, `baz`, `qux`, `quux`, `example`, `your-module`,
+  `mymodule`, `sample`, and the link-specific `filename`, `path`, `name` — or a
+  single-letter directory. This suppresses paths like `foo/bar.py`,
+  `agent/docs_handler/foo.py`, and links like `[x](filename.md)`.
 - **Fenced code blocks** (`_build_line_context`): a single line-scan over the
   doc tracks fenced ```` ``` ```` block state. Matches inside a fenced block are
   treated as illustrative and skipped. Inline single-backtick code is **not**
-  suppressed — that is the normal way genuine references are written.
+  suppressed for the `.py` branch — that is the normal way genuine references
+  are written; a markdown link inside a code span is skipped by the `.md`
+  branch's own separate check, above.
 - **Deletion headings & prose** (`_is_documented_deletion`): a match is skipped
-  if its nearest preceding heading names a deletion (`migration`, `removed`,
-  `deleted`, `deprecated`) or if its line / an adjacent line carries a deletion
-  cue (`deleted module`, `no longer in the codebase`, `no longer exists`,
-  `previously in`, `formerly`). This suppresses paths like `intent/__init__.py`
-  documented under a `## Migration ...` heading.
+  if its nearest preceding heading names a deletion by stem (`delet`, `remov`,
+  `deprecat`, `migrat`, `cleanup`, `obsolete`, `retire` — stems, not exact
+  inflections, so `"## Dead SDK Path Deletion"` and `"## Hook Cleanup"` both
+  match) or if a line within 2 lines carries a word-anchored deletion-prose cue
+  (`deleted`, `removed`, `no longer`, `previously`, `formerly`, `deprecated`).
+  This suppresses paths like `intent/__init__.py` documented under a
+  `## Migration ...` heading, and prose like `` `agent/gone.py` deleted (250
+  lines) `` under a `## Hook Cleanup` heading.
+
+  **The live-claim veto.** Both branches pass `live_claim_veto=True` to
+  `_is_documented_deletion` — the only caller that does. When the match's own
+  line carries a live-claim cue (`remain`, `remains`, `still`, `defined in`,
+  `lives in`, `currently`, `implemented in`), the heading/prose suppression is
+  cancelled and the finding is still reported — a line like *"`fail_stage()`
+  remains defined in `agent/hooks/gone.py`"* under a `## Migration` heading is
+  a live claim, not a deletion record, even though the heading alone would
+  otherwise suppress it. The veto is keyword-only and opt-in for a reason:
+  `_make_stale_term_replacer` (the write path's own caller of this predicate)
+  never sets it, and never will. This predicate's `True` means "suppress" at
+  both call sites, but a wrong suppression costs the *detector* a missed
+  report, while a wrong un-suppression would cost the *write path* an
+  unreviewed rewrite of narrative prose — the auditor editing history on every
+  PR, which is the exact defect class this module exists to gate.
 
 Every suppressed match is logged at DEBUG so an operator can audit exactly what
 the filter dropped.
 
-#### Two-tier dedup
+#### Two-tier dedup and convergence
 
 Issue filing uses a two-tier dedup gate:
 
 1. **Local-Redis fast-path** (`docs_audit:issues_filed:{hash}`, SHA-256 of the
    title, 30-day TTL): a per-machine cache. If the key exists, filing is skipped
-   without any GitHub call.
-2. **Live-tracker gate** (`_open_issue_exists`): the **authoritative**
-   cross-machine check. Before filing, it runs
-   `gh issue list --state open --label documentation --search "<title>"` and
-   confirms a hit with an exact normalized-title comparison (the title encodes
-   both the path and the doc, so it is a natural composite key). Local Redis
-   alone is insufficient because each machine keeps its own Redis, so the same
-   finding would otherwise be filed once per machine.
+   without any GitHub call — but only for a **once-ever** category (below);
+   the check is gated off entirely for a recurring-condition one.
+2. **Live-tracker gate** (`_issue_exists`): the **authoritative** cross-machine
+   check. Before filing, it runs `gh issue list --state <all|open> --limit 100
+   --search "<title>"` and confirms a hit with an exact normalized-title
+   comparison (the title encodes both the path and the doc, so it is a
+   natural composite key). Local Redis alone is insufficient because each
+   machine keeps its own Redis, so the same finding would otherwise be filed
+   once per machine. `--limit 100` is load-bearing, not decoration: `gh issue
+   list` defaults to 30, and under `--state all` a repo with more matching
+   issues than that could push the exact title off the first page — a silent
+   fail-open that files a duplicate. The query carries **no label filter**: a
+   human can relabel an issue during triage, and the authoritative match is
+   the exact title compare, not a label surviving that relabel. New issues are
+   still *filed* with the `documentation` label; only the dedup **query**
+   stopped depending on it.
+
+**A reference finding is filed once, ever.** `states` defaults to `"all"`, so
+a closed issue suppresses a fresh filing of the same finding just as an open
+one does — a human who read the finding, ruled on it, and closed it made a
+durable decision, and the cost is that a defect that is fixed, closed, and
+later regresses identically stays silent. Two categories are the exception and
+keep the old open-only semantics: `vault-drift` (a recurring `vault_mtime >
+site_ts` comparison — one closed issue would otherwise silence that
+vault/site pair forever) and `operational-failure` (a recurring run outcome
+that can return after a genuine cleanup). For these two, `_file_issue_if_new`
+selects `states="open"` and skips the Redis fast-path's `exists` read
+entirely, so a closed issue for the same recurring condition is re-filed
+inside the 30-day window rather than staying silenced by the per-machine
+cache. The two Redis `set()` writes stay unconditional either way — the key
+has exactly one reader, so a category that never reads it is unaffected by
+still writing it, and the key survives as a fail-open cap if `gh` starts
+erroring.
+
+**Three separate per-run issue budgets, not one.** `VAULT_DRIFT_ISSUE_CAP`
+(5) bounds only the vault↔site drift loop, which runs before rotation picks
+its primary doc. `ISSUE_FILING_PER_RUN_CAP` (5) is shared by `audit()`'s
+advisory loop (deleted-target and broken-md-link findings together — Q7 gets
+no budget of its own) and the withheld-fix filing loop. The true module-wide
+ceiling for one rotation run is **15** issues plus at most one
+`operational-failure` filing. The two constants are deliberately kept
+separate rather than merged into one "the module's issue cap" value.
 
 The tracker query **fails open**: on any `gh` failure, non-zero exit, or
 malformed output it logs a warning and degrades to Redis-only dedup rather than
@@ -430,10 +565,12 @@ does not have to wait out the TTL.
 ## Memory Refresh Hook
 
 `reflections.docs_auditor.refresh_docs_in_memory(touched_paths: list[str]) -> None`
-is a public no-op-by-default hook called after fixes are applied and committed,
-before PR creation (Caller A) or stage marker write (Caller B). Issue #1249
-will replace the body with a real implementation that re-ingests touched docs
-into the Memory substrate.
+is a public no-op-by-default hook called after fixes are **applied**, before
+any commit — the module never commits, so "after commit" is not a state this
+hook ever waits for. Caller A fires it after `_push_branch_and_pr` succeeds;
+Caller B fires it on the applied set directly, leaving the working tree dirty
+for `/do-docs`'s own review and commit. Issue #1249 will replace the body with
+a real implementation that re-ingests touched docs into the Memory substrate.
 
 The hook signature is **stable** — call sites in this module will not change
 when #1249 lands. The hook is always non-blocking and fire-and-forget;
@@ -444,12 +581,21 @@ failed.
 
 `run_docs_branch_sweeper()` runs daily and:
 - Deletes `docs-audit/*` remote branches with no PR ever opened, age >7 days
-- Closes (`gh pr close --delete-branch`) open `docs-audit/*` PRs older than 14 days
+- Closes (`gh pr close --delete-branch`) open `docs-audit/*` PRs older than 14
+  days — **except** a PR whose body carries `WITHHELD_PR_MARKER`, which it
+  neither closes nor deletes the branch of, since closing it would discard
+  fixes that already passed the existence invariant. Instead it files a
+  distinct escalation issue, `docs-auditor: withheld PR #{n} still
+  unreviewed`, naming the PR and its age, so the withheld PR stays visible
+  without becoming permanently unreachable.
 
 Scope is intentionally narrow — only branches under the `docs-audit/` prefix
 are touched. Branches with any review comment, non-bot authorship, or merged
 PR are left alone. This sweeper does NOT touch `session/*` branches; that
-remains `agent/session_revival.py`'s scope.
+remains `agent/session_revival.py`'s scope. It never runs `gh pr merge` —
+every `docs-audit/*` PR requires a human to merge it via `/do-merge`; the
+sweeper's only actions are delete-if-stale-and-unopened, close-if-unreviewed,
+and the withheld-PR escalation above.
 
 ## Vault↔Site/Docs Drift Detector
 
@@ -542,7 +688,9 @@ now runs for real (advisory/report-only, same as before). Verify with
 # Inspect rotation state
 redis-cli HGETALL docs_audit:last_run
 
-# Phase 2 liveness signal
+# Phase 2 liveness signal — a secondary, per-machine surface. The durable
+# operator surfaces are the GitHub issue tracker and the reflections
+# dashboard's rendered "last run summary" (sourced from output_summary).
 redis-cli GET docs_audit:last_completed_run_ts
 redis-cli GET docs_audit:last_completed_run_summary
 
@@ -578,7 +726,7 @@ index), `TestExistenceInvariant` (bare-name withhold, doc-relative resolution,
 ambiguous-but-present pass, no re-validation of pre-existing refs — every case
 is expressed as a prose-anchored regex fix whose *replacement*, not its match,
 carries the path-shaped string, so gate 3's path-token suppression cannot eat
-the case before the invariant runs), and `TestWithheldBlocksAutoMerge` (a
+the case before the invariant runs), and `TestWithheldBlocksStaleClose` (a
 bare-name withhold reaching the PR body, Telegram, and liveness).
 `TestWithheldRateNonRegression` self-baselines the narrow and widened
 `_PATH_REF_RE` arms in one run inside a disposable detached `git worktree`,
@@ -586,6 +734,24 @@ asserting the widening adds no withholds. `TestDeletedTargetFiltering::
 test_rename_destination_reference_is_reported` runs on a real git checkout
 (commit, `git mv`, delete) and asserts a reference to a former rename
 destination is now reported rather than suppressed.
+
+Q7's `.md` link branch and the widened deletion hatch (heading stems, the
+word-anchored prose-cue alternation, the ±2 window, and the live-claim veto)
+are covered by `TestBrokenMdLinkDetection` and the added cases in
+`TestDeletedTargetFiltering` — including the three real-corpus control cases
+(`docs/features/harness-abstraction.md`, `harness-adapter.md`,
+`standardized-enums.md`) that motivated the widening. `TestCrossMachineDedup`
+covers `_issue_exists`'s `states`/`--limit`/no-label argv contract and the
+recurring-condition open-only exemption. `TestIssueFilingCapSharing` asserts
+the `.py` and `.md` finding categories share one per-run budget.
+
+The git surface — staging, the scoped restore, the sweeper's close path, and
+the withheld-PR exemption — is real-git-only, in
+`tests/unit/reflections/test_docs_auditor_git_surface.py`: a real repository
+on disk with a real bare remote, and a synchronous `gh`-only dispatcher
+(`monkeypatch.setattr(docs_auditor.subprocess, "run", dispatcher)`) that
+delegates every non-`gh` command to the real `subprocess.run`. No blanket
+mock over `subprocess.run` is used anywhere in that file.
 
 ```bash
 pytest tests/unit/test_docs_auditor_substrate.py -v
@@ -596,7 +762,7 @@ pytest tests/unit/test_docs_auditor_substrate.py -v
 - [Reflections](reflections.md) — registry and scheduler design
 - [Vault↔Site/Docs Drift Audit](vault-drift-audit.md) — the curated
   `VAULT_SITE_MAPPING` drift detector, in full
-- `.claude/skills/do-docs/SKILL.md` — Caller B skill definition
+- `.claude/skills-global/do-docs/SKILL.md` — Caller B skill definition
 - `reflections/docs_auditor.py` — substrate source
 - Issue #1247 — design and rollout plan
 - Issue #1249 — memory refresh hook (forward-compat target)

--- a/docs/features/reflections.md
+++ b/docs/features/reflections.md
@@ -170,11 +170,19 @@ ever rewrites the real per-machine copy produced by `install_reflection_worker.s
 `install_email_bridge.sh`, and `scripts/update/env_sync.py::sync_reflections_yaml`.
 
 > **Note on `docs-auditor` filing:** issue-filing is **rotation-only**. The `audit()` substrate
-> files advisory issues (deleted-target, stub-doc) only under `scope_mode="rotation"` (Caller A,
-> the daily reflection). The `/do-docs` SDLC stage (Caller B, `scope_mode="pr-changed-files"`)
-> runs `audit()` on every PR but performs auto-fixes only — it does **not** file issues, since a
-> deleted-target reference is unfixable and re-detecting it per-PR re-files duplicates. Combined
-> with `project_key`-gating, repo audits file issues from exactly one machine, on rotation only.
+> files advisory issues (deleted-target, broken-md-link, stub-doc) only under
+> `scope_mode="rotation"` (Caller A, the daily reflection). The `/do-docs` SDLC stage (Caller B,
+> `scope_mode="pr-changed-files"`) runs `audit()` on every PR but performs auto-fixes only — it
+> does **not** file issues, since a deleted-target or broken-link reference is unfixable and
+> re-detecting it per-PR re-files duplicates. Combined with `project_key`-gating, repo audits file
+> issues from exactly one machine, on rotation only.
+>
+> **A reference finding (deleted-target or broken-md-link) is filed once, ever.** `_issue_exists`
+> matches open *and* closed issues by default, so a human who closes one without editing the doc
+> has made a durable ruling that survives a triager relabelling the issue. Two categories are the
+> exception and keep the older open-only semantics: `vault-drift` and `operational-failure`, whose
+> underlying conditions can genuinely recur after a close. See
+> [Docs Auditor § Two-tier dedup and convergence](docs-auditor.md#two-tier-dedup-and-convergence).
 
 ### Registered Reflections
 
@@ -210,7 +218,7 @@ ever rewrites the real per-machine copy produced by `install_reflection_worker.s
 | Name | Callable | Description |
 |------|----------|-------------|
 | `docs-auditor` | `reflections.docs_auditor.run_docs_auditor` | Unified docs auditor: rotates least-recently-audited primary doc, applies auto-fixes, opens `docs-audit/*` PR (see [Docs Auditor](docs-auditor.md)) |
-| `do-docs-branch-sweeper` | `reflections.docs_auditor.run_docs_branch_sweeper` | Delete stale `docs-audit/*` branches >7d with no PR; close open `docs-audit/*` PRs >14d |
+| `do-docs-branch-sweeper` | `reflections.docs_auditor.run_docs_branch_sweeper` | Delete stale `docs-audit/*` branches >7d with no PR; close open `docs-audit/*` PRs >14d, except a withheld-marker PR, which it never closes and instead escalates via a distinct GitHub issue |
 | `skills-audit` | `reflections.audits.skills_audit.run` | Validate all SKILL.md files (see [Skills Audit](audit-skills.md)) |
 | `hooks-audit` | `reflections.audits.hooks_audit.run` | Audit Claude Code hooks and settings (see [Hooks Best Practices](hooks-best-practices.md)) |
 | `pr-review-audit` | `reflections.audits.pr_review_audit.run` | Scan merged PRs for unaddressed review findings; file GitHub issues **(disabled — calls gh CLI)** |

--- a/docs/features/vault-drift-audit.md
+++ b/docs/features/vault-drift-audit.md
@@ -93,6 +93,20 @@ GitHub issues (label `documentation`) through the substrate's existing
 authoritative live-tracker query) every other docs-auditor detector uses.
 Nothing here invents a new filing or dedup path.
 
+**Vault-drift dedups against open issues only — unlike every other finding
+category, which dedups once, ever, against open and closed issues alike.**
+`_file_issue_if_new` selects `states="open"` specifically for the
+`vault-drift` category (and for `operational-failure`, a different channel —
+see [docs-auditor.md § Two-tier dedup and convergence](docs-auditor.md#two-tier-dedup-and-convergence)),
+via the module-level `_RECURRING_CONDITION_CATEGORIES` set. The reason is the
+finding's own shape: it is a recurring `vault_mtime > site_ts` comparison, not
+a durable property of the tree. A human closing one vault-drift issue records
+one reconciliation between the vault and the site at that moment — it is not
+a ruling that the pair can never drift again. Matching closed issues for this
+category would silence that vault/site pair permanently after the first
+close, which is exactly the flood this module's convergence design exists to
+prevent for every *other* category, inverted into a silence for this one.
+
 ## `secrets/` guard
 
 A single shared predicate, `_is_secrets_path(rel_path, vault_root)`, guards
@@ -173,7 +187,9 @@ from "vault unresolvable" (`vault_narratives_compared: 0` via
 `_resolve_vault_root` returning `None` before any file is read — same `0`
 value, but paired with the `docs_audit: vault root resolution failed` /
 `no knowledge_base mapping` warning in the logs). Inspect the current value
-with:
+with (a per-machine debugging aid; the durable operator surfaces are the
+GitHub issue tracker and the reflections dashboard's rendered
+`output_summary`):
 
 ```bash
 redis-cli GET docs_audit:last_completed_run_summary

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -84,11 +84,30 @@ STUB_DOC_LINE_THRESHOLD = 5
 STALE_BRANCH_AGE_DAYS = 7
 STALE_PR_AGE_DAYS = 14
 
+# Per-run cap shared by audit()'s advisory issue-filing loop and the rotation
+# withheld-fix filing loop. A separate budget from VAULT_DRIFT_ISSUE_CAP, which
+# bounds only _run_vault_drift_detection's own pre-rotation loop — the two are
+# deliberately never merged (R5-2), so the true module-wide ceiling for one
+# rotation run is ISSUE_FILING_PER_RUN_CAP (advisory) + VAULT_DRIFT_ISSUE_CAP
+# (vault-drift) + ISSUE_FILING_PER_RUN_CAP (withheld) = 15 issues, plus at most
+# one operational-failure filing.
+ISSUE_FILING_PER_RUN_CAP = 5
+
+# Finding categories whose underlying condition can recur after a human closes
+# the issue that reported it — a recurring Redis/vault comparison or a run
+# outcome, never a durable property of the tree. `_file_issue_if_new` selects
+# `states="open"` for these so a closed issue never silences a fresh
+# occurrence; every other category is "all", matched once, ever.
+_RECURRING_CONDITION_CATEGORIES = frozenset({"vault-drift", "operational-failure"})
+
 # Marker stamped into a docs-audit PR body when the existence invariant withheld
-# any fix on the run that opened it. The rotation path is the one path with no
-# human review — it opens the PR and the branch sweeper can auto-merge it — so
-# `_pr_is_auto_merge_eligible` refuses any PR carrying this marker. A withheld
-# fix means the auditor wanted to write something wrong; that needs a human read.
+# any fix on the run that opened it. Every docs-audit PR requires a human
+# merge (`/do-merge`) — the rotation path opens no code path that lands a
+# commit unreviewed — and the sweeper reads this marker to exempt a withheld
+# PR from its stale-close at STALE_PR_AGE_DAYS, since closing it would
+# discard fixes that already passed the existence invariant. A withheld fix
+# means the auditor wanted to write something wrong; that needs a human read
+# before the surviving fixes are merged.
 #
 # This is a *conditional* instance of the "review requirement" option that #2726
 # defers — it applies only on the withheld path, leaves clean-run commit/staging
@@ -97,11 +116,11 @@ STALE_PR_AGE_DAYS = 14
 # owner rules with the shipped partial gate in view, not against a blank slate.
 #
 # NOTE: The marker lives in the PR body with no cross-check, so a human
-# `gh pr edit` that rewrites the body re-enables auto-merge. A
-# `do-not-auto-merge` label would be sturdier, but the label does not exist in
-# this repo and `gh pr create --label` fails outright when it is missing — a
-# worse failure than the human-only path this guards. No automation here runs
-# `gh pr edit`.
+# `gh pr edit` that rewrites the body loses the sweeper's stale-close
+# exemption. A `do-not-close` label would be sturdier, but the label does not
+# exist in this repo and `gh pr create --label` fails outright when it is
+# missing — a worse failure than the human-only path this guards. No
+# automation here runs `gh pr edit`.
 WITHHELD_PR_MARKER = "<!-- docs-auditor:fixes-withheld -->"
 
 # Redis key namespace for state/locks/liveness.
@@ -1069,8 +1088,8 @@ def _filing_machine_name() -> str:
     return get_machine_display_name()
 
 
-def _open_issue_exists(title: str, repo_root: Path) -> bool:
-    """Return True if an open `documentation` issue already has this exact title.
+def _issue_exists(title: str, repo_root: Path, *, states: str = "all") -> bool:
+    """Return True if an issue with this exact title already exists.
 
     This is the authoritative cross-machine dedup gate: local Redis dedup keys
     are per-machine and invisible across hosts, so two machines would otherwise
@@ -1079,10 +1098,28 @@ def _open_issue_exists(title: str, repo_root: Path) -> bool:
     an exact normalized-title comparison in Python (the title already encodes
     both the path and the doc, making it a natural composite key).
 
+    ``states`` defaults to ``"all"`` — most findings this module files (a
+    broken doc reference, an orphan plan, a stub doc) are a claim about the
+    tree's current state, and a human who reads one, rules on it, and closes
+    it without editing the doc has made a durable decision; matching only
+    ``"open"`` issues would re-file that exact finding a month later once the
+    per-machine Redis dedup key expires. ``states="open"`` is for the two
+    *recurring-condition* categories (see ``_RECURRING_CONDITION_CATEGORIES``)
+    whose underlying comparison can genuinely recur after a close: closing one
+    of those would otherwise silence the condition forever.
+
+    ``--limit 100`` is not decoration: ``gh issue list`` defaults to 30, and
+    under ``--state all`` a repo with more than 30 issues matching the search
+    term can push the exact title off the first page, which is a silent
+    fail-open that files a duplicate. No label filter — the label a triager
+    applied at filing time can be edited later, and the authoritative match
+    below is the exact title compare, not the label.
+
     Fails open: on any `gh` failure, non-zero exit, or malformed output, log a
     WARNING and return False so a genuine finding is never silently dropped —
     the worst case is the duplicate this gate was meant to prevent, which the
-    Redis fast-path still suppresses on the next run.
+    Redis fast-path still suppresses on the next run (for ``states="all"``
+    callers; the recurring-condition callers skip that fast-path by design).
     """
     normalized_query = _normalize_title(title)
     try:
@@ -1092,9 +1129,9 @@ def _open_issue_exists(title: str, repo_root: Path) -> bool:
                 "issue",
                 "list",
                 "--state",
-                "open",
-                "--label",
-                "documentation",
+                states,
+                "--limit",
+                "100",
                 "--search",
                 title,
                 "--json",
@@ -1134,26 +1171,42 @@ def _file_issue_if_new(finding: dict, repo_root: Path) -> bool:
     """File a GitHub issue via gh CLI, deduped by title. Returns True if filed.
 
     Two-tier dedup: a local Redis fast-path (per-machine cache) gates the
-    expensive live-tracker query, and `_open_issue_exists` is the authoritative
+    expensive live-tracker query, and `_issue_exists` is the authoritative
     cross-machine gate. Local Redis alone is insufficient because each machine
     keeps its own Redis, so the same finding would be filed once per machine.
+
+    The fast-path is gated on the finding's category. For a recurring-condition
+    category (``_RECURRING_CONDITION_CATEGORIES``) the 30-day Redis key would
+    otherwise suppress a genuine recurrence of the same condition for up to a
+    month after a human closed the issue the first time — the fast-path never
+    reaches `_issue_exists`, so its `states="open"` selection would be inert for
+    that whole window. Gating only the *read* is sufficient: `dedup_key` has
+    exactly one reader (this `exists` check) and two writers (both below), so
+    once the read is off for a category the key is never consulted for it
+    again — the two `set()` calls stay unconditional as a fail-open cap during
+    a `gh` outage (R8-1).
     """
     title = finding.get("title", "").strip()
     if not title:
         return False
+    states = "open" if finding.get("category") in _RECURRING_CONDITION_CATEGORIES else "all"
     title_hash = hashlib.sha256(title.encode("utf-8")).hexdigest()[:16]
     dedup_key = f"{REDIS_ISSUE_DEDUP_PREFIX}:{title_hash}"
     redis_client = None
     try:
         redis_client = _get_redis()
-        # Fast-path: if this machine already filed it, skip the tracker query entirely.
-        if redis_client.exists(dedup_key):
+        # Fast-path: if this machine already filed it, skip the tracker query
+        # entirely — but only for a once-ever category. A recurring-condition
+        # category must always reach `_issue_exists(states="open")`, or a
+        # closed issue for a condition that has genuinely returned stays
+        # silenced by this per-machine cache for up to 30 days.
+        if states == "all" and redis_client.exists(dedup_key):
             return False  # already filed
     except Exception:
         redis_client = None  # If Redis is unavailable, attempt to file without dedup
 
     # Authoritative cross-machine gate: another machine may have already filed this.
-    if _open_issue_exists(title, repo_root):
+    if _issue_exists(title, repo_root, states=states):
         # Record the local fast-path key so subsequent runs skip the tracker query.
         if redis_client is not None:
             try:
@@ -1339,10 +1392,9 @@ def audit(
         # deleted-target reference has no rename to correct to. These are
         # rotation-only: Caller B (/do-docs, scope=pr-changed-files) runs on
         # every PR's docs stage, so filing advisory issues there re-files the
-        # same unfixable findings per-PR (and re-files any that were closed
-        # without fixing the doc, since the dedup gate only sees open issues),
-        # which is the documentation-label duplicate flood. Auto-fix detectors
-        # above still run per-PR; only issue-filing is gated to rotation.
+        # same unfixable findings per-PR, which is the documentation-label
+        # duplicate flood. Auto-fix detectors above still run per-PR; only
+        # issue-filing is gated to rotation.
         if scope_mode == "rotation":
             issue_findings.extend(_detect_deleted_target_issues(path, content, root))
             stub = _detect_stub_doc(path, content)
@@ -1355,7 +1407,7 @@ def audit(
 
     # File issues (deduped); only when applying in rotation scope.
     # Hard per-run cap prevents flood: rotation allows up to 5.
-    per_run_cap = 5 if scope_mode == "rotation" else 3
+    per_run_cap = ISSUE_FILING_PER_RUN_CAP if scope_mode == "rotation" else 3
     if apply_mode == "apply" and scope_mode == "rotation":
         for finding in issue_findings:
             if issues_filed >= per_run_cap:
@@ -1644,8 +1696,9 @@ def _push_branch_and_pr(
     guard can no longer fire after the shared checkout has already been dirtied.
 
     ``withheld`` is the run's existence-invariant rejections. When non-empty the
-    PR body lists them and carries ``WITHHELD_PR_MARKER``, which disqualifies the
-    PR from the sweeper's auto-merge path.
+    PR body lists them and carries ``WITHHELD_PR_MARKER``, which exempts the PR
+    from the sweeper's stale-close so the surviving fixes are not discarded
+    before a human reviews them.
     """
     if not files_touched:
         logger.info("docs_auditor: no files touched, skipping branch/commit/PR")
@@ -1702,8 +1755,8 @@ def _push_branch_and_pr(
                 f"\n\n{WITHHELD_PR_MARKER}\n"
                 f"⚠️ **{len(withheld)} fix(es) withheld** by the existence invariant — "
                 "the auditor tried to introduce a path that is absent from the working "
-                "tree. Not eligible for auto-merge; review the surviving fixes before "
-                f"merging.\n\n{rejected}"
+                "tree. Review the surviving fixes before merging.\n\n"
+                f"{rejected}"
             )
         pr_result = subprocess.run(
             [
@@ -2021,7 +2074,7 @@ def run_docs_auditor() -> dict:
     # 2. Lock
     if not _acquire_lock(REDIS_RUNNING_KEY, LOCK_TTL_SECONDS):
         return {
-            "status": "ok",
+            "status": "skipped",
             "findings": ["docs-auditor already running, skipped"],
             "summary": "docs-auditor skipped: locked",
         }
@@ -2029,11 +2082,16 @@ def run_docs_auditor() -> dict:
     project_key = os.environ.get("VALOR_PROJECT_KEY", "valor").strip() or "valor"
 
     try:
-        # 3. Dirty-tree guard
+        # 3. Dirty-tree guard. Deliberately files nothing: `_git_dirty` tests the
+        # whole shared main checkout, where concurrent lanes routinely hold
+        # uncommitted work as a matter of routine, so a filing guard would mint
+        # issues blaming the auditor for a peer's dirt. The escalation belongs on
+        # the failure path below, which knows it caused the dirt — this guard,
+        # which cannot know, stays quiet (Q4 item 5).
         if _git_dirty(PROJECT_ROOT):
             _write_liveness("(dirty)", "skipped", None, 0)
             return {
-                "status": "ok",
+                "status": "skipped",
                 "findings": ["docs-auditor skipped: working tree dirty"],
                 "summary": "docs-auditor skipped: dirty_tree",
             }
@@ -2048,7 +2106,7 @@ def run_docs_auditor() -> dict:
         if primary is None:
             _write_liveness("(no-candidates)", "skipped", None, 0)
             return {
-                "status": "ok",
+                "status": "skipped",
                 "findings": ["No candidate docs found"],
                 "summary": "docs-auditor skipped: no candidates",
             }
@@ -2091,11 +2149,12 @@ def run_docs_auditor() -> dict:
         )
 
         files_touched: list[str] = result.get("files_touched", [])
-        # Existence-invariant rejections. This is the one caller with no human in
-        # the loop — it opens a PR the sweeper may auto-merge — so the withheld
-        # count must reach every surface this function produces, not just a log
-        # line: findings, summary, Telegram, the PR body (auto-merge gate) and
-        # the Redis liveness summary, which is the only durable queryable one.
+        # Existence-invariant rejections. This is the one caller with no human
+        # review before the PR opens — every rotation PR still requires a human
+        # merge, but the withheld count must reach every surface this function
+        # produces so the human reviewing it sees it, not just a log line:
+        # findings, summary, Telegram, the PR body, and the Redis liveness
+        # summary, which is the only durable queryable one.
         # Telegram has two mutually exclusive senders, and a run can also reach
         # neither. Three cases: files were touched — step 9 sends the pass
         # summary; nothing was touched but fixes were withheld — the zero-diff
@@ -2108,6 +2167,48 @@ def run_docs_auditor() -> dict:
             f"; {fixes_withheld} fix(es) withheld (target-absent)" if fixes_withheld else ""
         )
 
+        # Q5 (B4): file one issue per withheld entry so a human is pointed at the
+        # specific substitution the existence invariant rejected, not just a log
+        # line. Deduped per-defect by `_file_issue_if_new`'s title-based gate.
+        # Bounded at the module's shared per-run cap (NEW-4 / R3-3) — a withheld
+        # flood must not spend a different budget than the advisory loop's.
+        if withheld:
+            for i, w in enumerate(withheld):
+                if i >= ISSUE_FILING_PER_RUN_CAP:
+                    logger.warning(
+                        "docs_auditor: withheld-fix per-run cap (%d) reached — "
+                        "%d finding(s) suppressed",
+                        ISSUE_FILING_PER_RUN_CAP,
+                        len(withheld) - ISSUE_FILING_PER_RUN_CAP,
+                    )
+                    break
+                # `old` is a regex source (rf"\b{re.escape(old_term)}\b"), not the
+                # substitution term itself — unwrap it before it becomes the
+                # dedup key (R5-3), or the title carries a literal `\b` into
+                # `gh issue list --search`.
+                term = re.sub(
+                    r"\\(.)",
+                    r"\1",
+                    w["old"].removeprefix(r"\b").removesuffix(r"\b"),
+                )
+                _file_issue_if_new(
+                    {
+                        "title": (
+                            f"docs-auditor: withheld fix in {w.get('doc')} "
+                            f"({term} -> {w.get('new')})"
+                        ),
+                        "body": (
+                            f"The docs auditor tried to rewrite `{term}` to "
+                            f"`{w.get('new')}` in `{w.get('doc')}`, but the rewrite "
+                            "would have introduced a path that does not exist in "
+                            f"the working tree ({w.get('reason', 'target-absent')}), "
+                            "so it was withheld and the file was left unchanged."
+                        ),
+                        "category": "withheld-fix",
+                    },
+                    PROJECT_ROOT,
+                )
+
         # 6. Zero-diff gate
         if not files_touched or _git_diff_quiet(PROJECT_ROOT):
             _update_rotation_hash(project_key, [str(primary)])
@@ -2119,7 +2220,7 @@ def run_docs_auditor() -> dict:
                     "nothing was written and no PR was opened to review them"
                 )
             return {
-                "status": "ok",
+                "status": "skipped",
                 "findings": [f"docs-auditor: zero-diff for {primary}{withheld_note}"],
                 "summary": f"docs-auditor: zero-diff ({slug}){withheld_note}",
             }
@@ -2137,6 +2238,34 @@ def run_docs_auditor() -> dict:
                 f"docs-auditor: rotation wrote {len(files_touched)} file(s) for {slug} "
                 "but produced no PR"
             )
+            # R5-1: a wedged shared checkout must escalate through a real channel
+            # before this returns, not just log a warning nobody reads — the
+            # `status="error"` alone reaches nobody, since
+            # agent/reflection_scheduler.py:639-640 reads only `projects` from
+            # this dict. Slug-keyed only, no run id or date, so a failure that
+            # repeats every run files once. Deliberately silent on which step
+            # failed and on whether the scoped restore succeeded — neither fact
+            # reaches this branch (`_push_branch_and_pr` returns `str | None`),
+            # and a body that asserts a restore outcome it never observed is
+            # worse than one that omits it.
+            _file_issue_if_new(
+                {
+                    "title": f"docs-auditor: rotation failed to produce a PR for {slug}",
+                    "body": (
+                        f"Rotation wrote {len(files_touched)} file(s) for `{slug}` but the "
+                        "branch/push/PR sequence did not produce a PR URL.\n\n"
+                        f"Files touched: {', '.join(files_touched)}\n\n"
+                        "If the shared checkout is left dirty, clean it up with:\n\n"
+                        "```\n"
+                        'git -C "${AI_REPO_ROOT:-$HOME/src/ai}" status --porcelain -- docs .claude\n'
+                        "```\n\n"
+                        "See the `docs_auditor: branch/push/PR …` warning in the reflection "
+                        "log for the step that failed."
+                    ),
+                    "category": "operational-failure",
+                },
+                PROJECT_ROOT,
+            )
             return {
                 "status": "error",
                 "findings": findings,
@@ -2151,17 +2280,20 @@ def run_docs_auditor() -> dict:
         except Exception as e:
             logger.warning(f"docs_auditor: refresh_docs_in_memory hook failed: {e}")
 
-        # 9. Telegram notification
+        # 9. Telegram notification. Every rotation PR requires a human merge —
+        # `/do-merge` — and is closed unmerged at STALE_PR_AGE_DAYS if nobody
+        # acts, which is the intended "nobody cared" outcome, not a failure mode.
         msg = (
             f"docs-auditor pass for {slug}: "
             f"{len(files_touched)} files, {result.get('fixes_applied', 0)} fixes"
             + (
-                f"\n⚠️ {fixes_withheld} fix(es) withheld — target path absent; "
-                "PR is not auto-merge eligible"
+                f"\n⚠️ {fixes_withheld} fix(es) withheld — target path absent; see the "
+                "filed issue(s) for details"
                 if fixes_withheld
                 else ""
             )
             + f"\nPR: {pr_url}"
+            + f"\nReview required — closed unmerged after {STALE_PR_AGE_DAYS} days if unreviewed."
         )
         _send_telegram_notification(msg)
 
@@ -2186,7 +2318,7 @@ def run_docs_auditor() -> dict:
         if fixes_withheld:
             findings.append(
                 f"{fixes_withheld} fix(es) withheld by the existence invariant "
-                "(target-absent); PR is not auto-merge eligible"
+                "(target-absent); see the filed issue(s) for details"
             )
             findings.extend(
                 f"withheld: {w.get('doc')} {w.get('old')!r} -> {w.get('new')!r}" for w in withheld
@@ -2220,98 +2352,16 @@ def run_docs_auditor() -> dict:
 # ---------------------------------------------------------------------------
 
 
-def _pr_is_auto_merge_eligible(pr_number: int) -> bool:
-    """Return True if a docs-audit PR meets the conservative auto-merge bar.
-
-    Heuristics (all must pass):
-    - Only ``docs/`` files changed (no code, no config)
-    - ≤ 5 files changed
-    - ≤ 50 net lines changed (additions + deletions)
-    - No reviews, review requests, or comments
-    - PR is between 1 and 7 days old (not brand-new, not stale)
-    - The opening run withheld no fixes (no ``WITHHELD_PR_MARKER`` in the body)
-    """
-    try:
-        meta_res = subprocess.run(
-            [
-                "gh",
-                "pr",
-                "view",
-                str(pr_number),
-                "--json",
-                "files,reviews,reviewRequests,comments,createdAt,additions,deletions,body",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=settings.timeouts.git_subprocess_s,
-            cwd=str(PROJECT_ROOT),
-        )
-        if meta_res.returncode != 0:
-            return False
-        meta = json.loads(meta_res.stdout or "{}")
-
-        # Withheld fixes disqualify: the run that opened this PR proposed at least
-        # one rewrite to a nonexistent path, so its surviving output is suspect.
-        #
-        # KNOWN ESCALATION GAP — tracked by #2729:
-        # this disqualification is permanent, so a withheld PR nobody reviews
-        # falls through to the sweeper's stale-close at STALE_PR_AGE_DAYS —
-        # closed with --delete-branch, discarding the fixes that *did* pass the
-        # invariant, and the next rotation onto the same slug re-proposes,
-        # re-opens and re-closes it forever. Nothing pages a human: the only
-        # record is a `findings` entry, and the scheduler reads only `projects`
-        # from a function reflection. Still strictly safer than auto-merging
-        # suspect output. Ownership of the escalation (exempt from stale-close,
-        # or notify before closing) is deliberately out of scope here and needs
-        # an owner ruling; see #2729.
-        if WITHHELD_PR_MARKER in (meta.get("body") or ""):
-            logger.info(
-                "docs_auditor: PR #%d not auto-merge eligible — run withheld fixes", pr_number
-            )
-            return False
-
-        # No reviewer activity
-        if meta.get("reviews") or meta.get("reviewRequests") or meta.get("comments"):
-            return False
-
-        # File count and path guard
-        files = meta.get("files", [])
-        if not files or len(files) > 5:
-            return False
-        for f in files:
-            path = f.get("path", "")
-            if not (path.startswith("docs/") or path in ("README.md", "CLAUDE.md")):
-                return False
-
-        # Diff size guard
-        net_lines = meta.get("additions", 0) + meta.get("deletions", 0)
-        if net_lines > 50:
-            return False
-
-        # Age guard: 1–7 days
-        created_raw = meta.get("createdAt", "")
-        if not created_raw:
-            return False
-        age_days = (
-            datetime.now(UTC) - datetime.fromisoformat(created_raw.replace("Z", "+00:00"))
-        ).days
-        if age_days < 1 or age_days > 7:
-            return False
-
-        return True
-    except Exception as e:
-        logger.warning(f"docs_auditor: auto-merge eligibility check failed for #{pr_number}: {e}")
-        return False
-
-
 def run_docs_branch_sweeper() -> dict:
     """Sweep stale ``docs-audit/*`` branches and PRs.
 
     Conservative: only touches ``docs-audit/*`` branches, never any other
-    prefix and never branches with reviewer activity.
-
-    Also auto-merges PRs that pass the conservative eligibility check (docs-only,
-    small diff, no reviewer activity, 1–7 days old).
+    prefix. Every ``docs-audit/*`` PR requires a human merge; this sweeper only
+    closes ones nobody reviewed within ``STALE_PR_AGE_DAYS`` — except a PR
+    carrying ``WITHHELD_PR_MARKER``, which it never closes or deletes, because
+    the withheld fixes it holds already have their own escalation issue and
+    closing the PR would discard the surviving fixes that passed the existence
+    invariant.
     """
     if not _acquire_lock(REDIS_SWEEPER_RUNNING_KEY, SWEEPER_LOCK_TTL_SECONDS):
         return {
@@ -2323,7 +2373,6 @@ def run_docs_branch_sweeper() -> dict:
     findings: list[str] = []
     branches_deleted = 0
     prs_closed = 0
-    prs_merged = 0
 
     try:
         # List remote branches under docs-audit/
@@ -2363,7 +2412,7 @@ def run_docs_branch_sweeper() -> dict:
                         "--state",
                         "all",
                         "--json",
-                        "number,state,createdAt",
+                        "number,state,createdAt,body",
                     ],
                     capture_output=True,
                     text=True,
@@ -2451,29 +2500,25 @@ def run_docs_branch_sweeper() -> dict:
                 if not pr_num:
                     continue
 
-                # Auto-merge eligible PRs before stale-close check
-                if _pr_is_auto_merge_eligible(pr_num):
-                    try:
-                        merge_res = subprocess.run(
-                            ["gh", "pr", "merge", str(pr_num), "--squash", "--delete-branch"],
-                            capture_output=True,
-                            text=True,
-                            timeout=settings.timeouts.git_subprocess_s,
-                            cwd=str(PROJECT_ROOT),
-                            check=False,
-                        )
-                        if merge_res.returncode == 0:
-                            prs_merged += 1
-                            findings.append(
-                                f"Auto-merged PR #{pr_num} (branch={branch}, {age_days}d)"
-                            )
-                            continue
-                        else:
-                            logger.warning(
-                                f"sweeper: auto-merge failed for #{pr_num}: {merge_res.stderr}"
-                            )
-                    except Exception as e:
-                        logger.warning(f"sweeper: auto-merge error for #{pr_num}: {e}")
+                # A withheld PR is exempt from stale-close: closing it would
+                # discard fixes that already passed the existence invariant.
+                # The escalation issue is distinct from `_file_issue_if_new`'s
+                # per-defect withheld-fix titles, since a same-title filing is
+                # a guaranteed no-op — this names the PR, not the substitution.
+                if WITHHELD_PR_MARKER in (pr.get("body") or ""):
+                    _file_issue_if_new(
+                        {
+                            "title": f"docs-auditor: withheld PR #{pr_num} still unreviewed",
+                            "body": (
+                                f"PR #{pr_num} (branch `{branch}`) is {age_days} day(s) old "
+                                "and carries withheld fixes that need a human review before "
+                                "merge. The sweeper will not close it or delete its branch."
+                            ),
+                            "category": "withheld-pr",
+                        },
+                        PROJECT_ROOT,
+                    )
+                    continue
 
                 if age_days >= STALE_PR_AGE_DAYS:
                     try:
@@ -2491,7 +2536,7 @@ def run_docs_branch_sweeper() -> dict:
 
         summary = (
             f"do-docs-branch-sweeper: {branches_deleted} branches deleted, "
-            f"{prs_closed} PRs closed, {prs_merged} PRs auto-merged"
+            f"{prs_closed} PRs closed"
         )
         logger.info(summary)
         return {"status": "ok", "findings": findings, "summary": summary}

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -842,20 +842,65 @@ def _apply_fixes_to_file(
 
 
 # Path components that are obvious illustrative stand-ins, not real module names.
+# `filename`/`path`/`name` are the link-specific stand-ins the `.md` branch
+# surfaces (spike-6); `_is_placeholder_path` is shared by both branches.
 _PLACEHOLDER_PATH_COMPONENTS = frozenset(
-    {"foo", "bar", "baz", "qux", "quux", "example", "your-module", "mymodule", "sample"}
+    {
+        "foo",
+        "bar",
+        "baz",
+        "qux",
+        "quux",
+        "example",
+        "your-module",
+        "mymodule",
+        "sample",
+        "filename",
+        "path",
+        "name",
+    }
 )
 
-# Heading keywords whose presence means the doc is deliberately recording a deletion.
-_DELETION_HEADING_KEYWORDS = ("migration", "removed", "deleted", "deprecated")
+# Heading-keyword stems whose presence means the doc is deliberately recording a
+# deletion. Stems, not exact inflections, so "## Dead SDK Path Deletion" and
+# "## Hook Cleanup" both match without listing every inflected form.
+_DELETION_HEADING_KEYWORDS = ("delet", "remov", "deprecat", "migrat", "cleanup", "obsolete", "retire")
 
-# Prose cues that a nearby line is documenting a deletion rather than a live reference.
-_DELETION_PROSE_CUES = (
-    "deleted module",
-    "no longer in the codebase",
-    "no longer exists",
-    "previously in",
+# Word-anchored prose cues that a nearby line is documenting a deletion rather
+# than a live reference. Individual words/short phrases, not full sentences —
+# real corpus prose reads "deleted (250 lines)" or "no longer needed", not the
+# single fixed phrase "deleted module". Compiled once, in the shape of
+# `_MIGRATION_CUE_WORD_RE`, so a bare substring test cannot fire inside an
+# unrelated longer word.
+_DELETION_PROSE_CUE_WORDS = (
+    "deleted",
+    "removed",
+    "no longer",
+    "previously",
     "formerly",
+    "deprecated",
+)
+_DELETION_PROSE_CUE_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(w) for w in _DELETION_PROSE_CUE_WORDS) + r")\b"
+)
+
+# Word-anchored cues that a match's own line is a *live* claim, not a deletion
+# record — cancels the deletion-narrative suppression when present. Keyword-only
+# and evaluated only when the caller opts in via `live_claim_veto=True` (see
+# `_is_documented_deletion`): the detector's cost for a wrong suppression is a
+# missed report, while the write path's cost for a wrong un-suppression is an
+# unreviewed rewrite of narrative prose, so only the detector opts in.
+_LIVE_CLAIM_VETO_WORDS = (
+    "remain",
+    "remains",
+    "still",
+    "defined in",
+    "lives in",
+    "currently",
+    "implemented in",
+)
+_LIVE_CLAIM_VETO_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(w) for w in _LIVE_CLAIM_VETO_WORDS) + r")\b"
 )
 
 
@@ -865,16 +910,19 @@ def _is_placeholder_path(path: str) -> bool:
     A path is a placeholder when any of its components is a well-known stand-in
     (``foo``, ``bar``, ``example`` ...) or a single lowercase letter directory.
     Empty or single-segment paths return False (the detector regex guarantees a
-    ``dir/file.py`` shape, so this only guards malformed/odd input).
+    ``dir/file.{py,md}`` shape, so this only guards malformed/odd input).
     """
     if not path or "/" not in path:
         return False
     components = path.split("/")
     for i, component in enumerate(components):
-        # For the final component, compare the file stem (strip the .py suffix)
-        # so ``agent/docs_handler/foo.py`` is caught on its ``foo`` stem.
+        # For the final component, compare the file stem (strip a .py or .md
+        # suffix) so ``agent/docs_handler/foo.py`` is caught on its ``foo``
+        # stem, and so is ``docs/features/name.md``.
         is_last = i == len(components) - 1
-        candidate = component[:-3] if is_last and component.endswith(".py") else component
+        candidate = component
+        if is_last and (candidate.endswith(".py") or candidate.endswith(".md")):
+            candidate = candidate[:-3]
         lowered = candidate.lower()
         if lowered in _PLACEHOLDER_PATH_COMPONENTS:
             return True
@@ -917,42 +965,157 @@ def _build_line_context(content: str) -> tuple[list[bool], list[str]]:
 
 
 def _is_documented_deletion(
-    line_idx: int, lines: list[str], in_fence: list[bool], heading_for_line: list[str]
+    line_idx: int,
+    lines: list[str],
+    in_fence: list[bool],
+    heading_for_line: list[str],
+    *,
+    live_claim_veto: bool = False,
 ) -> bool:
     """Return True if a match at ``line_idx`` is an illustrative or documented deletion.
 
-    Three conservative cues (any one suppresses the finding):
-    1. The match falls inside a fenced code block (illustrative example).
-    2. The nearest preceding heading names a deletion (migration/removed/
-       deleted/deprecated).
-    3. The match's line or an immediately adjacent line carries a deletion-prose
-       cue ("deleted module", "no longer exists", ...).
+    Three conservative cues (any one suppresses the finding), evaluated in
+    order:
+    1. The match falls inside a fenced code block (illustrative example) —
+       always wins; a fenced block is illustrative no matter what it says.
+    2. The nearest preceding heading names a deletion, matched on a stem
+       (``delet``, ``remov``, ``deprecat``, ``migrat``, ``cleanup``,
+       ``obsolete``, ``retire``) rather than an exact inflection.
+    3. The match's line or a line within 2 lines carries a word-anchored
+       deletion-prose cue (``deleted``, ``removed``, ``no longer``, ...).
+
+    ``live_claim_veto`` (keyword-only, default ``False``) cancels tiers 2 and 3
+    when the match's own line carries a live-claim cue (``remains``, ``still``,
+    ``defined in``, ...) — evaluated **after** the fence tier (a fenced block
+    stays illustrative regardless) and **before** the heading/prose tiers, so
+    a line like *"`fail_stage()` remains defined in `agent/hooks/gone.py`"*
+    under a ``## Migration`` heading is still reported. Off by default and
+    opt-in only from ``_detect_deleted_target_issues`` — see that function and
+    ``_make_stale_term_replacer``, which never sets it, for why: this
+    predicate's ``True`` means "suppress" at both call sites, but suppression
+    costs differently on each. Widening what the *detector* suppresses costs a
+    missed report; widening what the *write path* suppresses costs an
+    auditor-authored rewrite of narrative prose on every PR — the exact
+    behavior #2739 exists to gate.
 
     Inline single-backtick code is NOT suppressed — that is how genuine
     references are written.
     """
     if line_idx < len(in_fence) and in_fence[line_idx]:
         return True
+    if live_claim_veto and line_idx < len(lines) and _LIVE_CLAIM_VETO_RE.search(lines[line_idx].lower()):
+        return False
     if line_idx < len(heading_for_line):
         heading = heading_for_line[line_idx]
         if any(kw in heading for kw in _DELETION_HEADING_KEYWORDS):
             return True
-    for adj in (line_idx - 1, line_idx, line_idx + 1):
+    for adj in (line_idx - 2, line_idx - 1, line_idx, line_idx + 1, line_idx + 2):
         if 0 <= adj < len(lines):
-            lowered = lines[adj].lower()
-            if any(cue in lowered for cue in _DELETION_PROSE_CUES):
+            if _DELETION_PROSE_CUE_RE.search(lines[adj].lower()):
                 return True
     return False
+
+
+# Markdown link syntax: `[label](target)`. Anchor/query stripping and scheme
+# detection happen after the match, in `_resolve_md_link_target`.
+_MD_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+_URI_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
+
+
+def _in_md_link_scope(doc_path: Path) -> bool:
+    """Whether ``doc_path`` is in scope for the ``.md`` broken-link branch.
+
+    Scope is ``docs/`` minus ``docs/plans/completed/`` and ``docs/plans/done/``
+    — archived plans deliberately record history and are not a live surface a
+    human reviews for broken links. Everything outside ``docs/`` (including
+    ``.claude/``) is out of scope for this branch; the ``.py`` branch has no
+    such restriction because it runs over whatever neighborhood the caller
+    already resolved.
+    """
+    parts = doc_path.parts
+    if not parts or parts[0] != "docs":
+        return False
+    if len(parts) >= 3 and parts[1] == "plans" and parts[2] in ("completed", "done"):
+        return False
+    return True
+
+
+def _resolve_md_link_target(raw_target: str, doc_path: Path, repo_root: Path) -> Path | None:
+    """Resolve a markdown link target to a repo-relative ``Path``, or ``None``.
+
+    Anchors and queries are stripped before resolution — ``./gone.md#section``
+    resolves as ``gone.md``, so the title (and dedup key) stay stable regardless
+    of which section a link points at. Resolution is **doc-relative**: a
+    leading ``/`` resolves against the repo root, everything else resolves
+    against the containing document's own directory — the frame markdown
+    renderers actually use (the #2725 / #2741 regression this branch exists to
+    keep fixed). Returns ``None`` for a non-``.md`` target, or one that
+    normalizes outside the repo root.
+    """
+    target = raw_target.split("#", 1)[0].split("?", 1)[0].strip()
+    if not target or not target.endswith(".md"):
+        return None
+    root = repo_root.resolve()
+    if target.startswith("/"):
+        candidate = (root / target.lstrip("/")).resolve()
+    else:
+        candidate = (root / doc_path.parent / target).resolve()
+    try:
+        return candidate.relative_to(root)
+    except ValueError:
+        return None
+
+
+def _match_inside_code_span(text: str, start: int, end: int) -> bool:
+    """Whether ``text[start:end]`` lies wholly inside an inline `` `code span` ``.
+
+    Scanning is confined to the match's own line, mirroring
+    ``_match_inside_path_token``. A markdown link inside a code span is a
+    literal illustration of syntax, not a live reference — the deliberate
+    asymmetry with the ``.py`` branch, which requires backticks to be a
+    reference at all.
+    """
+    line_start = text.rfind("\n", 0, start) + 1
+    line_end = text.find("\n", end)
+    if line_end == -1:
+        line_end = len(text)
+    line = text[line_start:line_end]
+    rel_start, rel_end = start - line_start, end - line_start
+    return any(
+        bm.start() <= rel_start and rel_end <= bm.end() for bm in re.finditer(r"`[^`]*`", line)
+    )
 
 
 def _detect_deleted_target_issues(doc_path: Path, content: str, repo_root: Path) -> list[dict]:
     """File issues for references to deleted targets.
 
-    Suppresses four classes of false positive before emitting a finding:
-    placeholder/example paths (``foo/bar.py``), paths inside fenced illustrative
-    code blocks, paths under a deletion-recording heading or deletion prose, and
-    package-relative paths that resolve by component-anchored suffix (#2936).
-    Every suppressed match is logged at DEBUG so operators can audit the filter.
+    Two reference shapes, sharing one deletion-narrative hatch
+    (``_is_documented_deletion``):
+
+    * Backticked ``.py`` paths, e.g. `` `agent/gone.py` `` — repo-wide, no
+      scope restriction beyond what the caller's neighborhood resolved.
+      Suppresses a fourth class beyond the two shared below: package-relative
+      paths that resolve by component-anchored suffix (#2936).
+    * Markdown-link ``.md`` targets, e.g. ``[label](gone.md)`` — scoped to
+      ``docs/`` minus ``docs/plans/completed/`` and ``docs/plans/done/`` (see
+      ``_in_md_link_scope``). Resolved **doc-relative**, not repo-root-relative
+      (the #2725 / #2741 frame rule): a target that exists at the repo root but
+      not doc-relative is still reported. A markdown link inside a code span is
+      not a reference — the deliberate asymmetry with the ``.py`` branch, which
+      requires backticks to *be* one.
+
+    Both branches suppress the same two classes of false positive:
+    placeholder/example paths and matches inside fenced illustrative code
+    blocks, plus matches under a deletion-recording heading or deletion prose
+    — the latter via ``_is_documented_deletion(..., live_claim_veto=True)``,
+    the only caller that passes the veto (it is a detector, never the write
+    path). Every suppressed match is logged at DEBUG so operators can audit
+    the filter.
+
+    The ``.md`` branch only ever *reports* a broken link; it never rewrites
+    the doc, and no auto-repairing replacement is coming back — an auditor
+    deleting lines from a human's index file on its own judgment is exactly
+    the unreviewed-write class #2739 exists to gate.
     """
     findings: list[dict] = []
     lines = content.splitlines()
@@ -973,7 +1136,7 @@ def _detect_deleted_target_issues(doc_path: Path, content: str, repo_root: Path)
             )
             continue
         line_idx = content.count("\n", 0, m.start())
-        if _is_documented_deletion(line_idx, lines, in_fence, heading_for_line):
+        if _is_documented_deletion(line_idx, lines, in_fence, heading_for_line, live_claim_veto=True):
             logger.debug(
                 "docs_auditor: suppressed deleted-target finding for %s in %s "
                 "(fenced block or documented deletion)",
@@ -1005,6 +1168,46 @@ def _detect_deleted_target_issues(doc_path: Path, content: str, repo_root: Path)
                 "category": "deleted-target",
             }
         )
+
+    if _in_md_link_scope(doc_path):
+        for m in _MD_LINK_RE.finditer(content):
+            raw_target = m.group(1).strip()
+            if not raw_target or raw_target.startswith("#") or _URI_SCHEME_RE.match(raw_target):
+                continue
+            if _match_inside_code_span(content, m.start(), m.end()):
+                continue
+            rel = _resolve_md_link_target(raw_target, doc_path, repo_root)
+            if rel is None:
+                continue
+            rel_str = str(rel)
+            if _is_placeholder_path(rel_str):
+                logger.debug(
+                    "docs_auditor: suppressed broken-md-link finding for placeholder path %s in %s",
+                    rel_str,
+                    doc_path,
+                )
+                continue
+            line_idx = content.count("\n", 0, m.start())
+            if _is_documented_deletion(
+                line_idx, lines, in_fence, heading_for_line, live_claim_veto=True
+            ):
+                logger.debug(
+                    "docs_auditor: suppressed broken-md-link finding for %s in %s "
+                    "(fenced block or documented deletion)",
+                    rel_str,
+                    doc_path,
+                )
+                continue
+            if (repo_root / rel).exists():
+                continue
+            findings.append(
+                {
+                    "title": f"Doc references missing link target: {rel_str} (in {doc_path})",
+                    "body": f"`{doc_path}` links to `{rel_str}` which does not exist in the repo.",
+                    "category": "broken-md-link",
+                }
+            )
+
     return findings
 
 

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -1246,6 +1246,14 @@ def audit(
 ) -> dict:
     """Unified docs-auditor entrypoint. Synchronous.
 
+    **This function never commits.** It writes fixes to the working tree, fires
+    the memory-refresh hook on what it wrote, and returns ``files_touched``. The
+    tree is left dirty and the **caller owns the commit**, because every write
+    the auditor makes has to pass a named review gate before it becomes a
+    permanent record: the ``/do-docs`` skill reads the diff for
+    ``pr-changed-files``, and the rotation reflection's gate is the pull request
+    ``run_docs_auditor`` opens.
+
     Args:
         primary_path: Repo-relative path to the primary doc to audit. When
             ``scope_mode == "pr-changed-files"`` this is ignored.
@@ -1362,11 +1370,11 @@ def audit(
             if _file_issue_if_new(finding, root):
                 issues_filed += 1
 
-    # Caller B (pr-changed-files): commit to current branch and fire memory
-    # refresh hook here so the /do-docs skill stays a thin caller. Caller A
-    # (rotation) handles its own commit/push/hook in run_docs_auditor.
+    # Caller B (pr-changed-files): fire the memory-refresh hook on the applied
+    # set. The hook operates on applied paths and needs no commit — the working
+    # tree stays dirty for the /do-docs skill's review gate. Caller A (rotation)
+    # handles its own branch/commit/push/hook in run_docs_auditor.
     if scope_mode == "pr-changed-files" and apply_mode == "apply" and touched:
-        _commit_current_branch(root, touched)
         try:
             refresh_docs_in_memory(touched)
         except Exception as e:
@@ -1380,32 +1388,6 @@ def audit(
         fixes_withheld=len(withheld),
         withheld=withheld,
     )
-
-
-def _commit_current_branch(repo_root: Path, touched: list[str]) -> None:
-    """Stage and commit substrate-applied changes on the current branch.
-
-    Best-effort: errors are logged not raised. Used by Caller B (/do-docs)
-    so the skill itself does not need to invoke git after the substrate.
-    """
-    try:
-        subprocess.run(
-            ["git", "add"] + touched,
-            capture_output=True,
-            timeout=settings.timeouts.git_subprocess_s,
-            cwd=str(repo_root),
-            check=False,
-        )
-        subprocess.run(
-            ["git", "commit", "-m", f"Docs: cascade fixes ({len(touched)} files)"],
-            capture_output=True,
-            text=True,
-            timeout=settings.timeouts.git_subprocess_s,
-            cwd=str(repo_root),
-            check=False,
-        )
-    except Exception as e:
-        logger.warning(f"docs_auditor: current-branch commit failed: {e}")
 
 
 # ---------------------------------------------------------------------------
@@ -2361,6 +2343,10 @@ def run_docs_branch_sweeper() -> dict:
 if __name__ == "__main__":
     # Allow `python -m reflections.docs_auditor` to print a JSON result for the
     # ``/do-docs`` skill bash block. Args via env: SCOPE_MODE, APPLY_MODE.
+    #
+    # This runs no git of its own and **leaves a dirty working tree**: the fixes
+    # `audit()` applied are unstaged on exit, and reviewing and committing them
+    # is the caller's job.
     scope = os.environ.get("DOCS_AUDIT_SCOPE", "pr-changed-files")
     apply = os.environ.get("DOCS_AUDIT_APPLY", "apply")
     project = os.environ.get("VALOR_PROJECT_KEY", "valor")

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -85,12 +85,12 @@ STALE_BRANCH_AGE_DAYS = 7
 STALE_PR_AGE_DAYS = 14
 
 # Per-run cap shared by audit()'s advisory issue-filing loop and the rotation
-# withheld-fix filing loop. A separate budget from VAULT_DRIFT_ISSUE_CAP, which
-# bounds only _run_vault_drift_detection's own pre-rotation loop — the two are
-# deliberately never merged (R5-2), so the true module-wide ceiling for one
-# rotation run is ISSUE_FILING_PER_RUN_CAP (advisory) + VAULT_DRIFT_ISSUE_CAP
-# (vault-drift) + ISSUE_FILING_PER_RUN_CAP (withheld) = 15 issues, plus at most
-# one operational-failure filing.
+# withheld-fix filing loop. A separate budget from the vault-drift cap defined
+# just above, which bounds only _run_vault_drift_detection's own pre-rotation
+# loop — the two are deliberately never merged (R5-2), so the true
+# module-wide ceiling for one rotation run is this cap (advisory) + the
+# vault-drift cap + this cap again (withheld) = 15 issues, plus at most one
+# operational-failure filing.
 ISSUE_FILING_PER_RUN_CAP = 5
 
 # Finding categories whose underlying condition can recur after a human closes

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -1510,32 +1510,156 @@ def _record_daily_pr(repo_root: Path) -> None:
         logger.warning(f"docs_auditor: daily PR cap record failed: {e}")
 
 
+def _current_ref(repo_root: Path) -> str | None:
+    """Return the ref the checkout is currently on, or None if it cannot be read."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=settings.timeouts.git_subprocess_s,
+            cwd=str(repo_root),
+        )
+        if result.returncode != 0:
+            return None
+        return (result.stdout or "").strip() or None
+    except Exception as e:
+        logger.warning(f"docs_auditor: current-ref read failed: {e}")
+        return None
+
+
+def _restore_checkout(
+    repo_root: Path, starting_ref: str, branch: str, files_touched: list[str]
+) -> bool:
+    """Return the checkout to ``starting_ref`` and discard only the auditor's own paths.
+
+    Scoped by construction: no ``checkout -f``, no ``reset --hard``, no ``clean``.
+    The auditor runs in the shared main checkout where other lanes routinely hold
+    uncommitted work, so a whole-tree force-restore would destroy it. Foreign dirt
+    *outside* ``files_touched`` is preserved by design.
+
+    ``git checkout HEAD -- <paths>`` is deliberate and the ``HEAD`` is load-bearing:
+    the bare ``git checkout -- <paths>`` restores the worktree from the **index**,
+    which on the staged-then-commit-failed path still holds the auditor's own
+    content. The ``HEAD`` form resets index *and* worktree for those paths only.
+
+    Returns True only when the postcondition holds: HEAD is back on
+    ``starting_ref`` **and** no ``files_touched`` path is dirty in either column of
+    ``git status --porcelain``.
+    """
+    ok = True
+    try:
+        checkout = subprocess.run(
+            ["git", "checkout", starting_ref],
+            capture_output=True,
+            text=True,
+            timeout=settings.timeouts.git_subprocess_s,
+            cwd=str(repo_root),
+        )
+        if checkout.returncode != 0:
+            ok = False
+            logger.error(
+                f"docs_auditor: restore failed to check out {starting_ref}: "
+                f"{(checkout.stderr or '').strip()}"
+            )
+
+        if files_touched:
+            discard = subprocess.run(
+                ["git", "checkout", "HEAD", "--", *files_touched],
+                capture_output=True,
+                text=True,
+                timeout=settings.timeouts.git_subprocess_s,
+                cwd=str(repo_root),
+            )
+            if discard.returncode != 0:
+                ok = False
+                logger.error(
+                    "docs_auditor: restore failed to discard auditor paths: "
+                    f"{(discard.stderr or '').strip()}"
+                )
+
+        # Delete the created branch if it exists.
+        exists = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"],
+            capture_output=True,
+            text=True,
+            timeout=settings.timeouts.git_subprocess_s,
+            cwd=str(repo_root),
+        )
+        if exists.returncode == 0:
+            subprocess.run(
+                ["git", "branch", "-D", branch],
+                capture_output=True,
+                text=True,
+                timeout=settings.timeouts.git_subprocess_s,
+                cwd=str(repo_root),
+            )
+
+        # Postcondition (a): back on the starting ref.
+        if _current_ref(repo_root) != starting_ref:
+            ok = False
+            logger.error(f"docs_auditor: restore left the checkout off {starting_ref}")
+
+        # Postcondition (b): no files_touched path dirty in either column. This is
+        # deliberately NOT `not _git_dirty(repo_root)` — foreign dirt outside
+        # files_touched is expected to survive.
+        if files_touched:
+            scoped = subprocess.run(
+                ["git", "status", "--porcelain", "--", *files_touched],
+                capture_output=True,
+                text=True,
+                timeout=settings.timeouts.git_subprocess_s,
+                cwd=str(repo_root),
+            )
+            if (scoped.stdout or "").strip():
+                ok = False
+                logger.error(
+                    "docs_auditor: restore left auditor paths dirty: "
+                    f"{(scoped.stdout or '').strip()}"
+                )
+    except Exception as e:
+        logger.error(f"docs_auditor: restore error: {e}")
+        return False
+    return ok
+
+
 def _push_branch_and_pr(
-    slug: str, repo_root: Path, withheld: list[dict] | None = None
+    slug: str, repo_root: Path, files_touched: list[str], withheld: list[dict] | None = None
 ) -> str | None:
     """Create timestamped branch, push, open PR. Returns PR URL or None on failure.
 
-    Always returns the repo to the main branch afterward, even on error.
-    Skips PR creation if an open PR for the same slug already exists or if
-    the daily cap (1 PR per calendar day) has been reached.
+    ``files_touched`` is the exact set of repo-relative paths the substrate wrote,
+    and it is the **only** thing staged: the commit is built from
+    ``git add -- <files_touched>``, never a whole-tree sweep. An empty list means
+    the auditor wrote nothing, so no branch is created and no commit is run.
+
+    On every exit path the checkout is returned to the ref it started on and the
+    auditor's own paths are discarded, scoped to ``files_touched`` — see
+    ``_restore_checkout``. A failed restore is reported: the function returns None
+    even if the PR was created, so the caller escalates rather than recording a
+    clean run over a wedged checkout.
+
+    The daily-cap and open-PR guards do **not** live here. They run in
+    ``run_docs_auditor``'s preflight, before the substrate writes anything, so a
+    guard can no longer fire after the shared checkout has already been dirtied.
 
     ``withheld`` is the run's existence-invariant rejections. When non-empty the
     PR body lists them and carries ``WITHHELD_PR_MARKER``, which disqualifies the
     PR from the sweeper's auto-merge path.
     """
+    if not files_touched:
+        logger.info("docs_auditor: no files touched, skipping branch/commit/PR")
+        return None
+
+    starting_ref = _current_ref(repo_root)
+    if starting_ref is None:
+        logger.error("docs_auditor: cannot read starting ref, refusing to branch")
+        return None
+
     ts = datetime.now(UTC).strftime("%Y%m%d-%H%M")
     branch = f"docs-audit/{slug}-{ts}"
+    url: str | None = None
     try:
-        # Guard: daily cap
-        if _daily_pr_cap_reached(repo_root):
-            logger.info("docs_auditor: daily PR cap reached, skipping PR creation")
-            return None
-
-        # Guard: open PR already exists for this slug
-        if _has_open_pr_for_slug(slug, repo_root):
-            logger.info(f"docs_auditor: open PR already exists for {slug}, skipping")
-            return None
-
         subprocess.run(
             ["git", "checkout", "-b", branch],
             capture_output=True,
@@ -1545,7 +1669,7 @@ def _push_branch_and_pr(
             check=True,
         )
         subprocess.run(
-            ["git", "add", "-A"],
+            ["git", "add", "--", *files_touched],
             capture_output=True,
             timeout=settings.timeouts.git_subprocess_s,
             cwd=str(repo_root),
@@ -1597,25 +1721,22 @@ def _push_branch_and_pr(
             cwd=str(repo_root),
             check=False,
         )
-        url = (pr_result.stdout or "").strip().splitlines()[-1] if pr_result.stdout else None
-        if url and url.startswith("http"):
+        candidate = (pr_result.stdout or "").strip().splitlines()[-1] if pr_result.stdout else None
+        if candidate and candidate.startswith("http"):
             _record_daily_pr(repo_root)
-            return url
-        return None
+            url = candidate
     except subprocess.CalledProcessError as e:
         logger.warning(f"docs_auditor: branch/push/PR failed: {e}")
-        return None
     except Exception as e:
         logger.warning(f"docs_auditor: branch/push/PR error: {e}")
-        return None
     finally:
-        # Always return to main so the next run starts from a clean base.
-        subprocess.run(
-            ["git", "checkout", "main"],
-            capture_output=True,
-            timeout=settings.timeouts.git_subprocess_s,
-            cwd=str(repo_root),
-        )
+        # Verified, scoped restore — runs on every exit path.
+        restored = _restore_checkout(repo_root, starting_ref, branch, files_touched)
+
+    if not restored:
+        logger.error("docs_auditor: shared checkout restore failed, reporting failure")
+        return None
+    return url
 
 
 def _write_liveness(
@@ -1876,7 +1997,7 @@ def run_docs_auditor() -> dict:
       1. Auth probe (cheap, no side effects)
       2. SETNX lock acquire (global)
       3. Dirty-tree guard
-      4. Rotation pick
+      4. Rotation pick, then the daily-cap and open-PR guards (pre-write)
       5. Run substrate
       6. Zero-diff gate
       7. (If diff) push branch + PR
@@ -1934,6 +2055,32 @@ def run_docs_auditor() -> dict:
 
         slug = _path_to_slug(primary)
 
+        # 4b. PR guards — hoisted here from _push_branch_and_pr so they fire
+        # strictly BEFORE the substrate writes to the shared main checkout. They
+        # sit after the dirty-tree guard, after _run_vault_drift_detection (which
+        # its own comment declares runs unconditionally), and after `slug` is
+        # computed, which _has_open_pr_for_slug needs. A fired guard performs no
+        # working-tree write and no git operation — but it MUST still stamp the
+        # rotation hash for the picked doc, exactly as the zero-diff path does.
+        # Without the stamp, _select_primary_doc re-picks the same
+        # least-recently-audited doc on every subsequent run for as long as the
+        # guard fires, and a withheld PR (which the sweeper never closes) would
+        # pin the rotation on one doc permanently while reporting "skipped".
+        guard_reason: str | None = None
+        if _daily_pr_cap_reached(PROJECT_ROOT):
+            guard_reason = "daily PR cap reached"
+        elif _has_open_pr_for_slug(slug, PROJECT_ROOT):
+            guard_reason = f"open PR already exists for {slug}"
+        if guard_reason is not None:
+            logger.info(f"docs_auditor: {guard_reason}, skipping before any write")
+            _update_rotation_hash(project_key, [str(primary)])
+            _write_liveness(slug, "skipped", None, 0, fixes_withheld=0)
+            return {
+                "status": "skipped",
+                "findings": [f"docs-auditor skipped: {guard_reason}"],
+                "summary": f"docs-auditor skipped ({slug}): {guard_reason}",
+            }
+
         # 5. Substrate
         result = audit(
             primary_path=primary,
@@ -1978,8 +2125,26 @@ def run_docs_auditor() -> dict:
             }
 
         # 7. Memory refresh hook (fire-and-forget) — fired after commit
-        # 8. Push branch + PR
-        pr_url = _push_branch_and_pr(slug, PROJECT_ROOT, withheld=withheld)
+        # 8. Push branch + PR. The guards moved to the preflight, so a None here
+        # unambiguously means the branch/commit/push/PR or the restore failed —
+        # never "a guard declined". That routes to status="error": no success
+        # Telegram, no rotation-hash stamp (the doc was written but not audited to
+        # completion, so re-picking it next run is correct), and no liveness "ok".
+        pr_url = _push_branch_and_pr(slug, PROJECT_ROOT, files_touched, withheld=withheld)
+
+        if pr_url is None:
+            findings.append(
+                f"docs-auditor: rotation wrote {len(files_touched)} file(s) for {slug} "
+                "but produced no PR"
+            )
+            return {
+                "status": "error",
+                "findings": findings,
+                "summary": (
+                    f"docs-auditor error ({slug}): {len(files_touched)} file(s) written, "
+                    f"no PR created{withheld_note}"
+                ),
+            }
 
         try:
             refresh_docs_in_memory(files_touched)
@@ -1996,7 +2161,7 @@ def run_docs_auditor() -> dict:
                 if fixes_withheld
                 else ""
             )
-            + (f"\nPR: {pr_url}" if pr_url else "")
+            + f"\nPR: {pr_url}"
         )
         _send_telegram_notification(msg)
 
@@ -2026,8 +2191,7 @@ def run_docs_auditor() -> dict:
             findings.extend(
                 f"withheld: {w.get('doc')} {w.get('old')!r} -> {w.get('new')!r}" for w in withheld
             )
-        if pr_url:
-            findings.append(f"PR: {pr_url}")
+        findings.append(f"PR: {pr_url}")
 
         return {
             "status": "ok",
@@ -2035,7 +2199,7 @@ def run_docs_auditor() -> dict:
             "summary": (
                 f"docs-auditor: {len(files_touched)} files touched, "
                 f"{result.get('fixes_applied', 0)} fixes{withheld_note}, "
-                f"PR={pr_url or 'none'}"
+                f"PR={pr_url}"
             ),
         }
 

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -2406,7 +2406,7 @@ def run_docs_auditor() -> dict:
                 term = re.sub(
                     r"\\(.)",
                     r"\1",
-                    w["old"].removeprefix(r"\b").removesuffix(r"\b"),
+                    w.get("old", "").removeprefix(r"\b").removesuffix(r"\b"),
                 )
                 _file_issue_if_new(
                     {
@@ -2448,6 +2448,11 @@ def run_docs_auditor() -> dict:
         # never "a guard declined". That routes to status="error": no success
         # Telegram, no rotation-hash stamp (the doc was written but not audited to
         # completion, so re-picking it next run is correct), and no liveness "ok".
+        # NOTE (#3050): `_restore_checkout` only runs inside this call's own
+        # `finally`. An exception raised between the substrate write above and
+        # this call leaves the shared checkout dirty with no restore; the next
+        # rotation's dirty-tree guard then skips silently. Left as-is pending a
+        # decision on widening the try/finally — see #3050.
         pr_url = _push_branch_and_pr(slug, PROJECT_ROOT, files_touched, withheld=withheld)
 
         if pr_url is None:
@@ -2729,6 +2734,10 @@ def run_docs_branch_sweeper() -> dict:
                 # it is made. Filing on sight would title a minutes-old PR as
                 # stale, and the dedup key is once-ever, so the wrong wording
                 # would be the permanent record.
+                # NOTE (#3049): the exemption never expires and the escalation
+                # above fires once-ever, so there is no re-nag and no ceiling on
+                # simultaneously-open withheld PRs. Left as-is pending an owner
+                # ruling on aging-out — see #3049.
                 if WITHHELD_PR_MARKER in (pr.get("body") or ""):
                     if age_days >= STALE_PR_AGE_DAYS:
                         _file_issue_if_new(

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -2723,19 +2723,26 @@ def run_docs_branch_sweeper() -> dict:
                 # The escalation issue is distinct from `_file_issue_if_new`'s
                 # per-defect withheld-fix titles, since a same-title filing is
                 # a guaranteed no-op — this names the PR, not the substitution.
+                # The exemption is unconditional; the *filing* waits for the
+                # same staleness threshold that would have closed a plain PR,
+                # so the title's "still unreviewed" claim is true at the moment
+                # it is made. Filing on sight would title a minutes-old PR as
+                # stale, and the dedup key is once-ever, so the wrong wording
+                # would be the permanent record.
                 if WITHHELD_PR_MARKER in (pr.get("body") or ""):
-                    _file_issue_if_new(
-                        {
-                            "title": f"docs-auditor: withheld PR #{pr_num} still unreviewed",
-                            "body": (
-                                f"PR #{pr_num} (branch `{branch}`) is {age_days} day(s) old "
-                                "and carries withheld fixes that need a human review before "
-                                "merge. The sweeper will not close it or delete its branch."
-                            ),
-                            "category": "withheld-pr",
-                        },
-                        PROJECT_ROOT,
-                    )
+                    if age_days >= STALE_PR_AGE_DAYS:
+                        _file_issue_if_new(
+                            {
+                                "title": f"docs-auditor: withheld PR #{pr_num} still unreviewed",
+                                "body": (
+                                    f"PR #{pr_num} (branch `{branch}`) is {age_days} day(s) old "
+                                    "and carries withheld fixes that need a human review before "
+                                    "merge. The sweeper will not close it or delete its branch."
+                                ),
+                                "category": "withheld-pr",
+                            },
+                            PROJECT_ROOT,
+                        )
                     continue
 
                 if age_days >= STALE_PR_AGE_DAYS:

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -864,7 +864,15 @@ _PLACEHOLDER_PATH_COMPONENTS = frozenset(
 # Heading-keyword stems whose presence means the doc is deliberately recording a
 # deletion. Stems, not exact inflections, so "## Dead SDK Path Deletion" and
 # "## Hook Cleanup" both match without listing every inflected form.
-_DELETION_HEADING_KEYWORDS = ("delet", "remov", "deprecat", "migrat", "cleanup", "obsolete", "retire")
+_DELETION_HEADING_KEYWORDS = (
+    "delet",
+    "remov",
+    "deprecat",
+    "migrat",
+    "cleanup",
+    "obsolete",
+    "retire",
+)
 
 # Word-anchored prose cues that a nearby line is documenting a deletion rather
 # than a live reference. Individual words/short phrases, not full sentences —
@@ -1003,7 +1011,11 @@ def _is_documented_deletion(
     """
     if line_idx < len(in_fence) and in_fence[line_idx]:
         return True
-    if live_claim_veto and line_idx < len(lines) and _LIVE_CLAIM_VETO_RE.search(lines[line_idx].lower()):
+    if (
+        live_claim_veto
+        and line_idx < len(lines)
+        and _LIVE_CLAIM_VETO_RE.search(lines[line_idx].lower())
+    ):
         return False
     if line_idx < len(heading_for_line):
         heading = heading_for_line[line_idx]
@@ -1136,7 +1148,9 @@ def _detect_deleted_target_issues(doc_path: Path, content: str, repo_root: Path)
             )
             continue
         line_idx = content.count("\n", 0, m.start())
-        if _is_documented_deletion(line_idx, lines, in_fence, heading_for_line, live_claim_veto=True):
+        if _is_documented_deletion(
+            line_idx, lines, in_fence, heading_for_line, live_claim_veto=True
+        ):
             logger.debug(
                 "docs_auditor: suppressed deleted-target finding for %s in %s "
                 "(fenced block or documented deletion)",
@@ -2460,7 +2474,8 @@ def run_docs_auditor() -> dict:
                         f"Files touched: {', '.join(files_touched)}\n\n"
                         "If the shared checkout is left dirty, clean it up with:\n\n"
                         "```\n"
-                        'git -C "${AI_REPO_ROOT:-$HOME/src/ai}" status --porcelain -- docs .claude\n'
+                        'git -C "${AI_REPO_ROOT:-$HOME/src/ai}" status --porcelain '
+                        "-- docs .claude\n"
                         "```\n\n"
                         "See the `docs_auditor: branch/push/PR …` warning in the reflection "
                         "log for the step that failed."
@@ -2738,8 +2753,7 @@ def run_docs_branch_sweeper() -> dict:
                         logger.warning(f"sweeper: gh pr close failed for #{pr_num}: {e}")
 
         summary = (
-            f"do-docs-branch-sweeper: {branches_deleted} branches deleted, "
-            f"{prs_closed} PRs closed"
+            f"do-docs-branch-sweeper: {branches_deleted} branches deleted, {prs_closed} PRs closed"
         )
         logger.info(summary)
         return {"status": "ok", "findings": findings, "summary": summary}

--- a/tests/README.md
+++ b/tests/README.md
@@ -287,7 +287,7 @@ tests/
 | Level | File | Tests | Description |
 |-------|------|------:|-------------|
 | unit | `test_docs_auditor_substrate.py` | 191 | Documentation reference validation |
-| unit | `test_docs_auditor_git_surface.py` | 14 | Docs-auditor real-git surface: staging, restore, sweeper close path |
+| unit | `test_docs_auditor_git_surface.py` | 15 | Docs-auditor real-git surface: staging, restore, sweeper close path |
 | unit | `test_hook_target.py` | 128 | Shared hook-payload target resolution and scope filtering (`hook_target.py`) |
 | unit | `test_validate_no_gos_justification.py` | 77 | No-Gos section justification validation |
 | unit | `test_validate_file_contains.py` | 49 | Required-content file validation, payload-targeted |

--- a/tests/README.md
+++ b/tests/README.md
@@ -286,7 +286,7 @@ tests/
 
 | Level | File | Tests | Description |
 |-------|------|------:|-------------|
-| unit | `test_docs_auditor_substrate.py` | 191 | Documentation reference validation |
+| unit | `test_docs_auditor_substrate.py` | 196 | Documentation reference validation |
 | unit | `test_docs_auditor_git_surface.py` | 15 | Docs-auditor real-git surface: staging, restore, sweeper close path |
 | unit | `test_hook_target.py` | 128 | Shared hook-payload target resolution and scope filtering (`hook_target.py`) |
 | unit | `test_validate_no_gos_justification.py` | 77 | No-Gos section justification validation |

--- a/tests/README.md
+++ b/tests/README.md
@@ -286,7 +286,8 @@ tests/
 
 | Level | File | Tests | Description |
 |-------|------|------:|-------------|
-| unit | `test_docs_auditor_substrate.py` | 130 | Documentation reference validation |
+| unit | `test_docs_auditor_substrate.py` | 191 | Documentation reference validation |
+| unit | `test_docs_auditor_git_surface.py` | 14 | Docs-auditor real-git surface: staging, restore, sweeper close path |
 | unit | `test_hook_target.py` | 128 | Shared hook-payload target resolution and scope filtering (`hook_target.py`) |
 | unit | `test_validate_no_gos_justification.py` | 77 | No-Gos section justification validation |
 | unit | `test_validate_file_contains.py` | 49 | Required-content file validation, payload-targeted |

--- a/tests/unit/reflections/test_docs_auditor_git_surface.py
+++ b/tests/unit/reflections/test_docs_auditor_git_surface.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -563,6 +564,39 @@ class TestSweeperClosePath:
         assert close_calls == []
         assert filed, "a withheld PR must file its own escalation issue"
         assert filed[0]["title"] == "docs-auditor: withheld PR #42 still unreviewed"
+
+    def test_fresh_withheld_pr_is_exempt_but_files_no_stale_claim_yet(
+        self, repo: Path, gh, monkeypatch, fake_redis
+    ):
+        """The exemption is immediate; the "still unreviewed" filing waits.
+
+        A withheld PR opened minutes ago must never be closed, but it must also
+        not yet be titled as stale: the dedup key is once-ever, so a filing made
+        on sight would make the wrong wording the permanent record.
+        """
+        self._push_docs_audit_branch(repo, "withheld-fresh-20260101-0000")
+        monkeypatch.setattr(docs_auditor, "PROJECT_ROOT", repo)
+        monkeypatch.setattr(docs_auditor, "_get_redis", lambda: fake_redis)
+        fresh = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        gh.pr_list_result = [
+            {
+                "number": 43,
+                "state": "OPEN",
+                "createdAt": fresh,
+                "body": f"pass\n\n{docs_auditor.WITHHELD_PR_MARKER}\nwithheld",
+            }
+        ]
+
+        filed: list[dict] = []
+        monkeypatch.setattr(
+            docs_auditor, "_file_issue_if_new", lambda f, r: (filed.append(f), True)[1]
+        )
+
+        docs_auditor.run_docs_branch_sweeper()
+
+        close_calls = [c for c in gh.calls if c[:3] == ["gh", "pr", "close"]]
+        assert close_calls == [], "a withheld PR is exempt from stale-close at any age"
+        assert filed == [], "no staleness claim before STALE_PR_AGE_DAYS"
 
     def test_non_marker_stale_pr_is_still_closed(self, repo: Path, gh, monkeypatch, fake_redis):
         self._push_docs_audit_branch(repo, "plain-20260101-0000")

--- a/tests/unit/reflections/test_docs_auditor_git_surface.py
+++ b/tests/unit/reflections/test_docs_auditor_git_surface.py
@@ -1,0 +1,594 @@
+"""Real-git test surface for reflections/docs_auditor.py (#2739).
+
+Blanket ``unittest.mock.patch`` over ``subprocess.run`` is explicitly not an
+acceptable strategy for ``_push_branch_and_pr``, the staging set, the restore
+path, or the sweeper's close path — every ``git`` command in those paths must
+actually run against a real repository on disk.
+
+The sanctioned pattern (no in-repo precedent existed for a synchronous
+dispatcher — ``tests/unit/reflections/test_merged_branch_cleanup.py`` patches
+``asyncio.create_subprocess_exec`` because its module is async, so it is not
+reusable here): ``monkeypatch.setattr(docs_auditor.subprocess, "run",
+dispatcher)``, module-scoped, where ``dispatcher`` intercepts only
+``cmd[0] == "gh"`` and returns a canned ``CompletedProcess``, delegating
+everything else to the real ``subprocess.run``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from reflections import docs_auditor
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    """A real git checkout with a real bare 'origin' remote.
+
+    A bare local remote lets ``git push -u origin <branch>`` inside
+    ``_push_branch_and_pr`` actually succeed, so the checkout/add/commit/push
+    sequence runs for real; only the ``gh`` calls are intercepted.
+    """
+    remote = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(remote)], check=True)
+
+    root = tmp_path / "repo"
+    root.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "Docs Auditor Git Surface Test"], cwd=root, check=True)
+    (root / "docs" / "features").mkdir(parents=True)
+    (root / "README.md").write_text("# Test\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=root, check=True)
+    subprocess.run(["git", "remote", "add", "origin", str(remote)], cwd=root, check=True)
+    subprocess.run(["git", "push", "-q", "-u", "origin", "main"], cwd=root, check=True)
+    return root
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _porcelain(cwd: Path, *paths: str) -> str:
+    return subprocess.run(
+        ["git", "status", "--porcelain", "--", *paths] if paths else ["git", "status", "--porcelain"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+class GhDispatcher:
+    """Records every ``gh`` invocation and returns a configurable canned response.
+
+    Delegates every non-``gh`` command to the real ``subprocess.run`` — never a
+    blanket mock over the git surface. Configure behavior per test via the
+    public attributes before installing the dispatcher.
+    """
+
+    def __init__(self) -> None:
+        # Captured before installation. `subprocess` is a singleton module, so
+        # `monkeypatch.setattr(docs_auditor.subprocess, "run", self)` patches
+        # the one and only `subprocess.run` everywhere it is imported —
+        # including inside this file's own module scope. Delegating through
+        # `subprocess.run` after that point would call this dispatcher again
+        # (infinite recursion); the real function must be captured first.
+        self._real_run = subprocess.run
+        self.calls: list[list[str]] = []
+        self.pr_create_url: str | None = "https://github.com/o/r/pull/1"
+        self.pr_create_returncode = 0
+        self.issue_list_result: list[dict] = []
+        self.issue_list_returncode = 0
+        self.issue_create_returncode = 0
+        self.pr_list_result: list[dict] = []
+        self.pr_close_returncode = 0
+        self.pr_merge_calls: list[list[str]] = []
+
+    def __call__(self, cmd, *args, **kwargs):
+        if not cmd or cmd[0] != "gh":
+            return self._real_run(cmd, *args, **kwargs)
+        self.calls.append(list(cmd))
+
+        if cmd[:3] == ["gh", "pr", "create"]:
+            if self.pr_create_url is None:
+                return MagicMock(returncode=1, stdout="", stderr="pr create failed")
+            return MagicMock(returncode=0, stdout=f"{self.pr_create_url}\n", stderr="")
+
+        if cmd[:3] == ["gh", "issue", "list"]:
+            return MagicMock(
+                returncode=self.issue_list_returncode,
+                stdout=json.dumps(self.issue_list_result),
+                stderr="",
+            )
+
+        if cmd[:3] == ["gh", "issue", "create"]:
+            return MagicMock(returncode=self.issue_create_returncode, stdout="", stderr="")
+
+        if cmd[:3] == ["gh", "pr", "list"]:
+            return MagicMock(returncode=0, stdout=json.dumps(self.pr_list_result), stderr="")
+
+        if cmd[:3] == ["gh", "pr", "close"]:
+            return MagicMock(returncode=self.pr_close_returncode, stdout="", stderr="")
+
+        if cmd[:3] == ["gh", "pr", "merge"]:
+            self.pr_merge_calls.append(list(cmd))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        # Default: succeed with empty output (e.g. `gh auth status`).
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+
+@pytest.fixture()
+def gh(monkeypatch) -> GhDispatcher:
+    dispatcher = GhDispatcher()
+    monkeypatch.setattr(docs_auditor.subprocess, "run", dispatcher)
+    return dispatcher
+
+
+@pytest.fixture()
+def fake_redis():
+    fake = MagicMock()
+    fake.set.return_value = True
+    fake.exists.return_value = 0
+    fake.hgetall.return_value = {}
+    fake.hset.return_value = 1
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# R5-1 — a failed rotation escalates through a real channel
+# ---------------------------------------------------------------------------
+
+
+class TestFailedRotationEscalates:
+    def test_files_one_issue_before_returning_status_error(self, repo: Path, gh, monkeypatch, fake_redis):
+        """``_push_branch_and_pr`` returning None must file an issue naming the
+        slug, category ``operational-failure``, before the ``status="error"``
+        return — a plain dict alone reaches nobody
+        (``agent/reflection_scheduler.py:639-640`` reads only ``projects``)."""
+        primary = repo / "docs" / "features" / "foo.md"
+        primary.write_text("# Foo\n\nThe SessionLog tracks state.\n" + "Padding line.\n" * 6)
+
+        filed: list[dict] = []
+
+        def fake_file_issue(finding, repo_root):
+            filed.append(finding)
+            return True
+
+        monkeypatch.setattr(docs_auditor, "PROJECT_ROOT", repo)
+        monkeypatch.setattr(docs_auditor, "_get_redis", lambda: fake_redis)
+        monkeypatch.setattr(docs_auditor, "_check_auth", lambda: (True, ""))
+        monkeypatch.setattr(docs_auditor, "_git_dirty", lambda root: False)
+        monkeypatch.setattr(docs_auditor, "_git_diff_quiet", lambda root: False)
+        monkeypatch.setattr(docs_auditor, "_run_vault_drift_detection", lambda pk: 0)
+        monkeypatch.setattr(docs_auditor, "_push_branch_and_pr", lambda *a, **kw: None)
+        monkeypatch.setattr(docs_auditor, "_send_telegram_notification", lambda msg: None)
+        monkeypatch.setattr(docs_auditor, "_file_issue_if_new", fake_file_issue)
+
+        result = docs_auditor.run_docs_auditor()
+
+        assert result["status"] == "error"
+        assert len(filed) == 1
+        finding = filed[0]
+        assert finding["title"] == "docs-auditor: rotation failed to produce a PR for docs_features_foo_md"
+        assert finding["category"] == "operational-failure"
+        # No volatile fields: no date, count, or run id.
+        assert "20" not in finding["title"]  # no year-like date fragment
+
+
+# ---------------------------------------------------------------------------
+# R5-3 — withheld titles carry the term, not the regex source
+# ---------------------------------------------------------------------------
+
+
+class TestWithheldTitleUnwrap:
+    def test_title_has_no_backslash(self, repo: Path, gh, monkeypatch, fake_redis):
+        primary = repo / "docs" / "features" / "foo.md"
+        primary.write_text("# Foo\n" + "Padding line.\n" * 6)
+
+        withheld_entry = {
+            "doc": "docs/features/foo.md",
+            "old": r"\breal\b",
+            "new": "realistic",
+            "reason": "target-absent",
+        }
+        audit_result = {
+            "status": "ok",
+            "files_touched": [],
+            "fixes_applied": 0,
+            "fixes_withheld": 1,
+            "withheld": [withheld_entry],
+            "issues_filed": 0,
+        }
+
+        filed: list[dict] = []
+
+        def fake_file_issue(finding, repo_root):
+            filed.append(finding)
+            return True
+
+        monkeypatch.setattr(docs_auditor, "PROJECT_ROOT", repo)
+        monkeypatch.setattr(docs_auditor, "_get_redis", lambda: fake_redis)
+        monkeypatch.setattr(docs_auditor, "_check_auth", lambda: (True, ""))
+        monkeypatch.setattr(docs_auditor, "_git_dirty", lambda root: False)
+        monkeypatch.setattr(docs_auditor, "_run_vault_drift_detection", lambda pk: 0)
+        monkeypatch.setattr(docs_auditor, "audit", lambda **kw: audit_result)
+        monkeypatch.setattr(docs_auditor, "_send_telegram_notification", lambda msg: None)
+        monkeypatch.setattr(docs_auditor, "_file_issue_if_new", fake_file_issue)
+
+        docs_auditor.run_docs_auditor()
+
+        assert len(filed) == 1
+        title = filed[0]["title"]
+        assert "(real -> realistic)" in title
+        assert "\\" not in title
+
+
+# ---------------------------------------------------------------------------
+# Early-return restore, per failure mode
+# ---------------------------------------------------------------------------
+
+
+class TestEarlyReturnRestore:
+    def _seed_touched_file(self, repo: Path) -> None:
+        (repo / "docs" / "features" / "x.md").write_text("# X\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-q", "-m", "seed touched file")
+        _git(repo, "push", "-q", "origin", "main")
+
+    def test_gh_pr_create_failure_restores_head_and_deletes_branch(self, repo: Path, gh):
+        self._seed_touched_file(repo)
+        starting_ref = _git(repo, "rev-parse", "--abbrev-ref", "HEAD").strip()
+        (repo / "docs" / "features" / "x.md").write_text("# X\n\nedited\n")
+
+        gh.pr_create_url = None  # force gh pr create to fail
+
+        url = docs_auditor._push_branch_and_pr(
+            "slug", repo, ["docs/features/x.md"]
+        )
+
+        assert url is None
+        assert _git(repo, "rev-parse", "--abbrev-ref", "HEAD").strip() == starting_ref
+        branches = _git(repo, "branch", "--list")
+        assert "docs-audit/" not in branches
+        assert _porcelain(repo, "docs/features/x.md") == ""
+
+    def test_git_add_missing_path_restores_cleanly(self, repo: Path, gh):
+        self._seed_touched_file(repo)
+        starting_ref = _git(repo, "rev-parse", "--abbrev-ref", "HEAD").strip()
+
+        # `files_touched` names a path that was never written — `git add --`
+        # fails outright (pathspec did not match).
+        url = docs_auditor._push_branch_and_pr(
+            "slug", repo, ["docs/features/does_not_exist_xyz.md"]
+        )
+
+        assert url is None
+        assert _git(repo, "rev-parse", "--abbrev-ref", "HEAD").strip() == starting_ref
+        branches = _git(repo, "branch", "--list")
+        assert "docs-audit/" not in branches
+
+    def test_push_to_unreachable_remote_restores_cleanly(self, repo: Path, gh):
+        self._seed_touched_file(repo)
+        starting_ref = _git(repo, "rev-parse", "--abbrev-ref", "HEAD").strip()
+        (repo / "docs" / "features" / "x.md").write_text("# X\n\nedited\n")
+        # Point origin at a nonexistent path so the real `git push` fails.
+        _git(repo, "remote", "set-url", "origin", "/nonexistent/path/origin.git")
+
+        url = docs_auditor._push_branch_and_pr(
+            "slug", repo, ["docs/features/x.md"]
+        )
+
+        assert url is None
+        assert _git(repo, "rev-parse", "--abbrev-ref", "HEAD").strip() == starting_ref
+        branches = _git(repo, "branch", "--list")
+        assert "docs-audit/" not in branches
+        assert _porcelain(repo, "docs/features/x.md") == ""
+
+
+# ---------------------------------------------------------------------------
+# Race 1 — foreign dirt outside files_touched survives a failed restore
+# ---------------------------------------------------------------------------
+
+
+class TestForeignDirtSurvives:
+    def test_unrelated_modified_file_is_untouched_by_the_restore(self, repo: Path, gh):
+        (repo / "docs" / "features" / "x.md").write_text("# X\n")
+        (repo / "docs" / "features" / "foreign.md").write_text("# Foreign\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-q", "-m", "seed")
+        _git(repo, "push", "-q", "origin", "main")
+
+        # The auditor never touches foreign.md; a peer lane holds it dirty.
+        (repo / "docs" / "features" / "foreign.md").write_text("# Foreign\n\nunrelated edit\n")
+        (repo / "docs" / "features" / "x.md").write_text("# X\n\nedited\n")
+
+        gh.pr_create_url = None  # force a failure so the restore path runs
+
+        docs_auditor._push_branch_and_pr("slug", repo, ["docs/features/x.md"])
+
+        # Foreign dirt outside files_touched survives, byte for byte.
+        assert (repo / "docs" / "features" / "foreign.md").read_text() == (
+            "# Foreign\n\nunrelated edit\n"
+        )
+        assert "docs/features/foreign.md" in _porcelain(repo)
+        # And it did not carry the auditor's own path into a reported error tree.
+        assert _porcelain(repo, "docs/features/x.md") == ""
+
+
+# ---------------------------------------------------------------------------
+# Failed-restore reporting
+# ---------------------------------------------------------------------------
+
+
+class TestFailedRestoreReporting:
+    def test_restore_checkout_failure_is_reported_and_run_returns_error(
+        self, repo: Path, gh, monkeypatch, fake_redis
+    ):
+        (repo / "docs" / "features" / "x.md").write_text("# X\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-q", "-m", "seed")
+        _git(repo, "push", "-q", "origin", "main")
+        (repo / "docs" / "features" / "x.md").write_text("# X\n\nedited\n")
+
+        gh.pr_create_url = None  # force the failure path
+
+        real_run = docs_auditor.subprocess.run
+
+        def failing_checkout(cmd, *a, **kw):
+            if cmd[:2] == ["git", "checkout"] and len(cmd) == 3 and cmd[2] == "main":
+                return MagicMock(returncode=1, stdout="", stderr="simulated checkout failure")
+            return real_run(cmd, *a, **kw)
+
+        monkeypatch.setattr(docs_auditor.subprocess, "run", failing_checkout)
+
+        url = docs_auditor._push_branch_and_pr("slug", repo, ["docs/features/x.md"])
+        assert url is None
+
+        # Drive the full reflection: the restore failure must route to "error".
+        # `audit()` is stubbed directly so the zero-diff gate never intercepts
+        # this — the point under test is the pr_url-is-None branch, not the
+        # substrate's own auto-fix detection.
+        audit_result = {
+            "status": "ok",
+            "files_touched": ["docs/features/x.md"],
+            "fixes_applied": 1,
+            "fixes_withheld": 0,
+            "withheld": [],
+            "issues_filed": 0,
+        }
+        monkeypatch.setattr(docs_auditor, "PROJECT_ROOT", repo)
+        monkeypatch.setattr(docs_auditor, "_get_redis", lambda: fake_redis)
+        monkeypatch.setattr(docs_auditor, "_check_auth", lambda: (True, ""))
+        monkeypatch.setattr(docs_auditor, "_git_dirty", lambda root: False)
+        monkeypatch.setattr(docs_auditor, "_git_diff_quiet", lambda root: False)
+        monkeypatch.setattr(docs_auditor, "_run_vault_drift_detection", lambda pk: 0)
+        monkeypatch.setattr(docs_auditor, "audit", lambda **kw: audit_result)
+        monkeypatch.setattr(docs_auditor, "_push_branch_and_pr", lambda *a, **kw: None)
+        monkeypatch.setattr(docs_auditor, "_send_telegram_notification", lambda msg: None)
+        monkeypatch.setattr(docs_auditor, "_file_issue_if_new", lambda finding, root: True)
+
+        result = docs_auditor.run_docs_auditor()
+        assert result["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# NEW-1 — a guard-fired run performs no working-tree write
+# ---------------------------------------------------------------------------
+
+
+class TestGuardFiredNoWorkingTreeWrite:
+    def test_daily_cap_guard_leaves_the_tree_byte_identical(self, repo: Path, gh, monkeypatch, fake_redis):
+        primary = repo / "docs" / "features" / "foo.md"
+        primary.write_text("# Foo\n" + "Padding line.\n" * 6)
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-q", "-m", "seed foo.md")
+
+        before = _porcelain(repo)
+
+        audit_mock_calls: list[int] = []
+
+        def fake_audit(**kw):
+            audit_mock_calls.append(1)
+            raise AssertionError("audit() must not be called when a guard fires")
+
+        monkeypatch.setattr(docs_auditor, "PROJECT_ROOT", repo)
+        monkeypatch.setattr(docs_auditor, "_get_redis", lambda: fake_redis)
+        monkeypatch.setattr(docs_auditor, "_check_auth", lambda: (True, ""))
+        monkeypatch.setattr(docs_auditor, "_git_dirty", lambda root: False)
+        monkeypatch.setattr(docs_auditor, "_run_vault_drift_detection", lambda pk: 0)
+        monkeypatch.setattr(docs_auditor, "_daily_pr_cap_reached", lambda root: True)
+        monkeypatch.setattr(docs_auditor, "_has_open_pr_for_slug", lambda slug, root: False)
+        monkeypatch.setattr(docs_auditor, "audit", fake_audit)
+        monkeypatch.setattr(docs_auditor, "_send_telegram_notification", lambda msg: None)
+
+        result = docs_auditor.run_docs_auditor()
+
+        assert result["status"] == "skipped"
+        assert not audit_mock_calls
+        assert _porcelain(repo) == before
+
+
+# ---------------------------------------------------------------------------
+# NEW-2 — the sweeper reads the WITHHELD_PR_MARKER from its own query
+# ---------------------------------------------------------------------------
+
+
+class TestSweeperReadsMarkerFromOwnQuery:
+    def test_pr_list_query_requests_body(self, repo: Path, gh, monkeypatch, fake_redis):
+        monkeypatch.setattr(docs_auditor, "PROJECT_ROOT", repo)
+        monkeypatch.setattr(docs_auditor, "_get_redis", lambda: fake_redis)
+        gh.pr_list_result = []
+
+        docs_auditor.run_docs_branch_sweeper()
+
+        pr_list_calls = [c for c in gh.calls if c[:3] == ["gh", "pr", "list"]]
+        # No docs-audit/* branches exist in this fresh repo, so no pr-list call
+        # is made at all — assert the built code requests `body` when it is
+        # made, which the marker test below exercises for real.
+        for c in pr_list_calls:
+            assert "number,state,createdAt,body" in c
+
+    def test_marker_check_fails_loudly_without_body_in_payload(self, repo: Path, gh, monkeypatch, fake_redis):
+        """A `pr list` payload without `body` must not be silently read as
+        unmarked and closed — that would pass the sweeper test vacuously."""
+        branch = "docs-audit/foo-20260101-0000"
+        _git(repo, "push", "-q", "origin", f"HEAD:refs/heads/{branch}")
+
+        monkeypatch.setattr(docs_auditor, "PROJECT_ROOT", repo)
+        monkeypatch.setattr(docs_auditor, "_get_redis", lambda: fake_redis)
+        gh.pr_list_result = [
+            {"number": 1, "state": "OPEN", "createdAt": "2020-01-01T00:00:00Z"}
+        ]  # no "body" key
+
+        result = docs_auditor.run_docs_branch_sweeper()
+
+        # With no `body` key, `.get("body")` degrades to None/"" — the marker
+        # is absent, so the PR is treated as unmarked (not exempted). This is
+        # documented behavior; the point of this test is the companion
+        # structural assertion that the query itself requests `body`.
+        pr_list_calls = [c for c in gh.calls if c[:3] == ["gh", "pr", "list"]]
+        assert pr_list_calls, "sweeper must query gh pr list for the seeded branch"
+        assert "number,state,createdAt,body" in pr_list_calls[0]
+        assert result["status"] in ("ok", "error")
+
+
+# ---------------------------------------------------------------------------
+# NEW-4 / R3-3 — withheld filing respects the per-run cap
+# ---------------------------------------------------------------------------
+
+
+class TestWithheldFilingCap:
+    def test_more_than_cap_withheld_entries_files_exactly_the_cap(
+        self, repo: Path, gh, monkeypatch, fake_redis, caplog
+    ):
+        primary = repo / "docs" / "features" / "foo.md"
+        primary.write_text("# Foo\n" + "Padding line.\n" * 6)
+
+        n = docs_auditor.ISSUE_FILING_PER_RUN_CAP + 3
+        withheld = [
+            {"doc": "docs/features/foo.md", "old": f"a/{i}.py", "new": f"b/{i}.py", "reason": "x"}
+            for i in range(n)
+        ]
+        audit_result = {
+            "status": "ok",
+            "files_touched": [],
+            "fixes_applied": 0,
+            "fixes_withheld": n,
+            "withheld": withheld,
+            "issues_filed": 0,
+        }
+
+        filed: list[dict] = []
+
+        def fake_file_issue(finding, repo_root):
+            filed.append(finding)
+            return True
+
+        monkeypatch.setattr(docs_auditor, "PROJECT_ROOT", repo)
+        monkeypatch.setattr(docs_auditor, "_get_redis", lambda: fake_redis)
+        monkeypatch.setattr(docs_auditor, "_check_auth", lambda: (True, ""))
+        monkeypatch.setattr(docs_auditor, "_git_dirty", lambda root: False)
+        monkeypatch.setattr(docs_auditor, "_run_vault_drift_detection", lambda pk: 0)
+        monkeypatch.setattr(docs_auditor, "audit", lambda **kw: audit_result)
+        monkeypatch.setattr(docs_auditor, "_send_telegram_notification", lambda msg: None)
+        monkeypatch.setattr(docs_auditor, "_file_issue_if_new", fake_file_issue)
+
+        with caplog.at_level("WARNING", logger="reflections.docs_auditor"):
+            result = docs_auditor.run_docs_auditor()
+
+        assert len(filed) == docs_auditor.ISSUE_FILING_PER_RUN_CAP
+        assert any(
+            "cap" in r.message.lower() and "suppress" in r.message.lower() for r in caplog.records
+        )
+        # Suppression alone does not affect the run's status.
+        assert result["status"] in ("skipped", "ok", "error")
+
+
+# ---------------------------------------------------------------------------
+# Sweeper close path — WITHHELD_PR_MARKER exemption, plain-PR close, anti-criterion
+# ---------------------------------------------------------------------------
+
+
+class TestSweeperClosePath:
+    def _push_docs_audit_branch(self, repo: Path, name: str) -> str:
+        branch = f"docs-audit/{name}"
+        _git(repo, "push", "-q", "origin", f"HEAD:refs/heads/{branch}")
+        return branch
+
+    def test_withheld_pr_is_not_closed_and_branch_is_not_deleted(
+        self, repo: Path, gh, monkeypatch, fake_redis
+    ):
+        branch = self._push_docs_audit_branch(repo, "withheld-20260101-0000")
+        monkeypatch.setattr(docs_auditor, "PROJECT_ROOT", repo)
+        monkeypatch.setattr(docs_auditor, "_get_redis", lambda: fake_redis)
+        gh.pr_list_result = [
+            {
+                "number": 42,
+                "state": "OPEN",
+                "createdAt": "2000-01-01T00:00:00Z",
+                "body": f"pass\n\n{docs_auditor.WITHHELD_PR_MARKER}\nwithheld",
+            }
+        ]
+
+        filed: list[dict] = []
+        monkeypatch.setattr(
+            docs_auditor, "_file_issue_if_new", lambda f, r: (filed.append(f), True)[1]
+        )
+
+        docs_auditor.run_docs_branch_sweeper()
+
+        close_calls = [c for c in gh.calls if c[:3] == ["gh", "pr", "close"]]
+        assert close_calls == []
+        assert filed, "a withheld PR must file its own escalation issue"
+        assert filed[0]["title"] == "docs-auditor: withheld PR #42 still unreviewed"
+
+    def test_non_marker_stale_pr_is_still_closed(self, repo: Path, gh, monkeypatch, fake_redis):
+        self._push_docs_audit_branch(repo, "plain-20260101-0000")
+        monkeypatch.setattr(docs_auditor, "PROJECT_ROOT", repo)
+        monkeypatch.setattr(docs_auditor, "_get_redis", lambda: fake_redis)
+        gh.pr_list_result = [
+            {
+                "number": 43,
+                "state": "OPEN",
+                "createdAt": "2000-01-01T00:00:00Z",
+                "body": "Automated docs auditor pass.",
+            }
+        ]
+
+        docs_auditor.run_docs_branch_sweeper()
+
+        close_calls = [c for c in gh.calls if c[:3] == ["gh", "pr", "close"]]
+        assert len(close_calls) == 1
+        assert "43" in close_calls[0]
+
+    def test_sweeper_never_dispatches_a_merge(self, repo: Path, gh, monkeypatch, fake_redis):
+        """Anti-criterion: no `gh pr merge` is ever dispatched, marker or not."""
+        self._push_docs_audit_branch(repo, "any-20260101-0000")
+        monkeypatch.setattr(docs_auditor, "PROJECT_ROOT", repo)
+        monkeypatch.setattr(docs_auditor, "_get_redis", lambda: fake_redis)
+        gh.pr_list_result = [
+            {
+                "number": 44,
+                "state": "OPEN",
+                "createdAt": "2000-01-01T00:00:00Z",
+                "body": "Automated docs auditor pass.",
+            }
+        ]
+
+        docs_auditor.run_docs_branch_sweeper()
+
+        assert gh.pr_merge_calls == []
+        assert not any(c[:3] == ["gh", "pr", "merge"] for c in gh.calls)

--- a/tests/unit/reflections/test_docs_auditor_git_surface.py
+++ b/tests/unit/reflections/test_docs_auditor_git_surface.py
@@ -45,7 +45,9 @@ def repo(tmp_path: Path) -> Path:
     root.mkdir()
     subprocess.run(["git", "init", "-q", "-b", "main"], cwd=root, check=True)
     subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=root, check=True)
-    subprocess.run(["git", "config", "user.name", "Docs Auditor Git Surface Test"], cwd=root, check=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Docs Auditor Git Surface Test"], cwd=root, check=True
+    )
     (root / "docs" / "features").mkdir(parents=True)
     (root / "README.md").write_text("# Test\n", encoding="utf-8")
     subprocess.run(["git", "add", "README.md"], cwd=root, check=True)
@@ -63,7 +65,9 @@ def _git(cwd: Path, *args: str) -> str:
 
 def _porcelain(cwd: Path, *paths: str) -> str:
     return subprocess.run(
-        ["git", "status", "--porcelain", "--", *paths] if paths else ["git", "status", "--porcelain"],
+        ["git", "status", "--porcelain", "--", *paths]
+        if paths
+        else ["git", "status", "--porcelain"],
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -153,7 +157,9 @@ def fake_redis():
 
 
 class TestFailedRotationEscalates:
-    def test_files_one_issue_before_returning_status_error(self, repo: Path, gh, monkeypatch, fake_redis):
+    def test_files_one_issue_before_returning_status_error(
+        self, repo: Path, gh, monkeypatch, fake_redis
+    ):
         """``_push_branch_and_pr`` returning None must file an issue naming the
         slug, category ``operational-failure``, before the ``status="error"``
         return — a plain dict alone reaches nobody
@@ -182,7 +188,10 @@ class TestFailedRotationEscalates:
         assert result["status"] == "error"
         assert len(filed) == 1
         finding = filed[0]
-        assert finding["title"] == "docs-auditor: rotation failed to produce a PR for docs_features_foo_md"
+        assert (
+            finding["title"]
+            == "docs-auditor: rotation failed to produce a PR for docs_features_foo_md"
+        )
         assert finding["category"] == "operational-failure"
         # No volatile fields: no date, count, or run id.
         assert "20" not in finding["title"]  # no year-like date fragment
@@ -255,9 +264,7 @@ class TestEarlyReturnRestore:
 
         gh.pr_create_url = None  # force gh pr create to fail
 
-        url = docs_auditor._push_branch_and_pr(
-            "slug", repo, ["docs/features/x.md"]
-        )
+        url = docs_auditor._push_branch_and_pr("slug", repo, ["docs/features/x.md"])
 
         assert url is None
         assert _git(repo, "rev-parse", "--abbrev-ref", "HEAD").strip() == starting_ref
@@ -287,9 +294,7 @@ class TestEarlyReturnRestore:
         # Point origin at a nonexistent path so the real `git push` fails.
         _git(repo, "remote", "set-url", "origin", "/nonexistent/path/origin.git")
 
-        url = docs_auditor._push_branch_and_pr(
-            "slug", repo, ["docs/features/x.md"]
-        )
+        url = docs_auditor._push_branch_and_pr("slug", repo, ["docs/features/x.md"])
 
         assert url is None
         assert _git(repo, "rev-parse", "--abbrev-ref", "HEAD").strip() == starting_ref
@@ -390,7 +395,9 @@ class TestFailedRestoreReporting:
 
 
 class TestGuardFiredNoWorkingTreeWrite:
-    def test_daily_cap_guard_leaves_the_tree_byte_identical(self, repo: Path, gh, monkeypatch, fake_redis):
+    def test_daily_cap_guard_leaves_the_tree_byte_identical(
+        self, repo: Path, gh, monkeypatch, fake_redis
+    ):
         primary = repo / "docs" / "features" / "foo.md"
         primary.write_text("# Foo\n" + "Padding line.\n" * 6)
         _git(repo, "add", "-A")
@@ -441,7 +448,9 @@ class TestSweeperReadsMarkerFromOwnQuery:
         for c in pr_list_calls:
             assert "number,state,createdAt,body" in c
 
-    def test_marker_check_fails_loudly_without_body_in_payload(self, repo: Path, gh, monkeypatch, fake_redis):
+    def test_marker_check_fails_loudly_without_body_in_payload(
+        self, repo: Path, gh, monkeypatch, fake_redis
+    ):
         """A `pr list` payload without `body` must not be silently read as
         unmarked and closed — that would pass the sweeper test vacuously."""
         branch = "docs-audit/foo-20260101-0000"
@@ -531,7 +540,7 @@ class TestSweeperClosePath:
     def test_withheld_pr_is_not_closed_and_branch_is_not_deleted(
         self, repo: Path, gh, monkeypatch, fake_redis
     ):
-        branch = self._push_docs_audit_branch(repo, "withheld-20260101-0000")
+        self._push_docs_audit_branch(repo, "withheld-20260101-0000")
         monkeypatch.setattr(docs_auditor, "PROJECT_ROOT", repo)
         monkeypatch.setattr(docs_auditor, "_get_redis", lambda: fake_redis)
         gh.pr_list_result = [

--- a/tests/unit/test_docs_auditor_substrate.py
+++ b/tests/unit/test_docs_auditor_substrate.py
@@ -236,7 +236,7 @@ class TestSetnxLock:
         fake_redis.set.return_value = None  # already locked
         with patch("reflections.docs_auditor.PROJECT_ROOT", repo):
             result = docs_auditor.run_docs_auditor()
-        assert result["status"] == "ok"
+        assert result["status"] == "skipped"
         assert "locked" in result["summary"].lower() or "locked" in str(result["findings"]).lower()
 
 
@@ -259,7 +259,9 @@ class TestZeroDiffGate:
         ):
             result = docs_auditor.run_docs_auditor()
 
-        assert result["status"] == "ok"
+        # "ok" survives on exactly one return in run_docs_auditor — the one that
+        # created a PR. A zero-diff pass produced no PR, so it is "skipped" (R7-2).
+        assert result["status"] == "skipped"
         # Push must NOT be called when zero-diff
         mock_push.assert_not_called()
 
@@ -546,6 +548,76 @@ class TestNonMarkdownApplyGuard:
         assert result["fixes_applied"] >= 1
         assert "docs/features/runtime.md" in result["files_touched"]
 
+    def test_live_claim_veto_does_not_reach_the_write_path(self, repo: Path, auth_ok, patch_redis):
+        """Q7b / R4-1 regression: the veto is keyword-only and off by default.
+
+        `_make_stale_term_replacer` never passes `live_claim_veto=True`, so a
+        `STALE_TERMS` hit on a line reading "X remains defined in Y" under a
+        `## Migration` heading must still land in `suppressed` and the file
+        must come back byte-identical. A build that evaluates the veto
+        unconditionally would rewrite this line — the auditor editing
+        narrative prose on the cascade path, which #2739 exists to gate.
+        """
+        md = repo / "docs" / "features" / "runtime.md"
+        content = (
+            "# Runtime\n\n"
+            "## Migration\n\n"
+            "The `session_log` field remains defined in `agent/x.py`.\n"
+            + "Padding line.\n" * 6
+        )
+        md.write_text(content)
+
+        with (
+            patch(
+                "reflections.docs_auditor._resolve_pr_changed_files",
+                return_value=[Path("docs/features/runtime.md")],
+            ),
+            patch.object(docs_auditor, "refresh_docs_in_memory"),
+        ):
+            result = docs_auditor.audit(
+                primary_path=None,
+                scope_mode="pr-changed-files",
+                apply_mode="apply",
+                project_key="test",
+                repo_root=repo,
+            )
+
+        assert md.read_text() == content
+        assert result["files_touched"] == []
+        assert result["fixes_applied"] == 0
+
+    def test_live_claim_veto_mirror_control_still_suppressed_on_plain_line(
+        self, repo: Path, auth_ok, patch_redis
+    ):
+        """The same stale term under the same heading, with no live-claim cue,
+        is still suppressed — pins that the heading tier alone (not the veto)
+        is what's doing the work in the case above."""
+        md = repo / "docs" / "features" / "runtime.md"
+        content = (
+            "# Runtime\n\n"
+            "## Migration\n\n"
+            "The `session_log` field is referenced here.\n" + "Padding line.\n" * 6
+        )
+        md.write_text(content)
+
+        with (
+            patch(
+                "reflections.docs_auditor._resolve_pr_changed_files",
+                return_value=[Path("docs/features/runtime.md")],
+            ),
+            patch.object(docs_auditor, "refresh_docs_in_memory"),
+        ):
+            result = docs_auditor.audit(
+                primary_path=None,
+                scope_mode="pr-changed-files",
+                apply_mode="apply",
+                project_key="test",
+                repo_root=repo,
+            )
+
+        assert md.read_text() == content
+        assert result["files_touched"] == []
+
 
 # ---------------------------------------------------------------------------
 # TestRotationKeyExplosion — single Redis hash, not per-file keys
@@ -608,7 +680,7 @@ class TestStaleTermDictionary:
         Every case here is a document that *correctly* records a completed
         rename. Rewriting any occurrence in it produces a sentence saying the
         new name was formerly itself — a false statement that ships with
-        ``fixes_withheld == 0`` and auto-merges unread.
+        ``fixes_withheld == 0`` and reaches a human review unflagged.
         """
         assert docs_auditor._detect_stale_term_fixes(content) == []
 
@@ -1193,33 +1265,17 @@ class TestExistenceInvariant:
 # ---------------------------------------------------------------------------
 
 
-class TestWithheldBlocksAutoMerge:
-    """A run that withheld a fix must not produce an auto-mergeable PR."""
+class TestWithheldBlocksStaleClose:
+    """A run that withheld a fix still requires a human merge, and the sweeper
+    must not close or delete the branch of a PR carrying the withheld marker.
 
-    @staticmethod
-    def _meta(body: str) -> dict:
-        return {
-            "files": [{"path": "docs/features/foo.md"}],
-            "reviews": [],
-            "reviewRequests": [],
-            "comments": [],
-            "additions": 1,
-            "deletions": 1,
-            "createdAt": (datetime.now(UTC) - timedelta(days=3)).isoformat().replace("+00:00", "Z"),
-            "body": body,
-        }
-
-    def _eligible(self, body: str) -> bool:
-        with patch("reflections.docs_auditor.subprocess.run") as run:
-            run.return_value = MagicMock(returncode=0, stdout=json.dumps(self._meta(body)))
-            return docs_auditor._pr_is_auto_merge_eligible(123)
-
-    def test_clean_pr_is_eligible(self):
-        assert self._eligible("Automated docs auditor pass.") is True
-
-    def test_withheld_marker_disqualifies(self):
-        body = f"Automated docs auditor pass.\n\n{docs_auditor.WITHHELD_PR_MARKER}\n1 withheld"
-        assert self._eligible(body) is False
+    Previously "TestWithheldBlocksAutoMerge" / auto-merge eligibility — Q2
+    deleted `_pr_is_auto_merge_eligible` outright, so this class's valid
+    subject is what survives: the withheld marker still reaches the PR body,
+    Telegram, and Redis liveness, and the sweeper's stale-close exemption
+    (covered in the real-git test file) is what replaces the old auto-merge
+    disqualification.
+    """
 
     def test_pr_body_carries_marker_when_fixes_withheld(self, repo):
         calls: list[list[str]] = []
@@ -1255,8 +1311,8 @@ class TestWithheldBlocksAutoMerge:
         """The new bare-name withhold class must reach every operator surface.
 
         Computing the withhold is not enough — #2759's whole value is that the
-        rotation PR becomes auto-merge-ineligible and a human hears about it.
-        The withheld record here is produced by a real ``audit()`` run, not
+        rotation PR carries the withheld marker and a human hears about it. The
+        withheld record here is produced by a real ``audit()`` run, not
         hand-written, so the first assertion is the one that fails on ``main``.
         """
         # Prose anchor, not a path token — see the #2744 note on the sibling
@@ -1310,8 +1366,6 @@ class TestWithheldBlocksAutoMerge:
         body = create[create.index("--body") + 1]
         assert docs_auditor.WITHHELD_PR_MARKER in body
         assert "ghost_module.py" in body
-        # ...and that marker is what makes the PR auto-merge-ineligible.
-        assert self._eligible(body) is False
 
         # Surfaces 2 and 3 — the Telegram notification and Redis liveness.
         with (
@@ -1319,13 +1373,21 @@ class TestWithheldBlocksAutoMerge:
             patch("reflections.docs_auditor._git_dirty", return_value=False),
             patch("reflections.docs_auditor._run_vault_drift_detection", return_value=0),
             patch("reflections.docs_auditor.audit", return_value=audit_result),
+            patch(
+                "reflections.docs_auditor._push_branch_and_pr",
+                return_value="https://github.com/o/r/pull/1",
+            ),
+            patch("reflections.docs_auditor._file_issue_if_new", return_value=False),
             patch("reflections.docs_auditor._send_telegram_notification") as notify,
             patch("reflections.docs_auditor._update_rotation_hash"),
             patch("reflections.docs_auditor._write_liveness") as liveness,
         ):
             result = docs_auditor.run_docs_auditor()
 
-        assert result["status"] == "ok"
+        # The one fix was entirely withheld, so files_touched is empty and the
+        # run hits the zero-diff gate — "skipped", not "ok" (R7-2); the mocked
+        # _push_branch_and_pr above is never reached on this path.
+        assert result["status"] == "skipped"
         assert "1 fix(es) withheld" in notify.call_args.args[0]
         assert liveness.call_args.kwargs["fixes_withheld"] == 1
 
@@ -1352,6 +1414,7 @@ class TestWithheldBlocksAutoMerge:
                 "reflections.docs_auditor._push_branch_and_pr",
                 return_value="https://github.com/o/r/pull/1",
             ) as push,
+            patch("reflections.docs_auditor._file_issue_if_new", return_value=False) as file_issue,
             patch("reflections.docs_auditor._send_telegram_notification") as notify,
             patch("reflections.docs_auditor._update_rotation_hash"),
             patch("reflections.docs_auditor._write_liveness"),
@@ -1365,6 +1428,8 @@ class TestWithheldBlocksAutoMerge:
         assert push.call_args.args[2] == audit_result["files_touched"]
         assert push.call_args.kwargs["withheld"] == audit_result["withheld"]
         assert "withheld" in notify.call_args.args[0]
+        # One issue filed per withheld entry (Q5 / B4).
+        assert file_issue.call_count == 2
 
     def test_all_withheld_zero_diff_run_still_notifies(self, repo, auth_ok, patch_redis):
         """Every fix rejected => no files touched => the step-9 notify is unreachable.
@@ -1389,19 +1454,24 @@ class TestWithheldBlocksAutoMerge:
             patch("reflections.docs_auditor._git_dirty", return_value=False),
             patch("reflections.docs_auditor._run_vault_drift_detection", return_value=0),
             patch("reflections.docs_auditor.audit", return_value=audit_result),
+            patch("reflections.docs_auditor._file_issue_if_new", return_value=False) as file_issue,
             patch("reflections.docs_auditor._send_telegram_notification") as notify,
             patch("reflections.docs_auditor._update_rotation_hash"),
             patch("reflections.docs_auditor._write_liveness") as liveness,
         ):
             result = docs_auditor.run_docs_auditor()
 
-        assert result["status"] == "ok"
+        # A zero-diff pass produced no PR, so "skipped" — "ok" survives only on
+        # the PR-created return (R7-2).
+        assert result["status"] == "skipped"
         assert "zero-diff" in result["summary"]
         assert notify.call_count == 1
         msg = notify.call_args.args[0]
         assert "2 fix(es) withheld" in msg
         assert "docs_features_foo_md" in msg  # the rotation slug
         assert liveness.call_args.kwargs["fixes_withheld"] == 2
+        # One issue filed per withheld entry (Q5 / B4), even on the no-PR path.
+        assert file_issue.call_count == 2
 
     def test_clean_zero_diff_run_does_not_notify(self, repo, auth_ok, patch_redis):
         """No withholding => a zero-diff pass stays silent, as before."""
@@ -1587,10 +1657,17 @@ class TestDirtyTreeGuard:
         with (
             patch("reflections.docs_auditor.PROJECT_ROOT", repo),
             patch("reflections.docs_auditor._git_dirty", return_value=True),
+            patch("reflections.docs_auditor._file_issue_if_new") as file_issue,
         ):
             result = docs_auditor.run_docs_auditor()
-        assert result["status"] == "ok"
+        # The guard now returns "skipped", matching the _write_liveness(...,
+        # "skipped", ...) call it sits beside (R5-1). It must stay quiet: the
+        # whole shared checkout is dirty here, which concurrent lanes routinely
+        # cause, so a filing guard would mint issues blaming the auditor for a
+        # peer's uncommitted work (Q4 item 5).
+        assert result["status"] == "skipped"
         assert "dirty" in result["summary"].lower()
+        file_issue.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -1620,6 +1697,33 @@ class TestPRCreationFailure:
         # preflight, so a None from _push_branch_and_pr after a write can only
         # mean failure — it routes to "error", never a silent "ok".
         assert result["status"] == "error"
+
+    def test_push_failure_escalates_via_operational_failure_issue(
+        self, repo, auth_ok, patch_redis
+    ):
+        """R5-1: status="error" alone reaches nobody — a real issue must be filed
+        before the function returns, or the wedge signal dies at the return."""
+        primary = repo / "docs" / "features" / "foo.md"
+        primary.write_text("# Foo\n\nThe SessionLog tracks state.\n" + "Padding line.\n" * 6)
+
+        with (
+            patch("reflections.docs_auditor.PROJECT_ROOT", repo),
+            patch("reflections.docs_auditor._git_dirty", return_value=False),
+            patch("reflections.docs_auditor._git_diff_quiet", return_value=False),
+            patch("reflections.docs_auditor._run_vault_drift_detection", return_value=0),
+            patch("reflections.docs_auditor._push_branch_and_pr", return_value=None),
+            patch("reflections.docs_auditor._send_telegram_notification"),
+            patch("reflections.docs_auditor._file_issue_if_new", return_value=False) as file_issue,
+        ):
+            result = docs_auditor.run_docs_auditor()
+
+        assert result["status"] == "error"
+        file_issue.assert_called_once()
+        finding = file_issue.call_args.args[0]
+        assert finding["title"] == "docs-auditor: rotation failed to produce a PR for docs_features_foo_md"
+        assert finding["category"] == "operational-failure"
+        # No volatile fields — no date, count, or run id in the title.
+        assert "docs-auditor: rotation failed to produce a PR for docs_features_foo_md" == finding["title"]
 
 
 # ---------------------------------------------------------------------------
@@ -1799,9 +1903,18 @@ class TestDeletedTargetFiltering:
         assert docs_auditor._is_placeholder_path("pkg/example.py") is True
         assert docs_auditor._is_placeholder_path("a/thing.py") is True  # single-letter dir
 
+    def test_is_placeholder_path_md_stand_ins(self):
+        """Q7a: the .md stem strip and the link-specific stand-in names."""
+        assert docs_auditor._is_placeholder_path("docs/foo.md") is True
+        assert docs_auditor._is_placeholder_path("docs/features/filename.md") is True
+        assert docs_auditor._is_placeholder_path("docs/features/path.md") is True
+        assert docs_auditor._is_placeholder_path("docs/features/name.md") is True
+        assert docs_auditor._is_placeholder_path("docs/features/foo/bar.md") is True
+
     def test_is_placeholder_path_real_paths(self):
         assert docs_auditor._is_placeholder_path("reflections/docs_auditor.py") is False
         assert docs_auditor._is_placeholder_path("agent/output_router.py") is False
+        assert docs_auditor._is_placeholder_path("docs/features/docs-auditor.md") is False
 
     def test_is_placeholder_path_empty_and_single_segment(self):
         assert docs_auditor._is_placeholder_path("") is False
@@ -1838,6 +1951,106 @@ class TestDeletedTargetFiltering:
             "The `some/removed_module.py` is no longer in the codebase as of the refactor.\n"
         )
         assert _mk_finding(content, repo) == []
+
+    # -- Q7b: each widening exercised on its own --------------------------
+
+    def test_heading_stem_dead_sdk_path_deletion(self, repo: Path):
+        """'## Dead SDK Path Deletion' — 'deleted' in 'deletion' was False pre-Q7b."""
+        content = "## Dead SDK Path Deletion\n\nRemoved `agent/gone_thing_xyz.py` wholesale.\n"
+        assert _mk_finding(content, repo) == []
+
+    def test_heading_stem_hook_cleanup(self, repo: Path):
+        """'## Hook Cleanup' — the heading tuple had no 'cleanup' entry pre-Q7b."""
+        content = "## Hook Cleanup (Phase 5)\n\ndeleted `agent/hooks/gone_thing_xyz.py` (250 lines)\n"
+        assert _mk_finding(content, repo) == []
+
+    def test_word_level_prose_cue_deleted_parenthetical(self, repo: Path):
+        """'deleted (250 lines)' — the old cue list wanted the exact phrase 'deleted module'."""
+        content = (
+            "## Architecture\n\n"
+            "`agent/gone_thing_xyz.py` deleted (250 lines) — no longer needed.\n"
+        )
+        assert _mk_finding(content, repo) == []
+
+    def test_prose_cue_window_widened_to_two_lines(self, repo: Path):
+        """The cue sits two lines above the match — the old window was +/-1."""
+        content = (
+            "## Architecture\n\n"
+            "This module was removed in the refactor.\n"
+            "See the historical note above.\n"
+            "`agent/gone_thing_xyz.py`\n"
+        )
+        assert _mk_finding(content, repo) == []
+
+    def test_word_anchoring_does_not_fire_on_a_substring(self, repo: Path):
+        """A line containing only 'removed_at' must NOT suppress — word-anchored, not substring."""
+        content = "## Architecture\n\nThe `removed_at` field is a timestamp.\n`agent/gone_thing_xyz.py` is live.\n"
+        findings = _mk_finding(content, repo)
+        assert len(findings) == 1
+
+    # -- Q7b: the live-claim veto ------------------------------------------
+
+    def test_live_claim_veto_reports_on_the_detector_path(self, repo: Path):
+        content = (
+            "## Migration\n\n`fail_stage()` remains defined in `agent/hooks/gone_thing_xyz.py`\n"
+        )
+        findings = _mk_finding(content, repo)
+        assert len(findings) == 1
+        assert "agent/hooks/gone_thing_xyz.py" in findings[0]["title"]
+
+    @pytest.mark.parametrize(
+        "cue", ["remains", "still", "defined in", "lives in", "currently", "implemented in"]
+    )
+    def test_live_claim_veto_words(self, repo: Path, cue: str):
+        content = f"## Migration\n\n`agent/hooks/gone_thing_xyz.py` {cue} the codebase today.\n"
+        findings = _mk_finding(content, repo)
+        assert len(findings) == 1
+
+    def test_live_claim_veto_is_opt_in_default_false(self):
+        content = "## Migration\n\n`x` remains defined in `y`\n"
+        lines = content.splitlines()
+        in_fence, heading_for_line = docs_auditor._build_line_context(content)
+        # Default (no veto): the heading suppresses.
+        assert docs_auditor._is_documented_deletion(2, lines, in_fence, heading_for_line) is True
+        # Opt-in veto: the live-claim cue cancels the suppression.
+        assert (
+            docs_auditor._is_documented_deletion(
+                2, lines, in_fence, heading_for_line, live_claim_veto=True
+            )
+            is False
+        )
+
+    def test_both_shapes_share_one_hatch(self, repo: Path):
+        """A .md link under a '## Removed' heading is suppressed via the same hatch."""
+        content = "## Removed\n\nSee [gone](./gone_thing_xyz.md) for the old approach.\n"
+        assert _mk_finding(content, repo) == []
+
+    # -- Q7b controls: the two real false positives go, the true positive stays --
+
+    def test_q7b_control_dead_sdk_path_deletion_suppressed(self, repo: Path):
+        content = (
+            "## Dead SDK Path Deletion\n\n"
+            "Removed wholesale, no legacy tolerance:\n\n"
+            "- `agent/sdk_client_xyz.py` and its dependents\n"
+        )
+        assert _mk_finding(content, repo) == []
+
+    def test_q7b_control_hook_cleanup_suppressed(self, repo: Path):
+        content = (
+            "## Hook Cleanup (Phase 5)\n\n"
+            "- **`agent/hooks/session_registry_xyz.py`** deleted (250 lines) — "
+            "UUID-to-bridge-session mapping no longer needed\n"
+        )
+        assert _mk_finding(content, repo) == []
+
+    def test_q7b_control_live_table_row_still_reported(self, repo: Path):
+        content = (
+            "| `SessionType.GRANITE` | `\"granite\"` | Direct invocations of the standalone "
+            "`valor-granite-loop` CLI (`tools/granite_thing_xyz/cli.py`) |\n"
+        )
+        findings = _mk_finding(content, repo)
+        assert len(findings) == 1
+        assert "tools/granite_thing_xyz/cli.py" in findings[0]["title"]
 
     def test_genuine_dead_reference_not_suppressed(self, repo: Path):
         # Normal prose, normal heading, inline code, path does not exist on disk.
@@ -1944,6 +2157,171 @@ class TestDeletedTargetFiltering:
 
 
 # ---------------------------------------------------------------------------
+# TestBrokenMdLinkDetection — Q7a (#2834): the .md markdown-link branch
+# ---------------------------------------------------------------------------
+
+
+class TestBrokenMdLinkDetection:
+    def test_broken_md_link_reports_a_finding(self, repo: Path):
+        content = "See [x](./gone_thing_xyz.md) for details.\n"
+        findings = docs_auditor._detect_deleted_target_issues(
+            Path("docs/features/a.md"), content, repo
+        )
+        assert len(findings) == 1
+        assert findings[0]["category"] == "broken-md-link"
+        assert "docs/features/gone_thing_xyz.md" in findings[0]["title"]
+
+    def test_doc_relative_frame_root_target_not_enough(self, repo: Path):
+        """The #2725 regression: a target existing at the repo root but not
+        doc-relative is still reported — doc-relative is the frame markdown
+        renderers actually use."""
+        (repo / "target_xyz.md").write_text("hi")
+        findings = docs_auditor._detect_deleted_target_issues(
+            Path("docs/features/a.md"), "[x](target_xyz.md)", repo
+        )
+        assert len(findings) == 1
+
+    def test_doc_relative_frame_doc_relative_target_present(self, repo: Path):
+        (repo / "docs" / "features").mkdir(parents=True, exist_ok=True)
+        (repo / "docs" / "features" / "target_xyz.md").write_text("hi")
+        findings = docs_auditor._detect_deleted_target_issues(
+            Path("docs/features/a.md"), "[x](target_xyz.md)", repo
+        )
+        assert findings == []
+
+    def test_dotdot_resolution(self, repo: Path):
+        (repo / "docs" / "guides").mkdir(parents=True, exist_ok=True)
+        (repo / "docs" / "guides" / "y_xyz.md").write_text("hi")
+        findings = docs_auditor._detect_deleted_target_issues(
+            Path("docs/features/a.md"), "[x](../guides/y_xyz.md)", repo
+        )
+        assert findings == []
+
+    def test_leading_slash_resolves_against_repo_root(self, repo: Path):
+        (repo / "docs" / "guides").mkdir(parents=True, exist_ok=True)
+        (repo / "docs" / "guides" / "y_xyz.md").write_text("hi")
+        findings = docs_auditor._detect_deleted_target_issues(
+            Path("docs/features/a.md"), "[x](/docs/guides/y_xyz.md)", repo
+        )
+        assert findings == []
+
+    def test_target_normalizing_outside_repo_root_produces_no_finding(self, repo: Path):
+        content = "[x](../../../../../../etc/passwd_xyz.md)\n"
+        findings = docs_auditor._detect_deleted_target_issues(
+            Path("docs/features/a.md"), content, repo
+        )
+        assert findings == []
+
+    def test_anchor_and_query_stripped_from_title(self, repo: Path):
+        findings = docs_auditor._detect_deleted_target_issues(
+            Path("docs/features/a.md"), "[x](./gone_thing_xyz.md#section)", repo
+        )
+        assert len(findings) == 1
+        assert "gone_thing_xyz.md#section" not in findings[0]["title"]
+        assert "gone_thing_xyz.md" in findings[0]["title"]
+
+    @pytest.mark.parametrize(
+        "target",
+        [
+            "http://example.com/gone_xyz.md",
+            "https://example.com/gone_xyz.md",
+            "mailto:someone@example.com",
+            "file:///etc/gone_xyz.md",
+            "#anchor-only",
+        ],
+    )
+    def test_uri_schemes_and_bare_anchors_skipped(self, repo: Path, target: str):
+        findings = docs_auditor._detect_deleted_target_issues(
+            Path("docs/features/a.md"), f"[x]({target})", repo
+        )
+        assert findings == []
+
+    def test_inline_code_span_skipped(self, repo: Path):
+        content = (
+            "`[Feature Name](gone_thing_xyz.md)`\n" "[Feature Name](gone_thing_xyz2.md)\n"
+        )
+        findings = docs_auditor._detect_deleted_target_issues(
+            Path("docs/features/a.md"), content, repo
+        )
+        assert len(findings) == 1
+        assert "gone_thing_xyz2.md" in findings[0]["title"]
+
+    @pytest.mark.parametrize(
+        "doc_path",
+        [
+            "docs/plans/completed/a.md",
+            "docs/plans/done/a.md",
+            ".claude/skills-global/x/SKILL_TEMPLATE.md",
+        ],
+    )
+    def test_scope_rule_excludes_completed_done_and_non_docs(self, repo: Path, doc_path: str):
+        findings = docs_auditor._detect_deleted_target_issues(
+            Path(doc_path), "[x](./gone_thing_xyz.md)", repo
+        )
+        assert findings == []
+
+    def test_scope_rule_includes_docs_features(self, repo: Path):
+        findings = docs_auditor._detect_deleted_target_issues(
+            Path("docs/features/a.md"), "[x](./gone_thing_xyz.md)", repo
+        )
+        assert len(findings) == 1
+
+    @pytest.mark.parametrize("target", ["filename.md", "foo/bar.md"])
+    def test_placeholder_targets_produce_no_finding(self, repo: Path, target: str):
+        findings = docs_auditor._detect_deleted_target_issues(
+            Path("docs/features/a.md"), f"[x]({target})", repo
+        )
+        assert findings == []
+
+    def test_no_repair_path_exists_for_md_links(self, repo: Path):
+        """Q7a reports only — it must never write to the doc."""
+        doc = repo / "docs" / "features" / "a.md"
+        doc.parent.mkdir(parents=True, exist_ok=True)
+        content = "See [x](./gone_thing_xyz.md) for details.\n"
+        doc.write_text(content)
+        docs_auditor._detect_deleted_target_issues(Path("docs/features/a.md"), content, repo)
+        assert doc.read_text() == content
+
+
+# ---------------------------------------------------------------------------
+# TestIssueFilingCapSharing — Q7 shares audit()'s advisory budget
+# ---------------------------------------------------------------------------
+
+
+class TestIssueFilingCapSharing:
+    def test_mixed_findings_file_at_most_the_shared_cap(self, repo: Path, auth_ok, patch_redis):
+        """A mix of deleted-target and broken-md-link findings shares one budget.
+
+        Q7 must not get its own per-run cap: ``ISSUE_FILING_PER_RUN_CAP`` bounds
+        the total across both finding categories from the advisory loop.
+        """
+        primary = repo / "docs" / "features" / "primary.md"
+        lines = ["# Primary\n"]
+        for i in range(4):
+            lines.append(f"See `agent/gone_py_{i:02d}.py` for details.\n")
+        for i in range(4):
+            lines.append(f"See [x](./gone_md_{i:02d}.md) for details.\n")
+        primary.write_text("".join(lines))
+
+        filed_titles: list[str] = []
+
+        def fake_file_issue(finding, repo_root):
+            filed_titles.append(finding["title"])
+            return True
+
+        with patch.object(docs_auditor, "_file_issue_if_new", side_effect=fake_file_issue):
+            docs_auditor.audit(
+                primary_path="docs/features/primary.md",
+                scope_mode="rotation",
+                apply_mode="apply",
+                project_key="test",
+                repo_root=repo,
+            )
+
+        assert len(filed_titles) <= docs_auditor.ISSUE_FILING_PER_RUN_CAP
+
+
+# ---------------------------------------------------------------------------
 # TestCrossMachineDedup — live-tracker gate + Redis fast-path
 # ---------------------------------------------------------------------------
 
@@ -1953,50 +2331,93 @@ def _gh_list_result(stdout: str, returncode: int = 0):
 
 
 class TestCrossMachineDedup:
-    def test_open_issue_exists_exact_match(self, repo: Path):
+    def test_issue_exists_no_longer_named_open(self):
+        """The old name is gone — no compatibility alias (Principle 1)."""
+        assert not hasattr(docs_auditor, "_open_issue_exists")
+        assert hasattr(docs_auditor, "_issue_exists")
+
+    def test_issue_exists_default_argv_is_all_states_limit_100_no_label(self, repo: Path):
+        title = "Doc references deleted target: a/b.py (in docs/x.md)"
+        with patch("subprocess.run", return_value=_gh_list_result("[]")) as run:
+            docs_auditor._issue_exists(title, repo)
+        cmd = run.call_args.args[0]
+        assert cmd[:3] == ["gh", "issue", "list"]
+        assert cmd[cmd.index("--state") + 1] == "all"
+        assert cmd[cmd.index("--limit") + 1] == "100"
+        assert "--label" not in cmd
+
+    def test_issue_exists_states_open_overrides_default(self, repo: Path):
+        with patch("subprocess.run", return_value=_gh_list_result("[]")) as run:
+            docs_auditor._issue_exists("t", repo, states="open")
+        cmd = run.call_args.args[0]
+        assert cmd[cmd.index("--state") + 1] == "open"
+
+    def test_issue_exists_matches_a_closed_issue(self, repo: Path):
+        """``states="all"`` means a closed issue is a match too — the once-ever
+        convergence semantics: a human who read a finding, ruled on it, and
+        closed it made a durable decision.
+        """
+        title = "Doc references deleted target: a/b.py (in docs/x.md)"
+        out = f'[{{"number": 5, "title": "{title}", "state": "CLOSED"}}]'
+        with patch("subprocess.run", return_value=_gh_list_result(out)):
+            assert docs_auditor._issue_exists(title, repo) is True
+
+    def test_issue_exists_exact_match(self, repo: Path):
         title = "Doc references deleted target: a/b.py (in docs/x.md)"
         out = f'[{{"number": 5, "title": "{title}"}}]'
         with patch("subprocess.run", return_value=_gh_list_result(out)):
-            assert docs_auditor._open_issue_exists(title, repo) is True
+            assert docs_auditor._issue_exists(title, repo) is True
 
-    def test_open_issue_exists_whitespace_normalized(self, repo: Path):
+    def test_issue_exists_whitespace_normalized(self, repo: Path):
         title = "Doc references deleted target: a/b.py (in docs/x.md)"
         # Tracker title has collapsed/extra whitespace — still an exact match.
         tracker_title = "Doc references deleted   target: a/b.py (in docs/x.md)"
         out = f'[{{"number": 5, "title": "{tracker_title}"}}]'
         with patch("subprocess.run", return_value=_gh_list_result(out)):
-            assert docs_auditor._open_issue_exists(title, repo) is True
+            assert docs_auditor._issue_exists(title, repo) is True
 
-    def test_open_issue_exists_no_match(self, repo: Path):
+    def test_issue_exists_no_match(self, repo: Path):
         title = "Doc references deleted target: a/b.py (in docs/x.md)"
         out = '[{"number": 5, "title": "Some unrelated issue"}]'
         with patch("subprocess.run", return_value=_gh_list_result(out)):
-            assert docs_auditor._open_issue_exists(title, repo) is False
+            assert docs_auditor._issue_exists(title, repo) is False
 
-    def test_open_issue_exists_empty_list(self, repo: Path):
+    def test_issue_exists_empty_list(self, repo: Path):
         with patch("subprocess.run", return_value=_gh_list_result("[]")):
-            assert docs_auditor._open_issue_exists("anything", repo) is False
+            assert docs_auditor._issue_exists("anything", repo) is False
 
-    def test_open_issue_exists_nonzero_rc_fails_open(self, repo: Path, caplog):
+    def test_issue_exists_nonzero_rc_fails_open(self, repo: Path, caplog):
         with patch("subprocess.run", return_value=_gh_list_result("", returncode=1)):
-            assert docs_auditor._open_issue_exists("t", repo) is False
+            assert docs_auditor._issue_exists("t", repo) is False
         assert any("dedup" in r.message.lower() for r in caplog.records)
 
-    def test_open_issue_exists_malformed_json_fails_open(self, repo: Path, caplog):
+    def test_issue_exists_malformed_json_fails_open(self, repo: Path, caplog):
         with patch("subprocess.run", return_value=_gh_list_result("not json{{")):
-            assert docs_auditor._open_issue_exists("t", repo) is False
+            assert docs_auditor._issue_exists("t", repo) is False
         assert any("dedup" in r.message.lower() for r in caplog.records)
 
-    def test_open_issue_exists_subprocess_raises_fails_open(self, repo: Path, caplog):
+    def test_issue_exists_subprocess_raises_fails_open(self, repo: Path, caplog):
         with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("gh", 20)):
-            assert docs_auditor._open_issue_exists("t", repo) is False
+            assert docs_auditor._issue_exists("t", repo) is False
         assert any("dedup" in r.message.lower() for r in caplog.records)
+
+    def test_a_closed_issue_without_the_documentation_label_still_suppresses(self, repo: Path):
+        """R5-4: the query side no longer filters on ``--label documentation``.
+
+        A relabelled-and-closed issue is invisible to a label-filtered gate;
+        the authoritative match is the exact title compare, which a label
+        change cannot defeat.
+        """
+        title = "Doc references deleted target: a/b.py (in docs/x.md)"
+        out = f'[{{"number": 5, "title": "{title}", "state": "CLOSED", "labels": []}}]'
+        with patch("subprocess.run", return_value=_gh_list_result(out)):
+            assert docs_auditor._issue_exists(title, repo) is True
 
     def test_open_match_skips_filing(self, repo: Path, patch_redis):
         patch_redis.exists.return_value = False
         finding = {"title": "Doc references deleted target: a/b.py (in docs/x.md)", "body": "b"}
         with (
-            patch.object(docs_auditor, "_open_issue_exists", return_value=True),
+            patch.object(docs_auditor, "_issue_exists", return_value=True),
             patch("subprocess.run") as run,
         ):
             filed = docs_auditor._file_issue_if_new(finding, repo)
@@ -2010,7 +2431,7 @@ class TestCrossMachineDedup:
         patch_redis.exists.return_value = False
         finding = {"title": "Doc references deleted target: a/b.py (in docs/x.md)", "body": "b"}
         with (
-            patch.object(docs_auditor, "_open_issue_exists", return_value=False),
+            patch.object(docs_auditor, "_issue_exists", return_value=False),
             patch("subprocess.run", return_value=_gh_list_result("https://gh/issues/9")) as run,
         ):
             filed = docs_auditor._file_issue_if_new(finding, repo)
@@ -2024,17 +2445,18 @@ class TestCrossMachineDedup:
         assert create_cmd[:3] == ["gh", "issue", "create"]
 
     def test_redis_fast_path_skips_tracker_query(self, repo: Path, patch_redis):
-        # If the local Redis key already exists, the tracker query is skipped.
+        # If the local Redis key already exists, the tracker query is skipped
+        # — for a once-ever (non-recurring-condition) finding.
         patch_redis.exists.return_value = True
         finding = {"title": "Doc references deleted target: a/b.py (in docs/x.md)", "body": "b"}
-        with patch.object(docs_auditor, "_open_issue_exists") as gate:
+        with patch.object(docs_auditor, "_issue_exists") as gate:
             filed = docs_auditor._file_issue_if_new(finding, repo)
         assert filed is False
         gate.assert_not_called()
 
     def test_tracker_failure_falls_back_to_filing(self, repo: Path, patch_redis, caplog):
-        # Simulate gh issue list failing inside _open_issue_exists (fail-open ->
-        # _open_issue_exists returns False) so filing proceeds via gh create.
+        # Simulate gh issue list failing inside _issue_exists (fail-open ->
+        # _issue_exists returns False) so filing proceeds via gh create.
         patch_redis.exists.return_value = False
         finding = {"title": "Doc references deleted target: a/b.py (in docs/x.md)", "body": "b"}
 
@@ -2051,6 +2473,86 @@ class TestCrossMachineDedup:
 
     def test_empty_title_returns_false(self, repo: Path, patch_redis):
         assert docs_auditor._file_issue_if_new({"title": "", "body": "b"}, repo) is False
+
+    # -- Q7c: recurring-condition categories keep the open-only gate ---------
+
+    @pytest.mark.parametrize("category", ["vault-drift", "operational-failure"])
+    def test_recurring_condition_categories_query_state_open(
+        self, repo: Path, patch_redis, category
+    ):
+        patch_redis.exists.return_value = False
+        finding = {"title": "t", "body": "b", "category": category}
+        with patch("subprocess.run", return_value=_gh_list_result("[]")) as run:
+            docs_auditor._file_issue_if_new(finding, repo)
+        list_call = next(c for c in run.call_args_list if c.args[0][:3] == ["gh", "issue", "list"])
+        cmd = list_call.args[0]
+        assert cmd[cmd.index("--state") + 1] == "open"
+
+    @pytest.mark.parametrize("category", ["deleted-target", "broken-md-link", None])
+    def test_reference_categories_query_state_all(self, repo: Path, patch_redis, category):
+        patch_redis.exists.return_value = False
+        finding = {"title": "t", "body": "b"}
+        if category is not None:
+            finding["category"] = category
+        with patch("subprocess.run", return_value=_gh_list_result("[]")) as run:
+            docs_auditor._file_issue_if_new(finding, repo)
+        list_call = next(c for c in run.call_args_list if c.args[0][:3] == ["gh", "issue", "list"])
+        cmd = list_call.args[0]
+        assert cmd[cmd.index("--state") + 1] == "all"
+
+    def test_closed_drift_issue_does_not_suppress_a_fresh_filing(self, repo: Path, patch_redis):
+        """A closed vault-drift issue is one reconciliation, not a standing ruling.
+
+        The Redis fast-path is seeded as if this machine already filed it —
+        the ordinary first-filing path writes the key unconditionally — and a
+        second filing for the same recurring condition must still reach
+        ``gh issue create``, because the read is gated off for this category.
+        """
+        patch_redis.exists.return_value = True  # would short-circuit a non-recurring finding
+        finding = {"title": "docs-auditor: vault narrative drift", "body": "b", "category": "vault-drift"}
+        out = f'[{{"number": 5, "title": "{finding["title"]}", "state": "CLOSED"}}]'
+
+        def fake_run(cmd, *a, **k):
+            if cmd[:3] == ["gh", "issue", "list"]:
+                # Simulate gh's own server-side --state filtering: a closed
+                # issue is returned only when the query asked for closed/all
+                # states, never when it asked for --state open.
+                state_idx = cmd.index("--state")
+                if cmd[state_idx + 1] == "open":
+                    return _gh_list_result("[]")
+                return _gh_list_result(out)
+            return _gh_list_result("https://gh/issues/9")
+
+        with patch("subprocess.run", side_effect=fake_run) as run:
+            filed = docs_auditor._file_issue_if_new(finding, repo)
+
+        assert filed is True
+        create_calls = [c for c in run.call_args_list if c.args[0][:3] == ["gh", "issue", "create"]]
+        assert len(create_calls) == 1
+
+    def test_closed_reference_issue_still_suppresses_with_key_set(self, repo: Path, patch_redis):
+        """Mirror of the above: a once-ever category stays gated by the fast-path."""
+        patch_redis.exists.return_value = True
+        finding = {"title": "Doc references missing link target: a.md (in b.md)", "body": "b"}
+        with patch("subprocess.run") as run:
+            filed = docs_auditor._file_issue_if_new(finding, repo)
+        assert filed is False
+        assert run.call_count == 0
+
+    def test_dedup_key_writes_stay_unconditional_for_recurring_categories(
+        self, repo: Path, patch_redis
+    ):
+        """R8-1: the two ``set()`` writes are never gated, only the ``exists`` read.
+
+        A key written but never read suppresses nothing for the category it was
+        written for, so leaving the writes unconditional costs nothing and keeps
+        the key available as a fail-open cap if ``gh`` starts erroring.
+        """
+        patch_redis.exists.return_value = False
+        finding = {"title": "t", "body": "b", "category": "operational-failure"}
+        with patch("subprocess.run", return_value=_gh_list_result("https://gh/issues/9")):
+            docs_auditor._file_issue_if_new(finding, repo)
+        patch_redis.set.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_docs_auditor_substrate.py
+++ b/tests/unit/test_docs_auditor_substrate.py
@@ -1259,7 +1259,7 @@ class TestExistenceInvariant:
 
 
 # ---------------------------------------------------------------------------
-# TestWithheldBlocksAutoMerge — the rotation path's only review gate
+# TestWithheldBlocksStaleClose — the rotation path's only review gate
 # ---------------------------------------------------------------------------
 
 
@@ -1267,12 +1267,9 @@ class TestWithheldBlocksStaleClose:
     """A run that withheld a fix still requires a human merge, and the sweeper
     must not close or delete the branch of a PR carrying the withheld marker.
 
-    Previously "TestWithheldBlocksAutoMerge" / auto-merge eligibility — Q2
-    deleted `_pr_is_auto_merge_eligible` outright, so this class's valid
-    subject is what survives: the withheld marker still reaches the PR body,
-    Telegram, and Redis liveness, and the sweeper's stale-close exemption
-    (covered in the real-git test file) is what replaces the old auto-merge
-    disqualification.
+    The withheld marker reaches the PR body, Telegram, and Redis liveness, and
+    the sweeper exempts a withheld-marker PR from stale-close (covered in the
+    real-git test file).
     """
 
     def test_pr_body_carries_marker_when_fixes_withheld(self, repo):
@@ -2051,8 +2048,8 @@ class TestDeletedTargetFiltering:
 
     def test_q7b_control_live_table_row_still_reported(self, repo: Path):
         content = (
-            '| `SessionType.GRANITE` | `"granite"` | Direct invocations of the standalone '
-            "`valor-granite-loop` CLI (`tools/granite_thing_xyz/cli.py`) |\n"
+            '| `SessionType.LEGACY_XYZ` | `"legacy_xyz"` | Direct invocations of the standalone '
+            "`valor-legacy-xyz-loop` CLI (`tools/granite_thing_xyz/cli.py`) |\n"
         )
         findings = _mk_finding(content, repo)
         assert len(findings) == 1

--- a/tests/unit/test_docs_auditor_substrate.py
+++ b/tests/unit/test_docs_auditor_substrate.py
@@ -35,17 +35,34 @@ def repo(tmp_path: Path) -> Path:
     return tmp_path
 
 
+def _git(cwd: Path, *args: str) -> str:
+    """Run a real git command in ``cwd`` and return stdout."""
+    return subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _porcelain(cwd: Path) -> str:
+    """``git status --porcelain`` output, stripped."""
+    return _git(cwd, "status", "--porcelain").strip()
+
+
 @pytest.fixture()
 def git_repo(repo: Path) -> Path:
-    """A ``repo`` that is also a real git checkout.
+    """A ``repo`` that is also a real git checkout, able to commit.
 
     The bare-name existence oracle (#2759) resolves a filename with no ``/``
     against a ``git ls-files --cached --others --exclude-standard`` basename
     index. That index only exists inside a git checkout, so ambiguity and
     index-backed resolution have to be exercised here rather than on the plain
     ``tmp_path`` ``repo`` fixture.
+
+    Identity is set locally so tests asserting on commit state can create a
+    baseline commit without depending on the machine's global git config.
     """
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Docs Auditor Test")
     return repo
 
 
@@ -388,12 +405,18 @@ class TestDoDocsContract:
         # Substrate must not push branches in any scope mode
         mock_push.assert_not_called()
 
-    def test_hook_invocation_under_pr_mode(self, repo: Path, auth_ok, patch_redis):
-        # In pr-changed-files mode the substrate fires the memory refresh hook
-        # itself, so the /do-docs skill is a true thin caller (no skill-level
-        # work needed per Task 4 acceptance criteria).
-        primary = repo / "docs" / "features" / "foo.md"
+    def test_hook_fires_and_nothing_is_committed_under_pr_mode(
+        self, git_repo: Path, auth_ok, patch_redis
+    ):
+        # In pr-changed-files mode the substrate fires the memory refresh hook on
+        # the *applied* set and commits nothing: the /do-docs skill owns the
+        # commit, because the diff has to pass a review gate before it becomes a
+        # permanent record. The applied fix must therefore still be dirty on exit.
+        primary = git_repo / "docs" / "features" / "foo.md"
         primary.write_text("# Foo\n\nThe SessionLog tracks state.\n" + "Padding line.\n" * 6)
+        _git(git_repo, "add", "-A")
+        _git(git_repo, "commit", "-q", "-m", "baseline")
+        assert _porcelain(git_repo) == ""
 
         with (
             patch(
@@ -401,7 +424,6 @@ class TestDoDocsContract:
                 return_value=[Path("docs/features/foo.md")],
             ),
             patch.object(docs_auditor, "_file_issue_if_new", return_value=False),
-            patch.object(docs_auditor, "_commit_current_branch") as mock_commit,
             patch.object(docs_auditor, "refresh_docs_in_memory") as mock_hook,
         ):
             result = docs_auditor.audit(
@@ -409,12 +431,15 @@ class TestDoDocsContract:
                 scope_mode="pr-changed-files",
                 apply_mode="apply",
                 project_key="test",
-                repo_root=repo,
+                repo_root=git_repo,
             )
 
         assert "docs/features/foo.md" in result["files_touched"]
-        mock_commit.assert_called_once()
         mock_hook.assert_called_once_with(["docs/features/foo.md"])
+        # The write landed and stayed uncommitted, for the skill to review.
+        assert "AgentSession" in primary.read_text()
+        assert "docs/features/foo.md" in _porcelain(git_repo)
+        assert _git(git_repo, "rev-list", "--count", "HEAD").strip() == "1"
 
     def test_rotation_mode_does_not_fire_hook_inside_audit(self, repo: Path, auth_ok, patch_redis):
         # In rotation mode, the hook is fired by run_docs_auditor (Caller A),
@@ -475,7 +500,6 @@ class TestNonMarkdownApplyGuard:
                 "reflections.docs_auditor._resolve_pr_changed_files",
                 return_value=[Path("site/runtime.html")],
             ),
-            patch.object(docs_auditor, "_commit_current_branch") as mock_commit,
             patch.object(docs_auditor, "refresh_docs_in_memory") as mock_hook,
         ):
             result = docs_auditor.audit(
@@ -491,8 +515,7 @@ class TestNonMarkdownApplyGuard:
         assert result["status"] == "ok"
         assert result["files_touched"] == []
         assert result["fixes_applied"] == 0
-        # No commit / memory refresh fires when nothing was touched.
-        mock_commit.assert_not_called()
+        # No memory refresh fires when nothing was touched.
         mock_hook.assert_not_called()
 
     def test_markdown_sibling_still_rewritten(self, repo: Path, auth_ok, patch_redis):
@@ -505,7 +528,6 @@ class TestNonMarkdownApplyGuard:
                 "reflections.docs_auditor._resolve_pr_changed_files",
                 return_value=[Path("docs/features/runtime.md")],
             ),
-            patch.object(docs_auditor, "_commit_current_branch"),
             patch.object(docs_auditor, "refresh_docs_in_memory"),
         ):
             result = docs_auditor.audit(
@@ -1146,7 +1168,6 @@ class TestExistenceInvariant:
                 "_resolve_pr_changed_files",
                 return_value=[Path("docs/features/aud.md")],
             ),
-            patch.object(docs_auditor, "_commit_current_branch") as commit,
         ):
             result = docs_auditor.audit(
                 primary_path=None,
@@ -1160,7 +1181,6 @@ class TestExistenceInvariant:
         assert result["fixes_withheld"] == 1
         assert result["withheld"][0]["new"] == "ghost_module.py"
         assert result["files_touched"] == []
-        commit.assert_not_called()
         assert "ghost_module.py" not in p.read_text()
 
 
@@ -1251,7 +1271,6 @@ class TestWithheldBlocksAutoMerge:
                 "_resolve_pr_changed_files",
                 return_value=[Path("docs/features/foo.md")],
             ),
-            patch.object(docs_auditor, "_commit_current_branch"),
         ):
             audit_result = docs_auditor.audit(
                 primary_path=None,

--- a/tests/unit/test_docs_auditor_substrate.py
+++ b/tests/unit/test_docs_auditor_substrate.py
@@ -1501,9 +1501,10 @@ class TestWithheldRateNonRegression:
     """Widening ``_PATH_REF_RE`` adds no withholds on the real corpus (#2759 AC4).
 
     This is the mechanical proof behind the plan's ruling that #2759 does **not**
-    block on #2729 (withheld PRs are auto-merge-ineligible forever and stale-close
-    at day 14). Two measurement paths report a reassuring zero regardless of the
-    change's real effect and are therefore not used:
+    block on #2729 (a withheld-fix PR carries ``WITHHELD_PR_MARKER`` and is
+    exempt from the sweeper's stale-close; there is no auto-merge concept).
+    Two measurement paths report a reassuring zero regardless of the change's
+    real effect and are therefore not used:
 
     1. ``_detect_stale_term_fixes`` alone never reaches ``_absent_new_path_refs``;
        ``fixes_withheld`` is populated only by ``_apply_fixes_to_file``.

--- a/tests/unit/test_docs_auditor_substrate.py
+++ b/tests/unit/test_docs_auditor_substrate.py
@@ -74,6 +74,10 @@ def fake_redis():
     fake.delete.return_value = 1
     fake.hgetall.return_value = {}
     fake.hset.return_value = 1
+    # A blank fake holds no keys. Without this, MagicMock's truthy default makes
+    # _daily_pr_cap_reached() report a cap on every run, which now short-circuits
+    # run_docs_auditor at the hoisted preflight guard.
+    fake.exists.return_value = 0
     return fake
 
 
@@ -1234,11 +1238,11 @@ class TestWithheldBlocksAutoMerge:
         ]
         with (
             patch("reflections.docs_auditor.subprocess.run", side_effect=fake_run),
-            patch("reflections.docs_auditor._daily_pr_cap_reached", return_value=False),
-            patch("reflections.docs_auditor._has_open_pr_for_slug", return_value=False),
             patch("reflections.docs_auditor._record_daily_pr"),
         ):
-            docs_auditor._push_branch_and_pr("slug", repo, withheld=withheld)
+            docs_auditor._push_branch_and_pr(
+                "slug", repo, ["docs/features/x.md"], withheld=withheld
+            )
 
         create = next(c for c in calls if c[:3] == ["gh", "pr", "create"])
         body = create[create.index("--body") + 1]
@@ -1293,11 +1297,14 @@ class TestWithheldBlocksAutoMerge:
 
         with (
             patch("reflections.docs_auditor.subprocess.run", side_effect=fake_run),
-            patch("reflections.docs_auditor._daily_pr_cap_reached", return_value=False),
-            patch("reflections.docs_auditor._has_open_pr_for_slug", return_value=False),
             patch("reflections.docs_auditor._record_daily_pr"),
         ):
-            docs_auditor._push_branch_and_pr("slug", repo, withheld=audit_result["withheld"])
+            docs_auditor._push_branch_and_pr(
+                "slug",
+                repo,
+                ["docs/features/foo.md"],
+                withheld=audit_result["withheld"],
+            )
 
         create = next(c for c in calls if c[:3] == ["gh", "pr", "create"])
         body = create[create.index("--body") + 1]
@@ -1341,7 +1348,10 @@ class TestWithheldBlocksAutoMerge:
             patch("reflections.docs_auditor._git_diff_quiet", return_value=False),
             patch("reflections.docs_auditor._run_vault_drift_detection", return_value=0),
             patch("reflections.docs_auditor.audit", return_value=audit_result),
-            patch("reflections.docs_auditor._push_branch_and_pr", return_value=None) as push,
+            patch(
+                "reflections.docs_auditor._push_branch_and_pr",
+                return_value="https://github.com/o/r/pull/1",
+            ) as push,
             patch("reflections.docs_auditor._send_telegram_notification") as notify,
             patch("reflections.docs_auditor._update_rotation_hash"),
             patch("reflections.docs_auditor._write_liveness"),
@@ -1351,6 +1361,8 @@ class TestWithheldBlocksAutoMerge:
         assert result["status"] == "ok"
         assert any("2 fix(es) withheld" in f for f in result["findings"])
         assert "withheld" in result["summary"]
+        # The staging set is passed explicitly — never a whole-tree `git add -A`.
+        assert push.call_args.args[2] == audit_result["files_touched"]
         assert push.call_args.kwargs["withheld"] == audit_result["withheld"]
         assert "withheld" in notify.call_args.args[0]
 
@@ -1604,8 +1616,157 @@ class TestPRCreationFailure:
         ):
             result = docs_auditor.run_docs_auditor()
 
-        # Failure to create PR should not raise
-        assert result["status"] in ("ok", "error")
+        # Failure to create PR must not raise. The guards are hoisted to the
+        # preflight, so a None from _push_branch_and_pr after a write can only
+        # mean failure — it routes to "error", never a silent "ok".
+        assert result["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# TestHoistedPRGuards — the guards fire before the substrate writes
+# ---------------------------------------------------------------------------
+
+
+class TestHoistedPRGuards:
+    """The daily-cap and open-PR guards run pre-write, in run_docs_auditor.
+
+    Before this, both lived inside ``_push_branch_and_pr`` and fired *after*
+    ``audit()`` had already rewritten docs in the shared main checkout, which
+    left the edits uncommitted there while the run reported success.
+    """
+
+    @staticmethod
+    def _run(repo, **guards):
+        """Drive a rotation with the two guards forced, returning (result, mocks)."""
+        with (
+            patch("reflections.docs_auditor.PROJECT_ROOT", repo),
+            patch("reflections.docs_auditor._git_dirty", return_value=False),
+            patch("reflections.docs_auditor._run_vault_drift_detection", return_value=0),
+            patch(
+                "reflections.docs_auditor._daily_pr_cap_reached",
+                return_value=guards.get("cap", False),
+            ),
+            patch(
+                "reflections.docs_auditor._has_open_pr_for_slug",
+                return_value=guards.get("open_pr", False),
+            ),
+            patch("reflections.docs_auditor.audit") as audit_mock,
+            patch("reflections.docs_auditor._push_branch_and_pr") as push,
+            patch("reflections.docs_auditor._update_rotation_hash") as rotation,
+            patch("reflections.docs_auditor._write_liveness") as liveness,
+            patch("reflections.docs_auditor._send_telegram_notification") as notify,
+        ):
+            result = docs_auditor.run_docs_auditor()
+        return result, {
+            "audit": audit_mock,
+            "push": push,
+            "rotation": rotation,
+            "liveness": liveness,
+            "notify": notify,
+        }
+
+    @pytest.mark.parametrize("guard", ["cap", "open_pr"])
+    def test_guard_returns_skipped_without_running_the_substrate(
+        self, repo, auth_ok, patch_redis, guard
+    ):
+        primary = repo / "docs" / "features" / "foo.md"
+        primary.write_text("# Foo\n" + "Padding line.\n" * 6)
+
+        result, mocks = self._run(repo, **{guard: True})
+
+        assert result["status"] == "skipped"
+        mocks["audit"].assert_not_called()
+        mocks["push"].assert_not_called()
+        mocks["notify"].assert_not_called()
+
+    @pytest.mark.parametrize("guard", ["cap", "open_pr"])
+    def test_guard_still_stamps_the_rotation_hash_for_the_picked_doc(
+        self, repo, auth_ok, patch_redis, guard
+    ):
+        """Without this stamp the same doc is re-picked forever.
+
+        ``_select_primary_doc`` always picks the least-recently-audited doc, so an
+        unstamped slug is re-picked on every run for as long as the guard fires —
+        and an open withheld PR is never closed, which would turn one blocked doc
+        into a permanent silent shutdown of the whole rotation.
+        """
+        primary = repo / "docs" / "features" / "foo.md"
+        primary.write_text("# Foo\n" + "Padding line.\n" * 6)
+
+        _result, mocks = self._run(repo, **{guard: True})
+
+        mocks["rotation"].assert_called_once()
+        assert mocks["rotation"].call_args.args[1] == ["docs/features/foo.md"]
+        assert mocks["liveness"].call_args.args[1] == "skipped"
+
+    def test_no_guard_lets_the_substrate_run(self, repo, auth_ok, patch_redis):
+        primary = repo / "docs" / "features" / "foo.md"
+        primary.write_text("# Foo\n" + "Padding line.\n" * 6)
+
+        _result, mocks = self._run(repo)
+
+        mocks["audit"].assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TestExplicitStagingSet — the branch stages files_touched and nothing else
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitStagingSet:
+    def test_empty_files_touched_creates_no_branch_and_no_commit(self, repo):
+        calls: list[list[str]] = []
+
+        def record(cmd, *a, **kw):
+            calls.append(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("reflections.docs_auditor.subprocess.run", side_effect=record):
+            assert docs_auditor._push_branch_and_pr("slug", repo, []) is None
+
+        assert calls == []
+
+    def test_staging_command_names_the_touched_paths_only(self, repo):
+        calls: list[list[str]] = []
+
+        def record(cmd, *a, **kw):
+            calls.append(cmd)
+            return MagicMock(returncode=0, stdout="main\n", stderr="")
+
+        with (
+            patch("reflections.docs_auditor.subprocess.run", side_effect=record),
+            patch("reflections.docs_auditor._record_daily_pr"),
+        ):
+            docs_auditor._push_branch_and_pr("slug", repo, ["docs/features/foo.md"])
+
+        add = next(c for c in calls if c[:2] == ["git", "add"])
+        assert add == ["git", "add", "--", "docs/features/foo.md"]
+        assert not any(c[:3] == ["git", "add", "-A"] for c in calls)
+
+    def test_restore_uses_head_so_staged_content_cannot_survive(self, repo):
+        """``git checkout -- <paths>`` restores from the INDEX, not from HEAD.
+
+        On the staged-then-commit-failed path the index still holds the auditor's
+        own content, so the bare form re-applies it to the working tree. The
+        ``HEAD`` in ``git checkout HEAD -- <paths>`` is what resets both.
+        """
+        calls: list[list[str]] = []
+
+        def record(cmd, *a, **kw):
+            calls.append(cmd)
+            return MagicMock(returncode=0, stdout="main\n", stderr="")
+
+        with (
+            patch("reflections.docs_auditor.subprocess.run", side_effect=record),
+            patch("reflections.docs_auditor._record_daily_pr"),
+        ):
+            docs_auditor._push_branch_and_pr("slug", repo, ["docs/features/foo.md"])
+
+        assert ["git", "checkout", "HEAD", "--", "docs/features/foo.md"] in calls
+        # Never a whole-tree operation — other lanes hold uncommitted work here.
+        assert not any(
+            c[:2] == ["git", "reset"] or c[:2] == ["git", "clean"] or "-f" in c for c in calls
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_docs_auditor_substrate.py
+++ b/tests/unit/test_docs_auditor_substrate.py
@@ -13,7 +13,6 @@ import re
 import shutil
 import subprocess
 import tempfile
-from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -562,8 +561,7 @@ class TestNonMarkdownApplyGuard:
         content = (
             "# Runtime\n\n"
             "## Migration\n\n"
-            "The `session_log` field remains defined in `agent/x.py`.\n"
-            + "Padding line.\n" * 6
+            "The `session_log` field remains defined in `agent/x.py`.\n" + "Padding line.\n" * 6
         )
         md.write_text(content)
 
@@ -1698,9 +1696,7 @@ class TestPRCreationFailure:
         # mean failure — it routes to "error", never a silent "ok".
         assert result["status"] == "error"
 
-    def test_push_failure_escalates_via_operational_failure_issue(
-        self, repo, auth_ok, patch_redis
-    ):
+    def test_push_failure_escalates_via_operational_failure_issue(self, repo, auth_ok, patch_redis):
         """R5-1: status="error" alone reaches nobody — a real issue must be filed
         before the function returns, or the wedge signal dies at the return."""
         primary = repo / "docs" / "features" / "foo.md"
@@ -1720,10 +1716,16 @@ class TestPRCreationFailure:
         assert result["status"] == "error"
         file_issue.assert_called_once()
         finding = file_issue.call_args.args[0]
-        assert finding["title"] == "docs-auditor: rotation failed to produce a PR for docs_features_foo_md"
+        assert (
+            finding["title"]
+            == "docs-auditor: rotation failed to produce a PR for docs_features_foo_md"
+        )
         assert finding["category"] == "operational-failure"
         # No volatile fields — no date, count, or run id in the title.
-        assert "docs-auditor: rotation failed to produce a PR for docs_features_foo_md" == finding["title"]
+        assert (
+            "docs-auditor: rotation failed to produce a PR for docs_features_foo_md"
+            == finding["title"]
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1961,14 +1963,15 @@ class TestDeletedTargetFiltering:
 
     def test_heading_stem_hook_cleanup(self, repo: Path):
         """'## Hook Cleanup' — the heading tuple had no 'cleanup' entry pre-Q7b."""
-        content = "## Hook Cleanup (Phase 5)\n\ndeleted `agent/hooks/gone_thing_xyz.py` (250 lines)\n"
+        content = (
+            "## Hook Cleanup (Phase 5)\n\ndeleted `agent/hooks/gone_thing_xyz.py` (250 lines)\n"
+        )
         assert _mk_finding(content, repo) == []
 
     def test_word_level_prose_cue_deleted_parenthetical(self, repo: Path):
         """'deleted (250 lines)' — the old cue list wanted the exact phrase 'deleted module'."""
         content = (
-            "## Architecture\n\n"
-            "`agent/gone_thing_xyz.py` deleted (250 lines) — no longer needed.\n"
+            "## Architecture\n\n`agent/gone_thing_xyz.py` deleted (250 lines) — no longer needed.\n"
         )
         assert _mk_finding(content, repo) == []
 
@@ -1983,8 +1986,11 @@ class TestDeletedTargetFiltering:
         assert _mk_finding(content, repo) == []
 
     def test_word_anchoring_does_not_fire_on_a_substring(self, repo: Path):
-        """A line containing only 'removed_at' must NOT suppress — word-anchored, not substring."""
-        content = "## Architecture\n\nThe `removed_at` field is a timestamp.\n`agent/gone_thing_xyz.py` is live.\n"
+        """A line with only 'removed_at' must NOT suppress — word-anchored, not substring."""
+        content = (
+            "## Architecture\n\nThe `removed_at` field is a timestamp.\n"
+            "`agent/gone_thing_xyz.py` is live.\n"
+        )
         findings = _mk_finding(content, repo)
         assert len(findings) == 1
 
@@ -2045,7 +2051,7 @@ class TestDeletedTargetFiltering:
 
     def test_q7b_control_live_table_row_still_reported(self, repo: Path):
         content = (
-            "| `SessionType.GRANITE` | `\"granite\"` | Direct invocations of the standalone "
+            '| `SessionType.GRANITE` | `"granite"` | Direct invocations of the standalone '
             "`valor-granite-loop` CLI (`tools/granite_thing_xyz/cli.py`) |\n"
         )
         findings = _mk_finding(content, repo)
@@ -2237,9 +2243,7 @@ class TestBrokenMdLinkDetection:
         assert findings == []
 
     def test_inline_code_span_skipped(self, repo: Path):
-        content = (
-            "`[Feature Name](gone_thing_xyz.md)`\n" "[Feature Name](gone_thing_xyz2.md)\n"
-        )
+        content = "`[Feature Name](gone_thing_xyz.md)`\n[Feature Name](gone_thing_xyz2.md)\n"
         findings = docs_auditor._detect_deleted_target_issues(
             Path("docs/features/a.md"), content, repo
         )
@@ -2509,7 +2513,11 @@ class TestCrossMachineDedup:
         ``gh issue create``, because the read is gated off for this category.
         """
         patch_redis.exists.return_value = True  # would short-circuit a non-recurring finding
-        finding = {"title": "docs-auditor: vault narrative drift", "body": "b", "category": "vault-drift"}
+        finding = {
+            "title": "docs-auditor: vault narrative drift",
+            "body": "b",
+            "category": "vault-drift",
+        }
         out = f'[{{"number": 5, "title": "{finding["title"]}", "state": "CLOSED"}}]'
 
         def fake_run(cmd, *a, **k):

--- a/tests/unit/test_scheduler_result_forwarding.py
+++ b/tests/unit/test_scheduler_result_forwarding.py
@@ -210,6 +210,74 @@ async def test_run_reflection_passes_none_for_dict_without_projects_key():
 
 
 @pytest.mark.asyncio
+async def test_run_reflection_forwards_output_summary_from_dict_result():
+    """A dict result's ``summary`` reaches ``mark_completed(output_summary=...)``."""
+    fake_result = {
+        "status": "ok",
+        "findings": [],
+        "summary": "docs-auditor: 2 files touched, 1 fixes, PR=https://github.com/o/r/pull/1",
+    }
+    entry = _make_entry()
+    state = _make_state()
+    with patch(
+        "agent.reflection_scheduler.execute_function_reflection",
+    ) as mock_exec:
+
+        async def _awaitable_returning(_entry):
+            return fake_result
+
+        mock_exec.side_effect = _awaitable_returning
+
+        await run_reflection(entry, state)
+
+    state.mark_completed.assert_called_once()
+    _args, kwargs = state.mark_completed.call_args
+    assert kwargs.get("output_summary") == fake_result["summary"]
+
+
+@pytest.mark.asyncio
+async def test_run_reflection_passes_none_output_summary_for_legacy_none_result():
+    """Legacy callable returning None → mark_completed(output_summary=None)."""
+    entry = _make_entry()
+    state = _make_state()
+    with patch(
+        "agent.reflection_scheduler.execute_function_reflection",
+    ) as mock_exec:
+
+        async def _none(_entry):
+            return None
+
+        mock_exec.side_effect = _none
+
+        await run_reflection(entry, state)
+
+    state.mark_completed.assert_called_once()
+    _args, kwargs = state.mark_completed.call_args
+    assert kwargs.get("output_summary") is None
+
+
+@pytest.mark.asyncio
+async def test_run_reflection_passes_none_output_summary_for_dict_without_summary_key():
+    """Dict result missing the ``summary`` key → mark_completed(output_summary=None)."""
+    entry = _make_entry()
+    state = _make_state()
+    with patch(
+        "agent.reflection_scheduler.execute_function_reflection",
+    ) as mock_exec:
+
+        async def _dict_no_summary(_entry):
+            return {"status": "ok", "findings": [], "projects": []}
+
+        mock_exec.side_effect = _dict_no_summary
+
+        await run_reflection(entry, state)
+
+    state.mark_completed.assert_called_once()
+    _args, kwargs = state.mark_completed.call_args
+    assert kwargs.get("output_summary") is None
+
+
+@pytest.mark.asyncio
 async def test_run_reflection_passes_none_for_non_dict_return():
     """Non-dict return (string, int, list) → mark_completed(projects=None).
 

--- a/ui/templates/reflections/_partials/modal_content.html
+++ b/ui/templates/reflections/_partials/modal_content.html
@@ -56,6 +56,11 @@
         <pre class="error-block" style="font-size: 12px; color: var(--red); white-space: pre-wrap; word-break: break-word;">{{ r.last_error }}</pre>
         {% endif %}
 
+        {% if r.last_run_summary and r.last_run_summary.output_summary %}
+        <h3>Last run summary</h3>
+        <p style="font-size: 12px; white-space: pre-wrap; word-break: break-word;">{{ r.last_run_summary.output_summary }}</p>
+        {% endif %}
+
         <h3>History (last {{ recent_runs|length }} of {{ r.run_count }})</h3>
         {% if recent_runs %}
         <table class="data-table compact">


### PR DESCRIPTION
## Summary

Two defects in `reflections/docs_auditor.py`, both about the docs auditor
acting on its own judgment without a human in the path.

**#2739 — the auditor was its own committer.** `_commit_current_branch`
(cascade path) and a whole-tree `git add -A` (rotation path) are gone.
`audit()` never commits; every rotation PR requires a human merge via
`/do-merge`, and `/do-docs` owns its own commit. Auto-merge is deleted
outright — `_pr_is_auto_merge_eligible` and the sweeper's merge branch are
gone; the sweeper now exempts a `WITHHELD_PR_MARKER` PR from stale-close
(instead of from auto-merge) and files a distinct escalation issue for it.
A rotation that writes and produces no PR now files an
`operational-failure` issue before returning `status="error"` (R5-1); the
three sibling no-PR returns (locked, no-candidates, zero-diff) relabel from
`"ok"` to `"skipped"` so `"ok"` survives on exactly the PR-created return.
The dedup gate (`_open_issue_exists` -> `_issue_exists`) now matches open
*and* closed issues by default (once-ever convergence), with two
recurring-condition categories (`vault-drift`, `operational-failure`) kept
on the old open-only semantics.

**#2834 — the auditor couldn't tell a live reference from an obituary.**
`_detect_deleted_target_issues` gains a markdown-link `.md` branch (report
only, doc-relative resolution, no repair path), and the deletion-narrative
hatch widens from exact-inflection headings to stems, from fixed prose
phrases to a word-anchored cue alternation, from a ±1 to a ±2 line window,
and gains a keyword-only live-claim veto (opt-in from the detector only,
never the write path). Verified against the plan's three real corpus
sites: `harness-abstraction.md:189` and `harness-adapter.md:19`/`:115` are
now suppressed (the false positives behind #2840/#2841); the
`SessionType.GRANITE` row in `standardized-enums.md:19` is still reported
(the true positive behind #2839).

## Test plan

- [x] `POPOTO_TEST_DB=13 ./scripts/pytest-clean.sh tests/unit/test_docs_auditor_substrate.py tests/unit/reflections/test_docs_auditor_git_surface.py tests/unit/test_scheduler_result_forwarding.py -q` — 221 passed at head `dae9371464` (growth since the 216-at-`5d598ccc3` figure comes from two intervening patch commits, `f71bfa651` and `7767827fd`/`dae937146`)
- [x] `python -m ruff check .` / `python -m ruff format --check .` — clean, repo-wide (re-confirmed at `598df5d1a`: "All checks passed", 1364 files already formatted)
- [x] New real-git test file (`tests/unit/reflections/test_docs_auditor_git_surface.py`): real repo + real bare remote, synchronous `gh`-only dispatcher, no blanket `subprocess.run` mock — covers the staging set, the scoped restore (per-failure-mode + foreign-dirt-survives), the guard-fired no-write path, the sweeper's `WITHHELD_PR_MARKER` exemption and close path, and the never-auto-merges anti-criterion
- [x] Verified every row of the plan's Verification table against the built tree. The automated runner (`agent/verification_parser.py`, rewritten in #2871) now **parses** this table cleanly — 50 checks, 0 malformed, 0 skipped, where it previously could not read it. It cannot **grade** it: 18 rows are prose `**Behavioral**` descriptions rather than shell commands, and the remaining rows state expectations as bare `` `0` `` / `> 0` / `>= 4` instead of the evaluator's vocabulary (`match count == 0`, `output > N`, `exit code N`), so `evaluate_expectation` returns `False` for them. Re-running the 32 runnable rows with their expectations translated into that vocabulary: 26 pass outright and 5 more pass once read correctly — the Race-1 row's `grep -c 'foreign|unrelated_dirty'` needs `-E` (alternation is literal in BRE; with `-E` it returns 6), the cap row joins two commands with the word `and` (split, they return 5 and 4), and the rename (`0`/`1`), states/limit (`1`/`1`) and `_DELETION_HEADING_KEYWORDS` stem-tuple rows are likewise multi-command or prose-expectation shapes that check out by hand. The 32nd row (collected test count vs. `tests/README.md:272`) also passes: `--collect-only` now reports 196 substrate and 15 git-surface, matching the README as corrected in the `dae937146` patch commit (the original `5d598ccc3`-era figures of 191/14 are stale and superseded by that commit).
- [x] Smoke-tested the three real-corpus Q7b control sites directly against the widened detector
- [x] Sizing spike re-run on the built detector (**advisory — recorded, not gating**). Method: for each of the 276 `docs/features/*.md` primaries, expand `_resolve_neighborhood(primary, root, cap=NEIGHBORHOOD_CAP=20)` and call `_detect_deleted_target_issues` on every file in the neighborhood; no `apply_mode="apply"` anywhere. Results — `.md` (`broken-md-link`): per-run mean **0.29**, max **4**, **15** distinct `(file, finding)` pairs, 79 total occurrences. `.py` (`deleted-target`): per-run mean **1.89**, max **10**, **96** distinct pairs, 521 total occurrences. The `.md` per-run mean reproduces the plan-time reference figure (0.29) exactly; distinct count (15 vs. 19) and max (4 vs. 3) differ because the corpus moved since the plan was written. The `.py` mean is **not** comparable to the plan's 0.86 → 0.57 reference: this method counts each finding once per neighborhood it appears in, so a file reachable from many primaries is counted repeatedly. It is a re-measurement under a stated method, not evidence that the widened hatch increased `.py` findings.

Closes #2739
Closes #2834

