### PR TITLE
fix(tests): make test_real_search_limit assert a non-empty result set

### DIFF
--- a/tests/integration/test_youtube_search_live.py
+++ b/tests/integration/test_youtube_search_live.py
@@ -28,4 +28,5 @@ class TestSearchIntegration:
 
     def test_real_search_limit(self):
         results = youtube_search_sync("python", limit=2)
-        assert len(results) <= 2
+        # Non-empty bound: the previous `len(results) <= 2` was vacuous against an empty result set.
+        assert 0 < len(results) <= 2


### PR DESCRIPTION
## Summary

Fixes the secondary finding in #2915. `test_real_search_limit` asserted `len(results) <= 2`, which is vacuously satisfied by an empty result set — the assertion could never catch a `limit` that silently returns nothing, and the only way the node went red was an exception from `youtube_search_sync`. Tightened to `assert 0 < len(results) <= 2` so the test actually asserts that `limit` caps a **non-empty** result set, with a brief comment noting the non-empty bound. Test-only change; no runtime-path modification.

## Test plan

The live test was **not executed**: this machine's LAN gateway TLS-intercepts `www.youtube.com` (UniFi CA, per #2915's primary finding), so any live-YouTube run fails environmentally with `SSL: CERTIFICATE_VERIFY_FAILED` regardless of this change. The change is a pure assertion-strengthening with no runtime-path change, so it is correct irrespective of the network condition.

Static verification (worktree venv, Python 3.14, on-pin):

```
$ python -m ruff check tests/integration/test_youtube_search_live.py
All checks passed!

$ python -m ruff format --check tests/integration/test_youtube_search_live.py
1 file already formatted
```

(The only stderr noise is a pre-existing config warning about the removed `UP038` rule; unrelated to this change.)

Refs #2915 — this addresses only the assertion defect; the primary environmental cause (gateway TLS interception) remains open.
