### PR TITLE
Migrate reflections.yaml off the agent_session_queue hub (phase 2 of #2876)

### DIFF
--- a/scripts/migrate_reflections_callables.py
+++ b/scripts/migrate_reflections_callables.py
@@ -55,6 +55,11 @@ CLI:
     python scripts/migrate_reflections_callables.py [--target PATH ...] [--dry-run]
         [--check-idempotent] [--json]
 
+``--dry-run`` and ``--check-idempotent`` are mutually exclusive and passing both
+is a hard error: idempotence is a property of the post-write state, so it cannot
+be checked without writing. To check without touching a real registry, copy one
+and pass ``--target``.
+
 Invoked from ``scripts/update/run.py`` Step 1.659, which runs BEFORE Step 1.66's
 vault->config copy so a freshly-rewritten vault also propagates on the same
 cycle.
@@ -352,7 +357,8 @@ def main(argv: list[str] | None = None) -> int:
             "property of the post-write state. To check without touching a real "
             "registry, copy one and pass --target: "
             "cp config/reflections.yaml /tmp/refl.yaml && "
-            f"{parser.prog} --target /tmp/refl.yaml --check-idempotent"
+            "python scripts/migrate_reflections_callables.py "
+            "--target /tmp/refl.yaml --check-idempotent"
         )
 
     targets = args.target or default_targets()

--- a/scripts/migrate_reflections_callables.py
+++ b/scripts/migrate_reflections_callables.py
@@ -188,7 +188,17 @@ def verify_targets_importable(matched: set[str]) -> None:
         module_path, _, attr = new.rpartition(".")
         try:
             module = importlib.import_module(module_path)
-        except ImportError as e:
+        except Exception as e:
+            # Deliberately broader than ImportError. Importing a target module
+            # executes it, and anything it raises on the way up — a pydantic
+            # ValidationError out of config/settings.py on a machine with a
+            # malformed .env, a RuntimeError, a SyntaxError — is just as much
+            # "this target is not usable" as a missing module. Narrowing to
+            # ImportError lets those escape `migrate_targets`' and `main`'s
+            # `except MigrationError`, so a per-file abort AFTER an earlier
+            # file was written would exit on an uncaught traceback instead of
+            # the PartialMigrationError contract, and Step 1.659 would surface
+            # a traceback tail as its WARN while the disk state went unreported.
             raise MigrationError(
                 f"migration target for {old!r} does not import: {new} ({e})"
             ) from e
@@ -380,7 +390,11 @@ def main(argv: list[str] | None = None) -> int:
                         "rewrote": bool(written),
                         "rewrites_count": sum(r.rewrites_count for r in written),
                         "targets": [str(r.target) for r in written],
-                        "partial": bool(written),
+                        # Distinct from `rewrote`: some targets reached disk and
+                        # some did not. `rewrote` alone cannot say that — an
+                        # abort on the very last target writes every other one
+                        # and is still an incomplete application.
+                        "partial": bool(written) and len(written) < len(targets),
                         "error": str(e),
                     }
                 ),

--- a/scripts/migrate_reflections_callables.py
+++ b/scripts/migrate_reflections_callables.py
@@ -1,11 +1,23 @@
-"""Migrate ``reflections.yaml`` callables off the ``agent.sustainability`` shim.
+"""Migrate ``reflections.yaml`` callables onto the modules that own them.
 
-Issue #2875.
+Issues #2875 and #2876. Two independent families share one table, because both
+have the same shape: the registry names a dotted path on a module that does not
+own the callable, and the owning module cannot be cleaned up until every
+machine's registry names it directly.
 
