### PR TITLE
Stop the unprompted Telegram repeat replies, and make replies match the room

### DIFF
--- a/.claude/commands/roles/prime-pm-role.md
+++ b/.claude/commands/roles/prime-pm-role.md
@@ -82,6 +82,14 @@ These `tools.job_tool` invocations are the one sanctioned exception to the no-sh
 - When the user is clearly asking for status rather than action, prefer `route: "user"` over engaging the developer.
 - If a tool or capability you need is missing from your environment, state it plainly on its own line starting with exactly `[missing-capability]` (e.g. `[missing-capability] gh CLI unavailable — cannot query the PR`); the runner escalates that line for you, so never work around the gap silently.
 
+## Match the room
+
+- **A chat reply is prose, a few sentences long.** No headers, no bold, no numbered lists — unless the human asked for a list.
+- **Length is proportional to the ask.** A one-line question gets a one-to-three-line answer. The human is reading on a phone, not auditing a build log.
+- **Long-form analysis goes to a file**, attached via `file_paths`, with a caption of about two sentences in the `message`. The chat carries the caption; the file carries the detail.
+- **Read the room before a non-trivial group reply.** `valor-telegram read --chat-id <id>` shows the recent history — write at the length and register the humans in that room are using.
+- **Keep the load-bearing specifics** — commit hashes, PR and issue numbers, verdicts. Drop the process narration: what you tried, which subagent ran, how many turns it took.
+
 # What the user said
 
 $ARGUMENTS

--- a/.claude/commands/roles/prime-teammate-role.md
+++ b/.claude/commands/roles/prime-teammate-role.md
@@ -45,6 +45,14 @@ You are a capable operational colleague, not a read-only observer. The **one** h
 - **Issue creation is your job.** If the user has a bug or feature request, run `/do-issue` and file it yourself — don't hand the command to the user.
 - **Defer complex SDLC work.** Code changes, multi-step implementations, and planning route to Dev. Do not attempt those yourself.
 
+## Match the room
+
+- **A chat reply is prose, a few sentences long.** No headers, no bold, no numbered lists — unless the human asked for a list.
+- **Length is proportional to the ask.** A one-line question gets a one-to-three-line answer. The human is reading on a phone, not auditing a build log.
+- **Long-form analysis goes to a file**, attached via `file_paths`, with a caption of about two sentences in the `message`. The chat carries the caption; the file carries the detail.
+- **Read the room before a non-trivial group reply.** `valor-telegram read --chat-id <id>` shows the recent history — write at the length and register the humans in that room are using.
+- **Keep the load-bearing specifics** — commit hashes, PR and issue numbers, verdicts. Drop the process narration: what you tried, what you checked first, how many turns it took.
+
 # What I help with
 
 - Answering questions about the codebase or architecture

--- a/agent/output_handler.py
+++ b/agent/output_handler.py
@@ -888,7 +888,6 @@ class TelegramRelayOutputHandler:
                         if _ctx.pop("deferred_self_draft_pending", None) is not None:
                             _ctx.pop("deferred_self_draft_text", None)
                             _target.extra_context = _ctx
-                            _target.save(update_fields=["extra_context"])
                             # Stamp response_delivered_at (#3270). Reaching
                             # here means the agent redrafted a deferred reply
                             # and this send is delivering it — the second of
@@ -908,9 +907,20 @@ class TelegramRelayOutputHandler:
                             # mirrors: any caller that keeps holding this
                             # object and later hands it to a lifecycle write
                             # would otherwise persist the pre-stamp snapshot.
+                            #
+                            # Both mutations land in ONE narrow save: the
+                            # cleared `extra_context` and the stamp describe
+                            # the same delivery, and a single write keeps them
+                            # from ever persisting apart.
                             _stamp_at = datetime.now(UTC)
                             _target.response_delivered_at = _stamp_at
-                            _target.save(update_fields=["response_delivered_at", "updated_at"])
+                            _target.save(
+                                update_fields=[
+                                    "extra_context",
+                                    "response_delivered_at",
+                                    "updated_at",
+                                ]
+                            )
                             if session is not _target:
                                 session.response_delivered_at = _stamp_at
                     except Exception as _clear_err:

--- a/agent/output_handler.py
+++ b/agent/output_handler.py
@@ -922,7 +922,29 @@ class TelegramRelayOutputHandler:
                                 ]
                             )
                             if session is not _target:
+                                # BOTH fields, not just the stamp. Mirroring
+                                # the stamp alone leaves the caller's own
+                                # `extra_context` still carrying
+                                # `deferred_self_draft_pending`, and
+                                # `finalize_session`'s trailing full save
+                                # re-arms it with the ORIGINALLY REJECTED
+                                # draft text -- which
+                                # `_deferred_self_draft_backstop_sweep` then
+                                # selects on that flag alone and delivers on
+                                # top of the successful resend. The precedent
+                                # site in
+                                # agent/session_health.py::flush_deferred_self_draft_sync
+                                # mirrors both for exactly this reason.
                                 session.response_delivered_at = _stamp_at
+                                _caller_ctx = dict(session.extra_context or {})
+                                _had_pending = (
+                                    _caller_ctx.pop("deferred_self_draft_pending", None) is not None
+                                )
+                                _had_text = (
+                                    _caller_ctx.pop("deferred_self_draft_text", None) is not None
+                                )
+                                if _had_pending or _had_text:
+                                    session.extra_context = _caller_ctx
                     except Exception as _clear_err:
                         # Best-effort; never blocks delivery. Worst case is the
                         # pre-existing stale-flag behavior this fix targets.

--- a/agent/output_handler.py
+++ b/agent/output_handler.py
@@ -1539,6 +1539,15 @@ class TelegramRelayOutputHandler:
         signature. The extra fields are merged into the event dict after the
         base fields are populated, so they can never shadow ``type``, ``ts``,
         ``chat_id``, ``reason``, or ``draft_preview``.
