### PR TITLE
fix(memory): PostToolUse recall silently discarded by malformed output shape

### DIFF
--- a/.claude/hooks/post_tool_use.py
+++ b/.claude/hooks/post_tool_use.py
@@ -51,13 +51,15 @@ QUALITY_COMMANDS = ("pytest", "ruff", "ruff-format")
 # common paths early-exit (or bump the recall counter) WITHOUT importing the
 # popoto-heavy module; the genuinely heavy branches still import lazily.
 #
-# ``_RECALL_WINDOW_SIZE`` / ``_RECALL_BUFFER_SIZE`` MUST stay in sync with
-# ``hook_utils.memory_bridge.WINDOW_SIZE`` / ``BUFFER_SIZE`` — they are
-# duplicated here only so the counter-only fast path can mirror recall()'s
-# non-query branch byte-for-byte. recall() remains the source of truth; the
-# WINDOW_SIZE-th call delegates to it for the real BM25/bloom work.
+# ``_RECALL_BUFFER_SIZE`` MUST stay in sync with
+# ``hook_utils.memory_bridge.BUFFER_SIZE`` — it is duplicated here only so the
+# counter-only path can mirror recall()'s non-query branch byte-for-byte.
+#
+# This hook no longer delegates to recall() on the WINDOW_SIZE-th call, because
+# PostToolUse has no injection channel to deliver its output — see
+# _run_memory_recall(). The window constant is therefore gone from this file;
+# memory_bridge.WINDOW_SIZE remains the source of truth for recall() itself.
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
-_RECALL_WINDOW_SIZE = 3
 _RECALL_BUFFER_SIZE = 9
 
 
@@ -361,41 +363,62 @@ def check_file_reminders(hook_input: dict) -> None:
             print(reminder)
 
 
-def _run_memory_recall(hook_input: dict) -> str | None:
-    """Run memory recall and return additionalContext string or None.
+def _run_memory_recall(hook_input: dict) -> None:
+    """Advance the recall sliding window. Never injects, by design.
 
