### PR TITLE
fix(docs): past-tense the granite PTY container in three feature docs

### DIFF
--- a/docs/features/email-bridge.md
+++ b/docs/features/email-bridge.md
@@ -125,16 +125,17 @@ Without **either** path, a session with `transport=email` would still write to `
 
 ### Persona resolution for email-spawned sessions
 
-As of issue #1692, persona is delivered to the granite PTY container via prime
-commands (`.claude/commands/granite/prime-*-role.md`), not via
+Persona is delivered via the role prime commands
+(`.claude/commands/roles/prime-{pm,dev,teammate}-role.md`), not via
 `--append-system-prompt`. The `compose_system_prompt` / `load_persona_prompt`
-path has been retired from the granite execution path.
+path is not part of the session-execution path.
 
-**Email sessions in the granite container:**
+**Email sessions:**
 
 - Email-spawned sessions become `SessionType.TEAMMATE` sessions.
-- The granite container primes the PM with `/granite:prime-teammate-role` (if
-  `session_type == TEAMMATE`) or `/granite:prime-pm-role` (if `ENG`).
+- The headless session runner primes the session with
+  `/roles:prime-teammate-role` (if `session_type == TEAMMATE`) or
+  `/roles:prime-pm-role` (if `ENG`).
 - The `_resolve_compose_args` resolver in `session_executor.py` is preserved to
   derive the `(persona, access_level)` tuple from `project.email.persona`; this
   will be used for prime-command selection in a future issue.

--- a/docs/features/harness-abstraction.md
+++ b/docs/features/harness-abstraction.md
@@ -98,7 +98,7 @@ Sentry token resolution cascade: `SENTRY_PERSONAL_TOKEN` env var → `SENTRY_AUT
 
 ### Engineer persona injection — `--append-system-prompt` (issue #1148)
 
-> **Granite PTY sessions (all bridge-originated sessions) no longer use this path.** As of issue #1692, persona is delivered to the granite PTY container via prime commands (`.claude/commands/granite/prime-*-role.md`) at PTY startup — `--append-system-prompt` is not set at all. The description below applies to the headless `claude -p` path only (direct `get_response_via_harness()` callers, drafter turns, non-bridge tool invocations).
+> **Runner-driven sessions (all bridge-originated sessions) do not use this path.** Persona is delivered via the role prime commands (`.claude/commands/roles/prime-{pm,dev,teammate}-role.md`) at turn 1 — `--append-system-prompt` is not set at all. The description below applies to the headless `claude -p` path only (direct `get_response_via_harness()` callers, drafter turns, non-bridge tool invocations).
 
 Eng sessions append the engineer persona to `claude -p`'s default system prompt via `--append-system-prompt`:
 

--- a/docs/features/sdlc-parallel-execution.md
+++ b/docs/features/sdlc-parallel-execution.md
@@ -11,6 +11,6 @@ The SDLC parallel execution feature provided two mechanisms:
 
 ## Why it was removed
 
-The PM/Dev session split that this feature was built on (PM orchestrates, Dev executes, one Dev session per stage) has been collapsed into a single Eng session type. With a unified Eng session handling both orchestration and execution through the granite PTY container, the multi-dev fan-out machinery (`sdlc-decompose`, sub-slug session creation, merge-integration sessions) no longer has a substrate to run on.
+The PM/Dev session split that this feature was built on (PM orchestrates, Dev executes, one Dev session per stage) has been collapsed into a single Eng session type. With a unified Eng session handling both orchestration and execution, the multi-dev fan-out machinery (`sdlc-decompose`, sub-slug session creation, merge-integration sessions) no longer has a substrate to run on.
 
 The associated CLI entry point (`sdlc-decompose`) and supporting code have been deleted.


### PR DESCRIPTION
## Summary

Past-tense fix for the three `docs/features/` sites from [issue #2896](https://github.com/tomcounsell/ai/issues/2896)'s suggested-scope item 1 — the last present-tense descriptions of the granite PTY container (deleted with plan #1924; replaced outright by the headless `claude -p` session runner per `config/enums.py`'s `SessionType` docstring and `docs/features/headless-session-runner.md`):

- **`docs/features/email-bridge.md`** — "Persona resolution for email-spawned sessions": now states persona is delivered via the role prime commands (`.claude/commands/roles/prime-{pm,dev,teammate}-role.md`), that `compose_system_prompt` / `load_persona_prompt` is not part of the session-execution path, and that the headless session runner primes the session with `/roles:prime-teammate-role` / `/roles:prime-pm-role`.
- **`docs/features/harness-abstraction.md`** — the "Engineer persona injection" callout: "Runner-driven sessions (all bridge-originated sessions) do not use this path" — persona is delivered via the role prime commands at turn 1; `--append-system-prompt` is not set at all.
- **`docs/features/sdlc-parallel-execution.md`** — "Why it was removed": dropped "through the granite PTY container"; the unified Eng session handles both orchestration and execution, so the multi-dev fan-out machinery has no substrate to run on.

Per repo doctrine, each rewrite describes only the new status quo — no "formerly", no deletion narrative.

**Deliberately excluded** — the two code sites (`tools/valor_session.py:867` and `tests/unit/test_valor_session_cli.py:257`) remain untouched, gated on the human decision about the #1633 stopgap (issue #2896 documents why those are load-bearing context for a stopgap whose status is unsettled). This PR is therefore a partial fix.

## Test plan

Markdown-only change — no test run. `tests/unit/test_stale_reference_sweep.py` is unaffected: its granite tokens are path-based (`granite_interactive_tui_poc`, `tools/granite_loop`), and none of the prose changes introduce those tokens. Per issue #2896, an automated phrase sweep would be false comfort anyway (the phrase legitimately appears ~20 times); the fix was made and verified by reading each passage against the ground truth above.

Refs #2896
