### PR TITLE
Remove deprecated AgentSession aliases, dead methods, and legacy kwarg mapping

### DIFF
--- a/agent/goal_gates.py
+++ b/agent/goal_gates.py
@@ -28,6 +28,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from config.settings import settings
+from models.session_event import format_event_lines
+
 if TYPE_CHECKING:
     from models.agent_session import AgentSession
 
@@ -64,13 +67,14 @@ def _run_gh_command(args: list[str], working_dir: str | Path | None = None) -> s
 
     Raises:
         subprocess.CalledProcessError: If the command fails.
-        subprocess.TimeoutExpired: If the command takes longer than 10 seconds.
+        subprocess.TimeoutExpired: If the command exceeds
+            ``settings.timeouts.git_subprocess_s``.
     """
     result = subprocess.run(
         ["gh", *args],
         capture_output=True,
         text=True,
-        timeout=10,
+        timeout=settings.timeouts.git_subprocess_s,
         cwd=working_dir,
     )
     result.check_returncode()
@@ -167,7 +171,7 @@ def check_test_gate(slug: str, session: AgentSession | None = None) -> GateResul
     # Primary: check session history
     if session is not None:
         try:
-            history = session.get_history_list()
+            history = format_event_lines(session.session_events)
             for entry in history:
                 if not isinstance(entry, str):
                     continue

--- a/docs/features/agent-session-model.md
+++ b/docs/features/agent-session-model.md
@@ -343,7 +343,9 @@ cleaned up by the TTL when they next touch Redis).
 
 ## Backward Compatibility
 
-- `_normalize_kwargs()` maps old field names to their new consolidated equivalents: `message_text`, `sender_name`, `sender_id`, `telegram_message_id`, `chat_title` -> `initial_telegram_message`; `revival_context`, `classification_type`, `classification_confidence` -> `extra_context`; `work_item_slug` -> `slug`; `last_activity` -> `updated_at`; `scheduled_after` -> `scheduled_at`; `history` -> `session_events`; `watchdog_unhealthy` -> `unhealthy_reason` (schema diet, #1927)
+- `_normalize_kwargs()` maps constituent field names into their consolidated DictFields: `message_text`, `sender_name`, `sender_id`, `telegram_message_id`, `chat_title` -> `initial_telegram_message`; `revival_context`, `classification_type`, `classification_confidence` -> `extra_context`. It also back-aliases `watchdog_unhealthy` -> `unhealthy_reason` (schema diet, #1927) and discards `agent_session_id` (an `AutoKeyField`).
+- `_normalize_kwargs()` maps **nothing else**. The legacy paths for `work_item_slug`, `last_activity`, `scheduled_after`, `parent_job_id`, `job_id`, `history`, `stage_states`, `commit_sha`, `summary`, and the dead-field pop list were removed in #2873, along with the `.sender` and `.history` property aliases and the `get_parent_chat_session()` / `get_dev_sessions()` / `get_history_list()` wrappers. Pass the canonical field names (`slug`, `updated_at`, `scheduled_at`, `parent_agent_session_id`, `session_events`) instead. Render an event log for display with `models.session_event.format_event_lines()`.
+- Unknown kwargs are harmless: Popoto's `Model.__init__` does `self.__dict__.update(kwargs)`, so an unrecognized key lands in the instance dict and never raises, and encoding iterates `_meta.fields` only, so it is never persisted.
 - `__setattr__` auto-converts float timestamps to `datetime` for DatetimeField fields
 - Property accessors provide read access to old field names (`sender_name`, `message_text`, etc.) for backward compatibility
 - `models/agent_session.py` exports `AgentSession = AgentSession` (shim)

--- a/docs/guides/sdlc-storyline-example.md
+++ b/docs/guides/sdlc-storyline-example.md
@@ -442,12 +442,12 @@ The pipeline graph edge `("PATCH", "success") -> "TEST"` fires, but since the wo
 **What could go wrong (stuck in a patch loop)**: Suppose the fix for the off-by-one introduced a new failure. The pipeline would cycle: TEST(fail) -> PATCH -> TEST(fail) -> PATCH -> TEST. The `cycle_count` parameter tracks this:
 
 ```python
-# Count PATCH cycles from history for the max-cycle safety valve
+# Count PATCH cycles from the event log for the max-cycle safety valve
 cycle_count = 0
-history = session.get_history_list()
-for entry in history:
-    if isinstance(entry, dict) and entry.get("stage") == "PATCH":
-        cycle_count += 1
+for event in session.session_events or []:
+    if isinstance(event, dict) and event.get("event_type") == "stage":
+        if "PATCH" in event.get("text", ""):
+            cycle_count += 1
 ```
 
 When `cycle_count >= MAX_PATCH_CYCLES` (which is 3), `get_next_stage` returns `None`:

--- a/models/agent_session.py
+++ b/models/agent_session.py
@@ -15,10 +15,13 @@ Session types (permission model):
     Participates in group conversations without orchestration authority.
 
 Parent-child relationship:
-  parent_agent_session_id is the canonical parent link.
-  parent_session_id and parent_chat_session_id are deprecated aliases that
-  delegate to parent_agent_session_id via property.
-  Use create_child() to spawn child sessions.
+  parent_agent_session_id is the sole parent link; get_parent_session() and
+  get_child_sessions() traverse it. Use create_child() to spawn child sessions.
+
+Event storage:
+  session_events is the sole event log (a list of SessionEvent dicts, see
+  models/session_event.py). Use append_event() to write and
+  models.session_event.format_event_lines() to render display strings.
 
 Status lifecycle (see models/session_lifecycle.py for canonical mutation functions):
   Non-terminal: pending -> running -> active -> dormant | waiting_for_children | superseded
@@ -836,32 +839,6 @@ class AgentSession(Model):
         if ec_fields and "extra_context" not in kwargs:
             kwargs["extra_context"] = ec_fields
 
-        # Map deprecated field names
-        if "work_item_slug" in kwargs and "slug" not in kwargs:
-            kwargs["slug"] = kwargs.pop("work_item_slug")
-        elif "work_item_slug" in kwargs:
-            kwargs.pop("work_item_slug")
-
-        if "last_activity" in kwargs and "updated_at" not in kwargs:
-            kwargs["updated_at"] = kwargs.pop("last_activity")
-        elif "last_activity" in kwargs:
-            kwargs.pop("last_activity")
-
-        if "scheduled_after" in kwargs and "scheduled_at" not in kwargs:
-            val = kwargs.pop("scheduled_after")
-            if isinstance(val, int | float):
-                kwargs["scheduled_at"] = datetime.fromtimestamp(val, tz=UTC)
-            else:
-                kwargs["scheduled_at"] = val
-        elif "scheduled_after" in kwargs:
-            kwargs.pop("scheduled_after")
-
-        # Map old field names to new ones  # legacy
-        if "parent_job_id" in kwargs and "parent_agent_session_id" not in kwargs:  # legacy
-            kwargs["parent_agent_session_id"] = kwargs.pop("parent_job_id")  # legacy
-        elif "parent_job_id" in kwargs:  # legacy
-            kwargs.pop("parent_job_id")  # legacy
-
         # Schema diet (#1927): watchdog_unhealthy -> unhealthy_reason back-alias.
         if "watchdog_unhealthy" in kwargs and "unhealthy_reason" not in kwargs:
             kwargs["unhealthy_reason"] = kwargs.pop("watchdog_unhealthy")
@@ -871,62 +848,11 @@ class AgentSession(Model):
         if "agent_session_id" in kwargs:
             kwargs.pop("agent_session_id")  # AutoKeyField, ignore
 
-        if "job_id" in kwargs:  # legacy
-            kwargs.pop("job_id")  # legacy
-
-        # Map old history to session_events
-        if "history" in kwargs and "session_events" not in kwargs:
-            kwargs["session_events"] = kwargs.pop("history")
-        elif "history" in kwargs:
-            kwargs.pop("history")
-
-        # Convert stage_states to a session event
-        stage_states_val = kwargs.pop("stage_states", None)
-        if stage_states_val is not None and "session_events" not in kwargs:
-            if isinstance(stage_states_val, str):
-                try:
-                    stages_dict = _json.loads(stage_states_val)
-                except (ValueError, TypeError):
-                    stages_dict = None
-            elif isinstance(stage_states_val, dict):
-                stages_dict = stage_states_val
-            else:
-                stages_dict = None
-            if stages_dict:
-                event = SessionEvent.stage_change("bulk", "init", stages_dict)
-                kwargs["session_events"] = [event.model_dump()]
-
-        # Convert commit_sha to a session event
-        commit_sha_val = kwargs.pop("commit_sha", None)
-        if commit_sha_val is not None:
-            events = kwargs.get("session_events", []) or []
-            event = SessionEvent.checkpoint(commit_sha_val)
-            events.append(event.model_dump())
-            kwargs["session_events"] = events
-
-        # Convert summary to a session event
-        summary_val = kwargs.pop("summary", None)
-        if summary_val is not None:
-            events = kwargs.get("session_events", []) or []
-            event = SessionEvent.summary(summary_val)
-            events.append(event.model_dump())
-            kwargs["session_events"] = events
-
-        # Remove dead fields silently. Note: fields removed by the schema
-        # diet (#1927 -- see scripts/migrate_schema_diet_fields.py's
-        # module docstring for the exact deleted-field list) do NOT need an
-        # entry here: Popoto's Model.__init__ silently drops any kwarg that
-        # doesn't match a declared field (verified empirically and matching
-        # the #1924 PTY-teardown precedent, which added no pop-list entries
-        # either), so an archive-restore payload carrying an old dead-field
-        # key never raises.
-        for dead in (
-            "depends_on",
-            "stable_agent_session_id",
-            "scheduling_depth",
-            "_qa_mode_legacy",
-        ):
-            kwargs.pop(dead, None)
+        # No pop-list for fields deleted by past schema changes (#2873, #1927,
+        # #1924). Popoto's Model.__init__ does ``self.__dict__.update(kwargs)``
+        # (popoto/models/base.py), so an unknown key lands harmlessly in the
+        # instance dict and never raises; encoding iterates ``_meta.fields``
+        # only, so it is never persisted and disappears on the next save.
 
         # Ensure created_at has a default (SortedField is not nullable)
         if "created_at" not in kwargs:
@@ -1555,11 +1481,6 @@ class AgentSession(Model):
         self.initial_telegram_message = itm
 
     @property
-    def sender(self) -> str | None:
-        """Alias for sender_name (SessionLog used 'sender')."""
-        return self.sender_name
-
-    @property
     def revival_context(self) -> str | None:
         """Extract revival_context from extra_context."""
         ec = self.extra_context
@@ -1994,13 +1915,6 @@ class AgentSession(Model):
             )
             return None
 
-    def get_parent_chat_session(self) -> "AgentSession | None":
-        """Backward-compat wrapper for get_parent_session().
-
-        Deprecated: Use get_parent_session() instead.
-        """
-        return self.get_parent_session()
-
     def get_child_sessions(self) -> list["AgentSession"]:
         """Return all child sessions linked via parent_agent_session_id."""
         try:
@@ -2008,13 +1922,6 @@ class AgentSession(Model):
         except Exception as e:
             logger.warning(f"Failed to query child sessions for {self.id}: {e}")
             return []
-
-    def get_dev_sessions(self) -> list["AgentSession"]:
-        """Backward-compat wrapper for get_child_sessions().
-
-        Deprecated: Use get_child_sessions() instead.
-        """
-        return self.get_child_sessions()
 
     # === Chat message log helpers (issue #1192) ===
 
@@ -2149,34 +2056,6 @@ class AgentSession(Model):
             )
 
     # === Event log helpers ===
-
-    def get_history_list(self) -> list:
-        """Get session_events as a list of formatted strings (backward compat)."""
-        events = self.session_events
-        if not isinstance(events, list):
-            return []
-        result = []
-        for event in events:
-            if isinstance(event, dict):
-                etype = event.get("event_type", "system")
-                text = event.get("text", "")
-                result.append(f"[{etype}] {text}")
-            elif isinstance(event, str):
-                result.append(event)
-        return result
-
-    # Keep private alias for internal callers
-    _get_history_list = get_history_list
-
-    @property
-    def history(self) -> list | None:
-        """Backward-compatible alias for session_events."""
-        return self.session_events
-
-    @history.setter
-    def history(self, value) -> None:
-        """Backward-compatible setter for session_events."""
-        self.session_events = value
 
     def append_event(self, event_type: str, text: str, data: dict | None = None) -> None:
         """Append a structured event to session_events.

