### PR TITLE
fix(gh): scope gh pr list fallback and gh pr diff with --repo in build_audit_set

### DIFF
--- a/scripts/build_audit_set.py
+++ b/scripts/build_audit_set.py
@@ -107,13 +107,13 @@ def parse_frontmatter(content):
 def get_issue_pr(issue_number):
     """Find the merged PR for a given issue number.
 
-    Scoped with ``--repo``: a bare ``gh issue view`` resolves GH_REPO from the
-    environment before cwd, so under a foreign GH_REPO (or from a wrong cwd)
-    it would answer about a *different* repository's issue #N and exit 0
-    (issue #2889). The slug resolves via the shared ladder (GH_REPO env first,
-    else ``gh repo view --json nameWithOwner`` from the working-tree root /
-    ``SDLC_TARGET_REPO``); when nothing resolves, the argv degrades to the
-    prior unscoped shape.
+    Scoped with ``--repo``: a bare ``gh issue view`` (and the ``gh pr list
+    --search`` fallback) resolves GH_REPO from the environment before cwd, so
+    under a foreign GH_REPO (or from a wrong cwd) it would answer about a
+    *different* repository's issue #N and exit 0 (issue #2889). The slug
+    resolves via the shared ladder (GH_REPO env first, else ``gh repo view
+    --json nameWithOwner`` from the working-tree root / ``SDLC_TARGET_REPO``);
+    when nothing resolves, the argv degrades to the prior unscoped shape.
     """
     repo = _resolve_target_repo_fallback()
     repo_flag = f" --repo {repo}" if repo else ""
