### PR TITLE
refactor(skills): consolidate sdlc router into do-sdlc, thin /sdlc shim

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -85,7 +85,7 @@ Spawn multiple agents for independent work. The system auto-parallelizes when:
 
 ### /sdlc - AI Developer Workflow
 
-Single entry point for all development work. It's a **dispatcher** — assesses state and invokes the right sub-skill (`/do-plan`, `/do-build`, `/do-test`, `/do-patch`, `/do-pr-review`, `/do-docs`). See `.claude/skills/sdlc/SKILL.md` for ground truth on stages.
+Single entry point for all development work. It's a **dispatcher** — assesses state and invokes the right sub-skill (`/do-plan`, `/do-build`, `/do-test`, `/do-patch`, `/do-pr-review`, `/do-docs`). See `.claude/skills-global/do-sdlc/SKILL.md` for ground truth on stages.
 
 Stages: Plan → Build → Test → Patch → Review → Patch → Docs → Merge
 

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -176,7 +176,7 @@ From CLAUDE.md:
 - **No legacy code tolerance** - All deprecated patterns must go
 - **No mocks in tests** - Use real integrations
 - **Always commit and push** - Work should be preserved
-- **SDLC pattern** - Plan → Build → Test → Patch → Review → Patch → Docs → Merge (see `.claude/skills/sdlc/SKILL.md`)
+- **SDLC pattern** - Plan → Build → Test → Patch → Review → Patch → Docs → Merge (see `.claude/skills-global/do-sdlc/SKILL.md`)
 
 ## When to Approve
 

