### PR TITLE
fix(doctor): correct NUL-shebang comment's ValueError attribution

### DIFF
--- a/docs/plans/completed/doctor-console-script-interpreter-check.md
+++ b/docs/plans/completed/doctor-console-script-interpreter-check.md
@@ -1529,7 +1529,7 @@ new finding inside an existing check that the agent already knows how to run and
   | Remedy checkout reverted to `PROJECT_DIR` instead of the flagged shim's `match.parent.parent` | case 15b |
   | Terminal period dropped from the remedy sentence (`--all-extras Then re-run.`) | case 15b |
   | Multi-checkout remedy rendering collapsed to `where = checkouts[0]` | case 15c |
-  | NUL rejection dropped from the shebang-target guard (`ValueError` escapes both I/O handlers) | case 6c |
+  | NUL rejection dropped from the shebang-target guard (`ValueError` from `os.path.realpath` in the missing branch escapes both I/O handlers) | case 6c |
 
   The realpath rule is verified **here**, by mutation, and not by a source scan: the
   whole-file regex row an earlier draft carried matched the prohibition written in prose and

--- a/tools/doctor.py
+++ b/tools/doctor.py
@@ -190,9 +190,12 @@ def _shebang_interpreter(path: Path) -> str | None:
     if not rest:
         return None
     prog = rest.split()[0]
-    # An embedded NUL is rejected before `Path`, which raises `ValueError` (not
-    # `OSError`) on one -- the two handlers above would not catch it and the
-    # documented "never a crash" contract would break on a corrupt shim.
+    # An embedded NUL is rejected here rather than later: `Path` tolerates NUL
+    # at every step (`.exists()` returns `False`), so a NUL target slips
+    # through to `os.path.realpath` in `_classify_interpreter`'s missing
+    # branch, which raises `ValueError` (not `OSError`) -- neither of the two
+    # handlers above would catch it and the documented "never a crash"
+    # contract would break on a corrupt shim.
     if not prog.startswith("/") or "\0" in prog:
         return None
     if Path(prog).name in {"sh", "bash", "dash", "env"}:


### PR DESCRIPTION
## Summary

Comment-only follow-up to PR #2882's doctor console-script check (issue #2748). The NUL-shebang guard in `tools/doctor.py`'s `_shebang_interpreter` is correct and mutation-verified, but its comment misattributes the `ValueError`.

Measured on the pinned interpreter (3.14.6): `Path('/usr/bin/py\x00thon3')` constructs fine, `.name` returns the NUL-bearing name, and `.exists()` returns `False` — `Path` tolerates NUL at every step. The `ValueError` actually comes from `os.path.realpath` in `_classify_interpreter`'s `missing` branch, which a NUL target reaches precisely because `.exists()` returns `False`. The old wording likely described pre-3.13 pathlib behavior.

The rewritten comment keeps the guard-placement rationale (rejecting in `_shebang_interpreter` keeps the NUL from ever reaching `realpath`; `ValueError` is not caught by either the `OSError` or `UnicodeDecodeError` handler, so without the guard it escapes to `run_checks`' outer net) while attributing the exception correctly.

Two sites updated: the comment in `tools/doctor.py`, and the matching mutation-table row in `docs/plans/completed/doctor-console-script-interpreter-check.md` (row 25), which copied the same misattributed wording. `docs/features/local-doctor.md`'s "both" enumeration was left as-is per the issue's scope — it is non-exhaustive but not wrong, and the NUL case is a guard rejection rather than an I/O failure, so folding it into the fail-open paragraph would not be a one-line edit.

The diff contains no executable-line change.

## Test plan

- [x] `scripts/pytest-clean.sh tests/unit/test_doctor_console_scripts.py -n0` — 48 passed in 6.81s, including `test_case6c_nul_in_shebang_target_is_unverified_not_a_crash` (the mutation that pins this guard)
- [x] `uv run ruff check tools/doctor.py` — All checks passed!
- [x] `uv run ruff format --check tools/doctor.py` — 1 file already formatted

Closes #2903
