### PR TITLE
Unmask the fixture save-stub TypeError and close out the #2949 constructor-kwarg audit

### DIFF
--- a/tests/unit/test_agent_session.py
+++ b/tests/unit/test_agent_session.py
@@ -4,6 +4,7 @@ Tests for create_local() behavior, including the chat_id defaulting logic,
 and worker_key property behavior.
 """
 
+import logging
 import uuid
 from unittest.mock import MagicMock, patch
 
@@ -34,7 +35,7 @@ class TestCreateLocalChatId:
         saved_sessions = []
         original_save = AgentSession.save
 
-        def mock_save(self):
+        def mock_save(self, *args, **kwargs):
             saved_sessions.append(self)
 
         AgentSession.save = mock_save
@@ -59,7 +60,7 @@ class TestCreateLocalChatId:
 
         original_save = AgentSession.save
 
-        def mock_save(self):
+        def mock_save(self, *args, **kwargs):
             saved_sessions.append(self)
 
         AgentSession.save = mock_save
@@ -85,7 +86,7 @@ class TestCreateLocalChatId:
         session_uuid = "claude-session-xyz789"
         original_save = AgentSession.save
 
-        def mock_save(self):
+        def mock_save(self, *args, **kwargs):
             pass
 
         AgentSession.save = mock_save
@@ -117,7 +118,7 @@ class TestCreateLocalChatId:
 
         original_save = AgentSession.save
 
-        def mock_save(self):
+        def mock_save(self, *args, **kwargs):
             pass
 
         AgentSession.save = mock_save
@@ -151,7 +152,11 @@ def _make_session(current_stage: str | None = None, **kwargs):
     import json
 
     original_save = AgentSession.save
-    AgentSession.save = lambda self: None
+    # #3074: the stub must accept save()'s real signature. A bare `lambda self:
+    # None` made append_event's `self.save(update_fields=[...])` raise TypeError
+    # on every stage-setting construction — swallowed by append_event's handler,
+    # so tests stayed green while every construction logged a masked failure.
+    AgentSession.save = lambda self, *args, **kwargs: None
     try:
         defaults = {
             "project_key": "test-project",
@@ -189,6 +194,45 @@ def _make_session(current_stage: str | None = None, **kwargs):
         return session
     finally:
         AgentSession.save = original_save
+
+
+class TestFixtureSaveStubFidelity:
+    """#3074: save stubs must match AgentSession.save's real signature.
+
+    A stub of ``lambda self: None`` made append_event's internal
+    ``self.save(update_fields=[...])`` raise TypeError on every stage-setting
+    construction. append_event catches and logs that failure, so the suite
+    stayed green while every fixture construction emitted a masked exception.
+    """
+
+    def test_fixture_construction_emits_no_masked_save_failure(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="models.agent_session"):
+            _make_session(current_stage="BUILD")
+        masked = [r for r in caplog.records if "append_event save failed" in r.getMessage()]
+        assert not masked, (
+            "fixture construction logged a masked append_event save failure — "
+            "the save stub's signature drifted from AgentSession.save again: "
+            f"{masked[0].getMessage()}"
+        )
+
+    def test_unknown_constructor_kwarg_is_tolerated_and_unpersisted(self):
+        """Pins popoto's current tolerance while the #3074 decision stays open.
+
+        Popoto's ``Model.__init__`` does ``self.__dict__.update(kwargs)``, so an
+        unknown kwarg lands as a plain instance attribute, is never a declared
+        Field, and is never persisted (encoding iterates ``_meta.fields`` only).
+        If this test starts failing because construction raises, the ORM went
+        strict upstream: delete this pin and record the #3074 rejection decision
+        as settled.
+        """
+        import popoto
+
+        s = _make_session(definitely_not_a_field_xyz="boom")
+        assert s.definitely_not_a_field_xyz == "boom"
+        assert not isinstance(
+            vars(type(s)).get("definitely_not_a_field_xyz"),
+            popoto.fields.field.Field,
+        )
 
 
 class TestWorkerKeyProperty:

--- a/tests/unit/test_agent_session_liveness_fields.py
+++ b/tests/unit/test_agent_session_liveness_fields.py
@@ -27,7 +27,6 @@ def _make_session(suffix: str) -> AgentSession:
         session_type=SessionType.ENG,
         message_text="x",
         sender_name="x",
-        agent_session_id=f"liveness-fields-{suffix}",
     )
 
 

--- a/tests/unit/test_agent_session_thread_rollup_fields.py
+++ b/tests/unit/test_agent_session_thread_rollup_fields.py
@@ -34,7 +34,6 @@ def _make_session(suffix: str) -> AgentSession:
         session_type=SessionType.ENG,
         message_text="x",
         sender_name="x",
-        agent_session_id=f"thread-rollup-fields-{suffix}",
     )
 
 

--- a/tests/unit/test_harness_oom_backoff.py
+++ b/tests/unit/test_harness_oom_backoff.py
@@ -50,7 +50,6 @@ def test_exit_returncode_field_defaults_to_zero():
         session_type=SessionType.ENG,
         message_text="x",
         sender_name="x",
-        agent_session_id="x-default-test",
     )
     try:
         assert s.exit_returncode == 0
@@ -139,7 +138,6 @@ def test_pending_scan_skips_deferred(clean_sessions):
         session_type=SessionType.ENG,
         message_text="x",
         sender_name="x",
-        agent_session_id="sid-defer-future",
         status="pending",
     )
     deferred.scheduled_at = future
@@ -152,7 +150,6 @@ def test_pending_scan_skips_deferred(clean_sessions):
         session_type=SessionType.ENG,
         message_text="x",
         sender_name="x",
-        agent_session_id="sid-eligible",
         status="pending",
     )
     not_deferred.scheduled_at = None
@@ -221,7 +218,6 @@ def test_store_exit_returncode_persists_value(clean_sessions, monkeypatch):
         session_type=SessionType.ENG,
         message_text="x",
         sender_name="x",
-        agent_session_id="sid-exit-rc",
         session_id="session-id-exit-rc",
     )
     s.save()

--- a/tests/unit/test_session_health_compacting_reprieve.py
+++ b/tests/unit/test_session_health_compacting_reprieve.py
@@ -41,7 +41,6 @@ def _make_session(project_key: str, last_compaction_ts: float | None) -> AgentSe
         session_type=SessionType.ENG,
         message_text="seed",
         sender_name="tester",
-        agent_session_id=f"sid-{int(time.time() * 1000)}",
     )
     s.last_compaction_ts = last_compaction_ts
     s.save()

--- a/tests/unit/test_session_token_accumulator.py
+++ b/tests/unit/test_session_token_accumulator.py
@@ -35,7 +35,6 @@ def test_session():
     s = AgentSession(
         session_id=sid,
         project_key="tst-accum",
-        agent_session_id=f"as-{sid}",
         status="running",
     )
     s.save()


### PR DESCRIPTION
Closes #3074.

Work Item 2 residue from #3001, per the issue's own scope correction: the fixture migration (56e80d843) is untouched; this PR delivers the three residue items.

## 1. The masked TypeError is unmasked and pinned

`_make_session`'s stub was `lambda self: None`, but `append_event` calls `self.save(update_fields=[...])` — every stage-setting construction raised a TypeError that `append_event` caught and logged. All five save stubs in `tests/unit/test_agent_session.py` (four `mock_save` defs plus the fixture lambda) now accept `save`'s real shape (`self, *args, **kwargs`).

New `TestFixtureSaveStubFidelity::test_fixture_construction_emits_no_masked_save_failure` asserts no `append_event save failed` warning is logged during fixture construction, so the masking cannot silently return when the stub next drifts.

**Mutation evidence (item 1):** with the narrow stub temporarily restored, the new test fails naming the masked failure (`1 failed, 1 passed`); restored, `2 passed`.

**Guard liveness (acceptance criterion 2):** with `worker_key`'s slug-precedence branch temporarily neutralized (`if False and ...`), the two worker-key classes report `9 failed, 16 passed`; restored, `25 passed`. The guard is live, not merely green.

## 2. Constructor-kwarg audit (#2949 class)

AST audit over every tracked `.py`: all `AgentSession(...)` call sites, keyword args diffed against the 92 runtime-declared Popoto fields plus the aliases `_normalize_kwargs` explicitly maps.

| Category | Sites | Disposition |
|---|---|---|
| `stage_states=` / `summary=` / `commit_sha=` (the #2949 property conversions) as constructor kwargs | **0** | None found — the 56e80d843 migration covered them all |
| `message_text=` / `sender_name=` / `classification_type=` etc. | 26 | Supported: `_normalize_kwargs` maps them into `initial_telegram_message` / `extra_context`. Not drops. |
| `agent_session_id=` as constructor kwarg | **8** (5 test files) | **Genuine silent drops, removed here.** `_normalize_kwargs` deliberately pops the key ("AutoKeyField, ignore"), verified by runtime probe: the passed value is discarded and the row gets an auto-generated id. All eight literals were referenced nowhere else, so no behavior depended on them — they only misled readers into thinking the id was pinned. |

Post-fix re-audit: **0 silently-dropped kwarg sites remain.**

Files: `test_agent_session_liveness_fields.py`, `test_agent_session_thread_rollup_fields.py`, `test_harness_oom_backoff.py` (4 sites), `test_session_health_compacting_reprieve.py`, `test_session_token_accumulator.py`.

## 3. The unknown-kwargs rejection decision (for the owner to rule)

Not implemented; framed for a ruling as the issue asks. The mechanics, verified by probe: popoto's `Model.__init__` does `self.__dict__.update(kwargs)`, so an unknown kwarg becomes a plain instance attribute — present on the instance, never a declared Field, never persisted (encoding iterates `_meta.fields` only). New `test_unknown_constructor_kwarg_is_tolerated_and_unpersisted` pins this exact behavior with a docstring pointing back here, so an upstream strictness change surfaces as a named test failure rather than a mystery.

**The tradeoff:**

- **Reject (strict `__init__`)** is the durable fix #3001 wanted: the next property conversion fails loudly at the first fixture that constructs with a dead kwarg. But strictness lives upstream in popoto and would need either an upstream change (every downstream consumer inherits it, and hydration paths that round-trip extra keys would need auditing there) or a repo-side `AgentSession.__init__` allowlist that must track popoto's own constructor contract forever.
- **Tolerate (status quo)** keeps hydration and legacy-alias flexibility, and this repo's exposure is now fenced by three guards instead of zero: the fixture self-check (56e80d843), the stub-fidelity warning assert (this PR), and the tolerance pin (this PR).

Recommendation: keep tolerance locally; if strictness is wanted, take it upstream in popoto as an opt-in `Meta.strict_init` so hydration paths choose their own posture. A recorded "no, and here is why" closes the criterion per the issue; the ruling is the owner's.

## Verification

- 105 passed across all seven touched test files (`-n 0`, worktree-pinned imports)
- `tests/unit/test_agent_session_legacy_surface.py` green — the kwarg mapping stays removed
- PLAN/ISSUE negative controls confirmed non-vacuous: the fixture's internal `current_stage` assert guarantees the stage lands, and under the guard-liveness mutation they correctly kept passing (they assert the fallback) while 9 slug-routing tests failed
- ruff check + format clean