--- a/.claude/skill-context/cowork.md
+++ b/.claude/skill-context/cowork.md
@@ -62,7 +62,7 @@ cutover.
   local `/sentry` on-demand recipe and by the cloud routine (via the GitHub connector or
   the cloned repo's own `gh`) for filing and dedup.
 - `sdlc-tool stage-query --issue-number {N}` — once a routine files an issue, the normal
-  SDLC pipeline (see `.claude/skills/sdlc/SKILL.md`) picks it up from there; the routine's
+  SDLC pipeline (see `.claude/skills-global/do-sdlc/SKILL.md`) picks it up from there; the routine's
   job stops at "issue filed," it does not drive the pipeline.
 
 ## Reference implementation

--- a/.claude/skills-global/do-sdlc/SKILL.md
+++ b/.claude/skills-global/do-sdlc/SKILL.md
@@ -1,38 +1,91 @@
 ---
 name: do-sdlc
-description: "Supervise a full SDLC pipeline run to merge in a local Claude Code session. Triggered by 'do-sdlc', 'run the full pipeline', 'ship this issue end to end', 'supervise the sdlc'."
+description: "Supervise a full SDLC pipeline run to merge in a local Claude Code session. Triggered by 'do-sdlc', 'run the full pipeline', 'ship this issue end to end', 'supervise the sdlc'. Also the home of the single-stage router contract that /sdlc (in this repo) executes."
 context: fork
 ---
 
-# do-sdlc — Local Pipeline Supervisor
+# do-sdlc — SDLC Pipeline Supervisor and Single-Stage Router
 
-This skill is the **local stand-in for the bridge PM session**. `/sdlc` (in this repo) is a single-stage router by contract: it dispatches ONE sub-skill and returns, expecting a PM session to re-invoke it. In a local Claude Code session there is no PM loop — this skill IS that loop: it re-invokes the router, dispatching each stage to a subagent on the stage-appropriate model (opus/sonnet), until merge, a blocking guard, or the iteration cap.
+This skill is the **one substantive SDLC skill**. It has two entry modes over one shared step
+spine:
 
-You are the supervisor, not the worker. You assess, dispatch, and track. The stage subagents do all the work.
+| Mode | Entry | Executes | Contract |
+|------|-------|----------|----------|
+| **Router mode** | `/sdlc` (in this repo) | Steps 1–4 once | dispatch ONE sub-skill, then return; the PM session re-invokes |
+| **Supervisor mode** | `/do-sdlc` | Steps 1–7 | loop until merge/blocked |
 
-**Redundant-context check (issue #2026, WS-F):** if a bridge PM/dev context already owns this issue — a live eng session (e.g. a bridge PM session) — then `/do-sdlc` is redundant: that context IS the supervision loop. Do not run it; drive via `/sdlc` (in this repo, the single-stage router) instead. A live *supervised-run signal* for the issue number is a different case — see the refusal decision table in Step 2: if the signal's `owner_run_id` is one this run already holds, it is this run's own hand-off, not another owner, and must be inherited rather than treated as redundant-context grounds to stand down.
+The router mode is the bridge PM's production contract — a single-stage router that assesses
+state and dispatches exactly one `/do-*` skill, expecting the PM session (bridge or this skill's
+supervisor loop) to re-invoke it after each stage completes. The supervisor mode is the local
+stand-in for the bridge PM session: it re-invokes the router, dispatching each stage to a
+subagent on the stage-appropriate model (opus/sonnet), until merge, a blocking guard, or the
+iteration cap.
+
+You are the supervisor or router, never the worker. You assess, dispatch, and track. The stage
+subagents do all the work.
+
+**Redundant-context check (issue #2026, WS-F):** if a bridge PM/dev context already owns this
+issue — a live eng session (e.g. a bridge PM session) — then supervisor mode is redundant: that
+context IS the supervision loop. Do not run it; drive via `/sdlc` (in this repo, the single-stage
+router) instead. A live *supervised-run signal* for the issue number is a different case — see
+the refusal decision table in Step 2: if the signal's `owner_run_id` is one this run already
+holds, it is this run's own hand-off, not another owner, and must be inherited rather than
+treated as redundant-context grounds to stand down.
 
 ## Repo Context Probe
 
-If `docs/sdlc/do-sdlc.md` exists, read it and honor its declarations; otherwise use the generic defaults described below. The defaults drive the pipeline through `sdlc-tool` (synced to every machine via `~/.local/bin`), `gh`, and `git`.
+If `docs/sdlc/do-sdlc.md` exists, read it and honor its declarations; otherwise use the generic
+defaults described below. The defaults drive the pipeline through `sdlc-tool` (synced to every
+machine via `~/.local/bin`), `gh`, and `git`. Repo-coupled specifics — worktree ownership,
+`SDLC_TARGET_REPO`/`GH_REPO` semantics, the G1–G9 guard table's repo path references, and
+`sdlc-tool` command discipline — live in that context file, not in this global body.
 
 ## Hard Rules
 
-1. **NEVER write code, run tests, or create plans directly** — every stage executes inside a stage subagent that invokes the stage's `/do-*` skill.
-2. **NEVER decide dispatch yourself** — `sdlc-tool next-skill` is the only source of dispatch decisions. It encodes all guards (G1–G9) and dispatch rows. Do not second-guess it, reorder stages, or skip it "because the next stage is obvious".
-3. **NEVER continue past a `blocked` decision** — surface the reason to the human and stop. Guards block for a reason.
-4. **ALWAYS pass `model:` per the Stage→Model table** when spawning a stage subagent. Never rely on the inherited default.
-5. **ALWAYS record the dispatch before spawning the subagent** — this preserves the G4 oscillation signal even if the subagent crashes.
-6. **ALWAYS dispatch with `run_in_background: false`, never end the turn waiting on a background child.** This skill runs in a forked context (`context: fork`) that gets exactly one turn. The Agent tool defaults to background execution — it returns immediately and notifies later. A fork has no later turn to be notified on, so a background dispatch is unrecoverable: the fork reports "running in the background, I'll continue when it completes" and then never does (issue #1915). Every stage subagent must be spawned with `run_in_background: false` so its result is in hand before the loop advances.
-7. **NEVER spawn agent teammates for stage work.** Where Claude Code agent teams are enabled, ignore those affordances: a teammate's idle notification is not a completion signal (teammates go idle mid-task with deliverables unfinished), and an in-process teammate cannot be reliably resumed. Every dispatch is a foreground subagent per Rule 6.
+1. **NEVER write code, run tests, or create plans directly** — every stage executes inside a
+   stage subagent that invokes the stage's `/do-*` skill (supervisor mode), or is dispatched as
+   exactly one sub-skill and then the router returns (router mode).
+2. **NEVER decide dispatch yourself** — `sdlc-tool next-skill` is the only source of dispatch
+   decisions. It encodes all guards (G1–G9) and dispatch rows. Do not second-guess it, reorder
+   stages, or skip it "because the next stage is obvious".
+3. **NEVER continue past a `blocked` decision** — surface the reason to the human and stop.
+   Guards block for a reason.
+4. **ALWAYS pass `model:` per the Stage→Model table** when spawning a stage subagent. Never rely
+   on the inherited default.
+5. **ALWAYS record the dispatch before spawning the subagent** — this preserves the G4
+   oscillation signal even if the subagent crashes.
+6. **ALWAYS dispatch with `run_in_background: false`, never end the turn waiting on a background child.**
+   This skill runs in a forked context (`context: fork`) that gets exactly one turn. The
+   Agent tool defaults to background execution — it returns immediately and notifies later. A
+   fork has no later turn to be notified on, so a background dispatch is unrecoverable: the fork
+   reports "running in the background, I'll continue when it completes" and then never does
+   (issue #1915). Every stage subagent must be spawned with `run_in_background: false` so its
+   result is in hand before the loop advances. In router mode the same rule applies to the one
+   stage you dispatch: it must complete before you return.
+7. **NEVER spawn agent teammates for stage work.** Where Claude Code agent teams are enabled,
+   ignore those affordances: a teammate's idle notification is not a completion signal (teammates
+   go idle mid-task with deliverables unfinished), and an in-process teammate cannot be reliably
+   resumed. Every dispatch is a foreground subagent per Rule 6.
+8. **NEVER loop in router mode** — invoke one sub-skill, then return. The PM session handles
+   progression.
 
 ## Worktree & branch ownership
 
-**Slug identity always wins.** Each issue's build fork exclusively owns `.worktrees/{slug}` and `session/{slug}`, where `{slug}` is the lane's identity, recorded once at lane start and read (never re-derived) via `tools/lane_identity.py::resolve_lane_slug` — this is the single source of truth (`worktree_manager.py` + `resolve_branch_for_stage`; see [`docs/features/sdlc-lane-identity.md`](../../../docs/features/sdlc-lane-identity.md) in repos that have it). Do NOT pre-allocate per-supervisor `.worktrees/sdlc-{N}` lanes: nothing reads a lane override, so lane instructions are silently dropped and every issue's builders land in `.worktrees/{slug}` regardless. Converging fork + supervisor onto one branch per plan is deliberate — it structurally collapses duplicate PRs, since GitHub permits only one open PR per head branch. Concurrent builders inside the one slug worktree must write disjoint file sets (do-build's `Parallel: true` convention: no shared-file writes).
+**Slug identity always wins.** Each issue's build fork exclusively owns `.worktrees/{slug}` and
+`session/{slug}`, where `{slug}` is the lane's identity, recorded once at lane start and read
+(never re-derived) via the lane-identity resolver — the single source of truth (worktree manager
++ branch resolution; see the repo context probe for this repo's exact paths). Do NOT pre-allocate
+per-supervisor `.worktrees/sdlc-{N}` lanes: nothing reads a lane override, so lane instructions
+are silently dropped and every issue's builders land in `.worktrees/{slug}` regardless.
+Converging fork + supervisor onto one branch per plan is deliberate — it structurally collapses
+duplicate PRs, since GitHub permits only one open PR per head branch. Concurrent builders inside
+the one slug worktree must write disjoint file sets (do-build's `Parallel: true` convention: no
+shared-file writes).
 
 ## Stage→Model Dispatch Table
 
-Mirrors the engineer persona's table (`config/personas/engineer.md`) — the local equivalent of `valor-session create --model`.
+Mirrors the engineer persona's table (`config/personas/engineer.md`) — the local equivalent of
+`valor-session create --model`.
 
 | Stage | Skill | `model:` | Rationale |
 |-------|-------|----------|-----------|
@@ -46,15 +99,28 @@ Mirrors the engineer persona's table (`config/personas/engineer.md`) — the loc
 | DOCS | /do-docs | sonnet | Structured writing |
 | MERGE | /do-merge | sonnet | Programmatic gate |
 
-## Step 1: Resolve the Issue
+## Step 1: Resolve the Issue or PR
 
-Same resolution as `/sdlc` (in this repo) Step 1:
+Determine whether the input is an issue reference, a PR reference, or a bare feature description.
+Scope `gh` reads with `--repo` when the repository is known or derivable — under a foreign
+`GH_REPO` (or from a wrong cwd) a bare `gh` command answers about a *different* repository and
+exits 0. When the target repo is not this one, resolve the slug from `GH_REPO` (already an
+org/repo slug) or `gh repo view --json nameWithOwner -q .nameWithOwner` from the target repo
+root, and pass it as `gh ... --repo <slug>`.
 
-- **Issue reference** (`208`, `issue #208`): `gh issue view {number}`
-- **PR reference** (`PR 363`): `gh pr view {number} --json number,title,state,headRefName,reviewDecision,statusCheckRollup,body` and extract the linked issue number from the body (`Closes #N` / `Fixes #N`)
-- **Bare feature description** (no number): dispatch a `/do-issue` stage subagent first (sonnet), read the created issue number from its report, then proceed.
+- **Issue reference** (e.g., `issue 123`, `issue #123`): `gh issue view {number} --repo <resolved>` when
+  a slug resolved.
+- **PR reference** (e.g., `PR 363`, `pr #363`): `gh pr view {number} --repo <resolved> --json
+  number,title,state,headRefName,reviewDecision,statusCheckRollup,body` to get the branch name,
+  review state, and check status. Then extract the linked issue number from the PR body (look
+  for `Closes #N` or `Fixes #N`).
+- **Bare feature description** (no number): in supervisor mode, dispatch a `/do-issue` stage
+  subagent first (sonnet), read the created issue number from its report, then proceed. In
+  router mode, do not proceed without an issue number — surface that to the PM.
 
-Do not proceed without an issue number.
+**PR state informs Step 3**: when a PR is provided, its current state (checks passing/failing,
+review approved/changes-requested, etc.) tells you which pipeline stage to resume from. Skip
+stages that are already complete — do not restart from scratch.
 
 ## Step 2: Ensure the Tracking Session
 
@@ -69,7 +135,7 @@ export SDLC_TARGET_REPO
 # Run identity (issue #2003): `session-ensure` is the EXCLUSIVE minting site for the
 # run_id — one uuid-hex identity for this whole supervision run, minted by winning the
 # issue lock and emitted in the JSON output. No env vars, no run files: every
-# state-mutating `sdlc-tool` call in Step 3 passes it back explicitly via
+# state-mutating `sdlc-tool` call in Step 4/5 passes it back explicitly via
 # `--run-id {run_id}`. The standalone worker threads its own run_id in-process, so the
 # real worker-vs-local guard is preserved.
 sdlc-tool session-ensure --issue-number {issue_number} --issue-url "https://github.com/$SDLC_REPO/issues/{issue_number}"
@@ -79,20 +145,33 @@ Let stderr through and read the JSON payload. `session-ensure` reports a refusal
 (`{"blocked": true, "reason": ...}`), not through the exit code — it exits 0 either way — so a
 discarded diagnostic here is a run that proceeds under an identity it does not hold.
 
-Read the JSON from the tool result and **record the `run_id`** (`{"session_id": ..., "created": ..., "run_id": "<hex>"}`) — carry it through every iteration of the Step 3 loop. Reuses the existing `sdlc-local-{N}` session on re-runs. The ownership contract:
+Read the JSON from the tool result and **record the `run_id`** (`{"session_id": ..., "created": ..., "run_id": "<hex>"}`) — carry it through every subsequent step. Reuses the existing
+`sdlc-local-{N}` session on re-runs. The ownership contract:
 
 - **Every state-mutating `sdlc-tool` call** (`dispatch record`, `stage-marker`, `verdict record`, `meta-set`) **MUST pass `--run-id {run_id}` explicitly.** A missing flag is a named non-zero error (`RUN_ID_REQUIRED`) — the call never mints or adopts an identity.
+- **Pass `--issue-number` to every `sdlc-tool` invocation.** It is the authoritative session selector.
+- **`stage-query`, `verdict get`, and `dispatch get` accept no `--run-id` argument** — they have no lock to compare against. `next-skill` sits in neither bucket: it *accepts* `--run-id` as a read-only identity assertion for its issue-lock peek — always pass it there (issue #2766).
+- **Do NOT export `AGENT_SESSION_ID`** — env vars do not persist across Claude Code bash blocks.
+
+**Self-heal on resume (issue #2144).** State-mutating writes (`stage-marker`, `verdict record`,
+`meta-set`, `dispatch record`) now **self-heal** their run identity: if a resumed turn has lost
+the `run_id` from context (worker restart mid-pipeline), the write re-establishes the *same*
+run's identity from the environment (live supervised signal → `.sdlc-run` / `active_run_id` →
+verified re-acquire of the free lock) and retries once, instead of silently refusing
+`RUN_ID_REQUIRED`/`LEASE_ABSENT` and freezing the ledger. This is best-effort and non-blocking;
+a foreign live lease still hard-refuses. Still pass `--run-id` on the happy path; the heal is a
+safety net for the resume edge, not a license to omit it.
 
 ### Three-way refusal decision table
 
-`session-ensure` (and any subsequent re-ensure — see Step 3's between-stage continuity check) can
+`session-ensure` (and any subsequent re-ensure — see Step 5's between-stage continuity check) can
 refuse with exactly three payload shapes. Discriminate them; do not collapse all three to "stop":
 
 | Refusal | Shape | Action |
 |---|---|---|
 | **Hand-off** | `{"blocked": true, "reason": "SUPERVISED_RUN_ACTIVE", "run_id", "owner_run_id", "owner_session_id"}` | This is a **designed hand-off**, not a block. It mints nothing — the supervisor already owns the run. **Pass the self-identity check below first.** If it confirms your own signal: **inherit** `owner_run_id` (carry it forward as `run_id`, pass it back via `--run-id`/`--reuse-run-id`), and **continue** — never stop for a confirmed-own signal. |
 | **Orphaned lock** | `{"blocked": true, "reason": "ISSUE_LOCKED", "owner_run_id", "owner_session_id", "orphaned_lock": true}` | The prior owner died before renewing; the lock frees within its TTL (duration and renewal semantics are #2446's — cross-reference it, do not reimplement). Wait, re-ensure, then **rebind `run_id` to whatever the re-ensure returns** before continuing — a post-TTL fresh contest mints a NEW run_id, and every downstream `--run-id` call must use the rebound value or it silently orphans. |
-| **Foreign holder** | `{"blocked": true, "reason": "ISSUE_LOCKED", "owner_run_id", "owner_session_id", "orphaned_lock": false}` | Apply the same self-identity check as the hand-off row: `owner_run_id ∈ {run_ids this run has held}` means this is your own lock, not a foreign one — **inherit and continue**, never stop. Only when `owner_run_id` is genuinely foreign is this the **unconditional stop condition.** A genuine live foreign run owns the issue. Stop and report. (issue #2766 — always pass `--run-id {run_id}` on Step 3a's `next-skill` call so this row is only ever reached for a genuine rival, never your own lock.) |
+| **Foreign holder** | `{"blocked": true, "reason": "ISSUE_LOCKED", "owner_run_id", "owner_session_id", "orphaned_lock": false}` | Apply the same self-identity check as the hand-off row: `owner_run_id ∈ {run_ids this run has held}` means this is your own lock, not a foreign one — **inherit and continue**, never stop. Only when `owner_run_id` is genuinely foreign is this the **unconditional stop condition.** A genuine live foreign run owns the issue. Stop and report. (issue #2766 — always pass `--run-id {run_id}` on Step 4's `next-skill` call so this row is only ever reached for a genuine rival, never your own lock.) |
 
 **Self-identity check before standing down** (applies to the hand-off row above): `SUPERVISED_RUN_ACTIVE`
 fires only on a LIVE signal — a stale/expired one falls through to the orphaned-lock/foreign-holder
@@ -109,11 +188,314 @@ explicitly; do not substitute `run_id` (the sibling field the tool also returns)
   a live executable session. It permanently shows `status=running` and carries the run's `_meta` stage
   state — it must **not** be killed, and a running-looking anchor is not evidence of a rogue pipeline.
 
-## Step 3: Supervision Loop
+## Step 3: Assess Current State
 
-Repeat the following cycle. **Iteration cap: 15 dispatches** (a happy path is 8 stages; the cap is a backstop above realistic patch/re-review cycles — G4 catches genuine oscillation long before it).
+Check what already exists for this issue. Use `$SDLC_TARGET_REPO` for local operations (defaults
+to `.` for same-repo work). Run ALL of these checks — do not skip any.
 
-### 3a. Ask the router
+**Command discipline (applies to every check in Steps 3-4):** run each check as a separate
+single-line command and read the output from the tool result — no pipes, no command substitution,
+no `||` fallbacks, no environment-variable capture. You interpret the output and decide the next
+step.
+
+### Step 3.0: Query stage_states from PipelineStateMachine (primary signal)
+
+Query the PM session's `stage_states` for authoritative stage completion data. This is the
+**exclusive signal** for routing decisions. Stage completion is determined ONLY by stored state —
+never by artifact inference.
+
+The tool resolves the active session from `VALOR_SESSION_ID`, `AGENT_SESSION_ID`, or
+`--issue-number` internally.
+
+```bash
+sdlc-tool stage-query --issue-number {issue_number}
+```
+
+Interpret the JSON output from the tool result:
+- Non-empty object with stage keys (e.g. `{"ISSUE": "completed", "PLAN": "completed", "BUILD": "in_progress"}`): use it as the **exclusive signal** for the dispatch table. A stage is behind us ONLY if its value is `"completed"` — or `"skipped"`, which only PLAN and CRITIQUE can ever hold and which means the pipeline never dispatched that stage because this issue has no plan document (#2577, see [`docs/features/off-pipeline-merge-path.md`](../../../docs/features/off-pipeline-merge-path.md)). Never re-dispatch a skipped stage. Skip steps 3a-3e.
+- Empty `{}` or an `unavailable` marker: fall through to the dispatch-history fallback in steps 3a-3e. Do NOT infer stage completion from artifacts.
+
+### Steps 3a-3e: Dispatch History Fallback
+
+These checks run ONLY when stage_states is unavailable (empty JSON from step 3.0). When
+stage_states IS available, skip directly to the dispatch table using stage_states as the source
+of truth.
+
+**IMPORTANT: Never infer stage completion from artifacts (plan files, PR existence, docs/ files,
+etc.). Stage completion is exclusively determined by stored state.**
+
+When stage_states is unavailable, use conversation context to identify which skills were already
+dispatched in this session. Artifacts are used only to check preconditions (e.g., "does a PR
+exist?") — not to declare stages complete.
+
+`$SDLC_TARGET_REPO` is exported by the harness so `git -C` picks it up without further shell
+composition; `gh` uses `$GH_REPO` automatically for the cross-repo case.
+
+```bash
+# 3a. Check if a plan doc references this issue
+grep -r "#{issue_number}" docs/plans/
+```
+
+```bash
+# 3b. List all branches (filter for session/ prefix in the tool result)
+git -C "$SDLC_TARGET_REPO" branch -a
+```
+
+```bash
+# 3c. Check if a PR already exists
+gh pr list --repo <resolved> --search "#{issue_number}" --state open
+# Cross-check with live refs — the --search index lags GitHub; --head queries live refs:
+#   gh pr list --repo <resolved> --head session/{slug} --state open   (reuse if present; keyed by head branch, not issue #)
+```
+
+If a PR exists, fetch its full state for assessment:
+```bash
+# 3d. Get PR state: checks, review, branch
+gh pr view {pr_number} --repo <resolved> --json number,headRefName,reviewDecision,statusCheckRollup,body
+
+# 3e. Check review status — look for APPROVED, CHANGES_REQUESTED, or no review
+# reviewDecision: "APPROVED" means formal GitHub review approved (non-self-authored PRs)
+# reviewDecision: "CHANGES_REQUESTED" means formal GitHub review requested changes
+# reviewDecision: "" (empty) — AMBIGUOUS for self-authored PRs:
+#   - For non-self-authored PRs: no review posted yet
+#   - For self-authored PRs: expected even after review — check _verdicts["REVIEW"] from sdlc_stage_query
+# Always cross-check _meta.latest_review_verdict before concluding no review exists.
+```
+
+### Step 3.4: Check Documentation Status
+
+This step is REQUIRED when a PR exists and review is clean (APPROVED). Skip it only if the
+pipeline hasn't reached the REVIEW stage yet.
+
+```bash
+# 3.4a. List files changed in the PR (count docs/ entries from the tool result)
+gh pr diff {pr_number} --repo <resolved> --name-only
+```
+
+```bash
+# 3.4b. Find the plan path for this issue (first match from the tool result)
+grep -rl "#{issue_number}" docs/plans/
+```
+
+```bash
+# 3.4c. Read the plan's Documentation section (inspect for unchecked tasks in the tool result)
+cat docs/plans/{plan-filename}.md
+```
+
+For the DOCS stage completion check, re-read the `sdlc-tool stage-query` output from Step 3.0. Do
+not pipe JSON through a shell here.
+
+**Decision logic for docs**:
+- If the plan has a `## Documentation` section with unchecked tasks → docs NOT done
+- If PR has zero `docs/` file changes AND plan requires doc tasks → docs NOT done
+- If docs tasks are all checked AND `docs/` changes exist in PR → docs done
+- When in doubt, dispatch `/do-docs` — it is idempotent and will no-op if nothing needs updating
+
+## Step 3.5: Legal Dispatch Guards (reference)
+
+`sdlc-tool next-skill` evaluates the G1–G9 guards itself — do NOT re-evaluate them by hand. The
+table below exists so you can interpret a `blocked` decision or a forced dispatch when the tool
+returns one. Canonical implementation: `agent.sdlc_router.decide_next_dispatch()`; the parity
+test `tests/unit/test_sdlc_skill_md_parity.py` keeps this table in sync with the Python rules.
+Repo-specific guard nuances are declared in the repo context probe (`docs/sdlc/do-sdlc.md`).
+
+Guards are evaluated in the **pinned `GUARDS` list order** `[G1, G2, G3, G4, G9, G8, G7, G5, G6]` — the first to return a non-`None` decision wins. Guard IDs are historical (assigned in introduction order), not evaluation order; the table below is listed in evaluation order:
+
+| Guard | Condition | Forced Dispatch |
+|-------|-----------|-----------------|
+| G1: Critique loop | Latest critique verdict contains `NEEDS REVISION` or `MAJOR REWORK` AND `last_dispatched_skill == /do-plan-critique` | `/do-plan` |
+| G2: Critique cycle cap | `critique_cycle_count >= MAX_CRITIQUE_CYCLES` (2) AND CRITIQUE is not completed | Escalate: `blocked` with reason `critique cycle cap reached` |
+| G3: PR lock | `pr_number` is set AND (`last_dispatched_skill` OR proposed dispatch) is `/do-plan` or `/do-plan-critique` | `/do-merge` (if REVIEW and DOCS complete), `/do-patch` (if review requested changes), else `/do-pr-review` |
+| G4: Oscillation (universal) | `same_stage_dispatch_count >= 3` | Escalate: `blocked` with reason `stage oscillation — {skill} dispatched {N} times without state change` |
+| G9: Blocked-on-conflict | Recorded REVIEW verdict contains `BLOCKED_ON_CONFLICT` AND `pr_merge_state` not in the non-conflicting set (`CLEAN`, `HAS_HOOKS`, `UNSTABLE`, `BLOCKED`, `BEHIND`) AND the verdict is not stale (no `/do-patch` landed after it, #2796) | Escalate: `blocked` with reason naming the PR, the merge state, and the rebase — no SDLC skill resolves merge conflicts |
+| G8: Stage-advance verification | `context["stage_artifacts_verified"] is False` (a claimed stage artifact — PR, branch, plan commit — failed live verification) | Re-dispatch the skill owning `context["unverified_stage"]` |
+| G7: Plan-revising lock | `pr_number` is None AND `plan_revising == True` AND no `/do-plan` revision has landed since the latest CRITIQUE verdict (event-scoped, #2787 — NOT the sticky `revision_applied` boolean) | `/do-plan` (if `last_dispatched_skill == /do-plan-critique`); Escalate `blocked` (if no `/do-plan` in last `MAX_PLAN_REVISING_DISPATCHES + 1` turns) |
+| G5: Unchanged critique artifact | `_verdicts["CRITIQUE"]` has `artifact_hash` AND current plan file hash matches | Use cached verdict: `/do-plan` (NEEDS REVISION) or `/do-build` (READY TO BUILD, no concerns). Never re-dispatch `/do-plan-critique` on an unchanged plan. **Steps aside unconditionally on `READY TO BUILD (with concerns)`** so rows 2b/4b/4c own that state (#2787); the bound there is `MAX_CONCERN_RECRITIQUE_ROUNDS`, not G5. |
+| G6: Terminal merge ready | `pr_number` set AND `pr_merge_state == "CLEAN"` AND `ci_all_passing == True` AND `DOCS == "completed"` AND `_verdicts["REVIEW"]` contains `APPROVED` | `/do-merge {pr_number}` |
+
+**G4 is universal** — it applies to EVERY stage, including DOCS and MERGE. Repeated dispatches of
+`/do-docs` or `/do-merge` without state change WILL trip the guard.
+
+**G4 precedes G8 by design (issue #1267).** G8 re-dispatches the same stage's skill on a false
+artifact claim, with nothing upstream to stop it on a persistently false claim. Because G4 runs
+first, it fires and blocks once `same_stage_dispatch_count >= MAX_SAME_STAGE_DISPATCHES` before
+G8 gets another chance to re-dispatch — silent re-dispatch first, escalate via the existing G4
+cap second, not an immediate block on the first mismatch.
+
+**G9 (issue #2796).** A `BLOCKED_ON_CONFLICT` REVIEW verdict previously routed by accident — row 8
+sent it to `/do-patch` (which cannot rebase), row 8b sent it back to `/do-pr-review` (whose
+preflight re-recorded the same verdict) — ping-ponging until G4 escalated with a reason naming
+neither the conflict nor the rebase. G9 escalates immediately with a reason that names both. Its
+non-conflicting step-aside set (`CLEAN`, `HAS_HOOKS`, `UNSTABLE`, `BLOCKED`, `BEHIND`) mirrors
+`/do-pr-review`'s own preflight decision table exactly, so a PR that is merely `BEHIND` or
+`UNSTABLE` is never wrongly told it has merge conflicts. `tools/sdlc_stage_query.py::_fetch_pr_merge_state`
+retries once on a transient `UNKNOWN` read before G9 (or G6) ever sees the value.
+
+**G8 makes no live calls.** Live verification of claimed stage artifacts happens in the
+next-skill context-assembly path (`tools/sdlc_next_skill.py`), which sets
+`context["stage_artifacts_verified"]` / `context["unverified_stage"]`; G8
+(`agent.sdlc_router.guard_g8_artifact_verification`) only reads those flags. This keeps
+`agent/sdlc_router.py` import-free of `tools/` (see `tests/unit/test_architectural_constraints.py`).
+Absent/unset/`True` is a no-op, and a stage whose claimed artifact has no resolvable identifier
+(e.g. no recorded `pr_number`) is skipped rather than reported as a mismatch (#2757). The
+verifier's `git` checks run with `cwd=_target_repo_cwd()` (`SDLC_TARGET_REPO`, a filesystem path)
+so they inspect the SDLC target repo, not the process cwd — see the cwd-threading contract
+(#2078) in `docs/features/sdlc-router-oscillation-guard.md`.
+
+**G5 applies to CRITIQUE only**, not REVIEW. Review verdicts legitimately change on unchanged
+diffs (CI flips, new comments, linked issues). G4 handles REVIEW non-determinism instead.
+
+**G1 open-PR step-aside (#1932):** once `pr_number` is set, G1 no longer fires — it steps aside
+and defers to G3, the canonical open-PR plan-stage redirect. Without this, a NEEDS
+REVISION/MAJOR REWORK critique verdict recorded before the PR was opened could route a shipped PR
+back to `/do-plan`.
+
+**G5 open-PR step-aside (#1932):** on its NEEDS_REVISION/MAJOR_REWORK branch (cached critique
+verdict, unchanged plan hash), G5 also steps aside once `pr_number` is set and defers to G3
+instead of re-dispatching `/do-plan`. The READY_TO_BUILD branch already deferred on `pr_number`
+or `BUILD == completed`; this closes the same gap on the revision branch.
+
+**G7 blocks build while plan revision is in flight.** The lock is set by `/do-plan-critique`
+(Step 5.6) when the verdict requires a revision pass, cleared by `/do-plan` (Phase 4, Step 2b)
+after pushing the revision, and self-heals when `revision_applied: true` is in the plan
+frontmatter. Gated on `pr_number is None` so an already-shipped PR is never blocked.
+
+**G7 precedes G5 and G6 in list order (issue #1871).** G5's cached READY-TO-BUILD fast path does
+not itself read `plan_revising`, so G7 must run first to intercept a stale-hash cache hit while a
+revision is pending. The "an already-mergeable PR is never blocked by a stale `plan_revising`
+flag" guarantee does **not** come from list position relative to G6 — it comes from G7's own Gate
+1 (`pr_number` set → return `None`). G6 only ever fires when `pr_number` is set, so in every
+state where G6 could dispatch `/do-merge`, G7 has already deferred at Gate 1; G6 always wins
+regardless of list position.
+
+**Convergence latch — `revision_applied_at` (issue #1760).** `revision_applied` is sticky:
+`/do-plan` sets it `true` on every revision pass and it never resets, so it can't tell "this is
+the settle-and-build revision the critique verdict judged" apart from "a later, unrelated
+`/do-plan` dispatch". `/do-plan` Phase 4 Step 2a now also writes an event-scoped
+`revision_applied_at: <ISO-8601 UTC timestamp>` in the SAME step as `revision_applied: true`
+(never a follow-up edit). `agent.sdlc_router._critique_verdict_is_stale()` uses it as a latch: a
+`/do-plan` dispatch at or before `revision_applied_at` is treated as converged (not stale); one
+that postdates it re-stales normally, so a later unrelated revision never gets a free pass to
+BUILD. Absent/unparseable `revision_applied_at` leaves the latch inert (fail-safe to pre-#1760
+timestamp-only staleness). **Verdict-kind gate (#2049):** the latch engages only for verdicts that
+do not require a revision (the settle-and-build READY TO BUILD path); for NEEDS REVISION / MAJOR
+REWORK the settled revision *invalidates* the verdict — it stays stale and row 2b routes to
+`/do-plan-critique`, never back to `/do-plan`. **With-concerns scope (#2787):** on the `READY TO
+BUILD (with concerns)` path a bounded branch runs ahead of the latch — below
+`MAX_CONCERN_RECRITIQUE_ROUNDS` the concern-closing revision re-stales the verdict so row 2b
+re-critiques it; at the bound the latch engages and row 4c builds with the residual concerns
+recorded as accepted. See [With-Concerns Re-Critique Gate](../../../docs/features/with-concerns-recritique-gate.md)
+and [SDLC Pipeline — Convergence Latch](../../../docs/features/sdlc-pipeline.md#convergence-latch-revision_applied_at-issue-1760)
+for the full mechanism.
+
+**ISSUE_LOCKED (not a G-guard, issues #1954/#2003):** `sdlc-tool next-skill` checks the
+issue-level ownership lock *before* evaluating G1-G9, and short-circuits to
+`{"blocked": true, "reason": "ISSUE_LOCKED", "owner_run_id": ..., "owner_session_id": ...,
+"orphaned_lock": ...}` if a foreign run holds the lock for this issue. Ownership is keyed by
+`run_id` (minted only by `session-ensure`, carried via `--run-id`), never by session_id or
+process identity. `ensure_session` surfaces the same `{"blocked": true, ...}` shape at its own
+call site. `dispatch record`'s CLI wrapper surfaces the lock differently: on a failed write it
+peeks the lock and, if contention caused the failure, merges `reason`/`owner_run_id`/
+`owner_session_id` into its existing `{"ok": false, "history_length": N}` result (never
+`blocked`) — see `_cli_record()` in `tools/sdlc_dispatch.py`. `orphaned_lock: true` means the
+owning run died before its next renewal — the lock frees itself within the lease TTL
+(`ISSUE_LOCK_TTL_SECONDS`, default 30 min; the happy path releases it immediately at run end).
+**The signal is renewal freshness, not process liveness (issue #2620):** the lease payload's
+`pid` belongs to the ephemeral `session-ensure` CLI and is dead within seconds of acquire, so
+`_lock_owner_is_live` keys on the `renewed_at` stamp that every renewal tick refreshes. A
+recently-renewed lease is a LIVE owner (`orphaned_lock: false` → stop), and only a lease nobody
+has renewed for `ISSUE_LOCK_RENEWAL_FRESHNESS_SECONDS` (default 20 min) reads orphaned.
+**Self-owned continue path:** if `owner_run_id` is a `run_id` this run has already held (minted
+at the start of the run, or inherited from the supervisor per Step 2), the lock is YOURS — this
+is not a block. Continue the stage under that run_id (a bare `session-ensure` under the live
+supervised-run signal returns `SUPERVISED_RUN_ACTIVE` carrying the same run_id — inherit it, per
+Step 2). Only a FOREIGN `owner_run_id` is a hard block: surface the `reason` and `owner_run_id`
+to the human and stop; do not loop, do not attempt to route around it.
+
+**Known gap — stale REVIEW verdict after PATCH (issue #1932 / PR #1941):** G3 and G6 above key
+off `_verdicts["REVIEW"]` containing `APPROVED`, not off whether that verdict was recorded
+*after* the most recent PATCH commit. Before PR #1941's router fix (and for any similar gap not
+yet caught), `next-skill` can propose `/do-merge` on a stale pre-patch `APPROVED`/`CHANGES
+REQUESTED` verdict because nothing forces a fresh `/do-pr-review` after `/do-patch` resolves
+REVIEW findings. Before trusting a router-proposed `/do-merge`, verify with `sdlc-tool verdict
+get --stage REVIEW --issue-number {N}` that the recorded verdict is `APPROVED` and postdates the
+patch commit; if not, manually dispatch `/do-pr-review` first.
+
+**Row 10 merge gate:** `/do-merge` fires only when REVIEW and DOCS are complete, the PR merge
+state is CLEAN, CI is all-passing, and the recorded REVIEW verdict is APPROVED at the current
+head.
+
+
+## Step 4: Dispatch ONE Sub-Skill
+
+**Do not pattern-match against a hand-edited table.** Instead, call the routing tool and dispatch
+whatever skill it returns. The tool evaluates all guards (G1–G9) and dispatch rules (19 rows)
+against live state. In router mode this is the whole job: call `next-skill`, record the dispatch,
+invoke the ONE returned skill, then **return**. In supervisor mode the same call feeds Step 5's
+loop.
+
+```bash
+# Get the next dispatch decision
+sdlc-tool next-skill --issue-number {issue_number} --run-id {run_id}
+```
+
+The tool dispatches at most ONE skill per call. It outputs JSON in one of these shapes:
+
+Single dispatch:
+```json
+{"skill": "/do-build", "reason": "...", "row_id": "4a", "dispatched": true}
+```
+
+Blocked:
+```json
+{"blocked": true, "reason": "G4: stage oscillation ...", "guard_id": "G4"}
+```
+
+Blocked (issue-level ownership lock -- not a G-guard, see Step 3.6):
+```json
+{"blocked": true, "reason": "ISSUE_LOCKED", "owner_run_id": "...", "owner_session_id": "...", "orphaned_lock": false}
+```
+
+**How to use the output:**
+1. If `dispatched` is `true`: record the dispatch via `sdlc-tool dispatch record` (see below),
+   then invoke the returned `skill`.
+2. If `blocked` is `true`: surface the `reason` to the human and wait. Do NOT loop or guess an
+   alternative skill. This applies identically whether the block came from a G1-G9 guard or from
+   `reason: "ISSUE_LOCKED"` (another live session already owns this issue) -- report
+   `owner_session_id` to the human, do not loop, do not attempt to route around it.
+3. If neither key is present (error): log the `error` field and escalate to the human.
+
+**Before recording and dispatching**, also supply `--proposed-skill` when you already know what
+skill you intend to invoke (enables G3 PR-lock detection):
+```bash
+sdlc-tool next-skill --issue-number {issue_number} --run-id {run_id} --proposed-skill /do-build
+```
+
+Record every dispatch decision via `sdlc-tool dispatch record` BEFORE invoking the sub-skill —
+this preserves the G4 oscillation signal even if the sub-skill crashes mid-execution.
+
+```bash
+# Record a dispatch event (call BEFORE invoking the sub-skill)
+sdlc-tool dispatch record --skill /do-build --issue-number {issue_number} --run-id {run_id}
+
+# Record with PR context (for review/patch/merge stages)
+sdlc-tool dispatch record --skill /do-pr-review --issue-number {issue_number} --pr-number {pr_number} --run-id {run_id}
+
+# Inspect the dispatch history (debug G4 state; read-only, no --run-id)
+sdlc-tool dispatch get --issue-number {issue_number}
+```
+
+The CLI wraps `agent.sdlc_router.record_dispatch()` and `tools.stage_states_helpers.update_stage_states()` — it is the correct runtime entry point. Never call `record_dispatch()` directly from a shell or skill script; always use `sdlc-tool dispatch record`.
+
+Do NOT restart from scratch if prior stages are already complete.
+
+## Step 5: Supervision Loop (supervisor mode only)
+
+Repeat the following cycle. **Iteration cap: 15 dispatches** (a happy path is 8 stages; the cap
+is a backstop above realistic patch/re-review cycles — G4 catches genuine oscillation long before
+it). Router mode never enters this step — it returns after Step 4.
+
+### 5a. Ask the router
 
 ```bash
 sdlc-tool next-skill --issue-number {issue_number} --run-id {run_id}
@@ -123,7 +505,7 @@ sdlc-tool next-skill --issue-number {issue_number} --run-id {run_id}
 identity assertion: it peeks under the caller's own stated identity so this run is never told to
 stand down for a lock it holds itself, issue #2766. Always pass it here.)
 
-Interpret the JSON from the tool result:
+Interpret the JSON from the tool result (same shapes as Step 4):
 
 - `{"blocked": true, "reason": "ISSUE_LOCKED", ...}` → the payload additionally carries
   `peek_identity` (`"caller"` | `"session_mirror"` | `"unresolved"`) and, only when `--run-id` was
@@ -134,25 +516,40 @@ Interpret the JSON from the tool result:
   Apply the self-identity check below to the row's `owner_run_id` before deciding whether this is
   actually your own lock.
 - `{"blocked": true, ...}` (other reasons) → **STOP the loop.** Report the `reason` and `guard_id` to the human, plus a summary of stages completed so far. Do not retry, do not guess an alternative skill.
-- `{"skill": "...", "dispatched": true, ...}` → continue to 3b. The router dispatches at most ONE skill per call; there is no parallel-pair shape.
+- `{"skill": "...", "dispatched": true, ...}` → continue to 5b. The router dispatches at most ONE skill per call; there is no parallel-pair shape.
 - Anything else (error key, empty) → STOP and surface the error.
 
-### 3b. Record the dispatch
+### 5b. Record the dispatch
 
 ```bash
 sdlc-tool dispatch record --skill {skill} --issue-number {issue_number} --run-id {run_id}
 # include --pr-number {pr} once a PR exists (review/patch/docs/merge stages)
 ```
 
-### 3c. Spawn the stage subagent
+### 5c. Spawn the stage subagent
 
-**One writer per artifact — enumerate live children before you dispatch.** Every stage you dispatch is a writer on a shared artifact, and the plan doc in particular is a single file on the shared main checkout that no worktree isolates. Before spawning, account for the children you already have out: if a child is still holding the plan doc, do not dispatch a second one onto it, and do not edit it yourself while it does. Wait for the outstanding child to report, then dispatch.
+**One writer per artifact — enumerate live children before you dispatch.** Every stage you
+dispatch is a writer on a shared artifact, and the plan doc in particular is a single file on the
+shared main checkout that no worktree isolates. Before spawning, account for the children you
+already have out: if a child is still holding the plan doc, do not dispatch a second one onto it,
+and do not edit it yourself while it does. Wait for the outstanding child to report, then
+dispatch.
 
-This is not hypothetical. On 2026-08-07 one plan doc took two concurrent revision children twice over (#2650, shape 3) — a writer watched its line count grow from 62 to 111 between its own reads and had to stop and ask who owned the file — and a supervisor patched a plan task while its own dispatched child held the doc, then had to warn the child mid-flight to re-read before committing (shape 4). Both were recovered only because an agent happened to notice the file moving underneath it.
+This is not hypothetical. On 2026-08-07 one plan doc took two concurrent revision children twice
+over (#2650, shape 3) — a writer watched its line count grow from 62 to 111 between its own
+reads and had to stop and ask who owned the file — and a supervisor patched a plan task while its
+own dispatched child held the doc, then had to warn the child mid-flight to re-read before
+committing (shape 4). Both were recovered only because an agent happened to notice the file
+moving underneath it.
 
-Since Hard Rule 6 already requires `run_in_background: false`, the ordinary loop has exactly one child out at a time and satisfies this for free. The rule bites when you are tempted to fan out, or to "just fix one line" in a doc a child is revising. Neither is safe; the second is the one that feels harmless.
+Since Hard Rule 6 already requires `run_in_background: false`, the ordinary loop has exactly one
+child out at a time and satisfies this for free. The rule bites when you are tempted to fan out,
+or to "just fix one line" in a doc a child is revising. Neither is safe; the second is the one
+that feels harmless.
 
-Use the Agent tool (general-purpose), with `model:` from the Stage→Model table and **`run_in_background: false`** (Hard Rule 6 — this fork cannot be resumed by a background notification). Prompt template:
+Use the Agent tool (general-purpose), with `model:` from the Stage→Model table and
+**`run_in_background: false`** (Hard Rule 6 — this fork cannot be resumed by a background
+notification). Prompt template:
 
 ```
 You are executing ONE SDLC stage for issue #{issue_number} in {repo_path}.
@@ -175,11 +572,14 @@ When done, report back (this is data for the supervisor, not prose for a human):
 - failures: test failures, blockers, or errors verbatim if any
 ```
 
-Carry forward context between iterations: the `run_id` goes into every stage prompt, and once BUILD reports a PR number, include it in every subsequent prompt and in `dispatch record --pr-number`.
+Carry forward context between iterations: the `run_id` goes into every stage prompt, and once
+BUILD reports a PR number, include it in every subsequent prompt and in `dispatch record
+--pr-number`.
 
-### 3d. Backfill stage markers (TEST and PATCH only)
+### 5d. Backfill stage markers (TEST and PATCH only)
 
-`/do-test` and `/do-patch` do not write their own stage markers — on the bridge, the worker's dev-completion handler does it. Locally, the supervisor must:
+`/do-test` and `/do-patch` do not write their own stage markers — on the bridge, the worker's
+dev-completion handler does it. Locally, the supervisor must:
 
 ```bash
 sdlc-tool stage-marker --stage TEST --status completed --issue-number {issue_number} --run-id {run_id}
@@ -195,15 +595,15 @@ you think it says. Read the stderr diagnostic and route it:
   owns this issue. **Stop the loop** and report; continuing writes nothing and
   loses the run.
 - `LEASE_ABSENT`, or `ISSUE_LOCKED` naming an id you recognize as your own →
-  your lease lapsed. Run the Step 3d.6 re-ensure, **adopt the `run_id` it
+  your lease lapsed. Run the Step 5e.6 re-ensure, **adopt the `run_id` it
   returns**, and retry the marker once under the adopted id.
 - Anything else (a Redis/broker error, a timeout) → transient. Retry once, and
   only report-and-continue if it persists. A transient error is never an
   unconditional pipeline abort.
 
-### 3d.4. REVIEW self-check gate (issue #2193)
+### 5d.4. REVIEW self-check gate (issue #2193)
 
-If the stage just dispatched in 3c was `/do-pr-review`, do not treat its
+If the stage just dispatched in 5c was `/do-pr-review`, do not treat its
 return as sufficient to advance. `/do-pr-review` should have already called
 `sdlc-tool verdict finalize` internally (an atomic verdict+trailer+marker
 write) before returning — but the supervisor is the loud, committed backstop
@@ -217,8 +617,8 @@ Interpret the typed JSON result (`{ok, verdict_present, trailer_matches_head,
 marker_completed, reason}`):
 
 - `{"ok": true, ...}` → the verdict, its freshness trailer, and the REVIEW
-  completion marker are all confirmed present. Proceed to 3e / loop back to
-  3a as normal.
+  completion marker are all confirmed present. Proceed to 5e / loop back to
+  5a as normal.
 - `{"ok": false, ...}` → **HALT the loop immediately.** Print the machine-readable
   `reason` field loudly to the operator (e.g. "REVIEW SELF-CHECK FAILED:
   reason={reason} — pr={pr_number} issue={issue_number}"), along with which of
@@ -226,7 +626,7 @@ marker_completed, reason}`):
   Do NOT re-dispatch REVIEW yourself, do NOT advance to DOCS/MERGE, and do NOT
   silently loop back to the router — this is a single loud refusal, replacing
   the old failure mode where the router would silently re-dispatch REVIEW
-  forever on the same missing state. Report this as a stop condition in Step 4
+  forever on the same missing state. Report this as a stop condition in Step 6
   (Final Report) just like a `blocked` router decision.
 
 This gate is prose/logic in this skill body only — it does not modify
@@ -235,17 +635,22 @@ re-dispatch on missing state; see the router's rows 8/8b/9). It exists
 specifically to make the supervised `/do-sdlc` path *loud* on the exact
 failure the router would otherwise handle silently over multiple iterations.
 
-### 3d.5. Tool-availability mismatch guard (issue #2022)
+### 5d.5. Tool-availability mismatch guard (issue #2022)
 
-Inspect every stage subagent's final report before acting on it. If the final message is (or begins with) a **bare shell command** — it starts with `git `, `gh `, `cd `, `pytest`, `python `, or otherwise reads as a command line rather than the outcome/verdict/artifacts report the prompt template asks for — AND the child made **zero tool calls**, the child was spawned on an agent type without the tools its first step needed: it emitted the command it could not run as plain text. Treat this as a **tool-availability mismatch, never a normal completion**:
+Inspect every stage subagent's final report before acting on it. If the final message is (or
+begins with) a **bare shell command** — it starts with `git `, `gh `, `cd `, `pytest`, `python
+`, or otherwise reads as a command line rather than the outcome/verdict/artifacts report the
+prompt template asks for — AND the child made **zero tool calls**, the child was spawned on an
+agent type without the tools its first step needed: it emitted the command it could not run as
+plain text. Treat this as a **tool-availability mismatch, never a normal completion**:
 
 1. Log it: "TOOL-AVAILABILITY MISMATCH: stage={skill}, final message is a bare shell command with zero tool calls"
 2. Re-dispatch the same stage once on a Bash-capable agent type (`general-purpose`)
 3. If the re-dispatch shows the same signature, stop and surface the mismatch to the human — do not loop
 
-### 3d.6. Between-stage continuity re-ensure (issue #2452)
+### 5d.6. Between-stage continuity re-ensure (issue #2452)
 
-After the stage subagent returns (3c/3d/3d.4/3d.5) and before asking the router again (3a), re-ensure
+After the stage subagent returns (5c/5d/5d.4/5d.5) and before asking the router again (5a), re-ensure
 this run's identity:
 
 ```bash
@@ -289,14 +694,14 @@ relocate from the top of the loop to this stage seam:
   transient** — that is the wrapper/usage error above, and retrying it forever is how a broken
   install turns into an identity-less run.
 
-### 3e. Check exit conditions
+### 5e. Check exit conditions
 
-- Dispatched skill was `/do-merge` AND the subagent reports a merge → verify with `gh pr view {pr} --json state,mergedAt` from the tool result. If `MERGED`: **exit the loop, success.**
-- Router returned `blocked` → already stopped in 3a.
+- Dispatched skill was `/do-merge` AND the subagent reports a merge → verify with `gh pr view {pr} --repo <resolved> --json state,mergedAt` from the tool result. If `MERGED`: **exit the loop, success.**
+- Router returned `blocked` → already stopped in 5a.
 - Iteration cap reached → stop and report how far the pipeline got.
-- Otherwise → loop back to 3a. Brief one-line progress note per iteration (e.g. "CRITIQUE done (READY TO BUILD) → dispatching BUILD on sonnet").
+- Otherwise → loop back to 5a. Brief one-line progress note per iteration (e.g. "CRITIQUE done (READY TO BUILD) → dispatching BUILD on sonnet").
 
-## Step 4: Final Report
+## Step 6: Final Report
 
 On exit (any path), report:
 
@@ -305,7 +710,7 @@ On exit (any path), report:
 3. **Artifacts**: issue, plan path, PR number, merge commit
 4. **Anything needing human attention**: unresolved blockers, skipped acknowledgments, follow-ups
 
-## Step 5: Release the run lease
+## Step 7: Release the run lease
 
 You hold this issue's run lease for as long as this supervision loop lives, and
 nothing reclaims it when you simply stop — there is no terminal transition on a
@@ -320,8 +725,8 @@ whenever in doubt and never let its output change your reported outcome.
 
 Do this on the exits nothing else observes:
 
-- the **3d.4 REVIEW self-check HALT**
-- a **`blocked`** router decision (3a / 3e)
+- the **5d.4 REVIEW self-check HALT**
+- a **`blocked`** router decision (5a / 5e)
 - the **iteration cap** being reached
 
 The **merged** exit needs no action from you — completing the MERGE stage
@@ -338,4 +743,7 @@ makes the merged path correct.
 | Model assignment | PM passes `--model` when spawning dev sessions | supervisor passes `model:` on the Agent tool |
 | Where it runs | bridge PM sessions + local | local Claude Code sessions |
 
-Both consume the same router (`sdlc-tool next-skill` → `agent.sdlc_router.decide_next_dispatch()`) and the same stored stage state — there is exactly one source of dispatch truth.
+`/sdlc` is a thin `context: fork` shim over this skill's router mode: it reads this body's Step
+1–4 (resolve → session-ensure → assess → dispatch ONE), executes them once, and returns. Both
+entry points consume the same router (`sdlc-tool next-skill` → `agent.sdlc_router.decide_next_dispatch()`)
+and the same stored stage state — there is exactly one source of dispatch truth.

--- a/.claude/skills/sdlc/SKILL.md
+++ b/.claude/skills/sdlc/SKILL.md
@@ -6,270 +6,29 @@ context: fork
 
 # SDLC — Single-Stage Router
 
-This skill is a **router**, not an orchestrator. It assesses where work stands, invokes ONE sub-skill, and returns. The PM session handles pipeline progression by re-invoking `/sdlc` after each stage completes. In a local Claude Code session (no PM loop), use `/do-sdlc` to supervise the full pipeline in one invocation.
+This skill is a **router**, not an orchestrator. It assesses where work stands, invokes ONE
+sub-skill, and returns. The PM session handles pipeline progression by re-invoking this skill
+after each stage completes. In a local Claude Code session (no PM loop), use `/do-sdlc` to
+supervise the full pipeline in one invocation.
 
 You MUST NOT write code, run tests, or create plans directly -- delegate everything to sub-skills.
 
-## Worktree & branch ownership
-
-**Slug identity always wins.** Each issue's build fork exclusively owns `.worktrees/{slug}` and `session/{slug}`, derived from the plan slug — this is the single source of truth (`worktree_manager.py` + `resolve_branch_for_stage`). Do NOT pre-allocate per-supervisor `.worktrees/sdlc-{N}` lanes: nothing reads a lane override, so lane instructions are silently dropped and every issue's builders land in `.worktrees/{slug}` regardless. Converging fork + supervisor onto one branch per plan is deliberate — it structurally collapses duplicate PRs, since GitHub permits only one open PR per head branch. Concurrent builders inside the one slug worktree must write disjoint file sets (do-build's `Parallel: true` convention: no shared-file writes).
-
-## Cross-Repo Resolution
-
-For cross-project SDLC work, three resolution mechanisms cover the three different operations the pipeline runs:
-
-- `GH_REPO` (e.g., `tomcounsell/popoto`) — The `gh` CLI natively respects this, so all `gh` commands automatically target the correct repository. Set by `sdk_client.py`.
-- `SDLC_TARGET_REPO` (e.g., `~/src/popoto`) — The absolute path to the target project's repo root. Use this for all local filesystem and git operations instead of assuming cwd is the target repo. Set by `sdk_client.py`.
-- `AI_REPO_ROOT` (default `~/src/ai`) — Used by the `sdlc-tool` wrapper to resolve where the SDLC tooling Python modules live, independent of cwd. The wrapper dispatches into `tools.sdlc_*` from the ai/ repo even when the orchestrator's cwd is a target project. See [`docs/features/sdlc-tool-resolver.md`](../../../docs/features/sdlc-tool-resolver.md).
-
-**When `SDLC_TARGET_REPO` is set, you MUST use it** for plan lookups, branch listings, and any git commands. The orchestrator's cwd is the ai/ repo, NOT the target project. **For SDLC tooling (`sdlc-tool stage-query`, `sdlc-tool verdict record`, etc.), no env var is needed** — the wrapper resolves `AI_REPO_ROOT` itself with a `~/src/ai` default.
-
-## Step 1: Resolve the Issue or PR
-
-Determine whether the input is an issue reference or a PR reference:
-
-- **Issue reference** (e.g., `issue 123`, `issue #123`): Fetch with `gh issue view {number}`
-- **PR reference** (e.g., `PR 363`, `pr #363`): Fetch with `gh pr view {number}` to get the branch name, review state, and check status. Then extract the linked issue number from the PR body (look for `Closes #N` or `Fixes #N`).
-
-```bash
-# For issue references:
-gh issue view {number}
-
-# For PR references — get structured state for assessment:
-gh pr view {number} --json number,title,state,headRefName,reviewDecision,statusCheckRollup,body
-```
-
-**PR state informs Step 2 assessment**: When a PR is provided, its current state (checks passing/failing, review approved/changes-requested, etc.) tells you which pipeline stage to resume from. Skip stages that are already complete -- do not restart from scratch.
-
-If NO issue or PR number was provided (just a feature description), invoke `/do-issue` to create a quality issue. Do not proceed without an issue number.
-
-## Step 1.5: Session Tracking
-
-The run identity is a single `run_id` minted **once** at the start of the run and held for the whole pipeline by the supervising session (issue #2026, WS1 — single-owner lease). Stage forks **inherit** that `run_id` through the supervised-run signal; they never re-mint and never juggle the lock.
-
-```bash
-# Start of the run — mint the run_id and acquire the lease (writes the signal):
-sdlc-tool session-ensure --issue-number {issue_number}
-# => {"session_id": ..., "created": ..., "run_id": "<hex>"}
-```
-
-**Inheriting the run_id in a stage fork.** If this conversation already carries the `run_id` (from the supervisor or an earlier stage), just use it — do **not** call `session-ensure` again. If you re-run a bare `session-ensure` while the supervised run is live, the tool refuses with the named `SUPERVISED_RUN_ACTIVE`, carrying the supervisor's `run_id` for you to inherit:
-
-```json
-{"blocked": true, "reason": "SUPERVISED_RUN_ACTIVE", "run_id": "<hex>", "owner_run_id": "<hex>", "owner_session_id": "..."}
-```
-
-**The goal: one run identity per issue, and never adopt a stranger's.** The decisive test is whether `owner_run_id` is a `run_id` this run has already held.
-
-- **It is yours** (the supervisor that forked you, or an earlier stage of this same run) → inherit `owner_run_id`, carry it forward as your `run_id`, and continue the stage. This is a hand-off, not a block.
-- **You have never held it** → a genuine concurrent rival owns this issue. Stop and report `owner_run_id` / `owner_session_id`. Do not inherit, do not route around it.
-
-`owner_session_id == sdlc-local-{issue_number}` is *not* the test — ledger anchors are keyed by issue number, so a rival run on the same issue emits a byte-identical `owner_session_id`. Compare `owner_run_id`, and do not substitute the sibling `run_id` field for it.
-
-A stale/expired signal (the lease was released at run end, or its TTL lapsed) falls back to normal standalone semantics and mints fresh. `/do-sdlc` Step 2 holds the full refusal decision table covering the orphaned-lock and foreign-holder cases; it is the authority — when this file and that table disagree, that table wins.
-
-`session-ensure` remains the EXCLUSIVE minting site for the run identity (issue #2003). Three rules that DO matter:
-
-- **Pass `--issue-number` to every `sdlc-tool` invocation.** It is the authoritative session selector.
-- **Pass `--run-id {run_id}` to every state *write*** (`dispatch record`, `verdict record`, `meta-set`, `stage-marker`, and `merge_predicate --run-id`). A missing flag is a named non-zero error (`RUN_ID_REQUIRED`) — no mint, no adopt. `stage-query`, `verdict get`, and `dispatch get` have no lock to compare against and accept no `--run-id` argument at all. `next-skill` sits in neither bucket: it *accepts* `--run-id` too, but as a read-only identity assertion, not a write authorization — always pass it there (issue #2766) so its issue-lock peek runs under your own stated identity instead of inferring one, and this run is never told to stand down for its own lock.
-- **Do NOT export `AGENT_SESSION_ID`** — env vars do not persist across Claude Code bash blocks.
-
-**Self-heal on resume (issue #2144).** State-mutating writes (`stage-marker`, `verdict record`, `meta-set`, `dispatch record`) now **self-heal** their run identity: if a resumed turn has lost the `run_id` from context (worker restart mid-pipeline), the write re-establishes the *same* run's identity from the environment (live supervised signal → `.sdlc-run` / `active_run_id` → verified re-acquire of the free lock) and retries once, instead of silently refusing `RUN_ID_REQUIRED`/`LEASE_ABSENT` and freezing the ledger. This is best-effort and non-blocking; a foreign live lease still hard-refuses. You no longer need to hand-run `session-ensure --reuse-run-id <id>` as a workaround before markers resume flowing — see [`docs/features/sdlc-run-identity-self-heal.md`](../../../docs/features/sdlc-run-identity-self-heal.md). Still pass `--run-id` on the happy path; the heal is a safety net for the resume edge, not a license to omit it.
-
-## Step 2: Assess Current State
-
-Check what already exists for this issue. Use `$SDLC_TARGET_REPO` for local operations (defaults to `.` for same-repo work). Run ALL of these checks — do not skip any.
-
-**Command discipline (applies to every check in Steps 2-3):** run each check as a separate single-line command and read the output from the tool result — no pipes, no command substitution, no `||` fallbacks, no environment-variable capture. You interpret the output and decide the next step.
-
-### Step 2.0: Query stage_states from PipelineStateMachine (primary signal)
-
-Query the PM session's `stage_states` for authoritative stage completion data. This is the **exclusive signal** for routing decisions. Stage completion is determined ONLY by stored state — never by artifact inference.
-
-The tool resolves the active session from `VALOR_SESSION_ID`, `AGENT_SESSION_ID`, or `--issue-number` internally.
-
-```bash
-sdlc-tool stage-query --issue-number {issue_number}
-```
-
-Interpret the JSON output from the tool result:
-- Non-empty object with stage keys (e.g. `{"ISSUE": "completed", "PLAN": "completed", "BUILD": "in_progress"}`): use it as the **exclusive signal** for the dispatch table. A stage is behind us ONLY if its value is `"completed"` — or `"skipped"`, which only PLAN and CRITIQUE can ever hold and which means the pipeline never dispatched that stage because this issue has no plan document (#2577, see [`docs/features/off-pipeline-merge-path.md`](../../../docs/features/off-pipeline-merge-path.md)). Never re-dispatch a skipped stage. Skip steps 2a-2e.
-- Empty `{}` or an `unavailable` marker: fall through to the dispatch-history fallback in steps 2a-2e. Do NOT infer stage completion from artifacts.
-
-### Steps 2a-2e: Dispatch History Fallback
-
-These checks run ONLY when stage_states is unavailable (empty JSON from step 2.0). When stage_states IS available, skip directly to the dispatch table using stage_states as the source of truth.
-
-**IMPORTANT: Never infer stage completion from artifacts (plan files, PR existence, docs/ files, etc.). Stage completion is exclusively determined by stored state.**
-
-When stage_states is unavailable, use conversation context to identify which skills were already dispatched in this session. Artifacts are used only to check preconditions (e.g., "does a PR exist?") — not to declare stages complete.
-
-`$SDLC_TARGET_REPO` is exported by the harness so `git -C` picks it up without further shell composition; `gh` uses `$GH_REPO` automatically for the cross-repo case.
-
-```bash
-# 2a. Check if a plan doc references this issue
-grep -r "#{issue_number}" docs/plans/
-```
-
-```bash
-# 2b. List all branches (filter for session/ prefix in the tool result)
-git -C "$SDLC_TARGET_REPO" branch -a
-```
-
-```bash
-# 2c. Check if a PR already exists
-gh pr list --search "#{issue_number}" --state open
-# Cross-check with live refs — the --search index lags GitHub; --head queries live refs:
-#   gh pr list --head session/{slug} --state open   (reuse if present; keyed by head branch, not issue #)
-```
-
-If a PR exists, fetch its full state for assessment:
-```bash
-# 2d. Get PR state: checks, review, branch
-gh pr view {pr_number} --json number,headRefName,reviewDecision,statusCheckRollup,body
-
-# 2e. Check review status — look for APPROVED, CHANGES_REQUESTED, or no review
-# reviewDecision: "APPROVED" means formal GitHub review approved (non-self-authored PRs)
-# reviewDecision: "CHANGES_REQUESTED" means formal GitHub review requested changes
-# reviewDecision: "" (empty) — AMBIGUOUS for self-authored PRs:
-#   - For non-self-authored PRs: no review posted yet
-#   - For self-authored PRs: expected even after review — check _verdicts["REVIEW"] from sdlc_stage_query
-# Always cross-check _meta.latest_review_verdict before concluding no review exists.
-```
-
-## Step 3: Check Documentation Status
-
-This step is REQUIRED when a PR exists and review is clean (APPROVED). Skip it only if the pipeline hasn't reached the REVIEW stage yet.
-
-```bash
-# 3a. List files changed in the PR (count docs/ entries from the tool result)
-gh pr diff {pr_number} --name-only
-```
-
-```bash
-# 3b. Find the plan path for this issue (first match from the tool result)
-grep -rl "#{issue_number}" docs/plans/
-```
-
-```bash
-# 3c. Read the plan's Documentation section (inspect for unchecked tasks in the tool result)
-cat docs/plans/{plan-filename}.md
-```
-
-For the DOCS stage completion check, re-read the `sdlc-tool stage-query` output from Step 2.0. Do not pipe JSON through a shell here.
-
-**Decision logic for docs**:
-- If the plan has a `## Documentation` section with unchecked tasks → docs NOT done
-- If PR has zero `docs/` file changes AND plan requires doc tasks → docs NOT done
-- If docs tasks are all checked AND `docs/` changes exist in PR → docs done
-- When in doubt, dispatch `/do-docs` — it is idempotent and will no-op if nothing needs updating
-
-## Step 3.5: Legal Dispatch Guards (reference)
-
-`sdlc-tool next-skill` (Step 4) evaluates these guards itself — do NOT re-evaluate them by hand. The table exists so you can interpret a `blocked` decision or a forced dispatch when the tool returns one. Canonical implementation: `agent.sdlc_router.decide_next_dispatch()`; the parity test `tests/unit/test_sdlc_skill_md_parity.py` keeps this table in sync with the Python rules.
-
-Guards are evaluated in the **pinned `GUARDS` list order** `[G1, G2, G3, G4, G9, G8, G7, G5, G6]` — the first to return a non-`None` decision wins. Guard IDs are historical (assigned in introduction order), not evaluation order; the table below is listed in evaluation order:
-
-| Guard | Condition | Forced Dispatch |
-|-------|-----------|-----------------|
-| G1: Critique loop | Latest critique verdict contains `NEEDS REVISION` or `MAJOR REWORK` AND `last_dispatched_skill == /do-plan-critique` | `/do-plan` |
-| G2: Critique cycle cap | `critique_cycle_count >= MAX_CRITIQUE_CYCLES` (2) AND CRITIQUE is not completed | Escalate: `blocked` with reason `critique cycle cap reached` |
-| G3: PR lock | `pr_number` is set AND (`last_dispatched_skill` OR proposed dispatch) is `/do-plan` or `/do-plan-critique` | `/do-merge` (if REVIEW and DOCS complete), `/do-patch` (if review requested changes), else `/do-pr-review` |
-| G4: Oscillation (universal) | `same_stage_dispatch_count >= 3` | Escalate: `blocked` with reason `stage oscillation — {skill} dispatched {N} times without state change` |
-| G9: Blocked-on-conflict | Recorded REVIEW verdict contains `BLOCKED_ON_CONFLICT` AND `pr_merge_state` not in the non-conflicting set (`CLEAN`, `HAS_HOOKS`, `UNSTABLE`, `BLOCKED`, `BEHIND`) AND the verdict is not stale (no `/do-patch` landed after it, #2796) | Escalate: `blocked` with reason naming the PR, the merge state, and the rebase — no SDLC skill resolves merge conflicts |
-| G8: Stage-advance verification | `context["stage_artifacts_verified"] is False` (a claimed stage artifact — PR, branch, plan commit — failed live verification) | Re-dispatch the skill owning `context["unverified_stage"]` |
-| G7: Plan-revising lock | `pr_number` is None AND `plan_revising == True` AND no `/do-plan` revision has landed since the latest CRITIQUE verdict (event-scoped, #2787 — NOT the sticky `revision_applied` boolean) | `/do-plan` (if `last_dispatched_skill == /do-plan-critique`); Escalate `blocked` (if no `/do-plan` in last `MAX_PLAN_REVISING_DISPATCHES + 1` turns) |
-| G5: Unchanged critique artifact | `_verdicts["CRITIQUE"]` has `artifact_hash` AND current plan file hash matches | Use cached verdict: `/do-plan` (NEEDS REVISION) or `/do-build` (READY TO BUILD, no concerns). Never re-dispatch `/do-plan-critique` on an unchanged plan. **Steps aside unconditionally on `READY TO BUILD (with concerns)`** so rows 2b/4b/4c own that state (#2787); the bound there is `MAX_CONCERN_RECRITIQUE_ROUNDS`, not G5. |
-| G6: Terminal merge ready | `pr_number` set AND `pr_merge_state == "CLEAN"` AND `ci_all_passing == True` AND `DOCS == "completed"` AND `_verdicts["REVIEW"]` contains `APPROVED` | `/do-merge {pr_number}` |
-
-**G4 is universal** — it applies to EVERY stage, including DOCS and MERGE. Repeated dispatches of `/do-docs` or `/do-merge` without state change WILL trip the guard.
-
-**G4 precedes G8 by design (issue #1267).** G8 re-dispatches the same stage's skill on a false artifact claim, with nothing upstream to stop it on a persistently false claim. Because G4 runs first, it fires and blocks once `same_stage_dispatch_count >= MAX_SAME_STAGE_DISPATCHES` before G8 gets another chance to re-dispatch — silent re-dispatch first, escalate via the existing G4 cap second, not an immediate block on the first mismatch.
-
-**G9 (issue #2796).** A `BLOCKED_ON_CONFLICT` REVIEW verdict previously routed by accident — row 8 sent it to `/do-patch` (which cannot rebase), row 8b sent it back to `/do-pr-review` (whose preflight re-recorded the same verdict) — ping-ponging until G4 escalated with a reason naming neither the conflict nor the rebase. G9 escalates immediately with a reason that names both. Its non-conflicting step-aside set (`CLEAN`, `HAS_HOOKS`, `UNSTABLE`, `BLOCKED`, `BEHIND`) mirrors `/do-pr-review`'s own preflight decision table exactly, so a PR that is merely `BEHIND` or `UNSTABLE` is never wrongly told it has merge conflicts. `tools/sdlc_stage_query.py::_fetch_pr_merge_state` retries once on a transient `UNKNOWN` read before G9 (or G6) ever sees the value.
-
-**G8 makes no live calls.** Live verification of claimed stage artifacts happens in the next-skill context-assembly path (`tools/sdlc_next_skill.py`), which sets `context["stage_artifacts_verified"]` / `context["unverified_stage"]`; G8 (`agent.sdlc_router.guard_g8_artifact_verification`) only reads those flags. This keeps `agent/sdlc_router.py` import-free of `tools/` (see `tests/unit/test_architectural_constraints.py`). Absent/unset/`True` is a no-op, and a stage whose claimed artifact has no resolvable identifier (e.g. no recorded `pr_number`) is skipped rather than reported as a mismatch (#2757). The verifier's `git` checks run with `cwd=_target_repo_cwd()` (`SDLC_TARGET_REPO`, a filesystem path) so they inspect the SDLC target repo, not the process cwd — see the cwd-threading contract (#2078) in `docs/features/sdlc-router-oscillation-guard.md`.
-
-**G5 applies to CRITIQUE only**, not REVIEW. Review verdicts legitimately change on unchanged diffs (CI flips, new comments, linked issues). G4 handles REVIEW non-determinism instead.
-
-**G1 open-PR step-aside (#1932):** once `pr_number` is set, G1 no longer fires — it steps aside and defers to G3, the canonical open-PR plan-stage redirect. Without this, a NEEDS REVISION/MAJOR REWORK critique verdict recorded before the PR was opened could route a shipped PR back to `/do-plan`.
-
-**G5 open-PR step-aside (#1932):** on its NEEDS_REVISION/MAJOR_REWORK branch (cached critique verdict, unchanged plan hash), G5 also steps aside once `pr_number` is set and defers to G3 instead of re-dispatching `/do-plan`. The READY_TO_BUILD branch already deferred on `pr_number` or `BUILD == completed`; this closes the same gap on the revision branch.
-
-**G7 blocks build while plan revision is in flight.** The lock is set by `/do-plan-critique` (Step 5.6) when the verdict requires a revision pass, cleared by `/do-plan` (Phase 4, Step 2b) after pushing the revision, and self-heals when `revision_applied: true` is in the plan frontmatter. Gated on `pr_number is None` so an already-shipped PR is never blocked.
-
-**G7 precedes G5 and G6 in list order (issue #1871).** G5's cached READY-TO-BUILD fast path does not itself read `plan_revising`, so G7 must run first to intercept a stale-hash cache hit while a revision is pending. The "an already-mergeable PR is never blocked by a stale `plan_revising` flag" guarantee does **not** come from list position relative to G6 — it comes from G7's own Gate 1 (`pr_number` set → return `None`). G6 only ever fires when `pr_number` is set, so in every state where G6 could dispatch `/do-merge`, G7 has already deferred at Gate 1; G6 always wins regardless of list position.
-
-**Convergence latch — `revision_applied_at` (issue #1760).** `revision_applied` is sticky: `/do-plan` sets it `true` on every revision pass and it never resets, so it can't tell "this is the settle-and-build revision the critique verdict judged" apart from "a later, unrelated `/do-plan` dispatch". `/do-plan` Phase 4 Step 2a now also writes an event-scoped `revision_applied_at: <ISO-8601 UTC timestamp>` in the SAME step as `revision_applied: true` (never a follow-up edit). `agent.sdlc_router._critique_verdict_is_stale()` uses it as a latch: a `/do-plan` dispatch at or before `revision_applied_at` is treated as converged (not stale); one that postdates it re-stales normally, so a later unrelated revision never gets a free pass to BUILD. Absent/unparseable `revision_applied_at` leaves the latch inert (fail-safe to pre-#1760 timestamp-only staleness). **Verdict-kind gate (#2049):** the latch engages only for verdicts that do not require a revision (the settle-and-build READY TO BUILD path); for NEEDS REVISION / MAJOR REWORK the settled revision *invalidates* the verdict — it stays stale and row 2b routes to `/do-plan-critique`, never back to `/do-plan`. **With-concerns scope (#2787):** on the `READY TO BUILD (with concerns)` path a bounded branch runs ahead of the latch — below `MAX_CONCERN_RECRITIQUE_ROUNDS` the concern-closing revision re-stales the verdict so row 2b re-critiques it; at the bound the latch engages and row 4c builds with the residual concerns recorded as accepted. See [With-Concerns Re-Critique Gate](../../../docs/features/with-concerns-recritique-gate.md) and [SDLC Pipeline — Convergence Latch](../../../docs/features/sdlc-pipeline.md#convergence-latch-revision_applied_at-issue-1760) for the full mechanism.
-
-**ISSUE_LOCKED (not a G-guard, issues #1954/#2003):** `sdlc-tool next-skill` checks the issue-level ownership lock *before* evaluating G1-G9, and short-circuits to `{"blocked": true, "reason": "ISSUE_LOCKED", "owner_run_id": ..., "owner_session_id": ..., "orphaned_lock": ...}` if a foreign run holds the lock for this issue. Ownership is keyed by `run_id` (minted only by `session-ensure`, carried via `--run-id`), never by session_id or process identity. `ensure_session` surfaces the same `{"blocked": true, ...}` shape at its own call site. `dispatch record`'s CLI wrapper surfaces the lock differently: on a failed write it peeks the lock and, if contention caused the failure, merges `reason`/`owner_run_id`/`owner_session_id` into its existing `{"ok": false, "history_length": N}` result (never `blocked`) — see `_cli_record()` in `tools/sdlc_dispatch.py`. `orphaned_lock: true` means the owning run died before its next renewal — the lock frees itself within the lease TTL (`ISSUE_LOCK_TTL_SECONDS`, default 30 min; the happy path releases it immediately at run end). **The signal is renewal freshness, not process liveness (issue #2620):** the lease payload's `pid` belongs to the ephemeral `session-ensure` CLI and is dead within seconds of acquire, so `_lock_owner_is_live` keys on the `renewed_at` stamp that every renewal tick refreshes. A recently-renewed lease is a LIVE owner (`orphaned_lock: false` → stop), and only a lease nobody has renewed for `ISSUE_LOCK_RENEWAL_FRESHNESS_SECONDS` (default 20 min) reads orphaned. **Self-owned continue path:** if `owner_run_id` is a `run_id` this run has already held (minted at the start of the run, or inherited from the supervisor per Step 1.5), the lock is YOURS — this is not a block. Continue the stage under that run_id (a bare `session-ensure` under the live supervised-run signal returns `SUPERVISED_RUN_ACTIVE` carrying the same run_id — inherit it, per Step 1.5). Only a FOREIGN `owner_run_id` is a hard block: surface the `reason` and owner identifiers to the human, do not loop, and do not attempt to route around it by guessing an alternative skill — exactly like a G1-G9 block. **Always pass `--run-id {run_id}` to `next-skill` (issue #2766)** so its peek runs under your own stated identity directly instead of a session lookup that can legitimately miss (terminal status, non-eng session_type, or a lookup exception) and produce a false self-block. The blocked payload additionally carries `peek_identity` (`"caller"` | `"session_mirror"` | `"unresolved"`) and, on the `--run-id`-supplied blocked path only, `session_mirror_run_id` — both are diagnostics for a human reading the block, never control-flow: `peek_identity: "unresolved"` is reported as *inconclusive*, not as a confirmed rival, and there is no automatic re-ensure/retry keyed on either key.
-
-**Known gap — stale REVIEW verdict after PATCH (issue #1932 / PR #1941):** G3 and G6 above key off `_verdicts["REVIEW"]` containing `APPROVED`, not off whether that verdict was recorded *after* the most recent PATCH commit. Before PR #1941's router fix (and for any similar gap not yet caught), `next-skill` can propose `/do-merge` on a stale pre-patch `APPROVED`/`CHANGES REQUESTED` verdict because nothing forces a fresh `/do-pr-review` after `/do-patch` resolves REVIEW findings. Before trusting a router-proposed `/do-merge`, verify with `sdlc-tool verdict get --stage REVIEW --issue-number {N}` that the recorded verdict is `APPROVED` and postdates the patch commit; if not, manually dispatch `/do-pr-review` first.
-
-Record every dispatch decision via `sdlc-tool dispatch record` BEFORE invoking the sub-skill — this preserves the G4 oscillation signal even if the sub-skill crashes mid-execution.
-
-```bash
-# Record a dispatch event (call BEFORE invoking the sub-skill)
-sdlc-tool dispatch record --skill /do-build --issue-number {issue_number} --run-id {run_id}
-
-# Record with PR context (for review/patch/merge stages)
-sdlc-tool dispatch record --skill /do-pr-review --issue-number {issue_number} --pr-number {pr_number} --run-id {run_id}
-
-# Inspect the dispatch history (debug G4 state; read-only, no --run-id)
-sdlc-tool dispatch get --issue-number {issue_number}
-```
-
-The CLI wraps `agent.sdlc_router.record_dispatch()` and `tools.stage_states_helpers.update_stage_states()` — it is the correct runtime entry point. Never call `record_dispatch()` directly from a shell or skill script; always use `sdlc-tool dispatch record`.
-
-## Step 4: Dispatch ONE Sub-Skill
-
-**Do not pattern-match against a hand-edited table.** Instead, call the routing tool and dispatch whatever skill it returns. The tool evaluates all guards (G1–G9) and dispatch rules (19 rows) against live state.
-
-**Row 3 open-PR step-aside (#1932):** row 3 (`NEEDS REVISION` critique → `/do-plan`) already steps aside when the critique verdict is stale (plan revised since); it now also steps aside once `pr_number` is set, so a PR that already exists never gets routed back to `/do-plan` off a stale-but-not-yet-superseded NEEDS REVISION verdict — row 7 / G3 own PR-stage routing instead.
-
-**Row 8d — crashed re-review recovery (#1932):** if `/do-pr-review` was dispatched after PATCH completed but crashed before persisting a REVIEW verdict, REVIEW is left at either `failed` (dead-ends at `Blocked`) or `completed` (silently misroutes to row 9's `/do-docs`, skipping review). Row 8d matches on the *absence* of a recorded verdict plus `last_dispatched_skill == /do-pr-review` (marker-agnostic — it does not require a specific REVIEW value) and re-dispatches `/do-pr-review`. Ordered before row 9 so it intercepts both crash markers. Loop-bound by G4.
-
-**Row 9 verdict gate (#1932):** row 9 (`/do-docs`) now requires a recorded `APPROVED` review verdict, not just `REVIEW == completed`. Previously REVIEW could be marked `completed` with no verdict ever recorded (the row 8d crash state above), which silently misrouted to `/do-docs`, skipping review entirely. Row 8d now owns that no-verdict state instead — the two rows are disjoint by verdict, not by table-position luck.
-
-**Row 8e — no-verdict completion recovery (#2062):** any remaining `REVIEW == completed` + no-recorded-verdict state that row 8d's preconditions exclude (e.g. `PATCH=pending`, `last=/do-build` — the #1897 misroute state) is owned by row 8e, which re-dispatches `/do-pr-review`. This is also the recovery row for the `stage-marker` REVIEW-completion refusal: `stage-marker --stage REVIEW --status completed` now refuses with the named `REVIEW_VERDICT_MISSING` when no substrate verdict is readable, and the refused state redirects here to re-review instead of deadlocking. Loop-bound by G4.
-
-**Row 10 verdict gate (#2062):** row 10 (`/do-merge`) now requires a recorded `APPROVED` review verdict (mirroring row 9) AND head_sha freshness — `REVIEW == completed` alone is no longer merge-ready, so the no-verdict crash state can never fall through to `/do-merge`.
-
-**Head_sha staleness (row 8f + G6, #2062):** `next-skill` context assembly fetches the live PR head and the router compares it against the head SHA the verdict attributes to, surfaced as `_meta.latest_review_head_sha` — the same freshness definition `tools/merge_predicate` enforces, ending the router↔predicate oscillation. An APPROVED verdict that names a different head (post-approval commit), attributes to no resolvable head SHA, or whose live-head lookup failed (fail-closed) routes to `/do-pr-review` at the new head via row 8f; G6 steps aside for the same signal. Re-review records a fresh verdict against the current head, so the loop converges (G4-bounded).
-
-```bash
-# Get the next dispatch decision
-sdlc-tool next-skill --issue-number {issue_number} --run-id {run_id}
-```
-
-The tool dispatches at most ONE skill per call. It outputs JSON in one of these shapes:
-
-Single dispatch:
-```json
-{"skill": "/do-build", "reason": "...", "row_id": "4a", "dispatched": true}
-```
-
-Blocked:
-```json
-{"blocked": true, "reason": "G4: stage oscillation ...", "guard_id": "G4"}
-```
-
-Blocked (issue-level ownership lock -- not a G-guard, see Step 3.5):
-```json
-{"blocked": true, "reason": "ISSUE_LOCKED", "owner_run_id": "...", "owner_session_id": "...", "orphaned_lock": false}
-```
-
-**How to use the output:**
-1. If `dispatched` is `true`: record the dispatch via `sdlc-tool dispatch record` (see Step 3.5), then invoke the returned `skill`.
-2. If `blocked` is `true`: surface the `reason` to the human and wait. Do NOT loop or guess an alternative skill. This applies identically whether the block came from a G1-G9 guard or from `reason: "ISSUE_LOCKED"` (another live session already owns this issue) -- report `owner_session_id` to the human, do not loop, do not attempt to route around it.
-3. If neither key is present (error): log the `error` field and escalate to the human.
-
-**Before recording and dispatching**, also supply `--proposed-skill` when you already know what skill you intend to invoke (enables G3 PR-lock detection):
-```bash
-sdlc-tool next-skill --issue-number {issue_number} --run-id {run_id} --proposed-skill /do-build
-```
-
-Do NOT restart from scratch if prior stages are already complete.
+**The substantive procedure lives in the merged SDLC skill.** Read
+`.claude/skills-global/do-sdlc/SKILL.md` and execute its **router mode** — Steps 1–4 (Resolve →
+Ensure the Tracking Session → Assess Current State → Dispatch ONE Sub-Skill) — then **return**.
+Do not run the supervisor loop (Step 5+) or the final-report/release steps; those belong to
+`/do-sdlc`. Honor the repo context probe it declares (`docs/sdlc/do-sdlc.md`).
+
+## Router-mode dispatch notes
+
+- **Dispatch via `sdlc-tool next-skill`** (Step 4 of the merged body). Record the dispatch with
+  `sdlc-tool dispatch record` before invoking the returned skill. Surface `blocked` decisions to
+  the PM; never guess an alternative skill.
+- **Live-ref cross-check:** `gh pr list --head session/{slug} --state open` queries live refs
+  because the `--search` index lags GitHub (Step 3c of the merged body).
+- **Merge gate (row 10):** `/do-merge` fires only when REVIEW and DOCS are complete, the PR merge
+  state is CLEAN, CI is all-passing, and the recorded REVIEW verdict is APPROVED at the current
+  head — see the guard table in the merged body.
 
 ## Hard Rules
 
@@ -283,15 +42,6 @@ Do NOT restart from scratch if prior stages are already complete.
 
 ## Pipeline Stages Reference
 
-Pipeline state transitions are defined in `agent/pipeline_graph.py` (state-machine bookkeeping: which stage is next-ready when one completes). Dispatch logic is defined in `agent/sdlc_router.py` (`decide_next_dispatch`). Both are accessed at runtime via `sdlc-tool`. The table below is for human readability only.
-
-```
-Happy path: ISSUE -> PLAN -> CRITIQUE -> BUILD -> TEST -> REVIEW -> DOCS -> MERGE
-Cycles:     CRITIQUE(fail) -> PLAN -> CRITIQUE (max 2 cycles)
-            TEST(fail) -> PATCH -> TEST
-            REVIEW(fail|partial) -> PATCH -> TEST -> REVIEW
-```
-
 | Stage | Skill | Dev Model | Notes |
 |-------|-------|-----------|-------|
 | ISSUE | /do-issue | — | Or already exists |
@@ -304,4 +54,7 @@ Cycles:     CRITIQUE(fail) -> PLAN -> CRITIQUE (max 2 cycles)
 | DOCS | /do-docs | sonnet | Structured writing |
 | MERGE | /do-merge {pr_number} | sonnet | Programmatic merge gate: verifies all stages, then merges |
 
-The **Dev Model** column shows the model the PM should pass via `--model` when spawning a dev session for that stage (see Stage→Model Dispatch Table in PM persona).
+The **Dev Model** column shows the model the PM should pass via `--model` when spawning a dev
+session for that stage (see Stage→Model Dispatch Table in PM persona). Pipeline state transitions
+are defined in `agent/pipeline_graph.py`; dispatch logic in `agent/sdlc_router.py` — both
+accessed at runtime via `sdlc-tool`.

--- a/.opencode/agents/code-reviewer.md
+++ b/.opencode/agents/code-reviewer.md
@@ -177,7 +177,7 @@ From CLAUDE.md:
 - **No legacy code tolerance** - All deprecated patterns must go
 - **No mocks in tests** - Use real integrations
 - **Always commit and push** - Work should be preserved
-- **SDLC pattern** - Plan → Build → Test → Patch → Review → Patch → Docs → Merge (see `.claude/skills/sdlc/SKILL.md`)
+- **SDLC pattern** - Plan → Build → Test → Patch → Review → Patch → Docs → Merge (see `.claude/skills-global/do-sdlc/SKILL.md`)
 
 ## When to Approve
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Never point a debug script at a test db with `os.environ.setdefault("REDIS_URL",
 6. **MINIMAL TOOLS** — loading all tools pollutes context and degrades performance. Start minimal, expand only if needed.
 7. **DEFINITION OF DONE** — the authoritative list lives in [`.claude/skills-global/do-build/SKILL.md`](.claude/skills-global/do-build/SKILL.md) and is enforced by `/do-build` and the builder agent.
 8. **PARALLEL EXECUTION** — spawn parallel sub-agents for genuinely independent tasks; never for sequential or dependent work. Aggregate results before reporting.
-9. **SDLC PIPELINE** — an Eng-role AgentSession handles both orchestration and execution. `/sdlc` is a **single-stage router**: assess state, invoke ONE sub-skill, return. Never write code, run tests, or create plans directly; always delegate through sub-skills. Agent gating reads of a PR's head SHA must resolve through `tools/pr_head_resolver.py::resolve_pr_head_sha` (git-first via `git ls-remote refs/pull/N/head`), never a bare `gh` read: a stale `gh` head SHA matches the recorded verdict's trailer and flips the verdict-staleness gate from fail-closed to fail-open (see [`docs/features/gh-stale-state-verdict-gate.md`](docs/features/gh-stale-state-verdict-gate.md)). Ground truth on stages: [`.claude/skills/sdlc/SKILL.md`](.claude/skills/sdlc/SKILL.md).
+9. **SDLC PIPELINE** — an Eng-role AgentSession handles both orchestration and execution. `/sdlc` is a **single-stage router**: assess state, invoke ONE sub-skill, return. Never write code, run tests, or create plans directly; always delegate through sub-skills. Agent gating reads of a PR's head SHA must resolve through `tools/pr_head_resolver.py::resolve_pr_head_sha` (git-first via `git ls-remote refs/pull/N/head`), never a bare `gh` read: a stale `gh` head SHA matches the recorded verdict's trailer and flips the verdict-staleness gate from fail-closed to fail-open (see [`docs/features/gh-stale-state-verdict-gate.md`](docs/features/gh-stale-state-verdict-gate.md)). Ground truth on stages: [`.claude/skills-global/do-sdlc/SKILL.md`](.claude/skills-global/do-sdlc/SKILL.md).
 10. **RESTART RUNNING SERVICES** — see the restart note under Commands.
 
 ## Development Workflow
@@ -80,7 +80,7 @@ Sync wiring is `scripts/update/hardlinks.py`. Adding a directory with a `SKILL.m
 
 Global skill bodies stay generic; repo-specific behavior layers in via `.claude/skill-context/{skill}.md` (non-SDLC) or `docs/sdlc/{skill}.md` (SDLC stages). Coupled bodies carry the probe sentence "If <context-path> exists, read it and honor its declarations; otherwise use the generic defaults described below." See [`docs/features/skill-context-convention.md`](docs/features/skill-context-convention.md).
 
-Some skills are too coupled to generalize even with a probe: `setup`, `prime`, `sdlc`, and `do-deploy` stay project-only.
+Some skills are too coupled to generalize even with a probe: `setup`, `prime`, and `do-deploy` stay project-only. The `sdlc` skill is now a thin `context: fork` router shim over the global `do-sdlc` skill — the substantive SDLC body lives in `.claude/skills-global/do-sdlc/` with this repo's specifics in `docs/sdlc/do-sdlc.md`.
 
 ## Testing Philosophy
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Valor ships real features through a structured pipeline — a directed cyclic gr
 - **Hard patches resume the builder.** When a Patch needs the original builder's accumulated context, PM resumes the Build session's Claude Code transcript instead of starting fresh — the dashed edge in the diagram.
 - **PM orchestrates, Dev executes.** A read-only PM session steers the pipeline stage-by-stage; each stage spawns a full-permission Dev session that runs one skill and reports back.
 
-The pipeline graph is defined in [`agent/pipeline_graph.py`](agent/pipeline_graph.py). See [`.claude/skills/sdlc/SKILL.md`](.claude/skills/sdlc/SKILL.md) for the ground truth on stage definitions and [`docs/features/pipeline-graph.md`](docs/features/pipeline-graph.md) for the feature doc.
+The pipeline graph is defined in [`agent/pipeline_graph.py`](agent/pipeline_graph.py). See [`.claude/skills-global/do-sdlc/SKILL.md`](.claude/skills-global/do-sdlc/SKILL.md) for the ground truth on stage definitions and [`docs/features/pipeline-graph.md`](docs/features/pipeline-graph.md) for the feature doc.
 
 ## Subsystems
 

--- a/agent/sdlc_router.py
+++ b/agent/sdlc_router.py
@@ -1,7 +1,7 @@
 """Production SDLC router dispatch algorithm.
 
 This module is the **canonical dispatch source of truth** for the SDLC pipeline.
-The PM session (via ``.claude/skills/sdlc/SKILL.md``) calls the CLI wrapper
+The PM session (via ``.claude/skills-global/do-sdlc/SKILL.md``) calls the CLI wrapper
 ``sdlc-tool next-skill`` (implemented in ``tools/sdlc_next_skill.py``) which
 delegates to ``decide_next_dispatch()`` in this module.
 

--- a/config/personas/engineer.md
+++ b/config/personas/engineer.md
@@ -365,7 +365,7 @@ exit — the pipeline is not complete until the gate passes.
 ### G4 Convergence Rule
 
 The SDLC router's G4 oscillation guard caps same-skill dispatches at 3 without
-state change (`.claude/skills/sdlc/SKILL.md`). If the same blocker category
+state change (`.claude/skills-global/do-sdlc/SKILL.md`). If the same blocker category
 recurs 3 times in a row, escalate to the human with the specific blocker text
 from the gate output. Do not loop further. G4 is load-bearing and must not be
 bypassed — it is the only backstop between a recoverable gate failure and an

--- a/config/personas/segments/work-patterns.md
+++ b/config/personas/segments/work-patterns.md
@@ -265,7 +265,7 @@ The engineer running longer threads of useful work outperforms others. The engin
 
 ### AI Developer Workflows (ADWs)
 
-Complex work follows the SDLC pipeline (see `.claude/skills/sdlc/SKILL.md` for ground truth):
+Complex work follows the SDLC pipeline (see `.claude/skills-global/do-sdlc/SKILL.md` for ground truth):
 
 **Plan -> Build -> Test -> Patch -> Review -> Patch -> Docs -> Merge**
 

--- a/docs/features/git-state-guard.md
+++ b/docs/features/git-state-guard.md
@@ -88,7 +88,7 @@ python -c "from agent.worktree_manager import ensure_clean_git_state; from pathl
 | `tests/unit/test_git_state_guard.py` | 21 unit tests covering all detection/resolution paths |
 | `.claude/skills/do-build/SKILL.md` | Guard call at Step 6 |
 | `.claude/skills/do-pr-review/SKILL.md` | Guard call in Step 1 before `gh pr checkout` |
-| `.claude/skills/sdlc/SKILL.md` | Guard call at Step 2 |
+| `.claude/skills-global/do-sdlc/SKILL.md` | Guard call in Step 3 (assess current state) |
 
 ## Tracking
 

--- a/docs/features/goal-gates.md
+++ b/docs/features/goal-gates.md
@@ -55,7 +55,7 @@ Gate checks never raise exceptions. All subprocess and IO errors are caught and 
 | `agent/goal_gates.py` | Pure gate check functions -- no side effects, no codebase imports |
 | `agent/agent_session_queue.py` | Nudge loop checks gate status before delivery |
 | `agent/agent_session_queue.py` | Completion guard appends warning for unsatisfied gates |
-| `.claude/skills/sdlc/SKILL.md` | Step 2.5 gate check instructions before stage dispatch |
+| `.claude/skills-global/do-sdlc/SKILL.md` | Gate checks before stage dispatch (Step 4) |
 | `tests/test_goal_gates.py` | 37 unit tests covering all gates, edge cases, and error paths |
 
 ## Design Decisions

--- a/docs/features/multi-judge-consensus.md
+++ b/docs/features/multi-judge-consensus.md
@@ -268,7 +268,7 @@ recorded `_judges` entry is self-describing.
 - `tools/cross_vendor_judge.py` — cross-vendor judge CLI (issue #1626).
 - `.claude/skills-global/do-pr-review/SKILL.md` — orchestration site.
 - `.claude/commands/do-merge.md` — downstream consumer (unchanged).
-- `.claude/skills/sdlc/SKILL.md` G6 — downstream consumer
+- `.claude/skills-global/do-sdlc/SKILL.md` G6 — downstream consumer
   (unchanged).
 - `tests/unit/test_review_multi_judge.py` — consensus rules + ordering
   regression.

--- a/docs/features/pipeline-state-machine.md
+++ b/docs/features/pipeline-state-machine.md
@@ -115,7 +115,7 @@ Promotes the ISSUE-rooted success spine behind `stage` to `completed`, using `_r
 
 ### Marker vs. Router Semantics
 
-The marker tool (`tools/sdlc_stage_marker.py`) and the router (`.claude/skills/sdlc/SKILL.md`) both operate on the same `PipelineStateMachine`, but with different intent:
+The marker tool (`tools/sdlc_stage_marker.py`) and the router (`.claude/skills-global/do-sdlc/SKILL.md`) both operate on the same `PipelineStateMachine`, but with different intent:
 
 - **The marker tool records reality.** A marker write means "we reached this stage" — an unrecorded predecessor is evidence it happened, not an ordering violation, so the tool opts into backfill.
 - **The router enforces ordering.** It decides which stage to dispatch next, so a missing predecessor there is a genuine misorder signal, and it keeps the strict default so it still raises.
@@ -164,7 +164,7 @@ Falls back to `"ambiguous"` when no pattern matches, for the Observer LLM to han
 
 ## Router Integration (Read Path)
 
-The SDLC router skill (`.claude/skills/sdlc/SKILL.md`) reads `stage_states` as the **primary signal** for routing decisions. This completes the read/write cycle: the in-session hooks write stage transitions (via `start_stage()` on skill invoke and `complete_stage()` on skill return), and the router reads the resulting state to determine which sub-skill to dispatch next.
+The SDLC router skill (`.claude/skills-global/do-sdlc/SKILL.md`) reads `stage_states` as the **primary signal** for routing decisions. This completes the read/write cycle: the in-session hooks write stage transitions (via `start_stage()` on skill invoke and `complete_stage()` on skill return), and the router reads the resulting state to determine which sub-skill to dispatch next.
 
 ### How the Router Reads stage_states
 
@@ -206,7 +206,7 @@ Final delivery is driven by `_agent_session_hierarchy_health_check` (`agent/sess
 
 ## Integration Points
 
-- **SDLC Router** (`.claude/skills/sdlc/SKILL.md`): Reads `stage_states` via `tools/sdlc_stage_query.py` CLI tool as primary routing signal
+- **SDLC Router** (`.claude/skills-global/do-sdlc/SKILL.md`): Reads `stage_states` via `tools/sdlc_stage_query.py` CLI tool as primary routing signal
 - **Stage Query Tool** (`tools/sdlc_stage_query.py`): CLI interface for reading `stage_states` from an eng session by session ID or issue number
 - **PreToolUse hook** (`agent/hooks/pre_tool_use.py`): Calls `start_stage()` on skill invoke (`_handle_skill_tool_start()` with `_SKILL_TO_STAGE` mapping), marking the stage as `in_progress`
 - **PostToolUse hook** (`agent/hooks/post_tool_use.py`): Calls `complete_stage()` when a mapped SDLC Skill tool finishes, reading the current `in_progress` stage via `current_stage()`
@@ -232,7 +232,7 @@ Final delivery is driven by `_agent_session_hierarchy_health_check` (`agent/sess
 | `tools/sdlc_stage_query.py` | CLI tool for reading stage_states (used by SDLC router, supports `--issue-number`) |
 | `tools/sdlc_session_ensure.py` | CLI tool to create/find local SDLC sessions keyed by issue number |
 | `tools/_sdlc_utils.py` | Shared `find_session_by_issue()` helper (deduplicated from sdlc_stage_query) |
-| `.claude/skills/sdlc/SKILL.md` | SDLC router skill (reads stage_states in Step 2.0) |
+| `.claude/skills-global/do-sdlc/SKILL.md` | SDLC router skill (reads stage_states in Step 3.0) |
 | `agent/hooks/pre_tool_use.py` | `start_stage()` wiring on skill invoke via `_handle_skill_tool_start()` + `_SKILL_TO_STAGE` |
 | `agent/hooks/post_tool_use.py` | `complete_stage()` wiring on skill return via `_complete_pipeline_stage()` |
 | `agent/session_health.py` | `_agent_session_hierarchy_health_check()` — drives `schedule_pipeline_completion()` for final delivery |

--- a/docs/features/sdlc-critique-stage.md
+++ b/docs/features/sdlc-critique-stage.md
@@ -93,7 +93,7 @@ The `do-plan` skill adds a **Phase 2.6 Propagation Check** after all tasks are w
 | `.claude/skills-global/do-plan-critique/SKILL.md` | Finding format, Implementation Note field, Outcome Contract, structural check, artifact-based roster barrier (#1690) |
 | `.claude/skills-global/do-plan-critique/CRITICS.md` | SOURCE_FILES block in critic prompt template; seven critic personas including Consistency Auditor (#1042) and serialization-boundary item in Skeptic |
 | `tools/critique_roster_check.py` | `critique-roster-check` CLI helper — reads `_roster.json`, verifies terminal fences, exits 0 with JSON gate decision when full roster is complete (#1690) |
-| `.claude/skills/sdlc/SKILL.md` | Row 4a/4b/4c dispatch split, concern-triggered revision path |
+| `.claude/skills-global/do-sdlc/SKILL.md` | Row 4a/4b/4c dispatch split, concern-triggered revision path |
 | `.claude/skills/do-plan/SKILL.md` | Phase 2.6 Propagation Check |
 | `.claude/skills/do-plan/PLAN_TEMPLATE.md` | Critique Results table with Implementation Note column |
 | `config/personas/engineer.md` | Hard gate rule: CRITIQUE mandatory after PLAN — Rule 1 (in-repo fallback) |

--- a/docs/features/sdlc-enforcement.md
+++ b/docs/features/sdlc-enforcement.md
@@ -68,7 +68,7 @@ Set `SKIP_SDLC=1` to bypass **all** SDLC stop gates — both the Claude Code hoo
 
 ## Pipeline Stage Model
 
-See `.claude/skills/sdlc/SKILL.md` for the ground truth on pipeline stages.
+See `.claude/skills-global/do-sdlc/SKILL.md` for the ground truth on pipeline stages.
 
 Stages: **Plan → Critique → Build → Test → Patch → Review → Patch → Docs → Merge**
 

--- a/docs/features/sdlc-fork-turn-boundary.md
+++ b/docs/features/sdlc-fork-turn-boundary.md
@@ -16,8 +16,8 @@ Commit `8542ffb19` ("Fix do-sdlc/do-build fork phantom-wait: force `run_in_backg
 - `.claude/skills-global/do-build/WORKFLOW.md:76`: explicit rule forbidding background dispatch inside the fork, with the failure mode spelled out.
 - `.claude/skills-global/do-build/WORKFLOW.md:98`: the old 15-minute poll/resume block is gone. Step 4 verifies builder results in-turn, since they are already in hand.
 - `.claude/skills-global/do-build/SKILL.md:154`: orchestrator rule, "Run parallel tasks together, always in the foreground."
-- `.claude/skills-global/do-sdlc/SKILL.md:26`: Hard Rule 6, always dispatch with `run_in_background: false`.
-- `.claude/skills-global/do-sdlc/SKILL.md:135`: the stage-dispatch prompt itself carries the explicit `run_in_background: false` flag.
+- `.claude/skills-global/do-sdlc/SKILL.md:57`: Hard Rule 6, always dispatch with `run_in_background: false`.
+- `.claude/skills-global/do-sdlc/SKILL.md:551`: the stage-dispatch prompt itself carries the explicit `run_in_background: false` flag.
 
 ## The concurrent-foreground builder model
 
@@ -31,7 +31,7 @@ Each issue's build fork exclusively owns `.worktrees/{slug}` and `session/{slug}
 
 Supervisors and the resumable `dev` subagent do not allocate separate `.worktrees/sdlc-{N}` lanes. Nothing in the codebase reads a lane override, so lane instructions were silently dropped, which is exactly how #1904, #1899, and #1898 collided: a supervisor's separate branch and the fork's own branch both tried to own the same issue's build.
 
-Converging fork and supervisor onto one branch per plan structurally collapses duplicate PRs, because GitHub permits only one open PR per head branch. The ownership rule is declared in `.claude/skills-global/do-sdlc/SKILL.md:26` and `.claude/skills/sdlc/SKILL.md:13`, under a "Worktree & branch ownership" heading in both files.
+Converging fork and supervisor onto one branch per plan structurally collapses duplicate PRs, because GitHub permits only one open PR per head branch. The ownership rule is declared in `.claude/skills-global/do-sdlc/SKILL.md:72`, under the "Worktree & branch ownership" heading in the merged SDLC body.
 
 ## The live-ref PR dedup guard
 

--- a/docs/features/sdlc-issue-ownership-lock.md
+++ b/docs/features/sdlc-issue-ownership-lock.md
@@ -223,7 +223,7 @@ is alive (issue #2620).** The payload's `pid` is stamped by the short-lived
 `sdlc-tool session-ensure` CLI at acquire time -- that process exits within
 seconds, and renewal never re-stamps the field -- so pid inference alone read
 **every** locally-minted lease as orphaned. That inverted the router's
-contract (`.claude/skills/sdlc/SKILL.md`): `orphaned_lock: true` means "the
+contract (`.claude/skills-global/do-sdlc/SKILL.md`): `orphaned_lock: true` means "the
 owning run died, wait out the TTL" while `false` is the unconditional stop, so
 a rival meeting a genuinely LIVE local owner was told to wait instead of stop.
 PR #2615 had already removed the heartbeat's dependence on the signal; #2620
@@ -407,7 +407,7 @@ The consequence is the one the table above states: a ledger write of any kind ex
 
 When a lock check finds the issue owned by a different live run, the caller surfaces a blocked signal parallel to the existing G-guard `blocked` shape (`{"blocked": true, "reason": ..., "guard_id": ...}`) used elsewhere in SDLC routing.
 
-`/sdlc` and `/do-sdlc` treat this exactly like a guard block: surface `reason`, `owner_run_id`, and `owner_session_id` to the human, do not loop, do not attempt to route around it by guessing an alternative skill. See `.claude/skills/sdlc/SKILL.md`'s ISSUE_LOCKED guard documentation for the pipeline-level interpretation contract -- not duplicated here.
+`/sdlc` and `/do-sdlc` treat this exactly like a guard block: surface `reason`, `owner_run_id`, and `owner_session_id` to the human, do not loop, do not attempt to route around it by guessing an alternative skill. See `.claude/skills-global/do-sdlc/SKILL.md`'s ISSUE_LOCKED guard documentation for the pipeline-level interpretation contract -- not duplicated here.
 
 ### Where the literal JSON shape is actually emitted
 
@@ -461,5 +461,5 @@ The deploy runbook pairs the merge with an immediate worker restart: `./scripts/
 | `tools/sdlc_meta_set.py` | `--run-id` CLI flag on state-mutating keys (e.g. `pr_number`); ownership guard (no renewal) |
 | `tools/sdlc_next_skill.py` | `decide()`'s peek pre-check |
 | `agent/session_executor.py` | `_tick_issue_lock_renewal()` (tier-1 heartbeat, `active_run_id` read-back) |
-| `.claude/skills/sdlc/SKILL.md` | `ISSUE_LOCKED` guard interpretation contract for `/sdlc`/`/do-sdlc`; `--run-id` threading rules |
+| `.claude/skills-global/do-sdlc/SKILL.md` | `ISSUE_LOCKED` guard interpretation contract for `/sdlc`/`/do-sdlc`; `--run-id` threading rules |
 | `.claude/skills-global/do-sdlc/SKILL.md` | Reads `run_id` from `session-ensure`'s JSON output and threads `--run-id` through every state-mutating `sdlc-tool` call for the run |

--- a/docs/features/sdlc-pipeline.md
+++ b/docs/features/sdlc-pipeline.md
@@ -332,4 +332,4 @@ The enriched stage query output (`sdlc-tool stage-query`) includes a `_meta` dic
 - `tools/sdlc_stage_query.py` — enriched query and `_compute_meta()`
 - `tools/sdlc_meta_set.py` — whitelisted metadata writes
 - `docs/sdlc/` — per-stage skill addenda
-- `.claude/skills/sdlc/SKILL.md` — runtime routing instructions
+- `.claude/skills-global/do-sdlc/SKILL.md` — runtime routing instructions (router mode = Steps 1–4)

--- a/docs/features/sdlc-router-oscillation-guard.md
+++ b/docs/features/sdlc-router-oscillation-guard.md
@@ -22,7 +22,7 @@ runs against an unchanged PR.
 | `tools/sdlc_stage_query.py` | Extended to return enriched payload: `{stages, _meta}` with cycle counters, verdicts, PR number, dispatch counter, last dispatched skill. `--format legacy` preserves the flat shape for older callers. |
 | `tools/stage_states_helpers.py` | `update_stage_states(session, update_fn, max_retries=3)` — optimistic-retry helper for concurrent writes to the JSON `stage_states` field. |
 | `agent/pipeline_state.py::classify_outcome` | Routes verdict writes through `sdlc_verdict.record_verdict()` — ONE writer to `_verdicts`. |
-| `.claude/skills/sdlc/SKILL.md` | Dispatch table rows cite the Python implementation; a parity test fails CI if markdown and Python drift. |
+| `.claude/skills-global/do-sdlc/SKILL.md` | Dispatch table rows cite the Python implementation; a parity test fails CI if markdown and Python drift. |
 
 ### The `Blocked` escalation contract
 

--- a/docs/features/sdlc-run-identity-self-heal.md
+++ b/docs/features/sdlc-run-identity-self-heal.md
@@ -159,7 +159,7 @@ frozen ledger becomes diagnosable and a healed one shows the recovery:
 
 There is **no** artifact-inference `--reconcile`. The SDLC invariant — "never
 infer stage completion from artifacts; completion is exclusively determined by
-stored state" — is load-bearing (`.claude/skills/sdlc/SKILL.md`). Instead:
+stored state" — is load-bearing (`.claude/skills-global/do-sdlc/SKILL.md`). Instead:
 
 - **Forward repair is automatic:** with self-heal, the next state-mutating
   write after a resume re-establishes identity and lands, so the ledger

--- a/docs/features/skills-dependency-map.md
+++ b/docs/features/skills-dependency-map.md
@@ -97,7 +97,7 @@ The old "Tier 2 — Specialists (13)" pack and the stub agents (planner, reviewe
 
 ## Skill Categories
 
-### SDLC Core (the critical path — see `.claude/skills/sdlc/SKILL.md` for ground truth)
+### SDLC Core (the critical path — see `.claude/skills-global/do-sdlc/SKILL.md` for ground truth)
 ```
 do-plan → do-build → do-test → do-patch → do-pr-review → do-patch → do-docs → merge
 ```

--- a/docs/sdlc/do-sdlc.md
+++ b/docs/sdlc/do-sdlc.md
@@ -26,7 +26,7 @@ stage-tracking history over.
 
 ## `session-ensure` re-ensure invocations, this repo's paths
 
-Both the Step 2 initial ensure and the Step 3d.6 between-stage continuity re-ensure run the same
+Both the Step 2 initial ensure and the Step 5d.6 between-stage continuity re-ensure run the same
 `sdlc-tool` entry point (installed to `~/.local/bin` by `/update`, so no repo-relative path is
 needed) and are cwd-independent per `docs/features/sdlc-tool-resolver.md`:
 
@@ -34,7 +34,7 @@ needed) and are cwd-independent per `docs/features/sdlc-tool-resolver.md`:
 # Initial (Step 2)
 sdlc-tool session-ensure --issue-number {issue_number} --issue-url "https://github.com/$SDLC_REPO/issues/{issue_number}"
 
-# Between-stage continuity re-ensure (Step 3d.6) — always includes --reuse-run-id
+# Between-stage continuity re-ensure (Step 5d.6) — always includes --reuse-run-id
 sdlc-tool session-ensure --issue-number {issue_number} --reuse-run-id {run_id}
 ```
 
@@ -42,7 +42,7 @@ sdlc-tool session-ensure --issue-number {issue_number} --reuse-run-id {run_id}
 forces its own cwd to `~/src/ai` and relies on this env var to locate the target repo's plans and
 worktree when the target repo is not `ai` itself.
 
-### Step 3d.6 is loud, and its `run_id` is authoritative (issue #2675)
+### Step 5d.6 is loud, and its `run_id` is authoritative (issue #2675)
 
 Neither invocation may be wrapped in anything that discards stderr. Both used to carry
 `2>/dev/null || true`, which routed every `LEASE_ABSENT`/`ISSUE_LOCKED` diagnostic to `/dev/null` —
@@ -55,7 +55,7 @@ Two obligations follow:
 - **Adopt the returned identity.** On an unblocked payload, read `run_id` out of the JSON and use
   *that* value for every subsequent stage and `--run-id` flag. It can legitimately differ from the
   one you passed in: a re-ensure rebinds a lapsed lease, and a fresh contest mints a new id. This is
-  also the value Step 5's `session-release` must carry.
+  also the value Step 7's `session-release` must carry.
 - **Branch on the payload, not the exit code.** `session-ensure` exits 0 on every outcome it can
   report (`tools/sdlc_session_ensure.py::main` prints the result and returns) and signals refusal as
   `{"blocked": true, "reason": ...}`, so an exit-code check would never fire on one. The exception
@@ -70,7 +70,7 @@ Two obligations follow:
 
 The disposition is per-tool and does not generalize: `stage-marker` genuinely does exit non-zero on
 an ownership refusal (`RUN_ID_REQUIRED`, `ISSUE_LOCKED`), which is why the stage-marker guidance in
-`docs/sdlc/do-plan.md` and `.claude/skills-global/do-sdlc/SKILL.md` Step 3d.3 *is* written against
+`docs/sdlc/do-plan.md` and `.claude/skills-global/do-sdlc/SKILL.md` Step 5d *is* written against
 the exit code. See [SDLC Tool Resolver](../features/sdlc-tool-resolver.md) for the loud/best-effort
 split across the whole `sdlc-tool` surface.
 
@@ -78,16 +78,16 @@ Rebinding after a lapse is now backed by the durable, issue-keyed `_run_identiti
 `PipelineLedger` rather than by the session record alone — see
 [SDLC Issue Ownership Lock](../features/sdlc-issue-ownership-lock.md) for the four reuse proofs.
 
-## `session-release` invocation, this repo's path (Step 5)
+## `session-release` invocation, this repo's path (Step 7)
 
-Step 5's release runs through the same `sdlc-tool` entry point as `session-ensure` (installed to
+Step 7's release runs through the same `sdlc-tool` entry point as `session-ensure` (installed to
 `~/.local/bin` by `/update`; cwd-independent per `docs/features/sdlc-tool-resolver.md`):
 
 ```bash
 sdlc-tool session-release --issue-number {issue_number} --run-id {run_id}
 ```
 
-`{run_id}` is the value this run is carrying — the one Step 3d.6 passes as `--reuse-run-id`, rebound
+`{run_id}` is the value this run is carrying — the one Step 5d.6 passes as `--reuse-run-id`, rebound
 if any refusal in the Step 2 table made you re-ensure. Pass the *current* value; a stale one is
 refused as a foreign release and leaves the lease held.
 
@@ -101,5 +101,5 @@ Output is typed JSON, exit code always 0:
 | `missing_args` | You passed an empty/absent issue number or `run_id`. |
 | `error` | The Redis substrate raised; the lease may still be held and will lapse on its own TTL. |
 
-Never let any of these change the outcome you reported in Step 4. The release is a courtesy that
+Never let any of these change the outcome you reported in Step 6. The release is a courtesy that
 shortens the *next* run's wait, not part of this run's result.

--- a/docs/sdlc/merge-troubleshooting.md
+++ b/docs/sdlc/merge-troubleshooting.md
@@ -4,7 +4,7 @@ When the merge gate (`/do-merge`) fails on a PR that is otherwise approved,
 mergeable, and green, the PM session can self-resolve the blocker using the
 recipes below. Each section follows the house style of other `docs/sdlc/`
 pages: terse, command-first, with explicit verify-then-proceed hooks. The
-G4 oscillation guard (`.claude/skills/sdlc/SKILL.md`) caps same-category
+G4 oscillation guard (`.claude/skills-global/do-sdlc/SKILL.md`) caps same-category
 retries at 3; anything beyond that escalates to a human.
 
 See also:
@@ -50,7 +50,7 @@ Then re-dispatch `/do-merge {pr}`.
 ## G4 Oscillation (Same Skill Dispatched 3x)
 
 **Symptom.** The SDLC router's G4 guard refuses to dispatch the same skill
-a fourth time without a state change (`.claude/skills/sdlc/SKILL.md`). The
+a fourth time without a state change (`.claude/skills-global/do-sdlc/SKILL.md`). The
 PM is looping on the same remediation without making progress.
 
 **Diagnose.** Look at the last three dispatches for this issue:

--- a/tests/fixtures/persona/eng_worker_repo_baseline.txt
+++ b/tests/fixtures/persona/eng_worker_repo_baseline.txt
@@ -399,7 +399,7 @@ The engineer running longer threads of useful work outperforms others. The engin
 
 ### AI Developer Workflows (ADWs)
 
-Complex work follows the SDLC pipeline (see `.claude/skills/sdlc/SKILL.md` for ground truth):
+Complex work follows the SDLC pipeline (see `.claude/skills-global/do-sdlc/SKILL.md` for ground truth):
 
 **Plan -> Build -> Test -> Patch -> Review -> Patch -> Docs -> Merge**
 
@@ -1030,7 +1030,7 @@ exit — the pipeline is not complete until the gate passes.
 ### G4 Convergence Rule
 
 The SDLC router's G4 oscillation guard caps same-skill dispatches at 3 without
-state change (`.claude/skills/sdlc/SKILL.md`). If the same blocker category
+state change (`.claude/skills-global/do-sdlc/SKILL.md`). If the same blocker category
 recurs 3 times in a row, escalate to the human with the specific blocker text
 from the gate output. Do not loop further. G4 is load-bearing and must not be
 bypassed — it is the only backstop between a recoverable gate failure and an

--- a/tests/unit/test_sdlc_skill_md_parity.py
+++ b/tests/unit/test_sdlc_skill_md_parity.py
@@ -25,12 +25,21 @@ from pathlib import Path
 from agent.sdlc_router import DISPATCH_RULES, GUARDS
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
-SKILL_MD = REPO_ROOT / ".claude" / "skills" / "sdlc" / "SKILL.md"
-DO_SDLC_MD = REPO_ROOT / ".claude" / "skills-global" / "do-sdlc" / "SKILL.md"
+# After the sdlc → do-sdlc consolidation (#2930), the router contract (Step 4
+# dispatch + Step 3.5 guard table) lives in the single merged body; the thin
+# /sdlc shim (.claude/skills/sdlc/SKILL.md) only points at it and carries no
+# dispatch table or guard rows of its own. The parity checks therefore read
+# the merged body.
+SKILL_MD = REPO_ROOT / ".claude" / "skills-global" / "do-sdlc" / "SKILL.md"
+DO_SDLC_MD = SKILL_MD
 
-# Every skill body that is told how to interpret the router's JSON. Both consume
-# `sdlc-tool next-skill`, so both must describe shapes the router can emit.
-ROUTER_CONSUMER_SKILLS = (SKILL_MD, DO_SDLC_MD)
+# Every skill body that is told how to interpret the router's JSON. Both the
+# merged body and the /sdlc shim consume `sdlc-tool next-skill`, so both must
+# describe shapes the router can emit.
+ROUTER_CONSUMER_SKILLS = (
+    SKILL_MD,
+    REPO_ROOT / ".claude" / "skills" / "sdlc" / "SKILL.md",
+)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Consolidates the two SDLC skills into one substantive body, per issue #2930 (user-directed: "migrate all sdlc skill into the do-sdlc skill so we don't have 2 skills").

**Before:** `.claude/skills/sdlc/SKILL.md` (project-only single-stage router, 307 lines) and `.claude/skills-global/do-sdlc/SKILL.md` (global supervisor loop, 341 lines) duplicated resolve/assess/dispatch content and both taught unscoped `gh issue view` forms (the #2889/#2925 bug class).

**After:**

1. **`do-sdlc` (global)** is the single substantive SDLC skill with one shared step spine and two entry modes:
   - **Router mode** (`/sdlc` executes): Steps 1–4 — Resolve → Ensure Tracking Session → Assess Current State (stage_states + dispatch-history fallback + docs check) → Dispatch ONE Sub-Skill. Includes the full Step 3.5 G1–G9 guard table.
   - **Supervisor mode** (`/do-sdlc` executes): the loop (Step 5) through merge/blocked, Final Report (Step 6), Release lease (Step 7).
   - `--repo`-when-known threaded into the `gh` forms in Step 1/3 (fixes the unscoped-form defect while merging).
2. **`.claude/skills/sdlc/SKILL.md`** is a thin `context: fork` router shim (291 lines → 59) that points at the merged body's Steps 1–4 and retains the router-only operational notes the tests pin: `gh pr list --head` live-ref cross-check, `sdlc-tool next-skill`, and the merge gate.
3. **Repo-coupled specifics** stay out of the global body per the skill-context convention (`docs/sdlc/do-sdlc.md`); step references in that file renumbered to the merged spine (5d.6, Step 7, Step 6).
4. **CLAUDE.md** doctrine line updated: `sdlc` is no longer "stay project-only" — it is a shim over the global `do-sdlc`. All ground-truth pointers (personas, agents, `.claude/README.md`, feature docs) now name `.claude/skills-global/do-sdlc/SKILL.md`.
5. **No `RENAMED_REMOVALS` entry**: the `sdlc` directory survives as the shim, so no stale hardlink is created on other machines — the plan's item 5 was dropped for that reason.

## Test plan

- `scripts/pytest-clean.sh tests/unit/test_sdlc_skill_md_parity.py tests/unit/test_sdlc_fork_no_background.py tests/unit/test_steering_mechanism.py tests/unit/test_commit_issue_disposition.py -n0` → **105 passed**. `test_sdlc_skill_md_parity.py` now reads the merged body for the Step 4 + Step 3.5 guard-table checks (the shim carries no table of its own); the shim retains the anchor strings `test_sdlc_fork_no_background` and `test_steering_mechanism` pin (`gh pr list --head`, `sdlc-tool next-skill`, merge gate).
- `uv run ruff check` on `agent/sdlc_router.py` and `tests/unit/test_sdlc_skill_md_parity.py` → clean.
- Markdown bodies verified by reading against the router implementation (`agent/sdlc_router.py`, `tools/sdlc_next_skill.py`).

Closes #2930