-    Queries subconscious memory based on accumulated tool calls.
+    PostToolUse has no context-injection channel. The harness contract
+    supports ``hookSpecificOutput.additionalContext`` on UserPromptSubmit,
+    UserPromptExpansion, and SessionStart only; PostToolUse output carries
+    ``systemMessage`` but not ``additionalContext``, and a bare top-level
+    ``{"additionalContext": ...}`` (what this hook used to print) is not a
+    supported shape on any event.
+
+    Measured before this change, over 8 recent sessions: every delivered
+    ``<thought>`` stub arrived in a ``hook_additional_context`` attachment
+    parented to a *user* record -- i.e. from ``prefetch()`` on
+    UserPromptSubmit. Not one arrived after a ``tool_result``, which is
+    where a PostToolUse injection would land. Session
+    ``eefc78b8`` recorded **181** entries in its sidecar ``injected[]``
+    while delivering **3** stubs to the model.
+
+    That gap was not merely wasted work. ``recall()`` extends the sidecar's
+    ``injected[]`` and calls ``record.confirm_access()`` on every record it
+    formats, so each undelivered batch:
+
+    * suppressed those memories from ``prefetch()``, the path that does
+      reach the model -- ``prefetch()`` excludes anything already in
+      ``injected[]``; and
+    * fed the outcome / confidence loop an access the model never saw,
+      biasing ``dismissal_count`` and importance decay against memories
+      that were never actually shown.
+
+    So this function now does the window bookkeeping and nothing else. The
+    ``recall()`` implementation in ``memory_bridge`` is left intact and
+    tested so it can be re-homed to a channel that can inject; until then,
+    ``prefetch()`` on UserPromptSubmit is the recall path.
+
     Fails silently -- memory errors never block tool execution.
     """
     try:
         session_id = hook_input.get("session_id", "unknown")
         tool_name = hook_input.get("tool_name", "")
         tool_input = hook_input.get("tool_input", {})
-        cwd = hook_input.get("cwd", "")
 
-        # Cheap fast path: only every WINDOW_SIZE-th tool call actually queries
-        # memory. The other (WINDOW_SIZE - 1) calls just bump the sliding-window
-        # counter and append to the buffer. Mirror recall()'s non-query branch
-        # inline here so those calls avoid importing the popoto-heavy
-        # memory_bridge module. The WINDOW_SIZE-th call (and any read failure)
-        # falls through to the real recall(), which re-reads the sidecar and
-        # performs the increment + BM25/bloom query itself (no double-count,
-        # since this branch does not write on delegation).
+        # Window bookkeeping only. Every call bumps the counter and appends
+        # to the buffer; none delegates to recall(). Previously the
+        # WINDOW_SIZE-th call fell through to recall(), whose output this
+        # event cannot deliver -- see the docstring. Keeping the counter and
+        # buffer preserves the sidecar shape that prefetch() load-modify-saves
+        # around, and costs no import of the popoto-heavy memory_bridge.
         state = _load_memory_buffer(session_id)
-        next_count = state.get("count", 0) + 1
-        if next_count % _RECALL_WINDOW_SIZE != 0:
-            state["count"] = next_count
-            buffer = state.get("buffer", [])
-            buffer.append({"tool_name": tool_name, "tool_input": tool_input})
-            if len(buffer) > _RECALL_BUFFER_SIZE:
-                buffer = buffer[-_RECALL_BUFFER_SIZE:]
-            state["buffer"] = buffer
-            _save_memory_buffer(session_id, state)
-            return None
-
-        from hook_utils.memory_bridge import recall
-
-        return recall(session_id, tool_name, tool_input, cwd=cwd)
+        state["count"] = state.get("count", 0) + 1
+        buffer = state.get("buffer", [])
+        buffer.append({"tool_name": tool_name, "tool_input": tool_input})
+        if len(buffer) > _RECALL_BUFFER_SIZE:
+            buffer = buffer[-_RECALL_BUFFER_SIZE:]
+        state["buffer"] = buffer
+        _save_memory_buffer(session_id, state)
+        return None
     except Exception:
         return None
 
@@ -567,12 +590,9 @@ def main():
 
     append_to_log(session_dir, "tool_use.jsonl", entry)
 
-    # Memory recall -- query subconscious memory and inject thoughts
-    additional_context = _run_memory_recall(hook_input)
-    if additional_context:
-        # Output hook response with additionalContext for thought injection
-        response = json.dumps({"additionalContext": additional_context})
-        print(response)
+    # Memory recall -- advance the sliding window only. See
+    # _run_memory_recall() for why this event cannot inject.
+    _run_memory_recall(hook_input)
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/post_tool_use.py
+++ b/.claude/hooks/post_tool_use.py
@@ -51,15 +51,13 @@ QUALITY_COMMANDS = ("pytest", "ruff", "ruff-format")
 # common paths early-exit (or bump the recall counter) WITHOUT importing the
 # popoto-heavy module; the genuinely heavy branches still import lazily.
 #
-# ``_RECALL_BUFFER_SIZE`` MUST stay in sync with
-# ``hook_utils.memory_bridge.BUFFER_SIZE`` — it is duplicated here only so the
-# counter-only path can mirror recall()'s non-query branch byte-for-byte.
-#
-# This hook no longer delegates to recall() on the WINDOW_SIZE-th call, because
-# PostToolUse has no injection channel to deliver its output — see
-# _run_memory_recall(). The window constant is therefore gone from this file;
-# memory_bridge.WINDOW_SIZE remains the source of truth for recall() itself.
+# ``_RECALL_WINDOW_SIZE`` / ``_RECALL_BUFFER_SIZE`` MUST stay in sync with
+# ``hook_utils.memory_bridge.WINDOW_SIZE`` / ``BUFFER_SIZE`` — they are
+# duplicated here only so the counter-only fast path can mirror recall()'s
+# non-query branch byte-for-byte. recall() remains the source of truth; the
+# WINDOW_SIZE-th call delegates to it for the real BM25/bloom work.
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_RECALL_WINDOW_SIZE = 3
 _RECALL_BUFFER_SIZE = 9
 
 
@@ -363,62 +361,41 @@ def check_file_reminders(hook_input: dict) -> None:
             print(reminder)
 
 
-def _run_memory_recall(hook_input: dict) -> None:
-    """Advance the recall sliding window. Never injects, by design.
+def _run_memory_recall(hook_input: dict) -> str | None:
+    """Run memory recall and return additionalContext string or None.
 
-    PostToolUse has no context-injection channel. The harness contract
-    supports ``hookSpecificOutput.additionalContext`` on UserPromptSubmit,
-    UserPromptExpansion, and SessionStart only; PostToolUse output carries
-    ``systemMessage`` but not ``additionalContext``, and a bare top-level
-    ``{"additionalContext": ...}`` (what this hook used to print) is not a
-    supported shape on any event.
-
-    Measured before this change, over 8 recent sessions: every delivered
-    ``<thought>`` stub arrived in a ``hook_additional_context`` attachment
-    parented to a *user* record -- i.e. from ``prefetch()`` on
-    UserPromptSubmit. Not one arrived after a ``tool_result``, which is
-    where a PostToolUse injection would land. Session
-    ``eefc78b8`` recorded **181** entries in its sidecar ``injected[]``
-    while delivering **3** stubs to the model.
-
-    That gap was not merely wasted work. ``recall()`` extends the sidecar's
-    ``injected[]`` and calls ``record.confirm_access()`` on every record it
-    formats, so each undelivered batch:
-
-    * suppressed those memories from ``prefetch()``, the path that does
-      reach the model -- ``prefetch()`` excludes anything already in
-      ``injected[]``; and
-    * fed the outcome / confidence loop an access the model never saw,
-      biasing ``dismissal_count`` and importance decay against memories
-      that were never actually shown.
-
-    So this function now does the window bookkeeping and nothing else. The
-    ``recall()`` implementation in ``memory_bridge`` is left intact and
-    tested so it can be re-homed to a channel that can inject; until then,
-    ``prefetch()`` on UserPromptSubmit is the recall path.
-
+    Queries subconscious memory based on accumulated tool calls.
     Fails silently -- memory errors never block tool execution.
     """
     try:
         session_id = hook_input.get("session_id", "unknown")
         tool_name = hook_input.get("tool_name", "")
         tool_input = hook_input.get("tool_input", {})
