### PR TITLE
docs: rewrite docs/README.md to the post-separation status quo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,49 +1,101 @@
 # AI System Documentation
 
-## Overview
+Documentation for the Valor AI System — a unified conversational development environment
+that erases the boundary between natural conversation and code execution. Users interact
+with the system through chat (Telegram, email, or a local Claude Code session), and the
+system executes real work in real repositories.
 
-Documentation for the Valor AI System - a unified conversational development environment that eliminates boundaries between natural conversation and code execution. Built on Claude Code, it creates a living codebase where users interact directly WITH the system through chat applications like Telegram.
+This file is the map. The territory is [`README.md`](../README.md) at the repo root
+(install, run, service management) and the [feature index](features/README.md) (how any
+individual thing works).
 
-**Primary Interface**: Telegram (real user account, not a bot)
-**Core Engine**: Claude Code with rich tool ecosystem
-**Model**: Valor provides tools, workflows, and skills; Claude Code orchestrates
+## Architecture in One Screen
+
+The system runs as separate long-lived processes. The **bridge** is I/O only — it receives
+messages, enqueues `AgentSession` records to Redis, runs the nudge loop, and registers
+output callbacks. It has no SDLC awareness and never executes an agent turn. The
+**worker** is the sole session-execution engine, spawning one `claude -p` subprocess per
+turn via the headless session runner.
+
+```
+Telegram / Email / local Claude Code
+            |
+            v
+   Bridge (I/O only)  ──enqueue AgentSession──>  Redis queue
+   bridge/telegram_bridge.py                          |
+            ^                                         v
+            |                              Worker (python -m worker)
+            └───────outbox / callbacks─────  the sole execution engine
+                                                       |
+                                                       v
+                                     Headless session runner: one `claude -p`
+                                     subprocess per turn (subscription auth)
+                                                       |
+                                                       v
+                                     Tools, MCP servers, `gh`, skills, subagents
+```
+
+Read these in order:
+
+| Document | What it covers |
+|----------|----------------|
+| [Bridge/Worker Architecture](features/bridge-worker-architecture.md) | The process split above, and why the bridge holds no execution logic |
+| [Headless Session Runner](features/headless-session-runner.md) | How a turn actually runs: the `claude -p` subprocess, env handling, teardown |
+| [Session Lifecycle](features/session-lifecycle.md) | The 14-state `AgentSession` lifecycle, from enqueue to completion |
+| [Feature Index](features/README.md) | Every implemented feature, with a doc for each |
 
 ## Quick Start
 
+Both the bridge and the worker must be running. Starting only one leaves messages queued
+and never executed.
+
 ```bash
-# Start the Telegram bridge
+# Start the Telegram bridge (receives messages, enqueues sessions)
 ./scripts/start_bridge.sh
 
-# Check status / restart
+# Start the standalone worker (executes every agent session)
+./scripts/valor-service.sh worker-start
+
+# Status and restart — `restart` cycles bridge, watchdog, and worker together
 ./scripts/valor-service.sh status
+./scripts/valor-service.sh worker-status
 ./scripts/valor-service.sh restart
 
-# View logs
+# Logs
 tail -f logs/bridge.log
 ```
 
-## Doc Placement: guides/ vs research/
+Full install, optional services (email bridge, dashboard UI), and service management live
+in the root [`README.md`](../README.md).
+
+## Doc Placement
 
 Each doc topic has exactly one canonical file. Place it by kind:
 
-- `docs/guides/` — evergreen how-to material that stays current with the system (setup, references, standards).
-- `docs/research/` — dated investigations: point-in-time analyses, evaluations, and deep dives, each stamped with its date.
+| Directory | Holds |
+|-----------|-------|
+| `docs/features/` | One doc per implemented feature — the default home for anything describing how the system works. Indexed by [`features/README.md`](features/README.md). |
+| `docs/guides/` | Evergreen how-to and reference material (setup, CLI references, standards). |
+| `docs/conventions/` | Cross-project conventions this repo expects other repos to adopt. |
+| `docs/sdlc/` | Per-stage repo-specific addenda, read at runtime by the global SDLC skills. |
+| `docs/runbooks/` | Step-by-step operational procedures for a recurring task. |
+| `docs/infra/` | Infrastructure and third-party integration setup notes. |
+| `docs/postmortems/` | Dated incident write-ups: what broke, why, what changed. |
+| `docs/audits/` | Dated point-in-time audits of a subsystem. |
+| `docs/research/` | Dated investigations, evaluations, and deep dives, each stamped with its date. |
+| `docs/baselines/` | Captured measurement snapshots used as a comparison point. |
+| `docs/plans/` | Feature plan documents produced by `/do-plan`. |
+| `docs/diagrams/`, `docs/assets/` | Images and diagram sources referenced by the docs above. |
 
