### PR TITLE
chore(docs-auditor): delete _write_liveness Redis channel, rehome vault count

### DIFF
--- a/docs/features/docs-auditor.md
+++ b/docs/features/docs-auditor.md
@@ -671,10 +671,13 @@ Summary of what lives in `reflections/docs_auditor.py`:
   compared (secrets-guarded, missing, or markitdown-sidecar entries don't
   count), appended as a trailing clause on the created-PR summary string
   **unconditionally**, including when the count is `0`. No other summary
-  string carries the clause — the four "skipped" returns never ran the vault
-  comparison as part of producing that summary, so "detector ran, found zero
-  drift" (clause reads `0`) stays distinguishable from "this run never
-  reached the created-PR path" (clause absent entirely).
+  string carries the clause. Of the five "skipped" returns, two (the lock
+  guard and the dirty-tree guard) fire before the vault comparison ever
+  runs; the other three (no candidates, the pre-write PR guards, zero-diff)
+  fire after it and simply don't thread the count into their own summary
+  strings. Either way, "detector ran, found zero drift" (clause reads `0`)
+  stays distinguishable from "this run never reached the created-PR path"
+  (clause absent entirely).
 - **Advisory only.** The detector files GitHub issues; it never rewrites
   `site/*.html` or vault files. The existing markdown-only apply guard is
   unchanged.

--- a/docs/features/docs-auditor.md
+++ b/docs/features/docs-auditor.md
@@ -370,12 +370,11 @@ applies at any age; the escalation issue waits for the same
 `STALE_PR_AGE_DAYS` threshold that would have closed a plain PR, so the
 title's "still unreviewed" claim is true when it is made. Because the dedup
 key fires once ever, a filing made on sight would make the wrong wording the