+        cwd = hook_input.get("cwd", "")
 
-        # Window bookkeeping only. Every call bumps the counter and appends
-        # to the buffer; none delegates to recall(). Previously the
-        # WINDOW_SIZE-th call fell through to recall(), whose output this
-        # event cannot deliver -- see the docstring. Keeping the counter and
-        # buffer preserves the sidecar shape that prefetch() load-modify-saves
-        # around, and costs no import of the popoto-heavy memory_bridge.
+        # Cheap fast path: only every WINDOW_SIZE-th tool call actually queries
+        # memory. The other (WINDOW_SIZE - 1) calls just bump the sliding-window
+        # counter and append to the buffer. Mirror recall()'s non-query branch
+        # inline here so those calls avoid importing the popoto-heavy
+        # memory_bridge module. The WINDOW_SIZE-th call (and any read failure)
+        # falls through to the real recall(), which re-reads the sidecar and
+        # performs the increment + BM25/bloom query itself (no double-count,
+        # since this branch does not write on delegation).
         state = _load_memory_buffer(session_id)
-        state["count"] = state.get("count", 0) + 1
-        buffer = state.get("buffer", [])
-        buffer.append({"tool_name": tool_name, "tool_input": tool_input})
-        if len(buffer) > _RECALL_BUFFER_SIZE:
-            buffer = buffer[-_RECALL_BUFFER_SIZE:]
-        state["buffer"] = buffer
-        _save_memory_buffer(session_id, state)
-        return None
+        next_count = state.get("count", 0) + 1
+        if next_count % _RECALL_WINDOW_SIZE != 0:
+            state["count"] = next_count
+            buffer = state.get("buffer", [])
+            buffer.append({"tool_name": tool_name, "tool_input": tool_input})
+            if len(buffer) > _RECALL_BUFFER_SIZE:
+                buffer = buffer[-_RECALL_BUFFER_SIZE:]
+            state["buffer"] = buffer
+            _save_memory_buffer(session_id, state)
+            return None
+
+        from hook_utils.memory_bridge import recall
+
+        return recall(session_id, tool_name, tool_input, cwd=cwd)
     except Exception:
         return None
 
@@ -590,9 +567,32 @@ def main():
 
     append_to_log(session_dir, "tool_use.jsonl", entry)
 