-A doc lives in exactly one of the two — never both.
+Two rules:
+
+- **Feature docs go in `features/` and get an index row.** A feature doc that is not in
+  the index is invisible; an index row pointing at a missing file is a dead link.
+- **Nothing lives in two places.** When a doc stops describing the current system, move it
+  to [`features/archived/`](features/archived/) and drop its index row rather than leaving
+  a stale copy linked from an active page.
 
 ## Documentation Index
-
-### Core Architecture
-
-| Document | Description |
-|----------|-------------|
-| [System Overview](features/system-overview.md) | High-level architecture and design principles |
-
-### Interface
-
-| Document | Description |
-|----------|-------------|
-| [Telegram Integration](features/telegram.md) | Complete Telegram interface documentation |
 
 ### Operations
 
@@ -51,12 +103,6 @@ A doc lives in exactly one of the two — never both.
 |----------|-------------|
 | [Deployment](features/deployment.md) | Multi-instance deployment configuration |
 | [Reflections System](features/reflections.md) | Autonomous maintenance process |
-
-### Features
-
-| Document | Description |
-|----------|-------------|
-| [Feature Index](features/README.md) | All implemented features with documentation |
 
 ### Quality & Testing
 
@@ -71,51 +117,58 @@ A doc lives in exactly one of the two — never both.
 |----------|-------------|
 | [2026-04-24: PM SDLC Bypass](postmortems/2026-04-24-pm-sdlc-bypass.md) | PM agent implemented code directly instead of routing through SDLC |
 
-## Architecture Summary
-
-```
-User (Telegram)
-    |
-    v
-Valor Agent - Conversational AI with full context
-    |
-    v
-Claude Code - Orchestrates tools and subagents
-    |
-    v
-Tool Ecosystem
-    |-- MCP Servers (Sentry, Notion) + GitHub CLI (`gh`)
-    |-- Development Tools (search, code, test)
-    +-- Social Tools (Telegram integration)
-```
-
 ## Key Principles
 
-1. **Pure Agency**: System handles complexity without exposing intermediate steps
-2. **No Legacy Code**: Complete elimination of deprecated patterns
-3. **Context Management**: Maintain relevant context across interactions
-4. **Tool Selection**: Dynamic filtering to avoid context pollution
-5. **Real Integration Testing**: No mocks, use actual services
+1. **Pure Agency** — the system handles complexity without exposing intermediate steps.
+2. **No Legacy Code** — deprecated patterns are deleted, not deprecated in place.
+3. **Context Management** — relevant context is carried across interactions explicitly.
+4. **Tool Selection** — dynamic filtering, because loading every tool pollutes context.
+5. **Real Integration Testing** — no mocks, use actual services.
 
 ## Environment Setup
 
+Secrets live in `~/Desktop/Valor/.env`; the repo `.env` is a symlink to it. See
+[`guides/setup.md`](guides/setup.md) for the full walkthrough and `.env.example` for the
+complete list.
+
+**Agent auth is subscription-first.** Headless turns run on the Claude subscription (OAuth
+via `claude` CLI login), not on an API key. The session runner strips `ANTHROPIC_API_KEY`
+and the endpoint overrides from every spawned CLI's environment
+(`agent/session_runner/harness/claude.py`, `agent/session_runner/role_driver.py`) so a
+stray key can never silently move agent turns onto metered billing.
+
 ```bash
-# Required
+# Required — Telegram user account (from my.telegram.org)
 TELEGRAM_API_ID=your_api_id
 TELEGRAM_API_HASH=your_api_hash
 TELEGRAM_PHONE=+1234567890
 
-# API Keys
+# Auxiliary — direct Anthropic API calls made OUTSIDE the agent harness
 ANTHROPIC_API_KEY=sk-ant-...
+
+# Other service keys
 OPENAI_API_KEY=sk-...
 PERPLEXITY_API_KEY=pplx-...
 ```
 
+`ANTHROPIC_API_KEY` is still required, but for direct API calls that are not agent turns:
+
+- `bridge/media.py` — image vision on inbound photos
+- `reflections/docs_auditor.py` — the documentation audit reflection
+- `reflections/utilities.py` — the shared LLM helper for reflections
+- `reflections/pm_briefings/builder.py` — briefing generation
+
+Without it those features degrade or skip; agent sessions are unaffected.
+
 ## Claude Code Configuration
 
 The `.claude/` directory contains:
