### PR TITLE
Wave 1: batched hotfix sweep (10 issues)

### DIFF
--- a/.claude/hooks/hook_utils/constants.py
+++ b/.claude/hooks/hook_utils/constants.py
@@ -2,9 +2,18 @@
 
 import json
 import os
-import sys
 from datetime import UTC, datetime
 from pathlib import Path
+
+# Single definition of the stdin-payload parser (issue #2750). This module
+# previously carried its own read_hook_input() that caught JSONDecodeError
+# only: it was annotated -> dict but returned whatever json.loads produced,
+# so a payload of `null`, `[1,2]`, `"str"` or `42` reached callers as a
+# non-dict and blew up on the first .get(). The hook_target.py version guards
+# that and is the one every caller now gets. Re-exported rather than moved so
+# existing `from hook_utils.constants import read_hook_input` imports keep
+# working — there is exactly one implementation behind both names.
+from .hook_target import read_hook_input  # noqa: F401
 
 
 def get_project_dir() -> Path:
@@ -36,17 +45,6 @@ def ensure_session_log_dir(session_id: str) -> Path:
     session_dir = project_dir / "logs" / "sessions" / session_id
     session_dir.mkdir(parents=True, exist_ok=True)
     return session_dir
-
-
-def read_hook_input() -> dict:
-    """Read and parse JSON input from stdin."""
-    try:
-        raw_input = sys.stdin.read()
-        if not raw_input.strip():
-            return {}
-        return json.loads(raw_input)
-    except json.JSONDecodeError:
-        return {}
 
 
 def append_to_log(session_dir: Path, filename: str, entry: dict) -> None:

--- a/.claude/hooks/manifest.toml
+++ b/.claude/hooks/manifest.toml
@@ -149,6 +149,15 @@ scope = "project"
 exit_policy = "propagate"
 
 [[hook]]
+manifest_id = "validate_verification_section"
+event = "PostToolUse"
+matcher = "Write"
+script = "validators/validate_verification_section.py"
+timeout = 10
+scope = "project"
+exit_policy = "propagate"
+
+[[hook]]
 manifest_id = "validate_no_gos_justification"
 event = "PostToolUse"
 matcher = "Write"

--- a/.claude/hooks/post_tool_use.py
+++ b/.claude/hooks/post_tool_use.py
@@ -499,7 +499,6 @@ def _update_agent_session(hook_input: dict) -> None:
                 return
             agent_session = matches[0]
 
-        agent_session.updated_at = time.time()
         agent_session.tool_call_count = (agent_session.tool_call_count or 0) + 1
         # Liveness (issue #1843, Gap A): clear the in-flight tool name and
         # refresh the timestamp, mirroring record_tool_boundary's Post=clear

--- a/.claude/hooks/user_prompt_submit.py
+++ b/.claude/hooks/user_prompt_submit.py
@@ -183,7 +183,6 @@ def main():
             agent_session_id = sidecar.get("agent_session_id")
             if agent_session_id:
                 # Subsequent prompt in same session -- re-activate
-                import time
 
                 from models.agent_session import AgentSession
 
@@ -216,7 +215,6 @@ def main():
                                 current_status,
                             )
                         else:
-                            agent_session.updated_at = time.time()
                             agent_session.completed_at = None
                             transition_status(
                                 agent_session,

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -75,6 +75,11 @@
           },
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/hook_python \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validators/validate_verification_section.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/hook_python \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validators/validate_no_gos_justification.py",
             "timeout": 15
           },

--- a/.claude/skills-global/do-docs/SKILL.md
+++ b/.claude/skills-global/do-docs/SKILL.md
@@ -296,9 +296,13 @@ After all edits are complete:
    from a cascade, run the push-ancestry guard so a worktree HEAD left detached at
    a PR branch head cannot register the open PR's ancestry as its merge:
    ```bash
-   sdlc-push-guard || { echo "Push refused: HEAD carries open-PR ancestry — checkout main / merge through gh pr merge"; exit 1; }
+   sdlc-push-guard --assume-head || { echo "Push refused: HEAD carries open-PR ancestry — checkout main / merge through gh pr merge"; exit 1; }
    git push
    ```
+   `--assume-head` is required here and is not optional decoration: this is an
+   explicit call with no pre-push stdin, and since #2800 the guard treats absent
+   stdin as "git had nothing to push" and exits 0. Without the flag this line is
+   a no-op that always passes.
    The guard only fires when HEAD is at/descended-from an OPEN PR head; a clean
    `main` checkout passes untouched. (The installed pre-push hook runs it too; this
    explicit call makes the protection independent of hook installation.)

