### PR TITLE
fix(merge-predicate): treat slash-bearing head-ref slug as unusable for the DOCS fallback

### DIFF
--- a/tests/unit/test_merge_predicate.py
+++ b/tests/unit/test_merge_predicate.py
@@ -633,3 +633,49 @@ def test_merge_predicate_head_sha_reader_import_stays_in_function():
             # Any occurrence must be indented (i.e. inside a function body).
             assert line != line.lstrip(), f"module-level tools import: {line!r}"
     assert not hasattr(mp, "head_sha_of_record")
+
+
+# ---------------------------------------------------------------------------
+# _derive_slug — the docs/features fallback's slug derivation (#2891)
+# ---------------------------------------------------------------------------
+#
+# A head ref that is not `session/`-prefixed keeps its prefix, so its slug
+# carries a `/` -- e.g. `fix/router-blocked-on-conflict` -- and the DOCS
+# fallback leg probes `docs/features/fix/router-blocked-on-conflict.md`, a
+# nested path that can never exist. The slug must degrade to "" for any
+# slash-bearing remainder so the leg emits the honest "no usable slug" refusal
+# instead of naming a specific absent file.
+
+
+def test_derive_slug_slash_bearing_non_session_head_ref_yields_no_slug():
+    """PR #2797's head ref: no slug, so the DOCS fallback refuses honestly."""
+    assert mp._derive_slug("fix/router-blocked-on-conflict") == ""
+
+
+def test_derive_slug_session_prefix_stripped():
+    """The session/ convention still yields the flat remainder as the slug."""
+    assert mp._derive_slug("session/foo-bar") == "foo-bar"
+
+
+def test_derive_slug_session_nested_remainder_yields_no_slug():
+    """A nested session branch (remainder still slash-bearing) is unusable too."""
+    assert mp._derive_slug("session/foo/bar") == ""
+
+
+def test_derive_slug_no_slug_refs():
+    """main/master/HEAD/empty/None can never be a usable slug."""
+    for head_ref in ("main", "master", "HEAD", "", None):
+        assert mp._derive_slug(head_ref) == ""
+
+
+def test_docs_stage_slash_bearing_head_ref_emits_honest_no_slug_refusal(monkeypatch):
+    """Regression pin for #2891: a non-session/ head ref must refuse with the
+    generic "no usable slug" message, never probe a nested docs/features path."""
+    monkeypatch.setattr(mp, "_run_stage_query", lambda issue, root: {"stages": {"DOCS": "ready"}})
+    failed: list[str] = []
+    notes: list[str] = []
+    mp._check_docs_stage(990033, "fix/router-blocked-on-conflict", REPO_ROOT, failed, notes)
+    assert len(failed) == 1
+    assert "no usable slug for the docs/features fallback" in failed[0]
+    assert "docs/features/fix/router-blocked-on-conflict.md absent" not in failed[0]
+    assert notes == []

--- a/tools/merge_predicate.py
+++ b/tools/merge_predicate.py
@@ -307,9 +307,15 @@ def _extract_issue_number(body: str | None) -> int | None:
 
 
 def _derive_slug(head_ref: str) -> str:
-    """Slug from a PR head ref: strip ``session/``; main/master/HEAD/empty → no slug."""
+    """Slug from a PR head ref: strip ``session/``; main/master/HEAD/empty → no slug.
+
+    A slug still containing ``/`` (any non-``session/`` prefixed head ref,
+    e.g. ``fix/router-blocked-on-conflict``) is likewise unusable -- the
+    docs/features fallback would otherwise probe a nested path that can never
+    exist. See #2891.
+    """
     slug = (head_ref or "").removeprefix("session/")
-    if slug in _NO_SLUG_REFS:
+    if slug in _NO_SLUG_REFS or "/" in slug:
         return ""
     return slug
 


### PR DESCRIPTION
## Summary

**Defect:** `tools/merge_predicate.py::_derive_slug` stripped only a `session/` prefix. Any other head-ref prefix survived into the slug, so for a head ref like `fix/router-blocked-on-conflict` the DOCS fallback leg probed `docs/features/fix/router-blocked-on-conflict.md` — a nested path that can never exist — and refused with a misleading message naming that specific absent file, which reads as "write this file" when the honest answer is that the fallback cannot resolve the ref to a slug at all.

**Minimal fix:** treat a slug that still contains `/` as no usable slug (`or "/" in slug` on the `_NO_SLUG_REFS` check). The DOCS fallback leg now degrades to the existing honest refusal: `DOCS marker not authoritative (status=...) and no usable slug for the docs/features fallback`.

**Out of scope (explicitly, per #2891):** whether the docs/features fallback should exist at all, given the DOCS marker is the real signal, remains an open design question. No derivation from a branch name can find docs whose filename is chosen independently of the branch (PR #2797's docs landed at `docs/features/sdlc-router-oscillation-guard.md`). This PR only makes the fallback say what it cannot do instead of asserting a specific absent path.

## Test plan

- `scripts/pytest-clean.sh tests/unit/test_merge_predicate.py -n0` — **34 passed** (5 new tests: slash-bearing non-session ref → no slug; `session/foo-bar` → `foo-bar`; nested `session/foo/bar` → no slug; `main`/`master`/`HEAD`/empty/None → no slug; DOCS leg emits the honest no-slug refusal and never probes a nested path).
- `uv run ruff check tools/merge_predicate.py tests/unit/test_merge_predicate.py` — **All checks passed!**
- `uv run ruff format --check tools/merge_predicate.py tests/unit/test_merge_predicate.py` — **2 files already formatted**.

Closes #2891
