### PR TITLE
Auto-preserve refuses to commit a wipe (#3167)

### DIFF
--- a/agent/worktree_manager.py
+++ b/agent/worktree_manager.py
@@ -1733,8 +1733,10 @@ def preserve_uncommitted_worktree_changes(repo_root: Path, slug: str, worktree_d
           "deleted_paths": <int>, "ref": ..., "errors": []}``. No commit, no
           ref write, branch head unmoved.
         - A failure salvaging a detected wipe (block B) returns the pure-wipe
-          shape above plus ``"guard_error": <str>``, still with ``"errors":
-          []`` — the outcome is a refusal, not a broken-git failure.
+          shape above minus ``"deleted_paths"`` (the salvage step failed
+          before that count could be determined) plus ``"guard_error":
+          <str>``, still with ``"errors": []`` — the outcome is a refusal,
+          not a broken-git failure.
         - Git subprocess failure (the pre-existing contract): ``{"preserved":
           False, "was_clean": False, "ref": ..., "errors": [<msg>, ...]}``,
           with no ``"refused"`` key. ``"refused"`` is therefore the sole
@@ -1769,13 +1771,28 @@ def preserve_uncommitted_worktree_changes(repo_root: Path, slug: str, worktree_d
         # `rev-parse --abbrev-ref HEAD` returns the literal string "HEAD",
         # which passes VALID_SLUG_RE and would otherwise produce
         # `refs/session-wip/HEAD`.
-        branch_result = subprocess.run(
-            ["git", "-C", str(worktree_dir), "rev-parse", "--abbrev-ref", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=settings.timeouts.git_subprocess_s,
-        )
-        branch = branch_result.stdout.strip() if branch_result.returncode == 0 else ""
+        try:
+            branch_result = subprocess.run(
+                ["git", "-C", str(worktree_dir), "rev-parse", "--abbrev-ref", "HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=settings.timeouts.git_subprocess_s,
+            )
+            branch = branch_result.stdout.strip() if branch_result.returncode == 0 else ""
+        except Exception as branch_exc:
+            # A non-zero rc already falls back to the `slug` default above; an
+            # exception (e.g. TimeoutExpired) must degrade the same way rather
+            # than propagate to the outer handler, which would skip the
+            # ordinary path's `add -A` + WIP commit + ref write entirely and
+            # lose legitimate uncommitted work (#3167 follow-up).
+            logger.warning(
+                "[worktree-wip-branch-resolve-failed] slug=%s worktree=%s error=%s — "
+                "falling back to slug-derived ref.",
+                slug,
+                worktree_dir,
+                branch_exc,
+            )
+            branch = ""
         session_match = re.match(r"^session/(.+)$", branch) if branch else None
         if session_match and VALID_SLUG_RE.match(session_match.group(1)):
             ref = f"refs/session-wip/{session_match.group(1)}"

--- a/agent/worktree_manager.py
+++ b/agent/worktree_manager.py
@@ -1629,9 +1629,9 @@ def preserve_uncommitted_worktree_changes(repo_root: Path, slug: str, worktree_d
     Session worktrees under ``.worktrees/{slug}`` are force-removed on session
     exit (normal, exception, or cancellation). The unmerged-branch guard (#1646)
     protects only *committed* work; staged, unstaged, and untracked edits are
-    otherwise discarded with no backstop. This helper captures ALL uncommitted
-    work as a WIP commit on ``session/{slug}`` plus a durable named ref
-    ``refs/session-wip/{slug}`` before any ``git worktree remove --force``.
+    otherwise discarded with no backstop. This helper captures uncommitted work
+    as a WIP commit on the worktree's checked-out branch plus a durable named
+    ref ``refs/session-wip/{name}`` before any ``git worktree remove --force``.
 
     Mechanism (WIP commit + named ref, NOT ``git stash``). The reason is NOT
     that a worktree's stash is worktree-local: ``refs/stash`` lives in the
@@ -1642,37 +1642,104 @@ def preserve_uncommitted_worktree_changes(repo_root: Path, slug: str, worktree_d
     is meaningless and a teardown backstop keyed on it would race every peer
     (issue #2650, shape 1). A WIP commit under a slug-scoped named ref is
     single-owner by construction, and it captures untracked files, which
-    ``git stash`` declines by default. Instead:
+    ``git stash`` declines by default.
 
     1. ``git -C <worktree> status --porcelain`` — if empty, no-op.
-    2. ``git -C <worktree> add -A`` — captures untracked + tracked edits.
-    3. ``git -C <worktree> commit --no-verify --no-gpg-sign`` — the WIP commit
+    2. **Wipe check (#3167).** ``git -C <worktree> ls-tree --name-only -d HEAD``
+       lists the directories HEAD tracks; if any is absent from disk, the tree
+       is a wipe (partially or fully deleted from under the worktree, e.g. by a
+       racing teardown pass or a `shutil.rmtree` that raised partway through),
+       not a tree whose deletions should be committed. This check runs BEFORE
+       staging: the signal is available without mutating the index, and after
+       ``git add -A`` the deletion signal is partly erased from the index
+       anyway. An earlier design considered a deletions/insertions ratio
+       (refusing when deletions dwarf insertions); it is rejected because the
+       reported incident's own commit carried 223,142 insertions alongside its
+       902,840 deletions — ``git add -A`` also stages untracked build
+       artifacts, which count as insertions and defeat any "insertions are
+       negligible" test.
+       - **No missing directory**: fall through to step 3 unchanged.
+       - **A directory is missing**: first ``git -C <worktree> reset -q`` (a
+         mixed reset — index to HEAD, working tree untouched). This is
+         index-recovery, not hygiene: without it, a wipe a *previous* teardown
+         pass already staged (``add -A`` succeeded, the following commit
+         failed) leaves both the "deleted" and "modified/others" plumbing
+         reads blind to it, and the additive salvage below would silently
+         discard real coexisting work. Then compute the additive-only
+         candidate set — ``ls-files --modified --others --exclude-standard``
+         minus ``ls-files --deleted`` — and stage exactly those paths (never
+         ``add -A``, which would restage the declined deletions). If the
+         candidate set is empty (the pure-wipe case), no staging or commit
+         happens at all. Otherwise the WIP commit carries the coexisting
+         additions/edits with **zero deletions**, plus a trailer recording
+         that deletions were declined. Either way the declined deletions are
+         logged at ERROR under ``[worktree-wip-refused-wipe]`` with enough
+         detail (slug, branch, HEAD sha, missing directories, path counts) to
+         reconstruct the event after the worktree is destroyed.
+       - **Fail-open asymmetry**: a failure reading the wipe signal itself
+         (before any directory is known missing) is not evidence of a wipe, so
+         it falls open to step 3 — this function's hardest contract is that it
+         never blocks or hangs teardown. A failure *after* a missing directory
+         is already confirmed (during the reset or the salvage reads) refuses
+         instead of falling through, because falling open there would commit
+         the very wipe just detected.
+    3. ``git -C <worktree> add -A`` — captures untracked + tracked edits.
+    4. ``git -C <worktree> commit --no-verify --no-gpg-sign`` — the WIP commit
        (``--no-verify`` avoids pre-commit hooks hanging teardown;
        ``--no-gpg-sign`` avoids signing prompts).
-    4. ``git -C <repo_root> update-ref refs/session-wip/{slug} <sha>`` — writes
+    5. ``git -C <repo_root> update-ref refs/session-wip/{name} <sha>`` — writes
        to the *common* ref store, so the ref survives both worktree removal and
-       the unmerged-branch-guard branch deletion.
+       the unmerged-branch-guard branch deletion. ``{name}`` is derived from
+       the worktree's checked-out branch (``session/<name>`` -> ``<name>``),
+       falling back to the ``slug`` argument on a detached HEAD, a non-session
+       branch, or a failed read — `_cleanup_stale_worktree` passes the foreign
+       *directory* name as `slug`, which can disagree with the branch the
+       commit actually lands on.
 
     Non-blocking contract: any subprocess failure, timeout, or exception is
     caught, logged at ERROR with the ``[worktree-wip-preserve-failed]`` tag,
     and returned in the result dict — this function NEVER raises into the
     teardown path and must never hang teardown.
 
-    Recovery: ``git checkout refs/session-wip/{slug}`` (or diff/cherry-pick the
+    Recovery: ``git checkout refs/session-wip/{name}`` (or diff/cherry-pick the
     WIP commit). ``git reset --soft HEAD~1`` on the resumed session unstages the
-    WIP commit to restore the dirty tree. Refs live in ``refs/session-wip/*``
-    and are reclaimed manually (no automated GC — see the plan No-Gos).
+    WIP commit to restore the dirty tree. This promise now holds even on a
+    half-deleted tree, because the ref never carries a wipe. Refs live in
+    ``refs/session-wip/*`` and are reclaimed manually (no automated GC — see
+    the plan No-Gos).
 
     Args:
         repo_root: Path to the main repository (common ref store owner).
-        slug: Work item slug (validated).
+        slug: Work item slug (validated). Used to name the ref only when the
+            worktree's checked-out branch cannot be resolved to a
+            ``session/<name>`` form.
         worktree_dir: Path to the worktree to preserve.
 
     Returns:
-        A result dict. On a clean tree: ``{"preserved": False, "was_clean":
-        True}``. On success: ``{"preserved": True, "was_clean": False, "sha":
-        <sha>, "ref": "refs/session-wip/{slug}", "errors": []}``. On failure:
-        ``{"preserved": False, "was_clean": False, "errors": [<msg>, ...]}``.
+        A result dict, always carrying ``"errors"`` (``[]`` unless a git
+        subprocess itself broke) and ``"ref"``.
+
+        - Clean tree: ``{"preserved": False, "was_clean": True, "ref": ...,
+          "errors": []}``.
+        - Ordinary dirty tree (no missing tracked directory): ``{"preserved":
+          True, "was_clean": False, "sha": <sha>, "ref": ..., "errors": []}``.
+        - Wipe, with coexisting additive work: ``{"preserved": True,
+          "was_clean": False, "refused": "missing-tracked-dirs", "missing":
+          [<dir>, ...], "deleted_paths": <int>, "sha": <sha>, "ref": ...,
+          "errors": []}``. The commit's diff against its parent has zero
+          deletions.
+        - Pure wipe (nothing coexisting): ``{"preserved": False, "was_clean":
+          False, "refused": "missing-tracked-dirs", "missing": [...],
+          "deleted_paths": <int>, "ref": ..., "errors": []}``. No commit, no
+          ref write, branch head unmoved.
+        - A failure salvaging a detected wipe (block B) returns the pure-wipe
+          shape above plus ``"guard_error": <str>``, still with ``"errors":
+          []`` — the outcome is a refusal, not a broken-git failure.
+        - Git subprocess failure (the pre-existing contract): ``{"preserved":
+          False, "was_clean": False, "ref": ..., "errors": [<msg>, ...]}``,
+          with no ``"refused"`` key. ``"refused"`` is therefore the sole
+          discriminator between a refusal and a git failure — never populate
+          ``"errors"`` on a refusal.
     """
     _validate_slug(slug)
     ref = f"refs/session-wip/{slug}"
@@ -1691,6 +1758,294 @@ def preserve_uncommitted_worktree_changes(repo_root: Path, slug: str, worktree_d
             # Clean tree — nothing to preserve.
             return {"preserved": False, "was_clean": True, "ref": ref, "errors": []}
 
+        # Resolve the worktree's checked-out branch once — reused both to name
+        # the WIP ref correctly (the recon-found slug/branch mismatch: a
+        # foreign worktree directory name can disagree with the branch that
+        # actually receives the commit) and as a field in the wipe-refusal log
+        # record below. A failed read (or a non-`session/` branch, or a
+        # detached HEAD) falls back to the `slug` argument — `ref` above
+        # already carries that default. The `session/` prefix match is the
+        # load-bearing gate, not VALID_SLUG_RE alone: a detached HEAD's
+        # `rev-parse --abbrev-ref HEAD` returns the literal string "HEAD",
+        # which passes VALID_SLUG_RE and would otherwise produce
+        # `refs/session-wip/HEAD`.
+        branch_result = subprocess.run(
+            ["git", "-C", str(worktree_dir), "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=settings.timeouts.git_subprocess_s,
+        )
+        branch = branch_result.stdout.strip() if branch_result.returncode == 0 else ""
+        session_match = re.match(r"^session/(.+)$", branch) if branch else None
+        if session_match and VALID_SLUG_RE.match(session_match.group(1)):
+            ref = f"refs/session-wip/{session_match.group(1)}"
+
+        # --- Wipe check (#3167), block A: detection ---
+        # A worktree missing a directory HEAD tracks is definitionally not a
+        # tree whose deletions should be committed. Runs BEFORE any staging:
+        # the signal is available without mutating the index, and staging
+        # first would leave a fully-staged wipe sitting in the index if the
+        # subsequent force-remove then fails and the directory survives.
+        missing: list[str] = []
+        try:
+            ls_tree = subprocess.run(
+                ["git", "-C", str(worktree_dir), "ls-tree", "--name-only", "-d", "HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=settings.timeouts.git_subprocess_s,
+            )
+            if ls_tree.returncode != 0:
+                raise RuntimeError(f"git ls-tree failed: {ls_tree.stderr.strip()}")
+            tracked_dirs = [d for d in ls_tree.stdout.splitlines() if d.strip()]
+            missing = sorted(d for d in tracked_dirs if not (worktree_dir / d).is_dir())
+        except Exception as guard_exc:
+            # Detection failure is not evidence of a wipe. Fall open to
+            # today's unconditional preserve rather than trade a rare
+            # committed wipe for a routine loss of the backstop on legitimate
+            # work every time a git read hiccups (e.g. an unborn HEAD).
+            logger.warning(
+                "[worktree-wip-guard-failed] slug=%s worktree=%s stage=detection "
+                "error=%s — wipe-detection read failed; falling through to "
+                "unconditional preserve.",
+                slug,
+                worktree_dir,
+                guard_exc,
+            )
+            missing = []
+
+        if missing:
+            # --- Wipe check, block B: response ---
+            # HEAD has already proven a tracked directory is missing from
+            # disk. The only open question is how much coexisting work can be
+            # salvaged — a failure anywhere in this block REFUSES rather than
+            # falling through, because falling open here would answer "a git
+            # read timed out" with "so commit the deletions".
+            try:
+                head_result = subprocess.run(
+                    ["git", "-C", str(worktree_dir), "rev-parse", "HEAD"],
+                    capture_output=True,
+                    text=True,
+                    timeout=settings.timeouts.git_subprocess_s,
+                )
+                if head_result.returncode != 0:
+                    raise RuntimeError(f"git rev-parse HEAD failed: {head_result.stderr.strip()}")
+                head_sha = head_result.stdout.strip()
+
+                # Step zero, and load-bearing rather than hygienic: a mixed
+                # reset (index to HEAD, working tree untouched) so the index
+                # equals HEAD before anything is staged. Without this, a wipe
+                # a previous pass already staged makes both plumbing reads
+                # below come back empty, silently discarding any real
+                # coexisting work. A mixed reset cannot itself destroy
+                # anything — deleted paths stay deleted on disk, edits stay
+                # edited, untracked files stay untracked. A failed reset must
+                # not fall forward: `git commit` commits the ENTIRE index, not
+                # only paths just staged, so an unchecked reset failure would
+                # let the additive commit below carry a pre-staged wipe.
+                reset = subprocess.run(
+                    ["git", "-C", str(worktree_dir), "reset", "-q"],
+                    capture_output=True,
+                    text=True,
+                    timeout=settings.timeouts.git_subprocess_s,
+                )
+                if reset.returncode != 0:
+                    raise RuntimeError(f"git reset failed: {reset.stderr.strip()}")
+
+                candidates_result = subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(worktree_dir),
+                        "ls-files",
+                        "--modified",
+                        "--others",
+                        "--exclude-standard",
+                        "-z",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=settings.timeouts.git_subprocess_s,
+                )
+                if candidates_result.returncode != 0:
+                    raise RuntimeError(
+                        f"git ls-files (modified/others) failed: {candidates_result.stderr.strip()}"
+                    )
+                deleted_result = subprocess.run(
+                    ["git", "-C", str(worktree_dir), "ls-files", "--deleted", "-z"],
+                    capture_output=True,
+                    text=True,
+                    timeout=settings.timeouts.git_subprocess_s,
+                )
+                if deleted_result.returncode != 0:
+                    raise RuntimeError(
+                        f"git ls-files --deleted failed: {deleted_result.stderr.strip()}"
+                    )
+
+                deleted_paths = [p for p in deleted_result.stdout.split("\0") if p]
+                deleted_set = set(deleted_paths)
+                candidates = [p for p in candidates_result.stdout.split("\0") if p]
+                additive = [p for p in candidates if p not in deleted_set]
+                preserved_paths = len(additive)
+
+                # Captured before staging/committing — the record is the sole
+                # durable evidence of the refusal on the pure-wipe branch, and
+                # the force-remove that follows destroys the worktree within
+                # milliseconds.
+                logger.error(
+                    "[worktree-wip-refused-wipe] slug=%s branch=%s head=%s missing=%s "
+                    "preserved_paths=%d deleted_paths=%d — auto-preserve declined to "
+                    "commit a wipe; teardown proceeds.",
+                    slug,
+                    branch or "<unknown>",
+                    head_sha,
+                    ",".join(missing),
+                    preserved_paths,
+                    len(deleted_paths),
+                )
+
+                if not additive:
+                    # Pure wipe. Do not call `git add` with an empty
+                    # pathspec — it exits 0 having staged nothing, and the
+                    # following `git commit` then fails with "nothing to
+                    # commit", logging a misleading
+                    # [worktree-wip-preserve-failed].
+                    return {
+                        "preserved": False,
+                        "was_clean": False,
+                        "refused": "missing-tracked-dirs",
+                        "missing": missing,
+                        "deleted_paths": len(deleted_paths),
+                        "ref": ref,
+                        "errors": [],
+                    }
+
+                # Stage exactly the additive set, on stdin — never a temp
+                # file, which would either race the very deletion that
+                # triggered this path (inside the worktree) or leak (in
+                # /tmp, with a cleanup obligation inside a never-raise
+                # contract). This call deliberately omits `text=True`:
+                # `input` must be bytes for a NUL-delimited pathspec: str
+                # encoding would mangle the separator. `git add` spells the
+                # NUL-delimited pathspec flag `--pathspec-file-nul`, not
+                # `-z` (that exits non-zero with "unknown switch `z`").
+                # Never use `git add -A` here — it restages the very
+                # deletions this branch exists to decline.
+                stage = subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(worktree_dir),
+                        "add",
+                        "--pathspec-from-file=-",
+                        "--pathspec-file-nul",
+                        "--",
+                    ],
+                    input=b"\0".join(p.encode() for p in additive) + b"\0",
+                    capture_output=True,
+                    timeout=settings.timeouts.git_subprocess_s,
+                )
+                if stage.returncode != 0:
+                    stage_err = stage.stderr.decode(errors="replace").strip()
+                    raise RuntimeError(f"git add (additive) failed: {stage_err}")
+
+                ts = datetime.datetime.now(datetime.UTC).isoformat()
+                subject = f"WIP: auto-preserved before teardown [{slug}] [{ts}]"
+                # Trailer, not a different subject: keeps the subject
+                # byte-identical to an ordinary preserve (anything keyed on
+                # that string keeps working) while recording the refusal in
+                # the durable commit itself, not only the rotating log.
+                trailer = (
+                    f"Auto-preserve declined deletions (#3167)\n"
+                    f"Missing-tracked-dirs: {','.join(missing)}\n"
+                    f"Declined-deletions: {len(deleted_paths)}"
+                )
+                commit = subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(worktree_dir),
+                        "commit",
+                        "--no-verify",
+                        "--no-gpg-sign",
+                        "-m",
+                        subject,
+                        "-m",
+                        trailer,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=settings.timeouts.git_subprocess_s,
+                )
+                if commit.returncode != 0:
+                    raise RuntimeError(f"git commit (additive) failed: {commit.stderr.strip()}")
+
+                rev = subprocess.run(
+                    ["git", "-C", str(worktree_dir), "rev-parse", "HEAD"],
+                    capture_output=True,
+                    text=True,
+                    timeout=settings.timeouts.git_subprocess_s,
+                )
+                if rev.returncode != 0:
+                    raise RuntimeError(f"git rev-parse HEAD failed: {rev.stderr.strip()}")
+                sha = rev.stdout.strip()
+
+                update = subprocess.run(
+                    ["git", "-C", str(repo_root), "update-ref", ref, sha],
+                    capture_output=True,
+                    text=True,
+                    timeout=settings.timeouts.git_subprocess_s,
+                )
+                if update.returncode != 0:
+                    raise RuntimeError(f"git update-ref failed: {update.stderr.strip()}")
+
+                logger.warning(
+                    "[worktree-wip-preserved] slug=%s ref=%s sha=%s — uncommitted work "
+                    "(additive only; deletions declined) preserved before teardown; "
+                    "recover with `git checkout %s`.",
+                    slug,
+                    ref,
+                    sha,
+                    ref,
+                )
+                return {
+                    "preserved": True,
+                    "was_clean": False,
+                    "refused": "missing-tracked-dirs",
+                    "missing": missing,
+                    "deleted_paths": len(deleted_paths),
+                    "sha": sha,
+                    "ref": ref,
+                    "errors": [],
+                }
+            except Exception as response_exc:
+                logger.warning(
+                    "[worktree-wip-guard-failed] slug=%s worktree=%s stage=response "
+                    "error=%s — wipe-response step failed; refusing rather than "
+                    "falling through.",
+                    slug,
+                    worktree_dir,
+                    response_exc,
+                )
+                logger.error(
+                    "[worktree-wip-refused-wipe] slug=%s branch=%s missing=%s "
+                    "preserved_paths=0 guard_error=%s — auto-preserve declined to "
+                    "commit a wipe after a salvage-step failure; teardown proceeds.",
+                    slug,
+                    branch or "<unknown>",
+                    ",".join(missing),
+                    response_exc,
+                )
+                return {
+                    "preserved": False,
+                    "was_clean": False,
+                    "refused": "missing-tracked-dirs",
+                    "missing": missing,
+                    "ref": ref,
+                    "errors": [],
+                    "guard_error": str(response_exc),
+                }
+
+        # --- No missing tracked directory: today's unconditional path ---
         add = subprocess.run(
             ["git", "-C", str(worktree_dir), "add", "-A"],
             capture_output=True,

--- a/docs/features/session-isolation.md
+++ b/docs/features/session-isolation.md
@@ -251,28 +251,32 @@ When the guard fires:
 
 Session worktrees are force-removed on session exit (`git worktree remove --force`). The unmerged-branch guard (#1646) protects only *committed* work; before #2137, staged, unstaged, and untracked edits in a dirty worktree were discarded with no backstop. A production incident destroyed six uncommitted files this way (the reflog showed `reset: moving to HEAD`). Three complementary layers close the gap: two PreToolUse guards covering opposite directions (destructive git *inside* a dirty worktree vs. whole-tree destructive git in the *shared main checkout*), plus a teardown backstop.
 
-**1. Auto-WIP-commit before teardown.** `preserve_uncommitted_worktree_changes(repo_root, slug, worktree_dir)` (`agent/worktree_manager.py`) runs *before* every force-remove. It is called from `remove_worktree()` and directly from `_cleanup_stale_worktree()` (which force-removes without going through `remove_worktree`). Mechanism:
+**1. Auto-WIP-commit before teardown.** `preserve_uncommitted_worktree_changes(repo_root, slug, worktree_dir)` (`agent/worktree_manager.py`) runs *before* every force-remove. It is called from `remove_worktree()` and directly from `_cleanup_stale_worktree()` (which force-removes without going through `remove_worktree`). `reap_idle_worktree()` is a third worktree-removal entry point (#3162) and deliberately never reaches this function: it refuses on a non-empty `git status --porcelain` before doing anything else, so a half-deleted tree reads as dirty and the lane is kept rather than torn down. Mechanism:
 
 1. `git -C <worktree> status --porcelain` — if clean, no-op (`{"preserved": False, "was_clean": True}`).
-2. `git -C <worktree> add -A` — captures untracked + tracked edits.
-3. `git -C <worktree> commit --no-verify --no-gpg-sign -m "WIP: auto-preserved before teardown [slug] [ISO-ts]"` — `--no-verify` avoids pre-commit hooks hanging teardown; `--no-gpg-sign` avoids signing prompts.
-4. `git -C <repo_root> update-ref refs/session-wip/{slug} <sha>` — writes to the **common** ref store (not the per-worktree one), so the ref survives both worktree removal and the unmerged-branch-guard branch deletion.
+2. **Wipe check (#3167).** `git -C <worktree> ls-tree --name-only -d HEAD` lists the directories HEAD tracks; if any is absent from disk, the tree has been (partially or fully) deleted out from under the worktree — by a racing teardown pass, an interrupted `shutil.rmtree`, or similar — and is not a tree whose deletions should be committed. This runs **before** staging, because the signal is cheapest and most reliable before `git add -A` touches the index.
+   - **No missing directory:** falls through to step 3, unchanged.
+   - **A directory is missing:** `git -C <worktree> reset -q` (mixed: index to HEAD, working tree untouched) recovers the index from anything a previous teardown pass already staged, then the additive-only candidate set — `ls-files --modified --others --exclude-standard` minus `ls-files --deleted` — is staged (never `add -A`, which would restage the declined deletions). A non-empty set commits with **zero deletions** plus a trailer recording the refusal; an empty set (the pure-wipe case) writes no commit and no ref at all, leaving the branch head unmoved. Either way, the declined deletions are logged at ERROR under `[worktree-wip-refused-wipe]` with the slug, branch, HEAD sha, missing directory names, and path counts — captured before the force-remove destroys the evidence.
+   - **Fail-open asymmetry:** a failure reading the wipe signal itself (before any directory is confirmed missing) falls open to step 3, logged at WARNING under `[worktree-wip-guard-failed]` — this function's hardest contract is that it never blocks or hangs teardown. A failure *after* a missing directory is confirmed instead refuses (returns the pure-wipe result), because falling open at that point would commit the very wipe just detected.
+3. `git -C <worktree> add -A` — captures untracked + tracked edits.
+4. `git -C <worktree> commit --no-verify --no-gpg-sign -m "WIP: auto-preserved before teardown [slug] [ISO-ts]"` — `--no-verify` avoids pre-commit hooks hanging teardown; `--no-gpg-sign` avoids signing prompts.
+5. `git -C <repo_root> update-ref refs/session-wip/{name} <sha>` — writes to the **common** ref store (not the per-worktree one), so the ref survives both worktree removal and the unmerged-branch-guard branch deletion. `{name}` follows the worktree's actual checked-out branch (`session/<name>` → `<name>`), falling back to the `slug` argument on a detached HEAD or a non-session branch — `_cleanup_stale_worktree` can pass a foreign directory name as `slug` that disagrees with the branch the commit lands on.
 
 The recovery pointer is logged at WARNING with a greppable tag: `[worktree-wip-preserved] slug=… ref=refs/session-wip/… sha=…`.
 
-**Why a WIP commit + named ref, not `git stash`.** A plain `git stash` inside a worktree writes to the *per-worktree* `refs/stash`, which is destroyed with the worktree — useless as a teardown backstop.
+**Why a WIP commit + named ref, not `git stash`.** The reason is *not* that a worktree's stash is worktree-local — `refs/stash` lives in the **common** ref store, so a stash pushed from a worktree is visible as `stash@{0}` from the main checkout and survives the worktree's removal (verified on git 2.50.1). That shared stack is precisely the problem: every lane on this machine pushes onto the same one, so an entry's position is meaningless and a teardown backstop keyed on it would race every peer (issue #2650, shape 1). A WIP commit under a slug-scoped named ref is single-owner by construction. `git stash` also declines untracked files by default, while the WIP commit captures them.
 
 **Non-blocking contract.** Preservation must never block or hang teardown. Any subprocess failure, timeout, or exception is caught, logged at ERROR with `[worktree-wip-preserve-failed]`, and returned in the result dict (`{"preserved": False, "errors": [...]}`) — the force-remove still proceeds.
 
-**Recovery procedure.** The preserved work lives at `refs/session-wip/{slug}` and as a WIP commit on `session/{slug}`:
+**Recovery procedure.** The preserved work lives at `refs/session-wip/{name}` and as a WIP commit on the worktree's branch. With the #3167 guard in place this promise is sound even on a half-deleted tree, because the ref never carries a wipe:
 
 ```bash
-git checkout refs/session-wip/{slug}      # inspect the preserved tree
-git cherry-pick refs/session-wip/{slug}   # or replay onto another branch
+git checkout refs/session-wip/{name}      # inspect the preserved tree
+git cherry-pick refs/session-wip/{name}   # or replay onto another branch
 git reset --soft HEAD~1                    # on a resumed session: unstage the WIP to restore the dirty tree
 ```
 
-**GC policy.** `refs/session-wip/*` refs are reclaimed **manually** — they are cheap pointers to dangling commits. There is no automated GC/TTL daemon in this feature (out of scope; a scheduled ref-GC reflection is a separate follow-up). Remove a stale ref with `git update-ref -d refs/session-wip/{slug}`.
+**GC policy.** `refs/session-wip/*` refs are reclaimed **manually** — they are cheap pointers to dangling commits. There is no automated GC/TTL daemon in this feature (out of scope; a scheduled ref-GC reflection is a separate follow-up). Remove a stale ref with `git update-ref -d refs/session-wip/{name}`.
 
 **2. Destructive-git PreToolUse guard — inside a dirty worktree (#2137).** `.claude/hooks/validators/validate_no_destructive_git_in_worktree.py` blocks an agent from destroying a dirty worktree in-session (before the teardown backstop can fire). It blocks `git reset --hard`, `git clean -f[dx]`, `git checkout -- .` / `git checkout .`, `git restore .`, and bare `git stash` / `git stash push` (no pathspec) **only when** the cwd resolves inside a `.worktrees/` path **and** the tree is dirty. It mirrors `validate_no_uv_sync_in_worktree.py`: a pure `find_violation(command, cwd, is_dirty)` core, command-position (not substring) detection, `cd … &&` chain resolution, and fail-open on any parse/git error.
 
@@ -304,7 +308,7 @@ Experiments validated the approach before implementation:
 
 | File | Purpose |
 |------|---------|
-| `agent/worktree_manager.py` | Git worktree create/remove/list/prune/cleanup operations; `preserve_uncommitted_worktree_changes()` auto-WIP-commit backstop (#2137) |
+| `agent/worktree_manager.py` | Git worktree create/remove/list/prune/cleanup operations; `preserve_uncommitted_worktree_changes()` auto-WIP-commit backstop (#2137), with a wipe-detection guard that declines to commit deletions from a half-deleted tree (#3167) |
 | `.claude/hooks/validators/validate_no_destructive_git_in_worktree.py` | PreToolUse guard blocking destructive git commands in a dirty worktree (#2137) |
 | `.claude/hooks/validators/validate_no_destructive_git_in_shared_checkout.py` | PreToolUse guard blocking whole-tree destructive git commands in the shared main checkout (#2448) |
 | `.claude/hooks/hook_utils/destructive_git_shapes.py` | Shared destructive-git shape-detection logic used by both guards above |

--- a/docs/plans/auto-preserve-teardown-half-deleted-worktree.md
+++ b/docs/plans/auto-preserve-teardown-half-deleted-worktree.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: docs_complete
 type: bug
 appetite: Small
 owner: Valor Engels
@@ -509,11 +509,11 @@ The one agent-facing surface in this subsystem is the sibling `validate_no_destr
 
 ### Feature Documentation
 
-- [ ] Update `docs/features/session-isolation.md` — the "**1. Auto-WIP-commit before teardown.**" subsection at line 254 (unmoved at `bf0a5d577`) describes the mechanism as an unconditional four-step sequence. Add the wipe check as step 2, the additive-only branch, the `[worktree-wip-refused-wipe]` log tag, and the corrected statement of what `refs/session-wip/{slug}` is guaranteed to contain (never a commit that deletes tracked directories). The `agent/worktree_manager.py` row in the file-map table at line 307 also needs it named.
-- [ ] **Fix the `git stash` contradiction between the two surfaces this task edits — they currently disagree, and a documentarian editing both in one pass will otherwise propagate the false version.** The paragraph beginning "**Why a WIP commit + named ref, not `git stash`.**" at `docs/features/session-isolation.md:263` claims a stash "writes to the *per-worktree* `refs/stash`, which is destroyed with the worktree." That is false, and the function's own docstring (`agent/worktree_manager.py:1636-1645`) says the opposite and is correct: `refs/stash` lives in the **common** ref store, so a stash pushed from a worktree is visible as `stash@{0}` from the main checkout and survives the worktree's removal (verified on git 2.50.1). Replace the doc's sentence with the docstring's actual reasoning — that shared stack is precisely the problem, because every lane on this machine pushes onto the same one so an entry's position is meaningless and a teardown backstop keyed on it would race every peer (issue #2650, shape 1) — and note that `git stash` declines untracked files by default while a WIP commit captures them.
-- [ ] Correct the recovery promise in the same document. The docstring and the feature doc both tell a human to run `git checkout refs/session-wip/{slug}` or `git reset --soft HEAD~1`; with the check in place that promise is sound, and the doc should say so explicitly rather than leaving the reader to infer it.
-- [ ] Note in the same subsection that `reap_idle_worktree` is the third worktree-removal entry point and deliberately never reaches preserve, so a reader auditing the teardown surface does not have to rediscover it.
-- [ ] `docs/features/README.md` — no new row needed (`session-isolation.md` is already indexed); verify its one-line description still reads correctly after the edit.
+- [x] Update `docs/features/session-isolation.md` — the "**1. Auto-WIP-commit before teardown.**" subsection at line 254 (unmoved at `bf0a5d577`) describes the mechanism as an unconditional four-step sequence. Add the wipe check as step 2, the additive-only branch, the `[worktree-wip-refused-wipe]` log tag, and the corrected statement of what `refs/session-wip/{slug}` is guaranteed to contain (never a commit that deletes tracked directories). The `agent/worktree_manager.py` row in the file-map table at line 307 also needs it named.
+- [x] **Fix the `git stash` contradiction between the two surfaces this task edits — they currently disagree, and a documentarian editing both in one pass will otherwise propagate the false version.** The paragraph beginning "**Why a WIP commit + named ref, not `git stash`.**" at `docs/features/session-isolation.md:263` claims a stash "writes to the *per-worktree* `refs/stash`, which is destroyed with the worktree." That is false, and the function's own docstring (`agent/worktree_manager.py:1636-1645`) says the opposite and is correct: `refs/stash` lives in the **common** ref store, so a stash pushed from a worktree is visible as `stash@{0}` from the main checkout and survives the worktree's removal (verified on git 2.50.1). Replace the doc's sentence with the docstring's actual reasoning — that shared stack is precisely the problem, because every lane on this machine pushes onto the same one so an entry's position is meaningless and a teardown backstop keyed on it would race every peer (issue #2650, shape 1) — and note that `git stash` declines untracked files by default while a WIP commit captures them.
+- [x] Correct the recovery promise in the same document. The docstring and the feature doc both tell a human to run `git checkout refs/session-wip/{slug}` or `git reset --soft HEAD~1`; with the check in place that promise is sound, and the doc should say so explicitly rather than leaving the reader to infer it.
+- [x] Note in the same subsection that `reap_idle_worktree` is the third worktree-removal entry point and deliberately never reaches preserve, so a reader auditing the teardown surface does not have to rediscover it.
+- [x] `docs/features/README.md` — no new row needed (`session-isolation.md` is already indexed); verify its one-line description still reads correctly after the edit.
 
 ### External Documentation Site
 
@@ -521,13 +521,13 @@ Not applicable — this repo has no Sphinx/MkDocs site.
 
 ### Inline Documentation
 
-- [ ] Rewrite the `preserve_uncommitted_worktree_changes` docstring's numbered mechanism list to include the wipe check as step 2, between the status read and staging, describe both wipe branches (additive-only commit vs. no commit at all), state the ordering constraint (before staging) with the reason, and name the `git reset -q` that opens the wipe path along with why it is index-recovery rather than hygiene.
-- [ ] State the fail-open asymmetry in the docstring explicitly: detection failure falls open, response failure refuses. A reader who assumes one uniform rule will "simplify" the two blocks into one and reopen the round-2 blocker.
-- [ ] Update the docstring's Returns block for the `refused` key and the two wipe shapes.
-- [ ] Add a comment at the check site recording why the insertions-ratio predicate was rejected, citing the incident's 223,142 insertions. This is the single most likely thing for a future reader to "simplify."
-- [ ] Add a comment on the staging call recording that `git add` spells NUL-separated pathspecs `--pathspec-file-nul` and rejects `-z`, that `git add -A` must never be used on the wipe path because it restages the deletions, and that this one call deliberately omits `text=True` because `input` has to be bytes for a NUL-delimited pathspec.
-- [ ] Document the return contract in the docstring's Returns block: `errors` stays `[]` on a refusal, `refused` is the sole discriminator against a git failure, and `missing` / `deleted_paths` carry the detail.
-- [ ] No `config/settings.py` docstring work — the revision dropped both fields.
+- [x] Rewrite the `preserve_uncommitted_worktree_changes` docstring's numbered mechanism list to include the wipe check as step 2, between the status read and staging, describe both wipe branches (additive-only commit vs. no commit at all), state the ordering constraint (before staging) with the reason, and name the `git reset -q` that opens the wipe path along with why it is index-recovery rather than hygiene.
+- [x] State the fail-open asymmetry in the docstring explicitly: detection failure falls open, response failure refuses. A reader who assumes one uniform rule will "simplify" the two blocks into one and reopen the round-2 blocker.
+- [x] Update the docstring's Returns block for the `refused` key and the two wipe shapes.
+- [x] Add a comment at the check site recording why the insertions-ratio predicate was rejected, citing the incident's 223,142 insertions. This is the single most likely thing for a future reader to "simplify."
+- [x] Add a comment on the staging call recording that `git add` spells NUL-separated pathspecs `--pathspec-file-nul` and rejects `-z`, that `git add -A` must never be used on the wipe path because it restages the deletions, and that this one call deliberately omits `text=True` because `input` has to be bytes for a NUL-delimited pathspec.
+- [x] Document the return contract in the docstring's Returns block: `errors` stays `[]` on a refusal, `refused` is the sole discriminator against a git failure, and `missing` / `deleted_paths` carry the detail.
+- [x] No `config/settings.py` docstring work — the revision dropped both fields.
 
 ## Success Criteria
 

--- a/docs/plans/auto-preserve-teardown-half-deleted-worktree.md
+++ b/docs/plans/auto-preserve-teardown-half-deleted-worktree.md
@@ -531,23 +531,23 @@ Not applicable — this repo has no Sphinx/MkDocs site.
 
 ## Success Criteria
 
-- [ ] On a worktree missing a directory tracked at HEAD **with no other uncommitted work**, `preserve_uncommitted_worktree_changes` writes no commit and no ref, leaves the branch head unmoved, and returns `{"preserved": False, "refused": "missing-tracked-dirs", ...}`.
-- [ ] On the same worktree **with coexisting edits or new files**, it commits exactly those paths — the resulting commit's diff against its parent has zero deletions — and returns `preserved: True` alongside the `refused` key. The removed directory is still tracked at the new HEAD.
-- [ ] That commit carries a **trailer** recording the refusal (`Auto-preserve declined deletions (#3167)`, `Missing-tracked-dirs:`, `Declined-deletions:`) with the subject line byte-identical to an ordinary preserve, so the durable artifact records the refusal and not only the rotating log.
-- [ ] `errors` is `[]` on both wipe branches and `refused` is the sole discriminator: on a git failure `errors` is truthy and `refused` is absent. Both directions asserted in one test.
-- [ ] Detection survives a partially-staged wipe: calling `git add -A` before preserve does not blind it (the signal reads HEAD, not the index).
-- [ ] It still preserves every legitimately dirty tree the existing suite covers — tracked edits, staged edits, untracked-only — through the unchanged `git add -A` path, and still commits deletions made *inside* a surviving directory.
-- [ ] After the pure-wipe case the index carries **no staged deletions** (`git diff --cached --diff-filter=D --name-only HEAD` empty), proving both that the check runs before staging and that the wipe path's `reset -q` cleared anything a previous pass staged. (This replaces the earlier "index unmodified" criterion, which the `reset -q` deliberately falsifies.)
-- [ ] A wipe whose real work was **already staged by a previous pass** is still preserved: with `git add -A` run before preserve, the additive commit still carries the edit and the new file and still has zero deletions.
-- [ ] Both live producers are covered by the one change: `_cleanup_stale_worktree` (`:1090`) and `remove_worktree` (`:1880`). `reap_idle_worktree` is untouched and `TestReapIdleWorktree` stays green.
-- [ ] `refs/session-wip/{slug}` names the branch the WIP commit actually landed on, falling back to the `slug` argument on detached HEAD — never `refs/session-wip/HEAD`.
-- [ ] A wipe response logs at ERROR under `[worktree-wip-refused-wipe]` with slug, branch, worktree HEAD sha, sorted missing directory names, and preserved/deleted path counts.
-- [ ] **Failure handling is asymmetric.** A failure of the *detection* read (`ls-tree`, block A) logs WARNING under `[worktree-wip-guard-failed]` and falls through to today's `git add -A` behavior. A failure of the *response* reads (`reset` / `ls-files`, block B, reached only after HEAD has proven a directory missing) logs WARNING under `[worktree-wip-guard-failed]` **and** ERROR under `[worktree-wip-refused-wipe]`, returns the pure-wipe dict, and **leaves the branch head unmoved** — it never falls through to `git add -A`. Asserted by patching each read independently.
-- [ ] The change adds no settings field and no env key.
-- [ ] Tests pass (`/do-test` — `scripts/pytest-clean.sh tests/unit/worktree_manager/`)
-- [ ] Documentation updated (`/do-docs`), including the `refs/stash` correction in `docs/features/session-isolation.md`.
-- [ ] No agent integration wiring needed — asserted by the absence of a new `[project.scripts]` entry in the diff.
-- [ ] No xfail conversions required — `grep -rn 'pytest.mark.xfail\|pytest.xfail(' tests/unit/worktree_manager/` returns nothing, so this bug has no expected-failure marker to convert.
+- [x] On a worktree missing a directory tracked at HEAD **with no other uncommitted work**, `preserve_uncommitted_worktree_changes` writes no commit and no ref, leaves the branch head unmoved, and returns `{"preserved": False, "refused": "missing-tracked-dirs", ...}`.
+- [x] On the same worktree **with coexisting edits or new files**, it commits exactly those paths — the resulting commit's diff against its parent has zero deletions — and returns `preserved: True` alongside the `refused` key. The removed directory is still tracked at the new HEAD.
+- [x] That commit carries a **trailer** recording the refusal (`Auto-preserve declined deletions (#3167)`, `Missing-tracked-dirs:`, `Declined-deletions:`) with the subject line byte-identical to an ordinary preserve, so the durable artifact records the refusal and not only the rotating log.
+- [x] `errors` is `[]` on both wipe branches and `refused` is the sole discriminator: on a git failure `errors` is truthy and `refused` is absent. Both directions asserted in one test.
+- [x] Detection survives a partially-staged wipe: calling `git add -A` before preserve does not blind it (the signal reads HEAD, not the index).
+- [x] It still preserves every legitimately dirty tree the existing suite covers — tracked edits, staged edits, untracked-only — through the unchanged `git add -A` path, and still commits deletions made *inside* a surviving directory.
+- [x] After the pure-wipe case the index carries **no staged deletions** (`git diff --cached --diff-filter=D --name-only HEAD` empty), proving both that the check runs before staging and that the wipe path's `reset -q` cleared anything a previous pass staged. (This replaces the earlier "index unmodified" criterion, which the `reset -q` deliberately falsifies.)
+- [x] A wipe whose real work was **already staged by a previous pass** is still preserved: with `git add -A` run before preserve, the additive commit still carries the edit and the new file and still has zero deletions.
+- [x] Both live producers are covered by the one change: `_cleanup_stale_worktree` (`:1090`) and `remove_worktree` (`:1880`). `reap_idle_worktree` is untouched and `TestReapIdleWorktree` stays green.
+- [x] `refs/session-wip/{slug}` names the branch the WIP commit actually landed on, falling back to the `slug` argument on detached HEAD — never `refs/session-wip/HEAD`.
+- [x] A wipe response logs at ERROR under `[worktree-wip-refused-wipe]` with slug, branch, worktree HEAD sha, sorted missing directory names, and preserved/deleted path counts.
+- [x] **Failure handling is asymmetric.** A failure of the *detection* read (`ls-tree`, block A) logs WARNING under `[worktree-wip-guard-failed]` and falls through to today's `git add -A` behavior. A failure of the *response* reads (`reset` / `ls-files`, block B, reached only after HEAD has proven a directory missing) logs WARNING under `[worktree-wip-guard-failed]` **and** ERROR under `[worktree-wip-refused-wipe]`, returns the pure-wipe dict, and **leaves the branch head unmoved** — it never falls through to `git add -A`. Asserted by patching each read independently.
+- [x] The change adds no settings field and no env key.
+- [x] Tests pass (`/do-test` — `scripts/pytest-clean.sh tests/unit/worktree_manager/`)
+- [x] Documentation updated (`/do-docs`), including the `refs/stash` correction in `docs/features/session-isolation.md`.
+- [x] No agent integration wiring needed — asserted by the absence of a new `[project.scripts]` entry in the diff.
+- [x] No xfail conversions required — `grep -rn 'pytest.mark.xfail\|pytest.xfail(' tests/unit/worktree_manager/` returns nothing, so this bug has no expected-failure marker to convert.
 
 ## Team Orchestration
 

--- a/docs/plans/auto-preserve-teardown-half-deleted-worktree.md
+++ b/docs/plans/auto-preserve-teardown-half-deleted-worktree.md
@@ -696,24 +696,24 @@ Every row is read the same way: **the command must exit 0.** Anti-criteria are w
 
 | Check | Command | Expected |
 |-------|---------|----------|
-| Worktree-manager tests pass | `scripts/pytest-clean.sh tests/unit/worktree_manager/ -q` | exit 0 |
-| Lint clean | `python -m ruff check .` | exit 0 |
-| Format clean | `python -m ruff format --check .` | exit 0 |
-| Refusal tag exists in the producer | `grep -q 'worktree-wip-refused-wipe' agent/worktree_manager.py` | exit 0 |
-| Fail-open tag exists | `grep -q 'worktree-wip-guard-failed' agent/worktree_manager.py` | exit 0 |
-| Structural signal is `ls-tree -d HEAD`, not a hardcoded list | `grep -q 'ls-tree --name-only -d HEAD' agent/worktree_manager.py` | exit 0 |
-| Additive staging uses the correct NUL flag | `grep -q -- '--pathspec-file-nul' agent/worktree_manager.py` | exit 0 |
-| Additive staging reads stdin, not a temp file | `grep -q -- '--pathspec-from-file=-' agent/worktree_manager.py` | exit 0 |
-| Anti-criterion — no temp file on the wipe path | `! grep -qE 'tempfile\|NamedTemporaryFile\|mkstemp' agent/worktree_manager.py` | exit 0 |
-| Refusal trailer is emitted | `grep -q 'Auto-preserve declined deletions' agent/worktree_manager.py` | exit 0 |
-| Fail-open asymmetry is tested | `grep -q 'def test_ls_files_failure_after_detection_refuses_and_never_commits' tests/unit/worktree_manager/test_worktree_manager_uncommitted.py && grep -q 'def test_guard_detection_failure_falls_open_and_warns' tests/unit/worktree_manager/test_worktree_manager_uncommitted.py` | exit 0 |
-| Wipe path resets the index before computing candidates | `grep -q '"reset", "-q"' agent/worktree_manager.py` | exit 0 |
-| Regression tests exist | `grep -q 'def test_pure_wipe_writes_no_commit_and_no_ref' tests/unit/worktree_manager/test_worktree_manager_uncommitted.py && grep -q 'def test_mixed_wipe_preserves_additions_and_drops_deletions' tests/unit/worktree_manager/test_worktree_manager_uncommitted.py && grep -q 'def test_partially_staged_wipe_still_detected' tests/unit/worktree_manager/test_worktree_manager_uncommitted.py && grep -q 'def test_pure_wipe_carries_no_staged_deletions' tests/unit/worktree_manager/test_worktree_manager_uncommitted.py && grep -q 'def test_pre_staged_wipe_is_unstaged_and_additive_work_still_preserved' tests/unit/worktree_manager/test_worktree_manager_uncommitted.py` | exit 0 |
-| Anti-criterion — no hardcoded top-level directory list | `! grep -qE '\["?(tests\|bridge\|agent\|config)/?"?,' agent/worktree_manager.py` | exit 0 |
-| Anti-criterion — the rejected insertions-ratio predicate is absent | `! grep -qE -- '--(numstat\|shortstat)' agent/worktree_manager.py` | exit 0 |
-| Anti-criterion — the dropped tunables were not reintroduced | `! grep -qE 'wipe_refusal_(min_deleted_files\|deleted_fraction)' config/settings.py` | exit 0 |
-| Anti-criterion (#3166 No-Go) — no bridge/watchdog code in the diff | `test -z "$(git diff --name-only origin/main...HEAD -- bridge/ monitoring/)"` | exit 0 |
-| No stale xfails in scope | `! grep -rq 'xfail' tests/unit/worktree_manager/` | exit 0 |
+| Worktree-manager tests pass | `scripts/pytest-clean.sh tests/unit/worktree_manager/ -q` | exit code 0 |
+| Lint clean | `python -m ruff check .` | exit code 0 |
+| Format clean | `python -m ruff format --check .` | exit code 0 |
+| Refusal tag exists in the producer | `grep -q 'worktree-wip-refused-wipe' agent/worktree_manager.py` | exit code 0 |
+| Fail-open tag exists | `grep -q 'worktree-wip-guard-failed' agent/worktree_manager.py` | exit code 0 |
+| Structural signal is `ls-tree -d HEAD`, not a hardcoded list | `grep -q 'ls-tree --name-only -d HEAD' agent/worktree_manager.py` | exit code 0 |
+| Additive staging uses the correct NUL flag | `grep -q -- '--pathspec-file-nul' agent/worktree_manager.py` | exit code 0 |
+| Additive staging reads stdin, not a temp file | `grep -q -- '--pathspec-from-file=-' agent/worktree_manager.py` | exit code 0 |
+| Anti-criterion — no temp file on the wipe path | `! grep -qE 'tempfile\|NamedTemporaryFile\|mkstemp' agent/worktree_manager.py` | exit code 0 |
+| Refusal trailer is emitted | `grep -q 'Auto-preserve declined deletions' agent/worktree_manager.py` | exit code 0 |
+| Fail-open asymmetry is tested | `grep -q 'def test_ls_files_failure_after_detection_refuses_and_never_commits' tests/unit/worktree_manager/test_worktree_manager_uncommitted.py && grep -q 'def test_guard_detection_failure_falls_open_and_warns' tests/unit/worktree_manager/test_worktree_manager_uncommitted.py` | exit code 0 |
+| Wipe path resets the index before computing candidates | `grep -q '"reset", "-q"' agent/worktree_manager.py` | exit code 0 |
+| Regression tests exist | `grep -q 'def test_pure_wipe_writes_no_commit_and_no_ref' tests/unit/worktree_manager/test_worktree_manager_uncommitted.py && grep -q 'def test_mixed_wipe_preserves_additions_and_drops_deletions' tests/unit/worktree_manager/test_worktree_manager_uncommitted.py && grep -q 'def test_partially_staged_wipe_still_detected' tests/unit/worktree_manager/test_worktree_manager_uncommitted.py && grep -q 'def test_pure_wipe_carries_no_staged_deletions' tests/unit/worktree_manager/test_worktree_manager_uncommitted.py && grep -q 'def test_pre_staged_wipe_is_unstaged_and_additive_work_still_preserved' tests/unit/worktree_manager/test_worktree_manager_uncommitted.py` | exit code 0 |
+| Anti-criterion — no hardcoded top-level directory list | `! grep -qE '\["?(tests\|bridge\|agent\|config)/?"?,' agent/worktree_manager.py` | exit code 0 |
+| Anti-criterion — the rejected insertions-ratio predicate is absent | `! grep -qE -- '--(numstat\|shortstat)' agent/worktree_manager.py` | exit code 0 |
+| Anti-criterion — the dropped tunables were not reintroduced | `! grep -qE 'wipe_refusal_(min_deleted_files\|deleted_fraction)' config/settings.py` | exit code 0 |
+| Anti-criterion (#3166 No-Go) — no bridge/watchdog code in the diff | `test -z "$(git diff --name-only origin/main...HEAD -- bridge/ monitoring/)"` | exit code 0 |
+| No stale xfails in scope | `! grep -rq 'xfail' tests/unit/worktree_manager/` | exit code 0 |
 
 The `"reset", "-q"` row was mutation-checked in the concern-closing pass, after round 3 found its first form (`grep -q 'reset'`) vacuous — that pattern exits 0 against unmodified `origin/main`, matching the producer docstring's ``git reset --soft HEAD~1`` at line 1662, so it would have certified a build that never added the reset. Re-verified both directions: `grep -q '"reset", "-q"'` exits **1** against `git show origin/main:agent/worktree_manager.py` and exits **0** against a seeded file carrying the argv form, so it bites.
 

--- a/tests/unit/worktree_manager/test_worktree_manager_uncommitted.py
+++ b/tests/unit/worktree_manager/test_worktree_manager_uncommitted.py
@@ -443,6 +443,52 @@ class TestPreserveWipeDetection:
         assert "worktree-wip-guard-failed" in joined
         assert "worktree-wip-refused-wipe" in joined
 
+    def test_branch_resolve_timeout_still_preserves_ordinary_dirty_tree(self, tmp_path, caplog):
+        """Regression (#3167 review follow-up): the `rev-parse --abbrev-ref
+        HEAD` read used to name the WIP ref runs on every preserve path,
+        including the ordinary non-wipe one, with no narrow try/except of its
+        own. A non-zero rc already falls back to the slug-derived ref; an
+        exception (e.g. `TimeoutExpired`) must degrade the same way rather
+        than propagate to the outer handler, which would skip `add -A`, the
+        WIP commit, and the ref write entirely -- losing legitimate
+        uncommitted work on a normally dirty worktree.
+        """
+        import subprocess as _sp
+
+        from agent import worktree_manager as wm
+
+        repo = _init_git_repo(tmp_path)
+        slug = "sdlc-branchto"
+        wt = _add_linked_worktree(repo, slug)
+        head_before = _git(wt, "rev-parse", "HEAD").stdout.strip()
+        _dirty(wt)
+
+        real_run = wm.subprocess.run
+
+        def fake_run(cmd, *args, **kwargs):
+            if "rev-parse" in cmd and "--abbrev-ref" in cmd and "HEAD" in cmd:
+                raise _sp.TimeoutExpired(cmd=cmd, timeout=5)
+            return real_run(cmd, *args, **kwargs)
+
+        with patch.object(wm.subprocess, "run", side_effect=fake_run):
+            with caplog.at_level(logging.WARNING, logger="agent.worktree_manager"):
+                result = wm.preserve_uncommitted_worktree_changes(repo, slug, wt)
+
+        assert result["preserved"] is True
+        assert result["was_clean"] is False
+        sha = result["sha"]
+        assert sha and sha != head_before
+        # Falls back to the slug-derived ref, exactly like a non-zero rc would.
+        assert result["ref"] == f"refs/session-wip/{slug}"
+
+        ref_sha = _git(repo, "rev-parse", f"refs/session-wip/{slug}").stdout.strip()
+        assert ref_sha == sha
+        assert _git(wt, "rev-parse", "HEAD").stdout.strip() == sha
+        assert _git(wt, "status", "--porcelain").stdout.strip() == ""
+
+        joined = " ".join(r.message for r in caplog.records)
+        assert "worktree-wip-branch-resolve-failed" in joined
+
     def test_ref_slug_follows_checked_out_branch(self, tmp_path):
         import subprocess as _sp
 

--- a/tests/unit/worktree_manager/test_worktree_manager_uncommitted.py
+++ b/tests/unit/worktree_manager/test_worktree_manager_uncommitted.py
@@ -43,6 +43,35 @@ def _dirty(wt: Path) -> None:
     (wt / "untracked.txt").write_text("untracked content\n")
 
 
+def _init_git_repo_with_dirs(tmp_path: Path, name: str, dirs: list[str]) -> Path:
+    """Like ``_init_git_repo`` but with tracked top-level directories (each
+    holding one tracked file, ``f1.py``) — the fixture shape needed by the
+    wipe-detection tests (#3167).
+    """
+    import subprocess as _sp
+
+    repo = tmp_path / name
+    repo.mkdir()
+    _sp.run(["git", "init", "-q", "-b", "main", str(repo)], check=True)
+    _sp.run(["git", "-C", str(repo), "config", "user.email", "t@example.com"], check=True)
+    _sp.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
+    (repo / "seed.txt").write_text("seed\n")
+    for d in dirs:
+        (repo / d).mkdir()
+        (repo / d / "f1.py").write_text(f"# {d}/f1\n")
+    _sp.run(["git", "-C", str(repo), "add", "-A"], check=True)
+    _sp.run(["git", "-C", str(repo), "commit", "-q", "-m", "seed"], check=True)
+    return repo
+
+
+def _gut(wt: Path, *dirs: str) -> None:
+    """Delete named tracked top-level directories from disk (simulates a wipe)."""
+    import shutil as _shutil
+
+    for d in dirs:
+        _shutil.rmtree(wt / d, ignore_errors=True)
+
+
 def _git(wt: Path, *args: str):
     import subprocess as _sp
 
@@ -132,6 +161,7 @@ class TestPreserveUncommittedChanges:
 
         assert result["preserved"] is False
         assert result.get("errors")
+        assert "refused" not in result
         joined = " ".join(r.message for r in caplog.records)
         assert "worktree-wip-preserve-failed" in joined
 
@@ -151,3 +181,303 @@ class TestPreserveUncommittedChanges:
         assert not wt.exists()
         # ... but the uncommitted work survives in the durable ref.
         assert _git(repo, "rev-parse", "--verify", f"refs/session-wip/{slug}").returncode == 0
+
+
+class TestPreserveWipeDetection:
+    """Regression tests for #3167: auto-preserve must never commit a wipe."""
+
+    def test_pure_wipe_writes_no_commit_and_no_ref(self, tmp_path, caplog):
+        from agent.worktree_manager import preserve_uncommitted_worktree_changes
+
+        repo = _init_git_repo_with_dirs(tmp_path, "repo", ["docs", "tests"])
+        slug = "sdlc-wipe1"
+        wt = _add_linked_worktree(repo, slug)
+        head_before = _git(wt, "rev-parse", "HEAD").stdout.strip()
+        _gut(wt, "docs", "tests")
+
+        with caplog.at_level(logging.ERROR, logger="agent.worktree_manager"):
+            result = preserve_uncommitted_worktree_changes(repo, slug, wt)
+
+        assert result["preserved"] is False
+        assert result["refused"] == "missing-tracked-dirs"
+        assert result["errors"] == []
+        assert _git(wt, "rev-parse", "HEAD").stdout.strip() == head_before
+        assert _git(repo, "rev-parse", "--verify", f"refs/session-wip/{slug}").returncode != 0
+
+        joined = " ".join(r.message for r in caplog.records)
+        assert "worktree-wip-refused-wipe" in joined
+        assert "docs" in joined and "tests" in joined
+
+    def test_mixed_wipe_preserves_additions_and_drops_deletions(self, tmp_path):
+        from agent.worktree_manager import preserve_uncommitted_worktree_changes
+
+        repo = _init_git_repo_with_dirs(tmp_path, "repo", ["docs", "tests"])
+        slug = "sdlc-wipe2"
+        wt = _add_linked_worktree(repo, slug)
+        parent_sha = _git(wt, "rev-parse", "HEAD").stdout.strip()
+
+        _gut(wt, "docs")
+        (wt / "tests" / "f1.py").write_text("# edited\n")
+        (wt / "tests" / "f4.py").write_text("# new\n")
+
+        result = preserve_uncommitted_worktree_changes(repo, slug, wt)
+
+        assert result["preserved"] is True
+        assert result["refused"] == "missing-tracked-dirs"
+        sha = result["sha"]
+        assert sha and sha != parent_sha
+
+        diff_stat = _git(wt, "diff", "--stat", parent_sha, sha).stdout
+        assert "f1.py" in diff_stat
+        assert "f4.py" in diff_stat
+        # Zero deletions in the commit's diff against its parent.
+        assert (
+            _git(wt, "diff", "--diff-filter=D", "--name-only", parent_sha, sha).stdout.strip() == ""
+        )
+        # The removed directory is still tracked at the new HEAD.
+        tracked_dirs = _git(wt, "ls-tree", "--name-only", "-d", "HEAD").stdout
+        assert "docs" in tracked_dirs
+
+        # Commit trailer records the refusal; subject line is unchanged.
+        body = _git(wt, "log", "-1", "--format=%B", sha).stdout
+        assert body.startswith("WIP: auto-preserved before teardown")
+        assert "Auto-preserve declined deletions (#3167)" in body
+        assert "Missing-tracked-dirs:" in body
+        assert "Declined-deletions:" in body
+
+    def test_refusal_and_git_failure_are_distinguishable_on_errors(self, tmp_path):
+        from agent.worktree_manager import preserve_uncommitted_worktree_changes
+
+        repo = _init_git_repo_with_dirs(tmp_path, "repo", ["docs"])
+        slug = "sdlc-wipe3"
+        wt = _add_linked_worktree(repo, slug)
+        _gut(wt, "docs")
+
+        refusal = preserve_uncommitted_worktree_changes(repo, slug, wt)
+        assert refusal["errors"] == []
+        assert refusal["refused"] == "missing-tracked-dirs"
+
+        repo2 = _init_git_repo(tmp_path, "repo2")
+        slug2 = "sdlc-wipe3b"
+        wt2 = _add_linked_worktree(repo2, slug2)
+        _dirty(wt2)
+        with patch("agent.worktree_manager.subprocess.run", side_effect=OSError("git exploded")):
+            failure = preserve_uncommitted_worktree_changes(repo2, slug2, wt2)
+        assert failure["errors"]
+        assert "refused" not in failure
+
+    def test_wipe_with_untracked_artifacts_still_refuses_deletions(self, tmp_path):
+        from agent.worktree_manager import preserve_uncommitted_worktree_changes
+
+        repo = _init_git_repo_with_dirs(tmp_path, "repo", ["docs", "tests"])
+        slug = "sdlc-wipe4"
+        wt = _add_linked_worktree(repo, slug)
+        parent_sha = _git(wt, "rev-parse", "HEAD").stdout.strip()
+
+        _gut(wt, "docs", "tests")
+        # Untracked build-artifact-shaped junk, so `git add -A` would report
+        # real insertions -- reproduces the incident's shape (spike-3).
+        artifact_dir = wt / ".venv" / "lib"
+        artifact_dir.mkdir(parents=True)
+        for i in range(3):
+            (artifact_dir / f"pkg{i}.pyc").write_text("junk\n")
+
+        result = preserve_uncommitted_worktree_changes(repo, slug, wt)
+
+        assert result["refused"] == "missing-tracked-dirs"
+        new_head = _git(wt, "rev-parse", "HEAD").stdout.strip()
+        # Whatever the outcome, the wipe's own deletions never land in a commit.
+        if result["preserved"]:
+            assert (
+                _git(
+                    wt, "diff", "--diff-filter=D", "--name-only", parent_sha, new_head
+                ).stdout.strip()
+                == ""
+            )
+        else:
+            assert new_head == parent_sha
+        tracked_dirs = _git(wt, "ls-tree", "--name-only", "-d", "HEAD").stdout
+        assert "docs" in tracked_dirs and "tests" in tracked_dirs
+
+    def test_partially_staged_wipe_still_detected(self, tmp_path):
+        from agent.worktree_manager import preserve_uncommitted_worktree_changes
+
+        repo = _init_git_repo_with_dirs(tmp_path, "repo", ["docs"])
+        slug = "sdlc-wipe5"
+        wt = _add_linked_worktree(repo, slug)
+        parent_sha = _git(wt, "rev-parse", "HEAD").stdout.strip()
+
+        _gut(wt, "docs")
+        _git(wt, "add", "-A")  # a previous pass already staged the wipe
+
+        result = preserve_uncommitted_worktree_changes(repo, slug, wt)
+
+        assert result["refused"] == "missing-tracked-dirs"
+        assert _git(wt, "rev-parse", "HEAD").stdout.strip() == parent_sha
+
+    def test_deletions_inside_a_surviving_directory_are_preserved_normally(self, tmp_path):
+        import subprocess as _sp
+
+        from agent.worktree_manager import preserve_uncommitted_worktree_changes
+
+        repo = _init_git_repo_with_dirs(tmp_path, "repo", ["tests"])
+        # A second tracked file inside tests/ so the directory survives on
+        # disk after one of its files is deleted.
+        (repo / "tests" / "f2.py").write_text("# f2\n")
+        _sp.run(["git", "-C", str(repo), "add", "-A"], check=True)
+        _sp.run(["git", "-C", str(repo), "commit", "-q", "-m", "add f2"], check=True)
+
+        slug = "sdlc-wipe6"
+        wt = _add_linked_worktree(repo, slug)
+        parent_sha = _git(wt, "rev-parse", "HEAD").stdout.strip()
+
+        (wt / "tests" / "f2.py").unlink()  # deletion inside a surviving directory
+        (wt / "tests" / "f1.py").write_text("# edited\n")  # a genuine edit
+
+        result = preserve_uncommitted_worktree_changes(repo, slug, wt)
+
+        assert result["preserved"] is True
+        assert "refused" not in result
+        sha = result["sha"]
+        deleted = _git(wt, "diff", "--diff-filter=D", "--name-only", parent_sha, sha).stdout
+        assert "tests/f2.py" in deleted
+
+    def test_pure_wipe_carries_no_staged_deletions(self, tmp_path):
+        from agent.worktree_manager import preserve_uncommitted_worktree_changes
+
+        repo = _init_git_repo_with_dirs(tmp_path, "repo", ["docs"])
+        slug = "sdlc-wipe7"
+        wt = _add_linked_worktree(repo, slug)
+        _gut(wt, "docs")
+
+        result = preserve_uncommitted_worktree_changes(repo, slug, wt)
+
+        assert result["preserved"] is False
+        assert (
+            _git(wt, "diff", "--cached", "--diff-filter=D", "--name-only", "HEAD").stdout.strip()
+            == ""
+        )
+
+    def test_pre_staged_wipe_is_unstaged_and_additive_work_still_preserved(self, tmp_path):
+        from agent.worktree_manager import preserve_uncommitted_worktree_changes
+
+        repo = _init_git_repo_with_dirs(tmp_path, "repo", ["docs", "tests"])
+        slug = "sdlc-wipe8"
+        wt = _add_linked_worktree(repo, slug)
+        parent_sha = _git(wt, "rev-parse", "HEAD").stdout.strip()
+
+        _gut(wt, "docs")
+        (wt / "tests" / "f1.py").write_text("# edited\n")
+        (wt / "tests" / "f4.py").write_text("# new\n")
+        _git(wt, "add", "-A")  # a previous pass already staged everything, wipe included
+
+        result = preserve_uncommitted_worktree_changes(repo, slug, wt)
+
+        assert result["preserved"] is True
+        sha = result["sha"]
+        diff_stat = _git(wt, "diff", "--stat", parent_sha, sha).stdout
+        assert "f1.py" in diff_stat
+        assert "f4.py" in diff_stat
+        assert (
+            _git(wt, "diff", "--diff-filter=D", "--name-only", parent_sha, sha).stdout.strip() == ""
+        )
+        tracked_dirs = _git(wt, "ls-tree", "--name-only", "-d", "HEAD").stdout
+        assert "docs" in tracked_dirs
+
+    def test_guard_detection_failure_falls_open_and_warns(self, tmp_path, caplog):
+        from agent import worktree_manager as wm
+
+        repo = _init_git_repo(tmp_path)
+        slug = "sdlc-wipe9"
+        wt = _add_linked_worktree(repo, slug)
+        _dirty(wt)
+
+        real_run = wm.subprocess.run
+
+        def fake_run(cmd, *args, **kwargs):
+            if "ls-tree" in cmd:
+                raise OSError("ls-tree exploded")
+            return real_run(cmd, *args, **kwargs)
+
+        with patch.object(wm.subprocess, "run", side_effect=fake_run):
+            with caplog.at_level(logging.WARNING, logger="agent.worktree_manager"):
+                result = wm.preserve_uncommitted_worktree_changes(repo, slug, wt)
+
+        assert result["preserved"] is True
+        assert "refused" not in result
+        joined = " ".join(r.message for r in caplog.records)
+        assert "worktree-wip-guard-failed" in joined
+        assert "stage=detection" in joined
+
+    def test_ls_files_failure_after_detection_refuses_and_never_commits(self, tmp_path, caplog):
+        from agent import worktree_manager as wm
+
+        repo = _init_git_repo_with_dirs(tmp_path, "repo", ["docs", "tests"])
+        slug = "sdlc-wipe10"
+        wt = _add_linked_worktree(repo, slug)
+        parent_sha = _git(wt, "rev-parse", "HEAD").stdout.strip()
+
+        _gut(wt, "docs")
+        (wt / "tests" / "f1.py").write_text("# edited\n")
+
+        real_run = wm.subprocess.run
+
+        def fake_run(cmd, *args, **kwargs):
+            if "ls-files" in cmd:
+                raise OSError("ls-files exploded")
+            return real_run(cmd, *args, **kwargs)
+
+        with patch.object(wm.subprocess, "run", side_effect=fake_run):
+            with caplog.at_level(logging.WARNING, logger="agent.worktree_manager"):
+                result = wm.preserve_uncommitted_worktree_changes(repo, slug, wt)
+
+        # The head sha is the assertion that matters -- under a single shared
+        # `except`, this scenario falls through to `git add -A` and commits
+        # the wipe, which "did not raise" alone would not catch.
+        assert _git(wt, "rev-parse", "HEAD").stdout.strip() == parent_sha
+        assert _git(repo, "rev-parse", "--verify", f"refs/session-wip/{slug}").returncode != 0
+        assert result["refused"] == "missing-tracked-dirs"
+        assert "guard_error" in result
+
+        joined = " ".join(r.message for r in caplog.records)
+        assert "worktree-wip-guard-failed" in joined
+        assert "worktree-wip-refused-wipe" in joined
+
+    def test_ref_slug_follows_checked_out_branch(self, tmp_path):
+        import subprocess as _sp
+
+        from agent.worktree_manager import preserve_uncommitted_worktree_changes
+
+        repo = _init_git_repo(tmp_path)
+        wt = repo / ".worktrees" / "foo"
+        _sp.run(
+            ["git", "-C", str(repo), "worktree", "add", "-q", "-b", "session/bar", str(wt)],
+            check=True,
+        )
+        _dirty(wt)
+
+        result = preserve_uncommitted_worktree_changes(repo, "foo", wt)
+
+        assert result["preserved"] is True
+        assert result["ref"] == "refs/session-wip/bar"
+        assert _git(repo, "rev-parse", "--verify", "refs/session-wip/bar").returncode == 0
+
+    def test_detached_head_falls_back_to_slug_argument(self, tmp_path):
+        import subprocess as _sp
+
+        from agent.worktree_manager import preserve_uncommitted_worktree_changes
+
+        repo = _init_git_repo(tmp_path)
+        head_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+        wt = repo / ".worktrees" / "detached-wt"
+        _sp.run(
+            ["git", "-C", str(repo), "worktree", "add", "-q", "--detach", str(wt), head_sha],
+            check=True,
+        )
+        _dirty(wt)
+
+        result = preserve_uncommitted_worktree_changes(repo, "detached-wt", wt)
+
+        assert result["preserved"] is True
+        assert result["ref"] == "refs/session-wip/detached-wt"
+        assert result["ref"] != "refs/session-wip/HEAD"


### PR DESCRIPTION
## Summary
`preserve_uncommitted_worktree_changes` (`agent/worktree_manager.py`) used to test only whether `git status --porcelain` was non-empty, then unconditionally `git add -A` and commit. A worktree caught mid-teardown (tracked directories deleted from disk) reads as maximally dirty, so the guard meant to skip a clean tree instead waved a total deletion straight through — the reported incident committed 902,840 deletions onto a live session branch. This PR adds a structural wipe check before staging, and fixes a related ref/branch-name mismatch found during recon.

## Changes
- **Wipe detection**: `git ls-tree --name-only -d HEAD` lists directories HEAD tracks; if any is absent from disk on the worktree, the tree is a wipe, not a tree whose deletions should be committed. No hardcoded directory list, no threshold, no new configuration.
- **Additive-only preserve on a wipe**: `git reset -q` (index-recovery, load-bearing — recovers from a wipe a previous teardown pass already staged) followed by staging exactly the additive candidate set (`ls-files --modified --others --exclude-standard` minus `ls-files --deleted`), via stdin with `--pathspec-file-nul` — never `git add -A`, which would restage the declined deletions. Coexisting real work is preserved with **zero deletions** in the commit; a pure wipe writes no commit and no ref at all, leaving the branch head unmoved.
- **Commit trailer**: the additive commit's subject stays byte-identical to an ordinary preserve; a trailer (`Auto-preserve declined deletions (#3167)`, `Missing-tracked-dirs:`, `Declined-deletions:`) records the refusal in the durable artifact, not only the rotating log.
- **Asymmetric fail-open**: a failure reading the wipe signal itself falls open to today's behavior (logged at WARNING, `[worktree-wip-guard-failed]`); a failure *after* a missing directory is confirmed refuses instead of falling through (also logged at ERROR, `[worktree-wip-refused-wipe]`) — falling open there would commit the very wipe just detected.
- **Ref-slug fix**: `refs/session-wip/{name}` now follows the worktree's actual checked-out branch (`session/<name>` → `<name>`) rather than the foreign directory name `_cleanup_stale_worktree` passes as `slug`, so the recovery pointer and the recovered content agree. Falls back to the `slug` argument on a detached HEAD or non-`session/` branch.
- Rejected the issue's proposed insertions/deletions-ratio predicate: the incident's own commit carried 223,142 insertions alongside 902,840 deletions (untracked build artifacts staged by `add -A` count as insertions), so a ratio test would not have fired. Pinned by a regression test.

## Testing
- [x] 12 new regression tests in `tests/unit/worktree_manager/test_worktree_manager_uncommitted.py` (pure wipe, mixed wipe, untracked artifacts, partially-staged wipe, pre-staged wipe, deletions inside a surviving directory, both fail-open/fail-closed asymmetry cases, ref-slug follows branch, detached-HEAD fallback, errors/refused discriminator)
- [x] All 5 pre-existing tests in the same file pass unmodified except the strengthened `errors`/`refused` assertion
- [x] `tests/unit/worktree_manager/` — 149 passed
- [x] Representative mutation checks run manually (disabling the structural check, replacing additive staging with `add -A`, removing the `reset -q`) each flip the corresponding test red
- [x] Lint/format clean on all changed files (`python -m ruff check` / `ruff format --check`)
- [ ] Full `tests/unit/` sweep could not complete during this build — this machine had ~10+ concurrent SDLC lanes running pytest-xdist simultaneously, exhausting the shared test-DB pool (`#2628`) and the xdist worker pool. The scoped, plan-mandated verification (`tests/unit/worktree_manager/`) passed cleanly and repeatedly under that same contention; the change touches exactly one function, its own test file, and one doc file.

## Documentation
- [x] `docs/features/session-isolation.md` updated: the wipe check (both branches, fail-open asymmetry, ref-naming fix) documented in the auto-WIP-commit mechanism, and the `refs/stash` paragraph corrected to match the function's own (accurate) docstring — the doc previously had it backwards.

## Definition of Done
- [x] Built: wipe detection, additive-only preserve, and ref-slug fix all implemented in `preserve_uncommitted_worktree_changes`
- [x] Tested: 149 tests passing in `tests/unit/worktree_manager/`
- [x] Documented: `docs/features/session-isolation.md` updated
- [x] Quality: lint and format clean

Closes #3167