-permanent record. It also passes the withheld
-count to `_write_liveness` as a keyword `fixes_withheld`, emitted into the
-Redis summary only when non-zero — a secondary signal now that the durable
-operator surface is the GitHub issue plus the reflection dashboard's rendered
-`output_summary` (see [Configuration](#configuration)), not a manual
-`redis-cli` read.
+permanent record. The withheld count also reaches the reflection dashboard's
+rendered `output_summary` (see [Configuration](#configuration)): every
+returned summary string that mentions a withheld run interpolates the count
+directly, so the durable operator surface is the GitHub issue plus that
+rendered summary, not a Redis read.
 
 A rotation run that writes to the working tree and then fails to produce a PR
 — a `git`/`gh` step failing, or the scoped restore itself failing — files its
@@ -404,11 +403,10 @@ that branch for the cascade.
 `run_docs_auditor`'s outcome vocabulary is separate and stricter: `"ok"`
 survives on exactly the one return that created a PR. Every other return that
 reached the lock — the lock-held return, the dirty-tree guard, no candidates
-found, and a zero-diff pass — reports `"skipped"`, matching each one's own
-`_write_liveness(..., "skipped", ...)` call, so the field means "a PR was
-opened" and nothing weaker. (`"disabled"`, returned when the auth probe fails
-before the lock is even acquired, is a pre-flight bail rather than a run
-outcome and sits outside this vocabulary.)
+found, and a zero-diff pass — reports `"skipped"`, so the field means "a PR
+was opened" and nothing weaker. (`"disabled"`, returned when the auth probe
+fails before the lock is even acquired, is a pre-flight bail rather than a
+run outcome and sits outside this vocabulary.)
 
 ### File-as-issue (judgment required)
 
@@ -579,6 +577,11 @@ them with a real vault-aware mechanism that runs **beside**, not through, this
 rotation — see [Vault↔Site/Docs Drift Detector](#vaultsitedocs-drift-detector)
 below.
 
+Run outcomes reach the operator through the reflection's `output_summary`,
+not through a `docs_audit:` Redis key: every return builds a summary string,
+the scheduler stores it on the `Reflection` record, and the reflections
+dashboard renders it (see [Operational Cheatsheet](#operational-cheatsheet)).
+
 ## Locking
 
 ```
@@ -586,8 +589,6 @@ docs_audit:running:global       — rotation reflection lock (TTL 1h)
 docs_audit:sweeper:running      — branch-sweeper lock (TTL 30min)
 docs_audit:issues_filed:{hash}  — per-finding dedup (TTL 30d)
 docs_audit:last_run             — rotation state hash
-docs_audit:last_completed_run_ts        — Phase 2 liveness signal
-docs_audit:last_completed_run_summary   — Phase 2 liveness JSON summary
 ```
 
 All locks use the established SETNX pattern: `r.set(key, "1", nx=True, ex=ttl)`.
@@ -668,13 +669,12 @@ Summary of what lives in `reflections/docs_auditor.py`:
   every other detector in this module.
 - **`vault_narratives_compared`** — a per-run count of narratives actually
   compared (secrets-guarded, missing, or markitdown-sidecar entries don't
-  count), threaded into `_write_liveness` via a new **explicit optional 5th
-  parameter** (`vault_narratives_compared: int | None = None`). The other four
-  existing call sites still pass exactly four positional args and are
-  unaffected — `_write_liveness` only includes the field in the liveness
-  summary when it is not `None`, so "detector ran, found zero drift" (`0`) is
-  distinguishable from "the field is absent because this call site never runs
-  the vault comparison."
+  count), appended as a trailing clause on the created-PR summary string
+  **unconditionally**, including when the count is `0`. No other summary
+  string carries the clause — the four "skipped" returns never ran the vault
+  comparison as part of producing that summary, so "detector ran, found zero
+  drift" (clause reads `0`) stays distinguishable from "this run never
+  reached the created-PR path" (clause absent entirely).
 - **Advisory only.** The detector files GitHub issues; it never rewrites
   `site/*.html` or vault files. The existing markdown-only apply guard is
   unchanged.
@@ -720,11 +720,9 @@ now runs for real (advisory/report-only, same as before). Verify with
 # Inspect rotation state
 redis-cli HGETALL docs_audit:last_run
 
-# Phase 2 liveness signal — a secondary, per-machine surface. The durable
-# operator surfaces are the GitHub issue tracker and the reflections
-# dashboard's rendered "last run summary" (sourced from output_summary).
-redis-cli GET docs_audit:last_completed_run_ts
-redis-cli GET docs_audit:last_completed_run_summary
+# Run outcomes: check the reflections dashboard's "Last run summary" panel
+# for docs-auditor, or query the Reflection model directly. output_summary
+# is the durable surface; there is no Redis key to read.
 
 # Force-clear the lock if a run hung
 redis-cli DEL docs_audit:running:global
@@ -743,10 +741,12 @@ neighborhood cap, zero-diff gate, auth probe degradation, memory-refresh
 hook, and the `/do-docs` thin-caller contract. `TestIsSecretsPath` and
 `TestVaultSiteDrift` cover the vault↔site/docs drift detector (mixed-case,
 near-miss, symlink-into-secrets, out-of-vault exclusion; compared-count
-correctness; issue-cap enforcement); `TestWriteLivenessVaultParam` covers
-the `_write_liveness` 4-arg/5-arg positional contract (`fixes_withheld` is a
-trailing keyword param, so that contract is unchanged); `TestVaultDeadCodeRemoved`
-asserts `DEFAULT_VAULT_WEIGHT`, `vault_weight`, and `_vault_field` are gone.
+correctness; issue-cap enforcement); `TestVaultClauseInSummary` covers the
+created-PR summary's `vault_narratives_compared` clause (unconditional,
+including `0`; absent from the "skipped" summaries); `TestVaultDeadCodeRemoved`
+asserts `DEFAULT_VAULT_WEIGHT`, `vault_weight`, and `_vault_field` are gone;
+`TestLivenessDeadCodeRemoved` asserts the retired liveness function and its
+two Redis-key constants are gone.
 
 The four gates are covered by `TestStaleTermDictionary` (cue tiers across
 backticked, cased, alias, and arrow forms; the channel stays
@@ -759,7 +759,7 @@ ambiguous-but-present pass, no re-validation of pre-existing refs — every case
 is expressed as a prose-anchored regex fix whose *replacement*, not its match,
 carries the path-shaped string, so gate 3's path-token suppression cannot eat
 the case before the invariant runs), and `TestWithheldBlocksStaleClose` (a
-bare-name withhold reaching the PR body, Telegram, and liveness).
+bare-name withhold reaching the PR body and Telegram).
 `TestWithheldRateNonRegression` self-baselines the narrow and widened
 `_PATH_REF_RE` arms in one run inside a disposable detached `git worktree`,
 asserting the widening adds no withholds. `TestDeletedTargetFiltering::

--- a/docs/features/vault-drift-audit.md
+++ b/docs/features/vault-drift-audit.md
@@ -153,47 +153,40 @@ run — one per site page plus one per optional repo-doc counterpart), so the
 cap is defense-in-depth against a future mapping that grows, not a load-bearing
 limiter today.
 
-## Liveness signal
+## Narratives-compared signal
 
 `_run_vault_drift_detection` returns `vault_narratives_compared` — the count
 of narratives that were actually read and compared (secrets-guarded, missing,
-or markitdown-sidecar entries don't count). This threads into
-`_write_liveness` through a new **explicit optional 5th parameter**:
+or markitdown-sidecar entries don't count). `_run_vault_drift_detection` is
+annotated `-> int` and returns an `int` on every exit: `0` when the vault
+root is unresolvable, the real `compared` count on success, and `0` from its
+own `except Exception`. It never returns `None`.
+
+The count reaches the operator by appending a trailing clause to the
+created-PR summary string, unconditionally, including when the count is `0`:
 
 ```python
-def _write_liveness(
-    slug: str,
-    status: str,
-    pr_url: str | None,
-    files_touched: int,
-    vault_narratives_compared: int | None = None,
-    fixes_withheld: int = 0,
-) -> None: ...
+f"...; vault {vault_narratives_compared} narratives compared"
 ```
 
-`_write_liveness` had a fixed 4-arg signature with four existing call sites,
-each passing exactly four positional args; a bare 5th positional arg would
-have raised `TypeError` inside the function's own swallow-and-log wrapper,
-silently dropping the liveness write. The explicit-optional-parameter approach
-avoids that: the summary dict only gains a `vault_narratives_compared` key
-when the value is not `None`, and only the rotation call site that actually
-ran the vault comparison passes it — the other three call sites are unchanged
-and unbroken.
+That clause is written only on the one return that created a PR. The other
+returns — locked, dirty-tree, no-candidates, guard-skipped, zero-diff — never
+carry it, because none of them ran to the point of producing a PR summary.
 
-This makes "detector ran, found zero drift" (`vault_narratives_compared: 0`,
-key present) observably different from "the mapping is silently broken" (key
-absent entirely, from a call site that never ran the vault comparison) or
-from "vault unresolvable" (`vault_narratives_compared: 0` via
-`_resolve_vault_root` returning `None` before any file is read — same `0`
-value, but paired with the `docs_audit: vault root resolution failed` /
-`no knowledge_base mapping` warning in the logs). Inspect the current value
-with (a per-machine debugging aid; the durable operator surfaces are the
-GitHub issue tracker and the reflections dashboard's rendered
-`output_summary`):
+This makes three outcomes distinguishable by reading the summary alone:
 
-```bash
-redis-cli GET docs_audit:last_completed_run_summary
-```
+- **"Detector ran and compared N narratives"** — the clause reads `N > 0`.
+- **"The run never reached the created-PR path"** — the clause is absent
+  from the summary entirely (any non-PR return).
+- **"Vault unresolvable"** — the clause reads `0` on a created-PR run, paired
+  with the `docs_audit: vault root resolution failed` / `no knowledge_base
+  mapping` warning in the logs, which is what separates it from "resolved and
+  genuinely found nothing to compare."
+
+Check the current value on the reflections dashboard's "Last run summary"
+panel for `docs-auditor` (sourced from the `Reflection` record's
+`output_summary`) — the durable operator surfaces are that panel plus the
+GitHub issue tracker; there is no Redis key to read.
 
 ## Advisory only
 
@@ -260,8 +253,8 @@ all three are gone and that `_select_primary_doc` still globs only
   repo-doc counterpart / missing file / markitdown sidecar / secrets-guarded
   entry never read), the issue cap, and vault-unresolvable graceful
   degradation.
-- `TestWriteLivenessVaultParam` — 4-arg call sites unaffected, 5-arg call
-  site includes the count.
+- `TestVaultClauseInSummary` — the created-PR summary carries the count
+  unconditionally, including `0`, and no other summary string carries it.
 - `TestVaultDeadCodeRemoved` — the removed schema hook stays removed.
 
 ```bash

--- a/docs/plans/delete-write-liveness-docs-auditor.md
+++ b/docs/plans/delete-write-liveness-docs-auditor.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: docs_complete
 type: chore
 appetite: Small
 owner: Valor Engels

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -129,12 +129,10 @@ _RECURRING_CONDITION_CATEGORIES = frozenset({"vault-drift", "operational-failure
 # automation here runs `gh pr edit`.
 WITHHELD_PR_MARKER = "<!-- docs-auditor:fixes-withheld -->"
 
-# Redis key namespace for state/locks/liveness.
+# Redis key namespace for state/locks.
 REDIS_LAST_RUN_HASH = "docs_audit:last_run"
 REDIS_RUNNING_KEY = "docs_audit:running:global"
 REDIS_SWEEPER_RUNNING_KEY = "docs_audit:sweeper:running"
-REDIS_LAST_COMPLETED_TS_KEY = "docs_audit:last_completed_run_ts"
-REDIS_LAST_COMPLETED_SUMMARY_KEY = "docs_audit:last_completed_run_summary"
 REDIS_ISSUE_DEDUP_PREFIX = "docs_audit:issues_filed"
 REDIS_DAILY_PR_KEY = "docs_audit:prs_today"  # capped at 1 PR per calendar day
 
@@ -2150,47 +2148,6 @@ def _push_branch_and_pr(
     return url
 
 
-def _write_liveness(
-    slug: str,
-    status: str,
-    pr_url: str | None,
-    files_touched: int,
-    vault_narratives_compared: int | None = None,
-    fixes_withheld: int = 0,
-) -> None:
-    """Persist liveness signals for PM monitoring (Phase 2).
-
-    ``vault_narratives_compared`` is emitted into the summary only when not None
-    (i.e. only from the rotation call site that actually ran the vault drift
-    comparison), so "detector ran, found zero drift" is distinguishable from
-    "narrative→page mapping is silently empty/broken".
-
-    ``fixes_withheld`` is emitted only when non-zero, mirroring the same pattern.
-    This is the only durable, queryable surface the rotation produces — the
-    scheduler consumes just ``projects`` from a function reflection's return, so
-    without this a withheld run would be byte-identical to a clean one in Redis.
-    Both extras are keyword params with defaults, so the positional 4-arg/5-arg
-    call contract asserted by ``TestWriteLivenessVaultParam`` is unchanged.
-    """
-    try:
-        r = _get_redis()
-        ts = time.time()
-        r.set(REDIS_LAST_COMPLETED_TS_KEY, str(ts))
-        summary = {
-            "slug": slug,
-            "pr_url": pr_url,
-            "files_touched": files_touched,
-            "status": status,
-        }
-        if vault_narratives_compared is not None:
-            summary["vault_narratives_compared"] = vault_narratives_compared
-        if fixes_withheld:
-            summary["fixes_withheld"] = fixes_withheld
-        r.set(REDIS_LAST_COMPLETED_SUMMARY_KEY, json.dumps(summary))
-    except Exception as e:
-        logger.warning(f"docs_auditor: liveness write failed: {e}")
-
-
 def _update_rotation_hash(project_key: str, paths: list[str]) -> None:
     """Stamp rotation hash with current timestamp for each touched path."""
     try:
@@ -2415,8 +2372,7 @@ def run_docs_auditor() -> dict:
       8. Memory refresh hook (fire-and-forget)
       9. Telegram notification
       10. Update rotation hash
-      11. Liveness signal
-      12. Lock release (try/finally)
+      11. Lock release (try/finally)
     """
     findings: list[str] = []
 
@@ -2447,7 +2403,6 @@ def run_docs_auditor() -> dict:
         # the failure path below, which knows it caused the dirt — this guard,
         # which cannot know, stays quiet (Q4 item 5).
         if _git_dirty(PROJECT_ROOT):
-            _write_liveness("(dirty)", "skipped", None, 0)
             return {
                 "status": "skipped",
                 "findings": ["docs-auditor skipped: working tree dirty"],
@@ -2462,7 +2417,6 @@ def run_docs_auditor() -> dict:
         # 4. Rotation pick
         primary, _last_run = _select_primary_doc(PROJECT_ROOT, project_key)
         if primary is None:
-            _write_liveness("(no-candidates)", "skipped", None, 0)
             return {
                 "status": "skipped",
                 "findings": ["No candidate docs found"],
@@ -2490,7 +2444,6 @@ def run_docs_auditor() -> dict:
         if guard_reason is not None:
             logger.info(f"docs_auditor: {guard_reason}, skipping before any write")
             _update_rotation_hash(project_key, [str(primary)])
-            _write_liveness(slug, "skipped", None, 0, fixes_withheld=0)
             return {
                 "status": "skipped",
                 "findings": [f"docs-auditor skipped: {guard_reason}"],
@@ -2511,8 +2464,7 @@ def run_docs_auditor() -> dict:
         # review before the PR opens — every rotation PR still requires a human
         # merge, but the withheld count must reach every surface this function
         # produces so the human reviewing it sees it, not just a log line:
-        # findings, summary, Telegram, the PR body, and the Redis liveness
-        # summary, which is the only durable queryable one.
+        # findings, the returned summary, Telegram, and the PR body.
         # Telegram has two mutually exclusive senders, and a run can also reach
         # neither. Three cases: files were touched — step 9 sends the pass
         # summary; nothing was touched but fixes were withheld — the zero-diff
@@ -2570,7 +2522,6 @@ def run_docs_auditor() -> dict:
         # 6. Zero-diff gate
         if not files_touched or _git_diff_quiet(PROJECT_ROOT):
             _update_rotation_hash(project_key, [str(primary)])
-            _write_liveness(slug, "skipped", None, 0, fixes_withheld=fixes_withheld)
             # Initialized unconditionally (mirroring withheld_note above): the
             # summary f-string below interpolates this on every zero-diff
             # return, including the clean path where the notify call never
@@ -2689,18 +2640,6 @@ def run_docs_auditor() -> dict:
         # 10. Update rotation hash for all touched files
         _update_rotation_hash(project_key, files_touched)
 
-        # 11. Liveness signal (threads the vault-drift compared count — the only
-        # call site that ran the vault comparison; the other 3 stay 4-arg — plus
-        # the withheld count, so Redis distinguishes a withheld run from a clean one).
-        _write_liveness(
-            slug,
-            "ok",
-            pr_url,
-            len(files_touched),
-            vault_narratives_compared,
-            fixes_withheld=fixes_withheld,
-        )
-
         findings.append(
             f"Touched {len(files_touched)} files; {result.get('fixes_applied', 0)} fixes applied"
         )
@@ -2720,7 +2659,7 @@ def run_docs_auditor() -> dict:
             "summary": (
                 f"docs-auditor: {len(files_touched)} files touched, "
                 f"{result.get('fixes_applied', 0)} fixes{withheld_note}{suppressed_note}, "
-                f"PR={pr_url}"
+                f"PR={pr_url}; vault {vault_narratives_compared} narratives compared"
             ),
         }
 
@@ -2732,7 +2671,7 @@ def run_docs_auditor() -> dict:
             "summary": f"docs-auditor error: {e}",
         }
     finally:
-        # 12. Lock release
+        # 11. Lock release
         _release_lock(REDIS_RUNNING_KEY)
 
 

--- a/reflections/docs_auditor.py
+++ b/reflections/docs_auditor.py
@@ -2333,8 +2333,9 @@ def _run_vault_drift_detection(project_key: str) -> int:
     the whole block is wrapped so ``run_docs_auditor`` continues on the repo-doc
     rotation. Vault-drift ``gh issue create`` volume is bounded by
     ``VAULT_DRIFT_ISSUE_CAP``, checked before every filing. Returns the count of
-    narratives actually compared (0 when the vault is unresolvable/empty), which is
-    threaded into the liveness payload.
+    narratives actually compared (0 when the vault is unresolvable/empty), which
+    is folded into the created-PR summary string that the scheduler stores as
+    ``output_summary`` and the reflections dashboard renders.
     """
     try:
         vault_root = _resolve_vault_root(project_key)
@@ -2554,7 +2555,7 @@ def run_docs_auditor() -> dict:
         # unambiguously means the branch/commit/push/PR or the restore failed —
         # never "a guard declined". That routes to status="error": no success
         # Telegram, no rotation-hash stamp (the doc was written but not audited to
-        # completion, so re-picking it next run is correct), and no liveness "ok".
+        # completion, so re-picking it next run is correct).
         # NOTE (#3050): `_restore_checkout` only runs inside this call's own
         # `finally`. An exception raised between the substrate write above and
         # this call leaves the shared checkout dirty with no restore; the next

--- a/scripts/update/migrations.py
+++ b/scripts/update/migrations.py
@@ -1199,6 +1199,45 @@ def _migrate_clear_orphaned_warn_state_key(project_dir: Path) -> str | None:
         return None
 
 
+def _migrate_clear_docs_audit_liveness_keys(project_dir: Path) -> str | None:
+    """Sweep the two orphaned ``docs_audit:last_completed_run_*`` Redis keys
+    left by the deleted docs-auditor liveness channel (issue #2743).
+
+    Nothing writes these keys anymore — the docs-auditor rotation now reports
+    its outcome through its return value alone, which the reflection scheduler
+    already forwards into ``Reflection.last_run_summary.output_summary`` for the
+    dashboard to render. Without this one-shot sweep the two keys would sit in
+    every machine's Redis forever, with no TTL and no reader.
+
+    The two key strings are hard-coded rather than imported: the constants that
+    named them (``REDIS_LAST_COMPLETED_TS_KEY``, ``REDIS_LAST_COMPLETED_SUMMARY_KEY``)
+    are deleted along with the function that wrote them.
+
+    Returns None unconditionally; a bookkeeping cleanup must never fail
+    ``/update``. A failure is logged, never swallowed silently, because
+    ``run_pending_migrations`` records a ``None`` return as permanently
+    completed -- a silently-swallowed exception here would never retry.
+    """
+    try:
+        import sys
+
+        sys.path.insert(0, str(project_dir))
+        from popoto.redis_db import POPOTO_REDIS_DB
+
+        deleted = POPOTO_REDIS_DB.delete(
+            "docs_audit:last_completed_run_ts",
+            "docs_audit:last_completed_run_summary",
+        )
+        logger.info(
+            "[migration:clear_docs_audit_liveness_keys] deleted %d orphaned key(s)",
+            deleted,
+        )
+        return None
+    except Exception as e:
+        logger.warning("clear_docs_audit_liveness_keys: %s", e)
+        return None
+
+
 MIGRATIONS: dict[str, tuple[callable, str]] = {
     "agent_session_keyfield_rename": (
         _migrate_agent_session_keyfield_rename,
@@ -1323,6 +1362,11 @@ MIGRATIONS: dict[str, tuple[callable, str]] = {
         _migrate_clear_orphaned_warn_state_key,
         "Clear the orphaned warn_state key left by the deleted server-side "
         "access-control layer (issue #3004)",
+    ),
+    "clear_docs_audit_liveness_keys": (
+        _migrate_clear_docs_audit_liveness_keys,
+        "Sweep the two orphaned docs_audit:last_completed_run_* Redis keys left "
+        "by the deleted docs-auditor liveness channel (issue #2743)",
     ),
 }
 

--- a/tests/unit/test_docs_auditor_substrate.py
+++ b/tests/unit/test_docs_auditor_substrate.py
@@ -8,7 +8,6 @@ contract (pr-changed-files mode).
 
 from __future__ import annotations
 
-import json
 import re
 import shutil
 import subprocess
@@ -1322,9 +1321,9 @@ class TestWithheldBlocksStaleClose:
     """A run that withheld a fix still requires a human merge, and the sweeper
     must not close or delete the branch of a PR carrying the withheld marker.
 
-    The withheld marker reaches the PR body, Telegram, and Redis liveness, and
-    the sweeper exempts a withheld-marker PR from stale-close (covered in the
-    real-git test file).
+    The withheld marker reaches the PR body and Telegram, and the sweeper
+    exempts a withheld-marker PR from stale-close (covered in the real-git
+    test file).
     """
 
     def test_pr_body_carries_marker_when_fixes_withheld(self, repo):
@@ -1355,7 +1354,7 @@ class TestWithheldBlocksStaleClose:
         assert docs_auditor.WITHHELD_PR_MARKER in body
         assert "a/c.py" in body
 
-    def test_bare_name_withhold_propagates_to_pr_body_telegram_and_liveness(
+    def test_bare_name_withhold_propagates_to_pr_body_and_telegram(
         self, repo, auth_ok, patch_redis
     ):
         """The new bare-name withhold class must reach every operator surface.
@@ -1417,7 +1416,7 @@ class TestWithheldBlocksStaleClose:
         assert docs_auditor.WITHHELD_PR_MARKER in body
         assert "ghost_module.py" in body
 
-        # Surfaces 2 and 3 — the Telegram notification and Redis liveness.
+        # Surface 2 — the Telegram notification, and the returned summary.
         with (
             patch("reflections.docs_auditor.PROJECT_ROOT", repo),
             patch("reflections.docs_auditor._git_dirty", return_value=False),
@@ -1430,7 +1429,6 @@ class TestWithheldBlocksStaleClose:
             patch("reflections.docs_auditor._file_issue_if_new", return_value=False),
             patch("reflections.docs_auditor._send_telegram_notification") as notify,
             patch("reflections.docs_auditor._update_rotation_hash"),
-            patch("reflections.docs_auditor._write_liveness") as liveness,
         ):
             result = docs_auditor.run_docs_auditor()
 
@@ -1440,7 +1438,7 @@ class TestWithheldBlocksStaleClose:
         assert result["status"] == "skipped"
         assert "1 fix(es) withheld" in notify.call_args.args[0]
         assert notify.call_args.kwargs["repo_root"] == repo
-        assert liveness.call_args.kwargs["fixes_withheld"] == 1
+        assert "1 fix(es) withheld" in result["summary"]
 
     def test_rotation_result_surfaces_withheld_count(self, repo, auth_ok, patch_redis):
         primary = repo / "docs" / "features" / "foo.md"
@@ -1468,7 +1466,6 @@ class TestWithheldBlocksStaleClose:
             patch("reflections.docs_auditor._file_issue_if_new", return_value=False) as file_issue,
             patch("reflections.docs_auditor._send_telegram_notification") as notify,
             patch("reflections.docs_auditor._update_rotation_hash"),
-            patch("reflections.docs_auditor._write_liveness"),
         ):
             result = docs_auditor.run_docs_auditor()
 
@@ -1509,7 +1506,6 @@ class TestWithheldBlocksStaleClose:
             patch("reflections.docs_auditor._file_issue_if_new", return_value=False) as file_issue,
             patch("reflections.docs_auditor._send_telegram_notification") as notify,
             patch("reflections.docs_auditor._update_rotation_hash"),
-            patch("reflections.docs_auditor._write_liveness") as liveness,
         ):
             result = docs_auditor.run_docs_auditor()
 
@@ -1522,7 +1518,7 @@ class TestWithheldBlocksStaleClose:
         assert "2 fix(es) withheld" in msg
         assert "docs_features_foo_md" in msg  # the rotation slug
         assert notify.call_args.kwargs["repo_root"] == repo
-        assert liveness.call_args.kwargs["fixes_withheld"] == 2
+        assert "2 fix(es) withheld" in result["summary"]
         # One issue filed per withheld entry (Q5 / B4), even on the no-PR path.
         assert file_issue.call_count == 2
 
@@ -1538,7 +1534,6 @@ class TestWithheldBlocksStaleClose:
             patch("reflections.docs_auditor.audit", return_value=audit_result),
             patch("reflections.docs_auditor._send_telegram_notification") as notify,
             patch("reflections.docs_auditor._update_rotation_hash"),
-            patch("reflections.docs_auditor._write_liveness"),
         ):
             result = docs_auditor.run_docs_auditor()
 
@@ -1751,7 +1746,6 @@ class TestTelegramSuppressionReachesSummary:
             patch("reflections.docs_auditor._file_issue_if_new", return_value=False),
             patch("reflections.docs_auditor._send_telegram_notification", return_value=False),
             patch("reflections.docs_auditor._update_rotation_hash"),
-            patch("reflections.docs_auditor._write_liveness"),
         ):
             result = docs_auditor.run_docs_auditor()
 
@@ -1778,7 +1772,6 @@ class TestTelegramSuppressionReachesSummary:
             patch("reflections.docs_auditor._file_issue_if_new", return_value=False),
             patch("reflections.docs_auditor._send_telegram_notification", return_value=False),
             patch("reflections.docs_auditor._update_rotation_hash"),
-            patch("reflections.docs_auditor._write_liveness"),
         ):
             result = docs_auditor.run_docs_auditor()
 
@@ -1957,9 +1950,8 @@ class TestDirtyTreeGuard:
             patch("reflections.docs_auditor._file_issue_if_new") as file_issue,
         ):
             result = docs_auditor.run_docs_auditor()
-        # The guard now returns "skipped", matching the _write_liveness(...,
-        # "skipped", ...) call it sits beside (R5-1). It must stay quiet: the
-        # whole shared checkout is dirty here, which concurrent lanes routinely
+        # The guard returns "skipped" (R5-1) and must stay quiet: the whole
+        # shared checkout is dirty here, which concurrent lanes routinely
         # cause, so a filing guard would mint issues blaming the auditor for a
         # peer's uncommitted work (Q4 item 5).
         assert result["status"] == "skipped"
@@ -2058,7 +2050,6 @@ class TestHoistedPRGuards:
             patch("reflections.docs_auditor.audit") as audit_mock,
             patch("reflections.docs_auditor._push_branch_and_pr") as push,
             patch("reflections.docs_auditor._update_rotation_hash") as rotation,
-            patch("reflections.docs_auditor._write_liveness") as liveness,
             patch("reflections.docs_auditor._send_telegram_notification") as notify,
         ):
             result = docs_auditor.run_docs_auditor()
@@ -2066,7 +2057,6 @@ class TestHoistedPRGuards:
             "audit": audit_mock,
             "push": push,
             "rotation": rotation,
-            "liveness": liveness,
             "notify": notify,
         }
 
@@ -2102,7 +2092,6 @@ class TestHoistedPRGuards:
 
         mocks["rotation"].assert_called_once()
         assert mocks["rotation"].call_args.args[1] == ["docs/features/foo.md"]
-        assert mocks["liveness"].call_args.args[1] == "skipped"
 
     def test_no_guard_lets_the_substrate_run(self, repo, auth_ok, patch_redis):
         primary = repo / "docs" / "features" / "foo.md"
@@ -3039,57 +3028,6 @@ class TestVaultSiteDrift:
             assert docs_auditor._resolve_vault_root("valor") == Path("/vault/valor")
 
 
-class TestWriteLivenessVaultParam:
-    def _summary(self, fake_redis) -> dict:
-        # Find the r.set call that persisted the summary JSON.
-        for c in fake_redis.set.call_args_list:
-            if c.args and c.args[0] == docs_auditor.REDIS_LAST_COMPLETED_SUMMARY_KEY:
-                return json.loads(c.args[1])
-        raise AssertionError("summary was not written")
-
-    def test_four_arg_call_omits_vault_count(self, fake_redis, patch_redis):
-        docs_auditor._write_liveness("slug", "ok", None, 3)
-        summary = self._summary(fake_redis)
-        assert "vault_narratives_compared" not in summary
-
-    def test_five_arg_call_includes_vault_count(self, fake_redis, patch_redis):
-        docs_auditor._write_liveness("slug", "ok", None, 3, 7)
-        summary = self._summary(fake_redis)
-        assert summary["vault_narratives_compared"] == 7
-
-    def test_five_arg_zero_is_emitted(self, fake_redis, patch_redis):
-        # 0 is distinct from None: a resolved-but-empty vault must be observable.
-        docs_auditor._write_liveness("slug", "ok", None, 0, 0)
-        summary = self._summary(fake_redis)
-        assert summary["vault_narratives_compared"] == 0
-
-    def test_withheld_count_absent_when_zero(self, fake_redis, patch_redis):
-        # A clean run must not carry the key at all — same shape as before.
-        docs_auditor._write_liveness("slug", "ok", None, 3)
-        assert "fixes_withheld" not in self._summary(fake_redis)
-
-    def test_withheld_count_emitted_when_nonzero(self, fake_redis, patch_redis):
-        # Redis is the only durable, queryable surface; a withheld run must not
-        # be byte-identical to a clean one there.
-        docs_auditor._write_liveness("slug", "ok", None, 3, fixes_withheld=2)
-        assert self._summary(fake_redis)["fixes_withheld"] == 2
-
-    def test_withheld_is_trailing_and_preserves_positional_contract(self):
-        import inspect
-
-        params = list(inspect.signature(docs_auditor._write_liveness).parameters)
-        # fixes_withheld must come last so existing 4-arg and 5-arg positional
-        # call sites keep their meaning.
-        assert params[-1] == "fixes_withheld"
-        assert params[:5] == [
-            "slug",
-            "status",
-            "pr_url",
-            "files_touched",
-            "vault_narratives_compared",
-        ]
-
-
 class TestVaultDeadCodeRemoved:
     def test_default_vault_weight_gone(self):
         assert not hasattr(docs_auditor, "DEFAULT_VAULT_WEIGHT")
@@ -3111,3 +3049,124 @@ class TestVaultDeadCodeRemoved:
         primary, _ = docs_auditor._select_primary_doc(repo, "valor")
         assert primary is not None
         assert str(primary).startswith("docs/features/")
+
+
+# ---------------------------------------------------------------------------
+# TestLivenessDeadCodeRemoved — #2743
+# ---------------------------------------------------------------------------
+
+
+class TestLivenessDeadCodeRemoved:
+    """The Redis liveness channel is gone; a revert must not silently bring it back."""
+
+    def test_write_liveness_gone(self):
+        assert not hasattr(docs_auditor, "_write_liveness")
+
+    def test_last_completed_ts_key_gone(self):
+        assert not hasattr(docs_auditor, "REDIS_LAST_COMPLETED_TS_KEY")
+
+    def test_last_completed_summary_key_gone(self):
+        assert not hasattr(docs_auditor, "REDIS_LAST_COMPLETED_SUMMARY_KEY")
+
+
+# ---------------------------------------------------------------------------
+# TestVaultClauseInSummary — #2743: vault_narratives_compared rehomed onto the
+# created-PR summary string, replacing the deleted Redis liveness payload.
+# ---------------------------------------------------------------------------
+
+
+class TestVaultClauseInSummary:
+    def test_created_pr_summary_carries_vault_count_including_zero(
+        self, repo, auth_ok, patch_redis
+    ):
+        """The clause is unconditional: even a resolved-but-empty vault (0) shows up."""
+        primary = repo / "docs" / "features" / "foo.md"
+        primary.write_text("# Foo\n" + "Padding line.\n" * 6)
+        audit_result = docs_auditor._ok_result(
+            "ok", files_touched=["docs/features/foo.md"], fixes_applied=1
+        )
+        with (
+            patch("reflections.docs_auditor.PROJECT_ROOT", repo),
+            patch("reflections.docs_auditor._git_dirty", return_value=False),
+            patch("reflections.docs_auditor._git_diff_quiet", return_value=False),
+            patch("reflections.docs_auditor._run_vault_drift_detection", return_value=0),
+            patch("reflections.docs_auditor.audit", return_value=audit_result),
+            patch(
+                "reflections.docs_auditor._push_branch_and_pr",
+                return_value="https://github.com/o/r/pull/1",
+            ),
+            patch("reflections.docs_auditor._file_issue_if_new", return_value=False),
+            patch("reflections.docs_auditor._send_telegram_notification", return_value=True),
+            patch("reflections.docs_auditor._update_rotation_hash"),
+        ):
+            result = docs_auditor.run_docs_auditor()
+
+        assert result["status"] == "ok"
+        assert "vault 0 narratives compared" in result["summary"]
+
+    def test_vault_clause_absent_from_zero_diff_summary(self, repo, auth_ok, patch_redis):
+        primary = repo / "docs" / "features" / "foo.md"
+        primary.write_text("# Foo\n" + "Padding line.\n" * 6)
+        audit_result = docs_auditor._ok_result("ok", files_touched=[], fixes_applied=0)
+        with (
+            patch("reflections.docs_auditor.PROJECT_ROOT", repo),
+            patch("reflections.docs_auditor._git_dirty", return_value=False),
+            patch("reflections.docs_auditor._run_vault_drift_detection", return_value=7),
+            patch("reflections.docs_auditor.audit", return_value=audit_result),
+            patch("reflections.docs_auditor._send_telegram_notification"),
+            patch("reflections.docs_auditor._update_rotation_hash"),
+        ):
+            result = docs_auditor.run_docs_auditor()
+
+        assert result["status"] == "skipped"
+        assert "vault" not in result["summary"]
+
+    def test_vault_clause_absent_from_no_candidates_summary(self, repo, auth_ok, patch_redis):
+        # No docs/features/*.md exist in `repo`, so _select_primary_doc finds nothing.
+        with (
+            patch("reflections.docs_auditor.PROJECT_ROOT", repo),
+            patch("reflections.docs_auditor._git_dirty", return_value=False),
+            patch("reflections.docs_auditor._run_vault_drift_detection", return_value=3),
+        ):
+            result = docs_auditor.run_docs_auditor()
+
+        assert result["status"] == "skipped"
+        assert "vault" not in result["summary"]
+
+
+def test_worst_case_summary_stays_under_truncation_budget(repo, auth_ok, patch_redis):
+    """Pins Risk 1's truncation budget: agent/reflection_scheduler.py truncates
+    ``output_summary`` to 500 characters, so the worst-realistic created-PR
+    summary (many files, many fixes, a withheld note, a suppressed-Telegram
+    note, a real PR URL, and the vault clause) must stay comfortably under it.
+    """
+    primary = repo / "docs" / "features" / "foo.md"
+    primary.write_text("# Foo\n" + "Padding line.\n" * 6)
+    files_touched = [f"docs/features/file_{i:02d}.md" for i in range(42)]
+    withheld = [{"doc": "docs/features/foo.md", "old": "a/b.py", "new": "a/c.py", "reason": "x"}]
+    audit_result = docs_auditor._ok_result(
+        "ok",
+        files_touched=files_touched,
+        fixes_applied=137,
+        fixes_withheld=1,
+        withheld=withheld,
+    )
+    with (
+        patch("reflections.docs_auditor.PROJECT_ROOT", repo),
+        patch("reflections.docs_auditor._git_dirty", return_value=False),
+        patch("reflections.docs_auditor._git_diff_quiet", return_value=False),
+        patch("reflections.docs_auditor._run_vault_drift_detection", return_value=0),
+        patch("reflections.docs_auditor.audit", return_value=audit_result),
+        patch(
+            "reflections.docs_auditor._push_branch_and_pr",
+            return_value="https://github.com/tomcounsell/ai/pull/123456",
+        ),
+        patch("reflections.docs_auditor._file_issue_if_new", return_value=False),
+        patch("reflections.docs_auditor._send_telegram_notification", return_value=False),
+        patch("reflections.docs_auditor._update_rotation_hash"),
+    ):
+        result = docs_auditor.run_docs_auditor()
+
+    assert result["status"] == "ok"
+    assert "narratives compared" in result["summary"]
+    assert len(result["summary"]) < 500

--- a/tests/unit/test_migrations.py
+++ b/tests/unit/test_migrations.py
@@ -491,3 +491,42 @@ class TestClearOrphanedWarnStateKey:
         fn, description = MIGRATIONS["clear_orphaned_warn_state_key"]
         assert fn is _migrate_clear_orphaned_warn_state_key
         assert description
+
+
+class TestClearDocsAuditLivenessKeys:
+    """One-shot sweep of the two orphaned ``docs_audit:last_completed_run_*``
+    Redis keys left by the deleted docs-auditor liveness channel (issue #2743).
+
+    Real Popoto/Redis against the test db (autouse ``redis_test_db``). The two
+    key strings are hard-coded in the migration itself since the constants
+    that named them are deleted, so this test hard-codes them too.
+    """
+
+    _TS_KEY = "docs_audit:last_completed_run_ts"
+    _SUMMARY_KEY = "docs_audit:last_completed_run_summary"
+
+    def test_deletes_both_orphaned_keys(self, tmp_path):
+        from scripts.update.migrations import _migrate_clear_docs_audit_liveness_keys
+
+        POPOTO_REDIS_DB.set(self._TS_KEY, "1234567890.0")
+        POPOTO_REDIS_DB.set(self._SUMMARY_KEY, '{"status": "ok"}')
+
+        assert _migrate_clear_docs_audit_liveness_keys(tmp_path) is None
+
+        assert POPOTO_REDIS_DB.exists(self._TS_KEY) == 0
+        assert POPOTO_REDIS_DB.exists(self._SUMMARY_KEY) == 0
+
+    def test_no_op_and_no_error_when_keys_are_already_absent(self, tmp_path):
+        from scripts.update.migrations import _migrate_clear_docs_audit_liveness_keys
+
+        POPOTO_REDIS_DB.delete(self._TS_KEY, self._SUMMARY_KEY)
+
+        assert _migrate_clear_docs_audit_liveness_keys(tmp_path) is None
+
+    def test_registered_in_migrations_dict(self):
+        from scripts.update.migrations import _migrate_clear_docs_audit_liveness_keys
+
+        assert "clear_docs_audit_liveness_keys" in MIGRATIONS
+        fn, description = MIGRATIONS["clear_docs_audit_liveness_keys"]
+        assert fn is _migrate_clear_docs_audit_liveness_keys
+        assert description

--- a/tests/unit/test_per_project_modal.py
+++ b/tests/unit/test_per_project_modal.py
@@ -243,3 +243,31 @@ class TestModalPerProjectRendering:
         html = _render_modal(env, runs)
         for cls in ("badge-ok", "badge-error", "badge-disabled", "badge-skipped"):
             assert cls in html, f"missing {cls} in rendered modal"
+
+
+class TestModalLastRunSummaryRendering:
+    """The docs-auditor's replacement surface (#2743): a rotation's returned
+    ``summary`` string, stored on ``Reflection.last_run_summary.output_summary``,
+    must actually reach the rendered modal HTML — not just the code path that
+    builds the string. No ORM write and no Redis I/O: merge the one key the
+    render guard checks directly into the context this file's own
+    ``_base_reflection_ctx()`` already supplies.
+    """
+
+    def test_output_summary_with_vault_clause_renders(self, env: Environment) -> None:
+        summary = (
+            "docs-auditor: 3 files touched, 2 fixes, "
+            "PR=https://github.com/o/r/pull/1; vault 0 narratives compared"
+        )
+        ctx = _base_reflection_ctx()
+        ctx["last_run_summary"] = {"output_summary": summary}
+        tmpl = env.get_template("reflections/_partials/modal_content.html")
+        html = tmpl.render(r=ctx, recent_runs=[], sparkline=[], manual_command=None)
+
+        assert "vault 0 narratives compared" in html
+        assert "Last run summary" in html
+
+    def test_absent_last_run_summary_renders_no_summary_section(self, env: Environment) -> None:
+        """The render guard is unchanged: no summary key, no heading."""
+        html = _render_modal(env, [])
+        assert "Last run summary" not in html


### PR DESCRIPTION
## Summary

Deletes `reflections/docs_auditor.py::_write_liveness`, its two Redis-key
constants, and its five call sites — the last surviving half of a
parallel-run migration. #2739 gave run outcomes a real reader (the
reflections dashboard's rendered `output_summary`), so this channel had
no code reading it and no TTL, leaving two orphaned keys sitting in
every machine's Redis forever.

- `vault_narratives_compared` is rehomed onto the created-PR summary
  string as a trailing clause, appended **unconditionally** (including
  when the count is `0`) — the field's whole reason for existing is
  distinguishing "compared zero" from "never ran the comparison."
- Seven test patch sites repaired, two behavioral assertions re-pointed
  from a mock's kwargs onto `result["summary"]` (a stronger test — it
  exercises the string an operator actually reads), and a new
  `TestLivenessDeadCodeRemoved` guard class stops a future revert from
  silently reintroducing the channel.
- A new `test_worst_case_summary_stays_under_truncation_budget` pins the
  500-char scheduler truncation budget the plan measured (227 chars
  worst-case, ~273 chars of headroom).
- A new direct Jinja2 render test in `test_per_project_modal.py` proves
  the vault clause actually reaches the dashboard modal HTML — not just
  that the code path that builds the string is correct.
- A one-shot `/update` migration (`clear_docs_audit_liveness_keys`)
  sweeps the two orphaned Redis keys on every machine.
- Nine documentation reference clusters across `docs-auditor.md` and
  `vault-drift-audit.md` rewritten around the summary-string surface;
  `docs/archive/` is untouched (verified `git diff --stat` empty).

Plan: `docs/plans/delete-write-liveness-docs-auditor.md`

## Verification

Every row of the plan's `## Verification` table was run directly and
passes under its stated semantics (all 13 grep-based rows return the
plan's expected value; full test suites for
`test_docs_auditor_substrate.py` (212 passed), `test_migrations.py` (21
passed), and `test_per_project_modal.py` (9 passed) are green; whole-repo
`ruff format --check .` is clean).

**Known non-blocking finding:** `scripts/validate_build.py` reports 13
false FAILs against this plan's Verification table. Its rows use bare
`0` / `1` / `> 0` in the Expected column; `agent/verification_parser.py`'s
`evaluate_expectation()` only recognizes `exit code N`, `output > N`,
`output contains X`, and `match count == 0` — none of which match bare
`0`/`1`/`> 0` literally, so every one of those rows falls through to
`return False` regardless of the actual (correct) output. I manually ran
every check's command and confirmed the output matches the plan's stated
expected value in every case. This is a pre-existing plan-authoring /
validator-grammar mismatch, not a defect in this PR's diff — worth a
follow-up issue, out of scope here.

Separately, whole-repo `ruff check .` reports one pre-existing `I001`
finding in `agent/agent_session_queue.py`, a file this PR does not touch
(confirmed identical to `main`) — version drift, not introduced here.

## Test plan

- [x] `scripts/pytest-clean.sh tests/unit/test_docs_auditor_substrate.py -q` — 212 passed
- [x] `scripts/pytest-clean.sh tests/unit/test_migrations.py -q` — 21 passed
- [x] `scripts/pytest-clean.sh tests/unit/test_per_project_modal.py -q -n0` — 9 passed
- [x] `python -m ruff check .` / `ruff format --check .` on all touched files — clean
- [x] `_write_liveness`, `REDIS_LAST_COMPLETED_*`, `docs_audit:last_completed_run_*` — zero occurrences outside `docs/archive/` and the plan doc
- [x] `docs/archive/` byte-identical to `origin/main`

Closes #2743