### PR TITLE
Test processes never attach the production bridge.log handler

### DIFF
--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -596,28 +596,41 @@ logging.basicConfig(
 # bridge.*, tools.*, etc.) inherit it automatically. Without this, only
 # the bridge.telegram_bridge module logger would write to bridge.log.
 root_logger = logging.getLogger()
-file_handler = logging.handlers.RotatingFileHandler(
-    LOG_DIR / "bridge.log",
-    maxBytes=10 * 1024 * 1024,  # 10MB per file
-    backupCount=5,
-)
-file_handler.setLevel(logging.DEBUG)
-# Use JSON formatter for structured logging (parseable by log aggregation tools)
-# Falls back to plain text if the module can't be imported
-try:
-    from bridge.log_format import StructuredJsonFormatter
+# Never build or attach the production file handler inside a pytest process
+# (#2854). This module-scope setup runs on import, so any test importing this
+# module (directly or transitively) was routing every logger's records into
+# logs/bridge.log, including test fixtures' deliberate failure-branch ERRORs,
+# which then read as daily production failures. "pytest" is in sys.modules
+# during collection and test phases alike; a bridge subprocess spawned BY a
+# test imports this module without pytest loaded and still attaches, which is
+# the intended production behavior. PYTEST_CURRENT_TEST covers a spawned
+# child that inherits the env but re-imports lazily mid-test. Constructing
+# the handler is also skipped so a test run never even creates the file.
+_UNDER_PYTEST = "pytest" in sys.modules or "PYTEST_CURRENT_TEST" in os.environ
+if not _UNDER_PYTEST:
+    file_handler = logging.handlers.RotatingFileHandler(
+        LOG_DIR / "bridge.log",
+        maxBytes=10 * 1024 * 1024,  # 10MB per file
+        backupCount=5,
+    )
+    file_handler.setLevel(logging.DEBUG)
+    # Use JSON formatter for structured logging (parseable by log aggregation
+    # tools); falls back to plain text if the module can't be imported
+    try:
+        from bridge.log_format import StructuredJsonFormatter
 
-    file_handler.setFormatter(StructuredJsonFormatter())
-except ImportError:
-    file_handler.setFormatter(logging.Formatter(FILE_FORMAT))
-file_handler.addFilter(InternalDebugFilter())
-# Guard against double-import adding the handler twice (e.g. __main__ + bridge.telegram_bridge)
-if not any(
-    isinstance(h, logging.handlers.RotatingFileHandler)
-    and getattr(h, "baseFilename", None) == str(LOG_DIR / "bridge.log")
-    for h in root_logger.handlers
-):
-    root_logger.addHandler(file_handler)
+        file_handler.setFormatter(StructuredJsonFormatter())
+    except ImportError:
+        file_handler.setFormatter(logging.Formatter(FILE_FORMAT))
+    file_handler.addFilter(InternalDebugFilter())
+    # Guard against double-import adding the handler twice
+    # (e.g. __main__ + bridge.telegram_bridge)
+    if not any(
+        isinstance(h, logging.handlers.RotatingFileHandler)
+        and getattr(h, "baseFilename", None) == str(LOG_DIR / "bridge.log")
+        for h in root_logger.handlers
+    ):
+        root_logger.addHandler(file_handler)
 
 # Module logger for this file. It inherits the root logger's file handler,
 # so we only need to set its level to DEBUG for verbose local output.

--- a/bridge/telegram_bridge.py
+++ b/bridge/telegram_bridge.py
@@ -601,11 +601,14 @@ root_logger = logging.getLogger()
 # module (directly or transitively) was routing every logger's records into
 # logs/bridge.log, including test fixtures' deliberate failure-branch ERRORs,
 # which then read as daily production failures. "pytest" is in sys.modules
-# during collection and test phases alike; a bridge subprocess spawned BY a
-# test imports this module without pytest loaded and still attaches, which is
-# the intended production behavior. PYTEST_CURRENT_TEST covers a spawned
-# child that inherits the env but re-imports lazily mid-test. Constructing
-# the handler is also skipped so a test run never even creates the file.
+# during collection and test phases alike; PYTEST_CURRENT_TEST is exported by
+# pytest into the process environment, so a bridge subprocess spawned BY a
+# test inherits it and also skips the handler (a test-spawned bridge should
+# not write the operator's production log). Only a process started outside
+# any pytest run — neither "pytest" in sys.modules nor PYTEST_CURRENT_TEST in
+# its environment — attaches it, which is the intended production behavior.
+# Constructing the handler is also skipped so a test run never even creates
+# the file.
 _UNDER_PYTEST = "pytest" in sys.modules or "PYTEST_CURRENT_TEST" in os.environ
 if not _UNDER_PYTEST:
     file_handler = logging.handlers.RotatingFileHandler(

--- a/docs/features/watchdog-log-isolation.md
+++ b/docs/features/watchdog-log-isolation.md
@@ -133,3 +133,42 @@ No behavioral change was made to recovery, escalation, health-check, or
 rotation logic — `LOG_MAX_SIZE`, `LOG_MAX_BACKUPS`, `LOG_BACKUP_HARD_CAP`, and
 `SELF_EXCLUDED_FILES` in `scripts/log_rotate.py` are untouched, and rotation
 settings (`maxBytes`/`backupCount`) are unchanged on both watchdogs.
+
+## A second instance of this bug class, solved a different way (#2854)
+
+`bridge/telegram_bridge.py` attaches its own `RotatingFileHandler` for
+`logs/bridge.log` to the root logger at **module scope** — exactly the
+pattern this doc's invariant forbids. It was not moved behind an
+`if __name__ == "__main__":` guard like the three modules above. The reason
+is `telegram_bridge.py`'s doc-comment: it keeps backward-compatible
+re-exports so `agent_catchup`, `telegram_relay`, `email_bridge`,
+`answer_routing`, and `routing` can all `import bridge.telegram_bridge` and
+use its symbols without ever running the module as `__main__` — there is no
+single entry point where "configure logging now" can live the way there is
+for a watchdog script.
+
+The sanctioned alternative for this shape is a **pytest-presence guard**
+rather than an entry-point relocation:
+
+```python
+_UNDER_PYTEST = "pytest" in sys.modules or "PYTEST_CURRENT_TEST" in os.environ
+if not _UNDER_PYTEST:
+    file_handler = logging.handlers.RotatingFileHandler(...)
+    ...
+```
+
+`"pytest" in sys.modules` catches the direct case: any pytest process that
+imports the module, at collection or test time. `PYTEST_CURRENT_TEST` is
+exported into the process environment by pytest for the duration of each
+test and is inherited by any subprocess a test spawns, so a bridge process
+started *by* a test also skips the handler — the desired behavior, since a
+test-spawned bridge should not write the operator's production log. Only a
+process started outside any pytest run (neither condition true) attaches it.
+The regression guard is `tests/unit/test_no_production_log_handlers.py`,
+paired with a companion subprocess probe (mirroring this file's `_run_probe`
+pattern) that pins the production side stays attached when neither
+condition holds.
+
+Use the entry-point-guard pattern from the rest of this doc when a module
+has one true entry point; use the `_UNDER_PYTEST` pattern when a module is
+imported for its symbols from many call sites with no single `__main__`.

--- a/tests/unit/test_no_production_log_handlers.py
+++ b/tests/unit/test_no_production_log_handlers.py
@@ -20,9 +20,11 @@ condition were inverted. ``test_production_process_still_attaches_the_handler``
 below is the companion probe (precedent:
 ``tests/unit/test_watchdog_log_isolation.py::_run_probe``) that runs the
 same import in a subprocess with ``PYTEST_CURRENT_TEST`` stripped and
-``pytest`` never imported, asserting the ``RotatingFileHandler`` for
-``logs/bridge.log`` IS attached to the root logger — pinning that production
-behavior is unchanged.
+``pytest`` never imported, asserting a ``RotatingFileHandler`` requesting
+exactly ``logs/bridge.log`` IS attached to the root logger — pinning that
+production behavior is unchanged. The probe redirects the handler's actual
+file into a tmp directory, so it never reads, writes, rotates, or restores
+the real production log.
 """
 
 from __future__ import annotations
@@ -31,6 +33,7 @@ import json
 import logging
 import os
 import pathlib
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -75,50 +78,82 @@ def test_production_process_still_attaches_the_handler():
     "pytest" is not in ``sys.modules``) with ``PYTEST_CURRENT_TEST`` scrubbed
     from the environment, mirroring
     ``tests/unit/test_watchdog_log_isolation.py::_run_probe``.
+
+    The probe must never touch the REAL ``logs/bridge.log``: a live bridge
+    (or a nightly run in the serving checkout) writes it concurrently, and a
+    snapshot/restore around the subprocess was proven to destroy those
+    concurrent writes. So BEFORE the import, the probe patches
+    ``RotatingFileHandler.__init__`` to record the requested filename and
+    redirect the actual open into a private tmp directory. The assertion is
+    on the recorded request — exact-path equality with
+    ``REPO_ROOT/logs/bridge.log`` — while the bytes land in the tmp file.
     """
     probe = f"""
-import json, logging, logging.handlers, sys
+import json, logging, logging.handlers, pathlib, sys, tempfile
 sys.path.insert(0, {str(REPO_ROOT)!r})
+
+requested = []
+tmp_dir = tempfile.mkdtemp(prefix="probe-bridge-log-")
+_real_init = logging.handlers.RotatingFileHandler.__init__
+
+def _redirecting_init(self, filename, *args, **kwargs):
+    requested.append(str(filename))
+    redirected = pathlib.Path(tmp_dir) / pathlib.Path(filename).name
+    _real_init(self, str(redirected), *args, **kwargs)
+
+# Patch the class __init__ (not a name binding), so every construction form
+# — logging.handlers.RotatingFileHandler(...) included — is redirected.
+logging.handlers.RotatingFileHandler.__init__ = _redirecting_init
+
 import bridge.telegram_bridge as m
 assert m.__file__.startswith({str(REPO_ROOT)!r}), m.__file__
 root = logging.getLogger()
-has_bridge_log_handler = any(
-    isinstance(h, logging.handlers.RotatingFileHandler)
-    and "bridge.log" in getattr(h, "baseFilename", "")
-    for h in root.handlers
-)
-print(json.dumps({{"has_bridge_log_handler": has_bridge_log_handler}}))
+attached = [
+    h for h in root.handlers
+    if isinstance(h, logging.handlers.RotatingFileHandler)
+]
+print(json.dumps({{
+    "has_bridge_log_handler": bool(attached),
+    "requested_paths": requested,
+    "actual_paths": [getattr(h, "baseFilename", "") for h in attached],
+    "tmp_dir": tmp_dir,
+}}))
 """
     env = {**os.environ, "PYTHONPATH": str(REPO_ROOT)}
     env.pop("PYTEST_CURRENT_TEST", None)
 
-    # The probe deliberately emulates a real (non-pytest) process, so
-    # bridge.telegram_bridge's module-scope import-time logging (e.g. the
-    # routing-map INFO lines) genuinely writes to the real logs/bridge.log —
-    # that IS the production behavior under test. Snapshot/restore the file
-    # around the subprocess so this probe does not itself leave test-run
-    # artifacts in the operator's production log (the exact class of
-    # pollution #2854 is about).
-    bridge_log = REPO_ROOT / "logs" / "bridge.log"
-    prior_bytes = bridge_log.read_bytes() if bridge_log.exists() else None
-    try:
-        result = subprocess.run(
-            [sys.executable, "-c", probe],
-            cwd=REPO_ROOT,
-            env=env,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-    finally:
-        if prior_bytes is None:
-            bridge_log.unlink(missing_ok=True)
-        else:
-            bridge_log.write_bytes(prior_bytes)
+    # timeout: this module has an import-time hang precedent (TCC/iCloud
+    # open() deadlock in _get_active_projects, fixed in 261ebbd77). A wedged
+    # probe should fail this test with output, not ride the 420s suite cap.
+    # 180s, not 60: under a pytest-inherited environment the probe import
+    # measures ~65s on a worker-only host (blocks ~60s, then completes), so
+    # a 60s bound fails a healthy probe. Measured 2026-09-05.
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=180,
+    )
 
     assert result.returncode == 0, result.stderr
     state = json.loads(result.stdout.strip().splitlines()[-1])
+
+    # Best-effort cleanup of the probe subprocess's redirect directory.
+    shutil.rmtree(state.get("tmp_dir", ""), ignore_errors=True)
+
     assert state["has_bridge_log_handler"] is True, (
         "Production process no longer attaches the logs/bridge.log handler "
         f"— production logging regressed: {state}"
+    )
+    expected = str(REPO_ROOT / "logs" / "bridge.log")
+    assert state["requested_paths"] == [expected], (
+        "Production process requested an unexpected log path "
+        f"(want exactly [{expected!r}]): {state}"
+    )
+    # The redirect held: nothing the probe attached points at the real log.
+    assert all(expected not in p for p in state["actual_paths"]), (
+        f"Probe redirect failed — real production log was opened: {state}"
     )

--- a/tests/unit/test_no_production_log_handlers.py
+++ b/tests/unit/test_no_production_log_handlers.py
@@ -1,0 +1,47 @@
+"""Regression guard for #2854: pytest processes never write production logs.
+
+``bridge/telegram_bridge.py`` attaches a RotatingFileHandler for
+``logs/bridge.log`` to the ROOT logger at module import time, so a single
+test importing it (directly or transitively) used to route every logger's
+records — including test fixtures' deliberate failure-branch ERRORs — into
+the production log file, where they read as daily production failures.
+
+The guard here deterministically imports the known attacher first, so it
+pins the real mechanism regardless of xdist scheduling, then asserts no
+handler on the root or ``bridge`` loggers targets a file under any
+``logs/`` directory. It cannot see attachers that run only in OTHER
+workers or later in this worker's schedule; it exists to keep the
+import-time attach in ``telegram_bridge`` (the one observed leaking) from
+regressing.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+
+def _log_file_handlers(logger: logging.Logger) -> list[str]:
+    return [
+        h.baseFilename
+        for h in logger.handlers
+        if isinstance(h, logging.FileHandler)
+        and "logs" in Path(getattr(h, "baseFilename", "")).parts
+    ]
+
+
+def test_pytest_process_attaches_no_production_log_file_handler():
+    # Import the known import-time attacher so this process has definitely
+    # executed the guarded attach path before we assert.
+    import bridge.telegram_bridge  # noqa: F401
+
+    offenders: dict[str, list[str]] = {}
+    for name in ("", "bridge", "bridge.room_inbox", "bridge.telegram_bridge"):
+        found = _log_file_handlers(logging.getLogger(name))
+        if found:
+            offenders[name or "<root>"] = found
+
+    assert not offenders, (
+        "Production log-file handler active under pytest — test-fixture "
+        f"ERROR lines will masquerade as production failures (#2854): {offenders}"
+    )

--- a/tests/unit/test_no_production_log_handlers.py
+++ b/tests/unit/test_no_production_log_handlers.py
@@ -13,12 +13,29 @@ handler on the root or ``bridge`` loggers targets a file under any
 workers or later in this worker's schedule; it exists to keep the
 import-time attach in ``telegram_bridge`` (the one observed leaking) from
 regressing.
+
+The absence assertion above is only half the guard: it would stay green if
+the production handler were deleted outright or the ``_UNDER_PYTEST``
+condition were inverted. ``test_production_process_still_attaches_the_handler``
+below is the companion probe (precedent:
+``tests/unit/test_watchdog_log_isolation.py::_run_probe``) that runs the
+same import in a subprocess with ``PYTEST_CURRENT_TEST`` stripped and
+``pytest`` never imported, asserting the ``RotatingFileHandler`` for
+``logs/bridge.log`` IS attached to the root logger — pinning that production
+behavior is unchanged.
 """
 
 from __future__ import annotations
 
+import json
 import logging
+import os
+import pathlib
+import subprocess
+import sys
 from pathlib import Path
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 
 
 def _log_file_handlers(logger: logging.Logger) -> list[str]:
@@ -44,4 +61,64 @@ def test_pytest_process_attaches_no_production_log_file_handler():
     assert not offenders, (
         "Production log-file handler active under pytest — test-fixture "
         f"ERROR lines will masquerade as production failures (#2854): {offenders}"
+    )
+
+
+def test_production_process_still_attaches_the_handler():
+    """Companion to the absence guard above: pin that a non-pytest process
+    still gets the production ``logs/bridge.log`` handler.
+
+    Without this, deleting the production handler entirely — or inverting
+    ``_UNDER_PYTEST`` in ``bridge/telegram_bridge.py`` — would leave the
+    absence-only guard green while silently killing all production log
+    output. Runs the import in a fresh subprocess (never touched pytest, so
+    "pytest" is not in ``sys.modules``) with ``PYTEST_CURRENT_TEST`` scrubbed
+    from the environment, mirroring
+    ``tests/unit/test_watchdog_log_isolation.py::_run_probe``.
+    """
+    probe = f"""
+import json, logging, logging.handlers, sys
+sys.path.insert(0, {str(REPO_ROOT)!r})
+import bridge.telegram_bridge as m
+assert m.__file__.startswith({str(REPO_ROOT)!r}), m.__file__
+root = logging.getLogger()
+has_bridge_log_handler = any(
+    isinstance(h, logging.handlers.RotatingFileHandler)
+    and "bridge.log" in getattr(h, "baseFilename", "")
+    for h in root.handlers
+)
+print(json.dumps({{"has_bridge_log_handler": has_bridge_log_handler}}))
+"""
+    env = {**os.environ, "PYTHONPATH": str(REPO_ROOT)}
+    env.pop("PYTEST_CURRENT_TEST", None)
+
+    # The probe deliberately emulates a real (non-pytest) process, so
+    # bridge.telegram_bridge's module-scope import-time logging (e.g. the
+    # routing-map INFO lines) genuinely writes to the real logs/bridge.log —
+    # that IS the production behavior under test. Snapshot/restore the file
+    # around the subprocess so this probe does not itself leave test-run
+    # artifacts in the operator's production log (the exact class of
+    # pollution #2854 is about).
+    bridge_log = REPO_ROOT / "logs" / "bridge.log"
+    prior_bytes = bridge_log.read_bytes() if bridge_log.exists() else None
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", probe],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    finally:
+        if prior_bytes is None:
+            bridge_log.unlink(missing_ok=True)
+        else:
+            bridge_log.write_bytes(prior_bytes)
+
+    assert result.returncode == 0, result.stderr
+    state = json.loads(result.stdout.strip().splitlines()[-1])
+    assert state["has_bridge_log_handler"] is True, (
+        "Production process no longer attaches the logs/bridge.log handler "
+        f"— production logging regressed: {state}"
     )


### PR DESCRIPTION
Closes #2854

## Root cause (acceptance criterion 1)

Neither the nightly runner nor conftest: the attach happens at **module import time** in `bridge/telegram_bridge.py`. It adds a `RotatingFileHandler` for `<checkout>/logs/bridge.log` to the **root** logger as an import side effect, so the first test in any pytest worker that imports the module (directly or transitively; many unit test files do) poisons that worker for the rest of its schedule. From then on every logger's records propagate to the production log, which is why `tests/unit/test_room_inbox_shadow.py`'s deliberate failure-branch fixtures (`chat=1 msg=1`, `redis down`) appeared in `logs/bridge.log` nightly. Reproduced deterministically: importing the module and logging one ERROR through `bridge.room_inbox` wrote the exact issue signature to the file.

`config/settings.py::setup_logging` also builds a file handler but only runs via an explicit `validate_configuration()` call, not at import; it was not the leak path.

## Fix (criterion 2: isolation at the source, not per-test suppression)

Under pytest (`"pytest" in sys.modules or "PYTEST_CURRENT_TEST" in os.environ`) the file handler is neither constructed nor attached, so a test run never creates or writes the file. `PYTEST_CURRENT_TEST` is exported into the process environment by pytest and inherited by any subprocess a test spawns, so a bridge subprocess spawned BY a test also skips the handler; only a process started outside any pytest run attaches it, which is the intended production behavior. Verified directly: with the env scrubbed, root handlers include the bridge.log path; with `PYTEST_CURRENT_TEST` set, they do not.

## Regression guard (criterion 3)

`tests/unit/test_no_production_log_handlers.py` imports the known attacher first (deterministic regardless of xdist scheduling), then asserts no handler on the root or bridge loggers targets a file under `logs/`.

## Evidence (criterion 4)

| Configuration | Guard test | logs/bridge.log |
|---|---|---|
| Fix active | passes | never created |
| Guard neutralized (`_UNDER_PYTEST = False`) | FAILS | gains 3 `chat=1 msg=1` fixture lines |
| Production probe (no pytest in modules) | n/a | handler attached, path correct |

Sanity slice (guard + shadow + bridge logic + log rotate + media timeout): 82 passed. Ruff check and format clean.
