### PR TITLE
Busy-guard scan: narrow the query, unamplify the sweep

### DIFF
--- a/agent/worktree_manager.py
+++ b/agent/worktree_manager.py
@@ -454,17 +454,82 @@ def verify_worktree_branch(worktree_path: Path, expected_branch: str) -> None:
     )
 
 
-def _scan_worktree_sessions(repo_root: Path, slug: str) -> tuple[str, str, str]:
+def _fetch_live_sessions() -> tuple[list, str]:
+    """Fetch every non-terminal ``AgentSession`` row, once, materialized.
+
+    This is the single place that decides what "live session" means at the
+    Redis boundary, and the single place where Redis is actually touched for
+    a busy-guard decision. It narrows on the indexed ``status`` field
+    (``status__in=NON_TERMINAL_STATUSES``) instead of hydrating the whole
+    table and discarding terminal rows in Python — a strict push-down of a
+    filter the matching loop already performed, so it cannot change which
+    sessions are considered.
+
+    The ``list(...)`` wrapper is load-bearing, not stylistic:
+    ``AgentSession.query.filter(...)`` returns a lazy
+    ``popoto.models.query.QueryBuilder`` that re-runs the whole query on every
+    iteration and issues no Redis command itself, so a ``try`` around
+    ``filter()`` alone would catch nothing — the connection error surfaces
+    during iteration. Materializing here, inside this function's own
+    ``try``, is what turns a Redis outage into ``("error", ...)`` instead of
+    an exception that escapes every caller. Handing a bare, unmaterialized
+    builder to a caller that loops it once per slug would also reintroduce
+    one full Redis query per slug — the exact amplification this function
+    exists to remove, one layer down. Mirrors the established shape at
+    ``models/agent_session.py:1389`` (``rows = list(cls.query.filter(...))``).
+
+    Returns:
+        ``(rows, error_reason)``. On success, ``rows`` is a materialized
+        ``list`` of ``AgentSession`` instances and ``error_reason`` is
+        ``""``. On failure, ``rows`` is ``[]`` and ``error_reason`` is
+        ``"model_import_failed:{Type}"`` or ``"query_failed:{Type}"``.
+    """
+    try:
+        from models.agent_session import AgentSession
+        from models.session_lifecycle import NON_TERMINAL_STATUSES
+    except Exception as e:
+        logger.warning("_fetch_live_sessions: model imports failed (%s)", e)
+        return ([], f"model_import_failed:{type(e).__name__}")
+
+    try:
+        rows = list(AgentSession.query.filter(status__in=sorted(NON_TERMINAL_STATUSES)))
+    except Exception as e:
+        logger.warning("_fetch_live_sessions: AgentSession query failed (%s)", e)
+        return ([], f"query_failed:{type(e).__name__}")
+
+    return (rows, "")
+
+
+def _scan_worktree_sessions(
+    repo_root: Path, slug: str, *, sessions: list | None = None
+) -> tuple[str, str, str]:
     """Check whether any non-terminal AgentSession references this worktree.
 
-    Walks the AgentSession table looking for rows whose ``working_dir`` lives
-    inside ``.worktrees/{slug}/`` (or is exactly that directory) and whose
-    ``status`` is not in ``TERMINAL_STATUSES``. The first match wins.
+    Matches rows whose ``working_dir`` lives inside ``.worktrees/{slug}/``
+    (or is exactly that directory) and whose ``status`` is not in
+    ``TERMINAL_STATUSES``. The first match wins.
 
-    Imports of ``models.agent_session`` and ``models.session_lifecycle`` are
-    deferred to function body to keep ``worktree_manager.py``'s import-time
-    graph unchanged (worktree_manager is loaded by tooling that should not
-    pay the Popoto bootstrap cost just to validate slugs).
+    When ``sessions`` is ``None`` (the default, used by every single-slug
+    caller), this fetches the candidate rows itself via
+    :func:`_fetch_live_sessions` — one indexed, materialized query per call.
+    When ``sessions`` is given (used by :func:`worktree_busy_probe_many`),
+    this matches against that pre-fetched list instead of querying again, so
+    batch and single-slug callers share one matcher and cannot drift apart.
+
+    Import of ``models.session_lifecycle`` is deferred to function body to
+    keep ``worktree_manager.py``'s import-time graph unchanged
+    (worktree_manager is loaded by tooling that should not pay the Popoto
+    bootstrap cost just to validate slugs). This import is unconditional —
+    it happens whether or not ``sessions`` was injected — because the
+    injected-``sessions=`` path never calls ``_fetch_live_sessions`` and so
+    would otherwise leave ``TERMINAL_STATUSES`` unbound in this frame.
+
+    The Python ``status not in TERMINAL_STATUSES`` check below is kept even
+    though the indexed query above already narrows on ``status``: they are
+    not the same predicate. A status value outside the known enum is
+    non-terminal under this check (fail-closed) but absent from the index
+    union (fail-open), so deleting this check would silently flip that case
+    from fail-closed to fail-open the moment an unrecognized status appears.
 
     Path comparison normalizes both sides via ``os.path.normpath`` (no symlink
     resolution) then matches the worktree's path components segment-by-segment
@@ -481,6 +546,8 @@ def _scan_worktree_sessions(repo_root: Path, slug: str) -> tuple[str, str, str]:
     Args:
         repo_root: Path to the main repository.
         slug: Work item slug whose worktree we want to remove.
+        sessions: Pre-fetched, materialized rows to match against instead of
+            fetching. ``None`` (default) fetches internally.
 
     Returns:
         ``(state, a, b)`` where ``state`` is one of ``"clear"``, ``"busy"``, or
@@ -488,7 +555,6 @@ def _scan_worktree_sessions(repo_root: Path, slug: str) -> tuple[str, str, str]:
         agent_session_id. For ``"error"``, ``a`` is the reason.
     """
     try:
-        from models.agent_session import AgentSession
         from models.session_lifecycle import TERMINAL_STATUSES
     except Exception as e:
         logger.warning("_scan_worktree_sessions: model imports failed (%s)", e)
@@ -498,11 +564,10 @@ def _scan_worktree_sessions(repo_root: Path, slug: str) -> tuple[str, str, str]:
     worktree_norm = os.path.normpath(str(worktree_dir))
     worktree_parts = Path(worktree_norm).parts
 
-    try:
-        sessions = AgentSession.query.all()
-    except Exception as e:
-        logger.warning("_scan_worktree_sessions: AgentSession query failed (%s)", e)
-        return ("error", f"query_failed:{type(e).__name__}", "")
+    if sessions is None:
+        sessions, error_reason = _fetch_live_sessions()
+        if error_reason:
+            return ("error", error_reason, "")
 
     for session in sessions:
         try:
@@ -574,6 +639,52 @@ def worktree_busy_probe(repo_root: Path, slug: str) -> tuple[str, str]:
     if state == "error":
         return ("error", a)
     return ("clear", "")
+
+
+def worktree_busy_probe_many(repo_root: Path, slugs: list[str]) -> dict[str, tuple[str, str]]:
+    """Tri-state busy check for many slugs, fetched once instead of per-slug.
+
+    This is :func:`worktree_busy_probe` for a whole sweep: fetches the
+    non-terminal session rows exactly once via :func:`_fetch_live_sessions`,
+    then matches each requested slug against that same materialized list by
+    calling :func:`_scan_worktree_sessions` with ``sessions=`` pre-populated.
+    It shares one matcher with the single-slug path — it does not
+    re-implement containment matching — so batch and single-slug results
+    cannot drift apart as either is maintained.
+
+    Never raises: every Redis touch happens inside ``_fetch_live_sessions``'s
+    own ``try``, and the per-row matching keeps its own ``try``. If the fetch
+    fails, every requested slug gets ``("error", reason)`` — the failure is
+    fanned out to all of them rather than defaulting any of them to
+    ``"clear"``, so a Redis outage during a sweep skips every lane instead of
+    silently clearing one.
+
+    Args:
+        repo_root: Path to the main repository.
+        slugs: Worktree slugs to check. An empty list returns ``{}`` and
+            issues no query.
+
+    Returns:
+        ``{slug: (state, detail)}`` with the same tri-state each single-slug
+        :func:`worktree_busy_probe` call would have produced for that slug.
+    """
+    if not slugs:
+        return {}
+
+    rows, error_reason = _fetch_live_sessions()
+    if error_reason:
+        return dict.fromkeys(slugs, ("error", error_reason))
+
+    result: dict[str, tuple[str, str]] = {}
+    for slug in slugs:
+        state, a, b = _scan_worktree_sessions(repo_root, slug, sessions=rows)
+        if state == "busy":
+            result[slug] = ("busy", a or b or "unknown")
+        elif state == "error":
+            result[slug] = ("error", a)
+        else:
+            result[slug] = ("clear", "")
+    return result
 
 
 def _worktree_has_live_process(worktree_dir: Path) -> int | None:

--- a/agent/worktree_manager.py
+++ b/agent/worktree_manager.py
@@ -524,12 +524,19 @@ def _scan_worktree_sessions(
     injected-``sessions=`` path never calls ``_fetch_live_sessions`` and so
     would otherwise leave ``TERMINAL_STATUSES`` unbound in this frame.
 
-    The Python ``status not in TERMINAL_STATUSES`` check below is kept even
-    though the indexed query above already narrows on ``status``: they are
-    not the same predicate. A status value outside the known enum is
-    non-terminal under this check (fail-closed) but absent from the index
-    union (fail-open), so deleting this check would silently flip that case
-    from fail-closed to fail-open the moment an unrecognized status appears.
+    Narrowing on the index accepts a fail-open reading for any status outside
+    ``ALL_STATUSES``: such a row is absent from the ``status__in`` union, so it
+    is never fetched and the lane reads clear. That trade is deliberate --
+    spike 4 found no live out-of-enum values and no write site for one outside
+    ``models/session_lifecycle.py``, whose setter rejects unknown statuses --
+    and it is settled at the query, not here. The Python
+    ``status not in TERMINAL_STATUSES`` check below therefore cannot exclude a
+    row on either shipped path: ``TERMINAL_STATUSES`` and
+    ``NON_TERMINAL_STATUSES`` are disjoint, so every fetched row passes it by
+    construction, and ``worktree_busy_probe_many`` injects index-filtered rows
+    too. It is kept because it is cheap and it is the correct predicate for a
+    caller that injects rows of its own -- the only path that can present an
+    out-of-enum status -- not because it is what holds the fail-closed line.
 
     Path comparison normalizes both sides via ``os.path.normpath`` (no symlink
     resolution) then matches the worktree's path components segment-by-segment

--- a/docs/features/scheduled-disk-reclaim.md
+++ b/docs/features/scheduled-disk-reclaim.md
@@ -138,10 +138,15 @@ posture differs.
 
 `_scan_worktree_sessions` no longer hydrates the whole `AgentSession` table.
 `_fetch_live_sessions()` issues one indexed, materialized query —
-`AgentSession.query.filter(status__in=NON_TERMINAL_STATUSES)` — and the Python
-loop still drops any row whose status is unrecognized as non-terminal, so an
-enum value the index doesn't know about still reads busy rather than
-silently clearing. `worktree_busy_probe_many(repo_root, slugs)` fetches once
+`AgentSession.query.filter(status__in=NON_TERMINAL_STATUSES)`. Narrowing on the
+index accepts a fail-open reading for any status outside `ALL_STATUSES`: such a
+row is never fetched, so its lane reads clear. The trade is deliberate — no live
+out-of-enum value exists and the only status write site
+(`models/session_lifecycle.py`) rejects unknown values — and it is settled at the
+query. The Python `status not in TERMINAL_STATUSES` check that follows cannot
+exclude a fetched row (the two status sets are disjoint); it is retained as the
+correct predicate for a caller that injects rows of its own.
+`worktree_busy_probe_many(repo_root, slugs)` fetches once
 and matches every candidate slug against that one in-memory list through the
 same segment-aware containment matcher the single-slug wrappers use, so batch
 and single-slug results cannot drift apart.

--- a/docs/features/scheduled-disk-reclaim.md
+++ b/docs/features/scheduled-disk-reclaim.md
@@ -131,7 +131,35 @@ Redis hiccup would cause more pain than the guard prevents.
 
 It is wrong for an unattended reaper, which would delete every lane during an
 outage. `worktree_busy_probe()` returns `clear` / `busy` / `error` so the sweep
-can skip on `error`. Both wrap one scan; only the failure posture differs.
+can skip on `error`. Both wrap `_scan_worktree_sessions`; only the failure
+posture differs.
+
+### The batch probe: one scan per sweep, not one per lane
+
+`_scan_worktree_sessions` no longer hydrates the whole `AgentSession` table.
+`_fetch_live_sessions()` issues one indexed, materialized query —
+`AgentSession.query.filter(status__in=NON_TERMINAL_STATUSES)` — and the Python
+loop still drops any row whose status is unrecognized as non-terminal, so an
+enum value the index doesn't know about still reads busy rather than
+silently clearing. `worktree_busy_probe_many(repo_root, slugs)` fetches once
+and matches every candidate slug against that one in-memory list through the
+same segment-aware containment matcher the single-slug wrappers use, so batch
+and single-slug results cannot drift apart.
+
+`sweep_worktrees` builds this batch map lazily, the first time a lane reaches
+the busy guard — an all-`too_young` sweep still pays zero session queries, and
+a sweep that does reach the guard pays exactly one, materialized once, for
+however many lanes are classified against it. A missing slug in the map reads
+as `error`/`not_probed`, never as `clear`.
+
+The batch snapshot is a point-in-time read, and everything the sweep does for
+the remaining lanes after it (`_tree_stats`, `git status`, `merged_via_tree`)
+can take long enough for a new session to start inside one of them. So on the
+`apply=True` path only, immediately before `cleanup_after_merge`,
+`sweep_worktrees` re-probes that one lane fresh with the single-slug,
+fail-closed `worktree_busy_probe()` — the authorizing read for an actual
+deletion is never older than the guard right below it. The dry-run path
+(`apply=False`) deletes nothing, so it takes no re-probe.
 
 ## Registering the reflection
 
@@ -170,6 +198,7 @@ transcripts — the preserved `memory/` stores are text files measured in KB.
 
 - `docs/features/worktree-venv-isolation.md` — how lanes get their env, and the measurement
 - `docs/features/adding-reflection-tasks.md` — the reflection contract
-- `agent/worktree_manager.py` — `cleanup_after_merge`, `worktree_busy_probe`
+- `agent/worktree_manager.py` — `cleanup_after_merge`, `worktree_busy_probe`,
+  `worktree_busy_probe_many`
 - `docs/features/nightly-regression-tests.md` — the nightly baseline classifier that
   owns `.worktrees/nightly-baseline/`, the one lane `PROTECTED_WORKTREE_SLUGS` excludes

--- a/docs/features/session-isolation.md
+++ b/docs/features/session-isolation.md
@@ -223,7 +223,7 @@ The function returns a status dict with `worktree_removed`, `branch_deleted`, `a
 
 ### Worktree Busy Guard (Issue #1357)
 
-`remove_worktree()` enforces a runtime invariant: **a worktree at `.worktrees/{slug}/` is removable only if no non-terminal `AgentSession` references it as `working_dir`**. The guard is implemented by `worktree_busy_check(repo_root, slug)`, which scans `AgentSession.query.all()` for live sessions and matches their `working_dir` against the target worktree path using segment-aware containment (so `.worktrees/sdlc-1218` matches `.worktrees/sdlc-1218/subdir` but not `.worktrees/sdlc-1218-other`).
+`remove_worktree()` enforces a runtime invariant: **a worktree at `.worktrees/{slug}/` is removable only if no non-terminal `AgentSession` references it as `working_dir`**. The guard is implemented by `worktree_busy_check(repo_root, slug)`, which queries `AgentSession.query.filter(status__in=NON_TERMINAL_STATUSES)` — an indexed lookup, not a full-table scan — for live sessions and matches their `working_dir` against the target worktree path using segment-aware containment (so `.worktrees/sdlc-1218` matches `.worktrees/sdlc-1218/subdir` but not `.worktrees/sdlc-1218-other`). `worktree_busy_probe_many()` runs that same query and matcher once for a whole batch of slugs instead of once per slug; see [`docs/features/scheduled-disk-reclaim.md`](scheduled-disk-reclaim.md#the-batch-probe-one-scan-per-sweep-not-one-per-lane).
 
 When the guard fires:
 

--- a/docs/plans/busy-guard-scan-per-lane-amplification.md
+++ b/docs/plans/busy-guard-scan-per-lane-amplification.md
@@ -909,13 +909,13 @@ Not applicable — this repo has no Sphinx/MkDocs site.
 
 ## Success Criteria
 
-- [ ] `_scan_worktree_sessions` issues an indexed `status__in` query; `AgentSession.query.all()`
+- [x] `_scan_worktree_sessions` issues an indexed `status__in` query; `AgentSession.query.all()`
       no longer appears in `agent/worktree_manager.py`.
-- [ ] The query result is **materialized** — `_fetch_live_sessions` returns a `list`, and the
+- [x] The query result is **materialized** — `_fetch_live_sessions` returns a `list`, and the
       `list(...)` sits inside the `try` that produces `query_failed:{Type}` (Decision 0).
-- [ ] The `working_dir` segment-prefix matcher is byte-for-byte the predicate it is today;
+- [x] The `working_dir` segment-prefix matcher is byte-for-byte the predicate it is today;
       no `filter(slug=` appears in `agent/worktree_manager.py`.
-- [ ] A sweep over N lanes performs **one batch session query, materialized once**, plus,
+- [x] A sweep over N lanes performs **one batch session query, materialized once**, plus,
       **on the `apply=True` path**, **one fresh single-slug re-probe per lane actually
       removed** (Decision 4), and **zero of both** when every lane is filtered out above
       guard 5. Measured by counting iterations of the fetched rows, not `filter()` calls, and
@@ -923,30 +923,30 @@ Not applicable — this repo has no Sphinx/MkDocs site.
       `apply=True`. Under `apply=False` the expected re-probe count is **zero** regardless of
       `len(sweep.removed)`, because the dry-run branch returns at
       `tools/disk_reclaim.py:437`–`:440` before `cleanup_after_merge` and deletes nothing.
-- [ ] The re-measured saving is recorded, not assumed: the one-materialization test's
+- [x] The re-measured saving is recorded, not assumed: the one-materialization test's
       counter is the measurement, and Task 6 additionally reports the observed
       materialization count from a real `python -m tools.disk_reclaim --json` dry run. The
       plan's justification is a millisecond figure, so something must re-measure it after
       the change rather than only confirming the query's shape.
-- [ ] `worktree_busy_check` returns `None` for both clear and error; `worktree_busy_probe`
+- [x] `worktree_busy_check` returns `None` for both clear and error; `worktree_busy_probe`
       returns `clear`/`busy`/`error`; a batch fetch failure yields `error` for every
       requested slug.
-- [ ] `worktree_busy_probe_many` and N single-slug probes agree on identical fixture rows
+- [x] `worktree_busy_probe_many` and N single-slug probes agree on identical fixture rows
       across all three states.
-- [ ] The three stale-monkeypatch tests in `tests/unit/test_disk_reclaim.py` exercise the
+- [x] The three stale-monkeypatch tests in `tests/unit/test_disk_reclaim.py` exercise the
       new guard path, proven by mutation: forcing the batch probe to return clear makes
       `test_busy_check_error_also_blocks_removal` fail.
-- [ ] `grep -n 'query\.all' tests/unit/worktree_manager/test_worktree_manager_busy_guards.py`
+- [x] `grep -n 'query\.all' tests/unit/worktree_manager/test_worktree_manager_busy_guards.py`
       returns nothing, and each of the five predicate tests named in Test Impact turns red
       under a mutation of the predicate it asserts (terminal-status skip removed,
       segment-aware containment replaced with substring containment, falsy `working_dir`
       back-filled with the lane path) rather than passing vacuously against an empty
       `MagicMock` sequence.
-- [ ] The per-row matching `except` branch has a test — it had none before this change, and
+- [x] The per-row matching `except` branch has a test — it had none before this change, and
       Task 1 refactors the loop it lives in.
-- [ ] Tests pass (`/do-test`)
-- [ ] Documentation updated (`/do-docs`)
-- [ ] No xfail conversions apply — no expected-failure markers exist in
+- [x] Tests pass (`/do-test`)
+- [x] Documentation updated (`/do-docs`)
+- [x] No xfail conversions apply — no expected-failure markers exist in
       `tests/unit/test_disk_reclaim.py` or `tests/unit/worktree_manager/` (verified at plan time).
 
 ## Team Orchestration

--- a/docs/plans/busy-guard-scan-per-lane-amplification.md
+++ b/docs/plans/busy-guard-scan-per-lane-amplification.md
@@ -288,10 +288,16 @@ Four spikes ran against live Redis on this checkout, read-only, through the ORM.
   `grep -rn '\.status *= *"'` finds no direct AgentSession status write outside
   `models/session_lifecycle.py` (the three hits are `models/job.py`, a different model).
 - **Confidence**: high
-- **Impact on plan**: the Python `status not in TERMINAL_STATUSES` check is **kept** after
-  the indexed query rather than deleted as now-redundant. It costs one set membership test
-  per surviving row and it is the thing that keeps the fail-closed posture honest if the
-  enum ever grows. Risk 2 and a dedicated test cover it.
+- **Impact on plan**: the narrowing accepts a **fail-open** reading for any status outside
+  `ALL_STATUSES` — such a row is never fetched, so its lane reads clear. That is settled at
+  the query, and no surviving Python check can undo it, because `TERMINAL_STATUSES` and
+  `NON_TERMINAL_STATUSES` are disjoint and every fetched row passes `not in
+  TERMINAL_STATUSES` by construction. The trade is accepted on this spike's evidence: no
+  live out-of-enum value, and no status write site outside `models/session_lifecycle.py`,
+  whose setter rejects unknown values. The Python check is **kept** anyway — one set
+  membership test, and it is the correct predicate for the one path that can present an
+  out-of-enum status, a caller injecting rows via `sessions=`. Risk 2 and a dedicated test
+  cover that path.
 
 ## Data Flow
 
@@ -439,11 +445,12 @@ leaving the `working_dir` predicate exactly as it is — it is a push-down of a 
 Python loop *already performs*, so by construction it cannot change which sessions are
 considered.
 
-**Decision 2 — keep the Python `status not in TERMINAL_STATUSES` check.** It looks
-redundant after the indexed query and it is not (spike-4): an unknown status value is
-non-terminal under the current check and absent from the index union, so deleting the
-Python check would silently flip that case from fail-closed to fail-open. One set
-membership test per surviving row is not a cost worth arguing about.
+**Decision 2 — keep the Python `status not in TERMINAL_STATUSES` check, and record what it
+does and does not buy.** It cannot exclude a fetched row: the two status sets are disjoint,
+so every row the index returns passes it. The fail-open reading of an out-of-enum status is
+accepted at the query on spike-4's evidence, not prevented here. The check is kept because
+it is one set membership test and it is the correct predicate for a caller that injects its
+own rows via `sessions=` — the only path that can present an out-of-enum status.
 
 **Decision 3 — inject rows rather than write a second matcher.** `worktree_busy_probe_many`
 does not re-implement containment matching; it calls `_scan_worktree_sessions` with
@@ -728,9 +735,11 @@ fetch fails.
 **Impact:** A status value outside `ALL_STATUSES` would be treated as busy today
 (fail-closed) and as clear after an index-only narrowing (fail-open) — a live worktree
 deleted under a running session.
-**Mitigation:** Decision 2 keeps the Python `not in TERMINAL_STATUSES` check after the
-indexed query, so the fail-closed reading survives for any status the index union misses.
-Pinned by a test that feeds a row with a fabricated status and asserts `busy`.
+**Mitigation:** Accepted, not prevented (spike-4): no live out-of-enum value exists and the
+only status write site rejects unknown values. Decision 2 keeps the Python `not in
+TERMINAL_STATUSES` check, which holds the fail-closed reading on the one path that can still
+present such a row — a caller injecting rows via `sessions=`. Pinned by a test that feeds an
+injected row with a fabricated status and asserts `busy`.
 
 ### Risk 3: The batch snapshot is stale by the time a lane is removed
 **Impact:** A session that starts inside a lane mid-sweep is missed, and the lane is
@@ -1141,12 +1150,12 @@ so they can run in parallel without the shared-worktree livelock.
 | Batch probe wired into the sweep | `grep -c 'worktree_busy_probe_many' tools/disk_reclaim.py` | output > 0 |
 | Full scan gone (anti-criterion) | `grep -c 'query\.all()' agent/worktree_manager.py` | match count == 0 |
 | Slug narrowing rejected (anti-criterion, Decision 1) | `grep -c 'filter(slug=' agent/worktree_manager.py` | match count == 0 |
-| No lazy builder crosses a function boundary (anti-criterion, Decision 0) | `python -c "import ast,sys; t=ast.parse(open('agent/worktree_manager.py').read()); f=[n for n in ast.walk(t) if isinstance(n,ast.FunctionDef) and n.name=='_fetch_live_sessions'][0]; print('OK' if any(isinstance(n,ast.Call) and getattr(n.func,'id','')=='list' for n in ast.walk(f)) else 'BAD')"` | output `OK` |
-| No clear-valued default on the map read (anti-criterion, Risk 4; AST so a black-wrapped default cannot slip past) | `python -c "import ast; t=ast.parse(open('tools/disk_reclaim.py').read()); bad=[n.lineno for n in ast.walk(t) if isinstance(n,ast.Call) and isinstance(n.func,ast.Attribute) and n.func.attr=='get' and len(n.args)>=2 and isinstance(n.args[1],ast.Tuple) and n.args[1].elts and isinstance(n.args[1].elts[0],ast.Constant) and n.args[1].elts[0].value=='clear']; print('BAD' if bad else 'OK', bad)"` | output `OK []` |
+| No lazy builder crosses a function boundary (anti-criterion, Decision 0) | `python -c "import ast,sys; t=ast.parse(open('agent/worktree_manager.py').read()); f=[n for n in ast.walk(t) if isinstance(n,ast.FunctionDef) and n.name=='_fetch_live_sessions'][0]; print('OK' if any(isinstance(n,ast.Call) and getattr(n.func,'id','')=='list' for n in ast.walk(f)) else 'BAD')"` | output contains OK |
+| No clear-valued default on the map read (anti-criterion, Risk 4; AST so a black-wrapped default cannot slip past) | `python -c "import ast; t=ast.parse(open('tools/disk_reclaim.py').read()); bad=[n.lineno for n in ast.walk(t) if isinstance(n,ast.Call) and isinstance(n.func,ast.Attribute) and n.func.attr=='get' and len(n.args)>=2 and isinstance(n.args[1],ast.Tuple) and n.args[1].elts and isinstance(n.args[1].elts[0],ast.Constant) and n.args[1].elts[0].value=='clear']; print('BAD' if bad else 'OK', bad)"` | output contains OK [] |
 | Terminal-status check survives (anti-criterion, Decision 2) | `grep -c 'in TERMINAL_STATUSES' agent/worktree_manager.py` | output > 0 |
 | Fail-open wrapper intact | `grep -c 'def worktree_busy_check' agent/worktree_manager.py` | output > 0 |
 | Fail-closed wrapper intact | `grep -c 'def worktree_busy_probe' agent/worktree_manager.py` | output > 0 |
-| Guard order unchanged in the sweep | `sed -n '/^def sweep_worktrees/,/^def [a-z_]/p' tools/disk_reclaim.py \| grep -oE '"protected"\|"too_young"\|"uncommitted_changes"\|live_process:\|busy_check_error:\|live_session:\|"open_pr"\|"unmerged"' \| paste -sd, -` | exactly `"protected","too_young","uncommitted_changes",live_process:,busy_check_error:,live_session:,"open_pr","unmerged"` |
+| Guard order unchanged in the sweep | `sed -n '/^def sweep_worktrees/,/^def [a-z_]/p' tools/disk_reclaim.py \| grep -oE '"protected"\|"too_young"\|"uncommitted_changes"\|live_process:\|busy_check_error:\|live_session:\|"open_pr"\|"unmerged"' \| paste -sd, -` | output contains "protected","too_young","uncommitted_changes",live_process:,busy_check_error:,live_session:,"open_pr","unmerged" |
 | No stale `query.all` mocks left behind (Test Impact completion check) | `grep -c 'query\.all' tests/unit/worktree_manager/test_worktree_manager_busy_guards.py` | match count == 0 |
 | No stale xfails in scope | `grep -rn 'xfail' tests/unit/test_disk_reclaim.py tests/unit/worktree_manager/` | exit code 1 |
 

--- a/docs/plans/busy-guard-scan-per-lane-amplification.md
+++ b/docs/plans/busy-guard-scan-per-lane-amplification.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: docs_complete
 type: chore
 appetite: Small
 owner: Valor Engels
@@ -876,35 +876,35 @@ agent-invocation integration test to add.
 ## Documentation
 
 ### Feature Documentation
-- [ ] Update `docs/features/scheduled-disk-reclaim.md` — the fail-open/fail-closed
+- [x] Update `docs/features/scheduled-disk-reclaim.md` — the fail-open/fail-closed
       explanation at `:127`–`:133` and the touched-files list at `:173` are correct today
       and describe a per-lane probe. Document the batch probe, the lazy snapshot, and the
       fresh re-probe before removal, keeping the fail-closed rationale as the reason the
       re-probe exists.
-- [ ] Update `docs/features/session-isolation.md:226` — "scans `AgentSession.query.all()`
+- [x] Update `docs/features/session-isolation.md:226` — "scans `AgentSession.query.all()`
       for live sessions" becomes the indexed non-terminal query. The surrounding
       segment-aware-containment description stays exactly as written; it is still the
       matcher, and saying so explicitly is the point.
-- [ ] No new file in `docs/features/`, so no new row in `docs/features/README.md`. Both
+- [x] No new file in `docs/features/`, so no new row in `docs/features/README.md`. Both
       features are already indexed there.
 
 ### External Documentation Site
 Not applicable — this repo has no Sphinx/MkDocs site.
 
 ### Inline Documentation
-- [ ] Rewrite the `_scan_worktree_sessions` docstring: it currently says "Walks the
+- [x] Rewrite the `_scan_worktree_sessions` docstring: it currently says "Walks the
       AgentSession table", which stops being true. State the indexed query, and state why
       the Python terminal-status check survives it (Decision 2) so nobody deletes it as
       dead code later.
-- [ ] Docstring on `_fetch_live_sessions` stating that the `list(...)` is load-bearing:
+- [x] Docstring on `_fetch_live_sessions` stating that the `list(...)` is load-bearing:
       `filter()` returns a lazy `QueryBuilder` that re-queries on every iteration and issues
       no Redis command itself, so removing the `list()` would both reintroduce the per-lane
       amplification and move the Redis failure outside this function's `except` (Decision 0).
       Without that sentence the wrapper reads as noise and the next reader deletes it.
-- [ ] Docstring on `worktree_busy_probe_many` covering the contract, the fan-out of a fetch
+- [x] Docstring on `worktree_busy_probe_many` covering the contract, the fan-out of a fetch
       error to every requested slug, the never-raises guarantee (Decision 6), and the fact
       that it shares one matcher with the single-slug path.
-- [ ] A comment at the `sweep_worktrees` map read naming why the default is
+- [x] A comment at the `sweep_worktrees` map read naming why the default is
       `("error", "not_probed")` and not `("clear", "")` (Risk 4).
 
 ## Success Criteria

--- a/docs/plans/busy-guard-scan-per-lane-amplification.md
+++ b/docs/plans/busy-guard-scan-per-lane-amplification.md
@@ -644,9 +644,17 @@ exactly what makes the vacuous set easy to miss on an otherwise-red-then-green r
       `::test_session_with_no_working_dir_skipped` (`:114`),
       `TestWorktreeBusyProbe::test_unrelated_sessions_report_clear` (`:174`),
       `::test_terminal_session_in_lane_reports_clear` (`:183`).
-      Prove they bite with the same mutation discipline Risk 1 prescribes: make the matcher
-      return clear unconditionally and confirm all five turn **red**. A test that stays
-      green under that mutation is reaching no code.
+      Prove they bite with the same mutation discipline Risk 1 prescribes, aimed at the
+      predicate each one actually asserts. All five assert *clear*, so a
+      matcher-returns-clear mutation leaves every one of them green by construction and
+      proves nothing; the mutation has to break the specific rule under test:
+      remove the terminal-status skip → `test_terminal_session_does_not_block` and
+      `test_terminal_session_in_lane_reports_clear` turn **red**; replace segment-aware
+      containment with plain substring containment →
+      `test_substring_near_miss_does_not_block` and `test_unrelated_sessions_report_clear`
+      turn **red**; back-fill a falsy `working_dir` with the lane's own path →
+      `test_session_with_no_working_dir_skipped` turns **red**. A test that stays green
+      under the mutation aimed at its own predicate is reaching no code.
 - [ ] `TestWorktreeBusyCheck` / `TestWorktreeBusyProbe` / `TestScanWorktreeSessions`
       (`:37`–`:236`) — the assertions themselves are the fail-open/fail-closed contract and
       must not change meaning by one character. Only the mock plumbing moves.
@@ -929,8 +937,10 @@ Not applicable — this repo has no Sphinx/MkDocs site.
       new guard path, proven by mutation: forcing the batch probe to return clear makes
       `test_busy_check_error_also_blocks_removal` fail.
 - [ ] `grep -n 'query\.all' tests/unit/worktree_manager/test_worktree_manager_busy_guards.py`
-      returns nothing, and the five predicate tests named in Test Impact turn red under a
-      matcher-returns-clear mutation rather than passing vacuously against an empty
+      returns nothing, and each of the five predicate tests named in Test Impact turns red
+      under a mutation of the predicate it asserts (terminal-status skip removed,
+      segment-aware containment replaced with substring containment, falsy `working_dir`
+      back-filled with the lane path) rather than passing vacuously against an empty
       `MagicMock` sequence.
 - [ ] The per-row matching `except` branch has a test — it had none before this change, and
       Task 1 refactors the loop it lives in.
@@ -1085,14 +1095,21 @@ so they can run in parallel without the shared-worktree livelock.
   a row that raises on attribute access is skipped and a later busy row still wins; an
   unknown status value reads `busy`; `worktree_busy_probe_many(root, [])` returns `{}` and
   queries nothing.
-- **Mutation-check each guard and re-measure after each change** — three mutations, each
-  re-measured on its own:
+- **Mutation-check each guard and re-measure after each change** — five mutations, each
+  re-measured on its own. Aim each one at the predicate the tests it targets assert; a
+  matcher-returns-clear mutation discriminates only the busy- and error-asserting tests,
+  and leaves every clear-asserting test green by construction:
   1. Force `worktree_busy_probe_many` to return clear unconditionally → both
      `test_busy_check_error_also_blocks_removal` and `test_skips_lane_with_live_session`
      must **fail**.
-  2. Make the matcher return clear unconditionally → all five predicate tests named in Test
-     Impact must **fail**. Any that stays green is reaching no code.
-  3. Delete the `list(` wrapper in `_fetch_live_sessions` → the one-materialization test
+  2. Remove the terminal-status skip → `test_terminal_session_does_not_block` and
+     `test_terminal_session_in_lane_reports_clear` must **fail**.
+  3. Replace segment-aware containment with plain substring containment →
+     `test_substring_near_miss_does_not_block` and `test_unrelated_sessions_report_clear`
+     must **fail**.
+  4. Back-fill a falsy `working_dir` with the lane's own path →
+     `test_session_with_no_working_dir_skipped` must **fail**.
+  5. Delete the `list(` wrapper in `_fetch_live_sessions` → the one-materialization test
      must **fail** with a count of N rather than 1.
   Paste each red output into the PR.
 
@@ -1109,7 +1126,7 @@ so they can run in parallel without the shared-worktree livelock.
   the last one via the AST row, and demonstrated red against the black-wrapped form.
 - Confirm `_fetch_live_sessions` returns a materialized `list` and that the `list(...)` sits
   inside the `try` (Decision 0), and that no `QueryBuilder` crosses a function boundary.
-- Confirm the three mutation runs each reported red for the guards they target.
+- Confirm the five mutation runs each reported red for the guards they target.
 
 ### 5. Documentation
 - **Task ID**: document-feature

--- a/tests/unit/test_disk_reclaim.py
+++ b/tests/unit/test_disk_reclaim.py
@@ -12,6 +12,7 @@ import os
 import re
 import subprocess
 import time
+from unittest.mock import patch
 
 import pytest
 
@@ -63,6 +64,12 @@ def all_clear(monkeypatch):
         return {"worktree_removed": True, "branch_deleted": True, "errors": []}
 
     monkeypatch.setattr(wm, "_worktree_has_live_process", lambda _p: None)
+    # The happy path now crosses both the lazy batch map and the fresh
+    # single-slug re-probe immediately before removal (Decision 4) -- stub
+    # both so a test that neutralizes "every guard" actually does.
+    monkeypatch.setattr(
+        wm, "worktree_busy_probe_many", lambda _r, slugs: {s: ("clear", "") for s in slugs}
+    )
     monkeypatch.setattr(wm, "worktree_busy_probe", lambda _r, _s: ("clear", ""))
     monkeypatch.setattr(wm, "merged_via_tree", lambda *_a, **_k: True)
     monkeypatch.setattr(wm, "cleanup_after_merge", fake_cleanup)
@@ -185,9 +192,17 @@ def test_skips_lane_with_live_os_process(repo, all_clear, monkeypatch):
 
 
 def test_skips_lane_with_live_session(repo, all_clear, monkeypatch):
+    """The batch map -- not the single-slug wrapper -- is what guard 5 reads.
+
+    Once `sweep_worktrees` consults `worktree_busy_probe_many`, patching only
+    `worktree_busy_probe` leaves this test passing vacuously against a guard
+    the code no longer calls at that point.
+    """
     import agent.worktree_manager as wm
 
-    monkeypatch.setattr(wm, "worktree_busy_probe", lambda _r, _s: ("busy", "sess-1"))
+    monkeypatch.setattr(
+        wm, "worktree_busy_probe_many", lambda _r, slugs: {"lane": ("busy", "sess-1")}
+    )
     sweep = sweep_worktrees(repo, apply=True)
     assert _reasons(sweep)["lane"] == "live_session:sess-1"
     assert all_clear == []
@@ -198,12 +213,15 @@ def test_busy_check_error_also_blocks_removal(repo, all_clear, monkeypatch):
 
     `worktree_busy_check` is fail-open by design and returns None both when a
     lane is genuinely idle and when Redis is unreachable. An unattended reaper
-    that used it would delete every lane during a Redis outage.
+    that used it would delete every lane during a Redis outage. This exercises
+    the batch guard-5 path, which is where a Redis outage now surfaces first.
     """
     import agent.worktree_manager as wm
 
     monkeypatch.setattr(
-        wm, "worktree_busy_probe", lambda _r, _s: ("error", "query_failed:ConnectionError")
+        wm,
+        "worktree_busy_probe_many",
+        lambda _r, slugs: dict.fromkeys(slugs, ("error", "query_failed:ConnectionError")),
     )
     sweep = sweep_worktrees(repo, apply=True)
     assert sweep.removed == []
@@ -315,6 +333,162 @@ def test_protected_worktree_is_skipped_even_when_pr_state_is_unavailable(repo, m
 def test_missing_worktrees_dir_is_not_an_error(tmp_path, all_clear):
     sweep = sweep_worktrees(tmp_path / "empty", apply=True)
     assert sweep.removed == [] and sweep.skipped == [] and sweep.errors == []
+
+
+# --- batch probe: one scan per sweep, not one per lane (Decision 0/4/5) -----
+
+
+class _CountingRows(list):
+    """A list subclass that counts how many times it was iterated.
+
+    Stands in for the materialized rows `_fetch_live_sessions` returns, so a
+    test can prove the batch fetch is consumed exactly once per sweep-wide
+    query rather than once per lane classified against it (Decision 0).
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.iterations = 0
+
+    def __iter__(self):
+        self.iterations += 1
+        return super().__iter__()
+
+
+def _multi_lane_repo(tmp_path, names):
+    root = tmp_path / "repo"
+    for name in names:
+        lane = root / ".worktrees" / name
+        lane.mkdir(parents=True)
+        (lane / "file.txt").write_text("content")
+    _age(root / ".worktrees")
+    return root
+
+
+def test_reprobe_call_count_equals_removed_count_under_apply_true(repo, all_clear, monkeypatch):
+    """Decision 4: the fresh single-slug re-probe fires once per lane
+    actually removed under `apply=True`, driven through the real
+    `worktree_busy_probe` (wrapped only to count, not to change behavior).
+    """
+    import agent.worktree_manager as wm
+
+    calls: list[str] = []
+    original = wm.worktree_busy_probe
+
+    def counting_probe(repo_root, slug):
+        calls.append(slug)
+        return original(repo_root, slug)
+
+    monkeypatch.setattr(wm, "worktree_busy_probe", counting_probe)
+    sweep = sweep_worktrees(repo, apply=True)
+    assert sweep.removed == ["lane"]
+    assert calls == ["lane"]
+    assert len(calls) == len(sweep.removed)
+
+
+def test_reprobe_call_count_is_zero_under_apply_false(repo, all_clear, monkeypatch):
+    """The `apply=False` early return deletes nothing, so it opens no TOCTOU
+    window and pays no re-probe -- the expected count is zero regardless of
+    `len(sweep.removed)`.
+    """
+    import agent.worktree_manager as wm
+
+    calls: list[str] = []
+    original = wm.worktree_busy_probe
+
+    def counting_probe(repo_root, slug):
+        calls.append(slug)
+        return original(repo_root, slug)
+
+    monkeypatch.setattr(wm, "worktree_busy_probe", counting_probe)
+    sweep = sweep_worktrees(repo, apply=False)
+    assert sweep.removed == ["lane"]
+    assert calls == []
+
+
+def test_snapshot_clear_but_reprobe_busy_blocks_removal(repo, all_clear, monkeypatch):
+    """Race 1: a session can start in the window between the batch snapshot
+    and the fresh re-probe. The re-probe, not the stale snapshot, must win.
+    """
+    import agent.worktree_manager as wm
+
+    monkeypatch.setattr(wm, "worktree_busy_probe", lambda _r, _s: ("busy", "sess-late"))
+    sweep = sweep_worktrees(repo, apply=True)
+    assert sweep.removed == []
+    assert _reasons(sweep)["lane"] == "live_session:sess-late"
+
+
+def test_sweep_materializes_session_query_exactly_once_across_many_lanes(monkeypatch, tmp_path):
+    """One batch session query for the whole sweep, not one per lane that
+    reaches guard 5 -- measured by counting iterations of the fetched rows,
+    never by counting `filter()` calls (Decision 0, Success Criterion 4).
+
+    Driven under `apply=False` so no per-lane re-probe (Decision 4) adds its
+    own materialization on top of the batch one; that count is covered
+    separately by the reprobe-count tests above.
+    """
+    import agent.worktree_manager as wm
+
+    root = _multi_lane_repo(tmp_path, ["lane-a", "lane-b", "lane-c"])
+    monkeypatch.setattr(wm, "_worktree_has_live_process", lambda _p: None)
+    monkeypatch.setattr(wm, "merged_via_tree", lambda *_a, **_k: True)
+    monkeypatch.setattr(disk_reclaim, "open_pr_branches", lambda _root: set())
+    monkeypatch.setattr(disk_reclaim, "_worktree_is_dirty", lambda _p: False)
+
+    rows = _CountingRows([])
+    with patch("models.agent_session.AgentSession") as mock_as:
+        mock_as.query.filter.return_value = rows
+        sweep = sweep_worktrees(root, apply=False)
+
+    assert sorted(sweep.removed) == ["lane-a", "lane-b", "lane-c"]
+    assert rows.iterations == 1
+    assert mock_as.query.filter.call_count == 1
+
+
+def test_sweep_makes_zero_materializations_when_every_lane_is_too_young(monkeypatch, tmp_path):
+    """An all-`too_young` sweep never reaches guard 5, so the batch map is
+    never built and the session table is never touched at all.
+    """
+    root = tmp_path / "repo"
+    for name in ("lane-a", "lane-b"):
+        lane = root / ".worktrees" / name
+        lane.mkdir(parents=True)
+        (lane / "file.txt").write_text("content")
+    # Freshly touched (no _age() call): every lane fails the age guard before
+    # guard 5 is ever reached.
+    monkeypatch.setattr(disk_reclaim, "open_pr_branches", lambda _root: set())
+
+    rows = _CountingRows([])
+    with patch("models.agent_session.AgentSession") as mock_as:
+        mock_as.query.filter.return_value = rows
+        sweep = sweep_worktrees(root, apply=True)
+
+    assert sweep.removed == []
+    assert {reason for _, reason in sweep.skipped} == {"too_young"}
+    assert rows.iterations == 0
+    mock_as.query.filter.assert_not_called()
+
+
+def test_sweep_completes_when_batch_fetch_raises(repo, monkeypatch):
+    """Decision 6: a raising fetch must not escape into the sweep itself.
+
+    `tools/disk_reclaim.py` has no `except` around guard 5 by design -- the
+    never-raises guarantee belongs to `worktree_busy_probe_many` alone. This
+    drives the *real* batch probe (not a mock of it) so the raise happens
+    exactly where it does in production: inside `_fetch_live_sessions`.
+    """
+    import agent.worktree_manager as wm
+
+    monkeypatch.setattr(wm, "_worktree_has_live_process", lambda _p: None)
+    monkeypatch.setattr(disk_reclaim, "open_pr_branches", lambda _root: set())
+    monkeypatch.setattr(disk_reclaim, "_worktree_is_dirty", lambda _p: False)
+
+    with patch("models.agent_session.AgentSession") as mock_as:
+        mock_as.query.filter.side_effect = RuntimeError("redis down")
+        sweep = sweep_worktrees(repo, apply=True)  # must not raise
+
+    assert sweep.removed == []
+    assert _reasons(sweep)["lane"] == "busy_check_error:query_failed:RuntimeError"
 
 
 # --- open_pr_branches fails closed ------------------------------------------

--- a/tests/unit/test_disk_reclaim.py
+++ b/tests/unit/test_disk_reclaim.py
@@ -367,8 +367,10 @@ def _multi_lane_repo(tmp_path, names):
 
 def test_reprobe_call_count_equals_removed_count_under_apply_true(repo, all_clear, monkeypatch):
     """Decision 4: the fresh single-slug re-probe fires once per lane
-    actually removed under `apply=True`, driven through the real
-    `worktree_busy_probe` (wrapped only to count, not to change behavior).
+    actually removed under `apply=True`. The counter wraps whatever the
+    `all_clear` fixture installed at `wm.worktree_busy_probe` (a clear-returning
+    stub), purely to count calls -- it does not change behavior. What this
+    pins is the real call site and its count, not the probe implementation.
     """
     import agent.worktree_manager as wm
 

--- a/tests/unit/worktree_manager/test_worktree_manager_busy_guards.py
+++ b/tests/unit/worktree_manager/test_worktree_manager_busy_guards.py
@@ -9,12 +9,14 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from agent.worktree_manager import (
+    _fetch_live_sessions,
     _scan_worktree_sessions,
     _worktree_has_live_process,
     cleanup_after_merge,
     remove_worktree,
     worktree_busy_check,
     worktree_busy_probe,
+    worktree_busy_probe_many,
 )
 
 
@@ -34,17 +36,50 @@ def _make_session(
     )
 
 
+class _RaisingOnIter:
+    """A ``query.filter(...)`` return value that raises when materialized.
+
+    ``AgentSession.query.filter(...)`` returns a lazy ``QueryBuilder`` in
+    production; the real failure surfaces during iteration (``list(...)``),
+    not at the ``filter()`` call itself (Decision 0). A plain
+    ``side_effect`` on ``.filter`` would raise too early and leave that
+    failure mode untested, so these fixtures raise from ``__iter__`` instead.
+    """
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    def __iter__(self):
+        raise self._exc
+
+
+class _CountingRows(list):
+    """A list subclass that counts how many times it was iterated.
+
+    Used to prove a batch fetch materializes exactly once per sweep rather
+    than once per slug (Decision 0 / Risk 1b).
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.iterations = 0
+
+    def __iter__(self):
+        self.iterations += 1
+        return super().__iter__()
+
+
 class TestWorktreeBusyCheck:
     """Tests for worktree_busy_check (issue #1357)."""
 
     @patch("models.agent_session.AgentSession")
     def test_no_sessions_returns_none(self, mock_as):
-        mock_as.query.all.return_value = []
+        mock_as.query.filter.return_value = []
         assert worktree_busy_check(Path("/fake/repo"), "sdlc-1218") is None
 
     @patch("models.agent_session.AgentSession")
     def test_terminal_session_does_not_block(self, mock_as):
-        mock_as.query.all.return_value = [
+        mock_as.query.filter.return_value = [
             _make_session("/fake/repo/.worktrees/sdlc-1218", "completed"),
             _make_session("/fake/repo/.worktrees/sdlc-1218", "killed"),
             _make_session("/fake/repo/.worktrees/sdlc-1218", "failed"),
@@ -55,7 +90,7 @@ class TestWorktreeBusyCheck:
 
     @patch("models.agent_session.AgentSession")
     def test_running_session_blocks(self, mock_as):
-        mock_as.query.all.return_value = [
+        mock_as.query.filter.return_value = [
             _make_session(
                 "/fake/repo/.worktrees/sdlc-1218",
                 "running",
@@ -69,7 +104,7 @@ class TestWorktreeBusyCheck:
     @patch("models.agent_session.AgentSession")
     def test_subdir_match_blocks(self, mock_as):
         """working_dir below the worktree root still counts as busy."""
-        mock_as.query.all.return_value = [
+        mock_as.query.filter.return_value = [
             _make_session(
                 "/fake/repo/.worktrees/sdlc-1218/sub/dir",
                 "running",
@@ -83,7 +118,7 @@ class TestWorktreeBusyCheck:
     @patch("models.agent_session.AgentSession")
     def test_substring_near_miss_does_not_block(self, mock_as):
         """sdlc-1218-other must NOT match sdlc-1218 (segment-aware)."""
-        mock_as.query.all.return_value = [
+        mock_as.query.filter.return_value = [
             _make_session(
                 "/fake/repo/.worktrees/sdlc-1218-other",
                 "running",
@@ -94,7 +129,7 @@ class TestWorktreeBusyCheck:
     @patch("models.agent_session.AgentSession")
     def test_relative_working_dir_match(self, mock_as):
         """working_dir stored as a relative path resolves against repo_root."""
-        mock_as.query.all.return_value = [
+        mock_as.query.filter.return_value = [
             _make_session(".worktrees/sdlc-1218", "running", session_id="0_REL"),
         ]
         # Use the actual cwd-resolvable repo root so resolve() works.
@@ -107,12 +142,12 @@ class TestWorktreeBusyCheck:
     @patch("models.agent_session.AgentSession")
     def test_query_raises_returns_none(self, mock_as):
         """Popoto query failure fails open (returns None) and logs WARNING."""
-        mock_as.query.all.side_effect = RuntimeError("redis down")
+        mock_as.query.filter.return_value = _RaisingOnIter(RuntimeError("redis down"))
         assert worktree_busy_check(Path("/fake/repo"), "sdlc-1218") is None
 
     @patch("models.agent_session.AgentSession")
     def test_session_with_no_working_dir_skipped(self, mock_as):
-        mock_as.query.all.return_value = [
+        mock_as.query.filter.return_value = [
             _make_session(None, "running"),
             _make_session("", "running"),
         ]
@@ -132,7 +167,7 @@ class TestWorktreeBusyProbe:
     @patch("models.agent_session.AgentSession")
     def test_query_failure_reports_error_state(self, mock_as):
         """A Redis outage must read as "error", never as "clear"."""
-        mock_as.query.all.side_effect = RuntimeError("redis down")
+        mock_as.query.filter.return_value = _RaisingOnIter(RuntimeError("redis down"))
         state, detail = worktree_busy_probe(Path("/fake/repo"), "sdlc-1218")
         assert state == "error"
         assert detail.startswith("query_failed:")
@@ -147,7 +182,7 @@ class TestWorktreeBusyProbe:
 
     @patch("models.agent_session.AgentSession")
     def test_live_session_in_lane_reports_busy(self, mock_as):
-        mock_as.query.all.return_value = [
+        mock_as.query.filter.return_value = [
             _make_session(
                 "/fake/repo/.worktrees/sdlc-1218",
                 "running",
@@ -160,7 +195,7 @@ class TestWorktreeBusyProbe:
     @patch("models.agent_session.AgentSession")
     def test_busy_falls_back_to_agent_session_id(self, mock_as):
         """An empty session_id must not degrade the detail into a falsy blank."""
-        mock_as.query.all.return_value = [
+        mock_as.query.filter.return_value = [
             _make_session(
                 "/fake/repo/.worktrees/sdlc-1218",
                 "running",
@@ -172,7 +207,7 @@ class TestWorktreeBusyProbe:
 
     @patch("models.agent_session.AgentSession")
     def test_unrelated_sessions_report_clear(self, mock_as):
-        mock_as.query.all.return_value = [
+        mock_as.query.filter.return_value = [
             _make_session("/fake/repo/.worktrees/sdlc-9999", "running"),
             _make_session("/fake/repo/.worktrees/sdlc-1218-other", "running"),
             _make_session("/fake/repo", "running"),
@@ -182,7 +217,7 @@ class TestWorktreeBusyProbe:
     @patch("models.agent_session.AgentSession")
     def test_terminal_session_in_lane_reports_clear(self, mock_as):
         """The probe's own terminal filtering, observable at the probe level."""
-        mock_as.query.all.return_value = [
+        mock_as.query.filter.return_value = [
             _make_session("/fake/repo/.worktrees/sdlc-1218", "completed"),
             _make_session("/fake/repo/.worktrees/sdlc-1218", "killed"),
             _make_session("/fake/repo/.worktrees/sdlc-1218", "failed"),
@@ -191,7 +226,7 @@ class TestWorktreeBusyProbe:
 
     @patch("models.agent_session.AgentSession")
     def test_no_sessions_reports_clear(self, mock_as):
-        mock_as.query.all.return_value = []
+        mock_as.query.filter.return_value = []
         assert worktree_busy_probe(Path("/fake/repo"), "sdlc-1218") == ("clear", "")
 
 
@@ -200,7 +235,7 @@ class TestScanWorktreeSessions:
 
     @patch("models.agent_session.AgentSession")
     def test_query_failure_tuple(self, mock_as):
-        mock_as.query.all.side_effect = ValueError("boom")
+        mock_as.query.filter.return_value = _RaisingOnIter(ValueError("boom"))
         assert _scan_worktree_sessions(Path("/fake/repo"), "sdlc-1218") == (
             "error",
             "query_failed:ValueError",
@@ -216,7 +251,7 @@ class TestScanWorktreeSessions:
 
     @patch("models.agent_session.AgentSession")
     def test_busy_tuple_carries_both_ids(self, mock_as):
-        mock_as.query.all.return_value = [
+        mock_as.query.filter.return_value = [
             _make_session(
                 "/fake/repo/.worktrees/sdlc-1218/sub",
                 "running",
@@ -232,8 +267,175 @@ class TestScanWorktreeSessions:
 
     @patch("models.agent_session.AgentSession")
     def test_clear_tuple(self, mock_as):
-        mock_as.query.all.return_value = []
+        mock_as.query.filter.return_value = []
         assert _scan_worktree_sessions(Path("/fake/repo"), "sdlc-1218") == ("clear", "", "")
+
+    def test_unknown_status_value_reads_busy(self):
+        """A status outside ALL_STATUSES must stay fail-closed (Risk 2, spike-4).
+
+        It is non-terminal under the surviving Python check but absent from
+        the index union that produced ``sessions``, so this exercises the
+        Python `` not in TERMINAL_STATUSES`` check directly rather than the
+        index — the row is handed in via ``sessions=`` as if the index had
+        already (correctly, for a real deployment) returned it.
+        """
+        rows = [
+            _make_session(
+                "/fake/repo/.worktrees/sdlc-1218",
+                "some_future_status",
+                session_id="0_UNKNOWN",
+            ),
+        ]
+        assert _scan_worktree_sessions(Path("/fake/repo"), "sdlc-1218", sessions=rows) == (
+            "busy",
+            "0_UNKNOWN",
+            "agt-1",
+        )
+
+    def test_raising_row_is_skipped_and_later_busy_row_still_wins(self):
+        """A row that raises on attribute access is skipped, not fatal.
+
+        Covers the per-row ``except Exception`` / ``continue`` branch, which
+        had zero test coverage before this change. ``MagicMock(spec=["status"])``
+        has a ``status`` attribute but no ``working_dir``, so
+        ``getattr(session, "working_dir", None)`` does not raise -- the
+        matcher must be exercised with a row that raises on the attribute it
+        *does* try to read.
+        """
+
+        class _BoomOnWorkingDir:
+            @property
+            def working_dir(self):
+                raise RuntimeError("attribute access exploded")
+
+        rows = [
+            _BoomOnWorkingDir(),
+            _make_session(
+                "/fake/repo/.worktrees/sdlc-1218",
+                "running",
+                session_id="0_LATER",
+            ),
+        ]
+        assert _scan_worktree_sessions(Path("/fake/repo"), "sdlc-1218", sessions=rows) == (
+            "busy",
+            "0_LATER",
+            "agt-1",
+        )
+
+    def test_injected_sessions_skips_fetch(self):
+        """``sessions=`` bypasses ``_fetch_live_sessions`` entirely.
+
+        A model-import failure that would normally produce
+        ``model_import_failed:`` must not surface when rows are injected --
+        the injected path never touches the deferred import that fetching
+        would use.
+        """
+        rows = [
+            _make_session("/fake/repo/.worktrees/sdlc-1218", "running", session_id="0_INJ"),
+        ]
+        with patch.dict(sys.modules, {"models.agent_session": None}):
+            result = _scan_worktree_sessions(Path("/fake/repo"), "sdlc-1218", sessions=rows)
+        assert result == ("busy", "0_INJ", "agt-1")
+
+
+class TestFetchLiveSessions:
+    """Tests for ``_fetch_live_sessions`` — the single Redis touch point."""
+
+    @patch("models.agent_session.AgentSession")
+    def test_materializes_exactly_once(self, mock_as):
+        """``list(...)`` must consume the query object exactly once (Decision 0)."""
+        rows = _CountingRows(
+            [_make_session("/fake/repo/.worktrees/sdlc-1218", "running")],
+        )
+        mock_as.query.filter.return_value = rows
+        fetched, error_reason = _fetch_live_sessions()
+        assert error_reason == ""
+        assert len(fetched) == 1
+        assert rows.iterations == 1
+
+    @patch("models.agent_session.AgentSession")
+    def test_query_failure_on_iteration(self, mock_as):
+        mock_as.query.filter.return_value = _RaisingOnIter(RuntimeError("redis down"))
+        rows, error_reason = _fetch_live_sessions()
+        assert rows == []
+        assert error_reason == "query_failed:RuntimeError"
+
+    def test_model_import_failure(self):
+        with patch.dict(sys.modules, {"models.agent_session": None}):
+            rows, error_reason = _fetch_live_sessions()
+        assert rows == []
+        assert error_reason.startswith("model_import_failed:")
+
+    @patch("models.agent_session.AgentSession")
+    def test_filters_on_non_terminal_status(self, mock_as):
+        """The query is built from ``status__in=NON_TERMINAL_STATUSES``."""
+        mock_as.query.filter.return_value = []
+        _fetch_live_sessions()
+        assert mock_as.query.filter.call_count == 1
+        _, kwargs = mock_as.query.filter.call_args
+        assert "status__in" in kwargs
+
+
+class TestWorktreeBusyProbeMany:
+    """Tests for ``worktree_busy_probe_many`` — the batch probe (Task 1)."""
+
+    def test_empty_slugs_returns_empty_and_queries_nothing(self):
+        with patch("agent.worktree_manager._fetch_live_sessions") as mock_fetch:
+            result = worktree_busy_probe_many(Path("/fake/repo"), [])
+        assert result == {}
+        mock_fetch.assert_not_called()
+
+    @patch("models.agent_session.AgentSession")
+    def test_agrees_with_single_slug_probe_across_states(self, mock_as):
+        """One rows object, two slugs, two different verdicts."""
+        mock_as.query.filter.return_value = [
+            _make_session(
+                "/fake/repo/.worktrees/lane-b",
+                "running",
+                session_id="0_B",
+                agent_session_id="agt-B",
+            ),
+        ]
+        result = worktree_busy_probe_many(Path("/fake/repo"), ["lane-a", "lane-b"])
+        assert result == {
+            "lane-a": ("clear", ""),
+            "lane-b": ("busy", "0_B"),
+        }
+        # Same fixture, driven through the single-slug wrapper, must agree.
+        assert worktree_busy_probe(Path("/fake/repo"), "lane-a") == ("clear", "")
+        assert worktree_busy_probe(Path("/fake/repo"), "lane-b") == ("busy", "0_B")
+
+    @patch("models.agent_session.AgentSession")
+    def test_fetch_error_fans_out_to_every_slug(self, mock_as):
+        """A Redis outage must not default any requested slug to clear."""
+        mock_as.query.filter.return_value = _RaisingOnIter(RuntimeError("redis down"))
+        result = worktree_busy_probe_many(Path("/fake/repo"), ["lane-a", "lane-b"])
+        assert result == {
+            "lane-a": ("error", "query_failed:RuntimeError"),
+            "lane-b": ("error", "query_failed:RuntimeError"),
+        }
+
+    @patch("models.agent_session.AgentSession")
+    def test_never_raises_on_fetch_failure(self, mock_as):
+        """Decision 6: the batch probe itself must not propagate."""
+        mock_as.query.filter.side_effect = RuntimeError("boom before even building a builder")
+        result = worktree_busy_probe_many(Path("/fake/repo"), ["lane-a"])
+        assert result == {"lane-a": ("error", "query_failed:RuntimeError")}
+
+    @patch("models.agent_session.AgentSession")
+    def test_one_rows_object_serves_many_slugs_with_one_materialization(self, mock_as):
+        rows = _CountingRows(
+            [_make_session("/fake/repo/.worktrees/lane-a", "running", session_id="0_A")]
+        )
+        mock_as.query.filter.return_value = rows
+        result = worktree_busy_probe_many(
+            Path("/fake/repo"), ["lane-a", "lane-b", "lane-c", "lane-d"]
+        )
+        assert result["lane-a"] == ("busy", "0_A")
+        assert result["lane-b"] == ("clear", "")
+        assert result["lane-c"] == ("clear", "")
+        assert result["lane-d"] == ("clear", "")
+        assert rows.iterations == 1
 
 
 class TestRemoveWorktreeBusyGuard:

--- a/tests/unit/worktree_manager/test_worktree_manager_busy_guards.py
+++ b/tests/unit/worktree_manager/test_worktree_manager_busy_guards.py
@@ -271,13 +271,13 @@ class TestScanWorktreeSessions:
         assert _scan_worktree_sessions(Path("/fake/repo"), "sdlc-1218") == ("clear", "", "")
 
     def test_unknown_status_value_reads_busy(self):
-        """A status outside ALL_STATUSES must stay fail-closed (Risk 2, spike-4).
+        """An injected out-of-enum status stays fail-closed (Risk 2, spike-4).
 
-        It is non-terminal under the surviving Python check but absent from
-        the index union that produced ``sessions``, so this exercises the
-        Python `` not in TERMINAL_STATUSES`` check directly rather than the
-        index — the row is handed in via ``sessions=`` as if the index had
-        already (correctly, for a real deployment) returned it.
+        The index union cannot return such a row, so this is the one path
+        where the surviving Python ``not in TERMINAL_STATUSES`` check can
+        still exclude something: a caller handing rows in via ``sessions=``.
+        The out-of-enum status read on the fetching path is fail-open by
+        accepted trade, settled at the query, and is not what this asserts.
         """
         rows = [
             _make_session(

--- a/tools/disk_reclaim.py
+++ b/tools/disk_reclaim.py
@@ -361,6 +361,7 @@ def sweep_worktrees(
         cleanup_after_merge,
         merged_via_tree,
         worktree_busy_probe,
+        worktree_busy_probe_many,
     )
 
     sweep = Sweep(category="worktrees")
@@ -378,8 +379,17 @@ def sweep_worktrees(
         return sweep
 
     cutoff = time.time() - (min_age_days * 86400)
+    children = sorted(worktrees_root.iterdir())
 
-    for child in sorted(worktrees_root.iterdir()):
+    # Batch busy map, built lazily on first need: one session query for the
+    # whole sweep instead of one per lane that reaches this guard. Queried
+    # over every non-protected lane (a superset of the lanes that will
+    # actually reach guard 5) -- correct, and free, because the underlying
+    # fetch is one query regardless of how many slugs are classified against
+    # it. An all-`too_young` sweep never builds this and pays zero queries.
+    busy_map: dict[str, tuple[str, str]] | None = None
+
+    for child in children:
         if not child.is_dir():
             continue
         slug = child.name
@@ -412,7 +422,14 @@ def sweep_worktrees(
             sweep.skip(slug, f"live_process:{live_pid}")
             continue
 
-        state, detail = worktree_busy_probe(repo_root, slug)
+        if busy_map is None:
+            candidate_slugs = [
+                c.name for c in children if c.is_dir() and c.name not in PROTECTED_WORKTREE_SLUGS
+            ]
+            busy_map = worktree_busy_probe_many(repo_root, candidate_slugs)
+        # Never default a missing slug to "clear" -- a lookup bug must read
+        # as an unanswerable question, not as a silent all-clear.
+        state, detail = busy_map.get(slug, ("error", "not_probed"))
         if state == "error":
             sweep.skip(slug, f"busy_check_error:{detail}")
             continue
@@ -437,6 +454,22 @@ def sweep_worktrees(
         if not apply:
             sweep.removed.append(slug)
             sweep.freed_bytes += size
+            continue
+
+        # Fresh, single-slug, fail-closed re-probe immediately before
+        # authorizing removal. The batch snapshot above can be seconds to
+        # minutes stale by the time a lane reaches here -- everything the
+        # sweep does per remaining lane after it (_tree_stats, git status,
+        # merged_via_tree) sits inside that window -- so the read that
+        # actually authorizes deletion is never older than the guard right
+        # below it. Skipped on the apply=False path above: dry run deletes
+        # nothing, so there is no TOCTOU window here to close.
+        state, detail = worktree_busy_probe(repo_root, slug)
+        if state == "error":
+            sweep.skip(slug, f"busy_check_error:{detail}")
+            continue
+        if state == "busy":
+            sweep.skip(slug, f"live_session:{detail}")
             continue
 
         try:


### PR DESCRIPTION
## Summary

Closes #2712.

`_scan_worktree_sessions()` no longer hydrates `AgentSession.query.all()` and
discards terminal rows in Python. `_fetch_live_sessions()` issues one
indexed, materialized `status__in=NON_TERMINAL_STATUSES` query instead —
a strict push-down of the filter the matching loop already performed, so it
cannot change which sessions are considered for any status the index knows.
Narrowing on the index does accept a **fail-open** reading for a status outside
`ALL_STATUSES`: such a row is never fetched, so its lane reads clear. That trade
is settled at the query and is accepted on spike-4's evidence — no live
out-of-enum value, and no status write site outside `models/session_lifecycle.py`,
whose setter rejects unknown values. The Python `not in TERMINAL_STATUSES` check
survives, but it is not what holds that line: `TERMINAL_STATUSES` and
`NON_TERMINAL_STATUSES` are disjoint, so every fetched row passes it by
construction. It is kept as the correct predicate for the one path that can
present an out-of-enum status — a caller injecting rows via `sessions=`.

`worktree_busy_probe_many(repo_root, slugs)` fetches once and matches every
candidate slug against that one in-memory list through the existing
segment-aware containment matcher (`_scan_worktree_sessions(..., sessions=)`),
so batch and single-slug results cannot drift apart. `sweep_worktrees` builds
this batch map lazily, the first lane that reaches the busy guard — an
all-`too_young` sweep still pays zero session queries. On the `apply=True`
path only, immediately before `cleanup_after_merge`, the sweep re-probes that
one lane fresh with the single-slug, fail-closed `worktree_busy_probe()` —
the read that authorizes an actual deletion is never older than the guard
right below it (Decision 4 / Race 1). `worktree_busy_check()` stays
fail-open, `worktree_busy_probe()` stays fail-closed, bit for bit.

The `list(...)` wrapper around the query in `_fetch_live_sessions` is
load-bearing, not stylistic (Decision 0): `AgentSession.query.filter(...)`
returns a lazy `QueryBuilder` that re-executes on every iteration and issues
no Redis command by itself, so handing an unmaterialized builder to the batch
probe would reintroduce one full query per slug — the exact amplification
this PR removes — and a bare `try` around `filter()` alone would catch
nothing (the connection error surfaces during iteration).

## Anti-criteria demonstrated red then reverted (plan requirement)

- `query.all()` injected → `grep -c 'query\.all()'` went from 0 to 1, reverted to 0.
- `filter(slug=` injected → same pattern, 0 → 1 → 0.
- Deleted the `list(` wrapper in `_fetch_live_sessions` → the Decision-0 AST
  check flipped `OK` → `BAD`, reverted to `OK`.
- A `("clear", "")` default on the batch-map `.get()` read, injected both as
  a single line and as a black-wrapped multi-line call → the Risk-4 AST check
  (which parses the tree rather than grepping, specifically so a reformat
  cannot slip past it) flipped `OK []` → `BAD [432]` in both forms, reverted
  to `OK []`.

## Mutation-checked tests (plan requirement)

Every count below was re-measured for this round on a sandboxed copy of the
branch, running both touched test files together (100 tests, all green
unmutated). The checkout itself was never mutated; `git diff --quiet` stayed
clean throughout.

- **Matcher's busy branch forced never to fire** → **11 red, all 11 in
  `tests/unit/worktree_manager/test_worktree_manager_busy_guards.py` and 0 in
  `tests/unit/test_disk_reclaim.py`** (the disk-reclaim tests stub
  `worktree_busy_probe_many`, so this mutation cannot reach them). Every one of
  the 11 asserts busy or error, or is coverage this PR adds:
  `test_running_session_blocks`, `test_subdir_match_blocks`,
  `test_relative_working_dir_match`, `test_live_session_in_lane_reports_busy`,
  `test_busy_falls_back_to_agent_session_id`,
  `test_busy_tuple_carries_both_ids`, `test_unknown_status_value_reads_busy`,
  `test_raising_row_is_skipped_and_later_busy_row_still_wins`,
  `test_injected_sessions_skips_fetch`,
  `test_agrees_with_single_slug_probe_across_states`,
  `test_one_rows_object_serves_many_slugs_with_one_materialization`. None of
  the five predicate tests named in Test Impact is among them, and none can be:
  all five assert *clear*, so a matcher that never reports busy leaves them
  green by construction.
- **The five predicate tests are pinned separately**, each by a mutation of the
  predicate it actually asserts:
  - terminal-status skip removed (`if not status or status in
    TERMINAL_STATUSES` → `if not status`) → **2 red**:
    `test_terminal_session_does_not_block`,
    `test_terminal_session_in_lane_reports_clear`.
  - segment-aware containment replaced with plain substring containment
    (`if worktree_norm in session_norm`) → **2 red**:
    `test_substring_near_miss_does_not_block`,
    `test_unrelated_sessions_report_clear`.
  - falsy `working_dir` back-filled with the lane's own path
    (`wd = getattr(session, "working_dir", None) or worktree_norm`) → **1 red**:
    `test_session_with_no_working_dir_skipped`. Deleting the
    `if not wd: continue` skip on its own is **not** discriminating and was
    measured green (100 passed, 0 red): a `None`/`""` `working_dir` then falls
    through to the path branch, raises inside the inner `try`, normalizes to a
    non-matching string, and the lane still reads clear. The back-fill is the
    mutation that models the bug this test guards against.
- **`list(` wrapper deleted in `_fetch_live_sessions`** → **8 red**. Three are
  materialization counts, each off by exactly the amplification the wrapper
  prevents, all against an expected 1: `test_materializes_exactly_once` counts
  0 (the lazy builder is never iterated, so no query is attempted),
  `test_sweep_materializes_session_query_exactly_once_across_many_lanes` counts
  3 (once per lane), and
  `test_one_rows_object_serves_many_slugs_with_one_materialization` counts 4
  (once per slug). The other five are the error paths that only close when the
  query is materialized inside the `try`: `test_query_failure_on_iteration`,
  `test_query_failure_tuple`, `test_query_raises_returns_none`,
  `test_query_failure_reports_error_state`,
  `test_fetch_error_fans_out_to_every_slug`.

## Re-measured, not assumed (Task 6)

Ran `sweep_worktrees` against this checkout's real `.worktrees/` (11 lanes)
with a counting wrapper on `AgentSession.query.filter`:

- **1** `filter()` call materializes the whole sweep — was up to 2 full
  `query.all()` scans pre-change (one per lane reaching the probe).
- Guard-5 classification is unchanged from the plan's Freshness Check
  baseline: 8 `too_young`, 1 `uncommitted_changes`, 2 reaching the busy guard
  and landing `unmerged` (`rv2888`, `sdlc-2817` — the same two lanes the plan
  measured).

This run is a dry run (`apply=False`), so it shows zero re-probe calls by
construction — that path is evidenced by the dedicated
`apply=True`/`apply=False` re-probe-count tests instead, not by this run.

## Test plan

- [x] `./scripts/pytest-clean.sh tests/unit/worktree_manager/test_worktree_manager_busy_guards.py -q` — 42 passed
- [x] `./scripts/pytest-clean.sh tests/unit/test_disk_reclaim.py -q` — 58 passed
- [x] `python -m ruff check` / `ruff format --check` on all four touched files — clean
- [x] The plan's whole Verification table runs **0 FAIL / 0 malformed** under the
      declared runner (`parse_verification_table` + `run_checks`), 17/17 rows
- [x] Guard order unchanged (the row asserts the sweep's first 8 skip-reason
      literals as a substring; the re-probe reuses two of them per Decision
      4/Task 2, so they appear twice and the substring form tolerates that
      without weakening what the row pins)

## Note for reviewers

Three Verification rows were authored in an Expected grammar
`agent/verification_parser.py::evaluate_expectation` does not implement:
the Expected cells read "output &#96;OK&#96;", "output &#96;OK []&#96;", and
"exactly &#96;...&#96;" — backtick-wrapped values none of the five supported
forms accept. All three rows were therefore
permanently red regardless of the code — including the two most safety-critical
anti-criteria, Decision 0's materialization check and Risk 4's clear-valued-default
check. All three are rewritten in the supported `output contains X` form. The
guard-order row's substring form still pins the first eight literals in order
while tolerating the two the Decision-4 re-probe legitimately appends, so it
asserts what it was meant to assert instead of being unfixably red.

Each rewritten row was re-verified red under mutation: dropping the `list(`
wrapper flips it to `BAD`; a black-wrapped `("clear", "")` default flips it to
`BAD [432]`; swapping the `"open_pr"`/`"unmerged"` guard order breaks the
substring. All reverted.

The plan's mutation direction for the five predicate tests is corrected in this
round at all three sites that carried it — Test Impact, Success Criterion 9, and
the Team Orchestration mutation list — so the specification, the criterion, and
this PR body now name the same three discriminating mutations. Criterion 9 as
originally written could not be honestly ticked: it asked five clear-asserting
tests to redden under a matcher-returns-clear mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