--- a/models/session_event.py
+++ b/models/session_event.py
@@ -93,3 +93,27 @@ class SessionEvent(BaseModel):
     def user(cls, text: str) -> "SessionEvent":
         """Create a user input event."""
         return cls(event_type=EventType.USER, text=text)
+
+
+def format_event_lines(events) -> list[str]:
+    """Render an ``AgentSession.session_events`` list as display strings.
+
+    Each dict event becomes ``"[{event_type}] {text}"``; flat legacy string
+    entries pass through unchanged; anything else is skipped. Callers that match
+    on the bracketed prefix (``agent/goal_gates.py``) depend on this exact shape.
+
+    Args:
+        events: The raw ``session_events`` value. Non-list input yields ``[]``.
+
+    Returns:
+        One display string per renderable event, in order.
+    """
+    if not isinstance(events, list):
+        return []
+    lines: list[str] = []
+    for event in events:
+        if isinstance(event, dict):
+            lines.append(f"[{event.get('event_type', 'system')}] {event.get('text', '')}")
+        elif isinstance(event, str):
+            lines.append(event)
+    return lines

--- a/monitoring/session_status.py
+++ b/monitoring/session_status.py
@@ -16,6 +16,8 @@ from pathlib import Path
 PROJECT_DIR = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_DIR))
 