-    # Memory recall -- advance the sliding window only. See
-    # _run_memory_recall() for why this event cannot inject.
-    _run_memory_recall(hook_input)
+    # Memory recall -- query subconscious memory and inject thoughts.
+    #
+    # The payload MUST be nested under ``hookSpecificOutput``. A bare
+    # top-level ``{"additionalContext": ...}`` is not a recognized shape on
+    # any hook event: the harness parses the JSON, finds no key it acts on,
+    # and discards it silently -- exit 0, no warning, nothing injected.
+    #
+    # Verified end to end on this harness with a scratch PostToolUse hook and
+    # a nonce the model was asked to echo:
+    #   {"hookSpecificOutput": {"hookEventName": "PostToolUse",
+    #                           "additionalContext": "<nonce>"}}  -> delivered
+    #   {"additionalContext": "<nonce>"}                          -> discarded
+    #
+    # Matches the shape used for PostToolUse in agent/health_check.py and the
+    # SDK's PostToolUseHookSpecificOutput TypedDict.
+    additional_context = _run_memory_recall(hook_input)
+    if additional_context:
+        response = json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PostToolUse",
+                    "additionalContext": additional_context,
+                }
+            }
+        )
+        print(response)
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/user_prompt_submit.py
+++ b/.claude/hooks/user_prompt_submit.py
@@ -16,9 +16,12 @@ That position is load-bearing and must not be "corrected" to the system
 prompt or any other pre-history location. Prompt caches are keyed on an
 exact token prefix, so appending at the tail costs only the injected
 tokens, while writing above the history invalidates everything behind it
--- the whole context, on every turn that recall changes. This hook is the
-only memory path that reaches the model; see
-``post_tool_use._run_memory_recall`` for why PostToolUse is not.
+-- the whole context, on every turn that recall changes.
+
+This is the turn-granularity half of recall; ``post_tool_use.py`` carries
+the tool-granularity half. Both inject via the same
+``hookSpecificOutput.additionalContext`` channel, and both land at the
+tail, so both are append-only against the cache.
 
 All operations fail silently -- memory errors never block prompt submission.
 """

--- a/.claude/hooks/user_prompt_submit.py
+++ b/.claude/hooks/user_prompt_submit.py
@@ -8,7 +8,17 @@ as Memory records via memory_bridge.ingest().
 After ingest, runs memory_bridge.prefetch() to surface up to 3 relevant
 <thought> blocks against the user's prompt before any tool fires. The
 result is emitted as a hookSpecificOutput JSON object on stdout, which
-Claude Code prepends to the agent's first system message.
+Claude Code appends to the *user turn* -- it arrives as a
+``hook_additional_context`` attachment parented to the user record, after
+all sealed history.
+
+That position is load-bearing and must not be "corrected" to the system
+prompt or any other pre-history location. Prompt caches are keyed on an
+exact token prefix, so appending at the tail costs only the injected
+tokens, while writing above the history invalidates everything behind it
+-- the whole context, on every turn that recall changes. This hook is the
+only memory path that reaches the model; see
+``post_tool_use._run_memory_recall`` for why PostToolUse is not.
 
 All operations fail silently -- memory errors never block prompt submission.
 """

--- a/site/memory.html
+++ b/site/memory.html
@@ -136,12 +136,12 @@
 <section>
   <p class="sec-label">2 · Recall</p>
   <h2>The bloom filter and the <code>&lt;thought&gt;</code> stub</h2>
-  <p>Recall runs in the UserPromptSubmit hook, once per turn, before any tool fires — so the agent already carries relevant memory when it starts thinking. It is affordable because most checks cost nothing:</p>
+  <p>Recall runs twice over. Once per turn, before any tool fires, so the agent starts out already carrying what it knows; and again on a sliding window across tool calls, so a task that wanders into new territory picks up memory it could not have asked for at the outset. Both are affordable because most checks cost nothing:</p>
   <div class="diagram-wrap">
-  <svg viewBox="0 0 1000 232" role="img" aria-label="Recall funnel: each user prompt is checked against a bloom filter; on no match nothing is injected; on a possible match a compact thought stub enters the context, and the agent pulls the full memory over MCP only when it wants the whole story">
+  <svg viewBox="0 0 1000 232" role="img" aria-label="Recall funnel: each prompt and every third tool call is checked against a bloom filter; on no match nothing is injected; on a possible match a compact thought stub enters the context, and the agent pulls the full memory over MCP only when it wants the whole story">
     <rect class="dg-box" x="20" y="76" width="160" height="60"/>