@@ -137,7 +137,8 @@ def get_issue_pr(issue_number):
 
         # Fallback: search for PR by issue reference
         search_result = subprocess.run(
-            f"gh pr list --search 'Closes #{issue_number}' --state merged --json number,title",
+            f"gh pr list{repo_flag} --search 'Closes #{issue_number}'"
+            " --state merged --json number,title",
             shell=True,
             capture_output=True,
             text=True,
@@ -154,10 +155,25 @@ def get_issue_pr(issue_number):
 
 
 def fetch_pr_diff(pr_number, slug):
-    """Fetch PR diff and save to file."""
+    """Fetch PR diff and save to file.
+
+    Scoped with ``--repo`` like ``get_issue_pr`` (issue #2928): a bare
+    ``gh pr diff`` resolves GH_REPO from the environment before cwd, so under
+    a foreign GH_REPO (or from a wrong cwd) it would answer about a
+    *different* repository's PR #N and exit 0. The slug resolves via the
+    shared ladder (GH_REPO env first, else ``gh repo view --json
+    nameWithOwner`` from the working-tree root / ``SDLC_TARGET_REPO``); when
+    nothing resolves, the argv degrades to the prior unscoped shape.
+    """
     diff_path = DIFFS_DIR / f"{slug}.diff"
+    repo = _resolve_target_repo_fallback()
+    repo_flag = f" --repo {repo}" if repo else ""
     result = subprocess.run(
-        f"gh pr diff {pr_number}", shell=True, capture_output=True, text=True, cwd=str(WORKTREE)
+        f"gh pr diff{repo_flag} {pr_number}",
+        shell=True,
+        capture_output=True,
+        text=True,
+        cwd=str(WORKTREE),
     )
     if result.returncode == 0 and result.stdout:
         # Truncate if over 200KB

--- a/tests/unit/test_build_audit_set.py
+++ b/tests/unit/test_build_audit_set.py
@@ -1,9 +1,10 @@
 """Unit tests for scripts/build_audit_set.py.
 
-Issue #2889/#2921: the `gh issue view` readers in `get_issue_pr` and
-`get_issue_body` must be scoped with --repo. A bare ``gh issue view N``
-resolves GH_REPO from the environment before cwd, so under a foreign GH_REPO
-it answers about a *different* repository's issue #N and exits 0.
+Issue #2889/#2921/#2928: the `gh issue view` readers in `get_issue_pr` and
+`get_issue_body`, plus the `gh pr list` fallback in `get_issue_pr` and the
+`gh pr diff` reader in `fetch_pr_diff`, must be scoped with --repo. A bare
+`gh ... N` resolves GH_REPO from the environment before cwd, so under a
+foreign GH_REPO it answers about a *different* repository and exits 0.
 """
 
 import scripts.build_audit_set as bas
@@ -94,3 +95,134 @@ class TestIssueViewRepoScoping:
         assert bas.get_issue_body(42) == "hello"
         assert "--repo" not in captured[-1]
         assert captured[-1].startswith("gh issue view 42")
+
+
+class TestPrListFallbackRepoScoping:
+    """Issue #2928: the ``gh pr list --search`` fallback inside ``get_issue_pr``.
+
+    Same wrong-repository bug class as #2889: a bare ``gh pr list`` under a
+    foreign GH_REPO (or from a wrong cwd) searches a *different* repository
+    and exits 0, so the fallback could resolve PR #N from the wrong repo. The
+    argv must carry ``--repo <resolved-slug>`` in the scoped case and degrade
+    to the prior unscoped shape when nothing resolves.
+    """
+
+    def test_pr_list_fallback_scoped_from_gh_repo_env(self, monkeypatch):
+        captured: list = []
+
+        class FakeResult:
+            returncode = 0
+            stdout = '{"title": "T", "closedByPullRequestsReferences": []}'
+
+        class FakeListResult:
+            returncode = 0
+            stdout = '[{"number": 9, "title": "T"}]'
+
+        def fake_run(cmd, **kwargs):
+            captured.append(cmd)
+            if "gh pr list" in cmd:
+                return FakeListResult()
+            return FakeResult()
+
+        monkeypatch.setenv("GH_REPO", "tomcounsell/ai")
+        monkeypatch.setattr(bas.subprocess, "run", fake_run)
+        assert bas.get_issue_pr(42) == (9, "T")
+        assert "--repo tomcounsell/ai" in captured[-1]
+        assert captured[-1].startswith("gh pr list --repo tomcounsell/ai")
+
+    def test_pr_list_fallback_unscoped_when_repo_resolution_fails(self, monkeypatch):
+        """No GH_REPO and git root resolution fails: degrade to unscoped argv."""
+        captured: list = []
+
+        class FakeResult:
+            returncode = 0
+            stdout = '{"title": "T", "closedByPullRequestsReferences": []}'
+
+        class FakeListResult:
+            returncode = 0
+            stdout = '[{"number": 9, "title": "T"}]'
+
+        def fake_run(cmd, **kwargs):
+            captured.append(cmd)
+            if "rev-parse" in cmd:
+                return type("FailResult", (), {"returncode": 1, "stdout": ""})()
+            if "gh pr list" in cmd:
+                return FakeListResult()
+            return FakeResult()
+
+        monkeypatch.delenv("GH_REPO", raising=False)
+        monkeypatch.delenv("SDLC_TARGET_REPO", raising=False)
+        monkeypatch.setattr(bas.subprocess, "run", fake_run)
+        assert bas.get_issue_pr(42) == (9, "T")
+        assert "--repo" not in captured[-1]
+        assert captured[-1].startswith("gh pr list --search")
+
+
+class TestPrDiffRepoScoping:
+    """Issue #2928: the ``gh pr diff`` reader in ``fetch_pr_diff``.
+
+    Same wrong-repository bug class as #2889: a bare ``gh pr diff`` under a
+    foreign GH_REPO (or from a wrong cwd) diffs a *different* repository's PR
+    #N and exits 0. The argv must carry ``--repo <resolved-slug>`` in the
+    scoped case and degrade to the prior unscoped shape when nothing resolves;
+    the existing failure value (``None``) is preserved in both cases.
+    """
+
+    def test_pr_diff_scoped_from_gh_repo_env(self, monkeypatch, tmp_path):
+        captured: list = []
+
+        class FakeResult:
+            returncode = 0
+            stdout = "diff --git a/x b/x"
+
+        def fake_run(cmd, **kwargs):
+            captured.append(cmd)
+            return FakeResult()
+
+        monkeypatch.setenv("GH_REPO", "tomcounsell/ai")
+        # DIFFS_DIR must sit under WORKTREE so the relative return path resolves.
+        monkeypatch.setattr(bas, "WORKTREE", tmp_path.parent)
+        monkeypatch.setattr(bas, "DIFFS_DIR", tmp_path)
+        monkeypatch.setattr(bas.subprocess, "run", fake_run)
+        result = bas.fetch_pr_diff(9, "some-slug")
+        assert "--repo tomcounsell/ai" in captured[0]
+        assert captured[0].startswith("gh pr diff --repo tomcounsell/ai")
+        assert result is not None
+
+    def test_pr_diff_unscoped_when_repo_resolution_fails(self, monkeypatch, tmp_path):
+        captured: list = []
+
+        class FakeResult:
+            returncode = 0
+            stdout = "diff --git a/x b/x"
+
+        def fake_run(cmd, **kwargs):
+            captured.append(cmd)
+            if "rev-parse" in cmd:
+                return type("FailResult", (), {"returncode": 1, "stdout": ""})()
+            return FakeResult()
+
+        monkeypatch.delenv("GH_REPO", raising=False)
+        monkeypatch.delenv("SDLC_TARGET_REPO", raising=False)
+        monkeypatch.setattr(bas, "WORKTREE", tmp_path.parent)
+        monkeypatch.setattr(bas, "DIFFS_DIR", tmp_path)
+        monkeypatch.setattr(bas.subprocess, "run", fake_run)
+        result = bas.fetch_pr_diff(9, "some-slug")
+        assert "--repo" not in captured[-1]
+        assert captured[-1].startswith("gh pr diff 9")
+        assert result is not None
+
+    def test_pr_diff_failure_returns_none(self, monkeypatch, tmp_path):
+        """Preserve the existing failure value: non-zero rc → None."""
+        captured: list = []
+
+        def fake_run(cmd, **kwargs):
+            captured.append(cmd)
+            return type("FailResult", (), {"returncode": 1, "stdout": ""})()
+
+        monkeypatch.setenv("GH_REPO", "tomcounsell/ai")
+        monkeypatch.setattr(bas, "WORKTREE", tmp_path.parent)
+        monkeypatch.setattr(bas, "DIFFS_DIR", tmp_path)
+        monkeypatch.setattr(bas.subprocess, "run", fake_run)
+        assert bas.fetch_pr_diff(9, "some-slug") is None
+        assert "--repo tomcounsell/ai" in captured[0]


### PR DESCRIPTION
## Summary

Follow-up to #2925. The `gh issue view` readers were scoped with `--repo` in #2925, but two `gh pr` readers in `scripts/build_audit_set.py` remained unscoped — the same wrong-repository bug class as #2889:

1. **`get_issue_pr`'s fallback** (~`:126`): `gh pr list --search 'Closes #{issue_number}' --state merged --json number,title` — a bare search under a foreign `GH_REPO` (or from a wrong cwd) searches a *different* repository and exits 0.
2. **`fetch_pr_diff`** (~`:146`): `gh pr diff {pr_number}` — a bare diff under a foreign `GH_REPO` (or from a wrong cwd) diffs a *different* repository's PR and exits 0.

Both now thread `--repo <resolved>` exactly like #2925's `get_issue_pr`/`get_issue_body`: resolve via `tools/_sdlc_utils.py::_resolve_target_repo_fallback()` (GH_REPO env first with zero subprocess, else `gh repo view --json nameWithOwner -q .nameWithOwner` from the git working-tree root / `SDLC_TARGET_REPO`); degrade to the prior unscoped command when nothing resolves; preserve each function's existing failure values (`get_issue_pr` → `(None, None)` / fallback intact; `fetch_pr_diff` → `None` on non-zero rc).

## Test plan

- `scripts/pytest-clean.sh tests/unit/test_build_audit_set.py -n0` → **9 passed** — new `TestPrListFallbackRepoScoping` and `TestPrDiffRepoScoping` classes assert `--repo <slug>` in the argv for the scoped case and its absence (degrade) when resolution fails, plus the preserved `None`-on-failure contract, mirroring the existing `TestIssueViewRepoScoping` pattern.
- `uv run ruff check` + `uv run ruff format --check` on `scripts/build_audit_set.py` and `tests/unit/test_build_audit_set.py` → clean.

Closes #2928