+from models.session_event import format_event_lines  # noqa: E402 -- needs sys.path above
+
 
 def format_duration(seconds: float) -> str:
     """Format seconds into human-readable duration."""
@@ -79,7 +81,7 @@ def get_session_report(include_completed: bool = False, stalled_only: bool = Fal
         stall_marker = " STALLED" if is_stalled else ""
 
         # Last history entry for context
-        history = s._get_history_list() if hasattr(s, "_get_history_list") else []
+        history = format_event_lines(s.session_events)
         last_entry = history[-1] if history else "no history"
 
         session_id = s.session_id or s.agent_session_id or "unknown"

--- a/monitoring/session_watchdog.py
+++ b/monitoring/session_watchdog.py
@@ -47,6 +47,7 @@ from popoto.exceptions import ModelException
 
 from config.settings import settings
 from models.agent_session import AgentSession
+from models.session_event import format_event_lines
 
 
 def _to_timestamp(val) -> float | None:
@@ -414,10 +415,9 @@ def check_stalled_sessions() -> list[dict]:
                     # Get last history entry for diagnostic context
                     last_history = "no history"
                     try:
-                        if hasattr(session, "_get_history_list"):
-                            history = session._get_history_list()
-                            if history:
-                                last_history = str(history[-1])[:120]
+                        history = format_event_lines(session.session_events)
+                        if history:
+                            last_history = str(history[-1])[:120]
                     except Exception:  # noqa: S110 -- best-effort diagnostic context
                         pass
 

--- a/tests/e2e/test_session_lifecycle.py
+++ b/tests/e2e/test_session_lifecycle.py
@@ -11,6 +11,7 @@ import pytest
 
 from bridge.dedup import is_duplicate_message, record_message_processed
 from models.agent_session import AgentSession
+from models.session_event import format_event_lines
 
 
 @pytest.mark.e2e
@@ -194,7 +195,7 @@ class TestHistoryAccumulation:
         session.append_history("system", "Agent started")
 
         reloaded = list(AgentSession.query.filter(session_id=session.session_id))[0]
-        history = reloaded.get_history_list()
+        history = format_event_lines(reloaded.session_events)
         assert len(history) == 3
         assert "[user]" in history[0]
         assert "[classify]" in history[1]

--- a/tests/integration/test_agent_session_lifecycle.py
+++ b/tests/integration/test_agent_session_lifecycle.py
@@ -1,12 +1,12 @@
 """Tests for AgentSession lifecycle, summarizer composition, and markdown send.
 
 Covers the gaps identified in PR #180 review:
-1. AgentSession history tracking (append_history, cap at 20, get_stage_progress)
+1. AgentSession event tracking (append_event, session_events, get_stage_progress)
 2. AgentSession link tracking (set_link, get_links)
 3. Summarizer composition (_compose_structured_draft)
 4. Summarizer with session context (draft_message with session param)
 5. Markdown send (send_markdown fallback behavior)
-6. Backward compat (SessionLog shim, sender property)
+6. Backward compat (SessionLog shim, sender_name property)
 7. Full lifecycle simulations (SDLC, Teammate, chit-chat)
 """
 
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from models.agent_session import SDLC_STAGES, AgentSession
+from models.session_event import SessionEvent, format_event_lines
 
 
 def _make_stage_states(completed=None, in_progress=None):
@@ -53,7 +54,7 @@ def session(redis_test_db):
 @pytest.fixture
 def sdlc_session(redis_test_db):
     """Create an AgentSession with SDLC stage states and links."""
-    all_completed = _make_stage_states(completed=SDLC_STAGES)
+    all_completed = json.loads(_make_stage_states(completed=SDLC_STAGES))
     s = AgentSession.create(
         session_id="sdlc-lifecycle-1",
         project_key="test",
@@ -68,7 +69,7 @@ def sdlc_session(redis_test_db):
         branch_name="session/summarizer-bullet-format",
         turn_count=15,
         tool_call_count=42,
-        stage_states=all_completed,
+        session_events=[SessionEvent.stage_change("bulk", "init", all_completed).model_dump()],
     )
     s.append_history("user", "SDLC 177")
     s.set_link("issue", "https://github.com/tomcounsell/ai/issues/177")
@@ -117,11 +118,11 @@ def chat_session(redis_test_db):
 
 
 class TestHistoryTracking:
-    """Tests for append_history, _get_history_list, and history cap."""
+    """Tests for append_event/append_history, session_events, and format_event_lines."""
 
     def test_append_history_single(self, session):
         session.append_history("user", "SDLC 177")
-        history = session._get_history_list()
+        history = format_event_lines(session.session_events)
         assert len(history) == 1
         assert history[0] == "[user] SDLC 177"
 
@@ -129,7 +130,7 @@ class TestHistoryTracking:
         session.append_history("user", "SDLC 177")
         session.append_history("classify", "feature")
         session.append_history("stage", "ISSUE completed ☑")
-        history = session._get_history_list()
+        history = format_event_lines(session.session_events)
         assert len(history) == 3
         assert "[classify] feature" in history
 
@@ -141,24 +142,24 @@ class TestHistoryTracking:
         n = 60
         for i in range(n):
             session.append_history("test", f"entry {i}")
-        history = session._get_history_list()
+        history = format_event_lines(session.session_events)
         assert len(history) == n
         assert f"entry {n - 1}" in history[-1]
         # Oldest entries are retained, not trimmed away.
         assert any("entry 0" in h for h in history)
 
-    def test_get_history_list_empty(self, session):
-        assert session._get_history_list() == []
+    def test_format_event_lines_empty(self, session):
+        assert format_event_lines(session.session_events) == []
 
-    def test_get_history_list_none_safe(self, redis_test_db):
+    def test_format_event_lines_none_safe(self, redis_test_db):
         s = AgentSession.create(
             session_id="no-history",
             project_key="test",
             status="active",
             created_at=datetime.now(tz=UTC),
         )
-        # history field is None by default
-        assert s._get_history_list() == []
+        # session_events is None by default
+        assert format_event_lines(s.session_events) == []
 
 
 # ── Stage Progress ────────────────────────────────────────────────────────────
@@ -449,7 +450,7 @@ class TestEscapeMarkdown:
 
 
 class TestBackwardCompatibility:
-    """Tests for SessionLog shim and sender property."""
+    """Tests for the SessionLog shim and the sender_name property."""
 
     def test_session_log_is_agent_session(self):
         from models.session_log import SessionLog
@@ -462,9 +463,8 @@ class TestBackwardCompatibility:
 
         assert AgentSessionAlias is SessionLogAlias
 
-    def test_sender_property(self, session):
-        assert session.sender == session.sender_name
-        assert session.sender == "Tom"
+    def test_sender_name_property(self, session):
+        assert session.sender_name == "Tom"
 
     def test_create_via_session_log_shim(self, redis_test_db):
         from models.session_log import SessionLog
@@ -624,7 +624,7 @@ class TestSDLCClassificationTypeLifecycle:
         # The continuation session starts fresh but has classification_type
         assert s.is_sdlc is True
         # Even without stage_states, is_sdlc returns True via classification_type
-        assert s._get_history_list() == []
+        assert format_event_lines(s.session_events) == []
 
         # Add stage progress via stage_states
         s.stage_states = _make_stage_states(completed=SDLC_STAGES)

--- a/tests/integration/test_connectivity_gaps.py
+++ b/tests/integration/test_connectivity_gaps.py
@@ -16,6 +16,7 @@ from datetime import UTC, datetime
 import pytest
 
 from models.agent_session import AgentSession
+from models.session_event import format_event_lines
 
 # ── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -55,7 +56,7 @@ def running_session(redis_test_db):
         slug="test-slug",
         classification_type="bug",
         classification_confidence=0.95,
-        history=["[user] SDLC 209", "[stage] ISSUE completed"],
+        session_events=["[user] SDLC 209", "[stage] ISSUE completed"],
         issue_url="https://github.com/org/repo/issues/209",
         plan_url="https://github.com/org/repo/blob/main/docs/plans/fix.md",
         pr_url="https://github.com/org/repo/pull/210",
@@ -163,7 +164,7 @@ class TestCompleteTranscriptFieldPreservation:
 
         found = list(AgentSession.query.filter(session_id=running_session.session_id))
         s = found[0]
-        history = s._get_history_list()
+        history = format_event_lines(s.session_events)
         assert len(history) >= 2
         assert "[user] SDLC 209" in history[0]
 

--- a/tests/integration/test_lifecycle_transition.py
+++ b/tests/integration/test_lifecycle_transition.py
@@ -15,6 +15,7 @@ import pytest
 
 # claude_agent_sdk mock is centralized in conftest.py
 from models.agent_session import AgentSession
+from models.session_event import format_event_lines
 
 # ── AgentSession.log_lifecycle_transition() ──────────────────────────────────
 
@@ -32,7 +33,7 @@ class TestLogLifecycleTransition:
         )
         s.log_lifecycle_transition("running", "worker picked up")
 
