### PR TITLE
Poll inbound path: propagate FloodWaitError, cover the reconcile loop

### DIFF
--- a/bridge/poll_reconcile.py
+++ b/bridge/poll_reconcile.py
@@ -148,6 +148,11 @@ async def adopt_orphaned_polls(client) -> None:
     for hint, row in iter_pending_polls():
         try:
             found = await _find_already_sent_poll(client, numeric_peer(row["chat_id"]), hint)
+        except FloodWaitError:
+            # #3095: a rate-limited scan must slow the whole loop via
+            # poll_reconcile_loop's backoff branch, not continue to the next
+            # hint at full cadence.
+            raise
         except Exception as e:  # noqa: BLE001
             logger.warning("poll adoption scan failed for hint %s: %s", hint, e)
             continue

--- a/bridge/poll_vote.py
+++ b/bridge/poll_vote.py
@@ -137,10 +137,11 @@ async def translate_poll_vote(client, poll_id) -> None:
     """Translate one vote into a steer or a completed-session re-enqueue.
 
     Idempotent and safe to call from both observers concurrently. Raises only
-    ``FloodWaitError`` (#3095), which both callers handle — the reconcile loop
-    backs off, and the ``events.Raw`` fast path's blanket handler logs and
-    drops the latency win. Nothing else escapes into a Telethon update loop or
-    a background task.
+    ``FloodWaitError`` (#3095), and only from the Telegram RPCs — both callers
+    handle it (the reconcile loop backs off; the ``events.Raw`` fast path's
+    blanket handler logs and drops the latency win). Registry I/O errors
+    propagate as before and are contained by the callers' own handlers;
+    nothing escapes into a Telethon update loop or a background task.
     """
     row = lookup_poll(poll_id)
     if row is None:

--- a/bridge/poll_vote.py
+++ b/bridge/poll_vote.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 
 import logging
 
+from telethon.errors import FloodWaitError
+
 from bridge.answer_routing import (
     AnswerTargetKind,
     resolve_answer_target,
@@ -134,8 +136,11 @@ def _resolve_sender_name(target) -> str:
 async def translate_poll_vote(client, poll_id) -> None:
     """Translate one vote into a steer or a completed-session re-enqueue.
 
-    Idempotent and safe to call from both observers concurrently. Never raises
-    into a Telethon update loop or a background task.
+    Idempotent and safe to call from both observers concurrently. Raises only
+    ``FloodWaitError`` (#3095), which both callers handle — the reconcile loop
+    backs off, and the ``events.Raw`` fast path's blanket handler logs and
+    drops the latency win. Nothing else escapes into a Telethon update loop or
+    a background task.
     """
     row = lookup_poll(poll_id)
     if row is None:
@@ -158,6 +163,10 @@ async def translate_poll_vote(client, poll_id) -> None:
 
         response = await client(GetPollResultsRequest(peer=numeric_peer(chat_id), msg_id=msg_id))
         results = response.updates[0].results
+    except FloodWaitError:
+        # #3095: reach the reconcile loop's backoff branch. The events.Raw fast
+        # path catches this in its own blanket handler and drops the latency win.
+        raise
     except Exception as e:  # noqa: BLE001 — a read failure is retried next tick
         logger.warning("translate_poll_vote: GetPollResultsRequest failed for %s: %s", poll_id, e)
         return
@@ -201,6 +210,13 @@ async def translate_poll_vote(client, poll_id) -> None:
             row=row,
             chosen=options[chosen_index],
         )
+    except FloodWaitError:
+        # #3095: same claim bookkeeping as the generic failure path below, then
+        # propagate so the reconcile loop backs off instead of retrying the
+        # whole scan at full cadence.
+        if not poll_dispatched(poll_id):
+            release_poll_claim(poll_id)
+        raise
     except Exception as e:  # noqa: BLE001
         # Release the claim so the next reconciliation tick retries — but ONLY
         # when the side effect has not already happened. A blanket release would