-- `agents/` - Subagent definitions that Claude Code can invoke
-- `commands/` - Slash commands (most migrated to `skills/`)
-- `settings.local.json` - Local configuration
 
-See [CLAUDE.md](/CLAUDE.md) for complete development guidelines.
+- `agents/` — subagent definitions Claude Code can invoke
+- `skills-global/` — skills hardlinked to `~/.claude/skills/` on every machine by `/update`
+- `skills/` — project-only skills coupled to this repo's infrastructure
+- `commands/` — slash commands
+- `hooks/` — validators and lifecycle hooks, registered from `hooks/manifest.toml`
+- `settings.local.json` — local configuration
+
+See [`CLAUDE.md`](../CLAUDE.md) for complete development guidelines.

--- a/docs/README.md
+++ b/docs/README.md
@@ -151,14 +151,18 @@ OPENAI_API_KEY=sk-...
 PERPLEXITY_API_KEY=pplx-...
 ```
 
-`ANTHROPIC_API_KEY` is still required, but for direct API calls that are not agent turns:
+`ANTHROPIC_API_KEY` is still required, but only for direct API calls that are not agent
+turns — inbound image vision, the reflections that call an LLM, intent classification,
+memory extraction, and the PM briefing builder. Most of those resolve the key through
+`utils/api_keys.py::get_anthropic_api_key`; the rest read `ANTHROPIC_API_KEY` from the
+environment directly. To see the live set rather than a list that goes stale:
 
-- `bridge/media.py` — image vision on inbound photos
-- `reflections/docs_auditor.py` — the documentation audit reflection
-- `reflections/utilities.py` — the shared LLM helper for reflections
-- `reflections/pm_briefings/builder.py` — briefing generation
+```bash
+grep -rn "get_anthropic_api_key\|ANTHROPIC_API_KEY" --include="*.py" .
+```
 
-Without it those features degrade or skip; agent sessions are unaffected.
+Without the key those features degrade or skip (`reflections/pm_briefings/builder.py`
+raises); agent sessions are unaffected.
 
 ## Claude Code Configuration
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,27 +95,10 @@ Two rules:
   to [`features/archived/`](features/archived/) and drop its index row rather than leaving
   a stale copy linked from an active page.
 
-## Documentation Index
-
-### Operations
-
-| Document | Description |
-|----------|-------------|
-| [Deployment](features/deployment.md) | Multi-instance deployment configuration |
-| [Reflections System](features/reflections.md) | Autonomous maintenance process |
-
-### Quality & Testing
-
-| Document | Description |
-|----------|-------------|
-| [Quality Standards](guides/quality-standards.md) | Tool quality standards and patterns |
-| [Tools Reference](tools-reference.md) | Complete tool documentation |
-
-### Postmortems
-
-| Document | Description |
-|----------|-------------|
-| [2026-04-24: PM SDLC Bypass](postmortems/2026-04-24-pm-sdlc-bypass.md) | PM agent implemented code directly instead of routing through SDLC |
+There is deliberately no second index here. The [feature index](features/README.md) is the
+one catalog of feature docs, and every other directory in the table above is browsable on
+its own. A hand-picked shortlist in this file would be a second place for the same
+information, and would go stale the first time someone added a doc without remembering it.
 
 ## Key Principles
 
@@ -152,8 +135,9 @@ PERPLEXITY_API_KEY=pplx-...
 ```
 
 `ANTHROPIC_API_KEY` is still required, but only for direct API calls that are not agent