-        history = s._get_history_list()
+        history = format_event_lines(s.session_events)
         assert len(history) >= 1
         lifecycle_entries = [h for h in history if "[lifecycle]" in h]
         assert len(lifecycle_entries) == 1
@@ -49,7 +50,7 @@ class TestLogLifecycleTransition:
         )
         s.log_lifecycle_transition("completed", "transcript completed: completed")
 
-        history = s._get_history_list()
+        history = format_event_lines(s.session_events)
         lifecycle_entries = [h for h in history if "[lifecycle]" in h]
         assert any("transcript completed" in entry for entry in lifecycle_entries)
 
@@ -86,7 +87,7 @@ class TestLogLifecycleTransition:
         s.log_lifecycle_transition("completed", "done")
 
         # Verify lifecycle entry was appended (duration is in the log, not a field)
-        history = s._get_history_list()
+        history = format_event_lines(s.session_events)
         lifecycle_entries = [h for h in history if "[lifecycle]" in h]
         assert len(lifecycle_entries) >= 1
         assert "completed" in lifecycle_entries[-1]
@@ -103,7 +104,7 @@ class TestLogLifecycleTransition:
         s.status = None
         s.log_lifecycle_transition("active", "recovery")
 
-        history = s._get_history_list()
+        history = format_event_lines(s.session_events)
         lifecycle_entries = [h for h in history if "[lifecycle]" in h]
         assert len(lifecycle_entries) >= 1
         assert "none" in lifecycle_entries[0]
@@ -173,7 +174,7 @@ class TestSessionTranscriptLifecycleLogging:
         # Verify the lifecycle transition was logged
         sessions = list(AgentSession.query.filter(session_id="st-lc-test-1"))
         assert len(sessions) == 1
-        history = sessions[0]._get_history_list()
+        history = format_event_lines(sessions[0].session_events)
         lifecycle_entries = [h for h in history if "[lifecycle]" in h]
         assert len(lifecycle_entries) >= 1
         assert "active" in lifecycle_entries[0]
@@ -195,7 +196,7 @@ class TestSessionTranscriptLifecycleLogging:
         # Verify lifecycle transition was logged for completion
         sessions = list(AgentSession.query.filter(session_id="st-lc-test-2"))
         assert len(sessions) == 1
-        history = sessions[0]._get_history_list()
+        history = format_event_lines(sessions[0].session_events)
         lifecycle_entries = [h for h in history if "[lifecycle]" in h]
         # Should have at least 2: one from start, one from complete
         assert len(lifecycle_entries) >= 2
@@ -227,7 +228,7 @@ class TestSessionTranscriptLifecycleLogging:
         # Verify history was preserved
         sessions = list(AgentSession.query.filter(session_id="st-lc-test-3"))
         assert len(sessions) == 1
-        history = sessions[0]._get_history_list()
+        history = format_event_lines(sessions[0].session_events)
         assert len(history) >= 1
 
 
@@ -254,7 +255,7 @@ class TestJobQueueLifecycleLogging:
 
         sessions = list(AgentSession.query.filter(session_id="jq-lc-test-1"))
         assert len(sessions) == 1
-        history = sessions[0]._get_history_list()
+        history = format_event_lines(sessions[0].session_events)
         lifecycle_entries = [h for h in history if "[lifecycle]" in h]
         assert len(lifecycle_entries) >= 1
         assert any("pending" in entry for entry in lifecycle_entries)
@@ -286,7 +287,7 @@ class TestJobQueueLifecycleLogging:
                 running_session = s
                 break
         assert running_session is not None
-        history = running_session._get_history_list()
+        history = format_event_lines(running_session.session_events)
         lifecycle_entries = [h for h in history if "[lifecycle]" in h]
         assert any("running" in entry for entry in lifecycle_entries)
 