-The five self-healing reflections moved to ``reflections/agents/*.py`` in #1028,
-and ``agent/sustainability.py`` has existed since then purely so the registry's
-historical dotted paths keep resolving. Retiring the shim requires the registry
-to name the real modules first.
+**#2875 — the ``agent.sustainability`` shim.** The five self-healing reflections
+moved to ``reflections/agents/*.py`` in #1028, and ``agent/sustainability.py``
+has existed since then purely so the registry's historical dotted paths keep
+resolving. Retiring the shim requires the registry to name the real modules
+first.
+
+**#2876 — the ``agent.agent_session_queue`` re-export hub.** Three registry
+entries resolve two callables through the queue module, which re-exports them
+from ``agent.session_health`` and ``agent.session_revival``.
+``cleanup_stale_branches_all_projects`` is a pure re-export and blocked phase 1
+of that issue outright; ``cleanup_corrupted_agent_sessions`` is used by the
+hub's own code and would survive deletion, but pointing the registry at a
+module that does not own it re-creates the coupling #2876 exists to remove.
 
 **Why this is a script and not a file edit.** ``config/reflections.yaml`` is
 gitignored — deliberately untracked in c2af09602 (Apr 2026) via ``git rm
@@ -29,8 +41,14 @@ execution inside a broad ``except Exception`` in ``run_reflection``, which
 records ``last_error`` and keeps ticking with no Sentry hook or alert. A typo'd
 path would load cleanly and silently disable a reflection. So this script
 imports every migration TARGET before touching disk, and aborts if one is
-missing. Only the five targets are checked — validating the whole registry would
-let an unrelated broken entry block a safe migration.
+missing. Only the targets actually MATCHED in the file being rewritten are
+checked — validating the whole table would let an unrelated broken entry block a
+safe migration. That scoping is load-bearing now that the table spans two
+independent migrations (the ``agent.sustainability`` shim and the
+``agent.agent_session_queue`` re-export hub, issue #2876): without it a
+transient import failure in one family aborts the other's migration, and
+``scripts/update/run.py`` Step 1.659 only WARNs — so the machine would stay
+silently un-migrated with no indication the cause was unrelated.
 
 CLI:
 
@@ -72,6 +90,21 @@ CALLABLE_MIGRATIONS: dict[str, str] = {
     "agent.sustainability.failure_loop_detector": "reflections.agents.failure_loop_detector.run",
     "agent.sustainability.session_recovery_drip": "reflections.agents.session_recovery_drip.run",
     "agent.sustainability.sustainability_digest": "reflections.agents.system_health_digest.run",
+    # De-hubbing agent/agent_session_queue.py (issue #2876). The registry reaches
+    # these two through the re-export hub, which owns neither. `_resolve_callable`
+    # getattrs them off the hub, so the hub cannot drop the re-export until every
+    # machine's registry names the owning module. `cleanup_stale_branches_all_projects`
+    # is a pure re-export and would break outright; `cleanup_corrupted_agent_sessions`
+    # is used by the hub's own code and would survive, but leaving it pointed at a
+    # module that does not own it re-creates the coupling #2876 exists to remove.
+    # One key each: the rewrite is global, and `cleanup_corrupted_agent_sessions`
+    # appears twice in the registry.
+    "agent.agent_session_queue.cleanup_corrupted_agent_sessions": (
+        "agent.session_health.cleanup_corrupted_agent_sessions"
+    ),
+    "agent.agent_session_queue.cleanup_stale_branches_all_projects": (
+        "agent.session_revival.cleanup_stale_branches_all_projects"
+    ),
 }
 
 # Match a `callable:` line, capturing optional matched quotes, the dotted path,
@@ -98,7 +131,7 @@ class CallableMigrationResult:
     target: Path
 
 
-def rewrite_callable_lines(text: str) -> tuple[str, int]:
+def rewrite_callable_lines(text: str) -> tuple[str, int, set[str]]:
     """Rewrite every shim ``callable:`` line to its canonical module path.
 
     Preserves indentation, the original quoting style, and any trailing
@@ -107,9 +140,13 @@ def rewrite_callable_lines(text: str) -> tuple[str, int]:
     second pass finds nothing to do.
 
     Returns:
-        ``(new_text, substitutions_performed)``.
+        ``(new_text, substitutions_performed, matched_shim_paths)``. The third
+        element is the set of :data:`CALLABLE_MIGRATIONS` keys this file
+        actually contained, which is what scopes the import check — see
+        :func:`verify_targets_importable`.
     """
     n = 0
+    matched: set[str] = set()
 
     def _sub(match: re.Match[str]) -> str:
         nonlocal n
@@ -118,19 +155,26 @@ def rewrite_callable_lines(text: str) -> tuple[str, int]:
         if new is None:
             return match.group(0)
         n += 1
+        matched.add(old)
         q = match.group("q")
         return f"{match.group('indent')}callable: {q}{new}{q}{match.group('trail')}"
 
-    return _CALLABLE_LINE_RE.sub(_sub, text), n
+    return _CALLABLE_LINE_RE.sub(_sub, text), n, matched
 
 
-def verify_targets_importable() -> None:
-    """Import every migration target, aborting if one does not resolve.
+def verify_targets_importable(matched: set[str]) -> None:
+    """Import the migration targets for ``matched``, aborting if one does not resolve.
 
     The scheduler swallows resolution failures silently (see module docstring),
     so this is the only place a bad mapping gets caught loudly.
+
+    Args:
+        matched: The :data:`CALLABLE_MIGRATIONS` keys actually present in the
+            file being rewritten. Scoping to these — rather than checking the
+            whole table — keeps one migration family's broken target from
+            blocking an unrelated family's safe migration.
     """
-    for old, new in sorted(CALLABLE_MIGRATIONS.items()):
+    for old, new in sorted((o, t) for o, t in CALLABLE_MIGRATIONS.items() if o in matched):
         module_path, _, attr = new.rpartition(".")
         try:
             module = importlib.import_module(module_path)
@@ -163,13 +207,13 @@ def migrate_yaml_callables(
         raise MigrationError(f"target YAML does not exist: {target}")
 
     original = target.read_text()
-    rewritten, count = rewrite_callable_lines(original)
+    rewritten, count, matched = rewrite_callable_lines(original)
 
     if count == 0:
         return CallableMigrationResult(rewrote=False, rewrites_count=0, target=target)
 
     if verify:
-        verify_targets_importable()
+        verify_targets_importable(matched)
 
     if not dry_run:
         # Atomic temp write + rename: a concurrent load_registry() read sees

--- a/scripts/migrate_reflections_callables.py
+++ b/scripts/migrate_reflections_callables.py
@@ -341,6 +341,20 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    if args.check_idempotent and args.dry_run:
+        # Idempotence is a property of the state AFTER a write, so it cannot be
+        # checked without writing. This used to be a silent skip, which made
+        # `--check-idempotent --dry-run` look like the safe way to run the check
+        # and instead produce a hollow green: exit 0, no `idempotence OK` line,
+        # nothing verified. Fail loudly; point at the actually-safe invocation.
+        parser.error(
+            "--check-idempotent cannot be combined with --dry-run: idempotence is a "
+            "property of the post-write state. To check without touching a real "
+            "registry, copy one and pass --target: "
+            "cp config/reflections.yaml /tmp/refl.yaml && "
+            f"{parser.prog} --target /tmp/refl.yaml --check-idempotent"
+        )
+
     targets = args.target or default_targets()
     if not args.json:
         print(f"[migrate-callables] targets: {[str(t) for t in targets]}")
@@ -395,7 +409,7 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print(f"[migrate-callables] rewrote={rewrote} rewrites_count={total}")
 
-    if args.check_idempotent and not args.dry_run:
+    if args.check_idempotent:
         second = migrate_targets(targets, dry_run=True)
         remaining = sum(r.rewrites_count for r in second)
         if remaining:

--- a/scripts/migrate_reflections_callables.py
+++ b/scripts/migrate_reflections_callables.py
@@ -240,7 +240,8 @@ def migrate_yaml_callables(
 def default_targets() -> list[Path]:
     """Both registry copies: the iCloud vault original and the local materialization.
 
-    Order matters only cosmetically. Missing paths are filtered by
+    Order determines only which copy is written first on a partial abort; both
+    writes are independently correct. Missing paths are filtered by
     :func:`migrate_targets` — a fresh machine may have no vault, and a checkout
     that has never run ``/update`` may have no config copy.
     """
@@ -277,8 +278,8 @@ class PartialMigrationError(MigrationError):
     """
 
     def __init__(self, cause: MigrationError, completed: list[CallableMigrationResult]) -> None:
+        # `raise ... from e` in migrate_targets sets __cause__; no second copy.
         super().__init__(str(cause))
-        self.cause = cause
         self.completed = completed
 
 
@@ -349,8 +350,8 @@ def main(argv: list[str] | None = None) -> int:
     except MigrationError as e:
         # Report what actually reached disk before the abort. A bare
         # `rewrote: false` would be factually wrong about a partial run, and
-        # Step 1.659 forwards this payload verbatim as its only record.
-        completed = getattr(e, "completed", [])
+        # Step 1.659 forwards this stderr as its only record.
+        completed = e.completed if isinstance(e, PartialMigrationError) else []
         written = [r for r in completed if r.rewrote]
         if args.json:
             print(

--- a/scripts/migrate_reflections_callables.py
+++ b/scripts/migrate_reflections_callables.py
@@ -77,11 +77,16 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-#: Historical shim path -> canonical per-reflection module path.
+#: Non-owning dotted path -> the module that actually owns the callable.
 #:
-#: Mirrors the re-export table in ``agent/sustainability.py``'s docstring. Note
-#: that ``sustainability_digest`` maps to the ``system_health_digest`` module —
-#: the module name does NOT match the old callable name, and the naive
+#: Two families, one table — see the module docstring. The SOURCE-side keys must
+#: stay verbatim: they are what the rewrite matches against on a machine that has
+#: not yet run ``/update``.
+#:
+#: The sustainability half mirrors the re-export table in
+#: ``agent/sustainability.py``'s docstring. Note that ``sustainability_digest``
+#: maps to the ``system_health_digest`` module — the module name does NOT match
+#: the old callable name, and the naive
 #: ``reflections.agents.sustainability_digest.run`` would be a silent
 #: ImportError at execution time.
 CALLABLE_MIGRATIONS: dict[str, str] = {
@@ -261,24 +266,59 @@ def default_targets() -> list[Path]:
     return unique
 
 
+class PartialMigrationError(MigrationError):
+    """A target failed *after* an earlier target was already written to disk.
+
+    Carries the results accumulated before the failure so callers can report
+    what is actually on disk. Without this the abort path claims nothing was
+    written, which is false whenever the loop got past its first target.
+
+    See :func:`migrate_targets` for why partial application became reachable.
+    """
+
+    def __init__(self, cause: MigrationError, completed: list[CallableMigrationResult]) -> None:
+        super().__init__(str(cause))
+        self.cause = cause
+        self.completed = completed
+
+
 def migrate_targets(targets: list[Path], *, dry_run: bool = False) -> list[CallableMigrationResult]:
     """Migrate every target that exists, skipping the ones that do not.
 
     A missing registry copy is not an error: machines legitimately have one,
     both, or (on a fresh checkout) neither.
+
+    **Partial application is reachable and is not rolled back.** Each target is
+    written independently, and since the import check is scoped to the entries a
+    given file actually contains (see :func:`verify_targets_importable`), two
+    registry copies with divergent content can take different code paths —
+    exactly the divergence ``env_sync.sync_reflections_yaml``'s mtime guard
+    permits. So the vault can be rewritten and committed to disk before the
+    ``config/`` copy aborts on an unrelated broken table entry.
+
+    Rolling back is the wrong fix: the completed write is *correct*, and the
+    next ``/update`` re-migrates it as a no-op. What matters is that the failure
+    not lie about disk state, so a failure after any write raises
+    :class:`PartialMigrationError` carrying the completed results.
     """
     results: list[CallableMigrationResult] = []
     for target in targets:
         target = Path(target)
         if not target.exists():
             continue
-        results.append(migrate_yaml_callables(target, dry_run=dry_run))
+        try:
+            results.append(migrate_yaml_callables(target, dry_run=dry_run))
+        except MigrationError as e:
+            written = [r for r in results if r.rewrote]
+            if written and not dry_run:
+                raise PartialMigrationError(e, results) from e
+            raise
     return results
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Migrate reflections.yaml callables off the agent.sustainability shim."
+        description="Migrate reflections.yaml callables onto the modules that own them."
     )
     parser.add_argument(
         "--target",
@@ -307,13 +347,35 @@ def main(argv: list[str] | None = None) -> int:
     try:
         results = migrate_targets(targets, dry_run=args.dry_run)
     except MigrationError as e:
+        # Report what actually reached disk before the abort. A bare
+        # `rewrote: false` would be factually wrong about a partial run, and
+        # Step 1.659 forwards this payload verbatim as its only record.
+        completed = getattr(e, "completed", [])
+        written = [r for r in completed if r.rewrote]
         if args.json:
             print(
-                _json.dumps({"rewrote": False, "rewrites_count": 0, "error": str(e)}),
+                _json.dumps(
+                    {
+                        "rewrote": bool(written),
+                        "rewrites_count": sum(r.rewrites_count for r in written),
+                        "targets": [str(r.target) for r in written],
+                        "partial": bool(written),
+                        "error": str(e),
+                    }
+                ),
                 file=sys.stderr,
             )
         else:
             print(f"[migrate-callables] ABORT: {e}", file=sys.stderr)
+        # Trailing plain-text summary, emitted on BOTH paths and always last.
+        # Step 1.659's wrapper keeps only `stderr[-500:]` for its WARN, so the
+        # partial-write evidence has to sit at the tail to survive truncation --
+        # the JSON above leads with it, which is exactly the part that gets cut.
+        for r in written:
+            print(
+                f"[migrate-callables] ALREADY WRITTEN: {r.target} ({r.rewrites_count} line(s))",
+                file=sys.stderr,
+            )
         return 1
 
     total = sum(r.rewrites_count for r in results)

--- a/scripts/update/reflections_callables.py
+++ b/scripts/update/reflections_callables.py
@@ -1,7 +1,9 @@
-"""Update-system hook that repoints reflections.yaml off the sustainability shim.
+"""Update-system hook that repoints reflections.yaml onto owning modules.
 
 Wraps ``scripts/migrate_reflections_callables.py`` so ``scripts/update/run.py``
-Step 1.659 can render machine-readable status. Issue #2875.
+Step 1.659 can render machine-readable status. Issues #2875 (the
+``agent.sustainability`` shim) and #2876 (the ``agent.agent_session_queue``
+re-export hub); see that script's docstring for why both families share a table.
 
 Runs at Step 1.659 — BEFORE Step 1.66's vault->config copy — so a vault rewrite
 also propagates into ``config/reflections.yaml`` on the same cycle. The

--- a/scripts/update/run.py
+++ b/scripts/update/run.py
@@ -1045,28 +1045,33 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
         log(f"WARN: sdlc-upvote-pickup registration: {upr.detail}", v, always=True)
         _append_warning(result, f"sdlc-upvote-pickup registration: {upr.detail}")
 
-    # Step 1.659: Repoint the five self-healing reflections off the
-    # `agent.sustainability.*` shim onto `reflections.agents.*` (#2875).
+    # Step 1.659: Repoint reflection callables onto the modules that own them.
+    # Two migration families share one table: the `agent.sustainability.*` shim
+    # -> `reflections.agents.*` (#2875), and the `agent.agent_session_queue.*`
+    # re-export hub -> `agent.session_health` / `agent.session_revival` (#2876).
+    # Keep these strings family-agnostic: naming one family makes the log false
+    # on a machine where the other fires, and an operator verifying #2876's
+    # propagation gate reads exactly this output.
     # config/reflections.yaml is gitignored, so this registry edit can only
     # reach machines as tracked code that rewrites the file. Runs BEFORE Step
     # 1.66's vault->config copy (same ordering rationale as Steps 1.655-1.658)
     # so a vault rewrite propagates on this same cycle; the migration also
     # rewrites the config copy directly, because Step 1.66 skips the copy when
     # the config copy is not older than the vault. Idempotent no-op once done.
-    log("Ensuring reflection callables are off the sustainability shim...", v)
+    log("Ensuring reflection callables name their owning modules...", v)
     result.reflections_callables_result = reflections_callables.run_reflections_callables_migration(
         project_dir
     )
     rcr = result.reflections_callables_result
     if rcr.action == "rewrote":
         log(
-            f"reflection callables repointed to reflections.agents.* "
+            f"reflection callables repointed onto their owning modules "
             f"({rcr.rewrites_count} line(s) across {len(rcr.targets or [])} file(s))",
             v,
             always=True,
         )
     elif rcr.action == "noop":
-        log("reflection callables already off the sustainability shim", v)
+        log("reflection callables already name their owning modules", v)
     if not rcr.success:
         log(f"WARN: reflection callable migration: {rcr.error}", v, always=True)
         _append_warning(result, f"reflection callable migration: {rcr.error}")

--- a/tests/unit/test_migrate_reflections_callables.py
+++ b/tests/unit/test_migrate_reflections_callables.py
@@ -411,7 +411,11 @@ def test_main_json_abort_reports_the_partial_write(tmp_path, monkeypatch, capsys
     err = capsys.readouterr().err
 
     assert rc == 1
-    payload = json.loads(err.splitlines()[0])
+    # Select the JSON line by content, not position: coupling the payload
+    # assertions to ordering makes an ordering regression fail here with a
+    # JSONDecodeError instead of at the endswith() below, which is the
+    # assertion that actually owns the "must be LAST" claim.
+    payload = json.loads(next(ln for ln in err.splitlines() if ln.startswith("{")))
     assert payload["rewrote"] is True, "abort must not claim nothing was written"
     assert payload["partial"] is True
     assert payload["rewrites_count"] == 1
@@ -420,3 +424,26 @@ def test_main_json_abort_reports_the_partial_write(tmp_path, monkeypatch, capsys
     # The plain-text summary must be LAST: the Step 1.659 wrapper keeps only
     # stderr[-500:], which truncates the JSON's leading partial-write evidence.
     assert err.rstrip().endswith(f"ALREADY WRITTEN: {vault} (1 line(s))")
+
+
+def test_check_idempotent_rejects_dry_run():
+    """The safe-looking invocation must fail loudly, not verify nothing.
+
+    `--check-idempotent --dry-run` used to be a silent skip: exit 0, no
+    `idempotence OK` line, nothing checked. That made the only invocation that
+    does not touch a real registry also the one that proves nothing.
+    """
+    with pytest.raises(SystemExit) as exc:
+        main(["--target", "/tmp/does-not-matter.yaml", "--check-idempotent", "--dry-run"])
+    assert exc.value.code == 2, "argparse.error() exits 2"
+
+
+def test_check_idempotent_verifies_against_a_target_copy(tmp_path):
+    """The sanctioned safe form: --target a copy, no --dry-run."""
+    target = _write_registry(
+        tmp_path / "refl.yaml",
+        ["agent.agent_session_queue.cleanup_stale_branches_all_projects"],
+    )
+
+    assert main(["--target", str(target), "--check-idempotent"]) == 0
+    assert "agent.session_revival.cleanup_stale_branches_all_projects" in target.read_text()

--- a/tests/unit/test_migrate_reflections_callables.py
+++ b/tests/unit/test_migrate_reflections_callables.py
@@ -438,8 +438,14 @@ def test_check_idempotent_rejects_dry_run():
     assert exc.value.code == 2, "argparse.error() exits 2"
 
 
-def test_check_idempotent_verifies_against_a_target_copy(tmp_path):
-    """The sanctioned safe form: --target a copy, no --dry-run."""
+def test_check_idempotent_verifies_against_a_target_copy(tmp_path, capsys):
+    """The sanctioned safe form: --target a copy, no --dry-run.
+
+    The `idempotence OK` assertion is the one that owns this test's name. Exit 0
+    plus a rewritten file both still hold with the `--check-idempotent` block
+    deleted entirely, so asserting only those would leave the test green while
+    the feature it names is gone — the same hollow shape this PR exists to kill.
+    """
     target = _write_registry(
         tmp_path / "refl.yaml",
         ["agent.agent_session_queue.cleanup_stale_branches_all_projects"],
@@ -447,3 +453,4 @@ def test_check_idempotent_verifies_against_a_target_copy(tmp_path):
 
     assert main(["--target", str(target), "--check-idempotent"]) == 0
     assert "agent.session_revival.cleanup_stale_branches_all_projects" in target.read_text()
+    assert "idempotence OK" in capsys.readouterr().out

--- a/tests/unit/test_migrate_reflections_callables.py
+++ b/tests/unit/test_migrate_reflections_callables.py
@@ -1,8 +1,13 @@
-"""Tests for the ``agent.sustainability.*`` -> ``reflections.agents.*`` callable migration.
+"""Tests for the ``reflections.yaml`` callable migrations.
 
-Issue #2875. The migration ships a registry edit to every machine via ``/update``
-because ``config/reflections.yaml`` is gitignored (deliberately untracked in
-c2af09602) and therefore cannot carry the change as a file edit.
+Two independent families share one table:
+
+* ``agent.sustainability.*`` -> ``reflections.agents.*`` (issue #2875)
+* ``agent.agent_session_queue.*`` -> owning module (issue #2876)
+
+Both ship a registry edit to every machine via ``/update`` because
+``config/reflections.yaml`` is gitignored (deliberately untracked in c2af09602)
+and therefore cannot carry the change as a file edit.
 """
 
 from __future__ import annotations
@@ -27,14 +32,18 @@ pytestmark = pytest.mark.unit
 # --------------------------------------------------------------------------
 
 
-def test_mapping_covers_the_five_shim_reexports():
-    """All five historical shim paths are migrated, and nothing else."""
+def test_mapping_covers_both_migration_families():
+    """Every historical shim/hub path is migrated, and nothing else."""
     assert set(CALLABLE_MIGRATIONS) == {
+        # agent/sustainability.py shim (#2875)
         "agent.sustainability.circuit_health_gate",
         "agent.sustainability.session_count_throttle",
         "agent.sustainability.failure_loop_detector",
         "agent.sustainability.session_recovery_drip",
         "agent.sustainability.sustainability_digest",
+        # agent/agent_session_queue.py re-export hub (#2876)
+        "agent.agent_session_queue.cleanup_corrupted_agent_sessions",
+        "agent.agent_session_queue.cleanup_stale_branches_all_projects",
     }
 
 
@@ -73,7 +82,7 @@ def test_digest_maps_to_system_health_digest_module():
 
 def test_rewrite_preserves_indent_and_double_quotes():
     text = '    callable: "agent.sustainability.circuit_health_gate"\n'
-    out, n = rewrite_callable_lines(text)
+    out, n, _matched = rewrite_callable_lines(text)
     assert n == 1
     assert out == '    callable: "reflections.agents.circuit_health_gate.run"\n'
 
@@ -83,26 +92,29 @@ def test_rewrite_handles_unquoted_and_single_quoted_and_trailing_comment():
         "  callable: agent.sustainability.failure_loop_detector\n"
         "  callable: 'agent.sustainability.session_recovery_drip'  # keep me\n"
     )
-    out, n = rewrite_callable_lines(text)
+    out, n, _matched = rewrite_callable_lines(text)
     assert n == 2
     assert "callable: reflections.agents.failure_loop_detector.run\n" in out
     assert "callable: 'reflections.agents.session_recovery_drip.run'  # keep me\n" in out
 
 
 def test_rewrite_leaves_unrelated_callables_untouched():
+    # Both lines must name callables absent from CALLABLE_MIGRATIONS. The hub
+    # paths that used to serve as the example here are migrated as of #2876.
     text = (
         '    callable: "reflections.maintenance.run_disk_space_check"\n'
-        '    callable: "agent.agent_session_queue.cleanup_corrupted_agent_sessions"\n'
+        '    callable: "reflections.stall_advisory.run_stall_advisory"\n'
     )
-    out, n = rewrite_callable_lines(text)
+    out, n, matched = rewrite_callable_lines(text)
     assert n == 0
+    assert matched == set()
     assert out == text
 
 
 def test_rewrite_is_idempotent():
     text = '    callable: "agent.sustainability.session_count_throttle"\n'
-    once, n1 = rewrite_callable_lines(text)
-    twice, n2 = rewrite_callable_lines(once)
+    once, n1, _m1 = rewrite_callable_lines(text)
+    twice, n2, _m2 = rewrite_callable_lines(once)
     assert n1 == 1
     assert n2 == 0
     assert twice == once
@@ -219,3 +231,93 @@ def test_migrate_targets_skips_missing_paths(tmp_path):
     assert len(results) == 1
     assert results[0].target == present
     assert results[0].rewrote is True
+
+
+# --------------------------------------------------------------------------
+# Import-check scoping (#2876).
+#
+# The table spans two independent migration families. The import check must be
+# scoped to the entries a given file actually contains, or one family's broken
+# target blocks the other's safe migration -- silently, because Step 1.659 only
+# WARNs on failure and `run_reflection` swallows resolution errors per-tick.
+# --------------------------------------------------------------------------
+
+
+def test_matched_unimportable_target_aborts_without_writing(tmp_path, monkeypatch):
+    """A broken target for a callable THIS file names must abort before any write."""
+    target = _write_registry(
+        tmp_path / "reflections.yaml",
+        ["agent.agent_session_queue.cleanup_stale_branches_all_projects"],
+    )
+    before = target.read_text()
+
+    monkeypatch.setitem(
+        CALLABLE_MIGRATIONS,
+        "agent.agent_session_queue.cleanup_stale_branches_all_projects",
+        "agent.no_such_module_xyz.nope",
+    )
+
+    with pytest.raises(MigrationError):
+        migrate_yaml_callables(target)
+
+    assert target.read_text() == before, "aborted migration must leave the file untouched"
+    assert list(tmp_path.iterdir()) == [target], "no temp file may survive an abort"
+
+
+def test_unmatched_unimportable_target_does_not_block_migration(tmp_path, monkeypatch):
+    """A broken target the file does NOT name must not abort the migration.
+
+    This is the regression guard for the scoping fix. Before it,
+    ``verify_targets_importable()`` walked the whole table, so breaking any
+    entry broke every file's migration regardless of relevance.
+    """
+    target = _write_registry(
+        tmp_path / "reflections.yaml",
+        ["agent.agent_session_queue.cleanup_stale_branches_all_projects"],
+    )
+
+    # Break a member of the OTHER migration family, which this file never names.
+    monkeypatch.setitem(
+        CALLABLE_MIGRATIONS,
+        "agent.sustainability.circuit_health_gate",
+        "reflections.no_such_module_xyz.nope",
+    )
+
+    result = migrate_yaml_callables(target)
+
+    assert result.rewrote is True
+    assert result.rewrites_count == 1
+    assert "agent.session_revival.cleanup_stale_branches_all_projects" in target.read_text()
+    assert "agent.agent_session_queue" not in target.read_text()
+
+
+def test_rewrite_reports_only_the_keys_the_file_contained(tmp_path):
+    """``matched`` is the scoping input for the import check -- it must be exact."""
+    text = (
+        '    callable: "agent.agent_session_queue.cleanup_corrupted_agent_sessions"\n'
+        '    callable: "agent.agent_session_queue.cleanup_corrupted_agent_sessions"\n'
+        '    callable: "reflections.maintenance.run_disk_space_check"\n'
+    )
+    _out, n, matched = rewrite_callable_lines(text)
+
+    # Two substitutions, but one distinct key: the registry names this callable
+    # twice, which is why the table needs one key rather than two.
+    assert n == 2
+    assert matched == {"agent.agent_session_queue.cleanup_corrupted_agent_sessions"}
+
+
+def test_hub_migration_targets_resolve_on_their_owning_modules():
+    """The #2876 targets must actually exist where the table says they do.
+
+    `_resolve_callable` getattrs these off the named module at reflection time
+    and the failure is swallowed, so a wrong module path here would silently
+    disable a daily job.
+    """
+    for shim_path in (
+        "agent.agent_session_queue.cleanup_corrupted_agent_sessions",
+        "agent.agent_session_queue.cleanup_stale_branches_all_projects",
+    ):
+        target = CALLABLE_MIGRATIONS[shim_path]
+        module_path, _, attr = target.rpartition(".")
+        module = importlib.import_module(module_path)
+        assert callable(getattr(module, attr, None)), f"{target} does not resolve"

--- a/tests/unit/test_migrate_reflections_callables.py
+++ b/tests/unit/test_migrate_reflections_callables.py
@@ -13,6 +13,7 @@ and therefore cannot carry the change as a file edit.
 from __future__ import annotations
 
 import importlib
+import json
 
 import pytest
 
@@ -20,6 +21,7 @@ from scripts.migrate_reflections_callables import (
     CALLABLE_MIGRATIONS,
     MigrationError,
     PartialMigrationError,
+    main,
     migrate_targets,
     migrate_yaml_callables,
     rewrite_callable_lines,
@@ -384,3 +386,37 @@ def test_dry_run_abort_is_never_a_partial(tmp_path, monkeypatch):
 
     assert not isinstance(exc.value, PartialMigrationError)
     assert "agent.sustainability" in vault.read_text(), "dry run must not write"
+
+
+def test_main_json_abort_reports_the_partial_write(tmp_path, monkeypatch, capsys):
+    """The CLI abort payload is the operator-facing artifact, so pin it directly.
+
+    Without this, reverting the abort branch to a bare
+    ``{"rewrote": False, "rewrites_count": 0}`` keeps every other test green —
+    and that payload is precisely what Step 1.659 surfaces to the human running
+    the #2876 propagation check.
+    """
+    vault = _write_registry(tmp_path / "vault.yaml", ["agent.sustainability.circuit_health_gate"])
+    config = _write_registry(
+        tmp_path / "config.yaml",
+        ["agent.agent_session_queue.cleanup_stale_branches_all_projects"],
+    )
+    monkeypatch.setitem(
+        CALLABLE_MIGRATIONS,
+        "agent.agent_session_queue.cleanup_stale_branches_all_projects",
+        "agent.no_such_module_xyz.nope",
+    )
+
+    rc = main(["--target", str(vault), "--target", str(config), "--json"])
+    err = capsys.readouterr().err
+
+    assert rc == 1
+    payload = json.loads(err.splitlines()[0])
+    assert payload["rewrote"] is True, "abort must not claim nothing was written"
+    assert payload["partial"] is True
+    assert payload["rewrites_count"] == 1
+    assert payload["targets"] == [str(vault)]
+
+    # The plain-text summary must be LAST: the Step 1.659 wrapper keeps only
+    # stderr[-500:], which truncates the JSON's leading partial-write evidence.
+    assert err.rstrip().endswith(f"ALREADY WRITTEN: {vault} (1 line(s))")

--- a/tests/unit/test_migrate_reflections_callables.py
+++ b/tests/unit/test_migrate_reflections_callables.py
@@ -19,6 +19,7 @@ import pytest
 from scripts.migrate_reflections_callables import (
     CALLABLE_MIGRATIONS,
     MigrationError,
+    PartialMigrationError,
     migrate_targets,
     migrate_yaml_callables,
     rewrite_callable_lines,
@@ -47,6 +48,11 @@ def test_mapping_covers_both_migration_families():
     }
 
 
+# Parametrized over the WHOLE table, so both migration families are covered by
+# construction -- including the two #2876 hub entries, whose presence is pinned
+# by test_mapping_covers_both_migration_families above. Those two matter
+# especially: `_resolve_callable` getattrs them off a module the registry names
+# by string, and the registry is untracked vault config no repo grep can see.
 @pytest.mark.parametrize(("old", "new"), sorted(CALLABLE_MIGRATIONS.items()))
 def test_every_migration_target_actually_resolves(old, new):
     """Each new dotted path imports to a real callable.
@@ -306,18 +312,75 @@ def test_rewrite_reports_only_the_keys_the_file_contained(tmp_path):
     assert matched == {"agent.agent_session_queue.cleanup_corrupted_agent_sessions"}
 
 
-def test_hub_migration_targets_resolve_on_their_owning_modules():
-    """The #2876 targets must actually exist where the table says they do.
+# --------------------------------------------------------------------------
+# Partial application across registry copies.
+#
+# Scoping the import check per-file (above) means two registry copies with
+# divergent content can take different code paths, so one can be written before
+# a later one aborts. The write is correct and self-heals on the next /update;
+# what must not happen is the abort claiming nothing was written.
+# --------------------------------------------------------------------------
 
-    `_resolve_callable` getattrs these off the named module at reflection time
-    and the failure is swallowed, so a wrong module path here would silently
-    disable a daily job.
-    """
-    for shim_path in (
-        "agent.agent_session_queue.cleanup_corrupted_agent_sessions",
+
+def test_abort_after_a_write_reports_what_reached_disk(tmp_path, monkeypatch):
+    vault = _write_registry(tmp_path / "vault.yaml", ["agent.sustainability.circuit_health_gate"])
+    config = _write_registry(
+        tmp_path / "config.yaml",
+        ["agent.agent_session_queue.cleanup_stale_branches_all_projects"],
+    )
+    monkeypatch.setitem(
+        CALLABLE_MIGRATIONS,
         "agent.agent_session_queue.cleanup_stale_branches_all_projects",
-    ):
-        target = CALLABLE_MIGRATIONS[shim_path]
-        module_path, _, attr = target.rpartition(".")
-        module = importlib.import_module(module_path)
-        assert callable(getattr(module, attr, None)), f"{target} does not resolve"
+        "agent.no_such_module_xyz.nope",
+    )
+
+    with pytest.raises(PartialMigrationError) as exc:
+        migrate_targets([vault, config])
+
+    # The vault write really happened -- this is the state the old bare
+    # `rewrote: false` payload misreported.
+    assert "reflections.agents.circuit_health_gate.run" in vault.read_text()
+    assert "agent.agent_session_queue" in config.read_text(), "config must be untouched"
+
+    written = [r for r in exc.value.completed if r.rewrote]
+    assert [r.target for r in written] == [vault]
+    assert sum(r.rewrites_count for r in written) == 1
+
+
+def test_abort_before_any_write_is_not_a_partial(tmp_path, monkeypatch):
+    """First-target failure writes nothing, so it stays a plain MigrationError."""
+    config = _write_registry(
+        tmp_path / "config.yaml",
+        ["agent.agent_session_queue.cleanup_stale_branches_all_projects"],
+    )
+    monkeypatch.setitem(
+        CALLABLE_MIGRATIONS,
+        "agent.agent_session_queue.cleanup_stale_branches_all_projects",
+        "agent.no_such_module_xyz.nope",
+    )
+
+    with pytest.raises(MigrationError) as exc:
+        migrate_targets([config])
+
+    assert not isinstance(exc.value, PartialMigrationError)
+    assert "agent.agent_session_queue" in config.read_text()
+
+
+def test_dry_run_abort_is_never_a_partial(tmp_path, monkeypatch):
+    """A dry run touches no disk, so it can never be partially applied."""
+    vault = _write_registry(tmp_path / "vault.yaml", ["agent.sustainability.circuit_health_gate"])
+    config = _write_registry(
+        tmp_path / "config.yaml",
+        ["agent.agent_session_queue.cleanup_stale_branches_all_projects"],
+    )
+    monkeypatch.setitem(
+        CALLABLE_MIGRATIONS,
+        "agent.agent_session_queue.cleanup_stale_branches_all_projects",
+        "agent.no_such_module_xyz.nope",
+    )
+
+    with pytest.raises(MigrationError) as exc:
+        migrate_targets([vault, config], dry_run=True)
+
+    assert not isinstance(exc.value, PartialMigrationError)
+    assert "agent.sustainability" in vault.read_text(), "dry run must not write"

--- a/tests/unit/test_migrate_reflections_callables.py
+++ b/tests/unit/test_migrate_reflections_callables.py
@@ -426,7 +426,7 @@ def test_main_json_abort_reports_the_partial_write(tmp_path, monkeypatch, capsys
     assert err.rstrip().endswith(f"ALREADY WRITTEN: {vault} (1 line(s))")
 
 
-def test_check_idempotent_rejects_dry_run():
+def test_check_idempotent_rejects_dry_run(tmp_path):
     """The safe-looking invocation must fail loudly, not verify nothing.
 
     `--check-idempotent --dry-run` used to be a silent skip: exit 0, no
@@ -434,7 +434,11 @@ def test_check_idempotent_rejects_dry_run():
     does not touch a real registry also the one that proves nothing.
     """
     with pytest.raises(SystemExit) as exc:
-        main(["--target", "/tmp/does-not-matter.yaml", "--check-idempotent", "--dry-run"])
+        # tmp_path, not a literal /tmp path: the whole point of this test is to
+        # fail if the guard regresses, and in exactly that regression the target
+        # would start being resolved for real against a machine-global path
+        # shared with every other agent testing on this box.
+        main(["--target", str(tmp_path / "nope.yaml"), "--check-idempotent", "--dry-run"])
     assert exc.value.code == 2, "argparse.error() exits 2"
 
 
@@ -454,3 +458,45 @@ def test_check_idempotent_verifies_against_a_target_copy(tmp_path, capsys):
     assert main(["--target", str(target), "--check-idempotent"]) == 0
     assert "agent.session_revival.cleanup_stale_branches_all_projects" in target.read_text()
     assert "idempotence OK" in capsys.readouterr().out
+
+
+def test_non_import_error_during_target_import_is_still_a_partial(tmp_path, monkeypatch):
+    """A target module that raises something other than ImportError still honors the contract.
+
+    Importing a target module executes it, so it can raise anything — a pydantic
+    ValidationError out of `config/settings.py` on a machine with a malformed
+    `.env`, a RuntimeError, a SyntaxError. Those are just as much "this target is
+    unusable" as a missing module, but when the import check caught only
+    ImportError they escaped `migrate_targets`' and `main`'s `except
+    MigrationError` entirely: `main()` exited on an uncaught traceback, emitting
+    no JSON payload and no ALREADY WRITTEN line, while an earlier target was
+    already rewritten on disk. Step 1.659 would then WARN with a traceback tail
+    and no record of what it had changed.
+    """
+    vault = _write_registry(tmp_path / "vault.yaml", ["agent.sustainability.circuit_health_gate"])
+    config = _write_registry(
+        tmp_path / "config.yaml",
+        ["agent.agent_session_queue.cleanup_stale_branches_all_projects"],
+    )
+
+    real_import = importlib.import_module
+
+    def _boom(name, *a, **kw):
+        if name == "agent.session_revival":
+            raise RuntimeError("settings blew up while importing the target")
+        return real_import(name, *a, **kw)
+
+    monkeypatch.setattr(importlib, "import_module", _boom)
+
+    with pytest.raises(PartialMigrationError) as exc:
+        migrate_targets([vault, config])
+
+    # The RuntimeError was converted, not propagated.
+    assert "does not import" in str(exc.value)
+    assert "settings blew up" in str(exc.value)
+
+    # And the contract still reports what reached disk.
+    written = [r for r in exc.value.completed if r.rewrote]
+    assert [r.target for r in written] == [vault]
+    assert "reflections.agents.circuit_health_gate.run" in vault.read_text()
+    assert "agent.agent_session_queue" in config.read_text(), "config must be untouched"


### PR DESCRIPTION
Phase 2 of 5 for #2876. **Scope: the untracked vault registry only.** No module under `agent/` is touched, the re-export block is unchanged, and no importer is migrated — those are phases 3-5.

Plan: [`docs/plans/sdlc-2876.md`](https://github.com/tomcounsell/ai/blob/main/docs/plans/sdlc-2876.md)

## What this does

Four files, +476/-47. Adds both `agent.agent_session_queue.*` callables to `CALLABLE_MIGRATIONS`, so `/update` Step 1.659 repoints every machine's `reflections.yaml` onto the modules that actually own them.

| Registry path | Owning module |
|---|---|
| `agent.agent_session_queue.cleanup_corrupted_agent_sessions` | `agent.session_health` |
| `agent.agent_session_queue.cleanup_stale_branches_all_projects` | `agent.session_revival` |

Two keys, three registry lines — `cleanup_corrupted_agent_sessions` appears twice and the rewrite is global.

### Why this phase exists at all

`config/reflections.yaml` is gitignored and materialized from an iCloud-synced vault original, so **no `git grep` can see these references**. That is not an oversight in the tooling; it is structural. It is why phase 1 (#2952) deleted `cleanup_stale_branches_all_projects` and then had to restore it.

The failure mode is silent: `ReflectionEntry.validate` only asserts the callable string is non-empty, and `run_reflection` swallows resolution failures in a broad `except Exception`. A hub deletion that outruns the registry kills a daily job with no alert and a green worker.

### Second change: scoping the import check

`verify_targets_importable()` walked the entire `CALLABLE_MIGRATIONS` table, directly contradicting its own docstring:

> Only the five targets are checked — validating the whole registry would let an unrelated broken entry block a safe migration.

That was harmless while the table held one migration family. With two, a transient import failure in the `agent.sustainability` family aborts the `agent_session_queue` migration and vice versa — and `scripts/update/run.py` Step 1.659 only WARNs, so the machine stays silently un-migrated with nothing indicating the cause was unrelated. It now checks only the keys the file being rewritten actually contained, which is what the docstring always claimed.

## Verification

### Dry run against the real registry

**This output is no longer reproducible on this machine, and that is expected.** It was captured while `~/Desktop/Valor/reflections.yaml` still named the hub 3 times. During review the plan's idempotence acceptance row — which at the time read `--check-idempotent` with no `--target`, and so resolved to the production vault — migrated that file for real (3 → 0, 2026-08-26). Re-running the command below now correctly reports `{"rewrote": false, "rewrites_count": 0}`.

The migrated state is the correct end state and both callables resolve on `main`; it has deliberately **not** been reverted, since a second unsanctioned write to move it backwards would be worse than the first. The consequence is recorded in the plan: phase 5's propagation gate no longer observes the 3 → 0 transition and has been restated as three conjuncts (ancestry of the phase-2 merge, the Step 1.659 log line proving the step executed, and `grep` == 0 on the config copy). The generalized hazard — a verification step that mutates the state it verifies — is filed as **#3020**. This PR makes the specific trigger impossible: `--check-idempotent --dry-run` is now a hard `argparse` error, and the plan's row targets a copy.

```
$ python scripts/migrate_reflections_callables.py --dry-run --json
{"rewrote": true, "rewrites_count": 3, "targets": ["/Users/valorengels/Desktop/Valor/reflections.yaml"]}

substitutions=3  distinct_keys=['agent.agent_session_queue.cleanup_corrupted_agent_sessions',
                                'agent.agent_session_queue.cleanup_stale_branches_all_projects']
  - callable: "agent.agent_session_queue.cleanup_corrupted_agent_sessions"
  + callable: "agent.session_health.cleanup_corrupted_agent_sessions"
  - callable: "agent.agent_session_queue.cleanup_stale_branches_all_projects"
  + callable: "agent.session_revival.cleanup_stale_branches_all_projects"
  - callable: "agent.agent_session_queue.cleanup_corrupted_agent_sessions"
  + callable: "agent.session_health.cleanup_corrupted_agent_sessions"
```

Both targets resolve on their owning modules **today**, so this is safe in either merge order:

```
agent.session_health.cleanup_corrupted_agent_sessions -> True
agent.session_revival.cleanup_stale_branches_all_projects -> True
```

### Demonstrated red for the scoping fix

A passing suite does not prove the new regression test blocks anything, so the old unscoped form was restored and the test re-run.

**RED** — with `verify_targets_importable()` walking the whole table, breaking a member of the *other* migration family aborts this file's migration:

```
tests/unit/test_migrate_reflections_callables.py:286:
    in test_unmatched_unimportable_target_does_not_block_migration
E   MigrationError: migration target for 'agent.sustainability.circuit_health_gate'
    does not import: reflections.no_such_module_xyz.nope
1 failed, 1 passed, 21 deselected
```

(Captured at `fe1cec1b1`. Tests have been added since, so the `deselected` count in the excerpt no longer matches a run at the current head. **The excerpt pins the pass/fail shape — one failure, in the named test, on the named `MigrationError` — and nothing else.** No count in this block is a claim about the current head.)

Note `test_matched_unimportable_target_aborts_without_writing` **passed** in the same run — the guard still catches genuinely broken matched targets, so the fix narrows the check rather than disabling it.

**GREEN** — with the scoped form restored:

```
2 passed               # both scoping tests green with the scoped form restored
```

### Tests

```
tests/unit/test_migrate_reflections_callables.py
tests/unit/test_update_reflections_callables.py      33 passed in 11.56s

python -m ruff check scripts/ tests/unit/test_migrate_reflections_callables.py   All checks passed
python -m ruff format --check .                                                  1408 files already formatted
```

**Ten tests added, one renamed** — `test_migrate_reflections_callables.py` goes from 13 test functions to 23 (29 collected after parametrization; the other 4 of the 33 are `test_update_reflections_callables.py`).

| Test | Pins |
|---|---|
| `test_matched_unimportable_target_aborts_without_writing` | a broken target the file *does* name aborts before any write, leaving no temp file |
| `test_unmatched_unimportable_target_does_not_block_migration` | a broken target the file does *not* name cannot block it — the scoping regression guard |
| `test_rewrite_reports_only_the_keys_the_file_contained` | `matched` is exact; two substitutions of one callable yield one key |
| `test_abort_after_a_write_reports_what_reached_disk` | `PartialMigrationError` carries the completed results |
| `test_abort_before_any_write_is_not_a_partial` | first-target failure stays a plain `MigrationError` |
| `test_dry_run_abort_is_never_a_partial` | a dry run touches no disk, so it can never be partial |
| `test_main_json_abort_reports_the_partial_write` | the CLI payload itself, plus the `ALREADY WRITTEN` line being **last** |
| `test_check_idempotent_rejects_dry_run` | `--check-idempotent --dry-run` is a hard `argparse` error (exit 2), not the silent no-op it used to be |
| `test_non_import_error_during_target_import_is_still_a_partial` | a target module raising something *other* than `ImportError` is still converted to `MigrationError`, so the `PartialMigrationError` contract holds. Demonstrated red by narrowing the guard back to `except ImportError`: the test fails on an uncaught `RuntimeError`, with `test_abort_after_a_write_reports_what_reached_disk` passing in the same run as the control. |
| `test_check_idempotent_verifies_against_a_target_copy` | the sanctioned safe form — `--target <copy>` with no `--dry-run` — migrates, returns 0, **and prints `idempotence OK`**. That last assertion is what owns the test's name: exit 0 and a rewritten file both still hold with the `--check-idempotent` block deleted, so without it the test would stay green while the feature it names was gone. Demonstrated red by deleting the block: `1 failed, 1 passed` — and `test_check_idempotent_rejects_dry_run` passing in that same run is the control showing the deletion was correctly scoped. |

`test_mapping_covers_the_five_shim_reexports` is renamed to `test_mapping_covers_both_migration_families` and now pins all seven table keys.

`test_hub_migration_targets_resolve_on_their_owning_modules` was **removed** on review: `test_every_migration_target_actually_resolves` is parametrized over the whole table, so both hub entries were already covered by construction. Its rationale moved to a comment beside the parametrize.

One existing test needed a real correction rather than a mechanical update: `test_rewrite_leaves_unrelated_callables_untouched` used `agent.agent_session_queue.cleanup_corrupted_agent_sessions` as its example of an *unrelated* callable — which this PR moves into the table. It now uses a genuinely unrelated path. `rewrite_callable_lines` returns a 3-tuple, so five call sites were updated.

## Interaction with PR #3007 — read before merging

**This PR and #3007 both edit three of these four files**, and all three conflict. Trial merge re-run at the current head `441073b60` (`git merge-tree --write-tree --name-only HEAD pr3007-head`) — 3 files, **6 conflict hunks** (2 + 1 + 3), one per table row below:

```
CONFLICT (content): Merge conflict in scripts/migrate_reflections_callables.py
CONFLICT (content): Merge conflict in scripts/update/reflections_callables.py
CONFLICT (content): Merge conflict in scripts/update/run.py
```

Every conflict is **prose** — module docstrings, comments, and log strings. No functional hunk overlaps. That does **not** make them safe to resolve by picking a side.

### The resolution table is the spec — read it before touching a conflict marker

The two PRs are not competing wordings of the same claim. **Each side asserts something true that the other does not say**, so "take ours" and "take theirs" both land a comment that is wrong on the merged tree. The table below is exhaustive over the three conflicted files: one row per conflict, what each side uniquely asserts, and what the resolved text must contain.

The shared root cause: this PR generalizes every string to cover two migration families, because naming one family makes the string false on a machine where the other fires. #3007 deletes `agent/sustainability.py` and sharpens the same strings to the past tense, because after it lands the shim no longer exists and the registry must never reacquire it. Both are true after both land.

| # | File / site | THIS PR uniquely asserts | #3007 uniquely asserts | Resolved text must contain |
|---|---|---|---|---|
| 1 | `scripts/migrate_reflections_callables.py` — module docstring | The two family paragraphs — that one table serves two migrations, and `#2876`'s hub half. (The `verify_targets_importable` scoping rationale is further down the same docstring, **outside** this conflict marker, and auto-merges; it is not this row's business.) | `agent/sustainability.py` **existed from #1028 until #2875 and is now deleted**; a machine whose registry reacquires a shim path "has nothing to fall back on" | Both halves of the table, **and** the shim in the **past tense** with the no-fallback consequence. This PR's present-tense "has existed since then purely so the registry's historical dotted paths keep resolving" is false once #3007 lands and must not survive. |
| 2 | `scripts/migrate_reflections_callables.py` — `CALLABLE_MIGRATIONS` comment | The `#2876` hub entries and why each is in the table | This table is **"the sole surviving record of the deleted shim's re-export map"**, which is #3007's *justification* for the verbatim-SOURCE-keys rule both sides state. New in #3007 — absent from the merge base. | The hub-entry rationale, **and** #3007's sole-surviving-record clause, **and** a cross-reference that still resolves. This PR's "mirrors the re-export table in `agent/sustainability.py`'s docstring" points at a file #3007 deletes (verified: 79 deletions) and must be dropped — after #3007 lands there is no table to mirror, which is exactly what #3007's clause says. |
| 3 | `scripts/update/reflections_callables.py` — line-1 docstring | The wrapper serves **both** issues (`#2875` and `#2876`) and defers to the script's docstring for why | The wrapper's job is keeping the registry from **reacquiring the deleted shim**, and it also wraps `scripts/verify_registry_without_shim.py` for **Step 4.65** | Both families named, **and** #3007's Step 4.65 / `verify_registry_without_shim.py` clause, which this PR's rewrite drops entirely because that script does not exist on `main` yet. |
| 4 | `scripts/update/run.py` — comment block above Step 1.659 | Family-agnostic framing: two families share one table (`agent.sustainability.*` → `reflections.agents.*` for #2875; `agent.agent_session_queue.*` → `agent.session_health` / `agent.session_revival` for #2876), plus the `# Keep these strings family-agnostic` rationale | `agent/sustainability.py` **is deleted, so the registry must never reacquire those paths, and this step rewrites any that it still carries** — the entire justification for keeping Step 1.659 alive once its own migration is done | Both. Neither side alone says both. |
| 5 | `scripts/update/run.py` — `log(...)` before the call | `Ensuring reflection callables name their owning modules...` | `Ensuring reflection callables have not reacquired the deleted sustainability shim...` | This PR's wording. #3007's names one family and is false on a machine where the hub migration fires — and this line is what an operator reads when verifying #2876's propagation gate. |
| 6 | `scripts/update/run.py` — `elif rcr.action == "noop"` | `reflection callables already name their owning modules` | `reflection callables already clear of the deleted sustainability shim` | This PR's wording, same reason as row 5. This line is **conjunct 2** of phase 5's restated propagation gate. |

Auto-merging and to be kept as-is: #3007's `if not rcr.success:` explanatory comment and its Step 4.65 block.

### Why the `run.py` conflict is the one that had to happen

The `run.py` conflict did not exist in this PR's first revision; **a review fix created it**, and that is the point. Before it, neither PR touched the other's lines, so **git would have merged both cleanly and landed the divergence silently** — a log line naming only the sustainability family on a machine where the hub migration fires. Now it stops and demands rows 4-6.

This PR does not pre-emptively carry #3007's past-tense clauses, because `agent/sustainability.py` still exists on `main` today; writing "the deleted sustainability shim" here would land a false comment. Those clauses become true when #3007 lands, which is why **#3007 is the resolver**.

### The `verify_targets_importable()` scoping finding is resolved HERE, not deferred

#3007 carries an open review finding that `verify_targets_importable()` imports the whole `CALLABLE_MIGRATIONS` table rather than matched keys. **This PR fixes it**, and the fix is load-bearing here specifically because this PR is what grows the table 5 → 7 and turns the over-broad import from harmless into actively wrong.

The function lives in `scripts/migrate_reflections_callables.py`, not the `scripts/update/reflections_callables.py` wrapper, and #3007's diff does not touch it. So **#3007 should drop that finding as fixed upstream**, not implement it independently.

### Merge order

**This PR lands first; #3007 rebases onto it and resolves all six conflicts per the resolution table above.**

**The reason is wall-clock propagation, not dependency unblocking.** Phase 5 depends on `build-vault-migration` **(propagated)** — a human-gated, cross-machine deploy whose clock only starts once this PR's code is on `main` and each machine has run `/update`. Landing this first starts that clock earlier, and it is the longest-latency prerequisite in the plan.

To be precise about what this does **not** buy, since an earlier revision of this description got it backwards: phase 3 is **not** blocked behind this PR. `docs/plans/sdlc-2876.md:831` gives phase 3's dependency as "PR #3007 merged (external gate, not a task)", and the plan's `## No-Gos` carry an `[ORDERED]` entry that phases 3 and 5 do not begin until #3007 merges. #3007 is on the critical path for both phases; this PR is on neither's directly. Merging #3007 first would immediately unblock phase 3, which is a real argument for the opposite order — the propagation clock is the reason it loses.

The cost of this order is one rebase of #3007 (~30 files, already reviewed), which changes its head SHA and invalidates its recorded verdict under the staleness gate. #3007 re-runs its own gates after the rebase either way.

## Not in this PR

- **Applying the migration to the vault on every other machine.** The code ships here; `/update` applies it. Per the plan's Race 1, the vault original is skipped when `VALOR_LAUNCHD` is set (TCC blocks `~/Desktop`), so at least one machine must run `/update` from an interactive shell for the migrated vault to be what iCloud propagates. That is a human-gated step.

  **On this machine, both registries are already migrated** — the vault *and* `config/reflections.yaml`. `default_targets()` returns both paths, so the un-`--target`ed `--check-idempotent` that ran during review wrote both: identical 19330 bytes, identical `Aug 26 12:02` mtime, `grep -c 'agent\.agent_session_queue\.'` == `0` on each. This satisfies the "at least one interactive machine" condition for iCloud propagation, but **on this machine specifically, conjunct 3 of phase 5's gate (`grep` == 0 on the config copy) carries no independent evidential weight** — it is pre-satisfied by that same write rather than by Step 1.659. That is exactly why the restated gate adds conjuncts 1 and 2. Every other machine's config copy is untouched and its conjunct 3 remains meaningful.
- Any change to `agent/agent_session_queue.py`. Phases 3 and 5 own that and are gated on PR #3007.

Closes #3018
Refs #2876

`#3018` is the closeable record for phase 2. **#2876 is the umbrella and stays OPEN** — phases 3, 4 and 5 remain.