--- a/agent/health_check.py
+++ b/agent/health_check.py
@@ -639,8 +639,6 @@ async def watchdog_hook(
     # tracking failure degrades to a legacy-only drain, never breaks the hook.
     steering_room_id: str | None = None
     try:
-        import time
-
         from models.agent_session import AgentSession
         from models.room import room_id_for_session
 
@@ -655,7 +653,6 @@ async def watchdog_hook(
             sessions.sort(key=lambda s: (s.created_at is not None, s.created_at), reverse=True)
             s = sessions[0]
             s.tool_call_count = count
-            s.updated_at = time.time()
             s.save()
             steering_room_id = room_id_for_session(s)
     except Exception as e:

--- a/bridge/session_transcript.py
+++ b/bridge/session_transcript.py
@@ -202,7 +202,6 @@ def append_turn(
         if sessions:
             s = sessions[0]
             s.turn_count = (s.turn_count or 0) + 1
-            s.updated_at = time.time()
             s.save()
     except Exception as e:
         logger.debug(f"Failed to update SessionLog turn_count for {session_id}: {e}")
@@ -243,7 +242,6 @@ def append_tool_result(
         if sessions:
             s = sessions[0]
             s.tool_call_count = (s.tool_call_count or 0) + 1
-            s.updated_at = time.time()
             s.save()
     except Exception as e:
         logger.debug(f"Failed to update SessionLog tool_call_count for {session_id}: {e}")

--- a/docs/features/message-drafter.md
+++ b/docs/features/message-drafter.md
@@ -177,7 +177,7 @@ To prevent infinite steering loops (the agent's self-draft also fails validation
 
 ### `_derive_context_summary(raw_text) -> str | None`
 
-Derives a coarse one-sentence routing hint from the narration-stripped text. This is deliberately simple — first non-blank, non-heading line, capped at 140 characters at a word boundary. No NLP, no LLM. Purpose: give `bridge/job_router.py` — the single routing authority — and other routing readers a coarse topic hint. Not a quality deliverable, not user-facing prose. Returns `None` for empty or whitespace-only input.
+Derives a coarse one-sentence routing hint from the narration-stripped text. This is deliberately simple — first non-blank, non-heading line, capped at 140 characters at a word boundary. No NLP, no LLM. Purpose: give the intake classifier in `bridge/telegram_bridge.py` and other routing readers a coarse topic hint. Not a quality deliverable, not user-facing prose. Returns `None` for empty or whitespace-only input.
 
 ### `_extract_open_questions(text) -> list[str]`
 

--- a/docs/features/sdlc-fork-artifact-grounding.md
+++ b/docs/features/sdlc-fork-artifact-grounding.md
@@ -80,6 +80,13 @@ The guard is wired into both the installed pre-push hook body
 (`tools/doctor.py::install_pre_push_hook()`) and the `do-docs` cascade push step, so
 protection does not depend on hook installation.
 
+The two call sites declare the pushed SHA differently, and the difference is
+load-bearing. The hook pipes git's pre-push stdin protocol, so the guard reads
+the pushed SHA from it. The `do-docs` step has no such stdin and must pass
+`--assume-head` to have HEAD judged. Absent stdin on its own means "git had
+nothing to push" and exits 0 (#2800) — a bare `sdlc-push-guard` in an explicit
+call site is a guard that cannot fire.
+
 ## Configuration
 
 | Constant | Default | Override | Purpose |

--- a/docs/features/vault-drift-audit.md
+++ b/docs/features/vault-drift-audit.md
@@ -153,6 +153,7 @@ def _write_liveness(
     pr_url: str | None,
     files_touched: int,
     vault_narratives_compared: int | None = None,
+    fixes_withheld: int = 0,
 ) -> None: ...
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     # unconditionally, so every call dies at argument binding (see #2960).
     "anthropic==0.125.0",
     "pydantic-ai-slim[anthropic]==2.9.0", # CRITICAL — pin exact, upgrade via /update only. Slim + anthropic extra only (avoids openai/google/mcp/logfire/cli/evals/web extras pulled in by the `pydantic-ai` meta-package)
-    "claude-agent-sdk==0.2.144", # CRITICAL — pin exact, upgrade via /update only
+    "claude-agent-sdk==0.2.145", # CRITICAL — pin exact, upgrade via /update only
     "mcp>=1.28.1", # Required by claude-agent-sdk for ToolAnnotations (see issue #235)
     "python-dotenv>=1.0.0",
     "httpx>=0.27.0",

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -1257,7 +1257,10 @@ def audit(
 
     Returns:
         Dict with ``status``, ``files_touched``, ``fixes_applied``,
-        ``issues_filed``, ``pr_url``.
+        ``issues_filed``, ``pr_url``, ``fixes_withheld``, ``withheld``.
+
+        Callers must branch on ``fixes_withheld > 0`` rather than trust
+        ``status``: a run that withheld every fix still reports success.
     """
     # The name existence oracle is a per-*run* snapshot: a long-lived process
     # must not answer from an index built before the last commit (#2759).

--- a/scripts/update/reflection_register.py
+++ b/scripts/update/reflection_register.py
@@ -29,15 +29,15 @@ vault source (``~/Desktop/Valor/reflections.yaml``), refreshed by
 ``env_sync.sync_reflections_yaml()`` (Step 1.66) on every ``/update``. Appending
 the entry only to the in-repo copy is silently clobbered the next time that copy
 step runs, so registration for real means appending the entry to the *vault*
-file. The target is resolved via
-``agent.reflection_scheduler._resolve_registry_path()`` (critique C6), which
-picks the vault ahead of the config copy **only when ``VALOR_LAUNCHD`` is
-unset** -- that resolver gates the vault candidate on the environment, not on
-checkout identity. Under ``VALOR_LAUNCHD=1`` it returns the soon-clobbered
-config copy even in the primary checkout, reproducing #1539's "looks wired,
-never lands" failure; a builder who hardcoded the config copy would reproduce it
-unconditionally. See ``_resolve_target``'s docstring for both reachable paths
-and issue #2855 for the fix. This step runs BEFORE Step 1.66's vault->config
+file. The target is resolved by :func:`_resolve_write_target`, a write-side
+resolver independent of the scheduler's read-side
+``agent.reflection_scheduler._resolve_registry_path()`` (issue #2855). The read
+side gates its vault candidate on ``VALOR_LAUNCHD`` because macOS TCC blocks
+``~/Desktop`` from launchd agents; applying that environment gate to a *write*
+sent registration to the soon-clobbered ``config/reflections.yaml`` instead,
+reproducing #1539's "looks wired, never lands" failure silently. The write side
+has no fallback level, so registration now either lands in the vault or fails
+loudly. This step runs BEFORE Step 1.66's vault->config
 copy (critique NIT) so the appended entry propagates into the per-machine
 ``config/reflections.yaml`` on the same cycle.
 
@@ -183,62 +183,44 @@ def _vault_reflections_path() -> Path:
     return Path.home() / "Desktop" / "Valor" / "reflections.yaml"
 
 
-def _resolve_target() -> Path:
-    """Resolve the registry file to write, prioritizing the vault (critique C6).
+def _resolve_write_target(vault_path: Path) -> Path:
+    """Resolve the registry file to WRITE. Always the vault (issue #2855).
 
-    Delegates to ``agent.reflection_scheduler._resolve_registry_path`` -- the
-    same resolver the scheduler reads at runtime. That resolver gained a
-    fourth fallback level (issue #2734): when *this* checkout's
-    ``config/reflections.yaml`` is absent, it reads the owning checkout's copy
-    instead of the vault. C6 -- "the entry lands where the scheduler will
-    actually look, not in the soon-clobbered config copy" -- holds only when
-    ``VALOR_LAUNCHD`` is unset. It is **not** guaranteed by running in the
-    primary checkout, and the resolver does not always prefer the vault.
+    This is the write-side resolver, deliberately independent of the
+    scheduler's read-side ``_resolve_registry_path``. Sharing that resolver is
+    what caused the silent-loss bug described below; splitting them is the
+    ``[ORDERED]`` No-Go in ``docs/plans/reflection-registry-schedule-contract.md``
+    (Risk 3), and this is that split.
 
-    The vault level is gated on the environment, not on checkout identity:
-    ``agent/reflection_scheduler.py`` appends the vault candidate only ``if not
-    os.environ.get("VALOR_LAUNCHD")`` (macOS TCC blocks ``~/Desktop`` access
-    from launchd agents). So there are two distinct ways to land on a
-    soon-clobbered ``config/reflections.yaml``:
+    Why the vault is unconditionally correct here: both callers have already
+    returned early unless ``vault_path.exists()`` and this machine owns the
+    ``valor`` project. That existence check reads ``~/Desktop``. If macOS TCC
+    were blocking this process from the vault -- the entire reason the read
+    side gates on ``VALOR_LAUNCHD`` -- the check would have failed and we would
+    have skipped before reaching this function. Reaching here is positive
+    evidence the vault is readable by this process, so the environment gate
+    that belongs on the read side must not be applied to the write.
 
-    - **Under ``VALOR_LAUNCHD=1``, even in the primary checkout.** The vault
-      candidate is skipped, control reaches the local-config level, and that
-      file exists in the primary checkout -- so this function returns the
-      config copy. The worker plist sets ``VALOR_LAUNCHD=1`` and a
-      worker-spawned ``claude -p`` session inherits it, so an agent running
-      ``/update`` hits this path. The write succeeds silently and Step 1.66's
-      vault->config copy discards it on the next cycle: #1539's "looks wired,
-      never lands" failure, with no error.
-    - **From a worktree under ``VALOR_LAUNCHD=1``**, where the local copy is
-      absent, the fourth owning-checkout level (issue #2734) resolves to the
-      *primary checkout's* copy, with the same silent-loss outcome.
+    The bug this replaces: the read-side resolver appends its vault candidate
+    the vault candidate was skipped, control fell through to the local-config
+    level, and ``config/reflections.yaml`` exists in the primary checkout -- so
+    registration wrote there. The worker plist sets ``VALOR_LAUNCHD=1`` and a
+    worker-spawned ``claude -p`` session inherits it, so an agent running
+    ``/update`` always hit this path. The write succeeded silently and Step
+    1.66's vault->config copy discarded it on the next cycle: #1539's "looks
+    wired, never lands" failure, with no error. From a worktree the fourth
+    owning-checkout level (issue #2734) resolved to the primary checkout's copy
+    with the same outcome.
 
-    Issue #2855 tracks the real fix. It is not attempted here because a
-    write-side caller must not share the scheduler's read-side resolver at all;
-    splitting them into distinct read and write functions is the ``[ORDERED]``
-    No-Go in ``docs/plans/reflection-registry-schedule-contract.md`` (Risk 3),
-    sequenced as a separate change. Until then, treat "unset ``VALOR_LAUNCHD``"
-    as a precondition of correct registration rather than an invariant this
-    module enforces.
+    Returning the vault makes both of those unreachable: there is no longer a
+    fallback level for a write to land on, so registration either lands where
+    the scheduler will read it or fails loudly.
 
-    ``_this_machine_owns_valor`` is **not** a second, independent leg. It fails
-    closed in a worktree only because ``config/projects.json`` is gitignored and
-    therefore absent there -- and ``scripts/update/run.py`` calls
-    ``env_sync.sync_projects_json(project_dir)`` at Step 1.65, which runs *before*
-    the registration steps, so a ``run.py --project-dir <worktree>`` invocation
-    would materialize that file and arm the ownership guard within the same run.
-    Treat the primary-checkout leg as the containment; do not relax it on the
-    assumption that ownership would catch a worktree caller. The containment must
-    not be relaxed without first splitting this shared resolver into distinct read
-    and write functions (the ``[ORDERED]`` No-Go in that plan; a separate,
-    sequenced change, not done here).
-
-    Imported lazily because the scheduler transitively imports heavy models;
-    the update step only needs it at call time.
+    ``_this_machine_owns_valor`` remains the containment against a non-owning
+    machine mutating the shared iCloud file; it is checked by the callers, not
+    here.
     """
-    from agent.reflection_scheduler import _resolve_registry_path
-
-    return _resolve_registry_path()
+    return vault_path
 
 
 def _this_machine_owns_valor(project_dir: Path) -> bool:
@@ -457,10 +439,7 @@ def remove_reflection(project_dir: Path, *, name: str) -> RegisterResult:
     if not _this_machine_owns_valor(project_dir):
         return RegisterResult(True, "skipped", "this machine does not own the 'valor' project")
 
-    try:
-        target = _resolve_target()
-    except Exception:  # pragma: no cover - defensive
-        target = vault_path
+    target = _resolve_write_target(vault_path)
 
     verdict = _remove_entry(target, name)
     if verdict == "absent":
@@ -531,13 +510,9 @@ def register_reflection(
     if not _this_machine_owns_valor(project_dir):
         return RegisterResult(True, "skipped", "this machine does not own the 'valor' project")
 
-    # Resolve via the scheduler's vault-first resolver (critique C6). With the
-    # vault present and not running under launchd, this returns the vault file.
-    try:
-        target = _resolve_target()
-    except Exception as e:  # pragma: no cover - defensive
-        target = vault_path
-        _ = e
+    # Write-side resolver (#2855): always the vault, never the scheduler's
+    # environment-gated read-side resolver.
+    target = _resolve_write_target(vault_path)
 
     entry_kwargs = {
         "name": name,

--- a/scripts/update/run.py
+++ b/scripts/update/run.py
@@ -2703,4 +2703,23 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Configure the root logger at the entry point (issue #2678).
+    #
+    # This module's three logging.getLogger(__name__).warning() calls were
+    # formatted only as an accidental import side effect: run.py imported
+    # log_cleanup, which imported scripts.log_rotate, which called
+    # basicConfig() at module scope. #2643 moved that call into log_rotate's
+    # own __main__ guard, so without this run.py's warnings would fall through
+    # to logging.lastResort and print bare, unprefixed, untimestamped.
+    #
+    # Mirrors scripts/log_rotate.py's format and stream deliberately: both are
+    # /update entry points and their output interleaves in logs/update.log.
+    # stderr keeps them off stdout, which --json mode reserves for its payload.
+    import logging
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        stream=sys.stderr,
+    )
     sys.exit(main())

--- a/scripts/update/run.py
+++ b/scripts/update/run.py
@@ -70,6 +70,17 @@ class UpdateConfig:
     do_mcp: bool = False  # Only in full mode
     do_log_cleanup: bool = True  # Deletes oversized log backups — off under --verify
 
+    # The authoritative "--verify promises no changes" flag (issues #2898,
+    # #3026). Every step that mutates state outside this process must consult
+    # it. The per-behavior booleans above are about WHICH steps a mode runs;
+    # this one is about whether the run is allowed to leave a trace at all.
+    #
+    # It exists because the opt-out-per-behavior shape kept failing open: a
+    # newly added mutating step defaults to running, so --verify quietly broke
+    # its contract twice (warn_state persistence, then ~/.claude hardlinking
+    # and migrations) before anyone noticed.
+    read_only: bool = False
+
     # Options
     verbose: bool = False
     json_output: bool = False
@@ -119,6 +130,7 @@ class UpdateConfig:
             do_ollama=True,
             do_mcp=True,
             do_log_cleanup=False,  # --verify promises no changes; sweep deletes files
+            read_only=True,
             verbose=True,
         )
 
@@ -817,6 +829,12 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
     result = UpdateResult()
     v = config.verbose
 
+    # Honor the read-only contract in the suppression-state module before any
+    # step can call should_emit (#2898). Set unconditionally, so a non-verify
+    # run in the same process re-enables persistence rather than inheriting a
+    # previous verify run's switch.
+    warn_state.set_read_only(config.read_only)
+
     # Step 1: Git pull
     if config.do_git_pull:
         log("Pulling latest changes...", v)
@@ -858,10 +876,19 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
         log("hooks: ~/.claude/hooks is a real user directory", v)
 
     # Step 1.5: Sync .claude hardlinks (skills + commands to ~/.claude/)
-    log("Syncing .claude hardlinks...", v)
-    result.hardlink_result = hardlinks.sync_claude_dirs(project_dir)
+    #
+    # Writes into ~/.claude and can migrate the hooks dir-symlink, so it is a
+    # real mutation of machine-global state and is off under --verify (#3026).
+    # An empty result stands in so the reporting below still runs and honestly
+    # reports zero rather than needing its own skip branch.
+    if config.read_only:
+        log("Skipping .claude hardlink sync — --verify makes no changes (#3026)", v, always=True)
+        result.hardlink_result = hardlinks.HardlinkSyncResult()
+    else:
+        log("Syncing .claude hardlinks...", v)
+        result.hardlink_result = hardlinks.sync_claude_dirs(project_dir)
 
-    if hooks_alias is not None:
+    if hooks_alias is not None and not config.read_only:
         # The predicate lives beside its emitter in hardlinks so the two cannot
         # drift; matching a bare "dir-symlink" substring here once reported a
         # hooks migration that the skills migration had actually performed.
@@ -1400,8 +1427,16 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
                     _append_warning(result, "Dep bump succeeded but commit/push failed")
 
     # Step 3.6: Run pending data migrations (after git pull, before service restart)
-    log("Checking pending migrations...", v)
-    result.migration_result = migrations.run_pending_migrations(project_dir)
+    #
+    # Migrations rewrite persistent data and are irreversible, which makes them
+    # the single least appropriate thing for a mode advertised as safe to run
+    # from a scratch worktree (#3026). Off under --verify.
+    if config.read_only:
+        log("Skipping pending migrations — --verify makes no changes (#3026)", v, always=True)
+        result.migration_result = migrations.MigrationResult()
+    else:
+        log("Checking pending migrations...", v)
+        result.migration_result = migrations.run_pending_migrations(project_dir)
     mig = result.migration_result
     if mig.ran:
         for name in mig.ran:
@@ -1417,44 +1452,63 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
     # Step 3.65: Migrate reflections.yaml (interval: -> every:) on every pull.
     # Idempotent — issue #1273 unified Reflection grammar. Runs after Step 3
     # `uv sync` so the migration's schema-validation phase can import croniter.
-    log("Migrating reflections.yaml schedule grammar...", v)
-    result.reflections_yaml_result = reflections_yaml.run_reflections_yaml_migration(project_dir)
-    ry = result.reflections_yaml_result
-    if ry.success:
-        if ry.action == "rewrote":
-            log(
-                f"  reflections.yaml: rewrote {ry.rewrites_count} interval line(s) -> every:",
-                v,
-                always=True,
-            )
-        elif ry.action == "noop":
-            log("  reflections.yaml: already migrated", v)
-        elif ry.action == "skipped":
-            log(
-                f"  reflections.yaml: skipped ({ry.error or 'target missing'})",
-                v,
-            )
+    # Rewrites the reflections.yaml in the iCloud vault — off under --verify
+    # (#3026). "Idempotent" is not the same as "no changes": it still writes.
+    if config.read_only:
+        log(
+            "Skipping reflections.yaml grammar migration — --verify makes no changes (#3026)",
+            v,
+            always=True,
+        )
     else:
-        log(f"  WARN: reflections.yaml migration failed: {ry.error}", v, always=True)
-        _append_warning(result, f"reflections.yaml migration: {ry.error}")
+        log("Migrating reflections.yaml schedule grammar...", v)
+        result.reflections_yaml_result = reflections_yaml.run_reflections_yaml_migration(
+            project_dir
+        )
+        ry = result.reflections_yaml_result
+        if ry.success:
+            if ry.action == "rewrote":
+                log(
+                    f"  reflections.yaml: rewrote {ry.rewrites_count} interval line(s) -> every:",
+                    v,
+                    always=True,
+                )
+            elif ry.action == "noop":
+                log("  reflections.yaml: already migrated", v)
+            elif ry.action == "skipped":
+                log(
+                    f"  reflections.yaml: skipped ({ry.error or 'target missing'})",
+                    v,
+                )
+        else:
+            log(f"  WARN: reflections.yaml migration failed: {ry.error}", v, always=True)
+            _append_warning(result, f"reflections.yaml migration: {ry.error}")
 
     # Step 3.66: Arm the merged-branch-cleanup plan-migration backstop
     # (issue #1900, Tier 0). Runs after the reflections.yaml copy (Step 1.66)
     # and grammar migration (Step 3.65) so it flips the CURRENT vault + repo
     # copies. Guarded on the vault file existing and this machine owning the
     # 'valor' project -- a no-op everywhere else.
-    log("Arming plan-migration backstop reflection...", v)
-    result.reflection_arm_result = reflection_arm.arm_merged_branch_cleanup(project_dir)
-    ar = result.reflection_arm_result
-    if ar.action == "armed":
-        log(f"  merged-branch-cleanup: {ar.detail}", v, always=True)
-    elif ar.action == "noop":
-        log(f"  merged-branch-cleanup: {ar.detail}", v)
-    elif ar.action == "skipped":
-        log(f"  merged-branch-cleanup: skipped ({ar.detail})", v)
-    if not ar.success:
-        log(f"  WARN: merged-branch-cleanup arm failed: {ar.detail}", v, always=True)
-        _append_warning(result, f"merged-branch-cleanup arm: {ar.detail}")
+    # Flips the current vault + repo reflections copies — off under --verify (#3026).
+    if config.read_only:
+        log(
+            "Skipping plan-migration backstop arming — --verify makes no changes (#3026)",
+            v,
+            always=True,
+        )
+    else:
+        log("Arming plan-migration backstop reflection...", v)
+        result.reflection_arm_result = reflection_arm.arm_merged_branch_cleanup(project_dir)
+        ar = result.reflection_arm_result
+        if ar.action == "armed":
+            log(f"  merged-branch-cleanup: {ar.detail}", v, always=True)
+        elif ar.action == "noop":
+            log(f"  merged-branch-cleanup: {ar.detail}", v)
+        elif ar.action == "skipped":
+            log(f"  merged-branch-cleanup: skipped ({ar.detail})", v)
+        if not ar.success:
+            log(f"  WARN: merged-branch-cleanup arm failed: {ar.detail}", v, always=True)
+            _append_warning(result, f"merged-branch-cleanup arm: {ar.detail}")
 
     # Step 3.7: OfficeCLI binary install/update
     log("Checking OfficeCLI...", v)
@@ -2387,13 +2441,21 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
                     log(f"  {tool.name}: resolved", v, always=True)
                     result.warn_keys_emitted.add(tool.name)
 
-        # Migrate legacy Desktop/claude_code paths in settings.json
-        log("Migrating settings.json paths...", v)
-        settings_migration = verify.migrate_settings_json_paths()
-        if settings_migration.get("migrated"):
-            log(f"  Settings: {settings_migration.get('reason')}", v, always=True)
+        # Migrate legacy Desktop/claude_code paths in settings.json.
+        # Rewrites a settings.json outside this checkout — off under --verify (#3026).
+        if config.read_only:
+            log(
+                "  Settings: skipped path migration — --verify makes no changes (#3026)",
+                v,
+                always=True,
+            )
         else:
-            log(f"  Settings: {settings_migration.get('reason')}", v)
+            log("Migrating settings.json paths...", v)
+            settings_migration = verify.migrate_settings_json_paths()
+            if settings_migration.get("migrated"):
+                log(f"  Settings: {settings_migration.get('reason')}", v, always=True)
+            else:
+                log(f"  Settings: {settings_migration.get('reason')}", v)
 
         # Sync Claude OAuth credentials
         log("Syncing Claude OAuth credentials...", v)

--- a/scripts/update/run.py
+++ b/scripts/update/run.py
@@ -962,187 +962,208 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
     for label in obsolete_removed:
         log(f"Removed obsolete launchd job {label} (feature deleted from codebase)", v, always=True)
 
-    # Step 1.6: Verify .env symlink
-    log("Verifying .env symlink...", v)
-    result.env_sync_result = env_sync.sync_env_from_vault(project_dir)
-    env_r = result.env_sync_result
-    if env_r.created:
-        log(".env symlink created → ~/Desktop/Valor/.env", v, always=True)
-    if env_r.error:
-        log(f"WARN: Env symlink: {env_r.error}", v)
-        _append_warning(result, f"Env symlink: {env_r.error}")
-
-    # Step 1.65: Ensure config/projects.json is a real file copy (never a symlink —
-    # launchd TCC blocks open() on iCloud-synced ~/Desktop paths).
-    log("Verifying config/projects.json...", v)
-    projects_r = env_sync.sync_projects_json(project_dir)
-    if projects_r.created:
-        log("config/projects.json copied from vault (was symlink or stale)", v, always=True)
-    elif projects_r.ok:
-        log("config/projects.json OK (real file copy)", v)
-    if projects_r.error:
-        log(f"WARN: projects.json: {projects_r.error}", v, always=True)
-        _append_warning(result, f"projects.json: {projects_r.error}")
-
-    # Step 1.655: Ensure the crash-recovery reflection is registered in the
-    # vault registry (issue #1917). Runs BEFORE Step 1.66's vault→config copy
-    # (critique NIT) so the appended entry propagates into the per-machine
-    # config/reflections.yaml on this same cycle. Guarded on vault presence +
-    # 'valor' ownership; idempotent no-op once the entry exists.
-    log("Ensuring crash-recovery reflection is registered...", v)
-    result.reflection_register_result = reflection_register.register_crash_recovery(project_dir)
-    rr = result.reflection_register_result
-    if rr.action == "registered":
-        log("crash-recovery reflection registered in vault reflections.yaml", v, always=True)
-    elif rr.action == "noop":
-        log("crash-recovery reflection already registered", v)
-    elif rr.action == "skipped":
-        log(f"crash-recovery registration skipped: {rr.detail}", v)
-    if not rr.success:
-        log(f"WARN: crash-recovery registration: {rr.detail}", v, always=True)
-        _append_warning(result, f"crash-recovery registration: {rr.detail}")
-
-    # Step 1.656: Remove reflections whose callables no longer ship in the
-    # repo (reflection_register.REMOVED_REFLECTIONS) so no machine keeps
-    # scheduling an entry that can no longer import (#2376). Same ordering
-    # rationale as Step 1.655: runs BEFORE Step 1.66's vault→config copy so
-    # the removal propagates on this same cycle.
-    for removed_name in reflection_register.REMOVED_REFLECTIONS:
-        log(f"Ensuring {removed_name} reflection is removed...", v)
-        rm = reflection_register.remove_reflection(project_dir, name=removed_name)
-        result.reflection_removal_results.append(rm)
-        if rm.action == "removed":
-            log(f"{removed_name} reflection removed from vault reflections.yaml", v, always=True)
-        elif rm.action == "noop":
-            log(f"{removed_name} reflection already absent", v)
-        elif rm.action == "skipped":
-            log(f"{removed_name} removal skipped: {rm.detail}", v)
-        if not rm.success:
-            log(f"WARN: {removed_name} removal: {rm.detail}", v, always=True)
-            _append_warning(result, f"{removed_name} removal: {rm.detail}")
-
-    # Step 1.657: Ensure the memory-distill-backfill reflection is registered
-    # (#2202) via the same generalized register path. Same ordering rationale
-    # as Steps 1.655/1.656: runs BEFORE Step 1.66's vault→config copy so the
-    # entry propagates into the per-machine config/reflections.yaml on this
-    # same cycle.
-    log("Ensuring memory-distill-backfill reflection is registered...", v)
-    result.memory_distill_backfill_register_result = (
-        reflection_register.register_memory_distill_backfill(project_dir)
-    )
-    mdr = result.memory_distill_backfill_register_result
-    if mdr.action == "registered":
+    # Steps 1.6-1.68 mutate machine-global state outside this checkout: the
+    # .env symlink, config/projects.json, three reflection registrations into
+    # the shared iCloud vault, the vault->config reflections copy, ~/.zshenv,
+    # and gh CLI auth. All are off under --verify (#3026).
+    #
+    # The reflection registrations are the sharpest case. Since #2855 the
+    # write-side resolver targets the vault unconditionally, so leaving these
+    # ungated would make --verify write ~/Desktop/Valor/reflections.yaml --
+    # a shared, iCloud-synced file -- where it previously only dirtied a
+    # repo-local copy. The read_only flag has to lead the fix, not trail it.
+    if config.read_only:
         log(
-            "memory-distill-backfill reflection registered in vault reflections.yaml",
+            "Skipping machine-global sync steps 1.6-1.68 "
+            "(.env, projects.json, reflection registration, zshenv, gh auth) "
+            "— --verify makes no changes (#3026)",
             v,
             always=True,
         )
-    elif mdr.action == "noop":
-        log("memory-distill-backfill reflection already registered", v)
-    elif mdr.action == "skipped":
-        log(f"memory-distill-backfill registration skipped: {mdr.detail}", v)
-    if not mdr.success:
-        log(f"WARN: memory-distill-backfill registration: {mdr.detail}", v, always=True)
-        _append_warning(result, f"memory-distill-backfill registration: {mdr.detail}")
+    else:
+        # Step 1.6: Verify .env symlink
+        log("Verifying .env symlink...", v)
+        result.env_sync_result = env_sync.sync_env_from_vault(project_dir)
+        env_r = result.env_sync_result
+        if env_r.created:
+            log(".env symlink created → ~/Desktop/Valor/.env", v, always=True)
+        if env_r.error:
+            log(f"WARN: Env symlink: {env_r.error}", v)
+            _append_warning(result, f"Env symlink: {env_r.error}")
 
-    # Step 1.658: Ensure the sdlc-upvote-pickup reflection is registered
-    # (#2717) via the same generalized register path. Same ordering
-    # rationale as Steps 1.655/1.656/1.657: runs BEFORE Step 1.66's
-    # vault→config copy so the entry propagates into the per-machine
-    # config/reflections.yaml on this same cycle.
-    log("Ensuring sdlc-upvote-pickup reflection is registered...", v)
-    result.sdlc_upvote_pickup_register_result = reflection_register.register_sdlc_upvote_pickup(
-        project_dir
-    )
-    upr = result.sdlc_upvote_pickup_register_result
-    if upr.action == "registered":
-        log(
-            "sdlc-upvote-pickup reflection registered in vault reflections.yaml",
-            v,
-            always=True,
+        # Step 1.65: Ensure config/projects.json is a real file copy (never a symlink —
+        # launchd TCC blocks open() on iCloud-synced ~/Desktop paths).
+        log("Verifying config/projects.json...", v)
+        projects_r = env_sync.sync_projects_json(project_dir)
+        if projects_r.created:
+            log("config/projects.json copied from vault (was symlink or stale)", v, always=True)
+        elif projects_r.ok:
+            log("config/projects.json OK (real file copy)", v)
+        if projects_r.error:
+            log(f"WARN: projects.json: {projects_r.error}", v, always=True)
+            _append_warning(result, f"projects.json: {projects_r.error}")
+
+        # Step 1.655: Ensure the crash-recovery reflection is registered in the
+        # vault registry (issue #1917). Runs BEFORE Step 1.66's vault→config copy
+        # (critique NIT) so the appended entry propagates into the per-machine
+        # config/reflections.yaml on this same cycle. Guarded on vault presence +
+        # 'valor' ownership; idempotent no-op once the entry exists.
+        log("Ensuring crash-recovery reflection is registered...", v)
+        result.reflection_register_result = reflection_register.register_crash_recovery(project_dir)
+        rr = result.reflection_register_result
+        if rr.action == "registered":
+            log("crash-recovery reflection registered in vault reflections.yaml", v, always=True)
+        elif rr.action == "noop":
+            log("crash-recovery reflection already registered", v)
+        elif rr.action == "skipped":
+            log(f"crash-recovery registration skipped: {rr.detail}", v)
+        if not rr.success:
+            log(f"WARN: crash-recovery registration: {rr.detail}", v, always=True)
+            _append_warning(result, f"crash-recovery registration: {rr.detail}")
+
+        # Step 1.656: Remove reflections whose callables no longer ship in the
+        # repo (reflection_register.REMOVED_REFLECTIONS) so no machine keeps
+        # scheduling an entry that can no longer import (#2376). Same ordering
+        # rationale as Step 1.655: runs BEFORE Step 1.66's vault→config copy so
+        # the removal propagates on this same cycle.
+        for removed_name in reflection_register.REMOVED_REFLECTIONS:
+            log(f"Ensuring {removed_name} reflection is removed...", v)
+            rm = reflection_register.remove_reflection(project_dir, name=removed_name)
+            result.reflection_removal_results.append(rm)
+            if rm.action == "removed":
+                log(
+                    f"{removed_name} reflection removed from vault reflections.yaml", v, always=True
+                )
+            elif rm.action == "noop":
+                log(f"{removed_name} reflection already absent", v)
+            elif rm.action == "skipped":
+                log(f"{removed_name} removal skipped: {rm.detail}", v)
+            if not rm.success:
+                log(f"WARN: {removed_name} removal: {rm.detail}", v, always=True)
+                _append_warning(result, f"{removed_name} removal: {rm.detail}")
+
+        # Step 1.657: Ensure the memory-distill-backfill reflection is registered
+        # (#2202) via the same generalized register path. Same ordering rationale
+        # as Steps 1.655/1.656: runs BEFORE Step 1.66's vault→config copy so the
+        # entry propagates into the per-machine config/reflections.yaml on this
+        # same cycle.
+        log("Ensuring memory-distill-backfill reflection is registered...", v)
+        result.memory_distill_backfill_register_result = (
+            reflection_register.register_memory_distill_backfill(project_dir)
         )
-    elif upr.action == "noop":
-        log("sdlc-upvote-pickup reflection already registered", v)
-    elif upr.action == "skipped":
-        log(f"sdlc-upvote-pickup registration skipped: {upr.detail}", v)
-    if not upr.success:
-        log(f"WARN: sdlc-upvote-pickup registration: {upr.detail}", v, always=True)
-        _append_warning(result, f"sdlc-upvote-pickup registration: {upr.detail}")
+        mdr = result.memory_distill_backfill_register_result
+        if mdr.action == "registered":
+            log(
+                "memory-distill-backfill reflection registered in vault reflections.yaml",
+                v,
+                always=True,
+            )
+        elif mdr.action == "noop":
+            log("memory-distill-backfill reflection already registered", v)
+        elif mdr.action == "skipped":
+            log(f"memory-distill-backfill registration skipped: {mdr.detail}", v)
+        if not mdr.success:
+            log(f"WARN: memory-distill-backfill registration: {mdr.detail}", v, always=True)
+            _append_warning(result, f"memory-distill-backfill registration: {mdr.detail}")
 
-    # Step 1.659: Repoint reflection callables onto the modules that own them.
-    # Two migration families share one table: the `agent.sustainability.*` shim
-    # -> `reflections.agents.*` (#2875), and the `agent.agent_session_queue.*`
-    # re-export hub -> `agent.session_health` / `agent.session_revival` (#2876).
-    # Keep these strings family-agnostic: naming one family makes the log false
-    # on a machine where the other fires, and an operator verifying #2876's
-    # propagation gate reads exactly this output.
-    # config/reflections.yaml is gitignored, so this registry edit can only
-    # reach machines as tracked code that rewrites the file. Runs BEFORE Step
-    # 1.66's vault->config copy (same ordering rationale as Steps 1.655-1.658)
-    # so a vault rewrite propagates on this same cycle; the migration also
-    # rewrites the config copy directly, because Step 1.66 skips the copy when
-    # the config copy is not older than the vault. Idempotent no-op once done.
-    log("Ensuring reflection callables name their owning modules...", v)
-    result.reflections_callables_result = reflections_callables.run_reflections_callables_migration(
-        project_dir
-    )
-    rcr = result.reflections_callables_result
-    if rcr.action == "rewrote":
-        log(
-            f"reflection callables repointed onto their owning modules "
-            f"({rcr.rewrites_count} line(s) across {len(rcr.targets or [])} file(s))",
-            v,
-            always=True,
+        # Step 1.658: Ensure the sdlc-upvote-pickup reflection is registered
+        # (#2717) via the same generalized register path. Same ordering
+        # rationale as Steps 1.655/1.656/1.657: runs BEFORE Step 1.66's
+        # vault→config copy so the entry propagates into the per-machine
+        # config/reflections.yaml on this same cycle.
+        log("Ensuring sdlc-upvote-pickup reflection is registered...", v)
+        result.sdlc_upvote_pickup_register_result = reflection_register.register_sdlc_upvote_pickup(
+            project_dir
         )
-    elif rcr.action == "noop":
-        log("reflection callables already name their owning modules", v)
-    if not rcr.success:
-        log(f"WARN: reflection callable migration: {rcr.error}", v, always=True)
-        _append_warning(result, f"reflection callable migration: {rcr.error}")
+        upr = result.sdlc_upvote_pickup_register_result
+        if upr.action == "registered":
+            log(
+                "sdlc-upvote-pickup reflection registered in vault reflections.yaml",
+                v,
+                always=True,
+            )
+        elif upr.action == "noop":
+            log("sdlc-upvote-pickup reflection already registered", v)
+        elif upr.action == "skipped":
+            log(f"sdlc-upvote-pickup registration skipped: {upr.detail}", v)
+        if not upr.success:
+            log(f"WARN: sdlc-upvote-pickup registration: {upr.detail}", v, always=True)
+            _append_warning(result, f"sdlc-upvote-pickup registration: {upr.detail}")
 
-    # Step 1.66: Ensure config/reflections.yaml is a real file copy (never a
-    # symlink — the launchd worker's reflection scheduler reads it, and a
-    # symlink to ~/Desktop hangs the asyncio event loop under launchd TCC).
-    log("Verifying config/reflections.yaml...", v)
-    result.reflections_sync_result = env_sync.sync_reflections_yaml(project_dir)
-    refl_r = result.reflections_sync_result
-    if refl_r.created:
-        log("config/reflections.yaml copied from vault (was symlink or stale)", v, always=True)
-    elif refl_r.ok:
-        log("config/reflections.yaml OK (real file copy)", v)
-    elif refl_r.skipped:
-        log("config/reflections.yaml: vault not found, using in-repo fallback", v)
-    if refl_r.error:
-        log(f"WARN: reflections.yaml: {refl_r.error}", v, always=True)
-        _append_warning(result, f"reflections.yaml: {refl_r.error}")
+        # Step 1.659: Repoint reflection callables onto the modules that own them.
+        # Two migration families share one table: the `agent.sustainability.*` shim
+        # -> `reflections.agents.*` (#2875), and the `agent.agent_session_queue.*`
+        # re-export hub -> `agent.session_health` / `agent.session_revival` (#2876).
+        # Keep these strings family-agnostic: naming one family makes the log false
+        # on a machine where the other fires, and an operator verifying #2876's
+        # propagation gate reads exactly this output.
+        # config/reflections.yaml is gitignored, so this registry edit can only
+        # reach machines as tracked code that rewrites the file. Runs BEFORE Step
+        # 1.66's vault->config copy (same ordering rationale as Steps 1.655-1.658)
+        # so a vault rewrite propagates on this same cycle; the migration also
+        # rewrites the config copy directly, because Step 1.66 skips the copy when
+        # the config copy is not older than the vault. Idempotent no-op once done.
+        log("Ensuring reflection callables name their owning modules...", v)
+        result.reflections_callables_result = (
+            reflections_callables.run_reflections_callables_migration(project_dir)
+        )
+        rcr = result.reflections_callables_result
+        if rcr.action == "rewrote":
+            log(
+                f"reflection callables repointed onto their owning modules "
+                f"({rcr.rewrites_count} line(s) across {len(rcr.targets or [])} file(s))",
+                v,
+                always=True,
+            )
+        elif rcr.action == "noop":
+            log("reflection callables already name their owning modules", v)
+        if not rcr.success:
+            log(f"WARN: reflection callable migration: {rcr.error}", v, always=True)
+            _append_warning(result, f"reflection callable migration: {rcr.error}")
 
-    # Step 1.67: Bootstrap cross-machine zshenv loader.
-    # Seeds ~/Desktop/Valor/zshenv.sh (vault) if missing and ensures ~/.zshenv
-    # sources it. Idempotent — most runs are no-ops. Critical on fresh machines
-    # so shared secrets (GITHUB_PAT_*, etc.) land in every shell.
-    log("Verifying ~/.zshenv → vault loader...", v)
-    result.zshenv_sync_result = zshenv_sync.sync_zshenv()
-    zr = result.zshenv_sync_result
-    if zr.vault_seeded:
-        log("Seeded ~/Desktop/Valor/zshenv.sh (vault loader)", v, always=True)
-    if zr.guard_added:
-        log("Added Valor source guard to ~/.zshenv", v, always=True)
-    if zr.error:
-        log(f"WARN: zshenv sync: {zr.error}", v, always=True)
-        _append_warning(result, f"zshenv sync: {zr.error}")
+        # Step 1.66: Ensure config/reflections.yaml is a real file copy (never a
+        # symlink — the launchd worker's reflection scheduler reads it, and a
+        # symlink to ~/Desktop hangs the asyncio event loop under launchd TCC).
+        log("Verifying config/reflections.yaml...", v)
+        result.reflections_sync_result = env_sync.sync_reflections_yaml(project_dir)
+        refl_r = result.reflections_sync_result
+        if refl_r.created:
+            log("config/reflections.yaml copied from vault (was symlink or stale)", v, always=True)
+        elif refl_r.ok:
+            log("config/reflections.yaml OK (real file copy)", v)
+        elif refl_r.skipped:
+            log("config/reflections.yaml: vault not found, using in-repo fallback", v)
+        if refl_r.error:
+            log(f"WARN: reflections.yaml: {refl_r.error}", v, always=True)
+            _append_warning(result, f"reflections.yaml: {refl_r.error}")
 
-    # Step 1.68: Configure gh CLI with GITHUB_PAT_YUDAME.
-    # Ensures all machines use the correct primary GitHub token consistently.
-    # Idempotent — safe to run on every update tick.
-    log("Configuring gh CLI auth...", v)
-    gh_auth_result = gh_auth.configure_gh_auth(project_dir)
-    if gh_auth_result.action == "configured":
-        log("gh auth: configured with GITHUB_PAT_YUDAME", v, always=True)
-    elif gh_auth_result.action == "skipped":
-        log(f"gh auth: skipped — {gh_auth_result.detail}", v)
-    elif not gh_auth_result.success:
-        log(f"WARN: gh auth: {gh_auth_result.error}", v, always=True)
-        _append_warning(result, f"gh auth: {gh_auth_result.error}")
+        # Step 1.67: Bootstrap cross-machine zshenv loader.
+        # Seeds ~/Desktop/Valor/zshenv.sh (vault) if missing and ensures ~/.zshenv
+        # sources it. Idempotent — most runs are no-ops. Critical on fresh machines
+        # so shared secrets (GITHUB_PAT_*, etc.) land in every shell.
+        log("Verifying ~/.zshenv → vault loader...", v)
+        result.zshenv_sync_result = zshenv_sync.sync_zshenv()
+        zr = result.zshenv_sync_result
+        if zr.vault_seeded:
+            log("Seeded ~/Desktop/Valor/zshenv.sh (vault loader)", v, always=True)
+        if zr.guard_added:
+            log("Added Valor source guard to ~/.zshenv", v, always=True)
+        if zr.error:
+            log(f"WARN: zshenv sync: {zr.error}", v, always=True)
+            _append_warning(result, f"zshenv sync: {zr.error}")
+
+        # Step 1.68: Configure gh CLI with GITHUB_PAT_YUDAME.
+        # Ensures all machines use the correct primary GitHub token consistently.
+        # Idempotent — safe to run on every update tick.
+        log("Configuring gh CLI auth...", v)
+        gh_auth_result = gh_auth.configure_gh_auth(project_dir)
+        if gh_auth_result.action == "configured":
+            log("gh auth: configured with GITHUB_PAT_YUDAME", v, always=True)
+        elif gh_auth_result.action == "skipped":
+            log(f"gh auth: skipped — {gh_auth_result.detail}", v)
+        elif not gh_auth_result.success:
+            log(f"WARN: gh auth: {gh_auth_result.error}", v, always=True)
+            _append_warning(result, f"gh auth: {gh_auth_result.error}")
 
     # Step 1.69: Check Google Workspace CLI (`gws`) auth state.
     # Detection only — the OAuth consent flow is human-gated and browser-based,

--- a/scripts/update/run.py
+++ b/scripts/update/run.py
@@ -2478,32 +2478,40 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
             else:
                 log(f"  Settings: {settings_migration.get('reason')}", v)
 
-        # Sync Claude OAuth credentials
-        log("Syncing Claude OAuth credentials...", v)
-        oauth_sync = verify.sync_claude_oauth(project_dir)
-        if oauth_sync.get("synced"):
-            if oauth_sync.get("refreshed_from_live"):
-                log("  OAuth: refreshed source from live token", v)
-            else:
-                log(f"  OAuth: {oauth_sync.get('reason')}", v)
-            # Resolved — clear stored state (and emit one resolved note) so a
-            # future regression warns again instead of staying silent.
-            if warn_state.should_emit("oauth-sync", "", project_dir):
-                log("  OAuth sync: resolved", v, always=True)
-                result.warn_keys_emitted.add("oauth-sync")
+        # Sync Claude OAuth credentials.
+        # Writes a credential file outside this checkout — off under --verify (#3026).
+        if config.read_only:
+            log(
+                "  OAuth: skipped credential sync — --verify makes no changes (#3026)",
+                v,
+                always=True,
+            )
         else:
-            # Human-gated (#2893): the source credential at
-            # ~/Desktop/Valor/claude_oauth_config.json is per-machine and only a
-            # human can provision it — structurally the same shape as
-            # google-token. One emission per state transition; the reason string
-            # is the signature, so a different failure mode re-warns. The
-            # verbose log stays outside the gate: it is diagnostic detail, not
-            # summary output, so it cannot respam the cron channel.
-            log(f"  OAuth: {oauth_sync.get('reason')}", v)
-            signature = f"unresolved:{oauth_sync.get('reason')}"
-            if warn_state.should_emit("oauth-sync", signature, project_dir):
-                _append_warning(result, f"OAuth sync: {oauth_sync.get('reason')}")
-                result.warn_keys_emitted.add("oauth-sync")
+            log("Syncing Claude OAuth credentials...", v)
+            oauth_sync = verify.sync_claude_oauth(project_dir)
+            if oauth_sync.get("synced"):
+                if oauth_sync.get("refreshed_from_live"):
+                    log("  OAuth: refreshed source from live token", v)
+                else:
+                    log(f"  OAuth: {oauth_sync.get('reason')}", v)
+                # Resolved — clear stored state (and emit one resolved note) so a
+                # future regression warns again instead of staying silent.
+                if warn_state.should_emit("oauth-sync", "", project_dir):
+                    log("  OAuth sync: resolved", v, always=True)
+                    result.warn_keys_emitted.add("oauth-sync")
+            else:
+                # Human-gated (#2893): the source credential at
+                # ~/Desktop/Valor/claude_oauth_config.json is per-machine and only a
+                # human can provision it — structurally the same shape as
+                # google-token. One emission per state transition; the reason string
+                # is the signature, so a different failure mode re-warns. The
+                # verbose log stays outside the gate: it is diagnostic detail, not
+                # summary output, so it cannot respam the cron channel.
+                log(f"  OAuth: {oauth_sync.get('reason')}", v)
+                signature = f"unresolved:{oauth_sync.get('reason')}"
+                if warn_state.should_emit("oauth-sync", signature, project_dir):
+                    _append_warning(result, f"OAuth sync: {oauth_sync.get('reason')}")
+                    result.warn_keys_emitted.add("oauth-sync")
 
         # Report SDK auth
         auth = result.verification.sdk_auth

--- a/scripts/update/warn_state.py
+++ b/scripts/update/warn_state.py
@@ -50,7 +50,36 @@ def _load(project_dir: Path) -> dict:
         return {}
 
 
+# Read-only mode (issue #2898). When set, this module computes and returns its
+# verdicts exactly as normal but persists nothing.
+#
+# `should_emit` writes the signature the instant it returns True, which under a
+# read-only `--verify` run silently consumed the one emission the next
+# unattended cron cycle would have made: an operator's diagnostic run left the
+# durable record in logs/update.log silent about a machine that was still
+# broken.
+#
+# The switch lives on the writer rather than on each of the six `should_emit`
+# call sites deliberately. A per-call-site `persist=` argument is a checklist
+# that the next call site added has to remember to join; a gate inside `_save`
+# is honored by every present and future writer in this module for free.
+_READ_ONLY = False
+
+
+def set_read_only(value: bool) -> None:
+    """Suppress all state persistence in this module.
+
+    Called once by the `--verify` entry point. Verdicts are unaffected, so
+    `--verify` still reports accurately -- it just stops mutating the
+    suppression state that the scheduled runs depend on.
+    """
+    global _READ_ONLY
+    _READ_ONLY = value
+
+
 def _save(project_dir: Path, state: dict) -> None:
+    if _READ_ONLY:
+        return
     try:
         path = _state_path(project_dir)
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/site/assets/graph.js
+++ b/site/assets/graph.js
@@ -845,19 +845,6 @@ window.VALOR_GRAPH = {
    "complexity": "complex"
   },
   {
-   "id": "file:bridge/session_router.py",
-   "type": "file",
-   "name": "session_router.py",
-   "filePath": "bridge/session_router.py",
-   "summary": "Routes an inbound message to a matching existing agent session based on thread, reply, and project scoping rules.",
-   "tags": [
-    "service",
-    "router",
-    "session-management"
-   ],
-   "complexity": "moderate"
-  },
-  {
    "id": "file:config/models.py",
    "type": "file",
    "name": "models.py",
@@ -1330,22 +1317,6 @@ window.VALOR_GRAPH = {
     "snapshot"
    ],
    "complexity": "moderate"
-  },
-  {
-   "id": "function:bridge/session_router.py:find_matching_session",
-   "type": "function",
-   "name": "find_matching_session",
-   "filePath": "bridge/session_router.py",
-   "lineRange": [
-    27,
-    180
-   ],
-   "summary": "Finds an existing agent session matching an inbound message by thread, reply, and project scope.",
-   "tags": [
-    "router",
-    "session-management"
-   ],
-   "complexity": "complex"
   },
   {
    "id": "function:config/models.py:ensure_generation_model",
@@ -22196,20 +22167,6 @@ window.VALOR_GRAPH = {
    "weight": 0.8
   },
   {
-   "source": "file:bridge/session_router.py",
-   "target": "function:bridge/session_router.py:find_matching_session",
-   "type": "contains",
-   "direction": "forward",
-   "weight": 1.0
-  },
-  {
-   "source": "file:bridge/session_router.py",
-   "target": "function:bridge/session_router.py:find_matching_session",
-   "type": "exports",
-   "direction": "forward",
-   "weight": 0.8
-  },
-  {
    "source": "file:config/models.py",
    "target": "function:config/models.py:ensure_generation_model",
    "type": "contains",
@@ -22533,27 +22490,6 @@ window.VALOR_GRAPH = {
   },
   {
    "source": "file:bridge/read_the_room.py",
-   "target": "file:utils/api_keys.py",
-   "type": "imports",
-   "direction": "forward",
-   "weight": 0.7
-  },
-  {
-   "source": "file:bridge/session_router.py",
-   "target": "file:agent/anthropic_client.py",
-   "type": "imports",
-   "direction": "forward",
-   "weight": 0.7
-  },
-  {
-   "source": "file:bridge/session_router.py",
-   "target": "file:config/models.py",
-   "type": "imports",
-   "direction": "forward",
-   "weight": 0.7
-  },
-  {
-   "source": "file:bridge/session_router.py",
    "target": "file:utils/api_keys.py",
    "type": "imports",
    "direction": "forward",
@@ -36044,7 +35980,6 @@ window.VALOR_GRAPH = {
     "file:bridge/knowledge_watcher.py",
     "file:bridge/promise_gate.py",
     "file:bridge/read_the_room.py",
-    "file:bridge/session_router.py",
     "file:bridge/session_logs.py",
     "file:bridge/dispatch.py",
     "file:bridge/message_drafter.py",
@@ -36527,11 +36462,10 @@ window.VALOR_GRAPH = {
   {
    "order": 2,
    "title": "Telegram Ingestion Bridge",
-   "description": "The runtime spine begins here. The Telethon bridge connects to Telegram, receives incoming events, and hands each one off: dispatch.py claims the message and enqueues an AgentSession for the worker, while session_router.py decides whether the message resumes an existing session (by thread or reply) or starts a fresh one. The bridge is deliberately I/O-only. It knows nothing about the SDLC pipeline, keeping ingestion decoupled from execution.",
+   "description": "The runtime spine begins here. The Telethon bridge connects to Telegram, receives incoming events, and hands each one off: dispatch.py claims the message and enqueues an AgentSession for the worker, while job_router.py, the single routing authority, decides whether the message binds to an existing Job or mints a new one. The bridge is deliberately I/O-only. It knows nothing about the SDLC pipeline, keeping ingestion decoupled from execution.",
    "nodeIds": [
     "file:bridge/telegram_bridge.py",
-    "file:bridge/dispatch.py",
-    "file:bridge/session_router.py"
+    "file:bridge/dispatch.py"
    ]
   },
   {

--- a/site/runtime.html
+++ b/site/runtime.html
@@ -104,7 +104,7 @@
   <h2>The bridge only listens</h2>
   <p>The bridge connects to Telegram (via Telethon) and email (IMAP/SMTP), receives each incoming message, and hands it off. That is all it does. It claims the message, decides whether it resumes an existing session or starts a fresh one, and enqueues an <code>AgentSession</code> for the worker.</p>
   <p>The bridge knows nothing about the SDLC pipeline. Keeping ingestion deliberately dumb is what lets execution live somewhere else: a session can run on a different machine than the one that received the message.</p>
-  <div class="file-chips" data-files="file:bridge/telegram_bridge.py,file:bridge/dispatch.py,file:bridge/session_router.py"></div>
+  <div class="file-chips" data-files="file:bridge/telegram_bridge.py,file:bridge/dispatch.py"></div>
 </section>
 
 <section>

--- a/tests/unit/test_push_ancestry_guard.py
+++ b/tests/unit/test_push_ancestry_guard.py
@@ -31,9 +31,35 @@ class TestPushTargetParsing:
         stdin = f"refs/heads/x {'0' * 40} refs/heads/main def456\n"
         assert g._pushes_to_main([], stdin) is None
 
-    def test_empty_stdin_falls_back_to_head(self):
+    def test_empty_stdin_is_nothing_to_push(self):
+        """Empty stdin means git had nothing to send, not 'judge HEAD' (#2800).
+
+        The old fallback returned HEAD here, so an up-to-date feature-branch
+        push was judged as a push of HEAD to main and refused -- contradicting
+        the guard's promise never to impede a feature branch.
+        """
         with patch.object(g, "_head_sha", return_value="headsha"):
-            assert g._pushes_to_main([], "") == "headsha"
+            assert g._pushes_to_main([], "") is None
+
+    def test_lone_newline_is_nothing_to_push(self):
+        """The pre-push hook's ``printf '%s\\n'`` turns empty stdin into a lone
+        newline, so that shape must be treated as nothing-to-push too (#2800)."""
+        with patch.object(g, "_head_sha", return_value="headsha"):
+            assert g._pushes_to_main([], "\n") is None
+
+    def test_assume_head_flag_judges_head(self):
+        """A caller that genuinely wants HEAD judged declares it (#2800).
+
+        Intent is stated, never inferred from an absence of stdin.
+        """
+        with patch.object(g, "_head_sha", return_value="headsha"):
+            assert g._pushes_to_main(["--assume-head"], "") == "headsha"
+
+    def test_assume_head_wins_over_unrelated_stdin(self):
+        """The explicit flag is authoritative even when stdin names no main push."""
+        stdin = "refs/heads/a s1 refs/heads/feature r1\n"
+        with patch.object(g, "_head_sha", return_value="headsha"):
+            assert g._pushes_to_main(["--assume-head"], stdin) == "headsha"
 
     def test_multiple_lines_only_main_line_matters(self):
         stdin = "refs/heads/a s1 refs/heads/feature r1\nrefs/heads/b s2 refs/heads/main r2\n"

--- a/tools/push_ancestry_guard.py
+++ b/tools/push_ancestry_guard.py
@@ -141,10 +141,20 @@ def _pushes_to_main(argv: list[str], stdin_text: str) -> str | None:
     """Return the local SHA being pushed to ``refs/heads/main``, or None if none.
 
     Reads the git pre-push stdin protocol (``<local ref> <local sha> <remote ref>
-    <remote sha>`` per line). When stdin is empty (explicit skill call), falls back
-    to the current HEAD as the pushed SHA (the skill only calls this right before a
-    ``git push origin main``).
+    <remote sha>`` per line).
+
+    Empty stdin means git had nothing to send — an up-to-date push — and is NOT
+    a push to main. Issue #2800: this used to fall back to HEAD, so a no-op
+    feature-branch push was judged as a push of HEAD to main and refused, in
+    direct contradiction of this guard's promise never to impede a feature
+    branch. The hook's ``printf '%s\\n'`` also turns empty into a lone newline,
+    so "no lines" and "empty" must both be treated as nothing-to-push.
+
+    A caller that genuinely wants HEAD judged as a main push must say so with
+    ``--assume-head``. Intent is declared, never inferred from an absence.
     """
+    if "--assume-head" in argv:
+        return _head_sha()
     for line in stdin_text.splitlines():
         parts = line.split()
         if len(parts) == 4:
@@ -154,9 +164,6 @@ def _pushes_to_main(argv: list[str], stdin_text: str) -> str | None:
                 if set(local_sha) == {"0"}:
                     return None
                 return local_sha
-    # No stdin protocol lines: explicit call. Treat HEAD as the pushed sha.
-    if not stdin_text.strip():
-        return _head_sha()
     return None
 
 
@@ -206,8 +213,11 @@ def check(pushed_sha: str) -> int:
                 f"push to main carries the ancestry of OPEN PR #{number} "
                 f"(head {head_oid[:12]}, branch '{pr.get('headRefName')}'). A plain push must "
                 "not register an open PR's branch as its merge — run `gh pr merge --squash` "
-                f"through the gate, or write 'override: <reason>' to "
-                f"data/merge_authorized_{number} to break glass.",
+                "through the gate.\n"
+                "There is a break-glass override for this gate. It is a human "
+                "decision and is deliberately not documented here: an agent that "
+                "reads a remedy out of a refusal message and applies it has not "
+                "made that decision, it has bypassed it (issue #2800).",
             )
     return 0
 

--- a/uv.lock
+++ b/uv.lock
@@ -290,7 +290,7 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.2.144"
+version = "0.2.145"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -298,13 +298,13 @@ dependencies = [
     { name = "mcp" },
     { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/e0/00d873adf589a4ba7899bc7e6ab5306fa55c8e9f4a2313a6f5fef95a473b/claude_agent_sdk-0.2.144.tar.gz", hash = "sha256:bf3df9930024bb7cf963313321af59b9ad7b6a13ec28bea6b864f457cff9afbc", size = 344707 }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/af/fe4d108fd6ee3d2dc70b3f54298e37a712e38ed34f69dfd37d3bb304c5d8/claude_agent_sdk-0.2.145.tar.gz", hash = "sha256:1eb929472b6935cbbe9d4eb3e88490a47707ce59b3b275db91638d29f90bc31f", size = 344711 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/c6/3623b5e32d903a359f0daca3b9bd5e3ca4a501e104fafbdd32bf80c6d624/claude_agent_sdk-0.2.144-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a69da08f88518695630cf88155ad5888e9c2f322b05ef4e96bb4e5460b815544", size = 92931035 },
-    { url = "https://files.pythonhosted.org/packages/1d/bd/ba760bd6c7bae939105e50df983eea65ec0cba86f748c4abbedb8abbd8eb/claude_agent_sdk-0.2.144-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:e685e624f598249a215a2db57c3a2fbbea5a7f7078a4cc632e099dedca303a69", size = 97959616 },
-    { url = "https://files.pythonhosted.org/packages/0e/5a/946d37a573b52be868dbcac349fcdd2090b43ea31273d2ff7e71cfd6fd99/claude_agent_sdk-0.2.144-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:8fb664212f3eca5b0e4081f71ff8ccdf72b15e57609ff0c93e626bfea914360a", size = 102347684 },
-    { url = "https://files.pythonhosted.org/packages/00/bc/b3b859736291b73d3065a0eb69149f39fbbe61cd800087b085690f944df0/claude_agent_sdk-0.2.144-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:8aa83aa3ea4f51ca6db113a5fe27c10db25e2af99ba0eed140738141d99a0837", size = 103339972 },
-    { url = "https://files.pythonhosted.org/packages/aa/15/484ffc9205ff9e947f819e0e2204e377da37f87bf3526f37433c9f72027c/claude_agent_sdk-0.2.144-py3-none-win_amd64.whl", hash = "sha256:c6ecd3e8d4ae756c244513388f09f220734ea300395b9744779c96bb94b80a13", size = 103521738 },
+    { url = "https://files.pythonhosted.org/packages/99/be/1ee51670f8429513d437fc7d5b0eb60f83055e339f4c890ad66b5ca93301/claude_agent_sdk-0.2.145-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7adcd67f8c89c428ea356a6551642e2d5b4aa88743d017df26b6f55a7b81c756", size = 91496316 },
+    { url = "https://files.pythonhosted.org/packages/85/ac/0f59168f99d47e6984382eddf1d5c54c7c575cdd854ac6ad0b2a169b071a/claude_agent_sdk-0.2.145-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:8a010a3d262a191ad6ede6d9694b05b35041d635d3c7748a940a946e9da57293", size = 96198553 },
+    { url = "https://files.pythonhosted.org/packages/1b/63/49d0c78a84ae95f1ed334f3a1a05febf1c76d88531cb93983650d0570dc5/claude_agent_sdk-0.2.145-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:662bd793c0a658d5d9766f28972233c1506f9edfe527a4a139050e4bfb12984d", size = 101543505 },
+    { url = "https://files.pythonhosted.org/packages/bb/54/fd0681eefaefab52110a8a547d0a9b5eb1356e517dd456e991962b599c54/claude_agent_sdk-0.2.145-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:e3859ed1c8acc3759c204104bfe2719f144df3bdc726c6b8283f88b3ef3de2f9", size = 101758355 },
+    { url = "https://files.pythonhosted.org/packages/2e/04/c3febcc4750026d7006a3dde0dc3ff13badb4150d55ab71b67e5348236b7/claude_agent_sdk-0.2.145-py3-none-win_amd64.whl", hash = "sha256:4a3d9dbd14235d285cd8597924683000c6d96e9c62286d6faf5e42f80fa31ea8", size = 104375365 },
 ]
 
 [[package]]
@@ -3484,7 +3484,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = "==0.125.0" },
-    { name = "claude-agent-sdk", specifier = "==0.2.144" },
+    { name = "claude-agent-sdk", specifier = "==0.2.145" },
     { name = "croniter", specifier = ">=2.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "google-api-python-client", specifier = ">=2.100.0" },


### PR DESCRIPTION
Wave 1 of `docs/bug-backlog-waves.md` — the batched mechanical sweep. Ten issues, disjoint files, no plan document per the playbook. One review surface instead of ten hotfix commits on `main`.

## What landed

| Issue | Fix |
|---|---|
| #2674 | Stop writing floats into `AgentSession.updated_at` (a `DatetimeField`) |
| #2678 | Configure logging at `scripts/update/run.py`'s entry point |
| #2778 | Register `validate_verification_section` in `manifest.toml` |
| #2750 | Collapse the two `read_hook_input()` to the hardened one |
| #2800 | Stop refusing no-op pushes; stop advertising the merge-gate break-glass |
| #2898 + #3026 | Make `--verify` actually make no changes |
| #2752 | Three doc/comment accuracy fixes severed from PR #2728 |
| #2855 | Split the reflection-registry write resolver from the read one |
| #2727 | Remove deleted `bridge/session_router.py` from the deployed site graph |

## Notes for review

Three of these were wider than the issue described, and the commits say so:

- **#2674** listed three call sites; a sweep found **five**. The two hook sites pass `"updated_at"` in `update_fields`, so `save()` stamps them too. `models/chat.py` declares `updated_at` as `SortedField(type=float)`, so the `tools/telegram_history` writes are correct and untouched.
- **#3026** named `~/.claude` hardlinking and migrations; `--verify` was mutating in **five** places. Fixed at the contract level with a single `UpdateConfig.read_only` rather than adding more per-behavior opt-out booleans — that shape is *why* the contract kept breaking. `warn_state` gets the same treatment inside `_save()` rather than a `persist=` argument threaded through its six call sites.
- **#2752** had four items; the third (the "Exactly one of the two fires per run" quantifier) is **already correct on `main`**. No edit made.

**#2727** was the one non-mechanical item. `site/assets/graph.js` is a 36k-line JSON graph, so it was edited structurally, not by line surgery: its round-trip through `json.dumps(indent=1)` is byte-identical, which let the two dead nodes take their five edges and all membership entries with them. The `runtime.html` chip was **dropped** rather than repointed at `bridge/job_router.py`, which has no node in the graph and would have been a fresh dangling reference.

## Verification

- `--verify` run end to end: all five mutating steps report skipping, `~/.claude/skills` mtime unchanged.
- Push guard: empty stdin and lone-newline both exit 0; `--assume-head` still reaches the check.
- `validate_verification_section` checked against the six most recent plan docs including the four in-flight lanes' — all pass, so activation is not disruptive.
- `graph.js` still parses as JS (1310 nodes / 2109 edges); zero dangling refs under `site/`.
- **1578 unit tests pass** across hooks, update, push-ancestry, docs-auditor, session-transcript, health-check — run with `PYTHONPATH` pinned to the worktree.
  > **Correction.** This line originally claimed 1545 passing and was wrong. This worktree has no `.venv`, so a bare run resolved imports from the primary checkout and tested `main`, not the branch — masking a stale test that #2800 should have updated. Caught in review; the hazard is filed as #3033.

Two Wave 1 carve-outs are deliberately excluded per the playbook: **#2896** (gated on a decision in #1633) and **#2837** (needs a human at the keyboard with the bridge stopped).

Closes #2674
Closes #2678
Closes #2727
Closes #2750
Closes #2752
Closes #2778
Closes #2800
Closes #2855
Closes #2898
Closes #3026
