### PR TITLE
Fix two unit tests broken by the #2803 run-identity anchor

### DIFF
--- a/docs/plans/fix-red-main-unit-tests.md
+++ b/docs/plans/fix-red-main-unit-tests.md
@@ -202,12 +202,12 @@ No agent integration required — this is a test-only change. No new CLI entry p
 
 ## Success Criteria
 
-- [ ] `tests/unit/test_sdlc_dispatch.py::TestDispatchRecordLease::test_lease_lost_between_peek_and_write_refuses` passes.
-- [ ] `tests/unit/test_sdlc_meta_set.py::TestMetaSetWriteMeta::test_pr_number_writes_ledger_field_not_meta_key` passes.
-- [ ] The two tests still assert their original intent (write refused / no `_pr_number` meta key).
-- [ ] No production code changed.
-- [ ] Tests pass (`/do-test`).
-- [ ] Documentation updated (`/do-docs`) — no changes needed.
+- [x] `tests/unit/test_sdlc_dispatch.py::TestDispatchRecordLease::test_lease_lost_between_peek_and_write_refuses` passes.
+- [x] `tests/unit/test_sdlc_meta_set.py::TestMetaSetWriteMeta::test_pr_number_writes_ledger_field_not_meta_key` passes.
+- [x] The two tests still assert their original intent (write refused / no `_pr_number` meta key).
+- [x] No production code changed.
+- [x] Tests pass (`/do-test`).
+- [x] Documentation updated (`/do-docs`) — no changes needed.
 
 ## Team Orchestration
 

--- a/docs/plans/fix-red-main-unit-tests.md
+++ b/docs/plans/fix-red-main-unit-tests.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: docs_complete
 type: bug
 appetite: Small
 owner: valor

--- a/tests/unit/test_sdlc_dispatch.py
+++ b/tests/unit/test_sdlc_dispatch.py
@@ -126,12 +126,17 @@ class TestDispatchRecordLease:
         with (
             patch("models.session_lifecycle.touch_issue_lock", mock_touch),
             patch("agent.pipeline_ledger.PipelineLedger.get_or_create") as mock_get_or_create,
+            patch("tools.sdlc_dispatch.record_dispatch_for_ledger") as mock_record_dispatch,
         ):
             result = sdlc_dispatch._cli_record(self._args())
 
         assert result["ok"] is False
         assert result["reason"] == "ISSUE_LOCKED"
-        mock_get_or_create.assert_not_called()
+        # The run-identity anchor's single get_or_create is legitimate; a second
+        # call would mean the write path ran. The dispatch write is refused, so
+        # record_dispatch_for_ledger is never called.
+        assert mock_get_or_create.call_count == 1
+        mock_record_dispatch.assert_not_called()
 
     def test_run_id_annotated_onto_dispatch_history(self):
         from tools import sdlc_dispatch

--- a/tests/unit/test_sdlc_meta_set.py
+++ b/tests/unit/test_sdlc_meta_set.py
@@ -254,18 +254,22 @@ class TestMetaSetWriteMeta:
     def test_pr_number_writes_ledger_field_not_meta_key(self):
         """#2003 T1.7 / #2012: `--key pr_number` writes the PipelineLedger.pr_number
         FIELD. Single-writer contract: no `_pr_number` meta key is ever
-        written to stage_states_json — update_stage_states must not be
-        called at all.
+        written to stage_states_json; the run-identity anchor may write
+        `_run_identities`.
         """
         from tools.sdlc_meta_set import write_meta
 
         mock_ledger = MagicMock()
         mock_ledger.pr_number = None
+        mock_ledger.stage_states_json = {}  # real dict, not a MagicMock
+
+        def _apply(_, update_fn, **kwargs):
+            mock_ledger.stage_states_json = update_fn(mock_ledger.stage_states_json) or {}
 
         with (
             patch("models.session_lifecycle.touch_issue_lock", return_value=_lock_result()),
             patch("agent.pipeline_ledger.PipelineLedger.get_or_create", return_value=mock_ledger),
-            patch("tools.stage_states_helpers.update_stage_states") as update_mock,
+            patch("tools.stage_states_helpers.update_stage_states", side_effect=_apply),
         ):
             result = write_meta(key="pr_number", value="42", issue_number=1, run_id="run-test")
 
@@ -273,7 +277,7 @@ class TestMetaSetWriteMeta:
         assert mock_ledger.pr_number == 42
         assert isinstance(mock_ledger.pr_number, int)
         mock_ledger.save.assert_called_once()
-        update_mock.assert_not_called()
+        assert "_pr_number" not in mock_ledger.stage_states_json
 
     def test_pr_number_save_failure_returns_empty_dict(self):
         """Field-write path fails soft: ledger.save() raising returns {}."""


### PR DESCRIPTION
Closes #2904

## Summary
`main` was red at `0f261bf0d`: three unit tests failed. Two are genuine, unowned defects sharing a single root cause — the #2803 run-identity anchor's side-effect calls on the confirmed-owner path inside `resolve_ledger_lease`. The third is owned by #2805 (out of scope).

The production code is correct: the dispatch write IS refused and `pr_number` IS field-backed. Only the two tests' strict `assert_not_called()` assertions were stale.

## Changes
- **`test_lease_lost_between_peek_and_write_refuses`**: replaced the stale `mock_get_or_create.assert_not_called()` with `assert mock_get_or_create.call_count == 1` (the anchor's single `get_or_create` is legitimate) and added an additive `record_dispatch_for_ledger.assert_not_called()` — the load-bearing guard that the dispatch write is refused.
- **`test_pr_number_writes_ledger_field_not_meta_key`**: replaced the bare `update_stage_states` patch with a real `side_effect` that applies the updater to a shared real dict, then asserts `"_pr_number" not in mock_ledger.stage_states_json`. Amended the docstring to the anchor-aware contract.

## Verification
- Both tests pass individually.
- No production code changed (`git diff --stat` shows only the two test files).
- `ruff check` and `ruff format --check` clean on both files.

## Note
The plan's Verification table "No production code changed" check (`git diff --stat -- tools/ agent/ models/` with expected "output does not contain tools/") reports a false negative: the evaluator's empty-stdout gate returns False on empty output, so the check can never pass when there is genuinely no production change. This is the NIT the plan's own Critique Results flagged. The actual intent is verified manually.