### PR TITLE
Reconcile Codex dev-lane plan with skills and durability foundations

### DIFF
--- a/docs/plans/codex-exec-dev-lane.md
+++ b/docs/plans/codex-exec-dev-lane.md
@@ -5,7 +5,8 @@ appetite: Large
 owner: Valor Engels
 created: 2026-07-13
 tracking: https://github.com/tomcounsell/ai/issues/2001
-last_comment_id: 4952368338
+last_comment_id: 5087021248
+reconciled: 2026-09-07
 ---
 
 # Phase 3: Codex Exec as Opt-in Dev-Lane Executor Within Eng Sessions
@@ -35,53 +36,42 @@ the explicit flag, behavior and tool exposure are unchanged.
 
 ## Freshness Check
 
-**Baseline commit:** `c8bef664746fe362fc677ea83cf61a1c5fa92e9e`
-**Issue filed at:** `2026-07-10T06:26:32Z`
-**Disposition:** Minor drift
+**Reconciled:** 2026-09-07
+**Baseline commit:** `d5633bb238e4ff5a061342eeb0f62c540dc8d12a`
+**Disposition:** Update dependencies and durability contracts before implementation.
 
-**File:line references re-verified:**
-- `agent/session_runner/runner.py:1314-1342` — the issue's former
-  `runner.py:1249-1277` reference drifted; Dev identity is still captured by a
-  post-turn sidechain scan and persisted as `dev_agent_id`.
-- `models/agent_session.py:232-252` — the four-scalar Claude resume contract
-  remains; it has no Codex dev-lane selection, thread, version, or turn-count
-  fields.
-- `agent/session_runner/router.py:22-29,61-69` — the schema intentionally has no
-  external `dev` route because Claude Dev runs inline.
-- `agent/session_runner/role_driver.py:417-470` — every top-level turn still
-  constructs `ClaudeHarnessAdapter`; this is the invariant Phase 3 must retain.
-- `.claude/commands/roles/prime-pm-role.md:13-37` — the PM still delegates
-  implementation through `Agent(dev)` and is not taught a Codex tool.
+- #1996 Phases 1 and 2 are complete; #2000 shipped the adapter seam via #2038.
+  `agent/session_runner/harness/base.py` exposes synchronous live callbacks,
+  normalized results, and the existing `ExitReason`. There is still no
+  `agent/session_runner/harness/codex.py` on main.
+- [PR #3213](https://github.com/tomcounsell/ai/pull/3213) is open/unmerged at
+  head `671fc1c874bffd5c8f45a551801477829e5f008e`. It provides 57 native
+  skills (14 project, 43 general), AGENTS.md, scoped installation, and drift
+  validation. Its reported offline validation does not prove headless SDLC
+  execution or runtime enforcement. Landing it is a pilot prerequisite, not
+  a prerequisite to isolated adapter development.
+- [#2494's owner decisions](https://github.com/tomcounsell/ai/issues/2494#issuecomment-5142251045)
+  supersede the original issue sketch: no AgentRun model; execution records
+  stay on AgentSession. Promises are PM-authored/discharged Job goal versions,
+  not a separate obligation ledger.
+- `models/agent_session.py` now owns `exec_pid`, `pid_create_time`,
+  `exec_cwd`, `exec_harness`, and append-only `spawn_history`.
+  `live_fence` selects its newest record. Codex must not replace the live
+  Claude PM fence while both processes exist.
+- The [durability plan](durability-room-job-agentrun.md) records shipped M1,
+  Room foundations (#2622), and Job foundations (#2631).
+  `bridge/room_inbox.py` still declares shadow append/routing; the live intake
+  calls these alongside existing dispatch. Authoritative inbox dispatch and
+  legacy-path retirement remain separately gated #2494 releases.
+- Top-level Claude-only execution and blocking developer delegation remain
+  the scope constraints from #1924/#1928/#2001. Non-harness classifiers remain
+  outside this feature; do not reverse #2494's later granite/PydanticAI decision.
+- The earlier 0.144.3 probe is evidence for that exact build and host only.
+  Binary, login, worktree, skill discovery, and current CLI behavior must be
+  checked on the selected worker; this reconciliation did not run live probes.
 
-**Cited sibling issues/PRs re-checked:**
-- #1996 remains open as the three-phase umbrella; its Phase 3 delegates to this
-  issue and is coordination context, not a competing implementation plan.
-- #2000 is closed/completed by merged PR #2038. The `HarnessAdapter` protocol,
-  normalized events, and schema-first Claude routing are now on main.
-- #1925 is closed/completed. Its harness half shipped in #2038 and its
-  two-transport rule is settled: Codex Dev is a harness subprocess, never a
-  PydanticAI call.
-- #1924 and #1928 are closed/completed. Their owner-approved topology is one
-  top-level Claude PM with an in-turn, blocking Dev lane and persisted resume
-  identity.
-
-**Commits on main since issue filing that changed the premise:**
-- `347882f2` (PR #2038) delivered the adapter seam and Claude schema routing —
-  it clears the code prerequisite rather than solving the Codex lane.
-- `1a23e1e8` pruned AgentSession fields but retained the Claude resume quartet;
-  the new Codex fields must follow the nullable-field and migration conventions
-  now on main.
-- `e1ec8695` centralized settings literals; Codex version/sandbox/resume limits
-  therefore belong in typed settings rather than adapter constants.
-
-**Active plans overlapping this area:** `harness-cross-compat.md` is the parent
-program plan and explicitly assigns Phase 3 to #2001. No other active plan
-implements a Codex dev lane.
-
-**Notes:** The issue's 2026-07-13 comment said the machine lacked Codex and auth.
-That is now stale: `codex-cli 0.144.3` is installed and `codex login status`
-reports ChatGPT authentication. The premise is unchanged and the human gate is
-cleared.
+The reconciliation changes this plan only. It does not mark implementation,
+deployment, fault-injection, or the durability cutover as complete.
 
 ## Prior Art
 
@@ -129,11 +119,11 @@ cleared.
   `thread_id=019f5a7e-339a-7323-bf14-1d30931abc86`; the final schema object was
   JSON text in `item.completed{type=agent_message}`; `turn.completed` carried
   usage. Resume accepted `--strict-config -c sandbox_mode="read-only"` and
-  `--output-schema`. Input context grew from 14,429 to 28,894 tokens, confirming
-  the need for a bounded-resume guard.
+  `--output-schema`. Input context grew from 14,429 to 28,894 tokens across these two turns.
+  This supports a conservative provisional guard; it does not establish that
+  current Codex builds lack compaction.
 - **Confidence**: high
-- **Impact on plan**: Parse final agent-message JSON, pin the verified minimum
-  CLI to `0.144.3`, repeat explicit approval/sandbox/cwd globals on resume, and
+- **Impact on plan**: Parse final agent-message JSON, use `0.144.3` as the recorded baseline pending the worker contract gate, repeat explicit approval/sandbox/cwd globals on resume, and
   persist a turn count with a hard, actionable guard rather than silent rollover.
 
 ### spike-2: Choose the PM-facing integration mechanism
@@ -179,7 +169,7 @@ cleared.
    prime replaces only the `Agent(dev)` instructions; research subagents and
    final StructuredOutput routing remain unchanged.
 4. **PM delegation:** the PM invokes `codex_dev.run` with the literal developer
-   instruction. The stateless MCP handler resolves `AGENT_SESSION_ID`, verifies
+   instruction. The MCP handler, with durable state owned by AgentSession, resolves `AGENT_SESSION_ID`, verifies
    `session_type=eng` and `dev_harness=codex`, acquires the session's dev-lane
    lease, and reads the persisted Codex context.
 5. **First Codex turn:** `CodexHarnessAdapter` runs `codex` with global
@@ -192,13 +182,15 @@ cleared.
 7. **Later turns:** the handler invokes `codex ... exec resume <thread_id>
    --json --output-schema <temp-file> -`, repeating approval/sandbox/cwd globals.
    A stable id is asserted; drift is logged and returned as an actionable error.
-8. **Return to PM:** the adapter maps usage/failure into `TurnResult`, decodes
-   the final schema-valid report, and the MCP tool returns it to the same Claude
-   PM turn. The PM then routes `user`, `complete`, or continues normally.
-9. **Steering/restart:** steering terminates the Claude process group, including
-   its MCP server and Codex child. The already-persisted thread is reintroduced
-   by the Codex PM prime on the next Claude resume. Worker restart follows the
-   same persisted path.
+8. **Return to PM:** the adapter maps usage/failure into `TurnResult` and
+   decodes the final schema-valid report. The handler persists the invocation
+   outcome and artifact references before returning it to the same Claude PM
+   turn; an interrupted return can be recovered by invocation id. The PM then routes `user`, `complete`, or continues normally.
+9. **Steering/restart:** steering terminates and reaps the owned process tree.
+   The next PM turn first reconciles the durable invocation: return a stored
+   result, inspect interrupted work, or resume the exact saved thread. Worker
+   restart follows the same path; process-group membership and orphan handling
+   are verified by the ownership gate below.
 
 ## Architectural Impact
 
@@ -213,9 +205,11 @@ cleared.
 - **Data ownership:** `AgentSession` owns selection and continuity. The PM model
   cannot select/switch the harness, and Codex rollout files are not the source
   of application truth.
-- **Reversibility:** Omit/disable the creation flag and update opt-in to return to
-  the Claude lane. Nullable fields and the MCP server can remain dormant during
-  rollback; no destructive migration is required.
+- **Reversibility:** Disable new Codex selections; existing Codex lanes retain
+  their worktrees, transcripts, reports, and handles for drain or explicit
+  recovery. Never reinterpret a Codex handle as a Claude handle or silently
+  change an active lane. Provisioning rollback must not uninstall a CLI needed
+  by retained sessions.
 
 ## Appetite
 
@@ -231,16 +225,110 @@ The appetite is driven by a security-sensitive subprocess boundary, persistent
 cross-process continuity, a new agent tool surface, update propagation, and a
 real multi-turn validation—not by the adapter's raw line count.
 
+## Reliability Contracts and Release Gates
+
+### Skills and enforcement
+
+Land #3213 before the live pilot and record the installed skill manifest revision.
+Run its collection check and exercise discovery in the actual worker worktree,
+including user-installed general skills. Inventory required SDLC tools, credentials,
+resources, and interactive-only procedures. A required missing capability blocks
+that operation with an actionable error; do not assume desktop tools are available
+in headless exec.
+
+For every mandatory Claude-hook invariant used by this lane, name its executable
+Codex-side enforcement point and a negative test. Use the shared SDLC/tool boundary
+or an equivalent restrictive runtime policy. A final acceptance check is sufficient
+only for reversible output validation; prohibited writes must be prevented before
+they happen. Skill prose is not enforcement. Optional enrichment/telemetry may
+fail observably; authorization and required validation may not fail open.
+
+### PM ownership and durable dev invocations
+
+Keep AgentSession's existing live execution fence and spawn history owned by the
+Claude PM. Do not call `stamp_execution_spawn` on that record for the concurrent
+Codex child. Record dev invocation identity separately in nullable, non-indexed
+AgentSession-owned state, with atomic ORM updates; do not introduce AgentRun or a
+second top-level session. The schema gate must specify storage, retention, and
+queue-recreation behavior before builders add fields.
+
+Each invocation records a stable request id, parent session/owner generation,
+request fingerprint, state, thread id when known, child pid/create-time/pgid,
+worktree, CLI version, timestamps, and outcome/artifact references. The PM retries
+or retrieves using the same request id. A different payload under that id is an
+error. Persist intent before spawn and the validated result before MCP return;
+acknowledge PM consumption durably so restart can reinject an unconsumed report.
+Retain completed reports until consumption and the job's recovery/retention policy
+permit cleanup. Keep request content out of telemetry.
+
+Use the PM child/process-group handle as the primary cancellation authority and
+child identity as recovery evidence. `(pid, create_time)` is best-effort detection
+on macOS, not a race-free guarantee. Confirm death/reap before takeover or worktree
+cleanup. Test descendants that change process groups; `start_new_session=False`
+alone is not proof that every descendant is covered.
+
+The dev-lane lease needs an ownership token/generation, renewal while running,
+bounded acquisition, and compare-owner release. Expiry alone never authorizes a
+second writer: reconcile and reap the previous child first. Old owners cannot
+publish results or release a successor's lease. Implement through the repository's
+ORM-supported atomic operations and preserve existing index/repair conventions.
+
+Thread-id persistence is a durability barrier. If it fails, stop/reap the child
+and leave the invocation visibly interrupted. A crash before the first handle is
+saved is uncertain execution, not evidence that nothing happened. Reconcile the
+worktree and retained local run evidence before retry; never choose `resume --last`
+or silently manufacture a replacement thread. Preserve Codex session storage as
+well as the id, and fail explicitly if it or the worktree is missing. No portable
+cross-harness or cross-machine resume is promised by storing an id alone.
+
+A crash after side effects but before result persistence cannot guarantee exactly
+once execution. Recovery must inspect artifacts and external side-effect evidence,
+then resume/reconcile or request operator action. Do not blindly replay the task.
+
+### Completion and rollout
+
+`turn.completed`, exit 0, and schema-valid JSON establish turn success only.
+The PM accepts artifact/test evidence before reporting development completion.
+User delivery is successful only after the existing delivery path confirms it;
+failed delivery remains outstanding. Active children, interrupted invocations,
+unconsumed reports, and unsaved work block destructive worktree cleanup.
+
+Two release gates apply:
+
+1. **Supervised pilot (#2001):** translated skills available; required enforcement
+   proven; adapter/ownership/recovery tests pass; one manually selected worker
+   completes the live lifecycle. This may precede authoritative Room dispatch.
+2. **End-to-end reliability and expansion (#2494 + #1996):** all intake/recovery
+   paths use the authoritative durable inbox and Job binding, with pending-message
+   retention/backpressure, idempotent recovery, confirmed delivery, and legacy-path
+   retirement validated under #2494. Shadow parity is a prerequisite, not the
+   durability barrier. This plan does not implement that shared cutover.
+
+Before collecting canary results, record a matched Claude-dev/Codex-dev workload,
+sample size, observation window, and acceptable completion-rate difference. Use
+identical artifact acceptance criteria. Report accepted completion, restart recovery,
+manual interventions, duplicate execution, silent loss, latency, and usage by
+harness and CLI/skill revision. Unknown subscription cost stays unknown, not zero.
+Zero observed silent loss, concurrent writers, or destructive cleanup is a hard
+release gate, not a claim of zero future probability. Fault-injection coverage is
+mandatory even if ordinary canary jobs all succeed. A missing recovery-monitor
+heartbeat must itself alert through a live production caller.
+
 ## Prerequisites
 
 | Requirement | Check Command | Purpose |
 |-------------|---------------|---------|
-| Codex CLI 0.144.3+ | `python -c "import re,subprocess; s=subprocess.check_output(['codex','--version'],text=True); v=tuple(map(int,re.search(r'(\d+)\.(\d+)\.(\d+)',s).groups())); assert v >= (0,144,3)"` | Verified JSONL/schema/resume contract |
+| Codex CLI 0.144.3+ | `python -c "import re,subprocess; s=subprocess.check_output(['codex','--version'],text=True); v=tuple(map(int,re.search(r'(\d+)\.(\d+)\.(\d+)',s).groups())); assert v >= (0,144,3)"` | Preliminary floor; exact-build probe required |
 | Codex auth | `python -c "import os,subprocess; assert os.getenv('CODEX_API_KEY') or subprocess.run(['codex','login','status'],capture_output=True).returncode == 0"` | Headless turns cannot open an interactive login |
 | Phase 2 seam | `python -c "from agent.session_runner.harness.base import HarnessAdapter,TurnRequest,TurnResult"` | Required adapter protocol is present |
 | Git worktree | `git rev-parse --is-inside-work-tree` | Codex refuses non-repository roots by default |
 
 Run with `python scripts/check_prerequisites.py docs/plans/codex-exec-dev-lane.md`.
+The numeric floor and credential-presence check are preliminary only: the worker
+contract gate must probe the exact selected CLI build, usable auth, first/resume
+schema and sandbox behavior, process ownership, and required skill/tool discovery.
+Record the validated version in typed settings; a newer version is not automatically
+compatible merely because it exceeds the floor.
 
 ## Solution
 
@@ -281,7 +369,7 @@ continues** → later turn/restart resumes the same Codex thread.
 - Add a stateless FastMCP server under `mcp_servers/`. Resolve
   `AGENT_SESSION_ID` per call, enforce the persisted capability and eng type,
   bound execution with a timeout, and serialize each session's Codex turns with
-  a crash-releasing/TTL-backed lease.
+  a renewable owner-fenced lease under the reliability contract above.
 - Pass a generated MCP config only to flagged sessions and select a Codex PM
   prime variant. Runtime authorization remains mandatory even though the tool
   is hidden from unflagged sessions.
@@ -292,8 +380,11 @@ continues** → later turn/restart resumes the same Codex thread.
   old thread; never silently roll over or discard context.
 - Auth precedence is saved CLI login or `CODEX_API_KEY` for the single exec
   subprocess. Do not add `OPENAI_API_KEY` fallback or inspect/log auth tokens.
-- Pin the initial minimum version to the live-probed `0.144.3`. A version bump
-  must update fixtures/probes before changing the gate.
+- Use `0.144.3` as the historical probe baseline. Set the rollout version gate
+  from the worker contract probe; validate upgrades before enabling them.
+- Persist invocation intent/result and PM-consumption state through the same
+  lease and generation checks used for thread continuity. Treat persistence
+  failure as a blocked/interrupted invocation, never successful tool completion.
 
 ## Failure Path Test Strategy
 
@@ -358,7 +449,8 @@ continues** → later turn/restart resumes the same Codex thread.
 - Do not build a universal Codex/Claude event superset. Normalize only events
   consumed for lifecycle, persistence, liveness, usage, and failure.
 - Do not emulate headless compaction or silently create replacement threads.
-  The bounded guard is an explicit capability degradation.
+  The bounded guard is a conservative policy pending current-version probes;
+  do not claim two observed turns prove compaction is unavailable.
 - Do not register the Codex Dev MCP server globally or teach unflagged PMs to
   shell out to `codex exec`.
 
@@ -374,7 +466,7 @@ add inverse grep and behavioral tests.
 ### Risk 2: CLI contract/version drift
 **Impact:** JSONL parsing, schema output, resume flags, or safety policy silently
 change after an upgrade.
-**Mitigation:** Pin minimum `0.144.3`, use `--strict-config`, record fixtures,
+**Mitigation:** Validate the selected CLI build and strict-configuration flags, record fixtures,
 fail on unknown terminal shapes, and make update validation explicit.
 
 ### Risk 3: Thread continuity is lost on crash or recreation
@@ -386,8 +478,9 @@ and test crash boundaries.
 ### Risk 4: Concurrent calls corrupt one Codex thread
 **Impact:** Two `exec resume` processes race on the same rollout and return
 misordered work.
-**Mitigation:** Acquire a session-scoped lease with timeout/TTL, re-read persisted
-state after acquisition, increment count atomically, and release in `finally`.
+**Mitigation:** Acquire a renewable owner-fenced lease, re-read persisted state, increment
+count atomically, and compare ownership before release. Expiry requires child
+reconciliation/reap before takeover; a stale owner cannot publish.
 
 ### Risk 5: Credentials or untrusted prompt text escape
 **Impact:** Secrets leak to logs/child processes, or a prompt becomes shell input.
@@ -415,16 +508,18 @@ immediately; no deferred task or post-return persistence.
 **Data prerequisite:** Thread id persisted if `thread.started` already fired.
 **State prerequisite:** Codex must remain in the PM process group.
 **Mitigation:** MCP adapter uses `start_new_session=False`; existing killpg reaches
-the entire tree. Next PM resume reuses the saved thread; if no thread existed,
-the next invocation starts the first thread cleanly.
+the entire tree. Next PM resume reconciles the saved invocation before continuing its thread.
+Without a saved handle, inspect interrupted work and local run evidence; absence
+of a handle does not authorize an automatic fresh execution.
 
 ### Race 3: Parallel PM tool calls resume the same thread
 **Location:** Codex Dev MCP handler
 **Trigger:** Claude schedules two tool calls or a stale worker overlaps takeover.
 **Data prerequisite:** Latest thread id and turn count after lease acquisition.
 **State prerequisite:** One live session owner.
-**Mitigation:** Cross-process session lease with bounded acquisition and TTL;
-re-read after lock; return a busy error instead of parallel resume.
+**Mitigation:** Renewable cross-process lease with owner generation and bounded acquisition;
+re-read after lock; reconcile/reap before takeover; stale-owner writes and releases
+are rejected. Return a busy error instead of parallel resume.
 
 ### Race 4: Queue recreation drops continuation fields
 **Location:** `agent/agent_session_queue.py` manual field allowlist
@@ -442,19 +537,34 @@ never infer continuity from rollout files alone.
 **Mitigation:** Check/increment only while holding the same dev-lane lease and
 save with explicit update fields before spawn.
 
+### Race 6: Codex finishes but the PM never receives the report
+**Location:** result persistence → MCP return → PM consumption
+**Mitigation:** Persist report/artifact references before return; retry with the
+same invocation id retrieves the result. PM restart reinjects unconsumed results.
+A death before persistence triggers evidence reconciliation, not blind replay.
+
+### Race 7: Child registration overwrites the PM fence
+**Location:** AgentSession live execution fields and spawn history
+**Mitigation:** Keep the PM fence unchanged throughout the dev call. Store child
+identity in dev invocation state; assert both identities remain recoverable.
+Worktree cleanup waits for child death and durable result reconciliation.
+
 ## No-Gos (Out of Scope)
 
 - [EXTERNAL] Automatic harness selection by project, cost, latency, or
   capability remains an owner policy decision after comparative telemetry.
   This phase is manual-only and does not silently decide that product policy.
-- [ORDERED] Removing Phase 2's prefix-regex routing fallback waits for the telemetry review scheduled one week after PR #2038 landed (2026-07-18); this phase files the tracking issue but must not remove the fallback.
+- [ORDERED] Prefix-regex fallback removal remains deferred to its telemetry
+  review. The original 2026-07-18 review date is overdue; find or file its tracking
+  issue during implementation, and do not remove the fallback in this phase.
 - [SEPARATE-SLUG #1925] PydanticAI standardization for non-harness LLM calls is
   a separate completed workstream and is not reopened here.
 
 ## Update System
 
 - Add typed provisional Codex settings: install opt-in (default false), package,
-  minimum version `0.144.3`, model override, sandbox default, turn timeout, and
+  validated CLI version gate (historical probe baseline `0.144.3`), model override,
+  sandbox default, turn timeout, and
   maximum resumed turns. Environment overrides use the settings catalog rather
   than inline literals.
 - Create `scripts/update/codex_cli.py` rather than adding Codex to unconditional
@@ -465,7 +575,7 @@ save with explicit update fields before spawn.
   warnings for general updates but execution remains fail-fast for flagged
   sessions.
 - Add and register an idempotent migration in `scripts/update/migrations.py`
-  that confirms the four nullable Codex fields read cleanly on legacy
+  that confirms nullable Codex continuity and invocation fields read cleanly on legacy
   AgentSession rows. No raw Redis operations and no backfill/index rebuild.
 
 ## Agent Integration
@@ -490,6 +600,9 @@ save with explicit update fields before spawn.
   `docs/features/headless-session-runner.md`, and
   `docs/features/eng-session-architecture.md`.
 - [ ] Add the feature to `docs/features/README.md`.
+
+- [ ] Document skill installation/discovery and the mandatory-invariant enforcement
+  matrix, invocation recovery/retention, and the separate pilot/expansion gates.
 
 ### Infrastructure Documentation
 - [ ] Maintain `docs/infra/harness-cross-compat.md` with dependency, auth,
@@ -517,9 +630,40 @@ save with explicit update fields before spawn.
 - [ ] `/update` supports opt-in install/upgrade and version/auth validation.
 - [ ] Telemetry distinguishes `harness=claude|codex`, PM turns, Dev turns,
   usage, failure, resume, and guard exhaustion without secret-bearing payloads.
-- [ ] Ordered tracking issue filed for the 2026-07-18 prefix-fallback telemetry review;
+- [ ] Existing or newly filed tracking issue covers the overdue prefix-fallback review;
   automatic-selection policy remains explicitly unresolved.
 - [ ] Tests pass (`/do-test`) and documentation is updated (`/do-docs`).
+
+- [ ] Required skill/tool discovery and negative enforcement tests pass headlessly.
+- [ ] PM fence remains intact while Codex runs; child ownership and reap are proven.
+- [ ] Durable invocation deduplication, stored-report recovery, and missing-transcript
+  handling pass; stale lease owners cannot write, release, or overlap a successor.
+- [ ] Interrupted/unconsumed work blocks destructive cleanup; delivery failure stays
+  visibly outstanding.
+- [ ] Every fault below passes for the supported worker build. Canary criteria are
+  declared before evaluation; pilot success is distinguished from the separately
+  gated #2494 authoritative-inbox rollout and broad reliability claim.
+
+## Fault-Injection Acceptance Matrix
+
+| Injected fault | Required outcome |
+|---|---|
+| Worker dies during Codex execution | Worktree/session storage/known handle survive; one recovery owner reaps or resumes. |
+| Death before thread-id persistence | Invocation remains uncertain; evidence reconciled before any new execution. |
+| Redis fails at intent/handle/result persistence | No success response; child stopped when persistence safety is lost; work retained. |
+| PM dies after Codex result persistence | Same invocation returns stored report; no duplicate development. |
+| Side effect succeeds before result persistence | Inspect effect/artifact evidence; no blind replay or exactly-once claim. |
+| Stop and unrelated steering arrive together | Stop executes; unrelated instructions remain pending. |
+| Lease expires while child runs; old owner returns | No second writer; old owner cannot release lease or publish over successor. |
+| PID reused or descendant changes process group | No unrelated process signalled; owned descendants accounted for before cleanup. |
+| Missing transcript/worktree or mismatched thread | Explicit recovery error; original handle/evidence preserved. |
+| Auth/quota/native failure, malformed stream, missing terminal, invalid schema | Typed visible failure with bounded retry; no false completion. |
+| PM exits cleanly with unfinished child/unconsumed report | Outstanding work detected; worktree cleanup blocked. |
+| Delivery fails after accepted development | Delivery remains outstanding through the shared delivery path. |
+| Monitor caller stops running | Missing monitor heartbeat detected, not interpreted as health. |
+
+Add these cases to the adapter/tool unit suites and live integration suite below;
+record which were simulated and which were exercised against real subprocesses.
 
 ## Team Orchestration
 
@@ -566,9 +710,24 @@ build directly.
 
 ## Step by Step Tasks
 
+### 0. Revalidate the worker contract and settle the persistence schema
+- **Task ID**: validate-codex-contract
+- **Depends On**: none
+- **Assigned To**: codex-test-engineer
+- **Agent Type**: test-engineer
+- **Parallel**: false
+- Probe the selected worker CLI/auth, first/resume schema/sandbox flags, cancellation,
+  and session-storage behavior. Update version/config requirements from evidence.
+- Specify AgentSession-owned invocation storage, atomic lease/generation operations,
+  retention, PM fence preservation, and queue recreation before schema changes.
+- Inventory mandatory hook invariants and name executable enforcement points.
+- Record unresolved capabilities as explicit build gates, not assumed equivalence.
+  Isolated adapter work can precede #3213 merge; pilot validation cannot.
+
+
 ### 1. Implement the Codex harness adapter
 - **Task ID**: build-codex-adapter
-- **Depends On**: none
+- **Depends On**: validate-codex-contract
 - **Validates**: `tests/unit/session_runner/test_codex_adapter.py` (create)
 - **Informed By**: spike-1
 - **Assigned To**: codex-adapter-builder
@@ -583,7 +742,7 @@ build directly.
 
 ### 2. Add immutable selection and persistent Codex continuity
 - **Task ID**: build-codex-persistence
-- **Depends On**: none
+- **Depends On**: validate-codex-contract
 - **Validates**: `tests/unit/test_valor_session_cli.py`,
   `tests/unit/test_agent_session_queue.py`, `tests/unit/test_agent_session.py`
 - **Informed By**: spike-3
@@ -595,6 +754,8 @@ build directly.
   only; no raw Redis mutation.
 - Add `dev_harness`, `codex_thread_id`, `codex_version`, `codex_turn_count`, CLI
   validation, queue persistence/recreation, and migration registration.
+- Add the gated AgentSession-owned invocation schema and atomic state transitions;
+  preserve the PM live fence and implement retention and cleanup eligibility.
 - Restore the existing Claude resume scalars to the recreation allowlist while
   touching that chokepoint and add a regression test.
 
@@ -610,11 +771,15 @@ build directly.
 - **Parallel**: false
 - **Domain: mcp-tool** — derive schema from type hints, resolve context per
   request, bound every call with `asyncio.wait_for`, never retain session state
-  in the server, and map auth/native errors deterministically.
+  in the server, and map auth/native errors deterministically. Durable invocation state lives
+  on AgentSession, not in server memory.
 - Add runtime capability gating, session lease, immediate thread persistence,
   resume/count guard, conditional MCP config, and Codex PM prime selection.
 - Keep Codex as a child of the existing PM process group and prove steering /
-  cancellation cleanup.
+  cancellation cleanup, including descendants and orphan recovery.
+- Implement durable request ids, intent-before-spawn, result-before-return,
+  report retrieval/PM consumption, lease renewal/fenced takeover, and evidence
+  reconciliation. Enforce required SDLC invariants at executable boundaries.
 
 ### 4. Add typed settings, update provisioning, migration, and telemetry
 - **Task ID**: build-codex-ops
@@ -640,8 +805,11 @@ build directly.
 - **Domain: async** — retain task references, cancel/await children on shutdown,
   treat `CancelledError` as expected, and timeout every external wait/lease.
 - Execute the hostile-input and native-failure matrix.
-- On this provisioned machine, run the acceptance lifecycle and record stable
-  thread id, restart, steer, cleanup, and telemetry evidence.
+- After #3213 lands, verify installed manifest/discovery and mandatory tool
+  enforcement on the selected worker. Run every fault-injection matrix row.
+- Run the live lifecycle and a predeclared matched canary; record thread continuity,
+  stored-report recovery, restart, steer, cleanup, delivery, and telemetry evidence.
+  Report missing integrations as untested, not passing.
 
 ### 6. Security and architecture review
 - **Task ID**: review-codex-boundary
@@ -664,8 +832,11 @@ build directly.
 - Create/update the Documentation section's feature and infra files and index.
 - Reconcile Phase 3 wording in `docs/plans/harness-cross-compat.md` with this
   issue's dev-lane-only mechanism.
-- File the prefix-fallback telemetry review issue for 2026-07-18 and link it
-  from #2001; record automatic selection as an unresolved owner policy.
+- Find the existing prefix-fallback telemetry-review issue or file the required
+  follow-up if absent; its original 2026-07-18 review date is overdue, not a future
+  schedule. Link the disposition from the plan; do not remove the fallback.
+- Record automatic selection as unresolved and #2494 authoritative inbox/legacy
+  retirement as an expansion gate. Do not duplicate those changes in this build.
 
 ### 8. Final validation
 - **Task ID**: validate-codex-dev-lane
@@ -676,19 +847,22 @@ build directly.
 - Run all machine-readable checks, targeted/full affected suites, prerequisites,
   update dry-run, docs validators, and the provisioned smoke evidence.
 - Verify every success criterion and report pass/fail without repairing code.
+- Distinguish #2001 supervised-pilot acceptance from full-program reliability;
+  do not claim the latter or recommend broad expansion until #2494's authoritative
+  cutover and the matched canary gates have independent evidence.
 
 ## Verification
 
 | Check | Command | Expected |
 |-------|---------|----------|
 | Prerequisites | `python scripts/check_prerequisites.py docs/plans/codex-exec-dev-lane.md` | exit code 0 |
-| Codex adapter tests | `pytest -q tests/unit/session_runner/test_codex_adapter.py` | exit code 0 |
-| Dev tool tests | `pytest -q tests/unit/session_runner/test_codex_dev_tool.py` | exit code 0 |
-| Selection/persistence tests | `pytest -q tests/unit/test_valor_session_cli.py tests/unit/test_agent_session_queue.py tests/unit/test_session_executor_runner_dispatch.py` | exit code 0 |
-| Settings/update tests | `pytest -q tests/unit/test_settings.py tests/unit/test_update_codex_cli.py` | exit code 0 |
-| Telemetry tests | `pytest -q tests/unit/test_session_telemetry.py tests/integration/test_session_telemetry_e2e.py` | exit code 0 |
-| Existing runner regression | `pytest -q tests/unit/session_runner/test_runner_dev_subagent.py tests/unit/session_runner/test_runner_resume.py tests/unit/session_runner/test_harness_argv_golden.py` | exit code 0 |
-| Live Codex lifecycle | `pytest -q -m codex_live tests/integration/test_codex_dev_lane.py` | exit code 0 |
+| Codex adapter tests | `./scripts/pytest-clean.sh -q tests/unit/session_runner/test_codex_adapter.py` | exit code 0 |
+| Dev tool tests | `./scripts/pytest-clean.sh -q tests/unit/session_runner/test_codex_dev_tool.py` | exit code 0 |
+| Selection/persistence tests | `./scripts/pytest-clean.sh -q tests/unit/test_valor_session_cli.py tests/unit/test_agent_session_queue.py tests/unit/test_session_executor_runner_dispatch.py` | exit code 0 |
+| Settings/update tests | `./scripts/pytest-clean.sh -q tests/unit/test_settings.py tests/unit/test_update_codex_cli.py` | exit code 0 |
+| Telemetry tests | `./scripts/pytest-clean.sh -q tests/unit/test_session_telemetry.py tests/integration/test_session_telemetry_e2e.py` | exit code 0 |
+| Existing runner regression | `./scripts/pytest-clean.sh -q tests/unit/session_runner/test_runner_dev_subagent.py tests/unit/session_runner/test_runner_resume.py tests/unit/session_runner/test_harness_argv_golden.py` | exit code 0 |
+| Live Codex lifecycle | `./scripts/pytest-clean.sh -q -m codex_live tests/integration/test_codex_dev_lane.py` | exit code 0 |
 | Top-level remains Claude | `rg -n 'CodexHarnessAdapter' agent/session_runner/role_driver.py` | exit code 1 |
 | No ephemeral threads | `rg -n -- '--ephemeral|--full-auto' agent/session_runner/harness/codex.py` | exit code 1 |
 | No global Codex MCP | `rg -n 'codex.dev|codex_dev' .mcp.json .claude/settings.json config/mcp_library.json` | exit code 1 |


### PR DESCRIPTION
The Codex dev-lane plan predates the translated skills and shipped durability foundations. Reconcile it with PR #3213 and #2494 while preserving the Claude PM and opt-in developer lane.

Specify skill enforcement, PM/child process ownership, durable invocation and report recovery, fenced leases, and 13 fault-injection scenarios. Separate supervised pilot acceptance from the authoritative inbox cutover required for broader reliability claims.

Validation: document structure and task dependency checks passed; git apply --check passed against the unchanged main plan. Documentation only; no runtime tests or live probes were run.

Refs #2001, #1996, #2494.