--- a/tests/unit/test_agent_session_legacy_surface.py
+++ b/tests/unit/test_agent_session_legacy_surface.py
@@ -1,0 +1,90 @@
+"""Issue #2873: the removed ``AgentSession`` legacy surface stays removed.
+
+Two things are pinned here:
+
+1. The deprecated aliases and zero-caller wrappers no longer exist on the model.
+2. ``_normalize_kwargs`` no longer rewrites legacy field names. The
+   ``commit_sha``/``summary`` paths in particular were unguarded and appended an
+   event to ``session_events`` on *every* hydration of a row that carried both a
+   live ``session_events`` key and a stale legacy key -- unbounded growth on a
+   read path.
+"""
+
+import pytest
+
+from models.agent_session import AgentSession
+
+
+class TestRemovedAliases:
+    """Deprecated aliases and zero-caller wrappers are gone."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "get_parent_chat_session",
+            "get_dev_sessions",
+            "get_history_list",
+            "_get_history_list",
+            "sender",
+            "history",
+        ],
+    )
+    def test_attribute_absent(self, name):
+        assert not hasattr(AgentSession, name), f"AgentSession.{name} should have been removed"
+
+    @pytest.mark.parametrize(
+        "name",
+        ["get_parent_session", "get_child_sessions", "sender_name", "session_events"],
+    )
+    def test_canonical_replacement_present(self, name):
+        assert hasattr(AgentSession, name)
+
+
+class TestNormalizeKwargsLegacyPathsRemoved:
+    """Legacy field names are no longer mapped onto canonical fields."""
+
+    @pytest.mark.parametrize(
+        ("legacy_key", "legacy_value", "canonical_key"),
+        [
+            ("work_item_slug", "some-slug", "slug"),
+            ("last_activity", 1_700_000_000, "updated_at"),
+            ("scheduled_after", 1_700_000_000, "scheduled_at"),
+            ("parent_job_id", "parent-123", "parent_agent_session_id"),
+            ("history", ["old entry"], "session_events"),
+        ],
+    )
+    def test_legacy_key_is_not_remapped(self, legacy_key, legacy_value, canonical_key):
+        result = AgentSession._normalize_kwargs({legacy_key: legacy_value})
+        assert canonical_key not in result
+
+    @pytest.mark.parametrize(
+        "legacy_key",
+        [
+            "job_id",
+            "depends_on",
+            "stable_agent_session_id",
+            "scheduling_depth",
+            "_qa_mode_legacy",
+            "stage_states",
+            "commit_sha",
+            "summary",
+        ],
+    )
+    def test_legacy_key_does_not_crash_normalization(self, legacy_key):
+        """Unknown keys survive normalization untouched; Popoto never persists them."""
+        result = AgentSession._normalize_kwargs({legacy_key: "legacy-value"})
+        assert result[legacy_key] == "legacy-value"
+
+    @pytest.mark.parametrize("legacy_key", ["commit_sha", "summary"])
+    def test_no_duplicate_event_growth_on_hydration(self, legacy_key):
+        """A row with live ``session_events`` plus a stale legacy key does not grow.
+
+        This was the unguarded-append bug: ``commit_sha`` and ``summary`` were the
+        only two paths lacking the ``"session_events" not in kwargs`` guard.
+        """
+        live_events = [{"event_type": "lifecycle", "text": "pending->running"}]
+        kwargs = {"session_events": list(live_events), legacy_key: "abc123"}
+
+        result = AgentSession._normalize_kwargs(kwargs)
+
+        assert result["session_events"] == live_events

--- a/tests/unit/test_goal_gates.py
+++ b/tests/unit/test_goal_gates.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 from agent.goal_gates import (
     GATE_STAGES,
@@ -120,7 +120,7 @@ class TestCheckBuildGate:
 class TestCheckTestGate:
     def test_session_history_has_test_completed(self):
         session = MagicMock()
-        session.get_history_list.return_value = [
+        session.session_events = [
             "[stage] TEST COMPLETED",
             "Some other entry",
         ]
@@ -130,7 +130,7 @@ class TestCheckTestGate:
 
     def test_session_history_case_insensitive(self):
         session = MagicMock()
-        session.get_history_list.return_value = [
+        session.session_events = [
             "[Stage] test Completed successfully",
         ]
         result = check_test_gate("slug", session=session)
@@ -138,7 +138,7 @@ class TestCheckTestGate:
 
     def test_session_history_no_test(self):
         session = MagicMock()
-        session.get_history_list.return_value = [
+        session.session_events = [
             "[stage] BUILD COMPLETED",
         ]
         result = check_test_gate("slug", session=session)
@@ -169,13 +169,15 @@ class TestCheckTestGate:
 
     def test_session_history_exception_handled(self):
         session = MagicMock()
-        session.get_history_list.side_effect = RuntimeError("Redis down")
+        # session_events is a plain attribute now, so the failure has to come
+        # from the attribute access itself to exercise the gate's try/except.
+        type(session).session_events = PropertyMock(side_effect=RuntimeError("Redis down"))
         result = check_test_gate("slug", session=session)
         assert result.satisfied is False
 
     def test_session_history_non_string_entries(self):
         session = MagicMock()
-        session.get_history_list.return_value = [
+        session.session_events = [
             42,
             None,
             {"key": "value"},
@@ -308,7 +310,7 @@ class TestCheckGate:
 
     def test_dispatches_to_test_with_session(self):
         session = MagicMock()
-        session.get_history_list.return_value = ["[stage] TEST COMPLETED"]
+        session.session_events = ["[stage] TEST COMPLETED"]
         result = check_gate("TEST", "slug", ".", session=session)
         assert result.satisfied is True
 

--- a/tests/unit/test_message_drafter.py
+++ b/tests/unit/test_message_drafter.py
@@ -441,11 +441,6 @@ class TestNoMessageEcho:
         from unittest.mock import MagicMock
 
         session = MagicMock()
-        session._get_history_list.return_value = [
-            "[user] SDLC 190",
-            "[stage] ISSUE completed ☑",
-            "[stage] PLAN completed ☑",
-        ]
         session.message_text = "continue"
         session.status = "running"
         session.is_sdlc = True
@@ -464,7 +459,6 @@ class TestNoMessageEcho:
         from unittest.mock import MagicMock
 
         session = MagicMock()
-        session._get_history_list.return_value = ["[user] What time is it?"]
         session.message_text = "What time is it?"
         session.status = "completed"
         session.session_type = SessionType.ENG
@@ -551,9 +545,6 @@ class TestComposeStructuredDraftWithSession:
             {"ISSUE": "completed", "PLAN": "completed", "BUILD": "in_progress"},
             links=links,
         )
-        session._get_history_list.return_value = [
-            "[user] /sdlc 190",
-        ]
         session.message_text = "continue"
         session.status = "running"
 
@@ -573,7 +564,6 @@ class TestComposeStructuredDraftWithSession:
     def test_non_sdlc_session_no_stage_line(self):
         """Non-SDLC session skips stage progress line."""
         session = _mock_session_with_stages({})  # All pending
-        session._get_history_list.return_value = ["[user] What time is it?"]
         session.message_text = "What time is it?"
         session.status = "running"
 
@@ -744,9 +734,6 @@ class TestErrorStateRendering:
             {"ISSUE": "completed", "PLAN": "completed", "BUILD": "failed"},
             links={"issue": "https://github.com/org/repo/issues/200"},
         )
-        session._get_history_list.return_value = [
-            "[user] /sdlc 200",
-        ]
         session.message_text = "continue"
         session.status = "failed"
         session.is_sdlc = True
@@ -766,7 +753,6 @@ class TestErrorStateRendering:
         session = _mock_session_with_stages(
             {"ISSUE": "completed", "PLAN": "completed", "BUILD": "completed", "TEST": "failed"},
         )
-        session._get_history_list.return_value = ["[user] test"]
         session.message_text = "test"
         session.status = "failed"
 
@@ -784,7 +770,6 @@ class TestErrorStateRendering:
         session = _mock_session_with_stages(
             {"ISSUE": "completed", "PLAN": "completed", "BUILD": "failed"},
         )
-        session._get_history_list.return_value = []
         session.message_text = "continue"
         session.status = "failed"
         session.is_sdlc = True
@@ -801,7 +786,6 @@ class TestErrorStateRendering:
     def test_error_message_propagated_to_output(self):
         """Error messages in the summary text should reach the rendered output."""
         session = _mock_session_with_stages({})  # All pending
-        session._get_history_list.return_value = []
         session.message_text = "continue"
         session.status = "failed"
 
@@ -821,7 +805,6 @@ class TestErrorStateRendering:
             {"ISSUE": "completed", "PLAN": "completed", "BUILD": "failed"},
             links={"issue": "https://github.com/org/repo/issues/200"},
         )
-        session._get_history_list.return_value = []
         session.message_text = "continue"
         session.status = "failed"
         session.is_sdlc = True

--- a/tests/unit/test_model_relationships.py
+++ b/tests/unit/test_model_relationships.py
@@ -553,8 +553,9 @@ class TestAgentSessionFieldPresence:
 
         assert "claude_code_session_id" not in AgentSession._meta.field_names
 
-    def test_sender_property_exists(self):
-        """AgentSession should have a sender property aliasing sender_name."""
+    def test_sender_name_property_exists(self):
+        """sender_name is the canonical accessor; the old `sender` alias is gone."""
         from models.agent_session import AgentSession
 
-        assert isinstance(AgentSession.sender, property)
+        assert isinstance(AgentSession.sender_name, property)
+        assert not hasattr(AgentSession, "sender")

--- a/tests/unit/test_sdlc_mode.py
+++ b/tests/unit/test_sdlc_mode.py
@@ -62,23 +62,25 @@ class TestIsSdlcJobClassificationType:
         assert session.is_sdlc is False
 
     def test_stage_states_triggers_sdlc(self):
-        """stage_states with active stages should trigger SDLC."""
-        import json
+        """A stage event with active stages should trigger SDLC."""
+        from models.session_event import SessionEvent
 
         session = AgentSession(
             session_id="test_legacy_246",
             project_key="test",
-            stage_states=json.dumps({"PLAN": "in_progress"}),
+            session_events=[
+                SessionEvent.stage_change("bulk", "init", {"PLAN": "in_progress"}).model_dump()
+            ],
         )
         assert session.is_sdlc is True
 
-    def test_classification_takes_priority_over_empty_history(self):
-        """classification_type=sdlc should work even with empty history."""
+    def test_classification_takes_priority_over_empty_events(self):
+        """classification_type=sdlc should work even with no session events."""
         session = AgentSession(
             session_id="test_priority_246",
             project_key="test",
             classification_type="sdlc",
-            history=[],
+            session_events=[],
         )
         assert session.is_sdlc is True
 
@@ -88,6 +90,6 @@ class TestIsSdlcJobClassificationType:
             session_id="test_activated_246",
             project_key="test",
             classification_type="sdlc",
-            history=["[user] SDLC issue 246"],
+            session_events=["[user] SDLC issue 246"],
         )
         assert session.is_sdlc is True

--- a/tests/unit/test_session_event_formatting.py
+++ b/tests/unit/test_session_event_formatting.py
@@ -1,0 +1,65 @@
+"""Tests for ``models.session_event.format_event_lines``.
+
+The helper replaces the removed ``AgentSession.get_history_list()`` /
+``_get_history_list`` methods (issue #2873). Three production call sites depend
+on the exact ``"[{event_type}] {text}"`` shape, so it is pinned here.
+"""
+
+import pytest
+
+from models.session_event import SessionEvent, format_event_lines
+
+
+class TestFormatEventLines:
+    """The formatting contract inherited from the removed model method."""
+
+    @pytest.mark.parametrize(
+        ("events", "expected"),
+        [
+            pytest.param(None, [], id="none"),
+            pytest.param([], [], id="empty"),
+            pytest.param("not-a-list", [], id="non-list"),
+            pytest.param({"event_type": "stage"}, [], id="bare-dict-not-a-list"),
+            pytest.param(
+                [{"event_type": "stage", "text": "test=completed"}],
+                ["[stage] test=completed"],
+                id="dict-event",
+            ),
+            pytest.param(
+                [{"text": "no type"}],
+                ["[system] no type"],
+                id="dict-missing-event-type-defaults-to-system",
+            ),
+            pytest.param(
+                [{"event_type": "summary"}],
+                ["[summary] "],
+                id="dict-missing-text-is-empty",
+            ),
+            pytest.param(
+                ["legacy flat string"],
+                ["legacy flat string"],
+                id="str-event-passes-through",
+            ),
+            pytest.param([12345, None], [], id="unsupported-entries-skipped"),
+            pytest.param(
+                [{"event_type": "stage", "text": "a"}, "b", 7],
+                ["[stage] a", "b"],
+                id="mixed-entries",
+            ),
+        ],
+    )
+    def test_formatting(self, events, expected):
+        assert format_event_lines(events) == expected
+
+    def test_accepts_serialized_session_event(self):
+        """A real ``SessionEvent.model_dump()`` round-trips into the pinned shape."""
+        event = SessionEvent.stage_change("test", "completed")
+        assert format_event_lines([event.model_dump()]) == ["[stage] test=completed"]
+
+    def test_goal_gate_match_shape(self):
+        """``agent/goal_gates.py`` matches on ``[stage]``/``test``/``completed``."""
+        line = format_event_lines([SessionEvent.stage_change("test", "completed").model_dump()])[0]
+        lowered = line.lower()
+        assert "[stage]" in lowered
+        assert "test" in lowered
+        assert "completed" in lowered

--- a/tests/unit/test_session_status.py
+++ b/tests/unit/test_session_status.py
@@ -46,7 +46,7 @@ def _make_fake_session(
     started_at=None,
     updated_at=None,
     project_key="test",
-    history=None,
+    session_events=None,
 ):
     """Create a mock AgentSession for report testing."""
     now = time.time()
@@ -58,7 +58,7 @@ def _make_fake_session(
     mock.started_at = started_at or now - 200
     mock.updated_at = updated_at or now - 10
     mock.project_key = project_key
-    mock._get_history_list.return_value = history or []
+    mock.session_events = session_events or []
     return mock
 
 

--- a/tests/unit/test_stall_detection.py
+++ b/tests/unit/test_stall_detection.py
@@ -43,7 +43,7 @@ def _make_agent_session(
     project_key="test",
     chat_id="12345",
     agent_session_id="session-001",
-    history=None,
+    session_events=None,
 ):
     now = time.time()
     ns = SimpleNamespace(
@@ -56,8 +56,7 @@ def _make_agent_session(
         project_key=project_key,
         chat_id=chat_id,
     )
-    _history = history or []
-    ns._get_history_list = lambda: _history
+    ns.session_events = session_events or []
     ns.log_lifecycle_transition = MagicMock()
     ns.save = MagicMock()
     ns.delete = MagicMock()

--- a/tests/unit/test_transcript_liveness.py
+++ b/tests/unit/test_transcript_liveness.py
@@ -149,7 +149,7 @@ class TestCheckStalledSessionsWithTranscript:
             updated_at=now - (STALL_THRESHOLD_ACTIVE + 120),
             project_key="test",
         )
-        session._get_history_list = lambda: []
+        session.session_events = []
 
         # Create a fresh transcript file
         session_dir = tmp_path / "transcript-fresh"
@@ -198,7 +198,7 @@ class TestCheckStalledSessionsWithTranscript:
             updated_at=now - (STALL_THRESHOLD_ACTIVE + 120),
             project_key="test",
         )
-        session._get_history_list = lambda: []
+        session.session_events = []
 
         def mock_filter(**kwargs):
             status = kwargs.get("status", "")
@@ -238,7 +238,7 @@ class TestCheckStalledSessionsWithTranscript:
             updated_at=now,
             project_key="test",
         )
-        session._get_history_list = lambda: []
+        session.session_events = []
 
         def mock_filter(**kwargs):
             status = kwargs.get("status", "")

--- a/tests/unit/test_ui_sdlc_data.py
+++ b/tests/unit/test_ui_sdlc_data.py
@@ -30,7 +30,7 @@ def _make_mock_session(**overrides):
         "completed_at": None,
         "updated_at": time.time(),
         "stage_states": None,
-        "history": [],
+        "session_events": [],
         "issue_url": None,
         "plan_url": None,
         "pr_url": None,
@@ -646,7 +646,7 @@ class TestSessionToPipeline:
         mock_session = _make_mock_session(
             issue_url=None,
             pr_url=None,
-            history=[
+            session_events=[
                 {"role": "lifecycle", "text": "Created issue https://github.com/org/repo/issues/7"},
                 {"role": "lifecycle", "text": "Opened PR https://github.com/org/repo/pull/8"},
             ],
@@ -662,7 +662,7 @@ class TestSessionToPipeline:
         mock_session = _make_mock_session(
             issue_url="https://github.com/org/repo/issues/1",
             pr_url=None,
-            history=[
+            session_events=[
                 {
                     "role": "lifecycle",
                     "text": "Created issue https://github.com/org/repo/issues/999",
@@ -694,7 +694,7 @@ class TestSessionToPipeline:
         mock_session.completed_at = time.time()
         mock_session.updated_at = time.time()
         mock_session.stage_states = None
-        mock_session.history = []
+        mock_session.session_events = []
         mock_session.issue_url = None
         mock_session.plan_url = None
         mock_session.pr_url = None

--- a/tools/session_tags.py
+++ b/tools/session_tags.py
@@ -253,7 +253,7 @@ def auto_tag_session(session_id: str) -> None:
             new_tags.append("tested")
 
     # Rule 4: Reflections detection
-    sender = session.sender or ""
+    sender = session.sender_name or ""
     if "reflections" in sender.lower() or "reflections" in session_id.lower():
         new_tags.append("reflections")
 

--- a/ui/data/sdlc.py
+++ b/ui/data/sdlc.py
@@ -982,7 +982,8 @@ def _session_to_pipeline(session) -> PipelineProgress:
 
     stages = _resolve_display_stages(session)
 
-    history_list = session.history if isinstance(session.history, list) else None
+    events = session.session_events
+    history_list = events if isinstance(events, list) else None
     events = _parse_history(history_list)
 
     from agent.session_health import _is_ledger


### PR DESCRIPTION
Closes #2873

Removes the deprecated `AgentSession` surface: two zero-caller wrappers, two property aliases, the `get_history_list()` / `_get_history_list` pair, and **all nine** legacy field-mapping paths in `_normalize_kwargs()`. The model now exposes only its current, real API.

## What was removed

| Symbol | Replacement at the call site |
|---|---|
| `get_parent_chat_session()` | `get_parent_session()` (was already the only implementation) |
| `get_dev_sessions()` | `get_child_sessions()` (ditto) |
| `get_history_list()` / `_get_history_list` | `models.session_event.format_event_lines(session.session_events)` |
| `.sender` property | `.sender_name` |
| `.history` property + setter | `.session_events` |

`_normalize_kwargs()` legacy paths deleted: `work_item_slug` → `slug`; `last_activity` → `updated_at`; `scheduled_after` → `scheduled_at`; `parent_job_id` → `parent_agent_session_id`; `history` → `session_events`; `stage_states` → event; `commit_sha` → event; `summary` → event; the `job_id` discard; and the dead-field pop list (`depends_on`, `stable_agent_session_id`, `scheduling_depth`, `_qa_mode_legacy`).

What `_normalize_kwargs()` still does, unchanged: constituent-field consolidation into `initial_telegram_message` / `extra_context`, the `watchdog_unhealthy` → `unhealthy_reason` back-alias (#1927), the `agent_session_id` `AutoKeyField` discard, and the `response_delivered_at` defensive coercion (#929).

Note that `stage_states`, `commit_sha`, `summary`, and `work_item_slug` remain live **properties** on the model (several with setters that append the appropriate event). Only their `_normalize_kwargs` constructor-kwarg paths are gone. `AgentSession.create_child()` keeps its own explicit `stage_states` parameter and is unaffected.

## Bug fixed: unbounded event-log growth on a read path

`commit_sha` and `summary` were the only two mapping paths **lacking** the `"session_events" not in kwargs` guard that the other event-producing paths had. They unconditionally did `events.append(...)` onto whatever came out of Redis.

The consequence: any row carrying *both* a live `session_events` key and a stale `commit_sha`/`summary` key grew one extra event on **every** `query.get()`. If that instance was then saved, the duplicate persisted — while the stale hash key remained, ready to do it again on the next read. `session_events` has no count cap (deliberately, per the durability work in #2494), so nothing bounded this. Deleting these two paths removes the growth mechanism outright.

Regression coverage: `tests/unit/test_agent_session_legacy_surface.py::test_no_duplicate_event_growth_on_hydration`.

## New helper

`models/session_event.py` gains `format_event_lines(events) -> list[str]`, a module-level function that renders `session_events` as display strings: dict entries become `f"[{event_type}] {text}"`, flat legacy string entries pass through, anything else is skipped, non-list input yields `[]`. Byte-identical output to the removed method. It lives next to `SessionEvent` because that is where the shape is defined, and because a module function does not re-add API surface to the model.

Three production call sites migrated to it: `agent/goal_gates.py` (matches on the `[stage]` prefix, so the exact format is load-bearing), `monitoring/session_status.py`, `monitoring/session_watchdog.py`.

**Silent-degradation trap, closed.** Two of those three call sites were written as `if hasattr(session, "_get_history_list")`. Deleting the method without touching them would have made both quietly evaluate to "no history" forever instead of failing loudly. Both guards are gone; the calls are now unconditional.

The issue text says there are four production callers and names `ui/data/sdlc.py` as one. That is wrong — there are three. `ui/data/sdlc.py` used the `.history` property, not `get_history_list()`, and is migrated to `.session_events` separately.

## Required disclosure: the hydration assumption

**Operative assumption, an explicit owner decision made with the risk stated: no `AgentSession` rows written before 2026-04-01 survive in Redis, or their legacy field data is acceptable to lose.**

This matters because **"no live Python caller" is the wrong test for these paths.** Popoto's non-lazy decode does `model_class(**model_attrs)` with the **raw Redis hash** — every key the hash contains, not a declared-field subset (`popoto/models/encoding.py:337`). So `query.get()`, `get_many()`, `async_get()`, and `async_get_many()` all run `_normalize_kwargs` over whatever legacy keys a row happens to carry, with no Python caller ever naming them. (`filter()` and `all()` default `lazy=True`, use `object.__new__`, and bypass `__init__` entirely — those paths never ran the mapping in the first place.)

Two of the nine paths carry real consequence if such rows exist:

- **`parent_job_id`** — a pre-rename row would previously surface with its parent link intact. It now hydrates with `parent_agent_session_id=None` and, on the next save, persists as **orphaned**.
- **`history`** — a pre-rename row now hydrates with an empty event log, and the next save wipes the old entries.

The remaining seven are benign: `job_id` and the dead-field pop list moved no data at all, and `work_item_slug` / `last_activity` / `scheduled_after` / `stage_states` / `commit_sha` / `summary` degrade to a missing display value rather than a broken link.

Three further facts, so the assumption is judged on real evidence:

1. **The "old rows aged out" argument does not hold here.** `Meta.ttl` is 30 days (`models/agent_session.py`), but it **never actually fired** until #2698: the corruption sweep full-`save()`d every hydrated row as a validation probe, and every `save()` resets the key's TTL to the ceiling. The clock was reset on every worker start, every `/update`, and every hourly cleanup tick, indefinitely. The model's own `Meta` comment documents this.
2. **No existing migration covers this field set.** The fields were removed in `3d2823923` (#609 / #628) on 2026-04-01. The three strip migrations in the tree — `migrate_schema_diet_fields.py`, `migrate_strip_pty_fields.py`, `migrate_strip_pid_fields.py` — target the #1927 and #1924 field sets, not this one.
3. **`agent/session_archive.py` is ruled out as a legacy-key source.** `_serialize_session` enumerates `session._meta.fields` — only currently-declared fields — and the archive was created 2026-07-04, three months after the field removal. A restore therefore cannot reintroduce a legacy key.

Deliberately **not touched**: the `agent_session_id` pop in `_normalize_kwargs` (and its counterpart note in `agent/session_archive.py`). Removing it would mint a fresh `AutoKeyField` UUID on every archive restore and dangle every `parent_agent_session_id` link. It was never on this list.

## Corrected comment

The pop-list comment claimed Popoto "silently drops any kwarg that doesn't match a declared field". Directionally right about crash-safety, technically wrong: `Model.__init__` does `self.__dict__.update(kwargs)` (`popoto/models/base.py:518`), so unknown keys land in the instance dict. They are simply never *persisted* — encoding iterates `_meta.fields` only. The replacement comment says that. Same conclusion (an unknown key never raises), accurate mechanism.

## Docstring and docs corrections

The module docstring claimed `parent_session_id` and `parent_chat_session_id` were deprecated property aliases delegating to `parent_agent_session_id`. **Neither property exists anywhere in the file** — the docstring was describing history. Replaced with the current parent link plus a section naming `session_events` as the sole event log.

`docs/features/agent-session-model.md` carried the same stale mapping list and is updated.

A code sample in `docs/guides/sdlc-storyline-example.md` called `get_history_list()` and then tested each entry with `isinstance(entry, dict)` — which could never match, since the method returned strings. Rewritten against `session_events` directly, which is what it meant.

Historical `docs/plans/completed/` mentions were left alone as archives.

## Incidental, guard-forced

`agent/goal_gates.py` carried a bare `timeout=10` on its `gh` subprocess call. Touching the file tripped the repo's inline-timeout-literal commit guard, which blocks the commit outright. Switched to `settings.timeouts.git_subprocess_s`, the field whose own description names `gh` CLI calls as its family. This raises the ceiling from 10s to 60s; it is a hang ceiling, not an added delay.

## Verification

`python -m ruff check .` — All checks passed. `python -m ruff format --check .` — 1374 files already formatted.

Targeted runs via `scripts/pytest-clean.sh` (never bare pytest). Note these ran with `-n 0`: the machine had several other agents' suites running concurrently (load 22, 23 pytest processes), and xdist workers were being killed off before collection finished. Serial runs are unaffected.

```
tests/unit/{test_session_event_formatting, test_agent_session_legacy_surface,
            test_goal_gates, test_sdlc_mode, test_model_relationships}   -> 131 passed

tests/unit/{test_message_drafter, test_session_status, test_stall_detection,
            test_transcript_liveness, test_ui_sdlc_data}                 -> 317 passed

tests/unit/{test_agent_session_queue, test_session_archive,
            test_pipeline_state_machine, test_stage_states_helpers}      -> 288 passed
            (the _normalize_kwargs-adjacent suites, as blast-radius insurance)

tests/integration/{test_agent_session_lifecycle, test_connectivity_gaps,
                   test_lifecycle_transition} + tests/e2e/test_session_lifecycle.py
                                                                         -> 77 passed, 2 failed
```

The 2 failures are `test_connectivity_gaps.py::TestSdkClientEnvVar::{test_valor_session_id_in_source, test_valor_session_id_conditional_on_session_id}`. They assert on the *source text* of `agent/sdk_client.py`, which this branch does not touch. **Verified pre-existing rather than assumed:** both were re-run in a throwaway worktree checked out at `origin/main` and fail there identically.
