### PR TITLE
fix(gh): scope issue-view readers with --repo in migrate_completed_plan and agent_session_scheduler

### DIFF
--- a/scripts/migrate_completed_plan.py
+++ b/scripts/migrate_completed_plan.py
@@ -29,6 +29,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from tools._sdlc_utils import _resolve_target_repo_fallback
+
 
 def extract_tracking_issue(plan_text: str) -> str | None:
     """Extract tracking issue URL from plan frontmatter.
@@ -360,10 +362,27 @@ def find_plan_by_issue(issue_number: str, plans_dir: Path = Path("docs/plans")) 
 
 
 def _gh_issue_state(issue_number: str) -> str:
-    """Look up a GitHub issue's state via gh. Returns 'unknown' on any failure."""
+    """Look up a GitHub issue's state via gh. Returns 'unknown' on any failure.
+
+    Scoped with ``--repo``: a bare ``gh issue view`` resolves GH_REPO from the
+    environment before cwd, so under a foreign GH_REPO (or from the wrong
+    checkout) it would answer about a different repository's issue #N and
+    exit 0 (issue #2889). The resolved slug mirrors
+    ``tools/sdlc_stage_query.py``'s ladder (GH_REPO env first, else
+    ``gh repo view --json nameWithOwner`` from the working-tree root).
+    """
     try:
