### PR TITLE
Nightly triage filing idempotency: three prompts share one REST lookup, per-node dispatch carries its dispositions and a replay ledger

### DIFF
--- a/docs/features/nightly-regression-tests.md
+++ b/docs/features/nightly-regression-tests.md
@@ -513,9 +513,12 @@ dispatch and, since #3134, comments on rather than re-files any finding whose
 issue is already open — which closes the common cross-machine case, but it is
 a read-then-act check with no lock, so two machines dispatching inside the
 same window still both file. The literal title remains the contract: the detector
-emits it verbatim, the triage session is instructed to search for it, and
-nothing verifies an issue was actually filed under it, so a future change to
-the title format silently reopens #2429/#2430/#2462 across the fleet.
+emits it verbatim, the triage session is handed the same REST read the
+detector uses and told to match that literal title against it (never the
+index-backed lookup, whose lag produced the #2960-#2999 wave — see
+`nightly-triage-dispatch.md`), and nothing verifies an issue was actually filed
+under it, so a future change to the title format silently reopens
+#2429/#2430/#2462 across the fleet.
 `MAX_ISSUES_PER_RUN` (10) bounds the blast radius of any single run;
 a shared, Redis-backed dispatch set is the real fix and is deliberately
 deferred.

--- a/docs/features/nightly-triage-dispatch.md
+++ b/docs/features/nightly-triage-dispatch.md
@@ -48,9 +48,100 @@ three behaviors layered around that base run:
    and closed sets: an open issue gets a recurrence comment instead of a second issue,
    and a title closed `NOT_PLANNED` (by its most recent closure) is commented on and
    never re-filed, while one closed `COMPLETED` re-files because failing again after a
-   fix is new information. The triage prompt states the same open-and-closed rule so
-   the pre-flight and the agent's instructions cannot drift (see the base doc's
-   "Comment-over-create" decision and issue #3075).
+   fix is new information. The prompts state the same open-and-closed rule so the
+   pre-flight and the agent's instructions cannot drift (see the base doc's
+   "Comment-over-create" decision and issue #3075). Three defences then keep a
+   *replayed* turn from filing a second issue for a node the same session already
+   opened, which is what produced the #2960–#2999 wave (issue #3170):
+   - **All three prompts hand over the lookup command.** `ISSUE_LOOKUP_INSTRUCTION`
+     carries the literal `gh issue list --state all …` REST read, so the agent sees an
+     issue the instant it exists rather than waiting on an index that lags creation by
+     minutes.
+   - **The per-node dispatch carries the detector's own resolved dispositions**, so the
+     agent confirms a decision instead of re-deriving one.
+   - **The per-node dispatch seeds a session ledger** recording what it has already
+     filed. See "Replay Idempotency" below.
+
+   Fixes two and three stop at the per-node path deliberately, and the gap is a
+   decision rather than an oversight: the cascade umbrella and the re-baseline seed
+   pre-render their own prompt at the call site and their builders take no disposition
+   or ledger parameter, so a disposition built for them would have no reader. Every
+   observed duplicate-filing incident came out of the per-node path. Both override
+   paths still get the lookup command, which is the defence that addresses the read
+   failure itself. Widening the other two is the first thing to do if a cascade or seed
+   duplicate is ever seen.
+
+### Three prompts, one lookup instruction
+
+There are **three** issue-filing prompts, not one, and each dispatches a session that
+opens real GitHub issues:
+
+| Builder | Dispatched from | Files |
+|---------|-----------------|-------|
+| `_build_triage_prompt` | `dispatch_findings`, per surviving node | One issue per node |
+| `_build_cascade_prompt` | `dispatch_findings`, per collapsed cascade | One umbrella issue |
+| `_build_seed_prompt` | `main()`, on a collection re-baseline | One seed umbrella issue |
+
+All three interpolate the same `ISSUE_LOOKUP_INSTRUCTION` constant. That matters
+historically: the doc used to imply a single prompt, which is how the cascade and seed
+prompts went four passes at this bug without ever being hardened — each carried its own
+copy of the sentence, and each pass fixed the copy it happened to be looking at. The
+seed prompt lived inline inside `main()` until #3170 and could not be rendered by a
+test or scanned by a gate at all; extracting it into a named builder is what made its
+copy of the defect visible.
+
+### Replay Idempotency
+
+`data/nightly-triage-ledger/{slug}.json` is the third and last-resort defence: a record
+on disk of what one triage session has already filed, so a turn replayed with a fresh
+context reads its predecessor's work instead of starting from zero.
+
+```json
+{
+  "slug": "nightly-triage-a1b2c3d4",
+  "created_at": "2026-09-05T06:00:00Z",
+  "entries": [
+    {"node": "tests/unit/test_a.py::test_1",
+     "title": "Nightly regression: tests/unit/test_a.py::test_1",
+     "disposition": "file",
+     "resolved_against": "gh issue list --state all (open+closed REST read)",
+     "resolved_at": "2026-09-05T06:00:00Z"}
+  ],
+  "filed": []
+}
+```
+
+- **Who writes what.** `write_triage_ledger` seeds `slug`, `created_at`, `entries` and
+  an empty `filed` before the session subprocess starts; the triage agent appends to
+  `filed` after each `gh issue create`, before moving to the next entry.
+- **Per-node dispatch only.** `entries` derives from the `dispositions` argument and
+  from nothing else, so the two `prompt=`-override dispatches produce an empty entry
+  list, no file is created for them, and `nightly-triage-baseline.json` never exists.
+  One gate does the whole narrowing; there is no separate branch.
+- **Advisory and fail-open.** Any write failure logs a `WARNING` naming the slug and
+  returns `None`; the dispatch proceeds without a ledger paragraph in its prompt. A
+  ledger that cannot be written must not stop the night from filing, the same posture
+  `open_issues()` takes when it cannot read. The prompt also tells the agent to treat a
+  missing or unparseable ledger as an empty `filed` list.
+- **Written after the `--dry-run` short-circuit.** A preview writes no state file.
+- **Deliberately unlocked.** Two sessions share a ledger only when dispatched for an
+  identical node set, which the run lock and `compute_dispatch_set` make
+  near-impossible within a machine, and the file is machine-local so two hosts never
+  share one. The one case defended is a same-slug retry landing on a ledger a live
+  session is appending to: an existing file whose `filed` array is non-empty is left
+  exactly as it is. The write itself goes through a temp file and `os.replace`, because
+  truncated JSON is worse for the agent than stale-but-valid JSON.
+- **Why `data/` and not the lane worktree.** The issue asked for a session-local file
+  under `.worktrees/{slug}/`. That worktree is a git checkout, so a file there shows up
+  in the agent's own `git status` and dies with the lane on teardown — and the
+  stale-branch sweep described under "Lane reaping" keeps any lane whose tree is dirty,
+  so a ledger inside the lane would make every triage worktree permanently unreapable,
+  reintroducing the accumulation #3162 just fixed. `data/` is already this script's
+  state home, is gitignored, survives teardown, and is reachable by absolute path from
+  inside a worktree. The slug-keyed filename preserves the session-local property.
+- **Growth is bounded by distinct failure sets, not by nights.** The per-node dispatch
+  never passes `slug_suffix`, so its slug is always the sha256 of the sorted node set
+  and a recurring failure set overwrites its own file. No pruning job.
 
 ## Run Lock (Race 1)
 
@@ -154,6 +245,7 @@ by a script with nothing to come back for. `tools/disk_reclaim.py` remains the
 | `scripts/nightly_regression_tests.py` | Adds `_acquire_run_lock` and `maybe_dispatch_triage_session` around the existing detector; see `docs/features/nightly-regression-tests.md` for the base run mechanics |
 | `data/nightly_tests.lock` | Advisory lock file for `_acquire_run_lock` (gitignored, empty — existence and the flock state are all that matter) |
 | `data/nightly_tests_last_run.json` | Now also carries `dispatched_nodes` and `dispatched_session_id` alongside the existing delta-state fields |
+| `data/nightly-triage-ledger/{slug}.json` | Per-node dispatch replay ledger (gitignored, machine-local, advisory) — see "Replay Idempotency" |
 
 ## Design Decisions
 

--- a/docs/features/nightly-triage-dispatch.md
+++ b/docs/features/nightly-triage-dispatch.md
@@ -123,6 +123,13 @@ context reads its predecessor's work instead of starting from zero.
   ledger that cannot be written must not stop the night from filing, the same posture
   `open_issues()` takes when it cannot read. The prompt also tells the agent to treat a
   missing or unparseable ledger as an empty `filed` list.
+- **Degraded read, same no-file outcome, different cause.** A degraded read (either the
+  open-issues or closed-issues REST read fails) also produces no ledger file:
+  `dispatch_findings` passes `dispositions=None` in that case, `maybe_dispatch_triage_session`
+  calls `write_triage_ledger` with an empty entries list, and `write_triage_ledger` returns
+  `None`, the same no-file outcome as the write failure above but from withheld dispositions
+  rather than a failed write, with the live REST-read instruction in every prompt remaining
+  undemoted as the defense that actually covers a degraded read.
 - **Written after the `--dry-run` short-circuit.** A preview writes no state file.
 - **Deliberately unlocked.** Two sessions share a ledger only when dispatched for an
   identical node set, which the run lock and `compute_dispatch_set` make

--- a/docs/plans/nightly-triage-filing-idempotency.md
+++ b/docs/plans/nightly-triage-filing-idempotency.md
@@ -1,5 +1,5 @@
 ---
-status: Ready
+status: docs_complete
 type: bug
 appetite: Small
 owner: Valor Engels

--- a/docs/plans/nightly-triage-filing-idempotency.md
+++ b/docs/plans/nightly-triage-filing-idempotency.md
@@ -485,26 +485,26 @@ Not applicable — this repo has no Sphinx/MkDocs/Read the Docs site.
 ## Success Criteria
 
 
