### PR TITLE
Reply-chain media renders as an actionable descriptor, never the literal [media]

### DIFF
--- a/bridge/context.py
+++ b/bridge/context.py
@@ -1,5 +1,6 @@
 """Context building, conversation history, reply chains, and link summaries."""
 
+import asyncio
 import logging
 import os
 import re
@@ -10,6 +11,7 @@ from telethon import TelegramClient
 
 # Reuse the canonical tool-log filter from bridge.response (single source of truth).
 # See docs/features/bridge-response-improvements.md and issue #1359.
+from bridge.media import MEDIA_DIR, get_media_type
 from bridge.response import filter_tool_logs
 from config.settings import settings
 from tools.link_analysis import (
@@ -376,6 +378,103 @@ def build_conversation_history(chat_id: str, limit: int = 5) -> str:
 # =============================================================================
 
 
+def _media_descriptor(
+    kind: str,
+    filename: str | None,
+    media_type: str | None,
+    local_path: str | None,
+    reason: str | None,
+) -> dict:
+    """Build the media descriptor attached to a reply-chain entry.
+
+    `kind` is "resolved" (file readable at `local_path`) or "unreadable"
+    (`reason` names why). The descriptor is data, not text: the renderer owns
+    presentation and tests assert on this structure.
+    """
+    return {
+        "kind": kind,
+        "filename": filename,
+        "media_type": media_type,
+        "local_path": local_path,
+        "reason": reason,
+    }
+
+
+async def _resolve_media_descriptor(msg, chat_id: int) -> dict | None:
+    """Resolve the media descriptor for one reply-chain hop.
+
+    Returns None when the message carries no media. Otherwise returns a
+    descriptor (see `_media_descriptor`): media type and filename come from
+    the Telethon message already in hand, the on-disk path from the
+    `TelegramMessage` record the bridge wrote at intake. The two sources
+    degrade separately — a Redis miss still yields a named attachment,
+    downgraded to "unreadable" with a specific reason.
+
+    Never raises: any failure logs at warning and degrades to an
+    "unreadable" descriptor so the chain walk continues past this hop.
+    """
+    if not (getattr(msg, "file", None) or getattr(msg, "media", None)):
+        return None
+
+    try:
+        media_type = get_media_type(msg)
+        filename = getattr(getattr(msg, "file", None), "name", None)
+        if not filename:
+            # Photos genuinely have no filename — synthesize a stable label.
+            filename = f"{media_type or 'media'}-{msg.id}"
+
+        # Lazy import: models.telegram pulls in Popoto/Redis, which this
+        # module must not require at import time (same shape as _cache_walk_root).
+        from models.telegram import TelegramMessage
+
+        # Popoto is synchronous redis-py; an inline call here would block the
+        # bridge event loop and make the callers' asyncio.wait_for guard
+        # unenforceable. chat_id scoping is a hard requirement: message ids
+        # are per-chat sequences, so an unscoped lookup could resolve another
+        # chat's file.
+        records = await asyncio.to_thread(
+            lambda: list(TelegramMessage.query.filter(chat_id=str(chat_id), message_id=msg.id))
+        )
+        if not records:
+            return _media_descriptor("unreadable", filename, media_type, None, "no_record")
+
+        record = records[0]
+        download_error = getattr(record, "media_download_error", None)
+        if download_error:
+            return _media_descriptor(
+                "unreadable", filename, media_type, None, f"download_error: {download_error}"
+            )
+
+        local_path = getattr(record, "media_local_path", None)
+        if not local_path or not str(local_path).strip():
+            return _media_descriptor("unreadable", filename, media_type, None, "no_path_recorded")
+
+        path = Path(str(local_path).strip())
+        try:
+            inside_media_dir = path.resolve().is_relative_to(MEDIA_DIR.resolve())
+        except (OSError, ValueError):
+            inside_media_dir = False
+        if not inside_media_dir:
+            return _media_descriptor("unreadable", filename, media_type, None, "invalid_path")
+
+        if not (path.exists() and os.access(path, os.R_OK)):
+            return _media_descriptor("unreadable", filename, media_type, None, "file_missing")
+
+        return _media_descriptor("resolved", filename, media_type, str(path), None)
+    except Exception as e:
+        logger.warning(
+            f"Could not resolve media descriptor for message "
+            f"{getattr(msg, 'id', 'unknown')} in chat {chat_id}: {e}"
+        )
+        return _media_descriptor(
+            "unreadable",
+            f"media-{getattr(msg, 'id', 'unknown')}",
+            None,
+            None,
+            "resolution_error",
+        )
+
+
 async def fetch_reply_chain(
     client: TelegramClient,
     chat_id: int,
@@ -395,7 +494,8 @@ async def fetch_reply_chain(
         max_depth: Maximum number of messages to fetch in the chain
 
     Returns:
-        List of message dicts with 'sender', 'content', 'message_id', 'date'
+        List of message dicts with 'sender', 'content', 'message_id', 'date',
+        and 'media' (a descriptor dict for hops carrying media, else None)
     """
     chain = []
     current_id = message_id
@@ -419,12 +519,17 @@ async def fetch_reply_chain(
             if msg.out:
                 sender_name = "Valor"
 
+            # Never raises — a resolution failure degrades this hop to an
+            # "unreadable" descriptor instead of reaching the loop-tail break.
+            media = await _resolve_media_descriptor(msg, chat_id)
+
             chain.append(
                 {
                     "sender": sender_name,
                     "content": msg.text or "[media]",
                     "message_id": msg.id,
                     "date": msg.date,
+                    "media": media,
                 }
             )
 

--- a/bridge/context.py
+++ b/bridge/context.py
@@ -526,7 +526,7 @@ async def fetch_reply_chain(
             chain.append(
                 {
                     "sender": sender_name,
-                    "content": msg.text or "[media]",
+                    "content": msg.text or "",
                     "message_id": msg.id,
                     "date": msg.date,
                     "media": media,
@@ -548,9 +548,30 @@ async def fetch_reply_chain(
     return chain
 
 
+def _format_media_descriptor(media: dict) -> str:
+    """Render one media descriptor as a compact single-line marker.
+
+    The filename (a basename) is the human-readable name to quote; the
+    absolute path is an explicitly machine-facing affordance for the agent's
+    file tools. The unreadable rendering names the file and the reason and is
+    textually distinguishable from the resolved one.
+    """
+    name = media.get("filename") or "unnamed"
+    media_type = media.get("media_type") or "file"
+    local_path = media.get("local_path")
+    if media.get("kind") == "resolved" and local_path:
+        return f"[attachment: {name} ({media_type}) at machine path {local_path}]"
+    reason = media.get("reason") or "unknown"
+    return f"[unreadable attachment: {name} ({media_type}) reason: {reason}]"
+
+
 def format_reply_chain(chain: list[dict]) -> str:
     """
     Format a reply chain for inclusion in agent context.
+
+    Each entry's line composes the human-authored text with its media
+    descriptor: both when both exist, the descriptor alone when the text is
+    empty, the text alone when the entry carries no media.
 
     Args:
         chain: List of message dicts from fetch_reply_chain()
@@ -567,11 +588,14 @@ def format_reply_chain(chain: list[dict]) -> str:
     for msg in chain:
         sender = msg["sender"]
         content = msg["content"]
+        media = msg.get("media")
 
-        # Filter tool logs from Valor's messages
+        # Filter tool logs from Valor's messages. A hop whose text filters to
+        # nothing is still kept when it carries media — its descriptor is the
+        # whole line.
         if sender == "Valor":
             content = filter_tool_logs(content)
-            if not content:
+            if not content and not media:
                 continue
 
         # Valor's messages are already summarized — include in full
@@ -580,6 +604,14 @@ def format_reply_chain(chain: list[dict]) -> str:
         max_len = 2000 if sender == "Valor" else 500
         if len(content) > max_len:
             content = content[:max_len] + "..."
+
+        # Compose after filtering and truncation: filter_tool_logs is written
+        # for human/tool text and must never see the descriptor, and
+        # truncation measures the human-authored text so it can never bisect
+        # a path.
+        if media:
+            descriptor = _format_media_descriptor(media)
+            content = f"{content} {descriptor}" if content else descriptor
 
         # Format with timestamp if available
         date_str = ""

--- a/bridge/context.py
+++ b/bridge/context.py
@@ -403,7 +403,9 @@ def _media_descriptor(
 async def _resolve_media_descriptor(msg, chat_id: int) -> dict | None:
     """Resolve the media descriptor for one reply-chain hop.
 
-    Returns None when the message carries no media. Otherwise returns a
+    Returns None when the message carries no media, or media that is not a
+    downloadable file (get_media_type is the eligibility authority: only
+    photo/document kinds ever resolve). Otherwise returns a
     descriptor (see `_media_descriptor`): media type and filename come from
     the Telethon message already in hand, the on-disk path from the
     `TelegramMessage` record the bridge wrote at intake. The two sources
@@ -510,7 +512,9 @@ async def fetch_reply_chain(
 
     Returns:
         List of message dicts with 'sender', 'content', 'message_id', 'date',
-        and 'media' (a descriptor dict for hops carrying media, else None)
+        and 'media' (a descriptor dict for hops carrying downloadable file
+        media per get_media_type; None for text-only hops, non-file media,
+        or when resolve_media is False)
     """
     chain = []
     current_id = message_id

--- a/bridge/context.py
+++ b/bridge/context.py
@@ -8,6 +8,13 @@ import subprocess
 from pathlib import Path
 
 from telethon import TelegramClient
+from telethon.tl.types import (
+    MessageMediaContact,
+    MessageMediaDice,
+    MessageMediaGeo,
+    MessageMediaPoll,
+    MessageMediaWebPage,
+)
 
 # Reuse the canonical tool-log filter from bridge.response (single source of truth).
 # See docs/features/bridge-response-improvements.md and issue #1359.
@@ -377,6 +384,22 @@ def build_conversation_history(chat_id: str, limit: int = 5) -> str:
 # Reply Chain Management
 # =============================================================================
 
+# Telethon media kinds that are never a downloadable attachment. Telegram sets
+# MessageMediaWebPage on any plain-text message that gets a link preview, and
+# Message.file/.photo/.document fall back to the web preview's photo/document
+# for that case too — so neither `msg.media` nor `msg.file` truthiness alone
+# distinguishes "has an attachment" from "has a link preview". Polls, geo
+# pins, contacts, and dice hit the same non-file-media shape. Excluding these
+# up front keeps ordinary link messages from rendering a spurious
+# "[unreadable attachment]" marker (see PR #3146 review).
+_NON_FILE_MEDIA_TYPES = (
+    MessageMediaWebPage,
+    MessageMediaPoll,
+    MessageMediaGeo,
+    MessageMediaContact,
+    MessageMediaDice,
+)
+
 
 def _media_descriptor(
     kind: str,
@@ -413,7 +436,14 @@ async def _resolve_media_descriptor(msg, chat_id: int) -> dict | None:
     Never raises: any failure logs at warning and degrades to an
     "unreadable" descriptor so the chain walk continues past this hop.
     """
-    if not (getattr(msg, "file", None) or getattr(msg, "media", None)):
+    media = getattr(msg, "media", None)
+    if isinstance(media, _NON_FILE_MEDIA_TYPES):
+        # Checked before the file/media truthiness test below: Telethon's
+        # Message.file (and .photo/.document) fall back to the web preview's
+        # own photo/document for MessageMediaWebPage, so a truthy msg.file
+        # cannot be trusted to rule these out on its own.
+        return None
+    if not (getattr(msg, "file", None) or media):
         return None
 
     try:

--- a/bridge/context.py
+++ b/bridge/context.py
@@ -8,13 +8,6 @@ import subprocess
 from pathlib import Path
 
 from telethon import TelegramClient
-from telethon.tl.types import (
-    MessageMediaContact,
-    MessageMediaDice,
-    MessageMediaGeo,
-    MessageMediaPoll,
-    MessageMediaWebPage,
-)
 
 # Reuse the canonical tool-log filter from bridge.response (single source of truth).
 # See docs/features/bridge-response-improvements.md and issue #1359.
@@ -384,22 +377,6 @@ def build_conversation_history(chat_id: str, limit: int = 5) -> str:
 # Reply Chain Management
 # =============================================================================
 
-# Telethon media kinds that are never a downloadable attachment. Telegram sets
-# MessageMediaWebPage on any plain-text message that gets a link preview, and
-# Message.file/.photo/.document fall back to the web preview's photo/document
-# for that case too — so neither `msg.media` nor `msg.file` truthiness alone
-# distinguishes "has an attachment" from "has a link preview". Polls, geo
-# pins, contacts, and dice hit the same non-file-media shape. Excluding these
-# up front keeps ordinary link messages from rendering a spurious
-# "[unreadable attachment]" marker (see PR #3146 review).
-_NON_FILE_MEDIA_TYPES = (
-    MessageMediaWebPage,
-    MessageMediaPoll,
-    MessageMediaGeo,
-    MessageMediaContact,
-    MessageMediaDice,
-)
-
 
 def _media_descriptor(
     kind: str,
@@ -436,22 +413,26 @@ async def _resolve_media_descriptor(msg, chat_id: int) -> dict | None:
     Never raises: any failure logs at warning and degrades to an
     "unreadable" descriptor so the chain walk continues past this hop.
     """
-    media = getattr(msg, "media", None)
-    if isinstance(media, _NON_FILE_MEDIA_TYPES):
-        # Checked before the file/media truthiness test below: Telethon's
-        # Message.file (and .photo/.document) fall back to the web preview's
-        # own photo/document for MessageMediaWebPage, so a truthy msg.file
-        # cannot be trusted to rule these out on its own.
-        return None
-    if not (getattr(msg, "file", None) or media):
+    if not getattr(msg, "media", None):
         return None
 
     try:
+        # Classifier gate (PR #3146 review, round 2): get_media_type is
+        # non-None exactly for the Photo/Document set the intake download
+        # path can resolve, so a descriptor exists only when a file could
+        # ever have been downloaded. Everything else — link previews (whose
+        # msg.file falls back to the web preview's own photo/document),
+        # polls, geo pins static or live, venues, contacts, dice, stories,
+        # and every future Telethon media kind — fails closed with no
+        # descriptor, instead of rendering a false "[unreadable attachment]"
+        # marker for a file that never existed.
         media_type = get_media_type(msg)
+        if media_type is None:
+            return None
         filename = getattr(getattr(msg, "file", None), "name", None)
         if not filename:
             # Photos genuinely have no filename — synthesize a stable label.
-            filename = f"{media_type or 'media'}-{msg.id}"
+            filename = f"{media_type}-{msg.id}"
 
         # Lazy import: models.telegram pulls in Popoto/Redis, which this
         # module must not require at import time (same shape as _cache_walk_root).
@@ -510,6 +491,7 @@ async def fetch_reply_chain(
     chat_id: int,
     message_id: int,
     max_depth: int = 20,
+    resolve_media: bool = True,
 ) -> list[dict]:
     """
     Fetch the entire reply chain for a message.
@@ -522,6 +504,9 @@ async def fetch_reply_chain(
         chat_id: Chat ID to fetch from
         message_id: Starting message ID (the one being replied to)
         max_depth: Maximum number of messages to fetch in the chain
+        resolve_media: when False, skip per-hop media descriptor resolution
+            (and its Redis lookups) entirely — for callers that consume only
+            sender/message_id, like the session-routing walk
 
     Returns:
         List of message dicts with 'sender', 'content', 'message_id', 'date',
@@ -551,7 +536,7 @@ async def fetch_reply_chain(
 
             # Never raises — a resolution failure degrades this hop to an
             # "unreadable" descriptor instead of reaching the loop-tail break.
-            media = await _resolve_media_descriptor(msg, chat_id)
+            media = await _resolve_media_descriptor(msg, chat_id) if resolve_media else None
 
             chain.append(
                 {
@@ -625,8 +610,13 @@ def format_reply_chain(chain: list[dict]) -> str:
         # whole line.
         if sender == "Valor":
             content = filter_tool_logs(content)
-            if not content and not media:
-                continue
+
+        # Any hop with no text and no descriptor renders nothing: a bare
+        # "Sender:" label carries no information. Covers Valor hops whose
+        # text filtered away and caption-less non-file media (a poll or geo
+        # share) whose descriptor is deliberately absent (PR #3146 review).
+        if not content and not media:
+            continue
 
         # Valor's messages are already summarized — include in full
         # so resumed sessions have complete context of what was sent.
@@ -764,7 +754,11 @@ async def resolve_root_session_id(
             f"[session-root] cache miss for msg_id={reply_to_msg_id}, "
             f"falling back to Telegram API chain walk"
         )
-        chain = await fetch_reply_chain(client, chat_id, reply_to_msg_id)
+        # resolve_media=False: this walk consumes only sender/message_id, so
+        # paying per-hop Redis descriptor resolution here would add
+        # Redis-health-bounded latency to session routing for data nothing
+        # reads (PR #3146 review).
+        chain = await fetch_reply_chain(client, chat_id, reply_to_msg_id, resolve_media=False)
         # Chain is chronological (oldest first). Find the first non-Valor message.
         for entry in chain:
             if entry.get("sender") != "Valor":

--- a/docs/features/media-enrichment.md
+++ b/docs/features/media-enrichment.md
@@ -90,6 +90,25 @@ On `TimeoutError`, the helper retries **once** with a 2x leash (still capped at 
 
 The reply-chain branch in `bridge/enrichment.py` still requires a Telethon client and is therefore **silently skipped in the worker** until a follow-up issue lands. Tracked as a companion to #1297. Reply-context enrichment that the bridge handler hydrates synchronously (the existing `REPLY_THREAD_CONTEXT_HEADER` block) is unaffected — it's already pre-baked into `session.message_text`.
 
+## Chain-Ancestor Media Is Reference-Only
+
+Chain-ancestor media never goes through `enrich_message`'s AI pass —
+no vision description, no transcription, no document extraction.
+`bridge/context.py`'s reply-chain resolver hands the agent a path reference
+instead: filename, media type, and (when resolvable) the absolute on-disk
+path, composed into the rendered chain line by `format_reply_chain`. See
+[Reply-Thread Context Hydration](reply-thread-context-hydration.md#chain-ancestor-media-rendering)
+for the three rendering states.
+
+The reasoning: a chain can run up to 20 hops deep, and the reply-chain fetch
+shares the same 3-second budget as the Telethon RPCs already in that loop.
+Running AI enrichment over every hop that carries media cannot fit that
+budget, and most of it is wasted work — a description or transcript for a
+file nobody in the conversation ends up asking about. A path reference costs
+one scoped Redis lookup per hop; the agent spends a tool call only on the
+one file that matters to the turn it is answering, reading it with `Read` or
+`valor-ingest` the same way it would any other file on disk.
+
 ## Implementation files
 
 - `bridge/telegram_bridge.py` — handler, intake timing, bridge-side download, persistence. Hosts `_download_media_with_retry` (size-aware timeout + 1-retry wrapper around `download_media`).

--- a/docs/features/media-enrichment.md
+++ b/docs/features/media-enrichment.md
@@ -88,7 +88,7 @@ On `TimeoutError`, the helper retries **once** with a 2x leash (still capped at 
 
 ## Reply-chain note
 
-The reply-chain branch in `bridge/enrichment.py` still requires a Telethon client and is therefore **silently skipped in the worker** until a follow-up issue lands. Tracked as a companion to #1297. Reply-context enrichment that the bridge handler hydrates synchronously (the existing `REPLY_THREAD_CONTEXT_HEADER` block) is unaffected — it's already pre-baked into `session.message_text`.
+The reply-chain branch in `bridge/enrichment.py` still requires a Telethon client and is therefore **silently skipped in the worker**. Reply-context enrichment that the bridge handler hydrates synchronously (the existing `REPLY_THREAD_CONTEXT_HEADER` block) is unaffected — it's already pre-baked into `session.message_text`. What that block carries for a chain ancestor's media is the settled status quo described in the next section.
 
 ## Chain-Ancestor Media Is Reference-Only
 

--- a/docs/features/media-enrichment.md
+++ b/docs/features/media-enrichment.md
@@ -98,16 +98,19 @@ no vision description, no transcription, no document extraction.
 instead: filename, media type, and (when resolvable) the absolute on-disk
 path, composed into the rendered chain line by `format_reply_chain`. See
 [Reply-Thread Context Hydration](reply-thread-context-hydration.md#chain-ancestor-media-rendering)
-for the three rendering states.
+for the rendering outcomes.
 
 The reasoning: a chain can run up to 20 hops deep, and the reply-chain fetch
 shares the same 3-second budget as the Telethon RPCs already in that loop.
 Running AI enrichment over every hop that carries media cannot fit that
 budget, and most of it is wasted work — a description or transcript for a
 file nobody in the conversation ends up asking about. A path reference costs
-one scoped Redis lookup per hop; the agent spends a tool call only on the
-one file that matters to the turn it is answering, reading it with `Read` or
-`valor-ingest` the same way it would any other file on disk.
+one scoped Redis lookup per hop carrying downloadable file media (per
+`get_media_type`; non-file media resolves nothing), and the session-routing
+walk skips resolution entirely via `resolve_media=False`. The agent spends a
+tool call only on the one file that matters to the turn it is answering,
+reading it with `Read` or `valor-ingest` the same way it would any other
+file on disk.
 
 ## Implementation files
 

--- a/docs/features/reply-thread-context-hydration.md
+++ b/docs/features/reply-thread-context-hydration.md
@@ -41,6 +41,53 @@ This string is the canonical substring used by:
 
 Do not duplicate this string. Import from `bridge.context`.
 
+## Chain-Ancestor Media Rendering
+
+Chain-ancestor media — a photo, voice note, or document attached to one of
+the messages `fetch_reply_chain` walks — is rendered, never dropped.
+`_resolve_media_descriptor` (`bridge/context.py`) builds a small descriptor
+for that hop, and `format_reply_chain` composes it into the rendered line.
+Three states, each textually distinguishable:
+
+1. **Resolved.** The ancestor's `TelegramMessage` record carries a
+   `media_local_path` that stats readable. The line carries the caption (if
+   any) plus the descriptor — filename, media type, and the absolute path as
+   a machine-facing affordance, e.g. `[attachment: report.pdf (document) at
+   machine path /Users/.../data/media/document_..._123.pdf]`. A caption
+   composes with the descriptor rather than replacing it, so the agent sees
+   both the human's note and the file.
+2. **Referenced but unreadable.** Media exists per Telethon but the on-disk
+   path cannot be trusted: no `TelegramMessage` record (`no_record`), no
+   path recorded (`no_path_recorded`), a persisted download error
+   (`download_error: ...`), the file missing from disk (`file_missing`), a
+   path outside `MEDIA_DIR` (`invalid_path`), or an unexpected resolution
+   failure (`resolution_error`). The line names the file and the reason,
+   e.g. `[unreadable attachment: voice-456 (voice) reason:
+   no_path_recorded]`, so the agent can report the gap precisely instead of
+   guessing. Valor's own outbound media hops always render this way:
+   outbound stores never set `media_local_path`, so a file Valor sent is
+   honestly unreadable rather than silently dropped.
+3. **Text only.** No media on the hop. Renders exactly as it always has.
+
+**Chat scoping.** The path lookup filters
+`TelegramMessage.query.filter(chat_id=str(chat_id), message_id=msg.id)` —
+the same shape used elsewhere in this module. `data/media/` is one flat
+directory shared by every chat and project on the machine, and Telegram
+message ids are per-chat sequences, so a record with the same `message_id`
+in a different chat can genuinely exist; the `chat_id` filter is what keeps
+that record from ever answering a lookup for the wrong chat. The resolver
+never globs `MEDIA_DIR` for a match — the scoped `TelegramMessage` record is
+the only path into a descriptor.
+
+**Path disclosure.** A resolved descriptor carries the file's absolute path
+so the agent can read it in one call. That path is a machine-facing
+affordance, not the label meant for a human eye: the descriptor's
+human-readable name is the file's basename, so quoting the attachment back
+into a chat naturally reproduces the filename rather than the surrounding
+directory structure. This is a disclosure-of-shape risk, not a cross-tenant
+one — chat scoping above is what keeps a file from surfacing in the wrong
+chat at all.
+
 ## Flow
 
 ### Reply-To Arrives, Resolves To Completed Session

--- a/docs/features/reply-thread-context-hydration.md
+++ b/docs/features/reply-thread-context-hydration.md
@@ -43,11 +43,15 @@ Do not duplicate this string. Import from `bridge.context`.
 
 ## Chain-Ancestor Media Rendering
 
-Chain-ancestor media — a photo, voice note, or document attached to one of
-the messages `fetch_reply_chain` walks — is rendered, never dropped.
+Chain-ancestor file media — a photo, voice note, or document attached to one
+of the messages `fetch_reply_chain` walks — is rendered, never dropped.
 `_resolve_media_descriptor` (`bridge/context.py`) builds a small descriptor
 for that hop, and `format_reply_chain` composes it into the rendered line.
-Three states, each textually distinguishable:
+Descriptor eligibility is decided by `get_media_type` (`bridge/media.py`),
+the same classifier the download path uses: only photo and document kinds
+ever resolve, so the renderer can never claim a file exists for media the
+bridge could never have downloaded. Four outcomes, each textually
+distinguishable:
 
 1. **Resolved.** The ancestor's `TelegramMessage` record carries a
    `media_local_path` that stats readable. The line carries the caption (if
@@ -68,6 +72,16 @@ Three states, each textually distinguishable:
    outbound stores never set `media_local_path`, so a file Valor sent is
    honestly unreadable rather than silently dropped.
 3. **Text only.** No media on the hop. Renders exactly as it always has.
+4. **Non-file media.** Link previews, polls, geo and live locations, venues,
+   contacts, dice, games, invoices, and every other kind `get_media_type`
+   declines yield no descriptor: the hop renders its text alone, and a
+   caption-less such hop renders nothing at all (the same skip applied to
+   empty hops generally). This is what keeps a shared live location from
+   producing a false `[unreadable attachment]` claim.
+
+The session-routing walk (`resolve_root_session_id`) consumes only sender
+and message id, so it calls `fetch_reply_chain(..., resolve_media=False)`
+and skips descriptor resolution — and its Redis lookups — entirely.
 
 **Chat scoping.** The path lookup filters
 `TelegramMessage.query.filter(chat_id=str(chat_id), message_id=msg.id)` —

--- a/docs/plans/reply-chain-media-renders-as-literal-string.md
+++ b/docs/plans/reply-chain-media-renders-as-literal-string.md
@@ -493,19 +493,19 @@ email side, and this plan should not reproduce it.
 
 ## Success Criteria
 
-- [ ] `bridge/context.py::fetch_reply_chain` emits the literal string `[media]` under no input. A caption-less attachment in a chain renders with its filename, media type, and a readable path.
-- [ ] Replaying the reported exchange shape (attachment, then two text replies) produces agent turn input containing a path sufficient to read the attachment without asking the human.
-- [ ] A caption on a chain-ancestor attachment renders together with the attachment descriptor, so the agent sees both the note and the file.
-- [ ] An unresolvable attachment renders as an explicit unreadable marker naming the file and the reason, textually distinguishable from the resolved rendering, for each of: no record, no path, download error, file absent from disk.
-- [ ] A `chat_id`-scoped resolution test proves a same-`message_id` record in a different chat is never resolved.
-- [ ] A 20-deep chain with media at every hop completes inside the 3-second `_REPLY_CHAIN_FETCH_TIMEOUT_S` budget, and the rendered block stays under an asserted size ceiling.
-- [ ] The bare-placeholder guard covers `bridge/` including `bridge/email_bridge.py`, and its red state is proven by an in-suite positive fixture plus a negative fixture that keeps a `logger.` line unflagged.
-- [ ] The write-only-context scan passes with an empirically derived allow-list containing only keys the scan proves unread under its stated reader predicate, each email-seam entry annotated `# known gap: #3136`, and asserts every entry is still unread so the allow-list can only shrink.
-- [ ] The 20-hop budget test exercises a *stalled* lookup, proving `asyncio.wait_for` can actually interrupt the walk — an inline blocking `filter` fails it.
-- [ ] `docs/features/reply-thread-context-hydration.md` and `docs/features/media-enrichment.md` both describe how chain-ancestor media is represented.
-- [ ] Tests pass (`/do-test`)
-- [ ] Documentation updated (`/do-docs`)
-- [ ] No xfail conversions required — the repo currently contains zero `pytest.mark.xfail` or runtime `pytest.xfail()` markers in `tests/`, verified at plan time.
+- [x] `bridge/context.py::fetch_reply_chain` emits the literal string `[media]` under no input. A caption-less attachment in a chain renders with its filename, media type, and a readable path.
+- [x] Replaying the reported exchange shape (attachment, then two text replies) produces agent turn input containing a path sufficient to read the attachment without asking the human.
+- [x] A caption on a chain-ancestor attachment renders together with the attachment descriptor, so the agent sees both the note and the file.
+- [x] An unresolvable attachment renders as an explicit unreadable marker naming the file and the reason, textually distinguishable from the resolved rendering, for each of: no record, no path, download error, file absent from disk.
+- [x] A `chat_id`-scoped resolution test proves a same-`message_id` record in a different chat is never resolved.
+- [x] A 20-deep chain with media at every hop completes inside the 3-second `_REPLY_CHAIN_FETCH_TIMEOUT_S` budget, and the rendered block stays under an asserted size ceiling.
+- [x] The bare-placeholder guard covers `bridge/` including `bridge/email_bridge.py`, and its red state is proven by an in-suite positive fixture plus a negative fixture that keeps a `logger.` line unflagged.
+- [x] The write-only-context scan passes with an empirically derived allow-list containing only keys the scan proves unread under its stated reader predicate, each email-seam entry annotated `# known gap: #3136`, and asserts every entry is still unread so the allow-list can only shrink.
+- [x] The 20-hop budget test exercises a *stalled* lookup, proving `asyncio.wait_for` can actually interrupt the walk — an inline blocking `filter` fails it.
+- [x] `docs/features/reply-thread-context-hydration.md` and `docs/features/media-enrichment.md` both describe how chain-ancestor media is represented.
+- [x] Tests pass (`/do-test`)
+- [x] Documentation updated (`/do-docs`)
+- [x] No xfail conversions required — the repo currently contains zero `pytest.mark.xfail` or runtime `pytest.xfail()` markers in `tests/`, verified at plan time.
 
 ## Team Orchestration
 

--- a/tests/integration/test_steering.py
+++ b/tests/integration/test_steering.py
@@ -946,7 +946,7 @@ class TestResolveRootSessionId:
         mock_query = type("Q", (), {"filter": staticmethod(mock_filter)})()
 
         # API chain: returns a chain with root human message at msg_id=8800
-        async def mock_fetch_reply_chain(client, cid, mid, max_depth=20):
+        async def mock_fetch_reply_chain(client, cid, mid, max_depth=20, resolve_media=True):
             return [
                 {"sender": "Bob", "content": "hello", "message_id": 8800, "date": None},
                 {"sender": "Valor", "content": "hi", "message_id": 8801, "date": None},
@@ -2509,6 +2509,19 @@ class _MediaFakeFile:
         self.name = name
 
 
+def _media_fake_document(filename: str = "report.pdf"):
+    """A genuine MessageMediaDocument the resolver's classifier gate accepts
+    (PR #3146 review round 2): get_media_type is the descriptor gate, so a
+    bare object() no longer reads as an attachment."""
+    from types import SimpleNamespace
+
+    from telethon.tl.types import DocumentAttributeFilename, MessageMediaDocument
+
+    media = MessageMediaDocument.__new__(MessageMediaDocument)
+    media.document = SimpleNamespace(attributes=[DocumentAttributeFilename(file_name=filename)])
+    return media
+
+
 class _MediaFakeSender:
     first_name = "Hazem"
 
@@ -2544,7 +2557,7 @@ def _media_chain_msgs(depth: int) -> list[_MediaFakeMsg]:
             i,
             text=f"hop {i}: short caption for this attachment",
             reply_to=i - 1 if i > 1 else None,
-            media=object(),
+            media=_media_fake_document(),
             file=_MediaFakeFile(f"file_{i}.pdf"),
         )
         for i in range(1, depth + 1)
@@ -2675,7 +2688,10 @@ class TestReplyChainMessageTextDelivery:
         return _MediaFakeClient(
             [
                 _MediaFakeMsg(
-                    1, text="", media=object(), file=_MediaFakeFile("recommendation.pdf")
+                    1,
+                    text="",
+                    media=_media_fake_document(),
+                    file=_MediaFakeFile("recommendation.pdf"),
                 ),
                 _MediaFakeMsg(
                     2,

--- a/tests/integration/test_steering.py
+++ b/tests/integration/test_steering.py
@@ -2497,3 +2497,331 @@ class TestLegacyByRuleWriters:
                 "must pass room_id=None — it feeds _reenqueue_leftover_steering, which "
                 "spawns a continuation session."
             )
+
+
+# =============================================================================
+# #2732: reply-chain media — budget, stall liveness, and message_text delivery
+# =============================================================================
+
+
+class _MediaFakeFile:
+    def __init__(self, name):
+        self.name = name
+
+
+class _MediaFakeSender:
+    first_name = "Hazem"
+
+
+class _MediaFakeMsg:
+    """Minimal Telethon Message stand-in for driving fetch_reply_chain."""
+
+    def __init__(self, id, text="", reply_to=None, media=None, file=None, out=False):
+        self.id = id
+        self.text = text
+        self.reply_to_msg_id = reply_to
+        self.media = media
+        self.file = file
+        self.out = out
+        self.date = None
+
+    async def get_sender(self):
+        return _MediaFakeSender()
+
+
+class _MediaFakeClient:
+    def __init__(self, msgs):
+        self._msgs = {m.id: m for m in msgs}
+
+    async def get_messages(self, chat_id, ids=None):
+        return self._msgs.get(ids)
+
+
+def _media_chain_msgs(depth: int) -> list[_MediaFakeMsg]:
+    """A depth-deep chain with media at EVERY hop — the Risk 1 worst case."""
+    return [
+        _MediaFakeMsg(
+            i,
+            text=f"hop {i}: short caption for this attachment",
+            reply_to=i - 1 if i > 1 else None,
+            media=object(),
+            file=_MediaFakeFile(f"file_{i}.pdf"),
+        )
+        for i in range(1, depth + 1)
+    ]
+
+
+def _unique_chat_id() -> int:
+    return int(uuid.uuid4().int % 10**9) + 2 * 10**9
+
+
+class TestReplyChainMediaBudget:
+    """#2732 Task 4: the 20-hop worst case fits the 3s budget, the budget is
+    enforceable against a stalled Redis, and the rendered block stays bounded."""
+
+    async def test_reply_chain_20_hop_media_walk_fits_budget(self):
+        import asyncio
+
+        from bridge.context import fetch_reply_chain
+        from bridge.telegram_bridge import _REPLY_CHAIN_FETCH_TIMEOUT_S
+
+        client = _MediaFakeClient(_media_chain_msgs(20))
+        chat_id = _unique_chat_id()
+
+        t0 = time.monotonic()
+        chain = await asyncio.wait_for(
+            fetch_reply_chain(client, chat_id, 20, max_depth=20),
+            timeout=_REPLY_CHAIN_FETCH_TIMEOUT_S,
+        )
+        elapsed = time.monotonic() - t0
+
+        assert len(chain) == 20
+        assert all(entry["media"] is not None for entry in chain), (
+            "every hop carries media in this fixture; each must get a descriptor"
+        )
+        assert elapsed < _REPLY_CHAIN_FETCH_TIMEOUT_S, (
+            f"20-hop media walk took {elapsed:.2f}s — must fit the "
+            f"{_REPLY_CHAIN_FETCH_TIMEOUT_S}s pre-hydration budget with room to spare"
+        )
+
+    async def test_reply_chain_stalled_lookup_timing_bound_keeps_loop_live(self):
+        """Risk 4 discriminator: an inline blocking filter does not hang — it
+        returns LATE, and wait_for raises the same TimeoutError afterwards.
+        Only wall time (and event-loop liveness) tells the implementations
+        apart, so this asserts a monotonic bound, not just the exception.
+
+        The stall is 5s, not 60s: the asyncio.to_thread worker is not
+        cancellable and keeps sleeping after the test returns, so a long
+        stall would hang teardown.
+        """
+        import asyncio
+
+        from bridge.context import fetch_reply_chain
+
+        client = _MediaFakeClient(_media_chain_msgs(20))
+        chat_id = _unique_chat_id()
+
+        def _stalled_filter(**kwargs):
+            time.sleep(5.0)
+            return []
+
+        ticks = 0
+
+        async def _heartbeat():
+            nonlocal ticks
+            while True:
+                await asyncio.sleep(0.2)
+                ticks += 1
+
+        heartbeat = asyncio.get_running_loop().create_task(_heartbeat())
+        try:
+            with patch("models.telegram.TelegramMessage") as mock_tm:
+                mock_tm.query.filter = _stalled_filter
+                t0 = time.monotonic()
+                with pytest.raises(asyncio.TimeoutError):
+                    await asyncio.wait_for(
+                        fetch_reply_chain(client, chat_id, 20, max_depth=20),
+                        timeout=3.0,
+                    )
+                elapsed = time.monotonic() - t0
+        finally:
+            heartbeat.cancel()
+
+        assert elapsed < 4.0, (
+            f"wait_for could not preempt the walk until {elapsed:.2f}s — the Redis "
+            "lookup is blocking the event loop instead of running under "
+            "asyncio.to_thread (Risk 4: an inline filter makes the 3s guard nominal)"
+        )
+        assert ticks >= 5, (
+            f"heartbeat ticked only {ticks} times during the stall — the bridge "
+            "event loop froze, which stalls every handler, the nudge loop, and "
+            "output callbacks, not just this hydration"
+        )
+
+    async def test_reply_chain_rendered_block_size_bounded(self):
+        """Risk 1: twenty descriptor lines must not crowd the prompt. Ceiling
+        gives each hop ~400 chars (caption + one compact descriptor line +
+        formatting overhead) — a verbose descriptor blows through it."""
+        from bridge.context import fetch_reply_chain, format_reply_chain
+
+        client = _MediaFakeClient(_media_chain_msgs(20))
+        chat_id = _unique_chat_id()
+
+        chain = await fetch_reply_chain(client, chat_id, 20, max_depth=20)
+        formatted = format_reply_chain(chain)
+
+        assert len(chain) == 20
+        assert formatted.count("attachment:") == 20, "every hop renders exactly one descriptor"
+        assert "[media]" not in formatted
+        assert len(formatted) < 8000, (
+            f"rendered 20-hop media block is {len(formatted)} chars — descriptor "
+            "verbosity is crowding the prompt (Risk 1 ceiling: 8000)"
+        )
+
+
+class TestReplyChainMessageTextDelivery:
+    """#2732 Task 5 — owns Success Criterion 2: the rendered chain block that
+    reaches AgentSession.message_text carries a resolvable absolute path for
+    an ancestor attachment, at BOTH hydration call sites. Stamping a
+    descriptor that never arrives is the email-seam failure mode (spike-4)
+    this must rule out. Assertion shape follows
+    tests/integration/test_private_tag_ingestion.py (strip_private coverage).
+    """
+
+    def _make_client(self):
+        # The reported exchange shape: caption-less attachment, two text
+        # replies. Hop 2 carries a <private> region to prove strip_private
+        # covers the block without stripping the descriptor.
+        return _MediaFakeClient(
+            [
+                _MediaFakeMsg(
+                    1, text="", media=object(), file=_MediaFakeFile("recommendation.pdf")
+                ),
+                _MediaFakeMsg(
+                    2,
+                    text="we use <private>OLDSECRET2732</private> for staging",
+                    reply_to=1,
+                ),
+                _MediaFakeMsg(3, text="valor can help flesh this out", reply_to=2),
+            ]
+        )
+
+    async def _hydrated_chain_block(self, chat_id: int) -> str:
+        """Mirror both call sites exactly: fetch under the 3s guard, format,
+        then the caller-side strip_private pass."""
+        import asyncio
+
+        from agent.private_tag import strip_private
+        from bridge.context import fetch_reply_chain, format_reply_chain
+        from bridge.telegram_bridge import _REPLY_CHAIN_FETCH_TIMEOUT_S
+
+        chain = await asyncio.wait_for(
+            fetch_reply_chain(self._make_client(), chat_id, 3),
+            timeout=_REPLY_CHAIN_FETCH_TIMEOUT_S,
+        )
+        return strip_private(format_reply_chain(chain))
+
+    def _seed_ancestor_media(self, chat_id: int):
+        from bridge.media import MEDIA_DIR
+        from models.telegram import TelegramMessage
+
+        media_file = MEDIA_DIR / f"test2732_delivery_{uuid.uuid4().hex}.pdf"
+        media_file.write_bytes(b"%PDF delivery")
+        TelegramMessage(
+            chat_id=str(chat_id),
+            message_id=1,
+            direction="in",
+            sender="Hazem",
+            content="",
+            timestamp=time.time(),
+            has_media=True,
+            media_local_path=str(media_file),
+        ).save()
+        return media_file
+
+    def _cleanup(self, chat_id: int, session_id: str, media_file):
+        from models.agent_session import AgentSession
+        from models.telegram import TelegramMessage
+
+        media_file.unlink(missing_ok=True)
+        for record in TelegramMessage.query.filter(chat_id=str(chat_id)):
+            record.delete()
+        for record in AgentSession.query.filter(session_id=session_id):
+            record.delete()
+
+    def _assert_delivered(self, message_text: str, media_file):
+        from bridge.context import REPLY_THREAD_CONTEXT_HEADER
+
+        assert str(media_file) in message_text, (
+            "the ancestor attachment's absolute path must reach the agent's turn "
+            "input — a descriptor that never arrives is the spike-4 failure mode"
+        )
+        assert "recommendation.pdf" in message_text
+        assert REPLY_THREAD_CONTEXT_HEADER in message_text
+        assert "[media]" not in message_text
+        # strip_private ran over the block: the wrapped region is gone, the
+        # surrounding non-private context and the descriptor both survive.
+        assert "OLDSECRET2732" not in message_text
+        assert "<private>" not in message_text
+        assert "for staging" in message_text
+
+    async def test_resume_completed_message_text_delivery_carries_resolved_path(self):
+        """Resume-completed call site, end-to-end through the real
+        resume_completed_session -> dispatch -> enqueue machinery."""
+        from bridge.answer_routing import resume_completed_session
+        from models.agent_session import AgentSession
+
+        chat_id = _unique_chat_id()
+        session_id = _uid("test_msgtext_delivery_resume")
+        media_file = self._seed_ancestor_media(chat_id)
+        try:
+            reply_chain_context = await self._hydrated_chain_block(chat_id)
+
+            completed = AgentSession(
+                session_id=session_id,
+                project_key="test",
+                status="completed",
+                message_text="original task",
+                context_summary="prior work on the recommendation",
+                created_at=datetime.now(tz=UTC),
+            )
+            completed.save()
+
+            await resume_completed_session(
+                completed=completed,
+                text="what do you think?",
+                sender_name="Tom",
+                telegram_chat_id=str(chat_id),
+                telegram_message_id=int(uuid.uuid4().int % 10**9),
+                project_key="test",
+                working_dir=str(pathlib.Path(__file__).resolve().parents[2]),
+                reply_chain_context=reply_chain_context,
+            )
+
+            records = list(AgentSession.query.filter(session_id=session_id))
+            assert records, "resume must re-enqueue an AgentSession"
+            delivered = [r for r in records if str(media_file) in (r.message_text or "")]
+            assert delivered, (
+                "no re-enqueued AgentSession.message_text carries the resolved path — "
+                f"got: {[(r.status, (r.message_text or '')[:120]) for r in records]}"
+            )
+            self._assert_delivered(delivered[0].message_text, media_file)
+            assert "what do you think?" in delivered[0].message_text
+        finally:
+            self._cleanup(chat_id, session_id, media_file)
+
+    async def test_fresh_session_message_text_delivery_carries_resolved_path(self):
+        """Fresh-session call site: the handler splices the chain block ahead
+        of CURRENT MESSAGE and enqueues with reply_chain_hydrated stamped."""
+        from agent.agent_session_queue import enqueue_agent_session
+        from models.agent_session import AgentSession
+
+        chat_id = _unique_chat_id()
+        session_id = _uid("test_msgtext_delivery_fresh")
+        media_file = self._seed_ancestor_media(chat_id)
+        try:
+            reply_chain_context = await self._hydrated_chain_block(chat_id)
+            enqueued_message_text = f"{reply_chain_context}\n\nCURRENT MESSAGE:\nwhat do you think?"
+
+            await enqueue_agent_session(
+                project_key="test",
+                session_id=session_id,
+                working_dir=str(pathlib.Path(__file__).resolve().parents[2]),
+                message_text=enqueued_message_text,
+                sender_name="Tom",
+                chat_id=str(chat_id),
+                telegram_message_id=int(uuid.uuid4().int % 10**9),
+                extra_context_overrides={"reply_chain_hydrated": True},
+            )
+
+            records = list(AgentSession.query.filter(session_id=session_id))
+            assert records, "fresh-session enqueue must create an AgentSession"
+            message_text = records[0].message_text or ""
+            self._assert_delivered(message_text, media_file)
+            assert "CURRENT MESSAGE:\nwhat do you think?" in message_text
+            assert (records[0].extra_context or {}).get("reply_chain_hydrated") is True, (
+                "the hydration flag and the delivered block must travel together — "
+                "a stamped flag without the block suppresses the worker's retry"
+            )
+        finally:
+            self._cleanup(chat_id, session_id, media_file)

--- a/tests/unit/test_bridge_context_guards.py
+++ b/tests/unit/test_bridge_context_guards.py
@@ -1,0 +1,544 @@
+"""Cross-medium static guards for agent-facing bridge context (#2732).
+
+Three AST scans, each written as a pure function over source text so the
+red-state fixtures below run without touching the filesystem (Risk 5 in
+docs/plans/reply-chain-media-renders-as-literal-string.md):
+
+1. **Placeholder shape** — flags the ``X or "[media]"`` fallback: a
+   ``BoolOp(op=Or)`` whose right-hand operand is a bracketed string constant.
+   This is the exact shape of the defect #2732 fixes and of PR #953's original
+   line. Applied across every module in ``bridge/``.
+2. **Write-only agent context** — every key written onto ``extra_context``
+   (subscript assignment, dict-literal call argument, or dict literal bound to
+   an extra-context/overrides name) in ``bridge/`` and ``agent/`` must have at
+   least one reader outside ``tests/``. This is the shape spike-4 found on the
+   email side: context stamped for the agent and never delivered. The
+   allow-list below is derived empirically and ratchets shut — a new reader
+   for an allow-listed key fails the stale check and forces the entry's
+   removal, so the list can only shrink.
+3. **Off-loop enforcement** — every ``TelegramMessage.query.filter`` call in
+   ``bridge/context.py``'s async functions (``fetch_reply_chain`` and the
+   ``_resolve_media_descriptor`` helper it awaits) must run under
+   ``asyncio.to_thread``, with a ratcheted exemption for the pre-existing
+   ``_cache_walk_root`` defect the plan leaves out of scope. Popoto is
+   synchronous redis-py; an inline call blocks the bridge event loop and
+   makes the 3-second ``asyncio.wait_for`` guard unenforceable (Risk 4).
+
+Test names are selectable with ``-k placeholder``, ``-k write_only_context``,
+and ``-k off_loop`` respectively, matching the plan's Verification rows.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BRIDGE_DIR = REPO_ROOT / "bridge"
+
+
+# ---------------------------------------------------------------------------
+# Scan 1: bare bracketed-placeholder fallbacks (`X or "[media]"`)
+# ---------------------------------------------------------------------------
+
+# The named placeholders from the plan ([media], [image], [attachment],
+# [document], [file]) are all instances of this general shape.
+_PLACEHOLDER_RE = re.compile(r"^\[[a-z_ ]+\]$")
+
+
+class PlaceholderFinding(NamedTuple):
+    lineno: int
+    placeholder: str
+
+
+def find_placeholder_fallbacks(source: str) -> list[PlaceholderFinding]:
+    """Flag every ``or``-fallback to a bracketed placeholder string.
+
+    Matches any ``BoolOp(op=Or)`` whose right-hand operand is a string
+    ``Constant`` of the ``^\\[[a-z_ ]+\\]$`` shape. Log lines like
+    ``logger.info(f"[media] ...")`` are ``JoinedStr`` arguments to a call,
+    not ``BoolOp`` operands, so they are structurally invisible to this scan
+    — no allow-list needed.
+    """
+    findings: list[PlaceholderFinding] = []
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.BoolOp) and isinstance(node.op, ast.Or):
+            for operand in node.values[1:]:
+                if (
+                    isinstance(operand, ast.Constant)
+                    and isinstance(operand.value, str)
+                    and _PLACEHOLDER_RE.match(operand.value)
+                ):
+                    findings.append(PlaceholderFinding(operand.lineno, operand.value))
+    return findings
+
+
+def test_placeholder_fixture_flags_bare_fallback():
+    """Red state, proven in-suite: the exact defect shape yields one finding."""
+    findings = find_placeholder_fallbacks('content = msg.text or "[media]"')
+    assert len(findings) == 1
+    assert findings[0].placeholder == "[media]"
+
+
+def test_placeholder_fixture_ignores_logger_fstring():
+    """A bracketed tag inside a log f-string is not a fallback and stays clean."""
+    findings = find_placeholder_fallbacks('logger.info(f"[media] download failed {e}")')
+    assert findings == []
+
+
+def test_placeholder_fixture_covers_named_placeholders():
+    """Every named placeholder from the plan matches the general shape."""
+    for name in ("[media]", "[image]", "[attachment]", "[document]", "[file]"):
+        findings = find_placeholder_fallbacks(f'x = y or "{name}"')
+        assert len(findings) == 1, f"{name} must be flagged"
+    # A bracketed string in *left* position is not a fallback.
+    assert find_placeholder_fallbacks('x = "[media]" in y or z') == []
+
+
+def test_no_placeholder_fallbacks_across_bridge():
+    """No module in bridge/ falls back to a bare bracketed placeholder."""
+    findings: dict[str, list[PlaceholderFinding]] = {}
+    for path in sorted(BRIDGE_DIR.glob("*.py")):
+        found = find_placeholder_fallbacks(path.read_text())
+        if found:
+            findings[path.name] = found
+    assert not findings, (
+        "Bare placeholder fallback(s) in bridge/ — a constant string standing in "
+        "for content the agent cannot read. Carry the real reference (path, "
+        f"filename, or explicit unreadable marker) instead: {findings}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scan 2: write-only extra_context keys (written for the agent, never read)
+# ---------------------------------------------------------------------------
+
+# Matches the names context payloads travel under: extra_context,
+# extra_context_overrides, extra_overrides, _completed_extra_overrides.
+_EXTRA_CONTEXT_NAME_RE = re.compile(r"extra_(context|overrides)")
+
+
+class ContextWrite(NamedTuple):
+    key: str
+    lineno: int
+
+
+def _bound_name(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _dict_literal_keys(value: ast.expr) -> list[ContextWrite]:
+    if not isinstance(value, ast.Dict):
+        return []
+    return [
+        ContextWrite(k.value, k.lineno)
+        for k in value.keys
+        # `**unpack` entries carry a None key; only literal string keys count.
+        if isinstance(k, ast.Constant) and isinstance(k.value, str)
+    ]
+
+
+def collect_extra_context_writes(source: str) -> list[ContextWrite]:
+    """Collect every key written onto an extra-context payload.
+
+    Three forms (a subscript-only collector under-detects):
+    - ``extra_context["key"] = ...`` (any receiver named like extra context)
+    - ``fn(extra_context={...})`` / ``fn(extra_context_overrides={...})``
+    - ``extra_overrides = {**(extra_overrides or {}), "key": ...}`` — a dict
+      literal bound to an extra-context/overrides name, the shape both
+      ``bridge/telegram_bridge.py`` hydration branches use.
+    """
+    writes: list[ContextWrite] = []
+    for node in ast.walk(ast.parse(source)):
+        targets: list[ast.expr] = []
+        value: ast.expr | None = None
+        if isinstance(node, ast.Assign):
+            targets, value = node.targets, node.value
+        elif isinstance(node, (ast.AnnAssign, ast.AugAssign)):
+            targets, value = [node.target], node.value
+        for target in targets:
+            if isinstance(target, ast.Subscript):
+                receiver = _bound_name(target.value)
+                if (
+                    receiver
+                    and _EXTRA_CONTEXT_NAME_RE.search(receiver)
+                    and isinstance(target.slice, ast.Constant)
+                    and isinstance(target.slice.value, str)
+                ):
+                    writes.append(ContextWrite(target.slice.value, target.lineno))
+            elif isinstance(target, ast.Name) and _EXTRA_CONTEXT_NAME_RE.search(target.id):
+                if value is not None:
+                    writes.extend(_dict_literal_keys(value))
+        if isinstance(node, ast.Call):
+            for kw in node.keywords:
+                if kw.arg and _EXTRA_CONTEXT_NAME_RE.search(kw.arg):
+                    writes.extend(_dict_literal_keys(kw.value))
+    return writes
+
+
+def collect_read_keys(source: str) -> set[str]:
+    """Collect every string key read anywhere in the source.
+
+    Receiver-agnostic but key-position-scoped: real readers use renamed
+    locals (``extra.get("customer_id")``, ``_inj_ctx.get(...)``), so a read is
+    - any Load-context ``Subscript`` whose key is a string constant, on ANY
+      receiver;
+    - any ``.get()`` call whose first argument is a string constant, on ANY
+      receiver;
+    - string-constant membership in a tuple/list being iterated (the
+      ``models/agent_session.py`` ``for key in ("revival_context", ...)``
+      shape).
+
+    Writer statements contribute nothing: a Store-context subscript target and
+    a dict-literal key are not read positions.
+    """
+    reads: set[str] = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Subscript) and isinstance(node.ctx, ast.Load):
+            if isinstance(node.slice, ast.Constant) and isinstance(node.slice.value, str):
+                reads.add(node.slice.value)
+        elif isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Attribute) and func.attr == "get" and node.args:
+                first = node.args[0]
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    reads.add(first.value)
+        elif isinstance(node, (ast.For, ast.AsyncFor, ast.comprehension)):
+            if isinstance(node.iter, (ast.Tuple, ast.List)):
+                for elt in node.iter.elts:
+                    if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                        reads.add(elt.value)
+    return reads
+
+
+def _tracked_python_files() -> list[Path]:
+    """Every tracked .py file present in the working tree."""
+    result = subprocess.run(
+        ["git", "ls-files", "-z", "*.py"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    paths = [REPO_ROOT / rel for rel in result.stdout.split("\0") if rel]
+    return [p for p in paths if p.exists()]
+
+
+def _tree_write_only_keys() -> tuple[dict[str, list[str]], set[str]]:
+    """(writes-by-key with locations, keys read anywhere outside tests/)."""
+    files = _tracked_python_files()
+    writes: dict[str, list[str]] = {}
+    for path in files:
+        rel = path.relative_to(REPO_ROOT)
+        if rel.parts[0] not in ("bridge", "agent"):
+            continue
+        for write in collect_extra_context_writes(path.read_text()):
+            writes.setdefault(write.key, []).append(f"{rel}:{write.lineno}")
+    read_keys: set[str] = set()
+    for path in files:
+        if path.relative_to(REPO_ROOT).parts[0] == "tests":
+            continue
+        read_keys |= collect_read_keys(path.read_text())
+    return writes, read_keys
+
+
+# Derived empirically against the tree; every entry is asserted STILL unread
+# below, so this list can only shrink — landing a reader forces the entry's
+# removal. Email-seam entries are #3136's delivery gap: stamped onto the email
+# session's extra_context in bridge/email_bridge.py and consumed by nothing.
+# (attachments_truncated is NOT here: it is read via parsed.get(...) at
+# bridge/email_bridge.py, so under the receiver-agnostic predicate it has
+# readers.) The two session-snapshot keys are save_session_snapshot metadata
+# serialized wholesale for humans; no code reads them in key position.
+WRITE_ONLY_ALLOW_LIST = {
+    "attachments_unrecoverable",  # known gap: #3136
+    "attachments_recovered_count",  # known gap: #3136
+    "attachments_referenced",  # known gap: #3136
+    "email_attachments",  # known gap: #3136
+    "email_from",  # known gap: #3136 (email transport metadata, same seam)
+    "correlation_id",  # session-snapshot metadata, serialized wholesale
+    "message_preview",  # session-snapshot metadata, serialized wholesale
+}
+
+
+def test_write_only_context_collector_sees_all_three_write_forms():
+    source = textwrap.dedent(
+        """
+        extra_context["alpha"] = 1
+        session.extra_context["beta"] = 2
+        extra_overrides = {**(extra_overrides or {}), "gamma": True}
+        extra_context: dict = {"delta": 4}
+        enqueue(extra_context={"epsilon": 5}, extra_context_overrides={"zeta": 6})
+        """
+    )
+    keys = {w.key for w in collect_extra_context_writes(source)}
+    assert keys == {"alpha", "beta", "gamma", "delta", "epsilon", "zeta"}
+
+
+def test_write_only_context_collector_ignores_unrelated_dicts():
+    source = 'payload["alpha"] = 1\nconfig = {"beta": 2}\nfn(options={"gamma": 3})'
+    assert collect_extra_context_writes(source) == []
+
+
+def test_write_only_context_reader_predicate_is_receiver_agnostic():
+    source = textwrap.dedent(
+        """
+        value = extra.get("customer_id")
+        banner = _inj_ctx["injection_risk_banner"]
+        for key in ("revival_context", "classification_type"):
+            consume(key)
+        """
+    )
+    assert collect_read_keys(source) == {
+        "customer_id",
+        "injection_risk_banner",
+        "revival_context",
+        "classification_type",
+    }
+
+
+def test_write_only_context_writer_statement_is_not_a_read():
+    """A write contributes no read — but a genuine read on its RHS does.
+
+    The second fixture is the bridge/email_bridge.py shape the critique
+    ruled on: ``extra_context["attachments_truncated"] =
+    bool(parsed.get("attachments_truncated"))`` reads the key off a *parsed*
+    payload, so under the receiver-agnostic predicate that key is read and is
+    not a gap.
+    """
+    assert collect_read_keys('extra_context["omega"] = compute()') == set()
+    both = 'extra_context["attachments_truncated"] = bool(parsed.get("attachments_truncated"))'
+    assert collect_read_keys(both) == {"attachments_truncated"}
+    assert {w.key for w in collect_extra_context_writes(both)} == {"attachments_truncated"}
+
+
+def test_write_only_context_allow_list_matches_tree():
+    """Every extra_context write has a reader, except the ratcheted allow-list.
+
+    Fails in two directions:
+    - a NEW write-only key appeared → deliver it to a consumer or (for a
+      deliberate, reviewed gap) add it here;
+    - an allow-listed key gained a reader (or lost its writer) → remove the
+      entry. The allow-list only shrinks.
+    """
+    writes, read_keys = _tree_write_only_keys()
+
+    # Non-vacuity pins: the collector must keep seeing the known real sites.
+    # bridge/email_bridge.py subscript writes:
+    assert "attachments_unrecoverable" in writes, (
+        "collector no longer sees bridge/email_bridge.py's subscript writes — "
+        "the scan went blind, fix the collector before trusting a green run"
+    )
+    # bridge/telegram_bridge.py dict-literal-bound-to-name writes:
+    assert "reply_chain_hydrated" in writes, (
+        "collector no longer sees bridge/telegram_bridge.py's override-dict "
+        "writes — the scan went blind, fix the collector before trusting a "
+        "green run"
+    )
+
+    unread = {key for key in writes if key not in read_keys}
+
+    new_gaps = unread - WRITE_ONLY_ALLOW_LIST
+    assert not new_gaps, (
+        "extra_context key(s) written for the agent but read by nothing "
+        "outside tests/ — context that never arrives is the email-seam "
+        "failure mode (#3136). Wire a reader or add a reviewed allow-list "
+        "entry: " + ", ".join(f"{k} (written at {writes[k]})" for k in sorted(new_gaps))
+    )
+
+    stale = WRITE_ONLY_ALLOW_LIST - unread
+    assert not stale, (
+        "allow-listed extra_context key(s) now have a reader (or the write "
+        f"was removed) — delete the entries, the list only shrinks: {sorted(stale)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scan 3: fetch_reply_chain Redis lookups must run off-loop
+# ---------------------------------------------------------------------------
+
+
+def _is_telegram_filter_call(node: ast.AST) -> bool:
+    """``TelegramMessage.query.filter(...)`` call shape."""
+    if not isinstance(node, ast.Call):
+        return False
+    f = node.func
+    return (
+        isinstance(f, ast.Attribute)
+        and f.attr == "filter"
+        and isinstance(f.value, ast.Attribute)
+        and f.value.attr == "query"
+        and isinstance(f.value.value, ast.Name)
+        and f.value.value.id == "TelegramMessage"
+    )
+
+
+def _has_to_thread_ancestor(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> bool:
+    current = parents.get(node)
+    while current is not None:
+        if isinstance(current, ast.Call):
+            f = current.func
+            if (
+                isinstance(f, ast.Attribute)
+                and f.attr == "to_thread"
+                and isinstance(f.value, ast.Name)
+                and f.value.id == "asyncio"
+            ):
+                return True
+        current = parents.get(current)
+    return False
+
+
+def find_inline_filter_calls(source: str, func_name: str = "fetch_reply_chain") -> list[int]:
+    """Line numbers of ``TelegramMessage.query.filter`` calls inside the async
+    function ``func_name`` that have no ``asyncio.to_thread`` ancestor call.
+
+    Raises ``ValueError`` when no ``async def`` of that name exists, so the
+    tree test cannot pass vacuously by the function being renamed away.
+    """
+    func: ast.AsyncFunctionDef | None = None
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == func_name:
+            func = node
+            break
+    if func is None:
+        raise ValueError(f"no async def {func_name} found")
+
+    parents: dict[ast.AST, ast.AST] = {}
+    for parent in ast.walk(func):
+        for child in ast.iter_child_nodes(parent):
+            parents[child] = parent
+
+    return [
+        node.lineno
+        for node in ast.walk(func)
+        if _is_telegram_filter_call(node) and not _has_to_thread_ancestor(node, parents)
+    ]
+
+
+def find_inline_filter_calls_by_async_function(source: str) -> dict[str, list[int]]:
+    """Map each async function to its unwrapped ``TelegramMessage.query.filter``
+    calls, module-wide. Only functions with at least one violation appear.
+
+    This exists because the chain-walk lookup is factored into a helper
+    (``_resolve_media_descriptor``) that ``fetch_reply_chain`` awaits — a scan
+    scoped to ``fetch_reply_chain``'s own body would be vacuous against the
+    real tree, which is the Risk 5 failure mode.
+    """
+    violations: dict[str, list[int]] = {}
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.AsyncFunctionDef):
+            continue
+        parents: dict[ast.AST, ast.AST] = {}
+        for parent in ast.walk(node):
+            for child in ast.iter_child_nodes(parent):
+                parents[child] = parent
+        inline = [
+            call.lineno
+            for call in ast.walk(node)
+            if _is_telegram_filter_call(call) and not _has_to_thread_ancestor(call, parents)
+        ]
+        if inline:
+            violations[node.name] = inline
+    return violations
+
+
+_OFF_LOOP_INLINE_FIXTURE = textwrap.dedent(
+    """
+    async def fetch_reply_chain(client, chat_id, msg_id):
+        records = list(TelegramMessage.query.filter(chat_id=str(chat_id), message_id=msg_id))
+        return records
+    """
+)
+
+_OFF_LOOP_WRAPPED_FIXTURE = textwrap.dedent(
+    """
+    async def fetch_reply_chain(client, chat_id, msg_id):
+        records = await asyncio.to_thread(
+            lambda: list(TelegramMessage.query.filter(chat_id=str(chat_id), message_id=msg_id))
+        )
+        return records
+    """
+)
+
+
+def test_off_loop_fixture_inline_filter_is_flagged():
+    """An inline blocking filter inside the async def must fail the predicate."""
+    assert len(find_inline_filter_calls(_OFF_LOOP_INLINE_FIXTURE)) == 1
+
+
+def test_off_loop_fixture_to_thread_wrapped_passes():
+    """The sanctioned asyncio.to_thread(lambda: ...) shape passes."""
+    assert find_inline_filter_calls(_OFF_LOOP_WRAPPED_FIXTURE) == []
+
+
+def test_off_loop_fixture_missing_function_raises():
+    """A renamed-away fetch_reply_chain is an error, never a vacuous pass."""
+    with pytest.raises(ValueError):
+        find_inline_filter_calls("async def something_else():\n    pass\n")
+
+
+def test_off_loop_fixture_covers_helper_factoring():
+    """The real tree factors the lookup into a helper fetch_reply_chain awaits;
+    the module-wide scan must flag an inline call there too."""
+    source = textwrap.dedent(
+        """
+        async def _resolve(msg, chat_id):
+            return list(TelegramMessage.query.filter(chat_id=str(chat_id), message_id=msg.id))
+
+        async def fetch_reply_chain(client, chat_id, msg_id):
+            return await _resolve(None, chat_id)
+        """
+    )
+    assert list(find_inline_filter_calls_by_async_function(source)) == ["_resolve"]
+
+
+# _cache_walk_root's inline filter is a pre-existing defect of the same shape,
+# explicitly out of scope for #2732 (plan No-Gos: moving it off-loop changes
+# root-resolution cache behavior under load and deserves its own issue). The
+# stale check below forces this exemption's removal the moment it is fixed.
+_OFF_LOOP_EXEMPT_FUNCTIONS = {"_cache_walk_root"}
+
+
+def test_fetch_reply_chain_lookups_are_off_loop():
+    """Every TelegramMessage.query.filter in bridge/context.py's async
+    functions is wrapped in asyncio.to_thread — the mechanical backstop for
+    Risk 4 — except the ratcheted pre-existing exemption above. Scoped
+    module-wide because the chain-walk lookup lives in the
+    _resolve_media_descriptor helper, not lexically inside fetch_reply_chain.
+    """
+    source = (BRIDGE_DIR / "context.py").read_text()
+    # Anchor: the walk entry point must still exist (raises if renamed away)
+    # and must itself contain no inline lookup.
+    assert find_inline_filter_calls(source, "fetch_reply_chain") == []
+
+    by_function = find_inline_filter_calls_by_async_function(source)
+    violations = {
+        name: lines for name, lines in by_function.items() if name not in _OFF_LOOP_EXEMPT_FUNCTIONS
+    }
+    assert not violations, (
+        "inline blocking TelegramMessage.query.filter call(s) in "
+        f"bridge/context.py: {violations} — Popoto is synchronous redis-py; "
+        "wrap the lookup in asyncio.to_thread so the callers' 3s "
+        "asyncio.wait_for guard can actually preempt the walk (Risk 4)"
+    )
+
+    # Ratchet: every exemption must still match a real inline call, so a
+    # stale entry fails loudly instead of silently widening the guard.
+    stale = _OFF_LOOP_EXEMPT_FUNCTIONS - set(by_function)
+    assert not stale, (
+        f"off-loop exemption(s) no longer match an inline call: {sorted(stale)} "
+        "— the pre-existing defect was fixed, delete the exemption"
+    )

--- a/tests/unit/test_context_helpers.py
+++ b/tests/unit/test_context_helpers.py
@@ -778,6 +778,25 @@ class TestResolveMediaDescriptor:
         assert descriptor["media_type"] is None
         assert descriptor["filename"] == "media-7"
 
+    async def test_link_preview_message_yields_no_descriptor(self, chain_chat_id):
+        """Regression (PR #3146 review): MessageMediaWebPage is set on any
+        plain-text message that gets a link preview. It must never be
+        treated as an attachment, even though Telethon's Message.file can
+        fall back to the web preview's own photo/document and read truthy."""
+        from telethon.tl.types import MessageMediaWebPage, WebPageEmpty
+
+        from bridge.context import _resolve_media_descriptor
+
+        web_page_media = MessageMediaWebPage(webpage=WebPageEmpty(id=1))
+        msg = _FakeChainMsg(
+            555,
+            text="check this out https://example.com",
+            media=web_page_media,
+            file=_FakeFile("example.com"),
+        )
+        descriptor = await _resolve_media_descriptor(msg, chain_chat_id)
+        assert descriptor is None, "a link-preview message must not render an attachment marker"
+
     async def test_chat_id_scoped_lookup_ignores_other_chats_record(self, chain_chat_id):
         """Risk 3: a record with a matching message_id in a DIFFERENT chat
         must never resolve — message ids are per-chat sequences and the

--- a/tests/unit/test_context_helpers.py
+++ b/tests/unit/test_context_helpers.py
@@ -28,11 +28,32 @@ class TestReplyThreadContextHeader:
     def test_format_reply_chain_uses_the_constant(self):
         from bridge.context import format_reply_chain
 
-        chain = [{"sender": "Tom", "content": "hello", "message_id": 1, "date": None}]
-        formatted = format_reply_chain(chain)
-        # Idempotency guard in agent_session_queue relies on this substring.
-        assert REPLY_THREAD_CONTEXT_HEADER in formatted
-        assert formatted.count(REPLY_THREAD_CONTEXT_HEADER) == 1
+        # #2732: chain dicts now carry a `media` key. The header contract must
+        # hold with the key absent (legacy dict shape), None, and populated.
+        chains = [
+            [{"sender": "Tom", "content": "hello", "message_id": 1, "date": None}],
+            [{"sender": "Tom", "content": "hello", "message_id": 1, "date": None, "media": None}],
+            [
+                {
+                    "sender": "Tom",
+                    "content": "hello",
+                    "message_id": 1,
+                    "date": None,
+                    "media": {
+                        "kind": "resolved",
+                        "filename": "a.pdf",
+                        "media_type": "document",
+                        "local_path": "/tmp/a.pdf",
+                        "reason": None,
+                    },
+                }
+            ],
+        ]
+        for chain in chains:
+            formatted = format_reply_chain(chain)
+            # Idempotency guard in agent_session_queue relies on this substring.
+            assert REPLY_THREAD_CONTEXT_HEADER in formatted
+            assert formatted.count(REPLY_THREAD_CONTEXT_HEADER) == 1
 
 
 class TestReferencesPriorContextNegativeGuards:
@@ -272,6 +293,24 @@ class TestFilterToolLogsParity:
         assert "Here is the analysis you asked for." in formatted
         assert "The duplicate definition is at line 104." in formatted
 
+        # #2732: sanitisation must still apply on a composed caption-plus-
+        # descriptor line. The descriptor is appended AFTER filter_tool_logs
+        # runs, so the traces stay filtered and the descriptor stays intact.
+        chain[1]["media"] = {
+            "kind": "resolved",
+            "filename": "trace.log",
+            "media_type": "document",
+            "local_path": "/data/media/doc_1_2.log",
+            "reason": None,
+        }
+        composed = format_reply_chain(chain)
+        assert "\U0001f6e0" not in composed, "wrench emoji tool trace leaked past descriptor"
+        assert "`cd bridge && ls -la`" not in composed, "backtick echo leaked past descriptor"
+        assert "Here is the analysis you asked for." in composed
+        assert "[attachment: trace.log (document) at machine path /data/media/doc_1_2.log]" in (
+            composed
+        )
+
     def test_format_reply_chain_omits_messages_below_length_floor(self):
         """Through-pipeline assertion: when `filter_tool_logs` returns `""`
         because the post-filter remainder is below the `<5` char floor,
@@ -304,3 +343,546 @@ class TestFilterToolLogsParity:
         # The surrounding messages must still be present.
         assert "Tom: run ls" in formatted
         assert "Tom: thanks" in formatted
+
+
+# =============================================================================
+# #2732: reply-chain media descriptor — rendering states, resolver, walk
+# =============================================================================
+
+
+def _descriptor(
+    kind="resolved",
+    filename="report.pdf",
+    media_type="document",
+    local_path="/data/media/doc_1_10.pdf",
+    reason=None,
+):
+    from bridge.context import _media_descriptor
+
+    return _media_descriptor(kind, filename, media_type, local_path, reason)
+
+
+class TestMediaDescriptorRendering:
+    """The three rendering states of format_reply_chain (#2732).
+
+    All chain dicts here are built by hand — the renderer is pure, so these
+    need neither Redis nor a Telegram client.
+    """
+
+    def test_resolved_with_caption_composes_both(self):
+        from bridge.context import format_reply_chain
+
+        chain = [
+            {
+                "sender": "Hazem",
+                "content": "here is the recommendation",
+                "message_id": 10,
+                "date": None,
+                "media": _descriptor(),
+            }
+        ]
+        formatted = format_reply_chain(chain)
+        line = next(ln for ln in formatted.splitlines() if ln.startswith("Hazem:"))
+        assert "here is the recommendation" in line
+        assert "[attachment: report.pdf (document) at machine path /data/media/doc_1_10.pdf]" in (
+            line
+        ), "caption and descriptor must compose on ONE line"
+
+    def test_resolved_without_caption_renders_descriptor_alone(self):
+        from bridge.context import format_reply_chain
+
+        chain = [
+            {
+                "sender": "Hazem",
+                "content": "",
+                "message_id": 10,
+                "date": None,
+                "media": _descriptor(),
+            }
+        ]
+        formatted = format_reply_chain(chain)
+        assert (
+            "Hazem: [attachment: report.pdf (document) at machine path /data/media/doc_1_10.pdf]"
+            in formatted
+        ), "caption-less hop must render the descriptor alone, with no leading space"
+
+    def test_text_only_chain_is_byte_identical_with_and_without_media_key(self):
+        """Regression fence: a text-only chain renders exactly as before #2732,
+        whether the entry omits the media key (legacy shape) or carries
+        media=None (new shape)."""
+        from bridge.context import format_reply_chain
+
+        legacy = [
+            {"sender": "Tom", "content": "hello", "message_id": 1, "date": None},
+            {
+                "sender": "Valor",
+                "content": "hi there, what do you need?",
+                "message_id": 2,
+                "date": None,
+            },
+        ]
+        new_shape = [dict(entry, media=None) for entry in legacy]
+        expected = (
+            f"{REPLY_THREAD_CONTEXT_HEADER} (oldest to newest):\n"
+            + "-" * 40
+            + "\nTom: hello\n\nValor: hi there, what do you need?\n\n"
+            + "-" * 40
+        )
+        assert format_reply_chain(legacy) == expected
+        assert format_reply_chain(new_shape) == expected
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            "no_record",
+            "no_path_recorded",
+            "download_error: timeout",
+            "file_missing",
+            "invalid_path",
+            "resolution_error",
+        ],
+    )
+    def test_unreadable_rendering_names_file_and_reason(self, reason):
+        from bridge.context import format_reply_chain
+
+        chain = [
+            {
+                "sender": "Hazem",
+                "content": "",
+                "message_id": 10,
+                "date": None,
+                "media": _descriptor(kind="unreadable", local_path=None, reason=reason),
+            }
+        ]
+        formatted = format_reply_chain(chain)
+        assert f"[unreadable attachment: report.pdf (document) reason: {reason}]" in formatted
+
+    def test_resolved_and_unreadable_renderings_are_distinguishable(self):
+        from bridge.context import _format_media_descriptor
+
+        resolved = _format_media_descriptor(_descriptor())
+        unreadable = _format_media_descriptor(
+            _descriptor(kind="unreadable", local_path=None, reason="no_record")
+        )
+        assert resolved != unreadable
+        # Each state carries a marker the other never does, so an agent (and a
+        # test) can tell them apart without heuristics.
+        assert "at machine path" in resolved and "at machine path" not in unreadable
+        assert "unreadable attachment:" in unreadable and "unreadable attachment:" not in resolved
+
+    def test_media_literal_appears_in_no_rendering_state(self):
+        """The literal `[media]` must appear in no output under any state."""
+        from bridge.context import format_reply_chain
+
+        chains = [
+            [{"sender": "Tom", "content": "text only", "message_id": 1, "date": None}],
+            [
+                {
+                    "sender": "Tom",
+                    "content": "cap",
+                    "message_id": 1,
+                    "date": None,
+                    "media": _descriptor(),
+                }
+            ],
+            [
+                {
+                    "sender": "Tom",
+                    "content": "",
+                    "message_id": 1,
+                    "date": None,
+                    "media": _descriptor(),
+                }
+            ],
+            [
+                {
+                    "sender": "Tom",
+                    "content": "",
+                    "message_id": 1,
+                    "date": None,
+                    "media": _descriptor(kind="unreadable", local_path=None, reason="no_record"),
+                }
+            ],
+            [
+                {
+                    "sender": "Valor",
+                    "content": "",
+                    "message_id": 1,
+                    "date": None,
+                    "media": _descriptor(
+                        kind="unreadable",
+                        filename=None,
+                        media_type=None,
+                        local_path=None,
+                        reason="resolution_error",
+                    ),
+                }
+            ],
+        ]
+        for chain in chains:
+            assert "[media]" not in format_reply_chain(chain)
+
+    def test_filename_none_renders_unnamed_not_dangling(self):
+        from bridge.context import _format_media_descriptor
+
+        rendered = _format_media_descriptor(
+            _descriptor(kind="unreadable", filename=None, local_path=None, reason="no_record")
+        )
+        assert rendered == "[unreadable attachment: unnamed (document) reason: no_record]"
+
+    def test_media_type_none_renders_generic_label(self):
+        from bridge.context import _format_media_descriptor
+
+        rendered = _format_media_descriptor(_descriptor(media_type=None))
+        assert rendered == (
+            "[attachment: report.pdf (file) at machine path /data/media/doc_1_10.pdf]"
+        )
+
+    def test_empty_chain_still_returns_empty_string(self):
+        from bridge.context import format_reply_chain
+
+        assert format_reply_chain([]) == ""
+
+    def test_below_floor_valor_hop_with_media_is_retained(self):
+        """Sibling of test_format_reply_chain_omits_messages_below_length_floor:
+        a Valor hop whose text filters below the <5 floor is RETAINED when it
+        carries media — its descriptor is the whole line. This is the case the
+        old 7-char "[media]" string was accidentally protecting."""
+        from bridge.context import format_reply_chain
+
+        valor_short = "\U0001f6e0️ exec: ls\nok"
+        chain = [
+            {"sender": "Tom", "content": "run ls", "message_id": 1, "date": None},
+            {
+                "sender": "Valor",
+                "content": valor_short,
+                "message_id": 2,
+                "date": None,
+                "media": _descriptor(
+                    kind="unreadable",
+                    filename="shot.png",
+                    media_type="photo",
+                    local_path=None,
+                    reason="no_path_recorded",
+                ),
+            },
+            {"sender": "Tom", "content": "thanks", "message_id": 3, "date": None},
+        ]
+        formatted = format_reply_chain(chain)
+        assert "Valor: [unreadable attachment: shot.png (photo) reason: no_path_recorded]" in (
+            formatted
+        ), "below-floor Valor hop with media must be retained as its descriptor"
+        assert "ok" not in formatted, "below-floor text remainder must still be dropped"
+
+    def test_truncation_never_bisects_descriptor_path(self):
+        """Truncation measures the human-authored text only; the descriptor
+        (and its path) is appended afterwards, intact."""
+        from bridge.context import format_reply_chain
+
+        long_caption = "x" * 600  # over the 500-char non-Valor cap
+        path = "/data/media/doc_1_10.pdf"
+        chain = [
+            {
+                "sender": "Tom",
+                "content": long_caption,
+                "message_id": 10,
+                "date": None,
+                "media": _descriptor(local_path=path),
+            },
+        ]
+        formatted = format_reply_chain(chain)
+        assert "x" * 500 + "..." in formatted, "caption must still truncate at 500"
+        assert "x" * 501 not in formatted
+        assert f"at machine path {path}]" in formatted, "path must survive truncation intact"
+
+
+class _FakeFile:
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeSender:
+    first_name = "Hazem"
+
+
+class _FakeChainMsg:
+    """Minimal Telethon Message stand-in for the resolver and the chain walk."""
+
+    def __init__(self, id, text="", reply_to=None, media=None, file=None, out=False):
+        self.id = id
+        self.text = text
+        self.reply_to_msg_id = reply_to
+        self.media = media
+        self.file = file
+        self.out = out
+        self.date = None
+
+    async def get_sender(self):
+        return _FakeSender()
+
+
+class _FakeChainClient:
+    def __init__(self, msgs):
+        self._msgs = {m.id: m for m in msgs}
+
+    async def get_messages(self, chat_id, ids=None):
+        return self._msgs.get(ids)
+
+
+def _save_telegram_record(chat_id: int, message_id: int, **fields):
+    import time as _time
+
+    from models.telegram import TelegramMessage
+
+    record = TelegramMessage(
+        chat_id=str(chat_id),
+        message_id=message_id,
+        direction="in",
+        sender="Hazem",
+        content="",
+        timestamp=_time.time(),
+        has_media=True,
+        **fields,
+    )
+    record.save()
+    return record
+
+
+@pytest.fixture
+def chain_chat_id():
+    """Unique chat id per test; deletes that chat's records on teardown."""
+    import uuid
+
+    from models.telegram import TelegramMessage
+
+    chat_id = int(uuid.uuid4().int % 10**9) + 10**9
+    yield chat_id
+    for record in TelegramMessage.query.filter(chat_id=str(chat_id)):
+        record.delete()
+
+
+class TestResolveMediaDescriptor:
+    """_resolve_media_descriptor against real TelegramMessage records in the
+    claimed test Redis db. Each unreadable reason is a distinct, asserted
+    state (#2732 Failure Path Test Strategy)."""
+
+    async def test_no_media_returns_none(self, chain_chat_id):
+        from bridge.context import _resolve_media_descriptor
+
+        msg = _FakeChainMsg(10, text="plain text")
+        assert await _resolve_media_descriptor(msg, chain_chat_id) is None
+
+    async def test_missing_record_is_unreadable_no_record(self, chain_chat_id):
+        from bridge.context import _resolve_media_descriptor
+
+        msg = _FakeChainMsg(10, media=object(), file=_FakeFile("report.pdf"))
+        descriptor = await _resolve_media_descriptor(msg, chain_chat_id)
+        assert descriptor["kind"] == "unreadable"
+        assert descriptor["reason"] == "no_record"
+        assert descriptor["filename"] == "report.pdf", (
+            "a Redis miss must still yield a NAMED attachment — the two sources degrade separately"
+        )
+        assert descriptor["local_path"] is None
+
+    async def test_download_error_is_unreadable_with_specific_reason(self, chain_chat_id):
+        from bridge.context import _resolve_media_descriptor
+
+        _save_telegram_record(chain_chat_id, 10, media_download_error="timeout after 120s")
+        msg = _FakeChainMsg(10, media=object(), file=_FakeFile("report.pdf"))
+        descriptor = await _resolve_media_descriptor(msg, chain_chat_id)
+        assert descriptor["kind"] == "unreadable"
+        assert descriptor["reason"] == "download_error: timeout after 120s"
+
+    async def test_missing_path_is_unreadable_no_path_recorded(self, chain_chat_id):
+        from bridge.context import _resolve_media_descriptor
+
+        _save_telegram_record(chain_chat_id, 10, media_local_path=None)
+        msg = _FakeChainMsg(10, media=object(), file=_FakeFile("report.pdf"))
+        descriptor = await _resolve_media_descriptor(msg, chain_chat_id)
+        assert descriptor["kind"] == "unreadable"
+        assert descriptor["reason"] == "no_path_recorded"
+
+    async def test_whitespace_path_is_unreadable_no_path_recorded(self, chain_chat_id):
+        from bridge.context import _resolve_media_descriptor
+
+        _save_telegram_record(chain_chat_id, 10, media_local_path="   ")
+        msg = _FakeChainMsg(10, media=object(), file=_FakeFile("report.pdf"))
+        descriptor = await _resolve_media_descriptor(msg, chain_chat_id)
+        assert descriptor["kind"] == "unreadable"
+        assert descriptor["reason"] == "no_path_recorded"
+
+    async def test_path_outside_media_dir_is_unreadable_invalid_path(self, chain_chat_id):
+        from bridge.context import _resolve_media_descriptor
+
+        # /etc/hosts exists and is readable — outside data/media it must
+        # still never be rendered as a resolved path.
+        _save_telegram_record(chain_chat_id, 10, media_local_path="/etc/hosts")
+        msg = _FakeChainMsg(10, media=object(), file=_FakeFile("report.pdf"))
+        descriptor = await _resolve_media_descriptor(msg, chain_chat_id)
+        assert descriptor["kind"] == "unreadable"
+        assert descriptor["reason"] == "invalid_path"
+        assert descriptor["local_path"] is None
+
+    async def test_recorded_path_absent_from_disk_is_unreadable_file_missing(self, chain_chat_id):
+        import uuid
+
+        from bridge.context import _resolve_media_descriptor
+        from bridge.media import MEDIA_DIR
+
+        ghost = MEDIA_DIR / f"test2732_ghost_{uuid.uuid4().hex}.pdf"
+        _save_telegram_record(chain_chat_id, 10, media_local_path=str(ghost))
+        msg = _FakeChainMsg(10, media=object(), file=_FakeFile("report.pdf"))
+        descriptor = await _resolve_media_descriptor(msg, chain_chat_id)
+        assert descriptor["kind"] == "unreadable"
+        assert descriptor["reason"] == "file_missing"
+
+    async def test_resolved_when_record_and_file_exist(self, chain_chat_id, tmp_path):
+        import uuid
+
+        from bridge.context import _resolve_media_descriptor
+        from bridge.media import MEDIA_DIR
+
+        real = MEDIA_DIR / f"test2732_{uuid.uuid4().hex}.pdf"
+        real.write_bytes(b"%PDF test")
+        try:
+            _save_telegram_record(chain_chat_id, 10, media_local_path=str(real))
+            msg = _FakeChainMsg(10, media=object(), file=_FakeFile("report.pdf"))
+            descriptor = await _resolve_media_descriptor(msg, chain_chat_id)
+            assert descriptor["kind"] == "resolved"
+            assert descriptor["filename"] == "report.pdf"
+            assert descriptor["local_path"] == str(real)
+            assert descriptor["reason"] is None
+        finally:
+            real.unlink(missing_ok=True)
+
+    async def test_photo_without_filename_gets_synthetic_label(self, chain_chat_id):
+        from telethon.tl.types import MessageMediaPhoto
+
+        from bridge.context import _resolve_media_descriptor
+
+        photo_media = MessageMediaPhoto.__new__(MessageMediaPhoto)
+        msg = _FakeChainMsg(42, media=photo_media, file=_FakeFile(None))
+        descriptor = await _resolve_media_descriptor(msg, chain_chat_id)
+        assert descriptor["media_type"] == "photo"
+        assert descriptor["filename"] == "photo-42", (
+            "photos have no filename — the synthetic {media_type}-{message_id} label must apply"
+        )
+
+    async def test_unknown_media_type_still_yields_descriptor(self, chain_chat_id):
+        from bridge.context import _resolve_media_descriptor
+
+        # get_media_type returns None for a non-Telethon media object; the
+        # descriptor must degrade to a generic label rather than crash.
+        msg = _FakeChainMsg(7, media=object(), file=_FakeFile(None))
+        descriptor = await _resolve_media_descriptor(msg, chain_chat_id)
+        assert descriptor["media_type"] is None
+        assert descriptor["filename"] == "media-7"
+
+    async def test_chat_id_scoped_lookup_ignores_other_chats_record(self, chain_chat_id):
+        """Risk 3: a record with a matching message_id in a DIFFERENT chat
+        must never resolve — message ids are per-chat sequences and the
+        media dir is shared across every chat on the machine."""
+        import uuid
+
+        from bridge.context import _resolve_media_descriptor
+        from bridge.media import MEDIA_DIR
+        from models.telegram import TelegramMessage
+
+        other_chat = chain_chat_id + 1
+        other_file = MEDIA_DIR / f"test2732_other_{uuid.uuid4().hex}.pdf"
+        other_file.write_bytes(b"%PDF other tenant")
+        try:
+            _save_telegram_record(other_chat, 10, media_local_path=str(other_file))
+            msg = _FakeChainMsg(10, media=object(), file=_FakeFile("report.pdf"))
+            descriptor = await _resolve_media_descriptor(msg, chain_chat_id)
+            assert descriptor["kind"] == "unreadable"
+            assert descriptor["reason"] == "no_record"
+            assert descriptor["local_path"] is None, (
+                "another chat's file must be unnameable through this resolver"
+            )
+        finally:
+            other_file.unlink(missing_ok=True)
+            for record in TelegramMessage.query.filter(chat_id=str(other_chat)):
+                record.delete()
+
+    async def test_resolver_failure_logs_warning_and_returns_unreadable(
+        self, chain_chat_id, caplog
+    ):
+        """The resolver's own except path: log at warning, return an
+        unreadable descriptor — never None, never a re-raise."""
+        import logging
+        from unittest.mock import patch
+
+        from bridge.context import _resolve_media_descriptor
+
+        msg = _FakeChainMsg(99, media=object(), file=_FakeFile("report.pdf"))
+        with (
+            patch("bridge.context.get_media_type", side_effect=RuntimeError("boom")),
+            caplog.at_level(logging.WARNING, logger="bridge.context"),
+        ):
+            descriptor = await _resolve_media_descriptor(msg, chain_chat_id)
+        assert descriptor is not None
+        assert descriptor["kind"] == "unreadable"
+        assert descriptor["reason"] == "resolution_error"
+        assert any("Could not resolve media descriptor" in rec.message for rec in caplog.records), (
+            "resolver failure must be observable at WARNING"
+        )
+
+
+class TestFetchReplyChainMediaFailurePath:
+    """A per-hop descriptor-resolution failure must degrade that hop and let
+    the walk continue — it must never reach fetch_reply_chain's loop-tail
+    `except Exception: break` (#2732 Failure Path Test Strategy)."""
+
+    async def test_hop_resolution_failure_degrades_and_walk_continues(self, chain_chat_id):
+        from unittest.mock import patch
+
+        from bridge.context import fetch_reply_chain
+
+        msgs = [
+            _FakeChainMsg(1, text="", media=object(), file=_FakeFile("doc.pdf")),
+            _FakeChainMsg(2, text="middle reply", reply_to=1),
+            _FakeChainMsg(3, text="latest reply", reply_to=2),
+        ]
+        client = _FakeChainClient(msgs)
+
+        def _exploding_get_media_type(m):
+            raise RuntimeError("classifier exploded")
+
+        with patch("bridge.context.get_media_type", _exploding_get_media_type):
+            chain = await fetch_reply_chain(client, chain_chat_id, 3)
+
+        assert len(chain) == 3, "one bad hop must not lose the rest of the walk"
+        # Chronological order: the media hop is oldest (first).
+        assert chain[0]["media"] is not None
+        assert chain[0]["media"]["kind"] == "unreadable"
+        assert chain[0]["media"]["reason"] == "resolution_error"
+        assert chain[1]["media"] is None
+        assert chain[2]["media"] is None
+        assert [entry["content"] for entry in chain] == ["", "middle reply", "latest reply"]
+
+    async def test_media_hop_end_to_end_renders_resolved_path(self, chain_chat_id):
+        """The reported exchange shape (attachment, then two text replies)
+        through fetch_reply_chain + format_reply_chain: the rendered block
+        carries the readable absolute path and no `[media]` literal."""
+        import uuid
+
+        from bridge.context import fetch_reply_chain, format_reply_chain
+        from bridge.media import MEDIA_DIR
+
+        real = MEDIA_DIR / f"test2732_e2e_{uuid.uuid4().hex}.pdf"
+        real.write_bytes(b"%PDF chain")
+        try:
+            _save_telegram_record(chain_chat_id, 1, media_local_path=str(real))
+            msgs = [
+                _FakeChainMsg(1, text="", media=object(), file=_FakeFile("recommendation.pdf")),
+                _FakeChainMsg(2, text="brushes over many details", reply_to=1),
+                _FakeChainMsg(3, text="valor can help flesh this out", reply_to=2),
+            ]
+            chain = await fetch_reply_chain(_FakeChainClient(msgs), chain_chat_id, 3)
+            formatted = format_reply_chain(chain)
+            assert str(real) in formatted, "agent must receive the readable absolute path"
+            assert "recommendation.pdf" in formatted
+            assert "[media]" not in formatted
+        finally:
+            real.unlink(missing_ok=True)

--- a/tests/unit/test_context_helpers.py
+++ b/tests/unit/test_context_helpers.py
@@ -605,6 +605,19 @@ class _FakeSender:
     first_name = "Hazem"
 
 
+def _document_media(filename: str = "report.pdf"):
+    """A genuine MessageMediaDocument that get_media_type classifies as
+    "document" — the resolver's gate is the repo's own classifier (PR #3146
+    review round 2), so descriptor tests must use media it accepts."""
+    from types import SimpleNamespace
+
+    from telethon.tl.types import DocumentAttributeFilename, MessageMediaDocument
+
+    media = MessageMediaDocument.__new__(MessageMediaDocument)
+    media.document = SimpleNamespace(attributes=[DocumentAttributeFilename(file_name=filename)])
+    return media
+
+
 class _FakeChainMsg:
     """Minimal Telethon Message stand-in for the resolver and the chain walk."""
 
@@ -675,7 +688,7 @@ class TestResolveMediaDescriptor:
     async def test_missing_record_is_unreadable_no_record(self, chain_chat_id):
         from bridge.context import _resolve_media_descriptor
 
-        msg = _FakeChainMsg(10, media=object(), file=_FakeFile("report.pdf"))
+        msg = _FakeChainMsg(10, media=_document_media(), file=_FakeFile("report.pdf"))
         descriptor = await _resolve_media_descriptor(msg, chain_chat_id)
         assert descriptor["kind"] == "unreadable"
         assert descriptor["reason"] == "no_record"
@@ -688,7 +701,7 @@ class TestResolveMediaDescriptor:
         from bridge.context import _resolve_media_descriptor
 
         _save_telegram_record(chain_chat_id, 10, media_download_error="timeout after 120s")
-        msg = _FakeChainMsg(10, media=object(), file=_FakeFile("report.pdf"))
+        msg = _FakeChainMsg(10, media=_document_media(), file=_FakeFile("report.pdf"))
         descriptor = await _resolve_media_descriptor(msg, chain_chat_id)
         assert descriptor["kind"] == "unreadable"
         assert descriptor["reason"] == "download_error: timeout after 120s"
@@ -697,7 +710,7 @@ class TestResolveMediaDescriptor:
         from bridge.context import _resolve_media_descriptor
 
         _save_telegram_record(chain_chat_id, 10, media_local_path=None)
-        msg = _FakeChainMsg(10, media=object(), file=_FakeFile("report.pdf"))
+        msg = _FakeChainMsg(10, media=_document_media(), file=_FakeFile("report.pdf"))
         descriptor = await _resolve_media_descriptor(msg, chain_chat_id)
         assert descriptor["kind"] == "unreadable"
         assert descriptor["reason"] == "no_path_recorded"
@@ -706,7 +719,7 @@ class TestResolveMediaDescriptor:
         from bridge.context import _resolve_media_descriptor
 
         _save_telegram_record(chain_chat_id, 10, media_local_path="   ")
-        msg = _FakeChainMsg(10, media=object(), file=_FakeFile("report.pdf"))
+        msg = _FakeChainMsg(10, media=_document_media(), file=_FakeFile("report.pdf"))
         descriptor = await _resolve_media_descriptor(msg, chain_chat_id)
         assert descriptor["kind"] == "unreadable"
         assert descriptor["reason"] == "no_path_recorded"
@@ -717,7 +730,7 @@ class TestResolveMediaDescriptor:
         # /etc/hosts exists and is readable — outside data/media it must
         # still never be rendered as a resolved path.
         _save_telegram_record(chain_chat_id, 10, media_local_path="/etc/hosts")
-        msg = _FakeChainMsg(10, media=object(), file=_FakeFile("report.pdf"))
+        msg = _FakeChainMsg(10, media=_document_media(), file=_FakeFile("report.pdf"))
         descriptor = await _resolve_media_descriptor(msg, chain_chat_id)
         assert descriptor["kind"] == "unreadable"
         assert descriptor["reason"] == "invalid_path"
@@ -731,7 +744,7 @@ class TestResolveMediaDescriptor:
 
         ghost = MEDIA_DIR / f"test2732_ghost_{uuid.uuid4().hex}.pdf"
         _save_telegram_record(chain_chat_id, 10, media_local_path=str(ghost))
-        msg = _FakeChainMsg(10, media=object(), file=_FakeFile("report.pdf"))
+        msg = _FakeChainMsg(10, media=_document_media(), file=_FakeFile("report.pdf"))
         descriptor = await _resolve_media_descriptor(msg, chain_chat_id)
         assert descriptor["kind"] == "unreadable"
         assert descriptor["reason"] == "file_missing"
@@ -746,7 +759,7 @@ class TestResolveMediaDescriptor:
         real.write_bytes(b"%PDF test")
         try:
             _save_telegram_record(chain_chat_id, 10, media_local_path=str(real))
-            msg = _FakeChainMsg(10, media=object(), file=_FakeFile("report.pdf"))
+            msg = _FakeChainMsg(10, media=_document_media(), file=_FakeFile("report.pdf"))
             descriptor = await _resolve_media_descriptor(msg, chain_chat_id)
             assert descriptor["kind"] == "resolved"
             assert descriptor["filename"] == "report.pdf"
@@ -768,15 +781,70 @@ class TestResolveMediaDescriptor:
             "photos have no filename — the synthetic {media_type}-{message_id} label must apply"
         )
 
-    async def test_unknown_media_type_still_yields_descriptor(self, chain_chat_id):
+    async def test_unknown_extension_document_still_yields_descriptor(self, chain_chat_id):
         from bridge.context import _resolve_media_descriptor
 
-        # get_media_type returns None for a non-Telethon media object; the
-        # descriptor must degrade to a generic label rather than crash.
-        msg = _FakeChainMsg(7, media=object(), file=_FakeFile(None))
+        # A genuine document with an extension no classifier bucket knows is
+        # still a downloadable file: it classifies as "document" and must
+        # yield a descriptor rather than vanish.
+        msg = _FakeChainMsg(7, media=_document_media("data.xyz9"), file=_FakeFile(None))
         descriptor = await _resolve_media_descriptor(msg, chain_chat_id)
-        assert descriptor["media_type"] is None
-        assert descriptor["filename"] == "media-7"
+        assert descriptor["media_type"] == "document"
+        assert descriptor["filename"] == "document-7"
+
+    @pytest.mark.parametrize(
+        "type_name",
+        [
+            "MessageMediaGeoLive",
+            "MessageMediaVenue",
+            "MessageMediaGame",
+            "MessageMediaInvoice",
+            "MessageMediaPoll",
+            "MessageMediaGeo",
+            "MessageMediaContact",
+            "MessageMediaDice",
+            "MessageMediaWebPage",
+        ],
+    )
+    async def test_non_file_media_yields_no_descriptor(self, chain_chat_id, type_name):
+        """Regression (PR #3146 review round 2): every non-file media kind —
+        current and future — must fail closed at the classifier gate. A
+        record with has_media=True and no path exists (the production intake
+        shape), so a fail-open gate would render a false
+        "[unreadable attachment ... no_path_recorded]" marker."""
+        from telethon.tl import types as tl_types
+
+        from bridge.context import _resolve_media_descriptor
+
+        media_cls = getattr(tl_types, type_name)
+        _save_telegram_record(chain_chat_id, 11)
+        msg = _FakeChainMsg(11, media=media_cls.__new__(media_cls))
+        assert await _resolve_media_descriptor(msg, chain_chat_id) is None, (
+            f"{type_name} is not a downloadable attachment and must yield no descriptor"
+        )
+
+    async def test_live_location_hop_renders_no_false_marker(self, chain_chat_id):
+        """End to end: a caption-less live-location hop renders neither a
+        false unreadable marker nor a bare 'Hazem:' label — the hop simply
+        does not appear (PR #3146 review round 2, blocker + nit)."""
+        from telethon.tl import types as tl_types
+
+        from bridge.context import fetch_reply_chain, format_reply_chain
+
+        geolive = tl_types.MessageMediaGeoLive.__new__(tl_types.MessageMediaGeoLive)
+        _save_telegram_record(chain_chat_id, 1)
+        msgs = [
+            _FakeChainMsg(1, text="", media=geolive),
+            _FakeChainMsg(2, text="on my way", reply_to=1),
+        ]
+        chain = await fetch_reply_chain(_FakeChainClient(msgs), chain_chat_id, 2)
+        formatted = format_reply_chain(chain)
+        assert "unreadable" not in formatted
+        assert "no_path_recorded" not in formatted
+        hazem_lines = [line for line in formatted.splitlines() if line.startswith("Hazem")]
+        assert hazem_lines == ["Hazem: on my way"], (
+            "the caption-less excluded hop must render nothing, not a bare label"
+        )
 
     async def test_link_preview_message_yields_no_descriptor(self, chain_chat_id):
         """Regression (PR #3146 review): MessageMediaWebPage is set on any
@@ -812,7 +880,7 @@ class TestResolveMediaDescriptor:
         other_file.write_bytes(b"%PDF other tenant")
         try:
             _save_telegram_record(other_chat, 10, media_local_path=str(other_file))
-            msg = _FakeChainMsg(10, media=object(), file=_FakeFile("report.pdf"))
+            msg = _FakeChainMsg(10, media=_document_media(), file=_FakeFile("report.pdf"))
             descriptor = await _resolve_media_descriptor(msg, chain_chat_id)
             assert descriptor["kind"] == "unreadable"
             assert descriptor["reason"] == "no_record"
@@ -834,7 +902,7 @@ class TestResolveMediaDescriptor:
 
         from bridge.context import _resolve_media_descriptor
 
-        msg = _FakeChainMsg(99, media=object(), file=_FakeFile("report.pdf"))
+        msg = _FakeChainMsg(99, media=_document_media(), file=_FakeFile("report.pdf"))
         with (
             patch("bridge.context.get_media_type", side_effect=RuntimeError("boom")),
             caplog.at_level(logging.WARNING, logger="bridge.context"),
@@ -859,7 +927,7 @@ class TestFetchReplyChainMediaFailurePath:
         from bridge.context import fetch_reply_chain
 
         msgs = [
-            _FakeChainMsg(1, text="", media=object(), file=_FakeFile("doc.pdf")),
+            _FakeChainMsg(1, text="", media=_document_media(), file=_FakeFile("doc.pdf")),
             _FakeChainMsg(2, text="middle reply", reply_to=1),
             _FakeChainMsg(3, text="latest reply", reply_to=2),
         ]
@@ -894,7 +962,9 @@ class TestFetchReplyChainMediaFailurePath:
         try:
             _save_telegram_record(chain_chat_id, 1, media_local_path=str(real))
             msgs = [
-                _FakeChainMsg(1, text="", media=object(), file=_FakeFile("recommendation.pdf")),
+                _FakeChainMsg(
+                    1, text="", media=_document_media(), file=_FakeFile("recommendation.pdf")
+                ),
                 _FakeChainMsg(2, text="brushes over many details", reply_to=1),
                 _FakeChainMsg(3, text="valor can help flesh this out", reply_to=2),
             ]
@@ -905,3 +975,52 @@ class TestFetchReplyChainMediaFailurePath:
             assert "[media]" not in formatted
         finally:
             real.unlink(missing_ok=True)
+
+
+class TestResolveMediaFlag:
+    """PR #3146 review, tech debt: the session-routing walk must not pay
+    per-hop Redis descriptor resolution for data it never reads."""
+
+    async def test_resolve_media_false_skips_descriptor_resolution(self, chain_chat_id):
+        from unittest.mock import AsyncMock, patch
+
+        from bridge.context import fetch_reply_chain
+
+        msgs = [
+            _FakeChainMsg(1, text="root", media=_document_media()),
+            _FakeChainMsg(2, text="reply", reply_to=1),
+        ]
+        spy = AsyncMock(return_value=None)
+        with patch("bridge.context._resolve_media_descriptor", spy):
+            chain = await fetch_reply_chain(
+                _FakeChainClient(msgs), chain_chat_id, 2, resolve_media=False
+            )
+        assert spy.await_count == 0, "resolve_media=False must perform zero descriptor lookups"
+        assert len(chain) == 2
+        assert all(entry["media"] is None for entry in chain)
+
+    async def test_session_routing_walk_passes_resolve_media_false(self):
+        from unittest.mock import AsyncMock, patch
+
+        from bridge.context import resolve_root_session_id
+
+        recorded = {}
+
+        async def _fake_fetch(client, chat_id, message_id, max_depth=20, resolve_media=True):
+            recorded["resolve_media"] = resolve_media
+            return [
+                {"sender": "Hazem", "content": "root", "message_id": 5, "date": None, "media": None}
+            ]
+
+        with (
+            patch("bridge.context._get_cached_root", AsyncMock(return_value=None)),
+            patch("bridge.context._cache_walk_root", AsyncMock(return_value=None)),
+            patch("bridge.context.fetch_reply_chain", _fake_fetch),
+            patch("bridge.context._set_cached_root", AsyncMock()),
+        ):
+            session_id = await resolve_root_session_id(object(), 123, 9, "valor")
+
+        assert recorded["resolve_media"] is False, (
+            "the Step 2 API fallback consumes only sender/message_id and must skip media"
+        )
+        assert session_id == "tg_valor_123_5"


### PR DESCRIPTION
## Summary

Reply-chain hydration no longer collapses a chain ancestor's attachment to the literal string `[media]`. Each media-carrying hop now gets a structured descriptor — filename, media type, and the absolute on-disk path recorded at intake — resolved by a chat_id-scoped `TelegramMessage` lookup run off the event loop via `asyncio.to_thread`. A captioned attachment renders caption plus descriptor; an unresolvable one renders an explicit unreadable marker naming the file and the specific reason (no record, no path recorded, download error, file absent from disk).

Plan: `docs/plans/reply-chain-media-renders-as-literal-string.md` (built past the G2 critique cap on the owner override recorded on the issue; the round-2 blockers were applied to the plan at c99cb231d before build).

## Changes

- `bridge/context.py`: media descriptor record, per-hop ancestor resolver (`_resolve_media_descriptor`, off-loop Popoto lookup, path statted before trusting, per-hop fail-quiet degradation), and renderer composition in `format_reply_chain` (three distinguishable states; Valor drop condition now retains below-floor hops that carry media; descriptor never fed to `filter_tool_logs`; truncation never bisects a path). The `msg.text or "[media]"` fallback is deleted.
- `tests/unit/test_context_helpers.py`: the three rendering states, all unreadable reasons, photo synthetic label, `media_type=None`, chat_id scoping, Valor floor both ways, byte-identical text-only regression fence.
- `tests/unit/test_bridge_context_guards.py`: cross-medium static guards — AST placeholder-shape scan over `bridge/` with in-suite red-state fixtures, write-only `extra_context` scan (receiver-agnostic reader predicate, empirically derived ratcheting allow-list annotated `# known gap: #3136`), and the off-loop enforcement scan.
- `tests/integration/test_steering.py`: 20-hop budget test, stalled-lookup timing-bound test (5s stall, monotonic elapsed < 4.0s, heartbeat liveness), rendered-block size ceiling, and end-to-end `message_text` delivery assertions for both hydration call sites (resume-completed and fresh-session), proving the descriptor survives `strip_private` and reaches `AgentSession.message_text`.
- `docs/features/reply-thread-context-hydration.md`, `docs/features/media-enrichment.md`: chain-ancestor media rendering documented (three states, chat scoping, path-disclosure note; reference-only, never AI enrichment).

## Testing

- [x] All 16 Verification-table rows pass exactly as specified
- [x] Unit tests passing (78 in test_context_helpers, 14 guard tests; full tests/unit run: 4 failures + 9 errors all reproduced on main or non-reproducing in isolation — classified pre-existing/environmental, none in files this branch touches)
- [x] Integration tests passing (reply_chain, message_text_delivery, private-tag ingestion)
- [x] Guard mutation-verified red: injected placeholder fails the tree scan; inlined blocking filter fails the stalled-lookup timing bound
- [x] Lint/format clean (`ruff check`, `ruff format --check`)

## Documentation

- [x] Both feature docs updated per plan
- [x] Related docs scanned (LOW-confidence matches only)

## Definition of Done

- [x] Built: code implemented and working
- [x] Tested: plan-scoped suites green, no regressions attributable to this diff
- [x] Reviewed: independent validator passed all six checks; final validator passed all Verification rows and Success Criteria
- [x] Documented: docs created/updated and gate passed
- [x] Quality: lint and format checks pass

Closes #2732