### PR TITLE
Nightly triage: closed-issue-aware dedup, body-failure collapsing, environmental classification

### DIFF
--- a/docs/features/nightly-regression-tests.md
+++ b/docs/features/nightly-regression-tests.md
@@ -21,7 +21,8 @@ added (issue #2823); baseline classification stage and shadow decision gate
 added (issue #2334) — see "Baseline Classification (Shadow Mode)" below;
 cascade collapsing, pre-file dedup, and a per-run issue budget added (issue
 #3131); comment-over-create, signature-keyed cascade identity, and removal of
-all notification added (issue #3134).
+all notification added (issue #3134); closed-issue-aware dedup, body-failure
+cascade collapsing, and environmental-failure exclusion added (issue #3075).
 Autonomous-fix action on the gate's verdict is **not shipped**; it is deferred
 to #3076.
 
@@ -62,12 +63,32 @@ to #3076.
   `Nightly regression cascade [{digest}]: {message}`, with the node list in a
   collapsed section. Detection groups by (worker, message); filing merges by
   message, so four identically-poisoned workers produce one issue
-- **Comments instead of filing a twin.** Open issues are read once via
-  `gh issue list --json number,title` (the REST path, not the index-lagged
-  `--search`) immediately before dispatch. A finding that already has an open
-  issue gets a recurrence comment carrying the run timestamp, HEAD, blast
-  radius, and xdist worker ids — not silence. An unreadable list fails open
-  (it files). This is the only dedup that spans machines
+- Collapses body-failure cascades the same way (issue #3075): nodes whose
+  failure normalizes to one identical first error line group into one umbrella
+  once the group reaches `BODY_CASCADE_MIN_GROUP_SIZE` (default 5, env
+  `NIGHTLY_BODY_CASCADE_MIN_GROUP_SIZE`), under a distinct `body::` state-key
+  namespace so setup and body umbrellas never collide. A node that fails alone
+  in its own body stays its own finding
+- Excludes environmental failures before any grouping or filing (issue #3075):
+  a node classifies environmental only when EVERY failing phase's normalized
+  first error line looks network-shaped (DNS, TLS, refused/reset, connect
+  errors) — an assertion failure in any phase disqualifies it, so a regression
+  whose assert-diff merely mentions a network string still files. Environmental
+  nodes file nothing and are deliberately never recorded as dispatched, so they
+  re-evaluate every night; the escalation gap for a persistent
+  environmental-looking failure is tracked in #3163
+- **Comments instead of filing a twin.** Open AND closed issues are read once
+  via `gh issue list` (the REST path, not the index-lagged `--search`)
+  immediately before dispatch. A finding with an open issue gets a recurrence
+  comment carrying the run timestamp, HEAD, blast radius, and xdist worker
+  ids — not silence. A finding whose exact title exists only CLOSED resolves
+  by the closure's `stateReason`, taken from the title's most recent closure
+  (max `closedAt`, since creation order diverges from closure order):
+  `NOT_PLANNED` means a human consolidated or declined it — comment on the
+  closed issue, never re-file; `COMPLETED` means it was fixed — failing again
+  is new information, so it re-files; an unknown reason comments. Either
+  unreadable list fails open (it files). This is the only dedup that spans
+  machines
 - Caps a single run at `MAX_ISSUES_PER_RUN` (10) issues, umbrellas and per-node
   alike drawing from one budget; the remainder is logged and retries on a later
   run. **Comments do not spend budget** — the cap bounds how much *new* tracker
@@ -85,6 +106,9 @@ a human is expected to notice; the log is the full record.
 | Run-integrity guard tripped | Cascade only — commented if already open, filed otherwise; per-node filing suppressed | `FATAL: {reason}` then `Integrity trip recorded: N issue(s) filed, M comment(s) posted` |
 | Newly-confirmed failure, no open issue | New issue via triage session | `Tracker: N issue(s) filed, M recurrence comment(s) posted` |
 | Newly-confirmed failure, issue already open | Recurrence comment on the existing issue | same line, with `M > 0` |
+| Newly-confirmed failure, exact title closed `NOT_PLANNED` (newest closure) | Recurrence comment on the closed issue; never re-filed | same line, with `M > 0` |
+| Newly-confirmed failure, exact title closed `COMPLETED` (newest closure) | New issue — failing again after a fix is new information | `Tracker: N issue(s) filed ...` |
+| Environmental failure (every failing phase network-shaped) | Nothing; unrecorded, re-evaluates nightly (escalation gap: #3163) | environmental exclusion logged, surfaced in the run summary |
 | Issue budget exhausted | Nothing; the finding stays unrecorded and retries next run | `Issue budget reached: deferring ...` |
 | Collection errors, no newly-confirmed failures | Nothing | `Collection error ({new_errors} errors)` |
 | TTFT regression | Nothing | `TTFT regression: {detail}` |

--- a/docs/features/nightly-triage-dispatch.md
+++ b/docs/features/nightly-triage-dispatch.md
@@ -44,9 +44,13 @@ three behaviors layered around that base run:
 1. **Run lock** — prevents two overlapping launchd invocations from both running the
    suite and both filing against the same window.
 2. **Triage dispatch** — spins up an Eng session to investigate failures that have not
-   been triaged before and file a GitHub issue, deduped per node so a failure that
-   already has an issue open against it gets a recurrence comment instead of a second
-   issue (see the base doc's "Comment-over-create" decision).
+   been triaged before and file a GitHub issue, deduped per node against BOTH the open
+   and closed sets: an open issue gets a recurrence comment instead of a second issue,
+   and a title closed `NOT_PLANNED` (by its most recent closure) is commented on and
+   never re-filed, while one closed `COMPLETED` re-files because failing again after a
+   fix is new information. The triage prompt states the same open-and-closed rule so
+   the pre-flight and the agent's instructions cannot drift (see the base doc's
+   "Comment-over-create" decision and issue #3075).
 
 ## Run Lock (Race 1)
 

--- a/scripts/nightly_regression_tests.py
+++ b/scripts/nightly_regression_tests.py
@@ -1601,25 +1601,34 @@ _ENVIRONMENTAL_MARKERS = (
 
 
 def is_environmental_failure(test: dict) -> bool:
-    """True when the failure ITSELF is a network-layer fault, not a code path.
+    """True when EVERY failing phase is a network-layer fault, not a code path.
 
-    Each phase's normalized first error line is checked, lowercased. An
-    assertion failure never classifies, whatever its compared data contains: a
-    genuine network fault surfaces as a raised ConnectionRefusedError /
-    gaierror / SSLError first line, while an ``assert`` whose expected string
-    happens to mention a network error is a code regression the detector must
-    file. A node classified environmental is logged and excluded from filing —
-    no issue, no umbrella (the exclusion runs before cascade grouping) — and
-    deliberately NOT recorded as dispatched, so it re-evaluates every night and
-    starts filing again the moment its failure stops looking environmental.
+    Each failing phase's normalized first error line is checked, lowercased. A
+    single code-level failure anywhere disqualifies the node: an assertion
+    failure (whatever its compared data contains) or any non-network error in
+    one phase means the node files, even when another phase — say a teardown
+    flake — looks environmental. Only a node whose failures are network-shaped
+    in every failing phase classifies: a genuine network fault surfaces as a
+    raised ConnectionRefusedError / gaierror / SSLError first line. A node
+    classified environmental is logged and excluded from filing — no issue, no
+    umbrella (the exclusion runs before cascade grouping) — and deliberately
+    NOT recorded as dispatched, so it re-evaluates every night and starts
+    filing again the moment its failure stops looking environmental. That
+    non-recording also means a persistently environmental-looking code bug is
+    silenced to log lines with no escalation path — tracked in #3163.
     """
+    saw_environmental = False
     for phase in ("setup", "call", "teardown"):
         line = _normalized_first_error_line(_phase_text(test, phase)).lower()
-        if not line or line.startswith(("assert ", "assertionerror")):
+        if not line:
             continue
+        if line.startswith(("assert ", "assertionerror")):
+            return False
         if any(marker in line for marker in _ENVIRONMENTAL_MARKERS):
-            return True
-    return False
+            saw_environmental = True
+        else:
+            return False
+    return saw_environmental
 
 
 def cascade_title(message: str) -> str:
@@ -1933,7 +1942,7 @@ def closed_issue_dispositions(
                 "--limit",
                 str(limit),
                 "--json",
-                "number,title,stateReason",
+                "number,title,stateReason,closedAt",
             ],
             cwd=PROJECT_DIR,
             capture_output=True,
@@ -1953,24 +1962,37 @@ def closed_issue_dispositions(
 
     try:
         rows = json.loads(result.stdout)
-        if len(rows) >= CLOSED_ISSUE_LIST_LIMIT:
+        if len(rows) >= limit:
+            # INFO, not WARNING: at this repo's size (~1888 closed issues vs
+            # the 1000-row window) saturation is the steady state, so an
+            # alarm-grade line every night is noise. Scoping or widening the
+            # window is tracked in #3163.
             log(
-                f"WARNING: closed-issue dedup window saturated ({len(rows)} rows at the "
-                f"{CLOSED_ISSUE_LIST_LIMIT} limit) — closures older than the window are "
-                "invisible to dedup and may re-file"
+                f"INFO: closed-issue dedup window saturated ({len(rows)} rows at the "
+                f"{limit} limit) — closures older than the window are "
+                "invisible to dedup and may re-file (#3163)"
             )
-        # `gh issue list` orders newest-created first, so the FIRST row per
-        # title is the newest closure — the authoritative disposition. A title
-        # closed more than once is the designed steady state (COMPLETED →
-        # legitimate re-file → later NOT_PLANNED consolidation), and keeping
-        # the last row instead resolved six live nightly nodes to their oldest
-        # closure, re-introducing the churn this map exists to stop.
+        # The authoritative disposition for a duplicated title is its newest
+        # CLOSURE (max closedAt), not its newest-created row: creation order
+        # diverges from closure order in exactly the wave-dup shape #3161
+        # keeps generating — a later-created duplicate closed NOT_PLANNED
+        # early while the original was closed COMPLETED later. Keying on
+        # creation order suppressed the design's one legitimate re-file case
+        # (a fixed bug regressing); keying on the last listed row resolved six
+        # live nodes to their oldest closure. Max closedAt drops any reliance
+        # on gh's implicit sort. A missing closedAt loses to any real one;
+        # among rows with none, the first (newest-created) wins as fallback.
         dispositions: dict[str, tuple[int, str]] = {}
+        newest_closed_at: dict[str, str] = {}
         for row in rows:
-            if row.get("title") and row.get("number") is not None:
-                dispositions.setdefault(
-                    row["title"], (int(row["number"]), str(row.get("stateReason") or ""))
-                )
+            title = row.get("title")
+            if not title or row.get("number") is None:
+                continue
+            closed_at = str(row.get("closedAt") or "")
+            if title in dispositions and closed_at <= newest_closed_at[title]:
+                continue
+            dispositions[title] = (int(row["number"]), str(row.get("stateReason") or ""))
+            newest_closed_at[title] = closed_at
         return dispositions
     except Exception as exc:  # noqa: BLE001
         log(f"WARNING: could not parse closed issues for dedup ({exc})")

--- a/scripts/nightly_regression_tests.py
+++ b/scripts/nightly_regression_tests.py
@@ -329,8 +329,11 @@ OPEN_ISSUE_LIST_TIMEOUT_SECONDS = 60
 # How many closed issues the closed-state dedup read pulls (#3075 defect 1:
 # a node whose exact-title issue was closed as a duplicate was re-reported as
 # "previously untriaged" forever, because dedup consulted open issues only).
-# `gh issue list` returns most-recently-updated first, so the window covers
-# the closures that can plausibly recur.
+# `gh issue list` orders newest-CREATED first, not most-recently-updated, so
+# an old issue closed recently can sit outside this window, and the repo
+# already holds more closed issues than the limit. closed_issue_dispositions()
+# logs a warning when the read saturates the window so the truncation is
+# visible instead of silent.
 CLOSED_ISSUE_LIST_LIMIT = 1000
 
 # Posting one recurrence comment. Bounded on the same rule as the list read
@@ -1572,8 +1575,11 @@ def body_failure_signature(test: dict) -> str | None:
 # Deliberately narrow: a bare TimeoutError / asyncio.TimeoutError is NOT here,
 # because unit-test timeouts are routinely genuine code regressions and
 # classifying them environmental would silence exactly the failures the
-# detector exists to catch. Matching is substring-on-normalized-text, ordered
-# by specificity none of which overlaps.
+# detector exists to catch. Matching is substring over each phase's NORMALIZED
+# FIRST ERROR LINE only, and assertion failures never classify: an assert-diff
+# that embeds "Connection refused" as compared DATA is a code-level
+# expectation mismatch, and matching raw full phase text silently suppressed
+# exactly that shape (#3142 review).
 _ENVIRONMENTAL_MARKERS = (
     "socket.gaierror",
     "getaddrinfo",
@@ -1595,15 +1601,25 @@ _ENVIRONMENTAL_MARKERS = (
 
 
 def is_environmental_failure(test: dict) -> bool:
-    """True when the failure text names a network-layer fault, not a code path.
+    """True when the failure ITSELF is a network-layer fault, not a code path.
 
-    Checked across every phase, lowercased. A node classified environmental is
-    logged and excluded from filing — no issue, no umbrella — and deliberately
-    NOT recorded as dispatched, so it re-evaluates every night and starts
-    filing again the moment its failure text stops looking environmental.
+    Each phase's normalized first error line is checked, lowercased. An
+    assertion failure never classifies, whatever its compared data contains: a
+    genuine network fault surfaces as a raised ConnectionRefusedError /
+    gaierror / SSLError first line, while an ``assert`` whose expected string
+    happens to mention a network error is a code regression the detector must
+    file. A node classified environmental is logged and excluded from filing —
+    no issue, no umbrella (the exclusion runs before cascade grouping) — and
+    deliberately NOT recorded as dispatched, so it re-evaluates every night and
+    starts filing again the moment its failure stops looking environmental.
     """
-    text = "\n".join(_phase_text(test, phase) for phase in ("setup", "call", "teardown")).lower()
-    return any(marker in text for marker in _ENVIRONMENTAL_MARKERS)
+    for phase in ("setup", "call", "teardown"):
+        line = _normalized_first_error_line(_phase_text(test, phase)).lower()
+        if not line or line.startswith(("assert ", "assertionerror")):
+            continue
+        if any(marker in line for marker in _ENVIRONMENTAL_MARKERS):
+            return True
+    return False
 
 
 def cascade_title(message: str) -> str:
@@ -1936,11 +1952,26 @@ def closed_issue_dispositions(
         return None
 
     try:
-        return {
-            row["title"]: (int(row["number"]), str(row.get("stateReason") or ""))
-            for row in json.loads(result.stdout)
-            if row.get("title") and row.get("number") is not None
-        }
+        rows = json.loads(result.stdout)
+        if len(rows) >= CLOSED_ISSUE_LIST_LIMIT:
+            log(
+                f"WARNING: closed-issue dedup window saturated ({len(rows)} rows at the "
+                f"{CLOSED_ISSUE_LIST_LIMIT} limit) — closures older than the window are "
+                "invisible to dedup and may re-file"
+            )
+        # `gh issue list` orders newest-created first, so the FIRST row per
+        # title is the newest closure — the authoritative disposition. A title
+        # closed more than once is the designed steady state (COMPLETED →
+        # legitimate re-file → later NOT_PLANNED consolidation), and keeping
+        # the last row instead resolved six live nightly nodes to their oldest
+        # closure, re-introducing the churn this map exists to stop.
+        dispositions: dict[str, tuple[int, str]] = {}
+        for row in rows:
+            if row.get("title") and row.get("number") is not None:
+                dispositions.setdefault(
+                    row["title"], (int(row["number"]), str(row.get("stateReason") or ""))
+                )
+        return dispositions
     except Exception as exc:  # noqa: BLE001
         log(f"WARNING: could not parse closed issues for dedup ({exc})")
         return None
@@ -1974,6 +2005,19 @@ def partition_closed_matches(
     return to_file, closed_matches
 
 
+def closed_epilogue(state_reason: str) -> str:
+    """The one policy sentence for a recurrence on a CLOSED, not-re-filed issue.
+
+    Shared by the per-node and cascade recurrence comments so the wording
+    cannot drift between the two (#3142 review nit: it already had).
+    """
+    return (
+        f"This issue is closed ({state_reason or 'unknown'}), so no duplicate was filed. "
+        "If this closure consolidated into another issue, that issue is the live tracker "
+        "for the recurrence; close as completed instead if recurrence should re-file."
+    )
+
+
 def closed_recurrence_comment(
     node: str, state_reason: str, *, run_at: str, head_commit: str | None
 ) -> str:
@@ -1989,10 +2033,7 @@ def closed_recurrence_comment(
             *_recurrence_header(run_at, head_commit),
             f"- Node: `{node}`",
             "",
-            f"This issue is closed ({state_reason}), so no duplicate was filed. If this "
-            "closure consolidated into another issue, that issue is the live tracker for "
-            "the recurrence; if this node should be re-filed on recurrence instead, close "
-            "as completed rather than not-planned.",
+            closed_epilogue(state_reason),
         ]
     )
 
@@ -2309,10 +2350,12 @@ def dispatch_findings(
     ordinary path and the integrity-trip path so the two cannot drift in how
     they dedup. The order is deliberate:
 
-    1. Collapse the blast radius **before** anything is filed: setup storms via
-       :func:`group_setup_error_cascades` (278 errors once became 26 issues),
-       then environmental exclusion (:func:`is_environmental_failure` — network
-       faults file nothing), then same-root-cause body failures via
+    1. Collapse the blast radius **before** anything is filed: environmental
+       exclusion first (:func:`is_environmental_failure` — network faults file
+       nothing, not even a cascade umbrella, so a DNS outage poisoning fixture
+       setup on a whole worker cannot masquerade as a code regression), then
+       setup storms via :func:`group_setup_error_cascades` (278 errors once
+       became 26 issues), then same-root-cause body failures via
        :func:`group_body_failure_cascades` (39 issues once covered 2 causes).
     2. Read the open and closed issue sets once each, and only when there is
        something to file — a clean night must not shell out to ``gh`` at all.
@@ -2331,17 +2374,24 @@ def dispatch_findings(
     shapes. Comments do not spend budget: the cap exists to bound how much
     *new* tracker surface one night creates, and a comment creates none.
     """
-    cascades, single_nodes = group_setup_error_cascades(report, dispatch_nodes)
-
     tests_by_id = {t.get("nodeid"): t for t in report.get("tests", []) if t.get("nodeid")}
-    environmental = [n for n in single_nodes if is_environmental_failure(tests_by_id.get(n) or {})]
+    # Environmental exclusion runs FIRST, on the full dispatch set, so a
+    # network fault that poisons fixture setup on a whole worker is excluded
+    # before cascade grouping can collapse it into a code-regression umbrella
+    # (#3142 review blocker: the grouped case is the most likely real-world
+    # environmental shape).
+    environmental = [
+        n for n in dispatch_nodes if is_environmental_failure(tests_by_id.get(n) or {})
+    ]
     if environmental:
         env_set = set(environmental)
-        single_nodes = [n for n in single_nodes if n not in env_set]
+        dispatch_nodes = [n for n in dispatch_nodes if n not in env_set]
         log(
             f"{len(environmental)} node(s) classified ENVIRONMENTAL (network-layer "
             "failure text) — no issue filed, re-evaluated next run: " + ", ".join(environmental)
         )
+
+    cascades, single_nodes = group_setup_error_cascades(report, dispatch_nodes)
 
     if not cascades_only:
         body_cascades, single_nodes = group_body_failure_cascades(report, single_nodes)
@@ -2395,9 +2445,8 @@ def dispatch_findings(
             number, reason = closed_entry
             body = (
                 cascade_recurrence_comment(cascade, run_at=run_at, head_commit=head_commit)
-                + f"\n\nThis issue is closed ({reason or 'unknown'}), so no duplicate was "
-                "filed. If this closure consolidated into another issue, that issue is the "
-                "live tracker; close as completed instead if recurrence should re-file."
+                + "\n\n"
+                + closed_epilogue(reason)
             )
             if comment_on_issue(number, body, dry_run=dry_run):
                 outcome.comments_posted += 1
@@ -2729,9 +2778,13 @@ def main() -> int:
                 f"(old={prev.get('collection')!r}, new={COLLECTION_PATHS!r}). "
                 f"The following {seed_size} node(s) were already failing at the "
                 "moment of the re-baseline and have been absorbed into the seed — "
-                "they are NOT individually filed. Search open issues for the EXACT "
-                f'title "{seed_title}". If found, comment on it. If not found, open '
-                f"ONE umbrella issue with EXACTLY that title, summarizing the "
+                "they are NOT individually filed. Search open AND closed issues for "
+                f'the EXACT title "{seed_title}". If an open one exists, comment on '
+                "it. If a closed one exists, comment there and do NOT re-file — the "
+                "seed umbrella is a declaration, and a re-baseline retry at the same "
+                "commit must not mint a twin, whatever the close reason. Only if "
+                f"neither exists, open ONE umbrella issue with EXACTLY that title, "
+                "summarizing the "
                 "population, its size, and pointing at the persisted state file "
                 "for the full node list. Do NOT file per-node issues for these. Do "
                 "NOT attempt an auto-hotfix.\n\n"
@@ -2786,7 +2839,8 @@ def main() -> int:
             current["dispatched_session_id"] = outcome.session_id
         log(
             f"Tracker: {outcome.issues_filed} issue(s) filed, "
-            f"{outcome.comments_posted} recurrence comment(s) posted"
+            f"{outcome.comments_posted} recurrence comment(s) posted, "
+            f"{len(outcome.environmental)} node(s) excluded as environmental"
         )
 
     # Carry the seed's umbrella coverage forward on EVERY run, not just seed

--- a/scripts/nightly_regression_tests.py
+++ b/scripts/nightly_regression_tests.py
@@ -147,7 +147,7 @@ import signal
 import subprocess
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -291,6 +291,19 @@ MAX_ISSUES_PER_RUN_DEFAULT = 10
 # the evidence that exists.
 CASCADE_MIN_GROUP_SIZE_DEFAULT = 3
 
+# A group of nodes whose test BODIES fail with the same normalized first error
+# line is one root cause once it reaches this size (#3075: 2026-08-24 filed 39
+# issues over what were two causes, both body failures the setup-cascade path
+# could not see). Deliberately higher than the setup threshold: body failures
+# sharing a message are more often coincidence than setup storms are, and the
+# false-merge cost (two distinct bugs behind one umbrella) is real. The rule is
+# exact equality of the normalized first `E ` line — the 2026-08-24 second
+# cause (nine worker-key nodes inside a 66-node TypeError batch) had a
+# different first line and stays a separate group under it.
+#
+# Provisional/tunable via NIGHTLY_BODY_CASCADE_MIN_GROUP_SIZE.
+BODY_CASCADE_MIN_GROUP_SIZE_DEFAULT = 5
+
 # Ceiling on setup-error outcomes before validate_run_integrity calls the run
 # infrastructure rather than a red suite.
 #
@@ -312,6 +325,13 @@ MAX_SETUP_ERRORS_DEFAULT = 50
 # triage sessions file the same title twice.
 OPEN_ISSUE_LIST_LIMIT = 1000
 OPEN_ISSUE_LIST_TIMEOUT_SECONDS = 60
+
+# How many closed issues the closed-state dedup read pulls (#3075 defect 1:
+# a node whose exact-title issue was closed as a duplicate was re-reported as
+# "previously untriaged" forever, because dedup consulted open issues only).
+# `gh issue list` returns most-recently-updated first, so the window covers
+# the closures that can plausibly recur.
+CLOSED_ISSUE_LIST_LIMIT = 1000
 
 # Posting one recurrence comment. Bounded on the same rule as the list read
 # above; a comment that cannot be posted is logged and the finding is left
@@ -1431,11 +1451,17 @@ def _build_triage_prompt(dispatch_nodes: list[str]) -> str:
     titles = [f"Nightly regression: {n}" for n in dispatch_nodes]
     lines = [
         "Nightly regression detector found confirmed test failures that have not "
-        "been triaged before. For EACH node below, search open issues for the "
-        "EXACT title given. If found, comment on it with any new information. If "
-        "not found, open a new issue with EXACTLY that title, describing the "
-        "failure, its likely cause, and suggested next steps. Do NOT attempt an "
-        "auto-hotfix — this is an investigation-and-file-an-issue task only.\n",
+        "been triaged before. For EACH node below, search ALL issues — open AND "
+        "closed — for the EXACT title given. If an OPEN issue exists, comment on "
+        "it with any new information. If a CLOSED issue exists, the close reason "
+        "decides: closed as not-planned (duplicate/consolidated) — comment there "
+        "pointing at the recurrence and do NOT open a new issue, the consolidation "
+        "target is the live tracker; closed as completed (fixed) — the failure "
+        "recurring after a fix is new information, open a new issue with EXACTLY "
+        "the title and link the closed one. If no issue exists in any state, open "
+        "a new issue with EXACTLY that title, describing the failure, its likely "
+        "cause, and suggested next steps. Do NOT attempt an auto-hotfix — this is "
+        "an investigation-and-file-an-issue task only.\n",
     ]
     for node, title in zip(dispatch_nodes, titles, strict=True):
         lines.append(f'- Title: "{title}"\n  Node: {node}')
@@ -1488,25 +1514,96 @@ def setup_error_signature(test: dict) -> tuple[str, str] | None:
             worker = match.group(1)
             break
 
+    normalized = _normalized_first_error_line(message)
+    if not normalized:
+        return None
+    return worker, normalized
+
+
+def _normalized_first_error_line(message: str) -> str:
+    """First substantive line of a failure message, normalized for grouping.
+
+    Shared by the setup-cascade and body-failure signatures so the two cannot
+    drift in what counts as "the same error". Skips xdist's ``[gwN]`` banner
+    line (which would otherwise BE the signature for every node), strips
+    pytest's ``E `` error-line marker, collapses whitespace, and replaces digit
+    runs with ``#`` (ports, pids, worker numbers, temp-dir suffixes).
+    """
     first_line = ""
     for line in message.splitlines():
         stripped = line.strip()
-        # Skip xdist's own banner line, which carries the worker id and the
-        # interpreter path and would otherwise BE the signature for every node.
         if not stripped or _WORKER_RE.search(stripped):
             continue
         first_line = stripped
         break
     if not first_line:
-        return None
-
-    # Strip pytest's `E   ` error-line marker so the title reads as the exception,
-    # not as the report formatting around it.
+        return ""
     if first_line.startswith("E ") or first_line == "E":
         first_line = first_line[1:].strip()
+    return _DIGITS_RE.sub("#", " ".join(first_line.split()))
 
-    normalized = _DIGITS_RE.sub("#", " ".join(first_line.split()))
-    return worker, normalized
+
+def body_failure_signature(test: dict) -> str | None:
+    """Normalized first error line for a test that failed in its own BODY, else ``None``.
+
+    The complement of :func:`setup_error_signature`: setup must have passed and
+    the ``call`` phase must have failed, so the two signatures partition a
+    failure set rather than double-counting it.
+
+    Unlike a setup cascade, a body-failure group is keyed on the message alone,
+    never the worker: one broken shared dependency (the 2026-08-24 case was a
+    ``TypeError`` at argument binding inside the LLM wrapper) fails its callers
+    on every worker at once, and a per-worker key would split one cause into
+    ten groups all below threshold.
+    """
+    if (test.get("setup") or {}).get("outcome") != "passed":
+        return None
+    if (test.get("call") or {}).get("outcome") not in ("failed", "error"):
+        return None
+    message = _phase_text(test, "call")
+    if not message:
+        return None
+    return _normalized_first_error_line(message) or None
+
+
+# Failure text that names a NETWORK operation failing — DNS, TLS, connection
+# refused/reset, connect-phase timeouts — is environmental (#3075 defect 3,
+# carried from #2932): the code did not regress, the world around the run did.
+# Deliberately narrow: a bare TimeoutError / asyncio.TimeoutError is NOT here,
+# because unit-test timeouts are routinely genuine code regressions and
+# classifying them environmental would silence exactly the failures the
+# detector exists to catch. Matching is substring-on-normalized-text, ordered
+# by specificity none of which overlaps.
+_ENVIRONMENTAL_MARKERS = (
+    "socket.gaierror",
+    "getaddrinfo",
+    "name or service not known",
+    "nodename nor servname provided",
+    "temporary failure in name resolution",
+    "ssl.sslerror",
+    "sslcertverificationerror",
+    "certificate_verify_failed",
+    "ssl handshake",
+    "connectionrefusederror",
+    "connection refused",
+    "connectionreseterror",
+    "connection reset by peer",
+    "connecttimeout",
+    "httpx.connecterror",
+    "requests.exceptions.connectionerror",
+)
+
+
+def is_environmental_failure(test: dict) -> bool:
+    """True when the failure text names a network-layer fault, not a code path.
+
+    Checked across every phase, lowercased. A node classified environmental is
+    logged and excluded from filing — no issue, no umbrella — and deliberately
+    NOT recorded as dispatched, so it re-evaluates every night and starts
+    filing again the moment its failure text stops looking environmental.
+    """
+    text = "\n".join(_phase_text(test, phase) for phase in ("setup", "call", "teardown")).lower()
+    return any(marker in text for marker in _ENVIRONMENTAL_MARKERS)
 
 
 def cascade_title(message: str) -> str:
@@ -1519,6 +1616,97 @@ def cascade_title(message: str) -> str:
     """
     digest = hashlib.sha256(message.encode()).hexdigest()[:8]
     return f"Nightly regression cascade [{digest}]: {message[:80]}"
+
+
+_BODY_CASCADE_KEY_PREFIX = "body::"
+
+
+def body_cascade_title(message: str) -> str:
+    """The byte-stable umbrella title for one normalized body-failure group.
+
+    A separate namespace from :func:`cascade_title` so a body-failure group and
+    a setup cascade that happen to share a normalized message can never collide
+    on one title — they are different defects by construction (setup poisoning
+    vs. shared-dependency breakage) and merging their recurrence threads would
+    hide one behind the other.
+    """
+    digest = hashlib.sha256((_BODY_CASCADE_KEY_PREFIX + message).encode()).hexdigest()[:8]
+    return f"Nightly regression group [{digest}]: {message[:80]}"
+
+
+def cascade_state_key(cascade: dict) -> str:
+    """The ``cascade_issues`` persistence key for one cascade dict."""
+    if cascade.get("kind") == "body":
+        return _BODY_CASCADE_KEY_PREFIX + cascade["message"]
+    return cascade["message"]
+
+
+def title_for_state_key(key: str) -> str:
+    """Recompute the umbrella title a persisted ``cascade_issues`` key filed under."""
+    if key.startswith(_BODY_CASCADE_KEY_PREFIX):
+        return body_cascade_title(key[len(_BODY_CASCADE_KEY_PREFIX) :])
+    return cascade_title(key)
+
+
+def group_body_failure_cascades(
+    report: dict,
+    node_ids: list[str],
+    *,
+    min_group_size: int | None = None,
+) -> tuple[list[dict], list[str]]:
+    """Split ``node_ids`` into same-root-cause body-failure groups and singles.
+
+    The 39-for-2 fix (#3075): nodes whose test bodies fail with an identical
+    normalized first error line are one root cause once the group is large.
+    Returns ``(groups, singles)`` in the same ``{"message", "title", "workers",
+    "nodes", "kind"}`` shape as :func:`group_setup_error_cascades`, so the two
+    share one filing path.
+
+    **False-merge risk, stated plainly:** two genuinely distinct defects that
+    raise the same exception with byte-identical normalized first lines will
+    merge into one umbrella. That is accepted as the smaller harm — the
+    triage session reads the node list and can split the issue, whereas 39
+    separate issues drowned the two real causes entirely. The grouping rule is
+    exact equality of the normalized line, nothing fuzzier, precisely to keep
+    that risk small: the 2026-08-24 second cause (worker-key assertions inside
+    a TypeError batch) had a different first line and stays separate under it.
+    """
+    if min_group_size is None:
+        min_group_size = resolve_int_knob(
+            "NIGHTLY_BODY_CASCADE_MIN_GROUP_SIZE", BODY_CASCADE_MIN_GROUP_SIZE_DEFAULT
+        )
+
+    tests_by_id = {t.get("nodeid"): t for t in report.get("tests", []) if t.get("nodeid")}
+
+    by_message: dict[str, list[str]] = {}
+    for node in node_ids:
+        signature = body_failure_signature(tests_by_id.get(node) or {})
+        if signature is None:
+            continue
+        by_message.setdefault(signature, []).append(node)
+
+    groups = []
+    for message in sorted(by_message):
+        nodes = by_message[message]
+        if len(nodes) < min_group_size:
+            continue
+        workers = set()
+        for node in nodes:
+            match = _WORKER_RE.search(_phase_text(tests_by_id.get(node) or {}, "call"))
+            if match:
+                workers.add(match.group(1))
+        groups.append(
+            {
+                "message": message,
+                "title": body_cascade_title(message),
+                "workers": sorted(workers),
+                "nodes": sorted(nodes),
+                "kind": "body",
+            }
+        )
+
+    grouped = {n for g in groups for n in g["nodes"]}
+    return groups, [n for n in node_ids if n not in grouped]
 
 
 def group_setup_error_cascades(
@@ -1571,7 +1759,13 @@ def group_setup_error_cascades(
         worker, message = signature
         cascade = by_message.setdefault(
             message,
-            {"message": message, "title": cascade_title(message), "workers": set(), "nodes": []},
+            {
+                "message": message,
+                "title": cascade_title(message),
+                "workers": set(),
+                "nodes": [],
+                "kind": "setup",
+            },
         )
         cascade["workers"].add(worker)
         cascade["nodes"].append(node)
@@ -1591,19 +1785,37 @@ def _build_cascade_prompt(cascade: dict) -> str:
     """Build the umbrella prompt for one cascade — ONE issue, node list collapsed."""
     nodes = cascade["nodes"]
     workers = ", ".join(cascade["workers"]) or "serial run"
+    if cascade.get("kind") == "body":
+        shape = (
+            f"{len(nodes)} test node(s) whose test BODIES all failed with the same "
+            "normalized error line — one shared root cause (a broken common "
+            "dependency), not independent findings"
+        )
+        error_label = "Shared failure line (normalized)"
+        cause_hint = "the shared root cause"
+    else:
+        shape = (
+            f"{len(nodes)} test node(s) that all errored in fixture SETUP with the same "
+            f"message, on xdist worker(s) {workers}"
+        )
+        error_label = "Shared setup error (normalized)"
+        cause_hint = "the likely cause of the poisoning"
     return (
         "Nightly regression detector found a CASCADE: "
-        f"{len(nodes)} test node(s) that all errored in fixture SETUP with the same "
-        f"message, on xdist worker(s) {workers}. This is ONE defect, not "
-        f"{len(nodes)}. Search open issues for the EXACT title below. If found, "
-        "comment on it with the new occurrence. If not found, open exactly ONE new "
-        "issue with EXACTLY that title. Put the full node list inside a collapsed "
-        "<details> section — the body must lead with the shared error and the likely "
-        "cause of the poisoning, not with the node list. Do NOT open per-node issues "
-        "for any node below. Do NOT attempt an auto-hotfix — investigate and file "
-        "only.\n\n"
+        f"{shape}. This is ONE defect, not "
+        f"{len(nodes)}. Search ALL issues — open AND closed — for the EXACT title "
+        "below. If an OPEN one exists, comment on it with the new occurrence. If a "
+        "CLOSED one exists: closed as not-planned means comment there and do NOT "
+        "re-file (its consolidation target is the live tracker); closed as "
+        "completed means the recurrence is new information — open exactly ONE new "
+        "issue with EXACTLY that title, linking the closed one. If none exists, "
+        "open exactly ONE new issue with EXACTLY that title. Put the full node "
+        "list inside a collapsed <details> section — the body must lead with the "
+        f"shared error and {cause_hint}, not with the node list. Do NOT open "
+        "per-node issues for any node below. Do NOT attempt an auto-hotfix — "
+        "investigate and file only.\n\n"
         f'Title: "{cascade["title"]}"\n\n'
-        f"Shared setup error (normalized): {cascade['message']}\n\n"
+        f"{error_label}: {cascade['message']}\n\n"
         "Affected node IDs:\n" + "\n".join(f"- {n}" for n in nodes)
     )
 
@@ -1669,6 +1881,120 @@ def open_issues(
     except Exception as exc:  # noqa: BLE001
         log(f"WARNING: could not parse open issues for dedup ({exc})")
         return None
+
+
+def closed_issue_dispositions(
+    *,
+    limit: int = CLOSED_ISSUE_LIST_LIMIT,
+    timeout: int = OPEN_ISSUE_LIST_TIMEOUT_SECONDS,
+) -> dict[str, tuple[int, str]] | None:
+    """Map ``title -> (number, state_reason)`` for closed issues, or ``None``.
+
+    The closed half of the dedup (#3075 defect 1). ``stateReason`` is what
+    makes closed state usable at all — closed-as-duplicate and closed-as-fixed
+    demand opposite responses:
+
+    - ``NOT_PLANNED`` (duplicate, consolidated, won't-fix): the finding is
+      already on record somewhere; re-filing it is the churn this exists to
+      end. The caller comments on the closed issue instead.
+    - ``COMPLETED`` (fixed): the node failing AGAIN after a fix is genuinely
+      new information and deserves a fresh issue. The caller re-files.
+    - Empty/unknown reason: treated like ``NOT_PLANNED`` — a comment preserves
+      the recurrence signal either way, and a comment on the wrong side costs
+      nothing where a duplicate issue costs tracker noise forever.
+
+    ``None`` means "could not tell"; the caller fails open by filing, matching
+    :func:`open_issues`.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--state",
+                "closed",
+                "--limit",
+                str(limit),
+                "--json",
+                "number,title,stateReason",
+            ],
+            cwd=PROJECT_DIR,
+            capture_output=True,
+            text=True,
+            timeout=timeout,  # timeout-guard: allow
+        )
+    except Exception as exc:  # noqa: BLE001
+        log(f"WARNING: could not list closed issues for dedup ({exc})")
+        return None
+
+    if result.returncode != 0:
+        log(
+            f"WARNING: `gh issue list --state closed` exited {result.returncode} for dedup: "
+            f"{(result.stderr or '').strip()}"
+        )
+        return None
+
+    try:
+        return {
+            row["title"]: (int(row["number"]), str(row.get("stateReason") or ""))
+            for row in json.loads(result.stdout)
+            if row.get("title") and row.get("number") is not None
+        }
+    except Exception as exc:  # noqa: BLE001
+        log(f"WARNING: could not parse closed issues for dedup ({exc})")
+        return None
+
+
+def partition_closed_matches(
+    nodes: list[str], closed_map: dict[str, tuple[int, str]] | None
+) -> tuple[list[str], list[tuple[str, int, str]]]:
+    """Split unfiled candidates into ``(to_file, closed_matches)``.
+
+    Runs AFTER :func:`partition_already_open`, on the nodes with no open issue.
+    ``closed_matches`` holds ``(node, number, state_reason)`` for nodes whose
+    exact title matches a closed issue that must NOT be re-filed
+    (``NOT_PLANNED`` or unknown reason). A ``COMPLETED`` closure stays in
+    ``to_file`` — a failure recurring after its fix is new information, the
+    one legitimate re-file case.
+
+    ``closed_map`` of ``None`` (unreadable) disables the suppression rather
+    than guessing, same fail-open posture as the open partition.
+    """
+    if closed_map is None:
+        return list(nodes), []
+    to_file: list[str] = []
+    closed_matches: list[tuple[str, int, str]] = []
+    for node in nodes:
+        entry = closed_map.get(f"Nightly regression: {node}")
+        if entry is None or entry[1] == "COMPLETED":
+            to_file.append(node)
+        else:
+            closed_matches.append((node, entry[0], entry[1] or "unknown"))
+    return to_file, closed_matches
+
+
+def closed_recurrence_comment(
+    node: str, state_reason: str, *, run_at: str, head_commit: str | None
+) -> str:
+    """Recurrence comment for a node whose issue is CLOSED and not re-filed.
+
+    Says explicitly why no new issue was opened, so a human reading the closed
+    issue understands the detector saw the recurrence and where the live
+    tracker is expected to be (a NOT_PLANNED closure normally points at its
+    consolidation target in its own close comment).
+    """
+    return "\n".join(
+        [
+            *_recurrence_header(run_at, head_commit),
+            f"- Node: `{node}`",
+            "",
+            f"This issue is closed ({state_reason}), so no duplicate was filed. If this "
+            "closure consolidated into another issue, that issue is the live tracker for "
+            "the recurrence; if this node should be re-filed on recurrence instead, close "
+            "as completed rather than not-planned.",
+        ]
+    )
 
 
 def comment_on_issue(number: int, body: str, *, dry_run: bool = False) -> bool:
@@ -1782,7 +2108,7 @@ def resolve_cascade_issue(
     """
     if open_issue_map is None:
         return None
-    recorded = prev_cascade_issues.get(cascade["message"])
+    recorded = prev_cascade_issues.get(cascade_state_key(cascade))
     if isinstance(recorded, int) and recorded in set(open_issue_map.values()):
         return recorded
     return open_issue_map.get(cascade["title"])
@@ -1924,6 +2250,11 @@ class DispatchOutcome:
     session_id: str | None = None
     issues_filed: int = 0
     comments_posted: int = 0
+    # Nodes classified environmental (network-layer failure text) and filed
+    # nowhere. Deliberately never merged into ``recorded``: an environmental
+    # node re-evaluates every night and files normally the moment its failure
+    # stops looking environmental.
+    environmental: list[str] = field(default_factory=list)
 
 
 def carry_cascade_issues(
@@ -1951,14 +2282,14 @@ def carry_cascade_issues(
 
     open_numbers = set(open_issue_map.values())
     carried: dict[str, int | None] = {}
-    for message, number in prev_cascade_issues.items():
+    for key, number in prev_cascade_issues.items():
         if number is None:
-            resolved = open_issue_map.get(cascade_title(message))
+            resolved = open_issue_map.get(title_for_state_key(key))
             if resolved is not None:
-                carried[message] = resolved
+                carried[key] = resolved
             continue
         if number in open_numbers:
-            carried[message] = number
+            carried[key] = number
     return carried
 
 
@@ -1978,13 +2309,17 @@ def dispatch_findings(
     ordinary path and the integrity-trip path so the two cannot drift in how
     they dedup. The order is deliberate:
 
-    1. Collapse the blast radius (:func:`group_setup_error_cascades`) **before**
-       anything is filed. N nodes sharing one setup-error message are one
-       defect, and filing them individually is how 278 errors became 26 issues.
-    2. Read the open issues once, and only when there is something to file — a
-       clean night must not shell out to ``gh`` at all.
-    3. For every finding that already has an open issue, comment. For the rest,
-       spend the issue budget.
+    1. Collapse the blast radius **before** anything is filed: setup storms via
+       :func:`group_setup_error_cascades` (278 errors once became 26 issues),
+       then environmental exclusion (:func:`is_environmental_failure` — network
+       faults file nothing), then same-root-cause body failures via
+       :func:`group_body_failure_cascades` (39 issues once covered 2 causes).
+    2. Read the open and closed issue sets once each, and only when there is
+       something to file — a clean night must not shell out to ``gh`` at all.
+    3. For every finding that already has an open issue, comment. For one whose
+       issue is CLOSED as not-planned, comment there — never re-file
+       (#3075 defect 1); a closure marked completed re-files, because failing
+       again after a fix is new information. For the rest, spend the budget.
 
     ``cascades_only`` suppresses per-node filing entirely. The integrity-trip
     path passes it: on a night this script has just declared infrastructural,
@@ -1997,20 +2332,40 @@ def dispatch_findings(
     *new* tracker surface one night creates, and a comment creates none.
     """
     cascades, single_nodes = group_setup_error_cascades(report, dispatch_nodes)
+
+    tests_by_id = {t.get("nodeid"): t for t in report.get("tests", []) if t.get("nodeid")}
+    environmental = [n for n in single_nodes if is_environmental_failure(tests_by_id.get(n) or {})]
+    if environmental:
+        env_set = set(environmental)
+        single_nodes = [n for n in single_nodes if n not in env_set]
+        log(
+            f"{len(environmental)} node(s) classified ENVIRONMENTAL (network-layer "
+            "failure text) — no issue filed, re-evaluated next run: " + ", ".join(environmental)
+        )
+
+    if not cascades_only:
+        body_cascades, single_nodes = group_body_failure_cascades(report, single_nodes)
+        cascades = cascades + body_cascades
+
     for cascade in cascades:
+        shared = "one setup error" if cascade.get("kind") != "body" else "one failure line"
         log(
             f"Cascade collapsed: {len(cascade['nodes'])} node(s) on worker(s) "
-            f"{','.join(cascade['workers']) or 'serial'} share one setup error — "
+            f"{','.join(cascade['workers']) or 'serial'} share {shared} — "
             f"one finding, not {len(cascade['nodes'])}: {cascade['title']}"
         )
 
     open_issue_map = open_issues() if dispatch_nodes else None
     if dispatch_nodes and open_issue_map is None:
         log("Dedup disabled for this run (open issues unreadable) — failing open")
+    closed_issue_map = closed_issue_dispositions() if dispatch_nodes else None
+    if dispatch_nodes and closed_issue_map is None:
+        log("Closed-state dedup disabled for this run (closed issues unreadable) — failing open")
 
     outcome = DispatchOutcome(
         recorded=[],
         cascade_issues=carry_cascade_issues(prev.get("cascade_issues") or {}, open_issue_map),
+        environmental=environmental,
     )
 
     max_issues = resolve_int_knob("NIGHTLY_MAX_ISSUES_PER_RUN", MAX_ISSUES_PER_RUN_DEFAULT)
@@ -2028,7 +2383,25 @@ def dispatch_findings(
             if posted:
                 outcome.comments_posted += 1
                 outcome.recorded.extend(cascade["nodes"])
-                outcome.cascade_issues[cascade["message"]] = existing
+                outcome.cascade_issues[cascade_state_key(cascade)] = existing
+            continue
+        closed_entry = (closed_issue_map or {}).get(cascade["title"])
+        if closed_entry is not None and closed_entry[1] != "COMPLETED":
+            # Closed as not-planned (duplicate/consolidated): the umbrella is
+            # already on record; re-filing it is the churn. Comment the
+            # recurrence there and deliberately record NO cascade_issues entry
+            # — the issue is closed, and a COMPLETED closure would have fallen
+            # through to a legitimate re-file instead.
+            number, reason = closed_entry
+            body = (
+                cascade_recurrence_comment(cascade, run_at=run_at, head_commit=head_commit)
+                + f"\n\nThis issue is closed ({reason or 'unknown'}), so no duplicate was "
+                "filed. If this closure consolidated into another issue, that issue is the "
+                "live tracker; close as completed instead if recurrence should re-file."
+            )
+            if comment_on_issue(number, body, dry_run=dry_run):
+                outcome.comments_posted += 1
+                outcome.recorded.extend(cascade["nodes"])
             continue
         if issue_budget <= 0:
             deferred_cascades.append(cascade)
@@ -2036,7 +2409,7 @@ def dispatch_findings(
         session_id = maybe_dispatch_triage_session(
             [f"cascade:{cascade['title']}"],
             prompt=_build_cascade_prompt(cascade),
-            slug_suffix=hashlib.sha256(cascade["message"].encode()).hexdigest()[:8],
+            slug_suffix=hashlib.sha256(cascade_state_key(cascade).encode()).hexdigest()[:8],
             dry_run=dry_run,
         )
         if session_id is not None:
@@ -2046,7 +2419,7 @@ def dispatch_findings(
             outcome.session_id = session_id
             # Pending: the triage session opens the issue, so its number is not
             # knowable here. carry_cascade_issues() upgrades this on a later run.
-            outcome.cascade_issues[cascade["message"]] = None
+            outcome.cascade_issues[cascade_state_key(cascade)] = None
 
     if deferred_cascades:
         log(
@@ -2075,6 +2448,22 @@ def dispatch_findings(
         log(
             f"{len(already_open)} node(s) already have an open issue — commented the "
             "recurrence instead of filing: " + ", ".join(n for n, _ in already_open)
+        )
+
+    single_nodes, closed_matches = partition_closed_matches(single_nodes, closed_issue_map)
+    for node, number, reason in closed_matches:
+        if comment_on_issue(
+            number,
+            closed_recurrence_comment(node, reason, run_at=run_at, head_commit=head_commit),
+            dry_run=dry_run,
+        ):
+            outcome.comments_posted += 1
+            outcome.recorded.append(node)
+    if closed_matches:
+        log(
+            f"{len(closed_matches)} node(s) have a CLOSED not-planned issue — commented "
+            "the recurrence there instead of re-filing (#3075): "
+            + ", ".join(n for n, _, _ in closed_matches)
         )
 
     if len(single_nodes) > issue_budget:

--- a/tests/unit/test_nightly_regression_tests.py
+++ b/tests/unit/test_nightly_regression_tests.py
@@ -1158,6 +1158,7 @@ class TestDispatchFindings:
     def _dispatch(self, monkeypatch, tmp_path, *, nodes, open_map, prev=None, report=None, **kw):
         monkeypatch.setattr(nrt, "LOG_FILE", tmp_path / "nightly.log")
         monkeypatch.setattr(nrt, "open_issues", lambda: open_map)
+        monkeypatch.setattr(nrt, "closed_issue_dispositions", lambda: {})
         commented: list[int] = []
         monkeypatch.setattr(
             nrt, "comment_on_issue", lambda n, body, **kw: commented.append(n) or True
@@ -1217,6 +1218,7 @@ class TestDispatchFindings:
         monkeypatch.setattr(nrt, "LOG_FILE", tmp_path / "nightly.log")
         nodes = [f"tests/unit/test_m.py::test_{i}" for i in range(9)]
         monkeypatch.setattr(nrt, "open_issues", lambda: {nrt.cascade_title(self.MSG): 4242})
+        monkeypatch.setattr(nrt, "closed_issue_dispositions", lambda: {})
         monkeypatch.setattr(nrt, "comment_on_issue", lambda *a, **k: False)
         monkeypatch.setattr(nrt, "maybe_dispatch_triage_session", lambda *a, **k: None)
         outcome = nrt.dispatch_findings(
@@ -1270,6 +1272,7 @@ class TestDispatchFindings:
         )
         monkeypatch.setattr(nrt, "LOG_FILE", tmp_path / "nightly.log")
         monkeypatch.setattr(nrt, "open_issues", lambda: {})
+        monkeypatch.setattr(nrt, "closed_issue_dispositions", lambda: {})
         filed: list[list[str]] = []
         monkeypatch.setattr(
             nrt,
@@ -1291,6 +1294,9 @@ class TestDispatchFindings:
     def test_a_clean_night_never_shells_out_to_gh(self, monkeypatch, tmp_path: Path) -> None:
         monkeypatch.setattr(nrt, "LOG_FILE", tmp_path / "nightly.log")
         monkeypatch.setattr(nrt, "open_issues", lambda: pytest.fail("read gh on a clean night"))
+        monkeypatch.setattr(
+            nrt, "closed_issue_dispositions", lambda: pytest.fail("read gh closed set")
+        )
         monkeypatch.setattr(nrt, "maybe_dispatch_triage_session", lambda *a, **k: None)
         outcome = nrt.dispatch_findings({"tests": []}, [], {}, run_at="RUN", head_commit="HEAD")
         assert outcome.recorded == []
@@ -1318,6 +1324,7 @@ class TestHandleIntegrityTrip:
         monkeypatch.setattr(nrt, "LOG_FILE", tmp_path / "nightly.log")
         monkeypatch.setattr(nrt, "LAST_RUN_FILE", tmp_path / "last_run.json")
         monkeypatch.setattr(nrt, "open_issues", lambda: {})
+        monkeypatch.setattr(nrt, "closed_issue_dispositions", lambda: {})
         monkeypatch.setattr(nrt, "_get_head_commit", lambda: "cafe1234")
         filed: list[list[str]] = []
         monkeypatch.setattr(
@@ -1341,6 +1348,7 @@ class TestHandleIntegrityTrip:
         monkeypatch.setattr(nrt, "LOG_FILE", tmp_path / "nightly.log")
         monkeypatch.setattr(nrt, "LAST_RUN_FILE", tmp_path / "last_run.json")
         monkeypatch.setattr(nrt, "open_issues", lambda: {})
+        monkeypatch.setattr(nrt, "closed_issue_dispositions", lambda: {})
         monkeypatch.setattr(nrt, "_get_head_commit", lambda: "cafe1234")
         monkeypatch.setattr(nrt, "maybe_dispatch_triage_session", lambda ns, **kw: "sess-1")
         _, report = self._storm()
@@ -1357,6 +1365,9 @@ class TestHandleIntegrityTrip:
         monkeypatch.setattr(nrt, "LOG_FILE", tmp_path / "nightly.log")
         monkeypatch.setattr(nrt, "LAST_RUN_FILE", tmp_path / "last_run.json")
         monkeypatch.setattr(nrt, "open_issues", lambda: pytest.fail("read gh with no report"))
+        monkeypatch.setattr(
+            nrt, "closed_issue_dispositions", lambda: pytest.fail("read gh closed set")
+        )
         assert nrt._handle_integrity_trip("no report", None, None, self._prev()) == 1
         assert not nrt.LAST_RUN_FILE.exists()
 
@@ -1366,6 +1377,7 @@ class TestHandleIntegrityTrip:
         monkeypatch.setattr(nrt, "LAST_RUN_FILE", tmp_path / "last_run.json")
         monkeypatch.setattr(nrt, "_get_head_commit", lambda: "cafe1234")
         monkeypatch.setattr(nrt, "open_issues", lambda: {nrt.cascade_title(self.MSG): 4242})
+        monkeypatch.setattr(nrt, "closed_issue_dispositions", lambda: {})
         commented: list[int] = []
         monkeypatch.setattr(
             nrt, "comment_on_issue", lambda n, body, **kw: commented.append(n) or True
@@ -1384,6 +1396,7 @@ class TestHandleIntegrityTrip:
         monkeypatch.setattr(nrt, "LOG_FILE", tmp_path / "nightly.log")
         monkeypatch.setattr(nrt, "LAST_RUN_FILE", tmp_path / "last_run.json")
         monkeypatch.setattr(nrt, "open_issues", lambda: {})
+        monkeypatch.setattr(nrt, "closed_issue_dispositions", lambda: {})
         monkeypatch.setattr(nrt, "_get_head_commit", lambda: "cafe1234")
         monkeypatch.setattr(nrt, "maybe_dispatch_triage_session", lambda ns, **kw: "sess-1")
         _, report = self._storm()
@@ -1550,6 +1563,8 @@ class TestMainDispatchPersistence:
             patch.object(
                 nrt, "maybe_dispatch_triage_session", return_value=dispatch_return
             ) as mock_dispatch,
+            patch.object(nrt, "open_issues", return_value={}),
+            patch.object(nrt, "closed_issue_dispositions", return_value={}),
             patch.object(nrt, "run_ttft_gate", return_value=None),
             patch.object(nrt, "_get_head_commit", return_value="deadbeef"),
         ):
@@ -1651,6 +1666,8 @@ class TestMainDispatchPersistence:
             ),
             patch.object(nrt, "reconfirm_serial", return_value=(list(confirmed), [], True)),
             patch.object(nrt, "maybe_dispatch_triage_session", return_value="sentinel") as disp,
+            patch.object(nrt, "open_issues", return_value={}),
+            patch.object(nrt, "closed_issue_dispositions", return_value={}),
             patch.object(nrt, "run_ttft_gate", return_value=None),
             patch.object(nrt, "_get_head_commit", return_value="deadbeef"),
         ):
@@ -1709,6 +1726,8 @@ class TestMainDispatchPersistence:
             ),
             patch.object(nrt, "reconfirm_serial", return_value=(list(confirmed), [], True)),
             patch.object(nrt, "maybe_dispatch_triage_session", return_value="sentinel"),
+            patch.object(nrt, "open_issues", return_value={}),
+            patch.object(nrt, "closed_issue_dispositions", return_value={}),
             patch.object(nrt, "run_ttft_gate", return_value=None),
             patch.object(nrt, "_get_head_commit", return_value="deadbeef"),
         ):
@@ -2142,6 +2161,8 @@ class TestPersistedStateKeyInvariance:
             ),
             patch.object(nrt, "reconfirm_serial", return_value=(list(confirmed), [], True)),
             patch.object(nrt, "maybe_dispatch_triage_session", return_value="sess-1"),
+            patch.object(nrt, "open_issues", return_value={}),
+            patch.object(nrt, "closed_issue_dispositions", return_value={}),
             patch.object(nrt, "run_ttft_gate", return_value=None),
             patch.object(nrt, "_get_head_commit", return_value="headsha"),
             patch.object(nrt, "classify_against_baseline", return_value=classification),
@@ -2155,3 +2176,306 @@ class TestPersistedStateKeyInvariance:
         assert set(shadow_state) == set(off_state)
         assert "classify_attempts" not in shadow_state
         assert "fix_sessions" not in shadow_state
+
+
+def _body_failed(nodeid: str, worker: str, line: str) -> dict:
+    """A pytest-json-report entry shaped like a real test-BODY failure."""
+    return {
+        "nodeid": nodeid,
+        "outcome": "failed",
+        "setup": {"outcome": "passed"},
+        "call": {
+            "outcome": "failed",
+            "longrepr": f"[{worker}] darwin -- Python 3.14.3\n{line}",
+        },
+    }
+
+
+class TestBodyFailureGrouping:
+    """Same normalized first error line across test bodies = one root cause (#3075).
+
+    The 2026-08-24 incident: 39 issues filed over two causes, both body
+    failures the setup-cascade path could not see.
+    """
+
+    LINE = "E   TypeError: AsyncAnthropic.__init__() got an unexpected keyword argument"
+    OTHER = "E   AssertionError: worker_key must route to the lane slug"
+
+    def test_same_line_across_workers_collapses_to_one_group(self) -> None:
+        nodes = [f"tests/unit/test_llm_{i}.py::test_{i}" for i in range(6)]
+        report = {"tests": [_body_failed(n, f"gw{i % 3}", self.LINE) for i, n in enumerate(nodes)]}
+        groups, singles = nrt.group_body_failure_cascades(report, nodes)
+        assert singles == []
+        assert len(groups) == 1
+        assert groups[0]["nodes"] == sorted(nodes)
+        assert groups[0]["kind"] == "body"
+        assert groups[0]["workers"] == ["gw0", "gw1", "gw2"]
+
+    def test_second_cause_with_different_line_stays_separate(self) -> None:
+        """The worker-key nodes inside the TypeError batch must NOT merge."""
+        typeerror = [f"tests/unit/test_llm_{i}.py::test_{i}" for i in range(6)]
+        workerkey = [f"tests/unit/test_wk_{i}.py::test_{i}" for i in range(3)]
+        report = {
+            "tests": [_body_failed(n, "gw0", self.LINE) for n in typeerror]
+            + [_body_failed(n, "gw0", self.OTHER) for n in workerkey]
+        }
+        groups, singles = nrt.group_body_failure_cascades(report, typeerror + workerkey)
+        assert len(groups) == 1
+        assert groups[0]["nodes"] == sorted(typeerror)
+        assert sorted(singles) == sorted(workerkey)
+
+    def test_below_threshold_stays_per_node(self) -> None:
+        nodes = [f"tests/unit/test_m.py::test_{i}" for i in range(3)]
+        report = {"tests": [_body_failed(n, "gw1", self.LINE) for n in nodes]}
+        groups, singles = nrt.group_body_failure_cascades(report, nodes)
+        assert groups == []
+        assert singles == nodes
+
+    def test_setup_errors_are_not_body_grouped(self) -> None:
+        """Setup storms belong to group_setup_error_cascades, not this grouper."""
+        nodes = [f"tests/unit/test_m.py::test_{i}" for i in range(6)]
+        report = {"tests": [_errored(n, "gw1", "RuntimeError: poisoned") for n in nodes]}
+        groups, singles = nrt.group_body_failure_cascades(report, nodes)
+        assert groups == []
+        assert singles == nodes
+
+    def test_title_namespace_is_distinct_from_setup_cascades(self) -> None:
+        msg = "TypeError: same normalized message"
+        assert nrt.body_cascade_title(msg) != nrt.cascade_title(msg)
+        assert nrt.title_for_state_key(msg) == nrt.cascade_title(msg)
+        assert nrt.title_for_state_key("body::" + msg) == nrt.body_cascade_title(msg)
+
+
+class TestEnvironmentalClassification:
+    """Network-layer failure text files nothing (#3075 defect 3, from #2932)."""
+
+    def test_connection_refused_is_environmental(self) -> None:
+        test = _body_failed("t.py::a", "gw0", "E   ConnectionRefusedError: [Errno 61]")
+        assert nrt.is_environmental_failure(test)
+
+    def test_dns_failure_is_environmental(self) -> None:
+        test = _body_failed(
+            "t.py::a", "gw0", "E   socket.gaierror: [Errno 8] nodename nor servname provided"
+        )
+        assert nrt.is_environmental_failure(test)
+
+    def test_tls_failure_is_environmental(self) -> None:
+        test = _body_failed("t.py::a", "gw0", "E   ssl.SSLError: CERTIFICATE_VERIFY_FAILED")
+        assert nrt.is_environmental_failure(test)
+
+    def test_plain_assertion_is_not_environmental(self) -> None:
+        test = _body_failed("t.py::a", "gw0", "E   AssertionError: expected 3 == 4")
+        assert not nrt.is_environmental_failure(test)
+
+    def test_bare_timeout_is_deliberately_not_environmental(self) -> None:
+        """Unit-test timeouts are routinely genuine regressions; do not silence them."""
+        test = _body_failed("t.py::a", "gw0", "E   TimeoutError: took too long")
+        assert not nrt.is_environmental_failure(test)
+
+
+class TestClosedIssueDedup:
+    """A closed exact-title issue must never be silently re-filed (#3075 defect 1)."""
+
+    def _dispatch(self, monkeypatch, tmp_path, *, nodes, report, open_map, closed_map, prev=None):
+        monkeypatch.setattr(nrt, "LOG_FILE", tmp_path / "nightly.log")
+        monkeypatch.setattr(nrt, "open_issues", lambda: open_map)
+        monkeypatch.setattr(nrt, "closed_issue_dispositions", lambda: closed_map)
+        commented: list[int] = []
+        monkeypatch.setattr(
+            nrt, "comment_on_issue", lambda n, body, **kw: commented.append(n) or True
+        )
+        filed: list[list[str]] = []
+
+        def fake_dispatch(ns, **kw):
+            if not ns:
+                return None
+            filed.append(list(ns))
+            return "sess-1"
+
+        monkeypatch.setattr(nrt, "maybe_dispatch_triage_session", fake_dispatch)
+        outcome = nrt.dispatch_findings(
+            report, nodes, prev or {}, run_at="2026-09-04T03:00:00Z", head_commit="cafe1234"
+        )
+        return outcome, commented, filed
+
+    def test_closed_not_planned_node_gets_a_comment_never_a_refile(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """The regression test the acceptance criteria demand: only issue is CLOSED."""
+        node = "tests/unit/test_dead.py::test_watchdog"
+        outcome, commented, filed = self._dispatch(
+            monkeypatch,
+            tmp_path,
+            nodes=[node],
+            report={"tests": [_body_failed(node, "gw0", "E   AssertionError: dead")]},
+            open_map={},
+            closed_map={f"Nightly regression: {node}": (2971, "NOT_PLANNED")},
+        )
+        assert filed == []
+        assert commented == [2971]
+        assert outcome.recorded == [node]
+        assert outcome.issues_filed == 0
+
+    def test_closed_completed_refiles_because_recurrence_is_new_information(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        node = "tests/unit/test_fixed.py::test_regressed_again"
+        outcome, commented, filed = self._dispatch(
+            monkeypatch,
+            tmp_path,
+            nodes=[node],
+            report={"tests": [_body_failed(node, "gw0", "E   AssertionError: back")]},
+            open_map={},
+            closed_map={f"Nightly regression: {node}": (2500, "COMPLETED")},
+        )
+        assert commented == []
+        assert filed == [[node]]
+        assert outcome.issues_filed == 1
+
+    def test_unknown_close_reason_comments_rather_than_refiling(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        node = "tests/unit/test_x.py::test_y"
+        _, commented, filed = self._dispatch(
+            monkeypatch,
+            tmp_path,
+            nodes=[node],
+            report={"tests": [_body_failed(node, "gw0", "E   AssertionError: eh")]},
+            open_map={},
+            closed_map={f"Nightly regression: {node}": (11, "")},
+        )
+        assert filed == []
+        assert commented == [11]
+
+    def test_unreadable_closed_set_fails_open_and_files(self, monkeypatch, tmp_path: Path) -> None:
+        node = "tests/unit/test_x.py::test_y"
+        _, commented, filed = self._dispatch(
+            monkeypatch,
+            tmp_path,
+            nodes=[node],
+            report={"tests": [_body_failed(node, "gw0", "E   AssertionError: eh")]},
+            open_map={},
+            closed_map=None,
+        )
+        assert commented == []
+        assert filed == [[node]]
+
+    def test_open_issue_wins_over_closed_record(self, monkeypatch, tmp_path: Path) -> None:
+        """An open issue is the live tracker even when a closed twin also matches."""
+        node = "tests/unit/test_x.py::test_y"
+        title = f"Nightly regression: {node}"
+        _, commented, filed = self._dispatch(
+            monkeypatch,
+            tmp_path,
+            nodes=[node],
+            report={"tests": [_body_failed(node, "gw0", "E   AssertionError: eh")]},
+            open_map={title: 99},
+            closed_map={title: (11, "NOT_PLANNED")},
+        )
+        assert filed == []
+        assert commented == [99]
+
+    def test_closed_not_planned_cascade_comments_instead_of_refiling(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        msg = "RuntimeError: registry mismatch client=localhost:6379"
+        nodes = [f"tests/unit/test_m.py::test_{i}" for i in range(6)]
+        report = {"tests": [_errored(n, "gw2", msg) for n in nodes]}
+        normalized = nrt.setup_error_signature(report["tests"][0])[1]
+        outcome, commented, filed = self._dispatch(
+            monkeypatch,
+            tmp_path,
+            nodes=nodes,
+            report=report,
+            open_map={},
+            closed_map={nrt.cascade_title(normalized): (3131, "NOT_PLANNED")},
+        )
+        assert filed == []
+        assert commented == [3131]
+        assert outcome.recorded == sorted(nodes)
+        assert normalized not in outcome.cascade_issues
+
+    def test_environmental_nodes_are_excluded_and_reported(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        env_node = "tests/integration/test_net.py::test_fetch"
+        code_node = "tests/unit/test_logic.py::test_math"
+        report = {
+            "tests": [
+                _body_failed(env_node, "gw0", "E   httpx.ConnectError: Connection refused"),
+                _body_failed(code_node, "gw1", "E   AssertionError: 3 != 4"),
+            ]
+        }
+        outcome, commented, filed = self._dispatch(
+            monkeypatch,
+            tmp_path,
+            nodes=[env_node, code_node],
+            report=report,
+            open_map={},
+            closed_map={},
+        )
+        assert filed == [[code_node]]
+        assert outcome.environmental == [env_node]
+        assert env_node not in outcome.recorded
+
+    def test_body_group_files_one_umbrella_with_body_namespaced_state(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        line = "E   TypeError: AsyncAnthropic.__init__() got an unexpected keyword"
+        nodes = [f"tests/unit/test_llm_{i}.py::test_{i}" for i in range(6)]
+        report = {"tests": [_body_failed(n, "gw0", line) for n in nodes]}
+        normalized = nrt.body_failure_signature(report["tests"][0])
+        outcome, commented, filed = self._dispatch(
+            monkeypatch, tmp_path, nodes=nodes, report=report, open_map={}, closed_map={}
+        )
+        assert commented == []
+        assert len(filed) == 1
+        assert filed[0] == [f"cascade:{nrt.body_cascade_title(normalized)}"]
+        assert outcome.cascade_issues == {"body::" + normalized: None}
+        assert outcome.recorded == sorted(nodes)
+
+    def test_closed_issue_dispositions_parses_state_reason(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(nrt, "LOG_FILE", tmp_path / "nightly.log")
+        seen: dict[str, list[str]] = {}
+
+        class FakeResult:
+            returncode = 0
+            stdout = (
+                '[{"number": 5, "title": "Nightly regression: a::t1", '
+                '"stateReason": "NOT_PLANNED"},'
+                ' {"number": 6, "title": "Nightly regression: b::t2", "stateReason": null}]'
+            )
+            stderr = ""
+
+        def fake_run(argv, **kwargs):
+            seen["argv"] = argv
+            return FakeResult()
+
+        monkeypatch.setattr(nrt.subprocess, "run", fake_run)
+        assert nrt.closed_issue_dispositions() == {
+            "Nightly regression: a::t1": (5, "NOT_PLANNED"),
+            "Nightly regression: b::t2": (6, ""),
+        }
+        assert "--state" in seen["argv"] and "closed" in seen["argv"]
+        assert "--search" not in seen["argv"]
+
+    @pytest.mark.parametrize("failure", ["rc", "raise", "garbage"])
+    def test_closed_issue_dispositions_returns_none_on_any_failure(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, failure: str
+    ) -> None:
+        monkeypatch.setattr(nrt, "LOG_FILE", tmp_path / "nightly.log")
+
+        class FakeResult:
+            returncode = 1 if failure == "rc" else 0
+            stdout = "not json" if failure == "garbage" else "[]"
+            stderr = "boom"
+
+        def fake_run(argv, **kwargs):
+            if failure == "raise":
+                raise OSError("gh missing")
+            return FakeResult()
+
+        monkeypatch.setattr(nrt.subprocess, "run", fake_run)
+        assert nrt.closed_issue_dispositions() is None

--- a/tests/unit/test_nightly_regression_tests.py
+++ b/tests/unit/test_nightly_regression_tests.py
@@ -2479,3 +2479,187 @@ class TestClosedIssueDedup:
 
         monkeypatch.setattr(nrt.subprocess, "run", fake_run)
         assert nrt.closed_issue_dispositions() is None
+
+
+def _setup_failed(nodeid: str, worker: str, line: str) -> dict:
+    """A pytest-json-report entry shaped like a real SETUP-phase failure."""
+    return {
+        "nodeid": nodeid,
+        "outcome": "error",
+        "setup": {
+            "outcome": "failed",
+            "longrepr": f"[{worker}] darwin -- Python 3.14.3\n{line}",
+        },
+    }
+
+
+class TestReviewFindings3142:
+    """Regression pins for the #3142 review round (blocker + tech debt)."""
+
+    def _dispatch(self, monkeypatch, tmp_path, *, nodes, report, open_map, closed_map, prev=None):
+        monkeypatch.setattr(nrt, "LOG_FILE", tmp_path / "nightly.log")
+        monkeypatch.setattr(nrt, "open_issues", lambda: open_map)
+        monkeypatch.setattr(nrt, "closed_issue_dispositions", lambda: closed_map)
+        commented: list[int] = []
+        monkeypatch.setattr(
+            nrt, "comment_on_issue", lambda n, body, **kw: commented.append(n) or True
+        )
+        filed: list[list[str]] = []
+
+        def fake_dispatch(ns, **kw):
+            if not ns:
+                return None
+            filed.append(list(ns))
+            return "sess-1"
+
+        monkeypatch.setattr(nrt, "maybe_dispatch_triage_session", fake_dispatch)
+        outcome = nrt.dispatch_findings(
+            report, nodes, prev or {}, run_at="2026-09-05T03:00:00Z", head_commit="cafe1234"
+        )
+        return outcome, commented, filed
+
+    def test_duplicate_closed_titles_resolve_to_newest_closure(self, monkeypatch, tmp_path):
+        """The FIRST row per title (newest-created) wins, never the oldest.
+
+        The #3142 review blocker: last-write-wins over gh's newest-first
+        listing resolved six live nightly nodes to their oldest COMPLETED
+        closure, re-filing nodes whose newest closure was NOT_PLANNED.
+        """
+        monkeypatch.setattr(nrt, "LOG_FILE", tmp_path / "nightly.log")
+
+        class FakeResult:
+            returncode = 0
+            stdout = (
+                '[{"number": 3112, "title": "Nightly regression: a::t", '
+                '"stateReason": "NOT_PLANNED"},'
+                ' {"number": 2919, "title": "Nightly regression: a::t", '
+                '"stateReason": "COMPLETED"},'
+                ' {"number": 2917, "title": "Nightly regression: a::t", '
+                '"stateReason": "COMPLETED"}]'
+            )
+            stderr = ""
+
+        monkeypatch.setattr(nrt.subprocess, "run", lambda argv, **kw: FakeResult())
+        closed_map = nrt.closed_issue_dispositions()
+        assert closed_map == {"Nightly regression: a::t": (3112, "NOT_PLANNED")}
+        to_file, closed_matches = nrt.partition_closed_matches(["a::t"], closed_map)
+        assert to_file == []
+        assert closed_matches == [("a::t", 3112, "NOT_PLANNED")]
+
+    def test_saturated_closed_window_logs_a_warning(self, monkeypatch, tmp_path):
+        log_file = tmp_path / "nightly.log"
+        monkeypatch.setattr(nrt, "LOG_FILE", log_file)
+        monkeypatch.setattr(nrt, "CLOSED_ISSUE_LIST_LIMIT", 2)
+
+        class FakeResult:
+            returncode = 0
+            stdout = (
+                '[{"number": 2, "title": "t1", "stateReason": "COMPLETED"},'
+                ' {"number": 1, "title": "t2", "stateReason": "COMPLETED"}]'
+            )
+            stderr = ""
+
+        monkeypatch.setattr(nrt.subprocess, "run", lambda argv, **kw: FakeResult())
+        assert nrt.closed_issue_dispositions() is not None
+        assert "saturated" in log_file.read_text()
+
+    def test_assert_diff_embedding_network_string_is_not_environmental(self):
+        """A formatter regression comparing against 'Connection refused...' files."""
+        test = _body_failed(
+            "t.py::a",
+            "gw0",
+            "E   AssertionError: assert 'wrong output' == 'Connection refused by upstream'",
+        )
+        assert not nrt.is_environmental_failure(test)
+
+    def test_raised_connection_error_in_setup_is_environmental(self):
+        test = _setup_failed(
+            "t.py::a", "gw0", "E   ConnectionRefusedError: [Errno 61] Connection refused"
+        )
+        assert nrt.is_environmental_failure(test)
+
+    def test_environmental_setup_storm_files_nothing(self, monkeypatch, tmp_path):
+        """A >=3-node network setup storm is excluded BEFORE cascade grouping.
+
+        The #3142 formal-review blocker: grouped environmental setup errors
+        were collapsed into a cascade umbrella and filed as a code regression.
+        """
+        nodes = [f"t.py::storm{i}" for i in range(3)]
+        report = {
+            "tests": [
+                _setup_failed(n, "gw3", "E   ConnectionRefusedError: [Errno 61] Connection refused")
+                for n in nodes
+            ]
+        }
+        outcome, commented, filed = self._dispatch(
+            monkeypatch, tmp_path, nodes=nodes, report=report, open_map={}, closed_map={}
+        )
+        assert sorted(outcome.environmental) == sorted(nodes)
+        assert filed == []
+        assert commented == []
+        assert outcome.issues_filed == 0
+
+    def test_end_to_end_replay_dispatch_shapes(self, monkeypatch, tmp_path):
+        """One dispatch_findings call over a 16-node constructed report.
+
+        In-suite replay per issue #3075 AC 1: setup storm collapses to one
+        umbrella, five same-line body failures to another, environmental nodes
+        file nothing, an open issue and a NOT_PLANNED closure get comments,
+        and only a COMPLETED closure re-files.
+        """
+        storm = [f"t.py::fd{i}" for i in range(6)]
+        body = [f"t.py::typeerr{i}" for i in range(5)]
+        env = ["t.py::dns0", "t.py::dns1"]
+        node_open = "t.py::already_open"
+        node_np = "t.py::consolidated"
+        node_done = "t.py::fixed_regressed"
+        nodes = storm + body + env + [node_open, node_np, node_done]
+        assert len(nodes) == 16
+        report = {
+            "tests": [
+                *[
+                    _setup_failed(n, "gw2", "E   OSError: [Errno 24] Too many open files")
+                    for n in storm
+                ],
+                *[
+                    _body_failed(
+                        n,
+                        "gw1",
+                        "E   TypeError: run_typed() got an unexpected keyword 'temperature'",
+                    )
+                    for n in body
+                ],
+                *[
+                    _body_failed(n, "gw0", "E   socket.gaierror: [Errno 8] nodename nor servname")
+                    for n in env
+                ],
+                _body_failed(node_open, "gw0", "E   ValueError: open case"),
+                _body_failed(node_np, "gw0", "E   ValueError: consolidated case"),
+                _body_failed(node_done, "gw0", "E   ValueError: regressed case"),
+            ]
+        }
+        outcome, commented, filed = self._dispatch(
+            monkeypatch,
+            tmp_path,
+            nodes=nodes,
+            report=report,
+            open_map={f"Nightly regression: {node_open}": 500},
+            closed_map={
+                f"Nightly regression: {node_np}": (501, "NOT_PLANNED"),
+                f"Nightly regression: {node_done}": (502, "COMPLETED"),
+            },
+        )
+        assert sorted(outcome.environmental) == sorted(env)
+        cascade_dispatches = [f for f in filed if f[0].startswith("cascade:")]
+        assert len(cascade_dispatches) == 2
+        assert [node_done] in filed
+        assert len(filed) == 3
+        assert sorted(commented) == [500, 501]
+        assert outcome.issues_filed == 3
+        assert outcome.comments_posted == 2
+
+    def test_epilogue_is_single_sourced(self):
+        node_comment = nrt.closed_recurrence_comment(
+            "a::t", "NOT_PLANNED", run_at="R", head_commit="H"
+        )
+        assert nrt.closed_epilogue("NOT_PLANNED") in node_comment

--- a/tests/unit/test_nightly_regression_tests.py
+++ b/tests/unit/test_nightly_regression_tests.py
@@ -2519,7 +2519,7 @@ class TestReviewFindings3142:
         return outcome, commented, filed
 
     def test_duplicate_closed_titles_resolve_to_newest_closure(self, monkeypatch, tmp_path):
-        """The FIRST row per title (newest-created) wins, never the oldest.
+        """The row with the newest ``closedAt`` per title wins, never the oldest.
 
         The #3142 review blocker: last-write-wins over gh's newest-first
         listing resolved six live nightly nodes to their oldest COMPLETED
@@ -2531,11 +2531,11 @@ class TestReviewFindings3142:
             returncode = 0
             stdout = (
                 '[{"number": 3112, "title": "Nightly regression: a::t", '
-                '"stateReason": "NOT_PLANNED"},'
+                '"stateReason": "NOT_PLANNED", "closedAt": "2026-09-03T21:00:00Z"},'
                 ' {"number": 2919, "title": "Nightly regression: a::t", '
-                '"stateReason": "COMPLETED"},'
+                '"stateReason": "COMPLETED", "closedAt": "2026-08-25T10:00:00Z"},'
                 ' {"number": 2917, "title": "Nightly regression: a::t", '
-                '"stateReason": "COMPLETED"}]'
+                '"stateReason": "COMPLETED", "closedAt": "2026-08-24T10:00:00Z"}]'
             )
             stderr = ""
 
@@ -2546,10 +2546,41 @@ class TestReviewFindings3142:
         assert to_file == []
         assert closed_matches == [("a::t", 3112, "NOT_PLANNED")]
 
+    def test_wave_shape_newest_closure_wins_over_newest_created(self, monkeypatch, tmp_path):
+        """Creation order is not closure order: max ``closedAt`` decides.
+
+        The #3142 round-2 blocker, in the wave-dup shape #3161 keeps
+        generating: the later-created duplicate (#3061) was closed NOT_PLANNED
+        early, the original (#3057) was closed COMPLETED later. The newest
+        CLOSURE is COMPLETED, so the node must re-file (the one legitimate
+        re-file case). First-row-per-title keyed on creation order suppressed
+        it.
+        """
+        monkeypatch.setattr(nrt, "LOG_FILE", tmp_path / "nightly.log")
+
+        class FakeResult:
+            returncode = 0
+            stdout = (
+                '[{"number": 3061, "title": "Nightly regression: w::t", '
+                '"stateReason": "NOT_PLANNED", "closedAt": "2026-08-31T05:31:00Z"},'
+                ' {"number": 3059, "title": "Nightly regression: w::t", '
+                '"stateReason": "NOT_PLANNED", "closedAt": "2026-08-31T05:31:30Z"},'
+                ' {"number": 3057, "title": "Nightly regression: w::t", '
+                '"stateReason": "COMPLETED", "closedAt": "2026-08-31T09:20:00Z"}]'
+            )
+            stderr = ""
+
+        monkeypatch.setattr(nrt.subprocess, "run", lambda argv, **kw: FakeResult())
+        closed_map = nrt.closed_issue_dispositions()
+        assert closed_map == {"Nightly regression: w::t": (3057, "COMPLETED")}
+        to_file, closed_matches = nrt.partition_closed_matches(["w::t"], closed_map)
+        assert to_file == ["w::t"]
+        assert closed_matches == []
+
     def test_saturated_closed_window_logs_a_warning(self, monkeypatch, tmp_path):
+        """Saturation compares the caller's ``limit``, not the module constant."""
         log_file = tmp_path / "nightly.log"
         monkeypatch.setattr(nrt, "LOG_FILE", log_file)
-        monkeypatch.setattr(nrt, "CLOSED_ISSUE_LIST_LIMIT", 2)
 
         class FakeResult:
             returncode = 0
@@ -2560,7 +2591,7 @@ class TestReviewFindings3142:
             stderr = ""
 
         monkeypatch.setattr(nrt.subprocess, "run", lambda argv, **kw: FakeResult())
-        assert nrt.closed_issue_dispositions() is not None
+        assert nrt.closed_issue_dispositions(limit=2) is not None
         assert "saturated" in log_file.read_text()
 
     def test_assert_diff_embedding_network_string_is_not_environmental(self):
@@ -2577,6 +2608,26 @@ class TestReviewFindings3142:
             "t.py::a", "gw0", "E   ConnectionRefusedError: [Errno 61] Connection refused"
         )
         assert nrt.is_environmental_failure(test)
+
+    def test_call_assertion_with_teardown_network_flake_is_not_environmental(self):
+        """A code-level failure in ANY phase disqualifies the node (#3142 r2 nit).
+
+        Under any-phase classification, a teardown network flake suppressed a
+        genuine call-phase assertion regression. Every failing phase must look
+        network-shaped for the node to classify environmental.
+        """
+        test = _body_failed(
+            "t.py::mixed",
+            "gw0",
+            "E   AssertionError: assert 'wrong output' == 'expected output'",
+        )
+        test["teardown"] = {
+            "outcome": "failed",
+            "longrepr": (
+                "[gw0] darwin\nE   ConnectionResetError: [Errno 54] Connection reset by peer"
+            ),
+        }
+        assert not nrt.is_environmental_failure(test)
 
     def test_environmental_setup_storm_files_nothing(self, monkeypatch, tmp_path):
         """A >=3-node network setup storm is excluded BEFORE cascade grouping.


### PR DESCRIPTION
Closes #3075

Builds directly on `8524e765b`'s machinery (storm ceiling, setup-cascade collapsing, open-issue dedup), per the 2026-09-04 triage boundary comment. No parallel mechanism was added; the three remaining defects each extend an existing seam.

## What changed

**1. Closed-issue-aware dedup (defect 1, the big one).** `closed_issue_dispositions()` reads the closed issue set (`gh issue list --state closed`, REST path, same fail-open posture as `open_issues()`), keyed on `stateReason`:

- `NOT_PLANNED` (duplicate/consolidated/won't-fix): recurrence comment on the closed issue, never a re-file. Applies to per-node findings (`partition_closed_matches`) and cascade umbrellas alike.
- `COMPLETED` (fixed): stays fileable — a node failing again after its fix is genuinely new information, the one legitimate re-file case.
- Unknown/empty reason: comment, since a comment preserves the recurrence signal at zero tracker cost.

Both triage prompts (`_build_triage_prompt`, `_build_cascade_prompt`) now state the same open/closed rule, so the deterministic pre-flight and the agent instruction cannot drift.

**2. Body-failure collapsing (the 39-for-2 case).** `group_body_failure_cascades()` groups nodes whose test bodies fail with an identical normalized first error line into one umbrella, reusing the cascade filing path under a distinct title namespace (`body_cascade_title`) and persistence key (`body::` prefix). Grouping rule is exact equality of the normalized line, message-keyed across workers (a broken shared dependency fails callers on every worker), threshold `NIGHTLY_BODY_CASCADE_MIN_GROUP_SIZE` (default 5, higher than setup's 3). **False-merge risk, acknowledged per the issue:** two distinct defects sharing a byte-identical normalized line will merge; accepted as the smaller harm than 39 issues, and the 2026-08-24 second cause (worker-key assertions) has a different first line and provably stays separate (test: `test_second_cause_with_different_line_stays_separate`).

**3. Environmental classification (defect 3, from #2932).** `is_environmental_failure()` matches network-layer markers (DNS/gaierror, TLS/SSL, connection refused/reset, connect errors) across all phases. Environmental nodes are logged, excluded from filing, and deliberately never recorded as dispatched, so they re-evaluate nightly and file normally the moment the failure stops looking environmental. Bare `TimeoutError` is deliberately NOT environmental — unit-test timeouts are routinely real regressions (pinned by `test_bare_timeout_is_deliberately_not_environmental`).

## Replay evidence (constructed 2026-08-24 shape)

16 failing nodes: 10 sharing one TypeError line, 3 worker-key assertions, 1 node with a NOT_PLANNED closed issue, 1 with a COMPLETED closed issue, 1 environmental.

- **Fix active:** 5 dispatches instead of 16 per-node issues — 1 TypeError umbrella, 3 worker-key singles (below body threshold, correctly separate), 1 legitimate COMPLETED re-file. NOT_PLANNED node got a comment on its closed issue (#2971 in the replay) and was not re-filed. Environmental node filed nothing.
- **Mutation (closed state made invisible, the pre-fix world):** the NOT_PLANNED node re-files — the exact churn defect 1 describes — proving the closed check is load-bearing, not decorative.

## Tests

`tests/unit/test_nightly_regression_tests.py`: 167 existing kept green, 22 added (`TestBodyFailureGrouping`, `TestEnvironmentalClassification`, `TestClosedIssueDedup` — including the acceptance criteria's named regression test: a node whose only issue is CLOSED produces no new issue). The `main()`-driven persistence harnesses were also made hermetic (both issue reads stubbed; they previously relied on ambient `gh` behavior). Full file: 189 passed. Ruff check and format clean.

## Coordination and scope notes

- **#2334**: CLOSED since the issue's recon; the `_build_triage_prompt` collision constraint is moot. This lane owns `scripts/nightly_regression_tests.py` + its test file only.
- **Re-baseline umbrella idempotency** (acceptance criterion 5): already satisfied on main before this lane — the seed title embeds head commit and population, the prompt is search-before-file on that exact title, and a failed seed dispatch refuses to save state.
- **Follow-notes, deliberately not in this PR** (judgment-heavy or separately owned, per the dispatch directive):
  - The three-filing-waves root cause (one session filing at 20:35/20:40/20:46) is a session-lifecycle question, not a filing-contract one; the deterministic pre-flight here bounds its blast radius (re-runs now hit the dedup) but the nudge/retry mechanism itself was not investigated. **Now tracked: #3161.**
  - The 13 stale `session/nightly-triage-*` branches and 14 stale worktrees: operator cleanup plus `scripts/worktree-gc.sh` coverage check, machine-state work outside this file's scope. **Now tracked: #3162.**
  - `docs/features/nightly-alert-triage.md` filing-contract update rides the supervisor's docs cascade, per lane convention.



## Post-review patch (2026-09-05)

All findings from the review round addressed in one commit: newest-closure-wins duplicate-title resolution (blocker, mutation-verified), environmental exclusion moved ahead of cascade grouping (formal-review blocker, mutation-verified), environmental matching re-anchored on each phase's normalized first error line with assertion failures excluded, window comment corrected plus a saturation warning, seed prompt now states the open-AND-closed rule, shared closed_epilogue() helper, environmental count surfaced in the run summary, and an in-suite 16-node end-to-end replay test (AC 1). Suite: 196 passed. Follow-ups #3161 and #3162 filed per AC 6/7.

## Post-review patch (round 2, 2026-09-05, c19057aaf)

The round-2 blocker is fixed by resolving each closed title on max `closedAt` (creation order diverges from closure order in the #3161 wave-dup shape; the diverging-order regression test is mutation-verified). Environmental classification now requires every failing phase to look network-shaped, so a teardown flake cannot silence a call-phase assertion regression. Saturation compares the caller's limit and logs at INFO as the steady-state condition it currently is. The environmental persistence-escalation gap and closed-window scoping are tracked in #3163, referenced from the code. 198 tests green, ruff clean.