-- [ ] `ISSUE_LOOKUP_INSTRUCTION` exists at module scope and is interpolated by **all three** prompt builders: `_build_triage_prompt`, `_build_cascade_prompt`, `_build_seed_prompt`.
-- [ ] Each of the three **rendered** prompts contains the literal `gh issue list --state all --json number,title,state,stateReason --limit 200`.
-- [ ] Each of the three **rendered** prompts contains the prohibition on GitHub's search index, carrying its reason (#2960–#2999).
-- [ ] A case-insensitive scan of the three **rendered** prompts for `--search`, `gh search`, `search all`, `search open` returns **zero** matches. The prohibition is worded as "the search index" / "the search API" precisely so this row and the row above are simultaneously satisfiable — the earlier draft demanded a token the same gate forbade, which was unreachable.
-- [ ] The three pre-existing `--search` mentions in the module's constant comments and `open_issues`' docstring are **unchanged** — they are the REST-not-search rationale this work extends, and they sit outside the scanned prompt region.
-- [ ] Each of the three rendered prompts warns that `stateReason` is `""` for open issues, so the agent branches on `state` first (Research finding).
-- [ ] Every prompt's open / closed-`NOT_PLANNED` / closed-`COMPLETED` decision rule is unchanged in meaning from what #3075 landed — the read mechanism changed, the rule did not. This includes the seed prompt's stricter rule (comment and do NOT re-file whatever the close reason), which extraction into `_build_seed_prompt` must preserve verbatim.
-- [ ] `dispatch_findings` passes `dispositions=` for exactly the surviving `single_nodes` into `maybe_dispatch_triage_session`, and that list contains no already-open and no closed-not-planned node.
-- [ ] The cascade call site (~2598) and the seed call site (~2934) pass **no** `dispositions` and are otherwise unchanged in shape; neither produces a file under `data/nightly-triage-ledger/`, and neither rendered prompt contains a ledger paragraph. `_build_cascade_prompt` and `_build_seed_prompt` gain no `dispositions` or `ledger_path` parameter.
-- [ ] `_build_seed_prompt(seed_title, seeded_nodes, *, prior_collection=None)` renders text **byte-identical to the inline original in `main()`** apart from the one replaced lookup sentence — including the `(old={prior_collection!r}, new={COLLECTION_PATHS!r})` clause, which a two-parameter signature could not reproduce. `main()` calls it as `_build_seed_prompt(seed_title, confirmed_failing, prior_collection=prev.get("collection"))`.
-- [ ] `grep -c -- '--search' scripts/nightly_regression_tests.py` still reports exactly `3` after the change (Verification row 9). No comment, constant, prompt body, or prompt-builder docstring added by this work spells a forbidden token.
-- [ ] `write_triage_ledger` writes `data/nightly-triage-ledger/{slug}.json` with the seeded entries and an empty `filed` array, **before** the session subprocess starts and **after** the `dry_run` short-circuit, and returns the absolute path (or `None`).
-- [ ] A `--dry-run` invocation creates no file under `data/nightly-triage-ledger/`, and its rendered prompt carries no ledger paragraph.
-- [ ] When `ledger_path` is non-`None`, the prompt names the ledger's absolute path and instructs the agent to read it first each turn and append to `filed` immediately after each `gh issue create`, before moving to the next entry. When it is `None`, no ledger paragraph appears at all.
-- [ ] A ledger write failure logs a `WARNING` naming the slug, returns `None`, and does not prevent dispatch.
-- [ ] `_build_triage_prompt` returns the plain prompt for `dispositions=None` **and** `dispositions=[]`, and raises `ValueError` only for a non-empty list whose length differs from the node list.
-- [ ] Tests pass (`/do-test`) — `./scripts/pytest-clean.sh tests/unit/test_nightly_regression_tests.py -q` exits 0.
-- [ ] Documentation updated (`/do-docs`) — `docs/features/nightly-triage-dispatch.md` describes all three prompts, states each defense's reach (fix 1 on all three, fixes 2 and 3 on the per-node path) with the reason for the narrowing, and gives the ledger's shape and location rationale.
-- [ ] `python -m ruff check` and `python -m ruff format --check` clean on the changed files.
-- [ ] The branch is rooted on `main`, not on the stale local `session/nightly-triage-idempotency-3075` (`git merge-base --is-ancestor origin/main HEAD`).
+- [x] `ISSUE_LOOKUP_INSTRUCTION` exists at module scope and is interpolated by **all three** prompt builders: `_build_triage_prompt`, `_build_cascade_prompt`, `_build_seed_prompt`.
+- [x] Each of the three **rendered** prompts contains the literal `gh issue list --state all --json number,title,state,stateReason --limit 200`.
+- [x] Each of the three **rendered** prompts contains the prohibition on GitHub's search index, carrying its reason (#2960–#2999).
+- [x] A case-insensitive scan of the three **rendered** prompts for `--search`, `gh search`, `search all`, `search open` returns **zero** matches. The prohibition is worded as "the search index" / "the search API" precisely so this row and the row above are simultaneously satisfiable — the earlier draft demanded a token the same gate forbade, which was unreachable.
+- [x] The three pre-existing `--search` mentions in the module's constant comments and `open_issues`' docstring are **unchanged** — they are the REST-not-search rationale this work extends, and they sit outside the scanned prompt region.
+- [x] Each of the three rendered prompts warns that `stateReason` is `""` for open issues, so the agent branches on `state` first (Research finding).
+- [x] Every prompt's open / closed-`NOT_PLANNED` / closed-`COMPLETED` decision rule is unchanged in meaning from what #3075 landed — the read mechanism changed, the rule did not. This includes the seed prompt's stricter rule (comment and do NOT re-file whatever the close reason), which extraction into `_build_seed_prompt` must preserve verbatim.
+- [x] `dispatch_findings` passes `dispositions=` for exactly the surviving `single_nodes` into `maybe_dispatch_triage_session`, and that list contains no already-open and no closed-not-planned node.
+- [x] The cascade call site (~2598) and the seed call site (~2934) pass **no** `dispositions` and are otherwise unchanged in shape; neither produces a file under `data/nightly-triage-ledger/`, and neither rendered prompt contains a ledger paragraph. `_build_cascade_prompt` and `_build_seed_prompt` gain no `dispositions` or `ledger_path` parameter.
+- [x] `_build_seed_prompt(seed_title, seeded_nodes, *, prior_collection=None)` renders text **byte-identical to the inline original in `main()`** apart from the one replaced lookup sentence — including the `(old={prior_collection!r}, new={COLLECTION_PATHS!r})` clause, which a two-parameter signature could not reproduce. `main()` calls it as `_build_seed_prompt(seed_title, confirmed_failing, prior_collection=prev.get("collection"))`.
+- [x] `grep -c -- '--search' scripts/nightly_regression_tests.py` still reports exactly `3` after the change (Verification row 9). No comment, constant, prompt body, or prompt-builder docstring added by this work spells a forbidden token.
+- [x] `write_triage_ledger` writes `data/nightly-triage-ledger/{slug}.json` with the seeded entries and an empty `filed` array, **before** the session subprocess starts and **after** the `dry_run` short-circuit, and returns the absolute path (or `None`).
+- [x] A `--dry-run` invocation creates no file under `data/nightly-triage-ledger/`, and its rendered prompt carries no ledger paragraph.
+- [x] When `ledger_path` is non-`None`, the prompt names the ledger's absolute path and instructs the agent to read it first each turn and append to `filed` immediately after each `gh issue create`, before moving to the next entry. When it is `None`, no ledger paragraph appears at all.
+- [x] A ledger write failure logs a `WARNING` naming the slug, returns `None`, and does not prevent dispatch.
+- [x] `_build_triage_prompt` returns the plain prompt for `dispositions=None` **and** `dispositions=[]`, and raises `ValueError` only for a non-empty list whose length differs from the node list.
+- [x] Tests pass (`/do-test`) — `./scripts/pytest-clean.sh tests/unit/test_nightly_regression_tests.py -q` exits 0.
+- [x] Documentation updated (`/do-docs`) — `docs/features/nightly-triage-dispatch.md` describes all three prompts, states each defense's reach (fix 1 on all three, fixes 2 and 3 on the per-node path) with the reason for the narrowing, and gives the ledger's shape and location rationale.
+- [x] `python -m ruff check` and `python -m ruff format --check` clean on the changed files.
+- [x] The branch is rooted on `main`, not on the stale local `session/nightly-triage-idempotency-3075` (`git merge-base --is-ancestor origin/main HEAD`).
 
 ## Team Orchestration
 

--- a/scripts/nightly_regression_tests.py
+++ b/scripts/nightly_regression_tests.py
@@ -326,6 +326,25 @@ MAX_SETUP_ERRORS_DEFAULT = 50
 OPEN_ISSUE_LIST_LIMIT = 1000
 OPEN_ISSUE_LIST_TIMEOUT_SECONDS = 60
 
