### PR TITLE
fix(tests): isolate bot_loop_guard from telegram_bridge import-time routing mutation

### DIFF
--- a/tests/integration/test_bot_loop_guard.py
+++ b/tests/integration/test_bot_loop_guard.py
@@ -24,16 +24,27 @@ from bridge import routing
 @pytest.fixture
 def registered_bot_map():
     """Register a bot peer the way the bridge does at startup, kept ONLY in the
-    bot map (never in DM_USER_TO_PROJECT / GROUP_TO_PROJECT)."""
+    bot map (never in DM_USER_TO_PROJECT / GROUP_TO_PROJECT).
+
+    Also pins the DM-path module globals RESPOND_TO_DMS/DM_WHITELIST to their
+    defaults: a sibling test importing bridge.telegram_bridge on the same xdist
+    worker rebinds routing.DM_WHITELIST to the real whitelist and
+    routing.RESPOND_TO_DMS to the production value, which would flip
+    should_respond_sync to False for the non-bot DM sender (#2916, #2917, #2918,
+    #2919 — the same hazard fixed for the sibling unit fixture in #2093).
+    """
     bot_id = 8837490628
     saved_bots = dict(routing.BOT_ID_TO_PROJECT)
     saved_dm = dict(routing.DM_USER_TO_PROJECT)
     saved_groups = dict(routing.GROUP_TO_PROJECT)
     saved_whitelist = set(routing.DM_WHITELIST)
+    saved_respond_to_dms = routing.RESPOND_TO_DMS
 
     routing.BOT_ID_TO_PROJECT.clear()
     routing.BOT_ID_TO_PROJECT[bot_id] = {"_key": "valor", "name": "Valor AI"}
     # Deliberately do NOT add to DM_USER_TO_PROJECT / GROUP_TO_PROJECT / whitelist.
+    routing.RESPOND_TO_DMS = True
+    routing.DM_WHITELIST = set()
     yield bot_id
 
     routing.BOT_ID_TO_PROJECT.clear()
@@ -42,8 +53,8 @@ def registered_bot_map():
     routing.DM_USER_TO_PROJECT.update(saved_dm)
     routing.GROUP_TO_PROJECT.clear()
     routing.GROUP_TO_PROJECT.update(saved_groups)
-    routing.DM_WHITELIST.clear()
-    routing.DM_WHITELIST.update(saved_whitelist)
+    routing.DM_WHITELIST = saved_whitelist
+    routing.RESPOND_TO_DMS = saved_respond_to_dms
 
 
 def test_registered_bot_resolves_no_project_on_spawn_path(registered_bot_map):


### PR DESCRIPTION
## Summary

Root cause (shared by #2916, #2917, #2918, #2919): `bridge/telegram_bridge.py:688-689` rebinds `routing.RESPOND_TO_DMS` / `routing.DM_WHITELIST` at import time from the machine's production config. The `registered_bot_map` fixture in `tests/integration/test_bot_loop_guard.py` saved/restored `DM_WHITELIST` but never pinned it to empty at setup and never touched `RESPOND_TO_DMS`. When any sibling test imports `bridge.telegram_bridge` first on the same xdist worker, `should_respond_sync` becomes default-deny for senders outside the production whitelist, flipping `test_non_bot_sender_unaffected` and `test_quarantined_id_is_not_suppressed` to False — an order- and machine-dependent failure.

The fix pins both DM-path globals to their routing-module defaults for the test duration, mirroring the sibling fixture in `tests/unit/test_bot_registry_routing.py` (added in #2093 for the identical hazard):

- setup: save `routing.RESPOND_TO_DMS`, then set `RESPOND_TO_DMS = True` and `DM_WHITELIST = set()`;
- teardown: restore both by rebinding the saved references (replacing the `clear()`/`update()` mutation, which also mutated the bridge's live whitelist object in-process).

Test-only change; `bridge/telegram_bridge.py` and `bridge/routing.py` are untouched.

## Test plan

This machine's `~/Desktop/Valor/projects.json` has an empty `dms.whitelist`, so the natural reproducer passes both before and after here. To reproduce the nightly-machine condition (non-empty whitelist) deterministically, `PROJECTS_CONFIG_PATH` was pointed at a temp `projects.json` with a 2-entry whitelist — exercising the exact real code path (`telegram_bridge` import builds the whitelist and rebinds `routing`).

1. `scripts/pytest-clean.sh tests/integration/test_private_tag_ingestion.py tests/integration/test_bot_loop_guard.py -p no:randomly -n0` (whitelisted config): **before 2 failed, 13 passed → after 15 passed**
2. `scripts/pytest-clean.sh tests/unit/test_should_store_inbound.py tests/integration/test_bot_loop_guard.py -n0` (whitelisted config): **before 2 failed, 7 passed → after 9 passed**
3. `scripts/pytest-clean.sh tests/integration/test_bot_loop_guard.py -n0`: **4 passed** (also 4 passed under the whitelisted config)
4. `python -m ruff check tests/integration/test_bot_loop_guard.py` and `python -m ruff format --check tests/integration/test_bot_loop_guard.py`: clean

The two before-failures matched the issues' verbatim output (`assert False is True` from `should_respond_sync` at `test_bot_loop_guard.py:89` and `:130`).

Closes #2916
Closes #2917
Closes #2918
Closes #2919