+
+        The save is narrowed to ``["session_events", "updated_at"]`` (#3270).
+        A bare ``save()`` on an AgentSession is a lifecycle write: ``status``
+        is an ``IndexedField`` and popoto's ``save(update_fields=None)`` path
+        encodes the whole instance into one HSET and runs ``on_save()`` for
+        every field, so appending a best-effort event to a possibly-stale
+        ``session`` object was silently authorized to rewrite the row's
+        lifecycle state and its status index, with no LIFECYCLE log and — the
+        sharpest irony of the write — no ``session_events`` entry recording it.
         """
         if session is None:
             return
@@ -1557,7 +1566,7 @@ class TelegramRelayOutputHandler:
             events.append(event)
             session.session_events = events
             if hasattr(session, "save"):
-                session.save()
+                session.save(update_fields=["session_events", "updated_at"])
         except Exception as e:  # pragma: no cover - defensive
             logger.debug("RTR event append failed (non-fatal): %s", e)
 

--- a/agent/output_handler.py
+++ b/agent/output_handler.py
@@ -15,6 +15,7 @@ import logging
 import os
 import time
 import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
@@ -888,6 +889,30 @@ class TelegramRelayOutputHandler:
                             _ctx.pop("deferred_self_draft_text", None)
                             _target.extra_context = _ctx
                             _target.save(update_fields=["extra_context"])
+                            # Stamp response_delivered_at (#3270). Reaching
+                            # here means the agent redrafted a deferred reply
+                            # and this send is delivering it — the second of
+                            # the two real delivery paths that never recorded
+                            # the fact, leaving #918's
+                            # `_delivery_belongs_to_current_run` reading None
+                            # and the #944 orphan net free to requeue a row
+                            # that had already answered the human.
+                            #
+                            # Narrow save: a bare save() here would be a full
+                            # popoto HSET of a possibly-stale instance, i.e. a
+                            # silent lifecycle write.
+                            #
+                            # The caller's `session` object is mirrored for the
+                            # same reason the flush in
+                            # agent/session_health.py::flush_deferred_self_draft_sync
+                            # mirrors: any caller that keeps holding this
+                            # object and later hands it to a lifecycle write
+                            # would otherwise persist the pre-stamp snapshot.
+                            _stamp_at = datetime.now(UTC)
+                            _target.response_delivered_at = _stamp_at
+                            _target.save(update_fields=["response_delivered_at", "updated_at"])
+                            if session is not _target:
+                                session.response_delivered_at = _stamp_at
                     except Exception as _clear_err:
                         # Best-effort; never blocks delivery. Worst case is the
                         # pre-existing stale-flag behavior this fix targets.

--- a/agent/output_handler.py
+++ b/agent/output_handler.py
@@ -1485,13 +1485,22 @@ class TelegramRelayOutputHandler:
         (its own transient concept — verbatim questions for the human) is
         never persisted to the session row; Job expectations (#2708) are the
         durable obligation record and live on the Job, not here.
+
+        The save is narrowed to ``["context_summary", "updated_at"]`` (#3270).
+        A bare ``save()`` on an AgentSession is a lifecycle write: ``status``
+        is an ``IndexedField`` and popoto's ``save(update_fields=None)`` path
+        encodes the whole instance into one HSET and runs ``on_save()`` for
+        every field, so this routing-field write — reached from a possibly
+        long-held ``session`` object — was silently authorized to rewrite the
+        row's lifecycle state and its status index from a stale snapshot, with
+        no LIFECYCLE log and no ``session_events`` entry.
         """
         try:
             context_summary = getattr(draft, "context_summary", None)
 
             if context_summary:
                 session.context_summary = context_summary
-                session.save()
+                session.save(update_fields=["context_summary", "updated_at"])
                 logger.debug(
                     "Persisted routing fields to session %s (context_summary=%s)",
                     getattr(session, "session_id", "<unknown>"),

--- a/agent/session_health.py
+++ b/agent/session_health.py
@@ -2858,6 +2858,41 @@ def flush_deferred_self_draft_sync(session: "AgentSession", status: str | None =
         )
         delivered = True
 
+        # Stamp response_delivered_at (#3270). This flush is the path PM/eng
+        # replies actually take, and until now it wrote the outbox payload
+        # without recording that the human had been answered. The only two
+        # other writers (agent/session_executor.py under `action == "deliver"`,
+        # agent/session_completion.py gated on `delivery_attempted`) are
+        # unreachable from here, so #918's duplicate-delivery guard
+        # `_delivery_belongs_to_current_run` read None and returned False for
+        # every deferred-self-draft delivery — and the #944 orphan net requeued
+        # rows that had already replied, once per tick.
+        #
+        # Narrow save: a bare save() here would be a full popoto HSET of a
+        # possibly-stale instance, i.e. a silent lifecycle write.
+        #
+        # ALSO mutate the caller's in-memory `session` object, for the same
+        # reason the extra_context clear below does: `finalize_session` runs a
+        # full `session.save()` on its own `session` parameter immediately
+        # after this flush returns, which writes back whatever that object
+        # still holds. Without the mirror the stamp is erased microseconds
+        # after it lands, on the very save that finalizes the transition.
+        try:
+            _stamp_at = datetime.now(tz=UTC)
+            _stamp_target = get_authoritative_session(session_id) or source
+            _stamp_target.response_delivered_at = _stamp_at
+            _stamp_target.save(update_fields=["response_delivered_at", "updated_at"])
+            if session is not None and session is not _stamp_target:
+                session.response_delivered_at = _stamp_at
+        except Exception as _stamp_err:
+            logger.warning(
+                "[session-health] failed to stamp response_delivered_at for %s after "
+                "successful flush (non-fatal; the #918 delivery guard stays blind for "
+                "this row): %s",
+                session_id,
+                _stamp_err,
+            )
+
         # Post-delivery flag clear (#3053 correction — the flush is NOT
         # self-clearing via #2489; that clear covers only the redraft-success
         # path in TelegramRelayOutputHandler.send(), never this flush). Without

--- a/agent/session_health.py
+++ b/agent/session_health.py
@@ -3449,6 +3449,17 @@ async def _apply_recovery_transition(
     # that the delivery belongs to the current run's epoch
     # (response_delivered_at >= started_at, falling back to created_at; a
     # legacy row with no anchor still passes through, unguarded).
+    #
+    # No live-fence gate here, unlike the sibling guard in
+    # `_agent_session_health_check` (#3270). The difference is what this branch
+    # is an alternative TO: every caller of `_apply_recovery_transition` has
+    # already evaluated liveness and decided this row is being taken away from
+    # its runner — the only open question is whether it lands `pending`,
+    # `failed`, or `abandoned`. Finalizing a delivered row `completed` is
+    # strictly the gentler of those outcomes, so adding a fence gate here would
+    # not spare a live row, it would only route it into a harsher transition.
+    # The sibling guard needs the gate precisely because it runs BEFORE any
+    # liveness evaluation.
     if _delivery_belongs_to_current_run(entry):
         try:
             from models.session_lifecycle import (
@@ -4681,7 +4692,23 @@ async def _agent_session_health_check() -> None:
         # falling back to created_at) so a stale prior-run delivery doesn't
         # suppress recovery of a genuinely stuck current run; legacy rows
         # with no anchor still pass through unguarded.
-        if _delivery_belongs_to_current_run(entry):
+        #
+        # ...and the row must not be EXECUTING (#3270). Because this branch
+        # deliberately skips the worker_alive/_has_progress evaluation, the
+        # only thing standing between it and a live mid-turn row is this
+        # check. `response_delivered_at` is now stamped mid-run on the
+        # deferred-self-draft redraft path (`agent/output_handler.py::send`),
+        # so a long eng/PM run that answers the human and then keeps working
+        # past this 300s cadence presents exactly the shape the branch below
+        # finalizes: status `running`, delivery inside the current run's
+        # epoch. Finalizing it `completed` writes a terminal status onto a row
+        # the runner is still driving — the mid-turn status corruption #3270
+        # exists to stop. A live execution fence is the same discriminator
+        # `models/session_lifecycle.py`'s idempotent-skip WARNING uses: the
+        # per-turn subprocess is still ours and still alive. A dead or absent
+        # fence still falls through, so the #918 duplicate-delivery guard this
+        # branch exists for is unchanged for genuinely stranded rows.
+        if _delivery_belongs_to_current_run(entry) and not _session_has_live_fence(entry):
             try:
                 from models.session_lifecycle import StatusConflictError, finalize_session
 

--- a/agent/session_runner/runner.py
+++ b/agent/session_runner/runner.py
@@ -116,10 +116,8 @@ TEAMMATE_TURN_TIMEOUT_S: float = float(
 # for hours, so a short TTL would expire between re-runs and re-spam. It is
 # safe to be long ONLY because the key is run-scoped -- a later, unrelated
 # request in the same thread carries a new record id and a fresh key.
-# PROVISIONAL/TUNABLE --
-# grain of salt: sized to comfortably outlive a stranded row's re-enqueue
-# cadence (the incident re-ran the same row hourly for hours), while still
-# expiring so abandoned sessions need no cleanup step. Override with
+# PROVISIONAL/TUNABLE -- grain of salt: it still expires, so abandoned
+# sessions need no cleanup step. Override with
 # SESSION_RUNNER_TIMEOUT_NOTICE_DEDUP_TTL_S.
 TIMEOUT_NOTICE_DEDUP_TTL_S: int = int(
     os.environ.get("SESSION_RUNNER_TIMEOUT_NOTICE_DEDUP_TTL_S", "86400")
@@ -306,14 +304,15 @@ def _claim_timeout_notice(session_id: str, run_id: str = "") -> bool:
             empty id means the row is unidentifiable, so no dedupe is possible
             and the notice is delivered.
         run_id: The AgentSession record's ``id``, minted fresh on every
-            reply-resume. Empty is safe: it degrades to a thread-wide key for
-            a row that has no id yet, which cannot collide with an identified
-            row's key.
+            reply-resume. Empty means the run is unidentifiable, so the notice
+            is delivered rather than deduped on a thread-wide key -- that key
+            would be the silence bug in miniature, and failing open here is the
+            same stance as the Redis-outage path above.
 
     Returns:
         True if this run owns the send, False if an earlier run already sent it.
     """
-    if not session_id:
+    if not session_id or not run_id:
         return True
     try:
         from popoto.redis_db import POPOTO_REDIS_DB  # noqa: PLC0415

--- a/agent/session_runner/runner.py
+++ b/agent/session_runner/runner.py
@@ -109,9 +109,14 @@ TEAMMATE_TURN_TIMEOUT_S: float = float(
     os.environ.get("SESSION_RUNNER_TEAMMATE_TURN_TIMEOUT_S", "900")
 )
 
-# TTL (seconds) on the per-session `timeout-notice-sent:{session_id}` dedupe
-# key that makes TIMEOUT_NEEDS_ATTENTION_MESSAGE a once-per-SESSION notice
-# rather than a once-per-RUN one (#3270 defect 7). PROVISIONAL/TUNABLE --
+# TTL (seconds) on the `timeout-notice-sent:{session_id}:{run_id}` dedupe key
+# that stops TIMEOUT_NEEDS_ATTENTION_MESSAGE from being re-posted on every
+# re-run of one stranded row (#3270 defect 7). The TTL is deliberately long
+# relative to the re-enqueue cadence: the incident re-ran the same row hourly
+# for hours, so a short TTL would expire between re-runs and re-spam. It is
+# safe to be long ONLY because the key is run-scoped -- a later, unrelated
+# request in the same thread carries a new record id and a fresh key.
+# PROVISIONAL/TUNABLE --
 # grain of salt: sized to comfortably outlive a stranded row's re-enqueue
 # cadence (the incident re-ran the same row hourly for hours), while still
 # expiring so abandoned sessions need no cleanup step. Override with
@@ -263,7 +268,7 @@ RUNNER_ERROR_USER_MESSAGE = (
 )
 
 
-def _claim_timeout_notice(session_id: str) -> bool:
+def _claim_timeout_notice(session_id: str, run_id: str = "") -> bool:
     """Claim the right to deliver the timeout needs-attention notice ONCE.
 
     ``TIMEOUT_NEEDS_ATTENTION_MESSAGE`` describes a *session-level* condition
@@ -272,9 +277,22 @@ def _claim_timeout_notice(session_id: str) -> bool:
     incident posted the byte-identical text into a chat once per re-enqueue.
 
     Follows this repo's established one-shot-notice convention (Redis SETNX on
-    a per-session key with a TTL, e.g. ``failed-sent:{session_id}`` in
-    ``agent.session_executor``): the first caller wins, later callers are
-    suppressed. The key is a plain Redis string, NOT an AgentSession field --
+    a keyed marker with a TTL, e.g. ``self_draft_completed_flush_sent:``
+    ``{session_id}:{run_id}`` in ``agent.session_health``): the first caller
+    wins, later callers are suppressed.
+
+    **Scoped per-RUN, not per-thread.** The key carries the AgentSession
+    record's ``id`` alongside the thread ``session_id``. A resumed session
+    reuses its thread ``session_id``, so a ``session_id``-only key would
+    silently swallow the notice for a *later, unrelated* request in the same
+    chat thread -- and that suppression is unrecoverable, because
+    ``ExitReason.TURN_TIMEOUT`` is ``wrapup_eligible=False``
+    (``agent/session_runner/router.py``), so the wrap-up guard never fires to
+    say anything else. The human would get pure silence for a request they
+    made hours later. Re-runs of the SAME stranded row keep the same record
+    ``id``, which is the #3270 spam this dedupes.
+
+    The key is a plain Redis string, NOT an AgentSession field --
     a bare ``save()`` on an AgentSession is a lifecycle write (popoto's default
     save path is a full HSET and ``status`` is an ``IndexedField``), so a
     cosmetic dedupe marker must never travel on that path.
@@ -284,9 +302,13 @@ def _claim_timeout_notice(session_id: str) -> bool:
     turn that was preempted mid-flight.
 
     Args:
-        session_id: The AgentSession the notice would be delivered for. An
+        session_id: The chat thread the notice would be delivered to. An
             empty id means the row is unidentifiable, so no dedupe is possible
             and the notice is delivered.
+        run_id: The AgentSession record's ``id``, minted fresh on every
+            reply-resume. Empty is safe: it degrades to a thread-wide key for
+            a row that has no id yet, which cannot collide with an identified
+            row's key.
 
     Returns:
         True if this run owns the send, False if an earlier run already sent it.
@@ -298,7 +320,7 @@ def _claim_timeout_notice(session_id: str) -> bool:
 
         claimed = bool(
             POPOTO_REDIS_DB.set(
-                f"timeout-notice-sent:{session_id}",
+                f"timeout-notice-sent:{session_id}:{run_id}",
                 "1",
                 nx=True,
                 ex=TIMEOUT_NOTICE_DEDUP_TTL_S,
@@ -928,7 +950,8 @@ class SessionRunner:
                         # in the transcript; surface needs-attention -- but at
                         # most ONCE per session, not once per run (#3270).
                         if _claim_timeout_notice(
-                            str(getattr(self._agent_session, "session_id", "") or "")
+                            str(getattr(self._agent_session, "session_id", "") or ""),
+                            str(getattr(self._agent_session, "id", "") or ""),
                         ):
                             self._adapter.on_user_payload(TIMEOUT_NEEDS_ATTENTION_MESSAGE)
                         summary.exit_reason = ExitReason.TURN_TIMEOUT

--- a/agent/session_runner/runner.py
+++ b/agent/session_runner/runner.py
@@ -109,6 +109,17 @@ TEAMMATE_TURN_TIMEOUT_S: float = float(
     os.environ.get("SESSION_RUNNER_TEAMMATE_TURN_TIMEOUT_S", "900")
 )
 
+# TTL (seconds) on the per-session `timeout-notice-sent:{session_id}` dedupe
+# key that makes TIMEOUT_NEEDS_ATTENTION_MESSAGE a once-per-SESSION notice
+# rather than a once-per-RUN one (#3270 defect 7). PROVISIONAL/TUNABLE --
+# grain of salt: sized to comfortably outlive a stranded row's re-enqueue
+# cadence (the incident re-ran the same row hourly for hours), while still
+# expiring so abandoned sessions need no cleanup step. Override with
+# SESSION_RUNNER_TIMEOUT_NOTICE_DEDUP_TTL_S.
+TIMEOUT_NOTICE_DEDUP_TTL_S: int = int(
+    os.environ.get("SESSION_RUNNER_TIMEOUT_NOTICE_DEDUP_TTL_S", "86400")
+)
+
 # How often the preempt watcher polls the steering list during a turn.
 # Provisional/tunable — override with SESSION_RUNNER_STEER_POLL_INTERVAL_S.
 STEER_POLL_INTERVAL_S: float = float(os.environ.get("SESSION_RUNNER_STEER_POLL_INTERVAL_S", "2.0"))
@@ -250,6 +261,63 @@ TIMEOUT_NEEDS_ATTENTION_MESSAGE = (
 RUNNER_ERROR_USER_MESSAGE = (
     "I hit a problem finishing this and had to stop. Please try again or follow up."
 )
+
+
+def _claim_timeout_notice(session_id: str) -> bool:
+    """Claim the right to deliver the timeout needs-attention notice ONCE.
+
+    ``TIMEOUT_NEEDS_ATTENTION_MESSAGE`` describes a *session-level* condition
+    ("I've paused the work and kept the progress so far"), so re-delivering it
+    on every re-run of the same row is pure noise to the human -- the #3270
+    incident posted the byte-identical text into a chat once per re-enqueue.
+
+    Follows this repo's established one-shot-notice convention (Redis SETNX on
+    a per-session key with a TTL, e.g. ``failed-sent:{session_id}`` in
+    ``agent.session_executor``): the first caller wins, later callers are
+    suppressed. The key is a plain Redis string, NOT an AgentSession field --
+    a bare ``save()`` on an AgentSession is a lifecycle write (popoto's default
+    save path is a full HSET and ``status`` is an ``IndexedField``), so a
+    cosmetic dedupe marker must never travel on that path.
+
+    **Fail-open**: if Redis is unavailable the notice is delivered anyway. A
+    duplicate needs-attention message is strictly better than silence about a
+    turn that was preempted mid-flight.
+
+    Args:
+        session_id: The AgentSession the notice would be delivered for. An
+            empty id means the row is unidentifiable, so no dedupe is possible
+            and the notice is delivered.
+
+    Returns:
+        True if this run owns the send, False if an earlier run already sent it.
+    """
+    if not session_id:
+        return True
+    try:
+        from popoto.redis_db import POPOTO_REDIS_DB  # noqa: PLC0415
+
+        claimed = bool(
+            POPOTO_REDIS_DB.set(
+                f"timeout-notice-sent:{session_id}",
+                "1",
+                nx=True,
+                ex=TIMEOUT_NOTICE_DEDUP_TTL_S,
+            )
+        )
+    except Exception as dedup_err:
+        logger.debug(
+            "[%s] timeout-notice dedupe unavailable (%s); delivering anyway",
+            session_id,
+            dedup_err,
+        )
+        return True
+    if not claimed:
+        logger.info(
+            "[%s] timeout needs-attention notice suppressed — already delivered "
+            "for this session (#3270)",
+            session_id,
+        )
+    return claimed
 
 
 def turn_timeout_for(session_type: str | None) -> float:
@@ -857,8 +925,12 @@ class SessionRunner:
                     self._record_turn_event(handle, turn_end_source=source)
                     if handle.kill_cause == "timeout":
                         # Graceful preempt, not an error: partial work stays
-                        # in the transcript; surface needs-attention.
-                        self._adapter.on_user_payload(TIMEOUT_NEEDS_ATTENTION_MESSAGE)
+                        # in the transcript; surface needs-attention -- but at
+                        # most ONCE per session, not once per run (#3270).
+                        if _claim_timeout_notice(
+                            str(getattr(self._agent_session, "session_id", "") or "")
+                        ):
+                            self._adapter.on_user_payload(TIMEOUT_NEEDS_ATTENTION_MESSAGE)
                         summary.exit_reason = ExitReason.TURN_TIMEOUT
                         break
                     # Steer preempt: pending steers drain at the next

--- a/agent/session_runner/runner.py
+++ b/agent/session_runner/runner.py
@@ -335,7 +335,7 @@ def _claim_timeout_notice(session_id: str, run_id: str = "") -> bool:
     if not claimed:
         logger.info(
             "[%s] timeout needs-attention notice suppressed — already delivered "
-            "for this session (#3270)",
+            "for this run (#3270)",
             session_id,
         )
     return claimed
@@ -947,7 +947,7 @@ class SessionRunner:
                     if handle.kill_cause == "timeout":
                         # Graceful preempt, not an error: partial work stays
                         # in the transcript; surface needs-attention -- but at
-                        # most ONCE per session, not once per run (#3270).
+                        # most ONCE per run, not once per chat thread (#3270).
                         if _claim_timeout_notice(
                             str(getattr(self._agent_session, "session_id", "") or ""),
                             str(getattr(self._agent_session, "id", "") or ""),

--- a/agent/steering.py
+++ b/agent/steering.py
@@ -264,8 +264,12 @@ def push_steering_message(
     front: bool = False,
     room_id: str | None = None,
     timestamp: float | None = None,
-) -> None:
+) -> str:
     """Push a message to a steering queue — the Room leg, or the legacy leg.
+
+    Returns the serialized payload exactly as it was written, so a caller
+    whose own follow-up work fails can hand it back to
+    :func:`remove_steering_message` and undo the push. Most callers ignore it.
 
     Args:
         session_id: The active session to steer
@@ -334,6 +338,46 @@ def push_steering_message(
         f"[steering] Pushed {'ABORT' if is_abort else 'message'} to {key}: "
         f"{text[:80]!r} (from {sender}){target_suffix}{front_suffix}"
     )
+    return payload
+
+
+def remove_steering_message(
+    session_id: str,
+    payload: str,
+    room_id: str | None = None,
+) -> bool:
+    """Undo a single :func:`push_steering_message`, by exact payload.
+
+    Exists for the push-then-do-something-that-can-fail shape: a caller that
+    must push BEFORE a second write (to close a two-write race) has no other
+    way to clean up when that second write raises. Without it the orphaned
+    steer sits on the legacy key forever — the legacy leg carries no TTL and
+    is never age-bounded at drain time (only the Room leg is, via
+    ``steering_room_max_age_s``) — and is injected verbatim whenever that
+    session next runs, however much later that is.
+
+    Removes the LAST occurrence (``LREM count=-1``), which is the entry a
+    just-completed ``RPUSH`` wrote. Concurrent pushes of *different* text are
+    unaffected; a byte-identical duplicate would lose its newest copy, which
+    is the correct one to drop here.
+
+    The leg is re-derived from the payload's own ``is_abort`` so it always
+    matches the key ``push_steering_message`` chose, including for a keyword
+    auto-detected abort. Never raises.
+    """
+    try:
+        is_abort = bool(json.loads(payload).get("is_abort"))
+    except Exception:
+        is_abort = False
+    key = _room_queue_key(room_id) if (room_id and not is_abort) else _queue_key(session_id)
+    try:
+        removed = _get_redis().lrem(key, -1, payload)
+    except Exception as e:
+        logger.warning("[steering] Failed to remove steering message from %s: %s", key, e)
+        return False
+    if removed:
+        logger.info("[steering] Removed %s orphaned steering message(s) from %s", removed, key)
+    return bool(removed)
 
 
 def pop_all_steering_messages(session_id: str, room_id: str | None = None) -> list[dict]:

--- a/config/personas/segments/identity.md
+++ b/config/personas/segments/identity.md
@@ -36,9 +36,6 @@ world, ship working code); community-driven technology.
 
 ## Communication Style
 
-<!-- If you modify this section, review DRAFTER_SYSTEM_PROMPT in
-     bridge/message_drafter.py to ensure it still matches Valor's voice. -->
-
 I communicate via Telegram. For how to trigger work or interact with me, refer
 collaborators to `docs/features/telegram-pm-guide.md` (`issue 363` starts SDLC, `PR 363`
 resumes it, reply-to continues a session).
@@ -54,9 +51,10 @@ response reaches Telegram my session is OVER — "I'll update that", "going forw
 "next time" are lies unless the change already happened this session. I show evidence of
 what I DID (commit hash, file path) or honestly say I didn't.
 
-Long outputs are condensed by the message drafter (`bridge/message_drafter.py`, Haiku),
-which represents me as a senior developer reporting to a PM: outcomes over process,
-blockers flagged, hashes and URLs preserved.
+Nothing rewrites my words on the way out: the message drafter
+(`bridge/message_drafter.py`) validates and composes, it does not summarize. Length is
+mine to control. A response too long for the medium is attached as a file rather than
+shortened, so writing short is my job, not the pipeline's.
 
 ## When I Reach Out
 

--- a/docs/features/pm-voice-refinement.md
+++ b/docs/features/pm-voice-refinement.md
@@ -1,36 +1,28 @@
 # PM Voice Refinement
 
-The PM persona's Telegram output reads as natural human prose: SDLC stage labels are naturalized, crash messages vary, truncation lands on sentence boundaries, developer metrics stay out of stakeholder-facing text, and the completion emoji is reserved for milestones.
+The PM persona's Telegram output reads as natural human prose: the agent's own text reaches the human verbatim, truncation lands on sentence boundaries, question prefixes are normalized, issue and PR references are linkified, and the completion emoji is reserved for milestones.
 
 ## Behavior
 
-### SDLC Stage Naturalization
+### Verbatim Pass-Through
 
-The `DRAFTER_SYSTEM_PROMPT` in `bridge/message_drafter.py` instructs the LLM to translate raw SDLC stage labels to natural language: PLAN becomes "planning", BUILD becomes "building", TEST becomes "testing", REVIEW becomes "reviewing", DOCS becomes "documenting", MERGE becomes "merging". The term "SDLC" itself remains acceptable as a process reference. This is a prompt-only behavior — the LLM handles the translation at draft time.
-
-### Crash Message Pool
-
-`agent/sdk_client.py` defines `CRASH_MESSAGE_POOL`, a list of five varied crash fallback messages. Each includes next-step language ("retry", "try again", "re-trigger", "re-send"). The `_get_crash_message()` function selects randomly from the pool while tracking `_last_crash_message` at module level to prevent consecutive repeats. If the pool is empty, a hardcoded default is returned.
+`bridge/message_drafter.py` performs validation and structural composition, not summarization. There is no LLM rewriting step: the agent's text is stripped of process narration (`_strip_process_narration()`), validated against the per-medium wire format, and composed with the emoji prefix, SDLC stage line, and link footer by `_compose_structured_draft()`. A response too long for the medium is written out and attached as a `.txt` file by `_write_full_output_file()`, never shortened.
 
 ### Question Prefix
 
-The question prefix is `>> ` for better visual distinction in Telegram. The `_normalize_question_prefix()` function converts any legacy `? ` prefixes to `>> `. Both `DRAFTER_SYSTEM_PROMPT` and `_parse_summary_and_questions()` use the current format.
+The question prefix is `>> ` for better visual distinction in Telegram. `_normalize_question_prefix()` converts any legacy `? ` prefixes to `>> `, and `_parse_draft_and_questions()` splits the composed draft into bullet text and a questions block.
 
 ### Link Footer Standardization
 
-The drafter prompt instructs the LLM to use short-form references only in bullet text (e.g., "PR #N", "issue #N") and never include full URLs in bullets. Full URL rendering is handled by the `_linkify_references()` post-processor.
+Bullet text carries short-form references only (e.g. "PR #N", "issue #N"). Full URL rendering is handled by the `_linkify_references()` post-processor, which resolves those references against the session's project before the draft is sent.
 
 ### Sentence-Aware Truncation
 
-`bridge/response.py` provides `_truncate_at_sentence_boundary()` to replace a raw `text[:4093] + "..."` slice at Telegram's 4096-character limit. The function searches the last 500 characters of the allowed window for sentence-ending punctuation (`.`, `!`, `?`) followed by whitespace or end-of-string, and cuts there. If no sentence boundary is found, it falls back to the ellipsis truncation.
-
-### Developer Metrics Suppression
-
-The drafter prompt instructs the LLM to avoid line counts, file counts, addition/deletion counts, and exact test pass/fail numbers. Instead it uses outcome language: "shipped and tested", "all tests passing", "reviewed and approved".
+`bridge/message_drafter.py` provides `_truncate_at_sentence_boundary()` instead of a raw slice at Telegram's 4096-character limit. The function searches the last 500 characters of the allowed window for sentence-ending punctuation (`.`, `!`, `?`) followed by whitespace or end-of-string, and cuts there. If no sentence boundary is found, it falls back to ellipsis truncation.
 
 ### Dual-Personality Guard
 
-The `pm_bypass` path in `response.py` prevents sending both PM self-messages and a drafted version of the same content. The guard blocks both drafting and text sending when the PM has already delivered its own messages.
+The `pm_bypass` path in `bridge/telegram_bridge.py` prevents sending both PM self-messages and a drafted version of the same content. When the PM session (or its parent PM session in SDLC flows) has already delivered messages via `tools/send_message.py`, the drafter is skipped entirely. File attachments still send — they would otherwise be lost.
 
 ### Milestone-Selective Emoji
 
@@ -49,9 +41,8 @@ Routine completions produce no emoji prefix. Only merged PRs and closed issues g
 
 ## Key Files
 
-- `bridge/message_drafter.py` — prompt updates (naturalization, question prefix, link format, metrics suppression), `_get_status_emoji()` milestone logic, `_normalize_question_prefix()`, `_parse_summary_and_questions()`
-- `bridge/response.py` — `_truncate_at_sentence_boundary()`, dual-personality guard
-- `agent/sdk_client.py` — `CRASH_MESSAGE_POOL`, `_get_crash_message()`
+- `bridge/message_drafter.py` — `_strip_process_narration()`, `_truncate_at_sentence_boundary()`, `_normalize_question_prefix()`, `_parse_draft_and_questions()`, `_linkify_references()`, `_get_status_emoji()`, `_write_full_output_file()`, `_compose_structured_draft()`
+- `bridge/telegram_bridge.py` — `pm_bypass` dual-personality guard
 
 ## Related
 

--- a/models/session_lifecycle.py
+++ b/models/session_lifecycle.py
@@ -495,8 +495,20 @@ def finalize_session(
         # lifecycle event was emitted — and a later stale save flipped the row
         # back to `running`, where the orphan net requeued it once a tick for
         # days. The live fence is the discriminator rather than a caller flag
-        # or a reason-string match: health-checker and watchdog finalizes run
-        # precisely when the runner is gone, so they cannot trip it.
+        # or a reason-string match, because it is a property of the row rather
+        # than of the caller.
+        #
+        # What the fence actually points at: the per-turn `claude -p`
+        # subprocess stamped by `agent/session_runner/runner.py` at spawn. By
+        # the ordinary turn-end finalize (`agent/session_executor.py`'s
+        # completion-exit guard) that subprocess has already exited, so the
+        # fence reads dead and the WARNING does NOT fire on the normal path —
+        # including the #3270 turn-end skip itself, which is why the incident
+        # was invisible in the first place. The finalizes that CAN trip it are
+        # the concurrent ones: a health-check or watchdog finalize landing
+        # while a turn's subprocess is still executing. That is exactly the
+        # signal wanted here — a terminal status being written onto a row
+        # somebody else is still running.
         #
         # Observability ONLY. The idempotency semantics are unchanged; that is
         # #3253's territory.

--- a/models/session_lifecycle.py
+++ b/models/session_lifecycle.py
@@ -471,6 +471,7 @@ def finalize_session(
     current_status = getattr(session, "status", None)
     if current_status == status:
         _pending_on_reread = False
+        _fresh_for_idem = None
         try:
             _idem_sid = getattr(session, "session_id", None)
             if _idem_sid:
@@ -483,12 +484,57 @@ def finalize_session(
                     )
         except Exception:
             _pending_on_reread = False
-        _idem_log = logger.info if _pending_on_reread else logger.debug
-        _idem_log(
-            f"[lifecycle] Session {getattr(session, 'session_id', '?')} "
-            f"already in terminal state {status!r}, skipping finalize"
-            + (" (deferred_self_draft_pending still set)" if _pending_on_reread else "")
-        )
+
+        # Promoted to WARNING when a LIVE execution fence is still bound to the
+        # row (#3270). A skip is routine when nobody is executing the session
+        # any more; it is an anomaly when the runner that owns this turn is
+        # still alive, because that is the turn-end finalize racing a status
+        # some other writer already put on the row. In the #3270 incident a
+        # stale full save wrote `completed` onto a mid-turn row, the real
+        # turn-end finalize skipped here, `completed_at` was never set, no
+        # lifecycle event was emitted — and a later stale save flipped the row
+        # back to `running`, where the orphan net requeued it once a tick for
+        # days. The live fence is the discriminator rather than a caller flag
+        # or a reason-string match: health-checker and watchdog finalizes run
+        # precisely when the runner is gone, so they cannot trip it.
+        #
+        # Observability ONLY. The idempotency semantics are unchanged; that is
+        # #3253's territory.
+        _live_runner_pid = None
+        try:
+            _fence_src = _fresh_for_idem if _fresh_for_idem is not None else session
+            _fence = getattr(_fence_src, "live_fence", None)
+            if _fence:
+                from agent.pid_fence import fence_is_live
+
+                _fence_pid = _fence.get("pid")
+                if _fence_pid is not None and fence_is_live(
+                    int(_fence_pid), _fence.get("create_time")
+                ):
+                    _live_runner_pid = int(_fence_pid)
+        except Exception:
+            _live_runner_pid = None
+
+        if _live_runner_pid is not None:
+            logger.warning(
+                "[lifecycle] Session %s: finalize to %r skipped as idempotent while "
+                "runner pid=%s is still live — status found on the authoritative "
+                "record is %r. The turn is ending against a status this call did not "
+                "write, so completed_at and the lifecycle event are both lost. "
+                "reason=%r",
+                getattr(session, "session_id", "?"),
+                status,
+                _live_runner_pid,
+                getattr(_fresh_for_idem, "status", current_status),
+                reason,
+            )
+        else:
+            _idem_log = logger.info if _pending_on_reread else logger.debug
+            _idem_log(
+                f"[lifecycle] Session {getattr(session, 'session_id', '?')} "
+                f"already in terminal state {status!r}, skipping finalize"
+                + (" (deferred_self_draft_pending still set)" if _pending_on_reread else "")
+            )
         return
 
     # Terminal-state guard: refuse to re-classify a terminal session unless explicitly opted out.

--- a/reflections/sdlc_progress.py
+++ b/reflections/sdlc_progress.py
@@ -846,7 +846,14 @@ def _pick_steer_target(project_key: str, lane_slug: str | None = None) -> tuple[
         return ("unknown", None)
 
     def _same_lane(row) -> bool:
-        """Eligibility for BOTH rungs: this row belongs to this lane, period."""
+        """Eligibility for BOTH rungs: this row belongs to this lane, period.
+
+        A falsy ``lane_slug`` admits NOTHING, so the caller falls through to
+        ``("create", None)``. That is the intended fail-closed direction: with
+        no lane to match, #3270's defect was picking the most-recently-updated
+        eng row, which was routinely a slugless human conversation thread.
+        Creating a fresh session is always safe; resuming a stranger's is not.
+        """
         slug = getattr(row, "slug", None)
         return bool(lane_slug) and slug is not None and slug == lane_slug
 

--- a/reflections/sdlc_progress.py
+++ b/reflections/sdlc_progress.py
@@ -845,17 +845,21 @@ def _pick_steer_target(project_key: str, lane_slug: str | None = None) -> tuple[
         logger.warning("sdlc_progress: target query failed for %s: %s", project_key, exc)
         return ("unknown", None)
 
-    def _same_lane(row) -> bool:
-        """Eligibility for BOTH rungs: this row belongs to this lane, period.
+    # A falsy ``lane_slug`` admits NOTHING, so this returns ``("create", None)``
+    # without scanning a row. That is the intended fail-closed direction: with
+    # no lane to match, #3270's defect was picking the most-recently-updated
+    # eng row, which was routinely a slugless human conversation thread.
+    # Creating a fresh session is always safe; resuming a stranger's is not.
+    # Hoisted above the loop because it is loop-invariant -- and kept BELOW the
+    # query so a Redis failure still reports ``("unknown", None)`` rather than
+    # being masked as "no candidates".
+    if not lane_slug:
+        return ("create", None)
 
-        A falsy ``lane_slug`` admits NOTHING, so the caller falls through to
-        ``("create", None)``. That is the intended fail-closed direction: with
-        no lane to match, #3270's defect was picking the most-recently-updated
-        eng row, which was routinely a slugless human conversation thread.
-        Creating a fresh session is always safe; resuming a stranger's is not.
-        """
+    def _same_lane(row) -> bool:
+        """Eligibility for BOTH rungs: this row belongs to this lane, period."""
         slug = getattr(row, "slug", None)
-        return bool(lane_slug) and slug is not None and slug == lane_slug
+        return slug is not None and slug == lane_slug
 
     def _rank(row) -> float:
         """Most recently updated, among rows the lane filter already admitted."""

--- a/reflections/sdlc_progress.py
+++ b/reflections/sdlc_progress.py
@@ -808,17 +808,28 @@ def _send_alert(project_dict: dict, message: str) -> bool:
 def _pick_steer_target(project_key: str, lane_slug: str | None = None) -> tuple[str, Any]:
     """Return ``(kind, session)`` with kind in steer | resume | create | unknown.
 
-    Rung 1 prefers a live (non-terminal, non-ledger) eng session for the
-    project. Rung 2 falls back to a resumable eng session that carries a
-    ``claude_session_uuid`` (required by ``resume_session``). Otherwise the
-    caller creates one.
+    Rung 1 takes a live (non-terminal, non-ledger) eng session for the lane.
+    Rung 2 falls back to a resumable eng session for the lane that carries a
+    ``claude_session_uuid`` (required by ``resume_session``) and did not
+    already fail. Otherwise the caller creates one.
 
-    Within BOTH buckets, a session whose ``slug`` matches ``lane_slug`` wins
-    over a merely-more-recent one. This is not cosmetic: ``resume_session``
-    transitions the row in place and the worker runs it in that row's own
-    ``working_dir``, so resuming a session belonging to another lane makes work
-    for issue A land as commits on lane B's branch. Only when no
-    same-lane candidate exists does most-recently-updated decide.
+    The lane match is a FILTER on both buckets, not a preference: a row is
+    eligible only when its ``slug`` is non-``None`` and equal to ``lane_slug``.
+    This is not cosmetic. ``resume_session`` transitions the row in place and
+    the worker runs it in that row's own ``working_dir``, so acting on a
+    session belonging to another lane makes work for issue A land as commits on
+    lane B's branch — and acting on a *slugless* row drops an unprompted
+    message into a human conversation thread (#3270). Recency only ranks rows
+    the filter already admitted; with no same-lane candidate the caller creates
+    a fresh session, which is the recoverable outcome.
+
+    Rung 1 falls through to rung 2, never straight to ``create``: a lane with
+    no live session may still have a perfectly good resumable one.
+
+    ``failed`` is excluded from rung 2 only. A row that failed once fails the
+    same way again, so re-resuming it on a timer is a loop, not a recovery.
+    The check has no place in rung 1 — ``failed`` is terminal and can never
+    reach the live bucket.
 
     ``("unknown", None)`` means the session query itself failed — the caller
     declines to act rather than guessing.
@@ -834,21 +845,29 @@ def _pick_steer_target(project_key: str, lane_slug: str | None = None) -> tuple[
         logger.warning("sdlc_progress: target query failed for %s: %s", project_key, exc)
         return ("unknown", None)
 
-    def _rank(row) -> tuple[int, float]:
-        """Same-lane first, then most recently updated."""
-        same_lane = 1 if (lane_slug and getattr(row, "slug", None) == lane_slug) else 0
-        return (same_lane, to_unix_ts(getattr(row, "updated_at", None)) or 0.0)
+    def _same_lane(row) -> bool:
+        """Eligibility for BOTH rungs: this row belongs to this lane, period."""
+        slug = getattr(row, "slug", None)
+        return bool(lane_slug) and slug is not None and slug == lane_slug
+
+    def _rank(row) -> float:
+        """Most recently updated, among rows the lane filter already admitted."""
+        return to_unix_ts(getattr(row, "updated_at", None)) or 0.0
 
     live: list[Any] = []
     resumable: list[Any] = []
     for row in rows:
         try:
-            if _is_ledger(row):
+            if _is_ledger(row) or not _same_lane(row):
                 continue
             status = getattr(row, "status", None)
             if status in NON_TERMINAL_STATUSES:
                 live.append(row)
-            elif status in RESUMABLE_STATUSES and getattr(row, "claude_session_uuid", None):
+            elif (
+                status in RESUMABLE_STATUSES
+                and status != "failed"
+                and getattr(row, "claude_session_uuid", None)
+            ):
                 resumable.append(row)
         except Exception as exc:  # pragma: no cover — defensive per-row guard
             logger.debug("sdlc_progress: target selection skipped a row: %r", exc)
@@ -1046,10 +1065,10 @@ def _check_project_stalls(project: dict) -> dict:
     creates_this_tick = 0
     # Same per-call, non-atomic status as `creates_this_tick`. `actions_this_tick`
     # is the secondary count bound; `targets_this_tick` is the PRIMARY burst
-    # guard -- `_pick_steer_target` queries project-wide with same-lane only a
-    # ranking preference, so several newly-visible lanes with no same-lane
-    # session all select the SAME eng session, which a count cap alone would
-    # happily steer three times in one tick with three different issues.
+    # guard -- `_pick_steer_target` queries project-wide and filters by lane, so
+    # two newly-visible lanes resolving to the same slug still select the SAME
+    # eng session, which a count cap alone would happily steer twice in one tick
+    # with two different issues.
     actions_this_tick = 0
     targets_this_tick: set[str] = set()
 

--- a/tests/fixtures/persona/eng_worker_repo_baseline.txt
+++ b/tests/fixtures/persona/eng_worker_repo_baseline.txt
@@ -50,9 +50,6 @@ world, ship working code); community-driven technology.
 
 ## Communication Style
 
-<!-- If you modify this section, review DRAFTER_SYSTEM_PROMPT in
-     bridge/message_drafter.py to ensure it still matches Valor's voice. -->
-
 I communicate via Telegram. For how to trigger work or interact with me, refer
 collaborators to `docs/features/telegram-pm-guide.md` (`issue 363` starts SDLC, `PR 363`
 resumes it, reply-to continues a session).
@@ -68,9 +65,10 @@ response reaches Telegram my session is OVER — "I'll update that", "going forw
 "next time" are lies unless the change already happened this session. I show evidence of
 what I DID (commit hash, file path) or honestly say I didn't.
 
-Long outputs are condensed by the message drafter (`bridge/message_drafter.py`, Haiku),
-which represents me as a senior developer reporting to a PM: outcomes over process,
-blockers flagged, hashes and URLs preserved.
+Nothing rewrites my words on the way out: the message drafter
+(`bridge/message_drafter.py`) validates and composes, it does not summarize. Length is
+mine to control. A response too long for the medium is attached as a file rather than
+shortened, so writing short is my job, not the pipeline's.
 
 ## When I Reach Out
 

--- a/tests/unit/output_handler/test_output_handler_delivery.py
+++ b/tests/unit/output_handler/test_output_handler_delivery.py
@@ -214,6 +214,56 @@ class TestDeferredSelfDraftRelease:
         # Concurrent keys must survive the merge.
         assert auth_session.extra_context.get("transport") == "telegram"
 
+    def test_clean_send_mirrors_the_clear_onto_the_callers_own_object(self):
+        """The clear must land on the CALLER's object too, not just the fresh read.
+
+        Failure scenario without the mirror: the redraft succeeds, the
+        authoritative row is cleared, and then ``finalize_session`` runs its
+        trailing full ``session.save()`` on the caller's object -- which still
+        holds ``deferred_self_draft_pending`` plus the originally rejected
+        draft text. That write re-arms the flag on the terminal row, and
+        ``_deferred_self_draft_backstop_sweep`` selects terminal rows on that
+        flag alone and re-delivers the rejected text on top of the successful
+        rewrite. Both fields have to be mirrored; the stamp alone is not enough.
+        """
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        handler = self._make_handler()
+        session = MagicMock()
+        session.session_id = "sess-mirror"
+        session.response_delivered_at = None
+        session.extra_context = {
+            "transport": "telegram",
+            "deferred_self_draft_pending": True,
+            "deferred_self_draft_text": "the originally rejected text",
+        }
+
+        auth_session = MagicMock()
+        auth_session.extra_context = dict(session.extra_context)
+        auth_session.save = MagicMock()
+
+        with (
+            patch(
+                "bridge.message_drafter.draft_message",
+                AsyncMock(side_effect=self._bypass_drafter),
+            ),
+            patch("agent.steering.reset_self_draft_attempts"),
+            patch(
+                "models.session_lifecycle.get_authoritative_session",
+                return_value=auth_session,
+            ),
+        ):
+            outcome = asyncio.run(handler.send("123", "the successful rewrite", 0, session=session))
+
+        assert outcome == DeliveryOutcome.sent
+        assert "deferred_self_draft_pending" not in session.extra_context, (
+            "the caller's own object still carries the pending flag; "
+            "finalize_session's trailing full save will re-arm it"
+        )
+        assert "deferred_self_draft_text" not in session.extra_context
+        assert session.extra_context.get("transport") == "telegram"
+        assert session.response_delivered_at is not None
+
     def test_clean_send_without_pending_flag_does_not_touch_extra_context(self):
         """When the flag was never set, the clean path must not perform the
         authoritative RMW at all (cheap-check gate)."""

--- a/tests/unit/output_handler/test_output_handler_stale_snapshot.py
+++ b/tests/unit/output_handler/test_output_handler_stale_snapshot.py
@@ -1,0 +1,133 @@
+"""Red-first regression test for the stale-snapshot lifecycle clobber (#3270, A3a).
+
+**A bare ``save()`` on an AgentSession is a lifecycle write.** ``status`` is an
+``IndexedField`` (``models/agent_session.py``), and popoto's
+``save(update_fields=None)`` path encodes the *entire* instance into one HSET
+and runs ``on_save()`` for every field. So any code that reads a row, mutates
+one unrelated field, and calls a bare ``save()`` is silently authorized to
+rewrite the session's lifecycle state from a stale snapshot -- with no
+LIFECYCLE log line and no ``session_events`` entry to show for it.
+
+``agent/output_handler.py`` had two such writers on the incident path:
+
+* ``_persist_routing_fields`` -- writes ``context_summary``
+* ``_rtr_emit_event``        -- writes ``session_events``
+
+Both are narrowed to ``save(update_fields=[...])``. This test encodes the rule
+rather than the site count: it is parametrized over both call sites because the
+field sets differ, so a test written against one proves nothing about the other.
+
+Real Redis (per-worker test db via the autouse ``redis_test_db`` fixture) and
+real ``AgentSession`` rows. Session ids use the ``test-oh-stale-`` prefix.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from agent.output_handler import TelegramRelayOutputHandler
+from models.agent_session import AgentSession
+
+SID_PREFIX = "test-oh-stale-"
+
+
+@pytest.fixture
+def cleanup(redis_test_db):
+    created: list[str] = []
+    yield created
+    for sid in created:
+        try:
+            for rec in list(AgentSession.query.filter(session_id=sid)):
+                rec.delete()
+        except Exception:
+            pass
+
+
+def _make_session(session_id: str) -> AgentSession:
+    now = datetime.now(tz=UTC)
+    return AgentSession.create(
+        session_id=session_id,
+        session_type="teammate",
+        project_key="test-oh-stale",
+        status="running",
+        chat_id="test-oh-stale-chat",
+        telegram_message_id=99,
+        sender_name="TestUser",
+        message_text="hello",
+        created_at=now,
+        started_at=now,
+        updated_at=now,
+    )
+
+
+def _invoke_persist_routing_fields(handler, session):
+    """Drive the production ``_persist_routing_fields`` write path."""
+
+    class _Draft:
+        context_summary = "routing summary written from a stale snapshot"
+
+    handler._persist_routing_fields(session, _Draft())
+
+
+def _invoke_rtr_emit_event(handler, session):
+    """Drive the production ``_rtr_emit_event`` write path."""
+    handler._rtr_emit_event(
+        session,
+        "rtr.suppressed",
+        chat_id="test-oh-stale-chat",
+        draft_text="a draft the room did not need",
+        reason="stale-snapshot regression",
+    )
+
+
+@pytest.mark.parametrize(
+    ("invoke", "persisted_field"),
+    [
+        pytest.param(
+            _invoke_persist_routing_fields, "context_summary", id="persist_routing_fields"
+        ),
+        pytest.param(_invoke_rtr_emit_event, "session_events", id="rtr_emit_event"),
+    ],
+)
+def test_stale_snapshot_cannot_clobber_a_concurrently_written_status(
+    cleanup, invoke, persisted_field
+):
+    """A stale in-memory copy must not rewrite ``status`` through these writers.
+
+    Sequence: load a row, hold a stale in-memory copy, let a *different*
+    writer move the row's status in Redis, then drive the production save path
+    on the stale copy. The status in Redis must be unchanged, and the writer's
+    own field must still have landed.
+
+    Red before the fix: the bare ``save()`` HSETs the whole stale instance, so
+    ``status`` reverts to the snapshot's value and the ``status`` index follows
+    it -- silently, with no lifecycle log and no ``session_events`` entry.
+    """
+    sid = f"{SID_PREFIX}{persisted_field}"
+    cleanup.append(sid)
+    _make_session(sid)
+
+    # The stale caller's snapshot: read while the row still says "running".
+    stale = next(iter(AgentSession.query.filter(session_id=sid)))
+    assert stale.status == "running", "precondition: snapshot captured at running"
+
+    # A concurrent lifecycle write moves the row on. Narrow by construction so
+    # the only candidate clobber in this test is the one under examination.
+    concurrent = next(iter(AgentSession.query.filter(session_id=sid)))
+    concurrent.status = "completed"
+    concurrent.save(update_fields=["status"])
+
+    handler = TelegramRelayOutputHandler()
+    invoke(handler, stale)
+
+    after = next(iter(AgentSession.query.filter(session_id=sid)))
+    assert after.status == "completed", (
+        f"a bare save() in the {persisted_field!r} writer resurrected the stale "
+        f"snapshot's status -- got {after.status!r}, expected 'completed'. A bare "
+        "save() on an AgentSession is a lifecycle write."
+    )
+    assert getattr(after, persisted_field, None), (
+        f"the narrowed save must still persist {persisted_field!r}"
+    )

--- a/tests/unit/reflections/test_reflections_progress_check.py
+++ b/tests/unit/reflections/test_reflections_progress_check.py
@@ -148,16 +148,26 @@ class _FakeQuery:
         return _Rows()
 
 
+# The lane every default-fixture test stalls: ``stalled_pr`` serves
+# ``_pr(branch="session/sdlc-1395")``, so this is the slug the lane filter
+# (#3270) actually matches against on those tests. ``_Row`` defaults to it so
+# the filter is EXERCISED rather than bypassed -- a row seeded with a
+# match-anything slug would let every ladder test pass even if the filter were
+# deleted. Tests that stall a differently-named lane pass that lane's real
+# slug; tests about the filter itself pass a rival slug or ``None``.
+_DEFAULT_LANE_SLUG = "sdlc-1395"
+
+
 class _AnyLane(str):
     """A slug that belongs to whichever lane the test is exercising.
 
-    Target selection filters rows by lane (#3270), so a slugless row is
-    ineligible for every rung. The ladder tests below are about the *ladder* --
-    cooldowns, attempt budgets, action windows, escalation volume -- and not
-    about which row gets picked, so their seeded session uses this slug to say
-    "this row belongs to the lane under test" without each of them repeating
-    the lane's slug. Tests that are about lane matching pass a real slug, or
-    ``None`` for the slugless conversation thread the filter must exclude.
+    Deliberately narrow: the ONLY remaining use is the pair of target-dedupe
+    tests that need one row to be selected for TWO different lanes in a single
+    tick. Post-#3270 a real row cannot do that (it carries one slug), so the
+    scenario the dedupe defends against is reachable only through this
+    sentinel. Never reach for it to avoid naming a lane -- pass the lane's
+    real slug, or ``None`` for the slugless conversation thread the filter
+    must exclude.
     """
 
     def __eq__(self, other):
@@ -185,7 +195,7 @@ class _Row:
         claude_session_uuid=None,
         updated_at=None,
         project_key="valor",
-        slug=_ANY_LANE,
+        slug=_DEFAULT_LANE_SLUG,
     ):
         self.session_id = session_id
         self.status = status
@@ -461,7 +471,7 @@ def test_human_named_lane_is_discovered_and_steered(lab, stub_workdir, gh_payloa
         }
     ]
     monkeypatch.setattr(sdlc_progress, "_last_commit", lambda cwd, b: ("sha-dev-1", now - 9 * 3600))
-    lab.query.by_project = [_Row("eng-live", status="running")]
+    lab.query.by_project = [_Row("eng-live", status="running", slug="dev-41a59eee")]
 
     result = sdlc_progress._check_project_stalls(_AI_PROJECT)
 
@@ -506,7 +516,9 @@ def test_ledger_rung_resolves_a_lane_the_branch_name_cannot(lab, stub_workdir, s
     """Rung 1: a recorded ``pr_number`` binds a human-named lane to its issue."""
     stale_lanes["prs"] = [_lane_pr(2798, "session/dashboard-jinja-filter-registrar")]
     lab.ledger.records = [_LedgerRecord(pr_number=2798, issue_number=2719)]
-    lab.query.by_project = [_Row("eng-live", status="running")]
+    lab.query.by_project = [
+        _Row("eng-live", status="running", slug="dashboard-jinja-filter-registrar")
+    ]
 
     sdlc_progress._check_project_stalls(_AI_PROJECT)
 
@@ -518,7 +530,7 @@ def test_ledger_rung_wins_over_a_disagreeing_closing_reference(lab, stub_workdir
     """The entire justification for the rung ordering, asserted directly."""
     stale_lanes["prs"] = [_lane_pr(2798, "session/some-lane", closing=[555])]
     lab.ledger.records = [_LedgerRecord(pr_number=2798, issue_number=2719)]
-    lab.query.by_project = [_Row("eng-live", status="running")]
+    lab.query.by_project = [_Row("eng-live", status="running", slug="some-lane")]
 
     sdlc_progress._check_project_stalls(_AI_PROJECT)
 
@@ -563,7 +575,7 @@ def test_two_ledger_records_on_one_pr_are_ambiguous_not_an_overwrite(
         _LedgerRecord(pr_number=2798, issue_number=2719),
         _LedgerRecord(pr_number=2798, issue_number=2720),
     ]
-    lab.query.by_project = [_Row("eng-live", status="running")]
+    lab.query.by_project = [_Row("eng-live", status="running", slug="some-lane")]
 
     result = sdlc_progress._check_project_stalls(_AI_PROJECT)
 
@@ -576,7 +588,9 @@ def test_two_closing_references_are_ambiguous_and_produce_no_action(lab, stub_wo
     stale_lanes["prs"] = [
         _lane_pr(2746, "session/hook-validator-target-resolution", closing=[2689, 2738])
     ]
-    lab.query.by_project = [_Row("eng-live", status="running")]
+    lab.query.by_project = [
+        _Row("eng-live", status="running", slug="hook-validator-target-resolution")
+    ]
 
     result = sdlc_progress._check_project_stalls(_AI_PROJECT)
 
@@ -599,7 +613,7 @@ def test_cross_repo_closing_reference_does_not_resolve(lab, stub_workdir, stale_
             "closingIssuesReferences": [_closing_ref(77, owner="tomcounsell", repo="popoto")],
         }
     ]
-    lab.query.by_project = [_Row("eng-live", status="running")]
+    lab.query.by_project = [_Row("eng-live", status="running", slug="some-lane")]
 
     result = sdlc_progress._check_project_stalls(_AI_PROJECT)
 
@@ -628,7 +642,7 @@ def test_no_target_repo_issues_no_ledger_query_and_trusts_no_reference(
     """Both read-based rungs need a repo to scope by; without one they are skipped."""
     stale_lanes["prs"] = [_lane_pr(2798, "session/some-lane", closing=[999])]
     lab.ledger.records = [_LedgerRecord(pr_number=2798, issue_number=2719)]
-    lab.query.by_project = [_Row("eng-live", status="running")]
+    lab.query.by_project = [_Row("eng-live", status="running", slug="some-lane")]
 
     result = sdlc_progress._check_project_stalls(_PROJECT)  # no github block
 
@@ -643,7 +657,7 @@ def test_the_ledger_is_enumerated_once_per_tick_not_once_per_pr(lab, stub_workdi
         _lane_pr(2, "session/lane-two", closing=[102]),
         _lane_pr(3, "session/lane-three", closing=[103]),
     ]
-    lab.query.by_project = [_Row("eng-live", status="running")]
+    lab.query.by_project = [_Row("eng-live", status="running", slug="lane-one")]
 
     sdlc_progress._check_project_stalls(_AI_PROJECT)
 
@@ -659,7 +673,7 @@ def test_errored_ledger_still_lets_a_steer_through(lab, stub_workdir, stale_lane
     """Reading is fail-soft: a Redis outage must not blind the detector."""
     lab.ledger.raises = True
     stale_lanes["prs"] = [_lane_pr(2695, "session/dev-41a59eee", closing=[2694])]
-    lab.query.by_project = [_Row("eng-live", status="running")]
+    lab.query.by_project = [_Row("eng-live", status="running", slug="dev-41a59eee")]
 
     result = sdlc_progress._check_project_stalls(_AI_PROJECT)
 
@@ -755,7 +769,7 @@ def test_two_lanes_never_dispatch_to_the_same_session_in_one_tick(lab, stub_work
         _lane_pr(1, "session/lane-one", closing=[101]),
         _lane_pr(2, "session/lane-two", closing=[102]),
     ]
-    lab.query.by_project = [_Row("only-eng-session", status="running")]
+    lab.query.by_project = [_Row("only-eng-session", status="running", slug=_ANY_LANE)]
 
     result = sdlc_progress._check_project_stalls(_AI_PROJECT)
 
@@ -768,7 +782,7 @@ def test_a_lane_deferred_by_the_target_dedupe_owes_no_cooldown(lab, stub_workdir
         _lane_pr(1, "session/lane-one", closing=[101]),
         _lane_pr(2, "session/lane-two", closing=[102]),
     ]
-    lab.query.by_project = [_Row("only-eng-session", status="running")]
+    lab.query.by_project = [_Row("only-eng-session", status="running", slug=_ANY_LANE)]
 
     sdlc_progress._check_project_stalls(_AI_PROJECT)
 
@@ -839,7 +853,7 @@ def test_escalation_volume_with_resume_disabled_is_one_page_per_visible_lane(
         _lane_pr(2, "session/lane-two", closing=[102]),
         _lane_pr(3, "session/lane-three", closing=[103]),
     ]
-    lab.query.by_project = [_Row("eng-live", status="running")]
+    lab.query.by_project = [_Row("eng-live", status="running", slug="lane-one")]
 
     sdlc_progress._check_project_stalls(_AI_PROJECT)
 

--- a/tests/unit/reflections/test_reflections_progress_check.py
+++ b/tests/unit/reflections/test_reflections_progress_check.py
@@ -1007,6 +1007,60 @@ def test_target_falls_back_to_recency_when_no_session_matches_the_lane(fake_quer
     assert (kind, session.session_id) == ("steer", "newest")
 
 
+# ---------------------------------------------------------------------------
+# The lane match is a FILTER, not a ranking preference (#3270)
+#
+# Both rungs rank with the same closure, in which the slug used to be only a
+# tiebreaker. With no same-lane candidate the ladder therefore reached for the
+# most-recently-updated eng row -- routinely a slugless human conversation
+# thread, which the stall check then steered or resumed on behalf of unrelated
+# engineering work. A row with no slug, or a slug belonging to another lane, is
+# now structurally ineligible for either rung.
+# ---------------------------------------------------------------------------
+
+
+def test_resume_rung_never_reaches_a_slugless_conversation_thread(fake_query):
+    """The #3270 loop: a finished chat thread resumed for an unrelated lane."""
+    now = time.time()
+    fake_query.by_project = [
+        _Row("chat-thread", status="completed", claude_session_uuid="u1", slug=None, updated_at=now)
+    ]
+    assert sdlc_progress._pick_steer_target("valor", lane_slug="X") == ("create", None)
+
+
+def test_steer_rung_never_reaches_a_slugless_conversation_thread(fake_query):
+    """Rung 1's twin of the same defect: an unprompted steer into a stranger's thread."""
+    now = time.time()
+    fake_query.by_project = [_Row("chat-thread", status="running", slug=None, updated_at=now)]
+    assert sdlc_progress._pick_steer_target("valor", lane_slug="X") == ("create", None)
+
+
+def test_steer_rung_falls_through_to_the_resume_rung_not_to_create(fake_query):
+    """No same-lane LIVE row must not skip a perfectly good same-lane resumable one."""
+    now = time.time()
+    fake_query.by_project = [
+        _Row("chat-thread", status="running", slug=None, updated_at=now),
+        _Row(
+            "this-lane",
+            status="completed",
+            claude_session_uuid="u1",
+            slug="X",
+            updated_at=now - 3600,
+        ),
+    ]
+    kind, session = sdlc_progress._pick_steer_target("valor", lane_slug="X")
+    assert (kind, session.session_id) == ("resume", "this-lane")
+
+
+def test_resume_rung_never_selects_a_failed_row(fake_query):
+    """A row that failed once fails the same way again -- re-resuming it is a loop."""
+    now = time.time()
+    fake_query.by_project = [
+        _Row("this-lane", status="failed", claude_session_uuid="u1", slug="X", updated_at=now)
+    ]
+    assert sdlc_progress._pick_steer_target("valor", lane_slug="X") == ("create", None)
+
+
 def test_ladder_threads_the_stalled_lanes_slug_into_target_selection(lab, stub_workdir, stalled_pr):
     now = time.time()
     lab.query.by_project = [

--- a/tests/unit/reflections/test_reflections_progress_check.py
+++ b/tests/unit/reflections/test_reflections_progress_check.py
@@ -148,6 +148,31 @@ class _FakeQuery:
         return _Rows()
 
 
+class _AnyLane(str):
+    """A slug that belongs to whichever lane the test is exercising.
+
+    Target selection filters rows by lane (#3270), so a slugless row is
+    ineligible for every rung. The ladder tests below are about the *ladder* --
+    cooldowns, attempt budgets, action windows, escalation volume -- and not
+    about which row gets picked, so their seeded session uses this slug to say
+    "this row belongs to the lane under test" without each of them repeating
+    the lane's slug. Tests that are about lane matching pass a real slug, or
+    ``None`` for the slugless conversation thread the filter must exclude.
+    """
+
+    def __eq__(self, other):
+        return isinstance(other, str)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(str(self))
+
+
+_ANY_LANE = _AnyLane("<any-lane>")
+
+
 class _Row:
     """Minimal AgentSession row shape the reflection actually reads."""
 
@@ -160,7 +185,7 @@ class _Row:
         claude_session_uuid=None,
         updated_at=None,
         project_key="valor",
-        slug=None,
+        slug=_ANY_LANE,
     ):
         self.session_id = session_id
         self.status = status
@@ -907,45 +932,60 @@ def test_lane_is_live_malformed_payload_is_unknown(fake_redis, fake_query):
 
 def test_target_prefers_live_over_resumable(fake_query):
     fake_query.by_project = [
-        _Row("resumable", status="completed", claude_session_uuid="u1"),
-        _Row("live", status="running"),
+        _Row("resumable", status="completed", claude_session_uuid="u1", slug="sdlc-1395"),
+        _Row("live", status="running", slug="sdlc-1395"),
     ]
-    kind, session = sdlc_progress._pick_steer_target("valor")
+    kind, session = sdlc_progress._pick_steer_target("valor", lane_slug="sdlc-1395")
     assert (kind, session.session_id) == ("steer", "live")
 
 
-def test_target_live_picks_most_recently_updated(fake_query):
+def test_target_live_picks_most_recently_updated_within_the_lane(fake_query):
+    """Recency still decides -- but only among rows the lane filter admitted."""
     now = time.time()
     fake_query.by_project = [
-        _Row("old", status="running", updated_at=now - 900),
-        _Row("newest", status="running", updated_at=now),
+        _Row("old", status="running", slug="sdlc-1395", updated_at=now - 900),
+        _Row("newest", status="running", slug="sdlc-1395", updated_at=now),
     ]
-    kind, session = sdlc_progress._pick_steer_target("valor")
+    kind, session = sdlc_progress._pick_steer_target("valor", lane_slug="sdlc-1395")
     assert (kind, session.session_id) == ("steer", "newest")
 
 
-def test_target_falls_back_to_most_recent_resumable(fake_query):
+def test_target_falls_back_to_the_most_recent_resumable_in_the_lane(fake_query):
     now = time.time()
     fake_query.by_project = [
-        _Row("older", status="completed", claude_session_uuid="u1", updated_at=now - 900),
-        _Row("newer", status="killed", claude_session_uuid="u2", updated_at=now),
+        _Row(
+            "older",
+            status="completed",
+            claude_session_uuid="u1",
+            slug="sdlc-1395",
+            updated_at=now - 900,
+        ),
+        _Row("newer", status="killed", claude_session_uuid="u2", slug="sdlc-1395", updated_at=now),
     ]
-    kind, session = sdlc_progress._pick_steer_target("valor")
+    kind, session = sdlc_progress._pick_steer_target("valor", lane_slug="sdlc-1395")
     assert (kind, session.session_id) == ("resume", "newer")
 
 
 def test_target_resumable_without_uuid_is_not_resumable(fake_query):
     """resume_session requires a claude_session_uuid; without one we create."""
-    fake_query.by_project = [_Row("no-uuid", status="completed", claude_session_uuid=None)]
-    assert sdlc_progress._pick_steer_target("valor") == ("create", None)
+    fake_query.by_project = [
+        _Row("no-uuid", status="completed", claude_session_uuid=None, slug="sdlc-1395")
+    ]
+    assert sdlc_progress._pick_steer_target("valor", lane_slug="sdlc-1395") == ("create", None)
 
 
 def test_target_ledger_anchors_are_never_selected(fake_query):
     fake_query.by_project = [
-        _Row("sdlc-local-1395", status="running", is_ledger=True),
-        _Row("ledger-terminal", status="completed", is_ledger=True, claude_session_uuid="u1"),
+        _Row("sdlc-local-1395", status="running", is_ledger=True, slug="sdlc-1395"),
+        _Row(
+            "ledger-terminal",
+            status="completed",
+            is_ledger=True,
+            claude_session_uuid="u1",
+            slug="sdlc-1395",
+        ),
     ]
-    assert sdlc_progress._pick_steer_target("valor") == ("create", None)
+    assert sdlc_progress._pick_steer_target("valor", lane_slug="sdlc-1395") == ("create", None)
 
 
 def test_target_query_is_scoped_to_project_and_eng(fake_query):
@@ -997,14 +1037,19 @@ def test_resume_target_also_prefers_the_stalled_lanes_own_session(fake_query):
     assert (kind, session.session_id) == ("resume", "this-lane")
 
 
-def test_target_falls_back_to_recency_when_no_session_matches_the_lane(fake_query):
+def test_target_is_the_create_rung_when_no_session_matches_the_lane(fake_query):
+    """No same-lane row means a FRESH session, never the most recent stranger.
+
+    This case used to assert the recency fallback. That fallback is the #3270
+    defect: a stalled lane with no session of its own reached for whichever eng
+    row was touched last, up to and including a human conversation thread.
+    """
     now = time.time()
     fake_query.by_project = [
-        _Row("old", status="running", slug="sdlc-1", updated_at=now - 900),
-        _Row("newest", status="running", slug=None, updated_at=now),
+        _Row("other-lane", status="running", slug="sdlc-1", updated_at=now - 900),
+        _Row("slugless", status="running", slug=None, updated_at=now),
     ]
-    kind, session = sdlc_progress._pick_steer_target("valor", lane_slug="sdlc-1395")
-    assert (kind, session.session_id) == ("steer", "newest")
+    assert sdlc_progress._pick_steer_target("valor", lane_slug="sdlc-1395") == ("create", None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/session_runner/test_runner_preempt.py
+++ b/tests/unit/session_runner/test_runner_preempt.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import signal
+import uuid
 from unittest.mock import patch
 
 from agent.session_runner.adapter import SessionRunnerAdapter
@@ -289,6 +290,9 @@ async def test_timeout_expiry_is_graceful_preempt_not_error():
         pid_alive_fn=lambda pid: False,
         turn_timeout_s=0.12,
     )
+    # Unique id: the notice is deduped per session (#3270 A6b), so a shared
+    # fixture id would let a previous test run's dedupe key suppress this send.
+    session.session_id = f"dbg-a6b-single-{uuid.uuid4()}"
     summary = await runner.run("long task")
     assert kills and kills[0][1] == signal.SIGTERM
     assert summary.exit_reason == "turn_timeout"
@@ -785,3 +789,41 @@ async def test_stamp_failure_never_breaks_the_turn():
 
     assert summary.exit_reason is ExitReason.PM_USER
     assert deliveries == ["done"]
+
+
+async def test_timeout_notice_delivered_once_across_two_runs_of_one_session():
+    """A6b (#3270): the needs-attention notice is per-SESSION, not per-run.
+
+    The incident: a stranded conversation row was re-enqueued on a ~hourly
+    cadence and every re-run timed out and re-posted the byte-identical
+    ``TIMEOUT_NEEDS_ATTENTION_MESSAGE`` into the human's chat. Two runs of the
+    SAME ``session_id`` must produce exactly ONE delivery.
+    """
+    session_id = f"dbg-a6b-{uuid.uuid4()}"
+    deliveries: list[str] = []
+
+    async def _timeout_run() -> None:
+        driver = KillableDriver()
+
+        def fake_kill(pid, sig):
+            driver.kill_event.set()
+
+        runner, _, session = make_preempt_runner(
+            driver,
+            steering=lambda: [],
+            deliveries=deliveries,
+            kill_fn=fake_kill,
+            killpg_fn=fake_kill,
+            pid_alive_fn=lambda pid: False,
+            turn_timeout_s=0.12,
+        )
+        session.session_id = session_id
+        summary = await runner.run("long task")
+        assert summary.exit_reason == "turn_timeout"
+
+    await _timeout_run()
+    await _timeout_run()
+
+    assert deliveries.count(TIMEOUT_NEEDS_ATTENTION_MESSAGE) == 1, (
+        f"timeout notice re-delivered once per run: {deliveries!r}"
+    )

--- a/tests/unit/session_runner/test_runner_preempt.py
+++ b/tests/unit/session_runner/test_runner_preempt.py
@@ -791,39 +791,64 @@ async def test_stamp_failure_never_breaks_the_turn():
     assert deliveries == ["done"]
 
 
-async def test_timeout_notice_delivered_once_across_two_runs_of_one_session():
-    """A6b (#3270): the needs-attention notice is per-SESSION, not per-run.
+async def _run_until_timeout(session_id: str, row_id: str, deliveries: list[str]) -> None:
+    """Drive one turn to TURN_TIMEOUT for a given (thread, row) identity."""
+    driver = KillableDriver()
+
+    def fake_kill(pid, sig):
+        driver.kill_event.set()
+
+    runner, _, session = make_preempt_runner(
+        driver,
+        steering=lambda: [],
+        deliveries=deliveries,
+        kill_fn=fake_kill,
+        killpg_fn=fake_kill,
+        pid_alive_fn=lambda pid: False,
+        turn_timeout_s=0.12,
+    )
+    session.session_id = session_id
+    session.id = row_id
+    summary = await runner.run("long task")
+    assert summary.exit_reason == "turn_timeout"
+
+
+async def test_timeout_notice_delivered_once_across_two_runs_of_one_row():
+    """A6b (#3270): the needs-attention notice is once per stranded ROW.
 
     The incident: a stranded conversation row was re-enqueued on a ~hourly
     cadence and every re-run timed out and re-posted the byte-identical
-    ``TIMEOUT_NEEDS_ATTENTION_MESSAGE`` into the human's chat. Two runs of the
-    SAME ``session_id`` must produce exactly ONE delivery.
+    ``TIMEOUT_NEEDS_ATTENTION_MESSAGE`` into the human's chat. Re-runs of that
+    row keep its record ``id``, so two runs must produce exactly ONE delivery.
+    """
+    session_id = f"dbg-a6b-{uuid.uuid4()}"
+    row_id = f"row-{uuid.uuid4()}"
+    deliveries: list[str] = []
+
+    await _run_until_timeout(session_id, row_id, deliveries)
+    await _run_until_timeout(session_id, row_id, deliveries)
+
+    assert deliveries.count(TIMEOUT_NEEDS_ATTENTION_MESSAGE) == 1, (
+        f"timeout notice re-delivered once per run: {deliveries!r}"
+    )
+
+
+async def test_timeout_notice_redelivered_for_a_later_unrelated_request():
+    """A6b must not silence a NEW request that happens to time out too.
+
+    A resumed session reuses its thread ``session_id`` but is minted a fresh
+    AgentSession record ``id``. A ``session_id``-only dedupe key would suppress
+    the notice for a request the human made hours later -- and that suppression
+    is unrecoverable, because ``TURN_TIMEOUT`` is not ``wrapup_eligible``, so
+    nothing else would be said. The human would get pure silence.
     """
     session_id = f"dbg-a6b-{uuid.uuid4()}"
     deliveries: list[str] = []
 
-    async def _timeout_run() -> None:
-        driver = KillableDriver()
+    await _run_until_timeout(session_id, f"row-{uuid.uuid4()}", deliveries)
+    await _run_until_timeout(session_id, f"row-{uuid.uuid4()}", deliveries)
 
-        def fake_kill(pid, sig):
-            driver.kill_event.set()
-
-        runner, _, session = make_preempt_runner(
-            driver,
-            steering=lambda: [],
-            deliveries=deliveries,
-            kill_fn=fake_kill,
-            killpg_fn=fake_kill,
-            pid_alive_fn=lambda pid: False,
-            turn_timeout_s=0.12,
-        )
-        session.session_id = session_id
-        summary = await runner.run("long task")
-        assert summary.exit_reason == "turn_timeout"
-
-    await _timeout_run()
-    await _timeout_run()
-
-    assert deliveries.count(TIMEOUT_NEEDS_ATTENTION_MESSAGE) == 1, (
-        f"timeout notice re-delivered once per run: {deliveries!r}"
+    assert deliveries.count(TIMEOUT_NEEDS_ATTENTION_MESSAGE) == 2, (
+        "a later, unrelated request in the same thread was silenced by the "
+        f"A6b dedupe: {deliveries!r}"
     )

--- a/tests/unit/test_finalize_idempotent_skip_observability.py
+++ b/tests/unit/test_finalize_idempotent_skip_observability.py
@@ -1,0 +1,131 @@
+"""Red-first observability test for ``finalize_session``'s idempotent skip (#3270, A2).
+
+``finalize_session`` treats "already in this terminal state" as success and
+returns silently. In the #3270 incident that silence is what stranded the
+session: a stale full save had already written ``completed`` onto a row whose
+harness was still mid-turn, so the real turn-end finalize hit the idempotency
+skip, never set ``completed_at``, never emitted a lifecycle event -- and a later
+stale save put the row back to ``running``, where the orphan net found it. The
+chain ran for days with nothing above DEBUG to show for it.
+
+A skip that coincides with a LIVE execution fence is the anomalous case: the
+row is already terminal while the runner that owns it is still alive. That is
+the turn-end race, and it now logs at WARNING naming the session id, the status
+found on the authoritative record, and the status requested.
+
+**Observability only.** The idempotency semantics are unchanged and out of
+scope here (#3253) -- the skip still returns without side effects.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+
+from models.agent_session import AgentSession
+from models.session_lifecycle import finalize_session
+
+SID_PREFIX = "test-idem-warn-"
+
+
+@pytest.fixture
+def cleanup(redis_test_db):
+    created: list[str] = []
+    yield created
+    for sid in created:
+        try:
+            for rec in list(AgentSession.query.filter(session_id=sid)):
+                rec.delete()
+        except Exception:
+            pass
+
+
+def _make_terminal_session(session_id: str, *, with_fence: bool) -> AgentSession:
+    now = datetime.now(tz=UTC)
+    kwargs: dict = {}
+    if with_fence:
+        # Our own pid, with its real create_time, is a fence that resolves live.
+        kwargs["exec_pid"] = os.getpid()
+        kwargs["pid_create_time"] = _own_create_time()
+    return AgentSession.create(
+        session_id=session_id,
+        session_type="teammate",
+        project_key="test-idem-warn",
+        status="completed",
+        chat_id="test-idem-warn-chat",
+        sender_name="TestUser",
+        message_text="hello",
+        created_at=now,
+        started_at=now,
+        updated_at=now,
+        **kwargs,
+    )
+
+
+def _own_create_time() -> float:
+    from agent.pid_fence import proc_create_time
+
+    return proc_create_time(os.getpid())
+
+
+def test_idempotent_skip_with_a_live_fence_warns(cleanup, caplog):
+    """A turn-end finalize skipped as idempotent while its runner is alive WARNs.
+
+    Red before the fix: the skip logs at DEBUG, so the strand is invisible.
+    """
+    sid = f"{SID_PREFIX}live-fence"
+    cleanup.append(sid)
+    session = _make_terminal_session(sid, with_fence=True)
+
+    with caplog.at_level(logging.DEBUG, logger="models.session_lifecycle"):
+        finalize_session(session, "completed", reason="transcript completed: completed")
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING and sid in r.getMessage()]
+    assert warnings, (
+        "an idempotent skip racing a live runner fence must be visible at WARNING; "
+        f"got only {[(r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+    msg = warnings[0].getMessage()
+    assert "completed" in msg, "the message must name the status found and requested"
+
+    # Observability only: the skip still returns without side effects (#3253).
+    assert session.completed_at is None, "the idempotency semantics must not change"
+
+
+def test_idempotent_skip_without_a_live_fence_does_not_warn(cleanup, caplog):
+    """No bound runner pid means an ordinary double-finalize -- no WARNING."""
+    sid = f"{SID_PREFIX}no-fence"
+    cleanup.append(sid)
+    session = _make_terminal_session(sid, with_fence=False)
+
+    with caplog.at_level(logging.DEBUG, logger="models.session_lifecycle"):
+        finalize_session(session, "completed", reason="ordinary double finalize")
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING and sid in r.getMessage()]
+    assert not warnings, (
+        "a routine double-finalize with no live runner must stay below WARNING; "
+        f"got {[r.getMessage() for r in warnings]}"
+    )
+
+
+def test_idempotent_skip_with_a_dead_fence_does_not_warn(cleanup, caplog):
+    """A bound but DEAD/recycled pid is residue, not a racing runner."""
+    sid = f"{SID_PREFIX}dead-fence"
+    cleanup.append(sid)
+    session = _make_terminal_session(sid, with_fence=True)
+
+    with (
+        patch("agent.pid_fence.fence_is_live", return_value=False),
+        caplog.at_level(logging.DEBUG, logger="models.session_lifecycle"),
+    ):
+        finalize_session(session, "completed", reason="dead fence residue")
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING and sid in r.getMessage()]
+    assert not warnings, (
+        "a dead or recycled fence pid is not a racing runner; "
+        f"got {[r.getMessage() for r in warnings]}"
+    )

--- a/tests/unit/test_response_delivered_stamp.py
+++ b/tests/unit/test_response_delivered_stamp.py
@@ -225,3 +225,182 @@ async def test_health_check_finalizes_delivered_row_instead_of_requeuing(cleanup
         "the health check requeued a row that had already answered the human -- "
         f"got status={after.status!r}; each requeue posts another unprompted reply"
     )
+
+
+# ---------------------------------------------------------------------------
+# The stamp arms a guard that must not fire on a LIVE row
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_health_check_leaves_a_live_fenced_delivered_row_alone(cleanup):
+    """A running row with a LIVE execution fence is never finalized here.
+
+    The delivery guard in ``_agent_session_health_check`` deliberately skips
+    the ``worker_alive``/``_has_progress`` evaluation, so before #3270 the only
+    thing keeping it off a mid-turn row was that ``response_delivered_at`` was
+    effectively never set. A1 changed that: the redraft path in
+    ``agent/output_handler.py::send`` now stamps mid-run, while the row is
+    still ``running``. A long eng/PM run that answers the human and then keeps
+    working past the 300s health-check cadence therefore presents exactly the
+    shape this guard finalizes -- and finalizing it writes a terminal status
+    onto a row its runner is still driving, which is the mid-turn corruption
+    #3270 exists to stop.
+
+    The fence here is this test process' own pid, so ``fence_is_live`` answers
+    with a real, unmocked liveness verdict.
+    """
+    import os
+
+    from agent.pid_fence import proc_create_time
+
+    sid = f"{SID_PREFIX}live-fence"
+    cleanup.append(sid)
+    session = _make_session(sid, pending_self_draft=False)
+    session.stamp_execution_spawn(
+        pid=os.getpid(),
+        create_time=proc_create_time(os.getpid()),
+        cwd="/tmp",
+        harness="claude",
+    )
+    session.response_delivered_at = datetime.now(tz=UTC)
+    session.save()
+
+    entry = get_authoritative_session(sid)
+    assert entry is not None and entry.status == "running"
+    assert (entry.live_fence or {}).get("pid") == os.getpid(), "precondition: fence is bound"
+
+    # The worker bookkeeping also says this row is being executed, so the ONLY
+    # thing that can finalize it in this pass is the delivery guard.
+    mock_cls = MagicMock()
+    mock_cls.query.filter.return_value = [entry]
+    live_worker = MagicMock()
+    live_worker.done.return_value = False
+    with (
+        patch("agent.session_health.AgentSession", mock_cls),
+        patch("agent.session_health._active_workers", {entry.worker_key: live_worker}),
+        patch("agent.session_health._active_sessions", {entry.agent_session_id: MagicMock()}),
+    ):
+        from agent.session_health import _agent_session_health_check
+
+        await _agent_session_health_check()
+
+    after = get_authoritative_session(sid)
+    assert after is not None
+    assert after.status == "running", (
+        "the delivery guard finalized a row whose runner is still executing -- "
+        f"got status={after.status!r}, the mid-turn terminal-status corruption of #3270"
+    )
+
+
+@pytest.mark.asyncio
+async def test_health_check_still_finalizes_a_delivered_row_with_a_dead_fence(cleanup):
+    """The twin of the test above: no live fence, so #918's guard still fires.
+
+    Same row shape, same fresh ``response_delivered_at`` -- only the fence
+    differs (a pid that is not ours). The liveness gate must narrow the guard
+    to genuinely stranded rows, not disable it.
+    """
+    from agent.pid_fence import proc_create_time
+
+    sid = f"{SID_PREFIX}dead-fence"
+    cleanup.append(sid)
+    session = _make_session(sid, pending_self_draft=False)
+    # A recorded create_time that cannot match whatever holds this pid now:
+    # `fence_is_live` answers False for both "dead" and "recycled".
+    session.stamp_execution_spawn(
+        pid=999_999,
+        create_time=(proc_create_time(1) or 1.0) - 10_000.0,
+        cwd="/tmp",
+        harness="claude",
+    )
+    session.response_delivered_at = datetime.now(tz=UTC)
+    session.save()
+
+    entry = get_authoritative_session(sid)
+    assert entry is not None and entry.status == "running"
+
+    # Identical worker bookkeeping to the live-fence twin above, so the fence
+    # is the ONLY variable between the two tests.
+    mock_cls = MagicMock()
+    mock_cls.query.filter.return_value = [entry]
+    live_worker = MagicMock()
+    live_worker.done.return_value = False
+    with (
+        patch("agent.session_health.AgentSession", mock_cls),
+        patch("agent.session_health._active_workers", {entry.worker_key: live_worker}),
+        patch("agent.session_health._active_sessions", {entry.agent_session_id: MagicMock()}),
+    ):
+        from agent.session_health import _agent_session_health_check
+
+        await _agent_session_health_check()
+
+    after = get_authoritative_session(sid)
+    assert after is not None
+    assert after.status == "completed", (
+        "the #918 duplicate-delivery guard stopped firing on a stranded "
+        f"delivered row -- got status={after.status!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# A1c sibling -- the output_handler.send stamp, through a stale-passing caller
+# ---------------------------------------------------------------------------
+
+
+def test_send_stamp_survives_finalize_session_by_the_same_caller_object(cleanup):
+    """The second stamp site, exercised through the caller shape that clobbers.
+
+    The `finalize_session` caller enumeration classified two production paths
+    as BOTH stale-passing and holding the very object handed to
+    `TelegramRelayOutputHandler.send` as ``session=``:
+    `agent/session_completion.py:1144` (`parent`, the same object passed to
+    `send_cb` a few lines earlier) and the notice-delivery finalizes in
+    `agent/session_health.py` (`entry`, routed into `send` via
+    `deliver_system_notice`). Both then hand that object to `finalize_session`,
+    whose trailing bare `session.save()` writes the object's whole in-memory
+    snapshot back over the row.
+
+    So this test reproduces that exact ordering on one object: redraft-success
+    `send`, then `finalize_session` on the same object. Without the
+    caller-object mirror the stamp is erased and the cleared
+    `deferred_self_draft_pending` is re-armed with the originally rejected
+    draft text -- which `_deferred_self_draft_backstop_sweep` selects on and
+    re-delivers on top of the successful rewrite.
+    """
+    import asyncio
+
+    from agent.output_handler import TelegramRelayOutputHandler
+    from bridge.message_drafter import MessageDraft
+
+    sid = f"{SID_PREFIX}send-stamp-stale"
+    cleanup.append(sid)
+    session = _make_session(sid)
+    assert session.response_delivered_at is None, "precondition: unstamped"
+
+    handler = TelegramRelayOutputHandler()
+    handler._redis = MagicMock()
+
+    async def _bypass_drafter(text, *, session=None, medium="telegram"):
+        return MessageDraft(text=text, artifacts={})
+
+    with (
+        patch("bridge.message_drafter.draft_message", _bypass_drafter),
+        patch("agent.steering.reset_self_draft_attempts"),
+    ):
+        asyncio.run(handler.send(sid, "the successful rewrite", 0, session=session))
+
+    # The caller now hands its OWN object to finalize_session, as the two
+    # enumerated production sites do.
+    finalize_session(session, "completed", reason="test: caller-object finalize")
+
+    fresh = get_authoritative_session(sid)
+    assert fresh is not None
+    assert fresh.status == "completed"
+    assert fresh.response_delivered_at is not None, (
+        "finalize_session's trailing full save erased the send-path stamp"
+    )
+    assert not (fresh.extra_context or {}).get("deferred_self_draft_pending"), (
+        "finalize_session's trailing full save re-armed deferred_self_draft_pending "
+        "with the originally rejected draft text; the backstop sweep will re-deliver it"
+    )

--- a/tests/unit/test_response_delivered_stamp.py
+++ b/tests/unit/test_response_delivered_stamp.py
@@ -1,0 +1,227 @@
+"""Red-first regression tests for the ``response_delivered_at`` stamp (#3270).
+
+Background: ``response_delivered_at`` had exactly two non-test writers
+(``agent/session_executor.py`` under ``action == "deliver"``, and
+``agent/session_completion.py`` gated on ``delivery_attempted``), and neither
+fires for PM/eng sessions whose reply is deferred for self-draft. Those replies
+are delivered by ``agent.session_health.flush_deferred_self_draft_sync``, which
+RPUSHes straight to ``telegram:outbox:`` without stamping the row. The #918
+duplicate-delivery guard ``_delivery_belongs_to_current_run`` therefore returned
+``False`` for every such row, and the #944 orphan net kept requeuing rows that
+had already answered the human.
+
+Three layers are covered here:
+
+* **A1** -- the flush stamps ``response_delivered_at`` on the authoritative row.
+* **A1c** -- the stamp SURVIVES ``finalize_session``'s own trailing full
+  ``session.save()`` on the caller's (possibly stale) object. Testing the flush
+  in isolation is not sufficient: the flush is fresh-reading by design, so an
+  isolated test is green while the production bug survives intact.
+* **A1b** -- with stamp and caller-object mirror in place, the health check
+  finalizes a delivered-but-unfinalized row ``completed`` instead of requeuing
+  it to ``pending``. This is the orphan-bounce reproduction.
+
+Real Redis (per-worker test db via the autouse ``redis_test_db`` fixture), real
+``AgentSession`` rows through the ORM. Session ids use the ``test-rda-`` prefix
+and are deleted in teardown.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.session_health import flush_deferred_self_draft_sync
+from models.agent_session import AgentSession
+from models.session_lifecycle import finalize_session, get_authoritative_session
+
+SID_PREFIX = "test-rda-"
+
+REPLY = (
+    "I committed the card and opened the pull request as requested. "
+    "The change is ready for your review whenever you have a moment."
+)
+
+
+def _redis():
+    """The live test-db Redis handle the flush writes its outbox payload through."""
+    import popoto.redis_db as rdb
+
+    return rdb.POPOTO_REDIS_DB
+
+
+def _outbox_len(session_id: str) -> int:
+    return _redis().llen(f"telegram:outbox:{session_id}")
+
+
+def _make_session(
+    session_id: str,
+    *,
+    status: str = "running",
+    chat_id: str = "test-rda-chat",
+    started_minutes_ago: int = 120,
+    pending_self_draft: bool = True,
+) -> AgentSession:
+    """Create and SAVE a real row carrying a pending deferred self-draft."""
+    extra_context: dict = {"transport": "telegram"}
+    if pending_self_draft:
+        extra_context["deferred_self_draft_pending"] = True
+        extra_context["deferred_self_draft_text"] = REPLY
+    started = datetime.now(tz=UTC) - timedelta(minutes=started_minutes_ago)
+    return AgentSession.create(
+        session_id=session_id,
+        session_type="teammate",
+        project_key="test-rda",
+        status=status,
+        chat_id=chat_id,
+        telegram_message_id=4242,
+        sender_name="TestUser",
+        message_text="commit the card and open a PR",
+        extra_context=extra_context,
+        created_at=started,
+        started_at=started,
+        updated_at=started,
+        turn_count=1,
+        tool_call_count=0,
+    )
+
+
+@pytest.fixture
+def cleanup(redis_test_db):
+    """Track created session_ids; remove rows, outboxes and dedup keys in teardown."""
+    created: list[str] = []
+    yield created
+    r = _redis()
+    for sid in created:
+        run_ids: list[str] = []
+        try:
+            for rec in list(AgentSession.query.filter(session_id=sid)):
+                run_ids.append(str(getattr(rec, "id", "") or ""))
+                rec.delete()
+        except Exception:
+            pass
+        try:
+            r.delete(f"telegram:outbox:{sid}")
+            for rid in {*run_ids, ""}:
+                r.delete(f"self_draft_completed_flush_sent:{sid}:{rid}")
+                r.delete(f"self_draft_fallback_sent:{sid}:{rid}")
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# A1 -- the flush stamps the field
+# ---------------------------------------------------------------------------
+
+
+def test_flush_stamps_response_delivered_at(cleanup):
+    """``flush_deferred_self_draft_sync`` stamps ``response_delivered_at``.
+
+    Red before the fix: the flush writes the outbox payload and returns without
+    ever touching the field, leaving it ``None`` and starving the #918 guard.
+    """
+    sid = f"{SID_PREFIX}flush-stamp"
+    cleanup.append(sid)
+    session = _make_session(sid)
+
+    assert flush_deferred_self_draft_sync(session, "completed") is True
+    assert _outbox_len(sid) == 1, "precondition: the reply was delivered"
+
+    fresh = get_authoritative_session(sid)
+    assert fresh is not None
+    assert fresh.response_delivered_at is not None, (
+        "the flush delivered the reply to the human but never stamped "
+        "response_delivered_at, so the #918 delivery guard can never fire"
+    )
+
+
+# ---------------------------------------------------------------------------
+# A1c -- the stamp survives finalize_session's trailing full save
+# ---------------------------------------------------------------------------
+
+
+def test_stamp_survives_finalize_session_with_stale_caller_object(cleanup):
+    """End-to-end ``finalize_session`` with a STALE caller object.
+
+    ``finalize_session`` invokes the flush (fresh-reading, writes the
+    authoritative record) and then runs a bare ``session.save()`` on the
+    caller's own object -- a full popoto HSET that writes back whatever the
+    caller's in-memory copy holds. A caller whose ``response_delivered_at`` is
+    still ``None`` therefore erases the stamp microseconds after it lands,
+    unless the flush also mirrors the value onto the caller's object.
+
+    RED both against unfixed code (nothing stamps at all) and against a
+    fresh-object-only fix (the trailing save clobbers it). The isolated flush
+    test above is green in the second case -- that gap is the point.
+    """
+    sid = f"{SID_PREFIX}stale-caller"
+    cleanup.append(sid)
+    stale_caller = _make_session(sid)
+    assert stale_caller.response_delivered_at is None, "precondition: caller snapshot is unstamped"
+
+    finalize_session(stale_caller, "completed", reason="test: turn end")
+
+    fresh = get_authoritative_session(sid)
+    assert fresh is not None
+    assert fresh.status == "completed"
+    assert fresh.response_delivered_at is not None, (
+        "finalize_session's trailing full save on the caller's stale object "
+        "resurrected response_delivered_at=None over the flush's stamp"
+    )
+
+
+# ---------------------------------------------------------------------------
+# A1b -- orphan-bounce reproduction through the real health check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_health_check_finalizes_delivered_row_instead_of_requeuing(cleanup):
+    """The orphan-bounce reproduction (#944 net vs. #918 guard).
+
+    A row that answered the human through the deferred-self-draft flush and
+    then had its ``status`` corrupted back to ``running`` by a stale full save
+    must be finalized ``completed`` by the health check, not requeued to
+    ``pending`` (which posts a second, unprompted reply).
+
+    Red before the fix: ``response_delivered_at`` is ``None``, so
+    ``_delivery_belongs_to_current_run`` returns ``False`` and the row is
+    recovered to ``pending``.
+    """
+    sid = f"{SID_PREFIX}orphan-bounce"
+    cleanup.append(sid)
+    session = _make_session(sid)
+
+    # The reply reaches the human through the real terminal-path flush.
+    finalize_session(session, "completed", reason="test: turn end")
+    assert _outbox_len(sid) == 1, "precondition: the reply was delivered"
+
+    # A concurrent stale full save rewrites the status back to running -- the
+    # corruption this issue documents. Written narrowly so nothing else moves.
+    corrupted = get_authoritative_session(sid)
+    assert corrupted is not None
+    corrupted.status = "running"
+    corrupted.save(update_fields=["status"])
+
+    entry = get_authoritative_session(sid)
+    assert entry is not None and entry.status == "running", "precondition: row reads running"
+
+    mock_cls = MagicMock()
+    mock_cls.query.filter.return_value = [entry]
+    with (
+        patch("agent.session_health.AgentSession", mock_cls),
+        patch("agent.session_health._active_workers", {}),
+        patch("agent.session_health._active_sessions", {}),
+    ):
+        from agent.session_health import _agent_session_health_check
+
+        await _agent_session_health_check()
+
+    after = get_authoritative_session(sid)
+    assert after is not None
+    assert after.status == "completed", (
+        "the health check requeued a row that had already answered the human -- "
+        f"got status={after.status!r}; each requeue posts another unprompted reply"
+    )

--- a/tests/unit/test_valor_session_resume_release.py
+++ b/tests/unit/test_valor_session_resume_release.py
@@ -59,10 +59,10 @@ def _make_session(
     s.retain_for_resume = retain
     s.pr_url = pr_url
     s.slug = slug
-    # A real project_key string so the resume path's derived room id
-    # (room_id_for_session → "test|system") is assertable rather than a
-    # MagicMock repr. Shared by ~30 call sites; no test asserts on
-    # project_key being absent.
+    # A real project_key string. The resume steer is session-scoped (#3270), so
+    # nothing derives a room id from it any more, but ~30 call sites share this
+    # helper and other paths still read project_key; a MagicMock repr there is
+    # noise. No test asserts on project_key being absent.
     s.project_key = "test"
     # Default to a non-null UUID so existing happy-path tests continue to
     # exercise the status-guard path without tripping the null-UUID guard
@@ -189,9 +189,7 @@ class TestCmdResumeHappyPath:
 
         assert result == 0
         # Steering message must be pushed to Redis before transition_status is called
-        mock_push.assert_called_once_with(
-            "sess-ok", "Do the patch.", "resume:valor-session resume", room_id="test|system"
-        )
+        mock_push.assert_called_once_with("sess-ok", "Do the patch.", "resume:valor-session resume")
         mock_transition.assert_called_once_with(
             session, "pending", reason="resume (valor-session resume)", reject_from_terminal=False
         )
@@ -308,7 +306,6 @@ class TestCmdResumeKilledFailedSupport:
             "sess-k",
             "Pick up where we left off.",
             "resume:valor-session resume",
-            room_id="test|system",
         )
         mock_transition.assert_called_once_with(
             session, "pending", reason="resume (valor-session resume)", reject_from_terminal=False
@@ -318,9 +315,7 @@ class TestCmdResumeKilledFailedSupport:
         session = _make_session("sess-f", status="failed", claude_session_uuid="uuid-failed")
         result, mock_transition, mock_push = self._run_resume(session, message="Recover.")
         assert result == 0
-        mock_push.assert_called_once_with(
-            "sess-f", "Recover.", "resume:valor-session resume", room_id="test|system"
-        )
+        mock_push.assert_called_once_with("sess-f", "Recover.", "resume:valor-session resume")
         mock_transition.assert_called_once_with(
             session, "pending", reason="resume (valor-session resume)", reject_from_terminal=False
         )
@@ -482,7 +477,6 @@ class TestCmdResumeAbandonedSupport:
             "sess-a",
             "Pick up where we left off.",
             "resume:valor-session resume",
-            room_id="test|system",
         )
         mock_transition.assert_called_once()
         _, kwargs = mock_transition.call_args
@@ -648,9 +642,7 @@ class TestResumeSessionCore:
 
         assert result.success is True
         assert call_order.index("push") < call_order.index("transition")
-        mock_push.assert_called_once_with(
-            "core-sess", "continue", "resume:cli", room_id="test|system"
-        )
+        mock_push.assert_called_once_with("core-sess", "continue", "resume:cli")
 
     def test_transition_error_returns_failure(self):
         session = self._make_mock_session(status="failed")

--- a/tests/unit/test_valor_session_resume_release.py
+++ b/tests/unit/test_valor_session_resume_release.py
@@ -189,7 +189,9 @@ class TestCmdResumeHappyPath:
 
         assert result == 0
         # Steering message must be pushed to Redis before transition_status is called
-        mock_push.assert_called_once_with("sess-ok", "Do the patch.", "resume:valor-session resume")
+        mock_push.assert_called_once_with(
+            "sess-ok", "Do the patch.", "resume:valor-session resume", room_id=None
+        )
         mock_transition.assert_called_once_with(
             session, "pending", reason="resume (valor-session resume)", reject_from_terminal=False
         )
@@ -306,6 +308,7 @@ class TestCmdResumeKilledFailedSupport:
             "sess-k",
             "Pick up where we left off.",
             "resume:valor-session resume",
+            room_id=None,
         )
         mock_transition.assert_called_once_with(
             session, "pending", reason="resume (valor-session resume)", reject_from_terminal=False
@@ -315,7 +318,9 @@ class TestCmdResumeKilledFailedSupport:
         session = _make_session("sess-f", status="failed", claude_session_uuid="uuid-failed")
         result, mock_transition, mock_push = self._run_resume(session, message="Recover.")
         assert result == 0
-        mock_push.assert_called_once_with("sess-f", "Recover.", "resume:valor-session resume")
+        mock_push.assert_called_once_with(
+            "sess-f", "Recover.", "resume:valor-session resume", room_id=None
+        )
         mock_transition.assert_called_once_with(
             session, "pending", reason="resume (valor-session resume)", reject_from_terminal=False
         )
@@ -477,6 +482,7 @@ class TestCmdResumeAbandonedSupport:
             "sess-a",
             "Pick up where we left off.",
             "resume:valor-session resume",
+            room_id=None,
         )
         mock_transition.assert_called_once()
         _, kwargs = mock_transition.call_args
@@ -642,7 +648,7 @@ class TestResumeSessionCore:
 
         assert result.success is True
         assert call_order.index("push") < call_order.index("transition")
-        mock_push.assert_called_once_with("core-sess", "continue", "resume:cli")
+        mock_push.assert_called_once_with("core-sess", "continue", "resume:cli", room_id=None)
 
     def test_transition_error_returns_failure(self):
         session = self._make_mock_session(status="failed")

--- a/tests/unit/test_valor_session_resume_steering_scope.py
+++ b/tests/unit/test_valor_session_resume_steering_scope.py
@@ -1,0 +1,83 @@
+"""``resume_session`` steers the ONE row it resumes, not the whole Room (#3270).
+
+A resume names a specific session, transitions that row in place, and the
+worker runs it in that row's own ``working_dir``. Writing the steer to the
+Room key ``steering:room:{room_id}`` hands it to whichever session next drains
+the Room, which is how a resume aimed at a stalled engineering lane landed an
+unprompted message in a human conversation thread.
+
+The assertion is on the Redis key itself rather than on the ``room_id`` kwarg,
+because the key is the thing that decides who drains the message
+(``agent/steering.py`` selects it from ``room_id``).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import agent.steering as steering
+from tools.valor_session import resume_session
+
+_RESUMABLE_STATUSES = frozenset({"completed", "killed", "failed", "abandoned"})
+
+
+class _KeyRecordingRedis:
+    """Records RPUSH/LPUSH targets so the chosen steering key is assertable."""
+
+    def __init__(self):
+        self.pushes: list[tuple[str, str]] = []
+
+    def rpush(self, key, payload):
+        self.pushes.append((key, payload))
+
+    def lpush(self, key, payload):
+        self.pushes.append((key, payload))
+
+
+@pytest.fixture
+def redis_keys(monkeypatch):
+    r = _KeyRecordingRedis()
+    monkeypatch.setattr(steering, "_get_redis", lambda: r)
+    return r
+
+
+def _session(session_id="sess-scope"):
+    s = MagicMock()
+    s.session_id = session_id
+    s.status = "completed"
+    s.claude_session_uuid = "uuid-1"
+    s.project_key = "test"
+    s.slug = ""
+    s.pr_url = ""
+    return s
+
+
+def test_resume_steer_lands_on_the_session_key_not_the_room_key(redis_keys):
+    session = _session()
+
+    with (
+        patch("tools.valor_session._load_env"),
+        patch("tools.valor_session._publish_resume_notify"),
+        patch.dict(
+            "sys.modules",
+            {
+                "models.session_lifecycle": MagicMock(
+                    transition_status=MagicMock(),
+                    RESUMABLE_STATUSES=_RESUMABLE_STATUSES,
+                ),
+            },
+        ),
+    ):
+        result = resume_session(session, "Continue.", source="sdlc-stall")
+
+    assert result.success
+    keys = [key for key, _ in redis_keys.pushes]
+    assert keys == ["steering:sess-scope"], (
+        "a resume targets one row; a room-scoped key is drained by whichever "
+        "session next serves the room"
+    )
+    assert not any(key.startswith("steering:room:") for key in keys)
+    assert json.loads(redis_keys.pushes[0][1])["text"].endswith("Continue.")

--- a/tests/unit/test_valor_session_resume_steering_scope.py
+++ b/tests/unit/test_valor_session_resume_steering_scope.py
@@ -25,7 +25,11 @@ _RESUMABLE_STATUSES = frozenset({"completed", "killed", "failed", "abandoned"})
 
 
 class _KeyRecordingRedis:
-    """Records RPUSH/LPUSH targets so the chosen steering key is assertable."""
+    """Records RPUSH/LPUSH targets so the chosen steering key is assertable.
+
+    ``lrem`` is modelled too, because the rollback path has to remove exactly
+    the entry it pushed rather than truncating the list.
+    """
 
     def __init__(self):
         self.pushes: list[tuple[str, str]] = []
@@ -35,6 +39,11 @@ class _KeyRecordingRedis:
 
     def lpush(self, key, payload):
         self.pushes.append((key, payload))
+
+    def lrem(self, key, count, payload):
+        before = len(self.pushes)
+        self.pushes = [p for p in self.pushes if p != (key, payload)]
+        return before - len(self.pushes)
 
 
 @pytest.fixture
@@ -81,3 +90,41 @@ def test_resume_steer_lands_on_the_session_key_not_the_room_key(redis_keys):
     )
     assert not any(key.startswith("steering:room:") for key in keys)
     assert json.loads(redis_keys.pushes[0][1])["text"].endswith("Continue.")
+
+
+def test_a_failed_transition_leaves_no_orphaned_resume_steer(redis_keys):
+    """The push precedes the transition, so a failed transition must roll it back.
+
+    ``resume_session`` pushes BEFORE ``transition_status`` on purpose (it closes
+    the two-write race). When the transition then raises, the row is never
+    resumed -- but the steer is already on ``steering:{session_id}``, which
+    carries no TTL and, unlike the Room leg, is never age-bounded at drain time
+    (``_drain_list`` applies ``steering_room_max_age_s`` to the Room key only).
+    Left there, "your lane stalled, continue" is injected verbatim the next
+    time that session runs, however many hours later.
+    """
+    session = _session("sess-rollback")
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError("another process raced us")
+
+    with (
+        patch("tools.valor_session._load_env"),
+        patch("tools.valor_session._publish_resume_notify"),
+        patch.dict(
+            "sys.modules",
+            {
+                "models.session_lifecycle": MagicMock(
+                    transition_status=_boom,
+                    RESUMABLE_STATUSES=_RESUMABLE_STATUSES,
+                ),
+            },
+        ),
+    ):
+        result = resume_session(session, "Continue.", source="sdlc-stall")
+
+    assert not result.success
+    assert redis_keys.pushes == [], (
+        "a resume steer outlived the transition that failed; it will be "
+        f"injected on the next run of this session -- leftover: {redis_keys.pushes}"
+    )

--- a/tools/valor_session.py
+++ b/tools/valor_session.py
@@ -1086,9 +1086,9 @@ def resume_session(session, message: str, *, source: str = "cli") -> "ResumeResu
 
     - Validates session is in RESUMABLE_STATUSES (not cancelled, not running/pending)
     - Validates session has a claude_session_uuid
-    - Pushes the steering message onto the Redis steering list BEFORE transition
-      (eliminates the race window — the write is independent of any in-flight
-      ORM save on this instance)
+    - Pushes the steering message onto the resumed session's OWN steering list
+      BEFORE transition (eliminates the race window — the write is independent
+      of any in-flight ORM save on this instance)
     - Atomically transitions to pending via transition_status(..., reject_from_terminal=False)
 
     Returns a ResumeResult. Never raises — caller checks result.success.
@@ -1135,7 +1135,6 @@ def resume_session(session, message: str, *, source: str = "cli") -> "ResumeResu
     # This RPUSHes directly to Redis, independent of session.save(), so it
     # cannot be clobbered by a stale bound instance.
     from agent.steering import push_steering_message
-    from models.room import room_id_for_session
 
     # Fold the session's goal into the first turn input so a resumed session
     # can state its own objective without asking the human (issue #2136),
@@ -1150,11 +1149,11 @@ def resume_session(session, message: str, *, source: str = "cli") -> "ResumeResu
         if goal:
             outbound = f"[Prior session context: {goal}]\n\n{message}"
 
-    # Room-targeted: a resume steer is a conversation-level instruction, so it
-    # survives this session and is served by whichever session next drains the Room.
-    push_steering_message(
-        session_id, outbound, f"resume:{source}", room_id=room_id_for_session(session)
-    )
+    # Session-targeted: a resume names ONE row, transitions that row in place,
+    # and the worker runs it in that row's own working_dir. Passing no room_id
+    # keeps the write on `steering:{session_id}`, so only the resumed session
+    # can drain it (#3270).
+    push_steering_message(session_id, outbound, f"resume:{source}")
 
     # Transition to pending (atomic — fails if another process raced us).
     # Steering message is already persisted above, so no race window.

--- a/tools/valor_session.py
+++ b/tools/valor_session.py
@@ -1134,7 +1134,7 @@ def resume_session(session, message: str, *, source: str = "cli") -> "ResumeResu
     # always sees it — eliminates the two-write race (transition then save).
     # This RPUSHes directly to Redis, independent of session.save(), so it
     # cannot be clobbered by a stale bound instance.
-    from agent.steering import push_steering_message
+    from agent.steering import push_steering_message, remove_steering_message
 
     # Fold the session's goal into the first turn input so a resumed session
     # can state its own objective without asking the human (issue #2136),
@@ -1153,7 +1153,15 @@ def resume_session(session, message: str, *, source: str = "cli") -> "ResumeResu
     # and the worker runs it in that row's own working_dir. Passing no room_id
     # keeps the write on `steering:{session_id}`, so only the resumed session
     # can drain it (#3270).
-    push_steering_message(session_id, outbound, f"resume:{source}")
+    _steer_payload = push_steering_message(
+        session_id,
+        outbound,
+        f"resume:{source}",
+        # room_id=None deliberately: see the paragraph above. A resume names ONE
+        # row; a Room write would serve this instruction to whichever session
+        # next drains that Room, which is the #3270 cross-talk.
+        room_id=None,
+    )
 
     # Transition to pending (atomic — fails if another process raced us).
     # Steering message is already persisted above, so no race window.
@@ -1162,6 +1170,16 @@ def resume_session(session, message: str, *, source: str = "cli") -> "ResumeResu
             session, "pending", reason=f"resume ({source})", reject_from_terminal=False
         )
     except Exception as e:
+        # Roll the steer back. The push has to precede the transition to close
+        # the two-write race, which means a failed transition leaves a resume
+        # instruction on a row that was never resumed. The legacy leg has no
+        # TTL and, unlike the Room leg, is not age-bounded at drain time
+        # (`_drain_list` applies `steering_room_max_age_s` to the Room key
+        # only), so that orphan would be injected verbatim whenever this
+        # session next runs — hours or days later, telling it to continue a
+        # lane that already moved on. Best-effort: `remove_steering_message`
+        # never raises, and a surviving orphan must not mask the real error.
+        remove_steering_message(session_id, _steer_payload)
         return ResumeResult(
             success=False,
             session_id=session_id,


### PR DESCRIPTION
Closes #3270
Closes #3271

Plan: `docs/plans/telegram-reply-duplication-and-room-register.md`

Two independent defects made Valor a bad chat participant, and a human named both directly. They touch disjoint file sets and ship together as one behavior fix.

## A. Extra messages nobody asked for (#3270)

Finished Telegram threads were re-run on a ~30-minute cadence, and every re-run posted a new reply. Two auto-recovery loops fed each other. Established from the append-only `session_events` ledger of `tg_valor_-1003449100931_1450`, which is independent of the corrupted `status` field:

```
13:23:32  running→completed: transcript completed   <-- the ONLY terminal transition ever recorded
14:21:33  completed→pending: resume (sdlc-stall)
15:02:47  exit_summary turns=3                      <-- run ended, NO terminal transition
15:07:33  running→pending: health check (kind=no_progress)
15:12:33  running→failed: 2 recovery attempts
15:21:41  failed→pending: resume (sdlc-stall)       <-- failed rows get re-resumed forever
```

Four defects combine, and each is fixed:

- **A4 — the stall ladder resumed anything.** `_pick_steer_target` treated a lane-slug match as a *tiebreaker*, so with no slug match the most-recently-updated eng session won — routinely a slugless human conversation thread. Both rungs now require a non-`None` slug equal to the lane slug, and rung 2 excludes `failed`; otherwise it falls through to create.
- **A1 — the `#918` delivery guard was starved of input.** `_delivery_belongs_to_current_run` would have finalized these rows `completed` rather than requeuing them, but returned `False` because `response_delivered_at` was always `None`. Its two existing writers never fired once across the whole retained log window; real delivery flows through `flush_deferred_self_draft_sync`, which RPUSHed straight to the outbox without stamping. Now stamped on the paths that actually deliver, with a narrow `save(update_fields=[...])` **and the caller-object mirror**, so the stamp survives the trailing save by a stale caller.
- **A3a — a silent full-row save corrupted `status`.** popoto's `save(update_fields=None)` HSETs the entire encoded instance and re-runs `on_save()` for every field. `status` is an `IndexedField`, so a bare `save()` from a stale instance rewrites both the hash and the index, emitting no LIFECYCLE log and no `session_events` entry. The two evidenced sites in `agent/output_handler.py` are narrowed to `update_fields`.
- **A2 — the turn-end finalize was silently skipped.** With `completed` already on the row, `finalize_session` hit its idempotency skip and returned with no `completed_at`. It now WARNs when an idempotent skip coincides with a bound live runner PID (no behavior change) so this is visible next time.

Also: **A5** scopes the resume steer to the session rather than the room, and **A6b** dedupes the timeout needs-attention notice to once per run (key `timeout-notice-sent:{session_id}:{run_id}`).

### finalize_session caller enumeration (A1)

`finalize_session` ends in a bare `session.save()` (`models/session_lifecycle.py:665`), a full popoto HSET of the caller's in-memory snapshot. A caller that re-reads immediately before the call is harmless; one that passes a batch-read loop variable, a long-held parameter, or an object that survived awaits can write a stale snapshot back over a field another writer just persisted. Every production (non-test) call site, classified:

| file:line | arg | class | why |
|---|---|---|---|
| `bridge/session_transcript.py:343` | `s` | fresh | `get_authoritative_session()` at `:316` |
| `agent/session_executor.py:2470` | `_auth` | fresh | `get_authoritative_session()` 3 lines earlier |
| `agent/session_executor.py:2782` | `_auth` | fresh | `get_authoritative_session()` at `:2763` |
| `agent/session_completion.py:162` | `session` | fresh | rebound from `rows_for_session_id()` at `:130`, no awaits |
| `agent/agent_session_queue.py:781` | `session` | fresh | `get_by_id()` at `:760` |
| `agent/agent_session_queue.py:2743` | `fresh` | fresh | `query.get()` at `:2735` |
| `tools/valor_session.py:1705` | `session` | fresh | `_find_session()` at `:1691` |
| `.claude/hooks/stop.py:201` | `agent_session` | fresh | `get_by_id()` at `:168` |
| **`agent/session_completion.py:1144`** | `parent` | **stale** | last read at `:922`; **the same object passed to `send_cb` at `:1060`** |
| **`agent/session_health.py:3727 / :3753 / :3790 / :3863`** | `entry` | **stale** | `_apply_recovery_transition` param, each preceded by an `await` notice delivery that routes the SAME object into `send` via `deliver_system_notice` |
| `agent/session_health.py:3476` | `entry` | stale | same param, but runs before any delivery |
| `agent/session_health.py:1267 / :1425 / :4721 / :4900` | `entry` | stale | batch loop variables |
| `agent/session_executor.py:1103 / :1145 / :2041` | `session` | stale | the executor's long-held queue-popped object — a *different* object from the `agent_session` handed to `send`, and all three fire before the runner is constructed |
| `agent/agent_session_queue.py:1698` | `stuck` | stale | loop variable over `pending` built at `:1683` |
| `models/session_lifecycle.py:1774` | `parent` | stale | `_transition_parent` parameter |
| `tools/valor_session.py:1685` | `s` | stale | loop variable over an `enumerate_sessions` batch |
| `tools/sdlc_session_ensure.py:1194` | `s` | stale | loop variable over the orphan scan |
| `tools/agent_session_scheduler.py:1158 / :1185` | `target` / `child` | stale | `_kill_process` sleeps up to ~3.5s first |
| `scripts/update/run.py:541 / :607` | `s` | stale | loop variables over a batch query |
| `monitoring/session_watchdog.py:298 / :1287` | `session` | stale | watchdog loop variable, after health-assessment work |

**Reachable from the `output_handler.py::send` stamp** — i.e. stale-passing *and* holding the very object `send` received as `session=`: `agent/session_completion.py:1144` and the four `agent/session_health.py` notice-delivery finalizes. Both are covered by A1's caller-object mirror, which now mirrors **both** `response_delivered_at` and the cleared `extra_context` (mirroring the stamp alone let the trailing full save re-arm `deferred_self_draft_pending` with the originally rejected draft text, which `_deferred_self_draft_backstop_sweep` then re-delivers). `test_send_stamp_survives_finalize_session_by_the_same_caller_object` in `tests/unit/test_response_delivered_stamp.py` is the A1c sibling for that shape, and is RED without the mirror. The remaining stale-passing sites never see an object `send` mutated; they are sweeper/CLI/watchdog rows independently re-read from Redis, and are #3272's territory.

### The stamp arms a previously dormant guard

Stamping mid-run made the delivery guard in `_agent_session_health_check` (`agent/session_health.py`) live on **running** rows: it deliberately skips the `worker_alive`/`_has_progress` evaluation, so a long eng/PM run that redrafts a deferred reply and keeps working past the 300s cadence would have been finalized `completed` out from under its own runner — the mid-turn corruption #3270 exists to stop. That guard is now gated on the absence of a live execution fence, the same discriminator A2 uses. The sibling guard inside `_apply_recovery_transition` is deliberately left ungated: every caller has already decided to take the row away from its runner, so finalizing a delivered row `completed` is the gentler of the outcomes on the table.

## B. Replies that didn't fit the room (#3271)

In chat `-1003449100931`, human messages run a median of 8 words on 1 line with no headers or lists. Valor's agent-composed replies ran a median of ~247 words; 17 of 70 used `#` headers, 18 used numbered lists, the longest was 1029 words in reply to a 17-word question.

- **B1** adds a "Match the room" section to `prime-pm-role.md` and `prime-teammate-role.md` — the operative style text, since the runner prepends the prime on turn 1 and never calls `compose_system_prompt`. Edited in place (fleet hardlink inode preserved and verified), additive only, no existing paragraph or header touched.
- **B2** corrects the stale claim that a Haiku drafter condenses output; `bridge/message_drafter.py` is validation-only. Fixed in `config/personas/segments/identity.md` and `docs/features/pm-voice-refinement.md`, along with two wrong symbol references.

`tests/unit/test_pm_progress_updates.py` passes **unmodified**, which is the acceptance criterion for B1 staying in bounds.

## Follow-up

- #3272 — AgentSession `save()` hardening sweep (A3b). The remaining bare-`save()` sites are enumerated there; no code fix for them in this PR. The deferred rate-limit-relay routing (A6a) is folded into that issue.

## Tests

Red-first throughout: A0 committed failing guards for the stall-ladder lane filter and the resume steer scope before any fix, and A1/A1c prove `response_delivered_at` stays `None` today.

```
215 passed  (output_handler stale-snapshot, reflections progress check, runner preempt,
             finalize idempotent-skip observability, response_delivered stamp,
             valor_session resume release + steering scope, pm progress updates)
 48 passed  (session_health deferred_backstop, orphan_reap, fence_guards)
```

`python -m ruff check` and `python -m ruff format --check` both clean.

Docs (`docs/features/agent-session-lifecycle-writes.md`, `session-steering.md`, `README.md` index) are on `main` per repo convention: c5d82ead6.