+# The one lookup instruction all three issue-filing prompts interpolate: the
+# per-node dispatch, the cascade umbrella, and the re-baseline seed. It hands
+# the agent a REST list command instead of naming GitHub's index-backed lookup,
+# which lags issue creation by minutes -- reading it inside its own lag window
+# is how one dispatch filed the same node three times and the #2960-#2999 wave
+# followed. `8524e765b` established that principle for this module's own reads;
+# the prompts went three more passes still pointing at the index, because each
+# builder carried its own copy of the sentence. One constant, three readers, so
+# they cannot drift apart again.
+#
+# The wording constraint is load-bearing and two gates enforce it from opposite
+# directions. This comment, the constant, every prompt body, and every
+# prompt-builder docstring must express the prohibition as "the search index"
+# and "the search API" and must never spell the flag or the phrasings out
+# literally: one gate scans the rendered prompts and requires zero hits, and
+# another counts the flag across this whole module and requires exactly the
+# three legitimate mentions in the constant comments above and in
+# `open_issues`' docstring. Spelling a token out here to forbid it adds a
+# fourth and fails a passing build.
 ISSUE_LOOKUP_INSTRUCTION = (
     "To find out whether an issue already exists, run exactly this ONCE for the "
     "whole list below and filter the JSON locally on each exact title:\n"

--- a/scripts/nightly_regression_tests.py
+++ b/scripts/nightly_regression_tests.py
@@ -2938,6 +2938,11 @@ def dispatch_findings(
     # plain per-node form, so the agent's own live lookup (already always in
     # the prompt) stays the sole, undemoted defense (#3170). An empty
     # single_nodes carries no such risk either way, so it always gets `[]`.
+    # dispositions=None also withdraws the session ledger, not just the
+    # prompt paragraph: maybe_dispatch_triage_session passes list(None or [])
+    # to write_triage_ledger, which returns None (writes no file) on an empty
+    # entries list -- acceptable only because the live REST-read instruction
+    # above stays undemoted on this path.
     if not single_nodes:
         dispositions = []
     elif read_shape == ["open", "closed"]:

--- a/scripts/nightly_regression_tests.py
+++ b/scripts/nightly_regression_tests.py
@@ -147,7 +147,7 @@ import signal
 import subprocess
 import sys
 import time
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -325,6 +325,19 @@ MAX_SETUP_ERRORS_DEFAULT = 50
 # triage sessions file the same title twice.
 OPEN_ISSUE_LIST_LIMIT = 1000
 OPEN_ISSUE_LIST_TIMEOUT_SECONDS = 60
+
+ISSUE_LOOKUP_INSTRUCTION = (
+    "To find out whether an issue already exists, run exactly this ONCE for the "
+    "whole list below and filter the JSON locally on each exact title:\n"
+    "  gh issue list --state all --json number,title,state,stateReason --limit 200\n"
+    "Do NOT use GitHub's search index or the search API to answer this — that "
+    "index lags issue creation by minutes, and reading it inside the lag window "
+    "is how the #2960-#2999 duplicate wave happened (see 8524e765b). The list "
+    "endpoint above sees an issue the instant it exists.\n"
+    "Note: stateReason is the empty string on OPEN rows, not null and not "
+    "absent. Branch on state first and read stateReason only when state is "
+    "CLOSED.\n"
+)
 
 # How many closed issues the closed-state dedup read pulls (#3075 defect 1:
 # a node whose exact-title issue was closed as a duplicate was re-reported as
@@ -1455,20 +1468,41 @@ def carry_dispatched_nodes(
     return sorted(still_failing | set(just_dispatched))
 
 
-def _build_triage_prompt(dispatch_nodes: list[str]) -> str:
+def _build_triage_prompt(
+    dispatch_nodes: list[str],
+    *,
+    dispositions: list[NodeDisposition] | None = None,
+    ledger_path: str | None = None,
+) -> str:
     """Build the default per-node triage prompt with literal, computed titles.
 
     Titles are computed in Python — ``f"Nightly regression: {n}"`` — rather
     than left for the agent to derive, so the same failing node produces a
     byte-identical title on every machine and the prompt itself pins the
-    dedup contract (#2559): the agent must search for the exact title before
-    opening a new issue.
+    dedup contract (#2559).
+
+    The lookup paragraph is :data:`ISSUE_LOOKUP_INSTRUCTION`, shared verbatim
+    with :func:`_build_cascade_prompt` and :func:`_build_seed_prompt` so the
+    three can no longer drift. It hands over a REST list command instead of
+    naming GitHub's index-backed lookup, which lags issue creation by minutes:
+    reading that index inside its own lag window is how the #2960-#2999
+    duplicate wave happened, and ``8524e765b`` established the same principle
+    for this module's own reads a pass before the prompts caught up.
+
+    ``dispositions`` renders what :func:`dispatch_findings` already resolved,
+    one entry per node in the same order. ``None`` and ``[]`` both degrade to
+    the plain prompt, checked before the zip; only a non-empty list of the
+    wrong length raises. ``ledger_path`` appends the session-ledger paragraph,
+    and only a non-``None`` path does — which is what keeps the ledger scoped
+    to this prompt and independently revertible.
     """
     titles = [f"Nightly regression: {n}" for n in dispatch_nodes]
     lines = [
         "Nightly regression detector found confirmed test failures that have not "
-        "been triaged before. For EACH node below, search ALL issues — open AND "
-        "closed — for the EXACT title given. If an OPEN issue exists, comment on "
+        "been triaged before.\n"
+        + ISSUE_LOOKUP_INSTRUCTION
+        + "For EACH node below, match the EXACT title given against that JSON. "
+        "If an OPEN issue exists, comment on "
         "it with any new information. If a CLOSED issue exists, the close reason "
         "decides: closed as not-planned (duplicate/consolidated) — comment there "
         "pointing at the recurrence and do NOT open a new issue, the consolidation "
@@ -1479,8 +1513,36 @@ def _build_triage_prompt(dispatch_nodes: list[str]) -> str:
         "cause, and suggested next steps. Do NOT attempt an auto-hotfix — this is "
         "an investigation-and-file-an-issue task only.\n",
     ]
-    for node, title in zip(dispatch_nodes, titles, strict=True):
-        lines.append(f'- Title: "{title}"\n  Node: {node}')
+    if not dispositions:
+        for node, title in zip(dispatch_nodes, titles, strict=True):
+            lines.append(f'- Title: "{title}"\n  Node: {node}')
+    else:
+        for (node, title), disposition in zip(
+            zip(dispatch_nodes, titles, strict=True), dispositions, strict=True
+        ):
+            lines.append(
+                f'- Title: "{title}"\n  Node: {node}\n'
+                f"  Already resolved by the detector: it read all open and closed "
+                f"issues at {disposition.resolved_at} via "
+                f"{disposition.resolved_against} and found no issue carrying that "
+                f'exact title, so its finding is "{disposition.disposition}". Your '
+                f"own lookup above is a second check covering issues created since "
+                f"that read, not a re-derivation of it."
+            )
+    if ledger_path is not None:
+        lines.append(
+            f"\nSession ledger: {ledger_path}\n"
+            "Read that file FIRST on every turn, before opening anything. Its "
+            '"entries" array is exactly the list above and its "filed" array is '
+            "what this session has already opened. Skip any entry whose node "
+            'already appears in "filed". Immediately after each `gh issue create` '
+            'returns, append {"number": N, "title": ..., "node": ...} to '
+            '"filed" and save the file BEFORE moving on to the next entry — that '
+            "ordering is the whole point, since a turn replayed mid-list reads "
+            "this file to learn what its predecessor already did. If the file is "
+            'missing or cannot be parsed as JSON, treat it as if "filed" were '
+            "empty and rely on the lookup above."
+        )
     return "\n".join(lines)
 
 
@@ -1888,7 +1950,15 @@ def group_setup_error_cascades(
 
 
 def _build_cascade_prompt(cascade: dict) -> str:
-    """Build the umbrella prompt for one cascade — ONE issue, node list collapsed."""
+    """Build the umbrella prompt for one cascade — ONE issue, node list collapsed.
+
+    Its lookup paragraph is :data:`ISSUE_LOOKUP_INSTRUCTION`, shared verbatim
+    with :func:`_build_triage_prompt` and :func:`_build_seed_prompt`: a REST
+    list command rather than GitHub's index-backed lookup, which lags issue
+    creation by minutes and produced the #2960-#2999 duplicate wave when it was
+    read inside that window (``8524e765b``). This builder takes no dispositions
+    and no ledger — see the deferral recorded in the plan for #3170.
+    """
     nodes = cascade["nodes"]
     workers = ", ".join(cascade["workers"]) or "serial run"
     if cascade.get("kind") == "body":
@@ -1909,8 +1979,9 @@ def _build_cascade_prompt(cascade: dict) -> str:
     return (
         "Nightly regression detector found a CASCADE: "
         f"{shape}. This is ONE defect, not "
-        f"{len(nodes)}. Search ALL issues — open AND closed — for the EXACT title "
-        "below. If an OPEN one exists, comment on it with the new occurrence. If a "
+        f"{len(nodes)}.\n" + ISSUE_LOOKUP_INSTRUCTION + "Match the EXACT title "
+        "below against that JSON. If an OPEN one exists, comment on it with the "
+        "new occurrence. If a "
         "CLOSED one exists: closed as not-planned means comment there and do NOT "
         "re-file (its consolidation target is the live tracker); closed as "
         "completed means the recurrence is new information — open exactly ONE new "
@@ -1923,6 +1994,52 @@ def _build_cascade_prompt(cascade: dict) -> str:
         f'Title: "{cascade["title"]}"\n\n'
         f"{error_label}: {cascade['message']}\n\n"
         "Affected node IDs:\n" + "\n".join(f"- {n}" for n in nodes)
+    )
+
+
+def _build_seed_prompt(
+    seed_title: str, seeded_nodes: list[str], *, prior_collection: object = None
+) -> str:
+    """Build the re-baseline seed umbrella prompt (issue #2823).
+
+    Extracted out of :func:`main` so all three issue-filing prompts are named,
+    testable functions: an inline string inside a 200-line function cannot be
+    rendered by a test or scanned by a gate, which is how this prompt's copy of
+    the lookup defect went four passes unnoticed.
+
+    Its lookup paragraph is :data:`ISSUE_LOOKUP_INSTRUCTION`, shared verbatim
+    with :func:`_build_triage_prompt` and :func:`_build_cascade_prompt`: a REST
+    list command rather than GitHub's index-backed lookup, which lags issue
+    creation by minutes and produced the #2960-#2999 duplicate wave when it was
+    read inside that window (``8524e765b``).
+
+    Its dedup rule is deliberately stricter than the per-node one and is
+    reproduced verbatim from the inline original: a closed umbrella is
+    commented on and never re-filed, whatever the close reason, because the
+    seed is a declaration and a re-baseline retry at the same commit must not
+    mint a twin. ``prior_collection`` exists because the text opens with the
+    collection the run moved away from, which is a :func:`main` local derivable
+    from neither other parameter; it is keyword-only and defaulted so a
+    two-positional call stays valid. This builder takes no dispositions and no
+    ledger — see the deferral recorded in the plan for #3170.
+    """
+    seed_size = len(seeded_nodes)
+    return (
+        "Nightly regression detector re-baselined its test collection "
+        f"(old={prior_collection!r}, new={COLLECTION_PATHS!r}). "
+        f"The following {seed_size} node(s) were already failing at the "
+        "moment of the re-baseline and have been absorbed into the seed — "
+        "they are NOT individually filed.\n" + ISSUE_LOOKUP_INSTRUCTION + "The EXACT "
+        f'title to match is "{seed_title}". If an open one exists, comment on '
+        "it. If a closed one exists, comment there and do NOT re-file — the "
+        "seed umbrella is a declaration, and a re-baseline retry at the same "
+        "commit must not mint a twin, whatever the close reason. Only if "
+        "neither exists, open ONE umbrella issue with EXACTLY that title, "
+        "summarizing the "
+        "population, its size, and pointing at the persisted state file "
+        "for the full node list. Do NOT file per-node issues for these. Do "
+        "NOT attempt an auto-hotfix.\n\n"
+        "Seeded node IDs:\n" + "\n".join(f"- {n}" for n in seeded_nodes)
     )
 
 
@@ -2292,11 +2409,99 @@ def partition_already_open(
 DRY_RUN_SESSION_ID = "dry-run-session"
 
 
+@dataclass(frozen=True)
+class NodeDisposition:
+    """One node's pre-resolved filing decision, carried across the dispatch boundary.
+
+    Everything here was already established in :func:`dispatch_findings` against a
+    live REST read of the open and closed issue sets. Handing it to the triage
+    agent is what stops the agent re-deriving a decision Python had already made
+    seconds earlier -- the choke point that survived four passes at the duplicate
+    filing bug (#2559, ``8524e765b``, #3134, #3075) because every one of them
+    widened what the script knew without widening what it said.
+    """
+
+    node: str
+    title: str
+    disposition: str
+    resolved_against: str
+    resolved_at: str
+
+
+def write_triage_ledger(slug: str, entries: list[NodeDisposition]) -> str | None:
+    """Seed ``data/nightly-triage-ledger/{slug}.json`` and return its absolute path.
+
+    The third and cheapest-to-lose of this module's three replay defences. The
+    file records the entries one triage session is permitted to file and an
+    empty ``filed`` array the agent appends to as it goes, so a turn replayed
+    with a fresh context reads what its predecessor already opened instead of
+    starting from zero. The first two defences (a live REST lookup instruction,
+    and the pre-resolved dispositions above) do the real work; this one only has
+    to hold when both are somehow bypassed.
+
+    **Fail-open, deliberately.** Any failure logs a ``WARNING`` naming the slug
+    and returns ``None``; nothing raises into the dispatch path. A ledger that
+    cannot be written must not stop the night from filing, for the same reason
+    :func:`open_issues` returns ``None`` rather than aborting: a silent night
+    during a real regression is the larger harm.
+
+    **The return type is load-bearing.** A path on success, ``None`` on failure
+    and on an empty ``entries`` list. That value is threaded straight into the
+    prompt builder, which emits its ledger paragraph only for a non-``None``
+    path -- so a caller that passes no dispositions gets no file, no paragraph
+    and no dangling instruction to read something that was never created. It is
+    also what makes this defence independently revertible.
+
+    **No file locking, on purpose.** Two sessions share a ledger only when they
+    were dispatched for an identical node set, which the run lock and
+    :func:`compute_dispatch_set` make near-impossible within a machine, and the
+    file is machine-local so two hosts never share one. A lost update degrades
+    the ledger to partial, which falls back to the two stronger defences. The
+    one case worth defending is a same-slug retry landing on a ledger a live
+    session is already appending to, so an existing file whose ``filed`` array
+    is non-empty is left exactly as it is. The write itself goes through a
+    sibling temp file and :func:`os.replace`, so a reader mid-write sees the old
+    content or the new one and never a truncated one -- unparseable JSON is
+    worse for the agent than stale-but-valid JSON.
+    """
+    if not entries:
+        return None
+
+    path = DATA_DIR / "nightly-triage-ledger" / f"{slug}.json"
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if path.exists():
+            try:
+                existing = json.loads(path.read_text())
+            except (json.JSONDecodeError, OSError):
+                existing = None
+            if isinstance(existing, dict) and existing.get("filed"):
+                log(
+                    f"Triage ledger for slug={slug} already records filed issue(s) — "
+                    "leaving it as it is so a same-slug retry cannot erase them"
+                )
+                return str(path.resolve())
+        payload = {
+            "slug": slug,
+            "created_at": datetime.now(UTC).isoformat(),
+            "entries": [asdict(e) if isinstance(e, NodeDisposition) else dict(e) for e in entries],
+            "filed": [],
+        }
+        tmp_path = path.with_name(f"{path.name}.tmp")
+        tmp_path.write_text(json.dumps(payload, indent=2) + "\n")
+        os.replace(tmp_path, path)
+        return str(path.resolve())
+    except Exception as exc:  # noqa: BLE001  # covers OSError, TypeError, anything
+        log(f"WARNING: could not write triage ledger for slug={slug} ({exc})")
+        return None
+
+
 def maybe_dispatch_triage_session(
     dispatch_nodes: list[str],
     *,
     prompt: str | None = None,
     slug_suffix: str | None = None,
+    dispositions: list[NodeDisposition] | None = None,
     dry_run: bool = False,
 ) -> str | None:
     """Dispatch one triage Eng session for node IDs that have never been filed.
@@ -2312,6 +2517,24 @@ def maybe_dispatch_triage_session(
     triage session for a re-baseline seed instead of one issue per node.
     ``slug_suffix`` overrides the sha256-derived slug, so a retried seed
     dispatch reuses one slug instead of hashing a synthetic node ID.
+
+    ``dispositions`` carries the filing decisions :func:`dispatch_findings`
+    already resolved against a live REST read, one per node, in the same order
+    as ``dispatch_nodes``. It is the whole of what the per-node dispatch hands
+    across this boundary: it seeds the session ledger and it is rendered into
+    the default prompt so the agent confirms a decision rather than re-deriving
+    one. Three callers reach this function -- the per-node dispatch, which
+    passes it; and the cascade-umbrella and re-baseline-seed dispatches, which
+    pre-render their own ``prompt`` and pass none. Because the ledger's entries
+    come from this argument and from nothing else, those two produce no ledger
+    file and no ledger paragraph, with no separate branch to maintain.
+
+    **Ordering matters here.** The ledger write sits *below* the ``dry_run``
+    short-circuit and above the subprocess, so a preview writes no state file
+    and a real dispatch has its ledger on disk the instant the session can
+    start. Putting it above the short-circuit would put state writes back into
+    the one command an operator reaches for to preview a night safely -- the
+    exact defect the sentinel documented below was introduced to fix.
 
     ``dry_run`` short-circuits before the subprocess and returns
     :data:`DRY_RUN_SESSION_ID`. Without it ``--dry-run`` suppressed only the
@@ -2335,14 +2558,21 @@ def maybe_dispatch_triage_session(
         slug_hash = hashlib.sha256(",".join(sorted(set(dispatch_nodes))).encode()).hexdigest()[:8]
         slug = f"nightly-triage-{slug_hash}"
 
-    message = prompt if prompt is not None else _build_triage_prompt(dispatch_nodes)
-
     if dry_run:
         log(
             f"[DRY RUN] Would dispatch triage session slug={slug} for "
             f"{len(dispatch_nodes)} node(s); no session created, no issue filed"
         )
         return DRY_RUN_SESSION_ID
+
+    ledger_path = write_triage_ledger(slug, list(dispositions or []))
+    message = (
+        prompt
+        if prompt is not None
+        else _build_triage_prompt(
+            dispatch_nodes, dispositions=dispositions, ledger_path=ledger_path
+        )
+    )
 
     try:
         result = subprocess.run(
@@ -2528,6 +2758,11 @@ def dispatch_findings(
     closed_issue_map = closed_issue_dispositions() if dispatch_nodes else None
     if dispatch_nodes and closed_issue_map is None:
         log("Closed-state dedup disabled for this run (closed issues unreadable) — failing open")
+    # Stamped here, right after the two reads, because this is the instant the
+    # dispositions below are true as of. The triage agent is told this timestamp
+    # so it can treat its own lookup as a check for issues created since, not as
+    # the authority.
+    issue_read_at = datetime.now(UTC).isoformat()
 
     outcome = DispatchOutcome(
         recorded=[],
@@ -2665,7 +2900,34 @@ def dispatch_findings(
         )
         single_nodes = single_nodes[:issue_budget]
 
-    session_id = maybe_dispatch_triage_session(single_nodes, dry_run=dry_run)
+    # Everything still in single_nodes survived partition_already_open and
+    # partition_closed_matches, so the script has already established that it has
+    # no issue in any state — the answer is uniformly "file". Passing that across
+    # the boundary is fix 2 of #3170: four earlier passes each made this function
+    # smarter and then threw the answer away at this one call.
+    read_shape = [
+        name
+        for name, mapping in (("open", open_issue_map), ("closed", closed_issue_map))
+        if mapping is not None
+    ]
+    resolved_against = (
+        f"gh issue list --state all ({'+'.join(read_shape)} REST read)"
+        if read_shape
+        else "no open/closed issue read succeeded this run"
+    )
+    dispositions = [
+        NodeDisposition(
+            node=node,
+            title=f"Nightly regression: {node}",
+            disposition="file",
+            resolved_against=resolved_against,
+            resolved_at=issue_read_at,
+        )
+        for node in single_nodes
+    ]
+    session_id = maybe_dispatch_triage_session(
+        single_nodes, dispositions=dispositions, dry_run=dry_run
+    )
     if session_id is not None:
         outcome.issues_filed += len(single_nodes)
         outcome.recorded.extend(single_nodes)
@@ -2914,22 +3176,8 @@ def main() -> int:
                 f"Nightly regression baseline: {seed_size} nodes absorbed "
                 f"on {current['head_commit']}"
             )
-            seed_prompt = (
-                "Nightly regression detector re-baselined its test collection "
-                f"(old={prev.get('collection')!r}, new={COLLECTION_PATHS!r}). "
-                f"The following {seed_size} node(s) were already failing at the "
-                "moment of the re-baseline and have been absorbed into the seed — "
-                "they are NOT individually filed. Search open AND closed issues for "
-                f'the EXACT title "{seed_title}". If an open one exists, comment on '
-                "it. If a closed one exists, comment there and do NOT re-file — the "
-                "seed umbrella is a declaration, and a re-baseline retry at the same "
-                "commit must not mint a twin, whatever the close reason. Only if "
-                f"neither exists, open ONE umbrella issue with EXACTLY that title, "
-                "summarizing the "
-                "population, its size, and pointing at the persisted state file "
-                "for the full node list. Do NOT file per-node issues for these. Do "
-                "NOT attempt an auto-hotfix.\n\n"
-                "Seeded node IDs:\n" + "\n".join(f"- {n}" for n in confirmed_failing)
+            seed_prompt = _build_seed_prompt(
+                seed_title, confirmed_failing, prior_collection=prev.get("collection")
             )
             triage_session_id = maybe_dispatch_triage_session(
                 [f"seed:{len(confirmed_failing)}"],

--- a/scripts/nightly_regression_tests.py
+++ b/scripts/nightly_regression_tests.py
@@ -2503,7 +2503,7 @@ def write_triage_ledger(slug: str, entries: list[NodeDisposition]) -> str | None
         payload = {
             "slug": slug,
             "created_at": datetime.now(UTC).isoformat(),
-            "entries": [asdict(e) if isinstance(e, NodeDisposition) else dict(e) for e in entries],
+            "entries": [asdict(e) for e in entries],
             "filed": [],
         }
         tmp_path = path.with_name(f"{path.name}.tmp")
@@ -2929,21 +2929,31 @@ def dispatch_findings(
         for name, mapping in (("open", open_issue_map), ("closed", closed_issue_map))
         if mapping is not None
     ]
-    resolved_against = (
-        f"gh issue list --state all ({'+'.join(read_shape)} REST read)"
-        if read_shape
-        else "no open/closed issue read succeeded this run"
-    )
-    dispositions = [
-        NodeDisposition(
-            node=node,
-            title=f"Nightly regression: {node}",
-            disposition="file",
-            resolved_against=resolved_against,
-            resolved_at=issue_read_at,
-        )
-        for node in single_nodes
-    ]
+    # A degraded read (either map is None) means partition_already_open /
+    # partition_closed_matches fail-open above already let unfiltered nodes
+    # through single_nodes without knowing whether they truly have no issue.
+    # Only a complete read licenses the disposition's claim that "the detector
+    # already resolved this" -- on a degraded night with survivors still to
+    # dispatch, dispositions=None makes _build_triage_prompt fall back to its
+    # plain per-node form, so the agent's own live lookup (already always in
+    # the prompt) stays the sole, undemoted defense (#3170). An empty
+    # single_nodes carries no such risk either way, so it always gets `[]`.
+    if not single_nodes:
+        dispositions = []
+    elif read_shape == ["open", "closed"]:
+        resolved_against = f"gh issue list --state all ({'+'.join(read_shape)} REST read)"
+        dispositions = [
+            NodeDisposition(
+                node=node,
+                title=f"Nightly regression: {node}",
+                disposition="file",
+                resolved_against=resolved_against,
+                resolved_at=issue_read_at,
+            )
+            for node in single_nodes
+        ]
+    else:
+        dispositions = None
     session_id = maybe_dispatch_triage_session(
         single_nodes, dispositions=dispositions, dry_run=dry_run
     )

--- a/tests/unit/test_nightly_regression_tests.py
+++ b/tests/unit/test_nightly_regression_tests.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import fcntl
 import hashlib
 import json
+import re
 import signal
 import subprocess
 import sys
@@ -17,6 +18,30 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 import nightly_regression_tests as nrt
+
+# The four spellings of the index-backed lookup no prompt may name. Compiled
+# here rather than written inline at each call site: the same alternation lives
+# in the #3170 plan's Verification table, where a markdown cell escaped its
+# pipes and made the row pass on entirely unfixed code.
+SEARCH_TOKENS = re.compile(r"--search|gh search|search all|search open", re.I)
+
+
+def _assert_per_node_dispatch(mock_dispatch, nodes: list[str]) -> None:
+    """Assert the per-node dispatch went out for ``nodes`` with matching dispositions.
+
+    Replaces a bare ``assert_called_once_with(nodes, dry_run=False)``: the
+    per-node call now also carries the ``dispositions=`` the detector resolved
+    (#3170 fix 2), and an exact-kwargs assertion would have to be rewritten
+    again the next time the channel widens. This checks the two things the old
+    assertion checked plus the one the new argument is for -- that the
+    dispositions cover exactly the dispatched nodes, in order.
+    """
+    mock_dispatch.assert_called_once()
+    args, kwargs = mock_dispatch.call_args
+    assert args == (nodes,)
+    assert kwargs["dry_run"] is False
+    assert [d.node for d in kwargs["dispositions"]] == nodes
+    assert all(d.disposition == "file" for d in kwargs["dispositions"])
 
 
 class TestLoadLastRun:
@@ -790,14 +815,72 @@ class TestCarryDispatchedNodes:
         assert nrt.carry_dispatched_nodes(prev, ["a::t1"], []) == []
 
 
+def _disposition(node: str, *, at: str = "2026-09-05T06:00:00+00:00") -> nrt.NodeDisposition:
+    return nrt.NodeDisposition(
+        node=node,
+        title=f"Nightly regression: {node}",
+        disposition="file",
+        resolved_against="gh issue list --state all (open+closed REST read)",
+        resolved_at=at,
+    )
+
+
 class TestBuildTriagePrompt:
     """Titles are computed in Python -- literal, not agent-derived (#2559)."""
 
     def test_literal_titles_present(self) -> None:
+        """The titles, AND the lookup mechanism the agent is told to use.
+
+        The title half alone stayed true across the #3170 change and was
+        therefore blind to it: the prompt could keep every literal title while
+        still directing the agent at the index-backed lookup that produced the
+        #2960-#2999 wave. The two halves belong in one test.
+        """
         nodes = ["tests/unit/test_a.py::test_1", "tests/unit/test_b.py::test_2"]
         prompt = nrt._build_triage_prompt(nodes)
         for n in nodes:
             assert f"Nightly regression: {n}" in prompt
+        assert "gh issue list --state all" in prompt
+        assert not SEARCH_TOKENS.search(prompt)
+
+    def test_dispositions_render_the_detectors_own_finding_per_node(self) -> None:
+        nodes = ["tests/unit/test_a.py::test_1", "tests/unit/test_b.py::test_2"]
+        dispositions = [_disposition(n) for n in nodes]
+        prompt = nrt._build_triage_prompt(nodes, dispositions=dispositions)
+        for n in nodes:
+            assert f"Nightly regression: {n}" in prompt
+        assert prompt.count("2026-09-05T06:00:00+00:00") == 2
+        assert prompt.count("gh issue list --state all (open+closed REST read)") == 2
+
+    def test_empty_disposition_list_degrades_to_the_plain_prompt(self) -> None:
+        """``[]`` and ``None`` both take the same branch, checked before the zip.
+
+        The pair with the mismatch test below pins an ordering that reads as a
+        contradiction unless it is stated: ``if not dispositions`` runs first,
+        so an empty list never reaches ``zip(..., strict=True)`` and never
+        raises, while a non-empty wrong-length list always does.
+        """
+        nodes = ["a::t1", "b::t2", "c::t3"]
+        assert nrt._build_triage_prompt(nodes, dispositions=[]) == nrt._build_triage_prompt(nodes)
+
+    def test_wrong_length_disposition_list_raises(self) -> None:
+        nodes = ["a::t1", "b::t2", "c::t3"]
+        with pytest.raises(ValueError):
+            nrt._build_triage_prompt(
+                nodes, dispositions=[_disposition("a::t1"), _disposition("b::t2")]
+            )
+
+    def test_ledger_paragraph_is_emitted_only_for_a_non_none_path(self) -> None:
+        nodes = ["a::t1"]
+        without = nrt._build_triage_prompt(nodes)
+        assert "Session ledger" not in without
+        assert "nightly-triage-ledger" not in without
+        with_path = nrt._build_triage_prompt(nodes, ledger_path="/abs/nightly-triage-ledger/x.json")
+        assert "/abs/nightly-triage-ledger/x.json" in with_path
+        assert "Read that file FIRST on every turn" in with_path
+        assert "BEFORE moving on to the next entry" in with_path
+        assert "cannot be parsed as JSON" in with_path
+        assert not SEARCH_TOKENS.search(with_path)
 
 
 def _errored(nodeid: str, worker: str, message: str) -> dict:
@@ -1302,6 +1385,94 @@ class TestDispatchFindings:
         assert outcome.recorded == []
 
 
+class TestDispositionHandoff:
+    """What dispatch_findings knows must reach the agent, and only for per-node."""
+
+    MSG = "RuntimeError: redis client is not on the claimed server"
+
+    def _body_failures(self, nodes):
+        return {
+            "tests": [
+                {
+                    "nodeid": n,
+                    "outcome": "failed",
+                    "setup": {"outcome": "passed"},
+                    "call": {"outcome": "failed", "longrepr": f"[gw1] AssertionError: {n}"},
+                }
+                for n in nodes
+            ]
+        }
+
+    def _run(self, monkeypatch, tmp_path, *, nodes, report, open_map, closed_map):
+        monkeypatch.setattr(nrt, "LOG_FILE", tmp_path / "nightly.log")
+        monkeypatch.setattr(nrt, "open_issues", lambda: open_map)
+        monkeypatch.setattr(nrt, "closed_issue_dispositions", lambda: closed_map)
+        monkeypatch.setattr(nrt, "comment_on_issue", lambda n, body, **kw: True)
+        calls: list[tuple[list[str], dict]] = []
+
+        def spy(ns, **kw):
+            calls.append((list(ns), kw))
+            return "sess-1" if ns else None
+
+        monkeypatch.setattr(nrt, "maybe_dispatch_triage_session", spy)
+        nrt.dispatch_findings(
+            report,
+            nodes,
+            {},
+            run_at="2026-09-05T03:00:00Z",
+            head_commit="cafe1234",
+        )
+        return calls
+
+    def test_dispositions_cover_the_survivors_and_nothing_already_tracked(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """The second-writer hazard, pinned.
+
+        An already-open node and a closed-not-planned node are commented on by
+        the script itself and dropped before the dispatch. Handing either to the
+        agent would make it a second writer for the same comment, so the channel
+        must carry only the nodes the agent is being asked to act on.
+        """
+        already_open = "tests/unit/test_open.py::test_1"
+        closed_np = "tests/unit/test_closed.py::test_2"
+        survivor = "tests/unit/test_new.py::test_3"
+        nodes = [already_open, closed_np, survivor]
+        calls = self._run(
+            monkeypatch,
+            tmp_path,
+            nodes=nodes,
+            report=self._body_failures(nodes),
+            open_map={f"Nightly regression: {already_open}": 11},
+            closed_map={f"Nightly regression: {closed_np}": (22, "NOT_PLANNED")},
+        )
+        per_node = [c for c in calls if c[0]]
+        assert len(per_node) == 1
+        dispatched, kwargs = per_node[0]
+        assert dispatched == [survivor]
+        assert [d.node for d in kwargs["dispositions"]] == [survivor]
+        assert kwargs["dispositions"][0].title == f"Nightly regression: {survivor}"
+        assert kwargs["dispositions"][0].disposition == "file"
+        assert kwargs["dispositions"][0].resolved_at
+        assert "gh issue list --state all" in kwargs["dispositions"][0].resolved_against
+
+    def test_cascade_dispatch_is_handed_no_dispositions(self, monkeypatch, tmp_path: Path) -> None:
+        """The narrowing, pinned in behaviour rather than only in prose.
+
+        Fixes 2 and 3 stop at the per-node path. The cascade umbrella keeps its
+        pre-rendered ``prompt=`` and gets no disposition, which is what keeps
+        it from acquiring a ledger it has no builder parameter to read.
+        """
+        nodes = [f"tests/unit/test_m.py::test_{i}" for i in range(9)]
+        report = {"tests": [_errored(n, "gw2", self.MSG) for n in nodes]}
+        calls = self._run(
+            monkeypatch, tmp_path, nodes=nodes, report=report, open_map={}, closed_map={}
+        )
+        cascade_calls = [c for c in calls if c[1].get("prompt") is not None]
+        assert len(cascade_calls) == 1
+        assert "dispositions" not in cascade_calls[0][1]
+
+
 class TestHandleIntegrityTrip:
     """A storm must not become invisible now that nothing alerts (#3134)."""
 
@@ -1513,6 +1684,81 @@ class TestMaybeDispatchTriage:
             assert nrt.maybe_dispatch_triage_session([]) is None
             mock_run.assert_not_called()
 
+    def _ledger_dir(self, monkeypatch, tmp_path: Path) -> Path:
+        monkeypatch.setattr(nrt, "LOG_FILE", tmp_path / "test.log")
+        monkeypatch.setattr(nrt, "DATA_DIR", tmp_path / "data")
+        return tmp_path / "data" / "nightly-triage-ledger"
+
+    def test_real_per_node_dispatch_seeds_a_ledger_and_names_it_in_the_message(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        ledger_dir = self._ledger_dir(monkeypatch, tmp_path)
+        nodes = ["tests/unit/test_a.py::test_1"]
+        with patch(
+            "subprocess.run", return_value=self._fake_result('{"session_id": "abc123"}')
+        ) as mock_run:
+            nrt.maybe_dispatch_triage_session(nodes, dispositions=[_disposition(nodes[0])])
+        written = sorted(ledger_dir.glob("*.json"))
+        assert len(written) == 1
+        payload = json.loads(written[0].read_text())
+        assert [e["node"] for e in payload["entries"]] == nodes
+        assert payload["filed"] == []
+        msg = mock_run.call_args.args[0][mock_run.call_args.args[0].index("--message") + 1]
+        assert str(written[0].resolve()) in msg
+
+    def test_dry_run_writes_no_ledger(self, monkeypatch, tmp_path: Path) -> None:
+        """The ledger write sits BELOW the dry-run short-circuit, and must stay there.
+
+        ``--dry-run`` is the one command an operator reaches for to preview a
+        night. The sentinel exists because an earlier version spawned real
+        sessions that filed real issues under it; a state write placed above
+        the short-circuit puts that class of defect back.
+        """
+        ledger_dir = self._ledger_dir(monkeypatch, tmp_path)
+        nodes = ["tests/unit/test_a.py::test_1"]
+        with patch("subprocess.run") as mock_run:
+            session_id = nrt.maybe_dispatch_triage_session(
+                nodes, dispositions=[_disposition(nodes[0])], dry_run=True
+            )
+        mock_run.assert_not_called()
+        assert session_id == nrt.DRY_RUN_SESSION_ID
+        assert not ledger_dir.exists()
+
+    def test_prompt_override_dispatch_writes_no_ledger(self, monkeypatch, tmp_path: Path) -> None:
+        """The scope narrowing, at the one place it is enforced.
+
+        The cascade and re-baseline-seed dispatches pass a pre-rendered prompt
+        and no dispositions, so the entry list is empty, no file is created,
+        and ``nightly-triage-baseline.json`` never exists. One gate does the
+        whole narrowing; there is no separate branch to keep in step.
+        """
+        ledger_dir = self._ledger_dir(monkeypatch, tmp_path)
+        with patch(
+            "subprocess.run", return_value=self._fake_result('{"session_id": "abc123"}')
+        ) as mock_run:
+            nrt.maybe_dispatch_triage_session(
+                ["seed:3"], prompt="CUSTOM UMBRELLA PROMPT", slug_suffix="baseline"
+            )
+        assert not ledger_dir.exists()
+        argv = mock_run.call_args.args[0]
+        assert argv[argv.index("--message") + 1] == "CUSTOM UMBRELLA PROMPT"
+
+    def test_a_failed_ledger_write_does_not_stop_the_dispatch(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(nrt, "LOG_FILE", tmp_path / "test.log")
+        monkeypatch.setattr(nrt, "write_triage_ledger", lambda slug, entries: None)
+        nodes = ["tests/unit/test_a.py::test_1"]
+        with patch(
+            "subprocess.run", return_value=self._fake_result('{"session_id": "abc123"}')
+        ) as mock_run:
+            session_id = nrt.maybe_dispatch_triage_session(
+                nodes, dispositions=[_disposition(nodes[0])]
+            )
+        assert session_id == "abc123"
+        argv = mock_run.call_args.args[0]
+        assert "nightly-triage-ledger" not in argv[argv.index("--message") + 1]
+
 
 class TestMainDispatchPersistence:
     """main() persists only what actually went out to triage (issue #2559)."""
@@ -1590,7 +1836,7 @@ class TestMainDispatchPersistence:
             tmp_path, prev, [standing, fresh], "triage-session-1"
         )
         assert rc == 0
-        mock_dispatch.assert_called_once_with([fresh], dry_run=False)
+        _assert_per_node_dispatch(mock_dispatch, [fresh])
         assert saved["dispatched_nodes"] == sorted([standing, fresh])
 
     def test_no_dispatch_when_everything_is_already_filed(self, tmp_path: Path) -> None:
@@ -1598,7 +1844,7 @@ class TestMainDispatchPersistence:
         prev = self._prev(failing_tests=[standing], dispatched_nodes=[standing])
         rc, saved, mock_dispatch, _ = self._run_main(tmp_path, prev, [standing], None)
         assert rc == 0
-        mock_dispatch.assert_called_once_with([], dry_run=False)
+        mock_dispatch.assert_called_once_with([], dispositions=[], dry_run=False)
         assert saved["dispatched_nodes"] == [standing]
 
     def test_failed_dispatch_leaves_nodes_unfiled_for_retry(self, tmp_path: Path) -> None:
@@ -1608,7 +1854,7 @@ class TestMainDispatchPersistence:
         )
         rc, saved, mock_dispatch, _ = self._run_main(tmp_path, prev, [node], None)
         assert rc == 0
-        mock_dispatch.assert_called_once_with([node], dry_run=False)
+        _assert_per_node_dispatch(mock_dispatch, [node])
         assert saved["dispatched_nodes"] == []
         assert saved["dispatched_session_id"] == "earlier-session"
 
@@ -1826,7 +2072,7 @@ class TestMainDispatchPersistence:
         rc, saved, mock_dispatch, log_text = self._run_main(tmp_path, prev, [node], None)
 
         assert rc == 0
-        mock_dispatch.assert_called_once_with([], dry_run=False)
+        mock_dispatch.assert_called_once_with([], dispositions=[], dry_run=False)
         assert saved["seeded_nodes"] == [node]
         # The regression is still recorded even though no issue is filed.
         assert "newly-confirmed failure" in log_text
@@ -1843,7 +2089,7 @@ class TestMainDispatchPersistence:
         prev = self._prev(failing_tests=[], dispatched_nodes=[], seeded_nodes=[])
         rc, saved, mock_dispatch, _ = self._run_main(tmp_path, prev, [node], "new-session")
         assert rc == 0
-        mock_dispatch.assert_called_once_with([node], dry_run=False)
+        _assert_per_node_dispatch(mock_dispatch, [node])
         assert saved["dispatched_nodes"] == [node]
 
     def test_collection_mismatch_regression_seed_survives_successful_dispatch(
@@ -2833,3 +3079,222 @@ class TestReviewFindings3142:
             "a::t", "NOT_PLANNED", run_at="R", head_commit="H"
         )
         assert nrt.closed_epilogue("NOT_PLANNED") in node_comment
+
+
+class TestPromptsNeverNameTheSearchIndex:
+    """All THREE issue-filing prompts hand over a REST command (#3170 fix 1).
+
+    The module's own reads were moved off GitHub's index-backed lookup by
+    ``8524e765b`` and are held there by
+    ``test_open_issues_uses_the_rest_list_not_the_lagging_search``. This is the
+    same contract one layer out, for the reads the module tells an *agent* to
+    make -- the layer that stayed unfixed through four passes and produced the
+    #2960-#2999 duplicate wave. The two tests are one contract; a prompt that
+    names the index is the same defect as a script that queries it.
+
+    Parametrized over all three prompts on purpose: hardening one and gating on
+    it reported clean with two thirds of the hole open.
+    """
+
+    def _prompts(self) -> dict[str, str]:
+        cascade = {
+            "nodes": ["tests/unit/test_a.py::test_1"],
+            "workers": ["gw1"],
+            "kind": "body",
+            "title": "Nightly regression cascade: boom",
+            "message": "AssertionError: boom",
+        }
+        return {
+            "per-node": nrt._build_triage_prompt(["tests/unit/test_a.py::test_1"]),
+            "cascade": nrt._build_cascade_prompt(cascade),
+            "seed": nrt._build_seed_prompt("Nightly regression baseline: 2 nodes", ["a::t1"]),
+        }
+
+    @pytest.mark.parametrize("name", ["per-node", "cascade", "seed"])
+    def test_prompt_hands_over_the_rest_command(self, name: str) -> None:
+        prompt = self._prompts()[name]
+        assert (
+            "gh issue list --state all --json number,title,state,stateReason --limit 200" in prompt
+        )
+
+    @pytest.mark.parametrize("name", ["per-node", "cascade", "seed"])
+    def test_prompt_carries_the_prohibition_and_its_reason(self, name: str) -> None:
+        prompt = self._prompts()[name]
+        assert "search index" in prompt
+        assert "#2960-#2999" in prompt
+
+    @pytest.mark.parametrize("name", ["per-node", "cascade", "seed"])
+    def test_prompt_warns_that_statereason_is_empty_on_open_rows(self, name: str) -> None:
+        prompt = self._prompts()[name]
+        assert "stateReason" in prompt
+        assert "empty string on OPEN rows" in prompt
+
+    @pytest.mark.parametrize("name", ["per-node", "cascade", "seed"])
+    def test_prompt_never_names_the_index_backed_lookup(self, name: str) -> None:
+        assert SEARCH_TOKENS.findall(self._prompts()[name]) == []
+
+    def test_all_three_share_one_constant(self) -> None:
+        """One string, three readers -- so the three cannot drift again."""
+        for prompt in self._prompts().values():
+            assert nrt.ISSUE_LOOKUP_INSTRUCTION in prompt
+
+
+class TestBuildSeedPrompt:
+    """Extraction out of main() must be a move, not a rewrite (#3170)."""
+
+    TITLE = "Nightly regression baseline: 2 nodes absorbed on abc1234"
+    NODES = ["tests/unit/test_a.py::test_1", "tests/unit/test_b.py::test_2"]
+
+    def _inline_original(self, prior_collection) -> str:
+        """The text as main() carried it, before extraction.
+
+        Kept literal here rather than described, so byte-identity is *gated*
+        rather than asserted: the seed's dedup rule is stricter than the
+        per-node one (a closed umbrella is commented on and never re-filed,
+        whatever the close reason) and a paraphrase during the move would have
+        softened it silently.
+        """
+        seed_size = len(self.NODES)
+        seed_title = self.TITLE
+        return (
+            "Nightly regression detector re-baselined its test collection "
+            f"(old={prior_collection!r}, new={nrt.COLLECTION_PATHS!r}). "
+            f"The following {seed_size} node(s) were already failing at the "
+            "moment of the re-baseline and have been absorbed into the seed — "
+            "they are NOT individually filed. Search open AND closed issues for "
+            f'the EXACT title "{seed_title}". If an open one exists, comment on '
+            "it. If a closed one exists, comment there and do NOT re-file — the "
+            "seed umbrella is a declaration, and a re-baseline retry at the same "
+            "commit must not mint a twin, whatever the close reason. Only if "
+            "neither exists, open ONE umbrella issue with EXACTLY that title, "
+            "summarizing the "
+            "population, its size, and pointing at the persisted state file "
+            "for the full node list. Do NOT file per-node issues for these. Do "
+            "NOT attempt an auto-hotfix.\n\n"
+            "Seeded node IDs:\n" + "\n".join(f"- {n}" for n in self.NODES)
+        )
+
+    def _substitute_back(self, rendered: str) -> str:
+        """Undo the one sentence fix 1 replaced, so the rest can be diffed exactly."""
+        new_unit = "\n" + nrt.ISSUE_LOOKUP_INSTRUCTION + "The EXACT title to match is"
+        assert new_unit in rendered
+        return rendered.replace(new_unit, " Search open AND closed issues for the EXACT title", 1)
+
+    def test_byte_identical_to_the_inline_original_apart_from_the_lookup_sentence(self) -> None:
+        prior = ["tests/", "docs/"]
+        rendered = nrt._build_seed_prompt(self.TITLE, self.NODES, prior_collection=prior)
+        assert self._substitute_back(rendered) == self._inline_original(prior)
+
+    def test_prior_collection_renders_and_defaults_to_none(self) -> None:
+        """The third parameter is the one a two-parameter signature would drop.
+
+        ``old=`` interpolates a main() local derivable from neither the title
+        nor the node list, so a signature without it loses the clause outright
+        while every other assertion here still passes.
+        """
+        with_prior = nrt._build_seed_prompt(self.TITLE, self.NODES, prior_collection=["old/"])
+        assert "(old=['old/'], new=['tests/'])" in with_prior
+        default = nrt._build_seed_prompt(self.TITLE, self.NODES)
+        assert "(old=None, new=['tests/'])" in default
+
+    def test_the_stricter_closed_rule_survives_the_move(self) -> None:
+        rendered = nrt._build_seed_prompt(self.TITLE, self.NODES)
+        assert "comment there and do NOT re-file" in rendered
+        assert "whatever the close reason" in rendered
+
+    def test_carries_no_ledger_and_no_pre_resolved_block(self) -> None:
+        rendered = nrt._build_seed_prompt(self.TITLE, self.NODES)
+        assert "nightly-triage-ledger" not in rendered
+        assert "Already resolved by the detector" not in rendered
+
+
+class TestWriteTriageLedger:
+    """The third, advisory replay defence: seeded by the script, appended by the agent."""
+
+    SLUG = "nightly-triage-a1b2c3d4"
+
+    def _ledger_dir(self, monkeypatch, tmp_path: Path) -> Path:
+        monkeypatch.setattr(nrt, "LOG_FILE", tmp_path / "nightly.log")
+        monkeypatch.setattr(nrt, "DATA_DIR", tmp_path / "data")
+        return tmp_path / "data" / "nightly-triage-ledger"
+
+    def test_happy_path_shape_and_absolute_return(self, monkeypatch, tmp_path: Path) -> None:
+        ledger_dir = self._ledger_dir(monkeypatch, tmp_path)
+        entries = [_disposition("a::t1"), _disposition("b::t2")]
+        returned = nrt.write_triage_ledger(self.SLUG, entries)
+        assert Path(returned).is_absolute()
+        assert Path(returned) == (ledger_dir / f"{self.SLUG}.json").resolve()
+        payload = json.loads(Path(returned).read_text())
+        assert payload["slug"] == self.SLUG
+        assert payload["created_at"]
+        assert payload["filed"] == []
+        assert [e["node"] for e in payload["entries"]] == ["a::t1", "b::t2"]
+        assert payload["entries"][0]["disposition"] == "file"
+
+    def test_empty_entries_writes_nothing_and_returns_none(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """An empty ledger would read to a replay as 'nothing left to file'."""
+        ledger_dir = self._ledger_dir(monkeypatch, tmp_path)
+        assert nrt.write_triage_ledger(self.SLUG, []) is None
+        assert not ledger_dir.exists()
+
+    def test_an_unwritable_target_logs_a_warning_and_returns_none(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """Fail-open: a ledger that cannot be written must not stop the night filing."""
+        log_file = tmp_path / "nightly.log"
+        monkeypatch.setattr(nrt, "LOG_FILE", log_file)
+        blocker = tmp_path / "data"
+        blocker.write_text("not a directory")
+        monkeypatch.setattr(nrt, "DATA_DIR", blocker)
+        assert nrt.write_triage_ledger(self.SLUG, [_disposition("a::t1")]) is None
+        assert "WARNING" in log_file.read_text()
+        assert self.SLUG in log_file.read_text()
+
+    def test_a_live_sessions_appends_are_never_re_seeded_away(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """A same-slug retry must not erase what the first session already filed.
+
+        maybe_dispatch_triage_session returns None whenever the subprocess exits
+        zero but its stdout will not parse, so an identical node set can come
+        back on a later run under the same sha256 slug while the first session's
+        issues really exist.
+        """
+        ledger_dir = self._ledger_dir(monkeypatch, tmp_path)
+        first = nrt.write_triage_ledger(self.SLUG, [_disposition("a::t1")])
+        payload = json.loads(Path(first).read_text())
+        payload["filed"] = [{"number": 4242, "title": "t", "node": "a::t1"}]
+        Path(first).write_text(json.dumps(payload))
+
+        second = nrt.write_triage_ledger(self.SLUG, [_disposition("a::t1")])
+        assert second == first
+        assert json.loads(Path(first).read_text())["filed"] == payload["filed"]
+        assert sorted(x.name for x in ledger_dir.iterdir()) == [f"{self.SLUG}.json"]
+
+    def test_an_untouched_ledger_with_no_filings_is_re_seeded(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """The guard keys on filings, not on the file existing."""
+        self._ledger_dir(monkeypatch, tmp_path)
+        nrt.write_triage_ledger(self.SLUG, [_disposition("a::t1")])
+        returned = nrt.write_triage_ledger(self.SLUG, [_disposition("b::t2")])
+        payload = json.loads(Path(returned).read_text())
+        assert [e["node"] for e in payload["entries"]] == ["b::t2"]
+
+    def test_the_write_is_atomic_and_leaves_no_temp_file(self, monkeypatch, tmp_path: Path) -> None:
+        """Truncated JSON is worse for the agent than stale-but-valid JSON."""
+        ledger_dir = self._ledger_dir(monkeypatch, tmp_path)
+        nrt.write_triage_ledger(self.SLUG, [_disposition("a::t1")])
+        assert [x.name for x in ledger_dir.iterdir()] == [f"{self.SLUG}.json"]
+
+    def test_a_corrupt_existing_ledger_is_overwritten_rather_than_raising(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        ledger_dir = self._ledger_dir(monkeypatch, tmp_path)
+        ledger_dir.mkdir(parents=True)
+        (ledger_dir / f"{self.SLUG}.json").write_text("{ truncated")
+        returned = nrt.write_triage_ledger(self.SLUG, [_disposition("a::t1")])
+        assert returned is not None
+        assert json.loads(Path(returned).read_text())["filed"] == []

--- a/tests/unit/test_nightly_regression_tests.py
+++ b/tests/unit/test_nightly_regression_tests.py
@@ -1456,6 +1456,61 @@ class TestDispositionHandoff:
         assert kwargs["dispositions"][0].resolved_at
         assert "gh issue list --state all" in kwargs["dispositions"][0].resolved_against
 
+    def test_no_dispositions_when_open_read_fails(self, monkeypatch, tmp_path: Path) -> None:
+        """A failed open-issue read must not assert a detector resolution.
+
+        ``partition_already_open`` fails open on ``open_map=None`` -- every
+        node, including ones that actually have an open issue, survives into
+        ``single_nodes`` unfiltered. Without this fix, dispatch_findings would
+        still hand those survivors a ``dispositions`` list claiming "it read
+        all open and closed issues... and found no issue carrying that exact
+        title", which is false, and which demotes the agent's own live lookup
+        to "a second check" on exactly the night that lookup is the only real
+        defense left.
+        """
+        survivor = "tests/unit/test_new.py::test_3"
+        nodes = [survivor]
+        calls = self._run(
+            monkeypatch,
+            tmp_path,
+            nodes=nodes,
+            report=self._body_failures(nodes),
+            open_map=None,
+            closed_map={},
+        )
+        per_node = [c for c in calls if c[0]]
+        assert len(per_node) == 1
+        dispatched, kwargs = per_node[0]
+        assert dispatched == [survivor]
+        assert kwargs["dispositions"] is None
+
+    def test_no_dispositions_when_closed_read_fails(self, monkeypatch, tmp_path: Path) -> None:
+        """A partial read (only one of open/closed readable) is still degraded.
+
+        ``open_map={}`` is readable-but-empty while ``closed_map=None`` means
+        the closed-issue read failed, so ``read_shape == ["open"]``: a partial
+        read, not the full read fix 2 requires. Handing out a disposition here
+        would render a ``resolved_against`` naming only the open read while the
+        prompt sentence still claims "it read all open and closed issues" --
+        self-contradictory, and it demotes the agent's own lookup on the one
+        night a closed-not-planned recurrence could otherwise slip through.
+        """
+        survivor = "tests/unit/test_new.py::test_3"
+        nodes = [survivor]
+        calls = self._run(
+            monkeypatch,
+            tmp_path,
+            nodes=nodes,
+            report=self._body_failures(nodes),
+            open_map={},
+            closed_map=None,
+        )
+        per_node = [c for c in calls if c[0]]
+        assert len(per_node) == 1
+        dispatched, kwargs = per_node[0]
+        assert dispatched == [survivor]
+        assert kwargs["dispositions"] is None
+
     def test_cascade_dispatch_is_handed_no_dispositions(self, monkeypatch, tmp_path: Path) -> None:
         """The narrowing, pinned in behaviour rather than only in prose.
 


### PR DESCRIPTION
## Summary

Closes #3170.

On 2026-08-24 one nightly triage dispatch filed the same failing node three times (#2960, #2972, #2990) from the same worktree at the same commit, and the wave came to 39 issues. Every filing ran the prompt's instruction to search all issues for the exact title, and every one came up empty: GitHub's search index lags issue creation by minutes, and each wave searched inside the lag window its own predecessor had opened issues in. The turn was replayed; the filing step had no defence of its own.

Three defences, cheapest first.

**Fix 1 — every prompt reads live state.** A new module-level `ISSUE_LOOKUP_INSTRUCTION` carries the literal `gh issue list --state all --json number,title,state,stateReason --limit 200` REST command, the prohibition on the index-backed lookup with the incident behind it, and the note that `stateReason` is `""` on OPEN rows. It reaches **all three** issue-filing prompts. There are three, not one: the per-node dispatch, the cascade umbrella, and the re-baseline seed. That is why four prior passes each hardened one copy of the sentence and left the others. The seed prompt lived inline inside `main()` and could not be rendered by a test or scanned by a gate at all; `_build_seed_prompt` extracts it, byte-identically apart from the replaced sentence.

**Fix 2 — the script's decisions cross the boundary.** By the time nodes reach `maybe_dispatch_triage_session`, `dispatch_findings` has already established against a live REST read that they have no issue in any state. Only a *complete* read (both the open-issues and closed-issues REST maps resolved) licenses that claim: a degraded read — either map unreadable, with survivors still to dispatch — yields `dispositions=None`, and `_build_triage_prompt` falls back to its plain per-node form rather than asserting a resolution that never happened. `write_triage_ledger` then also writes no ledger file for that dispatch, since `maybe_dispatch_triage_session` passes it an empty entries list in the `dispositions=None` case — the same no-file outcome the ledger already has for a write failure, from a different cause. The live REST-read instruction in every prompt (fix 1) stays the undemoted defense on a degraded night. On a full read, the prompt carries a `NodeDisposition` per node and leads with what was checked and when, so the agent's read is a confirmation rather than a derivation.

**Fix 3 — a session ledger.** `data/nightly-triage-ledger/{slug}.json` records the entries one session may file and what it has already filed. It is seeded before the session starts, appended to by the agent after each `gh issue create`, and read first on every turn, so a replayed turn inherits its predecessor's work.

Fixes 2 and 3 stop at the per-node path, which is where every observed duplicate came from. Both override paths still get fix 1. The scoping needs no branch: `entries` derives from `dispositions` and nothing else, so a caller that passes none gets no file, no ledger paragraph, and no dangling instruction — `nightly-triage-baseline.json` never exists.

## Verification

All 17 rows of the plan's Verification table, run in the worktree at `1f0baa896` (the last commit that changed runtime behavior; a documentation-only follow-up patch landed afterward to describe the degraded-read/no-ledger branch above and touches none of these numbers):

| # | Row | Result |
|---|-----|--------|
| 1 | Unit tests pass | 240 passed |
| 2 | Lint clean | exit 0 |
| 3 | Format clean | exit 0 |
| 4 | All three prompts hand over the REST command | `1` (> 0) |
| 5 | No prompt names the index-backed lookup (anti-criterion) | `0` — was `3` pre-fix |
| 6 | Every prompt carries the prohibition | `1` (> 0) |
| 7 | Every prompt warns about the open-issue `stateReason` | `3` (> 0) |
| 8 | The seed prompt is an addressable function | `1` |
| 9 | The module's three legitimate rationale mentions preserved (invariant) | `3` |
| 10 | Ledger helper exists | `1` |
| 11 | Ledger write follows the dry-run short-circuit | `1` |
| 12 | Dispositions cross the dispatch boundary | `1` (> 0) |
| 13 | Named new tests exist and pass | 29 passed |
| 14 | Dry run writes no ledger (behavioural) | 1 passed |
| 15 | Branch rooted on main, not the stale #3075 lane | exit 0 |
| 16 | Cascade and seed prompts carry no ledger (scope guard) | `0` |
| 17 | The per-node prompt carries the ledger path when given one | `1` |

Note on `scripts/validate_build.py`: it reports 18 FAILs on this plan and every one is exit 127 or exit 2, i.e. "command not found". Its table parser reads only the first three columns, so on this plan's four-column `| # | Check | Command | Expected |` table it runs the **Check** prose as the command. The rows above were run directly instead.

## Mutation results

Each new guard was broken individually, the specific test re-run, and the source restored:

| Mutation | Guard | Result |
|---|---|---|
| Prompts name the index again | `TestPromptsNeverNameTheSearchIndex` | RED |
| Seed prompt drops `prior_collection` | `TestBuildSeedPrompt` | RED |
| Ledger seeds a non-empty `filed` | `TestWriteTriageLedger` | RED |
| Ledger clobbers a live session's appends | `TestWriteTriageLedger` | RED |
| Empty entries still writes a file | `TestWriteTriageLedger` | RED |
| Ledger write moves above the dry-run short-circuit | `TestMaybeDispatchTriage` | RED |
| Dispositions stop crossing the boundary | `TestDispositionHandoff` | RED |
| Already-open nodes leak into the dispositions | `TestDispositionHandoff` | RED |
| Cascade dispatch acquires a ledger | `TestDispositionHandoff` | RED |
| Ledger paragraph emitted unconditionally | `TestBuildTriagePrompt` | RED |
| Empty disposition list reaches the zip | `TestBuildTriagePrompt` | RED |
| `zip` loses `strict=True` | `TestBuildTriagePrompt` | RED |

Two of these first measured GREEN and the reading was wrong: those runs collapsed under `-n auto` on a loaded machine ("no tests ran", every worker down) and the wrapper returned 0. Re-run at `-n 2` both go red at `1 failed`. The same artifact produced a `row1_exit=0` on a run where no test executed, which is worth knowing about this wrapper.

## Test changes

The dispatch stubs were audited rather than blanket-rewritten: **14** stub sites, not the nine the plan estimated, and none binds the new argument positionally, so none changed. Five *assertions* in `TestMainDispatchPersistence` did have to move, since `assert_called_once_with([node], dry_run=False)` is an exact-kwargs match on the call that now carries `dispositions=`. They went through a helper that checks what the old assertion checked plus that the dispositions cover exactly the dispatched nodes, so the next widening of this channel does not rewrite them again.

New coverage: `TestPromptsNeverNameTheSearchIndex` (parametrized over all three rendered prompts), `TestBuildSeedPrompt` (byte-identity against the inline original, gated rather than asserted), `TestWriteTriageLedger`, `TestDispositionHandoff`, plus extensions to `TestBuildTriagePrompt` and `TestMaybeDispatchTriage`. 204 tests to 238, then +2 (`test_no_dispositions_when_open_read_fails`, `test_no_dispositions_when_closed_read_fails`) to 240 fixing the round-1 review blocker: the degraded-read branch now has both halves — `open_map=None` and the partial `closed_map=None` — covered under mutation.

## Notes for review

- **The wording constraint is real and two gates enforce it from opposite directions.** Row 5 scans the rendered prompts and requires zero hits for four spellings; row 9 counts the flag across the whole module and requires exactly the three legitimate rationale mentions. A comment that spells a forbidden token out to prohibit it fails row 9 on otherwise correct code. The comment above the constant says so.
- **The ledger is advisory and fail-open.** A write failure logs a WARNING naming the slug and returns `None`; dispatch proceeds without a ledger paragraph. It is deliberately unlocked (reasoning in the docstring and the doc), written atomically via `os.replace`, and a same-slug retry landing on a ledger with non-empty `filed` leaves it alone rather than re-seeding an empty one over a live session's appends. A degraded read produces the same no-file outcome for a different reason — see "Fix 2" above and the "Replay Idempotency" section of `docs/features/nightly-triage-dispatch.md`, both updated in the documentation-only follow-up commit that closed this out.
- **No service restart.** `com.valor.nightly-tests` invokes the script fresh each schedule fire; the bridge and worker do not import it.
- The stale local `session/nightly-triage-idempotency-3075` branch was not used as a base (row 15).