-    <text class="dg-title" x="100" y="101" text-anchor="middle">User prompt</text>
-    <text class="dg-sub" x="100" y="119" text-anchor="middle">every turn</text>
+    <text class="dg-title" x="100" y="101" text-anchor="middle">Prompt · tool call</text>
+    <text class="dg-sub" x="100" y="119" text-anchor="middle">turn and window</text>
 
     <rect class="dg-box store" x="256" y="76" width="190" height="60"/>
     <text class="dg-title" x="351" y="101" text-anchor="middle">Bloom filter</text>
@@ -177,7 +177,7 @@
     <div class="tag">Concept · Prompt caching</div>
     <p>Providers cache the model's context by exact token <em>prefix</em>: a turn is billed at a fraction of the input price for every token it shares with the previous request, up to the first byte that differs. So the cost of writing into the context is not the size of what you wrote — it is the size of everything that comes <em>after</em> it. Editing one line near the top of a 100,000-token context re-bills almost all of it.</p>
   </aside>
-  <p>Recall therefore obeys two rules. It <strong>only ever appends</strong>, landing in the user turn after all sealed history, so an injection costs the stub's own tokens and nothing more. And it <strong>never rewrites</strong> — no memory block is edited or withdrawn once sent, because removing a block behind the cursor invalidates every token behind it and costs more than leaving it in place.</p>
+  <p>Recall therefore obeys two rules. It <strong>only ever appends</strong> — a stub lands after all sealed history, whether it arrives with the prompt or after a tool result — so an injection costs its own tokens and nothing more. And it <strong>never rewrites</strong>: no memory block is edited or withdrawn once sent, because removing a block behind the cursor invalidates every token behind it and costs more than leaving it in place.</p>
   <p>The stub is what makes the append affordable in aggregate. Injected blocks accumulate for the life of a session, so the per-turn size is paid on every later turn too; a twenty-token stub compounds where a full memory body would not. Memories already surfaced this session are suppressed rather than re-injected, which is also append-only — declining to add costs nothing, while pruning would cost the prefix.</p>
 </section>
 

--- a/site/memory.html
+++ b/site/memory.html
@@ -136,12 +136,12 @@
 <section>
   <p class="sec-label">2 · Recall</p>
   <h2>The bloom filter and the <code>&lt;thought&gt;</code> stub</h2>
-  <p>Recall happens inside the PostToolUse hook while the agent works, on a sliding window across tool calls, affordable because most checks cost nothing:</p>
+  <p>Recall runs in the UserPromptSubmit hook, once per turn, before any tool fires — so the agent already carries relevant memory when it starts thinking. It is affordable because most checks cost nothing:</p>
   <div class="diagram-wrap">
-  <svg viewBox="0 0 1000 232" role="img" aria-label="Recall funnel: tool activity is checked against a bloom filter; on no match nothing is injected; on a possible match a compact thought stub enters the context, and the agent pulls the full memory over MCP only when it wants the whole story">
+  <svg viewBox="0 0 1000 232" role="img" aria-label="Recall funnel: each user prompt is checked against a bloom filter; on no match nothing is injected; on a possible match a compact thought stub enters the context, and the agent pulls the full memory over MCP only when it wants the whole story">
     <rect class="dg-box" x="20" y="76" width="160" height="60"/>
-    <text class="dg-title" x="100" y="101" text-anchor="middle">Tool call</text>
-    <text class="dg-sub" x="100" y="119" text-anchor="middle">every one</text>
+    <text class="dg-title" x="100" y="101" text-anchor="middle">User prompt</text>
+    <text class="dg-sub" x="100" y="119" text-anchor="middle">every turn</text>
 
     <rect class="dg-box store" x="256" y="76" width="190" height="60"/>
     <text class="dg-title" x="351" y="101" text-anchor="middle">Bloom filter</text>
@@ -172,6 +172,13 @@
     <div class="tag">Concept · Bloom filter</div>
     <p>A bloom filter is a probabilistic set-membership structure: it answers "have I seen this?" with no false negatives and tunable false positives, in constant space. Here it gates memory recall cheaply, so the hook injects small stubs and the agent pulls full bodies only when needed.</p>
   </aside>
