### PR TITLE
Repoint test importers off the agent_session_queue re-export hub (phase 4 of 5)

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -140,6 +140,8 @@ Check counts with: `pytest -m <marker> --collect-only -q`
 
 When a test patches a symbol, patch the **canonical module that owns the symbol**, not the shim that re-exports it. After PR #1023 split `agent/agent_session_queue.py` into purpose-specific modules (`session_health`, `session_completion`, `session_executor`, `branch_manager`, etc.), tests that still patched `agent.agent_session_queue.<X>` silently no-op'd because the new modules import helpers via direct paths (`from agent.session_executor import steer_session as _steer_session`). The shim keeps re-exports for type checkers and editor navigation, but patch targets must hit the runtime import site. See #1041 and the post-mortem in its plan for details.
 
+Attribute access through a module alias — `_queue.<X>`, where `_queue` is the hub module object — is the same mistake in a second syntax, and a write through it (`_queue.X = fake`) rebinds only the hub's copy, so the owning module never sees it. `tests/unit/test_hub_alias_references.py` guards both forms. It derives the hazard set from the hub's own AST (a name the hub imports and never references in its own body) rather than pinning a list, so it stays honest as the hub changes.
+
 ## Test-Reliability Layers
 
 - **PR-branch flaky filter** (`/do-test`, PR #484, issue #476) — when a test fails on the PR branch, pytest retries the failure once; tests that pass on retry are dropped from the failure report. This layer addresses flakiness *on the PR branch*.
@@ -299,6 +301,7 @@ tests/
 | unit | `test_validate_commit_message.py` | 16 | Commit message format |
 | unit | `test_validate_sdlc_on_stop.py` | 12 | SDLC stop validation |
 | unit | `test_build_validation.py` | 6 | Build process validation |
+| unit | `test_hub_alias_references.py` | 5 | Module-alias reference guard (#2876): no tracked Python reaches an `agent.agent_session_queue` pure re-export through a module alias. Hazard set derived from the hub's AST, not pinned; discovery via `git ls-files`, no exemption set |
 | unit | `test_stale_reference_sweep.py` | 3 | Stale-prose sweep (#2853, #2839): the unregistered reflection name, the two deleted granite package paths, and a scoped cadence-wording anti-criterion. Enumerates via `git ls-files` (untracked scratch Markdown is not repo content) and assembles every compared token by concatenation so the file cannot trip its own sweeps |
 | unit | `test_site_graph_consistency.py` | 2 | Public-site knowledge-graph staleness (#2531): every `data-files` chip reference resolves to a `graph.js` node; frameworks named by the graph are still declared dependencies |
 

--- a/tests/e2e/test_nudge_loop.py
+++ b/tests/e2e/test_nudge_loop.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from agent.agent_session_queue import MAX_NUDGE_COUNT, SendToChatResult
+from agent.output_router import MAX_NUDGE_COUNT, SendToChatResult
 from models.agent_session import AgentSession
 
 

--- a/tests/integration/test_agent_session_health_monitor.py
+++ b/tests/integration/test_agent_session_health_monitor.py
@@ -249,7 +249,7 @@ class TestJobHealthCheck:
     @pytest.mark.asyncio
     async def test_recovers_job_with_dead_worker(self):
         """A running session whose worker task is done should be recovered."""
-        from agent.agent_session_queue import _agent_session_health_check
+        from agent.session_health import _agent_session_health_check
 
         # Create a running session that has been running long enough
         _create_test_session(
@@ -277,7 +277,7 @@ class TestJobHealthCheck:
     @pytest.mark.asyncio
     async def test_recovers_job_with_no_worker(self):
         """A running session with no entry in _active_workers should be recovered."""
-        from agent.agent_session_queue import _agent_session_health_check
+        from agent.session_health import _agent_session_health_check
 
         _create_test_session(
             status="running",
@@ -300,7 +300,7 @@ class TestJobHealthCheck:
     @pytest.mark.asyncio
     async def test_skips_job_with_alive_worker_under_timeout(self):
         """A running session with an alive worker under timeout should NOT be recovered."""
-        from agent.agent_session_queue import _agent_session_health_check
+        from agent.session_health import _agent_session_health_check
 
         _create_test_session(
             status="running",
@@ -327,7 +327,7 @@ class TestJobHealthCheck:
     async def test_long_running_session_with_fresh_heartbeat_survives(self):
         """Issue #1172: a session with a fresh heartbeat is NOT killed regardless
         of wall-clock duration. The previous wall-clock cap is gone."""
-        from agent.agent_session_queue import _agent_session_health_check
+        from agent.session_health import _agent_session_health_check
 
         # Simulate a 4-hour-old session — far beyond any prior wall-clock cap.
         s = _create_test_session(
@@ -357,7 +357,7 @@ class TestJobHealthCheck:
     @pytest.mark.asyncio
     async def test_skips_recently_started_job_with_dead_worker(self):
         """Sessions running < AGENT_SESSION_HEALTH_MIN_RUNNING not recovered (race guard)."""
-        from agent.agent_session_queue import _agent_session_health_check
+        from agent.session_health import _agent_session_health_check
 
         _create_test_session(
             status="running",
@@ -381,7 +381,7 @@ class TestJobHealthCheck:
     @pytest.mark.asyncio
     async def test_handles_job_without_started_at(self):
         """Jobs without started_at (legacy) should still be checked for dead workers."""
-        from agent.agent_session_queue import _agent_session_health_check
+        from agent.session_health import _agent_session_health_check
 
         # A running session with no started_at (legacy session that predates this field)
         _create_test_session(
@@ -406,7 +406,7 @@ class TestJobHealthCheck:
     @pytest.mark.asyncio
     async def test_no_running_jobs_is_noop(self):
         """When no running sessions exist, health check should do nothing."""
-        from agent.agent_session_queue import _agent_session_health_check
+        from agent.session_health import _agent_session_health_check
 
         # Create only a pending session
         _create_test_session(status="pending")
@@ -439,9 +439,9 @@ class TestJobHealthCheck:
         """
         import logging
 
-        from agent.agent_session_queue import (
+        from agent.agent_session_queue import _active_workers
+        from agent.session_health import (
             AGENT_SESSION_HEALTH_MIN_RUNNING,
-            _active_workers,
             _agent_session_health_check,
         )
 
@@ -525,7 +525,7 @@ class TestJobHealthCheck:
         _delivery_belongs_to_current_run instead of before it, this test
         would fail with the session incorrectly finalized to "completed".
         """
-        from agent.agent_session_queue import (
+        from agent.session_health import (
             AGENT_SESSION_HEALTH_MIN_RUNNING,
             _agent_session_health_check,
         )
@@ -568,7 +568,7 @@ class TestJobHealthCheck:
         aged past the orphan threshold with a 'local'-prefixed worker_key (so
         it WOULD hit the orphaned-local-pending abandon branch), must NOT be
         abandoned by the health check's PENDING loop."""
-        from agent.agent_session_queue import (
+        from agent.session_health import (
             AGENT_SESSION_HEALTH_MIN_RUNNING,
             _agent_session_health_check,
         )
@@ -603,7 +603,7 @@ class TestJobHealthConstants:
 
     def test_constants_exist(self):
         """Health check constants that survived the #1172 simplification."""
-        from agent.agent_session_queue import (
+        from agent.session_health import (
             AGENT_SESSION_HEALTH_CHECK_INTERVAL,
             AGENT_SESSION_HEALTH_MIN_RUNNING,
         )

--- a/tests/integration/test_agent_session_queue_race.py
+++ b/tests/integration/test_agent_session_queue_race.py
@@ -20,10 +20,10 @@ from agent.agent_session_queue import (
     _ensure_worker,
     _pop_agent_session,
     _pop_agent_session_with_fallback,
-    _recover_interrupted_agent_sessions_startup,
     _starting_workers,
     clone_agent_session_fields,
 )
+from agent.session_health import _recover_interrupted_agent_sessions_startup
 from models.agent_session import AgentSession
 
 

--- a/tests/integration/test_bug_a_worker_future_leak.py
+++ b/tests/integration/test_bug_a_worker_future_leak.py
@@ -370,7 +370,7 @@ class TestBugACancelledErrorContract:
         """
         from datetime import timedelta
 
-        from agent.agent_session_queue import _recover_interrupted_agent_sessions_startup
+        from agent.session_health import _recover_interrupted_agent_sessions_startup
 
         session_id = "bug-a-cancelled-recovery-001"
         old_started = datetime.now(tz=UTC) - timedelta(seconds=600)

--- a/tests/integration/test_pm_long_run_no_kill.py
+++ b/tests/integration/test_pm_long_run_no_kill.py
@@ -22,10 +22,8 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from agent.agent_session_queue import (
-    _active_workers,
-    _agent_session_health_check,
-)
+from agent.agent_session_queue import _active_workers
+from agent.session_health import _agent_session_health_check
 from models.agent_session import AgentSession
 
 

--- a/tests/integration/test_session_heartbeat_progress.py
+++ b/tests/integration/test_session_heartbeat_progress.py
@@ -23,10 +23,10 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from agent.agent_session_queue import (
+from agent.agent_session_queue import _active_sessions
+from agent.session_health import (
     HEARTBEAT_FRESHNESS_WINDOW,
     MAX_RECOVERY_ATTEMPTS,
-    _active_sessions,
     _has_progress,
     _tier2_reprieve_signal,
 )

--- a/tests/integration/test_session_zombie_health_check.py
+++ b/tests/integration/test_session_zombie_health_check.py
@@ -66,7 +66,7 @@ class TestHealthCheckOrphanFixPreservesStatus:
     ):
         """A completed child with an orphaned parent must remain completed
         after the health check clears the parent reference."""
-        from agent.agent_session_queue import _agent_session_hierarchy_health_check
+        from agent.session_health import _agent_session_hierarchy_health_check
 
         child = completed_child_with_orphaned_parent
         original_session_id = child.session_id
@@ -96,7 +96,7 @@ class TestHealthCheckOrphanFixPreservesStatus:
     ):
         """A failed child with an orphaned parent must remain failed
         after the health check clears the parent reference."""
-        from agent.agent_session_queue import _agent_session_hierarchy_health_check
+        from agent.session_health import _agent_session_hierarchy_health_check
 
         child = failed_child_with_orphaned_parent
         original_session_id = child.session_id
@@ -119,7 +119,7 @@ class TestHealthCheckOrphanFixPreservesStatus:
     async def test_orphaned_parent_reference_is_cleared(self, completed_child_with_orphaned_parent):
         """The health check must clear the parent_agent_session_id when the
         parent no longer exists, allowing the child to stand alone."""
-        from agent.agent_session_queue import _agent_session_hierarchy_health_check
+        from agent.session_health import _agent_session_hierarchy_health_check
 
         child = completed_child_with_orphaned_parent
 

--- a/tests/integration/test_silent_failures.py
+++ b/tests/integration/test_silent_failures.py
@@ -158,7 +158,7 @@ class TestEnqueueContinuationSessionLookupLogging:
         from unittest.mock import AsyncMock as _AsyncMock
 
         with (
-            caplog.at_level(logging.ERROR, logger="agent.agent_session_queue"),
+            caplog.at_level(logging.ERROR, logger="agent.session_executor"),
             patch(
                 "agent.agent_session_queue.enqueue_agent_session",
                 new_callable=_AsyncMock,
@@ -265,7 +265,7 @@ class TestCheckRevivalBranchLogging:
         with (
             patch("agent.session_revival._load_cooldowns", return_value={}),
             patch("subprocess.run", side_effect=Exception("git not found")),
-            caplog.at_level(logging.WARNING, logger="agent.agent_session_queue"),
+            caplog.at_level(logging.WARNING, logger="agent.session_revival"),
         ):
             result = check_revival(
                 project_key="test-revival-project",

--- a/tests/integration/test_silent_failures.py
+++ b/tests/integration/test_silent_failures.py
@@ -164,7 +164,7 @@ class TestEnqueueContinuationSessionLookupLogging:
                 new_callable=_AsyncMock,
             ),
         ):
-            from agent.agent_session_queue import _enqueue_nudge
+            from agent.session_executor import _enqueue_nudge
 
             await _enqueue_nudge(
                 session=mock_session_entry,
@@ -243,7 +243,7 @@ class TestCheckRevivalBranchLogging:
         """When subprocess fails checking branch existence, a warning is emitted."""
         import time as _time
 
-        from agent.agent_session_queue import check_revival
+        from agent.session_revival import check_revival
         from models.agent_session import AgentSession
 
         # Create a session in Redis that belongs to this chat so the branch
@@ -263,7 +263,7 @@ class TestCheckRevivalBranchLogging:
         )
 
         with (
-            patch("agent.agent_session_queue._load_cooldowns", return_value={}),
+            patch("agent.session_revival._load_cooldowns", return_value={}),
             patch("subprocess.run", side_effect=Exception("git not found")),
             caplog.at_level(logging.WARNING, logger="agent.agent_session_queue"),
         ):

--- a/tests/integration/test_stage_aware_auto_continue.py
+++ b/tests/integration/test_stage_aware_auto_continue.py
@@ -10,7 +10,7 @@ Tests use Redis db=1 via the autouse redis_test_db fixture in conftest.py.
 import json
 
 # claude_agent_sdk mock is centralized in conftest.py
-from agent.agent_session_queue import MAX_NUDGE_COUNT
+from agent.output_router import MAX_NUDGE_COUNT
 from models.agent_session import AgentSession
 
 

--- a/tests/integration/test_worker_concurrency.py
+++ b/tests/integration/test_worker_concurrency.py
@@ -285,6 +285,8 @@ class TestPerChatSerialization:
 
         original_semaphore = _ss._slot_registry
         try:
+            # Headroom, not an assertion: this test's subject is per-chat serialization,
+            # so the ceiling is deliberately set above what the test can reach.
             _ss._slot_registry = SlotLeaseRegistry(3)  # Global ceiling
 
             with patch("agent.agent_session_queue._execute_agent_session", new=fake_execute):
@@ -300,11 +302,13 @@ class TestPerChatSerialization:
                 f"Expected 3 sessions to execute, got {len(execution_order)}: {execution_order}"
             )
         finally:
-            _ss._slot_registry = original_semaphore
+            # Cancel the in-flight workers before restoring the registry: a task
+            # still running could otherwise acquire against the restored value.
             task = _active_workers.pop(chat_id, None)
             if task:
                 task.cancel()
             _starting_workers.discard(chat_id)
+            _ss._slot_registry = original_semaphore
 
     @pytest.mark.asyncio
     async def test_global_ceiling_across_multiple_chat_ids(self):
@@ -359,12 +363,14 @@ class TestPerChatSerialization:
                 "hold time."
             )
         finally:
-            _ss._slot_registry = original_semaphore
+            # Cancel the in-flight workers before restoring the registry: a task
+            # still running could otherwise acquire against the restored value.
             for cid in chat_ids:
                 task = _active_workers.pop(cid, None)
                 if task:
                     task.cancel()
                 _starting_workers.discard(cid)
+            _ss._slot_registry = original_semaphore
 
 
 class TestPMProjectKeySerialization:
@@ -399,6 +405,8 @@ class TestPMProjectKeySerialization:
 
         original_semaphore = _ss._slot_registry
         try:
+            # Headroom, not an assertion: this test's subject is project-keyed serialization,
+            # so the ceiling is deliberately set above what the test can reach.
             _ss._slot_registry = SlotLeaseRegistry(5)
             with patch("agent.agent_session_queue._execute_agent_session", new=fake_execute):
                 # Both PM sessions should route to the same project-keyed worker
@@ -410,11 +418,13 @@ class TestPMProjectKeySerialization:
                 "Project-keyed serialization is broken."
             )
         finally:
-            _ss._slot_registry = original_semaphore
+            # Cancel the in-flight workers before restoring the registry: a task
+            # still running could otherwise acquire against the restored value.
             task = _active_workers.pop(project_key, None)
             if task:
                 task.cancel()
             _starting_workers.discard(project_key)
+            _ss._slot_registry = original_semaphore
 
 
 class TestDevWorktreeParallelism:
@@ -453,6 +463,8 @@ class TestDevWorktreeParallelism:
 
         original_semaphore = _ss._slot_registry
         try:
+            # Headroom, not an assertion: this test's subject is worktree parallelism,
+            # so the ceiling is deliberately set above what the test can reach.
             _ss._slot_registry = SlotLeaseRegistry(5)
             with patch("agent.agent_session_queue._execute_agent_session", new=fake_execute):
                 # Each slugged dev session gets its own slug-keyed worker.
@@ -469,12 +481,14 @@ class TestDevWorktreeParallelism:
                 "Slugged dev sessions should run in parallel."
             )
         finally:
-            _ss._slot_registry = original_semaphore
+            # Cancel the in-flight workers before restoring the registry: a task
+            # still running could otherwise acquire against the restored value.
             for sl in slugs:
                 task = _active_workers.pop(sl, None)
                 if task:
                     task.cancel()
                 _starting_workers.discard(sl)
+            _ss._slot_registry = original_semaphore
 
     @pytest.mark.asyncio
     async def test_two_slugged_dev_sessions_same_chat_id_execute_concurrently(self):
@@ -513,6 +527,8 @@ class TestDevWorktreeParallelism:
 
         original_semaphore = _ss._slot_registry
         try:
+            # Headroom, not an assertion: this test's subject is slug-keyed parallelism,
+            # so the ceiling is deliberately set above what the test can reach.
             _ss._slot_registry = SlotLeaseRegistry(5)
             with patch("agent.agent_session_queue._execute_agent_session", new=fake_execute):
                 # Each slugged dev session gets its own slug-keyed worker,
@@ -528,12 +544,14 @@ class TestDevWorktreeParallelism:
                 "via slug-keyed workers (issue #1085)."
             )
         finally:
-            _ss._slot_registry = original_semaphore
+            # Cancel the in-flight workers before restoring the registry: a task
+            # still running could otherwise acquire against the restored value.
             for sl in slugs:
                 task = _active_workers.pop(sl, None)
                 if task:
                     task.cancel()
                 _starting_workers.discard(sl)
+            _ss._slot_registry = original_semaphore
 
     @pytest.mark.asyncio
     async def test_slug_keyed_pop_finds_session_by_slug(self):

--- a/tests/integration/test_worker_concurrency.py
+++ b/tests/integration/test_worker_concurrency.py
@@ -8,6 +8,12 @@ Validates:
 5. Dev sessions with slug from different chat_ids run concurrently (chat-keyed workers)
 
 All tests use redis_test_db fixture (autouse=True in conftest.py) for Redis isolation.
+
+The concurrency ceiling lives in `agent.session_state._slot_registry`, and that is
+the only module these tests may set it through. `agent.agent_session_queue` binds
+the name at import time, so assigning through the hub rebinds a copy the runtime
+never reads: the ceiling is silently never installed and the test passes without
+testing anything.
 """
 
 import asyncio
@@ -16,7 +22,7 @@ from unittest.mock import patch
 
 import pytest
 
-import agent.agent_session_queue as _queue
+import agent.session_state as _ss
 from agent.agent_session_queue import (
     _active_workers,
     _ensure_worker,
@@ -126,8 +132,6 @@ class TestGlobalSemaphore:
         _execute_agent_session with a controlled delay. Verifies the global
         semaphore caps peak concurrent executions.
         """
-        import agent.session_state as _ss
-
         max_sessions = 2
         original_semaphore = _ss._slot_registry
 
@@ -187,7 +191,6 @@ class TestGlobalSemaphore:
         from popoto.redis_db import POPOTO_REDIS_DB
 
         import agent.session_health as _sh
-        import agent.session_state as _ss
 
         original = _ss._slot_registry
         try:
@@ -223,9 +226,9 @@ class TestGlobalSemaphore:
         This is the backward-compatible mode before the worker initializes
         the semaphore (e.g., in tests that don't call _run_worker).
         """
-        original_semaphore = _queue._slot_registry
+        original_semaphore = _ss._slot_registry
         try:
-            _queue._slot_registry = None
+            _ss._slot_registry = None
             # Just verify the pop path doesn't crash when semaphore is None
             chat_id = "test-semaphore-none"
             _create_test_session(chat_id=chat_id, session_id="sess-no-sem")
@@ -233,7 +236,7 @@ class TestGlobalSemaphore:
             assert result is not None
             assert result.status == "running"
         finally:
-            _queue._slot_registry = original_semaphore
+            _ss._slot_registry = original_semaphore
 
 
 class TestPerChatSerialization:
@@ -280,9 +283,9 @@ class TestPerChatSerialization:
             async with count_lock:
                 running_count[0] -= 1
 
-        original_semaphore = _queue._slot_registry
+        original_semaphore = _ss._slot_registry
         try:
-            _queue._slot_registry = SlotLeaseRegistry(3)  # Global ceiling
+            _ss._slot_registry = SlotLeaseRegistry(3)  # Global ceiling
 
             with patch("agent.agent_session_queue._execute_agent_session", new=fake_execute):
                 _ensure_worker(chat_id)
@@ -297,7 +300,7 @@ class TestPerChatSerialization:
                 f"Expected 3 sessions to execute, got {len(execution_order)}: {execution_order}"
             )
         finally:
-            _queue._slot_registry = original_semaphore
+            _ss._slot_registry = original_semaphore
             task = _active_workers.pop(chat_id, None)
             if task:
                 task.cancel()
@@ -310,13 +313,7 @@ class TestPerChatSerialization:
         Post-#1029 default is MAX_CONCURRENT_SESSIONS=8. We enqueue 12 sessions
         across distinct chat_ids with a faster-than-ceiling arrival rate and
         verify the semaphore caps peak concurrency at 8.
-
-        The runtime reads the semaphore from agent.session_state, not from
-        agent.agent_session_queue's import-time alias — so the test patches
-        the canonical module.
         """
-        import agent.session_state as _ss
-
         max_sessions = 8
         chat_ids = [f"global-ceil-chat-{i}" for i in range(max_sessions + 4)]
 
@@ -400,9 +397,9 @@ class TestPMProjectKeySerialization:
             async with count_lock:
                 running_count[0] -= 1
 
-        original_semaphore = _queue._slot_registry
+        original_semaphore = _ss._slot_registry
         try:
-            _queue._slot_registry = SlotLeaseRegistry(5)
+            _ss._slot_registry = SlotLeaseRegistry(5)
             with patch("agent.agent_session_queue._execute_agent_session", new=fake_execute):
                 # Both PM sessions should route to the same project-keyed worker
                 _ensure_worker(project_key, is_project_keyed=True)
@@ -413,7 +410,7 @@ class TestPMProjectKeySerialization:
                 "Project-keyed serialization is broken."
             )
         finally:
-            _queue._slot_registry = original_semaphore
+            _ss._slot_registry = original_semaphore
             task = _active_workers.pop(project_key, None)
             if task:
                 task.cancel()
@@ -454,9 +451,9 @@ class TestDevWorktreeParallelism:
             async with count_lock:
                 running_count[0] -= 1
 
-        original_semaphore = _queue._slot_registry
+        original_semaphore = _ss._slot_registry
         try:
-            _queue._slot_registry = SlotLeaseRegistry(5)
+            _ss._slot_registry = SlotLeaseRegistry(5)
             with patch("agent.agent_session_queue._execute_agent_session", new=fake_execute):
                 # Each slugged dev session gets its own slug-keyed worker.
                 # Stagger starts so Worker A can pop its session before Worker B
@@ -472,7 +469,7 @@ class TestDevWorktreeParallelism:
                 "Slugged dev sessions should run in parallel."
             )
         finally:
-            _queue._slot_registry = original_semaphore
+            _ss._slot_registry = original_semaphore
             for sl in slugs:
                 task = _active_workers.pop(sl, None)
                 if task:
@@ -514,9 +511,9 @@ class TestDevWorktreeParallelism:
             async with count_lock:
                 running_count[0] -= 1
 
-        original_semaphore = _queue._slot_registry
+        original_semaphore = _ss._slot_registry
         try:
-            _queue._slot_registry = SlotLeaseRegistry(5)
+            _ss._slot_registry = SlotLeaseRegistry(5)
             with patch("agent.agent_session_queue._execute_agent_session", new=fake_execute):
                 # Each slugged dev session gets its own slug-keyed worker,
                 # regardless of shared chat_id.
@@ -531,7 +528,7 @@ class TestDevWorktreeParallelism:
                 "via slug-keyed workers (issue #1085)."
             )
         finally:
-            _queue._slot_registry = original_semaphore
+            _ss._slot_registry = original_semaphore
             for sl in slugs:
                 task = _active_workers.pop(sl, None)
                 if task:

--- a/tests/integration/test_worker_concurrency.py
+++ b/tests/integration/test_worker_concurrency.py
@@ -56,7 +56,7 @@ class TestPopLockContention:
         This simulates the TOCTOU race scenario: a second worker calling
         _pop_agent_session for the same chat_id while the first is mid-transition.
         """
-        from agent.agent_session_queue import _acquire_pop_lock, _release_pop_lock
+        from agent.session_pickup import _acquire_pop_lock, _release_pop_lock
 
         chat_id = "test-contention-chat"
         _create_test_session(chat_id=chat_id, session_id="session-contention-1")
@@ -78,7 +78,7 @@ class TestPopLockContention:
     @pytest.mark.asyncio
     async def test_pop_succeeds_after_lock_released(self):
         """_pop_agent_session succeeds once the lock is released."""
-        from agent.agent_session_queue import _acquire_pop_lock, _release_pop_lock
+        from agent.session_pickup import _acquire_pop_lock, _release_pop_lock
 
         chat_id = "test-contention-after-release"
         _create_test_session(chat_id=chat_id, session_id="session-after-release-1")

--- a/tests/unit/test_agent_session_hierarchy.py
+++ b/tests/unit/test_agent_session_hierarchy.py
@@ -165,7 +165,7 @@ class TestFinalizeParent:
 
     def test_transition_parent_completed(self):
         """_transition_parent transitions parent to completed via lifecycle module."""
-        from agent.agent_session_queue import _transition_parent
+        from agent.session_completion import _transition_parent
 
         parent = self._make_session(agent_session_id="p1", status="waiting_for_children")
 
@@ -178,7 +178,7 @@ class TestFinalizeParent:
 
     def test_transition_parent_failed(self):
         """_transition_parent transitions parent to failed via lifecycle module."""
-        from agent.agent_session_queue import _transition_parent
+        from agent.session_completion import _transition_parent
 
         parent = self._make_session(agent_session_id="p1", status="waiting_for_children")
 
@@ -190,7 +190,7 @@ class TestFinalizeParent:
 
     def test_transition_parent_waiting_no_completed_at(self):
         """_transition_parent does not set completed_at for non-terminal status."""
-        from agent.agent_session_queue import _transition_parent
+        from agent.session_completion import _transition_parent
 
         parent = self._make_session(agent_session_id="p1", status="running")
         parent.completed_at = None

--- a/tests/unit/test_agent_session_queue.py
+++ b/tests/unit/test_agent_session_queue.py
@@ -20,15 +20,14 @@ import pytest
 
 import agent.agent_session_queue as asq
 from agent.agent_session_queue import (
-    _acquire_pop_lock,
     _complete_agent_session,
     _copyable_agent_session_fields,
     _pop_agent_session,
     _push_agent_session,
-    _release_pop_lock,
     _worker_loop,
     clone_agent_session_fields,
 )
+from agent.session_pickup import _acquire_pop_lock, _release_pop_lock
 from models.agent_session import AgentSession
 from models.session_lifecycle import StatusConflictError
 
@@ -179,11 +178,11 @@ class TestPopLock:
         Failing open preserves backward compatibility: workers continue to
         function without the lock rather than deadlocking when Redis is down.
         """
-        with patch("agent.agent_session_queue._acquire_pop_lock") as mock_acquire:
-            # Simulate the fail-open path by returning True even on error
-            mock_acquire.return_value = True
-            result = mock_acquire("test-chat-id")
-            assert result is True
+        # Make the Redis SETNX raise, then call the real function. Patching
+        # _acquire_pop_lock itself and asserting on the mock's return value
+        # would exercise unittest.mock rather than the fail-open branch.
+        with patch("popoto.redis_db.POPOTO_REDIS_DB.set", side_effect=Exception("redis down")):
+            assert _acquire_pop_lock("test-chat-id") is True
 
     def test_pop_lock_key_is_chat_id_scoped(self):
         """Pop lock key format must be worker:pop_lock:{chat_id}."""
@@ -472,7 +471,7 @@ class TestHealthCheckDeliveryGuard:
             mock_transition = MagicMock()
             lifecycle_mod.transition_status = mock_transition
             try:
-                from agent.agent_session_queue import _agent_session_health_check
+                from agent.session_health import _agent_session_health_check
 
                 await _agent_session_health_check()
             finally:
@@ -518,7 +517,7 @@ class TestHealthCheckDeliveryGuard:
             lifecycle_mod.finalize_session = mock_finalize
             lifecycle_mod.transition_status = mock_transition
             try:
-                from agent.agent_session_queue import _agent_session_health_check
+                from agent.session_health import _agent_session_health_check
 
                 await _agent_session_health_check()
             finally:
@@ -735,7 +734,7 @@ class TestHealthCheckNoProgressRecovery:
             lifecycle_ctx,
         ):
             mock_cls.query.filter.return_value = [session]
-            from agent.agent_session_queue import _agent_session_health_check
+            from agent.session_health import _agent_session_health_check
 
             await _agent_session_health_check()
 
@@ -763,7 +762,7 @@ class TestHealthCheckNoProgressRecovery:
             lifecycle_ctx,
         ):
             mock_cls.query.filter.return_value = [session]
-            from agent.agent_session_queue import _agent_session_health_check
+            from agent.session_health import _agent_session_health_check
 
             await _agent_session_health_check()
 
@@ -824,7 +823,7 @@ class TestHealthCheckNoProgressRecovery:
             lifecycle_ctx,
         ):
             mock_cls.query.filter.return_value = [session]
-            from agent.agent_session_queue import _agent_session_health_check
+            from agent.session_health import _agent_session_health_check
 
             await _agent_session_health_check()
 
@@ -851,7 +850,7 @@ class TestHealthCheckNoProgressRecovery:
             lifecycle_ctx,
         ):
             mock_cls.query.filter.return_value = [session]
-            from agent.agent_session_queue import _agent_session_health_check
+            from agent.session_health import _agent_session_health_check
 
             await _agent_session_health_check()
 
@@ -887,7 +886,7 @@ class TestHealthCheckNoProgressRecovery:
             lifecycle_ctx,
         ):
             mock_cls.query.filter.return_value = [session]
-            from agent.agent_session_queue import _agent_session_health_check
+            from agent.session_health import _agent_session_health_check
 
             await _agent_session_health_check()
 
@@ -984,7 +983,7 @@ class TestHealthCheckNoProgressRecovery:
             _ctx(),
         ):
             mock_cls.query.filter.return_value = [session]
-            from agent.agent_session_queue import _agent_session_health_check
+            from agent.session_health import _agent_session_health_check
 
             await _agent_session_health_check()
 

--- a/tests/unit/test_agent_session_queue_async.py
+++ b/tests/unit/test_agent_session_queue_async.py
@@ -179,7 +179,7 @@ class TestEnqueueContinuationAsyncWrapping:
 
     def test_continuation_filter_uses_to_thread(self, mock_agent_session):
         """The session lookup in _enqueue_nudge should use to_thread."""
-        from agent.agent_session_queue import _enqueue_nudge
+        from agent.session_executor import _enqueue_nudge
 
         # Create a mock agent session
         mock_rj = MagicMock()

--- a/tests/unit/test_agent_session_queue_revival_helper.py
+++ b/tests/unit/test_agent_session_queue_revival_helper.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from agent.agent_session_queue import maybe_send_revival_prompt
+from agent.session_revival import maybe_send_revival_prompt
 
 
 class TestMaybeSendRevivalPrompt:

--- a/tests/unit/test_agent_session_scheduler_kill.py
+++ b/tests/unit/test_agent_session_scheduler_kill.py
@@ -574,7 +574,7 @@ class TestRecoveryExcludesKilled:
         """
         import time
 
-        from agent.agent_session_queue import (
+        from agent.session_health import (
             AGENT_SESSION_HEALTH_MIN_RUNNING,
             _recover_interrupted_agent_sessions_startup,
         )

--- a/tests/unit/test_harness_retry.py
+++ b/tests/unit/test_harness_retry.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from agent.agent_session_queue import (
+from agent.session_executor import (
     _HARNESS_EXHAUSTION_MSG,
     _HARNESS_NOT_FOUND_PREFIX,
     _handle_harness_not_found,

--- a/tests/unit/test_health_check_recovery_finalization.py
+++ b/tests/unit/test_health_check_recovery_finalization.py
@@ -240,7 +240,7 @@ class TestHasProgressChildActivity:
         entry = self._make_entry()
         entry.get_children = lambda: [self._make_child(status="running")]
 
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         assert _has_progress(entry) is True
 
@@ -249,7 +249,7 @@ class TestHasProgressChildActivity:
         entry = self._make_entry()
         entry.get_children = lambda: [self._make_child(status="pending")]
 
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         assert _has_progress(entry) is True
 
@@ -262,7 +262,7 @@ class TestHasProgressChildActivity:
             self._make_child(status="killed"),
         ]
 
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         assert _has_progress(entry) is False
 
@@ -271,7 +271,7 @@ class TestHasProgressChildActivity:
         entry = self._make_entry()
         entry.get_children = lambda: []
 
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         assert _has_progress(entry) is False
 
@@ -321,7 +321,7 @@ class TestHasProgressDualHeartbeat:
     def test_queue_heartbeat_within_window_returns_true(self):
         """last_heartbeat_at fresh + no per-turn output → True (startup-window sub-check B)."""
         entry = self._make_entry(last_heartbeat_at=_ago(30))
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         assert _has_progress(entry) is True
 
@@ -332,7 +332,7 @@ class TestHasProgressDualHeartbeat:
         the buggy behavior (#1226 fix: last_sdk_heartbeat_at removed from Tier 1).
         """
         entry = self._make_entry(last_sdk_heartbeat_at=_ago(30))
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         assert _has_progress(entry) is False
 
@@ -342,7 +342,7 @@ class TestHasProgressDualHeartbeat:
             last_tool_use_at=_ago(30),
             last_sdk_heartbeat_at=_ago(300),  # stale watchdog tick: irrelevant
         )
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         assert _has_progress(entry) is True
 
@@ -352,21 +352,21 @@ class TestHasProgressDualHeartbeat:
             last_heartbeat_at=_ago(300),
             last_sdk_heartbeat_at=_ago(300),
         )
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         assert _has_progress(entry) is False
 
     def test_queue_heartbeat_at_boundary_returns_true(self):
         """last_heartbeat_at at age=89s (just inside 90s window) + sdk_ever_output=False → True."""
         entry = self._make_entry(last_heartbeat_at=_ago(89))
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         assert _has_progress(entry) is True
 
     def test_per_turn_fields_none_turn_count_set_returns_true(self):
         """turn_count=5 + fresh heartbeat → True (own-progress, heartbeat-gated by #1614)."""
         entry = self._make_entry(turn_count=5, last_heartbeat_at=_ago(30))
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         assert _has_progress(entry) is True
 
@@ -421,7 +421,7 @@ class TestStdoutStaleRetired:
         NOT a resurrection of the deleted #1046 stdout-freshness kill path
         (that path compared stdout freshness directly; this is the OR-input
         broadening of a different, presence-based signal)."""
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         entry = self._make_entry(last_stdout_at=_ago(700))
         assert _has_progress(entry) is False
@@ -430,7 +430,7 @@ class TestStdoutStaleRetired:
         """Fresh heartbeats + stale stdout + a FRESH tool/turn signal → progress
         (the deleted #1046 stdout-freshness kill path must NOT fire; sub-check
         A's tool/turn freshness is authoritative and finds real evidence)."""
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         entry = self._make_entry(last_stdout_at=_ago(700), last_tool_use_at=_ago(30))
         assert _has_progress(entry) is True
@@ -439,7 +439,7 @@ class TestStdoutStaleRetired:
         """No stdout, no tool/turn, but a fresh heartbeat and a young session →
         sdk_ever_output stays False, so sub-check B's heartbeat fallback still
         applies unchanged for sessions that have never streamed anything."""
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         entry = self._make_entry(last_stdout_at=None, started_at=_ago(30))
         assert _has_progress(entry) is True
@@ -456,7 +456,7 @@ class TestStdoutStaleRetired:
         #1172) — the structural guards on the deleted constants live in
         ``tests/unit/test_session_health_inference_removed.py``.
         """
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         entry = self._make_entry(last_stdout_at=None, started_at=_ago(400))
         assert _has_progress(entry) is False
@@ -468,7 +468,7 @@ class TestStdoutStaleRetired:
         ``STARTUP_GRACE_SECONDS`` (300s) window so the no-output budget gate
         added in #1356 does not fire — fresh heartbeat alone passes.
         """
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         entry = self._make_entry(last_stdout_at=None, started_at=_ago(120))
         assert _has_progress(entry) is True
@@ -527,14 +527,14 @@ class TestSubCheckBNoOutputBudget:
 
     def test_legacy_started_at_and_created_at_none_preserves_fast_path(self):
         """Both started_at and created_at None (truly legacy) → fast-path."""
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         entry = self._make_entry(started_at=None, created_at=None)
         assert _has_progress(entry) is True
 
     def test_running_30s_in_startup_grace_returns_true(self):
         """running_seconds=30 (well inside STARTUP_GRACE_SECONDS=300) → True."""
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         entry = self._make_entry(started_at=_ago(30))
         assert _has_progress(entry) is True
@@ -548,7 +548,7 @@ class TestSubCheckBNoOutputBudget:
         bound the session is inside the widened cold-start window and stays
         alive (see ``test_running_299s_in_startup_grace_returns_true``).
         """
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         entry = self._make_entry(started_at=_ago(1300))
         assert _has_progress(entry) is False
@@ -561,7 +561,7 @@ class TestSubCheckBNoOutputBudget:
         heartbeat signals progress. This is the inversion of the pre-widening
         behavior, where the 150s D0 gate denied the fast-path at 299s.
         """
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         entry = self._make_entry(started_at=_ago(299))
         assert _has_progress(entry) is True
@@ -573,7 +573,7 @@ class TestSubCheckBNoOutputBudget:
         grace-to-budget band for sessions with zero SDK output: past 150s the
         fresh heartbeat no longer signals progress.
         """
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         entry = self._make_entry(started_at=_ago(600))
         assert _has_progress(entry) is False
@@ -581,7 +581,7 @@ class TestSubCheckBNoOutputBudget:
     def test_running_1500s_late_in_band_returns_false_d0_gate(self):
         """running_seconds=1500s (old #1356 late-band leg) → False since #1724
         (commit 2efb58ce, D0 never-started gate)."""
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         entry = self._make_entry(started_at=_ago(1500))
         assert _has_progress(entry) is False
@@ -595,14 +595,14 @@ class TestSubCheckBNoOutputBudget:
         the fresh-heartbeat fast-path long before 1801s, so the False result
         is unchanged — it is now reached via the gate, not the removed band.
         """
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         entry = self._make_entry(started_at=_ago(1801))
         assert _has_progress(entry) is False
 
     def test_running_4h_no_output_returns_false(self):
         """The 11h-wedge pattern: 4h running, no SDK output ever → False."""
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         entry = self._make_entry(started_at=_ago(4 * 3600))
         assert _has_progress(entry) is False
@@ -616,7 +616,7 @@ class TestSubCheckBNoOutputBudget:
         the verdict. With ``last_tool_use_at`` stale (older than 30 min),
         sub-check A returns no-progress and ``_has_progress`` returns False.
         """
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         entry = self._make_entry(
             started_at=_ago(4 * 3600),
@@ -626,7 +626,7 @@ class TestSubCheckBNoOutputBudget:
 
     def test_negative_running_seconds_clock_skew_preserves_fast_path(self):
         """started_at in the future (clock skew) → treated as in startup grace, True."""
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         # _ago(-30) → started_at is 30s in the future. Negative running_seconds
         # is < STARTUP_GRACE_SECONDS by construction, so the fast-path holds.
@@ -637,7 +637,7 @@ class TestSubCheckBNoOutputBudget:
         """started_at as naive datetime → coerced to UTC, gate evaluated normally."""
         from datetime import UTC, datetime, timedelta
 
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         # Naive (no tzinfo) datetime 4h in the past. Mirrors the coercion
         # pattern used for last_heartbeat_at in the source.
@@ -652,7 +652,7 @@ class TestSubCheckBNoOutputBudget:
         ``started_ref = started_at or created_at`` fallback ensures sub-check B
         does not silently re-enter the legacy fast-path on those records.
         """
-        from agent.agent_session_queue import _has_progress
+        from agent.session_health import _has_progress
 
         entry = self._make_entry(started_at=None, created_at=_ago(4 * 3600))
         assert _has_progress(entry) is False
@@ -702,8 +702,11 @@ class TestSubCheckBNoOutputBudget:
         until ``MAX_NO_OUTPUT_REPRIEVES`` (20) is reached, at which point
         ``_tier2_reprieve_signal`` returns None (recovery proceeds).
         """
-        from agent.agent_session_queue import _has_progress, _tier2_reprieve_signal
-        from agent.session_health import MAX_NO_OUTPUT_REPRIEVES
+        from agent.session_health import (
+            MAX_NO_OUTPUT_REPRIEVES,
+            _has_progress,
+            _tier2_reprieve_signal,
+        )
 
         entry = self._make_entry(started_at=_ago(4 * 3600))
         # Tier 1 declines.
@@ -732,7 +735,7 @@ class TestTier2ReprieveGates:
         return SimpleNamespace(**defaults)
 
     def _make_handle(self):
-        from agent.agent_session_queue import SessionHandle
+        from agent.session_state import SessionHandle
 
         # Use a done task so we can construct SessionHandle without running one.
         # Durability plan #2494: SessionHandle no longer carries a pid; the
@@ -753,7 +756,7 @@ class TestTier2ReprieveGates:
 
         monkeypatch.setattr(_psutil, "Process", lambda pid: _Proc())
         _fence_reads_as_ours(monkeypatch)
-        from agent.agent_session_queue import _tier2_reprieve_signal
+        from agent.session_health import _tier2_reprieve_signal
 
         handle = self._make_handle()
         assert _tier2_reprieve_signal(handle, self._make_entry(pid=12345)) == "alive"
@@ -771,7 +774,7 @@ class TestTier2ReprieveGates:
 
         monkeypatch.setattr(_psutil, "Process", lambda pid: _Proc())
         _fence_reads_as_ours(monkeypatch)
-        from agent.agent_session_queue import _tier2_reprieve_signal
+        from agent.session_health import _tier2_reprieve_signal
 
         handle = self._make_handle()
         assert _tier2_reprieve_signal(handle, self._make_entry(pid=12345)) == "children"
@@ -791,7 +794,7 @@ class TestTier2ReprieveGates:
         # Fence matches, so the None below is the zombie gate's answer and not
         # the fence withdrawing the pid out from under it.
         _fence_reads_as_ours(monkeypatch)
-        from agent.agent_session_queue import _tier2_reprieve_signal
+        from agent.session_health import _tier2_reprieve_signal
 
         handle = self._make_handle()
         assert _tier2_reprieve_signal(handle, self._make_entry(pid=12345)) is None
@@ -807,14 +810,14 @@ class TestTier2ReprieveGates:
         # Fence matches, so the None below is ``NoSuchProcess`` reaching the
         # Tier-2 gates rather than the fence short-circuiting ahead of them.
         _fence_reads_as_ours(monkeypatch)
-        from agent.agent_session_queue import _tier2_reprieve_signal
+        from agent.session_health import _tier2_reprieve_signal
 
         handle = self._make_handle()
         assert _tier2_reprieve_signal(handle, self._make_entry(pid=999999)) is None
 
     def test_no_reprieve_on_recent_stdout(self):
         """The "stdout" gate was retired by #1172 — recent stdout no longer reprieves."""
-        from agent.agent_session_queue import _tier2_reprieve_signal
+        from agent.session_health import _tier2_reprieve_signal
 
         handle = self._make_handle()
         entry = self._make_entry(last_stdout_at=_ago(30))
@@ -822,13 +825,13 @@ class TestTier2ReprieveGates:
 
     def test_no_reprieve_on_handle_none(self):
         """handle=None and no other evidence → None."""
-        from agent.agent_session_queue import _tier2_reprieve_signal
+        from agent.session_health import _tier2_reprieve_signal
 
         assert _tier2_reprieve_signal(None, self._make_entry()) is None
 
     def test_no_reprieve_on_stdout_when_handle_none(self):
         """handle=None and no compaction → None even if stdout is fresh (#1172)."""
-        from agent.agent_session_queue import _tier2_reprieve_signal
+        from agent.session_health import _tier2_reprieve_signal
 
         entry = self._make_entry(last_stdout_at=_ago(30))
         assert _tier2_reprieve_signal(None, entry) is None
@@ -841,7 +844,8 @@ class TestRecoveryCancellation:
         """SessionHandle round-trips through _active_sessions."""
         import asyncio
 
-        from agent.agent_session_queue import SessionHandle, _active_sessions
+        from agent.agent_session_queue import _active_sessions
+        from agent.session_state import SessionHandle
 
         async def _test():
             t = asyncio.current_task()
@@ -857,7 +861,7 @@ class TestRecoveryCancellation:
 
     def test_recovery_handles_missing_registry_entry(self):
         """handle=None → _tier2_reprieve_signal still works gracefully."""
-        from agent.agent_session_queue import _tier2_reprieve_signal
+        from agent.session_health import _tier2_reprieve_signal
 
         # No handle, no fresh signals → None
         entry = SimpleNamespace(last_stdout_at=None)
@@ -867,7 +871,7 @@ class TestRecoveryCancellation:
         """A done task with done()==True → no crash during cancel wait."""
         import asyncio
 
-        from agent.agent_session_queue import SessionHandle
+        from agent.session_state import SessionHandle
 
         async def _test():
             async def _trivial():
@@ -997,7 +1001,7 @@ class TestSessionHandleTaskInvariant:
 
     def test_session_handle_task_defaults_to_none(self):
         """SessionHandle() constructed without args has task=None."""
-        from agent.agent_session_queue import SessionHandle
+        from agent.session_state import SessionHandle
 
         handle = SessionHandle()
         assert handle.task is None
@@ -1009,7 +1013,7 @@ class TestSessionHandleTaskInvariant:
         is nothing session-scoped to cancel; a bare `.cancel()` call on
         None would crash the health check.
         """
-        from agent.agent_session_queue import SessionHandle
+        from agent.session_state import SessionHandle
 
         handle = SessionHandle(task=None)
         # Mirror the health-check guard (agent_session_queue.py ~L1900).
@@ -1028,7 +1032,7 @@ class TestSessionHandleTaskInvariant:
         """
         import asyncio
 
-        from agent.agent_session_queue import SessionHandle
+        from agent.session_state import SessionHandle
 
         async def _test():
             # Two distinct long-running "session" tasks (simulating two
@@ -1391,7 +1395,7 @@ class TestTier2ReprieveEscalation:
         return SimpleNamespace(**defaults)
 
     def _make_handle(self):
-        from agent.agent_session_queue import SessionHandle
+        from agent.session_state import SessionHandle
 
         # Durability plan #2494: pid now lives on the AgentSession fence.
         fake_task = MagicMock()

--- a/tests/unit/test_health_check_recovery_finalization.py
+++ b/tests/unit/test_health_check_recovery_finalization.py
@@ -905,7 +905,7 @@ class TestRecoveryAttempts:
         health-check kills — Risk 3 in plan)."""
         import inspect
 
-        from agent import agent_session_queue as q
+        from agent import session_health as q
 
         src = inspect.getsource(q._recover_interrupted_agent_sessions_startup)
         assert "recovery_attempts" not in src, (
@@ -947,7 +947,7 @@ class TestDisableProgressKill:
         """The env var must be read in the health-check recovery branch."""
         import inspect
 
-        from agent import agent_session_queue as q
+        from agent import session_health as q
 
         src = inspect.getsource(q._agent_session_health_check)
         assert "DISABLE_PROGRESS_KILL" in src, "kill-switch env var not wired"

--- a/tests/unit/test_hub_alias_references.py
+++ b/tests/unit/test_hub_alias_references.py
@@ -1,0 +1,212 @@
+"""Guard: nothing reaches a re-exported symbol through an `agent_session_queue` module alias.
+
+Issue #2876 is removing `agent/agent_session_queue.py`'s role as a re-export hub.
+Phases 3 and 4 repointed callers at the modules that actually own each symbol, but
+the sweep that drove those phases matched only ``from agent.agent_session_queue
+import X``. Attribute access through a module alias — ``_queue.X``, where ``_queue``
+is the hub module object — is a second reference class, and it was missed. PR #3048's
+review found 17 such sites.
+
+Those sites fail in two distinct ways, which is why this guard is worth its weight:
+
+1. **They break at phase 5.** The hub's re-exports are deleted there, so
+   ``_queue.<re-export>`` becomes ``AttributeError``.
+2. **Writes through them are already vacuous.** ``from X import y`` binds a *copy*
+   of ``y`` onto the importing module at import time. Assigning ``_queue.y = z``
+   rebinds that copy; the module that owns ``y``, and every reader that resolves it
+   from the owner, never sees the change. Fifteen of the seventeen sites were of
+   this shape, and the concurrency ceiling those tests existed to verify was never
+   actually installed.
+
+The hazard set is derived from the hub's own AST rather than pinned as a name list.
+A name is a *pure re-export* when the hub imports it and never references it in its
+own body — the plan's Finding 1 definition. Names the hub actually uses are working
+imports: they survive phase 5, and an alias reaching them resolves the same object
+the hub does. Deriving rather than pinning is what keeps this guard honest as the
+hub changes, and it still fires if a re-export is reintroduced and reached this way
+later.
+
+Two constraints inherited from `docs/features/legacy-artifact-guard.md`:
+
+- **Tracked content only.** File discovery goes through ``git ls-files``, never a
+  filesystem walk. Compiled bytecode caches embed their module's string literals
+  verbatim, so a stale cache produces a phantom match that is unreproducible in a
+  fresh checkout (#2807).
+- **No positional exemptions.** This guard has no exemption set at all. It does not
+  need one: it matches on AST shape, so its own source — which necessarily names the
+  hub as a string — is structurally invisible to it.
+"""
+
+import ast
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HUB_MODULE = "agent.agent_session_queue"
+HUB_PATH = "agent/agent_session_queue.py"
+
+# Nodes that open a new name-binding scope. A binding made inside one of these
+# shadows the enclosing scope's binding of the same name, which matters here:
+# test files routinely rebind a short alias like `q` to a different module in each
+# test function, so a module-wide alias table would report false positives.
+_SCOPE_NODES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).parent.parent.parent
+
+
+def _tracked_python_files() -> list[str]:
+    """Tracked ``*.py`` paths, via git. Never walks the filesystem."""
+    result = subprocess.run(
+        ["git", "ls-files", "*.py"],
+        cwd=_repo_root(),
+        capture_output=True,
+        text=True,
+    )
+    # An empty match set is signalled by exit status, not by a printed count, so a
+    # broken invocation must never read as "nothing found".
+    assert result.returncode == 0, f"git ls-files failed: {result.stderr.strip()}"
+    files = result.stdout.split()
+    assert files, "git ls-files returned no Python files — invocation is broken"
+    return files
+
+
+def _hub_reexports() -> set[str]:
+    """Names the hub imports and never references in its own body.
+
+    This is the plan's Finding 1 definition of a *pure re-export*, and the
+    distinction is load-bearing rather than pedantic. A name the hub actually uses
+    is a working import: it survives phase 5, and reaching it through the alias
+    resolves to the same object the hub itself resolves. A name the hub never
+    touches exists solely to be re-exported — that is the one that disappears at
+    phase 5, and the one whose write-through rebinds a copy nothing reads.
+
+    ``agent.session_state`` (bound as ``_session_state``) shows why the narrower
+    rule is the correct one: the hub uses it, and it is a *module object*, so an
+    alias reaching through it sees live attributes rather than an import-time copy.
+    A rule keyed only on "imported but not defined here" would flag it and every
+    other working import, and a guard that fires on safe code is one people learn
+    to route around.
+
+    Derived, not pinned: no name list to fall out of date as the hub changes.
+    """
+    tree = ast.parse((_repo_root() / HUB_PATH).read_text(encoding="utf-8"))
+
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported.add(alias.asname or alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                imported.add(alias.asname or alias.name)
+
+    # Every Name load in the hub outside its own import statements.
+    referenced: set[str] = set()
+
+    class _Referenced(ast.NodeVisitor):
+        def visit_Import(self, node):  # noqa: N802 - visitor protocol
+            pass
+
+        def visit_ImportFrom(self, node):  # noqa: N802 - visitor protocol
+            pass
+
+        def visit_Name(self, node):  # noqa: N802 - visitor protocol
+            referenced.add(node.id)
+
+    _Referenced().visit(tree)
+    return imported - referenced
+
+
+def _scope_bindings(node: ast.AST) -> dict[str, str]:
+    """``{bound_name: dotted_module}`` for imports directly in this scope."""
+    bindings: dict[str, str] = {}
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, _SCOPE_NODES):
+            continue  # a nested scope owns its own bindings
+        for sub in ast.walk(child):
+            if isinstance(sub, ast.Import):
+                for alias in sub.names:
+                    bindings[alias.asname or alias.name.split(".")[0]] = alias.name
+            elif isinstance(sub, ast.ImportFrom) and sub.module:
+                for alias in sub.names:
+                    bindings[alias.asname or alias.name] = f"{sub.module}.{alias.name}"
+    return bindings
+
+
+def _alias_hits(node: ast.AST, inherited: dict[str, str], reexports: set[str]) -> list[tuple]:
+    """Walk scopes innermost-first so a rebound alias shadows the outer binding."""
+    env = {**inherited, **_scope_bindings(node)}
+    hits: list[tuple] = []
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, _SCOPE_NODES):
+            hits.extend(_alias_hits(child, env, reexports))
+            continue
+        for sub in ast.walk(child):
+            if isinstance(sub, _SCOPE_NODES):
+                hits.extend(_alias_hits(sub, env, reexports))
+            elif (
+                isinstance(sub, ast.Attribute)
+                and isinstance(sub.value, ast.Name)
+                and env.get(sub.value.id) == HUB_MODULE
+                and sub.attr in reexports
+            ):
+                hits.append((sub.lineno, sub.value.id, sub.attr, type(sub.ctx).__name__))
+    return hits
+
+
+def find_hub_alias_reexport_references() -> dict[str, list[tuple]]:
+    """Every tracked-Python site reaching a hub re-export through a module alias."""
+    reexports = _hub_reexports()
+    root = _repo_root()
+    found: dict[str, list[tuple]] = {}
+    for rel in _tracked_python_files():
+        if rel == HUB_PATH:
+            continue  # the hub's own body legitimately uses what it imports
+        try:
+            tree = ast.parse((root / rel).read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError, OSError):
+            continue
+        hits = sorted(set(_alias_hits(tree, {}, reexports)))
+        if hits:
+            found[rel] = hits
+    return found
+
+
+def test_hub_reexport_set_is_derivable_and_non_empty():
+    """The hazard set must actually resolve, or the main check passes vacuously.
+
+    Until phase 5 lands, the hub still carries re-exports, so this is non-empty.
+    Phase 5 empties it by deleting them — at which point this assertion is the one
+    that must be updated, deliberately, in the same diff that does the deleting.
+    """
+    reexports = _hub_reexports()
+    assert reexports, (
+        "No pure re-exports derived from the hub. Either phase 5 has landed (in "
+        "which case update this test alongside it) or the AST derivation is broken."
+    )
+    # A symbol the hub defines itself is not a re-export.
+    assert "_push_agent_session" not in reexports
+    # Nor is one the hub imports and actually uses — see _hub_reexports' docstring.
+    assert "AgentSession" not in reexports
+    assert "_session_state" not in reexports
+
+
+def test_no_module_alias_reaches_a_hub_reexport():
+    """No tracked Python may reach a hub re-export through a module alias."""
+    found = find_hub_alias_reexport_references()
+    if found:
+        detail = "\n".join(
+            f"  {path}\n"
+            + "\n".join(f"    L{ln}  {alias}.{attr}  [{ctx}]" for ln, alias, attr, ctx in hits)
+            for path, hits in sorted(found.items())
+        )
+        pytest.fail(
+            "Module-alias access to a symbol the hub only re-exports:\n"
+            f"{detail}\n\n"
+            "Reach the symbol through the module that owns it. Reading through the "
+            "hub alias breaks when the re-export is deleted; writing through it "
+            "rebinds an import-time copy that nothing reads."
+        )

--- a/tests/unit/test_hub_alias_references.py
+++ b/tests/unit/test_hub_alias_references.py
@@ -120,40 +120,94 @@ def _hub_reexports() -> set[str]:
     return imported - referenced
 
 
-def _scope_bindings(node: ast.AST) -> dict[str, str]:
-    """``{bound_name: dotted_module}`` for imports directly in this scope."""
-    bindings: dict[str, str] = {}
+def _own_scope_nodes(node: ast.AST):
+    """Descendants belonging to ``node``'s own scope, not descending into nested ones.
+
+    Both the binding pass and the reference pass go through this one helper, which
+    is what makes the walk order-independent. Reaching for ``ast.walk`` here instead
+    descends into a ``FunctionDef`` nested under an ``if`` / ``with`` / ``try``, so
+    that function's bindings leak outward and its references get evaluated against
+    the enclosing scope's aliases — a verdict that then flips with source ordering,
+    in both the false-negative and false-positive directions.
+    """
     for child in ast.iter_child_nodes(node):
         if isinstance(child, _SCOPE_NODES):
             continue  # a nested scope owns its own bindings
-        for sub in ast.walk(child):
-            if isinstance(sub, ast.Import):
-                for alias in sub.names:
-                    bindings[alias.asname or alias.name.split(".")[0]] = alias.name
-            elif isinstance(sub, ast.ImportFrom) and sub.module:
-                for alias in sub.names:
-                    bindings[alias.asname or alias.name] = f"{sub.module}.{alias.name}"
+        yield child
+        yield from _own_scope_nodes(child)
+
+
+def _nested_scopes(node: ast.AST):
+    """Scope nodes directly owned by ``node``, at any statement depth beneath it."""
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, _SCOPE_NODES):
+            yield child
+        else:
+            yield from _nested_scopes(child)
+
+
+def _scope_bindings(node: ast.AST) -> dict[str, str]:
+    """``{bound_name: dotted_path}`` for imports in this scope.
+
+    ``import a.b.c`` binds only ``a``, so the name maps to ``a`` — not to ``a.b.c``,
+    which is a different module and would make the fully-dotted access form resolve
+    against the wrong entry.
+    """
+    bindings: dict[str, str] = {}
+    for sub in _own_scope_nodes(node):
+        if isinstance(sub, ast.Import):
+            for alias in sub.names:
+                if alias.asname:
+                    bindings[alias.asname] = alias.name
+                else:
+                    top = alias.name.split(".")[0]
+                    bindings[top] = top
+        elif isinstance(sub, ast.ImportFrom) and sub.module:
+            for alias in sub.names:
+                bindings[alias.asname or alias.name] = f"{sub.module}.{alias.name}"
     return bindings
 
 
+def _resolve_dotted(node: ast.AST, env: dict[str, str]) -> str | None:
+    """Resolve an expression to the dotted path it names, or ``None``.
+
+    Handles every binding form that can reach the hub: ``import ... as asq`` then
+    ``asq.X``; ``from agent import agent_session_queue as q`` then ``q.X``; and the
+    bare ``import agent.agent_session_queue`` then fully-dotted
+    ``agent.agent_session_queue.X``, which parses as an Attribute *of an Attribute*
+    and is invisible to a matcher keyed on ``Name`` alone.
+    """
+    parts: list[str] = []
+    current = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if not isinstance(current, ast.Name):
+        return None
+    base = env.get(current.id)
+    if base is None:
+        return None
+    parts.reverse()
+    return ".".join([base, *parts])
+
+
 def _alias_hits(node: ast.AST, inherited: dict[str, str], reexports: set[str]) -> list[tuple]:
-    """Walk scopes innermost-first so a rebound alias shadows the outer binding."""
+    """Collect hits in this scope, then recurse into nested scopes with its env.
+
+    Bindings for the whole scope are gathered before any reference is evaluated, so
+    a hit does not depend on whether the import happens to sit above or below it.
+    """
     env = {**inherited, **_scope_bindings(node)}
     hits: list[tuple] = []
-    for child in ast.iter_child_nodes(node):
-        if isinstance(child, _SCOPE_NODES):
-            hits.extend(_alias_hits(child, env, reexports))
-            continue
-        for sub in ast.walk(child):
-            if isinstance(sub, _SCOPE_NODES):
-                hits.extend(_alias_hits(sub, env, reexports))
-            elif (
-                isinstance(sub, ast.Attribute)
-                and isinstance(sub.value, ast.Name)
-                and env.get(sub.value.id) == HUB_MODULE
-                and sub.attr in reexports
-            ):
-                hits.append((sub.lineno, sub.value.id, sub.attr, type(sub.ctx).__name__))
+    for sub in _own_scope_nodes(node):
+        if (
+            isinstance(sub, ast.Attribute)
+            and sub.attr in reexports
+            and _resolve_dotted(sub.value, env) == HUB_MODULE
+        ):
+            hits.append((sub.lineno, ast.unparse(sub.value), sub.attr, type(sub.ctx).__name__))
+    for scope in _nested_scopes(node):
+        hits.extend(_alias_hits(scope, env, reexports))
     return hits
 
 
@@ -173,6 +227,80 @@ def find_hub_alias_reexport_references() -> dict[str, list[tuple]]:
         if hits:
             found[rel] = hits
     return found
+
+
+def _analyze(source: str, reexports: set[str]) -> list[tuple]:
+    """Run the analyzer over a source string. Used to test the guard's own machinery."""
+    return sorted(set(_alias_hits(ast.parse(source), {}, reexports)))
+
+
+# The analyzer is the artifact phase 5 leans on, so it carries its own tests. Both
+# cases below are regressions: PR #3048's round-2 review reproduced each as a real
+# defect in the first version of this file.
+
+_REORDER_HIT = """
+import agent.agent_session_queue as q
+q._slot_registry = None
+"""
+
+_REORDER_SHADOW = """
+if True:
+    def inner():
+        from agent import session_state as q
+
+        return q._slot_registry
+"""
+
+
+def test_scope_walk_does_not_depend_on_source_ordering():
+    """A nested scope's alias must not leak out, in either order.
+
+    The first version walked non-scope children with ``ast.walk``, which descends
+    into a function nested under an ``if``. That made the verdict depend on which
+    block came first: hub-import-first hid a real hit, ``if``-first reported a
+    perfectly safe ``agent.session_state`` line as a violation.
+    """
+    reexports = {"_slot_registry"}
+
+    hit_first = _analyze(_REORDER_HIT + _REORDER_SHADOW, reexports)
+    shadow_first = _analyze(_REORDER_SHADOW + _REORDER_HIT, reexports)
+
+    assert [(a, s, c) for _, a, s, c in hit_first] == [("q", "_slot_registry", "Store")]
+    assert [(a, s, c) for _, a, s, c in shadow_first] == [("q", "_slot_registry", "Store")]
+
+    # The shadowed inner read of agent.session_state is safe and must never appear,
+    # and the real hub write must never disappear — whichever block is written first.
+    assert len(hit_first) == len(shadow_first) == 1
+
+
+def test_bare_dotted_import_form_is_detected():
+    """``import agent.agent_session_queue`` + fully-dotted access is Attribute-of-Attribute.
+
+    A matcher keyed on ``Attribute.value`` being a ``Name`` never sees this form.
+    """
+    source = """
+import agent.agent_session_queue
+
+agent.agent_session_queue._slot_registry = None
+print(agent.agent_session_queue.steer_session)
+"""
+    hits = _analyze(source, {"_slot_registry", "steer_session"})
+    assert [(a, s) for _, a, s, _ in hits] == [
+        ("agent.agent_session_queue", "_slot_registry"),
+        ("agent.agent_session_queue", "steer_session"),
+    ]
+
+
+def test_working_imports_are_not_flagged():
+    """Reaching a module the hub genuinely uses is safe and must stay silent."""
+    source = """
+import agent.agent_session_queue as asq
+
+asq._session_state._slot_registry = None
+print(asq.AgentSession)
+"""
+    # `_session_state` and `AgentSession` are hub-used, so they are not re-exports.
+    assert _analyze(source, {"_slot_registry", "steer_session"}) == []
 
 
 def test_hub_reexport_set_is_derivable_and_non_empty():

--- a/tests/unit/test_nudge_loop.py
+++ b/tests/unit/test_nudge_loop.py
@@ -4,7 +4,7 @@ Tests the send_to_chat nudge behavior: completion detection, rate-limit
 backoff, max nudge safety cap, and empty output handling.
 """
 
-from agent.agent_session_queue import MAX_NUDGE_COUNT, NUDGE_MESSAGE, determine_delivery_action
+from agent.output_router import MAX_NUDGE_COUNT, NUDGE_MESSAGE, determine_delivery_action
 
 
 class TestNudgeConstants:

--- a/tests/unit/test_pipeline_integrity.py
+++ b/tests/unit/test_pipeline_integrity.py
@@ -189,7 +189,7 @@ class TestEnqueueContinuationFallback:
 
     def test_diagnose_missing_session_returns_dict(self):
         """Verify _diagnose_missing_session returns diagnostic info."""
-        from agent.agent_session_queue import _diagnose_missing_session
+        from agent.session_completion import _diagnose_missing_session
 
         result = _diagnose_missing_session("nonexistent-session-id-12345")
         assert isinstance(result, dict)

--- a/tests/unit/test_qa_nudge_cap.py
+++ b/tests/unit/test_qa_nudge_cap.py
@@ -1,6 +1,6 @@
 """Tests for Teammate reduced nudge cap in the nudge loop."""
 
-from agent.agent_session_queue import MAX_NUDGE_COUNT, determine_delivery_action
+from agent.output_router import MAX_NUDGE_COUNT, determine_delivery_action
 from agent.teammate_handler import TEAMMATE_MAX_NUDGE_COUNT
 
 

--- a/tests/unit/test_recovery_respawn_safety.py
+++ b/tests/unit/test_recovery_respawn_safety.py
@@ -80,7 +80,7 @@ class TestDetermineDeliveryActionTerminalStatuses:
     @pytest.mark.parametrize("terminal_status", sorted(TERMINAL_STATUSES))
     def test_terminal_status_returns_already_completed(self, terminal_status):
         """Each terminal status should return deliver_already_completed."""
-        from agent.agent_session_queue import determine_delivery_action
+        from agent.output_router import determine_delivery_action
 
         action = determine_delivery_action(
             msg="some output",
@@ -96,7 +96,7 @@ class TestDetermineDeliveryActionTerminalStatuses:
 
     def test_non_terminal_does_not_return_already_completed(self):
         """Non-terminal statuses should NOT return deliver_already_completed."""
-        from agent.agent_session_queue import determine_delivery_action
+        from agent.output_router import determine_delivery_action
 
         action = determine_delivery_action(
             msg="some output",
@@ -115,7 +115,7 @@ class TestEnqueueNudgeTerminalGuard:
     @pytest.mark.parametrize("terminal_status", sorted(TERMINAL_STATUSES))
     async def test_nudge_main_path_skips_terminal(self, terminal_status):
         """_enqueue_nudge() entry guard blocks terminal sessions from being nudged."""
-        from agent.agent_session_queue import _enqueue_nudge
+        from agent.session_executor import _enqueue_nudge
 
         session = _mock_agent_session(status=terminal_status)
 
@@ -137,14 +137,14 @@ class TestEnqueueNudgeTerminalGuard:
     @pytest.mark.asyncio
     async def test_nudge_fallback_path_skips_terminal(self):
         """_enqueue_nudge() fallback path blocks terminal sessions from async_create."""
-        from agent.agent_session_queue import _enqueue_nudge
+        from agent.session_executor import _enqueue_nudge
 
         # Session is completed but Redis returns empty (triggering fallback path)
         session = _mock_agent_session(status="completed")
 
         with (
             patch("agent.agent_session_queue.AgentSession") as mock_as,
-            patch("agent.agent_session_queue._diagnose_missing_session", return_value="diag"),
+            patch("agent.session_executor._diagnose_missing_session", return_value="diag"),
             patch(
                 "agent.agent_session_queue.continuation_agent_session_fields",
                 return_value={},
@@ -166,7 +166,7 @@ class TestEnqueueNudgeTerminalGuard:
     @pytest.mark.asyncio
     async def test_nudge_reread_guard_catches_late_terminal(self):
         """Main path re-read guard catches session that became terminal after entry check."""
-        from agent.agent_session_queue import _enqueue_nudge
+        from agent.session_executor import _enqueue_nudge
 
         # Session starts as "running" (passes entry guard) but Redis returns
         # a version that is now "completed" (another process finalized it).
@@ -194,7 +194,7 @@ class TestCheckRevivalTerminalFilter:
 
     def test_revival_skips_completed_session_branch(self):
         """check_revival() returns None when all candidate branches have terminal siblings."""
-        from agent.agent_session_queue import check_revival
+        from agent.session_revival import check_revival
 
         pending_session = _mock_agent_session(
             session_id="chat-123-msg-1", status="pending", chat_id="12345"
@@ -229,7 +229,7 @@ class TestCheckRevivalTerminalFilter:
 
     def test_revival_passes_non_terminal_branches(self):
         """check_revival() returns revival info for branches without terminal siblings."""
-        from agent.agent_session_queue import check_revival
+        from agent.session_revival import check_revival
 
         pending_session = _mock_agent_session(
             session_id="chat-123-msg-2", status="pending", chat_id="12345"
@@ -318,7 +318,7 @@ class TestStartupRecoverySkipsTerminal:
         Also asserts that local sessions in the stale set are abandoned (not re-queued),
         and that bridge sessions are recovered.
         """
-        from agent.agent_session_queue import _recover_interrupted_agent_sessions_startup
+        from agent.session_health import _recover_interrupted_agent_sessions_startup
 
         # The function queries AgentSession.query.filter(status="running").
         # Terminal sessions are never queried, so they cannot be recovered.
@@ -334,7 +334,7 @@ class TestStartupRecoverySkipsTerminal:
         """Startup recovery does not call update_session('pending') for local teammate sessions."""
         import time
 
-        from agent.agent_session_queue import (
+        from agent.session_health import (
             AGENT_SESSION_HEALTH_MIN_RUNNING,
             _recover_interrupted_agent_sessions_startup,
         )
@@ -367,7 +367,7 @@ class TestStartupRecoverySkipsTerminal:
         """Startup recovery calls update_session('pending') for local eng sessions (#1092)."""
         import time
 
-        from agent.agent_session_queue import (
+        from agent.session_health import (
             AGENT_SESSION_HEALTH_MIN_RUNNING,
             _recover_interrupted_agent_sessions_startup,
         )
@@ -409,7 +409,7 @@ class TestStartupRecoveryLocalSessionGuard:
         """Create a mock session that is old enough to be considered stale."""
         import time
 
-        from agent.agent_session_queue import AGENT_SESSION_HEALTH_MIN_RUNNING
+        from agent.session_health import AGENT_SESSION_HEALTH_MIN_RUNNING
 
         defaults = dict(
             session_id="test-session",
@@ -425,7 +425,7 @@ class TestStartupRecoveryLocalSessionGuard:
         """Local non-ENG session (session_id starts with 'local') is finalized as 'abandoned'."""
         import time
 
-        from agent.agent_session_queue import _recover_interrupted_agent_sessions_startup
+        from agent.session_health import _recover_interrupted_agent_sessions_startup
 
         local_session = self._stale_session(
             session_id="local-abc123",
@@ -463,7 +463,7 @@ class TestStartupRecoveryLocalSessionGuard:
         """
         import time
 
-        from agent.agent_session_queue import _recover_interrupted_agent_sessions_startup
+        from agent.session_health import _recover_interrupted_agent_sessions_startup
 
         local_session = self._stale_session(
             session_id="local-teammate-abc",
@@ -496,7 +496,7 @@ class TestStartupRecoveryLocalSessionGuard:
         """
         import time
 
-        from agent.agent_session_queue import _recover_interrupted_agent_sessions_startup
+        from agent.session_health import _recover_interrupted_agent_sessions_startup
 
         local_session = self._stale_session(
             session_id="local-dev-abc",
@@ -534,7 +534,7 @@ class TestStartupRecoveryLocalSessionGuard:
         """
         import time
 
-        from agent.agent_session_queue import _recover_interrupted_agent_sessions_startup
+        from agent.session_health import _recover_interrupted_agent_sessions_startup
 
         local_session = self._stale_session(
             session_id="local-legacy-abc",
@@ -565,7 +565,7 @@ class TestStartupRecoveryLocalSessionGuard:
         """Bridge session (session_id does NOT start with 'local') is reset to pending."""
         import time
 
-        from agent.agent_session_queue import _recover_interrupted_agent_sessions_startup
+        from agent.session_health import _recover_interrupted_agent_sessions_startup
 
         bridge_session = self._stale_session(
             session_id="tg-xyz789",
@@ -596,7 +596,7 @@ class TestStartupRecoveryLocalSessionGuard:
         """
         import time
 
-        from agent.agent_session_queue import _recover_interrupted_agent_sessions_startup
+        from agent.session_health import _recover_interrupted_agent_sessions_startup
 
         local_pm_session = self._stale_session(
             session_id="local-pm-abc",
@@ -664,7 +664,7 @@ class TestStartupRecoveryLedgerGuard:
     def _stale_ledger_session(self, **kwargs):
         import time
 
-        from agent.agent_session_queue import AGENT_SESSION_HEALTH_MIN_RUNNING
+        from agent.session_health import AGENT_SESSION_HEALTH_MIN_RUNNING
 
         defaults = dict(
             session_id="sdlc-local-9042",
@@ -685,7 +685,7 @@ class TestStartupRecoveryLedgerGuard:
         call, and it does not count toward the recovered total."""
         import time
 
-        from agent.agent_session_queue import _recover_interrupted_agent_sessions_startup
+        from agent.session_health import _recover_interrupted_agent_sessions_startup
 
         ledger_session = self._stale_ledger_session()
 
@@ -715,7 +715,7 @@ class TestStartupRecoveryLedgerGuard:
         decision), not something the guard needs to dedup."""
         import time
 
-        from agent.agent_session_queue import _recover_interrupted_agent_sessions_startup
+        from agent.session_health import _recover_interrupted_agent_sessions_startup
 
         dup_a = self._stale_ledger_session(agent_session_id="agent-ledger-dup-a")
         dup_b = self._stale_ledger_session(agent_session_id="agent-ledger-dup-b")
@@ -793,7 +793,7 @@ class TestSessionWatchdogSafe:
 
     def test_watchdog_unhealthy_flag_routes_to_deliver(self):
         """Watchdog sets unhealthy flag which routes to deliver, not nudge."""
-        from agent.agent_session_queue import determine_delivery_action
+        from agent.output_router import determine_delivery_action
 
         action = determine_delivery_action(
             msg="some output",
@@ -924,7 +924,7 @@ class TestStartupRecoveryOwnershipGuard:
     def _run_recovery(self, sessions):
         import time
 
-        from agent.agent_session_queue import _recover_interrupted_agent_sessions_startup
+        from agent.session_health import _recover_interrupted_agent_sessions_startup
 
         with (
             patch("agent.session_health.AgentSession") as mock_as,
@@ -965,7 +965,7 @@ class TestStartupRecoveryOwnershipGuard:
     def test_stale_legacy_session_without_stamp_still_recovered(self):
         import time
 
-        from agent.agent_session_queue import AGENT_SESSION_HEALTH_MIN_RUNNING
+        from agent.session_health import AGENT_SESSION_HEALTH_MIN_RUNNING
 
         session = self._recent_bridge_session(
             worker_pid=None,

--- a/tests/unit/test_recovery_respawn_safety.py
+++ b/tests/unit/test_recovery_respawn_safety.py
@@ -121,7 +121,7 @@ class TestEnqueueNudgeTerminalGuard:
 
         # If the guard works, it returns early without querying Redis or calling
         # transition_status. We patch AgentSession.query to detect any leak.
-        with patch("agent.agent_session_queue.AgentSession") as mock_as:
+        with patch("agent.session_executor.AgentSession") as mock_as:
             mock_as.query.filter.return_value = []
             await _enqueue_nudge(
                 session=session,
@@ -143,7 +143,7 @@ class TestEnqueueNudgeTerminalGuard:
         session = _mock_agent_session(status="completed")
 
         with (
-            patch("agent.agent_session_queue.AgentSession") as mock_as,
+            patch("agent.session_executor.AgentSession") as mock_as,
             patch("agent.session_executor._diagnose_missing_session", return_value="diag"),
             patch(
                 "agent.agent_session_queue.continuation_agent_session_fields",

--- a/tests/unit/test_recovery_respawn_safety.py
+++ b/tests/unit/test_recovery_respawn_safety.py
@@ -119,10 +119,14 @@ class TestEnqueueNudgeTerminalGuard:
 
         session = _mock_agent_session(status=terminal_status)
 
-        # If the guard works, it returns early without querying Redis or calling
-        # transition_status. We patch AgentSession.query to detect any leak.
+        # If the guard works, _enqueue_nudge returns before reaching the recreate
+        # path. Assert on async_create, as the fallback-path sibling does: with the
+        # query returning empty, a session that got past the guard would fall
+        # through to recreating the record, so this call is the observable
+        # consequence of the guard failing.
         with patch("agent.session_executor.AgentSession") as mock_as:
             mock_as.query.filter.return_value = []
+            mock_as.async_create = MagicMock()
             await _enqueue_nudge(
                 session=session,
                 branch_name="session/test",
@@ -131,8 +135,7 @@ class TestEnqueueNudgeTerminalGuard:
                 output_msg="agent output",
                 nudge_feedback="continue",
             )
-            # Should NOT have queried Redis (guard returns before that)
-            mock_as.query.filter.assert_not_called()
+            mock_as.async_create.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_nudge_fallback_path_skips_terminal(self):

--- a/tests/unit/test_resume_hydration.py
+++ b/tests/unit/test_resume_hydration.py
@@ -92,7 +92,7 @@ class TestMaybeInjectResumeHydration:
 
     def _run(self, session, worker_key="test-worker"):
         """Run the async helper synchronously."""
-        from agent.agent_session_queue import _maybe_inject_resume_hydration
+        from agent.session_pickup import _maybe_inject_resume_hydration
 
         asyncio.run(_maybe_inject_resume_hydration(session, worker_key))
 

--- a/tests/unit/test_steering_mechanism.py
+++ b/tests/unit/test_steering_mechanism.py
@@ -51,7 +51,14 @@ class TestOutputRouterExports:
 
 
 class TestBackwardCompatExports:
-    """Verify symbols are still importable from agent.agent_session_queue for backward compat."""
+    """Verify symbols are still importable from agent.agent_session_queue for backward compat.
+
+    Deliberately retained through phase 4 of issue #2876 as the one exception to
+    that phase's repoint-everything-off-the-hub rule: it is the tripwire that
+    fails loudly when the re-exports go away, rather than letting them go
+    quietly. Phase 5 deletes those re-exports and must delete this class in the
+    same diff — the proposition asserted here is exactly the one phase 5 inverts.
+    """
 
     def test_max_nudge_count_from_queue(self):
         from agent.agent_session_queue import MAX_NUDGE_COUNT

--- a/tests/unit/test_steering_mechanism.py
+++ b/tests/unit/test_steering_mechanism.py
@@ -89,14 +89,14 @@ class TestSteerSessionGuards:
     """Unit tests for steer_session() edge cases (no Redis required)."""
 
     def test_empty_message_rejected(self):
-        from agent.agent_session_queue import steer_session
+        from agent.session_executor import steer_session
 
         result = steer_session("nonexistent-session", "")
         assert result["success"] is False
         assert "Empty message" in result["error"]
 
     def test_whitespace_only_message_rejected(self):
-        from agent.agent_session_queue import steer_session
+        from agent.session_executor import steer_session
 
         result = steer_session("nonexistent-session", "   ")
         assert result["success"] is False
@@ -104,7 +104,7 @@ class TestSteerSessionGuards:
 
     def test_nonexistent_session_returns_error(self):
         """steer_session on a non-existent session returns an error dict."""
-        from agent.agent_session_queue import steer_session
+        from agent.session_executor import steer_session
 
         result = steer_session("definitely-does-not-exist-xyz-123", "hello")
         assert result["success"] is False
@@ -136,14 +136,14 @@ class TestSteerSessionLedgerGuard:
         session.delete()
 
     def test_ledger_session_rejected(self, ledger_session):
-        from agent.agent_session_queue import steer_session
+        from agent.session_executor import steer_session
 
         result = steer_session(ledger_session.session_id, "hello ledger")
         assert result["success"] is False
         assert "ledger" in result["error"].lower()
 
     def test_ledger_rejection_pushes_nothing(self, ledger_session):
-        from agent.agent_session_queue import steer_session
+        from agent.session_executor import steer_session
         from agent.steering import has_steering_messages
 
         steer_session(ledger_session.session_id, "hello ledger")

--- a/tests/unit/test_valor_session_resume_release.py
+++ b/tests/unit/test_valor_session_resume_release.py
@@ -907,7 +907,7 @@ class TestDualIdLookupAcrossSubcommands:
                 "sys.modules",
                 {
                     "models.agent_session": MagicMock(AgentSession=mock_cls),
-                    "agent.agent_session_queue": MagicMock(steer_session=mock_steer),
+                    "agent.session_executor": MagicMock(steer_session=mock_steer),
                 },
             ),
         ):
@@ -931,7 +931,7 @@ class TestDualIdLookupAcrossSubcommands:
                 "sys.modules",
                 {
                     "models.agent_session": MagicMock(AgentSession=mock_cls),
-                    "agent.agent_session_queue": MagicMock(steer_session=mock_steer),
+                    "agent.session_executor": MagicMock(steer_session=mock_steer),
                 },
             ),
         ):

--- a/tests/unit/test_zombie_session_resurrection.py
+++ b/tests/unit/test_zombie_session_resurrection.py
@@ -72,7 +72,7 @@ class TestStartupRecoverySkipsTerminalSessions:
     @patch("agent.agent_session_queue.AgentSession")
     def test_terminal_session_not_recovered(self, mock_cls, terminal_status):
         """Sessions with any terminal hash status should not be recovered."""
-        from agent.agent_session_queue import _recover_interrupted_agent_sessions_startup
+        from agent.session_health import _recover_interrupted_agent_sessions_startup
 
         zombie = _make_session(
             status=terminal_status,
@@ -87,7 +87,7 @@ class TestStartupRecoverySkipsTerminalSessions:
     @patch("agent.session_health.AgentSession")
     def test_legitimate_running_session_still_recovered(self, mock_cls, mock_update):
         """A truly running session (non-terminal) should still be recovered."""
-        from agent.agent_session_queue import _recover_interrupted_agent_sessions_startup
+        from agent.session_health import _recover_interrupted_agent_sessions_startup
 
         legit = _make_session(status="running", session_id="tg_proj_chat_legit")
         mock_cls.query.filter.return_value = [legit]
@@ -100,7 +100,7 @@ class TestStartupRecoverySkipsTerminalSessions:
     @patch("agent.session_health.AgentSession")
     def test_mixed_terminal_and_running_only_recovers_running(self, mock_cls, mock_update):
         """When both zombie and legitimate sessions exist, only the running one is recovered."""
-        from agent.agent_session_queue import _recover_interrupted_agent_sessions_startup
+        from agent.session_health import _recover_interrupted_agent_sessions_startup
 
         zombie = _make_session(
             agent_session_id="zombie-1",
@@ -134,7 +134,7 @@ class TestHealthCheckSkipsTerminalSessions:
     @patch("agent.agent_session_queue.AgentSession")
     async def test_terminal_session_not_recovered_by_health_check(self, mock_cls, terminal_status):
         """Health check should skip a terminal session found in running index."""
-        from agent.agent_session_queue import _agent_session_health_check
+        from agent.session_health import _agent_session_health_check
 
         zombie = _make_session(
             status=terminal_status,

--- a/tests/unit/test_zombie_session_resurrection.py
+++ b/tests/unit/test_zombie_session_resurrection.py
@@ -69,7 +69,7 @@ class TestStartupRecoverySkipsTerminalSessions:
     """Startup recovery must skip sessions whose hash status is terminal."""
 
     @pytest.mark.parametrize("terminal_status", sorted(TERMINAL_STATUSES))
-    @patch("agent.agent_session_queue.AgentSession")
+    @patch("agent.session_health.AgentSession")
     def test_terminal_session_not_recovered(self, mock_cls, terminal_status):
         """Sessions with any terminal hash status should not be recovered."""
         from agent.session_health import _recover_interrupted_agent_sessions_startup
@@ -131,7 +131,7 @@ class TestHealthCheckSkipsTerminalSessions:
     @pytest.mark.asyncio
     @patch("agent.agent_session_queue._active_workers", {})
     @patch("agent.agent_session_queue._active_events", {})
-    @patch("agent.agent_session_queue.AgentSession")
+    @patch("agent.session_health.AgentSession")
     async def test_terminal_session_not_recovered_by_health_check(self, mock_cls, terminal_status):
         """Health check should skip a terminal session found in running index."""
         from agent.session_health import _agent_session_health_check


### PR DESCRIPTION
Phase 4 of 5 for #2876. Repoints test-side references off the `agent/agent_session_queue.py` re-export hub and onto the modules that own each symbol, so phase 5 can delete the re-exports without breaking the suite.

Touches test files only — no production file is modified. Verify with:

```
git diff --name-only $(git merge-base HEAD origin/main) HEAD | grep -v '^tests/'
```

## What a "mover" is

A symbol is a **pure re-export** when the hub imports it and never references it in its own body. Those are exactly what phase 5 deletes, so those are what this phase repoints. Symbols the hub actually uses — `AgentSession`, `_session_state`, `_pop_agent_session`, `_ensure_worker` — are working imports that survive phase 5 and are deliberately left alone.

The set is derived, never pinned. `tests/unit/test_hub_alias_references.py::_hub_reexports` computes it from the hub's AST; `len(_hub_reexports())` matches the plan's Finding 1.

## Reference classes swept

The plan asks each phase to re-run detection across every class by which a symbol can be reached. This phase covers:

1. **`from agent.agent_session_queue import X`** — the import class.
2. **Patch-target strings** — `patch("agent.agent_session_queue.X")`.
3. **Module-alias attribute access** — `<alias>.X`. **This class was missed in the first round** and was caught in review; see below.
4. **`sys.modules` injection** — a fake module registered under the hub's name.
5. **Untracked vault config** — `reflections.yaml` callables, closed by phase 2.

## The module-alias class, and the guard for it

Review found the original sweep matched the import class but not attribute access through a module alias. Those sites fail two different ways:

- **They break at phase 5.** `<alias>.<re-export>` becomes `AttributeError`.
- **Writes through them are already vacuous.** `from X import y` binds a *copy* onto the importing module at import time, so `<alias>.y = z` rebinds a copy the owning module and its readers never consult.

`tests/integration/test_worker_concurrency.py` held the majority, and they were the second kind: the concurrency ceiling those tests exist to verify was never actually installed. The file already contained its own counter-example — sibling tests reaching `agent.session_state` directly, under a comment explaining why the hub alias is the wrong seam. The hub alias existed there solely to reach `_slot_registry`, so it is replaced outright and the rationale hoisted to the module docstring, where it governs every test rather than the one that happened to hit the bug.

`tests/unit/test_hub_alias_references.py` adds the sweep to the phase's verification so **phase 5 cannot inherit the blind spot**. It is scope-aware: test files routinely rebind a short alias like `q` to a different module per test function, and a module-wide alias table reports false positives on exactly that shape.

An earlier draft of the guard keyed on "imported but not defined here" and flagged `asq._session_state` and `asq.AgentSession`. Both are safe — the hub uses them, and a *module object* reached through an alias exposes live attributes rather than an import-time copy. The narrower Finding-1 rule is the correct one; a guard that fires on safe code is one people learn to route around.

Deriving rather than pinning also keeps it honest through phase 5: when the re-exports go away the derived set empties, and the companion check fails rather than passing vacuously.

### The guard audits itself

Round-2 review found two gaps in the guard's first version. Both are closed, and both are now pinned by tests of the analyzer's own machinery — a guard phase 5 will lean on should not rest on a single reading of its walk.

- **Scope walk.** The first version reached for `ast.walk` on every non-scope child, which descends into a function nested under an `if` / `with` / `try`. That function's bindings leaked outward and its references were evaluated against the enclosing scope, so the verdict flipped on **source ordering** — hiding a real hit in one arrangement and reporting a safe `agent.session_state` line as a violation in the other. Both passes now share one `_own_scope_nodes` helper that stops at scope boundaries, and a scope's bindings are gathered before any reference in it is evaluated, which is what removes the ordering dependence.
- **Bare dotted imports.** Matching `Attribute.value` against `Name` alone never saw `import agent.agent_session_queue` followed by fully-dotted access, which parses as Attribute-of-Attribute. `_resolve_dotted` flattens the chain so every binding form resolves through one path. Relatedly, `import a.b.c` binds only `a`, so it now maps to `a` rather than to `a.b.c` — the wrong module for that name.

### Demonstrated red, per check, each alone

| Check | Injected fault | Result |
|-------|----------------|--------|
| `test_no_module_alias_reaches_a_hub_reexport` | restored `from agent import agent_session_queue as q` at `test_health_check_recovery_finalization.py:952` | `1 failed, 1 passed` — named that exact site |
| `test_hub_reexport_set_is_derivable_and_non_empty` | `HUB_PATH` pointed at a hub with the re-exports pruned (simulated post-phase-5) | `1 failed, 1 passed` |
| `test_scope_walk_does_not_depend_on_source_ordering` | previous implementation restored | failed with the reported symptom (`[]`), siblings green |
| `test_bare_dotted_import_form_is_detected` | previous implementation restored | failed with the reported symptom (`[]`), siblings green |

Each fired alone with its siblings green, so none is passing as part of a batch.

## Vacuous patch targets fixed

Same root cause, lower stakes — patching a name on the hub that the code under test resolves from its own module:

- `test_recovery_respawn_safety.py` — `_enqueue_nudge` resolves `AgentSession` from `agent/session_executor.py`. The sibling `continuation_agent_session_fields` patch is hub-defined and correctly retained.

  The main-path terminal test was vacuous a *second* way, unrelated to the hub: it asserted `query.filter.assert_not_called()`, but `_enqueue_nudge` never calls `AgentSession.query`, so it asserted against a call that cannot happen and stayed green with the guard removed. It now asserts on `async_create`, as the fallback-path sibling does — with the query returning empty, a session past the guard falls through to recreating the record. Demonstrated red by disabling both terminal guards in `session_executor.py`, which turns the test red where it previously passed.
- `test_zombie_session_resurrection.py` — functions under test live in `session_health`, where in-file siblings already patch correctly.
- `test_silent_failures.py` — `check_revival` emits under `agent.session_revival`, not the hub. The caplog site exercising `_push_agent_session` is left alone: the hub defines that one.

## Reconciling the plan's patch-string count

Plan Finding 3 tables 11 breaking patch-target strings; the real merge-base set in `tests/` is **3**, all fixed here. The other 8 are not patch targets at all, and a phase-5 reader checking the plan's acceptance criterion would otherwise see 3-of-11 and suspect misses:

- `_agent_session_health_check` — its only site is a *docstring example* in `agent/reflection_scheduler.py`.
- `steer_session`, `_write_worker_heartbeat` — zero `.py` sites.
- `cleanup_stale_branches_all_projects` — a legacy migration-map key in `tests/unit/test_migrate_reflections_callables.py` that must be **retained**, since the migration script has to keep recognizing the old dotted path.

The `_pop_agent_session` prediction that did not survive is likewise a non-mover: the hub uses it.

## Deliberately retained

`TestBackwardCompatExports` in `tests/unit/test_steering_mechanism.py` is the one class exempt from this phase's rule. It asserts the re-exports are still importable, which is the proposition phase 5 inverts — so it is a tripwire that fails loudly at phase 5 rather than letting the deletion pass quietly. It now carries a comment recording that, and that phase 5 must delete it in the same diff. Every remaining hub import of a pure re-export in `tests/` lives in this class.

## Also fixed: a phase-3 regression that left `main` red

`tests/unit/test_valor_session_resume_release.py` injected a fake module into `sys.modules` under the hub's name, but phase 3 repointed `tools/valor_session.py` to `agent.session_executor`, so the fake was no longer consulted and the real function ran. This fails identically on the merge base — it is not this PR's damage — but phase 4 is the test-side phase for exactly this class of phase-3 fallout, so it is fixed here rather than deferred past phase 5's gate. A `sys.modules` key is a reference the import-statement and patch-string sweeps both miss.

## Concurrency-test hygiene

Now that `test_worker_concurrency.py`'s registries are live rather than vacuous, two follow-through changes:

- Each `finally` cancels its in-flight worker tasks **before** restoring the slot registry, so a still-running task cannot acquire against the restored value.
- The ceilings that are headroom rather than assertions are marked as such. Their test subjects are serialization and worktree parallelism, not the cap; the genuine ceiling coverage lives in the two tests that already reached for `agent.session_state` directly.

## Deferred deliberately

`_active_workers` / `_active_events` are patched on the hub in `test_zombie_session_resurrection.py` while `agent/session_health.py` binds both from `agent.session_state`, so those patches cannot reach the function under test. Both are **non-movers** — the hub uses them, so they survive phase 5 and this guard rightly ignores them. That makes it a live coverage gap rather than a phase-4 or phase-5 hazard, and it is filed as **#3055** with the falsification transcript, rather than widened into this PR.

## Verification

```
python -m ruff check . && python -m ruff format --check .
python -c "import agent, worker.__main__, tools.valor_session, tools.agent_session_scheduler, bridge.telegram_bridge"
scripts/pytest-clean.sh tests/unit/test_hub_alias_references.py -n0
```

Plan rows marked `[P5]` remain red by design; they are phase 5's to close.

Closes #3047
Refs #2876