@@ -238,6 +254,10 @@ async def _dispatch_answer(client, *, poll_id, row: dict, chosen: str) -> None:
     try:
         fetched = await client.get_messages(numeric_peer(chat_id), ids=msg_id)
         await close_poll(client, numeric_peer(chat_id), msg_id, getattr(fetched, "media", None))
+    except FloodWaitError:
+        # #3095: never swallow a backoff request. translate_poll_vote's own
+        # FloodWaitError handler releases the claim, then propagates.
+        raise
     except Exception as e:  # noqa: BLE001 — a failure to close never blocks the answer
         logger.debug("translate_poll_vote: could not close poll %s: %s", poll_id, e)
 

--- a/bridge/telegram_relay.py
+++ b/bridge/telegram_relay.py
@@ -1109,6 +1109,12 @@ async def _find_already_sent_poll(telegram_client, chat_id, poll_id_hint: str):
             _index, prefix = decode_option(getattr(answers[0], "option", None))
             if correlation_matches(prefix, poll_id_hint):
                 matches.append((msg.id, poll.id))
+    except FloodWaitError:
+        # #3095: propagate so the caller's backoff actually runs — process_outbox's
+        # FloodWaitError handler on the send path, poll_reconcile_loop's on the
+        # adoption path. Swallowing it here kept both rescanning at full cadence
+        # while Telegram was asking the account to stop.
+        raise
     except Exception as e:  # noqa: BLE001 — a scan failure must not block the send
         logger.warning("Relay: poll lookup scan failed for hint %s: %s", poll_id_hint, e)
         return None

--- a/docs/features/telegram-poll-questions.md
+++ b/docs/features/telegram-poll-questions.md
@@ -250,6 +250,17 @@ Both call the same idempotent `translate_poll_vote`, so adding the fast path can
 second behavior. Making `GetPollResultsRequest` reconciliation the guaranteed mechanism buys
 restart-survivability and tolerance of a dropped update for free.
 
