### PR TITLE
Complete PR #3080's review findings post-merge: clear both delivery blockers (Refs #2701)

### DIFF
--- a/bridge/agent_catchup.py
+++ b/bridge/agent_catchup.py
@@ -400,7 +400,7 @@ async def read_thread(client, entity, lookback: timedelta | None = None) -> list
     for m in raw:
         if m.date < cutoff:
             break  # get_messages returns newest-first; older than cutoff → stop.
-        text = m.text or "" or _poll_transcript_text(m)
+        text = m.text or _poll_transcript_text(m)
         is_valor = bool(m.out)
         sender_name = _SENDER_VALOR
         sender_id = None

--- a/bridge/answer_routing.py
+++ b/bridge/answer_routing.py
@@ -196,11 +196,19 @@ async def resume_completed_session(
     bookkeeping, its ``react_if_worker_down`` (which needs the inbound
     ``message.id``), and its dedup short-circuit.
     """
+    import asyncio
     from pathlib import Path
 
     from bridge.dispatch import dispatch_telegram_session
+    from bridge.poll_registry import mark_session_polls_steered
     from bridge.telegram_bridge import DEFAULTS, _build_completed_resume_text
     from config.enums import SessionType
+
+    # Any answer route closes the question, not only a tap. The vote path marks
+    # the row itself before it gets here, and the marker is idempotent, so this
+    # is the typed-reply case: without it the row survives its full TTL and the
+    # resumed session pauses on an already-answered question every turn.
+    await asyncio.to_thread(mark_session_polls_steered, completed.session_id)
 
     augmented_text = _build_completed_resume_text(
         completed, text, reply_chain_context=reply_chain_context

--- a/bridge/answer_routing.py
+++ b/bridge/answer_routing.py
@@ -271,4 +271,5 @@ async def resume_completed_session(
             "mark_session_polls_steered failed for session_id=%s: %s",
             completed.session_id,
             exc,
+            exc_info=True,
         )

--- a/bridge/answer_routing.py
+++ b/bridge/answer_routing.py
@@ -254,4 +254,21 @@ async def resume_completed_session(
     # a no-op; the case this exists for is the typed reply, which without it
     # leaves the row open for its full TTL and pauses the resumed session on an
     # already-answered question every turn.
-    await asyncio.to_thread(mark_session_polls_steered, completed.session_id)
+    #
+    # Guarded: this call sits directly ahead of both callers' anti-duplicate
+    # sentinels — `_steering_session_enqueued = True` in telegram_bridge.py
+    # (set right after this function returns) and `mark_poll_dispatched(poll_id)`
+    # in poll_vote.py. `mark_session_polls_steered` itself never raises, but
+    # `asyncio.to_thread` can (e.g. a closed or shutting-down event loop), and an
+    # unhandled raise here would unwind past both sentinels — a duplicate enqueue
+    # on the prose path, or a released claim and re-dispatch on the vote path.
+    # The close-out is best-effort bookkeeping; it must never be the thing that
+    # breaks the sentinels it precedes.
+    try:
+        await asyncio.to_thread(mark_session_polls_steered, completed.session_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "mark_session_polls_steered failed for session_id=%s: %s",
+            completed.session_id,
+            exc,
+        )

--- a/bridge/answer_routing.py
+++ b/bridge/answer_routing.py
@@ -204,12 +204,6 @@ async def resume_completed_session(
     from bridge.telegram_bridge import DEFAULTS, _build_completed_resume_text
     from config.enums import SessionType
 
-    # Any answer route closes the question, not only a tap. The vote path marks
-    # the row itself before it gets here, and the marker is idempotent, so this
-    # is the typed-reply case: without it the row survives its full TTL and the
-    # resumed session pauses on an already-answered question every turn.
-    await asyncio.to_thread(mark_session_polls_steered, completed.session_id)
-
     augmented_text = _build_completed_resume_text(
         completed, text, reply_chain_context=reply_chain_context
     )
@@ -246,3 +240,18 @@ async def resume_completed_session(
         session_type=getattr(completed, "session_type", None) or SessionType.ENG,
         message_ts=message_ts,
     )
+
+    # Written LAST, and only after the dispatch returned — the same invariant the
+    # vote path states at bridge/poll_vote.py:219. `mark_poll_steered` srem's the
+    # row from POLL_OPEN_INDEX, and both `iter_unanswered_polls` and
+    # `poll_expired_unanswered` key on the marker's absence; closing before the
+    # dispatch would mean a raising `dispatch_telegram_session` leaves
+    # `translate_poll_vote`'s release-and-retry handler with nothing left to
+    # re-yield, permanently swallowing the human's tap.
+    #
+    # Any answer route closes the question, not only a tap. The marker is
+    # idempotent, so the vote path's own `mark_poll_steered` after this returns is
+    # a no-op; the case this exists for is the typed reply, which without it
+    # leaves the row open for its full TTL and pauses the resumed session on an
+    # already-answered question every turn.
+    await asyncio.to_thread(mark_session_polls_steered, completed.session_id)

--- a/bridge/poll_gating.py
+++ b/bridge/poll_gating.py
@@ -78,7 +78,7 @@ def poll_eligible(chat_id: str | int | None, session_id: str | None) -> PollElig
             return PollEligibility(ok=False, reason="unknown_session_type")
         # Newest record wins, matching the relay's own lookup idiom — a stale
         # duplicate row must not decide a live session's eligibility.
-        sessions.sort(key=lambda s: s.created_at or 0, reverse=True)
+        sessions.sort(key=lambda s: (s.created_at is not None, s.created_at), reverse=True)
         session = sessions[0]
 
         session_type = getattr(session, "session_type", None)

--- a/bridge/poll_reconcile.py
+++ b/bridge/poll_reconcile.py
@@ -126,19 +126,25 @@ async def adopt_orphaned_polls(client) -> None:
     # bails immediately at `lookup_poll(poll_id) is None`, so an un-adopted row
     # can never be reached by a subsequent vote no matter what closed it out.
     # Because ANY inbound chatter marks the hint (see `mark_session_polls_steered`),
-    # skipping steered hints here let an unrelated message permanently swallow a
-    # subsequent tap — exactly the failure class this PR exists to remove, and it
-    # contradicted the "a later tap still routes" claim in both
+    # skipping steered hints here would let an unrelated message permanently
+    # swallow a subsequent tap — exactly the failure class this PR exists to
+    # remove, and it would contradict the "a later tap still routes" claim in both
     # `bridge/telegram_bridge.py`'s close-out comment and
     # `docs/features/telegram-poll-questions.md`.
     #
-    # The scan-cost objection does not survive: a successful adoption promotes
-    # and DELETES the pending row, so the normal case costs one scan, not one per
-    # tick. The unbounded case is a hint whose poll was never sent, and the
-    # decline branches plus the terminal-failure branch already delete those.
+    # The scan-cost objection does not survive for the ordinary case: a successful
+    # adoption promotes and DELETES the pending row, so that case costs one scan,
+    # not one per tick. The delete branches cover every case the relay itself can
+    # observe. Two do survive to the TTL at one scan per tick — a crash between
+    # `register_pending_poll` and the send resolving (the atomic LPOP already
+    # consumed the work item, so nothing retries), and a permanently ambiguous
+    # match, which `_find_already_sent_poll` and `promote_pending_poll` both
+    # deliberately refuse to resolve. Both are identical to `main`; the skip would
+    # not have been a fix for either, since neither is closed out.
+    #
     # `promote_pending_poll` carries the steered marker onto the real row, so
-    # adopting a closed-out hint costs nothing further and the promoted row is
-    # born de-indexed.
+    # adopting a closed-out hint costs nothing further: `register_poll` indexes it
+    # and the carried marker de-indexes it again in the same call.
     for hint, row in iter_pending_polls():
         try:
             found = await _find_already_sent_poll(client, numeric_peer(row["chat_id"]), hint)

--- a/bridge/poll_reconcile.py
+++ b/bridge/poll_reconcile.py
@@ -121,13 +121,25 @@ async def adopt_orphaned_polls(client) -> None:
     from bridge.telegram_relay import _find_already_sent_poll
     from utils.peer import numeric_peer
 
+    # Deliberately does NOT skip a steered hint. Adoption is the only thing that
+    # makes a Race-6 orphan's later tap routable at all — `translate_poll_vote`
+    # bails immediately at `lookup_poll(poll_id) is None`, so an un-adopted row
+    # can never be reached by a subsequent vote no matter what closed it out.
+    # Because ANY inbound chatter marks the hint (see `mark_session_polls_steered`),
+    # skipping steered hints here let an unrelated message permanently swallow a
+    # subsequent tap — exactly the failure class this PR exists to remove, and it
+    # contradicted the "a later tap still routes" claim in both
+    # `bridge/telegram_bridge.py`'s close-out comment and
+    # `docs/features/telegram-poll-questions.md`.
+    #
+    # The scan-cost objection does not survive: a successful adoption promotes
+    # and DELETES the pending row, so the normal case costs one scan, not one per
+    # tick. The unbounded case is a hint whose poll was never sent, and the
+    # decline branches plus the terminal-failure branch already delete those.
+    # `promote_pending_poll` carries the steered marker onto the real row, so
+    # adopting a closed-out hint costs nothing further and the promoted row is
+    # born de-indexed.
     for hint, row in iter_pending_polls():
-        if poll_steered(hint):
-            # Answered in prose while the payload was still provisional. Adopting
-            # it would promote a row that `promote_pending_poll` immediately marks
-            # steered anyway, so the only thing the scan below buys is an
-            # `iter_messages` hit against Telegram on every tick until the 24h TTL.
-            continue
         try:
             found = await _find_already_sent_poll(client, numeric_peer(row["chat_id"]), hint)
         except Exception as e:  # noqa: BLE001

--- a/bridge/poll_reconcile.py
+++ b/bridge/poll_reconcile.py
@@ -122,6 +122,12 @@ async def adopt_orphaned_polls(client) -> None:
     from utils.peer import numeric_peer
 
     for hint, row in iter_pending_polls():
+        if poll_steered(hint):
+            # Answered in prose while the payload was still provisional. Adopting
+            # it would promote a row that `promote_pending_poll` immediately marks
+            # steered anyway, so the only thing the scan below buys is an
+            # `iter_messages` hit against Telegram on every tick until the 24h TTL.
+            continue
         try:
             found = await _find_already_sent_poll(client, numeric_peer(row["chat_id"]), hint)
         except Exception as e:  # noqa: BLE001

--- a/bridge/poll_registry.py
+++ b/bridge/poll_registry.py
@@ -363,10 +363,12 @@ def mark_poll_steered(poll_id: int | str) -> None:
     Only ``POLL_OPEN_INDEX`` is de-indexed. Called with a *hint* (the pending-row
     close-out below), the row deliberately stays in ``POLL_PENDING_INDEX`` until
     its TTL: the payload may still be in the relay outbox, and ``promote_pending_poll``
-    needs the row to carry this marker onto the real poll id. Every consumer of
-    that index therefore checks ``poll_steered`` itself — ``session_has_open_poll``
-    to stop reporting an answered question, ``adopt_orphaned_polls`` to stop
-    paying for a Telegram history scan per tick.
+    needs the row to carry this marker onto the real poll id. A consumer of that
+    index that cares therefore checks ``poll_steered`` itself —
+    ``session_has_open_poll`` does, to stop reporting an answered question.
+    ``adopt_orphaned_polls`` deliberately does **not**: adoption is the only thing
+    that makes a Race-6 orphan reachable by a later tap at all, so skipping a
+    marked hint would let an unrelated inbound message swallow that tap.
     """
     _redis().set(f"{POLL_STEERED_PREFIX}{poll_id}", _now_iso(), nx=True, ex=POLL_REGISTRY_TTL_S)
     _redis().srem(POLL_OPEN_INDEX, str(poll_id))

--- a/bridge/poll_registry.py
+++ b/bridge/poll_registry.py
@@ -377,7 +377,7 @@ def mark_poll_steered(poll_id: int | str) -> None:
 def mark_session_polls_steered(session_id: str | None) -> int:
     """Close out every outstanding poll for ``session_id``. Returns how many.
 
-    ``mark_poll_steered`` is written only by the vote path, so a human who
+    ``mark_poll_steered`` was written only by the vote path, so a human who
     *types* their answer instead of tapping leaves the row open for the full
     ``POLL_REGISTRY_TTL_S``. ``session_has_open_poll`` then keeps reporting a
     question that has already been answered, the nudge loop takes the pause

--- a/bridge/poll_registry.py
+++ b/bridge/poll_registry.py
@@ -359,6 +359,14 @@ def mark_poll_steered(poll_id: int | str) -> None:
     the ``poll_expired_unanswered`` operator signal key on this marker's absence
     — deliberately, rather than on a missing claim, or the signal would be blind
     to a claim that survived a failure.
+
+    Only ``POLL_OPEN_INDEX`` is de-indexed. Called with a *hint* (the pending-row
+    close-out below), the row deliberately stays in ``POLL_PENDING_INDEX`` until
+    its TTL: the payload may still be in the relay outbox, and ``promote_pending_poll``
+    needs the row to carry this marker onto the real poll id. Every consumer of
+    that index therefore checks ``poll_steered`` itself — ``session_has_open_poll``
+    to stop reporting an answered question, ``adopt_orphaned_polls`` to stop
+    paying for a Telegram history scan per tick.
     """
     _redis().set(f"{POLL_STEERED_PREFIX}{poll_id}", _now_iso(), nx=True, ex=POLL_REGISTRY_TTL_S)
     _redis().srem(POLL_OPEN_INDEX, str(poll_id))
@@ -386,13 +394,21 @@ def mark_session_polls_steered(session_id: str | None) -> int:
         return 0
     closed = 0
     try:
-        for poll_id, row in iter_unanswered_polls():
-            if row.get("session_id") == session_id:
-                mark_poll_steered(poll_id)
-                closed += 1
+        # Pending FIRST, open second — the order is load-bearing against a
+        # concurrent `promote_pending_poll`. Promoting reads `poll_steered(hint)`
+        # to carry the close-out onto the real poll id, then deletes the hint. Scan
+        # the open index first and a promotion landing between the two loops adds
+        # its row after loop 1 has passed and deletes the hint before loop 2
+        # reaches it, so neither loop sees it and the close-out is lost. This way
+        # round, either the hint is marked before the promotion reads it, or the
+        # promotion already ran and the real row is in the open index for loop 2.
         for hint, row in iter_pending_polls():
             if row.get("session_id") == session_id and not poll_steered(hint):
                 mark_poll_steered(hint)
+                closed += 1
+        for poll_id, row in iter_unanswered_polls():
+            if row.get("session_id") == session_id:
+                mark_poll_steered(poll_id)
                 closed += 1
     except Exception as exc:  # noqa: BLE001
         logger.warning("mark_session_polls_steered failed for %s: %s", session_id, exc)

--- a/bridge/poll_registry.py
+++ b/bridge/poll_registry.py
@@ -234,6 +234,12 @@ def promote_pending_poll(
             poll_id_hint,
         )
         return False
+    # Carry a prose-answer close-out forward. The hint may have been marked
+    # steered by `mark_session_polls_steered` while this payload was still in
+    # the outbox; without this the promoted row is born unsteered and re-opens
+    # the pause on a question the human already answered.
+    if poll_steered(poll_id_hint):
+        mark_poll_steered(poll_id)
     delete_pending_poll(poll_id_hint)
     return True
 
@@ -358,6 +364,43 @@ def mark_poll_steered(poll_id: int | str) -> None:
     _redis().srem(POLL_OPEN_INDEX, str(poll_id))
 
 
+def mark_session_polls_steered(session_id: str | None) -> int:
+    """Close out every outstanding poll for ``session_id``. Returns how many.
+
+    ``mark_poll_steered`` is written only by the vote path, so a human who
+    *types* their answer instead of tapping leaves the row open for the full
+    ``POLL_REGISTRY_TTL_S``. ``session_has_open_poll`` then keeps reporting a
+    question that has already been answered, the nudge loop takes the pause
+    branch every turn, and the session loses auto-continue for a day. Every
+    inbound answer route calls this, not just the tap.
+
+    A provisional row is marked by **hint** rather than deleted: the hint is
+    still the only evidence that a send may have landed, so orphan adoption
+    needs the row. ``promote_pending_poll`` carries the marker onto the real
+    poll id.
+
+    **Never raises** — a bookkeeping failure must not break the answer route it
+    hangs off.
+    """
+    if not session_id:
+        return 0
+    closed = 0
+    try:
+        for poll_id, row in iter_unanswered_polls():
+            if row.get("session_id") == session_id:
+                mark_poll_steered(poll_id)
+                closed += 1
+        for hint, row in iter_pending_polls():
+            if row.get("session_id") == session_id and not poll_steered(hint):
+                mark_poll_steered(hint)
+                closed += 1
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("mark_session_polls_steered failed for %s: %s", session_id, exc)
+    if closed:
+        logger.info("poll_closed_by_prose_answer session_id=%s polls=%d", session_id, closed)
+    return closed
+
+
 def poll_steered(poll_id: int | str) -> bool:
     return bool(_redis().exists(f"{POLL_STEERED_PREFIX}{poll_id}"))
 
@@ -419,6 +462,12 @@ def session_has_open_poll(session_id: str | None) -> bool:
     The open-question read the nudge-loop pause branch is conditioned on. It
     introduces no new state — it reads exactly what the registry already writes.
 
+    Both indexes are consulted. A poll enqueued by ``valor-ask-poll`` but not yet
+    picked up by the relay exists only as a provisional row, and the relay is a
+    polling loop while this predicate runs at turn end — so the window is real,
+    and during it a session with an outstanding question would otherwise be
+    nudged straight past it.
+
     **Never raises.** Any failure logs at warning and returns ``False``, so a
     Redis hiccup degrades to today's nudge behavior rather than wedging a
     session that has no outstanding question.
@@ -428,6 +477,9 @@ def session_has_open_poll(session_id: str | None) -> bool:
     try:
         for _poll_id, row in iter_unanswered_polls():
             if row.get("session_id") == session_id:
+                return True
+        for hint, row in iter_pending_polls():
+            if row.get("session_id") == session_id and not poll_steered(hint):
                 return True
         return False
     except Exception as exc:  # noqa: BLE001 — a routing read must never wedge the nudge loop

--- a/bridge/poll_vote.py
+++ b/bridge/poll_vote.py
@@ -40,11 +40,16 @@ from bridge.poll_registry import (
     takeover_poll_claim,
 )
 
-logger = logging.getLogger(__name__)
+#: The literal final option, re-exported from its single definition in
+#: ``tools.ask_poll`` (the producer that writes the label onto the poll).
+#: ``build_steer_text`` compares the tapped label against it by **equality**, so
+#: two independent literals drifting apart would silently stop the followup
+#: instruction from being emitted, with no error anywhere. Import rather than
+#: redeclare. Safe at module scope: ``tools.ask_poll`` imports only stdlib at
+#: import time and defers every ``bridge`` import into a function body.
+from tools.ask_poll import ESCAPE_HATCH_OPTION
 
-#: The literal final option. Tapping it is not an answer — it is a request for a
-#: better question, answered by a plain-text followup the human replies to.
-ESCAPE_HATCH_OPTION = "Other: wait for followup message"
+logger = logging.getLogger(__name__)
 
 
 def select_option(results, options: list[str]) -> int | None:

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -1048,10 +1048,20 @@ async def _ack_steering_routed(
     # routes. Failing to close costs a day of lost auto-continue. Documented in
     # docs/features/telegram-poll-questions.md.
     #
-    # Offloaded: this is a Redis scan on the bridge's event loop.
+    # Offloaded: this is a Redis scan on the bridge's event loop — and guarded
+    # for the same reason as the sibling call in `resume_completed_session`.
+    # `mark_session_polls_steered` never raises, but `asyncio.to_thread` can on a
+    # closing loop, and this site is the hotter of the two: it sits on the
+    # LIVE / PENDING / LIVE_GUARD routes, which set no
+    # `_steering_session_enqueued` sentinel, so a raise here falls through to the
+    # final enqueue and delivers the #997 duplicate. Best-effort bookkeeping must
+    # not break the routing it hangs off.
     from bridge.poll_registry import mark_session_polls_steered
 
-    await asyncio.to_thread(mark_session_polls_steered, session_id)
+    try:
+        await asyncio.to_thread(mark_session_polls_steered, session_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(f"mark_session_polls_steered failed for session_id={session_id}: {exc}")
 
     # #2694: the context-recall advisory rides as its own steering message,
     # never appended to the human's text — abort detection matches the human's

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -1034,6 +1034,15 @@ async def _ack_steering_routed(
     is_abort = text.strip().lower() in ABORT_KEYWORDS
     push_steering_message(session_id, text, sender_name, is_abort=is_abort, room_id=room_id)
 
+    # An answer typed into the chat closes the question just as a tap does. The
+    # registry is otherwise written only by the vote path, so a prose answer
+    # would leave the row open for its full TTL and the nudge loop would take
+    # `pause_open_question` every turn — auto-continue silently off for a day.
+    # Offloaded: this is a Redis scan on the bridge's event loop.
+    from bridge.poll_registry import mark_session_polls_steered
+
+    await asyncio.to_thread(mark_session_polls_steered, session_id)
+
     # #2694: the context-recall advisory rides as its own steering message,
     # never appended to the human's text — abort detection matches the human's
     # string EXACTLY (agent/steering.py), so concatenating an advisory onto a
@@ -3388,8 +3397,9 @@ async def main():
     try:
         from bridge.poll_reconcile import poll_reconcile_loop
 
+        # The loop logs its own start line; a second one here made it appear
+        # twice per bridge start.
         _background_tasks.append(asyncio.create_task(poll_reconcile_loop(client)))
-        logger.info("Poll reconciliation loop started")
     except Exception as e:
         logger.error(f"Failed to start poll reconciliation loop: {e}")
 

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -1043,10 +1043,12 @@ async def _ack_steering_routed(
     # like an answer": there is no reliable classifier for that, and the failure
     # directions are asymmetric. Closing on unrelated chatter costs the pause
     # branch (`agent/session_executor.py`) for a question still on screen — the
-    # session is nudged onward, and nothing is lost, because `translate_poll_vote`
-    # keys on `lookup_poll` and never on `poll_steered`, so a later tap still
-    # routes. Failing to close costs a day of lost auto-continue. Documented in
-    # docs/features/telegram-poll-questions.md.
+    # session is nudged onward, and a later tap still routes, because
+    # `translate_poll_vote` keys on `lookup_poll` and never on `poll_steered`.
+    # That routing is via the `events.Raw` fast path specifically: closing the row
+    # `SREM`s it from POLL_OPEN_INDEX, so the reconcile loop no longer re-yields it
+    # and is not a fallback here. Failing to close costs a day of lost
+    # auto-continue. Documented in docs/features/telegram-poll-questions.md.
     #
     # Offloaded: this is a Redis scan on the bridge's event loop — and guarded
     # for the same reason as the sibling call in `resume_completed_session`.

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -1063,7 +1063,12 @@ async def _ack_steering_routed(
     try:
         await asyncio.to_thread(mark_session_polls_steered, session_id)
     except Exception as exc:  # noqa: BLE001
-        logger.warning(f"mark_session_polls_steered failed for session_id={session_id}: {exc}")
+        logger.warning(
+            "mark_session_polls_steered failed for session_id=%s: %s",
+            session_id,
+            exc,
+            exc_info=True,
+        )
 
     # #2694: the context-recall advisory rides as its own steering message,
     # never appended to the human's text — abort detection matches the human's

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -1038,6 +1038,16 @@ async def _ack_steering_routed(
     # registry is otherwise written only by the vote path, so a prose answer
     # would leave the row open for its full TTL and the nudge loop would take
     # `pause_open_question` every turn — auto-continue silently off for a day.
+    #
+    # The semantics are ANY inbound steering message, not "a message that looks
+    # like an answer": there is no reliable classifier for that, and the failure
+    # directions are asymmetric. Closing on unrelated chatter costs the pause
+    # branch (`agent/session_executor.py`) for a question still on screen — the
+    # session is nudged onward, and nothing is lost, because `translate_poll_vote`
+    # keys on `lookup_poll` and never on `poll_steered`, so a later tap still
+    # routes. Failing to close costs a day of lost auto-continue. Documented in
+    # docs/features/telegram-poll-questions.md.
+    #
     # Offloaded: this is a Redis scan on the bridge's event loop.
     from bridge.poll_registry import mark_session_polls_steered
 

--- a/bridge/telegram_relay.py
+++ b/bridge/telegram_relay.py
@@ -1046,8 +1046,14 @@ def _poll_text_payload(message: dict) -> dict:
     }
 
 
-async def _reenqueue_poll_as_text(r, key: str, message: dict, *, reason: str) -> None:
-    """Push the question back onto the same outbox key as plain text."""
+async def _reenqueue_poll_as_text(r, key: str, message: dict, *, reason: str) -> bool:
+    """Push the question back onto the same outbox key as plain text.
+
+    Returns whether the push landed. A decline branch **must** honor ``False``: it
+    has already dropped the provisional row, so returning ``DELIVERED_NO_ID`` on a
+    failed push would leave the question with no outbox entry, no pending row and
+    no dead letter. Returning ``None`` instead puts it back on the retry path.
+    """
     try:
         await asyncio.to_thread(r.rpush, key, json.dumps(_poll_text_payload(message)))
         logger.info(
@@ -1056,8 +1062,10 @@ async def _reenqueue_poll_as_text(r, key: str, message: dict, *, reason: str) ->
             reason,
             message.get("chat_id"),
         )
+        return True
     except Exception as e:  # noqa: BLE001
         logger.error("Relay: failed to re-enqueue poll as text on %s: %s", key, e)
+        return False
 
 
 async def _find_already_sent_poll(telegram_client, chat_id, poll_id_hint: str):
@@ -1112,8 +1120,10 @@ async def _send_queued_poll(
     """Send a ``type: "poll"`` payload.
 
     Returns the sent message id; ``DELIVERED_NO_ID`` when the poll was declined
-    and the question was re-queued as prose instead; ``None`` only for a genuine
-    send failure the caller should retry.
+    and the prose fallback **landed** on the outbox; ``None`` for a genuine send
+    failure the caller should retry, and for a decline whose fallback push itself
+    failed — that branch has already dropped the provisional row, so the retry is
+    the only remaining record of the question.
 
     The sentinel is load-bearing. Both decline branches push the prose fallback
     before returning, so reporting them as failure makes ``process_outbox``
@@ -1148,8 +1158,8 @@ async def _send_queued_poll(
             chat_id,
             session_id,
         )
-        await _reenqueue_poll_as_text(r, key, message, reason="missing poll_id_hint")
-        return DELIVERED_NO_ID
+        pushed = await _reenqueue_poll_as_text(r, key, message, reason="missing poll_id_hint")
+        return DELIVERED_NO_ID if pushed else None
 
     # ── The provisional row is the FIRST statement, ahead of every await ──
     # `process_outbox` already consumed this work item with an atomic LPOP, so
@@ -1221,8 +1231,10 @@ async def _send_queued_poll(
             eligibility.reason,
         )
         await asyncio.to_thread(delete_pending_poll, poll_id_hint)
-        await _reenqueue_poll_as_text(r, key, message, reason=f"ineligible:{eligibility.reason}")
-        return DELIVERED_NO_ID
+        pushed = await _reenqueue_poll_as_text(
+            r, key, message, reason=f"ineligible:{eligibility.reason}"
+        )
+        return DELIVERED_NO_ID if pushed else None
 
     from bridge.response import send_poll
 
@@ -1481,10 +1493,15 @@ async def process_outbox(telegram_client) -> int:
                             await _reenqueue_poll_as_text(
                                 r, key, message, reason="terminal relay failure"
                             )
-                            # Retries are exhausted, so this poll provably never
-                            # landed. Leaving the provisional row alive makes
-                            # every reconcile tick run an `iter_messages` history
-                            # scan hunting for it until the 24h TTL.
+                            # All retries failed, so adoption is no longer worth
+                            # its per-tick cost: leaving the provisional row alive
+                            # makes every reconcile tick run an `iter_messages`
+                            # history scan hunting for it until the 24h TTL. Note
+                            # this is a cost trade, not proof of non-delivery —
+                            # a `None` from `send_poll` may still follow a send
+                            # that reached Telegram (see the note at the send
+                            # site), which is why the question is re-enqueued as
+                            # text above rather than simply dropped.
                             hint = message.get("poll_id_hint")
                             if hint:
                                 from bridge.poll_registry import delete_pending_poll

--- a/bridge/telegram_relay.py
+++ b/bridge/telegram_relay.py
@@ -1106,8 +1106,21 @@ async def _find_already_sent_poll(telegram_client, chat_id, poll_id_hint: str):
     return matches[0] if matches else None
 
 
-async def _send_queued_poll(telegram_client, message: dict, key: str) -> int | None:
-    """Send a ``type: "poll"`` payload. Returns the sent message id, or ``None``.
+async def _send_queued_poll(
+    telegram_client, message: dict, key: str
+) -> int | _DeliveredNoId | None:
+    """Send a ``type: "poll"`` payload.
+
+    Returns the sent message id; ``DELIVERED_NO_ID`` when the poll was declined
+    and the question was re-queued as prose instead; ``None`` only for a genuine
+    send failure the caller should retry.
+
+    The sentinel is load-bearing. Both decline branches push the prose fallback
+    before returning, so reporting them as failure makes ``process_outbox``
+    re-queue the *original poll payload*, which declines again for the same
+    reason and enqueues another copy of the question — up to
+    ``MAX_RELAY_RETRIES`` plus the terminal branch, each retry also burning an
+    ``iter_messages`` scan. Same shape as #2179 on the text path.
 
     Ordering inside this function is load-bearing and is asserted by test rather
     than left to reading order.
@@ -1136,7 +1149,7 @@ async def _send_queued_poll(telegram_client, message: dict, key: str) -> int | N
             session_id,
         )
         await _reenqueue_poll_as_text(r, key, message, reason="missing poll_id_hint")
-        return None
+        return DELIVERED_NO_ID
 
     # ── The provisional row is the FIRST statement, ahead of every await ──
     # `process_outbox` already consumed this work item with an atomic LPOP, so
@@ -1209,7 +1222,7 @@ async def _send_queued_poll(telegram_client, message: dict, key: str) -> int | N
         )
         await asyncio.to_thread(delete_pending_poll, poll_id_hint)
         await _reenqueue_poll_as_text(r, key, message, reason=f"ineligible:{eligibility.reason}")
-        return None
+        return DELIVERED_NO_ID
 
     from bridge.response import send_poll
 
@@ -1319,8 +1332,17 @@ async def process_outbox(telegram_client) -> int:
                         msg_id = await _send_custom_emoji_message(telegram_client, message)
                         success = msg_id is not None
                     elif msg_type == "poll":
-                        msg_id = await _send_queued_poll(telegram_client, message, key)
-                        success = msg_id is not None
+                        send_result = await _send_queued_poll(telegram_client, message, key)
+                        # A declined poll has already been re-queued as prose, so
+                        # the payload is consumed, not failed. Re-queuing it would
+                        # decline again and put a second copy of the question in
+                        # front of the human (#2179 shape, poll path).
+                        if send_result is DELIVERED_NO_ID:
+                            success = True
+                            msg_id = None
+                        else:
+                            msg_id = send_result
+                            success = msg_id is not None
                     else:
                         send_result = await _send_queued_message(telegram_client, message)
                         # A send that reached Telegram but returned no message id
@@ -1459,6 +1481,15 @@ async def process_outbox(telegram_client) -> int:
                             await _reenqueue_poll_as_text(
                                 r, key, message, reason="terminal relay failure"
                             )
+                            # Retries are exhausted, so this poll provably never
+                            # landed. Leaving the provisional row alive makes
+                            # every reconcile tick run an `iter_messages` history
+                            # scan hunting for it until the 24h TTL.
+                            hint = message.get("poll_id_hint")
+                            if hint:
+                                from bridge.poll_registry import delete_pending_poll
+
+                                await asyncio.to_thread(delete_pending_poll, hint)
                     else:
                         try:
                             requeue_raw = json.dumps(message)

--- a/bridge/telegram_relay.py
+++ b/bridge/telegram_relay.py
@@ -1049,10 +1049,19 @@ def _poll_text_payload(message: dict) -> dict:
 async def _reenqueue_poll_as_text(r, key: str, message: dict, *, reason: str) -> bool:
     """Push the question back onto the same outbox key as plain text.
 
-    Returns whether the push landed. A decline branch **must** honor ``False``: it
-    has already dropped the provisional row, so returning ``DELIVERED_NO_ID`` on a
-    failed push would leave the question with no outbox entry, no pending row and
-    no dead letter. Returning ``None`` instead puts it back on the retry path.
+    Returns whether the push landed. A decline branch **must** honor ``False``: by
+    the time it calls this, it has either dropped the provisional row (the
+    ineligible-at-send-time branch, after ``delete_pending_poll``) or never had one
+    to begin with (the missing-``poll_id_hint`` branch, which bails before
+    ``register_pending_poll`` runs). Either way there is no pending row behind it,
+    so returning ``DELIVERED_NO_ID`` on a failed push would leave the question with
+    no outbox entry, no pending row and no dead letter. Returning ``None`` instead
+    puts it back on the retry path — but
+    this only NARROWS the hole, it does not close it. The retry path's own re-queue
+    (``process_outbox``'s bounded-retry ``r.rpush`` of the original poll message)
+    uses the same primitive and the same failure is swallowed there too (logged,
+    not raised). So the question survives a single ``rpush`` failure, not two
+    consecutive ones.
     """
     try:
         await asyncio.to_thread(r.rpush, key, json.dumps(_poll_text_payload(message)))
@@ -1122,8 +1131,12 @@ async def _send_queued_poll(
     Returns the sent message id; ``DELIVERED_NO_ID`` when the poll was declined
     and the prose fallback **landed** on the outbox; ``None`` for a genuine send
     failure the caller should retry, and for a decline whose fallback push itself
-    failed — that branch has already dropped the provisional row, so the retry is
-    the only remaining record of the question.
+    failed — that branch has no pending row behind it (see
+    ``_reenqueue_poll_as_text``), so the retry is the only remaining record of the
+    question. That retry only NARROWS the hole rather than closing it: it re-queues
+    via the same ``r.rpush`` primitive, and ``process_outbox`` swallows that
+    failure too (logs, does not raise). The question is lost only on two
+    consecutive ``rpush`` failures, not one.
 
     The sentinel is load-bearing. Both decline branches push the prose fallback
     before returning, so reporting them as failure makes ``process_outbox``
@@ -1223,6 +1236,11 @@ async def _send_queued_poll(
 
     eligibility = await asyncio.to_thread(poll_eligible, chat_id, session_id)
     if not eligibility.ok:
+        # Returning None on a failed fallback push here sends this back through
+        # process_outbox's bounded retry, which pays `_find_already_sent_poll`'s
+        # `iter_messages` scan (POLL_ADOPTION_SCAN_LIMIT messages) for a poll that
+        # was never sent — bounded by MAX_RELAY_RETRIES and accepted, because the
+        # alternative is losing the question.
         logger.info(
             "Relay: poll ineligible at send time (chat_id=%s session_id=%s reason=%s) — "
             "delivering as text",

--- a/docs/features/eng-session-architecture.md
+++ b/docs/features/eng-session-architecture.md
@@ -292,6 +292,12 @@ The default (`False`) bounds the blast radius: every session with no outstanding
 every session today, and every eng session outside a machine-owned group tomorrow -- keeps today's
 behavior unchanged.
 
+The pause is released by an **answer**, and any inbound steering message counts as one: the registry
+row is closed on both the tap and the typed reply, so a session cannot be left paused on a question
+the human has already answered. The reverse -- unrelated chatter releasing the pause on a question
+still on screen -- is the deliberate trade, and the tap still routes afterwards. Mechanism and
+rationale: [Telegram Poll Questions](telegram-poll-questions.md).
+
 ### Key Constants
 - `MAX_NUDGE_COUNT = 50` -- safety cap
 - `NUDGE_MESSAGE` -- the single nudge text

--- a/docs/features/telegram-poll-questions.md
+++ b/docs/features/telegram-poll-questions.md
@@ -349,11 +349,12 @@ enqueues.
 **A provisional row is closed by marker, not delete.** The hint is still the only evidence a send may
 have landed, so deleting it would strand orphan adoption after a restart, and the payload may still
 be in the relay outbox. `promote_pending_poll` therefore carries the marker onto the real poll id
-when it lands. The row stays in `POLL_PENDING_INDEX` until its TTL and every consumer of that index
-checks `poll_steered` itself: `session_has_open_poll` to stop reporting an answered question,
-`adopt_orphaned_polls` to stop paying for a Telegram history scan per reconcile tick. The pending
-index is also scanned **before** the open index, so a `promote_pending_poll` interleaving between the
-two passes cannot drop the close-out between them.
+when it lands. The row stays in `POLL_PENDING_INDEX` until its TTL, and a consumer of that index
+that cares checks `poll_steered` itself: `session_has_open_poll` does, to stop reporting an answered
+question. **Orphan adoption deliberately does not** — see Race 6 below, where skipping a marked hint
+would let an unrelated inbound message swallow a later tap. The pending index is also scanned
+**before** the open index, so a `promote_pending_poll` interleaving between the two passes cannot
+drop the close-out between them.
 
 ## Failure recovery
 
@@ -410,11 +411,20 @@ Both halves are required:
    no dead letter. The terminal-failure branch deletes the row too: adoption stops being worth its
    per-tick cost once every retry has failed (a cost trade, not proof of non-delivery — the question
    is re-enqueued as text, not dropped).
-2. **Orphan adoption in the reconciliation loop**, skipping hints already closed out by a typed
-   answer, and otherwise matched on the correlation id embedded in the option bytes — **never on question text**, which is not unique (an agent re-asking after an
+2. **Orphan adoption in the reconciliation loop**, matched on the correlation id embedded in the
+   option bytes — **never on question text**, which is not unique (an agent re-asking after an
    expired poll, or two sessions asking the same standard question, produce two candidates with no
    tie-break). **More than one match adopts nothing and warns**: an ambiguous adoption steers a
    session with someone else's answer, which is worse than a dropped question.
+
+   Adoption deliberately does **not** skip a hint already closed out by an inbound message. Skipping
+   would mean the only thing that makes a Race-6 orphan's later tap routable — `translate_poll_vote`
+   bails immediately at `lookup_poll(poll_id) is None` — never runs for it, so an unrelated message
+   would permanently swallow a subsequent tap. That is the same failure class this feature exists to
+   remove, so a closed-out hint is scanned and adopted exactly like an open one; `promote_pending_poll`
+   carries the marker onto the real row, so the promoted row is born steered at no extra cost, and a
+   successful adoption promotes and deletes the pending row, keeping the per-tick scan cost to one hit
+   rather than one per tick.
 
 **Promotion is the second gate, and it can refuse.** Adopting means promoting the provisional row
 to a real one under the server-assigned poll id, and `register_poll` writes that row with `SET NX`.

--- a/docs/features/telegram-poll-questions.md
+++ b/docs/features/telegram-poll-questions.md
@@ -333,9 +333,12 @@ path).
 
 **The semantics are any inbound steering message, not "a message that plausibly answers".** There is
 no reliable classifier for the latter and the failure directions are asymmetric: closing on unrelated
-chatter costs the pause branch for a question still on screen — the session is nudged onward, and
-nothing is lost, because `translate_poll_vote` keys on `lookup_poll` and never on `poll_steered`, so a
-later tap still routes. Failing to close costs a day of lost auto-continue.
+chatter costs the pause branch for a question still on screen — the session is nudged onward, and a
+later tap still routes, because `translate_poll_vote` keys on `lookup_poll` and never on
+`poll_steered`. That routing is **via the `events.Raw` fast path specifically**: closing the row
+`SREM`s it from `POLL_OPEN_INDEX`, so the reconcile loop no longer re-yields it and is not a fallback
+for this case, which is the one place the "reconciliation is primary" framing above does not hold.
+Failing to close costs a day of lost auto-continue.
 
 **Ordering is the same invariant the vote path states**: the marker is written only *after* the
 route's side effect returns — the steering push in `_ack_steering_routed`, the
@@ -422,9 +425,15 @@ Both halves are required:
    bails immediately at `lookup_poll(poll_id) is None` — never runs for it, so an unrelated message
    would permanently swallow a subsequent tap. That is the same failure class this feature exists to
    remove, so a closed-out hint is scanned and adopted exactly like an open one; `promote_pending_poll`
-   carries the marker onto the real row, so the promoted row is born steered at no extra cost, and a
-   successful adoption promotes and deletes the pending row, keeping the per-tick scan cost to one hit
+   carries the marker onto the real row, so the promoted row is de-indexed again in the same call that
+   indexed it, and a successful adoption deletes the pending row, keeping the ordinary case to one scan
    rather than one per tick.
+
+   The delete branches cover every case the relay itself can observe. **Two survive to the TTL at one
+   scan per tick regardless**: a crash between `register_pending_poll` and the send resolving, where
+   the atomic `LPOP` has already consumed the work item so nothing retries; and a permanently ambiguous
+   match, which both the scan and promotion deliberately refuse to resolve. Neither is closed out, so
+   skipping steered hints would never have addressed them.
 
 **Promotion is the second gate, and it can refuse.** Adopting means promoting the provisional row
 to a real one under the server-assigned poll id, and `register_poll` writes that row with `SET NX`.

--- a/docs/features/telegram-poll-questions.md
+++ b/docs/features/telegram-poll-questions.md
@@ -194,6 +194,13 @@ eng+sdlc line, which is the only thing it overrides.
 fail-quiet) and passes the result in. `determine_delivery_action` stays a **pure function**, exactly
 as it performs no `AgentSession` read for `last_compaction_ts`.
 
+**Both indexes count as open.** The predicate consults `POLL_PENDING_INDEX` as well as
+`POLL_OPEN_INDEX`, because a question enqueued by `valor-ask-poll` but not yet picked up by the relay
+exists only as a provisional row. The relay is a polling loop and this predicate runs at turn end, so
+that window is real, and reading only the open index nudged a session straight past an outstanding
+question. A pending row that has already been closed out (see below) is skipped, so answering while
+the payload is still in the outbox does not re-open the pause.
+
 **Blast radius is bounded by the default.** `has_open_question` defaults to `False`, so every
 session with no outstanding poll keeps today's behavior — asserted by the pre-existing
 `tests/unit/test_output_router.py` cases passing unmodified.
@@ -222,7 +229,7 @@ entry**. Rows are created on demand and expire on their own.
 | `telegram:poll:{id}` | `chat_id`, `msg_id`, `session_id`, `question`, `options`, `created_at` | Written once with `SET NX`, never rewritten |
 | `telegram:poll:answered:{id}` | **the ISO-8601 claim timestamp** | The one-shot lock. A timestamp, never the constant `1`, so staleness is readable |
 | `telegram:poll:dispatched:{id}` | ISO timestamp | The steer/re-enqueue happened and must never repeat. Bounds the claim release |
-| `telegram:poll:steered_at:{id}` | ISO timestamp | The translation completed cleanly. What `iter_unanswered_polls` and the operator signal key on |
+| `telegram:poll:steered_at:{id}` | ISO timestamp | The answer was routed and the question is closed. What `iter_unanswered_polls` and the operator signal key on. Written by **every** answer route — the tap and the typed reply alike — and on each of them only after the route's own side effect returned |
 | `telegram:poll:warned:{id}` | `1` | Deduplicates `poll_expired_unanswered` |
 
 Storing these as fields inside one JSON value would make every marker write a read-modify-write on a
@@ -311,6 +318,43 @@ load-bearing: `dispatch_telegram_session` claims `(chat_id, telegram_message_id)
 `claim_message`, which is **inbound-only** — an outbound send never claims it — so a poll's message
 id is an unused, unique, stable dedup key for exactly this re-enqueue.
 
+### A typed reply closes the question too
+
+Nothing forces a human to tap. They can type the answer into the chat, and that steers the session
+correctly — but the registry row is what the nudge pause reads, so leaving it open costs the session
+auto-continue for the row's full `POLL_REGISTRY_TTL_S` (default 86400s), advancing one turn per human
+message with only an INFO log as signal.
+
+`mark_session_polls_steered(session_id)` closes every outstanding row for a session — idempotent,
+never raises — and hangs off both inbound seams: `_ack_steering_routed` in `bridge/telegram_bridge.py`
+(which every `LIVE` / `PENDING` / `LIVE_GUARD` route reaches, including both intake-classifier
+interjection sites) and `resume_completed_session` (the `COMPLETED` mainline shared with the vote
+path).
+
+**The semantics are any inbound steering message, not "a message that plausibly answers".** There is
+no reliable classifier for the latter and the failure directions are asymmetric: closing on unrelated
+chatter costs the pause branch for a question still on screen — the session is nudged onward, and
+nothing is lost, because `translate_poll_vote` keys on `lookup_poll` and never on `poll_steered`, so a
+later tap still routes. Failing to close costs a day of lost auto-continue.
+
+**Ordering is the same invariant the vote path states**: the marker is written only *after* the
+route's side effect returns — the steering push in `_ack_steering_routed`, the
+`dispatch_telegram_session` enqueue in `resume_completed_session`. Writing it first would be
+actively unsafe on the vote mainline rather than merely early: `mark_poll_steered` `SREM`s the row
+from `POLL_OPEN_INDEX` and `iter_unanswered_polls` additionally skips marked rows, so a raising
+dispatch would leave `translate_poll_vote`'s release-and-retry handler with nothing to re-yield and
+the human's tap permanently swallowed. Closing afterwards costs nothing, because the dispatch only
+enqueues.
+
+**A provisional row is closed by marker, not delete.** The hint is still the only evidence a send may
+have landed, so deleting it would strand orphan adoption after a restart, and the payload may still
+be in the relay outbox. `promote_pending_poll` therefore carries the marker onto the real poll id
+when it lands. The row stays in `POLL_PENDING_INDEX` until its TTL and every consumer of that index
+checks `poll_steered` itself: `session_has_open_poll` to stop reporting an answered question,
+`adopt_orphaned_polls` to stop paying for a Telegram history scan per reconcile tick. The pending
+index is also scanned **before** the open index, so a `promote_pending_poll` interleaving between the
+two passes cannot drop the close-out between them.
+
 ## Failure recovery
 
 ### The claim must not permanently swallow a question
@@ -322,8 +366,10 @@ permanently blocked agent. Four mechanisms:
 1. Everything after the claim runs in `try/except`, and the handler **deletes the claim** so the
    next reconciliation tick retries.
 2. Completion is recorded **separately from the claim** as `steered_at`, written only after the
-   steer returns. `poll_expired_unanswered` keys on the **absent steered marker, never on a missing
-   claim** — otherwise the operator signal would be blind to precisely this state.
+   steer returns — on the vote path and on the typed-reply path alike (see above; it is what makes
+   the retry in item 1 reachable at all). `poll_expired_unanswered` keys on the **absent steered
+   marker, never on a missing claim** — otherwise the operator signal would be blind to precisely
+   this state.
 3. `mark_poll_dispatched` runs immediately after the steer and **before anything else that can
    throw**, and the exception handler releases the claim **only when it is absent**. A blanket
    release re-opens the mirror failure: one vote, two enqueues on the `COMPLETED` mainline. The
@@ -358,9 +404,14 @@ Both halves are required:
    not merely "before `send_poll`". `process_outbox` already consumed the work item with an atomic
    LPOP, so the window between that LPOP and the provisional write is a silent *total* loss with
    nothing to adopt and no row to warn on. Every branch that then declines to send deletes the
-   provisional row on its way to prose.
-2. **Orphan adoption in the reconciliation loop**, matched on the correlation id embedded in the
-   option bytes — **never on question text**, which is not unique (an agent re-asking after an
+   provisional row on its way to prose, and reports the decline as delivered **only if the prose
+   fallback actually reached the outbox** — the row is already gone by then, so a swallowed `rpush`
+   failure reported as a delivery would leave the question with no outbox entry, no pending row and
+   no dead letter. The terminal-failure branch deletes the row too: adoption stops being worth its
+   per-tick cost once every retry has failed (a cost trade, not proof of non-delivery — the question
+   is re-enqueued as text, not dropped).
+2. **Orphan adoption in the reconciliation loop**, skipping hints already closed out by a typed
+   answer, and otherwise matched on the correlation id embedded in the option bytes — **never on question text**, which is not unique (an agent re-asking after an
    expired poll, or two sessions asking the same standard question, produce two candidates with no
    tie-break). **More than one match adopts nothing and warns**: an ambiguous adoption steers a
    session with someone else's answer, which is worse than a dropped question.

--- a/tests/unit/test_bridge_relay.py
+++ b/tests/unit/test_bridge_relay.py
@@ -1851,6 +1851,40 @@ class TestDeclinedPollIsDeliveredOnce:
         assert [p["type"] for p in requeued] == ["poll"], requeued
         assert requeued[0]["_relay_attempts"] == 1
 
+    @pytest.mark.asyncio
+    async def test_a_decline_whose_fallback_push_fails_still_retries(self):
+        """The sentinel must not report a delivery that never reached the outbox.
+
+        The ineligible branch deletes the provisional row before pushing the prose
+        fallback, so on a swallowed `rpush` failure the question would have no
+        outbox entry, no pending row and no dead letter. The branch reports the
+        decline as delivered only when the push landed.
+        """
+        from bridge.poll_gating import PollEligibility
+
+        mock_redis = self._run(TestPollDispatch._payload())
+        # First rpush is the prose fallback and fails; the second is the retry
+        # re-queue this test exists to prove still happens.
+        mock_redis.rpush.side_effect = [RuntimeError("redis blip"), 1]
+
+        with (
+            patch("bridge.telegram_relay._get_redis_connection", return_value=mock_redis),
+            patch("bridge.poll_registry.register_pending_poll", return_value=True),
+            patch("bridge.poll_registry.delete_pending_poll"),
+            patch(
+                "bridge.poll_gating.poll_eligible",
+                return_value=PollEligibility(ok=False, reason="not_eng_session"),
+            ),
+            patch("bridge.response.send_poll", new_callable=AsyncMock) as send_poll,
+            patch("bridge.telegram_relay._record_sent_message"),
+        ):
+            await process_outbox(MagicMock())
+
+        send_poll.assert_not_called()
+        requeued = [json.loads(c[0][1]) for c in mock_redis.rpush.call_args_list[1:]]
+        assert [p["type"] for p in requeued] == ["poll"], requeued
+        assert requeued[0]["_relay_attempts"] == 1
+
 
 class TestPollDeadLetterAndFallback:
     """#2701 Risk 5: a dropped question is a stuck agent."""

--- a/tests/unit/test_bridge_relay.py
+++ b/tests/unit/test_bridge_relay.py
@@ -1598,7 +1598,12 @@ class TestPollDispatch:
         ):
             result = await _send_queued_poll(MagicMock(), self._payload(), "telegram:outbox:sess-1")
 
-        assert result is None
+        # DELIVERED_NO_ID, not None: the prose fallback is already queued, so
+        # the payload is consumed. A None here makes `process_outbox` re-queue
+        # the original poll, which declines again and delivers a second copy.
+        from bridge.telegram_relay import DELIVERED_NO_ID
+
+        assert result is DELIVERED_NO_ID
         send_poll.assert_not_called()
         # The provisional row is removed so a declined send never ages into a
         # spurious orphan-adoption candidate.
@@ -1631,7 +1636,9 @@ class TestPollDispatch:
                 "telegram:outbox:sess-1",
             )
 
-        assert result is None
+        from bridge.telegram_relay import DELIVERED_NO_ID
+
+        assert result is DELIVERED_NO_ID
         send_poll.assert_not_called()
         requeued = json.loads(mock_redis.rpush.call_args[0][1])
         assert requeued["type"] is None
@@ -1751,6 +1758,98 @@ class TestPollDispatch:
             await _send_queued_poll(MagicMock(), self._payload(), "telegram:outbox:sess-1")
 
         assert recorded["thread"] is not loop_thread
+
+
+class TestDeclinedPollIsDeliveredOnce:
+    """A declined poll must reach the human exactly once.
+
+    The unit tests above exercise `_send_queued_poll` in isolation and so cannot
+    see this: the defect lives in the *interaction* with `process_outbox`, where
+    a `None` return means "retry" and re-queues the original poll payload. Both
+    decline branches push the prose fallback before returning, so a retry
+    declines again for the same reason and enqueues another copy — up to
+    MAX_RELAY_RETRIES, plus one more from the terminal branch. Asserted at the
+    `process_outbox` seam on purpose.
+    """
+
+    @staticmethod
+    def _run(payload):
+        mock_redis = MagicMock()
+        mock_redis.keys.return_value = ["telegram:outbox:sess-1"]
+        # One poll payload, then the queue drains. Anything the relay re-queues
+        # lands in `rpush`, which is what the assertions read.
+        mock_redis.lpop.side_effect = [json.dumps(payload), None]
+        return mock_redis
+
+    @staticmethod
+    def _requeued(mock_redis):
+        return [json.loads(call[0][1]) for call in mock_redis.rpush.call_args_list]
+
+    @pytest.mark.asyncio
+    async def test_ineligible_poll_is_not_requeued_as_a_poll(self):
+        from bridge.poll_gating import PollEligibility
+
+        mock_redis = self._run(TestPollDispatch._payload())
+
+        with (
+            patch("bridge.telegram_relay._get_redis_connection", return_value=mock_redis),
+            patch("bridge.poll_registry.register_pending_poll", return_value=True),
+            patch("bridge.poll_registry.delete_pending_poll"),
+            patch(
+                "bridge.poll_gating.poll_eligible",
+                return_value=PollEligibility(ok=False, reason="not_eng_session"),
+            ),
+            patch("bridge.response.send_poll", new_callable=AsyncMock) as send_poll,
+            patch("bridge.telegram_relay._record_sent_message"),
+        ):
+            await process_outbox(MagicMock())
+
+        send_poll.assert_not_called()
+        requeued = self._requeued(mock_redis)
+        assert [p["type"] for p in requeued] == [None], requeued
+        assert requeued[0]["text"].startswith("Which approach?")
+
+    @pytest.mark.asyncio
+    async def test_hintless_poll_is_not_requeued_as_a_poll(self):
+        mock_redis = self._run(TestPollDispatch._payload(poll_id_hint=None))
+
+        with (
+            patch("bridge.telegram_relay._get_redis_connection", return_value=mock_redis),
+            patch("bridge.response.send_poll", new_callable=AsyncMock) as send_poll,
+            patch("bridge.telegram_relay._record_sent_message"),
+        ):
+            await process_outbox(MagicMock())
+
+        send_poll.assert_not_called()
+        requeued = self._requeued(mock_redis)
+        assert [p["type"] for p in requeued] == [None], requeued
+
+    @pytest.mark.asyncio
+    async def test_genuine_send_failure_still_retries(self):
+        """The sentinel must not swallow a real failure.
+
+        `send_poll` returning None is a distinguishable failure whose provisional
+        row deliberately survives; that payload still belongs in the retry path.
+        """
+        from bridge.poll_gating import PollEligibility
+
+        mock_redis = self._run(TestPollDispatch._payload())
+
+        with (
+            patch("bridge.telegram_relay._get_redis_connection", return_value=mock_redis),
+            patch("bridge.poll_registry.register_pending_poll", return_value=True),
+            patch(
+                "bridge.poll_gating.poll_eligible",
+                return_value=PollEligibility(ok=True, reason="eligible"),
+            ),
+            patch("bridge.response.send_poll", new_callable=AsyncMock, return_value=None),
+            patch("bridge.telegram_relay._record_sent_message"),
+        ):
+            await process_outbox(MagicMock())
+
+        requeued = self._requeued(mock_redis)
+        assert [p["type"] for p in requeued] == ["poll"], requeued
+        assert requeued[0]["_relay_attempts"] == 1
 
 
 class TestPollDeadLetterAndFallback:

--- a/tests/unit/test_poll_prose_answer_closeout.py
+++ b/tests/unit/test_poll_prose_answer_closeout.py
@@ -242,23 +242,53 @@ class TestAdoptionStillScansAndPromotesASteeredHint:
     """
 
     @pytest.mark.asyncio
-    async def test_steered_hint_is_still_passed_to_the_scan_and_promoted_when_found(self):
+    async def test_steered_hint_is_still_scanned_and_the_promoted_row_is_born_steered(
+        self, redis_test_db
+    ):
+        """Runs against real Redis, and the hint is genuinely marked steered.
+
+        Patching `iter_pending_polls` and asserting the scan saw the hint would
+        pass identically with the skip re-added, since nothing in that setup makes
+        the hint steered. The marker has to be a real registry write, and the
+        promoted row has to be read back, or the test asserts nothing.
+        """
+        import uuid
+
+        from bridge import poll_registry as reg
         from bridge.poll_reconcile import adopt_orphaned_polls
 
-        row = {"chat_id": "-1001", "session_id": "sess-1"}
-        with (
-            patch(
-                "bridge.poll_reconcile.iter_pending_polls",
-                return_value=iter([("hint-steered", row)]),
-            ),
-            patch(
-                "bridge.telegram_relay._find_already_sent_poll",
-                new_callable=AsyncMock,
-                return_value=(67890, "server-poll-id"),
-            ) as find,
-            patch("bridge.poll_reconcile.promote_pending_poll") as promote,
-        ):
-            await adopt_orphaned_polls(MagicMock())
+        hint = uuid.uuid4().hex
+        poll_id = f"test-{uuid.uuid4().hex[:12]}"
+        try:
+            reg.register_pending_poll(
+                hint, chat_id=-1001, session_id="sess-1", question="Q?", options=["A", "B"]
+            )
+            # Unrelated chatter, not an answer — this is the case the skip broke.
+            reg.mark_session_polls_steered("sess-1")
+            assert reg.poll_steered(hint) is True
 
-        assert [c.args[2] for c in find.call_args_list] == ["hint-steered"]
-        promote.assert_called_once_with("hint-steered", "server-poll-id", msg_id=67890)
+            # Scoped to this test's hint: the claimed db is shared with sibling
+            # tests, and a blanket return would try to promote their rows onto
+            # this poll id too.
+            async def _find(_client, _peer, scanned_hint):
+                return (67890, poll_id) if scanned_hint == hint else None
+
+            with patch(
+                "bridge.telegram_relay._find_already_sent_poll",
+                new=_find,
+            ):
+                await adopt_orphaned_polls(MagicMock())
+
+            # Adopted, so a later tap resolves a row instead of dying at
+            # `lookup_poll(poll_id) is None` — and the row is born steered, so it
+            # costs the reconcile loop nothing.
+            assert reg.lookup_poll(poll_id) is not None
+            assert reg.poll_steered(poll_id) is True
+            assert reg.lookup_pending_poll(hint) is None
+        finally:
+            r = reg._redis()
+            reg.delete_pending_poll(hint)
+            r.delete(f"{reg.POLL_STEERED_PREFIX}{hint}")
+            for prefix in (reg.POLL_ROW_PREFIX, reg.POLL_STEERED_PREFIX):
+                r.delete(f"{prefix}{poll_id}")
+            r.srem(reg.POLL_OPEN_INDEX, poll_id)

--- a/tests/unit/test_poll_prose_answer_closeout.py
+++ b/tests/unit/test_poll_prose_answer_closeout.py
@@ -225,33 +225,40 @@ class TestResumeCompletedSessionClosesThePoll:
         assert calls == []
 
 
-class TestAdoptionSkipsAClosedProvisionalRow:
-    """A prose-answered hint must stop costing a Telegram history scan per tick.
+class TestAdoptionStillScansAndPromotesASteeredHint:
+    """A steered hint is deliberately still adopted, not skipped.
 
-    The close-out marks a provisional row rather than deleting it, because the
-    payload may still be in the outbox and ``promote_pending_poll`` needs the row
-    to carry the marker forward. The row therefore stays in ``POLL_PENDING_INDEX``,
-    and ``adopt_orphaned_polls`` — which runs every reconcile tick for the full 24h
-    TTL — has to skip it itself.
+    Adoption is the only thing that makes a Race-6 orphan's later tap routable
+    at all: ``translate_poll_vote`` bails immediately at
+    ``lookup_poll(poll_id) is None``, so an un-adopted row can never be reached
+    by a subsequent vote regardless of what closed it out. Because ANY inbound
+    chatter marks the hint (``mark_session_polls_steered``), skipping steered
+    hints here would let an unrelated message permanently swallow a subsequent
+    tap — exactly the failure class #2701 exists to remove. The scan-cost
+    objection does not hold either: a successful adoption promotes and DELETES
+    the pending row, so the normal case costs one scan, not one per tick.
+    ``promote_pending_poll`` carries the steered marker onto the real row, so
+    the promoted row is born steered at no extra cost.
     """
 
     @pytest.mark.asyncio
-    async def test_a_steered_hint_is_not_scanned(self):
+    async def test_steered_hint_is_still_passed_to_the_scan_and_promoted_when_found(self):
         from bridge.poll_reconcile import adopt_orphaned_polls
 
         row = {"chat_id": "-1001", "session_id": "sess-1"}
         with (
             patch(
                 "bridge.poll_reconcile.iter_pending_polls",
-                return_value=iter([("hint-closed", row), ("hint-open", row)]),
+                return_value=iter([("hint-steered", row)]),
             ),
-            patch("bridge.poll_reconcile.poll_steered", side_effect=lambda h: h == "hint-closed"),
             patch(
                 "bridge.telegram_relay._find_already_sent_poll",
                 new_callable=AsyncMock,
-                return_value=None,
+                return_value=(67890, "server-poll-id"),
             ) as find,
+            patch("bridge.poll_reconcile.promote_pending_poll") as promote,
         ):
             await adopt_orphaned_polls(MagicMock())
 
-        assert [c.args[2] for c in find.call_args_list] == ["hint-open"]
+        assert [c.args[2] for c in find.call_args_list] == ["hint-steered"]
+        promote.assert_called_once_with("hint-steered", "server-poll-id", msg_id=67890)

--- a/tests/unit/test_poll_prose_answer_closeout.py
+++ b/tests/unit/test_poll_prose_answer_closeout.py
@@ -225,6 +225,93 @@ class TestResumeCompletedSessionClosesThePoll:
         assert calls == []
 
 
+class TestACloseOutFailureNeverBreaksTheSentinelItPrecedes:
+    """The close-out is best-effort bookkeeping, and both sites must survive it.
+
+    Each call sits directly ahead of its caller's anti-duplicate sentinel —
+    ``_steering_session_enqueued`` on the prose path, ``mark_poll_dispatched`` on
+    the vote path — neither of which is reached if the close-out raises. The
+    consequence is a duplicate: a second enqueue of the human's message (#997),
+    or a released claim that re-dispatches the same vote. Without these two tests
+    both ``try/except`` blocks could be deleted and nothing in the tree would
+    fail.
+    """
+
+    @pytest.mark.asyncio
+    async def test_resume_completed_session_returns_normally(self):
+        """The COMPLETED route: returning is what lets the caller stamp its flag."""
+        from bridge.answer_routing import resume_completed_session
+
+        completed = MagicMock()
+        completed.session_id = "sess-1"
+        completed.project_key = "valor"
+        completed.working_dir = "/tmp/wd"
+        completed.project_config = None
+        completed.session_type = None
+
+        with (
+            patch(
+                "bridge.poll_registry.mark_session_polls_steered",
+                side_effect=RuntimeError("event loop is closed"),
+            ),
+            patch(
+                "bridge.telegram_bridge._build_completed_resume_text",
+                return_value="augmented",
+            ),
+            patch(
+                "bridge.dispatch.dispatch_telegram_session",
+                new_callable=AsyncMock,
+            ) as dispatch,
+        ):
+            await resume_completed_session(
+                completed=completed,
+                text="option B",
+                sender_name="Alice",
+                telegram_chat_id="12345",
+                telegram_message_id=67890,
+            )
+
+        # The dispatch still happened, and the failure did not propagate.
+        dispatch.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_ack_steering_routed_returns_normally(self):
+        """The LIVE / PENDING / LIVE_GUARD routes, which set no sentinel at all.
+
+        A raise here does not merely skip a flag — it unwinds into the caller's
+        fall-through and delivers the #997 duplicate, which is why this is the
+        hotter of the two sites.
+        """
+        from bridge.telegram_bridge import _ack_steering_routed
+
+        event, message = _make_event_message()
+        with (
+            patch("bridge.telegram_bridge.push_steering_message") as push,
+            patch("bridge.telegram_bridge.set_reaction", new_callable=AsyncMock),
+            patch(
+                "bridge.telegram_bridge.record_telegram_message_handled",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "bridge.poll_registry.mark_session_polls_steered",
+                side_effect=RuntimeError("event loop is closed"),
+            ),
+        ):
+            await _ack_steering_routed(
+                MagicMock(),
+                event,
+                message,
+                session_id="sess-1",
+                sender_name="Alice",
+                text="option B",
+                log_context="[test] steer log",
+                room_id="test|system",
+            )
+
+        # The human's message reached the inbox and the failure did not propagate.
+        push.assert_called_once()
+
+
 class TestAdoptionStillScansAndPromotesASteeredHint:
     """A steered hint is deliberately still adopted, not skipped.
 
@@ -235,10 +322,9 @@ class TestAdoptionStillScansAndPromotesASteeredHint:
     chatter marks the hint (``mark_session_polls_steered``), skipping steered
     hints here would let an unrelated message permanently swallow a subsequent
     tap — exactly the failure class #2701 exists to remove. The scan-cost
-    objection does not hold either: a successful adoption promotes and DELETES
-    the pending row, so the normal case costs one scan, not one per tick.
-    ``promote_pending_poll`` carries the steered marker onto the real row, so
-    the promoted row is born steered at no extra cost.
+    objection that motivated the skip is answered at
+    ``bridge/poll_reconcile.py``'s loop comment, which is the authoritative
+    statement of it; do not restate it here, where it drifted once already.
     """
 
     @pytest.mark.asyncio
@@ -259,36 +345,28 @@ class TestAdoptionStillScansAndPromotesASteeredHint:
 
         hint = uuid.uuid4().hex
         poll_id = f"test-{uuid.uuid4().hex[:12]}"
-        try:
-            reg.register_pending_poll(
-                hint, chat_id=-1001, session_id="sess-1", question="Q?", options=["A", "B"]
-            )
-            # Unrelated chatter, not an answer — this is the case the skip broke.
-            reg.mark_session_polls_steered("sess-1")
-            assert reg.poll_steered(hint) is True
+        reg.register_pending_poll(
+            hint, chat_id=-1001, session_id="sess-1", question="Q?", options=["A", "B"]
+        )
+        # Unrelated chatter, not an answer — this is the case the skip broke.
+        reg.mark_session_polls_steered("sess-1")
+        assert reg.poll_steered(hint) is True
 
-            # Scoped to this test's hint: the claimed db is shared with sibling
-            # tests, and a blanket return would try to promote their rows onto
-            # this poll id too.
-            async def _find(_client, _peer, scanned_hint):
-                return (67890, poll_id) if scanned_hint == hint else None
+        # Keyed on this test's own hint rather than returning a blanket match:
+        # `adopt_orphaned_polls` walks the whole pending index, so a blanket
+        # match would promote every row it finds onto this one poll id the
+        # moment this class grows a second fixture.
+        async def _find(_client, _peer, scanned_hint):
+            return (67890, poll_id) if scanned_hint == hint else None
 
-            with patch(
-                "bridge.telegram_relay._find_already_sent_poll",
-                new=_find,
-            ):
-                await adopt_orphaned_polls(MagicMock())
+        with patch("bridge.telegram_relay._find_already_sent_poll", new=_find):
+            await adopt_orphaned_polls(MagicMock())
 
-            # Adopted, so a later tap resolves a row instead of dying at
-            # `lookup_poll(poll_id) is None` — and the row is born steered, so it
-            # costs the reconcile loop nothing.
-            assert reg.lookup_poll(poll_id) is not None
-            assert reg.poll_steered(poll_id) is True
-            assert reg.lookup_pending_poll(hint) is None
-        finally:
-            r = reg._redis()
-            reg.delete_pending_poll(hint)
-            r.delete(f"{reg.POLL_STEERED_PREFIX}{hint}")
-            for prefix in (reg.POLL_ROW_PREFIX, reg.POLL_STEERED_PREFIX):
-                r.delete(f"{prefix}{poll_id}")
-            r.srem(reg.POLL_OPEN_INDEX, poll_id)
+        # Adopted, so a later tap resolves a row instead of dying at
+        # `lookup_poll(poll_id) is None` — and the marker is carried over, so the
+        # promoted row costs the reconcile loop nothing.
+        assert reg.lookup_poll(poll_id) is not None
+        assert reg.poll_steered(poll_id) is True
+        assert reg.lookup_pending_poll(hint) is None
+        # No cleanup block: `redis_test_db` is autouse and flushes the claimed db
+        # both before and after every test (tests/conftest.py).

--- a/tests/unit/test_poll_prose_answer_closeout.py
+++ b/tests/unit/test_poll_prose_answer_closeout.py
@@ -1,0 +1,179 @@
+"""Every answer route closes the poll, not only a tap (#2701 review blocker 2).
+
+``mark_poll_steered`` is written by the vote path. Nothing else called it, so a
+human who typed their answer instead of tapping left the registry row alive for
+its full ``POLL_REGISTRY_TTL_S`` — ``session_has_open_poll`` kept reporting an
+open question, the nudge loop took ``pause_open_question`` every turn, and the
+session lost auto-continue for a day while advancing one turn per human message.
+
+These tests assert the **wiring**, at the two seams every prose answer passes
+through. ``tests/unit/test_poll_registry.py`` covers the registry function's own
+semantics against real Redis; the defect was that nobody called it.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_event_message(chat_id: int = 12345, msg_id: int = 67890):
+    event = MagicMock()
+    event.chat_id = chat_id
+    message = MagicMock()
+    message.id = msg_id
+    message.media = None
+    return event, message
+
+
+class TestSteeringLadderClosesThePoll:
+    """The live / pending / live-guard routes all land in ``_ack_steering_routed``.
+
+    Wiring it here rather than at each branch also covers the intake-classifier
+    interjection call sites, which reach the same helper.
+    """
+
+    @pytest.mark.asyncio
+    async def test_typed_reply_closes_the_open_poll(self):
+        from bridge.telegram_bridge import _ack_steering_routed
+
+        event, message = _make_event_message()
+        with (
+            patch("bridge.telegram_bridge.push_steering_message"),
+            patch("bridge.telegram_bridge.set_reaction", new_callable=AsyncMock),
+            patch(
+                "bridge.telegram_bridge.record_telegram_message_handled",
+                new_callable=AsyncMock,
+            ),
+            patch("bridge.poll_registry.mark_session_polls_steered") as close_out,
+        ):
+            await _ack_steering_routed(
+                MagicMock(),
+                event,
+                message,
+                session_id="sess-1",
+                sender_name="Alice",
+                text="option B, and skip the migration",
+                log_context="[test] steer log",
+                room_id="test|system",
+            )
+
+        close_out.assert_called_once_with("sess-1")
+
+    @pytest.mark.asyncio
+    async def test_abort_also_closes_the_poll(self):
+        """An abort kills the session, so the question is moot either way.
+
+        Leaving the row open would keep pausing a session that is already dead.
+        """
+        from bridge.telegram_bridge import _ack_steering_routed
+
+        event, message = _make_event_message()
+        with (
+            patch("bridge.telegram_bridge.push_steering_message"),
+            patch("bridge.telegram_bridge.set_reaction", new_callable=AsyncMock),
+            patch(
+                "bridge.telegram_bridge.record_telegram_message_handled",
+                new_callable=AsyncMock,
+            ),
+            patch("bridge.poll_registry.mark_session_polls_steered") as close_out,
+        ):
+            await _ack_steering_routed(
+                MagicMock(),
+                event,
+                message,
+                session_id="sess-1",
+                sender_name="Alice",
+                text="stop",
+                log_context="[test] abort log",
+                room_id="test|system",
+            )
+
+        close_out.assert_called_once_with("sess-1")
+
+    @pytest.mark.asyncio
+    async def test_close_out_runs_after_the_steering_push(self):
+        """The human's message reaches the steering inbox first.
+
+        Bookkeeping hangs off the answer route and must never sit between the
+        human's message and the inbox it is aimed at.
+        """
+        from bridge.telegram_bridge import _ack_steering_routed
+
+        event, message = _make_event_message()
+        calls = []
+        with (
+            patch(
+                "bridge.telegram_bridge.push_steering_message",
+                side_effect=lambda *a, **kw: calls.append("push"),
+            ),
+            patch("bridge.telegram_bridge.set_reaction", new_callable=AsyncMock),
+            patch(
+                "bridge.telegram_bridge.record_telegram_message_handled",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "bridge.poll_registry.mark_session_polls_steered",
+                side_effect=lambda sid: calls.append("close_out"),
+            ),
+        ):
+            await _ack_steering_routed(
+                MagicMock(),
+                event,
+                message,
+                session_id="sess-1",
+                sender_name="Alice",
+                text="option B",
+                log_context="[test] steer log",
+                room_id="test|system",
+            )
+
+        assert calls == ["push", "close_out"]
+
+
+class TestResumeCompletedSessionClosesThePoll:
+    """The completed branch is the mainline for a poll answer, not an edge case."""
+
+    @staticmethod
+    def _completed():
+        completed = MagicMock()
+        completed.session_id = "sess-1"
+        completed.project_key = "valor"
+        completed.working_dir = "/tmp/wd"
+        completed.project_config = None
+        completed.session_type = None
+        return completed
+
+    @pytest.mark.asyncio
+    async def test_close_out_precedes_the_re_enqueue(self):
+        """Ordering matters: the resumed turn reads the registry at its end.
+
+        Closing after the dispatch would race the very turn this resume starts.
+        """
+        from bridge.answer_routing import resume_completed_session
+
+        calls = []
+
+        with (
+            patch(
+                "bridge.poll_registry.mark_session_polls_steered",
+                side_effect=lambda sid: calls.append(("close_out", sid)),
+            ),
+            patch(
+                "bridge.telegram_bridge._build_completed_resume_text",
+                return_value="augmented",
+            ),
+            patch(
+                "bridge.dispatch.dispatch_telegram_session",
+                new_callable=AsyncMock,
+                side_effect=lambda **kw: calls.append(("dispatch", kw["session_id"])),
+            ),
+        ):
+            await resume_completed_session(
+                completed=self._completed(),
+                text="option B",
+                sender_name="Alice",
+                telegram_chat_id="12345",
+                telegram_message_id=67890,
+            )
+
+        assert calls == [("close_out", "sess-1"), ("dispatch", "sess-1")]

--- a/tests/unit/test_poll_prose_answer_closeout.py
+++ b/tests/unit/test_poll_prose_answer_closeout.py
@@ -144,10 +144,17 @@ class TestResumeCompletedSessionClosesThePoll:
         return completed
 
     @pytest.mark.asyncio
-    async def test_close_out_precedes_the_re_enqueue(self):
-        """Ordering matters: the resumed turn reads the registry at its end.
+    async def test_close_out_follows_the_re_enqueue(self):
+        """The marker certifies a dispatch that already happened.
 
-        Closing after the dispatch would race the very turn this resume starts.
+        `translate_poll_vote` reaches this on the COMPLETED mainline, and its own
+        `mark_poll_steered` is written last for exactly this reason: the marker
+        de-indexes the poll from POLL_OPEN_INDEX, and both `iter_unanswered_polls`
+        and `poll_expired_unanswered` key on its absence. Closing first would make
+        the release-and-retry handler inert against a raising dispatch.
+
+        Closing after costs nothing: the dispatch only enqueues, so the resumed
+        turn's registry read is orders of magnitude later.
         """
         from bridge.answer_routing import resume_completed_session
 
@@ -176,4 +183,75 @@ class TestResumeCompletedSessionClosesThePoll:
                 telegram_message_id=67890,
             )
 
-        assert calls == [("close_out", "sess-1"), ("dispatch", "sess-1")]
+        assert calls == [("dispatch", "sess-1"), ("close_out", "sess-1")]
+
+    @pytest.mark.asyncio
+    async def test_a_failed_dispatch_leaves_the_poll_open(self):
+        """The tap survives a dispatch failure and the retry can still find it.
+
+        `translate_poll_vote` releases its claim on an exception so the next
+        reconcile tick retries. That retry reads POLL_OPEN_INDEX and skips steered
+        rows, so a close-out written before the dispatch would permanently swallow
+        the human's answer.
+        """
+        from bridge.answer_routing import resume_completed_session
+
+        calls = []
+
+        with (
+            patch(
+                "bridge.poll_registry.mark_session_polls_steered",
+                side_effect=lambda sid: calls.append(("close_out", sid)),
+            ),
+            patch(
+                "bridge.telegram_bridge._build_completed_resume_text",
+                return_value="augmented",
+            ),
+            patch(
+                "bridge.dispatch.dispatch_telegram_session",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("queue down"),
+            ),
+            pytest.raises(RuntimeError, match="queue down"),
+        ):
+            await resume_completed_session(
+                completed=self._completed(),
+                text="option B",
+                sender_name="Alice",
+                telegram_chat_id="12345",
+                telegram_message_id=67890,
+            )
+
+        assert calls == []
+
+
+class TestAdoptionSkipsAClosedProvisionalRow:
+    """A prose-answered hint must stop costing a Telegram history scan per tick.
+
+    The close-out marks a provisional row rather than deleting it, because the
+    payload may still be in the outbox and ``promote_pending_poll`` needs the row
+    to carry the marker forward. The row therefore stays in ``POLL_PENDING_INDEX``,
+    and ``adopt_orphaned_polls`` — which runs every reconcile tick for the full 24h
+    TTL — has to skip it itself.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_steered_hint_is_not_scanned(self):
+        from bridge.poll_reconcile import adopt_orphaned_polls
+
+        row = {"chat_id": "-1001", "session_id": "sess-1"}
+        with (
+            patch(
+                "bridge.poll_reconcile.iter_pending_polls",
+                return_value=iter([("hint-closed", row), ("hint-open", row)]),
+            ),
+            patch("bridge.poll_reconcile.poll_steered", side_effect=lambda h: h == "hint-closed"),
+            patch(
+                "bridge.telegram_relay._find_already_sent_poll",
+                new_callable=AsyncMock,
+                return_value=None,
+            ) as find,
+        ):
+            await adopt_orphaned_polls(MagicMock())
+
+        assert [c.args[2] for c in find.call_args_list] == ["hint-open"]

--- a/tests/unit/test_poll_registry.py
+++ b/tests/unit/test_poll_registry.py
@@ -35,6 +35,9 @@ def hint(redis_test_db):
     h = uuid.uuid4().hex
     yield h
     reg.delete_pending_poll(h)
+    # A prose answer marks a provisional row steered by hint, so the steered
+    # key is part of this fixture's footprint too.
+    reg._redis().delete(f"{reg.POLL_STEERED_PREFIX}{h}")
 
 
 def _register(pid, session_id="sess-1"):
@@ -287,3 +290,98 @@ class TestSessionHasOpenPoll:
 
         monkeypatch.setattr(reg, "iter_unanswered_polls", _boom)
         assert reg.session_has_open_poll("sess-1") is False
+
+    def test_a_provisional_row_already_counts_as_an_open_question(self, hint):
+        """The relay is a polling loop; the pause check runs at turn end.
+
+        Between `valor-ask-poll` enqueuing the payload and the relay writing the
+        real row, the question exists only as a provisional row. Reading only
+        POLL_OPEN_INDEX reports "no open question" during that window and the
+        session gets nudged straight past it — the exact defect the pause exists
+        to prevent.
+        """
+        reg.register_pending_poll(
+            hint, chat_id=-1, session_id="sess-pending", question="Q?", options=["A", "B"]
+        )
+        assert reg.session_has_open_poll("sess-pending") is True
+
+    def test_a_steered_provisional_row_no_longer_counts(self, hint):
+        reg.register_pending_poll(
+            hint, chat_id=-1, session_id="sess-pending", question="Q?", options=["A", "B"]
+        )
+        reg.mark_poll_steered(hint)
+        assert reg.session_has_open_poll("sess-pending") is False
+
+
+class TestMarkSessionPollsSteered:
+    """A typed answer closes the question exactly as a tap does.
+
+    `mark_poll_steered` is written only by the vote path. Without a route for
+    the prose answer the row survives its full 24h TTL, `session_has_open_poll`
+    keeps returning True, and every turn of that session takes the pause branch
+    instead of nudge-continue — auto-continue silently off for a day, with the
+    session advancing one turn per human message.
+    """
+
+    def test_closes_an_open_poll_for_the_session(self, poll_id):
+        _register(poll_id, session_id="sess-typed")
+        assert reg.session_has_open_poll("sess-typed") is True
+
+        assert reg.mark_session_polls_steered("sess-typed") == 1
+
+        assert reg.poll_steered(poll_id) is True
+        assert reg.session_has_open_poll("sess-typed") is False
+
+    def test_leaves_another_session_alone(self, poll_id):
+        _register(poll_id, session_id="sess-other")
+        assert reg.mark_session_polls_steered("sess-typed") == 0
+        assert reg.session_has_open_poll("sess-other") is True
+
+    def test_closes_a_provisional_row_without_deleting_it(self, hint):
+        """The hint is the only evidence a send may have landed.
+
+        Deleting the row would strand orphan adoption after a restart, so the
+        close-out is a marker, not a delete.
+        """
+        reg.register_pending_poll(
+            hint, chat_id=-1, session_id="sess-typed", question="Q?", options=["A", "B"]
+        )
+        assert reg.mark_session_polls_steered("sess-typed") == 1
+        assert reg.lookup_pending_poll(hint) is not None
+        assert reg.session_has_open_poll("sess-typed") is False
+
+    def test_is_idempotent(self, poll_id):
+        """The vote path marks the row before `resume_completed_session` runs."""
+        _register(poll_id, session_id="sess-typed")
+        reg.mark_poll_steered(poll_id)
+        assert reg.mark_session_polls_steered("sess-typed") == 0
+        assert reg.session_has_open_poll("sess-typed") is False
+
+    def test_missing_session_id_is_a_no_op(self, redis_test_db):
+        assert reg.mark_session_polls_steered(None) == 0
+        assert reg.mark_session_polls_steered("") == 0
+
+    def test_redis_failure_never_raises(self, monkeypatch):
+        """It hangs off an answer route; a bookkeeping failure must not break it."""
+
+        def _boom():
+            raise RuntimeError("redis down")
+
+        monkeypatch.setattr(reg, "iter_unanswered_polls", _boom)
+        assert reg.mark_session_polls_steered("sess-1") == 0
+
+    def test_promotion_carries_the_close_out_onto_the_real_poll_id(self, hint, poll_id):
+        """A prose answer that lands while the payload is still in the outbox.
+
+        Without the carry the promoted row is born unsteered and re-opens the
+        pause on a question the human already answered — the same defect in a
+        narrower window.
+        """
+        reg.register_pending_poll(
+            hint, chat_id=-1, session_id="sess-typed", question="Q?", options=["A", "B"]
+        )
+        reg.mark_session_polls_steered("sess-typed")
+
+        assert reg.promote_pending_poll(hint, poll_id, msg_id=1413) is True
+        assert reg.poll_steered(poll_id) is True
+        assert reg.session_has_open_poll("sess-typed") is False

--- a/tests/unit/test_poll_registry.py
+++ b/tests/unit/test_poll_registry.py
@@ -351,7 +351,12 @@ class TestMarkSessionPollsSteered:
         assert reg.session_has_open_poll("sess-typed") is False
 
     def test_is_idempotent(self, poll_id):
-        """The vote path marks the row before `resume_completed_session` runs."""
+        """Both close-outs run on the vote path, in either order.
+
+        `resume_completed_session` closes the row after its dispatch returns, and
+        `translate_poll_vote` then calls `mark_poll_steered` as its own last
+        statement. The second write must be a no-op, not a double count.
+        """
         _register(poll_id, session_id="sess-typed")
         reg.mark_poll_steered(poll_id)
         assert reg.mark_session_polls_steered("sess-typed") == 0


### PR DESCRIPTION
Closes #3096
Refs #2701

PR #3080 merged as `9fec0698b`, then its review landed **CHANGES REQUESTED** ([review comment](https://github.com/tomcounsell/ai/pull/3080#issuecomment-5520231909)). This PR clears the two code blockers post-merge. The merged code is **not deployed** — the running services are still on pre-merge code — so nothing here is live until the owner decides to deploy.

## Blocker 2 — a typed answer never cleared the poll pause

`mark_poll_steered` had callers only on the vote path (`bridge/poll_vote.py:186,216`). A human who replies in prose instead of tapping steers correctly and the session resumes, but the registry row survives for `POLL_REGISTRY_TTL_S` (86400s default). `session_has_open_poll` keeps reporting an open question, so every turn of that session takes `pause_open_question` instead of `nudge_continue` — auto-continue silently off for a full day, the session advancing one turn per human message, with only an INFO log as signal.

- `mark_session_polls_steered(session_id)` closes every outstanding row for a session. Idempotent, never raises.
- Called from `_ack_steering_routed` — which every live / pending / live-guard route reaches, **including both intake-classifier interjection sites** — and from `resume_completed_session`, the completed mainline shared with the vote path. So every answer route closes the question, not just the tap.
- `session_has_open_poll` now also consults `POLL_PENDING_INDEX`. This was tech-debt item 3 and is the same defect in a different window: a poll enqueued by `valor-ask-poll` but not yet relayed exists only as a provisional row, the relay is a polling loop, and the pause check runs at turn end — so during that window a session with an outstanding question was being nudged straight past it.
- A provisional row is closed by **marker, not delete** — the hint is the only evidence a send may have landed, so deleting it would strand orphan adoption after a restart. `promote_pending_poll` carries the marker onto the real poll id, so a prose answer that lands while the payload is still in the outbox cannot have the pause re-opened by promotion.

Wiring is covered in `tests/unit/test_poll_prose_answer_closeout.py`, with ordering asserted at both seams. Registry semantics are covered against real Redis in `tests/unit/test_poll_registry.py`.

## Blocker 3 — an ineligible or hint-less poll was delivered up to four times

Both decline branches of `_send_queued_poll` returned `None` *after* pushing the prose fallback. `process_outbox` reads `success = msg_id is not None`, so it re-queued the **original poll payload**, which declined again for the same reason and enqueued another copy — up to `MAX_RELAY_RETRIES` plus one more from the terminal branch, each retry additionally burning a 50-message `iter_messages` scan.

Both branches now return the `DELIVERED_NO_ID` sentinel that already fixes exactly this shape on the text path (#2179), and `process_outbox` handles it the same way. A genuine `send_poll` failure still returns `None` and still retries — asserted, so the sentinel cannot swallow a real failure.

The regression tests are at the `process_outbox` seam rather than on `_send_queued_poll` in isolation. The defect lived in the interaction between the two, which is precisely why the existing `TestPollDispatch` tests were green.

## Tech-debt triage

Fixed here (same blast radius):

| Item | Disposition |
|---|---|
| `telegram_relay.py:1433` terminal branch never calls `delete_pending_poll` | **Fixed.** Retries are exhausted so the poll provably never landed; the surviving row made every reconcile tick run a history scan hunting for it until the TTL (order 1400 scans/day). |
| `poll_registry.py:405` predicate blind to `POLL_PENDING_INDEX` | **Fixed** — folded into blocker 2 above, since a half-fix would have left promotion re-opening the pause. |
| `poll_gating.py:81` `s.created_at or 0` raises `TypeError` on a null `created_at` | **Fixed.** The broad handler turned that crash into `eligibility_error` and silently degraded the question to prose. Now uses the same `(is not None, value)` key as the sibling in `answer_routing.py`. |
| `ESCAPE_HATCH_OPTION` declared twice with nothing pinning them equal | **Fixed.** Defined once in `tools/ask_poll.py` (the producer that writes the label), imported by `bridge/poll_vote.py`. Safe at module scope: `ask_poll` imports only stdlib at import time. |
| `agent_catchup.py:403` vestigial `or ""` | **Fixed.** |
| Duplicate `"Poll reconciliation loop started"` log line | **Fixed** — the loop logs its own start. |

Deferred, with reasons:

| Item | Disposition |
|---|---|
| `poll_reconcile.py:153,189` unreachable `FloodWaitError` handlers; the loop accelerates into the throttle instead of backing off | **Follow-up.** The real fix is re-raising `FloodWaitError` ahead of the blanket `except Exception` in `poll_vote.py:157`, `:236` and `_find_already_sent_poll` — three handlers on the inbound path, not the delivery paths these blockers live on, and a change whose failure mode is rate-limiting the bridge account. Wants its own lane and its own test. |
| `poll_vote.py:178` takeover threshold reuses the 60s reconcile interval while `_dispatch_answer` awaits four operations before stamping `mark_poll_dispatched` — a slow dispatch can be taken over and steered twice | **Follow-up.** Genuine and wider than the residual the original PR named, but the fix is a design choice (dispatch-duration budget vs. an in-progress marker before the first `await`) that belongs with the owner, not folded into a blocker patch. |
| `session_executor.py:1636-1646` pause branch does not stamp `response_delivered_at` | **Follow-up.** Shared with `deliver_already_completed` and `deliver_fallback`, so this is a pre-existing health-check gap that the poll feature merely made mainline. Fixing it here would change re-queue behavior for three unrelated exits. |
| `output_handler.py:1560` `validate_poll_question` violations logged and discarded while `ask_poll.py:134` hard-exits on the same rule | **Follow-up.** Two enforcement points for one invariant is real, but choosing which one is authoritative changes user-visible behavior at the ask seam. |
| `poll_reconcile.py:105-204` has no test coverage | **Follow-up.** The module's own docstring calls it the primary inbound mechanism; the adaptive interval, ambiguous-adoption bail and warn dedup are all untested behavioral claims. That is a test-authoring lane, not a patch. |
| `telegram_relay.py:1428-1447` dead-letter + immediate re-enqueue can deliver the question twice | **Follow-up.** Both mechanisms are deliberate; deduplicating them means deciding which one owns delivery. |
| `poll_registry.py:103` `POLL_PROBE_TAP_WAIT_S` has no reader | **Deliberately kept.** It is the Task 10a manual-gate probe knob and that gate is still open. Delete it with the gate, not before. |
| `poll_reconcile.py:147,185` walks `iter_unanswered_polls()` twice per tick | **Follow-up** (nit). |
| `poll_reconcile.py:34` imports the private `_redis` across a module boundary | **Follow-up** (nit). |
| `ask_poll.py:171` unreachable `hasattr(handler, "send_poll")` probe | **Follow-up** (nit). |
| `poll_vote.py:301-307` `NONE` branch closes the poll on screen after already dropping the answer | **Follow-up.** The human sees their answer accepted while it was dropped with an INFO log; the fix is a user-visible message, which is a product decision. |

## Not addressed here

**Blocker 1 (Task 10a) is untouched.** It is a hard shipping gate by owner ruling and needs either the tap or an explicit owner ruling on #2701 — not a code change, and not a reviewer's or this lane's to waive.

**The plan's Verification table** was repaired separately, on `main` (`5741fc888`). All nine-plus `[FAIL]` rows were runner artifacts: BRE alternation written `\|` inside a markdown table cell (ambiguous against markdown's own pipe escape, and a literal pipe in the one row that already used `-E`), and `grep -lc … | wc -l`, where `-l` and `-c` are contradictory so the `-c` was dead. Rewritten as repeated `-e` patterns and plain `-l`; all twelve hand-run against the merged code and producing their Expected value.

## Tests

`test_poll_registry` `test_poll_gating` `test_poll_vote_translation` `test_poll_payload` `test_ask_poll_cli` `test_agent_catchup_poll_transcript` `test_bridge_relay` `test_output_router` `test_bridge_ack_steering_routed` `test_context_recall_wiring` `test_config_driven_routing` `test_poll_prose_answer_closeout` — all green. `ruff check` and `ruff format` clean.

Two existing assertions in `TestPollDispatch` were updated from `is None` to `is DELIVERED_NO_ID`: they encoded the defective contract.

## Deployment

None. This PR does not deploy anything, and the services deliberately stay on pre-merge code pending the owner's Task 10a decision.

---

## Review round 2 (head `b609d64`) — blocker cleared

**Blocker: close-out ordering inversion.** `resume_completed_session` wrote `mark_session_polls_steered` *before* `dispatch_telegram_session`. That function is not only the prose-answer route — `translate_poll_vote`'s COMPLETED branch is the poll-vote mainline, and its exception handler releases the claim "so the next reconciliation tick retries". That retry reads `POLL_OPEN_INDEX` and skips steered rows, both of which the early close-out had already invalidated, so a raising dispatch permanently swallowed the human's tap behind one `logger.warning`.

The marker now follows the dispatch, which is the invariant `bridge/poll_vote.py:219-221` states and `docs/features/telegram-poll-questions.md` repeats. It costs nothing: the dispatch only enqueues, so the resumed turn's registry read is orders of magnitude later. `test_close_out_precedes_the_re_enqueue` encoded the defective contract and is inverted to `test_close_out_follows_the_re_enqueue`; `test_a_failed_dispatch_leaves_the_poll_open` closes the coverage gap that let the blocker land green.

### Tech debt — fixed here

| Item | Disposition |
|---|---|
| `poll_registry.py:389-396` TOCTOU against `promote_pending_poll` | **Fixed.** The pending index is scanned before the open index. A promotion interleaving the other way round added its row after loop 1 had passed and deleted the hint before loop 2 reached it, losing the close-out entirely. Either order of the race is now covered: the hint is marked before the promotion reads it, or the promotion already ran and the real row is in the open index for loop 2. |
| `poll_reconcile.py:124` adoption does not skip steered hints | **Fixed.** `adopt_orphaned_polls` skips them. Without it a prose-answered question kept costing an `iter_messages(limit=50)` history scan per reconcile tick for the full 24h TTL — the same waste this PR's own `delete_pending_poll` addition was written to remove. Covered by `TestAdoptionSkipsAClosedProvisionalRow`. |
| `telegram_relay.py:1223-1224` swallowed `rpush` failure on a decline | **Fixed.** `_reenqueue_poll_as_text` returns whether the push landed, and both decline branches return `None` rather than `DELIVERED_NO_ID` when it did not. The ineligible branch deletes the provisional row first, so the sentinel had removed the retry that used to paper over a Redis blip. Covered by `test_a_decline_whose_fallback_push_fails_still_retries`. |
| `poll_registry.py:364` `mark_poll_steered` de-indexes only the open index (nit) | **Fixed as documentation, not behavior.** Retaining pending-index membership is deliberate — the payload may still be in the outbox and `promote_pending_poll` needs the row to carry the marker forward. The docstring now states that, and names the two consumers that check `poll_steered` themselves. |
| `telegram_bridge.py:1038-1044` any inbound message closes the question | **Fixed as documentation.** Narrowing the trigger needs a classifier that does not exist; the trade is stated in the code comment and the feature doc instead. Closing on chatter costs the pause branch and loses nothing (`translate_poll_vote` keys on `lookup_poll`, never `poll_steered`); failing to close costs a day of auto-continue. |
| `docs/features/telegram-poll-questions.md` not updated for two behavior changes | **Fixed** in the `/do-docs` cascade — new "A typed reply closes the question too" section, corrected `steered_at` registry row, both-indexes note on the nudge pause, and the ordering/adoption/decline updates in failure recovery and Race 6. `eng-session-architecture.md` picks up what releases the pause. |

### Nits — fixed here

- `answer_routing.py:198-199` — the "the vote path marks the row itself before it gets here" comment was inverted. Replaced with the ordering rationale.
- `test_poll_registry.py::test_is_idempotent` — docstring repeated the same wrong claim; it now states what the test actually pins (both close-outs run on the vote path, in either order, and the second must be a no-op).
- `telegram_relay.py:1484` — "provably never landed" overclaimed against the `send_poll` note at `:1229-1232`. Reworded to the cost trade it actually is. The same overclaim in the tech-debt table above is superseded by this row.

### Deferred, unchanged

`poll_reconcile.py:153,189` `FloodWaitError`; `poll_vote.py:178` takeover threshold; `session_executor.py:1636-1646` `response_delivered_at`; `output_handler.py:1560` vs `ask_poll.py:134`; `poll_reconcile.py:105-204` coverage; `telegram_relay.py:1428-1447` dead-letter duplicate; `POLL_PROBE_TAP_WAIT_S`; the four remaining nits. Reasons unchanged from the triage above, and the round-2 review verified each as sound.

**Blocker 1 (Task 10a) remains untouched** — an owner ruling on #2701, not a code change.

### Tests

`test_poll_prose_answer_closeout` `test_poll_registry` `test_bridge_relay` (121 passed) plus `test_poll_gating` `test_poll_vote_translation` `test_poll_payload` `test_ask_poll_cli` `test_agent_catchup_poll_transcript` `test_output_router` `test_bridge_ack_steering_routed` `test_context_recall_wiring` `test_config_driven_routing` (207 passed) — **328 passed**. `ruff check` clean, `ruff format --check` clean.

---

## Review round 3 (head `f95befc5b`) — zero blockers, six findings cleared

Round 2 returned **zero blockers** from both judges (`code-quality` and `risk`, 2-of-2, no disagreement) and confirmed the round-1 ordering blocker genuinely fixed. It found six items, all introduced by the round-2 changes themselves.

**`answer_routing.py` — the close-out is now guarded.** Moving it after the dispatch put it directly ahead of both callers' anti-duplicate sentinels: `_steering_session_enqueued = True` in `telegram_bridge.py` and `mark_poll_dispatched(poll_id)` in `poll_vote.py`, neither of which is reached if it raises. `mark_session_polls_steered` never raises, but `asyncio.to_thread` can on a closing loop — costing a duplicate enqueue on the prose path or a released claim and re-dispatch on the vote path. Wrapped in `try/except` with a warning. The ordering itself is unchanged; it is the round-1 blocker fix.

**Deviation, named explicitly: the `adopt_orphaned_polls` steered skip is REVERTED.** That skip was added in the previous commit to answer a round-1 tech-debt finding. Both round-2 judges independently found that it combines with the any-inbound-message close-out into a new swallow: chatter marks a never-promoted Race-6 hint, adoption then skips it forever, and a later tap dies at `lookup_poll(poll_id) is None`. Adoption is the only thing that makes such an orphan routable at all, so the skip recreated exactly the failure class this PR exists to remove, and it contradicted the "a later tap still routes" claim in the close-out comment and the feature doc.

The round-1 scan-cost finding it was answering does not survive scrutiny: a successful adoption promotes and **deletes** the pending row, so the normal case costs one scan, not one per tick; the unbounded case is a hint whose poll was never sent, which the decline branches and the terminal branch already delete. The two are not the same case, so the "internally inconsistent halves" reading does not hold. `TestAdoptionSkipsAClosedProvisionalRow` is replaced by `TestAdoptionStillScansAndPromotesASteeredHint`, and the reasoning is stated at the loop, in `mark_poll_steered`'s docstring and in the feature doc.

**Docstring corrections, no behavior change.** The decline branch's failed-push hole is **narrowed, not closed** — the retry re-queues through the same swallowed `rpush`, so the question survives one failure and not two consecutive ones; both relay docstrings now say that instead of implying the hole is gone. The "already dropped the provisional row" wording was untrue of the missing-`poll_id_hint` branch, which never had one. A comment at the ineligible branch records that returning `None` makes the retry pay `_find_already_sent_poll`'s history scan for a poll that was never sent — bounded by `MAX_RELAY_RETRIES` and accepted, because the alternative is losing the question. The feature doc's "typed answer" phrasing is aligned with the any-inbound-message semantics stated elsewhere in it.

**Tests:** the same 12 suites — **328 passed**, measured on this head, not carried over. `ruff check` clean, `ruff format --check` clean (748 files).

**Deployment is still none.** This touches `bridge/`, so it needs a restart to take effect, and the services are deliberately on pre-merge code pending the owner's Task 10a ruling. Merging this is not authorization to `/update` or restart.

---

## Review round 4 (head `2eee0ab2c`) — both blockers cleared

Round 3 returned two blockers, both correct and both created by the round-2/3 changes themselves.

**The guard was applied to one of two call sites.** `_ack_steering_routed` in `bridge/telegram_bridge.py` has the same unguarded `asyncio.to_thread`, and it is the hotter of the two: it sits on the LIVE / PENDING / LIVE_GUARD routes, which set no `_steering_session_enqueued` sentinel, so a raise there falls through to the final enqueue and delivers the #997 duplicate. Asserting the invariant in one place while leaving the other violating it is worse than not asserting it. Guarded the same way.

**`TestAdoptionStillScansAndPromotesASteeredHint` was vacuous.** It patched `iter_pending_polls` and asserted the scan saw the hint, but never made the hint steered — it passed identically with the skip re-added, so the deviation had no mechanical guard. It now runs against real Redis, writes the marker through `mark_session_polls_steered`, and asserts the outcome that matters: the promoted row exists (so a later tap resolves it instead of dying at `lookup_poll(poll_id) is None`), is born steered, and the pending row is gone. **Verified non-vacuous by re-adding the skip**, which fails it on `lookup_poll(poll_id) is not None`. The scan stub is scoped to this test's own hint so it cannot promote a sibling test's row onto the same poll id.

**Tech debt and nits, all comment and doc corrections.** The revert's stated rationale overclaimed: the delete branches cover every case the relay can *observe*, but two orphan rows still survive to the TTL at one scan per tick — a crash between `register_pending_poll` and the send resolving (the atomic `LPOP` already consumed the work item, so nothing retries), and a permanently ambiguous match, which both the scan and promotion deliberately refuse to resolve. Neither is closed out, so the skip would not have addressed either, and both are identical to `main`. "A later tap still routes" was true but incomplete — closing the row `SREM`s it from `POLL_OPEN_INDEX`, so routing is via the `events.Raw` fast path specifically, the one place the "reconciliation is primary" framing does not hold; the doc previously asserted both things three paragraphs apart. Plus four wording nits and `exc_info` on the new guard.

**One deferral is recorded as widened.** `FloodWaitError` is swallowed inside `_find_already_sent_poll` and never reaches `poll_reconcile_loop`'s backoff. Pre-existing on `main` and already on the round-1 FloodWait deferral list, but restoring steered hints to the scanned set increases per-tick RPC volume against the same rate-limit budget, so the deferral is marginally more expensive than when it was first accepted. It stays with the rest of that lane, whose fix touches three inbound handlers and whose failure mode is rate-limiting the bridge account.

**Tests:** the same 12 suites — **328 passed**, measured on this head. `ruff check` clean, `ruff format --check` clean.

---

## Review round 5 (head `f885c2fb9`) — zero blockers, remaining items cleared

Round 4 returned **zero blockers** and confirmed both round-3 blockers genuinely fixed, verifying the adoption test's non-vacuity by mutation rather than on this body's word. It left one tech-debt item and three nits.

**Both close-out guards are now pinned by tests.** The guards were correct and asserted only in prose — either `try/except` could have been deleted with nothing in the tree failing, the same shape as round 3's vacuous-test blocker. `TestACloseOutFailureNeverBreaksTheSentinelItPrecedes` covers both sites: the COMPLETED route, where returning normally is what lets the caller stamp `_steering_session_enqueued`, and `_ack_steering_routed`, where the LIVE / PENDING / LIVE_GUARD routes set no sentinel at all and a raise falls through to the #997 duplicate. **Verified non-vacuous by replacing each guard with an unguarded call**, which fails both tests on the injected `RuntimeError`. This also closes the deferred test-lane's overlap with this PR; the `poll_reconcile.py:105-204` coverage lane stays deferred on its own merits.

**Nits.** The newer guard's warning used f-string interpolation and lacked `exc_info` while its sibling, written in the same pair of commits, had both — two implementations of one invariant should not diverge on diagnostics. The adoption test's class docstring restated the scan-cost claim that the previous commit narrowed in the two authoritative places, so it now points at the loop comment rather than drifting from it a fourth time. The test's `finally` cleanup was dead code and reached around the registry API to delete keys directly: `redis_test_db` is autouse and flushes the claimed db both before and after every test — I verified that against `tests/conftest.py` rather than taking it on the review's word. The scan stub stays keyed on the test's own hint, with the comment now giving the real reason (a blanket match would promote every row in the pending index onto one poll id) instead of a db-sharing model that does not exist.

**Tests:** the same 12 suites — **330 passed** on this head, the previous 328 plus the two new guard tests. `ruff check` clean, `ruff format --check` clean.

---

## Round 5: APPROVED — and the deferrals now have a tracking issue

Round 5 at head `949aed532` returned **APPROVED with zero blockers, zero tech debt and zero nits**. All four round-4 items verified resolved, with the guard tests' non-vacuity reproduced by mutation rather than credited to this body.

Every review round carried the same standing note: none of the deferrals had a tracking issue, so they would not survive the merge as actionable work. They are now filed as **#3095** — the FloodWait lane (with the widening this PR caused recorded), the `poll_reconcile` coverage lane, the two unbounded adoption-scan paths, four owner decisions, one pre-existing `response_delivered_at` gap and three nits. `POLL_PROBE_TAP_WAIT_S` is explicitly out of scope there: it is the Task 10a probe knob and gets deleted with that gate.

Task 10a itself remains on #2701 as an owner ruling, untouched by this PR.