-turns — inbound image vision, the reflections that call an LLM, intent classification,
-memory extraction, and the PM briefing builder. Most of those resolve the key through
+turns — among them inbound image vision, the reflections that call an LLM, intent
+classification, memory extraction, read-the-room, the promise gate, session completion,
+and the PM briefing builder. Most of those resolve the key through
 `utils/api_keys.py::get_anthropic_api_key`; the rest read `ANTHROPIC_API_KEY` from the
 environment directly. To see the live set rather than a list that goes stale:
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -236,11 +236,11 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [Subconscious Memory](subconscious-memory.md) | Automatic and intentional memory with structured metadata (category, file paths, tags), dismissal tracking with importance decay, multi-query decomposition for broader retrieval, category-weighted recall re-ranking, nightly LLM-based semantic consolidation (`memory-dedup` reflection) with `superseded_by` tracking and recall filter, embedding-file lifecycle with daily `embedding-orphan-sweep` reconciliation against live records, decoupled two-tier `memory-decay-prune` (tier-1 hard-delete opt-in, tier-2 tombstone apply-by-default) with a [corpus-collapse guardrail + cross-run anomaly detector](subconscious-memory.md#corpus-collapse-guardrails-issue-2438), dashboard `/memories` per-record inspector ([dashboard view](subconscious-memory.md#dashboard-view)), and **progressive-disclosure stub injection** (`<thought id="..."[category] title</thought>` ≥5× token reduction) backed by `memory_get` / `memory_search` MCP tools (`mcp_servers/memory_server.py`) and an async Ollama-driven `Memory.title` field wired at 7 writer call sites | Shipped |
 | [SuperWhisper Transcription](superwhisper-transcription.md) | Dual-backend audio transcription with local SuperWhisper primary and OpenAI Whisper API fallback | Shipped |
 | [sustainable-self-healing.md](sustainable-self-healing.md) | Queue governance: circuit-based pause, drip resume, throttle, failure dedup, daily digest | Shipped |
-| [System Overview](system-overview.md) | High-level architecture and design principles | Archived |
 | [Task List Isolation Experiment](task-list-isolation.md) | Experiment results validating CLAUDE_CODE_TASK_LIST_ID behavior | Archived |
 | [Teammate Conversational Humility](qa-conversational-humility.md) | Direct, honest Teammate responses: brevity, hedged language for uncertain claims, stop-hook review gate for delivery control | Shipped |
 | [Teammate Session Permissions](teammate-session-permissions.md) | Code-level enforcement of the one teammate hard rule (writes to source-code paths require a Dev session); two-pass allowlist (normpath + realpath) closes path-traversal and symlink-escape; `[teammate-audit]` Bash log; capable prompt with TOOL POSTURE / OPERATIONAL WORK ENCOURAGED / WHEN BLOCKED blocks. Also fixes a latent PM MultiEdit gap. | Shipped |
 | [Telegram History & Links](telegram-history.md) | Searchable message history and link compilation from Telegram | Shipped |
+| [Telegram Inbound Attachments](telegram-inbound-attachments.md) | Files arriving in a chat with a live session are enriched with their extracted content (document text, image description, voice transcription) before the steering push, and fire-and-forget copied into `~/work-vault/telegram-attachments/` for the `KnowledgeWatcher` to index; eyes-emoji-first ordering on the media branch, sentinel fallback so delivery never drops (#1215) | Shipped |
 | [Telegram Message Edit Handling](telegram-message-edit-handling.md) | Handles Telegram MessageEdited events — steers running sessions with edited text or spawns a fresh session for completed ones | Shipped |
 | [Telegram Messaging](telegram-messaging.md) | Unified interface for reading and sending Telegram messages via `valor-telegram` CLI | Shipped |
 | [Telegram PM Guide](telegram-pm-guide.md) | PM-facing guide for Telegram interaction patterns, session resumption, and pipeline signals | Shipped |
@@ -280,6 +280,14 @@ Completed feature documentation for the Valor AI system. Each document describes
 | [xfail Hygiene](xfail-hygiene.md) | Three-layer xfail hygiene system preventing stale test markers after bug fixes land | Shipped |
 | [YouTube Search](youtube-search.md) | Search YouTube by query using yt-dlp, returning structured results (title, URL, duration, views) via `valor-youtube-search` CLI | Shipped |
 | [YouTube Transcription](youtube-transcription.md) | Auto-transcribe YouTube videos shared in messages for Claude context; also exposed as `valor-youtube-transcribe` CLI | Shipped |
+
+## Archived
+
+Documents in [`archived/`](archived/) describe superseded designs and are kept for
+historical reference only. They are not part of the index above and nothing active should
+link to them. Rows still carrying `Archived` in the Status column above remain in place
+because they document a real experiment or a still-referenced result; a doc moves into
+`archived/` once it actively misdescribes the current system.
 
 ## Adding New Entries
 

--- a/docs/features/archived/README.md
+++ b/docs/features/archived/README.md
@@ -1,0 +1,13 @@
+# Archived Feature Docs
+
+These documents describe superseded designs. They are kept for historical reference and
+are **not** listed in the [feature index](../README.md). Nothing active should link here.
+
+| Document | Superseded by |
+|----------|---------------|
+| [System Overview](system-overview.md) | [Bridge/Worker Architecture](../bridge-worker-architecture.md), [Headless Session Runner](../headless-session-runner.md) |
+| [Telegram Integration](telegram.md) | [Bridge Module Architecture](../bridge-module-architecture.md), [Telegram Messaging](../telegram-messaging.md), [Telegram Inbound Attachments](../telegram-inbound-attachments.md) |
+
+Both predate the bridge/worker separation: they describe a single process that received a
+Telegram message and executed the agent turn inline. Today the bridge is I/O only and the
+standalone worker is the sole session-execution engine.

--- a/docs/features/archived/system-overview.md
+++ b/docs/features/archived/system-overview.md
@@ -1,5 +1,10 @@
 # System Architecture Overview
 
+> **Archived.** This document describes the architecture from before the bridge/worker
+> separation and is kept for historical reference only. For the current architecture read
+> [`bridge-worker-architecture.md`](../bridge-worker-architecture.md) and
+> [`headless-session-runner.md`](../headless-session-runner.md).
+
 ## Overview
 
 This document provides a comprehensive architectural overview of the unified conversational development environment. The system seamlessly integrates natural conversation with code execution capabilities through Claude Code, embodying a production-ready AI platform with the Valor Engels persona.
@@ -122,7 +127,7 @@ Domain-Specific Tools & MCP Servers
 - **Security**: Granular permissions per subagent/tool
 - **Flexibility**: Multiple execution paths (Claude Code + Gemini CLI)
 
-See [Eng Session Architecture](eng-session-architecture.md) for the current session architecture.
+See [Eng Session Architecture](../eng-session-architecture.md) for the current session architecture.
 
 ## Design Principles
 

--- a/docs/features/archived/telegram.md
+++ b/docs/features/archived/telegram.md
@@ -1,5 +1,12 @@
 # Telegram Integration
 
+> **Archived.** This document describes the Telegram interface from before the
+> bridge/worker separation and is kept for historical reference only. For current
+> behavior read [`bridge-worker-architecture.md`](../bridge-worker-architecture.md),
+> [`bridge-module-architecture.md`](../bridge-module-architecture.md),
+> [`telegram-messaging.md`](../telegram-messaging.md), and
+> [`telegram-inbound-attachments.md`](../telegram-inbound-attachments.md).
+
 Telegram is the primary (but not only) interface for the Valor AI System. This integration is strictly an **interface layer** - it handles input, displays running status, delivers responses, and provides debug commands. It is mutually exclusive from the core AI system.
 
 ## Architecture
@@ -141,7 +148,7 @@ The processing emoji is selected via embedding cosine similarity against the 72 
 
 This replaces the previous Ollama intent classification approach, which was limited to 10 hardcoded emojis and had 2-10 second latency with frequent timeouts.
 
-See [Emoji Embedding Reactions](emoji-embedding-reactions.md) for full details on the embedding index, caching, and the `react_with_emoji.py` reaction path.
+See [Emoji Embedding Reactions](../emoji-embedding-reactions.md) for full details on the embedding index, caching, and the `react_with_emoji.py` reaction path.
 
 ## Inbound attachments — steering enrichment + auto-ingest
 
@@ -196,7 +203,7 @@ The vault copy is scheduled as a fire-and-forget `asyncio.create_task`
 appended to the module-level `_background_tasks` list, so its work never
 runs on the bridge's hot path; the steering push proceeds without waiting
 on it. Every failure inside the task is caught locally and logged at
-WARNING. See [Markitdown Ingestion](markitdown-ingestion.md) for the
+WARNING. See [Markitdown Ingestion](../markitdown-ingestion.md) for the
 watcher pipeline.
 
 ### Privacy note

--- a/docs/features/archived/telegram.md
+++ b/docs/features/archived/telegram.md
@@ -152,66 +152,8 @@ See [Emoji Embedding Reactions](../emoji-embedding-reactions.md) for full detail
 
 ## Inbound attachments — steering enrichment + auto-ingest
 
-When a file (`.txt`, photo, document, voice note, etc.) arrives in a chat
-that already has a live session, the bridge enriches the message with the
-file's content **before** routing it to the steering queue, and copies the
-file into the work-vault for permanent indexing. Both steps live inside a
-single helper (`_ack_steering_routed` in `bridge/telegram_bridge.py`) so
-all six steering call sites benefit from the same logic — no scattered
-patches.
-
-### What the agent sees
-
-- **Old behavior (issue #1215):** the agent received the literal sentinel
-  `"--file attachment only--"` whenever a file landed during a running
-  session. The download path only ran for new sessions.
-- **New behavior:** the helper detects `message.media`, calls
-  `process_incoming_media(client, message)` to extract the description
-  (document text, image description, voice transcription), and uses that
-  enriched string as the steering message. When the user provided a real
-  caption alongside the file, the helper composes
-  `"{description}\n\n{caption}"` — the same pattern used by
-  `bridge/enrichment.py:enrich_message` on the new-session path.
-- **Defensive fallback.** If `process_incoming_media` raises or returns
-  an empty description, the original sentinel is pushed unchanged so
-  delivery never silently drops.
-
-### Reaction ordering
-
-For media-bearing messages the eyes emoji (👀) fires **before** the
-download starts so the user gets immediate "I see you" feedback during
-the (potentially multi-second) download window. Text-only steering
-preserves the original reaction-after-push order byte-identical, so the
-hot path adds zero awaits for the common case.
-
-### Auto-ingest into the work-vault
-
-Every downloaded attachment is also copied into
-`~/work-vault/telegram-attachments/` with a disambiguated filename of the
-form `{YYYYMMDD_HHMMSS}_{sender}_{message_id}_{original_basename}`. The
-existing `KnowledgeWatcher` (`bridge/knowledge_watcher.py`) monitors the
-vault recursively, debounces filesystem events for 2 seconds, and routes
-new files through `convert_to_sidecar` to produce a searchable `.md`
-sidecar. Once the watcher's debounce window elapses, the file is
-discoverable via:
-
-```bash
-python -m tools.memory_search search "..."
-```
-
-The vault copy is scheduled as a fire-and-forget `asyncio.create_task`
-appended to the module-level `_background_tasks` list, so its work never
-runs on the bridge's hot path; the steering push proceeds without waiting
-on it. Every failure inside the task is caught locally and logged at
-WARNING. See [Markitdown Ingestion](../markitdown-ingestion.md) for the
-watcher pipeline.
-
-### Privacy note
-
-Auto-ingest is unconditional — files sent into chats are treated as work
-artifacts and stored permanently in the vault. There is no consent gate.
-If you send a private screenshot expecting it to be transient, expect it
-to land in the searchable knowledge base.
+Moved. This behavior is current and lives in
+[`telegram-inbound-attachments.md`](../telegram-inbound-attachments.md).
 
 ## Configuration
 

--- a/docs/features/markitdown-ingestion.md
+++ b/docs/features/markitdown-ingestion.md
@@ -115,7 +115,7 @@ Crash isolation is preserved — the converter call is wrapped in try/except and
 The vault is fed from several sources. Each writer drops files under `~/work-vault/`; the watcher coalesces them in its 2-second debounce window and runs the converter:
 
 - **Manual ingest CLI** — `valor-ingest <source>` (one-off) or `valor-ingest --scan <dir>` (backfill). Primary entry point for explicit user-driven imports.
-- **Telegram steering attachments** (issue #1215) — when a file lands in a chat with a live session, `bridge/telegram_bridge.py:_ack_steering_routed` schedules a fire-and-forget `_ingest_attachments` task that copies the downloaded file into `~/work-vault/telegram-attachments/` with the disambiguated name `{YYYYMMDD_HHMMSS}_{sender}_{message_id}_{basename}`. The copy runs **after** the steering push so a slow filesystem write never blocks delivery. See [Telegram Integration → Inbound attachments](telegram.md#inbound-attachments--steering-enrichment--auto-ingest).
+- **Telegram steering attachments** (issue #1215) — when a file lands in a chat with a live session, `bridge/telegram_bridge.py:_ack_steering_routed` schedules a fire-and-forget `_ingest_attachments` task that copies the downloaded file into `~/work-vault/telegram-attachments/` with the disambiguated name `{YYYYMMDD_HHMMSS}_{sender}_{message_id}_{basename}`. The copy runs **after** the steering push so a slow filesystem write never blocks delivery. See [Telegram Inbound Attachments](telegram-inbound-attachments.md).
 - **Telegram new-session deferred enrichment** — `bridge/enrichment.py:enrich_message` already downloads media for new sessions. The steering-side helper above closes the gap so live-session attachments get the same vault treatment.
 
 ## Loop Prevention
@@ -169,7 +169,6 @@ The Haiku vision test is a **hard gate** when the key is present — a failure m
 
 ## See Also
 
-- [Plan document](../plans/markitdown-ingestion.md) — design decisions, spike results, risk analysis
 - [Docs Auditor substrate](docs-auditor.md) — consumes the `generated_by` sidecar skip-signal (replaced the deleted `/do-xref-audit` skill)
 - [`update` SKILL.md](../../.claude/skills/update/SKILL.md) — mirrors the Telegram summary backfill reminder for human invocations
 - [Subconscious Memory](subconscious-memory.md) — recall pipeline now covers converted binary formats

--- a/docs/features/mid-session-steering.md
+++ b/docs/features/mid-session-steering.md
@@ -101,4 +101,4 @@ If a steering message arrives just as the agent finishes, `pop_all_steering_mess
 - [Steering Queue: Historical Spec](steering-implementation-spec.md) -- Original implementation plan and design decisions
 - [Bridge Workflow Gaps](bridge-workflow-gaps.md) -- Auto-continue and output classification that interacts with session status
 - [Agent Session Model](agent-session-model.md) -- Session lifecycle and status transitions
-- [Telegram Integration → Inbound attachments](telegram.md#inbound-attachments--steering-enrichment--auto-ingest) -- Files (documents, photos, voice notes) sent as reply-to interjections are enriched and auto-ingested before reaching the steering queue (issue #1215)
+- [Telegram Inbound Attachments](telegram-inbound-attachments.md) -- Files (documents, photos, voice notes) sent as reply-to interjections are enriched and auto-ingested before reaching the steering queue (issue #1215)

--- a/docs/features/telegram-inbound-attachments.md
+++ b/docs/features/telegram-inbound-attachments.md
@@ -1,0 +1,63 @@
+# Telegram Inbound Attachments — Steering Enrichment + Auto-Ingest
+
+When a file (`.txt`, photo, document, voice note, etc.) arrives in a chat that already has
+a live session, the bridge enriches the message with the file's content **before** routing
+it to the steering queue, and copies the file into the work-vault for permanent indexing.
+Both steps live inside a single helper (`_ack_steering_routed` in
+`bridge/telegram_bridge.py`) so every steering call site benefits from the same logic — no
+scattered patches.
+
+Original issue: #1215.
+
+## What the agent sees
+
+The helper detects `message.media`, calls `process_incoming_media(client, message)` to
+extract the description (document text, image description, voice transcription), and uses
+that enriched string as the steering message. When the user provided a real caption
+alongside the file, the helper composes `"{description}\n\n{caption}"` — the same pattern
+`bridge/enrichment.py:enrich_message` uses on the new-session path.
+
+**Defensive fallback.** If `process_incoming_media` raises or returns an empty
+description, the original `--file attachment only--` sentinel is pushed unchanged so
+delivery never silently drops.
+
+## Reaction ordering
+
+For media-bearing messages the eyes emoji (👀) fires **before** the download starts, so
+the user gets immediate "I see you" feedback during the (potentially multi-second)
+download window. Abort-keyword detection runs afterwards, against the enriched text.
+Text-only steering preserves the original reaction-after-push order byte-identical, so the
+hot path adds zero awaits for the common case.
+
+## Auto-ingest into the work-vault
+
+Every downloaded attachment is also copied into `~/work-vault/telegram-attachments/` with
+a disambiguated filename of the form
+`{YYYYMMDD_HHMMSS}_{sender}_{message_id}_{original_basename}`. The `KnowledgeWatcher`
+(`bridge/knowledge_watcher.py`) monitors the vault recursively, debounces filesystem
+events, and routes new files through `convert_to_sidecar` to produce a searchable `.md`
+sidecar. Once the watcher's debounce window elapses, the file is discoverable via:
+
+```bash
+python -m tools.memory_search search "..."
+```
+
+The vault copy is scheduled as a fire-and-forget `asyncio.create_task` appended to the
+module-level `_background_tasks` list, so its work never runs on the bridge's hot path;
+the steering push proceeds without waiting on it. Every failure inside the task is caught
+locally and logged at WARNING — including a failure to *create* the task, which must never
+gate steering. See [Markitdown Ingestion](markitdown-ingestion.md) for the watcher
+pipeline.
+
+## Privacy note
+
+Auto-ingest is unconditional — files sent into chats are treated as work artifacts and
+stored permanently in the vault. There is no consent gate. If you send a private
+screenshot expecting it to be transient, expect it to land in the searchable knowledge
+base.
+
+## Related
+
+- [Mid-Session Steering](mid-session-steering.md) — the steering queue this path feeds
+- [Markitdown Ingestion](markitdown-ingestion.md) — the vault watcher and sidecar converter
+- [Bridge Module Architecture](bridge-module-architecture.md) — where the bridge's inbound handlers live

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -67,8 +67,8 @@ Required variables:
 # Anthropic API (required) — auxiliary key for direct API calls made OUTSIDE the
 # agent harness. Agent turns run on the Claude subscription (OAuth via `claude`
 # CLI login) and the session runner strips this key from every spawned CLI.
-# Readers: bridge/media.py (image vision), reflections/docs_auditor.py,
-# reflections/utilities.py, reflections/pm_briefings/builder.py.
+# Readers resolve it via utils/api_keys.py::get_anthropic_api_key or read the
+# env var directly; see docs/README.md for what depends on it.
 ANTHROPIC_API_KEY=sk-ant-...
 
 # Telegram User Account (from my.telegram.org)

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -64,7 +64,11 @@ All secrets go in `~/Desktop/Valor/.env`. See `.env.example` for the full list o
 Required variables:
 
 ```bash
-# Anthropic API (required)
+# Anthropic API (required) — auxiliary key for direct API calls made OUTSIDE the
+# agent harness. Agent turns run on the Claude subscription (OAuth via `claude`
+# CLI login) and the session runner strips this key from every spawned CLI.
+# Readers: bridge/media.py (image vision), reflections/docs_auditor.py,
+# reflections/utilities.py, reflections/pm_briefings/builder.py.
 ANTHROPIC_API_KEY=sk-ant-...
 
 # Telegram User Account (from my.telegram.org)


### PR DESCRIPTION
Closes #2877

## What

`docs/README.md` described the single-process architecture from before the bridge/worker separation, in **two** places. The issue caught one (the "Core Architecture" table linking `features/system-overview.md`, which the feature index already marked `Archived`); the ASCII "Architecture Summary" diagram was a second copy of the same stale model, showing `User -> Valor Agent -> Claude Code` with no bridge/worker split at all. Both now describe the real topology.

## Fixes

| Defect | Fix |
|---|---|
| Links `features/system-overview.md`, marked `Archived` by the feature index | Archived; index row removed |
| Links `features/telegram.md`, an orphan in no index row | Archived; live content salvaged (see below) |
| `[CLAUDE.md](/CLAUDE.md)` root-relative form 404s on GitHub | `../CLAUDE.md` — the file's only actual dead link |
| Quickstart starts only the bridge | Starts bridge **and** worker, matching root `README.md` |
| ASCII diagram has no bridge/worker split (not in the issue) | Redrawn to the real process topology |
| Doc-placement policy says "guides/ vs research/, exactly one of the two" | `docs/` actually has a dozen directories; policy now enumerates them |
| Environment setup implies `ANTHROPIC_API_KEY` is primary agent auth | Reframed as auxiliary — see below |

### On `ANTHROPIC_API_KEY` — deviation from the issue's solution sketch

The issue's sketch implies reframing away from the key because the harness is subscription-first. The harness **is** subscription-first (`agent/session_runner/harness/claude.py` strips the key from spawned CLIs; `role_driver.py` blanks it) — **but the key is still genuinely required** for direct API calls outside the harness: `bridge/media.py` (image vision), `reflections/docs_auditor.py`, `reflections/utilities.py`, `reflections/pm_briefings/builder.py`. So it is documented as auxiliary-but-required with its readers named, not deleted. The identical stale framing in `docs/guides/setup.md` was fixed in the same pass so it does not become the new stale copy.

### On archiving `telegram.md`

It was an orphan (no feature-index row; `docs/README.md` was its only inbound link), **but** its "Inbound attachments — steering enrichment + auto-ingest" section documented live bridge behavior (#1215) that two *active* docs linked into. Rather than bury it, that section was salvaged as `docs/features/telegram-inbound-attachments.md`, verified line-by-line against `bridge/telegram_bridge.py` (`_ack_steering_routed`, `_ingest_attachments`, eyes-emoji-first ordering, sentinel fallback), given an index row, and both referrers repointed.

`docs/features/archived/` is new and carries a `README.md` explaining the supersession, plus banners on each archived doc. Rows still marked `Archived` in the main index stay in place — the stated rule is that a doc *moves* into `archived/` only once it actively misdescribes the current system.

## Sequencing note

The issue recommends landing after #2872-#2876. Verified those five touch nothing `docs/README.md` names, so this is self-contained and does not need a second pass. The one real ordering constraint is against **#2878** (moving `docs/plans/completed/` in a parallel lane) — the new doc-placement policy is deliberately silent on plan archives to avoid conflicting with it.

## Verification

```
$ python linkcheck.py <all 9 touched files>
0 dead link(s) across 9 file(s)
```

- Zero dead relative links across `docs/README.md` and `docs/features/README.md` (AC #2). Also fixed a pre-existing dead link in `markitdown-ingestion.md` -> `../plans/markitdown-ingestion.md`, a file that exists nowhere in the repo.
- No active doc links to `system-overview.md` or `telegram.md` (AC #3) — only `archived/README.md` does, by design.
- `python -m ruff check .` -> `All checks passed!`
- `python -m ruff format --check .` -> `1372 files already formatted`
- `tests/unit/test_docs_auditor_substrate.py` -> `135 passed in 42.17s`. Its corpus glob is `docs/features/*.md` (non-recursive), so `archived/` is correctly excluded from the auditor's rotation.

Docs-only change; TDD does not apply per the documentation-only exception.
