### PR TITLE
Move the UTC time helper out of bridge/ into utils/ (#2867)

### DIFF
--- a/agent/branch_manager.py
+++ b/agent/branch_manager.py
@@ -12,8 +12,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
-from bridge.utc import utc_now
 from config.settings import settings
+from utils.utc import utc_now
 
 logger = logging.getLogger(__name__)
 

--- a/agent/messenger.py
+++ b/agent/messenger.py
@@ -17,7 +17,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 
-from bridge.utc import utc_now
+from utils.utc import utc_now
 
 logger = logging.getLogger(__name__)
 

--- a/agent/output_handler.py
+++ b/agent/output_handler.py
@@ -515,8 +515,8 @@ class TelegramRelayOutputHandler:
         """
         session_id = getattr(session, "session_id", None) or str(chat_id)
         try:
-            from bridge.utc import utc_now
             from models.room import SYSTEM_ADDRESSEE, Room
+            from utils.utc import utc_now
 
             project_key = getattr(session, "project_key", None)
             room = Room.resolve(str(project_key), SYSTEM_ADDRESSEE)

--- a/agent/reflection_scheduler.py
+++ b/agent/reflection_scheduler.py
@@ -710,7 +710,7 @@ async def _enqueue_agent_reflection(entry: ReflectionEntry) -> None:
     import os
 
     from agent.agent_session_queue import _push_agent_session
-    from bridge.utc import utc_now
+    from utils.utc import utc_now
 
     if not entry.command:
         logger.error("[reflection] Agent reflection '%s' has no command", entry.name)

--- a/agent/session_runner/liveness.py
+++ b/agent/session_runner/liveness.py
@@ -65,7 +65,7 @@ def _read_field(entry: Any, name: str) -> Any:
 def _as_unix_ts(val: Any) -> float | None:
     """Coerce a datetime / int / float / ISO-string to a Unix timestamp.
 
-    Mirrors ``bridge.utc.to_unix_ts`` semantics (naive datetimes are treated
+    Mirrors ``utils.utc.to_unix_ts`` semantics (naive datetimes are treated
     as UTC — Popoto strips tzinfo on save) without importing it: this module
     stays stdlib-only so ``agent/crash_signature.py`` can import it where it
     deliberately cannot import ``agent/session_health.py``. Returns ``None``

--- a/agent/session_stall_classifier.py
+++ b/agent/session_stall_classifier.py
@@ -8,7 +8,7 @@ Design constraints:
   - Fail-soft: any exception inside classify_session_stall returns "healthy".
   - No import from agent.session_health — this classifier must never pull in
     the kill/recovery machinery (enforced by the test suite).
-  - Uses bridge.utc.to_unix_ts for all datetime → float conversions.
+  - Uses utils.utc.to_unix_ts for all datetime → float conversions.
 
 Usage::
 

--- a/agent/session_stall_classifier.py
+++ b/agent/session_stall_classifier.py
@@ -230,7 +230,7 @@ def _classify(
     project_counters: dict | None = None,
 ) -> StallVerdict:
     """Core classification logic.  Raises on unexpected errors (caller wraps)."""
-    from bridge.utc import to_unix_ts  # local import to avoid top-level coupling
+    from utils.utc import to_unix_ts  # local import to avoid top-level coupling
 
     events = events or []
     counters = project_counters or {}

--- a/bridge/dedup.py
+++ b/bridge/dedup.py
@@ -72,7 +72,7 @@ async def record_last_processed(chat_id, message_id: int, message_ts) -> None:
     ``record_message_processed``); catchup falls back to the global cutoff.
     """
     try:
-        from bridge.utc import to_unix_ts
+        from utils.utc import to_unix_ts
 
         unix_ts = to_unix_ts(message_ts)
         if unix_ts is None:
@@ -222,7 +222,7 @@ async def record_last_event(chat_id, event_ts=None) -> None:
     Best-effort: failures log a WARNING and never raise.
     """
     try:
-        from bridge.utc import to_unix_ts
+        from utils.utc import to_unix_ts
 
         unix_ts = to_unix_ts(event_ts)
         if unix_ts is None:

--- a/bridge/escape_hatch.py
+++ b/bridge/escape_hatch.py
@@ -9,7 +9,7 @@ not bypassed.
 
 import logging
 
-from bridge.utc import utc_iso
+from utils.utc import utc_iso
 
 logger = logging.getLogger(__name__)
 

--- a/bridge/session_transcript.py
+++ b/bridge/session_transcript.py
@@ -17,7 +17,7 @@ import logging
 import time
 from pathlib import Path
 
-from bridge.utc import utc_iso
+from utils.utc import utc_iso
 
 logger = logging.getLogger(__name__)
 

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -31,9 +31,9 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
-from bridge.utc import to_unix_ts, utc_iso, utc_now
 from config.machine import get_machine_name
 from config.settings import settings
+from utils.utc import to_unix_ts, utc_iso, utc_now
 
 # Load environment variables FIRST before any env checks.
 # Under launchd (VALOR_LAUNCHD=1), env vars are injected directly into the plist

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -152,7 +152,7 @@ def _pending_session_age_seconds(created_at, now_ts: float) -> float:
 
     ``AgentSession.created_at`` is a datetime (Popoto SortedField, naive on
     read); raw ``now_ts - created_at`` raises TypeError (#2458 D2). Coerce
-    through ``bridge.utc.to_unix_ts`` (naive treated as UTC). A missing or
+    through ``utils.utc.to_unix_ts`` (naive treated as UTC). A missing or
     uncoercible created_at returns +inf so the session falls outside any
     merge window instead of crashing the intake classifier.
     """

--- a/bridge/telegram_relay.py
+++ b/bridge/telegram_relay.py
@@ -365,8 +365,8 @@ def _record_sent_reaction(message: dict) -> None:
     every other outbound record. Best-effort: never raises into the relay.
     """
     try:
-        from bridge.utc import utc_now
         from tools.telegram_history import store_message
+        from utils.utc import utc_now
 
         chat_id = message.get("chat_id")
         reply_to = message.get("reply_to")
@@ -1175,7 +1175,7 @@ async def process_outbox(telegram_client) -> int:
                     if msg_type is None and msg_id is not None:
                         try:
                             from bridge.telegram_bridge import store_message
-                            from bridge.utc import utc_now
+                            from utils.utc import utc_now
 
                             await asyncio.to_thread(
                                 store_message,

--- a/docs/features/session-lifecycle.md
+++ b/docs/features/session-lifecycle.md
@@ -395,7 +395,7 @@ A stale caller can at worst append a spurious `session_events` entry. It cannot 
 
 ## Timestamp Convention — `updated_at` is Explicit UTC
 
-`AgentSession.updated_at` is always an explicit UTC wall-clock timestamp. It is stamped inside the `save()` override using `bridge.utc.utc_now()`, not by a Popoto `auto_now` field.
+`AgentSession.updated_at` is always an explicit UTC wall-clock timestamp. It is stamped inside the `save()` override using `utils.utc.utc_now()`, not by a Popoto `auto_now` field.
 
 **Why:** Popoto's `auto_now` calls `datetime.now()` (no `tz` argument), which mints a naive datetime in the host's local timezone. On non-UTC hosts the stored value is naive-local, but every downstream reader (watchdog, dashboard, stale-cleanup) interprets it as UTC. The result is a future-dated `updated_at` for sessions created on hosts running ahead of UTC, causing the watchdog/dashboard to report sessions as perpetually "fresh" and stale-cleanup to skip them forever.
 

--- a/docs/features/utc-timestamps.md
+++ b/docs/features/utc-timestamps.md
@@ -8,13 +8,15 @@ All timestamps in the system are stored and logged as **tz-aware UTC datetimes**
 - **Cross-machine consistency**: Deployed instances in different timezones produce identical timestamp formats.
 - **No naive datetimes**: Every `datetime` object in the system carries timezone info, preventing `TypeError` from mixed naive/aware comparisons.
 
-## The `bridge/utc` Module
+## The `utils/utc` Module
 
 Central utilities for timestamp handling:
 
 ```python
-from bridge.utc import utc_now, to_local, utc_iso, to_unix_ts
+from utils.utc import utc_now, to_local, utc_iso, to_unix_ts
 ```
+
+The module lives in `utils/` because it is dependency-free (stdlib `datetime` only) and standalone `tools/` packages import it, so it must not chain them to the harness (#2867).
 
 ### `utc_now() -> datetime`
 
@@ -57,7 +59,7 @@ Display surfaces fall into two categories:
 **Conversational output** (Telegram messages, UI relative times): convert to local time with `to_local()`:
 
 ```python
-from bridge.utc import utc_now, to_local
+from utils.utc import utc_now, to_local
 
 ts = utc_now()  # Store this
 display = to_local(ts).strftime("%H:%M")  # Show this to humans
@@ -82,7 +84,7 @@ The CLI uses `_format_ts()` in `tools/valor_session.py` (appends ` UTC` to all o
 - `time.time()` calls are unchanged -- epoch timestamps are timezone-neutral.
 - Telethon message timestamps were already UTC and are unchanged.
 - `AgentSession.updated_at` is explicitly UTC-stamped in `AgentSession.save()` (issue #1645 — Popoto's `auto_now=True` historically minted naive local wall-clock time). `created_at` and other `DatetimeField` timestamps are set explicitly at write time using `utc_now()`. As of **popoto >= 1.7.1** (issue #1653, popoto#421) `auto_now`/`auto_now_add` now stamp `datetime.now(timezone.utc)`, so the upstream producer bug is fixed and `auto_now` is safe to use. We nonetheless keep the explicit `utc_now()` stamp in `AgentSession.save()` for now: it also covers save paths that bypass `format_value_pre_save` (e.g. raw/pipeline updates). Removing the override is gated on confirming `auto_now` fires on every save path — until then, prefer explicit `utc_now()` stamps on `AgentSession`.
-- `SortedField` / `DatetimeField` deserialization can return naive datetimes — code that calls `.timestamp()` on values read from Popoto must treat them as UTC. **Use `bridge.utc.to_unix_ts(val)` for all read-path conversions.** It normalizes naive datetimes to UTC before `.timestamp()`, handles `None`/float/ISO-string inputs, and is the single source of truth for this coercion. Rewire sites include `scripts/update/run.py::_cleanup_stale_sessions`, `tools/agent_session_scheduler._to_ts`, `agent/sustainability`, `reflections/memory_management`, `tools/telegram_history._parse_ts`, and `models.agent_session.cleanup_expired`. Three older helpers (`monitoring/session_watchdog._to_timestamp`, `agent/session_health._to_ts`, `ui/data/sdlc._safe_float`) already implement the same `val.tzinfo is None` guard inline — they pre-date the shared helper and are intentionally left untouched. New code must import `to_unix_ts` rather than add a fourth copy (issues #777, hotfix 9e3a64f5).
+- `SortedField` / `DatetimeField` deserialization can return naive datetimes — code that calls `.timestamp()` on values read from Popoto must treat them as UTC. **Use `utils.utc.to_unix_ts(val)` for all read-path conversions.** It normalizes naive datetimes to UTC before `.timestamp()`, handles `None`/float/ISO-string inputs, and is the single source of truth for this coercion. Rewire sites include `scripts/update/run.py::_cleanup_stale_sessions`, `tools/agent_session_scheduler._to_ts`, `agent/sustainability`, `reflections/memory_management`, `tools/telegram_history._parse_ts`, and `models.agent_session.cleanup_expired`. Three older helpers (`monitoring/session_watchdog._to_timestamp`, `agent/session_health._ts`, `ui/data/sdlc._safe_float`) already implement the same `val.tzinfo is None` guard inline — they pre-date the shared helper and are intentionally left untouched. New code must import `to_unix_ts` rather than add a fourth copy (issues #777, hotfix 9e3a64f5).
 
 ## Related
 

--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -1019,7 +1019,7 @@ class AgentSession(Model):
 
         Popoto auto_now mints naive local time (bug #1645); instead we stamp
         explicitly so the stored value is always UTC wall-clock, consistent
-        with how created_at/started_at are handled (see bridge/utc.py::utc_now).
+        with how created_at/started_at are handled (see utils/utc.py::utc_now).
 
         update_fields guard: if update_fields omits 'updated_at', skip the stamp
         entirely (no in-memory mutation without a matching persist, to avoid
@@ -1132,7 +1132,7 @@ class AgentSession(Model):
                     continue  # None is safe — save() will stamp on next write
 
                 # Popoto strips tzinfo on load — treat naive datetimes as UTC
-                # (consistent with bridge/utc.py::to_unix_ts).
+                # (consistent with utils/utc.py::to_unix_ts).
                 updated_at_utc = record.updated_at
                 if updated_at_utc.tzinfo is None:
                     updated_at_utc = updated_at_utc.replace(tzinfo=UTC)

--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -1037,7 +1037,7 @@ class AgentSession(Model):
         the combination is a caller smell — a WARNING names the caller and no
         exception is raised (fail-quiet, matching every other guard here).
         """
-        from bridge.utc import utc_now
+        from utils.utc import utc_now
 
         if preserve_updated_at:
             if update_fields is not None and "updated_at" not in update_fields:
@@ -1116,7 +1116,7 @@ class AgentSession(Model):
         Returns the number of future-dated records detected (NOT healed —
         nothing is mutated or re-saved).
         """
-        from bridge.utc import utc_now
+        from utils.utc import utc_now
 
         now = utc_now()
         count = 0
@@ -2614,7 +2614,7 @@ class AgentSession(Model):
                 continue
             # Handle both datetime and float timestamps (migration period).
             # to_unix_ts treats naive datetimes as UTC (Popoto strips tzinfo).
-            from bridge.utc import to_unix_ts
+            from utils.utc import to_unix_ts
 
             ts = to_unix_ts(started)
             if ts is None:

--- a/models/job.py
+++ b/models/job.py
@@ -480,7 +480,7 @@ class Job(Model):
         """
         rested = 0
         try:
-            from bridge.utc import to_unix_ts
+            from utils.utc import to_unix_ts
 
             now_ts = now if now is not None else time.time()
             cutoff = now_ts - JOB_AT_REST_AGE_SECONDS
@@ -722,7 +722,7 @@ class Job(Model):
         """
         from popoto.redis_db import POPOTO_REDIS_DB
 
-        from bridge.utc import to_unix_ts
+        from utils.utc import to_unix_ts
 
         # Maintenance path never raises: an enumeration failure (Redis down,
         # popoto decode blow-up) logs and returns (0, 0) so repair_indexes

--- a/models/job.py
+++ b/models/job.py
@@ -692,7 +692,7 @@ class Job(Model):
 
         For each Job the stored score in its Room partition (key **derived**
         via ``SortedField.get_sortedset_db_key``, never hand-built) is
-        compared against ``bridge.utc.to_unix_ts(job.last_active_at)``; a row
+        compared against ``utils.utc.to_unix_ts(job.last_active_at)``; a row
         outside a 1-second tolerance is re-read fresh and repaired with the
         structural clobber-proof idiom
         ``fresh.save(update_fields=["last_active_at"])`` — a field-scoped

--- a/monitoring/alerts.py
+++ b/monitoring/alerts.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
 
-from bridge.utc import utc_now
+from utils.utc import utc_now
 
 logger = logging.getLogger(__name__)
 

--- a/monitoring/bridge_watchdog.py
+++ b/monitoring/bridge_watchdog.py
@@ -49,8 +49,8 @@ from pathlib import Path
 
 import redis
 
-from bridge.utc import utc_iso, utc_now
 from config.settings import settings
+from utils.utc import utc_iso, utc_now
 
 # Add project root to path
 PROJECT_DIR = Path(__file__).parent.parent

--- a/monitoring/resource_monitor.py
+++ b/monitoring/resource_monitor.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from bridge.utc import utc_now
+from utils.utc import utc_now
 
 if TYPE_CHECKING:
     from monitoring.alerts import Alert

--- a/monitoring/session_tracker.py
+++ b/monitoring/session_tracker.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Any
 
-from bridge.utc import utc_now
+from utils.utc import utc_now
 
 
 @dataclass

--- a/reflections/agents/failure_loop_detector.py
+++ b/reflections/agents/failure_loop_detector.py
@@ -201,7 +201,7 @@ def run() -> None:
             logger.info("[failure-loop-detector] Queue paused (API outage) — skipping failure scan")
             return
 
-        from bridge.utc import to_unix_ts
+        from utils.utc import to_unix_ts
 
         cutoff = time.time() - (4 * 3600)  # 4 hours ago
         # Phantom guard: drop records whose fields are still Popoto Field descriptors

--- a/reflections/agents/session_count_throttle.py
+++ b/reflections/agents/session_count_throttle.py
@@ -65,7 +65,7 @@ def run() -> None:
         # Phantom guard: drop records whose fields are still Popoto Field descriptors
         # (orphan $IndexF members).
         all_sessions = _filter_hydrated_sessions(AgentSession.query.filter(project_key=project_key))
-        from bridge.utc import to_unix_ts
+        from utils.utc import to_unix_ts
 
         recent = []
         for s in all_sessions:

--- a/reflections/agents/session_recovery_drip.py
+++ b/reflections/agents/session_recovery_drip.py
@@ -88,7 +88,7 @@ def run() -> None:
 
         # Pop oldest session (FIFO by created_at) — paused_circuit has priority
         def _ts(session):
-            from bridge.utc import to_unix_ts
+            from utils.utc import to_unix_ts
 
             return to_unix_ts(getattr(session, "created_at", None)) or 0.0
 

--- a/reflections/audits/hooks_audit.py
+++ b/reflections/audits/hooks_audit.py
@@ -166,7 +166,7 @@ def _hooks_audit_for_project(project: dict) -> dict:
     """
     import time as _time
 
-    from bridge.utc import utc_now
+    from utils.utc import utc_now
 
     wd = project.get("working_directory", "")
     repo_root = Path(wd) if wd else PROJECT_ROOT

--- a/reflections/audits/pr_review_audit.py
+++ b/reflections/audits/pr_review_audit.py
@@ -208,7 +208,7 @@ def run() -> dict:
 
     Runs in dry_run=True mode by default to avoid spurious issue creation.
     """
-    from bridge.utc import utc_now
+    from utils.utc import utc_now
 
     try:
         from models.reflections import PRReviewAudit

--- a/reflections/audits/principal_staleness.py
+++ b/reflections/audits/principal_staleness.py
@@ -36,7 +36,7 @@ async def run() -> dict:
         return {"status": "ok", "findings": [finding], "summary": finding}
 
     mod_time = datetime.fromtimestamp(principal_path.stat().st_mtime, tz=UTC)
-    from bridge.utc import utc_now
+    from utils.utc import utc_now
 
     age_days = (utc_now() - mod_time).days
     staleness_threshold = 90

--- a/reflections/expectation_reconciler.py
+++ b/reflections/expectation_reconciler.py
@@ -298,9 +298,9 @@ def _live_pm_session(project_key: str, holder: str):
     recently updated live non-ledger eng session in the project."""
     try:
         from agent.session_health import _is_ledger
-        from bridge.utc import to_unix_ts
         from models.agent_session import AgentSession
         from models.session_lifecycle import NON_TERMINAL_STATUSES
+        from utils.utc import to_unix_ts
 
         rows = list(AgentSession.query.filter(project_key=project_key, session_type="eng"))
         live = [

--- a/reflections/memory/memory_decay_prune.py
+++ b/reflections/memory/memory_decay_prune.py
@@ -152,7 +152,7 @@ def _created_ts(memory) -> float | None:
     created_at = getattr(memory, "created_at", None)
     if created_at is None:
         return None
-    from bridge.utc import to_unix_ts
+    from utils.utc import to_unix_ts
 
     return to_unix_ts(created_at)
 

--- a/reflections/memory/memory_quality_audit.py
+++ b/reflections/memory/memory_quality_audit.py
@@ -207,7 +207,7 @@ def _is_extraction_record(memory) -> bool:
 def _to_unix_ts_safe(memory) -> float | None:
     """Best-effort created_at -> unix timestamp; None on any failure."""
     try:
-        from bridge.utc import to_unix_ts
+        from utils.utc import to_unix_ts
 
         created_at = getattr(memory, "created_at", None)
         if created_at is None:

--- a/reflections/pm_briefings/daily_log.py
+++ b/reflections/pm_briefings/daily_log.py
@@ -914,8 +914,8 @@ def build(project: dict, slot_config: dict) -> tuple[str, str, dict[str, Any]]:
         ``(transcript, followup_markdown, raw_signals)``. On skip-when-empty
         (no activity for the target day), returns ``("", "", {})``.
     """
-    from bridge.utc import utc_now
     from reflections.pm_briefings import builder
+    from utils.utc import utc_now
 
     target_date = utc_now() - timedelta(days=1)
 

--- a/reflections/sdlc_progress.py
+++ b/reflections/sdlc_progress.py
@@ -808,9 +808,9 @@ def _pick_steer_target(project_key: str, lane_slug: str | None = None) -> tuple[
     """
     try:
         from agent.session_health import _is_ledger
-        from bridge.utc import to_unix_ts
         from models.agent_session import AgentSession
         from models.session_lifecycle import NON_TERMINAL_STATUSES, RESUMABLE_STATUSES
+        from utils.utc import to_unix_ts
 
         rows = list(AgentSession.query.filter(project_key=project_key, session_type="eng"))
     except Exception as exc:

--- a/reflections/sdlc_upvote_lanes.py
+++ b/reflections/sdlc_upvote_lanes.py
@@ -278,8 +278,8 @@ def _non_terminal_session_for(slug: str, project_key: str):
 def _recent_terminal_failed_session(slug: str, project_key: str, backoff_s: int):
     from datetime import UTC, datetime, timedelta
 
-    from bridge.utc import to_unix_ts
     from models.agent_session import AgentSession
+    from utils.utc import to_unix_ts
 
     cutoff_ts = (datetime.now(tz=UTC) - timedelta(seconds=backoff_s)).timestamp()
     for row in AgentSession.query.filter(slug=slug):

--- a/reflections/session_intelligence.py
+++ b/reflections/session_intelligence.py
@@ -126,7 +126,7 @@ def run() -> dict:
     Raises exceptions on sub-step failure (propagates to scheduler for
     last_status=error tracking).
     """
-    from bridge.utc import utc_now
+    from utils.utc import utc_now
 
     findings: list[str] = []
     yesterday = (utc_now() - timedelta(days=1)).strftime("%Y-%m-%d")

--- a/scripts/update/git.py
+++ b/scripts/update/git.py
@@ -113,7 +113,7 @@ def stash_changes(project_dir: Path) -> StashResult:
     import os
     import uuid
 
-    from bridge.utc import utc_now
+    from utils.utc import utc_now
 
     timestamp = utc_now().strftime("%Y%m%d-%H%M%S")
     # pid + random suffix: the token is the identity, so it must not collide

--- a/scripts/update/run.py
+++ b/scripts/update/run.py
@@ -252,9 +252,9 @@ def _cleanup_stale_sessions(
 
     from agent.pid_fence import fence_is_live
     from agent.session_health import _is_ledger
-    from bridge.utc import to_unix_ts
     from models.agent_session import AgentSession
     from models.session_lifecycle import finalize_session
+    from utils.utc import to_unix_ts
 
     # Attempt to import the live-worker registry; fails gracefully if the queue
     # module is not initialized in this process (standalone subprocess invocation).

--- a/site/assets/graph.js
+++ b/site/assets/graph.js
@@ -5629,10 +5629,10 @@ window.VALOR_GRAPH = {
    "complexity": "complex"
   },
   {
-   "id": "file:bridge/utc.py",
+   "id": "file:utils/utc.py",
    "type": "file",
    "name": "utc.py",
-   "filePath": "bridge/utc.py",
+   "filePath": "utils/utc.py",
    "summary": "Shared timezone helpers giving the whole codebase timezone-aware UTC clocks, ISO strings, and robust conversion to Unix timestamps.",
    "tags": [
     "utility",
@@ -5644,10 +5644,10 @@ window.VALOR_GRAPH = {
    "languageNotes": "Centralizes timezone-aware datetime handling to avoid naive-datetime bugs across modules."
   },
   {
-   "id": "function:bridge/utc.py:to_unix_ts",
+   "id": "function:utils/utc.py:to_unix_ts",
    "type": "function",
    "name": "to_unix_ts",
-   "filePath": "bridge/utc.py",
+   "filePath": "utils/utc.py",
    "lineRange": [
     38,
     64
@@ -5661,10 +5661,10 @@ window.VALOR_GRAPH = {
    "complexity": "moderate"
   },
   {
-   "id": "function:bridge/utc.py:to_local",
+   "id": "function:utils/utc.py:to_local",
    "type": "function",
    "name": "to_local",
-   "filePath": "bridge/utc.py",
+   "filePath": "utils/utc.py",
    "lineRange": [
     19,
     30
@@ -23632,7 +23632,7 @@ window.VALOR_GRAPH = {
   },
   {
    "source": "file:agent/branch_manager.py",
-   "target": "file:bridge/utc.py",
+   "target": "file:utils/utc.py",
    "type": "imports",
    "direction": "forward",
    "weight": 0.7
@@ -25655,7 +25655,7 @@ window.VALOR_GRAPH = {
   },
   {
    "source": "file:bridge/escape_hatch.py",
-   "target": "file:bridge/utc.py",
+   "target": "file:utils/utc.py",
    "type": "imports",
    "direction": "forward",
    "weight": 0.7
@@ -25690,7 +25690,7 @@ window.VALOR_GRAPH = {
   },
   {
    "source": "file:bridge/session_transcript.py",
-   "target": "file:bridge/utc.py",
+   "target": "file:utils/utc.py",
    "type": "imports",
    "direction": "forward",
    "weight": 0.7
@@ -25759,29 +25759,29 @@ window.VALOR_GRAPH = {
    "weight": 0.6
   },
   {
-   "source": "file:bridge/utc.py",
-   "target": "function:bridge/utc.py:to_unix_ts",
+   "source": "file:utils/utc.py",
+   "target": "function:utils/utc.py:to_unix_ts",
    "type": "contains",
    "direction": "forward",
    "weight": 1.0
   },
   {
-   "source": "file:bridge/utc.py",
-   "target": "function:bridge/utc.py:to_unix_ts",
+   "source": "file:utils/utc.py",
+   "target": "function:utils/utc.py:to_unix_ts",
    "type": "exports",
    "direction": "forward",
    "weight": 0.8
   },
   {
-   "source": "file:bridge/utc.py",
-   "target": "function:bridge/utc.py:to_local",
+   "source": "file:utils/utc.py",
+   "target": "function:utils/utc.py:to_local",
    "type": "contains",
    "direction": "forward",
    "weight": 1.0
   },
   {
-   "source": "file:bridge/utc.py",
-   "target": "function:bridge/utc.py:to_local",
+   "source": "file:utils/utc.py",
+   "target": "function:utils/utc.py:to_local",
    "type": "exports",
    "direction": "forward",
    "weight": 0.8
@@ -25823,7 +25823,7 @@ window.VALOR_GRAPH = {
   },
   {
    "source": "file:monitoring/alerts.py",
-   "target": "file:bridge/utc.py",
+   "target": "file:utils/utc.py",
    "type": "imports",
    "direction": "forward",
    "weight": 0.7
@@ -25865,7 +25865,7 @@ window.VALOR_GRAPH = {
   },
   {
    "source": "file:monitoring/bridge_watchdog.py",
-   "target": "file:bridge/utc.py",
+   "target": "file:utils/utc.py",
    "type": "imports",
    "direction": "forward",
    "weight": 0.7
@@ -26033,7 +26033,7 @@ window.VALOR_GRAPH = {
   },
   {
    "source": "file:monitoring/resource_monitor.py",
-   "target": "file:bridge/utc.py",
+   "target": "file:utils/utc.py",
    "type": "imports",
    "direction": "forward",
    "weight": 0.7
@@ -26054,7 +26054,7 @@ window.VALOR_GRAPH = {
   },
   {
    "source": "file:monitoring/session_tracker.py",
-   "target": "file:bridge/utc.py",
+   "target": "file:utils/utc.py",
    "type": "imports",
    "direction": "forward",
    "weight": 0.7
@@ -26201,7 +26201,7 @@ window.VALOR_GRAPH = {
   },
   {
    "source": "file:tools/image_gen/__init__.py",
-   "target": "file:bridge/utc.py",
+   "target": "file:utils/utc.py",
    "type": "imports",
    "direction": "forward",
    "weight": 0.7
@@ -26250,7 +26250,7 @@ window.VALOR_GRAPH = {
   },
   {
    "source": "file:tools/selfie/__init__.py",
-   "target": "file:bridge/utc.py",
+   "target": "file:utils/utc.py",
    "type": "imports",
    "direction": "forward",
    "weight": 0.7
@@ -26278,7 +26278,7 @@ window.VALOR_GRAPH = {
   },
   {
    "source": "file:tools/sms_reader/__init__.py",
-   "target": "file:bridge/utc.py",
+   "target": "file:utils/utc.py",
    "type": "imports",
    "direction": "forward",
    "weight": 0.7
@@ -26362,7 +26362,7 @@ window.VALOR_GRAPH = {
   },
   {
    "source": "file:tools/test_scheduler/__init__.py",
-   "target": "file:bridge/utc.py",
+   "target": "file:utils/utc.py",
    "type": "imports",
    "direction": "forward",
    "weight": 0.7
@@ -26474,7 +26474,7 @@ window.VALOR_GRAPH = {
   },
   {
    "source": "file:tools/valor_telegram.py",
-   "target": "file:bridge/utc.py",
+   "target": "file:utils/utc.py",
    "type": "imports",
    "direction": "forward",
    "weight": 0.7
@@ -27230,7 +27230,7 @@ window.VALOR_GRAPH = {
   },
   {
    "source": "file:bridge/telegram_bridge.py",
-   "target": "file:bridge/utc.py",
+   "target": "file:utils/utc.py",
    "type": "imports",
    "direction": "forward",
    "weight": 0.7
@@ -27734,7 +27734,7 @@ window.VALOR_GRAPH = {
   },
   {
    "source": "file:agent/messenger.py",
-   "target": "file:bridge/utc.py",
+   "target": "file:utils/utc.py",
    "type": "imports",
    "direction": "forward",
    "weight": 0.7
@@ -28833,7 +28833,7 @@ window.VALOR_GRAPH = {
   },
   {
    "source": "file:tools/valor_calendar.py",
-   "target": "file:bridge/utc.py",
+   "target": "file:utils/utc.py",
    "type": "imports",
    "direction": "forward",
    "weight": 0.7
@@ -29764,7 +29764,7 @@ window.VALOR_GRAPH = {
   },
   {
    "source": "file:ui/app.py",
-   "target": "file:bridge/utc.py",
+   "target": "file:utils/utc.py",
    "type": "imports",
    "direction": "forward",
    "weight": 0.7
@@ -36057,7 +36057,7 @@ window.VALOR_GRAPH = {
     "file:bridge/dedup.py",
     "file:bridge/escape_hatch.py",
     "file:bridge/session_transcript.py",
-    "file:bridge/utc.py",
+    "file:utils/utc.py",
     "file:bridge/dead_letters.py",
     "file:bridge/response.py",
     "file:bridge/telegram_bridge.py",

--- a/tests/integration/test_reflections_redis.py
+++ b/tests/integration/test_reflections_redis.py
@@ -104,7 +104,7 @@ class TestAnalyzeSessionsFromRedis:
             tool_call_count=20,
         )
 
-        today = __import__("bridge.utc", fromlist=["utc_now"]).utc_now().strftime("%Y-%m-%d")
+        today = __import__("utils.utc", fromlist=["utc_now"]).utc_now().strftime("%Y-%m-%d")
         result = _analyze_sessions_from_redis(today)
         assert result["sessions_analyzed"] == 1
         assert "thrash_sessions" not in result
@@ -126,7 +126,7 @@ class TestAnalyzeSessionsFromRedis:
             summary="Crashed during build step",
         )
 
-        today = __import__("bridge.utc", fromlist=["utc_now"]).utc_now().strftime("%Y-%m-%d")
+        today = __import__("utils.utc", fromlist=["utc_now"]).utc_now().strftime("%Y-%m-%d")
         result = _analyze_sessions_from_redis(today)
         assert len(result.get("error_patterns", [])) >= 1
 

--- a/tests/integration/test_updated_at_heal.py
+++ b/tests/integration/test_updated_at_heal.py
@@ -48,7 +48,7 @@ from models.agent_session import AgentSession
 def _as_utc(dt: datetime) -> datetime:
     """Attach UTC tzinfo to a naive datetime (popoto strips tzinfo on load).
 
-    This is the same logic used by bridge/utc.py::to_unix_ts and the
+    This is the same logic used by utils/utc.py::to_unix_ts and the
     AgentSession read-back normalization: naive == UTC.
     """
     if dt is None:

--- a/tests/performance/test_benchmarks.py
+++ b/tests/performance/test_benchmarks.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import pytest
 
-from bridge.utc import utc_now
+from utils.utc import utc_now
 
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))

--- a/tests/unit/reflections/test_sdlc_upvote_lanes.py
+++ b/tests/unit/reflections/test_sdlc_upvote_lanes.py
@@ -344,7 +344,7 @@ class TestRecentTerminalFailedSessionDirect:
         from datetime import UTC, datetime
 
         # This is literally what Popoto returns: naive, no tzinfo -- but
-        # representing UTC wall-clock time, per bridge.utc.to_unix_ts's
+        # representing UTC wall-clock time, per utils.utc.to_unix_ts's
         # documented contract ("Popoto strips tzinfo on save").
         recent_naive = datetime.now(UTC).replace(tzinfo=None, microsecond=469935)
         fake_agent_session.query = _GateFakeQuery(

--- a/tests/unit/session_runner/test_liveness.py
+++ b/tests/unit/session_runner/test_liveness.py
@@ -178,7 +178,7 @@ class TestHasDemonstrableActivityFreshness:
 
     def test_naive_datetime_treated_as_utc(self):
         """Popoto strips tzinfo on save; a naive datetime must be read as UTC
-        (mirrors bridge.utc.to_unix_ts), not machine-local time."""
+        (mirrors utils.utc.to_unix_ts), not machine-local time."""
         naive = _now().replace(tzinfo=None) - timedelta(seconds=30)
         entry = _ActivityEntry(last_tool_use_at=naive)
         assert has_demonstrable_activity(entry, freshness_window=300) is True

--- a/tests/unit/test_architectural_constraints.py
+++ b/tests/unit/test_architectural_constraints.py
@@ -36,8 +36,10 @@ def _iter_imports(filepath: str) -> list[tuple[str, int, int]]:
 
     imports: list[tuple[str, int, int]] = []
     for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom) and node.module:
-            imports.append((node.module, node.lineno, node.level))
+        if isinstance(node, ast.ImportFrom):
+            # ``from . import X`` parses with module=None; record it as "." so the
+            # node is still counted rather than silently dropped.
+            imports.append((node.module or ".", node.lineno, node.level))
         elif isinstance(node, ast.Import):
             imports.extend((alias.name, node.lineno, 0) for alias in node.names)
     return imports

--- a/tests/unit/test_architectural_constraints.py
+++ b/tests/unit/test_architectural_constraints.py
@@ -1,6 +1,9 @@
 """
-Architectural constraint tests for the SDLC router oscillation guard.
+Architectural constraint tests: import boundaries that no other test defends.
 
+Two independent families live here.
+
+**The SDLC router oscillation guard.**
 Asserts the one-way import boundary between tools/ and agent/sdlc_router.py:
   - tools/sdlc_dispatch.py MAY import from agent/sdlc_router.py (CLI wrapper)
   - agent/sdlc_router.py MUST NOT import from tools/sdlc_dispatch.py (cycle prevention)
@@ -10,30 +13,74 @@ The full tools/ -> agent/ direction is accepted (tools/sdlc_stage_query.py,
 tools/sdlc_dispatch.py, etc. all import from agent/). The constraint is
 specifically that the modules in agent/ which ARE imported by tools/ do not
 create a cycle by importing back.
+
+**The standalone tool package boundary (#2867).**
+Asserts that tools/selfie, tools/sms_reader, and tools/test_scheduler import no
+harness package at all, and that utils/__init__.py stays import-free so that
+importing utils.utc cannot drag the harness in behind it.
 """
 
 import ast
 import os
 
 
-def _get_imports(filepath: str) -> list[str]:
-    """Return all module names imported by the file at filepath."""
+def _iter_imports(filepath: str) -> list[tuple[str, int, int]]:
+    """Return (module, lineno, level) for every import in the file at filepath.
+
+    ``level`` is the relative-import depth: 0 for absolute imports, >0 for
+    ``from .x import y``. Uses ``ast.walk``, so function-local imports are
+    caught alongside top-level ones.
+    """
     with open(filepath) as fh:
         tree = ast.parse(fh.read(), filename=filepath)
 
-    imports: list[str] = []
+    imports: list[tuple[str, int, int]] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom) and node.module:
-            imports.append(node.module)
+            imports.append((node.module, node.lineno, node.level))
         elif isinstance(node, ast.Import):
-            imports.extend(alias.name for alias in node.names)
+            imports.extend((alias.name, node.lineno, 0) for alias in node.names)
     return imports
+
+
+def _get_imports(filepath: str) -> list[str]:
+    """Return all module names imported by the file at filepath."""
+    return [module for module, _lineno, _level in _iter_imports(filepath)]
 
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 SDLC_ROUTER = os.path.join(REPO_ROOT, "agent", "sdlc_router.py")
 SDLC_VERDICT = os.path.join(REPO_ROOT, "tools", "sdlc_verdict.py")
 SDLC_DISPATCH = os.path.join(REPO_ROOT, "tools", "sdlc_dispatch.py")
+
+# The three tools/ packages that #2867 detached from the harness entirely.
+# Deliberately NOT widened to tools/image_gen or tools/telegram_history: both
+# legitimately carry cross-package dependencies this guard does not police.
+STANDALONE_TOOL_PACKAGES = ("tools/selfie", "tools/sms_reader", "tools/test_scheduler")
+
+# First path segments a standalone tool package must never import.
+#
+# ``config`` is the load-bearing entry. It is absent from issue #2867's own list
+# and is here on measured evidence: importing any config submodule executes
+# config/__init__.py, which pulls 214 modules in 94 ms against utils's 2 in 1 ms.
+# That measurement is the entire reason utils/ was chosen as utc.py's home, so a
+# guard permitting ``from config.paths import ...`` here would wave through the
+# precise coupling the move exists to remove.
+FORBIDDEN_IMPORT_ROOTS = frozenset(
+    {
+        "bridge",
+        "agent",
+        "worker",
+        "models",
+        "config",
+        "monitoring",
+        "reflections",
+        "analytics",
+        "ui",
+    }
+)
+
+UTILS_INIT = os.path.join(REPO_ROOT, "utils", "__init__.py")
 
 
 class TestSdlcRouterImportBoundary:
@@ -100,4 +147,68 @@ class TestSdlcRouterImportBoundary:
         assert hasattr(mod, "decide_next_dispatch"), (
             "agent.sdlc_router.decide_next_dispatch not found — the dispatch function "
             "was renamed or removed."
+        )
+
+
+class TestStandaloneToolPackageBoundaries:
+    """
+    tools/selfie, tools/sms_reader, and tools/test_scheduler are standalone CLI
+    utilities. Before #2867 each had exactly one cross-package import in its whole
+    source tree, and it was the shared UTC helper, which then lived in the bridge
+    package — three self-contained tools chained to the Telegram I/O layer by a
+    call to datetime.now().
+
+    Moving that helper to utils/utc.py removed those edges. Nothing else keeps them removed:
+    utils/__init__.py is empty by accident, not by contract, and one harness import
+    added there later would silently re-couple all three packages with no test
+    failing. That is what these two assertions defend.
+    """
+
+    def test_standalone_tool_packages_have_no_harness_imports(self):
+        """No file in the three standalone packages may import a harness package."""
+        offenders: list[str] = []
+        scanned = 0
+
+        for package in STANDALONE_TOOL_PACKAGES:
+            package_dir = os.path.join(REPO_ROOT, package)
+            assert os.path.isdir(package_dir), (
+                f"{package} does not exist. If it was renamed or removed, update "
+                "STANDALONE_TOOL_PACKAGES — do not let this guard silently scan nothing."
+            )
+            # os.walk covers each package's tests/ directory too, which is where a
+            # harness import is most likely to sneak back in.
+            for dirpath, _dirnames, filenames in os.walk(package_dir):
+                for filename in sorted(filenames):
+                    if not filename.endswith(".py"):
+                        continue
+                    filepath = os.path.join(dirpath, filename)
+                    scanned += 1
+                    for module, lineno, level in _iter_imports(filepath):
+                        if level:
+                            continue  # relative import — cannot reach another package
+                        if module.split(".")[0] in FORBIDDEN_IMPORT_ROOTS:
+                            rel = os.path.relpath(filepath, REPO_ROOT)
+                            offenders.append(f"{rel}:{lineno} imports {module}")
+
+        assert scanned, "Scanned zero files — the guard is measuring nothing."
+        assert not offenders, (
+            "Standalone tool packages must not import harness packages "
+            f"({', '.join(sorted(FORBIDDEN_IMPORT_ROOTS))}):\n  "
+            + "\n  ".join(offenders)
+            + "\n\nThese CLIs are meant to stand alone (#2867). Move the shared helper "
+            "into utils/ instead of importing the harness from here."
+        )
+
+    def test_utils_package_init_imports_nothing(self):
+        """utils/__init__.py must stay import-free, by contract rather than by luck."""
+        imports = [
+            f"line {lineno}: {module}" for module, lineno, _level in _iter_imports(UTILS_INIT)
+        ]
+        assert not imports, (
+            "utils/__init__.py imports something:\n  "
+            + "\n  ".join(imports)
+            + "\n\nutils/__init__.py executes on every ``import utils.<anything>``, so an "
+            "import here is inherited by every consumer of utils.utc — silently "
+            "re-coupling tools/selfie, tools/sms_reader, and tools/test_scheduler to "
+            "the harness that #2867 detached them from."
         )

--- a/tests/unit/test_hooks_audit.py
+++ b/tests/unit/test_hooks_audit.py
@@ -369,7 +369,7 @@ class TestShimFailOpenSignal:
     """
 
     def _recent_ts(self) -> str:
-        from bridge.utc import utc_now
+        from utils.utc import utc_now
 
         return utc_now().strftime("%Y-%m-%d %H:%M:%S")
 

--- a/tests/unit/test_job_model.py
+++ b/tests/unit/test_job_model.py
@@ -263,7 +263,7 @@ class TestFieldScopedLifecycleSaves:
     clobbered by the whole-hash rewrite a bare ``save()`` would perform."""
 
     def test_touch_preserves_a_concurrent_goal_write(self, scratch_room_id):
-        from bridge.utc import to_unix_ts
+        from utils.utc import to_unix_ts
 
         a = Job.mint(scratch_room_id, "check the deploy")
         b = Job.query.get(id=a.id, room_id=scratch_room_id)
@@ -277,7 +277,7 @@ class TestFieldScopedLifecycleSaves:
         assert to_unix_ts(reloaded.last_active_at) > before
 
     def test_revive_preserves_a_concurrent_goal_write(self, scratch_room_id):
-        from bridge.utc import to_unix_ts
+        from utils.utc import to_unix_ts
 
         a = Job.mint(scratch_room_id, "check the deploy")
         a.mark_at_rest()
@@ -304,7 +304,7 @@ class TestFieldScopedLifecycleSaves:
         assert eid in {e["id"] for e in reloaded.open_expectations()}
 
     def test_mark_at_rest_does_not_refresh_recency(self, scratch_room_id):
-        from bridge.utc import to_unix_ts
+        from utils.utc import to_unix_ts
 
         job = Job.mint(scratch_room_id, "check the deploy")
         before_ts = to_unix_ts(job.last_active_at)
@@ -319,7 +319,7 @@ class TestFieldScopedLifecycleSaves:
 
     @pytest.mark.parametrize("method", ["touch", "revive"])
     def test_touch_and_revive_still_score_correctly(self, scratch_room_id, method):
-        from bridge.utc import to_unix_ts
+        from utils.utc import to_unix_ts
 
         job = Job.mint(scratch_room_id, "check the deploy")
         getattr(job, method)()
@@ -984,7 +984,7 @@ class TestGuardedRepair:
         """
         from popoto.redis_db import POPOTO_REDIS_DB
 
-        from bridge.utc import to_unix_ts
+        from utils.utc import to_unix_ts
 
         job = Job.mint(scratch_room_id, "repair me")
         partition = _partition_key(scratch_room_id)

--- a/tests/unit/test_messenger.py
+++ b/tests/unit/test_messenger.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from bridge.utc import utc_now
+from utils.utc import utc_now
 
 # Direct import of messenger module to avoid sdk_client dependency
 messenger_path = Path(__file__).parent.parent.parent / "agent" / "messenger.py"

--- a/tests/unit/test_migrations.py
+++ b/tests/unit/test_migrations.py
@@ -22,7 +22,6 @@ from popoto import SortedField
 from popoto.redis_db import POPOTO_REDIS_DB
 
 from agent.pipeline_ledger import PipelineLedger
-from bridge.utc import to_unix_ts
 from models.agent_session import AgentSession
 from models.job import Job
 from models.session_lifecycle import touch_issue_lock
@@ -31,6 +30,7 @@ from scripts.update.migrations import (
     _migrate_backfill_job_last_active_scores,
     _migrate_backfill_pipeline_ledger,
 )
+from utils.utc import to_unix_ts
 
 _TEST_REPO = "test-owner/test-repo"
 

--- a/tests/unit/test_public_api_contract.py
+++ b/tests/unit/test_public_api_contract.py
@@ -54,7 +54,7 @@ PUBLIC_API_SIGNATURES: dict[tuple[str, str], str] = {
         "(change_summary: 'str', top_n: 'int' = 20, repo_root: 'Path | None' = None) "
         "-> 'tuple[list[AffectedCode], ImpactFinderMeta]'"
     ),
-    ("bridge.utc", "utc_now"): "() -> datetime.datetime",
+    ("utils.utc", "utc_now"): "() -> datetime.datetime",
 }
 
 

--- a/tests/unit/test_reconciler.py
+++ b/tests/unit/test_reconciler.py
@@ -1129,7 +1129,7 @@ class TestPerChatCursorCutoff:
     async def test_future_cursor_never_shrinks_the_window(self):
         """Clock-skew guard: a cursor in the FUTURE must not shrink the window
         below the rolling floor (min(), never max()), and the cutoff math can
-        never go negative/absurd -- pinned via bridge.utc.to_unix_ts."""
+        never go negative/absurd -- pinned via utils.utc.to_unix_ts."""
         from utils.utc import to_unix_ts
 
         dialog = _make_dialog("Test Group", entity_id=706)

--- a/tests/unit/test_reconciler.py
+++ b/tests/unit/test_reconciler.py
@@ -1130,7 +1130,7 @@ class TestPerChatCursorCutoff:
         """Clock-skew guard: a cursor in the FUTURE must not shrink the window
         below the rolling floor (min(), never max()), and the cutoff math can
         never go negative/absurd -- pinned via bridge.utc.to_unix_ts."""
-        from bridge.utc import to_unix_ts
+        from utils.utc import to_unix_ts
 
         dialog = _make_dialog("Test Group", entity_id=706)
         recent_msg = _make_message(5001, text="inside rolling window", minutes_ago=5)

--- a/tests/unit/test_session_archive.py
+++ b/tests/unit/test_session_archive.py
@@ -26,8 +26,8 @@ from agent.constants import (
     SESSION_ARCHIVE_BUSY_TIMEOUT_MS,
     SESSION_ARCHIVE_ONLOOP_BUSY_TIMEOUT_MS,
 )
-from bridge.utc import to_unix_ts
 from models.agent_session import AgentSession
+from utils.utc import to_unix_ts
 
 pytestmark = pytest.mark.usefixtures("redis_test_db")
 

--- a/tests/unit/test_session_stall_classifier.py
+++ b/tests/unit/test_session_stall_classifier.py
@@ -294,8 +294,8 @@ class TestElapsedTimezoneGuard:
 
     def test_unparseable_timestamp_returns_healthy_not_stalled(self):
         # Patch to_unix_ts to always return None (simulates unparseable timestamp).
-        # _classify does `from bridge.utc import to_unix_ts` inside its body,
-        # so we patch `bridge.utc.to_unix_ts` which is what gets imported.
+        # _classify does `from utils.utc import to_unix_ts` inside its body,
+        # so we patch `utils.utc.to_unix_ts` which is what gets imported.
         session = _session(status="running", created_at="not-a-date")
         with patch("utils.utc.to_unix_ts", return_value=None):
             verdict = classify_session_stall([], session=session)

--- a/tests/unit/test_session_stall_classifier.py
+++ b/tests/unit/test_session_stall_classifier.py
@@ -297,7 +297,7 @@ class TestElapsedTimezoneGuard:
         # _classify does `from bridge.utc import to_unix_ts` inside its body,
         # so we patch `bridge.utc.to_unix_ts` which is what gets imported.
         session = _session(status="running", created_at="not-a-date")
-        with patch("bridge.utc.to_unix_ts", return_value=None):
+        with patch("utils.utc.to_unix_ts", return_value=None):
             verdict = classify_session_stall([], session=session)
         # With ts=None the never-started branch is skipped → falls through → healthy
         assert verdict.level == "healthy"

--- a/tests/unit/test_utc.py
+++ b/tests/unit/test_utc.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 
 import pytest
 
-from bridge.utc import to_local, to_unix_ts, utc_iso, utc_now
+from utils.utc import to_local, to_unix_ts, utc_iso, utc_now
 
 
 class TestUtcNow:

--- a/tests/unit/test_utc.py
+++ b/tests/unit/test_utc.py
@@ -1,4 +1,4 @@
-"""Tests for bridge.utc utility module."""
+"""Tests for utils.utc utility module."""
 
 from datetime import UTC, datetime
 

--- a/tests/unit/test_valor_telegram.py
+++ b/tests/unit/test_valor_telegram.py
@@ -10,8 +10,8 @@ import pytest
 
 # Import the module under test
 sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent.parent))
-from bridge.utc import utc_now
 from tools.valor_telegram import format_timestamp, parse_since, resolve_chat
+from utils.utc import utc_now
 
 
 @pytest.fixture(autouse=True)

--- a/tools/agent_session_scheduler.py
+++ b/tools/agent_session_scheduler.py
@@ -42,7 +42,7 @@ from models.session_lifecycle import NON_TERMINAL_STATUSES
 def _to_ts(val):
     """Convert datetime or float to Unix timestamp.
 
-    Delegates to ``bridge.utc.to_unix_ts`` which treats naive datetimes as UTC
+    Delegates to ``utils.utc.to_unix_ts`` which treats naive datetimes as UTC
     (Popoto strips tzinfo on save). Directly calling ``val.timestamp()`` on a
     naive datetime would interpret it as machine-local time and silently offset
     every derived age by the machine's UTC offset.

--- a/tools/agent_session_scheduler.py
+++ b/tools/agent_session_scheduler.py
@@ -47,7 +47,7 @@ def _to_ts(val):
     naive datetime would interpret it as machine-local time and silently offset
     every derived age by the machine's UTC offset.
     """
-    from bridge.utc import to_unix_ts
+    from utils.utc import to_unix_ts
 
     return to_unix_ts(val)
 

--- a/tools/image_gen/__init__.py
+++ b/tools/image_gen/__init__.py
@@ -18,13 +18,13 @@ from typing import Literal
 
 import requests
 
-from bridge.utc import utc_now
 from config.models import (
     IMAGE_ASPECT_RATIOS,
     IMAGE_GEN_PROVIDERS,
     OPENAI_IMAGE_SIZES,
     OPENROUTER_URL,
 )
+from utils.utc import utc_now
 
 
 class ImageGenError(Exception):

--- a/tools/selfie/__init__.py
+++ b/tools/selfie/__init__.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 from openai import OpenAI
 
-from bridge.utc import utc_now
+from utils.utc import utc_now
 
 load_dotenv()
 load_dotenv(Path.home() / "Desktop" / "Valor" / ".env")  # symlink target — no-op

--- a/tools/sms_reader/__init__.py
+++ b/tools/sms_reader/__init__.py
@@ -31,7 +31,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-from bridge.utc import utc_now
+from utils.utc import utc_now
 
 # macOS Messages database path
 MESSAGES_DB_PATH = Path.home() / "Library" / "Messages" / "chat.db"

--- a/tools/telegram_history/__init__.py
+++ b/tools/telegram_history/__init__.py
@@ -327,7 +327,7 @@ def _ts_to_iso(ts: float | None) -> str | None:
 def _parse_ts(ts_val) -> float:
     """Parse a timestamp value to unix float.
 
-    Uses ``bridge.utc.to_unix_ts`` to treat naive datetimes as UTC so age
+    Uses ``utils.utc.to_unix_ts`` to treat naive datetimes as UTC so age
     calculations stay correct on non-UTC hosts.
     """
     from utils.utc import to_unix_ts

--- a/tools/telegram_history/__init__.py
+++ b/tools/telegram_history/__init__.py
@@ -330,7 +330,7 @@ def _parse_ts(ts_val) -> float:
     Uses ``bridge.utc.to_unix_ts`` to treat naive datetimes as UTC so age
     calculations stay correct on non-UTC hosts.
     """
-    from bridge.utc import to_unix_ts
+    from utils.utc import to_unix_ts
 
     if ts_val is None:
         return time.time()

--- a/tools/test_scheduler/__init__.py
+++ b/tools/test_scheduler/__init__.py
@@ -12,7 +12,7 @@ import uuid
 from pathlib import Path
 from typing import Literal
 
-from bridge.utc import utc_iso
+from utils.utc import utc_iso
 
 # In-memory session storage (for simplicity)
 _sessions: dict[str, dict] = {}

--- a/tools/valor_calendar.py
+++ b/tools/valor_calendar.py
@@ -22,8 +22,8 @@ import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from bridge.utc import utc_now
 from config.paths import DATA_DIR
+from utils.utc import utc_now
 
 # Calendar config lives in ~/Desktop/Valor/, queue/cache in data/
 CALENDAR_CONFIG_PATH = Path.home() / "Desktop" / "Valor" / "calendar_config.json"

--- a/tools/valor_session.py
+++ b/tools/valor_session.py
@@ -599,8 +599,8 @@ def create_session(
         import os
 
         from agent.agent_session_queue import _push_agent_session
-        from bridge.utc import utc_now
         from config.enums import SessionType
+        from utils.utc import utc_now
 
         # ------------------------------------------------------------------
         # Stopgap (#1633): refuse parent-attached session creation here too.

--- a/tools/valor_telegram.py
+++ b/tools/valor_telegram.py
@@ -24,7 +24,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-from bridge.utc import utc_now
+from utils.utc import utc_now
 
 logger = logging.getLogger(__name__)
 

--- a/ui/app.py
+++ b/ui/app.py
@@ -23,7 +23,7 @@ from jinja2 import Environment
 
 from agent.constants import HEARTBEAT_STALENESS_THRESHOLD_S, WORKER_DOWN_THRESHOLD_S
 from agent.session_pickup import _truthy  # canonical untyped-Popoto-bool coercion (#2439)
-from bridge.utc import utc_now
+from utils.utc import utc_now
 
 logger = logging.getLogger(__name__)
 

--- a/utils/utc.py
+++ b/utils/utc.py
@@ -4,8 +4,11 @@ All timestamps in the system should be tz-aware UTC. Use these utilities
 instead of datetime.now() to ensure consistency across logs, storage,
 and cross-component correlation.
 
-Display conversion to local time happens only at the presentation boundary
-(e.g., Telegram messages to humans).
+Display conversion to local time happens only at the presentation boundary.
+
+This module is dependency-free by contract: it imports nothing outside the
+standard library. Standalone ``tools/`` packages import it, and any first-party
+import added here would chain them back to the harness.
 """
 
 from datetime import UTC, datetime


### PR DESCRIPTION
## Summary

Moves `bridge/utc.py` to `utils/utc.py` and rewrites every reference in the same change. The four functions (`utc_now`, `to_local`, `utc_iso`, `to_unix_ts`) are pure and stdlib-only; they sat in the Telegram I/O package for historical reasons, which forced standalone CLI tools to import the harness just to get the current time.

`tools/selfie`, `tools/sms_reader`, and `tools/test_scheduler` each had exactly **one** cross-package import in their whole source tree, and it was `from bridge.utc import ...`. All three now have **zero** harness imports, and a new guard test keeps them that way.

Closes #2867

## Reading this diff

**It is a rename, not a delete-plus-add.** `git diff --find-renames main...HEAD --stat -- bridge/utc.py utils/utc.py` reports `{bridge => utils}/utc.py`. Diffing `git show main:bridge/utc.py` against `utils/utc.py` shows **only the module docstring differs** — all four function bodies and signatures are byte-identical. The review budget belongs on the 62 call sites and the guard test, not on re-reading four unchanged functions.

## The completeness gate

The single proof for the whole change:

```
git grep -lE 'bridge[./]utc|from bridge import utc' -- '*.py' | wc -l   =>  0
```

It was **57** at the baseline. The gate is deliberately wider than any rewrite rule: the `bridge[./]utc` character class matches both the dotted `bridge.utc` and the path `bridge/utc.py` spellings. A dotted-only rule would have left three sites behind (`models/agent_session.py` x2, `tests/integration/test_updated_at_heal.py`).

Each of the five commits carries its gate reading, so the ledger of remaining work is a measured number in git history rather than a claim:

| Checkpoint | Contents | Gate |
|---|---|---|
| baseline | — | 57 |
| 1 | `git mv` + docstring + 59 import rewrites + ruff | **14** |
| 2 | the three executable non-import sites | **13** |
| 3 | the 15 prose (comment/docstring) sites | **0** |
| 4 | the boundary guard test | 0 |
| 5 | docs and generated graph | 0 |

Checkpoints 1 and 2 are deliberately **one commit**. Splitting them would leave a commit where all 50 import-bearing files raise `ModuleNotFoundError`; git still records the rename because it detects renames from content similarity across the whole commit.

## No shim — on purpose

`bridge/utc.py` is deleted outright. No re-export, no alias, no deprecation window. This is what makes a missed `patch("bridge.utc...")` raise `ModuleNotFoundError` instead of silently patching a module the code under test never reads and reporting green. That failure mode is the sharpest risk in a rename like this, and the hard move converts it from silent to loud.

## Added scope, flagged for review

Two things here go beyond the issue's acceptance criteria and should be approved knowingly, not waved through as inherited requirements:

1. **The boundary guard** (`TestStandaloneToolPackageBoundaries`). The issue asserts a *state*; it does not ask for a test enforcing it. `utils/__init__.py` is empty today by accident, not by contract — one `from models import ...` added there later would silently re-couple all three freed packages with nothing failing.

2. **`config` in the guard's forbidden set.** The issue's list is `bridge/agent/worker/models/monitoring/reflections`; this adds `analytics` and `ui` for symmetry and **`config`** on measured evidence. Importing any `config` submodule executes `config/__init__.py`, which pulls **214 modules in 94 ms** against `utils`'s 2 in 1 ms — that measurement is the entire reason the destination is `utils/` and not `config/`. A guard that forbade `from models import ...` while permitting `from config.paths import ...` would wave through precisely the coupling this change exists to remove. It costs no allowlist: all three packages' only cross-package import today is the one being rewritten.

A reviewer who wants the guard to match the issue's list exactly should say so — it is a deliberate, cheap, reversible addition.

## Verification

Every row of the plan's verification table was run, and every guard was mutation-checked rather than merely observed passing.

| Check | Result |
|---|---|
| `test -f utils/utc.py` | exit 0 |
| `test -e bridge/utc.py` | exit 1 (gone) |
| Completeness gate over `*.py` | **0** |
| Standalone tools carry no harness imports | **0** |
| Moved module imports no first-party package | tracked, **0** |
| `docs/features/*.md` + `site/assets/graph.js` cite old path | **0** |
| `tests/unit/test_utc.py` collected count | **20** (unchanged from baseline) |
| Guard class actually collected | exit **0** (not 5 / "no tests ran") |
| Targeted tests | 73 passed |
| Non-unit tests (integration + performance) | 29 passed, 4 skipped |
| `ruff check .` / `ruff format --check .` | exit 0 / exit 0 |

**Five mutation checks, five red runs** — a test that reaches no code passes for the wrong reason, so each guard was measured separately:

- patch-bite: flipping the `to_unix_ts` mock's `return_value` flips the test red, proving the patch reaches the code under test
- harness import into `tools/selfie/__init__.py` → red, naming file, line, module
- `from config.paths import ...` into `tools/sms_reader/__init__.py` → red (proves the added `config` entry is wired in, not just written down)
- harness import under `tools/test_scheduler/tests/` → red (proves the walk recurses into the packages' own `tests/`)
- any import into `utils/__init__.py` → red

### Full suite

`scripts/pytest-clean.sh` (no path arg): **29 failed, 15171 passed, 20 skipped** in 21m.

All 29 classified **not regressions**:

- Zero overlap between the 17 failing files and this branch's 62 changed files (`comm -12` is empty).
- Zero occurrences of `bridge.utc`, `utils.utc`, or a related `ModuleNotFoundError` anywhere in the run log.
- **27 of 29 reproduce on `main`** — re-running the same node ids in the main checkout gives `27 failed, 2 passed`. This is the known rotating failure set (#2628).
- **2 of 29 are parallel test-DB contention**, not regressions: `test_pdf_dropped_into_vault_produces_sidecar` and `test_missing_run_id_self_heals_on_free_lock`. Run serially on this branch they pass (`5 passed`). Same code, different concurrency, different result.

## Out of scope, deliberately

- Detaching `tools/telegram_history` (17 `models.*` imports) or `tools/image_gen` from `config.models` — the issue names these as not freed by this change.
- Collapsing the three inline `to_unix_ts` duplicates. #777 left them alone on purpose.
- Reorganizing `utils/` or introducing a `kernel/` package.
- Regenerating `site/assets/graph.js` wholesale — the 31 path strings were replaced in place, which is what a regeneration would produce for those nodes.

One incidental correction rode along: `docs/features/utc-timestamps.md` cited `agent/session_health._to_ts`, a function that does not exist and per `git log -S` never did. The real helper is `_ts` at line 398. That stale line is the one this change was already editing, and it is where the plan's own prior-art error was inherited from. `tools/agent_session_scheduler._to_ts` on the same line is real and was left alone.

## Post-merge

Five `bridge/` modules changed import paths, so the running services are on stale code until cycled:

```bash
./scripts/valor-service.sh restart
tail -5 logs/bridge.log        # expect "Connected to Telegram"
```

Then re-run the completeness gate on `main` — it is the only check that catches an importer merged from a concurrent PR between this branch's last rebase and the merge.