+**Rate limits propagate; nothing else does (#3095).** A `FloodWaitError` from any
+inbound-path Telegram RPC — the adoption scan (`_find_already_sent_poll` /
+`adopt_orphaned_polls`), `GetPollResultsRequest`, or the poll close in
+`_dispatch_answer` — re-raises past the blanket handlers so `poll_reconcile_loop`'s
+backoff branch actually slows the loop while Telegram is asking the account to
+stop. The `events.Raw` fast path's own handler logs it and drops the latency win,
+which is the right price for a path that is only a latency win. Every other
+exception keeps its degrade-in-place behavior: warn and continue, or release the
+claim (only when the side effect has not landed) so the next tick retries.
+`tests/unit/test_poll_reconcile.py` pins both directions at each site.
+
 `poll_update_observed` is logged from inside the Raw handler on every `UpdateMessagePoll`. That is
 how the un-gated question — *does the push update reach a user account at all?* — gets answered in
 production, rather than by opening a second updates-enabled client on the bridge's auth key, which

--- a/tests/unit/test_poll_reconcile.py
+++ b/tests/unit/test_poll_reconcile.py
@@ -1,0 +1,407 @@
+"""Poll reconcile loop + FloodWaitError propagation on the inbound path (#3095).
+
+Two halves:
+
+1. **FloodWaitError re-raise sites.** A rate-limited Telegram RPC must reach
+   ``poll_reconcile_loop``'s backoff branch (or ``process_outbox``'s on the
+   send path) instead of being swallowed by a blanket handler that keeps the
+   next scan on full cadence. One test per site; each fails if its
+   ``except FloodWaitError: raise`` is removed.
+
+2. **The reconcile loop's own behavioral claims** — the adaptive interval, the
+   ambiguous-adoption bail, and the warn dedup — which the module docstring
+   makes and nothing previously tested. Registry-backed tests use the real
+   (test-db-claimed) Redis, mirroring ``test_poll_registry.py``; only the
+   Telegram client boundary is faked.
+"""
+
+import asyncio
+import logging
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from telethon.errors import FloodWaitError
+
+from bridge import poll_registry as reg
+from bridge.answer_routing import AnswerTarget, AnswerTargetKind
+from bridge.poll_reconcile import (
+    _interval,
+    adopt_orphaned_polls,
+    poll_reconcile_loop,
+    warn_if_expired_unanswered,
+)
+from bridge.poll_registry import (
+    POLL_RECONCILE_FAST_INTERVAL_S,
+    POLL_RECONCILE_FAST_WINDOW_S,
+    POLL_RECONCILE_SLOW_INTERVAL_S,
+)
+from bridge.poll_vote import translate_poll_vote
+from bridge.telegram_relay import _find_already_sent_poll
+
+HINT = "a" * 32
+ROW = {
+    "chat_id": "-1003449100931",
+    "msg_id": 1413,
+    "session_id": "sess-1",
+    "question": "Which approach?",
+    "options": ["Approach A", "Approach B"],
+    "created_at": "2026-09-02T08:00:00+00:00",
+}
+
+
+def _flood(seconds: int = 30) -> FloodWaitError:
+    return FloodWaitError(request=None, capture=seconds)
+
+
+def _client_iter_raising(exc: BaseException) -> MagicMock:
+    """Client whose ``iter_messages`` fails on first iteration."""
+
+    async def _gen(*_a, **_k):
+        raise exc
+        yield  # pragma: no cover — makes this an async generator
+
+    client = MagicMock()
+    client.iter_messages = _gen
+    return client
+
+
+def _poll_msg(msg_id: int, poll_id: int, hint: str) -> MagicMock:
+    """A message carrying a real MessageMediaPoll whose option bytes match ``hint``."""
+    from telethon.tl.types import MessageMediaPoll
+
+    from bridge.response import encode_option
+
+    poll = MagicMock()
+    poll.id = poll_id
+    poll.answers = [MagicMock(option=encode_option(0, hint))]
+    msg = MagicMock()
+    msg.id = msg_id
+    msg.media = MessageMediaPoll(poll=poll, results=None)
+    return msg
+
+
+def _client_yielding(*msgs) -> MagicMock:
+    async def _gen(*_a, **_k):
+        for m in msgs:
+            yield m
+
+    client = MagicMock()
+    client.iter_messages = _gen
+    return client
+
+
+def _client_with_vote(option_index: int = 0) -> MagicMock:
+    """Client whose GetPollResultsRequest reports one voter on ``option_index``."""
+    from bridge.response import encode_option
+
+    results = MagicMock()
+    results.results = [MagicMock(option=encode_option(option_index, HINT), voters=1)]
+    update = MagicMock()
+    update.results = results
+    response = MagicMock()
+    response.updates = [update]
+
+    async def _call(_request):
+        return response
+
+    return MagicMock(side_effect=_call)
+
+
+def _target(kind=AnswerTargetKind.LIVE) -> AnswerTarget:
+    session = MagicMock()
+    session.session_id = "sess-1"
+    session.project_key = "proj"
+    session.initial_telegram_message = {"sender_name": "Tom"}
+    return AnswerTarget(kind=kind, session=session, matched_status="running")
+
+
+class TestFloodWaitPropagation:
+    """#3095 — each re-raise site, mutation-checked: remove it and the test fails."""
+
+    @pytest.mark.asyncio
+    async def test_already_sent_scan_reraises_floodwait(self):
+        """Site 1: ``_find_already_sent_poll``'s scan handler must not swallow it."""
+        with pytest.raises(FloodWaitError):
+            await _find_already_sent_poll(_client_iter_raising(_flood()), -100, HINT)
+
+    @pytest.mark.asyncio
+    async def test_already_sent_scan_still_degrades_on_ordinary_error(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            found = await _find_already_sent_poll(
+                _client_iter_raising(ValueError("boom")), -100, HINT
+            )
+        assert found is None
+        assert "poll lookup scan failed" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_adoption_loop_reraises_floodwait(self):
+        """Site 1b: the adoption loop's per-hint handler must pass it through,
+        or the relay-side re-raise can never reach the loop's backoff."""
+        with (
+            patch(
+                "bridge.poll_reconcile.iter_pending_polls",
+                return_value=[(HINT, dict(ROW))],
+            ),
+            patch(
+                "bridge.telegram_relay._find_already_sent_poll",
+                AsyncMock(side_effect=_flood()),
+            ),
+            pytest.raises(FloodWaitError),
+        ):
+            await adopt_orphaned_polls(MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_adoption_loop_still_continues_on_ordinary_error(self, caplog):
+        with (
+            patch(
+                "bridge.poll_reconcile.iter_pending_polls",
+                return_value=[(HINT, dict(ROW))],
+            ),
+            patch(
+                "bridge.telegram_relay._find_already_sent_poll",
+                AsyncMock(side_effect=ValueError("boom")),
+            ),
+            patch("bridge.poll_reconcile.promote_pending_poll") as promote,
+            caplog.at_level(logging.WARNING),
+        ):
+            await adopt_orphaned_polls(MagicMock())
+        promote.assert_not_called()
+        assert "poll adoption scan failed" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_results_read_reraises_floodwait(self):
+        """Site 2: ``translate_poll_vote``'s GetPollResultsRequest handler."""
+        with (
+            patch("bridge.poll_vote.lookup_poll", return_value=dict(ROW)),
+            pytest.raises(FloodWaitError),
+        ):
+            await translate_poll_vote(MagicMock(side_effect=_flood()), "poll-1")
+
+    @pytest.mark.asyncio
+    async def test_results_read_still_degrades_on_ordinary_error(self, caplog):
+        with (
+            patch("bridge.poll_vote.lookup_poll", return_value=dict(ROW)),
+            caplog.at_level(logging.WARNING),
+        ):
+            await translate_poll_vote(MagicMock(side_effect=ValueError("boom")), "poll-1")
+        assert "GetPollResultsRequest failed" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_dispatch_floodwait_releases_claim_and_reraises(self):
+        """Site 3: a flood inside ``_dispatch_answer`` (here: ``get_messages``
+        before the close) must release the claim like the generic failure path,
+        then propagate instead of being logged-and-forgotten."""
+        client = _client_with_vote()
+        client.get_messages = AsyncMock(side_effect=_flood())
+        with (
+            patch("bridge.poll_vote.lookup_poll", return_value=dict(ROW)),
+            patch("bridge.poll_vote.claim_poll_answer", return_value=True),
+            patch("bridge.poll_vote.poll_dispatched", return_value=False),
+            patch("bridge.poll_vote.release_poll_claim") as release,
+            patch("bridge.poll_vote.mark_poll_steered") as steered,
+        ):
+            with pytest.raises(FloodWaitError):
+                await translate_poll_vote(client, "poll-1")
+        release.assert_called_once_with("poll-1")
+        steered.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_ordinary_close_error_still_routes_the_answer(self):
+        """The pre-existing behavior stays: a non-flood close failure never
+        blocks the answer."""
+        client = _client_with_vote()
+        client.get_messages = AsyncMock(side_effect=ValueError("boom"))
+        with (
+            patch("bridge.poll_vote.lookup_poll", return_value=dict(ROW)),
+            patch("bridge.poll_vote.claim_poll_answer", return_value=True),
+            patch("bridge.poll_vote.poll_dispatched", return_value=False),
+            patch("bridge.poll_vote.mark_poll_dispatched"),
+            patch("bridge.poll_vote.mark_poll_steered") as steered,
+            patch("bridge.poll_vote.release_poll_claim") as release,
+            patch("bridge.poll_vote.resolve_answer_target", return_value=_target()),
+            patch("agent.steering.push_steering_message") as push,
+            patch("models.room.room_id_for_session", return_value="proj:room"),
+        ):
+            await translate_poll_vote(client, "poll-1")
+        push.assert_called_once()
+        steered.assert_called_once()
+        release.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_loop_backs_off_on_floodwait(self):
+        """End of the chain: the loop converts the propagated flood into a
+        padded, capped sleep instead of dying or continuing at full cadence."""
+        sleeps = []
+
+        async def _sleep(s):
+            sleeps.append(s)
+            raise asyncio.CancelledError
+
+        with (
+            patch(
+                "bridge.poll_reconcile.reconcile_once",
+                AsyncMock(side_effect=_flood(42)),
+            ),
+            patch("bridge.poll_reconcile.asyncio.sleep", _sleep),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await poll_reconcile_loop(MagicMock())
+        assert sleeps == [47]  # flood.seconds + 5
+
+    @pytest.mark.asyncio
+    async def test_loop_backoff_is_capped(self):
+        sleeps = []
+
+        async def _sleep(s):
+            sleeps.append(s)
+            raise asyncio.CancelledError
+
+        with (
+            patch(
+                "bridge.poll_reconcile.reconcile_once",
+                AsyncMock(side_effect=_flood(9999)),
+            ),
+            patch("bridge.poll_reconcile.asyncio.sleep", _sleep),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await poll_reconcile_loop(MagicMock())
+        assert sleeps == [300]
+
+
+class TestAdaptiveInterval:
+    """Fast right after a send, slow thereafter — the docstring's cadence claim."""
+
+    def test_no_rows_means_slow(self):
+        assert _interval(None) == POLL_RECONCILE_SLOW_INTERVAL_S
+
+    def test_young_row_means_fast(self):
+        assert _interval(POLL_RECONCILE_FAST_WINDOW_S - 1) == POLL_RECONCILE_FAST_INTERVAL_S
+
+    def test_window_boundary_is_slow(self):
+        """The window is exclusive: exactly at the boundary the fast phase ends."""
+        assert _interval(POLL_RECONCILE_FAST_WINDOW_S) == POLL_RECONCILE_SLOW_INTERVAL_S
+
+    @pytest.mark.asyncio
+    async def test_loop_sleeps_fast_while_a_recent_poll_is_open(self):
+        young_row = {"created_at": datetime.now(UTC).isoformat()}
+        sleeps = []
+
+        async def _sleep(s):
+            sleeps.append(s)
+            raise asyncio.CancelledError
+
+        with (
+            patch("bridge.poll_reconcile.reconcile_once", AsyncMock(return_value=1)),
+            patch(
+                "bridge.poll_reconcile.iter_unanswered_polls",
+                return_value=[("p", young_row)],
+            ),
+            patch("bridge.poll_reconcile.asyncio.sleep", _sleep),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await poll_reconcile_loop(MagicMock())
+        assert sleeps == [POLL_RECONCILE_FAST_INTERVAL_S]
+
+
+class TestAmbiguousAdoptionBail:
+    """More than one candidate: adopt nothing, warn — never guess."""
+
+    @pytest.mark.asyncio
+    async def test_two_matches_adopt_nothing_and_warn(self, caplog):
+        client = _client_yielding(_poll_msg(1, 11, HINT), _poll_msg(2, 22, HINT))
+        with caplog.at_level(logging.WARNING):
+            found = await _find_already_sent_poll(client, -100, HINT)
+        assert found is None
+        assert "poll_adoption_ambiguous" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_unique_match_returns_ids(self):
+        client = _client_yielding(_poll_msg(7, 77, HINT))
+        assert await _find_already_sent_poll(client, -100, HINT) == (7, 77)
+
+    @pytest.mark.asyncio
+    async def test_no_match_returns_none(self):
+        other_hint = "b" * 32
+        client = _client_yielding(_poll_msg(7, 77, other_hint))
+        assert await _find_already_sent_poll(client, -100, HINT) is None
+
+    @pytest.mark.asyncio
+    async def test_adoption_promotes_only_a_unique_find(self):
+        with (
+            patch(
+                "bridge.poll_reconcile.iter_pending_polls",
+                return_value=[(HINT, dict(ROW))],
+            ),
+            patch(
+                "bridge.telegram_relay._find_already_sent_poll",
+                AsyncMock(return_value=(7, 77)),
+            ),
+            patch("bridge.poll_reconcile.promote_pending_poll", return_value=True) as promote,
+        ):
+            await adopt_orphaned_polls(MagicMock())
+        promote.assert_called_once_with(HINT, 77, msg_id=7)
+
+    @pytest.mark.asyncio
+    async def test_adoption_skips_when_scan_finds_nothing(self):
+        with (
+            patch(
+                "bridge.poll_reconcile.iter_pending_polls",
+                return_value=[(HINT, dict(ROW))],
+            ),
+            patch(
+                "bridge.telegram_relay._find_already_sent_poll",
+                AsyncMock(return_value=None),
+            ),
+            patch("bridge.poll_reconcile.promote_pending_poll") as promote,
+        ):
+            await adopt_orphaned_polls(MagicMock())
+        promote.assert_not_called()
+
+
+@pytest.fixture
+def warned_poll_id(redis_test_db):
+    """Unique poll id whose warn/steer keys are cleaned up, per test_poll_registry."""
+    pid = f"test-{uuid.uuid4().hex[:12]}"
+    yield pid
+    r = reg._redis()
+    r.delete(f"{reg.POLL_WARNED_PREFIX}{pid}")
+    r.delete(f"{reg.POLL_STEERED_PREFIX}{pid}")
+
+
+def _aged_row(age_s: float) -> dict:
+    return dict(ROW, created_at=(datetime.now(UTC) - timedelta(seconds=age_s)).isoformat())
+
+
+class TestWarnDedup:
+    """``poll_expired_unanswered`` fires exactly once per poll, on the real registry."""
+
+    def test_expired_unanswered_warns_once(self, warned_poll_id, caplog):
+        row = _aged_row(reg.POLL_EXPIRY_WARN_AGE_S + 60)
+        with caplog.at_level(logging.WARNING):
+            warn_if_expired_unanswered(warned_poll_id, row)
+        assert "poll_expired_unanswered" in caplog.text
+
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            warn_if_expired_unanswered(warned_poll_id, row)
+        assert "poll_expired_unanswered" not in caplog.text
+
+    def test_young_poll_never_warns(self, warned_poll_id, caplog):
+        with caplog.at_level(logging.WARNING):
+            warn_if_expired_unanswered(warned_poll_id, _aged_row(1))
+        assert "poll_expired_unanswered" not in caplog.text
+
+    def test_steered_poll_never_warns(self, warned_poll_id, caplog):
+        reg.mark_poll_steered(warned_poll_id)
+        row = _aged_row(reg.POLL_EXPIRY_WARN_AGE_S + 60)
+        with caplog.at_level(logging.WARNING):
+            warn_if_expired_unanswered(warned_poll_id, row)
+        assert "poll_expired_unanswered" not in caplog.text
+
+    def test_unparseable_created_at_never_warns(self, warned_poll_id, caplog):
+        """_row_age_s treats a bad timestamp as age 0 — below the warn age."""
+        with caplog.at_level(logging.WARNING):
+            warn_if_expired_unanswered(warned_poll_id, dict(ROW, created_at="not-a-date"))
+        assert "poll_expired_unanswered" not in caplog.text


### PR DESCRIPTION
Builds the two items issue #3095 marks as wanting their own lane. `Refs #3095` — the issue is an umbrella and stays open for the rest.

## Item 1 — `FloodWaitError` is swallowed on the inbound poll path

The issue named three handlers; reading the path end to end found **five**, because a re-raise is only useful if nothing upstream re-swallows it. `_find_already_sent_poll` re-raising does nothing on the adoption path unless `adopt_orphaned_polls`' per-hint handler also passes it through, and a flood inside `_dispatch_answer` has to clear both its own close handler and the dispatch wrapper.

| Site | File | Was |
|---|---|---|
| Adoption / retry scan | `bridge/telegram_relay.py` `_find_already_sent_poll` | returned `None`, caller rescanned next tick |
| Per-hint adoption loop | `bridge/poll_reconcile.py` `adopt_orphaned_polls` | `continue` to the next hint at full cadence |
| `GetPollResultsRequest` read | `bridge/poll_vote.py` `translate_poll_vote` | logged, returned |
| `_dispatch_answer` wrapper | `bridge/poll_vote.py` `translate_poll_vote` | logged, returned |
| Close-poll | `bridge/poll_vote.py` `_dispatch_answer` | logged at debug |

Each now re-raises ahead of its blanket handler, reaching `poll_reconcile_loop`'s existing backoff branch (or `process_outbox`'s on the send path). The dispatch-wrapper site keeps the generic path's claim bookkeeping — release only when `poll_dispatched` is false — so a flood cannot strand a claim any more than an ordinary failure can.

**One contract change, stated in the docstring:** `translate_poll_vote` was "never raises"; it is now "raises only `FloodWaitError`". Both callers already handle it — the reconcile loop backs off, and the `events.Raw` fast path's blanket handler logs and drops the latency win, which is the correct degradation for a path that is explicitly a latency win over the loop.

## Item 2 — `bridge/poll_reconcile.py:105-204` had no coverage

`tests/unit/test_poll_reconcile.py` (23 tests) covers the docstring's untested behavioral claims:

- **Adaptive interval** — `_interval` slow with no rows, fast inside the window, and slow exactly *at* `POLL_RECONCILE_FAST_WINDOW_S` (the boundary is exclusive), plus the loop actually sleeping the fast interval while a recent poll is open.
- **Ambiguous-adoption bail** — two candidates adopt nothing and log `poll_adoption_ambiguous`; a unique match returns its ids and promotes exactly once; no match promotes nothing. Driven through real `MessageMediaPoll` objects with `encode_option`-built option bytes, so the correlation-matching is exercised rather than stubbed.
- **Warn dedup** — `poll_expired_unanswered` fires once and not twice for the same poll, against the real test-db-claimed Redis (mirroring `test_poll_registry.py`, since `mark_poll_warned`'s `SET NX` semantics are the property under test). Young polls, steered polls, and an unparseable `created_at` never warn.
- **Loop backoff** — the propagated flood becomes a padded sleep (`flood.seconds + 5`) capped at 300s.

Only the Telegram client boundary is faked, following the existing poll tests' idiom.

## Verification

- `tests/unit/test_poll_reconcile.py`: 23 passed.
- Full poll set (8 files) + `test_bridge_relay.py`: **257 passed**, no regressions.
- **Mutation-checked, all five sites**: neutralizing a site's `raise` turns its test red, one at a time, reverted after each. Each propagation test has a degrade-on-ordinary-error twin, so the handlers' existing tolerance is pinned too and the tests cannot pass by making everything raise.
- Ruff check and format clean.

## Checklist against #3095

- [x] `FloodWaitError` re-raise on the inbound poll path (3 named sites; 2 more found by tracing, same defect)
- [x] Test coverage for `bridge/poll_reconcile.py:105-204`
- [ ] Orphan-adoption per-tick history scans until the 24h TTL — left in the umbrella
- [ ] Owner decisions (stale-claim takeover threshold, dual `validate_poll_question` enforcement, `NONE`-branch close, dead-letter double delivery) — left in the umbrella
- [ ] Pre-existing `response_delivered_at` gap and the three nits — left in the umbrella

Note the issue's own caveat still stands: reverting the adoption steered-hint skip restored closed-out hints to the scanned set, so per-tick RPC volume rides on the same rate-limit budget. That is exactly why these handlers reaching the backoff matters.