+        repo = _resolve_target_repo_fallback()
         result = subprocess.run(
-            ["gh", "issue", "view", str(issue_number), "--json", "state"],
+            [
+                "gh",
+                "issue",
+                "view",
+                str(issue_number),
+                *(["--repo", repo] if repo else []),
+                "--json",
+                "state",
+            ],
             capture_output=True,
             text=True,
             timeout=30,

--- a/tests/unit/test_agent_session_scheduler_persona.py
+++ b/tests/unit/test_agent_session_scheduler_persona.py
@@ -58,3 +58,58 @@ class TestPersonaGate:
             result = _check_persona_permission("schedule")
             assert result is not None
             assert result["status"] == "error"
+
+
+class TestValidateIssueRepoScoping:
+    """Issue #2889: `_validate_issue` must scope `gh issue view` with --repo.
+
+    `_validate_issue` gates whether an autonomous session is scheduled on an
+    issue, so a wrong-repo lookup (bare ``gh issue view`` under a foreign
+    GH_REPO, which answers about the wrong repository and exits 0) could
+    schedule unattended work against the wrong repository. The argv must
+    carry ``--repo <resolved-slug>`` when a repo resolves; the fail-soft
+    contract (returns None on any failure) is preserved.
+    """
+
+    def test_argv_scoped_from_gh_repo_env(self, monkeypatch):
+        import tools.agent_session_scheduler as sched
+
+        captured: dict = {}
+
+        class FakeResult:
+            returncode = 0
+            stdout = (
+                '{"title": "T", "state": "open", "body": "B", '
+                '"url": "https://github.com/tomcounsell/ai/issues/7"}'
+            )
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = argv
+            return FakeResult()
+
+        monkeypatch.setenv("GH_REPO", "tomcounsell/ai")
+        monkeypatch.setattr(sched.subprocess, "run", fake_run)
+        result = sched._validate_issue(7)
+        assert result is not None
+        assert result["state"] == "open"
+        assert captured["argv"] == [
+            "gh",
+            "issue",
+            "view",
+            "7",
+            "--repo",
+            "tomcounsell/ai",
+            "--json",
+            "title,state,body,url",
+        ]
+
+    def test_fail_soft_on_gh_failure(self, monkeypatch):
+        """Any gh failure returns None -- the scheduler gate fails open."""
+        import tools.agent_session_scheduler as sched
+
+        def fake_run(argv, **kwargs):
+            raise OSError("gh missing")
+
+        monkeypatch.setenv("GH_REPO", "tomcounsell/ai")
+        monkeypatch.setattr(sched.subprocess, "run", fake_run)
+        assert sched._validate_issue(7) is None

--- a/tests/unit/test_migrate_completed_plan.py
+++ b/tests/unit/test_migrate_completed_plan.py
@@ -432,3 +432,108 @@ class TestRunIssueEvidenceGate:
         gate_calls = []
         monkeypatch.setattr(mcp, "_gh_issue_state", lambda n: gate_calls.append(n) or "closed")
         assert mcp.run_issue("999", apply=True) == 2
+
+
+class TestGhIssueStateRepoScoping:
+    """Issue #2889: `_gh_issue_state` must scope `gh issue view` with --repo.
+
+    A bare ``gh issue view N`` resolves GH_REPO from the environment before
+    cwd, so under a foreign GH_REPO it answers about a *different*
+    repository's issue #N and exits 0. The argv must carry
+    ``--repo <resolved-slug>`` when a repo resolves (mirroring the
+    tools/sdlc_stage_query.py ladder: GH_REPO env first, else
+    ``gh repo view --json nameWithOwner`` from the working-tree root); when
+    nothing resolves, the argv degrades to the prior unscoped shape and the
+    ``"unknown"``-on-failure contract is preserved.
+    """
+
+    def test_argv_scoped_from_gh_repo_env(self, monkeypatch):
+        import scripts.migrate_completed_plan as mcp
+
+        captured: dict = {}
+
+        class FakeResult:
+            returncode = 0
+            stdout = '{"state": "closed"}'
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = argv
+            return FakeResult()
+
+        monkeypatch.setenv("GH_REPO", "tomcounsell/ai")
+        monkeypatch.setattr(mcp.subprocess, "run", fake_run)
+        assert mcp._gh_issue_state("42") == "closed"
+        assert captured["argv"] == [
+            "gh",
+            "issue",
+            "view",
+            "42",
+            "--repo",
+            "tomcounsell/ai",
+            "--json",
+            "state",
+        ]
+
+    def test_argv_scoped_from_derived_repo(self, monkeypatch):
+        """GH_REPO unset: slug derived via gh repo view from the git root."""
+        import scripts.migrate_completed_plan as mcp
+
+        captured: list = []
+
+        class IssueResult:
+            returncode = 0
+            stdout = '{"state": "open"}'
+
+        def fake_run(argv, **kwargs):
+            captured.append(argv)
+            if argv[:2] == ["git", "rev-parse"]:
+                return type("GitResult", (), {"returncode": 0, "stdout": "/repo/root"})()
+            if argv[:3] == ["gh", "repo", "view"]:
+                return type("RepoResult", (), {"returncode": 0, "stdout": "tomcounsell/ai"})()
+            return IssueResult()
+
+        monkeypatch.delenv("GH_REPO", raising=False)
+        monkeypatch.setattr(mcp.subprocess, "run", fake_run)
+        assert mcp._gh_issue_state("42") == "open"
+        assert captured[-1] == [
+            "gh",
+            "issue",
+            "view",
+            "42",
+            "--repo",
+            "tomcounsell/ai",
+            "--json",
+            "state",
+        ]
+
+    def test_argv_unscoped_when_repo_resolution_fails(self, monkeypatch):
+        """No GH_REPO and gh repo view fails: degrade to the unscoped argv."""
+        import scripts.migrate_completed_plan as mcp
+
+        captured: list = []
+
+        class IssueResult:
+            returncode = 0
+            stdout = '{"state": "closed"}'
+
+        def fake_run(argv, **kwargs):
+            captured.append(argv)
+            if argv[:2] == ["git", "rev-parse"] or argv[:3] == ["gh", "repo", "view"]:
+                return type("FailResult", (), {"returncode": 1, "stdout": ""})()
+            return IssueResult()
+
+        monkeypatch.delenv("GH_REPO", raising=False)
+        monkeypatch.setattr(mcp.subprocess, "run", fake_run)
+        assert mcp._gh_issue_state("42") == "closed"
+        assert captured[-1] == ["gh", "issue", "view", "42", "--json", "state"]
+
+    def test_gh_failure_returns_unknown(self, monkeypatch):
+        """The fail-soft contract: any gh failure reads as "unknown"."""
+        import scripts.migrate_completed_plan as mcp
+
+        def fake_run(argv, **kwargs):
+            raise OSError("gh missing")
+
+        monkeypatch.setenv("GH_REPO", "tomcounsell/ai")
+        monkeypatch.setattr(mcp.subprocess, "run", fake_run)
+        assert mcp._gh_issue_state("42") == "unknown"

--- a/tools/agent_session_scheduler.py
+++ b/tools/agent_session_scheduler.py
@@ -37,6 +37,7 @@ from agent.constants import WORKER_DOWN_THRESHOLD_S
 from config.enums import SessionType
 from models.reflection import Reflection
 from models.session_lifecycle import NON_TERMINAL_STATUSES
+from tools._sdlc_utils import _resolve_target_repo_fallback
 
 
 def _to_ts(val):
@@ -141,10 +142,29 @@ def _check_rate_limit(project_key: str) -> bool:
 
 
 def _validate_issue(issue_number: int) -> dict | None:
-    """Validate GitHub issue exists and return its details."""
+    """Validate GitHub issue exists and return its details.
+
+    Scoped with ``--repo``: a bare ``gh issue view`` resolves GH_REPO from the
+    environment before cwd, so under a foreign GH_REPO (or from the wrong
+    checkout) it would answer about a different repository's issue #N and
+    exit 0 (issue #2889). This gates whether an autonomous session is
+    scheduled on an issue, so a wrong-repo lookup could schedule unattended
+    work against the wrong repository. The resolved slug mirrors
+    ``tools/sdlc_stage_query.py``'s ladder (GH_REPO env first, else
+    ``gh repo view --json nameWithOwner`` from the working-tree root).
+    """
     try:
+        repo = _resolve_target_repo_fallback()
         result = subprocess.run(
-            ["gh", "issue", "view", str(issue_number), "--json", "title,state,body,url"],
+            [
+                "gh",
+                "issue",
+                "view",
+                str(issue_number),
+                *(["--repo", repo] if repo else []),
+                "--json",
+                "title,state,body,url",
+            ],
             capture_output=True,
             text=True,
             timeout=15,  # timeout-guard: allow


### PR DESCRIPTION
## Summary

Fixes #2889. `gh` resolves `GH_REPO` from the environment **before** cwd, so a bare `gh issue view N` (no `--repo`) under a foreign `GH_REPO` — or from the wrong checkout — answers about a *different* repository's issue #N and **exits 0**, which a caller cannot distinguish from a correct lookup by exit code or result shape.

Two unscoped readers were threading no `--repo`:

1. **`scripts/migrate_completed_plan.py::_gh_issue_state`** — previously `["gh", "issue", "view", N, "--json", "state"]`; gates whether a completed-plan migration fires on a tracking issue.
2. **`tools/agent_session_scheduler.py::_validate_issue`** — previously `["gh", "issue", "view", N, "--json", "title,state,body,url"]`; gates whether an **autonomous session is scheduled on an issue**, so a wrong-repo answer could schedule unattended work against the wrong repository.

Both now thread `--repo <resolved-repo>` into the `gh` argv, mirroring the pattern in `tools/sdlc_stage_query.py::_resolve_issue_state` / `_fetch_pr_merge_state` (added by #2817): the slug resolves via `tools/_sdlc_utils.py::_resolve_target_repo_fallback` — `GH_REPO` env first (zero subprocess), else `gh repo view --json nameWithOwner -q .nameWithOwner` from the git working-tree root (or `SDLC_TARGET_REPO` path). When nothing resolves, the argv degrades to the prior unscoped shape, preserving both failure contracts: `_gh_issue_state` returns `"unknown"` on any failure, and `_validate_issue` returns `None` (fail-soft) on any failure.

**Scoping-only.** The issue also flags `_gh_issue_state`'s vocabulary divergence — `.lower()` + `"unknown"` fallback vs. the `{"OPEN", "CLOSED", None}` whitelist used by `_compute_meta` — which is intentionally **not** changed here; noted as a follow-up (the issue's Fix section lists it as a separate consideration, and this lane is scoping-only).

## Test plan

- `scripts/pytest-clean.sh tests/unit/test_migrate_completed_plan.py tests/unit/test_agent_session_scheduler_persona.py tests/unit/test_agent_session_scheduler_after_reflection.py tests/unit/test_agent_session_scheduler_kill.py -n0` → **76 passed** (new `TestGhIssueStateRepoScoping` and `TestValidateIssueRepoScoping` classes assert the `--repo` argv for the GH_REPO-env, derived-repo, and degrade paths, plus the fail-soft contracts).
- `scripts/pytest-clean.sh tests/unit/test_architectural_constraints.py tests/unit/test_plan_migration_invariant.py -n0` → **11 passed**.
- `scripts/pytest-clean.sh tests/unit/test_child_session_gate.py tests/unit/test_sdlc_utils.py -n0` → **80 passed** (scheduler `_validate_issue` patch sites unaffected).
- `scripts/pytest-clean.sh tests/unit/test_sdlc_stage_query.py -n0` → **91 passed** (reference pattern untouched).
- `uv run ruff check scripts/migrate_completed_plan.py tools/agent_session_scheduler.py tests/unit/test_migrate_completed_plan.py tests/unit/test_agent_session_scheduler_persona.py` → all checks passed.
- `uv run ruff format --check` on the same four files → all formatted.
- `python scripts/migrate_completed_plan.py` still imports/runs standalone from the worktree venv (repo packages are editable-installed).

Closes #2889
