### PR TITLE
docs: cascade the #2879 split renames and correct the promise-gate scope claim (Closes #3011)

### DIFF
--- a/docs/features/promise-gate.md
+++ b/docs/features/promise-gate.md
@@ -374,7 +374,7 @@ under tests.
   conditional session_events emission with real and synthetic
   session_ids.
 * `tests/unit/test_send_message.py`,
-  `valor_telegram/`, `test_valor_email.py` — each adds a
+  `valor_telegram/test_valor_telegram_rtr.py`, `test_valor_email.py` — each adds a
   `--help` anti-leak test asserting the help output never advertises
   the bypass syntax.
 

--- a/docs/features/sdlc-router-oscillation-guard.md
+++ b/docs/features/sdlc-router-oscillation-guard.md
@@ -664,8 +664,10 @@ deferred until optimistic retry proves insufficient in production.
 ## Regression Coverage
 
 - `tests/unit/sdlc_router_decision/` — pure-function tests for every
-  dispatch rule row (1 through 10b), including `TestReviewInProgressNoVerdictDeadEnd`
-  (row 8c, 7 cases mirroring `TestCritiqueInProgressNoVerdictDeadEnd`).
+  dispatch rule row (1 through 10b), split by theme. Row coverage lives in
+  `test_sdlc_router_decision_dispatch_rows.py`; `TestReviewInProgressNoVerdictDeadEnd`
+  (row 8c, 7 cases mirroring `TestCritiqueInProgressNoVerdictDeadEnd`) is in
+  `test_sdlc_router_decision_convergence.py`.
 - `tests/unit/test_sdlc_router.py` — `TestReReviewCrashRecovery` (row 8d, both
   `completed`/`failed` terminal markers recover), `TestRow3OpenPrStepAside`,
   `TestG1OpenPrStepAside`, `TestG5OpenPrStepAside` (NEEDS_REVISION and

--- a/docs/features/telegram-messaging.md
+++ b/docs/features/telegram-messaging.md
@@ -392,7 +392,7 @@ either substring-match all records or pass through silently.
 |------|---------|
 | `tools/valor_telegram.py` | CLI implementation |
 | `.claude/skills/telegram/SKILL.md` | Agent skill documentation |
-| `tests/unit/valor_telegram/` | Test suite |
+| `tests/unit/valor_telegram/` | Test suite (parsing, `cmd_send`, `cmd_read`, `cmd_chats`, RTR/promise gate, await, chat log, voice flag) |
 
 ## PM Tool vs CLI Tool
 

--- a/docs/features/tts.md
+++ b/docs/features/tts.md
@@ -154,4 +154,4 @@ The agent invokes this skill when the user asks for a spoken update.
 - `bridge/telegram_relay.py` — `_send_queued_message` voice-note branch + `_safe_unlink` + DLQ cleanup
 - `tools/valor_telegram.py` — `--voice-note` and `--cleanup-after-send` flags on `send`
 - `.claude/skills/do-debrief/SKILL.md` — the only user-invocable composite
-- Tests: `tools/tts/tests/`, `tests/unit/test_telegram_relay_voice_note.py`, `tests/unit/test_valor_telegram_voice_flag.py`
+- Tests: `tools/tts/tests/`, `tests/unit/test_telegram_relay_voice_note.py`, `tests/unit/valor_telegram/test_valor_telegram_voice_flag.py`

--- a/docs/guides/valor-name-references.md
+++ b/docs/guides/valor-name-references.md
@@ -153,7 +153,7 @@ References in prose, test fixtures, and examples. Low runtime impact — these f
 | File | References |
 |------|-----------|
 | `tests/unit/test_bridge_logic.py` | Routing assertions with "valor" usernames |
-| `tests/unit/test_valor_telegram.py` | CLI tool tests |
+| `tests/unit/valor_telegram/` | CLI tool tests |
 | `tests/unit/test_sdk_client.py` | Persona name assertions |
 | `tests/unit/test_sdk_client_sdlc.py` | SDLC mode tests |
 | `tests/unit/test_summarizer.py` | Summarizer tests |

--- a/tests/README.md
+++ b/tests/README.md
@@ -546,6 +546,10 @@ and take the first `pattern in basename` hit, exactly as `pytest_collection_modi
 does. Do this *before* writing the files; renaming afterwards is cheap, but only if you
 notice, and step 3's count check is what catches you if you didn't.
 
+This procedure is currently manual. Automating it as a standing regression guard — so a
+mistagged basename fails a test instead of relying on whoever does the split remembering
+to check — is tracked in [#3010](https://github.com/tomcounsell/ai/issues/3010).
+
 ### Feature Marker Registration
 
 New markers must be added in two places:

--- a/tests/unit/sdlc_session_ensure/conftest.py
+++ b/tests/unit/sdlc_session_ensure/conftest.py
@@ -14,7 +14,7 @@ def _stub_lane_identity(request):
     ``ensure_session`` mints the lane's identity on entry, which peeks the issue
     lock for the pinned target repo and writes a ``PipelineLedger``. That is
     correct behavior and ``TestLaneSlugMintedAtLaneStart`` asserts it -- but for
-    every other test in this file it is noise: it adds a ``touch_issue_lock``
+    every other test in this package it is noise: it adds a ``touch_issue_lock``
     call that the lock-wiring assertions count, and it leaves a real ledger
     record per test.
     """

--- a/tests/unit/valor_telegram/conftest.py
+++ b/tests/unit/valor_telegram/conftest.py
@@ -15,7 +15,29 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 
 @pytest.fixture(autouse=True)
 def _bypass_promise_gate(monkeypatch):
-    """Default-mock the promise gate so existing tests do not call the LLM."""
+    """Default-mock the promise gate so tests in this package do not call the LLM.
+
+    Hoisting this from the former monolith to a package conftest **widened its
+    scope**, contrary to what PR #3005's description claimed. The three files
+    absorbed into this package (``_await``, ``_chat_log``, ``_voice_flag``) never
+    had it before. The widening was missed because those files contain no literal
+    ``promise_gate`` reference to grep for -- the path is indirect:
+    ``_chat_log`` (5 tests) and ``_voice_flag`` (3 tests) call ``cmd_send``, and
+    ``tools/valor_telegram.py`` calls ``cli_check_or_exit`` unconditionally.
+    Those files mock only ``resolve_chat`` and ``_get_redis_connection``, so
+    before the move all 8 ran the real gate. ``_await`` is unaffected: it targets
+    ``tools.valor_telegram_await`` and never reaches ``cmd_send``.
+
+    Kept deliberately rather than scoped back. Those 8 tests assert relay-payload
+    shape, chat-log recording, and voice-flag/cleanup behavior -- never gate
+    behavior -- so running the real gate was incidental cost, not coverage.
+    ``cli_check_or_exit`` itself is covered directly by
+    ``tests/unit/test_promise_gate.py``; the CLI's contract with it here is the
+    ``--help`` anti-leak assertion in
+    ``test_valor_telegram_rtr.py::TestValorTelegramPromiseGate``, which needs no
+    real gate call. If a test in this package ever does need the live gate, it
+    must opt out explicitly -- nothing in the package overrides this fixture today.
+    """
     monkeypatch.setattr(
         "bridge.promise_gate.cli_check_or_exit",
         lambda text, transport, session_id: None,


### PR DESCRIPTION
Closes #3011
Refs #2879, #3010

Follow-up to PR #3005 (merged as `379f39427`), clearing the review findings that arrived after that PR had already merged. No test logic changes; the only code touched is two conftest docstrings.

## 1. Four feature docs named deleted file paths

| Doc | Was | Now |
|---|---|---|
| `read-the-room.md:33` | `tests/unit/test_valor_telegram.py::TestCmdSendRTR` | `tests/unit/valor_telegram/test_valor_telegram_rtr.py::TestCmdSendRTR` |
| `telegram-messaging.md:395` | `tests/unit/test_valor_telegram.py` | `tests/unit/valor_telegram/` (with the per-file breakdown) |
| `sdlc-router-oscillation-guard.md:666` | `tests/unit/test_sdlc_router_decision.py` | `tests/unit/sdlc_router_decision/`, naming which file now holds `TestReviewInProgressNoVerdictDeadEnd` |
| `promise-gate.md:377` | `test_valor_telegram.py` | `valor_telegram/test_valor_telegram_rtr.py` (where the `--help` anti-leak test actually lives) |

Each new path was resolved by locating the class or test, not by pattern-substituting the directory. `read-the-room.md` is the clearest case: PR #2941 already updated the row directly above this one when it split `test_output_handler.py`, so cascading is established precedent inside that very table.

## 2. Correcting a false claim in PR #3005's description

PR #3005 stated the `_bypass_promise_gate` hoist "does not widen its effective scope." **That is false**, and the correction is now recorded on the fixture itself in `tests/unit/valor_telegram/conftest.py` rather than only in a PR comment.

What actually happens: the three absorbed siblings never had this autouse fixture. The widening was missed because those files contain no literal `promise_gate` string to grep for — the path is indirect. `test_valor_telegram_chat_log.py` (5 tests) and `test_valor_telegram_voice_flag.py` (3 tests) call `cmd_send`, and `tools/valor_telegram.py:896` calls `cli_check_or_exit` unconditionally. Those files mock only `resolve_chat` and `_get_redis_connection`, so before the move all **8** ran the real gate.

Two corrections to the finding as originally reported, both verified directly:

- The figure is **8 tests, not 18**. `test_valor_telegram_await.py` (10 tests) targets `tools.valor_telegram_await.await_bot_reply` and never reaches `cmd_send`, so it was never gated.
- I also initially wrote that `TestValorTelegramPromiseGate` "overrides this fixture where it needs the real thing." It does not — that class holds a single argparse `--help` anti-leak assertion and never invokes the gate. The docstring now says so, and points at `tests/unit/test_promise_gate.py` as the actual coverage for `cli_check_or_exit`.

The widening is **kept deliberately**, not scoped back: those 8 tests assert relay-payload shape, chat-log recording, and voice-flag/cleanup behavior, never gate behavior, so a live Haiku call on each was incidental cost rather than coverage. The plan's own Risk 2 named this exact scenario and prescribed checking the siblings before hoisting; the check was performed but with too narrow a probe.

## 3. Tracking the deferred marker guard

PR #3005 deferred a standing `FEATURE_MAP` marker-regression guard as out of scope (it is new test logic, which #2879's mechanical-reorganization constraint forbids). That deferral now cites **#3010** in `tests/README.md`, so the procedure documented there says plainly that it is manual today and points at where automating it is tracked.

## 4. Nit from the review

`tests/unit/sdlc_session_ensure/conftest.py` — the hoisted `_stub_lane_identity` docstring still said "every other test in **this file**"; it applies package-wide now.

The other nit (dead `REPO_ROOT` + `import os` in the same conftest) was already fixed before #3005 merged, in `db69befe9`.

## Collection counts — the #2879 acceptance criterion, stated explicitly

Measured before and after the split **in the same worktree with the same venv**, which is the only way this comparison is controlled:

```
PRE-SPLIT  @627206c97   total = 14067    test_plan_docs = 28    rest = 14039
POST-SPLIT @db69befe9   total = 14067    test_plan_docs = 28    rest = 14039

the four targets, before (4 monoliths + 3 siblings) = 443
the four targets, after  (4 packages)               = 443
```

Unchanged on every decomposition. The `test_plan_docs` column is broken out because that file is parametrized over `docs/plans/`, so its contribution moves whenever any lane commits a plan — which is why the raw total is reported alongside the invariant remainder rather than on its own.

Re-verified on current `main` (`c3609fac3`): `tests/unit` collects **14067**, of which 28 are `test_plan_docs` — consistent with the post-split measurement.

## Verification

```
tests/unit/valor_telegram + tests/unit/sdlc_session_ensure  ->  229 passed in 95.23s
                                                                (115 + 114)
```

`ruff check tests/unit` exit 0. `ruff format --check tests/unit` exit 0. No stale reference to any of the four deleted paths remains under `docs/` or `tests/README.md`.