+  <p>Both halves of that design are also what keeps recall cheap against the model provider's <strong>prompt cache</strong>, which is the larger cost by far.</p>
+  <aside class="concept">
+    <div class="tag">Concept · Prompt caching</div>
+    <p>Providers cache the model's context by exact token <em>prefix</em>: a turn is billed at a fraction of the input price for every token it shares with the previous request, up to the first byte that differs. So the cost of writing into the context is not the size of what you wrote — it is the size of everything that comes <em>after</em> it. Editing one line near the top of a 100,000-token context re-bills almost all of it.</p>
+  </aside>
+  <p>Recall therefore obeys two rules. It <strong>only ever appends</strong>, landing in the user turn after all sealed history, so an injection costs the stub's own tokens and nothing more. And it <strong>never rewrites</strong> — no memory block is edited or withdrawn once sent, because removing a block behind the cursor invalidates every token behind it and costs more than leaving it in place.</p>
+  <p>The stub is what makes the append affordable in aggregate. Injected blocks accumulate for the life of a session, so the per-turn size is paid on every later turn too; a twenty-token stub compounds where a full memory body would not. Memories already surfaced this session are suppressed rather than re-injected, which is also append-only — declining to add costs nothing, while pruning would cost the prefix.</p>
 </section>
 
 <section>
@@ -201,6 +208,7 @@
   <p>The second store is ordinary files: the repository's <code>CLAUDE.md</code> operating instructions, a per-project <code>MEMORY.md</code> index with one Markdown file per durable fact, the <code>docs/</code> tree, and a curated knowledge vault of business context and decisions. This is the memory humans write, and the memory humans can <em>read</em>, diff, and version. Every change has a git history; every fact has an author.</p>
   <p>The two stores stay separate because they answer different questions on different clocks. Object memory answers "what have I learned that's relevant to this exact moment?", at tool-call granularity, thousands of times a day, ranked and decaying. Filesystem memory answers "how does this project work and what are the standing rules?", read once at session start, changed a few times a week, reviewed like code.</p>
   <p>Merging them would break both: files are too slow and too flat to consult on every tool call, and a Redis store is illegible to the humans who need to audit what the system believes.</p>
+  <p>Reading the files once, at session start, is also what makes them free. They are loaded into the context ahead of the conversation, so a file edited mid-session changes bytes that the running session has already stopped looking at — the agent can write to its own notes without re-billing the context it is sitting on. The price is honest and paid knowingly: a fact written at turn five does not appear in the files the model is reading until the next session starts. Keeping <em>this</em> session current is the object store's job, which is exactly why the two clocks are different.</p>
 </section>
 
 <div class="page-next">

--- a/tests/unit/test_post_tool_use_fast_path.py
+++ b/tests/unit/test_post_tool_use_fast_path.py
@@ -181,8 +181,21 @@ def test_counter_only_call_bumps_sidecar_counter(clean_session):
 
 
 def test_fast_path_state_matches_real_recall():
-    """Driving N calls through the hook helper yields the same sidecar state
-    as driving them through ``memory_bridge.recall()`` directly."""
+    """The hook helper tracks the same window as ``recall()`` but never injects.
+
+    ``count`` and ``buffer`` stay in lockstep with ``memory_bridge.recall()``
+    -- that is the sidecar contract ``prefetch()`` load-modify-saves around.
+
+    ``injected`` deliberately does NOT: PostToolUse has no channel to deliver
+    a thought stub, so the hook path must never mark a memory as injected.
+    Doing so suppressed it from ``prefetch()`` (which excludes anything in
+    ``injected[]``) and fed the outcome loop an access the model never saw.
+
+    This assertion is one-sided on purpose. It reads as vacuous whenever the
+    fixture's synthetic tool names miss the bloom filter and ``recall()``
+    injects nothing either -- which is the common case here. It is still the
+    assertion that catches a regression on a populated store.
+    """
     sys.path.insert(0, str(REPO_ROOT / ".claude" / "hooks"))
     sys.path.insert(0, str(REPO_ROOT))
     import post_tool_use as p
