### PR TITLE
REVIEW consensus refuses APPROVED on a judge quorum shortfall

### DIFF
--- a/.claude/skills-global/do-pr-review/sub-skills/outcome-contract.md
+++ b/.claude/skills-global/do-pr-review/sub-skills/outcome-contract.md
@@ -68,6 +68,18 @@ consumers into thinking multi-judge ran).
 <!-- OUTCOME {"status":"partial","stage":"REVIEW","verdict":"CHANGES_REQUESTED","artifacts":{"review_url":"{review_url}","blockers":0,"tech_debt":2,"nits":1,"judges_run":2,"consensus_disagreement":false},"notes":"Changes requested via 2-of-2 consensus: 2 tech_debt and 1 nit findings. Routing to /do-patch.","next_skill":"/do-patch"} -->
 ```
 
+**Multi-judge quorum shortfall (CHANGES_REQUESTED — fewer distinct judges reported than the declared roster):**
+```
+<!-- OUTCOME {"status":"fail","stage":"REVIEW","verdict":"CHANGES_REQUESTED","artifacts":{"review_url":"{review_url}","judges_run":1,"quorum_shortfall":true},"notes":"Quorum shortfall: 1 of 2 declared judges reported (risk did not return). Not read as consensus.","failure_reason":"quorum_shortfall — declared roster of 2 fell short, rule did not run","next_skill":"/do-patch"} -->
+```
+On a shortfall, `artifacts` carries `judges_run` and `quorum_shortfall: true`
+and **omits `consensus_disagreement`** — that field derives from `tied`,
+which is only meaningful once the rule has run over a full roster, and the
+rule never runs on a shortfall; reporting `false` would reproduce the exact
+"the judges agreed" misreading this variant exists to avoid. The `notes`
+field names the degraded run in its first clause so a human reading the
+transcript sees the shortfall, not an ordinary rejection.
+
 ## Multi-judge & cross-vendor consensus (optional, only if the context file declares it)
 
 The generic baseline is a **single reviewer**: you evaluate the diff, classify

--- a/agent/sdlc_review_consensus.py
+++ b/agent/sdlc_review_consensus.py
@@ -58,7 +58,9 @@ def _dedup_last_wins(judges: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [by_id[k] for k in sorted(by_id.keys())]
 
 
-def _conservative_outcome(rule: str, *, n: int = 0, expected_n: int | None = None) -> dict[str, Any]:
+def _conservative_outcome(
+    rule: str, *, n: int = 0, expected_n: int | None = None
+) -> dict[str, Any]:
     """Return a conservative CHANGES REQUESTED outcome.
 
     Shared by two call sites that are the same failure shape: zero judges

--- a/agent/sdlc_review_consensus.py
+++ b/agent/sdlc_review_consensus.py
@@ -5,9 +5,23 @@ when the repo addendum declares ≥2 judges. The parent skill collects per-judge
 dicts in memory, calls :func:`compute_consensus`, then makes a single
 ``record_verdict(... judges=[...], consensus=meta)`` call.
 
+**Quorum floor.** ``compute_consensus`` optionally learns how many judges
+were *declared* (``expected_judges``, the mandatory roster size only — never
+the number dispatched, never inclusive of optional judges) and refuses to
+run the rule when fewer distinct judges reported, returning the same
+conservative outcome the zero-judge case already used. The shortfall rides
+in the returned ``consensus`` dict as ``quorum_shortfall`` (bool, always
+present) and ``expected_n`` (the declared floor, or ``None``), so a
+degraded single-judge run is recorded as a shortfall rather than read back
+as agreement. The guard compares cardinality only, never membership: it
+cannot tell a mandatory judge id from a misnamed or optional one, so a
+shortfall proves under-reporting but a satisfied floor does not prove the
+declared roster specifically ran.
+
 Pure function. No I/O. Fully unit-testable.
 
-Reference: docs/plans/multi-judge-consensus-gates.md (rev1).
+Reference: docs/plans/multi-judge-consensus-gates.md (rev1),
+docs/plans/sdlc-3197.md (quorum floor).
 """
 
 from __future__ import annotations
@@ -44,11 +58,14 @@ def _dedup_last_wins(judges: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [by_id[k] for k in sorted(by_id.keys())]
 
 
-def _empty_conservative_outcome(rule: str) -> dict[str, Any]:
-    """Return a conservative CHANGES REQUESTED outcome for empty input.
+def _conservative_outcome(rule: str, *, n: int = 0, expected_n: int | None = None) -> dict[str, Any]:
+    """Return a conservative CHANGES REQUESTED outcome.
 
-    Matches the Failure Path strategy: the parent should never silently
-    approve when zero judges returned data.
+    Shared by two call sites that are the same failure shape: zero judges
+    reported (``n=0``), and a declared roster fell short of its floor
+    (``n`` between 1 and ``expected_n - 1``). Matches the Failure Path
+    strategy: the parent should never silently approve when the reporting
+    judges fall short of what was expected.
     """
     return {
         "verdict": "CHANGES REQUESTED",
@@ -56,19 +73,35 @@ def _empty_conservative_outcome(rule: str) -> dict[str, Any]:
         "tech_debt": 0,
         "consensus": {
             "rule": rule,
-            "k": 0,
-            "n": 0,
+            "k": n,
+            "n": n,
             "mean_confidence": 0.0,
             "blocker_aggregation": "max",
             "tied": False,
+            "expected_n": expected_n,
+            "quorum_shortfall": expected_n is not None and n < expected_n,
             "decided_at": datetime.now(UTC).isoformat(),
         },
     }
 
 
+def _validate_expected_judges(expected_judges: int | None) -> None:
+    if expected_judges is None:
+        return
+    # isinstance(True, int) is True in Python — reject bool explicitly before
+    # the int check, or a caller passing `expected_judges=True` would silently
+    # behave as `expected_judges=1`.
+    if isinstance(expected_judges, bool) or not isinstance(expected_judges, int):
+        raise ValueError(f"expected_judges must be an int >= 1 or None, got {expected_judges!r}")
+    if expected_judges < 1:
+        raise ValueError(f"expected_judges must be an int >= 1 or None, got {expected_judges!r}")
+
+
 def compute_consensus(
     judges: list[dict[str, Any]],
     rule: str = "any-blocker-wins",
+    *,
+    expected_judges: int | None = None,
 ) -> dict[str, Any]:
     """Aggregate per-judge dicts into a single scalar verdict + consensus meta.
 
@@ -79,28 +112,53 @@ def compute_consensus(
             ``reasoning_summary`` (str), ``review_url`` (str).
         rule: consensus rule. Either ``"any-blocker-wins"`` (default — Review
             uses this) or ``"unanimous-approved"`` (opt-in alternative).
+        expected_judges: the size of the *mandatory* declared judge roster
+            (keyword-only). When set, ``compute_consensus`` refuses to run
+            the rule and returns a conservative outcome if fewer distinct
+            judges reported than this floor. ``None`` (the default)
+            reproduces today's behavior byte-for-byte apart from the two
+            additive metadata keys below. Optional judges (e.g. the
+            cross-vendor judge) must never be counted in this number — an
+            optional judge that returns can only raise ``n`` above the
+            floor, and one that skips leaves the floor exactly where it was.
+            **Limit:** this bounds *how many* distinct ``judge_id``s
+            reported, never *which* — a misnamed, substituted, or optional
+            judge id satisfies the floor identically to a mandatory one. A
+            shortfall proves under-reporting; a satisfied floor does not
+            prove the declared roster specifically ran.
 
     Returns:
         dict with keys ``verdict``, ``blockers``, ``tech_debt``, ``consensus``
         (a metadata dict with ``rule``, ``k``, ``n``, ``mean_confidence``,
-        ``blocker_aggregation``, ``tied``, ``decided_at``).
+        ``blocker_aggregation``, ``tied``, ``expected_n``,
+        ``quorum_shortfall``, ``decided_at``). ``expected_n`` is ``None``
+        when the caller declared no expectation; ``quorum_shortfall`` is
+        always present as a bool (``True`` iff ``expected_n is not None and
+        n < expected_n``).
 
     Raises:
-        ValueError: on unknown rule or malformed judge dict (missing required
-            key, wrong types). Caller must catch and translate to a
-            conservative outcome before any verdict write.
+        ValueError: on unknown rule, an invalid ``expected_judges`` (not
+            ``None`` and not an ``int >= 1`` — a ``bool`` is rejected
+            explicitly since ``isinstance(True, int)`` is ``True``), or a
+            malformed judge dict (missing required key, wrong types).
+            Caller must catch and translate to a conservative outcome before
+            any verdict write.
     """
     if rule not in _VALID_RULES:
         raise ValueError(f"unknown consensus rule {rule!r}; valid rules: {sorted(_VALID_RULES)}")
+    _validate_expected_judges(expected_judges)
 
     if not judges:
-        return _empty_conservative_outcome(rule)
+        return _conservative_outcome(rule, n=0, expected_n=expected_judges)
 
     for j in judges:
         _validate_judge(j)
 
     deduped = _dedup_last_wins(judges)
     n = len(deduped)
+
+    if expected_judges is not None and n < expected_judges:
+        return _conservative_outcome(rule, n=n, expected_n=expected_judges)
 
     blockers_max = max(int(j["blockers"]) for j in deduped)
     tech_debt_max = max(int(j.get("tech_debt", 0) or 0) for j in deduped)
@@ -138,6 +196,8 @@ def compute_consensus(
             "mean_confidence": mean_confidence,
             "blocker_aggregation": "max",
             "tied": tied,
+            "expected_n": expected_judges,
+            "quorum_shortfall": False,
             "decided_at": datetime.now(UTC).isoformat(),
         },
     }

--- a/docs/features/multi-judge-consensus.md
+++ b/docs/features/multi-judge-consensus.md
@@ -77,7 +77,7 @@ from agent.sdlc_review_consensus import compute_consensus
 
 # Parent skill flow — single record_verdict call writes scalar + side-fields:
 judges = [judge_a_dict, judge_b_dict]
-agg = compute_consensus(judges, rule="any-blocker-wins")
+agg = compute_consensus(judges, rule="any-blocker-wins", expected_judges=2)
 record_verdict(
     session,
     "REVIEW",

--- a/docs/features/multi-judge-consensus.md
+++ b/docs/features/multi-judge-consensus.md
@@ -110,9 +110,10 @@ whose changed files are all docs (`docs/**`, `**/*.md`) or all lockfile sync
 (`uv.lock` / `pyproject.toml` only) force the legacy single-judge path. It is
 automatic and per-PR, which is what makes it the right shape for this — cost
 scales with what a PR actually is, not with what someone remembered to export.
-This path is unaffected by the quorum floor below: it is inline prose
-(`docs/sdlc/do-pr-review.md:250-254`, not a script — there is no shape
-classifier module) applied by the executing agent, and it never calls
+This path is unaffected by the quorum floor below: it is inline prose (the
+"Cost containment" bullet in `docs/sdlc/do-pr-review.md`'s Multi-Judge
+Consensus section, not a script — there is no shape classifier module)
+applied by the executing agent, and it never calls
 `compute_consensus` at all. It posts one judge's verdict directly, with no
 `judges`/`consensus` kwargs on `record_verdict` and no `judges_run` in its
 OUTCOME, so the floor has nothing to trip on that path.

--- a/docs/features/multi-judge-consensus.md
+++ b/docs/features/multi-judge-consensus.md
@@ -110,6 +110,12 @@ whose changed files are all docs (`docs/**`, `**/*.md`) or all lockfile sync
 (`uv.lock` / `pyproject.toml` only) force the legacy single-judge path. It is
 automatic and per-PR, which is what makes it the right shape for this — cost
 scales with what a PR actually is, not with what someone remembered to export.
+This path is unaffected by the quorum floor below: it is inline prose
+(`docs/sdlc/do-pr-review.md:250-254`, not a script — there is no shape
+classifier module) applied by the executing agent, and it never calls
+`compute_consensus` at all. It posts one judge's verdict directly, with no
+`judges`/`consensus` kwargs on `record_verdict` and no `judges_run` in its
+OUTCOME, so the floor has nothing to trip on that path.
 
 ## Consensus rules
 
@@ -133,6 +139,65 @@ judges ran", never "how many must agree", and there is no K to tune.
 The `_consensus.tied` flag is `true` when judges disagreed (i.e. at least
 one judge approved AND at least one blocked). It is descriptive — the
 verdict is already conservative under either rule.
+
+## Quorum floor (issue #3197)
+
+`compute_consensus` optionally accepts a keyword-only `expected_judges: int
+| None`, the size of the **mandatory declared roster** — today `2`
+(`code-quality`, `risk`) — and never the number of judges dispatched. The
+review skill passes `expected_judges=2`, derived from the same roster list
+it just iterated to dispatch, never a second hardcoded literal
+(`docs/sdlc/do-pr-review.md`'s Multi-Judge Consensus section).
+
+When fewer distinct judges report than the floor, `compute_consensus`
+refuses to run the rule and returns the conservative `CHANGES REQUESTED`
+outcome instead — the same outcome the zero-judge case already used,
+generalized into one shared builder (`_conservative_outcome`; there is no
+second builder and no orphaned `_empty_conservative_outcome` name). The
+consensus metadata carries two additive keys so the shortfall is recorded
+rather than merely inferable from `k`/`n`:
+
+| Key | Type | Meaning |
+|---|---|---|
+| `expected_n` | `int \| None` | The declared roster size the caller asserted, verbatim. `None` when the caller declared no expectation (every pre-#3197 call site). |
+| `quorum_shortfall` | `bool` | Always present. `True` iff `expected_n is not None and n < expected_n`. |
+
+**Optional judges are excluded by construction.** The cross-vendor judge
+(issue #1626) is designed to skip under normal operation — gate off,
+trivial diff, API failure. A skip means the parent appends nothing, so `n`
+legitimately sits at the mandatory roster size; that must satisfy the
+floor, not trip it. A cross-vendor *return* raises `n` above the floor and
+must not be penalized either. Both directions are tested in
+`tests/unit/test_review_multi_judge.py::TestComputeConsensusQuorumFloor`
+and `tests/unit/test_cross_vendor_orchestration.py`.
+
+**The guard's limit, stated plainly:** it compares cardinality only, never
+membership. `n < expected_judges` counts distinct `judge_id`s and never
+checks them against the declared roster's contents — a misnamed,
+substituted, or optional judge id satisfies the floor identically to a
+mandatory one. A shortfall proves under-reporting; a satisfied floor does
+not prove the declared roster specifically ran. Closing that gap would
+mean passing roster membership into the function, which moves roster
+ownership out of the caller and is deliberately out of scope.
+
+**A shortfall does not get a distinct verdict token.** It stays
+`CHANGES REQUESTED`, which routes the lane to `/do-patch` and re-dispatches
+the full roster at the next round — self-healing when the cause is
+transient. The cause actually observed (judges failing to spawn) can also
+be persistent, in which case `/do-patch` has no code defect to act on and
+the lane cycles REVIEW ⇄ `/do-patch` until the pipeline's round cap stops
+it. **`quorum_shortfall: true` recurring across consecutive REVIEW rounds
+on the same PR is the signature of a persistent judge-dispatch failure and
+warrants human escalation**, as distinct from a single-round shortfall the
+next round clears. That recurrence is not readable from a single
+`sdlc-tool verdict get` call — `record_verdict` overwrites
+`_verdicts["REVIEW"]` on every write (`tools/sdlc_verdict.py`'s `_apply`
+closure does `verdicts[stage] = record`), so the verdict record answers for
+the current round alone. The surface that actually accumulates is the run
+of aggregate `## Review:` PR comments, one posted per round (see
+[PR-comment ordering invariant](#pr-comment-ordering-invariant) below),
+each naming its own shortfall — that is where the across-rounds evidence
+lives.
 
 ## PR-comment ordering invariant
 
@@ -160,6 +225,12 @@ When multi-judge runs, the OUTCOME block records:
 
 These let operators grep session state for cost (judges-per-PR) and signal
 quality (disagreement rate) without a dedicated dashboard.
+
+On a quorum shortfall (see [Quorum floor](#quorum-floor-issue-3197) above),
+the artifacts instead carry `judges_run` and `quorum_shortfall: true`, and
+**omit `consensus_disagreement`** — that field derives from `tied`, which is
+only meaningful once the rule ran over a full roster, and the rule never
+runs on a shortfall.
 
 ## Back-compat
 

--- a/docs/plans/sdlc-3197.md
+++ b/docs/plans/sdlc-3197.md
@@ -292,17 +292,17 @@ No agent integration required. `compute_consensus` is invoked by the `/do-pr-rev
 
 ## Success Criteria
 
-- [ ] `compute_consensus` accepts a declared-roster size (`expected_judges`) and returns `CHANGES REQUESTED` instead of `APPROVED` when distinct reporting judges fall short of it.
-- [ ] The shortfall is recorded in consensus metadata as `quorum_shortfall` (bool, always present) and `expected_n`, not merely inferable from `k`/`n`.
-- [ ] The zero-judge and shortfall cases share one conservative-outcome builder; no second builder and no orphaned `_empty_conservative_outcome` name remain.
-- [ ] The intentional single-judge paths are covered by a test each: the trivial-diff check's single-judge path (asserted as a declaration-consistency property over the prose at `docs/sdlc/do-pr-review.md:250-254` — it never reaches `compute_consensus`, and there is no script to exercise) and the retired `SDLC_REVIEW_JUDGES` override (covered by the existing `tests/unit/test_review_judge_env_docs.py` guard, extended with an assertion pinning the retirement).
-- [ ] A legitimate cross-vendor skip does not trip the quorum, and a cross-vendor return at `n=3` against `expected_judges=2` does not either.
-- [ ] A test proves a 1-of-2 run cannot return `APPROVED`, and **fails when the guard is reverted** — mutation-checked, with the red output pasted into the PR description.
-- [ ] The `/do-pr-review` caller passes the declared roster size; the parameter name appears in the review skill's consensus instruction.
-- [ ] No change to roster size, round counts, or the `any-blocker-wins` rule itself.
-- [ ] Omitting `expected_judges` reproduces today's verdicts across the full existing test matrix.
-- [ ] Tests pass (`/do-test`)
-- [ ] Documentation updated (`/do-docs`)
+- [x] `compute_consensus` accepts a declared-roster size (`expected_judges`) and returns `CHANGES REQUESTED` instead of `APPROVED` when distinct reporting judges fall short of it.
+- [x] The shortfall is recorded in consensus metadata as `quorum_shortfall` (bool, always present) and `expected_n`, not merely inferable from `k`/`n`.
+- [x] The zero-judge and shortfall cases share one conservative-outcome builder; no second builder and no orphaned `_empty_conservative_outcome` name remain.
+- [x] The intentional single-judge paths are covered by a test each: the trivial-diff check's single-judge path (asserted as a declaration-consistency property over the prose at `docs/sdlc/do-pr-review.md:250-254` — it never reaches `compute_consensus`, and there is no script to exercise) and the retired `SDLC_REVIEW_JUDGES` override (covered by the existing `tests/unit/test_review_judge_env_docs.py` guard, extended with an assertion pinning the retirement).
+- [x] A legitimate cross-vendor skip does not trip the quorum, and a cross-vendor return at `n=3` against `expected_judges=2` does not either.
+- [x] A test proves a 1-of-2 run cannot return `APPROVED`, and **fails when the guard is reverted** — mutation-checked, with the red output pasted into the PR description.
+- [x] The `/do-pr-review` caller passes the declared roster size; the parameter name appears in the review skill's consensus instruction.
+- [x] No change to roster size, round counts, or the `any-blocker-wins` rule itself.
+- [x] Omitting `expected_judges` reproduces today's verdicts across the full existing test matrix.
+- [x] Tests pass (`/do-test`)
+- [x] Documentation updated (`/do-docs`)
 
 ## Team Orchestration
 

--- a/docs/sdlc/do-pr-review.md
+++ b/docs/sdlc/do-pr-review.md
@@ -245,13 +245,32 @@ expect:
 - The aggregate verdict is derived by `agent.sdlc_review_consensus.compute_consensus`
   with `rule="any-blocker-wins"` — any judge raising a blocker forces
   `CHANGES_REQUESTED`.
+- The parent passes `expected_judges=2` — the size of the mandatory declared
+  roster above, derived from the roster it just dispatched rather than from a
+  second hardcoded literal. Optional judges (the cross-vendor judge) are never
+  counted toward `expected_judges`: an optional judge that returns can only
+  raise `n` above the floor, and one that skips leaves the floor exactly where
+  it was. When fewer distinct judges report than `expected_judges`,
+  `compute_consensus` refuses `APPROVED` and returns `CHANGES REQUESTED` with
+  `quorum_shortfall: true` in the consensus metadata — a degraded single-judge
+  run is recorded as a shortfall, never read back as agreement. The aggregate
+  `## Review:` comment must state the shortfall explicitly rather than posting
+  a bare `CHANGES REQUESTED`.
 - The OUTCOME block includes `judges_run` (int) and `consensus_disagreement` (bool)
-  side-fields when multi-judge runs.
+  side-fields when multi-judge runs. On a `quorum_shortfall`, the artifacts
+  instead carry `judges_run` and `quorum_shortfall: true`, and omit
+  `consensus_disagreement` — that field derives from `tied`, which is only
+  meaningful once the rule has run over a full roster, and the rule never ran
+  on a shortfall. The `notes` field names the degraded run in its first
+  clause (e.g. "1 of 2 judges reported").
 - Cost containment: trivial PRs force the legacy single-judge path. A PR is
   trivial when its changed files (`gh pr diff $PR_NUMBER --name-only`) are all
   docs (`docs/**`, `**/*.md`) or all lockfile sync (`uv.lock` /
   `pyproject.toml` only). This is the only cost control on this surface, and
-  it needs no operator action.
+  it needs no operator action. This path never calls `compute_consensus` at
+  all — it posts one judge's verdict directly, with no `judges`/`consensus`
+  kwargs on `record_verdict` and no `judges_run` in its OUTCOME — so the
+  quorum floor above does not apply to it and needs no exemption.
 
 Full design: [`docs/features/multi-judge-consensus.md`](../features/multi-judge-consensus.md).
 

--- a/tests/unit/test_cross_vendor_orchestration.py
+++ b/tests/unit/test_cross_vendor_orchestration.py
@@ -65,6 +65,32 @@ class TestSkipEnvelopeNeverReachesComputeConsensus:
         assert result["verdict"] == "CHANGES REQUESTED"
         assert result["consensus"]["n"] == 0
 
+    def test_cross_vendor_skip_alongside_full_roster_satisfies_quorum(self):
+        """The cross-vendor judge skipping (its normal behavior when the gate
+        is off, the diff is trivial, or the API call fails) must never turn a
+        healthy two-judge roster into a quorum shortfall (issue #3197). Only
+        the two mandatory roster dicts reach compute_consensus here — the
+        cross-vendor envelope's skip means the parent appended nothing."""
+        judges = [
+            {
+                "judge_id": "code-quality",
+                "verdict": "APPROVED",
+                "blockers": 0,
+                "tech_debt": 0,
+                "confidence": 0.9,
+            },
+            {
+                "judge_id": "risk",
+                "verdict": "APPROVED",
+                "blockers": 0,
+                "tech_debt": 0,
+                "confidence": 0.9,
+            },
+        ]
+        result = compute_consensus(judges, rule="any-blocker-wins", expected_judges=2)
+        assert result["verdict"] == "APPROVED"
+        assert result["consensus"]["quorum_shortfall"] is False
+
 
 # ---------------------------------------------------------------------------
 # Validation layer — skip envelope dicts rejected before record_verdict

--- a/tests/unit/test_review_judge_env_docs.py
+++ b/tests/unit/test_review_judge_env_docs.py
@@ -98,6 +98,17 @@ def test_documented_review_env_vars_have_a_settings_field():
     )
 
 
+def test_sdlc_review_judges_stays_retired():
+    """Pin the retirement (#2831) so the quorum-floor fix (#3197) cannot
+    quietly re-introduce SDLC_REVIEW_JUDGES as an untested single-judge
+    override. This is stronger than the positive predicate above (which
+    would also pass if the name came back WITH a settings field) — the
+    override is retired outright, not merely wired up."""
+    found = _scan(SCANNED_DOCS)
+    assert "SDLC_REVIEW_JUDGES" not in found
+    assert "SDLC_REVIEW_K" not in found
+
+
 def test_scanned_docs_exist():
     """Guard the guard: a rename must not make the check vacuously pass."""
     for path in SCANNED_DOCS:

--- a/tests/unit/test_review_multi_judge.py
+++ b/tests/unit/test_review_multi_judge.py
@@ -83,6 +83,24 @@ class TestComputeConsensusAnyBlockerWins:
         assert meta["tied"] is False
         assert meta["mean_confidence"] == pytest.approx(0.85)
 
+    def test_omitting_expected_judges_preserves_todays_verdict(self):
+        """Back-compat contract: expected_judges defaults to None, which must
+        reproduce today's verdict across the existing matrix rather than being
+        assumed. Pinned here for the single-judge case explicitly."""
+        judges = [
+            {
+                "judge_id": "code-quality",
+                "verdict": "APPROVED",
+                "blockers": 0,
+                "tech_debt": 0,
+                "confidence": 0.9,
+            },
+        ]
+        result = compute_consensus(judges, rule="any-blocker-wins")
+        assert result["verdict"] == "APPROVED"
+        assert result["consensus"]["quorum_shortfall"] is False
+        assert result["consensus"]["expected_n"] is None
+
     def test_split_one_blocker_returns_changes_requested(self):
         judges = [
             {
@@ -202,6 +220,11 @@ class TestComputeConsensusEdgeCases:
         assert result["verdict"] == "CHANGES REQUESTED"
         assert result["blockers"] >= 1
         assert result["consensus"]["n"] == 0
+        # The zero-judge and shortfall paths now share one outcome builder,
+        # so the metadata keys are unconditionally present even with no
+        # expectation stated.
+        assert result["consensus"]["expected_n"] is None
+        assert result["consensus"]["quorum_shortfall"] is False
 
     def test_duplicate_judge_id_last_wins(self):
         judges = [
@@ -224,6 +247,32 @@ class TestComputeConsensusEdgeCases:
         # Dedup: only the LAST entry for code-quality counts.
         assert result["verdict"] == "CHANGES REQUESTED"
         assert result["consensus"]["n"] == 1
+
+    def test_duplicate_judge_id_collapse_trips_quorum(self):
+        """Two dicts under one judge_id must count as ONE distinct judge for
+        the quorum floor, not two — otherwise a retry that reported twice
+        under one id would satisfy a quorum of two."""
+        judges = [
+            {
+                "judge_id": "code-quality",
+                "verdict": "APPROVED",
+                "blockers": 0,
+                "tech_debt": 0,
+                "confidence": 0.5,
+            },
+            {
+                "judge_id": "code-quality",
+                "verdict": "APPROVED",
+                "blockers": 0,
+                "tech_debt": 0,
+                "confidence": 0.9,
+            },
+        ]
+        result = compute_consensus(judges, rule="any-blocker-wins", expected_judges=2)
+        assert result["verdict"] == "CHANGES REQUESTED"
+        assert result["consensus"]["n"] == 1
+        assert result["consensus"]["quorum_shortfall"] is True
+        assert result["consensus"]["expected_n"] == 2
 
     def test_deterministic_sort_by_judge_id(self):
         # Reverse order in input should not change output (sorted alphabetically).
@@ -268,6 +317,101 @@ class TestComputeConsensusEdgeCases:
         ]
         with pytest.raises(ValueError):
             compute_consensus(judges, rule="bogus-rule")
+
+
+# ---------------------------------------------------------------------------
+# compute_consensus — quorum floor (expected_judges), issue #3197
+# ---------------------------------------------------------------------------
+
+
+def _judge(judge_id: str, *, verdict: str = "APPROVED", blockers: int = 0) -> dict:
+    return {
+        "judge_id": judge_id,
+        "verdict": verdict,
+        "blockers": blockers,
+        "tech_debt": 0,
+        "confidence": 0.9,
+    }
+
+
+class TestComputeConsensusQuorumFloor:
+    def test_one_of_two_returns_changes_requested_with_shortfall(self):
+        """The mutation target: a single APPROVED judge against a declared
+        roster of two must never read back as consensus."""
+        judges = [_judge("code-quality")]
+        result = compute_consensus(judges, expected_judges=2)
+        assert result["verdict"] == "CHANGES REQUESTED"
+        assert result["consensus"]["quorum_shortfall"] is True
+        assert result["consensus"]["expected_n"] == 2
+        assert result["consensus"]["n"] == 1
+
+    def test_same_input_omitting_expected_judges_still_approves(self):
+        """Back-compat: the identical single-judge input approves when the
+        caller states no expectation — pinning that the default changes
+        nothing."""
+        judges = [_judge("code-quality")]
+        result = compute_consensus(judges)
+        assert result["verdict"] == "APPROVED"
+        assert result["consensus"]["quorum_shortfall"] is False
+
+    def test_zero_judges_with_expectation_is_conservative_shortfall(self):
+        result = compute_consensus([], expected_judges=2)
+        assert result["verdict"] == "CHANGES REQUESTED"
+        assert result["consensus"]["n"] == 0
+        assert result["consensus"]["expected_n"] == 2
+        assert result["consensus"]["quorum_shortfall"] is True
+
+    def test_zero_judges_no_expectation_unchanged_conservative(self):
+        result = compute_consensus([])
+        assert result["verdict"] == "CHANGES REQUESTED"
+        assert result["consensus"]["expected_n"] is None
+        assert result["consensus"]["quorum_shortfall"] is False
+
+    def test_quorum_satisfied_exactly_at_floor(self):
+        judges = [_judge("code-quality"), _judge("risk")]
+        result = compute_consensus(judges, expected_judges=2)
+        assert result["verdict"] == "APPROVED"
+        assert result["consensus"]["quorum_shortfall"] is False
+        assert result["consensus"]["n"] == 2
+
+    def test_quorum_satisfied_above_floor_cross_vendor_return(self):
+        """A cross-vendor judge that returns raises n above the mandatory
+        floor and must not be penalized for it."""
+        judges = [_judge("code-quality"), _judge("risk"), _judge("cross-vendor")]
+        result = compute_consensus(judges, expected_judges=2)
+        assert result["verdict"] == "APPROVED"
+        assert result["consensus"]["quorum_shortfall"] is False
+        assert result["consensus"]["n"] == 3
+
+    def test_cross_vendor_skip_still_satisfies_quorum(self):
+        """A cross-vendor skip means the parent never appends its dict, so
+        n legitimately sits at exactly the mandatory roster size. This must
+        NOT be treated as a shortfall."""
+        judges = [_judge("code-quality"), _judge("risk")]  # no cross-vendor dict
+        result = compute_consensus(judges, expected_judges=2)
+        assert result["verdict"] == "APPROVED"
+        assert result["consensus"]["quorum_shortfall"] is False
+
+    def test_expected_judges_one_with_one_judge_satisfied(self):
+        """Pins that the comparison reads the *parameter*, not a hardcoded
+        2 — a guard written as `n < 2` would pass every other case in this
+        class and fail only here."""
+        judges = [_judge("code-quality")]
+        result = compute_consensus(judges, expected_judges=1)
+        assert result["verdict"] == "APPROVED"
+        assert result["consensus"]["quorum_shortfall"] is False
+        assert result["consensus"]["expected_n"] == 1
+
+    @pytest.mark.parametrize("bad", [0, -1, 2.5, True, "2"])
+    def test_invalid_expected_judges_raises_value_error(self, bad):
+        judges = [_judge("code-quality")]
+        with pytest.raises(ValueError):
+            compute_consensus(judges, expected_judges=bad)
+
+    def test_none_expected_judges_is_valid_and_is_the_default(self):
+        judges = [_judge("code-quality")]
+        result = compute_consensus(judges, expected_judges=None)
+        assert result["consensus"]["quorum_shortfall"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -367,6 +511,39 @@ class TestRecordVerdictWithJudges:
         # Either reject outright OR write scalar without side-fields.
         # Spec: reject (return {}) so callers can't accidentally fork CRITIQUE shape.
         assert result == {}
+
+    def test_quorum_shortfall_consensus_survives_record_verdict_round_trip(
+        self, fake_session_reload_patched
+    ):
+        """A shortfall consensus dict persists intact through record_verdict —
+        record_verdict schema-validates only the `judges` list, so the two
+        new metadata keys cannot be dropped by validation."""
+        session = fake_session_reload_patched
+        judges = [
+            {
+                "judge_id": "code-quality",
+                "verdict": "APPROVED",
+                "blockers": 0,
+                "tech_debt": 0,
+                "confidence": 0.9,
+            },
+        ]
+        consensus_meta = compute_consensus(judges, expected_judges=2)["consensus"]
+        assert consensus_meta["quorum_shortfall"] is True
+        record = record_verdict(
+            session,
+            "REVIEW",
+            "CHANGES REQUESTED",
+            blockers=1,
+            tech_debt=0,
+            judges=judges,
+            consensus=consensus_meta,
+        )
+        assert record["verdict"] == "CHANGES REQUESTED"
+        data = json.loads(session.stage_states)
+        review = data["_verdicts"]["REVIEW"]
+        assert review["_consensus"]["quorum_shortfall"] is True
+        assert review["_consensus"]["expected_n"] == 2
 
 
 # ---------------------------------------------------------------------------
@@ -500,6 +677,41 @@ class TestCrossVendorJudgeConsensus:
         from tools.cross_vendor_judge import CROSS_VENDOR_JUDGE_ID
 
         assert CROSS_VENDOR_JUDGE_ID not in {"code-quality", "risk"}
+
+
+# ---------------------------------------------------------------------------
+# Trivial-diff path never reaches compute_consensus (issue #3197, spike-1)
+# ---------------------------------------------------------------------------
+
+
+class TestTrivialDiffPathDoesNotReachQuorumGuard:
+    """The trivial-diff check is inline prose applied by the executing agent
+    at docs/sdlc/do-pr-review.md:250-254 -- there is no shape-classifier
+    module to import or exempt (scripts/pr_shape_classify.py was deleted by
+    #2378). This is the honest testable property: the prose forces the
+    legacy single-judge path, and the outcome contract forbids the
+    consensus side-fields there, so the quorum floor inside
+    compute_consensus cannot fire on that path without ever being called."""
+
+    def test_no_shape_classifier_module_exists(self):
+        import importlib.util
+
+        assert importlib.util.find_spec("scripts.pr_shape_classify") is None
+
+    def test_do_pr_review_doc_declares_trivial_diff_forces_legacy_path(self):
+        import pathlib
+
+        doc = pathlib.Path("docs/sdlc/do-pr-review.md").read_text()
+        assert "trivial" in doc.lower()
+        assert "single-judge" in doc.lower() or "legacy" in doc.lower()
+
+    def test_outcome_contract_forbids_consensus_fields_on_single_judge_path(self):
+        import pathlib
+
+        doc = pathlib.Path(
+            ".claude/skills-global/do-pr-review/sub-skills/outcome-contract.md"
+        ).read_text()
+        assert "MUST NOT include these fields" in doc
 
 
 class TestRecordVerdictCLIShape:

--- a/tests/unit/test_review_multi_judge.py
+++ b/tests/unit/test_review_multi_judge.py
@@ -686,7 +686,8 @@ class TestCrossVendorJudgeConsensus:
 
 class TestTrivialDiffPathDoesNotReachQuorumGuard:
     """The trivial-diff check is inline prose applied by the executing agent
-    at docs/sdlc/do-pr-review.md:250-254 -- there is no shape-classifier
+    -- the "Cost containment" bullet in docs/sdlc/do-pr-review.md's
+    Multi-Judge Consensus section -- there is no shape-classifier
     module to import or exempt (scripts/pr_shape_classify.py was deleted by
     #2378). This is the honest testable property: the prose forces the
     legacy single-judge path, and the outcome contract forbids the


### PR DESCRIPTION
## Summary

`compute_consensus` learns how many judges were *declared* (`expected_judges`, a keyword-only parameter naming the mandatory roster size — never the number dispatched, never inclusive of optional judges) and refuses `APPROVED` when fewer distinct judges report than that floor. The zero-judge and shortfall cases now share one conservative-outcome builder (`_conservative_outcome`, replacing `_empty_conservative_outcome` with no alias). The shortfall is recorded in consensus metadata as `expected_n` / `quorum_shortfall` rather than being merely inferable from `k`/`n`.

The REVIEW caller (`docs/sdlc/do-pr-review.md`) now passes `expected_judges=2`, derived from the same two-judge roster it dispatches. The optional cross-vendor judge is excluded from that count by definition, so a legitimate skip never trips the floor.

Closes #3197

## Changes

- `agent/sdlc_review_consensus.py` — quorum floor, shared conservative-outcome builder, validated `expected_judges` parameter, docstrings.
- `docs/sdlc/do-pr-review.md` — caller states `expected_judges=2` and the shortfall behavior.
- `.claude/skills-global/do-pr-review/sub-skills/outcome-contract.md` — shortfall OUTCOME variant.
- `tests/unit/test_review_multi_judge.py`, `tests/unit/test_cross_vendor_orchestration.py`, `tests/unit/test_review_judge_env_docs.py` — guard tests, cross-vendor-skip coverage, `SDLC_REVIEW_JUDGES` retirement pin.
- `docs/features/multi-judge-consensus.md` — Quorum floor section, updated Cost Containment / Monitoring.

## Mutation check (Task 4, plan `docs/plans/sdlc-3197.md`)

Each guard mutated separately, sole ownership of the checkout for the duration, restored and re-verified green after each.

**Mutation 1 — deleted the shortfall comparison:**
```
FAILED tests/unit/test_review_multi_judge.py::TestComputeConsensusEdgeCases::test_duplicate_judge_id_collapse_trips_quorum
FAILED tests/unit/test_review_multi_judge.py::TestComputeConsensusQuorumFloor::test_one_of_two_returns_changes_requested_with_shortfall
FAILED tests/unit/test_review_multi_judge.py::TestRecordVerdictWithJudges::test_quorum_shortfall_consensus_survives_record_verdict_round_trip
3 failed, 38 passed in 9.95s
```

**Mutation 2 — gutted `_validate_expected_judges` to a no-op:**
```
FAILED tests/unit/test_review_multi_judge.py::TestComputeConsensusQuorumFloor::test_invalid_expected_judges_raises_value_error[0]
FAILED tests/unit/test_review_multi_judge.py::TestComputeConsensusQuorumFloor::test_invalid_expected_judges_raises_value_error[-1]
FAILED tests/unit/test_review_multi_judge.py::TestComputeConsensusQuorumFloor::test_invalid_expected_judges_raises_value_error[2.5]
FAILED tests/unit/test_review_multi_judge.py::TestComputeConsensusQuorumFloor::test_invalid_expected_judges_raises_value_error[True]
FAILED tests/unit/test_review_multi_judge.py::TestComputeConsensusQuorumFloor::test_invalid_expected_judges_raises_value_error[2]
5 failed, 36 passed in 10.93s
```

**Mutation 3 — hardcoded `quorum_shortfall` metadata key to `False`:**
```
FAILED tests/unit/test_review_multi_judge.py::TestComputeConsensusEdgeCases::test_duplicate_judge_id_collapse_trips_quorum
FAILED tests/unit/test_review_multi_judge.py::TestComputeConsensusQuorumFloor::test_one_of_two_returns_changes_requested_with_shortfall
FAILED tests/unit/test_review_multi_judge.py::TestComputeConsensusQuorumFloor::test_zero_judges_with_expectation_is_conservative_shortfall
FAILED tests/unit/test_review_multi_judge.py::TestRecordVerdictWithJudges::test_quorum_shortfall_consensus_survives_record_verdict_round_trip
4 failed, 37 passed in 10.31s
```

Guard restored after each mutation; `git diff` against the pre-mutation commit was empty. Final state: 54/54 passed across the three affected test files.

## Verification

Full plan Verification table run via `agent.verification_parser` — **15/15 checks passed**, 0 malformed rows:

```
[PASS] Consensus unit tests pass
[PASS] Cross-vendor orchestration tests pass
[PASS] Judge env-var doc guard passes
[PASS] Lint clean
[PASS] Format clean
[PASS] Quorum parameter exists
[PASS] Shortfall recorded in metadata
[PASS] One conservative-outcome builder (no orphaned name)
[PASS] Caller passes the declared roster size
[PASS] 1-of-2 guard test exists by name
[PASS] (anti-criterion) `any-blocker-wins` rule body unchanged
[PASS] (anti-criterion) Rule set unchanged — no new rule introduced
[PASS] (anti-criterion) Roster still declares both judges
[PASS] (anti-criterion) No K-of-N threshold reintroduced
[PASS] (anti-criterion) Retired env override stays retired
```

## Full unit suite

`scripts/pytest-clean.sh tests/unit/ -q`: **15430 passed, 6 failed, 7 skipped** (18m47s). The 6 failures (`test_session_archive.py`, `test_checkout_pin.py`, `test_agentsession_pending_index_leak.py`, `test_agentsession_index_guard_generalized.py` ×2, `test_should_store_inbound.py`) reference none of the files this PR touches and match the known test-DB-pool-exhaustion signature from concurrent agents sharing this machine (several other worktrees were active during this run). `compute_consensus` has no Python caller repo-wide outside tests, confirmed by grep, so the blast radius of this change is exactly the three test files exercised above plus prose.

## Documentation

`scripts/validate_docs_changed.py` passed: `docs/features/multi-judge-consensus.md`, `docs/sdlc/do-pr-review.md`, `.claude/skills-global/do-pr-review/sub-skills/outcome-contract.md`.
