### PR TITLE
Repoint production importers off the agent_session_queue re-export hub (phase 3 of 5)

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -3,11 +3,7 @@
 from .agent_session_queue import (
     PRIORITY_RANK,
     AgentSession,
-    check_revival,
-    cleanup_stale_branches,
     enqueue_agent_session,
-    queue_revival_agent_session,
-    record_revival_cooldown,
     register_callbacks,
 )
 from .branch_manager import (
@@ -32,6 +28,12 @@ from .sdk_client import (
     build_harness_turn_input,
     get_response_via_harness,
     verify_harness_health,
+)
+from .session_revival import (
+    check_revival,
+    cleanup_stale_branches,
+    queue_revival_agent_session,
+    record_revival_cooldown,
 )
 from .steering import (
     clear_steering_queue,

--- a/agent/session_pickup.py
+++ b/agent/session_pickup.py
@@ -329,7 +329,8 @@ async def _pop_agent_session(
                 # for worktree-stage PMs). Wrapped in try/except so a worker-start failure
                 # never blocks the pop loop.
                 try:
-                    from agent.agent_session_queue import _active_events, _ensure_worker
+                    from agent.agent_session_queue import _ensure_worker
+                    from agent.session_state import _active_events
 
                     for s in need_slug_worker:
                         slug_wk = s.worker_key  # slug at worktree stage

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -1830,7 +1830,7 @@ async def main():
         # === Session queue with per-session branching ===
         import re as _re
 
-        from agent.agent_session_queue import (
+        from agent.session_revival import (
             maybe_send_revival_prompt,
             queue_revival_agent_session,
         )
@@ -3067,8 +3067,8 @@ async def main():
             )
 
     # Register session queue callbacks for each project
-    from agent.agent_session_queue import cleanup_stale_branches
     from agent.agent_session_queue import register_callbacks as register_queue_callbacks
+    from agent.session_revival import cleanup_stale_branches
 
     for _pkey, _pconfig in CONFIG.get("projects", {}).items():
         _wd = _pconfig.get("working_directory", DEFAULTS.get("working_directory", ""))

--- a/docs/features/bridge-worker-architecture.md
+++ b/docs/features/bridge-worker-architecture.md
@@ -646,17 +646,27 @@ line) to the two-tier no-progress detector.
 
 ## Import Boundary
 
-The bridge imports from `agent.agent_session_queue` are allowlisted to these functions only:
+The bridge's imports from the session-lifecycle modules are pinned to exactly this
+inventory, keyed by the module that actually owns each symbol:
+
+`agent.agent_session_queue`
 - `enqueue_agent_session` — enqueue new sessions
-- `maybe_send_revival_prompt` — send a revival prompt to a dormant session
-- `queue_revival_agent_session` — enqueue a revival session from a reply
-- `cleanup_stale_branches` — clean up stale git branches on startup
 - `register_callbacks` — register output delivery callbacks
 - `clear_restart_flag` — clear stale update restart flag
 
+`agent.session_revival`
+- `maybe_send_revival_prompt` — send a revival prompt to a dormant session
+- `queue_revival_agent_session` — enqueue a revival session from a reply
+- `cleanup_stale_branches` — clean up stale git branches on startup
+
 Any function imported by the bridge that is not on this list is a violation of the boundary. The bridge does **not** import execution functions. If you see `_ensure_worker`, `_recover_interrupted_agent_sessions_startup`, `_agent_session_health_loop`, `_session_notify_listener`, `_cleanup_orphaned_claude_processes`, `_reap_orphan_session_processes`, or `register_worker_pid` imported in `bridge/telegram_bridge.py`, that is a regression.
 
-This boundary is enforced by a contract test that uses an allowlist to catch any unauthorized additions.
+This boundary is enforced by `tests/unit/test_worker_entry.py::TestWorkerImport::test_bridge_has_no_execution_function_imports`,
+which asserts **set equality per module** rather than a one-way allowlist difference. Equality
+is what makes the guard bidirectional: an import added outside the inventory fails, and so does
+an inventoried import that disappears. The one-way form went silently quiet when a symbol moved
+to its real owner, because the difference against a shrinking set is empty and the relocated
+import landed in a module the check never inspected.
 
 ## Operator CLI
 

--- a/scripts/steer_child.py
+++ b/scripts/steer_child.py
@@ -133,7 +133,7 @@ def _steer_child(session_id: str, message: str, parent_id: str, abort: bool) -> 
         # Non-abort messages go onto the Redis steering list (the sole inbox), drained
         # at the next turn boundary. This works for both SDK-harness and CLI-harness Dev
         # sessions. steer_session() looks up by session_id (the Popoto field).
-        from agent.agent_session_queue import steer_session
+        from agent.session_executor import steer_session
 
         target_session_id = child.session_id or session_id
         result = steer_session(session_id=target_session_id, message=message)

--- a/scripts/update/run.py
+++ b/scripts/update/run.py
@@ -429,7 +429,7 @@ def _cleanup_stale_sessions(
     # Attempt to import the live-worker registry; fails gracefully if the queue
     # module is not initialized in this process (standalone subprocess invocation).
     try:
-        from agent.agent_session_queue import _active_workers as active_workers_registry
+        from agent.session_state import _active_workers as active_workers_registry
     except Exception:
         import logging
 
@@ -2495,7 +2495,7 @@ def run_update(project_dir: Path, config: UpdateConfig) -> UpdateResult:
     # Then stale running/pending sessions are killed. Terminal sessions are
     # preserved for reflections to analyze.
     try:
-        from agent.agent_session_queue import cleanup_corrupted_agent_sessions
+        from agent.session_health import cleanup_corrupted_agent_sessions
 
         # Returns dict {"corrupted": int, "orphans": int} as of issue #1271.
         cleanup_result = cleanup_corrupted_agent_sessions()

--- a/tests/integration/test_steering.py
+++ b/tests/integration/test_steering.py
@@ -1666,7 +1666,7 @@ class TestSteerChildDelivery:
 
         # Patch at the source module — _steer_child imports steer_session lazily
         with patch(
-            "agent.agent_session_queue.steer_session",
+            "agent.session_executor.steer_session",
             return_value={
                 "success": False,
                 "session_id": child.session_id,

--- a/tests/unit/test_steer_child.py
+++ b/tests/unit/test_steer_child.py
@@ -37,7 +37,7 @@ def mock_child():
 # Patch targets: imports happen inside functions, so patch the source modules
 _AGENT_SESSION = "models.agent_session.AgentSession"
 _PUSH_STEERING = "agent.steering.push_steering_message"
-_STEER_SESSION = "agent.agent_session_queue.steer_session"
+_STEER_SESSION = "agent.session_executor.steer_session"
 
 
 class TestSteerChild:

--- a/tests/unit/test_worker_deadman.py
+++ b/tests/unit/test_worker_deadman.py
@@ -309,7 +309,7 @@ class TestDeadmanWriteFailure:
             patch.object(wm, "WORKER_DEADMAN_STALENESS_THRESHOLD", 90),
             patch.object(wm, "WORKER_DEADMAN_STARTUP_GRACE_MAX", 300),
             patch("agent.session_state.get_loop_tick", fake_get_loop_tick),
-            patch("agent.agent_session_queue._write_worker_heartbeat", bad_write),
+            patch("agent.session_health._write_worker_heartbeat", bad_write),
             patch("time.monotonic", return_value=now),
         ):
             with caplog.at_level(logging.WARNING, logger="worker"):

--- a/tests/unit/test_worker_entry.py
+++ b/tests/unit/test_worker_entry.py
@@ -180,59 +180,97 @@ class TestImportDecoupling:
                 pytest.fail(f"Module-level bridge import found: {stripped}")
 
     def test_bridge_has_no_execution_function_imports(self):
-        """bridge/telegram_bridge.py may only import allowlisted functions from agent_session_queue.
+        """The bridge's session-lifecycle imports are pinned to an exact per-module inventory.
 
-        The allowlist represents the public API the bridge is permitted to use.
-        Any import not on this list is a boundary violation — update the allowlist
-        (and the docs/features/bridge-worker-architecture.md boundary section) if
-        a new function is intentionally added.
+        This is an **inventory**, not a one-way allowlist. The assertion is set
+        equality per module, so it fires in both directions:
+
+        - an import *added* outside the inventory is a boundary violation;
+        - an import *removed* fails until the inventory is updated, which is
+          what keeps the guard honest when symbols migrate between modules.
+
+        The earlier form of this test computed ``imported_names - allowed`` against
+        a single hardcoded set scoped to ``agent.agent_session_queue`` alone. That
+        shape had two blind spots that this de-hubbing work walks straight into
+        (issue #2876): moving a symbol to its real owner shrank the observed set,
+        left the difference empty, and the guard went quiet while coverage dropped
+        — and the relocated import landed in a module the regex never looked at.
+
+        Keying by module fixes the second blind spot; set equality fixes the first.
+
+        When a bridge import legitimately changes, update ``bridge_imports`` below
+        and the boundary section of docs/features/bridge-worker-architecture.md.
         """
-        import re
+        import ast
+        from collections import defaultdict
 
-        # Hardcoded allowlist — only these functions may be imported from agent_session_queue
-        allowed_imports = {
-            "enqueue_agent_session",
-            "maybe_send_revival_prompt",
-            "queue_revival_agent_session",
-            "cleanup_stale_branches",
-            "register_callbacks",
-            "clear_restart_flag",
+        # Modules whose symbols make up the session-lifecycle surface. The hub
+        # re-exported from all of these, so a symbol repointed off the hub lands
+        # in one of them; any that the bridge imports from must be inventoried
+        # here or the guard fails closed.
+        watched_modules = {
+            "agent.agent_session_queue",
+            "agent.output_router",
+            "agent.session_completion",
+            "agent.session_executor",
+            "agent.session_health",
+            "agent.session_pickup",
+            "agent.session_revival",
+            "agent.session_state",
         }
+
+        # The exact inventory, keyed by module path. A watched module absent from
+        # this mapping must contribute zero imports.
+        bridge_imports: dict[str, set[str]] = {
+            "agent.agent_session_queue": {
+                "clear_restart_flag",
+                "enqueue_agent_session",
+                "register_callbacks",
+            },
+            "agent.session_revival": {
+                "cleanup_stale_branches",
+                "maybe_send_revival_prompt",
+                "queue_revival_agent_session",
+            },
+        }
+
+        assert bridge_imports.keys() <= watched_modules, (
+            "bridge_imports names a module outside watched_modules: "
+            f"{sorted(bridge_imports.keys() - watched_modules)}"
+        )
 
         source = (Path(__file__).parent.parent.parent / "bridge" / "telegram_bridge.py").read_text()
 
-        # Collect all names imported from agent.agent_session_queue
-        # Handles both single-line and multi-line imports:
-        #   from agent.agent_session_queue import foo
-        #   from agent.agent_session_queue import (foo, bar, ...)
-        imported_names: set[str] = set()
-        # Find each import block starting with "from agent.agent_session_queue import"
-        pattern = re.compile(
-            r"from agent\.agent_session_queue import\s+"
-            r"(?:\(([^)]+)\)|([^\n#(]+))",
-            re.MULTILINE,
-        )
-        for match in pattern.finditer(source):
-            block = match.group(1) or match.group(2)
-            # Each import item may look like "foo" or "foo as bar"
-            # Split on commas and whitespace, then take only the original name
-            for item in re.split(r",", block):
-                item = item.strip()
-                if not item:
-                    continue
-                # "name as alias" or just "name" (possibly with trailing whitespace/newline)
-                parts = re.split(r"\s+as\s+", item)
-                name = parts[0].strip()
-                if name:
-                    imported_names.add(name)
+        # AST-based collection covers module-level and function-local imports, and
+        # resolves `from X import a as b` to the original name `a` natively — the
+        # alias case the previous regex had to split on `\s+as\s+` by hand.
+        observed: dict[str, set[str]] = defaultdict(set)
+        for node in ast.walk(ast.parse(source)):
+            if isinstance(node, ast.ImportFrom) and node.module in watched_modules:
+                observed[node.module].update(alias.name for alias in node.names)
 
-        unauthorized = imported_names - allowed_imports
-        if unauthorized:
+        failures: list[str] = []
+        for module in sorted(watched_modules):
+            expected = bridge_imports.get(module, set())
+            actual = observed.get(module, set())
+            if actual == expected:
+                continue
+            unauthorized = sorted(actual - expected)
+            missing = sorted(expected - actual)
+            detail = []
+            if unauthorized:
+                detail.append(f"imports not in the inventory: {unauthorized}")
+            if missing:
+                detail.append(f"inventoried but no longer imported: {missing}")
+            failures.append(f"{module}: " + "; ".join(detail))
+
+        if failures:
             pytest.fail(
-                f"bridge/telegram_bridge.py imports unauthorized functions from "
-                f"agent.agent_session_queue: {sorted(unauthorized)}. "
-                f"Either remove these imports or add them to the allowlist in this test "
-                f"and update docs/features/bridge-worker-architecture.md."
+                "bridge/telegram_bridge.py's session-lifecycle imports do not match the "
+                "pinned inventory in this test:\n  "
+                + "\n  ".join(failures)
+                + "\nUpdate bridge_imports here and the boundary section of "
+                "docs/features/bridge-worker-architecture.md."
             )
 
     def test_reaction_constants_importable_from_agent(self):

--- a/tools/agent_session_scheduler.py
+++ b/tools/agent_session_scheduler.py
@@ -459,7 +459,7 @@ def cmd_schedule(args: argparse.Namespace) -> int:
         # Transition parent to waiting_for_children if not already
         if parent_session and parent_session.status != "waiting_for_children":
             try:
-                from agent.agent_session_queue import _transition_parent
+                from agent.session_completion import _transition_parent
 
                 _transition_parent(parent_session, "waiting_for_children")
                 logger.info(f"Parent {parent_id} transitioned to waiting_for_children")

--- a/tools/valor_session.py
+++ b/tools/valor_session.py
@@ -1278,7 +1278,7 @@ def cmd_steer(args: argparse.Namespace) -> int:
     """
     _load_env()
     try:
-        from agent.agent_session_queue import steer_session
+        from agent.session_executor import steer_session
 
         session = _find_session(args.id)
         if session is None:

--- a/worker/__main__.py
+++ b/worker/__main__.py
@@ -252,7 +252,7 @@ def _green_heartbeat_write() -> None:
     filesystem error must not be confused with a frozen event loop. Refreshes
     the Redis worker PID as a side effect (issue #1271).
     """
-    from agent.agent_session_queue import _write_worker_heartbeat  # noqa: PLC0415
+    from agent.session_health import _write_worker_heartbeat  # noqa: PLC0415
 
     try:
         _write_worker_heartbeat()
@@ -534,22 +534,24 @@ async def _run_worker(projects: dict, dry_run: bool = False) -> None:
     8. Waits for shutdown signal
     """
     from agent.agent_session_queue import (
-        _active_workers,
-        _agent_session_health_loop,
-        _cleanup_orphaned_claude_processes,
         _ensure_worker,
-        _recover_interrupted_agent_sessions_startup,
         _session_notify_listener,
+        register_callbacks,
+        request_shutdown,
+    )
+    from agent.output_handler import FileOutputHandler, TelegramRelayOutputHandler
+    from agent.session_health import (
+        _agent_session_health_loop,
+        _agent_session_tool_timeout_loop,
+        _cleanup_orphaned_claude_processes,
+        _recover_interrupted_agent_sessions_startup,
         _sweep_dead_worker_sessions,
         _sweep_stranded_waiting_for_children_parents,
         _write_worker_heartbeat,
         cleanup_corrupted_agent_sessions,
-        register_callbacks,
         register_worker_pid,
-        request_shutdown,
     )
-    from agent.output_handler import FileOutputHandler, TelegramRelayOutputHandler
-    from agent.session_health import _agent_session_tool_timeout_loop
+    from agent.session_state import _active_workers
 
     # Initialize the global concurrency slot registry BEFORE any worker loops
     # are created. Clamp to minimum 1 to prevent deadlock if


### PR DESCRIPTION
Phase 3 of #2876. Plan: `docs/plans/sdlc-2876.md`.

**Scope:** repoint the production importers that pull a pure re-export off `agent/agent_session_queue.py`, and repair the bridge boundary guard before this diff hollows it. `agent/agent_session_queue.py` itself is untouched — deleting the re-export block is phase 5.

## Why these files

A name may move only if the hub **imports** it and **never references it** in its own body. Names the hub's body uses keep resolving through the hub after phase 5 and must stay. That partition was re-derived by AST against this PR's merge base, not carried over from the plan's older base — the plan's hub-used count was written against a tree that predates #3007, #3028 and #3034.

The split-statement case is where a mechanical repoint goes wrong, and `worker/__main__.py:536` is the worst of them: nine names move to `agent.session_health` / `agent.session_state` while `_ensure_worker`, `_session_notify_listener`, `register_callbacks` and `request_shutdown` stay on the hub, out of a single import statement. `cleanup_corrupted_agent_sessions` and `_active_workers` look like movers but are referenced by the hub's own body, so they were checked against the hub-used set before being touched.

## The guard this diff would have hollowed

`tests/unit/test_worker_entry.py::test_bridge_has_no_execution_function_imports` asserted `imported_names - allowed_imports`. That difference is one-directional: it catches an import **added** outside the allowlist and is structurally blind to one **removed**.

This PR moves three of the bridge's six allowlisted symbols to `agent.session_revival`, a module the old regex never inspected. The observed set shrinks, the difference stays empty, and the guard goes on passing over half the coverage it used to have.

**Old guard, run against this PR's repointed bridge:**

```
########## OLD guard vs POST-phase-3 bridge (3 of its 6 allowlisted symbols no longer imported) ##########
1 passed in 7.61s
```

That is the regression this PR exists to prevent shipping.

### New form

Three changes, each fixing a distinct blind spot:

- **keyed by module path** — a symbol that relocates lands in a module the guard still inspects, instead of falling out of coverage;
- **set equality per module** instead of a one-way difference — removal now fails as loudly as addition;
- **AST collection** instead of regex — covers function-local imports (the bridge's are all function-local) and resolves `import x as y` to the original name natively, replacing the hand-rolled `\s+as\s+` split.

### Demonstrated red, both directions

Addition:

```
########## RED PROBE 1: import ADDED outside inventory ##########
E     agent.session_revival: imports not in the inventory: ['_load_cooldowns']
1 failed in 7.79s
```

Removal — the case the old form could not see:

```
########## RED PROBE 2: inventoried import REMOVED (old guard was blind to this) ##########
E     agent.session_revival: inventoried but no longer imported: ['cleanup_stale_branches']
1 failed in 7.59s
```

Both probes reverted; green restored:

```
########## RESTORED: green again ##########
1 passed in 7.41s
```

## Patch targets that this diff silently voided

Three test files that **do not appear in this diffstat's original form** patched a moved symbol on its hub path. Once the caller imports from the owning module, such a patch stops intercepting anything. They were found by asking *which tests reference a symbol this diff relocates*, not *which tests does this diff touch* — the narrow question is blind to files the diff never opens.

| File | Was patching | Now patches |
|---|---|---|
| `tests/unit/test_steer_child.py` | `agent.agent_session_queue.steer_session` | `agent.session_executor.steer_session` |
| `tests/integration/test_steering.py` | `agent.agent_session_queue.steer_session` | `agent.session_executor.steer_session` |
| `tests/unit/test_worker_deadman.py` | `agent.agent_session_queue._write_worker_heartbeat` | `agent.session_health._write_worker_heartbeat` |

These fail loudly rather than passing hollow, so they are fixed here rather than deferred to phase 4: without them this phase cannot leave `main` green.

```
FAILED tests/unit/test_steer_child.py::TestSteerChild::test_valid_steering
FAILED tests/unit/test_worker_deadman.py::TestDeadmanWriteFailure::test_write_failure_no_abort
FAILED tests/unit/test_steer_child.py::TestSteerChild::test_parent_id_from_env
3 failed, 67 passed in 13.21s
```

Patches on `cleanup_corrupted_agent_sessions` and `_active_workers` were checked and are **not** affected — both are hub-used, so the hub's own binding is still the one under test.

## Verification

| Check | Result |
|---|---|
| Production importers of a pure re-export remaining (AST, relative imports resolved) | `0` |
| Lines changed in `agent/agent_session_queue.py` | `0` — the re-export block is untouched |
| `python -m ruff check .` | `All checks passed!` |
| `python -m ruff format --check .` | `1411 files already formatted` |
| `python -c "import agent, worker.__main__, tools.valor_session, tools.agent_session_scheduler, bridge.telegram_bridge"` | `OK` |
| `agent.session_revival` module-level imports into the `agent` package root | none — no cycle |
| `tests/unit/test_worker_entry.py` | `38 passed` |
| Targeted suites (steer_child, worker_deadman, worker_persistent, agent_session_status_cli, zombie_session_resurrection, worker_entry, steering) | `220 passed` |

Scoped to the diff rather than a full run, per the repo's parallel-lane testing note.

## Not in this PR

- The hub's re-export block and its F401 suppressions (phase 5).
- The 24 test files importing pure re-exports (phase 4), except the three whose patch targets this diff actively voids.
- No `agent.*` module is deleted and no symbol is removed from the codebase, so `tests/unit/test_no_legacy_artifacts.py` needs no new row here. Phase 5 is where that guard becomes relevant.

Closes #3044
Refs #2876
