### PR TITLE
refactor(agent): drop 16 dead re-exports from agent_session_queue (phase 1 of #2876)

### DIFF
--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -32,7 +32,6 @@ from popoto.exceptions import ModelException
 
 # Shared mutable session-tracking state — re-exported here for backward compatibility.
 import agent.session_state as _session_state  # noqa: F401 (also used for mutation sites)
-from agent.branch_manager import get_branch_state  # noqa: F401
 from agent.output_handler import OutputHandler
 
 # Output routing — decision logic lives in output_router; re-exported here
@@ -49,22 +48,17 @@ from agent.redis_offload import offload_redis
 
 # Session completion (post-execution lifecycle) — re-exported here for backward compatibility.
 from agent.session_completion import (  # noqa: F401
-    _CONTINUATION_PM_MAX_DEPTH,
     _complete_agent_session,
     _diagnose_missing_session,
-    _extract_issue_number,
     _transition_parent,
 )
 
 # Session executor (CLI harness, nudge/re-enqueue, steer) — re-exported for backward compatibility.
 from agent.session_executor import (  # noqa: F401
     _HARNESS_EXHAUSTION_MSG,
-    _HARNESS_NOT_FOUND_MAX_RETRIES,
     _HARNESS_NOT_FOUND_PREFIX,
-    _calendar_heartbeat,
     _enqueue_nudge,
     _execute_agent_session,
-    _find_valor_calendar,
     _handle_harness_not_found,
     re_enqueue_session,
     steer_session,
@@ -75,7 +69,6 @@ from agent.session_health import (  # noqa: F401
     AGENT_SESSION_HEALTH_CHECK_INTERVAL,
     AGENT_SESSION_HEALTH_MIN_RUNNING,
     HEARTBEAT_FRESHNESS_WINDOW,
-    HEARTBEAT_WRITE_INTERVAL,
     MAX_RECOVERY_ATTEMPTS,
     TASK_CANCEL_TIMEOUT,
     _agent_session_health_check,
@@ -83,10 +76,8 @@ from agent.session_health import (  # noqa: F401
     _agent_session_hierarchy_health_check,
     _apply_recovery_transition,
     _cleanup_orphaned_claude_processes,
-    _dependency_health_check,
     _has_progress,
     _is_ledger,
-    _reap_orphan_session_processes,
     _recover_interrupted_agent_sessions_startup,
     _should_kill_no_progress,
     _sweep_dead_worker_sessions,
@@ -102,26 +93,19 @@ from agent.session_logs import save_session_snapshot
 
 # Session pickup (pop locking, startup steering drain, dependency checks) — re-exported here.
 from agent.session_pickup import (  # noqa: F401
-    _POP_LOCK_TTL_SECONDS,
     _acquire_pop_lock,
-    _drain_startup_steering,
     _maybe_inject_resume_hydration,
     _pop_agent_session,
     _pop_agent_session_with_fallback,
     _release_pop_lock,
-    dependency_status,
 )
 
 # Revival detection — re-exported here for backward compatibility.
 from agent.session_revival import (  # noqa: F401
-    _COOLDOWN_FILE,
-    REVIVAL_COOLDOWN_SECONDS,
     _load_cooldowns,
-    _save_cooldowns,
     _session_branch_name,
     check_revival,
     cleanup_stale_branches,
-    cleanup_stale_branches_all_projects,
     maybe_send_revival_prompt,
     queue_revival_agent_session,
     record_revival_cooldown,

--- a/agent/agent_session_queue.py
+++ b/agent/agent_session_queue.py
@@ -106,6 +106,13 @@ from agent.session_revival import (  # noqa: F401
     _session_branch_name,
     check_revival,
     cleanup_stale_branches,
+    # Resolved at runtime by the reflection scheduler through this hub path:
+    # config/reflections.yaml's `stale-branch-cleanup` entry declares
+    # `callable: "agent.agent_session_queue.cleanup_stale_branches_all_projects"`,
+    # which reflection_scheduler._resolve_callable getattrs off this module.
+    # Untracked config, so no repo-wide source sweep can see the reference.
+    # Deleting this needs the yaml migrated to agent.session_revival first.
+    cleanup_stale_branches_all_projects,
     maybe_send_revival_prompt,
     queue_revival_agent_session,
     record_revival_cooldown,


### PR DESCRIPTION
Phase 1 of 7 for #2876. Scope is deliberately narrow: **delete re-exported symbols from `agent/agent_session_queue.py` that nothing references.** No importer is migrated, the re-export block itself stays, and the architectural test is not added — those are later phases owned by other lanes.

## Result

**15 symbols deleted** (`agent/agent_session_queue.py`). The re-export surface drops from 81 symbols to 66.

> **Merge-gate correction.** This PR originally deleted **16**. Review found `cleanup_stale_branches_all_projects` is genuinely live: `config/reflections.yaml` (vault-owned, gitignored) declares `callable: "agent.agent_session_queue.cleanup_stale_branches_all_projects"` for the enabled daily `stale-branch-cleanup` job, and `reflection_scheduler._resolve_callable` getattrs it off the hub. No repo-wide source sweep can see an untracked-config reference. Verified by reproduction: `AttributeError` on the 16-deletion tree, resolves on the 15-deletion tree. That re-export is restored with an explanatory comment; deleting it needs the yaml migrated to `agent.session_revival` first.

| Symbol | Canonical module |
|---|---|
| `get_branch_state` | `agent.branch_manager` |
| `_CONTINUATION_PM_MAX_DEPTH` | `agent.session_completion` |
| `_extract_issue_number` | `agent.session_completion` |
| `_HARNESS_NOT_FOUND_MAX_RETRIES` | `agent.session_executor` |
| `_calendar_heartbeat` | `agent.session_executor` |
| `_find_valor_calendar` | `agent.session_executor` |
| `HEARTBEAT_WRITE_INTERVAL` | `agent.session_health` |
| `_dependency_health_check` | `agent.session_health` |
| `_reap_orphan_session_processes` | `agent.session_health` |
| `_POP_LOCK_TTL_SECONDS` | `agent.session_pickup` |
| `_drain_startup_steering` | `agent.session_pickup` |
| `dependency_status` | `agent.session_pickup` |
| `REVIVAL_COOLDOWN_SECONDS` | `agent.session_revival` |
| `_COOLDOWN_FILE` | `agent.session_revival` |
| `_save_cooldowns` | `agent.session_revival` |

Every one of these is still exported by its canonical module and still reached there by its real callers. Nothing reached them *through the hub*.

## Method

Per symbol, across every tracked file, a hit in any of these four categories disqualifies deletion:

1. **Imports from the hub** — AST `ImportFrom` with module `agent.agent_session_queue`, **including relative imports** resolved against the importing file's package.
2. **Attribute access** — `agent_session_queue.<sym>`, plus aliased module access (`asq.`, `q.`, `queue_module.`) resolved per-file from the actual alias binding.
3. **Patch target strings** — `patch("agent.agent_session_queue.<sym>")` and `patch.object(<hub alias>, "<sym>")`. A symbol referenced only by a patch string is live; deleting it would silently turn the patch into a no-op or an `AttributeError`.
4. **Internal use by the hub's own code** — AST `Name`/`Attribute` loads outside the import block. These are needed imports, not re-exports, and were kept.

## Deviation from the assigned recon

The task brief predicted **34 dead symbols of 80**. The verified count is **16 of 81**. Flagging rather than forcing the number, because the gap is two concrete false-dead classes that a coarser sweep misses — and deleting either set would have broken `main`:

- **Relative imports.** `agent/__init__.py` does `from .agent_session_queue import (...)`, which does not match a `from agent.agent_session_queue import` grep. That alone keeps `record_revival_cooldown`, `check_revival`, `cleanup_stale_branches`, and `queue_revival_agent_session` alive.
- **Patch strings on otherwise-unimported symbols.** `tests/integration/test_silent_failures.py:266` patches `agent.agent_session_queue._load_cooldowns`. The symbol has no importer at all; only the patch string keeps it load-bearing.

The remaining difference is symbols the hub's own code calls (28 of them), which are needed imports rather than re-exports.

Two intermediate analyzer bugs were found and fixed while narrowing this down (missed relative imports; an alias regex greedy enough to treat `sr.` / `session_health.` references to *canonical* modules as hub references). The 16 above survived the corrected analysis and a full-repo confirmation grep showing no hub-qualified reference to any of them.

The `agent.session_stall_classifier` import at the file's tail is a genuine internal import used by the hub, not a re-export, so it is untouched.

## Verification

```
tests/unit/test_agent_session_queue.py + test_steering_mechanism + test_harness_retry     119 passed
tests/unit/test_health_check_recovery_finalization.py + never_started_recovery
  + stale_cleanup + session_health_fence_guards + recovery_respawn_safety                207 passed
tests/unit/test_agent_session_queue_async.py + nudge_loop + worker_entry
  + agent_session_hierarchy + resume_hydration + qa_nudge_cap + pipeline_integrity
  + agent_session_queue_revival_helper                                                   183 passed
tests/integration/test_silent_failures.py + test_session_zombie_health_check.py             9 passed
                                                                                        ---------
                                                                                         518 passed, 0 failed
```

Selected as the unit and integration files that import from, alias, or patch the hub. `python -m ruff check .` → All checks passed. `python -m ruff format --check agent/` → 86 files already formatted. Import smoke test confirms `agent`, `worker.__main__`, `tools.agent_session_scheduler`, `tools.valor_session` and all eight formerly-re-exported modules still import, all 65 surviving re-exports still resolve, and all 16 deleted symbols are gone from the hub.

A full `tests/unit` run was attempted first but collapsed with all 50 xdist workers down and the test-DB slot pool exhausted — the machine had 161 live pytest processes from concurrent sibling lanes. `scripts/reap-xdist.sh` reported no orphans, so that was contention, not a regression; the targeted files above were then run serially with `-n 0`.

Closes #2952
Refs #2876

`#2952` is the closeable record for phase 1 and closes on merge. **#2876 is the
umbrella issue and stays OPEN** — it covers phases 2-7 of de-hubbing
`agent/agent_session_queue.py` and must survive six more merges.