@@ -209,7 +222,8 @@ def test_fast_path_state_matches_real_recall():
         state_b = json.loads(_sidecar(b).read_text())
         assert state_a["count"] == state_b["count"]
         assert state_a["buffer"] == state_b["buffer"]
-        assert state_a.get("injected") == state_b.get("injected")
+        # The hook path never records injections, whatever recall() did.
+        assert not state_b.get("injected")
     finally:
         for sid in (a, b):
             shutil.rmtree(REPO_ROOT / "data" / "sessions" / sid, ignore_errors=True)

--- a/tests/unit/test_post_tool_use_fast_path.py
+++ b/tests/unit/test_post_tool_use_fast_path.py
@@ -181,21 +181,8 @@ def test_counter_only_call_bumps_sidecar_counter(clean_session):
 
 
 def test_fast_path_state_matches_real_recall():
-    """The hook helper tracks the same window as ``recall()`` but never injects.
-
-    ``count`` and ``buffer`` stay in lockstep with ``memory_bridge.recall()``
-    -- that is the sidecar contract ``prefetch()`` load-modify-saves around.
-
-    ``injected`` deliberately does NOT: PostToolUse has no channel to deliver
-    a thought stub, so the hook path must never mark a memory as injected.
-    Doing so suppressed it from ``prefetch()`` (which excludes anything in
-    ``injected[]``) and fed the outcome loop an access the model never saw.
-
-    This assertion is one-sided on purpose. It reads as vacuous whenever the
-    fixture's synthetic tool names miss the bloom filter and ``recall()``
-    injects nothing either -- which is the common case here. It is still the
-    assertion that catches a regression on a populated store.
-    """
+    """Driving N calls through the hook helper yields the same sidecar state
+    as driving them through ``memory_bridge.recall()`` directly."""
     sys.path.insert(0, str(REPO_ROOT / ".claude" / "hooks"))
     sys.path.insert(0, str(REPO_ROOT))
     import post_tool_use as p
@@ -222,8 +209,54 @@ def test_fast_path_state_matches_real_recall():
         state_b = json.loads(_sidecar(b).read_text())
         assert state_a["count"] == state_b["count"]
         assert state_a["buffer"] == state_b["buffer"]
-        # The hook path never records injections, whatever recall() did.
-        assert not state_b.get("injected")
+        assert state_a.get("injected") == state_b.get("injected")
     finally:
         for sid in (a, b):
             shutil.rmtree(REPO_ROOT / "data" / "sessions" / sid, ignore_errors=True)
+
+
+def test_recall_output_is_wrapped_in_hook_specific_output(capsys, monkeypatch, clean_session):
+    """Injected thoughts must be nested under ``hookSpecificOutput``.
+
+    A bare top-level ``{"additionalContext": ...}`` is not a recognized shape
+    on any hook event. The harness parses it, matches no key it acts on, and
+    discards it silently -- exit 0, no warning, nothing injected. That is what
+    this hook emitted before #3063, so every stub the sliding-window recall
+    produced was dropped while ``recall()`` still recorded it in the sidecar's
+    ``injected[]`` and called ``confirm_access()`` on it.
+
+    Verified end to end against the harness with a nonce the model was asked
+    to echo: the wrapped shape is delivered, the bare shape is not.
+    """
+    sys.path.insert(0, str(REPO_ROOT / ".claude" / "hooks"))
+    import post_tool_use as p
+
+    monkeypatch.setattr(
+        p, "_run_memory_recall", lambda _i: '<thought id="abc">[memory] x</thought>'
+    )
+    monkeypatch.setattr(
+        p,
+        "read_hook_input",
+        lambda: {
+            "session_id": clean_session,
+            "tool_name": "Read",
+            "tool_input": {"file_path": "/tmp/x.txt"},
+            "tool_output": "hello",
+            "cwd": str(REPO_ROOT),
+        },
+    )
+    for name in (
+        "check_file_reminders",
+        "update_sdlc_state_for_file_write",
+        "update_sdlc_state_for_bash",
+        "_update_agent_session",
+    ):
+        monkeypatch.setattr(p, name, lambda *_a, **_k: None)
+
+    p.main()
+
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert "additionalContext" not in payload, "bare top-level shape is silently discarded"
+    hso = payload["hookSpecificOutput"]
+    assert hso["hookEventName"] == "PostToolUse"
+    assert hso["additionalContext"].startswith("<thought")


