### PR TITLE
fix(docs-auditor): route Telegram notifications by audited repo root

### DIFF
--- a/docs/features/docs-auditor.md
+++ b/docs/features/docs-auditor.md
@@ -42,8 +42,16 @@ Picks the least-recently-audited primary doc from a Redis hash, expands its
 neighborhood (≤20 files via outbound links + inbound refs), runs auto-fix
 detectors, applies them, stages exactly `files_touched` (never a whole-tree
 `git add -A`), opens a `docs-audit/{slug}-{ts}` branch, posts a non-draft PR,
-and notifies the `Eng: Valor` Telegram chat that review is required. Errors
-are swallowed; the auditor never crashes the worker.
+and notifies that review is required. The notification destination is
+derived, not hardcoded: it goes to the `Eng:` group of the project whose
+`working_directory` (in `projects.json`) matches the audited repo root,
+addressed by numeric `chat_id` rather than group name. It falls back to the
+`Eng: Valor` literal only when the audited repo is this checkout and no
+project match is found; for any other unmatched or unregistered repo the
+Telegram notification is suppressed with a logged warning **and** a
+suppression notice spliced into the run's `summary` (placed before the PR
+URL so the 500-char truncation the reflection scheduler applies cannot drop
+it). Errors are swallowed; the auditor never crashes the worker.
 
 A guard-skipped run (daily PR cap reached, or an open PR already exists for
 the picked doc's slug) performs no working-tree write and no git operation,
@@ -342,10 +350,14 @@ withholds dedup independently rather than sharing one key. Filing is bounded
 by the module's shared per-run cap (`ISSUE_FILING_PER_RUN_CAP`, see
 [Two-tier dedup](#two-tier-dedup)); entries past the cap are logged and
 suppressed, not filed. It also threads the withheld set into its `findings`,
-`summary`, and Telegram message — which states plainly that review is
-required and that the PR is closed unmerged after `STALE_PR_AGE_DAYS` if
-nobody acts — and stamps `WITHHELD_PR_MARKER` plus the rejection list into the
-PR body. The branch sweeper reads that marker from its own `gh pr list` query
+`summary`, and, when a destination resolves, a Telegram message which states
+plainly that review is required and that the PR is closed unmerged after
+`STALE_PR_AGE_DAYS` if nobody acts. When no destination resolves for the
+audited repo, the Telegram notification is suppressed and the same
+`summary` field carries the suppression notice instead — `summary` is the
+only field the reflection scheduler persists, so it is the load-bearing
+carrier of this outcome, not just `findings`. It also stamps
+`WITHHELD_PR_MARKER` plus the rejection list into the PR body. The branch sweeper reads that marker from its own `gh pr list` query
 and never closes or deletes the branch of a PR carrying it — instead it files
 a **separate**, PR-scoped escalation issue (`docs-auditor: withheld PR #{n}
 still unreviewed`), distinct from the per-defect titles above so the two

--- a/docs/features/docs-auditor.md
+++ b/docs/features/docs-auditor.md
@@ -46,8 +46,10 @@ and notifies that review is required. The notification destination is
 derived, not hardcoded: it goes to the `Eng:` group of the project whose
 `working_directory` (in `projects.json`) matches the audited repo root,
 addressed by numeric `chat_id` rather than group name. It falls back to the
-`Eng: Valor` literal only when the audited repo is this checkout and no
-project match is found; for any other unmatched or unregistered repo the
+`Eng: Valor` literal only when the audited repo is this checkout **and** no
+`Eng:` group could be resolved for it, whether because no project matched, the
+matched project's `Eng:` group is misconfigured, or the lookup itself raised;
+for any other repo whose `Eng:` group does not resolve, the
 Telegram notification is suppressed with a logged warning **and** a
 suppression notice spliced into the run's `summary` (placed before the PR
 URL so the 500-char truncation the reflection scheduler applies cannot drop

--- a/docs/plans/docs-auditor-telegram-sender-hardcodes-eng-valor.md
+++ b/docs/plans/docs-auditor-telegram-sender-hardcodes-eng-valor.md
@@ -772,30 +772,30 @@ Not applicable — this repo has no Sphinx/MkDocs site.
 
 ## Success Criteria
 
-- [ ] `reflections/docs_auditor.py` contains no `"--chat", "Eng: Valor"` argv adjacency.
-- [ ] `_send_telegram_notification` resolves its destination through `resolve_eng_group`
+- [x] `reflections/docs_auditor.py` contains no `"--chat", "Eng: Valor"` argv adjacency.
+- [x] `_send_telegram_notification` resolves its destination through `resolve_eng_group`
       keyed on the audited repo root, and both call sites pass `repo_root=PROJECT_ROOT`.
-- [ ] **Production path:** auditing this checkout with the real-shaped `projects.json`
+- [x] **Production path:** auditing this checkout with the real-shaped `projects.json`
       sends to `str(chat_id)` (`"-1003449100931"` in the test stub), not to the group name.
-- [ ] A repo registered in `projects.json` with a configured `Eng:` group receives its
+- [x] A repo registered in `projects.json` with a configured `Eng:` group receives its
       notification at that group's numeric `chat_id`.
-- [ ] An audited repo with no resolvable `Eng:` group, other than this checkout, receives
+- [x] An audited repo with no resolvable `Eng:` group, other than this checkout, receives
       no notification, produces a `logger.warning` naming the repo path and both possible
       causes, and returns `False`.
-- [ ] A `False` return from either call site puts a suppression notice in
+- [x] A `False` return from either call site puts a suppression notice in
       `result["summary"]` (the only persisted field), with the step-9 notice placed before
       `PR={pr_url}` so 500-char truncation cannot cut it; a matching `findings` entry is
       appended as well.
-- [ ] A non-zero `valor-telegram` exit code on a resolved destination logs a warning
+- [x] A non-zero `valor-telegram` exit code on a resolved destination logs a warning
       carrying the exit code and still returns `True`.
-- [ ] Auditing this checkout with an unreadable or unmatched `projects.json` still sends
+- [x] Auditing this checkout with an unreadable or unmatched `projects.json` still sends
       to `Eng: Valor` — today's behavior preserved on the degraded path.
-- [ ] `docs/features/docs-auditor.md` no longer claims a fixed destination chat at `:45`
+- [x] `docs/features/docs-auditor.md` no longer claims a fixed destination chat at `:45`
       **and** no longer claims unconditional Telegram delivery at `:344-347`.
-- [ ] This PR touches no file named in #3072's sweep.
-- [ ] Tests pass (`/do-test`)
-- [ ] Documentation updated (`/do-docs`)
-- [ ] No xfail conversions needed — `tests/unit/test_docs_auditor_substrate.py` contains
+- [x] This PR touches no file named in #3072's sweep.
+- [x] Tests pass (`/do-test`)
+- [x] Documentation updated (`/do-docs`)
+- [x] No xfail conversions needed — `tests/unit/test_docs_auditor_substrate.py` contains
       no `xfail` markers related to this bug (verified at plan time).
 
 ## Team Orchestration

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -32,10 +32,15 @@ from pathlib import Path
 
 from config.machine import get_machine_display_name
 from config.settings import settings
+from reflections.utilities import load_local_projects, resolve_eng_group
 
 logger = logging.getLogger("reflections.docs_auditor")
 
 PROJECT_ROOT = Path(__file__).parent.parent
+
+# Fallback Telegram destination used only when the audited repo IS this checkout
+# and projects.json is unreadable or unmatched — see _resolve_notify_chat.
+FALLBACK_ENG_CHAT = "Eng: Valor"
 
 # ---------------------------------------------------------------------------
 # Module-level configuration
@@ -1479,26 +1484,101 @@ def _file_issue_if_new(finding: dict, repo_root: Path) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Telegram notification (mirrors _send_log_review_telegram pattern)
+# Telegram notification (destination resolved from the audited repo root)
 # ---------------------------------------------------------------------------
 
 
-def _send_telegram_notification(message: str) -> None:
-    """Best-effort Telegram notification. Swallows all subprocess failures."""
+def _resolve_notify_chat(repo_root: Path) -> str | None:
+    """Map the audited repo root to a ``--chat`` destination, or ``None``.
+
+    Ladder:
+      1. Match ``repo_root`` against a ``projects.json`` entry's
+         ``working_directory``.
+      2. If matched, resolve that project's ``Eng:`` group via
+         ``resolve_eng_group`` and return its numeric ``chat_id`` as a string
+         (never the group name — a name re-enters ``valor-telegram``'s
+         ambiguity-tolerant resolve_chat cascade; an id cannot).
+      3. If no project matches, or the matched project has no properly
+         configured ``Eng:`` group, return ``FALLBACK_ENG_CHAT`` **only when**
+         ``repo_root`` is this very checkout (``PROJECT_ROOT``) — never for a
+         foreign or unregistered repo. This is a deliberate narrowing: an
+         unconditional fallback would re-create the exact misroute this
+         function exists to remove, paging the valor engineers about a repo
+         they don't own. This checkout's own engineer group genuinely is
+         ``Eng: Valor``, so the fallback is provably correct only in that one
+         case — do not "simplify" this back into an unconditional default.
+      4. Any exception during lookup is swallowed, logged, and falls through
+         to the step-3 rule (best-effort: a notification failure must never
+         break an audit run).
+
+    Returns ``None`` to mean "do not send" — the caller must not shell out.
+    """
+    target = repo_root.resolve()
     try:
-        subprocess.run(
-            ["valor-telegram", "send", "--chat", "Eng: Valor", message],
+        for project in load_local_projects():
+            wd = project.get("working_directory")
+            if wd and Path(wd).resolve() == target:
+                resolved = resolve_eng_group(project)
+                if resolved is not None:
+                    _, chat_id = resolved
+                    return str(chat_id)
+                break
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("docs_auditor: project lookup for Telegram routing failed: %s", exc)
+
+    if target == PROJECT_ROOT.resolve():
+        return FALLBACK_ENG_CHAT
+
+    logger.warning(
+        "docs_auditor: no Eng: group for audited repo %s (repo not registered in "
+        "projects.json, or its project has no configured Eng: group); "
+        "Telegram notification suppressed",
+        target,
+    )
+    return None
+
+
+def _send_telegram_notification(message: str, *, repo_root: Path | None = None) -> bool:
+    """Best-effort Telegram notification, addressed by the audited repo root.
+
+    Resolves the destination via ``_resolve_notify_chat((repo_root or
+    PROJECT_ROOT).resolve())`` — computed here, not defaulted in the
+    signature, so a test that patches the module-level ``PROJECT_ROOT``
+    global is honored at call time rather than at import time.
+
+    Returns ``False`` **only** when no destination resolved — no subprocess
+    is invoked in that case. Every other path, including a swallowed
+    ``FileNotFoundError``/``TimeoutExpired``/``Exception`` or a non-zero
+    ``valor-telegram`` exit code, returns ``True``: a destination was
+    resolved and a send was attempted, so the caller's "no Eng: group
+    configured" finding text stays accurate only for the ``False`` case.
+    """
+    root = (repo_root or PROJECT_ROOT).resolve()
+    chat = _resolve_notify_chat(root)
+    if chat is None:
+        return False
+    try:
+        proc = subprocess.run(
+            ["valor-telegram", "send", "--chat", chat, message],
             capture_output=True,
             text=True,
             timeout=settings.timeouts.git_subprocess_s,
             check=False,
         )
+        if proc.returncode != 0:
+            logger.warning(
+                "docs_auditor: valor-telegram exited %s for chat %s: %s",
+                proc.returncode,
+                chat,
+                (proc.stderr or "")[:200],
+            )
     except FileNotFoundError:
         logger.warning("docs_auditor: valor-telegram not on PATH; skipping Telegram notify")
     except subprocess.TimeoutExpired:
         logger.warning("docs_auditor: valor-telegram send timed out")
     except Exception as e:
         logger.warning(f"docs_auditor: valor-telegram send failed: {e}")
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -2430,16 +2510,31 @@ def run_docs_auditor() -> dict:
         if not files_touched or _git_diff_quiet(PROJECT_ROOT):
             _update_rotation_hash(project_key, [str(primary)])
             _write_liveness(slug, "skipped", None, 0, fixes_withheld=fixes_withheld)
+            # Initialized unconditionally (mirroring withheld_note above): the
+            # summary f-string below interpolates this on every zero-diff
+            # return, including the clean path where the notify call never
+            # runs. Assigning it only inside the `if fixes_withheld:` guard
+            # would raise NameError on that common path, which the enclosing
+            # `except Exception` silently converts into {"status": "error"}.
+            suppressed_note = ""
+            zero_diff_findings = [f"docs-auditor: zero-diff for {primary}{withheld_note}"]
             if fixes_withheld:
-                _send_telegram_notification(
+                sent = _send_telegram_notification(
                     f"docs-auditor pass for {slug}: zero-diff, no PR"
                     f"\n⚠️ {fixes_withheld} fix(es) withheld — target path absent; "
-                    "nothing was written and no PR was opened to review them"
+                    "nothing was written and no PR was opened to review them",
+                    repo_root=PROJECT_ROOT,
                 )
+                if not sent:
+                    suppressed_note = f" [Telegram suppressed: no Eng: group for {PROJECT_ROOT}]"
+                    zero_diff_findings.append(
+                        f"docs-auditor: Telegram notification suppressed — no Eng: "
+                        f"group for {PROJECT_ROOT}"
+                    )
             return {
                 "status": "skipped",
-                "findings": [f"docs-auditor: zero-diff for {primary}{withheld_note}"],
-                "summary": f"docs-auditor: zero-diff ({slug}){withheld_note}",
+                "findings": zero_diff_findings,
+                "summary": f"docs-auditor: zero-diff ({slug}){withheld_note}{suppressed_note}",
             }
 
         # 7. Memory refresh hook (fire-and-forget) — fired after commit
@@ -2518,7 +2613,17 @@ def run_docs_auditor() -> dict:
             + f"\nPR: {pr_url}"
             + f"\nReview required — closed unmerged after {STALE_PR_AGE_DAYS} days if unreviewed."
         )
-        _send_telegram_notification(msg)
+        # Initialized unconditionally even though the sender is called
+        # unconditionally on this path — mirrors the zero-diff path's
+        # initialize-first rule so neither branch can leave this name unbound.
+        suppressed_note = ""
+        sent = _send_telegram_notification(msg, repo_root=PROJECT_ROOT)
+        if not sent:
+            suppressed_note = f" [Telegram suppressed: no Eng: group for {PROJECT_ROOT}]"
+            findings.append(
+                f"docs-auditor: Telegram notification suppressed for PR {pr_url} — "
+                f"no Eng: group for {PROJECT_ROOT}"
+            )
 
         # 10. Update rotation hash for all touched files
         _update_rotation_hash(project_key, files_touched)
@@ -2553,7 +2658,7 @@ def run_docs_auditor() -> dict:
             "findings": findings,
             "summary": (
                 f"docs-auditor: {len(files_touched)} files touched, "
-                f"{result.get('fixes_applied', 0)} fixes{withheld_note}, "
+                f"{result.get('fixes_applied', 0)} fixes{withheld_note}{suppressed_note}, "
                 f"PR={pr_url}"
             ),
         }

--- a/tests/unit/reflections/test_docs_auditor_git_surface.py
+++ b/tests/unit/reflections/test_docs_auditor_git_surface.py
@@ -181,7 +181,7 @@ class TestFailedRotationEscalates:
         monkeypatch.setattr(docs_auditor, "_git_diff_quiet", lambda root: False)
         monkeypatch.setattr(docs_auditor, "_run_vault_drift_detection", lambda pk: 0)
         monkeypatch.setattr(docs_auditor, "_push_branch_and_pr", lambda *a, **kw: None)
-        monkeypatch.setattr(docs_auditor, "_send_telegram_notification", lambda msg: None)
+        monkeypatch.setattr(docs_auditor, "_send_telegram_notification", lambda msg, **kw: True)
         monkeypatch.setattr(docs_auditor, "_file_issue_if_new", fake_file_issue)
 
         result = docs_auditor.run_docs_auditor()
@@ -235,11 +235,12 @@ class TestWithheldTitleUnwrap:
         monkeypatch.setattr(docs_auditor, "_git_dirty", lambda root: False)
         monkeypatch.setattr(docs_auditor, "_run_vault_drift_detection", lambda pk: 0)
         monkeypatch.setattr(docs_auditor, "audit", lambda **kw: audit_result)
-        monkeypatch.setattr(docs_auditor, "_send_telegram_notification", lambda msg: None)
+        monkeypatch.setattr(docs_auditor, "_send_telegram_notification", lambda msg, **kw: True)
         monkeypatch.setattr(docs_auditor, "_file_issue_if_new", fake_file_issue)
 
-        docs_auditor.run_docs_auditor()
+        result = docs_auditor.run_docs_auditor()
 
+        assert result["status"] == "skipped"
         assert len(filed) == 1
         title = filed[0]["title"]
         assert "(real -> realistic)" in title
@@ -383,7 +384,7 @@ class TestFailedRestoreReporting:
         monkeypatch.setattr(docs_auditor, "_run_vault_drift_detection", lambda pk: 0)
         monkeypatch.setattr(docs_auditor, "audit", lambda **kw: audit_result)
         monkeypatch.setattr(docs_auditor, "_push_branch_and_pr", lambda *a, **kw: None)
-        monkeypatch.setattr(docs_auditor, "_send_telegram_notification", lambda msg: None)
+        monkeypatch.setattr(docs_auditor, "_send_telegram_notification", lambda msg, **kw: True)
         monkeypatch.setattr(docs_auditor, "_file_issue_if_new", lambda finding, root: True)
 
         result = docs_auditor.run_docs_auditor()
@@ -420,7 +421,7 @@ class TestGuardFiredNoWorkingTreeWrite:
         monkeypatch.setattr(docs_auditor, "_daily_pr_cap_reached", lambda root: True)
         monkeypatch.setattr(docs_auditor, "_has_open_pr_for_slug", lambda slug, root: False)
         monkeypatch.setattr(docs_auditor, "audit", fake_audit)
-        monkeypatch.setattr(docs_auditor, "_send_telegram_notification", lambda msg: None)
+        monkeypatch.setattr(docs_auditor, "_send_telegram_notification", lambda msg, **kw: True)
 
         result = docs_auditor.run_docs_auditor()
 
@@ -513,12 +514,13 @@ class TestWithheldFilingCap:
         monkeypatch.setattr(docs_auditor, "_git_dirty", lambda root: False)
         monkeypatch.setattr(docs_auditor, "_run_vault_drift_detection", lambda pk: 0)
         monkeypatch.setattr(docs_auditor, "audit", lambda **kw: audit_result)
-        monkeypatch.setattr(docs_auditor, "_send_telegram_notification", lambda msg: None)
+        monkeypatch.setattr(docs_auditor, "_send_telegram_notification", lambda msg, **kw: True)
         monkeypatch.setattr(docs_auditor, "_file_issue_if_new", fake_file_issue)
 
         with caplog.at_level("WARNING", logger="reflections.docs_auditor"):
             result = docs_auditor.run_docs_auditor()
 
+        assert result["status"] == "skipped"
         assert len(filed) == docs_auditor.ISSUE_FILING_PER_RUN_CAP
         assert any(
             "cap" in r.message.lower() and "suppress" in r.message.lower() for r in caplog.records

--- a/tests/unit/test_docs_auditor_substrate.py
+++ b/tests/unit/test_docs_auditor_substrate.py
@@ -1384,6 +1384,7 @@ class TestWithheldBlocksStaleClose:
         # _push_branch_and_pr above is never reached on this path.
         assert result["status"] == "skipped"
         assert "1 fix(es) withheld" in notify.call_args.args[0]
+        assert notify.call_args.kwargs["repo_root"] == repo
         assert liveness.call_args.kwargs["fixes_withheld"] == 1
 
     def test_rotation_result_surfaces_withheld_count(self, repo, auth_ok, patch_redis):
@@ -1423,6 +1424,7 @@ class TestWithheldBlocksStaleClose:
         assert push.call_args.args[2] == audit_result["files_touched"]
         assert push.call_args.kwargs["withheld"] == audit_result["withheld"]
         assert "withheld" in notify.call_args.args[0]
+        assert notify.call_args.kwargs["repo_root"] == repo
         # One issue filed per withheld entry (Q5 / B4).
         assert file_issue.call_count == 2
 
@@ -1464,6 +1466,7 @@ class TestWithheldBlocksStaleClose:
         msg = notify.call_args.args[0]
         assert "2 fix(es) withheld" in msg
         assert "docs_features_foo_md" in msg  # the rotation slug
+        assert notify.call_args.kwargs["repo_root"] == repo
         assert liveness.call_args.kwargs["fixes_withheld"] == 2
         # One issue filed per withheld entry (Q5 / B4), even on the no-PR path.
         assert file_issue.call_count == 2
@@ -1482,9 +1485,252 @@ class TestWithheldBlocksStaleClose:
             patch("reflections.docs_auditor._update_rotation_hash"),
             patch("reflections.docs_auditor._write_liveness"),
         ):
-            docs_auditor.run_docs_auditor()
+            result = docs_auditor.run_docs_auditor()
 
         assert notify.call_count == 0
+        assert result["status"] == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# TestTelegramChatRouting — #2754
+# ---------------------------------------------------------------------------
+
+
+class TestTelegramChatRouting:
+    """``_send_telegram_notification`` resolves its destination from repo_root."""
+
+    VALOR_PROJECT = {
+        "slug": "valor",
+        "working_directory": str(docs_auditor.PROJECT_ROOT),
+        "telegram": {"groups": {"Eng: Valor": {"chat_id": -1003449100931}}},
+    }
+
+    def test_production_valor_path_routes_by_id(self):
+        """Case 1: the production valor path sends to the numeric chat_id, not the name."""
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, *a, **kw):
+            calls.append(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with (
+            patch("reflections.docs_auditor.subprocess.run", side_effect=fake_run),
+            patch(
+                "reflections.docs_auditor.load_local_projects",
+                return_value=[self.VALOR_PROJECT],
+            ),
+        ):
+            sent = docs_auditor._send_telegram_notification(
+                "hello", repo_root=docs_auditor.PROJECT_ROOT
+            )
+
+        assert sent is True
+        argv = calls[0]
+        assert "-1003449100931" in argv
+        assert "Eng: Valor" not in argv
+
+    def test_foreign_registered_repo_routes_to_its_own_group(self, tmp_path):
+        """Case 2: a foreign registered repo with a configured Eng: group."""
+        foreign_project = {
+            "slug": "popoto",
+            "working_directory": str(tmp_path),
+            "telegram": {"groups": {"Eng: Popoto": {"chat_id": -5189826365}}},
+        }
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, *a, **kw):
+            calls.append(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with (
+            patch("reflections.docs_auditor.subprocess.run", side_effect=fake_run),
+            patch(
+                "reflections.docs_auditor.load_local_projects",
+                return_value=[self.VALOR_PROJECT, foreign_project],
+            ),
+        ):
+            sent = docs_auditor._send_telegram_notification("hi", repo_root=tmp_path)
+
+        assert sent is True
+        assert "-5189826365" in calls[0]
+
+    def test_project_root_with_empty_projects_falls_back_to_literal(self):
+        """Case 3: repo_root == PROJECT_ROOT with load_local_projects returning []."""
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, *a, **kw):
+            calls.append(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with (
+            patch("reflections.docs_auditor.subprocess.run", side_effect=fake_run),
+            patch("reflections.docs_auditor.load_local_projects", return_value=[]),
+        ):
+            sent = docs_auditor._send_telegram_notification(
+                "hi", repo_root=docs_auditor.PROJECT_ROOT
+            )
+
+        assert sent is True
+        assert "Eng: Valor" in calls[0]
+
+    def test_foreign_unregistered_repo_suppresses_send(self, tmp_path, caplog):
+        """Case 4: a foreign, unregistered repo sends nothing and returns False."""
+        with (
+            patch("reflections.docs_auditor.subprocess.run") as run,
+            patch("reflections.docs_auditor.load_local_projects", return_value=[]),
+            caplog.at_level("WARNING"),
+        ):
+            sent = docs_auditor._send_telegram_notification("hi", repo_root=tmp_path)
+
+        assert sent is False
+        run.assert_not_called()
+        assert str(tmp_path) in caplog.text
+
+    def test_registered_repo_with_malformed_group_suppresses_send(self, tmp_path):
+        """Case 5: a registered repo whose Eng: group is malformed (the royop shape)."""
+        malformed_project = {
+            "slug": "royop",
+            "working_directory": str(tmp_path),
+            "telegram": {"groups": {}},
+        }
+        with (
+            patch("reflections.docs_auditor.subprocess.run") as run,
+            patch(
+                "reflections.docs_auditor.load_local_projects",
+                return_value=[malformed_project],
+            ),
+        ):
+            sent = docs_auditor._send_telegram_notification("hi", repo_root=tmp_path)
+
+        assert sent is False
+        run.assert_not_called()
+
+    def test_load_local_projects_raising_falls_back_for_project_root_only(self, tmp_path, caplog):
+        """Case 6: ``load_local_projects`` raising is swallowed; ``PROJECT_ROOT``
+        still falls back to the literal, a foreign path returns False."""
+        with (
+            patch("reflections.docs_auditor.subprocess.run") as run,
+            patch(
+                "reflections.docs_auditor.load_local_projects",
+                side_effect=RuntimeError("boom"),
+            ),
+            caplog.at_level("WARNING"),
+        ):
+            sent_root = docs_auditor._send_telegram_notification(
+                "hi", repo_root=docs_auditor.PROJECT_ROOT
+            )
+            sent_foreign = docs_auditor._send_telegram_notification("hi", repo_root=tmp_path)
+
+        assert sent_root is True
+        assert "Eng: Valor" in run.call_args_list[0].args[0]
+        assert sent_foreign is False
+        assert "boom" in caplog.text
+
+    def test_subprocess_filenotfounderror_still_returns_true(self):
+        """Case 7a: a resolved destination whose ``subprocess.run`` raises
+        ``FileNotFoundError`` still returns True — a send was attempted, not
+        suppressed."""
+        with (
+            patch(
+                "reflections.docs_auditor.subprocess.run",
+                side_effect=FileNotFoundError,
+            ),
+            patch(
+                "reflections.docs_auditor.load_local_projects",
+                return_value=[self.VALOR_PROJECT],
+            ),
+        ):
+            sent = docs_auditor._send_telegram_notification(
+                "hi", repo_root=docs_auditor.PROJECT_ROOT
+            )
+
+        assert sent is True
+
+    def test_nonzero_exit_code_logs_warning_and_still_returns_true(self, caplog):
+        """Case 7b: a non-zero ``valor-telegram`` exit code on a resolved
+        destination logs a warning and still returns True."""
+        with (
+            patch(
+                "reflections.docs_auditor.subprocess.run",
+                return_value=MagicMock(returncode=1, stdout="", stderr="boom"),
+            ),
+            patch(
+                "reflections.docs_auditor.load_local_projects",
+                return_value=[self.VALOR_PROJECT],
+            ),
+            caplog.at_level("WARNING"),
+        ):
+            sent = docs_auditor._send_telegram_notification(
+                "hi", repo_root=docs_auditor.PROJECT_ROOT
+            )
+
+        assert sent is True
+        assert "valor-telegram exited 1" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# TestTelegramSuppressionReachesSummary — #2754
+# ---------------------------------------------------------------------------
+
+
+class TestTelegramSuppressionReachesSummary:
+    """A ``False`` return threads a suppression notice into the persisted summary."""
+
+    def test_zero_diff_suppression_reaches_summary(self, repo, auth_ok, patch_redis):
+        primary = repo / "docs" / "features" / "foo.md"
+        primary.write_text("# Foo\n" + "Padding line.\n" * 6)
+        audit_result = docs_auditor._ok_result(
+            "ok",
+            files_touched=[],
+            fixes_applied=0,
+            fixes_withheld=1,
+            withheld=[
+                {"doc": "docs/features/foo.md", "old": "a/b.py", "new": "a/c.py", "reason": "x"}
+            ],
+        )
+        with (
+            patch("reflections.docs_auditor.PROJECT_ROOT", repo),
+            patch("reflections.docs_auditor._git_dirty", return_value=False),
+            patch("reflections.docs_auditor._run_vault_drift_detection", return_value=0),
+            patch("reflections.docs_auditor.audit", return_value=audit_result),
+            patch("reflections.docs_auditor._file_issue_if_new", return_value=False),
+            patch("reflections.docs_auditor._send_telegram_notification", return_value=False),
+            patch("reflections.docs_auditor._update_rotation_hash"),
+            patch("reflections.docs_auditor._write_liveness"),
+        ):
+            result = docs_auditor.run_docs_auditor()
+
+        assert result["status"] == "skipped"
+        assert "suppressed" in result["summary"]
+        assert any("suppressed" in f for f in result["findings"])
+
+    def test_step9_suppression_reaches_summary_before_pr_url(self, repo, auth_ok, patch_redis):
+        primary = repo / "docs" / "features" / "foo.md"
+        primary.write_text("# Foo\n" + "Padding line.\n" * 6)
+        audit_result = docs_auditor._ok_result(
+            "ok", files_touched=["docs/features/foo.md"], fixes_applied=1
+        )
+        with (
+            patch("reflections.docs_auditor.PROJECT_ROOT", repo),
+            patch("reflections.docs_auditor._git_dirty", return_value=False),
+            patch("reflections.docs_auditor._git_diff_quiet", return_value=False),
+            patch("reflections.docs_auditor._run_vault_drift_detection", return_value=0),
+            patch("reflections.docs_auditor.audit", return_value=audit_result),
+            patch(
+                "reflections.docs_auditor._push_branch_and_pr",
+                return_value="https://github.com/o/r/pull/1",
+            ),
+            patch("reflections.docs_auditor._file_issue_if_new", return_value=False),
+            patch("reflections.docs_auditor._send_telegram_notification", return_value=False),
+            patch("reflections.docs_auditor._update_rotation_hash"),
+            patch("reflections.docs_auditor._write_liveness"),
+        ):
+            result = docs_auditor.run_docs_auditor()
+
+        assert result["status"] == "ok"
+        assert "suppressed" in result["summary"]
+        assert result["summary"].index("suppressed") < result["summary"].index("PR=")
+        assert any("suppressed" in f for f in result["findings"])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`reflections/docs_auditor.py::_send_telegram_notification` hardcoded its
destination as the literal `--chat "Eng: Valor"`, independent of which repo
was actually audited. This PR routes the notification by the audited repo
root instead:

- New `_resolve_notify_chat(repo_root)` matches `repo_root` against
  `projects.json`'s `working_directory` entries, resolves the matched
  project's `Eng:` group via `resolve_eng_group`, and returns its numeric
  `chat_id` (never the group name).
- Falls back to the `Eng: Valor` literal (`FALLBACK_ENG_CHAT`) only when the
  audited repo *is this checkout* — never for a foreign or unmatched repo.
- `_send_telegram_notification` now returns `bool`: `False` only on the
  no-destination path (no subprocess spawned); `True` on every path where a
  send was attempted, including a swallowed subprocess failure or a
  non-zero `valor-telegram` exit code (now logged, previously discarded).
- Both call sites in `run_docs_auditor` pass `repo_root=PROJECT_ROOT` and,
  on a `False` return, splice a suppression notice into the returned
  `summary` (the only field `agent/reflection_scheduler.py` persists and
  the dashboard renders) — placed before `PR={pr_url}` on the step-9 path
  so 500-char truncation can't drop it.

Full context, settled decisions, and the failure-path test strategy are in
the plan: `docs/plans/docs-auditor-telegram-sender-hardcodes-eng-valor.md`.

Closes #2754

## Test plan

- [x] `scripts/pytest-clean.sh tests/unit/test_docs_auditor_substrate.py -q` — 206 passed (10 new: `TestTelegramChatRouting` x8, `TestTelegramSuppressionReachesSummary` x2)
- [x] `scripts/pytest-clean.sh tests/unit/reflections/test_docs_auditor_git_surface.py tests/unit/reflections/test_utilities_resolve_eng_group.py tests/unit/reflections/test_sdlc_upvote_lanes.py -q` — 63 passed, untouched
- [x] `python -m ruff check .` / `python -m ruff format --check .` — clean
- [x] Plan's `## Verification` table — all 12 rows pass
- [x] `scripts/validate_docs_changed.py` — pass