### PR TITLE
fix(docs): drop deleted granite test-file references from valor-cli-wrapper.md

### DIFF
--- a/docs/features/valor-cli-wrapper.md
+++ b/docs/features/valor-cli-wrapper.md
@@ -277,9 +277,6 @@ current test coverage.
 
 | Scope | Result |
 |-------|--------|
-| `tests/unit/granite_container/` (BridgeAdapter, PTYPool, container, classifier, persona priming) | 143 passed, 5 skipped |
-| `tests/integration/test_granite_container_loop.py` + `test_granite_pty_production.py` | 3 passed, 1 skipped |
-| `tests/unit/test_session_executor_granite.py` | green |
 | `tests/unit/test_agent_session_queue.py` | green |
 | Wider unit suite | 36 pre-existing failures (memory model, work request classifier, media handling) — confirmed on main, out of scope for this branch |
 

--- a/docs/features/valor-cli-wrapper.md
+++ b/docs/features/valor-cli-wrapper.md
@@ -271,9 +271,9 @@ tests.
 ## Tests Run on the Branch
 
 Historical record from this doc's originating PR (#1612), predating the
-granite-pty-teardown cutover (#1924) — the `granite_container` paths below no
-longer exist; see [Headless Session Runner](headless-session-runner.md) for
-current test coverage.
+granite-pty-teardown cutover (#1924) — the `granite_container` paths this
+section previously listed no longer exist; see [Headless Session
+Runner](headless-session-runner.md) for current test coverage.
 
 | Scope | Result |
 |-------|--------|


### PR DESCRIPTION
## Summary

Closes both #2864 and #2865 with one surgical doc fix.

`docs/features/valor-cli-wrapper.md`'s "## Tests Run on the Branch" section (a historical record from originating PR #1612, predating the granite-pty teardown #1924) still listed test files that no longer exist in the repo. Removed the three table rows naming deleted paths:

- `tests/unit/granite_container/` (BridgeAdapter, PTYPool, container, classifier, persona priming)
- `tests/integration/test_granite_container_loop.py` + `test_granite_pty_production.py`
- `tests/unit/test_session_executor_granite.py`

Rows naming still-existing files (`tests/unit/test_agent_session_queue.py`, wider unit suite) were kept. No history was rewritten and no test names were invented.

## Test plan

No test run needed — markdown-only change. Existence checks performed against the branch's own tree:

- `git ls-files tests/unit/granite_container/` → empty (deleted)
- `git ls-files tests/integration/test_granite_container_loop.py` → empty (deleted)
- `git ls-files tests/integration/test_granite_pty_production.py` → empty (deleted)
- `git ls-files tests/unit/test_session_executor_granite.py` → empty (deleted)
- `git ls-files tests/unit/test_agent_session_queue.py` → tracked (kept)
- `git diff --name-only` → only `docs/features/valor-cli-wrapper.md`
- grep for all four deleted path strings in the doc → no matches

Closes #2864
Closes #2865