### PR DESCRIPTION
## What this fixes

**The sliding-window memory recall in `post_tool_use.py` has never reached the model — because of its output shape — and while failing silently it was corrupting the memory feedback loop.**

The hook printed a bare top-level `{"additionalContext": ...}`. That is not a recognized shape on any hook event. The harness parses the JSON, matches no key it acts on, and discards it: exit 0, no warning, nothing injected.

### Root cause, verified end to end

I tested this directly against the harness with a scratch PostToolUse hook and a nonce the model was asked to echo back:

| Emitted by the hook | Result |
|---|---|
| `{"hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": "<nonce>"}}` | model quotes the nonce verbatim |
| `{"additionalContext": "<nonce>"}` | model reports no injected content |

So `PostToolUse` **does** support context injection — the SDK declares `additionalContext` on `PostToolUseHookSpecificOutput`, and `agent/health_check.py` already uses the correct shape. Only this one call site was malformed.

### Field evidence

Across the 8 most recent sessions, every delivered `<thought>` stub arrived as a `hook_additional_context` attachment **parented to a `user` record** — i.e. from `prefetch()` on UserPromptSubmit. Not one was parented to a `tool_result`, which is where this hook's injections would land.

The clincher is session `eefc78b8`: its sidecar recorded **181** entries in `injected[]` while **3** stubs reached the model.

### Why that was worse than lost injections

`recall()` extends the sidecar's `injected[]` and calls `record.confirm_access()` on every record it formats. So each discarded batch:

1. **Suppressed those memories from `prefetch()`** — the path that was working. `prefetch()` excludes anything already in `injected[]`, so 178 memories in that session were marked as shown and then withheld from the channel that could actually show them.
2. **Credited the outcome loop with an access the model never saw** — biasing `dismissal_count` and importance decay against memories that were never surfaced. The self-grading loop on the memory page was grading phantom impressions.

## Changes

- **`.claude/hooks/post_tool_use.py`** — wrap the payload in `hookSpecificOutput`. One-line behavioral fix; the sliding-window recall arm is restored intact.
- **`.claude/hooks/user_prompt_submit.py`** — the docstring claimed the output is "prepended to the agent's first system message". It is appended to the *user turn*. Corrected with the reason: that position is load-bearing for prompt-cache reuse, and following the old comment would invalidate the whole prefix every turn.
- **`tests/unit/test_post_tool_use_fast_path.py`** — regression test pinning the wrapped shape. Confirmed to fail against the bare form and pass against the fix.
- **`site/memory.html`** — recall described as both halves (once per turn at UserPromptSubmit, plus the tool-call window), which is what actually runs once this is fixed. Adds prompt-cache framing to §2 and §4: why stub injection and append-only recall are the cheap design, and why reading the file store once at session start is free.

## Note on the first commit on this branch

`42fa2933c` diagnosed this as "PostToolUse has no injection channel" and removed the recall arm entirely, reasoning from the public hooks documentation, which does not list `additionalContext` under PostToolUse. That was wrong — the docs are behind the SDK. `390899541` supersedes it: the arm is restored and only the shape is fixed. Reviewing the second commit alone is sufficient; the branch diff against `main` reflects the corrected fix.

## Verification

```
uv run pytest tests/unit/test_post_tool_use_fast_path.py tests/unit/test_post_tool_use_sdlc.py \
  tests/unit/test_hook_user_prompt_submit.py tests/unit/hooks \
  tests/unit/test_site_graph_consistency.py tests/unit/test_memory_bridge.py
255 passed

uv run ruff check .claude/hooks/post_tool_use.py .claude/hooks/user_prompt_submit.py
All checks passed
```

Regression test negative control: reverting the wrap makes `test_recall_output_is_wrapped_in_hook_specific_output` fail, restoring it passes.

`site/memory.html` re-parsed clean. Not deployed — `scripts/deploy-site.sh` runs on merge.

## Worth watching after merge

This restores an injection path that has been dark. Recall now fires on the tool window as designed, so injected tokens per session go up. Both halves append at the tail, so they are cache-safe, but injected blocks are resident for the life of a session — if context pressure rises noticeably, `MAX_THOUGHTS` (3) and `WINDOW_SIZE` (3) are the knobs.
